### PR TITLE
Add utilities to compute identifiable parameters of an msspoly expression

### DIFF
--- a/util/baseParameters.m
+++ b/util/baseParameters.m
@@ -1,0 +1,65 @@
+function [beta, independent_idx] = baseParameters(W)
+% Implements the method described in Appendix 5 of Kahlil and Dombre 2004.
+[r,m] = size(W);
+r_orig = r;
+m_orig = m;
+if isnumeric(W)
+  [~,R,e]=qr(W,0);
+  numerical_zero = r*eps*max(abs(diag(R)));
+  independent_idx = abs(diag(R)) > numerical_zero;
+  dependent_idx = ~independent_idx;
+  b = sum(independent_idx);
+  R1 = R(1:b,independent_idx);
+  R2 = R(1:b,dependent_idx);
+%   beta = R1\R2;
+  beta = inv(R1)*R2;
+  integer_entry_idx = abs(beta-round(beta)) < numerical_zero;
+  beta(integer_entry_idx) = round(beta(integer_entry_idx));
+  beta = [eye(b),beta];
+  beta(:,[e(independent_idx),e(dependent_idx)]) = beta;
+  beta_tmp = zeros(m);
+  beta_tmp(e(independent_idx),:) = beta;
+  beta_tmp(all(beta_tmp==0,2),:) = [];
+  beta = beta_tmp;
+  independent_idx = sort(e(independent_idx));
+%  independent_idx = e(independent_idx);
+elseif isa(W,'msspoly')
+  if r ~= 1
+    W = reshape(W',[],1)';
+  end
+  vars = decomp(W);
+  n_vars = length(vars);
+  r = 10*m;
+  data = rand(length(vars),r);
+  W_data = reshape(msubs(W',vars,data),m,r*r_orig)';
+  [beta, independent_idx] = getBaseParameters(W_data);
+elseif isa(W,'TrigPoly')
+  q = getVar(W);
+  s = getSin(W);
+  c = getCos(W);
+  nq = length(q);
+  vars = [];
+  for i = 1:size(W,1)
+    fprintf('i = %d\n',i);
+    vars = mss_unique([vars;decomp(getmsspoly(W(i,:)),[q;s;c])]);
+  end
+  if r ~= 1
+    W = reshape(W',[],1)';
+  end
+  r = 10*m; 
+  q_data = rand(nq,r); s_data = sin(q_data); c_data = cos(q_data);
+
+%   vars = decomp(getmsspoly(W),[q;s;c]);
+  data = [q_data;s_data;c_data;rand(length(vars),r)];
+  W_data = zeros(size(W,2),r); % [r x r_orig*m_orig]
+  for i=1:size(W,2)
+    fprintf('i = %d\n',i);
+    W_data(i,:) = msubs(getmsspoly(W(i)),[q;s;c;vars],data); % [r x 1]
+  end
+  W_data = reshape(W_data,m,r*r_orig)'; % [m x r*r_orig]
+  [beta, independent_idx] = getBaseParameters(W_data);
+else
+  error('getBaseParameters:invalidInput', ...
+    'Objects of class %s are not valid inputs for getBaseParameters.',class(W));
+end
+end

--- a/util/identifiableParameters.m
+++ b/util/identifiableParameters.m
@@ -1,0 +1,14 @@
+function [identifiable_params, coeff_mat, offsets,lin_params,beta] = identifiableParameters(expr,params)
+% Given an expression (expr) and a set of parameters (params) computes
+% a set of lumped parameters (identifiable_params), coefficients (coeff_mat), and
+% offsets such that
+%
+%   expr = coeff_mat*identifiable_params + offsets
+%
+% where all columns of coeff_mat are linearly independent.
+
+[lin_params,coeff_mat1,offsets] = linearParameters(expr,params);
+[beta,independent_idx] = baseParameters(coeff_mat1);
+identifiable_params = beta*lin_params;
+coeff_mat = coeff_mat1(:,independent_idx);
+end

--- a/util/linearParameters.m
+++ b/util/linearParameters.m
@@ -1,0 +1,45 @@
+function [lin_params,coeff_mat,offsets] = linearParameters(expr,params)
+% Given an expression (expr) and a set of parameters (params) computes
+% a set of lumped parameters (lin_params), coefficients (coeff_mat), and
+% offsets such that
+%
+%   expr = coeffs*lin_params + offsets
+%
+if isa(expr,'TrigPoly')
+  q = getVar(expr);
+  s = getSin(expr);
+  c = getCos(expr);
+  qt = TrigPoly(q,s,c);
+  isTrigPoly = true;
+  expr = getmsspoly(expr);
+else
+  isTrigPoly = false;
+end
+non_params = decomp(expr,params);
+[a,b,coeff_mat]=decomp(expr,non_params);
+coeff = msspoly(ones(size(b,1),1));
+deg_zero_ind=-1;
+for i=1:size(b,1)
+  % would use prod(a'.^b(i,:)) if msspoly implemented prod (bug 1712)
+  for k=find(b(i,:))
+    coeff(i) = coeff(i).*(a(k)^b(i,k));
+  end
+  if (deg(coeff(i))==0)
+    if (deg_zero_ind>0), error('should only get a single degree zero term'); end
+    deg_zero_ind = i;
+  end
+end
+
+if (deg_zero_ind>0)
+  offsets = coeff_mat(:,deg_zero_ind)*double(coeff(deg_zero_ind));
+  coeff_mat = coeff_mat(:,[1:deg_zero_ind-1,deg_zero_ind+1:end]);
+  lin_params = coeff([1:deg_zero_ind-1,deg_zero_ind+1:end]);
+else
+  offsets = zeros(size(expr,1));
+  lin_params = coeff;
+end
+if isTrigPoly
+  coeff_mat = coeff_mat+0*qt(1); % There must be a better way to go from msspoly to TrigPoly . . .
+  offsets = offsets+0*qt(1); % There must be a better way to go from msspoly to TrigPoly . . .
+end
+end


### PR DESCRIPTION
Given an expression and a vector of parameters, `linearParameters` splits the expression into a matrix of coefficients and a vector of parameters such that their matrix-vector product yields the original expression.

Given a coefficient matrix (numeric or `msspoly`), `baseParametes` uses the numerical technique described by Khalil and Dombre to compute the independent columns of the matrix.

Given an `msspoly` expression, `identifiableParameters` computes a set of identifiable parameters, a coefficient matrix with linearly independent columns, and an offset vector such that 

```
expr = coeff_mat*identifiable_parameters + offsets
```
