### PR TITLE
Fix frame handling in `findFixedPoint`.

### DIFF
--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -1010,8 +1010,8 @@ classdef RigidBodyManipulator < Manipulator
 
       [quz_sol,~,exitflag] = fmincon(problem);
       success=(exitflag==1);
-      xstar = [quz_sol(1:nq); zeros(nq,1)];
-      ustar = quz_sol(nq+(1:nu));
+      xstar = Point(obj.getStateFrame(), [quz_sol(1:nq); zeros(nq,1)]);
+      ustar = Point(obj.getInputFrame(), quz_sol(nq+(1:nu)));
       zstar = quz_sol(nq+nu+(1:nz));
       if (~success)
         error('failed to find fixed point');

--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -694,9 +694,13 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
         [varargout{:}] = inverseKinWrapup(obj.manip,varargin{:});
     end
     
-    function varargout = findFixedPoint(obj,varargin)
-      varargout = cell(1,nargout);
-      [varargout{:}]=findFixedPoint(obj.manip,varargin{:});
+    function varargout = findFixedPoint(obj,x0,varargin)
+      varargout=cell(1,nargout);
+      if isnumeric(x0)
+        x0 = Point(obj.getStateFrame(),x0);
+      end
+      [varargout{:}]=findFixedPoint(obj.manip,x0,varargin{:});
+      varargout{1} = varargout{1}.inFrame(obj.getStateFrame());
     end
     
     function varargout = collisionDetect(obj,varargin)

--- a/systems/plants/test/timeSteppingRigidBodyManipulatorFramesTest.m
+++ b/systems/plants/test/timeSteppingRigidBodyManipulatorFramesTest.m
@@ -37,4 +37,10 @@ sys = cascade(q_des_traj,sys_pd);
 [~,xtraj] = simulate(sys,[0,5],xstar);
 v.playback(xtraj);
 
+% Check fixed-point computation
+x0 = rand(p.getNumStates(),1);
+u0 = rand(p.getNumInputs(),1);
+[xstar,ustar,success] = findFixedPoint(p,x0,u0,struct('active_collision_groups','','visualize',true));
+v.draw(0,xstar)
+
 warning(S);


### PR DESCRIPTION
`findFixedPoint` (both in `RigidBodyManipulator` and
`TimeSteppingRigidBodyManipulator`) now outputs a `Point` in the state
frame.
