### PR TITLE
Multi-column decimate utility

### DIFF
--- a/util/decimateMultiCol.m
+++ b/util/decimateMultiCol.m
@@ -1,0 +1,7 @@
+function odata = decimateMultiCol(x,r,varargin)
+num_cols = size(x,2);
+odata = zeros(ceil(size(x,1)/r),num_cols);
+for i = 1:num_cols
+  odata(:,i) = decimate(x(:,i),r,varargin{:});
+end
+end


### PR DESCRIPTION
This branch adds a utility to loop-over the columns of a matrix and apply `decimate` to each. The implementation here is definitely _not_ the best way to do this. We should ask the Mathworks to push multi-column support into the built-in `decimate`. More details over email.
