### PR TITLE
Fix #6.

### DIFF
--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -74,8 +74,13 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
       if ~isDirectFeedthrough(obj)
         u=[];
       end
-      cv = obj.getStateFrame().splitCoordinates(x);
-      y = obj.manip.output(t,cv{1},u);
+      if isa(obj.getStateFrame(),'MultiCoordinateFrame')
+        cv = obj.getStateFrame().splitCoordinates(x);
+        x_manip = cv{1};
+      else
+        x_manip = x;
+      end
+      y = obj.manip.output(t,x_manip,u);
       for i=1:length(obj.sensor)
         y = [y; obj.sensor{i}.output(obj,i+1,t,x,u)];
       end

--- a/systems/plants/test/timeSteppingRigidBodyManipulatorFramesTest.m
+++ b/systems/plants/test/timeSteppingRigidBodyManipulatorFramesTest.m
@@ -7,6 +7,9 @@ S = warning('OFF','Drake:RigidBodyManipulator:WeldedLinkInd');
 urdf = [getDrakePath() '/systems/plants/test/ActuatedPendulum.urdf'];
 p = TimeSteppingRigidBodyManipulator(urdf,.01);
 
+% Check simulation w/out sensors
+[~,xtraj] = simulate(p,[0 5]);
+
 p = addSensor(p,FullStateFeedbackSensor());
 frame = p.getFrame(p.findFrameId('tip'));
 p = addSensor(p,ContactForceTorqueSensor(p,frame));


### PR DESCRIPTION
tsmanip's `output` method now checks the class of the state frame. If
it's a multi-coordinate frame, it splits the state and passes the
relevant portion on to the manip. Otherwise, it passes down the whole
state.
