### PR TITLE
Fix #13 by syncing frames within Atlas.

### DIFF
--- a/examples/Atlas/Atlas.m
+++ b/examples/Atlas/Atlas.m
@@ -38,9 +38,12 @@ classdef Atlas < TimeSteppingRigidBodyManipulator
       state_frame = AtlasState(obj);
       obj = obj.setStateFrame(state_frame);
       obj = obj.setOutputFrame(state_frame);
+      obj.manip = obj.manip.setStateFrame(state_frame);
+      obj.manip = obj.manip.setOutputFrame(state_frame);
     
       input_frame = AtlasInput(obj);
       obj = obj.setInputFrame(input_frame);
+      obj.manip = obj.manip.setInputFrame(input_frame);
     end
 
     function obj = setInitialState(obj,x0)


### PR DESCRIPTION
The problem was that `pdcontrol` looks for the state frame of the
`RigidBodyManipulator` in the output frame of the
`TimeSteppingRigidBodyManipulator`. Since `Atlas` resets it's state, input, and
output frames to Atlas specific versions, that lookup failed. I've resolved
this by having the `Atlas` constructor reset the state, input, and output
frames of the `RigidBodyManipulator` as well.

Note: This setup will need some tweaking when we want to add sensors to `Atlas`
objects. The approach we've used up to this point (resetting frames with
Atlas specific ones) will clobber the changes made to those frames by the
addition of the sensor. I'll create an issue for this.
