### PR TITLE
Add detail to the addJoint error message when joint already has a parent...

### DIFF
--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -193,7 +193,7 @@ classdef RigidBodyManipulator < Manipulator
       child = model.body(child_ind);
       
       if child.parent>0
-        error('there is already a joint connecting this child to a parent');
+        error(['there is already a joint connecting this child (' child.linkname ') to a parent (' model.body(parent_ind).linkname ') on joint ' name ]);
       end
       
       jointname = regexprep(name, '\.', '_', 'preservecase');


### PR DESCRIPTION
I was debugging my urdf file and got an error message about an incorrect link-joint hierarchy. While the error was correct, it didn't give me information as to which links/joints were wrong, so Andy and I went in and changed the error message.
