### PR TITLE
Fixed AVL configuration bug in checkDependency

### DIFF
--- a/util/checkDependency.m
+++ b/util/checkDependency.m
@@ -212,7 +212,7 @@ if ~ok
       end
       
     case 'bullet'
-      conf.bullet_enabled = ~isempty(getCMakeParam('bullet'),conf);
+      conf.bullet_enabled = ~isempty(getCMakeParam('bullet',conf));
       if (~conf.bullet_enabled)
         disp(' ');
         disp(' Bullet not found.  To resolve this you will have to rerun make (from the shell)');


### PR DESCRIPTION
I was having trouble getting AVL recognized by the drake checkDependency routine. Turns out the cmake command was running from the current matlab directory rather than from root, so it couldn't find /pod-build. Works for me now. Andy helped out a bit too.

Trajectory optimization and SOS installed no problem.
