### PR TITLE
IK posture truncation

### DIFF
--- a/systems/plants/@RigidBodyManipulator/inverseKinBackend.m
+++ b/systems/plants/@RigidBodyManipulator/inverseKinBackend.m
@@ -243,6 +243,9 @@ for i = 1:nT
   end
 end
 if(mode == 1)
+  success_idx = info<10;
+  q(:,success_idx) = reshape(max([reshape(q(:,success_idx),[],1) reshape(joint_min(:,success_idx),[],1)],[],2),nq,[]);
+  q(:,success_idx) = reshape(min([reshape(q(:,success_idx),[],1) reshape(joint_max(:,success_idx),[],1)],[],2),nq,[]);
   varargout{1} = q;
   varargout{2} = info;
   if(nargout == 3)
@@ -630,6 +633,11 @@ if(mode == 2)
     elseif(info == 32)
       info = 6;
     end
+  end
+  % Truncate the posture to be within the joint limit
+  if(info <10)
+    q = reshape(max([q(:) joint_min(:)],[],2),nq,nT);
+    q = reshape(min([q(:) joint_max(:)],[],2),nq,nT);
   end
   varargout{1} = q;
   varargout{2} = qdot;

--- a/systems/plants/inverseKinBackend.cpp
+++ b/systems/plants/inverseKinBackend.cpp
@@ -1027,7 +1027,15 @@ void inverseKinBackend(RigidBodyManipulator* model_input, const int mode, const 
       }
       memcpy(q_sol.col(i).data(),x,sizeof(double)*nq);
       INFO[i] = static_cast<int>(INFO_snopt[i]);
-       
+      if(INFO[i]<10)
+      {
+        for(int j = 0;j<nq;j++)
+        {
+          q_sol(j,i) = q_sol(j,i)>joint_limit_min(j,i)?q_sol(j,i):joint_limit_min(j,i);
+          q_sol(j,i) = q_sol(j,i)<joint_limit_max(j,i)?q_sol(j,i):joint_limit_max(j,i);
+        }
+      }
+      
       
       delete[] xmul; delete[] xstate; delete[] xnames;
       delete[] F; delete[] Fmul; delete[] Fstate; delete[] Fnames;
@@ -2125,6 +2133,17 @@ void inverseKinBackend(RigidBodyManipulator* model_input, const int mode, const 
       delete[] infeasible_constraint_idx;
     }
     *INFO = static_cast<int>(*INFO_snopt);
+    if(*INFO<10)
+    {
+      for(int i=0; i<nT;i++)
+      {
+        for(int j = 0;j<nq;j++)
+        {
+          q_sol(j,i) = q_sol(j,i)>joint_limit_max(j,i)?q_sol(j,i):joint_limit_max(j,i);
+          q_sol(j,i) = q_sol(j,i)<joint_limit_min(j,i)?q_sol(j,i):joint_limit_min(j,i);
+        }
+      }
+    }
 
     delete rw;
     delete[] xmul; delete[] xstate; delete[] xnames; 


### PR DESCRIPTION
In IK, the output posture from SNOPT can be outside of the posture bounds by the SNOPT numerical tolerance. Now if SNOPT finds the solution, IK checks the SNOPT output and truncates the solution within the posture bounds.
