### PR TITLE
Change to RigidBodyManipulator contactConstraints.

### DIFF
--- a/systems/plants/@RigidBodyManipulator/contactConstraints.m
+++ b/systems/plants/@RigidBodyManipulator/contactConstraints.m
@@ -41,8 +41,7 @@ end
 [pos,vel,normal,mu] = collisionDetect(obj,contact_pos);
 
 relpos = contact_pos - pos;
-s = sign(sum(relpos.*normal,1));
-phi = (sqrt(sum(relpos.^2,1)).*s)';
+phi = sum(relpos.*normal,1)';
 if (nargout>1)
   % recall that dphidx = normal'; n = dphidq = dphidx * dxdq
   % for a single contact, we'd have


### PR DESCRIPTION
Motivated by failure of original formulation when used with TaylorVars, changed contactConstraints so that 

phi = <relpos,normal>

instead of

phi = sgn(<relpos,normal>) \* ||relpos||

As a note, phi(x0) = 0 resulted in strange behavior on the sqrt() step
