### PR TITLE
RBM ignores negative transmission reductions when computing input limits

### DIFF
--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -444,8 +444,8 @@ classdef RigidBodyManipulator < Manipulator
         joint = model.body(model.actuator(i).joint);
         B(joint.dofnum,i) = model.actuator(i).reduction;
         if ~isinf(joint.effort_min) || ~isinf(joint.effort_max)
-          u_limit(i,1) = joint.effort_min/model.actuator(i).reduction;
-          u_limit(i,2) = joint.effort_max/model.actuator(i).reduction;
+          u_limit(i,1) = joint.effort_min/abs(model.actuator(i).reduction);
+          u_limit(i,2) = joint.effort_max/abs(model.actuator(i).reduction);
           if sum(B(joint.dofnum,:)~=0)>1
             warning('Drake:RigidBodyManipulator:UnsupportedJointEffortLimit','The specified joint effort limit cannot be expressed as simple input limits; the offending limits will be ignored');
             u_limit(B(joint.dofnum,:)~=0)=[-inf inf];


### PR DESCRIPTION
The PR2 example was failing because the URDF includes some negative reductions and they were flipping the min/max efforts. The previous behavior before asymmetric effort limits were supported was to take the absolute value of reductions, so I've put this logic back in.
