### PR TITLE
Use double precision for Bullet.

### DIFF
--- a/systems/plants/collision/CMakeLists.txt
+++ b/systems/plants/collision/CMakeLists.txt
@@ -6,7 +6,7 @@ set(drakeCollision_SRC_FILES Model.cpp GenericModel.cpp Element.cpp
 pods_find_pkg_config(bullet)
 
 if (bullet_FOUND)
-  add_definitions( -DBULLET_COLLISION )   
+  add_definitions( -DBULLET_COLLISION -DBT_USE_DOUBLE_PRECISION )   
   set( drakeCollision_SRC_FILES ${drakeCollision_SRC_FILES} BulletModel.cpp BulletElement.cpp BulletResultCollector.cpp )   
   set(bullet "yes" CACHE STRING "yes" )
 endif()


### PR DESCRIPTION
Define BT_USE_DOUBLE_PRECISION in collision CMakeLists.txt. We shouldn't need
to do this once we can read it from the pkg-config file properly. 

Note: This pull-request should be applied at the same time as RobotLocomotion/bullet-pod#1
