### PR TITLE
Changed LCMGL checkDependency to use cmake class path

### DIFF
--- a/util/checkDependency.m
+++ b/util/checkDependency.m
@@ -78,7 +78,9 @@ if ~ok
   
       if (~conf.lcmgl_enabled)
         try % try to add bot2-lcmgl.jar
-          javaaddpath(fullfile(pods_get_base_path,'share','java','bot2-lcmgl.jar'));
+          lcm_java_classpath = getCMakeParam('LCMGL_JAR_FILE',conf);
+          javaaddpath(lcm_java_classpath);
+          disp(' Added the lcmgl jar to your javaclasspath (found via cmake)');
         catch
         end
         conf.lcmgl_enabled = exist('bot_lcmgl.data_t','class');


### PR DESCRIPTION
checkDependency assumes that libbot is installed in the same place as drake, which isn't the case for my machine. Not totally sure how this is supposed to work, but I do have an LCMGL related cmake variable that points to the right place? Unclear if this is a general fix or just happens to work for me...
