### PR TITLE
Fix geval numerical with matrix output.

### DIFF
--- a/util/geval.m
+++ b/util/geval.m
@@ -197,9 +197,9 @@ switch (method)
           for k=1:o
             switch options.diff_type
               case 'forward'
-                varargout{p+k}(:,ind) = (df_p{k}-varargout{k})/da;
+                varargout{p+k}(:,ind) = (df_p{k}(:)-varargout{k}(:))/da;
               case 'central'
-                varargout{p+k}(:,ind) = (df_p{k}-df_m{k})/(2*da);
+                varargout{p+k}(:,ind) = (df_p{k}(:)-df_m{k}(:))/(2*da);
             end
           end
           varargin{i}(j)=varargin{i}(j)+da;

--- a/util/testGevalMatrixOutput.m
+++ b/util/testGevalMatrixOutput.m
@@ -1,0 +1,19 @@
+function testGevalMatrixOutput()
+  % testGevalMatrixOutput checks whether geval runs for numerical
+  % differentiation of matrix valued functions.
+  fun = @(x) [x(1),0;0,2*x(2)];
+  df = reshape([[1,0;0,0],[0,0;0,2]],4,2);
+  x0 = zeros(2,1);
+
+  options.grad_method = 'numerical';
+  [f,df_num] = geval(fun,x0,options);
+  valuecheck(df_num,df);
+
+  options.diff_type = 'forward';
+  [f,df_num] = geval(fun,x0,options);
+  valuecheck(df_num,df);
+
+  options.diff_type = 'central';
+  [f,df_num] = geval(fun,x0,options);
+  valuecheck(df_num,df);
+end


### PR DESCRIPTION
Surpised that none of our unit tests caught this one. Numerical differentiation
of matrix valued functions simply errored due to a subscripted assignment
dimension mismatch. This commit also adds a test that would have alerted us to
the problem.
