### PR TITLE
Remove the dependencies on MAT file in the C++ executables for IK test

### DIFF
--- a/systems/plants/test/CMakeLists.txt
+++ b/systems/plants/test/CMakeLists.txt
@@ -14,7 +14,7 @@ if (eigen3_FOUND AND Boost_FOUND)
 endif()
 
 macro(add_ik_cpp)
-  add_mex(${ARGV} EXECUTABLE ${ARGV}.cpp)
+  add_executable(${ARGV} ${ARGV}.cpp)
   include_directories( .. )
   set_target_properties(${ARGV} PROPERTIES COMPILE_FLAGS "-fPIC")
   target_link_libraries(${ARGV} drakeRBMurdf drakeURDFinterface drakeRigidBodyConstraint drakeIK)

--- a/systems/plants/test/testApproximateIK.cpp
+++ b/systems/plants/test/testApproximateIK.cpp
@@ -5,7 +5,6 @@
 #include "../IKoptions.h"
 #include <iostream>
 #include <cstdlib>
-#include "mat.h"
 
 using namespace std;
 using namespace Eigen;
@@ -18,22 +17,8 @@ int main()
   }
   Vector2d tspan;
   tspan<<0,1;
-  VectorXd q0;
-  MATFile *pmat;
-  pmat = matOpen("../../examples/Atlas/data/atlas_fp.mat","r");
-  if(pmat == NULL)
-  {
-    printf("Error reading mat file\n");
-    return(EXIT_FAILURE);
-  }
-  mxArray* pxstar = matGetVariable(pmat,"xstar");
-  if(pxstar == NULL)
-  {
-    printf("no xstar in mat file\n");
-    return(EXIT_FAILURE);
-  }
-  q0 = VectorXd(model->num_dof);
-  memcpy(q0.data(),mxGetPr(pxstar),sizeof(double)*model->num_dof);
+  VectorXd q0 = VectorXd::Zero(model->num_dof);
+  q0(3) = 0.8;
   Vector3d com_des = Vector3d::Zero();
   com_des(2) = nan("");
   WorldCoMConstraint* com_kc = new WorldCoMConstraint(model,com_des,com_des);
@@ -47,6 +32,5 @@ int main()
   printf("INFO = %d\n",info);
   delete com_kc;
   delete[] constraint_array;
-  matClose(pmat);
   return 0;
 }

--- a/systems/plants/test/testIK.cpp
+++ b/systems/plants/test/testIK.cpp
@@ -5,7 +5,6 @@
 #include "../IKoptions.h"
 #include <iostream>
 #include <cstdlib>
-#include "mat.h"
 #include <Eigen/Dense>
 
 using namespace std;
@@ -19,27 +18,9 @@ int main()
   }
   Vector2d tspan;
   tspan<<0,1;
-  VectorXd q0;
-  MATFile *pnommat;
+  VectorXd q0 = VectorXd::Zero(model->num_dof);
   // The state frame of cpp model does not match with the state frame of MATLAB model, since the dofname_to_dofnum is different in cpp and MATLAB
-  pnommat = matOpen("../../examples/Atlas/data/atlas_fp.mat","r");
-  if(pnommat == NULL)
-  {
-    printf("Error reading mat file\n");
-    return(EXIT_FAILURE);
-  }
-  mxArray* pxstar = matGetVariable(pnommat,"xstar");
-  if(pxstar == NULL)
-  {
-    printf("no xstar in mat file\n");
-    return(EXIT_FAILURE);
-  }
-  // for(int i = 0;i<model->num_bodies;i++)
-  // {
-  //   printf("%d %s %5.2f\n",i,model->bodies[i].linkname.c_str(),model->bodies[i].mass);
-  // }
-  q0 = VectorXd(model->num_dof);
-  memcpy(q0.data(),mxGetPr(pxstar),sizeof(double)*model->num_dof);
+  q0(3) = 0.8;
   Vector3d com_lb = Vector3d::Zero(); 
   Vector3d com_ub = Vector3d::Zero(); 
   com_lb(2) = 0.9;
@@ -53,11 +34,11 @@ int main()
   int info;
   vector<string> infeasible_constraint;
   inverseKin(model,q0,q0,num_constraints,constraint_array,q_sol,info,infeasible_constraint,ikoptions);
+  printf("INFO = %d\n",info);
   if(info != 1)
   {
     return 1;
   }
-  printf("INFO = %d\n",info);
   model->doKinematics(q_sol.data());
   Vector3d com;
   model->getCOM(com);
@@ -70,7 +51,6 @@ int main()
   matClose(presultmat);*/
   delete com_kc;
   delete[] constraint_array;
-  matClose(pnommat);
   return 0;
 }
   

--- a/systems/plants/test/testIKpointwise.cpp
+++ b/systems/plants/test/testIKpointwise.cpp
@@ -5,7 +5,6 @@
 #include "../IKoptions.h"
 #include <iostream>
 #include <cstdlib>
-#include "mat.h"
 
 using namespace std;
 using namespace Eigen;
@@ -18,25 +17,12 @@ int main()
   }
   Vector2d tspan;
   tspan<<0,1;
-  MATFile *pmat;
-  pmat = matOpen("../../examples/Atlas/data/atlas_fp.mat","r");
-  if(pmat == NULL)
-  {
-    printf("Error reading mat file\n");
-    return(EXIT_FAILURE);
-  }
-  mxArray* pxstar = matGetVariable(pmat,"xstar");
-  if(pxstar == NULL)
-  {
-    printf("no xstar in mat file\n");
-    return(EXIT_FAILURE);
-  }
   int nT = 3;
   double t[3]={0.0,0.5,1.0};
-  MatrixXd q0(model->num_dof,nT);
+  MatrixXd q0 = MatrixXd::Zero(model->num_dof,nT);
   for(int i = 0;i<nT;i++)
   {
-    memcpy(q0.data()+model->num_dof*i,mxGetPr(pxstar),sizeof(double)*model->num_dof);
+    q0(3,i) = 0.8;
   }
   Vector3d com_des = Vector3d::Zero();
   com_des(2) = nan("");
@@ -61,6 +47,5 @@ int main()
   delete com_kc;
   delete[] constraint_array;
   delete[] info;
-  matClose(pmat);
   return 0;
 }

--- a/systems/plants/test/testIKtraj.cpp
+++ b/systems/plants/test/testIKtraj.cpp
@@ -5,7 +5,6 @@
 #include "../IKoptions.h"
 #include <iostream>
 #include <cstdlib>
-#include "mat.h"
 
 using namespace std;
 using namespace Eigen;
@@ -18,19 +17,6 @@ int main()
   }
   Vector2d tspan;
   tspan<<0,1;
-  MATFile *pmat;
-  pmat = matOpen("../../examples/Atlas/data/atlas_fp.mat","r");
-  if(pmat == NULL)
-  {
-    printf("Error reading mat file\n");
-    return(EXIT_FAILURE);
-  }
-  mxArray* pxstar = matGetVariable(pmat,"xstar");
-  if(pxstar == NULL)
-  {
-    printf("no xstar in mat file\n");
-    return(EXIT_FAILURE);
-  }
   int l_hand;
   int r_hand;
   //int l_foot;
@@ -55,8 +41,8 @@ int main()
     //}
   }
   int nq = model->num_dof;
-  VectorXd qstar(nq);
-  memcpy(qstar.data(),mxGetPr(pxstar),sizeof(double)*nq);
+  VectorXd qstar = VectorXd::Zero(nq);
+  qstar(3) = 0.8;
   model->doKinematics(qstar.data());
   Vector3d com0;
   model->getCOM(com0);
@@ -75,11 +61,7 @@ int main()
   {
     t[i] = dt*i;
   }
-  MatrixXd q0(model->num_dof,nT);
-  for(int i = 0;i<nT;i++)
-  {
-    memcpy(q0.data()+model->num_dof*i,mxGetPr(pxstar),sizeof(double)*model->num_dof);
-  }
+  MatrixXd q0 = qstar.replicate(1,nT);
   VectorXd qdot0 = VectorXd::Zero(model->num_dof);
   Vector3d com_lb = com0;
   com_lb(0) = nan("");;
@@ -92,7 +74,7 @@ int main()
   Vector3d rhand_pos_lb = rhand_pos0;
   rhand_pos_lb(0) +=0.1;
   rhand_pos_lb(1) +=0.05;
-  rhand_pos_lb(2) +=0.75;
+  rhand_pos_lb(2) +=0.25;
   Vector3d rhand_pos_ub = rhand_pos_lb;
   rhand_pos_ub(2) += 0.25;
   Vector2d tspan_end;
@@ -137,6 +119,5 @@ int main()
   delete com_kc;
   delete[] constraint_array;
   delete[] t;
-  matClose(pmat);
   return 0;
 }


### PR DESCRIPTION
Now the IK C++ test only depends on drakeURDFinterface, and it does not depend on MATLAB any more
