### PR TITLE
Fix for gradient with position control enabled

### DIFF
--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -238,7 +238,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
             dtau = [zeros(num_q,1), matGradMult(dB,u) - dC, B];
           else
             tau = -C;
-            dtau = [zeros(num_q,1), -dC];
+            dtau = [zeros(num_q,1), -dC, zeros(size(B))];
           end
         end
         
@@ -296,7 +296,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
           nC=0;
           J = zeros(nL+nP,num_q);
           if (nargout>4)
-            dJ = sparse(nL+nP,num_q^2);
+            dJ = zeros(nL+nP,num_q^2);
           end
         end
         

--- a/systems/plants/test/testPositionControlGradients.m
+++ b/systems/plants/test/testPositionControlGradients.m
@@ -1,0 +1,24 @@
+function testPositionControlGradients
+
+p = TimeSteppingRigidBodyManipulator('ActuatedPendulum.urdf', .01);
+p = enableIdealizedPositionControl(p, true);
+p = compile(p);
+
+num_tests = 10;
+
+x = 100*rand(2,num_tests);
+u = rand(1,num_tests);
+
+for i=1:num_tests
+    
+    [xdn1,df1] = geval(1,@update,p,0,x(:,i),u(:,i),struct('grad_method','numerical'));
+    [xdn2,df2] = geval(1,@update,p,0,x(:,i),u(:,i),struct('grad_method','user'));
+
+    if (any(abs(xdn1-xdn2)>1e-5))
+        error('Next states when computing gradients don''t match!');
+    end
+    if (any(any(abs(df1-df2)>1e-5)))
+        error('Gradients don''t match!');
+    end
+
+end


### PR DESCRIPTION
Not ready to merge. The user gradient with respect to the input (the last column of df2) is zero for the user gradients but non-zero for the numerical ones. Do we have a bug in TimeSteppingRigidBodyManipulator? I can look into it I wanted to check I am not missing something conceptually first.
