### PR TITLE
Fix "reset" and the current speed being unreadable on Ubuntu

### DIFF
--- a/examples/Atlas/runAtlasWalkingPlanning.m
+++ b/examples/Atlas/runAtlasWalkingPlanning.m
@@ -38,7 +38,7 @@ else
   footstep_plan.draw_2d();
 end
 
-v.playback(xtraj);
+v.playback(xtraj, struct('slider', true));
 
 
 

--- a/systems/visualizers/Visualizer.m
+++ b/systems/visualizers/Visualizer.m
@@ -4,34 +4,34 @@ classdef Visualizer < DrakeSystem
 % to draw a pendulum given the position of the pendulum.  Visualizers can
 % be cascaded onto the output of a DynamicalSystem so that the
 % visualization occurs at the time of simulation, or can 'playback' the
-% trajectory that is the result of a simulation. 
+% trajectory that is the result of a simulation.
 
   methods (Abstract=true)
     draw(obj,t,y); % draw function interface
   end
 
-  methods 
+  methods
     function obj=Visualizer(input_frame)
       typecheck(input_frame,'CoordinateFrame');
       obj=obj@DrakeSystem(0,0,input_frame.dim,0,true);
       obj = setInputFrame(obj,input_frame);
     end
-    
+
     function x0 = getInitialState(obj)
       x0=[];
     end
     function xcdot = dynamics(obj,t,x,u)
-      error('shouldn''t get here'); 
+      error('shouldn''t get here');
     end
     function xdn = update(obj,t,x,u)
       error('shouldn''t get here');
     end
-    
+
     function y = output(obj,t,x,u)
       drawWrapper(obj,t,u);
       y=[];
     end
-    
+
     function ts = getSampleTime(obj)
       if (obj.display_dt>0)
         ts = [obj.display_dt;0];
@@ -39,7 +39,7 @@ classdef Visualizer < DrakeSystem
         ts = [-1;1];  % inherited sample time, fixed in minor offset
       end
     end
-    
+
     function drawWrapper(obj,t,y)
       sfigure(obj.fignum);
       clf; hold on;
@@ -49,7 +49,7 @@ classdef Visualizer < DrakeSystem
       end
       drawnow;
     end
-    
+
     function status = ode_draw(obj,t,x,flag)
       status=0;
       if (strcmp(flag,'done'))
@@ -57,7 +57,7 @@ classdef Visualizer < DrakeSystem
       end
       drawWrapper(obj,t,x);
     end
-   
+
     function playback(obj,xtraj,options)
       %   Animates the trajectory in quasi- correct time using a matlab timer
       %     optional controlobj will playback the corresponding control scopes
@@ -65,7 +65,7 @@ classdef Visualizer < DrakeSystem
       %   @param xtraj trajectory to visualize
       %   @param options visualizer configuration:
       %                     slider: create playback slider to control time and speed
-      
+
       typecheck(xtraj,'Trajectory');
       if (xtraj.getOutputFrame()~=obj.getInputFrame)
         xtraj = xtraj.inFrame(obj.getInputFrame);  % try to convert it
@@ -77,39 +77,39 @@ classdef Visualizer < DrakeSystem
       if ~isfield(options, 'slider')
         options.slider = false;
       end
-      
+
       f = sfigure(89);
       set(f, 'Visible', 'off');
       set(f, 'Position', [560 400 560 70]);
-      
+
       tspan = xtraj.getBreaks();
       t0 = tspan(1);
-      ts = getSampleTime(xtraj); 
+      ts = getSampleTime(xtraj);
       time_steps = (tspan(end)-tspan(1))/max(obj.display_dt,eps);
-      
+
       speed_format = 'Speed = %.3g';
       time_format = 'Time = %.3g';
-      
-      
+
+
       time_slider = uicontrol('Style', 'slider', 'Min', tspan(1), 'Max', tspan(end),...
-        'Value', tspan(1), 'Position', [110, 10, 440, 20],...
+        'Value', tspan(1), 'Position', [135, 10, 415, 20],...
         'Callback',{@update_time_display});
       speed_slider = uicontrol('Style', 'slider', 'Min', -3, 'Max', 1, ...
-        'Value', log10(obj.playback_speed), 'Position', [185, 35, 365, 20], ...
+        'Value', log10(obj.playback_speed), 'Position', [255, 35, 295, 20], ...
         'Callback', {@update_speed});
-      speed_display = uicontrol('Style', 'text', 'Position', [90, 35, 90, 20],...
+      speed_display = uicontrol('Style', 'text', 'Position', [130, 35, 120, 20],...
         'String', sprintf(speed_format, obj.playback_speed));
       rewind_button = uicontrol('Style', 'pushbutton', 'String', 'Reset', ...
-        'Position', [10, 35, 35, 20], 'Callback', {@rewind_vis});
+        'Position', [10, 35, 55, 20], 'Callback', {@rewind_vis});
       play_button = uicontrol('Style', 'pushbutton', 'String', 'Play', ...
-        'Position', [50, 35, 35, 20], 'Callback', {@start_playback},...
+        'Position', [70, 35, 55, 20], 'Callback', {@start_playback},...
         'Interruptible', 'on');
-      time_display = uicontrol('Style', 'text', 'Position', [10, 10, 90, 20],...
+      time_display = uicontrol('Style', 'text', 'Position', [10, 10, 120, 20],...
         'String', sprintf(time_format, tspan(1)));
-      
+
       % use a little undocumented matlab to get continuous slider feedback:
-      time_slider_listener = handle.listener(time_slider,'ActionEvent',@update_time_display);  
-      
+      time_slider_listener = handle.listener(time_slider,'ActionEvent',@update_time_display);
+
       function update_speed(source, eventdata)
         obj.playback_speed = 10 ^ (get(speed_slider, 'Value'));
         set(speed_display, 'String', sprintf(speed_format, obj.playback_speed));
@@ -125,7 +125,7 @@ classdef Visualizer < DrakeSystem
         obj.drawWrapper(t, xtraj.eval(t));
       end
       function start_playback(source, eventdata)
-        if ~ishandle(play_button) 
+        if ~ishandle(play_button)
           error('somebody deleted my uicontrols.  draw functions should not call clf without creating their own figure (it''s bad form)');
         end
         if get(play_button, 'UserData')
@@ -178,14 +178,14 @@ classdef Visualizer < DrakeSystem
         end
       end
       update_time_display(time_slider, [])
-      
+
       if options.slider
         set(f, 'Visible', 'on');
       else
         start_playback([], []);
       end
     end
-    
+
     function inspector(obj,x0,state_dims,minrange,maxrange)
       % set up a little gui with sliders to manually adjust each of the
       % coordinates.
@@ -195,11 +195,11 @@ classdef Visualizer < DrakeSystem
       if (nargin<3) state_dims = (1:fr.dim)'; end
       if (nargin<4) minrange = repmat(-5,size(state_dims)); end
       if (nargin<5) maxrange = -minrange; end
-      
+
       x0(state_dims) = max(min(x0(state_dims),maxrange),minrange);
-      
+
       obj.drawWrapper(0,x0);
-      
+
       rows = ceil(length(state_dims)/2);
       f = sfigure(99); clf;
       set(f, 'Position', [560 400 560 20 + 30*rows]);
@@ -216,7 +216,7 @@ classdef Visualizer < DrakeSystem
         slider_listener{i} = handle.listener(slider{i},'ActionEvent',@update_display);
         y = y - 30;
       end
-      
+
       function update_display(source, eventdata)
         t = 0; x = x0;
         for i=state_dims(:)'
@@ -224,9 +224,9 @@ classdef Visualizer < DrakeSystem
         end
         x
         obj.drawWrapper(t,x);
-      end      
+      end
     end
-    
+
     function playbackMovie(obj,xtraj,filename)
       if (nargin<2)
         [filename,pathname] = uiputfile('*','Save playback to movie');
@@ -257,7 +257,7 @@ classdef Visualizer < DrakeSystem
           playbackMovie(obj,xtraj,fullfile(path,[name,ext]));
       end
     end
-    
+
     function playbackAVI(obj,xtraj,filename)
       % Plays back a trajectory and creates an avi file.
       %   The filename argument is optional; if not specified, a gui will prompt
@@ -266,31 +266,31 @@ classdef Visualizer < DrakeSystem
       %  @param xtraj trajectory to visulalize
       %  @param filename file to produce (optional, if not given a GUI will
       %    pop up and ask for it)
-      
+
       typecheck(xtraj,'Trajectory');
       if (xtraj.getOutputFrame()~=obj.getInputFrame)
         xtraj = xtraj.inFrame(obj.getInputFrame);  % try to convert it
       end
-      ts = getSampleTime(xtraj); 
-      
+      ts = getSampleTime(xtraj);
+
       if (nargin<3)
         [filename,pathname] = uiputfile('*.avi','Save playback to AVI');
         filename = [pathname,'/',filename];
       end
-      
+
       if (obj.display_dt==0)
         if (ishandle(obj)) error('i assumed it wasn''t a handle'); end
         obj.display_dt = 1/30;  % just for the remainder of this file.
       end
-      
+
       breaks = getBreaks(xtraj);
       tspan = breaks(1):obj.display_dt:breaks(end);
       if (breaks(end)-tspan(end)>eps) tspan=[tspan,breaks(end)]; end
-      
+
       mov = VideoWriter(filename,'Motion JPEG AVI');
       mov.FrameRate = obj.playback_speed/obj.display_dt;
       open(mov);
-      
+
       width=[]; height=[];
       for i=1:length(tspan)
         t = tspan(i);
@@ -309,10 +309,10 @@ classdef Visualizer < DrakeSystem
         end
         writeVideo(mov,fr);
       end
-      
+
       close(mov);
     end
-    
+
     function playbackSWF(obj,xtraj,swf,options)
       % Creates a SWF (Flash) movie of the trajectory.  This is often
       % useful for presentations because the movie is all vector graphics,
@@ -323,11 +323,11 @@ classdef Visualizer < DrakeSystem
       % @param swf either the filename of the swf file to write, or an
       % instance of the SWFWriter class.  If swf is empty, then you will be
       % prompted for a filename (with the gui).
-      % 
+      %
       % @option poster set to true to export a pdf of the first frame.
       % @default false
       %
-      % Note: You must have <b>pdftk</b> and <b>swftools</b> installed for 
+      % Note: You must have <b>pdftk</b> and <b>swftools</b> installed for
       % this to work.
       %
       % If you want to print axes, you'll want to set your visualizer to
@@ -343,39 +343,39 @@ classdef Visualizer < DrakeSystem
       % @param xtraj Trajectory to make the movie around
       % @param filename name of swf file. (optional, if it isn't given a GUI will pop
       %   up and ask for it.)
-      
+
       typecheck(xtraj,'Trajectory');
       if (xtraj.getOutputFrame()~=obj.getInputFrame)
         xtraj = xtraj.inFrame(obj.getInputFrame);  % try to convert it
       end
-      ts = getSampleTime(xtraj); 
-      
+      ts = getSampleTime(xtraj);
+
       bCloseAtEnd = true;
       if (nargin<3 || isempty(swf))
         swf = SWFWriter();  % this will prompt for a filename
       elseif isa(swf,'char') % then it's a filename
-        swf = SWFWriter(swf); 
+        swf = SWFWriter(swf);
       else
         bCloseAtEnd = false;
       end
-      
+
       if (nargin<4) options=struct(); end
-      if (isfield(options,'poster')) 
+      if (isfield(options,'poster'))
         swf.poster = options.poster;
       end
       if (isfield(options,'loop'))
         swf.loop = options.loop;
       end
-      
+
       if (obj.display_dt==0)
         if (ishandle(obj)) error('i assumed it wasn''t a handle'); end
         obj.display_dt = 1/30;  % just for the remainder of this file.
       end
-      
+
       breaks = getBreaks(xtraj)/obj.playback_speed;
       tspan = obj.playback_speed*(breaks(1):obj.display_dt:breaks(end));
       if (breaks(end)-tspan(end)>eps) tspan=[tspan,breaks(end)]; end
-            
+
       for i=1:length(tspan)
         t = tspan(i);
         if (ts(1)>0) t = round((t-ts(2))/ts(1))*ts(1) + ts(2); end  % align with sample times if necessary
@@ -383,15 +383,15 @@ classdef Visualizer < DrakeSystem
         if (~obj.draw_axes) axis off; end
         swf.addFrame();
       end
-      
+
       if (bCloseAtEnd)
         swf.close();
       end
 
     end
   end
-  
-  properties 
+
+  properties
     display_dt=0; %0.05;  % requested time between display frames (use 0 for drawing as fast as possible)
     playback_speed=1;  % 1=realtime
     draw_axes=false;  % when making movies true=gcf,false=gca
@@ -399,5 +399,5 @@ classdef Visualizer < DrakeSystem
     axis;  % set this to non-empty for a fixed view (must be implemented by the draw method)
     fignum = 25;
   end
-  
+
 end


### PR DESCRIPTION
The slider widget looked nice on OSX, but the Ubuntu fonts didn't fit inside the display boxes, so it was impossible to read. 
