### PR TITLE
Fix non-rigid body transform for Ttree of first body in PlanarNLink

### DIFF
--- a/examples/PlanarNLink/PlanarNLink.m
+++ b/examples/PlanarNLink/PlanarNLink.m
@@ -18,7 +18,6 @@ classdef PlanarNLink < PlanarRigidBodyManipulator
       body=RigidBody();
       body.linkname='base';
       body.robotnum=1;
-      body.Ttree=[-1,0,0,0; 0,1,0,0; 0,0,1,0; 0 0 0 1];
       model.body=body;
       
       % first link


### PR DESCRIPTION
body.Ttree for first body in tree was set to [-1,0,0,0; 0,1,0,0; 0,0,1,0; 0 0 0 1], which is not a rigid body transform. Got rid of this line so that the default eye(4) is used.
