### PR TITLE
Fix footstep frames

### DIFF
--- a/systems/robotInterfaces/@Biped/planZMPTraj.m
+++ b/systems/robotInterfaces/@Biped/planZMPTraj.m
@@ -145,12 +145,12 @@ for f = {'right', 'left'}
   foot = f{1};
   frame_id = biped.foot_frame_id.(foot);
   body_ind = biped.getFrame(frame_id).body_ind;
-  T = inv(biped.getFrame(frame_id).T);
+  T = biped.getFrame(frame_id).T;
   step_poses = [step_knots.(foot)];
   for j = 1:size(step_poses, 2);
-    xyz1 = T * [step_poses(1:3,j); 1];
-    rpy = rotmat2rpy(rpy2rotmat(step_poses(4:6,j)) * T(1:3,1:3));
-    step_poses(:,j) = [xyz1(1:3); rpy];
+    Tsole = [rpy2rotmat(step_poses(4:6,j)), step_poses(1:3,j); 0 0 0 1];
+    Torig = Tsole * inv(T);
+    step_poses(:,j) = [Torig(1:3,4); rotmat2rpy(Torig(1:3,1:3))];
   end
   link_constraints(end+1) = struct('link_ndx', body_ind, 'pt', [0;0;0], 'min_traj', [], 'max_traj', [], 'traj', PPTrajectory(foh([step_knots.t], step_poses)));
 end

--- a/systems/robotInterfaces/Footstep.m
+++ b/systems/robotInterfaces/Footstep.m
@@ -28,11 +28,10 @@ classdef Footstep
 
     function msg = to_footstep_t(obj, biped)
       msg = drc.footstep_t();
-      T = inv(biped.getFrame(obj.frame_id).T);
-      pos = zeros(6,1);
-      xyz1 = T * [obj.pos(1:3);1];
-      pos(1:3) = xyz1(1:3);
-      pos(4:6) = rotmat2rpy(rpy2rotmat(obj.pos(4:6)) * T(1:3,1:3));
+      T = biped.getFrame(obj.frame_id).T;
+      Tsole = [rpy2rotmat(obj.pos(4:6)), obj.pos(1:3); 0 0 0 1];
+      Torig = Tsole * inv(T);
+      pos = [Torig(1:3,4); rotmat2rpy(Torig(1:3,1:3))];
       msg.pos = encodePosition3d(pos);
       msg.id = obj.id;
       if obj.frame_id == biped.foot_frame_id.right
@@ -69,10 +68,9 @@ classdef Footstep
       end
       msg_pos = decodePosition3d(msg.pos);
       T = biped.getFrame(frame_id).T;
-      pos = zeros(6,1);
-      xyz1 = T * [msg_pos(1:3);1];
-      pos(1:3) = xyz1(1:3);
-      pos(4:6) = rotmat2rpy(rpy2rotmat(msg_pos(4:6)) * T(1:3,1:3));
+      Torig = [rpy2rotmat(msg_pos(4:6)), msg_pos(1:3); 0 0 0 1];
+      Tsole = Torig * T;
+      pos = [Tsole(1:3,4); rotmat2rpy(Tsole(1:3,1:3))];
       is_in_contact = msg.is_in_contact;
       pos_fixed = [msg.fixed_x;
                    msg.fixed_y;


### PR DESCRIPTION
The translation layer used to convert footstep sole poses to origin poses was incorrect (so far this was only affecting DRC, not any of the Drake examples). I've fixed it now. 

I also updated to a better fixed point for Atlas (the same one we use in DRC) which keeps the knees a bit more bent and prevents them from going singular during walking. 
