### PR TITLE
RigidBodyInertialMeasurementUnit

### DIFF
--- a/systems/plants/RigidBodyInertialMeasurementUnit.m
+++ b/systems/plants/RigidBodyInertialMeasurementUnit.m
@@ -34,7 +34,7 @@ classdef RigidBodyInertialMeasurementUnit < RigidBodySensor
       
       kinsol = doKinematics(manip,q,false,true,qd);
       
-      [x,J] = forwardKin(manip,kinsol,obj.body,obj.xyz,1);   % ask for rpy (because I want to output omega in rpy)
+      [x,J] = forwardKin(manip,kinsol,obj.body,obj.xyz,1);
       Jdot = forwardJacDot(manip,kinsol,obj.body,obj.xyz,0,0);
       
       % x = f(q)


### PR DESCRIPTION
Updated RigidBodyInertialMeasurementUnit and added test. Output of IMU changed from [quat; rpydot; point acceleration in world frame] to [quat; angular velocity in body frame; point acceleration rotated to body frame]. Comparison between 2d and 3d currently fails because it's not possible to construct a RigidBodyInertialMeasurementUnit for a PlanarRigidBodyManipulator.
