### PR TITLE
ContactForceTorqueSensor update

### DIFF
--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -7,15 +7,15 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
     manip  % the CT manipulator
     sensor % additional TimeSteppingRigidBodySensors (beyond the sensors attached to manip)
     dirty=true;
-    LCP_cache = struct('t',[],'x',[],'u',[],'nargout',[], ...
-                       'z',[],'Mqdn',[],'wqdn',[], ...
-                       'dz',[],'dMqdn',[],'dwqdn',[],'contact_data',[]);
   end
 
   properties (SetAccess=protected)
     timestep
     twoD=false
     position_control=false;
+    LCP_cache = struct('t',[],'x',[],'u',[],'nargout',[], ...
+      'z',[],'Mqdn',[],'wqdn',[], ...
+      'dz',[],'dMqdn',[],'dwqdn',[],'contact_data',[]);
   end
 
   methods
@@ -274,7 +274,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
 
         if (nContactPairs > 0)
           if (nargout>4)
-            [phi,normal,d,xA,xB,idxA,idxB,mu,n,D,dn,dD] = obj.manip.contactConstraints(q,true);
+            [phiC,normal,d,xA,xB,idxA,idxB,mu,n,D,dn,dD] = obj.manip.contactConstraints(q,true);
             nC = length(phiC);
             mC = length(D);
             dJ = zeros(nL+nP+(mC+2)*nC,num_q^2);  % was sparse, but reshape trick for the transpose below didn't work
@@ -283,7 +283,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
             dD = vertcat(dD{:});
             dJ(nL+nP+nC+(1:mC*nC),:) = dD;
           else
-            [phi,normal,d,xA,xB,idxA,idxB,mu,n,D] = obj.manip.contactConstraints(q,true);
+            [phiC,normal,d,xA,xB,idxA,idxB,mu,n,D] = obj.manip.contactConstraints(q,true);
             nC = length(phiC);
             mC = length(D);
           end

--- a/systems/plants/dev/contactSensorTest.m
+++ b/systems/plants/dev/contactSensorTest.m
@@ -2,7 +2,8 @@ function contactSensorTest
 S = warning('OFF','Drake:RigidBodyManipulator:WeldedLinkInd');
 options.floating = true;
 options.twoD = true;
-p = TimeSteppingRigidBodyManipulator('FallingBrick.urdf',.01,options);
+options.terrain = RigidBodyFlatTerrain;
+p = TimeSteppingRigidBodyManipulator('FallingBrickContactPoints.urdf',.01,options);
 
 p = addSensor(p,FullStateFeedbackSensor());
 body = findLinkInd(p,'brick');
@@ -24,7 +25,7 @@ valuecheck(yf.torque,0);
 %v.playback(ytraj);
 
 options.twoD = false;
-p = TimeSteppingRigidBodyManipulator('FallingBrick.urdf',.01,options);
+p = TimeSteppingRigidBodyManipulator('FallingBrickContactPoints.urdf',.01,options);
 
 p = addSensor(p,FullStateFeedbackSensor);
 body = findLinkInd(p,'brick');


### PR DESCRIPTION
Updated `ContactForceTorqueSensor` to work with the new collision detection. Does a lot of this by caching the collision detection data inside `TimeSteppingRigidBodyManipulator`. The test case passes, though, when I tried to add a second object to the test (via `addRobotFromURDF`) there were error messages on compilation. This seemed like a more general issue related to sensors, however.
