### PR TITLE
On Mac, set DYLD_FRAMEWORK_PATH in addition to DYLD_LIBRARY_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,9 +144,13 @@ find_program(ffmpeg ffmpeg)
 set(lcm_java_classpath "${lcm-java_CLASSPATH}" CACHE FILEPATH "${lcm-java_CLASSPATH}" FORCE)
 
 if (APPLE)
-  set(DYLD_LIBRARY_PATH "$ENV{DYLD_LIBRARY_PATH}" CACHE STRING "$ENV{DYLD_LIBRARY_PATH}" )
+  set(DYLD_LIBRARY_PATH "$ENV{DYLD_LIBRARY_PATH}" CACHE STRING "Environment variable used to launch processes from Matlab")
+  set(DYLD_FRAMEWORK_PATH "$ENV{DYLD_FRAMEWORK_PATH}" CACHE STRING "Environment variable used to launch processes from Matlab")
+  mark_as_advanced(DYLD_LIBRARY_PATH)
+  mark_as_advanced(DYLD_FRAMEWORK_PATH)
 else()
-  set(LD_LIBRARY_PATH "$ENV{LD_LIBRARY_PATH}" CACHE STRING "$ENV{LD_LIBRARY_PATH}" )
+  set(LD_LIBRARY_PATH "$ENV{LD_LIBRARY_PATH}" CACHE STRING "Environment variable used to launch processes from Matlab")
+  mark_as_advanced(LD_LIBRARY_PATH)
 endif()
 
 add_test(NAME "RigidBodyManipulatorMemoryTest"

--- a/util/systemWCMakeEnv.m
+++ b/util/systemWCMakeEnv.m
@@ -6,13 +6,14 @@ function [status,result] = systemWCmakeEnv(command)
 % to run due to dynamic linking errors), I have the drake
 % cmake script the following environment varibles:
 %
-%   LD_LIBRARY_PATH  (DYLD_LIBRARY_PATH on mac)
+%   LD_LIBRARY_PATH  (DYLD_LIBRARY_PATH and DYLD_FRAMEWORK_PATH on mac)
 %
 % to disk.  This function temporarily
 % restores the values of those variables before calling 
 % command, to help with execution.  
 
 if (ismac)
+  command = [sprintf('export DYLD_FRAMEWORK_PATH=%s; ',getCMakeParam('DYLD_FRAMEWORK_PATH')), command];
   command = [sprintf('export DYLD_LIBRARY_PATH=%s; ',getCMakeParam('DYLD_LIBRARY_PATH')), command];
 else
   command = [sprintf('export LD_LIBRARY_PATH=%s; ',getCMakeParam('LD_LIBRARY_PATH')), command];


### PR DESCRIPTION
This change updates the top level CMakeLists.txt to capture the
DYLD_FRAMEWORK_PATH environment variable, too.  I also changed the
doc strings for the cache variables and added calls to mark_as_advanced.
