### PR TITLE
modify process launch command line in BotVisualizer

### DIFF
--- a/systems/plants/BotVisualizer.m
+++ b/systems/plants/BotVisualizer.m
@@ -28,7 +28,7 @@ classdef BotVisualizer < RigidBodyVisualizer
         error('Drake:MissingDependency:NoBotVisualizerOnWindowsYet','botvis doesn''t support windows yet');
       end
       
-      if ~exist(fullfile(pods_get_bin_path,'drake_viewer'),'file')
+      if ~exist(fullfile(pods_get_bin_path,'ddConsoleApp'),'file')
         error('Drake:MissingDependency:BotVisualizer','can''t find drake_viewer executable.  you might need to run make (from the shell).  note: BotVisualizer is not supported on windows yet');
       end
       typecheck(manip,'RigidBodyManipulator');
@@ -48,11 +48,11 @@ classdef BotVisualizer < RigidBodyVisualizer
       lc.subscribe('DRAKE_VIEWER_STATUS',obj.status_agg);
 
       % check if there is an instance of drake_viewer already running
-      [~,ck] = system('ps ax 2> /dev/null | grep -i drake_viewer | grep -c -v grep');
+      [~,ck] = system('ps ax 2> /dev/null | grep -i "ddConsoleApp -m ddapp.drakevisualizer" | grep -c -v grep');
       if (str2num(ck)<1) 
         % if not, then launch one...
         disp('launching drake_viewer...');
-        retval = systemWCMakeEnv([fullfile(pods_get_bin_path,'drake_viewer'),' &> drake_viewer.out &']);
+        retval = systemWCMakeEnv([fullfile(pods_get_bin_path,'ddConsoleApp'),' -m ddapp.drakevisualizer &> drake_viewer.out &']);
         
         if ismac % I'm missing valid acks on mac
           pause(1);


### PR DESCRIPTION
Placeholder pull request.  I do not recommend merging this yet.

Todos:
- add RobotLocomotion/director.git submodule (master branch, private for now) to drake-distro master
- add option to fallback to old drake_viewer, how should this be designed?
  - fix status/ack on Mac OSX.  It appears that Matlab cannot receive LCM messages on MacOSX.  Tested on my machine and one other mac.  The file  UDPMulticastProvider.java in lcm.jar fails to start the UDP reader thread.
- add tests
- add new ffmpeg command for BotVisualizer.playbackMovie
