### PR TITLE
Make the Atlas examples clean up their path changes

### DIFF
--- a/examples/Atlas/Atlas.m
+++ b/examples/Atlas/Atlas.m
@@ -18,8 +18,7 @@ classdef Atlas < TimeSteppingRigidBodyManipulator & Biped
         options.terrain = RigidBodyFlatTerrain;
       end
 
-      oldpath = addpath(fullfile(getDrakePath,'examples','Atlas','frames'));
-      finishup = onCleanup(@() path(oldpath));
+      path_handle = addpathTemporary(fullfile(getDrakePath,'examples','Atlas','frames'));
 
       w = warning('off','Drake:RigidBodyManipulator:UnsupportedVelocityLimits');
       obj = obj@TimeSteppingRigidBodyManipulator(urdf,options.dt,options);
@@ -40,8 +39,7 @@ classdef Atlas < TimeSteppingRigidBodyManipulator & Biped
     function obj = compile(obj)
       obj = compile@TimeSteppingRigidBodyManipulator(obj);
 
-      oldpath = addpath(fullfile(getDrakePath,'examples','Atlas','frames'));
-      finishup = onCleanup(@() path(oldpath));
+      path_handle = addpathTemporary(fullfile(getDrakePath,'examples','Atlas','frames'));
       
       atlas_state_frame = AtlasState(obj);
       tsmanip_state_frame = obj.getStateFrame();

--- a/examples/Atlas/runAtlasBalancing.m
+++ b/examples/Atlas/runAtlasBalancing.m
@@ -5,9 +5,9 @@ if ~checkDependency('gurobi')
   return;
 end
 
-oldpath = addpath(fullfile(getDrakePath,'examples','ZMP'));
-finishup = onCleanup(@() path(oldpath));
-addpath(fullfile(getDrakePath,'examples','Atlas','controllers'));
+path_handle = addpathTemporary({fullfile(getDrakePath,'examples','ZMP'),...
+                                fullfile(getDrakePath,'examples','Atlas','controllers'),...
+                                fullfile(getDrakePath,'examples','Atlas','frames')});
 
 % put robot in a random x,y,yaw position and balance for 2 seconds
 visualize = true;

--- a/examples/Atlas/runAtlasRunning.m
+++ b/examples/Atlas/runAtlasRunning.m
@@ -8,9 +8,8 @@ end
 if (nargin<1); use_mex = true; end
 if (nargin<2); use_angular_momentum = false; end
 
-oldpath = addpath(fullfile(getDrakePath,'examples','Atlas','controllers'));
-finishup = onCleanup(@() path(oldpath));
-addpath(fullfile(getDrakePath,'examples','Atlas','frames'));
+path_handle = addpathTemporary({fullfile(getDrakePath,'examples','Atlas','controllers'),...
+                                fullfile(getDrakePath,'examples','Atlas','frames')});
 
 % silence some warnings
 warning('off','Drake:RigidBodyManipulator:UnsupportedContactPoints')

--- a/examples/Atlas/runAtlasWalking.m
+++ b/examples/Atlas/runAtlasWalking.m
@@ -7,10 +7,9 @@ if ~checkDependency('gurobi')
   return;
 end
 
-oldpath = addpath(fullfile(getDrakePath,'examples','ZMP'));
-finishup = onCleanup(@() path(oldpath));
-addpath(fullfile(getDrakePath,'examples','Atlas','controllers'));
-
+path_handle = addpathTemporary({fullfile(getDrakePath,'examples','ZMP'),...
+                                fullfile(getDrakePath,'examples','Atlas','controllers'),...
+                                fullfile(getDrakePath,'examples','Atlas','frames')});
 
 plot_comtraj = true;
 

--- a/examples/Atlas/runAtlasWalkingPlanning.m
+++ b/examples/Atlas/runAtlasWalkingPlanning.m
@@ -8,8 +8,9 @@ function plan = runAtlasWalkingPlanning()
 
 
 checkDependency('lcmgl');
-oldpath = addpath(fullfile(getDrakePath(), 'examples', 'ZMP'));
-finishup = onCleanup(@() path(oldpath));
+
+path_handle = addpathTemporary(fullfile(getDrakePath(), 'examples', 'ZMP'));
+
 % Set up the model
 load('data/atlas_fp.mat', 'xstar');
 x0 = xstar;

--- a/examples/Atlas/test/runAtlasWalkingTestMex.m
+++ b/examples/Atlas/test/runAtlasWalkingTestMex.m
@@ -1,7 +1,6 @@
 function runAtlasWalkingTestMex()
 
-oldpath = addpath(fullfile(getDrakePath,'examples','Atlas'));
-finishup = onCleanup(@() path(oldpath));
+path_handle = addpathTemporary(fullfile(getDrakePath,'examples','Atlas'));
 runAtlasWalking(2,0,0,[0.5;0;0;0;0;0]);
 
 end

--- a/examples/Atlas/test/testIKGaze.m
+++ b/examples/Atlas/test/testIKGaze.m
@@ -1,7 +1,6 @@
 function testIKGaze
 
-oldpath = addpath(fullfile(getDrakePath,'examples','Atlas'));
-finishup = onCleanup(@() path(oldpath));
+path_handle = addpathTemporary(fullfile(getDrakePath,'examples','Atlas'));
 
 options.floating = true;
 options.dt = 0.001;

--- a/examples/Atlas/test/testIndividualCentersOfPressure.m
+++ b/examples/Atlas/test/testIndividualCentersOfPressure.m
@@ -1,6 +1,6 @@
 function testIndividualCentersOfPressure()
-oldpath = addpath(fullfile(getDrakePath,'examples','Atlas'));
-finishup = onCleanup(@() path(oldpath));
+
+path_handle = addpathTemporary(fullfile(getDrakePath,'examples','Atlas'));
 
 options.floating = true;
 options.use_mex = true;

--- a/util/addpathTemporary.m
+++ b/util/addpathTemporary.m
@@ -1,0 +1,40 @@
+function h = addpathTemporary(path_string_or_cell)
+% addpathTemporary: Add a string or cell array of strings to the MATLAB path
+% and automatically clean up afterward. 
+% USAGE: 
+% To use this function, you *must* assign its output to a local variable. The
+% modifications to the path will persist only until that variable is 
+% destroyed, typically when the function that contains it returns. If you do
+% not assign the output to a variable, then the path changes will be 
+% immediately undone when the next line of code executes. 
+% 
+% Typical usage might look like this:
+%     path_handle = addpathTemporary(fullfile(getDrakePath, 'examples', 'ZMP'));
+%
+% @param path_string_or_cell a single path string or a cell array of strings
+% @retval h the handle object which restores the path when it is destroyed
+
+if ischar(path_string_or_cell)
+  path_string_or_cell = {path_string_or_cell};
+end
+
+added_path = false(size(path_string_or_cell));
+path_cell = regexp(path(), pathsep(), 'split');
+
+for j = 1:length(path_string_or_cell)
+  s = path_string_or_cell{j};
+  if ~ismember(s, path_cell)
+    addpath(path_string_or_cell{j});
+    added_path(j) = true;
+  end
+end
+
+h = onCleanup(@() cleanupPaths(path_string_or_cell(added_path)));
+end
+
+function cleanupPaths(paths_to_clear)
+  for j = 1:length(paths_to_clear)
+    rmpath(paths_to_clear{j})
+  end
+end
+


### PR DESCRIPTION
This should prevent the Atlas examples from cluttering up the Matlab path. The use of the builtin [onCleanup function](http://www.mathworks.com/help/matlab/ref/oncleanup.html) means that the path should be restored even if the function terminates early with an error. 
