### PR TITLE
warn on LEAD_AUTO instead of error

### DIFF
--- a/systems/robotInterfaces/@Biped/planFootsteps.m
+++ b/systems/robotInterfaces/@Biped/planFootsteps.m
@@ -63,7 +63,7 @@ elseif options.step_params.leading_foot == 1 % lead right
   foot1 = 'right';
   foot2 = 'left';
 elseif options.step_params.leading_foot == -1 % lead auto
-  warning('Drake:planFootsteps:LeadAutoNotImplemented', 'AUTO leading foot selection is not implemented; will lead with RIGHT foot always');
+  obj.warning_manager.warnOnce('Drake:planFootsteps:LeadAutoNotImplemented', 'AUTO leading foot selection is not implemented; will lead with RIGHT foot always');
   foot1 = 'right';
   foot2 = 'left';
 else


### PR DESCRIPTION
A warning seems more appropriate in this case, and falling back to always leading with the right foot when the user requests "auto" mode is reasonable, I think. 
