### PR TITLE
fix exitflag in NonlinearProgram

### DIFF
--- a/solvers/NonlinearProgram.m
+++ b/solvers/NonlinearProgram.m
@@ -817,11 +817,11 @@ classdef NonlinearProgram
       % @retval objval  A double scaler. The value of the objective function after running the
       % solver
       % @retval exitflag   An integer scaler.
+      %                    1  -- Solved successful
       %                    *********************
       %                    If the solver is SNOPT, then exitflag is the same as the INFO returned by
       %                    the solver. Please refer to
       %                    http://www.cam.ucsd.edu/~peg/papers/sndoc7.pdf for more information
-      %                    1  -- Successfully solved through SNOPT
       %                    2  -- Solved with SNOPT, but the accuracy of the linear constraints
       %                    cannot be achieved.
       %                    3  -- Solved with SNOPT, but the accuracy of the nonlinear constraints
@@ -843,7 +843,6 @@ classdef NonlinearProgram
       %                    *********************
       %                    If the solver is fmincon, then the exitflag is 200 + fmincon_exitflag
       %                    200 -- In fmincon, number of iterations exceeds options.MaxIter
-      %                    201 -- In fmincon, the problem is solved successfully
       %                    199 -- In fmincon, stopped by an output function or plot function
       %                    198 -- In fmincon, no feasible point was found.
       %                    202 -- In fmincon, change in x was less than options.TolX and maximum constraint violation was less than options.TolCon.
@@ -854,7 +853,6 @@ classdef NonlinearProgram
       %                    197 -- In fmincon, objective function at current iteration went below options.ObjectiveLimit and maximum constraint violation was less than options.TolCon.
       %                    **********************
       %                    If the solver is IPOPT, then the exitflag = -100 + ipopt_exitflag
-      %                    -100  -- solved by Ipopt
       %                    -99   -- In ipopt, solved to acceptable level
       %                    -98   -- In ipopt, infeasible problem detected
       %                    -97   -- In ipopt, search direction becomes too small
@@ -1181,11 +1179,12 @@ classdef NonlinearProgram
                 msg='Objective function at current iteration went below options.ObjectiveLimit and maximum constraint violation was less than options.TolCon';
             end        
             warning('Drake:NonlinearProgram:FMINCONExitFlag',' FMINCON %2d %s',exitflag,msg); 
+            exitflag = exitflag+200;
           end
-          exitflag = exitflag+200;
+          
           
         case 'ipopt'
-          if(exitflag ~= 0 && exitflag ~= 1)
+          if(exitflag ~= 0)
             infeasible_constraint_name = infeasibleConstraint(obj,x);
             switch (exitflag)
               case 2
@@ -1220,8 +1219,11 @@ classdef NonlinearProgram
                 msg = 'internal error';
             end
             warning('Drake:NonlinearProgram:IPOPTExitFlag','Ipopt %4d %s',exitflag,msg);
+            exitflag = exitflag-100;
+          else
+            exitflag = 1;
           end
-          exitflag = exitflag-100;
+         
       end
     end 
   end

--- a/solvers/test/testNLP.m
+++ b/solvers/test/testNLP.m
@@ -121,6 +121,8 @@ x0 = [1;2;3];
 c2 = cnstr2_userfun(x);
 valuecheck(c2(1),1/6,1e-5);
 nlp1 = nlp1.setSolver('fmincon');
+nlp1 = nlp1.setSolverOptions('fmincon','Algorithm','active-set');
+nlp1 = nlp1.setSolverOptions('fmincon','MaxIter',1000);
 [x_fmincon,F,info] = nlp1.solve(x0);
 valuecheck(x,x_fmincon,1e-4);
 if(checkDependency('ipopt'))
@@ -259,18 +261,12 @@ end
 
   function [x,F,info] = solveWDefaultSolver(nlp,x)
     nlp = nlp.setSolver('default');
+    if(strcmp(nlp.solver,'fmincon'))
+      nlp = nlp.setSolverOptions('fmincon','Algorithm','sqp');
+      nlp = nlp.setSolverOptions('fmincon','MaxIter',1000);
+    end
     [x,F,info] = nlp.solve(x);
-    if(strcmpi(nlp.solver,'snopt'))
-      if(info>10)
-        error('snopt fails');
-      end
-    elseif(strcmpi(nlp.solver,'fmincon'))
-      if(info ~= 201)
-        error('fmincon fails');
-      end
-    elseif(strcmpi(nlp.solver,'ipopt'))
-      if(info ~= -100)
-        error('ipopt fails');
-      end
+    if(info ~= 1)
+      error('failed to solve the problem');
     end
   end


### PR DESCRIPTION
solves #350 and #255 
1. NonlinearProgram returns exitflag=1 when it solves the problem with any solver.
2. Switch to sqp method for fmincon in testNLP, the default interior-point-method does not solve it
