### PR TITLE
Force visualizer

### DIFF
--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -1213,6 +1213,14 @@ classdef RigidBodyManipulator < Manipulator
     end
     
     function drawLCMGLGravity(model,q,gravity_visual_magnitude)
+        % draws a vector centered at the robot's center 
+        % of mass having the direction of the gravitational
+        % force on the robot.
+        %
+        % @param q the position of the robot
+        % @param gravity_visual_magnitude specifies the visual length of 
+        % the vector representing the gravitational force.
+        
         if (nargin<3), gravity_visual_magnitude=0.25; end
         gravity_force = getMass(model)*model.gravity;
         vector_scale = gravity_visual_magnitude/norm(gravity_force,2);
@@ -1223,7 +1231,21 @@ classdef RigidBodyManipulator < Manipulator
     end
     
     function drawLCMGLForces(model,q,qd,gravity_visual_magnitude)
-        if (nargin<4), gravity_visual_magnitude = 0.25; end
+        % draws the forces and torques on the robot. They are
+        % spatial vectors (wrenches) and are drawn at the body's
+        % origin on which they act. Forces are in green and torques
+        % in purple. The magnitude of each vector is scaled by
+        % the same amount that the vector corresponding to the 
+        % gravitational force on the robot would be scaled in order to
+        % make it have a norm equal to gravity_visual_magnitude. Use 
+        % drawLCMGLGravity to draw the gravity.
+        %
+        % @param q the position of the robot
+        % @param qd the velocities of the robot
+        % @param gravity_visual_magnitude specifies the (would-be) visual 
+        % length of the vector representing the gravitational force.
+        
+        if (nargin<4), gravity_visual_magnitude=0.25; end
         gravity_force = getMass(model)*model.gravity;
         vector_scale = gravity_visual_magnitude/norm(gravity_force,2);
         

--- a/systems/plants/RigidBodyVisualizer.m
+++ b/systems/plants/RigidBodyVisualizer.m
@@ -2,12 +2,28 @@ classdef RigidBodyVisualizer < Visualizer
   properties (Access=protected)
     model;
   end
+  properties
+    gravity_visual_magnitude=.25;      
+  end
   methods
     function obj = RigidBodyVisualizer(manip)
       obj = obj@Visualizer(getStateFrame(manip));
       obj.model = manip;
     end
-    function inspector(obj,x0,state_dims,minrange,maxrange,gravity_visual_magnitude)
+    function inspector(obj,x0,state_dims,minrange,maxrange,options)
+      % brings up a simple slider gui that displays the robot
+      % in the specified state when possible. It also shows resulting
+      % forces and torques if some of the specified states are velocities.
+      % 
+      % @param x0 the initial state to display the robot in
+      % @param state_dims are the indices of the states to show on the
+      % slider. Including velocity states will display the forces and torques.
+      % @param minrange is the lower bound for the sliders
+      % @param maxrange is the upper bound for the sliders
+      % @option gravity_visual_magnitude specifies the visual length of 
+      % the vector representing the gravitational force. Other force 
+      % visualizations are scaled accordingly. 
+        
       if (nargin<2), x0 = getInitialState(obj.model); end
       if (nargin<3), state_dims = 1:getNumPositions(obj.model); end
       [jlmin,jlmax] = getJointLimits(obj.model);
@@ -16,9 +32,12 @@ classdef RigidBodyVisualizer < Visualizer
       xmax = [jlmax;100*ones(getNumVelocities(obj.model),1)];
       if (nargin<4), minrange = xmin(state_dims); end
       if (nargin<5), maxrange = xmax(state_dims); end
-      if (nargin<6), gravity_visual_magnitude=0.25; end
+      if (nargin<6), options = struct(); end
+      if isfield(options,'gravity_visual_magnitude') 
+          obj.gravity_visual_magnitude = options.gravity_visual_magnitude; 
+      end
       
-      inspector@Visualizer(obj,x0,state_dims,minrange,maxrange,obj.model,gravity_visual_magnitude);
+      inspector@Visualizer(obj,x0,state_dims,minrange,maxrange,obj.model);
     end
       
     function kinematicInspector(obj,body_or_frame_id,pt,q0,minrange,maxrange)

--- a/systems/visualizers/Visualizer.m
+++ b/systems/visualizers/Visualizer.m
@@ -195,11 +195,16 @@ classdef Visualizer < DrakeSystem
       end
     end
 
-    function inspector(obj,x0,state_dims,minrange,maxrange,visualized_system,gravity_visual_magnitude)
-      % set up a little gui with sliders to manually adjust each of the
-      % coordinates. @param gravity_visual_magnitude specifies the visual length of 
-      % the vector representing the gravitational force. Other force visualizations 
-      % are scaled accordingly.
+    function inspector(obj,x0,state_dims,minrange,maxrange,visualized_system)
+      % brings up a simple slider gui that displays the robot
+      % in the specified state when possible.
+      % 
+      % @param x0 the initial state to display the robot in
+      % @param state_dims are the indices of the states to show on the
+      % slider. Including velocity states will display the forces and torques.
+      % @param minrange is the lower bound for the sliders
+      % @param maxrange is the upper bound for the sliders
+      % @param visualized_system is the system to be displayed
 
       fr = obj.getInputFrame();
       if (nargin<2 || isempty(x0)), x0 = zeros(fr.dim,1); end
@@ -207,7 +212,6 @@ classdef Visualizer < DrakeSystem
       if (nargin<4), minrange = repmat(-5,size(state_dims)); end
       if (nargin<5), maxrange = -minrange; end
       if (nargin<6), visualized_system = []; end
-      if (nargin<7), gravity_visual_magnitude = 0.25; end
 
       x0(state_dims) = max(min(x0(state_dims),maxrange),minrange);
       if ~isempty(visualized_system),
@@ -278,12 +282,12 @@ classdef Visualizer < DrakeSystem
         x0 = x;
         obj.drawWrapper(t,x);
         
-        if (max(state_dims)>getNumPositions(visualized_system))
-          % was asked to show velocties, draw forces and torques
+        if (max(state_dims)>getNumPositions(visualized_system)&&isa(obj,'RigidBodyVisualizer'))
+          % was asked to show velocties on a RigidBodyManipulator, draw forces and torques
           q = x0(1:getNumPositions(visualized_system));
           qd = x0(getNumPositions(visualized_system)+1:getNumPositions(visualized_system)+getNumVelocities(visualized_system));
-          visualized_system.drawLCMGLGravity(q,gravity_visual_magnitude);
-          visualized_system.drawLCMGLForces(q,qd,gravity_visual_magnitude);
+          visualized_system.drawLCMGLGravity(q,obj.gravity_visual_magnitude);
+          visualized_system.drawLCMGLForces(q,qd,obj.gravity_visual_magnitude);
         end
         
       end


### PR DESCRIPTION
The forces are drawn in green, torques in purple (right hand rule) and gravity is in red for scale. You can visualize the wrenches by passing any velocity state(s) in the state_dims argument to inspector. So it assumes that if you want to visualize velocities, really you want to visualize forces and torques. It also classifies the forces by their type.

All of this is open to discussion obviously.

![complex_bird](https://cloud.githubusercontent.com/assets/2207326/4222239/8ed99874-3911-11e4-93bd-1868c07317c2.png)
