### PR TITLE
remove 'ignore-joint-limit' feature in PostureConstraint and IK

### DIFF
--- a/systems/plants/@RigidBodyManipulator/inverseKinBackend.m
+++ b/systems/plants/@RigidBodyManipulator/inverseKinBackend.m
@@ -47,14 +47,9 @@ ikoptions = varargin{end};
 %   qsc = QuasiStaticConstraint(obj);
 qsc = QuasiStaticConstraint(obj,[-inf,inf],1);
 qsc = qsc.setActive(false);
-if(ikoptions.use_rbm_joint_bnd)
-  [joint_min,joint_max] = obj.getJointLimits();
-  joint_min = bsxfun(@times,joint_min,ones(1,nT));
-  joint_max = bsxfun(@times,joint_max,ones(1,nT));
-else
-  joint_min = -inf(nq,nT);
-  joint_max = inf(nq,nT);
-end
+[joint_min,joint_max] = obj.getJointLimits();
+joint_min = bsxfun(@times,joint_min,ones(1,nT));
+joint_max = bsxfun(@times,joint_max,ones(1,nT));
 for i = 1:nT
   if(isempty(t))
     ti = [];

--- a/systems/plants/IKoptions.cpp
+++ b/systems/plants/IKoptions.cpp
@@ -31,7 +31,6 @@ IKoptions::IKoptions(const IKoptions &rhs)
   this->qd0_ub = rhs.qd0_ub;
   this->qdf_lb = rhs.qdf_lb;
   this->qdf_ub = rhs.qdf_ub;
-  this->use_rbm_joint_bnd = rhs.use_rbm_joint_bnd;
 }
 IKoptions::~IKoptions()
 {
@@ -59,7 +58,6 @@ void IKoptions::setDefaultParams(RigidBodyManipulator* robot)
   this->qd0_lb = VectorXd::Zero(this->nq);
   this->qdf_ub = VectorXd::Zero(this->nq);
   this->qdf_lb = VectorXd::Zero(this->nq);
-  this->use_rbm_joint_bnd = true;
 }
 
 RigidBodyManipulator* IKoptions::getRobotPtr() const
@@ -341,12 +339,3 @@ void IKoptions::updateRobot(RigidBodyManipulator* new_robot)
   }
 }
 
-void IKoptions::setUseRBMJointBnd(bool flag)
-{
-  this->use_rbm_joint_bnd = flag;
-}
-
-bool IKoptions::getUseRBMJointBnd() const
-{
-  return this->use_rbm_joint_bnd;
-}

--- a/systems/plants/IKoptions.h
+++ b/systems/plants/IKoptions.h
@@ -39,7 +39,6 @@ class DLLEXPORT IKoptions
     VectorXd qd0_ub;
     VectorXd qdf_lb;
     VectorXd qdf_ub;
-    bool use_rbm_joint_bnd;
   protected:
     void setDefaultParams(RigidBodyManipulator* robot);
   public:
@@ -79,8 +78,6 @@ class DLLEXPORT IKoptions
     void getqd0(VectorXd &lb, VectorXd &ub) const;
     void getqdf(VectorXd &lb, VectorXd &ub) const;
     void updateRobot(RigidBodyManipulator* new_robot);
-    void setUseRBMJointBnd(bool flag);
-    bool getUseRBMJointBnd() const;
 };
 #endif
 

--- a/systems/plants/IKoptions.m
+++ b/systems/plants/IKoptions.m
@@ -26,8 +26,6 @@ classdef IKoptions
 % @param qd0_lb             -- The lowerbound of the initial velocity
 % @param qdf_ub             -- The upper bound of the final velocity
 % @param qdf_lb             -- The lower bound of the final velocity
-% @param use_rbm_joint_bnd  -- A boolean variable. True if the robot uses the
-% RigidBodyManipulator's joint limits by default. @default is true
   properties(SetAccess=protected)
     robot
     nq
@@ -51,7 +49,6 @@ classdef IKoptions
     qdf_ub
     qdf_lb
     mex_ptr = 0;
-    use_rbm_joint_bnd = true;
   end
 
   methods(Access = protected)
@@ -314,15 +311,6 @@ classdef IKoptions
       if(obj.nq ~= nq_cache)
         obj = setDefaultParams(obj,robot);
       end
-    end
-    
-    function obj = setUseRBMJointBnd(obj,flag)
-      if obj.mex_ptr ~= 0
-        obj.mex_ptr = IKoptionsmex(3,obj.mex_ptr,'use_rbm_joint_bnd',flag);
-      end
-      typecheck(flag,'logical');
-      sizecheck(flag,[1,1]);
-      obj.use_rbm_joint_bnd = flag;
     end
   end
 end

--- a/systems/plants/IKoptionsmex.cpp
+++ b/systems/plants/IKoptionsmex.cpp
@@ -226,15 +226,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
           RigidBodyManipulator* new_robot = (RigidBodyManipulator*) getDrakeMexPointer(prhs[3]);
           ikoptions_new->updateRobot(new_robot);
         }
-        else if(field_str == "use_rbm_joint_bnd")
-        {
-          if(!mxIsLogicalScalar(prhs[3]))
-          {
-            mexErrMsgIdAndTxt("Drake:IKoptionsmex:BadInputs","use_rbm_joint_bnd should be a logical scalar");
-          }
-          bool flag = *mxGetLogicals(prhs[3]);
-          ikoptions_new->setUseRBMJointBnd(flag);
-        }
         else
         {
           mexErrMsgIdAndTxt("Drake:updatePtrIKoptionsmex:BadInputs","Unsupported field");

--- a/systems/plants/constraint/PostureConstraint.m
+++ b/systems/plants/constraint/PostureConstraint.m
@@ -1,44 +1,25 @@
 classdef PostureConstraint<RigidBodyConstraint
   % A bounding box constraint on robot posture
-  % @param robot                      -- A robot
-  % @param lb                         -- The lower bound of posture
-  % @param ub                         -- The upper bound of posture
-  % @param joint_limit_min0           -- The default lower bound of the
-  %                                      posture of the robot
-  % @param joint_limit_max0           -- The default upper bound of the
-  %                                      posture of the robot
-  % @param use_rbm_joint_bnd          -- A boolean, true if the posture limits will all be
-  % truncated to the RigidBodyManipulator's default joint limits. @default is true
   properties(SetAccess = protected)
-    lb
-    ub
-    joint_limit_min0;
-    joint_limit_max0;
-    use_rbm_joint_bnd;
+    lb % The lower bound of posture
+    ub % The upper bound of posture
+    joint_limit_min0;% The default lower bound of the  posture of the robot
+    joint_limit_max0;% The default upper bound of the  posture of the robot
   end
   
   methods
-    function obj = PostureConstraint(robot,tspan,use_rbm_joint_bnd)
+    function obj = PostureConstraint(robot,tspan)
+		% @param robot                      -- A RigidBodyManipulator or a TimeSteppingRigidBodyManipulator object
       if(nargin < 2)
         tspan = [-inf inf];
       end
-      if(nargin < 3)
-        use_rbm_joint_bnd = true;
-      end
       obj = obj@RigidBodyConstraint(RigidBodyConstraint.PostureConstraintCategory,robot,tspan);
-      obj.use_rbm_joint_bnd = use_rbm_joint_bnd;
-      if(obj.use_rbm_joint_bnd)
-        [obj.joint_limit_min0,obj.joint_limit_max0] = robot.getJointLimits();
-      else
-        nq = robot.getNumPositions();
-        obj.joint_limit_min0 = -inf(nq,1);
-        obj.joint_limit_max0 = inf(nq,1);
-      end
+			[obj.joint_limit_min0,obj.joint_limit_max0] = robot.getJointLimits();
       obj.lb = obj.joint_limit_min0;
       obj.ub = obj.joint_limit_max0;
       obj.type = RigidBodyConstraint.PostureConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.PostureConstraintType,robot.getMexModelPtr,tspan,use_rbm_joint_bnd);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.PostureConstraintType,robot.getMexModelPtr,tspan);
       end
     end
     
@@ -55,6 +36,9 @@ classdef PostureConstraint<RigidBodyConstraint
     end
     
     function obj = setJointLimits(obj,joint_ind,joint_min,joint_max)
+		  % @param joint_ind   A column vector. The indices of the joints whose joint limits are to be set
+			% @param joint_min   A column vector of the same size as joint_ind. The lower bound of the joints are max([robot.joint_limit_min(joint_ind) joint_min]),[],2);
+			% @param joint_max   A column vector of the same size as joint_ind. The upper bound of the joints are min([robot.joint_limit_max(joint_ind) joint_max]),[],2);
       if obj.mex_ptr~=0
         obj.mex_ptr = updatePtrRigidBodyConstraintmex(obj.mex_ptr,'bounds',joint_ind,joint_min,joint_max);
       end

--- a/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -270,20 +270,10 @@ void QuasiStaticConstraint::updateRobotnum(std::set<int> &robotnumset)
   this->m_robotnumset = robotnumset;
 }
 
-PostureConstraint::PostureConstraint(RigidBodyManipulator* robot, const Eigen::Vector2d &tspan, bool use_rbm_joint_bnd):RigidBodyConstraint(RigidBodyConstraint::PostureConstraintCategory,robot,tspan)
+PostureConstraint::PostureConstraint(RigidBodyManipulator* robot, const Eigen::Vector2d &tspan):RigidBodyConstraint(RigidBodyConstraint::PostureConstraintCategory,robot,tspan)
 {
-  this->use_rbm_joint_bnd = use_rbm_joint_bnd;
-  if(this->use_rbm_joint_bnd)
-  {
-    this->joint_limit_min0 = this->robot->joint_limit_min;
-    this->joint_limit_max0 = this->robot->joint_limit_max;
-  }
-  else
-  {
-    int nq = this->robot->num_dof;
-    this->joint_limit_min0 = VectorXd::Constant(nq,-std::numeric_limits<double>::infinity());
-    this->joint_limit_max0 = VectorXd::Constant(nq,std::numeric_limits<double>::infinity());
-  }
+	this->joint_limit_min0 = this->robot->joint_limit_min;
+	this->joint_limit_max0 = this->robot->joint_limit_max;
   this->lb = this->joint_limit_min0;
   this->ub = this->joint_limit_max0;
   this->type = RigidBodyConstraint::PostureConstraintType;
@@ -294,7 +284,6 @@ PostureConstraint::PostureConstraint(const PostureConstraint& rhs):RigidBodyCons
   int nq = this->robot->num_dof;
   this->lb.resize(nq);
   this->ub.resize(nq);
-  this->use_rbm_joint_bnd = rhs.use_rbm_joint_bnd;
   this->joint_limit_min0 = rhs.joint_limit_min0;
   this->joint_limit_max0 = rhs.joint_limit_max0;
   for(int i = 0;i<nq;i++)
@@ -318,12 +307,16 @@ void PostureConstraint::setJointLimits(int num_idx,const int* joint_idx, const V
     {
       std::cerr<<"joint_idx["<<i<<"] is should be within [0 nq-1]"<<std::endl;
     }
-    this->lb[joint_idx[i]] = (this->joint_limit_min0(joint_idx[i])<lb[i]? lb[i]:this->joint_limit_min0(joint_idx[i]));
-    this->ub[joint_idx[i]] = (this->joint_limit_max0(joint_idx[i])>ub[i]? ub[i]:this->joint_limit_max0(joint_idx[i]));
-    if(this->lb[joint_idx[i]]>this->ub[joint_idx[i]])
+		if(lb[i]>this->robot->joint_limit_max[joint_idx[i]])
+		{
+			std::cerr<<"joint lb is greater than the robot default joint maximum"<<std::endl;
+		}
+		if(ub[i]<this->robot->joint_limit_min[joint_idx[i]])
     {
-      std::cerr<<"joint "<<joint_idx[i]<<"  has lower bound larger than upper bound after calling setJointLimits function in PostureConstraint"<<std::endl;
+			std::cerr<<"joint ub is smaller than the robot default joint minimum"<<std::endl;
     }
+		this->lb[joint_idx[i]] = (this->robot->joint_limit_min[joint_idx[i]]<lb[i]?lb[i]:this->robot->joint_limit_min[joint_idx[i]]);
+		this->ub[joint_idx[i]] = (this->robot->joint_limit_max[joint_idx[i]]>ub[i]?ub[i]:this->robot->joint_limit_max[joint_idx[i]]);
   }
 }
 

--- a/systems/plants/constraint/RigidBodyConstraint.h
+++ b/systems/plants/constraint/RigidBodyConstraint.h
@@ -143,7 +143,6 @@ class DLLEXPORT QuasiStaticConstraint: public RigidBodyConstraint
  * @param tspan          -- The time span of the constraint being valid
  * @param lb             -- The lower bound of the joints
  * @param ub             -- The upper bound of the joints
- * @param use_rbm_joint_bnd  -- A boolean, true if the posture bounds will be truncated to the RigidBodyManipulator's joint limits. @default is true
  *
  * @function setJointLimits   set the limit of some joints
  *   @param num_idx    The number of joints whose limits are going to be set
@@ -158,9 +157,8 @@ class DLLEXPORT PostureConstraint: public RigidBodyConstraint
     Eigen::VectorXd ub;
     Eigen::VectorXd joint_limit_min0;
     Eigen::VectorXd joint_limit_max0;
-    bool use_rbm_joint_bnd;
   public:
-    PostureConstraint(RigidBodyManipulator *model, const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan, bool use_rbm_joint_bnd=true);
+    PostureConstraint(RigidBodyManipulator *model, const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
     PostureConstraint(const PostureConstraint& rhs);
     bool isTimeValid(const double* t) const;
     void setJointLimits(int num_idx, const int* joint_idx, const Eigen::VectorXd& lb, const Eigen::VectorXd& ub);

--- a/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
+++ b/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
@@ -75,9 +75,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     // PostureConstraint
     case RigidBodyConstraint::PostureConstraintType:
       {
-        if(nrhs != 2 && nrhs != 3 && nrhs != 4)
+        if(nrhs != 2 && nrhs != 3)
         {
-          mexErrMsgIdAndTxt("Drake:constructPtrRigidBodyConstraintmex:BadInputs","Usage ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint::PostureConstraintType,robot.mex_model_ptr,tspan,use_rbm_joint_bnd)");
+          mexErrMsgIdAndTxt("Drake:constructPtrRigidBodyConstraintmex:BadInputs","Usage ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint::PostureConstraintType,robot.mex_model_ptr,tspan)");
         }
         Vector2d tspan;
         if(nrhs < 3)
@@ -88,17 +88,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         {
           rigidBodyConstraintParseTspan(prhs[2],tspan);
         }
-        bool use_rbm_joint_bnd;
-        if(nrhs < 4)
-        {
-          use_rbm_joint_bnd = true;
-        }
-        else
-        {
-          use_rbm_joint_bnd = *mxGetLogicals(prhs[3]);
-        }
         RigidBodyManipulator* robot = (RigidBodyManipulator*) getDrakeMexPointer(prhs[1]);
-        PostureConstraint* cnst = new PostureConstraint(robot,tspan,use_rbm_joint_bnd);
+        PostureConstraint* cnst = new PostureConstraint(robot,tspan);
         plhs[0] = createDrakeConstraintMexPointer((void*)cnst,"PostureConstraint");
       }
       break;

--- a/systems/plants/constraint/test/testPostureConstraint.m
+++ b/systems/plants/constraint/test/testPostureConstraint.m
@@ -54,31 +54,4 @@ display('Check generateConstraint function')
 pc_bbcnstr = pc2.generateConstraint(t);
 valuecheck(pc_bbcnstr{1}.lb,lb2);
 valuecheck(pc_bbcnstr{1}.ub,ub2);
-
-display('Check the constraint when use_rbm_joint_bnd = false');
-pc3 = PostureConstraint(r,[-inf,inf],true);
-[joint_lb,joint_ub] = r.getJointLimits();
-valuecheck(joint_lb,pc3.lb);
-valuecheck(joint_ub,pc3.ub);
-[lb_mex,ub_mex] = testPostureConstraintmex(pc3.mex_ptr,t);
-valuecheck(joint_lb,lb_mex);
-valuecheck(joint_ub,ub_mex);
-pc3 = PostureConstraint(r,[-inf,inf],false);
-valuecheck(pc3.lb,-inf(nq,1));
-valuecheck(pc3.ub,inf(nq,1));
-[lb_mex,ub_mex] = testPostureConstraintmex(pc3.mex_ptr,t);
-valuecheck(lb_mex,-inf(nq,1));
-valuecheck(ub_mex,inf(nq,1));
-pc3 = pc3.setJointLimits([l_leg_kny;r_leg_kny],[0.2;0.2],[0.4;0.4]);
-inf_joint_idx = true(nq,1);
-inf_joint_idx([l_leg_kny;r_leg_kny]) = false;
-valuecheck(pc3.lb(inf_joint_idx),-inf(nq-2,1));
-valuecheck(pc3.ub(inf_joint_idx),inf(nq-2,1));
-valuecheck(pc3.lb([l_leg_kny;r_leg_kny]),[0.2;0.2]);
-valuecheck(pc3.ub([l_leg_kny;r_leg_kny]),[0.4;0.4]);
-[lb_mex,ub_mex] = testPostureConstraintmex(pc3.mex_ptr,t);
-valuecheck(lb_mex(inf_joint_idx),-inf(nq-2,1));
-valuecheck(ub_mex(inf_joint_idx),inf(nq-2,1));
-valuecheck(lb_mex([l_leg_kny;r_leg_kny]),[0.2;0.2]);
-valuecheck(ub_mex([l_leg_kny;r_leg_kny]),[0.4;0.4]);
 end

--- a/systems/plants/inverseKinBackend.cpp
+++ b/systems/plants/inverseKinBackend.cpp
@@ -439,24 +439,10 @@ void inverseKinBackend(RigidBodyManipulator* model_input, const int mode, const 
   qsc_ptr = nullptr;
   MatrixXd joint_limit_min(nq,nT);
   MatrixXd joint_limit_max(nq,nT);
-  if(ikoptions.getUseRBMJointBnd())
+	for(int i = 0;i<nT;i++)
   {
-    for(int i = 0;i<nT;i++)
-    {
-      joint_limit_min.col(i) = model->joint_limit_min;
-      joint_limit_max.col(i) = model->joint_limit_max;
-    }
-  }
-  else
-  {
-    for(int j = 0;j<nq;j++)
-    {
-      for(int i = 0;i<nT;i++)
-      {
-        joint_limit_min(j,i) = -numeric_limits<double>::infinity(); 
-        joint_limit_max(j,i) = numeric_limits<double>::infinity();
-      }
-    }
+		joint_limit_min.col(i) = model->joint_limit_min;
+		joint_limit_max.col(i) = model->joint_limit_max;
   }
   for(int i = 0;i<num_constraints;i++)
   {

--- a/systems/plants/test/testIK.m
+++ b/systems/plants/test/testIK.m
@@ -409,16 +409,6 @@ if(l_hand_pos(3)>1+1e-5 || l_hand_pos(3)<0-1e-5 || norm(l_hand_pos(1:2))>0.2+1e-
   error('point to line segment constraint is not satisfied')
 end
 
-display('Check without RigidBodyManipulator default joint limits');
-ikoptions = ikoptions.setUseRBMJointBnd(false);
-pc = PostureConstraint(robot,[-inf,inf],false);
-[joint_lb,joint_ub] =robot.getJointLimits();
-pc = pc.setJointLimits((1:nq)',joint_lb,joint_ub);
-pc = pc.setJointLimits([l_leg_kny;r_leg_kny],joint_ub([l_leg_kny;r_leg_kny])+0.1*pi,joint_ub([l_leg_kny;r_leg_kny])+0.1*pi);
-valuecheck(pc.lb([l_leg_kny;r_leg_kny]),joint_ub([l_leg_kny;r_leg_kny])+0.1*pi);
-valuecheck(pc.ub([l_leg_kny;r_leg_kny]),joint_ub([l_leg_kny;r_leg_kny])+0.1*pi);
-q = test_IK_userfun(robot,q_seed,q_nom,pc,qsc,kc2l,kc2r,hand_line_dist_cnst,ikoptions);
-
 display('Check with addRobotFromURDF');
 xyz = 0.1*randn(3,1)+[1;1;1];
 rpy = 0.1*pi*randn(3,1)+[pi/2;0;0];
@@ -482,19 +472,12 @@ ikmexoptions = ikmexoptions.setMex(true);
 tic
 ikproblem = InverseKinematics(r,q_nom,varargin{1:end-1});
 ikproblem = ikproblem.setQ(ikoptions.Q);
-if(~ikoptions.use_rbm_joint_bnd)
-  ikproblem = ikproblem.deleteBoundingBoxConstraint(ikproblem.rbm_joint_bnd_cnstr_id);
-end
 ikproblem = ikproblem.setSolverOptions('fmincon','Algorithm','sqp');
 ikproblem = ikproblem.setSolverOptions('fmincon','MaxIter',500);
 [qik,F,info,infeasible_cnstr_ik] = ikproblem.solve(q_seed);
 toc
 % valuecheck(qik,q,1e-6);
-if(ikoptions.use_rbm_joint_bnd)
-  testConstraint(r,[],qik,varargin{1:end-1});
-else
-  testConstraintWoRBMJointBnd(r,[],qik,varargin{1:end-1});
-end
+testConstraint(r,[],qik,varargin{1:end-1});
 if(checkDependency('snopt'))
   tic
   [qmex,info_mex] = inverseKin(r,q_seed,q_nom,varargin{1:end-1},ikmexoptions);
@@ -503,11 +486,7 @@ if(checkDependency('snopt'))
     error('SNOPT info is %d, IK mex fails to solve the problem',info_mex);
   end
   % valuecheck(q,qmex,5e-2);
-  if(ikoptions.use_rbm_joint_bnd)
-    testConstraint(r,[],qmex,varargin{1:end-1});
-  else
-    testConstraintWoRBMJointBnd(r,[],qmex,varargin{1:end-1});
-  end
+	testConstraint(r,[],qmex,varargin{1:end-1});
 end
 end
 
@@ -543,16 +522,12 @@ end
 end
 
 function testConstraint(robot,t,q_sol,varargin)
+kinsol = robot.doKinematics(q_sol,false,true);
 [q_lb,q_ub] = robot.getJointLimits();
 if(any(q_sol>q_ub) || any(q_sol<q_lb))
   error('solution must be within the robot default joint limits');
 end
-testConstraintWoRBMJointBnd(robot,t,q_sol,varargin{:});
-end
-
-function testConstraintWoRBMJointBnd(robot,t,q_sol,varargin)
-  kinsol = robot.doKinematics(q_sol,false,true);
-  for i = 1:nargin-3
+for i = 1:nargin-3
   if(isa(varargin{i},'SingleTimeKinematicConstraint'))
     if(varargin{i}.isTimeValid(t))
       [lb,ub] = varargin{i}.bounds(t);
@@ -585,5 +560,5 @@ function testConstraintWoRBMJointBnd(robot,t,q_sol,varargin)
   else
     error('The constraint is not supported');
   end
-  end  
+end  
 end

--- a/systems/plants/test/testIKoptions.m
+++ b/systems/plants/test/testIKoptions.m
@@ -98,15 +98,6 @@ valuecheck(ikoptions.additional_tSamples,[-2 -1 0 1]);
 display('setAdditionaltSamples pass');
 
 % check use_rbm_joint_bnd
-valuecheck(ikoptions.use_rbm_joint_bnd,true);
-checkIKoptions(ikoptions);
-ikoptions = ikoptions.setUseRBMJointBnd(false);
-valuecheck(ikoptions.use_rbm_joint_bnd,false);
-checkIKoptions(ikoptions);
-ikoptions = ikoptions.setUseRBMJointBnd(true);
-valuecheck(ikoptions.use_rbm_joint_bnd,true);
-checkIKoptions(ikoptions);
-
 % Check updateRobot
 urdf_new = [getDrakePath,'/examples/PR2/pr2.urdf'];
 w = warning('off','Drake:RigidBodyManipulator:BodyHasZeroInertia');
@@ -126,8 +117,7 @@ ikoptions_mex = ikoptions.mex_ptr;
   majorFeasibilityTolerance_mex,majorIterationsLimit_mex,...
   iterationsLimit_mex,superbasicsLimit_mex,majorOptimalityTolerance_mex,...
   additional_tSamples_mex,...
-  fixInitialState_mex,q0_lb_mex,q0_ub_mex,qd0_lb_mex,qd0_ub_mex,qdf_lb_mex,qdf_ub_mex,...
-  use_rbm_joint_bnd]...
+  fixInitialState_mex,q0_lb_mex,q0_ub_mex,qd0_lb_mex,qd0_ub_mex,qdf_lb_mex,qdf_ub_mex]...
   = testIKoptionsmex(ikoptions_mex);
 valuecheck(ikoptions.robot.getMexModelPtr.ptr,robot_address_mex);
 valuecheck(ikoptions.Q,Q_mex,1e-10);
@@ -148,5 +138,4 @@ valuecheck(ikoptions.qd0_lb,qd0_lb_mex);
 valuecheck(ikoptions.qd0_ub,qd0_ub_mex);
 valuecheck(ikoptions.qdf_lb,qdf_lb_mex);
 valuecheck(ikoptions.qdf_ub,qdf_ub_mex);
-valuecheck(ikoptions.use_rbm_joint_bnd,use_rbm_joint_bnd);
 end

--- a/systems/plants/testIKoptionsmex.cpp
+++ b/systems/plants/testIKoptionsmex.cpp
@@ -8,9 +8,9 @@ using namespace Eigen;
 
 void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
-  if(nlhs != 20 || nrhs != 1)
+  if(nlhs != 19 || nrhs != 1)
   {
-    mexErrMsgIdAndTxt("Drake:testIKoptions:BadInputs","Usage [robot_address,Q,Qa,Qv,debug_mode, sequentialSeedFlag,majorFeasibilityTolerance,majorIterationsLimit,iterationsLimit,superbasicsLimit,majorOptimalityTolerance,additional_tSamples,fixInitialState,q0_lb,q0_ub,qd0_lb,qd0_ub,qdf_lb,qdf_ub,use_rbm_joint_bnd] = testIKoptionsmex(ikoptions_ptr)");
+    mexErrMsgIdAndTxt("Drake:testIKoptions:BadInputs","Usage [robot_address,Q,Qa,Qv,debug_mode, sequentialSeedFlag,majorFeasibilityTolerance,majorIterationsLimit,iterationsLimit,superbasicsLimit,majorOptimalityTolerance,additional_tSamples,fixInitialState,q0_lb,q0_ub,qd0_lb,qd0_ub,qdf_lb,qdf_ub] = testIKoptionsmex(ikoptions_ptr)");
   }
   IKoptions* ikoptions = (IKoptions*) getDrakeMexPointer(prhs[0]);
   long long robot_address = reinterpret_cast<long long>(ikoptions->getRobotPtr());
@@ -37,7 +37,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
   ikoptions->getq0(q0_lb,q0_ub);
   ikoptions->getqd0(qd0_lb,qd0_ub);
   ikoptions->getqdf(qdf_lb,qdf_ub);
-  bool use_rbm_joint_bnd = ikoptions->getUseRBMJointBnd();
   plhs[0] = mxCreateDoubleScalar((double) robot_address);
   plhs[1] = mxCreateDoubleMatrix(nq,nq,mxREAL);
   memcpy(mxGetPr(plhs[1]),Q.data(),sizeof(double)*nq*nq);
@@ -74,5 +73,4 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
   memcpy(mxGetPr(plhs[17]),qdf_lb.data(),sizeof(double)*nq);
   plhs[18] = mxCreateDoubleMatrix(nq,1,mxREAL);
   memcpy(mxGetPr(plhs[18]),qdf_ub.data(),sizeof(double)*nq);
-  plhs[19] = mxCreateLogicalScalar(use_rbm_joint_bnd);
 }


### PR DESCRIPTION
resolves #467, this reverts most of the changes in #418. Now `PostureConstraint` and ik have to respect the joint limits of the robot.
