### PR TITLE
Add errorDeprecatedFunction

### DIFF
--- a/util/errorDeprecatedFunction.m
+++ b/util/errorDeprecatedFunction.m
@@ -1,0 +1,8 @@
+function errorDeprecatedFunction(replacement_name)
+[ST,I] = dbstack();
+name = ST(I+1).name;
+throwAsCaller(MException('Drake:DeprecatedFunction',...
+  '''%s'' is deprecated. Please use ''%s'' instead.', ...
+  name, replacement_name));
+end
+


### PR DESCRIPTION
This utility function is used in the stubs that were left after the "shape" => "geometry" renaming. Since we don't test calling deprecated functions, I didn't catch that it hadn't been pushed.
