### PR TITLE
Fix frames in swing planning

### DIFF
--- a/systems/robotInterfaces/@Biped/planSwingPitched.m
+++ b/systems/robotInterfaces/@Biped/planSwingPitched.m
@@ -102,8 +102,8 @@ terrain_pts_in_toe_local = inv(T_toe_local_to_world) * T_local_to_world * [terra
 swing1_toe_points_in_toe_local = T_toe_local_to_world \ swing1_toe_points_in_world;
 swing2_toe_points_in_toe_local = T_toe_local_to_world \ swing2_toe_points_in_world;
 
-quat_toe_off = rotmat2quat(rpy2rotmat([0;toe_off_angle;0]) * inv(T_sole_to_foot(1:3,1:3)) * rpy2rotmat(swing1.pos(4:6)));
-quat_swing2 = rotmat2quat(inv(T_sole_to_foot(1:3,1:3)) * rpy2rotmat(swing2.pos(4:6)));
+quat_toe_off = rotmat2quat(rpy2rotmat(swing1.pos(4:6)) * rpy2rotmat([0;toe_off_angle;0]) / T_sole_to_foot(1:3,1:3));
+quat_swing2 = rotmat2quat(rpy2rotmat(swing2.pos(4:6)) / T_sole_to_foot(1:3,1:3));
 
 cost = Point(biped.getStateFrame(),1);
 cost.base_x = 0;
@@ -176,8 +176,10 @@ function add_foot_origin_knot(swing_pose, speed)
   foot_origin_knots(end+1).(swing_foot_name) = [swing_pose; zeros(6,1)];
   foot_origin_knots(end).(stance_foot_name) = [stance_origin_pose; zeros(6,1)];
   cartesian_distance = norm(foot_origin_knots(end).(swing_foot_name)(1:3) - foot_origin_knots(end-1).(swing_foot_name)(1:3));
-  yaw_distance = abs(foot_origin_knots(end).(swing_foot_name)(6) - foot_origin_knots(end-1).(swing_foot_name)(6));
-  pitch_distance = abs(foot_origin_knots(end).(swing_foot_name)(5) - foot_origin_knots(end-1).(swing_foot_name)(5));
+  sole1 = rotmat2rpy(rpy2rotmat(foot_origin_knots(end-1).(swing_foot_name)(4:6)) * T_sole_to_foot(1:3,1:3));
+  sole2 = rotmat2rpy(rpy2rotmat(foot_origin_knots(end).(swing_foot_name)(4:6)) * T_sole_to_foot(1:3,1:3));
+  yaw_distance = abs(sole2(3) - sole1(3));
+  pitch_distance = abs(sole2(2) - sole1(2));
   dt = max([cartesian_distance / speed,...
             yaw_distance / FOOT_YAW_RATE,...
             pitch_distance / FOOT_PITCH_RATE]);


### PR DESCRIPTION
fix incorrect assumptions in swing planning (discovered when fixing bugs for Valkyrie, which has its foot frames in weird orientations)
- no longer assume that the orientation of the sole matches the orientation of the foot
- no longer assume that the transform from foot to sole is the same in both feet
