### PR TITLE
implemented ellipsoid scaling with equivalent masses.  resolves #603

### DIFF
--- a/systems/plants/BotVisualizer.m
+++ b/systems/plants/BotVisualizer.m
@@ -168,7 +168,7 @@ classdef BotVisualizer < RigidBodyVisualizer
               abc = zeros(3,1);
             else
               abchat = sqrt(abchat_sq);
-              k = nthroot(sum(I)/(2*sum(abchat_sq)*obj.inertia_ellipsoids_density*4/15*pi*prod(abchat)),3);
+              k = nthroot(sum(I)/(2*sum(abchat_sq)*obj.inertia_ellipsoids_density*4/15*pi*prod(abchat)),5);
               abc = k*abchat;
             end
             


### PR DESCRIPTION
resolves the unhelpful scaling of the standard inertial ellipsoids.
draws each inertial ellipse as if the link was an ellipsoid of a known constant density.  now you can actually see the inertial effects of each joint, e.g. on Atlas:

![2014-12-10-viewer 00](https://cloud.githubusercontent.com/assets/6442292/5375590/d9c41390-8039-11e4-883e-696a485af508.png)
