### PR TITLE
fix setJointLimits

### DIFF
--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -304,6 +304,13 @@ classdef RigidBodyManipulator < Manipulator
     function obj = setJointLimits(obj,jl_min,jl_max)
       obj = setJointLimits@Manipulator(obj,jl_min,jl_max);
       obj.dirty = true;
+      for i = 1:getNumBodies(obj)
+        pos_num = obj.body(i).position_num;
+        if(any(pos_num~= 0)) % not the world body
+          obj.body(i).joint_limit_min = jl_min(pos_num)';
+          obj.body(i).joint_limit_max = jl_max(pos_num)';
+        end
+      end
     end
 
     function g = getGravity(obj,grav)

--- a/systems/plants/test/testJointLimits.m
+++ b/systems/plants/test/testJointLimits.m
@@ -1,0 +1,13 @@
+function testJointLimits()
+r = RigidBodyManipulator([getDrakePath,'/examples/Atlas/urdf/atlas_minimal_contact.urdf'],struct('floating',true));
+[lb,ub] = r.getJointLimits;
+ub_new = ub;
+ub_new(13) = ub(13)+0.2;
+lb_new = lb;
+lb_new(14) = lb(14)+0.1;
+r = r.setJointLimits(lb_new,ub_new);
+r = r.compile();
+[lb_new,ub_new] = r.getJointLimits();
+valuecheck(lb(14)+0.1,lb_new(14));
+valuecheck(ub(13)+0.2,ub_new(13));
+end


### PR DESCRIPTION
As @patmarion found, after we call `setJointLimits` and `compile`, the joint limits are not changed. This is because `compile` takes joint limits in each `RigidBody` as the joint limits. So we need to change the RigidBody joint limits in `setJointLimits` function
