### PR TITLE
Fix to the spring gradients

### DIFF
--- a/systems/plants/RigidBodySpringDamper.m
+++ b/systems/plants/RigidBodySpringDamper.m
@@ -34,7 +34,7 @@ classdef RigidBodySpringDamper < RigidBodyForceElement
           length = norm(x1-x2);
           dlengthdq = ((x1-x2)'/(length+eps))*(J1-J2);
           vel = ((x1-x2)'*(v1-v2))/(length+eps);
-          dveldq =  (((J1-J2)'*(v1-v2)+(x1-x2)'*(dv1dq-dv2dq))*(length+eps)-((x1-x2)'*(v1-v2))*dlengthdq)/(length+eps)^2;
+          dveldq =  (((v1-v2)'*(J1-J2)+(x1-x2)'*(dv1dq-dv2dq))*(length+eps)-((x1-x2)'*(v1-v2))*dlengthdq)/(length+eps)^2;
           dveldqd = (((x1-x2)'*(dv1dqd-dv2dqd))*(length+eps))/(length+eps)^2;
         else
           kinsol = doKinematics(manip,q);
@@ -78,10 +78,10 @@ classdef RigidBodySpringDamper < RigidBodyForceElement
       fvect1 = force*(x2-x1)/(length+eps);
       fvect2 = force*(x1-x2)/(length+eps);
       if (nargout>1)
-          dfvect1dq = ((dforcedq*(x2-x1)+force*(J2-J1))*(length+eps)-force*(x2-x1)*dlengthdq)/(length+eps)^2;
-          dfvect1dqd = dforcedqd*(x2-x1)*(length+eps)/(length+eps)^2;
-          dfvect2dq = ((dforcedq*(x1-x2)+force*(J1-J2))*(length+eps)-force*(x1-x2)*dlengthdq)/(length+eps)^2;
-          dfvect2dqd = dforcedqd*(x1-x2)*(length+eps)/(length+eps)^2;
+          dfvect1dq = (((x2-x1)*dforcedq+force*(J2-J1))*(length+eps)-force*(x2-x1)*dlengthdq)/(length+eps)^2;
+          dfvect1dqd = (x2-x1)*dforcedqd*(length+eps)/(length+eps)^2;
+          dfvect2dq = (((x1-x2)*dforcedq+force*(J1-J2))*(length+eps)-force*(x1-x2)*dlengthdq)/(length+eps)^2;
+          dfvect2dqd = (x1-x2)*dforcedqd*(length+eps)/(length+eps)^2;
       end
       
       if (nargout>1)

--- a/systems/plants/test/FloatingMassSpringDamper.urdf
+++ b/systems/plants/test/FloatingMassSpringDamper.urdf
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<robot name="FloatingMassSpringDamper">
+  <material name="green">
+    <color rgba=".3 .6 .4 1" />
+  </material>
+  <material name="red">
+    <color rgba=".9 .1 0 1" />
+  </material>
+  <material name="blue">
+    <color rgba="0 0 1 1" />
+  </material>
+  <link name="mass1">
+    <inertial> 
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <mass value="1" />
+      <inertia ixx=".01" ixy="0" ixz="0" iyy=".01" iyz="0" izz=".01"/> 
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <box size="1 1 1" />
+      </geometry>
+      <material name="red" />
+    </visual> 
+  </link>
+  <link name="mass2">
+    <inertial> 
+      <origin xyz="2 0 0" rpy="0 0 0" />
+      <mass value="1" />
+      <inertia ixx=".01" ixy="0" ixz="0" iyy=".01" iyz="0" izz=".01"/> 
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <box size="1 1 1" />
+      </geometry>
+      <material name="red" />
+    </visual> 
+  </link>
+  <joint name="x" type="prismatic">
+    <parent link="mass1"/>
+    <child link="mass2" />
+    <axis xyz="1 0 0" />
+  </joint>
+  <force_element name="spring">
+    <linear_spring_damper stiffness="10" damping="1">
+      <link1 link="mass1" xyz="0 0 0" />
+      <link2 link="mass2" xyz="0 0 0" />
+    </linear_spring_damper>
+  </force_element>
+  <transmission type="SimpleTransmission" name="x_transmission">
+    <actuator name="x_actuator" />
+    <joint name="x" />
+    <mechanicalReduction>1</mechanicalReduction>
+  </transmission>
+</robot>

--- a/systems/plants/test/testFloatingMassSpringDamperForceGradients.m
+++ b/systems/plants/test/testFloatingMassSpringDamperForceGradients.m
@@ -1,0 +1,39 @@
+function testFloatingMassSpringDamperForceGradients()
+% Tests user gradients vs numerical gradients for consistency
+
+options.floating = true;
+p = RigidBodyManipulator('FloatingMassSpringDamper.urdf',options);
+fun = @(q,qd)vectorComputeSpatialForce(p,q,qd);
+
+% some random states to test
+q = 100*rand(7,10);
+qd = 100*rand(7,10);
+
+for i=1:size(q,2)
+  f1=cell(1,2);
+  [f1{:}]=geval(1,fun,q(:,i),qd(:,i),struct('grad_method','user'));
+
+  f2=cell(1,2);
+  [f2{:}]=geval(1,fun,q(:,i),qd(:,i),struct('grad_method','numerical'));
+  
+  if (any(any(abs(f1{1}-f2{1})>1e-4)))
+    error('forces when computing gradients don''t match!');
+  end
+  if (any(any(abs(f1{2}-f2{2})>1e-4)))
+    error('computing gradients don''t match!');
+  end
+  
+end
+
+end
+
+function [f_ext,df_ext] = vectorComputeSpatialForce(p,q,qd)
+if (nargout>1)
+    [f_ext,df_ext] = p.force{1}.computeSpatialForce(p,q,qd);
+    f_ext = reshape(f_ext,numel(f_ext),1);
+    df_ext = reshape(df_ext,numel(f_ext),size(q,1)+size(qd,1));
+else
+    f_ext = p.force{1}.computeSpatialForce(p,q,qd);
+    f_ext = reshape(f_ext,numel(f_ext),1);
+end
+end


### PR DESCRIPTION
Fixes the bug referenced here: https://github.com/RobotLocomotion/drake/issues/621. It had never been noticed because our tests use a 1dof urdf, so also adding a 7dof plant for better test converage in the future.
