### PR TITLE
make megaclear 100x faster by not calling vrwho

### DIFF
--- a/systems/plants/@RigidBodyWRLVisualizer/RigidBodyWRLVisualizer.m
+++ b/systems/plants/@RigidBodyWRLVisualizer/RigidBodyWRLVisualizer.m
@@ -25,6 +25,15 @@ classdef RigidBodyWRLVisualizer < RigidBodyVisualizer
       
       wrlfile = fullfile(tempdir,[obj.model.name{1},'.wrl']);
       writeWRL(obj,wrlfile,options);
+      
+      % For some inexplicable reason, any interaction with the VR system causes 
+      % subsequent calls to evalin('base', 'clear all classes java imports'); 
+      % to become incredibly slow (on the order of 20 seconds instead of 0.01 
+      % seconds). We are overwriting vrworld to set an environment variable so 
+      % that later, in megaclear, we can skip a call to vrwho() if no vr worlds 
+      % have been created. 
+
+      setenv('HAS_MATLAB_VRWORLD', '1');
       obj.wrl = vrworld(wrlfile);
       if ~strcmpi(get(obj.wrl,'Open'),'on')
         open(obj.wrl);

--- a/util/megaclear.m
+++ b/util/megaclear.m
@@ -7,12 +7,23 @@ function megaclear()
 
     force_close_system();
 
-%    while ~isempty(vrgcf), close(vrgcf); end
-    if usejava('awt'), vrclear; end
+    % Even if no VR worlds have ever been constructed, calling vrwho() and/or
+    % vrclear makes subsequent calls to evalin('base', 'clear all classes java
+    % imports'); incredibly slow (on the order of 20 seconds). We get around
+    % that by checking an environment variable which is set in
+    % RigidBodyWRLVisualizer.
+    if getenv('HAS_MATLAB_VRWORLD')
+        if usejava('awt')
+          vrclose;
+          vrclear; 
+        end
+        setenv('HAS_MATLAB_VRWORLD', '');
+    end
 
     evalin('base', 'h=findobj; if numel(h)>1, delete(h(2:end)); end');  % delete dangling handles first
     evalin('base', 'clear all classes java imports');    % now clear everything else
     evalin('base', 'clear mex');  
+    
 
     dbstop(current_breakpoints);
 


### PR DESCRIPTION
Instead, we set an environment variable (ugly, I know) to indicate if we've built a VR world, then only clear VR if that variable is set.

This could potentially screw over someone who was constructing VRworlds in some way other than RigidBodyWRLVisualizer and expecting megaclear to clear them, but:
- we have no evidence that such people exist, AND
- megaclear in its current form _does not actually clear vrworld figures anyway_. We had to add the `vrclose` command to megaclear to get them to go away. 
