### PR TITLE
Make rospack check for package.xml

### DIFF
--- a/util/rospack.m
+++ b/util/rospack.m
@@ -66,7 +66,7 @@ while ~isempty(path)
       packages=vertcat(packages,pt);
     end
   else  % if find fails for some reason (windows?), then do it the hard way...
-    packages = vertcat(packages,searchdir(token));
+    packages = vertcat(packages,searchdir(token,'package.xml'));
   end
   % Then look for manifest.xml (deprecated)
   [info,p] = system(['find -L ',token,' -iname manifest.xml']);
@@ -78,14 +78,14 @@ while ~isempty(path)
       packages=vertcat(packages,pt);
     end
   else  % if find fails for some reason (windows?), then do it the hard way...
-    packages = vertcat(packages,searchdir(token));
+    packages = vertcat(packages,searchdir(token,'manifest.xml'));
   end
 end
 
 end
 
-function packages = searchdir(path)
-  if ~isempty(dir(fullfile(path,'manifest.xml')));
+function packages = searchdir(path,str)
+  if ~isempty(dir(fullfile(path,str)));
     packages = {path};
     return;
   end
@@ -94,6 +94,6 @@ function packages = searchdir(path)
   d = dir(path);
   for i=find([d.isdir])
     if (d(i).name(1)=='.') continue; end
-    packages = vertcat(packages,searchdir(d(i).name));
+    packages = vertcat(packages,searchdir(d(i).name,str));
   end
 end


### PR DESCRIPTION
Leaving in check for manifest.xml to preserve backwards compatibility.
Resolves #646
