### PR TITLE
replaced frame check to avoid requiring spotless when creating linear systems

### DIFF
--- a/systems/@PolynomialSystem/PolynomialSystem.m
+++ b/systems/@PolynomialSystem/PolynomialSystem.m
@@ -143,7 +143,7 @@ classdef PolynomialSystem < DrakeSystem
 
     function obj = setInputFrame(obj,frame)
       if frame.dim>0
-        if obj.getNumStates()>0 && any(match(obj.getStateFrame.getPoly,frame.getPoly)~=0)
+        if obj.getNumStates()>0 && hasSamePrefix(obj.getStateFrame,frame)
           error('input frame poly clashes with current state frame poly.  this could lead to massive confusion');
         end
       end
@@ -153,7 +153,7 @@ classdef PolynomialSystem < DrakeSystem
 
     function obj = setStateFrame(obj,frame)
       if frame.dim>0
-        if obj.getNumInputs()>0 && any(match(obj.getInputFrame.getPoly,frame.getPoly)~=0)
+        if obj.getNumInputs()>0 && hasSamePrefix(obj.getInputFrame,frame)
           error('state frame poly clashes with current input frame poly.  this could lead to massive confusion');
         end
       end

--- a/systems/frames/CoordinateFrame.m
+++ b/systems/frames/CoordinateFrame.m
@@ -80,6 +80,11 @@ classdef CoordinateFrame < handle
         obj.coordinates = {coordinates{:}}';
       end
     end
+    
+    function tf = hasSamePrefix(frame1,frame2)
+      % useful for alarming on a possible prefix clash between two polys
+      tf = any(any(bsxfun(@eq,frame1.prefix,frame2.prefix')));
+    end
 
     function p = getPoly(obj)
       % create the poly now if it hasn't been created yet

--- a/util/checkDependency.m
+++ b/util/checkDependency.m
@@ -25,7 +25,6 @@ else % then try to evaluate the dependency now...
       end
 
     case 'spotless'
-      % require spotless
       conf.spotless_enabled = logical(exist('msspoly','class'));
       if ~conf.spotless_enabled
         if ~pod_pkg_config('spotless')


### PR DESCRIPTION
resolves #665 
now
````
limp = LinearInvertedPendulum(1);
```
runs without loading spotless.  
runAtlasWalking still loads spotless in here
```
Error using checkDependency (line 28)
trying to get rid of this one

Error in PolynomialLyapunovFunction (line 10)
      checkDependency('spotless');

Error in QuadraticLyapunovFunction (line 13)
      obj = obj@PolynomialLyapunovFunction(frame,true);

Error in LinearInvertedPendulum/ZMPtrackerClosedForm
(line 274)
        Vt =
        QuadraticLyapunovFunction(getInputFrame(ct),S,s1traj,s2traj);
        
Error in Biped/planWalkingZMP (line 28)
[c,V,comtraj] =
LinearInvertedPendulum.ZMPtrackerClosedForm(com(3)-zfeet,zmptraj,options);

Error in runAtlasWalking (line 54)
walking_plan_data =
r.planWalkingZMP(x0(1:r.getNumPositions()),
footstep_plan);
```
which seems reasonable.  
