### PR TITLE
Add PassByValueMap and test.

### DIFF
--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -60,7 +60,7 @@ classdef RigidBodyManipulator < Manipulator
       obj = setTerrain(obj,options.terrain);
       obj.contact_options = obj.parseContactOptions(options);
 
-      obj.collision_filter_groups=containers.Map('KeyType','char','ValueType','any');
+      obj.collision_filter_groups = PassByValueMap('KeyType','char','ValueType','any');
       obj.collision_filter_groups('no_collision') = CollisionFilterGroup();
 
       if (nargin>0 && ~isempty(filename))
@@ -2358,7 +2358,7 @@ classdef RigidBodyManipulator < Manipulator
       % In case no robots were loaded from urdf, initialize
       % collision_filter_groups here.
       if isempty(model.collision_filter_groups)
-        model.collision_filter_groups=containers.Map('KeyType','char','ValueType','any');
+        model.collision_filter_groups = PassByValueMap('KeyType','char','ValueType','any');
         model.collision_filter_groups('no_collision') = CollisionFilterGroup();
       end
       if model.contact_options.ignore_self_collisions

--- a/util/PassByValueMap.m
+++ b/util/PassByValueMap.m
@@ -1,0 +1,94 @@
+classdef PassByValueMap
+  % This class provides a pass-by-value version of the containers.Map
+  % class. See the documentation for that class for more description and
+  % instructions. PassByValueMap should not be used for large,
+  % frequently changing maps, as any modification to the map creates a
+  % copy.
+  
+  properties (Access = private)
+    map
+  end
+  methods
+    function obj = PassByValueMap(varargin)
+      obj.map = containers.Map(varargin{:});
+    end
+
+    function disp(obj)
+      disp(obj.map)
+    end
+
+    % Pass throughs
+    function [varargout] = isKey(obj, varargin)
+      varargout = cell(1, nargout);
+      [varargout{:}] = obj.map.isKey(varargin{:});
+    end
+
+    function [varargout] = keys(obj, varargin)
+      varargout = cell(1, max(1,nargout));
+      [varargout{:}] = obj.map.keys(varargin{:});
+    end
+
+    function [varargout] = values(obj, varargin)
+      varargout = cell(1, nargout);
+      [varargout{:}] = obj.map.values(varargin{:});
+    end
+
+    function [varargout] = size(obj, varargin)
+      varargout = cell(1, nargout);
+      [varargout{:}] = obj.map.size(varargin{:});
+    end
+
+    function [varargout] = length(obj, varargin)
+      varargout = cell(1, nargout);
+      [varargout{:}] = obj.map.length(varargin{:});
+    end
+
+    function [varargout] = isempty(obj, varargin)
+      varargout = cell(1, nargout);
+      [varargout{:}] = obj.map.isempty(varargin{:});
+    end
+
+    function count = Count(obj)
+      count = obj.map.Count();
+    end
+
+    function key_type = KeyType(obj)
+      key_type = obj.map.KeyType();
+    end
+
+    function value_type = ValueType(obj)
+      value_type = obj.map.ValueType();
+    end
+
+    % Modified methods
+    function varargout = subsref(obj, S)
+      varargout = cell(1, max(1, nargout));
+      if S(1).type == '.'
+        [varargout{:}] = builtin('subsref', obj, S);
+      else
+        [varargout{:}] = subsref(obj.map, S);
+      end
+    end
+
+    function obj = subsasgn(obj, varargin)
+      obj.map = obj.getCopyOfInternalMap();
+      obj.map = obj.map.subsasgn(varargin{:});
+    end
+
+    function obj = remove(obj, varargin)
+      obj.map = obj.getCopyOfInternalMap();
+      obj.map = obj.map.remove(varargin{:});
+    end
+
+    function new_map = getCopyOfInternalMap(obj)
+      new_map = containers.Map('KeyType', obj.map.KeyType, ...
+        'ValueType', obj.map.ValueType);
+      if ~isempty(obj.map.keys)
+        keys = obj.map.keys;
+        for i = 1:numel(obj.map.keys)
+          new_map(keys{i}) = obj.map(keys{i});
+        end
+      end
+    end
+  end
+end

--- a/util/test/PassByValueMapTest.m
+++ b/util/test/PassByValueMapTest.m
@@ -1,0 +1,57 @@
+function PassByValueMapTest()
+  handle_map = containers.Map();
+  value_map = PassByValueMap();
+
+  % Check that the empty maps are equal
+  assert(isequal(handle_map, value_map.getCopyOfInternalMap()))
+
+  % Check that isempty works for empty map
+  assert(isempty(value_map));
+
+  % Check simple assignment
+  handle_map('abc') = 1;
+  value_map('abc') = 1;
+  value_map2 = value_map;
+
+  handle_map('ghi') = 2;
+  value_map('ghi') = 2;
+  assert(isequal(handle_map, value_map.getCopyOfInternalMap()))
+
+  % Check that modifying value_map didn't modify value_map 2
+  assert(value_map.Count == 2);
+  assert(value_map2.Count == 1);
+
+  % Test methods
+  % iskey
+  assert(value_map.isKey('abc'));
+  assert(~value_map.isKey('def'));
+
+  % keys
+  assert(isequal(handle_map.keys, value_map.keys));
+
+  % values
+  assert(isequal(handle_map.values, value_map.values));
+
+  % size
+  assert(isequal(handle_map.size, value_map.size));
+
+  % length
+  assert(isequal(handle_map.length, value_map.length));
+
+  % isempty
+  assert(isequal(handle_map.isempty, value_map.isempty));
+
+  % KeyType
+  assert(isequal(handle_map.KeyType, value_map.KeyType));
+
+  % ValueType
+  assert(isequal(handle_map.ValueType, value_map.ValueType));
+
+  % remove
+  value_map3 = value_map;
+  value_map.remove('abc');
+  assert(isequal(value_map, value_map3));
+
+  value_map = value_map.remove('ghi');
+  assert(isequal(value_map, value_map2));
+end


### PR DESCRIPTION
Also makes RBM use PassByValueMap. This finally eliminates a nasty hidden
"pass-by-reference" behavior in RBM's collision_filter_groups.