### PR TITLE
Fix: Broken temp file if URDF string contains '%'

### DIFF
--- a/systems/plants/@RigidBodyManipulator/addRobotFromURDFString.m
+++ b/systems/plants/@RigidBodyManipulator/addRobotFromURDFString.m
@@ -18,7 +18,7 @@ function model=addRobotFromURDFString(model,urdf_string,varargin)
 typecheck(urdf_string,'char');
 urdf_filename = tempname;
 file_id = fopen(urdf_filename,'w');
-fprintf(file_id, urdf_string);
+fprintf(file_id, '%s', urdf_string);
 fclose(file_id);
 
 model = addRobotFromURDF(model, urdf_filename, varargin{:});


### PR DESCRIPTION
URDF strings may contain '%' (e.g. in comments) that would be interpreted as a format symbol by fprintf. Using the '%s' format string prevents that.