### PR TITLE
Minor mods to Atlas frame names, fleshing out IRB140

### DIFF
--- a/examples/Atlas/+atlasControllers/RobotiqControlBlock.m
+++ b/examples/Atlas/+atlasControllers/RobotiqControlBlock.m
@@ -17,8 +17,8 @@ classdef RobotiqControlBlock < MIMODrakeSystem
         options = struct();
       end
       
-      input_frame = atlasFrames.HandState(r, ind, [name, 'atlasFrames.HandState']);
-      output_frame = atlasFrames.HandInput(r, ind, [name, 'atlasFrames.HandInput']);
+      input_frame = atlasFrames.HandState(r, ind, [name, 'HandState']);
+      output_frame = atlasFrames.HandInput(r, ind, [name, 'HandInput']);
       
       obj = obj@MIMODrakeSystem(0,0,input_frame,output_frame,true,true);
       obj = setInputFrame(obj,input_frame);

--- a/examples/Atlas/Atlas.m
+++ b/examples/Atlas/Atlas.m
@@ -77,7 +77,7 @@ classdef Atlas < TimeSteppingRigidBodyManipulator & Biped
         % Sub in handstates for each hand
         % TODO: by name?
         for i=2:obj.getStateFrame().getNumFrames
-          atlas_state_frame = replaceFrameNum(atlas_state_frame,i,atlasFrames.HandState(obj,i,'atlasFrames.HandState'));
+          atlas_state_frame = replaceFrameNum(atlas_state_frame,i,atlasFrames.HandState(obj,i,'HandState'));
         end
       else
         atlas_state_frame = atlasFrames.AtlasState(obj);
@@ -101,7 +101,7 @@ classdef Atlas < TimeSteppingRigidBodyManipulator & Biped
         % Sub in handstates for each hand
         % TODO: by name?
         for i=2:obj.getInputFrame().getNumFrames
-          input_frame = replaceFrameNum(input_frame,i,atlasFrames.HandInput(obj,i,'atlasFrames.HandInput'));
+          input_frame = replaceFrameNum(input_frame,i,atlasFrames.HandInput(obj,i,'HandInput'));
         end
       else
         input_frame = atlasFrames.AtlasInput(obj);

--- a/examples/Atlas/urdf/block_hand.urdf
+++ b/examples/Atlas/urdf/block_hand.urdf
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+
+<robot name="block_hand" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <link name="block_hand_box">
+    <inertial>
+      <mass value="1.0"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 .5 1"/>
+      </material>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+    </visual>
+    <collision group="block_hand">
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1.0 0.0 .0 1"/>
+      </material>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+    </collision>
+  </link>
+</robot>

--- a/examples/IRB140/IRB140Input.m
+++ b/examples/IRB140/IRB140Input.m
@@ -11,7 +11,7 @@ classdef IRB140Input < SingletonCoordinateFrame
       input_names = manipInputFrame.coordinates;
       input_names = regexprep(input_names,'_motor',''); % remove motor suffix     
       
-      obj = obj@SingletonCoordinateFrame('IRB140',length(input_names),'x',input_names);
+      obj = obj@SingletonCoordinateFrame('IRB140Input',length(input_names),'x',input_names);
     end
   end
 end


### PR DESCRIPTION
On DRC side I'm planning on removing the HandState and HandInput classes (since they just duplicate Drake's copies), so on Drake side this changes the Atlas hand state name to be more general.

Adds another hand for simulated IRB hand (with super simple collision geom -- pretty much just a debug feature) and fixes up compilation of the IRB class.

(This is in support of DRC-side update.)