### PR TITLE
install urdf rbm, fix compile error, default joint limits for urdf

### DIFF
--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -71,6 +71,8 @@ classdef RigidBodyManipulator < Manipulator
           obj = addRobotFromURDF(obj,filename,zeros(3,1),zeros(3,1),options);
         elseif strcmpi(ext,'.sdf') || strcmpi(ext,'.world')
           obj = addRobotFromSDF(obj,filename,zeros(3,1),zeros(3,1),options);
+        else
+          error('Drake:RigidBodyManipulator:UnsupportedFileExtension','Unrecognized file extension: %s',ext);
         end          
       end
     end

--- a/systems/plants/CMakeLists.txt
+++ b/systems/plants/CMakeLists.txt
@@ -36,6 +36,7 @@ if (eigen3_FOUND)
     if (NOT MSVC)
     set_target_properties(drakeRBMurdf PROPERTIES COMPILE_FLAGS -fPIC )
     endif()
+    pods_install_headers(URDFRigidBodyManipulator.h DESTINATION drake)
     pods_install_libraries(drakeRBMurdf)
 
     add_subdirectory(urdf_interface)

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -31,7 +31,7 @@ using namespace Eigen;
 
 //extern std::set<int> emptyIntSet;  // was const std:set<int> emptyIntSet, but valgrind said I was leaking memory
 
-class DLLEXPORT_RBM RigidBodyManipulator 
+class DLLEXPORT_RBM RigidBodyManipulator
 {
 public:
   RigidBodyManipulator(int num_dof, int num_featherstone_bodies=-1, int num_rigid_body_objects=-1, int num_rigid_body_frames=0);
@@ -69,10 +69,10 @@ public:
 
   template <typename Derived>
     void getContactPositions(MatrixBase<Derived> &pos, const std::set<int> &body_idx);// = emptyIntSet);
-  
+
   template <typename Derived>
     void getContactPositionsJac(MatrixBase<Derived> &J, const std::set<int> &body_idx);// = emptyIntSet);
-  
+
   template <typename Derived>
     void getContactPositionsJacDot(MatrixBase<Derived> &Jdot, const std::set<int> &body_idx);// = emptyIntSet);
 
@@ -117,7 +117,7 @@ public:
 
   void updateCollisionElements(const int body_ind);
 
-  bool setCollisionFilter(const int body_ind, const uint16_t group, 
+  bool setCollisionFilter(const int body_ind, const uint16_t group,
                           const uint16_t mask);
 
   bool getPairwiseCollision(const int body_indA, const int body_indB, MatrixXd &ptsA, MatrixXd &ptsB, MatrixXd &normals, bool use_margins=true);
@@ -127,54 +127,54 @@ public:
   bool getPointCollision(const int body_ind, const int body_collision_ind, Vector3d &ptA, Vector3d &ptB, Vector3d &normal, bool use_margins=true);
 
   bool getPairwiseClosestPoint(const int body_indA, const int body_indB, Vector3d &ptA, Vector3d &ptB, Vector3d &normal, double &distance, bool use_margins=true);
-  
+
   bool collisionRaycast(const Matrix3Xd &origins, const Matrix3Xd &ray_endpoints, VectorXd &distances, bool use_margins=false);
 
   //bool closestPointsAllBodies( MatrixXd& ptsA, MatrixXd& ptsB,
                                //MatrixXd& normal, VectorXd& distance,
-                               //std::vector<int>& bodyA_idx, 
+                               //std::vector<int>& bodyA_idx,
                                //std::vector<int>& bodyB_idx);
 
-  bool collisionDetect( VectorXd& phi, MatrixXd& normal, 
-                        MatrixXd& xA, MatrixXd& xB, 
-                        std::vector<int>& bodyA_idx, 
+  bool collisionDetect( VectorXd& phi, MatrixXd& normal,
+                        MatrixXd& xA, MatrixXd& xB,
+                        std::vector<int>& bodyA_idx,
                         std::vector<int>& bodyB_idx,
                         const std::vector<int>& bodies_idx,
                         const std::set<std::string>& active_element_groups,
                         bool use_margins = true);
 
-  bool collisionDetect( VectorXd& phi, MatrixXd& normal, 
-                        MatrixXd& xA, MatrixXd& xB, 
-                        std::vector<int>& bodyA_idx, 
+  bool collisionDetect( VectorXd& phi, MatrixXd& normal,
+                        MatrixXd& xA, MatrixXd& xB,
+                        std::vector<int>& bodyA_idx,
                         std::vector<int>& bodyB_idx,
                         const std::vector<int>& bodies_idx,
                         bool use_margins = true);
 
-  bool collisionDetect( VectorXd& phi, MatrixXd& normal, 
-                        MatrixXd& xA, MatrixXd& xB, 
-                        std::vector<int>& bodyA_idx, 
+  bool collisionDetect( VectorXd& phi, MatrixXd& normal,
+                        MatrixXd& xA, MatrixXd& xB,
+                        std::vector<int>& bodyA_idx,
                         std::vector<int>& bodyB_idx,
                         const std::set<std::string>& active_element_groups,
                         bool use_margins = true);
 
-  bool collisionDetect( VectorXd& phi, MatrixXd& normal, 
-                        MatrixXd& xA, MatrixXd& xB, 
-                        std::vector<int>& bodyA_idx, 
+  bool collisionDetect( VectorXd& phi, MatrixXd& normal,
+                        MatrixXd& xA, MatrixXd& xB,
+                        std::vector<int>& bodyA_idx,
                         std::vector<int>& bodyB_idx,
                         bool use_margins = true);
 
 
-  bool allCollisions(std::vector<int>& bodyA_idx, std::vector<int>& bodyB_idx, 
+  bool allCollisions(std::vector<int>& bodyA_idx, std::vector<int>& bodyB_idx,
                      MatrixXd& ptsA, MatrixXd& ptsB,
                         bool use_margins = true);
 
   //bool closestDistanceAllBodies(VectorXd& distance, MatrixXd& Jd);
-  
+
   int findLinkId(std::string linkname, int robot = -1);
   //@param robot   the index of the robot. robot = -1 means to look at all the robots
-  
+
   std::string getBodyOrFrameName(int body_or_frame_id);
-  //@param body_or_frame_id   the index of the body or the id of the frame. 
+  //@param body_or_frame_id   the index of the body or the id of the frame.
 public:
   std::vector<std::string> robot_name;
 
@@ -184,7 +184,7 @@ public:
 
   // Rigid body objects
   int num_bodies;  // rigid body objects
-  std::vector<std::unique_ptr<RigidBody>> bodies;
+  std::vector<std::unique_ptr<RigidBody> > bodies;
 
   // Rigid body frames
   int num_frames;
@@ -223,8 +223,8 @@ private:
   //Variables for gradient calculations
   MatrixXd dTdTmult;
   std::vector<MatrixXd> dXupdq;
-  std::vector<std::vector<MatrixXd>> dIC;
-  std::vector<typename Gradient<Matrix<double, TWIST_SIZE, TWIST_SIZE>, Eigen::Dynamic>::type> dIc_new;
+  std::vector<std::vector<MatrixXd> > dIC;
+  std::vector<Gradient<Matrix<double, TWIST_SIZE, TWIST_SIZE>, Eigen::Dynamic>::type> dIc_new;
 
   std::vector<MatrixXd> dvdq;
   std::vector<MatrixXd> dvdqd;
@@ -242,15 +242,15 @@ private:
 
   // preallocate for CMM function
   MatrixXd Xg; // spatial centroidal projection matrix
-  MatrixXd dXg;  // dXg_dq * qd  
+  MatrixXd dXg;  // dXg_dq * qd
   std::vector<MatrixXd> Ic; // composite rigid body inertias
   std::vector<MatrixXd> dIc; // derivative of composite rigid body inertias
   std::vector<VectorXd> phi; // joint axis vectors
   std::vector<MatrixXd> Xworld; // spatial transforms from world to each body
   std::vector<MatrixXd> dXworld; // dXworld_dq * qd
-  std::vector<MatrixXd> dXup; // dXup_dq * qd 
+  std::vector<MatrixXd> dXup; // dXup_dq * qd
   MatrixXd Xcom; // spatial transform from centroid to world
-  MatrixXd Jcom; 
+  MatrixXd Jcom;
   MatrixXd dXcom;
   MatrixXd Xi;
   MatrixXd dXidq;
@@ -271,7 +271,7 @@ private:
   // These models are switched between with the use_margins flag
   // to collision-relevant methods of the RBM.
   std::shared_ptr< DrakeCollision::Model > collision_model;
-  std::shared_ptr< DrakeCollision::Model > collision_model_no_margins;  
+  std::shared_ptr< DrakeCollision::Model > collision_model_no_margins;
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 

--- a/systems/plants/urdf_interface/exceptions.h
+++ b/systems/plants/urdf_interface/exceptions.h
@@ -24,5 +24,10 @@ namespace urdf{
     protected:
       std::string error_msg_;
   };
+  
 }
+
+extern void ROS_ERROR(const char* format, ...);
+extern void ROS_DEBUG(const char* format, ...);
+
 #endif

--- a/systems/plants/urdf_interface/joint.cpp
+++ b/systems/plants/urdf_interface/joint.cpp
@@ -38,6 +38,7 @@
 #include <stdarg.h>
 #include <sstream>
 #include <boost/lexical_cast.hpp>
+#include <limits>
 
 #include "exceptions.h"
 #include "joint.h"
@@ -49,6 +50,15 @@ void ROS_ERROR(const char* format, ...) {
   va_end(vl);
   printf("\n");
   exit(1);
+}
+
+void ROS_DEBUG(const char* format, ...) {
+  printf("WARNING: ");
+  va_list vl;
+  va_start(vl, format);
+  vprintf(format, vl);
+  va_end(vl);
+  printf("\n");
 }
 
 namespace urdf{
@@ -113,8 +123,8 @@ bool JointLimits::initXml(TiXmlElement* config)
   // Get lower joint limit
   const char* lower_str = config->Attribute("lower");
   if (lower_str == NULL){
-    //ROS_DEBUG("joint limit: no lower, defaults to 0");
-    this->lower = 0;
+    ROS_DEBUG("joint limit: no lower, defaults to -inf");
+    this->lower = std::numeric_limits<double>::min();
   }
   else
   {
@@ -132,8 +142,8 @@ bool JointLimits::initXml(TiXmlElement* config)
   // Get upper joint limit
   const char* upper_str = config->Attribute("upper");
   if (upper_str == NULL){
-    //ROS_DEBUG("joint limit: no upper, , defaults to 0");
-    this->upper = 0;
+    ROS_DEBUG("joint limit: no upper, defaults to inf");
+    this->upper = std::numeric_limits<double>::max();
   }
   else
   {
@@ -151,8 +161,8 @@ bool JointLimits::initXml(TiXmlElement* config)
   // Get joint effort limit
   const char* effort_str = config->Attribute("effort");
   if (effort_str == NULL){
-    ROS_ERROR("joint limit: no effort");
-    return false;
+    ROS_DEBUG("joint limit: no effort, defaults to inf");
+    this->effort = std::numeric_limits<double>::max();
   }
   else
   {
@@ -162,7 +172,7 @@ bool JointLimits::initXml(TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      //ROS_ERROR("effort value (%s) is not a float",effort_str);
+      ROS_ERROR("effort value (%s) is not a float",effort_str);
       return false;
     }
   }
@@ -170,8 +180,8 @@ bool JointLimits::initXml(TiXmlElement* config)
   // Get joint velocity limit
   const char* velocity_str = config->Attribute("velocity");
   if (velocity_str == NULL){
-    ROS_ERROR("joint limit: no velocity");
-    return false;
+    ROS_DEBUG("joint limit: no velocity, defaults to inf");
+    this->velocity = std::numeric_limits<double>::max();
   }
   else
   {
@@ -197,7 +207,7 @@ bool JointSafety::initXml(TiXmlElement* config)
   const char* soft_lower_limit_str = config->Attribute("soft_lower_limit");
   if (soft_lower_limit_str == NULL)
   {
-    //ROS_DEBUG("joint safety: no soft_lower_limit, using default value");
+    ROS_DEBUG("joint safety: no soft_lower_limit, using default value");
     this->soft_lower_limit = 0;
   }
   else
@@ -217,7 +227,7 @@ bool JointSafety::initXml(TiXmlElement* config)
   const char* soft_upper_limit_str = config->Attribute("soft_upper_limit");
   if (soft_upper_limit_str == NULL)
   {
-    //ROS_DEBUG("joint safety: no soft_upper_limit, using default value");
+    ROS_DEBUG("joint safety: no soft_upper_limit, using default value");
     this->soft_upper_limit = 0;
   }
   else
@@ -237,7 +247,7 @@ bool JointSafety::initXml(TiXmlElement* config)
   const char* k_position_str = config->Attribute("k_position");
   if (k_position_str == NULL)
   {
-    //ROS_DEBUG("joint safety: no k_position, using default value");
+    ROS_DEBUG("joint safety: no k_position, using default value");
     this->k_position = 0;
   }
   else
@@ -283,7 +293,7 @@ bool JointCalibration::initXml(TiXmlElement* config)
   const char* rising_position_str = config->Attribute("rising");
   if (rising_position_str == NULL)
   {
-    //ROS_DEBUG("joint calibration: no rising, using default value");
+    ROS_DEBUG("joint calibration: no rising, using default value");
     this->rising.reset();
   }
   else
@@ -303,7 +313,7 @@ bool JointCalibration::initXml(TiXmlElement* config)
   const char* falling_position_str = config->Attribute("falling");
   if (falling_position_str == NULL)
   {
-    //ROS_DEBUG("joint calibration: no falling, using default value");
+    ROS_DEBUG("joint calibration: no falling, using default value");
     this->falling.reset();
   }
   else
@@ -331,8 +341,8 @@ bool JointMimic::initXml(TiXmlElement* config)
 
   if (joint_name_str == NULL)
   {
-    //ROS_ERROR("joint mimic: no mimic joint specified");
-    //return false;
+    ROS_ERROR("joint mimic: no mimic joint specified");
+    return false;
   }
   else
      this->joint_name = joint_name_str;
@@ -342,7 +352,7 @@ bool JointMimic::initXml(TiXmlElement* config)
 
   if (multiplier_str == NULL)
   {
-    //ROS_DEBUG("joint mimic: no multiplier, using default value of 1");
+    ROS_DEBUG("joint mimic: no multiplier, using default value of 1");
     this->multiplier = 1;    
   }
   else
@@ -363,7 +373,7 @@ bool JointMimic::initXml(TiXmlElement* config)
   const char* offset_str = config->Attribute("offset");
   if (offset_str == NULL)
   {
-    //ROS_DEBUG("joint mimic: no offset, using default value of 0");
+    ROS_DEBUG("joint mimic: no offset, using default value of 0");
     this->offset = 0;
   }
   else
@@ -399,7 +409,7 @@ bool Joint::initXml(TiXmlElement* config)
   TiXmlElement *origin_xml = config->FirstChildElement("origin");
   if (!origin_xml)
   {
-    //ROS_DEBUG("Joint '%s' missing origin tag under parent describing transform from Parent Link to Joint Frame, (using Identity transform).", this->name.c_str());
+    ROS_DEBUG("Joint '%s' missing origin tag under parent describing transform from Parent Link to Joint Frame, (using Identity transform).", this->name.c_str());
     this->parent_to_joint_origin_transform.clear();
   }
   else

--- a/systems/plants/urdf_interface/joint.cpp
+++ b/systems/plants/urdf_interface/joint.cpp
@@ -53,6 +53,7 @@ void ROS_ERROR(const char* format, ...) {
 }
 
 void ROS_DEBUG(const char* format, ...) {
+  return; // remove this to see debug spews
   printf("WARNING: ");
   va_list vl;
   va_start(vl, format);

--- a/systems/plants/urdf_interface/link.cpp
+++ b/systems/plants/urdf_interface/link.cpp
@@ -43,6 +43,7 @@
 #include "link.h"
 #include "exceptions.h"
 
+
 namespace urdf{
 
 boost::shared_ptr<Geometry> parseGeometry(TiXmlElement *g)
@@ -53,7 +54,7 @@ boost::shared_ptr<Geometry> parseGeometry(TiXmlElement *g)
   TiXmlElement *shape = g->FirstChildElement();
   if (!shape)
   {
-    //ROS_ERROR("Geometry tag contains no child element.");
+    ROS_ERROR("Geometry tag contains no child element.");
     return geom;
   }
 
@@ -68,7 +69,7 @@ boost::shared_ptr<Geometry> parseGeometry(TiXmlElement *g)
     geom.reset(new Mesh);
   else
   {
-    //ROS_ERROR("Unknown geometry type '%s'", type_name.c_str());
+    ROS_ERROR("Unknown geometry type '%s'", type_name.c_str());
     return geom;
   }
 

--- a/systems/plants/urdf_interface/model.h
+++ b/systems/plants/urdf_interface/model.h
@@ -121,10 +121,10 @@ public:
       std::string parent_link_name = joint->second->parent_link_name;
       std::string child_link_name = joint->second->child_link_name;
 
-      //ROS_DEBUG("build tree: joint: '%s' has parent link '%s' and child  link '%s'", joint->first.c_str(), parent_link_name.c_str(),child_link_name.c_str());
+      ROS_DEBUG("build tree: joint: '%s' has parent link '%s' and child  link '%s'", joint->first.c_str(), parent_link_name.c_str(),child_link_name.c_str());
       if (parent_link_name.empty() || child_link_name.empty())
       {
-        //ROS_ERROR("    Joint %s is missing a parent and/or child link specification.",(joint->second)->name.c_str());
+        ROS_ERROR("    Joint %s is missing a parent and/or child link specification.",(joint->second)->name.c_str());
         return false;
       }
       else
@@ -134,13 +134,13 @@ public:
         this->getLink(child_link_name, child_link);
         if (!child_link)
         {
-          //ROS_ERROR("    child link '%s' of joint '%s' not found", child_link_name.c_str(), joint->first.c_str() );
+          ROS_ERROR("    child link '%s' of joint '%s' not found", child_link_name.c_str(), joint->first.c_str() );
           return false;
         }
         this->getLink(parent_link_name, parent_link);
         if (!parent_link)
         {
-          //ROS_ERROR("    parent link '%s' of joint '%s' not found.  The Boxturtle urdf parser used to automatically add this link for you, but this is not valid according to the URDF spec. Every link you refer to from a joint needs to be explicitly defined in the robot description. To fix this problem you can either remove this joint from your urdf file, or add \"<link name=\"%s\" />\" to your urdf file.", parent_link_name.c_str(), joint->first.c_str(), parent_link_name.c_str() );
+          ROS_ERROR("    parent link '%s' of joint '%s' not found.  The Boxturtle urdf parser used to automatically add this link for you, but this is not valid according to the URDF spec. Every link you refer to from a joint needs to be explicitly defined in the robot description. To fix this problem you can either remove this joint from your urdf file, or add \"<link name=\"%s\" />\" to your urdf file.", parent_link_name.c_str(), joint->first.c_str(), parent_link_name.c_str() );
           return false;
         }
 
@@ -159,7 +159,7 @@ public:
         // fill in child/parent string map
         parent_link_tree[child_link->name] = parent_link_name;
       
-        //ROS_DEBUG("    now Link '%s' has %i children ", parent_link->name.c_str(), (int)parent_link->child_links.size());
+        ROS_DEBUG("    now Link '%s' has %i children ", parent_link->name.c_str(), (int)parent_link->child_links.size());
       }
     }
 
@@ -186,17 +186,17 @@ public:
         }
         // we already found a root link
         else{
-          //ROS_ERROR("Two root links found: '%s' and '%s'", this->root_link_->name.c_str(), l->first.c_str());
+          ROS_ERROR("Two root links found: '%s' and '%s'", this->root_link_->name.c_str(), l->first.c_str());
           return false;
         }
       }
     }
     if (!this->root_link_)
     {
-      //ROS_ERROR("No root link found. The robot xml is not a valid tree.");
+      ROS_ERROR("No root link found. The robot xml is not a valid tree.");
       return false;
     }
-    //ROS_DEBUG("Link '%s' is the root link", this->root_link_->name.c_str());
+    ROS_DEBUG("Link '%s' is the root link", this->root_link_->name.c_str());
 
     return true;
   };

--- a/util/makeROSCompatibleURDF.m
+++ b/util/makeROSCompatibleURDF.m
@@ -1,0 +1,65 @@
+function makeROSCompatibleURDF(input_urdf_filename,output_urdf_filename)
+% Drake supports urdf input beyond what ROS and other URDF readers
+% support.  Additional drake xml tags will simply be ignored by other URDF
+% parsers, but parameters and the ability to write matlab expressions in
+% place of floats can cause problems.  This script will parse the
+% parameters and write a new urdf which is compliant.
+%
+% @param input_urdf_filename string containing the filename
+% @param output_urdf_filename optional string containing the output
+% filename @default: input_urdf_filename with '_compatible' inserted in the name
+% just before the urdf
+
+if nargin<2,
+  [~,~,ext] = fileparts(input_urdf_filename);
+  output_urdf_filename = strrep(input_urdf_filename,ext,['_compatible',ext]);
+end
+
+param_db = struct();
+urdf = xmlread(input_urdf_filename);
+
+% parse parameters
+parameters = urdf.getElementsByTagName('parameter');
+for i=0:(parameters.getLength()-1)
+  param_db = parseParameter(param_db,parameters.item(i));
+end
+
+% now iterate through ALL nodes and evaluate them based on their parameters
+nodes = urdf.getElementsByTagName('*');
+for i=0:(nodes.getLength()-1)
+  attributes = nodes.item(i).getAttributes();
+  for j=0:(attributes.getLength()-1)
+    att = attributes.item(j);
+    att.setValue(parseParamString(param_db,char(att.getValue())));
+  end  
+end
+
+xmlwrite(output_urdf_filename,urdf);
+fprintf('Output written to %s\n',output_urdf_filename);
+
+end
+
+
+function param_db = parseParameter(param_db,node)
+  name = char(node.getAttribute('name'));    % mandatory
+  param_db.(name).value = str2num(char(node.getAttribute('value')));  % mandatory
+  n = char(node.getAttribute('lb'));  % optional
+  if isempty(n), param_db.(name).lb = -inf; else param_db.(name).lb = str2num(n); end
+  n = char(node.getAttribute('ub'));  % optional
+  if isempty(n), param_db.(name).ub = inf; else param_db.(name).ub = str2num(n); end
+end
+
+function default_value = parseParamString(param_db,str)
+  pstr2 = regexprep(str,'\$(\w+)','param_db.(''$1'').value');
+  try 
+    default_value = eval(['[',pstr2,']']);
+  catch
+    default_value = pstr2;
+    % intentionally fall through
+  end
+  if isnumeric(default_value)
+    default_value = num2str(default_value);
+  else
+    default_value = pstr2;
+  end
+end


### PR DESCRIPTION
pod install URDFRigidBodyManipulator.h
fixed a few whitespace issues in template arguments.
updated urdf loader by restoring commented out error / debug messages (now it might be too much spew).

note: default URDF loader (imported from ROS) set limits to zero and errored out if there were no effort/velocity limits.  but i decided that i had to respect the urdf spec in doc/drakeURDF.xsd, since that's what we've been using.  not real happy about that one.

Oh, and CONGRATS PATS!!