### PR TITLE
updates logic for collision filter groups

### DIFF
--- a/systems/plants/RigidBody.m
+++ b/systems/plants/RigidBody.m
@@ -50,7 +50,7 @@ classdef RigidBody < RigidBodyElement
 
     % Collision filter properties
     collision_filter = struct('belongs_to',CollisionFilterGroup.DEFAULT_COLLISION_FILTER_GROUP_ID, ...
-                             'collides_with',CollisionFilterGroup.ALL_COLLISION_FILTER_GROUPS);
+                             'ignores',CollisionFilterGroup.NO_COLLISION_FILTER_GROUPS);
   end
   
   methods    
@@ -242,7 +242,7 @@ classdef RigidBody < RigidBodyElement
     end
     
     function body = makeIgnoreNoCollisionFilterGroups(body)
-      body.collision_filter.collides_with = CollisionFilterGroup.ALL_COLLISION_FILTER_GROUPS;
+      body.collision_filter.ignores = CollisionFilterGroup.NO_COLLISION_FILTER_GROUPS;
     end
 
     function body = makeBelongToCollisionFilterGroup(body,collision_fg_id)
@@ -251,11 +251,11 @@ classdef RigidBody < RigidBodyElement
           bitor(body.collision_filter.belongs_to,bitshift(1,id-1));
       end
     end
-
+   
     function body = makeIgnoreCollisionFilterGroup(body,collision_fg_id)
       for id = reshape(collision_fg_id,1,[])
-        body.collision_filter.collides_with = ...
-          bitand(body.collision_filter.collides_with,bitcmp(bitshift(uint16(1),id-1)));
+        body.collision_filter.ignores = ...
+          bitor(body.collision_filter.ignores,bitshift(1,id-1));
       end
     end
 

--- a/systems/plants/collision/Body.h
+++ b/systems/plants/collision/Body.h
@@ -110,8 +110,8 @@ namespace DrakeCollision
       {
         return  ( !adjacentTo(other) || (body_idx == 0) || (other.getBodyIdx() == 0) ) &&
                 ( (body_idx == -1) || (other.getBodyIdx() == -1) || body_idx != other.getBodyIdx()) && 
-                (group & other.mask).any() && 
-                (other.group & mask).any();
+                !((group & other.mask).any() || 
+                (other.group & mask).any());
       };
 
     private:

--- a/systems/plants/collision/Body.h
+++ b/systems/plants/collision/Body.h
@@ -6,7 +6,7 @@ namespace DrakeCollision
   class Body {
     public:
       Body() : body_idx(-1), parent_idx(-1), group(DEFAULT_GROUP), 
-      mask(ALL_MASK), elements() {};
+      mask(NONE_MASK), elements() {};
 
       void addElement(const int body_idx, const int parent_idx, 
                       const Eigen::Matrix4d& T_elem_to_link, Shape shape, 
@@ -88,9 +88,9 @@ namespace DrakeCollision
 
       void addToGroup(const bitmask& group) { this->group |= group; }; 
 
-      void ignoreGroup(const bitmask& group) { this->mask &= ~group; };
+      void ignoreGroup(const bitmask& group) { this->mask |= group; };
 
-      void collideWithGroup(const bitmask& group) { this->mask |= group; };
+      void collideWithGroup(const bitmask& group) { this->mask &= ~group; };
 
       void updateElements(const Eigen::Matrix4d& T_link_to_world)
       {

--- a/systems/plants/collision/test/BodyTest.cpp
+++ b/systems/plants/collision/test/BodyTest.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(ignoreGroup_test)
   Body body1;
   bitmask group; group.set(7);
   body1.ignoreGroup(group);
-  BOOST_CHECK( (body1.getMask() & group) == 0 );
+  BOOST_CHECK( (body1.getMask() & group) != 0 );
 }
 
 BOOST_AUTO_TEST_CASE(collidesWith_test)

--- a/systems/plants/collision/test/BodyTest.cpp
+++ b/systems/plants/collision/test/BodyTest.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(constructor_test)
   BOOST_CHECK_EQUAL(body1.getBodyIdx(), -1);
   BOOST_CHECK_EQUAL(body1.getParentIdx(), -1);
   BOOST_CHECK_EQUAL(body1.getGroup(), DEFAULT_GROUP);
-  BOOST_CHECK_EQUAL(body1.getMask(), ALL_MASK);
+  BOOST_CHECK_EQUAL(body1.getMask(), NONE_MASK);
 }
 
 BOOST_AUTO_TEST_CASE(setGroup_test)

--- a/systems/plants/constructModelmex.cpp
+++ b/systems/plants/constructModelmex.cpp
@@ -259,7 +259,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       // Set collision filtering bitmasks
       pm = mxGetProperty(pBodies,i,"collision_filter");
       const uint16_t* group = (uint16_t*)mxGetPr(mxGetField(pm,0,"belongs_to"));
-      const uint16_t* mask = (uint16_t*)mxGetPr(mxGetField(pm,0,"collides_with"));
+      const uint16_t* mask = (uint16_t*)mxGetPr(mxGetField(pm,0,"ignores"));
       //DEBUG
       //cout << "constructModelmex: Group: " << *group << endl;
       //cout << "constructModelmex: Mask " << *mask << endl;


### PR DESCRIPTION
Now RigidBody.collision_filter has fields 'belongs_to' and 'ignores'. By default bodies A and B are always checked against each other unless they are adjacent or (A.belongs_to & B.ignores) is non-empty or (A.ignores & B.belongs_to) is non-empty. Thus the logic has changed from specifying which groups/bodies should be in collision to specifying which groups/bodies should NOT be in collision. 

@avalenzu could you take a look at this.

