### PR TITLE
fix two missing angle unwrap checks

### DIFF
--- a/examples/Atlas/+atlasControllers/FootContactBlock.m
+++ b/examples/Atlas/+atlasControllers/FootContactBlock.m
@@ -201,6 +201,7 @@ classdef FootContactBlock < MIMODrakeSystem
             obj.controller_data.link_constraints(ind).ts(break_ind) = t;
             tf = ctrl_data.link_constraints(ind).ts(break_ind+1);
             pf = ctrl_data.link_constraints(ind).poses(:,break_ind+1);
+            pf(4:6) = p(4:6) + angleDiff(p(4:6), pf(4:6));
             pfdot = ctrl_data.link_constraints(ind).dposes(:,break_ind+1);
             [a0, a1, a2, a3] = cubicSplineCoefficients(tf-t, p, pf, pdot, pfdot);
             obj.controller_data.link_constraints(ind).poses(:,break_ind) = p;
@@ -227,6 +228,7 @@ classdef FootContactBlock < MIMODrakeSystem
             obj.controller_data.link_constraints(ind).ts(break_ind) = t;
             tf = ctrl_data.link_constraints(ind).ts(break_ind+1);
             pf = ctrl_data.link_constraints(ind).poses(:,break_ind+1);
+            pf(4:6) = p(4:6) + angleDiff(p(4:6), pf(4:6));
             pfdot = ctrl_data.link_constraints(ind).dposes(:,break_ind+1);
             [a0, a1, a2, a3] = cubicSplineCoefficients(tf-t, p, pf, pdot, pfdot);
             obj.controller_data.link_constraints(ind).poses(:,break_ind) = p;

--- a/examples/Atlas/test/runAtlasWalkingTestWraparound.m
+++ b/examples/Atlas/test/runAtlasWalkingTestWraparound.m
@@ -1,0 +1,10 @@
+function runAtlasWalkingTestWraparound()
+
+path_handle = addpathTemporary(fullfile(getDrakePath,'examples','Atlas'));
+options = struct();
+options.initial_pose = [0;0;0;0;0;-pi+pi/16];
+options.navgoal = [0;0;0;0;0;pi-pi/16];
+runAtlasWalking(options);
+
+end
+

--- a/systems/robotInterfaces/@Biped/planSwingPitched.m
+++ b/systems/robotInterfaces/@Biped/planSwingPitched.m
@@ -184,8 +184,8 @@ function add_foot_origin_knot(swing_pose, speed)
   cartesian_distance = norm(foot_origin_knots(end).(swing_foot_name)(1:3) - foot_origin_knots(end-1).(swing_foot_name)(1:3));
   sole1 = rotmat2rpy(rpy2rotmat(foot_origin_knots(end-1).(swing_foot_name)(4:6)) * T_sole_to_foot(1:3,1:3));
   sole2 = rotmat2rpy(rpy2rotmat(foot_origin_knots(end).(swing_foot_name)(4:6)) * T_sole_to_foot(1:3,1:3));
-  yaw_distance = abs(sole2(3) - sole1(3));
-  pitch_distance = abs(sole2(2) - sole1(2));
+  yaw_distance = abs(angleDiff(sole2(3), sole1(3)));
+  pitch_distance = abs(angleDiff(sole2(2), sole1(2)));
   dt = max([cartesian_distance / speed,...
             yaw_distance / FOOT_YAW_RATE,...
             pitch_distance / FOOT_PITCH_RATE]);
@@ -218,8 +218,11 @@ constraints = {posture_constraint,...
 add_foot_origin_knot(pose);
 
 % Set the target velocities of the two apex poses based on the total distance traveled
-foot_origin_knots(end).(swing_foot_name)(7:12) = (foot_origin_knots(end).(swing_foot_name)(1:6) - foot_origin_knots(end-1).(swing_foot_name)(1:6)) / (foot_origin_knots(end).t - foot_origin_knots(end-1).t);
-foot_origin_knots(end-1).(swing_foot_name)(7:12) = (foot_origin_knots(end).(swing_foot_name)(1:6) - foot_origin_knots(end-1).(swing_foot_name)(1:6)) / (foot_origin_knots(end).t - foot_origin_knots(end-1).t);
+foot_origin_knots(end).(swing_foot_name)(7:9) = (foot_origin_knots(end).(swing_foot_name)(1:3) - foot_origin_knots(end-1).(swing_foot_name)(1:3)) / (foot_origin_knots(end).t - foot_origin_knots(end-1).t);
+foot_origin_knots(end-1).(swing_foot_name)(7:9) = (foot_origin_knots(end).(swing_foot_name)(1:3) - foot_origin_knots(end-1).(swing_foot_name)(1:3)) / (foot_origin_knots(end).t - foot_origin_knots(end-1).t);
+% angles require unwrapping to get the correct velocities
+foot_origin_knots(end).(swing_foot_name)(10:12) = angleDiff(foot_origin_knots(end).(swing_foot_name)(4:6), foot_origin_knots(end-1).(swing_foot_name)(4:6)) / (foot_origin_knots(end).t - foot_origin_knots(end-1).t);
+foot_origin_knots(end-1).(swing_foot_name)(10:12) = angleDiff(foot_origin_knots(end).(swing_foot_name)(4:6), foot_origin_knots(end-1).(swing_foot_name)(4:6)) / (foot_origin_knots(end).t - foot_origin_knots(end-1).t);
 
 % Landing knot
 add_foot_origin_knot(swing2_origin_pose, min(params.step_speed, MAX_LANDING_SPEED)/2);

--- a/systems/robotInterfaces/@Biped/planZMPTraj.m
+++ b/systems/robotInterfaces/@Biped/planZMPTraj.m
@@ -128,13 +128,8 @@ for f = {'right', 'left'}
   foot_poses = foot_states(1:6,:);
   frame_id = biped.foot_frame_id.(foot);
   body_ind = biped.getFrame(frame_id).body_ind;
-  for j = 4:6
-    % Unwrap rpy angles
-    foot_poses(j,2:end) = foot_poses(j,1:end-1) + angleDiff(foot_poses(j,1:end-1), foot_poses(j,2:end));
-  end
+  foot_poses(4:6,:) = unwrap(foot_poses(4:6,:), [], 2);
   ts = [foot_origin_knots.t];
-  % foot_traj = PPTrajectory(pchip(ts, foot_poses));
-  % dtraj = fnder(foot_traj);
 
   foot_dposes = foot_states(7:12,:);
   % Compute cubic polynomial coefficients to save work in the controller


### PR DESCRIPTION
The first was in planZMPTraj, which was *supposed* to unwrap foot yaw
angles but was actually doing no such thing. The second change is in the
FootContactBlock to ensure that when we re-compute the foot trajectory
spline coefficients, we unwrap the desired angles first.

This also adds a new test cast to explicitly try walking from near -pi to near +pi