### PR TITLE
optimized terrain contact forward kinematics

### DIFF
--- a/systems/plants/@RigidBodyManipulator/collisionDetect.m
+++ b/systems/plants/@RigidBodyManipulator/collisionDetect.m
@@ -140,17 +140,17 @@ if ~isempty(obj.terrain) && ...
                                  terrain_contact_point_struct, ...
                                  'UniformOutput',false));
 
-%    xA_new_in_world = ...
-%      cell2mat(arrayfun(@(x)forwardKin(obj,kinsol,x.idx,x.pts), ...
-%      terrain_contact_point_struct, 'UniformOutput',false));
-
-    % same as above, but also works for TaylorVar kinsols
-    tmp = arrayfun(@(x)forwardKin(obj,kinsol,x.idx,x.pts), ...
-      terrain_contact_point_struct, 'UniformOutput',false);
-    xA_new_in_world = horzcat(tmp{:});
+    numStructs = size(terrain_contact_point_struct,2);
+    terrain_pts = [];
+    terrain_idxs = [];
+    for i = 1:numStructs
+       terrain_pts = [terrain_pts, terrain_contact_point_struct(i).pts];
+       terrain_idxs = [terrain_idxs, terrain_contact_point_struct(i).idx];
+    end
+    xA_new_in_world = forwardKin(obj, kinsol, terrain_idxs, terrain_pts);
     
     % Note: only implements collisions with the obj.terrain so far
-    [phi_new,normal_new,xB_new,idxB_new] = ...
+ [phi_new,normal_new,xB_new,idxB_new] = ...
       collisionDetectTerrain(obj,xA_new_in_world);
 
     phi = [phi;phi_new];

--- a/systems/plants/@RigidBodyManipulator/collisionDetect.m
+++ b/systems/plants/@RigidBodyManipulator/collisionDetect.m
@@ -135,20 +135,23 @@ if ~isempty(obj.terrain) && ...
   end
 
   if ~isempty(terrain_contact_point_struct)
+    
     xA_new = [terrain_contact_point_struct.pts];
     numStructs = size(terrain_contact_point_struct,2);
+
+    %total_pts = size(horzcat(terrain_contact_point_struct.pts),2); %too slow
+    xA_new_in_world =  [];
     k = 1;
-    terrain_pts = horzcat(terrain_contact_point_struct.pts);
-    terrain_idxs = zeros(1,size(terrain_pts,2));
     for i = 1:numStructs
         numPts = size(terrain_contact_point_struct(i).pts,2);
+        xA_new_in_world = [xA_new_in_world, forwardKin(obj, kinsol, ...
+        terrain_contact_point_struct(i).idx, terrain_contact_point_struct(i).pts)];
         for j = 1:numPts
             terrain_idxs(k) = terrain_contact_point_struct(i).idx;
             k = k+1;
         end
     end
-    xA_new_in_world = forwardKin(obj, kinsol, terrain_idxs, terrain_pts);
-    
+
     % Note: only implements collisions with the obj.terrain so far
  [phi_new,normal_new,xB_new,idxB_new] = ...
       collisionDetectTerrain(obj,xA_new_in_world);

--- a/systems/plants/@RigidBodyManipulator/collisionDetect.m
+++ b/systems/plants/@RigidBodyManipulator/collisionDetect.m
@@ -136,13 +136,13 @@ if ~isempty(obj.terrain) && ...
 
   if ~isempty(terrain_contact_point_struct)
     xA_new = [terrain_contact_point_struct.pts];
-    
     numStructs = size(terrain_contact_point_struct,2);
     k = 1;
+    terrain_pts = horzcat(terrain_contact_point_struct.pts);
+    terrain_idxs = zeros(1,size(terrain_pts,2));
     for i = 1:numStructs
         numPts = size(terrain_contact_point_struct(i).pts,2);
         for j = 1:numPts
-            terrain_pts(:, k) = terrain_contact_point_struct(i).pts(:, j);
             terrain_idxs(k) = terrain_contact_point_struct(i).idx;
             k = k+1;
         end

--- a/systems/plants/@RigidBodyManipulator/collisionDetect.m
+++ b/systems/plants/@RigidBodyManipulator/collisionDetect.m
@@ -136,16 +136,16 @@ if ~isempty(obj.terrain) && ...
 
   if ~isempty(terrain_contact_point_struct)
     xA_new = [terrain_contact_point_struct.pts];
-    idxA_new = cell2mat(arrayfun(@(x)repmat(x.idx,1,size(x.pts,2)), ...
-                                 terrain_contact_point_struct, ...
-                                 'UniformOutput',false));
-
+    
     numStructs = size(terrain_contact_point_struct,2);
-    terrain_pts = [];
-    terrain_idxs = [];
+    k = 1;
     for i = 1:numStructs
-       terrain_pts = [terrain_pts, terrain_contact_point_struct(i).pts];
-       terrain_idxs = [terrain_idxs, terrain_contact_point_struct(i).idx];
+        numPts = size(terrain_contact_point_struct(i).pts,2);
+        for j = 1:numPts
+            terrain_pts(:, k) = terrain_contact_point_struct(i).pts(:, j);
+            terrain_idxs(k) = terrain_contact_point_struct(i).idx;
+            k = k+1;
+        end
     end
     xA_new_in_world = forwardKin(obj, kinsol, terrain_idxs, terrain_pts);
     
@@ -156,7 +156,7 @@ if ~isempty(obj.terrain) && ...
     phi = [phi;phi_new];
     normal = [normal,normal_new];
     xA = [xA,xA_new];
-    idxA = [idxA,idxA_new];
+    idxA = [idxA,terrain_idxs];
     xB = [xB,xB_new];
     idxB = [idxB,idxB_new];
   end


### PR DESCRIPTION
arrayfun has dreadful performance, especially when paired with an anonymous function. This single line was taking almost 60% of the total runtime of collisionDetect(). 
Even the sinful for-loop speeds it up by a factor of 3. 
Before:
![col_detect_before](https://cloud.githubusercontent.com/assets/3849600/6072892/17ba7dc0-ad75-11e4-9fd7-8635207f6545.png)
After:
![col_detect_after](https://cloud.githubusercontent.com/assets/3849600/6072899/2e3d2912-ad75-11e4-9d69-68acea1b156f.png)
