### PR TITLE
Fix incorrect usage of footstep terrain points

### DIFF
--- a/examples/Atlas/runDRCDoorTask.m
+++ b/examples/Atlas/runDRCDoorTask.m
@@ -36,7 +36,7 @@ combined_xtraj = [];
 
 while true
   options.navgoal = [options.initial_pose(1)+3; 0;0;0;0;0];
-  options.safe_regions(end+1) = region_server.getCSpaceRegionAtIndex(region_server.xy2ind(1, options.initial_pose(1:2)), options.initial_pose(6), region_args{:});
+  options.safe_regions(end+1) = region_server.getCSpaceRegionAtIndex(region_server.xy2ind(1, options.initial_pose(1:2)), options.initial_pose(6), region_args{:}, 'error_on_infeas_start', false);
 %   figure(i+20)
 %   i = i + 1;
 %   clf

--- a/systems/robotInterfaces/@Biped/planSwingPitched.m
+++ b/systems/robotInterfaces/@Biped/planSwingPitched.m
@@ -46,9 +46,11 @@ swing2.pos(4:6) = swing1.pos(4:6) + angleDiff(swing1.pos(4:6), swing2.pos(4:6));
 
 xy_dist = norm(swing2.pos(1:2) - swing1.pos(1:2));
 
-% The terrain slice is a 2xN matrix, where the first row is distance along the straight line path from swing1 to swing2 and the second row is height above the z position of swing1.
+% The terrain slice is a 2xN matrix, where the first row is distance along
+% the straight line path from swing1 to swing2 and the second row is global
+% z height of the terrain at that point along the line
 terrain_slice = double(swing2.terrain_pts);
-terrain_slice = [[0;0], terrain_slice, [xy_dist; 0]];
+terrain_slice = [[0;swing1.pos(3)], terrain_slice, [xy_dist; swing2.pos(3)]];
 terrain_pts_in_local = [terrain_slice(1,:); zeros(1, size(terrain_slice, 2)); 
                         terrain_slice(2,:)];
 


### PR DESCRIPTION
The terrain points passed along with a footstep plan are in world z, but
one line of planSwingPitched was assuming they were in z offset relative
to the starting pose of the foot. This only showed up when the robot's
feet were below z=0.

It is possible that this was responsible for some accidental high-stepping that we'd observed before. This one was tricky to find, because the incorrect terrain points are internal to the planner, so they aren't shown in the debug info published to the viewer. 