### PR TITLE
Cleanup: field renames

### DIFF
--- a/systems/controllers/QPControllermex.cpp
+++ b/systems/controllers/QPControllermex.cpp
@@ -96,7 +96,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     pdata->B.resize(mxGetM(prhs[3]),mxGetN(prhs[3]));
     memcpy(pdata->B.data(),mxGetPr(prhs[3]),sizeof(double)*mxGetM(prhs[3])*mxGetN(prhs[3]));
 
-    int nq = pdata->r->num_dof, nu = pdata->B.cols();
+    int nq = pdata->r->num_positions, nu = pdata->B.cols();
     
     pm = myGetProperty(pobj,"w_qdd");
     pdata->w_qdd.resize(nq);
@@ -178,7 +178,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 //  for (i=0; i<pdata->r->num_bodies; i++)
 //    mexPrintf("body %d (%s) has %d contact points\n", i, pdata->r->bodies[i].linkname.c_str(), pdata->r->bodies[i].contact_pts.cols());
 
-  int nu = pdata->B.cols(), nq = pdata->r->num_dof;
+  int nu = pdata->B.cols(), nq = pdata->r->num_positions;
   const int dim = 3, // 3D
   nd = 2*m_surface_tangents; // for friction cone approx, hard coded for now
   
@@ -453,10 +453,10 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     body_index = pdata->accel_bound_body_idx[i];
     pdata->r->forwardJac(body_index,orig,1,Jb);
     pdata->r->forwardJacDot(body_index,orig,1,Jbdot);
-    Ain.block(constraint_start_index,0,6,pdata->r->num_dof) = Jb;
+    Ain.block(constraint_start_index,0,6,pdata->r->num_positions) = Jb;
     bin.segment(constraint_start_index,6) = -Jbdot*qdvec + pdata->max_body_acceleration[i];
     constraint_start_index += 6;
-    Ain.block(constraint_start_index,0,6,pdata->r->num_dof) = -Jb;
+    Ain.block(constraint_start_index,0,6,pdata->r->num_positions) = -Jb;
     bin.segment(constraint_start_index,6) = Jbdot*qdvec - pdata->min_body_acceleration[i];
     constraint_start_index += 6;
   }

--- a/systems/controllers/bodyMotionControlmex.cpp
+++ b/systems/controllers/bodyMotionControlmex.cpp
@@ -53,7 +53,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
   memcpy(&pdata,mxGetData(prhs[0]),sizeof(pdata));
 
-  int nq = pdata->r->num_dof;
+  int nq = pdata->r->num_positions;
 
   int narg = 1;
   double *q = mxGetPr(prhs[narg++]);
@@ -73,7 +73,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
   // TODO: this must be updated to use quaternions/spatial velocity
   Vector6d body_pose;
-  MatrixXd J = MatrixXd::Zero(6,pdata->r->num_dof);
+  MatrixXd J = MatrixXd::Zero(6,pdata->r->num_positions);
   Vector4d zero = Vector4d::Zero();
   zero(3) = 1.0;
   pdata->r->forwardKin(pdata->body_index,zero,1,body_pose);

--- a/systems/controllers/controlUtil.cpp
+++ b/systems/controllers/controlUtil.cpp
@@ -139,7 +139,7 @@ int contactPhi(RigidBodyManipulator* r, SupportStateElement& supp, void *map_ptr
 
 int contactConstraints(RigidBodyManipulator *r, int nc, std::vector<SupportStateElement>& supp, void *map_ptr, MatrixXd &n, MatrixXd &D, MatrixXd &Jp, MatrixXd &Jpdot,double terrain_height)
 {
-  int j, k=0, nq = r->num_dof;
+  int j, k=0, nq = r->num_positions;
 
   n.resize(nc,nq);
   D.resize(nq,nc*2*m_surface_tangents);
@@ -185,7 +185,7 @@ int contactConstraints(RigidBodyManipulator *r, int nc, std::vector<SupportState
 
 int contactConstraintsBV(RigidBodyManipulator *r, int nc, double mu, std::vector<SupportStateElement>& supp, void *map_ptr, MatrixXd &B, MatrixXd &JB, MatrixXd &Jp, MatrixXd &Jpdot, MatrixXd &normals, double terrain_height)
 {
-  int j, k=0, nq = r->num_dof;
+  int j, k=0, nq = r->num_positions;
 
   B.resize(3,nc*2*m_surface_tangents);
   JB.resize(nq,nc*2*m_surface_tangents);

--- a/systems/controllers/pelvisMotionControlmex.cpp
+++ b/systems/controllers/pelvisMotionControlmex.cpp
@@ -74,7 +74,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexErrMsgIdAndTxt("DRC:pelvisMotionControlmex:BadInputs","the first argument should be the ptr");
   memcpy(&pdata,mxGetData(prhs[0]),sizeof(pdata));
 
-  int nq = pdata->r->num_dof;
+  int nq = pdata->r->num_positions;
   int narg = 1;
   double *q = mxGetPr(prhs[narg++]);
   double *qd = &q[nq];
@@ -87,7 +87,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
   // TODO: this must be updated to use quaternions/spatial velocity
   Vector6d pelvis_pose;
-  MatrixXd Jpelvis = MatrixXd::Zero(6,pdata->r->num_dof);
+  MatrixXd Jpelvis = MatrixXd::Zero(6,pdata->r->num_positions);
   Vector4d zero = Vector4d::Zero();
   zero(3) = 1.0;
   pdata->r->forwardKin(pdata->pelvis_body_index,zero,1,pelvis_pose);

--- a/systems/controllers/supportDetectmex.cpp
+++ b/systems/controllers/supportDetectmex.cpp
@@ -50,7 +50,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexErrMsgIdAndTxt("DRC:supportDetectmex:BadInputs","the first argument should be the ptr");
   memcpy(&pdata,mxGetData(prhs[0]),sizeof(pdata));
 
-  int nq = pdata->r->num_dof;
+  int nq = pdata->r->num_positions;
 
   int narg=1;  
   double *q = mxGetPr(prhs[narg++]);

--- a/systems/plants/HandCmex.cpp
+++ b/systems/plants/HandCmex.cpp
@@ -32,8 +32,8 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] ) {
   double *q,*qd;
   Map<MatrixXd> *f_ext=NULL;
   Map<MatrixXd> *df_ext=NULL;
-  if (static_cast<int>(mxGetNumberOfElements(prhs[1]))!=model->num_dof || static_cast<int>(mxGetNumberOfElements(prhs[2]))!=model->num_dof)
-    mexErrMsgIdAndTxt("Drake:HandCmex:BadInputs","q and qd must be size %d x 1",model->num_dof);
+  if (static_cast<int>(mxGetNumberOfElements(prhs[1]))!=model->num_positions || static_cast<int>(mxGetNumberOfElements(prhs[2]))!=model->num_positions)
+    mexErrMsgIdAndTxt("Drake:HandCmex:BadInputs","q and qd must be size %d x 1",model->num_positions);
   q = mxGetPr(prhs[1]);
   qd = mxGetPr(prhs[2]);
   if (nrhs>3) {
@@ -43,25 +43,25 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] ) {
   }
   if (nrhs>4) {
     if (!mxIsEmpty(prhs[4])) {
-      df_ext = new Map<MatrixXd>(mxGetPr(prhs[4]),6*model->NB,2*model->num_dof);
+      df_ext = new Map<MatrixXd>(mxGetPr(prhs[4]),6*model->NB,2*model->num_positions);
     }
   }
   
   Map<MatrixXd> *dH=NULL, *dC=NULL;
   
-  plhs[0] = mxCreateDoubleMatrix(model->num_dof,model->num_dof,mxREAL);
-  Map<MatrixXd> H(mxGetPr(plhs[0]),model->num_dof,model->num_dof);
+  plhs[0] = mxCreateDoubleMatrix(model->num_positions,model->num_positions,mxREAL);
+  Map<MatrixXd> H(mxGetPr(plhs[0]),model->num_positions,model->num_positions);
 
-  plhs[1] = mxCreateDoubleMatrix(model->num_dof,1,mxREAL);
-  Map<VectorXd> C(mxGetPr(plhs[1]),model->num_dof);
+  plhs[1] = mxCreateDoubleMatrix(model->num_positions,1,mxREAL);
+  Map<VectorXd> C(mxGetPr(plhs[1]),model->num_positions);
 
   if (nlhs>2) {
-    plhs[2] = mxCreateDoubleMatrix(model->num_dof*model->num_dof,model->num_dof,mxREAL);
-    dH = new Map<MatrixXd>(mxGetPr(plhs[2]),model->num_dof*model->num_dof,model->num_dof);
+    plhs[2] = mxCreateDoubleMatrix(model->num_positions*model->num_positions,model->num_positions,mxREAL);
+    dH = new Map<MatrixXd>(mxGetPr(plhs[2]),model->num_positions*model->num_positions,model->num_positions);
   }
   if (nlhs>3) {
-    plhs[3] = mxCreateDoubleMatrix(model->num_dof,2*model->num_dof,mxREAL);
-    dC = new Map<MatrixXd>(mxGetPr(plhs[3]),model->num_dof,2*model->num_dof);
+    plhs[3] = mxCreateDoubleMatrix(model->num_positions,2*model->num_positions,mxREAL);
+    dC = new Map<MatrixXd>(mxGetPr(plhs[3]),model->num_positions,2*model->num_positions);
   }  
   
   model->HandC(q,qd,f_ext,H,C,dH,dC,df_ext);

--- a/systems/plants/IKoptions.cpp
+++ b/systems/plants/IKoptions.cpp
@@ -39,7 +39,7 @@ IKoptions::~IKoptions()
 void IKoptions::setDefaultParams(RigidBodyManipulator* robot)
 {
   this->robot = robot;
-  this->nq = this->robot->num_dof;
+  this->nq = this->robot->num_positions;
   this->Q = MatrixXd::Identity(this->nq,this->nq);
   this->Qa = 0.1*MatrixXd::Identity(this->nq,this->nq);
   this->Qv = MatrixXd::Zero(this->nq,this->nq);
@@ -332,7 +332,7 @@ void IKoptions::updateRobot(RigidBodyManipulator* new_robot)
 {
   this->robot = new_robot;
   int nq_cache = this->nq;
-  this->nq = this->robot->num_dof;
+  this->nq = this->robot->num_positions;
   if(nq_cache != nq)
   {
     this->setDefaultParams(new_robot);

--- a/systems/plants/IKoptionsmex.cpp
+++ b/systems/plants/IKoptionsmex.cpp
@@ -43,7 +43,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         char* field = new char[strlen];
         mxGetString(prhs[2],field,strlen);
         string field_str(field);
-        int nq = ikoptions->getRobotPtr()->num_dof;
+        int nq = ikoptions->getRobotPtr()->num_positions;
         IKoptions* ikoptions_new = new IKoptions(*ikoptions);
         if(field_str == "Q")
         {

--- a/systems/plants/RigidBody.cpp
+++ b/systems/plants/RigidBody.cpp
@@ -27,9 +27,12 @@ RigidBody::RigidBody(void) :
     dSdotVdvi(TWIST_SIZE, 0),
     JdotV(TWIST_SIZE, 1),
     dJdotVdq(TWIST_SIZE, 0),
-    dJdotVdv(TWIST_SIZE, 0)
+    dJdotVdv(TWIST_SIZE, 0),
+    parent(-1),
+    robotnum(0),
+    pitch(-1)
 {
-	dofnum = 0;
+	position_num_start = 0;
 	velocity_num_start = 0;
 	mass = 0.0;
 	floating = 0;
@@ -87,7 +90,7 @@ const DrakeJoint& RigidBody::getJoint() const
 
 void RigidBody::computeAncestorDOFs(RigidBodyManipulator* model)
 {
-  if (dofnum>=0) {
+  if (position_num_start>=0) {
     int i,j;
     if (parent>=0) {
       ancestor_dofs = model->bodies[parent]->ancestor_dofs;
@@ -96,26 +99,26 @@ void RigidBody::computeAncestorDOFs(RigidBodyManipulator* model)
 
     if (floating==1) {
     	for (j=0; j<6; j++) {
-    		ancestor_dofs.insert(dofnum+j);
+    		ancestor_dofs.insert(position_num_start+j);
     		for (i=0; i<3*model->NB; i++) {
-    			ddTdqdq_nonzero_rows.insert(i*model->NB + dofnum + j);
-    			ddTdqdq_nonzero_rows.insert(3*model->NB*dofnum + i + j);
+    			ddTdqdq_nonzero_rows.insert(i*model->NB + position_num_start + j);
+    			ddTdqdq_nonzero_rows.insert(3*model->NB*position_num_start + i + j);
     		}
     	}
     } else if (floating==2) {
     	for (j=0; j<7; j++) {
-    		ancestor_dofs.insert(dofnum+j);
+    		ancestor_dofs.insert(position_num_start+j);
     		for (i=0; i<3*model->NB; i++) {
-    			ddTdqdq_nonzero_rows.insert(i*model->NB + dofnum + j);
-    			ddTdqdq_nonzero_rows.insert(3*model->NB*dofnum + i + j);
+    			ddTdqdq_nonzero_rows.insert(i*model->NB + position_num_start + j);
+    			ddTdqdq_nonzero_rows.insert(3*model->NB*position_num_start + i + j);
     		}
     	}
     }
     else {
-    	ancestor_dofs.insert(dofnum);
+    	ancestor_dofs.insert(position_num_start);
     	for (i=0; i<3*model->NB; i++) {
-    		ddTdqdq_nonzero_rows.insert(i*model->NB + dofnum);
-    		ddTdqdq_nonzero_rows.insert(3*model->NB*dofnum + i);
+    		ddTdqdq_nonzero_rows.insert(i*model->NB + position_num_start);
+    		ddTdqdq_nonzero_rows.insert(3*model->NB*position_num_start + i);
     	}
     }
 

--- a/systems/plants/RigidBody.h
+++ b/systems/plants/RigidBody.h
@@ -45,7 +45,7 @@ public:
   static const std::set<int> defaultRobotNumSet;
 // note: it's very ugly, but parent,dofnum,and pitch also exist currently (independently) at the rigidbodymanipulator level to represent the featherstone structure.  this version is for the kinematics.
   int parent;
-  int dofnum; // interpreted as start of position_num from Matlab
+  int position_num_start; // interpreted as start of position_num from Matlab
   int velocity_num_start;
   int floating; // FLOATINGBASE TODO: remove
   int pitch; // FLOATINGBASE TODO: remove

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -204,7 +204,7 @@ public:
 public:
   std::vector<std::string> robot_name;
 
-  int num_dof; // treated as nq now; TODO: rename to nq
+  int num_positions;
   int num_velocities;
   VectorXd joint_limit_min;
   VectorXd joint_limit_max;
@@ -314,7 +314,7 @@ public:
 // The following was required for building w/ DLLEXPORT_RBM on windows (due to the unique_ptrs).  See
 // http://stackoverflow.com/questions/8716824/cannot-access-private-member-error-only-when-class-has-export-linkage
 private:
-  RigidBodyManipulator(const RigidBodyManipulator&) {}
+  RigidBodyManipulator(const RigidBodyManipulator&); // {}
   RigidBodyManipulator& operator=(const RigidBodyManipulator&) { return *this; }
 };
 

--- a/systems/plants/URDFRigidBodyManipulator.cpp
+++ b/systems/plants/URDFRigidBodyManipulator.cpp
@@ -191,7 +191,7 @@ bool URDFRigidBodyManipulator::addURDF(boost::shared_ptr<urdf::ModelInterface> _
 {
   robot_map.insert(make_pair(_urdf_model->getName(),(int)robot_name.size()));
   robot_name.push_back(_urdf_model->getName());
-  resize(num_dof + (int)dofname_to_dofnum.size(),-1,num_bodies + (int)jointname_to_jointnum.size());
+  resize(num_positions + (int)dofname_to_dofnum.size(),-1,num_bodies + (int)jointname_to_jointnum.size());
   for (map<string, boost::shared_ptr<urdf::Joint> >::iterator j=_urdf_model->joints_.begin(); j!=_urdf_model->joints_.end(); j++)
   {
     setJointLimits(_urdf_model,j->second,dofname_to_dofnum,this->joint_limit_min,this->joint_limit_max);
@@ -251,7 +251,7 @@ bool URDFRigidBodyManipulator::addURDF(boost::shared_ptr<urdf::ModelInterface> _
     		}
     	}
 
-    	bodies[index]->dofnum = _dofnum;
+    	bodies[index]->position_num_start = _dofnum;
     	dofnum[index-1] = _dofnum;
 
     	// set pitch and floating
@@ -327,7 +327,7 @@ bool URDFRigidBodyManipulator::addURDF(boost::shared_ptr<urdf::ModelInterface> _
 //    	cout << "body[" << index << "] linkname: " << bodies[index]->linkname << ", jointname: " << bodies[index]->jointname << endl;
 
     	bodies[index]->parent = 0;
-    	bodies[index]->dofnum = _dofnum;
+    	bodies[index]->position_num_start = _dofnum;
       bodies[index]->floating = 1;
       // pitch is irrelevant
       bodies[index]->Ttree = Matrix4d::Identity();
@@ -821,7 +821,7 @@ bool URDFRigidBodyManipulator::addURDFfromXML(const string &xml_string, const st
     // note: i see no harm in adding the floating base here (even if the drake version does not have one)
     // because the base will be set to 0 and it adds minimal expense to the kinematic calculations
   {  
-    int dofnum=num_dof;
+    int dofnum=num_positions;
     int jointnum = num_bodies;
     string joint_name("base");
     makeNameUnique(joint_name,joint_name_set);

--- a/systems/plants/approximateIK.cpp
+++ b/systems/plants/approximateIK.cpp
@@ -13,7 +13,7 @@ template <typename DerivedA, typename DerivedB, typename DerivedC>
 void approximateIK(RigidBodyManipulator* model, const MatrixBase<DerivedA> &q_seed, const MatrixBase<DerivedB> &q_nom, const int num_constraints, RigidBodyConstraint** const constraint_array, MatrixBase<DerivedC> &q_sol, int &INFO, const IKoptions &ikoptions)
 {
   int num_kc = 0;
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   SingleTimeKinematicConstraint** kc_array = new SingleTimeKinematicConstraint*[num_constraints];
   double* joint_lb= new double[nq];
   double* joint_ub= new double[nq];

--- a/systems/plants/approximateIKEIQPmex.cpp
+++ b/systems/plants/approximateIKEIQPmex.cpp
@@ -70,7 +70,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
   // first get the model_ptr back from matlab
   RigidBodyManipulator *model= (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
 
-  int i, j, error, nq = model->num_dof;
+  int i, j, error, nq = model->num_positions;
   
   static RigidBodyManipulator* lastModel=NULL;
   static int lastNumJointLimits = 0;

--- a/systems/plants/approximateIKmex.cpp
+++ b/systems/plants/approximateIKmex.cpp
@@ -15,7 +15,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexErrMsgIdAndTxt("Drake:approximateIKmex:NotEnoughInputs","Usage approximateIKmex(model_ptr,q_seed,q_nom,constraint1,constraint2,...,ikoptions)");
   }
   RigidBodyManipulator *model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   Map<VectorXd> q_seed(mxGetPr(prhs[1]),nq);
   Map<VectorXd> q_nom(mxGetPr(prhs[2]),nq);
   //VectorXd q_seed(nq);

--- a/systems/plants/bodyKinmex.cpp
+++ b/systems/plants/bodyKinmex.cpp
@@ -24,7 +24,7 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
   RigidBodyManipulator *model= (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
 
   double* q = mxGetPr(prhs[1]);
-  for (int i = 0; i < model->num_dof; i++) {
+  for (int i = 0; i < model->num_positions; i++) {
     if (q[i] - model->cached_q[i] > 1e-8 || q[i] - model->cached_q[i] < -1e-8) {
       mexErrMsgIdAndTxt("Drake:bodyKinmex:InvalidKinematics","This kinsol is no longer valid.  Somebody has called doKinematics with a different q since the solution was computed.");
     }
@@ -52,8 +52,8 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
   Map<MatrixXd> *J=NULL, *P=NULL;
 
   if (nlhs>1) {
-    plhs[1] = mxCreateDoubleMatrix(dim*n_pts,model->num_dof,mxREAL);
-    J = new Map<MatrixXd>(mxGetPr(plhs[1]),dim*n_pts,model->num_dof);
+    plhs[1] = mxCreateDoubleMatrix(dim*n_pts,model->num_positions,mxREAL);
+    J = new Map<MatrixXd>(mxGetPr(plhs[1]),dim*n_pts,model->num_positions);
   }
   if (nlhs>2) {
     plhs[2] = mxCreateDoubleMatrix(dim*n_pts,dim*n_pts,mxREAL);

--- a/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -110,7 +110,7 @@ void QuasiStaticConstraint::eval(const double* t, const double* weights, VectorX
 {
   if(this->isTimeValid(t))
   {
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     dc.resize(2,nq+this->num_pts);
     Vector3d com;
     this->robot->getCOM(com,this->m_robotnumset);
@@ -280,7 +280,7 @@ PostureConstraint::PostureConstraint(RigidBodyManipulator* robot, const Eigen::V
 
 PostureConstraint::PostureConstraint(const PostureConstraint& rhs):RigidBodyConstraint(rhs)
 {
-  int nq = this->robot->num_dof;
+  int nq = this->robot->num_positions;
   this->lb.resize(nq);
   this->ub.resize(nq);
   this->joint_limit_min0 = rhs.joint_limit_min0;
@@ -302,7 +302,7 @@ void PostureConstraint::setJointLimits(int num_idx,const int* joint_idx, const V
 {
   for(int i = 0;i<num_idx;i++)
   {
-    if(joint_idx[i]>=this->robot->num_dof || joint_idx[i]<0)
+    if(joint_idx[i]>=this->robot->num_positions || joint_idx[i]<0)
     {
       std::cerr<<"joint_idx["<<i<<"] is should be within [0 nq-1]"<<std::endl;
     }
@@ -441,14 +441,14 @@ SingleTimeLinearPostureConstraint::SingleTimeLinearPostureConstraint(RigidBodyMa
   {
     std::cerr<<"Drake:RigidBodyConstraint:SingleTimeLinearPostureConstraint:min(iAfun) should be 0"<<std::endl;
   }
-  if(jAvar.minCoeff()<0 || jAvar.maxCoeff()>this->robot->num_dof-1)
+  if(jAvar.minCoeff()<0 || jAvar.maxCoeff()>this->robot->num_positions-1)
   {
     std::cerr<<"Drake:RigidBodyConstraint:SingleTimeLinearPostureConstraint: jAvar should be within[0 robot.nq-1]"<<std::endl;
   }
   this->iAfun = iAfun;
   this->jAvar = jAvar;
   this->A = A;
-  this->A_mat.resize(this->num_constraint,this->robot->num_dof);
+  this->A_mat.resize(this->num_constraint,this->robot->num_positions);
   this->A_mat.reserve(lenA);
   for(int i = 0;i<lenA;i++)
   {
@@ -608,7 +608,7 @@ void MultipleTimeKinematicConstraint::eval(const double* t, int n_breaks, const 
   if(num_valid_t>=2)
   {
     std::vector<bool> valid_time_flag = this->isTimeValid(t,n_breaks);
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     double* valid_t = new double[num_valid_t];
     MatrixXd valid_q(nq,num_valid_t);
     int valid_idx = 0;
@@ -757,10 +757,10 @@ void PositionConstraint::eval(const double* t, VectorXd &c, MatrixXd &dc) const
   if(this->isTimeValid(t))
   {
     MatrixXd pos(3,this->n_pts);
-    MatrixXd J(3*this->n_pts,this->robot->num_dof);
+    MatrixXd J(3*this->n_pts,this->robot->num_positions);
     this->evalPositions(pos,J);
     c.resize(this->getNumConstraint(t),1);
-    dc.resize(this->getNumConstraint(t),this->robot->num_dof);
+    dc.resize(this->getNumConstraint(t),this->robot->num_positions);
     int valid_row_idx = 0;
     int i = 0;
     while(i<this->getNumConstraint(t))
@@ -911,7 +911,7 @@ RelativePositionConstraint::RelativePositionConstraint(RigidBodyManipulator* rob
 
 void RelativePositionConstraint::evalPositions(MatrixXd &pos, MatrixXd &J) const
 {
-  int nq = this->robot->num_dof;
+  int nq = this->robot->num_positions;
   MatrixXd bodyA_pos(3,this->n_pts);
   MatrixXd JA(3*this->n_pts,nq);
   this->robot->forwardKin(this->bodyA_idx,this->pts,0,bodyA_pos);
@@ -993,11 +993,11 @@ void QuatConstraint::eval(const double* t, VectorXd &c, MatrixXd &dc) const
 {
   int num_constraint = this->getNumConstraint(t);
   c.resize(num_constraint);
-  dc.resize(num_constraint,this->robot->num_dof);
+  dc.resize(num_constraint,this->robot->num_positions);
   if(this->isTimeValid(t))
   {
     double prod;
-    MatrixXd dprod(1,this->robot->num_dof);
+    MatrixXd dprod(1,this->robot->num_positions);
     this->evalOrientationProduct(prod,dprod);
     c(0) = 2.0*prod*prod-1.0;
     dc = 4.0*prod*dprod;
@@ -1039,14 +1039,14 @@ WorldQuatConstraint::WorldQuatConstraint(RigidBodyManipulator *robot, int body, 
 void WorldQuatConstraint::evalOrientationProduct(double &prod, MatrixXd &dprod) const
 {
   Matrix<double,7,1>  x;
-  MatrixXd J(7,this->robot->num_dof);
+  MatrixXd J(7,this->robot->num_positions);
   Vector4d pts;
   pts << 0.0,0.0,0.0,1.0;
   this->robot->forwardKin(this->body,pts,2,x);
   this->robot->forwardJac(this->body,pts,2,J);
   Vector4d quat = x.tail(4);
   prod = (quat.transpose()*this->quat_des);
-  dprod = this->quat_des.transpose()*J.block(3,0,4,this->robot->num_dof);
+  dprod = this->quat_des.transpose()*J.block(3,0,4,this->robot->num_positions);
 }
 
 
@@ -1089,7 +1089,7 @@ RelativeQuatConstraint::RelativeQuatConstraint(RigidBodyManipulator* robot, int 
 
 void RelativeQuatConstraint::evalOrientationProduct(double &prod, MatrixXd &dprod) const
 {
-  int nq = this->robot->num_dof;
+  int nq = this->robot->num_positions;
   Vector4d origin_pt;
   origin_pt << 0.0,0.0,0.0,1.0;
   Matrix<double,7,1> pos_a;
@@ -1212,10 +1212,10 @@ void EulerConstraint::eval(const double* t, VectorXd &c, MatrixXd &dc) const
   if(this->isTimeValid(t))
   {
     Vector3d rpy;
-    MatrixXd drpy(3,this->robot->num_dof);
+    MatrixXd drpy(3,this->robot->num_positions);
     this->evalrpy(rpy,drpy);
     c.resize(n_constraint);
-    dc.resize(n_constraint,this->robot->num_dof);
+    dc.resize(n_constraint,this->robot->num_positions);
     int valid_row_idx = 0;
     int i = 0;
     while(i<n_constraint)
@@ -1262,11 +1262,11 @@ void WorldEulerConstraint::evalrpy(Vector3d &rpy,MatrixXd &J) const
   Vector4d pt;
   pt<<0.0,0.0,0.0,1.0;
   Matrix<double,6,1> x;
-  MatrixXd dx(6,this->robot->num_dof);
+  MatrixXd dx(6,this->robot->num_positions);
   this->robot->forwardKin(this->body,pt,1,x);
   this->robot->forwardJac(this->body,pt,1,dx);
   rpy = x.tail(3);
-  J = dx.block(3,0,3,this->robot->num_dof);
+  J = dx.block(3,0,3,this->robot->num_positions);
 }
 
 void WorldEulerConstraint::name(const double* t, std::vector<std::string> &name_str) const
@@ -1360,11 +1360,11 @@ void GazeOrientConstraint::eval(const double* t, VectorXd &c, MatrixXd &dc) cons
 {
   int num_constraint = this->getNumConstraint(t);
   c.resize(num_constraint);
-  dc.resize(num_constraint,this->robot->num_dof);
+  dc.resize(num_constraint,this->robot->num_positions);
   if(this->isTimeValid(t))
   {
     Vector4d quat;
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     MatrixXd dquat(4,nq);
     this->evalOrientation(quat,dquat);
     double axis_err = quatDiffAxisInvar(quat,this->quat_des,this->axis);
@@ -1409,13 +1409,13 @@ WorldGazeOrientConstraint::WorldGazeOrientConstraint(RigidBodyManipulator* robot
 void WorldGazeOrientConstraint::evalOrientation(Vector4d &quat, MatrixXd &dquat_dq) const
 {
   Matrix<double,7,1> x;
-  MatrixXd J(7,this->robot->num_dof);
+  MatrixXd J(7,this->robot->num_positions);
   Vector4d pts;
   pts<<0.0,0.0,0.0,1.0;
   this->robot->forwardKin(this->body,pts,2,x);
   this->robot->forwardJac(this->body,pts,2,J);
   quat = x.tail(4);
-  dquat_dq = J.block(3,0,4,this->robot->num_dof);
+  dquat_dq = J.block(3,0,4,this->robot->num_positions);
 }
 
 
@@ -1487,7 +1487,7 @@ void WorldGazeDirConstraint::eval(const double* t, VectorXd &c, MatrixXd &dc) co
     body_axis_ends.block(0,0,3,1) = MatrixXd::Zero(3,1);
     body_axis_ends.block(0,1,3,1) = this->axis;
     body_axis_ends.block(3,0,1,2) = MatrixXd::Ones(1,2);
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     MatrixXd axis_pos(3,2);
     MatrixXd daxis_pos(6,nq);
     this->robot->forwardKin(this->body,body_axis_ends,0,axis_pos);
@@ -1552,7 +1552,7 @@ WorldGazeTargetConstraint::WorldGazeTargetConstraint(RigidBodyManipulator* robot
 void WorldGazeTargetConstraint::eval(const double* t,VectorXd &c, MatrixXd &dc) const
 {
   int num_constraint = this->getNumConstraint(t);
-  int nq = this->robot->num_dof;
+  int nq = this->robot->num_positions;
   c.resize(num_constraint);
   dc.resize(num_constraint,nq);
   if(this->isTimeValid(t))
@@ -1561,7 +1561,7 @@ void WorldGazeTargetConstraint::eval(const double* t,VectorXd &c, MatrixXd &dc) 
     body_axis_ends.block(0,0,4,1) = this->gaze_origin;
     body_axis_ends.block(0,1,3,1) = this->gaze_origin.block(0,0,3,1)+this->axis;
     body_axis_ends.block(3,0,1,2) = MatrixXd::Ones(1,2);
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     MatrixXd axis_ends(3,2);
     MatrixXd daxis_ends(6,nq);
     this->robot->forwardKin(this->body, body_axis_ends, 0, axis_ends);
@@ -1615,7 +1615,7 @@ void RelativeGazeTargetConstraint::eval(const double* t, VectorXd &c, MatrixXd &
 {
   if(this->isTimeValid(t))
   {
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     Vector4d target_pt;
     target_pt<<this->target,1.0;
     Vector3d target_pos;
@@ -1692,7 +1692,7 @@ void RelativeGazeDirConstraint::eval(const double* t, VectorXd &c, MatrixXd &dc)
     body_dir_ends.block(0,0,3,1) = MatrixXd::Zero(3,1);
     body_dir_ends.block(0,1,3,1) = this->dir;
     body_dir_ends.block(3,0,1,2) = MatrixXd::Ones(1,2);
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     MatrixXd axis_pos(3,2);
     MatrixXd daxis_pos(6,nq);
     MatrixXd dir_pos(3,2);
@@ -1754,7 +1754,7 @@ void Point2PointDistanceConstraint::eval(const double* t, VectorXd &c, MatrixXd 
   {
     int num_cnst = this->getNumConstraint(t);
     MatrixXd posA(3,this->ptA.cols());
-    MatrixXd dposA(3*this->ptA.cols(),this->robot->num_dof);
+    MatrixXd dposA(3*this->ptA.cols(),this->robot->num_positions);
     if(this->bodyA != 0)
     {
       this->robot->forwardKin(this->bodyA,this->ptA,0,posA);
@@ -1763,10 +1763,10 @@ void Point2PointDistanceConstraint::eval(const double* t, VectorXd &c, MatrixXd 
     else
     {
       posA = this->ptA.block(0,0,3,this->ptA.cols());
-      dposA = MatrixXd::Zero(3*this->ptA.cols(),this->robot->num_dof);
+      dposA = MatrixXd::Zero(3*this->ptA.cols(),this->robot->num_positions);
     }
     MatrixXd posB(3,this->ptB.cols());
-    MatrixXd dposB(3*this->ptB.cols(),this->robot->num_dof);
+    MatrixXd dposB(3*this->ptB.cols(),this->robot->num_positions);
     if(this->bodyB != 0)
     {
       this->robot->forwardKin(this->bodyB,this->ptB,0,posB);
@@ -1775,7 +1775,7 @@ void Point2PointDistanceConstraint::eval(const double* t, VectorXd &c, MatrixXd 
     else
     {
       posB = this->ptB.block(0,0,3,this->ptB.cols());
-      dposB = MatrixXd::Zero(3*this->ptB.cols(),this->robot->num_dof);
+      dposB = MatrixXd::Zero(3*this->ptB.cols(),this->robot->num_positions);
     }
     MatrixXd d = posA-posB;
     MatrixXd dd = dposA-dposB;
@@ -1783,10 +1783,10 @@ void Point2PointDistanceConstraint::eval(const double* t, VectorXd &c, MatrixXd 
     MatrixXd tmp2 = tmp1.colwise().sum();
     c.resize(num_cnst,1);
     c = tmp2.transpose();
-    dc.resize(num_cnst,this->robot->num_dof);
+    dc.resize(num_cnst,this->robot->num_positions);
     for(int i = 0;i<num_cnst;i++)
     {
-      dc.row(i) = 2*d.col(i).transpose()*dd.block(3*i,0,3,this->robot->num_dof);
+      dc.row(i) = 2*d.col(i).transpose()*dd.block(3*i,0,3,this->robot->num_positions);
     }
   }
   else
@@ -1861,7 +1861,7 @@ void Point2LineSegDistConstraint::eval(const double* t, VectorXd &c, MatrixXd &d
 {
   if(this->isTimeValid(t))
   {
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     Vector3d pt_pos;
     MatrixXd J_pt(3,nq);
     this->robot->forwardKin(this->pt_body,this->pt,0,pt_pos);
@@ -1959,7 +1959,7 @@ int WorldFixedPositionConstraint::getNumConstraint(const double* t, int n_breaks
 void WorldFixedPositionConstraint::eval_valid(const double* valid_t, int num_valid_t, const MatrixXd &valid_q, VectorXd &c, MatrixXd &dc_valid) const
 {
   int n_pts = static_cast<int>(this->pts.cols());
-  int nq = this->robot->num_dof;
+  int nq = this->robot->num_positions;
   MatrixXd *pos = new MatrixXd[num_valid_t];
   MatrixXd *dpos = new MatrixXd[num_valid_t];
   for(int i = 0;i<num_valid_t;i++)
@@ -2051,7 +2051,7 @@ int WorldFixedOrientConstraint::getNumConstraint(const double* t, int n_breaks) 
 
 void WorldFixedOrientConstraint::eval_valid(const double* valid_t, int num_valid_t, const MatrixXd &valid_q, VectorXd &c, MatrixXd &dc_valid) const
 {
-  int nq = this->robot->num_dof;
+  int nq = this->robot->num_positions;
   Vector4d* quat = new Vector4d[num_valid_t];
   MatrixXd* dquat = new MatrixXd[num_valid_t];
   Vector4d origin_pt;
@@ -2142,7 +2142,7 @@ int WorldFixedBodyPoseConstraint::getNumConstraint(const double* t, int n_breaks
 
 void WorldFixedBodyPoseConstraint::eval_valid(const double* valid_t, int num_valid_t,const MatrixXd &valid_q, VectorXd &c, MatrixXd &dc_valid) const
 {
-  int nq = this->robot->num_dof;
+  int nq = this->robot->num_positions;
   Vector3d *pos = new Vector3d[num_valid_t];
   Vector4d *quat = new Vector4d[num_valid_t];
   MatrixXd *dpos = new MatrixXd[num_valid_t];
@@ -2289,9 +2289,9 @@ AllBodiesClosestDistanceConstraint::eval(const double* t, VectorXd& c, MatrixXd&
       }
     }
     int num_pts = static_cast<int>(xA.cols());
-    dc = MatrixXd::Zero(num_pts,robot->num_dof);
-    MatrixXd JA = MatrixXd::Zero(3,robot->num_dof);
-    MatrixXd JB = MatrixXd::Zero(3,robot->num_dof);
+    dc = MatrixXd::Zero(num_pts,robot->num_positions);
+    MatrixXd JA = MatrixXd::Zero(3,robot->num_positions);
+    MatrixXd JB = MatrixXd::Zero(3,robot->num_positions);
     for (int i = 0; i < num_pts; ++i) {
       Vector4d xA_1;
       Vector4d xB_1;
@@ -2380,7 +2380,7 @@ MinDistanceConstraint::eval(const double* t, VectorXd& c, MatrixXd& dc) const
   }
 
   int num_pts = static_cast<int>(xA.cols());
-  ddist_dq = MatrixXd::Zero(num_pts,robot->num_dof);
+  ddist_dq = MatrixXd::Zero(num_pts,robot->num_positions);
 
   // Compute Jacobian of closest distance vector
   //DEBUG
@@ -2427,7 +2427,7 @@ MinDistanceConstraint::eval(const double* t, VectorXd& c, MatrixXd& dc) const
       x_k.col(l) = xB.col(orig_idx_of_pt_on_bodyB.at(k).at(l-numA));
     }
     MatrixXd x_k_1(4,x_k.cols());
-    MatrixXd J_k(3*x_k.cols(),robot->num_dof);
+    MatrixXd J_k(3*x_k.cols(),robot->num_positions);
     x_k_1 << x_k, MatrixXd::Ones(1,x_k.cols());
     robot->forwardJac(k,x_k_1,0,J_k);
     l = 0;
@@ -2435,13 +2435,13 @@ MinDistanceConstraint::eval(const double* t, VectorXd& c, MatrixXd& dc) const
       //DEBUG
       //std::cout << "MinDistanceConstraint::eval: Fifth loop: " << l << std::endl;
       //END_DEBUG
-      ddist_dq.row(orig_idx_of_pt_on_bodyA.at(k).at(l)) += normal.col(orig_idx_of_pt_on_bodyA.at(k).at(l)).transpose() * J_k.block(3*l,0,3,robot->num_dof);
+      ddist_dq.row(orig_idx_of_pt_on_bodyA.at(k).at(l)) += normal.col(orig_idx_of_pt_on_bodyA.at(k).at(l)).transpose() * J_k.block(3*l,0,3,robot->num_positions);
     }
     for (; l < numA+numB; ++l) {
       //DEBUG
       //std::cout << "MinDistanceConstraint::eval: Sixth loop: " << l << std::endl;
       //END_DEBUG
-      ddist_dq.row(orig_idx_of_pt_on_bodyB.at(k).at(l-numA)) += -normal.col(orig_idx_of_pt_on_bodyB.at(k).at(l-numA)).transpose() * J_k.block(3*l,0,3,robot->num_dof);
+      ddist_dq.row(orig_idx_of_pt_on_bodyB.at(k).at(l-numA)) += -normal.col(orig_idx_of_pt_on_bodyB.at(k).at(l-numA)).transpose() * J_k.block(3*l,0,3,robot->num_positions);
     }
   }
   //DEBUG
@@ -2618,7 +2618,7 @@ void PostureChangeConstraint::geval(const double* t, int n_breaks, VectorXi &iAf
   {
     int num_joints = static_cast<int>(this->joint_ind.size());
     int nc = this->getNumConstraint(t,n_breaks);
-    int nq = this->robot->num_dof;
+    int nq = this->robot->num_positions;
     iAfun.resize(nc*2);
     jAvar.resize(nc*2);
     A.resize(nc*2);

--- a/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
+++ b/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
@@ -933,7 +933,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         for(int i = 0;i<num_joints;i++)
         {
           joint_ind(i) = (int) joint_ind_tmp(i)-1;
-          if(joint_ind(i)<0 || joint_ind(i)>=model->num_dof)
+          if(joint_ind(i)<0 || joint_ind(i)>=model->num_positions)
           {
             mexErrMsgIdAndTxt("Drake:constructPtrRigidBodyConstraintmex:BadInputs","joint_ind must be within [1,nq]");
           }

--- a/systems/plants/constraint/testMultipleTimeKinCnstmex.cpp
+++ b/systems/plants/constraint/testMultipleTimeKinCnstmex.cpp
@@ -27,7 +27,7 @@ void mexFunction(int nlhs,mxArray* plhs[], int nrhs, const mxArray * prhs[])
   int n_breaks = mxGetNumberOfElements(prhs[2]);
   double* t_ptr = new double[n_breaks];
   memcpy(t_ptr,mxGetPr(prhs[2]),sizeof(double)*n_breaks);
-  int nq = cnst->getRobotPointer()->num_dof;
+  int nq = cnst->getRobotPointer()->num_positions;
   MatrixXd q(nq,n_breaks);
   if(mxGetM(prhs[1]) != nq || mxGetN(prhs[1]) != n_breaks)
   {

--- a/systems/plants/constraint/testMultipleTimeLinearPostureConstraintmex.cpp
+++ b/systems/plants/constraint/testMultipleTimeLinearPostureConstraintmex.cpp
@@ -26,7 +26,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray *prhs[])
   int n_breaks = mxGetNumberOfElements(prhs[2]);
   double* t_ptr = new double[n_breaks];
   memcpy(t_ptr,mxGetPr(prhs[2]),sizeof(double)*n_breaks);
-  int nq = cnst->getRobotPointer()->num_dof;
+  int nq = cnst->getRobotPointer()->num_positions;
   MatrixXd q(nq,n_breaks);
   if(mxGetM(prhs[1]) != nq || mxGetN(prhs[1]) != n_breaks)
   {

--- a/systems/plants/constraint/testPostureConstraintmex.cpp
+++ b/systems/plants/constraint/testPostureConstraintmex.cpp
@@ -28,7 +28,7 @@ void mexFunction(int nlhs,mxArray* plhs[], int nrhs, const mxArray *prhs[])
     t_ptr = &t;
   }
   PostureConstraint* pc = (PostureConstraint*) getDrakeMexPointer(prhs[0]);
-  int nq = pc->getRobotPointer()->num_dof;
+  int nq = pc->getRobotPointer()->num_positions;
   VectorXd lb,ub;
   pc->bounds(t_ptr,lb,ub);
   plhs[0] = mxCreateDoubleMatrix(nq,1,mxREAL);

--- a/systems/plants/constraint/testQuasiStaticConstraintmex.cpp
+++ b/systems/plants/constraint/testQuasiStaticConstraintmex.cpp
@@ -39,7 +39,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
   QuasiStaticConstraint* qsc = (QuasiStaticConstraint*) getDrakeMexPointer(prhs[0]);
   bool active = qsc->isActive();
   RigidBodyManipulator* model = qsc->getRobotPointer();
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   double *q = new double[nq];
   memcpy(q,mxGetPr(prhs[1]),sizeof(double)*nq);
   int num_weights = qsc->getNumWeights();

--- a/systems/plants/constraint/testSingleTimeKinCnstmex.cpp
+++ b/systems/plants/constraint/testSingleTimeKinCnstmex.cpp
@@ -47,7 +47,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
   int type = cnst->getType();
   int num_cnst = cnst->getNumConstraint(t_ptr);
   //mexPrintf("num_cnst = %d\n",num_cnst);
-  int nq = cnst->getRobotPointer()->num_dof;
+  int nq = cnst->getRobotPointer()->num_positions;
   double* q = new double[nq];
   memcpy(q,mxGetPr(prhs[1]),sizeof(double)*nq);
   cnst->getRobotPointer()->doKinematics(q);

--- a/systems/plants/constraint/testSingleTimeLinearPostureConstraintmex.cpp
+++ b/systems/plants/constraint/testSingleTimeLinearPostureConstraintmex.cpp
@@ -28,7 +28,7 @@ void mexFunction(int nlhs,mxArray* plhs[], int nrhs, const mxArray * prhs[])
     mexErrMsgIdAndTxt("Drake:testSingleTimeLinearPostureConstraintmex:BadInputs","Usage [type,num_cnst,cnst_val,iAfun,jAvar,A,cnst_name,lb,ub] = testSingleTimeLinearPostureConstraintmex(stlpc_ptr,q,t)");
   }
   SingleTimeLinearPostureConstraint* stlpc = (SingleTimeLinearPostureConstraint*) getDrakeMexPointer(prhs[0]);
-  int nq = stlpc->getRobotPointer()->num_dof;
+  int nq = stlpc->getRobotPointer()->num_positions;
   if(!mxIsNumeric(prhs[1]) || mxGetN(prhs[1]) != 1 || mxGetM(prhs[1]) != nq)
   {
     mexErrMsgIdAndTxt("Drake:testSingleTimeLinearPostureConstraintmex:BadInputs","q must a numeric column vector with size nq");

--- a/systems/plants/constructModelmex.cpp
+++ b/systems/plants/constructModelmex.cpp
@@ -126,7 +126,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
     if (!mxIsEmpty(pm)) memcpy(model->bodies[i]->I.data(),mxGetPr(pm),sizeof(double)*6*6);
 
     pm = mxGetProperty(pBodies,i,"position_num");
-    model->bodies[i]->dofnum = (int) mxGetScalar(pm) - 1;  //zero-indexed
+    model->bodies[i]->position_num_start = (int) mxGetScalar(pm) - 1;  //zero-indexed
 
     pm = mxGetProperty(pBodies,i,"velocity_num");
     model->bodies[i]->velocity_num_start = (int) mxGetScalar(pm) - 1;  //zero-indexed
@@ -176,11 +176,11 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       model->bodies[i]->pitch = (int) mxGetScalar(pm);
     }
 
-    if (model->bodies[i]->dofnum>=0) {
+    if (model->bodies[i]->position_num_start>=0) {
        pm = mxGetProperty(pBodies,i,"joint_limit_min");
-       model->joint_limit_min[model->bodies[i]->dofnum] = mxGetScalar(pm);
+       model->joint_limit_min[model->bodies[i]->position_num_start] = mxGetScalar(pm);
        pm = mxGetProperty(pBodies,i,"joint_limit_max");
-       model->joint_limit_max[model->bodies[i]->dofnum] = mxGetScalar(pm);
+       model->joint_limit_max[model->bodies[i]->position_num_start] = mxGetScalar(pm);
     }
 
     pm = mxGetProperty(pBodies,i,"T_body_to_joint");
@@ -339,8 +339,8 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
   }
 
 
-  memcpy(model->joint_limit_min.data(), mxGetPr(mxGetProperty(pRBM,0,"joint_limit_min")), sizeof(double)*model->num_dof);
-  memcpy(model->joint_limit_max.data(), mxGetPr(mxGetProperty(pRBM,0,"joint_limit_max")), sizeof(double)*model->num_dof);
+  memcpy(model->joint_limit_min.data(), mxGetPr(mxGetProperty(pRBM,0,"joint_limit_min")), sizeof(double)*model->num_positions);
+  memcpy(model->joint_limit_max.data(), mxGetPr(mxGetProperty(pRBM,0,"joint_limit_max")), sizeof(double)*model->num_positions);
 
   const mxArray* a_grav_array = mxGetProperty(pRBM,0,"gravity");
   if (a_grav_array && mxGetNumberOfElements(a_grav_array)==3) {

--- a/systems/plants/doKinematicsNewmex.cpp
+++ b/systems/plants/doKinematicsNewmex.cpp
@@ -15,8 +15,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
   RigidBodyManipulator *model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
 
   double *q, *v = nullptr;
-  if (mxGetNumberOfElements(prhs[1]) != model->num_dof)
-    mexErrMsgIdAndTxt("Drake:doKinematicsmex:BadInputs", "q must be size %d x 1", model->num_dof);
+  if (mxGetNumberOfElements(prhs[1]) != model->num_positions)
+    mexErrMsgIdAndTxt("Drake:doKinematicsmex:BadInputs", "q must be size %d x 1", model->num_positions);
   q = mxGetPr(prhs[1]);
   bool compute_gradients = (bool) (mxGetLogicals(prhs[2]))[0];
   if (mxGetNumberOfElements(prhs[3]) > 0) {

--- a/systems/plants/forwardKinmex.cpp
+++ b/systems/plants/forwardKinmex.cpp
@@ -24,7 +24,7 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
   RigidBodyManipulator *model= (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
 
   double* q = mxGetPr(prhs[1]);
-  for (int i = 0; i < model->num_dof; i++) {
+  for (int i = 0; i < model->num_positions; i++) {
     if (q[i] - model->cached_q[i] > 1e-8 || q[i] - model->cached_q[i] < -1e-8) {
       mexErrMsgIdAndTxt("Drake:forwardKinmex:InvalidKinematics","This kinsol is no longer valid.  Somebody has called doKinematics with a different q since the solution was computed.");
     }
@@ -50,8 +50,8 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
       robotnum_set.insert((int) probotnum[i]-1);
     }
     if (b_jacdot && nlhs>0) {
-      plhs[0] = mxCreateDoubleMatrix(3,model->num_dof,mxREAL);
-      Map<MatrixXd> Jdot(mxGetPr(plhs[0]),3,model->num_dof);
+      plhs[0] = mxCreateDoubleMatrix(3,model->num_positions,mxREAL);
+      Map<MatrixXd> Jdot(mxGetPr(plhs[0]),3,model->num_positions);
       model->getCOMJacDot(Jdot,robotnum_set);
       return;
     }
@@ -62,14 +62,14 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
       model->getCOM(x,robotnum_set);
     }
     if (nlhs>1) {
-      plhs[1] = mxCreateDoubleMatrix(3,model->num_dof,mxREAL);
-      Map<MatrixXd> J(mxGetPr(plhs[1]),3,model->num_dof);
+      plhs[1] = mxCreateDoubleMatrix(3,model->num_positions,mxREAL);
+      Map<MatrixXd> J(mxGetPr(plhs[1]),3,model->num_positions);
       model->getCOMJac(J,robotnum_set);
     }
   
     if (nlhs>2) {
-      plhs[2] = mxCreateDoubleMatrix(3,model->num_dof*model->num_dof,mxREAL);
-      Map<MatrixXd> dJ(mxGetPr(plhs[2]),3,model->num_dof*model->num_dof);
+      plhs[2] = mxCreateDoubleMatrix(3,model->num_positions*model->num_positions,mxREAL);
+      Map<MatrixXd> dJ(mxGetPr(plhs[2]),3,model->num_positions*model->num_positions);
       model->getCOMdJac(dJ,robotnum_set);
     }
     
@@ -101,8 +101,8 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
   if (b_jacdot) {
     if (rotation_type>1) mexErrMsgIdAndTxt("Drake:forwardKinmex:NotImplemented","Jacobian dot of quaternions are not implemented yet");
 
-    plhs[0] = mxCreateDoubleMatrix(dim_with_rot*n_pts,model->num_dof,mxREAL); 
-    Map<MatrixXd> Jdot(mxGetPr(plhs[0]),dim_with_rot*n_pts,model->num_dof);
+    plhs[0] = mxCreateDoubleMatrix(dim_with_rot*n_pts,model->num_positions,mxREAL); 
+    Map<MatrixXd> Jdot(mxGetPr(plhs[0]),dim_with_rot*n_pts,model->num_positions);
     model->forwardJacDot(body_ind,pts,rotation_type,Jdot);
     return;
   } else {
@@ -112,15 +112,15 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
       model->forwardKin(body_ind,pts,rotation_type,x);
     }
     if (nlhs>1) {
-      plhs[1] = mxCreateDoubleMatrix(dim_with_rot*n_pts,model->num_dof,mxREAL);
-      Map<MatrixXd> J(mxGetPr(plhs[1]),dim_with_rot*n_pts,model->num_dof);
+      plhs[1] = mxCreateDoubleMatrix(dim_with_rot*n_pts,model->num_positions,mxREAL);
+      Map<MatrixXd> J(mxGetPr(plhs[1]),dim_with_rot*n_pts,model->num_positions);
       model->forwardJac(body_ind,pts,rotation_type,J);
     }
     
     if (nlhs>2) {
       if (rotation_type>0) mexErrMsgIdAndTxt("Drake:forwardKinmex:NotImplemented","Second derivatives of rotations are not implemented yet");
-      plhs[2] = mxCreateDoubleMatrix(dim*n_pts,model->num_dof*model->num_dof,mxREAL);
-      Map<MatrixXd> dJ(mxGetPr(plhs[2]),dim*n_pts,model->num_dof*model->num_dof);
+      plhs[2] = mxCreateDoubleMatrix(dim*n_pts,model->num_positions*model->num_positions,mxREAL);
+      Map<MatrixXd> dJ(mxGetPr(plhs[2]),dim*n_pts,model->num_positions*model->num_positions);
       model->forwarddJac(body_ind,pts,dJ);
     }
   }

--- a/systems/plants/getCMMmex.cpp
+++ b/systems/plants/getCMMmex.cpp
@@ -21,24 +21,24 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
   RigidBodyManipulator *model= (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
 
   double* q = mxGetPr(prhs[1]);
-  for (int i = 0; i < model->num_dof; i++) {
+  for (int i = 0; i < model->num_positions; i++) {
     if (q[i] - model->cached_q[i] > 1e-8 || q[i] - model->cached_q[i] < -1e-8) {
       mexErrMsgIdAndTxt("Drake:getCMMmex:InvalidKinematics","This kinsol is no longer valid.  Somebody has called doKinematics with a different q since the solution was computed.");
     }
   }
 
-  plhs[0] = mxCreateDoubleMatrix(6,model->num_dof,mxREAL);
-  Map<MatrixXd> A(mxGetPr(plhs[0]),6,model->num_dof);
-  plhs[1] = mxCreateDoubleMatrix(6,model->num_dof,mxREAL);
-  Map<MatrixXd> Adot(mxGetPr(plhs[1]),6,model->num_dof);
+  plhs[0] = mxCreateDoubleMatrix(6,model->num_positions,mxREAL);
+  Map<MatrixXd> A(mxGetPr(plhs[0]),6,model->num_positions);
+  plhs[1] = mxCreateDoubleMatrix(6,model->num_positions,mxREAL);
+  Map<MatrixXd> Adot(mxGetPr(plhs[1]),6,model->num_positions);
 
   double* qd;
   if (nrhs > 2) {
     qd = mxGetPr(prhs[2]);
   }
   else {
-    qd = new double[model->num_dof];
-    for (int i = 0; i < model->num_dof; i++) {
+    qd = new double[model->num_positions];
+    for (int i = 0; i < model->num_positions; i++) {
       qd[i] = 0;
     }
   }

--- a/systems/plants/inverseDynamicsmex.cpp
+++ b/systems/plants/inverseDynamicsmex.cpp
@@ -25,7 +25,7 @@ void mexFunction(int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[]) {
 
 
   RigidBodyManipulator *model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   int nv = model->num_velocities;
   const mxArray* f_ext_matlab = nullptr;
   const mxArray* vd_matlab = nullptr;

--- a/systems/plants/inverseKin.cpp
+++ b/systems/plants/inverseKin.cpp
@@ -10,8 +10,8 @@ using namespace std;
 template <typename DerivedA, typename DerivedB, typename DerivedC>
 drakeIK_DLLEXPORT void inverseKin(RigidBodyManipulator* model, const MatrixBase<DerivedA> &q_seed, const MatrixBase<DerivedB> &q_nom, const int num_constraints, RigidBodyConstraint** const constraint_array, MatrixBase<DerivedC> &q_sol, int &INFO, vector<string> &infeasible_constraint, const IKoptions &ikoptions) 
 {
-  VectorXd qdot_dummy(model->num_dof);
-  VectorXd qddot_dummy(model->num_dof);
+  VectorXd qdot_dummy(model->num_positions);
+  VectorXd qddot_dummy(model->num_positions);
   double* t = nullptr;
   inverseKinBackend(model, 1,1,t,q_seed,q_nom,num_constraints,constraint_array,q_sol,qdot_dummy,qddot_dummy,&INFO, infeasible_constraint, ikoptions);
 }

--- a/systems/plants/inverseKinBackend.cpp
+++ b/systems/plants/inverseKinBackend.cpp
@@ -429,7 +429,7 @@ void inverseKinBackend(RigidBodyManipulator* model_input, const int mode, const 
   model = model_input;
   nT = nT_input;
   t = const_cast<double*>(t_input);
-  nq = model->num_dof;
+  nq = model->num_positions;
   q_nom = q_nom_input;
   if(q_seed.rows() != nq || q_seed.cols() != nT || q_nom.rows() != nq || q_nom.cols() != nT)
   {

--- a/systems/plants/inverseKinPointwise.cpp
+++ b/systems/plants/inverseKinPointwise.cpp
@@ -10,7 +10,7 @@ using namespace Eigen;
 template <typename DerivedA, typename DerivedB, typename DerivedC>
 drakeIK_DLLEXPORT void inverseKinPointwise(RigidBodyManipulator* model, const int nT, const double* t, const MatrixBase<DerivedA> &q_seed, const MatrixBase<DerivedB> &q_nom, const int num_constraints, RigidBodyConstraint** const constraint_array, MatrixBase<DerivedC> &q_sol, int* INFO, vector<string> &infeasible_constraint, const IKoptions &ikoptions)
 {
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   MatrixXd qdot_dummy(nq,nT);
   MatrixXd qddot_dummy(nq,nT);
   inverseKinBackend(model,1,nT,t,q_seed,q_nom,num_constraints,constraint_array,q_sol,qdot_dummy,qddot_dummy,INFO,infeasible_constraint,ikoptions);

--- a/systems/plants/inverseKinPointwisemex.cpp
+++ b/systems/plants/inverseKinPointwisemex.cpp
@@ -16,7 +16,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexErrMsgIdAndTxt("Drake:inverseKinPointwisemex:NotEnoughInputs","Usage inverseKinPointwisemex(model_ptr,t,q_seed,q_nom,constraint1,constraint2,...,ikoptions");
   }
   RigidBodyManipulator* model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   int nT = static_cast<int>(mxGetNumberOfElements(prhs[1]));
   double* t = mxGetPr(prhs[1]);
   Map<MatrixXd> q_seed(mxGetPr(prhs[2]),nq,nT);

--- a/systems/plants/inverseKinTrajmex.cpp
+++ b/systems/plants/inverseKinTrajmex.cpp
@@ -16,7 +16,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexErrMsgIdAndTxt("Drake:inverseKinTrajmex:NotEnoughInputs","Usage inverseKinPointwisemex(model_ptr,t,qdot0_seed,q_seed,q_nom,constraint1,constraint2,...,ikoptions");
   }
   RigidBodyManipulator* model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   int nT = static_cast<int>(mxGetNumberOfElements(prhs[1]));
   double* t = mxGetPr(prhs[1]);
   Map<VectorXd> qdot0_seed(mxGetPr(prhs[2]),nq);

--- a/systems/plants/inverseKinmex.cpp
+++ b/systems/plants/inverseKinmex.cpp
@@ -16,7 +16,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexErrMsgIdAndTxt("Drake:inverseKinmex:NotEnoughInputs","Usage inverseKinmex(model_ptr,q_seed,q_nom,constraint1,constraint2,...,ikoptions");
   }
   RigidBodyManipulator* model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   Map<VectorXd> q_seed(mxGetPr(prhs[1]),nq);
   Map<VectorXd> q_nom(mxGetPr(prhs[2]),nq);
   int num_constraints = nrhs-4;

--- a/systems/plants/smoothDistancePenaltymex.cpp
+++ b/systems/plants/smoothDistancePenaltymex.cpp
@@ -38,7 +38,7 @@ smoothDistancePenalty(double& c, MatrixXd& dc,
   MatrixXd ddist_dq, dscaled_dist_ddist, dpairwise_costs_dscaled_dist;
 
   int num_pts = static_cast<int>(xA.cols());
-  ddist_dq = MatrixXd::Zero(num_pts,robot->num_dof);
+  ddist_dq = MatrixXd::Zero(num_pts,robot->num_positions);
 
   // Scale distance
   int nd = static_cast<int>(dist.size());
@@ -95,7 +95,7 @@ smoothDistancePenalty(double& c, MatrixXd& dc,
       x_k.col(l) = xB.col(orig_idx_of_pt_on_bodyB.at(k).at(l-numA));
     }
     MatrixXd x_k_1(4,x_k.cols());
-    MatrixXd J_k(3*x_k.cols(),robot->num_dof);
+    MatrixXd J_k(3*x_k.cols(),robot->num_positions);
     x_k_1 << x_k, MatrixXd::Ones(1,x_k.cols());
     robot->forwardJac(k,x_k_1,0,J_k);
     l = 0;
@@ -103,13 +103,13 @@ smoothDistancePenalty(double& c, MatrixXd& dc,
       //DEBUG
       //std::cout << "MinDistanceConstraint::eval: Fifth loop: " << l << std::endl;
       //END_DEBUG
-      ddist_dq.row(orig_idx_of_pt_on_bodyA.at(k).at(l)) += normal.col(orig_idx_of_pt_on_bodyA.at(k).at(l)).transpose() * J_k.block(3*l,0,3,robot->num_dof);
+      ddist_dq.row(orig_idx_of_pt_on_bodyA.at(k).at(l)) += normal.col(orig_idx_of_pt_on_bodyA.at(k).at(l)).transpose() * J_k.block(3*l,0,3,robot->num_positions);
     }
     for (; l < numA+numB; ++l) {
       //DEBUG
       //std::cout << "MinDistanceConstraint::eval: Sixth loop: " << l << std::endl;
       //END_DEBUG
-      ddist_dq.row(orig_idx_of_pt_on_bodyB.at(k).at(l-numA)) += -normal.col(orig_idx_of_pt_on_bodyB.at(k).at(l-numA)).transpose() * J_k.block(3*l,0,3,robot->num_dof);
+      ddist_dq.row(orig_idx_of_pt_on_bodyB.at(k).at(l-numA)) += -normal.col(orig_idx_of_pt_on_bodyB.at(k).at(l-numA)).transpose() * J_k.block(3*l,0,3,robot->num_positions);
     }
   }
   MatrixXd dcost_dscaled_dist(dpairwise_costs_dscaled_dist.colwise().sum());

--- a/systems/plants/test/debugManipulatorDynamics.cpp
+++ b/systems/plants/test/debugManipulatorDynamics.cpp
@@ -16,7 +16,7 @@ int main()
     cerr<<"ERROR: Failed to load model"<<endl;
   }
   int gradient_order = 1;
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   int nv = model->num_velocities;
 
   default_random_engine generator;
@@ -35,7 +35,7 @@ int main()
     body.I.bottomLeftCorner<3, 3>() = vectorToSkewSymmetric((-mass * com).eval());
   }
 
-  VectorXd q = VectorXd::Random(model->num_dof);
+  VectorXd q = VectorXd::Random(model->num_positions);
   VectorXd v = VectorXd::Random(model->num_velocities);
   model->doKinematicsNew(q.data(), true, v.data(), true);
 

--- a/systems/plants/test/testApproximateIK.cpp
+++ b/systems/plants/test/testApproximateIK.cpp
@@ -17,7 +17,7 @@ int main()
   }
   Vector2d tspan;
   tspan<<0,1;
-  VectorXd q0 = VectorXd::Zero(model->num_dof);
+  VectorXd q0 = VectorXd::Zero(model->num_positions);
   q0(3) = 0.8;
   Vector3d com_des = Vector3d::Zero();
   com_des(2) = nan("");
@@ -26,7 +26,7 @@ int main()
   RigidBodyConstraint** constraint_array = new RigidBodyConstraint*[num_constraints];
   constraint_array[0] = com_kc;
   IKoptions ikoptions(model);
-  VectorXd q_sol(model->num_dof);
+  VectorXd q_sol(model->num_positions);
   int info;
   approximateIK(model,q0,q0,num_constraints,constraint_array,q_sol,info,ikoptions);
   printf("INFO = %d\n",info);

--- a/systems/plants/test/testIK.cpp
+++ b/systems/plants/test/testIK.cpp
@@ -18,7 +18,7 @@ int main()
   }
   Vector2d tspan;
   tspan<<0,1;
-  VectorXd q0 = VectorXd::Zero(model->num_dof);
+  VectorXd q0 = VectorXd::Zero(model->num_positions);
   // The state frame of cpp model does not match with the state frame of MATLAB model, since the dofname_to_dofnum is different in cpp and MATLAB
   q0(3) = 0.8;
   Vector3d com_lb = Vector3d::Zero(); 
@@ -30,7 +30,7 @@ int main()
   RigidBodyConstraint** constraint_array = new RigidBodyConstraint*[num_constraints];
   constraint_array[0] = com_kc;
   IKoptions ikoptions(model);
-  VectorXd q_sol(model->num_dof);
+  VectorXd q_sol(model->num_positions);
   int info;
   vector<string> infeasible_constraint;
   inverseKin(model,q0,q0,num_constraints,constraint_array,q_sol,info,infeasible_constraint,ikoptions);

--- a/systems/plants/test/testIKpointwise.cpp
+++ b/systems/plants/test/testIKpointwise.cpp
@@ -19,7 +19,7 @@ int main()
   tspan<<0,1;
   int nT = 3;
   double t[3]={0.0,0.5,1.0};
-  MatrixXd q0 = MatrixXd::Zero(model->num_dof,nT);
+  MatrixXd q0 = MatrixXd::Zero(model->num_positions,nT);
   for(int i = 0;i<nT;i++)
   {
     q0(3,i) = 0.8;
@@ -31,7 +31,7 @@ int main()
   RigidBodyConstraint** constraint_array = new RigidBodyConstraint*[num_constraints];
   constraint_array[0] = com_kc;
   IKoptions ikoptions(model);
-  MatrixXd q_sol(model->num_dof,nT);
+  MatrixXd q_sol(model->num_positions,nT);
   int* info = new int[nT];
   vector<string> infeasible_constraint;
   inverseKinPointwise(model,nT,t,q0,q0,num_constraints,constraint_array,q_sol,info,infeasible_constraint,ikoptions);

--- a/systems/plants/test/testIKtraj.cpp
+++ b/systems/plants/test/testIKtraj.cpp
@@ -40,7 +40,7 @@ int main()
     //  r_foot = i;
     //}
   }
-  int nq = model->num_dof;
+  int nq = model->num_positions;
   VectorXd qstar = VectorXd::Zero(nq);
   qstar(3) = 0.8;
   model->doKinematics(qstar.data());
@@ -62,7 +62,7 @@ int main()
     t[i] = dt*i;
   }
   MatrixXd q0 = qstar.replicate(1,nT);
-  VectorXd qdot0 = VectorXd::Zero(model->num_dof);
+  VectorXd qdot0 = VectorXd::Zero(model->num_positions);
   Vector3d com_lb = com0;
   com_lb(0) = nan("");;
   com_lb(1) = nan("");
@@ -85,9 +85,9 @@ int main()
   constraint_array[0] = com_kc;
   constraint_array[1] = kc_rhand;
   IKoptions ikoptions(model);
-  MatrixXd q_sol(model->num_dof,nT);
-  MatrixXd qdot_sol(model->num_dof,nT);
-  MatrixXd qddot_sol(model->num_dof,nT);
+  MatrixXd q_sol(model->num_positions,nT);
+  MatrixXd qdot_sol(model->num_positions,nT);
+  MatrixXd qddot_sol(model->num_positions,nT);
   int info = 0;
   vector<string> infeasible_constraint;
   inverseKinTraj(model,nT,t,qdot0,q0,q0,num_constraints,constraint_array,q_sol,qdot_sol,qddot_sol,info,infeasible_constraint,ikoptions);

--- a/systems/plants/test/urdf_collision_test.cpp
+++ b/systems/plants/test/urdf_collision_test.cpp
@@ -20,11 +20,11 @@ int main(int argc, char* argv[])
   }
   
   // run kinematics with second derivatives 100 times
-  VectorXd q = VectorXd::Zero(model->num_dof);
+  VectorXd q = VectorXd::Zero(model->num_positions);
   int i;
 
-  if (argc>=2+model->num_dof) {
-  	for (i=0; i<model->num_dof; i++)
+  if (argc>=2+model->num_positions) {
+  	for (i=0; i<model->num_positions; i++)
   		sscanf(argv[2+i],"%lf",&q(i));
   }
   

--- a/systems/plants/test/urdf_kin_test.cpp
+++ b/systems/plants/test/urdf_kin_test.cpp
@@ -20,11 +20,11 @@ int main(int argc, char* argv[])
   }
   
   // run kinematics with second derivatives 100 times
-  VectorXd q = VectorXd::Zero(model->num_dof);
+  VectorXd q = VectorXd::Zero(model->num_positions);
   int i;
 
-  if (argc>=2+model->num_dof) {
-  	for (i=0; i<model->num_dof; i++)
+  if (argc>=2+model->num_positions) {
+  	for (i=0; i<model->num_positions; i++)
   		sscanf(argv[2+i],"%lf",&q(i));
   }
   

--- a/systems/plants/test/urdf_manipulator_dynamics_test.cpp
+++ b/systems/plants/test/urdf_manipulator_dynamics_test.cpp
@@ -25,18 +25,18 @@ int main(int argc, char* argv[])
     cout << model->bodies[i]->linkname << endl;
   }
 
-  VectorXd q = VectorXd::Zero(model->num_dof);
+  VectorXd q = VectorXd::Zero(model->num_positions);
   VectorXd v = VectorXd::Zero(model->num_velocities);
   int i;
 
-  if (argc >= 2 + model->num_dof) {
-    for (i = 0; i < model->num_dof; i++)
+  if (argc >= 2 + model->num_positions) {
+    for (i = 0; i < model->num_positions; i++)
       sscanf(argv[2 + i], "%lf", &q(i));
   }
 
-  if (argc >= 2 + model->num_dof + model->num_velocities) {
+  if (argc >= 2 + model->num_positions + model->num_velocities) {
     for (i = 0; i < model->num_velocities; i++)
-      sscanf(argv[2 + model->num_dof + i], "%lf", &v(i));
+      sscanf(argv[2 + model->num_positions + i], "%lf", &v(i));
   }
 
   model->doKinematicsNew(q.data(), true, v.data(), true);

--- a/systems/plants/testIKoptionsmex.cpp
+++ b/systems/plants/testIKoptionsmex.cpp
@@ -14,7 +14,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
   }
   IKoptions* ikoptions = (IKoptions*) getDrakeMexPointer(prhs[0]);
   long long robot_address = reinterpret_cast<long long>(ikoptions->getRobotPtr());
-  int nq = ikoptions->getRobotPtr()->num_dof;
+  int nq = ikoptions->getRobotPtr()->num_positions;
   MatrixXd Q;
   ikoptions->getQ(Q);
   MatrixXd Qv;


### PR DESCRIPTION
Fixes part of https://github.com/mitdrc/drc/issues/1001. Holding off on the options struct/class until we decide.
* RigidBody.dofnum --> position_num_start
* RigidBodyManipulator.dofnum --> num_positions
* fixed some warnings concerning uninitialized members.