### PR TITLE
fix crashing bug in QPControllermex

### DIFF
--- a/systems/controllers/QPControllermex.cpp
+++ b/systems/controllers/QPControllermex.cpp
@@ -224,14 +224,14 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
   Map<MatrixXd> D_ls(mxGetPr(prhs[narg]),mxGetM(prhs[narg]),mxGetN(prhs[narg])); narg++;
   Map<MatrixXd> S   (mxGetPr(prhs[narg]),mxGetM(prhs[narg]),mxGetN(prhs[narg])); narg++;
 
-  Map<VectorXd> s1(mxGetPr(prhs[narg]),mxGetM(prhs[narg])); narg++;
-  Map<VectorXd> s1dot(mxGetPr(prhs[narg]),mxGetM(prhs[narg])); narg++;
+  Map<VectorXd> s1(mxGetPr(prhs[narg]),mxGetNumberOfElements(prhs[narg])); narg++;
+  Map<VectorXd> s1dot(mxGetPr(prhs[narg]),mxGetNumberOfElements(prhs[narg])); narg++;
   double s2dot = mxGetScalar(prhs[narg++]);
-  Map<VectorXd> x0(mxGetPr(prhs[narg]),mxGetM(prhs[narg])); narg++;
-  Map<VectorXd> u0(mxGetPr(prhs[narg]),mxGetM(prhs[narg])); narg++;
-  Map<VectorXd> y0(mxGetPr(prhs[narg]),mxGetM(prhs[narg])); narg++;
-  Map<VectorXd> qdd_lb(mxGetPr(prhs[narg]),mxGetM(prhs[narg])); narg++;
-  Map<VectorXd> qdd_ub(mxGetPr(prhs[narg]),mxGetM(prhs[narg])); narg++;
+  Map<VectorXd> x0(mxGetPr(prhs[narg]),mxGetNumberOfElements(prhs[narg])); narg++;
+  Map<VectorXd> u0(mxGetPr(prhs[narg]),mxGetNumberOfElements(prhs[narg])); narg++;
+  Map<VectorXd> y0(mxGetPr(prhs[narg]),mxGetNumberOfElements(prhs[narg])); narg++;
+  Map<VectorXd> qdd_lb(mxGetPr(prhs[narg]),mxGetNumberOfElements(prhs[narg])); narg++;
+  Map<VectorXd> qdd_ub(mxGetPr(prhs[narg]),mxGetNumberOfElements(prhs[narg])); narg++;
   memcpy(pdata->w_qdd.data(),mxGetPr(prhs[narg++]),sizeof(double)*nq); 
   
   double mu = mxGetScalar(prhs[narg++]);


### PR DESCRIPTION
arguments were being passed in as row vectors instead of column vectors,... causing qdd_lb and qdd_ub (and possibly others) to be vectors of length 1 instead of length nq.  generalized the logic to be robust.  resolves the memory errors on my mac.