### PR TITLE
add a material tag 'yellow' in robotiq.urdf

### DIFF
--- a/examples/Atlas/urdf/robotiq.urdf
+++ b/examples/Atlas/urdf/robotiq.urdf
@@ -46,7 +46,9 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
+      <material name="yellow">
+	      <color rgba="0 1 1 1"/>
+      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>

--- a/examples/IRB140/urdf/irb_140_robotiq.urdf
+++ b/examples/IRB140/urdf/irb_140_robotiq.urdf
@@ -274,7 +274,9 @@
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
+      <material name="yellow">
+        <color rgba="0 1 1 1"/>
+      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>

--- a/examples/IRB140/urdf/irb_140_robotiq_ati.urdf
+++ b/examples/IRB140/urdf/irb_140_robotiq_ati.urdf
@@ -42,7 +42,9 @@
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
+      <material name="yellow">
+        <color rgba="0 1 1 1"/>
+      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>


### PR DESCRIPTION
The `yellow` material tag was not defined in `robotiq.urdf`, and `URDFRigidBodyManipulator` could not load it. Now I can load the urdf and tested it in `pod-build/bin/urdf_manipulator_dynamics_test`. I think this would resolve the issue in Pat's comment https://github.com/mitdrc/drc/pull/981