### PR TITLE
MultiCoordinateFrame helpers and TSRBM visualizer change

### DIFF
--- a/systems/frames/MultiCoordinateFrame.m
+++ b/systems/frames/MultiCoordinateFrame.m
@@ -317,8 +317,10 @@ classdef MultiCoordinateFrame < CoordinateFrame
     end
     
     function id = getFrameNumByNameRecursive(obj,name)
-      % Returns list of subframe ids to get to the supplied
-      % frame from the root.
+      % Returns vector of subframe ids to get to the supplied
+      % frame from the root. The first elem in the vec is
+      % the root level subframe -- each sequential item in
+      % the vec is the index into the next subframe down.
       to_search = obj.frame;
       frame_locations = num2cell(1:length(to_search));
       i = 1;

--- a/systems/frames/MultiCoordinateFrame.m
+++ b/systems/frames/MultiCoordinateFrame.m
@@ -293,8 +293,50 @@ classdef MultiCoordinateFrame < CoordinateFrame
       fr = obj.frame{id};
     end
     
+    function fr = getFrameByNameRecursive(obj,name)
+      % Looks in all subframes that are multicoordinate frames for this
+      % frame.
+      to_search = obj.frame;
+      i = 1;
+      while (i <= length(to_search))
+        if (isa(to_search{i}, 'MultiCoordinateFrame'))
+          to_search = [to_search to_search{i}.frame];
+        end
+        i = i + 1;
+      end
+      id = find(cellfun(@(a)strcmp(a.name,name),to_search));
+      
+      if length(id)~=1
+        error(['couldn''t find unique frame named ',name]);
+      end
+      fr = to_search{id};
+    end
+    
     function id = getFrameNumByName(obj,name)
       id = find(cellfun(@(a)strcmp(a.name,name),obj.frame));
+    end
+    
+    function id = getFrameNumByNameRecursive(obj,name)
+      % Returns list of subframe ids to get to the supplied
+      % frame from the root.
+      to_search = obj.frame;
+      frame_locations = num2cell(1:length(to_search));
+      i = 1;
+      while (i <= length(to_search))
+        if (isa(to_search{i}, 'MultiCoordinateFrame'))
+          to_search = [to_search to_search{i}.frame];
+          for j=1:length(to_search{i}.frame)
+            frame_locations{end+1} = [frame_locations{i} j];
+          end
+        end
+        i = i + 1;
+      end
+      id = find(cellfun(@(a)strcmp(a.name,name),to_search));
+      if length(id)>1
+        error(['couldn''t find unique frame named ',name]);
+      elseif length(id) == 1
+        id = frame_locations{id};
+      end
     end
     
     function id = getFrameNum(obj,frame)

--- a/systems/frames/test/deepMultiFrameTest.m
+++ b/systems/frames/test/deepMultiFrameTest.m
@@ -1,0 +1,53 @@
+function deepMultiFrameTest
+
+lfr1 = CoordinateFrame('leafframe1',2,'a');
+lfr2 = CoordinateFrame('leafframe2',2,'b');
+lfr3 = CoordinateFrame('leafframe3',2,'c');
+lfr4 = CoordinateFrame('leafframe4',2,'d');
+sfr1 = MultiCoordinateFrame({lfr1, lfr2});
+sfr2 = MultiCoordinateFrame({lfr3, sfr1});
+fr1 = MultiCoordinateFrame({sfr2, lfr4});
+
+% Test ability to pull out deeply embedded coordinate frames
+out_lfr1 = fr1.getFrameByNameRecursive('leafframe1');
+if (out_lfr1 ~= lfr1)
+  error('Returned incorrect subrame!');
+end
+out_lfr1_fr = fr1.getFrameNumByNameRecursive('leafframe1');
+sizecheck(out_lfr1_fr, [1 3]); valuecheck(out_lfr1_fr, [1 2 1]);
+
+out_lfr2 = fr1.getFrameByNameRecursive('leafframe2');
+if (out_lfr2 ~= lfr2)
+  error('Returned incorrect subrame!');
+end
+out_lfr2_fr = fr1.getFrameNumByNameRecursive('leafframe2');
+sizecheck(out_lfr2_fr, [1 3]); valuecheck(out_lfr2_fr,[1 2 2]);
+
+out_lfr3 = fr1.getFrameByNameRecursive('leafframe3');
+if (out_lfr3 ~= lfr3)
+  error('Returned incorrect subrame!');
+end
+out_lfr3_fr = fr1.getFrameNumByNameRecursive('leafframe3');
+sizecheck(out_lfr3_fr, [1 2]); valuecheck(out_lfr3_fr, [1 1]);
+
+out_lfr4 = fr1.getFrameByNameRecursive('leafframe4');
+if (out_lfr4 ~= lfr4)
+  error('Returned incorrect subrame!');
+end
+out_lfr4_fr = fr1.getFrameNumByNameRecursive('leafframe4');
+sizecheck(out_lfr4_fr, [1 1]); valuecheck(out_lfr4_fr, [2]);
+
+% And see if we can get the sub-multicoordinate frames too
+out_sfr1 = fr1.getFrameByNameRecursive('leafframe1+leafframe2');
+if (out_sfr1 ~= sfr1)
+  error('Returned incorrect subrame!');
+end
+out_sfr1_fr = fr1.getFrameNumByNameRecursive('leafframe1+leafframe2');
+sizecheck(out_sfr1_fr, [1 2]); valuecheck(out_sfr1_fr, [1 2]);
+
+out_sfr2 = fr1.getFrameByNameRecursive('leafframe3+leafframe1+leafframe2');
+if (out_sfr2 ~= sfr2)
+  error('Returned incorrect subrame!');
+end
+out_sfr2_fr = fr1.getFrameNumByNameRecursive('leafframe3+leafframe1+leafframe2');
+sizecheck(out_sfr2_fr, [1 1]); valuecheck(out_sfr2_fr, [1]);

--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -1030,8 +1030,8 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
 
     function v = constructVisualizer(obj,varargin)
       v = constructVisualizer(obj.manip,varargin{:});
-      v = v.setNumInputs(obj.getNumStates());
-      v = setInputFrame(v,obj.getStateFrame());
+      v = v.setNumInputs(obj.getNumOutputs());
+      v = setInputFrame(v,obj.getOutputFrame());
     end
 
     function getNumContacts(~)


### PR DESCRIPTION
Adds some helpers to find frames within subframes, and cleans up the Atlas compile to be a bit cleaner. 

Also proposes changing the TSRBM visualizer input to be the output frame of the system it is created from, and not the state. (The visualizer is usually cascaded with the system, so the TSRBM output is what it takes as input anyway -- it has just been generally required that the state frame is available in that output somewhere.)