### PR TITLE
Fix IRB140 hand rotation to match the merged URDF

### DIFF
--- a/examples/IRB140/IRB140.m
+++ b/examples/IRB140/IRB140.m
@@ -33,16 +33,16 @@ classdef IRB140 < TimeSteppingRigidBodyManipulator
         if (strcmp(options.hands, 'robotiq'))
           options_hand.weld_to_link = 7;
           obj.hands = 1;
-          obj = obj.addRobotFromURDF(getFullPathFromRelativePath('../Atlas/urdf/robotiq.urdf'), [0.11904; 0.0; 0.0], [pi; 0; pi/2], options_hand);
+          obj = obj.addRobotFromURDF(getFullPathFromRelativePath('../Atlas/urdf/robotiq.urdf'), [0.11904; 0.0; 0.0], [pi; pi; pi/2], options_hand);
         elseif (strcmp(options.hands, 'robotiq_weight_only'))
           % Adds a box with weight roughly approximating the hands, so that
           % the controllers know what's up
           options_hand.weld_to_link = 7;
-          obj = obj.addRobotFromURDF(getFullPathFromRelativePath('../Atlas/urdf/robotiq_box.urdf'), [0.11904; 0.0; 0.0], [pi; 0; pi/2], options_hand);
+          obj = obj.addRobotFromURDF(getFullPathFromRelativePath('../Atlas/urdf/robotiq_box.urdf'), [0.11904; 0.0; 0.0], [pi; pi; pi/2], options_hand);
         elseif (strcmp(options.hands, 'block_hand'))
           % Box with collision. Good for hitting things with...
           options_hand.weld_to_link = 7;
-          obj = obj.addRobotFromURDF(getFullPathFromRelativePath('../Atlas/urdf/block_hand.urdf'), [0.11904; 0.0; 0.0], [pi; 0; pi/2], options_hand);
+          obj = obj.addRobotFromURDF(getFullPathFromRelativePath('../Atlas/urdf/block_hand.urdf'), [0.11904; 0.0; 0.0], [pi; pi; pi/2], options_hand);
         else
           error('unsupported hand type');
         end


### PR DESCRIPTION
The merged IRB140 urdf (irb_140_robotiq.urdf), when visualized, had the hand spun around 180deg from where the manually-attached hand in the TSRBM appeared. I'm making an assumption that the merged urdf matches reality -- @hongkai-dai, is that correct?