### PR TITLE
Fixed issue with doKinematicsNew vToqdot and qdotToV computation

### DIFF
--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -967,7 +967,7 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
       double* q_body = &q[body.dofnum];
 
       // transform
-      Isometry3d T_body_to_parent = Isometry3d(body.Ttree) * body.getJoint().jointTransform(q_body);
+      Isometry3d T_body_to_parent = body.getJoint().getTransformToParentBody() * body.getJoint().jointTransform(q_body);
       body.T_new = bodies[body.parent]->T_new * T_body_to_parent;
 
       // motion subspace in body frame
@@ -979,7 +979,7 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
 
       // qdot to v
       Eigen::MatrixXd* dqdot_to_v = compute_gradients ? &(body.dqdot_to_v_dqi) : nullptr;
-      body.getJoint().qdot2v(q, body.qdot_to_v, dqdot_to_v);
+      body.getJoint().qdot2v(q_body, body.qdot_to_v, dqdot_to_v);
       if (compute_gradients) {
         body.dqdot_to_v_dq.setZero();
         body.dqdot_to_v_dq.middleCols(body.dofnum, body.getJoint().getNumPositions()) = body.dqdot_to_v_dqi;
@@ -987,7 +987,7 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
 
       // v to qdot
       Eigen::MatrixXd* dv_to_qdot = compute_gradients ? &(body.dv_to_qdot_dqi) : nullptr;
-      body.getJoint().v2qdot(q, body.v_to_qdot, dv_to_qdot);
+      body.getJoint().v2qdot(q_body, body.v_to_qdot, dv_to_qdot);
       if (compute_gradients) {
         body.dv_to_qdot_dq.setZero();
         body.dv_to_qdot_dq.middleCols(body.dofnum, body.getJoint().getNumPositions()) = body.dv_to_qdot_dqi;

--- a/systems/plants/test/testForwardKin.m
+++ b/systems/plants/test/testForwardKin.m
@@ -1,19 +1,20 @@
 function testForwardKin
 
-testFallingBrick('rpy');
+testTwoFallingBricks('rpy');
 testAtlas('rpy');
 
 options.use_new_kinsol = true;
-testFallingBrick('rpy',options);
+testTwoFallingBricks('rpy',options);
 testAtlas('rpy',options);
-testFallingBrick('quat',options);
+testTwoFallingBricks('quat',options);
 testAtlas('quat',options);
 
 end
 
-function testFallingBrick(floatingJointType,options)
+function testTwoFallingBricks(floatingJointType,options)
 options.floating = floatingJointType;
 robot = RigidBodyManipulator('FallingBrick.urdf',options);
+robot = robot.addRobotFromURDF('FallingBrick.urdf', [], [], options);
 for rotation_type = 0 : 2
   checkGradients(robot, rotation_type);  
   checkMex(robot, rotation_type);


### PR DESCRIPTION
Was passing q instead of q_body into DrakeJoint.qdot2v and DrakeJoint.v2qdot...
Fixes https://github.com/RobotLocomotion/drake/issues/808.

Also changed doKinematicsNew so that it uses body.getJoint().getTransformToParentBody() instead of Ttree while I was at it.
I changed testFallingBrick to testTwoFallingBricks to catch regressions.