### PR TITLE
Replaced double pointers in doKinematics and drakeJoint methods with Eigen types

### DIFF
--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -674,7 +674,10 @@ void RigidBodyManipulator::doKinematics(MatrixBase<DerivedA>  & q, bool b_comput
 void RigidBodyManipulator::doKinematics(double* q, bool b_compute_second_derivatives, double* qd)
 {
   if (use_new_kinsol) {
-    doKinematicsNew(q, b_compute_second_derivatives, qd, qd != nullptr);
+    Map<VectorXd> q_map(q, num_positions, 1);
+    double nv = qd == nullptr ? 0 : num_velocities;
+    Map<VectorXd> v_map(qd, nv, 1);
+    doKinematicsNew(q_map, v_map, b_compute_second_derivatives, qd != nullptr);
   }
   else {
 
@@ -933,13 +936,19 @@ void RigidBodyManipulator::doKinematics(double* q, bool b_compute_second_derivat
   }
 }
 
-void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, double* v, bool compute_JdotV) {
+template <typename DerivedQ, typename DerivedV>
+void RigidBodyManipulator::doKinematicsNew(const MatrixBase<DerivedQ>& q, const MatrixBase<DerivedV>& v, bool compute_gradients, bool compute_JdotV) {
+  EIGEN_STATIC_ASSERT_VECTOR_ONLY(MatrixBase<DerivedQ>);
+  EIGEN_STATIC_ASSERT_VECTOR_ONLY(MatrixBase<DerivedV>);
+  assert(q.rows() == num_positions);
+  assert(v.rows() == num_velocities || v.rows() == 0);
+
   if (kinematicsInit) {
     bool skip = true;
     if (compute_gradients && !gradients_cached) {
       skip = false;
     }
-    if (v != nullptr) {
+    if (v.rows() > 0) {
       if (!velocity_kinematics_cached) {
         skip = false;
       }
@@ -972,33 +981,34 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
     RigidBody& body = *bodies[i];
 
     if (body.hasParent()) {
-      double* q_body = &q[body.position_num_start];
+      const DrakeJoint& joint = body.getJoint();
+      auto q_body = q.middleRows(body.position_num_start, joint.getNumPositions());
 
       // transform
-      Isometry3d T_body_to_parent = body.getJoint().getTransformToParentBody() * body.getJoint().jointTransform(q_body);
+      Isometry3d T_body_to_parent = joint.getTransformToParentBody() * joint.jointTransform(q_body);
       body.T_new = bodies[body.parent]->T_new * T_body_to_parent;
 
       // motion subspace in body frame
       Eigen::MatrixXd* dSdq = compute_gradients ? &(body.dSdqi) : nullptr;
-      body.getJoint().motionSubspace(q_body, body.S, dSdq);
+      joint.motionSubspace(q_body, body.S, dSdq);
 
       // motion subspace in world frame
       body.J = transformSpatialMotion(body.T_new, body.S);
 
       // qdot to v
       Eigen::MatrixXd* dqdot_to_v = compute_gradients ? &(body.dqdot_to_v_dqi) : nullptr;
-      body.getJoint().qdot2v(q_body, body.qdot_to_v, dqdot_to_v);
+      joint.qdot2v(q_body, body.qdot_to_v, dqdot_to_v);
       if (compute_gradients) {
         body.dqdot_to_v_dq.setZero();
-        body.dqdot_to_v_dq.middleCols(body.position_num_start, body.getJoint().getNumPositions()) = body.dqdot_to_v_dqi;
+        body.dqdot_to_v_dq.middleCols(body.position_num_start, joint.getNumPositions()) = body.dqdot_to_v_dqi;
       }
 
       // v to qdot
       Eigen::MatrixXd* dv_to_qdot = compute_gradients ? &(body.dv_to_qdot_dqi) : nullptr;
-      body.getJoint().v2qdot(q_body, body.v_to_qdot, dv_to_qdot);
+      joint.v2qdot(q_body, body.v_to_qdot, dv_to_qdot);
       if (compute_gradients) {
         body.dv_to_qdot_dq.setZero();
-        body.dv_to_qdot_dq.middleCols(body.position_num_start, body.getJoint().getNumPositions()) = body.dv_to_qdot_dqi;
+        body.dv_to_qdot_dq.middleCols(body.position_num_start, joint.getNumPositions()) = body.dv_to_qdot_dqi;
       }
 
       if (compute_gradients) {
@@ -1006,26 +1016,25 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
         auto dT_body_to_parentdqi = dHomogTrans(T_body_to_parent, body.S, body.qdot_to_v).eval();
         Gradient<Isometry3d::MatrixType, Eigen::Dynamic>::type dT_body_to_parentdq(HOMOGENEOUS_TRANSFORM_SIZE, nq);
         dT_body_to_parentdq.setZero();
-        dT_body_to_parentdq.middleCols(body.position_num_start, body.getJoint().getNumPositions()) = dT_body_to_parentdqi;
+        dT_body_to_parentdq.middleCols(body.position_num_start, joint.getNumPositions()) = dT_body_to_parentdqi;
         body.dTdq_new = matGradMultMat(bodies[body.parent]->T_new.matrix(), T_body_to_parent.matrix(), bodies[body.parent]->dTdq_new, dT_body_to_parentdq);
 
         // gradient of motion subspace in world
         MatrixXd dSdq = MatrixXd::Zero(body.S.size(), nq);
-        dSdq.middleCols(body.position_num_start, body.getJoint().getNumPositions()) = body.dSdqi;
+        dSdq.middleCols(body.position_num_start, joint.getNumPositions()) = body.dSdqi;
         body.dJdq = dTransformSpatialMotion(body.T_new, body.S, body.dTdq_new, dSdq);
       }
 
-      if (v) {
+      if (v.rows() > 0) {
         // twist
-        double* v_body = &v[body.velocity_num_start];
-        Map<VectorXd> v_body_map(v_body, body.getJoint().getNumVelocities());
-        joint_twist.value().noalias() = body.J * v_body_map;
+        auto v_body = v.middleRows(body.velocity_num_start, joint.getNumVelocities());
+        joint_twist.value().noalias() = body.J * v_body;
         body.twist = bodies[body.parent]->twist;
         body.twist += joint_twist.value();
 
         if (compute_gradients) {
           // dtwistdq
-          joint_twist.gradient().value() = matGradMult(body.dJdq, v_body_map);
+          joint_twist.gradient().value() = matGradMult(body.dJdq, v_body);
           body.dtwistdq = bodies[body.parent]->dtwistdq + joint_twist.gradient().value();
         }
 
@@ -1033,7 +1042,7 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
           // Sdotv
           auto dSdotVdqi = compute_gradients ? &body.dSdotVdqi : nullptr;
           auto dSdotVdvi = compute_gradients ? &body.dSdotVdvi : nullptr;
-          body.getJoint().motionSubspaceDotTimesV(q_body, v_body, body.SdotV, dSdotVdqi, dSdotVdvi);
+          joint.motionSubspaceDotTimesV(q_body, v_body, body.SdotV, dSdotVdqi, dSdotVdvi);
 
           // Jdotv
           auto joint_accel = crossSpatialMotion(body.twist, joint_twist.value());
@@ -1045,7 +1054,7 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
             // TODO: exploit sparsity better
             Matrix<double, TWIST_SIZE, Eigen::Dynamic> dSdotVdq(TWIST_SIZE, nq);
             dSdotVdq.setZero();
-            dSdotVdq.middleCols(body.position_num_start, body.getJoint().getNumPositions()) = body.dSdotVdqi;
+            dSdotVdq.middleCols(body.position_num_start, joint.getNumPositions()) = body.dSdotVdqi;
             MatrixXd dcrm_twist_joint_twistdq(TWIST_SIZE, nq);
             dcrm(body.twist, joint_twist.value(), body.dtwistdq, joint_twist.gradient().value(), &dcrm_twist_joint_twistdq); // TODO: make dcrm templated
             body.dJdotVdq = bodies[body.parent]->dJdotVdq
@@ -1053,7 +1062,7 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
                 + dTransformSpatialMotion(body.T_new, body.SdotV, body.dTdq_new, dSdotVdq);
 
             // dJdotvdv
-            int nv_joint = body.getJoint().getNumVelocities();
+            int nv_joint = joint.getNumVelocities();
             std::vector<int> v_indices;
             auto dtwistdv = geometricJacobian<double>(0, i, 0, 0, false, &v_indices);
             std::size_t nv_branch = v_indices.size();
@@ -1090,7 +1099,7 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
         body.dTdq_new.setZero();
         // gradient of motion subspace in world is empty
       }
-      if (v) {
+      if (v.rows() > 0) {
         body.twist.setZero();
         if (compute_gradients) {
           body.dtwistdq.setZero();
@@ -1114,10 +1123,10 @@ void RigidBodyManipulator::doKinematicsNew(double* q, bool compute_gradients, do
   kinematicsInit = true;
   cached_inertia_gradients_order = -1;
   gradients_cached = compute_gradients;
-  velocity_kinematics_cached = v != nullptr;
+  velocity_kinematics_cached = v.rows() > 0;
   jdotV_cached = compute_JdotV && velocity_kinematics_cached;
   for (int i = 0; i < num_positions; i++) cached_q[i] = q[i];
-  if (v!=nullptr) for (int i = 0; i < num_velocities; i++) cached_v[i] = v[i];
+  if (v.rows() > 0) for (int i = 0; i < num_velocities; i++) cached_v[i] = v[i];
 }
 template <typename DerivedA, typename DerivedB>
 void RigidBodyManipulator::getCMM(MatrixBase<DerivedA> const & q, MatrixBase<DerivedA> const & qd, MatrixBase<DerivedB> &A, MatrixBase<DerivedB> &Adot)
@@ -1855,7 +1864,8 @@ GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::geometricJ
       const std::unique_ptr<RigidBody>& body = bodies[body_index];
       const DrakeJoint& joint = body->getJoint();
 
-      joint.motionSubspace(cached_q.data() + body->position_num_start, motion_subspace); // TODO: should just let DrakeJoints work with VectorXds
+      motion_subspace.resize(Eigen::NoChange, joint.getNumVelocities());
+      joint.motionSubspace(cached_q.middleRows(body->position_num_start, joint.getNumPositions()), motion_subspace);
 
       sign = kinematic_path.joint_direction_signs[i];
       auto block = J.template block<TWIST_SIZE, Dynamic>(0, col_start, TWIST_SIZE, joint.getNumVelocities());
@@ -2904,6 +2914,8 @@ GradientVar<Scalar, Eigen::Dynamic, 1> RigidBodyManipulator::positionConstraints
 // explicit instantiations (required for linking):
 template DLLEXPORT_RBM void RigidBodyManipulator::doKinematics(MatrixBase<VectorXd>  &, bool);
 template DLLEXPORT_RBM void RigidBodyManipulator::doKinematics(MatrixBase< Map<VectorXd> >  &, bool);
+template DLLEXPORT_RBM void RigidBodyManipulator::doKinematicsNew(const MatrixBase< Map<VectorXd> > &, const MatrixBase< Map<VectorXd> > &, bool, bool);
+template DLLEXPORT_RBM void RigidBodyManipulator::doKinematicsNew(const MatrixBase<VectorXd> &, const MatrixBase<VectorXd> &, bool, bool);
 
 template DLLEXPORT_RBM void RigidBodyManipulator::doKinematics(MatrixBase<VectorXd>  &, bool, MatrixBase<VectorXd>  &);
 template DLLEXPORT_RBM void RigidBodyManipulator::doKinematics(MatrixBase< Map<VectorXd> >  &, bool, MatrixBase< Map<VectorXd> >  &);

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -61,7 +61,8 @@ public:
   template <typename DerivedA, typename DerivedB>
   void doKinematics(MatrixBase<DerivedA> & q, bool b_compute_second_derivatives, MatrixBase<DerivedB> & v);
 
-  void doKinematicsNew(double* q, bool compute_gradients = false, double* v = nullptr, bool compute_JdotV = false);
+  template <typename DerivedQ, typename DerivedV>
+  void doKinematicsNew(const MatrixBase<DerivedQ>& q, const MatrixBase<DerivedV>& v, bool compute_gradients = false, bool compute_JdotV = false);
 
   void updateCompositeRigidBodyInertias(int gradient_order);
 

--- a/systems/plants/doKinematicsNewmex.cpp
+++ b/systems/plants/doKinematicsNewmex.cpp
@@ -14,17 +14,19 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
   // first get the model_ptr back from matlab
   RigidBodyManipulator *model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
 
-  double *q, *v = nullptr;
-  if (mxGetNumberOfElements(prhs[1]) != model->num_positions)
+  Map<VectorXd> q(mxGetPr(prhs[1]), mxGetNumberOfElements(prhs[1]));
+  if (q.rows() != model->num_positions)
     mexErrMsgIdAndTxt("Drake:doKinematicsmex:BadInputs", "q must be size %d x 1", model->num_positions);
-  q = mxGetPr(prhs[1]);
   bool compute_gradients = (bool) (mxGetLogicals(prhs[2]))[0];
-  if (mxGetNumberOfElements(prhs[3]) > 0) {
-    if (mxGetNumberOfElements(prhs[3]) != model->num_velocities)
-      mexErrMsgIdAndTxt("Drake:doKinematicsmex:BadInputs", "v must be size %d x 1", model->num_velocities);
-    v = mxGetPr(prhs[3]);
-  }
   bool compute_Jdotv = (bool) (mxGetLogicals(prhs[4]))[0];
-
-  model->doKinematicsNew(q, compute_gradients, v, compute_Jdotv);
+  if (mxGetNumberOfElements(prhs[3]) > 0) {
+    auto v = Map<VectorXd>(mxGetPr(prhs[3]), mxGetNumberOfElements(prhs[3]));
+    if (v.rows() != model->num_velocities)
+      mexErrMsgIdAndTxt("Drake:doKinematicsmex:BadInputs", "v must be size %d x 1", model->num_velocities);
+    model->doKinematicsNew(q, v, compute_gradients, compute_Jdotv);
+  }
+  else {
+    Map<VectorXd> v(nullptr, 0, 1);
+    model->doKinematicsNew(q, v, compute_gradients, compute_Jdotv);
+  }
 }

--- a/systems/plants/joints/DrakeJoint.h
+++ b/systems/plants/joints/DrakeJoint.h
@@ -51,19 +51,19 @@ public:
 
   const std::string& getName() const;
 
-  virtual Eigen::Isometry3d jointTransform(double* const q) const = 0;
+  virtual Eigen::Isometry3d jointTransform(const Eigen::Ref<const Eigen::VectorXd>& q) const = 0;
 
-  virtual void motionSubspace(double* const q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace = nullptr) const = 0;
+  virtual void motionSubspace(const Eigen::Ref<const Eigen::VectorXd>& q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace = nullptr) const = 0;
 
-  virtual void motionSubspaceDotTimesV(double* const q, double* const v, Vector6d& motion_subspace_dot_times_v,
+  virtual void motionSubspaceDotTimesV(const Eigen::Ref<const Eigen::VectorXd>& q, const Eigen::Ref<const Eigen::VectorXd>& v, Vector6d& motion_subspace_dot_times_v,
       Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq = nullptr,
       Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv = nullptr) const = 0;
 
-  virtual void randomConfiguration(double* q, std::default_random_engine& generator) const = 0;
+  virtual void randomConfiguration(Eigen::Ref<Eigen::VectorXd>& q, std::default_random_engine& generator) const = 0;
 
-  virtual void qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const = 0;
+  virtual void qdot2v(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const = 0;
 
-  virtual void v2qdot(double* q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const = 0;
+  virtual void v2qdot(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const = 0;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW;

--- a/systems/plants/joints/FixedAxisOneDoFJoint.cpp
+++ b/systems/plants/joints/FixedAxisOneDoFJoint.cpp
@@ -34,7 +34,7 @@ void FixedAxisOneDoFJoint::setJointLimits(double joint_limit_min, double joint_l
   this->joint_limit_max = joint_limit_max;
 }
 
-void FixedAxisOneDoFJoint::motionSubspace(double* const q, MotionSubspaceType& motion_subspace, MatrixXd* dmotion_subspace) const
+void FixedAxisOneDoFJoint::motionSubspace(const Eigen::Ref<const VectorXd>& q, MotionSubspaceType& motion_subspace, MatrixXd* dmotion_subspace) const
 {
   motion_subspace = joint_axis;
   if (dmotion_subspace) {
@@ -42,7 +42,7 @@ void FixedAxisOneDoFJoint::motionSubspace(double* const q, MotionSubspaceType& m
   }
 }
 
-void FixedAxisOneDoFJoint::motionSubspaceDotTimesV(double* const q, double* const v,
+void FixedAxisOneDoFJoint::motionSubspaceDotTimesV(const Eigen::Ref<const VectorXd>& q, const Eigen::Ref<const VectorXd>& v,
     Vector6d& motion_subspace_dot_times_v,
     Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq,
     Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv) const
@@ -58,7 +58,7 @@ void FixedAxisOneDoFJoint::motionSubspaceDotTimesV(double* const q, double* cons
   }
 }
 
-void FixedAxisOneDoFJoint::randomConfiguration(double* q, std::default_random_engine& generator) const
+void FixedAxisOneDoFJoint::randomConfiguration(Eigen::Ref<VectorXd>& q, std::default_random_engine& generator) const
 {
   if (isFinite(joint_limit_min) && isFinite(joint_limit_max)) {
     std::uniform_real_distribution<double> distribution(joint_limit_min, joint_limit_max);
@@ -88,7 +88,7 @@ void FixedAxisOneDoFJoint::randomConfiguration(double* q, std::default_random_en
   }
 }
 
-void FixedAxisOneDoFJoint::qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const
+void FixedAxisOneDoFJoint::qdot2v(const Eigen::Ref<const VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const
 {
   qdot_to_v.setIdentity(getNumVelocities(), getNumPositions());
   if (dqdot_to_v) {
@@ -96,7 +96,7 @@ void FixedAxisOneDoFJoint::qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eigen::
   }
 }
 
-void FixedAxisOneDoFJoint::v2qdot(double* q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const
+void FixedAxisOneDoFJoint::v2qdot(const Eigen::Ref<const VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const
 {
   v_to_qdot.setIdentity(getNumPositions(), getNumVelocities());
   if (dv_to_qdot) {

--- a/systems/plants/joints/FixedAxisOneDoFJoint.h
+++ b/systems/plants/joints/FixedAxisOneDoFJoint.h
@@ -23,17 +23,17 @@ public:
 
   void setJointLimits(double joint_limit_min, double joint_limit_max);
 
-  virtual void motionSubspace(double* const q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace) const; //override;
+  virtual void motionSubspace(const Eigen::Ref<const Eigen::VectorXd>& q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace) const; //override;
 
-  virtual void motionSubspaceDotTimesV(double* const q, double* const v, Vector6d& motion_subspace_dot_times_v,
+  virtual void motionSubspaceDotTimesV(const Eigen::Ref<const Eigen::VectorXd>& q, const Eigen::Ref<const Eigen::VectorXd>& v, Vector6d& motion_subspace_dot_times_v,
       Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq = nullptr,
       Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv = nullptr) const; //override;
 
-  virtual void randomConfiguration(double* q, std::default_random_engine& generator) const; //override;
+  virtual void randomConfiguration(Eigen::Ref<Eigen::VectorXd>& q, std::default_random_engine& generator) const; //override;
 
-  virtual void qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const; //override;
+  virtual void qdot2v(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const; //override;
 
-  virtual void v2qdot(double* q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const; //override;
+  virtual void v2qdot(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const; //override;
 };
 
 #endif /* ONEDOFJOINT_H_ */

--- a/systems/plants/joints/HelicalJoint.cpp
+++ b/systems/plants/joints/HelicalJoint.cpp
@@ -12,7 +12,7 @@ HelicalJoint::~HelicalJoint()
   // empty
 }
 
-Isometry3d HelicalJoint::jointTransform(double* const q) const
+Isometry3d HelicalJoint::jointTransform(const Eigen::Ref<const VectorXd>& q) const
 {
   Isometry3d ret;
   ret = AngleAxisd(q[0], axis) * Translation3d(q[0] * pitch * axis);

--- a/systems/plants/joints/HelicalJoint.h
+++ b/systems/plants/joints/HelicalJoint.h
@@ -19,7 +19,7 @@ public:
 
   virtual ~HelicalJoint();
 
-  virtual Eigen::Isometry3d jointTransform(double* const q) const; //override;
+  virtual Eigen::Isometry3d jointTransform(const Eigen::Ref<const Eigen::VectorXd>& q) const; //override;
 
 private:
   static Eigen::Matrix<double, TWIST_SIZE, 1> spatialJointAxis(const Eigen::Vector3d& axis, double pitch);

--- a/systems/plants/joints/PrismaticJoint.cpp
+++ b/systems/plants/joints/PrismaticJoint.cpp
@@ -13,7 +13,7 @@ PrismaticJoint::~PrismaticJoint()
   // empty
 }
 
-Isometry3d PrismaticJoint::jointTransform(double* const q) const
+Isometry3d PrismaticJoint::jointTransform(const Eigen::Ref<const VectorXd>& q) const
 {
   Isometry3d ret;
   ret.linear().setIdentity();

--- a/systems/plants/joints/PrismaticJoint.h
+++ b/systems/plants/joints/PrismaticJoint.h
@@ -17,7 +17,7 @@ public:
 
   virtual ~PrismaticJoint();
 
-  virtual Eigen::Isometry3d jointTransform(double* const q) const; //override;
+  virtual Eigen::Isometry3d jointTransform(const Eigen::Ref<const Eigen::VectorXd>& q) const; //override;
 
 private:
   static Eigen::Matrix<double, TWIST_SIZE, 1> spatialJointAxis(const Eigen::Vector3d& translation_axis);

--- a/systems/plants/joints/QuaternionFloatingJoint.cpp
+++ b/systems/plants/joints/QuaternionFloatingJoint.cpp
@@ -67,7 +67,7 @@ void QuaternionFloatingJoint::qdot2v(const Eigen::Ref<const VectorXd>& q, Eigen:
 {
   qdot_to_v.resize(getNumVelocities(), getNumPositions());
 
-  auto quat = q.template middleRows<QUAT_SIZE>(SPACE_DIMENSION);
+  auto quat = q.middleRows<QUAT_SIZE>(SPACE_DIMENSION);
   Matrix3d R = quat2rotmat(quat);
 
   Vector4d quattilde;
@@ -104,7 +104,7 @@ void QuaternionFloatingJoint::v2qdot(const Eigen::Ref<const VectorXd>& q, Eigen:
 {
   v_to_qdot.resize(getNumPositions(), getNumVelocities());
 
-  auto quat = q.template middleRows<QUAT_SIZE>(SPACE_DIMENSION);
+  auto quat = q.middleRows<QUAT_SIZE>(SPACE_DIMENSION);
   Matrix3d R = quat2rotmat(quat);
 
   Matrix<double, QUAT_SIZE, SPACE_DIMENSION> M;

--- a/systems/plants/joints/QuaternionFloatingJoint.cpp
+++ b/systems/plants/joints/QuaternionFloatingJoint.cpp
@@ -16,7 +16,7 @@ QuaternionFloatingJoint::~QuaternionFloatingJoint()
   // empty
 }
 
-Isometry3d QuaternionFloatingJoint::jointTransform(double* const q) const
+Isometry3d QuaternionFloatingJoint::jointTransform(const Eigen::Ref<const VectorXd>& q) const
 {
   Isometry3d ret(Quaterniond(q[3], q[4], q[5], q[6]));
   ret.translation() << q[0], q[1], q[2];
@@ -24,7 +24,7 @@ Isometry3d QuaternionFloatingJoint::jointTransform(double* const q) const
   return ret;
 }
 
-void QuaternionFloatingJoint::motionSubspace(double* const q, MotionSubspaceType& motion_subspace, MatrixXd* dmotion_subspace) const
+void QuaternionFloatingJoint::motionSubspace(const Eigen::Ref<const VectorXd>& q, MotionSubspaceType& motion_subspace, MatrixXd* dmotion_subspace) const
 {
   motion_subspace.setIdentity(TWIST_SIZE, getNumVelocities());
   if (dmotion_subspace) {
@@ -32,7 +32,7 @@ void QuaternionFloatingJoint::motionSubspace(double* const q, MotionSubspaceType
   }
 }
 
-void QuaternionFloatingJoint::motionSubspaceDotTimesV(double* const q, double* const v,
+void QuaternionFloatingJoint::motionSubspaceDotTimesV(const Eigen::Ref<const VectorXd>& q, const Eigen::Ref<const VectorXd>& v,
     Vector6d& motion_subspace_dot_times_v,
     Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq,
     Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv) const
@@ -46,7 +46,7 @@ void QuaternionFloatingJoint::motionSubspaceDotTimesV(double* const q, double* c
   }
 }
 
-void QuaternionFloatingJoint::randomConfiguration(double* q, std::default_random_engine& generator) const
+void QuaternionFloatingJoint::randomConfiguration(Eigen::Ref<VectorXd>& q, std::default_random_engine& generator) const
 {
   normal_distribution<double> normal;
 
@@ -63,11 +63,11 @@ void QuaternionFloatingJoint::randomConfiguration(double* q, std::default_random
   q[6] = quat(3);
 }
 
-void QuaternionFloatingJoint::qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const
+void QuaternionFloatingJoint::qdot2v(const Eigen::Ref<const VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const
 {
   qdot_to_v.resize(getNumVelocities(), getNumPositions());
 
-  Map<Vector4d> quat(&q[3]);
+  auto quat = q.template middleRows<QUAT_SIZE>(SPACE_DIMENSION);
   Matrix3d R = quat2rotmat(quat);
 
   Vector4d quattilde;
@@ -100,11 +100,11 @@ void QuaternionFloatingJoint::qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eige
   qdot_to_v.block<3, 4>(3, 3).setZero();
 }
 
-void QuaternionFloatingJoint::v2qdot(double* q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const
+void QuaternionFloatingJoint::v2qdot(const Eigen::Ref<const VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const
 {
   v_to_qdot.resize(getNumPositions(), getNumVelocities());
 
-  Map<Vector4d> quat(&q[3]);
+  auto quat = q.template middleRows<QUAT_SIZE>(SPACE_DIMENSION);
   Matrix3d R = quat2rotmat(quat);
 
   Matrix<double, QUAT_SIZE, SPACE_DIMENSION> M;

--- a/systems/plants/joints/QuaternionFloatingJoint.h
+++ b/systems/plants/joints/QuaternionFloatingJoint.h
@@ -15,19 +15,19 @@ public:
 
   virtual ~QuaternionFloatingJoint();
 
-  virtual Eigen::Isometry3d jointTransform(double* const q) const; //override;
+  virtual Eigen::Isometry3d jointTransform(const Eigen::Ref<const Eigen::VectorXd>& q) const; //override;
 
-  virtual void motionSubspace(double* const q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace = nullptr) const; //override;
+  virtual void motionSubspace(const Eigen::Ref<const Eigen::VectorXd>& q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace = nullptr) const; //override;
 
-  virtual void motionSubspaceDotTimesV(double* const q, double* const v, Vector6d& motion_subspace_dot_times_v,
+  virtual void motionSubspaceDotTimesV(const Eigen::Ref<const Eigen::VectorXd>& q, const Eigen::Ref<const Eigen::VectorXd>& v, Vector6d& motion_subspace_dot_times_v,
       Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq = nullptr,
       Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv = nullptr) const; //override;
 
-  virtual void randomConfiguration(double* q, std::default_random_engine& generator) const; //override;
+  virtual void randomConfiguration(Eigen::Ref<Eigen::VectorXd>& q, std::default_random_engine& generator) const; //override;
 
-  virtual void qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const; //override;
+  virtual void qdot2v(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const; //override;
 
-  virtual void v2qdot(double* q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const; //override;
+  virtual void v2qdot(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const; //override;
 };
 
 #endif /* QUATERNIONFLOATINGJOINT_H_ */

--- a/systems/plants/joints/RevoluteJoint.cpp
+++ b/systems/plants/joints/RevoluteJoint.cpp
@@ -13,7 +13,7 @@ RevoluteJoint::~RevoluteJoint()
   // empty
 }
 
-Isometry3d RevoluteJoint::jointTransform(double* const q) const
+Isometry3d RevoluteJoint::jointTransform(const Eigen::Ref<const VectorXd>& q) const
 {
   Isometry3d ret(AngleAxisd(q[0], rotation_axis));
   ret.makeAffine();

--- a/systems/plants/joints/RevoluteJoint.h
+++ b/systems/plants/joints/RevoluteJoint.h
@@ -17,7 +17,7 @@ public:
 
   virtual ~RevoluteJoint();
 
-  virtual Eigen::Isometry3d jointTransform(double* const q) const; //override;
+  virtual Eigen::Isometry3d jointTransform(const Eigen::Ref<const Eigen::VectorXd>& q) const; //override;
 
 private:
   static Eigen::Matrix<double, TWIST_SIZE, 1> spatialJointAxis(const Eigen::Vector3d& rotation_axis);

--- a/systems/plants/joints/RollPitchYawFloatingJoint.cpp
+++ b/systems/plants/joints/RollPitchYawFloatingJoint.cpp
@@ -18,8 +18,8 @@ RollPitchYawFloatingJoint::~RollPitchYawFloatingJoint()
 Isometry3d RollPitchYawFloatingJoint::jointTransform(const Eigen::Ref<const VectorXd>& q) const
 {
   Isometry3d ret;
-  auto pos = q.template middleRows<SPACE_DIMENSION>(0);
-  auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
+  auto pos = q.middleRows<SPACE_DIMENSION>(0);
+  auto rpy = q.middleRows<RPY_SIZE>(SPACE_DIMENSION);
   ret.linear() = rpy2rotmat(rpy);
   ret.translation() = pos;
   ret.makeAffine();
@@ -29,7 +29,7 @@ Isometry3d RollPitchYawFloatingJoint::jointTransform(const Eigen::Ref<const Vect
 void RollPitchYawFloatingJoint::motionSubspace(const Eigen::Ref<const VectorXd>& q, MotionSubspaceType& motion_subspace, MatrixXd* dmotion_subspace) const
 {
   motion_subspace.resize(TWIST_SIZE, getNumVelocities());
-  auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
+  auto rpy = q.middleRows<RPY_SIZE>(SPACE_DIMENSION);
   Matrix<double,SPACE_DIMENSION,RPY_SIZE> E;
   rpydot2angularvelMatrix(rpy,E);
   auto R = rpy2rotmat(rpy);
@@ -65,17 +65,17 @@ void RollPitchYawFloatingJoint::motionSubspaceDotTimesV(const Eigen::Ref<const V
     Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv) const
 {
   motion_subspace_dot_times_v.resize(TWIST_SIZE, 1);
-  auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
+  auto rpy = q.middleRows<RPY_SIZE>(SPACE_DIMENSION);
   double roll = rpy(0);
   double pitch = rpy(1);
   double yaw = rpy(2);
 
-  auto pd = v.template middleRows<SPACE_DIMENSION>(0);
+  auto pd = v.middleRows<SPACE_DIMENSION>(0);
   double xd = pd(0);
   double yd = pd(1);
   double zd = pd(2);
 
-  auto rpyd = v.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
+  auto rpyd = v.middleRows<RPY_SIZE>(SPACE_DIMENSION);
   double rolld = rpyd(0);
   double pitchd = rpyd(1);
   double yawd = rpyd(2);

--- a/systems/plants/joints/RollPitchYawFloatingJoint.cpp
+++ b/systems/plants/joints/RollPitchYawFloatingJoint.cpp
@@ -15,21 +15,21 @@ RollPitchYawFloatingJoint::~RollPitchYawFloatingJoint()
   // empty
 }
 
-Isometry3d RollPitchYawFloatingJoint::jointTransform(double* const q) const
+Isometry3d RollPitchYawFloatingJoint::jointTransform(const Eigen::Ref<const VectorXd>& q) const
 {
   Isometry3d ret;
-  Map<Vector3d> pos(&q[0]);
-  Map<Vector3d> rpy(&q[3]);
+  auto pos = q.template middleRows<SPACE_DIMENSION>(0);
+  auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
   ret.linear() = rpy2rotmat(rpy);
   ret.translation() = pos;
   ret.makeAffine();
   return ret;
 }
 
-void RollPitchYawFloatingJoint::motionSubspace(double* const q, MotionSubspaceType& motion_subspace, MatrixXd* dmotion_subspace) const
+void RollPitchYawFloatingJoint::motionSubspace(const Eigen::Ref<const VectorXd>& q, MotionSubspaceType& motion_subspace, MatrixXd* dmotion_subspace) const
 {
   motion_subspace.resize(TWIST_SIZE, getNumVelocities());
-  Map<Vector3d> rpy(&q[3]);
+  auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
   Matrix<double,SPACE_DIMENSION,RPY_SIZE> E;
   rpydot2angularvelMatrix(rpy,E);
   auto R = rpy2rotmat(rpy);
@@ -41,7 +41,6 @@ void RollPitchYawFloatingJoint::motionSubspace(double* const q, MotionSubspaceTy
   if (dmotion_subspace) {
     dmotion_subspace->resize(motion_subspace.size(), getNumPositions());
 
-    // TODO: would be nicer to use setSubMatrixGradient etc. Need rpy2rotmat gradient output for that
     using namespace std;
     double roll = rpy(0);
     double pitch = rpy(1);
@@ -60,23 +59,23 @@ void RollPitchYawFloatingJoint::motionSubspace(double* const q, MotionSubspaceTy
   }
 }
 
-void RollPitchYawFloatingJoint::motionSubspaceDotTimesV(double* const q, double* const v,
+void RollPitchYawFloatingJoint::motionSubspaceDotTimesV(const Eigen::Ref<const VectorXd>& q, const Eigen::Ref<const VectorXd>& v,
     Vector6d& motion_subspace_dot_times_v,
     Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq,
     Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv) const
 {
   motion_subspace_dot_times_v.resize(TWIST_SIZE, 1);
-  Map<Vector3d> rpy(&q[3]);
+  auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
   double roll = rpy(0);
   double pitch = rpy(1);
   double yaw = rpy(2);
 
-  Map<Vector3d> pd(&v[0]);
+  auto pd = v.template middleRows<SPACE_DIMENSION>(0);
   double xd = pd(0);
   double yd = pd(1);
   double zd = pd(2);
 
-  Map<Vector3d> rpyd(&v[3]);
+  auto rpyd = v.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
   double rolld = rpyd(0);
   double pitchd = rpyd(1);
   double yawd = rpyd(2);
@@ -114,7 +113,7 @@ void RollPitchYawFloatingJoint::motionSubspaceDotTimesV(double* const q, double*
   }
 }
 
-void RollPitchYawFloatingJoint::randomConfiguration(double* q, std::default_random_engine& generator) const
+void RollPitchYawFloatingJoint::randomConfiguration(Eigen::Ref<VectorXd>& q, std::default_random_engine& generator) const
 {
   std::normal_distribution<double> normal;
 
@@ -127,7 +126,7 @@ void RollPitchYawFloatingJoint::randomConfiguration(double* q, std::default_rand
   rpy = uniformlyRandomRPY(generator);
 }
 
-void RollPitchYawFloatingJoint::qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const
+void RollPitchYawFloatingJoint::qdot2v(const Eigen::Ref<const VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const
 {
   qdot_to_v.setIdentity(getNumVelocities(), getNumPositions());
 
@@ -136,7 +135,7 @@ void RollPitchYawFloatingJoint::qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Ei
   }
 }
 
-void RollPitchYawFloatingJoint::v2qdot(double* q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const
+void RollPitchYawFloatingJoint::v2qdot(const Eigen::Ref<const VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const
 {
   v_to_qdot.setIdentity(getNumPositions(), getNumVelocities());
 

--- a/systems/plants/joints/RollPitchYawFloatingJoint.h
+++ b/systems/plants/joints/RollPitchYawFloatingJoint.h
@@ -16,19 +16,19 @@ public:
 
   virtual ~RollPitchYawFloatingJoint();
 
-  virtual Eigen::Isometry3d jointTransform(double* const q) const; //override;
+  virtual Eigen::Isometry3d jointTransform(const Eigen::Ref<const Eigen::VectorXd>& q) const; //override;
 
-  virtual void motionSubspace(double* const q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace = nullptr) const; //override;
+  virtual void motionSubspace(const Eigen::Ref<const Eigen::VectorXd>& q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace = nullptr) const; //override;
 
-  virtual void motionSubspaceDotTimesV(double* const q, double* const v, Vector6d& motion_subspace_dot_times_v,
+  virtual void motionSubspaceDotTimesV(const Eigen::Ref<const Eigen::VectorXd>& q, const Eigen::Ref<const Eigen::VectorXd>& v, Vector6d& motion_subspace_dot_times_v,
       Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq = nullptr,
       Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv = nullptr) const; //override;
 
-  virtual void randomConfiguration(double* q, std::default_random_engine& generator) const; //override;
+  virtual void randomConfiguration(Eigen::Ref<Eigen::VectorXd>& q, std::default_random_engine& generator) const; //override;
 
-  virtual void qdot2v(double* q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const; //override;
+  virtual void qdot2v(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const; //override;
 
-  virtual void v2qdot(double* q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const; //override;
+  virtual void v2qdot(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const; //override;
 };
 
 #endif /* ROLLPITCHYAWFLOATINGJOINT_H_ */

--- a/systems/plants/joints/test/testDrakeJointsmex.cpp
+++ b/systems/plants/joints/test/testDrakeJointsmex.cpp
@@ -75,12 +75,12 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 
     mxArray* joint_struct_out = mxCreateStructArray(1, dims, 0, nullptr);
 
-    Isometry3d joint_transform = joint->jointTransform(q.data());
+    Isometry3d joint_transform = joint->jointTransform(q);
     safelySetField(joint_struct_out, "joint_transform", eigenToMatlab(joint_transform.matrix()));
 
     DrakeJoint::MotionSubspaceType motion_subspace;
     MatrixXd dmotion_subspace;
-    joint->motionSubspace(q.data(), motion_subspace, &dmotion_subspace);
+    joint->motionSubspace(q, motion_subspace, &dmotion_subspace);
     safelySetField(joint_struct_out, "motion_subspace", eigenToMatlab(motion_subspace));
     safelySetField(joint_struct_out, "dmotion_subspace", eigenToMatlab(dmotion_subspace));
 
@@ -89,7 +89,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
     Gradient<Vector6d, Eigen::Dynamic>::type dmotion_subspace_dot_times_vdq;
     Gradient<Vector6d, Eigen::Dynamic>::type dmotion_subspace_dot_times_vdv;
 
-    joint->motionSubspaceDotTimesV(q.data(), v.data(), motion_subspace_dot_times_v,
+    joint->motionSubspaceDotTimesV(q, v, motion_subspace_dot_times_v,
         &dmotion_subspace_dot_times_vdq,
         &dmotion_subspace_dot_times_vdv);
     safelySetField(joint_struct_out, "motion_subspace_dot_times_v", eigenToMatlab(motion_subspace_dot_times_v));
@@ -98,13 +98,13 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 
     MatrixXd qdot_to_v;
     MatrixXd dqdot_to_v;
-    joint->qdot2v(q.data(), qdot_to_v, &dqdot_to_v);
+    joint->qdot2v(q, qdot_to_v, &dqdot_to_v);
     safelySetField(joint_struct_out, "qdot_to_v", eigenToMatlab(qdot_to_v));
     safelySetField(joint_struct_out, "dqdot_to_v", eigenToMatlab(dqdot_to_v));
 
     MatrixXd v_to_qdot;
     MatrixXd dv_to_qdot;
-    joint->v2qdot(q.data(), v_to_qdot, &dv_to_qdot);
+    joint->v2qdot(q, v_to_qdot, &dv_to_qdot);
     safelySetField(joint_struct_out, "v_to_qdot", eigenToMatlab(v_to_qdot));
     safelySetField(joint_struct_out, "dv_to_qdot", eigenToMatlab(dv_to_qdot));
 

--- a/systems/plants/test/debugManipulatorDynamics.cpp
+++ b/systems/plants/test/debugManipulatorDynamics.cpp
@@ -38,7 +38,7 @@ int main()
   VectorXd q = VectorXd::Random(model->num_positions);
   VectorXd v = VectorXd::Random(model->num_velocities);
   model->use_new_kinsol = true;
-  model->doKinematicsNew(q.data(), true, v.data(), true);
+  model->doKinematicsNew(q, v, true, true);
 
 
   auto points = Matrix<double, 3, Eigen::Dynamic>::Random(3, 5).eval();

--- a/systems/plants/test/testManipulatorDynamics.m
+++ b/systems/plants/test/testManipulatorDynamics.m
@@ -139,10 +139,10 @@ v = randn(robot.getNumVelocities(), 1);
 [H_mex, C_mex, B_mex, dH_mex, dC_mex, dB_mex] = manipulatorDynamics(robot, q, v, true);
 
 valuecheck(H_mex, H);
-% valuecheck(C_mex, C);
+valuecheck(C_mex, C);
 valuecheck(B_mex, B);
 valuecheck(dH_mex, dH);
-% valuecheck(dC_mex, dC);
+valuecheck(dC_mex, dC);
 valuecheck(dB_mex, dB);
 end
 

--- a/systems/plants/test/testManipulatorDynamics.m
+++ b/systems/plants/test/testManipulatorDynamics.m
@@ -39,6 +39,8 @@ C_check = [...
   cross(twist_omega, m * twist_v) - m * gravity_body];
 valuecheck(C, C_check);
 valuecheck([nv 0], size(B));
+
+checkMex(r);
 end
 
 function testActuatedPendulum()
@@ -137,10 +139,10 @@ v = randn(robot.getNumVelocities(), 1);
 [H_mex, C_mex, B_mex, dH_mex, dC_mex, dB_mex] = manipulatorDynamics(robot, q, v, true);
 
 valuecheck(H_mex, H);
-valuecheck(C_mex, C);
+% valuecheck(C_mex, C);
 valuecheck(B_mex, B);
 valuecheck(dH_mex, dH);
-valuecheck(dC_mex, dC);
+% valuecheck(dC_mex, dC);
 valuecheck(dB_mex, dB);
 end
 

--- a/systems/plants/test/urdf_manipulator_dynamics_test.cpp
+++ b/systems/plants/test/urdf_manipulator_dynamics_test.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
       sscanf(argv[2 + model->num_positions + i], "%lf", &v(i));
   }
 
-  model->doKinematicsNew(q.data(), true, v.data(), true);
+  model->doKinematicsNew(q, v, true, true);
 
   auto H = model->massMatrix<double>();
   cout << H.value() << endl;

--- a/util/drakeGeometryUtil.cpp
+++ b/util/drakeGeometryUtil.cpp
@@ -1041,9 +1041,15 @@ template DLLEXPORT void normalizeVec(
     Gradient<Vector4d, 4, 1>::type*,
     Gradient<Vector4d, 4, 2>::type*);
 
+template DLLEXPORT void normalizeVec(
+    const MatrixBase< Eigen::Block<Eigen::Ref<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 0, Eigen::InnerStride<1> > const, 4, 1, false> >& x,
+    Vector4d& x_norm,
+    Gradient<Vector4d, 4, 1>::type*,
+    Gradient<Vector4d, 4, 2>::type*);
 
 template DLLEXPORT Vector4d quat2axis(const MatrixBase<Vector4d>&);
 template DLLEXPORT Matrix3d quat2rotmat(const MatrixBase<Vector4d>& q);
+template DLLEXPORT Matrix3d quat2rotmat(const MatrixBase<Eigen::Block<Eigen::Ref<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 0, Eigen::InnerStride<1> > const, 4, 1, false> >& q);
 template DLLEXPORT Vector3d quat2rpy(const MatrixBase<Vector4d>&);
 
 template DLLEXPORT Vector4d axis2quat(const MatrixBase<Vector4d>&);
@@ -1060,6 +1066,7 @@ template DLLEXPORT GradientVar<double, Eigen::Dynamic, 1> rotmat2Representation(
 template DLLEXPORT Vector4d rpy2axis(const Eigen::MatrixBase<Vector3d>&);
 template DLLEXPORT Vector4d rpy2quat(const Eigen::MatrixBase<Vector3d>&);
 template DLLEXPORT Matrix3d rpy2rotmat(const Eigen::MatrixBase<Vector3d>&);
+template DLLEXPORT Matrix3d rpy2rotmat(const Eigen::MatrixBase<Eigen::Block<Eigen::Ref<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 0, Eigen::InnerStride<1> > const, 3, 1, false>>&);
 
 template DLLEXPORT Vector4d quat2axis(const MatrixBase< Map<Vector4d> >&);
 template DLLEXPORT Matrix3d quat2rotmat(const MatrixBase< Map<Vector4d> >& q);
@@ -1137,6 +1144,7 @@ template DLLEXPORT Eigen::Matrix<double, TWIST_SIZE, Eigen::Dynamic> dCrossSpati
 
 template DLLEXPORT Gradient<Matrix3d, QUAT_SIZE>::type dquat2rotmat(const Eigen::MatrixBase<Vector4d>&);
 template DLLEXPORT Gradient<Matrix3d, QUAT_SIZE>::type dquat2rotmat(const Eigen::MatrixBase< Map<Vector4d> >&);
+template DLLEXPORT Gradient<Matrix3d, QUAT_SIZE>::type dquat2rotmat(const Eigen::MatrixBase<Eigen::Block<Eigen::Ref<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 0, Eigen::InnerStride<1> > const, 4, 1, false> >&);
 
 template DLLEXPORT Gradient<Vector3d, Dynamic>::type drotmat2rpy(
     const Eigen::MatrixBase<Matrix3d>&,
@@ -1250,6 +1258,9 @@ template DLLEXPORT void angularvel2quatdotMatrix(const Eigen::MatrixBase<Vector4
 template DLLEXPORT void angularvel2quatdotMatrix(const Eigen::MatrixBase<Map<Vector4d>>& q,
     Eigen::MatrixBase< Matrix<double, QUAT_SIZE, SPACE_DIMENSION> >& M,
     Eigen::MatrixBase< Gradient<Matrix<double, QUAT_SIZE, SPACE_DIMENSION>, QUAT_SIZE, 1>::type>* dM);
+template DLLEXPORT void angularvel2quatdotMatrix(const Eigen::MatrixBase< Eigen::Block<Eigen::Ref<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 0, Eigen::InnerStride<1> > const, 4, 1, false> >& q,
+    Eigen::MatrixBase< Matrix<double, QUAT_SIZE, SPACE_DIMENSION> >& M,
+    Eigen::MatrixBase< Gradient<Matrix<double, QUAT_SIZE, SPACE_DIMENSION>, QUAT_SIZE, 1>::type>* dM);
 
 template DLLEXPORT void angularvel2rpydotMatrix(const Eigen::MatrixBase<Vector3d>& rpy,
     Eigen::MatrixBase< Matrix<double, RPY_SIZE, SPACE_DIMENSION> >& phi,
@@ -1267,6 +1278,9 @@ template DLLEXPORT void rpydot2angularvelMatrix(const Eigen::MatrixBase<Vector3d
 template DLLEXPORT void rpydot2angularvelMatrix(const Eigen::MatrixBase<Map<Vector3d>>& rpy,
     Eigen::MatrixBase<Eigen::Matrix<double, SPACE_DIMENSION, RPY_SIZE> >& E,
     Gradient<Matrix<double,SPACE_DIMENSION,RPY_SIZE>,RPY_SIZE,1>::type* dE);
+template DLLEXPORT void rpydot2angularvelMatrix(const Eigen::MatrixBase< Eigen::Block<Eigen::Ref<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 0, Eigen::InnerStride<1> > const, 3, 1, false> >& rpy,
+    Eigen::MatrixBase<Eigen::Matrix<double, SPACE_DIMENSION, RPY_SIZE> >& E,
+    Gradient<Matrix<double,SPACE_DIMENSION,RPY_SIZE>,RPY_SIZE,1>::type* dE);
 
 template DLLEXPORT GradientVar<double, Eigen::Dynamic, SPACE_DIMENSION> angularvel2RepresentationDotMatrix(
     int rotation_type, const Eigen::MatrixBase<VectorXd>& qrot, int gradient_order);
@@ -1277,5 +1291,8 @@ template DLLEXPORT void quatdot2angularvelMatrix(const Eigen::MatrixBase<Vector4
     Eigen::MatrixBase< Matrix<double, SPACE_DIMENSION, QUAT_SIZE> >& M,
     Gradient<Matrix<double, SPACE_DIMENSION, QUAT_SIZE>, QUAT_SIZE, 1>::type* dM);
 template DLLEXPORT void quatdot2angularvelMatrix(const Eigen::MatrixBase<Map<Vector4d>>& q,
+    Eigen::MatrixBase< Matrix<double, SPACE_DIMENSION, QUAT_SIZE> >& M,
+    Gradient<Matrix<double, SPACE_DIMENSION, QUAT_SIZE>, QUAT_SIZE, 1>::type* dM);
+template DLLEXPORT void quatdot2angularvelMatrix(const Eigen::MatrixBase< Eigen::Block<Eigen::Ref<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 0, Eigen::InnerStride<1> > const, 4, 1, false> >& q,
     Eigen::MatrixBase< Matrix<double, SPACE_DIMENSION, QUAT_SIZE> >& M,
     Gradient<Matrix<double, SPACE_DIMENSION, QUAT_SIZE>, QUAT_SIZE, 1>::type* dM);

--- a/util/drakeGradientUtil.cpp
+++ b/util/drakeGradientUtil.cpp
@@ -190,6 +190,8 @@ MAKE_MATGRADMULT_BLOCK_B_EXPLICIT_INSTANTIATION(double, Eigen::Dynamic, Eigen::D
 MAKE_MATGRADMULT_BLOCK_B_EXPLICIT_INSTANTIATION(double, Eigen::Dynamic, Eigen::Dynamic, 6, 1, 3, 1, false)
 #undef MAKE_MATGRADMULT_EXPLICIT_INSTANTIATION
 
+template DLLEXPORT MatGradMult<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Block<Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> > const, -1, 1, false> >::type matGradMult<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Block<Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> > const, -1, 1, false> >(Eigen::MatrixBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> > const, -1, 1, false> > const&);
+
 #define MAKE_MATGRADMULT_TRANSPOSE_BLOCK_B_EXPLICIT_INSTANTIATION(Type, DARows, DACols, BRows, BCols, BBlockRows, BBlockCols, InnerPanel) \
     template DLLEXPORT MatGradMult<Eigen::Matrix<Type, DARows, DACols>, Eigen::Block< Eigen::Transpose< Eigen::Matrix<Type, BRows, BCols> > const, BBlockRows, BBlockCols, InnerPanel> >::type \
     matGradMult(const Eigen::MatrixBase< Eigen::Matrix<Type, DARows, DACols> >&, const Eigen::MatrixBase< Eigen::Block< Eigen::Transpose< Eigen::Matrix<Type, BRows, BCols> > const, BBlockRows, BBlockCols, InnerPanel> >&);


### PR DESCRIPTION
Had to use Eigen::Ref (http://eigen.tuxfamily.org/dox-devel/classEigen_1_1Ref.html) in the drakeJoint methods since you can't have templated virtual methods.