### PR TITLE
fixes lookup in findCollisionFilterGroupID

### DIFF
--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -2440,7 +2440,7 @@ classdef RigidBodyManipulator < Manipulator
     end
 
     function id = findCollisionFilterGroupID(model,collision_fg_name)
-        id = uint16(find(~cellfun(@isempty,strfind(model.collision_filter_groups.keys(),collision_fg_name))));
+        id = uint16(find(strcmp(model.collision_filter_groups.keys(),collision_fg_name)));
         if isempty(id)
           error('RigidBodyManipulator:findCollisionFilterGroupID', ...
                 'Unable to find collision filter group, %s',collision_fg_name);


### PR DESCRIPTION
Changes the lookup in findCollisionFilterGroupID method of RigidBodyManipulator to require an exact name match, rather than just a substring.

The reason for this change is that if you had collision filter groups named 'ground' and 'ignores_ground' then, depending on the order in which they were added to the RBM, when you called findCollisionFilterGroupID('ground') you would get returned the index for 'ignores_ground' instead. This can produce very strange collision detection behavior.

@hongkai-dai could you review this