### PR TITLE
MotionPlanningTree/extend returns TRAPPED if distance to sample point increases

### DIFF
--- a/solvers/MotionPlanningTree.m
+++ b/solvers/MotionPlanningTree.m
@@ -227,16 +227,16 @@ classdef MotionPlanningTree
 
     function [obj, status, id_new] = extend(obj, q)
       [obj, q_new, id_near] = newPoint(obj, q);
-      if ~isempty(q_new)
+      if isempty(q_new) || obj.distanceMetric(q_new, q) > obj.distanceMetric(obj.getVertex(obj.getParentId(id_near)), q)
+        id_new = [];
+        status = obj.TRAPPED;
+      else
         [obj, id_new] = obj.addVertex(q_new, id_near);
         if q_new == q
           status = obj.REACHED;
         else
           status = obj.ADVANCED;
         end
-      else
-        id_new = [];
-        status = obj.TRAPPED;
       end
     end
 


### PR DESCRIPTION
This addresses mitdrc/drc#1122 in which TaskSpaceMotionPlanning tree could get stuck during smoothing due to tolerances in the IK portion of extend. Now, after generating a new candidate point we check whether it's closer to the sample point than the nearest neighbor in the tree was. If not, then we're trapped.