### PR TITLE
Adds Joint Limit Constraints to C++ RBM

### DIFF
--- a/systems/plants/CMakeLists.txt
+++ b/systems/plants/CMakeLists.txt
@@ -77,6 +77,7 @@ if (eigen3_FOUND)
   add_rbm_mex(forwardJacDotTimesVmex)
   add_rbm_mex(contactConstraintsmex)
   add_rbm_mex(surfaceTangentsmex)
+  add_rbm_mex(jointLimitConstraintsmex)
 
   include_directories( constraint )
   add_library(drakeIKoptions SHARED IKoptions.cpp)

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -10,7 +10,7 @@
 #include <regex>
 #include <stdexcept>
 #include <limits>
-
+#include <float.h>
 //DEBUG
 //#include <stdexcept>
 //END_DEBUG
@@ -267,9 +267,15 @@ void getFiniteIndexes(T const & v, std::vector<int> &finite_indexes)
   const size_t n = v.size();
   for (size_t x = 0; x < n; x++)
   {
+    #if defined(WIN32) || defined(WIN64)
+    if (_finite(static_cast<double>(v[x]))) {
+      finite_indexes.push_back(x);
+    }
+    #else
     if (isfinite(static_cast<double>(v[x]))) {
       finite_indexes.push_back(x);
     }
+    #endif
   }
 }
 

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -10,7 +10,7 @@
 #include <regex>
 #include <stdexcept>
 #include <limits>
-#include <float.h>
+#include "drakeFloatingPointUtil.h" //for isFinite
 //DEBUG
 //#include <stdexcept>
 //END_DEBUG
@@ -267,15 +267,9 @@ void getFiniteIndexes(T const & v, std::vector<int> &finite_indexes)
   const size_t n = v.size();
   for (size_t x = 0; x < n; x++)
   {
-    #if defined(WIN32) || defined(WIN64)
-    if (_finite(static_cast<double>(v[x]))) {
+    if (isFinite<double>(static_cast<double>(v[x]))) {
       finite_indexes.push_back(x);
     }
-    #else
-    if (isfinite(static_cast<double>(v[x]))) {
-      finite_indexes.push_back(x);
-    }
-    #endif
   }
 }
 

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -1,9 +1,7 @@
 #include <iostream>
 #include <map>
 
-//#include "mex.h"
 #include "drakeGeometryUtil.h"
-//#include "drakeContactConstraintsUtil.h"
 #include "RigidBodyManipulator.h"
 #include "DrakeJoint.h"
 
@@ -262,7 +260,18 @@ void rotz(double theta, Matrix3d &M, Matrix3d &dM, Matrix3d &ddM)
   ddM << -c,s,0, -s,-c,0, 0,0,0;
 }
 
-
+template <typename T>
+void getFiniteIndexes(T const & v, std::vector<int> &finite_indexes)
+{
+  finite_indexes.clear();
+  const size_t n = v.size();
+  for (size_t x = 0; x < n; x++)
+  {
+    if (!std::isinf(static_cast<double>(v[x]))) {
+      finite_indexes.push_back(x);
+    }
+  }
+}
 
 
 RigidBodyManipulator::RigidBodyManipulator(int ndof, int num_featherstone_bodies, int num_rigid_body_objects, int num_rigid_body_frames)
@@ -2962,6 +2971,46 @@ GradientVar<Scalar, Eigen::Dynamic, 1> RigidBodyManipulator::positionConstraints
   return ret;
 }
 
+template <typename DerivedA, typename DerivedB, typename DerivedC>
+void RigidBodyManipulator::jointLimitConstraints(MatrixBase<DerivedA> const & q, MatrixBase<DerivedB> &phi, MatrixBase<DerivedC> &J) const 
+{
+  std::vector<int> finite_min_index;
+  std::vector<int> finite_max_index;
+
+  getFiniteIndexes(joint_limit_min, finite_min_index);
+  getFiniteIndexes(joint_limit_max, finite_max_index);
+
+  const int numFiniteMin = finite_min_index.size();
+  const int numFiniteMax = finite_max_index.size();
+
+  phi = VectorXd::Zero(numFiniteMin + numFiniteMax);
+  J = MatrixXd::Zero(phi.size(), num_positions);
+  for (int i = 0; i < numFiniteMin; i++)
+  {
+    const int fi = finite_min_index[i];
+    phi[i] = q[fi] - joint_limit_min[fi];
+    J(i, fi) = 1.0;
+  }
+  
+  for (int i = 0; i < numFiniteMax; i++)
+  {
+    const int fi = finite_max_index[i];
+    phi[i + numFiniteMin] = joint_limit_max[fi] - q[fi];
+    J(i + numFiniteMin, fi) = -1.0;
+  }
+}
+
+size_t RigidBodyManipulator::getNumJointLimitConstraints() const
+{
+  std::vector<int> finite_min_index;
+  std::vector<int> finite_max_index;
+
+  getFiniteIndexes(joint_limit_min, finite_min_index);
+  getFiniteIndexes(joint_limit_max, finite_max_index);
+
+  return finite_min_index.size() + finite_max_index.size();
+}
+
 // explicit instantiations (required for linking):
 template DLLEXPORT_RBM void RigidBodyManipulator::doKinematics(MatrixBase<VectorXd>  &, bool);
 template DLLEXPORT_RBM void RigidBodyManipulator::doKinematics(MatrixBase< Map<VectorXd> >  &, bool);
@@ -3034,3 +3083,6 @@ template DLLEXPORT_RBM void RigidBodyManipulator::HandC(MatrixBase< Map<VectorXd
 template DLLEXPORT_RBM void RigidBodyManipulator::HandC(MatrixBase< Map<VectorXd> > const &, MatrixBase< Map<VectorXd> > const &, MatrixBase< MatrixXd > * const, MatrixBase< MatrixXd > &, MatrixBase< VectorXd > &, MatrixBase< MatrixXd > *, MatrixBase< MatrixXd > *, MatrixBase< MatrixXd > * const);
 
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::positionConstraints(int);
+
+template DLLEXPORT_RBM void RigidBodyManipulator::jointLimitConstraints(MatrixBase<VectorXd> const &, MatrixBase<VectorXd> &, MatrixBase<MatrixXd> &) const ;
+template DLLEXPORT_RBM void RigidBodyManipulator::jointLimitConstraints(MatrixBase< Map<VectorXd> > const &, MatrixBase<VectorXd> &, MatrixBase<MatrixXd> &) const ;

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -3086,3 +3086,4 @@ template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulat
 
 template DLLEXPORT_RBM void RigidBodyManipulator::jointLimitConstraints(MatrixBase<VectorXd> const &, MatrixBase<VectorXd> &, MatrixBase<MatrixXd> &) const ;
 template DLLEXPORT_RBM void RigidBodyManipulator::jointLimitConstraints(MatrixBase< Map<VectorXd> > const &, MatrixBase<VectorXd> &, MatrixBase<MatrixXd> &) const ;
+template DLLEXPORT_RBM void RigidBodyManipulator::jointLimitConstraints(MatrixBase< Map<VectorXd> > const &, MatrixBase< Map<VectorXd> > &, MatrixBase< Map<MatrixXd> > &) const ;

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -267,7 +267,7 @@ void getFiniteIndexes(T const & v, std::vector<int> &finite_indexes)
   const size_t n = v.size();
   for (size_t x = 0; x < n; x++)
   {
-    if (!std::isinf(static_cast<double>(v[x]))) {
+    if (isfinite(static_cast<double>(v[x]))) {
       finite_indexes.push_back(x);
     }
   }

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -5,7 +5,7 @@
 #include <Eigen/LU>
 #include <set>
 #include <map>
-#include <Eigen/StdVector> //#include <vector>
+#include <Eigen/StdVector> 
 
 #include "collision/DrakeCollision.h"
 #include "KinematicPath.h"
@@ -110,6 +110,11 @@ public:
   template <typename Derived>
   void getCOM(MatrixBase<Derived> &com,const std::set<int> &robotnum = RigidBody::defaultRobotNumSet);
 
+  template <typename DerivedA, typename DerivedB, typename DerivedC>
+  void jointLimitConstraints(MatrixBase<DerivedA> const & q, MatrixBase<DerivedB> &phi, MatrixBase<DerivedC> &J) const;
+
+  size_t getNumJointLimitConstraints() const;
+
   template <typename Derived>
   void getCOMJac(MatrixBase<Derived> &J,const std::set<int> &robotnum = RigidBody::defaultRobotNumSet);
 
@@ -122,13 +127,13 @@ public:
   int getNumContacts(const std::set<int> &body_idx);// = emptyIntSet);
 
   template <typename Derived>
-    void getContactPositions(MatrixBase<Derived> &pos, const std::set<int> &body_idx);// = emptyIntSet);
+  void getContactPositions(MatrixBase<Derived> &pos, const std::set<int> &body_idx);// = emptyIntSet);
 
   template <typename Derived>
-    void getContactPositionsJac(MatrixBase<Derived> &J, const std::set<int> &body_idx);// = emptyIntSet);
+  void getContactPositionsJac(MatrixBase<Derived> &J, const std::set<int> &body_idx);// = emptyIntSet);
 
   template <typename Derived>
-    void getContactPositionsJacDot(MatrixBase<Derived> &Jdot, const std::set<int> &body_idx);// = emptyIntSet);
+  void getContactPositionsJacDot(MatrixBase<Derived> &Jdot, const std::set<int> &body_idx);// = emptyIntSet);
 
   void findAncestorBodies(std::vector<int>& ancestor_bodies, int body);
 

--- a/systems/plants/jointLimitConstraintsmex.cpp
+++ b/systems/plants/jointLimitConstraintsmex.cpp
@@ -1,0 +1,32 @@
+#include "mex.h"
+#include "drakeUtil.h"
+#include "RigidBodyManipulator.h"
+
+using namespace Eigen;
+using namespace std;
+
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) 
+{
+  if (nrhs < 2 || nlhs < 2) {
+    mexErrMsgIdAndTxt("Drake:jointLimitConstraintsmex:InvalidCall","Usage: [phi, J] = jointLimitConstraintsmex(mex_model_ptr, q) ");
+  }
+
+  RigidBodyManipulator *model= (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
+  
+  if (mxGetNumberOfElements(prhs[1]) != model->num_positions) {
+    mexErrMsgIdAndTxt("Drake:jointLimitConstraintsmex:InvalidPositionVectorLength", "q contains the wrong number of elements");
+  }
+
+  Map<VectorXd> q(mxGetPr(prhs[1]),model->num_positions);
+  
+  size_t numJointConstraints = model->getNumJointLimitConstraints();
+
+  plhs[0] = mxCreateDoubleMatrix(numJointConstraints, 1, mxREAL);
+  plhs[1] = mxCreateDoubleMatrix(numJointConstraints, model->num_positions, mxREAL);
+
+  Map<VectorXd> phi(mxGetPr(plhs[0]), numJointConstraints);
+  Map<MatrixXd> J(mxGetPr(plhs[1]), numJointConstraints, model->num_positions);
+
+  model->jointLimitConstraints(q, phi, J);
+}
+

--- a/systems/plants/test/testJointLimitConstraintsmex.m
+++ b/systems/plants/test/testJointLimitConstraintsmex.m
@@ -1,0 +1,41 @@
+function testJointLimitConstraintsmex
+
+%build an atlas model 
+robot = createAtlas('rpy');
+if robot.mex_model_ptr == 0
+  disp('testJointLimitConstraintsmex: no mex model pointer... nothing to test');
+  return;
+end
+
+%random initial pose
+q = getRandomConfiguration(robot);
+
+%get c++ jointLimitConstraints
+[phi_mex, J_mex] = jointLimitConstraintsmex(robot.mex_model_ptr, q);
+
+
+%get matlab jointLimitConstraints
+[phi, J] = robot.jointLimitConstraints(q);
+
+valuecheck(phi_mex, phi);
+valuecheck(J_mex, J);
+
+%also test the case where only some joints have limits
+robot = RigidBodyManipulator(fullfile('../../../examples/Atlas/urdf/robotiq_tendons.urdf'));
+
+x0 = robot.getInitialState;
+q = x0(1:robot.num_positions);
+
+%get c++ jointLimitConstraints
+[phi_mex, J_mex] = jointLimitConstraintsmex(robot.mex_model_ptr, q);
+
+
+%get matlab jointLimitConstraints
+[phi, J] = robot.jointLimitConstraints(q);
+
+valuecheck(phi_mex, phi);
+valuecheck(J_mex, J);
+
+
+end
+


### PR DESCRIPTION
This brings the ability to compute joint limit constraints and their Jacobian into c++.  There's also a mex wrapper for it and a unit test to compare functionality with the matlab implementation.  This is another piece that will be needed for building the time stepping LCP problem purely in mex.