### PR TITLE
Remove unused 'addCollisionElement' functions

### DIFF
--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -528,16 +528,6 @@ DrakeCollision::ElementId RigidBodyManipulator::addCollisionElement(const RigidB
   return id;
 }
 
-DrakeCollision::ElementId RigidBodyManipulator::addCollisionElement(DrakeShapes::Geometry& geometry, const shared_ptr<RigidBody>& body, const Matrix4d& T_element_to_link, string group_name)
-{
-  DrakeCollision::ElementId id(collision_model->addElement(unique_ptr<DrakeCollision::Element>(new RigidBody::CollisionElement(geometry, T_element_to_link, body))));
-  if (id != 0) {
-    body->collision_element_ids.push_back(id);
-    body->collision_element_groups[group_name].push_back(id);
-  }
-  return id;
-}
-
 void RigidBodyManipulator::updateCollisionElements(const shared_ptr<RigidBody>& body)
 {
   for (auto id_iter = body->collision_element_ids.begin(); 

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -198,8 +198,6 @@ public:
 
   DrakeCollision::ElementId addCollisionElement(const RigidBody::CollisionElement& element, const std::shared_ptr<RigidBody>& body, std::string group_name);
 
-  DrakeCollision::ElementId addCollisionElement(DrakeShapes::Geometry& geometry, const std::shared_ptr<RigidBody>& body, const Matrix4d& T_element_to_link, std::string group_name);
-
   void updateCollisionElements(const std::shared_ptr<RigidBody>& body);
 
   bool collisionRaycast(const Matrix3Xd &origins, const Matrix3Xd &ray_endpoints, VectorXd &distances, bool use_margins=false);

--- a/systems/plants/collision/Model.cpp
+++ b/systems/plants/collision/Model.cpp
@@ -15,17 +15,6 @@ namespace DrakeCollision
     return id;
   }
 
-  ElementId Model::addElement(std::unique_ptr<Element> element)
-  {
-    if (element != nullptr) {
-      ElementId id = element->getId();
-      this->elements.insert(make_pair(id, move(element)));
-      return id;
-    } else {
-      return 0;
-    }
-  }
-
   const Element* Model::readElement(ElementId id)
   {
     auto element_iter = elements.find(id);

--- a/systems/plants/collision/Model.h
+++ b/systems/plants/collision/Model.h
@@ -21,8 +21,6 @@ namespace DrakeCollision
 
       virtual ElementId addElement(const Element& element);
 
-      virtual ElementId addElement(std::unique_ptr<Element> element);
-
       virtual const Element* readElement(ElementId id);
 
       virtual void updateModel() {};

--- a/systems/plants/collision/test/ModelTest.cpp
+++ b/systems/plants/collision/test/ModelTest.cpp
@@ -67,9 +67,9 @@ int main()
 
   shared_ptr<Model> model = newModel();
   ElementId id1, id2, id3;
-  id1 = model->addElement(unique_ptr<Element>(new Element(DrakeShapes::Box(Vector3d(1,1,1)))));
-  id2 = model->addElement(unique_ptr<Element>(new Element(DrakeShapes::Sphere(0.5))));
-  id3 = model->addElement(unique_ptr<Element>(new Element(DrakeShapes::Sphere(0.5))));
+  id1 = model->addElement(Element(DrakeShapes::Box(Vector3d(1,1,1))));
+  id2 = model->addElement(Element(DrakeShapes::Sphere(0.5)));
+  id3 = model->addElement(Element(DrakeShapes::Sphere(0.5)));
   model->updateElementWorldTransform(id1, T_body1_to_world);
   model->updateElementWorldTransform(id2, T_body2_to_world);
   model->updateElementWorldTransform(id3, T_body3_to_world);


### PR DESCRIPTION
These were left in to keep code compiling during refactoring. They're no longer
needed.