### PR TITLE
Speed up updateCollisionElements

### DIFF
--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -312,8 +312,6 @@ RigidBodyManipulator::RigidBodyManipulator(void)
 
 RigidBodyManipulator::~RigidBodyManipulator(void)
 {
-  //  if (collision_model)
-  //    delete collision_model;
 }
 
 
@@ -458,7 +456,6 @@ void RigidBodyManipulator::compile(void)
 {
   /* todo:
    - set joint limits (from drakejoint to rbm)
-   - add collision elements (and don't add them before, e.g. in constructModelmex).. or update them here
    */
 
   // reorder body list to make sure that parents before children in the list
@@ -992,6 +989,9 @@ void RigidBodyManipulator::doKinematics(double* q, bool b_compute_second_derivat
     }
   }
 
+  // Have the collision model do any model-wide updates that it needs to
+  collision_model->updateModel();
+
   kinematicsInit = true;
   for (i = 0; i < num_positions; i++) {
     cached_q[i] = q[i];
@@ -1189,6 +1189,9 @@ void RigidBodyManipulator::doKinematicsNew(const MatrixBase<DerivedQ>& q, const 
       }
     }
   }
+
+  // Have the collision model do any model-wide updates that it needs to
+  collision_model->updateModel();
 
   kinematicsInit = true;
   cached_inertia_gradients_order = -1;

--- a/systems/plants/collision/BulletModel.cpp
+++ b/systems/plants/collision/BulletModel.cpp
@@ -223,12 +223,10 @@ namespace DrakeCollision
       auto bt_obj_no_margin_iter = bullet_world_no_margin.bt_collision_objects.find(id);
       if (bt_obj_iter != bullet_world.bt_collision_objects.end()) {
         bullet_world.bt_collision_objects.at(id)->setWorldTransform(btT);
-        bullet_world.bt_collision_world->updateAabbs();
       }
 
       if (bt_obj_no_margin_iter != bullet_world_no_margin.bt_collision_objects.end()) {
         bullet_world_no_margin.bt_collision_objects.at(id)->setWorldTransform(btT);
-        bullet_world_no_margin.bt_collision_world->updateAabbs();
       }
     }
     return element_exists;

--- a/systems/plants/collision/BulletModel.h
+++ b/systems/plants/collision/BulletModel.h
@@ -14,7 +14,7 @@ namespace DrakeCollision
 {
   class BulletModel;    // forward declaration
   
-  typedef std::map< ElementId, std::unique_ptr<btCollisionObject> > ElementToBtObjMap;
+  typedef std::unordered_map< ElementId, std::unique_ptr<btCollisionObject> > ElementToBtObjMap;
 
   struct OverlapFilterCallback : public btOverlapFilterCallback
   {

--- a/systems/plants/collision/Model.h
+++ b/systems/plants/collision/Model.h
@@ -2,7 +2,7 @@
 #define __DrakeCollisionModel_H__
 
 #include <memory>
-#include <map>
+#include <unordered_map>
 
 #include <Eigen/Dense>
 #include <Eigen/StdVector>
@@ -51,7 +51,7 @@ namespace DrakeCollision
       virtual bool collisionRaycast(const Eigen::Matrix3Xd &origin, const Eigen::Matrix3Xd &ray_endpoint, bool use_margins, Eigen::VectorXd &distances) { return false; };
 
     protected:
-      std::map< ElementId, std::unique_ptr<Element> >  elements;
+      std::unordered_map< ElementId, std::unique_ptr<Element> >  elements;
 
     private:
       Model(const Model&) {}


### PR DESCRIPTION
We were updating the AABBs in Bullet every time one of the elements had it's
transform updated. Now we do it once, by calling updateModel, after all of the
elements have been updated.

Also, the DrakeCollision::Model class now uses a `std::unordered_map` to store the collision elements, since we don't need an ordering there.

Also removes some unnecessary comments.