### PR TITLE
C++ Position Constraints w/o use_new_kinsol=true

### DIFF
--- a/systems/plants/CMakeLists.txt
+++ b/systems/plants/CMakeLists.txt
@@ -69,6 +69,7 @@ if (eigen3_FOUND)
   add_rbm_mex(contactConstraintsmex)
   add_rbm_mex(surfaceTangentsmex)
   add_rbm_mex(jointLimitConstraintsmex)
+  add_rbm_mex(positionConstraintsmex)
 
   include_directories( constraint )
   add_library(drakeIKoptions SHARED IKoptions.cpp)

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -3044,7 +3044,7 @@ void RigidBodyManipulator::positionConstraints(MatrixBase<DerivedA> & phi, Matri
   const size_t numConstraints = getNumPositionConstraints();
   phi = VectorXd::Zero(numConstraints);
   J = MatrixXd::Zero(numConstraints, nq);
-  Matrix<double, 7, 1> bTbp, bpTb, wTb;
+  Matrix<double, 7, 1> bpTb, wTb;
   
   Vector3d bodyA_pos;
   Vector4d ptA, origin_pt;
@@ -3053,33 +3053,27 @@ void RigidBodyManipulator::positionConstraints(MatrixBase<DerivedA> & phi, Matri
   Matrix4d dbTw_quat = dquatConjugate();
 
   for (size_t i = 0; i < numLoops; i++) {
-    bTbp << loops[i].ptB, 1.0, 0.0, 0.0, 0.0;
-    Vector4d bpTb_quat = quatConjugate(bTbp.block(3,0,4,1));
-    Vector3d bpTb_trans = quatRotateVec(bpTb_quat,-bTbp.block(0,0,3,1));
-    bpTb << bpTb_trans, bpTb_quat;
+    bpTb << -loops[i].ptB, 1.0, 0.0, 0.0, 0.0;
     ptA << loops[i].ptA, 1.0;
     forwardKin(loops[i].bodyA->body_index,ptA,0,bodyA_pos);
     forwardJac(loops[i].bodyA->body_index,ptA,0,JA);
     forwardKin(loops[i].bodyB->body_index,origin_pt,2,wTb);
     forwardJac(loops[i].bodyB->body_index,origin_pt,2,dwTb);
-    Vector4d bTw_quat = quatConjugate(wTb.block(3,0,4,1));
+    Vector4d bTw_quat = quatConjugate(wTb.tail<4>());
     MatrixXd dbTw_quatdq = dbTw_quat*dwTb.block(3,0,4,nq);
-    Vector3d bTw_trans = quatRotateVec(bTw_quat,-wTb.block(0,0,3,1));
-    Matrix<double,3,7> dbTw_trans = dquatRotateVec(bTw_quat,-wTb.block(0,0,3,1));
-    dbTw_transdq = dbTw_trans.block(0,0,3,4)*dbTw_quatdq-dbTw_trans.block(0,4,3,3)*dwTb.block(0,0,3,nq);
-    Vector3d bpTw_trans1 = quatRotateVec(bpTb.block(3,0,4,1),bTw_trans);
-    Matrix<double,3,7> dbpTw_trans1 = dquatRotateVec(bpTb.block(3,0,4,1),bTw_trans);
+    Vector3d bTw_trans = quatRotateVec(bTw_quat,-wTb.head<3>());
+    Matrix<double,3,7> dbTw_trans = dquatRotateVec(bTw_quat,-wTb.head<3>());
+    dbTw_transdq = dbTw_trans.block(0,0,3,4)*dbTw_quatdq-dbTw_trans.block(0,4,3,3)*dwTb.block(0,0,3,nq);    
+    Matrix<double,3,7> dbpTw_trans1 = dquatRotateVec(bpTb.tail<4>(),bTw_trans);
     MatrixXd dbpTw_trans1dq = dbpTw_trans1.block(0,4,3,3)*dbTw_transdq;
-    Vector3d bpTw_trans = bpTw_trans1+bpTb.block(0,0,3,1);
-    MatrixXd dbpTw_transdq = dbpTw_trans1dq;
-    Vector4d bpTw_quat = quatProduct(bpTb.block(3,0,4,1),bTw_quat);
-    Matrix<double,4,8> dbpTw_quat = dquatProduct(bpTb.block(3,0,4,1),bTw_quat);
+    Vector3d bpTw_trans = bTw_trans-loops[i].ptB;
+    Matrix<double,4,8> dbpTw_quat = dquatProduct(bpTb.tail<4>(),bTw_quat);
     MatrixXd dbpTw_quatdq = dbpTw_quat.block(0,4,4,4)*dbTw_quatdq;
-    Vector3d bp_bodyA_pos1 = quatRotateVec(bpTw_quat,bodyA_pos);
-    Matrix<double,3,7> dbp_bodyA_pos1 = dquatRotateVec(bpTw_quat,bodyA_pos);
+    Vector3d bp_bodyA_pos1 = quatRotateVec(bTw_quat,bodyA_pos);
+    Matrix<double,3,7> dbp_bodyA_pos1 = dquatRotateVec(bTw_quat,bodyA_pos);
     MatrixXd dbp_bodyA_pos1dq = dbp_bodyA_pos1.block(0,0,3,4)*dbpTw_quatdq+dbp_bodyA_pos1.block(0,4,3,3)*JA;
     phi.segment(3*i, 3) = bp_bodyA_pos1+bpTw_trans;
-    J.block(3*i, 0, 3, nq) = dbp_bodyA_pos1dq+dbpTw_transdq;
+    J.block(3*i, 0, 3, nq) = dbp_bodyA_pos1dq+dbpTw_trans1dq;
   }
 }
 

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -251,7 +251,12 @@ public:
   //@param body_or_frame_id   the index of the body or the id of the frame.
 
   template <typename Scalar>
-  GradientVar<Scalar, Eigen::Dynamic, 1> positionConstraints(int gradient_order);
+  GradientVar<Scalar, Eigen::Dynamic, 1> positionConstraintsNew(int gradient_order);
+
+  template <typename DerivedA, typename DerivedB>
+  void positionConstraints(Eigen::MatrixBase<DerivedA> & phi, Eigen::MatrixBase<DerivedB> & J);
+
+  size_t getNumPositionConstraints() const;
 
 public:
   std::vector<std::string> robot_name;

--- a/systems/plants/positionConstraintsmex.cpp
+++ b/systems/plants/positionConstraintsmex.cpp
@@ -1,0 +1,36 @@
+#include "mex.h"
+#include "drakeUtil.h"
+#include "RigidBodyManipulator.h"
+
+using namespace Eigen;
+using namespace std;
+
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) 
+{
+  if (nrhs < 2 || nlhs < 2) {
+    mexErrMsgIdAndTxt("Drake:positionConstraintsmex:InvalidCall","Usage: [phi, J] = positionConstraintsmex(mex_model_ptr, q) ");
+  }
+
+  RigidBodyManipulator *model= (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
+  
+  const size_t nq = model->num_positions;
+  
+  if (mxGetNumberOfElements(prhs[1]) != nq) {
+    mexErrMsgIdAndTxt("Drake:positionConstraintsmex:InvalidPositionVectorLength", "q contains the wrong number of elements");
+  }
+
+  Map<VectorXd> q(mxGetPr(prhs[1]),nq); 
+
+  model->doKinematics(q);
+
+  const size_t numPositionConstraints = model->getNumPositionConstraints();
+  
+  plhs[0] = mxCreateDoubleMatrix(numPositionConstraints, 1, mxREAL);
+  plhs[1] = mxCreateDoubleMatrix(numPositionConstraints, nq, mxREAL);
+
+  Map<VectorXd> phi(mxGetPr(plhs[0]), numPositionConstraints);
+  Map<MatrixXd> J(mxGetPr(plhs[1]), numPositionConstraints, nq);
+
+  model->positionConstraints(phi, J);  
+}
+

--- a/systems/plants/test/testPositionConstraintsmex.m
+++ b/systems/plants/test/testPositionConstraintsmex.m
@@ -1,8 +1,7 @@
 function testPositionConstraintsmex
 
-%create a robot with positions constraints
+%create a robot with a lot of positions constraints
 urdf = fullfile('../../../examples/Atlas/urdf/robotiq.urdf');
-%urdf = fullfile('../../../examples/SimpleFourBar/FourBar.urdf');
 robot = RigidBodyManipulator(urdf);
 robot_new = RigidBodyManipulator(urdf, struct('use_new_kinsol', true));
 
@@ -12,14 +11,16 @@ q = getRandomConfiguration(robot);
 robot.doKinematics(q);
 robot_new.doKinematics(q);
 
-%mex, old
+%mex
 [phi_mex, J_mex] = positionConstraintsmex(robot.mex_model_ptr, q); 
-%mex, new
+
+%mex, use_new_kinsol
 [phi_mex_new, J_mex_new] = positionConstraintsmex(robot_new.mex_model_ptr, q); 
 
-%matlab, old
+%matlab
 [phi, J] = robot.positionConstraints(q);
-%matlab, new
+
+%matlab, use_new_kinsol
 [phi_new, J_new] = robot_new.positionConstraints(q);
 
 %make sure every pair of implementations matches

--- a/systems/plants/test/testPositionConstraintsmex.m
+++ b/systems/plants/test/testPositionConstraintsmex.m
@@ -1,0 +1,39 @@
+function testPositionConstraintsmex
+
+%create a robot with positions constraints
+urdf = fullfile('../../../examples/Atlas/urdf/robotiq.urdf');
+%urdf = fullfile('../../../examples/SimpleFourBar/FourBar.urdf');
+robot = RigidBodyManipulator(urdf);
+robot_new = RigidBodyManipulator(urdf, struct('use_new_kinsol', true));
+
+%random initial pose
+q = getRandomConfiguration(robot);
+
+robot.doKinematics(q);
+robot_new.doKinematics(q);
+
+%mex, old
+[phi_mex, J_mex] = positionConstraintsmex(robot.mex_model_ptr, q); 
+%mex, new
+[phi_mex_new, J_mex_new] = positionConstraintsmex(robot_new.mex_model_ptr, q); 
+
+%matlab, old
+[phi, J] = robot.positionConstraints(q);
+%matlab, new
+[phi_new, J_new] = robot_new.positionConstraints(q);
+
+%make sure every pair of implementations matches
+valuecheck(phi_mex, phi_mex_new);
+valuecheck(phi_mex, phi);
+valuecheck(phi_mex, phi_new);
+valuecheck(phi_mex_new, phi);
+valuecheck(phi_mex_new, phi_new);
+valuecheck(phi, phi_new);
+valuecheck(J_mex, J_mex_new);
+valuecheck(J_mex, J);
+valuecheck(J_mex, J_new);
+valuecheck(J_mex_new, J);
+valuecheck(J_mex_new, J_new);
+valuecheck(J, J_new);
+end
+

--- a/systems/plants/test/urdfManipulatorDynamicsTest.cpp
+++ b/systems/plants/test/urdfManipulatorDynamicsTest.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
   cout << model->B << endl;
 
   if (model->loops.size()>0) {
-    auto phi = model->positionConstraints<double>(1);
+    auto phi = model->positionConstraintsNew<double>(1);
     cout << phi.value() << endl;
     cout << phi.gradient().value() << endl;
   }


### PR DESCRIPTION
This adds a c++ implementation of positionConstraints that works with both the old and new kinsols.  This will allow solveLCPmex to drop the dependency on use_new_kinsol.  There is also a mex wrapper that can replace any of the  (much slower)calls in matlab.  

The implementation is based on the code in drakeRigidBodyConstraint (thanks, @hongkai-dai )

A comprehensive unit test is included that compares all possible pairs of {matlab, mex} x {old_kinsol, new_kinsol}.

I also ran a quick test to see how they compare performance-wise.
![position_constraints](https://cloud.githubusercontent.com/assets/3849600/6740220/c81bb418-ce54-11e4-9d08-4e54bd3d29f2.png)
