### PR TITLE
removed inverseKin from the foot swing planner

### DIFF
--- a/systems/robotInterfaces/@Biped/planSwingPitched.m
+++ b/systems/robotInterfaces/@Biped/planSwingPitched.m
@@ -19,9 +19,6 @@ APEX_FRACTIONS = [0.15, 0.92]; % We plan only two poses of the foot during the a
 FOOT_YAW_RATE = 0.75; % rad/s
 FOOT_PITCH_RATE = 2*pi; % rad/s
 
-LATERAL_TOL = 1e-3; % Distance the sole can move to away from the line 
-                    % between step1 and step2
-
 MIN_DIST_FOR_TOE_OFF = 0.1; % minimum distance of *forward* progress for toe-off to be allowed.
                             % This disallows toe-off during backward stepping. 
                             % The distance is measured as the vector between the two swing poses
@@ -68,15 +65,6 @@ else
   toe_off_angle = 0;
 end
 
-% Create posture constraint
-xstar = biped.loadFixedPoint();
-xstar([1:2,6]) = stance.pos([1:2,6]);
-
-joint_position_indices = (7:biped.getNumPositions())';
-posture_constraint = PostureConstraint(biped);
-q_joints = xstar(joint_position_indices);
-posture_constraint = posture_constraint.setJointLimits(joint_position_indices, q_joints, q_joints);
-
 swing_body_index = biped.getFrame(swing1.frame_id).body_ind;
 stance_body_index = biped.getFrame(stance.frame_id).body_ind;
 swing_toe_points_in_foot = biped.getBody(swing_body_index).getTerrainContactPoints('toe');
@@ -99,31 +87,15 @@ toe2= mean(swing2_toe_points_in_world(1:3,:), 2);
 T_toe_local_to_world = [[rotmat(atan2(toe2(2) - toe1(2), toe2(1) - toe1(1))), [0;0];
                      0, 0, 1], toe1(1:3); 
                     0, 0, 0, 1];
-terrain_pts_in_toe_local = inv(T_toe_local_to_world) * T_local_to_world * [terrain_pts_in_local; ones(1, size(terrain_pts_in_local,2))];
-
-swing1_toe_points_in_toe_local = T_toe_local_to_world \ swing1_toe_points_in_world;
-swing2_toe_points_in_toe_local = T_toe_local_to_world \ swing2_toe_points_in_world;
+terrain_pts_in_toe_local = T_toe_local_to_world \ (T_local_to_world * [terrain_pts_in_local; ones(1, size(terrain_pts_in_local,2))]);
 
 quat_toe_off = rotmat2quat(rpy2rotmat(swing1.pos(4:6)) * rpy2rotmat([0;toe_off_angle;0]) / T_sole_to_foot(1:3,1:3));
 quat_swing2 = rotmat2quat(rpy2rotmat(swing2.pos(4:6)) / T_sole_to_foot(1:3,1:3));
-
-cost = Point(biped.getStateFrame(),1);
-cost.base_x = 0;
-cost.base_y = 0;
-cost.base_roll = 0;
-cost.base_pitch = 0;
-cost.base_yaw = 0;
-ikoptions = IKoptions(biped);
-ikoptions = ikoptions.setQ(diag(cost(1:biped.getNumPositions())));
-
-q_latest = xstar(1:biped.getNumPositions());
 
 if DEBUG
   v = biped.constructVisualizer();
   v.draw(0, q_latest);
 end
-
-quat_tol = 1e-6;
 
 T = biped.getFrame(stance.frame_id).T;
 stance_sole = [rpy2rotmat(stance.pos(4:6)), stance.pos(1:3); 0 0 0 1];
@@ -155,24 +127,6 @@ foot_origin_knots = struct('t', zmp_knots(end).t, ...
                            'is_landing', false,...
                            'toe_off_allowed', struct(swing_foot_name, swing_distance_in_local >= MIN_DIST_FOR_TOE_OFF, stance_foot_name, false));
 
-function [pose, q0] = solve_for_pose(constraints, q0)
-  [q0, info] = inverseKin(biped,q0,q0,constraints{:},ikoptions);
-  if info >= 10
-    % try again?
-    [q0, info] = inverseKin(biped,q0,q0,constraints{:},ikoptions);
-    if info < 10
-      warning('Whoa...tried inverseKin again and got a different result...');
-    else
-      error('Drake:planSwingPitched', 'The foot pose IK problem could not be solved. This should not happen and likely indicates a bug in the constraints.');
-    end
-  end
-  if DEBUG
-    v.draw(0, q0);
-  end
-  kinsol = biped.doKinematics(q0);
-  pose = biped.forwardKin(kinsol, swing_body_index, [0;0;0], 1);
-end
-
 function add_foot_origin_knot(swing_pose, speed)
   if nargin < 2
     speed = params.step_speed;
@@ -196,23 +150,13 @@ end
 % Apex knot 1
 max_terrain_ht = max(terrain_pts_in_toe_local(3,:));
 toe_ht_in_local = max_terrain_ht + params.step_height;
-toe_pos_in_local = interp1([0, 1], [mean(swing1_toe_points_in_toe_local, 2), mean(swing2_toe_points_in_toe_local, 2)]', APEX_FRACTIONS(1))';
-constraints = {posture_constraint,...
-               WorldQuatConstraint(biped, swing_body_index, quat_toe_off, quat_tol),...
-               WorldPositionInFrameConstraint(biped,swing_body_index,...
-                    mean(swing_toe_points_in_foot, 2), T_toe_local_to_world, [toe_pos_in_local(1); -LATERAL_TOL; toe_ht_in_local], [toe_pos_in_local(1); LATERAL_TOL; toe_ht_in_local])};
-[pose, q_latest] = solve_for_pose(constraints, q_latest);
+pose = [swing1_origin_pose(1:3)*(1-APEX_FRACTIONS(1)) + APEX_FRACTIONS(1)*swing2_origin_pose(1:3) + [0;0;toe_ht_in_local]; quat2rpy(quat_toe_off)];
 add_foot_origin_knot(pose, min(params.step_speed, MAX_TAKEOFF_SPEED)/2);
 
 % Apex knot 2
 max_terrain_ht = max(terrain_pts_in_toe_local(3,:));
 toe_ht_in_local = max_terrain_ht + params.step_height;
-toe_pos_in_local = interp1([0, 1], [mean(swing1_toe_points_in_toe_local, 2), mean(swing2_toe_points_in_toe_local, 2)]', APEX_FRACTIONS(2))';
-constraints = {posture_constraint,...
-               WorldQuatConstraint(biped, swing_body_index, quat_swing2, quat_tol),...
-               WorldPositionInFrameConstraint(biped,swing_body_index,...
-                    mean(swing_toe_points_in_foot, 2), T_toe_local_to_world, [toe_pos_in_local(1); -LATERAL_TOL; toe_ht_in_local], [toe_pos_in_local(1); LATERAL_TOL; toe_ht_in_local])};
-[pose, ~] = solve_for_pose(constraints, q_latest);
+pose = [swing1_origin_pose(1:3)*(1-APEX_FRACTIONS(2)) + APEX_FRACTIONS(2)*swing2_origin_pose(1:3) + [0;0;toe_ht_in_local]; quat2rpy(quat_swing2)];
 add_foot_origin_knot(pose);
 
 % Set the target velocities of the two apex poses based on the total distance traveled
@@ -233,6 +177,8 @@ zmp_knots(end).supp = RigidBodySupportState(biped, [stance_body_index, swing_bod
 % Final knot
 foot_origin_knots(end+1) = foot_origin_knots(end);
 foot_origin_knots(end).t = foot_origin_knots(end-1).t + hold_time / 2;
+
+
 end
 
 function pos = shift_step_inward(biped, step, instep_shift)


### PR DESCRIPTION
This removes the inverseKin call from the ZMP trajectory planner in favor of a simpler mechanism of generating swing phase knot points.  The plan generated is nearly identical to what inverseKin provides but is generated about 5 times faster.  This should help in the quest for online planning.

![swingplan](https://cloud.githubusercontent.com/assets/3849600/6756589/4eb65ca6-cf01-11e4-8d3e-83e87913e8d1.png)


