### PR TITLE
Add external wrenches to compensate for to QP controller

### DIFF
--- a/examples/Atlas/+atlasControllers/QPInputConstantHeight.m
+++ b/examples/Atlas/+atlasControllers/QPInputConstantHeight.m
@@ -138,6 +138,10 @@ classdef QPInputConstantHeight
         end
         obj.body_motion_data(j).coefs = reshape(msg.body_motion_data(j).coefs, [6, 1, 4]);
       end
+      for j = 1:length(msg.body_wrench_data)
+        obj.body_wrench_data(j).body_id = msg.body_wrench_data(j).body_id;
+        obj.body_wrench_data(j).wrench = msg.body_wrench_data(j).wrench;
+      end
       obj.whole_body_data.q_des = msg.whole_body_data.q_des;
       obj.whole_body_data.constrained_dofs = msg.whole_body_data.constrained_dofs;
       obj.param_set_name = char(msg.param_set_name);

--- a/examples/Atlas/+atlasControllers/QPInputConstantHeight.m
+++ b/examples/Atlas/+atlasControllers/QPInputConstantHeight.m
@@ -13,6 +13,7 @@ classdef QPInputConstantHeight
     zmp_data % information describing the setup and state of our linear inverted pendulum model
     support_data  % information describing available supports which the controller MAY use
     body_motion_data  % information describing body trajectories which the controller should track
+    body_wrench_data % information describing external wrenches to compensate for
     whole_body_data  % information about the desired whole-body posture
     param_set_name % the name of the current set of parameters. See atlasParams.getDefaults()
     joint_pd_override;
@@ -57,6 +58,8 @@ classdef QPInputConstantHeight
       obj.body_motion_data = struct('body_id', {},... % 3 d
                             'ts', {},... % 6 d
                             'coefs', {}); % 4 * 6 * 3 d
+      obj.body_wrench_data = struct('body_id', {},...
+                                    'wrench', {});
       obj.whole_body_data = struct('q_des', [],... % 34 d
                                'constrained_dofs', []); % 34 b
       obj.joint_pd_override = struct('position_ind', {},...
@@ -97,6 +100,14 @@ classdef QPInputConstantHeight
         msg.body_motion_data(j).body_id = obj.body_motion_data(j).body_id;
         msg.body_motion_data(j).ts = obj.body_motion_data(j).ts;
         msg.body_motion_data(j).coefs = reshape(obj.body_motion_data(j).coefs, 6, 4);
+      end
+      
+      num_external_wrenches = length(obj.body_wrench_data);
+      msg.num_external_wrenches = num_external_wrenches;
+      for j = 1 : num_external_wrenches
+        msg.body_wrench_data(j) = drake.lcmt_body_wrench_data();
+        msg.body_wrench_data(j).body_id = obj.body_wrench_data(j).body_id;
+        msg.body_motion_data(j).wrench = obj.body_wrench_data(j).wrench;
       end
       
       msg.whole_body_data = drake.lcmt_whole_body_data();

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -14,6 +14,7 @@ lcmtypes_build(LCM_TYPES
 			 lcmt_foot_flag.lcm
 			 lcmt_joint_pd_override.lcm
 			 lcmt_body_motion_data.lcm
+			 lcmt_body_wrench_data.lcm
 			 )
 
 #add_lcmtype(lcmt_drake_signal.lcm)

--- a/lcmtypes/lcmt_body_wrench_data.lcm
+++ b/lcmtypes/lcmt_body_wrench_data.lcm
@@ -1,0 +1,10 @@
+package drake;
+
+struct lcmt_body_wrench_data
+{
+	int64_t timestamp;
+
+	int32_t body_id;
+
+	double wrench[6];
+}

--- a/lcmtypes/lcmt_qp_controller_input.lcm
+++ b/lcmtypes/lcmt_qp_controller_input.lcm
@@ -13,6 +13,9 @@ struct lcmt_qp_controller_input
 
 	int32_t num_tracked_bodies;
 	lcmt_body_motion_data body_motion_data[num_tracked_bodies];
+	
+	int32_t num_external_wrenches;
+	lcmt_body_wrench_data body_wrench_data[num_external_wrenches];
 
 	lcmt_whole_body_data whole_body_data;
 

--- a/systems/controllers/QPCommon.cpp
+++ b/systems/controllers/QPCommon.cpp
@@ -100,6 +100,23 @@ std::shared_ptr<drake::lcmt_qp_controller_input> encodeQPInputLCM(const mxArray 
     }
   }
 
+  const mxArray* body_wrench_data = myGetProperty(qp_input, "body_wrench_data");
+  const int num_external_wrenches = mxGetN(body_wrench_data);
+  msg->num_external_wrenches = num_external_wrenches;
+  const int wrench_size = 6;
+  if (num_external_wrenches > 0) {
+    if (mxGetM(body_wrench_data) != 1) {
+      mexErrMsgTxt("body wrench data should be a 1xN struct array");
+    }
+    for (int i = 0; i < num_external_wrenches; i++) {
+      msg->body_wrench_data[i].timestamp = msg->timestamp;
+      msg->body_wrench_data[i].body_id = (int32_t) mxGetScalar(myGetField(body_wrench_data, i, "body_id"));
+      const mxArray* wrench = myGetField(body_motion_data, i, "wrench");
+      sizecheck(wrench, wrench_size, 1);
+      memcpy(msg->body_wrench_data[i].wrench, mxGetPr(myGetField(body_wrench_data, i, "wrench")), wrench_size * sizeof(double));
+    }
+  }
+
   const mxArray* whole_body_data = myGetProperty(qp_input, "whole_body_data");
   if (mxGetN(whole_body_data) != 1 || mxGetM(whole_body_data) != 1) mexErrMsgTxt("whole_body_data should be a 1x1 struct");
   const mxArray* q_des = myGetField(whole_body_data, "q_des");
@@ -381,7 +398,20 @@ int setupAndSolveQP(NewQPControllerData *pdata, std::shared_ptr<drake::lcmt_qp_c
     num_active_contact_pts += iter->contact_pts.size();
   }
 
-  pdata->r->HandC(robot_state.q,robot_state.qd,(MatrixXd*)nullptr,pdata->H,pdata->C,(MatrixXd*)nullptr,(MatrixXd*)nullptr,(MatrixXd*)nullptr);
+  // handle external wrenches to compensate for
+  std::unique_ptr<MatrixXd> f_ext(nullptr);
+  if (qp_input->body_wrench_data.size() > 0) {
+    const int wrench_size = 6;
+    f_ext = std::move(std::unique_ptr<MatrixXd>(new MatrixXd(wrench_size, pdata->r->num_bodies)));
+    f_ext->setZero();
+    for (auto it = qp_input->body_wrench_data.begin(); it != qp_input->body_wrench_data.end(); ++it) {
+      const drake::lcmt_body_wrench_data& body_wrench_data = *it;
+      Map< const Matrix<double, wrench_size, 1> > wrench(body_wrench_data.wrench);
+      f_ext->col(body_wrench_data.body_id) = wrench;
+    }
+  }
+
+  pdata->r->HandC(robot_state.q,robot_state.qd,f_ext.get(),pdata->H,pdata->C,(MatrixXd*)nullptr,(MatrixXd*)nullptr,(MatrixXd*)nullptr);
 
   pdata->H_float = pdata->H.topRows(6);
   pdata->H_act = pdata->H.bottomRows(nu);

--- a/systems/controllers/QPCommon.cpp
+++ b/systems/controllers/QPCommon.cpp
@@ -103,6 +103,7 @@ std::shared_ptr<drake::lcmt_qp_controller_input> encodeQPInputLCM(const mxArray 
   const mxArray* body_wrench_data = myGetProperty(qp_input, "body_wrench_data");
   const int num_external_wrenches = mxGetN(body_wrench_data);
   msg->num_external_wrenches = num_external_wrenches;
+  msg->body_wrench_data.resize(num_external_wrenches);
   const int wrench_size = 6;
   if (num_external_wrenches > 0) {
     if (mxGetM(body_wrench_data) != 1) {
@@ -111,9 +112,9 @@ std::shared_ptr<drake::lcmt_qp_controller_input> encodeQPInputLCM(const mxArray 
     for (int i = 0; i < num_external_wrenches; i++) {
       msg->body_wrench_data[i].timestamp = msg->timestamp;
       msg->body_wrench_data[i].body_id = (int32_t) mxGetScalar(myGetField(body_wrench_data, i, "body_id"));
-      const mxArray* wrench = myGetField(body_motion_data, i, "wrench");
+      const mxArray* wrench = myGetField(body_wrench_data, i, "wrench");
       sizecheck(wrench, wrench_size, 1);
-      memcpy(msg->body_wrench_data[i].wrench, mxGetPr(myGetField(body_wrench_data, i, "wrench")), wrench_size * sizeof(double));
+      memcpy(msg->body_wrench_data[i].wrench, mxGetPr(wrench), wrench_size * sizeof(double));
     }
   }
 
@@ -399,19 +400,20 @@ int setupAndSolveQP(NewQPControllerData *pdata, std::shared_ptr<drake::lcmt_qp_c
   }
 
   // handle external wrenches to compensate for
-  std::unique_ptr<MatrixXd> f_ext(nullptr);
   if (qp_input->body_wrench_data.size() > 0) {
     const int wrench_size = 6;
-    f_ext = std::move(std::unique_ptr<MatrixXd>(new MatrixXd(wrench_size, pdata->r->num_bodies)));
-    f_ext->setZero();
+    MatrixXd f_ext(wrench_size, pdata->r->num_bodies);
+    f_ext.setZero();
     for (auto it = qp_input->body_wrench_data.begin(); it != qp_input->body_wrench_data.end(); ++it) {
       const drake::lcmt_body_wrench_data& body_wrench_data = *it;
       Map< const Matrix<double, wrench_size, 1> > wrench(body_wrench_data.wrench);
-      f_ext->col(body_wrench_data.body_id) = wrench;
+      f_ext.col(body_wrench_data.body_id - 1) = wrench;
     }
+    pdata->r->HandC(robot_state.q,robot_state.qd,&f_ext,pdata->H,pdata->C,(MatrixXd*)nullptr,(MatrixXd*)nullptr,(MatrixXd*)nullptr);
   }
-
-  pdata->r->HandC(robot_state.q,robot_state.qd,f_ext.get(),pdata->H,pdata->C,(MatrixXd*)nullptr,(MatrixXd*)nullptr,(MatrixXd*)nullptr);
+  else {
+    pdata->r->HandC(robot_state.q,robot_state.qd,(MatrixXd*)nullptr,pdata->H,pdata->C,(MatrixXd*)nullptr,(MatrixXd*)nullptr,(MatrixXd*)nullptr);
+  }
 
   pdata->H_float = pdata->H.topRows(6);
   pdata->H_act = pdata->H.bottomRows(nu);


### PR DESCRIPTION
Adds the option to specify external wrenches to compensate for to the QP. These will basically just be passed into HandC as f_ext.

Needed for compliant control.