### PR TITLE
always just switch to FrozenPlan, even after walking

### DIFF
--- a/systems/robotInterfaces/FrozenPlan.m
+++ b/systems/robotInterfaces/FrozenPlan.m
@@ -1,0 +1,18 @@
+classdef FrozenPlan < QPControllerPlan
+  properties
+    frozen_qp_input;
+  end
+
+  methods
+    function obj = FrozenPlan(qp_input)
+      qp_input.param_set_name = 'standing';
+      obj.frozen_qp_input = qp_input;
+      obj.duration = inf;
+    end
+
+    function qp_input = getQPControllerInput(obj, varargin)
+      qp_input = obj.frozen_qp_input;
+    end
+  end
+end
+

--- a/systems/robotInterfaces/QPLocomotionPlan.m
+++ b/systems/robotInterfaces/QPLocomotionPlan.m
@@ -30,17 +30,7 @@ classdef QPLocomotionPlan < QPControllerPlan
     end
 
     function next_plan = getSuccessor(obj, t, x)
-      if isnumeric(obj.qtraj)
-        qf = obj.qtraj;
-        next_plan = QPLocomotionPlan.from_standing_state([x(1:6); qf(7:end); x(obj.robot.getNumPositions+1:end)], obj.robot, obj.supports(end));
-        next_plan.mu = obj.mu;
-        next_plan.g = obj.g;
-      else
-        % qf = fasteval(obj.qtraj, obj.qtraj.tspan(end));
-        next_plan = FrozenPlan(obj.last_qp_input);
-      end
-      % next_plan = QPLocomotionPlan.from_standing_state(x, obj.robot, obj.supports(end));
-
+      next_plan = FrozenPlan(obj.last_qp_input);
     end
 
     function qp_input = getQPControllerInput(obj, t_global, x, rpc, contact_force_detected)


### PR DESCRIPTION
Since the standing plan is just producing a constant output anyway, we can just use a FrozenPlan to hold the last qp_input, even after walking