### PR TITLE
Don't accept: just to investigate differences between build servers

### DIFF
--- a/systems/robotInterfaces/calibration/test/rand.m
+++ b/systems/robotInterfaces/calibration/test/rand.m
@@ -1,0 +1,11 @@
+function varargout = rand(varargin)
+if nargin == 0
+  varargout{1} = 0.1;
+elseif nargin == 1
+  varargout{1} = 0.1 * ones(varargin{1});
+elseif nargin == 2
+  varargout{1} = 0.1 * ones(varargin{1}, varargin{2});
+else
+  error('bla');
+end
+end

--- a/systems/robotInterfaces/calibration/test/randi.m
+++ b/systems/robotInterfaces/calibration/test/randi.m
@@ -1,0 +1,11 @@
+function varargout = randi(varargin)
+if nargin == 0
+  varargout{1} = 0.1;
+elseif nargin == 1
+  varargout{1} = 0.1 * ones(varargin{1});
+elseif nargin == 2
+  varargout{1} = 0.1 * ones(varargin{1}, varargin{2});
+else
+  error('bla');
+end
+end

--- a/systems/robotInterfaces/calibration/test/randn.m
+++ b/systems/robotInterfaces/calibration/test/randn.m
@@ -1,0 +1,11 @@
+function varargout = randn(varargin)
+if nargin == 0
+  varargout{1} = 0.1;
+elseif nargin == 1
+  varargout{1} = 0.1 * ones(varargin{1});
+elseif nargin == 2
+  varargout{1} = 0.1 * ones(varargin{1}, varargin{2});
+else
+  error('bla');
+end
+end

--- a/systems/robotInterfaces/calibration/test/randperm.m
+++ b/systems/robotInterfaces/calibration/test/randperm.m
@@ -1,0 +1,3 @@
+function varargout = randperm(varargin)
+error('bla');
+end

--- a/systems/robotInterfaces/calibration/test/testJointCalibration.m
+++ b/systems/robotInterfaces/calibration/test/testJointCalibration.m
@@ -1,5 +1,5 @@
 function testJointCalibration
-s = rng(215615, 'twister');
+% s = rng(215615, 'twister');
 testJointOffsetCalibration();
 testJointStiffnessCalibration();
 rng(s);
@@ -26,9 +26,9 @@ q_offset_error = angleDiff(q_offset_actual, q_offset_estimated);
 fprintf('q_offset_error:\n');
 disp(q_offset_error);
 
-valuecheck(q_offset_error, zeros(size(q_offset_actual)), 1e-2);
-checkMarkerPositions(marker_positions_actual, marker_functions, marker_params);
-checkFloatingStates(r, bodies, q_actual, floating_states, num_poses);
+% valuecheck(q_offset_error, zeros(size(q_offset_actual)), 1e-2);
+% checkMarkerPositions(marker_positions_actual, marker_functions, marker_params);
+% checkFloatingStates(r, bodies, q_actual, floating_states, num_poses);
 
 end
 
@@ -120,7 +120,7 @@ for i = 1 : length(bodies)
 
   marker_positions_actual{i} = 2 * (rand(3, num_markers) - 0.5) * marker_offset_max;
   marker_positions_measured{i} = nan(size(marker_positions_actual{i}));
-  measured_markers = randperm(num_markers, num_measured_markers);
+  measured_markers = 1 : num_measured_markers; % randperm(num_markers, num_measured_markers);
   measurement_error = marker_measurement_stddev * randn(3, length(measured_markers));
   marker_positions_measured{i}(:, measured_markers) = marker_positions_actual{i}(:, measured_markers) + measurement_error;
   num_unmeasured_markers{i} = num_markers - length(measured_markers);


### PR DESCRIPTION
Trying to figure out #866. This should make testJointCalibration completely deterministic without relying on rng. I'd like to see whether it is indeed the case that different versions of Matlab give different answers for the same problem.