### PR TITLE
FastQP in solveLCPmex

### DIFF
--- a/systems/plants/CMakeLists.txt
+++ b/systems/plants/CMakeLists.txt
@@ -70,8 +70,11 @@ if (eigen3_FOUND)
   add_rbm_mex(surfaceTangentsmex)
   add_rbm_mex(jointLimitConstraintsmex)
   add_rbm_mex(positionConstraintsmex)
-  add_rbm_mex(setupLCPmex)
-
+  
+  add_mex(setupLCPmex setupLCPmex.cpp)
+  target_link_libraries(setupLCPmex drakeRBM drakeUtil drakeQP)
+  
+  
   include_directories( constraint )
   add_library(drakeIKoptions SHARED IKoptions.cpp)
   target_link_libraries(drakeIKoptions drakeRBM)

--- a/systems/plants/CMakeLists.txt
+++ b/systems/plants/CMakeLists.txt
@@ -26,6 +26,7 @@ if (eigen3_FOUND)
     REQUIRES
     VERSION 0.0.1)
 
+  pods_find_pkg_config(gurobi)
   add_subdirectory(shapes)
   add_subdirectory(collision)
   add_subdirectory(constraint)
@@ -71,8 +72,10 @@ if (eigen3_FOUND)
   add_rbm_mex(jointLimitConstraintsmex)
   add_rbm_mex(positionConstraintsmex)
   
-  add_mex(setupLCPmex setupLCPmex.cpp)
-  target_link_libraries(setupLCPmex drakeRBM drakeUtil drakeQP)
+  if(gurobi_FOUND)
+    add_mex(setupLCPmex setupLCPmex.cpp)
+    target_link_libraries(setupLCPmex drakeRBM drakeUtil drakeQP)
+  endif()
   
   
   include_directories( constraint )


### PR DESCRIPTION
This lets the c++ implementation of solveLCP call fastQP first and only falls back on pathlcp when fastQP fails.  This substantially reduces the number of calls to pathlcp and makes this implementation much faster than solveLCP in all Atlas sims regardless of whether the hands are used.