### PR TITLE
Fixed drake joint

### DIFF
--- a/examples/SimpleDoublePendulum/SimpleDoublePendulum.urdf
+++ b/examples/SimpleDoublePendulum/SimpleDoublePendulum.urdf
@@ -13,7 +13,7 @@
     <color rgba="0 0 1 1" />
   </material>
 
-  <link name="world">
+  <link name="base">
     <inertial> <!-- drc-viewer needs this to have inertia to parse properly.  remove it when that bug is fixed -->
       <origin xyz="0 0 0" />
       <mass value="0.01" />
@@ -35,7 +35,7 @@
     </visual> 
   </link>
   <joint name="shoulder" type="continuous">
-    <parent link="world"/>
+    <parent link="base"/>
     <child link="upper_arm" />
     <axis xyz="0 1 0" />
     <dynamics damping="0.1" />

--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -879,7 +879,7 @@ classdef RigidBodyManipulator < Manipulator
       end
       
       if (model.num_contact_pairs>0)
-        warning('Drake:RigidBodyManipulator:UnsupportedContactPoints','Contact is not supported by the dynamics methods of this class.  Consider using TimeSteppingRigidBodyManipulator or HybridPlanarRigidBodyManipulator');
+        warnOnce(model.warning_manager,'Drake:RigidBodyManipulator:UnsupportedContactPoints','Contact is not supported by the dynamics methods of this class.  Consider using TimeSteppingRigidBodyManipulator or HybridPlanarRigidBodyManipulator');
       end
 
 %      H = manipulatorDynamics(model,zeros(model.num_positions,1),zeros(model.num_positions,1));

--- a/systems/plants/@RigidBodyManipulator/addRobotFromURDF.m
+++ b/systems/plants/@RigidBodyManipulator/addRobotFromURDF.m
@@ -375,51 +375,55 @@ end
 
 
 function model = parseForceElement(model,robotnum,node,options)
+
+name = char(node.getAttribute('name'));
+name = regexprep(name, '\.', '_', 'preservecase');
+
 fe = [];
 childNodes = node.getChildNodes();
 elnode = node.getElementsByTagName('linear_spring_damper').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodySpringDamper.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodySpringDamper.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 elnode = node.getElementsByTagName('torsional_spring').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodyTorsionalSpring.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodyTorsionalSpring.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 elnode = node.getElementsByTagName('wing').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodyWing.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodyWing.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 elnode = node.getElementsByTagName('wing_with_control_surface').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodyWingWithControlSurface.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodyWingWithControlSurface.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 elnode = node.getElementsByTagName('bluff_body').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodyBluffBody.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodyBluffBody.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 elnode = node.getElementsByTagName('thrust').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodyThrust.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodyThrust.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 elnode = node.getElementsByTagName('added_mass').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodyAddedMass.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodyAddedMass.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 elnode = node.getElementsByTagName('buoyancy').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodyBuoyant.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodyBuoyant.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 elnode = node.getElementsByTagName('propellor').item(0);
 if ~isempty(elnode)
-  [model,fe] = RigidBodyPropellor.parseURDFNode(model,robotnum,elnode,options);
+  [model,fe] = RigidBodyPropellor.parseURDFNode(model,name,robotnum,elnode,options);
 end
 
 

--- a/systems/plants/@RigidBodyWing/RigidBodyWing.m
+++ b/systems/plants/@RigidBodyWing/RigidBodyWing.m
@@ -756,7 +756,7 @@ classdef RigidBodyWing < RigidBodyForceElement
       
     end
 
-    function [model, obj] = parseURDFNode(model,robotnum,node,options)
+    function [model, obj] = parseURDFNode(model,name,robotnum,node,options)
       % Build a RigidBodyWing from a URDF.
       %
       % @param model model we are adding to
@@ -766,9 +766,6 @@ classdef RigidBodyWing < RigidBodyForceElement
       % @retval model updated model
       % @retval obj constructed RigidBodyWing
       
-      name = char(node.getAttribute('name'));
-      name = regexprep(name, '\.', '_', 'preservecase');
-
       elNode = node.getElementsByTagName('parent').item(0);
       parent = findLinkId(model,char(elNode.getAttribute('link')),robotnum);
 

--- a/systems/plants/RigidBodyAddedMass.m
+++ b/systems/plants/RigidBodyAddedMass.m
@@ -68,10 +68,7 @@ classdef RigidBodyAddedMass < RigidBodyForceElement
     end
     
     methods (Static)
-        function [model,obj] = parseURDFNode(model,robotnum,node,options)
-            name = char(node.getAttribute('name'));
-            name = regexprep(name, '\.', '_', 'preservecase');
-            
+        function [model,obj] = parseURDFNode(model,name,robotnum,node,options)
             elNode = node.getElementsByTagName('parent').item(0);
             parent = findLinkId(model,char(elNode.getAttribute('link')),robotnum);
             

--- a/systems/plants/RigidBodyBluffBody.m
+++ b/systems/plants/RigidBodyBluffBody.m
@@ -181,12 +181,9 @@ classdef RigidBodyBluffBody < RigidBodyForceElement
   
   methods (Static)
     
-    function [model,obj] = parseURDFNode(model,robotnum,node,options)
+    function [model,obj] = parseURDFNode(model,name,robotnum,node,options)
       % Parse URDF node for drag object.
       
-      name = char(node.getAttribute('name'));
-      name = regexprep(name, '\.', '_', 'preservecase');
-
       elNode = node.getElementsByTagName('parent').item(0);
       parent = findLinkId(model,char(elNode.getAttribute('link')),robotnum);
       

--- a/systems/plants/RigidBodyBuoyant.m
+++ b/systems/plants/RigidBodyBuoyant.m
@@ -31,10 +31,7 @@ classdef RigidBodyBuoyant < RigidBodyForceElement
   end
   
   methods (Static)
-    function [model,obj] = parseURDFNode(model,robotnum,node,options)
-      name = char(node.getAttribute('name'));
-      name = regexprep(name, '\.', '_', 'preservecase');
-      
+    function [model,obj] = parseURDFNode(model,name,robotnum,node,options)
       elNode = node.getElementsByTagName('parent').item(0);
       parent = findLinkId(model,char(elNode.getAttribute('link')),robotnum);
       

--- a/systems/plants/RigidBodyLoop.m
+++ b/systems/plants/RigidBodyLoop.m
@@ -88,7 +88,7 @@ classdef RigidBodyLoop < RigidBodyElement
       end
 
       % todo: add relativeQuatConstraint, too
-      warning('Drake:RigidBodyManipulator:ThreeDLoopJoints','3D loop joints do not properly enforce the joint axis constraint.  (they perform more like a ball joint)');
+      warnOnce(model.warning_manager,'Drake:RigidBodyManipulator:ThreeDLoopJoints','3D loop joints do not properly enforce the joint axis constraint.  (they perform more like a ball joint)');
     end
   end  
 end

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -1088,59 +1088,71 @@ void RigidBodyManipulator::doKinematicsNew(const MatrixBase<DerivedQ>& q, const 
       }
 
       if (v.rows() > 0) {
-        // twist
-        auto v_body = v.middleRows(body.velocity_num_start, joint.getNumVelocities());
-        joint_twist.value().noalias() = body.J * v_body;
-        body.twist = body.parent->twist;
-        body.twist += joint_twist.value();
-
-        if (compute_gradients) {
-          // dtwistdq
-          joint_twist.gradient().value() = matGradMult(body.dJdq, v_body);
-          body.dtwistdq = body.parent->dtwistdq + joint_twist.gradient().value();
-        }
-
-        if (compute_JdotV) {
-          // Sdotv
-          auto dSdotVdqi = compute_gradients ? &body.dSdotVdqi : nullptr;
-          auto dSdotVdvi = compute_gradients ? &body.dSdotVdvi : nullptr;
-          joint.motionSubspaceDotTimesV(q_body, v_body, body.SdotV, dSdotVdqi, dSdotVdvi);
-
-          // Jdotv
-          auto joint_accel = crossSpatialMotion(body.twist, joint_twist.value());
-          joint_accel += transformSpatialMotion(body.T_new, body.SdotV);
-          body.JdotV = body.parent->JdotV + joint_accel;
+        if (joint.getNumVelocities()==0) { // for fixed joints
+          body.twist = body.parent->twist;
+           if (compute_gradients) body.dtwistdq = body.parent->dtwistdq;
+           if (compute_JdotV) {
+             body.JdotV = body.parent->JdotV;
+             if (compute_gradients) {
+               body.dJdotVdq = body.parent->dJdotVdq;
+               body.dJdotVdv = body.parent->dJdotVdv;
+             }
+           }
+        } else {
+          // twist
+          auto v_body = v.middleRows(body.velocity_num_start, joint.getNumVelocities());
+          joint_twist.value().noalias() = body.J * v_body;
+          body.twist += joint_twist.value();
+          body.twist = body.parent->twist;
 
           if (compute_gradients) {
-            // dJdotvdq
-            // TODO: exploit sparsity better
-            Matrix<double, TWIST_SIZE, Eigen::Dynamic> dSdotVdq(TWIST_SIZE, nq);
-            dSdotVdq.setZero();
-            dSdotVdq.middleCols(body.position_num_start, joint.getNumPositions()) = body.dSdotVdqi;
-            MatrixXd dcrm_twist_joint_twistdq(TWIST_SIZE, nq);
-            dcrm(body.twist, joint_twist.value(), body.dtwistdq, joint_twist.gradient().value(), &dcrm_twist_joint_twistdq); // TODO: make dcrm templated
-            body.dJdotVdq = body.parent->dJdotVdq
-                + dcrm_twist_joint_twistdq
-                + dTransformSpatialMotion(body.T_new, body.SdotV, body.dTdq_new, dSdotVdq);
+            // dtwistdq
+            joint_twist.gradient().value() = matGradMult(body.dJdq, v_body);
+            body.dtwistdq = body.parent->dtwistdq + joint_twist.gradient().value();
+          }
 
-            // dJdotvdv
-            int nv_joint = joint.getNumVelocities();
-            std::vector<int> v_indices;
-            auto dtwistdv = geometricJacobian<double>(0, i, 0, 0, false, &v_indices);
-            int nv_branch = static_cast<int>(v_indices.size());
+          if (compute_JdotV) {
+            // Sdotv
+            auto dSdotVdqi = compute_gradients ? &body.dSdotVdqi : nullptr;
+            auto dSdotVdvi = compute_gradients ? &body.dSdotVdvi : nullptr;
+            joint.motionSubspaceDotTimesV(q_body, v_body, body.SdotV, dSdotVdqi, dSdotVdvi);
 
-            Matrix<double, TWIST_SIZE, Eigen::Dynamic> djoint_twistdv(TWIST_SIZE, nv_branch);
-            djoint_twistdv.setZero();
-            djoint_twistdv.rightCols(nv_joint) = body.J;
+            // Jdotv
+            auto joint_accel = crossSpatialMotion(body.twist, joint_twist.value());
+            joint_accel += transformSpatialMotion(body.T_new, body.SdotV);
+            body.JdotV = body.parent->JdotV + joint_accel;
 
-            Matrix<double, TWIST_SIZE, Eigen::Dynamic> djoint_acceldv(TWIST_SIZE, nv_branch);
-            djoint_acceldv = dCrossSpatialMotion(body.twist, joint_twist.value(), dtwistdv.value(), djoint_twistdv); // TODO: can probably exploit sparsity better
-            djoint_acceldv.rightCols(nv_joint) += transformSpatialMotion(body.T_new, *dSdotVdvi);
+            if (compute_gradients) {
+              // dJdotvdq
+              // TODO: exploit sparsity better
+              Matrix<double, TWIST_SIZE, Eigen::Dynamic> dSdotVdq(TWIST_SIZE, nq);
+              dSdotVdq.setZero();
+              dSdotVdq.middleCols(body.position_num_start, joint.getNumPositions()) = body.dSdotVdqi;
+              MatrixXd dcrm_twist_joint_twistdq(TWIST_SIZE, nq);
+              dcrm(body.twist, joint_twist.value(), body.dtwistdq, joint_twist.gradient().value(), &dcrm_twist_joint_twistdq); // TODO: make dcrm templated
+              body.dJdotVdq = body.parent->dJdotVdq
+                  + dcrm_twist_joint_twistdq
+                  + dTransformSpatialMotion(body.T_new, body.SdotV, body.dTdq_new, dSdotVdq);
 
-            body.dJdotVdv.setZero();
-            for (int j = 0; j < nv_branch; j++) {
-              int v_index = v_indices[j];
-              body.dJdotVdv.col(v_index) = body.parent->dJdotVdv.col(v_index) + djoint_acceldv.col(j);
+              // dJdotvdv
+              int nv_joint = joint.getNumVelocities();
+              std::vector<int> v_indices;
+              auto dtwistdv = geometricJacobian<double>(0, i, 0, 0, false, &v_indices);
+              int nv_branch = static_cast<int>(v_indices.size());
+
+              Matrix<double, TWIST_SIZE, Eigen::Dynamic> djoint_twistdv(TWIST_SIZE, nv_branch);
+              djoint_twistdv.setZero();
+              djoint_twistdv.rightCols(nv_joint) = body.J;
+
+              Matrix<double, TWIST_SIZE, Eigen::Dynamic> djoint_acceldv(TWIST_SIZE, nv_branch);
+              djoint_acceldv = dCrossSpatialMotion(body.twist, joint_twist.value(), dtwistdv.value(), djoint_twistdv); // TODO: can probably exploit sparsity better
+              djoint_acceldv.rightCols(nv_joint) += transformSpatialMotion(body.T_new, *dSdotVdvi);
+
+              body.dJdotVdv.setZero();
+              for (int j = 0; j < nv_branch; j++) {
+                int v_index = v_indices[j];
+                body.dJdotVdv.col(v_index) = body.parent->dJdotVdv.col(v_index) + djoint_acceldv.col(j);
+              }
             }
           }
         }

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -912,6 +912,7 @@ void RigidBodyManipulator::doKinematics(double* q, bool b_compute_second_derivat
     } else {
       shared_ptr<RigidBody> parent = bodies[i]->parent;
       double qi = q[bodies[i]->position_num_start];
+      if (bodies[i]->getJoint().getNumPositions()==0) qi = 0;  // fixed joint
       Tjcalc(bodies[i]->pitch,qi,&TJ);
       dTjcalc(bodies[i]->pitch,qi,&dTJ);
 
@@ -968,6 +969,7 @@ void RigidBodyManipulator::doKinematics(double* q, bool b_compute_second_derivat
 
       if (qd) {
         double qdi = qd[bodies[i]->position_num_start];
+        if (bodies[i]->getJoint().getNumVelocities()==0) qdi = 0;  // fixed joint
         TJdot = dTJ*qdi;
         ddTjcalc(bodies[i]->pitch,qi,&ddTJ);
         dTJdot = ddTJ*qdi;

--- a/systems/plants/RigidBodyManipulatorURDF.cpp
+++ b/systems/plants/RigidBodyManipulatorURDF.cpp
@@ -580,9 +580,13 @@ bool parseJoint(RigidBodyManipulator* model, TiXmlElement* node)
   }
 
   TiXmlElement* dynamics_node = node->FirstChildElement("dynamics");
-  if (dynamics_node) {
-    model->warnOnce("joint_dynamics", 
-        "Warning: joint dynamics xml tag not (re-)implemented yet; they will be ignored.");
+  if (fjoint != nullptr && dynamics_node) {
+    model->warnOnce("joint_dynamics", "Warning: joint dynamics xml tag is parsed, but not included in the dynamics methods yet.");
+  	double damping=0.0, coulomb_friction=0.0, coulomb_window=0.0;
+  	parseScalarAttribute(dynamics_node,"damping",damping);
+  	parseScalarAttribute(dynamics_node,"friction",coulomb_friction);
+  	parseScalarAttribute(dynamics_node,"coulomb_window",coulomb_window);
+  	fjoint->setDynamics(damping,coulomb_friction,coulomb_window);
   }
 
   TiXmlElement* limit_node = node->FirstChildElement("limit");

--- a/systems/plants/RigidBodyManipulatorURDF.cpp
+++ b/systems/plants/RigidBodyManipulatorURDF.cpp
@@ -142,6 +142,17 @@ int findLinkIndexByJointName(RigidBodyManipulator* model, string jointname)
   return index;
 }
 
+bool parseScalarValue(TiXmlElement* node, double &val)
+{
+  const char* strval = node->FirstChild()->Value();
+  if (strval) {
+    stringstream s(strval);
+    s >> val;
+    return true;
+  }
+  return false;
+}
+
 bool parseScalarAttribute(TiXmlElement* node, const char* attribute_name, double& val)
 {
   const char* attr = node->Attribute(attribute_name);
@@ -256,7 +267,7 @@ bool parseMaterial(TiXmlElement* node, map<string, Vector4d>& materials)
     }
     materials[name] = rgba;
   } else if (!already_in_map) {
-    cerr << "ERROR: material \"" << name << "\" is used before it is defined" << endl;
+    cerr << "WARNING: material \"" << name << "\" is not a simple color material (so is currently unsupported)" << endl;
     return false;
   }
   return true;
@@ -612,7 +623,7 @@ bool parseTransmission(RigidBodyManipulator* model, TiXmlElement* node)
 
   TiXmlElement* reduction_node = node->FirstChildElement("mechanicalReduction");
   double gain = 1.0;
-  if (reduction_node) sscanf(reduction_node->Value(),"%lf",&gain);
+  if (reduction_node) parseScalarValue(reduction_node, gain);
 
   RigidBodyActuator a(joint_name,model->bodies[body_index],gain);
   model->actuators.push_back(a);
@@ -659,9 +670,7 @@ bool parseRobot(RigidBodyManipulator* model, TiXmlElement* node, const map<strin
   // parse material elements
   map< string, Vector4d> materials;
   for (TiXmlElement* link_node = node->FirstChildElement("material"); link_node; link_node = link_node->NextSiblingElement("material")) {
-    if (!parseMaterial(link_node, materials)) {
-      return false;
-    }
+    parseMaterial(link_node, materials);  // accept failed material parsing
   }
   // parse link elements
   for (TiXmlElement* link_node = node->FirstChildElement("link"); link_node; link_node = link_node->NextSiblingElement("link"))

--- a/systems/plants/RigidBodyManipulatorURDF.cpp
+++ b/systems/plants/RigidBodyManipulatorURDF.cpp
@@ -7,6 +7,7 @@
 #include "tinyxml.h"
 #include "RigidBodyManipulator.h"
 #include "joints/drakeJointUtil.h"
+#include "joints/FixedJoint.h"
 #include "joints/HelicalJoint.h"
 #include "joints/PrismaticJoint.h"
 #include "joints/RevoluteJoint.h"
@@ -556,9 +557,7 @@ bool parseJoint(RigidBodyManipulator* model, TiXmlElement* node)
     joint = fjoint;
   } else if (type.compare("fixed") == 0) {
     // FIXME: implement a fixed joint class
-    fjoint = new RevoluteJoint(name, Ttree, axis);
-    fjoint->setJointLimits(0, 0);
-    joint = fjoint;
+    joint = new FixedJoint(name, Ttree);
   } else if (type.compare("prismatic") == 0) {
     fjoint = new PrismaticJoint(name, Ttree, axis);
     joint = fjoint;

--- a/systems/plants/RigidBodyPropellor.m
+++ b/systems/plants/RigidBodyPropellor.m
@@ -181,10 +181,7 @@ classdef RigidBodyPropellor < RigidBodyForceElement
   end
   
   methods (Static)
-    function [model,obj] = parseURDFNode(model,robotnum,node,options)
-      name = char(node.getAttribute('name'));
-      name = regexprep(name, '\.', '_', 'preservecase');
-      
+    function [model,obj] = parseURDFNode(model,name,robotnum,node,options)
       elnode = node.getElementsByTagName('parent').item(0);
       parent = findLinkId(model,char(elnode.getAttribute('link')),robotnum);
       

--- a/systems/plants/RigidBodySpringDamper.m
+++ b/systems/plants/RigidBodySpringDamper.m
@@ -132,11 +132,8 @@ classdef RigidBodySpringDamper < RigidBodyForceElement
   end
   
   methods (Static)
-    function [model,obj] = parseURDFNode(model,robotnum,node,options)
+    function [model,obj] = parseURDFNode(model,name,robotnum,node,options)
       obj = RigidBodySpringDamper();
-      
-      name = char(node.getAttribute('name'));
-      name = regexprep(name, '\.', '_', 'preservecase');
       obj.name = name;
       
       if node.hasAttribute('rest_length')

--- a/systems/plants/RigidBodyThrust.m
+++ b/systems/plants/RigidBodyThrust.m
@@ -55,10 +55,7 @@ classdef RigidBodyThrust < RigidBodyForceElement
   end
   
   methods (Static)
-    function [model,obj] = parseURDFNode(model,robotnum,node,options)
-      name = char(node.getAttribute('name'));
-      name = regexprep(name, '\.', '_', 'preservecase');
-      
+    function [model,obj] = parseURDFNode(model,name,robotnum,node,options)
       elnode = node.getElementsByTagName('parent').item(0);
       parent = findLinkId(model,char(elnode.getAttribute('link')),robotnum);
       

--- a/systems/plants/RigidBodyTorsionalSpring.m
+++ b/systems/plants/RigidBodyTorsionalSpring.m
@@ -56,11 +56,8 @@ classdef RigidBodyTorsionalSpring < RigidBodyForceElement
   end
   
   methods (Static)
-    function [model,obj] = parseURDFNode(model,robotnum,node,options)
+    function [model,obj] = parseURDFNode(model,name,robotnum,node,options)
       obj = RigidBodyTorsionalSpring();
-      
-      name = char(node.getAttribute('name'));
-      name = regexprep(name, '\.', '_', 'preservecase');
       obj.name = name;
       
       if node.hasAttribute('rest_angle')

--- a/systems/plants/RigidBodyWingWithControlSurface.m
+++ b/systems/plants/RigidBodyWingWithControlSurface.m
@@ -444,7 +444,7 @@ classdef RigidBodyWingWithControlSurface < RigidBodyWing
   
   methods (Static)
     
-    function [model, obj] = parseURDFNode(model,robotnum,node,options)
+    function [model, obj] = parseURDFNode(model,name,robotnum,node,options)
       % Parses URDF node for wing_with_control_surface
       %
       % @param model model we are buidling
@@ -455,10 +455,6 @@ classdef RigidBodyWingWithControlSurface < RigidBodyWing
       % @retval model updated model
       % @reval obj newly created RigidBodyWingWithControlSurface object
       
-      
-      name = char(node.getAttribute('name'));
-      name = regexprep(name, '\.', '_', 'preservecase');
-
       elNode = node.getElementsByTagName('parent').item(0);
       parent = findLinkId(model,char(elNode.getAttribute('link')),robotnum);
 

--- a/systems/plants/joints/CMakeLists.txt
+++ b/systems/plants/joints/CMakeLists.txt
@@ -1,13 +1,13 @@
 include_directories ( .. )
 include_directories ( ${CMAKE_SOURCE_DIR}/util )
 
-add_library(drakeJoints SHARED DrakeJoint.cpp FixedAxisOneDoFJoint.cpp HelicalJoint.cpp PrismaticJoint.cpp QuaternionFloatingJoint.cpp RevoluteJoint.cpp RollPitchYawFloatingJoint.cpp drakeJointUtil.cpp)
+add_library(drakeJoints SHARED DrakeJoint.cpp FixedAxisOneDoFJoint.cpp HelicalJoint.cpp PrismaticJoint.cpp QuaternionFloatingJoint.cpp RevoluteJoint.cpp RollPitchYawFloatingJoint.cpp FixedJoint.cpp drakeJointUtil.cpp)
 
 target_link_libraries(drakeJoints drakeGeometryUtil drakeGradientUtil)
 
 # enable_testing()
 
 pods_install_libraries(drakeJoints)
-pods_install_headers(DrakeJoint.h FixedAxisOneDoFJoint.h HelicalJoint.h PrismaticJoint.h QuaternionFloatingJoint.h RevoluteJoint.h RollPitchYawFloatingJoint.h drakeJointUtil.h DESTINATION drake)
+pods_install_headers(DrakeJoint.h FixedAxisOneDoFJoint.h HelicalJoint.h PrismaticJoint.h QuaternionFloatingJoint.h RevoluteJoint.h RollPitchYawFloatingJoint.h FixedJoint.h drakeJointUtil.h DESTINATION drake)
   
 add_subdirectory(test)

--- a/systems/plants/joints/FixedAxisOneDoFJoint.cpp
+++ b/systems/plants/joints/FixedAxisOneDoFJoint.cpp
@@ -15,7 +15,10 @@ FixedAxisOneDoFJoint::FixedAxisOneDoFJoint(const std::string& name, const Isomet
     DrakeJoint(name, transform_to_parent_body, 1, 1),
     joint_axis(joint_axis),
     joint_limit_min(-std::numeric_limits<double>::infinity()),
-    joint_limit_max(std::numeric_limits<double>::infinity())
+    joint_limit_max(std::numeric_limits<double>::infinity()),
+		damping(0.0),
+		coulomb_friction(0.0),
+		coulomb_window(0.0)
 {
   // empty
 }
@@ -34,6 +37,7 @@ void FixedAxisOneDoFJoint::setJointLimits(double joint_limit_min, double joint_l
   this->joint_limit_min = joint_limit_min;
   this->joint_limit_max = joint_limit_max;
 }
+
 
 void FixedAxisOneDoFJoint::motionSubspace(const Eigen::Ref<const VectorXd>& q, MotionSubspaceType& motion_subspace, MatrixXd* dmotion_subspace) const
 {
@@ -104,6 +108,24 @@ void FixedAxisOneDoFJoint::v2qdot(const Eigen::Ref<const VectorXd>& q, Eigen::Ma
     dv_to_qdot->setZero(v_to_qdot.size(), getNumPositions());
   }
 }
+
+void FixedAxisOneDoFJoint::setDynamics(double damping, double coulomb_friction, double coulomb_window)
+{
+	this->damping = damping;
+	this->coulomb_friction = coulomb_friction;
+	this->coulomb_window = coulomb_window;
+}
+
+/*
+GradientVar<double,1,1> FixedAxisOneDoFJoint::computeFrictionForce(const Eigen::Ref<const VectorXd>& v, int gradient_order) const
+{
+	GradientVar<double,1,1> force(1,1,1,gradient_order);
+	force.value() = damping*v[0];
+	if (gradient_order>0)
+		force.gradient().value() = damping;
+	return force;
+}
+*/
 
 void FixedAxisOneDoFJoint::setupOldKinematicTree(RigidBodyManipulator* model, int body_ind, int position_num_start, int velocity_num_start) const
 {

--- a/systems/plants/joints/FixedAxisOneDoFJoint.h
+++ b/systems/plants/joints/FixedAxisOneDoFJoint.h
@@ -14,6 +14,9 @@ private:
   Eigen::Matrix<double, TWIST_SIZE, 1> joint_axis;
   double joint_limit_min;
   double joint_limit_max;
+  double damping;
+  double coulomb_friction;
+  double coulomb_window;
 
 protected:
   FixedAxisOneDoFJoint(const std::string& name, const Eigen::Isometry3d& transform_to_parent_body, const Eigen::Matrix<double, TWIST_SIZE, 1>& joint_axis);
@@ -36,6 +39,9 @@ public:
   virtual void qdot2v(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const; //override;
 
   virtual void v2qdot(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const; //override;
+
+  void setDynamics(double damping, double coulomb_friction, double coulomb_window);
+//  GradientVar<double,1,1> computeFrictionForce(const Eigen::Ref<const VectorXd>& v, int gradient_order) const;
 
   virtual void setupOldKinematicTree(RigidBodyManipulator* model, int body_ind, int position_num_start, int velocity_num_start) const;
 };

--- a/systems/plants/joints/FixedJoint.cpp
+++ b/systems/plants/joints/FixedJoint.cpp
@@ -1,0 +1,63 @@
+/*
+ * FixedJoint.cpp
+ *
+ *  Created on: Mar 26, 2015
+ *      Author: twan
+ */
+
+#include "FixedJoint.h"
+
+FixedJoint::FixedJoint(const std::string& name, const Eigen::Isometry3d& transform_to_parent_body) :
+  DrakeJoint(name, transform_to_parent_body, 0, 0)
+{
+  // empty
+}
+
+FixedJoint::~FixedJoint()
+{
+  // empty
+}
+
+void FixedJoint::motionSubspace(const Eigen::Ref<const Eigen::VectorXd>& q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace) const
+{
+  motion_subspace.resize(TWIST_SIZE, getNumVelocities());
+  if (dmotion_subspace) {
+    dmotion_subspace->resize(motion_subspace.size(), getNumPositions());
+  }
+}
+
+void FixedJoint::motionSubspaceDotTimesV(const Eigen::Ref<const Eigen::VectorXd>& q, const Eigen::Ref<const Eigen::VectorXd>& v, Vector6d& motion_subspace_dot_times_v,
+    Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq,
+    Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv) const
+{
+  motion_subspace_dot_times_v.setZero();
+
+  if (dmotion_subspace_dot_times_vdq) {
+    dmotion_subspace_dot_times_vdq->setZero(TWIST_SIZE, 1);
+  }
+
+  if (dmotion_subspace_dot_times_vdv) {
+    dmotion_subspace_dot_times_vdv->setZero(TWIST_SIZE, 1);
+  }
+}
+
+void FixedJoint::randomConfiguration(Eigen::Ref<Eigen::VectorXd>& q, std::default_random_engine& generator) const
+{
+  // empty
+}
+
+void FixedJoint::qdot2v(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const
+{
+  qdot_to_v.resize(getNumVelocities(), getNumPositions());
+  if (dqdot_to_v) {
+    dqdot_to_v->setZero(qdot_to_v.size(), getNumPositions());
+  }
+}
+
+void FixedJoint::v2qdot(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const
+{
+  v_to_qdot.resize(getNumPositions(), getNumVelocities());
+  if (dv_to_qdot) {
+    dv_to_qdot->setZero(v_to_qdot.size(), getNumPositions());
+  }
+}

--- a/systems/plants/joints/FixedJoint.cpp
+++ b/systems/plants/joints/FixedJoint.cpp
@@ -18,6 +18,11 @@ FixedJoint::~FixedJoint()
   // empty
 }
 
+Eigen::Isometry3d FixedJoint::jointTransform(const Eigen::Ref<const Eigen::VectorXd>& q) const
+{
+  return Eigen::Isometry3d::Identity();
+}
+
 void FixedJoint::motionSubspace(const Eigen::Ref<const Eigen::VectorXd>& q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace) const
 {
   motion_subspace.resize(TWIST_SIZE, getNumVelocities());

--- a/systems/plants/joints/FixedJoint.h
+++ b/systems/plants/joints/FixedJoint.h
@@ -1,0 +1,33 @@
+/*
+ * FixedJoint.h
+ *
+ *  Created on: Mar 26, 2015
+ *      Author: twan
+ */
+
+#ifndef DRAKE_SYSTEMS_PLANTS_JOINTS_FIXEDJOINT_H_
+#define DRAKE_SYSTEMS_PLANTS_JOINTS_FIXEDJOINT_H_
+
+#include "DrakeJoint.h"
+
+class DLLEXPORT_DRAKEJOINT FixedJoint: public DrakeJoint
+{
+public:
+  FixedJoint(const std::string& name, const Eigen::Isometry3d& transform_to_parent_body);
+
+  virtual ~FixedJoint();
+
+  virtual void motionSubspace(const Eigen::Ref<const Eigen::VectorXd>& q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace = nullptr) const;
+
+  virtual void motionSubspaceDotTimesV(const Eigen::Ref<const Eigen::VectorXd>& q, const Eigen::Ref<const Eigen::VectorXd>& v, Vector6d& motion_subspace_dot_times_v,
+      Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq = nullptr,
+      Gradient<Vector6d, Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv = nullptr) const;
+
+  virtual void randomConfiguration(Eigen::Ref<Eigen::VectorXd>& q, std::default_random_engine& generator) const;
+
+  virtual void qdot2v(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& qdot_to_v, Eigen::MatrixXd* dqdot_to_v) const;
+
+  virtual void v2qdot(const Eigen::Ref<const Eigen::VectorXd>& q, Eigen::MatrixXd& v_to_qdot, Eigen::MatrixXd* dv_to_qdot) const;
+};
+
+#endif /* DRAKE_SYSTEMS_PLANTS_JOINTS_FIXEDJOINT_H_ */

--- a/systems/plants/joints/FixedJoint.h
+++ b/systems/plants/joints/FixedJoint.h
@@ -17,6 +17,8 @@ public:
 
   virtual ~FixedJoint();
 
+  virtual Eigen::Isometry3d jointTransform(const Eigen::Ref<const Eigen::VectorXd>& q) const;
+
   virtual void motionSubspace(const Eigen::Ref<const Eigen::VectorXd>& q, MotionSubspaceType& motion_subspace, Eigen::MatrixXd* dmotion_subspace = nullptr) const;
 
   virtual void motionSubspaceDotTimesV(const Eigen::Ref<const Eigen::VectorXd>& q, const Eigen::Ref<const Eigen::VectorXd>& v, Vector6d& motion_subspace_dot_times_v,

--- a/systems/plants/test/DoublePendWBiceptSpring.urdf
+++ b/systems/plants/test/DoublePendWBiceptSpring.urdf
@@ -12,7 +12,7 @@
   <material name="blue">
     <color rgba="0 0 1 1" />
   </material>
-  <link name="world"/>
+  <link name="base"/>
   <link name="upper_arm">
     <inertial>
       <origin xyz="0 0 -0.5" rpy="0 0 0" />
@@ -28,7 +28,7 @@
     </visual>
   </link>
   <joint name="shoulder" type="continuous">
-    <parent link="world" />
+    <parent link="base" />
     <child link="upper_arm" />
     <origin xyz="0 0 0"/>
     <axis xyz="0 1 0" />

--- a/systems/plants/test/MassSpringDamper.urdf
+++ b/systems/plants/test/MassSpringDamper.urdf
@@ -9,7 +9,7 @@
   <material name="blue">
     <color rgba="0 0 1 1" />
   </material>
-  <link name="world"/>
+  <link name="base"/>
   <link name="mass">
     <inertial> 
       <origin xyz="0 0 0" rpy="0 0 0" />
@@ -25,13 +25,13 @@
     </visual> 
   </link>
   <joint name="x" type="prismatic">
-    <parent link="world"/>
+    <parent link="base"/>
     <child link="mass" />
     <axis xyz="1 0 0" />
   </joint>
   <force_element name="spring">
     <linear_spring_damper stiffness="10" damping="1">
-      <link1 link="world" xyz="0 0 0" />
+      <link1 link="base" xyz="0 0 0" />
       <link2 link="mass" xyz="0 0 0" />
     </linear_spring_damper>
   </force_element>

--- a/systems/plants/test/MassSpringDamperThrust.urdf
+++ b/systems/plants/test/MassSpringDamperThrust.urdf
@@ -12,7 +12,7 @@
   <material name="blue">
     <color rgba="0 0 1 1" />
   </material>
-  <link name="world"/>
+  <link name="base"/>
   <link name="mass">
     <inertial> 
       <origin xyz="0 0 0" rpy="0 0 0" />
@@ -28,13 +28,13 @@
     </visual> 
   </link>
   <joint name="x" type="prismatic">
-    <parent link="world"/>
+    <parent link="base"/>
     <child link="mass" />
     <axis xyz="1 0 0" />
   </joint>
   <force_element name="spring">
     <linear_spring_damper damping="1" stiffness="10">
-      <link1 link="world" xyz="0 0 0" />
+      <link1 link="base" xyz="0 0 0" />
       <link2 link="mass" xyz="0 0 0" />
     </linear_spring_damper>    
   </force_element>

--- a/systems/plants/test/SpringPendulum.urdf
+++ b/systems/plants/test/SpringPendulum.urdf
@@ -12,7 +12,7 @@
   <material name="blue">
     <color rgba="0 0 1 1" />
   </material>
-  <link name="world"/>
+  <link name="base"/>
   <link name="arm">
     <inertial>
       <origin xyz="0 0 -0.5" rpy="0 0 0" />
@@ -28,7 +28,7 @@
     </visual>
   </link>
   <joint name="theta" type="continuous">
-    <parent link="world" />
+    <parent link="base" />
     <child link="arm" />
     <origin xyz="0 0 0"/>
     <axis xyz="0 1 0" />
@@ -55,7 +55,7 @@
   </joint>
   <force_element name="spring">
     <linear_spring_damper stiffness="10" damping="1">
-      <link1 link="world" xyz="1 0 0"/>
+      <link1 link="base" xyz="1 0 0"/>
       <link2 link="ball" xyz="0 0 0"/>
     </linear_spring_damper>
   </force_element>

--- a/systems/plants/test/fixedJointTest.urdf
+++ b/systems/plants/test/fixedJointTest.urdf
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+
+<robot xmlns="http://drake.mit.edu"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://drake.mit.edu ../../doc/drakeURDF.xsd" name="FurutaPendulum">
+
+  <link name="base_link">
+    <inertial>
+      <mass value="1" />
+      <inertia ixx=".0067" ixy="0" ixz="0" iyy=".0067" iyz="0" izz="0.0067" />
+    </inertial>
+    <visual>
+      <geometry>
+         <box size=".2 .2 .2" />
+      </geometry>
+      <material name="green">
+      	<color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="upper_link">
+    <inertial>
+      <origin xyz="0 .5 0" rpy="0 0 0" />
+      <mass value="1" />
+      <inertia ixx=".084" ixy="0" ixz="0" iyy=".0013" iyz="0" izz=".084" />
+    </inertial>
+    <visual>
+      <origin xyz="0 .45 0" rpy="1.5708 0 0" />
+      <geometry>
+         <cylinder length="1" radius=".05" />
+      </geometry>
+      <material name="red">
+	      <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="lower_link">
+    <inertial>
+      <origin xyz="0 0 -1" rpy="0 0 0" />
+      <mass value="1" />
+      <!-- note: the inertia of a solid ROD about it's COM is mr^2/2, 1/12 m*(3r^2+L^2) -->
+      <inertia ixx=".3681" ixy="0" ixz="0" iyy="0.3681" iyz="0" izz=".0013" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 -1" rpy="0 0 0" />
+      <geometry>
+        <cylinder length="2.1" radius=".05" />
+      </geometry>
+      <material name="blue">
+	      <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+  
+  <joint name="shoulder" type="fixed">
+    <parent link="base_link" />
+    <child link="upper_link" />
+    <origin xyz="0 0 .15" />
+    <axis xyz="0 0 1" />
+    <dynamics damping="0.1" />
+  </joint>
+
+  <joint name="elbow" type="continuous">
+    <parent link="upper_link" />
+    <child link="lower_link" />
+    <origin xyz="0 1 0" />
+    <axis xyz="0 1 0" />
+    <dynamics damping="0.1" />
+  </joint>
+
+  <transmission type="SimpleTransmission" name="shoulder_trans">
+    <actuator name="shoulder_torque" />
+    <joint name="shoulder" />
+    <mechanicalReduction>1</mechanicalReduction>
+  </transmission>
+</robot>

--- a/systems/plants/test/testPositionConstraintsmex.m
+++ b/systems/plants/test/testPositionConstraintsmex.m
@@ -1,7 +1,9 @@
-function testPositionConstraintsmex
+function testPositionConstraintsmex(urdf)
 
 %create a robot with a lot of positions constraints
-urdf = fullfile('../../../examples/Atlas/urdf/robotiq.urdf');
+if nargin<1 || isempty(urdf)
+  urdf = fullfile('../../../examples/Atlas/urdf/robotiq.urdf');
+end
 robot = RigidBodyManipulator(urdf);
 robot_new = RigidBodyManipulator(urdf, struct('use_new_kinsol', true));
 

--- a/systems/plants/test/testURDFmex.m
+++ b/systems/plants/test/testURDFmex.m
@@ -1,4 +1,4 @@
-function testURDFmex
+function testURDFmex(urdfs)
 
 urdf_kin_test = '../../../pod-build/bin/urdfKinTest';
 urdf_manipulator_dynamics_test = '../../../pod-build/bin/urdfManipulatorDynamicsTest';
@@ -14,9 +14,15 @@ if (~exist(urdf_manipulator_dynamics_test,'file'))
   error('Drake:MissingDependency','testURDFmex requires that urdfManipulatorDynamicsTest is built (from the command line).  skipping this test');
 end
 
-tol = 1e-2; % low tolerance because i'm writing finite precision strings to and from the ascii terminal
+tol = .1; % low tolerance because i'm writing finite precision strings to and from the ascii terminal
 
-for urdf = allURDFs()'
+if nargin<1 || isempty(urdfs)
+  urdfs = allURDFs();
+elseif ~iscell(urdfs)
+  urdfs = {urdfs};
+end
+
+for urdf = urdfs'
   urdffile = GetFullPath(urdf{1});
   fprintf(1,'testing %s\n', urdffile);
   r = RigidBodyManipulator(urdffile,struct('floating',true,'use_new_kinsol',true));
@@ -68,7 +74,6 @@ for urdf = allURDFs()'
       bi = findLinkId(r,linknames{i},-1,1);
     catch
       % welded case
-      P(end+1,1)=0;
       continue;
     end
     if r.body(bi).parent~=0
@@ -78,6 +83,8 @@ for urdf = allURDFs()'
       end
     end
   end
+%  assert(isequal(P,eye(size(P))));  % eventually want to get rid of P (but
+%  doesn't work yet)
   num_qc = size(P,1);  % todo: update this when num_q ~= num_v
   num_vc = size(P,1);
   num_u = length(r.actuator);  % not getNumInputs, because RigidBodyForce elements are not parsed in C++ yet

--- a/systems/plants/test/testURDFmex.m
+++ b/systems/plants/test/testURDFmex.m
@@ -105,7 +105,7 @@ for urdf = urdfs'
     continue;
   end
   
-  v = 0*rand(getNumVelocities(r),1);
+  v = rand(getNumVelocities(r),1);
 
   [retval,outstr] = systemWCMakeEnv([urdf_manipulator_dynamics_test,' ',urdffile,sprintf(' %f',[P*q;P*v]),' 2> /dev/null']);
   valuecheck(retval,0);

--- a/systems/plants/test/testURDFmex.m
+++ b/systems/plants/test/testURDFmex.m
@@ -78,12 +78,13 @@ for urdf = allURDFs()'
   end
   num_qc = size(P,1);  % todo: update this when num_q ~= num_v
   num_vc = size(P,1);
+  num_u = length(r.actuator);  % not getNumInputs, because RigidBodyForce elements are not parsed in C++ yet
 
   Hcpp = textscan(outstr,'%f','HeaderLines',1+num_bodies);
   index = num_vc^2;
   Ccpp = reshape(Hcpp{1}(index+(1:num_vc)),num_vc,1);
   index = index + num_vc;
-  Bcpp = reshape(Hcpp{1}(index+(1:getNumInputs(r)*num_vc)),getNumInputs(r),num_vc)';
+  Bcpp = reshape(Hcpp{1}(index+(1:num_u*num_vc)),num_u,num_vc)';
   index = index + numel(Bcpp);
   num_phi = 3*length(r.loop);
   phicpp = reshape(Hcpp{1}(index+(1:num_phi)),num_phi,1);
@@ -95,6 +96,7 @@ for urdf = allURDFs()'
   Ccpp = P'*Ccpp;
   Bcpp = P'*Bcpp;
   [H,C,B] = manipulatorDynamics(r,q,v);
+  B = B(:,1:num_u); % ignore rigid body force inputs
 
   % low tolerance because i'm just parsing the ascii printouts
   valuecheck(Hcpp,H,tol);

--- a/systems/plants/test/testURDFmex.m
+++ b/systems/plants/test/testURDFmex.m
@@ -30,6 +30,7 @@ for urdf = allURDFs()'
 
   [retval,outstr] = systemWCMakeEnv([urdf_kin_test,' ',urdffile,sprintf(' %f',q),' 2> /dev/null']);
   valuecheck(retval,0);
+  outstr_cell = regexp(outstr, '=======', 'split');  outstr = outstr_cell{2}(2:end);
   out = textscan(outstr,'%s %f %f %f %f %f %f');%,'delimiter',',');
   
   for i=1:getNumBodies(r)
@@ -54,6 +55,7 @@ for urdf = allURDFs()'
 
   [retval,outstr] = systemWCMakeEnv([urdf_manipulator_dynamics_test,' ',urdffile,sprintf(' %f',q),' 2> /dev/null']);
   valuecheck(retval,0);
+  outstr_cell = regexp(outstr, '=======', 'split');  outstr = outstr_cell{2}(2:end);
 
   num_bodies = textscan(outstr,'%d',1); num_bodies=num_bodies{1};
   linknames = textscan(outstr,'%s',num_bodies,'HeaderLines',1); linknames = linknames{1};

--- a/systems/plants/test/urdfKinTest.cpp
+++ b/systems/plants/test/urdfKinTest.cpp
@@ -17,6 +17,7 @@ int main(int argc, char* argv[])
   	cerr << "ERROR: Failed to load model from " << argv[1] << endl;
   	return -1;
   }
+  cout << "=======" << endl;
 
   // run kinematics with second derivatives 100 times
   VectorXd q = VectorXd::Zero(model->num_positions);

--- a/systems/plants/test/urdfKinTest.cpp
+++ b/systems/plants/test/urdfKinTest.cpp
@@ -20,6 +20,7 @@ int main(int argc, char* argv[])
 
   // run kinematics with second derivatives 100 times
   VectorXd q = VectorXd::Zero(model->num_positions);
+  VectorXd v = VectorXd::Zero(model->num_velocities);
   int i;
 
   if (argc>=2+model->num_positions) {
@@ -29,7 +30,7 @@ int main(int argc, char* argv[])
 
 // for (i=0; i<model->num_dof; i++)
 // 	 q(i)=(double)rand() / RAND_MAX;
-    model->doKinematics(q,false);
+    model->doKinematicsNew(q,v);
 //  }
 
 //  const Vector4d zero(0,0,0,1);

--- a/systems/plants/test/urdfManipulatorDynamicsTest.cpp
+++ b/systems/plants/test/urdfManipulatorDynamicsTest.cpp
@@ -16,6 +16,7 @@ int main(int argc, char* argv[])
     cerr << "ERROR: Failed to load model from " << argv[1] << endl;
     return -1;
   }
+  cout << "=======" << endl;
 
   // the order of the bodies may be different in matlab, so print it out once here
   cout << model->num_bodies << endl;


### PR DESCRIPTION
Adds explicit support for fixed joints in the c++ kinematics.  (with @tkoolen)
Resolves #822 by fixing a fairly ridiculous number of little parsing bugs (in matlab and c++!).  testURDFmex now passes for all urdfs in drake and with random q.  
but also revealed a new(?) bug in the use_new_kinsol dynamics when v is random. 
