### PR TITLE
Add constraint type for gravity compensation torque

### DIFF
--- a/systems/controllers/controlUtil.cpp
+++ b/systems/controllers/controlUtil.cpp
@@ -398,16 +398,6 @@ std::vector<SupportStateElement> getActiveSupports(RigidBodyManipulator* r, void
   return active_supports;
 }
 
-void sizecheck(const mxArray* mat, int M, int N) {
-  if (mxGetM(mat) != M) {
-    mexErrMsgIdAndTxt("Drake:WrongSize", "wrong number of rows. Expected: %d but got: %d", M, mxGetM(mat));
-  }
-  if (mxGetN(mat) != N) {
-    mexErrMsgIdAndTxt("Drake:WrongSize", "wrong number of columns. Expected: %d but got: %d", N, mxGetN(mat));
-  }
-  return;
-}
-
 Vector6d bodyMotionPD(RigidBodyManipulator *r, DrakeRobotState &robot_state, const int body_index, const Ref<const Vector6d> &body_pose_des, const Ref<const Vector6d> &body_v_des, const Ref<const Vector6d> &body_vdot_des, const Ref<const Vector6d> &Kp, const Ref<const Vector6d> &Kd) {
 
   r->doKinematics(robot_state.q,false,robot_state.qd);

--- a/systems/controllers/controlUtil.h
+++ b/systems/controllers/controlUtil.h
@@ -74,7 +74,6 @@ drakeControlUtilEXPORT int contactPhi(RigidBodyManipulator* r, SupportStateEleme
 drakeControlUtilEXPORT int contactConstraints(RigidBodyManipulator *r, int nc, std::vector<SupportStateElement>& supp, void *map_ptr, MatrixXd &n, MatrixXd &D, MatrixXd &Jp, MatrixXd &Jpdot,double terrain_height);
 drakeControlUtilEXPORT int contactConstraintsBV(RigidBodyManipulator *r, int nc, double mu, std::vector<SupportStateElement>& supp, void *map_ptr, MatrixXd &B, MatrixXd &JB, MatrixXd &Jp, MatrixXd &Jpdot, MatrixXd &normals, double terrain_height);
 drakeControlUtilEXPORT MatrixXd individualSupportCOPs(RigidBodyManipulator* r, const std::vector<SupportStateElement>& active_supports, const MatrixXd& normals, const MatrixXd& B, const VectorXd& beta);
-drakeControlUtilEXPORT void sizecheck(const mxArray* mat, int M, int N);
 drakeControlUtilEXPORT Vector6d bodyMotionPD(RigidBodyManipulator *r, DrakeRobotState &robot_state, const int body_index, const Ref<const Vector6d> &body_pose_des, const Ref<const Vector6d> &body_v_des, const Ref<const Vector6d> &body_vdot_des, const Ref<const Vector6d> &Kp, const Ref<const Vector6d> &Kd);
 
 drakeControlUtilEXPORT void evaluateCubicSplineSegment(double t, const Ref<const Matrix<double, 6, 4>> &coefs, Vector6d &y, Vector6d &ydot, Vector6d &yddot);

--- a/systems/plants/constraint/CMakeLists.txt
+++ b/systems/plants/constraint/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories ( .. )
 include_directories (../constraint)
+include_directories (../../controllers)
 
 macro(add_constraint_mex)
   add_mex(${ARGV} ${ARGV}.cpp)
@@ -18,7 +19,7 @@ if(eigen3_FOUND)
   pods_install_headers(RigidBodyConstraint.h DESTINATION drake)
 
   add_mex(drakeConstructRigidBodyConstraint SHARED constructPtrRigidBodyConstraint.cpp)
-  target_link_libraries(drakeConstructRigidBodyConstraint drakeRigidBodyConstraint drakeRBM drakeUtil drakeGeometryUtil)
+  target_link_libraries(drakeConstructRigidBodyConstraint drakeRigidBodyConstraint drakeRBM drakeUtil drakeGeometryUtil drakeControlUtil)
   add_constraint_mex(testSingleTimeKinCnstmex)
   add_constraint_mex(testMultipleTimeKinCnstmex)
   add_constraint_mex(testQuasiStaticConstraintmex)

--- a/systems/plants/constraint/CMakeLists.txt
+++ b/systems/plants/constraint/CMakeLists.txt
@@ -19,7 +19,7 @@ if(eigen3_FOUND)
   pods_install_headers(RigidBodyConstraint.h DESTINATION drake)
 
   add_mex(drakeConstructRigidBodyConstraint SHARED constructPtrRigidBodyConstraint.cpp)
-  target_link_libraries(drakeConstructRigidBodyConstraint drakeRigidBodyConstraint drakeRBM drakeUtil drakeGeometryUtil drakeControlUtil)
+  target_link_libraries(drakeConstructRigidBodyConstraint drakeRigidBodyConstraint drakeRBM drakeUtil drakeGeometryUtil)
   add_constraint_mex(testSingleTimeKinCnstmex)
   add_constraint_mex(testMultipleTimeKinCnstmex)
   add_constraint_mex(testQuasiStaticConstraintmex)

--- a/systems/plants/constraint/GravityCompensationTorqueConstraint.m
+++ b/systems/plants/constraint/GravityCompensationTorqueConstraint.m
@@ -1,0 +1,58 @@
+classdef GravityCompensationTorqueConstraint < SingleTimeKinematicConstraint
+  properties (SetAccess = protected)
+    joint_indices
+    lb
+    ub
+  end
+  methods
+    function obj = GravityCompensationTorqueConstraint(robot, joint_indices, lb, ub, tspan)
+      if nargin < 5, tspan = [-Inf, Inf]; end
+      obj = obj@SingleTimeKinematicConstraint(robot, tspan);
+      obj.joint_indices = reshape(joint_indices, [], 1);
+      if isscalar(lb)
+        lb = repmat(lb, size(obj.joint_indices));
+      else
+        assert(numel(lb) == numel(obj.joint_indices), ...
+             ['lb must be either a scalar, or a vector with the same number '...
+              'of elements as joint_indices']);
+      end
+      if isscalar(ub)
+        ub = repmat(ub, size(obj.joint_indices));
+      else
+        assert(numel(ub) == numel(obj.joint_indices), ...
+             ['ub must be either a scalar, or a vector with the same number '...
+              'of elements as joint_indices']);
+      end
+      obj.lb = lb;
+      obj.ub = ub;
+      obj.num_constraint = numel(obj.joint_indices);
+      if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.GravityCompensationTorqueConstraintType,robot.getMexModelPtr, obj.joint_indices, obj.lb, obj.ub, tspan);
+      end
+    end
+
+    function [lb, ub] = bounds(obj, ~)
+      lb = obj.lb;
+      ub = obj.ub;
+    end
+
+    function obj = updateRobot(obj,robot)
+      obj.robot = robot;
+      obj.mex_ptr = updatePtrRigidBodyConstraintmex(obj.mex_ptr,'robot',robot.getMexModelPtr);
+    end
+
+    function name_str = name(obj, t)
+      joint_names = obj.robot.getPositionFrame().coordinates;
+      name_str = cellStrCat({'Gravity compensation torque constraint on  '}, ...
+                             joint_names(obj.joint_indices), ...
+                            {sprintf(' at time %10.4f',t)})';
+    end
+  end
+  methods (Access = protected)
+    function [c, dc] = evalValidTime(obj, kinsol)
+      [~, G, ~, ~, dG] = obj.robot.manipulatorDynamics(kinsol.q, zeros(obj.robot.getNumVelocities,1));
+      c = G(obj.joint_indices);
+      dc = dG(obj.joint_indices, 1:obj.robot.getNumPositions());
+    end
+  end
+end

--- a/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -2757,6 +2757,12 @@ void GravityCompensationTorqueConstraint::name(const double* t, std::vector<std:
 
 void GravityCompensationTorqueConstraint::bounds(const double* t, VectorXd& lb, VectorXd& ub) const
 {
-  lb = this->lb;
-  ub = this->ub;
+  if(this->isTimeValid(t))
+  {
+    lb = this->lb;
+    ub = this->ub;
+  } else {
+    lb.resize(0);
+    ub.resize(0);
+  }
 }

--- a/systems/plants/constraint/RigidBodyConstraint.h
+++ b/systems/plants/constraint/RigidBodyConstraint.h
@@ -81,6 +81,7 @@ class DLLEXPORT RigidBodyConstraint
     static const int RelativeQuatConstraintType                 = 24;
     static const int RelativeGazeDirConstraintType              = 25;
     static const int MinDistanceConstraintType                  = 26;
+    static const int GravityCompensationTorqueConstraintType    = 27;
 };
 
 /**
@@ -689,5 +690,23 @@ class DLLEXPORT PostureChangeConstraint: public MultipleTimeLinearPostureConstra
     virtual void name(const double* t, int n_breaks, std::vector<std::string> &name_str) const;
     virtual void bounds(const double* t, int n_breaks, Eigen::VectorXd &lb, Eigen::VectorXd &ub) const;
     virtual ~PostureChangeConstraint(){};
+};
+
+class DLLEXPORT GravityCompensationTorqueConstraint: public SingleTimeKinematicConstraint
+{
+  public:
+    GravityCompensationTorqueConstraint(RigidBodyManipulator* model,
+                                        const Eigen::VectorXi& joint_indices,
+                                        const Eigen::VectorXd& lb,
+                                        const Eigen::VectorXd& ub,
+                                        const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+    virtual void eval(const double* t,Eigen::VectorXd& c, Eigen::MatrixXd& dc) const;
+    virtual void name(const double* t, std::vector<std::string> &name) const;
+    virtual void bounds(const double* t, Eigen::VectorXd& lb, Eigen::VectorXd& ub) const;
+    virtual ~GravityCompensationTorqueConstraint(){};
+  protected:
+    Eigen::VectorXi joint_indices;
+    Eigen::VectorXd lb;
+    Eigen::VectorXd ub;
 };
 #endif

--- a/systems/plants/constraint/RigidBodyConstraint.m
+++ b/systems/plants/constraint/RigidBodyConstraint.m
@@ -53,6 +53,7 @@ classdef RigidBodyConstraint
     RelativeQuatConstraintType = 24;
     RelativeGazeDirConstraintType = 25;
     MinDistanceConstraintType = 26;
+    GravityCompensationTorqueConstraintType = 27;
   end
   
   methods

--- a/systems/plants/constraint/constraintTypemex.cpp
+++ b/systems/plants/constraint/constraintTypemex.cpp
@@ -105,6 +105,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     case RigidBodyConstraint::MinDistanceConstraintType:
       plhs[0] = mxCreateString("MinDistanceConstraint");
       break;
+    case RigidBodyConstraint::GravityCompensationTorqueConstraintType:
+      plhs[0] = mxCreateString("GravityCompensationTorqueConstraint");
+      break;
     default:
       mexErrMsgIdAndTxt("Drake:constraintTypemex:BadInputs","The constraint type is not supported");
       break;

--- a/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
+++ b/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
@@ -1136,7 +1136,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if(nrhs != 5 && nrhs != 6)
         {
           mexErrMsgIdAndTxt("Drake:constructPtrRigidBodyConstraintmex:BadInputs",
-              "Usage ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint::GravityCompensationTorqueConstraint, robot.mex_model_ptr, joint_ind, lb, ub, tspan)");
+              "Usage ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint::GravityCompensationTorqueConstraintType, robot.mex_model_ptr, joint_ind, lb, ub, tspan)");
         }
         RigidBodyManipulator* model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[1]);
         Vector2d tspan;

--- a/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
+++ b/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
@@ -2,6 +2,7 @@
 #include "RigidBodyManipulator.h"
 #include "RigidBodyConstraint.h"
 #include "drakeUtil.h"
+#include "controlUtil.h"
 using namespace Eigen;
 using namespace std;
 
@@ -1128,6 +1129,51 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         auto cnst = new MinDistanceConstraint(model,min_distance,active_bodies_idx,active_group_names,tspan);
         plhs[0] = createDrakeConstraintMexPointer((void*)cnst,
                                         "MinDistanceConstraint");
+      }
+      break;
+    case RigidBodyConstraint::GravityCompensationTorqueConstraintType:
+      {
+        if(nrhs != 5 && nrhs != 6)
+        {
+          mexErrMsgIdAndTxt("Drake:constructPtrRigidBodyConstraintmex:BadInputs",
+              "Usage ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint::GravityCompensationTorqueConstraint, robot.mex_model_ptr, joint_ind, lb, ub, tspan)");
+        }
+        RigidBodyManipulator* model = (RigidBodyManipulator*) getDrakeMexPointer(prhs[1]);
+        Vector2d tspan;
+        if(nrhs == 5)
+        {
+          tspan<< -mxGetInf(), mxGetInf();
+        }
+        else
+        {
+          rigidBodyConstraintParseTspan(prhs[5],tspan);
+        }
+
+        size_t num_joints(mxGetNumberOfElements(prhs[2]));
+
+        VectorXd joint_ind_tmp(num_joints);
+        memcpy(joint_ind_tmp.data(),mxGetPrSafe(prhs[2]),sizeof(double)*num_joints);
+
+        VectorXi joint_ind(num_joints);
+        for(int i = 0;i<num_joints;i++)
+        {
+          joint_ind(i) = (int) joint_ind_tmp(i)-1;
+          if(joint_ind(i)<0 || joint_ind(i)>=model->num_positions)
+          {
+            mexErrMsgIdAndTxt("Drake:constructPtrRigidBodyConstraintmex:BadInputs","joint_ind must be within [1,nq]");
+          }
+        }
+
+        VectorXd lb(num_joints);
+        VectorXd ub(num_joints);
+        sizecheck(prhs[3], num_joints, 1);
+        sizecheck(prhs[4], num_joints, 1);
+        memcpy(lb.data(),mxGetPrSafe(prhs[3]),sizeof(double)*num_joints);
+        memcpy(ub.data(),mxGetPrSafe(prhs[4]),sizeof(double)*num_joints);
+
+        auto cnst = new GravityCompensationTorqueConstraint(model,joint_ind,lb,ub,tspan);
+        plhs[0] = createDrakeConstraintMexPointer((void*)cnst,
+                                        "GravityCompensationTorqueConstraint");
       }
       break;
     default:

--- a/systems/plants/constraint/constructRigidBodyConstraint.m
+++ b/systems/plants/constraint/constructRigidBodyConstraint.m
@@ -60,6 +60,8 @@ else
       obj = RelativeQuatConstraint(varargin{:});
     case RigidBodyConstraint.MinDistanceConstraintType
       obj = MinDistanceConstraint(varargin{:});
+    case RigidBodyConstraint.GravityCompensationTorqueConstraintType
+      obj = GravityCompensationTorqueConstraint(varargin{:});
     otherwise
       error('Drake:constructRigidBodyConstraint:UnsupportedConstraintType','The constraint type is not supported yet');
   end

--- a/systems/plants/constraint/test/testKinCnst.m
+++ b/systems/plants/constraint/test/testKinCnst.m
@@ -245,6 +245,10 @@ testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.RelativeQuatC
   r_hand,l_hand,rpy2quat(randn(3,1)),5/180*pi,tspan0);
 testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.RelativeQuatConstraintType,robot,...
   r_hand,l_hand,rpy2quat(randn(3,1)),5/180*pi,tspan0);
+
+display('Check gravity compenstaion torque constraint');
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.GravityCompensationTorqueConstraintType,robot,robot_aff,robot.findPositionIndices('elx'),[-50;-70],[60;90],tspan0);
+testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.GravityCompensationTorqueConstraintType,robot,robot.findPositionIndices('elx'),[-50;-70],[60;90],tspan0);
 end
 
 function testKinCnst_userfun(singleTimeFlag,always_use_mex_dynamics,t,q,q_aff,cnst_type,robot,robot_aff,varargin)

--- a/systems/plants/constraint/updatePtrRigidBodyConstraintmex.cpp
+++ b/systems/plants/constraint/updatePtrRigidBodyConstraintmex.cpp
@@ -456,6 +456,22 @@ void mexFunction(int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[])
         }
       }
       break;
+    case RigidBodyConstraint::GravityCompensationTorqueConstraintType:
+      {
+        GravityCompensationTorqueConstraint* cnst = (GravityCompensationTorqueConstraint*) constraint;
+        if(field_str=="robot")
+        {
+          RigidBodyManipulator* robot = (RigidBodyManipulator*) getDrakeMexPointer(prhs[2]);
+          GravityCompensationTorqueConstraint* cnst_new = new GravityCompensationTorqueConstraint(*cnst);
+          cnst_new->updateRobot(robot);
+          plhs[0] = createDrakeConstraintMexPointer((void*) cnst_new,"GravityCompensationTorqueConstraint");
+        }
+        else
+        {
+          mexErrMsgIdAndTxt("Drake:updatePtrRigidBodyConstraintmex:BadInputs","GravityCompensationTorqueConstraint:argument 2 is not accepted");
+        }
+      }
+      break;
     default:
       mexErrMsgIdAndTxt("Drake:updatePtrRigidBodyConstraintmex:BadInputs","Unsupported constraint type");
       break;

--- a/util/drakeUtil.cpp
+++ b/util/drakeUtil.cpp
@@ -172,3 +172,13 @@ double * mxGetPrSafe(const mxArray *pobj) {
   if (!mxIsDouble(pobj)) mexErrMsgIdAndTxt("Drake:mxGetPrSafe:BadInputs", "mxGetPr can only be called on arguments which correspond to Matlab doubles");
   return mxGetPr(pobj);
 }
+
+void sizecheck(const mxArray* mat, int M, int N) {
+  if (mxGetM(mat) != M) {
+    mexErrMsgIdAndTxt("Drake:WrongSize", "wrong number of rows. Expected: %d but got: %d", M, mxGetM(mat));
+  }
+  if (mxGetN(mat) != N) {
+    mexErrMsgIdAndTxt("Drake:WrongSize", "wrong number of columns. Expected: %d but got: %d", N, mxGetN(mat));
+  }
+  return;
+}

--- a/util/drakeUtil.h
+++ b/util/drakeUtil.h
@@ -92,4 +92,6 @@ DLLEXPORT std::pair<Eigen::Vector3d, double> resolveCenterOfPressure(Eigen::Vect
 
 DLLEXPORT double *mxGetPrSafe(const mxArray *pobj);
 
+DLLEXPORT void sizecheck(const mxArray* mat, int M, int N);
+
 #endif /* DRAKE_UTIL_H_ */


### PR DESCRIPTION
Allows planning of postures in which the torques required for specific joints to resist gravity remain within some bounds. 