### PR TITLE
Fix testDrakeGradientUtil

### DIFF
--- a/util/test/testDrakeGradientUtil.cpp
+++ b/util/test/testDrakeGradientUtil.cpp
@@ -75,8 +75,8 @@ void testMatGradMultMat(int ntests, bool check)
     volatile auto vol = dAB; // volatile to make sure that the result doesn't get discarded in compiler optimization
 
     if (check) {
-      auto dAB_check = Eigen::kroneckerProduct(Eigen::MatrixXd::Identity(B.cols(), B.cols()), A) * dB
-          + Eigen::kroneckerProduct(B.transpose(), Eigen::MatrixXd::Identity(A.rows(), A.rows())) * dA;
+      auto dAB_check = (Eigen::kroneckerProduct(Eigen::MatrixXd::Identity(B.cols(), B.cols()), A) * dB
+          + Eigen::kroneckerProduct(B.transpose(), Eigen::MatrixXd::Identity(A.rows(), A.rows())) * dA).eval();
 
       if (!dAB.isApprox(dAB_check, 1e-10)) {
         throw std::runtime_error("wrong.");


### PR DESCRIPTION
Add a missing .eval() in testMatGradMultMat.
Fixes #913.