### PR TITLE
Add kinematics cache checks to new kinematics methods

### DIFF
--- a/examples/Atlas/+atlasUtil/plotWalkingTraj.m
+++ b/examples/Atlas/+atlasUtil/plotWalkingTraj.m
@@ -58,7 +58,7 @@ for i=1:length(ts)
   qd=xt(nq+(1:nq));
   qdd=qddtraj.eval(t);
 
-  kinsol = doKinematics(r,q);
+  kinsol = doKinematics(r, q, qd);
 
   [com(:,i),J]=getCOM(r,kinsol);
   Jdotv = centerOfMassJacobianDotTimesV(r,kinsol,0);

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -1033,7 +1033,7 @@ void RigidBodyManipulator::doKinematicsNew(const MatrixBase<DerivedQ>& q, const 
   EIGEN_STATIC_ASSERT_VECTOR_ONLY(MatrixBase<DerivedV>);
   assert(q.rows() == num_positions);
   assert(v.rows() == num_velocities || v.rows() == 0);
-  compute_JdotV = compute_JdotV && (v.rows() > 0); // no sense in computing Jdot times v if v is not passed in
+  compute_JdotV = compute_JdotV && (v.rows() == num_velocities); // no sense in computing Jdot times v if v is not passed in
 
   if (kinematicsInit) {
     bool skip = true;
@@ -1063,6 +1063,7 @@ void RigidBodyManipulator::doKinematicsNew(const MatrixBase<DerivedQ>& q, const 
       return;
     }
   }
+  kinematicsInit = true; // doing this here because there is a geometricJacobian within doKinematics below which checks for kinematicsInit.
 
   int nq = num_positions;
   int gradient_order = compute_gradients ? 1 : 0;
@@ -1226,10 +1227,9 @@ void RigidBodyManipulator::doKinematicsNew(const MatrixBase<DerivedQ>& q, const 
   // Have the collision model do any model-wide updates that it needs to
   collision_model->updateModel();
 
-  kinematicsInit = true;
   cached_inertia_gradients_order = -1;
   gradients_cached = compute_gradients;
-  velocity_kinematics_cached = v.rows() > 0;
+  velocity_kinematics_cached = v.rows() == num_velocities;
   jdotV_cached = compute_JdotV && velocity_kinematics_cached;
   for (int i = 0; i < num_positions; i++) cached_q[i] = q[i];
   if (v.rows() > 0) for (int i = 0; i < num_velocities; i++) cached_v[i] = v[i];

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -464,7 +464,7 @@ void RigidBodyManipulator::compile(void)
         }
       }
       if (!hasChild) {
-      	cout << "welding " << bodies[i]->getJoint().getName() << "because it has no inertia beneath it" << endl;
+      	cout << "welding " << bodies[i]->getJoint().getName() << " because it has no inertia beneath it" << endl;
         unique_ptr<DrakeJoint> joint_unique_ptr(new FixedJoint(bodies[i]->getJoint().getName(), bodies[i]->getJoint().getTransformToParentBody()));
         bodies[i]->setJoint(move(joint_unique_ptr));
       }

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -3508,6 +3508,11 @@ template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulat
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::forwardJacDotTimesV(const MatrixBase< Matrix<double, 3, 1> >&, int, int, int, int);
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::massMatrix(int);
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::inverseDynamics(std::map<int, std::unique_ptr<GradientVar<double, TWIST_SIZE, 1> > >& f_ext, GradientVar<double, Eigen::Dynamic, 1>* vd, int);
+template DLLEXPORT_RBM GradientVar<double, TWIST_SIZE, 1> RigidBodyManipulator::relativeTwist<double>(int, int, int, int);
+template DLLEXPORT_RBM GradientVar<double, 6, Dynamic> RigidBodyManipulator::worldMomentumMatrix<double>(int, const std::set<int>&, bool);
+template DLLEXPORT_RBM GradientVar<double, 6, 1> RigidBodyManipulator::transformSpatialAcceleration<double>(GradientVar<double, 6, 1> const&, int, int, int, int);
+template DLLEXPORT_RBM GradientVar<double, 6, 1> RigidBodyManipulator::worldMomentumMatrixDotTimesV<double>(int, const std::set<int>&);
+
 
 template DLLEXPORT_RBM void RigidBodyManipulator::HandC(MatrixBase<VectorXd> const &, MatrixBase<VectorXd> const &, MatrixBase< Map<MatrixXd> > * const, MatrixBase< Map<MatrixXd> > &, MatrixBase< Map<VectorXd> > &, MatrixBase< Map<MatrixXd> > *, MatrixBase< Map<MatrixXd> > *, MatrixBase< Map<MatrixXd> > * const);
 template DLLEXPORT_RBM void RigidBodyManipulator::HandC(MatrixBase<VectorXd> const &, MatrixBase<VectorXd> const &, MatrixBase< MatrixXd > * const, MatrixBase< MatrixXd > &, MatrixBase< VectorXd > &, MatrixBase< MatrixXd > *, MatrixBase< MatrixXd > *, MatrixBase< MatrixXd > * const);

--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -256,7 +256,6 @@ void getFiniteIndexes(T const & v, std::vector<int> &finite_indexes)
   }
 }
 
-
 RigidBodyManipulator::RigidBodyManipulator(int ndof, int num_featherstone_bodies, int num_rigid_body_objects, int num_rigid_body_frames)
   :  collision_model(DrakeCollision::newModel())
 {
@@ -431,6 +430,11 @@ void RigidBodyManipulator::resize(int ndof, int num_featherstone_bodies, int num
   initialized = false;
   kinematicsInit = false;
   secondDerivativesCached = 0;
+
+  gradients_cached = false;
+  velocity_kinematics_cached = false;
+  jdotV_cached = false;
+  cached_inertia_gradients_order = -1;
 }
 
 
@@ -1029,6 +1033,7 @@ void RigidBodyManipulator::doKinematicsNew(const MatrixBase<DerivedQ>& q, const 
   EIGEN_STATIC_ASSERT_VECTOR_ONLY(MatrixBase<DerivedV>);
   assert(q.rows() == num_positions);
   assert(v.rows() == num_velocities || v.rows() == 0);
+  compute_JdotV = compute_JdotV && (v.rows() > 0); // no sense in computing Jdot times v if v is not passed in
 
   if (kinematicsInit) {
     bool skip = true;
@@ -1312,6 +1317,7 @@ void RigidBodyManipulator::updateCompositeRigidBodyInertias(int gradient_order) 
   if (gradient_order > 1) {
     throw std::runtime_error("only first order gradients are available");
   }
+  checkCachedKinematicsSettings(gradient_order > 0, false, false, "updateCompositeRigidBodyInertias");
 
   if (gradient_order > cached_inertia_gradients_order) {
     for (int i = 0; i < num_bodies; i++) {
@@ -1348,6 +1354,7 @@ GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::worldMomen
     throw std::runtime_error("method requires new kinsol format");
   if (gradient_order > 1)
     throw std::runtime_error("only first order gradient is available");
+  checkCachedKinematicsSettings(gradient_order > 0, false, false, "worldMomentumMatrix");
 
   updateCompositeRigidBodyInertias(gradient_order);
 
@@ -1406,6 +1413,7 @@ GradientVar<Scalar, TWIST_SIZE, 1> RigidBodyManipulator::worldMomentumMatrixDotT
 
   if (gradient_order > 1)
     throw std::runtime_error("only first order gradient is available");
+  checkCachedKinematicsSettings(gradient_order > 0, true, true, "worldMomentumMatrixDotTimesV");
 
   updateCompositeRigidBodyInertias(gradient_order);
 
@@ -1438,6 +1446,7 @@ GradientVar<Scalar, TWIST_SIZE, 1> RigidBodyManipulator::worldMomentumMatrixDotT
 template <typename Scalar>
 GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::centroidalMomentumMatrix(int gradient_order, const std::set<int>& robotnum, bool in_terms_of_qdot)
 {
+  // kinematics cache checks already being done in worldMomentumMatrix.
   auto ret = worldMomentumMatrix<Scalar>(gradient_order, robotnum, in_terms_of_qdot);
 
   // transform from world frame to COM frame
@@ -1495,6 +1504,7 @@ GradientVar<Scalar, TWIST_SIZE, 1> RigidBodyManipulator::centroidalMomentumMatri
     return ret;
   }
 
+  // kinematics cache checks already being done in worldMomentumMatrixDotTimesV
   auto ret = worldMomentumMatrixDotTimesV<Scalar>(gradient_order, robotnum);
 
   // transform from world frame to COM frame:
@@ -1545,6 +1555,7 @@ GradientVar<Scalar, SPACE_DIMENSION, 1> RigidBodyManipulator::centerOfMass(int g
 {
   if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
+  checkCachedKinematicsSettings(false, false, false, "centerOfMass"); // don't check for gradients, that will be done in centerOfMassJacobian below.
 
   int nq = num_positions;
   GradientVar<Scalar, SPACE_DIMENSION, 1> com(SPACE_DIMENSION, 1, nq, gradient_order);
@@ -1583,6 +1594,7 @@ GradientVar<Scalar, SPACE_DIMENSION, Eigen::Dynamic> RigidBodyManipulator::cente
 {
   if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
+  checkCachedKinematicsSettings(gradient_order > 0, false, false, "centerOfMassJacobian");
 
   auto A = worldMomentumMatrix<Scalar>(gradient_order, robotnum, in_terms_of_qdot);
   GradientVar<Scalar, SPACE_DIMENSION, Eigen::Dynamic> ret(SPACE_DIMENSION, A.value().cols(), num_positions, gradient_order);
@@ -1609,6 +1621,7 @@ GradientVar<Scalar, SPACE_DIMENSION, 1> RigidBodyManipulator::centerOfMassJacobi
     return ret;
   }
 
+  // kinematics cache checks are already being done in centroidalMomentumMatrixDotTimesV
   auto cmm_dot_times_v = centroidalMomentumMatrixDotTimesV<Scalar>(gradient_order, robotnum);
   GradientVar<Scalar, SPACE_DIMENSION, 1> ret(SPACE_DIMENSION, 1, num_positions, gradient_order);
   double total_mass = getMass(robotnum);
@@ -2022,6 +2035,7 @@ GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::geometricJ
     if (gradient_order > 1) {
       throw std::runtime_error("gradient order not supported");
     }
+    checkCachedKinematicsSettings(gradient_order > 0, false, false, "geometricJacobian");
 
     KinematicPath kinematic_path;
     findKinematicPath(kinematic_path, base_body_or_frame_ind, end_effector_body_or_frame_ind);
@@ -2175,6 +2189,8 @@ GradientVar<Scalar, TWIST_SIZE, 1> RigidBodyManipulator::geometricJacobianDotTim
     throw std::runtime_error("method requires new kinsol format");
   if (gradient_order > 1)
     throw std::runtime_error("only first order gradient available");
+  checkCachedKinematicsSettings(gradient_order > 0, true, true, "geometricJacobianDotTimesV");
+
   GradientVar<Scalar, TWIST_SIZE, 1> ret(TWIST_SIZE, 1, num_positions, gradient_order);
 
   int base_body_ind = parseBodyOrFrameID(base_body_or_frame_ind);
@@ -2194,6 +2210,7 @@ GradientVar<Scalar, TWIST_SIZE, 1> RigidBodyManipulator::relativeTwist(int base_
 {
   if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
+  checkCachedKinematicsSettings(gradient_order > 0, true, false, "relativeTwist");
 
   GradientVar<Scalar, TWIST_SIZE, 1> ret(TWIST_SIZE, 1, num_positions, gradient_order);
 
@@ -2220,11 +2237,13 @@ GradientVar<Scalar, TWIST_SIZE, 1> RigidBodyManipulator::transformSpatialAcceler
   if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
 
+  int gradient_order = spatial_acceleration.maxOrder();
+  checkCachedKinematicsSettings(gradient_order > 0, true, true, "transformSpatialAcceleration");
+
   if (old_expressed_in_body_or_frame_ind == new_expressed_in_body_or_frame_ind) {
     return spatial_acceleration;
   }
 
-  int gradient_order = spatial_acceleration.maxOrder();
   GradientVar<Scalar, TWIST_SIZE, 1> ret(TWIST_SIZE, 1, num_positions, gradient_order);
 
   auto twist_of_body_wrt_base = relativeTwist<Scalar>(base_ind, body_ind, old_expressed_in_body_or_frame_ind, gradient_order);
@@ -2249,6 +2268,7 @@ GradientVar<Scalar, SPACE_DIMENSION + 1, SPACE_DIMENSION + 1> RigidBodyManipulat
 {
   if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
+  checkCachedKinematicsSettings(gradient_order > 0, false, false, "relativeTransform");
 
   int nq = num_positions;
   GradientVar<Scalar, SPACE_DIMENSION + 1, SPACE_DIMENSION + 1> ret(SPACE_DIMENSION + 1, SPACE_DIMENSION + 1, nq, gradient_order);
@@ -2478,13 +2498,11 @@ void RigidBodyManipulator::forwarddJac(const int body_or_frame_id, const MatrixB
 template<typename Scalar>
 GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::massMatrix(int gradient_order)
 {
-  if (!use_new_kinsol) {
+  if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
-  }
-
-  if (gradient_order > 1) {
+  if (gradient_order > 1)
     throw std::runtime_error("only first order gradients are available");
-  }
+  checkCachedKinematicsSettings(gradient_order > 0, false, false, "massMatrix");
 
   int nv = num_velocities;
   int nq = num_positions;
@@ -2556,13 +2574,11 @@ GradientVar<Scalar, Eigen::Dynamic, 1> RigidBodyManipulator::inverseDynamics(
     std::map<int, std::unique_ptr<GradientVar<Scalar, TWIST_SIZE, 1> > >& f_ext,
     GradientVar<Scalar, Eigen::Dynamic, 1>* vd, int gradient_order)
 {
-  if (!use_new_kinsol) {
+  if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
-  }
-
-  if (gradient_order > 1) {
+  if (gradient_order > 1)
     throw std::runtime_error("only first order gradients are available");
-  }
+  checkCachedKinematicsSettings(gradient_order > 0, true, true, "inverseDynamics");
 
   updateCompositeRigidBodyInertias(gradient_order);
 
@@ -2690,19 +2706,16 @@ GradientVar<Scalar, Eigen::Dynamic, 1> RigidBodyManipulator::inverseDynamics(
 template <typename DerivedPoints>
 GradientVar<typename DerivedPoints::Scalar, Eigen::Dynamic, DerivedPoints::ColsAtCompileTime> RigidBodyManipulator::forwardKinNew(const MatrixBase<DerivedPoints>& points, int current_body_or_frame_ind, int new_body_or_frame_ind, int rotation_type, int gradient_order)
 {
-  if (!use_new_kinsol) {
+  if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
-  }
-  if (gradient_order > 2) {
+  if (gradient_order > 2)
     throw std::runtime_error("only first and second order gradients are available");
-  }
-  if (gradient_order > 1 && !gradients_cached) {
-    throw std::runtime_error("must call doKinematics with compute_gradients set to true to compute forwardKin second derivatives");
-  }
 
   bool compute_jacobian_without_transform_gradients = gradient_order > 0 && !gradients_cached;
   int x_gradient_order = compute_jacobian_without_transform_gradients ? 0 : std::min(gradient_order, 1);
   int J_gradient_order = gradient_order > 1 ? gradient_order - 1 : 0;
+
+  checkCachedKinematicsSettings(x_gradient_order > 0, false, false, "forwardKinNew"); // rely on check in forwardJacV for Jacobian gradients
 
   int nq = num_positions;
   int npoints = static_cast<int>(points.cols());
@@ -2767,10 +2780,9 @@ GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwar
 {
   if (!use_new_kinsol)
     throw std::runtime_error("method requires new kinsol format");
-
-  if (gradient_order > 1) {
+  if (gradient_order > 1)
     throw std::runtime_error("only first order gradient is available");
-  }
+  checkCachedKinematicsSettings(gradient_order > 0, false, false, "forwardJacV");
 
   int nq = num_positions;
   int nv = num_velocities;
@@ -2878,6 +2890,7 @@ GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwar
   }
   if (gradient_order > 1)
     throw std::runtime_error("Only first order gradients supported");
+  checkCachedKinematicsSettings(gradient_order > 0, false, false, "forwardKinPositionGradient");
 
   int nq = num_positions;
   auto Tinv = relativeTransform<Scalar>(current_body_or_frame_ind, new_body_or_frame_ind, gradient_order);
@@ -2918,9 +2931,9 @@ GradientVar<typename DerivedPoints::Scalar, Eigen::Dynamic, 1> RigidBodyManipula
     return ret;
   }
 
-  if (gradient_order > 1) {
+  if (gradient_order > 1)
     throw std::runtime_error("only first order gradients are available");
-  }
+  checkCachedKinematicsSettings(gradient_order > 0, true, true, "forwardJacDotTimesV");
 
   typedef typename DerivedPoints::Scalar Scalar;
   int npoints = static_cast<int>(points.cols());
@@ -3412,6 +3425,18 @@ void RigidBodyManipulator::positionConstraints(MatrixBase<DerivedA> & phi, Matri
     phi.segment(3*i, 3) = bp_bodyA_pos1+bpTw_trans;
     J.block(3*i, 0, 3, nq) = dbp_bodyA_pos1dq+dbpTw_trans1dq;
   }
+}
+
+void RigidBodyManipulator::checkCachedKinematicsSettings(bool kinematics_gradients_required, bool velocity_kinematics_required, bool jdot_times_v_required, const std::string& method_name)
+{
+  if (!kinematicsInit)
+    throw runtime_error((method_name + " requires doKinematics to have been called.").c_str());
+  if (kinematics_gradients_required && ! gradients_cached)
+    throw runtime_error((method_name + " requires kinematics gradients, which have not been cached. Please call doKinematics with compute_gradients set to true.").c_str());
+  if (velocity_kinematics_required && ! velocity_kinematics_cached)
+    throw runtime_error((method_name + " requires velocity kinematics, which have not been cached. Please call doKinematics with a velocity vector.").c_str());
+  if (jdot_times_v_required && !jdotV_cached)
+    throw runtime_error((method_name + " requires Jdot times v, which has not been cached. Please call doKinematics with a velocity vector and compute_JdotV set to true.").c_str());
 }
 
 // explicit instantiations (required for linking):

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -332,6 +332,7 @@ private:
   void accumulateSecondOrderContactJacobian(const size_t bodyInd, MatrixXd const & bodyPoints, std::vector<size_t> const & cindA, std::vector<size_t> const & cindB, MatrixXd & dJ);
 
   int parseBodyOrFrameID(const int body_or_frame_id, Matrix4d* Tframe = nullptr);
+  void checkCachedKinematicsSettings(bool kinematics_gradients_required, bool velocity_kinematics_required, bool jdot_times_v_required, const std::string& method_name);
 
   // variables for featherstone dynamics
   std::vector<VectorXd> S;

--- a/systems/plants/test/CMakeLists.txt
+++ b/systems/plants/test/CMakeLists.txt
@@ -17,7 +17,7 @@ if (eigen3_FOUND)
   
   add_executable(testKinematicsCacheChecks testKinematicsCacheChecks.cpp)
   target_link_libraries(testKinematicsCacheChecks drakeRBM)
-  add_test(NAME testKinematicsCacheChecks COMMAND testKinematicsCacheChecks)
+  add_test(NAME testKinematicsCacheChecks WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" COMMAND testKinematicsCacheChecks)
 endif()
 
 macro(add_ik_cpp)

--- a/systems/plants/test/CMakeLists.txt
+++ b/systems/plants/test/CMakeLists.txt
@@ -15,7 +15,7 @@ if (eigen3_FOUND)
   add_executable(urdfManipulatorDynamicsTest urdfManipulatorDynamicsTest.cpp)
   target_link_libraries(urdfManipulatorDynamicsTest drakeRBM)
   
-  if (MSVC10)
+  if (NOT MSVC10)
     # this test does not compile on MSVC 2010 because of the use of variadic templates
     add_executable(testKinematicsCacheChecks testKinematicsCacheChecks.cpp)
     target_link_libraries(testKinematicsCacheChecks drakeRBM)

--- a/systems/plants/test/CMakeLists.txt
+++ b/systems/plants/test/CMakeLists.txt
@@ -14,6 +14,10 @@ if (eigen3_FOUND)
 
   add_executable(urdfManipulatorDynamicsTest urdfManipulatorDynamicsTest.cpp)
   target_link_libraries(urdfManipulatorDynamicsTest drakeRBM)
+  
+  add_executable(testKinematicsCacheChecks testKinematicsCacheChecks.cpp)
+  target_link_libraries(testKinematicsCacheChecks drakeRBM)
+  add_test(NAME testKinematicsCacheChecks COMMAND testKinematicsCacheChecks)
 endif()
 
 macro(add_ik_cpp)

--- a/systems/plants/test/CMakeLists.txt
+++ b/systems/plants/test/CMakeLists.txt
@@ -15,9 +15,12 @@ if (eigen3_FOUND)
   add_executable(urdfManipulatorDynamicsTest urdfManipulatorDynamicsTest.cpp)
   target_link_libraries(urdfManipulatorDynamicsTest drakeRBM)
   
-  add_executable(testKinematicsCacheChecks testKinematicsCacheChecks.cpp)
-  target_link_libraries(testKinematicsCacheChecks drakeRBM)
-  add_test(NAME testKinematicsCacheChecks WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" COMMAND testKinematicsCacheChecks)
+  if (MSVC10)
+    # this test does not compile on MSVC 2010 because of the use of variadic templates
+    add_executable(testKinematicsCacheChecks testKinematicsCacheChecks.cpp)
+    target_link_libraries(testKinematicsCacheChecks drakeRBM)
+    add_test(NAME testKinematicsCacheChecks WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" COMMAND testKinematicsCacheChecks)
+  endif()
 endif()
 
 macro(add_ik_cpp)

--- a/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -1,0 +1,150 @@
+#include "RigidBodyManipulator.h"
+#include "RigidBodyManipulator.h"
+#include "drakeGeometryUtil.h"
+#include "GradientVar.h"
+#include <iostream>
+#include <cstdlib>
+#include <random>
+#include <memory>
+#include <stdexcept>
+#include <map>
+
+using namespace std;
+using namespace Eigen;
+
+struct CheckSettings {
+  bool expect_error_on_configuration_methods;
+  bool expect_error_on_velocity_methods;
+  bool expect_error_on_jdot_times_v_methods;
+};
+
+template<typename O, typename F, typename ...Args>
+void checkForErrors(bool expect_error, O& object, F function, Args&&... arguments)
+{
+  try {
+    (object.*function)(std::forward<Args>(arguments)...);
+  }
+  catch (runtime_error& e) {
+    if (expect_error)
+      return;
+    else
+      throw std::runtime_error("Caught an unexpected runtime error.");
+  }
+  if (expect_error)
+    throw std::runtime_error("Expected a runtime error, but did not catch one.");
+}
+
+void performChecks(RigidBodyManipulator& model, int gradient_order, const CheckSettings& settings)
+{
+  auto points = Matrix<double, 3, Eigen::Dynamic>::Random(3, 5).eval();
+  typedef decltype(points) PointsType;
+  int body_or_frame_ind = 8;
+  int base_or_frame_ind = 0;
+  int expressed_in_frame_ind = body_or_frame_ind;
+  int old_expressed_in_body_or_frame_ind = 7;
+  int new_expressed_in_body_or_frame_ind = 3;
+  int rotation_type = 0;
+  bool in_terms_of_qdot = false;
+  std::vector<int> v_or_qdot_indices;
+  int npoints = 3;
+  int nq = model.num_positions;
+  GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> x_gradientvar(points.rows() + rotationRepresentationSize(rotation_type), npoints, nq, gradient_order);
+  x_gradientvar.value().setRandom();
+  if (gradient_order > 0)
+    x_gradientvar.gradient().value().setRandom();
+  GradientVar<double, TWIST_SIZE, 1> spatial_acceleration(TWIST_SIZE, 1, nq, gradient_order);
+  spatial_acceleration.value().setRandom();
+  if (gradient_order > 0)
+    spatial_acceleration.gradient().value().setRandom();
+  std::map<int, std::unique_ptr<GradientVar<double, TWIST_SIZE, 1> > > f_ext;
+
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::worldMomentumMatrix<double>, gradient_order, RigidBody::defaultRobotNumSet, in_terms_of_qdot);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::centroidalMomentumMatrix<double>, gradient_order, RigidBody::defaultRobotNumSet, in_terms_of_qdot);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::centerOfMass<double>, gradient_order + 1, RigidBody::defaultRobotNumSet);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::centerOfMassJacobian<double>, gradient_order, RigidBody::defaultRobotNumSet, in_terms_of_qdot);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::geometricJacobian<double>, base_or_frame_ind, body_or_frame_ind, expressed_in_frame_ind, gradient_order, in_terms_of_qdot, &v_or_qdot_indices);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::relativeTransform<double>, base_or_frame_ind, body_or_frame_ind, gradient_order);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::massMatrix<double>, gradient_order);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::forwardKinNew<PointsType>, points, body_or_frame_ind, base_or_frame_ind, rotation_type, gradient_order + 1);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::forwardKinPositionGradient<double>, npoints, body_or_frame_ind, base_or_frame_ind, gradient_order);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::forwardJacV<double, Dynamic, Dynamic>, x_gradientvar, body_or_frame_ind, base_or_frame_ind, rotation_type, in_terms_of_qdot, gradient_order);
+
+  checkForErrors(settings.expect_error_on_velocity_methods, model, &RigidBodyManipulator::relativeTwist<double>, base_or_frame_ind, body_or_frame_ind, expressed_in_frame_ind, gradient_order);
+
+  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyManipulator::geometricJacobianDotTimesV<double>, base_or_frame_ind, body_or_frame_ind, expressed_in_frame_ind, gradient_order);
+  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyManipulator::worldMomentumMatrixDotTimesV<double>, gradient_order, RigidBody::defaultRobotNumSet);
+  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyManipulator::centroidalMomentumMatrixDotTimesV<double>, gradient_order, RigidBody::defaultRobotNumSet);
+  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyManipulator::centerOfMassJacobianDotTimesV<double>, gradient_order, RigidBody::defaultRobotNumSet);
+  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyManipulator::forwardJacDotTimesV<PointsType>, points, body_or_frame_ind, base_or_frame_ind, rotation_type, gradient_order);
+  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyManipulator::transformSpatialAcceleration<double>, spatial_acceleration, base_or_frame_ind, body_or_frame_ind, old_expressed_in_body_or_frame_ind, new_expressed_in_body_or_frame_ind);
+  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyManipulator::inverseDynamics<double>, f_ext, nullptr, gradient_order);
+}
+
+int main()
+{
+  std::unique_ptr<RigidBodyManipulator> model(new RigidBodyManipulator("examples/Atlas/urdf/atlas_minimal_contact.urdf"));
+  if(!model)
+  {
+    cerr<<"ERROR: Failed to load model"<<endl;
+  }
+  model->use_new_kinsol = true;
+  CheckSettings settings;
+  int max_gradient_order = 2;
+
+  // check before calling doKinematics
+  settings.expect_error_on_configuration_methods = true;
+  settings.expect_error_on_velocity_methods = true;
+  settings.expect_error_on_jdot_times_v_methods = true;
+  for (int gradient_order = 0; gradient_order < max_gradient_order; gradient_order++)
+    performChecks(*model, gradient_order, settings);
+
+  // q only, no gradients
+  VectorXd q = VectorXd::Random(model->num_positions);
+  VectorXd v = VectorXd::Zero(0);
+  model->doKinematicsNew(q, v, false, false);
+  for (int gradient_order = 1; gradient_order < max_gradient_order; gradient_order++)
+    performChecks(*model, gradient_order, settings); // still expect everything to fail for gradient_order > 0
+  settings.expect_error_on_configuration_methods = false;
+  performChecks(*model, 0, settings);
+
+  // q only, with gradients
+  model->doKinematicsNew(q, v, true, false);
+  for (int gradient_order = 0; gradient_order < max_gradient_order; gradient_order++)
+    performChecks(*model, gradient_order, settings);
+
+  // q and v, no gradients, no jdot_times_v
+  v = VectorXd::Random(model->num_velocities);
+  model->doKinematicsNew(q, v, false, false);
+  settings.expect_error_on_configuration_methods = true;
+  settings.expect_error_on_velocity_methods = true;
+  settings.expect_error_on_jdot_times_v_methods = true;
+  for (int gradient_order = 1; gradient_order < max_gradient_order; gradient_order++)
+    performChecks(*model, gradient_order, settings); // still expect everything to fail for gradient_order > 0
+  settings.expect_error_on_configuration_methods = false;
+  settings.expect_error_on_velocity_methods = false;
+  performChecks(*model, 0, settings);
+
+  // q and v, with gradients, no jdot_times_v
+  model->doKinematicsNew(q, v, true, false);
+  for (int gradient_order = 0; gradient_order < max_gradient_order; gradient_order++)
+    performChecks(*model, gradient_order, settings);
+
+  // q and v, no gradients, with jdot_times_v
+  model->doKinematicsNew(q, v, false, true);
+  settings.expect_error_on_configuration_methods = true;
+  settings.expect_error_on_velocity_methods = true;
+  settings.expect_error_on_jdot_times_v_methods = true;
+  for (int gradient_order = 1; gradient_order < max_gradient_order; gradient_order++)
+    performChecks(*model, gradient_order, settings); // still expect everything to fail for gradient_order > 0
+  settings.expect_error_on_configuration_methods = false;
+  settings.expect_error_on_velocity_methods = false;
+  settings.expect_error_on_jdot_times_v_methods = false;
+  performChecks(*model, 0, settings);
+
+  // q and v, with gradients, with jdot_times_v
+  model->doKinematicsNew(q, v, true, true);
+  for (int gradient_order = 0; gradient_order < max_gradient_order; gradient_order++)
+    performChecks(*model, gradient_order, settings);
+
+  return 0;
+}

--- a/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -83,7 +83,7 @@ void performChecks(RigidBodyManipulator& model, int gradient_order, const CheckS
 int main()
 {
   std::unique_ptr<RigidBodyManipulator> model(new RigidBodyManipulator("examples/Atlas/urdf/atlas_minimal_contact.urdf"));
-  if(!model)
+  if (model == nullptr)
   {
     cerr<<"ERROR: Failed to load model"<<endl;
   }


### PR DESCRIPTION
Also added a test that ensures that runtime errors are thrown if and only if you don't have the required kinematics quantities cached.
Fixes #923.