### PR TITLE
solveLCPmex now checks for gurobi at run time

### DIFF
--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -17,6 +17,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
     enable_fastqp; % whether we use the active set LCP
     lcmgl_contact_forces_scale = 0;  % <=0 implies no lcmgl
     z_inactive_guess_tol = .01;
+    gurobi_present = false;
   end
 
   methods
@@ -118,6 +119,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
 
     function model = compile(model)
       w = warning('off','Drake:RigidBodyManipulator:UnsupportedContactPoints');
+      model.gurobi_present = checkDependency('gurobi');
       model.manip = model.manip.compile();
       warning(w);
 
@@ -183,7 +185,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
       if (nargout>1)
         [obj,z,Mqdn,wqdn,dz,dMqdn,dwqdn] = solveLCP(obj,t,x,u);
       else
-        if (obj.manip.only_loops && obj.manip.mex_model_ptr~=0 && ~obj.position_control)
+        if (obj.gurobi_present && obj.manip.only_loops && obj.manip.mex_model_ptr~=0 && ~obj.position_control)
            [obj,z,Mqdn,wqdn] = solveMexLCP(obj,t,x,u);
            %[obj,z,Mqdn,wqdn] = solveLCP(obj,t,x,u);
         else


### PR DESCRIPTION
...and caches the result during compile.

Resolves #934 