### PR TITLE
Proposed fix for testJointCalibration failures + speedup

### DIFF
--- a/systems/robotInterfaces/calibration/motionCaptureJointCalibration.m
+++ b/systems/robotInterfaces/calibration/motionCaptureJointCalibration.m
@@ -67,7 +67,11 @@ if options.search_floating
     error('Calling this function with options.search_floating = true currently requires the first joint in the kinematic chain to be an rpy-parameterized floating joint.');
   end
   floating_indices = floating_body.position_num;
-  floating_states0 = [zeros(3, nposes); ones(1, nposes); zeros(3, nposes)]; % zero rotation in quaternion
+  floating_states0 = zeros(7, nposes);
+  floating_states0(1 : 3, :) = q_data(floating_body.position_num(1 : 3), :);
+  for i = 1 : nposes
+    floating_states0(4 : 7, i) = rpy2quat(q_data(floating_body.position_num(4 : 6), i));
+  end  
 else
   floating_indices = zeros(0, 1);
   floating_states0 = zeros(0, nposes);

--- a/systems/robotInterfaces/calibration/test/testJointCalibration.m
+++ b/systems/robotInterfaces/calibration/test/testJointCalibration.m
@@ -1,8 +1,6 @@
 function testJointCalibration
-s = rng(215615, 'twister');
 testJointOffsetCalibration();
 testJointStiffnessCalibration();
-rng(s);
 end
 
 function testJointOffsetCalibration()
@@ -12,10 +10,12 @@ num_poses = 10;
 q_offset_max = 1e-2;
 q_noise_stddev = 1e-6;
 
+s = rng(1234, 'twister');
 q_offset_actual = 2 * (rand(length(q_indices), 1) - 0.5) * q_offset_max;
 q_measured = q_actual + q_noise_stddev * randn(size(q_actual));
 q_measured(q_indices, :) = q_measured(q_indices, :) - repmat(q_offset_actual, 1, num_poses);
 scales = {100, 1};
+rng(s);
 
 options.search_floating = true;
 [q_offset_estimated, marker_params, floating_states] = jointOffsetCalibration(r, q_measured, q_indices, ...
@@ -33,7 +33,7 @@ checkFloatingStates(r, bodies, q_actual, floating_states, num_poses);
 end
 
 function testJointStiffnessCalibration()
-num_poses = 15;
+num_poses = 30;
 k_nominal = 0.5e4;
 k_max_deviation = 1e4;
 k_initial_stddev = 1e3;
@@ -41,6 +41,8 @@ q_noise_stddev = 1e-5;
 u_stddev = 150;
 
 [r, q_actual, q_indices, bodies, marker_positions_actual, marker_functions, num_unmeasured_markers, vicon_data] = setUp(num_poses);
+
+s = rng(1234, 'twister');
 
 nk = length(q_indices);
 k_actual = k_nominal * ones(nk, 1) + rand(nk, 1) * k_max_deviation;
@@ -58,10 +60,10 @@ q_measured(q_indices, :) = q_measured(q_indices, :) - dq_actual;
 k_initial = abs(k_actual + k_initial_stddev * randn(nk, 1));
 scales = {1, 1};
 
+rng(s);
+
 options.search_floating = true;
 
-
-options.search_floating = true;
 [k_estimated, marker_params, floating_states] = jointStiffnessCalibration(r, q_measured, u_data, q_indices, ...
   bodies, marker_functions, cellfun(@(x) 3 * x, num_unmeasured_markers, 'UniformOutput', false), vicon_data, ...
   scales, k_initial, options);
@@ -94,6 +96,8 @@ vicon_data_noise_stddev = 1e-6;
 marker_offset_max = 0.1;
 num_markers = 4;
 num_measured_markers = 3;
+
+s = rng(215615, 'twister');
 
 % actual ('perfect') joint configurations
 nq = r.getNumPositions();
@@ -143,6 +147,8 @@ marker_functions = cell(length(bodies), 1);
 for i = 1 : length(bodies)
   marker_functions{i} = @(params) markerPositions(params, marker_positions_measured{i});
 end
+
+rng(s);
 end
 
 function [x, dx] = markerPositions(params, marker_positions_measured)


### PR DESCRIPTION
Fixes #866.

testJointCalibration started failing reliably on drake004 on March 15. Although the test continued to pass on other machines, the exact values going into the valuecheck also changed on other machines around March 15.

testJointCalibration used a fixed random seed to try to get repeatable test results. We have already established that despite fixing the random seed, behavior can still differ between versions of Matlab and/or the OS.

I believe that a commit around March 15 probably introduced additional calls to one of Matlab's random functions (or deleted some), which changed the state of the random number generator at the point where the random test data was generated. Although I haven't been able to track down the exact commit where things changed, I think this is a likely explanation.

The goal of this pull request is to get repeatable behavior on any given machine, even if additional random function calls are done outside of the test code, by setting random seeds just before generating the mock measurements (as proposed by Russ). This also separates testJointOffsetCalibration from testJointStiffnessCalibration, in the sense that running them in any order gives the same results. I've also increased the number of poses for the stiffness calibration test from 15 to 30 because this significantly reduces stiffness estimation errors on average and this number of poses would likely be required for a test with real data. Finally, I tried to reduce the time it takes to run the test by setting the initial guess for the floating states to what's passed in as q_data for the floating joint. Even with real data, that's likely to be a far better guess than a zero floating base pose.
