### PR TITLE
Direct Mex-to-Mex LCP invocation

### DIFF
--- a/systems/plants/CMakeLists.txt
+++ b/systems/plants/CMakeLists.txt
@@ -1,7 +1,4 @@
-
-
 include_directories (${CMAKE_SOURCE_DIR}/util tinyxml)
-
 # IMPORTANT NOTE!!
 # matlab has it's own boost libraries.  DO NOT let any mex file depend
 # on the system boost (directly nor indirectly), or you're asking for trouble.
@@ -71,8 +68,9 @@ if (eigen3_FOUND)
   add_rbm_mex(surfaceTangentsmex)
   add_rbm_mex(jointLimitConstraintsmex)
   add_rbm_mex(positionConstraintsmex)
-  
+
   if(gurobi_FOUND)
+    add_definitions(-DPATHLCP_MEXFILE=\"${CMAKE_SOURCE_DIR}/thirdParty/path/lcppath.${MEX_EXT}\")
     add_mex(solveLCPmex solveLCPmex.cpp)
     target_link_libraries(solveLCPmex drakeRBM drakeUtil drakeQP)
   endif()

--- a/systems/plants/CMakeLists.txt
+++ b/systems/plants/CMakeLists.txt
@@ -73,8 +73,8 @@ if (eigen3_FOUND)
   add_rbm_mex(positionConstraintsmex)
   
   if(gurobi_FOUND)
-    add_mex(setupLCPmex setupLCPmex.cpp)
-    target_link_libraries(setupLCPmex drakeRBM drakeUtil drakeQP)
+    add_mex(solveLCPmex solveLCPmex.cpp)
+    target_link_libraries(solveLCPmex drakeRBM drakeUtil drakeQP)
   endif()
   
   

--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -18,7 +18,6 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
     lcmgl_contact_forces_scale = 0;  % <=0 implies no lcmgl
     z_inactive_guess_tol = .01;
     gurobi_present = false;
-    lcp_mexfile;
   end
 
   methods
@@ -121,7 +120,6 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
     function model = compile(model)
       w = warning('off','Drake:RigidBodyManipulator:UnsupportedContactPoints');
       model.gurobi_present = checkDependency('gurobi');
-      model.lcp_mexfile = which('lcppath');
       model.manip = model.manip.compile();
       warning(w);
 
@@ -241,7 +239,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
         v=x(num_q+(1:obj.manip.num_velocities));
         kinsol = doKinematics(obj,q);
         [phiC,~,~,~,~,~,~,mu,n,D] = obj.manip.contactConstraints(kinsol,true);
-        [z, Mqdn, wqdn] = solveLCPmex(obj.manip.mex_model_ptr, q, v, u, phiC, n, D, obj.timestep, obj.z_inactive_guess_tol, obj.LCP_cache.data.z, obj.lcp_mexfile);
+        [z, Mqdn, wqdn] = solveLCPmex(obj.manip.mex_model_ptr, q, v, u, phiC, n, D, obj.timestep, obj.z_inactive_guess_tol, obj.LCP_cache.data.z);
         obj.LCP_cache.data.z = z;
     end
     

--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -609,9 +609,10 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
               % M(z_active,z_inactive)*z(z_inactive)+w(z_active) >= 0  % since we're assuming that z(z_active) == 0
               z_active = ~z_inactive(1:(nL+nP+nC));  % only look at joint limit, position, and normal variables since if cn_i = 0, 
               % then that's a solution and we don't care about the relative velocity \lambda_i
-              QP_FAILED1 = (~isempty(w(z_active)) && any(M(z_active,z_inactive)*z(z_inactive)+w(z_active) < 0));
-              QP_FAILED2 = any(((z(z_inactive)>lb(z_inactive)+1e-8) & (M(z_inactive, z_inactive)*z(z_inactive)+w(z_inactive)>1e-8)));
-              QP_FAILED = QP_FAILED1 || QP_FAILED2;
+              
+              QP_FAILED = (~isempty(w(z_active)) && any(M(z_active,z_inactive)*z(z_inactive)+w(z_active) < 0)) || ...
+                  any(((z(z_inactive)>lb(z_inactive)+1e-8) & (M(z_inactive, z_inactive)*z(z_inactive)+w(z_inactive)>1e-8))) || ...
+                  any(abs(z_'*(Aeq*z_ - beq)) > 1e-6);
             end
           end
         end

--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -18,6 +18,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
     lcmgl_contact_forces_scale = 0;  % <=0 implies no lcmgl
     z_inactive_guess_tol = .01;
     gurobi_present = false;
+    lcp_mexfile;
   end
 
   methods
@@ -120,6 +121,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
     function model = compile(model)
       w = warning('off','Drake:RigidBodyManipulator:UnsupportedContactPoints');
       model.gurobi_present = checkDependency('gurobi');
+      model.lcp_mexfile = which('lcppath');
       model.manip = model.manip.compile();
       warning(w);
 
@@ -239,7 +241,7 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
         v=x(num_q+(1:obj.manip.num_velocities));
         kinsol = doKinematics(obj,q);
         [phiC,~,~,~,~,~,~,mu,n,D] = obj.manip.contactConstraints(kinsol,true);
-        [z, Mqdn, wqdn] = setupLCPmex(obj.manip.mex_model_ptr, q, v, u, phiC, n, D, obj.timestep, obj.z_inactive_guess_tol, obj.LCP_cache.data.z);
+        [z, Mqdn, wqdn] = solveLCPmex(obj.manip.mex_model_ptr, q, v, u, phiC, n, D, obj.timestep, obj.z_inactive_guess_tol, obj.LCP_cache.data.z, obj.lcp_mexfile);
         obj.LCP_cache.data.z = z;
     end
     

--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -237,9 +237,10 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
         num_q = obj.manip.num_positions;
         q=x(1:num_q); 
         v=x(num_q+(1:obj.manip.num_velocities));
-        kinsol = doKinematics(obj,q);
-        [phiC,~,~,~,~,~,~,mu,n,D] = obj.manip.contactConstraints(kinsol,true);
-        [z, Mqdn, wqdn] = solveLCPmex(obj.manip.mex_model_ptr, q, v, u, phiC, n, D, obj.timestep, obj.z_inactive_guess_tol, obj.LCP_cache.data.z);
+        kinsol = doKinematics(obj, q);
+        [H,C,B] = manipulatorDynamics(obj.manip, q, v);
+        [phiC,~,~,~,~,~,~,mu,n,D] = obj.manip.contactConstraints(kinsol, true);
+        [z, Mqdn, wqdn] = solveLCPmex(obj.manip.mex_model_ptr, q, v, u, phiC, n, D, obj.timestep, obj.z_inactive_guess_tol, obj.LCP_cache.data.z, H, C, B);
         obj.LCP_cache.data.z = z;
     end
     

--- a/systems/plants/solveLCPmex.cpp
+++ b/systems/plants/solveLCPmex.cpp
@@ -120,8 +120,6 @@ inline void filterByIndices(vector<size_t> const &indices, VectorXd const & v, V
   }
 }
 
-//fastQP(std::vector< Eigen::MatrixXd* > QblkDiag, const Eigen::VectorXd& f, const Eigen::MatrixXd& Aeq, 
-//const Eigen::VectorXd& beq, const Eigen::MatrixXd& Ain, const Eigen::VectorXd& bin, std::set<int>& active, Eigen::VectorXd& x);
 template <typename DerivedM, typename Derivedw, typename Derivedlb, typename Derivedz>
 bool callFastQP(MatrixBase<DerivedM> const & M, MatrixBase<Derivedw> const & w, MatrixBase<Derivedlb> const & lb, vector<bool> & z_inactive, const size_t checkLimit,  MatrixBase<Derivedz> & z) 
 {
@@ -182,11 +180,9 @@ bool callFastQP(MatrixBase<DerivedM> const & M, MatrixBase<Derivedw> const & w, 
 
 //[z, Mqdn, wqdn] = setupLCPmex(mex_model_ptr, q, qd, u, phiC, n, D, h, z_inactive_guess_tol)
 void mexFunction(int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) { 
-  
-  if (nlhs != 3 || nrhs != 11) {
-    mexErrMsgIdAndTxt("Drake:setupLCPmex:InvalidUsage","Usage: [z, Mqdn, wqdn, zqp] = setupLCPmex(mex_model_ptr, q, qd, u, phiC, n, D, h, z_inactive_guess_tol, z_cached, lcp_mexfile)");
+  if (nlhs != 3 || nrhs != 10) {
+    mexErrMsgIdAndTxt("Drake:setupLCPmex:InvalidUsage","Usage: [z, Mqdn, wqdn, zqp] = setupLCPmex(mex_model_ptr, q, qd, u, phiC, n, D, h, z_inactive_guess_tol, z_cached)");
   }
-  char lcp_mexfile[256];
 
   RigidBodyManipulator *model= (RigidBodyManipulator*) getDrakeMexPointer(prhs[0]);
   const int nq = model->num_positions;
@@ -202,7 +198,6 @@ void mexFunction(int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
   const mxArray* h_array = prhs[7];
   const mxArray* inactive_guess_array = prhs[8];
   const mxArray* z_cached_array = prhs[9];
-  const mxArray* lcp_mexfile_array = prhs[10];  
 
   const size_t num_z_cached = mxGetNumberOfElements(z_cached_array);
   const size_t num_contact_pairs = mxGetNumberOfElements(phiC_array);
@@ -215,7 +210,6 @@ void mexFunction(int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
   const Map<VectorXd> phiC(mxGetPrSafe(phiC_array), num_contact_pairs);
   const Map<MatrixXd> n(mxGetPrSafe(n_array), num_contact_pairs, nq);
   const Map<VectorXd> z_cached(mxGetPrSafe(z_cached_array), num_z_cached);
-  mxGetString(lcp_mexfile_array, lcp_mexfile, 256);
   
   VectorXd C, phiL, phiP, phiL_possible, phiC_possible, phiL_check, phiC_check;
   MatrixXd H, B, JP, JL, JL_possible, n_possible, JL_check, n_check;
@@ -350,8 +344,7 @@ void mexFunction(int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
     z_path = VectorXd::Zero(lcp_size);
     //fall back to pathlcp
     if(qp_failed) {
-      //TODO: fix this path
-      callMexStandalone(lcp_mexfile, 2, lhs, 7, const_cast<const mxArray**>(rhs));
+      callMexStandalone(PATHLCP_MEXFILE, 2, lhs, 7, const_cast<const mxArray**>(rhs));
       z = z_path;
       mxDestroyArray(lhs[0]);
       mxDestroyArray(lhs[1]);

--- a/systems/plants/solveLCPmex.cpp
+++ b/systems/plants/solveLCPmex.cpp
@@ -163,19 +163,26 @@ bool callFastQP(MatrixBase<DerivedM> const & M, MatrixBase<Derivedw> const & w, 
   filterByIndices(z_inactive_indices, M_temp.transpose(), M_check);  //and inactive columns
   filterByIndices(z_active_indices, w, w_check);
   getThresholdInclusion((M_check.transpose() * zqp + w_check).eval(), -SMALL, violations);
-  
+  //check equality constraints
   if (anyTrue(violations)) { 
     return false;
   }
-
+ 
   getThresholdInclusion((Ain * zqp - bin).eval(), -SMALL, ineq_violations);
   getThresholdInclusion((beq - Aeq.transpose() * zqp).eval(), -SMALL, violations);
-
+  //check inequality constraints
   for (size_t i = 0; i < num_inactive_z; i++) { 
     if (ineq_violations[i] && violations[i]) { 
       return false;
     }
   }
+
+  //check complementarity constraints
+  getThresholdInclusion((-(zqp.transpose()*(Aeq*zqp - beq)).cwiseAbs()).eval(), -SMALL, violations);
+  if(anyTrue(violations)) {
+    return false;
+  }
+  
   return true;
 }
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -16,12 +16,12 @@ if (LCM_FOUND)
 endif()
 
 if (eigen3_FOUND)
-  add_mex(drakeUtil SHARED drakeUtil.cpp)
+  add_mex(drakeUtil SHARED drakeUtil.cpp MexWrapper.cpp)
 
   # todo: use this again once I can assume everyone has CMAKE version >= 2.8.8
   #add_mex(drakeUtil OBJECT drakeUtil.cpp)
 
-  pods_install_headers(drakeUtil.h DESTINATION drake)
+  pods_install_headers(drakeUtil.h MexWrapper.h DESTINATION drake)
   pods_install_libraries(drakeUtil)
   pods_install_pkg_config_file(drake-util
     LIBS -ldrakeUtil

--- a/util/MexWrapper.cpp
+++ b/util/MexWrapper.cpp
@@ -1,7 +1,10 @@
 #include "MexWrapper.h"
+#include <dlfcn.h>
 
 MexWrapper::MexWrapper(std::string const & filename) : m_mex_file(filename)
 {	
+  m_good = false;
+
   m_handle = dlopen(m_mex_file.c_str(), RTLD_NOW);
   if (!m_handle) {
      fprintf(stderr,"%s\n",dlerror());
@@ -12,18 +15,25 @@ MexWrapper::MexWrapper(std::string const & filename) : m_mex_file(filename)
   *(void**) &(m_mexFunc) = dlsym(m_handle, "mexFunction");
   if ((error = dlerror()) != NULL) {
     fprintf(stderr,"%s\n", error);
+    dlclose(m_handle);
     return;
-  }
+  } 
+
+  m_good = true;
 }
 
 MexWrapper::~MexWrapper() 
 {
-  dlclose(m_handle);
+  if (m_good) {
+    dlclose(m_handle);
+  }
 }
 
 void MexWrapper::mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) const
 {
-  m_mexFunc(nlhs, plhs, nrhs, const_cast<const mxArray**>(prhs));
+  if (m_good) {
+   m_mexFunc(nlhs, plhs, nrhs, const_cast<const mxArray**>(prhs));
+  }
 }
 
 std::string MexWrapper::getMexFile() const 

--- a/util/MexWrapper.cpp
+++ b/util/MexWrapper.cpp
@@ -1,0 +1,32 @@
+#include "MexWrapper.h"
+
+MexWrapper::MexWrapper(std::string const & filename) : m_mex_file(filename)
+{	
+  m_handle = dlopen(m_mex_file.c_str(), RTLD_NOW);
+  if (!m_handle) {
+     fprintf(stderr,"%s\n",dlerror());
+     return;
+  }  
+
+  char* error;
+  *(void**) &(m_mexFunc) = dlsym(m_handle, "mexFunction");
+  if ((error = dlerror()) != NULL) {
+    fprintf(stderr,"%s\n", error);
+    return;
+  }
+}
+
+MexWrapper::~MexWrapper() 
+{
+  dlclose(m_handle);
+}
+
+void MexWrapper::mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) const
+{
+  m_mexFunc(nlhs, plhs, nrhs, const_cast<const mxArray**>(prhs));
+}
+
+std::string MexWrapper::getMexFile() const 
+{
+  return m_mex_file;
+}

--- a/util/MexWrapper.cpp
+++ b/util/MexWrapper.cpp
@@ -1,34 +1,48 @@
 #include "MexWrapper.h"
+#if defined(WIN32) || defined(WIN64)
+#else
 #include <dlfcn.h>
+#endif
+
 
 MexWrapper::MexWrapper(std::string const & filename) : m_mex_file(filename)
 {	
   m_good = false;
 
+  #if defined(WIN32) || defined(WIN64)
+  #else
+  //load the mexfile
   m_handle = dlopen(m_mex_file.c_str(), RTLD_NOW);
   if (!m_handle) {
      fprintf(stderr,"%s\n",dlerror());
      return;
   }  
 
+  //locate and store the entry point in a function pointer
   char* error;
   *(void**) &(m_mexFunc) = dlsym(m_handle, "mexFunction");
   if ((error = dlerror()) != NULL) {
     fprintf(stderr,"%s\n", error);
     dlclose(m_handle);
     return;
-  } 
+  }
 
   m_good = true;
+  #endif
 }
 
 MexWrapper::~MexWrapper() 
 {
+  #if defined(WIN32) || defined(WIN64)
+  #else
   if (m_good) {
     dlclose(m_handle);
   }
+  #endif
 }
 
+//the caller is responsible for allocating all of the mxArray* memory and freeing it when
+//
 void MexWrapper::mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) const
 {
   if (m_good) {

--- a/util/MexWrapper.h
+++ b/util/MexWrapper.h
@@ -4,7 +4,18 @@
 #include "mex.h"
 #include <string>
 
-class MexWrapper {
+#undef DLLEXPORT
+#if defined(WIN32) || defined(WIN64)
+  #if defined(drakeUtil_EXPORTS)
+    #define DLLEXPORT __declspec( dllexport )
+  #else
+    #define DLLEXPORT __declspec( dllimport )
+  #endif
+#else
+    #define DLLEXPORT
+#endif
+
+DLLEXPORT class MexWrapper {
   public:
     MexWrapper(std::string const & filename);
     ~MexWrapper();

--- a/util/MexWrapper.h
+++ b/util/MexWrapper.h
@@ -2,7 +2,6 @@
 #define MEX_WRAPPER_H
 
 #include "mex.h"
-#include <dlfcn.h>
 #include <string>
 
 class MexWrapper {
@@ -13,6 +12,7 @@ class MexWrapper {
     std::string getMexFile() const;
    private:
    	std::string m_mex_file;
+   	bool m_good;
    	void* m_handle;
     void (*m_mexFunc)(int, mxArray*[], int, const mxArray* []);
 };

--- a/util/MexWrapper.h
+++ b/util/MexWrapper.h
@@ -1,0 +1,20 @@
+#ifndef MEX_WRAPPER_H
+#define MEX_WRAPPER_H
+
+#include "mex.h"
+#include <dlfcn.h>
+#include <string>
+
+class MexWrapper {
+  public:
+    MexWrapper(std::string const & filename);
+    ~MexWrapper();
+    void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) const;
+    std::string getMexFile() const;
+   private:
+   	std::string m_mex_file;
+   	void* m_handle;
+    void (*m_mexFunc)(int, mxArray*[], int, const mxArray* []);
+};
+
+#endif

--- a/util/drakeUtil.cpp
+++ b/util/drakeUtil.cpp
@@ -184,33 +184,6 @@ void sizecheck(const mxArray* mat, int M, int N) {
   return;
 }
 
-void callMexStandalone(const char* mexFile, int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
-
-  void* handle;
-  void (*mexFunc)(int, mxArray*[], int, const mxArray* []);
-
-  // Dynamically load the mex file:
-  handle = dlopen(mexFile, RTLD_NOW);
-  if (!handle) {
-     fprintf(stderr,"%s\n",dlerror());
-     return;
-  }
-
-  //find the entry function pointer
-  char* error;
-  *(void**) &(mexFunc) = dlsym(handle, "mexFunction");
-  if ((error = dlerror()) != NULL) {
-    fprintf(stderr,"%s\n", error);
-    return;
-  }
-  
-  //call mexFunction()
-  mexFunc(nlhs, plhs, nrhs, const_cast<const mxArray**>(prhs));
-
-  //close mex file
-  dlclose(handle);
-}
-
 //builds a matlab sparse matrix in mex from a given eigen matrix
 //the caller is responsible for destroying the resulting array
 template <typename Derived>

--- a/util/drakeUtil.h
+++ b/util/drakeUtil.h
@@ -8,7 +8,6 @@
 #include "mex.h"
 #include <vector>
 #include <utility>
-#include <dlfcn.h>
 #include <Eigen/Core>
 
 #ifndef DRAKE_UTIL_H_
@@ -28,9 +27,6 @@
 // Helper routines
 DLLEXPORT bool isa(const mxArray* mxa, const char* class_str);
 DLLEXPORT bool mexCallMATLABsafe(int nlhs, mxArray* plhs[], int nrhs, mxArray* prhs[], const char* filename);
-
-//call a mex file from c++ without mexCallMATLAB
-void callMexStandalone(const char* mexFile, int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]);
 
 // Mex pointers shared through matlab
 DLLEXPORT mxArray* createDrakeMexPointer(void* ptr, const char* name="", int num_additional_inputs=0, mxArray *delete_fcn_additional_inputs[] = NULL, const char* subclass_name=NULL);  // increments lock count

--- a/util/drakeUtil.h
+++ b/util/drakeUtil.h
@@ -8,6 +8,7 @@
 #include "mex.h"
 #include <vector>
 #include <utility>
+#include <dlfcn.h>
 #include <Eigen/Core>
 
 #ifndef DRAKE_UTIL_H_
@@ -28,6 +29,8 @@
 DLLEXPORT bool isa(const mxArray* mxa, const char* class_str);
 DLLEXPORT bool mexCallMATLABsafe(int nlhs, mxArray* plhs[], int nrhs, mxArray* prhs[], const char* filename);
 
+//call a mex file from c++ without mexCallMATLAB
+void callMexStandalone(const char* mexFile, int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]);
 
 // Mex pointers shared through matlab
 DLLEXPORT mxArray* createDrakeMexPointer(void* ptr, const char* name="", int num_additional_inputs=0, mxArray *delete_fcn_additional_inputs[] = NULL, const char* subclass_name=NULL);  // increments lock count

--- a/util/drakeUtil.h
+++ b/util/drakeUtil.h
@@ -49,6 +49,9 @@ template <typename Derived> inline void destroyDrakeMexPointer(const mxArray* mx
 //  mexPrintf(mexIsLocked() ? "mex file is locked\n" : "mex file is unlocked\n");
 }
 
+template <typename Derived>
+DLLEXPORT mxArray* eigenToMatlabSparse(Eigen::MatrixBase<Derived> const & M, int & num_non_zero);
+
 template <typename DerivedA>
 mxArray* eigenToMatlab(const DerivedA &m)
 {


### PR DESCRIPTION
This gets rid of the ```mexCallMATLAB``` call in ```solveLCPmex```.

There are also two new utility functions in ```drakeUtil.cpp```.  The first is a ```callMexStandalone()``` function which allows mex files to be called  directly from c++.  The second is a function to build a MATLAB sparse matrix in mex.

In order to build a MATLAB sparse matrix in mex on 64-bit machines, the mex file must be compiled with the ```-largeArrayDims``` flag.  Currently, this is not the case so I suspect this will be broken until https://github.com/RobotLocomotion/cmake/pull/9 is incorporated.

Getting rid of the ```mexCallMATLAB``` function gives an additional 5-10% performance boost to solveLCPmex as there is now a more direct pathway to the path LCP solver.

Resolves #965