### PR TITLE
Name error in runLQR.m glider example

### DIFF
--- a/examples/Glider/runLQR.m
+++ b/examples/Glider/runLQR.m
@@ -10,8 +10,8 @@ try
   xtraj=trajs.xtraj;
   utraj=trajs.utraj;
 
-  utraj = setOutputFrame(utraj,p.getInputFrame);
-  xtraj = setOutputFrame(xtraj,p.getStateFrame);
+  utraj = setOutputFrame(utraj,pd.getInputFrame);
+  xtraj = setOutputFrame(xtraj,pd.getStateFrame);
 catch
   [utraj,xtraj]=runDircolPerching(pd);
 end


### PR DESCRIPTION
It was inside a ```try``` statement, so Matlab wouldn't throw the error and execute (unnecessarily) runDircolPerching inside the ```catch```.