### PR TITLE
No 3d animation

### DIFF
--- a/systems/plants/PlanarRigidBodyVisualizer.m
+++ b/systems/plants/PlanarRigidBodyVisualizer.m
@@ -111,6 +111,7 @@ classdef PlanarRigidBodyVisualizer < RigidBodyVisualizer
 
   properties (Access=protected)
     Tview;
+    body;  % body(i).x{j} and body(i).c{j} describe the jth geometry on body i
   end
   
   properties

--- a/systems/plants/PlanarRigidBodyVisualizer.m
+++ b/systems/plants/PlanarRigidBodyVisualizer.m
@@ -23,6 +23,7 @@ classdef PlanarRigidBodyVisualizer < RigidBodyVisualizer
       end
       warning(w);
       obj.Tview = Tview;
+      obj.preserve_view = false;
     end
     
     function draw(obj,t,x)

--- a/systems/plants/PlanarRigidBodyVisualizer.m
+++ b/systems/plants/PlanarRigidBodyVisualizer.m
@@ -110,14 +110,10 @@ classdef PlanarRigidBodyVisualizer < RigidBodyVisualizer
   end
 
   properties (Access=protected)
-    body;  % body(i).xyz{j} and body(i).c{j} describe the geometry of the jth patch on body i
     Tview;
   end
   
   properties
-    xlim=[-2,2]
-    ylim=[-2,2];
-    debug = false;  % if true, draws extras, like the coordinate frames and COMs for each link
     fade_percent = 0;     % 0 to 1 
     fade_color = [1 1 1];
   end

--- a/systems/plants/RigidBodyCylinder.m
+++ b/systems/plants/RigidBodyCylinder.m
@@ -103,6 +103,19 @@ classdef RigidBodyCylinder < RigidBodyGeometry
       
       capsule = RigidBodyCapsule(obj.radius,obj.len,obj.T);
     end
+    
+    function h = draw(obj,model,kinsol,body_ind)
+      persistent cylinder_pts; % for all cylinders
+      if isempty(cylinder_pts)
+        [x,y,z] = cylinder;
+        cylinder_pts = [x(:)'; y(:)'; z(:)'-.5; 1+0*x(:)'];
+      end
+      
+      pts = forwardKin(model,kinsol,body_ind,obj.T(1:3,:)*diag([obj.radius,obj.radius,obj.len,1])*cylinder_pts);
+      N = size(pts,2)/2;
+      % todo: specify the color
+      h = surf([pts(1,1:N);pts(1,N+1:end)],[pts(2,1:N);pts(2,N+1:end)],[pts(3,1:N);pts(3,N+1:end)]);
+    end
   end
   
   properties

--- a/systems/plants/RigidBodyGeometry.m
+++ b/systems/plants/RigidBodyGeometry.m
@@ -109,6 +109,9 @@ classdef RigidBodyGeometry
       
     end
     
+    function h = draw(obj,model,kinsol,body_ind)
+      % intentionally left blank, can be overloaded
+    end
   end
   
   methods (Static)

--- a/systems/plants/RigidBodySphere.m
+++ b/systems/plants/RigidBodySphere.m
@@ -99,6 +99,18 @@ classdef RigidBodySphere < RigidBodyGeometry
       end
     end
   
+    function h = draw(obj,model,kinsol,body_ind)
+      persistent sphere_pts; % for all spheres
+      if isempty(sphere_pts)
+        [x,y,z] = sphere;
+        sphere_pts = [x(:)'; y(:)'; z(:)'; 1+0*x(:)'];
+      end
+      
+      pts = forwardKin(model,kinsol,body_ind,obj.T(1:3,:)*obj.radius*sphere_pts);
+      N = size(pts,2)/2;
+      % todo: specify the color
+      h = surf([pts(1,1:N);pts(1,N+1:end)],[pts(2,1:N);pts(2,N+1:end)],[pts(3,1:N);pts(3,N+1:end)]);
+    end    
   end
   properties
     radius;

--- a/systems/plants/RigidBodyVisualizer.m
+++ b/systems/plants/RigidBodyVisualizer.m
@@ -4,13 +4,10 @@ classdef RigidBodyVisualizer < Visualizer
   end
   properties
     gravity_visual_magnitude=.25;      
-    body;  % body(i).xyz{j} and body(i).c{j} describe the jth geometry on body i
     debug = false;  % if true, draws extras, like the coordinate frames and COMs for each link
     xlim=[-2,2];
     ylim=[-2,2];
     zlim=[-2,2];
-    az = -24;
-    el = 80;
   end
   methods
     function obj = RigidBodyVisualizer(manip)
@@ -58,9 +55,6 @@ classdef RigidBodyVisualizer < Visualizer
       %h = [];
       % end debugging
 
-      figure(25); 
-      clf; hold on;
-      
       for i=1:length(obj.model.body)
         for j=1:length(obj.model.body(i).visual_geometry)
           draw(obj.model.body(i).visual_geometry{j},obj.model,kinsol,i);
@@ -90,9 +84,6 @@ classdef RigidBodyVisualizer < Visualizer
       end
       if ~isempty(obj.axis)
         axis(obj.axis);
-      end
-      if ~isempty(obj.az)
-        view(obj.az,obj.el);
       end
       
       xlabel('x');

--- a/systems/plants/RigidBodyVisualizer.m
+++ b/systems/plants/RigidBodyVisualizer.m
@@ -3,7 +3,7 @@ classdef RigidBodyVisualizer < Visualizer
     model;
   end
   properties
-    gravity_visual_magnitude=.25;      
+    gravity_visual_magnitude=.25;
     debug = false;  % if true, draws extras, like the coordinate frames and COMs for each link
     xlim=[-2,2];
     ylim=[-2,2];
@@ -19,16 +19,16 @@ classdef RigidBodyVisualizer < Visualizer
       % brings up a simple slider gui that displays the robot
       % in the specified state when possible. It also shows resulting
       % forces and torques if some of the specified states are velocities.
-      % 
+      %
       % @param x0 the initial state to display the robot in
       % @param state_dims are the indices of the states to show on the
       % slider. Including velocity states will display the forces and torques.
       % @param minrange is the lower bound for the sliders
       % @param maxrange is the upper bound for the sliders
-      % @option gravity_visual_magnitude specifies the visual length of 
-      % the vector representing the gravitational force. Other force 
-      % visualizations are scaled accordingly. 
-        
+      % @option gravity_visual_magnitude specifies the visual length of
+      % the vector representing the gravitational force. Other force
+      % visualizations are scaled accordingly.
+
       if (nargin<2), x0 = getInitialState(obj.model); end
       if (nargin<3), state_dims = 1:getNumPositions(obj.model); end
       [jlmin,jlmax] = getJointLimits(obj.model);
@@ -39,25 +39,25 @@ classdef RigidBodyVisualizer < Visualizer
       if (nargin<4), minrange = xmin(state_dims); end
       if (nargin<5), maxrange = xmax(state_dims); end
       if (nargin<6), options = struct(); end
-      if isfield(options,'gravity_visual_magnitude') 
-          obj.gravity_visual_magnitude = options.gravity_visual_magnitude; 
+      if isfield(options,'gravity_visual_magnitude')
+          obj.gravity_visual_magnitude = options.gravity_visual_magnitude;
       end
-      
+
       inspector@Visualizer(obj,x0,state_dims,minrange,maxrange,obj.model);
     end
-    
+
     function draw(obj,t,x)
-      n = obj.model.num_positions;
-      q = x(1:n); %qd=x(n+(1:n));
+      nq = obj.model.num_positions;
+      q = x(1:nq); %qd=x(nq+(1:nq));
       kinsol = obj.model.doKinematics(q);
-      
+
       % for debugging:
       %co = get(gca,'ColorOrder');
       %h = [];
       % end debugging
 
-      for i=1:length(obj.model.body)
-        for j=1:length(obj.model.body(i).visual_geometry)
+      for i=1:numel(obj.model.body)
+        for j=1:numel(obj.model.body(i).visual_geometry)
           draw(obj.model.body(i).visual_geometry{j},obj.model,kinsol,i);
         end
         if (obj.debug) % draw extra debugging info
@@ -75,7 +75,7 @@ classdef RigidBodyVisualizer < Visualizer
           end
         end
       end
-      
+
       axis equal;
       if ~isempty(obj.xlim)
         xlim(obj.xlim);
@@ -86,39 +86,39 @@ classdef RigidBodyVisualizer < Visualizer
       if ~isempty(obj.axis)
         axis(obj.axis);
       end
-      
+
       xlabel('x');
       ylabel('y');
       zlabel('z');
       title(['t = ', num2str(t,'%.2f') ' sec']);
     end
-      
+
     function kinematicInspector(obj,body_or_frame_id,pt,q0,minrange,maxrange)
       % kinematicInspector(model,body_or_frame_id,pt,q0)
       % brings up a simple slider gui (like the inspector() in Visualizer)
       % which calls inverse kinematics to drive the specified point on the
       % robot through a Cartesian endpoint (when possible).
-      % 
+      %
       % @param body_or_frame_id e.g. from findFrameId,findJointId, or
       % findLinkId
       % @param pt a 3x1 point in Cartesian space
       % @param q0 (optional) initial pose for the robot @default uses
       % getInitialState()
       %
-      
+
       nq = getNumPositions(obj.model);
       if nargin<4
         x0 = getInitialState(obj.model);
       else
         x0 = [q0;zeros(getNumVelocities(obj.model),1)];
       end
-      
+
       x = resolveConstraints(obj.model,x0);
       q0 = x(1:nq);
-      q = q0; 
-      
+      q = q0;
+
       obj.drawWrapper(0,x);
-      
+
       kinsol = doKinematics(obj.model,q);
       desired_pt = forwardKin(obj.model,kinsol,body_or_frame_id,pt);
 
@@ -129,7 +129,7 @@ classdef RigidBodyVisualizer < Visualizer
       rows = length(varnames);
       f = sfigure(98); clf;
       set(f, 'Position', [560 400 280 20 + 30*rows]);
-      
+
       y=30*rows-10;
       for i=1:rows
         label{i} = uicontrol('Style','text','String',varnames{i}, ...
@@ -141,7 +141,7 @@ classdef RigidBodyVisualizer < Visualizer
         slider_listener{i} = addlistener(slider{i},'ContinuousValueChange',@update_display);
         y = y - 30;
       end
-      
+
 
       function update_display(source, eventdata)
         if nargin>1 && isempty(eventdata), return; end  % was running twice for most events
@@ -154,12 +154,11 @@ classdef RigidBodyVisualizer < Visualizer
         [q,info] = inverseKin(obj.model,q,q,ik_constraint);
         if info~=1, info, end
         x(1:nq) = q;
-        
+
         obj.drawWrapper(0,x);
         desired_pt'
         q'
-      end      
-    end    
+      end
+    end
   end
 end
-

--- a/systems/plants/RigidBodyVisualizer.m
+++ b/systems/plants/RigidBodyVisualizer.m
@@ -13,6 +13,7 @@ classdef RigidBodyVisualizer < Visualizer
     function obj = RigidBodyVisualizer(manip)
       obj = obj@Visualizer(getPositionFrame(manip));
       obj.model = manip;
+      obj.preserve_view = true;
     end
     function inspector(obj,x0,state_dims,minrange,maxrange,options)
       % brings up a simple slider gui that displays the robot

--- a/systems/visualizers/Visualizer.m
+++ b/systems/visualizers/Visualizer.m
@@ -49,10 +49,16 @@ classdef Visualizer < DrakeSystem
 
     function drawWrapper(obj,t,y)
       sfigure(obj.fignum);
+      if (obj.preserve_view)
+        [az,el]=view;
+      end
       clf; hold on;
       draw(obj,t,y);
       if (obj.display_time)
         title(['t = ', num2str(t,'%.2f') ' sec']);
+      end
+      if (obj.preserve_view)
+        view(az,el);
       end
       drawnow;
     end
@@ -488,6 +494,7 @@ classdef Visualizer < DrakeSystem
     playback_speed=1;  % 1=realtime
     draw_axes=false;  % when making movies true=gcf,false=gca
     display_time=true; % when true, time is written to figure title
+    preserve_view=true; % when true, drawWrapper gets the view, calls draw, then restores the view
     axis;  % set this to non-empty for a fixed view (must be implemented by the draw method)
     fignum = 25;
   end

--- a/systems/visualizers/Visualizer.m
+++ b/systems/visualizers/Visualizer.m
@@ -494,7 +494,7 @@ classdef Visualizer < DrakeSystem
     playback_speed=1;  % 1=realtime
     draw_axes=false;  % when making movies true=gcf,false=gca
     display_time=true; % when true, time is written to figure title
-    preserve_view=true; % when true, drawWrapper gets the view, calls draw, then restores the view
+    preserve_view=false; % when true, drawWrapper gets the view, calls draw, then restores the view
     axis;  % set this to non-empty for a fixed view (must be implemented by the draw method)
     fignum = 25;
   end


### PR DESCRIPTION
I've had people asking if they can view their urdfs in matlab on windows without the simulink 3D animation toolbox.  This provides a quick and dirty solution for matlab figure-based rendering (of cylinders and spheres at least).  