### PR TITLE
drakeDebugMex now uses MexWrapper to call mexFunctions

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -58,7 +58,7 @@ add_mex(debugMex SHARED debugMexLib.cpp)
 target_link_libraries(debugMex -ldl)
 #set_property( SOURCE debugMexLib.cpp PROPERTY COMPILE_FLAGS -DMX_COMPAT_32 )
 add_mex(drake_debug_mex EXECUTABLE drakeDebugMex.cpp)
-target_link_libraries(drake_debug_mex -ldl)
+target_link_libraries(drake_debug_mex drakeUtil -ldl)
 
 message(STATUS "Writing drake_debug_mex.sh")
 file(WRITE ${CMAKE_BINARY_DIR}/bin/drake_debug_mex.sh


### PR DESCRIPTION
All standalone calls to mex files should now use the MexWrapper interface to avoid duplicate code.