### PR TITLE
Get rid of featherstone struct and newly unused RBM preallocated variables

### DIFF
--- a/examples/Atlas/test/testHybridMode.m
+++ b/examples/Atlas/test/testHybridMode.m
@@ -4,9 +4,9 @@ function testHybridMode
 options.floating = true;
 options.view = 'right';
 s = warning('off','Drake:PlanarRigidBodyManipulator:RemovedJoint');
-m = PlanarRigidBodyManipulator('../urdf/atlas_robot_minimal_contact.urdf',options);
+m = PlanarRigidBodyManipulator('../urdf/atlas_minimal_contact.urdf',options);
 warning(s);
-p = HybridRigidBodyMode(m,zeros(m.featherstone.NB,1),[1;zeros(3,1)]);
+p = HybridRigidBodyMode(m,zeros(m.num_velocities,1),[1;zeros(3,1)]);
 
 xtraj = simulate(p,[0 4]);
 v = p.constructVisualizer();

--- a/examples/dev/Hubo/HuboReachingControl.m
+++ b/examples/dev/Hubo/HuboReachingControl.m
@@ -30,7 +30,7 @@ classdef HuboReachingControl < DrakeSystem
       % Controller implementation.  
       % See derivation in HuboReachingControl.pdf
       
-      n = obj.model.featherstone.NB;
+      n = obj.model.num_positions;
       q = x(1:n); qd=x(n+(1:n));
       
       eta = [.01;1;.01];  

--- a/examples/dev/Manipulator2D/Gripper2D.m
+++ b/examples/dev/Manipulator2D/Gripper2D.m
@@ -53,7 +53,7 @@ classdef Gripper2D < PlanarRigidBodyManipulator
       [sphere_coords, dPts_sphere, ddPts_sphere] = obj.forwardKin(kinsol,4,[0;0]);
      
       
-      nBodies = obj.model.featherstone.NB + 1;
+      nBodies = length(obj.body);
       for i=1:nBodies;
         contact_pts = obj.model.body(i).contact_pts;
         nC = size(contact_pts,2);

--- a/examples/dev/Manipulator2D/Gripper2D_gcs.m
+++ b/examples/dev/Manipulator2D/Gripper2D_gcs.m
@@ -95,7 +95,7 @@ classdef Gripper2D_gcs < Gripper2D
       
       count=0;
 %       nBodies = length(obj.model.body);
-      nBodies = obj.model.featherstone.NB + 1;
+      nBodies = length(obj.body);
       for i=1:nBodies;
 %         body = obj.model.body(i);
         contact_pts = obj.model.body(i).contact_pts;

--- a/systems/controllers/QPCommon.cpp
+++ b/systems/controllers/QPCommon.cpp
@@ -411,9 +411,7 @@ int setupAndSolveQP(NewQPControllerData *pdata, std::shared_ptr<drake::lcmt_qp_c
     const drake::lcmt_body_wrench_data& body_wrench_data = *it;
     int body_id = body_wrench_data.body_id - 1;
     f_ext[body_id] = std::unique_ptr<WrenchGradientVarType>(new WrenchGradientVarType(TWIST_SIZE, 1, nq, 0));
-    Map<const Matrix<double, TWIST_SIZE, 1> > wrench_in_body_frame(body_wrench_data.wrench);
-    auto wrench_in_joint_frame = transformSpatialForce(Isometry3d(pdata->r->bodies[body_id]->T_body_to_joint), wrench_in_body_frame);
-    f_ext[body_id]->value() = wrench_in_joint_frame;
+    f_ext[body_id]->value() = Map<const Matrix<double, TWIST_SIZE, 1> >(body_wrench_data.wrench);
   }
 
   pdata->H = pdata->r->massMatrix<double>().value();

--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -1625,7 +1625,7 @@ classdef RigidBodyManipulator < Manipulator
       % construct a transform from the state vector to the COM
       checkDirty(model);
       tf = FunctionHandleCoordinateTransform(0,0,model.getStateFrame(),fr,true,true,[],[], ...
-        @(obj,~,~,x) getCOM(model,x(1:model.featherstone.NB)));
+        @(obj,~,~,x) getCOM(model,x(1:model.num_positions)));
 
       model.getStateFrame().addTransform(tf);
     end

--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -37,7 +37,6 @@ classdef RigidBodyManipulator < Manipulator
   end
 
   properties (Access=public)  % i think these should be private, but probably needed to access them from mex? - Russ
-    featherstone = [];
     B = [];
     mex_model_ptr = nullPointer();
     dirty = true;
@@ -400,7 +399,10 @@ classdef RigidBodyManipulator < Manipulator
       force = ftmp(:,1)-ftmp(:,2);
       f_body = [ cross(point,force,1); force ];  % spatial force in body coordinates
 
-      % convert to joint frame (featherstone dynamics algorithm never reasons in body coordinates)
+      % convert to joint frame. TODO: at this point X_joint_to_body is
+      % always identity, so this should not do anything. Need to get rid of
+      % this, as well as transformations to joint frameinside
+      % RigidBodyForceElements.
       f = obj.body(body_ind).X_joint_to_body'*f_body;
 
       if (nargout>1)
@@ -701,8 +703,6 @@ classdef RigidBodyManipulator < Manipulator
         model.actuator(i) = new_element;
       end
 
-      %% extract featherstone model structure
-      model = extractFeatherstone(model);
       % set position and velocity vector indices
       num_q=0;num_v=0;
       for i=1:length(model.body)
@@ -2184,105 +2184,6 @@ classdef RigidBodyManipulator < Manipulator
       end
       frame_dims = [inputparents.robotnum];
       fr = MultiCoordinateFrame.constructFrame(fr,frame_dims,true);
-    end
-
-    function model = extractFeatherstone(model)
-      % @ingroup Kinematic Tree
-
-      %      m=struct('NB',{},'parent',{},'jcode',{},'Xtree',{},'I',{});
-      dof=0;inds=[];
-      for i=1:length(model.body)
-        if model.body(i).parent>0
-          if (model.body(i).floating==1)
-            model.body(i).position_num=dof+(1:6)';
-            dof=dof+6;
-            inds = [inds,i];
-          elseif (model.body(i).floating==2)
-            model.body(i).position_num=dof+(1:7)';
-            dof=dof+7;
-            inds = [inds,i];
-          else
-            dof=dof+1;
-            model.body(i).position_num=dof;
-            inds = [inds,i];
-          end
-        else
-          model.body(i).position_num=0;
-        end
-      end
-      m = struct('NB',dof,'parent',[],'position_num',[],'pitch',[],'damping',[],'coulomb_friction',[],'static_friction',[],'coulomb_window',[],'Xtree',[],'X_joint_to_body',[],'I',[]);
-      m.NB= dof;
-      n=1;
-      m.f_ext_map_from = inds;  % size is length(model.body) output is index into NB, or zero
-      m.f_ext_map_to = [];
-
-      for i=1:length(inds) % number of links with parents
-        b=model.body(inds(i));
-        if (b.floating==1)   % implement relative ypr, but with position_nums as rpy
-          % todo:  remove this and handle the floating joint directly in
-          % HandC.  this is really just a short term hack.
-          m.position_num(n+(0:5)) = b.position_num([1;2;3;6;5;4]);
-          m.pitch(n+(0:2)) = inf;  % prismatic
-          m.pitch(n+(3:5)) = 0;    % revolute
-          m.damping(n+(0:5)) = 0;
-          m.coulomb_friction(n+(0:5)) = 0;
-          m.static_friction(n+(0:5)) = 0;
-          m.coulomb_window(n+(0:5)) = eps;
-          m.parent(n+(0:5)) = [model.body(b.parent).position_num,n+(0:4)];  % rel ypr
-          m.Xtree{n} = Xroty(pi/2);   % x
-          m.Xtree{n+1} = Xrotx(-pi/2)*Xroty(-pi/2); % y (note these are relative changes, x was up, now I'm rotating so y will be up)
-          m.Xtree{n+2} = Xrotx(pi/2); % z
-          m.Xtree{n+3} = eye(6);       % yaw
-          m.Xtree{n+4} = Xrotx(-pi/2);  % pitch
-          m.Xtree{n+5} = Xroty(pi/2)*Xrotx(pi/2);  % roll
-
-%          valuecheck(b.X_joint_to_body,eye(6))); % if this isn't true, then I probably need to handle it better on the line below
-          % but I can't leave the check in because it is also very ugly because this method gets run potentially
-          % multiple times, and will update b each time! (so the test will
-          % fail on the second pass)
-
-          for j=0:4, m.I{n+j} = zeros(6); end
-          m.I{n+5} = b.X_joint_to_body'*b.I*b.X_joint_to_body;
-          m.f_ext_map_to = [m.f_ext_map_to,n+5];
-          n=n+6;
-        elseif (b.floating==2)
-          if model.use_new_kinsol
-            % quick fix so that quaternion kinematics are usable
-            m.position_num(n+(0:6)) = b.position_num;
-            m.pitch(n+(0:6)) = nan;  % should not be used
-            m.damping(n+(0:6)) = 0;
-            m.coulomb_friction(n+(0:6)) = 0;
-            m.static_friction(n+(0:6)) = 0;
-            m.coulomb_window(n+(0:6)) = eps;
-            m.parent(n+(0:6)) = nan;
-            for j = 0 : 6
-              m.Xtree{n + j} = nan(6, 6);
-            end
-            b.X_joint_to_body = eye(6);
-            for j=0:6
-              m.I{n+j} = zeros(6);
-            end
-            m.f_ext_map_to = [m.f_ext_map_to,n+6];
-            n=n+7;
-          else
-            error('dynamics for quaternion floating base not implemented yet');
-          end
-        else
-          m.parent(n) = max(model.body(b.parent).position_num);
-          m.position_num(n) = b.position_num;  % note: only need this for my floating hack above (remove it when gone)
-          m.pitch(n) = b.pitch;
-          m.Xtree{n} = inv(b.X_joint_to_body)*b.Xtree*model.body(b.parent).X_joint_to_body;
-          m.I{n} = b.X_joint_to_body'*b.I*b.X_joint_to_body;
-          m.damping(n) = b.damping;  % add damping so that it's faster to look up in the dynamics functions.
-          m.coulomb_friction(n) = b.coulomb_friction;
-          m.static_friction(n) = b.static_friction;
-          m.coulomb_window(n) = b.coulomb_window;
-          m.f_ext_map_to = [m.f_ext_map_to,n];
-          n=n+1;
-        end
-        model.body(inds(i)) = b;  % b isn't a handle anymore, so store any changes
-      end
-      model.featherstone = m;
     end
 
     function model=removeFixedJoints(model)

--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -397,21 +397,13 @@ classdef RigidBodyManipulator < Manipulator
 
       % try to do it the Xtree way
       force = ftmp(:,1)-ftmp(:,2);
-      f_body = [ cross(point,force,1); force ];  % spatial force in body coordinates
-
-      % convert to joint frame. TODO: at this point X_joint_to_body is
-      % always identity, so this should not do anything. Need to get rid of
-      % this, as well as transformations to joint frameinside
-      % RigidBodyForceElements.
-      f = obj.body(body_ind).X_joint_to_body'*f_body;
+      f = [ cross(point,force,1); force ];  % spatial force in body coordinates
 
       if (nargout>1)
         dforcedq = ftmpJ(1:3,:)-ftmpJ(4:6,:);
         dforcedforce = ftmpP(1:3,1:size(force,1))-ftmpP(4:6,1:size(force,1));
-        df_bodydq = [ cross(repmat(point,1,size(dforcedq,2)),dforcedq); dforcedq ];
-        df_bodydforce = [ cross(repmat(point,1,size(dforcedforce,2)),dforcedforce); dforcedforce];
-        dfdq = obj.body(body_ind).X_joint_to_body'*df_bodydq;
-        dfdforce = obj.body(body_ind).X_joint_to_body'*df_bodydforce;
+        dfdq = [ cross(repmat(point,1,size(dforcedq,2)),dforcedq); dforcedq ];
+        dfdforce = [ cross(repmat(point,1,size(dforcedforce,2)),dforcedforce); dforcedforce];
       end
     end
 
@@ -1530,8 +1522,7 @@ classdef RigidBodyManipulator < Manipulator
                     body_ind = body_frame.body_ind;
                 end
                 f_ext = computeSpatialForce(force_element,model,q,qd);
-                joint_wrench = f_ext(:,body_ind);
-                body_wrench = inv(model.body(body_ind).X_joint_to_body)'*joint_wrench;
+                body_wrench = f_ext(:,body_ind);
                 pos = forwardKin(model,kinsol,body_ind,[zeros(3,1),body_wrench(1:3),body_wrench(4:6)]);
                 point = pos(:,1);
                 torque_ext = pos(:,2)-point;

--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -479,9 +479,6 @@ classdef RigidBodyManipulator < Manipulator
           axis_angle(1:3)=[0;1;0];
         end
         child.T_body_to_joint = [axis2rotmat(axis_angle), zeros(3,1); 0,0,0,1];
-        child.X_joint_to_body=transformAdjoint(homogTransInv(child.T_body_to_joint));
-
-        valuecheck(inv(child.X_joint_to_body)*[axis;zeros(3,1)],[0;0;1;zeros(3,1)],1e-6);
         valuecheck(child.T_body_to_joint*[axis;1],[0;0;1;1],1e-6);
       end
 

--- a/systems/plants/@RigidBodyManipulator/changeRootLink.m
+++ b/systems/plants/@RigidBodyManipulator/changeRootLink.m
@@ -89,9 +89,8 @@ while (true)
         valuecheck(sin(axis_angle(4)),0,1e-4);
         axis_angle(1:3)=[0;1;0];
       end
-      jointrpy = axis2rpy(axis_angle);
-      current_body.X_joint_to_body=Xrotx(jointrpy(1))*Xroty(jointrpy(2))*Xrotz(jointrpy(3));
-      current_body.T_body_to_joint=[rotz(jointrpy(3))*roty(jointrpy(2))*rotx(jointrpy(1)),zeros(3,1); 0,0,0,1];
+      child.T_body_to_joint = [axis2rotmat(axis_angle), zeros(3,1); 0,0,0,1];
+      child.X_joint_to_body = transformAdjoint(homogTransInv(child.T_body_to_joint));
  
       valuecheck(inv(current_body.X_joint_to_body)*[current_body.joint_axis;zeros(3,1)],[0;0;1;zeros(3,1)],1e-6);
       valuecheck(current_body.T_body_to_joint*[current_body.joint_axis;1],[0;0;1;1],1e-6);

--- a/systems/plants/@RigidBodyManipulator/changeRootLink.m
+++ b/systems/plants/@RigidBodyManipulator/changeRootLink.m
@@ -53,8 +53,7 @@ while (true)
     current_body.pitch = 0;
     current_body.floating = 0;
     current_body.Xtree = eye(6); 
-    current_body.Ttree = eye(4); 
-    current_body.X_joint_to_body = eye(6);
+    current_body.Ttree = eye(4);
     current_body.T_body_to_joint = eye(4);
 
     X_old_body_to_new_body = Xrotx(rpy(1))*Xroty(rpy(2))*Xrotz(rpy(3))*Xtrans(xyz);
@@ -90,9 +89,6 @@ while (true)
         axis_angle(1:3)=[0;1;0];
       end
       child.T_body_to_joint = [axis2rotmat(axis_angle), zeros(3,1); 0,0,0,1];
-      child.X_joint_to_body = transformAdjoint(homogTransInv(child.T_body_to_joint));
- 
-      valuecheck(inv(current_body.X_joint_to_body)*[current_body.joint_axis;zeros(3,1)],[0;0;1;zeros(3,1)],1e-6);
       valuecheck(current_body.T_body_to_joint*[current_body.joint_axis;1],[0;0;1;1],1e-6);
     end
     

--- a/systems/plants/RigidBody.cpp
+++ b/systems/plants/RigidBody.cpp
@@ -113,32 +113,32 @@ void RigidBody::computeAncestorDOFs(RigidBodyManipulator* model)
     if (floating==1) {
     	for (j=0; j<6; j++) {
     		ancestor_dofs.insert(position_num_start+j);
-    		for (i=0; i<3*model->NB; i++) {
-    			ddTdqdq_nonzero_rows.insert(i*model->NB + position_num_start + j);
-    			ddTdqdq_nonzero_rows.insert(3*model->NB*position_num_start + i + j);
+    		for (i=0; i<3*model->num_positions; i++) {
+    			ddTdqdq_nonzero_rows.insert(i*model->num_positions + position_num_start + j);
+    			ddTdqdq_nonzero_rows.insert(3*model->num_positions*position_num_start + i + j);
     		}
     	}
     } else if (floating==2) {
     	for (j=0; j<7; j++) {
     		ancestor_dofs.insert(position_num_start+j);
-    		for (i=0; i<3*model->NB; i++) {
-    			ddTdqdq_nonzero_rows.insert(i*model->NB + position_num_start + j);
-    			ddTdqdq_nonzero_rows.insert(3*model->NB*position_num_start + i + j);
+    		for (i=0; i<3*model->num_positions; i++) {
+    			ddTdqdq_nonzero_rows.insert(i*model->num_positions + position_num_start + j);
+    			ddTdqdq_nonzero_rows.insert(3*model->num_positions*position_num_start + i + j);
     		}
     	}
     }
     else {
     	ancestor_dofs.insert(position_num_start);
-    	for (i=0; i<3*model->NB; i++) {
-    		ddTdqdq_nonzero_rows.insert(i*model->NB + position_num_start);
-    		ddTdqdq_nonzero_rows.insert(3*model->NB*position_num_start + i);
+    	for (i=0; i<3*model->num_positions; i++) {
+    		ddTdqdq_nonzero_rows.insert(i*model->num_positions + position_num_start);
+    		ddTdqdq_nonzero_rows.insert(3*model->num_positions*position_num_start + i);
     	}
     }
 
 
     // compute matrix blocks
     IndexRange ind;  ind.start=-1; ind.length=0;
-    for (i=0; i<3*model->NB*model->NB; i++) {
+    for (i=0; i<3*model->num_positions*model->num_positions; i++) {
       if (ddTdqdq_nonzero_rows.find(i)!=ddTdqdq_nonzero_rows.end()) {
         if (ind.start<0) ind.start=i;
       } else {

--- a/systems/plants/RigidBody.h
+++ b/systems/plants/RigidBody.h
@@ -46,7 +46,7 @@ public:
 
   const DrakeShapes::VectorOfVisualElements& getVisualElements() const;
 
-  virtual void setCollisionFilter(const DrakeCollision::bitmask& group, 
+  void setCollisionFilter(const DrakeCollision::bitmask& group,
                                   const DrakeCollision::bitmask& ignores);
 
   const DrakeCollision::bitmask& getCollisionFilterGroup() const { return collision_filter_group; };

--- a/systems/plants/RigidBody.m
+++ b/systems/plants/RigidBody.m
@@ -23,7 +23,6 @@ classdef RigidBody < RigidBodyElement
     floating=0; % 0 = not floating base, 1 = rpy floating base, 2 = quaternion floating base
     joint_axis=[1;0;0]; 
     Xtree=eye(6);   % velocity space coordinate transform *from parent to this node*
-    X_joint_to_body=eye(6);  % velocity space coordinate transfrom from joint frame (where joint_axis = z-axis) to body frame 
     Ttree=eye(4);   % position space coordinate transform *from this node to parent*
     T_body_to_joint=eye(4);
     wrljoint='';  % tranformation to joint coordinates in wrl syntax

--- a/systems/plants/RigidBodyAddedMass.m
+++ b/systems/plants/RigidBodyAddedMass.m
@@ -63,7 +63,7 @@ classdef RigidBodyAddedMass < RigidBodyForceElement
 
             %Transform from body to joint coordinates
             force = sparse(6,getNumBodies(manip));
-            force(:,body_ind) = manip.body(body_ind).X_joint_to_body'*forceLocal;
+            force(:,body_ind) = forceLocal;
         end
     end
     

--- a/systems/plants/RigidBodyContactVisualizer.m
+++ b/systems/plants/RigidBodyContactVisualizer.m
@@ -19,8 +19,9 @@ classdef RigidBodyContactVisualizer < Visualizer
       sfigure(hFig);
       clf; hold on;
       
-      n = obj.model.featherstone.NB;
-      q = x(1:n); qd=x(n+(1:n));
+      nq = obj.getNumPositions();
+      nv = obj.getNumVelocities();
+      q = x(1 : nq); qd = x(nq + (1 : nv));
       kinsol = obj.doKinematics(q);
       
       % for debugging:

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -69,7 +69,7 @@ public:
 class DLLEXPORT_RBM RigidBodyManipulator
 {
 public:
-  RigidBodyManipulator(int num_dof, int num_featherstone_bodies=-1, int num_rigid_body_objects=-1, int num_rigid_body_frames=0);
+  RigidBodyManipulator(int num_dof, int num_rigid_body_objects=-1, int num_rigid_body_frames=0);
   RigidBodyManipulator(const std::string &urdf_filename, const DrakeJoint::FloatingBaseType floating_base_type = DrakeJoint::ROLLPITCHYAW);
   RigidBodyManipulator(void);
   virtual ~RigidBodyManipulator(void);
@@ -81,7 +81,7 @@ public:
 
   void surfaceTangents(Eigen::Map<Matrix3xd> const & normals, std::vector< Map<Matrix3xd> > & tangents);
   
-  void resize(int num_dof, int num_featherstone_bodies=-1, int num_rigid_body_objects=-1, int num_rigid_body_frames=0);
+  void resize(int num_dof, int num_rigid_body_objects=-1, int num_rigid_body_frames=0);
 
   void compile(void);  // call me after the model is loaded
 
@@ -320,20 +320,8 @@ public:
   // Rigid body loops
   std::vector<RigidBodyLoop,Eigen::aligned_allocator<RigidBodyLoop> > loops;
 
-  // featherstone data structure
-  int NB;  // featherstone bodies
-  VectorXi pitch;
-  VectorXi parent;
-  VectorXi dofnum;
-  VectorXd damping;
-  VectorXd coulomb_friction;
-  VectorXd coulomb_window;
-  VectorXd static_friction;
-  std::vector<MatrixXd> Xtree;
-  std::vector<MatrixXd> I;
   Matrix<double,TWIST_SIZE,1> a_grav;
   MatrixXd B;  // the B matrix maps inputs into joint-space forces
-  std::map<int, int> bodies_vector_index_to_featherstone_body_index;
 
   /*
    * Temporary solution, as we're switching from old kinematics to new.
@@ -363,51 +351,19 @@ private:
   void checkCachedKinematicsSettings(bool kinematics_gradients_required, bool velocity_kinematics_required, bool jdot_times_v_required, const std::string& method_name);
 
   // variables for featherstone dynamics
-  std::vector<VectorXd> S;
-  std::vector<MatrixXd> Xup;
-  std::vector<VectorXd> v;
-  std::vector<VectorXd> avp;
-  std::vector<VectorXd> fvp;
-  std::vector<MatrixXd> IC;
   std::vector<Matrix<double, TWIST_SIZE, TWIST_SIZE>, Eigen::aligned_allocator< Matrix<double, TWIST_SIZE, TWIST_SIZE> > > I_world;
   std::vector<Matrix<double, TWIST_SIZE, TWIST_SIZE>, Eigen::aligned_allocator< Matrix<double, TWIST_SIZE, TWIST_SIZE> > > Ic_new;
 
 
   //Variables for gradient calculations
   MatrixXd dTdTmult;
-  std::vector<MatrixXd> dXupdq;
-  std::vector<std::vector<MatrixXd> > dIC;
-    std::vector<Gradient<Matrix<double, TWIST_SIZE, TWIST_SIZE>, Eigen::Dynamic>::type> dI_world;
+  std::vector<Gradient<Matrix<double, TWIST_SIZE, TWIST_SIZE>, Eigen::Dynamic>::type> dI_world;
   std::vector<Gradient<Matrix<double, TWIST_SIZE, TWIST_SIZE>, Eigen::Dynamic>::type> dIc_new;
-
-  std::vector<MatrixXd> dvdq;
-  std::vector<MatrixXd> dvdqd;
-  std::vector<MatrixXd> davpdq;
-  std::vector<MatrixXd> davpdqd;
-  std::vector<MatrixXd> dfvpdq;
-  std::vector<MatrixXd> dfvpdqd;
-  MatrixXd dvJdqd_mat;
-  MatrixXd dcross;
 
   // preallocate for COM functions
   Vector3d bc;
   MatrixXd bJ;
   MatrixXd bdJ;
-
-  // preallocate for CMM function
-  MatrixXd Xg; // spatial centroidal projection matrix
-  MatrixXd dXg;  // dXg_dq * qd
-  std::vector<MatrixXd> Ic; // composite rigid body inertias
-  std::vector<MatrixXd> dIc; // derivative of composite rigid body inertias
-  std::vector<VectorXd> phi; // joint axis vectors
-  std::vector<MatrixXd> Xworld; // spatial transforms from world to each body
-  std::vector<MatrixXd> dXworld; // dXworld_dq * qd
-  std::vector<MatrixXd> dXup; // dXup_dq * qd
-  MatrixXd Xcom; // spatial transform from centroid to world
-  MatrixXd Jcom;
-  MatrixXd dXcom;
-  MatrixXd Xi;
-  MatrixXd dXidq;
 
   int num_contact_pts;
   bool initialized;

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -393,7 +393,7 @@ public:
 // The following was required for building w/ DLLEXPORT_RBM on windows (due to the unique_ptrs).  See
 // http://stackoverflow.com/questions/8716824/cannot-access-private-member-error-only-when-class-has-export-linkage
 private:
-  RigidBodyManipulator(const RigidBodyManipulator&) {}
+  RigidBodyManipulator(const RigidBodyManipulator&);
   RigidBodyManipulator& operator=(const RigidBodyManipulator&) { return *this; }
 
   std::set<std::string> already_printed_warnings;

--- a/systems/plants/RigidBodyManipulatorURDF.cpp
+++ b/systems/plants/RigidBodyManipulatorURDF.cpp
@@ -567,7 +567,6 @@ bool parseJoint(RigidBodyManipulator* model, TiXmlElement* node)
     fjoint = new RevoluteJoint(name, Ttree, axis);
     joint = fjoint;
   } else if (type.compare("fixed") == 0) {
-    // FIXME: implement a fixed joint class
     joint = new FixedJoint(name, Ttree);
   } else if (type.compare("prismatic") == 0) {
     fjoint = new PrismaticJoint(name, Ttree, axis);

--- a/systems/plants/RigidBodyTorsionalSpring.m
+++ b/systems/plants/RigidBodyTorsionalSpring.m
@@ -22,9 +22,6 @@ classdef RigidBodyTorsionalSpring < RigidBodyForceElement
          df_ext = sparse(6*getNumBodies(manip),size(q,1)+size(qd,1));
       end
 
-      % note, because featherstone coordinates do everything about the
-      % z-axis, the below is actually equivalent to
-      % f_ext(:,obj.child_body) = manip.body(obj.child_body).X_joint_to_body'*[zeros(3,1);torque*manip.body(obj.child_body).joint_axis];
       f_ext(:,obj.child_body) = [zeros(2,1);torque;zeros(3,1)]; 
       if obj.parent_body ~= 0 % don't apply force to world body
         f_ext(:,obj.parent_body) = -[zeros(2,1);torque;zeros(3,1)]; 

--- a/systems/plants/RigidBodyTorsionalSpring.m
+++ b/systems/plants/RigidBodyTorsionalSpring.m
@@ -22,14 +22,22 @@ classdef RigidBodyTorsionalSpring < RigidBodyForceElement
          df_ext = sparse(6*getNumBodies(manip),size(q,1)+size(qd,1));
       end
 
-      f_ext(:,obj.child_body) = [zeros(2,1);torque;zeros(3,1)]; 
+      wrench_on_child_in_child_joint_frame = [zeros(2,1);torque;zeros(3,1)];
+
+      % transform from body frame to joint frame
+      AdT_body_to_joint = transformAdjoint(manip.body(obj.child_body).T_body_to_joint);
+      f_ext(:,obj.child_body) = AdT_body_to_joint' * wrench_on_child_in_child_joint_frame;
+
       if obj.parent_body ~= 0 % don't apply force to world body
-        f_ext(:,obj.parent_body) = -[zeros(2,1);torque;zeros(3,1)]; 
+        T_parent_body_to_child_joint = homogTransInv(manip.body(obj.child_body.Ttree));
+        AdT_parent_body_to_child_joint = transformAdjoint(T_parent_body_to_child_joint);
+        f_ext(:,obj.parent_body) = -AdT_parent_body_to_child_joint' * wrench_on_child_in_child_joint_frame; 
       end
       if (nargout>1)
-         df_ext((obj.child_body-1)*6+1:obj.child_body*6,1:size(q,1)) = [zeros(2,size(q,1));dtorquedq;zeros(3,size(q,1))];
+        dwrench_on_child_in_child_joint_frame = [zeros(2,size(q,1)); dtorquedq; zeros(3,size(q,1))];
+        df_ext((obj.child_body-1)*6+1:obj.child_body*6,1:size(q,1)) = AdT_body_to_joint' * dwrench_on_child_in_child_joint_frame;
          if obj.parent_body ~= 0
-           df_ext((obj.parent_body-1)*6+1:obj.parent_body*6,1:size(q,1)) = -[zeros(2,size(q,1));dtorquedq;zeros(3,size(q,1))];
+           df_ext((obj.parent_body-1)*6+1:obj.parent_body*6,1:size(q,1)) = -AdT_parent_body_to_child_joint' * dwrench_on_child_in_child_joint_frame;
          end
          df_ext = reshape(df_ext,6,[]);
       end

--- a/systems/plants/RigidBodyTorsionalSpring.m
+++ b/systems/plants/RigidBodyTorsionalSpring.m
@@ -29,7 +29,7 @@ classdef RigidBodyTorsionalSpring < RigidBodyForceElement
       f_ext(:,obj.child_body) = AdT_body_to_joint' * wrench_on_child_in_child_joint_frame;
 
       if obj.parent_body ~= 0 % don't apply force to world body
-        T_parent_body_to_child_joint = homogTransInv(manip.body(obj.child_body.Ttree));
+        T_parent_body_to_child_joint = homogTransInv(manip.body(obj.child_body).Ttree);
         AdT_parent_body_to_child_joint = transformAdjoint(T_parent_body_to_child_joint);
         f_ext(:,obj.parent_body) = -AdT_parent_body_to_child_joint' * wrench_on_child_in_child_joint_frame; 
       end

--- a/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -27,14 +27,6 @@ void drakePrintMatrix(const MatrixXd &mat)
   }
 };
 
-//static void checkBodyInd(int body, int num_bodies, int min_body_ind = 0)
-//{
-//  if(body< min_body_ind || body>=num_bodies)
-//  {
-//    std::cerr<<"body should be within ["<<min_body_ind<<" robot.num_bodies-1]"<<std::endl;
-//  }
-//}
-
 namespace DrakeRigidBodyConstraint{
   Vector4d com_pts(0.0,0.0,0.0,1.0);
   const int WorldCoMDefaultRobotNum[1] = {0};

--- a/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -27,13 +27,14 @@ void drakePrintMatrix(const MatrixXd &mat)
   }
 };
 
-static void checkBodyInd(int body, int num_bodies, int min_body_ind = 0)
-{
-  if(body< min_body_ind || body>=num_bodies)
-  {
-    std::cerr<<"body should be within ["<<min_body_ind<<" robot.num_bodies-1]"<<std::endl;
-  }
-}
+//static void checkBodyInd(int body, int num_bodies, int min_body_ind = 0)
+//{
+//  if(body< min_body_ind || body>=num_bodies)
+//  {
+//    std::cerr<<"body should be within ["<<min_body_ind<<" robot.num_bodies-1]"<<std::endl;
+//  }
+//}
+
 namespace DrakeRigidBodyConstraint{
   Vector4d com_pts(0.0,0.0,0.0,1.0);
   const int WorldCoMDefaultRobotNum[1] = {0};

--- a/systems/plants/constructModelmex.cpp
+++ b/systems/plants/constructModelmex.cpp
@@ -40,9 +40,6 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
 
 //  model->robot_name = get_strings(mxGetProperty(pRBM,0,"name"));
 
-  const mxArray* featherstone = mxGetProperty(pRBM,0,"featherstone");
-  if (!featherstone) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs", "the featherstone array is invalid");
-
   const mxArray* pBodies = mxGetProperty(pRBM,0,"body");
   if (!pBodies) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","the body array is invalid");
   int num_bodies = static_cast<int>(mxGetNumberOfElements(pBodies));
@@ -51,63 +48,11 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
   if (!pFrames) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","the frame array is invalid");
   int num_frames = static_cast<int>(mxGetNumberOfElements(pFrames));
 
-  // set up the model
-  pm = mxGetField(featherstone,0,"NB");
-  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.NB.  Are you passing in the correct structure?");
-  model = new RigidBodyManipulator((int) mxGetScalar(pm), (int) mxGetScalar(pm), num_bodies, num_frames);
+  pm = mxGetProperty(pRBM, 0, "num_positions");
+  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","model should have a num_positions field");
+  int num_positions = static_cast<int>(*mxGetPrSafe(pm));
 
-  pm = mxGetField(featherstone,0,"parent");
-  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.parent.");
-  double* parent = mxGetPrSafe(pm);
-
-  pm = mxGetField(featherstone,0,"pitch");
-  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.pitch.");
-  double* pitch = mxGetPrSafe(pm);
-
-  pm = mxGetField(featherstone,0,"position_num");
-  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.position_num.");
-  double* dofnum = mxGetPrSafe(pm);
-//  throw runtime_error("here");
-
-  pm = mxGetField(featherstone,0,"damping");
-  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.damping.");
-  memcpy(model->damping.data(),mxGetPrSafe(pm),sizeof(double)*model->NB);
-
-  pm = mxGetField(featherstone,0,"coulomb_friction");
-  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.coulomb_friction.");
-  memcpy(model->coulomb_friction.data(),mxGetPrSafe(pm),sizeof(double)*model->NB);
-
-  pm = mxGetField(featherstone,0,"static_friction");
-  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.static_friction.");
-  memcpy(model->static_friction.data(),mxGetPrSafe(pm),sizeof(double)*model->NB);
-
-  pm = mxGetField(featherstone,0,"coulomb_window");
-  if (!pm) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.coulomb_window.");
-  memcpy(model->coulomb_window.data(),mxGetPrSafe(pm),sizeof(double)*model->NB);
-
-  mxArray* pXtree = mxGetField(featherstone,0,"Xtree");
-  if (!pXtree) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.Xtree.");
-
-  mxArray* pI = mxGetField(featherstone,0,"I");
-  if (!pI) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't find field model.featherstone.I.");
-
-  for (int i=0; i<model->NB; i++) {
-    model->parent[i] = ((int) parent[i]) - 1;  // since it will be used as a C index
-    model->pitch[i] = (int) pitch[i];
-    model->dofnum[i] = (int) dofnum[i] - 1; // zero-indexed
-
-    mxArray* pXtreei = mxGetCell(pXtree,i);
-    if (!pXtreei) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't access model.featherstone.Xtree{%d}",i);
-
-    // todo: check that the size is 6x6
-    memcpy(model->Xtree[i].data(),mxGetPrSafe(pXtreei),sizeof(double)*6*6);
-
-    mxArray* pIi = mxGetCell(pI,i);
-    if (!pIi) mexErrMsgIdAndTxt("Drake:constructModelmex:BadInputs","can't access model.featherstone.I{%d}",i);
-
-    // todo: check that the size is 6x6
-    memcpy(model->I[i].data(),mxGetPrSafe(pIi),sizeof(double)*6*6);
-  }
+  model = new RigidBodyManipulator(num_positions, num_bodies, num_frames);
 
   for (int i=0; i<model->num_bodies; i++) {
     //DEBUG

--- a/systems/plants/doKinematicsmex.cpp
+++ b/systems/plants/doKinematicsmex.cpp
@@ -23,8 +23,8 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] ) {
   int nq = model->num_positions;
   int nv = model->num_velocities;
   
-  if (mxGetNumberOfElements(prhs[1])!=model->NB)
-    mexErrMsgIdAndTxt("Drake:doKinematicsmex:BadInputs", "q must be size %d x 1", model->NB);
+  if (mxGetNumberOfElements(prhs[1])!=nq)
+    mexErrMsgIdAndTxt("Drake:doKinematicsmex:BadInputs", "q must be size %d x 1", nq);
   
   Map<VectorXd> q(mxGetPrSafe(prhs[1]), nq);
   bool b_compute_second_derivatives = (mxGetScalar(prhs[2])!=0.0);


### PR DESCRIPTION
Fixes #957.

This also changes the frame of f_ext from 'Featherstone joint frame' to body frame in manipulatorDynamics, setupAndSolveQP, and in the RigidBodyForceElements.