### PR TITLE
fix second-to-last footstep location not matching the goal pose

### DIFF
--- a/examples/Atlas/runAtlasFootstepPlanning.m
+++ b/examples/Atlas/runAtlasFootstepPlanning.m
@@ -18,7 +18,7 @@ start_pos = struct('right', forwardKin(r, kinsol, r.foot_frame_id.right, [0;0;0]
                    'left', forwardKin(r, kinsol, r.foot_frame_id.left, [0;0;0], 1));
 
 % Plan footsteps to the goal
-goal_pos = struct('right', [1;0;0;0;0;0], 'left', [1;0.26;0;0;0;0]);
+goal_pos = struct('right', [1;-0.13;0;0;0;0], 'left', [1;0.13;0;0;0;0]);
 plan = r.planFootsteps(start_pos, goal_pos);
 
 % Show the result

--- a/systems/robotInterfaces/+footstepPlanner/nonlinearCollocation.m
+++ b/systems/robotInterfaces/+footstepPlanner/nonlinearCollocation.m
@@ -295,14 +295,15 @@ function [Q, c] = footstepQuadraticCost(biped, seed_plan, weights, goal_pos, nom
   c = zeros(nvar, 1);
 
   w_goal = diag(weights.goal);
-  if seed_plan.footsteps(end).frame_id == biped.foot_frame_id.right
-    xg = reshape(goal_pos.right, [], 1);
-  else
-    xg = reshape(goal_pos.left, [], 1);
+  for j = (nsteps - 1):nsteps
+    if seed_plan.footsteps(j).frame_id == biped.foot_frame_id.right
+      xg = reshape(goal_pos.right, [], 1);
+    else
+      xg = reshape(goal_pos.left, [], 1);
+    end
+    Q(world_ndx(:,j), world_ndx(:,j)) = w_goal;
+    c(world_ndx(:,j)) = -2 * xg' * w_goal;
   end
-  j = nsteps;
-  Q(world_ndx(:,j), world_ndx(:,j)) = w_goal;
-  c(world_ndx(:,j)) = -2 * xg' * w_goal;
 
   w_rel = diag(weights.relative);
   for j = 2:nsteps


### PR DESCRIPTION
The goal pose objective was only being applied to the final footstep (in the nonlinear footstep planner), not the second-to-last footstep. This worked ok going forward, but resulted in uneven final steps when going backward because of the asymmetry of the relative step cost (basically, we penalize error from the nominal *forward* step, which creates an asymmetry between forward and backward walking).

With this fix, the feet should be much better aligned at the end of walking plans, especially when going backwards.  