### PR TITLE
increase timeout for memory test.  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,4 +178,4 @@ add_test(NAME "RigidBodyManipulatorMemoryTest"
 	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/examples/Acrobot"
 	COMMAND "matlab" #"${CMAKE_SOURCE_DIR}/cmake/matlab_clean.pl"
 	"-nosplash" "-nodisplay" "-r" "addpath('${CMAKE_INSTALL_PREFIX}/matlab'); addpath_${POD_NAME}; try, r = RigidBodyManipulator('Acrobot.urdf'); megaclear; catch ex, disp(getReport(ex,'extended')); disp(''); force_close_system; exit(1); end; force_close_system; exit(0)")
-set_tests_properties(RigidBodyManipulatorMemoryTest PROPERTIES TIMEOUT 60)
+set_tests_properties(RigidBodyManipulatorMemoryTest PROPERTIES TIMEOUT 300)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,5 +177,5 @@ endif()
 add_test(NAME "RigidBodyManipulatorMemoryTest"
 	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/examples/Acrobot"
 	COMMAND "matlab" #"${CMAKE_SOURCE_DIR}/cmake/matlab_clean.pl"
-	"-nosplash" "-nodisplay" "-r" "addpath('${CMAKE_INSTALL_PREFIX}/matlab'); addpath_${POD_NAME}; try, r = RigidBodyManipulator('Acrobot.urdf'); megaclear; catch ex, disp(getReport(ex,'extended')); disp(''); force_close_system; exit(1); end; force_close_system; exit(0)")
+	"-nosplash" "-nodisplay" "-wait" "-r" "addpath('${CMAKE_INSTALL_PREFIX}/matlab'); addpath_${POD_NAME}; try, r = RigidBodyManipulator('Acrobot.urdf'); megaclear; catch ex, disp(getReport(ex,'extended')); disp(''); force_close_system; exit(1); end; force_close_system; exit(0)")
 set_tests_properties(RigidBodyManipulatorMemoryTest PROPERTIES TIMEOUT 300)


### PR DESCRIPTION
apparently it takes more than 60 seconds for drake002 to start up matlab and load an RBM when parallel tests are running.  (drake006 takes ~ 14 seconds, and drake001 takes ~41 seconds).  it seems to take almost 60 seconds even when the machine is unloaded.  wow.

resolves #1025 .