### PR TITLE
Add point-cloud collision checking

### DIFF
--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -493,48 +493,18 @@ string RigidBodyManipulator::getStateName(int state_num) const
 		return getVelocityName(state_num);
 }
 
-map<string, int> RigidBodyManipulator::computeDofMap() const
+map<string, int> RigidBodyManipulator::computePositionNameToIndexMap() const
 {
   const RigidBodyManipulator* const model = this;
 
   const std::shared_ptr<RigidBody> worldBody = model->bodies[0];
 
-  map<string, int> dofMap;
+  map<string, int> name_to_index_map;
 
-  for (auto iter = this->bodies.begin(); iter != this->bodies.end(); ++iter) { 
-    std::shared_ptr<RigidBody> body(*iter);
-
-    if (!body->hasParent())
-    {
-      continue;
-    }
-
-    if (body->getJoint().getNumPositions() == 0)
-    {
-      continue;
-    }
-
-    int dofId = body->position_num_start;
-
-    if (body->parent == worldBody)
-    {
-      //printf("dofMap base\n");
-
-      dofMap["base_x"] = dofId + 0;
-      dofMap["base_y"] = dofId + 1;
-      dofMap["base_z"] = dofId + 2;
-      dofMap["base_roll"] = dofId + 3;
-      dofMap["base_pitch"] = dofId + 4;
-      dofMap["base_yaw"] = dofId + 5;
-    }
-    else
-    {
-      //printf("dofMap[%s] = %d\n", body->getJoint().getName().c_str(), dofId);
-      dofMap[body->getJoint().getName()] = dofId;
-    }
-
+  for (int i = 0; i < this->num_positions; ++i) {
+      name_to_index_map[getPositionName(i)] = i;
   }
-  return dofMap;
+  return name_to_index_map;
 }
 
 DrakeCollision::ElementId RigidBodyManipulator::addCollisionElement(const RigidBody::CollisionElement& element, const shared_ptr<RigidBody>& body, string group_name)

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -79,7 +79,7 @@ public:
   bool addRobotFromURDF(const std::string &urdf_filename, const DrakeJoint::FloatingBaseType floating_base_type = DrakeJoint::ROLLPITCHYAW);
   bool addRobotFromURDF(const std::string &urdf_filename, std::map<std::string,std::string>& package_map, const DrakeJoint::FloatingBaseType floating_base_type = DrakeJoint::ROLLPITCHYAW);
 
-  std::map<std::string, int> computeDofMap() const;
+  std::map<std::string, int> computePositionNameToIndexMap() const;
 
   void surfaceTangents(Eigen::Map<Matrix3xd> const & normals, std::vector< Map<Matrix3xd> > & tangents);
   

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -79,6 +79,8 @@ public:
   bool addRobotFromURDF(const std::string &urdf_filename, const DrakeJoint::FloatingBaseType floating_base_type = DrakeJoint::ROLLPITCHYAW);
   bool addRobotFromURDF(const std::string &urdf_filename, std::map<std::string,std::string>& package_map, const DrakeJoint::FloatingBaseType floating_base_type = DrakeJoint::ROLLPITCHYAW);
 
+  std::map<std::string, int> computeDofMap() const;
+
   void surfaceTangents(Eigen::Map<Matrix3xd> const & normals, std::vector< Map<Matrix3xd> > & tangents);
   
   void resize(int num_dof, int num_rigid_body_objects=-1, int num_rigid_body_frames=0);
@@ -268,6 +270,10 @@ public:
                            std::vector<int>& bodyB_idx, 
                            bool use_margins = true);
   //bool closestDistanceAllBodies(VectorXd& distance, MatrixXd& Jd);
+ 
+  virtual std::vector<size_t> collidingPoints(
+        const std::vector<Eigen::Vector3d>& points, 
+        double collision_threshold);
 
   void warnOnce(const std::string& id, const std::string& msg);
 

--- a/systems/plants/collision/BulletModel.cpp
+++ b/systems/plants/collision/BulletModel.cpp
@@ -28,7 +28,7 @@ namespace DrakeCollision
         return 0;
       }
     private:
-        bool in_collision;
+        bool in_collision = false;
   };
 
   bool OverlapFilterCallback::needBroadphaseCollision(btBroadphaseProxy* proxy0,

--- a/systems/plants/collision/BulletModel.cpp
+++ b/systems/plants/collision/BulletModel.cpp
@@ -12,6 +12,11 @@ namespace DrakeCollision
   struct BinaryContactResultCallback : public btCollisionWorld::ContactResultCallback
   {
     public:
+      BinaryContactResultCallback()
+      {
+        in_collision = false;
+      }
+
       bool isInCollision()
       {
         return in_collision;
@@ -28,7 +33,7 @@ namespace DrakeCollision
         return 0;
       }
     private:
-        bool in_collision = false;
+        bool in_collision;
   };
 
   bool OverlapFilterCallback::needBroadphaseCollision(btBroadphaseProxy* proxy0,

--- a/systems/plants/collision/BulletModel.cpp
+++ b/systems/plants/collision/BulletModel.cpp
@@ -42,13 +42,12 @@ namespace DrakeCollision
     if (collides) {
       btCollisionObject* bt_collision_object0 = (btCollisionObject*) proxy0->m_clientObject;
       btCollisionObject* bt_collision_object1 = (btCollisionObject*) proxy1->m_clientObject;
-      if ((bt_collision_object0->getUserPointer() == NULL) || 
-          (bt_collision_object1->getUserPointer() == NULL)) {
-        return false;
+      if ((bt_collision_object0->getUserPointer() != NULL) &&
+          (bt_collision_object1->getUserPointer() != NULL)) {
+        auto element0 = static_cast< Element* >(bt_collision_object0->getUserPointer());
+        auto element1 = static_cast< Element* >(bt_collision_object1->getUserPointer());
+        collides = collides && element0->collidesWith(element1);
       }
-      auto element0 = static_cast< Element* >(bt_collision_object0->getUserPointer());
-      auto element1 = static_cast< Element* >(bt_collision_object1->getUserPointer());
-      collides = collides && element0->collidesWith(element1);
     }
     return collides;
   }

--- a/systems/plants/collision/BulletModel.cpp
+++ b/systems/plants/collision/BulletModel.cpp
@@ -55,8 +55,8 @@ namespace DrakeCollision
   BulletCollisionWorldWrapper::BulletCollisionWorldWrapper()
     : bt_collision_configuration(), bt_collision_broadphase(), filter_callback()
   {
-    bt_collision_configuration.setConvexConvexMultipointIterations(PERTURBATION_ITERATIONS, MINIMUM_POINTS_PERTURBATION_THRESHOLD);
-    bt_collision_configuration.setPlaneConvexMultipointIterations(PERTURBATION_ITERATIONS, MINIMUM_POINTS_PERTURBATION_THRESHOLD);
+    bt_collision_configuration.setConvexConvexMultipointIterations(0, 0);
+    bt_collision_configuration.setPlaneConvexMultipointIterations(0, 0);
     bt_collision_dispatcher = unique_ptr<btCollisionDispatcher>(new btCollisionDispatcher(&bt_collision_configuration));
     bt_collision_world = unique_ptr<btCollisionWorld>(new btCollisionWorld(bt_collision_dispatcher.get(), &bt_collision_broadphase, &bt_collision_configuration));
 
@@ -229,6 +229,8 @@ namespace DrakeCollision
   vector<PointPair> BulletModel::potentialCollisionPoints(bool use_margins)
   {
     BulletCollisionWorldWrapper& bt_world = getBulletWorld(use_margins);
+    bt_world.bt_collision_configuration.setConvexConvexMultipointIterations(PERTURBATION_ITERATIONS, MINIMUM_POINTS_PERTURBATION_THRESHOLD);
+    bt_world.bt_collision_configuration.setPlaneConvexMultipointIterations(PERTURBATION_ITERATIONS, MINIMUM_POINTS_PERTURBATION_THRESHOLD);
     BulletResultCollector c;
     bt_world.bt_collision_world->performDiscreteCollisionDetection();
     size_t numManifolds = bt_world.bt_collision_world->getDispatcher()->getNumManifolds();
@@ -282,6 +284,8 @@ namespace DrakeCollision
       }
     }   
 
+    bt_world.bt_collision_configuration.setConvexConvexMultipointIterations(0, 0);
+    bt_world.bt_collision_configuration.setPlaneConvexMultipointIterations(0, 0);
     return c.getResults();
   }
 

--- a/systems/plants/collision/BulletModel.h
+++ b/systems/plants/collision/BulletModel.h
@@ -81,6 +81,10 @@ namespace DrakeCollision
 
       virtual std::vector<PointPair> potentialCollisionPoints(bool use_margins);
 
+      virtual std::vector<size_t> collidingPoints(
+          const std::vector<Eigen::Vector3d>& points, 
+          double collision_threshold);
+
       // END Required member functions
       
     protected:

--- a/systems/plants/collision/Model.h
+++ b/systems/plants/collision/Model.h
@@ -49,6 +49,11 @@ namespace DrakeCollision
       virtual std::vector<PointPair> potentialCollisionPoints(const bool use_margins) 
       { return std::vector<PointPair>(); };
 
+      virtual std::vector<size_t> collidingPoints(
+          const std::vector<Eigen::Vector3d>& points, 
+          double collision_threshold)
+      { return std::vector<size_t>(); };
+
       //
       // Performs raycasting collision detecting (like a LIDAR / laser rangefinder)
       //

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -37,6 +37,10 @@ add_library(drakeGeometryUtil SHARED drakeGeometryUtil.cpp expmap2quat.cpp)
 target_link_libraries(drakeGeometryUtil drakeGradientUtil)
 pods_install_libraries(drakeGeometryUtil)
 pods_install_headers(drakeGeometryUtil.h DESTINATION drake)
+pods_install_pkg_config_file(drake-geometry-util
+  LIBS -ldrakeGeometryUtil
+  REQUIRES
+  VERSION 0.0.1)
 
 pods_install_headers(drakeFloatingPointUtil.h DESTINATION drake)
 


### PR DESCRIPTION
This pull request adds a method to the C++ RBM, collidingPoints, which takes a vector of 3D points and returns the indices of those points that are within some distance of the robot. This enables us to use drake in the drc-lidar-passthrough process.

Same changes as mitdrc/drake#77