### PR TITLE
remove unused lines in QPCommon

### DIFF
--- a/systems/controllers/QPCommon.cpp
+++ b/systems/controllers/QPCommon.cpp
@@ -655,9 +655,6 @@ int setupAndSolveQP(NewQPControllerData *pdata, std::shared_ptr<drake::lcmt_qp_c
   
   // add in body spatial equality constraints
   // VectorXd body_vdot;
-  Vector4d orig1 = Vector4d::Zero();
-  orig1(3) = 1.0;
-  Vector3d orig = Vector3d::Zero();
   int equality_ind = 6+neps;
   MatrixXd Jb(6,nq);
   Vector6d Jbdotv;	


### PR DESCRIPTION
(was throwing a warning on mac clang)