### PR TITLE
Delay simulink load

### DIFF
--- a/systems/@DynamicalSystem/DynamicalSystem.m
+++ b/systems/@DynamicalSystem/DynamicalSystem.m
@@ -370,7 +370,7 @@ classdef DynamicalSystem
       inport = find_system(mdl,'SearchDepth',1,'BlockType','Inport');
       ts = [];
       for i=1:length(inport)
-        ts = [ts,Simulink.Block.getSampleTimes(inport{i}).Value'];
+        ts = [ts,getSimulinkSampleTimes(inport{i})];
       end
     end
     function ts = getOutputSampleTimes(obj)
@@ -380,7 +380,7 @@ classdef DynamicalSystem
       outport = find_system(mdl,'SearchDepth',1,'BlockType','Outport');
       ts = [];
       for i=1:length(outport)
-        ts = [ts,Simulink.Block.getSampleTimes(outport{i}).Value'];
+        ts = [ts,getSimulinkSampleTimes(outport{i})];
       end
     end
     
@@ -652,7 +652,7 @@ classdef DynamicalSystem
       if (nargin<3) mdl = getModel(obj); end
       
       if (isempty(obj.structured_x))
-        obj.structured_x = Simulink.BlockDiagram.getInitialState(mdl.name);
+        obj.structured_x = getSimulinkStateStructure(mdl.name);
       end
       xs = obj.structured_x;
       if (length(xs.signals)>1)

--- a/util/force_close_system.m
+++ b/util/force_close_system.m
@@ -8,6 +8,7 @@ if iscell(sys)
   end
 elseif ischar(sys)
   if (strcmpi(sys,'all'))
+    if isempty(license('inuse','simulink')), return; end  % don't load simulink if it's not loaded already
     force_close_system(find_system('SearchDepth',0));
   else
     try 

--- a/util/getSimulinkSampleTimes.m
+++ b/util/getSimulinkSampleTimes.m
@@ -1,0 +1,6 @@
+function ts = getSimulinkSampleTimes(ref)
+% Note: this used to be inside DynamicalSystem.stateVectorToStructure, but
+% having it there caused simulink to be loaded ( see 
+% https://github.com/RobotLocomotion/drake/issues/1044 )
+
+ts = Simulink.Block.getSampleTimes(ref).Value';

--- a/util/getSimulinkStateStructure.m
+++ b/util/getSimulinkStateStructure.m
@@ -1,0 +1,8 @@
+function x_struct = getSimulinkStateStructure(mdl)
+% Note: this used to be inside DynamicalSystem.stateVectorToStructure, but
+% having it there caused simulink to be loaded ( see 
+% https://github.com/RobotLocomotion/drake/issues/1044 )
+
+x_struct = Simulink.BlockDiagram.getInitialState(mdl);
+
+


### PR DESCRIPTION
After investigating #1044, it turned out that moving a few simulink calls out of the DynamicalSystem class allows RBM's to load without loading the entire simulink engine.

For instance, one can now call
```
addpath_drake;
cd examples/Atlas;
options.floating = true;
options.dt = 0.002;
options.use_new_kinsol = true;
r = Atlas('urdf/atlas_minimal_contact.urdf',options);
r = r.removeCollisionGroupsExcept({'heel','toe'});
r = compile(r);
```
and presumably more (short of simulation, etc) without simulink getting loaded. 
