### PR TITLE
work-around for `clear all` matlab bug.  

### DIFF
--- a/systems/frames/CoordinateFrame.m
+++ b/systems/frames/CoordinateFrame.m
@@ -9,7 +9,6 @@ classdef CoordinateFrame < handle
     dim=0;          % scalar dimension of this coordinate system
     transforms={};  % handles to CoordinateTransform objects
 
-    name_hash;      % unique hash of the string name
     coordinates={}; % list of coordinate names
 
     prefix;         % a vector character prefix used for the msspoly variables, or a vector of size dim listing prefixes for each variable
@@ -39,7 +38,6 @@ classdef CoordinateFrame < handle
 
       typecheck(name,'char');
       obj.name = name;
-      obj.name_hash = java.lang.String(obj.name).hashCode();
 
       typecheck(dim,'double');
       sizecheck(dim,[1 1]);

--- a/util/getDrakePath.m
+++ b/util/getDrakePath.m
@@ -9,10 +9,6 @@ function root = getDrakePath()
 persistent myroot;
 
 if (isempty(myroot))
-  known_file = which('LinearSystem');
-  if isempty(known_file)
-    error('Can''t find drake root.  Did you call addpath_drake?');
-  end
-  myroot = fileparts(fileparts(known_file));
+  myroot = fileparts(fileparts(which('getDrakePath')));
 end
 root = myroot;


### PR DESCRIPTION
resolves #635 .  take a look at my minimal example for a good laugh.

it's obviously a bug in matlab.  but this particular way that we trip it is sort of unbelievably unlucky and easy to work around.

also removes unused name_hash from `CoordinateFrame` that was loading `java.lang.String` unnecessarily.
