### PR TITLE
clean up:  don't add a state constraint for infinite joint limits.  (dif...

### DIFF
--- a/examples/SimpleDoublePendulum/runEndPointJac.m
+++ b/examples/SimpleDoublePendulum/runEndPointJac.m
@@ -1,23 +1,15 @@
 function runEndPointJac
 
-r = PlanarRigidBodyManipulator('SimpleDoublePendulum.urdf',struct('terrain',[]));
+r = PlanarRigidBodyManipulator('SimpleDoublePendulum.urdf');
 v = r.constructVisualizer();
 v.axis = [-2 2 -2 2];
 
-kp = diag([100 100]);
-kd = diag([10 10]);
+kp = diag([20 20]);
+kd = diag([4 4]);
 sys = pdcontrol(r,kp,kd);
 
 c = EndPointControl(sys,r);
 
-%endpoint_d = FunctionHandleTrajectory(@(t)[1;1-.5*sin(t/2)],2,[0 5]);
-%endpoint_d = setOutputFrame(endpoint_d,sys.getInputFrame);
-
-%tf = 15;
-%xtraj = simulate(feedback(sys,c),[0 tf]);
-%v.playback(xtraj);
-
-w = warning('off','Drake:DrakeSystem:UnsupportedSampleTime');
-simulate(cascade(feedback(sys,c),v),[0 5])
-warning(w);
+xtraj = simulate(feedback(sys,c),[0 3]);
+v.playback(xtraj);
 

--- a/examples/SimpleDoublePendulum/runSimplePendInv.m
+++ b/examples/SimpleDoublePendulum/runSimplePendInv.m
@@ -1,4 +1,4 @@
-function runDPSimplePend
+function runSimplePendInv
 % Simulate the passive acrobot
 
 d = DoublePendPlant;

--- a/systems/plants/@Manipulator/Manipulator.m
+++ b/systems/plants/@Manipulator/Manipulator.m
@@ -497,9 +497,13 @@ classdef Manipulator < DrakeSystem
       con = BoundingBoxConstraint(jl_min,jl_max);
       con = setName(con,cellfun(@(a) [a,'_limit'],obj.getPositionFrame.coordinates,'UniformOutput',false));
       if isempty(obj.joint_limit_constraint_id)
-        [obj,id] = addStateConstraint(obj,con,1:obj.getNumPositions);
-        obj.joint_limit_constraint_id = id;
+        if any(jl_min~=-inf) || any(jl_max~=inf)
+          [obj,id] = addStateConstraint(obj,con,1:obj.getNumPositions);
+          obj.joint_limit_constraint_id = id;
+        end
       else
+        % todo: delete the constraint if [-inf,inf] (but don't have a good
+        % mechanism for removing state constraints yet)
         obj = updateStateConstraint(obj,obj.joint_limit_constraint_id,con,1:obj.getNumPositions);
       end
     end


### PR DESCRIPTION
...fuses lots of unwarranted warnings about combining and simulating systems that should not actually have any state constraints)

clean up simple double pend examples (which appeared to somewhat randomly trip up the build servers.
http://kobol.csail.mit.edu/cd/viewTest.php?onlyfailed&buildid=12823