### PR TITLE
pass through the option of limiting data points stored during a simulink sim

### DIFF
--- a/systems/@DynamicalSystem/simulate.m
+++ b/systems/@DynamicalSystem/simulate.m
@@ -14,6 +14,8 @@ function [ytraj,xtraj,lcmlog] = simulate(obj,tspan,x0,options)
 % @option gui_control_interface set to true to bring up a figure with play/stop buttons @default false
 % @option lcm_control_interface channel on which to listen for lcmt_simulation_control messages.  @default '' -- which means no lcm
 %            interface
+% @option MaxDataPoints integer N to limit output to the last N data
+%            points.  useful for running very long simulations. 
 
 checkDependency('simulink');
 if ~exist('DCSFunction','file')
@@ -84,7 +86,13 @@ end
 pstruct.StateSaveName = 'xout';
 pstruct.SaveOutput = 'on';
 pstruct.OutputSaveName = 'yout';
-pstruct.LimitDataPoints = 'off';
+if isfield(options,'MaxDataPoints') && ~isinf(options.MaxDataPoints)
+  pstruct.LimitDataPoints = 'on';
+  pstruct.MaxDataPoints = num2str(options.MaxDataPoints);
+else
+  pstruct.LimitDataPoints = 'off'
+end
+  
 %pstruct.SaveOnModelUpdate = 'false';
 %pstruct.AutoSaveOptions.SaveModelOnUpdate = 'false';
 %pstruct.AutoSaveOptions.SaveBackupOnVersionUpgrade = 'false';


### PR DESCRIPTION
verified that I could simulate atlas balancing for 100 seconds (without matlab continually grabbing memory) and get back just the last few seconds.
i suspect this resolves https://github.com/mitdrc/drc/issues/1430