### PR TITLE
Fix atlas v5 hand position

### DIFF
--- a/examples/Atlas/Atlas.m
+++ b/examples/Atlas/Atlas.m
@@ -46,9 +46,9 @@ classdef Atlas < TimeSteppingRigidBodyManipulator & Biped
         hand_orientation_right = [0; -pi/2; pi];
         hand_orientation_left = [0; pi/2; pi];
       elseif options.atlas_version == 5
-        hand_position_right = [0; -0.195; -0.01];
+        hand_position_right = [0; -0.195; 0.0];
         hand_orientation_right = [0; -pi/2; pi];
-        hand_position_left = [0; -0.195; -0.01];
+        hand_position_left = [0; -0.195; 0.0];
         hand_orientation_left = [0; -pi/2; pi];
       end
 

--- a/examples/Atlas/Atlas.m
+++ b/examples/Atlas/Atlas.m
@@ -46,10 +46,10 @@ classdef Atlas < TimeSteppingRigidBodyManipulator & Biped
         hand_orientation_right = [0; -pi/2; pi];
         hand_orientation_left = [0; pi/2; pi];
       elseif options.atlas_version == 5
-        hand_position_right = [0; -0.1245; 0];
-        hand_orientation_right = [0; 0; pi];
-        hand_position_left = [0; -0.1245; 0];
-        hand_orientation_left = [0; 0; pi];
+        hand_position_right = [0; -0.195; -0.01];
+        hand_orientation_right = [0; -pi/2; pi];
+        hand_position_left = [0; -0.195; -0.01];
+        hand_orientation_left = [0; -pi/2; pi];
       end
 
       hand=options.hand_right;


### PR DESCRIPTION
This tweaks the hand positioning in atlas v5 to match the visualization from the director on the DRC side by pushing them a bit further out the wrist and rotating.