### PR TITLE
supports is a zero-order-hold, so it should be 1 element shorter than support_times

### DIFF
--- a/systems/robotInterfaces/QPLocomotionPlan.m
+++ b/systems/robotInterfaces/QPLocomotionPlan.m
@@ -126,8 +126,8 @@ classdef QPLocomotionPlan < QPControllerPlan
 
       if t_plan < obj.support_times(1)
         supp_idx = 1;
-      elseif t_plan > obj.support_times(end)
-        supp_idx = length(obj.support_times);
+      elseif t_plan >= obj.support_times(end)
+        supp_idx = length(obj.supports);
       else
         supp_idx = find(obj.support_times<=t_plan,1,'last');
       end
@@ -475,7 +475,7 @@ classdef QPLocomotionPlan < QPControllerPlan
       obj.x0 = x0;
       obj.support_times = [0, inf];
       obj.duration = inf;
-      obj.supports = [support_state, support_state];
+      obj.supports = support_state;
       obj.is_quasistatic = true;
 
       nq = obj.robot.getNumPositions();
@@ -736,6 +736,7 @@ classdef QPLocomotionPlan < QPControllerPlan
     function [supports, support_times] = getSupports(zmp_knots)
       supports = [zmp_knots.supp];
       support_times = [zmp_knots.t];
+      supports = supports(1:(numel(support_times)-1));
     end
 
     function zmptraj = getZMPTraj(zmp_knots)

--- a/systems/robotInterfaces/QPLocomotionPlan.m
+++ b/systems/robotInterfaces/QPLocomotionPlan.m
@@ -736,7 +736,6 @@ classdef QPLocomotionPlan < QPControllerPlan
     function [supports, support_times] = getSupports(zmp_knots)
       supports = [zmp_knots.supp];
       support_times = [zmp_knots.t];
-      supports = supports(1:(numel(support_times)-1));
     end
 
     function zmptraj = getZMPTraj(zmp_knots)


### PR DESCRIPTION
This will be useful in DRC to smoothly hold the current support configuration when transitioning to a new plan