### PR TITLE
add the ik test in cpp back

### DIFF
--- a/systems/plants/test/CMakeLists.txt
+++ b/systems/plants/test/CMakeLists.txt
@@ -38,7 +38,7 @@ if (gurobi_FOUND AND Boost_FOUND)
   add_ik_cpp(testApproximateIK)
 endif()
 
-if (snopt_cpp_FOUND AND Boost_FOUND)
+if (snopt_c_FOUND AND Boost_FOUND)
   add_ik_cpp(testIK)
   add_ik_cpp(testIKpointwise)
   add_ik_cpp(testIKtraj)


### PR DESCRIPTION
The C++ IK tests were not built because it is looking for `snopt_cpp`, but we changed it to `snopt_c` some time ago.