### PR TITLE
improved material handling in the C++ URDF parser

### DIFF
--- a/systems/plants/RigidBodyManipulatorURDF.cpp
+++ b/systems/plants/RigidBodyManipulatorURDF.cpp
@@ -389,7 +389,7 @@ bool parseVisual(shared_ptr<RigidBody> body, TiXmlElement* node, RigidBodyManipu
   if (material_node) {
     const char* attr;
     attr = material_node->Attribute("name");
-    if (attr && strlen(attr) > 0) {
+    if (attr && strlen(attr) > 0 && materials.find(attr) != materials.end()) {
       element.setMaterial(materials.at(attr));
     } else { 
       TiXmlElement* color_node = material_node->FirstChildElement("color");

--- a/systems/plants/RigidBodyManipulatorURDF.cpp
+++ b/systems/plants/RigidBodyManipulatorURDF.cpp
@@ -248,7 +248,7 @@ bool parseMaterial(TiXmlElement* node, map<string, Vector4d>& materials)
   const char* attr;
   attr = node->Attribute("name");
   if (!attr || strlen(attr) == 0) {
-    cerr << "WARNING: material tag is missing name attribute" << endl;
+    cerr << "WARNING: material tag is missing a name" << endl;
     return false;
   }
   string name(attr);
@@ -396,10 +396,12 @@ bool parseVisual(shared_ptr<RigidBody> body, TiXmlElement* node, RigidBodyManipu
       if (color_node) {
         Vector4d rgba;
         if (!parseVectorAttribute(color_node, "rgba", rgba)) {
-          cerr << "ERROR: Failed to parse color element rgba in visual" << endl;
+          cerr << "WARNING: Failed to parse color element rgba in visual" << endl;
         } else {
           element.setMaterial(rgba);
         }
+      } else {
+        cerr << "WARNING: visual element had a material with neither a name nor a nested color element" << endl;
       }
     }
   }

--- a/systems/plants/RigidBodyManipulatorURDF.cpp
+++ b/systems/plants/RigidBodyManipulatorURDF.cpp
@@ -247,7 +247,7 @@ bool parseMaterial(TiXmlElement* node, map<string, Vector4d>& materials)
 {
   const char* attr;
   attr = node->Attribute("name");
-  if (!attr) {
+  if (!attr || strlen(attr) == 0) {
     cerr << "WARNING: material tag is missing name attribute" << endl;
     return false;
   }
@@ -388,9 +388,19 @@ bool parseVisual(shared_ptr<RigidBody> body, TiXmlElement* node, RigidBodyManipu
   TiXmlElement* material_node = node->FirstChildElement("material");
   if (material_node) {
     const char* attr;
-    attr = node->Attribute("name");
-    if (attr) {
+    attr = material_node->Attribute("name");
+    if (attr && strlen(attr) > 0) {
       element.setMaterial(materials.at(attr));
+    } else { 
+      TiXmlElement* color_node = material_node->FirstChildElement("color");
+      if (color_node) {
+        Vector4d rgba;
+        if (!parseVectorAttribute(color_node, "rgba", rgba)) {
+          cerr << "ERROR: Failed to parse color element rgba in visual" << endl;
+        } else {
+          element.setMaterial(rgba);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Now directly parses the material from a nested color element when a material with no name (or an empty name) is encountered.  

Also fixes a bug where the material name attribute was incorrectly being grabbed from the visual element instead of the material element.  Visual elements don't support a name attribute according to the URDF spec.

Resolves #878