### PR TITLE
refactored surfaceTangents logic for planar RBMs

### DIFF
--- a/systems/plants/@PlanarRigidBodyManipulator/PlanarRigidBodyManipulator.m
+++ b/systems/plants/@PlanarRigidBodyManipulator/PlanarRigidBodyManipulator.m
@@ -141,7 +141,6 @@ classdef PlanarRigidBodyManipulator < RigidBodyManipulator
       % Follows surfaceTangents in RigidBodyManipulator, but produces only
       % a single tangent for each normal (instead of m), and restricts this
       % to the x-y plane.
-      
       normal = obj.T_2D_to_3D'*normal;
 
       % if the normal is [0;0] (because it was aligned with the viewing

--- a/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -1976,6 +1976,11 @@ classdef RigidBodyManipulator < Manipulator
         'Drake:RigidBodyManipulator:surfaceTangents:emptyNormals', ...
         '''normal'' must be a non-empty array')
 
+      if obj.mex_model_ptr ~= 0
+        d = surfaceTangentsmex(obj.mex_model_ptr, normal);
+        return
+      end
+
       t1=normal; % initialize size
 
       % handle the normal = [0;0;1] case

--- a/systems/plants/@RigidBodyManipulator/contactConstraintDerivatives.m
+++ b/systems/plants/@RigidBodyManipulator/contactConstraintDerivatives.m
@@ -1,7 +1,6 @@
-function [d, n, D, dn, dD] = contactConstraintDerivatives(obj, normal, kinsol, idxA, idxB, xA, xB)
+function [n, D, dn, dD] = contactConstraintDerivatives(obj, normal, kinsol, idxA, idxB, xA, xB, d)
 
 compute_second_derivative = nargout > 3;
-d = obj.surfaceTangents(normal);
 
 nq = obj.getNumPositions;  
 nk = size(d,2);

--- a/systems/plants/@RigidBodyManipulator/contactConstraints.m
+++ b/systems/plants/@RigidBodyManipulator/contactConstraints.m
@@ -57,26 +57,24 @@ end
 % For now, all coefficients of friction are 1
 mu = ones(nC,1);
 
+d = obj.surfaceTangents(normal);
+
 if obj.mex_model_ptr ~= 0
   if compute_first_derivative
     if ~compute_second_derivative
-      [d, n, D] = contactConstraintsmex(obj.mex_model_ptr, normal, int32(idxA), int32(idxB), xA, xB);
+      [n, D] = contactConstraintsmex(obj.mex_model_ptr, normal, int32(idxA), int32(idxB), xA, xB, d);
     else
-      [d, n, D, dn, dD] = contactConstraintsmex(obj.mex_model_ptr, normal, int32(idxA), int32(idxB), xA, xB);
+      [n, D, dn, dD] = contactConstraintsmex(obj.mex_model_ptr, normal, int32(idxA), int32(idxB), xA, xB, d);
     end
-  else
-    d = surfaceTangentsmex(obj.mex_model_ptr, normal);     
   end
+
 else %MATLAB implementation
   if compute_first_derivative
     if ~compute_second_derivative
-      [d, n, D] = contactConstraintDerivatives(obj, normal, kinsol, idxA, idxB, xA, xB);
+      [n, D] = contactConstraintDerivatives(obj, normal, kinsol, idxA, idxB, xA, xB, d);
     else
-      [d, n, D, dn, dD] = contactConstraintDerivatives(obj, normal, kinsol, idxA, idxB, xA, xB);
+      [n, D, dn, dD] = contactConstraintDerivatives(obj, normal, kinsol, idxA, idxB, xA, xB, d);
     end
-  else
-    d = obj.surfaceTangents(normal);
-  end
 end
 
 end

--- a/systems/plants/test/testContactConstraintsMex.m
+++ b/systems/plants/test/testContactConstraintsMex.m
@@ -18,16 +18,13 @@ kinsol = robot.doKinematics(q);
 idxA = idxA';
 idxB = idxB';
 
+d = robot.surfaceTangents(normal);
+
 %get the results from the mexed version
-[d_mex, n_mex, D_mex, dn_mex, dD_mex] =  contactConstraintsmex(robot.mex_model_ptr, normal, int32(idxA), int32(idxB), xA, xB);
+[n_mex, D_mex, dn_mex, dD_mex] =  contactConstraintsmex(robot.mex_model_ptr, normal, int32(idxA), int32(idxB), xA, xB, d);
 
 %get the results from the matlab version
-[d, n, D, dn, dD] = robot.contactConstraintDerivatives(normal, kinsol, idxA, idxB, xA, xB);
-
-%compare d
-for i = 1:size(d,2)
-  valuecheck(d_mex{i}, d{i});
-end
+[n, D, dn, dD] = robot.contactConstraintDerivatives(normal, kinsol, idxA, idxB, xA, xB, d);
 
 %compare n
 valuecheck(n_mex, n);

--- a/systems/plants/test/testSurfaceTangentsMex.m
+++ b/systems/plants/test/testSurfaceTangentsMex.m
@@ -21,7 +21,10 @@ kinsol = robot.doKinematics(q);
 d_mex  = surfaceTangentsmex(robot.mex_model_ptr, normal);
 
 %get the results from the matlab version
+temp = robot.mex_model_ptr;
+robot.mex_model_ptr = 0;
 d = robot.surfaceTangents(normal);
+robot.mex_model_ptr = temp;
 
 %compare d
 for i = 1:size(d,2)


### PR DESCRIPTION
Previously, the PlanarRigidBodyManipulator implementation of surfaceTangents was being ignored when mex was enabled.

This allows the implementation of surfaceTangents to decide whether or not it should use the mex version.

Resolves #1088 