### PR TITLE
forwardKin cleanup

### DIFF
--- a/systems/plants/RigidBodyManipulator.cpp
+++ b/systems/plants/RigidBodyManipulator.cpp
@@ -2699,108 +2699,78 @@ GradientVar<typename DerivedPoints::Scalar, Eigen::Dynamic, DerivedPoints::ColsA
 {
   if (gradient_order > 2)
     throw std::runtime_error("only first and second order gradients are available");
-
-  bool compute_jacobian_without_transform_gradients = gradient_order > 0 && !gradients_cached;
-  int x_gradient_order = compute_jacobian_without_transform_gradients ? 0 : std::min(gradient_order, 1);
-  int J_gradient_order = gradient_order > 1 ? gradient_order - 1 : 0;
-
-  checkCachedKinematicsSettings(x_gradient_order > 0, false, false, "forwardKinNew"); // rely on check in forwardJacV for Jacobian gradients
+  checkCachedKinematicsSettings(false, false, false, "forwardKinNew"); // rely on forwardJac for gradient cache check
 
   int nq = num_positions;
   int npoints = static_cast<int>(points.cols());
   typedef typename DerivedPoints::Scalar Scalar;
 
   // compute rotation and translation
-  GradientVar<Scalar, SPACE_DIMENSION + 1, SPACE_DIMENSION + 1> T = relativeTransform<Scalar>(new_body_or_frame_ind, current_body_or_frame_ind, x_gradient_order);
-
-  GradientVar<Scalar, SPACE_DIMENSION, SPACE_DIMENSION> R(SPACE_DIMENSION, SPACE_DIMENSION, nq, x_gradient_order);
-  R.value() = T.value().template topLeftCorner<SPACE_DIMENSION, SPACE_DIMENSION>();
-  if (x_gradient_order > 0)
-    R.gradient().value() = getSubMatrixGradient<Eigen::Dynamic>(T.gradient().value(), intRange<SPACE_DIMENSION>(0), intRange<SPACE_DIMENSION>(0), T.value().rows());
-
-  GradientVar<Scalar, SPACE_DIMENSION, 1> p(SPACE_DIMENSION, 1, nq, x_gradient_order);
-  p.value() = T.value().template topRightCorner<SPACE_DIMENSION, 1>();
-  if (x_gradient_order > 0)
-    p.gradient().value() = getSubMatrixGradient<Eigen::Dynamic>(T.gradient().value(), intRange<SPACE_DIMENSION>(0), intRange<1>(SPACE_DIMENSION), T.value().rows());
+  auto T = relativeTransform<Scalar>(new_body_or_frame_ind, current_body_or_frame_ind, 0).value();
+  auto R = T.template topLeftCorner<SPACE_DIMENSION, SPACE_DIMENSION>();
+  auto p = T.template topRightCorner<SPACE_DIMENSION, 1>();
 
   // transform points to new frame
   GradientVar<Scalar, Eigen::Dynamic, DerivedPoints::ColsAtCompileTime> x(SPACE_DIMENSION + rotationRepresentationSize(rotation_type), npoints, nq, gradient_order);
-  x.value().template topRows<SPACE_DIMENSION>().noalias() = R.value() * points;
-  x.value().template topRows<SPACE_DIMENSION>().colwise() += p.value();
+  x.value().template topRows<SPACE_DIMENSION>().colwise() = p;
+  x.value().template topRows<SPACE_DIMENSION>().noalias() += R * points;
 
   // convert rotation representation
-  GradientVar<Scalar, Eigen::Dynamic, 1> qrot = rotmat2Representation(R, rotation_type);
-  x.value().bottomRows(qrot.value().rows()).colwise() = qrot.value();
+  auto qrot = rotmat2Representation(R, rotation_type);
+  x.value().bottomRows(qrot.rows()).colwise() = qrot;
 
-  if (x_gradient_order > 0) {
-    x.gradient().value().setZero();
-    for (int i = 0; i < npoints; i++) {
-      const auto& point = points.template middleCols<1>(i);
-      auto point_gradient = matGradMult(R.gradient().value(), point).eval();
-      point_gradient += p.gradient().value();
-
-      // position rows
-      for (int row = 0; row < SPACE_DIMENSION; row++) {
-        setSubMatrixGradient<Eigen::Dynamic>(x.gradient().value(), getSubMatrixGradient<Eigen::Dynamic>(point_gradient, row, 0, point.rows()), row, i, x.value().rows());
-      }
-
-      // rotation rows
-      for (int row = 0; row < qrot.value().rows(); row++) {
-        setSubMatrixGradient<Eigen::Dynamic>(x.gradient().value(), qrot.gradient().value().row(row), row + SPACE_DIMENSION, i, x.value().rows());
-      }
-    }
-  }
-
-  if (gradient_order > 1 || compute_jacobian_without_transform_gradients) {
-    auto J = forwardJacV(x, current_body_or_frame_ind, new_body_or_frame_ind, rotation_type, true, J_gradient_order);
-    if (compute_jacobian_without_transform_gradients) {
-      x.gradient().value() = J.value();
-    }
-    else {
+  if (gradient_order > 0) {
+    int J_gradient_order = gradient_order - 1;
+    auto J = forwardJacV(points, current_body_or_frame_ind, new_body_or_frame_ind, rotation_type, true, J_gradient_order);
+    x.gradient().value() = J.value();
+    if (J_gradient_order > 0)
       x.gradient().gradient().value() = J.gradient().value();
-    }
   }
 
   return x;
 }
 
-template <typename Scalar, int XRows, int XCols>
-GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwardJacV(const GradientVar<Scalar, XRows, XCols>& x, int body_or_frame_ind, int base_or_frame_ind, int rotation_type, bool compute_analytic_jacobian, int gradient_order)
+template <typename DerivedPoints>
+GradientVar<typename DerivedPoints::Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwardJacV(const MatrixBase<DerivedPoints>& points, int current_body_or_frame_ind, int new_body_or_frame_ind, int rotation_type, bool in_terms_of_qdot, int gradient_order)
 {
   if (gradient_order > 1)
     throw std::runtime_error("only first order gradient is available");
   checkCachedKinematicsSettings(gradient_order > 0, false, false, "forwardJacV");
+  typedef typename DerivedPoints::Scalar Scalar;
+
+  // possibly slightly wasteful if we needed x anyway, but not terrible
+  auto x = forwardKinNew(points, current_body_or_frame_ind, new_body_or_frame_ind, rotation_type, 0).value();
 
   int nq = num_positions;
   int nv = num_velocities;
-  int cols = compute_analytic_jacobian ? nq : nv;
-  int npoints = static_cast<int>(x.value().cols());
+  int cols = in_terms_of_qdot ? nq : nv;
+  int npoints = static_cast<int>(x.cols());
 
   // compute geometric Jacobian
-  int body_ind = parseBodyOrFrameID(body_or_frame_ind);
-  int base_ind = parseBodyOrFrameID(base_or_frame_ind);
+  int body_ind = parseBodyOrFrameID(current_body_or_frame_ind);
+  int base_ind = parseBodyOrFrameID(new_body_or_frame_ind);
   int expressed_in = base_ind;
   std::vector<int> v_or_q_indices;
-  GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> J_geometric = geometricJacobian<Scalar>(base_ind, body_ind, expressed_in, gradient_order, compute_analytic_jacobian, &v_or_q_indices);
+  GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> J_geometric = geometricJacobian<Scalar>(base_ind, body_ind, expressed_in, gradient_order, in_terms_of_qdot, &v_or_q_indices);
 
   // split up into rotational and translational parts
   auto Jomega = J_geometric.value().template topRows<SPACE_DIMENSION>();
   auto Jv = J_geometric.value().template bottomRows<SPACE_DIMENSION>();
 
   // compute rotation Jacobian
-  DenseIndex rotation_representation_size = x.value().rows() - SPACE_DIMENSION;
-  auto qrot = x.value().template block<Eigen::Dynamic, 1>(SPACE_DIMENSION, 0, rotation_representation_size, 1);
+  DenseIndex rotation_representation_size = x.rows() - SPACE_DIMENSION;
+  auto qrot = x.template block<Eigen::Dynamic, 1>(SPACE_DIMENSION, 0, rotation_representation_size, 1);
   auto Phi = angularvel2RepresentationDotMatrix(rotation_type, qrot, gradient_order);
   auto Jrot = (Phi.value() * Jomega).eval();
 
   // compute J
-  GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> J(x.value().size(), cols, nq, gradient_order);
+  GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> J(x.size(), cols, nq, gradient_order);
   J.value().setZero();
   int row_start = 0;
   for (int i = 0; i < npoints; i++) {
     // translation part
     int col = 0;
-    const auto& point = x.value().template block<SPACE_DIMENSION, 1>(0, i);
+    const auto& point = x.template block<SPACE_DIMENSION, 1>(0, i);
     for (std::vector<int>::iterator it = v_or_q_indices.begin(); it != v_or_q_indices.end(); ++it) {
       J.value().template block<SPACE_DIMENSION, 1>(row_start, *it) = Jv.col(col);
       const auto& Jomega_col = Jomega.col(col);
@@ -2832,12 +2802,8 @@ GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwar
 
     KinematicPath path;
     findKinematicPath(path, base_ind, body_ind);
-    MatrixXd dqrotdq;
-    if (compute_analytic_jacobian)
-      dqrotdq = compactToFull(Jrot, path.joint_path, true);
-    else {
-      dqrotdq = transformVelocityMappingToPositionDotMapping(compactToFull(Jrot, path.joint_path, false));
-    }
+    MatrixXd dqrotdq = in_terms_of_qdot ? compactToFull(Jrot, path.joint_path, true) : transformVelocityMappingToPositionDotMapping(compactToFull(Jrot, path.joint_path, false));
+
     auto dPhidq = (Phi.gradient().value() * dqrotdq).eval();
     auto dJrot = matGradMultMat(Phi.value(), Jomega, dPhidq, dJomega);
 
@@ -2848,12 +2814,12 @@ GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwar
     for (int i = 0; i < npoints; i++) {
       // translation part
       int col = 0;
-      const auto& point = x.value().template block<SPACE_DIMENSION, 1>(0, i);
+      const auto& point = x.template block<SPACE_DIMENSION, 1>(0, i);
       Matrix<Scalar, SPACE_DIMENSION, Dynamic> dpoint;
-      if (compute_analytic_jacobian)
-        dpoint = getSubMatrixGradient<Eigen::Dynamic>(J.value(), rows, intRange<1>(i), x.value().rows());
+      if (in_terms_of_qdot)
+        dpoint = getSubMatrixGradient<Eigen::Dynamic>(J.value(), rows, intRange<1>(i), x.rows());
       else
-        dpoint = transformVelocityMappingToPositionDotMapping(getSubMatrixGradient<Eigen::Dynamic>(J.value(), rows, intRange<1>(i), x.value().rows()));
+        dpoint = transformVelocityMappingToPositionDotMapping(getSubMatrixGradient<Eigen::Dynamic>(J.value(), rows, intRange<1>(i), x.rows()));
 
       for (std::vector<int>::iterator it = v_or_q_indices.begin(); it != v_or_q_indices.end(); ++it) {
         const auto& Jomega_col = Jomega.col(col);
@@ -2864,8 +2830,8 @@ GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwar
         col++;
       }
       row_start += SPACE_DIMENSION;
-      // rotation part
 
+      // rotation part
       if (Jrot.rows() > 0) {
         col = 0;
         for (std::vector<int>::iterator it = v_or_q_indices.begin(); it != v_or_q_indices.end(); ++it) {
@@ -3364,7 +3330,7 @@ template DLLEXPORT_RBM GradientVar<double, TWIST_SIZE, 1> RigidBodyManipulator::
 template DLLEXPORT_RBM GradientVar<double, SPACE_DIMENSION + 1, SPACE_DIMENSION + 1> RigidBodyManipulator::relativeTransform(int, int, int);
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwardKinNew(const MatrixBase< Matrix<double, 3, Eigen::Dynamic> >&, int, int, int, int);
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::forwardKinNew(const MatrixBase< Matrix<double, 3, 1 > >&, int, int, int, int);
-template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwardJacV(const GradientVar<double, Eigen::Dynamic, Eigen::Dynamic>&, int, int, int, bool, int);
+template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwardJacV(const MatrixBase<Matrix3Xd>&, int, int, int, bool, int);
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwardKinPositionGradient(int, int, int, int);
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::forwardJacDotTimesV(const MatrixBase< Matrix<double, 3, Eigen::Dynamic> >&, int, int, int, int);
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::forwardJacDotTimesV(const MatrixBase< Matrix<double, 3, 1> >&, int, int, int, int);

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -314,9 +314,10 @@ Eigen::Matrix<typename Derived::Scalar, Derived::RowsAtCompileTime, Eigen::Dynam
   int compact_col_start = 0;
   for (std::vector<int>::const_iterator it = joint_path.begin(); it != joint_path.end(); ++it) {
     RigidBody& body = *bodies[*it];
-    int nv_joint = body.getJoint().getNumVelocities();
-    full.middleCols(body.velocity_num_start, nv_joint) = compact.middleCols(compact_col_start, nv_joint);
-    compact_col_start += nv_joint;
+    int ncols_joint = in_terms_of_qdot ? body.getJoint().getNumPositions() : body.getJoint().getNumVelocities();
+    int col_start = in_terms_of_qdot ? body.position_num_start : body.velocity_num_start;
+    full.middleCols(col_start, ncols_joint) = compact.middleCols(compact_col_start, ncols_joint);
+    compact_col_start += ncols_joint;
   }
   return full;
 };

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -300,7 +300,7 @@ public:
 
   template <typename Derived>
   Eigen::Matrix<typename Derived::Scalar, Derived::RowsAtCompileTime, Eigen::Dynamic> transformVelocityMappingToPositionDotMapping(
-      const Eigen::MatrixBase<Derived>& mat, const std::vector<int>& joint_path);
+      const Eigen::MatrixBase<Derived>& mat);
 
 template <typename Derived>
 Eigen::Matrix<typename Derived::Scalar, Derived::RowsAtCompileTime, Eigen::Dynamic> compactToFull(

--- a/systems/plants/RigidBodyManipulator.h
+++ b/systems/plants/RigidBodyManipulator.h
@@ -186,8 +186,8 @@ public:
   template <typename DerivedPoints>
   GradientVar<typename DerivedPoints::Scalar, Eigen::Dynamic, DerivedPoints::ColsAtCompileTime> forwardKinNew(const MatrixBase<DerivedPoints>& points, int current_body_or_frame_ind, int new_body_or_frame_ind, int rotation_type, int gradient_order);
 
-  template <typename Scalar, int XRows, int XCols>
-  GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> forwardJacV(const GradientVar<Scalar, XRows, XCols>& x, int body_or_frame_ind, int base_or_frame_ind, int rotation_type, bool compute_analytic_jacobian, int gradient_order);
+  template <typename DerivedPoints>
+  GradientVar<typename DerivedPoints::Scalar, Eigen::Dynamic, Eigen::Dynamic> forwardJacV(const MatrixBase<DerivedPoints>& points, int current_body_or_frame_ind, int new_body_or_frame_ind, int rotation_type, bool in_terms_of_qdot, int gradient_order);
 
   template <typename Scalar>
   GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> forwardKinPositionGradient(int npoints, int current_body_or_frame_ind, int new_body_or_frame_ind, int gradient_order);

--- a/systems/plants/forwardKinVmex.cpp
+++ b/systems/plants/forwardKinVmex.cpp
@@ -45,7 +45,7 @@ void mexFunction(int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[]) {
     auto x = model->forwardKinNew(points, body_or_frame_ind, base_or_frame_ind, rotation_type, gradient_order);
     plhs[0] = eigenToMatlab(x.value());
     if (nlhs > 1) {
-      auto J = model->forwardJacV(x, body_or_frame_ind, base_or_frame_ind, rotation_type, compute_analytic_jacobian, gradient_order);
+      auto J = model->forwardJacV(points, body_or_frame_ind, base_or_frame_ind, rotation_type, compute_analytic_jacobian, gradient_order);
       plhs[1] = eigenToMatlab(J.value());
       if (nlhs > 2) {
         plhs[2] = eigenToMatlab(J.gradient().value());

--- a/systems/plants/test/testForwardKin.m
+++ b/systems/plants/test/testForwardKin.m
@@ -16,9 +16,9 @@ options.floating = floatingJointType;
 robot = RigidBodyManipulator('FallingBrick.urdf',options);
 robot = robot.addRobotFromURDF('FallingBrick.urdf', [], [], options);
 for rotation_type = 0 : 2
-  checkGradients(robot, rotation_type);  
+%   checkGradients(robot, rotation_type);  
   checkMex(robot, rotation_type);
-  checkJacobianWithAndWithoutGradients(robot, rotation_type);
+%   checkJacobianWithAndWithoutGradients(robot, rotation_type);
 end
 end
 

--- a/systems/plants/test/testForwardKin.m
+++ b/systems/plants/test/testForwardKin.m
@@ -16,9 +16,9 @@ options.floating = floatingJointType;
 robot = RigidBodyManipulator('FallingBrick.urdf',options);
 robot = robot.addRobotFromURDF('FallingBrick.urdf', [], [], options);
 for rotation_type = 0 : 2
-%   checkGradients(robot, rotation_type);  
+  checkGradients(robot, rotation_type);  
   checkMex(robot, rotation_type);
-%   checkJacobianWithAndWithoutGradients(robot, rotation_type);
+  checkJacobianWithAndWithoutGradients(robot, rotation_type);
 end
 end
 

--- a/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -48,10 +48,6 @@ void performChecks(RigidBodyManipulator& model, int gradient_order, const CheckS
   std::vector<int> v_or_qdot_indices;
   int npoints = 3;
   int nq = model.num_positions;
-  GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> x_gradientvar(points.rows() + rotationRepresentationSize(rotation_type), npoints, nq, gradient_order);
-  x_gradientvar.value().setRandom();
-  if (gradient_order > 0)
-    x_gradientvar.gradient().value().setRandom();
   GradientVar<double, TWIST_SIZE, 1> spatial_acceleration(TWIST_SIZE, 1, nq, gradient_order);
   spatial_acceleration.value().setRandom();
   if (gradient_order > 0)
@@ -67,7 +63,7 @@ void performChecks(RigidBodyManipulator& model, int gradient_order, const CheckS
   checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::massMatrix<double>, gradient_order);
   checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::forwardKinNew<PointsType>, points, body_or_frame_ind, base_or_frame_ind, rotation_type, gradient_order + 1);
   checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::forwardKinPositionGradient<double>, npoints, body_or_frame_ind, base_or_frame_ind, gradient_order);
-  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::forwardJacV<double, Dynamic, Dynamic>, x_gradientvar, body_or_frame_ind, base_or_frame_ind, rotation_type, in_terms_of_qdot, gradient_order);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::forwardJacV<PointsType>, points, body_or_frame_ind, base_or_frame_ind, rotation_type, in_terms_of_qdot, gradient_order);
 
   checkForErrors(settings.expect_error_on_velocity_methods, model, &RigidBodyManipulator::relativeTwist<double>, base_or_frame_ind, body_or_frame_ind, expressed_in_frame_ind, gradient_order);
 

--- a/util/drakeGeometryUtil.cpp
+++ b/util/drakeGeometryUtil.cpp
@@ -339,6 +339,23 @@ Eigen::Matrix<typename Derived::Scalar, 3, 1> rotmat2rpy(const Eigen::MatrixBase
   return rpy;
 }
 
+template<typename Derived>
+DLLEXPORT Eigen::Matrix<typename Derived::Scalar, Eigen::Dynamic, 1> rotmat2Representation(const Eigen::MatrixBase<Derived>& R, int rotation_type)
+{
+  typedef typename Derived::Scalar Scalar;
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> ret;
+  switch (rotation_type) {
+  case 0:
+    return Eigen::Matrix<Scalar, Eigen::Dynamic, 1>(0, 1);
+  case 1:
+    return rotmat2rpy(R);
+  case 2:
+    return rotmat2quat(R);
+  default:
+    throw std::runtime_error("rotation representation type not recognized");
+  }
+}
+
 template<typename Scalar>
 DLLEXPORT GradientVar<Scalar, Eigen::Dynamic, 1> rotmat2Representation(const GradientVar<Scalar, SPACE_DIMENSION, SPACE_DIMENSION>& R, int rotation_type)
 {
@@ -1347,6 +1364,9 @@ template DLLEXPORT Vector3d axis2rpy(const MatrixBase<Vector4d>&);
 template DLLEXPORT Vector4d rotmat2axis(const MatrixBase<Matrix3d>&);
 template DLLEXPORT Vector4d rotmat2quat(const MatrixBase<Matrix3d>&);
 template DLLEXPORT Vector3d rotmat2rpy(const MatrixBase<Matrix3d>&);
+
+template DLLEXPORT Eigen::Matrix<Eigen::Block<Eigen::Matrix<double, 4, 4, 0, 4, 4>, 3, 3, false>::Scalar, -1, 1, 0, -1, 1> rotmat2Representation<Eigen::Block<Eigen::Matrix<double, 4, 4, 0, 4, 4>, 3, 3, false> >(Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 4, 4, 0, 4, 4>, 3, 3, false> > const&, int);
+
 template DLLEXPORT GradientVar<double, Eigen::Dynamic, 1> rotmat2Representation(
     const GradientVar<double, SPACE_DIMENSION, SPACE_DIMENSION>& R,
     int rotation_type);
@@ -1512,9 +1532,21 @@ template DLLEXPORT Eigen::Matrix<Eigen::Block<Eigen::Block<Eigen::Matrix<double,
     Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1> const, 3, 1, false> > const&, Gradient<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>, -1, 1>::type const&,
     Gradient<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1> const, 3, 1, false>, -1, 1>::type const&);
 
-template DLLEXPORT Eigen::Matrix<double, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true> >(Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true> > const&, Gradient<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, -1, 1>::type const&, Gradient<Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true>, -1, 1>::type const&);
+template DLLEXPORT Eigen::Matrix<double, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true> >(
+    Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true> > const&,
+    Gradient<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, -1, 1>::type const&, Gradient<Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true>, -1, 1>::type const&);
 
-template DLLEXPORT Eigen::Matrix<double, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true> >(Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true> > const&, Gradient<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, -1, 1>::type const&, Gradient<Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true>, -1, 1>::type const&);
+template DLLEXPORT Eigen::Matrix<double, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true> >(
+    Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true> > const&, Gradient<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, -1, 1>::type const&,
+    Gradient<Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true>, -1, 1>::type const&);
+
+template DLLEXPORT Eigen::Matrix<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>::Scalar, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>,
+    Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false> >(Eigen::MatrixBase<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false> > const&,
+    Gradient<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>, -1, 1>::type const&, Gradient<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, -1, 1>::type const&);
+
+template DLLEXPORT Eigen::Matrix<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>::Scalar, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>,
+    Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 3, 1, false> >(Eigen::MatrixBase<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 3, 1, false> > const&,
+    Gradient<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>, -1, 1>::type const&, Gradient<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 3, 1, false>, -1, 1>::type const&);
 
 template DLLEXPORT DHomogTrans<MatrixXd>::type dHomogTrans(
     const Isometry3d&,

--- a/util/drakeGeometryUtil.cpp
+++ b/util/drakeGeometryUtil.cpp
@@ -1503,6 +1503,15 @@ template DLLEXPORT Eigen::Matrix<double, 3, Eigen::Dynamic> dcrossProduct(
     const Gradient<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1>, 3, 1, false>, Eigen::Dynamic>::type& da,
     const Gradient<Eigen::Matrix<double, 3, 1, 0, 3, 1>, Eigen::Dynamic>::type& db);
 
+template DLLEXPORT Eigen::Matrix<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>::Scalar, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>,
+    Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 3, 1, false> >(Eigen::MatrixBase<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 3, 1, false> > const&,
+    Gradient<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>, -1, 1>::type const&, Gradient<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, 3, 1, false>, -1, 1>::type const&);
+
+template DLLEXPORT Eigen::Matrix<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>::Scalar, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>,
+    Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1> const, 3, 1, false> >(Eigen::MatrixBase<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true> > const&,
+    Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1> const, 3, 1, false> > const&, Gradient<Eigen::Block<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, 3, 1, true>, -1, 1>::type const&,
+    Gradient<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1> const, 3, 1, false>, -1, 1>::type const&);
+
 template DLLEXPORT Eigen::Matrix<double, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true> >(Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true> > const&, Gradient<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, -1, 1>::type const&, Gradient<Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3, 1, false>, 3, 1, true>, -1, 1>::type const&);
 
 template DLLEXPORT Eigen::Matrix<double, 3, -1, 0, 3, -1> dcrossProduct<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true> >(Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false> > const&, Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true> > const&, Gradient<Eigen::Block<Eigen::Matrix<double, 6, 1, 0, 6, 1> const, 3, 1, false>, -1, 1>::type const&, Gradient<Eigen::Block<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3, 1, true>, -1, 1>::type const&);
@@ -1611,6 +1620,11 @@ template DLLEXPORT GradientVar<double, Eigen::Dynamic, SPACE_DIMENSION> angularv
 template DLLEXPORT GradientVar<double, Eigen::Dynamic, SPACE_DIMENSION> angularvel2RepresentationDotMatrix(
     int rotation_type, const Eigen::MatrixBase< Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1>, -1, 1, false> >& qrot, int gradient_order);
 template DLLEXPORT GradientVar<double, -1, 3> angularvel2RepresentationDotMatrix<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, -1, 1, false> >(int, Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1>, -1, 1, false> > const&, int);
+template DLLEXPORT GradientVar<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, -1, 1, false>::Scalar, -1, 3> angularvel2RepresentationDotMatrix<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, -1, 1, false> >(int,
+    Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, -1, 1, 0, -1, 1> const, -1, 1, false> > const&, int);
+template DLLEXPORT GradientVar<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1> const, -1, 1, false>::Scalar, -1, 3> angularvel2RepresentationDotMatrix<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1> const, -1, 1, false> >(int,
+    Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1> const, -1, 1, false> > const&, int);
+
 
 template DLLEXPORT void quatdot2angularvelMatrix(const Eigen::MatrixBase<Vector4d>& q,
     Eigen::MatrixBase< Matrix<double, SPACE_DIMENSION, QUAT_SIZE> >& M,

--- a/util/drakeGeometryUtil.h
+++ b/util/drakeGeometryUtil.h
@@ -106,6 +106,9 @@ DLLEXPORT Eigen::Matrix<typename Derived::Scalar, 4, 1> rotmat2quat(const Eigen:
 template<typename Derived>
 DLLEXPORT Eigen::Matrix<typename Derived::Scalar, 3, 1> rotmat2rpy(const Eigen::MatrixBase<Derived>& R);
 
+template<typename Derived>
+DLLEXPORT Eigen::Matrix<typename Derived::Scalar, Eigen::Dynamic, 1> rotmat2Representation(const Eigen::MatrixBase<Derived>& R, int rotation_type);
+
 template<typename Scalar>
 DLLEXPORT GradientVar<Scalar, Eigen::Dynamic, 1> rotmat2Representation(const GradientVar<Scalar, SPACE_DIMENSION, SPACE_DIMENSION>& R, int rotation_type);
 

--- a/util/drakeGradientUtil.cpp
+++ b/util/drakeGradientUtil.cpp
@@ -245,6 +245,10 @@ MAKE_MATGRADMULTMAT_TRANSPOSE_B_EXPLICIT_INSTANTIATION(double, 3, 1, 3, 3, 3, 3)
 MAKE_MATGRADMULTMAT_TRANSPOSE_B_EXPLICIT_INSTANTIATION(double, 4, 1, 4, 4, 4, 4)
 #undef MAKE_MATGRADMULTMAT_TRANSPOSE_B_EXPLICIT_INSTANTIATION
 
+template DLLEXPORT MatGradMultMat<Eigen::Matrix<double, -1, 3, 0, -1, 3>, Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, Eigen::Matrix<double, -1, -1, 0, -1, -1> >::type matGradMultMat<Eigen::Matrix<double, -1, 3, 0, -1, 3>,
+    Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false>, Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1> >(Eigen::MatrixBase<Eigen::Matrix<double, -1, 3, 0, -1, 3> > const&,
+    Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 6, -1, 0, 6, -1>, 3, -1, false> > const&, Eigen::MatrixBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&);
+
 #define MAKE_SETSUBMATRIXGRADIENT_EXPLICIT_INSTANTIATION(Type, QSubvectorSize, DMRows, DMCols, DMSubRows, DMSubCols, NRows, NCols) \
 		template DLLEXPORT void setSubMatrixGradient<QSubvectorSize,Eigen::Matrix<Type, DMRows, DMCols>, Eigen::Matrix<Type, DMSubRows, DMSubCols>, NRows, NCols>(Eigen::MatrixBase< Eigen::Matrix<Type, DMRows, DMCols> >&, const Eigen::MatrixBase< Eigen::Matrix<Type, DMSubRows, DMSubCols> >&, const std::array<int, NRows>&, const std::array<int, NCols>&, Eigen::Matrix<Type, DMSubRows, DMSubCols>::Index, Eigen::Matrix<Type, DMSubRows, DMSubCols>::Index, Eigen::Matrix<Type, DMSubRows, DMSubCols>::Index);
 //MAKE_SETSUBMATRIXGRADIENT_EXPLICIT_INSTANTIATION(double, Eigen::Dynamic, Eigen::Dynamic, Eigen::Dynamic, 3, Eigen::Dynamic, 3, 1)


### PR DESCRIPTION
* Changed forwardJacV so that the points argument is a matrix instead of a GradientVar (nicer interface).
* forwardJacV is now able to compute the gradient of the Jacobian without using the gradient of the points argument as an input. This was pretty weird in the old implementation: in order to get gradient output from forwardJacV, you had to pass in the Jacobian already, while the whole idea of forwardJacV is that it computes a Jacobian (i.e. a gradient of the transformed points, at least if expressed in terms of qdot).
* simplified forwardKinNew so that it only computes the transformed points without (gradients) itself, and then calls forwardJacV if gradients are needed.