### PR TITLE
TSRBM never got updated after the conversion to visualizers using position frames

### DIFF
--- a/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -1066,8 +1066,6 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
 
     function v = constructVisualizer(obj,varargin)
       v = constructVisualizer(obj.manip,varargin{:});
-      v = v.setNumInputs(obj.getNumOutputs());
-      v = setInputFrame(v,obj.getOutputFrame());
     end
 
     function getNumContacts(~)


### PR DESCRIPTION
resolves crash of Quadrotor.runOpenLoop reported in #1153 .  (thanks for catching that; the build servers do not run the actual visualization code)