### PR TITLE
Fix logic for zero-radius spheres in RigidBodyGeometry

### DIFF
--- a/systems/plants/RigidBodyGeometry.m
+++ b/systems/plants/RigidBodyGeometry.m
@@ -126,7 +126,7 @@ classdef RigidBodyGeometry < RigidBodyElement
             size = parseParamString(model,robotnum,char(thisNode.getAttribute('size')));
             obj = RigidBodyBox(size(:));
           case 'sphere'
-            r = min(1e-7, parseParamString(model,robotnum,char(thisNode.getAttribute('radius'))));
+            r = max(1e-7, parseParamString(model,robotnum,char(thisNode.getAttribute('radius'))));
             obj = RigidBodySphere(r);
           case 'cylinder'
             r = parseParamString(model,robotnum,char(thisNode.getAttribute('radius')));


### PR DESCRIPTION
The current logic causes all spheres to be converted to spheres with radius = 1e-7. This makes them invisible.