### PR TITLE
Fix test closest expmap

### DIFF
--- a/util/test/testClosestExpmap.m
+++ b/util/test/testClosestExpmap.m
@@ -23,6 +23,14 @@ for i = 1:100
   testClosestExpmap_userfun(theta1*axis1,theta2*axis2);
 end
 
+% test when w2 is very small, thus the gradient dw1_dw2 is big
+axis1 = randn(3,1);
+axis1 = axis1/norm(axis1);
+theta1 = 4*pi + rand();
+axis2 = randn(3,1);
+axis2 = axis2/norm(axis2);
+theta2 = 1e-3*rand(); 
+testClosestExpmap_userfun(theta1*axis1,theta2*axis2);
 end
 
 function testClosestExpmap_userfun(w1,w2)
@@ -47,8 +55,15 @@ else
   valuecheck(w2_closest2,w2_closest,1e-3);
 end
 valuecheck(abs(expmap2quat(w2)'*expmap2quat(w2_closest)),1,1e-3);
-[~,dw2_closest_dw2_numeric] = geval(@(w2) closestExpmap(w1,w2),w2,struct('grad_method','numerical'));
-if(~valuecheck(dw2_closest_dw2,dw2_closest_dw2_numeric,1e-2) && ~valuecheck((dw2_closest_dw2-dw2_closest_dw2_numeric)*w2,zeros(3,1),1e-2));
-  error('The analytical gradient of closestExpmap does not match the numeric gradient');
+[~,dw2_closest_dw2_numeric] = geval(@(w2) closestExpmap(w1,w2),w2,struct('grad_method','numerical','da',norm(w2)*1e-7));
+tol = 1e-2;
+if(~valuecheck(dw2_closest_dw2,dw2_closest_dw2_numeric,tol))
+  gradient_err = dw2_closest_dw2 - dw2_closest_dw2_numeric;
+  gradient_err(abs(gradient_err(:)) <= tol) = 0;
+  gradient_err_normalize = gradient_err./dw2_closest_dw2;
+  gradient_err_normalize(isnan(gradient_err_normalize(:))) = 0;
+  if(any(abs(gradient_err_normalize(:)) > 5e-2))
+    error('The analytical gradient of closestExpmap does not match the numeric gradient');
+  end
 end
 end

--- a/util/test/testClosestExpmap.m
+++ b/util/test/testClosestExpmap.m
@@ -48,5 +48,7 @@ else
 end
 valuecheck(abs(expmap2quat(w2)'*expmap2quat(w2_closest)),1,1e-3);
 [~,dw2_closest_dw2_numeric] = geval(@(w2) closestExpmap(w1,w2),w2,struct('grad_method','numerical'));
-valuecheck(dw2_closest_dw2,dw2_closest_dw2_numeric,1e-2);
+if(~valuecheck(dw2_closest_dw2,dw2_closest_dw2_numeric,1e-2) && ~valuecheck((dw2_closest_dw2-dw2_closest_dw2_numeric)*w2,zeros(3,1),1e-2));
+  error('The analytical gradient of closestExpmap does not match the numeric gradient');
+end
 end


### PR DESCRIPTION
Add a test in `testClosestExpmap` for the case when `w2` is small, and thus the gradient is big. This used to cause test failure before, as we were doing naive value check between the analytical gradient and numerical gradient.