### PR TITLE
fix missing '-' in make invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT MAKE_EXECUTABLE)
       message(FATAL_ERROR "couldn't find gnu make")
    endif()
 endif()
-set(MAKE_COMMAND ${MAKE_EXECUTABLE} $ENV{MAKEFLAGS}) # didn't work on my first test, but should do no harm
+set(MAKE_COMMAND ${MAKE_EXECUTABLE} -$ENV{MAKEFLAGS}) # didn't work on my first test, but should do no harm
 
 # process optional projects
 # note: keep drake in this loop in case externals depend on drake (e.g. the director might in the near future)


### PR DESCRIPTION
The MAKEFLAGS environment variable contains make flags *without* the `-` prefix. `make options` (for some reason) sets the MAKEFLAGS to `s`. The result was that after running `make options`, the MAKE_COMMAND was set to `make s`, which tried to build a target called "s". And that would break the build until you manually ran cmake again. 

Maybe now this line will actually "do no harm" :wink: 