### PR TITLE
changed joint limits on acrobot runMaxROA

### DIFF
--- a/drake/examples/Acrobot/runMaxROA.m
+++ b/drake/examples/Acrobot/runMaxROA.m
@@ -3,7 +3,7 @@ function runMaxROA
 p = AcrobotPlant;
 
 % Set input limits
-p = setInputLimits(p,-4,4);
+p = setInputLimits(p,-20,20);
 
 % Do lqr
 Q = diag([10 10 1 1]);


### PR DESCRIPTION
This should fix the build server failures that have been cropping up on this test since saturations are no longer ignored.