### PR TITLE
Fix BMI test failure

### DIFF
--- a/drake/examples/grasping/forceClosure/test/testSynthesizeGrasp.m
+++ b/drake/examples/grasping/forceClosure/test/testSynthesizeGrasp.m
@@ -86,13 +86,7 @@ test_userfun(p);
 end
 
 function solver_sol = test_userfun(p)
-num_trial = 1;
-info = 0;
-p.itr_max = 200;
-while(num_trial <=3 && info ~= 1)
 [solver_sol,info,itr,solver_time] = p.optimize();
-num_trial = num_trial +1;
-end
 if(info~=1)
   error('Info = %d,Failed to find a force closure grasp',info);
 end

--- a/drake/solvers/BMI/BMIspotless.m
+++ b/drake/solvers/BMI/BMIspotless.m
@@ -11,7 +11,7 @@ classdef BMIspotless < spotsosprog
     res_tol; % When the rank residue res = trace(obj.W)-obj.w'*obj.w is less than this res_tol, the iteration terminates successfully
     itr_max; % The maximum iterations the program will run
     alpha_covW % The amount of randomness in w_direction. Default is 0.01
-    
+    trial_max; % The maximum number of trials the program will run. In each trial, if the sequential SDP converges to a non-zero value, then rerun the program, until either sequential SDP converges to 0, or trial_max is reached.
     % At `early_terminate_itr`, the program will check the residue, if the residue is
     % larger than `early_terminate_tol`, the program will terminate, as the problem is
     % unlikely to converge. early_terminate_itr should be less than itr_max
@@ -40,7 +40,8 @@ classdef BMIspotless < spotsosprog
       obj.blk1s = [];
       obj.res_tol = 1e-3;
       obj.alpha_covW = 0.01;
-      obj.itr_max = 1000;
+      obj.itr_max = 200;
+      obj.trial_max = 3;
       obj.early_terminate_itr = 100;
       obj.early_terminate_tol = 10;
       obj.plot_iteration = false;
@@ -52,7 +53,7 @@ classdef BMIspotless < spotsosprog
       elseif(checkDependency('sedumi'))
         obj.solver = @spot_sedumi;
       else
-        error('No solver found');
+        checkDependency('mosek');
       end
     end
     
@@ -83,67 +84,75 @@ classdef BMIspotless < spotsosprog
       else
         w_direction = zeros(size(obj.w));
       end
-      converged = false;
-      itr = 1;
-      solver_time = 0;
       options = spot_sdp_default_options();
       options.verbose = 0;
-      while(~converged && itr<=obj.itr_max)
-        solver_sol = obj.minimize(trace(obj.W)-2*w_direction'*obj.w,obj.solver,options);
-        solver_time = solver_time + solver_sol.info.wtime;
-        if(obj.plot_iteration)
-          [sol,sol_bilinear] = obj.retrieveSolution(solver_sol);
-          obj.plotSolution(sol,sol_bilinear);
-        end
-        if(~solver_sol.isPrimalFeasible)
-          info = 0;
-          return;
-        end
-        
-        sol_w = double(solver_sol.eval(obj.w));
-        sol_W = double(solver_sol.eval(obj.W));
-        res = trace(sol_W)-sol_w'*sol_w;
-        
-        fprintf('iteration: %d, residue:%5.5f\n',itr,res);
-        if(itr == obj.early_terminate_itr && res>obj.early_terminate_tol)
-          info = 3;
-          return;
-        end
-        if(res<obj.res_tol)
-          converged = true;
-          % backoff
-          if(obj.final_backoff_flag)
-            prev_objective = double(solver_sol.eval(trace(obj.W)-2*w_direction'*obj.w));
-            backoff_feasible = false;
-            backoff_iter = 1;
-            while(~backoff_feasible)
-              if(prev_objective<0)
-                obj_backoff = obj.withPos((1-obj.final_backoff_scale*backoff_iter)*prev_objective-(trace(obj.W)-2*w_direction'*obj.w));
-              else
-                obj_backoff = obj.withPos((1+obj.final_backoff_scale*backoff_iter)*prev_objective-(trace(obj.W)-2*w_direction'*obj.w));
-              end
-              solver_sol = obj_backoff.minimize(0,@spot_mosek,options);
-              if(solver_sol.isPrimalFeasible())
-                sol_w = double(solver_sol.eval(obj.w));
-                sol_W = double(solver_sol.eval(obj.W));
-                res = trace(sol_W)-sol_w'*sol_w;
+      info = 2;
+      trial_count = 1;
+      while(trial_count <= obj.trial_max && info > 1)
+        converged = false;
+        itr = 1;
+        solver_time = 0;
+        while(~converged && itr<=obj.itr_max)
+          solver_sol = obj.minimize(trace(obj.W)-2*w_direction'*obj.w,obj.solver,options);
+          solver_time = solver_time + solver_sol.info.wtime;
+          if(obj.plot_iteration)
+            [sol,sol_bilinear] = obj.retrieveSolution(solver_sol);
+            obj.plotSolution(sol,sol_bilinear);
+          end
+          if(~solver_sol.isPrimalFeasible)
+            info = 0;
+            return;
+          end
 
-                fprintf('backoff residue:%5.5f\n',res);
-                backoff_feasible = true;
-              else
-                backoff_iter = backoff_iter+1;
+          sol_w = double(solver_sol.eval(obj.w));
+          sol_W = double(solver_sol.eval(obj.W));
+          res = trace(sol_W)-sol_w'*sol_w;
+
+          fprintf('iteration: %d, residue:%5.5f\n',itr,res);
+          if(itr == obj.early_terminate_itr && res>obj.early_terminate_tol)
+            info = 3;
+            trial_count = trial_count + 1;
+            break;
+          end
+          if(res<obj.res_tol)
+            converged = true;
+            % backoff
+            if(obj.final_backoff_flag)
+              prev_objective = double(solver_sol.eval(trace(obj.W)-2*w_direction'*obj.w));
+              backoff_feasible = false;
+              backoff_iter = 1;
+              while(~backoff_feasible)
+                if(prev_objective<0)
+                  obj_backoff = obj.withPos((1-obj.final_backoff_scale*backoff_iter)*prev_objective-(trace(obj.W)-2*w_direction'*obj.w));
+                else
+                  obj_backoff = obj.withPos((1+obj.final_backoff_scale*backoff_iter)*prev_objective-(trace(obj.W)-2*w_direction'*obj.w));
+                end
+                solver_sol = obj_backoff.minimize(0,@spot_mosek,options);
+                if(solver_sol.isPrimalFeasible())
+                  sol_w = double(solver_sol.eval(obj.w));
+                  sol_W = double(solver_sol.eval(obj.W));
+                  res = trace(sol_W)-sol_w'*sol_w;
+
+                  fprintf('backoff residue:%5.5f\n',res);
+                  backoff_feasible = true;
+                else
+                  backoff_iter = backoff_iter+1;
+                end
               end
             end
+          else
+            w_direction = descentDirection(obj,sol_w,sol_W);
+            itr = itr+1;
           end
-        else
-          w_direction = descentDirection(obj,sol_w,sol_W);
-          itr = itr+1;
         end
-      end
-      if converged
-        info = 1;
-      else
-        info = 2;
+        if(info ~= 3)
+          if converged
+            info = 1;
+          else
+            info = 2;
+            trial_count = trial_count + 1;
+          end
+        end
       end
     end
     


### PR DESCRIPTION
run the BMI solver again if it fails to converge to 0, until it reaches maximum trials. Throw MissingDependency error in BMIspotless if either mosek or sedumi is found