### PR TITLE
make sure TrigPoly.h gets installed

### DIFF
--- a/drake/util/CMakeLists.txt
+++ b/drake/util/CMakeLists.txt
@@ -39,7 +39,7 @@ if (MATLAB_FOUND)
   # todo: use this again once I can assume everyone has CMAKE version >= 2.8.8
   #add_mex(drakeUtil OBJECT drakeUtil.cpp)
 
-  pods_install_headers(drakeMexUtil.h MexWrapper.h DESTINATION drake)
+  pods_install_headers(drakeMexUtil.h MexWrapper.h TrigPoly.h DESTINATION drake)
   pods_install_libraries(drakeMexUtil)
   pods_install_pkg_config_file(drake-mex-util
     LIBS -ldrakeMexUtil


### PR DESCRIPTION
TrigPoly.h is included by drakeMexUtil.h, so I've added TrigPoly.h to the
install rule for drakeMexUtil.h.