### PR TITLE
Fix testRunningPlanner

### DIFF
--- a/drake/examples/Atlas/test/testRunningPlanner.m
+++ b/drake/examples/Atlas/test/testRunningPlanner.m
@@ -427,9 +427,13 @@ function [sol,robot_vis,v,cdfkp] = testRunningPlanner(seed,stride_length,major_i
   % Solve trajectory optimization
   tic
   %profile on;
-  [x_sol,~,~] = cdfkp.solve(x_seed);
+  [x_sol,~,exitflag] = cdfkp.solve(x_seed);
   %profile off;
   toc
+  
+  if exitflag > 10
+    error(['Trajectory optimization failed. exitflag = ' num2str(exitflag)]);
+  end
 
   % Parse trajectory optimization output
   sol.x_sol = x_sol;

--- a/drake/solvers/trajectoryOptimization/SimpleDynamicsFullKinematicsPlanner.m
+++ b/drake/solvers/trajectoryOptimization/SimpleDynamicsFullKinematicsPlanner.m
@@ -114,6 +114,7 @@ classdef SimpleDynamicsFullKinematicsPlanner < DirectTrajectoryOptimization
 
     function data = kinematicsData(obj,q)
       options.compute_gradients = true;
+      options.use_mex = false;
       data = doKinematics(obj.robot,q,[],options);
     end
 

--- a/drake/systems/plants/@RigidBodyManipulator/centroidalMomentumMatrix.m
+++ b/drake/systems/plants/@RigidBodyManipulator/centroidalMomentumMatrix.m
@@ -19,23 +19,10 @@ end
 
 compute_gradients = nargout > 1;
 
-compute_kinematics = false;
 if ~isstruct(kinsol)  
   % treat input as centroidalMomentumMatrix(model,q)
   q = kinsol;
-  compute_kinematics = true;
-else
-  if ~isfield(kinsol, 'v')
-    kinsol_options.use_mex = kinsol.mex;
-    robot.warning_manager.warnOnce('Drake:centroidalMomentumMatrix:OldKinsol','You called centroidalMomentumMatrix with a kinsol in the old format. Redoing kinematics in new format using q from old kinsol');
-    q = kinsol.q;
-    compute_kinematics = true;
-  end
-end
-
-if compute_kinematics
   kinsol_options.compute_gradients = compute_gradients;
-  kinsol_options.force_new_kinsol = true;
   kinsol = robot.doKinematics(q, [], kinsol_options);
 end
 


### PR DESCRIPTION
testRunningPlanner was failing silently since my pull request https://github.com/RobotLocomotion/drake/pull/1190.  

When I got rid of the old kinematics, I made the doKinematics call in  SimpleDynamicsFullKinematicsPlanner use mex because I thought the only thing preventing this before was the need for gradients of the CMM. But the more important thing is that multiple kinsols need to be valid at the same time, while currently calling mex doKinematics overwrites the cache in RigidBodyManipulator. John and I are actually working on getting the kinematics cache out of RBM and using a separate DrakeMexPointer to a KinematicsCache object, to be stored in the Matlab kinsol struct.

Fixed this issue and also made it so that testRunningPlanner actually throws an error that tells us things are broken.

Also got rid of some obsolete code in centroidalMomentumMatrix.