### PR TITLE
IPv4 reverting in addpath_drake: use ~strcmp and check for Yosemite or greater

### DIFF
--- a/drake/addpath_drake.m
+++ b/drake/addpath_drake.m
@@ -59,18 +59,23 @@ addpath(fullfile(root,'solvers','BMI','kinematics'));
 
 javaaddpath(fullfile(pods_get_base_path,'share','java','drake.jar'));
 
-% OSX platform-specific: check if reverted to IPv4
+% OSX platform-specific
 if (strcmp(computer('arch'),'maci64'))
-  ipv4_preferred = java.lang.System.getProperty('java.net.preferIPv4Stack');
-  if isempty(ipv4_preferred)
-    ipv4_preferred = 'false';
-  end
-  if (strcmp(ipv4_preferred,'true'))
-    display('WARNING: Your JVM may crash if you do not set it to prefer IPv4 over IPv6.')
-    display('This may cause any dependencies that involve the JVM (including LCM) to crash at runtime.')
-    display('Please see bug report and solution here: https://github.com/RobotLocomotion/drake/issues/558.')
-    display('(It just involves adding one line to your java.opts file for Matlab.)')
-    display('Make sure to restart Matlab after editing your java.opts file.')
+  % Check if on Yosemite or after
+  [OSXvers,~] = evalc('system(''sw_vers -productVersion'')');
+  if ~isempty(regexp(OSXvers, '10\.1.', 'match'));
+    % Check if reverted to IPv4
+    ipv4_preferred = java.lang.System.getProperty('java.net.preferIPv4Stack');
+    if isempty(ipv4_preferred)
+      ipv4_preferred = 'false';
+    end
+    if ~(strcmp(ipv4_preferred,'true'))
+      display('WARNING: Your JVM may crash if you do not set it to prefer IPv4 over IPv6.')
+      display('This may cause any dependencies that involve the JVM (including LCM) to crash at runtime.')
+      display('Please see bug report and solution here: https://github.com/RobotLocomotion/drake/issues/558.')
+      display('(It just involves adding one line to your java.opts file for Matlab.)')
+      display('Make sure to restart Matlab after editing your java.opts file.')
+    end
   end
 end
 


### PR DESCRIPTION
Tested and this works on my machine.  Added a regular expression check for Yosemite or greater.

Can somebody on non-Yosemite OSX try out `[OSXvers,~] = evalc('system(''sw_vers -productVersion'')');` and check that my regular expression matching works?

@rdeits @hongkai-dai 