### PR TITLE
fix a segfault when multiple guards trigger

### DIFF
--- a/drake/systems/@HybridDrakeSystem/HybridDrakeSystem.m
+++ b/drake/systems/@HybridDrakeSystem/HybridDrakeSystem.m
@@ -299,7 +299,9 @@ classdef (InferiorClasses = {?DrakeSystem}) HybridDrakeSystem < DrakeSystem
         if (any(zcs2<0))
           active_id2 = find(zcs2<0);
           %        disp(obj);
-          warning('Drake:HybridDrakeSystem:SuccessiveZeroCrossings','Transitioned from mode %s to mode %s, and immediately triggered guard number %d\n',obj.mode_names{m},obj.mode_names{to_mode_num},active_id2);
+          for j = 1:numel(active_id2)
+            warning('Drake:HybridDrakeSystem:SuccessiveZeroCrossings','Transitioned from mode %s to mode %s, and immediately triggered guard number %d\n',obj.mode_names{m},obj.mode_names{to_mode_num},active_id2(j));
+          end
           %        keyboard;
         end % useful for debugging successive zcs.
       end


### PR DESCRIPTION
This one was fun to track down :wink: 

If a user has a badly structured hybrid system, it's possible for two guards to trigger at the same time. Normally, that's OK because `HybridDrakeSystem.transitionUpdate` throws a helpful error message:

```
if (length(active_id)>1) error('multiple guards tripped at the same time.  behavior is undefined.  consider reducing the step size'); end
```

However, if multiple guards trip *immediately after* a transition occurs, then the warning on line 302 of `HybridDrakeSystem` can fire with `active_id2` set to a vector instead of a scalar. That normally wouldn't be a problem. Calling `warning` with a format string and a vector value just results in a duplicate message:

```
>> warning('foo: %f\n', [1, 2])
Warning: foo: 1.000000
foo: 2.000000
```

But DCSFunction.cpp uses `mexCallMATLABWithTrap` on the `transitionUpdate`. For some reason, the duplicate input to `warning()` causes `mexCallMATLABWithTrap` to return an exception (?) containing not an error but a *warning* about that incorrect usage of `warning()` Confused yet? Then when we call `mexCallMATLAB(1, &report, 1, &ex, "getReport");` in `DCSFunction.mexCallMATLABSafe` the entire Matlab process crashes (perhaps because `ex` is a *warning* not an error and thus doesn't have a report? I'm not sure). 

Anyway, I believe the fix is just to make sure we don't try to pass vector-valued input into `warning()` when calling MATLAB from mex. 

