### PR TITLE
fix build when user has gurobi but not matlab

### DIFF
--- a/drake/systems/controllers/CMakeLists.txt
+++ b/drake/systems/controllers/CMakeLists.txt
@@ -17,6 +17,9 @@ pods_install_pkg_config_file(drake-control-util
 
 pods_find_pkg_config(gurobi)
 if (gurobi_FOUND)
+  include_directories (${PROJECT_SOURCE_DIR}/systems/trajectories )
+  include_directories (${PROJECT_SOURCE_DIR}/systems/plants )
+  include_directories (${PROJECT_SOURCE_DIR}/solvers )
   add_library(drakeQPCommon SHARED QPCommon.cpp)
   target_link_libraries(drakeQPCommon drakeControlUtil drakeQP drakeTrajectories drakeLCMUtil drakeSide)
   pods_use_pkg_config_packages(drakeQPCommon lcm)


### PR DESCRIPTION
The relevant folders would normally be included here: https://github.com/rdeits/drake/blob/bc55ad22353bf8f5baf3d65d4bf710f1d93f8cb5/drake/systems/controllers/CMakeLists.txt#L43 but not if the user doesn't have matlab. 