### PR TITLE
Adds release_filelist target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,14 @@ endif
 download-all: configure
 	cmake --build pod-build --config $(BUILD_TYPE) --target $@
 
+.PHONY: release_filelist
+release_filelist:
+	echo ".UNITTEST"
+	echo ".mlintopts"
+	find * -type f | grep -v "pod-build" | grep -v "\.valgrind" | grep -v "\.viewer-prefs" | grep -v "\.out" | grep -v "\.autosave" | grep -v "\.git" | grep -v "\.tmp" | grep -v "drake_config\.mat" | grep -v "DoxygenMatlab" | grep -v "\.aux" | grep -v "\.d" | grep -v "\.log" | grep -v "\.bib"
+	find drake/pod-build/lib -type f
+	-find pod-build/bin -type f 2> /dev/null
+
 .PHONY: clean
 clean:
 ifeq ($(BUILD_SYSTEM),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ download-all: configure
 
 .PHONY: release_filelist
 release_filelist:
-	echo ".UNITTEST"
+	echo "drake/.UNITTEST"
 	echo ".mlintopts"
 	find * -type f | grep -v "pod-build" | grep -v "\.valgrind" | grep -v "\.viewer-prefs" | grep -v "\.out" | grep -v "\.autosave" | grep -v "\.git" | grep -v "\.tmp" | grep -v "drake_config\.mat" | grep -v "DoxygenMatlab" | grep -v "\.aux" | grep -v "\.d" | grep -v "\.log" | grep -v "\.bib"
 	find drake/pod-build/lib -type f


### PR DESCRIPTION
This is a slightly modified version of what was previously here.  It now reflects the fact that drake is a subdirectory in the superbuild.

This should bring precompiled packaging back online.