### PR TITLE
Add quick benchmark of mass matrix gradient using AutoDiffScalar

### DIFF
--- a/drake/systems/controllers/QPCommon.cpp
+++ b/drake/systems/controllers/QPCommon.cpp
@@ -427,7 +427,7 @@ int setupAndSolveQP(
     if (qp_input->body_motion_data[i].body_id == 0)
       throw std::runtime_error("Body motion data with body id 0\n");
     int body_or_frame_id0 = qp_input->body_motion_data[i].body_id - 1;
-    int true_body_id0 = pdata->r->parseBodyOrFrameID(body_or_frame_id0, NULL);
+    int true_body_id0 = pdata->r->parseBodyOrFrameID(body_or_frame_id0);
     double weight = params->body_motion[true_body_id0].weight;
     desired_body_accelerations[i].body_or_frame_id0 = body_or_frame_id0;
     Map<Vector4d> quat_task_to_world(qp_input->body_motion_data[i].quat_task_to_world);
@@ -639,7 +639,7 @@ int setupAndSolveQP(
   Vector6d Jbdotv;	
   for (int i=0; i<desired_body_accelerations.size(); i++) {
     if (desired_body_accelerations[i].weight < 0) { // negative implies constraint
-      int body_id0 = pdata->r->parseBodyOrFrameID(desired_body_accelerations[i].body_or_frame_id0,(Matrix4d*)nullptr);
+      int body_id0 = pdata->r->parseBodyOrFrameID(desired_body_accelerations[i].body_or_frame_id0);
       if (desired_body_accelerations[i].control_pose_when_in_contact || !inSupport(active_supports,body_id0)) {
         auto J_geometric = pdata->r->geometricJacobian(cache, 0,desired_body_accelerations[i].body_or_frame_id0, desired_body_accelerations[i].body_or_frame_id0, 0, true, (std::vector<int> *) nullptr);
         auto J_geometric_dot_times_v = pdata->r->geometricJacobianDotTimesV(cache, 0,desired_body_accelerations[i].body_or_frame_id0,desired_body_accelerations[i].body_or_frame_id0,0);
@@ -814,7 +814,7 @@ int setupAndSolveQP(
     // add in body spatial acceleration cost terms
     for (int i=0; i<desired_body_accelerations.size(); i++) {
       if (desired_body_accelerations[i].weight > 0) {
-        int body_id0 = pdata->r->parseBodyOrFrameID(desired_body_accelerations[i].body_or_frame_id0,(Matrix4d*)nullptr);
+        int body_id0 = pdata->r->parseBodyOrFrameID(desired_body_accelerations[i].body_or_frame_id0);
         if (desired_body_accelerations[i].control_pose_when_in_contact || !inSupport(active_supports,body_id0)) {
           auto J_geometric = pdata->r->geometricJacobian(cache, 0,desired_body_accelerations[i].body_or_frame_id0,desired_body_accelerations[i].body_or_frame_id0,0,true,(std::vector<int>*)nullptr);
           auto J_geometric_dot_times_v = pdata->r->geometricJacobianDotTimesV(cache, 0, desired_body_accelerations[i].body_or_frame_id0, desired_body_accelerations[i].body_or_frame_id0, 0);

--- a/drake/systems/controllers/QPCommon.cpp
+++ b/drake/systems/controllers/QPCommon.cpp
@@ -439,7 +439,7 @@ int setupAndSolveQP(
     double expmap_kp_multiplier = qp_input->body_motion_data[i].expmap_kp_multiplier;
     double expmap_damping_ratio_multiplier = qp_input->body_motion_data[i].expmap_damping_ratio_multiplier;
     memcpy(desired_body_accelerations[i].weight_multiplier.data(),qp_input->body_motion_data[i].weight_multiplier,sizeof(double)*6);
-    pdata->r->findKinematicPath(desired_body_accelerations[i].body_path,0,desired_body_accelerations[i].body_or_frame_id0);
+    desired_body_accelerations[i].body_path = pdata->r->findKinematicPath(0, desired_body_accelerations[i].body_or_frame_id0);
 
     auto spline = decodePiecewisePolynomial(qp_input->body_motion_data[i].spline);
     evaluateXYZExpmapCubicSpline(robot_state.t, spline, body_pose_des, body_v_des, body_vdot_des);

--- a/drake/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
+++ b/drake/systems/plants/@RigidBodyManipulator/RigidBodyManipulator.m
@@ -73,7 +73,7 @@ classdef RigidBodyManipulator < Manipulator
         elseif strcmpi(ext,'.sdf') || strcmpi(ext,'.world')
           obj = addRobotFromSDF(obj,filename,zeros(3,1),zeros(3,1),options);
         else
-          error('Drake:RigidBodyManipulator:UnsupportedFileExtension','Unrecognized file extension: %s',ext);
+          error('Drake:RigidBodyManipulator:UnsupportedFileExtension','Unrecognized file extension: %s for file %s',ext,name);
         end
       end
     end

--- a/drake/systems/plants/RigidBodyManipulator.cpp
+++ b/drake/systems/plants/RigidBodyManipulator.cpp
@@ -519,11 +519,11 @@ void RigidBodyManipulator::updateCompositeRigidBodyInertias(KinematicsCache<Scal
   if (gradient_order > cache.getCachedInertiaGradientsOrder()) {
     for (int i = 0; i < bodies.size(); i++) {
       auto& element = cache.getElement(*bodies[i]);
-      Gradient<Isometry3d::MatrixType, Eigen::Dynamic>::type* dTdq = nullptr;
+      typename Gradient<typename Transform<Scalar, 3, Isometry>::MatrixType, Dynamic>::type* dTdq = nullptr;
       if (gradient_order > 0)
         dTdq = &element.dtransform_to_world_dq;
 
-      auto inertia_in_world = transformSpatialInertia(element.transform_to_world, dTdq, bodies[i]->I);
+      auto inertia_in_world = transformSpatialInertia(element.transform_to_world, dTdq, bodies[i]->I.cast<Scalar>());
       element.inertia_in_world.value() = inertia_in_world.value();
       element.crb_in_world.value() = inertia_in_world.value();
       if (gradient_order > 0) {
@@ -864,8 +864,9 @@ void RigidBodyManipulator::getContactPositionsJac(const KinematicsCache<typename
 }
 
 /* [body_ind,Tframe] = parseBodyOrFrameID(body_or_frame_id) */
-int RigidBodyManipulator::parseBodyOrFrameID(const int body_or_frame_id, Matrix4d* Tframe) const
-{
+template <typename Scalar>
+int RigidBodyManipulator::parseBodyOrFrameID(const int body_or_frame_id, Eigen::Transform<Scalar, 3, Isometry>* Tframe) const {
+
   int body_ind=0;
   if (body_or_frame_id == -1) {
     cerr << "parseBodyOrFrameID got a -1, which should have been reserved for COM.  Shouldn't have gotten here." << endl;
@@ -880,13 +881,18 @@ int RigidBodyManipulator::parseBodyOrFrameID(const int body_or_frame_id, Matrix4
     body_ind = frames[frame_ind]->body->body_index;
 
     if (Tframe)
-      (*Tframe) = frames[frame_ind]->transform_to_body;
+      (*Tframe) = frames[frame_ind]->transform_to_body.cast<Scalar>();
   } else {
     body_ind = body_or_frame_id;
     if (Tframe)
-      (*Tframe) = Matrix4d::Identity();
+      Tframe->setIdentity();
   }
   return body_ind;
+}
+
+int RigidBodyManipulator::parseBodyOrFrameID(const int body_or_frame_id) const
+{
+  return parseBodyOrFrameID<double>(body_or_frame_id, nullptr);
 }
 
 void RigidBodyManipulator::findAncestorBodies(std::vector<int>& ancestor_bodies, int body_idx) const
@@ -1013,7 +1019,7 @@ GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::geometricJ
   }
 
   auto T_world_to_frame = relativeTransform(cache, expressed_in_body_or_frame_ind, 0, 0);
-  Isometry3d H0(T_world_to_frame.value());
+  Transform<Scalar, 3, Isometry> H0(T_world_to_frame.value());
   if (expressed_in_body_or_frame_ind != 0) {
     J = transformSpatialMotion(H0, J);
   }
@@ -1029,7 +1035,7 @@ GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::geometricJ
       int sign = kinematic_path.joint_direction_signs[i];
       RigidBody& body_j = *bodies[j];
       const auto& element_j = cache.getElement(body_j);
-      Matrix<double, TWIST_SIZE, Dynamic, 0, TWIST_SIZE, DrakeJoint::MAX_NUM_POSITIONS> Jj = (sign * element_j.motion_subspace_in_world.value()).eval();
+      Matrix<Scalar, TWIST_SIZE, Dynamic, 0, TWIST_SIZE, DrakeJoint::MAX_NUM_POSITIONS> Jj = (sign * element_j.motion_subspace_in_world.value()).eval();
       if (in_terms_of_qdot) {
         Jj *= element_j.qdot_to_v.value();
       }
@@ -1039,7 +1045,7 @@ GradientVar<Scalar, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::geometricJ
         dSjdqj = matGradMultMat((sign * element_j.motion_subspace_in_body.value()).eval(), element_j.qdot_to_v.value(), dSjdqj, element_j.qdot_to_v.gradient().value().middleCols(body_j.position_num_start, body_j.getJoint().getNumPositions()));
       }
       auto Hj_gradientvar = relativeTransform(cache, expressed_in_body_or_frame_ind, j, 0);
-      Isometry3d Hj(Hj_gradientvar.value());
+      Transform<Scalar, 3, Isometry> Hj(Hj_gradientvar.value());
       auto Jj0_gradientvar = geometricJacobian(cache, expressed_in_body_or_frame_ind, j, 0, 0, true, &qdot_ind_ij);
 
       for (int Jj_col = 0; Jj_col < Jj.cols(); Jj_col++) {
@@ -1148,23 +1154,23 @@ GradientVar<Scalar, SPACE_DIMENSION + 1, SPACE_DIMENSION + 1> RigidBodyManipulat
   int nq = num_positions;
   GradientVar<Scalar, SPACE_DIMENSION + 1, SPACE_DIMENSION + 1> ret(SPACE_DIMENSION + 1, SPACE_DIMENSION + 1, nq, gradient_order);
 
-  Matrix4d Tbase_frame;
+  Transform<Scalar, 3, Isometry> Tbase_frame;
   int base_ind = parseBodyOrFrameID(base_or_frame_ind, &Tbase_frame);
-  Matrix4d Tbody_frame;
+  Transform<Scalar, 3, Isometry> Tbody_frame;
   int body_ind = parseBodyOrFrameID(body_or_frame_ind, &Tbody_frame);
 
   const auto& body_element = cache.getElement(*bodies[body_ind]);
   const auto& base_element = cache.getElement(*bodies[base_ind]);
 
-  Isometry3d Tbaseframe_to_world = base_element.transform_to_world * Isometry3d(Tbase_frame); // TODO: copy to Isometry3d
-  Isometry3d Tworld_to_baseframe = Tbaseframe_to_world.inverse();
-  Isometry3d Tbodyframe_to_world = body_element.transform_to_world * Isometry3d(Tbody_frame); // TODO: copy to Isometry3d
+  Transform<Scalar, 3, Isometry> Tbaseframe_to_world = base_element.transform_to_world * Tbase_frame;
+  Transform<Scalar, 3, Isometry> Tworld_to_baseframe = Tbaseframe_to_world.inverse();
+  Transform<Scalar, 3, Isometry> Tbodyframe_to_world = body_element.transform_to_world * Tbody_frame;
   ret.value() = (Tworld_to_baseframe * Tbodyframe_to_world).matrix();
 
   if (gradient_order > 0) {
-    auto dTbaseframe_to_world = matGradMult(base_element.dtransform_to_world_dq, Tbase_frame);
+    auto dTbaseframe_to_world = matGradMult(base_element.dtransform_to_world_dq, Tbase_frame.matrix());
     auto dTworld_to_baseframe = dHomogTransInv(Tbaseframe_to_world, dTbaseframe_to_world);
-    auto dTbodyframe_to_world = matGradMult(body_element.dtransform_to_world_dq, Tbody_frame);
+    auto dTbodyframe_to_world = matGradMult(body_element.dtransform_to_world_dq, Tbody_frame.matrix());
     ret.gradient().value() = matGradMultMat(Tworld_to_baseframe.matrix(), Tbodyframe_to_world.matrix(), dTworld_to_baseframe, dTbodyframe_to_world);
   }
   if (gradient_order > 1) {
@@ -1905,6 +1911,7 @@ template DLLEXPORT_RBM GradientVar<double, SPACE_DIMENSION, 1> RigidBodyManipula
 template DLLEXPORT_RBM GradientVar<double, SPACE_DIMENSION, Eigen::Dynamic> RigidBodyManipulator::centerOfMassJacobian(KinematicsCache<double>&, int, const std::set<int>&, bool) const;
 template DLLEXPORT_RBM GradientVar<double, SPACE_DIMENSION, 1> RigidBodyManipulator::centerOfMassJacobianDotTimesV(KinematicsCache<double>&, int, const std::set<int>&) const;
 template DLLEXPORT_RBM GradientVar<double, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::geometricJacobian<double>(const KinematicsCache<double>&, int, int, int, int, bool, std::vector<int>*) const;
+template DLLEXPORT_RBM GradientVar<AutoDiffScalar<VectorXd>, TWIST_SIZE, Eigen::Dynamic> RigidBodyManipulator::geometricJacobian< AutoDiffScalar<VectorXd> >(KinematicsCache< AutoDiffScalar<VectorXd> > const&, int, int, int, int, bool, vector<int>*) const;
 template DLLEXPORT_RBM GradientVar<double, TWIST_SIZE, 1> RigidBodyManipulator::geometricJacobianDotTimesV(const KinematicsCache<double>&, int, int, int, int) const;
 template DLLEXPORT_RBM GradientVar<double, SPACE_DIMENSION + 1, SPACE_DIMENSION + 1> RigidBodyManipulator::relativeTransform(const KinematicsCache<double>&, int, int, int) const;
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::forwardKin<Matrix3Xd >(const KinematicsCache<double>&, const MatrixBase<Matrix3Xd> &, int, int, int, int) const;
@@ -1921,6 +1928,7 @@ template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> Rigid
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::forwardJacDotTimesV(const KinematicsCache<double>&, const MatrixBase< Matrix<double, 3, Eigen::Dynamic> >&, int, int, int, int) const;
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::forwardJacDotTimesV(const KinematicsCache<double>&, const MatrixBase< Matrix<double, 3, 1> >&, int, int, int, int) const;
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::massMatrix(KinematicsCache<double>&, int) const;
+template DLLEXPORT_RBM GradientVar<AutoDiffScalar<VectorXd>, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::massMatrix<AutoDiffScalar<VectorXd> >(KinematicsCache<AutoDiffScalar<VectorXd> >&, int) const;
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::inverseDynamics(KinematicsCache<double>&, std::map<int, std::unique_ptr<GradientVar<double, TWIST_SIZE, 1> > >& f_ext, GradientVar<double, Eigen::Dynamic, 1>* vd, int) const;
 template DLLEXPORT_RBM GradientVar<double, TWIST_SIZE, 1> RigidBodyManipulator::relativeTwist<double>(const KinematicsCache<double>&, int, int, int, int) const;
 template DLLEXPORT_RBM GradientVar<double, 6, Dynamic> RigidBodyManipulator::worldMomentumMatrix<double>(KinematicsCache<double>&, int, const std::set<int>&, bool) const;

--- a/drake/systems/plants/RigidBodyManipulator.h
+++ b/drake/systems/plants/RigidBodyManipulator.h
@@ -143,7 +143,7 @@ public:
         element.transform_to_world = parent_element.transform_to_world * T_body_to_parent;
 
         // motion subspace in body frame
-        Eigen::MatrixXd* dSdq = compute_gradients ? &(element.motion_subspace_in_body.gradient().value()) : nullptr;
+        Matrix<Scalar, Dynamic, Dynamic>* dSdq = compute_gradients ? &(element.motion_subspace_in_body.gradient().value()) : nullptr;
         joint.motionSubspace(q_body, element.motion_subspace_in_body.value(), dSdq);
 
         // motion subspace in world frame
@@ -231,7 +231,7 @@ public:
               if (compute_gradients) {
                 // dJdotvdq
                 // TODO: exploit sparsity better
-                Matrix<double, TWIST_SIZE, Eigen::Dynamic> dSdotVdq(TWIST_SIZE, nq);
+                Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic> dSdotVdq(TWIST_SIZE, nq);
                 dSdotVdq.setZero();
                 auto& dSdotv = element.motion_subspace_in_body_dot_times_v.gradient().value();
                 dSdotVdq.middleCols(body.position_num_start, joint.getNumPositions()) = dSdotv.leftCols(joint.getNumPositions());
@@ -248,11 +248,11 @@ public:
                 auto dtwistdv = geometricJacobian(cache, 0, i, 0, 0, false, &v_indices);
                 int nv_branch = static_cast<int>(v_indices.size());
 
-                Matrix<double, TWIST_SIZE, Eigen::Dynamic> djoint_twistdv(TWIST_SIZE, nv_branch);
+                Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic> djoint_twistdv(TWIST_SIZE, nv_branch);
                 djoint_twistdv.setZero();
                 djoint_twistdv.rightCols(nv_joint) = element.motion_subspace_in_world.value();
 
-                Matrix<double, TWIST_SIZE, Eigen::Dynamic> djoint_acceldv(TWIST_SIZE, nv_branch);
+                Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic> djoint_acceldv(TWIST_SIZE, nv_branch);
                 djoint_acceldv = dCrossSpatialMotion(element.twist_in_world.value(), joint_twist.value(), dtwistdv.value(), djoint_twistdv); // TODO: can probably exploit sparsity better
                 auto dSdotVdvi = dSdotv.rightCols(joint.getNumVelocities());
                 djoint_acceldv.rightCols(nv_joint) += transformSpatialMotion(element.transform_to_world, dSdotVdvi);
@@ -485,7 +485,10 @@ public:
   std::string getBodyOrFrameName(int body_or_frame_id) const;
   //@param body_or_frame_id   the index of the body or the id of the frame.
 
-  int parseBodyOrFrameID(const int body_or_frame_id, Matrix4d* Tframe = nullptr) const;
+  // TODO: remove parseBodyOrFrameID methods
+  template <typename Scalar>
+  int parseBodyOrFrameID(const int body_or_frame_id, Eigen::Transform<Scalar, 3, Isometry>* Tframe) const;
+  int parseBodyOrFrameID(const int body_or_frame_id) const;
 
   template <typename Scalar>
   GradientVar<Scalar, Eigen::Dynamic, 1> positionConstraints(const KinematicsCache<Scalar>& cache, int gradient_order) const;

--- a/drake/systems/plants/RigidBodyManipulator.h
+++ b/drake/systems/plants/RigidBodyManipulator.h
@@ -359,7 +359,7 @@ public:
 
   void findAncestorBodies(std::vector<int>& ancestor_bodies, int body) const;
 
-  void findKinematicPath(KinematicPath& path, int start_body_or_frame_idx, int end_body_or_frame_idx) const;
+  KinematicPath findKinematicPath(int start_body_or_frame_idx, int end_body_or_frame_idx) const;
 
   template <typename Scalar>
   GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> massMatrix(KinematicsCache<Scalar>& cache, int gradient_order = 0) const;

--- a/drake/systems/plants/findKinematicPathmex.cpp
+++ b/drake/systems/plants/findKinematicPathmex.cpp
@@ -31,8 +31,7 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
   int start_body_or_frame_idx = ((int) mxGetScalar(prhs[1])) - 1; // base 1 to base 0
   int end_body_or_frame_idx = ((int) mxGetScalar(prhs[2])) - 1; // base 1 to base 0
 
-  KinematicPath path;
-  model->findKinematicPath(path, start_body_or_frame_idx, end_body_or_frame_idx);
+  KinematicPath path = model->findKinematicPath(start_body_or_frame_idx, end_body_or_frame_idx);
 
   if (nlhs > 0) {
     baseZeroToBaseOne(path.body_path);

--- a/drake/systems/plants/joints/DrakeJoint.cpp
+++ b/drake/systems/plants/joints/DrakeJoint.cpp
@@ -1,5 +1,4 @@
 #include "DrakeJoint.h"
-#include "RigidBodyManipulator.h"
 
 using namespace Eigen;
 

--- a/drake/systems/plants/joints/QuaternionFloatingJoint.cpp
+++ b/drake/systems/plants/joints/QuaternionFloatingJoint.cpp
@@ -1,8 +1,6 @@
 #include "QuaternionFloatingJoint.h"
 #include <random>
 
-#include "RigidBodyManipulator.h" // todo: remove this when I remove setupOldKinematicTree
-
 using namespace Eigen;
 using namespace std;
 

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.cpp
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.cpp
@@ -1,8 +1,6 @@
 #include "RollPitchYawFloatingJoint.h"
 #include <random>
 
-#include "RigidBodyManipulator.h" // todo: remove this when I remove setupOldKinematicTree
-
 using namespace Eigen;
 
 std::string RollPitchYawFloatingJoint::getPositionName(int index) const

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(debugManipulatorDynamics debugManipulatorDynamics.cpp)
 include_directories( .. )
 target_link_libraries(debugManipulatorDynamics drakeRBM)
 
+include_directories(${PROJECT_SOURCE_DIR}/util)
 add_executable(benchmarkAutoDiffScalar benchmarkAutoDiffScalar.cpp)
 target_link_libraries(benchmarkAutoDiffScalar drakeRBM)
 

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -48,7 +48,7 @@ add_executable(debugManipulatorDynamics debugManipulatorDynamics.cpp)
 include_directories( .. )
 target_link_libraries(debugManipulatorDynamics drakeRBM)
 
-include_directories(${PROJECT_SOURCE_DIR}/util)
+include_directories(${PROJECT_SOURCE_DIR}/util/test)
 add_executable(benchmarkAutoDiffScalar benchmarkAutoDiffScalar.cpp)
 target_link_libraries(benchmarkAutoDiffScalar drakeRBM)
 

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -48,6 +48,9 @@ add_executable(debugManipulatorDynamics debugManipulatorDynamics.cpp)
 include_directories( .. )
 target_link_libraries(debugManipulatorDynamics drakeRBM)
 
+add_executable(benchmarkAutoDiffScalar benchmarkAutoDiffScalar.cpp)
+target_link_libraries(benchmarkAutoDiffScalar drakeRBM)
+
 if (MATLAB_FOUND)
   macro(add_ikoptions_mex)
     add_mex(${ARGV} ${ARGV}.cpp)

--- a/drake/systems/plants/test/benchmarkAutoDiffScalar.cpp
+++ b/drake/systems/plants/test/benchmarkAutoDiffScalar.cpp
@@ -1,0 +1,48 @@
+#include "RigidBodyManipulator.h"
+#include "testUtil.h"
+
+using namespace std;
+using namespace Eigen;
+
+default_random_engine generator;
+
+void testUserGradients(const RigidBodyManipulator &model, int ntests) {
+  VectorXd q(model.num_positions);
+  KinematicsCache<double> cache(model.bodies, 1);
+
+  for (int i = 0; i < ntests; i++) {
+    model.getRandomConfiguration(q, generator);
+    cache.initialize(q);
+    model.doKinematics(cache, false);
+    auto H_gradientvar = model.massMatrix(cache, 1);
+  }
+}
+
+void testAutoDiffScalarGradients(const RigidBodyManipulator &model, int ntests) {
+  const int NUM_POSITIONS = Dynamic;
+  typedef Matrix<double, NUM_POSITIONS, 1> DerivativeType;
+  typedef AutoDiffScalar<DerivativeType> TaylorVar;
+  VectorXd q(model.num_positions);
+  Matrix<TaylorVar, NUM_POSITIONS, 1> q_taylorvar;
+  auto grad = Matrix<double, NUM_POSITIONS, NUM_POSITIONS>::Identity(model.num_positions, model.num_positions).eval();
+  KinematicsCache<TaylorVar> cache(model.bodies, 0);
+
+  for (int i = 0; i < ntests; i++) {
+    model.getRandomConfiguration(q, generator);
+    q_taylorvar = q.cast<TaylorVar>().eval();
+    gradientMatrixToAutoDiff(grad, q_taylorvar);
+    cache.initialize(q_taylorvar);
+    model.doKinematics(cache, false);
+    auto H_taylorvar = model.massMatrix(cache, 0);
+  }
+}
+
+int main() {
+  RigidBodyManipulator model("examples/Atlas/urdf/atlas_minimal_contact.urdf");
+
+  int ntests = 1000;
+  std::cout << "user gradients: " << measure<>::execution(testUserGradients, model, ntests) / static_cast<double>(ntests) << std::endl;
+  std::cout << "autodiff gradients: " << measure<>::execution(testAutoDiffScalarGradients, model, ntests) / static_cast<double>(ntests) << std::endl;
+
+  return 0;
+}

--- a/drake/systems/robotInterfaces/@QPLocomotionPlanCPPWrapper/CMakeLists.txt
+++ b/drake/systems/robotInterfaces/@QPLocomotionPlanCPPWrapper/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(..)
 
 if (MATLAB_FOUND)
-  if (LCM_FOUND AND NOT WIN32)
+  if (LCM_FOUND)
     macro(add_qplocomotionplan_mex)
       add_mex(${ARGV} ${ARGV}.cpp)
       target_link_libraries(${ARGV} drakeQPLocomotionPlan drakeMexUtil)

--- a/drake/systems/robotInterfaces/CMakeLists.txt
+++ b/drake/systems/robotInterfaces/CMakeLists.txt
@@ -15,7 +15,7 @@ pods_install_pkg_config_file(drake-side
 	REQUIRES
 	VERSION 0.0.1)
 
-if (LCM_FOUND AND NOT WIN32)
+if (LCM_FOUND)
   add_library(drakeQPLocomotionPlan SHARED QPLocomotionPlan.cpp BodyMotionData.cpp) # TODO: move BodyMotionData to a better place
   target_link_libraries(drakeQPLocomotionPlan drakeSplineGeneration drakeRBM drakeLCMUtil drakeSide drakeConvexHull drakeAtlasUtil drakeZMPUtil)
   pods_use_pkg_config_packages(drakeQPLocomotionPlan lcm)

--- a/drake/util/test/CMakeLists.txt
+++ b/drake/util/test/CMakeLists.txt
@@ -6,20 +6,16 @@
 include_directories(..)
 include_directories(${PROJECT_SOURCE_DIR}/systems/trajectories)
 
-if (NOT WIN32)
-  # doesn't work because the timing tests require the <chrono> include
-  add_executable(testDrakeGeometryUtil testDrakeGeometryUtil.cpp)
-  target_link_libraries(testDrakeGeometryUtil drakeGeometryUtil)
-  add_test(NAME testDrakeGeometryUtil COMMAND testDrakeGeometryUtil)
+add_executable(testDrakeGeometryUtil testDrakeGeometryUtil.cpp)
+target_link_libraries(testDrakeGeometryUtil drakeGeometryUtil)
+add_test(NAME testDrakeGeometryUtil COMMAND testDrakeGeometryUtil)
 
-  add_executable(testGradientVar testGradientVar.cpp)
-  #set_target_properties(testGradientVar PROPERTIES COMPILE_FLAGS "-g -O0")
-  #add_test(NAME testGradientVar COMMAND testGradientVar)
+add_executable(testGradientVar testGradientVar.cpp)
+#add_test(NAME testGradientVar COMMAND testGradientVar)
 
-  add_executable(testDrakeGradientUtil testDrakeGradientUtil.cpp)
-  target_link_libraries(testDrakeGradientUtil drakeGeometryUtil)
-  add_test(NAME testDrakeGradientUtil COMMAND testDrakeGradientUtil)
-endif (NOT WIN32)
+add_executable(testDrakeGradientUtil testDrakeGradientUtil.cpp)
+target_link_libraries(testDrakeGradientUtil drakeGeometryUtil)
+add_test(NAME testDrakeGradientUtil COMMAND testDrakeGradientUtil)
 
 if (MATLAB_FOUND)
   add_mex(testQuatmex testQuatmex.cpp)

--- a/drake/util/test/testUtil.h
+++ b/drake/util/test/testUtil.h
@@ -1,10 +1,7 @@
 #ifndef TESTUTIL_H_
 #define TESTUTIL_H_
 
-#if !defined(WIN32) && !defined(WIN64)
 #include <chrono>
-#endif
-
 #include <Eigen/Core>
 #include <sstream>
 #include <string>
@@ -12,7 +9,6 @@
 #include <cmath>
 
 // requires <chrono>, which isn't available in MSVC2010...
-#if !defined(WIN32) && !defined(WIN64)
 template<typename TimeT = std::chrono::milliseconds>
 struct measure
 {
@@ -25,12 +21,11 @@ struct measure
     func(std::forward<Args>(args)...);
 
     auto duration = std::chrono::duration_cast< TimeT>
-    (std::chrono::system_clock::now() - start);
+        (std::chrono::system_clock::now() - start);
 
     return duration.count();
   }
 };
-#endif
 
 template<typename Derived>
 std::string to_string(const Eigen::MatrixBase<Derived> & a)


### PR DESCRIPTION
Also fix some Scalar correctness issues, change KinematicPath so that it returns a KinematicPath instead of requiring a reference to be passed in (mostly to make it easier to swig later).

Based off of #1348.

See #1199 