### PR TITLE
Fixing broken reference to unknown variable 'mdl_handle'

### DIFF
--- a/drake/systems/@DynamicalSystem/runLCM.m
+++ b/drake/systems/@DynamicalSystem/runLCM.m
@@ -101,7 +101,7 @@ else % otherwise set up the LCM blocks and run simulink.
 
   if (~isempty(x0)) % handle initial conditions
     x0 = obj.stateVectorToStructure(double(x0),mdl);
-    pstruct.InitialState = registerParameter(mdl_handle,x0,'x0');
+    pstruct.InitialState = registerParameter(mdl,x0,'x0');
     pstruct.LoadInitialState = 'on';
 
     if (~isempty(find_system(mdl,'ClassName','InitialCondition')))


### PR DESCRIPTION
When running runLCM with initial conditions, MATLAB complains 'Undefined function or variable 'mdl_handle'. I suspect that the variable 'mdl' was once named 'mdl_handle', and that this reference did not get renamed. The other code that uses runLCM does not use initial conditions, so this bug does not surface when running other examples (Pendulum code).