### PR TITLE
allow gcc to fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,7 @@ env:
   matrix:
     - BUILD_TYPE=Release
     # - BUILD_TYPE=Debug
+
+matrix:
+  allow_failures:
+    - compiler: gcc


### PR DESCRIPTION
This should keep travis running the gcc build (so we can perhaps someday figure out what's going on) but allow it to fail without marking the commit as bad