### PR TITLE
flip to using the matlab dynamics instead of the rbm dynamics in the quad runLQR example

### DIFF
--- a/drake/examples/Quadrotor/QuadPlantPenn.m
+++ b/drake/examples/Quadrotor/QuadPlantPenn.m
@@ -18,6 +18,11 @@ classdef QuadPlantPenn < SecondOrderSystem
           I = obj.I;
         end
         
+        function u0 = nominalThrust(obj)
+          % each propellor commands -mg/4
+          u0 = Point(getInputFrame(obj),obj.m*9.81*ones(4,1)/4);
+        end
+        
         function qdd = sodynamics(obj,t,q,qd,u)
             % States
             % x
@@ -111,6 +116,13 @@ classdef QuadPlantPenn < SecondOrderSystem
             x = zeros(12,1);
         end
         
+        
+        function v = constructVisualizer(obj)
+          r = Quadrotor();
+          v = r.constructVisualizer();
+          tf = AffineTransform(obj.getOutputFrame(),v.getInputFrame(),[eye(6),zeros(6)],zeros(6,1));
+          obj.getOutputFrame().addTransform(tf);
+        end
     end
     properties
       m = .5;

--- a/drake/examples/Quadrotor/runLQR.m
+++ b/drake/examples/Quadrotor/runLQR.m
@@ -1,24 +1,16 @@
 function runLQR
 
-r = Quadrotor();
+%r = Quadrotor();
+r = QuadPlantPenn();  % sim is faster with this
 v = r.constructVisualizer();
 
 x0 = [0;0;1;zeros(9,1)];
 u0 = double(nominalThrust(r));
 
-%c = tilqr(r,x0,u0,diag([10*ones(5,1);0;ones(5,1);0]),eye(4));
-
-% the linearized system 
-[A,B] = linearize(r,0,x0,double(u0));
-
 Q = diag([10*ones(6,1); ones(6,1)]);
 R = .1*eye(4);
-K = lqr(full(A),full(B),Q,R);
 
-% u = u0 - K*(x-x0)
-c = AffineSystem([],[],[],[],[],[],[],-K,u0 + K*x0);
-c = setInputFrame(c,getStateFrame(r));
-c = setOutputFrame(c,getInputFrame(r));
+c = tilqr(r,x0,u0,Q,R);
 
 sys = feedback(r,c);
 


### PR DESCRIPTION
The rbm version spends lots of time in the kinematics calls (to compute the prop forces), including lots of annoying time spend on lines that should not take time, like obj.mex_model_ptr == 0.  i think the resolution is coming when we move the whole dynamics down into c++