### PR TITLE
Fix solveLCP gradients

### DIFF
--- a/drake/examples/Atlas/test/testOutputGradients.m
+++ b/drake/examples/Atlas/test/testOutputGradients.m
@@ -1,0 +1,26 @@
+function testOutputGradients()
+%% Load the model with a floating base
+atlas_path = fullfile(getDrakePath,'examples','Atlas');
+path_handle = addpathTemporary(atlas_path);
+dt = .001;
+options.floating = true;
+options.dt = dt;
+options.terrain = RigidBodyFlatTerrain;
+r = Atlas(fullfile(atlas_path, 'urdf', 'atlas_convex_hull.urdf'), options);
+%r = r.removeCollisionGroupsExcept({'heel','toe','back','front','knee','butt'});
+r = compile(r);
+nu = r.getNumInputs();
+
+%% Step through dynamics
+x0 = Point(r.getStateFrame());
+x0 = resolveConstraints(r,x0);
+
+u = zeros(nu,1);
+x = x0.double();
+t = 0;
+
+geval_options.grad_method = {'user', 'numerical'};
+geval_options.tol = 1e-5;
+[~, ~] = geval(1, @(t, x, u) r.update(t, x, u), t, x, u, geval_options);
+
+end

--- a/drake/systems/plants/TimeSteppingRigidBodyManipulator.m
+++ b/drake/systems/plants/TimeSteppingRigidBodyManipulator.m
@@ -311,7 +311,8 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
         qd = vToqdot*v;
         h = obj.timestep;
 
-        kinsol = doKinematics(obj,q);
+        kinematics_options.compute_gradients = nargout > 4;
+        kinsol = doKinematics(obj, q, [], kinematics_options);
 
         if (nargout<5)
           [H,C,B] = manipulatorDynamics(obj.manip,q,v);
@@ -419,7 +420,8 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
               nC = sum(possible_contact_indices);
               mC = length(D);
 
-              J = zeros(nL + nP + (mC+2)*nC,num_q)*q(1); % *q(1) is for taylorvar
+              J_size = [nL + nP + (mC+2)*nC,num_q];
+              J = zeros(J_size)*q(1); % *q(1) is for taylorvar
               lb = zeros(nL+nP+(mC+2)*nC,1);
               ub = Big*ones(nL+nP+(mC+2)*nC,1);
               D = vertcat(D{:});
@@ -443,11 +445,23 @@ classdef TimeSteppingRigidBodyManipulator < DrakeSystem
               J(nL+nP+nC+(1:mC*nC),:) = D;
 
               if nargout>4
-                dJ = zeros(nL+nP+(mC+2)*nC,num_q^2);  % was sparse, but reshape trick for the transpose below didn't work
-                dJ(nL+nP+(1:nC),:) = reshape(dn(possible_contact_indices,:),nC,[]);
-                dD = cellfun(@(A)reshape(A(possible_contact_indices,:),size(D{1},1),size(D{1},2)*size(dD{1},2)),dD,'UniformOutput',false);
-                dD = vertcat(dD{:});
-                dJ(nL+nP+nC+(1:mC*nC),:) = dD;
+                dJ = zeros(prod(J_size), num_q); % was sparse, but reshape trick for the transpose below didn't work
+                possible_contact_indices_found = find(possible_contact_indices);
+                n_size = [numel(possible_contact_indices), num_q];
+                col_indices = 1 : num_q;
+                dn = getSubMatrixGradient(reshape(dn, [], num_q), possible_contact_indices_found, col_indices, n_size);
+                dJ = setSubMatrixGradient(dJ, dn, nL+nP+(1:nC), 1 : J_size(2), J_size);
+                D_size = size(D);
+                dD_matrix = zeros(prod(D_size), num_q);
+                row_start = 0;
+                for i = 1 : mC
+                  dD_possible_contact = getSubMatrixGradient(dD{i}, possible_contact_indices_found, col_indices, n_size);
+                  dD_matrix = setSubMatrixGradient(dD_matrix, dD_possible_contact, row_start + (1 : nC), col_indices, D_size);
+                  row_start = row_start + nC;
+                end 
+                dD = dD_matrix;
+                dJ = setSubMatrixGradient(dJ, dD, nL+nP+nC + (1 : mC * nC), col_indices, J_size);
+                dJ = reshape(dJ, [], num_q^2);
               end
 
               contact_data.normal = normal(:,possible_contact_indices);


### PR DESCRIPTION
Fixes https://github.com/RobotLocomotion/drake/issues/1450.

Also adds a test that compares against numerical gradients based on the example code in that issue to make sure that the gradients are correct and to avoid regressions.