### PR TITLE
Hide the menubar and prevent resizing the window

### DIFF
--- a/drake/systems/visualizers/Visualizer.m
+++ b/drake/systems/visualizers/Visualizer.m
@@ -97,6 +97,8 @@ classdef Visualizer < DrakeSystem
       end
       f = sfigure(89);
       set(f, 'Visible', 'off');
+      set(f, 'MenuBar', 'none');
+      set(f, 'Resize', 'off');
       set(f, 'Position', [position(1:2), 560, 70]);
 
       tspan = xtraj.getBreaks();


### PR DESCRIPTION
As far as I can tell, the menubar serves no purpose here, and is a waste of screen space.

Since the controls don't resize with the windows, resizing is somewhat pointless too.