### PR TITLE
Modified runValueIteration example for Pendulum so figure does not st…

### DIFF
--- a/drake/examples/Pendulum/runValueIteration.m
+++ b/drake/examples/Pendulum/runValueIteration.m
@@ -11,7 +11,9 @@ ubins = linspace(-ulimit,ulimit,9);
 mdp = MarkovDecisionProcess.discretizeSystem(plant,cost,xbins,ubins,options);
 
 function drawfun(J,PI)
-  figure(2); clf;
+  fig = sfigure(2); 
+  set(fig, 'units', 'normalized', 'position', [.4 .1 .2 .75]);
+  clf;
   n1=length(xbins{1});
   n2=length(xbins{2});
   subplot(2,1,1);imagesc(xbins{1},xbins{2},reshape(ubins(PI),n1,n2)');

--- a/drake/examples/Pendulum/runValueIteration.m
+++ b/drake/examples/Pendulum/runValueIteration.m
@@ -12,6 +12,8 @@ mdp = MarkovDecisionProcess.discretizeSystem(plant,cost,xbins,ubins,options);
 
 function drawfun(J,PI)
   fig = sfigure(2); 
+  % figure size is hard-coded simply so that it is aesthetically pleasing.
+  % parameters for position set through trial-and-error.
   set(fig, 'units', 'normalized', 'position', [.4 .1 .2 .75]);
   clf;
   n1=length(xbins{1});


### PR DESCRIPTION
…eal focus and so that initial plot is at a reasonable aspect ratio.

(Didn't use `axis square` option because that prevents the user from resizing as they like).