### PR TITLE
Make generation of `coordinates` in CoordinateFrame lazy and adds testing

### DIFF
--- a/drake/systems/frames/CoordinateFrame.m
+++ b/drake/systems/frames/CoordinateFrame.m
@@ -15,8 +15,11 @@ classdef CoordinateFrame < handle
   properties (Access=private)
     coordinates={}; % list of coordinate names. must be kept
                     % private to ensure that lazy generation is
-                    % safe. furthermore, never access coordinates
-                    % directly, but rather use getCoordinateNames.
+                    % safe. 
+                    % WARNING: since coordinates are generated
+                    % lazily, never access coordinates
+                    % directly even from within the class. 
+                    % Use getCoordinateNames instead.
     poly=[];        % optional msspoly variables for this frame
   end
   
@@ -310,6 +313,9 @@ classdef CoordinateFrame < handle
     end
     
     function strs = getCoordinateNames(obj)
+      % getCoordinateNames encapsulates the lazy generation of the default
+      % coordinates. It may be worth considering making lazy values a
+      % separate class, but we're not doing this in this instance. 
       if isempty(obj.coordinates)
         obj.coordinates = CoordinateFrame.generateDefaultCoordinates(obj.prefix);
       end

--- a/drake/systems/frames/CoordinateFrame.m
+++ b/drake/systems/frames/CoordinateFrame.m
@@ -1,9 +1,9 @@
 classdef CoordinateFrame < handle
-% Every input, state, and output in a DynamicalSystem has a coordinate frame
-% attached to it.  Many bugs can be avoided by forcing developers to be
-% explicit about these coordinate systems when they make combinations of
-% systems.
-
+  % Every input, state, and output in a DynamicalSystem has a coordinate frame
+  % attached to it.  Many bugs can be avoided by forcing developers to be
+  % explicit about these coordinate systems when they make combinations of
+  % systems.
+  
   properties (SetAccess=private,GetAccess=public)
     name='';        % string name for this coordinate system
     dim=0;          % scalar dimension of this coordinate system
@@ -14,7 +14,7 @@ classdef CoordinateFrame < handle
     coordinates={}; % list of coordinate names
     poly=[];        % optional msspoly variables for this frame
   end
-
+  
   methods
     function obj=CoordinateFrame(name,dim,prefix,coordinates)
       % Constructs a new coordinate frame.
@@ -33,14 +33,15 @@ classdef CoordinateFrame < handle
       % where x is the prefix
       %
       % @retval obj the newly constructed CoordinateFrame
-
+      
       typecheck(name,'char');
       obj.name = name;
-
+      
       typecheck(dim,'double');
       sizecheck(dim,[1 1]);
       obj.dim = dim;
-
+      
+      % generating object prefix
       if (nargin<3 || isempty(prefix))
         ind = strfind(name,':');
         if isempty(ind)
@@ -57,7 +58,8 @@ classdef CoordinateFrame < handle
           obj.prefix = prefix(:);
         end
       end
-               
+      
+      % generating object coordinates (i.e. list of coordinate names)
       if (nargin < 4 || isempty(coordinates))
         obj.coordinates=CoordinateFrame.generateDefaultCoordinates(obj.prefix);
       else
@@ -71,12 +73,12 @@ classdef CoordinateFrame < handle
         obj.coordinates = {coordinates{:}}';
       end
     end
-       
+    
     function tf = hasSamePrefix(frame1,frame2)
       % useful for alarming on a possible prefix clash between two polys
       tf = any(any(bsxfun(@eq,frame1.prefix,frame2.prefix')));
     end
-
+    
     function p = getPoly(obj)
       % create the poly now if it hasn't been created yet
       if obj.dim>0 && isempty(obj.poly)
@@ -93,14 +95,14 @@ classdef CoordinateFrame < handle
       end
       p = obj.poly;
     end
-
+    
     function disp(obj)
       fprintf(1,'Coordinate Frame: %s (%d elements)\n',obj.name,obj.dim);
       for i=1:obj.dim
-        fprintf(1,'  %s\n',obj.coordinates{i});
+        fprintf(1,'  %s\n',obj.getCoordinateName(i));
       end
     end
-
+    
     function tf = isequal_modulo_transforms(a,b)
       % returns true if the two coordinate frames are the same.
       % the "modulo transforms" refers to the fact that two identical
@@ -111,13 +113,13 @@ classdef CoordinateFrame < handle
         isequal(a.coordinates,b.coordinates) && ...
         isequal(a.prefix,b.prefix);
     end
-
+    
     function s = getSym(obj)
       for i=1:length(obj.dim)
-        s(1) = sym(obj.coordinates{i},'real');
+        s(1) = sym(obj.getCoordinateName(i),'real');
       end
     end
-
+    
     function addTransform(obj,transform,bforce)
       % Attaches a new coordinate transform from the current frame to a
       % different frame. An error is throw if there already exists any
@@ -130,7 +132,7 @@ classdef CoordinateFrame < handle
       % search for existing transforms).  This was added to optimize
       % transform addition for the case when we are sure that no transform
       % already exists.  Use with caution.
-
+      
       typecheck(transform,'CoordinateTransform');
       if (nargin<3) bforce = false; end
       if (getInputFrame(transform) ~= obj || getOutputFrame(transform) == obj)
@@ -140,15 +142,15 @@ classdef CoordinateFrame < handle
         error('Drake:CoordinateFrame:ExistingTransform','i already have a transform that gets me to that frame');
       end
       obj.transforms{end+1}=transform;
-%      drawFrameGraph(obj); keyboard;
+      %      drawFrameGraph(obj); keyboard;
     end
-
+    
     function updateTransform(obj,newtransform)
       % find a current transform with the same target frame and replace it
       % with the new transform.  this only searches simple transforms (from
       % the current frame to the output frame), not multi-hop transforms
       % through multiple frames.
-
+      
       typecheck(newtransform,'CoordinateTransform');
       ind=find(cellfun(@(a)getOutputFrame(a)==newtransform.getOutputFrame,obj.transforms));
       if (isempty(ind))
@@ -159,7 +161,7 @@ classdef CoordinateFrame < handle
         obj.transforms{ind}=newtransform;
       end
     end
-
+    
     function addProjectionTransformByCoordinateNames(fr,fr2,fr2_defaultvals)
       % adds a transform from fr to fr2 which copies over the dimensions
       % with matching coordinate names, and sets the remaining elements of
@@ -170,7 +172,7 @@ classdef CoordinateFrame < handle
       % @param fr2_defaultvals a double vector or Point which specifies the
       % constant values of the elements in fr2 which do not get mapped from
       % fr
-
+      
       typecheck(fr2,'CoordinateFrame');
       if (nargin<3)
         fr2_defaultvals = Point(fr2);
@@ -183,29 +185,29 @@ classdef CoordinateFrame < handle
       if (fr2_defaultvals.getFrame()~=fr2)
         error('default values must be in the fr2 frame');
       end
-
+      
       [lia,locb] = ismember(fr2.coordinates,fr.coordinates);
       T = sparse(find(lia),locb(locb>0),1,fr2.dim,fr.dim);
       b = double(fr2_defaultvals); b(lia)=0;
       tf = AffineTransform(fr,fr2,T,b);
-
+      
       addTransform(fr,tf);
     end
-
+    
     function drawFrameGraph(obj)
       % Calls graphviz to visualize this frame plus all other frames that
       % are reachable by some (potentially multi-hop) transform.
       %
       % Note: requires that graphviz dot is installed on the system
-
+      
       [A,fr] = extractFrameGraph(obj);
-
+      
       if (size(A,1)<length(A)) A(length(A),end)=0; end
       if (size(A,2)<length(A)) A(end,length(A))=0; end
       drawGraph(A,cellfun(@(a) a.name,fr,'UniformOutput',false));
     end
-
-
+    
+    
     function [tf,options]=findTransform(obj,target,options)
       % Performs a simple breadth-first search of all available multi-hop
       % transforms for a transformation from the current frame to the
@@ -224,7 +226,7 @@ classdef CoordinateFrame < handle
       % this output enables recursive calls to the function, and is
       % intended only for internal use.
       %
-
+      
       if (obj==target)
         % note: it's tempting to replace this with
         % isequal_modulo_transforms, but I think it's more appropriate to
@@ -234,10 +236,10 @@ classdef CoordinateFrame < handle
         tf = ConstOrPassthroughSystem(repmat(nan,obj.dim,1),obj.dim);
         return;
       end
-
+      
       if (nargin<3) options=struct(); end
       if ~isfield(options,'throw_error_if_fail') options.throw_error_if_fail = false; end
-
+      
       typecheck(target,'CoordinateFrame');
       ind=find(cellfun(@(a)getOutputFrame(a)==target,obj.transforms));
       if isempty(ind)
@@ -245,30 +247,30 @@ classdef CoordinateFrame < handle
         if ~isfield(options,'dirty_list') options.dirty_list=[]; end
         if ~isfield(options,'queue') options.queue=[]; end
         if ~isfield(options,'tf_from_parent') options.tf_from_parent=[]; end
-
+        
         tf=[];
         if (options.depth>1)
           options.depth = options.depth-1;
-
+          
           % add myself to the dirty list
           options.dirty_list = horzcat(options.dirty_list, struct('frame',obj,'tf_from_parent',options.tf_from_parent));
-
+          
           % add my children to the queue
           options.queue = horzcat(options.queue,struct('frame',cellfun(@getOutputFrame,obj.transforms,'UniformOutput',false),'tf_from_parent',obj.transforms));
-
+          
           % now check the queue for a match
           while isempty(tf) && ~isempty(options.queue)
             a = options.queue(1);
             options.queue = options.queue(2:end);
-
+            
             if ismember(a.frame,{options.dirty_list(:).frame})
               continue;
             end
-
+            
             options.tf_from_parent = a.tf_from_parent;
             [tf,options] = findTransform(a.frame,target,options);
           end
-
+          
           if ~isempty(tf)  % then reconstruct tf chain
             parent = options.tf_from_parent;
             while ~isempty(parent)
@@ -279,7 +281,7 @@ classdef CoordinateFrame < handle
             return;
           end
         end
-
+        
         if (nargin>2 && options.throw_error_if_fail)
           error(['Could not find any transform between ',obj.name,' and ', target.name]);
         end
@@ -289,51 +291,54 @@ classdef CoordinateFrame < handle
         tf=obj.transforms{ind};
       end
     end
-
+    
     function str = getCoordinateName(obj,i)
-      str = obj.coordinates{i};
+      str = obj.getCoordinateNames{i};
     end
-
+    
     function ind = findCoordinateIndex(obj,varname)
-      ind = find(strcmp(varname,obj.coordinates));
+      ind = find(strcmp(varname,obj.getCoordinateNames));
     end
-
+    
     function strs = getCoordinateNames(obj)
+      if isempty(obj.coordinates)
+        obj.coordinates = generateDefaultCoordinates(obj.prefix);
+      end
       strs = obj.coordinates;
     end
-
+    
     function setCoordinateNames(obj,cnames)
       % Updates the coordinate names
       %
       % @param cnames must be a cell array vector of length dim populated
       % with strings
       %
-
+      
       if (iscellstr(cnames) && isvector(cnames) && length(cnames)==obj.dim)
         obj.coordinates=cnames;
       else
         error('cnames must be a cell vector of length dim populated with strings');
       end
     end
-
+    
     function fr=subFrame(obj,dims)
       % Extracts a new frame with a subset of the original variables, so that
-      % fr.coordinates = obj.coordinates(dims)
+      % fr.coordinates = obj.getCoordinateName(dims)
       %
-      % @param dims a numeric vector of index values such that fr.coordinates = obj.coordinates(dims)
+      % @param dims a numeric vector of index values such that fr.coordinates = obj.getCoordinateName(dims)
       %
       % @retval the newly constructed frame
       %
-
+      
       if ~isnumeric(dims) || ~isvector(dims) error('dims must be a numeric vector'); end
       if (any(dims>obj.dim | dims<1)) error(['dims must be between 1 and ',obj.dim]); end
       fr = CoordinateFrame([obj.name,mat2str(dims)], length(dims), obj.prefix(dims));
-      fr.coordinates = obj.coordinates(dims);
+      fr.coordinates = obj.getCoordinateName(dims);
       if ~isempty(fr.poly)
         fr.poly = obj.poly(dims);
       end
     end
-
+    
     function fr=constructFrameWithAnglesWrapped(obj,angle_flag,q0)
       % produces a copy of the current frame, but with a transform placed
       % between them that wraps the angles around 2pi.  The transform wraps all
@@ -345,9 +350,9 @@ classdef CoordinateFrame < handle
       % @param q0 double vector of with the default angle around which to
       % perform the wrapping.  it should be the length of the number of
       % wrapped angles (e.g., so that x(angle_flags) = q0).
-
-      fr = CoordinateFrame([obj.name,'Wrapped'],obj.dim,obj.prefix,obj.coordinates);
-
+      
+      fr = CoordinateFrame([obj.name,'Wrapped'],obj.dim,obj.prefix,obj.getCoordinateNames);
+      
       if (nargin>2)
         obj.addTransform(AngleWrappingTransform(obj,fr,angle_flag,q0));
       else
@@ -355,19 +360,19 @@ classdef CoordinateFrame < handle
       end
       fr.addTransform(AffineTransform(fr,obj,eye(obj.dim),zeros(obj.dim,1)));
     end
-
+    
     function scope(obj,t,val,options)
       % publishes coordinate information to the lcm scope
       if (nargin<4) options=struct(); end
       for i=1:length(obj.dim)
-        scope(obj.name,obj.coordinates{i},t,val(i),options);
+        scope(obj.name,obj.getCoordinateName(i),t,val(i),options);
       end
     end
-
+    
     function generateLCMType(obj,robot_name,signal_name)
       % writes an lcm type specification to file from the coordinate frame
       % description. not to be used frequently.
-
+      
       if (nargin<3)
         name = lower(obj.name);
       else
@@ -377,11 +382,11 @@ classdef CoordinateFrame < handle
       fname = [typename,'.lcm'];
       if strcmpi(input(['About to write file ',fname,' .  Should I proceed (y/n)? '],'s'),'y')
         fptr=fopen(fname,'w');
-
+        
         fprintf(fptr,'// Note: this file was automatically generated using the\n// CoordinateFrame.generateLCMType() method.\n\n');
         fprintf(fptr,'struct %s\n{\n  int64_t timestamp;\n\n',typename);
         for i=1:obj.dim
-          fprintf(fptr,'  double %s;\n',CoordinateFrame.stripSpecialChars(obj.coordinates{i}));
+          fprintf(fptr,'  double %s;\n',CoordinateFrame.stripSpecialChars(obj.getCoordinateName(i)));
         end
         fprintf(fptr,'}\n\n');
         fclose(fptr);
@@ -389,29 +394,29 @@ classdef CoordinateFrame < handle
       end
     end
   end
-
+  
   methods  % some functions which help operations MultiCoordinateFrames
     function n = getNumFrames(obj)
       n = 1;
     end
-
+    
     function fr = getFrameByNum(obj,n)
       if (n==1) fr = obj; else error('bad frame num'); end
     end
-
+    
     function id = getFrameNum(obj,fr)
       if (fr==obj) id=1;
       else error('Drake:CoordinateFrame:NoFrame', 'can''t find frame %s',fr.name); end
     end
-
+    
     function insys=setupMultiInput(obj,mdl,subsys)
       insys=subsys;
     end
-
+    
     function outsys=setupMultiOutput(obj,mdl,subsys)
       outsys=subsys;
     end
-
+    
     function setupLCMInputs(obj,mdl,subsys,subsys_portnum,options)
       typecheck(mdl,{'char','SimulinkModelHandle'});
       typecheck(subsys,'char');
@@ -421,7 +426,7 @@ classdef CoordinateFrame < handle
       add_block('simulink3/Sources/In1',[mdl,'/in',uid]);
       add_line(mdl,['in',uid,'/1'],[subsys,'/',num2str(subsys_portnum)]);
     end
-
+    
     function setupLCMOutputs(obj,mdl,subsys,subsys_portnum,options)
       typecheck(mdl,{'char','SimulinkModelHandle'});
       typecheck(subsys,'char');
@@ -431,13 +436,13 @@ classdef CoordinateFrame < handle
       add_block('simulink3/Sources/Terminator',[mdl,'/terminator',uid]);
       add_line(mdl,[subsys,'/',num2str(subsys_portnum)],['terminator',uid,'/1']);
     end
-
+    
     function connection = autoConnect(fr1,fr2,connection)
       % populates the connection structure as used in mimoCascade and
       % mimoFeedback
       % if connection is passed in, then it simply attempts to validate the
       % connection.
-
+      
       if nargin>2 && ~isempty(connection)
         typecheck(connection,'struct');
         if ~isempty(setxor(fieldnames(connection),{'from_output','to_input'}))
@@ -479,9 +484,9 @@ classdef CoordinateFrame < handle
         end
       end
     end
-
+    
   end
-
+  
   methods (Access=protected)
     function [tf,loc]=ismember(obj,cell_of_frames)
       % helper method for searching transforms
@@ -490,13 +495,13 @@ classdef CoordinateFrame < handle
       tf = ~isempty(loc);
     end
   end
-
+  
   methods (Access=protected)
     function [A,fr] = extractFrameGraph(obj)
       A = 0;
       fr = {obj};
       [A,fr]=recurseTFs(obj,A,fr);
-
+      
       function [A,fr]=recurseTFs(obj,A,fr)
         [~,ind]=ismember(obj,fr);
         children = cellfun(@getOutputFrame,obj.transforms,'UniformOutput',false);
@@ -514,24 +519,22 @@ classdef CoordinateFrame < handle
       end
     end
   end
-
+  
   methods (Static=true,Hidden=true)
     function s=stripSpecialChars(s)
       s=regexprep(s,'\\','');
     end
-  end
-  
-  methods (Static)
-      function coordinates = generateDefaultCoordinates(prefix)
-          % generates the default coordinate labels for a coordinate Frame
-          % when no value is passed in, based on the prefixes provided.
+    
+    function coordinates = generateDefaultCoordinates(prefix)
+      % generates the default coordinate labels for a coordinate Frame
+      % when no value is passed in, based on the prefixes provided.
       ind=1;
       [dim, ~] = size(prefix);
       function str=coordinateName(~)
-          str=[prefix(ind),sprintf('%d',sum(prefix(1:ind)==prefix(ind)))];
-          ind=ind+1;
+        str=[prefix(ind),sprintf('%d',sum(prefix(1:ind)==prefix(ind)))];
+        ind=ind+1;
       end
       coordinates = cellfun(@coordinateName,cell(dim,1),'UniformOutput',false);
-      end
+    end
   end
 end

--- a/drake/systems/frames/CoordinateFrame.m
+++ b/drake/systems/frames/CoordinateFrame.m
@@ -342,8 +342,8 @@ classdef CoordinateFrame < handle
       if ~isnumeric(dims) || ~isvector(dims) error('dims must be a numeric vector'); end
       if (any(dims>obj.dim | dims<1)) error(['dims must be between 1 and ',obj.dim]); end
       fr = CoordinateFrame([obj.name,mat2str(dims)], length(dims), obj.prefix(dims));
-      coordinates = obj.getCoordinateNames;
-      fr.coordinates = coordinates(dims);
+      current_frame_coordinates = obj.getCoordinateNames;
+      fr.coordinates = current_frame_coordinates(dims);
       if ~isempty(fr.poly)
         fr.poly = obj.poly(dims);
       end

--- a/drake/systems/frames/CoordinateFrame.m
+++ b/drake/systems/frames/CoordinateFrame.m
@@ -315,7 +315,12 @@ classdef CoordinateFrame < handle
     function strs = getCoordinateNames(obj)
       % getCoordinateNames encapsulates the lazy generation of the default
       % coordinates. It may be worth considering making lazy values a
-      % separate class, but we're not doing this in this instance. 
+      % separate class; this would be advantageous in terms of making 
+      % access to obj.coordinates even safer, rather than relying on future
+      % programmers to be careful enough to get the value of 
+      % obj.coordinates only via getCoordinateNames. 
+      % I'm not doing this in this instance since it's unclear how useful
+      % lazy values would be.
       if isempty(obj.coordinates)
         obj.coordinates = CoordinateFrame.generateDefaultCoordinates(obj.prefix);
       end

--- a/drake/systems/frames/CoordinateFrame.m
+++ b/drake/systems/frames/CoordinateFrame.m
@@ -154,7 +154,7 @@ classdef CoordinateFrame < handle
         error('Drake:CoordinateFrame:ExistingTransform','i already have a transform that gets me to that frame');
       end
       obj.transforms{end+1}=transform;
-      %      drawFrameGraph(obj); keyboard;
+%      drawFrameGraph(obj); keyboard;
     end
 
     function updateTransform(obj,newtransform)
@@ -269,7 +269,7 @@ classdef CoordinateFrame < handle
 
           % add my children to the queue
           options.queue = horzcat(options.queue,struct('frame',cellfun(@getOutputFrame,obj.transforms,'UniformOutput',false),'tf_from_parent',obj.transforms));
-  
+
           % now check the queue for a match
           while isempty(tf) && ~isempty(options.queue)
             a = options.queue(1);
@@ -282,7 +282,7 @@ classdef CoordinateFrame < handle
             options.tf_from_parent = a.tf_from_parent;
             [tf,options] = findTransform(a.frame,target,options);
           end
-  
+
           if ~isempty(tf)  % then reconstruct tf chain
             parent = options.tf_from_parent;
             while ~isempty(parent)
@@ -403,7 +403,7 @@ classdef CoordinateFrame < handle
       fname = [typename,'.lcm'];
       if strcmpi(input(['About to write file ',fname,' .  Should I proceed (y/n)? '],'s'),'y')
         fptr=fopen(fname,'w');
-  
+
         fprintf(fptr,'// Note: this file was automatically generated using the\n// CoordinateFrame.generateLCMType() method.\n\n');
         fprintf(fptr,'struct %s\n{\n  int64_t timestamp;\n\n',typename);
         for i=1:obj.dim
@@ -415,7 +415,7 @@ classdef CoordinateFrame < handle
       end
     end
   end
-  
+
   methods  % some functions which help operations MultiCoordinateFrames
     function n = getNumFrames(obj)
       n = 1;
@@ -505,9 +505,9 @@ classdef CoordinateFrame < handle
         end
       end
     end
-  
+
   end
-  
+
   methods (Access=protected)
     function [tf,loc]=ismember(obj,cell_of_frames)
       % helper method for searching transforms
@@ -516,7 +516,7 @@ classdef CoordinateFrame < handle
       tf = ~isempty(loc);
     end
   end
-  
+
   methods (Access=protected)
     function [A,fr] = extractFrameGraph(obj)
       A = 0;
@@ -540,7 +540,7 @@ classdef CoordinateFrame < handle
       end
     end
   end
-  
+
   methods (Static=true,Hidden=true)
     function s=stripSpecialChars(s)
       s=regexprep(s,'\\','');

--- a/drake/systems/frames/CoordinateFrame.m
+++ b/drake/systems/frames/CoordinateFrame.m
@@ -8,11 +8,15 @@ classdef CoordinateFrame < handle
     name='';        % string name for this coordinate system
     dim=0;          % scalar dimension of this coordinate system
     transforms={};  % handles to CoordinateTransform objects
-    prefix;         % a vector character prefix used for the msspoly variables, or a vector of size dim listing prefixes for each variable
+    prefix;         % a vector character prefix used for the
+                    % msspoly variables, or a vector of size dim
+                    % listing prefixes for each variable
   end
   properties (Access=private)
     coordinates={}; % list of coordinate names. must be kept
-                    % private to ensure that lazy generation is safe.
+                    % private to ensure that lazy generation is
+                    % safe. furthermore, never access coordinates
+                    % directly, but rather use getCoordinateNames.
     poly=[];        % optional msspoly variables for this frame
   end
   
@@ -115,7 +119,7 @@ classdef CoordinateFrame < handle
       % C, but A does not.
       tf = isequal(a.name,b.name) && ...
         isequal(a.dim,b.dim) && ...
-        isequal(a.coordinates,b.coordinates) && ...
+        isequal(a.getCoordinateNames,b.getCoordinateNames) && ...
         isequal(a.prefix,b.prefix);
     end
     
@@ -191,7 +195,7 @@ classdef CoordinateFrame < handle
         error('default values must be in the fr2 frame');
       end
       
-      [lia,locb] = ismember(fr2.coordinates,fr.coordinates);
+      [lia,locb] = ismember(fr2.getCoordinateNames,fr.getCoordinateNames);
       T = sparse(find(lia),locb(locb>0),1,fr2.dim,fr.dim);
       b = double(fr2_defaultvals); b(lia)=0;
       tf = AffineTransform(fr,fr2,T,b);

--- a/drake/systems/frames/CoordinateFrame.m
+++ b/drake/systems/frames/CoordinateFrame.m
@@ -1,9 +1,9 @@
 classdef CoordinateFrame < handle
-  % Every input, state, and output in a DynamicalSystem has a coordinate frame
-  % attached to it.  Many bugs can be avoided by forcing developers to be
-  % explicit about these coordinate systems when they make combinations of
-  % systems.
-  
+% Every input, state, and output in a DynamicalSystem has a coordinate frame
+% attached to it.  Many bugs can be avoided by forcing developers to be
+% explicit about these coordinate systems when they make combinations of
+% systems.
+
   properties (SetAccess=private,GetAccess=public)
     name='';        % string name for this coordinate system
     dim=0;          % scalar dimension of this coordinate system
@@ -22,7 +22,7 @@ classdef CoordinateFrame < handle
                     % Use getCoordinateNames instead.
     poly=[];        % optional msspoly variables for this frame
   end
-  
+
   methods
     function obj=CoordinateFrame(name,dim,prefix,coordinates)
       % Constructs a new coordinate frame.
@@ -41,14 +41,14 @@ classdef CoordinateFrame < handle
       % where x is the prefix
       %
       % @retval obj the newly constructed CoordinateFrame
-      
+
       typecheck(name,'char');
       obj.name = name;
-      
+
       typecheck(dim,'double');
       sizecheck(dim,[1 1]);
       obj.dim = dim;
-      
+
       % generating object prefix
       if (nargin<3 || isempty(prefix))
         ind = strfind(name,':');
@@ -66,7 +66,7 @@ classdef CoordinateFrame < handle
           obj.prefix = prefix(:);
         end
       end
-           
+
       if (nargin < 4 || isempty(coordinates))
         % we do not generate the default coordinate values here;
         % the values are only generated if the coordinate values
@@ -85,12 +85,12 @@ classdef CoordinateFrame < handle
         obj.coordinates = {coordinates{:}}';
       end
     end
-    
+
     function tf = hasSamePrefix(frame1,frame2)
       % useful for alarming on a possible prefix clash between two polys
       tf = any(any(bsxfun(@eq,frame1.prefix,frame2.prefix')));
     end
-    
+
     function p = getPoly(obj)
       % create the poly now if it hasn't been created yet
       if obj.dim>0 && isempty(obj.poly)
@@ -107,14 +107,14 @@ classdef CoordinateFrame < handle
       end
       p = obj.poly;
     end
-    
+
     function disp(obj)
       fprintf(1,'Coordinate Frame: %s (%d elements)\n',obj.name,obj.dim);
       for i=1:obj.dim
         fprintf(1,'  %s\n',obj.getCoordinateName(i));
       end
     end
-    
+
     function tf = isequal_modulo_transforms(a,b)
       % returns true if the two coordinate frames are the same.
       % the "modulo transforms" refers to the fact that two identical
@@ -125,13 +125,13 @@ classdef CoordinateFrame < handle
         isequal(a.getCoordinateNames,b.getCoordinateNames) && ...
         isequal(a.prefix,b.prefix);
     end
-    
+
     function s = getSym(obj)
       for i=1:length(obj.dim)
         s(1) = sym(obj.getCoordinateName(i),'real');
       end
     end
-    
+
     function addTransform(obj,transform,bforce)
       % Attaches a new coordinate transform from the current frame to a
       % different frame. An error is throw if there already exists any
@@ -144,7 +144,7 @@ classdef CoordinateFrame < handle
       % search for existing transforms).  This was added to optimize
       % transform addition for the case when we are sure that no transform
       % already exists.  Use with caution.
-      
+
       typecheck(transform,'CoordinateTransform');
       if (nargin<3) bforce = false; end
       if (getInputFrame(transform) ~= obj || getOutputFrame(transform) == obj)
@@ -156,13 +156,13 @@ classdef CoordinateFrame < handle
       obj.transforms{end+1}=transform;
       %      drawFrameGraph(obj); keyboard;
     end
-    
+
     function updateTransform(obj,newtransform)
       % find a current transform with the same target frame and replace it
       % with the new transform.  this only searches simple transforms (from
       % the current frame to the output frame), not multi-hop transforms
       % through multiple frames.
-      
+
       typecheck(newtransform,'CoordinateTransform');
       ind=find(cellfun(@(a)getOutputFrame(a)==newtransform.getOutputFrame,obj.transforms));
       if (isempty(ind))
@@ -173,7 +173,7 @@ classdef CoordinateFrame < handle
         obj.transforms{ind}=newtransform;
       end
     end
-    
+
     function addProjectionTransformByCoordinateNames(fr,fr2,fr2_defaultvals)
       % adds a transform from fr to fr2 which copies over the dimensions
       % with matching coordinate names, and sets the remaining elements of
@@ -184,7 +184,7 @@ classdef CoordinateFrame < handle
       % @param fr2_defaultvals a double vector or Point which specifies the
       % constant values of the elements in fr2 which do not get mapped from
       % fr
-      
+
       typecheck(fr2,'CoordinateFrame');
       if (nargin<3)
         fr2_defaultvals = Point(fr2);
@@ -197,29 +197,29 @@ classdef CoordinateFrame < handle
       if (fr2_defaultvals.getFrame()~=fr2)
         error('default values must be in the fr2 frame');
       end
-      
+
       [lia,locb] = ismember(fr2.getCoordinateNames,fr.getCoordinateNames);
       T = sparse(find(lia),locb(locb>0),1,fr2.dim,fr.dim);
       b = double(fr2_defaultvals); b(lia)=0;
       tf = AffineTransform(fr,fr2,T,b);
-      
+
       addTransform(fr,tf);
     end
-    
+
     function drawFrameGraph(obj)
       % Calls graphviz to visualize this frame plus all other frames that
       % are reachable by some (potentially multi-hop) transform.
       %
       % Note: requires that graphviz dot is installed on the system
-      
+
       [A,fr] = extractFrameGraph(obj);
-      
+
       if (size(A,1)<length(A)) A(length(A),end)=0; end
       if (size(A,2)<length(A)) A(end,length(A))=0; end
       drawGraph(A,cellfun(@(a) a.name,fr,'UniformOutput',false));
     end
-    
-    
+
+
     function [tf,options]=findTransform(obj,target,options)
       % Performs a simple breadth-first search of all available multi-hop
       % transforms for a transformation from the current frame to the
@@ -238,7 +238,7 @@ classdef CoordinateFrame < handle
       % this output enables recursive calls to the function, and is
       % intended only for internal use.
       %
-      
+
       if (obj==target)
         % note: it's tempting to replace this with
         % isequal_modulo_transforms, but I think it's more appropriate to
@@ -248,10 +248,10 @@ classdef CoordinateFrame < handle
         tf = ConstOrPassthroughSystem(repmat(nan,obj.dim,1),obj.dim);
         return;
       end
-      
+
       if (nargin<3) options=struct(); end
       if ~isfield(options,'throw_error_if_fail') options.throw_error_if_fail = false; end
-      
+
       typecheck(target,'CoordinateFrame');
       ind=find(cellfun(@(a)getOutputFrame(a)==target,obj.transforms));
       if isempty(ind)
@@ -259,30 +259,30 @@ classdef CoordinateFrame < handle
         if ~isfield(options,'dirty_list') options.dirty_list=[]; end
         if ~isfield(options,'queue') options.queue=[]; end
         if ~isfield(options,'tf_from_parent') options.tf_from_parent=[]; end
-        
+
         tf=[];
         if (options.depth>1)
           options.depth = options.depth-1;
-          
+
           % add myself to the dirty list
           options.dirty_list = horzcat(options.dirty_list, struct('frame',obj,'tf_from_parent',options.tf_from_parent));
-          
+
           % add my children to the queue
           options.queue = horzcat(options.queue,struct('frame',cellfun(@getOutputFrame,obj.transforms,'UniformOutput',false),'tf_from_parent',obj.transforms));
-          
+  
           % now check the queue for a match
           while isempty(tf) && ~isempty(options.queue)
             a = options.queue(1);
             options.queue = options.queue(2:end);
-            
+
             if ismember(a.frame,{options.dirty_list(:).frame})
               continue;
             end
-            
+
             options.tf_from_parent = a.tf_from_parent;
             [tf,options] = findTransform(a.frame,target,options);
           end
-          
+  
           if ~isempty(tf)  % then reconstruct tf chain
             parent = options.tf_from_parent;
             while ~isempty(parent)
@@ -293,7 +293,7 @@ classdef CoordinateFrame < handle
             return;
           end
         end
-        
+
         if (nargin>2 && options.throw_error_if_fail)
           error(['Could not find any transform between ',obj.name,' and ', target.name]);
         end
@@ -303,15 +303,15 @@ classdef CoordinateFrame < handle
         tf=obj.transforms{ind};
       end
     end
-    
+
     function str = getCoordinateName(obj,i)
       str = obj.getCoordinateNames{i};
     end
-    
+
     function ind = findCoordinateIndex(obj,varname)
       ind = find(strcmp(varname,obj.getCoordinateNames));
     end
-    
+
     function strs = getCoordinateNames(obj)
       % getCoordinateNames encapsulates the lazy generation of the default
       % coordinates. It may be worth considering making lazy values a
@@ -326,21 +326,21 @@ classdef CoordinateFrame < handle
       end
       strs = obj.coordinates;
     end
-    
+
     function setCoordinateNames(obj,cnames)
       % Updates the coordinate names
       %
       % @param cnames must be a cell array vector of length dim populated
       % with strings
       %
-      
+
       if (iscellstr(cnames) && isvector(cnames) && length(cnames)==obj.dim)
         obj.coordinates=cnames;
       else
         error('cnames must be a cell vector of length dim populated with strings');
       end
     end
-    
+
     function fr=subFrame(obj,dims)
       % Extracts a new frame with a subset of the original variables, so that
       % fr.coordinates = obj.coordinates(dims)
@@ -349,7 +349,7 @@ classdef CoordinateFrame < handle
       %
       % @retval the newly constructed frame
       %
-      
+
       if ~isnumeric(dims) || ~isvector(dims) error('dims must be a numeric vector'); end
       if (any(dims>obj.dim | dims<1)) error(['dims must be between 1 and ',obj.dim]); end
       fr = CoordinateFrame([obj.name,mat2str(dims)], length(dims), obj.prefix(dims));
@@ -359,7 +359,7 @@ classdef CoordinateFrame < handle
         fr.poly = obj.poly(dims);
       end
     end
-    
+
     function fr=constructFrameWithAnglesWrapped(obj,angle_flag,q0)
       % produces a copy of the current frame, but with a transform placed
       % between them that wraps the angles around 2pi.  The transform wraps all
@@ -371,9 +371,9 @@ classdef CoordinateFrame < handle
       % @param q0 double vector of with the default angle around which to
       % perform the wrapping.  it should be the length of the number of
       % wrapped angles (e.g., so that x(angle_flags) = q0).
-      
+
       fr = CoordinateFrame([obj.name,'Wrapped'],obj.dim,obj.prefix,obj.getCoordinateNames);
-      
+
       if (nargin>2)
         obj.addTransform(AngleWrappingTransform(obj,fr,angle_flag,q0));
       else
@@ -381,7 +381,7 @@ classdef CoordinateFrame < handle
       end
       fr.addTransform(AffineTransform(fr,obj,eye(obj.dim),zeros(obj.dim,1)));
     end
-    
+
     function scope(obj,t,val,options)
       % publishes coordinate information to the lcm scope
       if (nargin<4) options=struct(); end
@@ -389,11 +389,11 @@ classdef CoordinateFrame < handle
         scope(obj.name,obj.getCoordinateName(i),t,val(i),options);
       end
     end
-    
+
     function generateLCMType(obj,robot_name,signal_name)
       % writes an lcm type specification to file from the coordinate frame
       % description. not to be used frequently.
-      
+
       if (nargin<3)
         name = lower(obj.name);
       else
@@ -403,7 +403,7 @@ classdef CoordinateFrame < handle
       fname = [typename,'.lcm'];
       if strcmpi(input(['About to write file ',fname,' .  Should I proceed (y/n)? '],'s'),'y')
         fptr=fopen(fname,'w');
-        
+  
         fprintf(fptr,'// Note: this file was automatically generated using the\n// CoordinateFrame.generateLCMType() method.\n\n');
         fprintf(fptr,'struct %s\n{\n  int64_t timestamp;\n\n',typename);
         for i=1:obj.dim
@@ -420,24 +420,24 @@ classdef CoordinateFrame < handle
     function n = getNumFrames(obj)
       n = 1;
     end
-    
+
     function fr = getFrameByNum(obj,n)
       if (n==1) fr = obj; else error('bad frame num'); end
     end
-    
+
     function id = getFrameNum(obj,fr)
       if (fr==obj) id=1;
       else error('Drake:CoordinateFrame:NoFrame', 'can''t find frame %s',fr.name); end
     end
-    
+
     function insys=setupMultiInput(obj,mdl,subsys)
       insys=subsys;
     end
-    
+
     function outsys=setupMultiOutput(obj,mdl,subsys)
       outsys=subsys;
     end
-    
+
     function setupLCMInputs(obj,mdl,subsys,subsys_portnum,options)
       typecheck(mdl,{'char','SimulinkModelHandle'});
       typecheck(subsys,'char');
@@ -447,7 +447,7 @@ classdef CoordinateFrame < handle
       add_block('simulink3/Sources/In1',[mdl,'/in',uid]);
       add_line(mdl,['in',uid,'/1'],[subsys,'/',num2str(subsys_portnum)]);
     end
-    
+
     function setupLCMOutputs(obj,mdl,subsys,subsys_portnum,options)
       typecheck(mdl,{'char','SimulinkModelHandle'});
       typecheck(subsys,'char');
@@ -457,13 +457,13 @@ classdef CoordinateFrame < handle
       add_block('simulink3/Sources/Terminator',[mdl,'/terminator',uid]);
       add_line(mdl,[subsys,'/',num2str(subsys_portnum)],['terminator',uid,'/1']);
     end
-    
+
     function connection = autoConnect(fr1,fr2,connection)
       % populates the connection structure as used in mimoCascade and
       % mimoFeedback
       % if connection is passed in, then it simply attempts to validate the
       % connection.
-      
+
       if nargin>2 && ~isempty(connection)
         typecheck(connection,'struct');
         if ~isempty(setxor(fieldnames(connection),{'from_output','to_input'}))
@@ -505,7 +505,7 @@ classdef CoordinateFrame < handle
         end
       end
     end
-    
+  
   end
   
   methods (Access=protected)
@@ -522,7 +522,7 @@ classdef CoordinateFrame < handle
       A = 0;
       fr = {obj};
       [A,fr]=recurseTFs(obj,A,fr);
-      
+
       function [A,fr]=recurseTFs(obj,A,fr)
         [~,ind]=ismember(obj,fr);
         children = cellfun(@getOutputFrame,obj.transforms,'UniformOutput',false);
@@ -545,7 +545,7 @@ classdef CoordinateFrame < handle
     function s=stripSpecialChars(s)
       s=regexprep(s,'\\','');
     end
-    
+
     function coordinates = generateDefaultCoordinates(prefix)
       % generates the default coordinate labels for a coordinate Frame
       % when no value is passed in, based on the prefixes provided.

--- a/drake/systems/frames/test/CoordinateFrameCoordinatesTest.m
+++ b/drake/systems/frames/test/CoordinateFrameCoordinatesTest.m
@@ -1,0 +1,31 @@
+classdef CoordinateFrameCoordinatesTest < matlab.unittest.TestCase
+  %NOTEST
+  methods (Test)
+    
+    
+    function testSpecifiedCoordinateNames (testCase)
+      
+      % tests that we can work with the coordinate names of a CoordinateFrame
+      
+      f_set = CoordinateFrame('test1', 4, 'y', {'a', 'b', 'c', 'd'}); % coordinate names are set
+      testCase.assertEqual(f_set.getCoordinateName(2), 'b');
+      testCase.assertEqual(f_set.findCoordinateIndex('b'), 2);
+      testCase.assertEqual(f_set.getCoordinateNames, {'a', 'b', 'c', 'd'}');
+      
+      expectedSubFrame = f_set.subFrame([1 3]);
+      actualSubFrame = CoordinateFrame('test1[1 3]', 2, ['y', 'y'], {'a', 'c'});
+      testCase.assertEqual(expectedSubFrame, actualSubFrame);
+      
+    end
+    
+    function testGeneratedCoordinateNames (testCase)
+      f_generated = CoordinateFrame('test2', 4, 'z'); % coordinate names generated
+      testCase.assertEqual(f_generated.getCoordinateName(2), 'z2');
+    end
+    
+  end
+end
+
+
+
+

--- a/drake/systems/frames/test/CoordinateFrameCoordinatesTest.m
+++ b/drake/systems/frames/test/CoordinateFrameCoordinatesTest.m
@@ -1,7 +1,7 @@
 classdef CoordinateFrameCoordinatesTest < matlab.unittest.TestCase
   %NOTEST
   
-  % Tests that functions that touch the Coordinates property of
+  % Tests that functions that touch the coordinates property of
   % CoordinateFrame work.
   
   properties

--- a/drake/systems/frames/test/CoordinateFrameCoordinatesTest.m
+++ b/drake/systems/frames/test/CoordinateFrameCoordinatesTest.m
@@ -1,27 +1,60 @@
 classdef CoordinateFrameCoordinatesTest < matlab.unittest.TestCase
   %NOTEST
-  methods (Test)
+  
+  % Tests that functions that touch the Coordinates property of
+  % CoordinateFrame work.
+  
+  properties
+    SpecifiedFrame
+    GeneratedFrame
+  end
+  
+  methods(TestMethodSetup)
+    function createFrames (tc)
+      % SpecifiedFrame has coordinate names set by the user directly
+      tc.SpecifiedFrame = CoordinateFrame('test1', 4, 'y', {'a', 'b', 'c', 'd'});
+      
+      % GeneratedFrame has coordinate names that are
+      % automatically generated from the prefix provided.
+      tc.GeneratedFrame = CoordinateFrame('test2', 4, 'z');
+    end
+  end
+  
+  methods(Test)
     
+    function testGetCoordinateName (tc)
+      tc.assertEqual(tc.SpecifiedFrame.getCoordinateName(2), 'b');
+      tc.assertEqual(tc.GeneratedFrame.getCoordinateName(2), 'z2');
+    end
     
-    function testSpecifiedCoordinateNames (testCase)
-      
-      % tests that we can work with the coordinate names of a CoordinateFrame
-      
-      f_set = CoordinateFrame('test1', 4, 'y', {'a', 'b', 'c', 'd'}); % coordinate names are set
-      testCase.assertEqual(f_set.getCoordinateName(2), 'b');
-      testCase.assertEqual(f_set.findCoordinateIndex('b'), 2);
-      testCase.assertEqual(f_set.getCoordinateNames, {'a', 'b', 'c', 'd'}');
-      
-      expectedSubFrame = f_set.subFrame([1 3]);
+    function testFindCoordinateIndex (tc)
+      tc.assertEqual(tc.SpecifiedFrame.findCoordinateIndex('b'), 2);
+      tc.assertEqual(tc.GeneratedFrame.findCoordinateIndex('z2'), 2);
+    end
+    
+    function testGetCoordinateNames (tc)
+      tc.assertEqual(tc.SpecifiedFrame.getCoordinateNames, {'a', 'b', 'c', 'd'}');
+      tc.assertEqual(tc.GeneratedFrame.getCoordinateNames, {'z1', 'z2', 'z3', 'z4'}');
+    end
+    
+    function testSubFrameSpecifiedFrame (tc)
+      % ensures that we extract the appropriate subFrame
+      expectedSubFrame = tc.SpecifiedFrame.subFrame([1 3]);
       actualSubFrame = CoordinateFrame('test1[1 3]', 2, ['y', 'y'], {'a', 'c'});
-      testCase.assertEqual(expectedSubFrame, actualSubFrame);
-      
+      tc.assertEqual(expectedSubFrame, actualSubFrame);
     end
     
-    function testGeneratedCoordinateNames (testCase)
-      f_generated = CoordinateFrame('test2', 4, 'z'); % coordinate names generated
-      testCase.assertEqual(f_generated.getCoordinateName(2), 'z2');
+    function testSubFrameGeneratedFrame (tc)
+      expectedSubFrame = tc.GeneratedFrame.subFrame([1 3]);
+      actualSubFrame = CoordinateFrame('test2[1 3]', 2, ['z', 'z'], {'z1', 'z3'});
+      tc.assertEqual(expectedSubFrame, actualSubFrame);
     end
+    
+    % TODO
+    % Functions to write tests for: disp, isequal_modulo_transforms,
+    % getSym, addProjectionTransformByCoordinateNames,
+    % constructFrameWithAnglesWrapped, scope, generateLCMType,
+    % setCoordinates
     
   end
 end

--- a/drake/systems/frames/test/coordinateFrameCoordinatesTest.m
+++ b/drake/systems/frames/test/coordinateFrameCoordinatesTest.m
@@ -1,0 +1,9 @@
+function coordinateFrameCoordinatesTest
+
+% this is really hacky - I would rather be able to run a class-based test
+% directly.
+
+testResults = run(CoordinateFrameCoordinatesTest);
+didAllPass = all(arrayfun(@(testResult) testResult.Passed, testResults));
+
+assert(didAllPass)

--- a/drake/systems/frames/test/coordinateFrameCoordinatesTest.m
+++ b/drake/systems/frames/test/coordinateFrameCoordinatesTest.m
@@ -1,9 +1,0 @@
-function coordinateFrameCoordinatesTest
-
-% this is really hacky - I would rather be able to run a class-based test
-% directly.
-
-testResults = run(CoordinateFrameCoordinatesTest);
-didAllPass = all(arrayfun(@(testResult) testResult.Passed, testResults));
-
-assert(didAllPass)

--- a/drake/systems/frames/test/runCoordinateFrameCoordinatesTest.m
+++ b/drake/systems/frames/test/runCoordinateFrameCoordinatesTest.m
@@ -1,0 +1,21 @@
+function runCoordinateFrameCoordinatesTest
+
+% This is really hacky. The reason this is in place is so that I can run
+% the tests directly from Drake's unitTest framework. The key problem here
+% seems to be that I'm trying to use assertEqual. assertEqual does not
+% raise an error when a test fails, which is what Drake seems to be relying
+% on when it determines whether a test has passed or failed. This
+% necessitates manually checking whether a test has passed.
+
+% I'm preferring assertEqual here since the results of a test failure
+% for string comparison when using Matlab's assert and strcmp or when using
+% Drake's checkequal are not informative.
+
+% Please change this code if you know of a better way todo this.
+
+% save test results from running tests
+testResults = run(CoordinateFrameCoordinatesTest);
+% check whether all tests were passed
+didAllPass = all(arrayfun(@(testResult) testResult.Passed, testResults));
+
+assert(didAllPass);


### PR DESCRIPTION
When `coordinates` are not specified by the user, they are generated automatically based on the `prefix` (that can be either provided by the user or be itself automatically generated from the name of the `CoordinateFrame`). 

In a number of applications (such as in discretizing a system in [`MarkovDecisionProcess.discretizeSystem`](https://github.com/RobotLocomotion/drake/blob/4cb61d1c854fe48e7d54440f3904c395b0ec5971/drake/systems/MarkovDecisionProcess.m#L76), the `coordinates` are automatically generated but are never used. When no `coordinates` are specified by the user, this pull request makes generation of coordinates lazy, with the `coordinates` only generated when they are first requested by the user rather than upon the construction of the class.

**Note**: MATLAB does not seem to natively support laziness, hence the relatively hacky solution here. The closest to lazy evaluation I could find was [delaying evaluation of function inputs](http://blogs.mathworks.com/loren/2010/10/21/delaying-evaluation-of-function-inputs/) and [lazy evaluation in dependent property](http://stackoverflow.com/questions/4961331/matlab-lazy-evaluation-in-dependent-property). Neither of them meet what we need.

*As a bonus:* added testing to increase confidence in this and future changes.