### PR TITLE
Trajectory frame persistence

### DIFF
--- a/drake/systems/trajectories/DTTrajectory.m
+++ b/drake/systems/trajectories/DTTrajectory.m
@@ -1,4 +1,4 @@
-classdef (InferiorClasses = {?ConstantTrajectory,?FunctionHandleTrajectory,?PPTrajectory}) DTTrajectory < Trajectory
+classdef (InferiorClasses = {?ConstantTrajectory,?FunctionHandleTrajectory,?PPTrajectory,?Point}) DTTrajectory < Trajectory
   
   properties
     tt

--- a/drake/systems/trajectories/FunctionHandleTrajectory.m
+++ b/drake/systems/trajectories/FunctionHandleTrajectory.m
@@ -1,5 +1,5 @@
-classdef FunctionHandleTrajectory < Trajectory
 % Constructs a proper trajectory object from a function handle.
+classdef  (InferiorClasses = {?Point}) FunctionHandleTrajectory < Trajectory
   
   properties
     handle  % the function handle

--- a/drake/systems/trajectories/PPTrajectory.m
+++ b/drake/systems/trajectories/PPTrajectory.m
@@ -1,4 +1,4 @@
-classdef (InferiorClasses = {?ConstantTrajectory}) PPTrajectory < Trajectory
+classdef (InferiorClasses = {?ConstantTrajectory, ?Point}) PPTrajectory < Trajectory
   
   properties
     pp

--- a/drake/systems/trajectories/Trajectory.m
+++ b/drake/systems/trajectories/Trajectory.m
@@ -254,6 +254,7 @@ classdef Trajectory < DrakeSystem
       breaks(breaks>newtspan(2))=[];
       breaks = unique([newtspan(1),breaks,newtspan(2)]);
       traj = FunctionHandleTrajectory(@(t) eval(obj,t), obj.dim, breaks);
+      traj = setOutputFrame(traj, obj.getOutputFrame);
     end
     
     function tf = valuecheck(traj,desired_traj,tol,belementwise)

--- a/drake/systems/trajectories/Trajectory.m
+++ b/drake/systems/trajectories/Trajectory.m
@@ -102,9 +102,9 @@ classdef Trajectory < DrakeSystem
     end
     
     function [a,b,breaks] = setupTrajectoryPair(a,b)
-        if (isnumeric(a)) a = ConstantTrajectory(a); end
-        typecheck(a,'Trajectory'); 
-        if (isnumeric(b)) b = ConstantTrajectory(b); end
+        if (isnumeric(a) || isa(a,'Point')) a = ConstantTrajectory(a); end
+        typecheck(a,'Trajectory');
+        if (isnumeric(b) || isa(b,'Point')) b = ConstantTrajectory(b); end
         typecheck(b,'Trajectory');
         tspan = [max(a.tspan(1),b.tspan(1)),min(a.tspan(2),b.tspan(2))];
         if (tspan(2)<tspan(1))

--- a/drake/systems/trajectories/Trajectory.m
+++ b/drake/systems/trajectories/Trajectory.m
@@ -148,8 +148,9 @@ classdef Trajectory < DrakeSystem
         if (length(cdim)~=length(bdim) || any(cdim([1,3:end])~=bdim([1,3:end])))
           error('dimensions 1 and 3:end must match');
         end
+        fr = getOutputFrame(c);
         c = FunctionHandleTrajectory(@(t) horzcat(c.eval(t),b.eval(t)),[cdim(1),cdim(2)+bdim(2),cdim(3:end)],breaks);
-        c = setOutputFrame(c,MultiCoordinateFrame({getOutputFrame(c),getOutputFrame(b)}));
+        c = setOutputFrame(c,MultiCoordinateFrame({fr,getOutputFrame(b)}));
       end
     end
     


### PR DESCRIPTION
This fixes a bunch of cases where trajectory functions discard output frames. It also allows `traj <op> Point` to work as if it were `<traj> op numeric`.