### PR TITLE
Add option to not include velocity dependent terms in inverseDynamics

### DIFF
--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1036,11 +1036,6 @@ Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyTree::massMatrix(Kinemat
   return ret;
 }
 
-/**
- * note that this method can also be used to compute the gravitational term only by calling doKinematics with a zero joint velocity vector.
- * To compute only the Coriolis term, pass in nullptr for vd and set gravity to zero.
- * Note that the wrenches in f_ext are expressed in body frame.
- */
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::dynamicsBiasTerm(
     KinematicsCache<Scalar> &cache, const eigen_aligned_unordered_map<RigidBody const *, Matrix<Scalar, TWIST_SIZE, 1> > &f_ext, bool include_velocity_terms) const
@@ -1050,9 +1045,6 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::dynamicsBiasTerm(
   return inverseDynamics(cache, f_ext, vd, include_velocity_terms);
 };
 
-/*
- * Note that the wrenches in f_ext are expressed in body frame.
- */
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(KinematicsCache<Scalar>& cache,
                                                                  const eigen_aligned_unordered_map<RigidBody const *, Matrix<Scalar, TWIST_SIZE, 1> >& f_ext,

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -233,12 +233,50 @@ public:
 
   KinematicPath findKinematicPath(int start_body_or_frame_idx, int end_body_or_frame_idx) const;
 
+  /** \brief Compute the positive definite mass (configuration space) matrix \f$ H(q) \f$, defined by \f$T = \frac{1}{2} v^T H(q) v \f$, where \f$ T \f$ is kinetic energy.
+   *
+   * The mass matrix also appears in the manipulator equations
+   *  \f[
+   *  H(q) \dot{v} + C(q, v, f_\text{ext}) = B(q) u
+   * \f]
+   *
+   * \param cache a KinematicsCache constructed given \f$ q \f$
+   * \return the mass matrix \f$ H(q) \f$
+   */
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> massMatrix(KinematicsCache<Scalar>& cache) const;
 
+  /** \brief Compute the term \f$ C(q, v, f_\text{ext}) \f$ in the manipulator equations
+  *  \f[
+  *  H(q) \dot{v} + C(q, v, f_\text{ext}) = B(q) u
+  * \f]
+  *
+  * Convenience method that calls inverseDynamics with \f$ \dot{v} = 0 \f$. See inverseDynamics for argument descriptions.
+  * \see inverseDynamics
+  */
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, Eigen::Matrix<Scalar, TWIST_SIZE, 1> >& f_ext, bool include_velocity_terms = true) const;
 
+  /** \brief Compute
+  * \f[
+  *  H(q) \dot{v} + C(q, v, f_\text{ext})
+  * \f]
+  * that is, the left hand side of the manipulator equations
+  *  \f[
+  *  H(q) \dot{v} + C(q, v, f_\text{ext}) = B(q) u
+  * \f]
+  *
+  * Note that the 'dynamics bias term' \f$ C(q, v, f_\text{ext}) \f$ can be computed by simply setting \f$ \dot{v} = 0\f$.
+  * Note also that if only the gravitational terms contained in \f$ C(q, v, f_\text{ext}) \f$ are required, one can set \a include_velocity_terms to false.
+  * Alternatively, one can pass in a KinematicsCache created with \f$ v = 0\f$ or without specifying the velocity vector.
+  *
+  * Algorithm: recursive Newton-Euler. Does not explicitly compute mass matrix.
+  * \param cache a KinematicsCache constructed given \f$ q \f$ and \f$ v \f$
+  * \param f_ext external wrenches exerted upon bodies. Expressed in body frame.
+  * \param vd \f$ \dot{v} \f$
+  * \param include_velocity_terms whether to include velocity-dependent terms in \f$ C(q, v, f_\text{ext}) \f$. Setting \a include_velocity_terms to false is Equivalent to setting \f$ v = 0 \f$
+  * \return \f$ H(q) \dot{v} + C(q, v, f_\text{ext}) \f$
+  */
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> inverseDynamics(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, Eigen::Matrix<Scalar, TWIST_SIZE, 1> >& f_ext, const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& vd, bool include_velocity_terms = true) const;
 

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -237,10 +237,10 @@ public:
   Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> massMatrix(KinematicsCache<Scalar>& cache) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, Eigen::Matrix<Scalar, TWIST_SIZE, 1> >& f_ext) const;
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, Eigen::Matrix<Scalar, TWIST_SIZE, 1> >& f_ext, bool include_velocity_terms = true) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> inverseDynamics(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, Eigen::Matrix<Scalar, TWIST_SIZE, 1> >& f_ext, const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& vd) const;
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> inverseDynamics(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, Eigen::Matrix<Scalar, TWIST_SIZE, 1> >& f_ext, const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& vd, bool include_velocity_terms = true) const;
 
   template <typename DerivedV>
   Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, 1> frictionTorques(Eigen::MatrixBase<DerivedV> const & v) const;

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -2473,10 +2473,9 @@ void GravityCompensationTorqueConstraint::eval(const double* t, KinematicsCache<
   typedef AutoDiffScalar<VectorXd> Scalar;
   auto q = cache.getQ().cast<Scalar>().eval();
   gradientMatrixToAutoDiff(MatrixXd::Identity(robot->num_positions, robot->num_positions), q);
-  auto qd = Matrix<Scalar, Dynamic, 1>::Zero(robot->num_velocities).eval();
-  KinematicsCache<Scalar> cache_zero_velocity = robot->doKinematics(q, qd);
+  KinematicsCache<Scalar> cache_with_gradients = robot->doKinematics(q);
   eigen_aligned_unordered_map<RigidBody const *, Matrix<Scalar, TWIST_SIZE, 1> > f_ext;
-  auto G_autodiff = robot->dynamicsBiasTerm(cache_zero_velocity, f_ext);
+  auto G_autodiff = robot->dynamicsBiasTerm(cache_with_gradients, f_ext, false);
   auto G = autoDiffToValueMatrix(G_autodiff);
   auto dG = autoDiffToGradientMatrix(G_autodiff);
 

--- a/drake/systems/plants/constraint/RigidBodyConstraint.h
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.h
@@ -13,7 +13,9 @@
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
 #include <sstream>
+#include <plants/KinematicsCache.h>
 #include <drakeRigidBodyConstraint_export.h>
+#include <drakeUtil.h>
 
 
 template <typename Scalar> class KinematicsCache;

--- a/drake/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/drake/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -72,7 +72,8 @@ void performChecks(RigidBodyTree &model, KinematicsCache<double> &cache, const C
                  rotation_type);
   checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyTree::transformSpatialAcceleration<double>, cache, spatial_acceleration, base_or_frame_ind, body_or_frame_ind,
                  old_expressed_in_body_or_frame_ind, new_expressed_in_body_or_frame_ind);
-  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyTree::dynamicsBiasTerm<double>, cache, f_ext);
+  checkForErrors(settings.expect_error_on_jdot_times_v_methods, model, &RigidBodyTree::dynamicsBiasTerm<double>, cache, f_ext, true);
+  checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyTree::dynamicsBiasTerm<double>, cache, f_ext, false);
 }
 
 int main() {


### PR DESCRIPTION
Part of the cleanup list issue (https://github.com/RobotLocomotion/drake/issues/1476).

Based off of https://github.com/RobotLocomotion/drake/pull/1517.