### PR TITLE
Prevent weird error message

### DIFF
--- a/drake/systems/trajectories/Trajectory.m
+++ b/drake/systems/trajectories/Trajectory.m
@@ -425,6 +425,8 @@ classdef Trajectory < DrakeSystem
       error('parameters are not implemented for this type of trajetory'); 
     end
     
-    
+    function new_traj = append(obj, other)
+      error('Appending this type of trajectory is not (yet) supported'); 
+    end
   end
 end


### PR DESCRIPTION
Before, calling append on the wrong type of trajectory would give:

```
Error using append (line 38)
Wrong number of input arguments for obsolete matrix-based
syntax.
```

Because it would try matlab's built-in append.