### PR TITLE
Adding steering wheel lcm type

### DIFF
--- a/drake/lcmtypes/lcmt_driving_control_cmd_t.lcm
+++ b/drake/lcmtypes/lcmt_driving_control_cmd_t.lcm
@@ -1,0 +1,11 @@
+package drake;
+
+struct lcmt_driving_control_cmd_t
+{
+  int64_t timestamp;
+
+  double steering_angle; //assumed to be absolute steering angle 
+  double throttle_value; 
+  double brake_value;
+}
+


### PR DESCRIPTION
This lcm type allows for the subscription of lcm messages from the Logitech Driving Force GT steering wheel joystick and keyboard for manually operating models in drake.

I thought I had added this lcm type before, but apparently not.