### PR TITLE
Add -pthread to compile options for drakeLCMSystem

### DIFF
--- a/drake/systems/CMakeLists.txt
+++ b/drake/systems/CMakeLists.txt
@@ -13,6 +13,16 @@ if (LCM_FOUND)
   add_dependencies(drakeLCMSystem drake_lcmtypes lcmtype_agg_hpp)
   pods_use_pkg_config_packages(drakeLCMSystem lcm)
 
+  # from http://stackoverflow.com/a/29871891
+  find_package(Threads REQUIRED)
+  if (THREADS_HAVE_PTHREAD_ARG)
+    set_property(TARGET drakeLCMSystem PROPERTY COMPILE_OPTIONS "-pthread")
+    set_property(TARGET drakeLCMSystem PROPERTY INTERFACE_COMPILE_OPTIONS "-pthread")
+  endif()
+  if (CMAKE_THREAD_LIBS_INIT)
+    target_link_libraries(drakeLCMSystem "${CMAKE_THREAD_LIBS_INIT}")
+  endif()
+
   pods_install_headers(LCMSystem.h DESTINATION drake)
 endif()
 


### PR DESCRIPTION
Was getting the following error on ubuntu:
```
Linking CXX executable ../../bin/runPendulumDynamics
/usr/bin/ld: CMakeFiles/runPendulumDynamics.dir/runDynamics.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```
Resolved by adding -pthread to the compile options for drakeLCMSystem on linux.