### PR TITLE
Fix a bug in QuadraticSumConstraint

### DIFF
--- a/drake/solvers/QuadraticConstraint.m
+++ b/drake/solvers/QuadraticConstraint.m
@@ -22,6 +22,7 @@ classdef QuadraticConstraint < Constraint
 
   methods (Access = protected)
     function [c,dc,ddc] = constraintEval(obj,x)
+      x = x(:);
       c = .5*x'*obj.Q*x + obj.b'*x;
       if nargout > 1
         dc = x'*obj.Q + obj.b';

--- a/drake/solvers/QuadraticSumConstraint.m
+++ b/drake/solvers/QuadraticSumConstraint.m
@@ -33,19 +33,4 @@ classdef QuadraticSumConstraint < QuadraticConstraint
     end
   end
   
-  methods (Access = protected)
-    function [c,dc,ddc] = constraintEval(obj,x)
-      x = reshape(x,obj.x_rows,obj.x_cols);
-      xv = x-obj.v;
-      Qxv = obj.Qa*xv;
-      c = sum(sum(xv.*Qxv));
-      if(nargout>1)
-        dc = 2*reshape(Qxv,1,[]);
-      end
-      if(nargout>2)
-        ddc = reshape(obj.Q,1,[]);
-      end
-    end
-  end
-  
 end

--- a/drake/solvers/test/testConstraint.m
+++ b/drake/solvers/test/testConstraint.m
@@ -51,6 +51,28 @@ cnstr6 = BoundingBoxConstraint([0;1;2;3],[1;2;2;3]);
 valuecheck(cnstr6.lb,[0;1;2;3]);
 valuecheck(cnstr6.ub,[1;2;2;3]);
 
+display('Check QuadraticSumConstraint');
+x_des = [[0.5;1] [1;0.1]];
+cnstr = QuadraticSumConstraint(0,1,diag([1;10]),x_des);
+x = x_des;
+[val,dval] = cnstr.eval(x);
+if(val>cnstr.ub || val<cnstr.lb)
+  error('QuadraticSumConstraint is not imposed correctly');
+end
+valuecheck(dval,zeros(1,4));
+x = x_des;
+x(2,1) = x(2,1)+sqrt(1/10)*0.99;
+[val,dval] = cnstr.eval(x);
+if(val>cnstr.ub || val < cnstr.lb)
+  error('QuadraticSumConstraint is not imposed correctly');
+end
+valuecheck(dval,[0 2*(x(2,1)-x_des(2,1))*10 zeros(1,2)]);
+x = x_des;
+x(2,2) = x(2,2)+1;
+val = cnstr.eval(x);
+if(val<=cnstr.ub)
+  error('QuadraticSumConstraint is not imposed correctly');
+end
 
 display('Check setBounds')
 cnstr4 = cnstr4.setBounds([1;2],[3;2]);


### PR DESCRIPTION
Previously in `QuadraticSumConstraint`, it intends to impose `lb<=sum_i (x(:,i)-x_des(:,i))'*Q*(x(:,i)-x_des(:,i))<=ub`, but the constant term `x_des(:,i)'*Q*x_des(:,i)` was added for twice, when it overloads the `constraintEval` function of the parent class `QuadraticConstraint`