### PR TITLE
Fix compile due to missing drake_lcmtypes.lib

### DIFF
--- a/drake/systems/CMakeLists.txt
+++ b/drake/systems/CMakeLists.txt
@@ -5,8 +5,7 @@ endif()
 
 if (LCM_FOUND)
   add_library_with_exports(LIB_NAME drakeLCMSystem SOURCE_FILES LCMSystem.cpp)
-  add_dependencies(drakeLCMSystem lcmtype_agg_hpp)
-  target_link_libraries(drakeLCMSystem drake_lcmtypes)
+  add_dependencies(drakeLCMSystem drake_lcmtypes lcmtype_agg_hpp)
   pods_use_pkg_config_packages(drakeLCMSystem lcm)
 
   drake_install_headers(LCMSystem.h)


### PR DESCRIPTION
Go back to previous CMakeLists where drakeLCMSystem isn't linked to
drake_lcmtypes.
resolves #1652 