### PR TITLE
SNOPTWrapper: Use instance-specific work space for snOptA calls

### DIFF
--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -484,7 +484,7 @@ namespace Drake {
     struct NonlinearComplementarityProblem : public NonlinearProgram {};
     struct LinearComplementarityProblem : public NonlinearComplementarityProblem {};
 */
-    struct LeastSquares : public NonlinearProgram { //public LinearProgram, public LinearComplementarityProblem {
+    struct LeastSquares : public NonlinearProgram { //public LinearProgram, public LinearComplementarityProblem
       virtual MathematicalProgram* addLinearEqualityConstraint() override { return new LeastSquares; };
       virtual bool solve(OptimizationProblem& prog) const override {
         size_t num_constraints = 0;


### PR DESCRIPTION
Teach `OptimizationProblem` to store solver-specific data persistently in a general and type-safe way.  Convert most of the SNOPTWrapper global data use it.

GitHub-Issue: #1667
