### PR TITLE
Don't rely on `system('export ...; cmd')` working

### DIFF
--- a/drake/util/systemWCMakeEnv.m
+++ b/drake/util/systemWCMakeEnv.m
@@ -13,10 +13,17 @@ function [status,result] = systemWCmakeEnv(command)
 % command, to help with execution.  
 
 if (ismac)
-  command = [sprintf('export DYLD_FRAMEWORK_PATH=%s; ',getCMakeParam('DYLD_FRAMEWORK_PATH')), command];
-  command = [sprintf('export DYLD_LIBRARY_PATH=%s; ',getCMakeParam('DYLD_LIBRARY_PATH')), command];
+  old_fw_path = getenv('DYLD_FRAMEWORK_PATH');
+  old_lib_path = getenv('DYLD_LIBRARY_PATH');
+  setenv('DYLD_FRAMEWORK_PATH',getCMakeParam('DYLD_FRAMEWORK_PATH'));
+  setenv('DYLD_LIBRARY_PATH', getCMakeParam('DYLD_LIBRARY_PATH'));
+  
+  [status,result] = system(command);
+  setenv('DYLD_FRAMEWORK_PATH', old_fw_path);
+  setenv('DYLD_LIBRARY_PATH', old_lib_path);
 else
-  command = [sprintf('export LD_LIBRARY_PATH=%s; ',getCMakeParam('LD_LIBRARY_PATH')), command];
+  old_lib_path = getenv('LD_LIBRARY_PATH');
+  setenv('LD_LIBRARY_PATH',getCMakeParam('LD_LIBRARY_PATH'));
+  [status,result] = system(command);
+  setenv('LD_LIBRARY_PATH', old_lib_path);
 end
-
-[status,result] = system(command);


### PR DESCRIPTION
Tries to fix #1675, but only does half the job