### PR TITLE
fixes #1707 issue with double underscores in link names

### DIFF
--- a/drake/systems/plants/collision/CollisionFilterGroup.m
+++ b/drake/systems/plants/collision/CollisionFilterGroup.m
@@ -45,7 +45,8 @@ classdef CollisionFilterGroup
 
     function [linknames,robotnums] = getMembers(obj)
       if ~isempty(obj.members)
-        result = regexp(obj.members,'__','split');
+        % Split at last occurence of separator
+        result = regexp(obj.members,'__(?!.*__)','split');
         result = vertcat(result{:})';
         linknames = result(1,:);
         robotnums = cellfun(@str2num,result(2,:),'UniformOutput',false);


### PR DESCRIPTION
Simple fix to avoid breaking link names that include double underscores.