### PR TITLE
Optimization: Separate variable bindings from constraints

### DIFF
--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -35,8 +35,8 @@ void trivialLeastSquares() {
   valuecheckMatrix(b / 3, x.value(), 1e-10);
 
   std::shared_ptr<BoundingBoxConstraint> bbcon(
-          new BoundingBoxConstraint({x.head(2)}, MatrixXd::Constant(2, 1, -1000.0), MatrixXd::Constant(2, 1, 1000.0)));
-  prog.addConstraint(bbcon);
+          new BoundingBoxConstraint(MatrixXd::Constant(2, 1, -1000.0), MatrixXd::Constant(2, 1, 1000.0)));
+  prog.addConstraint(bbcon, {x.head(2)});
   prog.solve();  // now it will solve as a nonlinear program
   valuecheckMatrix(b.topRows(2) / 2, y.value(), 1e-10);
   valuecheckMatrix(b / 3, x.value(), 1e-10);
@@ -85,7 +85,7 @@ public:
 
 class GloptipolyConstrainedExampleConstraint : public Constraint {  // want to also support deriving directly from constraint without going through Drake::Function
 public:
-  GloptipolyConstrainedExampleConstraint(const VariableList& vars) : Constraint(vars, Vector1d::Constant(0), Vector1d::Constant(numeric_limits<double>::infinity())) {}
+  GloptipolyConstrainedExampleConstraint() : Constraint(1, Vector1d::Constant(0), Vector1d::Constant(numeric_limits<double>::infinity())) {}
 
   // for just these two types, implementing this locally is almost cleaner...
   virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const override { evalImpl(x,y); }
@@ -108,8 +108,8 @@ void gloptipolyConstrainedMinimization() {
   OptimizationProblem prog;
   auto x = prog.addContinuousVariables(3);
   prog.addCost(make_shared<GloptipolyConstrainedExampleObjective>());
-  std::shared_ptr<GloptipolyConstrainedExampleConstraint> qp_con(new GloptipolyConstrainedExampleConstraint({x}));
-  prog.addConstraint(qp_con);
+  std::shared_ptr<GloptipolyConstrainedExampleConstraint> qp_con(new GloptipolyConstrainedExampleConstraint());
+  prog.addConstraint(qp_con, {x});
   prog.addLinearConstraint(Vector3d(1,1,1).transpose(),Vector1d::Constant(-numeric_limits<double>::infinity()),Vector1d::Constant(4));
   prog.addLinearConstraint(Vector3d(0,3,1).transpose(),Vector1d::Constant(-numeric_limits<double>::infinity()),Vector1d::Constant(6));
   prog.addBoundingBoxConstraint(Vector3d(0,0,0),Vector3d(2,numeric_limits<double>::infinity(),3));

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -179,9 +179,8 @@ RigidBodySystem::OutputVector<double> RigidBodySystem::output(const double& t, c
 class SingleTimeKinematicConstraintWrapper : public Constraint
 {
 public:
-  SingleTimeKinematicConstraintWrapper(const VariableList& vars, const shared_ptr<SingleTimeKinematicConstraint>& rigid_body_constraint)
-          : Constraint(vars,rigid_body_constraint->getNumConstraint(nullptr)), rigid_body_constraint(rigid_body_constraint), kinsol(rigid_body_constraint->getRobotPointer()->bodies) {
-    assert(rigid_body_constraint->getRobotPointer()->num_positions == size(vars) && "Number of decision variables must match the number of positions in the RigidBodyTree");
+  SingleTimeKinematicConstraintWrapper(const shared_ptr<SingleTimeKinematicConstraint>& rigid_body_constraint)
+          : Constraint(rigid_body_constraint->getNumConstraint(nullptr)), rigid_body_constraint(rigid_body_constraint), kinsol(rigid_body_constraint->getRobotPointer()->bodies) {
     rigid_body_constraint->bounds(nullptr,lower_bound,upper_bound);
   }
   virtual ~SingleTimeKinematicConstraintWrapper() {}
@@ -228,11 +227,11 @@ DRAKERBSYSTEM_EXPORT RigidBodySystem::StateVector<double> Drake::getInitialState
     Vector3d zero = Vector3d::Zero();
     for (int i=0; i<loops.size(); i++) {
       auto con1 = make_shared<RelativePositionConstraint>(sys.tree.get(), zero, zero, zero, loops[i].frameA->frame_index, loops[i].frameB->frame_index,bTbp,tspan);
-      std::shared_ptr<SingleTimeKinematicConstraintWrapper> con1wrapper(new SingleTimeKinematicConstraintWrapper({qvar},con1));
-      prog.addConstraint(con1wrapper);
+      std::shared_ptr<SingleTimeKinematicConstraintWrapper> con1wrapper(new SingleTimeKinematicConstraintWrapper(con1));
+      prog.addConstraint(con1wrapper, {qvar});
       auto con2 = make_shared<RelativePositionConstraint>(sys.tree.get(), loops[i].axis, loops[i].axis, loops[i].axis, loops[i].frameA->frame_index, loops[i].frameB->frame_index,bTbp,tspan);
-      std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(new SingleTimeKinematicConstraintWrapper({qvar},con2));
-      prog.addConstraint(con2wrapper);
+      std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(new SingleTimeKinematicConstraintWrapper(con2));
+      prog.addConstraint(con2wrapper, {qvar});
     }
 
     VectorXd q_guess = x0.topRows(nq);


### PR DESCRIPTION
For each `Constraint` added to an `OptimizationProblem` we need to store
variable bindings that map decision variables from the problem onto
input variables to the constraint function.  Delay this association
until a constraint is added to a problem, and store it inside the
problem.  This avoids storing anything specific to one problem in a
constraint, and will allow a constraint to be shared among multiple
problems simultaneously.

GitHub-Issue: RobotLocomotion/drake#1666