### PR TITLE
Optimization: Replace Function hierarchy with type erasure

### DIFF
--- a/drake/core/Function.h
+++ b/drake/core/Function.h
@@ -3,6 +3,8 @@
 #include <vector>
 #include <stdexcept>
 #include <iostream>
+#include <functional>
+#include <memory>
 #include <Eigen/Dense>
 #include "Gradient.h"
 
@@ -118,6 +120,36 @@ namespace Drake {
     template <typename ScalarType>
     static void eval(F const& f, VecIn<ScalarType> const& x, VecOut<ScalarType>& y) {
       f.eval(x, y);
+    }
+  };
+
+  template <typename F>
+  struct FunctionTraits<std::reference_wrapper<F>> {
+    static size_t numInputs(std::reference_wrapper<F> const& f) { return f.get().numInputs(); }
+    static size_t numOutputs(std::reference_wrapper<F> const& f) { return f.get().numOutputs(); }
+    template <typename ScalarType>
+    static void eval(std::reference_wrapper<F> const& f, VecIn<ScalarType> const& x, VecOut<ScalarType>& y) {
+      f.get().eval(x, y);
+    }
+  };
+
+  template <typename F>
+  struct FunctionTraits<std::shared_ptr<F>> {
+    static size_t numInputs(std::shared_ptr<F> const& f) { return f->numInputs(); }
+    static size_t numOutputs(std::shared_ptr<F> const& f) { return f->numOutputs(); }
+    template <typename ScalarType>
+    static void eval(std::shared_ptr<F> const& f, VecIn<ScalarType> const& x, VecOut<ScalarType>& y) {
+      f->eval(x, y);
+    }
+  };
+
+  template <typename F>
+  struct FunctionTraits<std::unique_ptr<F>> {
+    static size_t numInputs(std::unique_ptr<F> const& f) { return f->numInputs(); }
+    static size_t numOutputs(std::unique_ptr<F> const& f) { return f->numOutputs(); }
+    template <typename ScalarType>
+    static void eval(std::unique_ptr<F> const& f, VecIn<ScalarType> const& x, VecOut<ScalarType>& y) {
+      f->eval(x, y);
     }
   };
 

--- a/drake/core/Function.h
+++ b/drake/core/Function.h
@@ -104,46 +104,24 @@ namespace Drake {
     }
   };
 
-  class Function {
-  public:
-    Function() : relation(InputOutputRelation::Form::ARBITRARY) {};
-    Function(InputOutputRelation::Form f) : relation(f) {};
-    virtual ~Function() {};
+  template <typename ScalarType> using VecIn = Eigen::Ref< Eigen::Matrix<ScalarType, Eigen::Dynamic, 1> const >;
+  template <typename ScalarType> using VecOut = Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>;
 
-    virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const = 0;
-    virtual const InputOutputRelation& getInputOutputRelation() const { return relation; };
-    // note: for multiple argument functions, this can be getInputOutputRelation(input_num,output_num)
-
-  protected:
-    InputOutputRelation relation;
-  };
-
-  class DifferentiableFunction : public Function {
-  public:
-    DifferentiableFunction() : Function(InputOutputRelation::Form::DIFFERENTIABLE) {};
-    virtual ~DifferentiableFunction() {};
-
-    virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const = 0;
-    virtual void eval(const Eigen::Ref<const TaylorVecXd>& x, TaylorVecXd& y) const = 0;
-  };
-
-  template <typename Derived>
-  class TemplatedDifferentiableFunction : public DifferentiableFunction {
-  public:
-    TemplatedDifferentiableFunction(Derived& derived) : DifferentiableFunction(), derived(derived) {};
-    virtual ~TemplatedDifferentiableFunction() {};
-
-    virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const override { derived.evalImpl(x,y); }
-    virtual void eval(const Eigen::Ref<const TaylorVecXd>& x, TaylorVecXd& y) const override { derived.evalImpl(x,y); }
-
-  private:
-    Derived& derived;
+  /** FunctionTraits
+   * @brief Define interface to a function of the form y = f(x).
+   */
+  template <typename F>
+  struct FunctionTraits {
+    // TODO: add in/out relation, possibly distinguish differentiable functions
+    static size_t numInputs(F const& f) { return f.numInputs(); }
+    static size_t numOutputs(F const& f) { return f.numOutputs(); }
+    template <typename ScalarType>
+    static void eval(F const& f, VecIn<ScalarType> const& x, VecOut<ScalarType>& y) {
+      f.eval(x, y);
+    }
   };
 
   // idea: use templates to support multi-input, multi-output functions which implement, e.g.
   // void eval(x1,...,xn,  y1,...,ym), and
   // InputOutputRelation getInputOutputRelation(input_index,output_index)
-
-  // idea: avoid dynamic allocation by having derived classes which template on input/output size?
-  // hopefully the use of Ref above will mean they can still derive from Function (and avoid the allocation)
 };

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -114,6 +114,8 @@ namespace Drake {
     }
     virtual ~Constraint() {}
 
+    // TODO: consider using a Ref for `y` too.  This will require the client
+    // to do allocation, but also allows it to choose stack allocation instead.
     virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const = 0;
     virtual void eval(const Eigen::Ref<const TaylorVecXd>& x, TaylorVecXd& y) const = 0;  // move this to DifferentiableConstraint derived class if/when we need to support non-differentiable functions
 
@@ -140,25 +142,6 @@ namespace Drake {
   private:
     Eigen::MatrixXd Q;
     Eigen::VectorXd b;
-  };
-
-  class DifferentiableFunctionConstraint : public Constraint {
-  public:
-    DifferentiableFunctionConstraint(const std::shared_ptr<DifferentiableFunction>& func, size_t num_constraints) : Constraint(num_constraints), func(func) {}
-
-    template <typename DerivedLB, typename DerivedUB>
-    DifferentiableFunctionConstraint(const std::shared_ptr<DifferentiableFunction>& func, const Eigen::MatrixBase<DerivedLB>& lb, const Eigen::MatrixBase<DerivedUB>& ub) : Constraint(lb,ub), func(func) {}
-    virtual ~DifferentiableFunctionConstraint() {}
-
-    virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const override {
-      func->eval(x,y);
-    }
-    virtual void eval(const Eigen::Ref<const TaylorVecXd>& x, TaylorVecXd& y) const override {
-      func->eval(x,y);
-    }
-
-  private:
-    const std::shared_ptr<DifferentiableFunction> func;
   };
 
   // todo: consider implementing DifferentiableConstraint, TwiceDifferentiableConstraint, PolynomialConstraint, QuadraticConstraint, ComplementarityConstraint, IntegerConstraint, ...
@@ -243,6 +226,38 @@ namespace Drake {
       VariableList const& getVariableList() const { return variable_list; }
     };
 
+    template <typename F>
+    class ConstraintImpl: public Constraint {
+      F const f_;
+    public:
+      // Construct by copying from an lvalue.
+      template <typename...Args>
+      ConstraintImpl(F const& f, Args&&...args):
+        Constraint(FunctionTraits<F>::numOutputs(f), std::forward<Args>(args)...),
+        f_(f) {
+        }
+
+      // Construct by moving from an rvalue.
+      template <typename...Args>
+      ConstraintImpl(F&& f, Args&&...args):
+        Constraint(FunctionTraits<F>::numOutputs(f), std::forward<Args>(args)...),
+        f_(std::forward<F>(f)) {
+        }
+
+      virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const override {
+        y.resize(FunctionTraits<F>::numOutputs(f_));
+        assert(x.rows() == FunctionTraits<F>::numInputs(f_));
+        assert(y.rows() == FunctionTraits<F>::numOutputs(f_));
+        FunctionTraits<F>::eval(f_, x, y);
+      }
+      virtual void eval(const Eigen::Ref<const TaylorVecXd>& x, TaylorVecXd& y) const override {
+        y.resize(FunctionTraits<F>::numOutputs(f_));
+        assert(x.rows() == FunctionTraits<F>::numInputs(f_));
+        assert(y.rows() == FunctionTraits<F>::numOutputs(f_));
+        FunctionTraits<F>::eval(f_, x, y);
+      }
+    };
+
   public:
     enum { INITIAL_VARIABLE_ALLOCATION_NUM = 100 }; // not const static int because the VectorXd constructor takes a reference to int so it is odr-used (see https://gcc.gnu.org/wiki/VerboseDiagnostics#missing_static_const_definition)
     OptimizationProblem() : problem_type(new LeastSquares), num_vars(0), x_initial_guess(static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)) {};
@@ -273,14 +288,18 @@ namespace Drake {
       addCost(obj, variable_views);
     }
 
-    std::shared_ptr<DifferentiableFunctionConstraint> addCost(const std::shared_ptr<DifferentiableFunction>& obj, const VariableList& vars) {
-      std::shared_ptr<DifferentiableFunctionConstraint> objective(new DifferentiableFunctionConstraint(obj,1));
-      addCost(objective, vars);
-      return objective;
+    template <typename F>
+    typename std::enable_if<!std::is_convertible<F, std::shared_ptr<Constraint>>::value, std::shared_ptr<Constraint>>::type
+    addCost(F&& f, VariableList const& vars) {
+      auto c = std::make_shared<ConstraintImpl<typename std::remove_reference<F>::type>>(std::forward<F>(f));
+      addCost(c, vars);
+      return c;
     }
 
-    std::shared_ptr<DifferentiableFunctionConstraint> addCost(const std::shared_ptr<DifferentiableFunction>& obj) {
-      return addCost(obj,variable_views);
+    template <typename F>
+    typename std::enable_if<!std::is_convertible<F, std::shared_ptr<Constraint>>::value, std::shared_ptr<Constraint>>::type
+    addCost(F&& f) {
+      return addCost(std::forward<F>(f), variable_views);
     }
 
     /** addQuadraticCost

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -302,6 +302,21 @@ namespace Drake {
       return addCost(std::forward<F>(f), variable_views);
     }
 
+    // libstdc++ 4.9 evaluates
+    // `std::is_convertible<std::unique_ptr<Unrelated>, std::shared_ptr<Constraint>>::value`
+    // incorrectly as `true` so our enable_if overload is not used.
+    // Provide an explicit alternative for this case.
+    template <typename F>
+    std::shared_ptr<Constraint> addCost(std::unique_ptr<F>&& f, VariableList const& vars) {
+      auto c = std::make_shared<ConstraintImpl<std::unique_ptr<F>>>(std::forward<std::unique_ptr<F>>(f));
+      addCost(c, vars);
+      return c;
+    }
+    template <typename F>
+    std::shared_ptr<Constraint> addCost(std::unique_ptr<F>&& f) {
+      return addCost(std::forward<std::unique_ptr<F>>(f), variable_views);
+    }
+
     /** addQuadraticCost
      * @brief adds a cost term of the form (x-x_desired)'*Q*(x-x_desired)
      */

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -7,6 +7,38 @@ using namespace std;
 using namespace Eigen;
 using namespace Drake;
 
+struct Movable {
+  Movable() = default;
+  Movable(Movable&&) = default;
+  Movable(Movable const&) = delete;
+  static size_t numInputs() { return 1; }
+  static size_t numOutputs() { return 1; }
+  template<typename ScalarType>
+  void eval(VecIn<ScalarType> const&, VecOut<ScalarType>&) const {}
+};
+
+struct Copyable {
+  Copyable() = default;
+  Copyable(Copyable&&) = delete;
+  Copyable(Copyable const&) = default;
+  static size_t numInputs() { return 1; }
+  static size_t numOutputs() { return 1; }
+  template<typename ScalarType>
+  void eval(VecIn<ScalarType> const&, VecOut<ScalarType>&) const {}
+};
+
+void testAddFunction() {
+  OptimizationProblem prog;
+  prog.addContinuousVariables(1);
+
+  Movable movable;
+  prog.addCost(std::move(movable));
+  prog.addCost(Movable());
+
+  Copyable copyable;
+  prog.addCost(copyable);
+}
+
 void trivialLeastSquares() {
   OptimizationProblem prog;
 
@@ -43,13 +75,15 @@ void trivialLeastSquares() {
 }
 
 
-class SixHumpCamelObjective : public TemplatedDifferentiableFunction<SixHumpCamelObjective> {
+class SixHumpCamelObjective {
 public:
-  SixHumpCamelObjective() : TemplatedDifferentiableFunction<SixHumpCamelObjective>(*this) {};
+  static size_t numInputs() { return 2; }
+  static size_t numOutputs() { return 1; }
 
   template<typename ScalarType>
-  void evalImpl(const Ref<const Matrix<ScalarType, Dynamic, 1>>& x, Matrix<ScalarType,Dynamic,1>& y) {
-    y.resize(1);
+  void eval(VecIn<ScalarType> const& x, VecOut<ScalarType>& y) const {
+    assert(x.rows() == numInputs());
+    assert(y.rows() == numOutputs());
     y(0) = x(0) * x(0) * (4 - 2.1 * x(0) * x(0) + x(0) * x(0) * x(0) * x(0) / 3) + x(0) * x(1) +
            x(1) * x(1) * (-4 + 4 * x(1) * x(1));
   }
@@ -58,7 +92,7 @@ public:
 void sixHumpCamel() {
   OptimizationProblem prog;
   auto x = prog.addContinuousVariables(2);
-  auto objective = prog.addCost(make_shared<SixHumpCamelObjective>());
+  auto objective = prog.addCost(SixHumpCamelObjective());
   prog.solve();
   prog.printSolution();
 
@@ -71,14 +105,15 @@ void sixHumpCamel() {
   }
 }
 
-class GloptipolyConstrainedExampleObjective
-        : public TemplatedDifferentiableFunction<GloptipolyConstrainedExampleObjective> {
+class GloptipolyConstrainedExampleObjective {
 public:
-  GloptipolyConstrainedExampleObjective() : TemplatedDifferentiableFunction<GloptipolyConstrainedExampleObjective>(*this) {};
+  static size_t numInputs() { return 3; }
+  static size_t numOutputs() { return 1; }
 
   template<typename ScalarType>
-  void evalImpl(const Ref<const Matrix<ScalarType, Dynamic, 1>>& x, Matrix<ScalarType,Dynamic,1>& y) const {
-    y.resize(1);
+  void eval(VecIn<ScalarType> const& x, VecOut<ScalarType>& y) const {
+    assert(x.rows() == numInputs());
+    assert(y.rows() == numOutputs());
     y(0) = -2*x(0) + x(1) - x(2);
   }
 };
@@ -107,7 +142,7 @@ public:
 void gloptipolyConstrainedMinimization() {
   OptimizationProblem prog;
   auto x = prog.addContinuousVariables(3);
-  prog.addCost(make_shared<GloptipolyConstrainedExampleObjective>());
+  prog.addCost(GloptipolyConstrainedExampleObjective());
   std::shared_ptr<GloptipolyConstrainedExampleConstraint> qp_con(new GloptipolyConstrainedExampleConstraint());
   prog.addConstraint(qp_con, {x});
   prog.addLinearConstraint(Vector3d(1,1,1).transpose(),Vector1d::Constant(-numeric_limits<double>::infinity()),Vector1d::Constant(4));
@@ -123,6 +158,7 @@ void gloptipolyConstrainedMinimization() {
 
 int main(int argc, char* argv[])
 {
+  testAddFunction();
   trivialLeastSquares();
   sixHumpCamel();
   gloptipolyConstrainedMinimization();

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -27,6 +27,16 @@ struct Copyable {
   void eval(VecIn<ScalarType> const&, VecOut<ScalarType>&) const {}
 };
 
+struct Unique {
+  Unique() = default;
+  Unique(Unique&&) = delete;
+  Unique(Unique const&) = delete;
+  static size_t numInputs() { return 1; }
+  static size_t numOutputs() { return 1; }
+  template<typename ScalarType>
+  void eval(VecIn<ScalarType> const&, VecOut<ScalarType>&) const {}
+};
+
 void testAddFunction() {
   OptimizationProblem prog;
   prog.addContinuousVariables(1);
@@ -37,6 +47,11 @@ void testAddFunction() {
 
   Copyable copyable;
   prog.addCost(copyable);
+
+  Unique unique;
+  prog.addCost(std::cref(unique));
+  prog.addCost(std::make_shared<Unique>());
+  prog.addCost(std::unique_ptr<Unique>(new Unique));
 }
 
 void trivialLeastSquares() {


### PR DESCRIPTION
Simplify the interface required of constraint function implementation
structures and avoid imposing inheritance on them.  Remove one layer of
virtual dispatch of constraint function evaluation by using a private
`Constraint` implementation within an `OptimizationProblem` that
statically dispatches the user-provided function implementation.

GitHub-Issue: RobotLocomotion/drake#1666
