### PR TITLE
update names in prius.urdf

### DIFF
--- a/drake/examples/Cars/README.md
+++ b/drake/examples/Cars/README.md
@@ -1,35 +1,42 @@
 How to run the car simulation
 =============================
- 
-Additional prerequisites
+
+Additional prerequisites 
 ------------------------
 
-Install pygame (e.g. with `brew install pygame`, or `apt-get install python-pygame`)
+Install pygame (e.g. with `brew install pygame`, or `apt-get install
+python-pygame`)
 
 Set up your python path, e.g. with
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export PYTHONPATH="/path/to/drake-distro/build/lib/python2.7/dist-packages:/path/to/drake-distro/build/lib/python2.7/site-packages:$PYTHONPATH"
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 e.g. for me it is
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export PYTHONPATH="/Users/russt/drake-distro/build/lib/python2.7/dist-packages:/Users/russt/drake-distro/build/lib/python2.7/site-packages:$PYTHONPATH"
-```
- 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
 
 Running the simulator
 ---------------------
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 cd drake-distro/drake/examples/Cars
 ../../../build/bin/drake-visualizer &
 python SteeringCommandDriver.py &
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+wait for the visualizer to open, then run
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ../../pod-build/bin/carSimLCM prius/prius.urdf stata_garage_p1.sdf
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-I recommend setting the viewer to chase cam mode.  Choose from the Menu 'View->Camera Control Panel'.
-Then click 'Select Target' and click on the prius.  Change track mode to 'Smooth Follow' and increase your elevation.
+I recommend setting the viewer to chase cam mode. Choose from the Menu
+'View-\>Camera Control Panel'. Then click 'Select Target' and click on the
+prius. Change track mode to 'Smooth Follow' and increase your elevation.
 
 Make sure that the (very small) pygame window has focus, then use your arrow
 keys to drive around. If you have a joystick / steering wheel.. you can use
@@ -39,12 +46,14 @@ If for some reason the python game interface is not to your liking (e.g. you
 don’t have python on your system, etc), then you can generate simple throttle
 and steering commands using the command line interface
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ../../pod-build/bin/publishDrivingCommand [throttle_value] [steering_value]
-```
-where the values in bracket should be replaced with desired values.  e.g.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-```
+where the values in bracket should be replaced with desired values. e.g.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ../../pod-build/bin/publishDrivingCommand 1.0 .4
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Every time that you run this command, it sends one LCM message.

--- a/drake/examples/Cars/prius/prius.urdf
+++ b/drake/examples/Cars/prius/prius.urdf
@@ -344,7 +344,7 @@
     </visual>
   </link>
   
-     <link name="front_left_contact_point">
+     <link name="front_left_wheel_center">
     <visual>
       <material>
         <color rgba="0 1 0 0"/>
@@ -354,7 +354,7 @@
       </geometry>
     </visual>
   </link>
-      <link name="front_right_contact_point">
+      <link name="front_right_wheel_center">
     <visual>
       <material>
         <color rgba="0 1 0 0"/>
@@ -364,7 +364,7 @@
       </geometry>
     </visual>
   </link>
-  <link name="rear_left_contact_point">
+  <link name="rear_left_wheel_center">
     <visual>
       <material>
         <color rgba="0 1 0 0"/>
@@ -374,7 +374,7 @@
       </geometry>
     </visual>
   </link>
-  <link name="rear_right_contact_point">
+  <link name="rear_right_wheel_center">
     <visual>
       <material>
         <color rgba="0 1 0 0"/>
@@ -450,9 +450,9 @@
     <axis xyz="0 0 0" />
   </joint>
 
-  <joint name="front_left_contact_sliding" type="prismatic">
+  <joint name="front_left_suspension" type="prismatic">
     <parent link="left_hub"/>
-    <child link="front_left_contact_point"/>
+    <child link="front_left_wheel_center"/>
     <origin xyz="0 .801993 0"/>
     <axis xyz="0 0 1"/>
     <limit lower="0" upper=".323342"/>
@@ -461,21 +461,21 @@
   <force_element name="front_left_spring">
     <linear_spring_damper rest_length=".323342" stiffness="10000" damping="100">
       <link1 link="left_hub" xyz="0 0.801993 .323342"/>
-      <link2 link="front_left_contact_point"/>
+      <link2 link="front_left_wheel_center"/>
     </linear_spring_damper>
   </force_element>
   
   <joint name="left_wheel_joint" type="continuous">
     <axis xyz="0 1 0"/>
-    <parent link="front_left_contact_point"/>
+    <parent link="front_left_wheel_center"/>
     <child link="left_wheel"/>
     <origin xyz="0 0 .323342"/>
     <dynamics damping="0"/>
   </joint>
   
-  <joint name="front_right_contact_sliding" type="prismatic">
+  <joint name="front_right_suspension" type="prismatic">
     <parent link="right_hub"/>
-    <child link="front_right_contact_point"/>
+    <child link="front_right_wheel_center"/>
     <origin xyz="0 -0.801993 0"/>
     <axis xyz="0 0 1"/>
     <limit lower="0" upper=".323342"/>
@@ -484,13 +484,13 @@
   <force_element name="front_right_spring">
     <linear_spring_damper rest_length=".323342" stiffness="10000" damping="100">
       <link1 link="right_hub" xyz="0 -0.801993 .323342"/>
-      <link2 link="front_right_contact_point"/>
+      <link2 link="front_right_wheel_center"/>
     </linear_spring_damper>
   </force_element>
   
   <joint name="right_wheel_joint" type="continuous">
     <axis xyz="0 1 0"/>
-    <parent link="front_right_contact_point"/>
+    <parent link="front_right_wheel_center"/>
     <child link="right_wheel"/>
     <origin xyz="0 0 .323342"/>
     <dynamics damping="0"/>
@@ -510,9 +510,9 @@
     <axis xyz="0 0 1" />
   </joint>
   
-   <joint name="rear_left_contact_sliding" type="prismatic">
+   <joint name="rear_left_suspension" type="prismatic">
     <parent link="rear_axle"/>
-    <child link="rear_left_contact_point"/>
+    <child link="rear_left_wheel_center"/>
     <origin xyz="-1.409480 .801993 -0.323342"/>
     <axis xyz="0 0 1"/>
     <limit lower="0" upper="0.34925"/>
@@ -521,21 +521,21 @@
   <force_element name="rear_left_spring">
     <linear_spring_damper rest_length="0.323342" stiffness="10000" damping="100">
       <link1 link="rear_axle" xyz="-1.409480 0.801993 0"/>
-      <link2 link="rear_left_contact_point"/>
+      <link2 link="rear_left_wheel_center"/>
     </linear_spring_damper>
   </force_element>
   
   <joint name="rear_left_wheel_joint" type="continuous">
     <axis xyz="0 1 0"/>
-    <parent link="rear_left_contact_point"/>
+    <parent link="rear_left_wheel_center"/>
     <child link="left_wheel_rear"/>
     <origin xyz="0 0 0.323342"/>
     <dynamics damping="0"/>
   </joint>
   
-  <joint name="rear_right_contact_sliding" type="prismatic">
+  <joint name="rear_right_suspension" type="prismatic">
     <parent link="rear_axle"/>
-    <child link="rear_right_contact_point"/>
+    <child link="rear_right_wheel_center"/>
     <origin xyz="-1.409480 -0.801993 -0.323342"/>
     <axis xyz="0 0 1"/>
     <limit lower="0" upper="0.34925"/>
@@ -544,13 +544,13 @@
   <force_element name="rear_right_spring">
     <linear_spring_damper rest_length="0.323342" stiffness="10000" damping="100">
       <link1 link="rear_axle" xyz="-1.409480 -0.801993 0"/>
-      <link2 link="rear_right_contact_point"/>
+      <link2 link="rear_right_wheel_center"/>
     </linear_spring_damper>
   </force_element>
   
   <joint name="rear_right_wheel_joint" type="continuous">
     <axis xyz="0 1 0"/>
-    <parent link="rear_right_contact_point"/>
+    <parent link="rear_right_wheel_center"/>
     <child link="right_wheel_rear"/>
     <origin xyz="0 0 0.323342"/>
     <dynamics damping="0"/>


### PR DESCRIPTION
the names of the suspension links were confusing (I believe because they started as the contact points at the bottom of the wheels, before we were doing the full cylinder collision geometry).  this PR cleans that up, and also clarifies the start-up instructions.

@Sproulx -- please review.