### PR TITLE
fixes #1778 segfault when calling inspector

### DIFF
--- a/drake/systems/plants/BotVisualizer.m
+++ b/drake/systems/plants/BotVisualizer.m
@@ -116,8 +116,10 @@ classdef BotVisualizer < RigidBodyVisualizer
     
     function draw(obj,t,q)
       obj.draw_msg.timestamp = int64(t*1000000);
-      
-      q = q(1:obj.model.num_positions);  % be robust to people passing in the full state
+
+      if ~isempty(q)
+        q = q(1:obj.model.num_positions);  % be robust to people passing in the full state
+      end
       
       kinsol = doKinematics(obj.model,q);
       for i=1:getNumBodies(obj.model)


### PR DESCRIPTION
When q==[], avoids running q=q(1:0).