### PR TITLE
Update std::shared_ptr argument passing to be closer to idiomatic C++.

### DIFF
--- a/drake/examples/Cars/simulateLCM.cpp
+++ b/drake/examples/Cars/simulateLCM.cpp
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
     world->addVisualElement(
         DrakeShapes::VisualElement(geom, T_element_to_link, color));
     tree->addCollisionElement(
-        RigidBody::CollisionElement(geom, T_element_to_link, world), world,
+        RigidBody::CollisionElement(geom, T_element_to_link, world), *world,
         "terrain");
     tree->updateStaticCollisionElements();
   }

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -41,7 +41,9 @@ int main(int argc, char* argv[]) {
   auto & world = tree->bodies[0];
   Vector4d color;  color <<  0.9297, 0.7930, 0.6758, 1;  // was hex2dec({'ee','cb','ad'})'/256 in matlab
   world->addVisualElement(DrakeShapes::VisualElement(geom,T_element_to_link,color));
-  tree->addCollisionElement(RigidBody::CollisionElement(geom,T_element_to_link,world),world,"terrain");
+  tree->addCollisionElement(
+      RigidBody::CollisionElement(geom,T_element_to_link,world), *world,
+      "terrain");
   tree->updateStaticCollisionElements();
 
 

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -455,23 +455,23 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    * @brief adds a constraint to the program.  method specializations ensure
    * that the constraint gets added in the right way
    */
-  void addConstraint(const std::shared_ptr<Constraint>& con,
+  void addConstraint(std::shared_ptr<Constraint> con,
                      VariableList const& vars) {
     problem_type.reset(problem_type->addGenericConstraint());
     generic_constraints.push_back(Binding<Constraint>(con, vars));
   }
-  void addConstraint(const std::shared_ptr<Constraint>& con) {
+  void addConstraint(std::shared_ptr<Constraint> con) {
     addConstraint(con, variable_views);
   }
 
-  void addConstraint(const std::shared_ptr<LinearEqualityConstraint>& con,
+  void addConstraint(std::shared_ptr<LinearEqualityConstraint> con,
                      VariableList const& vars) {
     problem_type.reset(problem_type->addLinearEqualityConstraint());
     linear_equality_constraints.push_back(
         Binding<LinearEqualityConstraint>(con, vars));
   }
 
-  void addConstraint(const std::shared_ptr<LinearEqualityConstraint>& con) {
+  void addConstraint(std::shared_ptr<LinearEqualityConstraint> con) {
     addConstraint(con, variable_views);
   }
 
@@ -657,12 +657,12 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     return p;
   }
 
-  void checkVariables(const std::shared_ptr<Constraint>& con) {
+  void checkVariables(const Constraint& con) {
     assert(checkVariablesImpl(con) &&
            "Constraint depends on variables that are not associated with this "
            "OptimizationProblem");
   }
-  bool checkVariablesImpl(const std::shared_ptr<Constraint>& con) {
+  bool checkVariablesImpl(const Constraint& con) {
     // todo: implement this
     return true;
   }

--- a/drake/systems/LCMSystem.h
+++ b/drake/systems/LCMSystem.h
@@ -70,7 +70,7 @@ class LCMInputSystem {
 
   template <typename System>
   LCMInputSystem(const System &wrapped_sys,
-                 const std::shared_ptr<lcm::LCM> &lcm)
+                 std::shared_ptr<lcm::LCM> lcm)
       : all_zeros(Eigen::VectorXd::Zero(getNumInputs(wrapped_sys))){};
 
   StateVector<double> dynamics(const double &t, const StateVector<double> &x,
@@ -102,7 +102,7 @@ class LCMInputSystem<
   const static bool has_lcm_input = true;
 
   template <typename System>
-  LCMInputSystem(const System &sys, const std::shared_ptr<lcm::LCM> &lcm) {
+  LCMInputSystem(const System &sys, std::shared_ptr<lcm::LCM> lcm) {
     lcm::Subscription *sub =
         lcm->subscribe(Vector<double>::channel(),
                        &LCMInputSystem<Vector>::handleMessage, this);
@@ -146,7 +146,7 @@ class LCMOutputSystem {
   template <typename ScalarType>
   using OutputVector = NullVector<ScalarType>;
 
-  LCMOutputSystem(const std::shared_ptr<lcm::LCM> &lcm){};
+  LCMOutputSystem(std::shared_ptr<lcm::LCM> lcm){};
 
   StateVector<double> dynamics(const double &t, const StateVector<double> &x,
                                const InputVector<double> &u) const {
@@ -172,7 +172,7 @@ class LCMOutputSystem<
   template <typename ScalarType>
   using OutputVector = NullVector<ScalarType>;
 
-  LCMOutputSystem(const std::shared_ptr<lcm::LCM> &lcm) : lcm(lcm){};
+  LCMOutputSystem(std::shared_ptr<lcm::LCM> lcm) : lcm(lcm){};
 
   StateVector<double> dynamics(const double &t, const StateVector<double> &x,
                                const InputVector<double> &u) const {
@@ -190,7 +190,7 @@ class LCMOutputSystem<
   }
 
  private:
-  std::shared_ptr<lcm::LCM> lcm;
+  const std::shared_ptr<lcm::LCM> lcm;
 };
 
 // todo: template specialization for the CombinedVector case
@@ -217,8 +217,8 @@ class DRAKELCMSYSTEM_EXPORT LCMLoop {
  */
 
 template <typename System>
-void runLCM(const std::shared_ptr<System> &sys,
-            const std::shared_ptr<lcm::LCM> &lcm, double t0, double tf,
+void runLCM(std::shared_ptr<System> sys,
+            std::shared_ptr<lcm::LCM> lcm, double t0, double tf,
             const typename System::template StateVector<double> &x0,
             const SimulationOptions &options = default_simulation_options) {
   if (!lcm->good()) throw std::runtime_error("bad LCM reference");
@@ -276,8 +276,8 @@ void runLCM(const std::shared_ptr<System> &sys,
 }
 
 template <typename System>
-void runLCM(const std::shared_ptr<System> &sys,
-            const std::shared_ptr<lcm::LCM> &lcm, double t0, double tf) {
+void runLCM(const System &sys,
+            std::shared_ptr<lcm::LCM> lcm, double t0, double tf) {
   runLCM(sys, lcm, t0, tf, getInitialState(*sys));
 }
 

--- a/drake/systems/System.h
+++ b/drake/systems/System.h
@@ -355,8 +355,8 @@ class FeedbackSystem {
  */
 template <typename System1, typename System2>
 std::shared_ptr<FeedbackSystem<System1, System2>> feedback(
-    const std::shared_ptr<System1>& sys1,
-    const std::shared_ptr<System2>& sys2) {
+    std::shared_ptr<System1> sys1,
+    std::shared_ptr<System2> sys2) {
   return std::make_shared<FeedbackSystem<System1, System2>>(sys1, sys2);
 };
 
@@ -455,8 +455,8 @@ class CascadeSystem {
  */
 template <typename System1, typename System2>
 std::shared_ptr<CascadeSystem<System1, System2>> cascade(
-    const std::shared_ptr<System1>& sys1,
-    const std::shared_ptr<System2>& sys2) {
+    std::shared_ptr<System1> sys1,
+    std::shared_ptr<System2> sys2) {
   return std::make_shared<CascadeSystem<System1, System2>>(sys1, sys2);
 };
 

--- a/drake/systems/plants/BotVisualizer.h
+++ b/drake/systems/plants/BotVisualizer.h
@@ -34,13 +34,13 @@ class BotVisualizer {
   template <typename ScalarType>
   using InputVector = RobotStateVector<ScalarType>;
 
-  BotVisualizer(const std::shared_ptr<lcm::LCM> &_lcm,
-                const std::shared_ptr<RigidBodyTree> &tree)
+  BotVisualizer(std::shared_ptr<lcm::LCM> _lcm,
+                std::shared_ptr<RigidBodyTree> tree)
       : tree(tree), lcm(_lcm) {
     init();
   }
 
-  BotVisualizer(const std::shared_ptr<lcm::LCM> &_lcm,
+  BotVisualizer(std::shared_ptr<lcm::LCM> _lcm,
                 const std::string &urdf_filename,
                 const DrakeJoint::FloatingBaseType floating_base_type)
       : tree(new RigidBodyTree(urdf_filename, floating_base_type)), lcm(_lcm) {

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -97,7 +97,7 @@ bool RigidBody::CollisionElement::collidesWith(
   auto other_rb = dynamic_cast<const RigidBody::CollisionElement*>(other);
   bool collides = true;
   if (other_rb != nullptr) {
-    collides = this->body->collidesWith(other_rb->body);
+    collides = this->body->collidesWith(*other_rb->body);
     // DEBUG
     // cout << "RigidBody::CollisionElement::collidesWith:" << endl;
     // cout << "  " << this->body->linkname << " & " <<

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -56,17 +56,17 @@ class DRAKERBM_EXPORT RigidBody {
     this->collision_filter_ignores &= ~group;
   };
 
-  bool adjacentTo(const std::shared_ptr<RigidBody>& other) const {
-    return ((parent == other && !(joint && joint->isFloating())) ||
-            (other->parent.get() == this &&
-             !(other->joint && other->joint->isFloating())));
+  bool adjacentTo(const RigidBody& other) const {
+    return ((parent.get() == &other && !(joint && joint->isFloating())) ||
+            (other.parent.get() == this &&
+             !(other.joint && other.joint->isFloating())));
   };
 
-  bool collidesWith(const std::shared_ptr<RigidBody>& other) const {
+  bool collidesWith(const RigidBody& other) const {
     bool ignored =
-        this == other.get() || adjacentTo(other) ||
-        (collision_filter_group & other->getCollisionFilterIgnores()).any() ||
-        (other->getCollisionFilterGroup() & collision_filter_ignores).any();
+        this == &other || adjacentTo(other) ||
+        (collision_filter_group & other.getCollisionFilterIgnores()).any() ||
+        (other.getCollisionFilterGroup() & collision_filter_ignores).any();
     return !ignored;
   };
 

--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -9,14 +9,14 @@ class RigidBodyTree;
 class DRAKERBM_EXPORT RigidBodyFrame {
  public:
   RigidBodyFrame(const std::string& _name,
-                 const std::shared_ptr<RigidBody>& _body,
+                 std::shared_ptr<RigidBody> _body,
                  const Eigen::Isometry3d& _transform_to_body)
       : name(_name),
         body(_body),
         transform_to_body(_transform_to_body),
         frame_index(0) {}
   RigidBodyFrame(const std::string& _name,
-                 const std::shared_ptr<RigidBody>& _body,
+                 std::shared_ptr<RigidBody> _body,
                  const Eigen::Vector3d& xyz = Eigen::Vector3d::Zero(),
                  const Eigen::Vector3d& rpy = Eigen::Vector3d::Zero())
       : name(_name), body(_body), frame_index(0) {

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -28,7 +28,7 @@ size_t RigidBodySystem::getNumOutputs() const {
 }
 
 
-void RigidBodySystem::addSensor(const std::shared_ptr<RigidBodySensor>& s) {
+void RigidBodySystem::addSensor(std::shared_ptr<RigidBodySensor> s) {
   if(s->isDirectFeedthrough()) {
     direct_feedthrough = true;
   }
@@ -413,7 +413,7 @@ Eigen::VectorXd RigidBodyGyroscope::output(const double &t,
 
 RigidBodyDepthSensor::RigidBodyDepthSensor(
     RigidBodySystem const& sys, const std::string& name,
-    const std::shared_ptr<RigidBodyFrame> frame, tinyxml2::XMLElement* node)
+    std::shared_ptr<RigidBodyFrame> frame, tinyxml2::XMLElement* node)
     : RigidBodySensor(sys, name),
       frame(frame),
       min_pitch(0.0),

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -139,7 +139,7 @@ class DRAKERBSYSTEM_EXPORT RigidBodySystem {
   template <typename ScalarType>
   using OutputVector = Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>;
 
-  RigidBodySystem(const std::shared_ptr<RigidBodyTree>& rigid_body_tree)
+  RigidBodySystem(std::shared_ptr<RigidBodyTree> rigid_body_tree)
       : tree(rigid_body_tree),
         use_multi_contact(false),
         penetration_stiffness(150.0),
@@ -174,11 +174,11 @@ class DRAKERBSYSTEM_EXPORT RigidBodySystem {
                         const DrakeJoint::FloatingBaseType floating_base_type =
                             DrakeJoint::QUATERNION);
 
-  void addForceElement(const std::shared_ptr<RigidBodyForceElement>& f) {
+  void addForceElement(std::shared_ptr<RigidBodyForceElement> f) {
     force_elements.push_back(f);
   }
 
-  void addSensor(const std::shared_ptr<RigidBodySensor>& s);
+  void addSensor(std::shared_ptr<RigidBodySensor> s);
 
   const std::shared_ptr<RigidBodyTree>& getRigidBodyTree(void) const { return tree; }
 
@@ -444,8 +444,9 @@ class DRAKERBSYSTEM_EXPORT RigidBodySensor {
  */
 class DRAKERBSYSTEM_EXPORT RigidBodyDepthSensor : public RigidBodySensor {
   public:
-    RigidBodyDepthSensor(RigidBodySystem const& sys, const std::string& name, const std::shared_ptr<RigidBodyFrame> frame, tinyxml2::XMLElement* node);
-
+    RigidBodyDepthSensor(RigidBodySystem const& sys, const std::string& name,
+                         std::shared_ptr<RigidBodyFrame> frame,
+                         tinyxml2::XMLElement* node);
     virtual ~RigidBodyDepthSensor() {}
 
     virtual size_t getNumOutputs() const override { return num_pixel_rows*num_pixel_cols; }

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -290,11 +290,11 @@ map<string, int> RigidBodyTree::computePositionNameToIndexMap() const {
 
 DrakeCollision::ElementId RigidBodyTree::addCollisionElement(
     const RigidBody::CollisionElement& element,
-    const shared_ptr<RigidBody>& body, const string& group_name) {
+    RigidBody& body, const string& group_name) {
   DrakeCollision::ElementId id = collision_model->addElement(element);
   if (id != 0) {
-    body->collision_element_ids.push_back(id);
-    body->collision_element_groups[group_name].push_back(id);
+    body.collision_element_ids.push_back(id);
+    body.collision_element_groups[group_name].push_back(id);
   }
   return id;
 }
@@ -1034,8 +1034,8 @@ Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic> RigidBodyTree::geometricJacobian(
   int body_index;
   for (size_t i = 0; i < kinematic_path.joint_path.size(); i++) {
     body_index = kinematic_path.joint_path[i];
-    const std::shared_ptr<RigidBody>& body = bodies[body_index];
-    const DrakeJoint& joint = body->getJoint();
+    const RigidBody& body = *bodies[body_index];
+    const DrakeJoint& joint = body.getJoint();
     cols +=
         in_terms_of_qdot ? joint.getNumPositions() : joint.getNumVelocities();
   }
@@ -1838,7 +1838,7 @@ size_t RigidBodyTree::getNumPositionConstraints() const {
   return loops.size() * 6;
 }
 
-void RigidBodyTree::addFrame(const std::shared_ptr<RigidBodyFrame>& frame) {
+void RigidBodyTree::addFrame(std::shared_ptr<RigidBodyFrame> frame) {
   frames.push_back(frame);
   frame->frame_index = -(static_cast<int>(frames.size()) - 1) - 2;  // yuck!!
 }

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -46,8 +46,8 @@ class DRAKERBM_EXPORT RigidBodyActuator {
 
 class DRAKERBM_EXPORT RigidBodyLoop {
  public:
-  RigidBodyLoop(const std::shared_ptr<RigidBodyFrame>& _frameA,
-                const std::shared_ptr<RigidBodyFrame>& _frameB,
+  RigidBodyLoop(std::shared_ptr<RigidBodyFrame> _frameA,
+                std::shared_ptr<RigidBodyFrame> _frameB,
                 const Eigen::Vector3d& _axis)
       : frameA(_frameA), frameB(_frameB), axis(_axis){};
 
@@ -98,7 +98,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
                        const DrakeJoint::FloatingBaseType floating_base_type =
                            DrakeJoint::QUATERNION);
 
-  void addFrame(const std::shared_ptr<RigidBodyFrame>& frame);
+  void addFrame(std::shared_ptr<RigidBodyFrame> frame);
 
   std::map<std::string, int> computePositionNameToIndexMap() const;
 
@@ -523,7 +523,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
 
   DrakeCollision::ElementId addCollisionElement(
       const RigidBody::CollisionElement& element,
-      const std::shared_ptr<RigidBody>& body, const std::string& group_name);
+      RigidBody& body, const std::string& group_name);
 
   template <class UnaryPredicate>
   void removeCollisionGroupsIf(UnaryPredicate test) {

--- a/drake/systems/plants/RigidBodyTreeSDF.cpp
+++ b/drake/systems/plants/RigidBodyTreeSDF.cpp
@@ -199,7 +199,7 @@ void parseSDFCollision(shared_ptr<RigidBody> body, XMLElement* node,
                         body->linkname + ".");
 
   if (element.hasGeometry()) {
-    model->addCollisionElement(element, body, group_name);
+    model->addCollisionElement(element, *body, group_name);
   }
 }
 

--- a/drake/systems/plants/RigidBodyTreeURDF.cpp
+++ b/drake/systems/plants/RigidBodyTreeURDF.cpp
@@ -295,7 +295,7 @@ void parseCollision(shared_ptr<RigidBody> body, XMLElement* node,
                         body->linkname + ".");
 
   if (element.hasGeometry()) {
-    model->addCollisionElement(element, body, group_name);
+    model->addCollisionElement(element, *body, group_name);
   }
 }
 

--- a/drake/systems/plants/constructModelmex.cpp
+++ b/drake/systems/plants/constructModelmex.cpp
@@ -251,7 +251,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
         // DEBUG
         // cout << "constructModelmex: geometry = " << geometry.get() << endl;
         // END_DEBUG
-        model->addCollisionElement(element, b, group_name);
+        model->addCollisionElement(element, *b, group_name);
       }
       // NOTE: the following should not be necessary since the same thing is
       // being done in RigidBodyTree::compile, which is called below.

--- a/drake/systems/plants/rigidBodyLCMNode.cpp
+++ b/drake/systems/plants/rigidBodyLCMNode.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
     world->addVisualElement(
         DrakeShapes::VisualElement(geom, T_element_to_link, color));
     tree->addCollisionElement(
-        RigidBody::CollisionElement(geom, T_element_to_link, world), world,
+        RigidBody::CollisionElement(geom, T_element_to_link, world), *world,
         "terrain");
     tree->updateStaticCollisionElements();
   }


### PR DESCRIPTION
The CppCoreGuidelines recommend that std::shared_ptr only be passed as
an argument when the callee explicitly needs to manage the lifetime of
the argument, and that 'const std::shared_ptr<T>&' should only be used
if there is a chance that lifetime will not be shared.

https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-smartptrparam

Many instances in drake were passing 'const std::shared_ptr<T>&'
around, often when no lifetime management was necessary, and otherwise
when lifetime sharing was unconditional.  This can be less efficient,
unnecessarily restrictive, and hides the intent of the API.

This patch converts those instances either to:
 * [const] T& if no lifetime sharing is required
 * std::shared_ptr<T> if lifetime sharing is always required