### PR TITLE
RigidBodyMagnetometer in C++

### DIFF
--- a/drake/examples/Quadrotor/QuadrotorOutput.h
+++ b/drake/examples/Quadrotor/QuadrotorOutput.h
@@ -8,7 +8,7 @@ template <typename ScalarType = double>
 class QuadrotorOutput {
 public:
 
-    const static int RowsAtCompileTime = 19;
+    const static int RowsAtCompileTime = 22;
     typedef drake::lcmt_quadrotor_output_t LCMMessageType;
     static std::string channel() { return "QUAD_OUTPUT"; };
 
@@ -18,6 +18,7 @@ public:
         twist.setZero();
         accelerometer.setZero();
         gyroscope.setZero();
+        magnetometer.setZero();
     }
 
     template <typename Derived>
@@ -39,6 +40,7 @@ public:
         x.segment<6>(7) = vec.twist;
         x.segment<3>(13) = vec.accelerometer;
         x.segment<3>(16) = vec.gyroscope;
+        x.segment<3>(19) = vec.magnetometer;
 
         return x;
     }
@@ -50,6 +52,7 @@ public:
         twist = x.template segment<6>(7);
         accelerometer = x.template segment<3>(13);
         gyroscope = x.template segment<3>(16);
+        magnetometer = x.template segment<3>(19);
     }
 
     friend std::string getCoordinateName(const QuadrotorOutput<ScalarType>& vec, unsigned int index) {
@@ -59,7 +62,8 @@ public:
            "xdot", "ydot", "zdot",
            "angvel_x", "angvel_y", "angvel_z",
            "accel_x", "accel_y", "accel_z",
-           "gyro_x", "gyro_y", "gyro_z"
+           "gyro_x", "gyro_y", "gyro_z",
+           "mag_x", "mag_y", "mag_z"
           };
       return index >= 0 && index < RowsAtCompileTime ? coordinate_names[index] : std::string("error");
     }
@@ -70,6 +74,7 @@ public:
     Eigen::Matrix<ScalarType, 6, 1> twist;
     Eigen::Matrix<ScalarType, 3, 1> accelerometer;
     Eigen::Matrix<ScalarType, 3, 1> gyroscope;
+    Eigen::Matrix<ScalarType, 3, 1> magnetometer;
 };
 
 bool encode(const double& t, const QuadrotorOutput<double> & x, drake::lcmt_quadrotor_output_t& msg) {
@@ -79,11 +84,13 @@ bool encode(const double& t, const QuadrotorOutput<double> & x, drake::lcmt_quad
   Eigen::Map<Eigen::Matrix<double, 6, 1>> lcm_twist(msg.twist);
   Eigen::Map<Eigen::Vector3d> lcm_accelerometer(msg.accelerometer);
   Eigen::Map<Eigen::Vector3d> lcm_gyroscope(msg.gyroscope);
+  Eigen::Map<Eigen::Vector3d> lcm_magnetometer(msg.magnetometer);
   lcm_position = x.position;
   lcm_orientation = x.orientation;
   lcm_twist = x.twist;
   lcm_accelerometer = x.accelerometer;
   lcm_gyroscope = x.gyroscope;
+  lcm_magnetometer = x.magnetometer;
   return true;
 }
 

--- a/drake/examples/Quadrotor/quadrotor_fla.urdf
+++ b/drake/examples/Quadrotor/quadrotor_fla.urdf
@@ -1,0 +1,81 @@
+<?xml version="1.0" ?>
+
+<!-- adapted from Daniel Mellinger, Nathan Michael, Vijay Kumar, "Trajectory Generation and Control for Precise Aggressive Maneuvers with Quadrotors" -->
+
+<robot xmlns="http://drake.mit.edu"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://drake.mit.edu ../../../../pods/drake/doc/drakeURDF.xsd" name="quadrotor">
+  <link name="base_link">
+    <inertial>
+      <mass value="0.5"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.0023" ixy="0.0" ixz="0.0" iyy="0.0023" iyz="0.0" izz="0.004"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="quadrotor_base.obj" scale=".1"/>
+      </geometry>
+    </visual>
+    <!-- note: the original hector quadrotor urdf had a (simplified, but still complex) collision mesh, too -->
+    <collision>
+      <origin rpy="0 0 0" xyz=".1750 0 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.1"/>
+      </geometry>
+    </collision>      
+    <collision>
+      <origin rpy="0 0 0" xyz="-.1750 0 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.1"/>
+      </geometry>
+    </collision>      
+    <collision>
+      <origin rpy="0 0 0" xyz="0 -.1750 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.1"/>
+      </geometry>
+    </collision>      
+    <collision>
+      <origin rpy="0 0 0" xyz="0 .1750 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.1"/>
+      </geometry>
+    </collision>      
+  </link>
+  <frame link="base_link" name="body" rpy="0 0 0.78539816339" xyz="0 0 0" />
+  
+  <force_element name="prop1">
+    <propellor lower_limit="0" upper_limit="10" scale_factor_thrust="2.0" scale_factor_moment="-0.0245">
+      <parent link="base_link"/>
+      <origin xyz="0 -.1750 0"/>
+      <axis xyz="0 0 1"/>
+    </propellor>
+  </force_element>
+  
+  <force_element name="prop2">
+    <propellor lower_limit="0" upper_limit="10" scale_factor_thrust="2.0" scale_factor_moment="-0.0245">
+      <parent link="base_link"/>
+      <origin xyz="0 .1750 0"/>
+      <axis xyz="0 0 1"/>
+    </propellor>
+  </force_element>
+
+  <force_element name="prop3">
+    <propellor lower_limit="0" upper_limit="10" scale_factor_thrust="2.0" scale_factor_moment="0.0245">
+      <parent link="base_link"/>
+      <origin xyz=".1750 0 0 "/>
+      <axis xyz="0 0 1"/>
+    </propellor>
+  </force_element>
+  
+  <force_element name="prop4">
+    <propellor lower_limit="0" upper_limit="10" scale_factor_thrust="2.0" scale_factor_moment="0.0245">
+      <parent link="base_link"/>
+      <origin xyz="-.1750 0 0"/>
+      <axis xyz="0 0 1"/>
+    </propellor>
+  </force_element>
+  
+</robot>
+

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* argv[]) {
   DrakeJoint::FloatingBaseType floating_base_type = DrakeJoint::QUATERNION;
   auto rigid_body_sys = make_shared<RigidBodySystem>();
   auto const & tree = rigid_body_sys->getRigidBodyTree();
-  rigid_body_sys->addRobotFromFile(getDrakePath()+"/examples/Quadrotor/quadrotor.urdf", floating_base_type);
+  rigid_body_sys->addRobotFromFile(getDrakePath()+"/examples/Quadrotor/quadrotor_fla.urdf", floating_base_type);
 
   auto sensor_frame = tree->findFrame("body");
 

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -26,12 +26,15 @@ int main(int argc, char* argv[]) {
 
   auto accelerometer = make_shared<RigidBodyAccelerometer>(*rigid_body_sys, "accelerometer", sensor_frame);
   auto gyroscope = make_shared<RigidBodyGyroscope>(*rigid_body_sys, "gyroscope", sensor_frame);
+  auto magnetometer = make_shared<RigidBodyMagnetometer>(*rigid_body_sys, "magnetometer", sensor_frame, 0.0);
   auto noise_model = make_shared<AdditiveGaussianNoiseModel<double, 3, Vector3d>>(0, 0.01);
   accelerometer->setNoiseModel(noise_model);
   gyroscope->setNoiseModel(noise_model);
+  magnetometer->setNoiseModel(noise_model);
+
   rigid_body_sys->addSensor(accelerometer);
   rigid_body_sys->addSensor(gyroscope);
-
+  rigid_body_sys->addSensor(magnetometer); 
 
   double box_width = 1000;
   double box_depth = 10;
@@ -48,7 +51,7 @@ int main(int argc, char* argv[]) {
   auto visualizer = make_shared<BotVisualizer<RigidBodySystem::StateVector>>(lcm,tree);
   
   auto quad_control_to_rbsys_input = make_shared<Gain<QuadrotorInput, RigidBodySystem::InputVector>>(Eigen::Matrix4d::Identity());
-  auto rbsys_output_to_quad_state = make_shared<Gain<RigidBodySystem::StateVector, QuadrotorOutput>>(Eigen::Matrix<double, 19, 19>::Identity());
+  auto rbsys_output_to_quad_state = make_shared<Gain<RigidBodySystem::StateVector, QuadrotorOutput>>(Eigen::Matrix<double, 22, 22>::Identity());
   
   auto sys_with_lcm_input = cascade(quad_control_to_rbsys_input, rigid_body_sys);
   
@@ -63,7 +66,7 @@ int main(int argc, char* argv[]) {
     
   auto lcmio_with_vis = cascade(sys_with_vis, rbsys_output_to_quad_state);
 
-  x0(2) = 1;
+  x0(2) = 0.2;
 
   runLCM(lcmio_with_vis, lcm, 0, final_time, x0, options);
   

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -28,7 +28,9 @@ int main(int argc, char* argv[]) {
   auto gyroscope = make_shared<RigidBodyGyroscope>(*rigid_body_sys, "gyroscope", sensor_frame);
   auto magnetometer = make_shared<RigidBodyMagnetometer>(*rigid_body_sys, "magnetometer", sensor_frame, 0.0);
   auto noise_model = make_shared<AdditiveGaussianNoiseModel<double, 3, Vector3d>>(0, 0.01);
+
   accelerometer->setNoiseModel(noise_model);
+  accelerometer->setGravityCompensation(true);
   gyroscope->setNoiseModel(noise_model);
   magnetometer->setNoiseModel(noise_model);
 

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -19,6 +19,10 @@ int main(int argc, char* argv[]) {
 
   DrakeJoint::FloatingBaseType floating_base_type = DrakeJoint::QUATERNION;
   auto rigid_body_sys = make_shared<RigidBodySystem>();
+
+  rigid_body_sys->penetration_stiffness = 50.0;
+  rigid_body_sys->penetration_damping = 5.0;
+
   auto const & tree = rigid_body_sys->getRigidBodyTree();
   rigid_body_sys->addRobotFromFile(getDrakePath()+"/examples/Quadrotor/quadrotor_fla.urdf", floating_base_type);
 

--- a/drake/lcmtypes/lcmt_quadrotor_output_t.lcm
+++ b/drake/lcmtypes/lcmt_quadrotor_output_t.lcm
@@ -8,5 +8,6 @@ struct lcmt_quadrotor_output_t
   double twist[6];
   double accelerometer[3];
   double gyroscope[3];
+  double magnetometer[3];
 }
 

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -484,7 +484,12 @@ class DRAKERBSYSTEM_EXPORT RigidBodyAccelerometer : public RigidBodySensor {
         noise_model = model;
     }
 
+    void setGravityCompensation(bool enable_compensation) {
+      gravity_compensation = enable_compensation;
+    }
+
   private:
+    bool gravity_compensation;
     std::shared_ptr<NoiseModel<double, 3, Eigen::Vector3d>> noise_model;
     const std::shared_ptr<RigidBodyFrame> frame;
 };

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -142,13 +142,13 @@ class DRAKERBSYSTEM_EXPORT RigidBodySystem {
   RigidBodySystem(const std::shared_ptr<RigidBodyTree>& rigid_body_tree)
       : tree(rigid_body_tree),
         use_multi_contact(false),
-        penetration_stiffness(150.0),
+        penetration_stiffness(50.0),
         penetration_damping(penetration_stiffness / 10.0),
         friction_coefficient(1.0),
         direct_feedthrough(false) {};
   RigidBodySystem()
       : use_multi_contact(false),
-        penetration_stiffness(150.0),
+        penetration_stiffness(50.0),
         penetration_damping(penetration_stiffness / 10.0),
         friction_coefficient(1.0),
         direct_feedthrough(false) {
@@ -506,6 +506,35 @@ class DRAKERBSYSTEM_EXPORT RigidBodyGyroscope : public RigidBodySensor {
     }
 
   private:
+    std::shared_ptr<NoiseModel<double, 3, Eigen::Vector3d>> noise_model;
+    const std::shared_ptr<RigidBodyFrame> frame;
+};
+
+    /** RigidBodyGyroscope
+     * @brief Simulates a sensor that measures angular rates
+     */
+class DRAKERBSYSTEM_EXPORT RigidBodyMagnetometer : public RigidBodySensor {
+  public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    RigidBodyMagnetometer(RigidBodySystem const& sys, const std::string& name, const std::shared_ptr<RigidBodyFrame> frame, double declination);
+    virtual ~RigidBodyMagnetometer() {}
+
+    virtual size_t getNumOutputs() const override { return 3; }
+    virtual Eigen::VectorXd output(const double& t, const KinematicsCache<double>& rigid_body_state, const RigidBodySystem::InputVector<double>& u) const override;
+
+    void setNoiseModel(std::shared_ptr<NoiseModel<double, 3, Eigen::Vector3d>> model) {
+        noise_model = model;
+    }
+
+    void setDeclination(double magnetic_declination) {
+      magnetic_north << cos(M_PI/2 + magnetic_declination), 
+                        sin(M_PI/2 + magnetic_declination), 
+                        0;
+    }
+
+  private:
+    Eigen::Vector3d magnetic_north;
     std::shared_ptr<NoiseModel<double, 3, Eigen::Vector3d>> noise_model;
     const std::shared_ptr<RigidBodyFrame> frame;
 };

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -142,13 +142,13 @@ class DRAKERBSYSTEM_EXPORT RigidBodySystem {
   RigidBodySystem(const std::shared_ptr<RigidBodyTree>& rigid_body_tree)
       : tree(rigid_body_tree),
         use_multi_contact(false),
-        penetration_stiffness(50.0),
+        penetration_stiffness(150.0),
         penetration_damping(penetration_stiffness / 10.0),
         friction_coefficient(1.0),
         direct_feedthrough(false) {};
   RigidBodySystem()
       : use_multi_contact(false),
-        penetration_stiffness(50.0),
+        penetration_stiffness(150.0),
         penetration_damping(penetration_stiffness / 10.0),
         friction_coefficient(1.0),
         direct_feedthrough(false) {

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -78,6 +78,10 @@ if (LCM_FOUND)
   target_link_libraries(testGyroscope drakeRBSystem)
   add_test(NAME testGyroscope COMMAND testGyroscope)
 
+  add_executable(testMagnetometer testMagnetometer.cpp)
+  target_link_libraries(testMagnetometer drakeRBSystem)
+  add_test(NAME testMagnetometer COMMAND testMagnetometer)
+
   add_executable(compareRigidBodySystems compareRigidBodySystems.cpp)
   target_link_libraries(compareRigidBodySystems drakeRBSystem)
   add_test(NAME compareAcrobotURDFtoSDF COMMAND compareRigidBodySystems Acrobot.urdf Acrobot.sdf WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/examples/Acrobot")

--- a/drake/systems/plants/test/testAccelerometer.cpp
+++ b/drake/systems/plants/test/testAccelerometer.cpp
@@ -12,7 +12,7 @@ Vector3d getAccelerometerOutput(shared_ptr<RigidBodySystem> const& sys, Vector3d
   x0.head(tree->num_positions) = tree->getZeroConfiguration();
   x0.segment(3, 4) = rpy2quat(rpy);
   auto const& system_output = sys->output(0, x0, u);
-  return system_output.tail<3>();
+  return system_output.segment<3>(13);
 }
 
 
@@ -61,4 +61,13 @@ int main(int argc, char* argv[]) {
                    Vector3d(-g, 0, 0),
                    tol);
 
+  //real accelerometers can't measure gravity during freefall
+  accelerometer->setGravityCompensation(true);
+  valuecheckMatrix(getAccelerometerOutput(rigid_body_sys, Vector3d::Zero(), Vector4d::Zero()),
+                 Vector3d(0, 0, 0),
+                 tol);
+
+  valuecheckMatrix(getAccelerometerOutput(rigid_body_sys, Vector3d(M_PI, 0, 0), Vector4d::Zero()),
+                   Vector3d(0, 0, 0),
+                   tol);
 }

--- a/drake/systems/plants/test/testAccelerometer.cpp
+++ b/drake/systems/plants/test/testAccelerometer.cpp
@@ -12,7 +12,7 @@ Vector3d getAccelerometerOutput(shared_ptr<RigidBodySystem> const& sys, Vector3d
   x0.head(tree->num_positions) = tree->getZeroConfiguration();
   x0.segment(3, 4) = rpy2quat(rpy);
   auto const& system_output = sys->output(0, x0, u);
-  return system_output.segment<3>(13);
+  return system_output.tail<3>();
 }
 
 

--- a/drake/systems/plants/test/testAccelerometer.cpp
+++ b/drake/systems/plants/test/testAccelerometer.cpp
@@ -62,6 +62,7 @@ int main(int argc, char* argv[]) {
                    tol);
 
   //real accelerometers can't measure gravity during freefall
+  //but will measure gravity while hovering
   accelerometer->setGravityCompensation(true);
   valuecheckMatrix(getAccelerometerOutput(rigid_body_sys, Vector3d::Zero(), Vector4d::Zero()),
                  Vector3d(0, 0, 0),
@@ -69,5 +70,9 @@ int main(int argc, char* argv[]) {
 
   valuecheckMatrix(getAccelerometerOutput(rigid_body_sys, Vector3d(M_PI, 0, 0), Vector4d::Zero()),
                    Vector3d(0, 0, 0),
+                   tol);
+
+  valuecheckMatrix(getAccelerometerOutput(rigid_body_sys, Vector3d::Zero(), hoverThrust),
+                   Vector3d(0, 0, g),
                    tol);
 }

--- a/drake/systems/plants/test/testMagnetometer.cpp
+++ b/drake/systems/plants/test/testMagnetometer.cpp
@@ -1,0 +1,52 @@
+#include "drake/systems/plants/RigidBodySystem.h"
+#include "drake/util/testUtil.h"
+
+using namespace std;
+using namespace Drake;
+using namespace Eigen;
+
+
+Vector3d getMagnetometerOutput(shared_ptr<RigidBodySystem> const& sys, Vector3d const& rpy) {
+  VectorXd x0 = VectorXd::Zero(sys->getNumStates());
+  auto const & tree = sys->getRigidBodyTree();
+  x0.head(tree->num_positions) = tree->getZeroConfiguration();
+  x0.segment(3, 4) = rpy2quat(rpy);
+  auto const& system_output = sys->output(0, x0, Vector4d::Zero());
+  return system_output.tail<3>();
+}
+
+
+int main(int argc, char* argv[]) {  
+
+  DrakeJoint::FloatingBaseType floating_base_type = DrakeJoint::QUATERNION;
+  auto rigid_body_sys = make_shared<RigidBodySystem>();
+  rigid_body_sys->addRobotFromFile(getDrakePath()+"/examples/Quadrotor/quadrotor.urdf", floating_base_type);
+  
+  auto const & tree = rigid_body_sys->getRigidBodyTree();
+  auto sensor_frame = tree->findFrame("body");
+  
+  auto magnetometer = make_shared<RigidBodyMagnetometer>(*rigid_body_sys, "magnetometer", sensor_frame, 0.0);
+  rigid_body_sys->addSensor(magnetometer);
+  
+  const double tol = 1e-6;
+
+  valuecheckMatrix(getMagnetometerOutput(rigid_body_sys, Vector3d::Zero()),
+                   Vector3d(0, 1, 0),
+                   tol);
+
+
+  valuecheckMatrix(getMagnetometerOutput(rigid_body_sys, Vector3d(0,0,M_PI/2)),
+                 Vector3d(1, 0, 0),
+                 tol);
+
+  magnetometer->setDeclination(M_PI/4);
+
+  valuecheckMatrix(getMagnetometerOutput(rigid_body_sys, Vector3d::Zero()),
+                 Vector3d(-std::sqrt(2)/2, std::sqrt(2)/2, 0),
+                 tol);
+
+  valuecheckMatrix(getMagnetometerOutput(rigid_body_sys,  Vector3d(0,0,M_PI/2)),
+                 Vector3d(std::sqrt(2)/2, std::sqrt(2)/2, 0),
+                 tol);
+
+}


### PR DESCRIPTION
Implements RigidBodyMagnetometer with the ability to set declination angle.

Adds a gravity compensation flag to RigidBodyAccelerometer since real accelerometers can't measure gravity in freefall.

Adds a new quadrotor urdf with the motors mounted according to PX4 standards and the thrust ratios adjusted to be in line with current hardware.

With these changes, the quadrotor example can be successfully flown manually by piping simulated IMU data into the pixhawk firmware and shuttling the motor commands back to Drake:

https://youtu.be/eVpiBn5erZY

Resolves one of the last remaining features in https://github.com/RobotLocomotion/drake/issues/1731


