### PR TITLE
Move getDrakePath back into the Drake namespace, using inline keyword.

### DIFF
--- a/drake/core/Path.h.in
+++ b/drake/core/Path.h.in
@@ -2,9 +2,9 @@
 
 #include <string>
 
-namespace {
-  const std::string& getDrakePath() {
-    static std::string root("@PROJECT_SOURCE_DIR@");
-    return root;
-  }
+namespace Drake {
+inline const std::string& getDrakePath() {
+  static std::string root("@PROJECT_SOURCE_DIR@");
+  return root;
+}
 } // end namespace Drake

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -110,7 +110,7 @@ void applyURDFModifications(std::unique_ptr<RigidBodyTree>& robot,
       throw std::runtime_error(
           "Could not find attachment frame when handling urdf modifications");
     }
-    robot->addRobotFromURDF(getDrakePath() + "/" + it->urdf_filename,
+    robot->addRobotFromURDF(Drake::getDrakePath() + "/" + it->urdf_filename,
                             it->joint_type, attach_to_frame);
   }
 

--- a/drake/systems/plants/xmlUtil.cpp
+++ b/drake/systems/plants/xmlUtil.cpp
@@ -150,7 +150,7 @@ void searchDirectory(map<string, string>& package_map, string path) {
 }
 
 void populatePackageMap(map<string, string>& package_map) {
-  searchDirectory(package_map, getDrakePath());
+  searchDirectory(package_map, Drake::getDrakePath());
 
   char* cstrpath = getenv("ROS_ROOT");
   if (cstrpath) searchDirectory(package_map, cstrpath);


### PR DESCRIPTION
(This is in response to the discussion from #1857)