### PR TITLE
Remove ignored qualifiers

### DIFF
--- a/drake/systems/plants/joints/DrakeJoint.cpp
+++ b/drake/systems/plants/joints/DrakeJoint.cpp
@@ -25,9 +25,9 @@ const Isometry3d& DrakeJoint::getTransformToParentBody() const {
   return transform_to_parent_body;
 }
 
-const int DrakeJoint::getNumPositions() const { return num_positions; }
+int DrakeJoint::getNumPositions() const { return num_positions; }
 
-const int DrakeJoint::getNumVelocities() const { return num_velocities; }
+int DrakeJoint::getNumVelocities() const { return num_velocities; }
 
 const std::string& DrakeJoint::getName() const { return name; }
 

--- a/drake/systems/plants/joints/DrakeJoint.h
+++ b/drake/systems/plants/joints/DrakeJoint.h
@@ -77,9 +77,9 @@ class DRAKEJOINTS_EXPORT DrakeJoint {
 
   const Eigen::Isometry3d &getTransformToParentBody() const;
 
-  const int getNumPositions() const;
+  int getNumPositions() const;
 
-  const int getNumVelocities() const;
+  int getNumVelocities() const;
 
   const std::string &getName() const;
 

--- a/drake/systems/plants/shapes/Element.cpp
+++ b/drake/systems/plants/shapes/Element.cpp
@@ -18,7 +18,7 @@ const Isometry3d& Element::getLocalTransform() const {
   return T_element_to_local;
 }
 
-const Shape Element::getShape() const { return geometry->getShape(); }
+Shape Element::getShape() const { return geometry->getShape(); }
 
 void Element::setGeometry(const Geometry& geometry) {
   this->geometry = std::unique_ptr<Geometry>(geometry.clone());

--- a/drake/systems/plants/shapes/Element.h
+++ b/drake/systems/plants/shapes/Element.h
@@ -34,7 +34,7 @@ class DRAKESHAPES_EXPORT Element {
 
   virtual void updateWorldTransform(const Eigen::Isometry3d& T_local_to_world);
 
-  const Shape getShape() const;
+  Shape getShape() const;
 
   void setGeometry(const Geometry& geometry);
 

--- a/drake/systems/plants/shapes/Geometry.cpp
+++ b/drake/systems/plants/shapes/Geometry.cpp
@@ -17,7 +17,7 @@ Geometry::Geometry(const Geometry &other) { shape = other.getShape(); }
 
 Geometry::Geometry(Shape shape) : shape(shape){};
 
-const Shape Geometry::getShape() const { return shape; }
+Shape Geometry::getShape() const { return shape; }
 
 Geometry *Geometry::clone() const { return new Geometry(*this); }
 

--- a/drake/systems/plants/shapes/Geometry.h
+++ b/drake/systems/plants/shapes/Geometry.h
@@ -30,7 +30,7 @@ class DRAKESHAPES_EXPORT Geometry {
 
   virtual Geometry *clone() const;
 
-  const Shape getShape() const;
+  Shape getShape() const;
 
   virtual void getPoints(Eigen::Matrix3Xd &points) const;
   virtual void getBoundingBoxPoints(Eigen::Matrix3Xd &points) const;


### PR DESCRIPTION
Remove `const` qualifier applied to POD return types. These have no meaning according to the C++ standard, and the compiler is free to (and does) remove them. As a result, their presence gives an inaccurate impression as to the return value type. (This fixes warnings raised by `-Wignored-qualifiers`.)