### PR TITLE
Fixed the lidarTest, testAccelerometer, and testGyroscope Unit Tests

### DIFF
--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -208,6 +208,10 @@ RigidBodySystem::OutputVector<double> RigidBodySystem::output(const double& t,
 {
   auto kinsol = tree->doKinematics(x.topRows(tree->num_positions), x.bottomRows(tree->num_velocities));
   Eigen::VectorXd y(getNumOutputs());
+
+  assert(getNumStates() == x.size());
+  assert(getNumInputs() == u.size());
+
   y.segment(0, getNumStates()) << x;
   int index=getNumStates();
   for (const auto& s : sensors) {

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -208,7 +208,7 @@ RigidBodySystem::OutputVector<double> RigidBodySystem::output(const double& t,
 {
   auto kinsol = tree->doKinematics(x.topRows(tree->num_positions), x.bottomRows(tree->num_velocities));
   Eigen::VectorXd y(getNumOutputs());
-  y << x;
+  y.segment(0, getNumStates()) << x;
   int index=getNumStates();
   for (const auto& s : sensors) {
     y.segment(index, s->getNumOutputs()) = s->output(t, kinsol, u);

--- a/drake/systems/plants/test/lidarTest.cpp
+++ b/drake/systems/plants/test/lidarTest.cpp
@@ -17,8 +17,8 @@ int main(int argc, char* argv[]) {
   rigid_body_sys->addRobotFromFile(getDrakePath() + "/systems/plants/test/lidarTest.sdf", DrakeJoint::FIXED);
 
   double t = 0;
-  VectorXd x = VectorXd::Zero(0);
-  VectorXd u = VectorXd::Zero(0);
+  VectorXd x = VectorXd::Zero(rigid_body_sys->getNumStates());
+  VectorXd u = VectorXd::Zero(rigid_body_sys->getNumInputs());
 
   //  rigid_body_sys->getRigidBodyTree()->drawKinematicTree("/tmp/lidar.dot");
 


### PR DESCRIPTION
See: https://github.com/RobotLocomotion/drake/issues/1907 and https://github.com/RobotLocomotion/drake/issues/1915.

Note that this simply allows the test to execute. It does not address https://github.com/RobotLocomotion/drake/issues/1712.