### PR TITLE
Fix addConstraint function names in OptimizationProgram to follow sty…

### DIFF
--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -83,7 +83,7 @@ void trivialLeastSquares() {
 
   std::shared_ptr<BoundingBoxConstraint> bbcon(new BoundingBoxConstraint(
       MatrixXd::Constant(2, 1, -1000.0), MatrixXd::Constant(2, 1, 1000.0)));
-  prog.addConstraint(bbcon, {x.head(2)});
+  prog.addBoundingBoxConstraint(bbcon, {x.head(2)});
   prog.solve();  // now it will solve as a nonlinear program
   valuecheckMatrix(b.topRows(2) / 2, y.value(), 1e-10);
   valuecheckMatrix(b / 3, x.value(), 1e-10);
@@ -173,7 +173,7 @@ void gloptipolyConstrainedMinimization() {
   prog.addCost(GloptipolyConstrainedExampleObjective());
   std::shared_ptr<GloptipolyConstrainedExampleConstraint> qp_con(
       new GloptipolyConstrainedExampleConstraint());
-  prog.addConstraint(qp_con, {x});
+  prog.addGenericConstraint(qp_con, {x});
   prog.addLinearConstraint(
       Vector3d(1, 1, 1).transpose(),
       Vector1d::Constant(-numeric_limits<double>::infinity()),

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -287,14 +287,14 @@ Drake::getInitialState(const RigidBodySystem& sys) {
           loops[i].frameB->frame_index, bTbp, tspan);
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con1wrapper(
           new SingleTimeKinematicConstraintWrapper(con1));
-      prog.addConstraint(con1wrapper, {qvar});
+      prog.addGenericConstraint(con1wrapper, {qvar});
       auto con2 = make_shared<RelativePositionConstraint>(
           sys.tree.get(), loops[i].axis, loops[i].axis, loops[i].axis,
           loops[i].frameA->frame_index, loops[i].frameB->frame_index, bTbp,
           tspan);
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(
           new SingleTimeKinematicConstraintWrapper(con2));
-      prog.addConstraint(con2wrapper, {qvar});
+      prog.addGenericConstraint(con2wrapper, {qvar});
     }
 
     VectorXd q_guess = x0.topRows(nq);


### PR DESCRIPTION
…le guide.

The addConstraint() variants were already being used incorrectly in
testOptimizationProblem, where a bounding box constraint was being
added as a generic constraint.  This should hopefully make that type
of error more difficult.

See https://google.github.io/styleguide/cppguide.html#Function_Overloading

I'm pretty sure this pull request conflicts with a number of other PRs which are also in flight.  I don't know what to do about that.  We can't all hold back our changes, so I guess it's conflict resolution roulette where the winner gets merged first.
