### PR TITLE
Fix lidar test for drake-visualizer's benefit

### DIFF
--- a/drake/systems/plants/test/lidarTest.cpp
+++ b/drake/systems/plants/test/lidarTest.cpp
@@ -47,8 +47,14 @@ int main(int argc, char* argv[]) {
     }
   }
 
+  // render for debugging; do this before publishing lidar so visualizer knows
+  // the sensor position
   auto lcm = make_shared<lcm::LCM>();
+  auto visualizer = make_shared<BotVisualizer<RigidBodySystem::StateVector>>(
+      lcm, rigid_body_sys->getRigidBodyTree());
+  visualizer->output(t, x, u);
 
+  // publish lidar message
   bot_core::planar_lidar_t msg;
   msg.utime = -1;
   msg.nintensities = 0;
@@ -59,12 +65,7 @@ int main(int argc, char* argv[]) {
   for (int i = 0; i < distances.size(); i++)
     msg.ranges.push_back(distances(i));
 
-  lcm->publish("DRAKE_POINTCLOUD_LIDAR_TEST", &msg);
-
-  // render for debugging:
-  auto visualizer = make_shared<BotVisualizer<RigidBodySystem::StateVector>>(
-      lcm, rigid_body_sys->getRigidBodyTree());
-  visualizer->output(t, x, u);
+  lcm->publish("DRAKE_PLANAR_LIDAR_0_rear_wall", &msg);
 
   return 0;
 }


### PR DESCRIPTION
Modify lidar test to emit the "world visualization" first, so that drake-visualizer can determine the location of the lidar sensor (which it needs to know before it receives lidar messages). Modify lidar message channel name to incorporate the sensor link name.

Needed to actually "see" the lidar with RobotLocomotion/director#234.