### PR TITLE
Updated Sphinx Docs with cpplint info and OS X text editor info

### DIFF
--- a/drake/doc/code_style_guide.rst
+++ b/drake/doc/code_style_guide.rst
@@ -11,15 +11,24 @@ Note: Many of the files in the repository were written before this style guide, 
 C++ Style
 =========
 
-We now strictly follow the `Google C++ Style Guide <https://google.github.io/styleguide/cppguide.html>`_ .  Here are some additional comments:
+We follow a slightly modified version of the `Google C++ Style Guide <https://google.github.io/styleguide/cppguide.html>`_ .  Here are the modifications:
 
 * Always prefer long, human-readable variable/method/class names to short acronyms.
 * Manually provide user gradients only when we know more than AutoDiffScalar possibly could (e.g. sparsity of the gradients).
 * Use exceptions for error handling.  Essential control loops must be exception safe.
-* Aim for no dynamic allocation in the inner simulation/control loops.  Code should be still be thread-safe (e.g. be careful with pre-allocations).
+* No dynamic allocation in the inner simulation/control loops.  Code should be still be thread-safe (e.g. be careful with pre-allocations).
 * Classes and methods should be documented using [doxygen](https://www.stack.nl/~dimitri/doxygen/manual/docblocks.html).
-* Embrace templates/C++11 when it makes the code more correct (more clear readable also implies more correct).  Minimize template requirements on public interfaces.  Avoid explicit template instantiations in cc files when possible.
+* Embrace templates/C++11 when it makes the code more correct (more clear or more readable also implies more correct).  Minimize template requirements on public interfaces.  Avoid explicit template instantiations in cc files when possible.
+* No need for a copyright line at the top of every file (this will change soon).
 
+There are several tools that can be used to achieve style compliance. They are listed below.
+
+cpplint
+-------
+
+`cpplint <https://github.com/google/styleguide/tree/gh-pages/cpplint>`_ is a tool for finding compliance violations. Here is the command:
+
+    cpplint --filter="-legal/copyright" [file name]
 
 MATLAB Style
 ============

--- a/drake/doc/code_style_guide.rst
+++ b/drake/doc/code_style_guide.rst
@@ -6,7 +6,13 @@ This section defines a style guide which should be followed by all code that is 
 in Drake. Being consistent with this style will make the code easier to read, debug,
 and maintain.
 
-Note: Many of the files in the repository were written before this style guide, or did not follow it precisely.  If you find style errors, go ahead and change it and submit a pull request.
+Note: Many of the files in the repository were written before this style guide, or did
+not follow it precisely.  If you find style errors, go ahead and change it and submit
+a pull request.
+
+.. contents:: `Table of contents`
+   :depth: 3
+   :local:
 
 C++ Style
 =========
@@ -34,8 +40,17 @@ Exceptions
 
 There are several tools that can be used to achieve style compliance. They are listed below.
 
+Tools
+-----
+There are several tools for helping you to compile with the required style. They are listed below.
+
+ClangFormat
+^^^^^^^^^^^
+
+(*Notes comming soon*)
+
 cpplint
--------
+^^^^^^^
 
 `cpplint <https://github.com/google/styleguide/tree/gh-pages/cpplint>`_ is a tool for finding compliance violations. Here is the command:
 
@@ -59,7 +74,7 @@ Java Style
 
 We also strictly follow the `Google Java Style Guide` <https://google.github.io/styleguide/javaguide.html>`_ .  Here are some additional comments:
 
-* Every class and method should have a brief _javadoc_ associated with it.
+* Every class and method should have a brief `_javadoc_` associated with it.
 * All Java classes should be in packages relative to the Drake root,
    e.g.: package drake.examples.Pendulum
 
@@ -67,7 +82,7 @@ We also strictly follow the `Google Java Style Guide` <https://google.github.io/
 LCM Style
 =========
 
-* LCM types are under_scored with a leading lcmt_ added. If the type is specific to a particular robot, then it begins with lcmt_robotname_.
+* LCM types are under_scored with a leading `lcmt_` added. If the type is specific to a particular robot, then it begins with `lcmt_robotname_`.
 * Variable names in LCM types follow the rules above.
 
 

--- a/drake/doc/development_on_osx.rst
+++ b/drake/doc/development_on_osx.rst
@@ -33,7 +33,7 @@ The version of `git <https://git-scm.com>`_ that comes with OS X may not include
     brew update
     brew install git
 
-If gitk does not start with an ``unknown color name "lime"`` error, upgrade your vesrion of Tcl/Tk:
+If gitk does not start with an ``unknown color name "lime"`` error, upgrade your version of Tcl/Tk:
 
     brew cask install tcl
 

--- a/drake/doc/development_on_osx.rst
+++ b/drake/doc/development_on_osx.rst
@@ -6,8 +6,19 @@ This page contains information that may be useful to people developing in OS X.
 
 *Note that the applications, tools, and libraries listed below are simply those that some have found useful. They should* **not** *be interpreted as mandatory.*
 
-Installing pygame
-===================================
+.. contents:: `Table of contents`
+   :depth: 2
+   :local:
+
+cpplint
+=======
+
+cpplint is a tool for checking whether C++ code conforms to a certain style. To install it on OS X, execute:
+
+    pip install cpplint
+
+pygame
+======
 
 `pygame <http://pygame.org>`_ is used by ``drake/examples/Cars/SteeringCommandDriver.py``.
 
@@ -25,8 +36,11 @@ Ensure your ``PYTHONPATH`` environment variable includes Drake's site-package an
 
 
 
-Running gitk
-============
+git Tools
+=========
+
+gitk
+----
 
 The version of `git <https://git-scm.com>`_ that comes with OS X may not include `gitk <https://git-scm.com/docs/gitk>`_, a GUI-based git repository browser. A workaround is to get a newer version using brew:
 
@@ -41,3 +55,31 @@ References:
 
 1. http://stackoverflow.com/questions/34637896/gitk-will-not-start-on-mac-unknown-color-name-lime
 2. http://stackoverflow.com/questions/17582685/install-gitk-on-mac
+
+SourceTree
+-----------
+
+`SourceTree <https://www.sourcetreeapp.com>`_ is a free git and mercurial client for Windows and Mac made by Atlassian.
+
+(*Notes comming soon*)
+
+Text Editors and IDEs
+=====================
+
+Below are some notes on various text edtiors and IDEs we've used on OS X.
+
+CLion
+-----
+
+(*Notes comming soon*)
+
+Sublime Text
+------------
+
+Recommended packages to install:
+
+1. https://packagecontrol.io/packages/SublimeLinter-cpplint
+
+To display the current file's full path in the title bar, open your user preferences by going to "Sublime Text," "Preferences," "Settings - User." Then add the following to your user preferences:
+
+    "show_full_path": true


### PR DESCRIPTION
Note that the `cpplint` command currently ignores the copyright rule. We will update the documentation to not have this exception once https://github.com/RobotLocomotion/drake/issues/1805 is resolved.