### PR TITLE
Update the ubuntu installation instructions

### DIFF
--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -56,6 +56,5 @@ When you are done with these platform-specific steps, return to :doc:`from_sourc
 
 Note that when you run drake commands from now on (including the
 ones in the linked instructions, such as `make` or `make test`),
-you must always precede them with
-`env CXX=g++-4.9 CC=gcc-4.9 PATH=/usr/lib/ccache:$PATH`,
+you must always precede them with `env CXX=g++-4.9 CC=gcc-4.9`,
 just like you did in the the `make options` step above).

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -30,13 +30,18 @@ Install the prerequisites::
     # Ubuntu 14.04 LTS (Trusty)
     sudo apt-get install cmake-curses-gui
 
+    # These are not required for the basic "make" rule.  We suggest that you
+    # wait to do this step until you actually need these tools.  (We intend
+    # to switch to non-pip instructions once that approach has been tested.)
     sudo pip install -U cpplint Sphinx
 
 Download the external dependencies::
 
     cd drake-distro
-    make options  # use the GUI to choose which externals you want, then press 'c' to configure, then 'g' to generate makefiles and exit
-    make download-all
+    env CXX=g++-4.9 CC=gcc-4.9 PATH=/usr/lib/ccache:$PATH make options
+    # Use the GUI to choose which externals you want, then press 'c' twice to configure, then 'g' to generate makefiles and exit.
+    # If you intend to modify Drake, we suggest that you set CMAKE_BUILD_TYPE to Debug instead of Release after the first 'g'.
+    env CXX=g++-4.9 CC=gcc-4.9 PATH=/usr/lib/ccache:$PATH make download-all
 
 The version of the standard C++ libraries that are shipped with the Linux distribution of MATLAB is severely outdated and can cause problems when running mex files that are built against a newer version of the standard.  The typical error message in this case reports "Invalid MEX-Files"
 
@@ -49,3 +54,9 @@ Update the symbolic link in MATLAB to point to the version that was installed ea
     sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/4.9/libstdc++.so libstdc++.so.6
 
 When you are done with these platform-specific steps, return to :doc:`from_source` to complete and test your installation.
+
+Note that when you run drake commands from now on (including the
+ones in the linked instructions, such as `make` or `make test`),
+you must always precede them with
+`env CXX=g++-4.9 CC=gcc-4.9 PATH=/usr/lib/ccache:$PATH`,
+just like you did in the the `make options` step above).

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -30,8 +30,6 @@ Install the prerequisites::
     # Ubuntu 14.04 LTS (Trusty)
     sudo apt-get install cmake-curses-gui
 
-    # These are not required for the basic "make" rule.  We suggest that you
-    # wait to do this step until you actually need these tools.
     sudo pip install -U cpplint Sphinx
 
 Download the external dependencies::

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -31,8 +31,7 @@ Install the prerequisites::
     sudo apt-get install cmake-curses-gui
 
     # These are not required for the basic "make" rule.  We suggest that you
-    # wait to do this step until you actually need these tools.  (We intend
-    # to switch to non-pip instructions once that approach has been tested.)
+    # wait to do this step until you actually need these tools.
     sudo pip install -U cpplint Sphinx
 
 Download the external dependencies::
@@ -40,7 +39,6 @@ Download the external dependencies::
     cd drake-distro
     env CXX=g++-4.9 CC=gcc-4.9 PATH=/usr/lib/ccache:$PATH make options
     # Use the GUI to choose which externals you want, then press 'c' twice to configure, then 'g' to generate makefiles and exit.
-    # If you intend to modify Drake, we suggest that you set CMAKE_BUILD_TYPE to Debug instead of Release after the first 'g'.
     env CXX=g++-4.9 CC=gcc-4.9 PATH=/usr/lib/ccache:$PATH make download-all
 
 The version of the standard C++ libraries that are shipped with the Linux distribution of MATLAB is severely outdated and can cause problems when running mex files that are built against a newer version of the standard.  The typical error message in this case reports "Invalid MEX-Files"

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -37,9 +37,9 @@ Install the prerequisites::
 Download the external dependencies::
 
     cd drake-distro
-    env CXX=g++-4.9 CC=gcc-4.9 PATH=/usr/lib/ccache:$PATH make options
+    env CXX=g++-4.9 CC=gcc-4.9 make options
     # Use the GUI to choose which externals you want, then press 'c' twice to configure, then 'g' to generate makefiles and exit.
-    env CXX=g++-4.9 CC=gcc-4.9 PATH=/usr/lib/ccache:$PATH make download-all
+    env CXX=g++-4.9 CC=gcc-4.9 make download-all
 
 The version of the standard C++ libraries that are shipped with the Linux distribution of MATLAB is severely outdated and can cause problems when running mex files that are built against a newer version of the standard.  The typical error message in this case reports "Invalid MEX-Files"
 
@@ -50,6 +50,9 @@ Update the symbolic link in MATLAB to point to the version that was installed ea
     cd /usr/local/MATLAB/R2015b/sys/os/glnxa64
     sudo rm libstdc++.so.6
     sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/4.9/libstdc++.so libstdc++.so.6
+
+You may wish to use `ccache` to speed up your (re)builds.
+To do so, add `/usr/lib/ccache` to the front of your `$PATH`.
 
 When you are done with these platform-specific steps, return to :doc:`from_source` to complete and test your installation.
 


### PR DESCRIPTION
Update the ubuntu installation instructions to document the current way of setting up g++-4.9 as the default compiler.