### PR TITLE
Add drake/core/test/pendulum.h, and use it in vector_test.

### DIFF
--- a/drake/core/test/CMakeLists.txt
+++ b/drake/core/test/CMakeLists.txt
@@ -1,6 +1,5 @@
-if (LCM_FOUND AND GTEST_FOUND) # LCM is only needed because it's using Pendulum.h for examples...
+if (GTEST_FOUND)
   add_executable(vector_test vector_test.cc)
   target_link_libraries(vector_test ${GTEST_BOTH_LIBRARIES})
-  add_dependencies(vector_test drake_lcmtypes lcmtype_agg_hpp)
   add_test(NAME vector_test COMMAND vector_test)
-endif (LCM_FOUND AND GTEST_FOUND)
+endif (GTEST_FOUND)

--- a/drake/core/test/pendulum.h
+++ b/drake/core/test/pendulum.h
@@ -1,0 +1,65 @@
+#ifndef DRAKE_CORE_TEST_PENDULUM_H_
+#define DRAKE_CORE_TEST_PENDULUM_H_
+
+#include <cmath>
+
+#include <Eigen/Dense>
+
+namespace drake {
+namespace core {
+namespace test {
+
+/// A simple Drake state for unit testing.
+template <typename ScalarType = double>
+class PendulumState {  // models the Drake::Vector concept
+ public:
+  PendulumState(void) : theta(0), thetadot(0) {}
+  template <typename Derived>
+  PendulumState(const Eigen::MatrixBase<Derived>& x)
+      : theta(x(0)), thetadot(x(1)) {}
+
+  template <typename Derived>
+  PendulumState& operator=(const Eigen::MatrixBase<Derived>& x) {
+    theta = x(0);
+    thetadot = x(1);
+    return *this;
+  }
+
+  friend Eigen::Matrix<ScalarType, 2, 1> toEigen(
+      const PendulumState<ScalarType>& vec) {
+    Eigen::Matrix<ScalarType, 2, 1> x;
+    x << vec.theta, vec.thetadot;
+    return x;
+  }
+
+  const static int RowsAtCompileTime = 2;
+
+  ScalarType theta;
+  ScalarType thetadot;
+};
+
+/// A simple Drake input for unit testing.
+template <typename ScalarType = double>
+class PendulumInput {
+ public:
+  PendulumInput(void) : tau(0) {}
+  template <typename Derived>
+  PendulumInput(const Eigen::MatrixBase<Derived>& x)
+      : tau(x(0)) {}
+
+  template <typename Derived>
+  PendulumInput& operator=(const Eigen::MatrixBase<Derived>& x) {
+    tau = x(0);
+    return *this;
+  }
+
+  const static int RowsAtCompileTime = 1;
+
+  ScalarType tau;
+};
+
+}  // namespace test
+}  // namespace core
+}  // namespace drake
+
+#endif  // DRAKE_CORE_TEST_PENDULUM_H_

--- a/drake/core/test/pendulum.h
+++ b/drake/core/test/pendulum.h
@@ -30,7 +30,7 @@ class PendulumState {  // models the Drake::Vector concept
     return x;
   }
 
-  const static int RowsAtCompileTime = 2;
+  static const int RowsAtCompileTime = 2;
 
   ScalarType theta;
   ScalarType thetadot;
@@ -51,7 +51,7 @@ class PendulumInput {
     return *this;
   }
 
-  const static int RowsAtCompileTime = 1;
+  static const int RowsAtCompileTime = 1;
 
   ScalarType tau;
 };

--- a/drake/core/test/pendulum.h
+++ b/drake/core/test/pendulum.h
@@ -1,8 +1,6 @@
 #ifndef DRAKE_CORE_TEST_PENDULUM_H_
 #define DRAKE_CORE_TEST_PENDULUM_H_
 
-#include <cmath>
-
 #include <Eigen/Dense>
 
 namespace drake {

--- a/drake/core/test/vector_test.cc
+++ b/drake/core/test/vector_test.cc
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
-#include "drake/examples/Pendulum/Pendulum.h"  // to get some types
+#include "drake/core/Core.h"
+#include "drake/core/test/pendulum.h"
 #include "drake/util/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
@@ -10,9 +11,12 @@ using Drake::CombinedVectorUtil;
 using Drake::NullVector;
 using Drake::InputOutputRelation;
 using drake::util::MatrixCompareType;
+using std::is_same;
+using std::string;
 
 namespace drake {
 namespace core {
+namespace test {
 namespace {
 
 // Tests the ability to set a PendulumState equal to a vector and vice versa.
@@ -138,5 +142,6 @@ TEST(VectorTest, InputOutputRelationCombinationTests) {
 }
 
 }  // namespace
+}  // namespace test
 }  // namespace core
 }  // namespace drake


### PR DESCRIPTION
Add drake/core/test/pendulum.h, and use it in vector_test.
This removes the drake/core/test dependency on examples and LCM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2002)
<!-- Reviewable:end -->
