### PR TITLE
Fix function names in OptimizationProblem (and related)

### DIFF
--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -23,24 +23,24 @@ namespace Drake {
 class Constraint {
   void check(size_t num_constraints) {
     static_cast<void>(num_constraints);
-    assert(lower_bound.size() == num_constraints &&
+    assert(lower_bound_.size() == num_constraints &&
            "Size of lower bound must match number of constraints.");
-    assert(upper_bound.size() == num_constraints &&
+    assert(upper_bound_.size() == num_constraints &&
            "Size of upper bound must match number of constraints.");
   }
 
  public:
   Constraint(size_t num_constraints)
-      : lower_bound(num_constraints), upper_bound(num_constraints) {
+      : lower_bound_(num_constraints), upper_bound_(num_constraints) {
     check(num_constraints);
-    lower_bound.setConstant(-std::numeric_limits<double>::infinity());
-    upper_bound.setConstant(std::numeric_limits<double>::infinity());
+    lower_bound_.setConstant(-std::numeric_limits<double>::infinity());
+    upper_bound_.setConstant(std::numeric_limits<double>::infinity());
   }
 
   template <typename DerivedLB, typename DerivedUB>
   Constraint(size_t num_constraints, Eigen::MatrixBase<DerivedLB> const& lb,
              Eigen::MatrixBase<DerivedUB> const& ub)
-      : lower_bound(lb), upper_bound(ub) {
+      : lower_bound_(lb), upper_bound_(ub) {
     check(num_constraints);
   }
   virtual ~Constraint() {}
@@ -56,12 +56,12 @@ class Constraint {
                                                 // to support non-differentiable
                                                 // functions
 
-  Eigen::VectorXd const& getLowerBound() const { return lower_bound; }
-  Eigen::VectorXd const& getUpperBound() const { return upper_bound; }
-  size_t getNumConstraints() const { return lower_bound.size(); }
+  Eigen::VectorXd const& lower_bound() const { return lower_bound_; }
+  Eigen::VectorXd const& upper_bound() const { return upper_bound_; }
+  size_t num_constraints() const { return lower_bound_.size(); }
 
  protected:
-  Eigen::VectorXd lower_bound, upper_bound;
+  Eigen::VectorXd lower_bound_, upper_bound_;
 };
 
 /** QuadraticConstraint
@@ -74,25 +74,25 @@ class QuadraticConstraint : public Constraint {
                       const Eigen::MatrixBase<Derivedb>& b, double lb,
                       double ub)
       : Constraint(1, Vector1d::Constant(lb), Vector1d::Constant(ub)),
-        Q(Q),
-        b(b) {}
+        Q_(Q),
+        b_(b) {}
   virtual ~QuadraticConstraint() {}
 
   virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                     Eigen::VectorXd& y) const override {
-    y.resize(getNumConstraints());
-    y = .5 * x.transpose() * Q * x + b.transpose() * x;
+    y.resize(num_constraints());
+    y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
   }
   virtual void eval(const Eigen::Ref<const TaylorVecXd>& x,
                     TaylorVecXd& y) const override {
-    y.resize(getNumConstraints());
-    y = .5 * x.transpose() * Q.cast<TaylorVarXd>() * x +
-        b.cast<TaylorVarXd>().transpose() * x;
+    y.resize(num_constraints());
+    y = .5 * x.transpose() * Q_.cast<TaylorVarXd>() * x +
+        b_.cast<TaylorVarXd>().transpose() * x;
   };
 
  private:
-  Eigen::MatrixXd Q;
-  Eigen::VectorXd b;
+  Eigen::MatrixXd Q_;
+  Eigen::VectorXd b_;
 };
 
 // todo: consider implementing DifferentiableConstraint,
@@ -108,32 +108,32 @@ class LinearConstraint : public Constraint {
   LinearConstraint(const Eigen::MatrixBase<DerivedA>& a,
                    const Eigen::MatrixBase<DerivedLB>& lb,
                    const Eigen::MatrixBase<DerivedUB>& ub)
-      : Constraint(a.rows(), lb, ub), A(a) {
-    assert(A.rows() == lb.rows());
+      : Constraint(a.rows(), lb, ub), A_(a) {
+    assert(a.rows() == lb.rows());
   }
   virtual ~LinearConstraint() {}
 
   virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                     Eigen::VectorXd& y) const override {
-    y.resize(getNumConstraints());
-    y = getMatrix() * x;
+    y.resize(num_constraints());
+    y = A_ * x;
   }
   virtual void eval(const Eigen::Ref<const TaylorVecXd>& x,
                     TaylorVecXd& y) const override {
-    y.resize(getNumConstraints());
-    y = getMatrix().cast<TaylorVarXd>() * x;
+    y.resize(num_constraints());
+    y = A_.cast<TaylorVarXd>() * x;
   };
 
-  virtual Eigen::SparseMatrix<double> getSparseMatrix() const {
-    return getMatrix().sparseView();
+  virtual Eigen::SparseMatrix<double> GetSparseMatrix() const {
+    return A_.sparseView();
   }
   virtual const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>&
-  getMatrix() const {
-    return A;
+  A() const {
+    return A_;
   }
 
  protected:
-  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> A;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> A_;
 };
 
 /** LinearEqualityConstraint
@@ -158,14 +158,14 @@ class LinearEqualityConstraint : public LinearConstraint {
   void updateConstraint(const Eigen::MatrixBase<DerivedA>& Aeq,
                         const Eigen::MatrixBase<DerivedB>& beq) {
     assert(Aeq.rows() == beq.rows());
-    if (Aeq.cols() != A.cols())
+    if (Aeq.cols() != A_.cols())
       throw std::runtime_error("Can't change the number of decision variables");
-    A.resize(Aeq.rows(), Eigen::NoChange);
-    A = Aeq;
-    lower_bound.conservativeResize(beq.rows());
-    lower_bound = beq;
-    upper_bound.conservativeResize(beq.rows());
-    upper_bound = beq;
+    A_.resize(Aeq.rows(), Eigen::NoChange);
+    A_ = Aeq;
+    lower_bound_.conservativeResize(beq.rows());
+    lower_bound_ = beq;
+    upper_bound_.conservativeResize(beq.rows());
+    upper_bound_ = beq;
   }
 };
 
@@ -186,12 +186,12 @@ class BoundingBoxConstraint : public LinearConstraint {
 
   virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                     Eigen::VectorXd& y) const override {
-    y.resize(getNumConstraints());
+    y.resize(num_constraints());
     y = x;
   }
   virtual void eval(const Eigen::Ref<const TaylorVecXd>& x,
                     TaylorVecXd& y) const override {
-    y.resize(getNumConstraints());
+    y.resize(num_constraints());
     y = x;
   }
 };
@@ -213,30 +213,30 @@ class LinearComplementarityConstraint : public Constraint {
   template <typename DerivedM, typename Derivedq>
   LinearComplementarityConstraint(const Eigen::MatrixBase<DerivedM>& M,
                                   const Eigen::MatrixBase<Derivedq>& q)
-      : Constraint(q.rows()), M(M), q(q) {}
+      : Constraint(q.rows()), M_(M), q_(q) {}
 
   virtual ~LinearComplementarityConstraint() {}
 
   /** Return Mx + q (the value of the slack variable). */
   virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                     Eigen::VectorXd& y) const override {
-    y.resize(getNumConstraints());
-    y = (M * x) + q;
+    y.resize(num_constraints());
+    y = (M_ * x) + q_;
   }
   virtual void eval(const Eigen::Ref<const TaylorVecXd>& x,
                     TaylorVecXd& y) const override {
-    y.resize(getNumConstraints());
-    y = (M.cast<TaylorVarXd>() * x) + q.cast<TaylorVarXd>();
+    y.resize(num_constraints());
+    y = (M_.cast<TaylorVarXd>() * x) + q_.cast<TaylorVarXd>();
   };
 
-  const Eigen::MatrixXd& getM() const { return M; }
-  const Eigen::VectorXd& getq() const { return q; }
+  const Eigen::MatrixXd& M() const { return M_; }
+  const Eigen::VectorXd& q() const { return q_; }
 
  private:
   // TODO(ggould-tri) We are storing what are likely statically sized matrices
   // in dynamically allocated containers.  This probably isn't optimal.
-  Eigen::MatrixXd M;
-  Eigen::VectorXd q;
+  Eigen::MatrixXd M_;
+  Eigen::VectorXd q_;
 };
 
 } // end namespace Drake

--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -6,79 +6,87 @@
 #include "SnoptSolver.h"
 
 namespace Drake {
-MathematicalProgramInterface::~MathematicalProgramInterface() { }
+MathematicalProgramInterface::~MathematicalProgramInterface() {}
 
 namespace {
 
 class MathematicalProgram : public MathematicalProgramInterface {
  public:
-  virtual ~MathematicalProgram() { }
+  virtual ~MathematicalProgram() {}
 
-/* these would be used to fill out the optimization hierarchy prototyped
-   below
-   virtual MathematicalProgramInterface* addIntegerVariable() { return new
-   MathematicalProgram; }
+  /* these would be used to fill out the optimization hierarchy prototyped
+     below
+     virtual MathematicalProgramInterface* AddIntegerVariable() { return new
+     MathematicalProgram; }
 
-   virtual MathematicalProgramInterface* addLinearCost() { return new
-   MathematicalProgram; }
-   virtual MathematicalProgramInterface* addQuadraticCost() { return new
-   MathematicalProgram; }
-   virtual MathematicalProgramInterface* addCost() { return new
-   MathematicalProgram; }
+     virtual MathematicalProgramInterface* AddLinearCost() { return new
+     MathematicalProgram; }
+     virtual MathematicalProgramInterface* AddQuadraticCost() { return new
+     MathematicalProgram; }
+     virtual MathematicalProgramInterface* AddCost() { return new
+     MathematicalProgram; }
 
-   virtual MathematicalProgramInterface* addSumsOfSquaresConstraint() { return new
-   MathematicalProgram; }
-   virtual MathematicalProgramInterface* addLinearMatrixInequalityConstraint() {
-   return new MathematicalProgram; }
-   virtual MathematicalProgramInterface* addSecondOrderConeConstraint() { return new
-   MathematicalProgram; }
-   virtual MathematicalProgramInterface* addComplementarityConstraint() { return new
-   MathematicalProgram; };
-*/
-  virtual MathematicalProgramInterface* addGenericObjective() override {
+     virtual MathematicalProgramInterface* AddSumsOfSquaresConstraint() { return
+     new
+     MathematicalProgram; }
+     virtual MathematicalProgramInterface* AddLinearMatrixInequalityConstraint()
+     {
+     return new MathematicalProgram; }
+     virtual MathematicalProgramInterface* AddSecondOrderConeConstraint() {
+     return new
+     MathematicalProgram; }
+     virtual MathematicalProgramInterface* AddComplementarityConstraint() {
+     return new
+     MathematicalProgram; };
+  */
+  virtual MathematicalProgramInterface* AddGenericObjective() override {
     return new MathematicalProgram;
   };
-  virtual MathematicalProgramInterface* addGenericConstraint() override {
+  virtual MathematicalProgramInterface* AddGenericConstraint() override {
     return new MathematicalProgram;
   };
-  virtual MathematicalProgramInterface* addLinearConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearConstraint() override {
     return new MathematicalProgram;
   };
-  virtual MathematicalProgramInterface* addLinearEqualityConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearEqualityConstraint() override {
     return new MathematicalProgram;
   };
-  virtual MathematicalProgramInterface*
-  addLinearComplementarityConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearComplementarityConstraint()
+      override {
     return new MathematicalProgram;
   };
-  virtual bool solve(OptimizationProblem& prog) const override {
+  virtual bool Solve(OptimizationProblem& prog) const override {
     throw std::runtime_error("not implemented yet");
   }
 };
 
 class NonlinearProgram : public MathematicalProgram {
  public:
-  virtual MathematicalProgramInterface* addGenericObjective() override {
+  virtual MathematicalProgramInterface* AddGenericObjective() override {
     return new NonlinearProgram;
   };
-  virtual MathematicalProgramInterface* addGenericConstraint() override {
+  virtual MathematicalProgramInterface* AddGenericConstraint() override {
     return new NonlinearProgram;
   };
-  virtual MathematicalProgramInterface* addLinearConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearConstraint() override {
     return new NonlinearProgram;
   };
-  virtual MathematicalProgramInterface* addLinearEqualityConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearEqualityConstraint() override {
     return new NonlinearProgram;
   };
-  virtual MathematicalProgramInterface*
-  addLinearComplementarityConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearComplementarityConstraint()
+      override {
     return new NonlinearProgram;
   }
 
-  virtual bool solve(OptimizationProblem& prog) const override {
-    if (snopt_solver.available()) { return snopt_solver.solve(prog); }
-    if (nlopt_solver.available()) { return nlopt_solver.solve(prog); }
-    return MathematicalProgram::solve(prog);
+  virtual bool Solve(OptimizationProblem& prog) const override {
+    if (snopt_solver.available()) {
+      return snopt_solver.Solve(prog);
+    }
+    if (nlopt_solver.available()) {
+      return nlopt_solver.Solve(prog);
+    }
+    return MathematicalProgram::Solve(prog);
   }
 
  private:
@@ -88,7 +96,8 @@ class NonlinearProgram : public MathematicalProgram {
 
 /*  // Prototype of the more complete optimization problem class hiearchy (to
     be implemented only as needed)
-    struct MixedIntegerNonlinearProgram : public MathematicalProgramInterface {};
+    struct MixedIntegerNonlinearProgram : public MathematicalProgramInterface
+   {};
     struct MixedIntegerSemidefiniteProgram : public
     MixedIntegerNonlinearProgram {};
     struct MixedIntegerSecondOrderConeProgram : public
@@ -106,9 +115,11 @@ class NonlinearProgram : public MathematicalProgram {
     MixedIntegerQuadraticProgram {};
     struct LinearProgram : public QuadraticProgram, public
     MixedIntegerLinearProgram {
-    virtual MathematicalProgramInterface* addLinearEqualityConstraint() { return new
+    virtual MathematicalProgramInterface* AddLinearEqualityConstraint() { return
+   new
     LinearProgram; };
-    virtual MathematicalProgramInterface* addLinearInequalityConstraint() { return
+    virtual MathematicalProgramInterface* AddLinearInequalityConstraint() {
+   return
     new LinearProgram; };
     };
 
@@ -119,59 +130,58 @@ class NonlinearProgram : public MathematicalProgram {
 
 class LinearComplementarityProblem : public MathematicalProgram {
  public:
-  virtual bool solve(OptimizationProblem& prog) const override {
+  virtual bool Solve(OptimizationProblem& prog) const override {
     // TODO ggould given the Moby solver's meticulous use of temporaries, it
     // would be an easy performance win to reuse this solver object by making
     // a static place to store it.
     MobyLCPSolver solver;
-    return solver.solve(prog);
+    return solver.Solve(prog);
   }
-  virtual MathematicalProgramInterface*
-  addLinearComplementarityConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearComplementarityConstraint()
+      override {
     return new LinearComplementarityProblem;
   };
 };
 
-class LeastSquares
-    : public NonlinearProgram {  // public LinearProgram, public
+class LeastSquares : public NonlinearProgram {  // public LinearProgram, public
  public:
   // LinearComplementarityProblem
-  virtual MathematicalProgramInterface* addLinearEqualityConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearEqualityConstraint() override {
     return new LeastSquares;
   };
-  virtual MathematicalProgramInterface*
-  addLinearComplementarityConstraint() override {
+  virtual MathematicalProgramInterface* AddLinearComplementarityConstraint()
+      override {
     return new LinearComplementarityProblem;
   };
 
-  virtual bool solve(OptimizationProblem& prog) const override {
+  virtual bool Solve(OptimizationProblem& prog) const override {
     size_t num_constraints = 0;
-    for (auto const& binding : prog.getLinearEqualityConstraints()) {
-      num_constraints += binding.getConstraint()->getMatrix().rows();
+    for (auto const& binding : prog.linear_equality_constraints()) {
+      num_constraints += binding.constraint()->A().rows();
     }
 
     Eigen::MatrixXd Aeq = Eigen::MatrixXd::Zero(
-        num_constraints, prog.getNumVars());  // todo: use a sparse matrix here?
+        num_constraints, prog.num_vars());  // todo: use a sparse matrix here?
     Eigen::VectorXd beq(num_constraints);
 
     size_t constraint_index = 0;
-    for (auto const& binding :  prog.getLinearEqualityConstraints()) {
-      auto const& c = binding.getConstraint();
-      size_t n = c->getMatrix().rows();
+    for (auto const& binding : prog.linear_equality_constraints()) {
+      auto const& c = binding.constraint();
+      size_t n = c->A().rows();
       size_t var_index = 0;
-      for (const DecisionVariableView& v : binding.getVariableList()) {
+      for (const DecisionVariableView& v : binding.variable_list()) {
         Aeq.block(constraint_index, v.index(), n, v.size()) =
-            c->getMatrix().middleCols(var_index, v.size());
+            c->A().middleCols(var_index, v.size());
         var_index += v.size();
       }
       beq.segment(constraint_index, n) =
-          c->getLowerBound();  // = c->getUpperBound() since it's an equality
+          c->lower_bound();  // = c->getUpperBound() since it's an equality
       // constraint
       constraint_index += n;
     }
 
     // least-squares solution
-    prog.setDecisionVariableValues(
+    prog.SetDecisionVariableValues(
         Aeq.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(beq));
     return true;
   }
@@ -179,10 +189,9 @@ class LeastSquares
 }
 
 std::shared_ptr<MathematicalProgramInterface>
-MathematicalProgramInterface::getLeastSquaresProgram() {
+MathematicalProgramInterface::GetLeastSquaresProgram() {
   return std::shared_ptr<MathematicalProgramInterface>(new LeastSquares);
 }
 
-MathematicalProgramSolverInterface::~MathematicalProgramSolverInterface() { }
-
+MathematicalProgramSolverInterface::~MathematicalProgramSolverInterface() {}
 }

--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -174,7 +174,7 @@ class LeastSquares : public NonlinearProgram {  // public LinearProgram, public
         var_index += v.size();
       }
       beq.segment(constraint_index, n) =
-          c->lower_bound();  // = c->getUpperBound() since it's an equality
+          c->lower_bound();  // = c->upper_bound() since it's an equality
       // constraint
       constraint_index += n;
     }

--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -118,8 +118,7 @@ class NonlinearProgram : public MathematicalProgram {
     virtual MathematicalProgramInterface* AddLinearEqualityConstraint() { return
    new
     LinearProgram; };
-    virtual MathematicalProgramInterface* AddLinearInequalityConstraint() {
-   return
+    virtual MathematicalProgramInterface* AddLinearInequalityConstraint() { return
     new LinearProgram; };
     };
 

--- a/drake/solvers/MathematicalProgram.h
+++ b/drake/solvers/MathematicalProgram.h
@@ -12,31 +12,32 @@ class OptimizationProblem;
 // variables and constraints are added to the program
 // note that there is dynamic allocation happening in here, but on a structure
 // of negligible size.  (is there a better way?)
-class DRAKEOPTIMIZATION_EXPORT  MathematicalProgramInterface {
+class DRAKEOPTIMIZATION_EXPORT MathematicalProgramInterface {
  public:
   virtual ~MathematicalProgramInterface();
 
   /* these would be used to fill out the optimization hierarchy:
 
-     virtual MathematicalProgramInterface* addIntegerVariable() = 0;
-     virtual MathematicalProgramInterface* addLinearCost() = 0;
-     virtual MathematicalProgramInterface* addQuadraticCost() = 0;
-     virtual MathematicalProgramInterface* addCost() = 0;
-     virtual MathematicalProgramInterface* addSumsOfSquaresConstraint() = 0;
-     virtual MathematicalProgramInterface* addLinearMatrixInequalityConstraint() = 0;
-     virtual MathematicalProgramInterface* addSecondOrderConeConstraint() = 0;
-     virtual MathematicalProgramInterface* addComplementarityConstraint() = 0;
+     virtual MathematicalProgramInterface* AddIntegerVariable() = 0;
+     virtual MathematicalProgramInterface* AddLinearCost() = 0;
+     virtual MathematicalProgramInterface* AddQuadraticCost() = 0;
+     virtual MathematicalProgramInterface* AddCost() = 0;
+     virtual MathematicalProgramInterface* AddSumsOfSquaresConstraint() = 0;
+     virtual MathematicalProgramInterface* AddLinearMatrixInequalityConstraint()
+     = 0;
+     virtual MathematicalProgramInterface* AddSecondOrderConeConstraint() = 0;
+     virtual MathematicalProgramInterface* AddComplementarityConstraint() = 0;
   */
-  virtual MathematicalProgramInterface* addGenericObjective() = 0;
-  virtual MathematicalProgramInterface* addGenericConstraint() = 0;
-  virtual MathematicalProgramInterface* addLinearConstraint() = 0;
-  virtual MathematicalProgramInterface* addLinearEqualityConstraint() = 0;
+  virtual MathematicalProgramInterface* AddGenericObjective() = 0;
+  virtual MathematicalProgramInterface* AddGenericConstraint() = 0;
+  virtual MathematicalProgramInterface* AddLinearConstraint() = 0;
+  virtual MathematicalProgramInterface* AddLinearEqualityConstraint() = 0;
   virtual MathematicalProgramInterface*
-      addLinearComplementarityConstraint() = 0;
+  AddLinearComplementarityConstraint() = 0;
 
-  virtual bool solve(OptimizationProblem& prog) const = 0;
+  virtual bool Solve(OptimizationProblem& prog) const = 0;
 
-  static std::shared_ptr<MathematicalProgramInterface> getLeastSquaresProgram();
+  static std::shared_ptr<MathematicalProgramInterface> GetLeastSquaresProgram();
 };
 
 /// Interface used by implementations of individual solvers.
@@ -44,7 +45,7 @@ class DRAKEOPTIMIZATION_EXPORT MathematicalProgramSolverInterface {
  public:
   virtual ~MathematicalProgramSolverInterface();
   virtual bool available() const = 0;
-  virtual bool solve(OptimizationProblem& prog) const = 0;
+  virtual bool Solve(OptimizationProblem& prog) const = 0;
 };
 }
 

--- a/drake/solvers/MobyLCP.cpp
+++ b/drake/solvers/MobyLCP.cpp
@@ -20,8 +20,7 @@ namespace {
 template <typename Derived>
 void selectSubMat(const Eigen::MatrixBase<Derived>& in,
                   const std::vector<unsigned>& rows,
-                  const std::vector<unsigned>& cols,
-                  Eigen::MatrixXd* out) {
+                  const std::vector<unsigned>& cols, Eigen::MatrixXd* out) {
   const int num_rows = rows.size();
   const int num_cols = cols.size();
   out->resize(num_rows, num_cols);
@@ -38,8 +37,7 @@ void selectSubMat(const Eigen::MatrixBase<Derived>& in,
 // TODO(sammy-tri) this could also use a more efficient implementation.
 template <typename Derived>
 void selectSubVec(const Eigen::MatrixBase<Derived>& in,
-                  const std::vector<unsigned>& rows,
-                  Eigen::VectorXd* out) {
+                  const std::vector<unsigned>& rows, Eigen::VectorXd* out) {
   const int num_rows = rows.size();
   out->resize(num_rows);
   for (int i = 0; i < num_rows; i++) {
@@ -49,8 +47,7 @@ void selectSubVec(const Eigen::MatrixBase<Derived>& in,
 
 template <typename DerivedA, typename DerivedB, typename F>
 void transformVecElements(const Eigen::MatrixBase<DerivedA>& in,
-                          Eigen::MatrixBase<DerivedB>* out,
-                          F func) {
+                          Eigen::MatrixBase<DerivedB>* out, F func) {
   assert(in.cols() == 1);
   assert(out->cols() == 1);
   assert(in.rows() == out->rows());
@@ -85,12 +82,9 @@ const double NEAR_ZERO = std::sqrt(std::numeric_limits<double>::epsilon());
 namespace Drake {
 
 // Sole constructor
-MobyLCPSolver::MobyLCPSolver() : log_enabled_(false) {
-}
+MobyLCPSolver::MobyLCPSolver() : log_enabled_(false) {}
 
-void MobyLCPSolver::setLoggingEnabled(bool enabled) {
-  log_enabled_ = enabled;
-}
+void MobyLCPSolver::SetLoggingEnabled(bool enabled) { log_enabled_ = enabled; }
 
 std::ostream& MobyLCPSolver::LOG() const {
   if (log_enabled_) {
@@ -99,7 +93,7 @@ std::ostream& MobyLCPSolver::LOG() const {
   return null_stream_;
 }
 
-void MobyLCPSolver::clearIndexVectors() const {
+void MobyLCPSolver::ClearIndexVectors() const {
   // clear all vectors
   _all.clear();
   _tlist.clear();
@@ -108,7 +102,7 @@ void MobyLCPSolver::clearIndexVectors() const {
   _j.clear();
 }
 
-bool MobyLCPSolver::solve(OptimizationProblem& prog) const {
+bool MobyLCPSolver::Solve(OptimizationProblem& prog) const {
   // TODO(ggould-tri) This solver currently imposes restrictions that its
   // problem:
   //
@@ -129,17 +123,16 @@ bool MobyLCPSolver::solve(OptimizationProblem& prog) const {
   // Restriction 3 could reasonably be relaxed to simply let unbound
   // variables sit at 0.
 
-  assert(prog.getGenericConstraints().empty());
-  assert(prog.getGenericObjectives().empty());
-  assert(prog.getAllLinearConstraints().empty());
-  assert(prog.getBoundingBoxConstraints().empty());
+  assert(prog.generic_constraints().empty());
+  assert(prog.generic_objectives().empty());
+  assert(prog.GetAllLinearConstraints().empty());
+  assert(prog.bounding_box_constraints().empty());
 
-  const auto& bindings =
-      prog.getLinearComplementarityConstraints();
+  const auto& bindings = prog.linear_complementarity_constraints();
 
   // Assert that the available LCPs cover the program and no two LCPs cover
   // the same variable.
-  for (int i = 0; i < prog.getNumVars(); i++) {
+  for (int i = 0; i < prog.num_vars(); i++) {
     bool coverings = 0;
     for (const auto& binding : bindings) {
       if (binding.covers(i)) {
@@ -161,44 +154,43 @@ bool MobyLCPSolver::solve(OptimizationProblem& prog) const {
   // Ms and qs into the appropriate places.  That would be equivalent to this
   // implementation but might perform better if the solver were to parallelize
   // internally.
-  Eigen::VectorXd solution(prog.getNumVars());
+  Eigen::VectorXd solution(prog.num_vars());
   for (const auto& binding : bindings) {
-    Eigen::VectorXd constraint_solution(binding.getNumElements());
+    Eigen::VectorXd constraint_solution(binding.GetNumElements());
     const std::shared_ptr<LinearComplementarityConstraint> constraint =
-        binding.getConstraint();
-    bool solved = lcp_lemke_regularized(
-        constraint->getM(), constraint->getq(),
-        &constraint_solution);
+        binding.constraint();
+    bool solved = SolveLCPLemkeRegularized(
+        constraint->M(), constraint->q(), &constraint_solution);
     if (!solved) {
       return false;
     }
-    binding.writeThrough(constraint_solution, &solution);
+    binding.WriteThrough(constraint_solution, &solution);
   }
-  prog.setDecisionVariableValues(solution);
+  prog.SetDecisionVariableValues(solution);
   return true;
 }
 
 /// Fast pivoting algorithm for denerate, monotone LCPs with few nonzero,
 /// nonbasic variables
-bool MobyLCPSolver::lcp_fast(
-    const Eigen::MatrixXd& M, const Eigen::VectorXd& q, Eigen::VectorXd* z,
-    double zero_tol) const {
+bool MobyLCPSolver::SolveLCPFast(const Eigen::MatrixXd& M,
+                                 const Eigen::VectorXd& q, Eigen::VectorXd* z,
+                                 double zero_tol) const {
   const unsigned N = q.rows();
   const unsigned UINF = std::numeric_limits<unsigned>::max();
 
-  LOG() << "MobyLCPSolver::lcp_fast() entered" << std::endl;
+  LOG() << "MobyLCPSolver::SolveLCPFast() entered" << std::endl;
 
   // look for trivial solution
   if (N == 0) {
-    LOG() << "MobyLCPSolver::lcp_fast() - empty problem" << std::endl;
+    LOG() << "MobyLCPSolver::SolveLCPFast() - empty problem" << std::endl;
     z->resize(0);
     return true;
   }
 
   // set zero tolerance if necessary
   if (zero_tol < 0.0) {
-    zero_tol = M.rows() * M.lpNorm<Eigen::Infinity>()
-        * std::numeric_limits<double>::epsilon();
+    zero_tol = M.rows() * M.lpNorm<Eigen::Infinity>() *
+               std::numeric_limits<double>::epsilon();
   }
 
   // prepare to setup basic and nonbasic variable indices for z
@@ -207,10 +199,10 @@ bool MobyLCPSolver::lcp_fast(
 
   // see whether to warm-start
   if (z->size() == q.size()) {
-    LOG() << "MobyLCPSolver::lcp_fast() - warm starting activated"
-        << std::endl;
+    LOG() << "MobyLCPSolver::SolveLCPFast() - warm starting activated"
+          << std::endl;
 
-    for (unsigned i=0; i< z->size(); i++) {
+    for (unsigned i = 0; i < z->size(); i++) {
       if (std::fabs((*z)[i]) < zero_tol) {
         _bas.push_back(i);
       } else {
@@ -221,8 +213,7 @@ bool MobyLCPSolver::lcp_fast(
     if (log_enabled_) {
       std::ostringstream str;
       str << " -- non-basic indices:";
-      for (unsigned i=0; i< _nonbas.size(); i++)
-        str << " " << _nonbas[i];
+      for (unsigned i = 0; i < _nonbas.size(); i++) str << " " << _nonbas[i];
       LOG() << str.str() << std::endl;
     }
   } else {
@@ -230,8 +221,8 @@ bool MobyLCPSolver::lcp_fast(
     Eigen::Index minw;
     const double minw_val = q.minCoeff(&minw);
     if (minw_val > -zero_tol) {
-      LOG() << "MobyLCPSolver::lcp_fast() - trivial solution found"
-          << std::endl;
+      LOG() << "MobyLCPSolver::SolveLCPFast() - trivial solution found"
+            << std::endl;
       z->resize(N);
       z->fill(0);
       return true;
@@ -239,8 +230,8 @@ bool MobyLCPSolver::lcp_fast(
 
     // setup basic and nonbasic variable indices
     _nonbas.push_back(minw);
-    _bas.resize(N-1);
-    for (unsigned i=0, j=0; i< N; i++) {
+    _bas.resize(N - 1);
+    for (unsigned i = 0, j = 0; i < N; i++) {
       if (i != minw) {
         _bas[j++] = i;
       }
@@ -249,8 +240,8 @@ bool MobyLCPSolver::lcp_fast(
 
   // loop for maximum number of pivots
   //  const unsigned MAX_PIV = std::max(N*N, (unsigned) 1000);
-  const unsigned MAX_PIV = 2*N;
-  for (pivots=0; pivots < MAX_PIV; pivots++) {
+  const unsigned MAX_PIV = 2 * N;
+  for (pivots = 0; pivots < MAX_PIV; pivots++) {
     // select nonbasic indices
     selectSubMat(M, _nonbas, _nonbas, &_Msub);
     selectSubMat(M, _bas, _nonbas, &_Mmix);
@@ -268,7 +259,7 @@ bool MobyLCPSolver::lcp_fast(
     unsigned minw = (_w.rows() > 0) ? minCoeffIdx(_w) : UINF;
 
     // TODO(sammy-tri) this log can't print when minw is UINF.
-    // LOG() << "MobyLCPSolver::lcp_fast() - minimum w after pivot: "
+    // LOG() << "MobyLCPSolver::SolveLCPFast() - minimum w after pivot: "
     // << _w[minw] << std::endl;
 
     // if w >= 0, check whether any component of z < 0
@@ -276,13 +267,13 @@ bool MobyLCPSolver::lcp_fast(
       // find the (a) minimum of z
       unsigned minz = (_z.rows() > 0) ? minCoeffIdx(_z) : UINF;
       if (log_enabled_ && _z.rows() > 0) {
-        LOG() << "MobyLCPSolver::lcp_fast() - minimum z after pivot: "
-            << _z[minz] << std::endl;
+        LOG() << "MobyLCPSolver::SolveLCPFast() - minimum z after pivot: "
+              << _z[minz] << std::endl;
       }
       if (minz < UINF && _z[minz] < -zero_tol) {
         // get the original index and remove it from the nonbasic set
         unsigned idx = _nonbas[minz];
-        _nonbas.erase(_nonbas.begin()+minz);
+        _nonbas.erase(_nonbas.begin() + minz);
 
         // move index to basic set and continue looping
         _bas.push_back(idx);
@@ -293,11 +284,11 @@ bool MobyLCPSolver::lcp_fast(
         z->fill(0);
 
         // set values of z corresponding to _z
-        for (unsigned i=0, j=0; j < _nonbas.size(); i++, j++) {
+        for (unsigned i = 0, j = 0; j < _nonbas.size(); i++, j++) {
           (*z)[_nonbas[j]] = _z[i];
         }
 
-        LOG() << "MobyLCPSolver::lcp_fast() - solution found!" << std::endl;
+        LOG() << "MobyLCPSolver::SolveLCPFast() - solution found!" << std::endl;
         return true;
       }
     } else {
@@ -306,42 +297,43 @@ bool MobyLCPSolver::lcp_fast(
       // one or more components of w violating w >= 0
       // move component of w from basic set to nonbasic set
       unsigned idx = _bas[minw];
-      _bas.erase(_bas.begin()+minw);
+      _bas.erase(_bas.begin() + minw);
       _nonbas.push_back(idx);
       std::sort(_nonbas.begin(), _nonbas.end());
 
       // look whether any component of z needs to move to basic set
       unsigned minz = (_z.rows() > 0) ? minCoeffIdx(_z) : UINF;
       if (log_enabled_ && _z.rows() > 0) {
-        LOG() << "MobyLCPSolver::lcp_fast() - minimum z after pivot: "
+        LOG() << "MobyLCPSolver::SolveLCPFast() - minimum z after pivot: "
               << _z[minz] << std::endl;
       }
       if (minz < UINF && _z[minz] < -zero_tol) {
         // move index to basic set and continue looping
         unsigned idx = _nonbas[minz];
-        LOG() << "MobyLCPSolver::lcp_fast() - moving index " << idx
+        LOG() << "MobyLCPSolver::SolveLCPFast() - moving index " << idx
               << " to basic set" << std::endl;
 
-        _nonbas.erase(_nonbas.begin()+minz);
+        _nonbas.erase(_nonbas.begin() + minz);
         _bas.push_back(idx);
         std::sort(_bas.begin(), _bas.end());
       }
     }
   }
 
-  LOG() << "MobyLCPSolver::lcp_fast() - maximum allowable pivots exceeded" << std::endl;
+  LOG() << "MobyLCPSolver::SolveLCPFast() - maximum allowable pivots exceeded"
+        << std::endl;
 
   // if we're here, then the maximum number of pivots has been exceeded
   return false;
 }
 
 /// Regularized wrapper around PPM I
-bool MobyLCPSolver::lcp_fast_regularized(
-    const Eigen::MatrixXd& M, const Eigen::VectorXd& q, Eigen::VectorXd* z,
-    int min_exp, unsigned step_exp, int max_exp,
-    double zero_tol) const {
-
-  LOG() << "MobyLCPSolver::lcp_fast_regularized() entered" << std::endl;
+bool MobyLCPSolver::SolveLCPFastRegularized(const Eigen::MatrixXd& M,
+                                            const Eigen::VectorXd& q,
+                                            Eigen::VectorXd* z, int min_exp,
+                                            unsigned step_exp, int max_exp,
+                                            double zero_tol) const {
+  LOG() << "MobyLCPSolver::SolveLCPFastRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -353,9 +345,10 @@ bool MobyLCPSolver::lcp_fast_regularized(
   _MM = M;
 
   // assign value for zero tolerance, if necessary
-  const double ZERO_TOL = (zero_tol > static_cast<double>(0.0))
-      ? zero_tol
-      : (q.size() * M.lpNorm<Eigen::Infinity>() * NEAR_ZERO);
+  const double ZERO_TOL =
+      (zero_tol > static_cast<double>(0.0))
+          ? zero_tol
+          : (q.size() * M.lpNorm<Eigen::Infinity>() * NEAR_ZERO);
 
   LOG() << " zero tolerance: " << ZERO_TOL << std::endl;
 
@@ -363,7 +356,7 @@ bool MobyLCPSolver::lcp_fast_regularized(
   unsigned total_piv = 0;
 
   // try non-regularized version first
-  bool result = lcp_fast(_MM, q, z, zero_tol);
+  bool result = SolveLCPFast(_MM, q, z, zero_tol);
   if (result) {
     // verify that solution truly is a solution -- check z
     if (z->minCoeff() >= -ZERO_TOL) {
@@ -376,33 +369,30 @@ bool MobyLCPSolver::lcp_fast_regularized(
         const double wx_max = _wx.maxCoeff();
 
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
-          LOG() << "  solved with no regularization necessary!"
-                            << std::endl;
-          LOG() << "  pivots / total pivots: " << pivots <<
-              " " << pivots << std::endl;
-          LOG() << "MobyLCPSolver::lcp_fast_regularized() exited" << std::endl;
+          LOG() << "  solved with no regularization necessary!" << std::endl;
+          LOG() << "  pivots / total pivots: " << pivots << " " << pivots
+                << std::endl;
+          LOG() << "MobyLCPSolver::SolveLCPFastRegularized() exited"
+                << std::endl;
 
           return true;
         } else {
-          LOG() << "MobyLCPSolver::lcp_fast_regularized() - "
-                <<"'<w, z> not within tolerance(min value: " << wx_min
-                << " max value: " << wx_max << ")"
-                << std::endl;
+          LOG() << "MobyLCPSolver::SolveLCPFastRegularized() - "
+                << "'<w, z> not within tolerance(min value: " << wx_min
+                << " max value: " << wx_max << ")" << std::endl;
         }
       } else {
-        LOG() << "  MobyLCPSolver::lcp_fast_regularized() - "
+        LOG() << "  MobyLCPSolver::SolveLCPFastRegularized() - "
               << "'w' not solved to desired tolerance" << std::endl;
-        LOG() << "  minimum w: " << _wx.minCoeff()
-              << std::endl;
+        LOG() << "  minimum w: " << _wx.minCoeff() << std::endl;
       }
     } else {
-      LOG() << "  MobyLCPSolver::lcp_fast_regularized() - "
-            <<"'z' not solved to desired tolerance" << std::endl;
-      LOG() << "  minimum z: " << z->minCoeff()
-            << std::endl;
+      LOG() << "  MobyLCPSolver::SolveLCPFastRegularized() - "
+            << "'z' not solved to desired tolerance" << std::endl;
+      LOG() << "  minimum z: " << z->minCoeff() << std::endl;
     }
   } else {
-    LOG() << "  MobyLCPSolver::lcp_fast_regularized() "
+    LOG() << "  MobyLCPSolver::SolveLCPFastRegularized() "
           << "- solver failed with zero regularization" << std::endl;
   }
 
@@ -413,20 +403,20 @@ bool MobyLCPSolver::lcp_fast_regularized(
   int rf = min_exp;
   while (rf < max_exp) {
     // setup regularization factor
-    double lambda = std::pow(static_cast<double>(10.0),
-                             static_cast<double>(rf));
+    double lambda =
+        std::pow(static_cast<double>(10.0), static_cast<double>(rf));
 
     LOG() << "  trying to solve LCP with regularization factor: " << lambda
-        << std::endl;
+          << std::endl;
 
     // regularize M
     _MM = M;
-    for (unsigned i=0; i< M.rows(); i++) {
+    for (unsigned i = 0; i < M.rows(); i++) {
       _MM(i, i) += lambda;
     }
 
     // try to solve the LCP
-    result = lcp_fast(_MM, q, z, zero_tol);
+    result = SolveLCPFast(_MM, q, z, zero_tol);
 
     // update total pivots
     total_piv += pivots;
@@ -444,25 +434,25 @@ bool MobyLCPSolver::lcp_fast_regularized(
 
           if (wx_min > -ZERO_TOL && wx_max < ZERO_TOL) {
             LOG() << "  solved with regularization factor: " << lambda
-                << std::endl;
-            LOG() << "  pivots / total pivots: " << pivots
-                              << " " << total_piv << std::endl;
-            LOG() << "MobyLCPSolver::lcp_fast_regularized() exited"
+                  << std::endl;
+            LOG() << "  pivots / total pivots: " << pivots << " " << total_piv
+                  << std::endl;
+            LOG() << "MobyLCPSolver::SolveLCPFastRegularized() exited"
                   << std::endl;
             pivots = total_piv;
             return true;
           } else {
-            LOG() << "MobyLCPSolver::lcp_fast_regularized() - "
+            LOG() << "MobyLCPSolver::SolveLCPFastRegularized() - "
                   << "'<w, z> not within tolerance(min value: " << wx_min
                   << " max value: " << wx_max << ")" << std::endl;
           }
         } else {
-          LOG() << "  MobyLCPSolver::lcp_fast_regularized() - "
+          LOG() << "  MobyLCPSolver::SolveLCPFastRegularized() - "
                 << "'w' not solved to desired tolerance" << std::endl;
           LOG() << "  minimum w: " << _wx.minCoeff() << std::endl;
         }
       } else {
-        LOG() << "  MobyLCPSolver::lcp_fast_regularized() - "
+        LOG() << "  MobyLCPSolver::SolveLCPFastRegularized() - "
               << "'z' not solved to desired tolerance" << std::endl;
         LOG() << "  minimum z: " << z->minCoeff() << std::endl;
       }
@@ -472,9 +462,8 @@ bool MobyLCPSolver::lcp_fast_regularized(
     rf += step_exp;
   }
 
-  LOG() << "  unable to solve given any regularization!"
-                    << std::endl;
-  LOG() << "MobyLCPSolver::lcp_fast_regularized() exited" << std::endl;
+  LOG() << "  unable to solve given any regularization!" << std::endl;
+  LOG() << "MobyLCPSolver::SolveLCPFastRegularized() exited" << std::endl;
 
   // store total pivots
   pivots = total_piv;
@@ -483,9 +472,9 @@ bool MobyLCPSolver::lcp_fast_regularized(
   return false;
 }
 
-bool MobyLCPSolver::checkLemkeTrivial(
-    int n, double zero_tol,
-    const Eigen::VectorXd& q, Eigen::VectorXd* z) const {
+bool MobyLCPSolver::CheckLemkeTrivial(int n, double zero_tol,
+                                      const Eigen::VectorXd& q,
+                                      Eigen::VectorXd* z) const {
   // see whether trivial solution exists
   if (q.minCoeff() > -zero_tol) {
     z->resize(n);
@@ -497,15 +486,17 @@ bool MobyLCPSolver::checkLemkeTrivial(
 }
 
 template <typename MatrixType>
-void MobyLCPSolver::lemkeFoundSolution(
-    const MatrixType& M, const Eigen::VectorXd& q, Eigen::VectorXd* z) const {
+void MobyLCPSolver::FinishLemkeSolution(const MatrixType& M,
+                                        const Eigen::VectorXd& q,
+                                        Eigen::VectorXd* z) const {
   std::vector<unsigned>::iterator iiter;
   int idx;
   for (idx = 0, iiter = _bas.begin(); iiter != _bas.end(); iiter++, idx++) {
     (*z)(*iiter) = _x(idx);
   }
 
-  // TODO(sammy-tri) is there a more efficient way to resize and preserve the data?
+  // TODO(sammy-tri) is there a more efficient way to resize and preserve the
+  // data?
   z->conservativeResize(q.size());
 
   // check to see whether tolerances are satisfied
@@ -525,17 +516,17 @@ void MobyLCPSolver::lemkeFoundSolution(
  * \param z a vector "close" to the solution on input (optional); contains
  *        the solution on output
  */
-bool MobyLCPSolver::lcp_lemke(
-    const Eigen::MatrixXd& M, const Eigen::VectorXd& q, Eigen::VectorXd* z,
-    double piv_tol, double zero_tol) const {
+bool MobyLCPSolver::SolveLCPLemke(const Eigen::MatrixXd& M,
+                                  const Eigen::VectorXd& q, Eigen::VectorXd* z,
+                                  double piv_tol, double zero_tol) const {
   if (log_enabled_) {
-    LOG() << "MobyLCPSolver::lcp_lemke() entered" << std::endl;
+    LOG() << "MobyLCPSolver::SolveLCPLemke() entered" << std::endl;
     LOG() << "  M: " << std::endl << M;
     LOG() << "  q: " << q << std::endl;
   }
 
   const unsigned n = q.size();
-  const unsigned MAXITER = std::min((unsigned) 1000, 50*n);
+  const unsigned MAXITER = std::min((unsigned)1000, 50 * n);
 
   // update the pivots
   pivots = 0;
@@ -548,13 +539,13 @@ bool MobyLCPSolver::lcp_lemke(
 
   // come up with a sensible value for zero tolerance if none is given
   if (zero_tol <= static_cast<double>(0.0)) {
-    zero_tol = M.lpNorm<Eigen::Infinity>()
-        * std::numeric_limits<double>::epsilon();
+    zero_tol =
+        M.lpNorm<Eigen::Infinity>() * std::numeric_limits<double>::epsilon();
   }
 
-  if (checkLemkeTrivial(n, zero_tol, q, z)) {
+  if (CheckLemkeTrivial(n, zero_tol, q, z)) {
     LOG() << " -- trivial solution found" << std::endl;
-    LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+    LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
     return true;
   }
 
@@ -567,15 +558,15 @@ bool MobyLCPSolver::lcp_lemke(
   // copy z to z0
   _z0 = *z;
 
-  clearIndexVectors();
+  ClearIndexVectors();
 
   // initialize variables
-  z->resize(n*2);
+  z->resize(n * 2);
   z->fill(0);
-  unsigned t = 2*n;
+  unsigned t = 2 * n;
   unsigned entering = t;
   unsigned leaving = 0;
-  for (unsigned i=0; i< n; i++) {
+  for (unsigned i = 0; i < n; i++) {
     _all.push_back(i);
   }
   unsigned lvindex;
@@ -585,10 +576,9 @@ bool MobyLCPSolver::lcp_lemke(
   // determine initial basis
   if (_z0.size() != n) {
     // setup the nonbasic indices
-    for (unsigned i=0; i< n; i++)
-      _nonbas.push_back(i);
+    for (unsigned i = 0; i < n; i++) _nonbas.push_back(i);
   } else {
-    for (unsigned i=0; i< n; i++) {
+    for (unsigned i = 0; i < n; i++) {
       if (_z0[i] > 0) {
         _bas.push_back(i);
       } else {
@@ -639,24 +629,24 @@ bool MobyLCPSolver::lcp_lemke(
   // check whether initial basis provides a solution
   if (_x.minCoeff() >= 0.0) {
     LOG() << " -- initial basis provides a solution!" << std::endl;
-    lemkeFoundSolution(M, q, z);
-    LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+    FinishLemkeSolution(M, q, z);
+    LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
     return true;
   }
 
   // use a new pivot tolerance if necessary
-  const double PIV_TOL = (piv_tol > static_cast<double>(0.0))
-      ? piv_tol
-      : (std::numeric_limits<double>::epsilon()
-         * n * std::max(static_cast<double>(1.0),
-                        M.lpNorm<Eigen::Infinity>()));
+  const double PIV_TOL =
+      (piv_tol > static_cast<double>(0.0))
+          ? piv_tol
+          : (std::numeric_limits<double>::epsilon() * n *
+             std::max(static_cast<double>(1.0), M.lpNorm<Eigen::Infinity>()));
 
   // determine initial leaving variable
   Eigen::Index min_x;
   const double min_x_val = _x.topRows(n).minCoeff(&min_x);
   double tval = -min_x_val;
   for (int i = 0; i < _nonbas.size(); i++) {
-      _bas.push_back(_nonbas[i] + n);
+    _bas.push_back(_nonbas[i] + n);
   }
   lvindex = min_x;
   iiter = _bas.begin();
@@ -664,13 +654,13 @@ bool MobyLCPSolver::lcp_lemke(
   leaving = *iiter;
   LOG() << " -- x: " << _x << std::endl;
   LOG() << " -- first pivot: leaving index=" << lvindex
-      << "  entering index=" << entering
-      << " minimum value: " << tval << std::endl;
+        << "  entering index=" << entering << " minimum value: " << tval
+        << std::endl;
 
   // pivot in the artificial variable
-  *iiter = t;    // replace w var with _z0 in basic indices
+  *iiter = t;  // replace w var with _z0 in basic indices
   _u.resize(n);
-  for (unsigned i=0; i< n; i++) {
+  for (unsigned i = 0; i < n; i++) {
     _u[i] = (_x[i] < 0.0) ? 1.0 : 0.0;
   }
   _Be = (_Bl * _u) * -1;
@@ -681,10 +671,10 @@ bool MobyLCPSolver::lcp_lemke(
   LOG() << "  new q: " << _x << std::endl;
 
   // main iterations begin here
-  for (pivots=0; pivots< MAXITER; pivots++) {
+  for (pivots = 0; pivots < MAXITER; pivots++) {
     if (log_enabled_) {
       std::ostringstream basic;
-      for (unsigned i=0; i< _bas.size(); i++) {
+      for (unsigned i = 0; i < _bas.size(); i++) {
         basic << " " << _bas[i];
       }
       LOG() << "basic variables:" << basic.str() << std::endl;
@@ -694,8 +684,8 @@ bool MobyLCPSolver::lcp_lemke(
     // check whether done; if not, get new entering variable
     if (leaving == t) {
       LOG() << "-- solved LCP successfully!" << std::endl;
-      lemkeFoundSolution(M, q, z);
-      LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+      FinishLemkeSolution(M, q, z);
+      LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
       return true;
     } else if (leaving < n) {
       entering = n + leaving;
@@ -718,7 +708,7 @@ bool MobyLCPSolver::lcp_lemke(
 
     // ** find new leaving variable
     _j.clear();
-    for (unsigned i=0; i< _dl.size(); i++) {
+    for (unsigned i = 0; i < _dl.size(); i++) {
       if (_dl[i] > PIV_TOL) {
         _j.push_back(i);
       }
@@ -726,16 +716,16 @@ bool MobyLCPSolver::lcp_lemke(
 
     // check for no new pivots; ray termination
     if (_j.empty()) {
-      LOG() << "MobyLCPSolver::lcp_lemke() - no new pivots (ray termination)"
-            << std::endl;
-      LOG() << "MobyLCPSolver::lcp_lemke() exiting" << std::endl;
+      LOG()
+          << "MobyLCPSolver::SolveLCPLemke() - no new pivots (ray termination)"
+          << std::endl;
+      LOG() << "MobyLCPSolver::SolveLCPLemke() exiting" << std::endl;
       return false;
     }
 
     if (log_enabled_) {
       std::ostringstream j;
-      for (unsigned i=0; i< _j.size(); i++)
-        j << " " << _j[i];
+      for (unsigned i = 0; i < _j.size(); i++) j << " " << _j[i];
       LOG() << "d: " << _dl << std::endl;
       LOG() << "j (before min ratio):" << j.str() << std::endl;
     }
@@ -748,8 +738,8 @@ bool MobyLCPSolver::lcp_lemke(
     _result.resize(_xj.size());
     _result.fill(zero_tol);
     transformVecElements(_xj, &_result, std::plus<double>());
-    transformVecElements(_dj, &_result, [](double a, double b) {
-      return b / a;});
+    transformVecElements(_dj, &_result,
+                         [](double a, double b) { return b / a; });
     double theta = _result.minCoeff();
 
     // NOTE: lexicographic ordering does not appear to be used here to prevent
@@ -769,7 +759,7 @@ bool MobyLCPSolver::lcp_lemke(
     }
     if (log_enabled_) {
       std::ostringstream j;
-      for (unsigned i=0; i< _j.size(); i++) {
+      for (unsigned i = 0; i < _j.size(); i++) {
         j << " " << _j[i];
       }
       LOG() << "j (after min ratio):" << j.str() << std::endl;
@@ -778,7 +768,7 @@ bool MobyLCPSolver::lcp_lemke(
     // if j is empty, then likely the zero tolerance is too low
     if (_j.empty()) {
       LOG() << "zero tolerance too low?" << std::endl;
-      LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+      LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
       return false;
     }
 
@@ -792,9 +782,10 @@ bool MobyLCPSolver::lcp_lemke(
       lvindex = iiter - _bas.begin();
     } else {
       // several indices pass the minimum ratio test, pick one randomly
-//      lvindex = _j[rand() % _j.size()];
-// NOTE: solver seems *much* more capable of solving when we pick the first
-// element rather than picking a random one
+      //      lvindex = _j[rand() % _j.size()];
+      // NOTE: solver seems *much* more capable of solving when we pick the
+      // first
+      // element rather than picking a random one
       lvindex = _j[0];
     }
 
@@ -804,28 +795,30 @@ bool MobyLCPSolver::lcp_lemke(
     leaving = *iiter;
 
     // ** perform pivot
-    double ratio = _x[lvindex]/_dl[lvindex];
+    double ratio = _x[lvindex] / _dl[lvindex];
     _dl *= ratio;
     _x -= _dl;
     _x[lvindex] = ratio;
     _Bl.col(lvindex) = _Be;
     *iiter = entering;
     LOG() << " -- pivoting: leaving index=" << lvindex
-                      << "  entering index=" << entering << std::endl;
+          << "  entering index=" << entering << std::endl;
   }
 
   LOG() << " -- maximum number of iterations exceeded (n=" << n
-                    << ", max=" << MAXITER << ")" << std::endl;
-  LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+        << ", max=" << MAXITER << ")" << std::endl;
+  LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
   return false;
 }
 
 /// Regularized wrapper around Lemke's algorithm
-bool MobyLCPSolver::lcp_lemke_regularized(
-    const Eigen::MatrixXd& M, const Eigen::VectorXd& q, Eigen::VectorXd* z,
-    int min_exp, unsigned step_exp, int max_exp,
-    double piv_tol, double zero_tol) const {
-  LOG() << "MobyLCPSolver::lcp_lemke_regularized() entered" << std::endl;
+bool MobyLCPSolver::SolveLCPLemkeRegularized(const Eigen::MatrixXd& M,
+                                             const Eigen::VectorXd& q,
+                                             Eigen::VectorXd* z, int min_exp,
+                                             unsigned step_exp, int max_exp,
+                                             double piv_tol,
+                                             double zero_tol) const {
+  LOG() << "MobyLCPSolver::SolveLCPLemkeRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -837,9 +830,10 @@ bool MobyLCPSolver::lcp_lemke_regularized(
   _MM = M;
 
   // assign value for zero tolerance, if necessary
-  const double ZERO_TOL = (zero_tol > static_cast<double>(0.0))
-      ? zero_tol
-      : (q.size() * M.lpNorm<Eigen::Infinity>() * NEAR_ZERO);
+  const double ZERO_TOL =
+      (zero_tol > static_cast<double>(0.0))
+          ? zero_tol
+          : (q.size() * M.lpNorm<Eigen::Infinity>() * NEAR_ZERO);
 
   LOG() << " zero tolerance: " << ZERO_TOL << std::endl;
 
@@ -847,7 +841,7 @@ bool MobyLCPSolver::lcp_lemke_regularized(
   unsigned total_piv = 0;
 
   // try non-regularized version first
-  bool result = lcp_lemke(_MM, q, z, piv_tol, zero_tol);
+  bool result = SolveLCPLemke(_MM, q, z, piv_tol, zero_tol);
   if (result) {
     // verify that solution truly is a solution -- check z
     if (z->minCoeff() >= -ZERO_TOL) {
@@ -860,22 +854,24 @@ bool MobyLCPSolver::lcp_lemke_regularized(
         const double wx_max = _wx.maxCoeff();
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
           LOG() << "  solved with no regularization necessary!" << std::endl;
-          LOG() << "MobyLCPSolver::lcp_lemke_regularized() exited" << std::endl;
+          LOG() << "MobyLCPSolver::SolveLCPLemkeRegularized() exited"
+                << std::endl;
 
           return true;
         } else {
-          LOG() << "MobyLCPSolver::lcp_lemke() - "
+          LOG() << "MobyLCPSolver::SolveLCPLemke() - "
                 << "'<w, z> not within tolerance(min value: " << wx_min
                 << " max value: " << wx_max << ")" << std::endl;
         }
       } else {
-        LOG() << "  MobyLCPSolver::lcp_lemke() - 'w' not solved to desired tolerance"
+        LOG() << "  MobyLCPSolver::SolveLCPLemke() - 'w' not solved to desired "
+                 "tolerance"
               << std::endl;
-        LOG() << "  minimum w: " << _wx.minCoeff()
-              << std::endl;
+        LOG() << "  minimum w: " << _wx.minCoeff() << std::endl;
       }
     } else {
-      LOG() << "  MobyLCPSolver::lcp_lemke() - 'z' not solved to desired tolerance"
+      LOG() << "  MobyLCPSolver::SolveLCPLemke() - 'z' not solved to desired "
+               "tolerance"
             << std::endl;
       LOG() << "  minimum z: " << z->minCoeff() << std::endl;
     }
@@ -888,20 +884,20 @@ bool MobyLCPSolver::lcp_lemke_regularized(
   int rf = min_exp;
   while (rf < max_exp) {
     // setup regularization factor
-    double lambda = std::pow(static_cast<double>(10.0),
-                             static_cast<double>(rf));
+    double lambda =
+        std::pow(static_cast<double>(10.0), static_cast<double>(rf));
 
     LOG() << "  trying to solve LCP with regularization factor: " << lambda
-        << std::endl;
+          << std::endl;
 
     // regularize M
     _MM = M;
-    for (unsigned i=0; i< M.rows(); i++) {
+    for (unsigned i = 0; i < M.rows(); i++) {
       _MM(i, i) += lambda;
     }
 
     // try to solve the LCP
-    result = lcp_lemke(_MM, q, z, piv_tol, zero_tol);
+    result = SolveLCPLemke(_MM, q, z, piv_tol, zero_tol);
 
     // update total pivots
     total_piv += pivots;
@@ -911,7 +907,7 @@ bool MobyLCPSolver::lcp_lemke_regularized(
       if (z->minCoeff() > -ZERO_TOL) {
         // check w
         _wx = (_MM * (*z)) + q;
-        if (_wx.minCoeff() > - ZERO_TOL) {
+        if (_wx.minCoeff() > -ZERO_TOL) {
           // check z'w
           transformVecElements(*z, &_wx, std::multiplies<double>());
           const double wx_min = _wx.minCoeff();
@@ -919,21 +915,24 @@ bool MobyLCPSolver::lcp_lemke_regularized(
           if (wx_min > -ZERO_TOL && wx_max < ZERO_TOL) {
             LOG() << "  solved with regularization factor: " << lambda
                   << std::endl;
-            LOG() << "MobyLCPSolver::lcp_lemke_regularized() exited" << std::endl;
+            LOG() << "MobyLCPSolver::SolveLCPLemkeRegularized() exited"
+                  << std::endl;
             pivots = total_piv;
             return true;
           } else {
-            LOG() << "MobyLCPSolver::lcp_lemke() - "
+            LOG() << "MobyLCPSolver::SolveLCPLemke() - "
                   << "'<w, z> not within tolerance(min value: " << wx_min
                   << " max value: " << wx_max << ")" << std::endl;
           }
         } else {
-          LOG() << "  MobyLCPSolver::lcp_lemke() - 'w' not solved to desired tolerance"
+          LOG() << "  MobyLCPSolver::SolveLCPLemke() - 'w' not solved to "
+                   "desired tolerance"
                 << std::endl;
           LOG() << "  minimum w: " << _wx.minCoeff() << std::endl;
         }
       } else {
-        LOG() << "  MobyLCPSolver::lcp_lemke() - 'z' not solved to desired tolerance"
+        LOG() << "  MobyLCPSolver::SolveLCPLemke() - 'z' not solved to desired "
+                 "tolerance"
               << std::endl;
         LOG() << "  minimum z: " << z->minCoeff() << std::endl;
       }
@@ -944,7 +943,7 @@ bool MobyLCPSolver::lcp_lemke_regularized(
   }
 
   LOG() << "  unable to solve given any regularization!" << std::endl;
-  LOG() << "MobyLCPSolver::lcp_lemke_regularized() exited" << std::endl;
+  LOG() << "MobyLCPSolver::SolveLCPLemkeRegularized() exited" << std::endl;
 
   // store total pivots
   pivots = total_piv;
@@ -953,24 +952,23 @@ bool MobyLCPSolver::lcp_lemke_regularized(
   return false;
 }
 
-
 /// Lemke's algorithm for solving linear complementarity problems using sparse
 /// matrices
 /**
  * \param z a vector "close" to the solution on input (optional); contains
  *        the solution on output
  */
-bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
-                              const Eigen::VectorXd& q, Eigen::VectorXd* z,
-                              double piv_tol, double zero_tol) const {
+bool MobyLCPSolver::SolveLCPLemke(const Eigen::SparseMatrix<double>& M,
+                                  const Eigen::VectorXd& q, Eigen::VectorXd* z,
+                                  double piv_tol, double zero_tol) const {
   if (log_enabled_) {
-    LOG() << "MobyLCPSolver::lcp_lemke() entered" << std::endl;
+    LOG() << "MobyLCPSolver::SolveLCPLemke() entered" << std::endl;
     LOG() << "  M: " << std::endl << M;
     LOG() << "  q: " << q << std::endl;
   }
 
   const unsigned n = q.size();
-  const unsigned MAXITER = std::min((unsigned) 1000, 50*n);
+  const unsigned MAXITER = std::min((unsigned)1000, 50 * n);
 
   // look for immediate exit
   if (n == 0) {
@@ -981,28 +979,28 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
   // come up with a sensible value for zero tolerance if none is given
   if (zero_tol <= static_cast<double>(0.0)) {
     Eigen::MatrixXd dense_M = M;
-    zero_tol = dense_M.lpNorm<Eigen::Infinity>()
-        * std::numeric_limits<double>::epsilon() * n;
+    zero_tol = dense_M.lpNorm<Eigen::Infinity>() *
+               std::numeric_limits<double>::epsilon() * n;
   }
 
-  if (checkLemkeTrivial(n, zero_tol, q, z)) {
+  if (CheckLemkeTrivial(n, zero_tol, q, z)) {
     LOG() << " -- trivial solution found" << std::endl;
-    LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+    LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
     return true;
   }
 
   // copy z to z0
   _z0 = *z;
 
-  clearIndexVectors();
+  ClearIndexVectors();
 
   // initialize variables
-  z->resize(n*2);
+  z->resize(n * 2);
   z->fill(0);
-  unsigned t = 2*n;
+  unsigned t = 2 * n;
   unsigned entering = t;
   unsigned leaving = 0;
-  for (unsigned i=0; i< n; i++) {
+  for (unsigned i = 0; i < n; i++) {
     _all.push_back(i);
   }
   unsigned lvindex;
@@ -1011,11 +1009,11 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
 
   // determine initial basis
   if (_z0.size() != n) {
-    for (unsigned i=0; i< n; i++) {
+    for (unsigned i = 0; i < n; i++) {
       _nonbas.push_back(i);
     }
   } else {
-    for (unsigned i=0; i< n; i++) {
+    for (unsigned i = 0; i < n; i++) {
       if (_z0[i] > 0) {
         _bas.push_back(i);
       } else {
@@ -1029,7 +1027,7 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
   if (!_bas.empty()) {
     typedef Eigen::Triplet<double> Triplet;
     std::vector<Triplet> triplet_list;
-    for (int i=0; i< M.outerSize(); i++) {
+    for (int i = 0; i < M.outerSize(); i++) {
       for (Eigen::SparseMatrix<double>::InnerIterator it(M, i); it; ++it) {
         int j = it.col();
         std::vector<unsigned>::const_iterator j_it =
@@ -1062,8 +1060,8 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
   // check whether initial basis provides a solution
   if (_x.minCoeff() >= 0.0) {
     LOG() << " -- initial basis provides a solution!" << std::endl;
-    lemkeFoundSolution(M, q, z);
-    LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+    FinishLemkeSolution(M, q, z);
+    LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
     return true;
   }
 
@@ -1080,9 +1078,9 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
   leaving = *iiter;
 
   // pivot in the artificial variable
-  *iiter = t;    // replace w var with _z0 in basic indices
+  *iiter = t;  // replace w var with _z0 in basic indices
   _u.resize(n);
-  for (unsigned i=0; i< n; i++) {
+  for (unsigned i = 0; i < n; i++) {
     _u[i] = (_x[i] < 0.0) ? 1.0 : 0.0;
   }
   _Be = (_sBl * _u) * -1;
@@ -1093,12 +1091,12 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
   LOG() << "  new q: " << _x << std::endl;
 
   // main iterations begin here
-  for (pivots=0;pivots < MAXITER; pivots++) {
+  for (pivots = 0; pivots < MAXITER; pivots++) {
     // check whether done; if not, get new entering variable
     if (leaving == t) {
       LOG() << "-- solved LCP successfully!" << std::endl;
-      lemkeFoundSolution(M, q, z);
-      LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+      FinishLemkeSolution(M, q, z);
+      LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
       return true;
     } else if (leaving < n) {
       entering = n + leaving;
@@ -1116,23 +1114,24 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
 
     // use a new pivot tolerance if necessary
     const double PIV_TOL = (piv_tol > static_cast<double>(0.0))
-        ? piv_tol
-        : (std::numeric_limits<double>::epsilon()
-           * n * std::max(static_cast<double>(1.0),
-                          _Be.lpNorm<Eigen::Infinity>()));
+                               ? piv_tol
+                               : (std::numeric_limits<double>::epsilon() * n *
+                                  std::max(static_cast<double>(1.0),
+                                           _Be.lpNorm<Eigen::Infinity>()));
 
     // ** find new leaving variable
     _j.clear();
-    for (unsigned i=0; i< _dl.size(); i++) {
+    for (unsigned i = 0; i < _dl.size(); i++) {
       if (_dl[i] > PIV_TOL) {
         _j.push_back(i);
       }
     }
     // check for no new pivots; ray termination
     if (_j.empty()) {
-      LOG() << "MobyLCPSolver::lcp_lemke() - no new pivots (ray termination)"
-            << std::endl;
-      LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+      LOG()
+          << "MobyLCPSolver::SolveLCPLemke() - no new pivots (ray termination)"
+          << std::endl;
+      LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
       return false;
     }
 
@@ -1146,8 +1145,8 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
     _result.resize(_xj.size());
     _result.fill(zero_tol);
     transformVecElements(_xj, &_result, std::plus<double>());
-    transformVecElements(_dj, &_result, [](double a, double b) {
-        return b / a;});
+    transformVecElements(_dj, &_result,
+                         [](double a, double b) { return b / a; });
     double theta = _result.minCoeff();
 
     // NOTE: lexicographic ordering does not appear to be used here to prevent
@@ -1157,7 +1156,7 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
     for (int i = 0; i < _result.size(); i++) {
       _result(i) = _xj(i) / _dj(i);
     }
-    for (iiter = _j.begin(), idx = 0; iiter != _j.end(); ) {
+    for (iiter = _j.begin(), idx = 0; iiter != _j.end();) {
       if (_result[idx++] <= theta) {
         iiter++;
       } else {
@@ -1167,7 +1166,7 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
     // if j is empty, then likely the zero tolerance is too low
     if (_j.empty()) {
       LOG() << "zero tolerance too low?" << std::endl;
-      LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+      LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
       return false;
     }
 
@@ -1181,7 +1180,7 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
       lvindex = iiter - _bas.begin();
     } else {
       // several indices pass the minimum ratio test, pick one randomly
-//      lvindex = _j[rand() % _j.size()];
+      //      lvindex = _j[rand() % _j.size()];
 
       // NOTE: solver seems *much* more capable of solving when we pick the
       // first element rather than picking a random one
@@ -1194,27 +1193,27 @@ bool MobyLCPSolver::lcp_lemke(const Eigen::SparseMatrix<double>& M,
     leaving = *iiter;
 
     // ** perform pivot
-    double ratio = _x[lvindex]/_dl[lvindex];
+    double ratio = _x[lvindex] / _dl[lvindex];
     _dl *= ratio;
     _x -= _dl;
     _x[lvindex] = ratio;
     _sBl.col(lvindex) = makeSparseVector(_Be);
     *iiter = entering;
     LOG() << " -- pivoting: leaving index=" << lvindex
-        << "  entering index=" << entering << std::endl;
+          << "  entering index=" << entering << std::endl;
   }
 
   LOG() << " -- maximum number of iterations exceeded" << std::endl;
-  LOG() << "MobyLCPSolver::lcp_lemke() exited" << std::endl;
+  LOG() << "MobyLCPSolver::SolveLCPLemke() exited" << std::endl;
   return false;
 }
 
 /// Regularized wrapper around Lemke's algorithm for srpase matrices
-bool MobyLCPSolver::lcp_lemke_regularized(
-  const Eigen::SparseMatrix<double>& M, const Eigen::VectorXd& q,
-  Eigen::VectorXd* z, int min_exp, unsigned step_exp, int max_exp,
-  double piv_tol, double zero_tol) const {
-  LOG() << "MobyLCPSolver::lcp_lemke_regularized() entered" << std::endl;
+bool MobyLCPSolver::SolveLCPLemkeRegularized(
+    const Eigen::SparseMatrix<double>& M, const Eigen::VectorXd& q,
+    Eigen::VectorXd* z, int min_exp, unsigned step_exp, int max_exp,
+    double piv_tol, double zero_tol) const {
+  LOG() << "MobyLCPSolver::SolveLCPLemkeRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -1226,11 +1225,11 @@ bool MobyLCPSolver::lcp_lemke_regularized(
   _MMs = M;
 
   // assign value for zero tolerance, if necessary
-  const double ZERO_TOL = (zero_tol > static_cast<double>(0.0))
-      ? zero_tol : q.size() * NEAR_ZERO;
+  const double ZERO_TOL =
+      (zero_tol > static_cast<double>(0.0)) ? zero_tol : q.size() * NEAR_ZERO;
 
   // try non-regularized version first
-  bool result = lcp_lemke(_MMs, q, z, piv_tol, zero_tol);
+  bool result = SolveLCPLemke(_MMs, q, z, piv_tol, zero_tol);
   if (result) {
     // verify that solution truly is a solution -- check z
     if (z->minCoeff() >= -ZERO_TOL) {
@@ -1243,15 +1242,15 @@ bool MobyLCPSolver::lcp_lemke_regularized(
         const double wx_max = _wx.maxCoeff();
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
           LOG() << "  solved with no regularization necessary!" << std::endl;
-          LOG() << "MobyLCPSolver::lcp_lemke_regularized() exited" << std::endl;
+          LOG() << "MobyLCPSolver::SolveLCPLemkeRegularized() exited"
+                << std::endl;
 
           return true;
         } else {
-          LOG() << "MobyLCPSolver::lcp_lemke() - "
+          LOG() << "MobyLCPSolver::SolveLCPLemke() - "
                 << "'<w, z> not within tolerance(min value: " << wx_min
                 << " max value: " << wx_max << ")"
                 << " tol " << ZERO_TOL << std::endl;
-
         }
       }
     }
@@ -1264,15 +1263,15 @@ bool MobyLCPSolver::lcp_lemke_regularized(
   int rf = min_exp;
   while (rf < max_exp) {
     // setup regularization factor
-    double lambda = std::pow(static_cast<double>(10.0),
-                             static_cast<double>(rf));
+    double lambda =
+        std::pow(static_cast<double>(10.0), static_cast<double>(rf));
     (_diag_lambda = _eye) *= lambda;
 
     // regularize M
     (_MMx = _MMs) += _diag_lambda;
 
     // try to solve the LCP
-    if ((result = lcp_lemke(_MMx, q, z, piv_tol, zero_tol))) {
+    if ((result = SolveLCPLemke(_MMx, q, z, piv_tol, zero_tol))) {
       // verify that solution truly is a solution -- check z
       if (z->minCoeff() > -ZERO_TOL) {
         // check w
@@ -1282,8 +1281,9 @@ bool MobyLCPSolver::lcp_lemke_regularized(
           transformVecElements(*z, &_wx, std::multiplies<double>());
           if (_wx.minCoeff() > -ZERO_TOL && _wx.maxCoeff() < ZERO_TOL) {
             LOG() << "  solved with regularization factor: " << lambda
-                << std::endl;
-            LOG() << "MobyLCPSolver::lcp_lemke_regularized() exited" << std::endl;
+                  << std::endl;
+            LOG() << "MobyLCPSolver::SolveLCPLemkeRegularized() exited"
+                  << std::endl;
 
             return true;
           }
@@ -1296,10 +1296,9 @@ bool MobyLCPSolver::lcp_lemke_regularized(
   }
 
   LOG() << "  unable to solve given any regularization!" << std::endl;
-  LOG() << "MobyLCPSolver::lcp_lemke_regularized() exited" << std::endl;
+  LOG() << "MobyLCPSolver::SolveLCPLemkeRegularized() exited" << std::endl;
 
   // still here?  failure...
   return false;
 }
-
 }

--- a/drake/solvers/MobyLCP.h
+++ b/drake/solvers/MobyLCP.h
@@ -13,47 +13,46 @@
 
 namespace Drake {
 
-class DRAKEOPTIMIZATION_EXPORT MobyLCPSolver :
-      public MathematicalProgramSolverInterface {
+class DRAKEOPTIMIZATION_EXPORT MobyLCPSolver
+    : public MathematicalProgramSolverInterface {
  public:
   MobyLCPSolver();
   virtual ~MobyLCPSolver() {}
-  void setLoggingEnabled(bool);
+  void SetLoggingEnabled(bool);
 
-  bool lcp_fast(
-      const Eigen::MatrixXd& M, const Eigen::VectorXd& q, Eigen::VectorXd* z,
-      double zero_tol = -1.0) const;
-  bool lcp_fast_regularized(
-      const Eigen::MatrixXd& M, const Eigen::VectorXd& q, Eigen::VectorXd* z,
-      int min_exp = -20, unsigned step_exp = 4, int max_exp = 20,
-      double zero_tol = -1.0) const;
-  bool lcp_lemke(
-      const Eigen::MatrixXd& M, const Eigen::VectorXd& q, Eigen::VectorXd* z,
-      double piv_tol = -1.0, double zero_tol = -1.0) const;
-  bool lcp_lemke_regularized(
-      const Eigen::MatrixXd& M, const Eigen::VectorXd& q, Eigen::VectorXd* z,
-      int min_exp = -20, unsigned step_exp = 1, int max_exp = 1,
-      double piv_tol = -1.0, double zero_tol = -1.0) const;
-  bool lcp_lemke(
-      const Eigen::SparseMatrix<double>& M, const Eigen::VectorXd& q,
-      Eigen::VectorXd* z,
-      double piv_tol = -1.0, double zero_tol = -1.0) const;
-  bool lcp_lemke_regularized(
-      const Eigen::SparseMatrix<double>& M, const Eigen::VectorXd& q,
-      Eigen::VectorXd* z,
-      int min_exp = -20, unsigned step_exp = 4, int max_exp = 20,
-      double piv_tol = -1.0, double zero_tol = -1.0) const;
+  bool SolveLCPFast(const Eigen::MatrixXd& M, const Eigen::VectorXd& q,
+                    Eigen::VectorXd* z, double zero_tol = -1.0) const;
+  bool SolveLCPFastRegularized(const Eigen::MatrixXd& M,
+                               const Eigen::VectorXd& q, Eigen::VectorXd* z,
+                               int min_exp = -20, unsigned step_exp = 4,
+                               int max_exp = 20, double zero_tol = -1.0) const;
+  bool SolveLCPLemke(const Eigen::MatrixXd& M, const Eigen::VectorXd& q,
+                     Eigen::VectorXd* z, double piv_tol = -1.0,
+                     double zero_tol = -1.0) const;
+  bool SolveLCPLemkeRegularized(const Eigen::MatrixXd& M,
+                                const Eigen::VectorXd& q, Eigen::VectorXd* z,
+                                int min_exp = -20, unsigned step_exp = 1,
+                                int max_exp = 1, double piv_tol = -1.0,
+                                double zero_tol = -1.0) const;
+  bool SolveLCPLemke(const Eigen::SparseMatrix<double>& M,
+                     const Eigen::VectorXd& q, Eigen::VectorXd* z,
+                     double piv_tol = -1.0, double zero_tol = -1.0) const;
+  bool SolveLCPLemkeRegularized(const Eigen::SparseMatrix<double>& M,
+                                const Eigen::VectorXd& q, Eigen::VectorXd* z,
+                                int min_exp = -20, unsigned step_exp = 4,
+                                int max_exp = 20, double piv_tol = -1.0,
+                                double zero_tol = -1.0) const;
 
   virtual bool available() const override { return true; }
-  virtual bool solve(OptimizationProblem& prog) const override;
+  virtual bool Solve(OptimizationProblem& prog) const override;
 
  private:
-  void clearIndexVectors() const;
-  bool checkLemkeTrivial(int n, double zero_tol,
-                         const Eigen::VectorXd& q, Eigen::VectorXd* z) const;
+  void ClearIndexVectors() const;
+  bool CheckLemkeTrivial(int n, double zero_tol, const Eigen::VectorXd& q,
+                         Eigen::VectorXd* z) const;
   template <typename MatrixType>
-  void lemkeFoundSolution(const MatrixType& M, const Eigen::VectorXd& q,
-                          Eigen::VectorXd* z) const;
+  void FinishLemkeSolution(const MatrixType& M, const Eigen::VectorXd& q,
+                           Eigen::VectorXd* z) const;
 
   // TODO(sammy-tri) replace this with a proper logging hookup
   std::ostream& LOG() const;
@@ -87,6 +86,6 @@ class DRAKEOPTIMIZATION_EXPORT MobyLCPSolver :
   mutable Eigen::SparseMatrix<double> _MMs, _MMx, _eye, _zero, _diag_lambda;
 };
 
-} // end namespace Drake
+}  // end namespace Drake
 
-#endif // DRAKE_SOLVERS_MOBYLCP_H_
+#endif  // DRAKE_SOLVERS_MOBYLCP_H_

--- a/drake/solvers/MobyLCP.h
+++ b/drake/solvers/MobyLCP.h
@@ -20,24 +20,24 @@ class DRAKEOPTIMIZATION_EXPORT MobyLCPSolver
   virtual ~MobyLCPSolver() {}
   void SetLoggingEnabled(bool);
 
-  bool SolveLCPFast(const Eigen::MatrixXd& M, const Eigen::VectorXd& q,
+  bool SolveLcpFast(const Eigen::MatrixXd& M, const Eigen::VectorXd& q,
                     Eigen::VectorXd* z, double zero_tol = -1.0) const;
-  bool SolveLCPFastRegularized(const Eigen::MatrixXd& M,
+  bool SolveLcpFastRegularized(const Eigen::MatrixXd& M,
                                const Eigen::VectorXd& q, Eigen::VectorXd* z,
                                int min_exp = -20, unsigned step_exp = 4,
                                int max_exp = 20, double zero_tol = -1.0) const;
-  bool SolveLCPLemke(const Eigen::MatrixXd& M, const Eigen::VectorXd& q,
+  bool SolveLcpLemke(const Eigen::MatrixXd& M, const Eigen::VectorXd& q,
                      Eigen::VectorXd* z, double piv_tol = -1.0,
                      double zero_tol = -1.0) const;
-  bool SolveLCPLemkeRegularized(const Eigen::MatrixXd& M,
+  bool SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
                                 const Eigen::VectorXd& q, Eigen::VectorXd* z,
                                 int min_exp = -20, unsigned step_exp = 1,
                                 int max_exp = 1, double piv_tol = -1.0,
                                 double zero_tol = -1.0) const;
-  bool SolveLCPLemke(const Eigen::SparseMatrix<double>& M,
+  bool SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
                      const Eigen::VectorXd& q, Eigen::VectorXd* z,
                      double piv_tol = -1.0, double zero_tol = -1.0) const;
-  bool SolveLCPLemkeRegularized(const Eigen::SparseMatrix<double>& M,
+  bool SolveLcpLemkeRegularized(const Eigen::SparseMatrix<double>& M,
                                 const Eigen::VectorXd& q, Eigen::VectorXd* z,
                                 int min_exp = -20, unsigned step_exp = 4,
                                 int max_exp = 20, double piv_tol = -1.0,

--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -57,18 +57,18 @@ double EvaluateCosts(const std::vector<double>& x,
     grad.assign(grad.size(), 0);
   }
 
-  for (auto const& binding : prog->getGenericObjectives()) {
+  for (auto const& binding : prog->generic_objectives()) {
     size_t index = 0;
-    for (const DecisionVariableView& v : binding.getVariableList()) {
+    for (const DecisionVariableView& v : binding.variable_list()) {
       this_x.segment(index, v.size()) = tx.segment(v.index(), v.size());
       index += v.size();
     }
 
-    binding.getConstraint()->eval(this_x, ty);
+    binding.constraint()->eval(this_x, ty);
 
     cost += ty(0).value();
     if (!grad.empty()) {
-      for (const DecisionVariableView& v : binding.getVariableList()) {
+      for (const DecisionVariableView& v : binding.variable_list()) {
         for (size_t j = v.index(); j < v.index() + v.size(); j++) {
           grad[j] += ty(0).derivatives()(j);
         }
@@ -130,18 +130,18 @@ double EvaluateScalarConstraint(const std::vector<double>& x,
   Eigen::VectorXd xvec = MakeEigenVector(x);
 
   const Constraint* c = wrapped->constraint;
-  assert(c->getNumConstraints() == 1);
+  assert(c->num_constraints() == 1);
 
   TaylorVecXd ty(1);
   TaylorVecXd this_x = MakeInputTaylorVec(xvec, *(wrapped->variable_list));
   c->eval(this_x, ty);
   const double result = ApplyConstraintBounds(
-      ty(0).value(), c->getLowerBound()(0), c->getUpperBound()(0));
+      ty(0).value(), c->lower_bound()(0), c->upper_bound()(0));
 
   if (!grad.empty()) {
     grad.assign(grad.size(), 0);
     const double grad_sign =
-        (c->getUpperBound()(0) ==
+        (c->upper_bound()(0) ==
          std::numeric_limits<double>::infinity()) ? -1 : 1;
     for (const DecisionVariableView& v : *(wrapped->variable_list)) {
       for (size_t j = v.index(); j < v.index() + v.size(); j++) {
@@ -166,15 +166,15 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
   }
 
   const Constraint* c = wrapped->constraint;
-  const size_t num_constraints = c->getNumConstraints();
+  const size_t num_constraints = c->num_constraints();
   assert(num_constraints == m);
 
   TaylorVecXd ty(m);
   TaylorVecXd this_x = MakeInputTaylorVec(xvec, *(wrapped->variable_list));
   c->eval(this_x, ty);
 
-  const Eigen::VectorXd& lower_bound = c->getLowerBound();
-  const Eigen::VectorXd& upper_bound = c->getUpperBound();
+  const Eigen::VectorXd& lower_bound = c->lower_bound();
+  const Eigen::VectorXd& upper_bound = c->upper_bound();
   for (size_t i = 0; i < num_constraints; i++) {
     result[i] = ApplyConstraintBounds(
         ty(i).value(), lower_bound(i), upper_bound(i));
@@ -184,7 +184,7 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
     for (const DecisionVariableView& v : *(wrapped->variable_list)) {
       for (size_t i = 0; i < num_constraints; i++) {
         const double grad_sign =
-            (c->getUpperBound()(i) ==
+            (c->upper_bound()(i) ==
              std::numeric_limits<double>::infinity()) ? -1 : 1;
          for (size_t j = v.index(); j < v.index() + v.size(); j++) {
            grad[j] += ty(i).derivatives()(j) * grad_sign;
@@ -199,14 +199,14 @@ bool NloptSolver::available() const {
   return true;
 }
 
-bool NloptSolver::solve(OptimizationProblem &prog) const {
+bool NloptSolver::Solve(OptimizationProblem &prog) const {
 
-  int nx = prog.getNumVars();
+  int nx = prog.num_vars();
 
   // Load the algo to use and the size.
   nlopt::opt opt(nlopt::LD_SLSQP, nx);
 
-  const Eigen::VectorXd& initial_guess = prog.getInitialGuess();
+  const Eigen::VectorXd& initial_guess = prog.initial_guess();
   std::vector<double> x(initial_guess.size());
   for (size_t i = 0; i < x.size(); i++) {
     x[i] = initial_guess[i];
@@ -215,11 +215,11 @@ bool NloptSolver::solve(OptimizationProblem &prog) const {
   std::vector<double> xlow(nx, -std::numeric_limits<double>::infinity());
   std::vector<double> xupp(nx, std::numeric_limits<double>::infinity());
 
-  for (auto const& binding : prog.getBoundingBoxConstraints()) {
-    auto const& c = binding.getConstraint();
-    const Eigen::VectorXd& lower_bound = c->getLowerBound();
-    const Eigen::VectorXd& upper_bound = c->getUpperBound();
-    for (const DecisionVariableView& v : binding.getVariableList()) {
+  for (auto const& binding : prog.bounding_box_constraints()) {
+    auto const& c = binding.constraint();
+    const Eigen::VectorXd& lower_bound = c->lower_bound();
+    const Eigen::VectorXd& upper_bound = c->upper_bound();
+    for (const DecisionVariableView& v : binding.variable_list()) {
       for (int k = 0; k < v.size(); k++) {
         const int idx = v.index() + k;
         xlow[idx] = std::max(lower_bound(k), xlow[idx]);
@@ -244,11 +244,11 @@ bool NloptSolver::solve(OptimizationProblem &prog) const {
 
   // TODO(sam.creasey): Missing test coverage for generic constraints
   // with >1 output.
-  for (const auto& c : prog.getGenericConstraints()) {
-    WrappedConstraint wrapped = { c.getConstraint().get(),
-                                  &c.getVariableList() };
+  for (const auto& c : prog.generic_constraints()) {
+    WrappedConstraint wrapped = { c.constraint().get(),
+                                  &c.variable_list() };
     wrapped_list.push_back(wrapped);
-    std::vector<double> tol(c.getConstraint()->getNumConstraints(),
+    std::vector<double> tol(c.constraint()->num_constraints(),
                             constraint_tol);
     opt.add_inequality_mconstraint(
         EvaluateVectorConstraint, &wrapped_list.back(), tol);
@@ -259,14 +259,14 @@ bool NloptSolver::solve(OptimizationProblem &prog) const {
   // outputs as a vector constraint.  This did not seem to work.  The
   // version below breaks out the problem into multiple constraints.
   std::list<LinearEqualityConstraint> equalities;
-  for (const auto& c : prog.getLinearEqualityConstraints()) {
-    const size_t num_constraints = c.getConstraint()->getNumConstraints();
-    const auto& A = c.getConstraint()->getMatrix();
-    const auto& b = c.getConstraint()->getLowerBound();
+  for (const auto& c : prog.linear_equality_constraints()) {
+    const size_t num_constraints = c.constraint()->num_constraints();
+    const auto& A = c.constraint()->A();
+    const auto& b = c.constraint()->lower_bound();
     for (size_t i = 0; i < num_constraints; i++) {
       equalities.push_back(LinearEqualityConstraint(A.row(i), b.row(i)));
       WrappedConstraint wrapped = { &equalities.back(),
-                                    &c.getVariableList() };
+                                    &c.variable_list() };
       wrapped_list.push_back(wrapped);
       opt.add_equality_constraint(
           EvaluateScalarConstraint, &wrapped_list.back(), constraint_tol);
@@ -275,11 +275,11 @@ bool NloptSolver::solve(OptimizationProblem &prog) const {
 
   // TODO(sam.creasey): Missing test coverage for linear constraints
   // with >1 output.
-  for (const auto& c : prog.getLinearConstraints()) {
-    WrappedConstraint wrapped = { c.getConstraint().get(),
-                                  &c.getVariableList() };
+  for (const auto& c : prog.linear_constraints()) {
+    WrappedConstraint wrapped = { c.constraint().get(),
+                                  &c.variable_list() };
     wrapped_list.push_back(wrapped);
-    std::vector<double> tol(c.getConstraint()->getNumConstraints(),
+    std::vector<double> tol(c.constraint()->num_constraints(),
                             constraint_tol);
     opt.add_inequality_mconstraint(
         EvaluateVectorConstraint, &wrapped_list.back(), tol);
@@ -295,7 +295,7 @@ bool NloptSolver::solve(OptimizationProblem &prog) const {
     sol(i) = x[i];
   }
 
-  prog.setDecisionVariableValues(sol);
+  prog.SetDecisionVariableValues(sol);
   return true;
 }
 }

--- a/drake/solvers/NloptSolver.h
+++ b/drake/solvers/NloptSolver.h
@@ -13,7 +13,7 @@ class DRAKEOPTIMIZATION_EXPORT NloptSolver :
   // This solver is implemented in various pieces depending on if
   // NLOpt was available during compilation.
   virtual bool available() const override;
-  virtual bool solve(OptimizationProblem& prog) const override;
+  virtual bool Solve(OptimizationProblem& prog) const override;
 };
 }
 

--- a/drake/solvers/NoNlopt.cpp
+++ b/drake/solvers/NoNlopt.cpp
@@ -7,7 +7,7 @@ bool Drake::NloptSolver::available() const {
   return false;
 }
 
-bool Drake::NloptSolver::solve(
+bool Drake::NloptSolver::Solve(
     OptimizationProblem &prog) const {
   throw std::runtime_error(
       "The Nlopt bindings were not compiled.  You'll need to use a different "

--- a/drake/solvers/NoSnopt.cpp
+++ b/drake/solvers/NoSnopt.cpp
@@ -7,7 +7,7 @@ bool Drake::SnoptSolver::available() const {
   return false;
 }
 
-bool Drake::SnoptSolver::solve(
+bool Drake::SnoptSolver::Solve(
     OptimizationProblem &prog) const {
   throw std::runtime_error(
       "The SNOPT bindings were not compiled.  You'll need to use a different "

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -62,13 +62,13 @@ class DecisionVariableView {  // enables users to access pieces of the decision
   ///
   /// @p var is aliased, and must remain valid for the lifetime of the view.
   DecisionVariableView(const DecisionVariable& var)
-      : var(var), start_index(0), length(var.value().rows()) {}
+      : var_(var), start_index_(0), size_(var_.value().rows()) {}
 
   /// Create a view covering part of a DecisionVariable.
   ///
   /// @p var is aliased, and must remain valid for the lifetime of the view.
   DecisionVariableView(const DecisionVariable& var, size_t start, size_t n)
-      : var(var), start_index(start), length(n) {
+      : var_(var), start_index_(start), size_(n) {
     assert(start + n < var.value().rows());
   }
 
@@ -76,27 +76,27 @@ class DecisionVariableView {  // enables users to access pieces of the decision
    * @brief returns the first index of this variable in the entire variable
    * vector for the program
    */
-  size_t index() const { return var.index() + start_index; }
+  size_t index() const { return var_.index() + start_index_; }
 
   /** size()
    * @brief returns the number of elements in the decision variable vector
    */
-  size_t size() const { return length; }
+  size_t size() const { return size_; }
 
   /** value()
    * @brief returns the actual stored value; which is only meaningful after
    * calling solve() in the program.
    */
   Eigen::VectorBlock<const Eigen::VectorXd, Eigen::Dynamic> value() const {
-    return var.value().segment(start_index, length);
+    return var_.value().segment(start_index_, size_);
   }
 
-  std::string getName() const {
-    if (start_index == 0 && length == var.value().size()) {
-      return var.name();
+  std::string name() const {
+    if (start_index_ == 0 && size_ == var_.value().size()) {
+      return var_.name();
     } else {
-      return var.name() + "(" + std::to_string(start_index) + ":" +
-             std::to_string(start_index + length) + ")";
+      return var_.name() + "(" + std::to_string(start_index_) + ":" +
+             std::to_string(start_index_ + size_) + ")";
     }
   }
 
@@ -104,33 +104,33 @@ class DecisionVariableView {  // enables users to access pieces of the decision
    * @brief returns true iff the given @p index of the enclosing
    * OptimizationProblem is included in this VariableView.*/
   bool covers(size_t var_index) const {
-    return (var_index >= index()) && (var_index < (index() + length));
+    return (var_index >= index()) && (var_index < (index() + size_));
   }
 
   const DecisionVariableView operator()(size_t i) const {
-    assert(i <= length);
-    return DecisionVariableView(var, start_index + i, 1);
+    assert(i <= size_);
+    return DecisionVariableView(var_, start_index_ + i, 1);
   }
   const DecisionVariableView row(size_t i) const {
-    assert(i <= length);
-    return DecisionVariableView(var, start_index + i, 1);
+    assert(i <= size_);
+    return DecisionVariableView(var_, start_index_ + i, 1);
   }
   const DecisionVariableView head(size_t n) const {
-    assert(n <= length);
-    return DecisionVariableView(var, start_index, n);
+    assert(n <= size_);
+    return DecisionVariableView(var_, start_index_, n);
   }
   const DecisionVariableView tail(size_t n) const {
-    assert(n <= length);
-    return DecisionVariableView(var, start_index + length - n, n);
+    assert(n <= size_);
+    return DecisionVariableView(var_, start_index_ + size_ - n, n);
   }
   const DecisionVariableView segment(size_t start, size_t n) const {
-    assert(start + n <= length);
-    return DecisionVariableView(var, start_index + start, n);
+    assert(start + n <= size_);
+    return DecisionVariableView(var_, start_index_ + start, n);
   }
 
  private:
-  const DecisionVariable& var;
-  size_t start_index, length;
+  const DecisionVariable& var_;
+  size_t start_index_, size_;
 };
 
 typedef std::list<DecisionVariableView> VariableList;
@@ -144,28 +144,28 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    */
   template <typename C>
   class Binding {
-    std::shared_ptr<C> constraint;
-    VariableList variable_list;
+    std::shared_ptr<C> constraint_;
+    VariableList variable_list_;
 
    public:
     Binding(std::shared_ptr<C> const& c, VariableList const& v)
-        : constraint(c), variable_list(v) {}
+        : constraint_(c), variable_list_(v) {}
     template <typename U>
     Binding(
         Binding<U> const& b,
         typename std::enable_if<std::is_convertible<
             std::shared_ptr<U>, std::shared_ptr<C>>::value>::type* = nullptr)
-        : Binding(b.getConstraint(), b.getVariableList()) {}
+        : Binding(b.constraint(), b.variable_list()) {}
 
-    std::shared_ptr<C> const& getConstraint() const { return constraint; }
+    std::shared_ptr<C> const& constraint() const { return constraint_; }
 
-    VariableList const& getVariableList() const { return variable_list; }
+    VariableList const& variable_list() const { return variable_list_; }
 
     /** covers()
      * @brief returns true iff the given @p index of the enclosing
      * OptimizationProblem is included in this Binding.*/
     bool covers(size_t index) const {
-      for (auto view : getVariableList()) {
+      for (auto view : variable_list_) {
         if (view.covers(index)) {
           return true;
         }
@@ -173,11 +173,11 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       return false;
     }
 
-    size_t getNumElements() const {
+    size_t GetNumElements() const {
       // TODO(ggould-tri) assumes that no index appears more than once in the
       // view, which is nowhere asserted (but seems assumed elsewhere).
       size_t count = 0;
-      for (auto view : getVariableList()) {
+      for (auto view : variable_list_) {
         count += view.size();
       }
       return count;
@@ -187,11 +187,11 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
      * @brief Write the elements of @p solution to the bound elements of
      * the @p output vector.
      */
-    void writeThrough(const Eigen::VectorXd& solution,
+    void WriteThrough(const Eigen::VectorXd& solution,
                       Eigen::VectorXd* output) const {
-      assert(solution.rows() == getNumElements());
+      assert(solution.rows() == GetNumElements());
       size_t solution_index = 0;
-      for (auto view : variable_list) {
+      for (auto view : variable_list_) {
         const auto& solution_segment =
             solution.segment(solution_index, view.size());
         output->segment(view.index(), view.size()) = solution_segment;
@@ -242,46 +242,47 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       // to int so it is odr-used (see
   // https://gcc.gnu.org/wiki/VerboseDiagnostics#missing_static_const_definition)
   OptimizationProblem()
-      : problem_type(MathematicalProgramInterface::getLeastSquaresProgram()),
-        num_vars(0),
-        x_initial_guess(
+      : problem_type_(MathematicalProgramInterface::GetLeastSquaresProgram()),
+        num_vars_(0),
+        x_initial_guess_(
             static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)){}
 
-  const DecisionVariableView addContinuousVariables(std::size_t num_new_vars,
+  const DecisionVariableView AddContinuousVariables(std::size_t num_new_vars,
                                                     std::string name = "x") {
     DecisionVariable v(DecisionVariable::VarType::CONTINUOUS, name,
-                       num_new_vars, num_vars);
-    num_vars += num_new_vars;
-    variables.push_back(v);
-    variable_views.push_back(DecisionVariableView(variables.back()));
-    x_initial_guess.conservativeResize(num_vars);
-    x_initial_guess.tail(num_vars) = 0.1 * Eigen::VectorXd::Random(num_vars);
+                       num_new_vars, num_vars_);
+    num_vars_ += num_new_vars;
+    variables_.push_back(v);
+    variable_views_.push_back(DecisionVariableView(variables_.back()));
+    x_initial_guess_.conservativeResize(num_vars_);
+    x_initial_guess_.tail(num_vars_) = 0.1 * Eigen::VectorXd::Random(num_vars_);
 
-    return variable_views.back();
+    return variable_views_.back();
   }
-  //    const DecisionVariable& addIntegerVariables(size_t num_new_vars,
+
+  //    const DecisionVariable& AddIntegerVariables(size_t num_new_vars,
   //    std::string name);
   //  ...
 
-  void addCost(std::shared_ptr<Constraint> const& obj,
+  void AddCost(std::shared_ptr<Constraint> const& obj,
                VariableList const& vars) {
-    problem_type.reset(problem_type->addGenericObjective());
-    generic_objectives.push_back(Binding<Constraint>(obj, vars));
+    problem_type_.reset(problem_type_->AddGenericObjective());
+    generic_objectives_.push_back(Binding<Constraint>(obj, vars));
   }
 
-  void addCost(std::shared_ptr<Constraint> const& obj) {
-    addCost(obj, variable_views);
+  void AddCost(std::shared_ptr<Constraint> const& obj) {
+    AddCost(obj, variable_views_);
   }
 
   template <typename F>
   typename std::enable_if<
       !std::is_convertible<F, std::shared_ptr<Constraint>>::value,
       std::shared_ptr<Constraint>>::type
-  addCost(F&& f, VariableList const& vars) {
+  AddCost(F&& f, VariableList const& vars) {
     auto c = std::make_shared<
         ConstraintImpl<typename std::remove_reference<F>::type>>(
         std::forward<F>(f));
-    addCost(c, vars);
+    AddCost(c, vars);
     return c;
   }
 
@@ -289,8 +290,8 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   typename std::enable_if<
       !std::is_convertible<F, std::shared_ptr<Constraint>>::value,
       std::shared_ptr<Constraint>>::type
-  addCost(F&& f) {
-    return addCost(std::forward<F>(f), variable_views);
+  AddCost(F&& f) {
+    return AddCost(std::forward<F>(f), variable_views_);
   }
 
   // libstdc++ 4.9 evaluates
@@ -299,37 +300,37 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   // incorrectly as `true` so our enable_if overload is not used.
   // Provide an explicit alternative for this case.
   template <typename F>
-  std::shared_ptr<Constraint> addCost(std::unique_ptr<F>&& f,
+  std::shared_ptr<Constraint> AddCost(std::unique_ptr<F>&& f,
                                       VariableList const& vars) {
     auto c = std::make_shared<ConstraintImpl<std::unique_ptr<F>>>(
         std::forward<std::unique_ptr<F>>(f));
-    addCost(c, vars);
+    AddCost(c, vars);
     return c;
   }
   template <typename F>
-  std::shared_ptr<Constraint> addCost(std::unique_ptr<F>&& f) {
-    return addCost(std::forward<std::unique_ptr<F>>(f), variable_views);
+  std::shared_ptr<Constraint> AddCost(std::unique_ptr<F>&& f) {
+    return AddCost(std::forward<std::unique_ptr<F>>(f), variable_views_);
   }
 
   /** addQuadraticCost
    * @brief adds a cost term of the form (x-x_desired)'*Q*(x-x_desired)
    */
   template <typename DerivedQ, typename Derivedb>
-  std::shared_ptr<QuadraticConstraint> addQuadraticCost(
+  std::shared_ptr<QuadraticConstraint> AddQuadraticCost(
       const Eigen::MatrixBase<DerivedQ>& Q,
       const Eigen::MatrixBase<Derivedb>& x_desired, const VariableList& vars) {
     std::shared_ptr<QuadraticConstraint> objective(new QuadraticConstraint(
         2 * Q, -2 * Q * x_desired, -std::numeric_limits<double>::infinity(),
         std::numeric_limits<double>::infinity()));
-    addCost(objective, vars);
+    AddCost(objective, vars);
     return objective;
   }
 
   template <typename DerivedQ, typename Derivedb>
-  std::shared_ptr<QuadraticConstraint> addQuadraticCost(
+  std::shared_ptr<QuadraticConstraint> AddQuadraticCost(
       const Eigen::MatrixBase<DerivedQ>& Q,
       const Eigen::MatrixBase<Derivedb>& x_desired) {
-    return addQuadraticCost(Q, x_desired, variable_views);
+    return AddQuadraticCost(Q, x_desired, variable_views_);
   }
 
   /** addGenericConstraint
@@ -339,230 +340,230 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    * available, as it may require the use of a significantly more
    * expensive solver.
    */
-  void addGenericConstraint(std::shared_ptr<Constraint> con,
-                     VariableList const& vars) {
-    problem_type.reset(problem_type->addGenericConstraint());
-    generic_constraints.push_back(Binding<Constraint>(con, vars));
+  void AddGenericConstraint(std::shared_ptr<Constraint> con,
+                            VariableList const& vars) {
+    problem_type_.reset(problem_type_->AddGenericConstraint());
+    generic_constraints_.push_back(Binding<Constraint>(con, vars));
   }
-  void addGenericConstraint(std::shared_ptr<Constraint> con) {
-    addGenericConstraint(con, variable_views);
+  void AddGenericConstraint(std::shared_ptr<Constraint> con) {
+    AddGenericConstraint(con, variable_views_);
   }
 
-  /** addLinearConstraint
+  /** AddLinearConstraint
    *
    * @brief adds linear constraints referencing potentially a subset
    * of the decision variables.
    */
-  void addLinearConstraint(
+  void AddLinearConstraint(
       std::shared_ptr<LinearConstraint> con,
       VariableList const& vars) {
-    problem_type.reset(problem_type->addLinearConstraint());
-    linear_constraints.push_back(
+    problem_type_.reset(problem_type_->AddLinearConstraint());
+    linear_constraints_.push_back(
         Binding<LinearConstraint>(con, vars));
   }
 
-  /** addLinearConstraint
+  /** AddLinearConstraint
    *
    * @brief adds linear constraints to the program for all (currently existing)
    * variables
    */
-  void addLinearConstraint(
+  void AddLinearConstraint(
       std::shared_ptr<LinearConstraint> con) {
-    addLinearConstraint(con, variable_views);
+    AddLinearConstraint(con, variable_views_);
   }
 
-  /** addLinearConstraint
+  /** AddLinearConstraint
    *
    * @brief adds linear constraints referencing potentially a subset
    * of the decision variables.
    */
   template <typename DerivedA, typename DerivedLB, typename DerivedUB>
-  std::shared_ptr<LinearConstraint> addLinearConstraint(
+  std::shared_ptr<LinearConstraint> AddLinearConstraint(
       const Eigen::MatrixBase<DerivedA>& A,
       const Eigen::MatrixBase<DerivedLB>& lb,
       const Eigen::MatrixBase<DerivedUB>& ub, const VariableList& vars) {
     auto constraint = std::make_shared<LinearConstraint>(A, lb, ub);
-    addLinearConstraint(constraint, vars);
+    AddLinearConstraint(constraint, vars);
     return constraint;
   }
 
-  /** addLinearConstraint
+  /** AddLinearConstraint
    *
    * @brief adds linear constraints to the program for all (currently existing)
    * variables
    */
   template <typename DerivedA, typename DerivedLB, typename DerivedUB>
-  std::shared_ptr<LinearConstraint> addLinearConstraint(
+  std::shared_ptr<LinearConstraint> AddLinearConstraint(
       const Eigen::MatrixBase<DerivedA>& A,
       const Eigen::MatrixBase<DerivedLB>& lb,
       const Eigen::MatrixBase<DerivedUB>& ub) {
-    return addLinearConstraint(A, lb, ub, variable_views);
+    return AddLinearConstraint(A, lb, ub, variable_views_);
   }
 
 
-  /** addLinearEqualityConstraint
+  /** AddLinearEqualityConstraint
    *
    * @brief adds linear equality constraints referencing potentially a
    * subset of the decision variables.
    */
-  void addLinearEqualityConstraint(
+  void AddLinearEqualityConstraint(
       std::shared_ptr<LinearEqualityConstraint> con,
       VariableList const& vars) {
-    problem_type.reset(problem_type->addLinearEqualityConstraint());
-    linear_equality_constraints.push_back(
+    problem_type_.reset(problem_type_->AddLinearEqualityConstraint());
+    linear_equality_constraints_.push_back(
         Binding<LinearEqualityConstraint>(con, vars));
   }
 
-  /** addLinearEqualityConstraint
+  /** AddLinearEqualityConstraint
    *
    * @brief adds linear equality constraints to the program for all
    * (currently existing) variables
    */
-  void addLinearEqualityConstraint(
+  void AddLinearEqualityConstraint(
       std::shared_ptr<LinearEqualityConstraint> con) {
-    addLinearEqualityConstraint(con, variable_views);
+    AddLinearEqualityConstraint(con, variable_views_);
   }
 
-  /** addLinearEqualityConstraint
+  /** AddLinearEqualityConstraint
    *
    * @brief adds linear equality constraints referencing potentially a subset of
    * the decision variables.
    * Example: to add and equality constraint which only depends on two of the
    * elements of x, you could use
-   *   auto x = prog.addContinuousDecisionVariable(6,"myvar");
-   *   prog.addLinearEqualityConstraint(Aeq, beq,{x.row(2), x.row(5)});
+   *   auto x = prog.AddContinuousDecisionVariable(6,"myvar");
+   *   prog.AddLinearEqualityConstraint(Aeq, beq,{x.row(2), x.row(5)});
    * where Aeq has exactly two columns.
    */
   template <typename DerivedA, typename DerivedB>
-  std::shared_ptr<LinearEqualityConstraint> addLinearEqualityConstraint(
+  std::shared_ptr<LinearEqualityConstraint> AddLinearEqualityConstraint(
       const Eigen::MatrixBase<DerivedA>& Aeq,
       const Eigen::MatrixBase<DerivedB>& beq, const VariableList& vars) {
 
     auto constraint = std::make_shared<LinearEqualityConstraint>(Aeq, beq);
-    addLinearEqualityConstraint(constraint, vars);
+    AddLinearEqualityConstraint(constraint, vars);
     return constraint;
   }
 
-  /** addLinearEqualityConstraint
+  /** AddLinearEqualityConstraint
    *
    * @brief adds linear equality constraints to the program for all
    * (currently existing) variables
    */
   template <typename DerivedA, typename DerivedB>
-  std::shared_ptr<LinearEqualityConstraint> addLinearEqualityConstraint(
+  std::shared_ptr<LinearEqualityConstraint> AddLinearEqualityConstraint(
       const Eigen::MatrixBase<DerivedA>& Aeq,
       const Eigen::MatrixBase<DerivedB>& beq) {
-    return addLinearEqualityConstraint(Aeq, beq, variable_views);
+    return AddLinearEqualityConstraint(Aeq, beq, variable_views_);
   }
 
-  /** addBoundingBoxConstraint
+  /** AddBoundingBoxConstraint
    *
    * @brief adds bounding box constraints referencing potentially a subset of
    * the decision variables.
    */
-  void addBoundingBoxConstraint(
+  void AddBoundingBoxConstraint(
       std::shared_ptr<BoundingBoxConstraint> con,
       VariableList const& vars) {
-    problem_type.reset(problem_type->addLinearConstraint());
-    bbox_constraints.push_back(
+    problem_type_.reset(problem_type_->AddLinearConstraint());
+    bbox_constraints_.push_back(
         Binding<BoundingBoxConstraint>(con, vars));
   }
 
-  /** addBoundingBoxConstraint
+  /** AddBoundingBoxConstraint
    *
    * @brief adds bounding box constraints to the program for all
    * (currently existing) variables
    */
-  void addBoundingBoxConstraint(
+  void AddBoundingBoxConstraint(
       std::shared_ptr<BoundingBoxConstraint> con) {
-    addBoundingBoxConstraint(con, variable_views);
+    AddBoundingBoxConstraint(con, variable_views_);
   }
 
-  /** addBoundingBoxConstraint
+  /** AddBoundingBoxConstraint
    *
    * @brief adds bounding box constraints referencing potentially a
    * subset of the decision variables.
    */
   template <typename DerivedLB, typename DerivedUB>
-  std::shared_ptr<BoundingBoxConstraint> addBoundingBoxConstraint(
+  std::shared_ptr<BoundingBoxConstraint> AddBoundingBoxConstraint(
       const Eigen::MatrixBase<DerivedLB>& lb,
       const Eigen::MatrixBase<DerivedUB>& ub, const VariableList& vars) {
     std::shared_ptr<BoundingBoxConstraint> constraint(
         new BoundingBoxConstraint(lb, ub));
-    addBoundingBoxConstraint(constraint, vars);
+    AddBoundingBoxConstraint(constraint, vars);
     return constraint;
   }
 
-  /** addBoundingBoxConstraint
+  /** AddBoundingBoxConstraint
    *
    * @brief adds bounding box constraints to the program for all
    * (currently existing) variables
    */
   template <typename DerivedLB, typename DerivedUB>
-  std::shared_ptr<BoundingBoxConstraint> addBoundingBoxConstraint(
+  std::shared_ptr<BoundingBoxConstraint> AddBoundingBoxConstraint(
       const Eigen::MatrixBase<DerivedLB>& lb,
       const Eigen::MatrixBase<DerivedUB>& ub) {
-    return addBoundingBoxConstraint(lb, ub, variable_views);
+    return AddBoundingBoxConstraint(lb, ub, variable_views_);
   }
 
-  /** addLinearComplementarityConstraint
-   *
-   * @brief adds a linear complementarity constraint to the program for all
-   * (currently existing) variables.
-   */
-  template <typename DerivedM, typename Derivedq>
-  std::shared_ptr<LinearComplementarityConstraint>
-      addLinearComplementarityConstraint(
-          const Eigen::MatrixBase<DerivedM>& M,
-          const Eigen::MatrixBase<Derivedq>& q) {
-    return addLinearComplementarityConstraint(M, q, variable_views);
-  }
-
-  /** addLinearComplementarityConstraint
+  /** AddLinearComplementarityConstraint
    *
    * @brief adds a linear complementarity constraints referencing a subset of
    * the decision variables.
    */
   template <typename DerivedM, typename Derivedq>
   std::shared_ptr<LinearComplementarityConstraint>
-      addLinearComplementarityConstraint(
+      AddLinearComplementarityConstraint(
           const Eigen::MatrixBase<DerivedM>& M,
           const Eigen::MatrixBase<Derivedq>& q,
           const VariableList& vars) {
-    problem_type.reset(
-        problem_type->addLinearComplementarityConstraint());
+    problem_type_.reset(
+        problem_type_->AddLinearComplementarityConstraint());
 
     // Linear Complementarity Constraint cannot currently coexist with any
     // other types of constraint or objective.
     // (TODO(ggould-tri) relax this to non-overlapping bindings, possibly by
     // calling multiple solvers.)
-    assert(generic_constraints.empty());
-    assert(generic_objectives.empty());
-    assert(linear_constraints.empty());
-    assert(linear_equality_constraints.empty());
-    assert(bbox_constraints.empty());
+    assert(generic_constraints_.empty());
+    assert(generic_objectives_.empty());
+    assert(linear_constraints_.empty());
+    assert(linear_equality_constraints_.empty());
+    assert(bbox_constraints_.empty());
 
     std::shared_ptr<LinearComplementarityConstraint> constraint(
         new LinearComplementarityConstraint(M, q));
-    linear_complementarity_constraints.push_back(
+    linear_complementarity_constraints_.push_back(
         Binding<LinearComplementarityConstraint>(constraint, vars));
     return constraint;
   }
 
+  /** AddLinearComplementarityConstraint
+   *
+   * @brief adds a linear complementarity constraint to the program for all
+   * (currently existing) variables.
+   */
+  template <typename DerivedM, typename Derivedq>
+  std::shared_ptr<LinearComplementarityConstraint>
+      AddLinearComplementarityConstraint(
+          const Eigen::MatrixBase<DerivedM>& M,
+          const Eigen::MatrixBase<Derivedq>& q) {
+    return AddLinearComplementarityConstraint(M, q, variable_views_);
+  }
+
   // template <typename FunctionType>
-  // void addCost(std::function..);
-  // void addLinearCost(const Eigen::MatrixBase<Derived>& c, const vector<const
+  // void AddCost(std::function..);
+  // void AddLinearCost(const Eigen::MatrixBase<Derived>& c, const vector<const
   // DecisionVariable&>& vars)
   // void addQuadraticCost ...
 
   template <typename Derived>
-  void setInitialGuess(const DecisionVariableView& var,
+  void SetInitialGuess(const DecisionVariableView& var,
                        const Eigen::MatrixBase<Derived>& x0) {
-    x_initial_guess.segment(var.index(), var.size()) = x0;
+    x_initial_guess_.segment(var.index(), var.size()) = x0;
   }
 
-  bool solve() {
-    return problem_type->solve(*this);
+  bool Solve() {
+    return problem_type_->Solve(*this);
   }  // todo: add argument for options
 
   //    template <typename Derived>
@@ -572,49 +573,49 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   //    getExitFlag();
   //    getInfeasibleConstraintNames();
 
-  void printSolution() {
-    for (const auto& v : variables) {
+  void PrintSolution() {
+    for (const auto& v : variables_) {
       std::cout << v.name() << " = " << v.value().transpose() << std::endl;
     }
   }
 
   template <typename Derived>
-  void setDecisionVariableValues(const Eigen::MatrixBase<Derived>& x) {
-    assert(x.rows() == num_vars);
+  void SetDecisionVariableValues(const Eigen::MatrixBase<Derived>& x) {
+    assert(x.rows() == num_vars_);
     size_t index = 0;
-    for (auto& v : variables) {
+    for (auto& v : variables_) {
       v.set_value(x.middleRows(index, v.value().rows()));
       index += v.value().rows();
     }
   }
 
-  const std::list<Binding<Constraint>>& getGenericObjectives() const {
-    return generic_objectives;
+  const std::list<Binding<Constraint>>& generic_objectives() const {
+    return generic_objectives_;
   }  // e.g. for snopt_user_fun
-  const std::list<Binding<Constraint>>& getGenericConstraints() const {
-    return generic_constraints;
+  const std::list<Binding<Constraint>>& generic_constraints() const {
+    return generic_constraints_;
   }  // e.g. for snopt_user_fun
   const std::list<Binding<LinearEqualityConstraint>>&
-      getLinearEqualityConstraints() const {
-    return linear_equality_constraints;
+      linear_equality_constraints() const {
+    return linear_equality_constraints_;
   }
   const std::list<Binding<LinearConstraint>>&
-      getLinearConstraints() const {
-    return linear_constraints;
+      linear_constraints() const {
+    return linear_constraints_;
   }
-  std::list<Binding<LinearConstraint>> getAllLinearConstraints() const {
-    std::list<Binding<LinearConstraint>> conlist = linear_constraints;
-    conlist.insert(conlist.end(), linear_equality_constraints.begin(),
-                   linear_equality_constraints.end());
+  std::list<Binding<LinearConstraint>> GetAllLinearConstraints() const {
+    std::list<Binding<LinearConstraint>> conlist = linear_constraints_;
+    conlist.insert(conlist.end(), linear_equality_constraints_.begin(),
+                   linear_equality_constraints_.end());
     return conlist;
   }
   const std::list<Binding<BoundingBoxConstraint>>&
-      getBoundingBoxConstraints() const {
-    return bbox_constraints;
+      bounding_box_constraints() const {
+    return bbox_constraints_;
   }
   const std::list<Binding<LinearComplementarityConstraint>>&
-      getLinearComplementarityConstraints() const {
-    return linear_complementarity_constraints;
+      linear_complementarity_constraints() const {
+    return linear_complementarity_constraints_;
   }
 
   // Base class for solver-specific data.  A solver implementation may derive
@@ -629,49 +630,39 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   // and stored, replacing data from any other solver in this problem
   // instance.
   template <typename T>
-  std::shared_ptr<T> getSolverData() {
-    auto p = std::dynamic_pointer_cast<T>(solver_data);
+  std::shared_ptr<T> GetSolverData() {
+    auto p = std::dynamic_pointer_cast<T>(solver_data_);
     if (!p) {
       p = std::make_shared<T>();
-      solver_data = p;
+      solver_data_ = p;
     }
     return p;
   }
 
-  size_t getNumVars() const { return num_vars; }
-  const Eigen::VectorXd& getInitialGuess() const { return x_initial_guess; }
+  size_t num_vars() const { return num_vars_; }
+  const Eigen::VectorXd& initial_guess() const { return x_initial_guess_; }
 
  private:
-  void checkVariables(const Constraint& con) {
-    assert(checkVariablesImpl(con) &&
-           "Constraint depends on variables that are not associated with this "
-           "OptimizationProblem");
-  }
-  bool checkVariablesImpl(const Constraint& con) {
-    // todo: implement this
-    return true;
-  }
-
   // note: use std::list instead of std::vector because realloc in std::vector
   // invalidates existing references to the elements
-  std::list<DecisionVariable> variables;
-  VariableList variable_views;
-  std::list<Binding<Constraint>> generic_objectives;
-  std::list<Binding<Constraint>> generic_constraints;
+  std::list<DecisionVariable> variables_;
+  VariableList variable_views_;
+  std::list<Binding<Constraint>> generic_objectives_;
+  std::list<Binding<Constraint>> generic_constraints_;
   std::list<Binding<LinearConstraint>>
-      linear_constraints;  // note: does not include linear_equality_constraints
-  std::list<Binding<LinearEqualityConstraint>> linear_equality_constraints;
-  std::list<Binding<BoundingBoxConstraint>> bbox_constraints;
+      linear_constraints_;  // note: does not include linear_equality_constraints_
+  std::list<Binding<LinearEqualityConstraint>> linear_equality_constraints_;
+  std::list<Binding<BoundingBoxConstraint>> bbox_constraints_;
 
   // Invariant:  The bindings in this list must be non-overlapping.
   // TODO(ggould-tri) can this constraint be relaxed?
   std::list<Binding<LinearComplementarityConstraint>>
-      linear_complementarity_constraints;
+      linear_complementarity_constraints_;
 
-  size_t num_vars;
-  Eigen::VectorXd x_initial_guess;
-  std::shared_ptr<SolverData> solver_data;
-  std::shared_ptr<MathematicalProgramInterface> problem_type;
+  size_t num_vars_;
+  Eigen::VectorXd x_initial_guess_;
+  std::shared_ptr<SolverData> solver_data_;
+  std::shared_ptr<MathematicalProgramInterface> problem_type_;
 };
 
 }  // end namespace Drake

--- a/drake/solvers/SnoptSolver.cpp
+++ b/drake/solvers/SnoptSolver.cpp
@@ -196,10 +196,10 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
   // evaluate objective
   auto tx = Drake::initializeAutoDiff(xvec);
   Drake::TaylorVecXd ty(1), this_x(*n);
-  for (auto const& binding : current_problem->getGenericObjectives()) {
-    auto const& obj = binding.getConstraint();
+  for (auto const& binding : current_problem->generic_objectives()) {
+    auto const& obj = binding.constraint();
     size_t index = 0;
-    for (const Drake::DecisionVariableView& v : binding.getVariableList()) {
+    for (const Drake::DecisionVariableView& v : binding.variable_list()) {
       this_x.segment(index, v.size()) = tx.segment(v.index(), v.size());
       index += v.size();
     }
@@ -208,7 +208,7 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
 
     F[constraint_index++] += static_cast<snopt::doublereal>(
         ty(0).value());
-    for (const Drake::DecisionVariableView& v : binding.getVariableList()) {
+    for (const Drake::DecisionVariableView& v : binding.variable_list()) {
       for (size_t j = v.index(); j < v.index() + v.size(); j++) {
         G[grad_index + j] +=
             static_cast<snopt::doublereal>(ty(0).derivatives()(j));
@@ -217,10 +217,10 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
   }
   grad_index += *n;
 
-  for (auto const& binding : current_problem->getGenericConstraints()) {
-    auto const& c = binding.getConstraint();
-    size_t index = 0, num_constraints = c->getNumConstraints();
-    for (const Drake::DecisionVariableView& v : binding.getVariableList()) {
+  for (auto const& binding : current_problem->generic_constraints()) {
+    auto const& c = binding.constraint();
+    size_t index = 0, num_constraints = c->num_constraints();
+    for (const Drake::DecisionVariableView& v : binding.variable_list()) {
       this_x.segment(index, v.size()) = tx.segment(v.index(), v.size());
       index += v.size();
     }
@@ -231,7 +231,7 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
     for (i = 0; i < num_constraints; i++) {
       F[constraint_index++] = static_cast<snopt::doublereal>(ty(i).value());
     }
-    for (const Drake::DecisionVariableView& v : binding.getVariableList()) {
+    for (const Drake::DecisionVariableView& v : binding.variable_list()) {
       for (i = 0; i < num_constraints; i++) {
         for (size_t j = v.index(); j < v.index() + v.size(); j++) {
           G[grad_index++] =
@@ -244,9 +244,9 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
   return 0;
 }
 
-bool Drake::SnoptSolver::solve(
+bool Drake::SnoptSolver::Solve(
     OptimizationProblem& prog) const {
-  auto d = prog.getSolverData<SNOPTData>();
+  auto d = prog.GetSolverData<SNOPTData>();
   SNOPTRun cur(*d);
 
   Drake::OptimizationProblem const* current_problem = &prog;
@@ -262,12 +262,12 @@ bool Drake::SnoptSolver::solve(
     std::copy(pcp, pcp + sizeof(current_problem), cu_cp);
   }
 
-  snopt::integer nx = prog.getNumVars();
+  snopt::integer nx = prog.num_vars();
   d->min_alloc_x(nx);
   snopt::doublereal* x = d->x.data();
   snopt::doublereal* xlow = d->xlow.data();
   snopt::doublereal* xupp = d->xupp.data();
-  const Eigen::VectorXd x_initial_guess = prog.getInitialGuess();
+  const Eigen::VectorXd x_initial_guess = prog.initial_guess();
   for (int i = 0; i < nx; i++) {
     x[i] = static_cast<snopt::doublereal>(x_initial_guess(i));
     xlow[i] =
@@ -275,10 +275,10 @@ bool Drake::SnoptSolver::solve(
     xupp[i] =
         static_cast<snopt::doublereal>(std::numeric_limits<double>::infinity());
   }
-  for (auto const& binding : prog.getBoundingBoxConstraints()) {
-    auto const& c = binding.getConstraint();
-    for (const DecisionVariableView& v : binding.getVariableList()) {
-      auto const lb = c->getLowerBound(), ub = c->getUpperBound();
+  for (auto const& binding : prog.bounding_box_constraints()) {
+    auto const& c = binding.constraint();
+    for (const DecisionVariableView& v : binding.variable_list()) {
+      auto const lb = c->lower_bound(), ub = c->upper_bound();
       for (int k = 0; k < v.size(); k++) {
         xlow[v.index() + k] = std::max<snopt::doublereal>(
             static_cast<snopt::doublereal>(lb(k)), xlow[v.index() + k]);
@@ -289,17 +289,17 @@ bool Drake::SnoptSolver::solve(
   }
 
   size_t num_nonlinear_constraints = 0, max_num_gradients = nx;
-  for (auto const& binding : prog.getGenericConstraints()) {
-    auto const& c = binding.getConstraint();
-    size_t n = c->getNumConstraints();
-    for (const DecisionVariableView& v : binding.getVariableList()) {
+  for (auto const& binding : prog.generic_constraints()) {
+    auto const& c = binding.constraint();
+    size_t n = c->num_constraints();
+    for (const DecisionVariableView& v : binding.variable_list()) {
       max_num_gradients += n * v.size();
     }
     num_nonlinear_constraints += n;
   }
   size_t num_linear_constraints = 0;
-  for (auto const& binding : prog.getLinearEqualityConstraints()) {
-    num_linear_constraints += binding.getConstraint()->getNumConstraints();
+  for (auto const& binding : prog.linear_equality_constraints()) {
+    num_linear_constraints += binding.constraint()->num_constraints();
   }
 
   snopt::integer nF = 1 + num_nonlinear_constraints + num_linear_constraints;
@@ -323,17 +323,17 @@ bool Drake::SnoptSolver::solve(
   size_t constraint_index = 1, grad_index = nx;  // constraint index starts at 1
                                                  // because the objective is the
                                                  // first row
-  for (auto const& binding : prog.getGenericConstraints()) {
-    auto const& c = binding.getConstraint();
-    size_t n = c->getNumConstraints();
+  for (auto const& binding : prog.generic_constraints()) {
+    auto const& c = binding.constraint();
+    size_t n = c->num_constraints();
 
-    auto const lb = c->getLowerBound(), ub = c->getUpperBound();
+    auto const lb = c->lower_bound(), ub = c->upper_bound();
     for (int i = 0; i < n; i++) {
       Flow[constraint_index + i] = static_cast<snopt::doublereal>(lb(i));
       Fupp[constraint_index + i] = static_cast<snopt::doublereal>(ub(i));
     }
 
-    for (const DecisionVariableView& v : binding.getVariableList()) {
+    for (const DecisionVariableView& v : binding.variable_list()) {
       for (size_t i = 0; i < n; i++) {
         for (size_t j = 0; j < v.size(); j++) {
           iGfun[grad_index] = constraint_index + i + 1;  // row order
@@ -348,15 +348,15 @@ bool Drake::SnoptSolver::solve(
   // http://eigen.tuxfamily.org/dox/group__TutorialSparse.html
   typedef Eigen::Triplet<double> T;
   std::vector<T> tripletList;
-  tripletList.reserve(num_linear_constraints * prog.getNumVars());
+  tripletList.reserve(num_linear_constraints * prog.num_vars());
 
   size_t linear_constraint_index = 0;
-  for (auto const& binding : prog.getLinearEqualityConstraints()) {
-    auto const& c = binding.getConstraint();
-    size_t n = c->getNumConstraints();
+  for (auto const& binding : prog.linear_equality_constraints()) {
+    auto const& c = binding.constraint();
+    size_t n = c->num_constraints();
     size_t var_index = 0;
-    Eigen::SparseMatrix<double> A_constraint = c->getSparseMatrix();
-    for (const DecisionVariableView& v : binding.getVariableList()) {
+    Eigen::SparseMatrix<double> A_constraint = c->GetSparseMatrix();
+    for (const DecisionVariableView& v : binding.variable_list()) {
       for (size_t k = 0; k < v.size(); ++k) {
         for (Eigen::SparseMatrix<double>::InnerIterator it(
                  A_constraint, var_index + k);
@@ -368,7 +368,7 @@ bool Drake::SnoptSolver::solve(
       var_index += v.size();
     }
 
-    auto const lb = c->getLowerBound(), ub = c->getUpperBound();
+    auto const lb = c->lower_bound(), ub = c->upper_bound();
     for (int i = 0; i < n; i++) {
       Flow[constraint_index + i] = static_cast<snopt::doublereal>(lb(i));
       Fupp[constraint_index + i] = static_cast<snopt::doublereal>(ub(i));
@@ -479,7 +479,7 @@ bool Drake::SnoptSolver::solve(
   for (int i = 0; i < nx; i++) {
     sol(i) = static_cast<double>(x[i]);
   }
-  prog.setDecisionVariableValues(sol);
+  prog.SetDecisionVariableValues(sol);
 
   // todo: extract the other useful quantities, too.
 

--- a/drake/solvers/SnoptSolver.h
+++ b/drake/solvers/SnoptSolver.h
@@ -13,7 +13,7 @@ class DRAKEOPTIMIZATION_EXPORT SnoptSolver :
     // This solver is implemented in various pieces depending on if
     // SNOPT was available during compilation.
     virtual bool available() const override;
-    virtual bool solve(OptimizationProblem& prog) const override;
+    virtual bool Solve(OptimizationProblem& prog) const override;
 };
 }
 

--- a/drake/solvers/test/testMobyLCP.cpp
+++ b/drake/solvers/test/testMobyLCP.cpp
@@ -34,7 +34,7 @@ Eigen::SparseMatrix<double> MakeSparseMatrix(
 /// Run all non-regularized solvers.  If @p expected_z is an empty
 /// vector, outputs will only be compared against each other.
 template <typename Derived>
-void RunBasicLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
+void RunBasicLcp(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
                  const Eigen::VectorXd& expected_z_in, bool expect_fast_pass) {
   Drake::MobyLCPSolver l;
   l.SetLoggingEnabled(verbose);
@@ -72,7 +72,7 @@ void RunBasicLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
 /// Run all regularized solvers.  If @p expected_z is an empty
 /// vector, outputs will only be compared against each other.
 template <typename Derived>
-void RunRegularizedLCP(const Eigen::MatrixBase<Derived>& M,
+void RunRegularizedLcp(const Eigen::MatrixBase<Derived>& M,
                        const Eigen::VectorXd& q,
                        const Eigen::VectorXd& expected_z_in,
                        bool expect_fast_pass) {
@@ -114,8 +114,8 @@ void RunRegularizedLCP(const Eigen::MatrixBase<Derived>& M,
 template <typename Derived>
 void runLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
             const Eigen::VectorXd& expected_z_in, bool expect_fast_pass) {
-  RunBasicLCP(M, q, expected_z_in, expect_fast_pass);
-  RunRegularizedLCP(M, q, expected_z_in, expect_fast_pass);
+  RunBasicLcp(M, q, expected_z_in, expect_fast_pass);
+  RunRegularizedLcp(M, q, expected_z_in, expect_fast_pass);
 }
 
 TEST(testMobyLCP, testTrivial) {
@@ -137,11 +137,11 @@ TEST(testMobyLCP, testTrivial) {
   q << -1, -1, -1, -1, -1, -1, -1, -1, -1;
 
   Eigen::VectorXd empty_z;
-  RunBasicLCP(M, q, empty_z, true);
+  RunBasicLcp(M, q, empty_z, true);
 
   // Mangle the input matrix so that some regularization occurs.
   M(0, 8) = 10;
-  RunRegularizedLCP(M, q, empty_z, true);
+  RunRegularizedLcp(M, q, empty_z, true);
 }
 
 TEST(testMobyLCP, testProblem1) {

--- a/drake/solvers/test/testMobyLCP.cpp
+++ b/drake/solvers/test/testMobyLCP.cpp
@@ -15,7 +15,7 @@ const double epsilon = 1e-6;
 const bool verbose = false;
 
 template <typename Derived>
-Eigen::SparseMatrix<double> makeSparseMatrix(
+Eigen::SparseMatrix<double> MakeSparseMatrix(
     const Eigen::MatrixBase<Derived>& M) {
   typedef Eigen::Triplet<double> Triplet;
   std::vector<Triplet> triplet_list;
@@ -34,15 +34,15 @@ Eigen::SparseMatrix<double> makeSparseMatrix(
 /// Run all non-regularized solvers.  If @p expected_z is an empty
 /// vector, outputs will only be compared against each other.
 template <typename Derived>
-void runBasicLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
+void RunBasicLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
                  const Eigen::VectorXd& expected_z_in, bool expect_fast_pass) {
   Drake::MobyLCPSolver l;
-  l.setLoggingEnabled(verbose);
+  l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd expected_z = expected_z_in;
 
   Eigen::VectorXd fast_z;
-  bool result = l.lcp_fast(M, q, &fast_z);
+  bool result = l.SolveLCPFast(M, q, &fast_z);
   if (expected_z.size() == 0) {
     ASSERT_TRUE(expect_fast_pass)
         << "Expected Z not provided and expect_fast_pass unset.";
@@ -58,13 +58,13 @@ void runBasicLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
   }
 
   Eigen::VectorXd lemke_z;
-  result = l.lcp_lemke(M, q, &lemke_z);
+  result = l.SolveLCPLemke(M, q, &lemke_z);
   EXPECT_TRUE(CompareMatrices(lemke_z, expected_z, epsilon,
                               MatrixCompareType::absolute));
 
-  Eigen::SparseMatrix<double> M_sparse = makeSparseMatrix(M);
+  Eigen::SparseMatrix<double> M_sparse = MakeSparseMatrix(M);
   lemke_z.setZero();
-  result = l.lcp_lemke(M_sparse, q, &lemke_z);
+  result = l.SolveLCPLemke(M_sparse, q, &lemke_z);
   EXPECT_TRUE(CompareMatrices(lemke_z, expected_z, epsilon,
                               MatrixCompareType::absolute));
 }
@@ -72,17 +72,17 @@ void runBasicLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
 /// Run all regularized solvers.  If @p expected_z is an empty
 /// vector, outputs will only be compared against each other.
 template <typename Derived>
-void runRegularizedLCP(const Eigen::MatrixBase<Derived>& M,
+void RunRegularizedLCP(const Eigen::MatrixBase<Derived>& M,
                        const Eigen::VectorXd& q,
                        const Eigen::VectorXd& expected_z_in,
                        bool expect_fast_pass) {
   Drake::MobyLCPSolver l;
-  l.setLoggingEnabled(verbose);
+  l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd expected_z = expected_z_in;
 
   Eigen::VectorXd fast_z;
-  bool result = l.lcp_fast_regularized(M, q, &fast_z);
+  bool result = l.SolveLCPFastRegularized(M, q, &fast_z);
   if (expected_z.size() == 0) {
     expected_z = fast_z;
   } else {
@@ -98,13 +98,13 @@ void runRegularizedLCP(const Eigen::MatrixBase<Derived>& M,
   }
 
   Eigen::VectorXd lemke_z;
-  result = l.lcp_lemke_regularized(M, q, &lemke_z);
+  result = l.SolveLCPLemkeRegularized(M, q, &lemke_z);
   EXPECT_TRUE(CompareMatrices(lemke_z, expected_z, epsilon,
                               MatrixCompareType::absolute));
 
-  Eigen::SparseMatrix<double> M_sparse = makeSparseMatrix(M);
+  Eigen::SparseMatrix<double> M_sparse = MakeSparseMatrix(M);
   lemke_z.setZero();
-  result = l.lcp_lemke_regularized(M_sparse, q, &lemke_z);
+  result = l.SolveLCPLemkeRegularized(M_sparse, q, &lemke_z);
   EXPECT_TRUE(CompareMatrices(lemke_z, expected_z, epsilon,
                               MatrixCompareType::absolute));
 }
@@ -114,8 +114,8 @@ void runRegularizedLCP(const Eigen::MatrixBase<Derived>& M,
 template <typename Derived>
 void runLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
             const Eigen::VectorXd& expected_z_in, bool expect_fast_pass) {
-  runBasicLCP(M, q, expected_z_in, expect_fast_pass);
-  runRegularizedLCP(M, q, expected_z_in, expect_fast_pass);
+  RunBasicLCP(M, q, expected_z_in, expect_fast_pass);
+  RunRegularizedLCP(M, q, expected_z_in, expect_fast_pass);
 }
 
 TEST(testMobyLCP, testTrivial) {
@@ -137,11 +137,11 @@ TEST(testMobyLCP, testTrivial) {
   q << -1, -1, -1, -1, -1, -1, -1, -1, -1;
 
   Eigen::VectorXd empty_z;
-  runBasicLCP(M, q, empty_z, true);
+  RunBasicLCP(M, q, empty_z, true);
 
   // Mangle the input matrix so that some regularization occurs.
   M(0, 8) = 10;
-  runRegularizedLCP(M, q, empty_z, true);
+  RunRegularizedLCP(M, q, empty_z, true);
 }
 
 TEST(testMobyLCP, testProblem1) {
@@ -223,19 +223,19 @@ TEST(testMobyLCP, testProblem4) {
   z << 1. / 90., 2. / 45., 1. / 90., 2. / 45.;
 
   Drake::MobyLCPSolver l;
-  l.setLoggingEnabled(verbose);
+  l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd fast_z;
-  bool result = l.lcp_fast(M, q, &fast_z);
+  bool result = l.SolveLCPFast(M, q, &fast_z);
   EXPECT_TRUE(CompareMatrices(fast_z, z, epsilon, MatrixCompareType::absolute));
 
   // TODO sammy the Lemke solvers find no solution at all, however.
   fast_z.setZero();
-  result = l.lcp_lemke(M, q, &fast_z);
+  result = l.SolveLCPLemke(M, q, &fast_z);
   EXPECT_FALSE(result);
 
-  Eigen::SparseMatrix<double> M_sparse = makeSparseMatrix(M);
-  result = l.lcp_lemke(M_sparse, q, &fast_z);
+  Eigen::SparseMatrix<double> M_sparse = MakeSparseMatrix(M);
+  result = l.SolveLCPLemke(M_sparse, q, &fast_z);
   EXPECT_FALSE(result);
 }
 
@@ -287,30 +287,30 @@ TEST(testMobyLCP, testEmpty) {
   Eigen::VectorXd empty_q(0);
   Eigen::VectorXd z;
   Drake::MobyLCPSolver l;
-  l.setLoggingEnabled(verbose);
+  l.SetLoggingEnabled(verbose);
 
-  bool result = l.lcp_fast(empty_M, empty_q, &z);
+  bool result = l.SolveLCPFast(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
-  result = l.lcp_lemke(empty_M, empty_q, &z);
+  result = l.SolveLCPLemke(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
   Eigen::SparseMatrix<double> empty_sparse_M(0, 0);
-  result = l.lcp_lemke(empty_sparse_M, empty_q, &z);
+  result = l.SolveLCPLemke(empty_sparse_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
-  result = l.lcp_fast_regularized(empty_M, empty_q, &z);
+  result = l.SolveLCPFastRegularized(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
-  result = l.lcp_lemke_regularized(empty_M, empty_q, &z);
+  result = l.SolveLCPLemkeRegularized(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
-  result = l.lcp_lemke_regularized(empty_sparse_M, empty_q, &z);
+  result = l.SolveLCPLemkeRegularized(empty_sparse_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 }

--- a/drake/solvers/test/testMobyLCP.cpp
+++ b/drake/solvers/test/testMobyLCP.cpp
@@ -42,7 +42,7 @@ void RunBasicLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
   Eigen::VectorXd expected_z = expected_z_in;
 
   Eigen::VectorXd fast_z;
-  bool result = l.SolveLCPFast(M, q, &fast_z);
+  bool result = l.SolveLcpFast(M, q, &fast_z);
   if (expected_z.size() == 0) {
     ASSERT_TRUE(expect_fast_pass)
         << "Expected Z not provided and expect_fast_pass unset.";
@@ -58,13 +58,13 @@ void RunBasicLCP(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
   }
 
   Eigen::VectorXd lemke_z;
-  result = l.SolveLCPLemke(M, q, &lemke_z);
+  result = l.SolveLcpLemke(M, q, &lemke_z);
   EXPECT_TRUE(CompareMatrices(lemke_z, expected_z, epsilon,
                               MatrixCompareType::absolute));
 
   Eigen::SparseMatrix<double> M_sparse = MakeSparseMatrix(M);
   lemke_z.setZero();
-  result = l.SolveLCPLemke(M_sparse, q, &lemke_z);
+  result = l.SolveLcpLemke(M_sparse, q, &lemke_z);
   EXPECT_TRUE(CompareMatrices(lemke_z, expected_z, epsilon,
                               MatrixCompareType::absolute));
 }
@@ -82,7 +82,7 @@ void RunRegularizedLCP(const Eigen::MatrixBase<Derived>& M,
   Eigen::VectorXd expected_z = expected_z_in;
 
   Eigen::VectorXd fast_z;
-  bool result = l.SolveLCPFastRegularized(M, q, &fast_z);
+  bool result = l.SolveLcpFastRegularized(M, q, &fast_z);
   if (expected_z.size() == 0) {
     expected_z = fast_z;
   } else {
@@ -98,13 +98,13 @@ void RunRegularizedLCP(const Eigen::MatrixBase<Derived>& M,
   }
 
   Eigen::VectorXd lemke_z;
-  result = l.SolveLCPLemkeRegularized(M, q, &lemke_z);
+  result = l.SolveLcpLemkeRegularized(M, q, &lemke_z);
   EXPECT_TRUE(CompareMatrices(lemke_z, expected_z, epsilon,
                               MatrixCompareType::absolute));
 
   Eigen::SparseMatrix<double> M_sparse = MakeSparseMatrix(M);
   lemke_z.setZero();
-  result = l.SolveLCPLemkeRegularized(M_sparse, q, &lemke_z);
+  result = l.SolveLcpLemkeRegularized(M_sparse, q, &lemke_z);
   EXPECT_TRUE(CompareMatrices(lemke_z, expected_z, epsilon,
                               MatrixCompareType::absolute));
 }
@@ -226,16 +226,16 @@ TEST(testMobyLCP, testProblem4) {
   l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd fast_z;
-  bool result = l.SolveLCPFast(M, q, &fast_z);
+  bool result = l.SolveLcpFast(M, q, &fast_z);
   EXPECT_TRUE(CompareMatrices(fast_z, z, epsilon, MatrixCompareType::absolute));
 
   // TODO sammy the Lemke solvers find no solution at all, however.
   fast_z.setZero();
-  result = l.SolveLCPLemke(M, q, &fast_z);
+  result = l.SolveLcpLemke(M, q, &fast_z);
   EXPECT_FALSE(result);
 
   Eigen::SparseMatrix<double> M_sparse = MakeSparseMatrix(M);
-  result = l.SolveLCPLemke(M_sparse, q, &fast_z);
+  result = l.SolveLcpLemke(M_sparse, q, &fast_z);
   EXPECT_FALSE(result);
 }
 
@@ -289,28 +289,28 @@ TEST(testMobyLCP, testEmpty) {
   Drake::MobyLCPSolver l;
   l.SetLoggingEnabled(verbose);
 
-  bool result = l.SolveLCPFast(empty_M, empty_q, &z);
+  bool result = l.SolveLcpFast(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
-  result = l.SolveLCPLemke(empty_M, empty_q, &z);
+  result = l.SolveLcpLemke(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
   Eigen::SparseMatrix<double> empty_sparse_M(0, 0);
-  result = l.SolveLCPLemke(empty_sparse_M, empty_q, &z);
+  result = l.SolveLcpLemke(empty_sparse_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
-  result = l.SolveLCPFastRegularized(empty_M, empty_q, &z);
+  result = l.SolveLcpFastRegularized(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
-  result = l.SolveLCPLemkeRegularized(empty_M, empty_q, &z);
+  result = l.SolveLcpLemkeRegularized(empty_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 
-  result = l.SolveLCPLemkeRegularized(empty_sparse_M, empty_q, &z);
+  result = l.SolveLcpLemkeRegularized(empty_sparse_M, empty_q, &z);
   EXPECT_TRUE(result);
   EXPECT_EQ(z.size(), 0);
 }

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -67,22 +67,22 @@ struct Unique {
 
 TEST(testOptimizationProblem, testAddFunction) {
   OptimizationProblem prog;
-  prog.addContinuousVariables(1);
+  prog.AddContinuousVariables(1);
 
   Movable movable;
-  prog.addCost(std::move(movable));
-  prog.addCost(Movable());
+  prog.AddCost(std::move(movable));
+  prog.AddCost(Movable());
 
   Copyable copyable;
-  prog.addCost(copyable);
+  prog.AddCost(copyable);
 
   Unique unique;
-  prog.addCost(std::cref(unique));
-  prog.addCost(std::make_shared<Unique>());
-  prog.addCost(std::unique_ptr<Unique>(new Unique));
+  prog.AddCost(std::cref(unique));
+  prog.AddCost(std::make_shared<Unique>());
+  prog.AddCost(std::unique_ptr<Unique>(new Unique));
 }
 
-void runNonlinearProgram(OptimizationProblem& prog,
+void RunNonlinearProgram(OptimizationProblem& prog,
                          std::function<void(void)> test_func) {
   NloptSolver nlopt_solver;
   SnoptSolver snopt_solver;
@@ -94,7 +94,7 @@ void runNonlinearProgram(OptimizationProblem& prog,
 
   for (const auto& solver : solvers) {
     if (!solver.second->available()) { continue; }
-    ASSERT_NO_THROW(solver.second->solve(prog)) <<
+    ASSERT_NO_THROW(solver.second->Solve(prog)) <<
         "Using solver: " << solver.first;
     EXPECT_NO_THROW(test_func()) << "Using solver: " << solver.first;
   }
@@ -103,15 +103,15 @@ void runNonlinearProgram(OptimizationProblem& prog,
 TEST(testOptimizationProblem, trivialLeastSquares) {
   OptimizationProblem prog;
 
-  auto const& x = prog.addContinuousVariables(4);
+  auto const& x = prog.AddContinuousVariables(4);
 
   auto x2 = x(2);
   auto xhead = x.head(3);
 
   Vector4d b = Vector4d::Random();
-  auto con = prog.addLinearEqualityConstraint(Matrix4d::Identity(), b, {x});
+  auto con = prog.AddLinearEqualityConstraint(Matrix4d::Identity(), b, {x});
 
-  prog.solve();
+  prog.Solve();
   EXPECT_TRUE(
       CompareMatrices(b, x.value(), 1e-10, MatrixCompareType::absolute));
 
@@ -121,9 +121,9 @@ TEST(testOptimizationProblem, trivialLeastSquares) {
 
   valuecheck(b(2), xhead(2).value()(0), 1e-10);  // a segment of a segment
 
-  auto const& y = prog.addContinuousVariables(2);
-  prog.addLinearEqualityConstraint(2 * Matrix2d::Identity(), b.topRows(2), {y});
-  prog.solve();
+  auto const& y = prog.AddContinuousVariables(2);
+  prog.AddLinearEqualityConstraint(2 * Matrix2d::Identity(), b.topRows(2), {y});
+  prog.Solve();
   EXPECT_TRUE(CompareMatrices(b.topRows(2) / 2, y.value(), 1e-10,
                               MatrixCompareType::absolute));
 
@@ -131,7 +131,7 @@ TEST(testOptimizationProblem, trivialLeastSquares) {
       CompareMatrices(b, x.value(), 1e-10, MatrixCompareType::absolute));
 
   con->updateConstraint(3 * Matrix4d::Identity(), b);
-  prog.solve();
+  prog.Solve();
   EXPECT_TRUE(CompareMatrices(b.topRows(2) / 2, y.value(), 1e-10,
                               MatrixCompareType::absolute));
 
@@ -140,10 +140,10 @@ TEST(testOptimizationProblem, trivialLeastSquares) {
 
   std::shared_ptr<BoundingBoxConstraint> bbcon(new BoundingBoxConstraint(
       MatrixXd::Constant(2, 1, -1000.0), MatrixXd::Constant(2, 1, 1000.0)));
-  prog.addBoundingBoxConstraint(bbcon, {x.head(2)});
+  prog.AddBoundingBoxConstraint(bbcon, {x.head(2)});
 
   // Now solve as a nonlinear program.
-  runNonlinearProgram(prog, [&]() {
+  RunNonlinearProgram(prog, [&]() {
       EXPECT_TRUE(CompareMatrices(b.topRows(2) / 2, y.value(), 1e-10,
                                   MatrixCompareType::absolute));
       EXPECT_TRUE(
@@ -172,20 +172,20 @@ class TestProblem1Objective {
 
 TEST(testOptimizationProblem, testProblem1) {
   OptimizationProblem prog;
-  auto x = prog.addContinuousVariables(5);
-  prog.addCost(TestProblem1Objective());
+  auto x = prog.AddContinuousVariables(5);
+  prog.AddCost(TestProblem1Objective());
   VectorXd constraint(5);
   constraint << 20, 12, 11, 7, 4;
-  prog.addLinearConstraint(
+  prog.AddLinearConstraint(
       constraint.transpose(),
       Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
       Drake::Vector1d::Constant(40));
-  prog.addBoundingBoxConstraint(
+  prog.AddBoundingBoxConstraint(
       MatrixXd::Constant(5, 1, 0), MatrixXd::Constant(5, 1, 1));
   VectorXd expected(5);
   expected << 1, 1, 0, 1, 0;
-  prog.setInitialGuess({x}, expected + .2 * VectorXd::Random(5));
-  runNonlinearProgram(prog, [&]() {
+  prog.SetInitialGuess({x}, expected + .2 * VectorXd::Random(5));
+  RunNonlinearProgram(prog, [&]() {
       EXPECT_TRUE(CompareMatrices(x.value(), expected, 1e-10,
                                   MatrixCompareType::absolute));
     });
@@ -242,34 +242,34 @@ class LowerBoundTestConstraint : public Constraint {
 
 TEST(testOptimizationProblem, lowerBoundTest) {
   OptimizationProblem prog;
-  auto x = prog.addContinuousVariables(6);
-  prog.addCost(LowerBoundTestObjective());
+  auto x = prog.AddContinuousVariables(6);
+  prog.AddCost(LowerBoundTestObjective());
   std::shared_ptr<Constraint> con1(new LowerBoundTestConstraint(2, 3));
-  prog.addGenericConstraint(con1);
+  prog.AddGenericConstraint(con1);
   std::shared_ptr<Constraint> con2(new LowerBoundTestConstraint(4, 5));
-  prog.addGenericConstraint(con2);
+  prog.AddGenericConstraint(con2);
 
   Eigen::VectorXd c1(6);
   c1 << 1, -3, 0, 0, 0, 0;
-  prog.addLinearConstraint(
+  prog.AddLinearConstraint(
       c1.transpose(),
       Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
       Drake::Vector1d::Constant(2));
   Eigen::VectorXd c2(6);
   c2 << -1, 1, 0, 0, 0, 0;
-  prog.addLinearConstraint(
+  prog.AddLinearConstraint(
       c2.transpose(),
       Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
       Drake::Vector1d::Constant(2));
   Eigen::VectorXd c3(6);
   c3 << 1, 1, 0, 0, 0, 0;
-  prog.addLinearConstraint(
+  prog.AddLinearConstraint(
       c3.transpose(),
       Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
       Drake::Vector1d::Constant(6));
   Eigen::VectorXd c4(6);
   c4 << 1, 1, 0, 0, 0, 0;
-  prog.addLinearConstraint(
+  prog.AddLinearConstraint(
       c4.transpose(),
       Drake::Vector1d::Constant(2),
       Drake::Vector1d::Constant(std::numeric_limits<double>::infinity()));
@@ -279,16 +279,16 @@ TEST(testOptimizationProblem, lowerBoundTest) {
   upper << std::numeric_limits<double>::infinity(),
       std::numeric_limits<double>::infinity(),
       5, 6, 5, 10;
-  prog.addBoundingBoxConstraint(lower, upper);
+  prog.AddBoundingBoxConstraint(lower, upper);
 
   Eigen::VectorXd expected(6);
   expected << 5, 1, 5, 0, 5, 10;
-  prog.setInitialGuess({x}, expected + .1 * Eigen::VectorXd::Random(6));
+  prog.SetInitialGuess({x}, expected + .1 * Eigen::VectorXd::Random(6));
 
   // This test actually fails in SNOPT but works in NLopt.
   NloptSolver nlopt_solver;
   if (!nlopt_solver.available()) { return; }
-  nlopt_solver.solve(prog);
+  nlopt_solver.Solve(prog);
 
   // This test seems to be fairly sensitive to how much the randomness
   // causes the initial guess to deviate, so the tolerance is a bit
@@ -314,10 +314,10 @@ class SixHumpCamelObjective {
 
 TEST(testOptimizationProblem, sixHumpCamel) {
   OptimizationProblem prog;
-  auto x = prog.addContinuousVariables(2);
-  auto objective = prog.addCost(SixHumpCamelObjective());
+  auto x = prog.AddContinuousVariables(2);
+  auto objective = prog.AddCost(SixHumpCamelObjective());
 
-  runNonlinearProgram(prog, [&]() {
+  RunNonlinearProgram(prog, [&]() {
       // check (numerically) if it is a local minimum
       VectorXd ystar, y;
       objective->eval(x.value(), ystar);
@@ -378,25 +378,25 @@ class GloptipolyConstrainedExampleConstraint
  */
 TEST(testOptimizationProblem, gloptipolyConstrainedMinimization) {
   OptimizationProblem prog;
-  auto x = prog.addContinuousVariables(3);
-  prog.addCost(GloptipolyConstrainedExampleObjective());
+  auto x = prog.AddContinuousVariables(3);
+  prog.AddCost(GloptipolyConstrainedExampleObjective());
   std::shared_ptr<GloptipolyConstrainedExampleConstraint> qp_con(
       new GloptipolyConstrainedExampleConstraint());
-  prog.addGenericConstraint(qp_con, {x});
-  prog.addLinearConstraint(
+  prog.AddGenericConstraint(qp_con, {x});
+  prog.AddLinearConstraint(
       Vector3d(1, 1, 1).transpose(),
       Vector1d::Constant(-std::numeric_limits<double>::infinity()),
       Vector1d::Constant(4));
-  prog.addLinearConstraint(
+  prog.AddLinearConstraint(
       Vector3d(0, 3, 1).transpose(),
       Vector1d::Constant(-std::numeric_limits<double>::infinity()),
       Vector1d::Constant(6));
-  prog.addBoundingBoxConstraint(
+  prog.AddBoundingBoxConstraint(
       Vector3d(0, 0, 0),
       Vector3d(2, std::numeric_limits<double>::infinity(), 3));
 
-  prog.setInitialGuess({x}, Vector3d(.5, 0, 3) + .1 * Vector3d::Random());
-  runNonlinearProgram(prog, [&]() {
+  prog.SetInitialGuess({x}, Vector3d(.5, 0, 3) + .1 * Vector3d::Random());
+  RunNonlinearProgram(prog, [&]() {
       EXPECT_TRUE(CompareMatrices(x.value(), Vector3d(0.5, 0, 3), 1e-4,
                                   MatrixCompareType::absolute));
     });
@@ -432,7 +432,7 @@ TEST(testOptimizationProblem, simpleLCPConstraintEval) {
 /** Simple linear complementarity problem example.
  * @brief a hand-created LCP easily solved.
  *
- * Note: This test is meant to test that OptimizationProblem.solve() works in
+ * Note: This test is meant to test that OptimizationProblem.Solve() works in
  * this case; tests of the correctness of the Moby LCP solver itself live in
  * testMobyLCP.
  */
@@ -447,10 +447,10 @@ TEST(testOptimizationProblem, simpleLCP) {
 
   Eigen::Vector2d q(-16, -15);
 
-  auto x = prog.addContinuousVariables(2);
+  auto x = prog.AddContinuousVariables(2);
 
-  prog.addLinearComplementarityConstraint(M, q, {x});
-  EXPECT_NO_THROW(prog.solve());
+  prog.AddLinearComplementarityConstraint(M, q, {x});
+  EXPECT_NO_THROW(prog.Solve());
   EXPECT_TRUE(CompareMatrices(x.value(), Vector2d(16, 0), 1e-4,
                               MatrixCompareType::absolute));
 }
@@ -470,12 +470,12 @@ TEST(testOptimizationProblem, multiLCP) {
 
   Eigen::Vector2d q(-16, -15);
 
-  auto x = prog.addContinuousVariables(2);
-  auto y = prog.addContinuousVariables(2);
+  auto x = prog.AddContinuousVariables(2);
+  auto y = prog.AddContinuousVariables(2);
 
-  prog.addLinearComplementarityConstraint(M, q, {x});
-  prog.addLinearComplementarityConstraint(M, q, {y});
-  EXPECT_NO_THROW(prog.solve());
+  prog.AddLinearComplementarityConstraint(M, q, {x});
+  prog.AddLinearComplementarityConstraint(M, q, {y});
+  EXPECT_NO_THROW(prog.Solve());
 
   EXPECT_TRUE(CompareMatrices(x.value(), Vector2d(16, 0), 1e-4,
                               MatrixCompareType::absolute));

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -57,7 +57,7 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
   // the optimization framework should support this (though it has not been
   // tested thoroughly yet)
   OptimizationProblem prog;
-  auto const& vdot = prog.addContinuousVariables(nv, "vdot");
+  auto const& vdot = prog.AddContinuousVariables(nv, "vdot");
 
   auto H = tree->massMatrix(kinsol);
   Eigen::MatrixXd H_and_neg_JT = H;
@@ -171,7 +171,7 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
     const double alpha = 5.0;  // 1/time constant of position constraint
                                // satisfaction (see my latex rigid body notes)
 
-    prog.addContinuousVariables(
+    prog.AddContinuousVariables(
         nc, "position constraint force");  // don't actually need to use the
                                            // decision variable reference that
                                            // would be returned...
@@ -183,17 +183,17 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
 
     // phiddot = -2 alpha phidot - alpha^2 phi  (0 + critically damped
     // stabilization term)
-    prog.addLinearEqualityConstraint(
+    prog.AddLinearEqualityConstraint(
         J, -(Jdotv + 2 * alpha * J * v + alpha * alpha * phi), {vdot});
     H_and_neg_JT.conservativeResize(NoChange, H_and_neg_JT.cols() + J.rows());
     H_and_neg_JT.rightCols(J.rows()) = -J.transpose();
   }
 
   // add [H,-J^T]*[vdot;f] = -C
-  prog.addLinearEqualityConstraint(H_and_neg_JT, -C);
+  prog.AddLinearEqualityConstraint(H_and_neg_JT, -C);
 
-  prog.solve();
-  //      prog.printSolution();
+  prog.Solve();
+  //      prog.PrintSolution();
 
   StateVector<double> dot(nq + nv);
   dot << kinsol.transformPositionDotMappingToVelocityMapping(
@@ -231,7 +231,7 @@ class SingleTimeKinematicConstraintWrapper : public Constraint {
       : Constraint(rigid_body_constraint->getNumConstraint(nullptr)),
         rigid_body_constraint(rigid_body_constraint),
         kinsol(rigid_body_constraint->getRobotPointer()->bodies) {
-    rigid_body_constraint->bounds(nullptr, lower_bound, upper_bound);
+    rigid_body_constraint->bounds(nullptr, lower_bound_, upper_bound_);
   }
   virtual ~SingleTimeKinematicConstraintWrapper() {}
 
@@ -275,7 +275,7 @@ Drake::getInitialState(const RigidBodySystem& sys) {
         loops = sys.tree->loops;
 
     int nq = sys.tree->num_positions;
-    auto qvar = prog.addContinuousVariables(nq);
+    auto qvar = prog.AddContinuousVariables(nq);
 
     Matrix<double, 7, 1> bTbp = Matrix<double, 7, 1>::Zero();
     bTbp(3) = 1.0;
@@ -289,19 +289,19 @@ Drake::getInitialState(const RigidBodySystem& sys) {
           loops[i].frameB->frame_index, bTbp, tspan);
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con1wrapper(
           new SingleTimeKinematicConstraintWrapper(con1));
-      prog.addGenericConstraint(con1wrapper, {qvar});
+      prog.AddGenericConstraint(con1wrapper, {qvar});
       auto con2 = make_shared<RelativePositionConstraint>(
           sys.tree.get(), loops[i].axis, loops[i].axis, loops[i].axis,
           loops[i].frameA->frame_index, loops[i].frameB->frame_index, bTbp,
           tspan);
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(
           new SingleTimeKinematicConstraintWrapper(con2));
-      prog.addGenericConstraint(con2wrapper, {qvar});
+      prog.AddGenericConstraint(con2wrapper, {qvar});
     }
 
     VectorXd q_guess = x0.topRows(nq);
-    prog.addQuadraticCost(MatrixXd::Identity(nq, nq), q_guess);
-    prog.solve();
+    prog.AddQuadraticCost(MatrixXd::Identity(nq, nq), q_guess);
+    prog.Solve();
 
     x0 << qvar.value(), VectorXd::Zero(sys.tree->num_velocities);
   }
@@ -739,4 +739,3 @@ void RigidBodySystem::addRobotFromFile(
     throw runtime_error("unknown file extension: " + ext);
   }
 }
-


### PR DESCRIPTION
Rename many functions/variables from the drake/solvers directory to be more compatible with the style guide.

This originally came up in #1962, and was moved into a separate PR.  Fixes #1984.