### PR TITLE
Stop suppressing cpplint runtime/printf

### DIFF
--- a/drake/CPPLINT.cfg
+++ b/drake/CPPLINT.cfg
@@ -43,7 +43,6 @@ filter=-runtime/arrays
 filter=-runtime/casting
 filter=-runtime/explicit
 filter=-runtime/int
-filter=-runtime/printf
 filter=-runtime/references
 filter=-runtime/string
 filter=-whitespace/blank_line

--- a/drake/systems/DCSFunction.cpp
+++ b/drake/systems/DCSFunction.cpp
@@ -45,10 +45,10 @@ bool mexCallMATLABsafe(SimStruct *S, int nlhs, mxArray *plhs[], int nrhs,
     mxArray *identifier = mxGetProperty(ex, 0, "identifier");
     char buffer[200];
     errmsg = mxArrayToString(identifier);
-    sprintf(buffer,
-            "\n\nDrakeSystem S-Function: error %s in MATLAB callback.\nSee "
-            "additional debugging information above",
-            errmsg);
+    snprintf(buffer, sizeof(buffer),
+             "\n\nDrakeSystem S-Function: error %s in MATLAB callback.\nSee "
+             "additional debugging information above",
+             errmsg);
     ssSetErrorStatus(S, buffer);
     mxFree(errmsg);
     //    mxFree(identifier);  // it appears I'm not supposed to free this

--- a/drake/systems/plants/inverseKinBackend.cpp
+++ b/drake/systems/plants/inverseKinBackend.cpp
@@ -697,12 +697,13 @@ void inverseKinBackend(
         string qsc_weights_cnst_name;
         if (&t[i] != nullptr) {
           char qsc_name_buffer[200];
-          sprintf(qsc_name_buffer,
-                  "quasi static constraint weights at time %7.3f", t[i]);
+          snprintf(qsc_name_buffer, sizeof(qsc_name_buffer),
+                   "quasi static constraint weights at time %7.3f", t[i]);
           qsc_weights_cnst_name = string(qsc_name_buffer);
         } else {
           char qsc_name_buffer[200];
-          sprintf(qsc_name_buffer, "quasi static constraint weights");
+          snprintf(qsc_name_buffer, sizeof(qsc_name_buffer),
+                   "quasi static constraint weights");
           qsc_weights_cnst_name = string(qsc_name_buffer);
         }
         Cname_array[i].push_back(qsc_weights_cnst_name);

--- a/drake/util/drakeDebugMex.cpp
+++ b/drake/util/drakeDebugMex.cpp
@@ -49,11 +49,11 @@ int main(
   }
 
   int i, count = 1;
-  char buff[100], countstr[6] = "00000";
+  char buff[6], countstr[6] = "00000";
   string name;
 
   while (true) {
-    sprintf(buff, "%d", count);
+    snprintf(buff, sizeof(buff), "%d", count);
     memcpy(&countstr[5 - strlen(buff)], buff, strlen(buff));
 
     name = "fun_";


### PR DESCRIPTION
Fix all the current errors, then stop suppressing cpplint runtime/printf.
