### PR TITLE
Add --non-realtime to many test programs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ Unreleased: changes on master, not yet released
 [//]: # "Smaller bug fixes.  No API changes."
 ### Fixes
 
+ - [#2027][] Realtime C++ tests no longer fail under ctest.
  - [#2008][] `Drake::simulate(4-arg)` actually compiles again now.
  - [#1990][] Windows builds that include `bullet` are working again.
- - [#1985][] `runQuadrotorDynamics` no longer fails under ctest.
  - [#1975][] Fix coordinate frame error in rigid body collisions.
  - (Assorted) Non-functional fixes for `cpplint` compliance.
 
@@ -49,10 +49,10 @@ Changes in version v0.9.11 and before are not provided.
 
 [//]: # "You can use PimpMyChangelog to auto-update this list."
 [//]: # "https://github.com/pcreux/pimpmychangelog"
+[#2027]: https://github.com/RobotLocomotion/drake/issues/2027
 [#1953]: https://github.com/RobotLocomotion/drake/issues/1953
 [#1970]: https://github.com/RobotLocomotion/drake/issues/1970
 [#1975]: https://github.com/RobotLocomotion/drake/issues/1975
-[#1985]: https://github.com/RobotLocomotion/drake/issues/1985
 [#1990]: https://github.com/RobotLocomotion/drake/issues/1990
 [#1992]: https://github.com/RobotLocomotion/drake/issues/1992
 [#2008]: https://github.com/RobotLocomotion/drake/issues/2008

--- a/drake/examples/Pendulum/CMakeLists.txt
+++ b/drake/examples/Pendulum/CMakeLists.txt
@@ -1,17 +1,17 @@
 if (LCM_FOUND)
   add_executable(runPendulumDynamics runDynamics.cpp)
   target_link_libraries(runPendulumDynamics drakeRBM drakeLCMSystem)
-  add_test(NAME runPendulumDynamics COMMAND runPendulumDynamics WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/Pendulum)
+  add_test(NAME runPendulumDynamics COMMAND runPendulumDynamics --non-realtime)
 
   add_executable(runPendulumEnergyShaping runEnergyShaping.cpp)
   target_link_libraries(runPendulumEnergyShaping drakeRBM drakeLCMSystem)
-#  add_test(NAME runPendulumEnergyShaping COMMAND runPendulumEnergyShaping)
+#  add_test(NAME runPendulumEnergyShaping COMMAND runPendulumEnergyShaping --non-realtime)
 #  set_tests_properties(runPendulumEnergyShaping PROPERTIES TIMEOUT 10)
     # disabled for now since it's not a good test, since it will always timeout
 
   add_executable(runPendulumLQR runLQR.cpp)
   target_link_libraries(runPendulumLQR drakeRBM drakeLCMSystem)
-  add_test(NAME runPendulumLQR COMMAND runPendulumLQR WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/Pendulum)
+  add_test(NAME runPendulumLQR COMMAND runPendulumLQR --non-realtime)
 
 #  write_procman(Pendulum.pmd
 #      GROUP "Simulate"

--- a/drake/examples/Pendulum/runDynamics.cpp
+++ b/drake/examples/Pendulum/runDynamics.cpp
@@ -6,6 +6,7 @@
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/cascade_system.h"
+#include "drake/util/drakeAppUtil.h"
 
 using namespace std;
 using namespace Drake;
@@ -31,6 +32,9 @@ int main(int argc, char* argv[]) {
 
   SimulationOptions options;
   options.realtime_factor = 1.0;
+  if (commandLineOptionExists(argv, argv + argc, "--non-realtime")) {
+    options.warn_real_time_violation = true;
+  }
 
   //  simulate(*sys, 0, 10, x0, options);
   runLCM(sys, lcm, 0, 10, x0, options);

--- a/drake/examples/Pendulum/runEnergyShaping.cpp
+++ b/drake/examples/Pendulum/runEnergyShaping.cpp
@@ -34,6 +34,9 @@ int main(int argc, char* argv[]) {
   } else {  // run a stand-alone simulation
     SimulationOptions options;
     options.realtime_factor = 1.0;
+    if (commandLineOptionExists(argv, argv + argc, "--non-realtime")) {
+      options.warn_real_time_violation = true;
+    }
 
     Eigen::Vector2d x0;
     x0 << 0.1, 0.2;

--- a/drake/examples/Pendulum/runLQR.cpp
+++ b/drake/examples/Pendulum/runLQR.cpp
@@ -5,6 +5,7 @@
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/cascade_system.h"
 #include "drake/systems/feedback_system.h"
+#include "drake/util/drakeAppUtil.h"
 
 using namespace std;
 using namespace Drake;
@@ -33,6 +34,9 @@ int main(int argc, char* argv[]) {
 
   SimulationOptions options;
   options.realtime_factor = 1.0;
+  if (commandLineOptionExists(argv, argv + argc, "--non-realtime")) {
+    options.warn_real_time_violation = true;
+  }
 
   for (int i = 0; i < 5; i++) {
     Eigen::Vector2d x0 = toEigen(xG);

--- a/drake/examples/Quadrotor/CMakeLists.txt
+++ b/drake/examples/Quadrotor/CMakeLists.txt
@@ -4,7 +4,7 @@ if (LCM_FOUND AND NOT WIN32)
   target_link_libraries(runQuadrotorDynamics drakeRBSystem drakeLCMSystem)
   add_dependencies(runQuadrotorDynamics drake_lcmtypes lcmtype_agg_hpp)
   pods_use_pkg_config_packages(runQuadrotorDynamics lcm)
-  add_test(NAME runQuadrotorDynamics COMMAND runQuadrotorDynamics 5.0 1.0 warn)
+  add_test(NAME runQuadrotorDynamics COMMAND runQuadrotorDynamics 5.0 1.0 --non-realtime)
 
   add_executable(runQuadrotorLQR runLQR.cpp)
   target_link_libraries(runQuadrotorLQR drakeRBM)

--- a/drake/examples/Quadrotor/CMakeLists.txt
+++ b/drake/examples/Quadrotor/CMakeLists.txt
@@ -10,7 +10,7 @@ if (LCM_FOUND AND NOT WIN32)
   target_link_libraries(runQuadrotorLQR drakeRBM)
   add_dependencies(runQuadrotorLQR drake_lcmtypes lcmtype_agg_hpp)
   pods_use_pkg_config_packages(runQuadrotorLQR lcm)
-  add_test(NAME runQuadrotorLQR COMMAND runQuadrotorLQR WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/Quadrotor)
+  add_test(NAME runQuadrotorLQR COMMAND runQuadrotorLQR --non-realtime)
 endif()
 
 add_matlab_test(NAME examples/Quadrotor/Quadrotor.runOpenLoop COMMAND Quadrotor.runOpenLoop)

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -5,6 +5,7 @@
 #include "drake/systems/cascade_system.h"
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/plants/RigidBodySystem.h"
+#include "drake/util/drakeAppUtil.h"
 
 #include "QuadrotorInput.h"
 #include "QuadrotorOutput.h"
@@ -29,9 +30,8 @@ int main(int argc, char* argv[]) {
 
   // Determine whether a warning should be printed or an exception should be
   // thrown if the simulation is delayed by more than the timeout threshold.
-  if (argc >= 4) {
-    options.warn_real_time_violation =
-        (std::string(argv[3]).compare("warn") == 0);
+  if (commandLineOptionExists(argv, argv + argc, "--non-realtime")) {
+    options.warn_real_time_violation = true;
   }
 
   cout << "Running simulation for " << final_time

--- a/drake/examples/Quadrotor/runLQR.cpp
+++ b/drake/examples/Quadrotor/runLQR.cpp
@@ -5,6 +5,7 @@
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/cascade_system.h"
 #include "drake/systems/feedback_system.h"
+#include "drake/util/drakeAppUtil.h"
 
 using namespace std;
 using namespace Eigen;
@@ -41,6 +42,9 @@ int main(int argc, char* argv[]) {
   SimulationOptions options;
   options.realtime_factor = 1.0;
   options.initial_step_size = 0.005;
+  if (commandLineOptionExists(argv, argv + argc, "--non-realtime")) {
+    options.warn_real_time_violation = true;
+  }
 
   for (int i = 0; i < 5; i++) {
     Eigen::Matrix<double, 12, 1> x0 = toEigen(xG);


### PR DESCRIPTION
This closes #2024.

It was impractical to factor this better, since SimulationOptions is not accessible to any the util/ helpers.