### PR TITLE
Remove instructions for Ubuntu 12.04 Trusty, which is no longer supported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Unreleased: changes on master, not yet released
 [//]: # "Lost functionality or APIs."
 ### Removed / Deprecated
 
- - [#2039][] Removed support for Ubuntu 12.04 Trusty.
+ - [#2039][] Ubuntu 12.04 Trusty is no longer supported.
 
 [//]: # "Smaller bug fixes.  No API changes."
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Unreleased: changes on master, not yet released
 [//]: # "Lost functionality or APIs."
 ### Removed / Deprecated
 
- - None
+ - [#2039][] Removed support for Ubuntu 12.04 Trusty.
 
 [//]: # "Smaller bug fixes.  No API changes."
 ### Fixes
@@ -50,6 +50,7 @@ Changes in version v0.9.11 and before are not provided.
 
 [//]: # "You can use PimpMyChangelog to auto-update this list."
 [//]: # "https://github.com/pcreux/pimpmychangelog"
+[#2039]: https://github.com/RobotLocomotion/drake/issues/2039
 [#2027]: https://github.com/RobotLocomotion/drake/issues/2027
 [#1953]: https://github.com/RobotLocomotion/drake/issues/1953
 [#1970]: https://github.com/RobotLocomotion/drake/issues/1970

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -1,6 +1,6 @@
-***********************************************
-Ubuntu 12.04 LTS (Precise) / 14.04 LTS (Trusty)
-***********************************************
+*************************
+Ubuntu 14.04 LTS (Trusty)
+*************************
 
 Install the prerequisites::
 
@@ -9,10 +9,6 @@ Install the prerequisites::
     sudo apt-get install --no-install-recommends lsb-core python-software-properties wget
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-
-    # Ubuntu 12.04 LTS (Precise)
-    sudo add-apt-repository -y "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main"
-    sudo add-apt-repository -y ppa:kalakris/cmake
 
     # Ubuntu 14.04 LTS (Trusty)
     sudo add-apt-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main"

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -10,7 +10,6 @@ Install the prerequisites::
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 
-    # Ubuntu 14.04 LTS (Trusty)
     sudo add-apt-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main"
 
     sudo apt-get update
@@ -23,7 +22,6 @@ Install the prerequisites::
       python-dev python-gtk2 python-numpy python-pip python-vtk subversion \
       swig valgrind
 
-    # Ubuntu 14.04 LTS (Trusty)
     sudo apt-get install cmake-curses-gui
 
     sudo pip install -U cpplint Sphinx


### PR DESCRIPTION
Resolves #2015

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2039) &emsp; Multiple assignees:&emsp;<img alt="@RussTedrake" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/6442292?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/RussTedrake">RussTedrake</a>,&emsp;<img alt="@david-german-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17437069?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/david-german-tri">david-german-tri</a>,&emsp;<img alt="@jwnimmer-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596505?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/jwnimmer-tri">jwnimmer-tri</a>
<!-- Reviewable:end -->
