### PR TITLE
Clarify some matrix element aliasing in QP.cpp (gurobi)

### DIFF
--- a/drake/CPPLINT.cfg
+++ b/drake/CPPLINT.cfg
@@ -36,7 +36,6 @@ filter=-readability/multiline_comment
 filter=-readability/namespace
 filter=-readability/todo
 filter=-runtime/arrays
-filter=-runtime/casting
 filter=-runtime/explicit
 filter=-runtime/int
 filter=-runtime/references

--- a/drake/solvers/QP.cpp
+++ b/drake/solvers/QP.cpp
@@ -423,7 +423,8 @@ GRBmodel* gurobiQP(GRBenv* env, vector<MatrixXd*> QblkDiag, VectorXd& f,
       d = Q->rows() * Q->cols();
       for (i = 0; i < d; i++) {
         Qi = i + startrow;
-        CGE(GRBaddqpterms(model, 1, &Qi, &Qi, &(Q->operator()(i))), env);
+        double& qval = Q->operator()(i);
+        CGE(GRBaddqpterms(model, 1, &Qi, &Qi, &qval), env);
       }
       startrow = startrow + d;
     } else {  // potentially dense matrix
@@ -437,7 +438,8 @@ GRBmodel* gurobiQP(GRBenv* env, vector<MatrixXd*> QblkDiag, VectorXd& f,
         for (j = 0; j < d; j++) {
           Qi = i + startrow;
           Qj = j + startrow;
-          CGE(GRBaddqpterms(model, 1, &Qi, &Qj, &(Q->operator()(i, j))), env);
+          double& qval = Q->operator()(i, j);
+          CGE(GRBaddqpterms(model, 1, &Qi, &Qj, &qval), env);
         }
       startrow = startrow + d;
     }
@@ -522,7 +524,8 @@ GRBmodel* gurobiActiveSetQP(GRBenv* env, vector<MatrixXd*> QblkDiag,
       d = Q->rows() * Q->cols();
       for (i = 0; i < d; i++) {
         Qi = i + startrow;
-        CGE(GRBaddqpterms(model, 1, &Qi, &Qi, &(Q->operator()(i))), env);
+        double& qval = Q->operator()(i);
+        CGE(GRBaddqpterms(model, 1, &Qi, &Qi, &qval), env);
       }
       startrow = startrow + d;
     } else {  // potentially dense matrix
@@ -536,7 +539,8 @@ GRBmodel* gurobiActiveSetQP(GRBenv* env, vector<MatrixXd*> QblkDiag,
         for (j = 0; j < d; j++) {
           Qi = i + startrow;
           Qj = j + startrow;
-          CGE(GRBaddqpterms(model, 1, &Qi, &Qj, &(Q->operator()(i, j))), env);
+          double& qval = Q->operator()(i, j);
+          CGE(GRBaddqpterms(model, 1, &Qi, &Qj, &qval), env);
         }
       startrow = startrow + d;
     }


### PR DESCRIPTION
The first commit clarifies some matrix element aliasing in QP.cpp (gurobi).  That also resolves the only cpplint runtime/casting warnings, so we can enable that rule.

~~Note that this MUST NOT BE MERGED until we confirm that a builder with Gurobi installed passes its tests.  Just passing Jenkins is not enough, per #2040.~~ _Edit: CI coverage has been confirmed._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2042)
<!-- Reviewable:end -->
