### PR TITLE
Modified "not implemented yet" error message to be more meaningful.

### DIFF
--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -56,7 +56,9 @@ class MathematicalProgram : public MathematicalProgramInterface {
     return new MathematicalProgram;
   };
   virtual bool Solve(OptimizationProblem& prog) const override {
-    throw std::runtime_error("not implemented yet");
+    throw std::runtime_error(
+        "MathematicalProgram::Solve: "
+        "No solver available for the given optimization problem!");
   }
 };
 


### PR DESCRIPTION
This replaces the vague "not implemented yet" exception with a more meaningful message. I tested it by disabling SNOPT and running `compareRigidBodySystems` on the Prius URDF/SDF models in [feature/debug_sdf_cleanup](https://github.com/liangfok/drake/tree/feature/debug_sdf_cleanup).

Here is example output when the exception is thrown when running the aforementioned application:

```
$ ./drake/pod-build/bin/compareRigidBodySystems ../drake2/drake/examples/Cars/prius/prius.urdf ../drake2/drake/examples/Cars/prius/prius.sdf
Running main() from compareRigidBodySystems.cpp
Calling testing::InitGoogleTest(...)
argc = 3
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from CompareRigidBodySystemsTest
[ RUN      ] CompareRigidBodySystemsTest.TestAll
unknown file: Failure
C++ exception with description "MathematicalProgram::Solve: No solver available for the given optimization problem!" thrown in the test body.
[  FAILED  ] CompareRigidBodySystemsTest.TestAll (64 ms)
[----------] 1 test from CompareRigidBodySystemsTest (64 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (64 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CompareRigidBodySystemsTest.TestAll
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2049)
<!-- Reviewable:end -->
