### PR TITLE
Fix comment typo

### DIFF
--- a/drake/solvers/QP.cpp
+++ b/drake/solvers/QP.cpp
@@ -78,7 +78,7 @@ int fastQPThatTakesQinv(vector<MatrixXd*> QinvblkDiag, const VectorXd& f,
         QinvAteq.block(startrow, 0, d, M) =
             thisQinv->asDiagonal() *
             Aeq.block(0, startrow, M, d)
-                .transpose();  // Aeq.transpoODse().block(startrow, 0, d, N)
+                .transpose();  // Aeq.transpose().block(startrow, 0, d, N)
       minusQinvf.segment(startrow, d) =
           -thisQinv->cwiseProduct(f.segment(startrow, d));
       startrow = startrow + d;


### PR DESCRIPTION
Looks like there's an escape sequence in the comment that's causing GitHub to misdetect the file's charset as `iso-2022-cn`.  Credit to @mithrandi for spotting it!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2052)
<!-- Reviewable:end -->
