### PR TITLE
Separate ResultCollector base

### DIFF
--- a/drake/systems/plants/collision/BulletResultCollector.cpp
+++ b/drake/systems/plants/collision/BulletResultCollector.cpp
@@ -8,22 +8,12 @@ using namespace std;
 using namespace Eigen;
 
 namespace DrakeCollision {
-Vector3d toVector3d(const Vector3d& vec) { return vec; }
-
 Vector3d toVector3d(const btVector3& bt_vec) {
   Vector3d vec;
   vec(0) = (double)bt_vec.getX();
   vec(1) = (double)bt_vec.getY();
   vec(2) = (double)bt_vec.getZ();
   return vec;
-}
-
-void ResultCollector::addPointPairResult(const PointPair& result) {
-  pts.push_back(result);
-}
-
-PointPair ResultCollector::minDistPoint() {
-  return *min_element(pts.begin(), pts.end());
 }
 
 btScalar BulletResultCollector::addSingleResult(

--- a/drake/systems/plants/collision/BulletResultCollector.cpp
+++ b/drake/systems/plants/collision/BulletResultCollector.cpp
@@ -1,15 +1,10 @@
-#include <iostream>
-#include <btBulletCollisionCommon.h>
+#include "drake/systems/plants/collision/BulletResultCollector.h"
 
 #include "drake/systems/plants/collision/DrakeCollision.h"
-#include "BulletResultCollector.h"
-
-using namespace std;
-using namespace Eigen;
 
 namespace DrakeCollision {
-Vector3d toVector3d(const btVector3& bt_vec) {
-  Vector3d vec;
+Eigen::Vector3d toVector3d(const btVector3& bt_vec) {
+  Eigen::Vector3d vec;
   vec(0) = (double)bt_vec.getX();
   vec(1) = (double)bt_vec.getY();
   vec(2) = (double)bt_vec.getZ();

--- a/drake/systems/plants/collision/BulletResultCollector.h
+++ b/drake/systems/plants/collision/BulletResultCollector.h
@@ -4,6 +4,8 @@
 #include "drake/systems/plants/collision/DrakeCollision.h"
 #include "drake/systems/plants/collision/ResultCollector.h"
 
+#include <btBulletCollisionCommon.h>
+
 namespace DrakeCollision {
 Eigen::Vector3d toVector3d(const btVector3& bt_vec);
 

--- a/drake/systems/plants/collision/BulletResultCollector.h
+++ b/drake/systems/plants/collision/BulletResultCollector.h
@@ -2,30 +2,10 @@
 #define DRAKE_SYSTEMS_PLANTS_COLLISION_BULLETRESULTCOLLECTOR_H_
 
 #include "drake/systems/plants/collision/DrakeCollision.h"
+#include "drake/systems/plants/collision/ResultCollector.h"
 
 namespace DrakeCollision {
-Eigen::Vector3d toVector3d(const Eigen::Vector3d& vec);
 Eigen::Vector3d toVector3d(const btVector3& bt_vec);
-
-class ResultCollector {
- public:
-  virtual ~ResultCollector() {}
-
-  virtual void addPointPairResult(const PointPair& result);
-
-  inline void addSingleResult(const ElementId idA, const ElementId idB,
-                              const Eigen::Vector3d& ptA,
-                              const Eigen::Vector3d& ptB,
-                              const Eigen::Vector3d& normal, double distance) {
-    addPointPairResult(PointPair(idA, idB, ptA, ptB, normal, distance));
-  }
-
-  std::vector<PointPair> getResults() const { return pts; }
-
-  PointPair minDistPoint();
-
-  std::vector<PointPair> pts;
-};
 
 class BulletResultCollector : public ResultCollector,
                               public btCollisionWorld::ContactResultCallback {
@@ -50,8 +30,6 @@ class BulletResultCollector : public ResultCollector,
   int curr_bodyA_idx;
   int curr_bodyB_idx;
 };
-
-typedef std::shared_ptr<ResultCollector> ResultCollShPtr;
 }
 
 #endif  // DRAKE_SYSTEMS_PLANTS_COLLISION_BULLETRESULTCOLLECTOR_H_

--- a/drake/systems/plants/collision/CMakeLists.txt
+++ b/drake/systems/plants/collision/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(drakeCollision_SRC_FILES DrakeCollision.cpp Element.cpp point_pair.cc Model.cpp)
+set(drakeCollision_SRC_FILES DrakeCollision.cpp Element.cpp point_pair.cc Model.cpp ResultCollector.cpp)
 pods_find_pkg_config(bullet)
 
 if (bullet_FOUND)

--- a/drake/systems/plants/collision/ResultCollector.cpp
+++ b/drake/systems/plants/collision/ResultCollector.cpp
@@ -1,10 +1,6 @@
-#include <iostream>
+#include "drake/systems/plants/collision/ResultCollector.h"
 
 #include "drake/systems/plants/collision/DrakeCollision.h"
-#include "ResultCollector.h"
-
-using namespace std;
-using namespace Eigen;
 
 namespace DrakeCollision {
 void ResultCollector::addPointPairResult(const PointPair& result) {
@@ -12,6 +8,6 @@ void ResultCollector::addPointPairResult(const PointPair& result) {
 }
 
 PointPair ResultCollector::minDistPoint() {
-  return *min_element(pts.begin(), pts.end());
+  return *std::min_element(pts.begin(), pts.end());
 }
 }

--- a/drake/systems/plants/collision/ResultCollector.cpp
+++ b/drake/systems/plants/collision/ResultCollector.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+
+#include "drake/systems/plants/collision/DrakeCollision.h"
+#include "ResultCollector.h"
+
+using namespace std;
+using namespace Eigen;
+
+namespace DrakeCollision {
+void ResultCollector::addPointPairResult(const PointPair& result) {
+  pts.push_back(result);
+}
+
+PointPair ResultCollector::minDistPoint() {
+  return *min_element(pts.begin(), pts.end());
+}
+}

--- a/drake/systems/plants/collision/ResultCollector.cpp
+++ b/drake/systems/plants/collision/ResultCollector.cpp
@@ -7,7 +7,7 @@ void ResultCollector::addPointPairResult(const PointPair& result) {
   pts.push_back(result);
 }
 
-PointPair ResultCollector::minDistPoint() {
+PointPair ResultCollector::minDistPoint() const {
   return *std::min_element(pts.begin(), pts.end());
 }
 }

--- a/drake/systems/plants/collision/ResultCollector.h
+++ b/drake/systems/plants/collision/ResultCollector.h
@@ -1,0 +1,30 @@
+#ifndef DRAKE_SYSTEMS_PLANTS_COLLISION_RESULTCOLLECTOR_H_
+#define DRAKE_SYSTEMS_PLANTS_COLLISION_RESULTCOLLECTOR_H_
+
+#include "drake/systems/plants/collision/DrakeCollision.h"
+
+namespace DrakeCollision {
+class ResultCollector {
+ public:
+  virtual ~ResultCollector() {}
+
+  virtual void addPointPairResult(const PointPair& result);
+
+  inline void addSingleResult(const ElementId idA, const ElementId idB,
+                              const Eigen::Vector3d& ptA,
+                              const Eigen::Vector3d& ptB,
+                              const Eigen::Vector3d& normal, double distance) {
+    addPointPairResult(PointPair(idA, idB, ptA, ptB, normal, distance));
+  }
+
+  std::vector<PointPair> getResults() const { return pts; }
+
+  PointPair minDistPoint();
+
+  std::vector<PointPair> pts;
+};
+
+typedef std::shared_ptr<ResultCollector> ResultCollShPtr;
+}
+
+#endif  // DRAKE_SYSTEMS_PLANTS_COLLISION_RESULTCOLLECTOR_H_

--- a/drake/systems/plants/collision/ResultCollector.h
+++ b/drake/systems/plants/collision/ResultCollector.h
@@ -20,7 +20,7 @@ class ResultCollector {
 
   std::vector<PointPair> getResults() const { return pts; }
 
-  PointPair minDistPoint();
+  PointPair minDistPoint() const;
 
   std::vector<PointPair> pts;
 };

--- a/drake/systems/plants/collision/ResultCollector.h
+++ b/drake/systems/plants/collision/ResultCollector.h
@@ -13,7 +13,8 @@ class ResultCollector {
   inline void addSingleResult(const ElementId idA, const ElementId idB,
                               const Eigen::Vector3d& ptA,
                               const Eigen::Vector3d& ptB,
-                              const Eigen::Vector3d& normal, double distance) {
+                              const Eigen::Vector3d& normal,
+                              const double distance) {
     addPointPairResult(PointPair(idA, idB, ptA, ptB, normal, distance));
   }
 


### PR DESCRIPTION
Move the base `ResultCollector` class into its own file, rather than embedding it in the source files for the `BulletResultCollector` subclass. This will make it possible to add other implementations.

In particular, this is going to become the new parent commit of #2010, which seems not likely to be merged soon. I have had to rebase that branch more than once due to changes in `ResultCollector`; it is hoped that merging this branch ASAP will make it easier to maintain the FCL branch until it can be merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2057)
<!-- Reviewable:end -->
