### PR TITLE
Added missing includes to RigidBodyFrame.h.

### DIFF
--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -4,6 +4,7 @@
 #include <Eigen/Dense>
 
 #include "drake/drakeRBSystem_export.h"
+#include "drake/systems/plants/RigidBody.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 
 namespace tinyxml2 {

--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -5,7 +5,6 @@
 
 #include "drake/drakeRBSystem_export.h"
 #include "drake/systems/plants/RigidBody.h"
-#include "drake/systems/plants/RigidBodyTree.h"
 
 namespace tinyxml2 {
 class XMLElement;

--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -1,6 +1,11 @@
 #ifndef DRAKE_SYSTEMS_PLANTS_RIGIDBODYFRAME_H_
 #define DRAKE_SYSTEMS_PLANTS_RIGIDBODYFRAME_H_
 
+#include <Eigen/Dense>
+
+#include "drake/drakeRBSystem_export.h"
+#include "drake/systems/plants/RigidBodyTree.h"
+
 namespace tinyxml2 {
 class XMLElement;
 }


### PR DESCRIPTION
To conform to the [C++ style guide](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes).


> You should include all the headers that define the symbols you rely upon, except in the unusual case of forward declaration. If you rely on symbols from bar.h, don't count on the fact that you included foo.h which (currently) includes bar.h: include bar.h yourself, unless foo.h explicitly demonstrates its intent to provide you the symbols of bar.h. However, any includes present in the related header do not need to be included again in the related cc (i.e., foo.cc can rely on foo.h's includes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2060)
<!-- Reviewable:end -->
