### PR TITLE
Updated Includes in RigidBodyFrame.h

### DIFF
--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -1,9 +1,6 @@
 #ifndef DRAKE_SYSTEMS_PLANTS_RIGIDBODYFRAME_H_
 #define DRAKE_SYSTEMS_PLANTS_RIGIDBODYFRAME_H_
 
-#include <Eigen/Dense>
-
-#include "drake/drakeRBSystem_export.h"
 #include "drake/systems/plants/RigidBody.h"
 
 namespace tinyxml2 {


### PR DESCRIPTION
Removed `#include` statements that are transitively included due to [C++ style guide update](https://github.com/RobotLocomotion/drake/pull/2066).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2072)
<!-- Reviewable:end -->
