### PR TITLE
Updated API of CompareMatrices.

### DIFF
--- a/drake/util/eigen_matrix_compare.h
+++ b/drake/util/eigen_matrix_compare.h
@@ -25,8 +25,8 @@ enum MatrixCompareType { absolute, relative };
 template <typename DerivedA, typename DerivedB>
 bool CompareMatrices(const Eigen::MatrixBase<DerivedA>& m1,
                      const Eigen::MatrixBase<DerivedB>& m2,
-                     const double tolerance,
-                     const MatrixCompareType compare_type,
+                     double tolerance,
+                     MatrixCompareType compare_type,
                      std::string* explanation = nullptr) {
   bool result = true;
 


### PR DESCRIPTION
Removed "const" keyword from parameters that are passed by value to clean up the API.

See: https://github.com/RobotLocomotion/drake/pull/2057/files/6c0eee297ab57c353c9c717040a0ed03421940ae#r59301054

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2073)
<!-- Reviewable:end -->
