### PR TITLE
Fix" default value of install prefix for non-pods builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,19 @@ endif()
 
 # PODs out-of-source build logic
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	find_file(_build_dir build PATHS ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/.. ${PROJECT_SOURCE_DIR}/../.. ${PROJECT_SOURCE_DIR}/../../.. ${PROJECT_SOURCE_DIR}/../../../..)
-	if (_build_dir)
-		set(CMAKE_INSTALL_PREFIX "${_build_dir}" CACHE STRING
-		"install prefix" FORCE)
+	if(POD_BUILD)
+		find_file(_build_dir build PATHS ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/.. ${PROJECT_SOURCE_DIR}/../.. ${PROJECT_SOURCE_DIR}/../../.. ${PROJECT_SOURCE_DIR}/../../../..)
+		if (_build_dir)
+			set(CMAKE_INSTALL_PREFIX "${_build_dir}" CACHE STRING
+				"Prefix for installation of sub-packages (note: required during build!)" FORCE)
+		else()
+			execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_SOURCE_DIR}/build)
+			set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR}/build
+			CACHE STRING "install prefix" FORCE)
+		endif()
 	else()
-		execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_SOURCE_DIR}/build)
-		set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR}/build
-		CACHE STRING "install prefix" FORCE)
+		set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE STRING
+			"Prefix for installation of sub-packages (note: required during build!)" FORCE)
 	endif()
 endif()
 message(STATUS CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
Disable the logic that tries to force the `CMAKE_INSTALL_PREFIX` when doing a non-pods build. This logic is a little flaky anyway, and shouldn't be used in a "traditional CMake" build.

Fixes #2093.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2099)
<!-- Reviewable:end -->
