### PR TITLE
Allow Quadrotor example to build on 64 bit Windows

### DIFF
--- a/drake/examples/Quadrotor/CMakeLists.txt
+++ b/drake/examples/Quadrotor/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Currently has alignment problems on 32 bit Windows.
+# Currently has alignment problems on 32 bit Windows apparently
+# due to a bug in Eigen; see issue #2106 and PR #2107.
 if (LCM_FOUND AND NOT (WIN32 AND (CMAKE_SIZEOF_VOID_P EQUAL 4)))
   add_executable(runQuadrotorDynamics runDynamics.cpp)
   target_link_libraries(runQuadrotorDynamics drakeRBSystem drakeLCMSystem)

--- a/drake/examples/Quadrotor/CMakeLists.txt
+++ b/drake/examples/Quadrotor/CMakeLists.txt
@@ -1,5 +1,5 @@
-
-if (LCM_FOUND AND NOT WIN32)
+# Currently has alignment problems on 32 bit Windows.
+if (LCM_FOUND AND NOT (WIN32 AND (CMAKE_SIZEOF_VOID_P EQUAL 4)))
   add_executable(runQuadrotorDynamics runDynamics.cpp)
   target_link_libraries(runQuadrotorDynamics drakeRBSystem drakeLCMSystem)
   add_dependencies(runQuadrotorDynamics drake_lcmtypes lcmtype_agg_hpp)

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -403,7 +403,7 @@ class DRAKERBSYSTEM_EXPORT RigidBodySpringDamper
  * @brief Represents generalized vector-valued noise
  */
 template <typename ScalarType, int Dimension, typename Derived>
-class DRAKERBSYSTEM_EXPORT NoiseModel {
+class NoiseModel {
  public:
   virtual Eigen::Matrix<ScalarType, Dimension, 1> generateNoise(
       Eigen::MatrixBase<Derived> const& input) = 0;
@@ -414,7 +414,7 @@ class DRAKERBSYSTEM_EXPORT NoiseModel {
  * distribution is parameterized by a Gaussian
  */
 template <typename ScalarType, int Dimension, typename Derived>
-class DRAKERBSYSTEM_EXPORT AdditiveGaussianNoiseModel
+class AdditiveGaussianNoiseModel
     : public NoiseModel<ScalarType, Dimension, Derived> {
  public:
   AdditiveGaussianNoiseModel(double mean, double std_dev)


### PR DESCRIPTION
The Quadrotor example was excluded from Windows builds. This PR (which replaces #1849) fixes a bug in the noise model class declarations that was causing a link failure, and enables the example when building 64 bit Windows. A [problem with Eigen's `result_of` struct](http://eigen.tuxfamily.org/bz/show_bug.cgi?id=96) that is allegedly fixed in Eigen 3.3 prevents 32 bit builds at the moment. 

I filed issue #2106 as a reminder to retry this when we have Eigen 3.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2107)
<!-- Reviewable:end -->
