### PR TITLE
Fix an issue in SnoptSolver where linear equality constraints weren't working with non-square constraint matrices.

### DIFF
--- a/drake/solvers/SnoptSolver.cpp
+++ b/drake/solvers/SnoptSolver.cpp
@@ -362,7 +362,7 @@ bool Drake::SnoptSolver::Solve(
                  A_constraint, var_index + k);
              it; ++it) {
           tripletList.push_back(
-              T(linear_constraint_index + it.col(), v.index() + k, it.value()));
+              T(linear_constraint_index + it.row(), v.index() + k, it.value()));
         }
       }
       var_index += v.size();

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -151,6 +151,21 @@ TEST(testOptimizationProblem, trivialLeastSquares) {
     });
 }
 
+TEST(testOptimizationProblem, trivalLinearEquality) {
+  OptimizationProblem prog;
+
+  auto vars = prog.AddContinuousVariables(2);
+
+  // Use a non-square matrix to catch row/column mistakes in the solvers.
+  prog.AddLinearEqualityConstraint(
+      Vector2d(0, 1).transpose(), Vector1d::Constant(1));
+  prog.SetInitialGuess(vars, Vector2d(2, 2));
+  RunNonlinearProgram(prog, [&]() {
+      EXPECT_DOUBLE_EQ(vars.value()(0), 2);
+      EXPECT_DOUBLE_EQ(vars.value()(1), 1);
+    });
+}
+
 // This test comes from Section 2.2 of "Handbook of Test Problems in
 // Local and Global Optimization"
 class TestProblem1Objective {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2117)
<!-- Reviewable:end -->
