### PR TITLE
Improve Doxygen C++ configuration

### DIFF
--- a/drake/doc/Doxyfile_CXX.in
+++ b/drake/doc/Doxyfile_CXX.in
@@ -28,8 +28,8 @@ ABBREVIATE_BRIEF       = a \
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = YES
-STRIP_FROM_PATH        =
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_PATH        = "@drake_SOURCE_DIR@/.."
+STRIP_FROM_INC_PATH    = "@drake_SOURCE_DIR@/.."
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
 QT_AUTOBRIEF           = NO
@@ -112,7 +112,7 @@ WARN_LOGFILE           = "@CMAKE_CURRENT_BINARY_DIR@/doxygen_cxx.log"
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = "@CMAKE_SOURCE_DIR@"
+INPUT                  = "@drake_SOURCE_DIR@"
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \
@@ -125,9 +125,9 @@ FILE_PATTERNS          = *.c \
                          *.hpp \
                          *.h++
 RECURSIVE              = YES
-EXCLUDE                = "@CMAKE_SOURCE_DIR@/examples" \
-                         "@CMAKE_SOURCE_DIR@/pod-build" \
-                         "@CMAKE_SOURCE_DIR@/thirdParty"
+EXCLUDE                = "@drake_SOURCE_DIR@/examples" \
+                         "@drake_SOURCE_DIR@/pod-build" \
+                         "@drake_SOURCE_DIR@/thirdParty"
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       =
 EXCLUDE_SYMBOLS        =

--- a/drake/doc/Doxyfile_CXX.in
+++ b/drake/doc/Doxyfile_CXX.in
@@ -287,7 +287,7 @@ EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           =
 INCLUDE_FILE_PATTERNS  =
-PREDEFINED             =
+PREDEFINED             = DRAKE_DOXYGEN_CXX
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------


### PR DESCRIPTION
Fix generated documentation to provide the proper `#include <drake/...>` path to Drake header files.

Also provide a way for C++ code to detect when it is preprocessed by Doxygen so that it can adapt accordingly.

See individual commit messages for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2197)
<!-- Reviewable:end -->
