### PR TITLE
Remove timespan and isTimeValid from Inverse Kinematics

### DIFF
--- a/drake/solvers/test/testMultipleTaskSpaceRRTStar.m
+++ b/drake/solvers/test/testMultipleTaskSpaceRRTStar.m
@@ -80,16 +80,16 @@ kinsol = r.doKinematics(state);
 
 footPose = r.forwardKin(kinsol,l_foot, [0; 0; 0], 2);
 leftFootPosConstraint = WorldPositionConstraint(r, l_foot, [0; 0; 0], footPose(1:3), footPose(1:3));
-leftFootQuatConstraint = WorldQuatConstraint(r, l_foot, footPose(4:7), 0.0, [0.0, 1.0]);
+leftFootQuatConstraint = WorldQuatConstraint(r, l_foot, footPose(4:7), 0.0);
 
 footPose = r.forwardKin(kinsol,r_foot, [0; 0; 0], 2);
 rightFootPosConstraint = WorldPositionConstraint(r, r_foot, [0; 0; 0], footPose(1:3), footPose(1:3));
-rightFootQuatConstraint = WorldQuatConstraint(r, r_foot, footPose(4:7), 0.0, [0.0, 1.0]);
+rightFootQuatConstraint = WorldQuatConstraint(r, r_foot, footPose(4:7), 0.0);
 
 %Quasi tatic constraint
 l_foot_pts = r.getBody(l_foot).getTerrainContactPoints();
 r_foot_pts = r.getBody(r_foot).getTerrainContactPoints();
-quasiStaticConstraint = QuasiStaticConstraint(r, [-inf, inf], 1);
+quasiStaticConstraint = QuasiStaticConstraint(r, 1);
 quasiStaticConstraint = quasiStaticConstraint.setShrinkFactor(0.5);
 quasiStaticConstraint = quasiStaticConstraint.setActive(true);
 quasiStaticConstraint = quasiStaticConstraint.addContact(l_foot, l_foot_pts);
@@ -105,7 +105,7 @@ startPoseConstraints = {leftFootPosConstraint, leftFootQuatConstraint, rightFoot
 [q_start, info, infeasible_constraint] = inverseKin(r, ik_seed_pose, ik_nominal_pose, startPoseConstraints{:}, ikoptions);
 if options.visualize
   v.draw(0,q_start);
-  
+
 end
 
 %Set end pose constraints and compute end configuration

--- a/drake/solvers/test/testTaskSpaceRRT.m
+++ b/drake/solvers/test/testTaskSpaceRRT.m
@@ -56,7 +56,7 @@ warning(w);
 xyz_quat_start = [0.5969; -0.1587; 0.85; -0.584; -0.457; 0.662; 0.112];
 
 % IK constraints
-qsc_constraint_0 = QuasiStaticConstraint(r, [-inf, inf], 1);
+qsc_constraint_0 = QuasiStaticConstraint(r, 1);
 qsc_constraint_0 = qsc_constraint_0.setShrinkFactor(0.5);
 qsc_constraint_0 = qsc_constraint_0.setActive(true);
 qsc_constraint_0 = qsc_constraint_0.addContact(l_foot, l_foot_pts);
@@ -67,10 +67,10 @@ ref_frame = [0.99999962214379723, 3.8873668451910772e-05, 0.00086844752325226373
 lower_bounds = [0.0; 0.0; 0.0] + [0.0; 0.0; 0.0];
 upper_bounds = [0.0; 0.0; 0.0] + [0.0; 0.0; 0.0];
 ref_frame = inv(ref_frame);
-position_constraint_1 = WorldPositionConstraint(r, l_foot, ref_frame(1:3,:)*[point_in_link_frame;1], lower_bounds, upper_bounds, [0.0, 1.0]);
+position_constraint_1 = WorldPositionConstraint(r, l_foot, ref_frame(1:3,:)*[point_in_link_frame;1], lower_bounds, upper_bounds);
 
 
-quat_constraint_2 = WorldQuatConstraint(r, l_foot, [0.99999680768841015; -0.0024891132733300568; 0.00043417407699420605; -2.0517608182535892e-05], 0.0, [0.0, 1.0]);
+quat_constraint_2 = WorldQuatConstraint(r, l_foot, [0.99999680768841015; -0.0024891132733300568; 0.00043417407699420605; -2.0517608182535892e-05], 0.0);
 
 
 point_in_link_frame = [0.0; 0.0; 0.0];
@@ -78,31 +78,31 @@ ref_frame = [0.99999972333813658, -3.8603987442147522e-05, 0.0007428548865743092
 lower_bounds = [0.0; 0.0; 0.0] + [0.0; 0.0; 0.0];
 upper_bounds = [0.0; 0.0; 0.0] + [0.0; 0.0; 0.0];
 ref_frame = inv(ref_frame);
-position_constraint_3 = WorldPositionConstraint(r, r_foot, ref_frame(1:3,:)*[point_in_link_frame;1], lower_bounds, upper_bounds, [0.0, 1.0]);
+position_constraint_3 = WorldPositionConstraint(r, r_foot, ref_frame(1:3,:)*[point_in_link_frame;1], lower_bounds, upper_bounds);
 
 
-quat_constraint_4 = WorldQuatConstraint(r, r_foot, [0.99999684531339206; 0.0024841562616134435; 0.00037137837375452614; 2.0224619435999976e-05], 0.0, [0.0, 1.0]);
+quat_constraint_4 = WorldQuatConstraint(r, r_foot, [0.99999684531339206; 0.0024841562616134435; 0.00037137837375452614; 2.0224619435999976e-05], 0.0);
 
-posture_constraint_5 = PostureConstraint(r, [-inf, inf]);
+posture_constraint_5 = PostureConstraint(r);
 joint_inds = [joints.back_bkx; joints.back_bky; joints.back_bkz];
 joints_lower_limit = q_zero(joint_inds) + [-0.08726646259971647; -0.08726646259971647; -inf];
 joints_upper_limit = q_zero(joint_inds) + [0.08726646259971647; 0.08726646259971647; inf];
 posture_constraint_5 = posture_constraint_5.setJointLimits(joint_inds, joints_lower_limit, joints_upper_limit);
 
-posture_constraint_6 = PostureConstraint(r, [-inf, inf]);
+posture_constraint_6 = PostureConstraint(r);
 joint_inds = [joints.base_x; joints.base_y; joints.base_roll; joints.base_pitch; joints.base_yaw];
 joints_lower_limit = q_nom(joint_inds) + [0.0; 0.0; 0.0; 0.0; 0.0];
 joints_upper_limit = q_nom(joint_inds) + [0.0; 0.0; 0.0; 0.0; 0.0];
 posture_constraint_6 = posture_constraint_6.setJointLimits(joint_inds, joints_lower_limit, joints_upper_limit);
 
 % fixed right arm
-posture_constraint_7 = PostureConstraint(r, [-inf, inf]);
+posture_constraint_7 = PostureConstraint(r);
 joint_inds = [joints.r_arm_shz; joints.r_arm_shx; joints.r_arm_ely; joints.r_arm_elx; joints.r_arm_uwy; joints.r_arm_mwx; joints.neck_ay];
 joints_lower_limit = q_nom(joint_inds);
 joints_upper_limit = q_nom(joint_inds);
 posture_constraint_7 = posture_constraint_7.setJointLimits(joint_inds, joints_lower_limit, joints_upper_limit);
 
-posture_constraint_8 = PostureConstraint(r, [-inf, inf]);
+posture_constraint_8 = PostureConstraint(r);
 joint_inds = [joints.l_leg_kny;joints.r_leg_kny];
 joints_lower_limit = 30*pi/180*[1;1];
 joints_upper_limit = 120*pi/180*[1;1];
@@ -112,7 +112,7 @@ point_in_link_frame = [0; -0.24449999999999988; 0.011200000000000071];
 ref_frame = [0.10040853387866658, 0.30507204666777654, 0.94702121025152886, 0.19671872655867628; -0.070421541493923046, 0.95162340926777023, -0.29908810311880585, 1.0145817508809061; -0.9924509725008871, -0.036659695518642732, 0.11703475512224609, 0.9; 0.0, 0.0, 0.0, 1.0];
 lower_bounds = [0.0; 0.0; 0.0] + [-0; -0; -0];
 upper_bounds = [0.0; 0.0; 0.0] + [0.0; 0.0; 0.0];
-position_constraint_7 = WorldPositionInFrameConstraint(r, l_hand, point_in_link_frame, ref_frame, lower_bounds, upper_bounds, [1.0, 1.0]);
+position_constraint_7 = WorldPositionInFrameConstraint(r, l_hand, point_in_link_frame, ref_frame, lower_bounds, upper_bounds);
 %ref_frame = inv(ref_frame);
 %position_constraint_7 = WorldPositionConstraint(r, l_hand, ref_frame(1:3,:)*[point_in_link_frame;1], lower_bounds, upper_bounds, [1.0, 1.0]);
 
@@ -121,7 +121,7 @@ point_in_link_frame = [-0.35; -0.27; 0.011200000000000071];
 
 
 
-quat_constraint_8 = WorldQuatConstraint(r, l_hand, [0.1439; 0.6104; -0.0161; 0.7787], 10*pi/180, [1.0, 1.0]);
+quat_constraint_8 = WorldQuatConstraint(r, l_hand, [0.1439; 0.6104; -0.0161; 0.7787], 10*pi/180);
 
 l_hand_initial_quat_constraint = WorldQuatConstraint(r, l_hand, xyz_quat_start(4:7), 0*pi/180);
 
@@ -169,7 +169,7 @@ else
   v = [];
 end
 
-posture_constraint_6 = PostureConstraint(r, [-inf, inf]);
+posture_constraint_6 = PostureConstraint(r);
 joint_inds = [joints.base_x; joints.base_y; joints.base_roll; joints.base_pitch; joints.base_yaw];
 joints_lower_limit = q_start(joint_inds) + [0.0; 0.0; 0.0; 0.0; 0.0];
 joints_upper_limit = q_start(joint_inds) + [0.0; 0.0; 0.0; 0.0; 0.0];
@@ -192,9 +192,9 @@ if options.visualize
   v.draw(0,q_start);
 end
 
-position_constraint_7 = WorldPositionConstraint(r, l_hand, point_in_link_frame, xyz_quat_start(1:3), xyz_quat_start(1:3), [1.0, 1.0]);
+position_constraint_7 = WorldPositionConstraint(r, l_hand, point_in_link_frame, xyz_quat_start(1:3), xyz_quat_start(1:3));
 
-quat_constraint_8 = WorldQuatConstraint(r, l_hand, xyz_quat_start(4:7), 0, [1.0, 1.0]);
+quat_constraint_8 = WorldQuatConstraint(r, l_hand, xyz_quat_start(4:7), 0);
 
 active_constraints = [base_constraints,{position_constraint_7,quat_constraint_8}];
 
@@ -288,5 +288,3 @@ t_scaled = tf*(-real(acos(2*t_scaled/tf-1)+pi)/2);
 xtraj = PPTrajectory(pchip(t_scaled,[q_path(:,idx_unique); zeros(r.getNumVelocities(),numel(t_scaled))]));
 xtraj = xtraj.setOutputFrame(r.getStateFrame());
 end
-
-

--- a/drake/solvers/trajectoryOptimization/InverseKinematicsTrajectory.m
+++ b/drake/solvers/trajectoryOptimization/InverseKinematicsTrajectory.m
@@ -62,7 +62,7 @@ classdef InverseKinematicsTrajectory < NonlinearProgram
   properties(Access = private)
     bbcon_initial_state_id % The ID of the BoundingBoxConstraint on the initial state
   end
-  
+
   methods
     function obj = InverseKinematicsTrajectory(robot,t,q_nom_traj,fix_initial_state,x0,varargin)
       % obj =
@@ -133,21 +133,17 @@ classdef InverseKinematicsTrajectory < NonlinearProgram
         end
         if(isa(varargin{i},'SingleTimeKinematicConstraint'))
           for j = t_start:obj.nT
-            if(varargin{i}.isTimeValid(obj.t_knot(j)))
-              cnstr = varargin{i}.generateConstraint(obj.t_knot(j));
-              obj = obj.addKinematicConstraint(cnstr{1},j);
-            end
+            cnstr = varargin{i}.generateConstraint(obj.t_knot(j));
+            obj = obj.addKinematicConstraint(cnstr{1},j);
           end
         elseif(isa(varargin{i},'PostureConstraint'))
           for j = t_start:obj.nT
-            if(varargin{i}.isTimeValid(obj.t_knot(j)))
-              cnstr = varargin{i}.generateConstraint(obj.t_knot(j));
-              obj = obj.addBoundingBoxConstraint(cnstr{1},obj.q_idx(:,j));
-            end
+            cnstr = varargin{i}.generateConstraint(obj.t_knot(j));
+            obj = obj.addBoundingBoxConstraint(cnstr{1},obj.q_idx(:,j));
           end
         elseif(isa(varargin{i},'QuasiStaticConstraint'))
           for j = t_start:obj.nT
-            if(varargin{i}.isTimeValid(obj.t_knot(j)) && varargin{i}.active)
+            if(varargin{i}.active)
               if(~isempty(obj.qsc_weight_idx{j}))
                 error('Drake:InverseKinematicsTrajectory:currently only support at most one QuasiStaticConstraint at an individual time');
               end
@@ -165,10 +161,8 @@ classdef InverseKinematicsTrajectory < NonlinearProgram
           end
         elseif(isa(varargin{i},'SingleTimeLinearPostureConstraint'))
           for j = t_start:obj.nT
-            if(varargin{i}.isTimeValid(obj.t_knot(j)))
-              cnstr = varargin{i}.generateConstraint(obj.t_knot(j));
-              obj = obj.addLinearConstraint(cnstr{1},obj.q_idx(:,j));
-            end
+            cnstr = varargin{i}.generateConstraint(obj.t_knot(j));
+            obj = obj.addLinearConstraint(cnstr{1},obj.q_idx(:,j));
           end
         elseif(isa(varargin{i},'MultipleTimeKinematicConstraint'))
           valid_t_flag = varargin{i}.isTimeValid(obj.t_knot(t_start:end));

--- a/drake/systems/plants/@RigidBodyManipulator/inverseKinBackend.m
+++ b/drake/systems/plants/@RigidBodyManipulator/inverseKinBackend.m
@@ -462,8 +462,7 @@ if(mode == 2)
     mtlpc_nc(j) = mtlpc.getNumConstraint(t);
     [mtlpc_iAfun_j,mtlpc_jAvar_j,mtlpc_A_j] = mtlpc.geval(t);
     [mtlpc_lb_j,mtlpc_ub_j] = mtlpc.bounds(t);
-    mtlpc_valid_t_flag = mtlpc.isTimeValid(t);
-    if(ikoptions.fixInitialState && mtlpc_valid_t_flag(1))
+    if(ikoptions.fixInitialState)
       % Take out the entries in the sparsity matrix that corresponds to gradient with q0
       mtlpc_A_q0idx = mtlpc_jAvar_j<=nq;
       mtlpc_iAfun{j} = mtlpc_iAfun_j(~mtlpc_A_q0idx);
@@ -716,18 +715,16 @@ for i = 1:nT-1
     t_j = t_inbetween{i}(j)+t(i);
     kinsol_samples{inbetween_idx+i+j} = doKinematics(obj,q_inbetween(:,inbetween_idx+j),false,false);
     for k = 1:length(st_kc_cell)
-      if(st_kc_cell{k}.isTimeValid(t_j))
-        [c_k,dc_k] = st_kc_cell{k}.eval(t_j,kinsol_samples{inbetween_idx+i+j});
-        nc = st_kc_cell{k}.getNumConstraint(t_j);
-        f(nf_cum+(1:nc)) = c_k;
-        if(~fixInitialState)
-          G(nG_cum+(1:nc*nq*(num_qfree+num_qdotfree))) = reshape([dc_k*dqInbetweendqknot{i}(nq*(j-1)+(1:nq),:) dc_k*dqInbetweendqd0{i}(nq*(j-1)+(1:nq),:) dc_k*dqInbetweendqdf{i}(nq*(j-1)+(1:nq),:)],[],1);
-        else
-          G(nG_cum+(1:nc*nq*(num_qfree+num_qdotfree))) = reshape([dc_k*dqInbetweendqknot{i}(nq*(j-1)+(1:nq),nq+1:end) dc_k*dqInbetweendqdf{i}(nq*(j-1)+(1:nq),:)],[],1);
-        end
-        nf_cum = nf_cum+nc;
-        nG_cum = nG_cum+nc*nq*(num_qfree+num_qdotfree);
+      [c_k,dc_k] = st_kc_cell{k}.eval(t_j,kinsol_samples{inbetween_idx+i+j});
+      nc = st_kc_cell{k}.getNumConstraint(t_j);
+      f(nf_cum+(1:nc)) = c_k;
+      if(~fixInitialState)
+        G(nG_cum+(1:nc*nq*(num_qfree+num_qdotfree))) = reshape([dc_k*dqInbetweendqknot{i}(nq*(j-1)+(1:nq),:) dc_k*dqInbetweendqd0{i}(nq*(j-1)+(1:nq),:) dc_k*dqInbetweendqdf{i}(nq*(j-1)+(1:nq),:)],[],1);
+      else
+        G(nG_cum+(1:nc*nq*(num_qfree+num_qdotfree))) = reshape([dc_k*dqInbetweendqknot{i}(nq*(j-1)+(1:nq),nq+1:end) dc_k*dqInbetweendqdf{i}(nq*(j-1)+(1:nq),:)],[],1);
       end
+      nf_cum = nf_cum+nc;
+      nG_cum = nG_cum+nc*nq*(num_qfree+num_qdotfree);
     end
   end
   q_samples(:,inbetween_idx+i) = q(:,i);

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -243,7 +243,7 @@ class SingleTimeKinematicConstraintWrapper : public Constraint {
     kinsol.initialize(q);
     rigid_body_constraint->getRobotPointer()->doKinematics(kinsol);
     MatrixXd dy;
-    rigid_body_constraint->eval(nullptr, kinsol, y, dy);
+    rigid_body_constraint->eval(kinsol, y, dy);
   }
   virtual void eval(const Eigen::Ref<const TaylorVecXd>& tq,
                     TaylorVecXd& ty) const override {
@@ -251,7 +251,7 @@ class SingleTimeKinematicConstraintWrapper : public Constraint {
     rigid_body_constraint->getRobotPointer()->doKinematics(kinsol);
     VectorXd y;
     MatrixXd dy;
-    rigid_body_constraint->eval(nullptr, kinsol, y, dy);
+    rigid_body_constraint->eval(kinsol, y, dy);
     initializeAutoDiffGivenGradientMatrix(
         y, (dy * autoDiffToGradientMatrix(tq)).eval(), ty);
   }

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -282,21 +282,17 @@ Drake::getInitialState(const RigidBodySystem& sys) {
 
     Matrix<double, 7, 1> bTbp = Matrix<double, 7, 1>::Zero();
     bTbp(3) = 1.0;
-    Vector2d tspan;
-    tspan << -std::numeric_limits<double>::infinity(),
-        std::numeric_limits<double>::infinity();
     Vector3d zero = Vector3d::Zero();
     for (int i = 0; i < loops.size(); i++) {
       auto con1 = make_shared<RelativePositionConstraint>(
           sys.tree.get(), zero, zero, zero, loops[i].frameA->frame_index,
-          loops[i].frameB->frame_index, bTbp, tspan);
+          loops[i].frameB->frame_index, bTbp);
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con1wrapper(
           new SingleTimeKinematicConstraintWrapper(con1));
       prog.AddGenericConstraint(con1wrapper, {qvar});
       auto con2 = make_shared<RelativePositionConstraint>(
           sys.tree.get(), loops[i].axis, loops[i].axis, loops[i].axis,
-          loops[i].frameA->frame_index, loops[i].frameB->frame_index, bTbp,
-          tspan);
+          loops[i].frameA->frame_index, loops[i].frameB->frame_index, bTbp);
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(
           new SingleTimeKinematicConstraintWrapper(con2));
       prog.AddGenericConstraint(con2wrapper, {qvar});

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -231,10 +231,10 @@ class SingleTimeKinematicConstraintWrapper : public Constraint {
  public:
   SingleTimeKinematicConstraintWrapper(
       const shared_ptr<SingleTimeKinematicConstraint>& rigid_body_constraint)
-      : Constraint(rigid_body_constraint->getNumConstraint(nullptr)),
+      : Constraint(rigid_body_constraint->getNumConstraint()),
         rigid_body_constraint(rigid_body_constraint),
         kinsol(rigid_body_constraint->getRobotPointer()->bodies) {
-    rigid_body_constraint->bounds(nullptr, lower_bound_, upper_bound_);
+    rigid_body_constraint->bounds(lower_bound_, upper_bound_);
   }
   virtual ~SingleTimeKinematicConstraintWrapper() {}
 

--- a/drake/systems/plants/approximateIK.cpp
+++ b/drake/systems/plants/approximateIK.cpp
@@ -113,7 +113,7 @@ void approximateIK(RigidBodyTree* model, const MatrixBase<DerivedA>& q_seed,
     VectorXd c(nc);
     MatrixXd dc(nc, nq);
     kc_array[kc_idx]->bounds(lb, ub);
-    kc_array[kc_idx]->eval(nullptr, cache, c, dc);
+    kc_array[kc_idx]->eval(cache, c, dc);
     for (c_idx = 0; c_idx < nc; c_idx++) {
       VectorXd rowVec = dc.row(c_idx);
       double* Jrow = rowVec.data();

--- a/drake/systems/plants/approximateIK.cpp
+++ b/drake/systems/plants/approximateIK.cpp
@@ -37,7 +37,7 @@ void approximateIK(RigidBodyTree* model, const MatrixBase<DerivedA>& q_seed,
       VectorXd joint_min, joint_max;
       PostureConstraint* pc =
           static_cast<PostureConstraint*>(constraint_array[i]);
-      pc->bounds(nullptr, joint_min, joint_max);
+      pc->bounds(joint_min, joint_max);
       for (int j = 0; j < nq; j++) {
         joint_lb[j] = (joint_lb[j] < joint_min[j] ? joint_min[j] : joint_lb[j]);
         joint_ub[j] = (joint_ub[j] > joint_max[j] ? joint_max[j] : joint_ub[j]);
@@ -107,12 +107,12 @@ void approximateIK(RigidBodyTree* model, const MatrixBase<DerivedA>& q_seed,
   KinematicsCache<double> cache = model->doKinematics(q_seed);
   int kc_idx, c_idx;
   for (kc_idx = 0; kc_idx < num_kc; kc_idx++) {
-    int nc = kc_array[kc_idx]->getNumConstraint(nullptr);
+    int nc = kc_array[kc_idx]->getNumConstraint();
     VectorXd lb(nc);
     VectorXd ub(nc);
     VectorXd c(nc);
     MatrixXd dc(nc, nq);
-    kc_array[kc_idx]->bounds(nullptr, lb, ub);
+    kc_array[kc_idx]->bounds(lb, ub);
     kc_array[kc_idx]->eval(nullptr, cache, c, dc);
     for (c_idx = 0; c_idx < nc; c_idx++) {
       VectorXd rowVec = dc.row(c_idx);

--- a/drake/systems/plants/constraint/AllBodiesClosestDistanceConstraint.m
+++ b/drake/systems/plants/constraint/AllBodiesClosestDistanceConstraint.m
@@ -3,8 +3,6 @@ classdef AllBodiesClosestDistanceConstraint < SingleTimeKinematicConstraint
   % [lb,ub]
   % @param lb      -- a scalar, the lower bound of the distance
   % @param ub      -- a scalar, the upper bound of the distance
-  % @param tspan   -- a 1x2 vector, the time span of the constraint being
-  %                   active
   properties(SetAccess = protected)
     ub
     lb
@@ -32,16 +30,13 @@ classdef AllBodiesClosestDistanceConstraint < SingleTimeKinematicConstraint
     end
   end
   methods
-    function obj = AllBodiesClosestDistanceConstraint(robot,lb,ub,active_collision_options,tspan)
-      if(nargin < 5)
-        tspan = [-inf inf];
-      end
-      if nargin < 3 || isempty(active_collision_options) 
-        active_collision_options = struct(); 
+    function obj = AllBodiesClosestDistanceConstraint(robot,lb,ub,active_collision_options)
+      if nargin < 4 || isempty(active_collision_options)
+        active_collision_options = struct();
       end;
       sizecheck(lb,[1,1]);
       sizecheck(ub,[1,1]);
-      obj = obj@SingleTimeKinematicConstraint(robot,tspan);
+      obj = obj@SingleTimeKinematicConstraint(robot);
       obj = setNumConstraint(obj);
       assert(obj.num_constraint > 0, ...
         'Drake:AllBodiesClosestDistanceConstraint:noConstraints', ...
@@ -52,7 +47,7 @@ classdef AllBodiesClosestDistanceConstraint < SingleTimeKinematicConstraint
       obj.ub = repmat(ub,obj.num_constraint,1);
       obj.type = RigidBodyConstraint.AllBodiesClosestDistanceConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.AllBodiesClosestDistanceConstraintType,robot.getMexModelPtr,lb,ub,active_collision_options,tspan);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.AllBodiesClosestDistanceConstraintType,robot.getMexModelPtr,lb,ub,active_collision_options);
       end
     end
 
@@ -72,13 +67,8 @@ classdef AllBodiesClosestDistanceConstraint < SingleTimeKinematicConstraint
     end
 
     function [lb,ub] = bounds(obj,t)
-      if(obj.isTimeValid(t))
-        lb = obj.lb;
-        ub = obj.ub;
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = obj.lb;
+      ub = obj.ub;
     end
 
     function [constraintSatisfyFlag,dist,ptsA,ptsB,idxA,idxB] = checkConstraint(obj,q)
@@ -151,11 +141,7 @@ classdef AllBodiesClosestDistanceConstraint < SingleTimeKinematicConstraint
     end
 
     function name = name(obj,t)
-      if(obj.isTimeValid(t))
-        name = repmat({'Closest distance constraint for all non-adjacent bodies'},obj.getNumConstraint(t),1);
-      else
-        name = [];
-      end
+      name = repmat({'Closest distance constraint for all non-adjacent bodies'},obj.getNumConstraint(t),1);
     end
 
   end

--- a/drake/systems/plants/constraint/EulerConstraint.m
+++ b/drake/systems/plants/constraint/EulerConstraint.m
@@ -7,11 +7,11 @@ classdef EulerConstraint < SingleTimeKinematicConstraint
     null_constraint_rows
     avg_rpy
   end
-  
+
   methods(Abstract,Access = protected)
     [rpy,J] = evalrpy(obj,kinsol);
   end
-  
+
   methods(Access = protected)
     function [c,dc] = evalValidTime(obj,kinsol)
       [rpy,J] = evalrpy(obj,kinsol);
@@ -20,13 +20,10 @@ classdef EulerConstraint < SingleTimeKinematicConstraint
       dc = J(~obj.null_constraint_rows,:);
     end
   end
-  
+
   methods
-    function obj = EulerConstraint(robot,lb,ub,tspan)
-      if(nargin == 3)
-        tspan = [-inf, inf];
-      end
-      obj = obj@SingleTimeKinematicConstraint(robot,tspan);
+    function obj = EulerConstraint(robot,lb,ub)
+      obj = obj@SingleTimeKinematicConstraint(robot);
       typecheck(lb,'double');
       typecheck(ub,'double');
       sizecheck(lb,[3,1]);
@@ -44,15 +41,10 @@ classdef EulerConstraint < SingleTimeKinematicConstraint
       obj.avg_rpy = (obj.lb+obj.ub)/2;
       obj.num_constraint = sum(~obj.null_constraint_rows);
     end
-    
+
     function [lb,ub] = bounds(obj,t)
-      if(obj.isTimeValid(t))
-        lb = obj.lb;
-        ub = obj.ub;
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = obj.lb;
+      ub = obj.ub;
     end
   end
 end

--- a/drake/systems/plants/constraint/GazeConstraint.m
+++ b/drake/systems/plants/constraint/GazeConstraint.m
@@ -1,12 +1,12 @@
 classdef GazeConstraint < SingleTimeKinematicConstraint
   properties(SetAccess = protected)
-    axis % a 3x1 vector in the body frame, the gaze axis    
+    axis % a 3x1 vector in the body frame, the gaze axis
     conethreshold % the angle in radians, measures the angle intersected by actual gaze axis and the desired gaze axis, default is 0
   end
-  
+
   methods
-    function obj = GazeConstraint(robot,axis,conethreshold,tspan)
-      obj = obj@SingleTimeKinematicConstraint(robot,tspan);
+    function obj = GazeConstraint(robot,axis,conethreshold)
+      obj = obj@SingleTimeKinematicConstraint(robot);
       typecheck(axis,'double');
       sizecheck(axis,[3,1]);
       len_axis = norm(axis);
@@ -14,9 +14,6 @@ classdef GazeConstraint < SingleTimeKinematicConstraint
         error('Drake:GazeConstraint: axis must be a non zero vector');
       end
       obj.axis = axis/len_axis;
-      if(nargin == 3)
-        conethreshold = [];
-      end
       if(isempty(conethreshold))
         conethreshold = 0;
       end
@@ -26,6 +23,6 @@ classdef GazeConstraint < SingleTimeKinematicConstraint
       end
       obj.conethreshold = conethreshold;
     end
-    
+
   end
 end

--- a/drake/systems/plants/constraint/GazeDirConstraint.m
+++ b/drake/systems/plants/constraint/GazeDirConstraint.m
@@ -2,14 +2,11 @@ classdef GazeDirConstraint < GazeConstraint
   properties(SetAccess = protected)
     dir % a 3x1 vector in the world frame, the deried gaze direction
   end
-  
-  
+
+
   methods
-    function obj = GazeDirConstraint(robot,axis,dir,conethreshold,tspan)
-      if(nargin == 4)
-        tspan = [-inf inf];
-      end
-      obj = obj@GazeConstraint(robot,axis,conethreshold,tspan);
+    function obj = GazeDirConstraint(robot,axis,dir,conethreshold)
+      obj = obj@GazeConstraint(robot,axis,conethreshold);
       typecheck(dir,'double');
       sizecheck(dir,[3,1]);
       if(any(isinf(dir))||any(isnan(dir)))
@@ -22,17 +19,12 @@ classdef GazeDirConstraint < GazeConstraint
       obj.dir = dir/len_dir;
       obj.num_constraint = 1;
     end
-    
-    
+
+
     function [lb,ub] = bounds(obj,t)
-      if(obj.isTimeValid(t))
-        lb = cos(obj.conethreshold)-1;
-        ub = 0;
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = cos(obj.conethreshold)-1;
+      ub = 0;
     end
   end
-  
+
 end

--- a/drake/systems/plants/constraint/GazeOrientConstraint.m
+++ b/drake/systems/plants/constraint/GazeOrientConstraint.m
@@ -3,13 +3,13 @@ classdef GazeOrientConstraint < GazeConstraint
     threshold % the angle in radians, indicating how much the body can rotate along the axis, default is pi
     quat_des % a 4x1 vector, indicating the desired transformation from the body frame to the world frame
   end
-  
+
   methods(Abstract,Access = protected)
       [quat, dquat_dq] = evalOrientation(obj,kinsol);
   end
 
   methods(Access = protected)
-    function [c,dc] = evalValidTime(obj,kinsol)      
+    function [c,dc] = evalValidTime(obj,kinsol)
       [quat, dquat] = evalOrientation(obj,kinsol);
       [axis_err,daxis_err] = quatDiffAxisInvar(quat,obj.quat_des,obj.axis);
       daxis_err_dq = daxis_err(1:4)*dquat;
@@ -19,13 +19,10 @@ classdef GazeOrientConstraint < GazeConstraint
       dc = [daxis_err_dq;dq_diff_dq(1,:)];
     end
   end
-  
+
   methods
-    function obj = GazeOrientConstraint(robot,axis,quat_des,conethreshold,threshold,tspan)
-      if(nargin  == 5)
-        tspan = [-inf inf];
-      end
-      obj = obj@GazeConstraint(robot,axis,conethreshold,tspan);
+    function obj = GazeOrientConstraint(robot,axis,quat_des,conethreshold,threshold)
+      obj = obj@GazeConstraint(robot,axis,conethreshold);
       sizecheck(quat_des,[4,1]);
       if(any(isinf(quat_des)|isnan(quat_des)))
         error('Drake:GazeOrientConstraint:quat_des cannot have nan or inf entries');
@@ -46,15 +43,10 @@ classdef GazeOrientConstraint < GazeConstraint
       obj.threshold = threshold;
       obj.num_constraint = 2;
     end
-    
+
     function [lb,ub] = bounds(obj,t)
-      if(obj.isTimeValid(t))
-        lb = [cos(obj.conethreshold)-1;cos(obj.threshold/2)];
-        ub = [0;inf];
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = [cos(obj.conethreshold)-1;cos(obj.threshold/2)];
+      ub = [0;inf];
     end
   end
 end

--- a/drake/systems/plants/constraint/GazeTargetConstraint.m
+++ b/drake/systems/plants/constraint/GazeTargetConstraint.m
@@ -3,15 +3,12 @@ classdef GazeTargetConstraint < GazeConstraint
     target % a 3x1 vector, the target position in the world frame
     gaze_origin % a 3x1 vector, the origin of the gaze in the body frame
   end
-  
+
   methods
-    function obj = GazeTargetConstraint(robot,axis,target,gaze_origin,conethreshold,tspan)
-      if(nargin == 5)
-        tspan = [-inf inf];
-      end
+    function obj = GazeTargetConstraint(robot,axis,target,gaze_origin,conethreshold)
       % if conethreshold = [], then it means there is no
       % constraint on the conethreshold
-      obj = obj@GazeConstraint(robot,axis,conethreshold,tspan);
+      obj = obj@GazeConstraint(robot,axis,conethreshold);
       typecheck(target,'double');
       sizecheck(target,[3,1]);
       if(any(isinf(target))||any(isnan(target)))
@@ -26,15 +23,10 @@ classdef GazeTargetConstraint < GazeConstraint
       obj.gaze_origin = gaze_origin;
       obj.num_constraint = 1;
     end
-    
+
     function [lb,ub] = bounds(obj,t)
-      if(obj.isTimeValid(t))
-        lb = cos(obj.conethreshold)-1;
-        ub = 0;
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = cos(obj.conethreshold)-1;
+      ub = 0;
     end
   end
 end

--- a/drake/systems/plants/constraint/GravityCompensationTorqueConstraint.m
+++ b/drake/systems/plants/constraint/GravityCompensationTorqueConstraint.m
@@ -8,8 +8,8 @@ classdef GravityCompensationTorqueConstraint < SingleTimeKinematicConstraint
     ub
   end
   methods
-    function obj = GravityCompensationTorqueConstraint(robot, joint_indices, lb, ub, tspan)
-      % obj = GravityCompensationTorqueConstraint(robot, joint_indices, lb, ub, tspan)
+    function obj = GravityCompensationTorqueConstraint(robot, joint_indices, lb, ub)
+      % obj = GravityCompensationTorqueConstraint(robot, joint_indices, lb, ub)
       % @param robot          -- RigidBodyManipulator object
       % @param joint_indices  -- column vector containing the indices of the
       %                          joints to which the constraint will be applied
@@ -19,10 +19,8 @@ classdef GravityCompensationTorqueConstraint < SingleTimeKinematicConstraint
       % @param ub             -- Upper bound on the allowable torques. May be a
       %                          scalar, or a column vector with the same number
       %                          of elements as joint_indices
-      % @param tspan
 
-      if nargin < 5, tspan = [-Inf, Inf]; end
-      obj = obj@SingleTimeKinematicConstraint(robot, tspan);
+      obj = obj@SingleTimeKinematicConstraint(robot);
       obj.joint_indices = reshape(joint_indices, [], 1);
       if isscalar(lb)
         lb = repmat(lb, size(obj.joint_indices));
@@ -43,18 +41,13 @@ classdef GravityCompensationTorqueConstraint < SingleTimeKinematicConstraint
       obj.num_constraint = numel(obj.joint_indices);
       obj.type = RigidBodyConstraint.GravityCompensationTorqueConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.GravityCompensationTorqueConstraintType,robot.getMexModelPtr, obj.joint_indices, obj.lb, obj.ub, tspan);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.GravityCompensationTorqueConstraintType,robot.getMexModelPtr, obj.joint_indices, obj.lb, obj.ub);
       end
     end
 
     function [lb, ub] = bounds(obj, t)
-      if(obj.isTimeValid(t))
-        lb = obj.lb;
-        ub = obj.ub;
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = obj.lb;
+      ub = obj.ub;
     end
 
     function obj = updateRobot(obj,robot)
@@ -63,14 +56,10 @@ classdef GravityCompensationTorqueConstraint < SingleTimeKinematicConstraint
     end
 
     function name_str = name(obj, t)
-      if(obj.isTimeValid(t))
-        joint_names = obj.robot.getPositionFrame().getCoordinateNames();
-        name_str = cellStrCat({'Gravity compensation torque constraint on  '}, ...
-                               joint_names(obj.joint_indices), ...
-                              {sprintf(' at time %10.4f',t)})';
-      else
-        name_str = {};
-      end
+      joint_names = obj.robot.getPositionFrame().getCoordinateNames();
+      name_str = cellStrCat({'Gravity compensation torque constraint on  '}, ...
+                            joint_names(obj.joint_indices), ...
+                            {sprintf(' at time %10.4f',t)})';
     end
   end
   methods (Access = protected)

--- a/drake/systems/plants/constraint/MinDistanceConstraint.m
+++ b/drake/systems/plants/constraint/MinDistanceConstraint.m
@@ -1,10 +1,8 @@
 classdef MinDistanceConstraint < SingleTimeKinematicConstraint
   % Constrains the closest distance between all bodies to be greater
-  % than  min_distance. 
+  % than  min_distance.
   %
   % @param min_distance    -- a scalar, the lower bound of the distance
-  % @param tspan   -- a 1x2 vector, the time span of the constraint being
-  %                   active
   properties
     min_distance
     active_collision_options = struct('body_idx',{},'collision_groups',{});
@@ -31,19 +29,16 @@ classdef MinDistanceConstraint < SingleTimeKinematicConstraint
   end
 
   methods
-    function obj = MinDistanceConstraint(robot,min_distance,active_collision_options,tspan)
-      if(nargin < 4)
-        tspan = [-inf inf];
-      end
+    function obj = MinDistanceConstraint(robot,min_distance,active_collision_options)
       if nargin < 3, active_collision_options = struct(); end;
       sizecheck(min_distance,[1,1]);
       assert(min_distance>0);
       checkDependency('bullet');
-      obj = obj@SingleTimeKinematicConstraint(robot,tspan);
+      obj = obj@SingleTimeKinematicConstraint(robot);
       obj.type = RigidBodyConstraint.MinDistanceConstraintType;
       obj.min_distance = min_distance;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.MinDistanceConstraintType,robot.getMexModelPtr,min_distance,active_collision_options,tspan);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.MinDistanceConstraintType,robot.getMexModelPtr,min_distance,active_collision_options);
       end
       obj.num_constraint = 1;
       obj.active_collision_options = active_collision_options;
@@ -68,14 +63,14 @@ classdef MinDistanceConstraint < SingleTimeKinematicConstraint
       % element-wise to dist. This hinge loss is given by
       %
       % \f[
-      % c = 
+      % c =
       % \begin{cases}
       %   -de^{\frac{1}{d}}, & d <   0  \\
       %   0,                & d \ge 0.
       % \end{cases}
       % \f]
-      %           
-      
+      %
+
       idx_neg = find(dist < 0);
       cost = zeros(size(dist));
       dcost_ddist = zeros(numel(dist));
@@ -98,15 +93,11 @@ classdef MinDistanceConstraint < SingleTimeKinematicConstraint
       obj.active_collision_options.collision_groups = setdiff(obj.active_collision_options.collision_groups,collision_geometry_group_names);
 
       obj.mex_ptr.delete();
-      obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.MinDistanceConstraintType,obj.robot.getMexModelPtr,obj.min_distance,obj.active_collision_options,obj.tspan);
+      obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.MinDistanceConstraintType,obj.robot.getMexModelPtr,obj.min_distance,obj.active_collision_options);
     end
 
     function num = getNumConstraint(obj,t)
-      if obj.isTimeValid(t)
-        num = 1;
-      else
-        num = 0;
-      end
+      num = 1;
     end
 
     function obj = updateRobot(obj,robot)
@@ -115,13 +106,8 @@ classdef MinDistanceConstraint < SingleTimeKinematicConstraint
     end
 
     function [lb,ub] = bounds(obj,t)
-      if obj.isTimeValid(t)
-        lb = 0;
-        ub = 0;
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = 0;
+      ub = 0;
     end
 
     function name_str = name(obj,t)

--- a/drake/systems/plants/constraint/MultipleTimeKinematicConstraint.m
+++ b/drake/systems/plants/constraint/MultipleTimeKinematicConstraint.m
@@ -1,24 +1,17 @@
 classdef MultipleTimeKinematicConstraint < RigidBodyConstraint
   % A abstract class, that its eval function takes multiple time points as
   % the input, instead of being evluated at a single time.
-    
+
   methods
-    function obj = MultipleTimeKinematicConstraint(robot,tspan)
-      obj = obj@RigidBodyConstraint(RigidBodyConstraint.MultipleTimeKinematicConstraintCategory,robot,tspan);
+    function obj = MultipleTimeKinematicConstraint(robot)
+      obj = obj@RigidBodyConstraint(RigidBodyConstraint.MultipleTimeKinematicConstraintCategory,robot);
     end
-    
+
     function flag = isTimeValid(obj,t)
-      n_breaks = size(t,2);
-      if(n_breaks <=1)
-        error('Drake:WorldFixedPositionConstraint: t must have more than 1 entry');
-      end
-      flag = t>=obj.tspan(1)&t<=obj.tspan(end);
+      tspan = [-inf inf];
+      flag = t>=tspan(1)&t<=tspan(end);
     end
-    
-    function tspan = getTspan(obj)
-      tspan = obj.tspan;
-    end
-    
+
     function [c,dc] = eval(obj,t,kinsol_cell)
       valid_t_idx = obj.isTimeValid(t);
       valid_t = t(valid_t_idx);
@@ -37,14 +30,14 @@ classdef MultipleTimeKinematicConstraint < RigidBodyConstraint
         dc = [];
       end
     end
-    
+
     function obj = updateRobot(obj,robot)
       obj.robot = robot;
       if(robot.getMexModelPtr~=0 && exist('updatePtrRigidBodyConstraintmex','file'))
         obj.mex_ptr = updatePtrRigidBodyConstraintmex(obj.mex_ptr,'robot',robot.getMexModelPtr);
       end
     end
-    
+
     function cnstr = generateConstraint(obj,t,N)
       % generate a FunctionHandleConstraint for postures at all time t
       if isempty(t)
@@ -66,7 +59,7 @@ classdef MultipleTimeKinematicConstraint < RigidBodyConstraint
         t = t(:)';
         valid_t_idx = obj.isTimeValid(t);
         t_idx = (1:length(t));
-        valid_t_idx = t_idx(valid_t_idx);
+        valid_t_idx = t_idx
         num_valid_t = length(valid_t_idx);
         if(num_valid_t >= 2)
           [lb,ub] = obj.bounds(t);
@@ -84,21 +77,21 @@ classdef MultipleTimeKinematicConstraint < RigidBodyConstraint
         end
       end
     end
-    
+
     function joint_idx = kinematicPathJoints(obj)
       % return the indices of the joints used to evaluate the constraint. The default
       % value is (1:obj.robot.getNumPositions);
       joint_idx = (1:obj.robot.getNumPositions);
     end
   end
-  
+
   methods(Abstract)
     % N is the number of knot points considered by this constraint
     num = getNumConstraint(obj,N);
     [lb,ub] = bounds(obj,t,N)
     name_str = name(obj,t)
   end
-  
+
   methods(Abstract,Access = protected)
     [c,dc] = evalValidTime(obj,valid_kinsol_cell);
   end

--- a/drake/systems/plants/constraint/MultipleTimeLinearPostureConstraint.m
+++ b/drake/systems/plants/constraint/MultipleTimeLinearPostureConstraint.m
@@ -1,33 +1,24 @@
 classdef MultipleTimeLinearPostureConstraint < RigidBodyConstraint
   % A linear constraint on the robot posture for multiple times
-  
+
   methods
-    function obj = MultipleTimeLinearPostureConstraint(robot,tspan)
-      if(nargin<2)
-        tspan = [-inf inf];
-      end
-      obj = obj@RigidBodyConstraint(RigidBodyConstraint.MultipleTimeLinearPostureConstraintCategory,robot,tspan);
+    function obj = MultipleTimeLinearPostureConstraint(robot)
+      obj = obj@RigidBodyConstraint(RigidBodyConstraint.MultipleTimeLinearPostureConstraintCategory,robot);
     end
-    
+
     function flag = isTimeValid(obj,t)
-      diff_t = diff(t);
-      if(any(diff_t)<=0)
-        error('Drake:MultipleTimeLinearPostureConstraint: t must be in the ascending order');
-      end
-      n_breaks = size(t,2);
-      if(n_breaks<=1)
-        error('Drake:MultipleTimeLinearPostureConstraint: t must have more than one entry');
-      end
-      flag = t>=obj.tspan(1) & t<=obj.tspan(end);
+      % TODO(sam.creasey) Understand the callers of this function well enough to get rid of it.
+      tspan = [-inf inf];
+      flag = t>=tspan(1)&t<=tspan(end);
     end
-    
+
     function [c,dc] = eval(obj,t,q)
       c = obj.feval(t,q);
       [iAfun,jAvar,A] = geval(obj,t);
       num_cnst = obj.getNumConstraint(t);
       dc = sparse(iAfun,jAvar,A,num_cnst,numel(q));
     end
-    
+
     function cnstr = generateConstraint(obj,t)
       [iAfun,jAvar,A] = obj.geval(t);
       num_cnstr = obj.getNumConstraint(t);
@@ -38,7 +29,7 @@ classdef MultipleTimeLinearPostureConstraint < RigidBodyConstraint
       cnstr{1} = cnstr{1}.setName(name_str);
     end
   end
-  
+
   methods(Abstract)
     num = getNumConstraint(obj,t);
     c = feval(obj,t,q);

--- a/drake/systems/plants/constraint/PositionConstraint.m
+++ b/drake/systems/plants/constraint/PositionConstraint.m
@@ -11,15 +11,15 @@ classdef PositionConstraint < SingleTimeKinematicConstraint
     [pos,J] = evalPositions(obj,kinsol)
     cnst_names = evalNames(obj,t)
   end
-  
+
   methods(Access = protected)
     function [c,dc] = evalValidTime(obj,kinsol)
-      [pos,J] = evalPositions(obj,kinsol); 
+      [pos,J] = evalPositions(obj,kinsol);
       c = pos(~obj.null_constraint_rows);
       dc = J(~obj.null_constraint_rows,:);
     end
   end
-  
+
   methods(Access = protected)
     function obj = setConstraintBounds(obj, lb, ub)
       rows = size(lb,1);
@@ -42,13 +42,10 @@ classdef PositionConstraint < SingleTimeKinematicConstraint
       obj.num_constraint = sum(~obj.null_constraint_rows);
     end
   end
-  
+
   methods
-    function obj = PositionConstraint(robot,pts,lb,ub,tspan)
-      if(nargin == 4)
-        tspan = [-inf,inf];
-      end
-      obj = obj@SingleTimeKinematicConstraint(robot,tspan);
+    function obj = PositionConstraint(robot,pts,lb,ub)
+      obj = obj@SingleTimeKinematicConstraint(robot);
       if(size(pts,1)~=3)
         error('Incorrect size');
       end
@@ -56,25 +53,15 @@ classdef PositionConstraint < SingleTimeKinematicConstraint
       obj.n_pts = size(obj.pts,2);
       obj = setConstraintBounds(obj,lb,ub);
     end
-    
+
     function [lb,ub] = bounds(obj,t)
-      if(obj.isTimeValid(t))
-        lb = obj.lb;
-        ub = obj.ub;
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = obj.lb;
+      ub = obj.ub;
     end
 
     function name_str = name(obj,t)
-      if(obj.isTimeValid(t))
-        cnst_names = evalNames(obj,t);
-        name_str = cnst_names(~obj.null_constraint_rows);
-      else
-        name_str = [];
-      end
+      cnst_names = evalNames(obj,t);
+      name_str = cnst_names(~obj.null_constraint_rows);
     end
   end
 end
-

--- a/drake/systems/plants/constraint/PostureChangeConstraint.m
+++ b/drake/systems/plants/constraint/PostureChangeConstraint.m
@@ -1,17 +1,15 @@
 classdef PostureChangeConstraint < MultipleTimeLinearPostureConstraint
-  % This constrains that the change of joint i within time tspan must be within [lb,ub]
+  % This constrains that the change of joint i must be within [lb,ub]
   % @param robot
   % @param joint_idx             A nx1 vector, the index of the joints
   % @param lb_change             A nx1 vector, the lower bound of the change of joint angles
   % @param ub_change             A nx1 vector, the upper bound of the change of joint angles
-  % @param tspan                 A 1x2 vector, the time span. Optional argument. Default
-  %                              is [-inf inf]
   properties(SetAccess = protected)
     joint_ind
     lb_change
     ub_change
   end
-  
+
   methods(Access=protected)
     function obj = setJointChangeBounds(obj,joint_ind,lb_change,ub_change)
       if(any(~isnumeric(joint_ind)))
@@ -37,20 +35,17 @@ classdef PostureChangeConstraint < MultipleTimeLinearPostureConstraint
       obj.ub_change = ub_change;
     end
   end
-  
+
   methods
-    function obj = PostureChangeConstraint(robot,joint_ind,lb_change,ub_change,tspan)
-      if(nargin<5)
-        tspan = [-inf inf];
-      end
-      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.PostureChangeConstraintType,robot.getMexModelPtr,joint_ind,lb_change,ub_change,tspan);
-      obj = obj@MultipleTimeLinearPostureConstraint(robot,tspan);
+    function obj = PostureChangeConstraint(robot,joint_ind,lb_change,ub_change)
+      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.PostureChangeConstraintType,robot.getMexModelPtr,joint_ind,lb_change,ub_change);
+      obj = obj@MultipleTimeLinearPostureConstraint(robot);
       obj = obj.setJointChangeBounds(joint_ind,lb_change,ub_change);
       obj.type = RigidBodyConstraint.PostureChangeConstraintType;
       obj.mex_ptr = ptr;
     end
-    
-    
+
+
     function num = getNumConstraint(obj,t)
       valid_flag = obj.isTimeValid(t);
       num_valid_t = sum(valid_flag);
@@ -60,7 +55,7 @@ classdef PostureChangeConstraint < MultipleTimeLinearPostureConstraint
         num = 0;
       end
     end
-    
+
     function c = feval(obj,t,q)
       % c = [q(obj.joint_ind,2)-q(obj.joint_ind,1);
       % q(obj.joint_ind,3)-q(obj.joint_ind,1);...;q(obj.joint_ind,n)-q(obj.joint_ind,1)];
@@ -74,7 +69,7 @@ classdef PostureChangeConstraint < MultipleTimeLinearPostureConstraint
         c = [];
       end
     end
-    
+
     function [iAfun,jAvar,A] = geval(obj,t)
       % sparse(iAfun,jAvar,A,num_constraint,length(q)) is the gradient of the function feval w.r.t q
       valid_flag = obj.isTimeValid(t);
@@ -95,7 +90,7 @@ classdef PostureChangeConstraint < MultipleTimeLinearPostureConstraint
         A = [];
       end
     end
-    
+
     function [lb,ub] = bounds(obj,t)
       valid_flag = obj.isTimeValid(t);
       num_valid_t = sum(valid_flag);
@@ -107,7 +102,7 @@ classdef PostureChangeConstraint < MultipleTimeLinearPostureConstraint
         ub = [];
       end
     end
-    
+
     function name_str = name(obj,t)
       valid_flag = obj.isTimeValid(t);
       num_valid_t = sum(valid_flag);
@@ -124,6 +119,6 @@ classdef PostureChangeConstraint < MultipleTimeLinearPostureConstraint
         end
       end
     end
-    
+
   end
 end

--- a/drake/systems/plants/constraint/PostureConstraint.m
+++ b/drake/systems/plants/constraint/PostureConstraint.m
@@ -6,35 +6,20 @@ classdef PostureConstraint<RigidBodyConstraint
     joint_limit_min0;% The default lower bound of the  posture of the robot
     joint_limit_max0;% The default upper bound of the  posture of the robot
   end
-  
+
   methods
-    function obj = PostureConstraint(robot,tspan)
+    function obj = PostureConstraint(robot)
 		% @param robot                      -- A RigidBodyManipulator or a TimeSteppingRigidBodyManipulator object
-      if(nargin < 2)
-        tspan = [-inf inf];
-      end
-      obj = obj@RigidBodyConstraint(RigidBodyConstraint.PostureConstraintCategory,robot,tspan);
+      obj = obj@RigidBodyConstraint(RigidBodyConstraint.PostureConstraintCategory,robot);
 			[obj.joint_limit_min0,obj.joint_limit_max0] = robot.getJointLimits();
       obj.lb = obj.joint_limit_min0;
       obj.ub = obj.joint_limit_max0;
       obj.type = RigidBodyConstraint.PostureConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.PostureConstraintType,robot.getMexModelPtr,tspan);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.PostureConstraintType,robot.getMexModelPtr);
       end
     end
-    
-    function flag = isTimeValid(obj,t)
-      if(isempty(t))
-        flag = true;
-      else
-        if(t>=obj.tspan(1)&&t<=obj.tspan(end))
-          flag = true;
-        else
-          flag = false;
-        end
-      end
-    end
-    
+
     function obj = setJointLimits(obj,joint_ind,joint_min,joint_max)
 		  % @param joint_ind   A column vector. The indices of the joints whose joint limits are to be set
 			% @param joint_min   A column vector of the same size as joint_ind. The lower bound of the joints are max([robot.joint_limit_min(joint_ind) joint_min]),[],2);
@@ -60,26 +45,16 @@ classdef PostureConstraint<RigidBodyConstraint
         error('Either the joint_max is smaller than the robot default joint min, or the joint min is larger than the robot default joint max');
       end
     end
-    
+
     function [lb,ub] = bounds(obj,t)
-      if obj.isTimeValid(t)
-        lb = obj.lb;
-        ub = obj.ub;
-      else
-        lb = obj.joint_limit_min0;
-        ub = obj.joint_limit_max0;
-      end
+      lb = obj.lb;
+      ub = obj.ub;
     end
-    
+
     function cnstr = generateConstraint(obj,t)
       % generate a BoundingBoxConstraint on the robot posture if t is a valid time
       % or if no time is given
-      if nargin < 2, t = obj.tspan(1); end;
-      if(obj.isTimeValid(t))
-        cnstr = {BoundingBoxConstraint(obj.lb,obj.ub)};
-      else
-        cnstr = {};
-      end
+      cnstr = {BoundingBoxConstraint(obj.lb,obj.ub)};
     end
   end
 end

--- a/drake/systems/plants/constraint/QuatConstraint.m
+++ b/drake/systems/plants/constraint/QuatConstraint.m
@@ -1,14 +1,14 @@
 classdef QuatConstraint <SingleTimeKinematicConstraint
-  % Constrain the quaternion to satisfy the following conditions: 
+  % Constrain the quaternion to satisfy the following conditions:
   % 2*(quat'*quat_des)^2-1 in [cos(tol) 1]
   properties(SetAccess = protected)
     tol
   end
-  
+
   methods(Abstract,Access = protected)
     [orient_prod,dorient_prod] = evalOrientationProduct(obj,kinsol)
   end
-  
+
   methods(Access = protected)
     function [c,dc] = evalValidTime(obj,kinsol)
       [orient_prod, dorient_prod] = evalOrientationProduct(obj,kinsol);
@@ -16,10 +16,10 @@ classdef QuatConstraint <SingleTimeKinematicConstraint
       dc = 4*(orient_prod)*dorient_prod;
     end
   end
-  
+
   methods
-    function obj = QuatConstraint(robot,tol,tspan)
-      obj = obj@SingleTimeKinematicConstraint(robot,tspan);
+    function obj = QuatConstraint(robot,tol)
+      obj = obj@SingleTimeKinematicConstraint(robot);
       sizecheck(tol,[1,1]);
       if(tol<0||tol>pi)
         error('Drake:QuatConstraint:Tol must be within the range [0 pi]');
@@ -27,16 +27,11 @@ classdef QuatConstraint <SingleTimeKinematicConstraint
       obj.tol = tol;
       obj.num_constraint = 1;
     end
-    
+
     function [lb,ub] = bounds(obj,t)
-      if(obj.isTimeValid(t))
-        lb = cos(obj.tol);
-        ub = 1;
-      else
-        lb = [];
-        ub = [];
-      end
+      lb = cos(obj.tol);
+      ub = 1;
     end
-    
+
   end
 end

--- a/drake/systems/plants/constraint/RelativeGazeDirConstraint.m
+++ b/drake/systems/plants/constraint/RelativeGazeDirConstraint.m
@@ -8,13 +8,11 @@ classdef RelativeGazeDirConstraint < GazeDirConstraint
   % @param dir                    -- A 3x1 unit vector, in the body_b frame
   % @param conethreshold          -- A double scalar, the angle of the gaze cone, default
   %                                  is 0
-  % @param tspan                  -- A 1x2 vector, the time span of the constraint,
-  %                                  default is [-inf inf]
   properties(SetAccess = protected)
     body_a = struct('idx',[],'name','');
     body_b = struct('idx',[],'name','');
   end
-  
+
   methods(Access = protected)
     function [c,dc] = evalValidTime(obj,kinsol)
       [axis_pos,daxis_pos] = forwardKin(obj.robot,kinsol,obj.body_a.idx,[zeros(3,1) obj.axis],0);
@@ -27,21 +25,18 @@ classdef RelativeGazeDirConstraint < GazeDirConstraint
       dc = dir_world'*daxis_world + axis_world'*ddir_world;
     end
   end
-  
-  methods  
+
+  methods
     function obj = RelativeGazeDirConstraint(robot,body_a, ...
                                              body_b,axis,dir, ...
-                                             conethreshold,tspan)
-      if(nargin < 7)
-        tspan = [-inf inf];
-      end
+                                             conethreshold)
       if(nargin<6)
         conethreshold = 0;
       end
       body_a_idx = robot.parseBodyOrFrameID(body_a);
       body_b_idx = robot.parseBodyOrFrameID(body_b);
-      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.RelativeGazeDirConstraintType,robot.getMexModelPtr,body_a_idx,body_b_idx,axis,dir,conethreshold,tspan);
-      obj = obj@GazeDirConstraint(robot,axis,dir,conethreshold,tspan);
+      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.RelativeGazeDirConstraintType,robot.getMexModelPtr,body_a_idx,body_b_idx,axis,dir,conethreshold);
+      obj = obj@GazeDirConstraint(robot,axis,dir,conethreshold);
       obj.body_a.idx = body_a_idx;
       obj.body_a.name = getBodyOrFrameName(obj.robot, obj.body_a.idx);
       obj.body_b.idx = body_b_idx;
@@ -51,12 +46,8 @@ classdef RelativeGazeDirConstraint < GazeDirConstraint
     end
 
     function name_str = name(obj,t)
-      if(obj.isTimeValid(t))
-        name_str = {sprintf('%s relative to %s conic gaze constraint at time %10.4f', ...
-                        obj.body_a.name,obj.body_b.name,t)};
-      else
-        name_str = [];
-      end
+      name_str = {sprintf('%s relative to %s conic gaze constraint at time %10.4f', ...
+                          obj.body_a.name,obj.body_b.name,t)};
     end
 
     function drawConstraint(obj,q,lcmgl)
@@ -77,7 +68,7 @@ classdef RelativeGazeDirConstraint < GazeDirConstraint
       lcmgl.glTranslated(wTb(1,4),wTb(2,4),wTb(3,4));
       lcmgl.glRotated(ang_ax_b(4)*180/pi,ang_ax_b(1),ang_ax_b(2),ang_ax_b(3));
       lcmgl.glDrawAxes();
-      
+
       % Rotate and translate back to world frame
       lcmgl.glRotated(-ang_ax_b(4)*180/pi,ang_ax_b(1),ang_ax_b(2),ang_ax_b(3));
       lcmgl.glTranslated(-wTb(1,4),-wTb(2,4),-wTb(3,4));
@@ -115,7 +106,7 @@ classdef RelativeGazeDirConstraint < GazeDirConstraint
 
       lcmgl.switchBuffers();
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(obj.body_a.idx,obj.body_b.idx);
       joint_idx = vertcat(obj.robot.body(joint_path).position_num)';

--- a/drake/systems/plants/constraint/RelativeGazeOrientConstraint.m
+++ b/drake/systems/plants/constraint/RelativeGazeOrientConstraint.m
@@ -3,7 +3,7 @@ classdef RelativeGazeOrientConstraint < GazeOrientConstraint
     body_a = struct('idx',[],'name','');
     body_b = struct('idx',[],'name','');
   end
-  
+
   methods(Access = protected)
     function [quat, dquat_dq] = evalOrientation(obj,kinsol)
       [x_a,J_a] = forwardKin(obj.robot,kinsol,obj.body_a.idx,[0;0;0],2);
@@ -16,12 +16,12 @@ classdef RelativeGazeOrientConstraint < GazeOrientConstraint
       dquat_dq = dquat*[dquat_b;dquat_a];
     end
   end
-  
+
   methods
-    function obj = RelativeGazeOrientConstraint(robot,tspan,body_a, ...
+    function obj = RelativeGazeOrientConstraint(robot,body_a, ...
         body_b,axis,quat_des, ...
         threshold,conethreshold)
-      obj = obj@GazeOrientConstraint(robot,tspan,axis,quat_des,threshold, ...
+      obj = obj@GazeOrientConstraint(robot,axis,quat_des,threshold, ...
         conethreshold);
       body_a_idx = robot.parseBodyOrFrameID(body_a);
       body_b_idx = robot.parseBodyOrFrameID(body_b);
@@ -31,7 +31,7 @@ classdef RelativeGazeOrientConstraint < GazeOrientConstraint
       obj.body_b.name = getBodyOrFrameName(obj.robot, obj.body_b.idx);
     end
 
-    
+
 
     function drawConstraint(obj,q,lcmgl)
       norm_axis = obj.axis/norm(obj.axis);
@@ -140,14 +140,10 @@ classdef RelativeGazeOrientConstraint < GazeOrientConstraint
     end
 
     function name_str = name(obj,t)
-      if(t>=obj.tspan(1)&&t<=obj.tspan(end))||isempty(t)
-        name_str = {sprintf('%s relative to %s conic gaze constraint at time %10.4f', ...
-                        obj.body_a.name,obj.body_b.name,t);...
-                sprintf('%s relative to %s conic gaze constraint at time %10.4f', ...
-                        obj.body_a.name,obj.body_b.name,t)};
-      else
-        name_str = [];
-      end
+      name_str = {sprintf('%s relative to %s conic gaze constraint at time %10.4f', ...
+                          obj.body_a.name,obj.body_b.name,t);...
+                  sprintf('%s relative to %s conic gaze constraint at time %10.4f', ...
+                          obj.body_a.name,obj.body_b.name,t)};
     end
 
   end

--- a/drake/systems/plants/constraint/RelativeGazeTargetConstraint.m
+++ b/drake/systems/plants/constraint/RelativeGazeTargetConstraint.m
@@ -8,13 +8,11 @@ classdef RelativeGazeTargetConstraint < GazeTargetConstraint
   % @param gaze_origin            -- A 3x1 vector, the gaze origin on body_a frame
   % @param conethreshold          -- A double scalar, the angle of the gaze cone, default
   %                                  is 0
-  % @param tspan                  -- A 1x2 vector, the time span of the constraint,
-  %                                  default is [-inf inf]
   properties(SetAccess = protected)
     body_a = struct('idx',[],'name','');
     body_b = struct('idx',[],'name','');
   end
-  
+
   methods(Access = protected)
     function [c,dc] = evalValidTime(obj,kinsol)
       [pos_a,dpos_a_dq] = obj.robot.forwardKin(kinsol,obj.body_a.idx,[0;0;0],2);
@@ -32,20 +30,17 @@ classdef RelativeGazeTargetConstraint < GazeTargetConstraint
       dc = u_gv'*du_ga_dq + u_ga'*du_gv_dq;
     end
   end
-  
+
   methods
     function obj = RelativeGazeTargetConstraint(robot,body_a, ...
-        body_b,axis,target,gaze_origin,conethreshold,tspan)
-      if(nargin < 8)
-        tspan = [-inf inf];
-      end
+        body_b,axis,target,gaze_origin,conethreshold)
       if(nargin<7)
         conethreshold = 0;
       end
       body_a_idx = robot.parseBodyOrFrameID(body_a);
       body_b_idx = robot.parseBodyOrFrameID(body_b);
-      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.RelativeGazeTargetConstraintType,robot.getMexModelPtr,body_a_idx,body_b_idx,axis,target,gaze_origin,conethreshold,tspan);
-      obj = obj@GazeTargetConstraint(robot,axis,target,gaze_origin,conethreshold,tspan);
+      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.RelativeGazeTargetConstraintType,robot.getMexModelPtr,body_a_idx,body_b_idx,axis,target,gaze_origin,conethreshold);
+      obj = obj@GazeTargetConstraint(robot,axis,target,gaze_origin,conethreshold);
       obj.body_a.idx = body_a_idx;
       obj.body_a.name = getBodyOrFrameName(obj.robot, obj.body_a.idx);
       obj.body_b.idx = body_b_idx;
@@ -53,16 +48,11 @@ classdef RelativeGazeTargetConstraint < GazeTargetConstraint
       obj.type = RigidBodyConstraint.RelativeGazeTargetConstraintType;
       obj.mex_ptr = ptr;
     end
-    
-    function name_str = name(obj,t)
-      if(obj.isTimeValid(t))
-        name_str = {sprintf('%s relative to %s conic gaze constraint at time %10.4f', ...
-                        obj.body_a.name,obj.body_b.name,t)};
-      else
-        name_str = [];
-      end
-    end
 
+    function name_str = name(obj,t)
+      name_str = {sprintf('%s relative to %s conic gaze constraint at time %10.4f', ...
+                          obj.body_a.name,obj.body_b.name,t)};
+    end
 
     function drawConstraint(obj,q,lcmgl)
       norm_axis = obj.axis/norm(obj.axis);
@@ -116,7 +106,7 @@ classdef RelativeGazeTargetConstraint < GazeTargetConstraint
 
       lcmgl.switchBuffers();
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(obj.body_a.idx,obj.body_b.idx);
       joint_idx = vertcat(obj.robot.body(joint_path).position_num)';

--- a/drake/systems/plants/constraint/RelativePositionConstraint.m
+++ b/drake/systems/plants/constraint/RelativePositionConstraint.m
@@ -1,12 +1,12 @@
 classdef RelativePositionConstraint < PositionConstraint
   % Constraining points in body A to be within a bounding box in B' frame on body B
-  
+
   properties(SetAccess = protected)
     body_a = struct('idx',[],'name','');
     body_b = struct('idx',[],'name','');
     bTbp
   end
-  
+
   properties(SetAccess = protected,GetAccess = protected)
     bpTb
   end
@@ -38,7 +38,7 @@ classdef RelativePositionConstraint < PositionConstraint
         J(3*(i-1)+(1:3),:) = dbp_bodyA_pos1+dbpTw_trans;
       end
     end
-    
+
     function cnst_names = evalNames(obj,t)
       cnst_names = cell(3*obj.n_pts,1);
       if(isempty(t))
@@ -53,10 +53,10 @@ classdef RelativePositionConstraint < PositionConstraint
       end
     end
   end
-  
+
   methods
 function obj = RelativePositionConstraint(robot,pts,lb,ub, ...
-                      body_a,body_b,bTbp,tspan)
+                      body_a,body_b,bTbp)
     % @param robot
       % @param body_a         -- Either:
       %                             * An integer body index or frame id OR
@@ -78,13 +78,10 @@ function obj = RelativePositionConstraint(robot,pts,lb,ub, ...
       if(nargin < 7)
         bTbp = [0;0;0;1;0;0;0];
       end
-      if(nargin < 8)
-        tspan = [-inf,inf];
-      end
       body_a_idx = robot.parseBodyOrFrameID(body_a);
       body_b_idx = robot.parseBodyOrFrameID(body_b);
       ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.RelativePositionConstraintType,...
-        robot.getMexModelPtr,pts,lb,ub,body_a_idx,body_b_idx,bTbp,tspan);
+					       robot.getMexModelPtr,pts,lb,ub,body_a_idx,body_b_idx,bTbp);
       typecheck(bTbp,'double');
       sizecheck(bTbp,[7,1]);
       quat_norm = norm(bTbp(4:7));
@@ -93,7 +90,7 @@ function obj = RelativePositionConstraint(robot,pts,lb,ub, ...
       end
       bTbp(4:7) = bTbp(4:7)/quat_norm;
 
-      obj = obj@PositionConstraint(robot, pts, lb, ub,tspan);
+      obj = obj@PositionConstraint(robot, pts, lb, ub);
       obj.body_a.idx = body_a_idx;
       obj.body_a.name = getBodyOrFrameName(obj.robot, obj.body_a.idx);
       obj.body_b.idx = body_b_idx;
@@ -123,7 +120,7 @@ function obj = RelativePositionConstraint(robot,pts,lb,ub, ...
       lcmgl.box((obj.lb+obj.ub)/2,obj.ub-obj.lb);
       lcmgl.switchBuffers();
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(obj.body_a.idx,obj.body_b.idx);
       joint_idx = vertcat(obj.robot.body(joint_path).position_num)';

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -19,11 +19,9 @@ void drakePrintMatrix(const MatrixXd &mat) {
 namespace DrakeRigidBodyConstraint {
 Vector3d com_pts = Vector3d::Zero();
 const int WorldCoMDefaultRobotNum[1] = {0};
-Vector2d default_tspan(-std::numeric_limits<double>::infinity(),
-                       std::numeric_limits<double>::infinity());
 }
-RigidBodyConstraint::RigidBodyConstraint(int category, RigidBodyTree *robot,
-                                         const Vector2d &tspan) {
+
+RigidBodyConstraint::RigidBodyConstraint(int category, RigidBodyTree *robot) {
   if (category >= 0 || category <= -7) {
     std::cerr << "Drake:RigidBodyConstraint:Unsupported constraint category"
               << std::endl;
@@ -31,19 +29,10 @@ RigidBodyConstraint::RigidBodyConstraint(int category, RigidBodyTree *robot,
   this->category = category;
   this->type = 0;
   this->robot = robot;
-  if (tspan(0) > tspan(1)) {
-    std::cerr << "Drake:RigidBodyConstraint:tspan(0) should be no larger than "
-                 "tspan(1)" << std::endl;
-  }
-  this->tspan[0] = tspan(0);
-  this->tspan[1] = tspan(1);
 }
 
 RigidBodyConstraint::RigidBodyConstraint(const RigidBodyConstraint &rhs)
-    : category(rhs.category), type(rhs.type), robot(rhs.robot) {
-  this->tspan[0] = rhs.tspan[0];
-  this->tspan[1] = rhs.tspan[1];
-}
+    : category(rhs.category), type(rhs.type), robot(rhs.robot) {}
 
 RigidBodyConstraint::~RigidBodyConstraint(void) {}
 
@@ -59,10 +48,9 @@ const int QuasiStaticDefaultRobotNum[1] = {0};
 const std::set<int> QuasiStaticConstraint::defaultRobotNumSet(
     QuasiStaticDefaultRobotNum, QuasiStaticDefaultRobotNum + 1);
 QuasiStaticConstraint::QuasiStaticConstraint(RigidBodyTree *robot,
-                                             const Vector2d &tspan,
                                              const std::set<int> &robotnumset)
     : RigidBodyConstraint(RigidBodyConstraint::QuasiStaticConstraintCategory,
-                          robot, tspan) {
+                          robot) {
   this->m_robotnumset = robotnumset;
   this->shrinkFactor = 0.9;
   this->active = false;
@@ -84,17 +72,8 @@ QuasiStaticConstraint::QuasiStaticConstraint(const QuasiStaticConstraint &rhs)
 
 QuasiStaticConstraint::~QuasiStaticConstraint() {}
 
-bool QuasiStaticConstraint::isTimeValid(const double *t) const {
-  if (t == nullptr) return true;
-  return (*t) >= this->tspan[0] && (*t) <= this->tspan[1];
-}
-
 int QuasiStaticConstraint::getNumConstraint(const double *t) const {
-  if (this->isTimeValid(t)) {
-    return 3;
-  } else {
-    return 0;
-  }
+  return 3;
 }
 
 void QuasiStaticConstraint::updateRobot(RigidBodyTree *robot) {
@@ -104,66 +83,56 @@ void QuasiStaticConstraint::eval(const double *t,
                                  KinematicsCache<double> &cache,
                                  const double *weights, VectorXd &c,
                                  MatrixXd &dc) const {
-  if (this->isTimeValid(t)) {
-    int nq = this->robot->num_positions;
-    dc.resize(2, nq + this->num_pts);
-    auto com = robot->centerOfMass(cache, m_robotnumset);
-    auto dcom = robot->centerOfMassJacobian(cache, m_robotnumset, true);
-    MatrixXd contact_pos(3, this->num_pts);
-    MatrixXd dcontact_pos(3 * this->num_pts, nq);
-    int num_accum_pts = 0;
-    Vector3d center_pos = Vector3d::Zero();
-    MatrixXd dcenter_pos = MatrixXd::Zero(3, nq);
-    for (int i = 0; i < this->num_bodies; i++) {
-      auto body_contact_pos =
-          robot->transformPoints(cache, body_pts[i], bodies[i], 0);
-      auto dbody_contact_pos = robot->transformPointsJacobian(
-          cache, body_pts[i], bodies[i], 0, true);
+  int nq = this->robot->num_positions;
+  dc.resize(2, nq + this->num_pts);
+  auto com = robot->centerOfMass(cache, m_robotnumset);
+  auto dcom = robot->centerOfMassJacobian(cache, m_robotnumset, true);
+  MatrixXd contact_pos(3, this->num_pts);
+  MatrixXd dcontact_pos(3 * this->num_pts, nq);
+  int num_accum_pts = 0;
+  Vector3d center_pos = Vector3d::Zero();
+  MatrixXd dcenter_pos = MatrixXd::Zero(3, nq);
+  for (int i = 0; i < this->num_bodies; i++) {
+    auto body_contact_pos =
+        robot->transformPoints(cache, body_pts[i], bodies[i], 0);
+    auto dbody_contact_pos = robot->transformPointsJacobian(
+        cache, body_pts[i], bodies[i], 0, true);
 
-      contact_pos.block(0, num_accum_pts, 3, this->num_body_pts[i]) =
-          body_contact_pos;
-      dcontact_pos.block(3 * num_accum_pts, 0, 3 * this->num_body_pts[i], nq) =
-          dbody_contact_pos;
-      for (int j = 0; j < this->num_body_pts[i]; j++) {
-        center_pos = center_pos + body_contact_pos.col(j);
-        dcenter_pos = dcenter_pos + dbody_contact_pos.block(3 * j, 0, 3, nq);
-      }
-      num_accum_pts += this->num_body_pts[i];
+    contact_pos.block(0, num_accum_pts, 3, this->num_body_pts[i]) =
+        body_contact_pos;
+    dcontact_pos.block(3 * num_accum_pts, 0, 3 * this->num_body_pts[i], nq) =
+        dbody_contact_pos;
+    for (int j = 0; j < this->num_body_pts[i]; j++) {
+      center_pos = center_pos + body_contact_pos.col(j);
+      dcenter_pos = dcenter_pos + dbody_contact_pos.block(3 * j, 0, 3, nq);
     }
-    center_pos = center_pos / this->num_pts;
-    dcenter_pos = dcenter_pos / this->num_pts;
-    MatrixXd support_pos(2, this->num_pts);
-    MatrixXd dsupport_pos(2 * this->num_pts, nq);
-    c = com.head(2);
-    dc.block(0, 0, 2, nq) = dcom.block(0, 0, 2, nq);
-    for (int i = 0; i < this->num_pts; i++) {
-      support_pos.col(i) = center_pos.head(2) * (1.0 - this->shrinkFactor) +
-                           contact_pos.block(0, i, 2, 1) * this->shrinkFactor;
-      dsupport_pos.block(2 * i, 0, 2, nq) =
-          dcenter_pos.block(0, 0, 2, nq) * (1.0 - this->shrinkFactor) +
-          dcontact_pos.block(3 * i, 0, 2, nq) * this->shrinkFactor;
-      c = c - weights[i] * support_pos.col(i);
-      dc.block(0, 0, 2, nq) = dc.block(0, 0, 2, nq) -
-                              weights[i] * dsupport_pos.block(2 * i, 0, 2, nq);
-    }
-    dc.block(0, nq, 2, this->num_pts) = -support_pos;
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
+    num_accum_pts += this->num_body_pts[i];
   }
+  center_pos = center_pos / this->num_pts;
+  dcenter_pos = dcenter_pos / this->num_pts;
+  MatrixXd support_pos(2, this->num_pts);
+  MatrixXd dsupport_pos(2 * this->num_pts, nq);
+  c = com.head(2);
+  dc.block(0, 0, 2, nq) = dcom.block(0, 0, 2, nq);
+  for (int i = 0; i < this->num_pts; i++) {
+    support_pos.col(i) = center_pos.head(2) * (1.0 - this->shrinkFactor) +
+        contact_pos.block(0, i, 2, 1) * this->shrinkFactor;
+    dsupport_pos.block(2 * i, 0, 2, nq) =
+        dcenter_pos.block(0, 0, 2, nq) * (1.0 - this->shrinkFactor) +
+        dcontact_pos.block(3 * i, 0, 2, nq) * this->shrinkFactor;
+    c = c - weights[i] * support_pos.col(i);
+    dc.block(0, 0, 2, nq) = dc.block(0, 0, 2, nq) -
+        weights[i] * dsupport_pos.block(2 * i, 0, 2, nq);
+  }
+  dc.block(0, nq, 2, this->num_pts) = -support_pos;
 }
 
 void QuasiStaticConstraint::bounds(const double *t, VectorXd &lb,
                                    VectorXd &ub) const {
-  if (this->isTimeValid(t)) {
-    lb.resize(2);
-    ub.resize(2);
-    lb << 0.0, 0.0;
-    ub << 0.0, 0.0;
-  } else {
-    lb.resize(0);
-    ub.resize(0);
-  }
+  lb.resize(2);
+  ub.resize(2);
+  lb << 0.0, 0.0;
+  ub << 0.0, 0.0;
 }
 
 void QuasiStaticConstraint::name(const double *t,
@@ -235,10 +204,8 @@ void QuasiStaticConstraint::updateRobotnum(std::set<int> &robotnumset) {
   this->m_robotnumset = robotnumset;
 }
 
-PostureConstraint::PostureConstraint(RigidBodyTree *robot,
-                                     const Eigen::Vector2d &tspan)
-    : RigidBodyConstraint(RigidBodyConstraint::PostureConstraintCategory, robot,
-                          tspan) {
+PostureConstraint::PostureConstraint(RigidBodyTree *robot)
+    : RigidBodyConstraint(RigidBodyConstraint::PostureConstraintCategory, robot) {
   this->joint_limit_min0 = this->robot->joint_limit_min;
   this->joint_limit_max0 = this->robot->joint_limit_max;
   this->lb = this->joint_limit_min0;
@@ -257,11 +224,6 @@ PostureConstraint::PostureConstraint(const PostureConstraint &rhs)
     this->lb[i] = rhs.lb[i];
     this->ub[i] = rhs.ub[i];
   }
-}
-
-bool PostureConstraint::isTimeValid(const double *t) const {
-  if (t == nullptr) return true;
-  return (*t) >= this->tspan[0] && (*t) <= this->tspan[1];
 }
 
 void PostureConstraint::setJointLimits(const VectorXi &joint_idx,
@@ -295,64 +257,29 @@ void PostureConstraint::setJointLimits(int num_idx, const int *joint_idx,
 
 void PostureConstraint::bounds(const double *t, VectorXd &joint_min,
                                VectorXd &joint_max) const {
-  if (this->isTimeValid(t)) {
-    joint_min = this->lb;
-    joint_max = this->ub;
-  } else {
-    joint_min = this->robot->joint_limit_min;
-    joint_max = this->robot->joint_limit_max;
-  }
+  joint_min = this->lb;
+  joint_max = this->ub;
 }
 
 MultipleTimeLinearPostureConstraint::MultipleTimeLinearPostureConstraint(
-    RigidBodyTree *robot, const Eigen::Vector2d &tspan)
+    RigidBodyTree *robot)
     : RigidBodyConstraint(
           RigidBodyConstraint::MultipleTimeLinearPostureConstraintCategory,
-          robot, tspan) {}
+          robot) {}
 
 MultipleTimeLinearPostureConstraint::MultipleTimeLinearPostureConstraint(
     const MultipleTimeLinearPostureConstraint &rhs)
     : RigidBodyConstraint(rhs) {}
 
-std::vector<bool> MultipleTimeLinearPostureConstraint::isTimeValid(
-    const double *t, int n_breaks) const {
-  std::vector<bool> flag;
-  for (int i = 0; i < n_breaks; i++) {
-    if (i < n_breaks - 1) {
-      if (t[i + 1] < t[i]) {
-        std::cerr << "Drake:Constraint:BadInputs: t must be in ascending order"
-                  << std::endl;
-      }
-    }
-    if ((t[i] > this->tspan[1] || t[i] < this->tspan[0])) {
-      flag.push_back(false);
-    } else {
-      flag.push_back(true);
-    }
-  }
-  return flag;
-}
-
-int MultipleTimeLinearPostureConstraint::numValidTime(
-    const std::vector<bool> &valid_flag) const {
-  int num_valid_t = 0;
-  for (auto it = valid_flag.begin(); it != valid_flag.end(); it++) {
-    if (*it) {
-      num_valid_t++;
-    }
-  }
-  return num_valid_t;
-}
-
-void MultipleTimeLinearPostureConstraint::validTimeInd(
-    const std::vector<bool> &valid_flag, VectorXi &valid_t_ind) const {
+namespace {
+void validTimeInd(
+    int n_breaks, VectorXi &valid_t_ind) {
   valid_t_ind.resize(0);
-  for (int i = 0; i < valid_flag.size(); i++) {
-    if (valid_flag.at(i)) {
-      valid_t_ind.conservativeResize(valid_t_ind.size() + 1);
-      valid_t_ind(valid_t_ind.size() - 1) = i;
-    }
+  for (int i = 0; i < n_breaks; i++) {
+    valid_t_ind.conservativeResize(valid_t_ind.size() + 1);
+    valid_t_ind(valid_t_ind.size() - 1) = i;
   }
+}
 }
 
 void MultipleTimeLinearPostureConstraint::eval(const double *t, int n_breaks,
@@ -373,11 +300,9 @@ void MultipleTimeLinearPostureConstraint::eval(const double *t, int n_breaks,
 
 SingleTimeLinearPostureConstraint::SingleTimeLinearPostureConstraint(
     RigidBodyTree *robot, const VectorXi &iAfun, const VectorXi &jAvar,
-    const VectorXd &A, const VectorXd &lb, const VectorXd &ub,
-    const Vector2d &tspan)
+    const VectorXd &A, const VectorXd &lb, const VectorXd &ub)
     : RigidBodyConstraint(
-          RigidBodyConstraint::SingleTimeLinearPostureConstraintCategory, robot,
-          tspan) {
+          RigidBodyConstraint::SingleTimeLinearPostureConstraintCategory, robot) {
   this->lb = lb;
   this->ub = ub;
   this->num_constraint = static_cast<int>(this->lb.size());
@@ -436,87 +361,50 @@ SingleTimeLinearPostureConstraint::SingleTimeLinearPostureConstraint(
       num_constraint(rhs.num_constraint),
       A_mat(rhs.A_mat) {}
 
-bool SingleTimeLinearPostureConstraint::isTimeValid(const double *t) const {
-  if (t == nullptr) {
-    return true;
-  }
-  if (*t >= this->tspan[0] && *t <= this->tspan[1]) {
-    return true;
-  }
-  return false;
-}
-
 int SingleTimeLinearPostureConstraint::getNumConstraint(const double *t) const {
-  if (this->isTimeValid(t)) {
-    return this->num_constraint;
-  } else {
-    return 0;
-  }
+  return this->num_constraint;
 }
 
 void SingleTimeLinearPostureConstraint::bounds(const double *t, VectorXd &lb,
                                                VectorXd &ub) const {
-  if (this->isTimeValid(t)) {
-    lb = this->lb;
-    ub = this->ub;
-  } else {
-    lb.resize(0);
-    ub.resize(0);
-  }
+  lb = this->lb;
+  ub = this->ub;
 }
 
 void SingleTimeLinearPostureConstraint::feval(const double *t,
                                               const VectorXd &q,
                                               VectorXd &c) const {
-  if (this->isTimeValid(t)) {
-    c = this->A_mat * q;
-  } else {
-    c.resize(0);
-  }
+  c = this->A_mat * q;
 }
 
 void SingleTimeLinearPostureConstraint::geval(const double *t, VectorXi &iAfun,
                                               VectorXi &jAvar,
                                               VectorXd &A) const {
-  if (this->isTimeValid(t)) {
-    iAfun = this->iAfun;
-    jAvar = this->jAvar;
-    A = this->A;
-  } else {
-    iAfun.resize(0);
-    jAvar.resize(0);
-    A.resize(0);
-  }
+  iAfun = this->iAfun;
+  jAvar = this->jAvar;
+  A = this->A;
 }
 
 void SingleTimeLinearPostureConstraint::eval(const double *t, const VectorXd &q,
                                              VectorXd &c,
                                              SparseMatrix<double> &dc) const {
-  if (this->isTimeValid(t)) {
-    c = this->A_mat * q;
-    dc = this->A_mat;
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
-  }
+  c = this->A_mat * q;
+  dc = this->A_mat;
 }
 
 void SingleTimeLinearPostureConstraint::name(
     const double *t, std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    for (int i = 0; i < this->num_constraint; i++) {
-      name_str.push_back("SingleTimeLinearPostureConstraint row " +
-                         std::to_string(i) + time_str);
-    }
+  std::string time_str = this->getTimeString(t);
+  for (int i = 0; i < this->num_constraint; i++) {
+    name_str.push_back("SingleTimeLinearPostureConstraint row " +
+                       std::to_string(i) + time_str);
   }
 }
 
 SingleTimeKinematicConstraint::SingleTimeKinematicConstraint(
-    RigidBodyTree *robot, const Vector2d &tspan)
+    RigidBodyTree *robot)
     : RigidBodyConstraint(
-          RigidBodyConstraint::SingleTimeKinematicConstraintCategory, robot,
-          tspan) {
+          RigidBodyConstraint::SingleTimeKinematicConstraintCategory, robot) {
   this->num_constraint = 0;
 }
 
@@ -525,16 +413,9 @@ SingleTimeKinematicConstraint::SingleTimeKinematicConstraint(
     : RigidBodyConstraint(rhs) {
   this->num_constraint = rhs.num_constraint;
 }
-bool SingleTimeKinematicConstraint::isTimeValid(const double *t) const {
-  if (t == nullptr) return true;
-  return (*t) >= this->tspan[0] && (*t) <= this->tspan[1];
-}
 
 int SingleTimeKinematicConstraint::getNumConstraint(const double *t) const {
-  if (isTimeValid(t)) {
-    return this->num_constraint;
-  }
-  return 0;
+  return this->num_constraint;
 }
 
 void SingleTimeKinematicConstraint::updateRobot(RigidBodyTree *robot) {
@@ -542,10 +423,9 @@ void SingleTimeKinematicConstraint::updateRobot(RigidBodyTree *robot) {
 }
 
 MultipleTimeKinematicConstraint::MultipleTimeKinematicConstraint(
-    RigidBodyTree *robot, const Vector2d &tspan)
+    RigidBodyTree *robot)
     : RigidBodyConstraint(
-          RigidBodyConstraint::MultipleTimeKinematicConstraintCategory, robot,
-          tspan) {}
+          RigidBodyConstraint::MultipleTimeKinematicConstraintCategory, robot) {}
 
 MultipleTimeKinematicConstraint::MultipleTimeKinematicConstraint(
     const MultipleTimeKinematicConstraint &rhs)
@@ -554,21 +434,18 @@ MultipleTimeKinematicConstraint::MultipleTimeKinematicConstraint(
 void MultipleTimeKinematicConstraint::eval(const double *t, int n_breaks,
                                            const MatrixXd &q, VectorXd &c,
                                            MatrixXd &dc) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
-    std::vector<bool> valid_time_flag = this->isTimeValid(t, n_breaks);
     int nq = this->robot->num_positions;
     double *valid_t = new double[num_valid_t];
     MatrixXd valid_q(nq, num_valid_t);
     int valid_idx = 0;
     int *valid2tMap = new int[num_valid_t];
     for (int i = 0; i < n_breaks; i++) {
-      if (valid_time_flag[i]) {
-        valid_t[valid_idx] = t[i];
-        valid_q.col(valid_idx) = q.col(i);
-        valid2tMap[valid_idx] = i;
-        valid_idx++;
-      }
+      valid_t[valid_idx] = t[i];
+      valid_q.col(valid_idx) = q.col(i);
+      valid2tMap[valid_idx] = i;
+      valid_idx++;
     }
     MatrixXd dc_valid;
     this->eval_valid(valid_t, num_valid_t, valid_q, c, dc_valid);
@@ -586,39 +463,14 @@ void MultipleTimeKinematicConstraint::eval(const double *t, int n_breaks,
   }
 }
 
-std::vector<bool> MultipleTimeKinematicConstraint::isTimeValid(
-    const double *t, int n_breaks) const {
-  std::vector<bool> flag;
-  for (int i = 0; i < n_breaks; i++) {
-    if ((t[i] > this->tspan[1] || t[i] < this->tspan[0])) {
-      flag.push_back(false);
-    } else {
-      flag.push_back(true);
-    }
-  }
-  return flag;
-}
-
-int MultipleTimeKinematicConstraint::numValidTime(const double *t,
-                                                  int n_breaks) const {
-  std::vector<bool> valid_flag = this->isTimeValid(t, n_breaks);
-  int num_valid_t = 0;
-  for (auto it = valid_flag.begin(); it != valid_flag.end(); it++) {
-    if (*it) {
-      num_valid_t++;
-    }
-  }
-  return num_valid_t;
-}
-
 void MultipleTimeKinematicConstraint::updateRobot(RigidBodyTree *robot) {
   this->robot = robot;
 }
 
 PositionConstraint::PositionConstraint(RigidBodyTree *robot,
                                        const Matrix3Xd &pts, MatrixXd lb,
-                                       MatrixXd ub, const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan) {
+                                       MatrixXd ub)
+    : SingleTimeKinematicConstraint(robot) {
   this->n_pts = static_cast<int>(pts.cols());
   if (pts.rows() != 3) {
     std::cerr << "pts must have 3 rows" << std::endl;
@@ -685,56 +537,46 @@ PositionConstraint::PositionConstraint(const PositionConstraint &rhs)
 
 void PositionConstraint::eval(const double *t, KinematicsCache<double> &cache,
                               VectorXd &c, MatrixXd &dc) const {
-  if (this->isTimeValid(t)) {
-    Matrix3Xd pos(3, this->n_pts);
-    MatrixXd J(3 * this->n_pts, this->robot->num_positions);
-    this->evalPositions(cache, pos, J);
-    c.resize(this->getNumConstraint(t), 1);
-    dc.resize(this->getNumConstraint(t), this->robot->num_positions);
-    int valid_row_idx = 0;
-    int i = 0;
-    while (i < this->getNumConstraint(t)) {
-      if (!this->null_constraint_rows[valid_row_idx]) {
-        c(i) = pos(valid_row_idx);
-        dc.row(i) = J.row(valid_row_idx);
-        i++;
-        valid_row_idx++;
-      } else {
-        valid_row_idx++;
-      }
+  Matrix3Xd pos(3, this->n_pts);
+  MatrixXd J(3 * this->n_pts, this->robot->num_positions);
+  this->evalPositions(cache, pos, J);
+  c.resize(this->getNumConstraint(t), 1);
+  dc.resize(this->getNumConstraint(t), this->robot->num_positions);
+  int valid_row_idx = 0;
+  int i = 0;
+  while (i < this->getNumConstraint(t)) {
+    if (!this->null_constraint_rows[valid_row_idx]) {
+      c(i) = pos(valid_row_idx);
+      dc.row(i) = J.row(valid_row_idx);
+      i++;
+      valid_row_idx++;
+    } else {
+      valid_row_idx++;
     }
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
   }
 }
 
 void PositionConstraint::bounds(const double *t, VectorXd &lb,
                                 VectorXd &ub) const {
-  if (this->isTimeValid(t)) {
-    lb = this->lb;
-    ub = this->ub;
-  }
+  lb = this->lb;
+  ub = this->ub;
 }
 
 void PositionConstraint::name(const double *t,
                               std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::vector<std::string> cnst_names;
-    this->evalNames(t, cnst_names);
-    for (int i = 0; i < 3 * this->n_pts; i++) {
-      if (!this->null_constraint_rows[i]) {
-        name_str.push_back(cnst_names.at(i));
+  std::vector<std::string> cnst_names;
+  this->evalNames(t, cnst_names);
+  for (int i = 0; i < 3 * this->n_pts; i++) {
+    if (!this->null_constraint_rows[i]) {
+      name_str.push_back(cnst_names.at(i));
       }
-    }
   }
 }
 
 WorldPositionConstraint::WorldPositionConstraint(RigidBodyTree *robot, int body,
                                                  const Matrix3Xd &pts,
-                                                 MatrixXd lb, MatrixXd ub,
-                                                 const Vector2d &tspan)
-    : PositionConstraint(robot, pts, lb, ub, tspan) {
+                                                 MatrixXd lb, MatrixXd ub)
+    : PositionConstraint(robot, pts, lb, ub) {
   this->body = body;
   this->body_name = robot->getBodyOrFrameName(body);
   this->type = RigidBodyConstraint::WorldPositionConstraintType;
@@ -766,10 +608,9 @@ const std::set<int> WorldCoMConstraint::defaultRobotNumSet(
     DrakeRigidBodyConstraint::WorldCoMDefaultRobotNum + 1);
 
 WorldCoMConstraint::WorldCoMConstraint(RigidBodyTree *robot, Vector3d lb,
-                                       Vector3d ub, const Vector2d &tspan,
+                                       Vector3d ub,
                                        const std::set<int> &robotnum)
-    : PositionConstraint(robot, DrakeRigidBodyConstraint::com_pts, lb, ub,
-                         tspan) {
+    : PositionConstraint(robot, DrakeRigidBodyConstraint::com_pts, lb, ub) {
   this->m_robotnum = robotnum;
   this->body = -1;
   this->body_name = "CoM";
@@ -799,8 +640,8 @@ WorldCoMConstraint::~WorldCoMConstraint() {}
 RelativePositionConstraint::RelativePositionConstraint(
     RigidBodyTree *robot, const Matrix3Xd &pts, const MatrixXd &lb,
     const MatrixXd &ub, int bodyA_idx, int bodyB_idx,
-    const Matrix<double, 7, 1> &bTbp, const Vector2d &tspan)
-    : PositionConstraint(robot, pts, lb, ub, tspan) {
+    const Matrix<double, 7, 1> &bTbp)
+    : PositionConstraint(robot, pts, lb, ub) {
   this->bodyA_idx = bodyA_idx;
   this->bodyB_idx = bodyB_idx;
   bodyA_name = robot->getBodyOrFrameName(bodyA_idx);
@@ -838,9 +679,8 @@ void RelativePositionConstraint::evalNames(
 
 RelativePositionConstraint::~RelativePositionConstraint() {}
 
-QuatConstraint::QuatConstraint(RigidBodyTree *robot, double tol,
-                               const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan) {
+QuatConstraint::QuatConstraint(RigidBodyTree *robot, double tol)
+    : SingleTimeKinematicConstraint(robot) {
   if (tol < 0.0 || tol > M_PI) {
     std::cerr << "tol must be within [0 PI]" << std::endl;
   }
@@ -853,33 +693,25 @@ void QuatConstraint::eval(const double *t, KinematicsCache<double> &cache,
   int num_constraint = this->getNumConstraint(t);
   c.resize(num_constraint);
   dc.resize(num_constraint, this->robot->num_positions);
-  if (this->isTimeValid(t)) {
-    double prod;
-    MatrixXd dprod(1, this->robot->num_positions);
-    this->evalOrientationProduct(cache, prod, dprod);
-    c(0) = 2.0 * prod * prod - 1.0;
-    dc = 4.0 * prod * dprod;
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
-  }
+  double prod;
+  MatrixXd dprod(1, this->robot->num_positions);
+  this->evalOrientationProduct(cache, prod, dprod);
+  c(0) = 2.0 * prod * prod - 1.0;
+  dc = 4.0 * prod * dprod;
 }
 
 void QuatConstraint::bounds(const double *t, VectorXd &lb, VectorXd &ub) const {
   lb.resize(this->getNumConstraint(t));
   ub.resize(this->getNumConstraint(t));
-  if (this->isTimeValid(t)) {
-    lb[0] = cos(this->tol);
-    ub[0] = 1.0;
-  }
+  lb[0] = cos(this->tol);
+  ub[0] = 1.0;
 }
 
 QuatConstraint::~QuatConstraint(void) {}
 
 WorldQuatConstraint::WorldQuatConstraint(RigidBodyTree *robot, int body,
-                                         const Vector4d &quat_des, double tol,
-                                         const Vector2d &tspan)
-    : QuatConstraint(robot, tol, tspan) {
+                                         const Vector4d &quat_des, double tol)
+    : QuatConstraint(robot, tol) {
   this->body = body;
   this->body_name = robot->getBodyOrFrameName(body);
   if (quat_des.norm() <= 0) {
@@ -900,11 +732,9 @@ void WorldQuatConstraint::evalOrientationProduct(
 
 void WorldQuatConstraint::name(const double *t,
                                std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    for (int i = 0; i < this->num_constraint; i++) {
-      name_str.push_back(this->body_name + " quaternion constraint" + time_str);
-    }
+  std::string time_str = this->getTimeString(t);
+  for (int i = 0; i < this->num_constraint; i++) {
+    name_str.push_back(this->body_name + " quaternion constraint" + time_str);
   }
 }
 
@@ -913,9 +743,8 @@ WorldQuatConstraint::~WorldQuatConstraint() {}
 RelativeQuatConstraint::RelativeQuatConstraint(RigidBodyTree *robot,
                                                int bodyA_idx, int bodyB_idx,
                                                const Vector4d &quat_des,
-                                               double tol,
-                                               const Vector2d &tspan)
-    : QuatConstraint(robot, tol, tspan) {
+                                               double tol)
+    : QuatConstraint(robot, tol) {
   this->bodyA_idx = bodyA_idx;
   this->bodyB_idx = bodyB_idx;
   this->bodyA_name = this->robot->bodies[bodyA_idx]->linkname;
@@ -937,22 +766,20 @@ void RelativeQuatConstraint::evalOrientationProduct(
 
 void RelativeQuatConstraint::name(const double *t,
                                   std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    std::string tmp_name = this->bodyA_name + " relative to " +
-                           this->bodyB_name + " quaternion constraint" +
-                           time_str;
-    for (int i = 0; i < this->num_constraint; i++) {
-      name_str.push_back(tmp_name);
-    }
+  std::string time_str = this->getTimeString(t);
+  std::string tmp_name = this->bodyA_name + " relative to " +
+      this->bodyB_name + " quaternion constraint" +
+      time_str;
+  for (int i = 0; i < this->num_constraint; i++) {
+    name_str.push_back(tmp_name);
   }
 }
 
 RelativeQuatConstraint::~RelativeQuatConstraint() {}
 
 EulerConstraint::EulerConstraint(RigidBodyTree *robot, const Vector3d &lb,
-                                 const Vector3d &ub, const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan) {
+                                 const Vector3d &ub)
+    : SingleTimeKinematicConstraint(robot) {
   this->num_constraint = 0;
   Vector3d my_lb = lb, my_ub = ub;
   for (int i = 0; i < 3; i++) {
@@ -1007,44 +834,36 @@ EulerConstraint::EulerConstraint(const EulerConstraint &rhs)
 void EulerConstraint::eval(const double *t, KinematicsCache<double> &cache,
                            VectorXd &c, MatrixXd &dc) const {
   int n_constraint = this->getNumConstraint(t);
-  if (this->isTimeValid(t)) {
-    Vector3d rpy;
-    MatrixXd drpy(3, this->robot->num_positions);
-    this->evalrpy(cache, rpy, drpy);
-    c.resize(n_constraint);
-    dc.resize(n_constraint, this->robot->num_positions);
-    int valid_row_idx = 0;
-    int i = 0;
-    while (i < n_constraint) {
-      if (!this->null_constraint_rows[valid_row_idx]) {
-        c(i) = rpy(valid_row_idx);
-        c(i) = angleDiff(this->avg_rpy[i], c(i)) + this->avg_rpy[i];
-        dc.row(i) = drpy.row(valid_row_idx);
-        valid_row_idx++;
-        i++;
-      } else {
-        valid_row_idx++;
-      }
+  Vector3d rpy;
+  MatrixXd drpy(3, this->robot->num_positions);
+  this->evalrpy(cache, rpy, drpy);
+  c.resize(n_constraint);
+  dc.resize(n_constraint, this->robot->num_positions);
+  int valid_row_idx = 0;
+  int i = 0;
+  while (i < n_constraint) {
+    if (!this->null_constraint_rows[valid_row_idx]) {
+      c(i) = rpy(valid_row_idx);
+      c(i) = angleDiff(this->avg_rpy[i], c(i)) + this->avg_rpy[i];
+      dc.row(i) = drpy.row(valid_row_idx);
+      valid_row_idx++;
+      i++;
+    } else {
+      valid_row_idx++;
     }
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
   }
 }
 
 void EulerConstraint::bounds(const double *t, VectorXd &lb,
                              VectorXd &ub) const {
-  if (this->isTimeValid(t)) {
-    lb = this->lb;
-    ub = this->ub;
-  }
+  lb = this->lb;
+  ub = this->ub;
 }
 
 WorldEulerConstraint::WorldEulerConstraint(RigidBodyTree *robot, int body,
                                            const Vector3d &lb,
-                                           const Vector3d &ub,
-                                           const Vector2d &tspan)
-    : EulerConstraint(robot, lb, ub, tspan) {
+                                           const Vector3d &ub)
+    : EulerConstraint(robot, lb, ub) {
   this->body = body;
   this->body_name = robot->getBodyOrFrameName(body);
   this->type = RigidBodyConstraint::WorldEulerConstraintType;
@@ -1058,29 +877,27 @@ void WorldEulerConstraint::evalrpy(const KinematicsCache<double> &cache,
 
 void WorldEulerConstraint::name(const double *t,
                                 std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    int constraint_idx = 0;
-    if (!this->null_constraint_rows[0]) {
-      name_str.push_back(this->body_name + " roll" + time_str);
-      constraint_idx++;
-    }
-    if (!this->null_constraint_rows[1]) {
-      name_str.push_back(this->body_name + " pitch" + time_str);
-      constraint_idx++;
-    }
-    if (!this->null_constraint_rows[2]) {
-      name_str.push_back(this->body_name + " yaw" + time_str);
-      constraint_idx++;
-    }
+  std::string time_str = this->getTimeString(t);
+  int constraint_idx = 0;
+  if (!this->null_constraint_rows[0]) {
+    name_str.push_back(this->body_name + " roll" + time_str);
+    constraint_idx++;
+  }
+  if (!this->null_constraint_rows[1]) {
+    name_str.push_back(this->body_name + " pitch" + time_str);
+    constraint_idx++;
+  }
+  if (!this->null_constraint_rows[2]) {
+    name_str.push_back(this->body_name + " yaw" + time_str);
+    constraint_idx++;
   }
 }
 
 WorldEulerConstraint::~WorldEulerConstraint() {}
 
 GazeConstraint::GazeConstraint(RigidBodyTree *robot, const Vector3d &axis,
-                               double conethreshold, const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan) {
+                               double conethreshold)
+    : SingleTimeKinematicConstraint(robot) {
   double len_axis = axis.norm();
   if (len_axis <= 0) {
     std::cerr << "axis must be non-zero" << std::endl;
@@ -1094,8 +911,8 @@ GazeConstraint::GazeConstraint(RigidBodyTree *robot, const Vector3d &axis,
 
 GazeOrientConstraint::GazeOrientConstraint(
     RigidBodyTree *robot, const Vector3d &axis, const Vector4d &quat_des,
-    double conethreshold, double threshold, const Vector2d &tspan)
-    : GazeConstraint(robot, axis, conethreshold, tspan) {
+    double conethreshold, double threshold)
+    : GazeConstraint(robot, axis, conethreshold) {
   double len_quat_des = quat_des.norm();
   if (len_quat_des <= 0) {
     std::cerr << "quat_des must be non-zero" << std::endl;
@@ -1116,55 +933,46 @@ void GazeOrientConstraint::eval(const double *t, KinematicsCache<double> &cache,
   int num_constraint = this->getNumConstraint(t);
   c.resize(num_constraint);
   dc.resize(num_constraint, this->robot->num_positions);
-  if (this->isTimeValid(t)) {
-    Vector4d quat;
-    int nq = this->robot->num_positions;
-    MatrixXd dquat(4, nq);
-    this->evalOrientation(cache, quat, dquat);
+  Vector4d quat;
+  int nq = this->robot->num_positions;
+  MatrixXd dquat(4, nq);
+  this->evalOrientation(cache, quat, dquat);
 
-    auto axis_err_autodiff_args = initializeAutoDiffTuple(quat, quat_des, axis);
-    auto e_autodiff = quatDiffAxisInvar(get<0>(axis_err_autodiff_args),
-                                        get<1>(axis_err_autodiff_args),
-                                        get<2>(axis_err_autodiff_args));
-    auto axis_err = e_autodiff.value();
-    auto daxis_err = e_autodiff.derivatives().transpose().eval();
+  auto axis_err_autodiff_args = initializeAutoDiffTuple(quat, quat_des, axis);
+  auto e_autodiff = quatDiffAxisInvar(get<0>(axis_err_autodiff_args),
+                                      get<1>(axis_err_autodiff_args),
+                                      get<2>(axis_err_autodiff_args));
+  auto axis_err = e_autodiff.value();
+  auto daxis_err = e_autodiff.derivatives().transpose().eval();
 
-    MatrixXd daxis_err_dq(1, nq);
-    daxis_err_dq = daxis_err.block(0, 0, 1, 4) * dquat;
+  MatrixXd daxis_err_dq(1, nq);
+  daxis_err_dq = daxis_err.block(0, 0, 1, 4) * dquat;
 
-    auto quat_diff_autodiff_args = initializeAutoDiffTuple(quat, quat_des);
-    auto q_diff_autodiff = quatDiff(get<0>(quat_diff_autodiff_args),
-                                    get<1>(quat_diff_autodiff_args));
-    auto q_diff = autoDiffToValueMatrix(q_diff_autodiff);
-    auto dq_diff = autoDiffToGradientMatrix(q_diff_autodiff);
+  auto quat_diff_autodiff_args = initializeAutoDiffTuple(quat, quat_des);
+  auto q_diff_autodiff = quatDiff(get<0>(quat_diff_autodiff_args),
+                                  get<1>(quat_diff_autodiff_args));
+  auto q_diff = autoDiffToValueMatrix(q_diff_autodiff);
+  auto dq_diff = autoDiffToGradientMatrix(q_diff_autodiff);
 
-    MatrixXd dq_diff_dq(4, nq);
-    dq_diff_dq = dq_diff.block(0, 0, 4, 4) * dquat;
-    c << axis_err, q_diff(0);
-    dc.row(0) = daxis_err_dq;
-    dc.row(1) = dq_diff_dq.row(0);
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
-  }
+  MatrixXd dq_diff_dq(4, nq);
+  dq_diff_dq = dq_diff.block(0, 0, 4, 4) * dquat;
+  c << axis_err, q_diff(0);
+  dc.row(0) = daxis_err_dq;
+  dc.row(1) = dq_diff_dq.row(0);
 }
 
 void GazeOrientConstraint::bounds(const double *t, VectorXd &lb,
                                   VectorXd &ub) const {
   lb.resize(this->getNumConstraint(t));
   ub.resize(this->getNumConstraint(t));
-  if (this->isTimeValid(t)) {
-    lb << cos(this->conethreshold) - 1.0, cos(this->threshold / 2.0);
-    ub << 0, std::numeric_limits<double>::infinity();
-  }
+  lb << cos(this->conethreshold) - 1.0, cos(this->threshold / 2.0);
+  ub << 0, std::numeric_limits<double>::infinity();
 }
 
 WorldGazeOrientConstraint::WorldGazeOrientConstraint(
     RigidBodyTree *robot, int body, const Vector3d &axis,
-    const Vector4d &quat_des, double conethreshold, double threshold,
-    const Vector2d &tspan)
-    : GazeOrientConstraint(robot, axis, quat_des, conethreshold, threshold,
-                           tspan) {
+    const Vector4d &quat_des, double conethreshold, double threshold)
+    : GazeOrientConstraint(robot, axis, quat_des, conethreshold, threshold) {
   this->body = body;
   this->body_name = robot->getBodyOrFrameName(body);
   this->type = RigidBodyConstraint::WorldGazeOrientConstraintType;
@@ -1179,20 +987,17 @@ void WorldGazeOrientConstraint::evalOrientation(
 
 void WorldGazeOrientConstraint::name(const double *t,
                                      std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    name_str.push_back(this->body_name +
-                       " conic gaze orientation constraint at time" + time_str);
-    name_str.push_back(this->body_name +
-                       " revolute gaze orientation constraint at time" +
-                       time_str);
-  }
+  std::string time_str = this->getTimeString(t);
+  name_str.push_back(this->body_name +
+                     " conic gaze orientation constraint at time" + time_str);
+  name_str.push_back(this->body_name +
+                     " revolute gaze orientation constraint at time" +
+                     time_str);
 }
 
 GazeDirConstraint::GazeDirConstraint(RigidBodyTree *robot, const Vector3d &axis,
-                                     const Vector3d &dir, double conethreshold,
-                                     const Vector2d &tspan)
-    : GazeConstraint(robot, axis, conethreshold, tspan) {
+                                     const Vector3d &dir, double conethreshold)
+    : GazeConstraint(robot, axis, conethreshold) {
   double len_dir = dir.norm();
   if (len_dir <= 0) {
     std::cerr << "dir should be non-zero" << std::endl;
@@ -1206,18 +1011,15 @@ void GazeDirConstraint::bounds(const double *t, VectorXd &lb,
   int num_constraint = this->getNumConstraint(t);
   lb.resize(num_constraint);
   ub.resize(num_constraint);
-  if (this->isTimeValid(t)) {
-    lb[0] = cos(this->conethreshold) - 1.0;
-    ub[0] = 0.0;
-  }
+  lb[0] = cos(this->conethreshold) - 1.0;
+  ub[0] = 0.0;
 }
 
 WorldGazeDirConstraint::WorldGazeDirConstraint(RigidBodyTree *robot, int body,
                                                const Vector3d &axis,
                                                const Vector3d &dir,
-                                               double conethreshold,
-                                               const Vector2d &tspan)
-    : GazeDirConstraint(robot, axis, dir, conethreshold, tspan) {
+                                               double conethreshold)
+    : GazeDirConstraint(robot, axis, dir, conethreshold) {
   this->body = body;
   this->body_name = robot->getBodyOrFrameName(body);
   this->type = RigidBodyConstraint::WorldGazeDirConstraintType;
@@ -1226,39 +1028,32 @@ WorldGazeDirConstraint::WorldGazeDirConstraint(RigidBodyTree *robot, int body,
 void WorldGazeDirConstraint::eval(const double *t,
                                   KinematicsCache<double> &cache, VectorXd &c,
                                   MatrixXd &dc) const {
-  if (this->isTimeValid(t)) {
-    Matrix3Xd body_axis_ends(3, 2);
-    body_axis_ends.col(0).setZero();
-    body_axis_ends.col(1) = this->axis;
-    int nq = this->robot->num_positions;
-    auto axis_pos = robot->transformPoints(cache, body_axis_ends, body, 0);
-    auto daxis_pos =
-        robot->transformPointsJacobian(cache, body_axis_ends, body, 0, true);
-    Vector3d axis_world = axis_pos.col(1) - axis_pos.col(0);
-    MatrixXd daxis_world =
-        daxis_pos.block(3, 0, 3, nq) - daxis_pos.block(0, 0, 3, nq);
-    c.resize(1);
-    c(0) = axis_world.dot(this->dir) - 1.0;
-    dc = this->dir.transpose() * daxis_world;
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
-  }
+  Matrix3Xd body_axis_ends(3, 2);
+  body_axis_ends.col(0).setZero();
+  body_axis_ends.col(1) = this->axis;
+  int nq = this->robot->num_positions;
+  auto axis_pos = robot->transformPoints(cache, body_axis_ends, body, 0);
+  auto daxis_pos =
+      robot->transformPointsJacobian(cache, body_axis_ends, body, 0, true);
+  Vector3d axis_world = axis_pos.col(1) - axis_pos.col(0);
+  MatrixXd daxis_world =
+      daxis_pos.block(3, 0, 3, nq) - daxis_pos.block(0, 0, 3, nq);
+  c.resize(1);
+  c(0) = axis_world.dot(this->dir) - 1.0;
+  dc = this->dir.transpose() * daxis_world;
 }
 
 void WorldGazeDirConstraint::name(const double *t,
                                   std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    name_str.push_back(this->body_name + " conic gaze direction constraint" +
-                       time_str);
-  }
+  std::string time_str = this->getTimeString(t);
+  name_str.push_back(this->body_name + " conic gaze direction constraint" +
+                     time_str);
 }
 
 GazeTargetConstraint::GazeTargetConstraint(
     RigidBodyTree *robot, const Vector3d &axis, const Vector3d &target,
-    const Vector3d &gaze_origin, double conethreshold, const Vector2d &tspan)
-    : GazeConstraint(robot, axis, conethreshold, tspan) {
+    const Vector3d &gaze_origin, double conethreshold)
+    : GazeConstraint(robot, axis, conethreshold) {
   this->target = target;
   this->gaze_origin = gaze_origin;
   this->num_constraint = 1;
@@ -1269,18 +1064,14 @@ void GazeTargetConstraint::bounds(const double *t, VectorXd &lb,
   int num_constraint = this->getNumConstraint(t);
   lb.resize(num_constraint);
   ub.resize(num_constraint);
-  if (this->isTimeValid(t)) {
-    lb[0] = cos(this->conethreshold) - 1.0;
-    ub[0] = 0.0;
-  }
+  lb[0] = cos(this->conethreshold) - 1.0;
+  ub[0] = 0.0;
 }
 
 WorldGazeTargetConstraint::WorldGazeTargetConstraint(
     RigidBodyTree *robot, int body, const Vector3d &axis,
-    const Vector3d &target, const Vector3d &gaze_origin, double conethreshold,
-    const Vector2d &tspan)
-    : GazeTargetConstraint(robot, axis, target, gaze_origin, conethreshold,
-                           tspan) {
+    const Vector3d &target, const Vector3d &gaze_origin, double conethreshold)
+    : GazeTargetConstraint(robot, axis, target, gaze_origin, conethreshold) {
   this->body = body;
   this->body_name = robot->getBodyOrFrameName(body);
   this->type = RigidBodyConstraint::WorldGazeTargetConstraintType;
@@ -1293,50 +1084,40 @@ void WorldGazeTargetConstraint::eval(const double *t,
   int nq = this->robot->num_positions;
   c.resize(num_constraint);
   dc.resize(num_constraint, nq);
-  if (this->isTimeValid(t)) {
-    Matrix3Xd body_axis_ends(3, 2);
-    body_axis_ends.col(0) = this->gaze_origin;
-    body_axis_ends.col(1) = this->gaze_origin + this->axis;
-    int nq = this->robot->num_positions;
-    auto axis_ends = robot->transformPoints(cache, body_axis_ends, body, 0);
-    auto daxis_ends =
-        robot->transformPointsJacobian(cache, body_axis_ends, body, 0, true);
+  Matrix3Xd body_axis_ends(3, 2);
+  body_axis_ends.col(0) = this->gaze_origin;
+  body_axis_ends.col(1) = this->gaze_origin + this->axis;
+  auto axis_ends = robot->transformPoints(cache, body_axis_ends, body, 0);
+  auto daxis_ends =
+      robot->transformPointsJacobian(cache, body_axis_ends, body, 0, true);
 
-    Vector3d world_axis = axis_ends.col(1) - axis_ends.col(0);
-    MatrixXd dworld_axis =
-        daxis_ends.block(3, 0, 3, nq) - daxis_ends.block(0, 0, 3, nq);
-    Vector3d dir = this->target - axis_ends.col(0);
-    MatrixXd ddir = -daxis_ends.block(0, 0, 3, nq);
-    double dir_norm = dir.norm();
-    Vector3d dir_normalized = dir / dir_norm;
-    MatrixXd ddir_normalized = (MatrixXd::Identity(3, 3) * dir_norm * dir_norm -
-                                dir * dir.transpose()) /
-                               (std::pow(dir_norm, 3)) * ddir;
-    c(0) = dir_normalized.dot(world_axis) - 1.0;
-    dc = dir_normalized.transpose() * dworld_axis +
-         world_axis.transpose() * ddir_normalized;
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
-  }
+  Vector3d world_axis = axis_ends.col(1) - axis_ends.col(0);
+  MatrixXd dworld_axis =
+      daxis_ends.block(3, 0, 3, nq) - daxis_ends.block(0, 0, 3, nq);
+  Vector3d dir = this->target - axis_ends.col(0);
+  MatrixXd ddir = -daxis_ends.block(0, 0, 3, nq);
+  double dir_norm = dir.norm();
+  Vector3d dir_normalized = dir / dir_norm;
+  MatrixXd ddir_normalized = (MatrixXd::Identity(3, 3) * dir_norm * dir_norm -
+                              dir * dir.transpose()) /
+      (std::pow(dir_norm, 3)) * ddir;
+  c(0) = dir_normalized.dot(world_axis) - 1.0;
+  dc = dir_normalized.transpose() * dworld_axis +
+      world_axis.transpose() * ddir_normalized;
 }
 
 void WorldGazeTargetConstraint::name(const double *t,
                                      std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    name_str.push_back(this->body_name + " conic gaze target constraint" +
-                       time_str);
-  }
+  std::string time_str = this->getTimeString(t);
+  name_str.push_back(this->body_name + " conic gaze target constraint" +
+                     time_str);
 }
 
 RelativeGazeTargetConstraint::RelativeGazeTargetConstraint(
     RigidBodyTree *robot, int bodyA_idx, int bodyB_idx,
     const Eigen::Vector3d &axis, const Vector3d &target,
-    const Vector3d &gaze_origin, double conethreshold,
-    const Eigen::Vector2d &tspan)
-    : GazeTargetConstraint(robot, axis, target, gaze_origin, conethreshold,
-                           tspan) {
+    const Vector3d &gaze_origin, double conethreshold)
+    : GazeTargetConstraint(robot, axis, target, gaze_origin, conethreshold) {
   this->bodyA_idx = bodyA_idx;
   this->bodyB_idx = bodyB_idx;
   this->bodyA_name = this->robot->bodies[this->bodyA_idx]->linkname;
@@ -1347,61 +1128,54 @@ RelativeGazeTargetConstraint::RelativeGazeTargetConstraint(
 void RelativeGazeTargetConstraint::eval(const double *t,
                                         KinematicsCache<double> &cache,
                                         VectorXd &c, MatrixXd &dc) const {
-  if (this->isTimeValid(t)) {
-    int nq = this->robot->num_positions;
-    auto target_pos = robot->transformPoints(cache, target, bodyB_idx, 0);
-    auto dtarget_pos =
-        robot->transformPointsJacobian(cache, target, bodyB_idx, 0, true);
+  int nq = this->robot->num_positions;
+  auto target_pos = robot->transformPoints(cache, target, bodyB_idx, 0);
+  auto dtarget_pos =
+      robot->transformPointsJacobian(cache, target, bodyB_idx, 0, true);
 
-    auto origin_pos = robot->transformPoints(cache, gaze_origin, bodyA_idx, 0);
-    auto dorigin_pos =
-        robot->transformPointsJacobian(cache, gaze_origin, bodyA_idx, 0, true);
+  auto origin_pos = robot->transformPoints(cache, gaze_origin, bodyA_idx, 0);
+  auto dorigin_pos =
+      robot->transformPointsJacobian(cache, gaze_origin, bodyA_idx, 0, true);
 
-    auto axis_pos = robot->transformPoints(cache, axis, bodyA_idx, 0);
-    auto daxis_pos =
-        robot->transformPointsJacobian(cache, axis, bodyA_idx, 0, true);
+  auto axis_pos = robot->transformPoints(cache, axis, bodyA_idx, 0);
+  auto daxis_pos =
+      robot->transformPointsJacobian(cache, axis, bodyA_idx, 0, true);
 
-    Vector3d axis_origin = Vector3d::Zero();
-    auto axis_origin_pos =
-        robot->transformPoints(cache, axis_origin, bodyA_idx, 0);
-    auto daxis_origin_pos =
-        robot->transformPointsJacobian(cache, axis_origin, bodyA_idx, 0, true);
+  Vector3d axis_origin = Vector3d::Zero();
+  auto axis_origin_pos =
+      robot->transformPoints(cache, axis_origin, bodyA_idx, 0);
+  auto daxis_origin_pos =
+      robot->transformPointsJacobian(cache, axis_origin, bodyA_idx, 0, true);
 
-    axis_pos -= axis_origin_pos;
-    daxis_pos -= daxis_origin_pos;
+  axis_pos -= axis_origin_pos;
+  daxis_pos -= daxis_origin_pos;
 
-    Vector3d origin_to_target = target_pos - origin_pos;
-    MatrixXd dorigin_to_target = dtarget_pos - dorigin_pos;
-    double origin_to_target_norm = origin_to_target.norm();
-    c.resize(1);
-    c(0) = origin_to_target.dot(axis_pos) / origin_to_target_norm - 1.0;
-    dc.resize(1, nq);
-    MatrixXd dcdorigin_to_target =
-        (axis_pos.transpose() * origin_to_target_norm -
-         axis_pos.dot(origin_to_target) / origin_to_target_norm *
-             origin_to_target.transpose()) /
-        (origin_to_target_norm * origin_to_target_norm);
-    MatrixXd dcdaxis_pos = origin_to_target.transpose() / origin_to_target_norm;
-    dc = dcdorigin_to_target * dorigin_to_target + dcdaxis_pos * daxis_pos;
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
-  }
+  Vector3d origin_to_target = target_pos - origin_pos;
+  MatrixXd dorigin_to_target = dtarget_pos - dorigin_pos;
+  double origin_to_target_norm = origin_to_target.norm();
+  c.resize(1);
+  c(0) = origin_to_target.dot(axis_pos) / origin_to_target_norm - 1.0;
+  dc.resize(1, nq);
+  MatrixXd dcdorigin_to_target =
+      (axis_pos.transpose() * origin_to_target_norm -
+       axis_pos.dot(origin_to_target) / origin_to_target_norm *
+       origin_to_target.transpose()) /
+      (origin_to_target_norm * origin_to_target_norm);
+  MatrixXd dcdaxis_pos = origin_to_target.transpose() / origin_to_target_norm;
+  dc = dcdorigin_to_target * dorigin_to_target + dcdaxis_pos * daxis_pos;
 }
 
 void RelativeGazeTargetConstraint::name(
     const double *t, std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    name_str.push_back(this->bodyA_name + " relative to " + this->bodyB_name +
-                       " conic gaze constraint" + time_str);
-  }
+  std::string time_str = this->getTimeString(t);
+  name_str.push_back(this->bodyA_name + " relative to " + this->bodyB_name +
+                     " conic gaze constraint" + time_str);
 }
 
 RelativeGazeDirConstraint::RelativeGazeDirConstraint(
     RigidBodyTree *robot, int bodyA_idx, int bodyB_idx, const Vector3d &axis,
-    const Vector3d &dir, double conethreshold, const Eigen::Vector2d &tspan)
-    : GazeDirConstraint(robot, axis, dir, conethreshold, tspan),
+    const Vector3d &dir, double conethreshold)
+    : GazeDirConstraint(robot, axis, dir, conethreshold),
       bodyA_idx(bodyA_idx),
       bodyB_idx(bodyB_idx) {
   this->bodyA_name = this->robot->bodies[this->bodyA_idx]->linkname;
@@ -1412,53 +1186,45 @@ RelativeGazeDirConstraint::RelativeGazeDirConstraint(
 void RelativeGazeDirConstraint::eval(const double *t,
                                      KinematicsCache<double> &cache,
                                      VectorXd &c, MatrixXd &dc) const {
-  if (this->isTimeValid(t)) {
-    Matrix3Xd body_axis_ends(3, 2);
-    body_axis_ends.block(0, 0, 3, 1) = MatrixXd::Zero(3, 1);
-    body_axis_ends.block(0, 1, 3, 1) = this->axis;
-    Matrix3Xd body_dir_ends(3, 2);
-    body_dir_ends.block(0, 0, 3, 1) = MatrixXd::Zero(3, 1);
-    body_dir_ends.block(0, 1, 3, 1) = this->dir;
-    int nq = this->robot->num_positions;
+  Matrix3Xd body_axis_ends(3, 2);
+  body_axis_ends.block(0, 0, 3, 1) = MatrixXd::Zero(3, 1);
+  body_axis_ends.block(0, 1, 3, 1) = this->axis;
+  Matrix3Xd body_dir_ends(3, 2);
+  body_dir_ends.block(0, 0, 3, 1) = MatrixXd::Zero(3, 1);
+  body_dir_ends.block(0, 1, 3, 1) = this->dir;
+  int nq = this->robot->num_positions;
 
-    auto axis_pos = robot->transformPoints(cache, body_axis_ends, bodyA_idx, 0);
-    auto daxis_pos = robot->transformPointsJacobian(cache, body_axis_ends,
-                                                    bodyA_idx, 0, true);
+  auto axis_pos = robot->transformPoints(cache, body_axis_ends, bodyA_idx, 0);
+  auto daxis_pos = robot->transformPointsJacobian(cache, body_axis_ends,
+                                                  bodyA_idx, 0, true);
 
-    auto dir_pos = robot->transformPoints(cache, body_dir_ends, bodyB_idx, 0);
-    auto ddir_pos = robot->transformPointsJacobian(cache, body_dir_ends,
-                                                   bodyB_idx, 0, true);
+  auto dir_pos = robot->transformPoints(cache, body_dir_ends, bodyB_idx, 0);
+  auto ddir_pos = robot->transformPointsJacobian(cache, body_dir_ends,
+                                                 bodyB_idx, 0, true);
 
-    Vector3d axis_world = axis_pos.col(1) - axis_pos.col(0);
-    MatrixXd daxis_world =
-        daxis_pos.block(3, 0, 3, nq) - daxis_pos.block(0, 0, 3, nq);
-    Vector3d dir_world = dir_pos.col(1) - dir_pos.col(0);
-    MatrixXd ddir_world =
-        ddir_pos.block(3, 0, 3, nq) - ddir_pos.block(0, 0, 3, nq);
-    c.resize(1);
-    c(0) = axis_world.dot(dir_world) - 1.0;
-    dc = dir_world.transpose() * daxis_world +
-         axis_world.transpose() * ddir_world;
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
-  }
+  Vector3d axis_world = axis_pos.col(1) - axis_pos.col(0);
+  MatrixXd daxis_world =
+      daxis_pos.block(3, 0, 3, nq) - daxis_pos.block(0, 0, 3, nq);
+  Vector3d dir_world = dir_pos.col(1) - dir_pos.col(0);
+  MatrixXd ddir_world =
+      ddir_pos.block(3, 0, 3, nq) - ddir_pos.block(0, 0, 3, nq);
+  c.resize(1);
+  c(0) = axis_world.dot(dir_world) - 1.0;
+  dc = dir_world.transpose() * daxis_world +
+      axis_world.transpose() * ddir_world;
 }
 
 void RelativeGazeDirConstraint::name(const double *t,
                                      std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    name_str.push_back(this->bodyA_name + " relative to " + this->bodyB_name +
-                       " conic gaze constraint" + time_str);
-  }
+  std::string time_str = this->getTimeString(t);
+  name_str.push_back(this->bodyA_name + " relative to " + this->bodyB_name +
+                     " conic gaze constraint" + time_str);
 }
 
 Point2PointDistanceConstraint::Point2PointDistanceConstraint(
     RigidBodyTree *robot, int bodyA, int bodyB, const Matrix3Xd &ptA,
-    const Matrix3Xd &ptB, const VectorXd &dist_lb, const VectorXd &dist_ub,
-    const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan) {
+    const Matrix3Xd &ptB, const VectorXd &dist_lb, const VectorXd &dist_ub)
+    : SingleTimeKinematicConstraint(robot) {
   this->bodyA = bodyA;
   this->bodyB = bodyB;
   this->ptA = ptA;
@@ -1472,84 +1238,71 @@ Point2PointDistanceConstraint::Point2PointDistanceConstraint(
 void Point2PointDistanceConstraint::eval(const double *t,
                                          KinematicsCache<double> &cache,
                                          VectorXd &c, MatrixXd &dc) const {
-  if (this->isTimeValid(t)) {
-    int num_cnst = this->getNumConstraint(t);
-    MatrixXd posA(3, this->ptA.cols());
-    MatrixXd dposA(3 * this->ptA.cols(), this->robot->num_positions);
-    if (this->bodyA != 0) {
-      posA = robot->transformPoints(cache, ptA, bodyA, 0);
-      dposA = robot->transformPointsJacobian(cache, ptA, bodyA, 0, true);
-    } else {
-      posA = this->ptA.block(0, 0, 3, this->ptA.cols());
-      dposA = MatrixXd::Zero(3 * this->ptA.cols(), this->robot->num_positions);
-    }
-    MatrixXd posB(3, this->ptB.cols());
-    MatrixXd dposB(3 * this->ptB.cols(), this->robot->num_positions);
-    if (this->bodyB != 0) {
-      posB = robot->transformPoints(cache, ptB, bodyB, 0);
-      dposB = robot->transformPointsJacobian(cache, ptB, bodyB, 0, true);
-    } else {
-      posB = this->ptB.block(0, 0, 3, this->ptB.cols());
-      dposB = MatrixXd::Zero(3 * this->ptB.cols(), this->robot->num_positions);
-    }
-    MatrixXd d = posA - posB;
-    MatrixXd dd = dposA - dposB;
-    MatrixXd tmp1 = d.cwiseProduct(d);
-    MatrixXd tmp2 = tmp1.colwise().sum();
-    c.resize(num_cnst, 1);
-    c = tmp2.transpose();
-    dc.resize(num_cnst, this->robot->num_positions);
-    for (int i = 0; i < num_cnst; i++) {
-      dc.row(i) = 2 * d.col(i).transpose() *
-                  dd.block(3 * i, 0, 3, this->robot->num_positions);
-    }
+  int num_cnst = this->getNumConstraint(t);
+  MatrixXd posA(3, this->ptA.cols());
+  MatrixXd dposA(3 * this->ptA.cols(), this->robot->num_positions);
+  if (this->bodyA != 0) {
+    posA = robot->transformPoints(cache, ptA, bodyA, 0);
+    dposA = robot->transformPointsJacobian(cache, ptA, bodyA, 0, true);
   } else {
-    c.resize(0);
-    dc.resize(0, 0);
+    posA = this->ptA.block(0, 0, 3, this->ptA.cols());
+    dposA = MatrixXd::Zero(3 * this->ptA.cols(), this->robot->num_positions);
+  }
+  MatrixXd posB(3, this->ptB.cols());
+  MatrixXd dposB(3 * this->ptB.cols(), this->robot->num_positions);
+  if (this->bodyB != 0) {
+    posB = robot->transformPoints(cache, ptB, bodyB, 0);
+    dposB = robot->transformPointsJacobian(cache, ptB, bodyB, 0, true);
+  } else {
+    posB = this->ptB.block(0, 0, 3, this->ptB.cols());
+    dposB = MatrixXd::Zero(3 * this->ptB.cols(), this->robot->num_positions);
+  }
+  MatrixXd d = posA - posB;
+  MatrixXd dd = dposA - dposB;
+  MatrixXd tmp1 = d.cwiseProduct(d);
+  MatrixXd tmp2 = tmp1.colwise().sum();
+  c.resize(num_cnst, 1);
+  c = tmp2.transpose();
+  dc.resize(num_cnst, this->robot->num_positions);
+  for (int i = 0; i < num_cnst; i++) {
+    dc.row(i) = 2 * d.col(i).transpose() *
+        dd.block(3 * i, 0, 3, this->robot->num_positions);
   }
 }
 
 void Point2PointDistanceConstraint::name(
     const double *t, std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    int num_cnst = this->getNumConstraint(t);
-    std::string time_str = this->getTimeString(t);
-    for (int i = 0; i < num_cnst; i++) {
-      std::string bodyA_name;
-      if (this->bodyA != 0) {
-        bodyA_name = this->robot->bodies[bodyA]->linkname;
-      } else {
-        bodyA_name = "World";
-      }
-      std::string bodyB_name;
-      if (this->bodyB != 0) {
-        bodyB_name = this->robot->bodies[bodyB]->linkname;
-      } else {
-        bodyB_name = "World";
-      }
-      name_str.push_back("Distance from " + bodyA_name + " pt " +
-                         std::to_string(i) + " to " + bodyB_name + " pt " +
-                         std::to_string(i) + time_str);
+  int num_cnst = this->getNumConstraint(t);
+  std::string time_str = this->getTimeString(t);
+  for (int i = 0; i < num_cnst; i++) {
+    std::string bodyA_name;
+    if (this->bodyA != 0) {
+      bodyA_name = this->robot->bodies[bodyA]->linkname;
+    } else {
+      bodyA_name = "World";
     }
+    std::string bodyB_name;
+    if (this->bodyB != 0) {
+      bodyB_name = this->robot->bodies[bodyB]->linkname;
+    } else {
+      bodyB_name = "World";
+    }
+    name_str.push_back("Distance from " + bodyA_name + " pt " +
+                       std::to_string(i) + " to " + bodyB_name + " pt " +
+                       std::to_string(i) + time_str);
   }
 }
 
 void Point2PointDistanceConstraint::bounds(const double *t, VectorXd &lb,
                                            VectorXd &ub) const {
-  if (this->isTimeValid(t)) {
-    lb = this->dist_lb.cwiseProduct(this->dist_lb);
-    ub = this->dist_ub.cwiseProduct(this->dist_ub);
-  } else {
-    lb.resize(0);
-    ub.resize(0);
-  }
+  lb = this->dist_lb.cwiseProduct(this->dist_lb);
+  ub = this->dist_ub.cwiseProduct(this->dist_ub);
 }
 
 Point2LineSegDistConstraint::Point2LineSegDistConstraint(
     RigidBodyTree *robot, int pt_body, const Vector3d &pt, int line_body,
-    const Matrix<double, 3, 2> &line_ends, double dist_lb, double dist_ub,
-    const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan) {
+    const Matrix<double, 3, 2> &line_ends, double dist_lb, double dist_ub)
+    : SingleTimeKinematicConstraint(robot) {
   this->pt_body = pt_body;
   this->pt = pt;
   this->line_body = line_body;
@@ -1560,77 +1313,65 @@ Point2LineSegDistConstraint::Point2LineSegDistConstraint(
   this->type = RigidBodyConstraint::Point2LineSegDistConstraintType;
 }
 
-void Point2LineSegDistConstraint::eval(const double *t,
+void Point2LineSegDistConstraint::eval(const double *,
                                        KinematicsCache<double> &cache,
                                        VectorXd &c, MatrixXd &dc) const {
-  if (this->isTimeValid(t)) {
-    int nq = this->robot->num_positions;
+  int nq = this->robot->num_positions;
 
-    auto pt_pos = robot->transformPoints(cache, pt, pt_body, 0);
-    auto J_pt = robot->transformPointsJacobian(cache, pt, pt_body, 0, true);
+  auto pt_pos = robot->transformPoints(cache, pt, pt_body, 0);
+  auto J_pt = robot->transformPointsJacobian(cache, pt, pt_body, 0, true);
 
-    auto line_pos = robot->transformPoints(cache, line_ends, line_body, 0);
-    auto J_line =
-        robot->transformPointsJacobian(cache, line_ends, line_body, 0, true);
+  auto line_pos = robot->transformPoints(cache, line_ends, line_body, 0);
+  auto J_line =
+      robot->transformPointsJacobian(cache, line_ends, line_body, 0, true);
 
-    Vector3d x0 = pt_pos;
-    Vector3d x1 = line_pos.col(0);
-    Vector3d x2 = line_pos.col(1);
-    Vector3d x21 = x2 - x1;
-    MatrixXd J21 = J_line.block(3, 0, 3, nq) - J_line.block(0, 0, 3, nq);
-    Vector3d x10 = x1 - x0;
-    MatrixXd J10 = J_line.block(0, 0, 3, nq) - J_pt;
-    double x21_square = x21.squaredNorm();
-    double t = -x10.dot(x21) / x21_square;
-    MatrixXd dtdx10 = -x21.transpose() / x21_square;
-    MatrixXd dtdx21 =
-        -(x10.transpose() * x21_square - x10.dot(x21) * 2.0 * x21.transpose()) /
-        (x21_square * x21_square);
-    MatrixXd dtdq = dtdx10 * J10 + dtdx21 * J21;
-    Vector3d h = x0 - (x1 + x21 * t);
-    MatrixXd dhdq = J_pt - (J_line.block(0, 0, 3, nq) + J21 * t + x21 * dtdq);
-    double d = h.squaredNorm();
-    MatrixXd dddq = 2 * h.transpose() * dhdq;
-    c.resize(2);
-    dc.resize(2, nq);
-    c << d, t;
-    dc.block(0, 0, 1, nq) = dddq;
-    dc.block(1, 0, 1, nq) = dtdq;
-  } else {
-    c.resize(0);
-    dc.resize(0, 0);
-  }
+  Vector3d x0 = pt_pos;
+  Vector3d x1 = line_pos.col(0);
+  Vector3d x2 = line_pos.col(1);
+  Vector3d x21 = x2 - x1;
+  MatrixXd J21 = J_line.block(3, 0, 3, nq) - J_line.block(0, 0, 3, nq);
+  Vector3d x10 = x1 - x0;
+  MatrixXd J10 = J_line.block(0, 0, 3, nq) - J_pt;
+  double x21_square = x21.squaredNorm();
+  double t = -x10.dot(x21) / x21_square;
+  MatrixXd dtdx10 = -x21.transpose() / x21_square;
+  MatrixXd dtdx21 =
+      -(x10.transpose() * x21_square - x10.dot(x21) * 2.0 * x21.transpose()) /
+      (x21_square * x21_square);
+  MatrixXd dtdq = dtdx10 * J10 + dtdx21 * J21;
+  Vector3d h = x0 - (x1 + x21 * t);
+  MatrixXd dhdq = J_pt - (J_line.block(0, 0, 3, nq) + J21 * t + x21 * dtdq);
+  double d = h.squaredNorm();
+  MatrixXd dddq = 2 * h.transpose() * dhdq;
+  c.resize(2);
+  dc.resize(2, nq);
+  c << d, t;
+  dc.block(0, 0, 1, nq) = dddq;
+  dc.block(1, 0, 1, nq) = dtdq;
 }
 
 void Point2LineSegDistConstraint::bounds(const double *t, VectorXd &lb,
                                          VectorXd &ub) const {
-  if (this->isTimeValid(t)) {
-    lb.resize(2);
-    ub.resize(2);
-    lb << this->dist_lb * this->dist_lb, 0.0;
-    ub << this->dist_ub * this->dist_ub, 1.0;
-  } else {
-    lb.resize(0);
-    ub.resize(0);
-  }
+  lb.resize(2);
+  ub.resize(2);
+  lb << this->dist_lb * this->dist_lb, 0.0;
+  ub << this->dist_ub * this->dist_ub, 1.0;
 }
 
 void Point2LineSegDistConstraint::name(
     const double *t, std::vector<std::string> &name_str) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    name_str.push_back(
-        "Distance from " + this->robot->bodies[this->pt_body]->linkname +
-        " pt to a line on " + this->robot->bodies[this->line_body]->linkname +
-        time_str);
-    name_str.push_back("Fraction of point projection onto line segment " +
-                       time_str);
-  }
+  std::string time_str = this->getTimeString(t);
+  name_str.push_back(
+      "Distance from " + this->robot->bodies[this->pt_body]->linkname +
+      " pt to a line on " + this->robot->bodies[this->line_body]->linkname +
+      time_str);
+  name_str.push_back("Fraction of point projection onto line segment " +
+                     time_str);
 }
 
 WorldFixedPositionConstraint::WorldFixedPositionConstraint(
-    RigidBodyTree *robot, int body, const Matrix3Xd &pts, const Vector2d &tspan)
-    : MultipleTimeKinematicConstraint(robot, tspan) {
+    RigidBodyTree *robot, int body, const Matrix3Xd &pts)
+    : MultipleTimeKinematicConstraint(robot) {
   this->body = body;
   if (pts.rows() != 3) {
     std::cerr << "pts must have 3 rows" << std::endl;
@@ -1642,7 +1383,7 @@ WorldFixedPositionConstraint::WorldFixedPositionConstraint(
 
 int WorldFixedPositionConstraint::getNumConstraint(const double *t,
                                                    int n_breaks) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     return static_cast<int>(this->pts.cols());
   } else {
@@ -1695,7 +1436,7 @@ void WorldFixedPositionConstraint::eval_valid(const double *valid_t,
 
 void WorldFixedPositionConstraint::bounds(const double *t, int n_breaks,
                                           VectorXd &lb, VectorXd &ub) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     int n_pts = static_cast<int>(this->pts.cols());
     lb.resize(n_pts, 1);
@@ -1710,7 +1451,7 @@ void WorldFixedPositionConstraint::bounds(const double *t, int n_breaks,
 
 void WorldFixedPositionConstraint::name(
     const double *t, int n_breaks, std::vector<std::string> &name_str) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     int n_pts = static_cast<int>(this->pts.cols());
     for (int i = 0; i < n_pts; i++) {
@@ -1721,9 +1462,8 @@ void WorldFixedPositionConstraint::name(
 }
 
 WorldFixedOrientConstraint::WorldFixedOrientConstraint(RigidBodyTree *robot,
-                                                       int body,
-                                                       const Vector2d &tspan)
-    : MultipleTimeKinematicConstraint(robot, tspan) {
+                                                       int body)
+    : MultipleTimeKinematicConstraint(robot) {
   this->body = body;
   this->body_name = robot->getBodyOrFrameName(body);
   this->type = RigidBodyConstraint::WorldFixedOrientConstraintType;
@@ -1731,7 +1471,7 @@ WorldFixedOrientConstraint::WorldFixedOrientConstraint(RigidBodyTree *robot,
 
 int WorldFixedOrientConstraint::getNumConstraint(const double *t,
                                                  int n_breaks) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2)
     return 1;
   else
@@ -1777,7 +1517,7 @@ void WorldFixedOrientConstraint::eval_valid(const double *valid_t,
 
 void WorldFixedOrientConstraint::bounds(const double *t, int n_breaks,
                                         VectorXd &lb, VectorXd &ub) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     lb.resize(1);
     ub.resize(1);
@@ -1791,7 +1531,7 @@ void WorldFixedOrientConstraint::bounds(const double *t, int n_breaks,
 
 void WorldFixedOrientConstraint::name(
     const double *t, int n_breaks, std::vector<std::string> &name_str) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     name_str.push_back("World fixed orientation constraint for " +
                        this->body_name);
@@ -1799,8 +1539,8 @@ void WorldFixedOrientConstraint::name(
 }
 
 WorldFixedBodyPoseConstraint::WorldFixedBodyPoseConstraint(
-    RigidBodyTree *robot, int body, const Vector2d &tspan)
-    : MultipleTimeKinematicConstraint(robot, tspan) {
+    RigidBodyTree *robot, int body)
+    : MultipleTimeKinematicConstraint(robot) {
   this->body = body;
   this->body_name = robot->getBodyOrFrameName(body);
   this->type = RigidBodyConstraint::WorldFixedBodyPoseConstraintType;
@@ -1808,7 +1548,7 @@ WorldFixedBodyPoseConstraint::WorldFixedBodyPoseConstraint(
 
 int WorldFixedBodyPoseConstraint::getNumConstraint(const double *t,
                                                    int n_breaks) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     return 2;
   } else {
@@ -1869,7 +1609,7 @@ void WorldFixedBodyPoseConstraint::eval_valid(const double *valid_t,
 
 void WorldFixedBodyPoseConstraint::bounds(const double *t, int n_breaks,
                                           VectorXd &lb, VectorXd &ub) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     lb.resize(2);
     ub.resize(2);
@@ -1883,7 +1623,7 @@ void WorldFixedBodyPoseConstraint::bounds(const double *t, int n_breaks,
 
 void WorldFixedBodyPoseConstraint::name(
     const double *t, int n_breaks, std::vector<std::string> &name_str) const {
-  int num_valid_t = this->numValidTime(t, n_breaks);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     name_str.push_back("World fixed body pose constraint for " +
                        this->body_name + " position");
@@ -1895,8 +1635,8 @@ void WorldFixedBodyPoseConstraint::name(
 AllBodiesClosestDistanceConstraint::AllBodiesClosestDistanceConstraint(
     RigidBodyTree *robot, double lb, double ub,
     const std::vector<int> &active_bodies_idx,
-    const std::set<std::string> &active_group_names, const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan),
+    const std::set<std::string> &active_group_names)
+    : SingleTimeKinematicConstraint(robot),
       lb(lb),
       ub(ub),
       active_bodies_idx(active_bodies_idx),
@@ -1947,41 +1687,36 @@ void AllBodiesClosestDistanceConstraint::updateRobot(RigidBodyTree *robot) {
 void AllBodiesClosestDistanceConstraint::eval(const double *t,
                                               KinematicsCache<double> &cache,
                                               VectorXd &c, MatrixXd &dc) const {
-  if (this->isTimeValid(t)) {
-    Matrix3Xd xA, xB, normal;
-    std::vector<int> idxA;
-    std::vector<int> idxB;
+  Matrix3Xd xA, xB, normal;
+  std::vector<int> idxA;
+  std::vector<int> idxB;
 
-    if (active_bodies_idx.size() > 0) {
-      if (active_group_names.size() > 0) {
-        robot->collisionDetect(cache, c, normal, xA, xB, idxA, idxB,
-                               active_bodies_idx, active_group_names);
-      } else {
-        robot->collisionDetect(cache, c, normal, xA, xB, idxA, idxB,
-                               active_bodies_idx);
-      }
+  if (active_bodies_idx.size() > 0) {
+    if (active_group_names.size() > 0) {
+      robot->collisionDetect(cache, c, normal, xA, xB, idxA, idxB,
+                             active_bodies_idx, active_group_names);
     } else {
-      if (active_group_names.size() > 0) {
-        robot->collisionDetect(cache, c, normal, xA, xB, idxA, idxB,
-                               active_group_names);
-      } else {
-        robot->collisionDetect(cache, c, normal, xA, xB, idxA, idxB);
-      }
-    }
-    int num_pts = static_cast<int>(xA.cols());
-    dc = MatrixXd::Zero(num_pts, robot->num_positions);
-    MatrixXd JA = MatrixXd::Zero(3, robot->num_positions);
-    MatrixXd JB = MatrixXd::Zero(3, robot->num_positions);
-    for (int i = 0; i < num_pts; ++i) {
-      JA =
-          robot->transformPointsJacobian(cache, xA.col(i), idxA.at(i), 0, true);
-      JB =
-          robot->transformPointsJacobian(cache, xB.col(i), idxB.at(i), 0, true);
-      dc.row(i) = normal.col(i).transpose() * (JA - JB);
+      robot->collisionDetect(cache, c, normal, xA, xB, idxA, idxB,
+                             active_bodies_idx);
     }
   } else {
-    c.resize(0);
-    dc.resize(0, 0);
+    if (active_group_names.size() > 0) {
+      robot->collisionDetect(cache, c, normal, xA, xB, idxA, idxB,
+                             active_group_names);
+    } else {
+      robot->collisionDetect(cache, c, normal, xA, xB, idxA, idxB);
+    }
+  }
+  int num_pts = static_cast<int>(xA.cols());
+  dc = MatrixXd::Zero(num_pts, robot->num_positions);
+  MatrixXd JA = MatrixXd::Zero(3, robot->num_positions);
+  MatrixXd JB = MatrixXd::Zero(3, robot->num_positions);
+  for (int i = 0; i < num_pts; ++i) {
+    JA =
+        robot->transformPointsJacobian(cache, xA.col(i), idxA.at(i), 0, true);
+    JB =
+        robot->transformPointsJacobian(cache, xB.col(i), idxB.at(i), 0, true);
+    dc.row(i) = normal.col(i).transpose() * (JA - JB);
   }
 }
 
@@ -1989,30 +1724,24 @@ void AllBodiesClosestDistanceConstraint::bounds(const double *t, VectorXd &lb,
                                                 VectorXd &ub) const {
   lb.resize(num_constraint);
   ub.resize(num_constraint);
-  if (this->isTimeValid(t)) {
-    lb = VectorXd::Constant(num_constraint, this->lb);
-    ub = VectorXd::Constant(num_constraint, this->ub);
-  }
+  lb = VectorXd::Constant(num_constraint, this->lb);
+  ub = VectorXd::Constant(num_constraint, this->ub);
 }
 
 void AllBodiesClosestDistanceConstraint::name(
     const double *t, std::vector<std::string> &name) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    std::string cnst_name = "All-to-all closest distance constraint" + time_str;
-    for (int i = 0; i < this->num_constraint; i++) {
-      name.push_back(cnst_name);
-    }
-  } else {
-    name.push_back("");
+  std::string time_str = this->getTimeString(t);
+  std::string cnst_name = "All-to-all closest distance constraint" + time_str;
+  for (int i = 0; i < this->num_constraint; i++) {
+    name.push_back(cnst_name);
   }
 }
 
 MinDistanceConstraint::MinDistanceConstraint(
     RigidBodyTree *robot, double min_distance,
     const std::vector<int> &active_bodies_idx,
-    const std::set<std::string> &active_group_names, const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan),
+    const std::set<std::string> &active_group_names)
+    : SingleTimeKinematicConstraint(robot),
       min_distance(min_distance),
       active_bodies_idx(active_bodies_idx),
       active_group_names(active_group_names) {
@@ -2026,117 +1755,112 @@ void MinDistanceConstraint::eval(const double *t,
   // DEBUG
   // std::cout << "MinDistanceConstraint::eval: START" << std::endl;
   // END_DEBUG
-  if (this->isTimeValid(t)) {
-    VectorXd dist, scaled_dist, pairwise_costs;
-    Matrix3Xd xA, xB, normal;
-    MatrixXd ddist_dq, dscaled_dist_ddist, dpairwise_costs_dscaled_dist;
-    std::vector<int> idxA;
-    std::vector<int> idxB;
+  VectorXd dist, scaled_dist, pairwise_costs;
+  Matrix3Xd xA, xB, normal;
+  MatrixXd ddist_dq, dscaled_dist_ddist, dpairwise_costs_dscaled_dist;
+  std::vector<int> idxA;
+  std::vector<int> idxB;
 
-    if (active_bodies_idx.size() > 0) {
-      if (active_group_names.size() > 0) {
-        robot->collisionDetect(cache, dist, normal, xA, xB, idxA, idxB,
-                               active_bodies_idx, active_group_names);
-      } else {
-        robot->collisionDetect(cache, dist, normal, xA, xB, idxA, idxB,
-                               active_bodies_idx);
-      }
+  if (active_bodies_idx.size() > 0) {
+    if (active_group_names.size() > 0) {
+      robot->collisionDetect(cache, dist, normal, xA, xB, idxA, idxB,
+                             active_bodies_idx, active_group_names);
     } else {
-      if (active_group_names.size() > 0) {
-        robot->collisionDetect(cache, dist, normal, xA, xB, idxA, idxB,
-                               active_group_names);
-      } else {
-        robot->collisionDetect(cache, dist, normal, xA, xB, idxA, idxB);
-      }
+      robot->collisionDetect(cache, dist, normal, xA, xB, idxA, idxB,
+                             active_bodies_idx);
     }
-
-    int num_pts = static_cast<int>(xA.cols());
-    ddist_dq = MatrixXd::Zero(num_pts, robot->num_positions);
-
-    // Compute Jacobian of closest distance vector
-    // DEBUG
-    // std:: cout << "IntegratedClosestDistanceConstraint::eval_valid: Compute
-    // distance Jacobian" << std::endl;
-    // END_DEBUG
-    scaleDistance(dist, scaled_dist, dscaled_dist_ddist);
-    penalty(scaled_dist, pairwise_costs, dpairwise_costs_dscaled_dist);
-
-    std::vector<std::vector<int>> orig_idx_of_pt_on_bodyA(robot->bodies.size());
-    std::vector<std::vector<int>> orig_idx_of_pt_on_bodyB(robot->bodies.size());
-    for (int k = 0; k < num_pts; ++k) {
-      // DEBUG
-      // std::cout << "MinDistanceConstraint::eval: First loop: " << k <<
-      // std::endl;
-      // std::cout << "pairwise_costs.size() = " << pairwise_costs.size() <<
-      // std::endl;
-      // std::cout << "pairwise_costs.size() = " << pairwise_costs.size() <<
-      // std::endl;
-      // END_DEBUG
-      if (pairwise_costs(k) > 0) {
-        orig_idx_of_pt_on_bodyA.at(idxA.at(k)).push_back(k);
-        orig_idx_of_pt_on_bodyB.at(idxB.at(k)).push_back(k);
-      }
-    }
-    for (int k = 0; k < robot->bodies.size(); ++k) {
-      // DEBUG
-      // std::cout << "MinDistanceConstraint::eval: Second loop: " << k <<
-      // std::endl;
-      // END_DEBUG
-      int l = 0;
-      int numA = static_cast<int>(orig_idx_of_pt_on_bodyA.at(k).size());
-      int numB = static_cast<int>(orig_idx_of_pt_on_bodyB.at(k).size());
-      if (numA + numB == 0) {
-        continue;
-      }
-      Matrix3Xd x_k(3, numA + numB);
-      for (; l < numA; ++l) {
-        // DEBUG
-        // std::cout << "MinDistanceConstraint::eval: Third loop: " << l <<
-        // std::endl;
-        // END_DEBUG
-        x_k.col(l) = xA.col(orig_idx_of_pt_on_bodyA.at(k).at(l));
-      }
-      for (; l < numA + numB; ++l) {
-        // DEBUG
-        // std::cout << "MinDistanceConstraint::eval: Fourth loop: " << l <<
-        // std::endl;
-        // END_DEBUG
-        x_k.col(l) = xB.col(orig_idx_of_pt_on_bodyB.at(k).at(l - numA));
-      }
-
-      auto J_k = robot->transformPointsJacobian(cache, x_k, k, 0, true);
-
-      l = 0;
-      for (; l < numA; ++l) {
-        // DEBUG
-        // std::cout << "MinDistanceConstraint::eval: Fifth loop: " << l <<
-        // std::endl;
-        // END_DEBUG
-        ddist_dq.row(orig_idx_of_pt_on_bodyA.at(k).at(l)) +=
-            normal.col(orig_idx_of_pt_on_bodyA.at(k).at(l)).transpose() *
-            J_k.block(3 * l, 0, 3, robot->num_positions);
-      }
-      for (; l < numA + numB; ++l) {
-        // DEBUG
-        // std::cout << "MinDistanceConstraint::eval: Sixth loop: " << l <<
-        // std::endl;
-        // END_DEBUG
-        ddist_dq.row(orig_idx_of_pt_on_bodyB.at(k).at(l - numA)) +=
-            -normal.col(orig_idx_of_pt_on_bodyB.at(k).at(l - numA))
-                 .transpose() *
-            J_k.block(3 * l, 0, 3, robot->num_positions);
-      }
-    }
-    // DEBUG
-    // std::cout << "MinDistanceConstraint::eval: Set outputs" << std::endl;
-    // END_DEBUG
-    MatrixXd dcost_dscaled_dist(dpairwise_costs_dscaled_dist.colwise().sum());
-    c(0) = pairwise_costs.sum();
-    dc = dcost_dscaled_dist * dscaled_dist_ddist * ddist_dq;
   } else {
-    c.resize(0);
-    dc.resize(0, 0);
+    if (active_group_names.size() > 0) {
+      robot->collisionDetect(cache, dist, normal, xA, xB, idxA, idxB,
+                             active_group_names);
+    } else {
+      robot->collisionDetect(cache, dist, normal, xA, xB, idxA, idxB);
+    }
   }
+
+  int num_pts = static_cast<int>(xA.cols());
+  ddist_dq = MatrixXd::Zero(num_pts, robot->num_positions);
+
+  // Compute Jacobian of closest distance vector
+  // DEBUG
+  // std:: cout << "IntegratedClosestDistanceConstraint::eval_valid: Compute
+  // distance Jacobian" << std::endl;
+  // END_DEBUG
+  scaleDistance(dist, scaled_dist, dscaled_dist_ddist);
+  penalty(scaled_dist, pairwise_costs, dpairwise_costs_dscaled_dist);
+
+  std::vector<std::vector<int>> orig_idx_of_pt_on_bodyA(robot->bodies.size());
+  std::vector<std::vector<int>> orig_idx_of_pt_on_bodyB(robot->bodies.size());
+  for (int k = 0; k < num_pts; ++k) {
+    // DEBUG
+    // std::cout << "MinDistanceConstraint::eval: First loop: " << k <<
+    // std::endl;
+    // std::cout << "pairwise_costs.size() = " << pairwise_costs.size() <<
+    // std::endl;
+    // std::cout << "pairwise_costs.size() = " << pairwise_costs.size() <<
+    // std::endl;
+    // END_DEBUG
+    if (pairwise_costs(k) > 0) {
+      orig_idx_of_pt_on_bodyA.at(idxA.at(k)).push_back(k);
+      orig_idx_of_pt_on_bodyB.at(idxB.at(k)).push_back(k);
+    }
+  }
+  for (int k = 0; k < robot->bodies.size(); ++k) {
+    // DEBUG
+    // std::cout << "MinDistanceConstraint::eval: Second loop: " << k <<
+    // std::endl;
+    // END_DEBUG
+    int l = 0;
+    int numA = static_cast<int>(orig_idx_of_pt_on_bodyA.at(k).size());
+    int numB = static_cast<int>(orig_idx_of_pt_on_bodyB.at(k).size());
+    if (numA + numB == 0) {
+      continue;
+    }
+    Matrix3Xd x_k(3, numA + numB);
+    for (; l < numA; ++l) {
+      // DEBUG
+      // std::cout << "MinDistanceConstraint::eval: Third loop: " << l <<
+      // std::endl;
+      // END_DEBUG
+      x_k.col(l) = xA.col(orig_idx_of_pt_on_bodyA.at(k).at(l));
+    }
+    for (; l < numA + numB; ++l) {
+      // DEBUG
+      // std::cout << "MinDistanceConstraint::eval: Fourth loop: " << l <<
+      // std::endl;
+      // END_DEBUG
+      x_k.col(l) = xB.col(orig_idx_of_pt_on_bodyB.at(k).at(l - numA));
+    }
+
+    auto J_k = robot->transformPointsJacobian(cache, x_k, k, 0, true);
+
+    l = 0;
+    for (; l < numA; ++l) {
+      // DEBUG
+      // std::cout << "MinDistanceConstraint::eval: Fifth loop: " << l <<
+      // std::endl;
+      // END_DEBUG
+      ddist_dq.row(orig_idx_of_pt_on_bodyA.at(k).at(l)) +=
+          normal.col(orig_idx_of_pt_on_bodyA.at(k).at(l)).transpose() *
+          J_k.block(3 * l, 0, 3, robot->num_positions);
+    }
+    for (; l < numA + numB; ++l) {
+      // DEBUG
+      // std::cout << "MinDistanceConstraint::eval: Sixth loop: " << l <<
+      // std::endl;
+      // END_DEBUG
+      ddist_dq.row(orig_idx_of_pt_on_bodyB.at(k).at(l - numA)) +=
+          -normal.col(orig_idx_of_pt_on_bodyB.at(k).at(l - numA))
+          .transpose() *
+          J_k.block(3 * l, 0, 3, robot->num_positions);
+    }
+  }
+  // DEBUG
+  // std::cout << "MinDistanceConstraint::eval: Set outputs" << std::endl;
+  // END_DEBUG
+  MatrixXd dcost_dscaled_dist(dpairwise_costs_dscaled_dist.colwise().sum());
+  c(0) = pairwise_costs.sum();
+  dc = dcost_dscaled_dist * dscaled_dist_ddist * ddist_dq;
   // DEBUG
   // std::cout << "MinDistanceConstraint::eval: END" << std::endl;
   // END_DEBUG
@@ -2168,30 +1892,22 @@ void MinDistanceConstraint::penalty(const Eigen::VectorXd &dist,
 
 void MinDistanceConstraint::bounds(const double *t, VectorXd &lb,
                                    VectorXd &ub) const {
-  lb.resize(this->num_constraint);
-  ub.resize(this->num_constraint);
-  if (this->isTimeValid(t)) {
-    lb = VectorXd::Zero(num_constraint);
-    ub = VectorXd::Zero(num_constraint);
-  }
+  lb = VectorXd::Zero(num_constraint);
+  ub = VectorXd::Zero(num_constraint);
 }
 
 void MinDistanceConstraint::name(const double *t,
                                  std::vector<std::string> &name) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    std::string cnst_name("Minimum distance constraint" + time_str);
-    name.push_back(cnst_name);
-  } else {
-    name.push_back("");
-  }
+  std::string time_str = this->getTimeString(t);
+  std::string cnst_name("Minimum distance constraint" + time_str);
+  name.push_back(cnst_name);
 }
 
 WorldPositionInFrameConstraint::WorldPositionInFrameConstraint(
     RigidBodyTree *robot, int body, const Eigen::Matrix3Xd &pts,
     const Eigen::Matrix4d &T_frame_to_world, const Eigen::MatrixXd &lb,
-    const Eigen::MatrixXd &ub, const Eigen::Vector2d &tspan)
-    : WorldPositionConstraint(robot, body, pts, lb, ub, tspan) {
+    const Eigen::MatrixXd &ub)
+    : WorldPositionConstraint(robot, body, pts, lb, ub) {
   this->T_frame_to_world = T_frame_to_world;
   this->T_world_to_frame = T_frame_to_world.inverse();
   this->type = RigidBodyConstraint::WorldPositionInFrameConstraintType;
@@ -2223,9 +1939,8 @@ WorldPositionInFrameConstraint::~WorldPositionInFrameConstraint() {}
 PostureChangeConstraint::PostureChangeConstraint(RigidBodyTree *robot,
                                                  const VectorXi &joint_ind,
                                                  const VectorXd &lb_change,
-                                                 const VectorXd &ub_change,
-                                                 const Vector2d &tspan)
-    : MultipleTimeLinearPostureConstraint(robot, tspan) {
+                                                 const VectorXd &ub_change)
+    : MultipleTimeLinearPostureConstraint(robot) {
   this->setJointChangeBounds(joint_ind, lb_change, ub_change);
   this->type = RigidBodyConstraint::PostureChangeConstraintType;
 }
@@ -2250,8 +1965,7 @@ void PostureChangeConstraint::setJointChangeBounds(const VectorXi &joint_ind,
 
 int PostureChangeConstraint::getNumConstraint(const double *t,
                                               int n_breaks) const {
-  std::vector<bool> valid_flag = this->isTimeValid(t, n_breaks);
-  int num_valid_t = this->numValidTime(valid_flag);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2)
     return (num_valid_t - 1) * static_cast<int>(this->joint_ind.size());
   else
@@ -2260,11 +1974,10 @@ int PostureChangeConstraint::getNumConstraint(const double *t,
 
 void PostureChangeConstraint::feval(const double *t, int n_breaks,
                                     const MatrixXd &q, VectorXd &c) const {
-  std::vector<bool> valid_flag = this->isTimeValid(t, n_breaks);
-  int num_valid_t = this->numValidTime(valid_flag);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     VectorXi valid_t_ind;
-    this->validTimeInd(valid_flag, valid_t_ind);
+    validTimeInd(n_breaks, valid_t_ind);
     int nc = this->getNumConstraint(t, n_breaks);
     c.resize(nc);
     for (int i = 1; i < num_valid_t; i++) {
@@ -2282,8 +1995,7 @@ void PostureChangeConstraint::feval(const double *t, int n_breaks,
 void PostureChangeConstraint::geval(const double *t, int n_breaks,
                                     VectorXi &iAfun, VectorXi &jAvar,
                                     VectorXd &A) const {
-  std::vector<bool> valid_flag = this->isTimeValid(t, n_breaks);
-  int num_valid_t = this->numValidTime(valid_flag);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     int num_joints = static_cast<int>(this->joint_ind.size());
     int nc = this->getNumConstraint(t, n_breaks);
@@ -2292,7 +2004,7 @@ void PostureChangeConstraint::geval(const double *t, int n_breaks,
     jAvar.resize(nc * 2);
     A.resize(nc * 2);
     VectorXi valid_t_ind;
-    this->validTimeInd(valid_flag, valid_t_ind);
+    validTimeInd(n_breaks, valid_t_ind);
     for (int i = 0; i < num_valid_t - 1; i++) {
       for (int j = 0; j < num_joints; j++) {
         iAfun(i * num_joints + j) = i * num_joints + j;
@@ -2317,10 +2029,9 @@ void PostureChangeConstraint::geval(const double *t, int n_breaks,
 
 void PostureChangeConstraint::name(const double *t, int n_breaks,
                                    std::vector<std::string> &name_str) const {
-  std::vector<bool> valid_flag = this->isTimeValid(t, n_breaks);
-  int num_valid_t = this->numValidTime(valid_flag);
+  const int num_valid_t = n_breaks;
   VectorXi valid_t_ind;
-  this->validTimeInd(valid_flag, valid_t_ind);
+  validTimeInd(n_breaks, valid_t_ind);
   if (num_valid_t >= 2) {
     for (int i = 1; i < num_valid_t; i++) {
       for (int j = 0; j < this->joint_ind.size(); j++) {
@@ -2334,8 +2045,7 @@ void PostureChangeConstraint::name(const double *t, int n_breaks,
 
 void PostureChangeConstraint::bounds(const double *t, int n_breaks,
                                      VectorXd &lb, VectorXd &ub) const {
-  std::vector<bool> valid_flag = this->isTimeValid(t, n_breaks);
-  int num_valid_t = this->numValidTime(valid_flag);
+  const int num_valid_t = n_breaks;
   if (num_valid_t >= 2) {
     int nc = this->getNumConstraint(t, n_breaks);
     lb.resize(nc);
@@ -2353,8 +2063,8 @@ void PostureChangeConstraint::bounds(const double *t, int n_breaks,
 
 GravityCompensationTorqueConstraint::GravityCompensationTorqueConstraint(
     RigidBodyTree *robot, const VectorXi &joint_indices, const VectorXd &lb,
-    const VectorXd &ub, const Vector2d &tspan)
-    : SingleTimeKinematicConstraint(robot, tspan),
+    const VectorXd &ub)
+    : SingleTimeKinematicConstraint(robot),
       lb(lb),
       ub(ub),
       joint_indices(joint_indices) {
@@ -2389,24 +2099,15 @@ void GravityCompensationTorqueConstraint::eval(const double *t,
 
 void GravityCompensationTorqueConstraint::name(
     const double *t, std::vector<std::string> &name) const {
-  if (this->isTimeValid(t)) {
-    std::string time_str = this->getTimeString(t);
-    std::string cnst_name = "Gravity compensation torque constraint" + time_str;
-    for (int i = 0; i < this->num_constraint; i++) {
-      name.push_back(cnst_name);
-    }
-  } else {
-    name.push_back("");
+  std::string time_str = this->getTimeString(t);
+  std::string cnst_name = "Gravity compensation torque constraint" + time_str;
+  for (int i = 0; i < this->num_constraint; i++) {
+    name.push_back(cnst_name);
   }
 }
 
 void GravityCompensationTorqueConstraint::bounds(const double *t, VectorXd &lb,
                                                  VectorXd &ub) const {
-  if (this->isTimeValid(t)) {
-    lb = this->lb;
-    ub = this->ub;
-  } else {
-    lb.resize(0);
-    ub.resize(0);
-  }
+  lb = this->lb;
+  ub = this->ub;
 }

--- a/drake/systems/plants/constraint/RigidBodyConstraint.h
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.h
@@ -440,12 +440,13 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RelativePositionConstraint
                          std::vector<std::string> &cnst_names) const;
 
  public:
-  RelativePositionConstraint(RigidBodyTree *model, const Eigen::Matrix3Xd &pts,
-                             const Eigen::MatrixXd &lb,
-                             const Eigen::MatrixXd &ub, int bodyA_idx,
-                             int bodyB_idx,
-                             const Eigen::Matrix<double, 7, 1> &bTbp,
-                             const Eigen::Vector2d &tspan);
+  RelativePositionConstraint(
+      RigidBodyTree *model, const Eigen::Matrix3Xd &pts,
+      const Eigen::MatrixXd &lb,
+      const Eigen::MatrixXd &ub, int bodyA_idx,
+      int bodyB_idx,
+      const Eigen::Matrix<double, 7, 1> &bTbp,
+      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
   virtual ~RelativePositionConstraint();
 };
 

--- a/drake/systems/plants/constraint/RigidBodyConstraint.h
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.h
@@ -136,7 +136,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT QuasiStaticConstraint
           QuasiStaticConstraint::defaultRobotNumSet);
   QuasiStaticConstraint(const QuasiStaticConstraint &rhs);
   int getNumConstraint() const;
-  void eval(const double *t, KinematicsCache<double> &cache,
+  void eval(KinematicsCache<double> &cache,
             const double *weights, Eigen::VectorXd &c,
             Eigen::MatrixXd &dc) const;
   void bounds(Eigen::VectorXd &lb, Eigen::VectorXd &ub) const;
@@ -213,12 +213,12 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT MultipleTimeLinearPostureConstraint
   MultipleTimeLinearPostureConstraint(RigidBodyTree *model);
   MultipleTimeLinearPostureConstraint(
       const MultipleTimeLinearPostureConstraint &rhs);
-  void eval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
+  void eval(int n_breaks, const Eigen::MatrixXd &q,
             Eigen::VectorXd &c, Eigen::SparseMatrix<double> &dc) const;
   virtual int getNumConstraint(int n_breaks) const = 0;
-  virtual void feval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
+  virtual void feval(int n_breaks, const Eigen::MatrixXd &q,
                      Eigen::VectorXd &c) const = 0;
-  virtual void geval(const double *t, int n_breaks, Eigen::VectorXi &iAfun,
+  virtual void geval(int n_breaks, Eigen::VectorXi &iAfun,
                      Eigen::VectorXi &jAvar, Eigen::VectorXd &A) const = 0;
   virtual void name(const double *t, int n_breaks,
                     std::vector<std::string> &name_str) const = 0;
@@ -276,11 +276,11 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT SingleTimeLinearPostureConstraint
       const SingleTimeLinearPostureConstraint &rhs);
   int getNumConstraint() const;
   void bounds(Eigen::VectorXd &lb, Eigen::VectorXd &ub) const;
-  void feval(const double *t, const Eigen::VectorXd &q,
+  void feval(const Eigen::VectorXd &q,
              Eigen::VectorXd &c) const;
-  void geval(const double *t, Eigen::VectorXi &iAfun, Eigen::VectorXi &jAvar,
+  void geval(Eigen::VectorXi &iAfun, Eigen::VectorXi &jAvar,
              Eigen::VectorXd &A) const;
-  void eval(const double *t, const Eigen::VectorXd &q, Eigen::VectorXd &c,
+  void eval(const Eigen::VectorXd &q, Eigen::VectorXd &c,
             Eigen::SparseMatrix<double> &dc) const;
   void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~SingleTimeLinearPostureConstraint(void){}
@@ -300,7 +300,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT SingleTimeKinematicConstraint
   SingleTimeKinematicConstraint(RigidBodyTree *model);
   SingleTimeKinematicConstraint(const SingleTimeKinematicConstraint &rhs);
   int getNumConstraint() const;
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const = 0;
   virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const = 0;
@@ -316,9 +316,9 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT MultipleTimeKinematicConstraint
   MultipleTimeKinematicConstraint(RigidBodyTree *model);
   MultipleTimeKinematicConstraint(const MultipleTimeKinematicConstraint &rhs);
   virtual int getNumConstraint(int n_breaks) const = 0;
-  void eval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
+  void eval(int n_breaks, const Eigen::MatrixXd &q,
             Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
-  virtual void eval_valid(const double *valid_t, int num_valid_t,
+  virtual void eval_valid(int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
                           Eigen::MatrixXd &dc_valid) const = 0;
   virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
@@ -348,7 +348,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PositionConstraint
       RigidBodyTree *model, const Eigen::Matrix3Xd &pts, Eigen::MatrixXd lb,
       Eigen::MatrixXd ub);
   PositionConstraint(const PositionConstraint &rhs);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
@@ -426,7 +426,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT QuatConstraint
 
  public:
   QuatConstraint(RigidBodyTree *model, double tol);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
@@ -496,7 +496,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT EulerConstraint
       RigidBodyTree *model, const Eigen::Vector3d &lb,
       const Eigen::Vector3d &ub);
   EulerConstraint(const EulerConstraint &rhs);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
@@ -550,7 +550,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GazeOrientConstraint
   GazeOrientConstraint(
       RigidBodyTree *model, const Eigen::Vector3d &axis,
       const Eigen::Vector4d &quat_des, double conethreshold, double threshold);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
@@ -608,7 +608,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldGazeDirConstraint
   WorldGazeDirConstraint(
       RigidBodyTree *model, int body, const Eigen::Vector3d &axis,
       const Eigen::Vector3d &dir, double conethreshold);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~WorldGazeDirConstraint(void){}
@@ -646,7 +646,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldGazeTargetConstraint
       RigidBodyTree *model, int body, const Eigen::Vector3d &axis,
       const Eigen::Vector3d &target, const Eigen::Vector3d &gaze_origin,
       double conethreshold);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~WorldGazeTargetConstraint(void){}
@@ -665,7 +665,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RelativeGazeTargetConstraint
       RigidBodyTree *model, int bodyA_idx, int bodyB_idx,
       const Eigen::Vector3d &axis, const Eigen::Vector3d &target,
       const Eigen::Vector3d &gaze_origin, double conethreshold);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~RelativeGazeTargetConstraint(void){}
@@ -684,7 +684,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RelativeGazeDirConstraint
       RigidBodyTree *model, int bodyA_idx, int bodyB_idx,
       const Eigen::Vector3d &axis, const Eigen::Vector3d &dir,
       double conethreshold);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~RelativeGazeDirConstraint(void){}
@@ -705,7 +705,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT Point2PointDistanceConstraint
       RigidBodyTree *model, int bodyA, int bodyB, const Eigen::Matrix3Xd &ptA,
       const Eigen::Matrix3Xd &ptB, const Eigen::VectorXd &lb,
       const Eigen::VectorXd &ub);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual void bounds(Eigen::VectorXd &lb,
@@ -728,7 +728,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT Point2LineSegDistConstraint
       RigidBodyTree *model, int pt_body, const Eigen::Vector3d &pt,
       int line_body, const Eigen::Matrix<double, 3, 2> &line_ends,
       double dist_lb, double dist_ub);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual void bounds(Eigen::VectorXd &lb,
@@ -752,7 +752,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedPositionConstraint
   WorldFixedPositionConstraint(
       RigidBodyTree *model, int body, const Eigen::Matrix3Xd &pts);
   virtual int getNumConstraint(int n_breaks) const;
-  virtual void eval_valid(const double *valid_t, int num_valid_t,
+  virtual void eval_valid(int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
                           Eigen::MatrixXd &dc_valid) const;
   virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
@@ -771,7 +771,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedOrientConstraint
  public:
   WorldFixedOrientConstraint(RigidBodyTree *model, int body);
   virtual int getNumConstraint(int n_breaks) const;
-  virtual void eval_valid(const double *valid_t, int num_valid_t,
+  virtual void eval_valid(int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
                           Eigen::MatrixXd &dc_valid) const;
   virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
@@ -790,7 +790,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedBodyPoseConstraint
  public:
   WorldFixedBodyPoseConstraint(RigidBodyTree *model, int body);
   virtual int getNumConstraint(int n_breaks) const;
-  virtual void eval_valid(const double *valid_t, int num_valid_t,
+  virtual void eval_valid(int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
                           Eigen::MatrixXd &dc_valid) const;
   virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
@@ -816,7 +816,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT AllBodiesClosestDistanceConstraint
   // AllBodiesClosestDistanceConstraint(const
   // AllBodiesClosestDistanceConstraint& rhs);
   virtual void updateRobot(RigidBodyTree *robot);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name) const;
   virtual void bounds(Eigen::VectorXd &lb,
@@ -837,7 +837,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT MinDistanceConstraint
       const std::vector<int> &active_bodies_idx,
       const std::set<std::string> &active_group_names);
   // MinDistanceConstraint(const MinDistanceConstraint& rhs);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name) const;
   void scaleDistance(const Eigen::VectorXd &dist, Eigen::VectorXd &scaled_dist,
@@ -887,9 +887,9 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PostureChangeConstraint
       RigidBodyTree *model, const Eigen::VectorXi &joint_ind,
       const Eigen::VectorXd &lb_change, const Eigen::VectorXd &ub_change);
   virtual int getNumConstraint(int n_breaks) const;
-  virtual void feval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
+  virtual void feval(int n_breaks, const Eigen::MatrixXd &q,
                      Eigen::VectorXd &c) const;
-  virtual void geval(const double *t, int n_breaks, Eigen::VectorXi &iAfun,
+  virtual void geval(int n_breaks, Eigen::VectorXi &iAfun,
                      Eigen::VectorXi &jAvar, Eigen::VectorXd &A) const;
   virtual void name(const double *t, int n_breaks,
                     std::vector<std::string> &name_str) const;
@@ -904,7 +904,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GravityCompensationTorqueConstraint
   GravityCompensationTorqueConstraint(
       RigidBodyTree *model, const Eigen::VectorXi &joint_indices,
       const Eigen::VectorXd &lb, const Eigen::VectorXd &ub);
-  virtual void eval(const double *t, KinematicsCache<double> &cache,
+  virtual void eval(KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name) const;
   virtual void bounds(Eigen::VectorXd &lb,

--- a/drake/systems/plants/constraint/RigidBodyConstraint.h
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.h
@@ -135,11 +135,11 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT QuasiStaticConstraint
       const std::set<int> &robotnumset =
           QuasiStaticConstraint::defaultRobotNumSet);
   QuasiStaticConstraint(const QuasiStaticConstraint &rhs);
-  int getNumConstraint(const double *t) const;
+  int getNumConstraint() const;
   void eval(const double *t, KinematicsCache<double> &cache,
             const double *weights, Eigen::VectorXd &c,
             Eigen::MatrixXd &dc) const;
-  void bounds(const double *t, Eigen::VectorXd &lb, Eigen::VectorXd &ub) const;
+  void bounds(Eigen::VectorXd &lb, Eigen::VectorXd &ub) const;
   void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~QuasiStaticConstraint(void);
   bool isActive() const { return this->active; }
@@ -180,7 +180,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PostureConstraint
                       const Eigen::VectorXd &lb, const Eigen::VectorXd &ub);
   void setJointLimits(const Eigen::VectorXi &joint_idx,
                       const Eigen::VectorXd &lb, const Eigen::VectorXd &ub);
-  void bounds(const double *t, Eigen::VectorXd &joint_min,
+  void bounds(Eigen::VectorXd &joint_min,
               Eigen::VectorXd &joint_max) const;
   virtual ~PostureConstraint(void){}
 };
@@ -215,14 +215,14 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT MultipleTimeLinearPostureConstraint
       const MultipleTimeLinearPostureConstraint &rhs);
   void eval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
             Eigen::VectorXd &c, Eigen::SparseMatrix<double> &dc) const;
-  virtual int getNumConstraint(const double *t, int n_breaks) const = 0;
+  virtual int getNumConstraint(int n_breaks) const = 0;
   virtual void feval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
                      Eigen::VectorXd &c) const = 0;
   virtual void geval(const double *t, int n_breaks, Eigen::VectorXi &iAfun,
                      Eigen::VectorXi &jAvar, Eigen::VectorXd &A) const = 0;
   virtual void name(const double *t, int n_breaks,
                     std::vector<std::string> &name_str) const = 0;
-  virtual void bounds(const double *t, int n_breaks, Eigen::VectorXd &lb,
+  virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const = 0;
   virtual ~MultipleTimeLinearPostureConstraint(){}
 };
@@ -274,8 +274,8 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT SingleTimeLinearPostureConstraint
       const Eigen::VectorXd &lb, const Eigen::VectorXd &ub);
   SingleTimeLinearPostureConstraint(
       const SingleTimeLinearPostureConstraint &rhs);
-  int getNumConstraint(const double *t) const;
-  void bounds(const double *t, Eigen::VectorXd &lb, Eigen::VectorXd &ub) const;
+  int getNumConstraint() const;
+  void bounds(Eigen::VectorXd &lb, Eigen::VectorXd &ub) const;
   void feval(const double *t, const Eigen::VectorXd &q,
              Eigen::VectorXd &c) const;
   void geval(const double *t, Eigen::VectorXi &iAfun, Eigen::VectorXi &jAvar,
@@ -299,10 +299,10 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT SingleTimeKinematicConstraint
  public:
   SingleTimeKinematicConstraint(RigidBodyTree *model);
   SingleTimeKinematicConstraint(const SingleTimeKinematicConstraint &rhs);
-  int getNumConstraint(const double *t) const;
+  int getNumConstraint() const;
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const = 0;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const = 0;
   virtual void name(const double *t,
                     std::vector<std::string> &name_str) const = 0;
@@ -315,13 +315,13 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT MultipleTimeKinematicConstraint
  public:
   MultipleTimeKinematicConstraint(RigidBodyTree *model);
   MultipleTimeKinematicConstraint(const MultipleTimeKinematicConstraint &rhs);
-  virtual int getNumConstraint(const double *t, int n_breaks) const = 0;
+  virtual int getNumConstraint(int n_breaks) const = 0;
   void eval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
             Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void eval_valid(const double *valid_t, int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
                           Eigen::MatrixXd &dc_valid) const = 0;
-  virtual void bounds(const double *t, int n_breaks, Eigen::VectorXd &lb,
+  virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const = 0;
   virtual void name(const double *t, int n_breaks,
                     std::vector<std::string> &name_str) const = 0;
@@ -350,7 +350,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PositionConstraint
   PositionConstraint(const PositionConstraint &rhs);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~PositionConstraint(void){}
@@ -428,7 +428,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT QuatConstraint
   QuatConstraint(RigidBodyTree *model, double tol);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~QuatConstraint();
 };
@@ -498,7 +498,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT EulerConstraint
   EulerConstraint(const EulerConstraint &rhs);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~EulerConstraint(void){}
 };
@@ -552,7 +552,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GazeOrientConstraint
       const Eigen::Vector4d &quat_des, double conethreshold, double threshold);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~GazeOrientConstraint(void) {}
 
@@ -588,7 +588,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GazeDirConstraint
   GazeDirConstraint(
       RigidBodyTree *model, const Eigen::Vector3d &axis,
       const Eigen::Vector3d &dir, double conethreshold);
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~GazeDirConstraint(void) {}
 
@@ -625,7 +625,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GazeTargetConstraint
       RigidBodyTree *model, const Eigen::Vector3d &axis,
       const Eigen::Vector3d &target, const Eigen::Vector3d &gaze_origin,
       double conethreshold);
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~GazeTargetConstraint(void) {}
 
@@ -708,7 +708,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT Point2PointDistanceConstraint
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~Point2PointDistanceConstraint(void){}
 };
@@ -731,7 +731,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT Point2LineSegDistConstraint
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~Point2LineSegDistConstraint(void) {}
 
@@ -751,11 +751,11 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedPositionConstraint
  public:
   WorldFixedPositionConstraint(
       RigidBodyTree *model, int body, const Eigen::Matrix3Xd &pts);
-  virtual int getNumConstraint(const double *t, int n_breaks) const;
+  virtual int getNumConstraint(int n_breaks) const;
   virtual void eval_valid(const double *valid_t, int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
                           Eigen::MatrixXd &dc_valid) const;
-  virtual void bounds(const double *t, int n_breaks, Eigen::VectorXd &lb,
+  virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual void name(const double *t, int n_breaks,
                     std::vector<std::string> &name_str) const;
@@ -770,11 +770,11 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedOrientConstraint
 
  public:
   WorldFixedOrientConstraint(RigidBodyTree *model, int body);
-  virtual int getNumConstraint(const double *t, int n_breaks) const;
+  virtual int getNumConstraint(int n_breaks) const;
   virtual void eval_valid(const double *valid_t, int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
                           Eigen::MatrixXd &dc_valid) const;
-  virtual void bounds(const double *t, int n_breaks, Eigen::VectorXd &lb,
+  virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual void name(const double *t, int n_breaks,
                     std::vector<std::string> &name_str) const;
@@ -789,11 +789,11 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedBodyPoseConstraint
 
  public:
   WorldFixedBodyPoseConstraint(RigidBodyTree *model, int body);
-  virtual int getNumConstraint(const double *t, int n_breaks) const;
+  virtual int getNumConstraint(int n_breaks) const;
   virtual void eval_valid(const double *valid_t, int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
                           Eigen::MatrixXd &dc_valid) const;
-  virtual void bounds(const double *t, int n_breaks, Eigen::VectorXd &lb,
+  virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual void name(const double *t, int n_breaks,
                     std::vector<std::string> &name_str) const;
@@ -819,7 +819,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT AllBodiesClosestDistanceConstraint
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~AllBodiesClosestDistanceConstraint(){}
 };
@@ -844,7 +844,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT MinDistanceConstraint
                      Eigen::MatrixXd &dscaled_dist_ddist) const;
   void penalty(const Eigen::VectorXd &dist, Eigen::VectorXd &cost,
                Eigen::MatrixXd &dcost_ddist) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~MinDistanceConstraint(){}
 };
@@ -886,14 +886,14 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PostureChangeConstraint
   PostureChangeConstraint(
       RigidBodyTree *model, const Eigen::VectorXi &joint_ind,
       const Eigen::VectorXd &lb_change, const Eigen::VectorXd &ub_change);
-  virtual int getNumConstraint(const double *t, int n_breaks) const;
+  virtual int getNumConstraint(int n_breaks) const;
   virtual void feval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
                      Eigen::VectorXd &c) const;
   virtual void geval(const double *t, int n_breaks, Eigen::VectorXi &iAfun,
                      Eigen::VectorXi &jAvar, Eigen::VectorXd &A) const;
   virtual void name(const double *t, int n_breaks,
                     std::vector<std::string> &name_str) const;
-  virtual void bounds(const double *t, int n_breaks, Eigen::VectorXd &lb,
+  virtual void bounds(int n_breaks, Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~PostureChangeConstraint(){}
 };
@@ -907,7 +907,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GravityCompensationTorqueConstraint
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name) const;
-  virtual void bounds(const double *t, Eigen::VectorXd &lb,
+  virtual void bounds(Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~GravityCompensationTorqueConstraint() {}
 

--- a/drake/systems/plants/constraint/RigidBodyConstraint.h
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.h
@@ -28,7 +28,6 @@ class RigidBodyTree;
 namespace DrakeRigidBodyConstraint {
 extern DRAKERIGIDBODYCONSTRAINT_EXPORT Eigen::Vector3d com_pts;
 extern DRAKERIGIDBODYCONSTRAINT_EXPORT const int WorldCoMDefaultRobotNum[1];
-extern DRAKERIGIDBODYCONSTRAINT_EXPORT Eigen::Vector2d default_tspan;
 }
 
 DRAKERIGIDBODYCONSTRAINT_EXPORT void drakePrintMatrix(
@@ -39,12 +38,10 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RigidBodyConstraint {
   int category;
   int type;
   RigidBodyTree *robot;
-  double tspan[2];
 
  public:
   RigidBodyConstraint(
-      int category, RigidBodyTree *robot,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      int category, RigidBodyTree *robot);
   RigidBodyConstraint(const RigidBodyConstraint &rhs);
   int getType() const { return this->type; }
   int getCategory() const { return this->category; }
@@ -94,13 +91,11 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RigidBodyConstraint {
  * within the support polygon. The support polygon is a shrunk area of the
  * contact polygon
  * @param robot
- * @param tspan           -- The time span of this constraint being active
  * @param robotnumset     -- The set of the robots in the RigidBodyTree for
  * which the CoM is computed
  * @param shrinkFactor    -- The factor to shrink the contact polygon. The
  * shrunk area is the support polygon.
- * @param active          -- Whether the constraint is on/off. If active =
- * false, even the time t is within tspan, the constraint is still inactive
+ * @param active          -- Whether the constraint is on/off.
  * @param num_bodies      -- The total number of ground contact bodies/frames
  * @param num_pts         -- The total number of ground contact points
  * @param bodies          -- The index of ground contact bodies/frames
@@ -137,11 +132,9 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT QuasiStaticConstraint
  public:
   QuasiStaticConstraint(
       RigidBodyTree *robot,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan,
       const std::set<int> &robotnumset =
           QuasiStaticConstraint::defaultRobotNumSet);
   QuasiStaticConstraint(const QuasiStaticConstraint &rhs);
-  bool isTimeValid(const double *t) const;
   int getNumConstraint(const double *t) const;
   void eval(const double *t, KinematicsCache<double> &cache,
             const double *weights, Eigen::VectorXd &c,
@@ -161,7 +154,6 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT QuasiStaticConstraint
 
 /*
  * @class PostureConstraint   constrain the joint limits
- * @param tspan          -- The time span of the constraint being valid
  * @param lb             -- The lower bound of the joints
  * @param ub             -- The upper bound of the joints
  *
@@ -182,10 +174,8 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PostureConstraint
 
  public:
   PostureConstraint(
-      RigidBodyTree *model,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      RigidBodyTree *model);
   PostureConstraint(const PostureConstraint &rhs);
-  bool isTimeValid(const double *t) const;
   void setJointLimits(int num_idx, const int *joint_idx,
                       const Eigen::VectorXd &lb, const Eigen::VectorXd &ub);
   void setJointLimits(const Eigen::VectorXi &joint_idx,
@@ -219,18 +209,10 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PostureConstraint
  */
 class DRAKERIGIDBODYCONSTRAINT_EXPORT MultipleTimeLinearPostureConstraint
     : public RigidBodyConstraint {
- protected:
-  int numValidTime(const std::vector<bool> &valid_flag) const;
-  void validTimeInd(const std::vector<bool> &valid_flag,
-                    Eigen::VectorXi &valid_t_ind) const;
-
  public:
-  MultipleTimeLinearPostureConstraint(
-      RigidBodyTree *model,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+  MultipleTimeLinearPostureConstraint(RigidBodyTree *model);
   MultipleTimeLinearPostureConstraint(
       const MultipleTimeLinearPostureConstraint &rhs);
-  std::vector<bool> isTimeValid(const double *t, int n_breaks) const;
   void eval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
             Eigen::VectorXd &c, Eigen::SparseMatrix<double> &dc) const;
   virtual int getNumConstraint(const double *t, int n_breaks) const = 0;
@@ -256,7 +238,6 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT MultipleTimeLinearPostureConstraint
  *   @param A        The values of non zero entries
  *   @param lb       The lower bound of the constraint, a column vector.
  *   @param ub       The upper bound of the constraint, a column vector.
- *   @param tspan    The time span [tspan[0] tspan[1]] is the time span of the
  * constraint being active
  * @function eval return the value and gradient of the constraint
  *   @param t      array of time
@@ -290,11 +271,9 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT SingleTimeLinearPostureConstraint
   SingleTimeLinearPostureConstraint(
       RigidBodyTree *robot, const Eigen::VectorXi &iAfun,
       const Eigen::VectorXi &jAvar, const Eigen::VectorXd &A,
-      const Eigen::VectorXd &lb, const Eigen::VectorXd &ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::VectorXd &lb, const Eigen::VectorXd &ub);
   SingleTimeLinearPostureConstraint(
       const SingleTimeLinearPostureConstraint &rhs);
-  bool isTimeValid(const double *t) const;
   int getNumConstraint(const double *t) const;
   void bounds(const double *t, Eigen::VectorXd &lb, Eigen::VectorXd &ub) const;
   void feval(const double *t, const Eigen::VectorXd &q,
@@ -318,11 +297,8 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT SingleTimeKinematicConstraint
   int num_constraint;
 
  public:
-  SingleTimeKinematicConstraint(
-      RigidBodyTree *model,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+  SingleTimeKinematicConstraint(RigidBodyTree *model);
   SingleTimeKinematicConstraint(const SingleTimeKinematicConstraint &rhs);
-  bool isTimeValid(const double *t) const;
   int getNumConstraint(const double *t) const;
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const = 0;
@@ -336,15 +312,9 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT SingleTimeKinematicConstraint
 
 class DRAKERIGIDBODYCONSTRAINT_EXPORT MultipleTimeKinematicConstraint
     : public RigidBodyConstraint {
- protected:
-  int numValidTime(const double *t, int n_breaks) const;
-
  public:
-  MultipleTimeKinematicConstraint(
-      RigidBodyTree *model,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+  MultipleTimeKinematicConstraint(RigidBodyTree *model);
   MultipleTimeKinematicConstraint(const MultipleTimeKinematicConstraint &rhs);
-  std::vector<bool> isTimeValid(const double *t, int n_breaks) const;
   virtual int getNumConstraint(const double *t, int n_breaks) const = 0;
   void eval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
             Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
@@ -376,8 +346,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PositionConstraint
  public:
   PositionConstraint(
       RigidBodyTree *model, const Eigen::Matrix3Xd &pts, Eigen::MatrixXd lb,
-      Eigen::MatrixXd ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      Eigen::MatrixXd ub);
   PositionConstraint(const PositionConstraint &rhs);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
@@ -400,8 +369,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldPositionConstraint
  public:
   WorldPositionConstraint(
       RigidBodyTree *model, int body, const Eigen::Matrix3Xd &pts,
-      Eigen::MatrixXd lb, Eigen::MatrixXd ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      Eigen::MatrixXd lb, Eigen::MatrixXd ub);
   virtual ~WorldPositionConstraint();
 };
 
@@ -420,7 +388,6 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldCoMConstraint
  public:
   WorldCoMConstraint(
       RigidBodyTree *model, Eigen::Vector3d lb, Eigen::Vector3d ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan,
       const std::set<int> &robotnum = WorldCoMConstraint::defaultRobotNumSet);
   void updateRobotnum(const std::set<int> &robotnum);
   virtual ~WorldCoMConstraint();
@@ -445,8 +412,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RelativePositionConstraint
       const Eigen::MatrixXd &lb,
       const Eigen::MatrixXd &ub, int bodyA_idx,
       int bodyB_idx,
-      const Eigen::Matrix<double, 7, 1> &bTbp,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Matrix<double, 7, 1> &bTbp);
   virtual ~RelativePositionConstraint();
 };
 
@@ -459,9 +425,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT QuatConstraint
                                       Eigen::MatrixXd &dprod) const = 0;
 
  public:
-  QuatConstraint(
-      RigidBodyTree *model, double tol,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+  QuatConstraint(RigidBodyTree *model, double tol);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void bounds(const double *t, Eigen::VectorXd &lb,
@@ -482,8 +446,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldQuatConstraint
  public:
   WorldQuatConstraint(
       RigidBodyTree *model, int body, const Eigen::Vector4d &quat_des,
-      double tol,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      double tol);
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~WorldQuatConstraint();
 
@@ -508,8 +471,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RelativeQuatConstraint
  public:
   RelativeQuatConstraint(
       RigidBodyTree *model, int bodyA_idx, int bodyB_idx,
-      const Eigen::Vector4d &quat_des, double tol,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Vector4d &quat_des, double tol);
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~RelativeQuatConstraint();
 
@@ -532,8 +494,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT EulerConstraint
  public:
   EulerConstraint(
       RigidBodyTree *model, const Eigen::Vector3d &lb,
-      const Eigen::Vector3d &ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Vector3d &ub);
   EulerConstraint(const EulerConstraint &rhs);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
@@ -553,8 +514,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldEulerConstraint
  public:
   WorldEulerConstraint(
       RigidBodyTree *model, int body, const Eigen::Vector3d &lb,
-      const Eigen::Vector3d &ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Vector3d &ub);
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~WorldEulerConstraint();
 };
@@ -568,8 +528,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GazeConstraint
  public:
   GazeConstraint(
       RigidBodyTree *model, const Eigen::Vector3d &axis,
-      double conethreshold = 0.0,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      double conethreshold = 0.0);
   virtual ~GazeConstraint(void) {}
 
  public:
@@ -590,8 +549,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GazeOrientConstraint
  public:
   GazeOrientConstraint(
       RigidBodyTree *model, const Eigen::Vector3d &axis,
-      const Eigen::Vector4d &quat_des, double conethreshold, double threshold,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Vector4d &quat_des, double conethreshold, double threshold);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void bounds(const double *t, Eigen::VectorXd &lb,
@@ -616,8 +574,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldGazeOrientConstraint
  public:
   WorldGazeOrientConstraint(
       RigidBodyTree *model, int body, const Eigen::Vector3d &axis,
-      const Eigen::Vector4d &quat_des, double conethreshold, double threshold,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Vector4d &quat_des, double conethreshold, double threshold);
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
   virtual ~WorldGazeOrientConstraint(){}
 };
@@ -630,8 +587,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GazeDirConstraint
  public:
   GazeDirConstraint(
       RigidBodyTree *model, const Eigen::Vector3d &axis,
-      const Eigen::Vector3d &dir, double conethreshold,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Vector3d &dir, double conethreshold);
   virtual void bounds(const double *t, Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~GazeDirConstraint(void) {}
@@ -651,8 +607,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldGazeDirConstraint
  public:
   WorldGazeDirConstraint(
       RigidBodyTree *model, int body, const Eigen::Vector3d &axis,
-      const Eigen::Vector3d &dir, double conethreshold,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Vector3d &dir, double conethreshold);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
@@ -669,8 +624,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GazeTargetConstraint
   GazeTargetConstraint(
       RigidBodyTree *model, const Eigen::Vector3d &axis,
       const Eigen::Vector3d &target, const Eigen::Vector3d &gaze_origin,
-      double conethreshold,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      double conethreshold);
   virtual void bounds(const double *t, Eigen::VectorXd &lb,
                       Eigen::VectorXd &ub) const;
   virtual ~GazeTargetConstraint(void) {}
@@ -691,8 +645,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldGazeTargetConstraint
   WorldGazeTargetConstraint(
       RigidBodyTree *model, int body, const Eigen::Vector3d &axis,
       const Eigen::Vector3d &target, const Eigen::Vector3d &gaze_origin,
-      double conethreshold,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      double conethreshold);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
@@ -711,8 +664,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RelativeGazeTargetConstraint
   RelativeGazeTargetConstraint(
       RigidBodyTree *model, int bodyA_idx, int bodyB_idx,
       const Eigen::Vector3d &axis, const Eigen::Vector3d &target,
-      const Eigen::Vector3d &gaze_origin, double conethreshold,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::Vector3d &gaze_origin, double conethreshold);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
@@ -731,8 +683,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT RelativeGazeDirConstraint
   RelativeGazeDirConstraint(
       RigidBodyTree *model, int bodyA_idx, int bodyB_idx,
       const Eigen::Vector3d &axis, const Eigen::Vector3d &dir,
-      double conethreshold,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      double conethreshold);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
@@ -753,8 +704,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT Point2PointDistanceConstraint
   Point2PointDistanceConstraint(
       RigidBodyTree *model, int bodyA, int bodyB, const Eigen::Matrix3Xd &ptA,
       const Eigen::Matrix3Xd &ptB, const Eigen::VectorXd &lb,
-      const Eigen::VectorXd &ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::VectorXd &ub);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
@@ -777,8 +727,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT Point2LineSegDistConstraint
   Point2LineSegDistConstraint(
       RigidBodyTree *model, int pt_body, const Eigen::Vector3d &pt,
       int line_body, const Eigen::Matrix<double, 3, 2> &line_ends,
-      double dist_lb, double dist_ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      double dist_lb, double dist_ub);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name_str) const;
@@ -801,8 +750,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedPositionConstraint
 
  public:
   WorldFixedPositionConstraint(
-      RigidBodyTree *model, int body, const Eigen::Matrix3Xd &pts,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      RigidBodyTree *model, int body, const Eigen::Matrix3Xd &pts);
   virtual int getNumConstraint(const double *t, int n_breaks) const;
   virtual void eval_valid(const double *valid_t, int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
@@ -821,9 +769,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedOrientConstraint
   std::string body_name;
 
  public:
-  WorldFixedOrientConstraint(
-      RigidBodyTree *model, int body,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+  WorldFixedOrientConstraint(RigidBodyTree *model, int body);
   virtual int getNumConstraint(const double *t, int n_breaks) const;
   virtual void eval_valid(const double *valid_t, int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
@@ -842,9 +788,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldFixedBodyPoseConstraint
   std::string body_name;
 
  public:
-  WorldFixedBodyPoseConstraint(
-      RigidBodyTree *model, int body,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+  WorldFixedBodyPoseConstraint(RigidBodyTree *model, int body);
   virtual int getNumConstraint(const double *t, int n_breaks) const;
   virtual void eval_valid(const double *valid_t, int num_valid_t,
                           const Eigen::MatrixXd &valid_q, Eigen::VectorXd &c,
@@ -868,8 +812,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT AllBodiesClosestDistanceConstraint
   AllBodiesClosestDistanceConstraint(
       RigidBodyTree *model, double lb, double ub,
       const std::vector<int> &active_bodies_idx,
-      const std::set<std::string> &active_group_names,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const std::set<std::string> &active_group_names);
   // AllBodiesClosestDistanceConstraint(const
   // AllBodiesClosestDistanceConstraint& rhs);
   virtual void updateRobot(RigidBodyTree *robot);
@@ -892,8 +835,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT MinDistanceConstraint
   MinDistanceConstraint(
       RigidBodyTree *model, double min_distance,
       const std::vector<int> &active_bodies_idx,
-      const std::set<std::string> &active_group_names,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const std::set<std::string> &active_group_names);
   // MinDistanceConstraint(const MinDistanceConstraint& rhs);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
@@ -921,8 +863,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT WorldPositionInFrameConstraint
   WorldPositionInFrameConstraint(
       RigidBodyTree *model, int body, const Eigen::Matrix3Xd &pts,
       const Eigen::Matrix4d &T_world_to_frame, const Eigen::MatrixXd &lb,
-      const Eigen::MatrixXd &ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::MatrixXd &ub);
   virtual ~WorldPositionInFrameConstraint();
 
  public:
@@ -944,8 +885,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT PostureChangeConstraint
  public:
   PostureChangeConstraint(
       RigidBodyTree *model, const Eigen::VectorXi &joint_ind,
-      const Eigen::VectorXd &lb_change, const Eigen::VectorXd &ub_change,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::VectorXd &lb_change, const Eigen::VectorXd &ub_change);
   virtual int getNumConstraint(const double *t, int n_breaks) const;
   virtual void feval(const double *t, int n_breaks, const Eigen::MatrixXd &q,
                      Eigen::VectorXd &c) const;
@@ -963,8 +903,7 @@ class DRAKERIGIDBODYCONSTRAINT_EXPORT GravityCompensationTorqueConstraint
  public:
   GravityCompensationTorqueConstraint(
       RigidBodyTree *model, const Eigen::VectorXi &joint_indices,
-      const Eigen::VectorXd &lb, const Eigen::VectorXd &ub,
-      const Eigen::Vector2d &tspan = DrakeRigidBodyConstraint::default_tspan);
+      const Eigen::VectorXd &lb, const Eigen::VectorXd &ub);
   virtual void eval(const double *t, KinematicsCache<double> &cache,
                     Eigen::VectorXd &c, Eigen::MatrixXd &dc) const;
   virtual void name(const double *t, std::vector<std::string> &name) const;

--- a/drake/systems/plants/constraint/RigidBodyConstraint.m
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.m
@@ -5,17 +5,15 @@ classdef RigidBodyConstraint
   %                         class has a unique type. Please use positive number for
   %                         this category.
   % @param robot         -- A RigidBodyManipulator or TimeSteppingRigidBodyManipulator
-  % @param tspan         -- A 1 x 2 double vector. The time span 
   % @param mex_ptr       -- A DrakeConstraintMexPointer. The mex pointer of the
   % RigidBodyConstraint
   properties(SetAccess = protected)
     category
     type
     robot
-    tspan
     mex_ptr=0;
   end
-  
+
   properties(Constant)
     SingleTimeKinematicConstraintCategory = -1;
     MultipleTimeKinematicConstraintCategory = -2;
@@ -25,7 +23,7 @@ classdef RigidBodyConstraint
     SingleTimeLinearPostureConstraintCategory = -6;
     ContactWrenchConstraintCategory = -7;
   end
-  
+
   properties(Constant)
     QuasiStaticConstraintType = 1;
     PostureConstraintType = 2;
@@ -55,9 +53,9 @@ classdef RigidBodyConstraint
     MinDistanceConstraintType = 26;
     GravityCompensationTorqueConstraintType = 27;
   end
-  
+
   methods
-    function obj = RigidBodyConstraint(category,robot,tspan)
+    function obj = RigidBodyConstraint(category,robot)
       if(~isnumeric(category))
         error('Drake:RigidBodyConstraint:BadInput','category has to be an integer');
       end
@@ -71,19 +69,8 @@ classdef RigidBodyConstraint
         error('Drake:RigidBodyConstraint:BadInput','robot has to be a RigidBodyManipulator or a TimeSteppingRigidBodyManipulator');
       end
       obj.robot = robot;
-      if(nargin<3)
-        tspan = [-inf,inf];
-      end
-      if(isempty(tspan));
-        tspan = [-inf,inf];
-      end
-      tspan_size = size(tspan);
-      if(~isnumeric(tspan) || length(tspan_size) ~= 2 || tspan_size(1) ~= 1 || tspan_size(2) ~= 2 || tspan(1)>tspan(2))
-        error('Drake:RigidBodyConstraint:BadInput','tspan should be a 1 x 2 vector, and tspan(1) <= tspan(2)');
-      end
-      obj.tspan = tspan;
     end
-    
+
     function cat_str = categoryString(obj)
       if(obj.category == RigidBodyConstraint.SingleTimeKinematicConstraintCategory)
         cat_str = 'SingleTimeKinematicConstraint';
@@ -101,9 +88,9 @@ classdef RigidBodyConstraint
         error('Drake:RigidBody:UnsupportedCategory','The constraint category is not supported');
       end
     end
-    
+
   end
-  
+
   methods(Abstract)
     cnstr = generateConstraint(obj,t)
     % Given the time, this method would generate a cell of Constraint objects, that encode

--- a/drake/systems/plants/constraint/SingleTimeKinematicConstraint.m
+++ b/drake/systems/plants/constraint/SingleTimeKinematicConstraint.m
@@ -28,6 +28,7 @@ classdef SingleTimeKinematicConstraint < RigidBodyConstraint
 
     function cnstr = generateConstraint(obj,t)
       % generate a FunctionHandleConstraint object if time is valid or if no time is given
+      if nargin < 2, t = inf; end;
       [lb,ub] = obj.bounds(t);
       cnstr = {FunctionHandleConstraint(lb,ub,obj.robot.getNumPositions,@(~,kinsol) obj.eval(t,kinsol))};
       name_str = obj.name(t);

--- a/drake/systems/plants/constraint/SingleTimeKinematicConstraint.m
+++ b/drake/systems/plants/constraint/SingleTimeKinematicConstraint.m
@@ -5,80 +5,50 @@ classdef SingleTimeKinematicConstraint < RigidBodyConstraint
   properties(SetAccess = protected,GetAccess = protected)
     num_constraint
   end
-  
+
   methods
-    function obj = SingleTimeKinematicConstraint(robot,tspan)
-      obj = obj@RigidBodyConstraint(RigidBodyConstraint.SingleTimeKinematicConstraintCategory,robot,tspan);
+    function obj = SingleTimeKinematicConstraint(robot)
+      obj = obj@RigidBodyConstraint(RigidBodyConstraint.SingleTimeKinematicConstraintCategory,robot);
     end
-    
-    function tspan = getTspan(obj)
-      tspan = obj.tspan;
-    end
-    
-    function flag = isTimeValid(obj,t)
-      if(isempty(t))
-        flag = true;
-      else
-        if(t>=obj.tspan(1)&&t<=obj.tspan(end))
-          flag = true;
-        else
-          flag = false;
-        end
-      end
-    end
-    
+
     function n = getNumConstraint(obj,t)
-      if(obj.isTimeValid(t))
-        n = obj.num_constraint;
-      else
-        n = 0;
-      end
+      n = obj.num_constraint;
     end
-    
+
     function obj = updateRobot(obj,robot)
       obj.robot = robot;
       if(robot.getMexModelPtr~=0 && exist('updatePtrRigidBodyConstraintmex','file'))
         obj.mex_ptr = updatePtrRigidBodyConstraintmex(obj.mex_ptr,'robot',robot.getMexModelPtr);
       end
     end
-    
+
     function [c,dc] = eval(obj,t,kinsol)
-      if(obj.isTimeValid(t))
-        [c,dc] = obj.evalValidTime(kinsol);
-      else
-        c = [];
-        dc = [];
-      end
+      [c,dc] = obj.evalValidTime(kinsol);
     end
-    
+
     function cnstr = generateConstraint(obj,t)
       % generate a FunctionHandleConstraint object if time is valid or if no time is given
-      if nargin < 2, t = obj.tspan(1); end;
-      if(obj.isTimeValid(t))
-        [lb,ub] = obj.bounds(t);
-        cnstr = {FunctionHandleConstraint(lb,ub,obj.robot.getNumPositions,@(~,kinsol) obj.eval(t,kinsol))};
-        name_str = obj.name(t);
-        cnstr{1} = cnstr{1}.setName(name_str);
-        joint_idx = obj.kinematicsPathJoints();
-        cnstr{1} = cnstr{1}.setSparseStructure(reshape(bsxfun(@times,(1:obj.num_constraint)',ones(1,length(joint_idx))),[],1),...
-          reshape(bsxfun(@times,ones(obj.num_constraint,1),joint_idx),[],1));
-      else
-        cnstr = {};
-      end
+      [lb,ub] = obj.bounds(t);
+      cnstr = {FunctionHandleConstraint(lb,ub,obj.robot.getNumPositions,@(~,kinsol) obj.eval(t,kinsol))};
+      name_str = obj.name(t);
+      cnstr{1} = cnstr{1}.setName(name_str);
+      joint_idx = obj.kinematicsPathJoints();
+      cnstr{1} = cnstr{1}.setSparseStructure(reshape(bsxfun(@times,(1:obj.num_constraint)',ones(1,length(joint_idx))),[],1),...
+					     reshape(bsxfun(@times,ones(obj.num_constraint,1),joint_idx),[],1));
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       % return the indices of the joints used to evaluate the constraint. The default
       % value is (1:obj.robot.getNumPositions);
       joint_idx = (1:obj.robot.getNumPositions);
     end
   end
-  
+
   methods(Abstract)
     [lb,ub] = bounds(obj,t)
     name_str = name(obj,t)
   end
-  
+
   methods(Abstract,Access = protected)
     [c,dc] = evalValidTime(obj,kinsol);
   end

--- a/drake/systems/plants/constraint/WorldCoMConstraint.m
+++ b/drake/systems/plants/constraint/WorldCoMConstraint.m
@@ -1,22 +1,21 @@
 classdef WorldCoMConstraint < PositionConstraint
 % @param robot            A RigidBodyManipulator, or a
-%                         TimeSteppingRigidBodyManipulator 
+%                         TimeSteppingRigidBodyManipulator
 % @param lb, ub           Both are 3x1 vectors. [lb, ub]
-%                         represents the bounding box for the 
+%                         represents the bounding box for the
 %                         position of Center of Mass in the world frame
-% @param tspan            OPTIONAL argument. A 1x2 vector
 % @param robotnum         The indices of the robot whose CoM is computed as a whole,default is 1.
   properties(SetAccess = protected)
     robotnum
     body
     body_name
   end
-  
+
   methods(Access = protected)
     function [pos,J] = evalPositions(obj,kinsol)
       [pos,J] = getCOM(obj.robot,kinsol,obj.robotnum);
     end
-    
+
     function cnst_names = evalNames(obj,t)
       cnst_names = cell(3,1);
       if(isempty(t))
@@ -29,16 +28,13 @@ classdef WorldCoMConstraint < PositionConstraint
         cnst_names{3} = sprintf('CoM z %s',time_str);
     end
   end
-  
+
   methods
-    function obj = WorldCoMConstraint(robot,lb,ub,tspan,robotnum)
-      if(nargin<=4)
+    function obj = WorldCoMConstraint(robot,lb,ub,robotnum)
+      if(nargin <= 3)
         robotnum = 1;
       end
-      if(nargin <= 3)
-        tspan = [-inf inf];
-      end
-      obj = obj@PositionConstraint(robot,[0;0;0],lb,ub,tspan);
+      obj = obj@PositionConstraint(robot,[0;0;0],lb,ub);
       if(~isempty(setdiff(robotnum,1:length(obj.robot.name))))
         error('Drake:WorldCoMConstraint: robotnum is not accepted');
       end
@@ -47,21 +43,21 @@ classdef WorldCoMConstraint < PositionConstraint
       obj.body = 0;
       obj.type = RigidBodyConstraint.WorldCoMConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldCoMConstraintType,robot.getMexModelPtr,lb,ub,tspan,robotnum);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldCoMConstraintType,robot.getMexModelPtr,lb,ub,robotnum);
       end
     end
-    
-    
-    
+
+
+
     function obj = updateRobotnum(obj,robotnum)
       if(~isempty(setdiff(robotnum,1:length(obj.robot.name))))
         error('Drake:WorldCoMConstraint: robotnum is not accepted');
       end
       obj.robotnum = robotnum;
-      if obj.mex_ptr ~=0 
+      if obj.mex_ptr ~=0
         obj.mex_ptr = updatePtrRigidBodyConstraintmex(obj.mex_ptr,'robotnum',robotnum);
       end
     end
-    
+
   end
 end

--- a/drake/systems/plants/constraint/WorldEulerConstraint.m
+++ b/drake/systems/plants/constraint/WorldEulerConstraint.m
@@ -2,15 +2,14 @@ classdef WorldEulerConstraint <EulerConstraint
 % constraint the roll, pitch, yaw angles (in intrinsic z-y'-x'' order)
 % to be within the bounding box [lb ub];
 % @param robot            A RigidBodyManipulator, or a
-%                         TimeSteppingRigidBodyManipulator  
+%                         TimeSteppingRigidBodyManipulator
 % @param body             A scalar, the index of the body
 % @param lb ub            Both are 3x1 vectors.
-% @param tspan            OPTIONAL argument. A 1x2 vector
   properties(SetAccess = protected)
     body
     body_name
   end
-  
+
   methods(Access = protected)
     function [rpy,J] = evalrpy(obj,kinsol)
       [pos,dpos] = forwardKin(obj.robot,kinsol,obj.body,[0;0;0],1);
@@ -18,46 +17,39 @@ classdef WorldEulerConstraint <EulerConstraint
       J = dpos(4:6,:);
     end
   end
-  
+
   methods
-    function obj = WorldEulerConstraint(robot,body,lb,ub,tspan)
-      if(nargin ==4)
-        tspan = [-inf inf];
-      end
-      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldEulerConstraintType,robot.getMexModelPtr,body,lb,ub,tspan);
-      obj = obj@EulerConstraint(robot,lb,ub,tspan);
+    function obj = WorldEulerConstraint(robot,body,lb,ub)
+      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldEulerConstraintType,robot.getMexModelPtr,body,lb,ub);
+      obj = obj@EulerConstraint(robot,lb,ub);
       obj.body = obj.robot.parseBodyOrFrameID(body);
       obj.body_name = obj.robot.getBodyOrFrameName(obj.body);
       obj.type = RigidBodyConstraint.WorldEulerConstraintType;
       obj.mex_ptr = ptr;
     end
-    
-    
-    
+
+
+
     function name_str = name(obj,t)
-      if(obj.isTimeValid(t))
-        name_str = cell(obj.num_constraint,1);
-        time_str = '';
-        if(~isempty(t))
-          time_str = sprintf('at time %5.2f',t);
-        end
-        constraint_idx = 1;
-        if(~obj.null_constraint_rows(1))
-          name_str{constraint_idx} = sprintf('%s roll %s',obj.body_name,time_str);
-          constraint_idx = constraint_idx+1;
-        end
-        if(~obj.null_constraint_rows(2))
-          name_str{constraint_idx} = sprintf('%s pitch %s',obj.body_name,t);
-          constraint_idx = constraint_idx+1;
-        end
-        if(~obj.null_constraint_rows(3))
-          name_str{constraint_idx} = sprintf('%s yaw %s',obj.body_name,t);
-        end
-      else
-        name_str = [];
+      name_str = cell(obj.num_constraint,1);
+      time_str = '';
+      if(~isempty(t))
+        time_str = sprintf('at time %5.2f',t);
+      end
+      constraint_idx = 1;
+      if(~obj.null_constraint_rows(1))
+        name_str{constraint_idx} = sprintf('%s roll %s',obj.body_name,time_str);
+        constraint_idx = constraint_idx+1;
+      end
+      if(~obj.null_constraint_rows(2))
+        name_str{constraint_idx} = sprintf('%s pitch %s',obj.body_name,t);
+        constraint_idx = constraint_idx+1;
+      end
+      if(~obj.null_constraint_rows(3))
+        name_str{constraint_idx} = sprintf('%s yaw %s',obj.body_name,t);
       end
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(1,obj.body);
       if isa(obj.robot,'TimeSteppingRigidBodyManipulator')

--- a/drake/systems/plants/constraint/WorldFixedBodyPoseConstraint.m
+++ b/drake/systems/plants/constraint/WorldFixedBodyPoseConstraint.m
@@ -4,15 +4,12 @@ classdef WorldFixedBodyPoseConstraint < MultipleTimeKinematicConstraint
   % @param robot         -- A RigidBodyManipulator or a
   %                         TimeSteppingRigidBodyManipulator
   % @param body          -- An int scalar, the body index
-  % @param tspan         -- Optional input, a 1x2 double array, the time span
-  %                             of this constaint being active. Default is
-  %                             [-inf inf]
-  
+
   properties(SetAccess = protected)
-    body 
+    body
     body_name
   end
-  
+
   methods(Access = protected)
     function [c,dc_valid] = evalValidTime(obj,kinsol_cell)
       N = length(kinsol_cell);
@@ -49,14 +46,11 @@ classdef WorldFixedBodyPoseConstraint < MultipleTimeKinematicConstraint
       end
     end
   end
-  
+
   methods
-    function obj = WorldFixedBodyPoseConstraint(robot,body,tspan)
-      if(nargin == 2)
-        tspan = [-inf inf];
-      end
-      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldFixedBodyPoseConstraintType,robot.getMexModelPtr,body,tspan);
-      obj = obj@MultipleTimeKinematicConstraint(robot,tspan);
+    function obj = WorldFixedBodyPoseConstraint(robot,body)
+      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldFixedBodyPoseConstraintType,robot.getMexModelPtr,body);
+      obj = obj@MultipleTimeKinematicConstraint(robot);
       sizecheck(body,[1,1]);
       if(~isnumeric(body))
         error('Drake:WorldFixedBodyPoseConstraint: body must be an integer');
@@ -66,17 +60,12 @@ classdef WorldFixedBodyPoseConstraint < MultipleTimeKinematicConstraint
       obj.type = RigidBodyConstraint.WorldFixedBodyPoseConstraintType;
       obj.mex_ptr = ptr;
     end
-    
+
     function num = getNumConstraint(obj,t)
-      valid_t = t(obj.isTimeValid(t));
-      if(length(valid_t)>=2)
-        num = 2;
-      else
-        num = 0;
-      end
+      num = 2;
     end
-    
-    
+
+
     function [lb,ub] = bounds(obj,t,N)
       % [lb,ub] = bounds(obj,t) returns the upper and lower bounds for this
       % constraint at all valid times given in t.
@@ -107,17 +96,12 @@ classdef WorldFixedBodyPoseConstraint < MultipleTimeKinematicConstraint
         end
       end
     end
-    
+
     function name_str = name(obj,t)
-      valid_t = t(obj.isTimeValid(t));
-      if(length(valid_t)>=2)
-        name_str = {sprintf('World fixed body pose constraint for %s position',obj.body_name);...
-          sprintf('World fixed body pose constraint for %s orientation',obj.body_name)};
-      else
-        name_str = {};
-      end
+      name_str = {sprintf('World fixed body pose constraint for %s position',obj.body_name);...
+		  sprintf('World fixed body pose constraint for %s orientation',obj.body_name)};
     end
-    
+
     function joint_idx = kinematicPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(1,obj.body);
       joint_idx = vertcat(obj.robot.body(joint_path).position_num)';

--- a/drake/systems/plants/constraint/WorldFixedOrientConstraint.m
+++ b/drake/systems/plants/constraint/WorldFixedOrientConstraint.m
@@ -4,14 +4,11 @@ classdef WorldFixedOrientConstraint < MultipleTimeKinematicConstraint
   % @param robot           -- A RigidBodyManipulator or a
   %                           TimeSteppingRigidBodyManipulator
   % @param body            -- An int scalar, the body index
-  % @param tspan           -- Optional input, a 1x2 double array. The time
-  %                           span of this constraint being active. Default
-  %                           is [-inf inf];
   properties(SetAccess = protected)
     body
     body_name
   end
-  
+
   methods(Access = protected)
     function [c,dc_valid] = evalValidTime(obj,valid_kinsol_cell)
       num_valid_t = length(valid_kinsol_cell);
@@ -40,15 +37,12 @@ classdef WorldFixedOrientConstraint < MultipleTimeKinematicConstraint
       end
     end
   end
-  
-  
+
+
   methods
-    function obj = WorldFixedOrientConstraint(robot,body,tspan)
-      if(nargin == 2)
-        tspan = [-inf inf];
-      end
-      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldFixedOrientConstraintType,robot.getMexModelPtr,body,tspan);
-      obj = obj@MultipleTimeKinematicConstraint(robot,tspan);
+    function obj = WorldFixedOrientConstraint(robot,body)
+      ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldFixedOrientConstraintType,robot.getMexModelPtr,body);
+      obj = obj@MultipleTimeKinematicConstraint(robot);
       sizecheck(body,[1,1]);
       if(~isnumeric(body))
         error('Drake:WorldFixedPositionConstraint: body must be an integer');
@@ -58,17 +52,12 @@ classdef WorldFixedOrientConstraint < MultipleTimeKinematicConstraint
       obj.type = RigidBodyConstraint.WorldFixedOrientConstraintType;
       obj.mex_ptr = ptr;
     end
-    
+
     function num = getNumConstraint(obj,t)
-      valid_t = t(obj.isTimeValid(t));
-      if(length(valid_t)>=2)
-        num = 1;
-      else
-        num = 0;
-      end
+      num = 1;
     end
-    
-    
+
+
     function [lb,ub] = bounds(obj,t,N)
       % [lb,ub] = bounds(obj,t) returns the upper and lower bounds for this
       % constraint at all valid times given in t.
@@ -99,16 +88,11 @@ classdef WorldFixedOrientConstraint < MultipleTimeKinematicConstraint
         end
       end
     end
-    
+
     function name_str = name(obj,t)
-      valid_t = t(obj.isTimeValid(t));
-      if(length(valid_t)>=2)
-        name_str = {sprintf('World fixed orientation constraint for %s',obj.body_name)};
-      else
-        name_str = {};
-      end
+      name_str = {sprintf('World fixed orientation constraint for %s',obj.body_name)};
     end
-    
+
     function joint_idx = kinematicPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(1,obj.body);
       joint_idx = vertcat(obj.robot.body(joint_path).position_num)';

--- a/drake/systems/plants/constraint/WorldFixedPositionConstraint.m
+++ b/drake/systems/plants/constraint/WorldFixedPositionConstraint.m
@@ -6,17 +6,14 @@ classdef WorldFixedPositionConstraint < MultipleTimeKinematicConstraint
   % @param body              -- An int scalar, the body index
   % @param pts               -- A 3 x npts double array, pts(:,i) is the i'th
   %                             point
-  % @param tspan             -- Optional input, a 1x2 double array, the time span
-  %                             of this constaint being active. Default is
-  %                             [-inf inf]
-  
+
   properties(SetAccess = protected)
     body
     body_name;
     pts
     tol = 0; % tolerance for the constraint
   end
-  
+
   methods(Access = protected)
     function [c,dc_valid] = evalValidTime(obj,kinsol_cell)
       N = length(kinsol_cell);
@@ -47,14 +44,11 @@ classdef WorldFixedPositionConstraint < MultipleTimeKinematicConstraint
       end
     end
   end
-  
+
   methods
-    function obj = WorldFixedPositionConstraint(robot,body,pts,tspan)
-      if nargin == 3
-        tspan = [-inf inf];
-      end
-      mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldFixedPositionConstraintType,robot.getMexModelPtr,body,pts,tspan);
-      obj = obj@MultipleTimeKinematicConstraint(robot,tspan);
+    function obj = WorldFixedPositionConstraint(robot,body,pts)
+      mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldFixedPositionConstraintType,robot.getMexModelPtr,body,pts);
+      obj = obj@MultipleTimeKinematicConstraint(robot);
       sizecheck(body,[1,1]);
       if(~isnumeric(body))
         error('Drake:WorldFixedPositionConstraint: body must be an integer');
@@ -75,7 +69,7 @@ classdef WorldFixedPositionConstraint < MultipleTimeKinematicConstraint
       obj.type = RigidBodyConstraint.WorldFixedPositionConstraintType;
       obj.mex_ptr = mex_ptr;
     end
-    
+
     function num = getNumConstraint(obj,t)
       valid_t = t(obj.isTimeValid(t));
       if(length(valid_t)>=2)
@@ -84,7 +78,7 @@ classdef WorldFixedPositionConstraint < MultipleTimeKinematicConstraint
         num = 0;
       end
     end
-    
+
     function [lb,ub] = bounds(obj,t,N)
       % [lb,ub] = bounds(obj,t) returns the upper and lower bounds for this
       % constraint at all valid times given in t.
@@ -116,7 +110,7 @@ classdef WorldFixedPositionConstraint < MultipleTimeKinematicConstraint
         end
       end
     end
-    
+
     % set the tolerance for the constraint, default is 0.
     function obj = setTol(obj,tol)
       if ~isnumeric(tol)
@@ -130,10 +124,10 @@ classdef WorldFixedPositionConstraint < MultipleTimeKinematicConstraint
       if tol < 0
         error('Drake:WorldFixedPositionConstraint:SignError','tol must be >= 0');
       end
-      
-       obj.tol = tol; 
+
+       obj.tol = tol;
     end
-    
+
     function name_str = name(obj,t)
       valid_t = t(obj.isTimeValid(t));
       if(length(valid_t)>=2)

--- a/drake/systems/plants/constraint/WorldGazeDirConstraint.m
+++ b/drake/systems/plants/constraint/WorldGazeDirConstraint.m
@@ -5,14 +5,13 @@ classdef WorldGazeDirConstraint < GazeDirConstraint
 % @param axis             A 3x1 unit vector, in the body frame
 % @param dir              A 3x1 unit vector, in the world frame
 % @param conethreshold    A scalar in [0 pi], default is 0
-% @param tspan            OPTIONAL argument. A 1x2 vector
 % The body axis lies within a cone, with the cone
 % aperture being 2*conethreshold, the cone axis being dir
   properties(SetAccess = protected)
     body;
     body_name;
   end
-  
+
   methods(Access = protected)
     function [c,dc] = evalValidTime(obj,kinsol)
       [axis_pos,daxis_pos] = forwardKin(obj.robot,kinsol,obj.body,[zeros(3,1) obj.axis],0);
@@ -22,31 +21,24 @@ classdef WorldGazeDirConstraint < GazeDirConstraint
       dc = obj.dir'*daxis_world;
     end
   end
-  
-  methods  
-    function obj = WorldGazeDirConstraint(robot,body,axis,dir,conethreshold,tspan)
-      if(nargin == 5)
-        tspan = [-inf inf];
-      end
-      
-      obj = obj@GazeDirConstraint(robot,axis,dir,conethreshold,tspan);
+
+  methods
+    function obj = WorldGazeDirConstraint(robot,body,axis,dir,conethreshold)
+
+      obj = obj@GazeDirConstraint(robot,axis,dir,conethreshold);
       obj.body = obj.robot.parseBodyOrFrameID(body);
       obj.body_name = obj.robot.getBodyOrFrameName(obj.body);
       obj.type = RigidBodyConstraint.WorldGazeDirConstraintType;
       if(robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file'))
-        ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldGazeDirConstraintType,robot.getMexModelPtr,body,axis,dir,conethreshold,tspan);
+        ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldGazeDirConstraintType,robot.getMexModelPtr,body,axis,dir,conethreshold);
         obj.mex_ptr = ptr;
       end
     end
-    
+
     function name_str = name(obj,t)
-      if(obj.isTimeValid(t))
-        name_str = {sprintf('%s conic gaze direction constraint at time %10.4f',obj.body_name,t)};
-      else
-        name_str = [];
-      end
+      name_str = {sprintf('%s conic gaze direction constraint at time %10.4f',obj.body_name,t)};
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(1,obj.body);
       joint_idx = vertcat(obj.robot.body(joint_path).position_num)';

--- a/drake/systems/plants/constraint/WorldGazeOrientConstraint.m
+++ b/drake/systems/plants/constraint/WorldGazeOrientConstraint.m
@@ -6,7 +6,6 @@ classdef WorldGazeOrientConstraint < GazeOrientConstraint
 % @param quat_des            a 4x1 unit vector
 % @param conethreshold       a scalar in [0,pi], default is 0
 % @param threshold           a scalar in [0,pi], default is pi
-% @param tspan            OPTIONAL argument. A 1x2 vector
 % quat_des is the nominal orientation of the body. The actual orientation
 % of the body satisfies that the axis lies within a cone, with the cone
 % aperture being 2*conethreshold, the cone axis being the direction that
@@ -17,7 +16,7 @@ classdef WorldGazeOrientConstraint < GazeOrientConstraint
     body
     body_name
   end
-  
+
   methods(Access = protected)
     function [quat, dquat_dq] = evalOrientation(obj,kinsol)
       [x,J] = forwardKin(obj.robot,kinsol,obj.body,[0;0;0],2);
@@ -25,30 +24,23 @@ classdef WorldGazeOrientConstraint < GazeOrientConstraint
       dquat_dq = J(4:7,:);
     end
   end
-  
+
   methods
-    function obj = WorldGazeOrientConstraint(robot,body,axis,quat_des,conethreshold,threshold,tspan)
-      if(nargin == 6)
-        tspan = [-inf inf];
-      end
-      obj = obj@GazeOrientConstraint(robot,axis,quat_des,conethreshold,threshold,tspan);
+    function obj = WorldGazeOrientConstraint(robot,body,axis,quat_des,conethreshold,threshold)
+      obj = obj@GazeOrientConstraint(robot,axis,quat_des,conethreshold,threshold);
       obj.body = obj.robot.parseBodyOrFrameID(body);
       obj.body_name = obj.robot.getBodyOrFrameName(obj.body);
       obj.type = RigidBodyConstraint.WorldGazeOrientConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldGazeOrientConstraintType,robot.getMexModelPtr,body,axis,quat_des,conethreshold,threshold,tspan);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldGazeOrientConstraintType,robot.getMexModelPtr,body,axis,quat_des,conethreshold,threshold);
       end
     end
 
     function name_str = name(obj,t)
-      if(obj.isTimeValid(t))
-        name_str = {sprintf('%s conic gaze orientation constraint at time %10.4f',obj.body_name,t);...
-          sprintf('%s revolute gaze orientation constraint at time %10.4f',obj.body_name,t)};
-      else
-        name_str = [];
-      end
+      name_str = {sprintf('%s conic gaze orientation constraint at time %10.4f',obj.body_name,t);...
+		  sprintf('%s revolute gaze orientation constraint at time %10.4f',obj.body_name,t)};
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(1,obj.body);
       joint_idx = vertcat(obj.robot.body(joint_path).position_num)';

--- a/drake/systems/plants/constraint/WorldPositionConstraint.m
+++ b/drake/systems/plants/constraint/WorldPositionConstraint.m
@@ -5,19 +5,18 @@ classdef WorldPositionConstraint < PositionConstraint
 % @param pts              A 3xn_pts matrix, pts(:,i) represents ith pts in
 %                         the body
 % @param lb, ub           Both are 3xn_pts matrices. [lb(:,i), ub(:,i)]
-%                         represents the bounding box for the 
+%                         represents the bounding box for the
 %                         position of pts(:,i) in the world frame
-% @param tspan            OPTIONAL argument. A 1x2 vector
   properties(SetAccess = protected)
     body
     body_name
   end
-  
+
   methods(Access = protected)
     function [pos,J] = evalPositions(obj,kinsol)
       [pos,J] = forwardKin(obj.robot,kinsol,obj.body,obj.pts,0);
     end
-    
+
     function cnst_names = evalNames(obj,t)
       cnst_names = cell(3*obj.n_pts,1);
       if(isempty(t))
@@ -32,20 +31,19 @@ classdef WorldPositionConstraint < PositionConstraint
       end
     end
   end
-  
+
   methods
-    function obj = WorldPositionConstraint(robot,body,pts,lb,ub,tspan)
+    function obj = WorldPositionConstraint(robot,body,pts,lb,ub)
       if(nargin<5), ub = lb; end
-      if(nargin<6), tspan = [-inf,inf]; end
-      obj = obj@PositionConstraint(robot,pts,lb,ub,tspan);
+      obj = obj@PositionConstraint(robot,pts,lb,ub);
       obj.body = obj.robot.parseBodyOrFrameID(body);
       obj.body_name = obj.robot.getBodyOrFrameName(obj.body);
       obj.type = RigidBodyConstraint.WorldPositionConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldPositionConstraintType,robot.getMexModelPtr,body,pts,lb,ub,tspan);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldPositionConstraintType,robot.getMexModelPtr,body,pts,lb,ub);
       end
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(1,obj.body);
       if isa(obj.robot,'TimeSteppingRigidBodyManipulator')
@@ -54,6 +52,6 @@ classdef WorldPositionConstraint < PositionConstraint
         joint_idx = vertcat(obj.robot.body(joint_path).position_num)';
       end
     end
-    
+
   end
 end

--- a/drake/systems/plants/constraint/WorldPositionInFrameConstraint.m
+++ b/drake/systems/plants/constraint/WorldPositionInFrameConstraint.m
@@ -5,23 +5,22 @@ classdef WorldPositionInFrameConstraint < WorldPositionConstraint
 % @param pts              A 3xn_pts matrix, pts(:,i) represents ith pts in
 %                         the body
 % @param lb, ub           Both are 3xn_pts matrices. [lb(:,i), ub(:,i)]
-%                         represents the bounding box for the 
+%                         represents the bounding box for the
 %                         position of pts(:,i) in the world frame
 % @param T                Homogeneous transform of the frame in which the
 %                         positions should be evaluated
-% @param tspan            OPTIONAL argument. A 1x2 vector
   properties(SetAccess = protected)
     f_T_o
     o_T_f
   end
-  
+
   methods(Access = protected)
     function [pos,J] = evalPositions(obj,kinsol)
       [pos,J] = forwardKin(obj.robot,kinsol,obj.body,obj.pts,0);
       pos = homogTransMult(obj.f_T_o,pos);
       J = reshape(obj.f_T_o(1:3,1:3)*reshape(J,3,[]),3*obj.n_pts,[]);
     end
-    
+
     function cnst_names = evalNames(obj,t)
       cnst_names = cell(3*obj.n_pts,1);
       if(isempty(t))
@@ -36,24 +35,21 @@ classdef WorldPositionInFrameConstraint < WorldPositionConstraint
       end
     end
   end
-  
+
   methods
-    function obj = WorldPositionInFrameConstraint(robot,body,pts,o_T_f,lb,ub,tspan)
-      if(nargin < 7)
-        tspan = [-inf,inf];
-      end
-      obj = obj@WorldPositionConstraint(robot,body,pts,lb,ub,tspan);
+    function obj = WorldPositionInFrameConstraint(robot,body,pts,o_T_f,lb,ub)
+      obj = obj@WorldPositionConstraint(robot,body,pts,lb,ub);
       obj.o_T_f = o_T_f;
       obj.f_T_o = invHT(o_T_f);
       obj.type = RigidBodyConstraint.WorldPositionInFrameConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldPositionInFrameConstraintType,robot.getMexModelPtr,body,pts,o_T_f,lb,ub,tspan);
+        ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldPositionInFrameConstraintType,robot.getMexModelPtr,body,pts,o_T_f,lb,ub);
         obj.mex_ptr = ptr;
       end
     end
-    
-    
-    
+
+
+
     function drawConstraint(obj,q,lcmgl)
       kinsol = doKinematics(obj.robot,q,false,false);
       pts_w = forwardKin(obj.robot,kinsol,obj.body,obj.pts);

--- a/drake/systems/plants/constraint/WorldQuatConstraint.m
+++ b/drake/systems/plants/constraint/WorldQuatConstraint.m
@@ -3,7 +3,7 @@ classdef WorldQuatConstraint < QuatConstraint
 % @param robot            A RigidBodyManipulator, or a
 %                         TimeSteppingRigidBodyManipulator
 % @param body             A scalar. The index of the body
-% @param quat_des         A quaternion. The desired body orientation 
+% @param quat_des         A quaternion. The desired body orientation
 % @param tol              A nonnegative scalar between [0 pi]. tol is the maximum angle of
 %                         the allowable rotation that would rotate actual quaternion to quat_des
   properties(SetAccess = protected)
@@ -11,7 +11,7 @@ classdef WorldQuatConstraint < QuatConstraint
     quat_des
     body_name
   end
-  
+
   methods(Access = protected)
     function [orient_prod, dorient_prod] = evalOrientationProduct(obj,kinsol)
       [pos,J] = forwardKin(obj.robot,kinsol,obj.body,[0;0;0],2);
@@ -21,13 +21,10 @@ classdef WorldQuatConstraint < QuatConstraint
       dorient_prod = obj.quat_des'*dquat;
     end
   end
-  
+
   methods
-    function obj = WorldQuatConstraint(robot,body,quat_des,tol,tspan)
-      if(nargin == 4)
-        tspan = [-inf,inf];
-      end
-      obj = obj@QuatConstraint(robot,tol,tspan);
+    function obj = WorldQuatConstraint(robot,body,quat_des,tol)
+      obj = obj@QuatConstraint(robot,tol);
       sizecheck(quat_des,[4,1]);
       if(any(isinf(quat_des)|isnan(quat_des)))
         error('Drake:orientConstraint:quat_des cannot have nan or inf entries');
@@ -37,20 +34,14 @@ classdef WorldQuatConstraint < QuatConstraint
       obj.body_name = obj.robot.getBodyOrFrameName(obj.body);
       obj.type = RigidBodyConstraint.WorldQuatConstraintType;
       if robot.getMexModelPtr~=0 && exist('constructPtrRigidBodyConstraintmex','file')
-        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldQuatConstraintType,robot.getMexModelPtr,body,quat_des,tol,tspan);
+        obj.mex_ptr = constructPtrRigidBodyConstraintmex(RigidBodyConstraint.WorldQuatConstraintType,robot.getMexModelPtr,body,quat_des,tol);
       end
     end
-    
-    
-    
+
     function name_str = name(obj,t)
-      if(obj.isTimeValid(t))
-        name_str = {sprintf('%s quaternion constraint at time %10.4f',obj.body_name,t)};
-      else
-        name_str = [];
-      end
+      name_str = {sprintf('%s quaternion constraint at time %10.4f',obj.body_name,t)};
     end
-    
+
     function joint_idx = kinematicsPathJoints(obj)
       [~,joint_path] = obj.robot.findKinematicPath(1,obj.body);
       joint_idx = vertcat(obj.robot.body(joint_path).position_num)';

--- a/drake/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
+++ b/drake/systems/plants/constraint/constructPtrRigidBodyConstraintmex.cpp
@@ -44,7 +44,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
                           "robot_ptr, robotnum)");
       }
       RigidBodyTree* model = (RigidBodyTree*)getDrakeMexPointer(prhs[1]);
-      Vector2d tspan;
       int* robotnum;
       size_t num_robot;
       if (nrhs <= 2) {
@@ -61,10 +60,9 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
         }
         delete[] robotnum_tmp;
       }
-      tspan << -mxGetInf(), mxGetInf();
       set<int> robotnumset(robotnum, robotnum + num_robot);
       QuasiStaticConstraint* cnst =
-          new QuasiStaticConstraint(model, tspan, robotnumset);
+          new QuasiStaticConstraint(model, robotnumset);
       plhs[0] =
           createDrakeConstraintMexPointer((void*)cnst, "QuasiStaticConstraint");
       delete[] robotnum;
@@ -464,7 +462,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
       }
       RigidBodyTree* model = (RigidBodyTree*)getDrakeMexPointer(prhs[1]);
       WorldCoMConstraint* cnst = nullptr;
-      Vector2d tspan;
       int* robotnum;
       size_t num_robot;
       if (nrhs <= 4) {
@@ -481,7 +478,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
         }
         delete[] robotnum_tmp;
       }
-      tspan << -mxGetInf(), mxGetInf();
       set<int> robotnumset(robotnum, robotnum + num_robot);
       int n_pts = 1;
       if (mxGetM(prhs[2]) != 3 || mxGetM(prhs[3]) != 3 ||
@@ -494,7 +490,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
       Vector3d ub;
       memcpy(lb.data(), mxGetPrSafe(prhs[2]), sizeof(double) * 3);
       memcpy(ub.data(), mxGetPrSafe(prhs[3]), sizeof(double) * 3);
-      cnst = new WorldCoMConstraint(model, lb, ub, tspan, robotnumset);
+      cnst = new WorldCoMConstraint(model, lb, ub, robotnumset);
       plhs[0] =
           createDrakeConstraintMexPointer((void*)cnst, "WorldCoMConstraint");
       delete[] robotnum;

--- a/drake/systems/plants/constraint/test/RelativeGazeTargetConstraintTest.m
+++ b/drake/systems/plants/constraint/test/RelativeGazeTargetConstraintTest.m
@@ -19,5 +19,5 @@ function con = makeCon(r)
   %[x,y,z] = sph2cart(pi*rand-pi/2,pi*rand-pi/2,1);
   x = 1; y = 0; z = 0;
   ax = [x;y;z];
-  con = RelativeGazeTargetConstraint(r,body_a_idx,body_b_idx,ax,target,gaze_origin,pi/32,[0 1]);
+  con = RelativeGazeTargetConstraint(r,body_a_idx,body_b_idx,ax,target,gaze_origin,pi/32);
 end

--- a/drake/systems/plants/constraint/test/RelativePositionConstraintTest.m
+++ b/drake/systems/plants/constraint/test/RelativePositionConstraintTest.m
@@ -24,5 +24,5 @@ function con = makeCon(r)
   T = [xyz;rpy2quat(rpy)];
 %   T = [rpy2rotmat(rpy),xyz;zeros(1,3),1];
 
-  con = RelativePositionConstraint(r,pts,lb,ub,bodyA_idx,bodyB_idx,T,[0 1]);
+  con = RelativePositionConstraint(r,pts,lb,ub,bodyA_idx,bodyB_idx,T);
 end

--- a/drake/systems/plants/constraint/test/RelativeQuatConstraintTest.m
+++ b/drake/systems/plants/constraint/test/RelativeQuatConstraintTest.m
@@ -17,5 +17,5 @@ function con = makeCon(r)
   warning(w);
   rpy = 2*pi*rand(3,1) - pi;
   quat = rpy2quat(rpy);
-  con = RelativeQuatConstraint(r,bodyA_idx,bodyB_idx,quat,0,[0,1]);
+  con = RelativeQuatConstraint(r,bodyA_idx,bodyB_idx,quat,0);
 end

--- a/drake/systems/plants/constraint/test/WorldPositionInFrameConstraintTest.m
+++ b/drake/systems/plants/constraint/test/WorldPositionInFrameConstraintTest.m
@@ -24,5 +24,5 @@ function con = makeCon(r)
 
   T = [rpy2rotmat(rpy),xyz;zeros(1,3),1];
 
-  con = WorldPositionInFrameConstraint(r,bodyA_idx,pts,T,lb,ub,[0 1]);
+  con = WorldPositionInFrameConstraint(r,bodyA_idx,pts,T,lb,ub);
 end

--- a/drake/systems/plants/constraint/test/testConstraintConstructor.cpp
+++ b/drake/systems/plants/constraint/test/testConstraintConstructor.cpp
@@ -12,13 +12,11 @@ int main() {
     cerr << "ERROR: Failed to load model" << endl;
     return -1;
   }
-  Eigen::Vector2d tspan;
-  tspan << 0, 1;
   Eigen::Vector3d kc1_lb, kc1_ub;
   kc1_lb << 0, 0, 0;
   kc1_ub << 0, 0, 0;
   WorldCoMConstraint* kc1 =
-      new WorldCoMConstraint(model, kc1_lb, kc1_ub, tspan);
+      new WorldCoMConstraint(model, kc1_lb, kc1_ub);
   printf("construct WorldCoMConstraint\n");
   delete kc1;
   printf("delete WorldCoMConstraint\n");

--- a/drake/systems/plants/constraint/test/testKinCnst.m
+++ b/drake/systems/plants/constraint/test/testKinCnst.m
@@ -52,78 +52,57 @@ end
 
 q = getRandomConfiguration(robot);
 q_aff = [q;randn(length(robot_aff.getStateFrame.frame{2}.getCoordinateNames())/2,1)];
-tspan0 = [0,1];
-tspan1 = [];
 t_valid = 0.5;
-t_invalid = 1000;
 q_rot1 = q;
 q_rot1(6) = pi/2 + 0.01;
 kinsol = doKinematics(robot, q_rot1);
 l_foot_pos = forwardKin(robot, kinsol, l_foot, l_foot_pts, 2);
 
 display('Check world CoM constraint');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot,robot_aff,[0;0;0.9],[0;0;1],tspan0,1);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldCoMConstraintType,robot,[0;0;0.9],[0;0;1],tspan0,1);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot,robot_aff,[0;0;0.9],[0;0;1],1);
 display('Check world CoM constraint with empty robot number');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot,robot_aff,[0;0;0.9],[0;0;1],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldCoMConstraintType,robot,[0;0;0.9],[0;0;1],tspan0);
-display('Check world CoM constraint with empty tspan');
 testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot,robot_aff,[0;0;0.9],[0;0;1]);
 display('Check world CoM constraint with nan');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot,robot_aff,[-inf;nan;0.9],[nan;inf;0.92],tspan0/2);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldCoMConstraintType,robot,[-inf;nan;0.9],[nan;inf;0.92],tspan0/2);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot,robot_aff,[-inf;nan;0.9],[nan;inf;0.92]);
 display('Check world CoM constraint with multiple robots');
-testKinCnst_userfun(true,false,t_valid,q_aff,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot_aff,robot_aff,[0;0;0.9],[0;0;1],tspan0,[1,2]);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot_aff,[0;0;0.9],[0;0;1],tspan0);
+testKinCnst_userfun(true,false,t_valid,q_aff,q_aff,RigidBodyConstraint.WorldCoMConstraintType,robot_aff,robot_aff,[0;0;0.9],[0;0;1],[1,2]);
 
 display('Check world position constraint');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldPositionConstraintType,robot,robot_aff,l_foot,l_foot_pts,[-100*ones(2,nLPts);zeros(1,nLPts)],[100*ones(2,nLPts);zeros(1,nLPts)],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldPositionConstraintType,robot,l_foot,l_foot_pts,[-100*ones(2,nLPts);zeros(1,nLPts)],[100*ones(2,nLPts);zeros(1,nLPts)],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldPositionConstraintType,robot,robot_aff,l_foot,l_foot_pts,[-100*ones(2,nLPts);zeros(1,nLPts)],[100*ones(2,nLPts);zeros(1,nLPts)]);
 
 display('Check world position constraint with nan');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldPositionConstraintType,robot,robot_aff,l_foot,l_foot_pts,[nan(2,nLPts);zeros(1,nLPts)],[nan(2,nLPts);zeros(1,nLPts)],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldPositionConstraintType,robot,l_foot,l_foot_pts,[nan(2,nLPts);zeros(1,nLPts)],[nan(2,nLPts);zeros(1,nLPts)],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldPositionConstraintType,robot,robot_aff,l_foot,l_foot_pts,[nan(2,nLPts);zeros(1,nLPts)],[nan(2,nLPts);zeros(1,nLPts)]);
 
 display('Check world quaternion constraint')
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldQuatConstraintType,robot,robot_aff,r_foot,[1;0;0;0],0.01,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldQuatConstraintType,robot,r_foot,[1;0;0;0],0.01,tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldQuatConstraintType,robot,robot_aff,r_foot,[1;0;0;0],0.01);
 
 display('Check world quaternion constraint, a subtle case')
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldQuatConstraintType,robot,robot_aff,l_foot,l_foot_pos(4:7,1),0,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldQuatConstraintType,robot,l_foot,l_foot_pos(4:7,1),0,tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldQuatConstraintType,robot,robot_aff,l_foot,l_foot_pos(4:7,1),0);
 
 display('Check world euler constraint')
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldEulerConstraintType,robot,robot_aff,l_foot,[0;nan;0.9*pi],[0;nan;1.1*pi],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldEulerConstraintType,robot,l_foot,[0;nan;0.9*pi],[0;nan;1.1*pi],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldEulerConstraintType,robot,robot_aff,l_foot,[0;nan;0.9*pi],[0;nan;1.1*pi]);
 
 display('Check world gaze orientation constraint')
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeOrientConstraintType,robot,robot_aff,head,[1;0;0],[0.5;0.5;-0.5;0.5],0.3*pi,0.1*pi,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldGazeOrientConstraintType,robot,head,[1;0;0],[0.5;0.5;-0.5;0.5],0.3*pi,0.1*pi,tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeOrientConstraintType,robot,robot_aff,head,[1;0;0],[0.5;0.5;-0.5;0.5],0.3*pi,0.1*pi);
 
 display('Check world gaze orientation constraint with empty threshold')
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeOrientConstraintType,robot,robot_aff,head,[1;0;0],[0.5;0.5;-0.5;0.5],[],[],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldGazeOrientConstraintType,robot,head,[1;0;0],[0.5;0.5;-0.5;0.5],[],[],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeOrientConstraintType,robot,robot_aff,head,[1;0;0],[0.5;0.5;-0.5;0.5],[],[]);
 
 display('Check world gaze direction constraint')
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeDirConstraintType,robot,robot_aff,l_hand,[1;0;0],[0.5;0.3;0.4],0.3*pi,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldGazeDirConstraintType,robot,l_hand,[1;0;0],[0.5;0.3;0.4],0.3*pi,tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeDirConstraintType,robot,robot_aff,l_hand,[1;0;0],[0.5;0.3;0.4],0.3*pi);
 
 display('Check world gaze direction constraint with empty threshold')
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeDirConstraintType,robot,robot_aff,head,[1;0;0],[0.5;0.3;0.4],[],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldGazeDirConstraintType,robot,head,[1;0;0],[0.5;0.3;0.4],[],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeDirConstraintType,robot,robot_aff,head,[1;0;0],[0.5;0.3;0.4],[]);
 
 display('Check world gaze target constraint');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeTargetConstraintType,robot,robot_aff,head,[1;0;0],[20;10;1],[0.3;0.1;0.2],0.3*pi,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldGazeTargetConstraintType,robot,head,[1;0;0],[20;10;1],[0.3;0.1;0.2],0.3*pi,tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeTargetConstraintType,robot,robot_aff,head,[1;0;0],[20;10;1],[0.3;0.1;0.2],0.3*pi);
 
 display('Check world gaze target constraint with empty threshold');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeTargetConstraintType,robot,robot_aff,head,[1;0;0],[20;10;1],[0.3;0.1;0.2],[],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldGazeTargetConstraintType,robot,head,[1;0;0],[20;10;1],[0.3;0.1;0.2],[],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldGazeTargetConstraintType,robot,robot_aff,head,[1;0;0],[20;10;1],[0.3;0.1;0.2],[]);
 
 t2 = [0 0.5 1];
 q21 = randn(nq,length(t2));
 q22 = repmat(randn(nq,1),1,length(t2));
-tspan2 = [0.3 0.7];
 t3 = [0 0.1 0.4 0.5 0.6 0.8];
 q31 = repmat(randn(nq,1),1,length(t3));
 % q21_aff = randn(nq_aff,length(t2));
@@ -133,125 +112,110 @@ q21_aff = [q21;randn(length(robot_aff.getStateFrame.frame{2}.getCoordinateNames(
 q22_aff = [q22;repmat(randn(length(robot_aff.getStateFrame.frame{2}.getCoordinateNames())/2,1),1,length(t2))];
 q31_aff = [q31;repmat(randn(length(robot_aff.getStateFrame.frame{2}.getCoordinateNames())/2,1),1,length(t3))];
 display('Check world fixed position constraint')
-testKinCnst_userfun(false,false,t2,q21,q21_aff,RigidBodyConstraint.WorldFixedPositionConstraintType,robot,robot_aff,l_hand,[[0;0;1] [1;0;1]],tspan0);
-kc = WorldFixedPositionConstraint(robot,l_hand,[[0;0;1] [1;0;1]],tspan0);
+testKinCnst_userfun(false,false,t2,q21,q21_aff,RigidBodyConstraint.WorldFixedPositionConstraintType,robot,robot_aff,l_hand,[[0;0;1] [1;0;1]]);
+kc = WorldFixedPositionConstraint(robot,l_hand,[[0;0;1] [1;0;1]]);
 kinsol_cell = cell(1,size(q22,2));
 for i = 1:size(q22,2)
   kinsol_cell{i} = kc.robot.doKinematics(q22(:,i),false,false);
 end
 [c,dc] = kc.eval(t2,kinsol_cell);
 valuecheck(c,[0;0]);
-testKinCnst_userfun(false,false,t2,q22,q22_aff,RigidBodyConstraint.WorldFixedPositionConstraintType,robot,robot_aff,l_hand,[[0;0;1] [1;0;1]],tspan0);
+testKinCnst_userfun(false,false,t2,q22,q22_aff,RigidBodyConstraint.WorldFixedPositionConstraintType,robot,robot_aff,l_hand,[[0;0;1] [1;0;1]]);
 
-kc = WorldFixedPositionConstraint(robot,l_hand,[[0;0;1] [1;0;1]],tspan2);
+kc = WorldFixedPositionConstraint(robot,l_hand,[[0;0;1] [1;0;1]]);
 kinsol_cell = cell(1,size(q31,2));
 for i = 1:size(q31,2)
   kinsol_cell{i} = kc.robot.doKinematics(q31(:,i),false,false);
 end
 [c,dc] = kc.eval(t3,kinsol_cell);
 valuecheck(c,[0;0]);
-testKinCnst_userfun(false,false,t3,q31,q31_aff,RigidBodyConstraint.WorldFixedPositionConstraintType,robot,robot_aff,l_hand,[[0;0;1] [1;0;1]],tspan2);
+testKinCnst_userfun(false,false,t3,q31,q31_aff,RigidBodyConstraint.WorldFixedPositionConstraintType,robot,robot_aff,l_hand,[[0;0;1] [1;0;1]]);
 
 display('Check world fixed orientation constraint')
-testKinCnst_userfun(false,false,t2,q21,q21_aff,RigidBodyConstraint.WorldFixedOrientConstraintType,robot,robot_aff,l_hand,tspan0);
-kc = WorldFixedOrientConstraint(robot,l_hand,tspan0);
+testKinCnst_userfun(false,false,t2,q21,q21_aff,RigidBodyConstraint.WorldFixedOrientConstraintType,robot,robot_aff,l_hand);
+kc = WorldFixedOrientConstraint(robot,l_hand);
 kinsol_cell = cell(1,size(q22,2));
 for i = 1:size(q22,2)
   kinsol_cell{i} = kc.robot.doKinematics(q22(:,i),false,false);
 end
 [c,dc] = kc.eval(t2,kinsol_cell);
 valuecheck(c,length(t2));
-testKinCnst_userfun(false,false,t2,q22,q22_aff,RigidBodyConstraint.WorldFixedOrientConstraintType,robot,robot_aff,l_hand,tspan0);
+testKinCnst_userfun(false,false,t2,q22,q22_aff,RigidBodyConstraint.WorldFixedOrientConstraintType,robot,robot_aff,l_hand);
 
-kc = WorldFixedOrientConstraint(robot,l_hand,tspan2);
+kc = WorldFixedOrientConstraint(robot,l_hand);
 kinsol_cell = cell(1,size(q31,2));
 for i = 1:size(q31,2)
   kinsol_cell{i} = kc.robot.doKinematics(q31(:,i),false,false);
 end
 [c,dc] = kc.eval(t3,kinsol_cell);
-valuecheck(c,sum(kc.isTimeValid(t3)));
-testKinCnst_userfun(false,false,t3,q31,q31_aff,RigidBodyConstraint.WorldFixedOrientConstraintType,robot,robot_aff,l_hand,tspan2);
+testKinCnst_userfun(false,false,t3,q31,q31_aff,RigidBodyConstraint.WorldFixedOrientConstraintType,robot,robot_aff,l_hand);
 
 display('Check world fixed body pose constraint')
-testKinCnst_userfun(false,false,t2,q21,q21_aff,RigidBodyConstraint.WorldFixedBodyPoseConstraintType,robot,robot_aff,l_hand,tspan0);
-kc = WorldFixedBodyPoseConstraint(robot,l_hand,tspan0);
+testKinCnst_userfun(false,false,t2,q21,q21_aff,RigidBodyConstraint.WorldFixedBodyPoseConstraintType,robot,robot_aff,l_hand);
+kc = WorldFixedBodyPoseConstraint(robot,l_hand);
 kinsol_cell = cell(1,size(q22,2));
 for i = 1:size(q22,2)
   kinsol_cell{i} = kc.robot.doKinematics(q22(:,i),false,false);
 end
 [c,dc] = kc.eval(t2,kinsol_cell);
 valuecheck(c,[0;length(t2)]);
-testKinCnst_userfun(false,false,t2,q22,q22_aff,RigidBodyConstraint.WorldFixedBodyPoseConstraintType,robot,robot_aff,l_hand,tspan0);
+testKinCnst_userfun(false,false,t2,q22,q22_aff,RigidBodyConstraint.WorldFixedBodyPoseConstraintType,robot,robot_aff,l_hand);
 
-kc = WorldFixedBodyPoseConstraint(robot,l_hand,tspan2);
+kc = WorldFixedBodyPoseConstraint(robot,l_hand);
 kinsol_cell = cell(1,size(q31,2));
 for i = 1:size(q31,2)
   kinsol_cell{i} = kc.robot.doKinematics(q31(:,i),false,false);
 end
 [c,dc] = kc.eval(t3,kinsol_cell);
-valuecheck(c,[0;sum(kc.isTimeValid(t3))]);
-testKinCnst_userfun(false,false,t3,q31,q31_aff,RigidBodyConstraint.WorldFixedBodyPoseConstraintType,robot,robot_aff,l_hand,tspan2);
+testKinCnst_userfun(false,false,t3,q31,q31_aff,RigidBodyConstraint.WorldFixedBodyPoseConstraintType,robot,robot_aff,l_hand);
 
 
 if checkDependency('bullet')
   display('Check all-to-all closest-distance constraint');
-  testKinCnst_userfun(true,true,t_valid,q,q_aff,RigidBodyConstraint.AllBodiesClosestDistanceConstraintType,robot_collision,robot_collision_aff,0.05,1e1,struct(),tspan0);
-  testKinCnstInvalidTime_userfun(true,true,t_invalid,q,RigidBodyConstraint.AllBodiesClosestDistanceConstraintType,robot_collision,0.05,1e1,struct(),tspan0);
+  testKinCnst_userfun(true,true,t_valid,q,q_aff,RigidBodyConstraint.AllBodiesClosestDistanceConstraintType,robot_collision,robot_collision_aff,0.05,1e1,struct());
 
   display('Check minimum distance constraint');
-  testKinCnst_userfun(true,true,t_valid,q,q_aff,RigidBodyConstraint.MinDistanceConstraintType,robot_collision,robot_collision_aff,0.05,[],tspan0);
-  testKinCnstInvalidTime_userfun(true,true,t_invalid,q,RigidBodyConstraint.MinDistanceConstraintType,robot_collision,0.05,[],tspan0);
+  testKinCnst_userfun(true,true,t_valid,q,q_aff,RigidBodyConstraint.MinDistanceConstraintType,robot_collision,robot_collision_aff,0.05,[]);
 end
 
 display('Check point to point distance constraint');
 lhand_pts = rand(3,2);
 rhand_pts = rand(3,2);
-kc = Point2PointDistanceConstraint(robot,l_hand,r_hand,lhand_pts,rhand_pts,[0 0],[1 1],tspan0);
+kc = Point2PointDistanceConstraint(robot,l_hand,r_hand,lhand_pts,rhand_pts,[0 0],[1 1]);
 kinsol = doKinematics(robot,q);
 lhand_pos = forwardKin(robot,kinsol,l_hand,lhand_pts,0);
 rhand_pos = forwardKin(robot,kinsol,r_hand,rhand_pts,0);
 [c,dc] = kc.eval(t_valid,kinsol);
 valuecheck(c',sum((lhand_pos-rhand_pos).*(lhand_pos-rhand_pos),1));
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.Point2PointDistanceConstraintType,robot,robot_aff,l_hand,r_hand,lhand_pts,rhand_pts,[0 0],[1 1],tspan0);
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.Point2PointDistanceConstraintType,robot,robot_aff,1,r_hand,rand(3,2),rhand_pts,[0 0],[1 1],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.Point2PointDistanceConstraintType,robot,1,r_hand,rand(3,2),rhand_pts,[0 0],[1 1],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.Point2PointDistanceConstraintType,robot,robot_aff,l_hand,r_hand,lhand_pts,rhand_pts,[0 0],[1 1]);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.Point2PointDistanceConstraintType,robot,robot_aff,1,r_hand,rand(3,2),rhand_pts,[0 0],[1 1]);
 
 display('Check world position in frame constraint');
 rpy = 2*pi*rand(3,1) - pi;
 xyz = [0.2;0.2;0.2].*rand(3,1) + [0.5;0.0;0.5];
 T = [rpy2rotmat(rpy),xyz;zeros(1,3),1];
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldPositionInFrameConstraintType,robot,robot_aff,l_foot,l_foot_pts,T,[-100*ones(2,nLPts);zeros(1,nLPts)],[100*ones(2,nLPts);zeros(1,nLPts)],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.WorldPositionInFrameConstraintType,robot,l_foot,l_foot_pts,T,[-100*ones(2,nLPts);zeros(1,nLPts)],[100*ones(2,nLPts);zeros(1,nLPts)],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.WorldPositionInFrameConstraintType,robot,robot_aff,l_foot,l_foot_pts,T,[-100*ones(2,nLPts);zeros(1,nLPts)],[100*ones(2,nLPts);zeros(1,nLPts)]);
 
 display('Check point to line segment distance constraint');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.Point2LineSegDistConstraintType,robot,robot_aff,l_hand,[0;0;0],r_foot,r_foot_pts(:,1:2),0.1,1,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.Point2LineSegDistConstraintType,robot,l_hand,[0;0;0],r_foot,r_foot_pts(:,1:2),0.1,1,tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.Point2LineSegDistConstraintType,robot,robot_aff,l_hand,[0;0;0],r_foot,r_foot_pts(:,1:2),0.1,1);
 
 display('Check Relative gaze target constraint');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.RelativeGazeTargetConstraintType,robot,robot_aff,head,r_hand,[1;0;0],[0;0;0],[0;0;0],pi/30,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.RelativeGazeTargetConstraintType,robot,head,r_hand,[1;0;0],[0;0;0],[0;0;0],pi/30,tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.RelativeGazeTargetConstraintType,robot,robot_aff,head,r_hand,[1;0;0],[0;0;0],[0;0;0],pi/30);
 
 display('Check relative gaze direction constraint')
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.RelativeGazeDirConstraintType,robot,robot_aff,head,l_hand,[1;0;0],[0.5;0.3;0.4],0.3*pi,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.RelativeGazeDirConstraintType,robot,head,l_hand,[1;0;0],[0.5;0.3;0.4],0.3*pi,tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.RelativeGazeDirConstraintType,robot,robot_aff,head,l_hand,[1;0;0],[0.5;0.3;0.4],0.3*pi);
 
 display('Check Relative position constraint');
 testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.RelativePositionConstraintType,robot,robot_aff,...
   [[0;0;0],[0;1;0.2]],[[nan;-0.1;-0.2],[-0.2;nan;-0.4]],[[nan;0.1;0.2],[0.3;nan;0]],...
-  r_hand,head,[[0;0.1;0.2];rpy2quat(randn(3,1))],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.RelativePositionConstraintType,robot,...
-  [[0;0;0],[0;1;0.2]],[[nan;-0.1;-0.2],[-0.2;nan;-0.4]],[[nan;0.1;0.2],[0.3;nan;0]],...
-  r_hand,head,[[0;0.1;0.2];rpy2quat(randn(3,1))],tspan0);
+  r_hand,head,[[0;0.1;0.2];rpy2quat(randn(3,1))]);
 
 display('Check Relative quaternion constraint');
 testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.RelativeQuatConstraintType,robot,robot_aff,...
-  r_hand,l_hand,rpy2quat(randn(3,1)),5/180*pi,tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.RelativeQuatConstraintType,robot,...
-  r_hand,l_hand,rpy2quat(randn(3,1)),5/180*pi,tspan0);
+  r_hand,l_hand,rpy2quat(randn(3,1)),5/180*pi);
 
 display('Check gravity compensation torque constraint');
-testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.GravityCompensationTorqueConstraintType,robot,robot_aff,robot.findPositionIndices('elx'),[-50;-70],[60;90],tspan0);
-testKinCnstInvalidTime_userfun(true,false,t_invalid,q,RigidBodyConstraint.GravityCompensationTorqueConstraintType,robot,robot.findPositionIndices('elx'),[-50;-70],[60;90],tspan0);
+testKinCnst_userfun(true,false,t_valid,q,q_aff,RigidBodyConstraint.GravityCompensationTorqueConstraintType,robot,robot_aff,robot.findPositionIndices('elx'),[-50;-70],[60;90]);
 end
 
 function testKinCnst_userfun(singleTimeFlag,always_use_mex_dynamics,t,q,q_aff,cnst_type,robot,robot_aff,varargin)
@@ -356,58 +320,6 @@ valuecheck(c_mex,c,1e-8);
 valuecheck(dc_mex,dc,1e-8);
 valuecheck(lb_mex,lb,1e-8);
 valuecheck(ub_mex,ub,1e-8);
-end
-
-function testKinCnstInvalidTime_userfun(singleTimeFlag,always_use_mex_dynamics,t,q,cnst_type,robot,varargin)
-robot_ptr = robot.getMexModelPtr;
-nq = robot.getNumPositions();
-if(singleTimeFlag)
-  kc_mex = constructRigidBodyConstraint(cnst_type,true,robot_ptr,varargin{:});
-  kc = constructRigidBodyConstraint(cnst_type,false,robot,varargin{:});
-  [type_mex,num_cnst_mex,c_mex,dc_mex,cnst_name_mex,lb_mex,ub_mex] = testSingleTimeKinCnstmex(kc_mex,q,t);
-  [~,~,c_mex_ptr,~,~,~,~] = testSingleTimeKinCnstmex(kc.mex_ptr,q,t);
-  valuecheck(c_mex,c_mex_ptr,1e-5);
-else
-  kc_mex = constructRigidBodyConstraint(cnst_type,true,robot_ptr,varargin{:});
-  kc = constructRigidBodyConstraint(cnst_type,false,robot,varargin{:});
-  [type_mex,num_cnst_mex,c_mex,dc_mex,cnst_name_mex,lb_mex,ub_mex] = testMultipleTimeKinCnstmex(kc_mex,q,t);
-  [~,~,c_mex_ptr,~,~,~,~] = testMultipleTimeKinCnstmex(kc.mex_ptr,q,t);
-  valuecheck(c_mex,c_mex_ptr,1e-5);
-end
-num_cnst = kc.getNumConstraint(t);
-if(singleTimeFlag)
-  kinsol = kc.robot.doKinematics(q,false,always_use_mex_dynamics);
-  [c,dc] = kc.eval(t,kinsol);
-  cnstr = kc.generateConstraint(t);
-  kinsol = kc.robot.doKinematics(q,false,always_use_mex_dynamics);
-  if(~isempty(cnstr))
-    error('Should be empty');
-  end
-else
-  kinsol_cell = cell(1,length(t));
-  for i = 1:length(t)
-    kinsol_cell{i} = doKinematics(robot,q(:,i),false,always_use_mex_dynamics);
-  end
-  [c,dc] = kc.eval(t,kinsol_cell);
-  cnstr = kc.generateConstraint(t);
-  if(~isempty(cnstr))
-    error('Should be empty');
-  end
-end
-[lb,ub] = kc.bounds(t);
-cnst_name = kc.name(t);
-valuecheck(num_cnst_mex,0);
-valuecheck(num_cnst,0);
-if(~isempty(c) || ~isempty(c_mex))
-  error('Should be empty');
-end
-if(~isempty(lb_mex) || ~isempty(ub_mex) || ~isempty(lb) || ~isempty(ub))
-  error('Should be empty');
-end
-if(~isempty(cnst_name) || ~isempty(cnst_name_mex))
-  error('Should be empty');
-end
-
 end
 
 function c = eval_numerical(singleTimeFlag,constraint,t,q)

--- a/drake/systems/plants/constraint/test/testMultipleTimeLinearPostureConstraint.m
+++ b/drake/systems/plants/constraint/test/testMultipleTimeLinearPostureConstraint.m
@@ -10,7 +10,6 @@ nq = r.getNumPositions();
 l_leg_kny = find(strcmp(r.getStateFrame.getCoordinateNames(),'l_leg_kny'));
 r_leg_kny = find(strcmp(r.getStateFrame.getCoordinateNames(),'r_leg_kny'));
 
-tspan0 = [0,1];
 t = [-1 0 0.2 0.4 0.7 1 2];
 q = zeros(nq,length(t));
 for i = 1 : length(t)
@@ -18,7 +17,7 @@ for i = 1 : length(t)
 end
 
 display('Check posture change constraint');
-testMTLPC_userfun(t,q,RigidBodyConstraint.PostureChangeConstraintType,r,[l_leg_kny;r_leg_kny],[-0.1;-0.2],[0.2;0],tspan0);
+testMTLPC_userfun(t,q,RigidBodyConstraint.PostureChangeConstraintType,r,[l_leg_kny;r_leg_kny],[-0.1;-0.2],[0.2;0]);
 
 end
 

--- a/drake/systems/plants/constraint/test/testPostureConstraint.m
+++ b/drake/systems/plants/constraint/test/testPostureConstraint.m
@@ -9,9 +9,8 @@ r = RigidBodyManipulator(urdf,options);
 l_leg_kny = find(strcmp(r.getStateFrame.getCoordinateNames(),'l_leg_kny'));
 r_leg_kny = find(strcmp(r.getStateFrame.getCoordinateNames(),'r_leg_kny'));
 
-tspan0 = [0,1];
 t = 0.5;
-pc = PostureConstraint(r,tspan0);
+pc = PostureConstraint(r);
 pc = pc.setJointLimits([l_leg_kny;r_leg_kny],[0.2;0.2],inf(2,1));
 category_name_mex = constraintCategorymex(pc.mex_ptr);
 if(~strcmp(category_name_mex,pc.categoryString()))

--- a/drake/systems/plants/constraint/test/testQuasiStaticConstraint.m
+++ b/drake/systems/plants/constraint/test/testQuasiStaticConstraint.m
@@ -27,9 +27,8 @@ nom_data = load('../../../../examples/Atlas/data/atlas_fp.mat');
 q = nom_data.xstar(1:nq);
 
 shrinkFactor = 0.9;
-tspan = [0,1];
 t = 0.5;
-qsc = QuasiStaticConstraint(r,tspan);
+qsc = QuasiStaticConstraint(r);
 qsc = qsc.setActive(true);
 qsc = qsc.setShrinkFactor(shrinkFactor);
 qsc = qsc.addContact(l_foot,l_foot_pts,r_foot,r_foot_pts);

--- a/drake/systems/plants/constraint/test/testSingleTimeLinearPostureConstraint.m
+++ b/drake/systems/plants/constraint/test/testSingleTimeLinearPostureConstraint.m
@@ -17,9 +17,8 @@ jAvar = [l_leg_kny;r_leg_kny;l_leg_hpy;r_leg_hpy;l_leg_aky;r_leg_aky;l_leg_hpz;r
 A = [1;-1;1;-1;1;-1;1;-1];
 lb = [0;0;0;-0.1*pi];
 ub = [0;0;0;0.1*pi];
-tspan = [0 1];
 q = getRandomConfiguration(robot);
-stlpc = SingleTimeLinearPostureConstraint(robot,iAfun,jAvar,A,lb,ub,tspan);
+stlpc = SingleTimeLinearPostureConstraint(robot,iAfun,jAvar,A,lb,ub);
 
 % todo: move this farther down, so that more tests are included when this
 % dependency is not satisfied...
@@ -29,21 +28,7 @@ category_name_mex = constraintCategorymex(stlpc.mex_ptr);
 if(~strcmp(category_name_mex,stlpc.categoryString()))
   error('category name string do not match')
 end
-display('Check t within tspan');
 t = 0;
-num_cnst = stlpc.getNumConstraint(t);
-valuecheck(num_cnst,4);
-testSingleTimeLinearPostureConstraint_userfun(stlpc,q,t);
-display('Check t outside of tspan')
-t = -1;
-num_cnst = stlpc.getNumConstraint(t);
-valuecheck(num_cnst,0);
-testSingleTimeLinearPostureConstraint_userfun(stlpc,q,t);
-display('Check empty t')
-t = [];
-num_cnst = stlpc.getNumConstraint(t);
-valuecheck(num_cnst,4);
-testSingleTimeLinearPostureConstraint_userfun(stlpc,q,t);
 display('Check constraint value');
 q(l_leg_kny) = q(r_leg_kny);
 q(l_leg_hpy) = q(r_leg_hpy);

--- a/drake/systems/plants/constraint/testMultipleTimeKinCnstmex.cpp
+++ b/drake/systems/plants/constraint/testMultipleTimeKinCnstmex.cpp
@@ -41,13 +41,13 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   }
   memcpy(q.data(), mxGetPrSafe(prhs[1]), sizeof(double) * nq * n_breaks);
   int type = cnst->getType();
-  int num_cnst = cnst->getNumConstraint(t_ptr, n_breaks);
+  int num_cnst = cnst->getNumConstraint(n_breaks);
   Eigen::VectorXd c(num_cnst);
   Eigen::MatrixXd dc(num_cnst, nq * n_breaks);
   cnst->eval(t_ptr, n_breaks, q, c, dc);
   Eigen::VectorXd lb(num_cnst);
   Eigen::VectorXd ub(num_cnst);
-  cnst->bounds(t_ptr, n_breaks, lb, ub);
+  cnst->bounds(n_breaks, lb, ub);
   std::vector<std::string> cnst_names;
   cnst->name(t_ptr, n_breaks, cnst_names);
   int retvec_size;

--- a/drake/systems/plants/constraint/testMultipleTimeKinCnstmex.cpp
+++ b/drake/systems/plants/constraint/testMultipleTimeKinCnstmex.cpp
@@ -44,7 +44,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   int num_cnst = cnst->getNumConstraint(n_breaks);
   Eigen::VectorXd c(num_cnst);
   Eigen::MatrixXd dc(num_cnst, nq * n_breaks);
-  cnst->eval(t_ptr, n_breaks, q, c, dc);
+  cnst->eval(n_breaks, q, c, dc);
   Eigen::VectorXd lb(num_cnst);
   Eigen::VectorXd ub(num_cnst);
   cnst->bounds(n_breaks, lb, ub);

--- a/drake/systems/plants/constraint/testMultipleTimeLinearPostureConstraintmex.cpp
+++ b/drake/systems/plants/constraint/testMultipleTimeLinearPostureConstraintmex.cpp
@@ -45,11 +45,11 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   memcpy(q.data(), mxGetPrSafe(prhs[1]), sizeof(double) * nq * n_breaks);
   int num_cnst = cnst->getNumConstraint(n_breaks);
   Eigen::VectorXd c(num_cnst);
-  cnst->feval(t_ptr, n_breaks, q, c);
+  cnst->feval(n_breaks, q, c);
   Eigen::VectorXi iAfun;
   Eigen::VectorXi jAvar;
   Eigen::VectorXd A;
-  cnst->geval(t_ptr, n_breaks, iAfun, jAvar, A);
+  cnst->geval(n_breaks, iAfun, jAvar, A);
   std::vector<std::string> cnst_names;
   cnst->name(t_ptr, n_breaks, cnst_names);
   Eigen::VectorXd lb(num_cnst);

--- a/drake/systems/plants/constraint/testMultipleTimeLinearPostureConstraintmex.cpp
+++ b/drake/systems/plants/constraint/testMultipleTimeLinearPostureConstraintmex.cpp
@@ -43,7 +43,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
         "Argument 2 must be of size nq*n_breaks");
   }
   memcpy(q.data(), mxGetPrSafe(prhs[1]), sizeof(double) * nq * n_breaks);
-  int num_cnst = cnst->getNumConstraint(t_ptr, n_breaks);
+  int num_cnst = cnst->getNumConstraint(n_breaks);
   Eigen::VectorXd c(num_cnst);
   cnst->feval(t_ptr, n_breaks, q, c);
   Eigen::VectorXi iAfun;
@@ -54,7 +54,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   cnst->name(t_ptr, n_breaks, cnst_names);
   Eigen::VectorXd lb(num_cnst);
   Eigen::VectorXd ub(num_cnst);
-  cnst->bounds(t_ptr, n_breaks, lb, ub);
+  cnst->bounds(n_breaks, lb, ub);
   Eigen::VectorXd iAfun_tmp(iAfun.size());
   Eigen::VectorXd jAvar_tmp(jAvar.size());
   for (int i = 0; i < iAfun.size(); i++) {

--- a/drake/systems/plants/constraint/testPostureConstraintmex.cpp
+++ b/drake/systems/plants/constraint/testPostureConstraintmex.cpp
@@ -28,7 +28,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   PostureConstraint* pc = (PostureConstraint*)getDrakeMexPointer(prhs[0]);
   int nq = pc->getRobotPointer()->num_positions;
   Eigen::VectorXd lb, ub;
-  pc->bounds(t_ptr, lb, ub);
+  pc->bounds(lb, ub);
   plhs[0] = mxCreateDoubleMatrix(nq, 1, mxREAL);
   plhs[1] = mxCreateDoubleMatrix(nq, 1, mxREAL);
   memcpy(mxGetPrSafe(plhs[0]), lb.data(), sizeof(double) * nq);

--- a/drake/systems/plants/constraint/testQuasiStaticConstraintmex.cpp
+++ b/drake/systems/plants/constraint/testQuasiStaticConstraintmex.cpp
@@ -50,7 +50,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   int num_weights = qsc->getNumWeights();
   double* weights = new double[num_weights];
   memcpy(weights, mxGetPrSafe(prhs[2]), sizeof(double) * num_weights);
-  int num_qsc_cnst = qsc->getNumConstraint(t_ptr);
+  int num_qsc_cnst = qsc->getNumConstraint();
   VectorXd c(num_qsc_cnst - 1);
   MatrixXd dc = MatrixXd::Zero(num_qsc_cnst - 1, nq + num_weights);
   KinematicsCache<double> cache = model->doKinematics(q);
@@ -58,7 +58,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   VectorXd lb, ub;
   lb.resize(num_qsc_cnst - 1);
   ub.resize(num_qsc_cnst - 1);
-  qsc->bounds(t_ptr, lb, ub);
+  qsc->bounds(lb, ub);
   plhs[0] = mxCreateLogicalScalar(active);
   plhs[1] = mxCreateDoubleScalar((double)num_weights);
   plhs[2] = mxCreateDoubleMatrix(num_qsc_cnst - 1, 1, mxREAL);

--- a/drake/systems/plants/constraint/testQuasiStaticConstraintmex.cpp
+++ b/drake/systems/plants/constraint/testQuasiStaticConstraintmex.cpp
@@ -54,7 +54,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   VectorXd c(num_qsc_cnst - 1);
   MatrixXd dc = MatrixXd::Zero(num_qsc_cnst - 1, nq + num_weights);
   KinematicsCache<double> cache = model->doKinematics(q);
-  qsc->eval(t_ptr, cache, weights, c, dc);
+  qsc->eval(cache, weights, c, dc);
   VectorXd lb, ub;
   lb.resize(num_qsc_cnst - 1);
   ub.resize(num_qsc_cnst - 1);

--- a/drake/systems/plants/constraint/testSingleTimeKinCnstmex.cpp
+++ b/drake/systems/plants/constraint/testSingleTimeKinCnstmex.cpp
@@ -46,7 +46,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
     }
   }
   int type = cnst->getType();
-  int num_cnst = cnst->getNumConstraint(t_ptr);
+  int num_cnst = cnst->getNumConstraint();
   // mexPrintf("num_cnst = %d\n", num_cnst);
   int nq = cnst->getRobotPointer()->num_positions;
   Eigen::Map<Eigen::VectorXd> q(mxGetPrSafe(prhs[1]), nq);
@@ -57,7 +57,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   // mexPrintf("get c, dc\n");
   Eigen::VectorXd lb(num_cnst);
   Eigen::VectorXd ub(num_cnst);
-  cnst->bounds(t_ptr, lb, ub);
+  cnst->bounds(lb, ub);
   // mexPrintf("get lb, ub\n");
   std::vector<std::string> cnst_names;
   cnst->name(t_ptr, cnst_names);

--- a/drake/systems/plants/constraint/testSingleTimeKinCnstmex.cpp
+++ b/drake/systems/plants/constraint/testSingleTimeKinCnstmex.cpp
@@ -53,7 +53,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   KinematicsCache<double> cache = cnst->getRobotPointer()->doKinematics(q);
   Eigen::VectorXd c(num_cnst);
   Eigen::MatrixXd dc(num_cnst, nq);
-  cnst->eval(t_ptr, cache, c, dc);
+  cnst->eval(cache, c, dc);
   // mexPrintf("get c, dc\n");
   Eigen::VectorXd lb(num_cnst);
   Eigen::VectorXd ub(num_cnst);

--- a/drake/systems/plants/constraint/testSingleTimeLinearPostureConstraintmex.cpp
+++ b/drake/systems/plants/constraint/testSingleTimeLinearPostureConstraintmex.cpp
@@ -55,10 +55,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   int type = stlpc->getType();
   int num_cnst = stlpc->getNumConstraint();
   VectorXd c(num_cnst);
-  stlpc->feval(t_ptr, q, c);
+  stlpc->feval(q, c);
   VectorXi iAfun, jAvar;
   VectorXd A;
-  stlpc->geval(t_ptr, iAfun, jAvar, A);
+  stlpc->geval(iAfun, jAvar, A);
   vector<string> cnst_names;
   stlpc->name(t_ptr, cnst_names);
   VectorXd lb, ub;

--- a/drake/systems/plants/constraint/testSingleTimeLinearPostureConstraintmex.cpp
+++ b/drake/systems/plants/constraint/testSingleTimeLinearPostureConstraintmex.cpp
@@ -53,7 +53,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
     t_ptr = mxGetPrSafe(prhs[2]);
   }
   int type = stlpc->getType();
-  int num_cnst = stlpc->getNumConstraint(t_ptr);
+  int num_cnst = stlpc->getNumConstraint();
   VectorXd c(num_cnst);
   stlpc->feval(t_ptr, q, c);
   VectorXi iAfun, jAvar;
@@ -62,7 +62,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   vector<string> cnst_names;
   stlpc->name(t_ptr, cnst_names);
   VectorXd lb, ub;
-  stlpc->bounds(t_ptr, lb, ub);
+  stlpc->bounds(lb, ub);
   plhs[0] = mxCreateDoubleScalar((double)type);
   plhs[1] = mxCreateDoubleScalar((double)num_cnst);
   int retvec_size;

--- a/drake/systems/plants/constraint/wrapDeprecatedConstraint.m
+++ b/drake/systems/plants/constraint/wrapDeprecatedConstraint.m
@@ -10,18 +10,11 @@ function [kc_cell,qsc_pts] = wrapDeprecatedConstraint(robot,body,pts,pos,options
 %                           can have field 'gaze' and 'contact_state'
 % @param options   -- use_mex   A boolean flag, set to true would construct
 %                               mex constraint object only, default is true
-%                  -- tspan     A 1x2 double vector, the time span of the
-%                               constraint. default is [-inf inf];
 if(~isstruct(options))
   error('The last argument option must be a struct')
 end
 if(~isfield(options,'use_mex'))
   options.use_mex = true;
-end
-if(isfield(options,'tspan'))
-  tspan = options.tspan;
-else
-  tspan = [-inf inf];
 end
 if(isfield(options,'robotnum'))
   robotnum = options.robotnum;
@@ -53,15 +46,15 @@ if(isstruct(pos)&&isfield(pos,'type'))
       else
         quat_des = pos.gaze_orientation/norm(pos.gaze_orientation);
       end
-      kc_cell = {constructRigidBodyConstraint(RigidBodyConstraint.WorldGazeOrientConstraintType,options.use_mex,robot,body,axis,quat_des,conethreshold,threshold,tspan)};
+      kc_cell = {constructRigidBodyConstraint(RigidBodyConstraint.WorldGazeOrientConstraintType,options.use_mex,robot,body,axis,quat_des,conethreshold,threshold)};
     end
     if(isfield(pos,'gaze_target'))
       gaze_target = pos.gaze_target;
-      kc_cell = {constructRigidBodyConstraint(RigidBodyConstraint.WorldGazeTargetConstraintType,options.use_mex,robot,body,axis,gaze_target,[0;0;0],conethreshold,tspan)};
+      kc_cell = {constructRigidBodyConstraint(RigidBodyConstraint.WorldGazeTargetConstraintType,options.use_mex,robot,body,axis,gaze_target,[0;0;0],conethreshold)};
     end
     if(isfield(pos,'gaze_dir'))
       gaze_dir = pos.gaze_dir./norm(pos.gaze_dir);
-      kc_cell = {constructRigidBodyConstraint(RigidBodyConstraint.WorldGazeDirConstraintType,options.use_mex,robot,body,axis,gaze_dir,conethreshold,tspan)};
+      kc_cell = {constructRigidBodyConstraint(RigidBodyConstraint.WorldGazeDirConstraintType,options.use_mex,robot,body,axis,gaze_dir,conethreshold)};
     end
   end
 else
@@ -76,12 +69,12 @@ else
   posmin(isnan(posmin)) = -inf;
   rows = size(posmax,1);
   if(body == 0)
-    kc_cell = {constructRigidBodyConstraint(RigidBodyConstraint.WorldCoMConstraintType,options.use_mex,robot,posmin,posmax,tspan,robotnum)};
+    kc_cell = {constructRigidBodyConstraint(RigidBodyConstraint.WorldCoMConstraintType,options.use_mex,robot,posmin,posmax,robotnum)};
   else
     if(ischar(pts))
       pts = robot.getBody(body).getContactPoints(pts);
     end
-    kc1 = constructRigidBodyConstraint(RigidBodyConstraint.WorldPositionConstraintType,options.use_mex,robot,body,pts,posmin(1:3,:),posmax(1:3,:),tspan);
+    kc1 = constructRigidBodyConstraint(RigidBodyConstraint.WorldPositionConstraintType,options.use_mex,robot,body,pts,posmin(1:3,:),posmax(1:3,:));
     qsc_pts_idx = false(1,size(pts,2));
     if(isfield(pos,'contact_state'))
       if(iscell(pos.contact_state))
@@ -99,7 +92,7 @@ else
     elseif(rows == 6)
       rpymax = posmax(4:6);
       rpymin = posmin(4:6);
-      kc2 = constructRigidBodyConstraint(RigidBodyConstraint.WorldEulerConstraintType,options.use_mex,robot,body,rpymin,rpymax,tspan);
+      kc2 = constructRigidBodyConstraint(RigidBodyConstraint.WorldEulerConstraintType,options.use_mex,robot,body,rpymin,rpymax);
       kc_cell = {kc1,kc2};
     elseif(rows == 7)
       if(any(isinf(posmax(4:7,1))|isinf(posmin(4:7,1))))
@@ -115,7 +108,7 @@ else
           quat_des = 0.5*(quatmin+quatmax);
           tol = max([1-(quatmin'*quat_des)^2 1-(quatmax'*quat_des)^2]);
         end
-        kc2 = constructRigidBodyConstraint(RigidBodyConstraint.WorldQuatConstraintType,options.use_mex,robot,body,quat_des,tol,tspan);
+        kc2 = constructRigidBodyConstraint(RigidBodyConstraint.WorldQuatConstraintType,options.use_mex,robot,body,quat_des,tol);
         kc_cell = {kc1,kc2};
       end
     end

--- a/drake/systems/plants/test/testIK.cpp
+++ b/drake/systems/plants/test/testIK.cpp
@@ -16,8 +16,6 @@ using drake::util::MatrixCompareType;
 TEST(testIK, simpleIK) {
   RigidBodyTree model("examples/Atlas/urdf/atlas_minimal_contact.urdf");
 
-  Vector2d tspan;
-  tspan << 0, 1;
   VectorXd q0 = model.getZeroConfiguration();
   // The state frame of cpp model does not match with the state frame of MATLAB
   // model, since the dofname_to_dofnum is different in cpp and MATLAB
@@ -26,7 +24,7 @@ TEST(testIK, simpleIK) {
   Vector3d com_ub = Vector3d::Zero();
   com_lb(2) = 0.9;
   com_ub(2) = 1.0;
-  WorldCoMConstraint com_kc(&model, com_lb, com_ub, tspan);
+  WorldCoMConstraint com_kc(&model, com_lb, com_ub);
 
   std::vector<RigidBodyConstraint*> constraint_array;
   constraint_array.push_back(&com_kc);

--- a/drake/systems/plants/test/testIK.m
+++ b/drake/systems/plants/test/testIK.m
@@ -54,7 +54,6 @@ r_leg_aky = find(strcmp(coords,'r_leg_aky'));
 l_leg_hpz = find(strcmp(coords,'l_leg_hpz'));
 r_leg_hpz = find(strcmp(coords,'r_leg_hpz'));
 
-tspan = [0,1];
 nom_data = load('../../../examples/Atlas/data/atlas_fp.mat');
 q_nom = nom_data.xstar(1:nq);
 q_seed = q_nom+1e-2*randn(nq,1);
@@ -65,8 +64,8 @@ ikoptions = ikoptions.setMajorIterationsLimit(5000);
 ikmexoptions = ikoptions;
 ikmexoptions = ikmexoptions.setMex(true);
 
-kc1 = WorldCoMConstraint(robot,[0;0;0.9],[0;0;1],tspan,1);
-kc1prime = WorldCoMConstraint(robot,[nan;nan;0.9],[nan;nan;0.92],tspan/2,1);
+kc1 = WorldCoMConstraint(robot,[0;0;0.9],[0;0;1],1);
+kc1prime = WorldCoMConstraint(robot,[nan;nan;0.9],[nan;nan;0.92],1);
 display('Check a single CoM constraint')
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,ikoptions);
 kinsol = doKinematics(robot,q);
@@ -101,7 +100,7 @@ if(com(3)>1+1e-5 ||com(3)<0.9-1e-5)
   error('CoM constraint is not satisfied');
 end
 end
-pc_knee = PostureConstraint(robot,tspan);
+pc_knee = PostureConstraint(robot);
 l_knee_idx = find(strcmp(robot.getStateFrame.getCoordinateNames(),'l_leg_kny'));
 r_knee_idx = find(strcmp(robot.getStateFrame.getCoordinateNames(),'r_leg_kny'));
 pc_knee = pc_knee.setJointLimits([l_knee_idx;r_knee_idx],[0.2;0.2],[inf;inf]);
@@ -155,8 +154,8 @@ end
 
 
 display('Check a body position constraint')
-kc2l = WorldPositionConstraint(robot,l_foot,l_foot_pts,[nan(2,n_l_foot_pts);zeros(1,n_l_foot_pts)],[nan(2,n_l_foot_pts);zeros(1,n_l_foot_pts)],tspan);
-kc2r = WorldPositionConstraint(robot,r_foot,r_foot_pts,[nan(2,n_r_foot_pts);zeros(1,n_r_foot_pts)],[nan(2,n_r_foot_pts);zeros(1,n_r_foot_pts)],tspan);
+kc2l = WorldPositionConstraint(robot,l_foot,l_foot_pts,[nan(2,n_l_foot_pts);zeros(1,n_l_foot_pts)],[nan(2,n_l_foot_pts);zeros(1,n_l_foot_pts)]);
+kc2r = WorldPositionConstraint(robot,r_foot,r_foot_pts,[nan(2,n_r_foot_pts);zeros(1,n_r_foot_pts)],[nan(2,n_r_foot_pts);zeros(1,n_r_foot_pts)]);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,pc_knee,kc2l,kc2r,ikoptions);
 kinsol = doKinematics(robot,q);
 lfoot_pos = forwardKin(robot,kinsol,l_foot,l_foot_pts,0);
@@ -180,8 +179,8 @@ display('Check a body position (in random frame) constraint')
 rpy = [pi/10,pi/20,pi/10];
 xyz = [0.5;0.0;0.2];
 T = [rpy2rotmat(rpy),xyz;zeros(1,3),1];
-kc2l_frame = WorldPositionInFrameConstraint(robot,l_foot,l_foot_pts,T,[nan(2,n_l_foot_pts);zeros(1,n_l_foot_pts)],[nan(2,n_l_foot_pts);zeros(1,n_l_foot_pts)],tspan);
-kc2r_frame = WorldPositionInFrameConstraint(robot,r_foot,r_foot_pts,T,[nan(2,n_r_foot_pts);zeros(1,n_r_foot_pts)],[nan(2,n_r_foot_pts);zeros(1,n_r_foot_pts)],tspan);
+kc2l_frame = WorldPositionInFrameConstraint(robot,l_foot,l_foot_pts,T,[nan(2,n_l_foot_pts);zeros(1,n_l_foot_pts)],[nan(2,n_l_foot_pts);zeros(1,n_l_foot_pts)]);
+kc2r_frame = WorldPositionInFrameConstraint(robot,r_foot,r_foot_pts,T,[nan(2,n_r_foot_pts);zeros(1,n_r_foot_pts)],[nan(2,n_r_foot_pts);zeros(1,n_r_foot_pts)]);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,pc_knee,kc2l_frame,kc2r_frame,ikoptions);
 kinsol = doKinematics(robot,q);
 lfoot_pos = homogTransMult(invHT(T),forwardKin(robot,kinsol,l_foot,l_foot_pts,0));
@@ -202,7 +201,7 @@ end
 end
 
 display('Check the infeasible case')
-kc_err = WorldCoMConstraint(robot,[0;0;2],[0;0;inf],tspan);
+kc_err = WorldCoMConstraint(robot,[0;0;2],[0;0;inf]);
 if(checkDependency('snopt'))
 % [q,info,infeasible_constraint] = inverseKin(robot,q_seed,q_nom,kc_err,kc2l,kc2r,ikoptions);
 [qmex,info_mex,infeasible_constraint_mex] = inverseKin(robot,q_seed,q_nom,kc_err,kc2l,kc2r,ikmexoptions);
@@ -222,7 +221,7 @@ disp(infeasible_constraint_mex);
 end
 
 display('Check a body quaternion constraint')
-kc3 = WorldQuatConstraint(robot,r_foot,[1;0;0;0],0,tspan);
+kc3 = WorldQuatConstraint(robot,r_foot,[1;0;0;0],0);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,pc_knee,kc2l,kc2r,kc3,ikoptions);
 kinsol = doKinematics(robot,q);
 rfoot_pos = forwardKin(robot,kinsol,r_foot,[0;0;0],2);
@@ -238,7 +237,7 @@ end
 end
 
 display('Check a gaze orientation constraint')
-kc4 = WorldGazeOrientConstraint(robot,r_hand,[1;0;0],[0.5;0.5;-0.5;0.5],0.1*pi,0.8*pi,tspan);
+kc4 = WorldGazeOrientConstraint(robot,r_hand,[1;0;0],[0.5;0.5;-0.5;0.5],0.1*pi,0.8*pi);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,pc_knee,kc2l,kc2r,kc3,kc4,ikoptions);
 kinsol = doKinematics(robot,q);
 rhand_pos = forwardKin(robot,kinsol,r_hand,[0 1;0 0;0 0],0);
@@ -262,7 +261,7 @@ end
 end
 
 display('Check a gaze direction constraint')
-kc5 = WorldGazeDirConstraint(robot,l_hand,[1;0;0],[1;0;0],0.4*pi,tspan);
+kc5 = WorldGazeDirConstraint(robot,l_hand,[1;0;0],[1;0;0],0.4*pi);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,pc_knee,kc2l,kc2r,kc3,kc4,kc5,ikoptions);
 kinsol = doKinematics(robot,q);
 lhand_pos = forwardKin(robot,kinsol,l_hand,[0 1;0 0;0 0],0);
@@ -287,7 +286,7 @@ display('Check a gaze target constraint')
 gaze_target = [1;0;1.5];
 gaze_axis = [1;0;0];
 gaze_origin = [0.1;0.2;0.3];
-kc6 = WorldGazeTargetConstraint(robot,head,gaze_axis,gaze_target,gaze_origin,0.1*pi,tspan);
+kc6 = WorldGazeTargetConstraint(robot,head,gaze_axis,gaze_target,gaze_origin,0.1*pi);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,kc2l,kc2r,kc3,kc4,kc5,kc6,ikoptions);
 kinsol = doKinematics(robot,q);
 head_pos = forwardKin(robot,kinsol,head,[gaze_origin gaze_origin+gaze_axis],0);
@@ -314,13 +313,13 @@ end
 
 if(checkDependency('bullet'))
   display('Check all-to-all closest distance constraint')
-  abcdc = AllBodiesClosestDistanceConstraint(robot,0.05,1e3,tspan);
+  abcdc = AllBodiesClosestDistanceConstraint(robot,0.05,1e3);
   q = test_IK_userfun(robot,q_seed,q_nom,kc1,kc2l,kc2r,kc3,kc4,kc5,kc6,abcdc,ikoptions);
   display('Check IK pointwise with all-to-all closest distance constraint')
   q = test_IKpointwise_userfun(robot,[0,1],[q_seed,q_seed+1e-3*randn(nq,1)],[q_nom,q_nom],kc1,pc_knee,kc2l,kc2r,kc3,kc4,kc5,kc6,abcdc,ikoptions);
 
   display('Check minimum-distance constraint')
-  min_dist_cnstr = MinDistanceConstraint(robot,0.05,[],tspan);
+  min_dist_cnstr = MinDistanceConstraint(robot,0.05,[]);
   q = test_IK_userfun(robot,q_seed,q_nom,kc1,kc2l,kc2r,kc3,kc4,kc5,kc6,min_dist_cnstr,ikoptions);
   display('Check IK pointwise with minimum-distance constraint')
   q = test_IKpointwise_userfun(robot,[0,1],[q_seed,q_seed+1e-3*randn(nq,1)],[q_nom,q_nom],kc1,pc_knee,kc2l,kc2r,kc3,kc4,kc5,kc6,min_dist_cnstr,ikoptions);
@@ -359,7 +358,7 @@ jAvar = [l_leg_kny;r_leg_kny;l_leg_hpy;r_leg_hpy;l_leg_aky;r_leg_aky;l_leg_hpz;r
 A = [1;-1;1;-1;1;-1;1;-1];
 lb = [0;0;0;-0.1*pi];
 ub = [0;0;0;0.1*pi];
-stlpc = SingleTimeLinearPostureConstraint(robot,iAfun,jAvar,A,lb,ub,tspan);
+stlpc = SingleTimeLinearPostureConstraint(robot,iAfun,jAvar,A,lb,ub);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,kc2l,kc2r,pc_knee,stlpc,qsc,ikoptions);
 valuecheck(q([l_leg_kny;l_leg_hpy;l_leg_aky]),q([r_leg_kny;r_leg_hpy;r_leg_aky]),1e-10);
 if(abs(q(l_leg_hpz)-q(r_leg_hpz))>0.1*pi+1e-8)
@@ -375,7 +374,7 @@ end
 end
 
 display('Check point to point distance constraint')
-hands_distance_cnst = Point2PointDistanceConstraint(robot,l_hand,r_hand,[0;0;0],[0;0;0],0.5,1,tspan);
+hands_distance_cnst = Point2PointDistanceConstraint(robot,l_hand,r_hand,[0;0;0],[0;0;0],0.5,1);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,qsc,kc2l,kc2r,kc3,hands_distance_cnst,ikoptions);
 kinsol = doKinematics(robot,q);
 lhand_pos = forwardKin(robot,kinsol,l_hand,[0;0;0],0);
@@ -399,7 +398,7 @@ end
 
 head_pts = [[0;0;0] [0.1;0;0]];
 world_pts = [[0;0;0] [0.1;0;0]];
-head_world_dist_cnst = Point2PointDistanceConstraint(robot,head,world,head_pts,world_pts,[1.6 1.6],[1.9 1.9],tspan);
+head_world_dist_cnst = Point2PointDistanceConstraint(robot,head,world,head_pts,world_pts,[1.6 1.6],[1.9 1.9]);
 q = test_IK_userfun(robot,q_seed,q_nom,kc1,qsc,kc2l,kc2r,kc3,head_world_dist_cnst,ikoptions);
 kinsol = doKinematics(robot,q);
 head_pos = forwardKin(robot,kinsol,head,head_pts,0);
@@ -411,7 +410,7 @@ end
 
 display('Check point to line segment distance constraint')
 vertical_line = [[0;0;0] [0;0;1]];
-hand_line_dist_cnst = Point2LineSegDistConstraint(robot,l_hand,[0;0;0],1,vertical_line,0.1,0.2,tspan);
+hand_line_dist_cnst = Point2LineSegDistConstraint(robot,l_hand,[0;0;0],1,vertical_line,0.1,0.2);
 q = test_IK_userfun(robot,q_seed,q_nom,qsc,kc2l,kc2r,hand_line_dist_cnst,ikoptions);
 kinsol = doKinematics(robot,q);
 l_hand_pos = forwardKin(robot,kinsol,l_hand,[0;0;0],0);
@@ -541,36 +540,30 @@ if(any(q_sol>q_ub) || any(q_sol<q_lb))
 end
 for i = 1:nargin-3
   if(isa(varargin{i},'SingleTimeKinematicConstraint'))
-    if(varargin{i}.isTimeValid(t))
-      [lb,ub] = varargin{i}.bounds(t);
-      c = varargin{i}.eval(t,kinsol);
-      if(any(c-ub>1e-3) || any(c-lb<-1e-3))
-        error('solution does not satisfy the SingleTimeKinematicConstraint');
-      end
+    [lb,ub] = varargin{i}.bounds(t);
+    c = varargin{i}.eval(t,kinsol);
+    if(any(c-ub>1e-3) || any(c-lb<-1e-3))
+      error('solution does not satisfy the SingleTimeKinematicConstraint');
     end
   elseif(isa(varargin{i},'PostureConstraint'))
-    if(varargin{i}.isTimeValid(t))
-      [lb,ub] = varargin{i}.bounds(t);
-      if(any(q_sol>ub) || any(q_sol<lb))
-        error('solution does not satisfy the PostureConstraint');
-      end
+    [lb,ub] = varargin{i}.bounds(t);
+    if(any(q_sol>ub) || any(q_sol<lb))
+      error('solution does not satisfy the PostureConstraint');
     end
   elseif(isa(varargin{i},'QuasiStaticConstraint'))
-    if(varargin{i}.isTimeValid(t) && varargin{i}.active)
+    if(varargin{i}.active)
       if(~varargin{i}.checkConstraint(kinsol))
         error('solution does not satisfy the QuasiStaticConstraint');
       end
     end
   elseif(isa(varargin{i},'SingleTimeLinearPostureConstraint'))
-    if(varargin{i}.isTimeValid(t))
-      [lb,ub] = varargin{i}.bounds(t);
-      c = varargin{i}.feval(t,q_sol);
-      if(any(c-ub>1e-3) || any(c-lb < -1e-3))
-        error('solution does not satisfy the SingleTimeLinearPostureConstraint');
-      end
+    [lb,ub] = varargin{i}.bounds(t);
+    c = varargin{i}.feval(t,q_sol);
+    if(any(c-ub>1e-3) || any(c-lb < -1e-3))
+      error('solution does not satisfy the SingleTimeLinearPostureConstraint');
     end
   else
     error('The constraint is not supported');
   end
-end  
+end
 end

--- a/drake/systems/plants/test/testIKMoreConstraints.cpp
+++ b/drake/systems/plants/test/testIKMoreConstraints.cpp
@@ -40,9 +40,6 @@ void findJointAndInsert(const RigidBodyTree &model, const std::string &name,
 TEST(testIKMoreConstraints, IKMoreConstraints) {
   RigidBodyTree model("examples/Atlas/urdf/atlas_minimal_contact.urdf");
 
-  Vector2d tspan;
-  tspan << 0, 1;
-
   // Default Atlas v5 posture:
   VectorXd qstar(model.num_positions);
   qstar << -0.0260, 0, 0.8440, 0, 0, 0, 0, 0, 0, 0.2700, 0, 0.0550, -0.5700,
@@ -51,7 +48,7 @@ TEST(testIKMoreConstraints, IKMoreConstraints) {
       -0.5000, 0.0985, 0, 0.0008, 0.2564;
 
   // 1 Back Posture Constraint
-  PostureConstraint kc_posture_back(&model, tspan);
+  PostureConstraint kc_posture_back(&model);
   std::vector<int> back_idx;
   findJointAndInsert(model, "back_bkz", back_idx);
   findJointAndInsert(model, "back_bky", back_idx);
@@ -61,7 +58,7 @@ TEST(testIKMoreConstraints, IKMoreConstraints) {
   kc_posture_back.setJointLimits(3, back_idx.data(), back_lb, back_ub);
 
   // 2 Knees Constraint
-  PostureConstraint kc_posture_knees(&model, tspan);
+  PostureConstraint kc_posture_knees(&model);
   std::vector<int> knee_idx;
   findJointAndInsert(model, "l_leg_kny", knee_idx);
   findJointAndInsert(model, "r_leg_kny", knee_idx);
@@ -74,7 +71,7 @@ TEST(testIKMoreConstraints, IKMoreConstraints) {
   kc_posture_knees.setJointLimits(2, knee_idx.data(), knee_lb, knee_ub);
 
   // 3 Left Arm Constraint
-  PostureConstraint kc_posture_larm(&model, tspan);
+  PostureConstraint kc_posture_larm(&model);
   std::vector<int> larm_idx;
   findJointAndInsert(model, "l_arm_shz", larm_idx);
   findJointAndInsert(model, "l_arm_shx", larm_idx);
@@ -109,10 +106,10 @@ TEST(testIKMoreConstraints, IKMoreConstraints) {
   lfoot_pos_ub(2) += 0.01;
   // std::cout << lfoot_pos0.transpose() << " lfoot\n" ;
   WorldPositionConstraint kc_lfoot_pos(&model, l_foot, l_foot_pt, lfoot_pos_lb,
-                                       lfoot_pos_ub, tspan);
+                                       lfoot_pos_ub);
   Eigen::Vector4d quat_des(1, 0, 0, 0);
   double tol = 0.0017453292519943296;
-  WorldQuatConstraint kc_lfoot_quat(&model, l_foot, quat_des, tol, tspan);
+  WorldQuatConstraint kc_lfoot_quat(&model, l_foot, quat_des, tol);
 
   // 5 Right Foot Position and Orientation Constraints
   int r_foot = model.findLinkId("r_foot");
@@ -129,8 +126,8 @@ TEST(testIKMoreConstraints, IKMoreConstraints) {
   rfoot_pos_ub(2) += 0.001;
   // std::cout << rfoot_pos0.transpose() << " lfoot\n" ;
   WorldPositionConstraint kc_rfoot_pos(&model, r_foot, r_foot_pt, rfoot_pos_lb,
-                                       rfoot_pos_ub, tspan);
-  WorldQuatConstraint kc_rfoot_quat(&model, r_foot, quat_des, tol, tspan);
+                                       rfoot_pos_ub);
+  WorldQuatConstraint kc_rfoot_quat(&model, r_foot, quat_des, tol);
 
   // 6 Right Position Constraints (actual reaching constraint)
   int r_hand = model.findLinkId("r_hand");
@@ -148,10 +145,10 @@ TEST(testIKMoreConstraints, IKMoreConstraints) {
   rhand_pos_ub(2) += 0.05;
   // std::cout << rhand_pos_ub.transpose() << " rhand\n" ;
   WorldPositionConstraint kc_rhand(&model, r_hand, r_hand_pt, rhand_pos_lb,
-                                   rhand_pos_ub, tspan);
+                                   rhand_pos_ub);
 
   // 7 QuasiStatic Constraints
-  QuasiStaticConstraint kc_quasi(&model, tspan);
+  QuasiStaticConstraint kc_quasi(&model);
   kc_quasi.setShrinkFactor(0.2);
   kc_quasi.setActive(true);
   Eigen::Matrix3Xd l_foot_pts = Eigen::Matrix3Xd::Zero(3, 4);

--- a/drake/systems/plants/test/testIKtraj.cpp
+++ b/drake/systems/plants/test/testIKtraj.cpp
@@ -16,8 +16,6 @@ int main() {
   if (!model) {
     cerr << "ERROR: Failed to load model" << endl;
   }
-  Vector2d tspan;
-  tspan << 0, 1;
   int l_hand;
   int r_hand;
   // int l_foot;
@@ -67,10 +65,8 @@ int main() {
   rhand_pos_lb(2) += 0.25;
   Vector3d rhand_pos_ub = rhand_pos_lb;
   rhand_pos_ub(2) += 0.25;
-  Vector2d tspan_end;
-  tspan_end << t[nT - 1], t[nT - 1];
   WorldPositionConstraint* kc_rhand = new WorldPositionConstraint(
-      model, r_hand, r_hand_pt, rhand_pos_lb, rhand_pos_ub, tspan_end);
+      model, r_hand, r_hand_pt, rhand_pos_lb, rhand_pos_ub);
   int num_constraints = 2;
   RigidBodyConstraint** constraint_array =
       new RigidBodyConstraint* [num_constraints];

--- a/drake/systems/plants/test/testIKtraj.m
+++ b/drake/systems/plants/test/testIKtraj.m
@@ -52,15 +52,14 @@ r_hand_pos = forwardKin(r,kinsol0,r_hand,r_hand_pts,0);
 l_hand_pos = forwardKin(r,kinsol0,l_hand,l_hand_pts,0);
 com_pos0 = getCOM(r,kinsol0,1);
 com_height = com_pos0(3);
-tspan = [0,1];
-kc1 = {WorldPositionConstraint(r,r_foot,r_foot_pts,r_foot_pos(1:3),r_foot_pos(1:3),tspan),...
-  WorldQuatConstraint(r,r_foot,r_foot_pos(4:7),0,tspan)};
-kc2 = {WorldPositionConstraint(r,l_foot,l_foot_pts,l_foot_pos(1:3),l_foot_pos(1:3),tspan),...
-  WorldQuatConstraint(r,l_foot,l_foot_pos(4:7),0,tspan)};
-kc3 = WorldPositionConstraint(r,r_hand,r_hand_pts,r_hand_pos+[0.1;0.05;0.75],r_hand_pos+[0.1;0.05;1],[tspan(end) tspan(end)]);
-kc4 = WorldPositionConstraint(r,l_hand,l_hand_pts,l_hand_pos,l_hand_pos,[tspan(end) tspan(end)]);
-kc5 = WorldCoMConstraint(r,[-inf;-inf;com_height],[inf;inf;com_height+0.5],tspan,1);
-pc_knee = PostureConstraint(r,tspan);
+kc1 = {WorldPositionConstraint(r,r_foot,r_foot_pts,r_foot_pos(1:3),r_foot_pos(1:3)),...
+  WorldQuatConstraint(r,r_foot,r_foot_pos(4:7),0)};
+kc2 = {WorldPositionConstraint(r,l_foot,l_foot_pts,l_foot_pos(1:3),l_foot_pos(1:3)),...
+  WorldQuatConstraint(r,l_foot,l_foot_pos(4:7),0)};
+kc3 = WorldPositionConstraint(r,r_hand,r_hand_pts,r_hand_pos+[0.1;0.05;0.75],r_hand_pos+[0.1;0.05;1]);
+kc4 = WorldPositionConstraint(r,l_hand,l_hand_pts,l_hand_pos,l_hand_pos);
+kc5 = WorldCoMConstraint(r,[-inf;-inf;com_height],[inf;inf;com_height+0.5],1);
+pc_knee = PostureConstraint(r);
 
 pc_knee = pc_knee.setJointLimits([l_leg_kny;r_leg_kny],[0.2;0.2],[inf;inf]);
 
@@ -75,7 +74,7 @@ jAvar = [l_leg_kny;r_leg_kny;l_leg_hpy;r_leg_hpy;l_leg_aky;r_leg_aky;l_leg_hpz;r
 A = [1;-1;1;-1;1;-1;1;-1];
 lb = [0;0;0;-0.1*pi];
 ub = [0;0;0;0.1*pi];
-stlpc = SingleTimeLinearPostureConstraint(r,iAfun,jAvar,A,lb,ub,tspan);
+stlpc = SingleTimeLinearPostureConstraint(r,iAfun,jAvar,A,lb,ub);
 
 ikoptions = IKoptions(r);
 cost = Point(r.getStateFrame,1);
@@ -99,6 +98,7 @@ ikmexoptions = ikmexoptions.setMex(true);
 ikmexoptions = ikmexoptions.setDebug(true);
 nT = 5;
 % t = [tspan(1) tspan(1)+0.2*(tspan(end)-tspan(1)) tspan(1)+0.7*(tspan(end)-tspan(1)) tspan(end)];
+tspan = [0,1];
 t = linspace(tspan(1),tspan(end),nT);
 q_nom_traj = PPTrajectory(foh(t,repmat(q0,1,nT)));
 q_seed_traj = PPTrajectory(zoh(t,repmat(q0,1,nT)+[zeros(nq,1) 0*randn(nq,nT-1)]));
@@ -132,7 +132,7 @@ if(any(abs(q_breaks(l_leg_hpz,2:end)-q_breaks(r_leg_hpz,2:end))>0.1*pi+1e-8))
   error('SingleTimeLinearPostureConstraint is not satisfied');
 end
 display('Check IK traj with infeasibility')
-kc_err = WorldCoMConstraint(r,[nan;nan;2],inf(3,1),tspan);
+kc_err = WorldCoMConstraint(r,[nan;nan;2],inf(3,1));
 [xtraj,info,infeasible_constraint] = inverseKinTraj(r,t,q_seed_traj,q_nom_traj,kc_err,kc2{:},kc3,kc4,kc5,pc_knee,qsc,ikmexoptions);
 if(info ~= 13)
   error('The problem should be infeasible');
@@ -153,15 +153,15 @@ display(infeasible_constraint);
 % end
 
 display('Check IK with WorldFixedPositionConstraint');
-kc_fixedPosition = WorldFixedPositionConstraint(r,pelvis,[0;0;0],tspan);
+kc_fixedPosition = WorldFixedPositionConstraint(r,pelvis,[0;0;0]);
 xtraj = test_IKtraj_userfun(r,t,q_seed_traj,q_nom_traj,kc1{:},kc2{:},kc3,kc4,qsc,kc_fixedPosition,stlpc,ikoptions);
 
 display('Check IK with WorldFixedOrientConstraint');
-kc_fixedOrient = WorldFixedOrientConstraint(r,pelvis,tspan);
+kc_fixedOrient = WorldFixedOrientConstraint(r,pelvis);
 xtraj = test_IKtraj_userfun(r,t,q_seed_traj,q_nom_traj,kc1{:},kc2{:},kc3,kc4,qsc,kc_fixedOrient,stlpc,ikoptions);
 
 display('Check IK with WorldFixedBodyPoseConstraint');
-kc_fixedPose = WorldFixedBodyPoseConstraint(r,pelvis,tspan);
+kc_fixedPose = WorldFixedBodyPoseConstraint(r,pelvis);
 xtraj = test_IKtraj_userfun(r,t,q_seed_traj,q_nom_traj,kc1{:},kc2{:},kc3,kc4,qsc,pc_knee,kc_fixedPose,stlpc,ikoptions);
 
 display('Check IK with fixInitialState = false, the posture and velocity at the begining are also decision variables');
@@ -186,13 +186,8 @@ if(any(c_fixedPose-ub_fixedPose>1e-3) || any(c_fixedPose-lb_fixedPose<-1e-3))
 end
 
 ikoptions = ikoptions.setAdditionaltSamples([]);
-display('Check MultipleKinematicConstraint with tspan being only part of the t_breaks');
-tspan2 = [0.2 0.7];
-kc_fixedPose = WorldFixedBodyPoseConstraint(r,pelvis,tspan2);
-xtraj = test_IKtraj_userfun(r,t,q_seed_traj,q_nom_traj,kc1{:},kc2{:},kc3,kc4,qsc,pc_knee,kc_fixedPose,ikoptions);
-
 display('Check MultipleTimeLinearPostureConstraint');
-pc_change = PostureChangeConstraint(r,[l_leg_kny;r_leg_kny],[-0.1;-0.1],[0.05;0.05],tspan);
+pc_change = PostureChangeConstraint(r,[l_leg_kny;r_leg_kny],[-0.1;-0.1],[0.05;0.05]);
 ikoptions = ikoptions.setFixInitialState(true);
 xtraj = test_IKtraj_userfun(r,t,q_seed_traj,q_nom_traj,kc1{:},kc2{:},kc3,kc4,qsc,pc_change,ikoptions);
 xbreaks = xtraj.eval(t);
@@ -210,7 +205,7 @@ if(any(xbreaks(l_leg_kny,2:end)-xbreaks(l_leg_kny,1)>0.05+1e-10) || any(xbreaks(
 end
 
 display('Check MultipleTimeLinearPostureConstraint for time span being only part of the t_breaks');
-pc_change2 = PostureChangeConstraint(r,[l_leg_kny;r_leg_kny],[-0.1;-0.1],[0.05;0.05],[t(2) t(end)]);
+pc_change2 = PostureChangeConstraint(r,[l_leg_kny;r_leg_kny],[-0.1;-0.1],[0.05;0.05]);
 ikoptions = ikoptions.setFixInitialState(true);
 xtraj = test_IKtraj_userfun(r,t,q_seed_traj,q_nom_traj,kc1{:},kc2{:},kc3,kc4,qsc,pc_change2,ikoptions);
 xbreaks = xtraj.eval(t(2:end));
@@ -316,26 +311,22 @@ end
 for i = 1:nargin-4
   if(isa(varargin{i},'SingleTimeKinematicConstraint'))
     for j = t_start_idx:nT
-      if(varargin{i}.isTimeValid(t(j)))
-        [lb,ub] = varargin{i}.bounds(t(j));
-        c = varargin{i}.eval(t(j),kinsol{j});
-        if(any(c-ub>1e-3) || any(c-lb<-1e-3))
-          error('solution does not satisfy the SingleTimeKinematicConstraint');
-        end
+      [lb,ub] = varargin{i}.bounds(t(j));
+      c = varargin{i}.eval(t(j),kinsol{j});
+      if(any(c-ub>1e-3) || any(c-lb<-1e-3))
+        error('solution does not satisfy the SingleTimeKinematicConstraint');
       end
     end
   elseif(isa(varargin{i},'PostureConstraint'))
     for j = t_start_idx:nT
-      if(varargin{i}.isTimeValid(t(j)))
-        [lb,ub] = varargin{i}.bounds(t(j));
-        if(any(q_sol(:,j)>ub+1e-10) || any(q_sol(:,j)<lb-1e-10))
-          error('solution does not satisfy the PostureConstraint');
-        end
+      [lb,ub] = varargin{i}.bounds(t(j));
+      if(any(q_sol(:,j)>ub+1e-10) || any(q_sol(:,j)<lb-1e-10))
+        error('solution does not satisfy the PostureConstraint');
       end
     end
   elseif(isa(varargin{i},'QuasiStaticConstraint'))
     for j = t_start_idx:nT
-      if(varargin{i}.isTimeValid(t(j)) && varargin{i}.active)
+      if(varargin{i}.active)
         if(~varargin{i}.checkConstraint(kinsol{j}))
           error('solution does not satisfy the QuasiStaticConstraint');
         end
@@ -343,12 +334,10 @@ for i = 1:nargin-4
     end
   elseif(isa(varargin{i},'SingleTimeLinearPostureConstraint'))
     for j = t_start_idx:nT
-      if(varargin{i}.isTimeValid(t(j)))
-        [lb,ub] = varargin{i}.bounds(t(j));
-        c = varargin{i}.feval(t(j),q_sol(:,j));
-        if(any(c-ub>1e-3) || any(c-lb < -1e-3))
-          error('solution does not satisfy the SingleTimeLinearPostureConstraint');
-        end
+      [lb,ub] = varargin{i}.bounds(t(j));
+      c = varargin{i}.feval(t(j),q_sol(:,j));
+      if(any(c-ub>1e-3) || any(c-lb < -1e-3))
+        error('solution does not satisfy the SingleTimeLinearPostureConstraint');
       end
     end
   elseif(isa(varargin{i},'MultipleTimeKinematicConstraint'))


### PR DESCRIPTION
Based on a suggestion from @hongkai-dai that most if the timespan support was unused, and probably actively harmful if turned on.  I agreed on inspection, and the fact that the fairly extensive test library seems fine after excising it is causing me to agree.

Sorry for the mega-PR, API changes tend to do that.

There may be some initial CI breakage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2212)
<!-- Reviewable:end -->
