### PR TITLE
Disable flaky tests in repo rather than on CI

### DIFF
--- a/drake/bindings/matlab/test/CMakeLists.txt
+++ b/drake/bindings/matlab/test/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-add_matlab_test(NAME bindings/matlab/test/testRBTCoM COMMAND testRBTCoM)
-add_matlab_test(NAME bindings/matlab/test/testRBTIK_posture_constraint COMMAND testRBTIK_posture_constraint)
-add_matlab_test(NAME bindings/matlab/test/testRBTTransformPoints_gradient COMMAND testRBTTransformPoints_gradient)
-add_matlab_test(NAME bindings/matlab/test/testRBTTransformPoints_value COMMAND testRBTTransformPoints_value)
+# add_matlab_test(NAME bindings/matlab/test/testRBTCoM COMMAND testRBTCoM)  # FIXME
+# add_matlab_test(NAME bindings/matlab/test/testRBTIK_posture_constraint COMMAND testRBTIK_posture_constraint)  # FIXME: see #2101
+# add_matlab_test(NAME bindings/matlab/test/testRBTTransformPoints_gradient COMMAND testRBTTransformPoints_gradient)  # FIXME
+# add_matlab_test(NAME bindings/matlab/test/testRBTTransformPoints_value COMMAND testRBTTransformPoints_value)  # FIXME

--- a/drake/examples/Acrobot/test/CMakeLists.txt
+++ b/drake/examples/Acrobot/test/CMakeLists.txt
@@ -11,7 +11,7 @@ add_matlab_test(NAME examples/Acrobot/test/paramEstSyntheticData COMMAND paramEs
 add_matlab_test(NAME examples/Acrobot/test/paramExtractFromURDF COMMAND paramExtractFromURDF)
 add_matlab_test(NAME examples/Acrobot/test/polyIK COMMAND polyIK)
 add_matlab_test(NAME examples/Acrobot/test/testCpp COMMAND testCpp)
-add_matlab_test(NAME examples/Acrobot/test/testJointLimits COMMAND testJointLimits)
+# add_matlab_test(NAME examples/Acrobot/test/testJointLimits COMMAND testJointLimits)  # FIXME
 add_matlab_test(NAME examples/Acrobot/test/testKinematics COMMAND testKinematics)
 add_matlab_test(NAME examples/Acrobot/test/testManipulatorEquations COMMAND testManipulatorEquations)
 add_matlab_test(NAME examples/Acrobot/test/testMass COMMAND testMass)

--- a/drake/examples/Atlas/test/CMakeLists.txt
+++ b/drake/examples/Atlas/test/CMakeLists.txt
@@ -22,7 +22,7 @@ add_matlab_test(NAME examples/Atlas/test/testChangeRootLink COMMAND testChangeRo
 add_matlab_test(NAME examples/Atlas/test/testCollisionVolumes COMMAND testCollisionVolumes)
 add_matlab_test(NAME examples/Atlas/test/testKin COMMAND testKin)
 add_matlab_test(NAME examples/Atlas/test/testKin2 COMMAND testKin2)
-add_matlab_test(NAME examples/Atlas/test/testKneeSingularity COMMAND testKneeSingularity)
+# add_matlab_test(NAME examples/Atlas/test/testKneeSingularity COMMAND testKneeSingularity)  # FIXME: see #1603
 add_matlab_test(NAME examples/Atlas/test/testMex COMMAND testMex)
 add_matlab_test(NAME examples/Atlas/test/testOutputGradients COMMAND testOutputGradients)
 add_matlab_test(NAME examples/Atlas/test/testRunningPlanner COMMAND testRunningPlanner)

--- a/drake/examples/DubinsCar/CMakeLists.txt
+++ b/drake/examples/DubinsCar/CMakeLists.txt
@@ -1,4 +1,4 @@
 
-add_matlab_test(NAME examples/DubinsCar/runFunnel COMMAND runFunnel)
+# add_matlab_test(NAME examples/DubinsCar/runFunnel COMMAND runFunnel)  # FIXME
 
 add_subdirectory(test)

--- a/drake/examples/IRB140/CMakeLists.txt
+++ b/drake/examples/IRB140/CMakeLists.txt
@@ -1,2 +1,2 @@
 
-add_matlab_test(NAME examples/IRB140/runPlanning COMMAND runPlanning)
+# add_matlab_test(NAME examples/IRB140/runPlanning COMMAND runPlanning)  # FIXME

--- a/drake/examples/PR2/CMakeLists.txt
+++ b/drake/examples/PR2/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 add_matlab_test(NAME examples/PR2/drawPR2 COMMAND drawPR2)
 add_matlab_test(NAME examples/PR2/runPassive COMMAND runPassive)
-add_matlab_test(NAME examples/PR2/runSaggitalPassive COMMAND runSaggitalPassive)
+# add_matlab_test(NAME examples/PR2/runSaggitalPassive COMMAND runSaggitalPassive)  # FIXME

--- a/drake/examples/PlanarNLink/CMakeLists.txt
+++ b/drake/examples/PlanarNLink/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_matlab_test(NAME examples/PlanarNLink/runLQR COMMAND runLQR)
+# add_matlab_test(NAME examples/PlanarNLink/runLQR COMMAND runLQR)  # FIXME
 add_matlab_test(NAME examples/PlanarNLink/runPassive COMMAND runPassive)
 
 add_subdirectory(test)

--- a/drake/examples/Quadrotor/CMakeLists.txt
+++ b/drake/examples/Quadrotor/CMakeLists.txt
@@ -14,7 +14,7 @@ if (LCM_FOUND AND NOT (WIN32 AND (CMAKE_SIZEOF_VOID_P EQUAL 4)))
   add_test(NAME runQuadrotorLQR COMMAND runQuadrotorLQR --non-realtime)
 endif()
 
-add_matlab_test(NAME examples/Quadrotor/Quadrotor.runOpenLoop COMMAND Quadrotor.runOpenLoop)
+# add_matlab_test(NAME examples/Quadrotor/Quadrotor.runOpenLoop COMMAND Quadrotor.runOpenLoop)  # FIXME
 add_matlab_test(NAME examples/Quadrotor/runDircol COMMAND runDircol)
 add_matlab_test(NAME examples/Quadrotor/runDircolWObs COMMAND runDircolWObs)
 add_matlab_test(NAME examples/Quadrotor/runLQR COMMAND runLQR)

--- a/drake/examples/Quadrotor/test/CMakeLists.txt
+++ b/drake/examples/Quadrotor/test/CMakeLists.txt
@@ -4,7 +4,7 @@ if (LCM_FOUND AND GTEST_FOUND)
   add_test(NAME quadrotorURDFDynamicsTest COMMAND quadrotorURDFDynamicsTest)
 endif(LCM_FOUND AND GTEST_FOUND)
 
-add_matlab_test(NAME examples/Quadrotor/test/buildOcTree COMMAND buildOcTree)
+# add_matlab_test(NAME examples/Quadrotor/test/buildOcTree COMMAND buildOcTree)  # FIXME: see #2100
 add_matlab_test(NAME examples/Quadrotor/test/manipulatorGradients COMMAND manipulatorGradients)
 add_matlab_test(NAME examples/Quadrotor/test/propellorGradients COMMAND propellorGradients)
 add_matlab_test(NAME examples/Quadrotor/test/quadrotorDynamics COMMAND quadrotorDynamics)

--- a/drake/examples/RimlessWheel/CMakeLists.txt
+++ b/drake/examples/RimlessWheel/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_matlab_test(NAME examples/RimlessWheel/RimlessWheelPlant.run COMMAND RimlessWheelPlant.run)
 add_matlab_test(NAME examples/RimlessWheel/runDircol COMMAND runDircol)
-add_matlab_test(NAME examples/RimlessWheel/runPassiveLCP COMMAND runPassiveLCP) # see #374
+# add_matlab_test(NAME examples/RimlessWheel/runPassiveLCP COMMAND runPassiveLCP)  # FIXME: see #374
 
 add_subdirectory(test)

--- a/drake/examples/RimlessWheel/test/CMakeLists.txt
+++ b/drake/examples/RimlessWheel/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 
-add_matlab_test(NAME examples/RimlessWheel/test/testContactGradients COMMAND testContactGradients)
-add_matlab_test(NAME examples/RimlessWheel/test/testLCPgradients COMMAND testLCPgradients)
+# add_matlab_test(NAME examples/RimlessWheel/test/testContactGradients COMMAND testContactGradients)  # FIXME
+# add_matlab_test(NAME examples/RimlessWheel/test/testLCPgradients COMMAND testLCPgradients)  # FIXME

--- a/drake/examples/SimplePulleys/CMakeLists.txt
+++ b/drake/examples/SimplePulleys/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_matlab_test(NAME examples/SimplePulleys/ChineseYoYo.runPassive COMMAND ChineseYoYo.runPassive)
-add_matlab_test(NAME examples/SimplePulleys/multiple_pulleys COMMAND multiple_pulleys)
-add_matlab_test(NAME examples/SimplePulleys/simple_pulley COMMAND simple_pulley)
+# add_matlab_test(NAME examples/SimplePulleys/multiple_pulleys COMMAND multiple_pulleys)  # FIXME
+# add_matlab_test(NAME examples/SimplePulleys/simple_pulley COMMAND simple_pulley)  # FIXME
 add_matlab_test(NAME examples/SimplePulleys/soft_hand COMMAND soft_hand)
 add_matlab_test(NAME examples/SimplePulleys/tension COMMAND tension)

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -20,7 +20,7 @@ add_matlab_test(NAME solvers/test/rrt_bugtrap COMMAND rrt_bugtrap)
 add_matlab_test(NAME solvers/test/rrt_piano_mover COMMAND rrt_piano_mover)
 add_matlab_test(NAME solvers/test/rrt_piano_mover_rotation COMMAND rrt_piano_mover_rotation)
 add_matlab_test(NAME solvers/test/rrt_piano_mover_translation COMMAND rrt_piano_mover_translation)
-add_matlab_test(NAME solvers/test/sixHumpCamel COMMAND sixHumpCamel)
+# add_matlab_test(NAME solvers/test/sixHumpCamel COMMAND sixHumpCamel)  # FIXME
 add_matlab_test(NAME solvers/test/testConstraint COMMAND testConstraint)
 add_matlab_test(NAME solvers/test/testGurobiLCP COMMAND testGurobiLCP)
 add_matlab_test(NAME solvers/test/testLQRmex COMMAND testLQRmex)

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -191,7 +191,7 @@ add_matlab_test(NAME systems/plants/test/testPositionConstraintsmex COMMAND test
 add_matlab_test(NAME systems/plants/test/testPositionControlGradients COMMAND testPositionControlGradients)
 add_matlab_test(NAME systems/plants/test/testRelativeTwist COMMAND testRelativeTwist)
 add_matlab_test(NAME systems/plants/test/testRigidBodyBluffBody COMMAND testRigidBodyBluffBody)
-add_matlab_test(NAME systems/plants/test/testRigidBodyInertialMeasurementUnit COMMAND testRigidBodyInertialMeasurementUnit)
+# add_matlab_test(NAME systems/plants/test/testRigidBodyInertialMeasurementUnit COMMAND testRigidBodyInertialMeasurementUnit)  # FIXME
 add_matlab_test(NAME systems/plants/test/testRigidBodyPassByValue COMMAND testRigidBodyPassByValue)
 add_matlab_test(NAME systems/plants/test/testRigidBodyPropellor COMMAND testRigidBodyPropellor)
 add_matlab_test(NAME systems/plants/test/testRigidBodyWingChangingParams COMMAND testRigidBodyWingChangingParams)
@@ -203,7 +203,7 @@ add_matlab_test(NAME systems/plants/test/testTerrainContactJacobianDotTimesV COM
 add_matlab_test(NAME systems/plants/test/testThrust COMMAND testThrust)
 add_matlab_test(NAME systems/plants/test/testTorsionalSpring COMMAND testTorsionalSpring)
 add_matlab_test(NAME systems/plants/test/testTorsionalSpringGradient COMMAND testTorsionalSpringGradient)
-add_matlab_test(NAME systems/plants/test/testURDFmex COMMAND testURDFmex)
+# add_matlab_test(NAME systems/plants/test/testURDFmex COMMAND testURDFmex)  # FIXME: see #2013
 add_matlab_test(NAME systems/plants/test/testWing COMMAND testWing)
 add_matlab_test(NAME systems/plants/test/testWingForceGradients COMMAND testWingForceGradients)
 add_matlab_test(NAME systems/plants/test/testdHomogTrans COMMAND testdHomogTrans)

--- a/drake/util/test/CMakeLists.txt
+++ b/drake/util/test/CMakeLists.txt
@@ -85,8 +85,8 @@ add_matlab_test(NAME util/test/testQuat COMMAND testQuat)
 add_matlab_test(NAME util/test/testQuat2expmap COMMAND testQuat2expmap)
 add_matlab_test(NAME util/test/testQuat2expmapSequence COMMAND testQuat2expmapSequence)
 add_matlab_test(NAME util/test/testQuat2rotmat COMMAND testQuat2rotmat)
-add_matlab_test(NAME util/test/testQuatConjugate COMMAND testQuatConjugate)
-add_matlab_test(NAME util/test/testQuatProduct COMMAND testQuatProduct)
+# add_matlab_test(NAME util/test/testQuatConjugate COMMAND testQuatConjugate)  # FIXME
+# add_matlab_test(NAME util/test/testQuatProduct COMMAND testQuatProduct)  # FIXME
 add_matlab_test(NAME util/test/testQuatRotateVec COMMAND testQuatRotateVec)
 add_matlab_test(NAME util/test/testQuatdot2angularvel COMMAND testQuatdot2angularvel)
 add_matlab_test(NAME util/test/testQuatdot2angularvelMatrix COMMAND testQuatdot2angularvelMatrix)


### PR DESCRIPTION
The following were disabled on CI for varying levels of flakiness. It makes more sense for the disabling to be done in the main repo so that they are not forgotten. Once this is merged, I will remove the config file from CI. 

For reference, the complete list is:
```
bindings/matlab/test/testRBTCoM
bindings/matlab/test/testRBTIK_posture_constraint
bindings/matlab/test/testRBTTransformPoints_gradient
bindings/matlab/test/testRBTTransformPoints_value
examples/Acrobot/test/testJointLimits
examples/Atlas/test/testKneeSingularity
examples/DubinsCar/runFunnel
examples/IRB140/runPlanning
examples/Pendulum/test/testLCMPlant
examples/PlanarNLink/runLQR
examples/PR2/runSaggitalPassive
examples/Quadrotor/Quadrotor.runOpenLoop
examples/Quadrotor/test/buildOcTree
examples/RimlessWheel/runPassiveLCP
examples/RimlessWheel/test/testContactGradients
examples/RimlessWheel/test/testLCPgradients
examples/SimplePulleys/multiple_pulleys
examples/SimplePulleys/simple_pulley
solvers/test/sixHumpCamel
systems/plants/test/testRigidBodyInertialMeasurementUnit
systems/plants/test/testURDFmex
util/test/testQuatConjugate
util/test/testQuatProduct
```

@david-german-tri PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2234)
<!-- Reviewable:end -->
