### PR TITLE
Add mechanism for passing options to solvers in C++.

### DIFF
--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <list>
+#include <map>
 #include <memory>
 #include <initializer_list>
 #include <Eigen/Core>
@@ -639,6 +640,36 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   }
 
   /**
+   * Set an option for a particular solver.  This interface does not
+   * do any verification of solver parameters beyond what an
+   * individual solver does for itself.  It does not even verify that
+   * the specifed solver exists.  Use this only when you have
+   * particular knowledge of what solver is being invoked, and exactly
+   * what tuning is required.
+   */
+  void SetSolverOption(const std::string& solver_name,
+                       const std::string& solver_option,
+                       double option_value) {
+    solver_options_double_[solver_name][solver_option] = option_value;
+  }
+
+  void SetSolverOption(const std::string& solver_name,
+                       const std::string& solver_option,
+                       int option_value) {
+    solver_options_int_[solver_name][solver_option] = option_value;
+  }
+
+  const std::map<std::string, double>& GetSolverOptionsDouble(
+      const std::string& solver_name) {
+    return solver_options_double_[solver_name];
+  }
+
+  const std::map<std::string, int>& GetSolverOptionsInt(
+      const std::string& solver_name) {
+    return solver_options_int_[solver_name];
+  }
+
+  /**
    * Get the name and result code of the particular solver which was
    * used to solve this OptimizationProblem.  The solver names and
    * results are not documented here as this function is only intended
@@ -731,6 +762,8 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   std::shared_ptr<MathematicalProgramInterface> problem_type_;
   std::string solver_name_;
   int solver_result_;
+  std::map<std::string, std::map<std::string, double>> solver_options_double_;
+  std::map<std::string, std::map<std::string, int>> solver_options_int_;
 };
 
 }  // end namespace Drake

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -646,6 +646,12 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    * the specifed solver exists.  Use this only when you have
    * particular knowledge of what solver is being invoked, and exactly
    * what tuning is required.
+   *
+   * Supported solver names/options:
+   *
+   * "SNOPT" -- Paramater names and values as specified in SNOPT
+   * User's Guide section 7.7 "Description ofthe optional parameters",
+   * used as described in section 7.5 for snSet().
    */
   void SetSolverOption(const std::string& solver_name,
                        const std::string& solver_option,

--- a/drake/solvers/SnoptSolver.cpp
+++ b/drake/solvers/SnoptSolver.cpp
@@ -433,38 +433,13 @@ SolutionResult Drake::SnoptSolver::Solve(
   snopt::doublereal ObjAdd = 0.0;
   snopt::integer ObjRow = 1;  // feasibility problem (for now)
 
-  // TODO(sam.creasey) These should be made into options when #1879 is
-  // resolved or deleted.
-  /*
-    mysnseti("Derivative
-    option",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"DerivativeOption"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("Major iterations
-    limit",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"MajorIterationsLimit"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("Minor iterations
-    limit",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"MinorIterationsLimit"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnsetr("Major optimality
-    tolerance",static_cast<snopt::doublereal>(*mxGetPr(mxGetField(prhs[13],0,"MajorOptimalityTolerance"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnsetr("Major feasibility
-    tolerance",static_cast<snopt::doublereal>(*mxGetPr(mxGetField(prhs[13],0,"MajorFeasibilityTolerance"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnsetr("Minor feasibility
-    tolerance",static_cast<snopt::doublereal>(*mxGetPr(mxGetField(prhs[13],0,"MinorFeasibilityTolerance"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("Superbasics
-    limit",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"SuperbasicsLimit"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("Verify
-    level",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"VerifyLevel"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("Iterations
-    Limit",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"IterationsLimit"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("Scale
-    option",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"ScaleOption"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("New basis
-    file",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"NewBasisFile"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("Old basis
-    file",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"OldBasisFile"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnseti("Backup basis
-    file",static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"BackupBasisFile"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-    mysnsetr("Linesearch
-    tolerance",static_cast<snopt::doublereal>(*mxGetPr(mxGetField(prhs[13],0,"LinesearchTolerance"))),&iPrint,&iSumm,&INFO_snopt,cw.get(),&lencw,iw.get(),&leniw,rw.get(),&lenrw);
-  */
+  for (const auto it : prog.GetSolverOptionsDouble("SNOPT")) {
+    cur.snSetr(it.first, it.second);
+  }
+
+  for (const auto it : prog.GetSolverOptionsInt("SNOPT")) {
+    cur.snSeti(it.first, it.second);
+  }
 
   snopt::integer info;
   snopt::snopta_(


### PR DESCRIPTION
Toward #1879 -- add the ability to pass through options to SNOPT.

This is outwardly fairly similar to the mechanism provided for the MATLAB code in NonlinearProgram.  It's going to be needed eventually as part of the update of inverseKin* to use OptimizationProblem as the tests make use of the ability to set solver parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2238)
<!-- Reviewable:end -->
