### PR TITLE
Mesh filename publishing

### DIFF
--- a/drake/examples/Cars/models/prius/prius.urdf
+++ b/drake/examples/Cars/models/prius/prius.urdf
@@ -312,7 +312,7 @@
     <visual name="v1">
       <origin rpy="0 0 0" xyz="-2.27 -0.91139 -0.21858"/>
       <geometry>
-        <mesh filename="package://drake/examples/Cars/models/prius/prius.dae" scale="1.0 1.0 1.0"/>
+        <mesh filename="prius.dae" scale="1.0 1.0 1.0"/>
       </geometry>
     </visual>
   </link>

--- a/drake/examples/Cars/models/prius/prius.urdf
+++ b/drake/examples/Cars/models/prius/prius.urdf
@@ -312,7 +312,7 @@
     <visual name="v1">
       <origin rpy="0 0 0" xyz="-2.27 -0.91139 -0.21858"/>
       <geometry>
-        <mesh filename="prius.dae" scale="1.0 1.0 1.0"/>
+        <mesh filename="package://drake/examples/Cars/models/prius/prius.dae" scale="1.0 1.0 1.0"/>
       </geometry>
     </visual>
   </link>

--- a/drake/systems/plants/BotVisualizer.h
+++ b/drake/systems/plants/BotVisualizer.h
@@ -103,10 +103,13 @@ class BotVisualizer {
             gdata.num_float_data = 1;
             auto m = dynamic_cast<const DrakeShapes::Mesh &>(geometry);
             gdata.float_data.push_back(static_cast<float>(m.scale));
-            gdata.string_data = m.resolved_filename;  // looks like this could
-                                                      // be empty, but it is
-                                                      // what's used in the get
-                                                      // mesh points...
+
+            if (m.filename.find("package://") == 0) {
+              gdata.string_data = m.filename;
+            } else {
+              gdata.string_data = m.resolved_filename;
+            }
+
             break;
           }
           case DrakeShapes::CAPSULE: {

--- a/drake/systems/plants/xmlUtil.cpp
+++ b/drake/systems/plants/xmlUtil.cpp
@@ -205,7 +205,25 @@ string resolveFilename(const string& filename,
       return string();
     }
   } else {
-    mesh_filename_s = spruce::path(root_dir);
+    std::string normalized_root_dir = spruce::path(root_dir).getStr();
+
+    // if root_dir is a relative path then convert it to absolute
+#ifdef _WIN32
+    bool dirIsRelative = !(normalized_root_dir.size() >= 2
+                           && std::isalpha(normalized_root_dir[0])
+                           && normalized_root_dir[1] == ':');
+#else
+    bool dirIsRelative = !(normalized_root_dir.size() >= 1
+                           && normalized_root_dir[0] == '/');
+#endif
+    if (dirIsRelative) {
+      mesh_filename_s = spruce::path();
+      mesh_filename_s.setAsCurrent();
+      mesh_filename_s.append(normalized_root_dir);
+    } else {
+      mesh_filename_s = spruce::path(normalized_root_dir);
+    }
+
     mesh_filename_s.append(filename);
   }
   if (!mesh_filename_s.exists()) {


### PR DESCRIPTION
This addresses the discussion in #1636.

Note, this depends on the ability to check whether a path is relative or absolute. The spruce third party library that drake uses for filename manipulation does not provide this capability.  As a workaround, this pull request implements a check for relative paths that assumes posix paths, it does not work on Windows (so don't merge this yet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2239) &emsp; Multiple assignees:&emsp;<img alt="@david-german-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17437069?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/david-german-tri">david-german-tri</a>,&emsp;<img alt="@patmarion" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/90784?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/patmarion">patmarion</a>
<!-- Reviewable:end -->
