### PR TITLE
Make NiceTypeName recognize a wider class of compiler-inserted dummy namespaces

### DIFF
--- a/drake/common/nice_type_name.cc
+++ b/drake/common/nice_type_name.cc
@@ -58,8 +58,9 @@ string drake::common::NiceTypeName::Canonicalize(const string& demangled) {
     // alphanumeric or underscore.)
     SPair(std::regex("(\\w) (\\w)"), "$1!$2"),
     SPair(std::regex(" "), ""),  // Delete unwanted spaces.
-    // OSX clang throws in extra namespaces like "__1". Delete them.
-    SPair(std::regex("\\b__[0-9]+::"), ""),
+    // Some compilers throw in extra namespaces like "__1" or "__cxx11". 
+    // Delete them.
+    SPair(std::regex("\\b__[[:alnum:]_]+::"), ""),
     SPair(std::regex("!"), " "),  // Restore wanted spaces.
     // Recognize std::string's full name and abbreviate.
     SPair(std::regex("\\bstd::basic_string<char,std::char_traits<char>,"

--- a/drake/common/nice_type_name.cc
+++ b/drake/common/nice_type_name.cc
@@ -58,7 +58,7 @@ string drake::common::NiceTypeName::Canonicalize(const string& demangled) {
     // alphanumeric or underscore.)
     SPair(std::regex("(\\w) (\\w)"), "$1!$2"),
     SPair(std::regex(" "), ""),  // Delete unwanted spaces.
-    // Some compilers throw in extra namespaces like "__1" or "__cxx11". 
+    // Some compilers throw in extra namespaces like "__1" or "__cxx11".
     // Delete them.
     SPair(std::regex("\\b__[[:alnum:]_]+::"), ""),
     SPair(std::regex("!"), " "),  // Restore wanted spaces.

--- a/drake/common/test/nice_type_name_test.cc
+++ b/drake/common/test/nice_type_name_test.cc
@@ -47,7 +47,7 @@ GTEST_TEST(TestNiceTypeName, Canonicalize) {
   EXPECT_EQ(NiceTypeName::Canonicalize("lunch bucket"), "lunch bucket");
   // And keep funny looking namespaces if they aren't __digits.
   EXPECT_EQ(NiceTypeName::Canonicalize("std::my__1::__23x::resigned char"),
-            "std::my__1::__23x::resigned char");
+            "std::my__1::resigned char");
 }
 
 GTEST_TEST(TestNiceTypeName, BuiltIns) {

--- a/drake/common/test/nice_type_name_test.cc
+++ b/drake/common/test/nice_type_name_test.cc
@@ -45,7 +45,7 @@ GTEST_TEST(TestNiceTypeName, Canonicalize) {
 
   // Should leave spaces between words.
   EXPECT_EQ(NiceTypeName::Canonicalize("lunch bucket"), "lunch bucket");
-  // And keep funny looking namespaces if they aren't __digits.
+  // And keep funny looking namespaces if they aren't __something.
   EXPECT_EQ(NiceTypeName::Canonicalize("std::my__1::__23x::resigned char"),
             "std::my__1::resigned char");
 }


### PR DESCRIPTION
`NiceTypeName` removes compiler-added dummy namespaces from the canonicalized names it produces. Previously only namespaces like `__123` (two underscores followed by digits) were removed. Apparently gcc 5.3 (in Ubuntu 16.04) inserts `__cxx11::` so I widened the "nuke me" set to any namespace that starts with two underscores (always reserved for system use per standard).

Fixes #2236.

@ggould-tri: I am having trouble getting a gcc 5 build in my Ubuntu VM, and ci won't check either. Would you please pull this to verify it fixes your problem before it gets merged?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2246)
<!-- Reviewable:end -->
