### PR TITLE
Fix an obscure template-y bug in CascadeSystem...

### DIFF
--- a/drake/systems/cascade_system.h
+++ b/drake/systems/cascade_system.h
@@ -21,13 +21,12 @@ template <class System1, class System2>
 class CascadeSystem {
  public:
   template <typename ScalarType>
-  using StateVector = typename CombinedVectorUtil<
-      System1::template StateVector,
-      System2::template StateVector>::template type<ScalarType>;
-  template <typename ScalarType>
   using StateVector1 = typename System1::template StateVector<ScalarType>;
   template <typename ScalarType>
   using StateVector2 = typename System2::template StateVector<ScalarType>;
+  using util = CombinedVectorUtil<StateVector1, StateVector2>;
+  template <typename ScalarType>
+  using StateVector = typename util::template type<ScalarType>;
   template <typename ScalarType>
   using InputVector = typename System1::template InputVector<ScalarType>;
   template <typename ScalarType>
@@ -35,9 +34,8 @@ class CascadeSystem {
       typename System1::template OutputVector<ScalarType>;
   template <typename ScalarType>
   using OutputVector = typename System2::template OutputVector<ScalarType>;
-  typedef std::shared_ptr<System1> System1Ptr;
-  typedef std::shared_ptr<System2> System2Ptr;
-  typedef CombinedVectorUtil<StateVector1, StateVector2> util;
+  using System1Ptr = std::shared_ptr<System1>;
+  using System2Ptr = std::shared_ptr<System2>;
 
   static_assert(
       std::is_same<typename System1::template OutputVector<double>,


### PR DESCRIPTION
Fix (so it seems) an obscure template-y bug in CascadeSystem,
by deriving 'util' from 'StateVector1' and 'StateVector2' first,
and then 'StateVector' directly from that 'util', rather than having a
parallel construct of "CombineVectorUtil<System1::StateVector, ...>".

In the original form, the compiler was unable to lookup an appropriate
"util::first()" to apply to StateVector --- in some particular case
of StateVector1/2 being nested templates.

(Also, uniformly use "using" instead of "typedef".)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2277)
<!-- Reviewable:end -->
