### PR TITLE
Tune up clang-format to force pointers to the type for C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,8 @@
 ---
 BasedOnStyle:  Google
+---
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+---


### PR DESCRIPTION
Tune up clang-format to force pointers to the type for C++, even if the predominant convention in the file is otherwise.  This closes #2290 (at least, the underlying confusion).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2291) &emsp; Multiple assignees:&emsp;<img alt="@amcastro-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17601461?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/amcastro-tri">amcastro-tri</a>,&emsp;<img alt="@david-german-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17437069?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/david-german-tri">david-german-tri</a>
<!-- Reviewable:end -->
