### PR TITLE
CONTRIBUTING: Update Drake online developer documentation URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,7 @@
-
 ### Contributing code
 
-If you have improvements to Drake, send us your pull requests! 
+If you have improvements to Drake, send us your pull requests!
 
-Please make look at our devloper's page for details:
+Please see our developer's page for details:
 * `drake/doc/developers.rst`
 * [online version](http://drake002.csail.mit.edu/drake/sphinx/developers.html)
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ If you have improvements to Drake, send us your pull requests!
 
 Please see our developer's page for details:
 * `drake/doc/developers.rst`
-* [online version](http://drake002.csail.mit.edu/drake/sphinx/developers.html)
+* [online version](http://drake.mit.edu/developers.html)


### PR DESCRIPTION
We now host the documentation at `drake.mit.edu`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2309)
<!-- Reviewable:end -->
