### PR TITLE
BUILDCOP: Yet more MATLAB timeout fixes

### DIFF
--- a/drake/examples/PR2/CMakeLists.txt
+++ b/drake/examples/PR2/CMakeLists.txt
@@ -1,4 +1,7 @@
 
 add_matlab_test(NAME examples/PR2/drawPR2 COMMAND drawPR2)
-add_matlab_test(NAME examples/PR2/runPassive COMMAND runPassive)
 # add_matlab_test(NAME examples/PR2/runSaggitalPassive COMMAND runSaggitalPassive)  # FIXME
+
+if (LONG_RUNNING_TESTS)
+  add_matlab_test(NAME examples/PR2/runPassive COMMAND runPassive PROPERTIES TIMEOUT 3000)
+endif()

--- a/drake/examples/Strandbeest/CMakeLists.txt
+++ b/drake/examples/Strandbeest/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 if (LONG_RUNNING_TESTS)
-  add_matlab_test(NAME examples/Strandbeest/runPassiveDownhill COMMAND runPassiveDownhill PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Strandbeest/runWithMotor COMMAND runWithMotor PROPERTIES TIMEOUT 1500)
+  add_matlab_test(NAME examples/Strandbeest/runPassiveDownhill COMMAND runPassiveDownhill PROPERTIES TIMEOUT 3000)
+  add_matlab_test(NAME examples/Strandbeest/runWithMotor COMMAND runWithMotor PROPERTIES TIMEOUT 3000)
 endif()


### PR DESCRIPTION
See:
* linux-gcc-nightly-matlab-coverage: https://drake-cdash.csail.mit.edu/viewTest.php?onlyfailed&buildid=17410
* linux-gcc-nightly-matlab-open-source: https://drake-cdash.csail.mit.edu/viewTest.php?onlyfailed&buildid=17832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2312)
<!-- Reviewable:end -->
