### PR TITLE
BUILDCOP: Disable flaky test / fix timeouts for MSVC 32 MATLAB

### DIFF
--- a/drake/examples/Acrobot/test/CMakeLists.txt
+++ b/drake/examples/Acrobot/test/CMakeLists.txt
@@ -17,5 +17,5 @@ add_matlab_test(NAME examples/Acrobot/test/testManipulatorEquations COMMAND test
 add_matlab_test(NAME examples/Acrobot/test/testMass COMMAND testMass)
 add_matlab_test(NAME examples/Acrobot/test/testTSRB COMMAND testTSRB)
 add_matlab_test(NAME examples/Acrobot/test/testTrajOpt COMMAND testTrajOpt)
-add_matlab_test(NAME examples/Acrobot/test/trigPolyTest COMMAND trigPolyTest)
+add_matlab_test(NAME examples/Acrobot/test/trigPolyTest COMMAND trigPolyTest PROPERTIES TIMEOUT 750)
 add_matlab_test(NAME examples/Acrobot/test/urdfDynamicsTest COMMAND urdfDynamicsTest)

--- a/drake/examples/Acrobot/test/trigPolyTest.m
+++ b/drake/examples/Acrobot/test/trigPolyTest.m
@@ -47,3 +47,5 @@ function xnp = euler(dt)
 end
 
 end
+
+% TIMEOUT 750

--- a/drake/systems/plants/constraint/test/CMakeLists.txt
+++ b/drake/systems/plants/constraint/test/CMakeLists.txt
@@ -4,7 +4,7 @@ add_matlab_test(NAME systems/plants/constraint/test/RelativeGazeTargetConstraint
 add_matlab_test(NAME systems/plants/constraint/test/RelativePositionConstraintTest COMMAND RelativePositionConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/RelativeQuatConstraintTest COMMAND RelativeQuatConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/WorldPositionInFrameConstraintTest COMMAND WorldPositionInFrameConstraintTest)
-add_matlab_test(NAME systems/plants/constraint/test/testKinCnst COMMAND testKinCnst)
+add_matlab_test(NAME systems/plants/constraint/test/testKinCnst COMMAND testKinCnst PROPERTIES TIMEOUT 750)
 add_matlab_test(NAME systems/plants/constraint/test/testMultipleTimeLinearPostureConstraint COMMAND testMultipleTimeLinearPostureConstraint)
 add_matlab_test(NAME systems/plants/constraint/test/testPostureConstraint COMMAND testPostureConstraint)
 add_matlab_test(NAME systems/plants/constraint/test/testQuasiStaticConstraint COMMAND testQuasiStaticConstraint)

--- a/drake/systems/plants/constraint/test/testKinCnst.m
+++ b/drake/systems/plants/constraint/test/testKinCnst.m
@@ -422,3 +422,5 @@ function c = eval_numerical_matlab(constraint,t,q)
 kinsol = doKinematics(constraint.robot,q,false,false);
 c = constraint.eval(t,kinsol);
 end
+
+% TIMEOUT 750

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -125,7 +125,7 @@ add_matlab_test(NAME systems/plants/test/bullet_collision_all_bodies_jac_test CO
 add_matlab_test(NAME systems/plants/test/bullet_collision_closest_distance_jac_test COMMAND bullet_collision_closest_distance_jac_test)
 add_matlab_test(NAME systems/plants/test/bullet_collision_zero_rad_sphere_test COMMAND bullet_collision_zero_rad_sphere_test)
 add_matlab_test(NAME systems/plants/test/bullet_raycast_test COMMAND bullet_raycast_test)
-add_matlab_test(NAME systems/plants/test/collidingPointsTest COMMAND collidingPointsTest)
+# add_matlab_test(NAME systems/plants/test/collidingPointsTest COMMAND collidingPointsTest)  # FIXME: see #2320
 add_matlab_test(NAME systems/plants/test/collisionDetectBoxTest COMMAND collisionDetectBoxTest)
 add_matlab_test(NAME systems/plants/test/collisionDetectCHullTest COMMAND collisionDetectCHullTest)
 add_matlab_test(NAME systems/plants/test/collisionDetectCapsuleTest COMMAND collisionDetectCapsuleTest)


### PR DESCRIPTION
See #2320, https://drake-cdash.csail.mit.edu/viewTest.php?onlyfailed&buildid=18333.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2321)
<!-- Reviewable:end -->
