### PR TITLE
Add a `FunctionalForm` class to model functional forms

### DIFF
--- a/drake/core/CMakeLists.txt
+++ b/drake/core/CMakeLists.txt
@@ -1,4 +1,13 @@
 
 add_subdirectory(test)
 
-drake_install_headers(Function.h Gradient.h Vector.h)
+drake_install_headers(
+  Function.h
+  functional_form.h
+  Gradient.h
+  Vector.h
+  )
+
+add_library_with_exports(LIB_NAME drakeCore SOURCE_FILES
+  functional_form.cc
+  )

--- a/drake/core/functional_form.cc
+++ b/drake/core/functional_form.cc
@@ -48,6 +48,12 @@ class FunctionalForm::Internal {
   static Form const kAdd[kSize][kSize];
   static Form const kMul[kSize][kSize];
   static Form const kDiv[kSize][kSize];
+  static Form const kAbs[kSize];
+  static Form const kCos[kSize];
+  static Form const kExp[kSize];
+  static Form const kLog[kSize];
+  static Form const kSin[kSize];
+  static Form const kSqrt[kSize];
 
   // Only some of the forms need to carry variables.
   static bool need_vars(Form f) {
@@ -160,6 +166,36 @@ FunctionalForm operator/(FunctionalForm const& l, FunctionalForm const& r) {
     vars = FunctionalForm::Variables::Union(l.vars_, r.vars_);
   }
   return FunctionalForm(f, std::move(vars));
+}
+
+FunctionalForm abs(FunctionalForm const& x) {
+  return FunctionalForm(FunctionalForm::Internal::kAbs[IndexOf(x.form_)],
+                        FunctionalForm::Variables(x.vars_));
+}
+
+FunctionalForm cos(FunctionalForm const& x) {
+  return FunctionalForm(FunctionalForm::Internal::kCos[IndexOf(x.form_)],
+                        FunctionalForm::Variables(x.vars_));
+}
+
+FunctionalForm exp(FunctionalForm const& x) {
+  return FunctionalForm(FunctionalForm::Internal::kExp[IndexOf(x.form_)],
+                        FunctionalForm::Variables(x.vars_));
+}
+
+FunctionalForm log(FunctionalForm const& x) {
+  return FunctionalForm(FunctionalForm::Internal::kLog[IndexOf(x.form_)],
+                        FunctionalForm::Variables(x.vars_));
+}
+
+FunctionalForm sin(FunctionalForm const& x) {
+  return FunctionalForm(FunctionalForm::Internal::kSin[IndexOf(x.form_)],
+                        FunctionalForm::Variables(x.vars_));
+}
+
+FunctionalForm sqrt(FunctionalForm const& x) {
+  return FunctionalForm(FunctionalForm::Internal::kSqrt[IndexOf(x.form_)],
+                        FunctionalForm::Variables(x.vars_));
 }
 
 FunctionalForm& operator+=(FunctionalForm& l, FunctionalForm const& r) {
@@ -527,6 +563,54 @@ FunctionalForm::Form const FunctionalForm::Internal::kDiv[kSize][kSize] = {
     /* DIFF */ {UNDF, DIFF, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF},
     /* ARB  */ {UNDF,  ARB,  ARB,  ARB,  ARB,  ARB,  ARB, UNDF},
     /* UNDF */ {UNDF, UNDF, UNDF, UNDF, UNDF, UNDF, UNDF, UNDF},
+    /* clang-format on */
+};
+
+FunctionalForm::Form const FunctionalForm::Internal::kAbs[kSize] = {
+    /* clang-format off */
+    /* ZERO  CONS   LIN   AFF  POLY  DIFF   ARB  UNDF */
+    /* ----  ----  ----  ----  ----  ----  ----  ---- */
+       ZERO, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF,
+    /* clang-format on */
+};
+
+FunctionalForm::Form const FunctionalForm::Internal::kCos[kSize] = {
+    /* clang-format off */
+    /* ZERO  CONS   LIN   AFF  POLY  DIFF   ARB  UNDF */
+    /* ----  ----  ----  ----  ----  ----  ----  ---- */
+       CONS, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF,
+    /* clang-format on */
+};
+
+FunctionalForm::Form const FunctionalForm::Internal::kExp[kSize] = {
+    /* clang-format off */
+    /* ZERO  CONS   LIN   AFF  POLY  DIFF   ARB  UNDF */
+    /* ----  ----  ----  ----  ----  ----  ----  ---- */
+       CONS, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF,
+    /* clang-format on */
+};
+
+FunctionalForm::Form const FunctionalForm::Internal::kLog[kSize] = {
+    /* clang-format off */
+    /* ZERO  CONS   LIN   AFF  POLY  DIFF   ARB  UNDF */
+    /* ----  ----  ----  ----  ----  ----  ----  ---- */
+       UNDF, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF,
+    /* clang-format on */
+};
+
+FunctionalForm::Form const FunctionalForm::Internal::kSin[kSize] = {
+    /* clang-format off */
+    /* ZERO  CONS   LIN   AFF  POLY  DIFF   ARB  UNDF */
+    /* ----  ----  ----  ----  ----  ----  ----  ---- */
+       ZERO, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF,
+    /* clang-format on */
+};
+
+FunctionalForm::Form const FunctionalForm::Internal::kSqrt[kSize] = {
+    /* clang-format off */
+    /* ZERO  CONS   LIN   AFF  POLY  DIFF   ARB  UNDF */
+    /* ----  ----  ----  ----  ----  ----  ----  ---- */
+       ZERO, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF,
     /* clang-format on */
 };
 

--- a/drake/core/functional_form.cc
+++ b/drake/core/functional_form.cc
@@ -1,0 +1,365 @@
+#include "drake/core/functional_form.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <ostream>
+#include <type_traits>
+
+namespace drake {
+
+namespace {
+// Return the underlying index of an enum class type.
+template <typename T>
+constexpr typename std::underlying_type<T>::type IndexOf(T x) {
+  return static_cast<typename std::underlying_type<T>::type>(x);
+}
+}  // namespace
+
+// Hide this from doxygen because it incorrectly documents this
+// as public.  It is not user-facing anyway.
+#if !defined(DRAKE_DOXYGEN_CXX)
+enum class FunctionalForm::Form {
+  kZero,
+  kConstant,
+  kLinear,
+  kAffine,
+  kPolynomial,
+  kDifferentiable,
+  kArbitrary,
+  kUndefined,
+};
+#endif  // !defined(DRAKE_DOXYGEN_CXX)
+
+class FunctionalForm::Internal {
+ public:
+  // Only some of the forms need to carry variables.
+  static bool need_vars(Form f) {
+    return f != Form::kZero && f != Form::kConstant;
+  }
+};
+
+FunctionalForm::FunctionalForm() : FunctionalForm(Form::kUndefined, {}) {}
+
+FunctionalForm::FunctionalForm(double d)
+    : FunctionalForm(d == 0 ? Form::kZero : Form::kConstant, {}) {}
+
+FunctionalForm::FunctionalForm(Form f, Variables&& v)
+    : vars_(std::move(v)), form_(f) {
+  assert(form_ == Form::kUndefined ||
+         Internal::need_vars(form_) == !vars_.empty());
+}
+
+FunctionalForm FunctionalForm::Zero() {
+  return FunctionalForm(Form::kZero, {});
+}
+
+FunctionalForm FunctionalForm::Constant() {
+  return FunctionalForm(Form::kConstant, {});
+}
+
+FunctionalForm FunctionalForm::Linear(Variables v) {
+  return FunctionalForm(Form::kLinear, std::move(v));
+}
+
+FunctionalForm FunctionalForm::Affine(Variables v) {
+  return FunctionalForm(Form::kAffine, std::move(v));
+}
+
+FunctionalForm FunctionalForm::Polynomial(Variables v) {
+  return FunctionalForm(Form::kPolynomial, std::move(v));
+}
+
+FunctionalForm FunctionalForm::Differentiable(Variables v) {
+  return FunctionalForm(Form::kDifferentiable, std::move(v));
+}
+
+FunctionalForm FunctionalForm::Arbitrary(Variables v) {
+  return FunctionalForm(Form::kArbitrary, std::move(v));
+}
+
+FunctionalForm FunctionalForm::Undefined(Variables v) {
+  return FunctionalForm(Form::kUndefined, std::move(v));
+}
+
+bool FunctionalForm::IsZero() const { return form_ == Form::kZero; }
+
+bool FunctionalForm::IsConstant() const { return form_ == Form::kConstant; }
+
+bool FunctionalForm::IsLinear() const { return form_ == Form::kLinear; }
+
+bool FunctionalForm::IsAffine() const { return form_ == Form::kAffine; }
+
+bool FunctionalForm::IsPolynomial() const { return form_ == Form::kPolynomial; }
+
+bool FunctionalForm::IsDifferentiable() const {
+  return form_ == Form::kDifferentiable;
+}
+
+bool FunctionalForm::IsArbitrary() const { return form_ == Form::kArbitrary; }
+
+bool FunctionalForm::IsUndefined() const { return form_ == Form::kUndefined; }
+
+bool FunctionalForm::Is(FunctionalForm const& r) const {
+  return form_ == r.form_ && vars_ == r.vars_;
+}
+
+FunctionalForm::Variables FunctionalForm::GetVariables() const { return vars_; }
+
+static std::string const kFunctionalFormNames[] = {
+    "zero", "cons", "lin", "aff", "poly", "diff", "arb", "undf",
+};
+
+std::ostream& operator<<(std::ostream& os, FunctionalForm const& f) {
+  os << kFunctionalFormNames[IndexOf(f.form_)];
+  if (!f.vars_.empty()) {
+    os << "(";
+    const char* sep = "";
+    for (auto const& v : f.vars_) {
+      os << sep << v;
+      sep = ",";
+    }
+    os << ")";
+  }
+  return os;
+}
+
+//---------------------------------------------------------------------------
+
+// Hide this from doxygen because it incorrectly documents this
+// as public.  It is not user-facing anyway.
+#if !defined(DRAKE_DOXYGEN_CXX)
+enum class FunctionalForm::Variable::Tag { kNil, kIndex, kNamed };
+#endif  // !defined(DRAKE_DOXYGEN_CXX)
+
+FunctionalForm::Variable::Variable() : tag_(Tag::kNil) {}
+
+FunctionalForm::Variable::Variable(std::size_t index)
+    : index_(index), tag_(Tag::kIndex) {}
+
+FunctionalForm::Variable::Variable(std::string name)
+    : name_(std::move(name)), tag_(Tag::kNamed) {
+  assert(!name_.empty());
+}
+
+FunctionalForm::Variable::Variable(Variable const& v) : tag_(v.tag_) {
+  switch (tag_) {
+    case Tag::kNil:
+      break;
+    case Tag::kIndex:
+      new (&index_) std::size_t(v.index_);
+      break;
+    case Tag::kNamed:
+      new (&name_) std::string(v.name_);
+      break;
+  }
+}
+
+FunctionalForm::Variable::Variable(Variable&& v) noexcept : tag_(v.tag_) {
+  switch (tag_) {
+    case Tag::kNil:
+      break;
+    case Tag::kIndex:
+      new (&index_) std::size_t(std::move(v.index_));
+      break;
+    case Tag::kNamed:
+      new (&name_) std::string(std::move(v.name_));
+      break;
+  }
+  // Leave the object from which we moved in a default state.
+  v.~Variable();
+  new (&v) Variable();
+}
+
+FunctionalForm::Variable::~Variable() { Destruct(); }
+
+FunctionalForm::Variable& FunctionalForm::Variable::operator=(
+    Variable const& v) {
+  Variable tmp(v);
+  *this = std::move(tmp);
+  return *this;
+}
+
+FunctionalForm::Variable& FunctionalForm::Variable::operator=(
+    Variable&& v) noexcept {
+  Destruct();
+  new (this) Variable(std::move(v));
+  return *this;
+}
+
+void FunctionalForm::Variable::Destruct() noexcept {
+  switch (tag_) {
+    case Tag::kNil:
+      break;
+    case Tag::kIndex:
+      break;
+    case Tag::kNamed:
+      name_.~basic_string();
+      break;
+  }
+}
+
+bool FunctionalForm::Variable::is_nil() const { return tag_ == Tag::kNil; }
+
+bool FunctionalForm::Variable::is_index() const { return tag_ == Tag::kIndex; }
+
+bool FunctionalForm::Variable::is_named() const { return tag_ == Tag::kNamed; }
+
+static std::size_t constexpr kInvalidIndex = ~static_cast<std::size_t>(0);
+
+std::size_t FunctionalForm::Variable::index() const {
+  if (is_index()) {
+    return index_;
+  } else {
+    return kInvalidIndex;
+  }
+}
+
+static std::string const kInvalidName;
+
+std::string const& FunctionalForm::Variable::name() const {
+  if (is_named()) {
+    return name_;
+  } else {
+    return kInvalidName;
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, FunctionalForm::Variable const& v) {
+  using Tag = FunctionalForm::Variable::Tag;
+  switch (v.tag_) {
+    case Tag::kNil:
+      break;
+    case Tag::kIndex:
+      os << v.index_;
+      break;
+    case Tag::kNamed:
+      os << v.name_;
+      break;
+  }
+  return os;
+}
+
+bool operator==(FunctionalForm::Variable const& l,
+                FunctionalForm::Variable const& r) {
+  if (l.tag_ == r.tag_) {
+    using Tag = FunctionalForm::Variable::Tag;
+    switch (l.tag_) {
+      case Tag::kNil:
+        return true;
+      case Tag::kIndex:
+        return l.index_ == r.index_;
+      case Tag::kNamed:
+        return l.name_ == r.name_;
+    }
+  }
+  return false;
+}
+
+bool operator!=(FunctionalForm::Variable const& l,
+                FunctionalForm::Variable const& r) {
+  return !(l == r);
+}
+
+bool operator<(FunctionalForm::Variable const& l,
+               FunctionalForm::Variable const& r) {
+  if (l.tag_ == r.tag_) {
+    using Tag = FunctionalForm::Variable::Tag;
+    switch (l.tag_) {
+      case Tag::kNil:
+        return false;
+      case Tag::kIndex:
+        return l.index_ < r.index_;
+      case Tag::kNamed:
+        return l.name_ < r.name_;
+    }
+  }
+  return IndexOf(l.tag_) < IndexOf(r.tag_);
+}
+
+bool operator<=(FunctionalForm::Variable const& l,
+                FunctionalForm::Variable const& r) {
+  return !(r < l);
+}
+
+bool operator>(FunctionalForm::Variable const& l,
+               FunctionalForm::Variable const& r) {
+  return (r < l);
+}
+
+bool operator>=(FunctionalForm::Variable const& l,
+                FunctionalForm::Variable const& r) {
+  return !(l < r);
+}
+
+//---------------------------------------------------------------------------
+
+namespace {
+
+std::vector<FunctionalForm::Variable> Unique(
+    std::vector<FunctionalForm::Variable> vars) {
+  std::sort(vars.begin(), vars.end());
+  vars.erase(std::unique(vars.begin(), vars.end()), vars.end());
+  return vars;
+}
+
+}  // namespace
+
+FunctionalForm::Variables::Variables(std::initializer_list<Variable> init)
+    : Variables(std::vector<Variable>(std::move(init))) {}
+
+FunctionalForm::Variables::Variables(std::vector<Variable>&& vars)
+    : vars_(std::make_shared<std::vector<Variable>>(Unique(std::move(vars)))) {}
+
+FunctionalForm::Variables::const_iterator FunctionalForm::Variables::begin()
+    const {
+  return vars_ ? vars_->begin() : const_iterator();
+}
+
+FunctionalForm::Variables::const_iterator FunctionalForm::Variables::end()
+    const {
+  return vars_ ? vars_->end() : const_iterator();
+}
+
+bool FunctionalForm::Variables::empty() const {
+  return vars_ ? vars_->empty() : true;
+}
+
+std::size_t FunctionalForm::Variables::size() const {
+  return vars_ ? vars_->size() : 0;
+}
+
+FunctionalForm::Variables FunctionalForm::Variables::Union(Variables const& l,
+                                                           Variables const& r) {
+  if (r.empty()) {
+    return l;
+  }
+  if (l.empty()) {
+    return r;
+  }
+  std::vector<FunctionalForm::Variable> vars;
+  vars.insert(vars.end(), l.vars_->begin(), l.vars_->end());
+  vars.insert(vars.end(), r.vars_->begin(), r.vars_->end());
+  return Variables(std::move(vars));
+}
+
+bool operator==(FunctionalForm::Variables const& lhs,
+                FunctionalForm::Variables const& rhs) {
+  if (lhs.vars_ == rhs.vars_) {
+    return true;
+  }
+  if (!rhs.vars_) {
+    return lhs.vars_->empty();
+  }
+  if (!lhs.vars_) {
+    return rhs.vars_->empty();
+  }
+  return *lhs.vars_ == *rhs.vars_;
+}
+
+bool operator!=(FunctionalForm::Variables const& lhs,
+                FunctionalForm::Variables const& rhs) {
+  return !(lhs == rhs);
+}
+
+}  // namespace drake

--- a/drake/core/functional_form.h
+++ b/drake/core/functional_form.h
@@ -1,0 +1,327 @@
+#pragma once
+
+#include "drake/drakeCore_export.h"
+
+#include <cstddef>
+#include <initializer_list>
+#include <iosfwd>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace drake {
+
+/** \brief Represent an abstract form of a function of zero or more variables.
+ *
+ * We define a functional form to be a set of input variables along with an
+ * abstract description of how the variables are combined to express the
+ * output.  The form may be one of:
+ *
+ * - \anchor zero
+ *   A \b zero value with no variables (<tt>0</tt>).
+ * - \anchor constant
+ *   A \b constant value with no variables (<tt>c</tt>).
+ * - \anchor linear
+ *   A \b linear combination of one or more variables (<tt>b'*x</tt>).
+ * - \anchor affine
+ *   An \b affine combination of one or more variables (<tt>b'*x + c</tt>).
+ * - \anchor polynomial
+ *   A \b polynomial combination of one or more variables
+ *   (<tt>... + x'*A*x + b'*x + c</tt>).
+ * - \anchor differentiable
+ *   A \b differentiable (almost everywhere) combination of one or more
+ *   variables (<tt>f(x)</tt> such that <tt>f'(x)</tt> exists for
+ *   <i> almost all \c x in the domain of interest</i>).
+ * - \anchor arbitrary
+ *   An \b arbitrary combination of one or more variables (<tt>f(x)</tt>).
+ * - \anchor undefined
+ *   An \b undefined combination of zero or more variables
+ *   (<tt>f(x)</tt> where \c f contains an undefined operation).
+ *
+ * Each variable is represented by an instance of the Variable class
+ * which serves as a placeholder providing a distinguishing identifier.
+ * We do not represent any details about how an individual variable appears
+ * in the combination of one of the above forms, only that it participates.
+ */
+class DRAKECORE_EXPORT FunctionalForm {
+ public:
+  class Variable;
+  class Variables;
+
+  /** Construct an \ref undefined form with no variables. */
+  FunctionalForm();
+
+  /** Construct a \ref constant or \ref zero form with no variables.  */
+  explicit FunctionalForm(double d);
+
+  /** Return a \ref zero form with no variables. */
+  static FunctionalForm Zero();
+
+  /** Return a \ref constant form with no variables. */
+  static FunctionalForm Constant();
+
+  /** Return a \ref linear form of one or more variables. */
+  static FunctionalForm Linear(Variables v);
+
+  /** Return an \ref affine form of one or more variables. */
+  static FunctionalForm Affine(Variables v);
+
+  /** Return a \ref polynomial form of one or more variables. */
+  static FunctionalForm Polynomial(Variables v);
+
+  /** Return a \ref differentiable form of one or more variables. */
+  static FunctionalForm Differentiable(Variables v);
+
+  /** Return an \ref arbitrary form of one or more variables. */
+  static FunctionalForm Arbitrary(Variables v);
+
+  /** Return an \ref undefined form of zero or more variables. */
+  static FunctionalForm Undefined(Variables v);
+
+  /** Return true if the form is \ref zero. */
+  bool IsZero() const;
+
+  /** Return true if the form is \ref constant. */
+  bool IsConstant() const;
+
+  /** Return true if the form is \ref linear. */
+  bool IsLinear() const;
+
+  /** Return true if the form is \ref affine. */
+  bool IsAffine() const;
+
+  /** Return true if the form is \ref polynomial. */
+  bool IsPolynomial() const;
+
+  /** Return true if the form is \ref differentiable. */
+  bool IsDifferentiable() const;
+
+  /** Return true if the form is \ref arbitrary. */
+  bool IsArbitrary() const;
+
+  /** Return true if the form is \ref undefined. */
+  bool IsUndefined() const;
+
+  /** Return true if the given form combines the same variables
+      in the same way as we do.  */
+  bool Is(FunctionalForm const& f) const;
+
+  /** Return the set of variables combined by this form.  */
+  Variables GetVariables() const;
+
+  /** Print a description of this form to the given stream.
+   *
+   * The format is one of:
+   *
+   * - "zero"
+   * - "cons"
+   * - "lin(x,...)"
+   * - "aff(x,...)"
+   * - "poly(x,...)"
+   * - "diff(x,...)"
+   * - "arb(x,...)"
+   * - "undf(x,...)"
+   *
+   * where "x,..." represents a comma-separated list of the variables
+   * combined by the form.
+   */
+  friend DRAKECORE_EXPORT std::ostream& operator<<(std::ostream& os,
+                                                   FunctionalForm const& f);
+
+  /** \brief Represent a set of Variable instances.
+   *
+   * The set contains a list of Variable instances ordered according
+   * to the \ref VariableOrdering "Variable Ordering" without duplicates.
+   * The contained set is immutable.
+   */
+  class DRAKECORE_EXPORT Variables {
+   public:
+    /** Construct an empty set.  */
+    Variables() = default;
+
+    /** Construct a set from an initializer list.  */
+    Variables(std::initializer_list<Variable> init);
+
+    /** Move-construct a set from an rvalue.  */
+    Variables(Variables&&) = default;
+
+    /** Copy-construct a set from an lvalue.  */
+    Variables(Variables const&) = default;
+
+    /** Move-assign a set from an rvalue.  */
+    Variables& operator=(Variables&&) = default;
+
+    /** Copy-assign a set from an lvalue.  */
+    Variables& operator=(Variables const&) = default;
+
+    /** Return the union of two sets.  */
+    static Variables Union(Variables const& l, Variables const& r);
+
+#if defined(DRAKE_DOXYGEN_CXX)
+    /** Type used to iterate through the set.  The iterator dereferences
+        to <tt>const Variable</tt> and supports bidirectional iteration but
+        is otherwise of an unspecified type.  */
+    typedef unspecified_bidirectional_const_iterator<Variable> const_iterator;
+#else
+    typedef std::vector<Variable>::const_iterator const_iterator;
+#endif
+
+    /** Return an iterator at the beginning of the set.  */
+    const_iterator begin() const;
+
+    /** Return an iterator at the end of the set.  */
+    const_iterator end() const;
+
+    /** Return \c true if the set is empty and \c false otherwise.  */
+    bool empty() const;
+
+    /** Return the size of the set.  */
+    std::size_t size() const;
+
+    /** Return \c true if \c lhs and \c rhs represent the same set.  */
+    friend DRAKECORE_EXPORT bool operator==(Variables const& lhs,
+                                            Variables const& rhs);
+
+    /** Return \c false if \c lhs and \c rhs represent the same set.  */
+    friend DRAKECORE_EXPORT bool operator!=(Variables const& lhs,
+                                            Variables const& rhs);
+
+   private:
+    explicit Variables(std::vector<Variable>&& vars);
+    std::shared_ptr<std::vector<Variable> const> vars_;
+  };
+
+ private:
+  enum class Form;
+  FunctionalForm(Form f, Variables&& v);
+
+  Variables vars_;
+  Form form_;
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+  // Internal class for friendship-access in implementation file.
+  class Internal;
+  friend class Internal;
+#endif  // !defined(DRAKE_DOXYGEN_CXX)
+};
+
+/** \brief Represent a variable in a FunctionalForm.
+ *
+ * A FunctionalForm is defined with respect to zero or more variables that an
+ * expression combines in some form.  Instances of Variable serve as
+ * placeholders identifying distinct variables in a FunctionalForm.
+ * Each Variable has a distinguishing identifier of one of these types:
+ *
+ * - \b nil: No identifier.
+ * - \b index: Identified by a non-negative numeric index (type \c std::size_t).
+ * - \b named: Identified by a non-empty string name (type \c std::string).
+ *
+ * Instances are considered equivalent if they have the same identification
+ * type and value.
+ *
+ * \anchor VariableOrdering
+ *
+ * We define a Variable Ordering first by type (in the above order) and then by
+ * the natural order of values within each type.
+ */
+class
+#if !defined(DRAKE_DOXYGEN_CXX)
+    DRAKECORE_EXPORT
+#endif  // !defined(DRAKE_DOXYGEN_CXX)
+        FunctionalForm::Variable {
+ public:
+  /** Construct the nil variable.  */
+  Variable();
+
+  /** Construct a variable identified by a non-negative numeric \p index.  */
+  Variable(std::size_t index);
+
+  /** Construct a variable identified by a non-empty string \p name. */
+  Variable(std::string name);
+
+  /** Construct a variable identified by a non-empty string \p name
+      (string literal).  */
+  template <int N>
+  Variable(char const (&name)[N]) : Variable(std::string(name)) {}
+
+  /** Copy-construct a variable from an lvalue.  */
+  Variable(Variable const& v);
+
+  /** Move-construct a variable from an rvalue.  */
+  Variable(Variable&& v) noexcept;
+
+  /** Destroy a variable.  */
+  ~Variable();
+
+  /** Copy-assign a variable from an lvalue.  */
+  Variable& operator=(Variable const& v);
+
+  /** Move-assign a variable from an rvalue.  */
+  Variable& operator=(Variable&& v) noexcept;
+
+  /** Return true if this variable has no identifier.  */
+  bool is_nil() const;
+
+  /** Return true if this variable is identified by a numeric index.  */
+  bool is_index() const;
+
+  /** Return true if this variable is identified by a string name.  */
+  bool is_named() const;
+
+  /** If this variable is identified by a numeric index, return the index.
+      Otherwise, return the largest index representable by \c std::size_t.  */
+  std::size_t index() const;
+
+  /** If this variable is identified by a string name, return the name.
+      Otherwise, return the empty string.  */
+  std::string const& name() const;
+
+  /** Print the variable's identifier, if any, to the given stream.  */
+  friend DRAKECORE_EXPORT std::ostream& operator<<(std::ostream& os,
+                                                   Variable const& v);
+
+  /** Return true if both variables have the same identifier type and value.  */
+  friend DRAKECORE_EXPORT bool operator==(Variable const& lhs,
+                                          Variable const& rhs);
+
+  /** Return false if both variables have the same identifier type and value. */
+  friend DRAKECORE_EXPORT bool operator!=(Variable const& lhs,
+                                          Variable const& rhs);
+
+  /** Return true if \p lhs comes before \p rhs in the \ref VariableOrdering
+   * "Variable Ordering".  */
+  friend DRAKECORE_EXPORT bool operator<(Variable const& lhs,
+                                         Variable const& rhs);
+
+  /** Return true if \p lhs does not come after \p rhs in the \ref
+   * VariableOrdering "Variable Ordering".  */
+  friend DRAKECORE_EXPORT bool operator<=(Variable const& lhs,
+                                          Variable const& rhs);
+
+  /** Return true if \p lhs comes after \p rhs in the \ref VariableOrdering
+   * "Variable Ordering".  */
+  friend DRAKECORE_EXPORT bool operator>(Variable const& lhs,
+                                         Variable const& rhs);
+
+  /** Return true if \p lhs does not come before \p rhs in the \ref
+   * VariableOrdering "Variable Ordering".  */
+  friend DRAKECORE_EXPORT bool operator>=(Variable const& lhs,
+                                          Variable const& rhs);
+
+ private:
+  void Destruct() noexcept;
+
+// Hide this from doxygen because it incorrectly documents these
+// members as public.  They are not user-facing anyway.
+#if !defined(DRAKE_DOXYGEN_CXX)
+  union {
+    std::size_t index_;
+    std::string name_;
+  };
+#endif  // !defined(DRAKE_DOXYGEN_CXX)
+
+  enum class Tag;
+  Tag tag_;
+};
+
+}  // namespace drake

--- a/drake/core/functional_form.h
+++ b/drake/core/functional_form.h
@@ -432,7 +432,7 @@ class
   Variable(Variable const& v);
 
   /** Move-construct a variable from an rvalue.  */
-  Variable(Variable&& v) noexcept;
+  Variable(Variable&& v) noexcept;  // NOLINT(whitespace/operators) // false-pos
 
   /** Destroy a variable.  */
   ~Variable();

--- a/drake/core/functional_form.h
+++ b/drake/core/functional_form.h
@@ -7,7 +7,10 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
+
+#include <Eigen/Core>
 
 namespace drake {
 
@@ -94,6 +97,9 @@ namespace drake {
  *   \endcode
  *
  * See documentation of associated functions for those supported.
+ *
+ * FunctionalForm may also be used as the scalar type of an \c Eigen::Matrix<>.
+ * Basic matrix and vector expressions are supported.
  */
 class DRAKECORE_EXPORT FunctionalForm {
  public:
@@ -502,4 +508,231 @@ class
   Tag tag_;
 };
 
+/** \relates FunctionalForm
+ * Return a copy of \p lhs updated to record addition of a matrix of
+ * \ref constant and/or \ref zero components.
+ */
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    typename MatrixL::PlainObject>::type
+operator+(MatrixL const& lhs, MatrixR const& rhs) {
+  return lhs + rhs.template cast<FunctionalForm>();
+}
+
+/** \relates FunctionalForm
+ * Return a copy of \p rhs updated to record its addition to a matrix of
+ * \ref constant and/or \ref zero components.
+ */
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, double>::value &&
+        std::is_same<typename MatrixR::Scalar, FunctionalForm>::value,
+    typename MatrixR::PlainObject>::type
+operator+(MatrixL const& lhs, MatrixR const& rhs) {
+  return lhs.template cast<FunctionalForm>() + rhs;
+}
+
+/** \relates FunctionalForm
+ * Update \p lhs to record addition of a matrix of \ref constant and/or
+ * \ref zero components.
+ */
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    MatrixL&>::type
+operator+=(MatrixL& lhs, MatrixR const& rhs) {
+  return lhs += rhs.template cast<FunctionalForm>();
+}
+
+/** \relates FunctionalForm
+ * Return a copy of \p lhs updated to record subtraction of a matrix of
+ * \ref constant and/or \ref zero components.
+ */
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    typename MatrixL::PlainObject>::type
+operator-(MatrixL const& lhs, MatrixR const& rhs) {
+  return lhs - rhs.template cast<FunctionalForm>();
+}
+
+/** \relates FunctionalForm
+ * Return a copy of \p rhs updated to record its subtraction from a
+ * matrix of \ref constant and/or \ref zero components.
+ */
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, double>::value &&
+        std::is_same<typename MatrixR::Scalar, FunctionalForm>::value,
+    typename MatrixR::PlainObject>::type
+operator-(MatrixL const& lhs, MatrixR const& rhs) {
+  return lhs.template cast<FunctionalForm>() - rhs;
+}
+
+/** \relates FunctionalForm
+ * Update \p lhs to record subtraction of a matrix of \ref constant and/or
+ * \ref zero components.
+ */
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    MatrixL&>::type
+operator-=(MatrixL& lhs, MatrixR const& rhs) {
+  return lhs -= rhs.template cast<FunctionalForm>();
+}
+
+/** \relates FunctionalForm
+ * Return the result of right-multiplying \p lhs by a matrix of \ref constant
+ * and/or \ref zero components.
+ */
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    Eigen::Matrix<FunctionalForm, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(MatrixL const& lhs, MatrixR const& rhs) {
+  return lhs * rhs.template cast<FunctionalForm>();
+}
+
+/** \relates FunctionalForm
+ * Return the result of left-multiplying \p rhs by a matrix of \ref constant
+ * and/or \ref zero components.
+ */
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, double>::value &&
+        std::is_same<typename MatrixR::Scalar, FunctionalForm>::value,
+    Eigen::Matrix<FunctionalForm, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(MatrixL const& lhs, MatrixR const& rhs) {
+  return lhs.template cast<FunctionalForm>() * rhs;
+}
+
+/** \relates FunctionalForm
+ * Return a copy of \p lhs updated to record component-wise multiplication by a
+ * \ref constant or \ref zero scalar.
+ */
+template <typename MatrixL>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value,
+    typename MatrixL::PlainObject>::type
+operator*(MatrixL const& lhs, double rhs) {
+  return lhs * FunctionalForm(rhs);
+}
+
+/** \relates FunctionalForm
+ * Return a copy of \p rhs updated to record component-wise multiplication by a
+ * \ref constant or \ref zero scalar.
+ */
+template <typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixR::Scalar, FunctionalForm>::value,
+    typename MatrixR::PlainObject>::type
+operator*(double lhs, MatrixR const& rhs) {
+  return FunctionalForm(lhs) * rhs;
+}
+
+/** \relates FunctionalForm
+ * Update \p lhs to record component-wise multiplication by a \ref constant
+ * or \ref zero scalar.
+ */
+template <typename MatrixL>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value,
+    MatrixL&>::type
+operator*=(MatrixL& lhs, double rhs) {
+  return lhs *= FunctionalForm(rhs);
+}
+
+/** \relates FunctionalForm
+ * Return a copy of \p lhs updated to record component-wise division by
+ * a \ref constant or \ref zero scalar.
+ */
+template <typename MatrixL>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value,
+    typename MatrixL::PlainObject>::type
+operator/(MatrixL const& lhs, double rhs) {
+  return lhs / FunctionalForm(rhs);
+}
+
+/** \relates FunctionalForm
+ * Update \p lhs to record component-wise division by a \ref constant
+ * or \ref zero scalar.
+ */
+template <typename MatrixL>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_same<typename MatrixL::Scalar, FunctionalForm>::value,
+    MatrixL&>::type
+operator/=(MatrixL& lhs, double rhs) {
+  return lhs /= FunctionalForm(rhs);
+}
+
 }  // namespace drake
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+// Define Eigen traits needed for Matrix<FunctionalForm>.
+namespace Eigen {
+
+// Eigen scalar type traits for Matrix<FunctionalForm>.
+template <>
+struct NumTraits<drake::FunctionalForm> {
+  enum {
+    // Our set of allowed values is discrete, and no epsilon is allowed during
+    // equality comparison, so treat this as an unsigned integer type.
+    IsInteger = 1,
+    IsSigned = 0,
+    IsComplex = 0,
+    RequireInitialization = 1,
+    ReadCost = 1,
+    AddCost = 1,
+    MulCost = 1
+  };
+
+  typedef drake::FunctionalForm Real;
+  typedef drake::FunctionalForm Nested;
+
+  static inline Real dummy_precision() { return drake::FunctionalForm(); }
+};
+
+namespace internal {
+
+// Eigen component-wise Matrix<FunctionalForm>::isConstant(FunctionalForm).
+template <>
+struct scalar_fuzzy_impl<drake::FunctionalForm> {
+  static inline bool isApprox(drake::FunctionalForm x, drake::FunctionalForm y,
+                              drake::FunctionalForm) {
+    return x.Is(y);
+  }
+};
+
+}  // namespace internal
+}  // namespace Eigen
+#endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/drake/core/functional_form.h
+++ b/drake/core/functional_form.h
@@ -86,6 +86,14 @@ namespace drake {
  *   std::cout << f(g(x,y), c) << "\n"; // prints "poly(x,y)"
  *   std::cout << f(g(c,c), c) << "\n"; // prints "cons"
  *   \endcode
+ *
+ * A few basic mathematical functions are also supported:
+ *
+ *   \code{.cpp}
+ *   std::cout << sin(x) << "\n"; // prints "diff(x)"
+ *   \endcode
+ *
+ * See documentation of associated functions for those supported.
  */
 class DRAKECORE_EXPORT FunctionalForm {
  public:
@@ -260,6 +268,30 @@ class DRAKECORE_EXPORT FunctionalForm {
   /** Update \p lhs to record division by a \ref constant or \ref zero.  */
   friend DRAKECORE_EXPORT FunctionalForm& operator/=(FunctionalForm& lhs,
                                                      double rhs);
+
+  /** Return a copy of \p x updated to record application of an
+      \c abs function.  */
+  friend DRAKECORE_EXPORT FunctionalForm abs(FunctionalForm const& x);
+
+  /** Return a copy of \p x updated to record application of a
+      \c cos function.  */
+  friend DRAKECORE_EXPORT FunctionalForm cos(FunctionalForm const& x);
+
+  /** Return a copy of \p x updated to record application of a
+      \c exp function.  */
+  friend DRAKECORE_EXPORT FunctionalForm exp(FunctionalForm const& x);
+
+  /** Return a copy of \p x updated to record application of a
+      \c log function.  */
+  friend DRAKECORE_EXPORT FunctionalForm log(FunctionalForm const& x);
+
+  /** Return a copy of \p x updated to record application of a
+      \c sin function.  */
+  friend DRAKECORE_EXPORT FunctionalForm sin(FunctionalForm const& x);
+
+  /** Return a copy of \p x updated to record application of a
+      \c sqrt function.  */
+  friend DRAKECORE_EXPORT FunctionalForm sqrt(FunctionalForm const& x);
 
   /** \brief Represent a set of Variable instances.
    *

--- a/drake/core/functional_form.h
+++ b/drake/core/functional_form.h
@@ -205,6 +205,19 @@ class DRAKECORE_EXPORT FunctionalForm {
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
 };
 
+#if !defined(DRAKE_DOXYGEN_CXX)
+// Delete comparison operators because any function containing a conditional
+// cannot be evaluated directly with FunctionalForm as its scalar type.
+// Such functions will require a manual overload with FunctionalForm to
+// specify their form.
+bool operator==(FunctionalForm const&, FunctionalForm const&) = delete;
+bool operator!=(FunctionalForm const&, FunctionalForm const&) = delete;
+bool operator<(FunctionalForm const&, FunctionalForm const&) = delete;
+bool operator<=(FunctionalForm const&, FunctionalForm const&) = delete;
+bool operator>(FunctionalForm const&, FunctionalForm const&) = delete;
+bool operator>=(FunctionalForm const&, FunctionalForm const&) = delete;
+#endif  // !defined(DRAKE_DOXYGEN_CXX)
+
 /** \brief Represent a variable in a FunctionalForm.
  *
  * A FunctionalForm is defined with respect to zero or more variables that an

--- a/drake/core/functional_form.h
+++ b/drake/core/functional_form.h
@@ -42,6 +42,50 @@ namespace drake {
  * which serves as a placeholder providing a distinguishing identifier.
  * We do not represent any details about how an individual variable appears
  * in the combination of one of the above forms, only that it participates.
+ *
+ * FunctionalForm instances may be used in mathematical expressions to
+ * form new instances representing the form of the combined expression.
+ * For example:
+ *
+ *   \code{.cpp}
+ *   FunctionalForm x = FunctionalForm::Linear({"x"});
+ *   FunctionalForm c = FunctionalForm::Constant();
+ *   std::cout << (x * x) << "\n"; // prints "poly(x)"
+ *   std::cout << (x + c) << "\n"; // prints "aff(x)"
+ *   std::cout << (x * c) << "\n"; // prints "lin(x)"
+ *   std::cout << (x + 2) << "\n"; // prints "aff(x)"
+ *   std::cout << (x * 2) << "\n"; // prints "lin(x)"
+ *   std::cout << (x + 0) << "\n"; // prints "lin(x)"
+ *   std::cout << (x * 0) << "\n"; // prints "zero"
+ *   \endcode
+ *
+ * This class is therefore suitable for use as a scalar type to call
+ * a function template to extract its functional form with respect
+ * to some set of its inputs.  For example:
+ *
+ *   \code{.cpp}
+ *   template <typename S> S f(S x, S y) { return x + y; }
+ *   template <typename S> S g(S x, S y) { return x * y; }
+ *   // ...
+ *   FunctionalForm x = FunctionalForm::Linear({"x"});
+ *   FunctionalForm y = FunctionalForm::Linear({"y"});
+ *   FunctionalForm c = FunctionalForm::Constant();
+ *   std::cout << f(2, 3) << "\n"; // prints "5"
+ *   std::cout << f(x, y) << "\n"; // prints "lin(x,y)"
+ *   std::cout << f(x, c) << "\n"; // prints "aff(x)"
+ *   std::cout << g(2, 3) << "\n"; // prints "6"
+ *   std::cout << g(x, y) << "\n"; // prints "poly(x,y)"
+ *   std::cout << g(x, c) << "\n"; // prints "lin(x)"
+ *   \endcode
+ *
+ * Composition is supported naturally:
+ *
+ *   \code{.cpp}
+ *   std::cout << f(g(x,c), y) << "\n"; // prints "lin(x,y)"
+ *   std::cout << f(g(x,c), c) << "\n"; // prints "aff(x)"
+ *   std::cout << f(g(x,y), c) << "\n"; // prints "poly(x,y)"
+ *   std::cout << f(g(c,c), c) << "\n"; // prints "cons"
+ *   \endcode
  */
 class DRAKECORE_EXPORT FunctionalForm {
  public:
@@ -127,6 +171,95 @@ class DRAKECORE_EXPORT FunctionalForm {
    */
   friend DRAKECORE_EXPORT std::ostream& operator<<(std::ostream& os,
                                                    FunctionalForm const& f);
+
+  /** Return a copy of \p lhs updated to record addition of form \p rhs.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator+(FunctionalForm const& lhs,
+                                                   FunctionalForm const& rhs);
+
+  /** Return a copy of \p lhs updated to record addition of a \ref constant
+      or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator+(FunctionalForm const& lhs,
+                                                   double rhs);
+
+  /** Return a copy of \p rhs updated to record its addition to a
+      \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator+(double lhs,
+                                                   FunctionalForm const& rhs);
+
+  /** Update \p lhs to record addition of form \p rhs.  */
+  friend DRAKECORE_EXPORT FunctionalForm& operator+=(FunctionalForm& lhs,
+                                                     FunctionalForm const& rhs);
+
+  /** Update \p lhs to record addition of a \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm& operator+=(FunctionalForm& lhs,
+                                                     double rhs);
+
+  /** Return a copy of \p lhs updated to record subtraction of form \p rhs.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator-(FunctionalForm const& lhs,
+                                                   FunctionalForm const& rhs);
+
+  /** Return a copy of \p lhs updated to record subtraction of a
+      \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator-(FunctionalForm const& lhs,
+                                                   double rhs);
+
+  /** Return a copy of \p rhs updated to record its subtraction from a
+      \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator-(double lhs,
+                                                   FunctionalForm const& rhs);
+
+  /** Update \p lhs to record subtraction of form \p rhs.  */
+  friend DRAKECORE_EXPORT FunctionalForm& operator-=(FunctionalForm& lhs,
+                                                     FunctionalForm const& rhs);
+
+  /** Update \p lhs to record subtraction of a \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm& operator-=(FunctionalForm& lhs,
+                                                     double rhs);
+
+  /** Return a copy of \p lhs updated to record multiplication by \p rhs.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator*(FunctionalForm const& lhs,
+                                                   FunctionalForm const& rhs);
+
+  /** Return a copy of \p lhs updated to record multiplication by a
+      \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator*(FunctionalForm const& lhs,
+                                                   double rhs);
+
+  /** Return a copy of \p rhs updated to record its multiplication of a
+      \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator*(double lhs,
+                                                   FunctionalForm const& rhs);
+
+  /** Update \p lhs to record multiplication by \p rhs.  */
+  friend DRAKECORE_EXPORT FunctionalForm& operator*=(FunctionalForm& lhs,
+                                                     FunctionalForm const& rhs);
+
+  /** Update \p lhs to record multiplication by a \ref constant
+      or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm& operator*=(FunctionalForm& lhs,
+                                                     double rhs);
+
+  /** Return a copy of \p lhs updated to record division by \p rhs.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator/(FunctionalForm const& lhs,
+                                                   FunctionalForm const& rhs);
+
+  /** Return a copy of \p lhs updated to record division by a \ref constant
+      or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator/(FunctionalForm const& lhs,
+                                                   double rhs);
+
+  /** Return a copy of \p rhs updated to record its division of a
+      \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm operator/(double lhs,
+                                                   FunctionalForm const& rhs);
+
+  /** Update \p lhs to record division by \p rhs.  */
+  friend DRAKECORE_EXPORT FunctionalForm& operator/=(FunctionalForm& lhs,
+                                                     FunctionalForm const& rhs);
+
+  /** Update \p lhs to record division by a \ref constant or \ref zero.  */
+  friend DRAKECORE_EXPORT FunctionalForm& operator/=(FunctionalForm& lhs,
+                                                     double rhs);
 
   /** \brief Represent a set of Variable instances.
    *

--- a/drake/core/test/CMakeLists.txt
+++ b/drake/core/test/CMakeLists.txt
@@ -2,4 +2,8 @@ if (GTEST_FOUND)
   add_executable(vector_test vector_test.cc)
   target_link_libraries(vector_test ${GTEST_BOTH_LIBRARIES})
   add_test(NAME vector_test COMMAND vector_test)
+
+  add_executable(functional_form_test functional_form_test.cc)
+  target_link_libraries(functional_form_test drakeCore ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME functional_form_test COMMAND functional_form_test)
 endif (GTEST_FOUND)

--- a/drake/core/test/functional_form_test.cc
+++ b/drake/core/test/functional_form_test.cc
@@ -566,6 +566,52 @@ GTEST_TEST(FunctionalFormTest, Divide) {
   }
 }
 
+GTEST_TEST(FunctionalFormTest, Functions) {
+  using Variable = FunctionalForm::Variable;
+
+  {
+    FunctionalForm f = abs(FunctionalForm::Linear({"x"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = cos(FunctionalForm::Linear({"x"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = exp(FunctionalForm::Linear({"x"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = log(FunctionalForm::Linear({"x"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = log(FunctionalForm::Zero());
+    EXPECT_TRUE(f.IsUndefined());
+    EXPECT_EQ(f.GetVariables(), Vars());
+  }
+
+  {
+    FunctionalForm f = sin(FunctionalForm::Linear({"x"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = sqrt(FunctionalForm::Linear({"x"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace core

--- a/drake/core/test/functional_form_test.cc
+++ b/drake/core/test/functional_form_test.cc
@@ -364,6 +364,208 @@ GTEST_TEST(FunctionalFormTest, Stream) {
   }
 }
 
+GTEST_TEST(FunctionalFormTest, Add) {
+  using Variable = FunctionalForm::Variable;
+  {
+    FunctionalForm f = FunctionalForm::Zero() + FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f =
+        FunctionalForm::Linear({"x"}) + FunctionalForm::Linear({"y"});
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+
+  {
+    FunctionalForm f =
+        FunctionalForm::Constant() + FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsAffine());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = 1 + FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsAffine());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"}) + 1;
+    EXPECT_TRUE(f.IsAffine());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"});
+    f += 1;
+    EXPECT_TRUE(f.IsAffine());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"});
+    f += FunctionalForm::Linear({"y"});
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+}
+
+GTEST_TEST(FunctionalFormTest, Subtract) {
+  using Variable = FunctionalForm::Variable;
+  {
+    FunctionalForm f = FunctionalForm::Zero() - FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f =
+        FunctionalForm::Linear({"x"}) - FunctionalForm::Linear({"y"});
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+
+  {
+    FunctionalForm f =
+        FunctionalForm::Constant() - FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsAffine());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = 1 - FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsAffine());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"}) - 1;
+    EXPECT_TRUE(f.IsAffine());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"});
+    f -= 1;
+    EXPECT_TRUE(f.IsAffine());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"});
+    f -= FunctionalForm::Linear({"y"});
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+}
+
+GTEST_TEST(FunctionalFormTest, Multiply) {
+  using Variable = FunctionalForm::Variable;
+  {
+    FunctionalForm f = FunctionalForm::Zero() * FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsZero());
+    EXPECT_EQ(f.GetVariables(), Vars());
+  }
+
+  {
+    FunctionalForm f =
+        FunctionalForm::Linear({"x"}) * FunctionalForm::Linear({"y"});
+    EXPECT_TRUE(f.IsPolynomial());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+
+  {
+    FunctionalForm f =
+        FunctionalForm::Constant() * FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = 1 * FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"}) * 1;
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"});
+    f *= 1;
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"});
+    f *= FunctionalForm::Linear({"y"});
+    EXPECT_TRUE(f.IsPolynomial());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+}
+
+GTEST_TEST(FunctionalFormTest, Divide) {
+  using Variable = FunctionalForm::Variable;
+  {
+    FunctionalForm f = FunctionalForm::Zero() / FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsZero());
+    EXPECT_EQ(f.GetVariables(), Vars());
+  }
+
+  {
+    FunctionalForm f =
+        FunctionalForm::Linear({"x"}) / FunctionalForm::Linear({"y"});
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+
+  {
+    FunctionalForm f =
+        FunctionalForm::Constant() / FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = 1 / FunctionalForm::Linear({"x"});
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = 1 / FunctionalForm::Zero();
+    EXPECT_TRUE(f.IsUndefined());
+    EXPECT_EQ(f.GetVariables(), Vars());
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"}) / 1;
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"});
+    f /= 1;
+    EXPECT_TRUE(f.IsLinear());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = FunctionalForm::Linear({"x"});
+    f /= FunctionalForm::Linear({"y"});
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace core

--- a/drake/core/test/functional_form_test.cc
+++ b/drake/core/test/functional_form_test.cc
@@ -1,0 +1,370 @@
+#include "drake/core/functional_form.h"
+
+#include <sstream>
+
+#include "gtest/gtest.h"
+
+namespace drake {
+namespace core {
+namespace test {
+namespace {
+
+using Vars = FunctionalForm::Variables;
+
+GTEST_TEST(FunctionalFormVariableTest, NilVariant) {
+  using Variable = FunctionalForm::Variable;
+  Variable const v_nil;
+  EXPECT_TRUE(v_nil.is_nil());
+  EXPECT_NE(v_nil.index(), 0);
+
+  // copy ctor
+  Variable v(v_nil);
+  EXPECT_EQ(v, v_nil);
+
+  // move ctor
+  {
+    Variable v2(std::move(v));
+    EXPECT_EQ(v2, v_nil);
+    EXPECT_EQ(v, v_nil);
+  }
+
+  // copy assign
+  v = v_nil;
+  EXPECT_EQ(v, v_nil);
+
+  // move assign
+  {
+    Variable v2;
+    v2 = std::move(v);
+    EXPECT_EQ(v2, v_nil);
+    EXPECT_EQ(v, v_nil);
+  }
+
+  // comparison
+  EXPECT_TRUE(v_nil == v_nil);
+  EXPECT_FALSE(v_nil != v_nil);
+  EXPECT_FALSE(v_nil < v_nil);
+
+  // stream
+  {
+    std::ostringstream ss;
+    ss << v_nil;
+    EXPECT_EQ(ss.str(), "");
+  }
+}
+
+GTEST_TEST(FunctionalFormVariableTest, IndexVariant) {
+  using Variable = FunctionalForm::Variable;
+  Variable const v_nil;
+  Variable const v_index = 0;
+  EXPECT_TRUE(v_nil.is_nil());
+  EXPECT_TRUE(v_index.is_index());
+
+  // ctor
+  {
+    std::size_t index = 0;
+    Variable v1(index);
+    Variable v2(std::move(index));
+    std::vector<Variable> vec({{0}});
+    EXPECT_EQ(v1, v2);
+    EXPECT_EQ(v1, vec[0]);
+  }
+
+  // copy ctor
+  Variable v(v_index);
+  EXPECT_EQ(v, v_index);
+
+  // move ctor
+  {
+    Variable v2(std::move(v));
+    EXPECT_EQ(v2, v_index);
+    EXPECT_EQ(v, v_nil);
+  }
+
+  // copy assign
+  v = v_index;
+  EXPECT_EQ(v, v_index);
+
+  // move assign
+  {
+    Variable v2;
+    v2 = std::move(v);
+    EXPECT_EQ(v2, v_index);
+    EXPECT_EQ(v, v_nil);
+  }
+
+  // move assign from conversion temporary
+  v = 123;
+  EXPECT_TRUE(v.is_index());
+  EXPECT_EQ(v.index(), 123);
+
+  // comparison
+  EXPECT_TRUE(v_index == v_index);
+  EXPECT_TRUE(v_index <= v_index);
+  EXPECT_TRUE(v_index >= v_index);
+  EXPECT_FALSE(v_index != v_index);
+  EXPECT_FALSE(v_index < v_index);
+  EXPECT_FALSE(v_index < v_index);
+  EXPECT_FALSE(v_index == v_nil);
+  EXPECT_TRUE(v_nil < v_index);
+  EXPECT_TRUE(v_nil <= v_index);
+  EXPECT_TRUE(v_index > v_nil);
+  EXPECT_TRUE(v_index >= v_nil);
+
+  // stream
+  {
+    std::ostringstream ss;
+    ss << v_index;
+    EXPECT_EQ(ss.str(), "0");
+  }
+}
+
+GTEST_TEST(FunctionalFormVariableTest, NamedVariant) {
+  using Variable = FunctionalForm::Variable;
+  Variable const v_nil;
+  Variable const v_named = "x";
+  Variable const v_index = 0;
+  EXPECT_TRUE(v_nil.is_nil());
+  EXPECT_TRUE(v_named.is_named());
+  EXPECT_TRUE(v_index.is_index());
+
+  // ctor
+  {
+    std::string name = "x";
+    Variable v1(name);
+    Variable v2(std::move(name));
+    std::vector<Variable> vec({"x"});
+    EXPECT_EQ(v1, v2);
+    EXPECT_EQ(v1, vec[0]);
+  }
+
+  // copy ctor
+  Variable v(v_named);
+  EXPECT_EQ(v, v_named);
+
+  // move ctor
+  {
+    Variable v2(std::move(v));
+    EXPECT_EQ(v2, v_named);
+    EXPECT_EQ(v, v_nil);
+  }
+
+  // copy assign
+  v = v_named;
+  EXPECT_EQ(v, v_named);
+
+  // move assign
+  {
+    Variable v2;
+    v2 = std::move(v);
+    EXPECT_EQ(v2, v_named);
+    EXPECT_EQ(v, v_nil);
+  }
+
+  // move assign from conversion temporary
+  v = "x";
+  EXPECT_TRUE(v.is_named());
+  EXPECT_EQ(v.name(), "x");
+  v = std::string("y");
+  EXPECT_TRUE(v.is_named());
+  EXPECT_EQ(v.name(), "y");
+
+  // comparison
+  EXPECT_TRUE(v_named == v_named);
+  EXPECT_FALSE(v_named != v_named);
+  EXPECT_FALSE(v_named < v_named);
+  EXPECT_FALSE(v_named == v_nil);
+  EXPECT_TRUE(v_nil < v_named);
+  EXPECT_TRUE(v_index < v_named);
+
+  // stream
+  {
+    std::ostringstream ss;
+    ss << v_named;
+    EXPECT_EQ(ss.str(), "x");
+  }
+}
+
+GTEST_TEST(FunctionalFormVariablesTest, Basic) {
+  FunctionalForm::Variables v_default;
+  FunctionalForm::Variables v_init_empty({});
+  EXPECT_TRUE(v_default.empty());
+  EXPECT_EQ(v_default.begin(), v_default.end());
+  EXPECT_EQ(v_default, v_init_empty);
+
+  FunctionalForm::Variables a({"a1", "a2", 3});
+  {
+    ASSERT_EQ(a.size(), 3);
+    FunctionalForm::Variables::const_iterator i = a.begin();
+    EXPECT_EQ(*i, FunctionalForm::Variable(3));
+    ++i;
+    EXPECT_EQ(*i, FunctionalForm::Variable("a1"));
+    ++i;
+    EXPECT_EQ(*i, FunctionalForm::Variable("a2"));
+    ++i;
+    EXPECT_EQ(i, a.end());
+  }
+
+  FunctionalForm::Variables b({"b1", "b2", 3});
+  {
+    ASSERT_EQ(b.size(), 3);
+    FunctionalForm::Variables::const_iterator i = b.begin();
+    EXPECT_EQ(*i, FunctionalForm::Variable(3));
+    ++i;
+    EXPECT_EQ(*i, FunctionalForm::Variable("b1"));
+    ++i;
+    EXPECT_EQ(*i, FunctionalForm::Variable("b2"));
+    ++i;
+    EXPECT_EQ(i, b.end());
+  }
+
+  EXPECT_NE(a, b);
+
+  FunctionalForm::Variables u = FunctionalForm::Variables::Union(a, b);
+  {
+    ASSERT_EQ(u.size(), 5);
+    FunctionalForm::Variables::const_iterator i = u.begin();
+    EXPECT_EQ(*i, FunctionalForm::Variable(3));
+    ++i;
+    EXPECT_EQ(*i, FunctionalForm::Variable("a1"));
+    ++i;
+    EXPECT_EQ(*i, FunctionalForm::Variable("a2"));
+    ++i;
+    EXPECT_EQ(*i, FunctionalForm::Variable("b1"));
+    ++i;
+    EXPECT_EQ(*i, FunctionalForm::Variable("b2"));
+    ++i;
+    EXPECT_EQ(i, u.end());
+  }
+
+  // Copy assignment.
+  a = u;
+  EXPECT_EQ(a, u);
+
+  // Move assignment.
+  b = std::move(u);
+  EXPECT_EQ(b, a);
+  EXPECT_EQ(u, v_default);
+
+  // Copy construction.
+  FunctionalForm::Variables ca = a;
+  EXPECT_EQ(ca, a);
+  EXPECT_EQ(a, b);
+
+  // Move construction.
+  FunctionalForm::Variables cb = std::move(b);
+  EXPECT_EQ(cb, ca);
+  EXPECT_EQ(b, v_default);
+}
+
+GTEST_TEST(FunctionalFormTest, Construct) {
+  FunctionalForm default_constructed;
+  EXPECT_TRUE(default_constructed.IsUndefined());
+
+  FunctionalForm double_zero(0.0);
+  EXPECT_TRUE(double_zero.IsZero());
+
+  FunctionalForm double_nonzero(0.1);
+  EXPECT_TRUE(double_nonzero.IsConstant());
+}
+
+GTEST_TEST(FunctionalFormTest, Basic) {
+  FunctionalForm zero = FunctionalForm::Zero();
+  FunctionalForm cons = FunctionalForm::Constant();
+  FunctionalForm lin = FunctionalForm::Linear({"x"});
+  FunctionalForm aff = FunctionalForm::Affine({"x"});
+  FunctionalForm poly = FunctionalForm::Polynomial({"x"});
+  FunctionalForm diff = FunctionalForm::Differentiable({"x"});
+  FunctionalForm arb = FunctionalForm::Arbitrary({"x"});
+  FunctionalForm undf = FunctionalForm::Undefined({"x"});
+
+  EXPECT_TRUE(zero.IsZero());
+  EXPECT_TRUE(cons.IsConstant());
+  EXPECT_TRUE(lin.IsLinear());
+  EXPECT_TRUE(aff.IsAffine());
+  EXPECT_TRUE(poly.IsPolynomial());
+  EXPECT_TRUE(diff.IsDifferentiable());
+  EXPECT_TRUE(arb.IsArbitrary());
+  EXPECT_TRUE(undf.IsUndefined());
+
+  EXPECT_FALSE(zero.IsConstant());
+  EXPECT_FALSE(cons.IsLinear());
+  EXPECT_FALSE(lin.IsAffine());
+  EXPECT_FALSE(aff.IsPolynomial());
+  EXPECT_FALSE(poly.IsDifferentiable());
+  EXPECT_FALSE(diff.IsArbitrary());
+  EXPECT_FALSE(arb.IsUndefined());
+  EXPECT_FALSE(undf.IsZero());
+}
+
+GTEST_TEST(FunctionalFormTest, Equality) {
+  FunctionalForm zero = FunctionalForm::Zero();
+  FunctionalForm cons = FunctionalForm::Constant();
+  FunctionalForm lin = FunctionalForm::Linear({"x"});
+
+  EXPECT_TRUE(zero.Is(FunctionalForm::Zero()));
+  EXPECT_TRUE(cons.Is(FunctionalForm::Constant()));
+  EXPECT_TRUE(lin.Is(FunctionalForm::Linear({"x"})));
+  EXPECT_TRUE(!lin.Is(FunctionalForm::Linear({0})));
+}
+
+GTEST_TEST(FunctionalFormTest, Stream) {
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Zero();
+    EXPECT_EQ(ss.str(), "zero");
+  }
+
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Constant();
+    EXPECT_EQ(ss.str(), "cons");
+  }
+
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Linear({"x", "y", "z"});
+    EXPECT_EQ(ss.str(), "lin(x,y,z)");
+  }
+
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Affine({4, 3, 2, 1});
+    EXPECT_EQ(ss.str(), "aff(1,2,3,4)");
+  }
+
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Polynomial({"x", "y", "z"});
+    EXPECT_EQ(ss.str(), "poly(x,y,z)");
+  }
+
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Differentiable({"x", "y", "z"});
+    EXPECT_EQ(ss.str(), "diff(x,y,z)");
+  }
+
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Arbitrary({"x", 0});
+    EXPECT_EQ(ss.str(), "arb(0,x)");
+  }
+
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Undefined({});
+    EXPECT_EQ(ss.str(), "undf");
+  }
+
+  {
+    std::ostringstream ss;
+    ss << FunctionalForm::Undefined({"x", 0});
+    EXPECT_EQ(ss.str(), "undf(0,x)");
+  }
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace core
+}  // namespace drake


### PR DESCRIPTION
This adds a functional form representation suitable for use in issue #1666.  Basically `FunctionalForm` is a class that can be used as the scalar type of an expression and it records the form of the expression.  See `drake/core/functional_form.h` doxygen comments for detailed documentation.

Model a functional form as a set of function input variables along with an abstract description of how the variables are combined.  We do not need to represent any details of how individual variables appear in the combination.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2322) &emsp; Multiple assignees:&emsp;<img alt="@david-german-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17437069?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/david-german-tri">david-german-tri</a>,&emsp;<img alt="@ggould-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596413?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/ggould-tri">ggould-tri</a>
<!-- Reviewable:end -->
