### PR TITLE
Yet more timeouts

### DIFF
--- a/drake/examples/Strandbeest/CMakeLists.txt
+++ b/drake/examples/Strandbeest/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 if (LONG_RUNNING_TESTS)
-  add_matlab_test(NAME examples/Strandbeest/runPassiveDownhill COMMAND runPassiveDownhill PROPERTIES TIMEOUT 3000)
-  add_matlab_test(NAME examples/Strandbeest/runWithMotor COMMAND runWithMotor PROPERTIES TIMEOUT 3000)
+  add_matlab_test(NAME examples/Strandbeest/runPassiveDownhill COMMAND runPassiveDownhill PROPERTIES TIMEOUT 4500)
+  add_matlab_test(NAME examples/Strandbeest/runWithMotor COMMAND runWithMotor PROPERTIES TIMEOUT 4500)
 endif()

--- a/drake/systems/plants/constraint/test/CMakeLists.txt
+++ b/drake/systems/plants/constraint/test/CMakeLists.txt
@@ -4,8 +4,11 @@ add_matlab_test(NAME systems/plants/constraint/test/RelativeGazeTargetConstraint
 add_matlab_test(NAME systems/plants/constraint/test/RelativePositionConstraintTest COMMAND RelativePositionConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/RelativeQuatConstraintTest COMMAND RelativeQuatConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/WorldPositionInFrameConstraintTest COMMAND WorldPositionInFrameConstraintTest)
-add_matlab_test(NAME systems/plants/constraint/test/testKinCnst COMMAND testKinCnst PROPERTIES TIMEOUT 750)
 add_matlab_test(NAME systems/plants/constraint/test/testMultipleTimeLinearPostureConstraint COMMAND testMultipleTimeLinearPostureConstraint)
 add_matlab_test(NAME systems/plants/constraint/test/testPostureConstraint COMMAND testPostureConstraint)
 add_matlab_test(NAME systems/plants/constraint/test/testQuasiStaticConstraint COMMAND testQuasiStaticConstraint)
 add_matlab_test(NAME systems/plants/constraint/test/testSingleTimeLinearPostureConstraint COMMAND testSingleTimeLinearPostureConstraint)
+
+if (LONG_RUNNING_TESTS)
+  add_matlab_test(NAME systems/plants/constraint/test/testKinCnst COMMAND testKinCnst PROPERTIES TIMEOUT 1500)
+endif()

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -210,5 +210,5 @@ add_matlab_test(NAME systems/plants/test/testdTransformSpatialMotion COMMAND tes
 add_matlab_test(NAME systems/plants/test/timeSteppingRigidBodyManipulatorFramesTest COMMAND timeSteppingRigidBodyManipulatorFramesTest)
 
 if (LONG_RUNNING_TESTS)
-  add_matlab_test(NAME systems/plants/test/testIKtraj COMMAND testIKtraj PROPERTIES TIMEOUT 1500)
+  add_matlab_test(NAME systems/plants/test/testIKtraj COMMAND testIKtraj PROPERTIES TIMEOUT 3000)
 endif()


### PR DESCRIPTION
Hopefully this is the last batch. If the `Strandbeest` tests still timeout after this, I will disable them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2328)
<!-- Reviewable:end -->
