### PR TITLE
Move NiceTypeName to drake:: namespace rather than drake::common

### DIFF
--- a/drake/common/nice_type_name.cc
+++ b/drake/common/nice_type_name.cc
@@ -22,12 +22,11 @@ using std::string;
 #endif
 
 namespace drake {
-namespace common {
 
 // On gcc and clang typeid(T).name() returns an indecipherable mangled string
 // that requires processing to become human readable. Microsoft returns a
 // reasonable name directly.
-string drake::common::NiceTypeName::Demangle(const char* typeid_name) {
+string drake::NiceTypeName::Demangle(const char* typeid_name) {
 #if defined(__GNUG__)
   int status = -100;  // just in case it doesn't get set
   char* ret = abi::__cxa_demangle(typeid_name, NULL, NULL, &status);
@@ -44,7 +43,7 @@ string drake::common::NiceTypeName::Demangle(const char* typeid_name) {
 // Given a demangled string, attempt to canonicalize it for platform
 // indpendence. We'll remove Microsoft's "class ", "struct ", etc.
 // designations, and get rid of all unnecessary spaces.
-string drake::common::NiceTypeName::Canonicalize(const string& demangled) {
+string drake::NiceTypeName::Canonicalize(const string& demangled) {
   using SPair = std::pair<std::regex, string>;
   // These are applied in this order.
   const std::array<SPair, 8> subs{
@@ -75,6 +74,5 @@ string drake::common::NiceTypeName::Canonicalize(const string& demangled) {
   return canonical;
 }
 
-}  // namespace common
 }  // namespace drake
 

--- a/drake/common/nice_type_name.h
+++ b/drake/common/nice_type_name.h
@@ -9,7 +9,6 @@
 #include "drake/drakeCommon_export.h"
 
 namespace drake {
-namespace common {
 
 /** @brief Obtains canonicalized, platform-independent, human-readable names for
 arbitrarily-complicated C++ types.
@@ -18,7 +17,7 @@ Usage: @code
 using std::pair; using std::string;
 using MyVectorType = pair<int,string>;
 std::cout << "Type MyVectorType was: "
-          << NiceTypeName::Get<MyVectorType>() << std::endl;
+          << drake::NiceTypeName::Get<MyVectorType>() << std::endl;
 // Output: std::pair<int,std::string>
 @endcode
 
@@ -73,5 +72,4 @@ class NiceTypeName {
   NiceTypeName() = delete;
 };
 
-}  // namespace common
 }  // namespace drake

--- a/drake/common/test/nice_type_name_test.cc
+++ b/drake/common/test/nice_type_name_test.cc
@@ -11,11 +11,10 @@
 using std::string;
 
 namespace drake {
-namespace common {
 
 // Need a non-anonymous namespace here for testing; can't canonicalize
 // names in anonymous namespaces.
-namespace test_nice_type_name {
+namespace nice_type_name_test {
 enum class Color { Red, Green, Blue };
 
 struct ForTesting {
@@ -27,7 +26,7 @@ struct ForTesting {
 namespace {
 // Can't test much of NiceTypeName::Demangle because its behavior is compiler-
 // and platform-specific. Everyone should agree on simple types though.
-GTEST_TEST(TestNiceTypeName, Demangle) {
+GTEST_TEST(NiceTypeNameTest, Demangle) {
   EXPECT_EQ(NiceTypeName::Demangle(typeid(bool).name()), "bool");
   EXPECT_EQ(NiceTypeName::Demangle(typeid(int).name()), "int");
   EXPECT_EQ(NiceTypeName::Demangle(typeid(unsigned).name()), "unsigned int");
@@ -35,7 +34,7 @@ GTEST_TEST(TestNiceTypeName, Demangle) {
 
 // Standalone tests of the method that is used by NiceTypeName::Get<T>::Get()
 // to clean up the demangled names on various platforms.
-GTEST_TEST(TestNiceTypeName, Canonicalize) {
+GTEST_TEST(NiceTypeNameTest, Canonicalize) {
   // Get rid of extra spaces and useless names like "class".
   EXPECT_EQ(NiceTypeName::Canonicalize("class std :: vector < double   >"),
             "std::vector<double>");
@@ -50,7 +49,7 @@ GTEST_TEST(TestNiceTypeName, Canonicalize) {
             "std::my__1::resigned char");
 }
 
-GTEST_TEST(TestNiceTypeName, BuiltIns) {
+GTEST_TEST(NiceTypeNameTest, BuiltIns) {
   EXPECT_EQ(NiceTypeName::Get<bool>(), "bool");
   EXPECT_EQ(NiceTypeName::Get<signed char>(), "signed char");
   EXPECT_EQ(NiceTypeName::Get<unsigned char>(), "unsigned char");
@@ -79,7 +78,7 @@ GTEST_TEST(TestNiceTypeName, BuiltIns) {
             "std::complex<long double>");
 }
 
-GTEST_TEST(TestNiceTypeName, StdClasses) {
+GTEST_TEST(NiceTypeNameTest, StdClasses) {
   EXPECT_EQ(NiceTypeName::Get<std::string>(), "std::string");
   EXPECT_EQ(NiceTypeName::Get<string>(), "std::string");
 
@@ -101,7 +100,7 @@ GTEST_TEST(TestNiceTypeName, StdClasses) {
             "std::vector<unsigned int,std::allocator<unsigned int>>");
 }
 
-GTEST_TEST(TestNiceTypeName, Eigen) {
+GTEST_TEST(NiceTypeNameTest, Eigen) {
   EXPECT_EQ(NiceTypeName::Get<Eigen::Matrix3f>(),
             "Eigen::Matrix<float,3,3,0,3,3>");
 
@@ -111,23 +110,22 @@ GTEST_TEST(TestNiceTypeName, Eigen) {
             "Eigen::Matrix<double,3,1,0,3,1>>");
 }
 
-GTEST_TEST(TestNiceTypeName, Enum) {
-  EXPECT_EQ(NiceTypeName::Get<test_nice_type_name::Color>(),
-            "drake::common::test_nice_type_name::Color");
-  EXPECT_EQ(NiceTypeName::Get<test_nice_type_name::ForTesting>(),
-            "drake::common::test_nice_type_name::ForTesting");
-  EXPECT_EQ(NiceTypeName::Get<test_nice_type_name::ForTesting::MyEnum>(),
-            "drake::common::test_nice_type_name::ForTesting::MyEnum");
-  EXPECT_EQ(NiceTypeName::Get<test_nice_type_name::ForTesting::MyEnumClass>(),
-            "drake::common::test_nice_type_name::ForTesting::MyEnumClass");
+GTEST_TEST(NiceTypeNameTest, Enum) {
+  EXPECT_EQ(NiceTypeName::Get<nice_type_name_test::Color>(),
+            "drake::nice_type_name_test::Color");
+  EXPECT_EQ(NiceTypeName::Get<nice_type_name_test::ForTesting>(),
+            "drake::nice_type_name_test::ForTesting");
+  EXPECT_EQ(NiceTypeName::Get<nice_type_name_test::ForTesting::MyEnum>(),
+            "drake::nice_type_name_test::ForTesting::MyEnum");
+  EXPECT_EQ(NiceTypeName::Get<nice_type_name_test::ForTesting::MyEnumClass>(),
+            "drake::nice_type_name_test::ForTesting::MyEnumClass");
 
-  EXPECT_EQ(NiceTypeName::Get<decltype(test_nice_type_name::ForTesting::One)>(),
-            "drake::common::test_nice_type_name::ForTesting::MyEnum");
+  EXPECT_EQ(NiceTypeName::Get<decltype(nice_type_name_test::ForTesting::One)>(),
+            "drake::nice_type_name_test::ForTesting::MyEnum");
   EXPECT_EQ(NiceTypeName::Get<decltype(
-                test_nice_type_name::ForTesting::MyEnumClass::Four)>(),
-            "drake::common::test_nice_type_name::ForTesting::MyEnumClass");
+                nice_type_name_test::ForTesting::MyEnumClass::Four)>(),
+            "drake::nice_type_name_test::ForTesting::MyEnumClass");
 }
 
 }  // namespace
-}  // namespace common
 }  // namespace drake


### PR DESCRIPTION
Resolves #2348 since this is currently the only thing in `drake/common`. 
Also fixed internal naming in test to match revised test name.

No feature changes; platform review please @jwnimmer-tri.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2358)
<!-- Reviewable:end -->
