### PR TITLE
Set both relative and absolute tolerance for NLopt

### DIFF
--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -251,6 +251,7 @@ SolutionResult NloptSolver::Solve(OptimizationProblem &prog) const {
   // should be made configurable when #1879 is fixed.
   const double constraint_tol = 1e-6;
   const double xtol_rel = 1e-6;
+  const double xtol_abs = 1e-6;
 
   std::list<WrappedConstraint> wrapped_list;
 
@@ -309,7 +310,7 @@ SolutionResult NloptSolver::Solve(OptimizationProblem &prog) const {
   }
 
   opt.set_xtol_rel(xtol_rel);
-
+  opt.set_xtol_abs(xtol_abs);
 
   SolutionResult result = SolutionResult::kSolutionFound;
   nlopt::result nlopt_result = nlopt::FAILURE;

--- a/drake/solvers/test/system_identification_test.cpp
+++ b/drake/solvers/test/system_identification_test.cpp
@@ -162,10 +162,7 @@ TEST(SystemIdentificationTest, BASIC_ESTIMATE_TEST_NAME) {
       {{x_var, 1}, {y_var, 1}, {z_var, 3}},
       {{x_var, 1}, {y_var, 2}, {z_var, 4}},
       {{x_var, 2}, {y_var, 1}, {z_var, 7}},
-       // TODO(ggould-tri) The additional 1e-8 here is to work around an
-       // apparent nlopt bug that sometimes causes it to never terminate if
-       // equality constraints are exactly zero.
-      {{x_var, 2}, {y_var, 2}, {z_var, 8 + 1e-8}}};
+      {{x_var, 2}, {y_var, 2}, {z_var, 8}}};
 
     const SID::PartialEvalType expected_params {
       {a_var, 1}, {b_var, 1}, {c_var, 1}};


### PR DESCRIPTION
Fix an issue which @ggould-tri hit during parameter estimation implementation where NLopt was missing an absolute tolerance and had issues near zero...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2362)
<!-- Reviewable:end -->
