### PR TITLE
Add issue number citations to broken-out cpplint suppressions

### DIFF
--- a/drake/CPPLINT.cfg
+++ b/drake/CPPLINT.cfg
@@ -24,14 +24,29 @@ filter=-build/header_guard
 # It's not worth lint-gardening the documentation.
 exclude_files=doc
 
-# These disabled because they don't pass yet, but we want them to.
-# TODO(jeremy.nimmer@tri.global): PRs to get these cleaned up one by one.
+# TODO(#2364) Fix this.
 filter=-build/include
+
+# TODO(#2269) Fix this.
 filter=-build/include_order
+
+# TODO(#2270) Fix this.
 filter=-build/include_what_you_use
+
+# TODO(#2271) Fix this.
 filter=-build/namespaces
+
+# TODO(#1805) Fix this.
 filter=-legal/copyright
+
+# TODO(#2272) Fix this.
 filter=-readability/casting
+
+# TODO(#2273) Fix this.
 filter=-readability/namespace
+
+# TODO(#2274) Fix this.
 filter=-runtime/references
+
+# TODO(#2367) Fix this.
 filter=-runtime/string


### PR DESCRIPTION
For reference, only the cpplint jenkins needs to pass before merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2368) &emsp; Multiple assignees:&emsp;<img alt="@sammy-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596504?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/sammy-tri">sammy-tri</a>,&emsp;<img alt="@sherm1" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/4088016?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/sherm1">sherm1</a>
<!-- Reviewable:end -->
