### PR TITLE
Turn on -Wall for gcc, except for a few currently-failing warnings

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -63,7 +63,13 @@ include_directories(BEFORE ${PROJECT_SOURCE_DIR}/..)
 
 
 if (CMAKE_COMPILER_IS_GNUCC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wreturn-type -Wuninitialized -Wunused-variable")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
 
   execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
   if (NOT (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7))

--- a/drake/systems/robotInterfaces/constructQPLocomotionPlanmex.cpp
+++ b/drake/systems/robotInterfaces/constructQPLocomotionPlanmex.cpp
@@ -25,9 +25,10 @@ PiecewisePolynomial<double> matlabPPFormToPiecewisePolynomial(
 
   const mxArray* dim_mex = mxGetFieldSafe(pp, "dim");
   int num_dims_mex = mxGetNumberOfElements(dim_mex);
-  if (num_dims_mex == 0 | num_dims_mex > 2)
-    throw runtime_error("case not handled");  // because PiecewisePolynomial
-                                              // can't currently handle it
+  if ((num_dims_mex == 0) || (num_dims_mex > 2)) {
+    // PiecewisePolynomial can't currently handle it.
+    throw runtime_error("case not handled");
+  }
   const int kNumDims = 2;
   mwSize dims[kNumDims];
   if (!mxIsDouble(dim_mex))


### PR DESCRIPTION
This should prevent us from regressing, where new warning types start tripping.  Once this is in place, we can start to try to fix the four suppressions (#2372).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2373)
<!-- Reviewable:end -->
