### PR TITLE
Fixed indentation and removed trailing spaces from Stata garage model.

### DIFF
--- a/drake/examples/Cars/models/stata_garage_p1.sdf
+++ b/drake/examples/Cars/models/stata_garage_p1.sdf
@@ -26,7 +26,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="2">
+    <visual name="2">
       <pose>-1.648178 83.9216 1.524 0 0 0</pose>
       <geometry>
         <box>
@@ -36,7 +36,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="3">
+    <visual name="3">
       <pose>-1.94169 93.06719 1.524 0 0 0</pose>
       <geometry>
         <box> <size>.180622 18.51378 3.048</size></box>
@@ -45,7 +45,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="4">
+    <visual name="4">
       <pose>-4.38009 102.4144 1.524 0 0 0</pose>
       <geometry>
         <box><size>5.057422 .180622 3.048</size></box>
@@ -54,7 +54,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="5">
+    <visual name="5">
       <pose>-6.81849 104.0384 1.524 0 0 0</pose>
       <geometry>
         <box><size>.180622 3.070578 3.048</size></box>
@@ -63,7 +63,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="6">
+    <visual name="6">
       <pose>-4.064 105.6656 1.524 0 0 0</pose>
       <geometry>
         <box><size>5.6896 .180622 3.048</size></box>
@@ -72,7 +72,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="7">
+    <visual name="7">
       <pose>-1.3305 110.9472 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 10.38578 3.048</size></box>
@@ -81,7 +81,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="8">
+    <visual name="8">
       <pose>-47.4577 115.982 1.524 0 0 0</pose>
       <geometry>
         <box><size>92.02861 .316088 3.048</size></box>
@@ -90,7 +90,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="9">
+    <visual name="9">
       <pose>-3.22862 4.176888 1.524 0 0 0</pose>
       <geometry>
         <box><size>4.017256 .135466 3.048</size></box>
@@ -99,7 +99,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="10">
+    <visual name="10">
       <pose>-6.92979 4.199466 1.524 0 0 0</pose>
       <geometry>
         <box><size>2.122312 .180622 3.048</size></box>
@@ -108,7 +108,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="11">
+    <visual name="11">
       <pose>-5.55347 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.633766 .587022 3.048</size></box>
@@ -117,7 +117,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="12">
+    <visual name="12">
       <pose>-7.879644 2.05458 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 4.109156 3.048</size></box>
@@ -126,7 +126,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="13">
+    <visual name="13">
       <pose>-43.3042 -.09031 1.524 0 0 0</pose>
       <geometry>
         <box><size>71.07484 .180622 3.048</size></box>
@@ -135,7 +135,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="14">
+    <visual name="14">
       <pose>-78.9561 2.032 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 4.064 3.048</size></box>
@@ -144,7 +144,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="15">
+    <visual name="15">
       <pose>-79.7689 4.154322 1.524 0 0 0</pose>
       <geometry>
         <box><size>1.851378 .180622 3.048</size></box>
@@ -153,7 +153,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="16">
+    <visual name="16">
       <pose>-80.9865 4.425244 1.524 0 0 0</pose>
       <geometry>
         <box><size>.588609 .903112 3.048</size></box>
@@ -162,7 +162,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="17">
+    <visual name="17">
       <pose>-83.193 3.844359 1.524 0 0 .160621464</pose>
       <geometry>
         <box><size>3.904381 .17833 3.048</size></box>
@@ -171,7 +171,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="18">
+    <visual name="18">
       <pose>-89.3362 30.07934 1.524 0 0 .160951681</pose>
       <geometry>
         <box><size>.187107 53.5695 3.048</size></box>
@@ -180,7 +180,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="19">
+    <visual name="19">
       <pose>-93.58492 86.33901 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 59.6069 3.048</size></box>
@@ -189,7 +189,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="20">
+    <visual name="20">
       <pose>-91.7351 56.42187 1.524 0 0 0</pose>
       <geometry>
         <box><size>3.475391 .22578 3.048</size></box>
@@ -198,7 +198,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="21">
+    <visual name="21">
       <pose>-91.6656 55.74328 1.524 0 0 0.16150238427</pose>
       <geometry>
         <box><size>3.421301 .22287 3.048</size></box>
@@ -207,7 +207,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="22">
+    <visual name="22">
       <pose>-89.5209 56.21708 1.524 0 0 0</pose>
       <geometry>
         <box><size>.948266 .63218 3.048</size></box>
@@ -217,140 +217,140 @@
       </material>
     </visual>
 
-<collision name="1">
+    <collision name="1">
       <pose>-1.332088 44.13956 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 79.78978 3.048</size></box>
       </geometry>
     </collision>
-<collision name="2">
+    <collision name="2">
       <pose>-1.648178 83.9216 1.524 0 0 0</pose>
       <geometry>
         <box><size>.4064 .225778 3.048</size></box>
       </geometry>
     </collision>
-<collision name="3">
+    <collision name="3">
       <pose>-1.94169 93.06719 1.524 0 0 0</pose>
       <geometry>
         <box><size>.180622 18.51378 3.048</size></box>
       </geometry>
     </collision>
-<collision name="4">
+    <collision name="4">
       <pose>-4.38009 102.4144 1.524 0 0 0</pose>
       <geometry>
         <box><size>5.057422 .180622 3.048</size></box>
       </geometry>
     </collision>
-<collision name="5">
+    <collision name="5">
       <pose>-6.81849 104.0384 1.524 0 0 0</pose>
       <geometry>
         <box><size>.180622 3.070578 3.048</size></box>
       </geometry>
     </collision>
-<collision name="6">
+    <collision name="6">
       <pose>-4.064 105.6656 1.524 0 0 0</pose>
       <geometry>
         <box><size>5.6896 .180622 3.048</size></box>
       </geometry>
     </collision>
-<collision name="7">
+    <collision name="7">
       <pose>-1.3305 110.9472 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 10.38578 3.048</size></box>
       </geometry>
     </collision>
-<collision name="8">
+    <collision name="8">
       <pose>-47.4577 115.982 1.524 0 0 0</pose>
       <geometry>
         <box><size>92.02861 .316088 3.048</size></box>
       </geometry>
     </collision>
-<collision name="9">
+    <collision name="9">
       <pose>-3.22862 4.176888 1.524 0 0 0</pose>
       <geometry>
         <box><size>4.017256 .135466 3.048</size></box>
       </geometry>
     </collision>
-<collision name="10">
+    <collision name="10">
       <pose>-6.92979 4.199466 1.524 0 0 0</pose>
       <geometry>
         <box><size>2.122312 .180622 3.048</size></box>
       </geometry>
     </collision>
-<collision name="11">
+    <collision name="11">
       <pose>-5.55347 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.633766 .587022 3.048</size></box>
       </geometry>
     </collision>
-<collision name="12">
+    <collision name="12">
       <pose>-7.879644 2.05458 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 4.109156 3.048</size></box>
       </geometry>
     </collision>
-<collision name="13">
+    <collision name="13">
       <pose>-43.3042 -.09031 1.524 0 0 0</pose>
       <geometry>
         <box><size>71.07484 .180622 3.048</size></box>
       </geometry>
     </collision>
-<collision name="14">
+    <collision name="14">
       <pose>-78.9561 2.032 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 4.064 3.048</size></box>
       </geometry>
     </collision>
-<collision name="15">
+    <collision name="15">
       <pose>-79.7689 4.154322 1.524 0 0 0</pose>
       <geometry>
         <box><size>1.851378 .180622 3.048</size></box>
       </geometry>
     </collision>
-<collision name="16">
+    <collision name="16">
       <pose>-80.9865 4.425244 1.524 0 0 0</pose>
       <geometry>
         <box><size>.588609 .903112 3.048</size></box>
       </geometry>
     </collision>
-<collision name="17">
+    <collision name="17">
       <pose>-83.193 3.844359 1.524 0 0 .160621464</pose>
       <geometry>
         <box><size>3.904381 .17833 3.048</size></box>
       </geometry>
     </collision>
-<collision name="18">
+    <collision name="18">
       <pose>-89.3362 30.07934 1.524 0 0 .160951681</pose>
       <geometry>
         <box><size>.187107 53.5695 3.048</size></box>
       </geometry>
     </collision>
-<collision name="19">
+    <collision name="19">
       <pose>-93.58492 86.33901 1.524 0 0 0</pose>
       <geometry>
         <box><size>.225778 59.6069 3.048</size></box>
       </geometry>
     </collision>
-<collision name="20">
+    <collision name="20">
       <pose>-91.7351 56.42187 1.524 0 0 0</pose>
       <geometry>
         <box><size>3.475391 .22578 3.048</size></box>
       </geometry>
     </collision>
-<collision name="21">
+    <collision name="21">
       <pose>-91.6656 55.74328 1.524 0 0 0</pose>
       <geometry>
         <box><size>3.421301 .22287 3.048</size></box>
       </geometry>
     </collision>
-<collision name="22">
+    <collision name="22">
       <pose>-89.5209 56.21708 1.524 0 0 0</pose>
       <geometry>
         <box><size>.948266 .63218 3.048</size></box>
       </geometry>
     </collision>
-</link>
-  
+  </link>
+
   <link name="stairs">
     <inertial>    
       <mass>1</mass>
@@ -372,7 +372,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="24">
+    <visual name="24">
       <pose>-73.9648 21.22312 1.524 0 0 0</pose>
       <geometry>
         <box><size>1.6256 2.61902 3.048</size></box>
@@ -381,7 +381,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="25">
+    <visual name="25">
       <pose>-71.6619 88.32427 1.524 0 0 0.470404264136</pose>
       <geometry>
         <box><size>3.394271 3.8573 3.048</size></box>
@@ -390,7 +390,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="26">
+    <visual name="26">
       <pose>-27.432 18.71698 1.524 0 0 0</pose>
       <geometry>
         <box><size>4.380088 3.20604 3.048</size></box>
@@ -399,7 +399,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="27">
+    <visual name="27">
       <pose>-30.8904 19.8324 1.524 0 0 -0.505290184477</pose>
       <geometry>
         <box><size>4.850808 3.5175 3.048</size></box>
@@ -408,7 +408,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="28">
+    <visual name="28">
       <pose>-26.3031 68.86222 1.524 0 0 0</pose>
       <geometry>
         <box><size>2.8448 6.68302 3.048</size></box>
@@ -417,7 +417,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="29">
+    <visual name="29">
       <pose>-36.0793 68.8848 1.524 0 0 0</pose>
       <geometry>
         <box><size>.180622 9.07627 3.048</size></box>
@@ -426,7 +426,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="30">
+    <visual name="30">
       <pose>-27.8836 68.88437 1.524 0 0 0</pose>
       <geometry>
         <box><size>.316088 10.7288 3.048</size></box>
@@ -435,7 +435,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="31">
+    <visual name="31">
       <pose>-32.0176 64.12729 1.524 0 0 -0.097989311738</pose>
       <geometry>
         <box><size>7.945656 .43238 3.048</size></box>
@@ -444,7 +444,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="32">
+    <visual name="32">
       <pose>-32.0188 73.61092 1.524 0 0 0.0959625656</pose>
       <geometry>
         <box><size>7.936766 .50714 3.048</size></box>
@@ -453,7 +453,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="33">
+    <visual name="33">
       <pose>-23.5276 106.5671 1.524 0 0 0</pose>
       <geometry>
         <box><size>6.592712 3.16089 3.048</size></box>
@@ -462,7 +462,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="34">
+    <visual name="34">
       <pose>-25.4226 108.3056 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .31609 3.048</size></box>
@@ -471,7 +471,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="35">
+    <visual name="35">
       <pose>-47.2101 106.0252 1.524 0 0 0</pose>
       <geometry>
         <box><size>5.012266 3.07058 3.048</size></box>
@@ -480,7 +480,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="36">
+    <visual name="36">
       <pose>-47.5262 106.68 .0635 0 0 0</pose>
       <geometry>
         <box><size>60.82453 3.6576 .127</size></box>
@@ -489,7 +489,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="37">
+    <visual name="37">
       <pose>-78.4352 101.3291 1.524 0 0 0</pose>
       <geometry>
         <box><size>.995009 2.4384 3.048</size></box>
@@ -498,7 +498,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="38">
+    <visual name="38">
       <pose>-88.4597 108.3408 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
@@ -507,7 +507,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="39">
+    <visual name="39">
       <pose>-88.4597 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .63218 3.048</size></box>
@@ -516,7 +516,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="40">
+    <visual name="40">
       <pose>-88.6178 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>1.220788 .63218 3.048</size></box>
@@ -525,7 +525,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="41">
+    <visual name="41">
       <pose>-72.6101 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.633766 .90311 3.048</size></box>
@@ -534,7 +534,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="42">
+    <visual name="42">
       <pose>-64.2112 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -543,7 +543,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="43">
+    <visual name="43">
       <pose>-55.8348 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.587022 1.2192 3.048</size></box>
@@ -552,7 +552,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="44">
+    <visual name="44">
       <pose>-47.4585 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -561,7 +561,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="45">
+    <visual name="45">
       <pose>-39.0821 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.587022 .63377 3.048</size></box>
@@ -570,7 +570,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="46">
+    <visual name="46">
       <pose>-30.6832 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.588609 .90311 3.048</size></box>
@@ -579,7 +579,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="47">
+    <visual name="47">
       <pose>-22.3068 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .6322 3.048</size></box>
@@ -588,7 +588,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="48">
+    <visual name="48">
       <pose>-16.5269 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.9047 .63218 3.048</size></box>
@@ -597,7 +597,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="49">
+    <visual name="49">
       <pose>-6.45724 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .63218 3.048</size></box>
@@ -606,7 +606,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="50">
+    <visual name="50">
       <pose>-5.55413 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .63218 3.048</size></box>
@@ -615,7 +615,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="51">
+    <visual name="51">
       <pose>-5.55413 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
@@ -624,7 +624,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="52">
+    <visual name="52">
       <pose>-5.55413 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
@@ -633,7 +633,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="53">
+    <visual name="53">
       <pose>-5.55413 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .63218 3.048</size></box>
@@ -642,7 +642,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="54">
+    <visual name="54">
       <pose>-5.55413 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .63218 3.048</size></box>
@@ -651,7 +651,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="55">
+    <visual name="55">
       <pose>-5.55413 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
@@ -660,7 +660,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="56">
+    <visual name="56">
       <pose>-5.55413 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -669,7 +669,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="57">
+    <visual name="57">
       <pose>-5.55413 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -678,7 +678,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="58">
+    <visual name="58">
       <pose>-5.55413 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -687,7 +687,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="59">
+    <visual name="59">
       <pose>-5.55413 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -697,7 +697,7 @@
       </material>
     </visual>
 
-<visual name="60">
+    <visual name="60">
       <pose>-13.9305 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
@@ -706,7 +706,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="61">
+    <visual name="61">
       <pose>-13.9305 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -715,7 +715,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="62">
+    <visual name="62">
       <pose>-13.9305 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -724,7 +724,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="63">
+    <visual name="63">
       <pose>-13.9305 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -733,7 +733,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="64">
+    <visual name="64">
       <pose>-13.9305 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -742,7 +742,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="65">
+    <visual name="65">
       <pose>-13.9305 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -751,7 +751,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="66">
+    <visual name="66">
       <pose>-13.9305 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -760,7 +760,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="67">
+    <visual name="67">
       <pose>-13.9305 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -769,7 +769,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="68">
+    <visual name="68">
       <pose>-13.9305 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -778,7 +778,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="69">
+    <visual name="69">
       <pose>-13.9305 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -787,7 +787,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="70">
+    <visual name="70">
       <pose>-13.9305 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -797,7 +797,7 @@
       </material>
     </visual>
 
-<visual name="71">
+    <visual name="71">
       <pose>-22.3068 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
@@ -806,7 +806,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="72">
+    <visual name="72">
       <pose>-22.3068 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -815,7 +815,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="73">
+    <visual name="73">
       <pose>-22.3068 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -824,7 +824,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="73a">
+    <visual name="73a">
       <pose>-22.3068 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
@@ -833,7 +833,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="74">
+    <visual name="74">
       <pose>-22.3068 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
@@ -842,7 +842,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="75">
+    <visual name="75">
       <pose>-22.3068 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
@@ -851,7 +851,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="76">
+    <visual name="76">
       <pose>-22.3068 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
@@ -860,7 +860,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="77">
+    <visual name="77">
       <pose>-22.3068 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -869,7 +869,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="78">
+    <visual name="78">
       <pose>-22.3068 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
@@ -878,7 +878,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="79">
+    <visual name="79">
       <pose>-22.3068 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -887,7 +887,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="80">
+    <visual name="80">
       <pose>-22.3068 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .64911 3.048</size></box>
@@ -897,7 +897,7 @@
       </material>
     </visual>
 
-<visual name="81">
+    <visual name="81">
       <pose>-30.6832 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -906,7 +906,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="82">
+    <visual name="82">
       <pose>-30.6832 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -915,7 +915,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="83">
+    <visual name="83">
       <pose>-30.6832 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -924,7 +924,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="84">
+    <visual name="84">
       <pose>-30.6832 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -933,7 +933,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="85">
+    <visual name="85">
       <pose>-30.6832 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -942,7 +942,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="86">
+    <visual name="86">
       <pose>-30.6832 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -951,7 +951,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="87">
+    <visual name="87">
       <pose>-30.6832 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -960,7 +960,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="88">
+    <visual name="88">
       <pose>-30.6832 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
@@ -970,7 +970,7 @@
       </material>
     </visual>
 
-<visual name="89">
+    <visual name="89">
       <pose>-39.0821 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -979,7 +979,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="90">
+    <visual name="90">
       <pose>-39.0821 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -988,7 +988,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="91">
+    <visual name="91">
       <pose>-39.0821 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
@@ -997,7 +997,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="92">
+    <visual name="92">
       <pose>-39.0821 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -1006,7 +1006,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="93">
+    <visual name="93">
       <pose>-39.0821 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -1015,7 +1015,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="94">
+    <visual name="94">
       <pose>-39.0821 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1024,7 +1024,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="95">
+    <visual name="95">
       <pose>-39.0821 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -1033,7 +1033,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="96">
+    <visual name="96">
       <pose>-39.0821 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -1042,7 +1042,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="97">
+    <visual name="97">
       <pose>-39.0821 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1051,7 +1051,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="98">
+    <visual name="98">
       <pose>-39.0821 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -1060,7 +1060,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="99">
+    <visual name="99">
       <pose>-39.0821 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
@@ -1070,7 +1070,7 @@
       </material>
     </visual>
 
-<visual name="100">
+    <visual name="100">
       <pose>-47.45849 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1079,7 +1079,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="101">
+    <visual name="101">
       <pose>-47.45849 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
@@ -1088,7 +1088,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="102">
+    <visual name="102">
       <pose>-47.45849 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1097,7 +1097,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="103">
+    <visual name="103">
       <pose>-47.45849 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .63218 3.048</size></box>
@@ -1106,7 +1106,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="104">
+    <visual name="104">
       <pose>-47.45849 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1115,7 +1115,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="105">
+    <visual name="105">
       <pose>-47.45849 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
@@ -1124,7 +1124,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="106">
+    <visual name="106">
       <pose>-47.45849 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
@@ -1133,7 +1133,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="107">
+    <visual name="107">
       <pose>-47.45849 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1142,7 +1142,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="108">
+    <visual name="108">
       <pose>-47.45849 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1151,7 +1151,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="109">
+    <visual name="109">
       <pose>-47.45849 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1160,7 +1160,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="110">
+    <visual name="110">
       <pose>-47.45849 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
@@ -1170,7 +1170,7 @@
       </material>
     </visual>
 
-<visual name="111">
+    <visual name="111">
       <pose>-55.8348 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1179,7 +1179,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="112">
+    <visual name="112">
       <pose>-55.8348 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -1188,7 +1188,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="113">
+    <visual name="113">
       <pose>-55.8348 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1197,7 +1197,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="114">
+    <visual name="114">
       <pose>-55.8348 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -1206,7 +1206,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="115">
+    <visual name="115">
       <pose>-55.8348 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1215,7 +1215,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="116">
+    <visual name="116">
       <pose>-55.8348 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1224,7 +1224,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="117">
+    <visual name="117">
       <pose>-55.8348 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -1233,7 +1233,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="118">
+    <visual name="118">
       <pose>-55.8348 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
@@ -1242,7 +1242,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="119">
+    <visual name="119">
       <pose>-55.8348 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1251,7 +1251,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="120">
+    <visual name="120">
       <pose>-55.8348 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
@@ -1260,7 +1260,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="121">
+    <visual name="121">
       <pose>-55.8348 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1270,7 +1270,7 @@
       </material>
     </visual>
 
-<visual name="122">
+    <visual name="122">
       <pose>-64.2112 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1279,7 +1279,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="123">
+    <visual name="123">
       <pose>-64.2112 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1288,7 +1288,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="124">
+    <visual name="124">
       <pose>-64.2112 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -1297,7 +1297,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="125">
+    <visual name="125">
       <pose>-64.2112 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
@@ -1306,7 +1306,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="126">
+    <visual name="126">
       <pose>-64.2112 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
@@ -1315,7 +1315,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="127">
+    <visual name="127">
       <pose>-64.2112 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -1324,7 +1324,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="128">
+    <visual name="128">
       <pose>-64.2112 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1333,7 +1333,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="129">
+    <visual name="129">
       <pose>-64.2112 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1342,7 +1342,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="130">
+    <visual name="130">
       <pose>-64.2112 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1351,7 +1351,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="131">
+    <visual name="131">
       <pose>-64.2112 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
@@ -1360,7 +1360,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="132">
+    <visual name="132">
       <pose>-64.2112 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1370,7 +1370,7 @@
       </material>
     </visual>
 
-<visual name="133">
+    <visual name="133">
       <pose>-72.6101 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1379,7 +1379,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="134">
+    <visual name="134">
       <pose>-72.6101 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1388,7 +1388,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="135">
+    <visual name="135">
       <pose>-72.6101 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
@@ -1397,7 +1397,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="136">
+    <visual name="136">
       <pose>-72.6101 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1406,7 +1406,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="137">
+    <visual name="137">
       <pose>-72.6101 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
@@ -1415,7 +1415,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="138">
+    <visual name="138">
       <pose>-72.6101 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
@@ -1424,7 +1424,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="139">
+    <visual name="139">
       <pose>-72.6101 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1433,7 +1433,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="140">
+    <visual name="140">
       <pose>-72.6101 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
@@ -1442,7 +1442,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="141">
+    <visual name="141">
       <pose>-72.6101 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
@@ -1452,7 +1452,7 @@
       </material>
     </visual>
 
-<visual name="142">
+    <visual name="142">
       <pose>-80.9865 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1461,7 +1461,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="143">
+    <visual name="143">
       <pose>-80.9865 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1470,7 +1470,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="144">
+    <visual name="144">
       <pose>-80.9865 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1479,7 +1479,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="145">
+    <visual name="145">
       <pose>-80.9865 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1489,7 +1489,7 @@
       </material>
     </visual>
 
-<visual name="146">
+    <visual name="146">
       <pose>-89.3854 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>1.2192 .58702 3.048</size></box>
@@ -1498,7 +1498,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="147">
+    <visual name="147">
       <pose>-89.3628 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.90311 .58702 3.048</size></box>
@@ -1507,7 +1507,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="148">
+    <visual name="148">
       <pose>-89.3628 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.90311 .63218 3.048</size></box>
@@ -1516,7 +1516,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="149">
+    <visual name="149">
       <pose>-73.31 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
@@ -1526,7 +1526,7 @@
       </material>
     </visual>
 
-<visual name="150">
+    <visual name="150">
       <pose>-82.4315 13.23508 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>1.2192 .58702 3.048</size></box>
@@ -1535,7 +1535,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="151">
+    <visual name="151">
       <pose>-83.8087 21.76498 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>1.2192 .58702 3.048</size></box>
@@ -1544,7 +1544,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="152">
+    <visual name="152">
       <pose>-85.186 30.29938 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>1.2912 .58702 3.048</size></box>
@@ -1553,7 +1553,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="153">
+    <visual name="153">
       <pose>-86.5632 38.83378 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>.90311 .58702 3.048</size></box>
@@ -1562,7 +1562,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="154">
+    <visual name="154">
       <pose>-87.963 47.36818 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1572,7 +1572,7 @@
       </material>
     </visual>
 
-<visual name="155">
+    <visual name="155">
       <pose>-76.4484 30.29938 1.524 0 0 0.15264932381</pose>
       <geometry>
         <box><size>.58702 1.2912 3.048</size></box>
@@ -1581,7 +1581,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="156">
+    <visual name="156">
       <pose>-77.8256 38.83378 1.524 0 0 0.15264932381</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1590,7 +1590,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="157">
+    <visual name="157">
       <pose>-79.2028 47.36818 1.524 0 0 0.15264932381</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1599,7 +1599,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="158">
+    <visual name="158">
       <pose>-80.6027 56.0832 1.524 0 0 0.15264932381</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
@@ -1608,7 +1608,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="159">
+    <visual name="159">
       <pose>-78.39 107.5154 1.524 0 0 0</pose>
       <geometry>
         <box><size>.90311 .63218 3.048</size></box>
@@ -1617,7 +1617,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="160">
+    <visual name="160">
       <pose>-16.5269 107.5154 1.524 0 0 0</pose>
       <geometry>
         <box><size>.63218 .63218 3.048</size></box>
@@ -1626,7 +1626,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="161">
+    <visual name="161">
       <pose>-6.40644 108.3508 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
@@ -1635,7 +1635,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="162">
+    <visual name="162">
       <pose>-35.4245 106.1635 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
@@ -1644,7 +1644,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="163">
+    <visual name="163">
       <pose>-77.5547 105.0318 1.524 0 0 0.463647623362</pose>
       <geometry>
         <box><size>1.2192 .60579 3.048</size></box>
@@ -1654,7 +1654,7 @@
       </material>
     </visual>
 
-<visual name="164">
+    <visual name="164">
       <pose>-72.6101 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.63218 .58702 3.048</size></box>
@@ -1663,7 +1663,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="165">
+    <visual name="165">
       <pose>-66.8076 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.94827 .58702 3.048</size></box>
@@ -1672,7 +1672,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="166">
+    <visual name="166">
       <pose>-64.2112 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.63218 .58702 3.048</size></box>
@@ -1681,7 +1681,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="167">
+    <visual name="167">
       <pose>-55.8348 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1690,7 +1690,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="168">
+    <visual name="168">
       <pose>-47.4585 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
@@ -1699,7 +1699,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="169">
+    <visual name="169">
       <pose>-39.08213 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1708,7 +1708,7 @@
         <diffuse>0.8471 0.8471 0.8471 1</diffuse>
       </material>
     </visual>
-<visual name="170">
+    <visual name="170">
       <pose>-30.6832 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
@@ -1718,1402 +1718,1257 @@
       </material>
     </visual>
 
-<collision name="23">
+    <collision name="23">
       <pose>-72.0231 18.4912 1.524 0 0 0</pose>
       <geometry>
         <box><size>5.508978 2.8448 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="24">
+    <collision name="24">
       <pose>-73.9648 21.22312 1.524 0 0 0</pose>
       <geometry>
         <box><size>1.6256 2.61902 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="25">
+    <collision name="25">
       <pose>-71.6619 88.32427 1.524 0 0 0.470404264136</pose>
       <geometry>
         <box><size>3.394271 3.8573 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="26">
+    <collision name="26">
       <pose>-27.432 18.71698 1.524 0 0 0</pose>
       <geometry>
         <box><size>4.380088 3.20604 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="27">
+    <collision name="27">
       <pose>-30.8904 19.8324 1.524 0 0 -0.505290184477</pose>
       <geometry>
         <box><size>4.850808 3.5175 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="28">
+    <collision name="28">
       <pose>-26.3031 68.86222 1.524 0 0 0</pose>
       <geometry>
         <box><size>2.8448 6.68302 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="29">
+    <collision name="29">
       <pose>-36.0793 68.8848 1.524 0 0 0</pose>
       <geometry>
         <box><size>.180622 9.07627 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="30">
+    <collision name="30">
       <pose>-27.8836 68.88437 1.524 0 0 0</pose>
       <geometry>
         <box><size>.316088 10.7288 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="31">
+    <collision name="31">
       <pose>-32.0176 64.12729 1.524 0 0 -0.097989311738</pose>
       <geometry>
         <box><size>7.945656 .43238 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="32">
+    <collision name="32">
       <pose>-32.0188 73.61092 1.524 0 0 0.0959625656</pose>
       <geometry>
         <box><size>7.936766 .50714 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="33">
+    <collision name="33">
       <pose>-23.5276 106.5671 1.524 0 0 0</pose>
       <geometry>
         <box><size>6.592712 3.16089 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="34">
+    <collision name="34">
       <pose>-25.4226 108.3056 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .31609 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="35">
+    <collision name="35">
       <pose>-47.2101 106.0252 1.524 0 0 0</pose>
       <geometry>
         <box><size>5.012266 3.07058 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="36">
+    <collision name="36">
       <pose>-47.5262 106.68 .0635 0 0 0</pose>
       <geometry>
         <box><size>60.82453 3.6576 .127</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="37">
+    <collision name="37">
       <pose>-78.4352 101.3291 1.524 0 0 0</pose>
       <geometry>
         <box><size>.995009 2.4384 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="38">
+    <collision name="38">
       <pose>-88.4597 108.3408 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="39">
+    <collision name="39">
       <pose>-88.4597 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="40">
+    <collision name="40">
       <pose>-88.6178 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>1.220788 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="41">
+    <collision name="41">
       <pose>-72.6101 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.633766 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="42">
+    <collision name="42">
       <pose>-64.2112 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="43">
+    <collision name="43">
       <pose>-55.8348 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.587022 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="44">
+    <collision name="44">
       <pose>-47.4585 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="45">
+    <collision name="45">
       <pose>-39.0821 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.587022 .63377 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="46">
+    <collision name="46">
       <pose>-30.6832 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.588609 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="47">
+    <collision name="47">
       <pose>-22.3068 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .6322 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="48">
+    <collision name="48">
       <pose>-16.5269 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.9047 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="49">
+    <collision name="49">
       <pose>-6.45724 100.426 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="50">
+    <collision name="50">
       <pose>-5.55413 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="51">
+    <collision name="51">
       <pose>-5.55413 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="52">
+    <collision name="52">
       <pose>-5.55413 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="53">
+    <collision name="53">
       <pose>-5.55413 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="54">
+    <collision name="54">
       <pose>-5.55413 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="55">
+    <collision name="55">
       <pose>-5.55413 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="56">
+    <collision name="56">
       <pose>-5.55413 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="57">
+    <collision name="57">
       <pose>-5.55413 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="58">
+    <collision name="58">
       <pose>-5.55413 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="59">
+    <collision name="59">
       <pose>-5.55413 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="60">
+    <collision name="60">
       <pose>-13.9305 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="61">
+    <collision name="61">
       <pose>-13.9305 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="62">
+    <collision name="62">
       <pose>-13.9305 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="63">
+    <collision name="63">
       <pose>-13.9305 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="64">
+    <collision name="64">
       <pose>-13.9305 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="65">
+    <collision name="65">
       <pose>-13.9305 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="66">
+    <collision name="66">
       <pose>-13.9305 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="67">
+    <collision name="67">
       <pose>-13.9305 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="68">
+    <collision name="68">
       <pose>-13.9305 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="69">
+    <collision name="69">
       <pose>-13.9305 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="70">
+    <collision name="70">
       <pose>-13.9305 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="71">
+    <collision name="71">
       <pose>-22.3068 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="72">
+    <collision name="72">
       <pose>-22.3068 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="73">
+    <collision name="73">
       <pose>-22.3068 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="74">
+    <collision name="74">
       <pose>-22.3068 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="75">
+    <collision name="75">
       <pose>-22.3068 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="76">
+    <collision name="76">
       <pose>-22.3068 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="77">
+    <collision name="77">
       <pose>-22.3068 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="78">
+    <collision name="78">
       <pose>-22.3068 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="79">
+    <collision name="79">
       <pose>-22.3068 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="80">
+    <collision name="80">
       <pose>-22.3068 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="81">
+    <collision name="81">
       <pose>-22.3068 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .64911 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="82">
+    <collision name="82">
       <pose>-30.6832 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="83">
+    <collision name="83">
       <pose>-30.6832 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="84">
+    <collision name="84">
       <pose>-30.6832 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="85">
+    <collision name="85">
       <pose>-30.6832 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="86">
+    <collision name="86">
       <pose>-30.6832 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="87">
+    <collision name="87">
       <pose>-30.6832 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="88">
+    <collision name="88">
       <pose>-30.6832 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="89">
+    <collision name="89">
       <pose>-30.6832 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="90">
+    <collision name="90">
       <pose>-39.0821 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="91">
+    <collision name="91">
       <pose>-39.0821 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="92">
+    <collision name="92">
       <pose>-39.0821 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="93">
+    <collision name="93">
       <pose>-39.0821 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="94">
+    <collision name="94">
       <pose>-39.0821 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="95">
+    <collision name="95">
       <pose>-39.0821 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="96">
+    <collision name="96">
       <pose>-39.0821 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="97">
+    <collision name="97">
       <pose>-39.0821 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="98">
+    <collision name="98">
       <pose>-39.0821 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="99">
+    <collision name="99">
       <pose>-39.0821 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="100">
+    <collision name="100">
       <pose>-39.0821 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="101">
+    <collision name="101">
       <pose>-47.45849 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="102">
+    <collision name="102">
       <pose>-47.45849 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="103">
+    <collision name="103">
       <pose>-47.45849 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="104">
+    <collision name="104">
       <pose>-47.45849 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="105">
+    <collision name="105">
       <pose>-47.45849 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="106">
+    <collision name="106">
       <pose>-47.45849 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="107">
+    <collision name="107">
       <pose>-47.45849 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="108">
+    <collision name="108">
       <pose>-47.45849 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="109">
+    <collision name="109">
       <pose>-47.45849 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="110">
+    <collision name="110">
       <pose>-47.45849 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="111">
+    <collision name="111">
       <pose>-47.45849 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="112">
+    <collision name="112">
       <pose>-55.8348 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="113">
+    <collision name="113">
       <pose>-55.8348 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="114">
+    <collision name="114">
       <pose>-55.8348 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="115">
+    <collision name="115">
       <pose>-55.8348 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="116">
+    <collision name="116">
       <pose>-55.8348 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="117">
+    <collision name="117">
       <pose>-55.8348 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="118">
+    <collision name="118">
       <pose>-55.8348 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="119">
+    <collision name="119">
       <pose>-55.8348 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="120">
+    <collision name="120">
       <pose>-55.8348 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="121">
+    <collision name="121">
       <pose>-55.8348 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="122">
+    <collision name="122">
       <pose>-55.8348 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="123">
+    <collision name="123">
       <pose>-64.2112 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="124">
+    <collision name="124">
       <pose>-64.2112 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="125">
+    <collision name="125">
       <pose>-64.2112 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="126">
+    <collision name="126">
       <pose>-64.2112 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="127">
+    <collision name="127">
       <pose>-64.2112 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="128">
+    <collision name="128">
       <pose>-64.2112 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="129">
+    <collision name="129">
       <pose>-64.2112 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="130">
+    <collision name="130">
       <pose>-64.2112 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="131">
+    <collision name="131">
       <pose>-64.2112 21.78756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="132">
+    <collision name="132">
       <pose>-64.2112 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="133">
+    <collision name="133">
       <pose>-64.2112 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="134">
+    <collision name="134">
       <pose>-72.6101 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="135">
+    <collision name="135">
       <pose>-72.6101 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="136">
+    <collision name="136">
       <pose>-72.6101 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="137">
+    <collision name="137">
       <pose>-72.6101 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="138">
+    <collision name="138">
       <pose>-72.6101 56.21867 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="139">
+    <collision name="139">
       <pose>-72.6101 47.39076 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="140">
+    <collision name="140">
       <pose>-72.6101 38.85636 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="141">
+    <collision name="141">
       <pose>-72.6101 30.32196 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 .94827 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="142">
+    <collision name="142">
       <pose>-72.6101 4.402666 1.524 0 0 0</pose>
       <geometry>
         <box><size>.632178 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="143">
+    <collision name="143">
       <pose>-80.9865 91.57547 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="144">
+    <collision name="144">
       <pose>-80.9865 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="145">
+    <collision name="145">
       <pose>-80.9865 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="146">
+    <collision name="146">
       <pose>-80.9865 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="147">
+    <collision name="147">
       <pose>-89.3854 82.74756 1.524 0 0 0</pose>
       <geometry>
         <box><size>1.2192 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="148">
+    <collision name="148">
       <pose>-89.3628 73.89707 1.524 0 0 0</pose>
       <geometry>
         <box><size>.90311 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="149">
+    <collision name="149">
       <pose>-89.3628 65.06916 1.524 0 0 0</pose>
       <geometry>
         <box><size>.90311 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="150">
+    <collision name="150">
       <pose>-73.31 13.25316 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 1.2192 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="151">
+    <collision name="151">
       <pose>-82.4315 13.23508 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>1.2192 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="152">
+    <collision name="152">
       <pose>-83.8087 21.76498 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>1.2192 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="153">
+    <collision name="153">
       <pose>-85.186 30.29938 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>1.2912 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="154">
+    <collision name="154">
       <pose>-86.5632 38.83378 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>.90311 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="155">
+    <collision name="155">
       <pose>-87.963 47.36818 1.524 0 0 0.189988286964</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="156">
+    <collision name="156">
       <pose>-76.4484 30.29938 1.524 0 0 0.15264932381</pose>
       <geometry>
         <box><size>.58702 1.2912 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="157">
+    <collision name="157">
       <pose>-77.8256 38.83378 1.524 0 0 0.15264932381</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="158">
+    <collision name="158">
       <pose>-79.2028 47.36818 1.524 0 0 0.15264932381</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="159">
+    <collision name="159">
       <pose>-80.6027 56.0832 1.524 0 0 0.15264932381</pose>
       <geometry>
         <box><size>.58702 .90311 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="160">
+    <collision name="160">
       <pose>-78.39 107.5154 1.524 0 0 0</pose>
       <geometry>
         <box><size>.90311 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="161">
+    <collision name="161">
      <pose>-16.5269 107.5154 1.524 0 0 0</pose>
       <geometry>
         <box><size>.63218 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="162">
+    <collision name="162">
       <pose>-6.40644 108.3508 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="163">
+    <collision name="163">
       <pose>-35.4245 106.1635 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .63218 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="164">
+    <collision name="164">
       <pose>-77.5547 105.0318 1.524 0 0 0.463647623362</pose>
       <geometry>
         <box><size>1.2192 .60579 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
 
-<collision name="165">
+    <collision name="165">
       <pose>-72.6101 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.63218 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="166">
+    <collision name="166">
       <pose>-66.8076 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.94827 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="167">
+    <collision name="167">
       <pose>-64.2112 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.63218 .58702 3.048</size></box>
       </geometry>
       <material>
-        
       </material>
     </collision>
-<collision name="168">
+    <collision name="168">
       <pose>-55.8348 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.58702 .58702 3.048</size></box>
       </geometry>
-      <material>        
+      <material>
       </material>
     </collision>
-<collision name="169">
+    <collision name="169">
       <pose>-47.4585 107.8992 1.524 0 0 0</pose>
       <geometry>
         <box><size>.903112 .58702 3.048</size></box>
       </geometry>
-      <material>       
-      </material>
-    </collision>
-<collision name="170">
-      <pose>-39.08213 107.8992 1.524 0 0 0</pose>
-      <geometry>
-        <box><size>.58702 .58702 3.048</size></box>
-      </geometry>
       <material>
       </material>
     </collision>
-<collision name="171">
-      <pose>-30.6832 107.8992 1.5240 0 0 0</pose>
-      <geometry>
-        <box><size>.58702 .58702 3.048</size></box>
-      </geometry>
-      <material>  
-      </material>
-    </collision>
-</link>
+      <collision name="170">
+        <pose>-39.08213 107.8992 1.524 0 0 0</pose>
+        <geometry>
+          <box><size>.58702 .58702 3.048</size></box>
+        </geometry>
+        <material>
+        </material>
+      </collision>
+      <collision name="171">
+        <pose>-30.6832 107.8992 1.5240 0 0 0</pose>
+        <geometry>
+          <box><size>.58702 .58702 3.048</size></box>
+        </geometry>
+        <material>
+        </material>
+      </collision>
+    </link>
 
- <link name="ground">
-    <inertial>
-      <mass>1</mass>
-      <inertia>
-        <ixx>10</ixx>
-        <ixy>0</ixy>
-        <ixz>0</ixz>
-        <iyy>10</iyy>
-        <iyz>0</iyz>
-        <izz>10</izz>
-      </inertia>
-    </inertial>
-    <visual name="171">
-      <pose>-47.4585 57.97973 -.0254 0 0 0</pose>
-      <geometry>
-        <box><size>92.47858 116.321 .0508</size></box>
-      </geometry>
-      <material>
-        <diffuse>0.3451 0.3451 0.3451 1</diffuse>
-      </material>
-   </visual>
-   <collision name="172">
-      <pose>-47.4585 57.97973 -.0254 0 0 0</pose>
-      <geometry>
-        <box><size>92.47858 116.321 .0508</size></box>
-      </geometry>
-      <material>  
-      </material>
-    </collision>
-  </link>
-  
-  <joint name="walls_ground" type="fixed">
-   <parent>ground</parent>
-   <child>outer_wall</child>
-   <pose>0 0 0 0 0 0</pose>
-   <axis><xyz>0 0 1</xyz></axis> 
-  </joint>
-  
-  <joint name="stairs_ground" type="fixed">
-   <parent>stairs</parent>
-   <child>outer_wall</child>
-   <pose>0 0 0 0 0 0</pose>
-   <axis><xyz>0 0 1</xyz></axis> 
-   </joint>
+    <link name="ground">
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>10</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>10</iyy>
+          <iyz>0</iyz>
+          <izz>10</izz>
+        </inertia>
+      </inertial>
+      <visual name="171">
+        <pose>-47.4585 57.97973 -.0254 0 0 0</pose>
+        <geometry>
+          <box><size>92.47858 116.321 .0508</size></box>
+        </geometry>
+        <material>
+          <diffuse>0.3451 0.3451 0.3451 1</diffuse>
+        </material>
+      </visual>
+      <collision name="172">
+        <pose>-47.4585 57.97973 -.0254 0 0 0</pose>
+        <geometry>
+          <box><size>92.47858 116.321 .0508</size></box>
+        </geometry>
+        <material>
+        </material>
+      </collision>
+    </link>
 
-</model>
+    <joint name="walls_ground" type="fixed">
+      <parent>ground</parent>
+      <child>outer_wall</child>
+      <pose>0 0 0 0 0 0</pose>
+      <axis><xyz>0 0 1</xyz></axis>
+    </joint>
+
+    <joint name="stairs_ground" type="fixed">
+      <parent>stairs</parent>
+      <child>outer_wall</child>
+      <pose>0 0 0 0 0 0</pose>
+      <axis><xyz>0 0 1</xyz></axis>
+    </joint>
+
+  </model>
 </sdf>


### PR DESCRIPTION
This change was pulled out of https://github.com/RobotLocomotion/drake/pull/2253 in an attempt to offer smaller PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2378) &emsp; Multiple assignees:&emsp;<img alt="@david-german-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17437069?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/david-german-tri">david-german-tri</a>,&emsp;<img alt="@jwnimmer-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596505?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/jwnimmer-tri">jwnimmer-tri</a>
<!-- Reviewable:end -->
