### PR TITLE
Include the correct export file in RigidBodyFrame.h.

### DIFF
--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -2,7 +2,7 @@
 
 #include <Eigen/Dense>
 
-#include "drake/drakeRBSystem_export.h"
+#include "drake/drakeRBM_export.h"
 #include "drake/systems/plants/RigidBody.h"
 
 namespace tinyxml2 {


### PR DESCRIPTION
Closes #2357 (but does not resolve the various issues in which LCM is unexpectedly absent)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2391) &emsp; Multiple assignees:&emsp;<img alt="@avalenzu" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/2574034?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/avalenzu">avalenzu</a>,&emsp;<img alt="@jwnimmer-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596505?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/jwnimmer-tri">jwnimmer-tri</a>
<!-- Reviewable:end -->
