### PR TITLE
Remove -source 1.6 from javac calls

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -31,10 +31,8 @@ endif()
 set(POD_NAME drake)
 include(cmake/pods.cmake)
 
-# set up Java, use a target of 1.6
 find_package(Java REQUIRED)
 include(UseJava)
-set(CMAKE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} -source 6 -target 6)
 
 function(drake_install_headers)
   file(RELATIVE_PATH rel_path ${PROJECT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Incorrect for several reasons:
1. We specific a minimum of 1.7 in the system requirements.
2. We do not set the class path to a location containing the 1.6 libraries (nor do they exist on CI and most developer's machines, I would imagine).
3. This correctly causes a warning to show on CDash for all builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2404)
<!-- Reviewable:end -->
