### PR TITLE
Fix some issues with NLopt which affected solving IK problems

### DIFF
--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -94,10 +94,10 @@ struct WrappedConstraint {
 
   const Constraint* constraint;
   const VariableList* variable_list;
-  bool force_bounds; ///< force usage of only upper or lower bounds
-  bool force_upper; ///< Only used if force_bounds is set.  Selects
-                    ///< which bounds are being tested (lower bound
-                    ///< vs. upper bound).
+  bool force_bounds;  ///< force usage of only upper or lower bounds
+  bool force_upper;  ///< Only used if force_bounds is set.  Selects
+                     ///< which bounds are being tested (lower bound
+                     ///< vs. upper bound).
   // TODO(sam.creasey) It might be desirable to have a cache for the
   // result of evaluating the constraints if NLopt were being used in
   // a situation where constraints were frequently being wrapped in

--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -215,8 +215,10 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
   }
 }
 
-template <typename C>
-void WrapConstraint(const OptimizationProblem::Binding<C>& binding,
+// We can't declare a variable of type OptimizationProblem::Binding,
+// since that's private and clang gets annoyed.
+template <typename _Binding>
+void WrapConstraint(const _Binding& binding,
                     double constraint_tol,
                     nlopt::opt* opt,
                     std::list<WrappedConstraint>* wrapped_list) {


### PR DESCRIPTION
This PR represents my attempt to make NLopt handle constraints with mixed equalities/inequalities, as well as inequalities with different upper and lower bounds.  It is not sufficient to actually enable NLopt for IK problems, as IK problems frequently (partially) duplicate some constraints, and NLopt has issues with this case, thus I have not enabled IK based on the presence of NLopt.

Eventual IPOPT integration should handle the IK cases in the absence of SNOPT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2417) &emsp; Multiple assignees:&emsp;<img alt="@Lucy-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17619120?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/Lucy-tri">Lucy-tri</a>,&emsp;<img alt="@ggould-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596413?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/ggould-tri">ggould-tri</a>
<!-- Reviewable:end -->
