### PR TITLE
Switch BasicVector::get_value() to return a VectorBlock.

### DIFF
--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -37,7 +37,9 @@ class BasicVector : public VectorInterface<T> {
     values_ = value;
   }
 
-  const VectorX<T>& get_value() const override { return values_; }
+  const Eigen::VectorBlock<const VectorX<T>> get_value() const override {
+    return values_.head(values_.rows());
+  }
 
   Eigen::VectorBlock<VectorX<T>> get_mutable_value() override {
     return values_.head(values_.rows());

--- a/drake/systems/framework/named_value_vector.h
+++ b/drake/systems/framework/named_value_vector.h
@@ -15,13 +15,13 @@ namespace systems {
 
 /// NamedValueVector is a low-performance convenience implementation of
 /// VectorInterface that labels each element in a column vector with a string.
-template <typename ScalarType>
-class NamedValueVector : public VectorInterface<ScalarType> {
+template <typename T>
+class NamedValueVector : public VectorInterface<T> {
  public:
-  /// Constructs a vector with one ScalarType element per name in names. Throws
+  /// Constructs a vector with one T element per name in names. Throws
   /// an std::runtime_error if names are not unique.
   explicit NamedValueVector(const std::vector<std::string>& names)
-      : values_(VectorX<ScalarType>::Zero(names.size(), 1 /* column */)),
+      : values_(VectorX<T>::Zero(names.size(), 1 /* column */)),
         names_(MakeNameMap(names)) {
     if (names_.size() != names.size()) {
       throw std::runtime_error("NamedValueVector has non-unique names.");
@@ -31,7 +31,7 @@ class NamedValueVector : public VectorInterface<ScalarType> {
   /// Constructs a vector with the names and values in named_values. Throws an
   /// std::runtime_error if names are not unique.
   NamedValueVector(
-      const std::vector<std::pair<std::string, ScalarType>>& named_values)
+      const std::vector<std::pair<std::string, T>>& named_values)
       : NamedValueVector(GetKeys(named_values)) {
     for (int i = 0; i < named_values.size(); ++i) {
       values_[i] = named_values[i].second;
@@ -40,7 +40,7 @@ class NamedValueVector : public VectorInterface<ScalarType> {
 
   ~NamedValueVector() override {}
 
-  void set_value(const VectorX<ScalarType>& value) override {
+  void set_value(const VectorX<T>& value) override {
     if (value.rows() != values_.rows()) {
       throw std::runtime_error("Cannot set a NamedValueVector of size " +
                                std::to_string(values_.rows()) +
@@ -50,9 +50,11 @@ class NamedValueVector : public VectorInterface<ScalarType> {
     values_ = value;
   }
 
-  const VectorX<ScalarType>& get_value() const override { return values_; }
+  const Eigen::VectorBlock<const VectorX<T>> get_value() const override {
+    return values_.head(values_.rows());
+  }
 
-  Eigen::VectorBlock<VectorX<ScalarType>> get_mutable_value() override {
+  Eigen::VectorBlock<VectorX<T>> get_mutable_value() override {
     return values_.head(values_.rows());
   }
 
@@ -62,7 +64,7 @@ class NamedValueVector : public VectorInterface<ScalarType> {
 
   /// Sets the element with the given name. Throws std::runtime_error if
   /// the name doesn't exist.
-  void set_named_value(const std::string& name, ScalarType value) {
+  void set_named_value(const std::string& name, T value) {
     auto it = names_.find(name);
     if (it != names_.end()) {
       values_(it->second) = value;
@@ -72,7 +74,7 @@ class NamedValueVector : public VectorInterface<ScalarType> {
   }
 
   /// Returns the value with a given name, or nullptr if it doesn't exist.
-  const ScalarType* get_named_value(const std::string& name) const {
+  const T* get_named_value(const std::string& name) const {
     auto it = names_.find(name);
     if (it != names_.end()) {
       return &values_(it->second);
@@ -94,7 +96,7 @@ class NamedValueVector : public VectorInterface<ScalarType> {
 
   // Extracts the first element of each pair in named_values, preserving order.
   static std::vector<std::string> GetKeys(
-      const std::vector<std::pair<std::string, ScalarType>>& named_values) {
+      const std::vector<std::pair<std::string, T>>& named_values) {
     std::vector<std::string> keys;
     for (const auto& named_value : named_values) {
       keys.push_back(named_value.first);
@@ -102,8 +104,8 @@ class NamedValueVector : public VectorInterface<ScalarType> {
     return keys;
   }
 
-  // The column vector of ScalarType values.
-  VectorX<ScalarType> values_;
+  // The column vector of values.
+  VectorX<T> values_;
   // A map from a name, to the corresponding index in values_.
   const std::map<std::string, size_t> names_;
 };

--- a/drake/systems/framework/vector_interface.h
+++ b/drake/systems/framework/vector_interface.h
@@ -5,8 +5,8 @@
 namespace drake {
 namespace systems {
 
-template <typename ScalarType>
-using VectorX = Eigen::Matrix<ScalarType, Eigen::Dynamic, 1 /* column */>;
+template <typename T>
+using VectorX = Eigen::Matrix<T, Eigen::Dynamic, 1 /* column */>;
 
 /// VectorInterface is a pure abstract interface that real-valued signals
 /// between Systems must satisfy. Classes that inherit from VectorInterface
@@ -14,29 +14,29 @@ using VectorX = Eigen::Matrix<ScalarType, Eigen::Dynamic, 1 /* column */>;
 /// provide other computations for the convenience of Systems handling the
 /// signal. The vector is always a column vector.
 ///
-/// @tparam ScalarType Must be a Scalar compatible with Eigen.
-template <typename ScalarType> class VectorInterface {
+/// @tparam T Must be a Scalar compatible with Eigen.
+template <typename T> class VectorInterface {
  public:
   virtual ~VectorInterface() {}
 
   // VectorInterface objects are neither copyable nor moveable.
-  VectorInterface(const VectorInterface<ScalarType>& other) = delete;
-  VectorInterface& operator=(const VectorInterface<ScalarType>& other) = delete;
-  VectorInterface(VectorInterface<ScalarType>&& other) = delete;
-  VectorInterface& operator=(VectorInterface<ScalarType>&& other) = delete;
+  VectorInterface(const VectorInterface<T>& other) = delete;
+  VectorInterface& operator=(const VectorInterface<T>& other) = delete;
+  VectorInterface(VectorInterface<T>&& other) = delete;
+  VectorInterface& operator=(VectorInterface<T>&& other) = delete;
 
   /// Sets the vector to the given value. After a.set_value(b.get_value()), a
   /// must be identical to b.
   /// May throw std::runtime_error if the new value has different dimensions
   /// than expected by the concrete class implementing VectorInterface.
-  virtual void set_value(const VectorX<ScalarType>& value) = 0;
+  virtual void set_value(const VectorX<T>& value) = 0;
 
   /// Returns a column vector containing the entire value of the signal.
-  virtual const VectorX<ScalarType>& get_value() const = 0;
+  virtual const Eigen::VectorBlock<const VectorX<T>> get_value() const = 0;
 
   /// Returns a reference that allows mutation of the values in this vector, but
   /// does not allow resizing the vector itself.
-  virtual Eigen::VectorBlock<VectorX<ScalarType>> get_mutable_value() = 0;
+  virtual Eigen::VectorBlock<VectorX<T>> get_mutable_value() = 0;
 
  protected:
   VectorInterface() {}


### PR DESCRIPTION
This is useful for VectorInterfaces that are views into other VectorInterfaces.

Also convert a bunch of ScalarType template variables to T.

+@sherm1 for both feature and platform review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2419)
<!-- Reviewable:end -->
