### PR TITLE
Fixed issue where the plot of the cost-to-go and the policy could not…

### DIFF
--- a/drake/examples/Pendulum/runValueIteration.m
+++ b/drake/examples/Pendulum/runValueIteration.m
@@ -11,10 +11,6 @@ ubins = linspace(-ulimit,ulimit,9);
 mdp = MarkovDecisionProcess.discretizeSystem(plant,cost,xbins,ubins,options);
 
 function drawfun(J,PI)
-  fig = sfigure(2);
-  % figure size is hard-coded simply so that it is aesthetically pleasing.
-  % parameters for position set through trial-and-error.
-  set(fig, 'units', 'normalized', 'position', [.4 .1 .2 .75]);
   clf;
   n1=length(xbins{1});
   n2=length(xbins{2});
@@ -30,6 +26,11 @@ function drawfun(J,PI)
   title('J(x)');
   drawnow;
 end
+
+fig = figure(2);
+% figure size is hard-coded simply so that it is aesthetically pleasing.
+% parameters for position set through trial-and-error.
+set(fig, 'units', 'normalized', 'position', [.4 .1 .2 .75]);
 
 [J,PI] = valueIteration(mdp,0.001,@drawfun);
 

--- a/drake/examples/Pendulum/runValueIteration.m
+++ b/drake/examples/Pendulum/runValueIteration.m
@@ -11,6 +11,7 @@ ubins = linspace(-ulimit,ulimit,9);
 mdp = MarkovDecisionProcess.discretizeSystem(plant,cost,xbins,ubins,options);
 
 function drawfun(J,PI)
+  sfigure(2);
   clf;
   n1=length(xbins{1});
   n2=length(xbins{2});


### PR DESCRIPTION
… be resized or moved from the default position.

(It's really irritating in the old version, and should definitely be fixed before 6.832 starts in the Fall).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2421)
<!-- Reviewable:end -->
