### PR TITLE
Add an exception when a feedback system creates an algebraic loop

### DIFF
--- a/drake/systems/feedback_system.h
+++ b/drake/systems/feedback_system.h
@@ -112,7 +112,8 @@ class FeedbackSystem {
   // y2 is sys2's output.
   // u1 is the input to sys1 (u + y2).
   //
-  // If want_y2_u1 is not set, y2 and u1 may or may not be computed.
+  // If want_y2_u1 is true, y2 and u1 are always computed.
+  // If want_y2_u1 is false, y2 and u1 may or may not be computed.
   template <typename ScalarType>
   void subsystemOutputs(const ScalarType& t,
                         const StateVector1<ScalarType>& x1,

--- a/drake/systems/test/feedback_system_test.cc
+++ b/drake/systems/test/feedback_system_test.cc
@@ -18,13 +18,14 @@ std::shared_ptr<
                                 EigenVector<NumOutputs1>::template type,
                                 EigenVector<NumInputs1>::template type>>>
 MakeFeedbackLoopOfAffineSystems(size_t num_states_1, size_t num_inputs_1,
-                                size_t num_outputs_1, size_t num_states_2) {
+                                size_t num_outputs_1, size_t num_states_2,
+                                bool feedthrough_1, bool feedthrough_2) {
   auto sys1_ptr = system_test::CreateRandomAffineSystem<NumStates1, NumInputs1,
                                                         NumOutputs1>(
-      num_states_1, num_inputs_1, num_outputs_1);
+      num_states_1, num_inputs_1, num_outputs_1, feedthrough_1);
   auto sys2_ptr = system_test::CreateRandomAffineSystem<NumStates2, NumOutputs1,
                                                         NumInputs1>(
-      num_states_2, num_outputs_1, num_inputs_1);
+      num_states_2, num_outputs_1, num_inputs_1, feedthrough_2);
   return feedback(sys1_ptr, sys2_ptr);
 }
 
@@ -32,7 +33,8 @@ MakeFeedbackLoopOfAffineSystems(size_t num_states_1, size_t num_inputs_1,
 // feedback loop is fixed at compile time, the number of states, inputs, and
 // outputs for the combined system matches up.
 TEST(FeedbackSystemTest, ConstantSizes) {
-  auto combined = MakeFeedbackLoopOfAffineSystems<4, 2, 3, 5>(4, 2, 3, 5);
+  auto combined =
+      MakeFeedbackLoopOfAffineSystems<4, 2, 3, 5>(4, 2, 3, 5, true, false);
   EXPECT_EQ(4 + 5, getNumStates(*combined));
   EXPECT_EQ(4 + 5, createStateVector<double>(*combined).size());
   EXPECT_EQ(2, getNumInputs(*combined));
@@ -44,12 +46,19 @@ TEST(FeedbackSystemTest, ConstantSizes) {
 // and outputs for the combined system matches up.
 TEST(FeedbackSystemTest, DynamicSizes) {
   auto combined =
-      MakeFeedbackLoopOfAffineSystems<Dynamic, Dynamic, Dynamic, Dynamic>(4, 2,
-                                                                          3, 5);
+      MakeFeedbackLoopOfAffineSystems<Dynamic, Dynamic, Dynamic, Dynamic>(
+          4, 2, 3, 5, false, true);
   EXPECT_EQ(4 + 5, getNumStates(*combined));
   EXPECT_EQ(4 + 5, createStateVector<double>(*combined).size());
   EXPECT_EQ(2, getNumInputs(*combined));
   EXPECT_EQ(3, getNumOutputs(*combined));
+}
+
+// Tests that algebraic loops are rejected.
+TEST(FeedbackSystemTest, AlgebraicLoop) {
+  EXPECT_THROW(
+      (MakeFeedbackLoopOfAffineSystems<1, 1, 1, 1>(1, 1, 1, 1, true, true)),
+      std::exception);
 }
 
 }  // namespace

--- a/drake/systems/test/feedback_system_test.cc
+++ b/drake/systems/test/feedback_system_test.cc
@@ -32,7 +32,7 @@ MakeFeedbackLoopOfAffineSystems(size_t num_states_1, size_t num_inputs_1,
 // Tests that, if the number of inputs and outputs for each system in the
 // feedback loop is fixed at compile time, the number of states, inputs, and
 // outputs for the combined system matches up.
-TEST(FeedbackSystemTest, ConstantSizes) {
+GTEST_TEST(FeedbackSystemTest, ConstantSizes) {
   auto combined =
       MakeFeedbackLoopOfAffineSystems<4, 2, 3, 5>(4, 2, 3, 5, true, false);
   EXPECT_EQ(4 + 5, getNumStates(*combined));
@@ -44,7 +44,7 @@ TEST(FeedbackSystemTest, ConstantSizes) {
 // Tests that, if the number of inputs and outputs for each system in the
 // feedback loop is determined at construction, the number of states, inputs,
 // and outputs for the combined system matches up.
-TEST(FeedbackSystemTest, DynamicSizes) {
+GTEST_TEST(FeedbackSystemTest, DynamicSizes) {
   auto combined =
       MakeFeedbackLoopOfAffineSystems<Dynamic, Dynamic, Dynamic, Dynamic>(
           4, 2, 3, 5, false, true);
@@ -55,7 +55,7 @@ TEST(FeedbackSystemTest, DynamicSizes) {
 }
 
 // Tests that algebraic loops are rejected.
-TEST(FeedbackSystemTest, AlgebraicLoop) {
+GTEST_TEST(FeedbackSystemTest, AlgebraicLoop) {
   EXPECT_THROW(
       (MakeFeedbackLoopOfAffineSystems<1, 1, 1, 1>(1, 1, 1, 1, true, true)),
       std::exception);

--- a/drake/systems/test/system_test_util.h
+++ b/drake/systems/test/system_test_util.h
@@ -14,7 +14,7 @@ std::shared_ptr<AffineSystem<EigenVector<StatesAtCompileTime>::template type,
                              EigenVector<InputsAtCompileTime>::template type,
                              EigenVector<OutputsAtCompileTime>::template type>>
 CreateRandomAffineSystem(size_t num_states, size_t num_inputs,
-                         size_t num_outputs) {
+                         size_t num_outputs, bool direct_feedthrough = true) {
   using ReturnType =
       AffineSystem<EigenVector<StatesAtCompileTime>::template type,
                    EigenVector<InputsAtCompileTime>::template type,
@@ -33,7 +33,11 @@ CreateRandomAffineSystem(size_t num_states, size_t num_inputs,
           num_outputs, num_states)
           .eval();
   auto D =
+      direct_feedthrough ?
       Eigen::Matrix<double, OutputsAtCompileTime, InputsAtCompileTime>::Random(
+          num_outputs, num_inputs)
+          .eval() :
+      Eigen::Matrix<double, OutputsAtCompileTime, InputsAtCompileTime>::Zero(
           num_outputs, num_inputs)
           .eval();
   auto xdot0 =


### PR DESCRIPTION
Closes #2298.

Benchmarked with runQuadrotorLQR with realtime_factor=0.0 (as fast as possible) for 1000 seconds of simulated time.  New performance is indistinguishable from prior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2423) &emsp; Multiple assignees:&emsp;<img alt="@liangfok" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/1388098?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/liangfok">liangfok</a>,&emsp;<img alt="@sherm1" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/4088016?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/sherm1">sherm1</a>
<!-- Reviewable:end -->
