### PR TITLE
Header missing from install list

### DIFF
--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -18,6 +18,7 @@ set(installed_headers
     cache.h
     context.h
     named_value_vector.h
+    state.h
     system_interface.h
     system_output.h
     value.h


### PR DESCRIPTION
Header `state.h` was left off the list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2425) &emsp; Multiple assignees:&emsp;<img alt="@david-german-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17437069?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/david-german-tri">david-german-tri</a>,&emsp;<img alt="@sherm1" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/4088016?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/sherm1">sherm1</a>
<!-- Reviewable:end -->
