### PR TITLE
Disable Atlas and Valkyrie tests that are flaky in continuous

### DIFF
--- a/drake/examples/Atlas/CMakeLists.txt
+++ b/drake/examples/Atlas/CMakeLists.txt
@@ -23,9 +23,15 @@ if (LONG_RUNNING_TESTS)
   add_matlab_test(NAME examples/Atlas/runAtlasBalancingWithContactSensor COMMAND runAtlasBalancingWithContactSensor PROPERTIES TIMEOUT 1500)
   add_matlab_test(NAME examples/Atlas/runAtlasHandControl COMMAND runAtlasHandControl PROPERTIES TIMEOUT 3000)
   add_matlab_test(NAME examples/Atlas/runAtlasManip COMMAND runAtlasManip PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/runAtlasWalking COMMAND runAtlasWalking PROPERTIES TIMEOUT 1500)
+
+  # Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
+  # add_matlab_test(NAME examples/Atlas/runAtlasWalking COMMAND runAtlasWalking PROPERTIES TIMEOUT 1500)
+
+add_matlab_test(NAME examples/Atlas/runRobotiqTendons COMMAND runRobotiqTendons PROPERTIES TIMEOUT 1500)
+
+  # Deactivated due to excessive timeouts.
   # add_matlab_test(NAME examples/Atlas/runDRCPracticeTerrain COMMAND runDRCPracticeTerrain PROPERTIES TIMEOUT 3000)  # FIXME
-  add_matlab_test(NAME examples/Atlas/runRobotiqTendons COMMAND runRobotiqTendons PROPERTIES TIMEOUT 1500)
+
 endif()
 
 add_subdirectory(test)

--- a/drake/examples/Atlas/test/CMakeLists.txt
+++ b/drake/examples/Atlas/test/CMakeLists.txt
@@ -1,16 +1,19 @@
 
 if (LONG_RUNNING_TESTS)
   add_matlab_test(NAME examples/Atlas/test/multiRobotTest COMMAND multiRobotTest PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/test/runAtlasFastBackwardWalking COMMAND runAtlasFastBackwardWalking PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/test/runAtlasFastWalking COMMAND runAtlasFastWalking PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/test/runAtlasTurning COMMAND runAtlasTurning PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/test/runAtlasTurning270 COMMAND runAtlasTurning270 PROPERTIES TIMEOUT 1500)
+
+  # Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
+  # add_matlab_test(NAME examples/Atlas/test/runAtlasFastBackwardWalking COMMAND runAtlasFastBackwardWalking PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Atlas/test/runAtlasFastWalking COMMAND runAtlasFastWalking PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Atlas/test/runAtlasTurning COMMAND runAtlasTurning PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Atlas/test/runAtlasTurning270 COMMAND runAtlasTurning270 PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingNarrowStairs COMMAND runAtlasWalkingNarrowStairs PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingStairs COMMAND runAtlasWalkingStairs PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingTestWraparound COMMAND runAtlasWalkingTestWraparound PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingTiltedBlocks COMMAND runAtlasWalkingTiltedBlocks PROPERTIES TIMEOUT 1500)
+
   add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingDownStairs COMMAND runAtlasWalkingDownStairs PROPERTIES TIMEOUT 1500)
   add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingHeelSupport COMMAND runAtlasWalkingHeelSupport PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingNarrowStairs COMMAND runAtlasWalkingNarrowStairs PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingStairs COMMAND runAtlasWalkingStairs PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingTestWraparound COMMAND runAtlasWalkingTestWraparound PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Atlas/test/runAtlasWalkingTiltedBlocks COMMAND runAtlasWalkingTiltedBlocks PROPERTIES TIMEOUT 1500)
 endif()
 
 add_matlab_test(NAME examples/Atlas/test/runDRCDrillTask COMMAND runDRCDrillTask)

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -2,7 +2,8 @@
 if (LONG_RUNNING_TESTS)
   add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancing COMMAND runValkyrieBalancing PROPERTIES TIMEOUT 1500)
   add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancingPerturb COMMAND runValkyrieBalancingPerturb PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking COMMAND runValkyrieWalking PROPERTIES TIMEOUT 1500)
+  # Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
+  # add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking COMMAND runValkyrieWalking PROPERTIES TIMEOUT 1500)
 endif()
 
 add_matlab_test(NAME examples/Valkyrie/runValkyrieVisualize COMMAND runValkyrieVisualize)

--- a/drake/examples/Valkyrie/test/CMakeLists.txt
+++ b/drake/examples/Valkyrie/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 if (LONG_RUNNING_TESTS)
-  add_matlab_test(NAME examples/Valkyrie/test/runValkyrieFastWalking COMMAND runValkyrieFastWalking PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Valkyrie/test/runValkyrieTurning COMMAND runValkyrieTurning PROPERTIES TIMEOUT 1500)
-  add_matlab_test(NAME examples/Valkyrie/test/runValkyrieTurning270 COMMAND runValkyrieTurning270 PROPERTIES TIMEOUT 1500)
+  # Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
+  # add_matlab_test(NAME examples/Valkyrie/test/runValkyrieFastWalking COMMAND runValkyrieFastWalking PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Valkyrie/test/runValkyrieTurning COMMAND runValkyrieTurning PROPERTIES TIMEOUT 1500)
+  # add_matlab_test(NAME examples/Valkyrie/test/runValkyrieTurning270 COMMAND runValkyrieTurning270 PROPERTIES TIMEOUT 1500)
 endif()


### PR DESCRIPTION
See #2165, #2376.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2432) &emsp; Multiple assignees:&emsp;<img alt="@RussTedrake" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/6442292?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/RussTedrake">RussTedrake</a>,&emsp;<img alt="@sherm1" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/4088016?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/sherm1">sherm1</a>
<!-- Reviewable:end -->
