### PR TITLE
In gcc and clang, only turn on -Werror for warnings covered by -Wall

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -61,8 +61,7 @@ include_directories(BEFORE ${PROJECT_SOURCE_DIR}/..)
 
 
 if (CMAKE_COMPILER_IS_GNUCC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all")
   # TODO(#2372) These are warnings that we can't handle yet.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
@@ -76,7 +75,12 @@ if (CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wreturn-type -Wuninitialized -Wunused-variable")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedef")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
   if (APPLE)  # this was a step towards getting things to work with


### PR DESCRIPTION
In gcc and clang, only turn on -Werror for warnings covered by -Wall.  This way, things like -pedantic can still be turned on without breaking the build.  Also remove some -Wfoo items in clang that are subsumed by -Wall.  Also suppress some clang items within -Wall that are showing up as failures for me; I don't know why they are passing on master.

This might mitigate and/of fully resolve the msan nightly-build break mentioned in #2428, but in any case still seems like a good idea -- only the warnings we've opted into turn into errors, instead of any warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2437) &emsp; Multiple assignees:&emsp;<img alt="@david-german-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17437069?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/david-german-tri">david-german-tri</a>,&emsp;<img alt="@rpoyner-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17582368?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/rpoyner-tri">rpoyner-tri</a>
<!-- Reviewable:end -->
