### PR TITLE
Trigpoly feature parity reapply

### DIFF
--- a/drake/examples/Atlas/CMakeLists.txt
+++ b/drake/examples/Atlas/CMakeLists.txt
@@ -14,7 +14,10 @@ add_matlab_test(NAME examples/Atlas/runAtlasJumping COMMAND runAtlasJumping)
 add_matlab_test(NAME examples/Atlas/runAtlasSagittalDynamics COMMAND runAtlasSagittalDynamics)
 add_matlab_test(NAME examples/Atlas/runAtlasWalkingPlanning COMMAND runAtlasWalkingPlanning)
 add_matlab_test(NAME examples/Atlas/runCOMFixedPointSearch COMMAND runCOMFixedPointSearch)
-add_matlab_test(NAME examples/Atlas/runDRCDoorTask COMMAND runDRCDoorTask)
+
+# Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
+# add_matlab_test(NAME examples/Atlas/runDRCDoorTask COMMAND runDRCDoorTask)
+
 add_matlab_test(NAME examples/Atlas/runRobotiqPDControl COMMAND runRobotiqPDControl)
 
 if (LONG_RUNNING_TESTS)

--- a/drake/util/Polynomial.cpp
+++ b/drake/util/Polynomial.cpp
@@ -1,6 +1,8 @@
 #include "drake/util/Polynomial.h"
-#include <stdexcept>
+
 #include <cstring>
+#include <set>
+#include <stdexcept>
 
 using namespace std;
 using namespace Eigen;
@@ -294,9 +296,13 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::integral(
 template <typename CoefficientType>
 bool Polynomial<CoefficientType>::operator==(
     const Polynomial<CoefficientType>& other) const {
-  const std::set<Monomial> this_monomials(monomials.begin(), monomials.end());
-  const std::set<Monomial> other_monomials(other.monomials.begin(),
-                                           other.monomials.end());
+  // Comparison of unsorted vectors is faster copying them into std::set
+  // btrees rather than using std::is_permutation().
+  // TODO(#2216) switch from multiset to set for further performance gains.
+  const std::multiset<Monomial> this_monomials(monomials.begin(),
+                                               monomials.end());
+  const std::multiset<Monomial> other_monomials(other.monomials.begin(),
+                                                other.monomials.end());
   return this_monomials == other_monomials;
 }
 

--- a/drake/util/Polynomial.cpp
+++ b/drake/util/Polynomial.cpp
@@ -292,6 +292,15 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::integral(
 }
 
 template <typename CoefficientType>
+bool Polynomial<CoefficientType>::operator==(
+    const Polynomial<CoefficientType>& other) const {
+  const std::set<Monomial> this_monomials(monomials.begin(), monomials.end());
+  const std::set<Monomial> other_monomials(other.monomials.begin(),
+                                           other.monomials.end());
+  return this_monomials == other_monomials;
+}
+
+template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
     const Polynomial<CoefficientType>& other) {
   for (typename vector<Monomial>::const_iterator iter = other.monomials.begin();
@@ -543,6 +552,10 @@ template <typename CoefficientType>
 void Polynomial<CoefficientType>::makeMonomialsUnique(void) {
   VarType unique_var = 0;  // also update the univariate flag
   for (ptrdiff_t i = monomials.size() - 1; i >= 0; i--) {
+    if (monomials[i].coefficient == 0) {
+      monomials.erase(monomials.begin() + i);
+      continue;
+    }
     Monomial& mi = monomials[i];
     if (!mi.terms.empty()) {
       if (mi.terms.size() > 1) is_univariate = false;

--- a/drake/util/Polynomial.h
+++ b/drake/util/Polynomial.h
@@ -289,6 +289,8 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    */
   Polynomial integral(const CoefficientType& integration_constant = 0.0) const;
 
+  bool operator==(const Polynomial& other) const;
+
   Polynomial& operator+=(const Polynomial& other);
 
   Polynomial& operator-=(const Polynomial& other);

--- a/drake/util/test/CMakeLists.txt
+++ b/drake/util/test/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(testConvexHull drakeConvexHull)
 add_test(NAME testConvexHull COMMAND testConvexHull)
 
 add_executable(testTrigPoly testTrigPoly.cpp)
-target_link_libraries(testTrigPoly drakePolynomial)
+target_link_libraries(testTrigPoly drakePolynomial ${GTEST_BOTH_LIBRARIES})
 add_test(NAME testTrigPoly COMMAND testTrigPoly)
 
 if (GTEST_FOUND)

--- a/drake/util/test/CMakeLists.txt
+++ b/drake/util/test/CMakeLists.txt
@@ -27,11 +27,11 @@ add_executable(testConvexHull testConvexHull.cpp)
 target_link_libraries(testConvexHull drakeConvexHull)
 add_test(NAME testConvexHull COMMAND testConvexHull)
 
-add_executable(testTrigPoly testTrigPoly.cpp)
-target_link_libraries(testTrigPoly drakePolynomial ${GTEST_BOTH_LIBRARIES})
-add_test(NAME testTrigPoly COMMAND testTrigPoly)
-
 if (GTEST_FOUND)
+  add_executable(testTrigPoly testTrigPoly.cpp)
+  target_link_libraries(testTrigPoly drakePolynomial ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME testTrigPoly COMMAND testTrigPoly)
+
   add_executable(testDrakeGeometryUtil testDrakeGeometryUtil.cpp)
   target_link_libraries(testDrakeGeometryUtil drakeGeometryUtil ${GTEST_BOTH_LIBRARIES})
   add_test(NAME testDrakeGeometryUtil COMMAND testDrakeGeometryUtil)

--- a/drake/util/test/testPolynomial.cpp
+++ b/drake/util/test/testPolynomial.cpp
@@ -92,6 +92,10 @@ void testOperators() {
                poly1.evaluateUnivariate(t) / scalar, 1e-8);
     valuecheck(poly1_times_poly1.evaluateUnivariate(t),
                poly1.evaluateUnivariate(t) * poly1.evaluateUnivariate(t), 1e-8);
+
+    // Check the '==' operator.
+    EXPECT_TRUE(poly1 + poly2 == sum);
+    EXPECT_FALSE(poly1 == sum);
   }
 }
 
@@ -346,6 +350,14 @@ GTEST_TEST(PolynomialTest, EvaluatePartial) {
   EXPECT_EQ(
       dut.evaluatePartial(eval_point_y).evaluateMultivariate(eval_point_x),
       expected_result);
+
+  // Test that zeroing out one term gives a sensible result.
+  EXPECT_EQ(dut.evaluatePartial(
+      std::map<Polynomiald::VarType, double>{{x.getSimpleVariable(), 0}}),
+            (2 * y) + 1);
+  EXPECT_EQ(dut.evaluatePartial(
+      std::map<Polynomiald::VarType, double>{{y.getSimpleVariable(), 0}}),
+            (5 * x * x * x) + 1);
 }
 
 }  // anonymous namespace

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -14,6 +14,9 @@ namespace drake {
 namespace util {
 namespace {
 
+typedef std::map<TrigPolyd::VarType, double> MapType;
+const double kPi = 3.1415926535897;
+
 void test_serialization(TrigPolyd dut, std::string expect) {
   std::stringstream test_stream;
   test_stream << dut;
@@ -38,6 +41,41 @@ TEST(TrigPolyTest, SmokeTest) {
   test_serialization(cos(p), "c1");
   test_serialization(sin(p) * p * p + cos(p), "s1*q1^2+c1");
   test_serialization(sin(p + p), "s1*c1+c1*s1");
+}
+
+TEST(TrigPolyTest, EvaluateMultivariateTest) {
+  const TrigPolyd theta(Polynomiald("th"),
+                        Polynomiald("sth"), Polynomiald("cth"));
+  const TrigPolyd::VarType theta_var =
+      theta.getPolynomial().getSimpleVariable();
+
+  // Check some basic evaluations.
+  EXPECT_EQ(theta.evaluateMultivariate(MapType {{theta_var, 1}}), 1);
+  EXPECT_EQ(sin(theta).evaluateMultivariate(MapType {{theta_var, 0}}), 0);
+  EXPECT_EQ(cos(theta).evaluateMultivariate(MapType {{theta_var, 0}}), 1);
+
+  // Test that the pythagorean theorem is true for various angles.
+  for (const double angle : {0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4}) {
+    EXPECT_NEAR((sin(theta) * sin(theta) + cos(theta) * cos(theta) - 1)
+                .evaluateMultivariate(MapType {{theta_var, angle}}),
+                0,
+                1e-6);
+  }
+
+  // Test an arbitrary multivariate polynomial.
+  const TrigPolyd phi(Polynomiald("phi"),
+                      Polynomiald("sphi"), Polynomiald("cphi"));
+  const TrigPolyd::VarType phi_var = phi.getPolynomial().getSimpleVariable();
+  const TrigPolyd multivariate = theta + phi * cos(theta) + sin(phi + theta);
+  for (const double theta_value : {0., 1., kPi / 4, kPi / 2, -kPi / 4}) {
+    for (const double phi_value : {0., 1., kPi / 4, kPi / 2, -kPi / 4}) {
+      EXPECT_NEAR(multivariate.evaluateMultivariate(
+          MapType {{theta_var, theta_value}, {phi_var, phi_value}}),
+                  (theta_value + (phi_value * std::cos(theta_value)) +
+                   std::sin(phi_value + theta_value)),
+                  1e-6) << "phi: " << phi_value << " theta: " << theta_value;
+    }
+  }
 }
 
 }  // anonymous namespace

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <sstream>
 #include <map>
 
@@ -76,6 +75,20 @@ TEST(TrigPolyTest, EvaluateMultivariateTest) {
                   1e-6) << "phi: " << phi_value << " theta: " << theta_value;
     }
   }
+}
+
+TEST(TrigPolyTest, EvaluatePartialTest) {
+  const TrigPolyd theta(Polynomiald("th"),
+                        Polynomiald("sth"), Polynomiald("cth"));
+  const TrigPolyd::VarType theta_var =
+      theta.getPolynomial().getSimpleVariable();
+  const TrigPolyd phi(Polynomiald("phi"),
+                      Polynomiald("sphi"), Polynomiald("cphi"));
+  const TrigPolyd::VarType phi_var = phi.getPolynomial().getSimpleVariable();
+  const TrigPolyd multivariate = theta + phi * cos(theta) + sin(phi + theta);
+
+  EXPECT_EQ(multivariate.evaluatePartial(MapType {{theta_var, 0}}),
+            phi + sin(phi));
 }
 
 }  // anonymous namespace

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -1,10 +1,26 @@
-#include "drake/util/TrigPoly.h"
 #include <iostream>
+#include <sstream>
+#include <map>
+
+#include "gtest/gtest.h"
+
+#include "drake/util/Polynomial.h"
+#include "drake/util/TrigPoly.h"
 
 using namespace Eigen;
 using namespace std;
 
-int main(int argc, char **argv) {
+namespace drake {
+namespace util {
+namespace {
+
+void test_serialization(TrigPolyd dut, std::string expect) {
+  std::stringstream test_stream;
+  test_stream << dut;
+  EXPECT_EQ(test_stream.str(), expect);
+}
+
+TEST(TrigPolyTest, SmokeTest) {
   // Confirm that these conversions compile okay.
   TrigPolyd x(1.0);
   TrigPolyd y = 2.0;
@@ -17,10 +33,13 @@ int main(int argc, char **argv) {
 
   TrigPolyd p(q, s, c);
 
-  cout << p << endl;
-  cout << sin(p) << endl;
-  cout << cos(p) << endl;
-  cout << (sin(p) * p * p + cos(p)) << endl;
-
-  cout << "sin(p + p) = " << sin(p + p) << endl;
+  test_serialization(p, "q1");
+  test_serialization(sin(p), "s1");
+  test_serialization(cos(p), "c1");
+  test_serialization(sin(p) * p * p + cos(p), "s1*q1^2+c1");
+  test_serialization(sin(p + p), "s1*c1+c1*s1");
 }
+
+}  // anonymous namespace
+}  // namespace test
+}  // namespace drake

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -89,6 +89,13 @@ TEST(TrigPolyTest, EvaluatePartialTest) {
 
   EXPECT_EQ(multivariate.evaluatePartial(MapType {{theta_var, 0}}),
             phi + sin(phi));
+  EXPECT_EQ(multivariate.evaluatePartial(MapType {{phi_var, 0}}),
+            theta + sin(theta));
+  // TODO(#2216) This fails due to a known drake bug:
+#if 0
+  EXPECT_EQ(multivariate.evaluatePartial(MapType {{phi_var, 1}}),
+            theta + cos(theta) + sin(theta + 1));
+#endif
 }
 
 }  // anonymous namespace

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -23,7 +23,7 @@ void TestSerialization(TrigPolyd dut, std::string expect) {
   EXPECT_EQ(test_stream.str(), expect);
 }
 
-TEST(TrigPolyTest, SmokeTest) {
+GTEST_TEST(TrigPolyTest, SmokeTest) {
   // Confirm that these conversions compile okay.
   TrigPolyd x(1.0);
   TrigPolyd y = 2.0;
@@ -47,7 +47,7 @@ TEST(TrigPolyTest, SmokeTest) {
   TestSerialization(sin(p + p), "s1*c1+c1*s1");
 }
 
-TEST(TrigPolyTest, EvaluateMultivariateTest) {
+GTEST_TEST(TrigPolyTest, EvaluateMultivariateTest) {
   const TrigPolyd theta(Polynomiald("th"),
                         Polynomiald("sth"), Polynomiald("cth"));
   const TrigPolyd::VarType theta_var =
@@ -82,7 +82,7 @@ TEST(TrigPolyTest, EvaluateMultivariateTest) {
   }
 }
 
-TEST(TrigPolyTest, EvaluatePartialTest) {
+GTEST_TEST(TrigPolyTest, EvaluatePartialTest) {
   const TrigPolyd theta(Polynomiald("th"),
                         Polynomiald("sth"), Polynomiald("cth"));
   const TrigPolyd::VarType theta_var =

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -1,10 +1,11 @@
+#include "drake/util/TrigPoly.h"
+
 #include <sstream>
 #include <map>
 
 #include "gtest/gtest.h"
 
 #include "drake/util/Polynomial.h"
-#include "drake/util/TrigPoly.h"
 
 using namespace Eigen;
 using namespace std;
@@ -16,7 +17,7 @@ namespace {
 typedef std::map<TrigPolyd::VarType, double> MapType;
 const double kPi = 3.1415926535897;
 
-void test_serialization(TrigPolyd dut, std::string expect) {
+void TestSerialization(TrigPolyd dut, std::string expect) {
   std::stringstream test_stream;
   test_stream << dut;
   EXPECT_EQ(test_stream.str(), expect);
@@ -35,11 +36,15 @@ TEST(TrigPolyTest, SmokeTest) {
 
   TrigPolyd p(q, s, c);
 
-  test_serialization(p, "q1");
-  test_serialization(sin(p), "s1");
-  test_serialization(cos(p), "c1");
-  test_serialization(sin(p) * p * p + cos(p), "s1*q1^2+c1");
-  test_serialization(sin(p + p), "s1*c1+c1*s1");
+  TestSerialization(p, "q1");
+  TestSerialization(sin(p), "s1");
+  TestSerialization(cos(p), "c1");
+
+  // The following results could reasonably change if Polynomial changes its
+  // monomial sorting or fixes #2216.  They are retained here to catch any
+  // inadvertent changes to this behaviour.
+  TestSerialization(sin(p) * p * p + cos(p), "s1*q1^2+c1");
+  TestSerialization(sin(p + p), "s1*c1+c1*s1");
 }
 
 TEST(TrigPolyTest, EvaluateMultivariateTest) {
@@ -99,5 +104,5 @@ TEST(TrigPolyTest, EvaluatePartialTest) {
 }
 
 }  // anonymous namespace
-}  // namespace test
+}  // namespace util
 }  // namespace drake


### PR DESCRIPTION
Reapply #2345 now that offending tests have been nerfed in #2432 

This change has already been fully reviewed, as it is a conflict-free cherry-pick of #2345 onto current master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2440) &emsp; Multiple assignees:&emsp;<img alt="@david-german-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17437069?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/david-german-tri">david-german-tri</a>,&emsp;<img alt="@sammy-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596504?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/sammy-tri">sammy-tri</a>
<!-- Reviewable:end -->
