### PR TITLE
Fix error warnings

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -77,6 +77,9 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
+  endif()
 
   if (APPLE)  # this was a step towards getting things to work with
   #   clang on mac, but ultimately we didn't get there...   (but I would

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -60,25 +60,24 @@ include_directories(BEFORE ${PROJECT_BINARY_DIR}/exports/)
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/..)
 
 
-if (CMAKE_COMPILER_IS_GNUCC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7)
+    message(FATAL_ERROR "GCC version must be at least 4.7")
+  endif()
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=reorder")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=uninitialized")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=unused-variable")
+
   # TODO(#2372) These are warnings that we can't handle yet.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
 
-  execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-  if (NOT (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7))
-    message(FATAL_ERROR "requires gcc version >= 4.7")  # to support the c++0x flag below
-  else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-  endif()
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wreturn-type -Wuninitialized -Wunused-variable")
-
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
   if (APPLE)  # this was a step towards getting things to work with
   #   clang on mac, but ultimately we didn't get there...   (but I would
   #   be worried about sharing pointers between objects compiled against

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -75,10 +75,12 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
   # TODO(#2372) These are warnings that we can't handle yet.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
   endif()
 
   if (APPLE)  # this was a step towards getting things to work with

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -68,10 +68,6 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=reorder")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=uninitialized")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=unused-variable")
 
   # TODO(#2372) These are warnings that we can't handle yet.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")

--- a/drake/examples/Cars/curve2.h
+++ b/drake/examples/Cars/curve2.h
@@ -41,8 +41,8 @@ class Curve2 {
 
   /// A result type for the GetPosition method.
   struct PositionResult {
-    Point2 position{Point2::Zero()};
-    Point2 position_dot{Point2::Zero()};
+    Point2 position = Point2{Point2::Zero()};
+    Point2 position_dot = Point2{Point2::Zero()};
   };
 
   /// Returns the Curve's @p PositionResult::position at @p path_distance,

--- a/drake/examples/Quadrotor/Quadrotor.h
+++ b/drake/examples/Quadrotor/Quadrotor.h
@@ -141,7 +141,7 @@ class Quadrotor {
   template <typename ScalarType>
   using InputVector = QuadrotorInput<ScalarType>;
 
-  Quadrotor() : m(0.5), g(9.81), L(0.1750), I(Eigen::Matrix3d::Identity()) {
+  Quadrotor() : g(9.81), L(0.1750), m(0.5), I(Eigen::Matrix3d::Identity()) {
     I(0, 0) = 0.0023;
     I(1, 1) = 0.0023;
     I(2, 2) = 0.004;

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -247,10 +247,10 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       // to int so it is odr-used (see
   // https://gcc.gnu.org/wiki/VerboseDiagnostics#missing_static_const_definition)
   OptimizationProblem()
-      : problem_type_(MathematicalProgramInterface::GetLeastSquaresProgram()),
-        num_vars_(0),
+      : num_vars_(0),
         x_initial_guess_(
             static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)),
+        problem_type_(MathematicalProgramInterface::GetLeastSquaresProgram()),
       solver_result_(0) {}
 
   const DecisionVariableView AddContinuousVariables(std::size_t num_new_vars,

--- a/drake/systems/LCMSystem.h
+++ b/drake/systems/LCMSystem.h
@@ -207,7 +207,7 @@ class DRAKELCMSYSTEM_EXPORT LCMLoop {
   bool stop;
   lcm::LCM &lcm;
 
-  explicit LCMLoop(lcm::LCM &_lcm) : lcm(_lcm), stop(false) {}
+  explicit LCMLoop(lcm::LCM &_lcm) : stop(false), lcm(_lcm) {}
 
   void loopWithSelect();
 };

--- a/drake/systems/controllers/InstantaneousQPController.h
+++ b/drake/systems/controllers/InstantaneousQPController.h
@@ -20,18 +20,18 @@ class InstantaneousQPController {
       const std::map<std::string, QPControllerParams>& param_sets_in,
       const RobotPropertyCache& rpc_in)
       : robot(std::move(robot_in)),
-        cache(this->robot->bodies),
         param_sets(param_sets_in),
         rpc(rpc_in),
-        use_fast_qp(INSTQP_USE_FASTQP) {
+        use_fast_qp(INSTQP_USE_FASTQP),
+        cache(this->robot->bodies) {
     initialize();
   }
 
   InstantaneousQPController(std::unique_ptr<RigidBodyTree> robot_in,
                             const std::string& control_config_filename)
       : robot(std::move(robot_in)),
-        cache(this->robot->bodies),
-        use_fast_qp(INSTQP_USE_FASTQP) {
+        use_fast_qp(INSTQP_USE_FASTQP),
+        cache(this->robot->bodies) {
     loadConfigurationFromYAML(control_config_filename);
     initialize();
   }
@@ -39,8 +39,8 @@ class InstantaneousQPController {
   InstantaneousQPController(const std::string& urdf_filename,
                             const std::string& control_config_filename)
       : robot(std::unique_ptr<RigidBodyTree>(new RigidBodyTree(urdf_filename))),
-        cache(this->robot->bodies),
-        use_fast_qp(INSTQP_USE_FASTQP) {
+        use_fast_qp(INSTQP_USE_FASTQP),
+        cache(this->robot->bodies) {
     loadConfigurationFromYAML(control_config_filename);
     initialize();
   }

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -14,9 +14,9 @@ using std::stringstream;
 using std::vector;
 
 RigidBody::RigidBody()
-    : parent(nullptr),
-      collision_filter_group(DrakeCollision::DEFAULT_GROUP),
-      collision_filter_ignores(DrakeCollision::NONE_MASK) {
+    : collision_filter_group(DrakeCollision::DEFAULT_GROUP),
+      collision_filter_ignores(DrakeCollision::NONE_MASK),
+      parent(nullptr) {
   robotnum = 0;
   position_num_start = 0;
   velocity_num_start = 0;

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -399,7 +399,7 @@ RigidBodyMagnetometer::RigidBodyMagnetometer(
 RigidBodyAccelerometer::RigidBodyAccelerometer(
     RigidBodySystem const& sys, const std::string& name,
     const std::shared_ptr<RigidBodyFrame> frame)
-    : RigidBodySensor(sys, name), frame(frame), gravity_compensation(false) {}
+    : RigidBodySensor(sys, name), gravity_compensation(false), frame(frame) {}
 
 Eigen::VectorXd RigidBodyAccelerometer::output(
     const double& t, const KinematicsCache<double>& rigid_body_state,

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -146,11 +146,11 @@ class DRAKERBSYSTEM_EXPORT RigidBodySystem {
   using OutputVector = Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>;
 
   explicit RigidBodySystem(std::shared_ptr<RigidBodyTree> rigid_body_tree)
-      : tree(rigid_body_tree),
-        use_multi_contact(false),
+      : use_multi_contact(false),
         penetration_stiffness(150.0),
         penetration_damping(penetration_stiffness / 10.0),
         friction_coefficient(1.0),
+        tree(rigid_body_tree),
         direct_feedthrough(false) {}
 
   RigidBodySystem()

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -562,8 +562,8 @@ PositionConstraint::PositionConstraint(RigidBodyTree* robot,
                                        const Matrix3Xd& pts, MatrixXd lb,
                                        MatrixXd ub, const Vector2d& tspan)
     : SingleTimeKinematicConstraint(robot, tspan),
-      n_pts_(static_cast<int>(pts.cols())),
-      pts_(pts) {
+      pts_(pts),
+      n_pts_(static_cast<int>(pts.cols())) {
   if (pts_.rows() != 3) {
     throw std::runtime_error("pts must have 3 rows");
   }
@@ -1849,8 +1849,8 @@ AllBodiesClosestDistanceConstraint::AllBodiesClosestDistanceConstraint(
     const std::vector<int>& active_bodies_idx,
     const std::set<std::string>& active_group_names, const Vector2d& tspan)
     : SingleTimeKinematicConstraint(robot, tspan),
-      lb_(lb),
       ub_(ub),
+      lb_(lb),
       active_bodies_idx_(active_bodies_idx),
       active_group_names_(active_group_names) {
   set_type(RigidBodyConstraint::AllBodiesClosestDistanceConstraintType);
@@ -2294,9 +2294,9 @@ GravityCompensationTorqueConstraint::GravityCompensationTorqueConstraint(
     RigidBodyTree* robot, const VectorXi& joint_indices, const VectorXd& lb,
     const VectorXd& ub, const Vector2d& tspan)
     : SingleTimeKinematicConstraint(robot, tspan),
+      joint_indices_(joint_indices),
       lb_(lb),
-      ub_(ub),
-      joint_indices_(joint_indices) {
+      ub_(ub) {
   set_num_constraint(static_cast<int>(joint_indices.size()));
   set_type(RigidBodyConstraint::GravityCompensationTorqueConstraintType);
 }

--- a/drake/systems/plants/joints/DrakeJoint.cpp
+++ b/drake/systems/plants/joints/DrakeJoint.cpp
@@ -5,10 +5,10 @@ using namespace Eigen;
 DrakeJoint::DrakeJoint(const std::string& _name,
                        const Isometry3d& _transform_to_parent_body,
                        int _num_positions, int _num_velocities)
-    : name(_name),
-      transform_to_parent_body(_transform_to_parent_body),
+    : transform_to_parent_body(_transform_to_parent_body),
       num_positions(_num_positions),
       num_velocities(_num_velocities),
+      name(_name),
       joint_limit_min(VectorXd::Constant(
           _num_positions, -std::numeric_limits<double>::infinity())),
       joint_limit_max(VectorXd::Constant(

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -41,15 +41,15 @@ QPLocomotionPlan::QPLocomotionPlan(RigidBodyTree& robot,
                                    const std::string& lcm_channel)
     : robot(robot),
       settings(settings),
-      start_time(std::numeric_limits<double>::quiet_NaN()),
-      pelvis_id(robot.findLinkId(settings.pelvis_name)),
       foot_body_ids(createFootBodyIdMap(robot, settings.foot_names)),
       knee_indices(createJointIndicesMap(robot, settings.knee_names)),
-      akx_indices(createJointIndicesMap(robot, settings.akx_names)),
       aky_indices(createJointIndicesMap(robot, settings.aky_names)),
+      akx_indices(createJointIndicesMap(robot, settings.akx_names)),
+      pelvis_id(robot.findLinkId(settings.pelvis_name)),
+      start_time(std::numeric_limits<double>::quiet_NaN()),
       plan_shift(Vector3d::Zero()),
-      shifted_zmp_trajectory(settings.zmp_trajectory),
-      last_foot_shift_time(0.0) {
+      last_foot_shift_time(0.0),
+      shifted_zmp_trajectory(settings.zmp_trajectory) {
   for (int i = 1; i < settings.support_times.size(); i++) {
     if (settings.support_times[i] < settings.support_times[i - 1])
       throw std::runtime_error("support times must be increasing");

--- a/drake/systems/trajectories/PPTmex.cpp
+++ b/drake/systems/trajectories/PPTmex.cpp
@@ -38,9 +38,9 @@ class PPTrajectory {
                int d2)
       : m_breaks(breaks),
         m_coefs(coefs),
-        m_order(order),
         m_d1(d1),
         m_d2(d2),
+        m_order(order),
         m_cached_idx(-1) {}
 
   int d1() { return m_d1; }


### PR DESCRIPTION
Refactor and fix error/warning flags so as to not break the build for users (e.g. me) with additional warnings turned on (e.g. `-Wsign-conversion`), and to have less duplication between GCC and Clang. Also, fix `-Wreorder` violations (#2372).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2441) &emsp; Multiple assignees:&emsp;<img alt="@jonathan-owens" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/10732434?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/jonathan-owens">jonathan-owens</a>,&emsp;<img alt="@jwnimmer-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596505?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/jwnimmer-tri">jwnimmer-tri</a>
<!-- Reviewable:end -->
