### PR TITLE
Add back -source 1.6 for Windows javac calls

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -34,6 +34,10 @@ include(cmake/pods.cmake)
 find_package(Java REQUIRED)
 include(UseJava)
 
+if(WIN32)
+  set(CMAKE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} -source 6 -target 6)  # See #2442.
+endif()
+
 function(drake_install_headers)
   file(RELATIVE_PATH rel_path ${PROJECT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR})
   pods_install_headers(${ARGV} DESTINATION drake/${rel_path})


### PR DESCRIPTION
Partial revert of #2404 while I investigate Windows builds.

@mwoehlke-kitware (build-cop)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2442)
<!-- Reviewable:end -->
