### PR TITLE
Introduce System2 State, ContinuousSystemInterface, and a SpringMassSystem example.

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -65,11 +65,23 @@ endfunction()
 # This means that export headers can be included as drake/bla_export.h
 include(GenerateExportHeader)
 function(add_library_with_exports)
+  set(options STATIC)
   set(oneValueArgs LIB_NAME)
   set(multiValueArgs SOURCE_FILES)
   cmake_parse_arguments(parsed_args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  add_library(${parsed_args_LIB_NAME} SHARED ${parsed_args_SOURCE_FILES})
+  if(parsed_args_STATIC)
+    add_library(${parsed_args_LIB_NAME} STATIC ${parsed_args_SOURCE_FILES})
+    # Add a public preprocessor macro definition for LIB_NAME_STATIC_DEFINE,
+    # which suppresses platform-specific shared library export declarations
+    # in this target and all targets that depend on it.
+    string(TOUPPER ${parsed_args_LIB_NAME} capitalized_lib_name)
+    set(static_define ${capitalized_lib_name}_STATIC_DEFINE)
+    target_compile_definitions(${parsed_args_LIB_NAME} PUBLIC ${static_define})
+  else()
+    add_library(${parsed_args_LIB_NAME} SHARED ${parsed_args_SOURCE_FILES})
+  endif()
+
   set(exports_abs_path ${PROJECT_BINARY_DIR}/exports/drake/${parsed_args_LIB_NAME}_export.h)
   generate_export_header(${parsed_args_LIB_NAME} EXPORT_FILE_NAME ${exports_abs_path})
   install(FILES ${exports_abs_path} DESTINATION include/drake/)

--- a/drake/examples/spring_mass/CMakeLists.txt
+++ b/drake/examples/spring_mass/CMakeLists.txt
@@ -7,8 +7,9 @@ set(sources
 set(private_headers 
     spring_mass_system.h)
 
-add_library(drakeSpringMassSystem STATIC
-            ${sources} ${installed_headers} ${private_headers})
+add_library_with_exports(LIB_NAME drakeSpringMassSystem
+  STATIC
+  SOURCE_FILES ${sources} ${installed_headers} ${private_headers})
 add_dependencies(drakeSpringMassSystem drakeSystemFramework)
 target_link_libraries(drakeSpringMassSystem drakeSystemFramework)
 

--- a/drake/examples/spring_mass/CMakeLists.txt
+++ b/drake/examples/spring_mass/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Source files used to build drakeSpringMassSystem.
+set(sources 
+    spring_mass_system.cc)
+
+# Headers that are needed by code here but should not
+# be exposed anywhere else.
+set(private_headers 
+    spring_mass_system.h)
+
+add_library(drakeSpringMassSystem STATIC
+            ${sources} ${installed_headers} ${private_headers})
+add_dependencies(drakeSpringMassSystem drakeSystemFramework)
+target_link_libraries(drakeSpringMassSystem drakeSystemFramework)
+
+add_subdirectory(test)

--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -1,0 +1,125 @@
+#include "drake/examples/spring_mass/spring_mass_system.h"
+
+namespace drake {
+
+using systems::BasicVector;
+using systems::Context;
+using systems::ContinuousState;
+using systems::OutputPort;
+using systems::StateVectorInterface;
+using systems::SystemOutput;
+using systems::VectorInterface;
+using systems::VectorX;
+
+namespace examples {
+
+namespace {
+const ptrdiff_t kStateSize = 2;
+}  // namespace
+
+SpringMassStateVector::SpringMassStateVector(double initial_position,
+                                             double initial_velocity)
+    : BasicStateVector<double>(std::unique_ptr<BasicVector<double>>(
+          new BasicVector<double>(kStateSize))) {
+  set_position(initial_position);
+  set_velocity(initial_velocity);
+}
+
+SpringMassStateVector::~SpringMassStateVector() {}
+
+  // Order matters: Position (q) precedes velocity (v) in ContinuousState.
+double SpringMassStateVector::get_position() const { return GetAtIndex(0); }
+double SpringMassStateVector::get_velocity() const { return GetAtIndex(1); }
+void SpringMassStateVector::set_position(double q) { SetAtIndex(0, q); }
+void SpringMassStateVector::set_velocity(double v) { SetAtIndex(1, v); }
+
+SpringMassOutputVector::SpringMassOutputVector()
+    : BasicVector<double>(kStateSize) {}
+
+SpringMassOutputVector::~SpringMassOutputVector() {}
+
+double SpringMassOutputVector::get_position() const { return get_value()[0]; }
+double SpringMassOutputVector::get_velocity() const { return get_value()[1]; }
+
+void SpringMassOutputVector::set_position(double q) {
+  get_mutable_value()[0] = q;
+}
+
+void SpringMassOutputVector::set_velocity(double v) {
+  get_mutable_value()[1] = v;
+}
+
+SpringMassSystem::SpringMassSystem(const std::string& name,
+                                   double spring_constant_N_per_m,
+                                   double mass_kg)
+    : name_(name),
+      spring_constant_N_per_m_(spring_constant_N_per_m),
+      mass_kg_(mass_kg) {}
+
+SpringMassSystem::~SpringMassSystem() {}
+
+std::string SpringMassSystem::get_name() const { return name_; }
+
+// Reserve a context with no input, and a SpringMassStateVector state.
+std::unique_ptr<Context<double>> SpringMassSystem::CreateDefaultContext()
+    const {
+  std::unique_ptr<Context<double>> context(new Context<double>);
+  std::unique_ptr<SpringMassStateVector> state(new SpringMassStateVector(0, 0));
+  context->get_mutable_state()->continuous_state.reset(
+      new ContinuousState<double>(std::move(state), 1 /* size of q */,
+                                  1 /* size of v */, 0 /* size of z */));
+  return context;
+}
+
+std::unique_ptr<SystemOutput<double>> SpringMassSystem::AllocateOutput() const {
+  std::unique_ptr<SystemOutput<double>> output(new SystemOutput<double>);
+  {
+    OutputPort<double> port;
+    port.vector_output.reset(new SpringMassOutputVector());
+    output->ports.push_back(std::move(port));
+  }
+  return output;
+}
+
+std::unique_ptr<StateVectorInterface<double>>
+SpringMassSystem::AllocateStateDerivatives() const {
+  return std::unique_ptr<StateVectorInterface<double>>(
+      new SpringMassStateVector(0, 0));
+}
+
+// Assign the state to the output.
+void SpringMassSystem::Output(const Context<double>& context,
+                              SystemOutput<double>* output) const {
+  // TODO(david-german-tri): Add a cast that is dynamic_cast in Debug mode,
+  // and static_cast in Release mode.
+  // TODO(david-german-tri): Cache the output of this function.
+  const SpringMassStateVector& state =
+      dynamic_cast<const SpringMassStateVector&>(
+          context.get_state().continuous_state->get_state());
+  SpringMassOutputVector* output_vector = dynamic_cast<SpringMassOutputVector*>(
+      output->ports[0].vector_output.get());
+  output_vector->set_position(state.get_position());
+  output_vector->set_velocity(state.get_velocity());
+}
+
+// Compute the actual physics.
+void SpringMassSystem::Dynamics(
+    const Context<double>& context,
+    StateVectorInterface<double>* derivatives) const {
+  // TODO(david-german-tri): Cache the output of this function.
+  const SpringMassStateVector& state =
+      dynamic_cast<const SpringMassStateVector&>(
+          context.get_state().continuous_state->get_state());
+  SpringMassStateVector* derivative_vector =
+      dynamic_cast<SpringMassStateVector*>(derivatives);
+
+  // The derivative of position is velocity.
+  derivative_vector->set_position(state.get_velocity());
+
+  // The derivative of velocity is spring force divided by mass.
+  const double spring_force = -spring_constant_N_per_m_ * state.get_position();
+  derivative_vector->set_velocity(spring_force / mass_kg_);
+}
+
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "drake/systems/framework/basic_state_vector.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/continuous_system.h"
+#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/system_output.h"
+
+namespace drake {
+namespace examples {
+
+/// The state of a one-dimensional spring-mass system, consisting of the
+/// position and velocity of the mass, in meters.
+class SpringMassStateVector : public systems::BasicStateVector<double> {
+ public:
+  /// @param initial_position The position of the mass in meters.
+  /// @param initial_velocity The velocity of the mass in meters / second.
+  SpringMassStateVector(double initial_position, double initial_velocity);
+  ~SpringMassStateVector() override;
+
+  /// Returns the position of the mass in meters, where zero is the point
+  /// where the spring exerts no force.
+  double get_position() const;
+
+  /// Sets the position of the mass in meters.
+  void set_position(double v);
+
+  /// Returns the velocity of the mass in meters per second.
+  double get_velocity() const;
+
+  /// Sets the velocity of the mass in meters per second.
+  void set_velocity(double v);
+};
+
+/// The output of a one-dimensional spring-mass system, consisting of the
+/// position and velocity of the mass, in meters.
+class SpringMassOutputVector : public systems::BasicVector<double> {
+ public:
+  SpringMassOutputVector();
+  ~SpringMassOutputVector() override;
+
+  /// Returns the position of the mass in meters, where zero is the point
+  /// where the spring exerts no force.
+  double get_position() const;
+
+  /// Sets the position of the mass in meters.
+  void set_position(double v);
+
+  /// Returns the velocity of the mass in meters per second.
+  double get_velocity() const;
+
+  /// Sets the velocity of the mass in meters per second.
+  void set_velocity(double v);
+};
+
+/// A model of a one-dimensional spring-mass system.
+///
+/// @verbatim
+/// |-----\/\/ k /\/\----( m )  +x
+/// @endverbatim
+class SpringMassSystem : public systems::ContinuousSystem<double> {
+ public:
+  SpringMassSystem(const std::string& name, double spring_constant_N_per_m,
+                   double mass_kg);
+
+  ~SpringMassSystem() override;
+
+  std::string get_name() const override;
+
+  /// Allocates a state of type SpringMassStateVector.
+  /// Allocates no input ports.
+  std::unique_ptr<systems::Context<double>> CreateDefaultContext()
+      const override;
+
+  /// Allocates a single output port of type SpringMassStateVector.
+  std::unique_ptr<systems::SystemOutput<double>> AllocateOutput()
+      const override;
+
+  /// Allocates state derivatives of type SpringMassStateVector.
+  std::unique_ptr<systems::StateVectorInterface<double>>
+  AllocateStateDerivatives() const override;
+
+  void Output(const systems::Context<double>& context,
+              systems::SystemOutput<double>* output) const override;
+
+  void Dynamics(
+      const systems::Context<double>& context,
+      systems::StateVectorInterface<double>* derivatives) const override;
+
+ private:
+  const std::string name_;
+  const double spring_constant_N_per_m_;
+  const double mass_kg_;
+};
+
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include "drake/drakeSpringMassSystem_export.h"
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
@@ -15,7 +16,8 @@ namespace examples {
 
 /// The state of a one-dimensional spring-mass system, consisting of the
 /// position and velocity of the mass, in meters.
-class SpringMassStateVector : public systems::BasicStateVector<double> {
+class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassStateVector
+    : public systems::BasicStateVector<double> {
  public:
   /// @param initial_position The position of the mass in meters.
   /// @param initial_velocity The velocity of the mass in meters / second.
@@ -38,7 +40,8 @@ class SpringMassStateVector : public systems::BasicStateVector<double> {
 
 /// The output of a one-dimensional spring-mass system, consisting of the
 /// position and velocity of the mass, in meters.
-class SpringMassOutputVector : public systems::BasicVector<double> {
+class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassOutputVector
+    : public systems::BasicVector<double> {
  public:
   SpringMassOutputVector();
   ~SpringMassOutputVector() override;
@@ -62,7 +65,8 @@ class SpringMassOutputVector : public systems::BasicVector<double> {
 /// @verbatim
 /// |-----\/\/ k /\/\----( m )  +x
 /// @endverbatim
-class SpringMassSystem : public systems::ContinuousSystem<double> {
+class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
+    : public systems::ContinuousSystem<double> {
  public:
   SpringMassSystem(const std::string& name, double spring_constant_N_per_m,
                    double mass_kg);

--- a/drake/examples/spring_mass/test/CMakeLists.txt
+++ b/drake/examples/spring_mass/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+if (GTEST_FOUND)
+  add_executable(spring_mass_system_test spring_mass_system_test.cc)
+  target_link_libraries(spring_mass_system_test drakeSpringMassSystem drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME spring_mass_system_test COMMAND spring_mass_system_test)
+endif()

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -1,0 +1,144 @@
+#include "drake/examples/spring_mass/spring_mass_system.h"
+
+#include <memory>
+
+#include <Eigen/Dense>
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/state.h"
+#include "drake/systems/framework/state_subvector.h"
+#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/system_output.h"
+#include "drake/util/eigen_matrix_compare.h"
+
+namespace drake {
+
+using systems::Context;
+using systems::ContinuousState;
+using systems::StateSubvector;
+using systems::StateVectorInterface;
+using systems::SystemOutput;
+using util::MatrixCompareType;
+
+namespace examples {
+namespace {
+
+const double kSpring = 300.0;  // N/m
+const double kMass = 2.0;      // kg
+
+class SpringMassSystemTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    // Construct the system I/O objects.
+    system_.reset(new SpringMassSystem("test_system", kSpring, kMass));
+    context_ = system_->CreateDefaultContext();
+    system_output_ = system_->AllocateOutput();
+    erased_derivatives_ = system_->AllocateStateDerivatives();
+
+    // Set up some convenience pointers.
+    state_ = dynamic_cast<SpringMassStateVector*>(
+        context_->get_mutable_state()->continuous_state->get_mutable_state());
+    output_ = dynamic_cast<SpringMassOutputVector*>(
+        system_output_->ports[0].vector_output.get());
+    derivatives_ =
+        dynamic_cast<SpringMassStateVector*>(erased_derivatives_.get());
+  }
+
+  void InitializeState(const double position, const double velocity) {
+    state_->set_position(position);
+    state_->set_velocity(velocity);
+  }
+
+ protected:
+  std::unique_ptr<SpringMassSystem> system_;
+  std::unique_ptr<Context<double>> context_;
+  std::unique_ptr<SystemOutput<double>> system_output_;
+  SpringMassStateVector* state_;
+  SpringMassOutputVector* output_;
+  SpringMassStateVector* derivatives_;
+
+ private:
+  std::unique_ptr<StateVectorInterface<double>> erased_derivatives_;
+};
+
+TEST_F(SpringMassSystemTest, Name) {
+  EXPECT_EQ("test_system", system_->get_name());
+}
+
+// Tests that state is passed through to the output.
+TEST_F(SpringMassSystemTest, Output) {
+  InitializeState(0.1, 0.0);  // Displacement 100cm, no velocity.
+  system_->Output(*context_, system_output_.get());
+  ASSERT_EQ(1, system_output_->ports.size());
+
+  // Check the output through the application-specific interface.
+  EXPECT_NEAR(0.1, output_->get_position(), 1e-8);
+  EXPECT_EQ(0.0, output_->get_velocity());
+
+  // Check the output through the VectorInterface API.
+  ASSERT_EQ(2, output_->size());
+  EXPECT_NEAR(0.1, output_->get_value()[0], 1e-8);
+  EXPECT_EQ(0.0, output_->get_value()[1]);
+}
+
+// Tests that second-order structure is exposed in the state.
+TEST_F(SpringMassSystemTest, SecondOrderStructure) {
+  InitializeState(1.2, 3.4);  // Displacement 1.2m, velocity 3.4m/sec.
+  ContinuousState<double>* continuous_state =
+      context_->get_mutable_state()->continuous_state.get();
+  ASSERT_EQ(1, continuous_state->get_generalized_position().size());
+  ASSERT_EQ(1, continuous_state->get_generalized_velocity().size());
+  ASSERT_EQ(0, continuous_state->get_misc_continuous_state().size());
+  EXPECT_NEAR(1.2, continuous_state->get_generalized_position().GetAtIndex(0),
+              1e-8);
+  EXPECT_NEAR(3.4, continuous_state->get_generalized_velocity().GetAtIndex(0),
+              1e-8);
+}
+
+// Tests that second-order structure can be processed in
+// MapVelocityToConfigurationDerivative.
+TEST_F(SpringMassSystemTest, MapVelocityToConfigurationDerivative) {
+  InitializeState(1.2, 3.4);  // Displacement 1.2m, velocity 3.4m/sec.
+  ContinuousState<double>* continuous_state =
+      context_->get_mutable_state()->continuous_state.get();
+
+  // Slice just the configuration derivatives out of the derivative
+  // vector.
+  StateSubvector<double> configuration_derivatives(derivatives_, 0, 1);
+
+  system_->MapVelocityToConfigurationDerivatives(
+      *context_, continuous_state->get_generalized_velocity(),
+      &configuration_derivatives);
+
+  EXPECT_NEAR(3.4, derivatives_->get_position(), 1e-8);
+  EXPECT_NEAR(3.4, configuration_derivatives.GetAtIndex(0), 1e-8);
+}
+
+TEST_F(SpringMassSystemTest, ForcesPositiveDisplacement) {
+  InitializeState(0.1, 0.1);  // Displacement 0.1m, velocity 0.1m/sec.
+  system_->Dynamics(*context_, derivatives_);
+
+  ASSERT_EQ(2, derivatives_->size());
+  // The derivative of position is velocity.
+  EXPECT_NEAR(0.1, derivatives_->get_position(), 1e-8);
+  // The derivative of velocity is force over mass.
+  EXPECT_NEAR(-kSpring * 0.1 / kMass, derivatives_->get_velocity(), 1e-8);
+}
+
+TEST_F(SpringMassSystemTest, ForcesNegativeDisplacement) {
+  InitializeState(-0.1, 0.2);  // Displacement -0.1m, velocity 0.2m/sec.
+  system_->Dynamics(*context_, derivatives_);
+
+  ASSERT_EQ(2, derivatives_->size());
+  // The derivative of position is velocity.
+  EXPECT_NEAR(0.2, derivatives_->get_position(), 1e-8);
+  // The derivative of velocity is force over mass.
+  EXPECT_NEAR(-kSpring * -0.1 / kMass, derivatives_->get_velocity(), 1e-8);
+}
+
+// TODO(david-german-tri, sherm1): Add test cases using integration.
+
+}  // namespace
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -5,6 +5,7 @@
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
+#include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/state_subvector.h"

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -3,10 +3,14 @@ set(sources
   basic_vector.cc
   cache.cc
   context.cc
+  continuous_system.cc
   named_value_vector.cc
   state.cc
+  state_subvector.cc
+  state_vector_interface.cc
   system_interface.cc
   system_output.cc
+  basic_state_vector.cc
   value.cc
   vector_interface.cc
   primitives/adder.cc)
@@ -17,10 +21,14 @@ set(installed_headers
   basic_vector.h
   cache.h
   context.h
+  continuous_system.h
   named_value_vector.h
   state.h
+  state_subvector.h
+  state_vector_interface.h
   system_interface.h
   system_output.h
+  basic_state_vector.h
   value.h
   vector_interface.h
   primitives/adder.h)

--- a/drake/systems/framework/basic_state_vector.cc
+++ b/drake/systems/framework/basic_state_vector.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// basic_state_vector.h is a stand-alone header.
+
+#include "drake/systems/framework/basic_state_vector.h"

--- a/drake/systems/framework/basic_state_vector.h
+++ b/drake/systems/framework/basic_state_vector.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+
+#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/vector_interface.h"
+
+namespace drake {
+namespace systems {
+
+/// BasicStateVector is a concrete class template that implements
+/// StateVectorInterface in a convenient manner for leaf Systems,
+/// by owning and wrapping a VectorInterface<T>.
+///
+/// @tparam T A mathematical type compatible with Eigen's Scalar.
+template <typename T>
+class BasicStateVector : public StateVectorInterface<T> {
+ public:
+  explicit BasicStateVector(std::unique_ptr<VectorInterface<T>> vector)
+      : vector_(std::move(vector)) {}
+
+  ptrdiff_t size() const override { return vector_->get_value().rows(); }
+
+  const T GetAtIndex(ptrdiff_t index) const override {
+    if (index >= size()) {
+      throw std::out_of_range("Index " + std::to_string(index) +
+                              "out of bounds for state vector of size " +
+                              std::to_string(size()));
+    }
+    return vector_->get_value()[index];
+  }
+
+  void SetAtIndex(ptrdiff_t index, const T& value) override {
+    if (index >= size()) {
+      throw std::out_of_range("Index " + std::to_string(index) +
+                              "out of bounds for state vector of size " +
+                              std::to_string(size()));
+    }
+    vector_->get_mutable_value()[index] = value;
+  }
+
+  void SetFromVector(const Eigen::Ref<VectorX<T>>& value) override {
+    vector_->set_value(value);
+  }
+
+ private:
+  // BasicStateVector objects are neither copyable nor moveable.
+  BasicStateVector(const BasicStateVector& other) = delete;
+  BasicStateVector& operator=(const BasicStateVector& other) = delete;
+  BasicStateVector(BasicStateVector&& other) = delete;
+  BasicStateVector& operator=(BasicStateVector&& other) = delete;
+
+  std::unique_ptr<VectorInterface<T>> vector_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/continuous_system.cc
+++ b/drake/systems/framework/continuous_system.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// continuous_system.h is a stand-alone header.
+
+#include "drake/systems/framework/continuous_system.h"

--- a/drake/systems/framework/continuous_system.h
+++ b/drake/systems/framework/continuous_system.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/continuous_system_interface.h"
+#include "drake/systems/framework/state_vector_interface.h"
+
+namespace drake {
+namespace systems {
+
+/// An abstract base class template for Systems that have continuous dynamics.
+/// Defines some reasonable default implementations.
+template <typename T>
+class ContinuousSystem : public ContinuousSystemInterface<T> {
+ public:
+  ~ContinuousSystem() override {}
+
+  /// Applies the identity mapping. Throws std::out_of_range if the
+  /// @p generalized_velocity and @p configuration_derivatives are not the
+  /// same size. Child classes should override this function if qdot != v.
+  void MapVelocityToConfigurationDerivatives(
+      const Context<T>& context,
+      const StateVectorInterface<T>& generalized_velocity,
+      StateVectorInterface<T>* configuration_derivatives) const override {
+    if (generalized_velocity.size() != configuration_derivatives->size()) {
+      throw std::out_of_range(
+          "generalized_velocity.size() " +
+          std::to_string(generalized_velocity.size()) +
+          " != configuration_derivatives.size() " +
+          std::to_string(configuration_derivatives->size()) +
+          ". Do you need to override the default implementation of " +
+          "MapVelocityToConfigurationDerivatives?");
+    }
+
+    for (ptrdiff_t i = 0; i < generalized_velocity.size(); ++i) {
+      configuration_derivatives->SetAtIndex(
+          i, generalized_velocity.GetAtIndex(i));
+    }
+  }
+
+ protected:
+  ContinuousSystem() {}
+
+ private:
+  // ContinuousSystem objects are neither copyable nor moveable.
+  ContinuousSystem(const ContinuousSystem<T>& other) = delete;
+  ContinuousSystem& operator=(
+      const ContinuousSystem<T>& other) = delete;
+  ContinuousSystem(ContinuousSystem<T>&& other) = delete;
+  ContinuousSystem& operator=(ContinuousSystem<T>&& other) =
+      delete;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/continuous_system_interface.h
+++ b/drake/systems/framework/continuous_system_interface.h
@@ -2,8 +2,8 @@
 
 #include <string>
 
-#include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/context.h"
+#include "drake/systems/framework/state_vector_interface.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/system_interface.h"
 
@@ -14,9 +14,49 @@ namespace systems {
 template <typename T>
 class ContinuousSystemInterface : public SystemInterface<T> {
  public:
-  ~ContinuousSystemInterface() override  {}
+  ~ContinuousSystemInterface() override {}
 
-  // TODO(david-german-tri): Add state derivatives.
+  /// Returns a vector of the same size as the continuous_state allocated in
+  /// CreateDefaultContext. Solvers will provide this vector as the output
+  /// argument to Dynamics.
+  virtual std::unique_ptr<StateVectorInterface<T>> AllocateStateDerivatives()
+      const = 0;
+
+  /// Produces the derivatives of the continuous state xc with respect to time.
+  /// The @p derivatives vector will correspond elementwise with the state
+  /// vector Context.state.continuous_state.get_state(). Thus, if the state in
+  /// the Context has second-order structure, that same structure applies to
+  /// the derivatives.
+  ///
+  /// Implementations may assume that the output is of the type constructed in
+  /// CreateDefaultStateDerivatives.
+  ///
+  /// @param derivatives The output vector. Will be the same length as the
+  ///                    state vector Context.state.continuous_state.
+  virtual void Dynamics(const Context<T>& context,
+                        StateVectorInterface<T>* derivatives) const = 0;
+
+  /// Transforms the velocity (v) in the given Context state to the derivative
+  /// of the configuration (qdot). The transformation must be linear
+  /// (qdot = N(q) * v), and it must require no more than O(N) time to compute
+  /// in the number of generalized velocity states.
+  ///
+  /// Implementations may assume that @p configuration_derivatives is of
+  /// the same size as the generalized position allocated in
+  /// CreateDefaultContext()->continuous_state.get_generalized_position(),
+  /// and should populate it with elementwise-corresponding derivatives of
+  /// position. Implementations that are not second-order systems may simply
+  /// do nothing.
+  ///
+  /// @param context The complete evaluation context.
+  /// @param generalized_velocity The velocity to transform.
+  /// @param configuration_derivatives The output vector.  Must not be nullptr.
+  virtual void MapVelocityToConfigurationDerivatives(
+      const Context<T>& context,
+      const StateVectorInterface<T>& generalized_velocity,
+      StateVectorInterface<T>* configuration_derivatives) const = 0;
+
+  // TODO(david-german-tri): Add MapConfigurationDerivativesToVelocity.
 
  protected:
   ContinuousSystemInterface() {}

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -1,13 +1,133 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+#include "drake/systems/framework/state_subvector.h"
+#include "drake/systems/framework/state_vector_interface.h"
 #include "drake/systems/framework/vector_interface.h"
 
 namespace drake {
 namespace systems {
+
+/// The ContinuousState is a container for all the State variables that are
+/// unique to continuous Systems, i.e. Systems that satisfy
+/// ContinuousSystemInterface and have defined dynamics at all times.
+///
+/// @tparam T A mathematical type compatible with Eigen's Scalar.
+template <typename T>
+class ContinuousState {
+ public:
+  /// Constructs a ContinuousState for a system that does not have second-order
+  /// structure: All of the state is misc_continuous_state_.
+  explicit ContinuousState(std::unique_ptr<StateVectorInterface<T>> state) {
+    state_ = std::move(state);
+    generalized_position_.reset(new StateSubvector<T>(state_.get()));
+    generalized_velocity_.reset(new StateSubvector<T>(state_.get()));
+    misc_continuous_state_.reset(
+        new StateSubvector<T>(state_.get(), 0, state_.size()));
+  }
+
+  /// Constructs a ContinuousState that exposes second-order structure.
+  /// The contents of @p state must be laid out as follows:
+  ///
+  /// @verbatim
+  /// (index 0)|--q--|--v--|--z--|(index state.size() - 1)
+  ///
+  /// Where q is generalized position
+  ///       v is generalized velocity
+  ///       z is other continuous state
+  /// @endverbatim
+  ///
+  /// @param num_q The number of position variables.
+  /// @param num_v The number of velocity variables.
+  /// @param num_z  The number of other variables.
+  ContinuousState(std::unique_ptr<StateVectorInterface<T>> state, size_t num_q,
+                  size_t num_v, size_t num_z) {
+    state_ = std::move(state);
+    if (state_->size() != num_q + num_v + num_z) {
+      throw std::out_of_range(
+          "Continuous state of size " + std::to_string(state_->size()) +
+          "cannot be partitioned as" + " q " + std::to_string(num_q) + " v " +
+          std::to_string(num_v) + " z " + std::to_string(num_z));
+    }
+    if (num_v > num_q) {
+      throw std::logic_error("Number of velocity variables " +
+                             std::to_string(num_v) +
+                             " must not exceed number of position variables " +
+                             std::to_string(num_q));
+    }
+    generalized_position_.reset(new StateSubvector<T>(state_.get(), 0, num_q));
+    generalized_velocity_.reset(
+        new StateSubvector<T>(state_.get(), num_q, num_v));
+    misc_continuous_state_.reset(
+        new StateSubvector<T>(state_.get(), num_q + num_v, num_z));
+  }
+
+  // TODO(david-german-tri): Add a suitable constructor for the continuous
+  // state of a Diagram, using StateSupervectors.
+
+  /// Returns the entire state vector.
+  const StateVectorInterface<T>& get_state() { return *state_; }
+
+  /// Returns a mutable pointer to the entire state vector, never null.
+  StateVectorInterface<T>* get_mutable_state() { return state_.get(); }
+
+  /// Returns the subset of the state vector that is generalized position `q`.
+  const StateVectorInterface<T>& get_generalized_position() {
+    return *generalized_position_;
+  }
+
+  /// Returns a mutable pointer to the subset of the state vector that is
+  /// generalized position `q`.
+  StateVectorInterface<T>* get_mutable_generalized_position() {
+    return generalized_position_.get();
+  }
+
+  /// Returns the subset of the state vector that is generalized velocity `v`.
+  const StateVectorInterface<T>& get_generalized_velocity() {
+    return *generalized_velocity_;
+  }
+
+  /// Returns a mutable pointer to the subset of the state vector that is
+  /// generalized velocity `v`.
+  StateVectorInterface<T>* get_mutable_generalized_velocity() {
+    return generalized_velocity_.get();
+  }
+
+  /// Returns the subset of the state vector that is other continuous state `z`.
+  const StateVectorInterface<T>& get_misc_continuous_state() {
+    return *misc_continuous_state_;
+  }
+
+  /// Returns a mutable pointer to the subset of the state vector that is
+  /// other continuous state `z`.
+  StateVectorInterface<T>* get_mutable_misc_continuous_state() {
+    return misc_continuous_state_.get();
+  }
+
+ private:
+  /// The entire state vector.  May or may not own the underlying data.
+  std::unique_ptr<StateVectorInterface<T>> state_;
+
+  /// Generalized coordinates representing System configuration, conventionally
+  /// denoted `q`. These are second-order state variables.
+  /// This is a subset of state_ and does not own the underlying data.
+  std::unique_ptr<StateVectorInterface<T>> generalized_position_;
+
+  /// Generalized speeds representing System velocity. Conventionally denoted
+  /// `v`. These are first-order state variables that the System can linearly
+  /// map to time derivatives `qdot` of `q` above.
+  /// This is a subset of state_ and does not own the underlying data.
+  std::unique_ptr<StateVectorInterface<T>> generalized_velocity_;
+
+  /// Additional continuous, first-order state variables not representing
+  /// multibody system motion.  Conventionally denoted `z`.
+  /// This is a subset of state_ and does not own the underlying data.
+  std::unique_ptr<StateVectorInterface<T>> misc_continuous_state_;
+};
 
 /// The State is a container for all the data comprising the complete state of
 /// a particular System at a particular moment. Any field in the State may be
@@ -17,8 +137,9 @@ namespace systems {
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
 template <typename T>
 struct State {
-  // TODO(david-german-tri): Add state.
+  std::unique_ptr<ContinuousState<T>> continuous_state;
+  // TODO(david-german-tri): Add discrete state variables.
 };
 
 }  // namespace systems
-}  // namesapce drake
+}  // namespace drake

--- a/drake/systems/framework/state_subvector.cc
+++ b/drake/systems/framework/state_subvector.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// state_subvector.h is a stand-alone header.
+
+#include "drake/systems/framework/state_subvector.h"

--- a/drake/systems/framework/state_subvector.h
+++ b/drake/systems/framework/state_subvector.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include <stdexcept>
+
+#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/vector_interface.h"
+
+namespace drake {
+namespace systems {
+
+/// StateSubvector is a concrete class template that implements
+/// StateVectorInterface by providing a sliced view of a StateVectorInterface.
+///
+/// @tparam T A mathematical type compatible with Eigen's Scalar.
+template <typename T>
+class StateSubvector : public StateVectorInterface<T> {
+ public:
+  /// Constructs a subvector of vector that consists of num_elements starting
+  /// at first_element.
+  /// @param vector The vector to slice.  Must not be nullptr. Must remain
+  ///               valid for the lifetime of this object.
+  StateSubvector(StateVectorInterface<T>* vector, ptrdiff_t first_element,
+                 ptrdiff_t num_elements)
+      : vector_(vector),
+        first_element_(first_element),
+        num_elements_(num_elements) {
+    if (vector_ == nullptr) {
+      throw std::logic_error(
+          "Cannot create StateSubvector of a nullptr vector.");
+    }
+    if (first_element_ + num_elements_ > vector_->size()) {
+      throw std::out_of_range("StateSubvector out of bounds.");
+    }
+  }
+
+  /// Constructs an empty subvector.
+  /// @param vector The vector to slice.  Must not be nullptr. Must remain
+  ///               valid for the lifetime of this object.
+  explicit StateSubvector(StateVectorInterface<T>* vector)
+      : StateSubvector(vector, 0, 0) {}
+
+  ~StateSubvector() override {}
+
+  ptrdiff_t size() const override { return num_elements_; }
+
+  const T GetAtIndex(ptrdiff_t index) const override {
+    if (index >= size()) {
+      throw std::out_of_range("Index " + std::to_string(index) +
+                              " out of bounds for state subvector of size " +
+                              std::to_string(size()));
+    }
+    return vector_->GetAtIndex(first_element_ + index);
+  }
+
+  void SetAtIndex(ptrdiff_t index, const T& value) override {
+    if (index >= size()) {
+      throw std::out_of_range("Index " + std::to_string(index) +
+                              " out of bounds for state subvector of size " +
+                              std::to_string(size()));
+    }
+    vector_->SetAtIndex(first_element_ + index, value);
+  }
+
+  void SetFromVector(const Eigen::Ref<VectorX<T>>& value) override {
+    for (int i = 0; i < value.rows(); ++i) {
+      SetAtIndex(i, value[i]);
+    }
+  }
+
+ private:
+  // StateSubvector objects are neither copyable nor moveable.
+  StateSubvector(const StateSubvector& other) = delete;
+  StateSubvector& operator=(const StateSubvector& other) = delete;
+  StateSubvector(StateSubvector&& other) = delete;
+  StateSubvector& operator=(StateSubvector&& other) = delete;
+
+  StateVectorInterface<T>* vector_{nullptr};
+  ptrdiff_t first_element_{0};
+  ptrdiff_t num_elements_{0};
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/state_vector_interface.cc
+++ b/drake/systems/framework/state_vector_interface.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// state_vector_interface.h is a stand-alone header.
+
+#include "drake/systems/framework/state_vector_interface.h"

--- a/drake/systems/framework/state_vector_interface.h
+++ b/drake/systems/framework/state_vector_interface.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "drake/systems/framework/vector_interface.h"
+
+namespace drake {
+namespace systems {
+
+/// StateVectorInterface is an interface template for vector quantities within
+/// the state of a System.  Both composite Systems (Diagrams) and Systems that
+/// have no component systems have state that satisfies StateVectorInterface.
+///
+/// @tparam T A mathematical type compatible with Eigen's Scalar.
+template <typename T>
+class StateVectorInterface {
+ public:
+  virtual ~StateVectorInterface() {}
+
+  /// Returns the number of elements in the vector.
+  ///
+  /// Implementations should ensure this operation is O(1) and allocates no
+  /// memory.
+  virtual ptrdiff_t size() const = 0;
+
+  /// Returns the element at the given index in the vector. Throws
+  /// std::out_of_range if the index is >= size().
+  ///
+  /// Implementations should ensure this operation is O(1) and allocates no
+  /// memory.
+  virtual const T GetAtIndex(ptrdiff_t index) const = 0;
+
+  /// Replaces the state at the given index with the value. Throws
+  /// std::out_of_range if the index is >= size().
+  ///
+  /// Implementations should ensure this operation is O(1) and allocates no
+  /// memory.
+  virtual void SetAtIndex(ptrdiff_t index, const T& value) = 0;
+
+  /// Replaces the entire state with the contents of value. Throws
+  /// std::out_of_range if value is not a column vector with size() rows.
+  ///
+  /// Implementations should ensure this operation is O(N) in the size of the
+  /// value and allocates no memory.
+  virtual void SetFromVector(const Eigen::Ref<VectorX<T>>& value) = 0;
+
+ protected:
+  StateVectorInterface() {}
+
+ private:
+  // StateVectorInterface objects are neither copyable nor moveable.
+  StateVectorInterface(const StateVectorInterface& other) = delete;
+  StateVectorInterface& operator=(const StateVectorInterface& other) = delete;
+  StateVectorInterface(StateVectorInterface&& other) = delete;
+  StateVectorInterface& operator=(StateVectorInterface&& other) = delete;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -12,4 +12,24 @@ if(GTEST_FOUND)
   target_link_libraries(basic_vector_test drakeSystemFramework drakePolynomial
     drakeCore ${GTEST_BOTH_LIBRARIES})
   add_test(NAME basic_vector_test COMMAND basic_vector_test)
+
+  add_executable(basic_state_vector_test basic_state_vector_test.cc)
+  target_link_libraries(basic_state_vector_test drakeSystemFramework
+                        ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME basic_state_vector_test COMMAND basic_state_vector_test)
+
+  add_executable(state_subvector_test state_subvector_test.cc)
+  target_link_libraries(state_subvector_test drakeSystemFramework
+                        ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME state_subvector_test COMMAND state_subvector_test)
+
+  add_executable(state_test state_test.cc)
+  target_link_libraries(state_test drakeSystemFramework
+                        ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME state_test COMMAND state_test)
+
+  add_executable(continuous_system_test continuous_system_test.cc)
+  target_link_libraries(continuous_system_test drakeSystemFramework
+                        ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME continuous_system_test COMMAND continuous_system_test)
 endif()

--- a/drake/systems/framework/test/basic_state_vector_test.cc
+++ b/drake/systems/framework/test/basic_state_vector_test.cc
@@ -1,0 +1,58 @@
+#include "drake/systems/framework/basic_state_vector.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/state_vector_interface.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+const size_t kLength = 2;
+
+class BasicStateVectorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::unique_ptr<VectorInterface<int>> vec;
+    vec.reset(new BasicVector<int>(kLength));
+    vec->get_mutable_value() << 1, 2;
+    state_vector_.reset(new BasicStateVector<int>(std::move(vec)));
+  }
+
+  std::unique_ptr<StateVectorInterface<int>> state_vector_;
+};
+
+TEST_F(BasicStateVectorTest, Access) {
+  EXPECT_EQ(kLength, state_vector_->size());
+  EXPECT_EQ(1, state_vector_->GetAtIndex(0));
+  EXPECT_EQ(2, state_vector_->GetAtIndex(1));
+  EXPECT_THROW(state_vector_->GetAtIndex(2), std::out_of_range);
+}
+
+TEST_F(BasicStateVectorTest, InvalidAccess) {
+  EXPECT_THROW(state_vector_->GetAtIndex(kLength), std::out_of_range);
+}
+
+TEST_F(BasicStateVectorTest, Mutation) {
+  state_vector_->SetAtIndex(0, 42);
+  EXPECT_EQ(42, state_vector_->GetAtIndex(0));
+  EXPECT_EQ(2, state_vector_->GetAtIndex(1));
+}
+
+TEST_F(BasicStateVectorTest, SetFromVector) {
+  Eigen::Vector2i next_value(kLength);
+  next_value << 3, 4;
+
+  state_vector_->SetFromVector(next_value);
+  EXPECT_EQ(3, state_vector_->GetAtIndex(0));
+  EXPECT_EQ(4, state_vector_->GetAtIndex(1));
+}
+
+TEST_F(BasicStateVectorTest, InvalidMutation) {
+  EXPECT_THROW(state_vector_->SetAtIndex(kLength, 42), std::out_of_range);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/continuous_system_test.cc
+++ b/drake/systems/framework/test/continuous_system_test.cc
@@ -1,0 +1,83 @@
+#include "drake/systems/framework/continuous_system.h"
+
+#include <memory>
+#include <stdexcept>
+
+#include <Eigen/Dense>
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/basic_state_vector.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/system_output.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+const int kSize = 3;
+
+// A shell ContinuousSystem to test the default implementations.
+class TestContinuousSystem : public ContinuousSystem<double> {
+ public:
+  TestContinuousSystem() {}
+  ~TestContinuousSystem() override {}
+
+  std::string get_name() const override { return "TestContinuousSystem"; }
+
+  std::unique_ptr<StateVectorInterface<double>> AllocateStateDerivatives()
+      const override { return nullptr; }
+
+  std::unique_ptr<Context<double>> CreateDefaultContext() const override {
+    return nullptr;
+  }
+
+  std::unique_ptr<SystemOutput<double>> AllocateOutput() const override {
+    return nullptr;
+  }
+
+  void Output(const Context<double>& context,
+              SystemOutput<double>* output) const override {}
+
+
+  void Dynamics(const Context<double>& context,
+                StateVectorInterface<double>* derivatives) const override {}
+};
+
+class ContinuousSystemTest : public ::testing::Test {
+ protected:
+  TestContinuousSystem system_;
+  Context<double> context_;
+};
+
+TEST_F(ContinuousSystemTest, MapVelocityToConfigurationDerivatives) {
+  std::unique_ptr<BasicVector<double>> vec1(new BasicVector<double>(kSize));
+  std::unique_ptr<BasicVector<double>> vec2(new BasicVector<double>(kSize));
+  vec1->get_mutable_value() << 1.0, 2.0, 3.0;
+  BasicStateVector<double> state_vec1(std::move(vec1));
+  BasicStateVector<double> state_vec2(std::move(vec2));
+
+  system_.MapVelocityToConfigurationDerivatives(context_,
+                                                state_vec1, &state_vec2);
+  EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
+  EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
+  EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+}
+
+TEST_F(ContinuousSystemTest, VelocityConfigurationDerivativeSizeMismatch) {
+  std::unique_ptr<BasicVector<double>> vec1(new BasicVector<double>(kSize));
+  std::unique_ptr<BasicVector<double>> vec2(new BasicVector<double>(kSize + 1));
+  vec1->get_mutable_value() << 1.0, 2.0, 3.0;
+  BasicStateVector<double> state_vec1(std::move(vec1));
+  BasicStateVector<double> state_vec2(std::move(vec2));
+
+  EXPECT_THROW(system_.MapVelocityToConfigurationDerivatives(context_,
+                                                             state_vec1,
+                                                             &state_vec2),
+               std::out_of_range);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/state_subvector_test.cc
+++ b/drake/systems/framework/test/state_subvector_test.cc
@@ -1,0 +1,71 @@
+#include "drake/systems/framework/state_subvector.h"
+
+#include <memory>
+
+#include <Eigen/Dense>
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/basic_state_vector.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/state_vector_interface.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+const size_t kLength = 4;
+const size_t kSubVectorLength = 2;
+
+class StateSubvectorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::unique_ptr<VectorInterface<int>> vec;
+    vec.reset(new BasicVector<int>(kLength));
+    vec->get_mutable_value() << 1, 2, 3, 4;
+    state_vector_.reset(new BasicStateVector<int>(std::move(vec)));
+  }
+
+  std::unique_ptr<StateVectorInterface<int>> state_vector_;
+};
+
+TEST_F(StateSubvectorTest, NullptrVector) {
+  EXPECT_THROW(StateSubvector<int> subvec(nullptr), std::logic_error);
+}
+
+TEST_F(StateSubvectorTest, EmptySubvector) {
+  StateSubvector<int> subvec(state_vector_.get());
+  EXPECT_EQ(0, subvec.size());
+  EXPECT_THROW(subvec.GetAtIndex(0), std::out_of_range);
+}
+
+TEST_F(StateSubvectorTest, OutOfBoundsSubvector) {
+  EXPECT_THROW(StateSubvector<int>(state_vector_.get(), 1, 4),
+               std::out_of_range);
+}
+
+TEST_F(StateSubvectorTest, Access) {
+  StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
+  EXPECT_EQ(2, subvec.GetAtIndex(0));
+  EXPECT_EQ(3, subvec.GetAtIndex(1));
+  EXPECT_THROW(subvec.GetAtIndex(2), std::out_of_range);
+}
+
+// Tests that writes to the subvector pass through to the sliced vector.
+TEST_F(StateSubvectorTest, Mutation) {
+  StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
+  VectorX<int> next_value(kSubVectorLength);
+  next_value << 5, 6;
+  subvec.SetFromVector(next_value);
+  EXPECT_EQ(5, subvec.GetAtIndex(0));
+  EXPECT_EQ(6, subvec.GetAtIndex(1));
+
+  subvec.SetAtIndex(1, 42);
+  EXPECT_EQ(1, state_vector_->GetAtIndex(0));
+  EXPECT_EQ(5, state_vector_->GetAtIndex(1));
+  EXPECT_EQ(42, state_vector_->GetAtIndex(2));
+  EXPECT_EQ(4, state_vector_->GetAtIndex(3));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/state_test.cc
+++ b/drake/systems/framework/test/state_test.cc
@@ -1,0 +1,95 @@
+#include "drake/systems/framework/state.h"
+
+#include <memory>
+
+#include <Eigen/Dense>
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/basic_state_vector.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/state_vector_interface.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+constexpr size_t kPositionLength = 2;
+constexpr size_t kVelocityLength = 1;
+constexpr size_t kMiscLength = 1;
+constexpr size_t kLength = kPositionLength + kVelocityLength + kMiscLength;
+
+std::unique_ptr<StateVectorInterface<int>> MakeStateVector() {
+  std::unique_ptr<VectorInterface<int>> vec;
+  vec.reset(new BasicVector<int>(kLength));
+  vec->get_mutable_value() << 1, 2, 3, 4;
+
+  std::unique_ptr<StateVectorInterface<int>> state_vector(
+      new BasicStateVector<int>(std::move(vec)));
+  return state_vector;
+}
+
+class ContinuousStateTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    continuous_state_.reset(new ContinuousState<int>(
+        MakeStateVector(), kPositionLength, kVelocityLength, kMiscLength));
+  }
+
+  std::unique_ptr<ContinuousState<int>> continuous_state_;
+};
+
+TEST_F(ContinuousStateTest, Access) {
+  EXPECT_EQ(kPositionLength,
+            continuous_state_->get_generalized_position().size());
+  EXPECT_EQ(1, continuous_state_->get_generalized_position().GetAtIndex(0));
+  EXPECT_EQ(2, continuous_state_->get_generalized_position().GetAtIndex(1));
+
+  EXPECT_EQ(kVelocityLength,
+            continuous_state_->get_generalized_velocity().size());
+  EXPECT_EQ(3, continuous_state_->get_generalized_velocity().GetAtIndex(0));
+
+  EXPECT_EQ(kMiscLength, continuous_state_->get_misc_continuous_state().size());
+  EXPECT_EQ(4, continuous_state_->get_misc_continuous_state().GetAtIndex(0));
+}
+
+TEST_F(ContinuousStateTest, Mutation) {
+  continuous_state_->get_mutable_generalized_position()->SetAtIndex(0, 5);
+  continuous_state_->get_mutable_generalized_position()->SetAtIndex(1, 6);
+  continuous_state_->get_mutable_generalized_velocity()->SetAtIndex(0, 7);
+  continuous_state_->get_mutable_misc_continuous_state()->SetAtIndex(0, 8);
+
+  EXPECT_EQ(5, continuous_state_->get_state().GetAtIndex(0));
+  EXPECT_EQ(6, continuous_state_->get_state().GetAtIndex(1));
+  EXPECT_EQ(7, continuous_state_->get_state().GetAtIndex(2));
+  EXPECT_EQ(8, continuous_state_->get_state().GetAtIndex(3));
+}
+
+TEST_F(ContinuousStateTest, OutOfBoundsAccess) {
+  EXPECT_THROW(continuous_state_->get_generalized_position().GetAtIndex(2),
+               std::out_of_range);
+  EXPECT_THROW(
+      continuous_state_->get_mutable_generalized_velocity()->SetAtIndex(1, 42),
+      std::out_of_range);
+}
+
+// Tests that std::out_of_range is thrown if the component dimensions do not
+// sum to the state vector dimension.
+TEST_F(ContinuousStateTest, OutOfBoundsConstruction) {
+  EXPECT_THROW(continuous_state_.reset(
+                   new ContinuousState<int>(MakeStateVector(), kPositionLength,
+                                            kVelocityLength, kMiscLength + 1)),
+               std::out_of_range);
+}
+
+// Tests that std::logic_error is thrown if there are more velocity than
+// position variables.
+TEST_F(ContinuousStateTest, MoreVelocityThanPositionVariables) {
+  EXPECT_THROW(
+      continuous_state_.reset(new ContinuousState<int>(
+          MakeStateVector(), 1 /* num_q */, 2 /* num_v */, kMiscLength + 1)),
+      std::out_of_range);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
@sherm1 for feature review.  This is another regrettably large PR, although a third of the diff is tests.  Let me provide a quick tour and suggested order of review.

1. `drake/examples/spring_mass`.  This will give a sense of what the rest of the PR buys us: the implementation is in the `.cc` file, the state is self-describing, the second-order structure is exposed but not compelled, Output/Dynamics are zero-copy, and ports can be connected arbitrarily at runtime.

2. `drake/systems/framework/continuous_system_interface.h`.  There shouldn't be any surprises here.

3. `drake/systems/framework/state_vector_interface.h`.  This is the abstraction that unifies the states of leaf Systems and the states of Diagrams. 

4. `drake/systems/framework/state_subvector.h`.  This is the abstraction for exposing second-order structure as a view into an underlying `SystemStateVector`.

5. `drake/systems/framework/state.h`.  This is the actual `ContinuousState` using (2) and (3) in the obvious way.

6. `drake/systems/framework/basic_state_vector.h`.  This is a simple implementation of StateVectorInterface for use in leaf Systems, such as SpringMassSystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2448)
<!-- Reviewable:end -->
