### PR TITLE
Moved frame to be a member variable of RigidBodySensor. Added method …

### DIFF
--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -393,6 +393,15 @@ const std::string& RigidBodySensor::get_model_name() const {
   return frame_->body->model_name();
 }
 
+const std::shared_ptr<RigidBodyFrame> RigidBodySensor::get_frame() const {
+  return frame_;
+}
+
+/// Returns the rigid body system to which this sensor attaches.
+const RigidBodySystem& RigidBodySensor::get_rigid_body_system() const {
+  return sys_;
+}
+
 RigidBodyMagnetometer::RigidBodyMagnetometer(
     RigidBodySystem const& sys, const std::string& name,
     const std::shared_ptr<RigidBodyFrame> frame, double declination)
@@ -409,19 +418,19 @@ Eigen::VectorXd RigidBodyAccelerometer::output(
     const double& t, const KinematicsCache<double>& rigid_body_state,
     const RigidBodySystem::InputVector<double>& u) const {
   VectorXd x = rigid_body_state.getX();
-  auto xdd = sys_.dynamics(t, x, u);
-  auto const& tree = sys_.getRigidBodyTree();
+  auto xdd = get_rigid_body_system().dynamics(t, x, u);
+  auto const& tree = get_rigid_body_system().getRigidBodyTree();
   auto v_dot = xdd.bottomRows(rigid_body_state.getNumVelocities());
 
   Vector3d sensor_origin =
       Vector3d::Zero();  // assumes sensor coincides with the frame's origin;
   auto J = tree->transformPointsJacobian(rigid_body_state, sensor_origin,
-                                         frame_->frame_index, 0, false);
+                                         get_frame()->frame_index, 0, false);
   auto Jdot_times_v = tree->transformPointsJacobianDotTimesV(
-      rigid_body_state, sensor_origin, frame_->frame_index, 0);
+      rigid_body_state, sensor_origin, get_frame()->frame_index, 0);
 
   Vector4d quat_world_to_body =
-      tree->relativeQuaternion(rigid_body_state, 0, frame_->frame_index);
+      tree->relativeQuaternion(rigid_body_state, 0, get_frame()->frame_index);
 
   Vector3d accel_base = Jdot_times_v + J * v_dot;
   Vector3d accel_body = quatRotateVec(quat_world_to_body, accel_base);
@@ -442,10 +451,10 @@ RigidBodyGyroscope::RigidBodyGyroscope(
 Eigen::VectorXd RigidBodyMagnetometer::output(
     const double& t, const KinematicsCache<double>& rigid_body_state,
     const RigidBodySystem::InputVector<double>& u) const {
-  auto const& tree = sys_.getRigidBodyTree();
+  auto const& tree = get_rigid_body_system().getRigidBodyTree();
 
   Vector4d quat_world_to_body =
-      tree->relativeQuaternion(rigid_body_state, 0, frame_->frame_index);
+      tree->relativeQuaternion(rigid_body_state, 0, get_frame()->frame_index);
 
   Vector3d mag_body = quatRotateVec(quat_world_to_body, magnetic_north);
 
@@ -456,9 +465,9 @@ Eigen::VectorXd RigidBodyGyroscope::output(
     const double& t, const KinematicsCache<double>& rigid_body_state,
     const RigidBodySystem::InputVector<double>& u) const {
   // relative twist of body with respect to world expressed in body
-  auto const& tree = sys_.getRigidBodyTree();
+  auto const& tree = get_rigid_body_system().getRigidBodyTree();
   auto relative_twist = tree->relativeTwist(
-      rigid_body_state, 0, frame_->frame_index, frame_->frame_index);
+      rigid_body_state, 0, get_frame()->frame_index, get_frame()->frame_index);
   Eigen::Vector3d angular_rates = relative_twist.head<3>();
 
   return noise_model ? noise_model->generateNoise(angular_rates)
@@ -531,7 +540,7 @@ void RigidBodyDepthSensor::CheckValidConfiguration() {
     error_msg
         << "ERROR: RigidBodyDepthSensor: min pitch is greater than max pitch!"
         << std::endl
-        << "  - sensor name: " << name_ << std::endl
+        << "  - sensor name: " << get_name() << std::endl
         << "  - model name: " << get_model_name() << std::endl
         << "  - min pitch: " << min_pitch_ << std::endl
         << "  - max pitch: " << max_pitch_ << std::endl
@@ -544,7 +553,7 @@ void RigidBodyDepthSensor::CheckValidConfiguration() {
     std::stringstream error_msg;
     error_msg << "ERROR: RigidBodyDepthSensor: min yaw is greater than max yaw!"
               << std::endl
-              << "  - sensor name: " << name_ << std::endl
+              << "  - sensor name: " << get_name() << std::endl
               << "  - model name: " << get_model_name() << std::endl
               << "  - min yaw: " << min_yaw_ << std::endl
               << "  - max yaw: " << max_yaw_ << std::endl
@@ -560,7 +569,7 @@ void RigidBodyDepthSensor::CheckValidConfiguration() {
                  "Contradiction between min/max pitch and number of pixels per "
                  "row."
               << std::endl
-              << "  - sensor name: " << name_ << std::endl
+              << "  - sensor name: " << get_name() << std::endl
               << "  - model name: " << get_model_name() << std::endl
               << "  - min pitch: " << min_pitch_ << std::endl
               << "  - max pitch: " << max_pitch_ << std::endl
@@ -577,7 +586,7 @@ void RigidBodyDepthSensor::CheckValidConfiguration() {
                  "Contradiction between min/max yaw and number of pixels per "
                  "column."
               << std::endl
-              << "  - sensor name: " << name_ << std::endl
+              << "  - sensor name: " << get_name() << std::endl
               << "  - model name: " << get_model_name() << std::endl
               << "  - min yaw: " << min_yaw_ << std::endl
               << "  - max yaw: " << max_yaw_ << std::endl
@@ -619,14 +628,14 @@ Eigen::VectorXd RigidBodyDepthSensor::output(
 
   // Computes the origin of the rays in the world frame. The origin of
   // of the rays in the frame of the sensor is [0,0,0] (the Vector3d::Zero()).
-  Vector3d origin = sys_.getRigidBodyTree()->transformPoints(
-      rigid_body_state, Vector3d::Zero(), frame_->frame_index, 0);
+  Vector3d origin = get_rigid_body_system().getRigidBodyTree()->transformPoints(
+      rigid_body_state, Vector3d::Zero(), get_frame()->frame_index, 0);
 
   // Computes the end of the casted rays in the world frame.
-  Matrix3Xd raycast_endpoints_world = sys_.getRigidBodyTree()->transformPoints(
-      rigid_body_state, raycast_endpoints, frame_->frame_index, 0);
+  Matrix3Xd raycast_endpoints_world = get_rigid_body_system().getRigidBodyTree()->transformPoints(
+      rigid_body_state, raycast_endpoints, get_frame()->frame_index, 0);
 
-  sys_.getRigidBodyTree()->collisionRaycast(rigid_body_state, origin,
+  get_rigid_body_system().getRigidBodyTree()->collisionRaycast(rigid_body_state, origin,
                                            raycast_endpoints_world, distances);
 
   for (size_t i = 0; i < num_distances; i++) {

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -270,8 +270,8 @@ std::vector<const RigidBodySensor*> RigidBodySystem::GetSensors() const {
   return result;
 }
 
-DRAKERBSYSTEM_EXPORT RigidBodySystem::StateVector<double>
-getInitialState(const RigidBodySystem& sys) {
+DRAKERBSYSTEM_EXPORT RigidBodySystem::StateVector<double> getInitialState(
+    const RigidBodySystem& sys) {
   VectorXd x0(sys.tree->number_of_positions() +
               sys.tree->number_of_velocities());
 
@@ -304,16 +304,16 @@ getInitialState(const RigidBodySystem& sys) {
           sys.tree.get(), zero, zero, zero, loops[i].frameA->frame_index,
           loops[i].frameB->frame_index, bTbp, tspan));
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con1wrapper(
-          new SingleTimeKinematicConstraintWrapper(
-              &constraints.back(), &kin_helper));
+          new SingleTimeKinematicConstraintWrapper(&constraints.back(),
+                                                   &kin_helper));
       prog.AddGenericConstraint(con1wrapper, {qvar});
       constraints.push_back(RelativePositionConstraint(
           sys.tree.get(), loops[i].axis, loops[i].axis, loops[i].axis,
           loops[i].frameA->frame_index, loops[i].frameB->frame_index, bTbp,
           tspan));
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(
-          new SingleTimeKinematicConstraintWrapper(
-              &constraints.back(), &kin_helper));
+          new SingleTimeKinematicConstraintWrapper(&constraints.back(),
+                                                   &kin_helper));
       prog.AddGenericConstraint(con2wrapper, {qvar});
     }
 
@@ -632,11 +632,12 @@ Eigen::VectorXd RigidBodyDepthSensor::output(
       rigid_body_state, Vector3d::Zero(), get_frame().frame_index, 0);
 
   // Computes the end of the casted rays in the world frame.
-  Matrix3Xd raycast_endpoints_world = get_rigid_body_system().getRigidBodyTree()->transformPoints(
-      rigid_body_state, raycast_endpoints, get_frame().frame_index, 0);
+  Matrix3Xd raycast_endpoints_world =
+      get_rigid_body_system().getRigidBodyTree()->transformPoints(
+          rigid_body_state, raycast_endpoints, get_frame().frame_index, 0);
 
-  get_rigid_body_system().getRigidBodyTree()->collisionRaycast(rigid_body_state, origin,
-                                           raycast_endpoints_world, distances);
+  get_rigid_body_system().getRigidBodyTree()->collisionRaycast(
+      rigid_body_state, origin, raycast_endpoints_world, distances);
 
   for (size_t i = 0; i < num_distances; i++) {
     if (distances[i] < 0.0 || distances[i] > max_range_) {
@@ -656,7 +657,6 @@ size_t RigidBodyDepthSensor::getNumOutputs() const {
 bool RigidBodyDepthSensor::is_horizontal_scanner() const {
   return num_pixel_cols_ > 1;
 }
-
 
 bool RigidBodyDepthSensor::is_vertical_scanner() const {
   return num_pixel_rows_ > 1;

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -472,7 +472,7 @@ class DRAKERBSYSTEM_EXPORT RigidBodySensor {
    * to which the sensor is attached.
    */
   RigidBodySensor(const RigidBodySystem& sys, const std::string& name,
-    std::shared_ptr<RigidBodyFrame> frame)
+                  std::shared_ptr<RigidBodyFrame> frame)
       : sys_(sys), name_(name), frame_(frame) {}
 
   virtual ~RigidBodySensor() {}

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -454,26 +454,62 @@ class AdditiveGaussianNoiseModel
   std::mt19937 generator;
 };
 
-/** RigidBodySensor
- * @brief interface class for elements which define a sensor which reads the
- * state of a rigid body system
+/**
+ * An abstract parent class of all sensors.
+ *
+ * This is an abstract top-level class of all rigid body sensors in Drake.
  */
 class DRAKERBSYSTEM_EXPORT RigidBodySensor {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  RigidBodySensor(RigidBodySystem const& sys, const std::string& name)
-      : sys(sys), name(name) {}
+
+  /**
+   * The constructor.
+   *
+   * @param[in] sys The rigid body system to which the sensor is attached.
+   * @param[in] name The name of the sensor.
+   * @param[in] frame The frame within the rigid body system's rigid body tree
+   * to which the sensor is attached.
+   */
+  RigidBodySensor(RigidBodySystem const& sys, const std::string& name,
+    const std::shared_ptr<RigidBodyFrame> frame)
+      : sys_(sys), name_(name), frame_(frame) {}
+
   virtual ~RigidBodySensor() {}
+
   virtual bool isDirectFeedthrough() const { return false; }
+
   virtual size_t getNumOutputs() const { return 0; }
+
   virtual Eigen::VectorXd output(
       const double& t, const KinematicsCache<double>& rigid_body_state,
       const RigidBodySystem::InputVector<double>& u) const = 0;
-  const std::string& get_name() const { return name; }
+
+  /**
+   * Returns the name of the sensor.
+   */
+  const std::string& get_name() const { return name_; }
+
+  /**
+   * Returns the name of the model (i.e., robot) that owns this sensor.
+   */
+  const std::string& get_model_name() const;
 
  protected:
-  RigidBodySystem const& sys;
-  std::string name;
+  /**
+   * The rigid body tree to which the sensor is attached.
+   */
+  RigidBodySystem const& sys_;
+
+  /**
+   * The sensor's name.
+   */
+  std::string name_;
+
+  /**
+   * The frame within the rigid body tree to which this sensor is attached.
+   */
+  const std::shared_ptr<RigidBodyFrame> frame_;
 };
 
 /** RigidBodyDepthSensor
@@ -485,6 +521,7 @@ class DRAKERBSYSTEM_EXPORT RigidBodyDepthSensor : public RigidBodySensor {
   RigidBodyDepthSensor(RigidBodySystem const& sys, const std::string& name,
                        const std::shared_ptr<RigidBodyFrame> frame,
                        tinyxml2::XMLElement* node);
+
   RigidBodyDepthSensor(RigidBodySystem const& sys, const std::string& name,
                        const std::shared_ptr<RigidBodyFrame> frame,
                        std::size_t samples, double min_angle, double max_angle,
@@ -564,9 +601,6 @@ class DRAKERBSYSTEM_EXPORT RigidBodyDepthSensor : public RigidBodySensor {
   // length max_range, at the specific yaw (pitch) angle.
   void cacheRaycastEndpoints();
 
-  // The sensor's frame.
-  const std::shared_ptr<RigidBodyFrame> frame_;
-
   // The minimum pitch of the camera FOV in radians.
   double min_pitch_{};
 
@@ -624,7 +658,6 @@ class DRAKERBSYSTEM_EXPORT RigidBodyAccelerometer : public RigidBodySensor {
  private:
   bool gravity_compensation;
   std::shared_ptr<NoiseModel<double, 3, Eigen::Vector3d>> noise_model;
-  const std::shared_ptr<RigidBodyFrame> frame;
 };
 
 /** RigidBodyGyroscope
@@ -648,7 +681,6 @@ class DRAKERBSYSTEM_EXPORT RigidBodyGyroscope : public RigidBodySensor {
 
  private:
   std::shared_ptr<NoiseModel<double, 3, Eigen::Vector3d>> noise_model;
-  const std::shared_ptr<RigidBodyFrame> frame;
 };
 
 /** RigidBodyMagnetometer
@@ -680,7 +712,6 @@ class DRAKERBSYSTEM_EXPORT RigidBodyMagnetometer : public RigidBodySensor {
  private:
   Eigen::Vector3d magnetic_north;
   std::shared_ptr<NoiseModel<double, 3, Eigen::Vector3d>> noise_model;
-  const std::shared_ptr<RigidBodyFrame> frame;
 };
 
 }  // end namespace Drake

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -471,8 +471,8 @@ class DRAKERBSYSTEM_EXPORT RigidBodySensor {
    * @param[in] frame The frame within the rigid body system's rigid body tree
    * to which the sensor is attached.
    */
-  RigidBodySensor(RigidBodySystem const& sys, const std::string& name,
-    const std::shared_ptr<RigidBodyFrame> frame)
+  RigidBodySensor(const RigidBodySystem& sys, const std::string& name,
+    std::shared_ptr<RigidBodyFrame> frame)
       : sys_(sys), name_(name), frame_(frame) {}
 
   virtual ~RigidBodySensor() {}
@@ -485,30 +485,26 @@ class DRAKERBSYSTEM_EXPORT RigidBodySensor {
       const double& t, const KinematicsCache<double>& rigid_body_state,
       const RigidBodySystem::InputVector<double>& u) const = 0;
 
-  /**
-   * Returns the name of the sensor.
-   */
+  /// Returns the name of the sensor.
   const std::string& get_name() const { return name_; }
 
-  /**
-   * Returns the name of the model (i.e., robot) that owns this sensor.
-   */
+  /// Returns the name of the model (i.e., robot) that owns this sensor.
   const std::string& get_model_name() const;
 
- protected:
-  /**
-   * The rigid body tree to which the sensor is attached.
-   */
-  RigidBodySystem const& sys_;
+  /// Returns the frame to which thi sensor is attached.
+  const std::shared_ptr<RigidBodyFrame> get_frame() const;
 
-  /**
-   * The sensor's name.
-   */
-  std::string name_;
+  /// Returns the rigid body system to which this sensor attaches.
+  const RigidBodySystem& get_rigid_body_system() const;
 
-  /**
-   * The frame within the rigid body tree to which this sensor is attached.
-   */
+ private:
+  /// The rigid body tree to which the sensor is attached.
+  const RigidBodySystem& sys_;
+
+  /// The sensor's name.
+  const std::string name_;
+
+  /// The frame within the rigid body tree to which this sensor is attached.
   const std::shared_ptr<RigidBodyFrame> frame_;
 };
 

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -492,7 +492,7 @@ class DRAKERBSYSTEM_EXPORT RigidBodySensor {
   const std::string& get_model_name() const;
 
   /// Returns the frame to which thi sensor is attached.
-  const std::shared_ptr<RigidBodyFrame> get_frame() const;
+  const RigidBodyFrame& get_frame() const;
 
   /// Returns the rigid body system to which this sensor attaches.
   const RigidBodySystem& get_rigid_body_system() const;

--- a/drake/systems/plants/test/lidarTest.cpp
+++ b/drake/systems/plants/test/lidarTest.cpp
@@ -34,6 +34,11 @@ int do_main(int argc, char* argv[]) {
         "ERROR: Unable to obtain pointer to the LIDAR sensor.");
   }
 
+  if (lidar_sensor->get_model_name() != "room_w_lidar") {
+    throw std::runtime_error(
+      "ERROR: LIDAR scanner reported that it is part of the wrong model!");
+  }
+
   if (!lidar_sensor->is_horizontal_scanner()) {
     throw std::runtime_error(
       "ERROR: LIDAR scanner says it is not horizontal but it is!");


### PR DESCRIPTION
…to get the name of the model (robot) that owns the sensor.

Closes https://github.com/RobotLocomotion/drake/issues/2460

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2462) &emsp; Multiple assignees:&emsp;<img alt="@RussTedrake" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/6442292?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/RussTedrake">RussTedrake</a>,&emsp;<img alt="@jwnimmer-tri" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/17596505?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/jwnimmer-tri">jwnimmer-tri</a>,&emsp;<img alt="@liangfok" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/1388098?s=40&v=3">&nbsp;<a href="/robotlocomotion/drake/pulls/assigned/liangfok">liangfok</a>
<!-- Reviewable:end -->
