### PR TITLE
add ellipsoids as another geometry type for the drake visualizer

### DIFF
--- a/drake/lcmtypes/lcmt_viewer_geometry_data.lcm
+++ b/drake/lcmtypes/lcmt_viewer_geometry_data.lcm
@@ -10,6 +10,7 @@ struct lcmt_viewer_geometry_data
   const int8_t CYLINDER     = 3;
   const int8_t MESH         = 4;
   const int8_t CAPSULE      = 5;
+  const int8_t ELLIPSOID    = 6;
 
 
   float position[3];


### PR DESCRIPTION
This PR is meant to accompany https://github.com/RobotLocomotion/director/pull/272 but either can be safely merged first. I've updated the drake visualizer to support ellipsoids as another geometry primitive. This will make it easier to draw ellipsoids, which will in turn make it easier to, for example, visualize inertial ellipsoids, without the LCMGL code currently used in https://github.com/RobotLocomotion/drake/blob/master/drake/systems/plants/BotVisualizer.m#L178

Note that this modifies an LCM type definition, but because it's only adding an enum value and not modifying any fields, it should not change the LCM type fingerprint. It shouldn't affect compatibility with old LCM log files. 

@psiorx can you review this? :wink:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2464)
<!-- Reviewable:end -->
