### PR TITLE
Pay off some System2 technical debt.

### DIFF
--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -30,7 +30,7 @@ class BasicVector : public VectorInterface<T> {
 
   void set_value(const VectorX<T>& value) override {
     if (value.rows() != values_.rows()) {
-      throw std::runtime_error(
+      throw std::out_of_range(
           "Cannot set a BasicVector of size " + std::to_string(values_.rows()) +
           " with a value of size " + std::to_string(value.rows()));
     }

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -37,6 +37,10 @@ class BasicVector : public VectorInterface<T> {
     values_ = value;
   }
 
+  ptrdiff_t size() const override {
+    return values_.rows();
+  }
+
   const Eigen::VectorBlock<const VectorX<T>> get_value() const override {
     return values_.head(values_.rows());
   }

--- a/drake/systems/framework/named_value_vector.h
+++ b/drake/systems/framework/named_value_vector.h
@@ -40,10 +40,14 @@ class NamedValueVector : public VectorInterface<T> {
 
   ~NamedValueVector() override {}
 
+  ptrdiff_t size() const override {
+    return values_.rows();
+  }
+
   void set_value(const VectorX<T>& value) override {
-    if (value.rows() != values_.rows()) {
+    if (value.rows() != size()) {
       throw std::out_of_range("Cannot set a NamedValueVector of size " +
-                              std::to_string(values_.rows()) +
+                              std::to_string(size()) +
                               " with a value of size " +
                               std::to_string(value.rows()));
     }
@@ -51,11 +55,11 @@ class NamedValueVector : public VectorInterface<T> {
   }
 
   const Eigen::VectorBlock<const VectorX<T>> get_value() const override {
-    return values_.head(values_.rows());
+    return values_.head(size());
   }
 
   Eigen::VectorBlock<VectorX<T>> get_mutable_value() override {
-    return values_.head(values_.rows());
+    return values_.head(size());
   }
 
   bool has_named_value(const std::string& name) const {

--- a/drake/systems/framework/named_value_vector.h
+++ b/drake/systems/framework/named_value_vector.h
@@ -42,10 +42,10 @@ class NamedValueVector : public VectorInterface<T> {
 
   void set_value(const VectorX<T>& value) override {
     if (value.rows() != values_.rows()) {
-      throw std::runtime_error("Cannot set a NamedValueVector of size " +
-                               std::to_string(values_.rows()) +
-                               " with a value of size " +
-                               std::to_string(value.rows()));
+      throw std::out_of_range("Cannot set a NamedValueVector of size " +
+                              std::to_string(values_.rows()) +
+                              " with a value of size " +
+                              std::to_string(value.rows()));
     }
     values_ = value;
   }

--- a/drake/systems/framework/primitives/adder.cc
+++ b/drake/systems/framework/primitives/adder.cc
@@ -22,7 +22,7 @@ std::unique_ptr<Context<T>> Adder<T>::CreateDefaultContext() const {
 }
 
 template <typename T>
-std::unique_ptr<SystemOutput<T>> Adder<T>::CreateDefaultOutput() const {
+std::unique_ptr<SystemOutput<T>> Adder<T>::AllocateOutput() const {
   // An adder has just one output port, a BasicVector of the size specified
   // at construction time.
   std::unique_ptr<SystemOutput<T>> output(new SystemOutput<T>);
@@ -50,7 +50,7 @@ void Adder<T>::Output(const Context<T>& context,
 
   // Check that there are the expected number of input ports.
   if (context.get_input().ports.size() != num_inputs_) {
-    throw std::runtime_error(
+    throw std::out_of_range(
         "Expected " + std::to_string(num_inputs_) + "input ports, but had " +
         std::to_string(context.get_input().ports.size()));
   }
@@ -61,8 +61,8 @@ void Adder<T>::Output(const Context<T>& context,
     const VectorInterface<T>* input =
         context.get_input().ports[i].vector_input;
     if (input == nullptr || input->get_value().rows() != length_) {
-      throw std::runtime_error("Input port " + std::to_string(i) +
-                               "is nullptr or has incorrect size.");
+      throw std::out_of_range("Input port " + std::to_string(i) +
+                              "is nullptr or has incorrect size.");
     }
     output_port->get_mutable_value() += input->get_value();
   }

--- a/drake/systems/framework/primitives/adder.h
+++ b/drake/systems/framework/primitives/adder.h
@@ -25,7 +25,7 @@ class Adder : public SystemInterface<T> {
   std::unique_ptr<Context<T>> CreateDefaultContext() const override;
 
   /// Allocates one output port of the width specified in the constructor.
-  std::unique_ptr<SystemOutput<T>> CreateDefaultOutput() const override;
+  std::unique_ptr<SystemOutput<T>> AllocateOutput() const override;
 
   /// Sums the input ports into the output port. If the input ports are not
   /// of number num_inputs_ or size length_, std::runtime_error will be thrown.

--- a/drake/systems/framework/primitives/test/adder_test.cc
+++ b/drake/systems/framework/primitives/test/adder_test.cc
@@ -17,7 +17,7 @@ class AdderTest : public ::testing::Test {
   void SetUp() override {
     adder_.reset(new Adder<double>(2 /* inputs */, 3 /* length */));
     context_ = adder_->CreateDefaultContext();
-    output_ = adder_->CreateDefaultOutput();
+    output_ = adder_->AllocateOutput();
   }
 
   std::unique_ptr<Adder<double>> adder_;
@@ -46,17 +46,17 @@ TEST_F(AdderTest, AddTwoVectors) {
   EXPECT_EQ(expected, output_port->get_value());
 }
 
-// Tests that std::runtime_error is thrown when the wrong number of input ports
+// Tests that std::out_of_range is thrown when the wrong number of input ports
 // are connected.
 TEST_F(AdderTest, WrongNumberOfInputPorts) {
   // Hook up just one input.
   BasicVector<double> input0(3 /* length */);
   context_->get_mutable_input()->ports[0].vector_input = &input0;
 
-  EXPECT_THROW(adder_->Output(*context_, output_.get()), std::runtime_error);
+  EXPECT_THROW(adder_->Output(*context_, output_.get()), std::out_of_range);
 }
 
-// Tests that std::runtime_error is thrown when input ports of the wrong size
+// Tests that std::out_of_range is thrown when input ports of the wrong size
 // are connected.
 TEST_F(AdderTest, WrongSizeOfInputPorts) {
   // Hook up two inputs, but one of them is the wrong size.
@@ -66,7 +66,7 @@ TEST_F(AdderTest, WrongSizeOfInputPorts) {
   context_->get_mutable_input()->ports[0].vector_input = &input0;
   context_->get_mutable_input()->ports[1].vector_input = &input1;
 
-  EXPECT_THROW(adder_->Output(*context_, output_.get()), std::runtime_error);
+  EXPECT_THROW(adder_->Output(*context_, output_.get()), std::out_of_range);
 }
 
 // Tests that Adder allocates no state variables in the context_.

--- a/drake/systems/framework/system_interface.h
+++ b/drake/systems/framework/system_interface.h
@@ -56,7 +56,7 @@ class SystemInterface : public AbstractSystemInterface {
 
   // Returns a default output, initialized with the correct number of
   // concrete output ports for this System.
-  virtual std::unique_ptr<SystemOutput<T>> CreateDefaultOutput() const = 0;
+  virtual std::unique_ptr<SystemOutput<T>> AllocateOutput() const = 0;
 
   // Computes the output for the given context, possibly updating values
   // in the cache.

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -47,6 +47,12 @@ GTEST_TEST(BasicVectorTest, FunctionalFormInitiallyUndefined) {
   EXPECT_TRUE(vec.get_value()[0].IsUndefined());
 }
 
+// Tests that the BasicVector has a size as soon as it is constructed.
+GTEST_TEST(BasicVectorTest, Size) {
+  BasicVector<int> vec(5);
+  EXPECT_EQ(5, vec.size());
+}
+
 // Tests that the BasicVector can be mutated in-place.
 GTEST_TEST(BasicVectorTest, Mutate) {
   BasicVector<int> vec(2);

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -72,7 +72,7 @@ GTEST_TEST(BasicVectorTest, ReinitializeInvalid) {
   BasicVector<int> vec(2);
   Eigen::Vector3i next_value;
   next_value << 3, 4, 5;
-  EXPECT_THROW(vec.set_value(next_value), std::runtime_error);
+  EXPECT_THROW(vec.set_value(next_value), std::out_of_range);
 }
 
 }  // namespace

--- a/drake/systems/framework/test/named_value_vector_test.cc
+++ b/drake/systems/framework/test/named_value_vector_test.cc
@@ -70,7 +70,7 @@ GTEST_TEST(NamedValueVectorTest, ReinitializeInvalid) {
       std::vector<std::pair<std::string, int>>{{"foo", 1}, {"bar", 2}});
   Eigen::Matrix<int, 3, 1> next_value;
   next_value << 3, 4, 5;
-  EXPECT_THROW(vector.set_value(next_value), std::runtime_error);
+  EXPECT_THROW(vector.set_value(next_value), std::out_of_range);
 }
 
 // Tests that an error is thrown when there are multiple identically

--- a/drake/systems/framework/test/named_value_vector_test.cc
+++ b/drake/systems/framework/test/named_value_vector_test.cc
@@ -18,6 +18,7 @@ GTEST_TEST(NamedValueVectorTest, Access) {
       std::vector<std::pair<std::string, int>>{{"foo", 1}, {"bar", 2}});
   EXPECT_EQ(1, *vector.get_named_value("foo"));
   EXPECT_EQ(2, *vector.get_named_value("bar"));
+  EXPECT_EQ(2, vector.size());
   Eigen::Matrix<int, 2, 1> expected;
   expected << 1, 2;
   EXPECT_EQ(expected, vector.get_value());

--- a/drake/systems/framework/vector_interface.h
+++ b/drake/systems/framework/vector_interface.h
@@ -25,6 +25,10 @@ template <typename T> class VectorInterface {
   VectorInterface(VectorInterface<T>&& other) = delete;
   VectorInterface& operator=(VectorInterface<T>&& other) = delete;
 
+  /// Returns the size of the vector, which must be equal to the number of rows
+  /// in get_value().
+  virtual ptrdiff_t size() const = 0;
+
   /// Sets the vector to the given value. After a.set_value(b.get_value()), a
   /// must be identical to b.
   /// May throw std::out_of_range if the new value has different dimensions

--- a/drake/systems/framework/vector_interface.h
+++ b/drake/systems/framework/vector_interface.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include <Eigen/Dense>
 
 namespace drake {

--- a/drake/systems/framework/vector_interface.h
+++ b/drake/systems/framework/vector_interface.h
@@ -27,7 +27,7 @@ template <typename T> class VectorInterface {
 
   /// Sets the vector to the given value. After a.set_value(b.get_value()), a
   /// must be identical to b.
-  /// May throw std::runtime_error if the new value has different dimensions
+  /// May throw std::out_of_range if the new value has different dimensions
   /// than expected by the concrete class implementing VectorInterface.
   virtual void set_value(const VectorX<T>& value) = 0;
 


### PR DESCRIPTION
- Rename `SystemInterface<T>::CreateDefaultOutput` to `AllocateOutput`.
- Add `VectorInterface::size()`.
- Use `out_of_range` where appropriate.

+@jwnimmer-tri for feature and platform review (but not urgent, can wait until Tuesday)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2474)
<!-- Reviewable:end -->
