### PR TITLE
Revert "Generalize sysid / PolynomialConstraint to vectors"

### DIFF
--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -9,8 +9,8 @@
 
 namespace Drake {
 
-/**
- * A constraint is a function + lower and upper bounds.
+/* Constraint
+ * @brief A constraint is a function + lower and upper bounds.
  *
  * Some thoughts:
  * It should support evaluating the constraint, adding it to an optimization
@@ -66,8 +66,8 @@ class Constraint {
   Eigen::VectorXd lower_bound_, upper_bound_;
 };
 
-/**
- * lb <= .5 x'Qx + b'x <= ub
+/** QuadraticConstraint
+ * @brief  lb <= .5 x'Qx + b'x <= ub
  */
 class QuadraticConstraint : public Constraint {
  public:
@@ -101,11 +101,11 @@ class QuadraticConstraint : public Constraint {
   Eigen::VectorXd b_;
 };
 
-/**
- *  lb[i] <= P[i](x, y...) <= ub[i], where each P[i] is a multivariate
- *  polynomial in x, y...
+/** PolynomialConstraint
+ * @brief lb <= P(x, y...) <= ub where P is a multivariate polynomial
+ *  in x, y...
  *
- * A constraint on the values of multivariate polynomials.
+ * A constraint on the value of a multivariate polynomial.
  *
  * The Polynomial class uses a different variable naming scheme; thus the
  * caller must provide a list of Polynomial::VarType variables that correspond
@@ -114,42 +114,41 @@ class QuadraticConstraint : public Constraint {
  */
 class PolynomialConstraint : public Constraint {
  public:
+  static const int kNumConstraints = 1;
+
   PolynomialConstraint(
-      const VectorXPoly& polynomials,
+      const Polynomiald& polynomial,
       const std::vector<Polynomiald::VarType>& poly_vars,
-      const Eigen::VectorXd& lb, const Eigen::VectorXd& ub)
-      : Constraint(polynomials.rows(), lb, ub),
-        polynomials_(polynomials),
+      double lb, double ub)
+      : Constraint(kNumConstraints,
+                   Vector1d::Constant(lb), Vector1d::Constant(ub)),
+        polynomial_(polynomial),
         poly_vars_(poly_vars) {}
 
   ~PolynomialConstraint() override {}
 
   void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-            Eigen::VectorXd& y) const override {
+                    Eigen::VectorXd& y) const override {
     double_evaluation_point_.clear();
     for (size_t i = 0; i < poly_vars_.size(); i++) {
       double_evaluation_point_[poly_vars_[i]] = x[i];
     }
     y.resize(num_constraints());
-    for (int i = 0; i < num_constraints(); i++) {
-      y[i] = polynomials_[i].evaluateMultivariate(double_evaluation_point_);
-    }
+    y[0] = polynomial_.evaluateMultivariate(double_evaluation_point_);
   }
 
   void eval(const Eigen::Ref<const TaylorVecXd>& x,
-            TaylorVecXd& y) const override {
+                    TaylorVecXd& y) const override {
     taylor_evaluation_point_.clear();
     for (size_t i = 0; i < poly_vars_.size(); i++) {
       taylor_evaluation_point_[poly_vars_[i]] = x[i];
     }
     y.resize(num_constraints());
-    for (int i = 0; i < num_constraints(); i++) {
-      y[i] = polynomials_[i].evaluateMultivariate(taylor_evaluation_point_);
-    }
+    y[0] = polynomial_.evaluateMultivariate(taylor_evaluation_point_);
   }
 
  private:
-  const VectorXPoly polynomials_;
+  const Polynomiald polynomial_;
   const std::vector<Polynomiald::VarType> poly_vars_;
 
   /// To avoid repeated allocation, reuse a map for the evaluation point.
@@ -160,8 +159,8 @@ class PolynomialConstraint : public Constraint {
 // todo: consider implementing DifferentiableConstraint,
 // TwiceDifferentiableConstraint, ComplementarityConstraint,
 // IntegerConstraint, ...
-/**
- * Implements a constraint of the form @f lb <= Ax <= ub @f
+/** LinearConstraint
+ * @brief Implements a constraint of the form @f lb <= Ax <= ub @f
  */
 class LinearConstraint : public Constraint {
  public:
@@ -200,8 +199,8 @@ class LinearConstraint : public Constraint {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> A_;
 };
 
-/**
- * Implements a constraint of the form @f Ax = b @f
+/** LinearEqualityConstraint
+ * @brief Implements a constraint of the form @f Ax = b @f
  */
 class LinearEqualityConstraint : public LinearConstraint {
  public:
@@ -234,14 +233,11 @@ class LinearEqualityConstraint : public LinearConstraint {
   }
 };
 
-/**
-* Implements a constraint of the form @f lb <= x <= ub @f
-*
-* Note: the base Constraint class (as implemented at the moment) could
-* play this role.  But this class enforces that it is ONLY a bounding
-* box constraint, and not something more general.  Some solvers use
-* this information to handle bounding box constraints differently than
-* general constraints, so use of this form is encouraged.
+/** BoundingBoxConstraint
+*@brief Implements a constraint of the form @f lb <= x <= ub @f
+*Note: the base Constraint class (as implemented at the moment) could play this
+* role.  But this class enforces
+*that it is ONLY a bounding box constraint, and not something more general.
 */
 class BoundingBoxConstraint : public LinearConstraint {
  public:
@@ -266,15 +262,14 @@ class BoundingBoxConstraint : public LinearConstraint {
 };
 
 
-/**
- * Implements a constraint of the form:
+/** LinearComplementarityConstraint
  *
+ * Implements a constraint of the form:
  * <pre>
  *   Mx + q >= 0
  *   x >= 0
  *   x'(Mx + q) == 0
  * </pre>
- *
  * An implied slack variable complements any 0 component of x.  To get
  * the slack values at a given solution x, use eval(x).
  */

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -562,9 +562,9 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    */
   std::shared_ptr<PolynomialConstraint>
       AddPolynomialConstraint(
-          const VectorXPoly& polynomials,
+          const Polynomiald& polynomial,
           const std::vector<Polynomiald::VarType>& poly_vars,
-          const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
+          double lb, double ub,
           const VariableList& vars) {
     // TODO(ggould-tri) We treat polynomial constraints as generic for now,
     // but that need not be so.  Polynomials of degree 1 are linear
@@ -576,7 +576,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     problem_type_.reset(
         problem_type_->AddGenericConstraint());
     std::shared_ptr<PolynomialConstraint>
-        constraint(new PolynomialConstraint(polynomials, poly_vars, lb, ub));
+        constraint(new PolynomialConstraint(polynomial, poly_vars, lb, ub));
     AddGenericConstraint(constraint, vars);
     return constraint;
   }
@@ -588,11 +588,11 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    */
   std::shared_ptr<PolynomialConstraint>
       AddPolynomialConstraint(
-          const VectorXPoly& polynomials,
+          const Polynomiald& polynomial,
           const std::vector<Polynomiald::VarType>& poly_vars,
-          const Eigen::VectorXd& lb, const Eigen::VectorXd& ub) {
+          double lb, double ub) {
     return AddPolynomialConstraint(
-        polynomials, poly_vars, lb, ub, variable_views_);
+        polynomial, poly_vars, lb, ub, variable_views_);
   }
 
   // template <typename FunctionType>

--- a/drake/solvers/system_identification.h
+++ b/drake/solvers/system_identification.h
@@ -90,10 +90,13 @@ class DRAKEOPTIMIZATION_EXPORT SystemIdentification {
 
   /// Estimate some parameters of a polynomial based on empirical data.
   /**
-   * Given one or more polynomial equations P[i](a, b, ... x, y, ...) = 0, and
-   * measured values of some its arguments (x, y, ..., referred to as the
-   * "active variables"), estimate values for the remaining arguments (a, b,
-   * ..., referred to as the "parameters").
+   * Given a polynomial equation P(a, b, ... x, y, ...) = 0, and measured
+   * values of some its arguments (x, y, ..., referred to as the "active
+   * variables"), estimate values for the remaining arguments (a, b, ...,
+   * referred to as the "parameters").
+   *
+   * P in this case is a single polynomial.  A version that takes a vector of
+   * Polynomial is forthcoming (TODO(ggould-tri)).
    *
    * Measured x, y, ... is provided in a list of maps, active_var_values.
    *
@@ -104,7 +107,7 @@ class DRAKEOPTIMIZATION_EXPORT SystemIdentification {
    */
   typedef std::map<VarType, CoefficientType> PartialEvalType;
   static std::pair<PartialEvalType, CoefficientType> EstimateParameters(
-      const VectorXPoly& polys,
+      const PolyType& poly,
       const std::vector<PartialEvalType>& active_var_values);
 
  private:

--- a/drake/solvers/test/system_identification_test.cpp
+++ b/drake/solvers/test/system_identification_test.cpp
@@ -170,8 +170,7 @@ GTEST_TEST(SystemIdentificationTest, BASIC_ESTIMATE_TEST_NAME) {
     SID::PartialEvalType estimated_params;
     double error;
     std::tie(estimated_params, error) =
-        SID::EstimateParameters(VectorXPoly::Constant(1, poly),
-                                sample_points);
+        SID::EstimateParameters(poly, sample_points);
 
     EXPECT_LT(error, 1e-5);
     EXPECT_EQ(estimated_params.size(), 3);
@@ -193,8 +192,7 @@ GTEST_TEST(SystemIdentificationTest, BASIC_ESTIMATE_TEST_NAME) {
     SID::PartialEvalType estimated_params;
     double error;
     std::tie(estimated_params, error) =
-        SID::EstimateParameters(VectorXPoly::Constant(1, poly),
-                                sample_points);
+        SID::EstimateParameters(poly, sample_points);
 
     EXPECT_LT(error, 0.1);
     EXPECT_EQ(estimated_params.size(), 3);
@@ -263,19 +261,15 @@ std::vector<State> MakeTestData() {
 #define IDENTIFICATION_TEST_NAME DISABLED_SpringMassIdentification
 #endif
 
-// TODO(ggould-tri) It is likely that much of the logic below will be
-// boilerplate shared by all manipulator identification; it should eventually
-// be pulled into a function of its own inside of system_identification.
-
 GTEST_TEST(SystemIdentificationTest, IDENTIFICATION_TEST_NAME) {
-  Polynomiald pos = Polynomiald("pos");
-  auto pos_var = pos.getSimpleVariable();
-  Polynomiald velocity = Polynomiald("vel");
-  auto velocity_var = velocity.getSimpleVariable();
-  Polynomiald acceleration = Polynomiald("acc");
-  auto acceleration_var = acceleration.getSimpleVariable();
-  Polynomiald input_force = Polynomiald("f_in");
-  auto input_force_var = input_force.getSimpleVariable();
+  Polynomiald x = Polynomiald("x");
+  auto x_var = x.getSimpleVariable();
+  Polynomiald v = Polynomiald("v");
+  auto v_var = v.getSimpleVariable();
+  Polynomiald a = Polynomiald("a");
+  auto a_var = a.getSimpleVariable();
+  Polynomiald f = Polynomiald("f");
+  auto f_var = f.getSimpleVariable();
   Polynomiald mass = Polynomiald("m");
   auto mass_var = mass.getSimpleVariable();
   Polynomiald damping = Polynomiald("b");
@@ -283,47 +277,30 @@ GTEST_TEST(SystemIdentificationTest, IDENTIFICATION_TEST_NAME) {
   Polynomiald spring = Polynomiald("k");
   auto spring_var = spring.getSimpleVariable();
 
-  // Code style violations here:
-  // * Vector initializations use two statements on one line for clarity.
-  // * The short names and upper/lower case here are conventional in the
-  //   manipulator formulation.
-  //
-  // We write the manipulator as:
-  //   H*vdot + C*v + g = B*u + f
-  // Where f embodies any forces not appropriate to C.
-  VectorXPoly v(1); v << velocity;
-  VectorXPoly vdot(1); vdot << acceleration;
-  VectorXPoly H(1); H << mass;
-  VectorXPoly C(1); C << 0;
-  VectorXPoly g(1); g << (spring * pos);
-  VectorXPoly f(1); f << (velocity * damping);
-  VectorXPoly B(1); B << 1;
-  VectorXPoly u(1); u << input_force;
-
-  const VectorXPoly manipulator_left = (H * vdot) + (C * v) + g;
-  const VectorXPoly manipulator_right = (B * u) + f;
+  // We use a simple equation of motion rather than a manipulator equation
+  // here because we are testing the 1D version of parameter estimation.
+  Polynomiald force_equation = (mass * a) + (damping * v) + (spring * x) - f;
 
   std::default_random_engine noise_generator;
   noise_generator.seed(kNoiseSeed);
   std::uniform_real_distribution<double> noise_distribution(-kNoise, kNoise);
   auto noise = std::bind(noise_distribution, noise_generator);
 
-  const std::vector<State> oracular_data = MakeTestData();
+  std::vector<State> oracular_data = MakeTestData();
   std::vector<SID::PartialEvalType> measurements;
   for (const State& oracular_state : oracular_data) {
     SID::PartialEvalType measurement;
-    measurement[pos_var] = oracular_state.position + noise();
-    measurement[velocity_var] = oracular_state.velocity + noise();
-    measurement[acceleration_var] = oracular_state.acceleration + noise();
-    measurement[input_force_var] = oracular_state.force + noise();
+    measurement[x_var] = oracular_state.position + noise();
+    measurement[v_var] = oracular_state.velocity + noise();
+    measurement[a_var] = oracular_state.acceleration + noise();
+    measurement[f_var] = oracular_state.force + noise();
     measurements.push_back(measurement);
   }
 
   SID::PartialEvalType estimated_params;
   double error;
   std::tie(estimated_params, error) =
-      SID::EstimateParameters(manipulator_left - manipulator_right,
-                              measurements);
+      SID::EstimateParameters(force_equation, measurements);
 
   // Multiple layers of naive discrete-time numeric integration yields a very
   // high error value here, which almost all lands in the damping constant

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -540,15 +540,11 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
 
   // Given a degenerate polynomial, get the trivial solution.
   {
-    const Polynomiald x("x");
+    Polynomiald x("x");
     OptimizationProblem problem;
-    const auto x_var = problem.AddContinuousVariables(1);
-    const std::vector<Polynomiald::VarType> var_mapping = {
-      x.getSimpleVariable() };
-    problem.AddPolynomialConstraint(VectorXPoly::Constant(1, x),
-                                    var_mapping,
-                                    Vector1d::Constant(2),
-                                    Vector1d::Constant(2));
+    auto x_var = problem.AddContinuousVariables(1);
+    std::vector<Polynomiald::VarType> var_mapping = { x.getSimpleVariable() };
+    problem.AddPolynomialConstraint(x, var_mapping, 2, 2);
     RunNonlinearProgram(problem, [&]() {
         EXPECT_NEAR(x_var.value()[0], 2, kEpsilon);
         // TODO(ggould-tri) test this with a two-sided constraint, once
@@ -558,16 +554,12 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
 
   // Given a small univariate polynomial, find a low point.
   {
-    const Polynomiald x("x");
-    const Polynomiald poly = (x - 1) * (x - 1);
+    Polynomiald x("x");
+    Polynomiald poly = (x - 1) * (x - 1);
     OptimizationProblem problem;
-    const auto x_var = problem.AddContinuousVariables(1);
-    const std::vector<Polynomiald::VarType> var_mapping = {
-      x.getSimpleVariable() };
-    problem.AddPolynomialConstraint(VectorXPoly::Constant(1, poly),
-                                    var_mapping,
-                                    Eigen::VectorXd::Zero(1),
-                                    Eigen::VectorXd::Zero(1));
+    auto x_var = problem.AddContinuousVariables(1);
+    std::vector<Polynomiald::VarType> var_mapping = { x.getSimpleVariable() };
+    problem.AddPolynomialConstraint(poly, var_mapping, 0, 0);
     RunNonlinearProgram(problem, [&]() {
         EXPECT_NEAR(x_var.value()[0], 1, 0.2);
         EXPECT_LE(poly.evaluateUnivariate(x_var.value()[0]), kEpsilon);
@@ -576,18 +568,15 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
 
   // Given a small multivariate polynomial, find a low point.
   {
-    const Polynomiald x("x");
-    const Polynomiald y("y");
-    const Polynomiald poly = (x - 1) * (x - 1) + (y + 2) * (y + 2);
+    Polynomiald x("x");
+    Polynomiald y("y");
+    Polynomiald poly = (x - 1) * (x - 1) + (y + 2) * (y + 2);
     OptimizationProblem problem;
-    const auto xy_var = problem.AddContinuousVariables(2);
-    const std::vector<Polynomiald::VarType> var_mapping = {
+    auto xy_var = problem.AddContinuousVariables(2);
+    std::vector<Polynomiald::VarType> var_mapping = {
       x.getSimpleVariable(),
       y.getSimpleVariable()};
-    problem.AddPolynomialConstraint(VectorXPoly::Constant(1, poly),
-                                    var_mapping,
-                                    Eigen::VectorXd::Zero(1),
-                                    Eigen::VectorXd::Zero(1));
+    problem.AddPolynomialConstraint(poly, var_mapping, 0, 0);
     RunNonlinearProgram(problem, [&]() {
         EXPECT_NEAR(xy_var.value()[0], 1, 0.2);
         EXPECT_NEAR(xy_var.value()[1], -2, 0.2);
@@ -602,19 +591,14 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
   {
     // (x^4 - x^2 + 0.2 has two minima, one at 0.5 and the other at -0.5;
     // constrain x < 0 and EXPECT that the solver finds the negative one.)
-    const Polynomiald x("x");
-    const Polynomiald poly = x * x * x * x - x * x + 0.2;
+    Polynomiald x("x");
+    Polynomiald poly = x * x * x * x - x * x + 0.2;
     OptimizationProblem problem;
-    const auto x_var = problem.AddContinuousVariables(1);
+    auto x_var = problem.AddContinuousVariables(1);
     problem.SetInitialGuess({x_var}, Vector1d::Constant(-0.1));
-    const std::vector<Polynomiald::VarType> var_mapping = {
-      x.getSimpleVariable() };
-    VectorXPoly polynomials_vec(2, 1);
-    polynomials_vec << poly, x;
-    problem.AddPolynomialConstraint(polynomials_vec,
-                                    var_mapping,
-                                    Vector1d::Constant(-kInf),
-                                    Eigen::VectorXd::Zero(1));
+    std::vector<Polynomiald::VarType> var_mapping = { x.getSimpleVariable() };
+    problem.AddPolynomialConstraint(poly, var_mapping, -kInf, 0);
+    problem.AddPolynomialConstraint(x, var_mapping, -kInf, 0);
     RunNonlinearProgram(problem, [&]() {
         EXPECT_NEAR(x_var.value()[0], -0.7, 0.2);
         EXPECT_LE(poly.evaluateUnivariate(x_var.value()[0]), kEpsilon);

--- a/drake/util/Polynomial.h
+++ b/drake/util/Polynomial.h
@@ -492,6 +492,3 @@ std::ostream& operator<<(
 }
 
 typedef Polynomial<double> Polynomiald;
-
-/// A column vector of polynomials; used in several optimization classes.
-typedef Eigen::Matrix<Polynomiald, Eigen::Dynamic, 1> VectorXPoly;


### PR DESCRIPTION
Reverts RobotLocomotion/drake#2469

Dear @ggould-tri,

The oncall build cop, @jonathan-owens, believes that your #2469 may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration on presubmit, because additional
platforms and tests are built in postsubmit.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/job/linux-clang-continuous-debug/271/changes
https://drake-jenkins.csail.mit.edu/job/linux-clang-ninja-continuous-debug/43/changes
https://drake-jenkins.csail.mit.edu/job/mac-clang-continuous-debug/255/changes

Therefore, the build cop has created this revert PR and started a complete
postsubmit build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

Thanks!
Your Friendly Oncall Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2492)
<!-- Reviewable:end -->
