### PR TITLE
Remove pod-build from the documented Windows library paths.

### DIFF
--- a/drake/doc/windows.rst
+++ b/drake/doc/windows.rst
@@ -166,10 +166,9 @@ Note that after this initial build is done, if you change Drake's code, you can 
 Update PATH Environment Variable
 --------------------------------
 
-The compilation process generates a bunch of shared ``.dll`` libraries. You need to add the path to these directories to your ``PATH`` environment variable. Specifically, add the following:
+The compilation process generates a bunch of installed ``.dll`` libraries. You need to add the path to these libraries to your ``PATH`` environment variable:
 
-1. [build artifacts directory]\drake\lib\[build configuration]
-2. [build artifacts directory]\install\lib
+2. ``[build artifacts directory]\install\lib``
 
 Test Compilation Results
 ------------------------

--- a/drake/doc/windows.rst
+++ b/drake/doc/windows.rst
@@ -168,7 +168,7 @@ Update PATH Environment Variable
 
 The compilation process generates a bunch of installed ``.dll`` libraries. You need to add the path to these libraries to your ``PATH`` environment variable:
 
-2. ``[build artifacts directory]\install\lib``
+* ``[build artifacts directory]\install\lib``
 
 Test Compilation Results
 ------------------------


### PR DESCRIPTION
It is not supported in CI since https://github.com/RobotLocomotion/drake-ci/commit/538b885acaf760186aa852ae16bbdd3e4775f671.  It came back briefly for MATLAB, but has since been removed altogether.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2497)
<!-- Reviewable:end -->
