### PR TITLE
SimpleCar support for TaylorVarXd

### DIFF
--- a/drake/examples/Cars/simple_car-inl.h
+++ b/drake/examples/Cars/simple_car-inl.h
@@ -35,8 +35,9 @@ SimpleCar::StateVector<ScalarType> SimpleCar::dynamics(
   new_velocity = std::max(new_velocity, static_cast<ScalarType>(0.));
 
   // Apply steering.
-  ScalarType sane_steering_angle = remainder(
-      input.steering_angle(), static_cast<ScalarType>(2 * M_PI));
+  ScalarType sane_steering_angle = input.steering_angle();
+  assert(sane_steering_angle >= static_cast<ScalarType>(M_PI));
+  assert(sane_steering_angle <= static_cast<ScalarType>(M_PI));
   sane_steering_angle = std::min(
       sane_steering_angle,
       static_cast<ScalarType>(config_.max_abs_steering_angle));

--- a/drake/examples/Cars/simple_car-inl.h
+++ b/drake/examples/Cars/simple_car-inl.h
@@ -26,23 +26,28 @@ SimpleCar::StateVector<ScalarType> SimpleCar::dynamics(
   ScalarType new_velocity = state.velocity() +
                             input.throttle() * config_.max_acceleration *
                                 config_.velocity_lookahead_time;
-  new_velocity = std::min(new_velocity, config_.max_velocity);
+  new_velocity = std::min(
+      new_velocity, static_cast<ScalarType>(config_.max_velocity));
 
   // Apply simplistic brake.
   new_velocity += input.brake() * -config_.max_acceleration *
                   config_.velocity_lookahead_time;
-  new_velocity = std::max(new_velocity, 0.);
+  new_velocity = std::max(new_velocity, static_cast<ScalarType>(0.));
 
   // Apply steering.
-  ScalarType sane_steering_angle =
-      std::max(std::min(std::remainder(input.steering_angle(), 2 * M_PI),
-                        config_.max_abs_steering_angle),
-               -config_.max_abs_steering_angle);
-  ScalarType curvature = std::tan(sane_steering_angle) / config_.wheelbase;
+  ScalarType sane_steering_angle = remainder(
+      input.steering_angle(), static_cast<ScalarType>(2 * M_PI));
+  sane_steering_angle = std::min(
+      sane_steering_angle,
+      static_cast<ScalarType>(config_.max_abs_steering_angle));
+  sane_steering_angle = std::max(
+      sane_steering_angle,
+      static_cast<ScalarType>(-config_.max_abs_steering_angle));
+  ScalarType curvature = tan(sane_steering_angle) / config_.wheelbase;
 
   StateVector<ScalarType> rates;
-  rates.set_x(state.velocity() * std::cos(state.heading()));
-  rates.set_y(state.velocity() * std::sin(state.heading()));
+  rates.set_x(state.velocity() * cos(state.heading()));
+  rates.set_y(state.velocity() * sin(state.heading()));
   rates.set_heading(curvature * state.velocity());
   rates.set_velocity((new_velocity - state.velocity()) * config_.velocity_kp);
   return rates;

--- a/drake/examples/Cars/simple_car.cc
+++ b/drake/examples/Cars/simple_car.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/Cars/simple_car-inl.h"
 
+#include "drake/core/Gradient.h"
+
 namespace drake {
 
 const double kInchToMeter = 0.0254;
@@ -32,7 +34,7 @@ SimpleCar::OutputVector<ScalarType> drake::SimpleCar::output(   \
 
 // These instantiations must match the API documentation in simple_car.h.
 DRAKE_INSTANTIATE(double)
-// TODO(jwnimmer-tri) Add support for additional types.
+DRAKE_INSTANTIATE(Drake::TaylorVarXd)
 
 #undef DRAKE_INSTANTIATE
 

--- a/drake/examples/Cars/simple_car.h
+++ b/drake/examples/Cars/simple_car.h
@@ -23,8 +23,9 @@ namespace drake {
 /// * velocity
 ///
 /// input vector:
-/// * steering angle (virtual center wheel angle, with some limits);
-///   a positive angle means a positive change in heading (left turn)
+/// * steering angle (virtual center wheel angle);
+///   a positive angle means a positive change in heading (left turn);
+///   the value must lie within (-pi, +pi).
 /// * throttle (0-1)
 /// * brake (0-1)
 ///

--- a/drake/examples/Cars/simple_car.h
+++ b/drake/examples/Cars/simple_car.h
@@ -40,11 +40,10 @@ class DRAKECARS_EXPORT SimpleCar {
 
   const drake::lcmt_simple_car_config_t& config() const { return config_; }
 
-  // TODO(jwnimmer-tri) Clarify the type requirements in a future PR.
   /// @name Implement the Drake System concept.
   ///
-  /// @tparam ScalarType must support certain arithmetic operations,
-  /// which will be specified at a future time.
+  /// @tparam ScalarType must support certain arithmetic operations;
+  /// for details, see ./test/simple_car_scalartype_test.cc.
   ///
   /// Instantiated templates for the following ScalarTypes are provided:
   /// - double

--- a/drake/examples/Cars/simple_car.h
+++ b/drake/examples/Cars/simple_car.h
@@ -48,6 +48,7 @@ class DRAKECARS_EXPORT SimpleCar {
   ///
   /// Instantiated templates for the following ScalarTypes are provided:
   /// - double
+  /// - Drake::TaylorVarXd
   /// They are already available to link against in libdrakeCars.
   ///
   /// To use other unusual ScalarType substitutions,

--- a/drake/examples/Cars/test/CMakeLists.txt
+++ b/drake/examples/Cars/test/CMakeLists.txt
@@ -3,7 +3,9 @@ if(GTEST_FOUND AND LCM_FOUND AND NOT WIN32)
   target_link_libraries(curve2_test ${GTEST_BOTH_LIBRARIES} drakeCars)
   add_test(NAME curve2_test COMMAND curve2_test)
 
-  add_executable(simple_car_test simple_car_test.cc)
+  add_executable(simple_car_test
+    simple_car_test.cc
+    simple_car_scalartype_test.cc)
   target_link_libraries(simple_car_test ${GTEST_BOTH_LIBRARIES} drakeCars)
   add_test(NAME simple_car_test COMMAND simple_car_test)
 

--- a/drake/examples/Cars/test/simple_car_scalartype_test.cc
+++ b/drake/examples/Cars/test/simple_car_scalartype_test.cc
@@ -22,7 +22,6 @@ struct MST {
 
   bool operator<(const MST&) const { return true; }
 };
-MST remainder(const MST&, const MST&) { return MST{}; }
 MST sin(const MST&) { return MST{}; }
 MST cos(const MST&) { return MST{}; }
 MST tan(const MST&) { return MST{}; }

--- a/drake/examples/Cars/test/simple_car_scalartype_test.cc
+++ b/drake/examples/Cars/test/simple_car_scalartype_test.cc
@@ -1,0 +1,57 @@
+#include "drake/examples/Cars/simple_car-inl.h"
+
+/// @file
+/// Separate test program, so that we can use the -inl file.
+
+#include "gtest/gtest.h"
+
+namespace {
+/// An expression of the minimal ScalarType (MST) concept for SimpleCar.
+struct MST {
+  MST() {}
+  explicit MST(const double&) {}
+  MST& operator=(const MST&) { return *this; }
+
+  MST operator*(double) const { return *this; }
+  MST operator/(double) const { return *this; }
+
+  MST operator+(const MST&) const { return *this; }
+  MST operator-(const MST&) const { return *this; }
+  MST operator+=(const MST&) const { return *this; }
+  MST operator*(const MST&) const { return *this; }
+
+  bool operator<(const MST&) const { return true; }
+};
+MST remainder(const MST&, const MST&) { return MST{}; }
+MST sin(const MST&) { return MST{}; }
+MST cos(const MST&) { return MST{}; }
+MST tan(const MST&) { return MST{}; }
+}  // namespace
+
+namespace drake {
+namespace examples {
+namespace simple_car {
+namespace test {
+namespace {
+
+GTEST_TEST(SimpleCarScalarTypeTest, CompileTest) {
+  const SimpleCar dut;
+
+  const MST time_zero{};
+  const SimpleCarState<MST> state_zeros{};
+  const DrivingCommand<MST> input_zeros{};
+
+  const SimpleCarState<MST> dynamics =
+      dut.dynamics(time_zero, state_zeros, input_zeros);
+  const SimpleCarState<MST> output =
+      dut.output(time_zero, state_zeros, input_zeros);
+
+  // If we compiled, declare victory.
+  GTEST_SUCCEED();
+}
+
+}
+}
+}
+}
+}


### PR DESCRIPTION
Add SimpleCar support for TaylorVarXd:
- Express the minimal scalar type concept for simple car.
- Remove the modulus on steering_angle, in preparation for TaylorVarXd.
- Add pre-compiled TaylorVarXd support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2523)
<!-- Reviewable:end -->
