### PR TITLE
Fix some -Wsign-compare errors

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -96,7 +96,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all")
 
   # TODO(#2372) These are warnings that we can't handle yet.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")

--- a/drake/bindings/swig/CMakeLists.txt
+++ b/drake/bindings/swig/CMakeLists.txt
@@ -11,6 +11,11 @@ set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "-w315,-401")
 # Ignore SWIG errors about not being able to wrap operator <<
 set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "-w503")
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # The autodiff.i in swig has for-loop variable warnings.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 if(PYTHON_EXECUTABLE)
   include(SwigPython)
   set(python_install_subdir lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages ${CMAKE_CURRENT_SOURCE_DIR}/../python)

--- a/drake/examples/CMakeLists.txt
+++ b/drake/examples/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 add_matlab_test(NAME examples/CubicPolynomialExample.findFixedPointTest COMMAND CubicPolynomialExample.findFixedPointTest)
 add_matlab_test(NAME examples/CubicPolynomialExample.animate COMMAND CubicPolynomialExample.animate)
 add_matlab_test(NAME examples/CubicPolynomialExample.sosExample COMMAND CubicPolynomialExample.sosExample REQUIRES spotless)

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -1,5 +1,10 @@
 # TODO: still build something useful if Gurobi does not exist
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 pods_find_pkg_config(gurobi)
 
 if(gurobi_FOUND)

--- a/drake/systems/CMakeLists.txt
+++ b/drake/systems/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 if(simulink_FOUND)
   add_mex(DCSFunction DCSFunction.cpp)
 endif()

--- a/drake/util/Polynomial.cpp
+++ b/drake/util/Polynomial.cpp
@@ -243,7 +243,8 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::derivative(
 
   for (typename vector<Monomial>::const_iterator iter = monomials.begin();
        iter != monomials.end(); iter++) {
-    if (!iter->terms.empty() && iter->terms[0].power >= derivative_order) {
+    if (!iter->terms.empty() && (
+            iter->terms[0].power >= static_cast<PowerType>(derivative_order))) {
       Monomial m = *iter;
       for (unsigned int k = 0; k < derivative_order;
            k++) {  // take the remaining derivatives
@@ -544,7 +545,7 @@ string Polynomial<CoefficientType>::idToVariableName(const VarType id) {
                                                    (int)(kNameLength - 1));
   char name[kNameLength + 1];
   int j = 0;
-  for (int i = 0; i < kNameLength; i++) {
+  for (int i = 0; i < static_cast<int>(kNameLength); i++) {
     unsigned int name_ind = (name_part / multiplier) % (kNumNameChars + 1);
     if (name_ind > 0) name[j++] = kNameChars[name_ind - 1];
     multiplier /= kNumNameChars + 1;

--- a/drake/util/barycentricInterpolation.cpp
+++ b/drake/util/barycentricInterpolation.cpp
@@ -61,7 +61,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   int m = static_cast<int>(mxGetM(prhs[1])),
       n = static_cast<int>(mxGetN(prhs[1])), d = m + 1;
 
-  if (mxGetNumberOfElements(prhs[0]) != m)
+  if (static_cast<int>(mxGetNumberOfElements(prhs[0])) != m)
     mexErrMsgIdAndTxt(
         "Drake:barycentricInterpolation:BadInput",
         "the number of bins must equal the dimension of the points");

--- a/drake/util/convexHull.cpp
+++ b/drake/util/convexHull.cpp
@@ -81,7 +81,7 @@ double signedDistanceInsideConvexHull(
   Matrix2d R;
   R << 0, 1, -1, 0;
 
-  for (int i = 0; i < hull_pts.size() - 1; ++i) {
+  for (int i = 0; i < (static_cast<int>(hull_pts.size()) - 1); ++i) {
     Vector2d ai = R * Vector2d(hull_pts[i + 1].x - hull_pts[i].x,
                                hull_pts[i + 1].y - hull_pts[i].y);
     double b = ai.transpose() * Vector2d(hull_pts[i].x, hull_pts[i].y);

--- a/drake/util/drakeMexUtil.cpp
+++ b/drake/util/drakeMexUtil.cpp
@@ -225,7 +225,7 @@ mxArray* stdStringToMatlab(const std::string& str) {
 
 mxArray* vectorOfStdStringsToMatlab(const std::vector<std::string>& strs) {
   mxArray* cell = mxCreateCellMatrix(strs.size(), 1);
-  for (int i = 0; i < strs.size(); i++) {
+  for (size_t i = 0; i < strs.size(); i++) {
     mxSetCell(cell, i, mxCreateString(strs[i].c_str()));
   }
   return cell;
@@ -305,12 +305,12 @@ const std::vector<T> matlabToStdVector(const mxArray* in) {
   std::vector<T> ret;
   if (mxIsLogical(in)) {
     mxLogical* data = mxGetLogicals(in);
-    for (int i = 0; i < mxGetNumberOfElements(in); i++) {
+    for (size_t i = 0; i < mxGetNumberOfElements(in); i++) {
       ret.push_back(static_cast<T>(data[i]));
     }
   } else {
     double* data = mxGetPrSafe(in);
-    for (int i = 0; i < mxGetNumberOfElements(in); i++) {
+    for (size_t i = 0; i < mxGetNumberOfElements(in); i++) {
       ret.push_back(static_cast<T>(data[i]));
     }
   }
@@ -392,7 +392,7 @@ trigPolyToEigen(const mxArray* trigpoly) {
 mwSize sub2ind(mwSize ndims, const mwSize* dims, const mwSize* sub) {
   mwSize stride = 1;
   mwSize ret = 0;
-  for (int i = 0; i < ndims; i++) {
+  for (mwSize i = 0; i < ndims; i++) {
     ret += sub[i] * stride;
     stride *= dims[i];
   }

--- a/drake/util/lcmUtil.cpp
+++ b/drake/util/lcmUtil.cpp
@@ -46,7 +46,8 @@ void verifySubtypeSizes(drake::lcmt_support_data& support_data) {
     throw std::runtime_error("contact_pts must have 3 rows");
   }
   for (int j = 0; j < 3; ++j) {
-    if (support_data.contact_pts[j].size() != support_data.num_contact_pts) {
+    if (static_cast<int32_t>(support_data.contact_pts[j].size()) !=
+        support_data.num_contact_pts) {
       std::stringstream msg;
       msg << "num_contact_pts must match the size of each row of contact_pts."
           << std::endl;
@@ -61,19 +62,23 @@ void verifySubtypeSizes(drake::lcmt_support_data& support_data) {
 void verifySubtypeSizes(drake::lcmt_qp_controller_input& qp_input) {
   // Check (and try to fix) errors in the sizes of the variable-length fields in
   // our message
-  if (qp_input.support_data.size() != qp_input.num_support_data) {
+  if (static_cast<int32_t>(qp_input.support_data.size()) !=
+      qp_input.num_support_data) {
     std::cerr << "WARNING: num support data doesn't match" << std::endl;
     qp_input.num_support_data = qp_input.support_data.size();
   }
-  if (qp_input.body_motion_data.size() != qp_input.num_tracked_bodies) {
+  if (static_cast<int32_t>(qp_input.body_motion_data.size()) !=
+      qp_input.num_tracked_bodies) {
     std::cerr << "WARNING: num tracked bodies doesn't match" << std::endl;
     qp_input.num_tracked_bodies = qp_input.body_motion_data.size();
   }
-  if (qp_input.body_wrench_data.size() != qp_input.num_external_wrenches) {
+  if (static_cast<int32_t>(qp_input.body_wrench_data.size()) !=
+      qp_input.num_external_wrenches) {
     std::cerr << "WARNING: num external wrenches doesn't match" << std::endl;
     qp_input.num_external_wrenches = qp_input.body_wrench_data.size();
   }
-  if (qp_input.joint_pd_override.size() != qp_input.num_joint_pd_overrides) {
+  if (static_cast<int32_t>(qp_input.joint_pd_override.size()) !=
+      qp_input.num_joint_pd_overrides) {
     std::cerr << "WARNING: num joint pd override doesn't match" << std::endl;
     qp_input.num_joint_pd_overrides = qp_input.joint_pd_override.size();
   }

--- a/drake/util/publishLCMLog.cpp
+++ b/drake/util/publishLCMLog.cpp
@@ -26,7 +26,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
         "publishLCMLog failed: input must be a structure with fields 'channel' "
         "and 'data'");
 
-  for (int i = 0; i < mxGetNumberOfElements(prhs[0]); i++) {
+  for (size_t i = 0; i < mxGetNumberOfElements(prhs[0]); i++) {
     channel =
         mxArrayToString(mxGetFieldByNumber(prhs[0], i, channel_field_number));
     data = mxGetFieldByNumber(prhs[0], i, data_field_number);


### PR DESCRIPTION
Fix some `-Wsign-compare` errors.  This is portion of #2372.  The directories that still have sign-compare warnings are now explicitly tagged in their `CMakeLists.txt`, and we can pick them off incrementally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2524)
<!-- Reviewable:end -->
