### PR TITLE
Warn and set javac -target on mismatched MATLAB JVM and JDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,36 +93,40 @@ option(DISABLE_MATLAB "Don't use MATLAB even if it is present." OFF)
 if(DISABLE_MATLAB)
   message(STATUS "MATLAB is disabled.")
 else()
-  find_package(Matlab COMPONENTS MAIN_PROGRAM)
+  find_program(matlab matlab)
+  if(matlab)
+    message(STATUS "Found MATLAB at " ${matlab})
+  else()
+    message(STATUS "Looked for MATLAB but could not find it.")
+  endif()
 endif()
 
 ## The following projects are default ON when MATLAB is present and enabled.
 ## Otherwise, they are hidden and default OFF.
-cmake_dependent_option(WITH_SPOTLESS "polynomial optimization front-end for MATLAB" ON Matlab_FOUND OFF)
+cmake_dependent_option(WITH_SPOTLESS "polynomial optimization front-end for MATLAB" ON "NOT DISABLE_MATLAB;matlab" OFF)
 
 ## The following projects are default OFF when MATLAB is present and enabled.
 ## Otherwise, they are hidden and default OFF.
 ## Some of them may also be hidden on Windows regardless of the status of MATLAB.
-if(NOT WIN32)
-  cmake_dependent_option(WITH_BERTINI "solve polynomial equations; free but pod requires permissions (can't redistribute)" OFF Matlab_FOUND OFF)
-  cmake_dependent_option(WITH_GLOPTIPOLY "free global polynomial optimization tooblox" OFF Matlab_FOUND OFF)
-  cmake_dependent_option(WITH_IRIS "fast approximate convex segmentation" OFF "Matlab_FOUND;WITH_MOSEK" OFF)
-  cmake_dependent_option(WITH_MOSEK "convex optimization solver; free for academics" OFF Matlab_FOUND OFF)
-  cmake_dependent_option(WITH_SEDUMI "semi-definite programming solver" OFF Matlab_FOUND OFF)
-  cmake_dependent_option(WITH_YALMIP "free optimization front-end for MATLAB" OFF Matlab_FOUND OFF)
-  cmake_dependent_option(WITH_XFOIL "use w/ XFOIL to compute aerodynamic coefficients for airfoils" OFF Matlab_FOUND OFF)
-endif()
+cmake_dependent_option(WITH_BERTINI "solve polynomial equations; free but pod requires permissions (can't redistribute)" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
+cmake_dependent_option(WITH_GLOPTIPOLY "free global polynomial optimization tooblox" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
+cmake_dependent_option(WITH_IRIS "fast approximate convex segmentation" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32;WITH_MOSEK" OFF)
+cmake_dependent_option(WITH_MOSEK "convex optimization solver; free for academics" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
+cmake_dependent_option(WITH_SEDUMI "semi-definite programming solver" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
+cmake_dependent_option(WITH_YALMIP "free optimization front-end for MATLAB" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
+cmake_dependent_option(WITH_XFOIL "use w/ XFOIL to compute aerodynamic coefficients for airfoils" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
 
 ###########################################
 # External Projects that are OFF by default
 ###########################################
 option(WITH_SNOPT "nonlinear optimization solver; requires access to RobotLocomotion/snopt-pod")
+cmake_dependent_option(WITH_SIGNALSCOPE "live plotting tool for lcm messages" OFF "NOT WIN32;WITH_DIRECTOR" OFF)
+
 if(NOT WIN32) # many of these might work on win32 with little or no work... they just haven't been tried
   option(WITH_AVL "use w/ AVL to compute aerodynamic coefficients for airfoils")
   option(WITH_GUROBI "convex/integer optimization solver; free for academics (will prompt you for login bits)")
   option(WITH_MESHCONVERTERS "uses vcglib to convert a few standard filetypes")
   option(WITH_OCTOMAP "provides oct-tree data structures")
-  cmake_dependent_option(WITH_SIGNALSCOPE "live plotting tool for lcm messages" OFF WITH_DIRECTOR OFF)
   option(WITH_TEXTBOOK "pull in the Underactuated Robotics textbook and its examples")  # almost works on windows.  the update step call to git was complaining about local modifications on drake003
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ function(drake_forcebuild proj)
     ALWAYS 1)
 endfunction()
 
-# Require Java at the super-build level so libbot cannot configure without finding Java
-find_package(Java REQUIRED)
+# Require Java at the super-build level since libbot cannot configure without finding Java
+find_package(Java 1.6 REQUIRED)
 include(UseJava)
 
 # menu of extra examples
@@ -93,40 +93,36 @@ option(DISABLE_MATLAB "Don't use MATLAB even if it is present." OFF)
 if(DISABLE_MATLAB)
   message(STATUS "MATLAB is disabled.")
 else()
-  find_program(matlab matlab)
-  if(matlab)
-    message(STATUS "Found MATLAB at " ${matlab})
-  else()
-    message(STATUS "Looked for MATLAB but could not find it.")
-  endif()
+  find_package(Matlab COMPONENTS MAIN_PROGRAM)
 endif()
 
 ## The following projects are default ON when MATLAB is present and enabled.
 ## Otherwise, they are hidden and default OFF.
-cmake_dependent_option(WITH_SPOTLESS "polynomial optimization front-end for MATLAB" ON "NOT DISABLE_MATLAB;matlab" OFF)
+cmake_dependent_option(WITH_SPOTLESS "polynomial optimization front-end for MATLAB" ON Matlab_FOUND OFF)
 
 ## The following projects are default OFF when MATLAB is present and enabled.
 ## Otherwise, they are hidden and default OFF.
 ## Some of them may also be hidden on Windows regardless of the status of MATLAB.
-cmake_dependent_option(WITH_BERTINI "solve polynomial equations; free but pod requires permissions (can't redistribute)" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
-cmake_dependent_option(WITH_GLOPTIPOLY "free global polynomial optimization tooblox" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
-cmake_dependent_option(WITH_IRIS "fast approximate convex segmentation" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32;WITH_MOSEK" OFF)
-cmake_dependent_option(WITH_MOSEK "convex optimization solver; free for academics" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
-cmake_dependent_option(WITH_SEDUMI "semi-definite programming solver" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
-cmake_dependent_option(WITH_YALMIP "free optimization front-end for MATLAB" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
-cmake_dependent_option(WITH_XFOIL "use w/ XFOIL to compute aerodynamic coefficients for airfoils" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
+if(NOT WIN32)
+  cmake_dependent_option(WITH_BERTINI "solve polynomial equations; free but pod requires permissions (can't redistribute)" OFF Matlab_FOUND OFF)
+  cmake_dependent_option(WITH_GLOPTIPOLY "free global polynomial optimization tooblox" OFF Matlab_FOUND OFF)
+  cmake_dependent_option(WITH_IRIS "fast approximate convex segmentation" OFF "Matlab_FOUND;WITH_MOSEK" OFF)
+  cmake_dependent_option(WITH_MOSEK "convex optimization solver; free for academics" OFF Matlab_FOUND OFF)
+  cmake_dependent_option(WITH_SEDUMI "semi-definite programming solver" OFF Matlab_FOUND OFF)
+  cmake_dependent_option(WITH_YALMIP "free optimization front-end for MATLAB" OFF Matlab_FOUND OFF)
+  cmake_dependent_option(WITH_XFOIL "use w/ XFOIL to compute aerodynamic coefficients for airfoils" OFF Matlab_FOUND OFF)
+endif()
 
 ###########################################
 # External Projects that are OFF by default
 ###########################################
 option(WITH_SNOPT "nonlinear optimization solver; requires access to RobotLocomotion/snopt-pod")
-cmake_dependent_option(WITH_SIGNALSCOPE "live plotting tool for lcm messages" OFF "NOT WIN32;WITH_DIRECTOR" OFF)
-
 if(NOT WIN32) # many of these might work on win32 with little or no work... they just haven't been tried
   option(WITH_AVL "use w/ AVL to compute aerodynamic coefficients for airfoils")
   option(WITH_GUROBI "convex/integer optimization solver; free for academics (will prompt you for login bits)")
   option(WITH_MESHCONVERTERS "uses vcglib to convert a few standard filetypes")
   option(WITH_OCTOMAP "provides oct-tree data structures")
+  cmake_dependent_option(WITH_SIGNALSCOPE "live plotting tool for lcm messages" OFF WITH_DIRECTOR OFF)
   option(WITH_TEXTBOOK "pull in the Underactuated Robotics textbook and its examples")  # almost works on windows.  the update step call to git was complaining about local modifications on drake003
 endif()
 

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -51,12 +51,8 @@ endif()
 set(POD_NAME drake)
 include(cmake/pods.cmake)
 
-find_package(Java REQUIRED)
+find_package(Java 1.6 REQUIRED)
 include(UseJava)
-
-if(WIN32)
-  set(CMAKE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} -source 6 -target 6)  # See #2442.
-endif()
 
 function(drake_install_headers)
   file(RELATIVE_PATH rel_path ${PROJECT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR})
@@ -147,7 +143,30 @@ else()
   # if MATLAB is in the PATH then use cmake find_package to find it
   # along with what is needed to use matlab_add_unit_test
   if(MATLAB_FOUND)
-    find_package(Matlab COMPONENTS MAIN_PROGRAM)
+    find_package(Matlab COMPONENTS MAIN_PROGRAM REQUIRED)
+
+    set(Matlab_Java_MAIN_PROGRAM_ARGS -nodesktop -nodisplay -nosplash)
+    if(WIN32)
+      set(Matlab_Java_MAIN_PROGRAM_ARGS ${Matlab_Java_MAIN_PROGRAM_ARGS} -wait)
+    endif()
+    execute_process(
+      COMMAND ${Matlab_MAIN_PROGRAM} ${Matlab_Java_MAIN_PROGRAM_ARGS} -r "version -java"
+      RESULT_VARIABLE Matlab_Java_RESULT_VARIABLE
+      ERROR_VARIABLE Matlab_Java_OUTPUT_VARIABLE
+      OUTPUT_VARIABLE Matlab_Java_OUTPUT_VARIABLE
+      TIMEOUT 180)
+    if(NOT Matlab_Java_RESULT_VARIABLE AND Matlab_Java_OUTPUT_VARIABLE MATCHES "Java ([0-9]+\\.[0-9]+)\\.[0-9_.]+")
+      set(Matlab_Java_VERSION_MAJOR_MINOR ${CMAKE_MATCH_1})
+      set(Java_VERSION_MAJOR_MINOR "${Java_VERSION_MAJOR}.${Java_VERSION_MINOR}")
+      if(NOT Matlab_Java_VERSION_MAJOR_MINOR VERSION_EQUAL Java_VERSION_MAJOR_MINOR)
+        message(WARNING "MATLAB JVM version (${Matlab_Java_VERSION_MAJOR_MINOR}) does not match installed Java SDK version (${Java_VERSION_MAJOR_MINOR})")
+        if(Matlab_Java_VERSION_MAJOR_MINOR VERSION_LESS Java_VERSION_MAJOR_MINOR)
+          set(CMAKE_JAVA_COMPILE_FLAGS -target ${Matlab_Java_VERSION_MAJOR_MINOR})
+        endif()
+      endif()
+    else()
+      message(WARNING "Could not determine MATLAB JVM version")
+    endif()
   endif()
 endif()
 

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -150,7 +150,7 @@ else()
       set(Matlab_Java_MAIN_PROGRAM_ARGS ${Matlab_Java_MAIN_PROGRAM_ARGS} -wait)
     endif()
     execute_process(
-      COMMAND ${Matlab_MAIN_PROGRAM} ${Matlab_Java_MAIN_PROGRAM_ARGS} -r "version -java"
+      COMMAND ${Matlab_MAIN_PROGRAM} ${Matlab_Java_MAIN_PROGRAM_ARGS} -r "version -java,quit"
       RESULT_VARIABLE Matlab_Java_RESULT_VARIABLE
       ERROR_VARIABLE Matlab_Java_OUTPUT_VARIABLE
       OUTPUT_VARIABLE Matlab_Java_OUTPUT_VARIABLE
@@ -161,7 +161,7 @@ else()
       if(NOT Matlab_Java_VERSION_MAJOR_MINOR VERSION_EQUAL Java_VERSION_MAJOR_MINOR)
         message(WARNING "MATLAB JVM version (${Matlab_Java_VERSION_MAJOR_MINOR}) does not match installed Java SDK version (${Java_VERSION_MAJOR_MINOR})")
         if(Matlab_Java_VERSION_MAJOR_MINOR VERSION_LESS Java_VERSION_MAJOR_MINOR)
-          set(CMAKE_JAVA_COMPILE_FLAGS -target ${Matlab_Java_VERSION_MAJOR_MINOR})
+          set(CMAKE_JAVA_COMPILE_FLAGS -source ${Matlab_Java_VERSION_MAJOR_MINOR} -target ${Matlab_Java_VERSION_MAJOR_MINOR})
         endif()
       endif()
     else()


### PR DESCRIPTION
I am also setting the absolute minimum Java version to 1.6. It was previously unspecified and do not think it is reasonable to support anything less than that. Even with that, theoretically a version of MATLAB with an older version of Java could still work.

PTAL @david-german-tri and/or @jwnimmer-tri.

Fixes #2473.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2527)
<!-- Reviewable:end -->
