### PR TITLE
[WIP] Add DRAKE_ASSERT, DRAKE_FAIL, and DRAKE_FAIL_UNLESS capability

### DIFF
--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -3,15 +3,22 @@
 #
 
 # List all source files used to build libdrakeCommon.
-set(sources nice_type_name.cc)
+set(sources
+  drake_assert.cc
+  nice_type_name.cc
+  )
 
 # List headers that should be installed with Drake so that they
 # are available elsewhere via #include "drake/common/xxx.h".
-set(installed_headers nice_type_name.h)
+set(installed_headers
+  drake_assert.h
+  nice_type_name.h
+  )
 
 # List headers that are needed by code here but should not
 # be exposed anywhere else.
-set(private_headers)
+set(private_headers
+  )
 
 # Create the library target and note its dependencies. Also generates
 # a header defining DRAKECOMMON_EXPORT for dealing with .dlls on Windows.

--- a/drake/common/drake_assert.cc
+++ b/drake/common/drake_assert.cc
@@ -1,0 +1,23 @@
+#include "drake/common/drake_assert.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace drake {
+namespace detail {
+
+void Abort(const char* condition, const char* func, const char* file,
+           int line) {
+  std::cerr << "abort: failure at " << file << ":" << line << " in " << func;
+  if (condition) {
+    std::cerr << ": assertion '" << condition << "' failed.";
+  } else {
+    std::cerr << ".";
+  }
+  std::cerr << std::endl;
+
+  std::abort();
+}
+
+}  // namespace detail
+}  // namespace drake

--- a/drake/common/drake_assert.h
+++ b/drake/common/drake_assert.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+
+#include "drake/drakeCommon_export.h"
+
+/// @file
+/// Provides Drake's assertion implementation.  This is intended to be
+/// used both within Drake and by other software.
+
+#ifdef DRAKE_DOXYGEN_CXX
+/// @p DRAKE_ASSERT(condition) is similar to the built-in @p assert(condition)
+/// from the C++ system header @p <cassert>.  Unless Drake's assertions are
+/// disarmed by the pre-processor definitions listed below, @p DRAKE_ASSERT
+/// will evaluate @p condition and iff the value is false will ::abort() the
+/// program with a message showing at least the condition text, file, and line.
+///
+/// Assertions are enabled or disabled using the following pre-processor macros:
+/// - If @p DRAKE_ENABLE_ASSERTS is defined, then @p DRAKE_ASSERT is armed.
+/// - If @p DRAKE_DISABLE_ASSERTS is defined, then @p DRAKE_ASSERT is disarmed.
+/// - If both macros are defined, it is a compile-time error.
+/// - If neither are defined, then NDEBUG governs assertions as usual.
+///
+/// One difference versus the standard @p assert(condition) is that the
+/// @p condition within @p DRAKE_ASSERT is always syntax-checked, even if
+/// Drake's assertions are disarmed.
+///
+/// Treat @p DRAKE_ASSERT like a statement -- it must always be used
+/// in block scope, and must always be followed by a semicolon.
+#define DRAKE_ASSERT(condition)
+/// Like @p DRAKE_ASSERT, except is always armed.
+#define DRAKE_ABORT_UNLESS(condition)
+/// Like @p DRAKE_ABORT_UNLESS(false).
+#define DRAKE_ABORT()
+#else  //  DRAKE_DOXYGEN_CXX
+
+// Users should NOT set these; only this header should set them.
+#ifdef DRAKE_ASSERT_IS_ARMED
+# error Unexpected DRAKE_ASSERT_IS_ARMED defined.
+#endif
+#ifdef DRAKE_ASSERT_IS_DISARMED
+# error Unexpected DRAKE_ASSERT_IS_DISARMED defined.
+#endif
+
+// Decide whether Drake assertions are enabled.
+#if defined(DRAKE_ENABLE_ASSERTS) && defined(DRAKE_DISABLE_ASSERTS)
+# error Conflicting assertion toggles.
+#elif defined(DRAKE_ENABLE_ASSERTS)
+# define DRAKE_ASSERT_IS_ARMED
+#elif defined(DRAKE_DISABLE_ASSERTS) || defined(NDEBUG)
+# define DRAKE_ASSERT_IS_DISARMED
+#endif
+
+namespace drake {
+namespace detail {
+// Abort the program with an error message.
+DRAKECOMMON_EXPORT
+void Abort(const char* condition, const char* func, const char* file, int line);
+}
+}
+
+#define DRAKE_ABORT()                                           \
+  ::drake::detail::Abort(nullptr, __func__, __FILE__, __LINE__)
+
+#define DRAKE_ABORT_UNLESS(condition)                                   \
+  do {                                                                  \
+    if (!(condition)) {                                                 \
+      ::drake::detail::Abort(#condition, __func__, __FILE__, __LINE__); \
+    }                                                                   \
+  } while (0)
+
+#ifdef DRAKE_ASSERT_IS_ARMED
+// Assertions are enabled.
+#define DRAKE_ASSERT(condition) DRAKE_ABORT_UNLESS(condition)
+#else
+// Assertions are disabled, so just typecheck the expression.
+#define DRAKE_ASSERT(condition) static_assert(                  \
+      std::is_convertible<decltype(condition), bool>::value,    \
+      "Assertion condition should be bool-convertible.")
+#endif
+
+#endif  // DRAKE_DOXYGEN_CXX

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -4,4 +4,18 @@ if(GTEST_FOUND)
   add_executable(nice_type_name_test nice_type_name_test.cc)
   target_link_libraries(nice_type_name_test drakeCommon ${GTEST_BOTH_LIBRARIES})
   add_test(NAME nice_type_name_test COMMAND nice_type_name_test)
+
+  add_executable(drake_assert_test_default drake_assert_test.cc)
+  target_link_libraries(drake_assert_test_default drakeCommon ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME drake_assert_test_default COMMAND drake_assert_test_default)
+  # Same, but with assertions forced enabled.
+  add_executable(drake_assert_test_enabled drake_assert_test.cc)
+  target_compile_definitions(drake_assert_test_enabled PRIVATE DRAKE_ENABLE_ASSERTS)
+  target_link_libraries(drake_assert_test_enabled drakeCommon ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME drake_assert_test_enabled COMMAND drake_assert_test_enabled)
+  # Same, but with assertions forced disabled.
+  add_executable(drake_assert_test_disabled drake_assert_test.cc)
+  target_compile_definitions(drake_assert_test_disabled PRIVATE DRAKE_DISABLE_ASSERTS)
+  target_link_libraries(drake_assert_test_disabled drakeCommon ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disabled)
 endif()

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -19,3 +19,29 @@ if(GTEST_FOUND)
   target_link_libraries(drake_assert_test_disabled drakeCommon ${GTEST_BOTH_LIBRARIES})
   add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disabled)
 endif()
+
+# Confirm that the disarmed DRAKE_ASSERT still yields compilation errors.
+# - This version of the test should trivially pass.
+add_executable(
+  drake_assert_test_compile 
+  drake_assert_test_compile.cc)
+add_test(NAME 
+  drake_assert_test_compile COMMAND
+  drake_assert_test_compile)
+# - This version of the test should yield a compile error.
+add_executable(
+  drake_assert_test_nocompile 
+  drake_assert_test_compile.cc)
+target_compile_definitions(
+  drake_assert_test_nocompile PRIVATE DRAKE_ASSERT_TEST_COMPILE_ERROR)
+set_target_properties(
+  drake_assert_test_nocompile
+  PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+add_test(NAME 
+  drake_assert_test_nocompile
+  COMMAND ${CMAKE_COMMAND} --build . --target 
+  drake_assert_test_nocompile --config $<CONFIGURATION> 
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_tests_properties(
+  drake_assert_test_nocompile
+  PROPERTIES WILL_FAIL TRUE)

--- a/drake/common/test/drake_assert_test.cc
+++ b/drake/common/test/drake_assert_test.cc
@@ -1,0 +1,43 @@
+#include "drake/common/drake_assert.h"
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+GTEST_TEST(DrakeAssertTest, AbortTest) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH(
+      { DRAKE_ABORT(); },
+      "abort: failure at .*drake_assert_test.cc:.. in TestBody");
+}
+
+GTEST_TEST(DrakeAssertTest, AbortUnlessTest) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH(
+      { DRAKE_ABORT_UNLESS(false); },
+      "abort: failure at .*drake_assert_test.cc:.. in TestBody:"
+      " assertion 'false' failed");
+}
+
+struct BoolConvertible { operator bool() { return true; } };
+GTEST_TEST(DrakeAssertTest, AssertSyntaxTest) {
+  // These should compile.
+  DRAKE_ASSERT((2 + 2) == 4);
+  DRAKE_ASSERT(BoolConvertible());
+}
+
+// Only run this test if assertions are armed.
+#ifdef DRAKE_ASSERT_IS_ARMED
+GTEST_TEST(DrakeAssertTest, AssertFalseTest) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH(
+      { DRAKE_ASSERT((2 + 2) == 5); },
+      "abort: failure at .*drake_assert_test.cc:.. in TestBody: "
+      "assertion '\\(2 \\+ 2\\) == 5' failed");
+}
+#endif  //  DRAKE_ASSERT_IS_ARMED
+
+}  // namespace

--- a/drake/common/test/drake_assert_test_compile.cc
+++ b/drake/common/test/drake_assert_test_compile.cc
@@ -1,0 +1,13 @@
+#include "drake/common/drake_assert.h"
+
+namespace { struct NonBoolConvertible{}; }
+
+int main(int argc, const char* argv[]) {
+// The build system toggles this guard.  The program should compile
+// and pass when undefined, and should fail to compile when defined.
+#ifdef DRAKE_ASSERT_TEST_COMPILE_ERROR
+  DRAKE_ASSERT(NonBoolConvertible());
+#endif
+
+  return 0;
+}

--- a/drake/examples/Cars/CMakeLists.txt
+++ b/drake/examples/Cars/CMakeLists.txt
@@ -7,7 +7,7 @@ if(LCM_FOUND)
     curve2.cc
     simple_car.cc
     trajectory_car.cc)
-  target_link_libraries(drakeCars drakeRBSystem drakeShapes)
+  target_link_libraries(drakeCars drakeRBSystem drakeShapes drakeCommon)
   pods_install_libraries(drakeCars)
   drake_install_headers(
     curve2.h

--- a/drake/examples/Cars/simple_car-inl.h
+++ b/drake/examples/Cars/simple_car-inl.h
@@ -12,6 +12,7 @@
 
 #include <Eigen/Geometry>
 
+#include "drake/common/drake_assert.h"
 #include "drake/examples/Cars/gen/driving_command.h"
 #include "drake/examples/Cars/gen/simple_car_state.h"
 
@@ -36,8 +37,8 @@ SimpleCar::StateVector<ScalarType> SimpleCar::dynamics(
 
   // Apply steering.
   ScalarType sane_steering_angle = input.steering_angle();
-  assert(static_cast<ScalarType>(-M_PI) < sane_steering_angle);
-  assert(sane_steering_angle < static_cast<ScalarType>(M_PI));
+  DRAKE_ASSERT(static_cast<ScalarType>(-M_PI) < sane_steering_angle);
+  DRAKE_ASSERT(sane_steering_angle < static_cast<ScalarType>(M_PI));
   sane_steering_angle = std::min(
       sane_steering_angle,
       static_cast<ScalarType>(config_.max_abs_steering_angle));


### PR DESCRIPTION
Add `DRAKE_...` assertion-like macros as a step towards #1935.  This does not yet offer CMake options to force Drake assertions on or off, nor other exception-throwing or string-formatting tools.

This PR will serve to provide platform-matrix build coverage during development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2536)
<!-- Reviewable:end -->
