### PR TITLE
Rename StateVectorInterface to StateVector, and implement StateVector::operator+=.

### DIFF
--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -6,7 +6,7 @@ using systems::BasicVector;
 using systems::Context;
 using systems::ContinuousState;
 using systems::OutputPort;
-using systems::StateVectorInterface;
+using systems::StateVector;
 using systems::SystemOutput;
 using systems::VectorInterface;
 using systems::VectorX;
@@ -84,10 +84,9 @@ std::unique_ptr<SystemOutput<double>> SpringMassSystem::AllocateOutput() const {
   return output;
 }
 
-std::unique_ptr<StateVectorInterface<double>>
+std::unique_ptr<StateVector<double>>
 SpringMassSystem::AllocateStateDerivatives() const {
-  return std::unique_ptr<StateVectorInterface<double>>(
-      new SpringMassStateVector(0, 0));
+  return std::unique_ptr<StateVector<double>>(new SpringMassStateVector(0, 0));
 }
 
 // Assign the state to the output.
@@ -106,9 +105,8 @@ void SpringMassSystem::Output(const Context<double>& context,
 }
 
 // Compute the actual physics.
-void SpringMassSystem::Dynamics(
-    const Context<double>& context,
-    StateVectorInterface<double>* derivatives) const {
+void SpringMassSystem::Dynamics(const Context<double>& context,
+                                StateVector<double>* derivatives) const {
   // TODO(david-german-tri): Cache the output of this function.
   const SpringMassStateVector& state =
       dynamic_cast<const SpringMassStateVector&>(

--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -8,7 +8,7 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/continuous_system.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 #include "drake/systems/framework/system_output.h"
 
 namespace drake {
@@ -88,15 +88,14 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
       const override;
 
   /// Allocates state derivatives of type SpringMassStateVector.
-  std::unique_ptr<systems::StateVectorInterface<double>>
-  AllocateStateDerivatives() const override;
+  std::unique_ptr<systems::StateVector<double>> AllocateStateDerivatives()
+      const override;
 
   void Output(const systems::Context<double>& context,
               systems::SystemOutput<double>* output) const override;
 
-  void Dynamics(
-      const systems::Context<double>& context,
-      systems::StateVectorInterface<double>* derivatives) const override;
+  void Dynamics(const systems::Context<double>& context,
+                systems::StateVector<double>* derivatives) const override;
 
  private:
   const std::string name_;

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -10,7 +10,7 @@
 #include "drake/systems/framework/leaf_state_vector.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/state_subvector.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/util/eigen_matrix_compare.h"
 
@@ -20,7 +20,7 @@ using systems::Context;
 using systems::ContinuousState;
 using systems::LeafStateVector;
 using systems::StateSubvector;
-using systems::StateVectorInterface;
+using systems::StateVector;
 using systems::SystemOutput;
 using util::MatrixCompareType;
 
@@ -62,7 +62,7 @@ class SpringMassSystemTest : public ::testing::Test {
   SpringMassStateVector* derivatives_;
 
  private:
-  std::unique_ptr<StateVectorInterface<double>> erased_derivatives_;
+  std::unique_ptr<StateVector<double>> erased_derivatives_;
 };
 
 TEST_F(SpringMassSystemTest, Name) {

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -7,7 +7,7 @@ set(sources
   named_value_vector.cc
   state.cc
   state_subvector.cc
-  state_vector_interface.cc
+  state_vector.cc
   system_interface.cc
   system_output.cc
   basic_state_vector.cc
@@ -25,7 +25,7 @@ set(installed_headers
   named_value_vector.h
   state.h
   state_subvector.h
-  state_vector_interface.h
+  state_vector.h
   system_interface.h
   system_output.h
   basic_state_vector.h

--- a/drake/systems/framework/basic_state_vector.h
+++ b/drake/systems/framework/basic_state_vector.h
@@ -12,7 +12,7 @@ namespace drake {
 namespace systems {
 
 /// BasicStateVector is a concrete class template that implements
-/// StateVectorInterface in a convenient manner for leaf Systems,
+/// StateVector in a convenient manner for leaf Systems,
 /// by owning and wrapping a VectorInterface<T>.
 ///
 /// It will often be convenient to inherit from BasicStateVector, and add

--- a/drake/systems/framework/basic_state_vector.h
+++ b/drake/systems/framework/basic_state_vector.h
@@ -60,6 +60,21 @@ class BasicStateVector : public LeafStateVector<T> {
 
   VectorX<T> CopyToVector() const override { return vector_->get_value(); }
 
+  void AddToVector(Eigen::Ref<VectorX<T>> vec) const override {
+    if (vec.rows() != size()) {
+      throw std::out_of_range("Addends must be the same length.");
+    }
+    vec += vector_->get_value();
+  }
+
+  BasicStateVector& operator+=(const StateVector<T>& rhs) override {
+    if (size() != rhs.size()) {
+      throw std::out_of_range("Addends must be the same length.");
+    }
+    rhs.AddToVector(vector_->get_mutable_value());
+    return *this;
+  }
+
  protected:
   BasicStateVector(const BasicStateVector& other)
       : BasicStateVector(other.size()) {

--- a/drake/systems/framework/continuous_system.h
+++ b/drake/systems/framework/continuous_system.h
@@ -5,7 +5,7 @@
 
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/continuous_system_interface.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 
 namespace drake {
 namespace systems {
@@ -21,9 +21,8 @@ class ContinuousSystem : public ContinuousSystemInterface<T> {
   /// @p generalized_velocity and @p configuration_derivatives are not the
   /// same size. Child classes should override this function if qdot != v.
   void MapVelocityToConfigurationDerivatives(
-      const Context<T>& context,
-      const StateVectorInterface<T>& generalized_velocity,
-      StateVectorInterface<T>* configuration_derivatives) const override {
+      const Context<T>& context, const StateVector<T>& generalized_velocity,
+      StateVector<T>* configuration_derivatives) const override {
     if (generalized_velocity.size() != configuration_derivatives->size()) {
       throw std::out_of_range(
           "generalized_velocity.size() " +
@@ -35,8 +34,8 @@ class ContinuousSystem : public ContinuousSystemInterface<T> {
     }
 
     for (ptrdiff_t i = 0; i < generalized_velocity.size(); ++i) {
-      configuration_derivatives->SetAtIndex(
-          i, generalized_velocity.GetAtIndex(i));
+      configuration_derivatives->SetAtIndex(i,
+                                            generalized_velocity.GetAtIndex(i));
     }
   }
 
@@ -46,11 +45,9 @@ class ContinuousSystem : public ContinuousSystemInterface<T> {
  private:
   // ContinuousSystem objects are neither copyable nor moveable.
   ContinuousSystem(const ContinuousSystem<T>& other) = delete;
-  ContinuousSystem& operator=(
-      const ContinuousSystem<T>& other) = delete;
+  ContinuousSystem& operator=(const ContinuousSystem<T>& other) = delete;
   ContinuousSystem(ContinuousSystem<T>&& other) = delete;
-  ContinuousSystem& operator=(ContinuousSystem<T>&& other) =
-      delete;
+  ContinuousSystem& operator=(ContinuousSystem<T>&& other) = delete;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/continuous_system_interface.h
+++ b/drake/systems/framework/continuous_system_interface.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "drake/systems/framework/context.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/system_interface.h"
 
@@ -19,8 +19,7 @@ class ContinuousSystemInterface : public SystemInterface<T> {
   /// Returns a vector of the same size as the continuous_state allocated in
   /// CreateDefaultContext. Solvers will provide this vector as the output
   /// argument to Dynamics.
-  virtual std::unique_ptr<StateVectorInterface<T>> AllocateStateDerivatives()
-      const = 0;
+  virtual std::unique_ptr<StateVector<T>> AllocateStateDerivatives() const = 0;
 
   /// Produces the derivatives of the continuous state xc with respect to time.
   /// The @p derivatives vector will correspond elementwise with the state
@@ -34,7 +33,7 @@ class ContinuousSystemInterface : public SystemInterface<T> {
   /// @param derivatives The output vector. Will be the same length as the
   ///                    state vector Context.state.continuous_state.
   virtual void Dynamics(const Context<T>& context,
-                        StateVectorInterface<T>* derivatives) const = 0;
+                        StateVector<T>* derivatives) const = 0;
 
   /// Transforms the velocity (v) in the given Context state to the derivative
   /// of the configuration (qdot). The transformation must be linear
@@ -52,9 +51,8 @@ class ContinuousSystemInterface : public SystemInterface<T> {
   /// @param generalized_velocity The velocity to transform.
   /// @param configuration_derivatives The output vector.  Must not be nullptr.
   virtual void MapVelocityToConfigurationDerivatives(
-      const Context<T>& context,
-      const StateVectorInterface<T>& generalized_velocity,
-      StateVectorInterface<T>* configuration_derivatives) const = 0;
+      const Context<T>& context, const StateVector<T>& generalized_velocity,
+      StateVector<T>* configuration_derivatives) const = 0;
 
   // TODO(david-german-tri): Add MapConfigurationDerivativesToVelocity.
 

--- a/drake/systems/framework/leaf_state_vector.h
+++ b/drake/systems/framework/leaf_state_vector.h
@@ -2,19 +2,19 @@
 
 #include <Eigen/Dense>
 
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 
 namespace drake {
 namespace systems {
 
 /// LeafStateVector is an abstract class template that implements
-/// StateVectorInterface for leaf Systems, i.e. Systems that are not Diagrams.
+/// StateVector for leaf Systems, i.e. Systems that are not Diagrams.
 ///
 /// It introduces the additional Non-Virtual Interface method Clone(), with
 /// corresponding virtual implementation DoClone().  Children of LeafStateVector
 /// should override DoClone to return their concrete type.
 template <typename T>
-class LeafStateVector : public StateVectorInterface<T> {
+class LeafStateVector : public StateVector<T> {
  public:
   ~LeafStateVector() override {}
 

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "drake/systems/framework/state_subvector.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 #include "drake/systems/framework/vector_interface.h"
 
 namespace drake {
@@ -22,7 +22,7 @@ class ContinuousState {
  public:
   /// Constructs a ContinuousState for a system that does not have second-order
   /// structure: All of the state is misc_continuous_state_.
-  explicit ContinuousState(std::unique_ptr<StateVectorInterface<T>> state) {
+  explicit ContinuousState(std::unique_ptr<StateVector<T>> state) {
     state_ = std::move(state);
     generalized_position_.reset(new StateSubvector<T>(state_.get()));
     generalized_velocity_.reset(new StateSubvector<T>(state_.get()));
@@ -44,7 +44,7 @@ class ContinuousState {
   /// @param num_q The number of position variables.
   /// @param num_v The number of velocity variables.
   /// @param num_z  The number of other variables.
-  ContinuousState(std::unique_ptr<StateVectorInterface<T>> state, size_t num_q,
+  ContinuousState(std::unique_ptr<StateVector<T>> state, size_t num_q,
                   size_t num_v, size_t num_z) {
     state_ = std::move(state);
     if (state_->size() != num_q + num_v + num_z) {
@@ -70,63 +70,63 @@ class ContinuousState {
   // state of a Diagram, using StateSupervectors.
 
   /// Returns the entire state vector.
-  const StateVectorInterface<T>& get_state() const { return *state_; }
+  const StateVector<T>& get_state() const { return *state_; }
 
   /// Returns a mutable pointer to the entire state vector, never null.
-  StateVectorInterface<T>* get_mutable_state() { return state_.get(); }
+  StateVector<T>* get_mutable_state() { return state_.get(); }
 
   /// Returns the subset of the state vector that is generalized position `q`.
-  const StateVectorInterface<T>& get_generalized_position() const {
+  const StateVector<T>& get_generalized_position() const {
     return *generalized_position_;
   }
 
   /// Returns a mutable pointer to the subset of the state vector that is
   /// generalized position `q`.
-  StateVectorInterface<T>* get_mutable_generalized_position() {
+  StateVector<T>* get_mutable_generalized_position() {
     return generalized_position_.get();
   }
 
   /// Returns the subset of the state vector that is generalized velocity `v`.
-  const StateVectorInterface<T>& get_generalized_velocity() const {
+  const StateVector<T>& get_generalized_velocity() const {
     return *generalized_velocity_;
   }
 
   /// Returns a mutable pointer to the subset of the state vector that is
   /// generalized velocity `v`.
-  StateVectorInterface<T>* get_mutable_generalized_velocity() {
+  StateVector<T>* get_mutable_generalized_velocity() {
     return generalized_velocity_.get();
   }
 
   /// Returns the subset of the state vector that is other continuous state `z`.
-  const StateVectorInterface<T>& get_misc_continuous_state() const {
+  const StateVector<T>& get_misc_continuous_state() const {
     return *misc_continuous_state_;
   }
 
   /// Returns a mutable pointer to the subset of the state vector that is
   /// other continuous state `z`.
-  StateVectorInterface<T>* get_mutable_misc_continuous_state() {
+  StateVector<T>* get_mutable_misc_continuous_state() {
     return misc_continuous_state_.get();
   }
 
  private:
   /// The entire state vector.  May or may not own the underlying data.
-  std::unique_ptr<StateVectorInterface<T>> state_;
+  std::unique_ptr<StateVector<T>> state_;
 
   /// Generalized coordinates representing System configuration, conventionally
   /// denoted `q`. These are second-order state variables.
   /// This is a subset of state_ and does not own the underlying data.
-  std::unique_ptr<StateVectorInterface<T>> generalized_position_;
+  std::unique_ptr<StateVector<T>> generalized_position_;
 
   /// Generalized speeds representing System velocity. Conventionally denoted
   /// `v`. These are first-order state variables that the System can linearly
   /// map to time derivatives `qdot` of `q` above.
   /// This is a subset of state_ and does not own the underlying data.
-  std::unique_ptr<StateVectorInterface<T>> generalized_velocity_;
+  std::unique_ptr<StateVector<T>> generalized_velocity_;
 
   /// Additional continuous, first-order state variables not representing
   /// multibody system motion.  Conventionally denoted `z`.
   /// This is a subset of state_ and does not own the underlying data.
-  std::unique_ptr<StateVectorInterface<T>> misc_continuous_state_;
+  std::unique_ptr<StateVector<T>> misc_continuous_state_;
 };
 
 /// The State is a container for all the data comprising the complete state of

--- a/drake/systems/framework/state_subvector.h
+++ b/drake/systems/framework/state_subvector.h
@@ -4,24 +4,24 @@
 
 #include <stdexcept>
 
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 #include "drake/systems/framework/vector_interface.h"
 
 namespace drake {
 namespace systems {
 
 /// StateSubvector is a concrete class template that implements
-/// StateVectorInterface by providing a sliced view of a StateVectorInterface.
+/// StateVector by providing a sliced view of a StateVector.
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
 template <typename T>
-class StateSubvector : public StateVectorInterface<T> {
+class StateSubvector : public StateVector<T> {
  public:
   /// Constructs a subvector of vector that consists of num_elements starting
   /// at first_element.
   /// @param vector The vector to slice.  Must not be nullptr. Must remain
   ///               valid for the lifetime of this object.
-  StateSubvector(StateVectorInterface<T>* vector, ptrdiff_t first_element,
+  StateSubvector(StateVector<T>* vector, ptrdiff_t first_element,
                  ptrdiff_t num_elements)
       : vector_(vector),
         first_element_(first_element),
@@ -38,7 +38,7 @@ class StateSubvector : public StateVectorInterface<T> {
   /// Constructs an empty subvector.
   /// @param vector The vector to slice.  Must not be nullptr. Must remain
   ///               valid for the lifetime of this object.
-  explicit StateSubvector(StateVectorInterface<T>* vector)
+  explicit StateSubvector(StateVector<T>* vector)
       : StateSubvector(vector, 0, 0) {}
 
   ~StateSubvector() override {}
@@ -84,7 +84,7 @@ class StateSubvector : public StateVectorInterface<T> {
   StateSubvector(StateSubvector&& other) = delete;
   StateSubvector& operator=(StateSubvector&& other) = delete;
 
-  StateVectorInterface<T>* vector_{nullptr};
+  StateVector<T>* vector_{nullptr};
   ptrdiff_t first_element_{0};
   ptrdiff_t num_elements_{0};
 };

--- a/drake/systems/framework/state_vector.cc
+++ b/drake/systems/framework/state_vector.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// state_vector.h is a stand-alone header.
+
+#include "drake/systems/framework/state_vector.h"

--- a/drake/systems/framework/state_vector.h
+++ b/drake/systems/framework/state_vector.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdexcept>
+
 #include <Eigen/Dense>
 
 #include "drake/systems/framework/vector_interface.h"
@@ -7,7 +9,7 @@
 namespace drake {
 namespace systems {
 
-/// StateVector is an abstrat base class template for vector quantities within
+/// StateVector is an abstract base class template for vector quantities within
 /// the state of a System.  Both composite Systems (Diagrams) and leaf Systems
 /// have state that satisfies StateVector.
 ///
@@ -49,6 +51,38 @@ class StateVector {
   /// Implementations should ensure this operation is O(N) in the size of the
   /// value and allocates only the O(N) memory that it returns.
   virtual VectorX<T> CopyToVector() const = 0;
+
+  /// Adds this vector to @p vec, which must be the same size.
+  ///
+  /// Implementations may override this default implementation with a more
+  /// efficient approach, for instance if the vector is contiguous.
+  /// Implementations should ensure this operation remains O(N) in the size of
+  /// the value and allocates no memory.
+  virtual void AddToVector(Eigen::Ref<VectorX<T>> vec) const {
+    if (vec.rows() != size()) {
+      throw std::out_of_range("Addends must be the same length.");
+    }
+    for (ptrdiff_t i = 0; i < size(); ++i) {
+      vec[i] += GetAtIndex(i);
+    }
+  }
+
+  /// Adds the vector @p rhs to this vector. Both vectors must be the same size.
+  ///
+  /// Implementations may override this default implementation with a more
+  /// efficient approach, for instance if the vector is contiguous.
+  /// Implementations should ensure this operation remains O(N) in the size of
+  /// the value and allocates no memory.
+  virtual StateVector& operator+=(const StateVector<T>& rhs) {
+    if (size() != rhs.size()) {
+      throw std::out_of_range("Addends must be the same length.");
+    }
+    assert(size() == rhs.size());
+    for (ptrdiff_t i = 0; i < size(); ++i) {
+      SetAtIndex(i, GetAtIndex(i) + rhs.GetAtIndex(i));
+    }
+    return *this;
+  }
 
  protected:
   StateVector() {}

--- a/drake/systems/framework/state_vector.h
+++ b/drake/systems/framework/state_vector.h
@@ -7,15 +7,15 @@
 namespace drake {
 namespace systems {
 
-/// StateVectorInterface is an interface template for vector quantities within
+/// StateVector is an abstrat base class template for vector quantities within
 /// the state of a System.  Both composite Systems (Diagrams) and leaf Systems
-/// have state that satisfies StateVectorInterface.
+/// have state that satisfies StateVector.
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
 template <typename T>
-class StateVectorInterface {
+class StateVector {
  public:
-  virtual ~StateVectorInterface() {}
+  virtual ~StateVector() {}
 
   /// Returns the number of elements in the vector.
   ///
@@ -51,14 +51,14 @@ class StateVectorInterface {
   virtual VectorX<T> CopyToVector() const = 0;
 
  protected:
-  StateVectorInterface() {}
+  StateVector() {}
 
  private:
-  // StateVectorInterface objects are neither copyable nor moveable.
-  StateVectorInterface(const StateVectorInterface& other) = delete;
-  StateVectorInterface& operator=(const StateVectorInterface& other) = delete;
-  StateVectorInterface(StateVectorInterface&& other) = delete;
-  StateVectorInterface& operator=(StateVectorInterface&& other) = delete;
+  // StateVector objects are neither copyable nor moveable.
+  StateVector(const StateVector& other) = delete;
+  StateVector& operator=(const StateVector& other) = delete;
+  StateVector(StateVector&& other) = delete;
+  StateVector& operator=(StateVector&& other) = delete;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/state_vector_interface.cc
+++ b/drake/systems/framework/state_vector_interface.cc
@@ -1,4 +1,0 @@
-// For now, this is an empty .cc file that only serves to confirm
-// state_vector_interface.h is a stand-alone header.
-
-#include "drake/systems/framework/state_vector_interface.h"

--- a/drake/systems/framework/test/basic_state_vector_test.cc
+++ b/drake/systems/framework/test/basic_state_vector_test.cc
@@ -3,7 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 
 namespace drake {
 namespace systems {
@@ -20,7 +20,7 @@ class BasicStateVectorTest : public ::testing::Test {
     state_vector_.reset(new BasicStateVector<int>(std::move(vec)));
   }
 
-  std::unique_ptr<StateVectorInterface<int>> state_vector_;
+  std::unique_ptr<StateVector<int>> state_vector_;
 };
 
 TEST_F(BasicStateVectorTest, Access) {
@@ -41,8 +41,8 @@ TEST_F(BasicStateVectorTest, Clone) {
       dynamic_cast<LeafStateVector<int>*>(state_vector_.get())->Clone();
 
   // Verify that type and data were preserved in the clone.
-  BasicStateVector<int>* typed_clone = dynamic_cast<BasicStateVector<int>*>(
-      clone.get());
+  BasicStateVector<int>* typed_clone =
+      dynamic_cast<BasicStateVector<int>*>(clone.get());
   ASSERT_NE(nullptr, typed_clone);
   EXPECT_EQ(1, typed_clone->GetAtIndex(0));
   EXPECT_EQ(2, typed_clone->GetAtIndex(1));

--- a/drake/systems/framework/test/basic_state_vector_test.cc
+++ b/drake/systems/framework/test/basic_state_vector_test.cc
@@ -86,6 +86,43 @@ TEST_F(BasicStateVectorTest, SizeBasedConstructor) {
   EXPECT_EQ(42, state_vector_->GetAtIndex(4));
 }
 
+// Tests that the BasicStateVector can be added to an Eigen vector.
+TEST_F(BasicStateVectorTest, AddToVector) {
+  Eigen::Vector2i target;
+  target << 3, 4;
+  state_vector_->AddToVector(target);
+
+  Eigen::Vector2i expected;
+  expected << 4, 6;
+  EXPECT_EQ(expected, target);
+}
+
+TEST_F(BasicStateVectorTest, AddToVectorInvalidSize) {
+  Eigen::Vector3i target;
+  target << 3, 5, 7;
+  EXPECT_THROW(state_vector_->AddToVector(target), std::out_of_range);
+}
+
+// Tests that another StateVector can be added to the BasicStateVector.
+TEST_F(BasicStateVectorTest, PlusEq) {
+  BasicStateVector<int> addend(2);
+  addend.SetAtIndex(0, 5);
+  addend.SetAtIndex(1, 6);
+  *state_vector_ += addend;
+
+  EXPECT_EQ(6, state_vector_->GetAtIndex(0));
+  EXPECT_EQ(8, state_vector_->GetAtIndex(1));
+}
+
+TEST_F(BasicStateVectorTest, PlusEqInvalidSize) {
+  BasicStateVector<int> addend(3);
+  EXPECT_THROW(*state_vector_ += addend, std::out_of_range);
+}
+
+// TODO(david-german-tri): Once GMock is available in the Drake build, add a
+// test case demonstrating that the += operator on BasicStateVector calls
+// AddToVector on the addend.
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/test/continuous_system_test.cc
+++ b/drake/systems/framework/test/continuous_system_test.cc
@@ -9,7 +9,7 @@
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 #include "drake/systems/framework/system_output.h"
 
 namespace drake {
@@ -26,8 +26,10 @@ class TestContinuousSystem : public ContinuousSystem<double> {
 
   std::string get_name() const override { return "TestContinuousSystem"; }
 
-  std::unique_ptr<StateVectorInterface<double>> AllocateStateDerivatives()
-      const override { return nullptr; }
+  std::unique_ptr<StateVector<double>> AllocateStateDerivatives()
+      const override {
+    return nullptr;
+  }
 
   std::unique_ptr<Context<double>> CreateDefaultContext() const override {
     return nullptr;
@@ -40,9 +42,8 @@ class TestContinuousSystem : public ContinuousSystem<double> {
   void Output(const Context<double>& context,
               SystemOutput<double>* output) const override {}
 
-
   void Dynamics(const Context<double>& context,
-                StateVectorInterface<double>* derivatives) const override {}
+                StateVector<double>* derivatives) const override {}
 };
 
 class ContinuousSystemTest : public ::testing::Test {
@@ -58,8 +59,8 @@ TEST_F(ContinuousSystemTest, MapVelocityToConfigurationDerivatives) {
   BasicStateVector<double> state_vec1(std::move(vec1));
   BasicStateVector<double> state_vec2(std::move(vec2));
 
-  system_.MapVelocityToConfigurationDerivatives(context_,
-                                                state_vec1, &state_vec2);
+  system_.MapVelocityToConfigurationDerivatives(context_, state_vec1,
+                                                &state_vec2);
   EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
   EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
   EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
@@ -72,9 +73,8 @@ TEST_F(ContinuousSystemTest, VelocityConfigurationDerivativeSizeMismatch) {
   BasicStateVector<double> state_vec1(std::move(vec1));
   BasicStateVector<double> state_vec2(std::move(vec2));
 
-  EXPECT_THROW(system_.MapVelocityToConfigurationDerivatives(context_,
-                                                             state_vec1,
-                                                             &state_vec2),
+  EXPECT_THROW(system_.MapVelocityToConfigurationDerivatives(
+                   context_, state_vec1, &state_vec2),
                std::out_of_range);
 }
 

--- a/drake/systems/framework/test/state_subvector_test.cc
+++ b/drake/systems/framework/test/state_subvector_test.cc
@@ -7,7 +7,7 @@
 
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 
 namespace drake {
 namespace systems {
@@ -25,7 +25,7 @@ class StateSubvectorTest : public ::testing::Test {
     state_vector_.reset(new BasicStateVector<int>(std::move(vec)));
   }
 
-  std::unique_ptr<StateVectorInterface<int>> state_vector_;
+  std::unique_ptr<StateVector<int>> state_vector_;
 };
 
 TEST_F(StateSubvectorTest, NullptrVector) {

--- a/drake/systems/framework/test/state_subvector_test.cc
+++ b/drake/systems/framework/test/state_subvector_test.cc
@@ -73,6 +73,46 @@ TEST_F(StateSubvectorTest, Mutation) {
   EXPECT_EQ(4, state_vector_->GetAtIndex(3));
 }
 
+// Tests that a StateVector can be added to a StateSubvector.
+TEST_F(StateSubvectorTest, PlusEq) {
+  BasicStateVector<int> addend(2);
+  addend.SetAtIndex(0, 7);
+  addend.SetAtIndex(1, 8);
+
+  StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
+  subvec += addend;
+
+  EXPECT_EQ(1, state_vector_->GetAtIndex(0));
+  EXPECT_EQ(9, state_vector_->GetAtIndex(1));
+  EXPECT_EQ(11, state_vector_->GetAtIndex(2));
+  EXPECT_EQ(4, state_vector_->GetAtIndex(3));
+}
+
+TEST_F(StateSubvectorTest, PlusEqInvalidSize) {
+  BasicStateVector<int> addend(1);
+  StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
+  EXPECT_THROW(subvec += addend, std::out_of_range);
+}
+
+// Tests that a StateSubvector can be added to an Eigen vector.
+TEST_F(StateSubvectorTest, AddToVector) {
+  VectorX<int> target(2);
+  target << 100, 1000;
+
+  StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
+  subvec.AddToVector(target);
+
+  Eigen::Vector2i expected;
+  expected << 102, 1003;
+  EXPECT_EQ(expected, target);
+}
+
+TEST_F(StateSubvectorTest, AddToVectorInvalidSize) {
+  VectorX<int> target(3);
+  StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
+  EXPECT_THROW(subvec.AddToVector(target), std::out_of_range);
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/test/state_test.cc
+++ b/drake/systems/framework/test/state_test.cc
@@ -7,7 +7,7 @@
 
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/state_vector_interface.h"
+#include "drake/systems/framework/state_vector.h"
 
 namespace drake {
 namespace systems {
@@ -18,12 +18,12 @@ constexpr size_t kVelocityLength = 1;
 constexpr size_t kMiscLength = 1;
 constexpr size_t kLength = kPositionLength + kVelocityLength + kMiscLength;
 
-std::unique_ptr<StateVectorInterface<int>> MakeStateVector() {
+std::unique_ptr<StateVector<int>> MakeStateVector() {
   std::unique_ptr<VectorInterface<int>> vec;
   vec.reset(new BasicVector<int>(kLength));
   vec->get_mutable_value() << 1, 2, 3, 4;
 
-  std::unique_ptr<StateVectorInterface<int>> state_vector(
+  std::unique_ptr<StateVector<int>> state_vector(
       new BasicStateVector<int>(std::move(vec)));
   return state_vector;
 }


### PR DESCRIPTION
There is a default implementation in StateVector, and a higher-performance implementation in BasicStateVector (which has contiguous state).

+@sherm1 for feature and platform review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2552)
<!-- Reviewable:end -->
