### PR TITLE
Build "documentation" target only on explicit request

### DIFF
--- a/drake/doc/CMakeLists.txt
+++ b/drake/doc/CMakeLists.txt
@@ -86,6 +86,17 @@ if(ENV{OXYGEN_DIR})
 endif()
 
 if(DRAKE_DOCUMENTATION_OUTPUTS)
-  add_custom_target(documentation ALL DEPENDS ${DRAKE_DOCUMENTATION_OUTPUTS})
+  # Undocumented option for use by CI builds to build documentation
+  # as part of the default build targets ("all" or "ALL_BUILD").
+  # We do not do this by default because developers should only
+  # get documentation built by an explicit request for the target.
+  if(BUILD_DOCUMENTATION_ALWAYS)
+    set(_DRAKE_DOCUMENTATION_ALL ALL)
+  else()
+    set(_DRAKE_DOCUMENTATION_ALL "")
+  endif()
+
+  add_custom_target(documentation ${_DRAKE_DOCUMENTATION_ALL}
+    DEPENDS ${DRAKE_DOCUMENTATION_OUTPUTS})
   install(FILES .nojekyll CNAME DESTINATION ${DRAKE_DOCUMENTATION_DIR})
 endif()

--- a/drake/doc/doxygen_instructions.rst
+++ b/drake/doc/doxygen_instructions.rst
@@ -20,6 +20,7 @@ Coming soon. See issue
 
 Doxygen Website Generation
 ==========================
+
 First enable the ``documentation`` build target by executing the following::
 
     $ cd [build artifacts directory]
@@ -32,6 +33,7 @@ using the command line, and the second through Microsoft Visual Studio.
 
 Using the Command Line
 ----------------------
+
 To build the documentation via the command line, execute::
 
     $ cd [build artifacts directory]
@@ -45,11 +47,6 @@ favorite web browser::
 **Note 1:** If you're building Drake in-source (i.e., within the ``pod-build``
 directory), the ``[build artifacts directory]`` is typically
 ``[drake distro]/drake/pod-build/``.
-
-**Note 2:** By enabling the ``BUILD_DOCUMENTATION`` cmake option, the
-documentation will be built *every* time you compile Drake. To stop this
-behavior, see the instructions below on how to disable documentation
-generation.
 
 .. _doxygen-generation-visual-studio:
 


### PR DESCRIPTION
Remove the `documentation` target from the default build targets so that
developers that enable `BUILD_DOCUMENTATION` do not have to wait for the
documentation to re-build every time they build.  Instead it will build
only through the `make documentation` step that we already document.

Add an undocumented option to allow CI builds to drive documentation
as part of the default build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2558)
<!-- Reviewable:end -->
