### PR TITLE
Fix submodule download in pod-build mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,10 @@ foreach(proj ${EXTERNAL_PROJECTS})
       if(NOT ${proj}_BINARY_DIR)
         if(POD_BUILD)
           set(${proj}_BINARY_DIR "${${proj}_SOURCE_DIR}/pod-build")
+          # Make sure the source tree is empty before cloning into it.
+          set(${proj}_DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E remove_directory ${${proj}_GIT_SUBMODULE_PATH}/pod-build
+            COMMAND ${${proj}_DOWNLOAD_COMMAND}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${${proj}_GIT_SUBMODULE_PATH}/pod-build)
         else()
           set(${proj}_BINARY_DIR "${PROJECT_BINARY_DIR}/externals/${proj}")
         endif()


### PR DESCRIPTION
When using the PODS Makefile for an in-source build, the `POD_BUILD`
option to CMake causes `pod-build` directories to be created in the
externals' source trees.  The `pod-build` directory prevents the
`git clone` performed by `git submodule update` during the download
step from seeing an empty directory, so it refuses to clone.  Teach
the download step in `POD_BUILD` mode to remove the `pod-build`
directory prior to cloning.

Fixes #2565.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2567)
<!-- Reviewable:end -->
