### PR TITLE
Added gfortran to the list of things to install on Ubuntu.

### DIFF
--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -88,7 +88,7 @@ Other prerequisites may be installed as follows::
 
     sudo apt-get update
     sudo apt-get install --no-install-recommends autoconf automake bison \
-      default-jdk doxygen flex freeglut3-dev git gfortran \
+      default-jdk doxygen flex freeglut3-dev git gfortran-4.9 \
       graphviz libgtk2.0-dev libhtml-form-perl libjpeg-dev libmpfr-dev \
       libwww-perl libpng-dev libqt4-dev libqt4-opengl-dev libqwt-dev \
       libterm-readkey-perl libtool libvtk-java libvtk5-dev libvtk5-qt4-dev \

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -28,12 +28,13 @@ On Ubuntu 15.10 (Wily) and higher the system compiler is sufficient::
 Ubuntu 14.04 LTS (Trusty)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-On Ubuntu 14.04 LTS (Trusty) GCC 4.9 or higher must be installed, e.g.::
+On Ubuntu 14.04 LTS (Trusty) GCC 4.9 or higher and Fortran 4.9 must be
+installed, e.g.::
 
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     sudo apt-get update
     sudo apt-get upgrade
-    sudo apt-get install g++-4.9-multilib
+    sudo apt-get install g++-4.9-multilib gfortran-4.9
 
 Or, Clang 3.7::
 
@@ -88,7 +89,7 @@ Other prerequisites may be installed as follows::
 
     sudo apt-get update
     sudo apt-get install --no-install-recommends autoconf automake bison \
-      default-jdk doxygen flex freeglut3-dev git gfortran-4.9 \
+      default-jdk doxygen flex freeglut3-dev git \
       graphviz libgtk2.0-dev libhtml-form-perl libjpeg-dev libmpfr-dev \
       libwww-perl libpng-dev libqt4-dev libqt4-opengl-dev libqwt-dev \
       libterm-readkey-perl libtool libvtk-java libvtk5-dev libvtk5-qt4-dev \
@@ -106,12 +107,12 @@ version of Ubuntu is being used.
 Compiler Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the system's default compiler is not being used (for example if GCC/G++ 4.9
-fortran 4.9 is being used on Ubuntu 14.04 LTS), the desired compiler must be
-manually specified. One way to do this is to set the ``CC``, ``CXX``, and ``FC``
-environment variables. This can be done by executing the command below. To avoid
-needing to run this command each time a new terminal is opened, the command
-below can also be added to the ``~/.bashrc`` file::
+If the system's default compiler is not being used (for example if
+gcc/g++/gfortran 4.9 are being used on Ubuntu 14.04 LTS), the desired compiler
+must be manually specified. One way to do this is to set the ``CC``, ``CXX``,
+and ``FC`` environment variables. This can be done by executing the command
+below. To avoid needing to run this command each time a new terminal is opened,
+the command below can also be added to the ``~/.bashrc`` file::
 
     export CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9
 

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -88,13 +88,13 @@ Other prerequisites may be installed as follows::
 
     sudo apt-get update
     sudo apt-get install --no-install-recommends autoconf automake bison \
-      default-jdk doxygen flex freeglut3-dev git \
+      default-jdk doxygen flex freeglut3-dev git gfortran \
       graphviz libgtk2.0-dev libhtml-form-perl libjpeg-dev libmpfr-dev \
       libwww-perl libpng-dev libqt4-dev libqt4-opengl-dev libqwt-dev \
       libterm-readkey-perl libtool libvtk-java libvtk5-dev libvtk5-qt4-dev \
       make mpich2 perl pkg-config python-bs4 python-dev python-gtk2 \
       python-html5lib python-numpy python-pip python-sphinx python-vtk \
-      subversion swig unzip valgrind gfortran
+      subversion swig unzip valgrind
     sudo pip install -U cpplint
 
 Environment

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -28,8 +28,7 @@ On Ubuntu 15.10 (Wily) and higher the system compiler is sufficient::
 Ubuntu 14.04 LTS (Trusty)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-On Ubuntu 14.04 LTS (Trusty) GCC 4.9 or higher and Fortran 4.9 must be
-installed, e.g.::
+On Ubuntu 14.04 LTS (Trusty) GCC 4.9 or higher must be installed, e.g.::
 
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     sudo apt-get update

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -94,7 +94,7 @@ Other prerequisites may be installed as follows::
       libterm-readkey-perl libtool libvtk-java libvtk5-dev libvtk5-qt4-dev \
       make mpich2 perl pkg-config python-bs4 python-dev python-gtk2 \
       python-html5lib python-numpy python-pip python-sphinx python-vtk \
-      subversion swig unzip valgrind
+      subversion swig unzip valgrind gfortran
     sudo pip install -U cpplint
 
 Environment

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -107,18 +107,18 @@ Compiler Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the system's default compiler is not being used (for example if GCC/G++ 4.9
-is being used on Ubuntu 14.04 LTS), the desired compiler must be manually
-specified. One way to do this is to set the ``CC`` and ``CXX`` environment
-variables. This can be done by executing the command below. To avoid needing to
-run this command each time a new terminal is opened, the command below can also
-be added to the ``~/.bashrc`` file::
+fortran 4.9 is being used on Ubuntu 14.04 LTS), the desired compiler must be
+manually specified. One way to do this is to set the ``CC``, ``CXX``, and ``FC``
+environment variables. This can be done by executing the command below. To avoid
+needing to run this command each time a new terminal is opened, the command
+below can also be added to the ``~/.bashrc`` file::
 
-    export CC=gcc-4.9 CXX=g++-4.9
+    export CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9
 
 Alternatively, every call to ``make`` can be preceded with environment variable
 settings that specify the correct compiler::
 
-    env CC=gcc-4.9 CXX=g++-4.9 make ...
+    env CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9 make ...
 
 CMake Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is to resolve the following build-time problem:

```
checking for af77... no
checking for xlf_r... no
configure: WARNING: Failed to find a Fortran compiler!
configure: Fortran compiler options are:  
checking how to get verbose linking output from unavailable... configure: WARNING: compilation failed
checking for Fortran libraries of unavailable... 
checking for dummy main to link with Fortran libraries... none
checking for Fortran name-mangling scheme... configure: error: cannot compile a simple Fortran program
See `config.log' for more details.
configure: error: /bin/bash './configure' failed for ThirdParty/Blas
ninja: build stopped: subcommand failed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2570)
<!-- Reviewable:end -->
