### PR TITLE
Consistently use drake::solvers namespace 

### DIFF
--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -52,8 +52,9 @@ class Constraint {
   // to do allocation, but also allows it to choose stack allocation instead.
   virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                     Eigen::VectorXd& y) const = 0;
-  // move this to DifferentiableConstraint derived class if/when we
-  // need to support non-differentiable functions
+  // Move this to DifferentiableConstraint derived class if/when we
+  // need to support non-differentiable functions (at least, if
+  // DifferentiableConstraint is ever implemented).
   virtual void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
                     Drake::TaylorVecXd& y) const = 0;
 

--- a/drake/solvers/IpoptSolver.cpp
+++ b/drake/solvers/IpoptSolver.cpp
@@ -20,8 +20,6 @@ using Ipopt::IpoptData;
 using Ipopt::Number;
 using Ipopt::SolverReturn;
 
-using Drake::DecisionVariableView;
-using Drake::OptimizationProblem;
 using Drake::TaylorVecXd;
 
 namespace drake {
@@ -31,7 +29,7 @@ namespace {
 /// @param[out] lb Array of constraint lower bounds, parallel to @p ub
 /// @param[out] ub Array of constraint upper bounds, parallel to @p lb
 size_t GetConstraintBounds(
-    const Drake::Constraint& c, Number* lb, Number* ub) {
+    const Constraint& c, Number* lb, Number* ub) {
   const Eigen::VectorXd& lower_bound = c.lower_bound();
   const Eigen::VectorXd& upper_bound = c.upper_bound();
   for (size_t i = 0; i < c.num_constraints(); i++) {
@@ -45,7 +43,7 @@ size_t GetConstraintBounds(
 /// @param[out] num_grad number of gradients
 /// @return number of constraints
 size_t GetNumGradients(
-    const Drake::Constraint& c, const Drake::VariableList& variable_list,
+    const Constraint& c, const VariableList& variable_list,
     Index* num_grad) {
 
   size_t var_count = 0;
@@ -71,7 +69,7 @@ size_t GetNumGradients(
 ///
 /// @return the number of row/column pairs filled in.
 size_t GetGradientMatrix(
-    const Drake::Constraint& c, const Drake::VariableList& variable_list,
+    const Constraint& c, const VariableList& variable_list,
     Index constraint_idx, Index* iRow, Index* jCol) {
   const size_t m = c.num_constraints();
   size_t grad_index = 0;
@@ -104,7 +102,7 @@ Eigen::VectorXd MakeEigenVector(Index n, const Number* x) {
 /// @return number of gradient entries populated
 size_t EvaluateConstraint(
     const Eigen::VectorXd& xvec,
-    const Drake::Constraint& c, const Drake::VariableList& variable_list,
+    const Constraint& c, const VariableList& variable_list,
     Number* result, Number* grad) {
 
   // For constraints which don't use all of the variables in the X

--- a/drake/solvers/IpoptSolver.h
+++ b/drake/solvers/IpoptSolver.h
@@ -16,5 +16,5 @@ class DRAKEOPTIMIZATION_EXPORT IpoptSolver :
   SolutionResult Solve(OptimizationProblem& prog) const override;
 };
 
-}  // namespace drake
 }  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/IpoptSolver.h
+++ b/drake/solvers/IpoptSolver.h
@@ -8,13 +8,12 @@ namespace drake {
 namespace solvers {
 
 class DRAKEOPTIMIZATION_EXPORT IpoptSolver :
-      public Drake::MathematicalProgramSolverInterface  {
+      public MathematicalProgramSolverInterface  {
  public:
   // This solver is implemented in various pieces depending on if
   // Ipopt was available during compilation.
   bool available() const override;
-  drake::solvers::SolutionResult Solve(
-      Drake::OptimizationProblem& prog) const override;
+  SolutionResult Solve(OptimizationProblem& prog) const override;
 };
 
 }  // namespace drake

--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -198,5 +198,5 @@ MathematicalProgramInterface::GetLeastSquaresProgram() {
 
 MathematicalProgramSolverInterface::~MathematicalProgramSolverInterface() {}
 
-}
-}
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -6,9 +6,8 @@
 #include "Optimization.h"
 #include "SnoptSolver.h"
 
-using drake::solvers::SolutionResult;
-
-namespace Drake {
+namespace drake {
+namespace solvers {
 MathematicalProgramInterface::~MathematicalProgramInterface() {}
 
 namespace {
@@ -96,7 +95,7 @@ class NonlinearProgram : public MathematicalProgram {
   }
 
  private:
-  drake::solvers::IpoptSolver ipopt_solver;
+  IpoptSolver ipopt_solver;
   NloptSolver nlopt_solver;
   SnoptSolver snopt_solver;
 };
@@ -198,4 +197,6 @@ MathematicalProgramInterface::GetLeastSquaresProgram() {
 }
 
 MathematicalProgramSolverInterface::~MathematicalProgramSolverInterface() {}
+
+}
 }

--- a/drake/solvers/MathematicalProgram.h
+++ b/drake/solvers/MathematicalProgram.h
@@ -5,7 +5,8 @@
 #include "drake/drakeOptimization_export.h"
 #include "drake/solvers/solution_result.h"
 
-namespace Drake {
+namespace drake {
+namespace solvers {
 class OptimizationProblem;
 
 // uses virtual methods to crawl up the complexity hiearchy as new decision
@@ -35,8 +36,7 @@ class DRAKEOPTIMIZATION_EXPORT MathematicalProgramInterface {
   virtual MathematicalProgramInterface*
   AddLinearComplementarityConstraint() = 0;
 
-  virtual drake::solvers::SolutionResult Solve(
-      OptimizationProblem& prog) const = 0;
+  virtual SolutionResult Solve(OptimizationProblem& prog) const = 0;
 
   static std::shared_ptr<MathematicalProgramInterface> GetLeastSquaresProgram();
 };
@@ -46,7 +46,8 @@ class DRAKEOPTIMIZATION_EXPORT MathematicalProgramSolverInterface {
  public:
   virtual ~MathematicalProgramSolverInterface();
   virtual bool available() const = 0;
-  virtual drake::solvers::SolutionResult Solve(
-      OptimizationProblem& prog) const = 0;
+  virtual SolutionResult Solve(OptimizationProblem& prog) const = 0;
 };
+
+}
 }

--- a/drake/solvers/MathematicalProgram.h
+++ b/drake/solvers/MathematicalProgram.h
@@ -49,5 +49,5 @@ class DRAKEOPTIMIZATION_EXPORT MathematicalProgramSolverInterface {
   virtual SolutionResult Solve(OptimizationProblem& prog) const = 0;
 };
 
-}
-}
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/MobyLCP.cpp
+++ b/drake/solvers/MobyLCP.cpp
@@ -16,8 +16,8 @@
 
 #include "Optimization.h"
 
-using drake::solvers::SolutionResult;
-
+namespace drake {
+namespace solvers {
 namespace {
 template <typename Derived>
 void selectSubMat(const Eigen::MatrixBase<Derived>& in,
@@ -80,8 +80,6 @@ Eigen::Index minCoeffIdx(const Eigen::MatrixBase<Derived>& in) {
 
 const double NEAR_ZERO = std::sqrt(std::numeric_limits<double>::epsilon());
 }
-
-namespace Drake {
 
 // Sole constructor
 MobyLCPSolver::MobyLCPSolver() : log_enabled_(false) {}
@@ -1306,5 +1304,7 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
 
   // still here?  failure...
   return false;
+}
+
 }
 }

--- a/drake/solvers/MobyLCP.cpp
+++ b/drake/solvers/MobyLCP.cpp
@@ -1306,5 +1306,5 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
   return false;
 }
 
-}
-}
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/MobyLCP.h
+++ b/drake/solvers/MobyLCP.h
@@ -10,7 +10,8 @@
 
 #include "MathematicalProgram.h"
 
-namespace Drake {
+namespace drake {
+namespace solvers {
 
 class DRAKEOPTIMIZATION_EXPORT MobyLCPSolver
     : public MathematicalProgramSolverInterface {
@@ -43,8 +44,7 @@ class DRAKEOPTIMIZATION_EXPORT MobyLCPSolver
                                 double zero_tol = -1.0) const;
 
   bool available() const override { return true; }
-  drake::solvers::SolutionResult Solve(
-      OptimizationProblem& prog) const override;
+  SolutionResult Solve(OptimizationProblem& prog) const override;
 
  private:
   void ClearIndexVectors() const;
@@ -86,4 +86,5 @@ class DRAKEOPTIMIZATION_EXPORT MobyLCPSolver
   mutable Eigen::SparseMatrix<double> _MMs, _MMx, _eye, _zero, _diag_lambda;
 };
 
-}  // end namespace Drake
+}  // end namespace solvers
+}  // end namespace drake

--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -377,5 +377,5 @@ SolutionResult NloptSolver::Solve(OptimizationProblem &prog) const {
   return result;
 }
 
-}
-}
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -10,9 +10,11 @@
 #include "drake/core/Gradient.h"
 #include "drake/solvers/Optimization.h"
 
-using drake::solvers::SolutionResult;
+using Drake::TaylorVecXd;
 
-namespace Drake {
+namespace drake {
+namespace solvers {
+
 namespace {
 Eigen::VectorXd MakeEigenVector(const std::vector<double>& x) {
   Eigen::VectorXd xvec(x.size());
@@ -29,7 +31,7 @@ TaylorVecXd MakeInputTaylorVec(const Eigen::VectorXd& xvec,
     var_count += v.size();
   }
 
-  auto tx = initializeAutoDiff(xvec);
+  auto tx = Drake::initializeAutoDiff(xvec);
   TaylorVecXd this_x(var_count);
   size_t index = 0;
   for (const DecisionVariableView& v : variable_list) {
@@ -51,7 +53,7 @@ double EvaluateCosts(const std::vector<double>& x,
   double cost = 0;
   Eigen::VectorXd xvec = MakeEigenVector(x);
 
-  auto tx = initializeAutoDiff(xvec);
+  auto tx = Drake::initializeAutoDiff(xvec);
   TaylorVecXd ty(1);
   TaylorVecXd this_x;
 
@@ -373,5 +375,7 @@ SolutionResult NloptSolver::Solve(OptimizationProblem &prog) const {
   prog.SetDecisionVariableValues(sol);
   prog.SetSolverResult("NLopt", nlopt_result);
   return result;
+}
+
 }
 }

--- a/drake/solvers/NloptSolver.h
+++ b/drake/solvers/NloptSolver.h
@@ -16,5 +16,5 @@ class DRAKEOPTIMIZATION_EXPORT NloptSolver :
   SolutionResult Solve(OptimizationProblem& prog) const override;
 };
 
-}
-}
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/NloptSolver.h
+++ b/drake/solvers/NloptSolver.h
@@ -4,7 +4,8 @@
 
 #include "drake/solvers/MathematicalProgram.h"
 
-namespace Drake {
+namespace drake {
+namespace solvers {
 
 class DRAKEOPTIMIZATION_EXPORT NloptSolver :
       public MathematicalProgramSolverInterface  {
@@ -12,7 +13,8 @@ class DRAKEOPTIMIZATION_EXPORT NloptSolver :
   // This solver is implemented in various pieces depending on if
   // NLOpt was available during compilation.
   bool available() const override;
-  drake::solvers::SolutionResult Solve(
-      OptimizationProblem& prog) const override;
+  SolutionResult Solve(OptimizationProblem& prog) const override;
 };
+
+}
 }

--- a/drake/solvers/NoIpopt.cpp
+++ b/drake/solvers/NoIpopt.cpp
@@ -3,13 +3,18 @@
 
 #include <stdexcept>
 
-bool drake::solvers::IpoptSolver::available() const {
+namespace drake {
+namespace solvers {
+
+bool IpoptSolver::available() const {
   return false;
 }
 
-drake::solvers::SolutionResult drake::solvers::IpoptSolver::Solve(
-    Drake::OptimizationProblem &prog) const {
+SolutionResult IpoptSolver::Solve(OptimizationProblem &prog) const {
   throw std::runtime_error(
       "The IPOPT bindings were not compiled.  You'll need to use a different "
       "solver.");
 }
+
+}  // namespace drake
+}  // namespace solvers

--- a/drake/solvers/NoNlopt.cpp
+++ b/drake/solvers/NoNlopt.cpp
@@ -3,13 +3,18 @@
 
 #include <stdexcept>
 
-bool Drake::NloptSolver::available() const {
+namespace drake {
+namespace solvers {
+
+bool NloptSolver::available() const {
   return false;
 }
 
-drake::solvers::SolutionResult Drake::NloptSolver::Solve(
-    OptimizationProblem &prog) const {
+SolutionResult NloptSolver::Solve(OptimizationProblem &prog) const {
   throw std::runtime_error(
       "The Nlopt bindings were not compiled.  You'll need to use a different "
       "solver.");
 }
+
+}  // namespace drake
+}  // namespace solvers

--- a/drake/solvers/NoSnopt.cpp
+++ b/drake/solvers/NoSnopt.cpp
@@ -3,13 +3,18 @@
 
 #include <stdexcept>
 
-bool Drake::SnoptSolver::available() const {
+namespace drake {
+namespace solvers {
+
+bool SnoptSolver::available() const {
   return false;
 }
 
-drake::solvers::SolutionResult Drake::SnoptSolver::Solve(
-    OptimizationProblem &prog) const {
+SolutionResult SnoptSolver::Solve(OptimizationProblem &prog) const {
   throw std::runtime_error(
       "The SNOPT bindings were not compiled.  You'll need to use a different "
       "solver.");
 }
+
+}  // namespace drake
+}  // namespace solvers

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -16,8 +16,8 @@
 #include "drake/solvers/solution_result.h"
 #include "drake/util/Polynomial.h"
 
-
-namespace Drake {
+namespace drake {
+namespace solvers {
 
 /**
  * DecisionVariable
@@ -213,30 +213,30 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     // Construct by copying from an lvalue.
     template <typename... Args>
     ConstraintImpl(F const& f, Args&&... args)
-        : Constraint(FunctionTraits<F>::numOutputs(f),
+        : Constraint(Drake::FunctionTraits<F>::numOutputs(f),
                      std::forward<Args>(args)...),
           f_(f) {}
 
     // Construct by moving from an rvalue.
     template <typename... Args>
     ConstraintImpl(F&& f, Args&&... args)
-        : Constraint(FunctionTraits<F>::numOutputs(f),
+        : Constraint(Drake::FunctionTraits<F>::numOutputs(f),
                      std::forward<Args>(args)...),
           f_(std::forward<F>(f)) {}
 
     void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-                      Eigen::VectorXd& y) const override {
-      y.resize(FunctionTraits<F>::numOutputs(f_));
-      assert(x.rows() == FunctionTraits<F>::numInputs(f_));
-      assert(y.rows() == FunctionTraits<F>::numOutputs(f_));
-      FunctionTraits<F>::eval(f_, x, y);
+              Eigen::VectorXd& y) const override {
+      y.resize(Drake::FunctionTraits<F>::numOutputs(f_));
+      assert(x.rows() == Drake::FunctionTraits<F>::numInputs(f_));
+      assert(y.rows() == Drake::FunctionTraits<F>::numOutputs(f_));
+      Drake::FunctionTraits<F>::eval(f_, x, y);
     }
-    void eval(const Eigen::Ref<const TaylorVecXd>& x,
-                      TaylorVecXd& y) const override {
-      y.resize(FunctionTraits<F>::numOutputs(f_));
-      assert(x.rows() == FunctionTraits<F>::numInputs(f_));
-      assert(y.rows() == FunctionTraits<F>::numOutputs(f_));
-      FunctionTraits<F>::eval(f_, x, y);
+    void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+              Drake::TaylorVecXd& y) const override {
+      y.resize(Drake::FunctionTraits<F>::numOutputs(f_));
+      assert(x.rows() == Drake::FunctionTraits<F>::numInputs(f_));
+      assert(y.rows() == Drake::FunctionTraits<F>::numOutputs(f_));
+      Drake::FunctionTraits<F>::eval(f_, x, y);
     }
   };
 
@@ -612,7 +612,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    *
    * @return SolutionResult indicating if the solution was successful.
    */
-  drake::solvers::SolutionResult Solve() {
+  SolutionResult Solve() {
     return problem_type_->Solve(*this);
   }  // todo: add argument for options
 
@@ -788,4 +788,5 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   std::map<std::string, std::map<std::string, std::string>> solver_options_str_;
 };
 
-}  // end namespace Drake
+}  // end namespace solvers
+}  // end namespace drake

--- a/drake/solvers/SnoptSolver.cpp
+++ b/drake/solvers/SnoptSolver.cpp
@@ -246,7 +246,7 @@ int snopt_userfun(snopt::integer* Status, snopt::integer* n,
   return 0;
 }
 
-} // anon namespace
+}  // anon namespace
 
 bool SnoptSolver::available() const {
   return true;

--- a/drake/solvers/SnoptSolver.cpp
+++ b/drake/solvers/SnoptSolver.cpp
@@ -245,7 +245,8 @@ int snopt_userfun(snopt::integer* Status, snopt::integer* n,
 
   return 0;
 }
-}
+
+} // anon namespace
 
 bool SnoptSolver::available() const {
   return true;
@@ -475,5 +476,5 @@ SolutionResult SnoptSolver::Solve(OptimizationProblem& prog) const {
   return SolutionResult::kUnknownError;
 }
 
-}
-}
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/SnoptSolver.cpp
+++ b/drake/solvers/SnoptSolver.cpp
@@ -9,8 +9,6 @@
 
 #include "drake/solvers/Optimization.h"
 
-using drake::solvers::SolutionResult;
-
 namespace snopt {
 #include "snopt.hh"
 #include "snfilewrapper.hh"
@@ -23,16 +21,16 @@ namespace snopt {
 // constraints, ...)
 // todo:  avoid all dynamic allocation
 
+namespace drake {
+namespace solvers {
+namespace {
+
 // snopt minimum workspace requirements
 unsigned int constexpr snopt_mincw = 500;
 unsigned int constexpr snopt_miniw = 500;
 unsigned int constexpr snopt_minrw = 500;
 
-bool Drake::SnoptSolver::available() const {
-  return true;
-}
-
-struct SNOPTData : public Drake::OptimizationProblem::SolverData {
+struct SNOPTData : public OptimizationProblem::SolverData {
   std::vector<char> cw;
   std::vector<snopt::integer> iw;
   std::vector<snopt::doublereal> rw;
@@ -166,7 +164,7 @@ struct SNOPTRun {
   }
 };
 
-static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
+int snopt_userfun(snopt::integer* Status, snopt::integer* n,
                          snopt::doublereal x[], snopt::integer* needF,
                          snopt::integer* neF, snopt::doublereal F[],
                          snopt::integer* needG, snopt::integer* neG,
@@ -175,7 +173,7 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
                          snopt::doublereal ru[], snopt::integer* lenru) {
   // Our snOptA call passes the snopt workspace as the user workspace and
   // reserves one 8-char of space to pass the problem pointer.
-  Drake::OptimizationProblem const* current_problem = NULL;
+  OptimizationProblem const* current_problem = NULL;
   {
     char* const pcp = reinterpret_cast<char*>(&current_problem);
     char const* const cu_cp = cu + 8 * snopt_mincw;
@@ -197,7 +195,7 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
   for (auto const& binding : current_problem->generic_objectives()) {
     auto const& obj = binding.constraint();
     size_t index = 0;
-    for (const Drake::DecisionVariableView& v : binding.variable_list()) {
+    for (const DecisionVariableView& v : binding.variable_list()) {
       this_x.conservativeResize(index + v.size());
       this_x.segment(index, v.size()) = tx.segment(v.index(), v.size());
       index += v.size();
@@ -206,7 +204,7 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
 
     F[0] += static_cast<snopt::doublereal>(ty(0).value());
 
-    for (const Drake::DecisionVariableView& v : binding.variable_list()) {
+    for (const DecisionVariableView& v : binding.variable_list()) {
       for (size_t j = v.index(); j < v.index() + v.size(); j++) {
         G[j] += static_cast<snopt::doublereal>(ty(0).derivatives()(j));
       }
@@ -222,7 +220,7 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
   for (auto const& binding : current_problem->generic_constraints()) {
     auto const& c = binding.constraint();
     size_t index = 0, num_constraints = c->num_constraints();
-    for (const Drake::DecisionVariableView& v : binding.variable_list()) {
+    for (const DecisionVariableView& v : binding.variable_list()) {
       this_x.conservativeResize(index + v.size());
       this_x.segment(index, v.size()) = tx.segment(v.index(), v.size());
       index += v.size();
@@ -235,7 +233,7 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
       F[constraint_index++] = static_cast<snopt::doublereal>(ty(i).value());
     }
 
-    for (const Drake::DecisionVariableView& v : binding.variable_list()) {
+    for (const DecisionVariableView& v : binding.variable_list()) {
       for (i = 0; i < num_constraints; i++) {
         for (size_t j = v.index(); j < v.index() + v.size(); j++) {
           G[grad_index++] =
@@ -247,13 +245,17 @@ static int snopt_userfun(snopt::integer* Status, snopt::integer* n,
 
   return 0;
 }
+}
 
-SolutionResult Drake::SnoptSolver::Solve(
-    OptimizationProblem& prog) const {
+bool SnoptSolver::available() const {
+  return true;
+}
+
+SolutionResult SnoptSolver::Solve(OptimizationProblem& prog) const {
   auto d = prog.GetSolverData<SNOPTData>();
   SNOPTRun cur(*d);
 
-  Drake::OptimizationProblem const* current_problem = &prog;
+  OptimizationProblem const* current_problem = &prog;
 
   // Set the "maxcu" value to tell snopt to reserve one 8-char entry of user
   // workspace.  We are then allowed to use cw(snopt_mincw+1:maxcu), as
@@ -471,4 +473,7 @@ SolutionResult Drake::SnoptSolver::Solve(
     return SolutionResult::kInvalidInput;
   }
   return SolutionResult::kUnknownError;
+}
+
+}
 }

--- a/drake/solvers/SnoptSolver.h
+++ b/drake/solvers/SnoptSolver.h
@@ -4,7 +4,8 @@
 
 #include "drake/solvers/MathematicalProgram.h"
 
-namespace Drake {
+namespace drake {
+namespace solvers {
 
 class DRAKEOPTIMIZATION_EXPORT SnoptSolver :
     public MathematicalProgramSolverInterface  {
@@ -12,7 +13,8 @@ class DRAKEOPTIMIZATION_EXPORT SnoptSolver :
   // This solver is implemented in various pieces depending on if
   // SNOPT was available during compilation.
   bool available() const override;
-  drake::solvers::SolutionResult Solve(
-      OptimizationProblem& prog) const override;
+  SolutionResult Solve(OptimizationProblem& prog) const override;
 };
+
+}
 }

--- a/drake/solvers/SnoptSolver.h
+++ b/drake/solvers/SnoptSolver.h
@@ -16,5 +16,5 @@ class DRAKEOPTIMIZATION_EXPORT SnoptSolver :
   SolutionResult Solve(OptimizationProblem& prog) const override;
 };
 
-}
-}
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/system_identification.cpp
+++ b/drake/solvers/system_identification.cpp
@@ -270,7 +270,7 @@ SystemIdentification<T>::EstimateParameters(
   assert(num_data >= vars_to_estimate.size());
 
   // Build up our optimization problem's decision variables.
-  Drake::OptimizationProblem problem;
+  OptimizationProblem problem;
   const auto parameter_variables =
       problem.AddContinuousVariables(num_to_estimate, "param");
   const auto error_variables =
@@ -314,7 +314,7 @@ SystemIdentification<T>::EstimateParameters(
   auto cost = problem.AddQuadraticCost(
       Eigen::MatrixXd::Identity(num_err_terms, num_err_terms),
       Eigen::VectorXd::Zero(num_err_terms),
-      std::list<Drake::DecisionVariableView> { error_variables });
+      std::list<DecisionVariableView> { error_variables });
 
   // Solve the problem and copy out the result.
   SolutionResult solution_result = problem.Solve();

--- a/drake/solvers/test/testMobyLCP.cpp
+++ b/drake/solvers/test/testMobyLCP.cpp
@@ -36,7 +36,7 @@ Eigen::SparseMatrix<double> MakeSparseMatrix(
 template <typename Derived>
 void RunBasicLcp(const Eigen::MatrixBase<Derived>& M, const Eigen::VectorXd& q,
                  const Eigen::VectorXd& expected_z_in, bool expect_fast_pass) {
-  Drake::MobyLCPSolver l;
+  MobyLCPSolver l;
   l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd expected_z = expected_z_in;
@@ -77,7 +77,7 @@ void RunRegularizedLcp(const Eigen::MatrixBase<Derived>& M,
                        const Eigen::VectorXd& q,
                        const Eigen::VectorXd& expected_z_in,
                        bool expect_fast_pass) {
-  Drake::MobyLCPSolver l;
+  MobyLCPSolver l;
   l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd expected_z = expected_z_in;
@@ -223,7 +223,7 @@ GTEST_TEST(testMobyLCP, testProblem4) {
   Eigen::VectorXd z(4);
   z << 1. / 90., 2. / 45., 1. / 90., 2. / 45.;
 
-  Drake::MobyLCPSolver l;
+  MobyLCPSolver l;
   l.SetLoggingEnabled(verbose);
 
   Eigen::VectorXd fast_z;
@@ -287,7 +287,7 @@ GTEST_TEST(testMobyLCP, testEmpty) {
   Eigen::MatrixXd empty_M(0, 0);
   Eigen::VectorXd empty_q(0);
   Eigen::VectorXd z;
-  Drake::MobyLCPSolver l;
+  MobyLCPSolver l;
   l.SetLoggingEnabled(verbose);
 
   bool result = l.SolveLcpFast(empty_M, empty_q, &z);

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -21,17 +21,10 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::VectorXd;
 
-using Drake::Constraint;
 using Drake::TaylorVecXd;
 using Drake::VecIn;
 using Drake::Vector1d;
 using Drake::VecOut;
-using Drake::MathematicalProgramSolverInterface;
-using Drake::NloptSolver;
-using Drake::OptimizationProblem;
-using Drake::BoundingBoxConstraint;
-using Drake::SnoptSolver;
-using Drake::LinearComplementarityConstraint;
 using drake::util::MatrixCompareType;
 
 namespace drake {
@@ -200,8 +193,8 @@ GTEST_TEST(testOptimizationProblem, testProblem1) {
   constraint << 20, 12, 11, 7, 4;
   prog.AddLinearConstraint(
       constraint.transpose(),
-      Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
-      Drake::Vector1d::Constant(40));
+      Vector1d::Constant(-std::numeric_limits<double>::infinity()),
+      Vector1d::Constant(40));
   prog.AddBoundingBoxConstraint(MatrixXd::Constant(5, 1, 0),
                                 MatrixXd::Constant(5, 1, 1));
   VectorXd expected(5);
@@ -242,13 +235,13 @@ GTEST_TEST(testOptimizationProblem, testProblem2) {
   constraint1 << 6, 3, 3, 2, 1, 0;
   prog.AddLinearConstraint(
       constraint1.transpose(),
-      Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
-      Drake::Vector1d::Constant(6.5));
+      Vector1d::Constant(-std::numeric_limits<double>::infinity()),
+      Vector1d::Constant(6.5));
   constraint2 << 10, 0, 10, 0, 0, 1;
   prog.AddLinearConstraint(
       constraint2.transpose(),
-      Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
-      Drake::Vector1d::Constant(20));
+      Vector1d::Constant(-std::numeric_limits<double>::infinity()),
+      Vector1d::Constant(20));
   Eigen::VectorXd lower(6);
   lower << 0, 0, 0, 0, 0, 0;
   Eigen::VectorXd upper(6);
@@ -324,18 +317,18 @@ GTEST_TEST(testOptimizationProblem, lowerBoundTest) {
   c1 << 1, -3, 0, 0, 0, 0;
   prog.AddLinearConstraint(
       c1.transpose(),
-      Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
-      Drake::Vector1d::Constant(2));
+      Vector1d::Constant(-std::numeric_limits<double>::infinity()),
+      Vector1d::Constant(2));
   Eigen::VectorXd c2(6);
   c2 << -1, 1, 0, 0, 0, 0;
   prog.AddLinearConstraint(
       c2.transpose(),
-      Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
-      Drake::Vector1d::Constant(2));
+      Vector1d::Constant(-std::numeric_limits<double>::infinity()),
+      Vector1d::Constant(2));
   Eigen::VectorXd c3(6);
   c3 << 1, 1, 0, 0, 0, 0;
-  prog.AddLinearConstraint(c3.transpose(), Drake::Vector1d::Constant(2),
-                           Drake::Vector1d::Constant(6));
+  prog.AddLinearConstraint(c3.transpose(), Vector1d::Constant(2),
+                           Vector1d::Constant(6));
   Eigen::VectorXd lower(6);
   lower << 0, 0, 1, 0, 1, 0;
   Eigen::VectorXd upper(6);

--- a/drake/systems/plants/ConstraintWrappers.h
+++ b/drake/systems/plants/ConstraintWrappers.h
@@ -42,7 +42,8 @@ class KinematicsCacheHelper {
   KinematicsCache<Scalar> kinsol_;
 };
 
-class SingleTimeKinematicConstraintWrapper : public Constraint {
+class SingleTimeKinematicConstraintWrapper :
+      public drake::solvers::Constraint {
  public:
   /// All pointers are aliased for the lifetime of the wrapper.
   SingleTimeKinematicConstraintWrapper(
@@ -79,7 +80,8 @@ class SingleTimeKinematicConstraintWrapper : public Constraint {
   mutable KinematicsCacheHelper<double>* kin_helper_;
 };
 
-class QuasiStaticConstraintWrapper : public Constraint {
+class QuasiStaticConstraintWrapper :
+      public drake::solvers::Constraint {
  public:
   /// All pointers are aliased for the lifetime of the wrapper.  Also,
   /// the wrapped QuasiStaticConstraint claims to have three

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -93,7 +93,7 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
   // happily, this clunkier version seems fast enough for now
   // the optimization framework should support this (though it has not been
   // tested thoroughly yet)
-  OptimizationProblem prog;
+  drake::solvers::OptimizationProblem prog;
   auto const& vdot = prog.AddContinuousVariables(nv, "vdot");
 
   auto H = tree->massMatrix(kinsol);
@@ -284,7 +284,7 @@ DRAKERBSYSTEM_EXPORT RigidBodySystem::StateVector<double> getInitialState(
   if (sys.tree->getNumPositionConstraints()) {
     // todo: move this up to the system level?
 
-    OptimizationProblem prog;
+    drake::solvers::OptimizationProblem prog;
     std::vector<RigidBodyLoop, Eigen::aligned_allocator<RigidBodyLoop>> const&
         loops = sys.tree->loops;
 

--- a/drake/systems/plants/inverseKinBackend.cpp
+++ b/drake/systems/plants/inverseKinBackend.cpp
@@ -20,6 +20,9 @@ using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using Eigen::VectorXi;
 
+using drake::solvers::Constraint;
+using drake::solvers::DecisionVariableView;
+using drake::solvers::OptimizationProblem;
 using drake::solvers::SolutionResult;
 
 /// NOTE: The contents of this class are for the most part direct ports of


### PR DESCRIPTION
The drakeOptimization library previously contained a mix of items defined in the Drake and drake::solvers namespaces.  Move everything into drake::solvers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2571)
<!-- Reviewable:end -->
