### PR TITLE
Set ignore = dirty on IPOPT, since its own .gitignore is not comprehensive.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,3 +88,4 @@
 [submodule "externals/ipopt"]
 	path = externals/ipopt
 	url = https://github.com/RobotLocomotion/ipopt-mirror.git
+	ignore = dirty        


### PR DESCRIPTION
This will prevent `modified:   externals/ipopt (untracked content)` from appearing in `git status` after you compile post #2487.

@bradking, @sammy-tri, @amcastro-tri FYI

@ggould-tri for feature and platform review