### PR TITLE
Added World Link to Prius.urdf

### DIFF
--- a/drake/examples/Cars/car_simulation.cc
+++ b/drake/examples/Cars/car_simulation.cc
@@ -26,44 +26,10 @@ std::shared_ptr<RigidBodySystem> CreateRigidBodySystem(int argc,
     exit(EXIT_FAILURE);
   }
 
-  // The Z-axis offset between Drake's world frame and the vehicle's world
-  // frame.
-  double z_offset = 0;
-
-  // TODO(liangfok): Once PR 2171 is merged, modify prius.urdf to contain a
-  // world link and proper offset of the chassis_floor. For more information,
-  // see: https://github.com/RobotLocomotion/drake/pull/2171 and
-  // https://github.com/RobotLocomotion/drake/issues/2247
-  if (std::string(argv[1]).find("prius.urdf") != std::string::npos)
-    z_offset = 0.378326;
-
-  // The following variable, weld_to_frame, is only needed if the model is a
-  // URDF file. It is needed since URDF does not specify the location and
-  // orientation of the car's root node in the world. If the model is an SDF,
-  // weld_to_frame is ignored by the parser.
-  auto weld_to_frame = std::allocate_shared<RigidBodyFrame>(
-      Eigen::aligned_allocator<RigidBodyFrame>(),
-      // Weld the model to the world link.
-      "world",
-
-      // A pointer to a rigid body to which to weld the model is not needed
-      // since the model will be welded to the world, which can by automatically
-      // found within the rigid body tree.
-      nullptr,
-
-      // The following parameter specifies the X,Y,Z position of the car's root
-      // link in the world's frame.
-      Eigen::Vector3d(0, 0, z_offset),
-
-      // The following parameter specifies the roll, pitch, and yaw of the car's
-      // root link in the world's frame.
-      Eigen::Vector3d(0, 0, 0));
-
   // Instantiates a rigid body system and adds the robot to it.
   auto rigid_body_sys = std::allocate_shared<RigidBodySystem>(
       Eigen::aligned_allocator<RigidBodySystem>());
-  rigid_body_sys->addRobotFromFile(argv[1], DrakeJoint::QUATERNION,
-                                   weld_to_frame);
+  rigid_body_sys->addRobotFromFile(argv[1], DrakeJoint::QUATERNION);
 
   // Initializes duration to be infinity.
   *duration = std::numeric_limits<double>::infinity();

--- a/drake/examples/Cars/models/prius/prius.urdf
+++ b/drake/examples/Cars/models/prius/prius.urdf
@@ -1,5 +1,13 @@
 <?xml version="1.0" ?>
 <robot name="prius_1">
+  <link name="world" />
+
+  <joint name="world_to_prius_joint" type="continuous">
+    <origin rpy="0 0 0" xyz="0 0 0.378326"/>
+    <parent link="world"/>
+    <child link="chassis_floor"/>
+  </joint>
+
   <link name="chassis_floor">
     <inertial>
       <mass value="57.833"/>

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -102,7 +102,7 @@ if(LCM_FOUND)
     add_test(NAME compareAcrobotURDFtoSDF COMMAND compareRigidBodySystems Acrobot.urdf Acrobot.sdf WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/examples/Acrobot")
 
     if(snopt_c_FOUND)
-      add_test(NAME comparePriusURDFtoSDF COMMAND compareRigidBodySystems prius.sdf prius.urdf 0 0 0.378326 WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/examples/Cars/models/prius")
+      add_test(NAME comparePriusURDFtoSDF COMMAND compareRigidBodySystems prius.sdf prius.urdf WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/examples/Cars/models/prius")
     endif()
 
     add_executable(load_model_test load_model_test.cc)


### PR DESCRIPTION
Resolves #2247 

Modified `prius.urdf` to have a world link so it can be correctly offset in the world. Updated `car_simulation.cc` to not specify a `weld_to_frame` parameter since this information is now contained within the URDF and SDF files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2580)
<!-- Reviewable:end -->
