### PR TITLE
Updated documentation for RigidBodyTree::findBodyIndex().

### DIFF
--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1713,14 +1713,14 @@ shared_ptr<RigidBodyFrame> RigidBodyTree::findFrame(
   }
 }
 
-int RigidBodyTree::FindBodyIndex(const std::string& link_name,
+int RigidBodyTree::FindBodyIndex(const std::string& body_name,
                                  int model_id) const {
-  RigidBody* link = findLink(link_name, "", model_id);
+  RigidBody* link = findLink(body_name, "", model_id);
   if (link == nullptr) {
     throw std::logic_error(
-        "RigidBodyTree::findLinkID: ERROR: Could not find link id for link " +
-        std::string("named \"") + link_name + "\", model_id = " +
-        std::to_string(model_id));
+        "RigidBodyTree::FindBodyIndex: ERROR: Could not find index for rigid "
+        "body \"" + body_name + "\", model_id = " + std::to_string(model_id) +
+        ".");
   }
   return link->body_index;
 }

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -694,20 +694,22 @@ class DRAKERBM_EXPORT RigidBodyTree {
                       int model_id = -1) const;
 
   /**
-   * Obtains the body index of a link. Note that the body index of the link
-   * is different from the ID of the model to which the link belongs.
+   * Obtains the index of a rigid body within this rigid body tree. The rigid
+   * body tree maintains a vector of pointers to all rigid bodies that are part
+   * of the rigid body tree. The index of a rigid body is the index within this
+   * vector at which a pointer to the rigid body is stored.
    *
-   * @param[in] link_name The link whose body index we want to find. It should
+   * @param[in] body_name The body whose index we want to find. It should
    * be unique within the searched models, otherwise an exception will be
    * thrown.
    * @param[in] model_id The ID of the model. This parameter is optional. If
-   * supplied, only that model is searched; otherwise, all models are searched.
-   * @return The body index of the specified link. If this value is -1, all
-   * models are searched for a link named \p link_name.
-   * @throws std::logic_error if no link with the specified \p link_name and
-   * \p model_id were found or if multiple matching links were found.
+   * supplied, only the model with the specified ID is searched; otherwise, all
+   * models are searched.
+   * @return The index of the specified rigid body.
+   * @throws std::logic_error if no rigid body with the specified \p body_name
+   * and \p model_id was found or if multiple matching rigid bodies were found.
    */
-  int FindBodyIndex(const std::string& link_name, int model_id = -1) const;
+  int FindBodyIndex(const std::string& body_name, int model_id = -1) const;
 
   // TODO(amcastro-tri): The name of this method is misleading.
   // It returns a RigidBody when the user seems to request a joint.


### PR DESCRIPTION
Updated documentation for RigidBodyTree::findBodyIndex(). I'm switching from using "link" to "body" as standard terminology.

This also fixes a error message in an exception that used the old "findLinkID()" method name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2595)
<!-- Reviewable:end -->
