### PR TITLE
Update MATLAB code to support out-of-source builds.

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -344,7 +344,7 @@ endif()
 include(cmake/matlab_pods.cmake)
 pods_configure_matlab_paths()
 
-message(STATUS "Writing addpath_drake.m and rmpath_drake.m to ${CMAKE_INSTALL_PREFIX}/matlab")
+message(STATUS "Writing path utilities to ${CMAKE_INSTALL_PREFIX}/matlab")
 file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/addpath_drake.m
   "function addpath_drake()\n"
   "  addpath(fullfile('${CMAKE_INSTALL_PREFIX}', 'matlab'));\n"
@@ -359,6 +359,18 @@ file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/rmpath_drake.m
   "  wd = cd('${CMAKE_CURRENT_SOURCE_DIR}');\n"
   "  rmpath_drake();\n"
   "  cd(wd);\n")
+
+file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/get_drake_binary_dir.m
+  "function [binary_dir] = get_drake_binary_dir()\n"
+  "  binary_dir = '${PROJECT_BINARY_DIR}';\n"
+  "end\n"
+  "\n")
+
+file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/get_drake_install_dir.m
+  "function [install_dir] = get_drake_install_dir()\n"
+  "  install_dir = '${CMAKE_INSTALL_PREFIX}';\n"
+  "end\n"
+  "\n")
 
 find_program(avl avl PATHS ${CMAKE_INSTALL_DIR}/bin)
 find_program(xfoil xfoil PATHS ${CMAKE_INSTALL_DIR}/bin)

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -344,13 +344,11 @@ endif()
 include(cmake/matlab_pods.cmake)
 pods_configure_matlab_paths()
 
-file(RELATIVE_PATH relpath ${CMAKE_INSTALL_PREFIX}/matlab ${CMAKE_CURRENT_SOURCE_DIR})
-
 message(STATUS "Writing addpath_drake.m and rmpath_drake.m to ${CMAKE_INSTALL_PREFIX}/matlab")
 file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/addpath_drake.m
   "function addpath_drake()\n"
-  "  mfiledir = fileparts(which(mfilename));\n"
-  "  wd = cd(fullfile(mfiledir,'${relpath}'));\n"
+  "  addpath(fullfile('${CMAKE_INSTALL_PREFIX}', 'matlab'));\n"
+  "  wd = cd('${CMAKE_CURRENT_SOURCE_DIR}');\n"
   "  addpath_drake();\n"
   "  cd(wd);\n"
   "end\n"
@@ -358,8 +356,7 @@ file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/addpath_drake.m
 
 file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/rmpath_drake.m
   "function rmpath_drake()\n"
-  "  mfiledir = fileparts(which(mfilename));\n"
-  "  wd = cd(fullfile(mfiledir,'${relpath}'));\n"
+  "  wd = cd('${CMAKE_CURRENT_SOURCE_DIR}');\n"
   "  rmpath_drake();\n"
   "  cd(wd);\n")
 
@@ -393,3 +390,5 @@ endif()
 if(IS_DIRECTORY doc/textbook)
   add_subdirectory(doc/textbook)
 endif()
+
+add_subdirectory(regtests)

--- a/drake/addpath_drake.m
+++ b/drake/addpath_drake.m
@@ -61,7 +61,7 @@ addpath(fullfile(root,'solvers','BMI','util'));
 addpath(fullfile(root,'solvers','BMI','kinematics'));
 addpath(fullfile(root,'solvers','qpSpline'));
 addpath(fullfile(root,'bindings','matlab'));
-bindings_dir = fullfile(root,'pod-build','bindings','matlab');
+bindings_dir = fullfile(get_drake_binary_dir(),'bindings','matlab');
 if exist(bindings_dir, 'dir')
   addpath(bindings_dir);
 end
@@ -88,7 +88,7 @@ if (strcmp(computer('arch'),'maci64'))
 end
 
 if ispc
-  setenv('PATH',[getenv('PATH'),';',GetFullPath(pods_get_lib_path),';',fullfile(root,'pod-build','lib','Release'),';',fullfile(root,'pod-build','lib')]);
+  setenv('PATH',[getenv('PATH'),';',GetFullPath(pods_get_lib_path),';',fullfile(get_drake_install_dir(),'lib','Release')]);
 end
 
 

--- a/drake/regtests/CMakeLists.txt
+++ b/drake/regtests/CMakeLists.txt
@@ -1,0 +1,6 @@
+# This directory contains black-box regression tests that operate on the
+# installed outputs of the Drake build.
+
+if(MATLAB_FOUND)
+  add_matlab_test(NAME addpath_spotless_test COMMAND "addpath_spotless;")
+endif()

--- a/drake/systems/plants/test/testURDFcollisionmex.m
+++ b/drake/systems/plants/test/testURDFcollisionmex.m
@@ -6,7 +6,7 @@ checkDependency('bullet');
   old_ros_package_path = getenv('ROS_PACKAGE_PATH');
   setenv('ROS_PACKAGE_PATH', [old_ros_package_path, ':', ....
                               fullfile(getDrakePath(), 'examples')]);
-  urdf_collision_test = '../../../pod-build/bin/urdfCollisionTest';
+  urdf_collision_test = fullfile(get_drake_binary_dir(), 'bin/urdfCollisionTest');
   if ispc
     urdf_collision_test = [urdf_collision_test,'.exe'];
   end

--- a/drake/systems/plants/test/testURDFmex.m
+++ b/drake/systems/plants/test/testURDFmex.m
@@ -1,7 +1,7 @@
 function testURDFmex(urdfs)
 
-urdf_kin_test = '../../../pod-build/bin/urdfKinTest';
-urdf_manipulator_dynamics_test = '../../../pod-build/bin/urdfManipulatorDynamicsTest';
+urdf_kin_test = fullfile(get_drake_binary_dir(), '/bin/urdfKinTest');
+urdf_manipulator_dynamics_test = fullfile(get_drake_binary_dir(), '/bin/urdfManipulatorDynamicsTest');
 if ispc
   urdf_kin_test = [urdf_kin_test,'.exe'];
   urdf_manipulator_dynamics_test = [urdf_manipulator_dynamics_test,'.exe'];

--- a/drake/util/CMakeLists.txt
+++ b/drake/util/CMakeLists.txt
@@ -128,7 +128,7 @@ if(0)  # NOT WIN32
     "# Usage:\n"
     "#   % drake_debug_mex.sh [args]\n"
     "# will set up the environment and then run:\n"
-    "#   % args pod-build/bin/drake-debug-mex\n"
+    "#   % args drake-debug-mex\n"
     "#\n"
     "# For example,\n"
     "#   % drake_debug_mex.sh\n"

--- a/drake/util/getCMakeParam.m
+++ b/drake/util/getCMakeParam.m
@@ -1,28 +1,16 @@
 function val = getCMakeParam(param)
 % Checks the cmake cache and extracts the stored parameter
 
-cache_file_name = fullfile(getDrakePath,'pod-build','CMakeCache.txt');
-if ~exist(cache_file_name,'file')
-  val = [];  % fail silently
-  return;
+cache_file_name = fullfile(get_drake_binary_dir(),'CMakeCache.txt');
+if ~exist(cache_file_name, 'file')
+  error('Could not find CMakeCache.txt.')
 end
 
-txt = fileread(fullfile(getDrakePath,'pod-build','CMakeCache.txt'));
+txt = fileread(cache_file_name);
 tokens = regexp(txt,[param,':\w+=(.*)'],'tokens','dotexceptnewline');
 if isempty(tokens)
   val = [];
 else
   val = strtrim(tokens{1}{1});
 end
-
-% Note: This was the old way of doing it.  But we found it less robust,
-% because the matlab library path might not even allow one to run cmake.
-
-%[retval,val] = system(['cmake -L -N ',fullfile(getDrakePath,'pod-build'),' | grep ', param,' | cut -d "=" -f2']);
-%if (retval)
-%  val=[];
-%else
-%  val = strtrim(val);
-%end
-
 end


### PR DESCRIPTION
Add search logic to the hand-coded addpath_drake.m for the common out-of-source build cases. This allows addpath_drake to work correctly from the source-tree side.  Update the generated addpath_drake wrapper to use the `CMAKE_INSTALL_PREFIX`.  Add regression test coverage.  Generalize other uses of the build directory throughout the MATLAB code base.

Resolves #2808.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2599)
<!-- Reviewable:end -->
