### PR TITLE
Add eigen_types.h, and use it in RigidBodyTree.cpp.

### DIFF
--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -1,0 +1,41 @@
+/// @file
+/// This file contains abbreviated definitions for certain specializations of
+/// Eigen::Matrix that are commonly used in Drake.
+
+#pragma once
+
+#include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+
+namespace drake {
+
+/// A column vector of size 3, templated on scalar type.
+template <typename Scalar>
+using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
+
+/// A column vector of any size, templated on scalar type.
+template <typename Scalar>
+using VectorX = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
+
+/// A matrix of 3 rows, dynamic columns, templated on scalar type.
+template <typename Scalar>
+using Matrix3X = Eigen::Matrix<Scalar, 3, Eigen::Dynamic>;
+
+/// A matrix of 4 rows, dynamic columns, templated on scalar type.
+template <typename Scalar>
+using Matrix4X = Eigen::Matrix<Scalar, 4, Eigen::Dynamic>;
+
+/// A matrix of dynamic size, templated on scalar type.
+template <typename Scalar>
+using MatrixX = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+
+/// A column vector of dynamic size, up to a maximum of 73 elements.
+using VectorUpTo73d = Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73, 1>;
+
+/// An autodiff variable with a dynamic number of partials, up to 73 maximum.
+using AutoDiffUpTo73d = Eigen::AutoDiffScalar<VectorUpTo73d>;
+
+/// An autodiff variable with a dynamic number of partials.
+using AutoDiffXd = Eigen::AutoDiffScalar<Eigen::VectorXd>;
+
+}  // namespace drake

--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -9,7 +9,6 @@ using systems::OutputPort;
 using systems::StateVector;
 using systems::SystemOutput;
 using systems::VectorInterface;
-using systems::VectorX;
 
 namespace examples {
 

--- a/drake/systems/framework/vector_interface.h
+++ b/drake/systems/framework/vector_interface.h
@@ -2,13 +2,12 @@
 
 #include <cstddef>
 
+#include "drake/common/eigen_types.h"
+
 #include <Eigen/Dense>
 
 namespace drake {
 namespace systems {
-
-template <typename T>
-using VectorX = Eigen::Matrix<T, Eigen::Dynamic, 1 /* column */>;
 
 /// VectorInterface is a pure abstract interface that real-valued signals
 /// between Systems must satisfy. Classes that inherit from VectorInterface

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1,5 +1,6 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 
+#include "drake/common/eigen_types.h"
 #include "drake/systems/plants/joints/DrakeJoint.h"
 #include "drake/systems/plants/joints/FixedJoint.h"
 #include "drake/util/drakeGeometryUtil.h"
@@ -15,6 +16,21 @@
 
 using namespace std;
 using namespace Eigen;
+using drake::AutoDiffUpTo73d;
+using drake::AutoDiffXd;
+using drake::Matrix3X;
+using drake::Matrix4X;
+using drake::MatrixX;
+using drake::Vector3;
+using drake::VectorX;
+
+/// A column vector consisting of one twist.
+template <typename Scalar>
+using TwistVector = Eigen::Matrix<Scalar, TWIST_SIZE, 1>;
+
+/// A matrix with one twist per column, and dynamically many columns.
+template <typename Scalar>
+using TwistMatrix = Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic>;
 
 const set<int> RigidBodyTree::default_robot_num_set = {0};
 const char* const RigidBodyTree::kWorldLinkName = "world";
@@ -1719,8 +1735,8 @@ int RigidBodyTree::FindBodyIndex(const std::string& body_name,
   if (link == nullptr) {
     throw std::logic_error(
         "RigidBodyTree::FindBodyIndex: ERROR: Could not find index for rigid "
-        "body \"" + body_name + "\", model_id = " + std::to_string(model_id) +
-        ".");
+        "body \"" +
+        body_name + "\", model_id = " + std::to_string(model_id) + ".");
   }
   return link->body_index;
 }
@@ -2007,486 +2023,315 @@ int RigidBodyTree::AddFloatingJoint(
   return num_floating_joints_added;
 }
 
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, -1, -1, 0,
-    -1, -1>
-RigidBodyTree::massMatrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, -1, -1, 0,
-    -1, -1>
-RigidBodyTree::massMatrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, -1, 0, -1, -1>
+// Explicit template instantiations for massMatrix.
+template DRAKERBM_EXPORT MatrixX<AutoDiffUpTo73d> RigidBodyTree::massMatrix<
+    AutoDiffUpTo73d>(KinematicsCache<AutoDiffUpTo73d>&) const;
+template DRAKERBM_EXPORT MatrixX<AutoDiffXd>
+RigidBodyTree::massMatrix<AutoDiffXd>(KinematicsCache<AutoDiffXd>&) const;
+template DRAKERBM_EXPORT MatrixXd
 RigidBodyTree::massMatrix<double>(KinematicsCache<double>&) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-                  3, 1, 0, 3, 1>
-    RigidBodyTree::centerOfMass<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>&,
-        set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-                  3, 1, 0, 3, 1>
-    RigidBodyTree::centerOfMass<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>&,
-        set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 3, 1, 0, 3, 1>
-RigidBodyTree::centerOfMass<double>(
+
+// Explicit template instantiations for centerOfMass.
+template DRAKERBM_EXPORT Vector3<AutoDiffUpTo73d> RigidBodyTree::centerOfMass<
+    AutoDiffUpTo73d>(KinematicsCache<AutoDiffUpTo73d>&,
+                     set<int, less<int>, allocator<int>> const&) const;
+template DRAKERBM_EXPORT Vector3<AutoDiffXd> RigidBodyTree::centerOfMass<
+    AutoDiffXd>(KinematicsCache<AutoDiffXd>&,
+                set<int, less<int>, allocator<int>> const&) const;
+template DRAKERBM_EXPORT Vector3d RigidBodyTree::centerOfMass<double>(
     KinematicsCache<double>&, set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-                  -1, 1, 0, -1, 1>
-    RigidBodyTree::dynamicsBiasTerm<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>&,
-        unordered_map<
-            RigidBody const*,
-            Eigen::Matrix<
-                Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-                6, 1, 0, 6, 1>,
-            hash<RigidBody const*>, equal_to<RigidBody const*>,
-            Eigen::aligned_allocator<
-                pair<RigidBody const* const,
-                     Eigen::Matrix<Eigen::AutoDiffScalar<
-                                       Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-                                   6, 1, 0, 6, 1>>>> const&,
-        bool) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-                  -1, 1, 0, -1, 1>
-    RigidBodyTree::dynamicsBiasTerm<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>&,
-        unordered_map<
-            RigidBody const*,
-            Eigen::Matrix<
-                Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-                6, 1, 0, 6, 1>,
-            hash<RigidBody const*>, equal_to<RigidBody const*>,
-            Eigen::aligned_allocator<
-                pair<RigidBody const* const,
-                     Eigen::Matrix<Eigen::AutoDiffScalar<
-                                       Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-                                   6, 1, 0, 6, 1>>>> const&,
-        bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
-RigidBodyTree::dynamicsBiasTerm<double>(
-    KinematicsCache<double>&,
-    unordered_map<RigidBody const*, Eigen::Matrix<double, 6, 1, 0, 6, 1>,
-                  hash<RigidBody const*>, equal_to<RigidBody const*>,
-                  Eigen::aligned_allocator<
-                      pair<RigidBody const* const,
-                           Eigen::Matrix<double, 6, 1, 0, 6, 1>>>> const&,
+
+// Explicit template instantiations for dynamicsBiasTerm.
+template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
+RigidBodyTree::dynamicsBiasTerm<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d>&,
+    unordered_map<
+        RigidBody const*, TwistVector<AutoDiffUpTo73d>, hash<RigidBody const*>,
+        equal_to<RigidBody const*>,
+        Eigen::aligned_allocator<
+            pair<RigidBody const* const, TwistVector<AutoDiffUpTo73d>>>> const&,
     bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, 6, -1, 0, 6,
-    -1>
-RigidBodyTree::geometricJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    int, int, int, bool, vector<int, allocator<int>>*) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, 6, -1, 0, 6,
-    -1>
-RigidBodyTree::geometricJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    int, int, int, bool, vector<int, allocator<int>>*) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 6, -1, 0, 6, -1>
+template DRAKERBM_EXPORT VectorX<AutoDiffXd>
+RigidBodyTree::dynamicsBiasTerm<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd>&,
+    unordered_map<RigidBody const*, TwistVector<AutoDiffXd>,
+                  hash<RigidBody const*>, equal_to<RigidBody const*>,
+                  Eigen::aligned_allocator<pair<
+                      RigidBody const* const, TwistVector<AutoDiffXd>>>> const&,
+    bool) const;
+template DRAKERBM_EXPORT VectorXd RigidBodyTree::dynamicsBiasTerm<double>(
+    KinematicsCache<double>&,
+    unordered_map<RigidBody const*, TwistVector<double>, hash<RigidBody const*>,
+                  equal_to<RigidBody const*>,
+                  Eigen::aligned_allocator<pair<RigidBody const* const,
+                                                TwistVector<double>>>> const&,
+    bool) const;
+
+// Explicit template instantiations for geometricJacobian.
+template DRAKERBM_EXPORT TwistMatrix<AutoDiffUpTo73d>
+RigidBodyTree::geometricJacobian<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d> const&, int, int, int, bool,
+    vector<int, allocator<int>>*) const;
+template DRAKERBM_EXPORT TwistMatrix<AutoDiffXd>
+RigidBodyTree::geometricJacobian<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd> const&, int, int, int, bool,
+    vector<int, allocator<int>>*) const;
+template DRAKERBM_EXPORT TwistMatrix<double>
 RigidBodyTree::geometricJacobian<double>(KinematicsCache<double> const&, int,
                                          int, int, bool,
                                          vector<int, allocator<int>>*) const;
-template DRAKERBM_EXPORT Eigen::Transform<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, 3, 1, 0>
-RigidBodyTree::relativeTransform<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    int, int) const;
-template DRAKERBM_EXPORT Eigen::Transform<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, 3, 1, 0>
-RigidBodyTree::relativeTransform<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    int, int) const;
+
+// Explicit template instantiations for relativeTransform.
+template DRAKERBM_EXPORT Eigen::Transform<AutoDiffUpTo73d, 3, 1, 0>
+RigidBodyTree::relativeTransform<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d> const&, int, int) const;
+template DRAKERBM_EXPORT Eigen::Transform<AutoDiffXd, 3, 1, 0>
+RigidBodyTree::relativeTransform<AutoDiffXd>(KinematicsCache<AutoDiffXd> const&,
+                                             int, int) const;
 template DRAKERBM_EXPORT Eigen::Transform<double, 3, 1, 0>
 RigidBodyTree::relativeTransform<double>(KinematicsCache<double> const&, int,
                                          int) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-                  3, -1, 0, 3, -1>
-    RigidBodyTree::centerOfMassJacobian<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>&,
-        set<int, less<int>, allocator<int>> const&, bool) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-                  3, -1, 0, 3, -1>
-    RigidBodyTree::centerOfMassJacobian<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>&,
-        set<int, less<int>, allocator<int>> const&, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 3, -1, 0, 3, -1>
-RigidBodyTree::centerOfMassJacobian<double>(
+
+// Explicit template instantiations for centerOfMassJacobian.
+template DRAKERBM_EXPORT Matrix3X<AutoDiffUpTo73d>
+RigidBodyTree::centerOfMassJacobian<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d>&,
+    set<int, less<int>, allocator<int>> const&, bool) const;
+template DRAKERBM_EXPORT Matrix3X<AutoDiffXd>
+RigidBodyTree::centerOfMassJacobian<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd>&, set<int, less<int>, allocator<int>> const&,
+    bool) const;
+template DRAKERBM_EXPORT Matrix3Xd RigidBodyTree::centerOfMassJacobian<double>(
     KinematicsCache<double>&, set<int, less<int>, allocator<int>> const&,
     bool) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-                  6, -1, 0, 6, -1>
-    RigidBodyTree::centroidalMomentumMatrix<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>&,
-        set<int, less<int>, allocator<int>> const&, bool) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-                  6, -1, 0, 6, -1>
-    RigidBodyTree::centroidalMomentumMatrix<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>&,
-        set<int, less<int>, allocator<int>> const&, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 6, -1, 0, 6, -1>
+
+// Explicit template instantiations for centroidalMomentumMatrix.
+template DRAKERBM_EXPORT TwistMatrix<AutoDiffUpTo73d>
+RigidBodyTree::centroidalMomentumMatrix<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d>&,
+    set<int, less<int>, allocator<int>> const&, bool) const;
+template DRAKERBM_EXPORT TwistMatrix<AutoDiffXd>
+RigidBodyTree::centroidalMomentumMatrix<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd>&, set<int, less<int>, allocator<int>> const&,
+    bool) const;
+template DRAKERBM_EXPORT TwistMatrix<double>
 RigidBodyTree::centroidalMomentumMatrix<double>(
     KinematicsCache<double>&, set<int, less<int>, allocator<int>> const&,
     bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, -1, -1, 0,
-    -1, -1>
-RigidBodyTree::forwardKinPositionGradient<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    int, int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, -1, -1, 0,
-    -1, -1>
-RigidBodyTree::forwardKinPositionGradient<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    int, int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, -1, 0, -1, -1>
+
+// Explicit template instantiations for forwardKinPositionGradient.
+template DRAKERBM_EXPORT MatrixX<AutoDiffUpTo73d>
+RigidBodyTree::forwardKinPositionGradient<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d> const&, int, int, int) const;
+template DRAKERBM_EXPORT MatrixX<AutoDiffXd>
+RigidBodyTree::forwardKinPositionGradient<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd> const&, int, int, int) const;
+template DRAKERBM_EXPORT MatrixXd
 RigidBodyTree::forwardKinPositionGradient<double>(
     KinematicsCache<double> const&, int, int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, 6, 1, 0, 6,
-    1>
-RigidBodyTree::geometricJacobianDotTimesV<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    int, int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, 6, 1, 0, 6,
-    1>
-RigidBodyTree::geometricJacobianDotTimesV<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    int, int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 6, 1, 0, 6, 1>
+
+// Explicit template instantiations for geometricJacobianDotTimesV.
+template DRAKERBM_EXPORT TwistVector<AutoDiffUpTo73d>
+RigidBodyTree::geometricJacobianDotTimesV<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d> const&, int, int, int) const;
+template DRAKERBM_EXPORT TwistVector<AutoDiffXd>
+RigidBodyTree::geometricJacobianDotTimesV<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd> const&, int, int, int) const;
+template DRAKERBM_EXPORT TwistVector<double>
 RigidBodyTree::geometricJacobianDotTimesV<double>(
     KinematicsCache<double> const&, int, int, int) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-                  3, 1, 0, 3, 1>
-    RigidBodyTree::centerOfMassJacobianDotTimesV<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>&,
-        set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-                  3, 1, 0, 3, 1>
-    RigidBodyTree::centerOfMassJacobianDotTimesV<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>&,
-        set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 3, 1, 0, 3, 1>
+
+// Explicit template instantiations for centerOfMassJacobianDotTimesV.
+template DRAKERBM_EXPORT Vector3<AutoDiffUpTo73d>
+RigidBodyTree::centerOfMassJacobianDotTimesV<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d>&,
+    set<int, less<int>, allocator<int>> const&) const;
+template DRAKERBM_EXPORT Vector3<AutoDiffXd>
+RigidBodyTree::centerOfMassJacobianDotTimesV<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd>&,
+    set<int, less<int>, allocator<int>> const&) const;
+template DRAKERBM_EXPORT Vector3d
 RigidBodyTree::centerOfMassJacobianDotTimesV<double>(
     KinematicsCache<double>&, set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-                  6, 1, 0, 6, 1>
-    RigidBodyTree::centroidalMomentumMatrixDotTimesV<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>&,
-        set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT
-    Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-                  6, 1, 0, 6, 1>
-    RigidBodyTree::centroidalMomentumMatrixDotTimesV<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-        KinematicsCache<
-            Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>&,
-        set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 6, 1, 0, 6, 1>
+
+// Explicit template instantiations for centroidalMomentumMatrixDotTimesV.
+template DRAKERBM_EXPORT TwistVector<AutoDiffUpTo73d>
+RigidBodyTree::centroidalMomentumMatrixDotTimesV<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d>&,
+    set<int, less<int>, allocator<int>> const&) const;
+template DRAKERBM_EXPORT TwistVector<AutoDiffXd>
+RigidBodyTree::centroidalMomentumMatrixDotTimesV<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd>&,
+    set<int, less<int>, allocator<int>> const&) const;
+template DRAKERBM_EXPORT TwistVector<double>
 RigidBodyTree::centroidalMomentumMatrixDotTimesV<double>(
     KinematicsCache<double>&, set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
-RigidBodyTree::positionConstraints<double>(
+template DRAKERBM_EXPORT VectorXd RigidBodyTree::positionConstraints<double>(
     KinematicsCache<double> const&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, -1, 0, -1, -1>
+
+// Explicit template instantiations for positionConstraintsJacobian.
+template DRAKERBM_EXPORT MatrixXd
 RigidBodyTree::positionConstraintsJacobian<double>(
     KinematicsCache<double> const&, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
+
+// Explicit template instantiations for positionConstraintsJacDotTimesV.
+template DRAKERBM_EXPORT VectorXd
 RigidBodyTree::positionConstraintsJacDotTimesV<double>(
     KinematicsCache<double> const&) const;
-template DRAKERBM_EXPORT void
-RigidBodyTree::jointLimitConstraints<Eigen::Matrix<double, -1, 1, 0, -1, 1>,
-                                     Eigen::Matrix<double, -1, 1, 0, -1, 1>,
-                                     Eigen::Matrix<double, -1, -1, 0, -1, -1>>(
-    Eigen::MatrixBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>>&,
-    Eigen::MatrixBase<Eigen::Matrix<double, -1, -1, 0, -1, -1>>&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 6, 1, 0, 6, 1>
+template DRAKERBM_EXPORT void RigidBodyTree::jointLimitConstraints<
+    VectorXd, VectorXd, MatrixXd>(Eigen::MatrixBase<VectorXd> const&,
+                                  Eigen::MatrixBase<VectorXd>&,
+                                  Eigen::MatrixBase<MatrixXd>&) const;
+
+// Explicit template instantiations for relativeTwist.
+template DRAKERBM_EXPORT TwistVector<double>
 RigidBodyTree::relativeTwist<double>(KinematicsCache<double> const&, int, int,
                                      int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 6, -1, 0, 6, -1>
-RigidBodyTree::worldMomentumMatrix<double>(
-    KinematicsCache<double>&, set<int, less<int>, allocator<int>> const&,
-    bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 6, 1, 0, 6, 1>
-RigidBodyTree::transformSpatialAcceleration<double>(
-    KinematicsCache<double> const&, Eigen::Matrix<double, 6, 1, 0, 6, 1> const&,
-    int, int, int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 6, 1, 0, 6, 1>
+
+// Explicit template instantiations for worldMomentumMatrix.
+template DRAKERBM_EXPORT TwistMatrix<double> RigidBodyTree::worldMomentumMatrix<
+    double>(KinematicsCache<double>&,
+            set<int, less<int>, allocator<int>> const&, bool) const;
+
+// Explicit template instantiations for worldMomentumMatrixDotTimesV.
+template DRAKERBM_EXPORT TwistVector<double>
 RigidBodyTree::worldMomentumMatrixDotTimesV<double>(
     KinematicsCache<double>&, set<int, less<int>, allocator<int>> const&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
-RigidBodyTree::inverseDynamics<double>(
+
+// Explicit template instantiations for transformSpatialAcceleration.
+template DRAKERBM_EXPORT TwistVector<double>
+RigidBodyTree::transformSpatialAcceleration<double>(
+    KinematicsCache<double> const&, TwistVector<double> const&, int, int, int,
+    int) const;
+
+// Explicit template instantiations for inverseDynamics.
+template DRAKERBM_EXPORT VectorXd RigidBodyTree::inverseDynamics<double>(
     KinematicsCache<double>&,
-    unordered_map<RigidBody const*, Eigen::Matrix<double, 6, 1, 0, 6, 1>,
-                  hash<RigidBody const*>, equal_to<RigidBody const*>,
-                  Eigen::aligned_allocator<
-                      pair<RigidBody const* const,
-                           Eigen::Matrix<double, 6, 1, 0, 6, 1>>>> const&,
-    Eigen::Matrix<double, -1, 1, 0, -1, 1> const&, bool) const;
+    unordered_map<RigidBody const*, TwistVector<double>, hash<RigidBody const*>,
+                  equal_to<RigidBody const*>,
+                  Eigen::aligned_allocator<pair<RigidBody const* const,
+                                                TwistVector<double>>>> const&,
+    VectorXd const&, bool) const;
+
+// Explicit template instantiations for jointLimitConstraints.
 template DRAKERBM_EXPORT void RigidBodyTree::jointLimitConstraints<
-    Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0>>,
-    Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0>>,
-    Eigen::Map<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0,
-               Eigen::Stride<0, 0>>>(
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0,
-                                 Eigen::Stride<0, 0>>> const&,
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0,
-                                 Eigen::Stride<0, 0>>>&,
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0,
-                                 Eigen::Stride<0, 0>>>&) const;
-template DRAKERBM_EXPORT pair<Eigen::Matrix<double, 3, 1, 0, 3, 1>, double>
-RigidBodyTree::resolveCenterOfPressure<Eigen::Matrix<double, 3, 1, 0, 3, 1>,
-                                       Eigen::Matrix<double, 3, 1, 0, 3, 1>>(
+    Eigen::Map<VectorXd>, Eigen::Map<VectorXd>, Eigen::Map<MatrixXd>>(
+    Eigen::MatrixBase<Eigen::Map<VectorXd>> const&,
+    Eigen::MatrixBase<Eigen::Map<VectorXd>>&,
+    Eigen::MatrixBase<Eigen::Map<MatrixXd>>&) const;
+
+// Explicit template instantiations for resolveCenterOfPressure.
+template DRAKERBM_EXPORT pair<Vector3d, double>
+RigidBodyTree::resolveCenterOfPressure<Vector3d, Vector3d>(
     KinematicsCache<double> const&,
     vector<ForceTorqueMeasurement, allocator<ForceTorqueMeasurement>> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>> const&) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, -1, -1, 0,
-    -1, -1>
-RigidBodyTree::transformPointsJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-    Eigen::Matrix<double, 3, -1, 0, 3, -1>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, 3, -1, 0, 3, -1>> const&, int, int,
-    bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, -1, -1, 0,
-    -1, -1>
-RigidBodyTree::transformPointsJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-    Eigen::Matrix<double, 3, -1, 0, 3, -1>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, 3, -1, 0, 3, -1>> const&, int, int,
-    bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, -1, 0, -1, -1>
-RigidBodyTree::transformPointsJacobian<double,
-                                       Eigen::Matrix<double, 3, -1, 0, 3, -1>>(
+    Eigen::MatrixBase<Vector3d> const&,
+    Eigen::MatrixBase<Vector3d> const&) const;
+
+// Explicit template instantiations for transformPointsJacobian.
+template DRAKERBM_EXPORT MatrixX<AutoDiffUpTo73d>
+RigidBodyTree::transformPointsJacobian<AutoDiffUpTo73d, Matrix3Xd>(
+    KinematicsCache<AutoDiffUpTo73d> const&,
+    Eigen::MatrixBase<Matrix3Xd> const&, int, int, bool) const;
+template DRAKERBM_EXPORT MatrixX<AutoDiffXd>
+RigidBodyTree::transformPointsJacobian<AutoDiffXd, Matrix3Xd>(
+    KinematicsCache<AutoDiffXd> const&, Eigen::MatrixBase<Matrix3Xd> const&,
+    int, int, bool) const;
+template DRAKERBM_EXPORT MatrixXd
+RigidBodyTree::transformPointsJacobian<double, Matrix3Xd>(
+    KinematicsCache<double> const&, Eigen::MatrixBase<Matrix3Xd> const&, int,
+    int, bool) const;
+template DRAKERBM_EXPORT MatrixXd
+RigidBodyTree::transformPointsJacobian<double, Vector3d>(
+    KinematicsCache<double> const&, Eigen::MatrixBase<Vector3d> const&, int,
+    int, bool) const;
+template DRAKERBM_EXPORT MatrixXd RigidBodyTree::transformPointsJacobian<
+    double, Eigen::Block<Matrix3Xd, 3, 1, true>>(
     KinematicsCache<double> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, 3, -1, 0, 3, -1>> const&, int, int,
+    Eigen::MatrixBase<Eigen::Block<Matrix3Xd, 3, 1, true>> const&, int, int,
     bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
-RigidBodyTree::transformPointsJacobianDotTimesV<
-    double, Eigen::Matrix<double, 3, -1, 0, 3, -1>>(
+template DRAKERBM_EXPORT MatrixX<AutoDiffUpTo73d>
+RigidBodyTree::transformPointsJacobian<AutoDiffUpTo73d,
+                                       Eigen::Map<Matrix3Xd const>>(
+    KinematicsCache<AutoDiffUpTo73d> const&,
+    Eigen::MatrixBase<Eigen::Map<Matrix3Xd const>> const&, int, int,
+    bool) const;
+template DRAKERBM_EXPORT MatrixX<AutoDiffXd>
+RigidBodyTree::transformPointsJacobian<AutoDiffXd, Eigen::Map<Matrix3Xd const>>(
+    KinematicsCache<AutoDiffXd> const&,
+    Eigen::MatrixBase<Eigen::Map<Matrix3Xd const>> const&, int, int,
+    bool) const;
+template DRAKERBM_EXPORT MatrixXd
+RigidBodyTree::transformPointsJacobian<double, Eigen::Map<Matrix3Xd const>>(
     KinematicsCache<double> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, 3, -1, 0, 3, -1>> const&, int,
+    Eigen::MatrixBase<Eigen::Map<Matrix3Xd const>> const&, int, int,
+    bool) const;
+
+// Explicit template instantiations for transformPointsJacobianDotTimesV.
+template DRAKERBM_EXPORT VectorXd
+RigidBodyTree::transformPointsJacobianDotTimesV<double, Matrix3Xd>(
+    KinematicsCache<double> const&, Eigen::MatrixBase<Matrix3Xd> const&, int,
     int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 4, -1, 0, 4, -1>
+template DRAKERBM_EXPORT VectorXd
+RigidBodyTree::transformPointsJacobianDotTimesV<double, Vector3d>(
+    KinematicsCache<double> const&, Eigen::MatrixBase<Vector3d> const&, int,
+    int) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
+RigidBodyTree::transformPointsJacobianDotTimesV<AutoDiffUpTo73d,
+                                                Eigen::Map<Matrix3Xd const>>(
+    KinematicsCache<AutoDiffUpTo73d> const&,
+    Eigen::MatrixBase<Eigen::Map<Matrix3Xd const>> const&, int, int) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffXd>
+RigidBodyTree::transformPointsJacobianDotTimesV<AutoDiffXd,
+                                                Eigen::Map<Matrix3Xd const>>(
+    KinematicsCache<AutoDiffXd> const&,
+    Eigen::MatrixBase<Eigen::Map<Matrix3Xd const>> const&, int, int) const;
+template DRAKERBM_EXPORT VectorXd
+RigidBodyTree::transformPointsJacobianDotTimesV<double,
+                                                Eigen::Map<Matrix3Xd const>>(
+    KinematicsCache<double> const&,
+    Eigen::MatrixBase<Eigen::Map<Matrix3Xd const>> const&, int, int) const;
+
+// Explicit template instantiations for relativeQuaternionJacobian.
+template DRAKERBM_EXPORT Matrix4Xd
 RigidBodyTree::relativeQuaternionJacobian<double>(
     KinematicsCache<double> const&, int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, 3, -1, 0, 3, -1>
+template DRAKERBM_EXPORT Matrix4X<AutoDiffUpTo73d>
+RigidBodyTree::relativeQuaternionJacobian<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d> const&, int, int, bool) const;
+template DRAKERBM_EXPORT Matrix4X<AutoDiffXd>
+RigidBodyTree::relativeQuaternionJacobian<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd> const&, int, int, bool) const;
+
+// Explicit template instantiations for relativeRollPitchYawJacobian.
+template DRAKERBM_EXPORT Matrix3Xd
 RigidBodyTree::relativeRollPitchYawJacobian<double>(
     KinematicsCache<double> const&, int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
-RigidBodyTree::relativeQuaternionJacobianDotTimesV<double>(
-    KinematicsCache<double> const&, int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
+template DRAKERBM_EXPORT Matrix3X<AutoDiffUpTo73d>
+RigidBodyTree::relativeRollPitchYawJacobian<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d> const&, int, int, bool) const;
+template DRAKERBM_EXPORT Matrix3X<AutoDiffXd>
+RigidBodyTree::relativeRollPitchYawJacobian<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd> const&, int, int, bool) const;
+
+// Explicit template instantiations for relativeRollPitchYawJacobianDotTimesV.
+template DRAKERBM_EXPORT VectorXd
 RigidBodyTree::relativeRollPitchYawJacobianDotTimesV<double>(
     KinematicsCache<double> const&, int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, -1, 0, -1, -1>
-RigidBodyTree::transformPointsJacobian<double,
-                                       Eigen::Matrix<double, 3, 1, 0, 3, 1>>(
-    KinematicsCache<double> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>> const&, int, int,
-    bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
-RigidBodyTree::transformPointsJacobianDotTimesV<
-    double, Eigen::Matrix<double, 3, 1, 0, 3, 1>>(
-    KinematicsCache<double> const&,
-    Eigen::MatrixBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>> const&, int,
-    int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, -1, 0, -1, -1>
-RigidBodyTree::transformPointsJacobian<
-    double, Eigen::Block<Eigen::Matrix<double, 3, -1, 0, 3, -1>, 3, 1, true>>(
-    KinematicsCache<double> const&,
-    Eigen::MatrixBase<Eigen::Block<Eigen::Matrix<double, 3, -1, 0, 3, -1>, 3, 1,
-                                   true>> const&,
-    int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, -1, 1, 0, -1,
-    1>
-RigidBodyTree::relativeRollPitchYawJacobianDotTimesV<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, -1, -1, 0,
-    -1, -1>
-RigidBodyTree::transformPointsJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-    Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const, 0,
-               Eigen::Stride<0, 0>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const,
-                                 0, Eigen::Stride<0, 0>>> const&,
-    int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, -1, -1, 0,
-    -1, -1>
-RigidBodyTree::transformPointsJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-    Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const, 0,
-               Eigen::Stride<0, 0>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const,
-                                 0, Eigen::Stride<0, 0>>> const&,
-    int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, -1, 0, -1, -1>
-RigidBodyTree::transformPointsJacobian<
-    double, Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const, 0,
-                       Eigen::Stride<0, 0>>>(
-    KinematicsCache<double> const&,
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const,
-                                 0, Eigen::Stride<0, 0>>> const&,
-    int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, 4, -1, 0, 4,
-    -1>
-RigidBodyTree::relativeQuaternionJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, 4, -1, 0, 4,
-    -1>
-RigidBodyTree::relativeQuaternionJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, 3, -1, 0, 3,
-    -1>
-RigidBodyTree::relativeRollPitchYawJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, 3, -1, 0, 3,
-    -1>
-RigidBodyTree::relativeRollPitchYawJacobian<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    int, int, bool) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, -1, 1, 0, -1,
-    1>
-RigidBodyTree::transformPointsJacobianDotTimesV<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>,
-    Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const, 0,
-               Eigen::Stride<0, 0>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const,
-                                 0, Eigen::Stride<0, 0>>> const&,
-    int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, -1, 1, 0, -1,
-    1>
-RigidBodyTree::transformPointsJacobianDotTimesV<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>,
-    Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const, 0,
-               Eigen::Stride<0, 0>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const,
-                                 0, Eigen::Stride<0, 0>>> const&,
-    int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<double, -1, 1, 0, -1, 1>
-RigidBodyTree::transformPointsJacobianDotTimesV<
-    double, Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const, 0,
-                       Eigen::Stride<0, 0>>>(
-    KinematicsCache<double> const&,
-    Eigen::MatrixBase<Eigen::Map<Eigen::Matrix<double, 3, -1, 0, 3, -1> const,
-                                 0, Eigen::Stride<0, 0>>> const&,
-    int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, -1, 1, 0, -1,
-    1>
-RigidBodyTree::relativeQuaternionJacobianDotTimesV<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>, -1, 1, 0, -1,
-    1>
-RigidBodyTree::relativeQuaternionJacobianDotTimesV<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, -1, 1>>> const&,
-    int, int) const;
-template DRAKERBM_EXPORT Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>, -1, 1, 0, -1,
-    1>
-RigidBodyTree::relativeRollPitchYawJacobianDotTimesV<
-    Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>>(
-    KinematicsCache<
-        Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1, 0, 73, 1>>> const&,
-    int, int) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffXd>
+RigidBodyTree::relativeRollPitchYawJacobianDotTimesV<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd> const&, int, int) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
+RigidBodyTree::relativeRollPitchYawJacobianDotTimesV<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d> const&, int, int) const;
+
+// Explicit template instantiations for relativeQuaternionJacobianDotTimesV.
+template DRAKERBM_EXPORT VectorXd
+RigidBodyTree::relativeQuaternionJacobianDotTimesV<double>(
+    KinematicsCache<double> const&, int, int) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
+RigidBodyTree::relativeQuaternionJacobianDotTimesV<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d> const&, int, int) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffXd>
+RigidBodyTree::relativeQuaternionJacobianDotTimesV<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd> const&, int, int) const;


### PR DESCRIPTION
Makes forward declarations more concise.   Borrowed from @mwoehlke-kitware on #2074 

+@jwnimmer-tri for feature and platform review per offline conversation.  These changes are not so amenable to human review, but I claim that if this PR introduced any bugs, they would show up as compiler errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2601)
<!-- Reviewable:end -->
