### PR TITLE
Cleans up contact force computation.

### DIFF
--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -177,6 +177,9 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
         // Tangential velocity in world's frame.
         Vector3d urt_world = ur_world - urn * normal;
 
+        // Magnitude of the tangential contribution to the relative velocity.
+        double urt_norm = urt_world.norm();
+
         // Normal component magnitude of the collision force acting
         // on body A.
         double fAn = std::max<double>(
@@ -190,12 +193,12 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
         // on body A.
         // Notice that since fAn > 0 always, then fAn_world.norm() = fAn.
         double fAt = -std::min<double>(
-            penetration_damping * urt_world.norm(),
+            penetration_damping * urt_norm,
             friction_coefficient * fAn);
 
         // Tangential contribution to the contact force on body A in
         // world's frame.
-        Vector3d fAt_world = fAt * urt_world / (urt_world.norm() + EPSILON);
+        Vector3d fAt_world = fAt * urt_world / (urt_norm + EPSILON);
 
         // Total contact force on body A in world's frame.
         Vector3d fA_world = fAn_world + fAt_world;


### PR DESCRIPTION
The contact forces computation as implemented right now makes an [arbitrary choice for the tangential vectors](https://github.com/RobotLocomotion/drake/blob/master/drake/systems/plants/RigidBodySystem.cpp#L172) on the contact region. 
Physically, the contact force will be independent of the reference frame used to compute it.
Numerically, such a formulation could potentially introduce nonphysical asymmetries.

This PR introduces an updated way to compute contact forces that does not need the selection of an arbitrary frame at all, therefore removing the need to compute the transformation matrix from "world" to "surface" coordinates (`R` in the previous version).

The resulting formulation is cleaner, easier to understand and follow and potentially reduces the amount of computation (I didn't verify this).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2609)
<!-- Reviewable:end -->
