### PR TITLE
Added info to set the F77 environment variable

### DIFF
--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -109,16 +109,16 @@ Compiler Environment Variables
 If the system's default compiler is not being used (for example if
 gcc/g++/gfortran 4.9 are being used on Ubuntu 14.04 LTS), the desired compiler
 must be manually specified. One way to do this is to set the ``CC``, ``CXX``,
-and ``FC`` environment variables. This can be done by executing the command
+``FC``, and ``F77`` environment variables. This can be done by executing the command
 below. To avoid needing to run this command each time a new terminal is opened,
 the command below can also be added to the ``~/.bashrc`` file::
 
-    export CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9
+    export CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9 F77=gfortran-4.9
 
 Alternatively, every call to ``make`` or ``cmake`` can be preceded with
 environment variable settings that specify the correct compiler::
 
-    env CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9 make ...
+    env CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9 F77=gfortran-4.9 make ...
 
 CMake Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Needed so Blas/lapack from IPOPT/ThirdParty can find the fortran compiler.

Following build instructions without setting ``F77`` would result in a build error, since Blas looks for a ``gfortran`` binary, which would not exist from installing the instructed packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2617)
<!-- Reviewable:end -->
