### PR TITLE
Remove and prevent spurious return type qualifiers

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -89,7 +89,7 @@ include_directories(BEFORE ${PROJECT_BINARY_DIR}/exports/)
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/..)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all -Werror=ignored-qualifiers")
 
   # TODO(#2372) These are warnings that we can't handle yet.
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -30,7 +30,7 @@ const std::string& RigidBody::name() const { return name_; }
 
 const std::string& RigidBody::model_name() const { return model_name_; }
 
-const int RigidBody::get_model_id() const { return robotnum; }
+int RigidBody::get_model_id() const { return robotnum; }
 
 void RigidBody::set_model_id(int model_id) { robotnum = model_id; }
 

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -42,7 +42,7 @@ class DRAKERBM_EXPORT RigidBody {
   /**
    * Returns the ID of the model to which this rigid body belongs.
    */
-  const int get_model_id() const;
+  int get_model_id() const;
 
   /**
    * Sets the ID of the model to which this rigid body belongs.


### PR DESCRIPTION
Remove `const` qualifiers from the scalar (`int`) return type of RigidBody::get_model_id. Such qualifiers have no effect and are ignored by the compiler but can be misleading to users of the API. Turn on `-Werror=ignored-qualifiers` to prevent any such occurrences from being re-added.

Assigning initially to @liangfok who introduced this, but feel free to assign to someone else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2618)
<!-- Reviewable:end -->
