### PR TITLE
Fix sign-mismatch in test expects

### DIFF
--- a/drake/core/test/functional_form_test.cc
+++ b/drake/core/test/functional_form_test.cc
@@ -18,7 +18,7 @@ GTEST_TEST(FunctionalFormVariableTest, NilVariant) {
   using Variable = FunctionalForm::Variable;
   Variable const v_nil;
   EXPECT_TRUE(v_nil.is_nil());
-  EXPECT_NE(v_nil.index(), 0);
+  EXPECT_NE(v_nil.index(), 0u);
 
   // copy ctor
   Variable v(v_nil);
@@ -99,7 +99,7 @@ GTEST_TEST(FunctionalFormVariableTest, IndexVariant) {
   // move assign from conversion temporary
   v = 123;
   EXPECT_TRUE(v.is_index());
-  EXPECT_EQ(v.index(), 123);
+  EXPECT_EQ(v.index(), 123u);
 
   // comparison
   EXPECT_TRUE(v_index == v_index);
@@ -197,7 +197,7 @@ GTEST_TEST(FunctionalFormVariablesTest, Basic) {
 
   FunctionalForm::Variables a({"a1", "a2", 3});
   {
-    ASSERT_EQ(a.size(), 3);
+    ASSERT_EQ(a.size(), 3u);
     FunctionalForm::Variables::const_iterator i = a.begin();
     EXPECT_EQ(*i, FunctionalForm::Variable(3));
     ++i;
@@ -210,7 +210,7 @@ GTEST_TEST(FunctionalFormVariablesTest, Basic) {
 
   FunctionalForm::Variables b({"b1", "b2", 3});
   {
-    ASSERT_EQ(b.size(), 3);
+    ASSERT_EQ(b.size(), 3u);
     FunctionalForm::Variables::const_iterator i = b.begin();
     EXPECT_EQ(*i, FunctionalForm::Variable(3));
     ++i;
@@ -225,7 +225,7 @@ GTEST_TEST(FunctionalFormVariablesTest, Basic) {
 
   FunctionalForm::Variables u = FunctionalForm::Variables::Union(a, b);
   {
-    ASSERT_EQ(u.size(), 5);
+    ASSERT_EQ(u.size(), 5u);
     FunctionalForm::Variables::const_iterator i = u.begin();
     EXPECT_EQ(*i, FunctionalForm::Variable(3));
     ++i;

--- a/drake/core/test/vector_test.cc
+++ b/drake/core/test/vector_test.cc
@@ -29,7 +29,7 @@ GTEST_TEST(VectorTest, ValueAssignment) {
   state.theta = 0.2;
   state.thetadot = 0.3;
 
-  EXPECT_EQ(size(state), 2);
+  EXPECT_EQ(size(state), 2u);
 
   state = x;
   EXPECT_EQ(state.theta, 0.2);


### PR DESCRIPTION
Fix some signed/unsigned mismatches in tests comparing actual to expected values. These are genuine errors, but for some unclear reason, they are tripping in another branch of mine but not in current master (as of this commit).

This blocks #2582 (see e.g. https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=39894).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2632)
<!-- Reviewable:end -->
