### PR TITLE
Start extracting the massive template libraries in drake/util into smaller drake/math libraries.

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -318,6 +318,7 @@ include_directories(thirdParty/spruce/include)
 include_directories(thirdParty/cimg)
 
 add_subdirectory(common)
+add_subdirectory(math)
 add_subdirectory(core)
 add_subdirectory(util)
 add_subdirectory(solvers)

--- a/drake/core/Gradient.h
+++ b/drake/core/Gradient.h
@@ -1,3 +1,7 @@
+/// @file
+/// THIS FILE IS DEPRECATED.
+/// Its contents are moving into drake/math.
+
 #pragma once
 
 #include <Eigen/Core>
@@ -5,7 +9,6 @@
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/drake_assert.h"
-#include "drake/util/drakeGradientUtil.h"  // todo: pull the core tools into this file and zap the old gradient util.
 
 namespace Drake {
 // todo: recursive template to get arbitrary gradient order

--- a/drake/examples/Quadrotor/Quadrotor.h
+++ b/drake/examples/Quadrotor/Quadrotor.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
+
+#include "drake/math/gradient.h"
 #include "drake/systems/System.h"
 #include "drake/util/drakeGeometryUtil.h"
 
@@ -181,9 +183,9 @@ class Quadrotor {
     Eigen::Matrix<Scalar, 3, 1> pqr_dot =
         I.ldlt().solve(pqr_dot_term1 - pqr.cross(I * pqr));
     Eigen::Matrix<Scalar, 3, 3> Phi;
-    typename Gradient<Eigen::Matrix<Scalar, 3, 3>, 3>::type dPhi;
-    auto ddPhi =
-        (typename Gradient<Eigen::Matrix<Scalar, 3, 3>, 3, 2>::type*)nullptr;
+    typename drake::math::Gradient<Eigen::Matrix<Scalar, 3, 3>, 3>::type dPhi;
+    typename drake::math::Gradient<Eigen::Matrix<Scalar, 3, 3>, 3, 2>::type*
+        ddPhi = nullptr;
     angularvel2rpydotMatrix(rpy, Phi, &dPhi, ddPhi);
 
     Eigen::Matrix<Scalar, 9, 3> drpy2drotmat = drpy2rotmat(rpy);

--- a/drake/math/CMakeLists.txt
+++ b/drake/math/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Source files used to build drakeMath.
+set(sources
+  autodiff.cc
+  expmap.cc
+  gradient.cc)
+
+# Headers that should be installed with Drake so that they
+# are available elsewhere via #include.
+set(installed_headers
+  autodiff.h
+  expmap.h
+  gradient.h)
+
+# Headers that are needed by code here but should not
+# be exposed anywhere else.
+set(private_headers)
+
+add_library_with_exports(LIB_NAME drakeMath
+  SOURCE_FILES ${sources} ${installed_headers} ${private_headers})
+target_link_libraries(drakeMath drakeCommon)
+
+drake_install_headers(${installed_headers})
+
+pods_install_libraries(drakeMath)
+pods_install_pkg_config_file(drake-math
+  LIBS -ldrakeMath -ldrakeCommon
+  REQUIRES
+  VERSION 0.0.1)
+
+add_subdirectory(test)

--- a/drake/math/autodiff.cc
+++ b/drake/math/autodiff.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// autodiff.h is a stand-alone header.
+
+#include "drake/math/autodiff.h"

--- a/drake/math/autodiff.h
+++ b/drake/math/autodiff.h
@@ -1,0 +1,99 @@
+/// @file
+/// Utilities for arithmetic on AutoDiffScalar.
+
+#pragma once
+
+#include <cmath>
+
+#include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+
+#include "drake/math/gradient.h"
+
+/// Overloads round to mimic std::round from <cmath>.
+/// Must appear in global namespace so that ADL can select between this
+/// implementation and the STL one.
+template <typename DerType>
+double round(const Eigen::AutoDiffScalar<DerType>& x) {
+  return round(x.value());
+}
+
+/// Overloads floor to mimic std::floor from <cmath>.
+/// Must appear in global namespace so that ADL can select between this
+/// implementation and the STL one.
+template <typename DerType>
+double floor(const Eigen::AutoDiffScalar<DerType>& x) {
+  return floor(x.value());
+}
+
+namespace drake {
+namespace math {
+
+template <typename Derived>
+struct AutoDiffToValueMatrix {
+  typedef typename Eigen::Matrix<typename Derived::Scalar::Scalar,
+                                 Derived::RowsAtCompileTime,
+                                 Derived::ColsAtCompileTime> type;
+};
+
+template <typename Derived>
+typename AutoDiffToValueMatrix<Derived>::type autoDiffToValueMatrix(
+    const Eigen::MatrixBase<Derived>& auto_diff_matrix) {
+  typename AutoDiffToValueMatrix<Derived>::type ret(auto_diff_matrix.rows(),
+                                                    auto_diff_matrix.cols());
+  for (int i = 0; i < auto_diff_matrix.rows(); i++) {
+    for (int j = 0; j < auto_diff_matrix.cols(); ++j) {
+      ret(i, j) = auto_diff_matrix(i, j).value();
+    }
+  }
+  return ret;
+}
+
+template <typename Derived>
+struct AutoDiffToGradientMatrix {
+  typedef typename Gradient<
+      Eigen::Matrix<typename Derived::Scalar::Scalar,
+                    Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>,
+      Eigen::Dynamic>::type type;
+};
+
+template <typename Derived>
+typename AutoDiffToGradientMatrix<Derived>::type autoDiffToGradientMatrix(
+    const Eigen::MatrixBase<Derived>& auto_diff_matrix,
+    int num_variables = Eigen::Dynamic) {
+  int num_variables_from_matrix = 0;
+  for (int i = 0; i < auto_diff_matrix.size(); ++i) {
+    num_variables_from_matrix =
+        std::max(num_variables_from_matrix,
+                 static_cast<int>(auto_diff_matrix(i).derivatives().size()));
+  }
+  if (num_variables == Eigen::Dynamic) {
+    num_variables = num_variables_from_matrix;
+  } else if (num_variables_from_matrix != 0 &&
+             num_variables_from_matrix != num_variables) {
+    std::stringstream buf;
+    buf << "Input matrix has derivatives w.r.t " << num_variables_from_matrix
+        << " variables, whereas num_variables is " << num_variables << ".\n";
+    buf << "Either num_variables_from_matrix should be zero, or it should "
+           "match num_variables.";
+    throw std::runtime_error(buf.str());
+  }
+
+  typename AutoDiffToGradientMatrix<Derived>::type gradient(
+      auto_diff_matrix.size(), num_variables);
+  for (int row = 0; row < auto_diff_matrix.rows(); row++) {
+    for (int col = 0; col < auto_diff_matrix.cols(); col++) {
+      auto gradient_row =
+          gradient.row(row + col * auto_diff_matrix.rows()).transpose();
+      if (auto_diff_matrix(row, col).derivatives().size() == 0) {
+        gradient_row.setZero();
+      } else {
+        gradient_row = auto_diff_matrix(row, col).derivatives();
+      }
+    }
+  }
+  return gradient;
+}
+
+}  // namespace math
+}  // namespace drake

--- a/drake/math/expmap.cc
+++ b/drake/math/expmap.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// expmap.h is a stand-alone header.
+
+#include "drake/math/expmap.h"

--- a/drake/math/expmap.h
+++ b/drake/math/expmap.h
@@ -1,0 +1,172 @@
+/// @file
+/// Utilities for arithmetic on exponential maps.
+
+#pragma once
+
+#include <cmath>
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_assert.h"
+#include "drake/math/autodiff.h"
+
+namespace drake {
+namespace math {
+
+namespace internal {
+template <typename Derived>
+Eigen::Matrix<typename Derived::Scalar, 4, 1> expmap2quatNonDegenerate(
+    const Eigen::MatrixBase<Derived>& v,
+    typename Derived::Scalar& theta_squared) {
+  using namespace std;
+  typedef typename Derived::Scalar Scalar;
+  static_assert(
+      Derived::RowsAtCompileTime == 3 && Derived::ColsAtCompileTime == 1,
+      "Wrong size.");
+
+  Eigen::Matrix<Scalar, 4, 1> q;
+
+  Scalar theta = sqrt(theta_squared);
+  Scalar arg = theta / Scalar(2);
+  q(0) = cos(arg);
+  q.template bottomRows<3>() = v;
+  q.template bottomRows<3>() *= sin(arg) / theta;
+
+  return q;
+}
+
+template <typename Derived>
+Eigen::Matrix<typename Derived::Scalar, 4, 1> expmap2quatDegenerate(
+    const Eigen::MatrixBase<Derived>& v,
+    typename Derived::Scalar& theta_squared) {
+  typedef typename Derived::Scalar Scalar;
+  static_assert(
+      Derived::RowsAtCompileTime == 3 && Derived::ColsAtCompileTime == 1,
+      "Wrong size.");
+
+  Eigen::Matrix<Scalar, 4, 1> q;
+
+  q(0) = -theta_squared / 8.0 + 1.0;
+  q.template bottomRows<3>() = v;
+  q.template bottomRows<3>() *=
+      (theta_squared * 8.0E1 - 1.92E3) * (-2.604166666666667E-4);
+
+  return q;
+}
+}  // namespace internal
+
+template <typename Derived>
+Eigen::Matrix<typename Derived::Scalar, 4, 1> expmap2quat(
+    const Eigen::MatrixBase<Derived>& v) {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 3);
+  typedef typename Derived::Scalar Scalar;
+  Scalar theta_squared = v.squaredNorm();
+  if (theta_squared < pow(Eigen::NumTraits<Scalar>::epsilon(), 0.5)) {
+    return internal::expmap2quatDegenerate(v, theta_squared);
+  } else {
+    return internal::expmap2quatNonDegenerate(v, theta_squared);
+  }
+}
+
+template <typename DerivedQ>
+Eigen::Matrix<typename DerivedQ::Scalar, 3, 1> quat2expmap(
+    const Eigen::MatrixBase<DerivedQ>& q) {
+  typedef typename DerivedQ::Scalar Scalar;
+  static_assert(
+      DerivedQ::RowsAtCompileTime == 4 && DerivedQ::ColsAtCompileTime == 1,
+      "Wrong size.");
+
+  Scalar t = sqrt(Scalar(1) - q(0) * q(0));
+  bool is_degenerate = (t * t < Eigen::NumTraits<Scalar>::epsilon());
+  Scalar s(2);
+  if (!is_degenerate) s *= acos(q(0)) / t;
+  return s * q.template tail<3>();
+}
+
+template <typename Derived1, typename Derived2>
+Eigen::Matrix<typename Derived1::Scalar, 3, 1> closestExpmap(
+    const Eigen::MatrixBase<Derived1>& expmap1,
+    const Eigen::MatrixBase<Derived2>& expmap2) {
+  using namespace std;  // required for ADL of floor() and round().
+  static_assert(
+      Derived1::RowsAtCompileTime == 3 && Derived1::ColsAtCompileTime == 1,
+      "Wrong size.");
+  static_assert(
+      Derived2::RowsAtCompileTime == 3 && Derived2::ColsAtCompileTime == 1,
+      "Wrong size.");
+  static_assert(
+      std::is_same<typename Derived1::Scalar, typename Derived2::Scalar>::value,
+      "Scalar types don't match.");
+  typedef typename Derived1::Scalar Scalar;
+  typedef typename Eigen::NumTraits<Scalar>::Real Real;
+
+  Real expmap1_norm = expmap1.norm();
+  Real expmap2_norm = expmap2.norm();
+  Eigen::Matrix<Scalar, 3, 1> ret;
+  if (expmap2_norm < Eigen::NumTraits<Scalar>::epsilon()) {
+    if (expmap1_norm > Eigen::NumTraits<Scalar>::epsilon()) {
+      auto expmap1_axis = (expmap1 / expmap1_norm).eval();
+      auto expmap1_round = round(expmap1_norm / (2 * M_PI));
+      return expmap1_axis * expmap1_round * 2 * M_PI;
+    } else {
+      return expmap2;
+    }
+  } else {
+    auto expmap2_axis = (expmap2 / expmap2_norm).eval();
+    auto expmap2_closest_k =
+        ((expmap2_axis.transpose() * expmap1).value() - expmap2_norm) /
+        (2 * M_PI);
+    auto expmap2_closest_k1 = floor(expmap2_closest_k);
+    auto expmap2_closest_k2 = expmap2_closest_k1 + 1.0;
+    auto expmap2_closest1 =
+        (expmap2 + 2 * expmap2_closest_k1 * M_PI * expmap2_axis).eval();
+    auto expmap2_closest2 =
+        (expmap2 + 2 * expmap2_closest_k2 * M_PI * expmap2_axis).eval();
+    if ((expmap2_closest1 - expmap1).norm() <
+        (expmap2_closest2 - expmap1).norm()) {
+      return expmap2_closest1;
+    } else {
+      return expmap2_closest2;
+    }
+  }
+}
+
+template <typename DerivedQ, typename DerivedE>
+void quat2expmapSequence(const Eigen::MatrixBase<DerivedQ>& quat,
+                         const Eigen::MatrixBase<DerivedQ>& quat_dot,
+                         Eigen::MatrixBase<DerivedE>& expmap,
+                         Eigen::MatrixBase<DerivedE>& expmap_dot) {
+  static_assert(DerivedQ::RowsAtCompileTime == 4, "Wrong size.");
+  static_assert(DerivedE::RowsAtCompileTime == 3, "Wrong size.");
+  static_assert(
+      std::is_same<typename DerivedQ::Scalar, typename DerivedE::Scalar>::value,
+      "Scalar types don't match.");
+  typedef typename DerivedQ::Scalar Scalar;
+
+  DRAKE_ASSERT(quat.cols() == quat_dot.cols() &&
+               "number of columns of quat doesn't match quat_dot");
+  Eigen::Index N = quat.cols();
+
+  typedef Eigen::AutoDiffScalar<Eigen::Matrix<Scalar, 1, 1>> ADScalar;
+  auto quat_autodiff = quat.template cast<ADScalar>().eval();
+  for (int i = 0; i < quat.size(); i++) {
+    quat_autodiff(i).derivatives()(0) = quat_dot(i);
+  }
+
+  expmap.resize(3, N);
+  expmap_dot.resize(3, N);
+  Eigen::Matrix<ADScalar, 3, 1> expmap_autodiff_previous;
+  for (int i = 0; i < N; i++) {
+    auto expmap_autodiff = quat2expmap(quat_autodiff.col(i));
+    if (i >= 1) {
+      expmap_autodiff =
+          closestExpmap(expmap_autodiff_previous, expmap_autodiff);
+    }
+    expmap.col(i) = autoDiffToValueMatrix(expmap_autodiff);
+    expmap_dot.col(i) = autoDiffToGradientMatrix(expmap_autodiff);
+    expmap_autodiff_previous = expmap_autodiff;
+  }
+}
+
+}  // namespace math
+}  // namespace drake

--- a/drake/math/gradient.cc
+++ b/drake/math/gradient.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// gradient.h is a stand-alone header.
+
+#include "drake/math/gradient.h"

--- a/drake/math/gradient.h
+++ b/drake/math/gradient.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+namespace drake {
+namespace math {
+
+/*
+ * Recursively defined template specifying a matrix type of the correct size for
+ * a gradient of a matrix function with respect to Nq variables, of any order.
+ */
+template <typename Derived, int Nq, int DerivativeOrder = 1>
+struct Gradient {
+  typedef typename Eigen::Matrix<
+      typename Derived::Scalar,
+      ((Derived::SizeAtCompileTime == Eigen::Dynamic || Nq == Eigen::Dynamic)
+           ? Eigen::Dynamic
+           : Gradient<Derived, Nq,
+                      DerivativeOrder - 1>::type::SizeAtCompileTime),
+      Nq> type;
+};
+
+/*
+ * Base case for recursively defined gradient template.
+ */
+template <typename Derived, int Nq>
+struct Gradient<Derived, Nq, 1> {
+  typedef typename Eigen::Matrix<typename Derived::Scalar,
+                                 Derived::SizeAtCompileTime, Nq> type;
+};
+
+}  // namespace math
+}  // namespace drake

--- a/drake/math/test/CMakeLists.txt
+++ b/drake/math/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(autodiff_test autodiff_test.cc)
+target_link_libraries(autodiff_test ${GTEST_BOTH_LIBRARIES})
+add_test(NAME autodiff_test COMMAND autodiff_test)
+
+add_executable(expmap_test expmap_test.cc)
+target_link_libraries(expmap_test ${GTEST_BOTH_LIBRARIES})
+add_test(NAME expmap_test COMMAND expmap_test)

--- a/drake/math/test/autodiff_test.cc
+++ b/drake/math/test/autodiff_test.cc
@@ -1,0 +1,93 @@
+#include "drake/math/autodiff.h"
+
+#include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_types.h"
+#include "drake/util/eigen_matrix_compare.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+
+using util::CompareMatrices;
+using util::MatrixCompareType;
+
+namespace math {
+namespace {
+
+class AutodiffTest : public ::testing::Test {
+ protected:
+  typedef Eigen::AutoDiffScalar<VectorXd> Scalar;
+
+  void SetUp() override {
+    // The initial value of vec_ is [1.0, 10.0].
+    vec_.resize(2);
+    vec_[0].value() = 1.0;
+    vec_[1].value() = 10.0;
+    // We arbitrarily decide that the first element of the derivatives vector
+    // corresponds to vec_[0], and the second to vec_[1].
+    // The derivative of vec_[0] with respect to itself is initially 1, and
+    // with respect to vec_1 is initially 0: [1.0, 0.0].
+    vec_[0].derivatives() = Eigen::VectorXd::Unit(2, 0);
+    // The derivative of vec_[1] with respect to itself is initially 1, and
+    // with respect to vec_0 is initially 0: [0.0, 1.0].
+    vec_[1].derivatives() = Eigen::VectorXd::Unit(2, 1);
+
+    vec_ = DoMath(vec_);
+  }
+
+  // Computes a function in R^2 that has analytically easy partial
+  // derivatives.
+  static VectorX<Scalar> DoMath(const VectorX<Scalar>& vec) {
+    VectorX<Scalar> output(2);
+    // y1 = sin(v0) + v1
+    output[1] = sin(vec[0]) + vec[1];
+    // y0 = (sin(v0) + v1) * (cos(v0) / v1)
+    //    = cos(v0) + (sin(v0) * cos(v0) / v1)
+    output[0] = cos(vec[0]) / vec[1];
+    output[0] *= output[1];
+    return output;
+  }
+
+  VectorX<Scalar> vec_;
+};
+
+// Tests that ToValueMatrix extracts the values from the autodiff.
+TEST_F(AutodiffTest, ToValueMatrix) {
+  VectorXd values = autoDiffToValueMatrix(vec_);
+
+  VectorXd expected(2);
+  expected[1] = sin(1.0) + 10.0;
+  expected[0] = (cos(1.0) / 10.0) * expected[1];
+  EXPECT_TRUE(CompareMatrices(expected, values, 1e-10,
+                              MatrixCompareType::absolute)) << values;
+}
+
+// Tests that ToGradientMatrix extracts the gradients from the autodiff.
+TEST_F(AutodiffTest, ToGradientMatrix) {
+  MatrixXd gradients = autoDiffToGradientMatrix(vec_);
+
+  MatrixXd expected(2, 2);
+
+  // By the product rule, the derivative of y0 with respect to v0 is
+  // -sin(v0) + (1 / v1) * (cos(v0)^2 - sin(v0)^2)
+  expected(0, 0) =
+      -sin(1.0) + 0.1 * (cos(1.0) * cos(1.0) - sin(1.0) * sin(1.0));
+  // The derivative of y0 with respect to v1 is sin(v0) * cos(v0) * -1 * v1^-2
+  expected(0, 1) = sin(1.0) * cos(1.0) * -1.0 / (10.0 * 10.0);
+  // The derivative of y1 with respect to v0 is cos(v0).
+  expected(1, 0) = cos(1.0);
+  // The derivative of y1 with respect to v1 is 1.
+  expected(1, 1) = 1.0;
+
+  EXPECT_TRUE(CompareMatrices(expected, gradients, 1e-10,
+                              MatrixCompareType::absolute)) << gradients;
+}
+
+}  // namespace
+}  // namespace math
+}  // namespace drake

--- a/drake/math/test/expmap_test.cc
+++ b/drake/math/test/expmap_test.cc
@@ -1,0 +1,60 @@
+#include "drake/math/expmap.h"
+
+#include <unsupported/Eigen/AutoDiff>
+#include "gtest/gtest.h"
+
+#include "drake/core/Gradient.h"
+#include "drake/math/autodiff.h"
+#include "drake/util/eigen_matrix_compare.h"
+
+using Drake::initializeAutoDiff;
+using Eigen::AutoDiffScalar;
+using Eigen::Matrix3d;
+using Eigen::Vector4d;
+
+namespace drake {
+
+using util::CompareMatrices;
+using util::MatrixCompareType;
+
+namespace math {
+namespace {
+
+// Converts the given quaternion to an expmap and back. Asserts that the
+// two expressions are equivalent.
+void ConvertQuaternionToExpmapAndBack(const Vector4d& quat) {
+  auto quat_autodiff = initializeAutoDiff(quat);
+  auto expmap_autodiff = quat2expmap(quat_autodiff);
+  auto expmap = autoDiffToValueMatrix(expmap_autodiff);
+  auto expmap_grad = autoDiffToGradientMatrix(expmap_autodiff);
+  auto quat_back_autodiff = expmap2quat(initializeAutoDiff(expmap));
+  auto quat_back = autoDiffToValueMatrix(quat_back_autodiff);
+  auto quat_back_grad = autoDiffToGradientMatrix(quat_back_autodiff);
+
+  EXPECT_NEAR(std::abs((quat.transpose() * quat_back).value()), 1.0, 1e-8);
+  Matrix3d identity = Matrix3d::Identity();
+  EXPECT_TRUE(CompareMatrices((expmap_grad * quat_back_grad).eval(), identity,
+                              1e-10, MatrixCompareType::absolute));
+}
+
+GTEST_TEST(ExpmapTest, QuaternionConversion) {
+  Vector4d quat;
+  quat << 0.5, 0.5, 0.5, 0.5;
+  ConvertQuaternionToExpmapAndBack(quat);
+}
+
+GTEST_TEST(ExpmapTest, DegeneratePositiveQuaternionConversion) {
+  Vector4d quat_degenerate = Vector4d::Zero();
+  quat_degenerate(0) = 1.0;
+  ConvertQuaternionToExpmapAndBack(quat_degenerate);
+}
+
+GTEST_TEST(ExpmapTest, DegenerateNegativeQuaternionConversion) {
+  Vector4d quat_degenerate = Vector4d::Zero();
+  quat_degenerate(0) = -1.0;
+  ConvertQuaternionToExpmapAndBack(quat_degenerate);
+}
+
+}  // namespace
+}  // namespace math
+}  // namespace drake

--- a/drake/systems/controllers/LQR.h
+++ b/drake/systems/controllers/LQR.h
@@ -4,9 +4,12 @@
 #include "drake/core/Function.h"
 #include "drake/core/Gradient.h"
 #include "drake/core/Vector.h"
+#include "drake/math/autodiff.h"
 #include "drake/systems/LinearSystem.h"
 #include "drake/util/drakeGradientUtil.h"
 #include "drake/util/drakeUtil.h"
+
+using drake::math::autoDiffToGradientMatrix;
 
 namespace Drake {
 

--- a/drake/systems/controllers/controlUtil.cpp
+++ b/drake/systems/controllers/controlUtil.cpp
@@ -1,7 +1,13 @@
 #include "drake/systems/controllers/controlUtil.h"
+
+#include "drake/math/autodiff.h"
+#include "drake/math/expmap.h"
 #include "drake/util/drakeUtil.h"
 
 using namespace Eigen;
+
+using drake::math::autoDiffToValueMatrix;
+using drake::math::expmap2quat;
 
 template <typename DerivedA, typename DerivedB>
 void getRows(std::set<int> &rows, MatrixBase<DerivedA> const &M,

--- a/drake/systems/plants/ConstraintWrappers.h
+++ b/drake/systems/plants/ConstraintWrappers.h
@@ -5,6 +5,7 @@
 #include <Eigen/Core>
 
 #include "drake/core/Gradient.h"
+#include "drake/math/autodiff.h"
 #include "drake/solvers/Optimization.h"
 #include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 #include "drake/systems/plants/KinematicsCache.h"
@@ -65,14 +66,14 @@ class SingleTimeKinematicConstraintWrapper :
   }
   void eval(const Eigen::Ref<const TaylorVecXd>& tq,
                     TaylorVecXd& ty) const override {
-    Eigen::VectorXd q = autoDiffToValueMatrix(tq);
+    Eigen::VectorXd q = drake::math::autoDiffToValueMatrix(tq);
     auto& kinsol = kin_helper_->UpdateKinematics(
         q, rigid_body_constraint_->getRobotPointer());
     Eigen::VectorXd y;
     Eigen::MatrixXd dy;
     rigid_body_constraint_->eval(nullptr, kinsol, y, dy);
     initializeAutoDiffGivenGradientMatrix(
-        y, (dy * autoDiffToGradientMatrix(tq)).eval(), ty);
+        y, (dy * drake::math::autoDiffToGradientMatrix(tq)).eval(), ty);
   }
 
  private:
@@ -110,7 +111,7 @@ class QuasiStaticConstraintWrapper :
   }
   void eval(const Eigen::Ref<const TaylorVecXd>& tq,
             TaylorVecXd& ty) const override {
-    Eigen::VectorXd q = autoDiffToValueMatrix(tq);
+    Eigen::VectorXd q = drake::math::autoDiffToValueMatrix(tq);
     auto& kinsol = kin_helper_->UpdateKinematics(
         q.head(
             rigid_body_constraint_->getRobotPointer()->number_of_positions()),
@@ -122,7 +123,7 @@ class QuasiStaticConstraintWrapper :
     rigid_body_constraint_->eval(nullptr, kinsol, weights.data(), y, dy);
     y.conservativeResize(num_constraints());
     initializeAutoDiffGivenGradientMatrix(
-        y, (dy * autoDiffToGradientMatrix(tq)).eval(), ty);
+        y, (dy * drake::math::autoDiffToGradientMatrix(tq)).eval(), ty);
   }
 
  private:

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1,6 +1,8 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 
 #include "drake/common/eigen_types.h"
+#include "drake/math/autodiff.h"
+#include "drake/math/gradient.h"
 #include "drake/systems/plants/joints/DrakeJoints.h"
 #include "drake/systems/plants/joints/FixedJoint.h"
 #include "drake/util/drakeGeometryUtil.h"
@@ -16,6 +18,7 @@
 
 using namespace std;
 using namespace Eigen;
+
 using drake::AutoDiffUpTo73d;
 using drake::AutoDiffXd;
 using drake::Matrix3X;
@@ -23,6 +26,9 @@ using drake::Matrix4X;
 using drake::MatrixX;
 using drake::Vector3;
 using drake::VectorX;
+
+using drake::math::autoDiffToGradientMatrix;
+using drake::math::Gradient;
 
 /// A column vector consisting of one twist.
 template <typename Scalar>

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -4,10 +4,14 @@
 #include <stdexcept>
 
 #include "drake/core/Gradient.h"
+#include "drake/math/autodiff.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/util/drakeGeometryUtil.h"
 
 using namespace Eigen;
+
+using drake::math::autoDiffToValueMatrix;
+using drake::math::autoDiffToGradientMatrix;
 
 namespace DrakeRigidBodyConstraint {
 Vector2d default_tspan(-std::numeric_limits<double>::infinity(),

--- a/drake/systems/plants/inverseKinBackend.cpp
+++ b/drake/systems/plants/inverseKinBackend.cpp
@@ -9,6 +9,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/core/Function.h"
 #include "drake/core/Gradient.h"
+#include "drake/math/autodiff.h"
 #include "drake/solvers/Optimization.h"
 #include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 #include "drake/systems/plants/ConstraintWrappers.h"
@@ -21,6 +22,8 @@ using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using Eigen::VectorXi;
 
+using drake::math::autoDiffToGradientMatrix;
+using drake::math::autoDiffToValueMatrix;
 using drake::solvers::Constraint;
 using drake::solvers::DecisionVariableView;
 using drake::solvers::OptimizationProblem;

--- a/drake/systems/plants/joints/DrakeJoint.h
+++ b/drake/systems/plants/joints/DrakeJoint.h
@@ -1,44 +1,48 @@
 #pragma once
 
+#include <random>
+
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 #include <unsupported/Eigen/AutoDiff>
-#include <random>
+
+#include "drake/math/gradient.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/drakeJoints_export.h"
 
 #define POSITION_AND_VELOCITY_DEPENDENT_METHODS(Scalar)                    \
   virtual Eigen::Transform<Scalar, 3, Eigen::Isometry> jointTransform(     \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q) \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q) \
       const = 0;                                                           \
   virtual void motionSubspace(                                             \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q, \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
       Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic, 0, TWIST_SIZE,     \
-                    MAX_NUM_VELOCITIES> &motion_subspace,                  \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> *              \
+                    MAX_NUM_VELOCITIES>& motion_subspace,                  \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>*               \
           dmotion_subspace = nullptr) const = 0;                           \
   virtual void motionSubspaceDotTimesV(                                    \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q, \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &v, \
-      Eigen::Matrix<Scalar, 6, 1> &motion_subspace_dot_times_v,            \
-      Gradient<Eigen::Matrix<Scalar, 6, 1>, Eigen::Dynamic>::type *        \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v, \
+      Eigen::Matrix<Scalar, 6, 1>& motion_subspace_dot_times_v,            \
+      drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>,                   \
+                            Eigen::Dynamic>::type*                         \
           dmotion_subspace_dot_times_vdq = nullptr,                        \
-      Gradient<Eigen::Matrix<Scalar, 6, 1>, Eigen::Dynamic>::              \
-          type *dmotion_subspace_dot_times_vdv = nullptr) const = 0;       \
+      drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>, Eigen::Dynamic>:: \
+          type* dmotion_subspace_dot_times_vdv = nullptr) const = 0;       \
   virtual void qdot2v(                                                     \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q, \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
       Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,             \
-                    MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS> &qdot_to_v,     \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> *dqdot_to_v)   \
+                    MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS>& qdot_to_v,     \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dqdot_to_v)   \
       const = 0;                                                           \
   virtual void v2qdot(                                                     \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q, \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
       Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,             \
-                    MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES> &v_to_qdot,     \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> *dv_to_qdot)   \
+                    MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES>& v_to_qdot,     \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dv_to_qdot)   \
       const = 0;                                                           \
   virtual Eigen::Matrix<Scalar, Eigen::Dynamic, 1> frictionTorque(         \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &v) \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v) \
       const = 0;
 
 class DRAKEJOINTS_EXPORT DrakeJoint {
@@ -51,19 +55,19 @@ class DRAKEJOINTS_EXPORT DrakeJoint {
       AutoDiffFixedMaxSize;  // 73 is number of states of quat-parameterized
                              // Atlas
 
-  DrakeJoint(const std::string &name,
-             const Eigen::Isometry3d &transform_to_parent_body,
+  DrakeJoint(const std::string& name,
+             const Eigen::Isometry3d& transform_to_parent_body,
              int num_positions, int num_velocities);
 
   virtual ~DrakeJoint();
 
-  const Eigen::Isometry3d &getTransformToParentBody() const;
+  const Eigen::Isometry3d& getTransformToParentBody() const;
 
   int getNumPositions() const;
 
   int getNumVelocities() const;
 
-  const std::string &getName() const;
+  const std::string& getName() const;
 
   virtual std::string getPositionName(int index) const = 0;
 
@@ -76,11 +80,11 @@ class DRAKEJOINTS_EXPORT DrakeJoint {
   virtual Eigen::VectorXd zeroConfiguration() const = 0;
 
   virtual Eigen::VectorXd randomConfiguration(
-      std::default_random_engine &generator) const = 0;
+      std::default_random_engine& generator) const = 0;
 
-  virtual const Eigen::VectorXd &getJointLimitMin() const;
+  virtual const Eigen::VectorXd& getJointLimitMin() const;
 
-  virtual const Eigen::VectorXd &getJointLimitMax() const;
+  virtual const Eigen::VectorXd& getJointLimitMax() const;
 
   POSITION_AND_VELOCITY_DEPENDENT_METHODS(double)
 

--- a/drake/systems/plants/joints/DrakeJointImpl.h
+++ b/drake/systems/plants/joints/DrakeJointImpl.h
@@ -2,62 +2,67 @@
 
 #include "drake/systems/plants/joints/DrakeJoint.h"
 
-#define POSITION_AND_VELOCITY_DEPENDENT_METHODS_IMPL(Scalar)                 \
-  virtual Eigen::Transform<Scalar, 3, Eigen::Isometry> jointTransform(       \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q)   \
-      const override {                                                       \
-    return derived.jointTransform(q);                                        \
-  };                                                                         \
-  void motionSubspace(                                                       \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q,   \
-      Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic, 0, TWIST_SIZE,       \
-                    MAX_NUM_VELOCITIES> &motion_subspace,                    \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> *                \
-          dmotion_subspace = nullptr) const override {                       \
-    derived.motionSubspace(q, motion_subspace, dmotion_subspace);            \
-  };                                                                         \
-  void motionSubspaceDotTimesV(                                              \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q,   \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &v,   \
-      Eigen::Matrix<Scalar, 6, 1> &motion_subspace_dot_times_v,              \
-      typename Gradient<Eigen::Matrix<Scalar, 6, 1>, Eigen::Dynamic>::type * \
-          dmotion_subspace_dot_times_vdq = nullptr,                          \
-      typename Gradient<Eigen::Matrix<Scalar, 6, 1>, Eigen::Dynamic>::       \
-          type *dmotion_subspace_dot_times_vdv = nullptr) const override {   \
-    derived.motionSubspaceDotTimesV(q, v, motion_subspace_dot_times_v,       \
-                                    dmotion_subspace_dot_times_vdq,          \
-                                    dmotion_subspace_dot_times_vdv);         \
-  };                                                                         \
-  void qdot2v(                                                               \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q,   \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,               \
-                    MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS> &qdot_to_v,       \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> *dqdot_to_v)     \
-      const override {                                                       \
-    derived.qdot2v(q, qdot_to_v, dqdot_to_v);                                \
-  };                                                                         \
-  void v2qdot(                                                               \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &q,   \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,               \
-                    MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES> &v_to_qdot,       \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> *dv_to_qdot)     \
-      const override {                                                       \
-    derived.v2qdot(q, v_to_qdot, dv_to_qdot);                                \
-  };                                                                         \
-  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> frictionTorque(                   \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>> &v)   \
-      const override {                                                       \
-    return derived.frictionTorque(v);                                        \
+#include "drake/math/gradient.h"
+
+#define POSITION_AND_VELOCITY_DEPENDENT_METHODS_IMPL(Scalar)               \
+  virtual Eigen::Transform<Scalar, 3, Eigen::Isometry> jointTransform(     \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q) \
+      const override {                                                     \
+    return derived.jointTransform(q);                                      \
+  };                                                                       \
+  void motionSubspace(                                                     \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
+      Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic, 0, TWIST_SIZE,     \
+                    MAX_NUM_VELOCITIES>& motion_subspace,                  \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>*               \
+          dmotion_subspace = nullptr) const override {                     \
+    derived.motionSubspace(q, motion_subspace, dmotion_subspace);          \
+  };                                                                       \
+  void motionSubspaceDotTimesV(                                            \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v, \
+      Eigen::Matrix<Scalar, 6, 1>& motion_subspace_dot_times_v,            \
+      typename drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>,          \
+                                     Eigen::Dynamic>::type*                \
+          dmotion_subspace_dot_times_vdq = nullptr,                        \
+      typename drake::math::Gradient<                                      \
+          Eigen::Matrix<Scalar, 6, 1>,                                     \
+          Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv = nullptr) \
+      const override {                                                     \
+    derived.motionSubspaceDotTimesV(q, v, motion_subspace_dot_times_v,     \
+                                    dmotion_subspace_dot_times_vdq,        \
+                                    dmotion_subspace_dot_times_vdv);       \
+  };                                                                       \
+  void qdot2v(                                                             \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,             \
+                    MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS>& qdot_to_v,     \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dqdot_to_v)   \
+      const override {                                                     \
+    derived.qdot2v(q, qdot_to_v, dqdot_to_v);                              \
+  };                                                                       \
+  void v2qdot(                                                             \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,             \
+                    MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES>& v_to_qdot,     \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dv_to_qdot)   \
+      const override {                                                     \
+    derived.v2qdot(q, v_to_qdot, dv_to_qdot);                              \
+  };                                                                       \
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> frictionTorque(                 \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v) \
+      const override {                                                     \
+    return derived.frictionTorque(v);                                      \
   };
 
 template <typename Derived>
 class DrakeJointImpl : public DrakeJoint {
  private:
-  Derived &derived;
+  Derived& derived;
 
  public:
-  DrakeJointImpl(Derived &_derived, const std::string &name,
-                 const Eigen::Isometry3d &transform_to_parent_body,
+  DrakeJointImpl(Derived& _derived, const std::string& name,
+                 const Eigen::Isometry3d& transform_to_parent_body,
                  int num_positions, int num_velocities)
       : DrakeJoint(name, transform_to_parent_body, num_positions,
                    num_velocities),

--- a/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
+++ b/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
@@ -39,10 +39,11 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
   using DrakeJoint::getNumVelocities;
 
   template <typename DerivedQ, typename DerivedMS>
-  void motionSubspace(const Eigen::MatrixBase<DerivedQ>& q,
-                      Eigen::MatrixBase<DerivedMS>& motion_subspace,
-                      typename Gradient<DerivedMS, Eigen::Dynamic>::type*
-                          dmotion_subspace = nullptr) const {
+  void motionSubspace(
+      const Eigen::MatrixBase<DerivedQ>& q,
+      Eigen::MatrixBase<DerivedMS>& motion_subspace,
+      typename drake::math::Gradient<DerivedMS, Eigen::Dynamic>::type*
+          dmotion_subspace = nullptr) const {
     motion_subspace = joint_axis.cast<typename DerivedQ::Scalar>();
     if (dmotion_subspace) {
       dmotion_subspace->setZero(motion_subspace.size(), getNumPositions());
@@ -55,12 +56,12 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
       const Eigen::MatrixBase<DerivedV>& v,
       Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>&
           motion_subspace_dot_times_v,
-      typename Gradient<Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>,
-                        Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdq =
-          nullptr,
-      typename Gradient<Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>,
-                        Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv =
-          nullptr) const {
+      typename drake::math::Gradient<
+          Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
+          dmotion_subspace_dot_times_vdq = nullptr,
+      typename drake::math::Gradient<
+          Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
+          dmotion_subspace_dot_times_vdv = nullptr) const {
     motion_subspace_dot_times_v.setZero();
 
     if (dmotion_subspace_dot_times_vdq) {
@@ -115,8 +116,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
     return ret;
   }
 
-  void setJointLimits(
-      double joint_limit_min, double joint_limit_max) {
+  void setJointLimits(double joint_limit_min, double joint_limit_max) {
     if (joint_limit_min > joint_limit_max) {
       throw std::logic_error(
           "ERROR: joint_limit_min cannot be larger than joint_limit_max");

--- a/drake/systems/plants/joints/FixedJoint.h
+++ b/drake/systems/plants/joints/FixedJoint.h
@@ -4,24 +4,25 @@
 
 class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
  public:
-  FixedJoint(const std::string &name,
-             const Eigen::Isometry3d &transform_to_parent_body)
+  FixedJoint(const std::string& name,
+             const Eigen::Isometry3d& transform_to_parent_body)
       : DrakeJointImpl(*this, name, transform_to_parent_body, 0, 0) {}
 
   virtual ~FixedJoint() {}
 
   template <typename DerivedQ>
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
-  jointTransform(const Eigen::MatrixBase<DerivedQ> &q) const {
+  jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
     return Eigen::Transform<typename DerivedQ::Scalar, 3,
                             Eigen::Isometry>::Identity();
   }
 
   template <typename DerivedQ, typename DerivedMS>
-  void motionSubspace(const Eigen::MatrixBase<DerivedQ> &q,
-                      Eigen::MatrixBase<DerivedMS> &motion_subspace,
-                      typename Gradient<DerivedMS, Eigen::Dynamic>::type *
-                          dmotion_subspace = nullptr) const {
+  void motionSubspace(
+      const Eigen::MatrixBase<DerivedQ>& q,
+      Eigen::MatrixBase<DerivedMS>& motion_subspace,
+      typename drake::math::Gradient<DerivedMS, Eigen::Dynamic>::type*
+          dmotion_subspace = nullptr) const {
     motion_subspace.resize(TWIST_SIZE, getNumVelocities());
     if (dmotion_subspace) {
       dmotion_subspace->resize(motion_subspace.size(), getNumPositions());
@@ -30,16 +31,16 @@ class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
 
   template <typename DerivedQ, typename DerivedV>
   void motionSubspaceDotTimesV(
-      const Eigen::MatrixBase<DerivedQ> &q,
-      const Eigen::MatrixBase<DerivedV> &v,
-      Eigen::Matrix<typename DerivedQ::Scalar, 6, 1> &
+      const Eigen::MatrixBase<DerivedQ>& q,
+      const Eigen::MatrixBase<DerivedV>& v,
+      Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>&
           motion_subspace_dot_times_v,
-      typename Gradient<Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>,
-                        Eigen::Dynamic>::type *dmotion_subspace_dot_times_vdq =
-          nullptr,
-      typename Gradient<Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>,
-                        Eigen::Dynamic>::type *dmotion_subspace_dot_times_vdv =
-          nullptr) const {
+      typename drake::math::Gradient<
+          Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
+          dmotion_subspace_dot_times_vdq = nullptr,
+      typename drake::math::Gradient<
+          Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
+          dmotion_subspace_dot_times_vdv = nullptr) const {
     motion_subspace_dot_times_v.setZero();
 
     if (dmotion_subspace_dot_times_vdq) {
@@ -53,10 +54,10 @@ class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
 
   template <typename DerivedQ>
   void qdot2v(
-      const Eigen::MatrixBase<DerivedQ> &q,
+      const Eigen::MatrixBase<DerivedQ>& q,
       Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, Eigen::Dynamic,
-                    0, MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS> &qdot_to_v,
-      Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, Eigen::Dynamic> *
+                    0, MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS>& qdot_to_v,
+      Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, Eigen::Dynamic>*
           dqdot_to_v) const {
     qdot_to_v.resize(getNumVelocities(), getNumPositions());
     if (dqdot_to_v) {
@@ -66,10 +67,10 @@ class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
 
   template <typename DerivedQ>
   void v2qdot(
-      const Eigen::MatrixBase<DerivedQ> &q,
+      const Eigen::MatrixBase<DerivedQ>& q,
       Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, Eigen::Dynamic,
-                    0, MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES> &v_to_qdot,
-      Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, Eigen::Dynamic> *
+                    0, MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES>& v_to_qdot,
+      Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, Eigen::Dynamic>*
           dv_to_qdot) const {
     v_to_qdot.resize(getNumPositions(), getNumVelocities());
     if (dv_to_qdot) {
@@ -79,7 +80,7 @@ class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
 
   template <typename DerivedV>
   Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, 1> frictionTorque(
-      const Eigen::MatrixBase<DerivedV> &v) const {
+      const Eigen::MatrixBase<DerivedV>& v) const {
     return Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, 1>(
         getNumVelocities(), 1);
   }
@@ -87,7 +88,7 @@ class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
   std::string getPositionName(int index) const override;
   Eigen::VectorXd zeroConfiguration() const override;
   Eigen::VectorXd randomConfiguration(
-      std::default_random_engine &generator) const override;
+      std::default_random_engine& generator) const override;
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/systems/plants/joints/QuaternionFloatingJoint.h
+++ b/drake/systems/plants/joints/QuaternionFloatingJoint.h
@@ -11,15 +11,15 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
   // delete;
 
  public:
-  QuaternionFloatingJoint(const std::string &name,
-                          const Eigen::Isometry3d &transform_to_parent_body)
+  QuaternionFloatingJoint(const std::string& name,
+                          const Eigen::Isometry3d& transform_to_parent_body)
       : DrakeJointImpl(*this, name, transform_to_parent_body, 7, 6) {}
 
   virtual ~QuaternionFloatingJoint() {}
 
   template <typename DerivedQ>
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
-  jointTransform(const Eigen::MatrixBase<DerivedQ> &q) const {
+  jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
     Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry> ret;
     ret.linear() = quat2rotmat(q.template bottomRows<4>());
     ret.translation() << q[0], q[1], q[2];
@@ -28,10 +28,11 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
   }
 
   template <typename DerivedQ, typename DerivedMS>
-  void motionSubspace(const Eigen::MatrixBase<DerivedQ> &q,
-                      Eigen::MatrixBase<DerivedMS> &motion_subspace,
-                      typename Gradient<DerivedMS, Eigen::Dynamic>::type *
-                          dmotion_subspace = nullptr) const {
+  void motionSubspace(
+      const Eigen::MatrixBase<DerivedQ>& q,
+      Eigen::MatrixBase<DerivedMS>& motion_subspace,
+      typename drake::math::Gradient<DerivedMS, Eigen::Dynamic>::type*
+          dmotion_subspace = nullptr) const {
     motion_subspace.setIdentity(TWIST_SIZE, getNumVelocities());
     if (dmotion_subspace) {
       dmotion_subspace->setZero(motion_subspace.size(), getNumPositions());
@@ -40,16 +41,16 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
 
   template <typename DerivedQ, typename DerivedV>
   void motionSubspaceDotTimesV(
-      const Eigen::MatrixBase<DerivedQ> &q,
-      const Eigen::MatrixBase<DerivedV> &v,
-      Eigen::Matrix<typename DerivedQ::Scalar, 6, 1> &
+      const Eigen::MatrixBase<DerivedQ>& q,
+      const Eigen::MatrixBase<DerivedV>& v,
+      Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>&
           motion_subspace_dot_times_v,
-      typename Gradient<Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>,
-                        Eigen::Dynamic>::type *dmotion_subspace_dot_times_vdq =
-          nullptr,
-      typename Gradient<Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>,
-                        Eigen::Dynamic>::type *dmotion_subspace_dot_times_vdv =
-          nullptr) const {
+      typename drake::math::Gradient<
+          Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
+          dmotion_subspace_dot_times_vdq = nullptr,
+      typename drake::math::Gradient<
+          Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
+          dmotion_subspace_dot_times_vdv = nullptr) const {
     motion_subspace_dot_times_v.setZero();
     if (dmotion_subspace_dot_times_vdq) {
       dmotion_subspace_dot_times_vdq->setZero(
@@ -62,12 +63,12 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
   }
 
   template <typename DerivedQ>
-  void qdot2v(const Eigen::MatrixBase<DerivedQ> &q,
+  void qdot2v(const Eigen::MatrixBase<DerivedQ>& q,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic, 0, DrakeJoint::MAX_NUM_VELOCITIES,
-                            DrakeJoint::MAX_NUM_POSITIONS> &qdot_to_v,
+                            DrakeJoint::MAX_NUM_POSITIONS>& qdot_to_v,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
-                            Eigen::Dynamic> *dqdot_to_v) const {
+                            Eigen::Dynamic>* dqdot_to_v) const {
     if (dqdot_to_v) {
       throw std::runtime_error("no longer supported");
     }
@@ -78,8 +79,8 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
     auto R = quat2rotmat(quat);
 
     Eigen::Matrix<Scalar, 4, 1> quattilde;
-    typename Gradient<Eigen::Matrix<Scalar, 4, 1>, QUAT_SIZE, 1>::type
-        dquattildedquat;
+    typename drake::math::Gradient<Eigen::Matrix<Scalar, 4, 1>, QUAT_SIZE,
+                                   1>::type dquattildedquat;
     normalizeVec(quat, quattilde, &dquattildedquat);
     auto RTransposeM = (R.transpose() * quatdot2angularvelMatrix(quat)).eval();
     qdot_to_v.template block<3, 3>(0, 0).setZero();
@@ -90,12 +91,12 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
   }
 
   template <typename DerivedQ>
-  void v2qdot(const Eigen::MatrixBase<DerivedQ> &q,
+  void v2qdot(const Eigen::MatrixBase<DerivedQ>& q,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic, 0, DrakeJoint::MAX_NUM_POSITIONS,
-                            DrakeJoint::MAX_NUM_VELOCITIES> &v_to_qdot,
+                            DrakeJoint::MAX_NUM_VELOCITIES>& v_to_qdot,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
-                            Eigen::Dynamic> *dv_to_qdot) const {
+                            Eigen::Dynamic>* dv_to_qdot) const {
     typedef typename DerivedQ::Scalar Scalar;
     v_to_qdot.resize(getNumPositions(), getNumVelocities());
 
@@ -105,7 +106,7 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
     Eigen::Matrix<Scalar, QUAT_SIZE, SPACE_DIMENSION> M;
     if (dv_to_qdot) {
       auto dR = dquat2rotmat(quat);
-      typename Gradient<decltype(M), QUAT_SIZE, 1>::type dM;
+      typename drake::math::Gradient<decltype(M), QUAT_SIZE, 1>::type dM;
       angularvel2quatdotMatrix(quat, M, &dM);
 
       dv_to_qdot->setZero(v_to_qdot.size(), getNumPositions());
@@ -117,8 +118,8 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
                               v_to_qdot.rows(), 3);
     } else {
       angularvel2quatdotMatrix(
-          quat, M,
-          (typename Gradient<decltype(M), QUAT_SIZE, 1>::type *)nullptr);
+          quat, M, (typename drake::math::Gradient<decltype(M), QUAT_SIZE,
+                                                   1>::type*)nullptr);
     }
 
     v_to_qdot.template block<3, 3>(0, 0).setZero();
@@ -129,7 +130,7 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
 
   template <typename DerivedV>
   Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, 1> frictionTorque(
-      const Eigen::MatrixBase<DerivedV> &v) const {
+      const Eigen::MatrixBase<DerivedV>& v) const {
     return Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, 1>::Zero(
         getNumVelocities(), 1);
   }
@@ -139,7 +140,7 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
   std::string getVelocityName(int index) const override;
   Eigen::VectorXd zeroConfiguration() const override;
   Eigen::VectorXd randomConfiguration(
-      std::default_random_engine &generator) const override;
+      std::default_random_engine& generator) const override;
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
@@ -11,15 +11,15 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
   // delete;
 
  public:
-  RollPitchYawFloatingJoint(const std::string &name,
-                            const Eigen::Isometry3d &transform_to_parent_body)
+  RollPitchYawFloatingJoint(const std::string& name,
+                            const Eigen::Isometry3d& transform_to_parent_body)
       : DrakeJointImpl(*this, name, transform_to_parent_body, 6, 6) {}
 
   virtual ~RollPitchYawFloatingJoint() {}
 
   template <typename DerivedQ>
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
-  jointTransform(const Eigen::MatrixBase<DerivedQ> &q) const {
+  jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
     Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry> ret;
     auto pos = q.template middleRows<SPACE_DIMENSION>(0);
     auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
@@ -30,10 +30,11 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
   }
 
   template <typename DerivedQ, typename DerivedMS>
-  void motionSubspace(const Eigen::MatrixBase<DerivedQ> &q,
-                      Eigen::MatrixBase<DerivedMS> &motion_subspace,
-                      typename Gradient<DerivedMS, Eigen::Dynamic>::type *
-                          dmotion_subspace = nullptr) const {
+  void motionSubspace(
+      const Eigen::MatrixBase<DerivedQ>& q,
+      Eigen::MatrixBase<DerivedMS>& motion_subspace,
+      typename drake::math::Gradient<DerivedMS, Eigen::Dynamic>::type*
+          dmotion_subspace = nullptr) const {
     typedef typename DerivedQ::Scalar Scalar;
     motion_subspace.resize(TWIST_SIZE, getNumVelocities());
     auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
@@ -85,16 +86,16 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
 
   template <typename DerivedQ, typename DerivedV>
   void motionSubspaceDotTimesV(
-      const Eigen::MatrixBase<DerivedQ> &q,
-      const Eigen::MatrixBase<DerivedV> &v,
-      Eigen::Matrix<typename DerivedQ::Scalar, 6, 1> &
+      const Eigen::MatrixBase<DerivedQ>& q,
+      const Eigen::MatrixBase<DerivedV>& v,
+      Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>&
           motion_subspace_dot_times_v,
-      typename Gradient<Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>,
-                        Eigen::Dynamic>::type *dmotion_subspace_dot_times_vdq =
-          nullptr,
-      typename Gradient<Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>,
-                        Eigen::Dynamic>::type *dmotion_subspace_dot_times_vdv =
-          nullptr) const {
+      typename drake::math::Gradient<
+          Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
+          dmotion_subspace_dot_times_vdq = nullptr,
+      typename drake::math::Gradient<
+          Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
+          dmotion_subspace_dot_times_vdv = nullptr) const {
     typedef typename DerivedQ::Scalar Scalar;
     motion_subspace_dot_times_v.resize(TWIST_SIZE, 1);
     auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
@@ -214,12 +215,12 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
   }
 
   template <typename DerivedQ>
-  void qdot2v(const Eigen::MatrixBase<DerivedQ> &q,
+  void qdot2v(const Eigen::MatrixBase<DerivedQ>& q,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic, 0, DrakeJoint::MAX_NUM_VELOCITIES,
-                            DrakeJoint::MAX_NUM_POSITIONS> &qdot_to_v,
+                            DrakeJoint::MAX_NUM_POSITIONS>& qdot_to_v,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
-                            Eigen::Dynamic> *dqdot_to_v) const {
+                            Eigen::Dynamic>* dqdot_to_v) const {
     qdot_to_v.setIdentity(getNumVelocities(), getNumPositions());
     Drake::resizeDerivativesToMatchScalar(qdot_to_v, q(0));
 
@@ -229,12 +230,12 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
   }
 
   template <typename DerivedQ>
-  void v2qdot(const Eigen::MatrixBase<DerivedQ> &q,
+  void v2qdot(const Eigen::MatrixBase<DerivedQ>& q,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic, 0, DrakeJoint::MAX_NUM_POSITIONS,
-                            DrakeJoint::MAX_NUM_VELOCITIES> &v_to_qdot,
+                            DrakeJoint::MAX_NUM_VELOCITIES>& v_to_qdot,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
-                            Eigen::Dynamic> *dv_to_qdot) const {
+                            Eigen::Dynamic>* dv_to_qdot) const {
     v_to_qdot.setIdentity(getNumPositions(), getNumVelocities());
     Drake::resizeDerivativesToMatchScalar(v_to_qdot, q(0));
 
@@ -245,7 +246,7 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
 
   template <typename DerivedV>
   Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, 1> frictionTorque(
-      const Eigen::MatrixBase<DerivedV> &v) const {
+      const Eigen::MatrixBase<DerivedV>& v) const {
     return Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, 1>::Zero(
         getNumVelocities(), 1);
   }
@@ -253,7 +254,7 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
   bool isFloating() const override { return true; }
   Eigen::VectorXd zeroConfiguration() const override;
   Eigen::VectorXd randomConfiguration(
-      std::default_random_engine &generator) const override;
+      std::default_random_engine& generator) const override;
   std::string getPositionName(int index) const override;
 
  public:

--- a/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
+++ b/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
@@ -1,9 +1,14 @@
 #include <cmath>
+
+#include "drake/math/autodiff.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/util/testUtil.h"
 
 using namespace std;
 using namespace Eigen;
+
+using drake::math::autoDiffToGradientMatrix;
+using drake::math::autoDiffToValueMatrix;
 
 typedef DrakeJoint::AutoDiffFixedMaxSize AutoDiffFixedMaxSize;
 typedef AutoDiffScalar<VectorXd> AutoDiffDynamicSize;

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -1,17 +1,22 @@
 #include "drake/systems/robotInterfaces/QPLocomotionPlan.h"
-#include <stdexcept>
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include "drake/util/drakeGeometryUtil.h"
+#include <stdexcept>
+#include <string>
+
+#include "drake/core/Gradient.h"
+#include "drake/drakeQPLocomotionPlan_export.h"  // TODO(tkoolen): exports
+#include "drake/examples/Atlas/atlasUtil.h"
+#include "drake/math/autodiff.h"
+#include "drake/math/expmap.h"
+#include "drake/math/gradient.h"
 #include "drake/solvers/qpSpline/splineGeneration.h"
+#include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeUtil.h"
 #include "drake/util/lcmUtil.h"
-#include <string>
 #include "drake/util/convexHull.h"
-#include "drake/examples/Atlas/atlasUtil.h"
-#include "drake/drakeQPLocomotionPlan_export.h"  // TODO(tkoolen): exports
-#include "drake/core/Gradient.h"
 
 // TODO(tkoolen): discuss possibility of chatter in knee control
 // TODO(tkoolen): make body_motions a map from RigidBody* to BodyMotionData,
@@ -20,6 +25,13 @@
 using namespace std;
 using namespace Eigen;
 using namespace Drake;
+
+using drake::math::Gradient;
+using drake::math::autoDiffToGradientMatrix;
+using drake::math::autoDiffToValueMatrix;
+using drake::math::expmap2quat;
+using drake::math::closestExpmap;
+using drake::math::quat2expmap;
 
 const std::map<SupportLogicType, std::vector<bool>>
     QPLocomotionPlan::support_logic_maps =

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -1,3 +1,7 @@
+/// @file
+/// THIS FILE IS DEPRECATED.
+/// Its contents are moving into drake/math.
+
 #pragma once
 
 #include <Eigen/Dense>
@@ -6,8 +10,9 @@
 #include <random>
 
 #include "drake/common/drake_assert.h"
-#include "drake/util/drakeGradientUtil.h"
 #include "drake/drakeGeometryUtil_export.h"
+#include "drake/math/gradient.h"
+#include "drake/util/drakeGradientUtil.h"
 
 const int TWIST_SIZE = 6;
 const int QUAT_SIZE = 4;
@@ -169,9 +174,9 @@ DRAKEGEOMETRYUTIL_EXPORT Eigen::Vector3d uniformlyRandomRPY(
 template <typename Derived>
 void normalizeVec(
     const Eigen::MatrixBase<Derived>& x, typename Derived::PlainObject& x_norm,
-    typename Gradient<Derived, Derived::RowsAtCompileTime, 1>::type* dx_norm =
+    typename drake::math::Gradient<Derived, Derived::RowsAtCompileTime, 1>::type* dx_norm =
         nullptr,
-    typename Gradient<Derived, Derived::RowsAtCompileTime, 2>::type* ddx_norm =
+    typename drake::math::Gradient<Derived, Derived::RowsAtCompileTime, 2>::type* ddx_norm =
         nullptr) {
   typename Derived::Scalar xdotx = x.squaredNorm();
   typename Derived::Scalar norm_x = sqrt(xdotx);
@@ -315,66 +320,6 @@ Eigen::Matrix<typename Derived::Scalar, 3, 1> axis2rpy(
     const Eigen::MatrixBase<Derived>& a) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 4);
   return quat2rpy(axis2quat(a));
-}
-
-/*
- * expmap2x
- */
-namespace Drake {
-namespace internal {
-template <typename Derived>
-Eigen::Matrix<typename Derived::Scalar, 4, 1> expmap2quatNonDegenerate(
-    const Eigen::MatrixBase<Derived>& v,
-    typename Derived::Scalar& theta_squared) {
-  using namespace std;
-  typedef typename Derived::Scalar Scalar;
-  static_assert(
-      Derived::RowsAtCompileTime == 3 && Derived::ColsAtCompileTime == 1,
-      "Wrong size.");
-
-  Eigen::Matrix<Scalar, 4, 1> q;
-
-  Scalar theta = sqrt(theta_squared);
-  Scalar arg = theta / Scalar(2);
-  q(0) = cos(arg);
-  q.template bottomRows<3>() = v;
-  q.template bottomRows<3>() *= sin(arg) / theta;
-
-  return q;
-}
-
-template <typename Derived>
-Eigen::Matrix<typename Derived::Scalar, 4, 1> expmap2quatDegenerate(
-    const Eigen::MatrixBase<Derived>& v,
-    typename Derived::Scalar& theta_squared) {
-  typedef typename Derived::Scalar Scalar;
-  static_assert(
-      Derived::RowsAtCompileTime == 3 && Derived::ColsAtCompileTime == 1,
-      "Wrong size.");
-
-  Eigen::Matrix<Scalar, 4, 1> q;
-
-  q(0) = -theta_squared / 8.0 + 1.0;
-  q.template bottomRows<3>() = v;
-  q.template bottomRows<3>() *=
-      (theta_squared * 8.0E1 - 1.92E3) * (-2.604166666666667E-4);
-
-  return q;
-}
-}
-}
-
-template <typename Derived>
-Eigen::Matrix<typename Derived::Scalar, QUAT_SIZE, 1> expmap2quat(
-    const Eigen::MatrixBase<Derived>& v) {
-  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 3);
-  typedef typename Derived::Scalar Scalar;
-  Scalar theta_squared = v.squaredNorm();
-  if (theta_squared < pow(Eigen::NumTraits<Scalar>::epsilon(), 0.5)) {
-    return Drake::internal::expmap2quatDegenerate(v, theta_squared);
-  } else {
-    return Drake::internal::expmap2quatNonDegenerate(v, theta_squared);
-  }
 }
 
 /*
@@ -538,16 +483,16 @@ Eigen::Matrix<typename Derived::Scalar, 3, 3> rpy2rotmat(
  * rotation conversion gradient functions
  */
 template <typename Derived>
-typename Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
+typename drake::math::Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
                   QUAT_SIZE>::type
 dquat2rotmat(const Eigen::MatrixBase<Derived>& q) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
                                            QUAT_SIZE);
 
-  typename Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
+  typename drake::math::Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
                     QUAT_SIZE>::type ret;
   typename Eigen::MatrixBase<Derived>::PlainObject qtilde;
-  typename Gradient<Derived, QUAT_SIZE>::type dqtilde;
+  typename drake::math::Gradient<Derived, QUAT_SIZE>::type dqtilde;
   normalizeVec(q, qtilde, &dqtilde);
 
   typedef typename Derived::Scalar Scalar;
@@ -564,7 +509,7 @@ dquat2rotmat(const Eigen::MatrixBase<Derived>& q) {
 }
 
 template <typename DerivedR, typename DerivedDR>
-typename Gradient<Eigen::Matrix<typename DerivedR::Scalar, RPY_SIZE, 1>,
+typename drake::math::Gradient<Eigen::Matrix<typename DerivedR::Scalar, RPY_SIZE, 1>,
                   DerivedDR::ColsAtCompileTime>::type
 drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
             const Eigen::MatrixBase<DerivedDR>& dR) {
@@ -576,7 +521,7 @@ drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
 
   typename DerivedDR::Index nq = dR.cols();
   typedef typename DerivedR::Scalar Scalar;
-  typedef typename Gradient<Eigen::Matrix<Scalar, RPY_SIZE, 1>,
+  typedef typename drake::math::Gradient<Eigen::Matrix<Scalar, RPY_SIZE, 1>,
                             DerivedDR::ColsAtCompileTime>::type ReturnType;
   ReturnType drpy(RPY_SIZE, nq);
 
@@ -611,7 +556,7 @@ drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
 }
 
 template <typename DerivedR, typename DerivedDR>
-typename Gradient<Eigen::Matrix<typename DerivedR::Scalar, QUAT_SIZE, 1>,
+typename drake::math::Gradient<Eigen::Matrix<typename DerivedR::Scalar, QUAT_SIZE, 1>,
                   DerivedDR::ColsAtCompileTime>::type
 drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
              const Eigen::MatrixBase<DerivedDR>& dR) {
@@ -622,7 +567,7 @@ drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
       THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE);
 
   typedef typename DerivedR::Scalar Scalar;
-  typedef typename Gradient<Eigen::Matrix<Scalar, QUAT_SIZE, 1>,
+  typedef typename drake::math::Gradient<Eigen::Matrix<Scalar, QUAT_SIZE, 1>,
                             DerivedDR::ColsAtCompileTime>::type ReturnType;
   typename DerivedDR::Index nq = dR.cols();
 
@@ -766,8 +711,8 @@ Eigen::Matrix<typename Derived::Scalar, 3, 3> vectorToSkewSymmetric(
 template <typename DerivedA, typename DerivedB>
 Eigen::Matrix<typename DerivedA::Scalar, 3, Eigen::Dynamic> dcrossProduct(
     const Eigen::MatrixBase<DerivedA>& a, const Eigen::MatrixBase<DerivedB>& b,
-    const typename Gradient<DerivedA, Eigen::Dynamic>::type& da,
-    const typename Gradient<DerivedB, Eigen::Dynamic>::type& db) {
+    const typename drake::math::Gradient<DerivedA, Eigen::Dynamic>::type& da,
+    const typename drake::math::Gradient<DerivedB, Eigen::Dynamic>::type& db) {
   Eigen::Matrix<typename DerivedA::Scalar, 3, Eigen::Dynamic> ret(3, da.cols());
   ret.noalias() = da.colwise().cross(b);
   ret.noalias() -= db.colwise().cross(a);
@@ -862,7 +807,7 @@ void angularvel2rpydotMatrix(
 template <typename DerivedRPY, typename DerivedE>
 void rpydot2angularvelMatrix(
     const Eigen::MatrixBase<DerivedRPY>& rpy, Eigen::MatrixBase<DerivedE>& E,
-    typename Gradient<DerivedE, RPY_SIZE, 1>::type* dE = nullptr) {
+    typename drake::math::Gradient<DerivedE, RPY_SIZE, 1>::type* dE = nullptr) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedRPY>,
                                            RPY_SIZE);
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedE>,
@@ -902,7 +847,7 @@ void rpydot2angularvel(
     const Eigen::MatrixBase<DerivedRPY>& rpy,
     const Eigen::MatrixBase<DerivedRPYdot>& rpydot,
     Eigen::MatrixBase<DerivedOMEGA>& omega,
-    typename Gradient<DerivedOMEGA, RPY_SIZE, 1>::type* domega = nullptr) {
+    typename drake::math::Gradient<DerivedOMEGA, RPY_SIZE, 1>::type* domega = nullptr) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedRPY>,
                                            RPY_SIZE);
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedRPYdot>,
@@ -1107,7 +1052,7 @@ typename TransformSpatial<DerivedM>::type transformSpatialMotion(
 
 template <typename Scalar, typename DerivedX, typename DerivedDT,
           typename DerivedDX>
-typename Gradient<DerivedX, DerivedDX::ColsAtCompileTime, 1>::type
+typename drake::math::Gradient<DerivedX, DerivedDX::ColsAtCompileTime, 1>::type
 dTransformSpatialMotion(const Eigen::Transform<Scalar, 3, Eigen::Isometry>& T,
                         const Eigen::MatrixBase<DerivedX>& X,
                         const Eigen::MatrixBase<DerivedDT>& dT,
@@ -1125,7 +1070,7 @@ dTransformSpatialMotion(const Eigen::Transform<Scalar, 3, Eigen::Isometry>& T,
   auto dR = getSubMatrixGradient<Eigen::Dynamic>(dT, rows, R_cols, T.Rows);
   auto dp = getSubMatrixGradient<Eigen::Dynamic>(dT, rows, p_cols, T.Rows);
 
-  typename Gradient<DerivedX, DerivedDX::ColsAtCompileTime, 1>::type ret(
+  typename drake::math::Gradient<DerivedX, DerivedDX::ColsAtCompileTime, 1>::type ret(
       X.size(), nq);
   std::array<int, 3> Xomega_rows = {{0, 1, 2}};
   std::array<int, 3> Xv_rows = {{3, 4, 5}};
@@ -1171,7 +1116,7 @@ typename TransformSpatial<DerivedF>::type transformSpatialForce(
 
 template <typename Scalar, typename DerivedX, typename DerivedDT,
           typename DerivedDX>
-typename Gradient<DerivedX, DerivedDX::ColsAtCompileTime>::type
+typename drake::math::Gradient<DerivedX, DerivedDX::ColsAtCompileTime>::type
 dTransformSpatialForce(const Eigen::Transform<Scalar, 3, Eigen::Isometry>& T,
                        const Eigen::MatrixBase<DerivedX>& X,
                        const Eigen::MatrixBase<DerivedDT>& dT,
@@ -1189,7 +1134,7 @@ dTransformSpatialForce(const Eigen::Transform<Scalar, 3, Eigen::Isometry>& T,
   auto dR = getSubMatrixGradient<Eigen::Dynamic>(dT, rows, R_cols, T.Rows);
   auto dp = getSubMatrixGradient<Eigen::Dynamic>(dT, rows, p_cols, T.Rows);
 
-  typename Gradient<DerivedX, DerivedDX::ColsAtCompileTime>::type ret(X.size(),
+  typename drake::math::Gradient<DerivedX, DerivedDX::ColsAtCompileTime>::type ret(X.size(),
                                                                       nq);
   std::array<int, 3> Xomega_rows = {{0, 1, 2}};
   std::array<int, 3> Xv_rows = {{3, 4, 5}};
@@ -1348,8 +1293,8 @@ template <typename DerivedA, typename DerivedB>
 Eigen::Matrix<typename DerivedA::Scalar, TWIST_SIZE, Eigen::Dynamic>
 dCrossSpatialMotion(
     const Eigen::MatrixBase<DerivedA>& a, const Eigen::MatrixBase<DerivedB>& b,
-    const typename Gradient<DerivedA, Eigen::Dynamic>::type& da,
-    const typename Gradient<DerivedB, Eigen::Dynamic>::type& db) {
+    const typename drake::math::Gradient<DerivedA, Eigen::Dynamic>::type& da,
+    const typename drake::math::Gradient<DerivedB, Eigen::Dynamic>::type& db) {
   Eigen::Matrix<typename DerivedA::Scalar, TWIST_SIZE, Eigen::Dynamic> ret(
       TWIST_SIZE, da.cols());
   ret.row(0) = -da.row(2) * b[1] + da.row(1) * b[2] - a[2] * db.row(1) +
@@ -1374,8 +1319,8 @@ template <typename DerivedA, typename DerivedB>
 Eigen::Matrix<typename DerivedA::Scalar, TWIST_SIZE, Eigen::Dynamic>
 dCrossSpatialForce(
     const Eigen::MatrixBase<DerivedA>& a, const Eigen::MatrixBase<DerivedB>& b,
-    const typename Gradient<DerivedA, Eigen::Dynamic>::type& da,
-    const typename Gradient<DerivedB, Eigen::Dynamic>::type& db) {
+    const typename drake::math::Gradient<DerivedA, Eigen::Dynamic>::type& da,
+    const typename drake::math::Gradient<DerivedB, Eigen::Dynamic>::type& db) {
   Eigen::Matrix<typename DerivedA::Scalar, TWIST_SIZE, Eigen::Dynamic> ret(
       TWIST_SIZE, da.cols());
   ret.row(0) = da.row(2) * b[1] - da.row(1) * b[2] + da.row(5) * b[4] -
@@ -1478,22 +1423,6 @@ typename DHomogTrans<DerivedDT>::type dHomogTransInv(
   return ret;
 }
 
-template <typename DerivedQ>
-Eigen::Matrix<typename DerivedQ::Scalar, 3, 1> quat2expmap(
-    const Eigen::MatrixBase<DerivedQ>& q) {
-  using namespace Eigen;
-  typedef typename DerivedQ::Scalar Scalar;
-  static_assert(
-      DerivedQ::RowsAtCompileTime == 4 && DerivedQ::ColsAtCompileTime == 1,
-      "Wrong size.");
-
-  Scalar t = sqrt(Scalar(1) - q(0) * q(0));
-  bool is_degenerate = (t * t < NumTraits<Scalar>::epsilon());
-  Scalar s(2);
-  if (!is_degenerate) s *= acos(q(0)) / t;
-  return s * q.template tail<3>();
-}
-
 template <typename Derived>
 Eigen::Matrix<typename Derived::Scalar, 3, 1> flipExpmap(
     const Eigen::MatrixBase<Derived>& expmap) {
@@ -1535,108 +1464,5 @@ Eigen::Matrix<typename Derived1::Scalar, 3, 1> unwrapExpmap(
     return expmap2_flip;
   } else {
     return expmap2;
-  }
-}
-
-// TODO(tkoolen): move to AutoDiffScalar.h?
-/** AutoDiffScalar overloads of round to mimic std::round from <cmath>.
- */
-template <typename DerType>
-double round(const Eigen::AutoDiffScalar<DerType>& x) {
-  return round(x.value());
-}
-
-// TODO(tkoolen): move to AutoDiffScalar.h?
-/** AutoDiffScalar overloads of floor to mimic std::round from <cmath>.
- */
-template <typename DerType>
-double floor(const Eigen::AutoDiffScalar<DerType>& x) {
-  return floor(x.value());
-}
-
-template <typename Derived1, typename Derived2>
-Eigen::Matrix<typename Derived1::Scalar, 3, 1> closestExpmap(
-    const Eigen::MatrixBase<Derived1>& expmap1,
-    const Eigen::MatrixBase<Derived2>& expmap2) {
-  using namespace Eigen;
-  using namespace std;
-  static_assert(
-      Derived1::RowsAtCompileTime == 3 && Derived1::ColsAtCompileTime == 1,
-      "Wrong size.");
-  static_assert(
-      Derived2::RowsAtCompileTime == 3 && Derived2::ColsAtCompileTime == 1,
-      "Wrong size.");
-  static_assert(
-      std::is_same<typename Derived1::Scalar, typename Derived2::Scalar>::value,
-      "Scalar types don't match.");
-  typedef typename Derived1::Scalar Scalar;
-  typedef typename NumTraits<Scalar>::Real Real;
-
-  Real expmap1_norm = expmap1.norm();
-  Real expmap2_norm = expmap2.norm();
-  Eigen::Matrix<Scalar, 3, 1> ret;
-  if (expmap2_norm < NumTraits<Scalar>::epsilon()) {
-    if (expmap1_norm > NumTraits<Scalar>::epsilon()) {
-      auto expmap1_axis = (expmap1 / expmap1_norm).eval();
-      auto expmap1_round = round(expmap1_norm / (2 * M_PI));
-      return expmap1_axis * expmap1_round * 2 * M_PI;
-    } else {
-      return expmap2;
-    }
-  } else {
-    auto expmap2_axis = (expmap2 / expmap2_norm).eval();
-    auto expmap2_closest_k =
-        ((expmap2_axis.transpose() * expmap1).value() - expmap2_norm) /
-        (2 * M_PI);
-    auto expmap2_closest_k1 = floor(expmap2_closest_k);
-    auto expmap2_closest_k2 = expmap2_closest_k1 + 1.0;
-    auto expmap2_closest1 =
-        (expmap2 + 2 * expmap2_closest_k1 * M_PI * expmap2_axis).eval();
-    auto expmap2_closest2 =
-        (expmap2 + 2 * expmap2_closest_k2 * M_PI * expmap2_axis).eval();
-    if ((expmap2_closest1 - expmap1).norm() <
-        (expmap2_closest2 - expmap1).norm()) {
-      return expmap2_closest1;
-    } else {
-      return expmap2_closest2;
-    }
-  }
-}
-
-template <typename DerivedQ, typename DerivedE>
-void quat2expmapSequence(const Eigen::MatrixBase<DerivedQ>& quat,
-                         const Eigen::MatrixBase<DerivedQ>& quat_dot,
-                         Eigen::MatrixBase<DerivedE>& expmap,
-                         Eigen::MatrixBase<DerivedE>& expmap_dot) {
-  using namespace Eigen;
-  static_assert(DerivedQ::RowsAtCompileTime == 4, "Wrong size.");
-  static_assert(DerivedE::RowsAtCompileTime == 3, "Wrong size.");
-  static_assert(
-      std::is_same<typename DerivedQ::Scalar, typename DerivedE::Scalar>::value,
-      "Scalar types don't match.");
-  typedef typename DerivedQ::Scalar Scalar;
-
-  DRAKE_ASSERT(quat.cols() == quat_dot.cols() &&
-               "number of columns of quat doesn't match quat_dot");
-  Index N = quat.cols();
-
-  typedef AutoDiffScalar<Matrix<Scalar, 1, 1>> ADScalar;
-  auto quat_autodiff = quat.template cast<ADScalar>().eval();
-  for (int i = 0; i < quat.size(); i++) {
-    quat_autodiff(i).derivatives()(0) = quat_dot(i);
-  }
-
-  expmap.resize(3, N);
-  expmap_dot.resize(3, N);
-  Matrix<ADScalar, 3, 1> expmap_autodiff_previous;
-  for (int i = 0; i < N; i++) {
-    auto expmap_autodiff = quat2expmap(quat_autodiff.col(i));
-    if (i >= 1) {
-      expmap_autodiff =
-          closestExpmap(expmap_autodiff_previous, expmap_autodiff);
-    }
-    expmap.col(i) = autoDiffToValueMatrix(expmap_autodiff);
-    expmap_dot.col(i) = autoDiffToGradientMatrix(expmap_autodiff);
-    expmap_autodiff_previous = expmap_autodiff;
   }
 }

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -174,10 +174,10 @@ DRAKEGEOMETRYUTIL_EXPORT Eigen::Vector3d uniformlyRandomRPY(
 template <typename Derived>
 void normalizeVec(
     const Eigen::MatrixBase<Derived>& x, typename Derived::PlainObject& x_norm,
-    typename drake::math::Gradient<Derived, Derived::RowsAtCompileTime, 1>::type* dx_norm =
-        nullptr,
-    typename drake::math::Gradient<Derived, Derived::RowsAtCompileTime, 2>::type* ddx_norm =
-        nullptr) {
+    typename drake::math::Gradient<Derived, Derived::RowsAtCompileTime,
+                                   1>::type* dx_norm = nullptr,
+    typename drake::math::Gradient<Derived, Derived::RowsAtCompileTime,
+                                   2>::type* ddx_norm = nullptr) {
   typename Derived::Scalar xdotx = x.squaredNorm();
   typename Derived::Scalar norm_x = sqrt(xdotx);
   x_norm = x / norm_x;
@@ -291,7 +291,7 @@ Eigen::Vector4d axis2quat(const Eigen::MatrixBase<Derived>& a) {
   auto c = std::cos(arg);
   auto s = std::sin(arg);
   Eigen::Vector4d ret;
-  ret << c, s* axis;
+  ret << c, s * axis;
   return ret;
 }
 
@@ -308,9 +308,9 @@ Eigen::Matrix<typename Derived::Scalar, 3, 3> axis2rotmat(
   auto stheta = std::sin(theta);
   auto c = 1 - ctheta;
   Eigen::Matrix<typename Derived::Scalar, 3, 3> R;
-  R << ctheta + x* x* c, x* y* c - z* stheta, x* z* c + y* stheta,
-      y* x* c + z* stheta, ctheta + y* y* c, y* z* c - x* stheta,
-      z* x* c - y* stheta, z* y* c + x* stheta, ctheta + z* z* c;
+  R << ctheta + x * x * c, x * y * c - z * stheta, x * z * c + y * stheta,
+      y * x * c + z * stheta, ctheta + y * y * c, y * z * c - x * stheta,
+      z * x * c - y * stheta, z * y * c + x * stheta, ctheta + z * z * c;
 
   return R;
 }
@@ -484,13 +484,13 @@ Eigen::Matrix<typename Derived::Scalar, 3, 3> rpy2rotmat(
  */
 template <typename Derived>
 typename drake::math::Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
-                  QUAT_SIZE>::type
+                               QUAT_SIZE>::type
 dquat2rotmat(const Eigen::MatrixBase<Derived>& q) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
                                            QUAT_SIZE);
 
   typename drake::math::Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
-                    QUAT_SIZE>::type ret;
+                                 QUAT_SIZE>::type ret;
   typename Eigen::MatrixBase<Derived>::PlainObject qtilde;
   typename drake::math::Gradient<Derived, QUAT_SIZE>::type dqtilde;
   normalizeVec(q, qtilde, &dqtilde);
@@ -509,8 +509,9 @@ dquat2rotmat(const Eigen::MatrixBase<Derived>& q) {
 }
 
 template <typename DerivedR, typename DerivedDR>
-typename drake::math::Gradient<Eigen::Matrix<typename DerivedR::Scalar, RPY_SIZE, 1>,
-                  DerivedDR::ColsAtCompileTime>::type
+typename drake::math::Gradient<
+    Eigen::Matrix<typename DerivedR::Scalar, RPY_SIZE, 1>,
+    DerivedDR::ColsAtCompileTime>::type
 drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
             const Eigen::MatrixBase<DerivedDR>& dR) {
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedR>,
@@ -522,7 +523,8 @@ drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
   typename DerivedDR::Index nq = dR.cols();
   typedef typename DerivedR::Scalar Scalar;
   typedef typename drake::math::Gradient<Eigen::Matrix<Scalar, RPY_SIZE, 1>,
-                            DerivedDR::ColsAtCompileTime>::type ReturnType;
+                                         DerivedDR::ColsAtCompileTime>::type
+      ReturnType;
   ReturnType drpy(RPY_SIZE, nq);
 
   auto dR11_dq =
@@ -556,8 +558,9 @@ drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
 }
 
 template <typename DerivedR, typename DerivedDR>
-typename drake::math::Gradient<Eigen::Matrix<typename DerivedR::Scalar, QUAT_SIZE, 1>,
-                  DerivedDR::ColsAtCompileTime>::type
+typename drake::math::Gradient<
+    Eigen::Matrix<typename DerivedR::Scalar, QUAT_SIZE, 1>,
+    DerivedDR::ColsAtCompileTime>::type
 drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
              const Eigen::MatrixBase<DerivedDR>& dR) {
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedR>,
@@ -568,7 +571,8 @@ drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
 
   typedef typename DerivedR::Scalar Scalar;
   typedef typename drake::math::Gradient<Eigen::Matrix<Scalar, QUAT_SIZE, 1>,
-                            DerivedDR::ColsAtCompileTime>::type ReturnType;
+                                         DerivedDR::ColsAtCompileTime>::type
+      ReturnType;
   typename DerivedDR::Index nq = dR.cols();
 
   auto dR11_dq =
@@ -820,7 +824,7 @@ void rpydot2angularvelMatrix(
   Scalar sy = sin(y);
   Scalar cy = cos(y);
 
-  E << cp* cy, -sy, 0.0, cp* sy, cy, 0.0, -sp, 0.0, 1.0;
+  E << cp * cy, -sy, 0.0, cp * sy, cy, 0.0, -sp, 0.0, 1.0;
   if (dE) {
     (*dE) << 0.0, -sp * cy, -cp * sy, 0.0, -sp * sy, cp * cy, 0.0, -cp, 0.0,
         0.0, 0.0, -cy, 0.0, 0.0, -sy, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -847,7 +851,8 @@ void rpydot2angularvel(
     const Eigen::MatrixBase<DerivedRPY>& rpy,
     const Eigen::MatrixBase<DerivedRPYdot>& rpydot,
     Eigen::MatrixBase<DerivedOMEGA>& omega,
-    typename drake::math::Gradient<DerivedOMEGA, RPY_SIZE, 1>::type* domega = nullptr) {
+    typename drake::math::Gradient<DerivedOMEGA, RPY_SIZE, 1>::type* domega =
+        nullptr) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedRPY>,
                                            RPY_SIZE);
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedRPYdot>,
@@ -893,11 +898,11 @@ void cylindrical2cartesian(const Eigen::Matrix<Scalar, 3, 1>& m_cylinder_axis,
   double theta_dot = v_cylinder(1);
   double height_dot = v_cylinder(2);
   Eigen::Matrix<Scalar, 3, 1> x_pos_cartesian;
-  x_pos_cartesian << radius* c_theta, radius* s_theta, height;
+  x_pos_cartesian << radius * c_theta, radius * s_theta, height;
   x_pos_cartesian = R_cylinder2cartesian * x_pos_cartesian + cylinder_origin;
   Eigen::Matrix<Scalar, 3, 1> v_pos_cartesian;
-  v_pos_cartesian << radius * -s_theta* theta_dot + radius_dot* c_theta,
-      radius* c_theta* theta_dot + radius_dot* s_theta, height_dot;
+  v_pos_cartesian << radius * -s_theta * theta_dot + radius_dot * c_theta,
+      radius * c_theta * theta_dot + radius_dot * s_theta, height_dot;
   v_pos_cartesian = R_cylinder2cartesian * v_pos_cartesian;
   Eigen::Vector3d x_rpy_cylinder = x_cylinder.block(3, 0, 3, 1);
   Eigen::Matrix<Scalar, 3, 3> R_tangent = rpy2rotmat(x_rpy_cylinder);
@@ -1070,8 +1075,8 @@ dTransformSpatialMotion(const Eigen::Transform<Scalar, 3, Eigen::Isometry>& T,
   auto dR = getSubMatrixGradient<Eigen::Dynamic>(dT, rows, R_cols, T.Rows);
   auto dp = getSubMatrixGradient<Eigen::Dynamic>(dT, rows, p_cols, T.Rows);
 
-  typename drake::math::Gradient<DerivedX, DerivedDX::ColsAtCompileTime, 1>::type ret(
-      X.size(), nq);
+  typename drake::math::Gradient<DerivedX, DerivedDX::ColsAtCompileTime,
+                                 1>::type ret(X.size(), nq);
   std::array<int, 3> Xomega_rows = {{0, 1, 2}};
   std::array<int, 3> Xv_rows = {{3, 4, 5}};
   for (int col = 0; col < X.cols(); col++) {
@@ -1134,8 +1139,8 @@ dTransformSpatialForce(const Eigen::Transform<Scalar, 3, Eigen::Isometry>& T,
   auto dR = getSubMatrixGradient<Eigen::Dynamic>(dT, rows, R_cols, T.Rows);
   auto dp = getSubMatrixGradient<Eigen::Dynamic>(dT, rows, p_cols, T.Rows);
 
-  typename drake::math::Gradient<DerivedX, DerivedDX::ColsAtCompileTime>::type ret(X.size(),
-                                                                      nq);
+  typename drake::math::Gradient<DerivedX, DerivedDX::ColsAtCompileTime>::type
+      ret(X.size(), nq);
   std::array<int, 3> Xomega_rows = {{0, 1, 2}};
   std::array<int, 3> Xv_rows = {{3, 4, 5}};
   for (int col = 0; col < X.cols(); col++) {

--- a/drake/util/drakeGradientUtil.h
+++ b/drake/util/drakeGradientUtil.h
@@ -1,12 +1,20 @@
+/// @file
+/// THIS FILE IS DEPRECATED.
+/// Its contents are moving into drake/math.
+
 #pragma once
+
+#include <array>
+
+#include <cmath>
+#include <stdexcept>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>
-#include <cmath>
-#include <vector>
-#include <array>
-#include <stdexcept>
+
+#include "drake/math/gradient.h"
 
 #include "drake/common/drake_assert.h"
 
@@ -18,30 +26,6 @@ std::array<int, Size> intRange(int start) {
   }
   return ret;
 }
-
-/*
- * Recursively defined template specifying a matrix type of the correct size for
- * a gradient of a matrix function with respect to Nq variables, of any order.
- */
-template <typename Derived, int Nq, int DerivativeOrder = 1>
-struct Gradient {
-  typedef typename Eigen::Matrix<
-      typename Derived::Scalar,
-      ((Derived::SizeAtCompileTime == Eigen::Dynamic || Nq == Eigen::Dynamic)
-           ? Eigen::Dynamic
-           : Gradient<Derived, Nq,
-                      DerivativeOrder - 1>::type::SizeAtCompileTime),
-      Nq> type;
-};
-
-/*
- * Base case for recursively defined gradient template.
- */
-template <typename Derived, int Nq>
-struct Gradient<Derived, Nq, 1> {
-  typedef typename Eigen::Matrix<typename Derived::Scalar,
-                                 Derived::SizeAtCompileTime, Nq> type;
-};
 
 /*
  * Output type of matGradMultMat
@@ -94,21 +78,6 @@ struct GetSubMatrixGradientSingleElement {
                                 ((QSubvectorSize == Eigen::Dynamic)
                                      ? Derived::ColsAtCompileTime
                                      : QSubvectorSize)> type;
-};
-
-template <typename Derived>
-struct AutoDiffToValueMatrix {
-  typedef typename Eigen::Matrix<typename Derived::Scalar::Scalar,
-                                 Derived::RowsAtCompileTime,
-                                 Derived::ColsAtCompileTime> type;
-};
-
-template <typename Derived>
-struct AutoDiffToGradientMatrix {
-  typedef typename Gradient<
-      Eigen::Matrix<typename Derived::Scalar::Scalar,
-                    Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>,
-      Eigen::Dynamic>::type type;
 };
 
 /*
@@ -323,57 +292,6 @@ void setSubMatrixGradient(
                                        q_subvector_size) = dM_submatrix;
 }
 
-template <typename Derived>
-typename AutoDiffToValueMatrix<Derived>::type autoDiffToValueMatrix(
-    const Eigen::MatrixBase<Derived>& auto_diff_matrix) {
-  typename AutoDiffToValueMatrix<Derived>::type ret(auto_diff_matrix.rows(),
-                                                    auto_diff_matrix.cols());
-  for (int i = 0; i < auto_diff_matrix.rows(); i++) {
-    for (int j = 0; j < auto_diff_matrix.cols(); ++j) {
-      ret(i, j) = auto_diff_matrix(i, j).value();
-    }
-  }
-  return ret;
-}
-
-template <typename Derived>
-typename AutoDiffToGradientMatrix<Derived>::type autoDiffToGradientMatrix(
-    const Eigen::MatrixBase<Derived>& auto_diff_matrix,
-    int num_variables = Eigen::Dynamic) {
-  int num_variables_from_matrix = 0;
-  for (int i = 0; i < auto_diff_matrix.size(); ++i) {
-    num_variables_from_matrix =
-        std::max(num_variables_from_matrix,
-                 static_cast<int>(auto_diff_matrix(i).derivatives().size()));
-  }
-  if (num_variables == Eigen::Dynamic) {
-    num_variables = num_variables_from_matrix;
-  } else if (num_variables_from_matrix != 0 &&
-             num_variables_from_matrix != num_variables) {
-    std::stringstream buf;
-    buf << "Input matrix has derivatives w.r.t " << num_variables_from_matrix
-        << " variables, whereas num_variables is " << num_variables << ".\n";
-    buf << "Either num_variables_from_matrix should be zero, or it should "
-           "match num_variables.";
-    throw std::runtime_error(buf.str());
-  }
-
-  typename AutoDiffToGradientMatrix<Derived>::type gradient(
-      auto_diff_matrix.size(), num_variables);
-  for (int row = 0; row < auto_diff_matrix.rows(); row++) {
-    for (int col = 0; col < auto_diff_matrix.cols(); col++) {
-      auto gradient_row =
-          gradient.row(row + col * auto_diff_matrix.rows()).transpose();
-      if (auto_diff_matrix(row, col).derivatives().size() == 0) {
-        gradient_row.setZero();
-      } else {
-        gradient_row = auto_diff_matrix(row, col).derivatives();
-      }
-    }
-  }
-  return gradient;
-}
-
 template <typename DerivedGradient, typename DerivedAutoDiff>
 void gradientMatrixToAutoDiff(
     const Eigen::MatrixBase<DerivedGradient>& gradient,
@@ -410,7 +328,7 @@ struct ResizeDerivativesToMatchScalarImpl<Derived,
     }
   }
 };
-}
+}  // namespace internal
 
 /** Resize derivatives vector of each element of a matrix to to match the size
  * of the derivatives vector of a given scalar.
@@ -430,4 +348,4 @@ void resizeDerivativesToMatchScalar(Eigen::MatrixBase<Derived>& mat,
   internal::ResizeDerivativesToMatchScalarImpl<
       Derived, typename Derived::Scalar>::run(mat, scalar);
 }
-}
+}  // namespace Drake

--- a/drake/util/drakeMexUtil.h
+++ b/drake/util/drakeMexUtil.h
@@ -18,7 +18,13 @@
  */
 #include <unsupported/Eigen/AutoDiff>
 #include <Eigen/src/SparseCore/SparseMatrix.h>
+
+#include "drake/math/autodiff.h"
 #include "drake/util/drakeGradientUtil.h"
+
+using drake::math::autoDiffToValueMatrix;
+using drake::math::autoDiffToGradientMatrix;
+using drake::math::Gradient;
 
 #undef DLLEXPORT
 #if defined(WIN32) || defined(WIN64)

--- a/drake/util/expmap2quatImplmex.cpp
+++ b/drake/util/expmap2quatImplmex.cpp
@@ -1,13 +1,19 @@
 #include <Eigen/Core>
+
+#include "drake/math/autodiff.h"
+#include "drake/math/expmap.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"
-#include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/makeFunction.h"
 #include "drake/core/Gradient.h"
 
 using namespace std;
 using namespace Eigen;
 using namespace Drake;
+
+using drake::math::autoDiffToValueMatrix;
+using drake::math::autoDiffToGradientMatrix;
+using drake::math::expmap2quat;
 
 pair<Vector4d, typename Gradient<Vector4d, 3>::type> expmap2quatWithGradient(
     const MatrixBase<Map<const Vector3d>>& expmap) {

--- a/drake/util/flipExpmapmex.cpp
+++ b/drake/util/flipExpmapmex.cpp
@@ -1,4 +1,6 @@
 #include <Eigen/Core>
+
+#include "drake/math/autodiff.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"
 #include "drake/util/drakeGeometryUtil.h"
@@ -8,6 +10,9 @@
 using namespace std;
 using namespace Eigen;
 using namespace Drake;
+
+using drake::math::autoDiffToValueMatrix;
+using drake::math::autoDiffToGradientMatrix;
 
 pair<Vector3d, typename Gradient<Vector3d, 3>::type> quat2expmapWithGradient(
     const MatrixBase<Map<const Vector3d>>& expmap) {

--- a/drake/util/quat2expmapSequencemex.cpp
+++ b/drake/util/quat2expmapSequencemex.cpp
@@ -1,7 +1,7 @@
 #include <mex.h>
 
+#include "drake/math/expmap.h"
 #include "drake/util/drakeMexUtil.h"
-#include "drake/util/drakeGeometryUtil.h"
 
 using namespace std;
 using namespace Eigen;
@@ -29,7 +29,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   memcpy(quat_dot.data(), mxGetPr(prhs[1]), sizeof(double) * 4 * N);
   Matrix<double, 3, Dynamic> expmap(3, N);
   Matrix<double, 3, Dynamic> expmap_dot(3, N);
-  quat2expmapSequence(quat, quat_dot, expmap, expmap_dot);
+  drake::math::quat2expmapSequence(quat, quat_dot, expmap, expmap_dot);
   plhs[0] = eigenToMatlab(expmap);
   plhs[1] = eigenToMatlab(expmap_dot);
 }

--- a/drake/util/quat2expmapmex.cpp
+++ b/drake/util/quat2expmapmex.cpp
@@ -1,4 +1,6 @@
 #include <Eigen/Core>
+
+#include "drake/math/expmap.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"
 #include "drake/util/drakeGeometryUtil.h"
@@ -12,14 +14,14 @@ using namespace Drake;
 pair<Vector3d, typename Gradient<Vector3d, 4>::type> quat2expmapWithGradient(
     const MatrixBase<Map<const Vector4d>>& quat) {
   auto quat_autodiff = initializeAutoDiff(quat);
-  auto expmap_autodiff = quat2expmap(quat_autodiff);
+  auto expmap_autodiff = drake::math::quat2expmap(quat_autodiff);
   return make_pair(autoDiffToValueMatrix(expmap_autodiff),
                    autoDiffToGradientMatrix(expmap_autodiff));
 }
 
 void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   if (nlhs == 1) {
-    auto func = make_function(&quat2expmap<Map<const Vector4d>>);
+    auto func = make_function(&drake::math::quat2expmap<Map<const Vector4d>>);
     mexCallFunction(nlhs, plhs, nrhs, prhs, true, func);
   } else if (nlhs == 2) {
     auto func = make_function(&quat2expmapWithGradient);

--- a/drake/util/test/testDrakeGeometryUtil.cpp
+++ b/drake/util/test/testDrakeGeometryUtil.cpp
@@ -1,6 +1,8 @@
-#include <Eigen/Core>
 #include <cmath>
 #include <iostream>
+
+#include <Eigen/Core>
+
 #include "drake/core/Gradient.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/eigen_matrix_compare.h"
@@ -18,13 +20,10 @@ using Eigen::Quaterniond;
 using Eigen::Translation3d;
 using std::default_random_engine;
 using drake::util::MatrixCompareType;
-using Drake::initializeAutoDiff;
 
 namespace drake {
 namespace util {
 namespace {
-
-void testExpmap2quat(const Vector4d &quat);
 
 GTEST_TEST(DrakeGeometryUtilTest, RotationConversionFunctions) {
   int ntests = 1;
@@ -71,16 +70,6 @@ GTEST_TEST(DrakeGeometryUtilTest, RotationConversionFunctions) {
     Vector3d rpy_back = axis2rpy(axis);
     EXPECT_TRUE(
         CompareMatrices(rpy, rpy_back, 1e-6, MatrixCompareType::absolute));
-  }
-  // expmap2quat, quat2expmap
-  Vector4d quat_degenerate = Vector4d::Zero();
-  quat_degenerate(0) = 1.0;
-  testExpmap2quat(quat_degenerate);
-  quat_degenerate(0) = -1.0;
-  testExpmap2quat(quat_degenerate);
-  for (int i = 0; i < ntests; i++) {
-    Vector4d quat = uniformlyRandomQuat(generator);
-    testExpmap2quat(quat);
   }
   // quat2eigenQuaternion
   Vector4d quat = uniformlyRandomQuat(generator);
@@ -241,20 +230,6 @@ GTEST_TEST(DrakeGeometryUtilTest, drpy2rotmat) {
       valuecheck(dR(j, i), dR_num(j, i), 1e-3);
     }
   }
-}
-
-void testExpmap2quat(const Vector4d &quat) {
-  auto quat_autodiff = initializeAutoDiff(quat);
-  auto expmap_autodiff = quat2expmap(quat_autodiff);
-  auto expmap = autoDiffToValueMatrix(expmap_autodiff);
-  auto expmap_grad = autoDiffToGradientMatrix(expmap_autodiff);
-  auto quat_back_autodiff = expmap2quat(initializeAutoDiff(expmap));
-  auto quat_back = autoDiffToValueMatrix(quat_back_autodiff);
-  auto quat_back_grad = autoDiffToGradientMatrix(quat_back_autodiff);
-  valuecheck(std::abs((quat.transpose() * quat_back).value()), 1.0, 1e-8);
-  Matrix3d identity = Matrix3d::Identity();
-  EXPECT_TRUE(CompareMatrices((expmap_grad * quat_back_grad).eval(), identity,
-                              1e-10, MatrixCompareType::absolute));
 }
 
 }  // namespace

--- a/drake/util/test/testGeometryConversionFunctionsmex.cpp
+++ b/drake/util/test/testGeometryConversionFunctionsmex.cpp
@@ -1,8 +1,12 @@
+#include "drake/math/autodiff.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeMexUtil.h"
 #include "drake/core/Gradient.h"
 
 using namespace Eigen;
+
+using drake::math::autoDiffToValueMatrix;
+using drake::math::autoDiffToGradientMatrix;
 
 void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   if (nrhs != 2 || nlhs != 12) {

--- a/drake/util/test/testQuatmex.cpp
+++ b/drake/util/test/testQuatmex.cpp
@@ -1,11 +1,17 @@
 #include <mex.h>
 
 #include <tuple>
+
+#include "drake/math/autodiff.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/core/Gradient.h"
+
 using namespace Eigen;
 using namespace std;
 using namespace Drake;
+
+using drake::math::autoDiffToGradientMatrix;
+using drake::math::autoDiffToValueMatrix;
 
 void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   if (nrhs != 5) {

--- a/drake/util/unwrapExpmapmex.cpp
+++ b/drake/util/unwrapExpmapmex.cpp
@@ -1,4 +1,6 @@
 #include <Eigen/Core>
+
+#include "drake/math/autodiff.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"
 #include "drake/util/drakeGeometryUtil.h"
@@ -8,6 +10,9 @@
 using namespace std;
 using namespace Eigen;
 using namespace Drake;
+
+using drake::math::autoDiffToValueMatrix;
+using drake::math::autoDiffToGradientMatrix;
 
 // note: gradient only w.r.t. expmap2...
 pair<Vector3d, typename Gradient<Vector3d, 3>::type> unwrapExpmapWithGradient(


### PR DESCRIPTION
The util libraries are broadly #included throughout Drake, and thus contribute significantly to compile times, even though most individual functions in the libraries are used only a few places.

To establish a beachhead, this PR takes the smallest self-contained chunk I could find: the exponential-map functions.  It does not fix all the existing style violations in those functions.  It adds a little test coverage, but nothing comprehensive.  It does apply proper namespaces.

It's a lot of lines but hopefully low cognitive load per line.  The only substantive new code is in `autodiff_test.cc`.

+@jwnimmer-tri for feature review, since we talked about this f2f, and @ggould-tri for platform review because it's about to be Friday.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2636)
<!-- Reviewable:end -->
