### PR TITLE
Deprecated compile test

### DIFF
--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(nice_type_name_test nice_type_name_test.cc)
 target_link_libraries(nice_type_name_test drakeCommon ${GTEST_BOTH_LIBRARIES})
 add_test(NAME nice_type_name_test COMMAND nice_type_name_test)
 
+# Adds "drake_assert.h" unit testing.
 add_executable(drake_assert_test_default drake_assert_test.cc)
 target_link_libraries(drake_assert_test_default drakeCommon ${GTEST_BOTH_LIBRARIES})
 add_test(NAME drake_assert_test_default COMMAND drake_assert_test_default)
@@ -17,10 +18,6 @@ add_executable(drake_assert_test_disabled drake_assert_test.cc)
 target_compile_definitions(drake_assert_test_disabled PRIVATE DRAKE_DISABLE_ASSERTS)
 target_link_libraries(drake_assert_test_disabled drakeCommon ${GTEST_BOTH_LIBRARIES})
 add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disabled)
-
-add_executable(drake_deprecated_test drake_deprecated_test.cc)
-target_link_libraries(drake_deprecated_test drakeCommon ${GTEST_BOTH_LIBRARIES})
-add_test(NAME drake_deprecated_test COMMAND drake_deprecated_test)
 
 # The entire block of CMake build rules and CTests exists to confirm that the
 # disarmed DRAKE_ASSERT still yields compilation errors.
@@ -41,9 +38,9 @@ add_test(NAME drake_deprecated_test COMMAND drake_deprecated_test)
 #
 # - This first version of the test should trivially pass.
 add_executable(
-  drake_assert_test_compile 
+  drake_assert_test_compile
   drake_assert_test_compile.cc)
-add_test(NAME 
+add_test(NAME
   drake_assert_test_compile COMMAND
   drake_assert_test_compile)
 # - This second version of the test should yield a compile error, as follows:
@@ -53,18 +50,54 @@ add_test(NAME
 #  - add_test: Add a test that asks cmake to compile the executable.
 #  - set_test_properties: The test passes if and only if the exitcode was 1.
 add_executable(
-  drake_assert_test_nocompile 
+  drake_assert_test_nocompile
   drake_assert_test_compile.cc)
 target_compile_definitions(
   drake_assert_test_nocompile PRIVATE DRAKE_ASSERT_TEST_COMPILE_ERROR)
 set_target_properties(
   drake_assert_test_nocompile
   PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
-add_test(NAME 
+add_test(NAME
   drake_assert_test_nocompile
-  COMMAND ${CMAKE_COMMAND} --build . --target 
-  drake_assert_test_nocompile --config $<CONFIGURATION> 
+  COMMAND ${CMAKE_COMMAND} --build . --target
+  drake_assert_test_nocompile --config $<CONFIGURATION>
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(
   drake_assert_test_nocompile
   PROPERTIES WILL_FAIL TRUE)
+
+# Adds "drake_deprecated.h" unit testing.
+add_executable(drake_deprecated_test drake_deprecated_test.cc)
+target_link_libraries(drake_deprecated_test drakeCommon ${GTEST_BOTH_LIBRARIES})
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(
+    drake_deprecated_test
+    PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
+endif()
+add_test(NAME drake_deprecated_test COMMAND drake_deprecated_test)
+
+# This block proves that DRAKE_DEPRECATED does cause deprecation warnings,
+# by promoting that warning to an error and looking for compile failure,
+# similar to the assert "nocompile" test above.
+add_executable(
+  drake_deprecated_test_nocompile
+  drake_deprecated_test.cc)
+target_link_libraries(
+  drake_deprecated_test_nocompile
+  drakeCommon ${GTEST_BOTH_LIBRARIES})
+set_target_properties(
+  drake_deprecated_test_nocompile
+  PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(
+    drake_deprecated_test_nocompile
+    PROPERTIES COMPILE_FLAGS "-Werror=deprecated-declarations")
+  add_test(NAME
+    drake_deprecated_test_nocompile
+    COMMAND ${CMAKE_COMMAND} --build . --target
+    drake_deprecated_test_nocompile --config $<CONFIGURATION>
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  set_tests_properties(
+    drake_deprecated_test_nocompile
+    PROPERTIES WILL_FAIL TRUE)
+endif()

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -1,28 +1,26 @@
 # Build tests for Drake common utilities.
-#
-if(GTEST_FOUND)
-  add_executable(nice_type_name_test nice_type_name_test.cc)
-  target_link_libraries(nice_type_name_test drakeCommon ${GTEST_BOTH_LIBRARIES})
-  add_test(NAME nice_type_name_test COMMAND nice_type_name_test)
 
-  add_executable(drake_assert_test_default drake_assert_test.cc)
-  target_link_libraries(drake_assert_test_default drakeCommon ${GTEST_BOTH_LIBRARIES})
-  add_test(NAME drake_assert_test_default COMMAND drake_assert_test_default)
-  # Same, but with assertions forced enabled.
-  add_executable(drake_assert_test_enabled drake_assert_test.cc)
-  target_compile_definitions(drake_assert_test_enabled PRIVATE DRAKE_ENABLE_ASSERTS)
-  target_link_libraries(drake_assert_test_enabled drakeCommon ${GTEST_BOTH_LIBRARIES})
-  add_test(NAME drake_assert_test_enabled COMMAND drake_assert_test_enabled)
-  # Same, but with assertions forced disabled.
-  add_executable(drake_assert_test_disabled drake_assert_test.cc)
-  target_compile_definitions(drake_assert_test_disabled PRIVATE DRAKE_DISABLE_ASSERTS)
-  target_link_libraries(drake_assert_test_disabled drakeCommon ${GTEST_BOTH_LIBRARIES})
-  add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disabled)
+add_executable(nice_type_name_test nice_type_name_test.cc)
+target_link_libraries(nice_type_name_test drakeCommon ${GTEST_BOTH_LIBRARIES})
+add_test(NAME nice_type_name_test COMMAND nice_type_name_test)
 
-  add_executable(drake_deprecated_test drake_deprecated_test.cc)
-  target_link_libraries(drake_deprecated_test drakeCommon ${GTEST_BOTH_LIBRARIES})
-  add_test(NAME drake_deprecated_test COMMAND drake_deprecated_test)
-endif()
+add_executable(drake_assert_test_default drake_assert_test.cc)
+target_link_libraries(drake_assert_test_default drakeCommon ${GTEST_BOTH_LIBRARIES})
+add_test(NAME drake_assert_test_default COMMAND drake_assert_test_default)
+# Same, but with assertions forced enabled.
+add_executable(drake_assert_test_enabled drake_assert_test.cc)
+target_compile_definitions(drake_assert_test_enabled PRIVATE DRAKE_ENABLE_ASSERTS)
+target_link_libraries(drake_assert_test_enabled drakeCommon ${GTEST_BOTH_LIBRARIES})
+add_test(NAME drake_assert_test_enabled COMMAND drake_assert_test_enabled)
+# Same, but with assertions forced disabled.
+add_executable(drake_assert_test_disabled drake_assert_test.cc)
+target_compile_definitions(drake_assert_test_disabled PRIVATE DRAKE_DISABLE_ASSERTS)
+target_link_libraries(drake_assert_test_disabled drakeCommon ${GTEST_BOTH_LIBRARIES})
+add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disabled)
+
+add_executable(drake_deprecated_test drake_deprecated_test.cc)
+target_link_libraries(drake_deprecated_test drakeCommon ${GTEST_BOTH_LIBRARIES})
+add_test(NAME drake_deprecated_test COMMAND drake_deprecated_test)
 
 # The entire block of CMake build rules and CTests exists to confirm that the
 # disarmed DRAKE_ASSERT still yields compilation errors.

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -70,6 +70,7 @@ set_tests_properties(
 add_executable(drake_deprecated_test drake_deprecated_test.cc)
 target_link_libraries(drake_deprecated_test drakeCommon ${GTEST_BOTH_LIBRARIES})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # Remove spurious warnings from the default build output.
   set_target_properties(
     drake_deprecated_test
     PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
@@ -78,17 +79,19 @@ add_test(NAME drake_deprecated_test COMMAND drake_deprecated_test)
 
 # This block proves that DRAKE_DEPRECATED does cause deprecation warnings,
 # by promoting that warning to an error and looking for compile failure,
-# similar to the assert "nocompile" test above.
-add_executable(
-  drake_deprecated_test_nocompile
-  drake_deprecated_test.cc)
-target_link_libraries(
-  drake_deprecated_test_nocompile
-  drakeCommon ${GTEST_BOTH_LIBRARIES})
-set_target_properties(
-  drake_deprecated_test_nocompile
-  PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+# similar to the assert "nocompile" test above.  We cannot run this test
+# on Windows, because drake_deprecated.h forces C4996 to be a warning; as
+# the code exists now, we cannot promote to an error via the command line.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_executable(
+    drake_deprecated_test_nocompile
+    drake_deprecated_test.cc)
+  target_link_libraries(
+    drake_deprecated_test_nocompile
+    drakeCommon ${GTEST_BOTH_LIBRARIES})
+  set_target_properties(
+    drake_deprecated_test_nocompile
+    PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
   set_target_properties(
     drake_deprecated_test_nocompile
     PROPERTIES COMPILE_FLAGS "-Werror=deprecated-declarations")

--- a/drake/common/test/drake_deprecated_test.cc
+++ b/drake/common/test/drake_deprecated_test.cc
@@ -2,14 +2,9 @@
 
 #include "gtest/gtest.h"
 
-/* This test only verifies that the Drake build can still succeed if a
-deprecated class or function is in use.
-
-Note: It would be possible to test whether warnings are actually issued by
-building this test with compiler flags making the deprecated warning an error
-(-Werror=deprecated-declarations for gcc and clang), then using the technique
-used for drake_assert_test_compile to check for failure to compile. We are not
-doing that here. */
+/* This test verifies that the Drake build can still succeed if a deprecated
+class or function is in use, and (through CMakeLists.txt rules) that when
+deprecation warnings are promoted to errors, the build would fail. */
 
 namespace {
 


### PR DESCRIPTION
- Remove if(GTEST_FOUND) guard.
- Add drake_deprecated_test_nocompile test coverage.
  - This also allows us to turn of warnings in the default version of the test, which removes complaints from our default build output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2643)
<!-- Reviewable:end -->
