### PR TITLE
Enable BUILD_DOCUMENTATION by default.

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -380,9 +380,9 @@ if(MATLAB_FOUND)
     PROPERTIES TIMEOUT 300)
 endif()
 
-option(BUILD_DOCUMENTATION "Enable Doxygen and Sphinx documentation targets." ON)
+option(ENABLE_DOCUMENTATION "Enable build target for Doxygen and Sphinx documentation." ON)
 
-if(BUILD_DOCUMENTATION)
+if(ENABLE_DOCUMENTATION)
   add_subdirectory(doc)
 endif()
 

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -380,7 +380,7 @@ if(MATLAB_FOUND)
     PROPERTIES TIMEOUT 300)
 endif()
 
-option(BUILD_DOCUMENTATION "Build Doxygen and Sphinx documentation." OFF)
+option(BUILD_DOCUMENTATION "Enable Doxygen and Sphinx documentation targets." ON)
 
 if(BUILD_DOCUMENTATION)
   add_subdirectory(doc)

--- a/drake/doc/CMakeLists.txt
+++ b/drake/doc/CMakeLists.txt
@@ -22,7 +22,7 @@ if(SPHINX_EXECUTABLE)
     DESTINATION ${DRAKE_DOCUMENTATION_DIR} OPTIONAL)
   list(APPEND DRAKE_DOCUMENTATION_OUTPUTS sphinx_output)
 else()
-  message(WARNING "SPHINX_EXECUTABLE (sphinx-build) not found. Sphinx documentation will not be built.")
+  message(STATUS "SPHINX_EXECUTABLE (sphinx-build) not found. Sphinx will be excluded from the documentation build.")
 endif()
 
 find_package(Doxygen)
@@ -57,10 +57,10 @@ if(DOXYGEN_FOUND)
       DESTINATION ${DRAKE_DOCUMENTATION_DIR}/doxygen_matlab OPTIONAL)
     list(APPEND DRAKE_DOCUMENTATION_OUTPUTS doxygen_matlab_output)
   else()
-    message(WARNING "PERL_EXECUTABLE (perl) not found. MATLAB Doxygen documentation will not be built.")
+    message(STATUS "PERL_EXECUTABLE (perl) not found. MATLAB Doxygen will be excluded from the documentation build.")
   endif()
 else()
-  message(WARNING "DOXYGEN_EXECUTABLE (doxygen) not found. C++ and MATLAB Doxygen documentation will not be built.")
+  message(STATUS "DOXYGEN_EXECUTABLE (doxygen) not found. C++ and MATLAB Doxygen will be excluded from the documentation build.")
 endif()
 
 if(ENV{OXYGEN_DIR})
@@ -86,10 +86,11 @@ if(ENV{OXYGEN_DIR})
 endif()
 
 if(DRAKE_DOCUMENTATION_OUTPUTS)
-  # Undocumented option for use by CI builds to build documentation
-  # as part of the default build targets ("all" or "ALL_BUILD").
-  # We do not do this by default because developers should only
-  # get documentation built by an explicit request for the target.
+  # BUILD_DOCUMENTATION_ALWAYS is an undocumented option for use by CI builds.
+  # When set to ON, documentation is included in the default build targets
+  # "all" and "ALL_BUILD".
+  # BUILD_DOCUMENTATION_ALWAYS is off by default so that developers do not have
+  # to wait for the documentation to build every time they rebuild Drake itself.
   if(BUILD_DOCUMENTATION_ALWAYS)
     set(_DRAKE_DOCUMENTATION_ALL ALL)
   else()

--- a/drake/doc/doxygen_instructions.rst
+++ b/drake/doc/doxygen_instructions.rst
@@ -21,11 +21,6 @@ Coming soon. See issue
 Doxygen Website Generation
 ==========================
 
-First enable the ``documentation`` build target by executing the following::
-
-    $ cd [build artifacts directory]
-    $ cmake -DBUILD_DOCUMENTATION=ON ..
-
 There are at least two ways to generate Drake's Doxygen website. The first is
 using the command line, and the second through Microsoft Visual Studio.
 
@@ -44,9 +39,10 @@ favorite web browser::
 
     [build artifacts directory]/doc/doxygen_cxx/html/index.html
 
-**Note 1:** If you're building Drake in-source (i.e., within the ``pod-build``
-directory), the ``[build artifacts directory]`` is typically
-``[drake distro]/drake/pod-build/``.
+If you're building Drake in-source, the ``[build artifacts directory]`` is
+typically ``drake-distro/drake/pod-build/``. If you're building Drake
+out-of-source, the ``[build artifacts directory]`` is typically
+``drake-build/drake``.
 
 .. _doxygen-generation-visual-studio:
 
@@ -62,15 +58,4 @@ To build the documentation, simply select and build the ``documentation`` target
 in the IDE. Note that in Microsoft Visual Studio, the ``documentation`` target
 is not built when building the other targets, meaning there is one less reason
 to disable the ``documentation`` target.
-
-.. _disable-doxygen-generation:
-
-Disabling Documentation Generation
-----------------------------------
-
-To disable documentation generation, simply execute::
-
-    $ cd [build artifacts directory]
-    $ cmake -DBUILD_DOCUMENTATION=OFF ..
-    $ make
 


### PR DESCRIPTION
Downgrade missing documentation tools from WARNING to STATUS, so as not to spam users or CDash.

Fixes #2650.

@bradking for feature review, @sherm1 for platform review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2655)
<!-- Reviewable:end -->
