### PR TITLE
Rewrite MathematicalProgram as a capabilities bitmask

### DIFF
--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -13,17 +13,17 @@ namespace {
 
 enum ProblemAttributes {
   kNoCapabilities = 0,
-  kError = 1 << 0, ///< Do not use, to avoid & vs. && typos.
-  kGenericObjective                = 1 << 1,  ///< minimize f(x)
-  kGenericConstraint               = 1 << 2,  ///< require f(x) == 0
-  kQuadraticObjective              = 1 << 3,  ///< minimize x^2
-  kQuadraticConstraint             = 1 << 4,  ///< require x^2 - k == 0
-  kLinearObjective                 = 1 << 5,  ///< minimize x
-  kLinearConstraint                = 1 << 6,  ///< require x - k >/< 0
-  kLinearEqualityConstraint        = 1 << 7,  ///< require x - k == 0
-  kLinearComplementarityConstraint = 1 << 8,  ///< require x * y == 0
+  kError = 1 << 0,  ///< Do not use, to avoid & vs. && typos.
+  kGenericCost                     = 1 << 1,
+  kGenericConstraint               = 1 << 2,
+  kQuadraticCost                   = 1 << 3,
+  kQuadraticConstraint             = 1 << 4,
+  kLinearCost                      = 1 << 5,
+  kLinearConstraint                = 1 << 6,
+  kLinearEqualityConstraint        = 1 << 7,
+  kLinearComplementarityConstraint = 1 << 8
 };
-typedef int AttributesSet;
+typedef uint32_t AttributesSet;
 
 // TODO(ggould-tri) Refactor these capability advertisements into the
 // solver wrappers themselves.
@@ -38,15 +38,15 @@ AttributesSet kMobyLcpCapabilities = kLinearComplementarityConstraint;
 // to land.
 // AttributesSet kGurobiCapabilities = (
 //     kLinearEqualityConstraint | kLinearInequalityConstraint |
-//     kLinearObjective | kQuadraticObjective);
+//     kLinearCost | kQuadraticCost);
 
-// Solvers for generic systems of constraints and consts.
+// Solvers for generic systems of constraints and costs.
 AttributesSet kGenericSolverCapabilities = (
-    kGenericObjective | kGenericConstraint |
-    kQuadraticObjective | kQuadraticConstraint |
-    kLinearObjective | kLinearConstraint | kLinearEqualityConstraint);
+    kGenericCost | kGenericConstraint |
+    kQuadraticCost | kQuadraticConstraint |
+    kLinearCost | kLinearConstraint | kLinearEqualityConstraint);
 
-/// Returns true iff no capabilities are in required and not in available.
+// Returns true iff no capabilities are in required and not in available.
 bool is_satisfied(AttributesSet required, AttributesSet available) {
   return ((required & ~available) == kNoCapabilities);
 }
@@ -92,7 +92,7 @@ class DRAKEOPTIMIZATION_EXPORT LeastSquaresSolver :
   }
 };
 
-} // anon namespace
+}  // anon namespace
 
 
 MathematicalProgram::MathematicalProgram()
@@ -103,20 +103,20 @@ MathematicalProgram::MathematicalProgram()
       moby_lcp_solver_(new MobyLCPSolver()),
       least_squares_solver_(new LeastSquaresSolver()) {}
 
-void MathematicalProgram::AddGenericObjective() {
-  required_capabilities_ |= kGenericObjective;
+void MathematicalProgram::AddGenericCost() {
+  required_capabilities_ |= kGenericCost;
 }
 void MathematicalProgram::AddGenericConstraint() {
   required_capabilities_ |= kGenericConstraint;
 }
-void MathematicalProgram::AddQuadraticObjective() {
-  required_capabilities_ |= kQuadraticObjective;
+void MathematicalProgram::AddQuadraticCost() {
+  required_capabilities_ |= kQuadraticCost;
 }
 void MathematicalProgram::AddQuadraticConstraint() {
   required_capabilities_ |= kQuadraticConstraint;
 }
-void MathematicalProgram::AddLinearObjective() {
-  required_capabilities_ |= kLinearObjective;
+void MathematicalProgram::AddLinearCost() {
+  required_capabilities_ |= kLinearCost;
 }
 void MathematicalProgram::AddLinearConstraint() {
   required_capabilities_ |= kLinearConstraint;
@@ -155,7 +155,7 @@ SolutionResult MathematicalProgram::Solve(OptimizationProblem& prog) const {
         "MathematicalProgram::Solve: "
         "No solver available for the given optimization problem!");
   }
-};
+}
 
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -134,8 +134,8 @@ SolutionResult MathematicalProgram::Solve(OptimizationProblem& prog) const {
   // constraints present.
   if (is_satisfied(required_capabilities_, kLeastSquaresCapabilities) &&
       least_squares_solver_->available()) {
-    // TODO ggould Also allow quadratic objectives whose matrix is Identity:
-    // This is the objective function the solver uses anyway when
+    // TODO(ggould-tri) Also allow quadratic objectives whose matrix is
+    // Identity: This is the objective function the solver uses anyway when
     // underconstrainted, and is fairly common in real-world problems.
     return least_squares_solver_->Solve(prog);
   } else if (is_satisfied(required_capabilities_, kMobyLcpCapabilities) &&

--- a/drake/solvers/MathematicalProgram.cpp
+++ b/drake/solvers/MathematicalProgram.cpp
@@ -8,180 +8,55 @@
 
 namespace drake {
 namespace solvers {
-MathematicalProgramInterface::~MathematicalProgramInterface() {}
 
 namespace {
 
-class MathematicalProgram : public MathematicalProgramInterface {
- public:
-  virtual ~MathematicalProgram() {}
-
-  /* these would be used to fill out the optimization hierarchy prototyped
-     below
-     virtual MathematicalProgramInterface* AddIntegerVariable() { return new
-     MathematicalProgram; }
-     virtual MathematicalProgramInterface* AddSumsOfSquaresConstraint() { return
-     new
-     MathematicalProgram; }
-     virtual MathematicalProgramInterface* AddLinearMatrixInequalityConstraint()
-     {
-     return new MathematicalProgram; }
-     virtual MathematicalProgramInterface* AddSecondOrderConeConstraint() {
-     return new
-     MathematicalProgram; }
-     virtual MathematicalProgramInterface* AddComplementarityConstraint() {
-     return new
-     MathematicalProgram; };
-  */
-  MathematicalProgramInterface* AddQuadraticCost() override {
-    return new MathematicalProgram;
-  }
-  MathematicalProgramInterface* AddLinearCost() override {
-    return new MathematicalProgram;
-  }
-  MathematicalProgramInterface* AddGenericCost() override {
-    return new MathematicalProgram;
-  };
-  MathematicalProgramInterface* AddGenericConstraint() override {
-    return new MathematicalProgram;
-  };
-  MathematicalProgramInterface* AddLinearConstraint() override {
-    return new MathematicalProgram;
-  };
-  MathematicalProgramInterface* AddLinearEqualityConstraint() override {
-    return new MathematicalProgram;
-  };
-  MathematicalProgramInterface* AddLinearComplementarityConstraint() override {
-    return new MathematicalProgram;
-  };
-  SolutionResult Solve(OptimizationProblem& prog) const override {
-    throw std::runtime_error(
-        "MathematicalProgram::Solve: "
-        "No solver available for the given optimization problem!");
-  }
+enum ProblemAttributes {
+  kNoCapabilities = 0,
+  kError = 1 << 0, ///< Do not use, to avoid & vs. && typos.
+  kGenericObjective                = 1 << 1,  ///< minimize f(x)
+  kGenericConstraint               = 1 << 2,  ///< require f(x) == 0
+  kQuadraticObjective              = 1 << 3,  ///< minimize x^2
+  kQuadraticConstraint             = 1 << 4,  ///< require x^2 - k == 0
+  kLinearObjective                 = 1 << 5,  ///< minimize x
+  kLinearConstraint                = 1 << 6,  ///< require x - k >/< 0
+  kLinearEqualityConstraint        = 1 << 7,  ///< require x - k == 0
+  kLinearComplementarityConstraint = 1 << 8,  ///< require x * y == 0
 };
+typedef int AttributesSet;
 
-class NonlinearProgram : public MathematicalProgram {
- public:
-  // TODO(naveenoid) : bug exists in adding a Linear Quadratic or
-  // Generic Cost to a NonlinearProgram
-  MathematicalProgramInterface* AddGenericCost() override {
-    return new NonlinearProgram;
-  };
-  MathematicalProgramInterface* AddGenericConstraint() override {
-    return new NonlinearProgram;
-  };
-  MathematicalProgramInterface* AddLinearConstraint() override {
-    return new NonlinearProgram;
-  };
-  MathematicalProgramInterface* AddLinearEqualityConstraint() override {
-    return new NonlinearProgram;
-  };
-  MathematicalProgramInterface* AddLinearComplementarityConstraint() override {
-    return new NonlinearProgram;
-  }
+// TODO(ggould-tri) Refactor these capability advertisements into the
+// solver wrappers themselves.
 
-  SolutionResult Solve(OptimizationProblem& prog) const override {
-    if (snopt_solver.available()) {
-      return snopt_solver.Solve(prog);
-    }
-    if (ipopt_solver.available()) {
-      return ipopt_solver.Solve(prog);
-    }
-    if (nlopt_solver.available()) {
-      return nlopt_solver.Solve(prog);
-    }
-    return MathematicalProgram::Solve(prog);
-  }
+// Solver for simple linear systems of equalities
+AttributesSet kLeastSquaresCapabilities = kLinearEqualityConstraint;
 
- private:
-  IpoptSolver ipopt_solver;
-  NloptSolver nlopt_solver;
-  SnoptSolver snopt_solver;
-};
+// Solver for Linear Complementarity Problems (LCPs)
+AttributesSet kMobyLcpCapabilities = kLinearComplementarityConstraint;
 
-/*  // Prototype of the more complete optimization problem class hiearchy (to
-    be implemented only as needed)
-    struct MixedIntegerNonlinearProgram : public MathematicalProgramInterface
-   {};
-    struct MixedIntegerSemidefiniteProgram : public
-    MixedIntegerNonlinearProgram {};
-    struct MixedIntegerSecondOrderConeProgram : public
-    MixedIntegerSemidefiniteProgram {};
-    struct MixedIntegerQuadraticProgram : public
-    MixedIntegerSecondOrderConeProgram {};
-    struct MixedIntegerLinearProgram : public MixedIntegerQuadraticProgram {};
+// Solver for Quadratic Programs (QPs); commented out until Gurobi is ready
+// to land.
+// AttributesSet kGurobiCapabilities = (
+//     kLinearEqualityConstraint | kLinearInequalityConstraint |
+//     kLinearObjective | kQuadraticObjective);
 
-    struct NonlinearProgram : public MixedIntegerNonlinearProgram {};
-    struct SemidefiniteProgram : public NonlinearProgram, public
-    MixedIntegerSemidefiniteProgram {};
-    struct SecondOrderConeProgram : public SemidefiniteProgram, public
-    MixedIntegerSecondOrderConeProgram {};
-    struct QuadraticProgram : public SecondOrderConeProgram, public
-    MixedIntegerQuadraticProgram {};
-    struct LinearProgram : public QuadraticProgram, public
-    MixedIntegerLinearProgram {
-    virtual MathematicalProgramInterface* AddLinearEqualityConstraint() { return
-   new
-    LinearProgram; };
-    virtual MathematicalProgramInterface* AddLinearInequalityConstraint() {
-   return
-    new LinearProgram; };
-    };
+// Solvers for generic systems of constraints and consts.
+AttributesSet kGenericSolverCapabilities = (
+    kGenericObjective | kGenericConstraint |
+    kQuadraticObjective | kQuadraticConstraint |
+    kLinearObjective | kLinearConstraint | kLinearEqualityConstraint);
 
-    struct NonlinearComplementarityProblem : public NonlinearProgram {};
-    struct LinearComplementarityProblem : public
-    NonlinearComplementarityProblem {};
-*/
+/// Returns true iff no capabilities are in required and not in available.
+bool is_satisfied(AttributesSet required, AttributesSet available) {
+  return ((required & ~available) == kNoCapabilities);
+}
 
-class LinearComplementarityProblem : public MathematicalProgram {
- public:
-  SolutionResult Solve(OptimizationProblem& prog) const override {
-    // TODO(ggould-tri) given the Moby solver's meticulous use of temporaries,
-    // it would be an easy performance win to reuse this solver object by making
-    // a static place to store it.
-    MobyLCPSolver solver;
-    return solver.Solve(prog);
-  }
-  MathematicalProgramInterface* AddLinearComplementarityConstraint() override {
-    return new LinearComplementarityProblem;
-  };
-  // TODO(naveenoid) : bug exists in adding a QuadraticCost to an LCP Problem.
-  // Ideal fix involves rewrite of this entire class hierarchy.
-};
 
-class QuadraticProgram : public NonlinearProgram {
- public:
-  MathematicalProgramInterface* AddQuadraticCost() override {
-    return new QuadraticProgram;
-  };
-  MathematicalProgramInterface* AddLinearCost() override {
-    return new QuadraticProgram;
-  }
+class DRAKEOPTIMIZATION_EXPORT LeastSquaresSolver :
+      public MathematicalProgramSolverInterface {
+  ~LeastSquaresSolver() override {};
 
-  MathematicalProgramInterface* AddLinearConstraint() override {
-    return new QuadraticProgram;
-  };
-  MathematicalProgramInterface* AddLinearEqualityConstraint() override {
-    return new QuadraticProgram;
-  };
-
-  SolutionResult Solve(OptimizationProblem& prog) const override {
-    return NonlinearProgram::Solve(prog);
-  }
-
-  // TODO(naveenoid) : add Gurobi wrapper object, and solve here.
-};
-
-class LeastSquares : public QuadraticProgram {
- public:
-  // LinearComplementarityProblem
-  MathematicalProgramInterface* AddLinearEqualityConstraint() override {
-    return new LeastSquares;
-  };
-  MathematicalProgramInterface* AddLinearComplementarityConstraint() override {
-    return new LinearComplementarityProblem;
-  };
+  bool available() const override { return true; }
 
   SolutionResult Solve(OptimizationProblem& prog) const override {
     size_t num_constraints = 0;
@@ -216,14 +91,71 @@ class LeastSquares : public QuadraticProgram {
     return SolutionResult::kSolutionFound;
   }
 };
+
+} // anon namespace
+
+
+MathematicalProgram::MathematicalProgram()
+    : required_capabilities_(kNoCapabilities),
+      ipopt_solver_(new IpoptSolver()),
+      nlopt_solver_(new NloptSolver()),
+      snopt_solver_(new SnoptSolver()),
+      moby_lcp_solver_(new MobyLCPSolver()),
+      least_squares_solver_(new LeastSquaresSolver()) {}
+
+void MathematicalProgram::AddGenericObjective() {
+  required_capabilities_ |= kGenericObjective;
+}
+void MathematicalProgram::AddGenericConstraint() {
+  required_capabilities_ |= kGenericConstraint;
+}
+void MathematicalProgram::AddQuadraticObjective() {
+  required_capabilities_ |= kQuadraticObjective;
+}
+void MathematicalProgram::AddQuadraticConstraint() {
+  required_capabilities_ |= kQuadraticConstraint;
+}
+void MathematicalProgram::AddLinearObjective() {
+  required_capabilities_ |= kLinearObjective;
+}
+void MathematicalProgram::AddLinearConstraint() {
+  required_capabilities_ |= kLinearConstraint;
+}
+void MathematicalProgram::AddLinearEqualityConstraint() {
+  required_capabilities_ |= kLinearEqualityConstraint;
+}
+void MathematicalProgram::AddLinearComplementarityConstraint() {
+  required_capabilities_ |= kLinearComplementarityConstraint;
 }
 
-std::shared_ptr<MathematicalProgramInterface>
-MathematicalProgramInterface::GetLeastSquaresProgram() {
-  return std::shared_ptr<MathematicalProgramInterface>(new LeastSquares);
-}
-
-MathematicalProgramSolverInterface::~MathematicalProgramSolverInterface() {}
+SolutionResult MathematicalProgram::Solve(OptimizationProblem& prog) const {
+  // This implementation is simply copypasta for now; in the future we will
+  // want to tweak the order of preference of solvers based on the types of
+  // constraints present.
+  if (is_satisfied(required_capabilities_, kLeastSquaresCapabilities) &&
+      least_squares_solver_->available()) {
+    // TODO ggould Also allow quadratic objectives whose matrix is Identity:
+    // This is the objective function the solver uses anyway when
+    // underconstrainted, and is fairly common in real-world problems.
+    return least_squares_solver_->Solve(prog);
+  } else if (is_satisfied(required_capabilities_, kMobyLcpCapabilities) &&
+             moby_lcp_solver_->available()) {
+    return moby_lcp_solver_->Solve(prog);
+  } else if (is_satisfied(required_capabilities_, kGenericSolverCapabilities) &&
+             snopt_solver_->available()) {
+    return snopt_solver_->Solve(prog);
+  } else if (is_satisfied(required_capabilities_, kGenericSolverCapabilities) &&
+             ipopt_solver_->available()) {
+    return ipopt_solver_->Solve(prog);
+  } else if (is_satisfied(required_capabilities_, kGenericSolverCapabilities) &&
+             nlopt_solver_->available()) {
+    return nlopt_solver_->Solve(prog);
+  } else {
+    throw std::runtime_error(
+        "MathematicalProgram::Solve: "
+        "No solver available for the given optimization problem!");
+  }
+};
 
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/MathematicalProgram.h
+++ b/drake/solvers/MathematicalProgram.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "drake/drakeOptimization_export.h"

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -258,7 +258,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       : num_vars_(0),
         x_initial_guess_(
             static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)),
-        problem_type_(MathematicalProgramInterface::GetLeastSquaresProgram()),
+        problem_type_(),
         solver_result_(0) {}
 
   const DecisionVariableView AddContinuousVariables(std::size_t num_new_vars,
@@ -281,7 +281,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
 
   void AddCost(std::shared_ptr<Constraint> const& obj,
                VariableList const& vars) {
-    problem_type_.reset(problem_type_->AddGenericCost());
+    problem_type_.AddGenericObjective();
     generic_costs_.push_back(Binding<Constraint>(obj, vars));
   }
 
@@ -384,7 +384,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    */
   void AddGenericConstraint(std::shared_ptr<Constraint> con,
                             VariableList const& vars) {
-    problem_type_.reset(problem_type_->AddGenericConstraint());
+    problem_type_.AddGenericConstraint();
     generic_constraints_.push_back(Binding<Constraint>(con, vars));
   }
   void AddGenericConstraint(std::shared_ptr<Constraint> con) {
@@ -398,7 +398,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    */
   void AddLinearConstraint(std::shared_ptr<LinearConstraint> con,
                            VariableList const& vars) {
-    problem_type_.reset(problem_type_->AddLinearConstraint());
+    problem_type_.AddLinearConstraint();
     linear_constraints_.push_back(Binding<LinearConstraint>(con, vars));
   }
 
@@ -446,7 +446,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    */
   void AddLinearEqualityConstraint(
       std::shared_ptr<LinearEqualityConstraint> con, VariableList const& vars) {
-    problem_type_.reset(problem_type_->AddLinearEqualityConstraint());
+    problem_type_.AddLinearEqualityConstraint();
     linear_equality_constraints_.push_back(
         Binding<LinearEqualityConstraint>(con, vars));
   }
@@ -499,7 +499,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    */
   void AddBoundingBoxConstraint(std::shared_ptr<BoundingBoxConstraint> con,
                                 VariableList const& vars) {
-    problem_type_.reset(problem_type_->AddLinearConstraint());
+    problem_type_.AddLinearConstraint();
     bbox_constraints_.push_back(Binding<BoundingBoxConstraint>(con, vars));
   }
 
@@ -549,7 +549,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   AddLinearComplementarityConstraint(const Eigen::MatrixBase<DerivedM>& M,
                                      const Eigen::MatrixBase<Derivedq>& q,
                                      const VariableList& vars) {
-    problem_type_.reset(problem_type_->AddLinearComplementarityConstraint());
+    problem_type_.AddLinearComplementarityConstraint();
 
     // Linear Complementarity Constraint cannot currently coexist with any
     // other types of constraint or cost.
@@ -597,7 +597,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     // performance purposes, as automatically generated rigid body manipulator
     // equations subject to lumped parameter rewriting may frequently come out
     // as degree 1.
-    problem_type_.reset(problem_type_->AddGenericConstraint());
+    problem_type_.AddGenericConstraint();
     std::shared_ptr<PolynomialConstraint> constraint(
         new PolynomialConstraint(polynomials, poly_vars, lb, ub));
     AddGenericConstraint(constraint, vars);
@@ -635,7 +635,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
    * @return SolutionResult indicating if the solution was successful.
    */
   SolutionResult Solve() {
-    return problem_type_->Solve(*this);
+    return problem_type_.Solve(*this);
   }  // TODO(naveenoid) : add argument for options
 
   //    template <typename Derived>
@@ -799,7 +799,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   size_t num_vars_;
   Eigen::VectorXd x_initial_guess_;
   std::shared_ptr<SolverData> solver_data_;
-  std::shared_ptr<MathematicalProgramInterface> problem_type_;
+  MathematicalProgram problem_type_;
   std::string solver_name_;
   int solver_result_;
   std::map<std::string, std::map<std::string, double>> solver_options_double_;

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -281,7 +281,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
 
   void AddCost(std::shared_ptr<Constraint> const& obj,
                VariableList const& vars) {
-    problem_type_.AddGenericObjective();
+    problem_type_.AddGenericCost();
     generic_costs_.push_back(Binding<Constraint>(obj, vars));
   }
 


### PR DESCRIPTION
This should let us climb back down from the unmaintainable and unreadable type lattice approach.  The actually correct capabilities of the program classification should be the same (because subset-ness is a lattice-like relation); what we lose is the possibility of order-dependence, which is always wrong anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2658)
<!-- Reviewable:end -->
