### PR TITLE
Add I/O indirection, versioning, and invalidation notifications to System2.

### DIFF
--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -82,8 +82,9 @@ std::unique_ptr<Context<double>> SpringMassSystem::CreateDefaultContext()
 std::unique_ptr<SystemOutput<double>> SpringMassSystem::AllocateOutput() const {
   std::unique_ptr<SystemOutput<double>> output(new SystemOutput<double>);
   {
-    OutputPort<double> port;
-    port.vector_output.reset(new SpringMassOutputVector());
+    std::unique_ptr<VectorInterface<double>> data(new SpringMassOutputVector());
+    std::unique_ptr<OutputPort<double>> port(
+        new OutputPort<double>(std::move(data)));
     output->ports.push_back(std::move(port));
   }
   return output;
@@ -104,7 +105,7 @@ void SpringMassSystem::Output(const Context<double>& context,
       dynamic_cast<const SpringMassStateVector&>(
           context.get_state().continuous_state->get_state());
   SpringMassOutputVector* output_vector = dynamic_cast<SpringMassOutputVector*>(
-      output->ports[0].vector_output.get());
+      output->ports[0]->GetMutableVectorData());
   output_vector->set_position(state.get_position());
   output_vector->set_velocity(state.get_velocity());
 }

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -44,8 +44,8 @@ class SpringMassSystemTest : public ::testing::Test {
     // Set up some convenience pointers.
     state_ = dynamic_cast<SpringMassStateVector*>(
         context_->get_mutable_state()->continuous_state->get_mutable_state());
-    output_ = dynamic_cast<SpringMassOutputVector*>(
-        system_output_->ports[0].vector_output.get());
+    output_ = dynamic_cast<const SpringMassOutputVector*>(
+        system_output_->ports[0]->get_vector_data());
     derivatives_ =
         dynamic_cast<SpringMassStateVector*>(erased_derivatives_.get());
   }
@@ -60,7 +60,7 @@ class SpringMassSystemTest : public ::testing::Test {
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<SystemOutput<double>> system_output_;
   SpringMassStateVector* state_;
-  SpringMassOutputVector* output_;
+  const SpringMassOutputVector* output_;
   SpringMassStateVector* derivatives_;
 
  private:

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -14,6 +14,7 @@ set(sources
   state_subvector.cc
   state_vector.cc
   system_interface.cc
+  system_input.cc
   system_output.cc
   basic_state_vector.cc
   value.cc
@@ -32,6 +33,7 @@ set(installed_headers
   state_subvector.h
   state_vector.h
   system_interface.h
+  system_input.h
   system_output.h
   basic_state_vector.h
   value.h

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -6,29 +6,11 @@
 #include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/leaf_state_vector.h"
 #include "drake/systems/framework/state.h"
+#include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/vector_interface.h"
 
 namespace drake {
 namespace systems {
-
-template <typename T>
-struct InputPort {
-  /// The port data, if the port is vector-valued.
-  /// TODO(david-german-tri): Add abstract-valued ports.
-  const VectorInterface<T>* vector_input = nullptr;
-
-  /// The rate at which this port is sampled, in seconds.
-  /// If zero, the port is continuous.
-  double sample_time_sec{};
-};
-
-/// The Input is a container for pointers to all the data that is connected to
-/// a particular System from other Systems. The input data itself is not owned
-/// by the Input struct.
-template <typename T>
-struct Input {
-  std::vector<InputPort<T>> ports;
-};
 
 template <typename T>
 struct Time {
@@ -59,8 +41,44 @@ class Context {
   const Time<T>& get_time() const { return time_; }
   Time<T>* get_mutable_time() { return &time_; }
 
-  const Input<T>& get_input() const { return input_; }
-  Input<T>* get_mutable_input() { return &input_; }
+  /// Connects the input port @p port to this Context at the given @p index.
+  /// Disconnects whatever input port was previously there, and deregisters
+  /// it from the output port on which it depends.
+  void SetInputPort(int index, std::unique_ptr<InputPort<T>> port) {
+    if (index < 0 || index >= get_num_input_ports()) {
+      throw std::out_of_range("Input port out of range.");
+    }
+    // TODO(david-german-tri): Set invalidation callbacks.
+    inputs_[index] = std::move(port);
+  }
+
+  /// Removes all the input ports, and deregisters them from the output ports
+  /// on which they depend.
+  void ClearInputPorts() {
+    inputs_.clear();
+  }
+
+  /// Clears the input ports and allocates @p n new input ports, not connected
+  /// to anything.
+  void SetNumInputPorts(int n) {
+    ClearInputPorts();
+    inputs_.resize(n);
+  }
+
+  int get_num_input_ports() const { return inputs_.size(); }
+
+  /// Returns the vector data of the input port at @p index. Returns nullptr
+  /// if that port is not a vector-valued port, or if it is not connected.
+  /// Throws std::out_of_range if that port does not exist.
+  const VectorInterface<T>* get_vector_input(int index) const {
+    if (index >= get_num_input_ports()) {
+      throw std::out_of_range("Input port out of range.");
+    }
+    if (inputs_[index] == nullptr) {
+      return nullptr;
+    }
+    return inputs_[index]->get_vector_data();
+  }
 
   const State<T>& get_state() const { return state_; }
   State<T>* get_mutable_state() { return &state_; }
@@ -70,7 +88,8 @@ class Context {
   Cache<T>* get_mutable_cache() const { return &cache_; }
 
   /// Returns a deep copy of this Context. The clone's input ports will hold
-  /// pointers to the same output ports as the original Context.
+  /// deep copies of the data that appears on this context's port at the time
+  /// the clone is created.
   std::unique_ptr<Context<T>> Clone() const {
     return std::unique_ptr<Context<T>>(DoClone());
   }
@@ -92,9 +111,16 @@ class Context {
     context->get_mutable_state()->continuous_state.reset(
         new ContinuousState<T>(xc_vector.Clone(), num_q, num_v, num_z));
 
+    // Make deep copies of the inputs into FreestandingInputPorts.
+    // TODO(david-german-tri): Preserve version numbers as well.
+    for (const auto& port : this->inputs_) {
+      context->inputs_.emplace_back(
+          new FreestandingInputPort<T>(
+              port->get_vector_data()->Clone(), port->get_sample_time_sec()));
+    }
+
     // Make deep copies of everything else using the default copy constructors.
     *context->get_mutable_time() = this->get_time();
-    *context->get_mutable_input() = this->get_input();
     *context->get_mutable_cache() = *this->get_mutable_cache();
     return context;
   }
@@ -109,7 +135,7 @@ class Context {
   Time<T> time_;
 
   /// The external inputs to the System.
-  Input<T> input_;
+  std::vector<std::unique_ptr<InputPort<T>>> inputs_;
 
   /// The internal state of the System.
   State<T> state_;

--- a/drake/systems/framework/primitives/adder.cc
+++ b/drake/systems/framework/primitives/adder.cc
@@ -17,7 +17,7 @@ Adder<T>::Adder(int num_inputs, int length)
 template <typename T>
 std::unique_ptr<Context<T>> Adder<T>::CreateDefaultContext() const {
   std::unique_ptr<Context<T>> context(new Context<T>);
-  context->get_mutable_input()->ports.resize(num_inputs_);
+  context->SetNumInputPorts(num_inputs_);
   return context;
 }
 
@@ -27,8 +27,8 @@ std::unique_ptr<SystemOutput<T>> Adder<T>::AllocateOutput() const {
   // at construction time.
   std::unique_ptr<SystemOutput<T>> output(new SystemOutput<T>);
   {
-    OutputPort<T> port;
-    port.vector_output.reset(new BasicVector<T>(length_));
+    std::unique_ptr<BasicVector<T>> data(new BasicVector<T>(length_));
+    std::unique_ptr<OutputPort<T>> port(new OutputPort<T>(std::move(data)));
     output->ports.push_back(std::move(port));
   }
   return output;
@@ -43,23 +43,22 @@ void Adder<T>::Output(const Context<T>& context,
   // user error setting up the system graph. They do not require unit test
   // coverage, and should not run in release builds.
   DRAKE_ASSERT(output->ports.size() == 1);
-  VectorInterface<T>* output_port = output->ports[0].vector_output.get();
+  VectorInterface<T>* output_port = output->ports[0]->GetMutableVectorData();
   DRAKE_ASSERT(output_port != nullptr);
   DRAKE_ASSERT(output_port->get_value().rows() == length_);
   output_port->get_mutable_value() = VectorX<T>::Zero(length_);
 
   // Check that there are the expected number of input ports.
-  if (context.get_input().ports.size() != num_inputs_) {
-    throw std::out_of_range(
-        "Expected " + std::to_string(num_inputs_) + "input ports, but had " +
-        std::to_string(context.get_input().ports.size()));
+  if (context.get_num_input_ports() != num_inputs_) {
+    throw std::out_of_range("Expected " + std::to_string(num_inputs_) +
+                            "input ports, but had " +
+                            std::to_string(context.get_num_input_ports()));
   }
 
   // Sum each input port into the output, after checking that it has the
   // expected length.
-  for (int i = 0; i < context.get_input().ports.size(); i++) {
-    const VectorInterface<T>* input =
-        context.get_input().ports[i].vector_input;
+  for (int i = 0; i < context.get_num_input_ports(); i++) {
+    const VectorInterface<T>* input = context.get_vector_input(i);
     if (input == nullptr || input->get_value().rows() != length_) {
       throw std::out_of_range("Input port " + std::to_string(i) +
                               "is nullptr or has incorrect size.");

--- a/drake/systems/framework/primitives/test/adder_test.cc
+++ b/drake/systems/framework/primitives/test/adder_test.cc
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/system_input.h"
 
 #include "gtest/gtest.h"
 
@@ -18,30 +19,39 @@ class AdderTest : public ::testing::Test {
     adder_.reset(new Adder<double>(2 /* inputs */, 3 /* length */));
     context_ = adder_->CreateDefaultContext();
     output_ = adder_->AllocateOutput();
+    input0_.reset(new BasicVector<double>(3 /* length */));
+    input1_.reset(new BasicVector<double>(3 /* length */));
+  }
+
+  static std::unique_ptr<FreestandingInputPort<double>> MakeInput(
+      std::unique_ptr<BasicVector<double>> data) {
+    return std::unique_ptr<FreestandingInputPort<double>>(
+        new FreestandingInputPort<double>(std::move(data)));
   }
 
   std::unique_ptr<Adder<double>> adder_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<SystemOutput<double>> output_;
+  std::unique_ptr<BasicVector<double>> input0_;
+  std::unique_ptr<BasicVector<double>> input1_;
 };
 
 TEST_F(AdderTest, AddTwoVectors) {
   // Hook up two inputs of the expected size.
-  ASSERT_EQ(2, context_->get_mutable_input()->ports.size());
-  BasicVector<double> input0(3 /* length */);
-  BasicVector<double> input1(3 /* length */);
-  input0.get_mutable_value() << 1, 2, 3;
-  input1.get_mutable_value() << 4, 5, 6;
-  context_->get_mutable_input()->ports[0].vector_input = &input0;
-  context_->get_mutable_input()->ports[1].vector_input = &input1;
+  ASSERT_EQ(2, context_->get_num_input_ports());
+  input0_->get_mutable_value() << 1, 2, 3;
+  input1_->get_mutable_value() << 4, 5, 6;
+  context_->SetInputPort(0, MakeInput(std::move(input0_)));
+  context_->SetInputPort(1, MakeInput(std::move(input1_)));
 
   adder_->Output(*context_, output_.get());
 
   ASSERT_EQ(1, output_->ports.size());
-  BasicVector<double>* output_port = dynamic_cast<BasicVector<double>*>(
-      output_->ports[0].vector_output.get());
+  const BasicVector<double>* output_port =
+      dynamic_cast<const BasicVector<double>*>(
+          output_->ports[0]->get_vector_data());
   ASSERT_NE(nullptr, output_port);
-  Eigen::Matrix<double, 3, 1> expected;
+  Eigen::Vector3d expected;
   expected << 5, 7, 9;
   EXPECT_EQ(expected, output_port->get_value());
 }
@@ -50,9 +60,7 @@ TEST_F(AdderTest, AddTwoVectors) {
 // are connected.
 TEST_F(AdderTest, WrongNumberOfInputPorts) {
   // Hook up just one input.
-  BasicVector<double> input0(3 /* length */);
-  context_->get_mutable_input()->ports[0].vector_input = &input0;
-
+  context_->SetInputPort(0, MakeInput(std::move(input0_)));
   EXPECT_THROW(adder_->Output(*context_, output_.get()), std::out_of_range);
 }
 
@@ -60,11 +68,13 @@ TEST_F(AdderTest, WrongNumberOfInputPorts) {
 // are connected.
 TEST_F(AdderTest, WrongSizeOfInputPorts) {
   // Hook up two inputs, but one of them is the wrong size.
-  ASSERT_EQ(2, context_->get_mutable_input()->ports.size());
-  BasicVector<double> input0(3 /* length */);
-  BasicVector<double> input1(2 /* length */);
-  context_->get_mutable_input()->ports[0].vector_input = &input0;
-  context_->get_mutable_input()->ports[1].vector_input = &input1;
+  ASSERT_EQ(2, context_->get_num_input_ports());
+  std::unique_ptr<BasicVector<double>> short_input(
+      new BasicVector<double>(2 /* length */));
+  input0_->get_mutable_value() << 1, 2, 3;
+  short_input->get_mutable_value() << 4, 5;
+  context_->SetInputPort(0, MakeInput(std::move(input0_)));
+  context_->SetInputPort(1, MakeInput(std::move(short_input)));
 
   EXPECT_THROW(adder_->Output(*context_, output_.get()), std::out_of_range);
 }

--- a/drake/systems/framework/system_input.cc
+++ b/drake/systems/framework/system_input.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// system_input.h is a stand-alone header.
+
+#include "drake/systems/framework/system_input.h"

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -12,7 +12,8 @@ namespace drake {
 namespace systems {
 
 /// The InputPort describes a single input to a System, from another
-/// System or from an external driver.
+/// System or from an external driver. Users should not subclass InputPort:
+/// all InputPorts are either DependentInputPorts or FreestandingInputPorts.
 ///
 /// @tparam T The type of the input port. Must be a valid Eigen scalar.
 template <typename T>
@@ -56,24 +57,24 @@ class InputPort : public OutputPortListenerInterface {
   std::function<void()> invalidation_callback_ = nullptr;
 };
 
-/// The ConnectedInputPort wraps a pointer to the OutputPort of a System for use
-/// as an input to another System. Many ConnectedInputPorts may wrap a single
+/// The DependentInputPort wraps a pointer to the OutputPort of a System for use
+/// as an input to another System. Many DependentInputPorts may wrap a single
 /// OutputPort.
 ///
 /// @tparam T The type of the input port. Must be a valid Eigen scalar.
 template <typename T>
-class ConnectedInputPort : public InputPort<T> {
+class DependentInputPort : public InputPort<T> {
  public:
   /// Creates an input port with the given @p sample_time_sec, connected
   /// to the given @p output_port, which must not be nullptr. The output
   /// port must outlive this input port.
-  ConnectedInputPort(OutputPort<T>* output_port, double sample_time_sec)
+  DependentInputPort(OutputPort<T>* output_port, double sample_time_sec)
       : output_port_(output_port), sample_time_sec_(sample_time_sec) {
     output_port_->add_dependent(this);
   }
 
   /// Disconnects from the output port.
-  ~ConnectedInputPort() override {
+  ~DependentInputPort() override {
     output_port_->remove_dependent(this);
   }
 
@@ -91,11 +92,11 @@ class ConnectedInputPort : public InputPort<T> {
   }
 
  private:
-  // ConnectedInputPort objects are neither copyable nor moveable.
-  ConnectedInputPort(const ConnectedInputPort& other) = delete;
-  ConnectedInputPort& operator=(const ConnectedInputPort& other) = delete;
-  ConnectedInputPort(ConnectedInputPort&& other) = delete;
-  ConnectedInputPort& operator=(ConnectedInputPort&& other) = delete;
+  // DependentInputPort objects are neither copyable nor moveable.
+  DependentInputPort(const DependentInputPort& other) = delete;
+  DependentInputPort& operator=(const DependentInputPort& other) = delete;
+  DependentInputPort(DependentInputPort&& other) = delete;
+  DependentInputPort& operator=(DependentInputPort&& other) = delete;
 
   OutputPort<T>* output_port_;
   double sample_time_sec_;

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/vector_interface.h"
+
+namespace drake {
+namespace systems {
+
+/// The InputPort describes a single input to a System, from another
+/// System or from an external driver.
+///
+/// @tparam T The type of the input port. Must be a valid Eigen scalar.
+template <typename T>
+class InputPort : public OutputPortListenerInterface {
+ public:
+  ~InputPort() override {}
+
+  /// Returns a positive number that increases monotonically, and changes
+  /// whenever the data on this port changes, according to the source of
+  /// that data.
+  virtual int64_t get_version() const = 0;
+
+  /// Returns the sampling interval of this port in seconds, or zero if
+  /// this port is continuous.
+  virtual double get_sample_time_sec() const = 0;
+
+  /// Returns the vector data on this port, or nullptr if this port is not
+  /// vector-valued or not connected. Implementations must ensure that
+  /// get_vector_data is O(1) and initiates no substantive computation.
+  virtual const VectorInterface<T>* get_vector_data() const = 0;
+
+  /// Registers @p callback to be called whenever the value of get_version
+  /// changes. The callback should invalidate data that depends on the value
+  /// of this port, but should not do any substantive computation.
+  void set_invalidation_callback(std::function<void()> callback) {
+    invalidation_callback_ = callback;
+  }
+
+  /// Receives notification that the output port on which this InputPort
+  /// depends has changed, and calls the invalidation_callback_.
+  void Invalidate() override {
+    if (invalidation_callback_ != nullptr) {
+      invalidation_callback_();
+    }
+  }
+
+ protected:
+  InputPort() {}
+
+ private:
+  std::function<void()> invalidation_callback_ = nullptr;
+};
+
+/// The ConnectedInputPort wraps a pointer to the OutputPort of a System for use
+/// as an input to another System. Many ConnectedInputPorts may wrap a single
+/// OutputPort.
+///
+/// @tparam T The type of the input port. Must be a valid Eigen scalar.
+template <typename T>
+class ConnectedInputPort : public InputPort<T> {
+ public:
+  /// Creates an input port with the given @p sample_time_sec, connected
+  /// to the given @p output_port, which must not be nullptr. The output
+  /// port must outlive this input port.
+  ConnectedInputPort(OutputPort<T>* output_port, double sample_time_sec)
+      : output_port_(output_port), sample_time_sec_(sample_time_sec) {
+    output_port_->add_dependent(this);
+  }
+
+  /// Disconnects from the output port.
+  ~ConnectedInputPort() override {
+    output_port_->remove_dependent(this);
+  }
+
+  /// Returns the value version of the connected output port.
+  int64_t get_version() const override {
+    return output_port_->get_version();
+  }
+
+  double get_sample_time_sec() const override {
+    return sample_time_sec_;
+  }
+
+  const VectorInterface<T>* get_vector_data() const override {
+    return output_port_->get_vector_data();
+  }
+
+ private:
+  // ConnectedInputPort objects are neither copyable nor moveable.
+  ConnectedInputPort(const ConnectedInputPort& other) = delete;
+  ConnectedInputPort& operator=(const ConnectedInputPort& other) = delete;
+  ConnectedInputPort(ConnectedInputPort&& other) = delete;
+  ConnectedInputPort& operator=(ConnectedInputPort&& other) = delete;
+
+  OutputPort<T>* output_port_;
+  double sample_time_sec_;
+};
+
+/// The FreestandingInputPort encapsulates a vector of data for use as an input
+/// to a System.
+///
+/// @tparam T The type of the input port. Must be a valid Eigen scalar.
+template <typename T>
+class FreestandingInputPort : public InputPort<T> {
+ public:
+  /// Constructs a continuous FreestandingInputPort.
+  /// Takes ownership of @p vector_data.
+  explicit FreestandingInputPort(
+      std::unique_ptr<VectorInterface<T>> vector_data)
+      : FreestandingInputPort(std::move(vector_data), 0.0 /* continuous */) {}
+
+  /// Constructs a FreestandingInputPort with the given sample rate
+  /// @p sample_time_sec, which should be zero for continuous ports.
+  /// Takes ownership of @p vector_data.
+  FreestandingInputPort(std::unique_ptr<VectorInterface<T>> vector_data,
+                        double sample_time_sec)
+      : output_port_(std::move(vector_data)),
+        sample_time_sec_(sample_time_sec) {
+    output_port_.add_dependent(this);
+  }
+
+  ~FreestandingInputPort() override {
+    output_port_.remove_dependent(this);
+  }
+
+  /// Returns a positive and monotonically increasing number that is guaranteed
+  /// to change whenever GetMutableVectorData is called.
+  int64_t get_version() const override {
+    return output_port_.get_version();
+  }
+
+  double get_sample_time_sec() const override {
+    return sample_time_sec_;
+  }
+
+  const VectorInterface<T>* get_vector_data() const override {
+    return output_port_.get_vector_data();
+  }
+
+  /// Returns a pointer to the data inside this InputPort, and updates the
+  /// version so that Contexts depending on this InputPort know to invalidate
+  /// their caches.
+  ///
+  /// To ensure invalidation notifications are delivered, callers should
+  /// call this method every time they wish to update the stored value.  In
+  /// particular, callers MUST NOT write on the returned pointer if there is any
+  /// possibility this FreestandingInputPort has been accessed since the last
+  /// time this method was called.
+  VectorInterface<T>* GetMutableVectorData() {
+    return output_port_.GetMutableVectorData();
+  }
+
+ private:
+  // FreestandingInputPort objects are neither copyable nor moveable.
+  FreestandingInputPort(const FreestandingInputPort& other) = delete;
+  FreestandingInputPort& operator=(const FreestandingInputPort& other) = delete;
+  FreestandingInputPort(FreestandingInputPort&& other) = delete;
+  FreestandingInputPort& operator=(FreestandingInputPort&& other) = delete;
+
+  OutputPort<T> output_port_;
+  double sample_time_sec_ = 0.0;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -1,30 +1,105 @@
 #pragma once
 
 #include <memory>
+#include <set>
+#include <stdexcept>
 #include <vector>
 
+#include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/value.h"
 #include "drake/systems/framework/vector_interface.h"
 
 namespace drake {
 namespace systems {
 
+/// OutputPortListenerInterface is an interface that consumers of an output
+/// port must satisfy to receive notifications when the value on that output
+/// port's version number is incremented.
+///
+/// This interface is a Drake-internal detail. Users should not implement it.
+/// TODO(david-german-tri): Consider moving to its own file.
+class DRAKESYSTEMFRAMEWORK_EXPORT OutputPortListenerInterface {
+ public:
+  virtual ~OutputPortListenerInterface() {}
+
+  /// Invalidates any data that depends on the OutputPort. Called whenever
+  /// the OutputPort's version number is incremented.
+  virtual void Invalidate() = 0;
+};
+
+/// The OutputPort represents a data output from a System. Other Systems
+/// may depend on the OutputPort.
+///
+/// @tparam T The type of the output port. Must be a valid Eigen scalar.
 template <typename T>
-struct OutputPort {
+class OutputPort {
+ public:
+  /// Takes ownership of @p data.
+  explicit OutputPort(std::unique_ptr<VectorInterface<T>> data)
+      : vector_data_(std::move(data)) {}
+
+  /// Returns the vector of data in this output port, or nullptr if this is
+  /// an abstract-valued port.
+  const VectorInterface<T>* get_vector_data() const {
+    return vector_data_.get();
+  }
+
+  /// Returns a positive and monotonically increasing number that is guaranteed
+  /// to change whenever GetMutableVectorData is called.
+  int64_t get_version() const { return version_; }
+
+  /// Registers @p dependent to receive invalidation notifications whenever this
+  /// port's version number is incremented.
+  void add_dependent(OutputPortListenerInterface* dependent) {
+    dependents_.insert(dependent);
+  }
+
+  /// Unregisters @p dependent from invalidation notifications.
+  void remove_dependent(OutputPortListenerInterface* dependent) {
+    dependents_.erase(dependent);
+  }
+
+  /// Returns a pointer to the data inside this OutputPort, and updates the
+  /// version so that Contexts depending on this OutputPort know to invalidate
+  /// their caches. Callers MUST NOT write on the returned pointer if there is
+  /// any possibility this OutputPort has been accessed since the last time
+  /// GetMutableVectorData was called.
+  VectorInterface<T>* GetMutableVectorData() {
+    ++version_;
+    for (OutputPortListenerInterface* dependent : dependents_) {
+      dependent->Invalidate();
+    }
+    return vector_data_.get();
+  }
+
+ private:
+  // OutputPort objects are neither copyable nor moveable.
+  OutputPort(const OutputPort& other) = delete;
+  OutputPort& operator=(const OutputPort& other) = delete;
+  OutputPort(OutputPort&& other) = delete;
+  OutputPort& operator=(OutputPort&& other) = delete;
+
   /// The port data, if the port is vector-valued.
   /// TODO(david-german-tri): Add abstract-valued ports.
-  std::unique_ptr<VectorInterface<T>> vector_output;
+  std::unique_ptr<VectorInterface<T>> vector_data_;
+
+  /// The list of consumers that should be notified when the value on this
+  /// output port changes.
+  std::set<OutputPortListenerInterface*> dependents_;
 
   /// The rate at which this port produces output, in seconds.
   /// If zero, the port is continuous.
-  double sample_time_sec{};
+  double sample_time_sec_{};
+
+  int64_t version_ = 0;
 };
 
 /// A container for all the output of a System.
-/// @tparam T The mathematical type of the output.
+///
+/// @tparam T The type of the output data. Must be a valid Eigen scalar.
 template <typename T>
 struct SystemOutput {
-  std::vector<OutputPort<T>> ports;
+  std::vector<std::unique_ptr<OutputPort<T>>> ports;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -28,6 +28,16 @@ if(GTEST_FOUND)
                         ${GTEST_BOTH_LIBRARIES})
   add_test(NAME continuous_system_test COMMAND continuous_system_test)
 
+  add_executable(system_input_test system_input_test.cc)
+  target_link_libraries(system_input_test drakeSystemFramework
+                        ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME system_input_test COMMAND system_input_test)
+
+  add_executable(system_output_test system_output_test.cc)
+  target_link_libraries(system_output_test drakeSystemFramework
+                        ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME system_output_test COMMAND system_output_test)
+
   add_executable(context_test context_test.cc)
   target_link_libraries(context_test drakeSystemFramework
                         ${GTEST_BOTH_LIBRARIES})

--- a/drake/systems/framework/test/context_test.cc
+++ b/drake/systems/framework/test/context_test.cc
@@ -8,8 +8,14 @@
 
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/system_input.h"
+#include "drake/util/eigen_matrix_compare.h"
 
 namespace drake {
+
+using util::CompareMatrices;
+using util::MatrixCompareType;
+
 namespace systems {
 
 constexpr int kNumInputPorts = 2;
@@ -24,13 +30,20 @@ constexpr double kTime = 12.0;
 class ContextTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    // Time
     context_.get_mutable_time()->time_sec = kTime;
-    context_.get_mutable_input()->ports.resize(kNumInputPorts);
+
+    // Input
+    context_.SetNumInputPorts(kNumInputPorts);
     for (int i = 0; i < kNumInputPorts; ++i) {
-      input_data_.emplace_back(new BasicVector<double>(kInputSize[i]));
-      context_.get_mutable_input()->ports[i].vector_input =
-          input_data_.back().get();
+      std::unique_ptr<VectorInterface<double>> port_data(
+          new BasicVector<double>(kInputSize[i]));
+      std::unique_ptr<FreestandingInputPort<double>> port(
+          new FreestandingInputPort<double>(std::move(port_data)));
+      context_.SetInputPort(i, std::move(port));
     }
+
+    // State
     std::unique_ptr<BasicVector<double>> state_data(
         new BasicVector<double>(kStateSize));
     state_data->get_mutable_value() << 1.0, 2.0, 3.0, 5.0, 8.0;
@@ -44,8 +57,43 @@ class ContextTest : public ::testing::Test {
   }
 
   Context<double> context_;
-  std::vector<std::unique_ptr<BasicVector<double>>> input_data_;
 };
+
+TEST_F(ContextTest, GetNumInputPorts) {
+  ASSERT_EQ(kNumInputPorts, context_.get_num_input_ports());
+}
+
+TEST_F(ContextTest, ClearInputPorts) {
+  context_.ClearInputPorts();
+  EXPECT_EQ(0, context_.get_num_input_ports());
+}
+
+TEST_F(ContextTest, SetOutOfBoundsInputPort) {
+  EXPECT_THROW(context_.SetInputPort(3, nullptr), std::out_of_range);
+}
+
+TEST_F(ContextTest, GetVectorInput) {
+  Context<int> context;
+  context.SetNumInputPorts(2);
+
+  // Add input port 0 to the context, but leave input port 1 uninitialized.
+  std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
+  vec->get_mutable_value() << 5, 6;
+  std::unique_ptr<FreestandingInputPort<int>> port(
+      new FreestandingInputPort<int>(std::move(vec), 0.0 /* continuous */));
+  context.SetInputPort(0, std::move(port));
+
+  // Test that port 0 is retrievable.
+  VectorX<int> expected(2);
+  expected << 5, 6;
+  EXPECT_EQ(expected, context.get_vector_input(0)->get_value());
+
+  // Test that port 1 is nullptr.
+  EXPECT_EQ(nullptr, context.get_vector_input(1));
+
+  // Test that out-of-bounds ports throw an exception.
+  EXPECT_THROW(context.get_vector_input(2), std::out_of_range);
+}
 
 TEST_F(ContextTest, Clone) {
   std::unique_ptr<Context<double>> clone = context_.Clone();
@@ -53,10 +101,16 @@ TEST_F(ContextTest, Clone) {
   // Verify that the time was copied.
   EXPECT_EQ(kTime, clone->get_time().time_sec);
 
-  // Verify that the cloned input ports point to the same data.
-  EXPECT_EQ(kNumInputPorts, clone->get_input().ports.size());
+  // Verify that the cloned input ports contain the same data,
+  // but are different pointers.
+  EXPECT_EQ(kNumInputPorts, clone->get_num_input_ports());
   for (int i = 0; i < kNumInputPorts; ++i) {
-    EXPECT_EQ(input_data_[i].get(), clone->get_input().ports[i].vector_input);
+    EXPECT_NE(context_.get_vector_input(i),
+              clone->get_vector_input(i));
+    EXPECT_TRUE(CompareMatrices(
+        context_.get_vector_input(i)->get_value(),
+        clone->get_vector_input(i)->get_value(), 1e-8,
+        MatrixCompareType::absolute));
   }
 
   // Verify that the state was copied.

--- a/drake/systems/framework/test/system_input_test.cc
+++ b/drake/systems/framework/test/system_input_test.cc
@@ -1,0 +1,108 @@
+#include "drake/systems/framework/system_input.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace systems {
+
+class FreestandingInputPortTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
+    vec->get_mutable_value() << 5, 6;
+    port_.reset(new FreestandingInputPort<int>(std::move(vec), 42.0));
+    port_->set_invalidation_callback(
+        std::bind(&FreestandingInputPortTest::Invalidate, this));
+  }
+
+  std::unique_ptr<FreestandingInputPort<int>> port_;
+  int64_t latest_version_ = -1;
+
+ private:
+  void Invalidate() {
+    latest_version_ = port_->get_version();
+  }
+};
+
+TEST_F(FreestandingInputPortTest, Access) {
+  VectorX<int> expected(2);
+  expected << 5, 6;
+  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+  EXPECT_EQ(42.0, port_->get_sample_time_sec());
+}
+
+// Tests that changes to the vector data are propagated to the input port
+// that wraps it.
+TEST_F(FreestandingInputPortTest, Mutation) {
+  EXPECT_EQ(0, port_->get_version());
+  port_->GetMutableVectorData()->get_mutable_value() << 7, 8;
+
+  // Check that the version number was incremented.
+  EXPECT_EQ(1, port_->get_version());
+
+  // Check that the vector contents changed.
+  VectorX<int> expected(2);
+  expected << 7, 8;
+  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+}
+
+// Tests that the single-argument constructor for FreestandingInputPort creates
+// a continuous port.
+TEST_F(FreestandingInputPortTest, ContinouousPort) {
+  std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
+  port_.reset(new FreestandingInputPort<int>(std::move(vec)));
+  EXPECT_EQ(0.0, port_->get_sample_time_sec());
+}
+
+class ConnectedInputPortTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
+    vec->get_mutable_value() << 5, 6;
+    output_port_.reset(new OutputPort<int>(std::move(vec)));
+    port_.reset(new ConnectedInputPort<int>(output_port_.get(), 42.0));
+    port_->set_invalidation_callback(
+        std::bind(&ConnectedInputPortTest::Invalidate, this));
+  }
+
+  std::unique_ptr<OutputPort<int>> output_port_;
+  std::unique_ptr<ConnectedInputPort<int>> port_;
+  int64_t latest_version_ = -1;
+
+ private:
+  void Invalidate() {
+    latest_version_ = port_->get_version();
+  }
+};
+
+TEST_F(ConnectedInputPortTest, Access) {
+  VectorX<int> expected(2);
+  expected << 5, 6;
+  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+  EXPECT_EQ(42.0, port_->get_sample_time_sec());
+}
+
+// Tests that changes on the output port are propagated to the input port that
+// is connected to it.
+TEST_F(ConnectedInputPortTest, Mutation) {
+  EXPECT_EQ(0, port_->get_version());
+  output_port_->GetMutableVectorData()->get_mutable_value() << 7, 8;
+
+  // Check that the version number was incremented.
+  EXPECT_EQ(1, port_->get_version());
+
+  // Check that the invalidation callback was called.
+  EXPECT_EQ(1, latest_version_);
+
+  // Check that the vector contents changed.
+  VectorX<int> expected(2);
+  expected << 7, 8;
+  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/system_input_test.cc
+++ b/drake/systems/framework/test/system_input_test.cc
@@ -58,19 +58,19 @@ TEST_F(FreestandingInputPortTest, ContinouousPort) {
   EXPECT_EQ(0.0, port_->get_sample_time_sec());
 }
 
-class ConnectedInputPortTest : public ::testing::Test {
+class DependentInputPortTest : public ::testing::Test {
  protected:
   void SetUp() override {
     std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
     vec->get_mutable_value() << 5, 6;
     output_port_.reset(new OutputPort<int>(std::move(vec)));
-    port_.reset(new ConnectedInputPort<int>(output_port_.get(), 42.0));
+    port_.reset(new DependentInputPort<int>(output_port_.get(), 42.0));
     port_->set_invalidation_callback(
-        std::bind(&ConnectedInputPortTest::Invalidate, this));
+        std::bind(&DependentInputPortTest::Invalidate, this));
   }
 
   std::unique_ptr<OutputPort<int>> output_port_;
-  std::unique_ptr<ConnectedInputPort<int>> port_;
+  std::unique_ptr<DependentInputPort<int>> port_;
   int64_t latest_version_ = -1;
 
  private:
@@ -79,7 +79,7 @@ class ConnectedInputPortTest : public ::testing::Test {
   }
 };
 
-TEST_F(ConnectedInputPortTest, Access) {
+TEST_F(DependentInputPortTest, Access) {
   VectorX<int> expected(2);
   expected << 5, 6;
   EXPECT_EQ(expected, port_->get_vector_data()->get_value());
@@ -88,7 +88,7 @@ TEST_F(ConnectedInputPortTest, Access) {
 
 // Tests that changes on the output port are propagated to the input port that
 // is connected to it.
-TEST_F(ConnectedInputPortTest, Mutation) {
+TEST_F(DependentInputPortTest, Mutation) {
   EXPECT_EQ(0, port_->get_version());
   output_port_->GetMutableVectorData()->get_mutable_value() << 7, 8;
 

--- a/drake/systems/framework/test/system_output_test.cc
+++ b/drake/systems/framework/test/system_output_test.cc
@@ -1,0 +1,72 @@
+#include "drake/systems/framework/system_output.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace systems {
+
+class TestOutputPortListener : public OutputPortListenerInterface {
+ public:
+  void Invalidate() override {
+    invalidations_++;
+  };
+
+  int get_invalidations() { return invalidations_; }
+
+ private:
+  int invalidations_ = 0;
+};
+
+class OutputPortTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
+    vec->get_mutable_value() << 5, 6;
+    port_.reset(new OutputPort<int>(std::move(vec)));
+  }
+
+  std::unique_ptr<OutputPort<int>> port_;
+};
+
+TEST_F(OutputPortTest, Access) {
+  VectorX<int> expected(2);
+  expected << 5, 6;
+  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+}
+
+TEST_F(OutputPortTest, Mutation) {
+  EXPECT_EQ(0, port_->get_version());
+  port_->GetMutableVectorData()->get_mutable_value() << 7, 8;
+
+  // Check that the version number was incremented.
+  EXPECT_EQ(1, port_->get_version());
+
+  // Check that the vector contents changed.
+  VectorX<int> expected(2);
+  expected << 7, 8;
+  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+}
+
+TEST_F(OutputPortTest, Listeners) {
+  TestOutputPortListener a, b, c;
+  port_->add_dependent(&a);
+  port_->add_dependent(&b);
+  port_->GetMutableVectorData();
+  EXPECT_EQ(1, a.get_invalidations());
+  EXPECT_EQ(1, b.get_invalidations());
+  EXPECT_EQ(0, c.get_invalidations());
+
+  port_->remove_dependent(&a);
+  port_->add_dependent(&c);
+  port_->GetMutableVectorData();
+  EXPECT_EQ(1, a.get_invalidations());
+  EXPECT_EQ(2, b.get_invalidations());
+  EXPECT_EQ(1, c.get_invalidations());
+}
+
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This makes it possible to invalidate cache lines when inputs on which they depend are changed.

Refine Context::DoClone to make a deep copy of the input ports, so that invalidation notifications will not be propagated to input ports in cloned contexts.

@sherm1 for review; a lot of this you've seen before in #2510.  The new part is invalidation notifications: output ports know what input ports depend on them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2663)
<!-- Reviewable:end -->
