### PR TITLE
Replace TWIST_SIZE with drake::kTwistSize

### DIFF
--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -38,4 +38,19 @@ using AutoDiffUpTo73d = Eigen::AutoDiffScalar<VectorUpTo73d>;
 /// An autodiff variable with a dynamic number of partials.
 using AutoDiffXd = Eigen::AutoDiffScalar<Eigen::VectorXd>;
 
+/// https://en.wikipedia.org/wiki/Screw_theory#Twist
+constexpr int kTwistSize = 6;
+
+/// A column vector consisting of one twist.
+template <typename Scalar>
+using TwistVector = Eigen::Matrix<Scalar, kTwistSize, 1>;
+
+/// A matrix with one twist per column, and dynamically many columns.
+template <typename Scalar>
+using TwistMatrix = Eigen::Matrix<Scalar, kTwistSize, Eigen::Dynamic>;
+
+/// A six-by-six matrix.
+template <typename Scalar>
+using SquareTwistMatrix = Eigen::Matrix<Scalar, kTwistSize, kTwistSize>;
+
 }  // namespace drake

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -6,6 +6,7 @@
 
 #include "drake/Path.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
 #include "drake/solvers/fastQP.h"
 #include "drake/systems/controllers/controlUtil.h"
 #include "drake/util/eigen_matrix_compare.h"
@@ -790,14 +791,14 @@ int InstantaneousQPController::setupAndSolveQP(
   }
 
   // handle external wrenches to compensate for
-  eigen_aligned_unordered_map<RigidBody const*, Matrix<double, TWIST_SIZE, 1>>
+  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
       f_ext;
   for (auto it = qp_input.body_wrench_data.begin();
        it != qp_input.body_wrench_data.end(); ++it) {
     const drake::lcmt_body_wrench_data& body_wrench_data = *it;
     int body_id = body_or_frame_name_to_id.at(body_wrench_data.body_name);
     auto f_ext_i =
-        Map<const Matrix<double, TWIST_SIZE, 1>>(body_wrench_data.wrench);
+        Map<const drake::TwistVector<double>>(body_wrench_data.wrench);
     f_ext.insert({robot->bodies[body_id].get(), f_ext_i});
   }
 

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -288,8 +288,7 @@ InstantaneousQPController::loadAvailableSupports(
   // Parse a qp_input LCM message to extract its available supports as a vector
   // of SupportStateElements
   std::vector<SupportStateElement,
-              Eigen::aligned_allocator<SupportStateElement>>
-      available_supports;
+              Eigen::aligned_allocator<SupportStateElement>> available_supports;
   available_supports.resize(qp_input.num_support_data);
   for (int i = 0; i < qp_input.num_support_data; i++) {
     available_supports[i].body_idx =
@@ -647,10 +646,10 @@ int InstantaneousQPController::setupAndSolveQP(
               Eigen::aligned_allocator<SupportStateElement>>
       available_supports = loadAvailableSupports(qp_input);
   std::vector<SupportStateElement,
-              Eigen::aligned_allocator<SupportStateElement>>
-      active_supports = getActiveSupports(*robot, robot_state.q, robot_state.qd,
-                                          available_supports, contact_detected,
-                                          params.contact_threshold);
+              Eigen::aligned_allocator<SupportStateElement>> active_supports =
+      getActiveSupports(*robot, robot_state.q, robot_state.qd,
+                        available_supports, contact_detected,
+                        params.contact_threshold);
 
   // // whole_body_data
   if (qp_input.whole_body_data.num_positions != nq)

--- a/drake/systems/controllers/instantaneousQPControllermex.cpp
+++ b/drake/systems/controllers/instantaneousQPControllermex.cpp
@@ -22,7 +22,7 @@
 using namespace std;
 using namespace Eigen;
 
-void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   if (nrhs < 5)
     mexErrMsgTxt(
         "usage: "
@@ -31,8 +31,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
   if (nlhs < 1) mexErrMsgTxt("take at least one output... please.");
 
   // first get the ptr back from matlab
-  InstantaneousQPController *controller =
-      (InstantaneousQPController *)getDrakeMexPointer(prhs[0]);
+  InstantaneousQPController* controller =
+      (InstantaneousQPController*)getDrakeMexPointer(prhs[0]);
 
   // now retrieve the runtime params from their matlab object
   int narg = 1;
@@ -46,15 +46,15 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
   if (mxGetNumberOfElements(prhs[narg]) != (nq + nv))
     mexErrMsgTxt("size of x should be nq + nv\n");
   if (nq != nv) mexErrMsgTxt("still assume nv==nq");
-  double *q_ptr = mxGetPrSafe(prhs[narg]);
-  double *qd_ptr = &q_ptr[nq];
+  double* q_ptr = mxGetPrSafe(prhs[narg]);
+  double* qd_ptr = &q_ptr[nq];
   Map<VectorXd> q(q_ptr, nq);
   Map<VectorXd> qd(qd_ptr, nq);
   narg++;
 
   // qp_input
   drake::lcmt_qp_controller_input qp_input;
-  const mxArray *lcm_message_mex = prhs[narg];
+  const mxArray* lcm_message_mex = prhs[narg];
   if (!mxIsInt8(lcm_message_mex))
     mexErrMsgTxt("Expected an int8 array as the qp_input argument");
   qp_input.decode(mxGetData(lcm_message_mex), 0,
@@ -62,7 +62,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
   narg++;
 
   // contact_sensor
-  const mxArray *pobj = prhs[narg];
+  const mxArray* pobj = prhs[narg];
   Matrix<bool, Dynamic, 1> b_contact_force =
       Matrix<bool, Dynamic, 1>::Zero(controller->getRobot().bodies.size())
           .array();
@@ -87,7 +87,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 
   std::map<Side, ForceTorqueMeasurement> foot_force_torque_measurements;
   if (nrhs > 5) {
-    const mxArray *mex_foot_force_torque_measurements = prhs[narg++];
+    const mxArray* mex_foot_force_torque_measurements = prhs[narg++];
     if (!mxIsEmpty(mex_foot_force_torque_measurements)) {
       foot_force_torque_measurements[Side::LEFT].frame_idx =
           controller->getRobot().FindBodyIndex("l_foot");

--- a/drake/systems/controllers/instantaneousQPControllermex.cpp
+++ b/drake/systems/controllers/instantaneousQPControllermex.cpp
@@ -12,8 +12,11 @@
  */
 
 #include "InstantaneousQPController.h"
+
 #include <limits>
 #include <cmath>
+
+#include "drake/common/eigen_types.h"
 #include "drake/util/drakeMexUtil.h"
 
 using namespace std;
@@ -89,12 +92,12 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
       foot_force_torque_measurements[Side::LEFT].frame_idx =
           controller->getRobot().FindBodyIndex("l_foot");
       foot_force_torque_measurements[Side::LEFT].wrench =
-          matlabToEigenMap<TWIST_SIZE, 1>(
+          matlabToEigenMap<drake::kTwistSize, 1>(
               mxGetFieldSafe(mex_foot_force_torque_measurements, "left"));
       foot_force_torque_measurements[Side::RIGHT].frame_idx =
           controller->getRobot().FindBodyIndex("r_foot");
       foot_force_torque_measurements[Side::RIGHT].wrench =
-          matlabToEigenMap<TWIST_SIZE, 1>(
+          matlabToEigenMap<drake::kTwistSize, 1>(
               mxGetFieldSafe(mex_foot_force_torque_measurements, "right"));
     }
   }

--- a/drake/systems/plants/BotVisualizer.h
+++ b/drake/systems/plants/BotVisualizer.h
@@ -8,7 +8,6 @@
 // these could all go in the cpp file:
 #include "lcmtypes/drake/lcmt_viewer_load_robot.hpp"
 #include "lcmtypes/drake/lcmt_viewer_draw.hpp"
-#include "drake/util/drakeGeometryUtil.h"
 
 namespace Drake {
 

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -10,7 +10,13 @@ pods_install_pkg_config_file(drake-xml-util
   REQUIRES
   VERSION 0.0.1)
 
-add_library_with_exports(LIB_NAME drakeRBM SOURCE_FILES RigidBodyTree.cpp RigidBody.cpp RigidBodyTreeURDF.cpp RigidBodyTreeSDF.cpp RigidBodyTreeContact.cpp)
+add_library_with_exports(LIB_NAME drakeRBM SOURCE_FILES
+  RigidBodyTree.cpp
+  RigidBody.cpp
+  RigidBodyTreeURDF.cpp
+  RigidBodyTreeSDF.cpp
+  RigidBodyTreeContact.cpp
+  rigid_body_frame.cc)
 target_link_libraries(drakeRBM drakeCollision drakeJoints drakeUtil drakeXMLUtil)
 pods_install_libraries(drakeRBM)
 drake_install_headers(RigidBodyTree.h RigidBody.h RigidBodyFrame.h KinematicPath.h KinematicsCache.h ForceTorqueMeasurement.h)

--- a/drake/systems/plants/KinematicsCache.h
+++ b/drake/systems/plants/KinematicsCache.h
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
 #include "drake/systems/plants/RigidBody.h"
 #include "drake/systems/plants/joints/DrakeJoint.h"
 #include "drake/util/drakeGeometryUtil.h"
@@ -21,11 +22,12 @@ class KinematicsCacheElement {
   /*
    * Configuration dependent
    */
+
   Eigen::Transform<Scalar, SPACE_DIMENSION, Eigen::Isometry> transform_to_world;
-  Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic, 0, TWIST_SIZE,
+  Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic, 0, drake::kTwistSize,
                 DrakeJoint::MAX_NUM_VELOCITIES>
       motion_subspace_in_body;  // gradient w.r.t. q_i only
-  Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic, 0, TWIST_SIZE,
+  Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic, 0, drake::kTwistSize,
                 DrakeJoint::MAX_NUM_VELOCITIES>
       motion_subspace_in_world;  // gradient w.r.t. q
   Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,
@@ -34,24 +36,25 @@ class KinematicsCacheElement {
   Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,
                 DrakeJoint::MAX_NUM_POSITIONS,
                 DrakeJoint::MAX_NUM_VELOCITIES> v_to_qdot;  // gradient w.r.t. q
-  Eigen::Matrix<Scalar, TWIST_SIZE, TWIST_SIZE> inertia_in_world;
-  Eigen::Matrix<Scalar, TWIST_SIZE, TWIST_SIZE> crb_in_world;
+  drake::SquareTwistMatrix<Scalar> inertia_in_world;
+  drake::SquareTwistMatrix<Scalar> crb_in_world;
 
   /*
    * Configuration and velocity dependent
    */
-  Eigen::Matrix<Scalar, TWIST_SIZE, 1>
-      twist_in_world;  // gradient w.r.t. q only; gradient w.r.t. v is
-                       // motion_subspace_in_world
-  Eigen::Matrix<Scalar, TWIST_SIZE, 1>
-      motion_subspace_in_body_dot_times_v;  // gradient w.r.t. q_i and v_i only
-  Eigen::Matrix<Scalar, TWIST_SIZE, 1>
-      motion_subspace_in_world_dot_times_v;  // gradient w.r.t. q and v
+
+  // Gradient with respect to q only.  The gradient with respect to v is
+  // motion_subspace_in_world.
+  drake::TwistVector<Scalar> twist_in_world;
+  // Gradient with respect to q_i and v_i only.
+  drake::TwistVector<Scalar> motion_subspace_in_body_dot_times_v;
+  // Gradient with respect to q and v.
+  drake::TwistVector<Scalar> motion_subspace_in_world_dot_times_v;
 
  public:
   KinematicsCacheElement(int num_positions_joint, int num_velocities_joint)
-      : motion_subspace_in_body(TWIST_SIZE, num_velocities_joint),
-        motion_subspace_in_world(TWIST_SIZE, num_velocities_joint),
+      : motion_subspace_in_body(drake::kTwistSize, num_velocities_joint),
+        motion_subspace_in_world(drake::kTwistSize, num_velocities_joint),
         qdot_to_v(num_velocities_joint, num_positions_joint),
         v_to_qdot(num_positions_joint, num_velocities_joint) {
     // empty

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -43,8 +43,9 @@ const DrakeJoint& RigidBody::getJoint() const {
   if (joint) {
     return (*joint);
   } else {
-    throw runtime_error("ERROR: RigidBody::getJoint(): Rigid body \"" + name_
-      + "\" in model " + model_name_ + " does not have a joint!");
+    throw runtime_error("ERROR: RigidBody::getJoint(): Rigid body \"" + name_ +
+                        "\" in model " + model_name_ +
+                        " does not have a joint!");
   }
 }
 

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -1,6 +1,8 @@
-#include "RigidBody.h"
+#include "drake/systems/plants/RigidBody.h"
 
 #include <stdexcept>
+
+#include "drake/util/drakeGeometryUtil.h"
 
 using Eigen::Isometry3d;
 using Eigen::Matrix;
@@ -22,7 +24,7 @@ RigidBody::RigidBody()
   body_index = 0;
   mass = 0.0;
   com = Vector3d::Zero();
-  I << Matrix<double, TWIST_SIZE, TWIST_SIZE>::Zero();
+  I << drake::SquareTwistMatrix<double>::Zero();
 }
 
 const std::string& RigidBody::name() const { return name_; }

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -8,10 +8,10 @@
 #include <set>
 #include <string>
 
+#include "drake/common/eigen_types.h"
 #include "drake/drakeRBM_export.h"
 #include "drake/systems/plants/collision/DrakeCollision.h"
 #include "drake/systems/plants/joints/DrakeJoint.h"
-#include "drake/util/drakeGeometryUtil.h"
 
 class DRAKERBM_EXPORT RigidBody {
  private:
@@ -177,7 +177,7 @@ class DRAKERBM_EXPORT RigidBody {
 
   double mass;
   Eigen::Vector3d com;
-  Eigen::Matrix<double, TWIST_SIZE, TWIST_SIZE> I;
+  drake::SquareTwistMatrix<double> I;
 
   friend std::ostream& operator<<(std::ostream& out, const RigidBody& b);
 

--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -20,8 +20,7 @@ class DRAKERBM_EXPORT RigidBodyFrame {
                  const Eigen::Isometry3d& _transform_to_body)
       : name(_name),
         body(_body),
-        transform_to_body(_transform_to_body),
-        frame_index(0) {}
+        transform_to_body(_transform_to_body) {}
 
   /**
    * A constructor where the transform-to-body is specified using
@@ -29,19 +28,13 @@ class DRAKERBM_EXPORT RigidBodyFrame {
    */
   RigidBodyFrame(const std::string& _name, RigidBody* _body,
                  const Eigen::Vector3d& xyz = Eigen::Vector3d::Zero(),
-                 const Eigen::Vector3d& rpy = Eigen::Vector3d::Zero())
-      : name(_name), body(_body), frame_index(0) {
-    transform_to_body.matrix() << rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
-  }
+                 const Eigen::Vector3d& rpy = Eigen::Vector3d::Zero());
 
   /**
    * The default constructor.
    */
   RigidBodyFrame()
-      : name(""),
-        body(nullptr),
-        transform_to_body(Eigen::Isometry3d::Identity()),
-        frame_index(0) {}
+      : RigidBodyFrame("", nullptr, Eigen::Isometry3d::Identity()) {}
 
   /**
    * Returns the ID of the model to which this rigid body frame belongs.
@@ -51,7 +44,7 @@ class DRAKERBM_EXPORT RigidBodyFrame {
   std::string name;
   RigidBody* body;
   Eigen::Isometry3d transform_to_body;
-  int frame_index;  // this will be negative, but will also be gone soon!
+  int frame_index = 0;  // this will be negative, but will also be gone soon!
 
  public:
 #ifndef SWIG

--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -18,9 +18,7 @@ class DRAKERBM_EXPORT RigidBodyFrame {
    */
   RigidBodyFrame(const std::string& _name, RigidBody* _body,
                  const Eigen::Isometry3d& _transform_to_body)
-      : name(_name),
-        body(_body),
-        transform_to_body(_transform_to_body) {}
+      : name(_name), body(_body), transform_to_body(_transform_to_body) {}
 
   /**
    * A constructor where the transform-to-body is specified using

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -846,10 +846,9 @@ TwistVector<Scalar> RigidBodyTree::worldMomentumMatrixDotTimesV(
 }
 
 template <typename Scalar>
-TwistMatrix<Scalar>
-RigidBodyTree::centroidalMomentumMatrix(KinematicsCache<Scalar>& cache,
-                                        const std::set<int>& robotnum,
-                                        bool in_terms_of_qdot) const {
+TwistMatrix<Scalar> RigidBodyTree::centroidalMomentumMatrix(
+    KinematicsCache<Scalar>& cache, const std::set<int>& robotnum,
+    bool in_terms_of_qdot) const {
   // kinematics cache checks already being done in worldMomentumMatrix.
   auto ret = worldMomentumMatrix(cache, robotnum, in_terms_of_qdot);
 
@@ -1204,8 +1203,8 @@ TwistVector<Scalar> RigidBodyTree::relativeTwist(
 template <typename Scalar>
 TwistVector<Scalar> RigidBodyTree::transformSpatialAcceleration(
     const KinematicsCache<Scalar>& cache,
-    const TwistVector<Scalar>& spatial_acceleration, int base_ind,
-    int body_ind, int old_expressed_in_body_or_frame_ind,
+    const TwistVector<Scalar>& spatial_acceleration, int base_ind, int body_ind,
+    int old_expressed_in_body_or_frame_ind,
     int new_expressed_in_body_or_frame_ind) const {
   cache.checkCachedKinematicsSettings(true, true,
                                       "transformSpatialAcceleration");
@@ -1298,8 +1297,8 @@ Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyTree::massMatrix(
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::dynamicsBiasTerm(
     KinematicsCache<Scalar>& cache,
-    const eigen_aligned_unordered_map<RigidBody const*,
-                                      TwistVector<Scalar>>& f_ext,
+    const eigen_aligned_unordered_map<RigidBody const*, TwistVector<Scalar>>&
+        f_ext,
     bool include_velocity_terms) const {
   Matrix<Scalar, Eigen::Dynamic, 1> vd(num_velocities_, 1);
   vd.setZero();
@@ -1309,8 +1308,8 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::dynamicsBiasTerm(
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
     KinematicsCache<Scalar>& cache,
-    const eigen_aligned_unordered_map<RigidBody const*,
-                                      TwistVector<Scalar>>& f_ext,
+    const eigen_aligned_unordered_map<RigidBody const*, TwistVector<Scalar>>&
+        f_ext,
     const Matrix<Scalar, Eigen::Dynamic, 1>& vd,
     bool include_velocity_terms) const {
   cache.checkCachedKinematicsSettings(
@@ -1698,8 +1697,8 @@ RigidBody* RigidBodyTree::FindBody(const std::string& body_name,
 }
 
 RigidBody* RigidBodyTree::findLink(const std::string& link_name,
-                    const std::string& model_name,
-                    int model_id) const {
+                                   const std::string& model_name,
+                                   int model_id) const {
   return FindBody(link_name, model_name, model_id);
 }
 
@@ -1763,8 +1762,8 @@ int RigidBodyTree::FindBodyIndex(const std::string& body_name,
   return body->body_index;
 }
 
-int RigidBodyTree::findLinkId(const std::string& link_name, int model_id)
-                              const {
+int RigidBodyTree::findLinkId(const std::string& link_name,
+                              int model_id) const {
   return FindBodyIndex(link_name, model_id);
 }
 
@@ -2394,8 +2393,7 @@ template DRAKERBM_EXPORT KinematicsCache<double> RigidBodyTree::doKinematics(
     bool) const;
 template DRAKERBM_EXPORT KinematicsCache<double> RigidBodyTree::doKinematics(
     Eigen::MatrixBase<Eigen::Block<VectorXd, -1, 1, false>> const&,
-    Eigen::MatrixBase<Eigen::Block<VectorXd, -1, 1, false>> const&,
-    bool) const;
+    Eigen::MatrixBase<Eigen::Block<VectorXd, -1, 1, false>> const&, bool) const;
 template DRAKERBM_EXPORT KinematicsCache<AutoDiffXd>
 RigidBodyTree::doKinematics(Eigen::MatrixBase<VectorX<AutoDiffXd>> const&,
                             Eigen::MatrixBase<VectorX<AutoDiffXd>> const&,

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -197,19 +197,18 @@ class DRAKERBM_EXPORT RigidBodyTree {
       const std::set<int>& robotnum = default_robot_num_set) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic> worldMomentumMatrix(
+  drake::TwistMatrix<Scalar> worldMomentumMatrix(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set,
       bool in_terms_of_qdot = false) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, drake::kTwistSize, 1> worldMomentumMatrixDotTimesV(
+  drake::TwistVector<Scalar> worldMomentumMatrixDotTimesV(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic>
-  centroidalMomentumMatrix(
+  drake::TwistMatrix<Scalar> centroidalMomentumMatrix(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set,
       bool in_terms_of_qdot = false) const;

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -197,24 +197,25 @@ class DRAKERBM_EXPORT RigidBodyTree {
       const std::set<int>& robotnum = default_robot_num_set) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic> worldMomentumMatrix(
+  Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic> worldMomentumMatrix(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set,
       bool in_terms_of_qdot = false) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, TWIST_SIZE, 1> worldMomentumMatrixDotTimesV(
+  Eigen::Matrix<Scalar, drake::kTwistSize, 1> worldMomentumMatrixDotTimesV(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic> centroidalMomentumMatrix(
+  Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic>
+  centroidalMomentumMatrix(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set,
       bool in_terms_of_qdot = false) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, TWIST_SIZE, 1> centroidalMomentumMatrixDotTimesV(
+  drake::TwistVector<Scalar> centroidalMomentumMatrixDotTimesV(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set) const;
 
@@ -284,7 +285,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(
       KinematicsCache<Scalar>& cache,
       const eigen_aligned_unordered_map<
-          RigidBody const*, Eigen::Matrix<Scalar, TWIST_SIZE, 1> >& f_ext,
+          RigidBody const*, drake::TwistVector<Scalar>>& f_ext,
       bool include_velocity_terms = true) const;
 
   /** \brief Compute
@@ -317,7 +318,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> inverseDynamics(
       KinematicsCache<Scalar>& cache,
       const eigen_aligned_unordered_map<
-          RigidBody const*, Eigen::Matrix<Scalar, TWIST_SIZE, 1> >& f_ext,
+          RigidBody const*, drake::TwistVector<Scalar>>& f_ext,
       const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& vd,
       bool include_velocity_terms = true) const;
 
@@ -401,27 +402,27 @@ class DRAKERBM_EXPORT RigidBodyTree {
                                         int to_body_or_frame_ind) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic> geometricJacobian(
+  drake::TwistMatrix<Scalar> geometricJacobian(
       const KinematicsCache<Scalar>& cache, int base_body_or_frame_ind,
       int end_effector_body_or_frame_ind, int expressed_in_body_or_frame_ind,
       bool in_terms_of_qdot = false,
       std::vector<int>* v_indices = nullptr) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, TWIST_SIZE, 1> geometricJacobianDotTimesV(
+  drake::TwistVector<Scalar> geometricJacobianDotTimesV(
       const KinematicsCache<Scalar>& cache, int base_body_or_frame_ind,
       int end_effector_body_or_frame_ind,
       int expressed_in_body_or_frame_ind) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, TWIST_SIZE, 1> relativeTwist(
+  drake::TwistVector<Scalar> relativeTwist(
       const KinematicsCache<Scalar>& cache, int base_or_frame_ind,
       int body_or_frame_ind, int expressed_in_body_or_frame_ind) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, TWIST_SIZE, 1> transformSpatialAcceleration(
+  drake::TwistVector<Scalar> transformSpatialAcceleration(
       const KinematicsCache<Scalar>& cache,
-      const Eigen::Matrix<Scalar, TWIST_SIZE, 1>& spatial_acceleration,
+      const drake::TwistVector<Scalar>& spatial_acceleration,
       int base_or_frame_ind, int body_or_frame_ind, int old_body_or_frame_ind,
       int new_body_or_frame_ind) const;
 
@@ -802,7 +803,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   // Rigid body loops
   std::vector<RigidBodyLoop, Eigen::aligned_allocator<RigidBodyLoop> > loops;
 
-  Eigen::Matrix<double, TWIST_SIZE, 1> a_grav;
+  drake::TwistVector<double> a_grav;
   Eigen::MatrixXd B;  // the B matrix maps inputs into joint-space forces
 
  private:

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -129,7 +129,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
 
   void surfaceTangents(
       Eigen::Map<Eigen::Matrix3Xd> const& normals,
-      std::vector<Eigen::Map<Eigen::Matrix3Xd> >& tangents) const;
+      std::vector<Eigen::Map<Eigen::Matrix3Xd>>& tangents) const;
 
   /*!
    * Updates the frame of collision elements to be equal to the joint's frame.
@@ -284,8 +284,8 @@ class DRAKERBM_EXPORT RigidBodyTree {
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(
       KinematicsCache<Scalar>& cache,
-      const eigen_aligned_unordered_map<
-          RigidBody const*, drake::TwistVector<Scalar>>& f_ext,
+      const eigen_aligned_unordered_map<RigidBody const*,
+                                        drake::TwistVector<Scalar>>& f_ext,
       bool include_velocity_terms = true) const;
 
   /** \brief Compute
@@ -317,8 +317,8 @@ class DRAKERBM_EXPORT RigidBodyTree {
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> inverseDynamics(
       KinematicsCache<Scalar>& cache,
-      const eigen_aligned_unordered_map<
-          RigidBody const*, drake::TwistVector<Scalar>>& f_ext,
+      const eigen_aligned_unordered_map<RigidBody const*,
+                                        drake::TwistVector<Scalar>>& f_ext,
       const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& vd,
       bool include_velocity_terms = true) const;
 
@@ -575,13 +575,12 @@ class DRAKERBM_EXPORT RigidBodyTree {
                       const std::string& model_name = "",
                       int model_id = -1) const;
 
-  /**
-   * This is a deprecated version of `FindBody(...)`. Please use `FindBody(...)`
-   * instead.
-   */
+/**
+ * This is a deprecated version of `FindBody(...)`. Please use `FindBody(...)`
+ * instead.
+ */
 #ifndef SWIG
-      DRAKE_DEPRECATED(
-          "Please use RigidBodyTree::FindBody instead.")
+  DRAKE_DEPRECATED("Please use RigidBodyTree::FindBody instead.")
 #endif
   RigidBody* findLink(const std::string& link_name,
                       const std::string& model_name = "",
@@ -605,13 +604,12 @@ class DRAKERBM_EXPORT RigidBodyTree {
    */
   int FindBodyIndex(const std::string& body_name, int model_id = -1) const;
 
-  /**
-   * This is a deprecated version of `FindBodyIndex(...)`. Please use
-   * `FindBodyIndex(...)` instead.
-   */
+/**
+ * This is a deprecated version of `FindBodyIndex(...)`. Please use
+ * `FindBodyIndex(...)` instead.
+ */
 #ifndef SWIG
-      DRAKE_DEPRECATED(
-          "Pleasse use RigidBodyTree::FindBodyIndex instead.")
+  DRAKE_DEPRECATED("Pleasse use RigidBodyTree::FindBodyIndex instead.")
 #endif
   int findLinkId(const std::string& link_name, int model_id = -1) const;
 
@@ -696,8 +694,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
      */
     int ncols = in_terms_of_qdot ? num_positions_ : num_velocities_;
     Eigen::Matrix<typename Derived::Scalar, Derived::RowsAtCompileTime,
-                  Eigen::Dynamic>
-        full(compact.rows(), ncols);
+                  Eigen::Dynamic> full(compact.rows(), ncols);
     full.setZero();
     int compact_col_start = 0;
     for (std::vector<int>::const_iterator it = joint_path.begin();
@@ -791,17 +788,17 @@ class DRAKERBM_EXPORT RigidBodyTree {
   // TODO(amcastro-tri): make private and start using accessors body(int).
   // TODO(amcastro-tri): rename to bodies_ to follow Google's style guide once.
   // accessors are used throughout the code.
-  std::vector<std::unique_ptr<RigidBody> > bodies;
+  std::vector<std::unique_ptr<RigidBody>> bodies;
 
   // Rigid body frames
-  std::vector<std::shared_ptr<RigidBodyFrame> > frames;
+  std::vector<std::shared_ptr<RigidBodyFrame>> frames;
 
   // Rigid body actuators
-  std::vector<RigidBodyActuator, Eigen::aligned_allocator<RigidBodyActuator> >
+  std::vector<RigidBodyActuator, Eigen::aligned_allocator<RigidBodyActuator>>
       actuators;
 
   // Rigid body loops
-  std::vector<RigidBodyLoop, Eigen::aligned_allocator<RigidBodyLoop> > loops;
+  std::vector<RigidBodyLoop, Eigen::aligned_allocator<RigidBodyLoop>> loops;
 
   drake::TwistVector<double> a_grav;
   Eigen::MatrixXd B;  // the B matrix maps inputs into joint-space forces

--- a/drake/systems/plants/RigidBodyTreeSDF.cpp
+++ b/drake/systems/plants/RigidBodyTreeSDF.cpp
@@ -4,6 +4,7 @@
 
 #include "spruce.hh"
 
+#include "drake/common/eigen_types.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/thirdParty/tinyxml2/tinyxml2.h"
 #include "joints/DrakeJoints.h"
@@ -35,8 +36,7 @@ void parseSDFInertial(RigidBody* body, XMLElement* node, RigidBodyTree* model,
 
   body->com = T_link.inverse() * T.translation();
 
-  Matrix<double, TWIST_SIZE, TWIST_SIZE> I =
-      Matrix<double, TWIST_SIZE, TWIST_SIZE>::Zero();
+  drake::SquareTwistMatrix<double> I = drake::SquareTwistMatrix<double>::Zero();
   I.block(3, 3, 3, 3) << body->mass * Matrix3d::Identity();
 
   XMLElement* inertia = node->FirstChildElement("inertia");

--- a/drake/systems/plants/RigidBodyTreeURDF.cpp
+++ b/drake/systems/plants/RigidBodyTreeURDF.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <string>
 
+#include "drake/common/eigen_types.h"
 #include "drake/systems/plants/joints/DrakeJoints.h"
 #include "drake/systems/plants/material_map.h"
 #include "drake/systems/plants/rigid_body_tree_urdf.h"
@@ -96,8 +97,7 @@ void parseInertial(RigidBody* body, XMLElement* node, RigidBodyTree* model) {
 
   body->com << T(0, 3), T(1, 3), T(2, 3);
 
-  Matrix<double, TWIST_SIZE, TWIST_SIZE> I =
-      Matrix<double, TWIST_SIZE, TWIST_SIZE>::Zero();
+  drake::SquareTwistMatrix<double> I = drake::SquareTwistMatrix<double>::Zero();
   I.block(3, 3, 3, 3) << body->mass * Matrix3d::Identity();
 
   XMLElement* inertia = node->FirstChildElement("inertia");

--- a/drake/systems/plants/RigidBodyTreeURDF.cpp
+++ b/drake/systems/plants/RigidBodyTreeURDF.cpp
@@ -1060,8 +1060,8 @@ std::shared_ptr<RigidBodyFrame> MakeRigidBodyFrameFromURDFNode(
   std::string body_name = link->Attribute("link");
   RigidBody* body = model.FindBody(body_name);
   if (body == nullptr) {
-    throw runtime_error("ERROR: Couldn't find body \"" + body_name + "\""
-                        " referenced in frame \"" + name + "\".");
+    throw runtime_error("ERROR: Couldn't find body \"" + body_name +
+                        "\" referenced in frame \"" + name + "\".");
   }
 
   Vector3d xyz = Vector3d::Zero(), rpy = Vector3d::Zero();

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -384,7 +384,7 @@ SingleTimeLinearPostureConstraint::SingleTimeLinearPostureConstraint(
   jAvar_ = jAvar;
   A_ = A;
   A_mat_.resize(num_constraint_,
-    this->getRobotPointer()->number_of_positions());
+                this->getRobotPointer()->number_of_positions());
   A_mat_.reserve(lenA);
 
   for (int i = 0; i < lenA; i++) {
@@ -1416,7 +1416,7 @@ void Point2PointDistanceConstraint::eval(const double* t,
     int num_cnst = this->getNumConstraint(t);
     MatrixXd posA(3, ptA_.cols());
     MatrixXd dposA(3 * ptA_.cols(),
-      this->getRobotPointer()->number_of_positions());
+                   this->getRobotPointer()->number_of_positions());
     if (bodyA_ != 0) {
       posA = getRobotPointer()->transformPoints(cache, ptA_, bodyA_, 0);
       dposA = getRobotPointer()->transformPointsJacobian(cache, ptA_, bodyA_, 0,
@@ -1428,7 +1428,7 @@ void Point2PointDistanceConstraint::eval(const double* t,
     }
     MatrixXd posB(3, ptB_.cols());
     MatrixXd dposB(3 * ptB_.cols(),
-      this->getRobotPointer()->number_of_positions());
+                   this->getRobotPointer()->number_of_positions());
     if (bodyB_ != 0) {
       posB = getRobotPointer()->transformPoints(cache, ptB_, bodyB_, 0);
       dposB = getRobotPointer()->transformPointsJacobian(cache, ptB_, bodyB_, 0,
@@ -1446,9 +1446,9 @@ void Point2PointDistanceConstraint::eval(const double* t,
     c = tmp2.transpose();
     dc.resize(num_cnst, this->getRobotPointer()->number_of_positions());
     for (int i = 0; i < num_cnst; i++) {
-      dc.row(i) = 2 * d.col(i).transpose() *
-                  dd.block(3 * i, 0, 3,
-                    this->getRobotPointer()->number_of_positions());
+      dc.row(i) =
+          2 * d.col(i).transpose() *
+          dd.block(3 * i, 0, 3, this->getRobotPointer()->number_of_positions());
     }
   } else {
     c.resize(0);
@@ -1988,8 +1988,8 @@ void MinDistanceConstraint::eval(const double* t,
     }
 
     int num_pts = static_cast<int>(xA.cols());
-    ddist_dq = MatrixXd::Zero(num_pts,
-      getRobotPointer()->number_of_positions());
+    ddist_dq =
+        MatrixXd::Zero(num_pts, getRobotPointer()->number_of_positions());
 
     // Compute Jacobian of closest distance vector
     // DEBUG
@@ -2312,9 +2312,10 @@ void GravityCompensationTorqueConstraint::eval(const double* t,
   // FIXME: very inefficient:
   typedef AutoDiffScalar<VectorXd> Scalar;
   auto q = cache.getQ().cast<Scalar>().eval();
-  gradientMatrixToAutoDiff(MatrixXd::Identity(
-    getRobotPointer()->number_of_positions(),
-    getRobotPointer()->number_of_positions()), q);
+  gradientMatrixToAutoDiff(
+      MatrixXd::Identity(getRobotPointer()->number_of_positions(),
+                         getRobotPointer()->number_of_positions()),
+      q);
   KinematicsCache<Scalar> cache_with_gradients =
       getRobotPointer()->doKinematics(q);
   eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<Scalar>>
@@ -2330,9 +2331,8 @@ void GravityCompensationTorqueConstraint::eval(const double* t,
 
   for (int i = 0; i < num_constraint; ++i) {
     c(i) = G(joint_indices_(i));
-    dc.row(i) =
-        dG.block(joint_indices_(i), 0, 1,
-          getRobotPointer()->number_of_positions());
+    dc.row(i) = dG.block(joint_indices_(i), 0, 1,
+                         getRobotPointer()->number_of_positions());
   }
 }
 

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -2317,7 +2317,7 @@ void GravityCompensationTorqueConstraint::eval(const double* t,
     getRobotPointer()->number_of_positions()), q);
   KinematicsCache<Scalar> cache_with_gradients =
       getRobotPointer()->doKinematics(q);
-  eigen_aligned_unordered_map<RigidBody const*, Matrix<Scalar, TWIST_SIZE, 1>>
+  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<Scalar>>
       f_ext;
   auto G_autodiff =
       getRobotPointer()->dynamicsBiasTerm(cache_with_gradients, f_ext, false);

--- a/drake/systems/plants/joints/DrakeJoint.h
+++ b/drake/systems/plants/joints/DrakeJoint.h
@@ -6,43 +6,43 @@
 #include <Eigen/Geometry>
 #include <unsupported/Eigen/AutoDiff>
 
+#include "drake/common/eigen_types.h"
 #include "drake/math/gradient.h"
-#include "drake/util/drakeGeometryUtil.h"
 #include "drake/drakeJoints_export.h"
 
-#define POSITION_AND_VELOCITY_DEPENDENT_METHODS(Scalar)                    \
-  virtual Eigen::Transform<Scalar, 3, Eigen::Isometry> jointTransform(     \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q) \
-      const = 0;                                                           \
-  virtual void motionSubspace(                                             \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
-      Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic, 0, TWIST_SIZE,     \
-                    MAX_NUM_VELOCITIES>& motion_subspace,                  \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>*               \
-          dmotion_subspace = nullptr) const = 0;                           \
-  virtual void motionSubspaceDotTimesV(                                    \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v, \
-      Eigen::Matrix<Scalar, 6, 1>& motion_subspace_dot_times_v,            \
-      drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>,                   \
-                            Eigen::Dynamic>::type*                         \
-          dmotion_subspace_dot_times_vdq = nullptr,                        \
-      drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>, Eigen::Dynamic>:: \
-          type* dmotion_subspace_dot_times_vdv = nullptr) const = 0;       \
-  virtual void qdot2v(                                                     \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,             \
-                    MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS>& qdot_to_v,     \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dqdot_to_v)   \
-      const = 0;                                                           \
-  virtual void v2qdot(                                                     \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,             \
-                    MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES>& v_to_qdot,     \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dv_to_qdot)   \
-      const = 0;                                                           \
-  virtual Eigen::Matrix<Scalar, Eigen::Dynamic, 1> frictionTorque(         \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v) \
+#define POSITION_AND_VELOCITY_DEPENDENT_METHODS(Scalar)                      \
+  virtual Eigen::Transform<Scalar, 3, Eigen::Isometry> jointTransform(       \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q)   \
+      const = 0;                                                             \
+  virtual void motionSubspace(                                               \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q,   \
+      Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic, 0,            \
+                    drake::kTwistSize, MAX_NUM_VELOCITIES>& motion_subspace, \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>*                 \
+          dmotion_subspace = nullptr) const = 0;                             \
+  virtual void motionSubspaceDotTimesV(                                      \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q,   \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v,   \
+      Eigen::Matrix<Scalar, 6, 1>& motion_subspace_dot_times_v,              \
+      drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>,                     \
+                            Eigen::Dynamic>::type*                           \
+          dmotion_subspace_dot_times_vdq = nullptr,                          \
+      drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>, Eigen::Dynamic>::   \
+          type* dmotion_subspace_dot_times_vdv = nullptr) const = 0;         \
+  virtual void qdot2v(                                                       \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q,   \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,               \
+                    MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS>& qdot_to_v,       \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dqdot_to_v)     \
+      const = 0;                                                             \
+  virtual void v2qdot(                                                       \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q,   \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,               \
+                    MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES>& v_to_qdot,       \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dv_to_qdot)     \
+      const = 0;                                                             \
+  virtual Eigen::Matrix<Scalar, Eigen::Dynamic, 1> frictionTorque(           \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v)   \
       const = 0;
 
 class DRAKEJOINTS_EXPORT DrakeJoint {

--- a/drake/systems/plants/joints/DrakeJointImpl.h
+++ b/drake/systems/plants/joints/DrakeJointImpl.h
@@ -4,55 +4,55 @@
 
 #include "drake/math/gradient.h"
 
-#define POSITION_AND_VELOCITY_DEPENDENT_METHODS_IMPL(Scalar)               \
-  virtual Eigen::Transform<Scalar, 3, Eigen::Isometry> jointTransform(     \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q) \
-      const override {                                                     \
-    return derived.jointTransform(q);                                      \
-  };                                                                       \
-  void motionSubspace(                                                     \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
-      Eigen::Matrix<Scalar, TWIST_SIZE, Eigen::Dynamic, 0, TWIST_SIZE,     \
-                    MAX_NUM_VELOCITIES>& motion_subspace,                  \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>*               \
-          dmotion_subspace = nullptr) const override {                     \
-    derived.motionSubspace(q, motion_subspace, dmotion_subspace);          \
-  };                                                                       \
-  void motionSubspaceDotTimesV(                                            \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v, \
-      Eigen::Matrix<Scalar, 6, 1>& motion_subspace_dot_times_v,            \
-      typename drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>,          \
-                                     Eigen::Dynamic>::type*                \
-          dmotion_subspace_dot_times_vdq = nullptr,                        \
-      typename drake::math::Gradient<                                      \
-          Eigen::Matrix<Scalar, 6, 1>,                                     \
-          Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv = nullptr) \
-      const override {                                                     \
-    derived.motionSubspaceDotTimesV(q, v, motion_subspace_dot_times_v,     \
-                                    dmotion_subspace_dot_times_vdq,        \
-                                    dmotion_subspace_dot_times_vdv);       \
-  };                                                                       \
-  void qdot2v(                                                             \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,             \
-                    MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS>& qdot_to_v,     \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dqdot_to_v)   \
-      const override {                                                     \
-    derived.qdot2v(q, qdot_to_v, dqdot_to_v);                              \
-  };                                                                       \
-  void v2qdot(                                                             \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q, \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,             \
-                    MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES>& v_to_qdot,     \
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dv_to_qdot)   \
-      const override {                                                     \
-    derived.v2qdot(q, v_to_qdot, dv_to_qdot);                              \
-  };                                                                       \
-  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> frictionTorque(                 \
-      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v) \
-      const override {                                                     \
-    return derived.frictionTorque(v);                                      \
+#define POSITION_AND_VELOCITY_DEPENDENT_METHODS_IMPL(Scalar)                 \
+  virtual Eigen::Transform<Scalar, 3, Eigen::Isometry> jointTransform(       \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q)   \
+      const override {                                                       \
+    return derived.jointTransform(q);                                        \
+  };                                                                         \
+  void motionSubspace(                                                       \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q,   \
+      Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic, 0,            \
+                    drake::kTwistSize, MAX_NUM_VELOCITIES>& motion_subspace, \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>*                 \
+          dmotion_subspace = nullptr) const override {                       \
+    derived.motionSubspace(q, motion_subspace, dmotion_subspace);            \
+  };                                                                         \
+  void motionSubspaceDotTimesV(                                              \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q,   \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v,   \
+      Eigen::Matrix<Scalar, 6, 1>& motion_subspace_dot_times_v,              \
+      typename drake::math::Gradient<Eigen::Matrix<Scalar, 6, 1>,            \
+                                     Eigen::Dynamic>::type*                  \
+          dmotion_subspace_dot_times_vdq = nullptr,                          \
+      typename drake::math::Gradient<                                        \
+          Eigen::Matrix<Scalar, 6, 1>,                                       \
+          Eigen::Dynamic>::type* dmotion_subspace_dot_times_vdv = nullptr)   \
+      const override {                                                       \
+    derived.motionSubspaceDotTimesV(q, v, motion_subspace_dot_times_v,       \
+                                    dmotion_subspace_dot_times_vdq,          \
+                                    dmotion_subspace_dot_times_vdv);         \
+  };                                                                         \
+  void qdot2v(                                                               \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q,   \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,               \
+                    MAX_NUM_VELOCITIES, MAX_NUM_POSITIONS>& qdot_to_v,       \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dqdot_to_v)     \
+      const override {                                                       \
+    derived.qdot2v(q, qdot_to_v, dqdot_to_v);                                \
+  };                                                                         \
+  void v2qdot(                                                               \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q,   \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0,               \
+                    MAX_NUM_POSITIONS, MAX_NUM_VELOCITIES>& v_to_qdot,       \
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>* dv_to_qdot)     \
+      const override {                                                       \
+    derived.v2qdot(q, v_to_qdot, dv_to_qdot);                                \
+  };                                                                         \
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> frictionTorque(                   \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v)   \
+      const override {                                                       \
+    return derived.frictionTorque(v);                                        \
   };
 
 template <typename Derived>

--- a/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
+++ b/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
@@ -8,6 +8,7 @@
 #include <Eigen/Core>
 
 #include "DrakeJointImpl.h"
+#include "drake/common/eigen_types.h"
 #include "drake/util/drakeGradientUtil.h"
 
 template <typename Derived>
@@ -17,7 +18,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
   // FixedAxisOneDoFJoint& operator=(const FixedAxisOneDoFJoint&) = delete;
 
  private:
-  Eigen::Matrix<double, TWIST_SIZE, 1> joint_axis;
+  drake::TwistVector<double> joint_axis;
   double damping;
   double coulomb_friction;
   double coulomb_window;
@@ -25,7 +26,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
  protected:
   FixedAxisOneDoFJoint(Derived& derived, const std::string& name,
                        const Eigen::Isometry3d& transform_to_parent_body,
-                       const Eigen::Matrix<double, TWIST_SIZE, 1>& _joint_axis)
+                       const drake::TwistVector<double>& _joint_axis)
       : DrakeJointImpl<Derived>(derived, name, transform_to_parent_body, 1, 1),
         joint_axis(_joint_axis),
         damping(0.0),
@@ -65,11 +66,11 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
     motion_subspace_dot_times_v.setZero();
 
     if (dmotion_subspace_dot_times_vdq) {
-      dmotion_subspace_dot_times_vdq->setZero(TWIST_SIZE, 1);
+      dmotion_subspace_dot_times_vdq->setZero(drake::kTwistSize, 1);
     }
 
     if (dmotion_subspace_dot_times_vdv) {
-      dmotion_subspace_dot_times_vdv->setZero(TWIST_SIZE, 1);
+      dmotion_subspace_dot_times_vdv->setZero(drake::kTwistSize, 1);
     }
   }
 

--- a/drake/systems/plants/joints/FixedJoint.h
+++ b/drake/systems/plants/joints/FixedJoint.h
@@ -2,6 +2,8 @@
 
 #include "DrakeJointImpl.h"
 
+#include "drake/common/eigen_types.h"
+
 class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
  public:
   FixedJoint(const std::string& name,
@@ -23,7 +25,7 @@ class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
       Eigen::MatrixBase<DerivedMS>& motion_subspace,
       typename drake::math::Gradient<DerivedMS, Eigen::Dynamic>::type*
           dmotion_subspace = nullptr) const {
-    motion_subspace.resize(TWIST_SIZE, getNumVelocities());
+    motion_subspace.resize(drake::kTwistSize, getNumVelocities());
     if (dmotion_subspace) {
       dmotion_subspace->resize(motion_subspace.size(), getNumPositions());
     }
@@ -44,11 +46,11 @@ class DRAKEJOINTS_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
     motion_subspace_dot_times_v.setZero();
 
     if (dmotion_subspace_dot_times_vdq) {
-      dmotion_subspace_dot_times_vdq->setZero(TWIST_SIZE, 1);
+      dmotion_subspace_dot_times_vdq->setZero(drake::kTwistSize, 1);
     }
 
     if (dmotion_subspace_dot_times_vdv) {
-      dmotion_subspace_dot_times_vdv->setZero(TWIST_SIZE, 1);
+      dmotion_subspace_dot_times_vdv->setZero(drake::kTwistSize, 1);
     }
   }
 

--- a/drake/systems/plants/joints/HelicalJoint.cpp
+++ b/drake/systems/plants/joints/HelicalJoint.cpp
@@ -2,9 +2,9 @@
 
 using namespace Eigen;
 
-Matrix<double, TWIST_SIZE, 1> HelicalJoint::spatialJointAxis(
+drake::TwistVector<double> HelicalJoint::spatialJointAxis(
     const Vector3d& axis, double pitch) {
-  Matrix<double, TWIST_SIZE, 1> ret;
+  drake::TwistVector<double> ret;
   ret.topRows<3>() = axis;
   ret.bottomRows<3>() = pitch * axis;
   return ret;

--- a/drake/systems/plants/joints/HelicalJoint.cpp
+++ b/drake/systems/plants/joints/HelicalJoint.cpp
@@ -2,8 +2,8 @@
 
 using namespace Eigen;
 
-drake::TwistVector<double> HelicalJoint::spatialJointAxis(
-    const Vector3d& axis, double pitch) {
+drake::TwistVector<double> HelicalJoint::spatialJointAxis(const Vector3d& axis,
+                                                          double pitch) {
   drake::TwistVector<double> ret;
   ret.topRows<3>() = axis;
   ret.bottomRows<3>() = pitch * axis;

--- a/drake/systems/plants/joints/HelicalJoint.h
+++ b/drake/systems/plants/joints/HelicalJoint.h
@@ -2,6 +2,8 @@
 
 #include "FixedAxisOneDoFJoint.h"
 
+#include "drake/common/eigen_types.h"
+
 class DRAKEJOINTS_EXPORT HelicalJoint
     : public FixedAxisOneDoFJoint<HelicalJoint> {
   // disable copy construction and assignment
@@ -36,7 +38,7 @@ class DRAKEJOINTS_EXPORT HelicalJoint
   }
 
  private:
-  static Eigen::Matrix<double, TWIST_SIZE, 1> spatialJointAxis(
+  static drake::TwistVector<double> spatialJointAxis(
       const Eigen::Vector3d& axis, double pitch);
 
  public:

--- a/drake/systems/plants/joints/PrismaticJoint.cpp
+++ b/drake/systems/plants/joints/PrismaticJoint.cpp
@@ -2,9 +2,9 @@
 
 using namespace Eigen;
 
-Matrix<double, TWIST_SIZE, 1> PrismaticJoint::spatialJointAxis(
+drake::TwistVector<double> PrismaticJoint::spatialJointAxis(
     const Vector3d& translation_axis) {
-  Matrix<double, TWIST_SIZE, 1> ret;
+  drake::TwistVector<double> ret;
   ret.topRows<3>() = Vector3d::Zero();
   ret.bottomRows<3>() = translation_axis;
   return ret;

--- a/drake/systems/plants/joints/PrismaticJoint.h
+++ b/drake/systems/plants/joints/PrismaticJoint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
 #include "FixedAxisOneDoFJoint.h"
 
 class DRAKEJOINTS_EXPORT PrismaticJoint
@@ -37,7 +38,7 @@ class DRAKEJOINTS_EXPORT PrismaticJoint
   virtual ~PrismaticJoint() {}
 
  private:
-  static Eigen::Matrix<double, TWIST_SIZE, 1> spatialJointAxis(
+  static drake::TwistVector<double> spatialJointAxis(
       const Eigen::Vector3d& translation_axis);
 
  public:

--- a/drake/systems/plants/joints/QuaternionFloatingJoint.h
+++ b/drake/systems/plants/joints/QuaternionFloatingJoint.h
@@ -1,15 +1,12 @@
 #pragma once
 
-#include "DrakeJointImpl.h"
+#include "drake/common/eigen_types.h"
+#include "drake/systems/plants/joints/DrakeJointImpl.h"
 #include "drake/util/drakeGeometryUtil.h"
+#include "drake/util/drakeGradientUtil.h"
 
 class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
     : public DrakeJointImpl<QuaternionFloatingJoint> {
-  // disable copy construction and assignment
-  // QuaternionFloatingJoint(const QuaternionFloatingJoint&) = delete;
-  // QuaternionFloatingJoint& operator=(const QuaternionFloatingJoint&) =
-  // delete;
-
  public:
   QuaternionFloatingJoint(const std::string& name,
                           const Eigen::Isometry3d& transform_to_parent_body)
@@ -33,7 +30,7 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
       Eigen::MatrixBase<DerivedMS>& motion_subspace,
       typename drake::math::Gradient<DerivedMS, Eigen::Dynamic>::type*
           dmotion_subspace = nullptr) const {
-    motion_subspace.setIdentity(TWIST_SIZE, getNumVelocities());
+    motion_subspace.setIdentity(drake::kTwistSize, getNumVelocities());
     if (dmotion_subspace) {
       dmotion_subspace->setZero(motion_subspace.size(), getNumPositions());
     }

--- a/drake/systems/plants/joints/RevoluteJoint.cpp
+++ b/drake/systems/plants/joints/RevoluteJoint.cpp
@@ -2,9 +2,9 @@
 
 using namespace Eigen;
 
-Matrix<double, TWIST_SIZE, 1> RevoluteJoint::spatialJointAxis(
+drake::TwistVector<double> RevoluteJoint::spatialJointAxis(
     const Vector3d& rotation_axis) {
-  Matrix<double, TWIST_SIZE, 1> ret;
+  drake::TwistVector<double> ret;
   ret.topRows<3>() = rotation_axis;
   ret.bottomRows<3>() = Vector3d::Zero();
   return ret;

--- a/drake/systems/plants/joints/RevoluteJoint.h
+++ b/drake/systems/plants/joints/RevoluteJoint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
 #include "FixedAxisOneDoFJoint.h"
 #include <Eigen/Geometry>
 
@@ -37,7 +38,7 @@ class DRAKEJOINTS_EXPORT RevoluteJoint
   }
 
  private:
-  static Eigen::Matrix<double, TWIST_SIZE, 1> spatialJointAxis(
+  static drake::TwistVector<double> spatialJointAxis(
       const Eigen::Vector3d& rotation_axis);
 
  public:

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "DrakeJointImpl.h"
+#include "drake/common/eigen_types.h"
+#include "drake/util/drakeGeometryUtil.h"
+#include "drake/util/drakeGradientUtil.h"
 
 class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
     : public DrakeJointImpl<RollPitchYawFloatingJoint> {
@@ -36,7 +39,7 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
       typename drake::math::Gradient<DerivedMS, Eigen::Dynamic>::type*
           dmotion_subspace = nullptr) const {
     typedef typename DerivedQ::Scalar Scalar;
-    motion_subspace.resize(TWIST_SIZE, getNumVelocities());
+    motion_subspace.resize(drake::kTwistSize, getNumVelocities());
     auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
     Eigen::Matrix<Scalar, SPACE_DIMENSION, RPY_SIZE> E;
     rpydot2angularvelMatrix(rpy, E);
@@ -97,7 +100,7 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
           Eigen::Matrix<typename DerivedQ::Scalar, 6, 1>, Eigen::Dynamic>::type*
           dmotion_subspace_dot_times_vdv = nullptr) const {
     typedef typename DerivedQ::Scalar Scalar;
-    motion_subspace_dot_times_v.resize(TWIST_SIZE, 1);
+    motion_subspace_dot_times_v.resize(drake::kTwistSize, 1);
     auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
     Scalar roll = rpy(0);
     Scalar pitch = rpy(1);

--- a/drake/systems/plants/joints/test/testDrakeJointsmex.cpp
+++ b/drake/systems/plants/joints/test/testDrakeJointsmex.cpp
@@ -89,8 +89,8 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
     safelySetField(joint_struct_out, "joint_transform",
                    eigenToMatlab(joint_transform.matrix()));
 
-    Eigen::Matrix<double, drake::kTwistSize, Eigen::Dynamic, 0, drake::kTwistSize,
-                  DrakeJoint::MAX_NUM_VELOCITIES>
+    Eigen::Matrix<double, drake::kTwistSize, Eigen::Dynamic, 0,
+                  drake::kTwistSize, DrakeJoint::MAX_NUM_VELOCITIES>
         motion_subspace(6, joint->getNumVelocities());
     MatrixXd dmotion_subspace;
     joint->motionSubspace(q, motion_subspace, &dmotion_subspace);

--- a/drake/systems/plants/joints/test/testDrakeJointsmex.cpp
+++ b/drake/systems/plants/joints/test/testDrakeJointsmex.cpp
@@ -2,11 +2,14 @@
 #include <matrix.h>
 
 #include "drake/systems/plants/joints/DrakeJoints.h"
+
 #include <memory>
 #include <vector>
 #include <string>
 #include <iostream>
+
 #include <Eigen/Core>
+
 #include "drake/util/drakeMexUtil.h"
 
 using namespace Eigen;
@@ -86,7 +89,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
     safelySetField(joint_struct_out, "joint_transform",
                    eigenToMatlab(joint_transform.matrix()));
 
-    Eigen::Matrix<double, TWIST_SIZE, Eigen::Dynamic, 0, TWIST_SIZE,
+    Eigen::Matrix<double, drake::kTwistSize, Eigen::Dynamic, 0, drake::kTwistSize,
                   DrakeJoint::MAX_NUM_VELOCITIES>
         motion_subspace(6, joint->getNumVelocities());
     MatrixXd dmotion_subspace;

--- a/drake/systems/plants/rigidBodyTreeMexFunctions.cpp
+++ b/drake/systems/plants/rigidBodyTreeMexFunctions.cpp
@@ -4,6 +4,7 @@
 #include <Eigen/Sparse>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/plants/rigidBodyTreeMexConversions.h"
 #include "drake/util/makeFunction.h"
@@ -289,7 +290,7 @@ void geometricJacobianDotTimesVmex(int nlhs, mxArray *plhs[], int nrhs,
 }
 
 template <typename Scalar>
-Matrix<Scalar, TWIST_SIZE, Dynamic> geometricJacobianTemp(
+drake::TwistMatrix<Scalar> geometricJacobianTemp(
     const RigidBodyTree &model, const KinematicsCache<Scalar> &cache,
     int base_body_or_frame_ind, int end_effector_body_or_frame_ind,
     int expressed_in_body_or_frame_ind, bool in_terms_of_qdot) {

--- a/drake/systems/plants/rigidBodyTreeMexFunctions.cpp
+++ b/drake/systems/plants/rigidBodyTreeMexFunctions.cpp
@@ -20,8 +20,8 @@ typedef DrakeJoint::AutoDiffFixedMaxSize AutoDiffFixedMaxSize;
 /**
  * Mex function implementations
  */
-void centerOfMassJacobianDotTimesVmex(int nlhs, mxArray *plhs[], int nrhs,
-                                      const mxArray *prhs[]) {
+void centerOfMassJacobianDotTimesVmex(int nlhs, mxArray* plhs[], int nrhs,
+                                      const mxArray* prhs[]) {
   auto func_double =
       make_function(&RigidBodyTree::centerOfMassJacobianDotTimesV<double>);
   auto func_autodiff_fixed_max = make_function(
@@ -32,8 +32,8 @@ void centerOfMassJacobianDotTimesVmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void centerOfMassmex(int nlhs, mxArray *plhs[], int nrhs,
-                     const mxArray *prhs[]) {
+void centerOfMassmex(int nlhs, mxArray* plhs[], int nrhs,
+                     const mxArray* prhs[]) {
   auto func_double = make_function(&RigidBodyTree::centerOfMass<double>);
   auto func_autodiff_fixed_max =
       make_function(&RigidBodyTree::centerOfMass<AutoDiffFixedMaxSize>);
@@ -43,8 +43,8 @@ void centerOfMassmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void centerOfMassJacobianmex(int nlhs, mxArray *plhs[], int nrhs,
-                             const mxArray *prhs[]) {
+void centerOfMassJacobianmex(int nlhs, mxArray* plhs[], int nrhs,
+                             const mxArray* prhs[]) {
   auto func_double =
       make_function(&RigidBodyTree::centerOfMassJacobian<double>);
   auto func_autodiff_fixed_max =
@@ -55,8 +55,8 @@ void centerOfMassJacobianmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void centroidalMomentumMatrixDotTimesvmex(int nlhs, mxArray *plhs[], int nrhs,
-                                          const mxArray *prhs[]) {
+void centroidalMomentumMatrixDotTimesvmex(int nlhs, mxArray* plhs[], int nrhs,
+                                          const mxArray* prhs[]) {
   auto func_double =
       make_function(&RigidBodyTree::centroidalMomentumMatrixDotTimesV<double>);
   auto func_autodiff_fixed_max = make_function(
@@ -67,8 +67,8 @@ void centroidalMomentumMatrixDotTimesvmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void centroidalMomentumMatrixmex(int nlhs, mxArray *plhs[], int nrhs,
-                                 const mxArray *prhs[]) {
+void centroidalMomentumMatrixmex(int nlhs, mxArray* plhs[], int nrhs,
+                                 const mxArray* prhs[]) {
   auto func_double =
       make_function(&RigidBodyTree::centroidalMomentumMatrix<double>);
   auto func_autodiff_fixed_max = make_function(
@@ -80,10 +80,10 @@ void centroidalMomentumMatrixmex(int nlhs, mxArray *plhs[], int nrhs,
 }
 
 template <typename DerivedQ, typename DerivedV>
-void doKinematicsTemp(const RigidBodyTree &model,
-                      KinematicsCache<typename DerivedQ::Scalar> &cache,
-                      const MatrixBase<DerivedQ> &q,
-                      const MatrixBase<DerivedV> &v, bool compute_JdotV) {
+void doKinematicsTemp(const RigidBodyTree& model,
+                      KinematicsCache<typename DerivedQ::Scalar>& cache,
+                      const MatrixBase<DerivedQ>& q,
+                      const MatrixBase<DerivedV>& v, bool compute_JdotV) {
   // temporary solution. Explicit doKinematics calls will not be necessary in
   // the near future.
   if (v.size() == 0 && model.number_of_velocities() != 0)
@@ -93,8 +93,8 @@ void doKinematicsTemp(const RigidBodyTree &model,
   model.doKinematics(cache, compute_JdotV);
 }
 
-void doKinematicsmex(int nlhs, mxArray *plhs[], int nrhs,
-                     const mxArray *prhs[]) {
+void doKinematicsmex(int nlhs, mxArray* plhs[], int nrhs,
+                     const mxArray* prhs[]) {
   auto func_double = make_function(
       &doKinematicsTemp<Map<const VectorXd>, Map<const VectorXd>>);
 
@@ -110,17 +110,17 @@ void doKinematicsmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void findKinematicPathmex(int nlhs, mxArray *plhs[], int nrhs,
-                          const mxArray *prhs[]) {
+void findKinematicPathmex(int nlhs, mxArray* plhs[], int nrhs,
+                          const mxArray* prhs[]) {
   auto func = make_function(&RigidBodyTree::findKinematicPath);
   mexCallFunction(nlhs, plhs, nrhs, prhs, true, func);
 }
 
 template <typename Scalar, typename DerivedPoints>
 Matrix<Scalar, Dynamic, DerivedPoints::ColsAtCompileTime>
-forwardJacDotTimesVTemp(const RigidBodyTree &tree,
-                        const KinematicsCache<Scalar> &cache,
-                        const MatrixBase<DerivedPoints> &points,
+forwardJacDotTimesVTemp(const RigidBodyTree& tree,
+                        const KinematicsCache<Scalar>& cache,
+                        const MatrixBase<DerivedPoints>& points,
                         int current_body_or_frame_ind,
                         int new_body_or_frame_ind, int rotation_type) {
   auto Jtransdot_times_v = tree.transformPointsJacobianDotTimesV(
@@ -157,8 +157,8 @@ forwardJacDotTimesVTemp(const RigidBodyTree &tree,
   }
 }
 
-void forwardJacDotTimesVmex(int nlhs, mxArray *plhs[], int nrhs,
-                            const mxArray *prhs[]) {
+void forwardJacDotTimesVmex(int nlhs, mxArray* plhs[], int nrhs,
+                            const mxArray* prhs[]) {
   typedef Map<const Matrix3Xd> DerivedPoints;
   auto func_double =
       make_function(&forwardJacDotTimesVTemp<double, DerivedPoints>);
@@ -173,8 +173,8 @@ void forwardJacDotTimesVmex(int nlhs, mxArray *plhs[], int nrhs,
 
 template <typename Scalar, typename DerivedPoints>
 Matrix<Scalar, Dynamic, DerivedPoints::ColsAtCompileTime> forwardKinTemp(
-    const RigidBodyTree &tree, const KinematicsCache<Scalar> &cache,
-    const MatrixBase<DerivedPoints> &points, int current_body_or_frame_ind,
+    const RigidBodyTree& tree, const KinematicsCache<Scalar>& cache,
+    const MatrixBase<DerivedPoints>& points, int current_body_or_frame_ind,
     int new_body_or_frame_ind, int rotation_type) {
   Matrix<Scalar, Dynamic, DerivedPoints::ColsAtCompileTime> ret(
       3 + rotationRepresentationSize(rotation_type), points.cols());
@@ -190,7 +190,7 @@ Matrix<Scalar, Dynamic, DerivedPoints::ColsAtCompileTime> forwardKinTemp(
   return ret;
 }
 
-void forwardKinmex(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+void forwardKinmex(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   auto func_double =
       make_function(&forwardKinTemp<double, Map<const Matrix3Xd>>);
   auto func_autodiff_fixed_max_double_points = make_function(
@@ -213,8 +213,8 @@ void forwardKinmex(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 
 template <typename Scalar, typename DerivedPoints>
 Matrix<Scalar, Dynamic, Dynamic> forwardKinJacobianTemp(
-    const RigidBodyTree &tree, const KinematicsCache<Scalar> &cache,
-    const MatrixBase<DerivedPoints> &points, int current_body_or_frame_ind,
+    const RigidBodyTree& tree, const KinematicsCache<Scalar>& cache,
+    const MatrixBase<DerivedPoints>& points, int current_body_or_frame_ind,
     int new_body_or_frame_ind, int rotation_type, bool in_terms_of_qdot) {
   auto Jtrans =
       tree.transformPointsJacobian(cache, points, current_body_or_frame_ind,
@@ -249,8 +249,8 @@ Matrix<Scalar, Dynamic, Dynamic> forwardKinJacobianTemp(
   }
 }
 
-void forwardKinJacobianmex(int nlhs, mxArray *plhs[], int nrhs,
-                           const mxArray *prhs[]) {
+void forwardKinJacobianmex(int nlhs, mxArray* plhs[], int nrhs,
+                           const mxArray* prhs[]) {
   typedef Map<const Matrix3Xd> DerivedPoints;
   auto func_double =
       make_function(&forwardKinJacobianTemp<double, DerivedPoints>);
@@ -263,8 +263,8 @@ void forwardKinJacobianmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void forwardKinPositionGradientmex(int nlhs, mxArray *plhs[], int nrhs,
-                                   const mxArray *prhs[]) {
+void forwardKinPositionGradientmex(int nlhs, mxArray* plhs[], int nrhs,
+                                   const mxArray* prhs[]) {
   auto func_double =
       make_function(&RigidBodyTree::forwardKinPositionGradient<double>);
   auto func_autodiff_fixed_max = make_function(
@@ -276,8 +276,8 @@ void forwardKinPositionGradientmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void geometricJacobianDotTimesVmex(int nlhs, mxArray *plhs[], int nrhs,
-                                   const mxArray *prhs[]) {
+void geometricJacobianDotTimesVmex(int nlhs, mxArray* plhs[], int nrhs,
+                                   const mxArray* prhs[]) {
   auto func_double =
       make_function(&RigidBodyTree::geometricJacobianDotTimesV<double>);
   auto func_autodiff_fixed_max = make_function(
@@ -291,7 +291,7 @@ void geometricJacobianDotTimesVmex(int nlhs, mxArray *plhs[], int nrhs,
 
 template <typename Scalar>
 drake::TwistMatrix<Scalar> geometricJacobianTemp(
-    const RigidBodyTree &model, const KinematicsCache<Scalar> &cache,
+    const RigidBodyTree& model, const KinematicsCache<Scalar>& cache,
     int base_body_or_frame_ind, int end_effector_body_or_frame_ind,
     int expressed_in_body_or_frame_ind, bool in_terms_of_qdot) {
   // temporary solution. Gross v_or_qdot_indices pointer will be gone soon.
@@ -300,8 +300,8 @@ drake::TwistMatrix<Scalar> geometricJacobianTemp(
       expressed_in_body_or_frame_ind, in_terms_of_qdot, nullptr);
 }
 
-void geometricJacobianmex(int nlhs, mxArray *plhs[], int nrhs,
-                          const mxArray *prhs[]) {
+void geometricJacobianmex(int nlhs, mxArray* plhs[], int nrhs,
+                          const mxArray* prhs[]) {
   auto func_double = make_function(&geometricJacobianTemp<double>);
   auto func_autodiff_fixed_max =
       make_function(&geometricJacobianTemp<AutoDiffFixedMaxSize>);
@@ -311,7 +311,7 @@ void geometricJacobianmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void massMatrixmex(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+void massMatrixmex(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   auto func_double = make_function(&RigidBodyTree::massMatrix<double>);
   auto func_autodiff_fixed_max =
       make_function(&RigidBodyTree::massMatrix<AutoDiffFixedMaxSize>);
@@ -323,11 +323,11 @@ void massMatrixmex(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 
 template <typename Scalar, typename DerivedF>
 Matrix<Scalar, Dynamic, 1> dynamicsBiasTermTemp(
-    const RigidBodyTree &model, KinematicsCache<Scalar> &cache,
-    const MatrixBase<DerivedF> &f_ext_value) {
+    const RigidBodyTree& model, KinematicsCache<Scalar>& cache,
+    const MatrixBase<DerivedF>& f_ext_value) {
   // temporary solution.
 
-  eigen_aligned_unordered_map<const RigidBody *, Matrix<Scalar, 6, 1>> f_ext;
+  eigen_aligned_unordered_map<const RigidBody*, Matrix<Scalar, 6, 1>> f_ext;
 
   if (f_ext_value.size() > 0) {
     DRAKE_ASSERT(f_ext_value.cols() == model.bodies.size());
@@ -339,8 +339,8 @@ Matrix<Scalar, Dynamic, 1> dynamicsBiasTermTemp(
   return model.dynamicsBiasTerm(cache, f_ext);
 }
 
-void dynamicsBiasTermmex(int nlhs, mxArray *plhs[], int nrhs,
-                         const mxArray *prhs[]) {
+void dynamicsBiasTermmex(int nlhs, mxArray* plhs[], int nrhs,
+                         const mxArray* prhs[]) {
   auto func_double = make_function(
       &dynamicsBiasTermTemp<double, Map<const Matrix<double, 6, Dynamic>>>);
   auto func_autodiff_fixed_max = make_function(
@@ -356,7 +356,7 @@ void dynamicsBiasTermmex(int nlhs, mxArray *plhs[], int nrhs,
 
 template <typename Scalar>
 Matrix<Scalar, Dynamic, Dynamic> velocityToPositionDotMapping(
-    const KinematicsCache<Scalar> &cache) {
+    const KinematicsCache<Scalar>& cache) {
   auto nq = cache.getNumPositions();
   return cache.transformPositionDotMappingToVelocityMapping(
       Matrix<Scalar, Dynamic, Dynamic>::Identity(nq, nq));
@@ -364,14 +364,14 @@ Matrix<Scalar, Dynamic, Dynamic> velocityToPositionDotMapping(
 
 template <typename Scalar>
 Matrix<Scalar, Dynamic, Dynamic> positionDotToVelocityMapping(
-    const KinematicsCache<Scalar> &cache) {
+    const KinematicsCache<Scalar>& cache) {
   auto nv = cache.getNumVelocities();
   return cache.transformVelocityMappingToPositionDotMapping(
       Matrix<Scalar, Dynamic, Dynamic>::Identity(nv, nv));
 }
 
-void velocityToPositionDotMappingmex(int nlhs, mxArray *plhs[], int nrhs,
-                                     const mxArray *prhs[]) {
+void velocityToPositionDotMappingmex(int nlhs, mxArray* plhs[], int nrhs,
+                                     const mxArray* prhs[]) {
   auto func_double = make_function(&velocityToPositionDotMapping<double>);
   auto func_autodiff_fixed_max =
       make_function(&velocityToPositionDotMapping<AutoDiffFixedMaxSize>);
@@ -381,8 +381,8 @@ void velocityToPositionDotMappingmex(int nlhs, mxArray *plhs[], int nrhs,
                         func_autodiff_fixed_max, func_autodiff_dynamic);
 }
 
-void positionDotToVelocityMappingmex(int nlhs, mxArray *plhs[], int nrhs,
-                                     const mxArray *prhs[]) {
+void positionDotToVelocityMappingmex(int nlhs, mxArray* plhs[], int nrhs,
+                                     const mxArray* prhs[]) {
   auto func_double = make_function(&positionDotToVelocityMapping<double>);
   auto func_autodiff_fixed_max =
       make_function(&positionDotToVelocityMapping<AutoDiffFixedMaxSize>);

--- a/drake/systems/plants/rigid_body_frame.cc
+++ b/drake/systems/plants/rigid_body_frame.cc
@@ -1,0 +1,10 @@
+#include "drake/systems/plants/RigidBodyFrame.h"
+
+#include "drake/util/drakeGeometryUtil.h"
+
+RigidBodyFrame::RigidBodyFrame(const std::string& _name, RigidBody* _body,
+                               const Eigen::Vector3d& xyz,
+                               const Eigen::Vector3d& rpy)
+    : name(_name), body(_body) {
+  transform_to_body.matrix() << rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
+}

--- a/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
+++ b/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
@@ -54,8 +54,8 @@ void scenario2(
     const RigidBodyTree& model, KinematicsCache<Scalar>& cache,
     const vector<pair<Matrix<Scalar, Dynamic, 1>, Matrix<Scalar, Dynamic, 1>>>&
         states) {
-  const eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<Scalar>>
-      f_ext;
+  const eigen_aligned_unordered_map<RigidBody const*,
+                                    drake::TwistVector<Scalar>> f_ext;
   for (const auto& state : states) {
     cache.initialize(state.first, state.second);
     model.doKinematics(cache, true);
@@ -145,11 +145,9 @@ void testScenario2(const RigidBodyTree& model) {
 
   vector<pair<VectorXd, VectorXd>> states_double;
   vector<pair<Matrix<AutoDiffFixedMaxSize, Dynamic, 1>,
-              Matrix<AutoDiffFixedMaxSize, Dynamic, 1>>>
-      states_autodiff_fixed;
+              Matrix<AutoDiffFixedMaxSize, Dynamic, 1>>> states_autodiff_fixed;
   vector<pair<Matrix<AutoDiffDynamicSize, Dynamic, 1>,
-              Matrix<AutoDiffDynamicSize, Dynamic, 1>>>
-      states_autodiff_dynamic;
+              Matrix<AutoDiffDynamicSize, Dynamic, 1>>> states_autodiff_dynamic;
   default_random_engine generator;
 
   for (int i = 0; i < ntests; i++) {

--- a/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
+++ b/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 
+#include "drake/common/eigen_types.h"
 #include "drake/math/autodiff.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/util/testUtil.h"
@@ -53,8 +54,7 @@ void scenario2(
     const RigidBodyTree& model, KinematicsCache<Scalar>& cache,
     const vector<pair<Matrix<Scalar, Dynamic, 1>, Matrix<Scalar, Dynamic, 1>>>&
         states) {
-  const eigen_aligned_unordered_map<RigidBody const*,
-                                    Matrix<Scalar, TWIST_SIZE, 1>>
+  const eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<Scalar>>
       f_ext;
   for (const auto& state : states) {
     cache.initialize(state.first, state.second);

--- a/drake/systems/plants/test/compareParsersmex.cpp
+++ b/drake/systems/plants/test/compareParsersmex.cpp
@@ -2,6 +2,8 @@
 
 #include <cmath>
 #include <iostream>
+
+#include "drake/common/eigen_types.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/util/drakeMexUtil.h"
 #include "drake/util/eigen_matrix_compare.h"
@@ -103,8 +105,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
         cpp_model->doKinematics(cpp_q, cpp_v, true);
 
     {  // compare H, C, and B
-      eigen_aligned_unordered_map<RigidBody const*,
-                                  Matrix<double, TWIST_SIZE, 1>>
+      eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
           f_ext;
 
       auto matlab_H = matlab_model->massMatrix(matlab_cache);

--- a/drake/systems/plants/test/debugManipulatorDynamics.cpp
+++ b/drake/systems/plants/test/debugManipulatorDynamics.cpp
@@ -26,7 +26,7 @@ int main() {
   auto M = model.massMatrix<double>(cache);
   cout << M << endl << endl;
 
-  eigen_aligned_unordered_map<RigidBody const *, drake::TwistVector<double>>
+  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
       f_ext;
   drake::TwistVector<double> f_ext_r_foot;
   f_ext_r_foot.setRandom();

--- a/drake/systems/plants/test/debugManipulatorDynamics.cpp
+++ b/drake/systems/plants/test/debugManipulatorDynamics.cpp
@@ -1,10 +1,14 @@
-#include "drake/systems/plants/RigidBodyTree.h"
 #include <iostream>
 #include <cstdlib>
 #include <memory>
 
+#include "drake/common/eigen_types.h"
+#include "drake/systems/plants/RigidBodyTree.h"
+
 using namespace std;
-using namespace Eigen;
+
+using Eigen::VectorXd;
+
 int main() {
   RigidBodyTree model("examples/Atlas/urdf/atlas_minimal_contact.urdf");
 
@@ -13,7 +17,7 @@ int main() {
   VectorXd v = VectorXd::Random(model.number_of_velocities());
   KinematicsCache<double> cache = model.doKinematics(q, v);
 
-  auto points = Matrix<double, 3, Eigen::Dynamic>::Random(3, 5).eval();
+  auto points = drake::Matrix3X<double>::Random(3, 5).eval();
   int body_or_frame_ind = 8;
   int base_or_frame_ind = 0;
   model.transformPointsJacobianDotTimesV(cache, points, body_or_frame_ind,
@@ -22,13 +26,13 @@ int main() {
   auto M = model.massMatrix<double>(cache);
   cout << M << endl << endl;
 
-  eigen_aligned_unordered_map<RigidBody const *, Matrix<double, TWIST_SIZE, 1> >
+  eigen_aligned_unordered_map<RigidBody const *, drake::TwistVector<double>>
       f_ext;
-  Matrix<double, TWIST_SIZE, 1> f_ext_r_foot;
+  drake::TwistVector<double> f_ext_r_foot;
   f_ext_r_foot.setRandom();
   f_ext.insert({model.FindBody("r_foot"), f_ext_r_foot});
 
-  Matrix<double, Eigen::Dynamic, 1> vd(model.number_of_velocities());
+  VectorXd vd(model.number_of_velocities());
   vd.setRandom();
 
   auto C = model.inverseDynamics(cache, f_ext, vd);

--- a/drake/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/drake/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -20,11 +20,11 @@ struct CheckSettings {
 };
 
 template <typename O, typename F, typename... Args>
-void checkForErrors(bool expect_error, O &object, F function,
-                    Args &&... arguments) {
+void checkForErrors(bool expect_error, O& object, F function,
+                    Args&&... arguments) {
   try {
     (object.*function)(std::forward<Args>(arguments)...);
-  } catch (runtime_error &e) {
+  } catch (runtime_error& e) {
     if (expect_error)
       return;
     else
@@ -36,8 +36,8 @@ void checkForErrors(bool expect_error, O &object, F function,
         "Expected a runtime error, but did not catch one.");
 }
 
-void performChecks(RigidBodyTree &model, KinematicsCache<double> &cache,
-                   const CheckSettings &settings) {
+void performChecks(RigidBodyTree& model, KinematicsCache<double>& cache,
+                   const CheckSettings& settings) {
   auto points = drake::Matrix3X<double>::Random(3, 5).eval();
   typedef decltype(points) PointsType;
   int body_or_frame_ind = 8;
@@ -50,7 +50,7 @@ void performChecks(RigidBodyTree &model, KinematicsCache<double> &cache,
   int npoints = 3;
   drake::TwistVector<double> spatial_acceleration;
   spatial_acceleration.setRandom();
-  eigen_aligned_unordered_map<RigidBody const *, drake::TwistVector<double>>
+  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
       f_ext;
 
   checkForErrors(settings.expect_error_on_configuration_methods, model,

--- a/drake/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/drake/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -1,11 +1,14 @@
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "drake/util/drakeGeometryUtil.h"
+
 #include <iostream>
 #include <cstdlib>
 #include <random>
 #include <memory>
 #include <stdexcept>
 #include <map>
+
+#include "drake/common/eigen_types.h"
+#include "drake/util/drakeGeometryUtil.h"
 
 using namespace std;
 using namespace Eigen;
@@ -35,7 +38,7 @@ void checkForErrors(bool expect_error, O &object, F function,
 
 void performChecks(RigidBodyTree &model, KinematicsCache<double> &cache,
                    const CheckSettings &settings) {
-  auto points = Matrix<double, 3, Eigen::Dynamic>::Random(3, 5).eval();
+  auto points = drake::Matrix3X<double>::Random(3, 5).eval();
   typedef decltype(points) PointsType;
   int body_or_frame_ind = 8;
   int base_or_frame_ind = 0;
@@ -45,9 +48,9 @@ void performChecks(RigidBodyTree &model, KinematicsCache<double> &cache,
   bool in_terms_of_qdot = false;
   std::vector<int> v_or_qdot_indices;
   int npoints = 3;
-  Matrix<double, TWIST_SIZE, 1> spatial_acceleration;
+  drake::TwistVector<double> spatial_acceleration;
   spatial_acceleration.setRandom();
-  eigen_aligned_unordered_map<RigidBody const *, Matrix<double, TWIST_SIZE, 1> >
+  eigen_aligned_unordered_map<RigidBody const *, drake::TwistVector<double>>
       f_ext;
 
   checkForErrors(settings.expect_error_on_configuration_methods, model,

--- a/drake/systems/plants/test/urdfManipulatorDynamicsTest.cpp
+++ b/drake/systems/plants/test/urdfManipulatorDynamicsTest.cpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/eigen_types.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 
 using namespace std;
@@ -46,7 +47,7 @@ int main(int argc, char* argv[]) {
   auto H = model->massMatrix(cache);
   cout << H << endl;
 
-  eigen_aligned_unordered_map<RigidBody const*, Matrix<double, TWIST_SIZE, 1> >
+  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
       f_ext;
   auto C = model->dynamicsBiasTerm(cache, f_ext);
   cout << C << endl;

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -1196,8 +1196,7 @@ bool isRegularInertiaMatrix(const Eigen::MatrixBase<DerivedI>& I) {
 }
 
 template <typename DerivedI>
-drake::SquareTwistMatrix<typename DerivedI::Scalar>
-transformSpatialInertia(
+drake::SquareTwistMatrix<typename DerivedI::Scalar> transformSpatialInertia(
     const Eigen::Transform<typename DerivedI::Scalar, SPACE_DIMENSION,
                            Eigen::Isometry>& T_current_to_new,
     const Eigen::MatrixBase<DerivedI>& I) {
@@ -1295,12 +1294,12 @@ typename TransformSpatial<DerivedB>::type crossSpatialForce(
 }
 
 template <typename DerivedA, typename DerivedB>
-drake::TwistMatrix<typename DerivedA::Scalar>
-dCrossSpatialMotion(
+drake::TwistMatrix<typename DerivedA::Scalar> dCrossSpatialMotion(
     const Eigen::MatrixBase<DerivedA>& a, const Eigen::MatrixBase<DerivedB>& b,
     const typename drake::math::Gradient<DerivedA, Eigen::Dynamic>::type& da,
     const typename drake::math::Gradient<DerivedB, Eigen::Dynamic>::type& db) {
-  drake::TwistMatrix<typename DerivedA::Scalar> ret(drake::kTwistSize, da.cols());
+  drake::TwistMatrix<typename DerivedA::Scalar> ret(drake::kTwistSize,
+                                                    da.cols());
   ret.row(0) = -da.row(2) * b[1] + da.row(1) * b[2] - a[2] * db.row(1) +
                a[1] * db.row(2);
   ret.row(1) =
@@ -1320,12 +1319,12 @@ dCrossSpatialMotion(
 }
 
 template <typename DerivedA, typename DerivedB>
-drake::TwistMatrix<typename DerivedA::Scalar>
-dCrossSpatialForce(
+drake::TwistMatrix<typename DerivedA::Scalar> dCrossSpatialForce(
     const Eigen::MatrixBase<DerivedA>& a, const Eigen::MatrixBase<DerivedB>& b,
     const typename drake::math::Gradient<DerivedA, Eigen::Dynamic>::type& da,
     const typename drake::math::Gradient<DerivedB, Eigen::Dynamic>::type& db) {
-  drake::TwistMatrix<typename DerivedA::Scalar> ret(drake::kTwistSize, da.cols());
+  drake::TwistMatrix<typename DerivedA::Scalar> ret(drake::kTwistSize,
+                                                    da.cols());
   ret.row(0) = da.row(2) * b[1] - da.row(1) * b[2] + da.row(5) * b[4] -
                da.row(4) * b[5] + a[2] * db.row(1) - a[1] * db.row(2) +
                a[5] * db.row(4) - a[4] * db.row(5);

--- a/drake/util/test/testDrakeGeometryUtil.cpp
+++ b/drake/util/test/testDrakeGeometryUtil.cpp
@@ -3,6 +3,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/eigen_types.h"
 #include "drake/core/Gradient.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/eigen_matrix_compare.h"
@@ -205,8 +206,8 @@ GTEST_TEST(DrakeGeometryUtilTest, NormalizeVec) {
 }
 
 GTEST_TEST(DrakeGeometryUtilTest, SpatialCrossProduct) {
-  auto a = (Matrix<double, TWIST_SIZE, 1>::Random()).eval();
-  auto b = (Matrix<double, TWIST_SIZE, TWIST_SIZE>::Identity()).eval();
+  auto a = (drake::TwistVector<double>::Random()).eval();
+  auto b = (drake::SquareTwistMatrix<double>::Identity()).eval();
   auto a_crm_b = crossSpatialMotion(a, b);
   auto a_crf_b = crossSpatialForce(a, b);
   EXPECT_TRUE(CompareMatrices(a_crf_b, -a_crm_b.transpose(), 1e-8,

--- a/drake/util/test/testGeometryGradientsmex.cpp
+++ b/drake/util/test/testGeometryGradientsmex.cpp
@@ -1,8 +1,11 @@
 #include <mex.h>
 
+#include "drake/common/eigen_types.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeMexUtil.h"
-using namespace Eigen;
+
+using Eigen::Isometry3d;
+using Eigen::Vector4d;
 
 void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   if (nrhs != 6 || nlhs != 7) {
@@ -16,10 +19,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   Isometry3d T;
   memcpy(T.data(), mxGetPr(prhs[argnum++]),
          sizeof(double) * HOMOGENEOUS_TRANSFORM_SIZE);
-  auto S = matlabToEigen<TWIST_SIZE, Eigen::Dynamic>(prhs[argnum++]);
+  auto S = matlabToEigen<drake::kTwistSize, Eigen::Dynamic>(prhs[argnum++]);
   auto qdot_to_v =
       matlabToEigen<Eigen::Dynamic, Eigen::Dynamic>(prhs[argnum++]);
-  auto X = matlabToEigen<TWIST_SIZE, Eigen::Dynamic>(prhs[argnum++]);
+  auto X = matlabToEigen<drake::kTwistSize, Eigen::Dynamic>(prhs[argnum++]);
   auto dX = matlabToEigen<Eigen::Dynamic, Eigen::Dynamic>(prhs[argnum++]);
   auto x = matlabToEigen<4, 1>(prhs[argnum++]);
 


### PR DESCRIPTION
Makes it possible to remove `#include "drake/util/drakeGeometryUtil.h"` from a number of widely-used header files.  It does still make its way into `RigidBodyTree.h` via `KinematicsCache.h`, but this is progress!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2666)
<!-- Reviewable:end -->
