### PR TITLE
Fix sign-compare in systems (but not its children)

### DIFF
--- a/drake/systems/CMakeLists.txt
+++ b/drake/systems/CMakeLists.txt
@@ -1,9 +1,4 @@
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # TODO(#2372) These are warnings that we can't handle yet.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
-endif()
-
 if(simulink_FOUND)
   add_mex(DCSFunction DCSFunction.cpp)
 endif()

--- a/drake/systems/DCSFunction.cpp
+++ b/drake/systems/DCSFunction.cpp
@@ -491,7 +491,8 @@ static void mdlUpdate(SimStruct *S, int_T tid) {
   if (mexCallMATLABsafe(S, 1, plhs, sds ? 5 : 4, prhs,
                         sds ? "stochasticUpdate" : "update"))
     return;
-  if (!mxIsDouble(plhs[0]) || mxGetNumberOfElements(plhs[0]) != num_xd) {
+  if (!mxIsDouble(plhs[0]) || (
+          static_cast<int>(mxGetNumberOfElements(plhs[0])) != num_xd)) {
     mexPrintf("I expected xdn to have %d elements, but got  %d.\n", num_xd,
               mxGetNumberOfElements(plhs[0]));
     ssSetErrorStatus(S,

--- a/drake/systems/controllers/CMakeLists.txt
+++ b/drake/systems/controllers/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 drake_install_headers(LQR.h)
 
 add_library_with_exports(LIB_NAME drakeControlUtil SOURCE_FILES controlUtil.cpp)

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 # Source files used to build drakeSystemFramework.
 set(sources
   basic_vector.cc

--- a/drake/systems/n_ary_system.h
+++ b/drake/systems/n_ary_system.h
@@ -42,10 +42,12 @@ class NArySystem {
   StateVector<ScalarType> dynamics(const ScalarType& time,
                                    const StateVector<ScalarType>& state,
                                    const InputVector<ScalarType>& input) const {
-    if ((state.count() >= 0) && (state.count() != systems_.size())) {
+    if ((state.count() >= 0) && (
+            state.count() != static_cast<ptrdiff_t>(systems_.size()))) {
       throw std::invalid_argument("State count differs from systems count.");
     }
-    if ((input.count() >= 0) && (input.count() != systems_.size())) {
+    if ((input.count() >= 0) && (
+            input.count() != static_cast<ptrdiff_t>(systems_.size()))) {
       throw std::invalid_argument("Input count differs from systems count.");
     }
     StateVector<ScalarType> xdot(systems_.size());
@@ -60,10 +62,12 @@ class NArySystem {
   OutputVector<ScalarType> output(const ScalarType& time,
                                   const StateVector<ScalarType>& state,
                                   const InputVector<ScalarType>& input) const {
-    if ((state.count() >= 0) && (state.count() != systems_.size())) {
+    if ((state.count() >= 0) && (
+            state.count() != static_cast<ptrdiff_t>(systems_.size()))) {
       throw std::invalid_argument("State count differs from systems count.");
     }
-    if ((input.count() >= 0) && (input.count() != systems_.size())) {
+    if ((input.count() >= 0) && (
+            input.count() != static_cast<ptrdiff_t>(systems_.size()))) {
       throw std::invalid_argument("Input count differs from systems count.");
     }
     OutputVector<ScalarType> y(systems_.size());

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -2,6 +2,11 @@
 # matlab has it's own boost libraries.  DO NOT let any mex file depend
 # on the system boost (directly nor indirectly), or you're asking for trouble.
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 add_library_with_exports(LIB_NAME drakeXMLUtil SOURCE_FILES xmlUtil.cpp)
 target_link_libraries(drakeXMLUtil drakeCommon tinyxml2 spruce)
 pods_install_libraries(drakeXMLUtil)

--- a/drake/systems/robotInterfaces/CMakeLists.txt
+++ b/drake/systems/robotInterfaces/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 add_library_with_exports(LIB_NAME drakeSide SOURCE_FILES Side.cpp)
 drake_install_headers(Side.h)
 pods_install_libraries(drakeSide)

--- a/drake/systems/trajectories/CMakeLists.txt
+++ b/drake/systems/trajectories/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # TODO(#2372) These are warnings that we can't handle yet.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+endif()
+
 if(MATLAB_FOUND)
   add_mex(PPTmex PPTmex.cpp)
   add_mex(ExpPlusPPTrajectoryEvalmex ExpPlusPPTrajectoryEvalmex.cpp)


### PR DESCRIPTION
This another step for #2372.
- Fix sign-compare warnings in NAryFoo.
- Push the sign-compare warning suppressions down one level, from `systems` into its children.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2667)
<!-- Reviewable:end -->
