### PR TITLE
Moved ROS to be above LCM in drake/CMakeLists.txt 

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -235,6 +235,34 @@ set(drake_jar_requires)
 
 include(cmake/procman.cmake)  # helper script for writing procman files
 
+# Setup ROS if it is available on the local system. Note that this occurs before
+# LCM configuration to prevent ROS message generation from conflicting with LCM
+# message generation. This prevent ROS from generating its own custom messages.
+find_package(roscpp QUIET)
+if(roscpp_FOUND)
+  set(ROS_FOUND ON)
+  message(STATUS "Found roscpp installed at ${roscpp_DIR}, so building ROS-specific functionality.")
+  include_directories(${roscpp_INCLUDE_DIRS})
+
+  find_package(catkin REQUIRED)
+  find_package(genmsg REQUIRED)
+
+  find_package(std_msgs REQUIRED)
+  include_directories(${std_msgs_INCLUDE_DIRS})
+
+  find_package(sensor_msgs REQUIRED)
+  include_directories(${sensor_msgs_INCLUDE_DIRS})
+
+  find_package(ackermann_msgs REQUIRED)
+  include_directories(${ackermann_msgs_INCLUDE_DIRS})
+
+  find_package(tf REQUIRED)
+  include_directories(${tf_INCLUDE_DIRS})
+else()
+  set(ROS_FOUND OFF)
+  message(STATUS "Couldn't find roscpp so not building ROS-specific functionality. If you want ROS support, be sure to source the ROS setup.sh prior to building Drake.")
+endif()
+
 # set up and build lcm types
 include(cmake/lcmtypes.cmake)
 
@@ -288,32 +316,6 @@ else()
   else()
     message(FATAL_ERROR "Could not find eigen, which is a required depedency")
   endif()
-endif()
-
-# Setup ROS if it is available on the local system
-find_package(roscpp QUIET)
-if(roscpp_FOUND)
-  set(ROS_FOUND ON)
-  message(STATUS "Found roscpp installed at ${roscpp_DIR}, so building ROS-specific functionality.")
-  include_directories(${roscpp_INCLUDE_DIRS})
-
-  find_package(catkin REQUIRED)
-  find_package(genmsg REQUIRED)
-
-  find_package(std_msgs REQUIRED)
-  include_directories(${std_msgs_INCLUDE_DIRS})
-
-  find_package(sensor_msgs REQUIRED)
-  include_directories(${sensor_msgs_INCLUDE_DIRS})
-
-  find_package(ackermann_msgs REQUIRED)
-  include_directories(${ackermann_msgs_INCLUDE_DIRS})
-
-  find_package(tf REQUIRED)
-  include_directories(${tf_INCLUDE_DIRS})
-else()
-  set(ROS_FOUND OFF)
-  message(STATUS "Couldn't find roscpp so not building ROS-specific functionality. If you want ROS support, be sure to source the ROS setup.sh prior to building Drake.")
 endif()
 
 include_directories(thirdParty/spruce/include)


### PR DESCRIPTION
This is to prevent message generation conflicts. It essentially prioritizes generated LCM messages over generated ROS messages. Note that the ROS code within Drake currently does not generate any messages and, with this PR, if it did, LCM would overwrite these messages with its messages. Thus, this PR is simply due to an abundance of caution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2669)
<!-- Reviewable:end -->
