### PR TITLE
Adds suppression of deprecation warnings when compiling SWIG bindings.

### DIFF
--- a/drake/bindings/swig/CMakeLists.txt
+++ b/drake/bindings/swig/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "-w503")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # The autodiff.i in swig has for-loop variable warnings.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare -Wno-deprecated-declarations")
 endif()
 
 if(PYTHON_EXECUTABLE)

--- a/drake/bindings/swig/CMakeLists.txt
+++ b/drake/bindings/swig/CMakeLists.txt
@@ -13,7 +13,12 @@ set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "-w503")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # The autodiff.i in swig has for-loop variable warnings.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare -Wno-deprecated-declarations")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
+
+  # Suppresses warnings due to the existence of deprecated methods. These
+  # deprecated methods should still be made available through the SWIG-generated
+  # APIs until they are actually removed from the original C++ APIs.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 endif()
 
 if(PYTHON_EXECUTABLE)


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake/issues/2657.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2674)
<!-- Reviewable:end -->
