### PR TITLE
Attempting to fix Win32 SEH exception by disabling alignment.

### DIFF
--- a/drake/systems/test/simulation_termination_test.cc
+++ b/drake/systems/test/simulation_termination_test.cc
@@ -9,8 +9,6 @@
 
 using Eigen::Dynamic;
 
-#define EIGEN_DONT_ALIGN 1
-
 namespace drake {
 namespace systems {
 namespace test {
@@ -26,6 +24,8 @@ class SimulationTerminationTest : public ::testing::Test {
 
     xi_.setZero();
   }
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   // The system to simulate.
   std::shared_ptr<Drake::AffineSystem<EigenVector<10>::template type,

--- a/drake/systems/test/simulation_termination_test.cc
+++ b/drake/systems/test/simulation_termination_test.cc
@@ -9,6 +9,8 @@
 
 using Eigen::Dynamic;
 
+#define EIGEN_DONT_ALIGN 1
+
 namespace drake {
 namespace systems {
 namespace test {


### PR DESCRIPTION
I hope this resolves the following error on Win32 continuous:

```
12:50:15 [ RUN      ] SimulationTerminationTest.TerminationConditionDefault
12:50:15 unknown file: error: SEH exception with code 0xc0000005 thrown in SetUp().
12:50:15 [  FAILED  ] SimulationTerminationTest.TerminationConditionDefault (0 ms)
12:50:15 [ RUN      ] SimulationTerminationTest.TerminationConditionAfterHalfSecond
12:50:15 unknown file: error: SEH exception with code 0xc0000005 thrown in SetUp().
12:50:15 [  FAILED  ] SimulationTerminationTest.TerminationConditionAfterHalfSecond (0 ms)
12:50:15 [ RUN      ] SimulationTerminationTest.TerminationConditionTrue
12:50:15 unknown file: error: SEH exception with code 0xc0000005 thrown in SetUp().
12:50:15 [  FAILED  ] SimulationTerminationTest.TerminationConditionTrue (0 ms)
12:50:15 [----------] 3 tests from SimulationTerminationTest (0 ms total)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2679)
<!-- Reviewable:end -->
