### PR TITLE
Removed TODO that says LCM messages should be co-located with software that uses them.

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -269,9 +269,7 @@ include(cmake/lcmtypes.cmake)
 if(LCM_FOUND)
   # TODO(liang.fok) Remove the generation of LCM messages from this top-level
   # CMakeLists.txt. It should instead be co-located with the message
-  # definitions. Furthermore, the LCM messages are currently defined in
-  # drake/lcmtypes/. They should be moved to be co-located with the code that
-  # actually uses them.
+  # definitions.
   lcmtypes_build()
   pods_use_pkg_config_classpath(lcm-java)
 


### PR DESCRIPTION
For context, see: https://github.com/RobotLocomotion/drake/pull/2582#issuecomment-229120696

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2682)
<!-- Reviewable:end -->
