### PR TITLE
Add specific language about where and which unsigned types may be used

### DIFF
--- a/drake/doc/code_style_guide.rst
+++ b/drake/doc/code_style_guide.rst
@@ -60,6 +60,16 @@ Clarifications
 * The test file for the library declarations in ``drake/foo/bar.h`` should be
   ``drake/foo/test/bar_test.cc``.
   (`#2182 <https://github.com/RobotLocomotion/drake/issues/2182>`_)
+* When using `Integer Types
+  <https://google.github.io/styleguide/cppguide.html#Integer>`_
+  within Drake, the only allowed uses of unsigned types are (per `#2514
+  <https://github.com/RobotLocomotion/drake/issues/2514>`_):
+
+  * for bitfields -- where only ``uint32_t`` or ``uint64_t`` are allowed -- or,
+  * when a (1) non-Drake API uses unsigned types, and (2) casting to a signed
+    type during Drake's interactions with the non-Drake API would obscure the
+    readability of our code, and (3) subtraction underflow below zero is
+    obviously not at risk -- then ``size_t`` may be used.
 
 .. _code-style-guide-cpp-exceptions:
 

--- a/drake/doc/code_style_guide.rst
+++ b/drake/doc/code_style_guide.rst
@@ -62,14 +62,14 @@ Clarifications
   (`#2182 <https://github.com/RobotLocomotion/drake/issues/2182>`_)
 * When using `Integer Types
   <https://google.github.io/styleguide/cppguide.html#Integer>`_
-  within Drake, the only allowed uses of unsigned types are (per `#2514
-  <https://github.com/RobotLocomotion/drake/issues/2514>`_):
+  within Drake, unsigned types are forbidden, with the following exceptions
+  (per `#2514 <https://github.com/RobotLocomotion/drake/issues/2514>`_):
 
-  * for bitfields -- where only ``uint32_t`` or ``uint64_t`` are allowed -- or,
-  * when a (1) non-Drake API uses unsigned types, and (2) casting to a signed
-    type during Drake's interactions with the non-Drake API would obscure the
-    readability of our code, and (3) subtraction underflow below zero is
-    obviously not at risk -- then ``size_t`` may be used.
+  * ``uint32_t`` or ``uint64_t`` are allowed for bitfields, and
+  * ``size_t`` is allowed when a (1) non-Drake API uses unsigned types, and (2)
+    casting to a signed type during Drake's interactions with the non-Drake API
+    would obscure the readability of our code, and (3) subtraction underflow
+    below zero is obviously not at risk.
 
 .. _code-style-guide-cpp-exceptions:
 


### PR DESCRIPTION
Add specific language about where and which unsigned types may be used.  This is the unsigned-related part of #2514 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2686)
<!-- Reviewable:end -->
