### PR TITLE
Automatically synchronize submodule URL changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,10 @@ foreach(proj ${EXTERNAL_PROJECTS})
     # Compute the path to the submodule for this external.
     file(RELATIVE_PATH ${proj}_GIT_SUBMODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${${proj}_SOURCE_DIR})
 
+    # Initialize the submodule configuration now so parallel downloads do not conflict later.
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule init -- ${${proj}_GIT_SUBMODULE_PATH}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
     # Download externals as Git submodules.
     set(${proj}_DOWNLOAD_COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${${proj}_GIT_SUBMODULE_PATH})
 
@@ -340,10 +344,6 @@ foreach(proj ${EXTERNAL_PROJECTS})
     else()
       set(${proj}_UPDATE_COMMAND "")
     endif()
-
-    # Initialize the submodule configuration now so parallel downloads do not conflict later.
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule init -- ${${proj}_GIT_SUBMODULE_PATH}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     # now the actual project
     if(${proj}_IS_CMAKE_POD)
@@ -488,6 +488,10 @@ foreach(example IN ITEMS LittleDog)
   if(EXAMPLES_${example_upper})
     message(STATUS "Installation will include extra example: ${example}")
 
+    # Initialize the submodule configuration now so parallel downloads do not conflict later.
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule init -- drake/examples/${example}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
     # Download examples as Git submodules.
     set(${example}_DOWNLOAD_COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- drake/examples/${example})
     if(AUTO_UPDATE_EXTERNALS)
@@ -507,10 +511,6 @@ foreach(example IN ITEMS LittleDog)
     drake_forceupdate(download-${example})
     add_dependencies(drake download-${example})
     add_dependencies(download-all download-${example})
-
-    # Initialize the submodule configuration now so parallel downloads do not conflict later.
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule init -- drake/examples/${example}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,10 @@ foreach(proj ${EXTERNAL_PROJECTS})
 
     if(AUTO_UPDATE_EXTERNALS)
       set(${proj}_UPDATE_COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${${proj}_DOWNLOAD_COMMAND})
+
+      # Synchronize the submodule url now so parallel updates do not conflict later.
+      execute_process(COMMAND ${GIT_EXECUTABLE} submodule sync -- ${${proj}_GIT_SUBMODULE_PATH}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     else()
       set(${proj}_UPDATE_COMMAND "")
     endif()
@@ -496,6 +500,10 @@ foreach(example IN ITEMS LittleDog)
     set(${example}_DOWNLOAD_COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- drake/examples/${example})
     if(AUTO_UPDATE_EXTERNALS)
       set(${example}_UPDATE_COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${${example}_DOWNLOAD_COMMAND})
+
+      # Synchronize the submodule url now so parallel updates do not conflict later.
+      execute_process(COMMAND ${GIT_EXECUTABLE} submodule sync -- drake/examples/${example}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     else()
       set(${example}_UPDATE_COMMAND "")
     endif()


### PR DESCRIPTION
When `AUTO_UPDATE_EXTERNALS` is `ON` we are responsible for keeping external source trees up to date.  Use `git submodule sync` to honor changes to the submodule URLs.

Fixes #2694

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2695)
<!-- Reviewable:end -->
