### PR TITLE
Fix broken dependency

### DIFF
--- a/drake/examples/Acrobot/Acrobot.h
+++ b/drake/examples/Acrobot/Acrobot.h
@@ -9,8 +9,6 @@ using namespace std;
 template <typename ScalarType = double>
 class AcrobotState {  // models the Drake::Vector concept
  public:
-  static std::string channel() { return "AcrobotState"; }
-
   AcrobotState(void) : shoulder(0), elbow(0), shoulder_dot(0), elbow_dot(0) {}
 
   template <typename Derived>
@@ -56,8 +54,6 @@ class AcrobotState {  // models the Drake::Vector concept
 template <typename ScalarType = double>
 class AcrobotInput {
  public:
-  static std::string channel() { return "AcrobotInput"; }
-
   AcrobotInput(void) : tau(0) {}
 
   template <typename Derived>

--- a/drake/examples/Acrobot/Acrobot.h
+++ b/drake/examples/Acrobot/Acrobot.h
@@ -2,14 +2,13 @@
 
 #include <iostream>
 #include <cmath>
-#include "drake/systems/LCMSystem.h"
+#include <Eigen/Core>
 
 using namespace std;
 
 template <typename ScalarType = double>
 class AcrobotState {  // models the Drake::Vector concept
  public:
-  typedef drake::lcmt_drake_signal LCMMessageType;
   static std::string channel() { return "AcrobotState"; }
 
   AcrobotState(void) : shoulder(0), elbow(0), shoulder_dot(0), elbow_dot(0) {}
@@ -57,7 +56,6 @@ class AcrobotState {  // models the Drake::Vector concept
 template <typename ScalarType = double>
 class AcrobotInput {
  public:
-  typedef drake::lcmt_drake_signal LCMMessageType;
   static std::string channel() { return "AcrobotInput"; }
 
   AcrobotInput(void) : tau(0) {}


### PR DESCRIPTION
Don't include the LCMSystem header in the Acrobat example; it isn't actually used anywhere, and it creates a broken dependency as the header requires the LCM type headers, but because the example doesn't actually use LCMSystem, there is no expressed dependency to ensure that these have been generated before the example is built.

This should fix the CI failures. This didn't break previously due to a (superfluous) dependence of drakeRBSystem (to which the example *does* link) on drakeLCMSystem (which depended on the LCM type headers, thus ensuring that they exist before the library or its dependees are built). AFAICT it's pure dumb luck that it only fails on MSVC.

See also comments near the end of #2582.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2701)
<!-- Reviewable:end -->
