### PR TITLE
Disable clang sanitization in lcmgen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/RobotLocomotion/gtk-pod.git
 [submodule "externals/lcm"]
 	path = externals/lcm
-	url = https://github.com/RobotLocomotion/lcm.git
+	url = https://github.com/lcm-proj/lcm.git
 [submodule "externals/bot_core_lcmtypes"]
 	path = externals/bot_core_lcmtypes
 	url = https://github.com/mwoehlke-kitware/bot_core_lcmtypes


### PR DESCRIPTION
Update LCM to a branch that disables clang {address,memory} sanitization when building lcm-gen. This is needed as lcm-gen is sloppy about its memory management (reasonably so, as non-systemic leaks in a short lived process aren't really a problem), and so building with sanitization results in a broken executable, which causes problems later when we need to generate LCM bindings.

This also fixes a build error on Ubuntu if Lua is installed. (If LCM finds Lua, it tries to build the Lua module by default, but fails due to the headers on Ubuntu being in a non-standard location and because the include directory was not being added.) This was fixed upstream.

Upstream PR (pending): lcm-proj/lcm#78

Partially fixes #2708.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2711)
<!-- Reviewable:end -->
