### PR TITLE
Fix sign-compare warnings in systems/trajectories

### DIFF
--- a/drake/systems/trajectories/CMakeLists.txt
+++ b/drake/systems/trajectories/CMakeLists.txt
@@ -1,9 +1,4 @@
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # TODO(#2372) These are warnings that we can't handle yet.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
-endif()
-
 if(MATLAB_FOUND)
   add_mex(PPTmex PPTmex.cpp)
   add_mex(ExpPlusPPTrajectoryEvalmex ExpPlusPPTrajectoryEvalmex.cpp)

--- a/drake/systems/trajectories/PiecewiseFunction.cpp
+++ b/drake/systems/trajectories/PiecewiseFunction.cpp
@@ -85,7 +85,7 @@ std::vector<double> PiecewiseFunction::randomSegmentTimes(
 bool PiecewiseFunction::segmentTimesEqual(const PiecewiseFunction& other,
                                           double tol) const {
   if (segment_times.size() != other.segment_times.size()) return false;
-  for (int i = 0; i < segment_times.size(); i++) {
+  for (size_t i = 0; i < segment_times.size(); i++) {
     if (std::abs(segment_times[i] - other.segment_times[i]) > tol) return false;
   }
   return true;

--- a/drake/systems/trajectories/PiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/PiecewisePolynomial.cpp
@@ -30,7 +30,7 @@ PiecewisePolynomial<CoefficientType>::PiecewisePolynomial(
     : PiecewisePolynomialBase(segment_times) {
   DRAKE_ASSERT(segment_times.size() == (polynomials.size() + 1));
 
-  for (int i = 0; i < polynomials.size(); i++) {
+  for (size_t i = 0; i < polynomials.size(); i++) {
     PolynomialMatrix matrix(1, 1);
     matrix(0, 0) = polynomials[i];
     this->polynomials.push_back(matrix);
@@ -142,7 +142,7 @@ operator+=(const PiecewisePolynomial<CoefficientType>& other) {
   if (!segmentTimesEqual(other, 1e-10))
     throw runtime_error(
         "Addition not yet implemented when segment times are not equal");
-  for (int i = 0; i < polynomials.size(); i++)
+  for (size_t i = 0; i < polynomials.size(); i++)
     polynomials[i] += other.polynomials[i];
   return *this;
 }
@@ -153,7 +153,7 @@ operator-=(const PiecewisePolynomial<CoefficientType>& other) {
   if (!segmentTimesEqual(other, 1e-10))
     throw runtime_error(
         "Addition not yet implemented when segment times are not equal");
-  for (int i = 0; i < polynomials.size(); i++)
+  for (size_t i = 0; i < polynomials.size(); i++)
     polynomials[i] -= other.polynomials[i];
   return *this;
 }
@@ -164,7 +164,7 @@ operator*=(const PiecewisePolynomial<CoefficientType>& other) {
   if (!segmentTimesEqual(other, 1e-10))
     throw runtime_error(
         "Multiplication not yet implemented when segment times are not equal");
-  for (int i = 0; i < polynomials.size(); i++)
+  for (size_t i = 0; i < polynomials.size(); i++)
     polynomials[i] *= other.polynomials[i];
   return *this;
 }
@@ -173,7 +173,7 @@ template <typename CoefficientType>
 PiecewisePolynomial<CoefficientType>& PiecewisePolynomial<CoefficientType>::
 operator+=(const typename PiecewisePolynomial<
     CoefficientType>::CoefficientMatrix& offset) {
-  for (int i = 0; i < polynomials.size(); i++)
+  for (size_t i = 0; i < polynomials.size(); i++)
     polynomials[i] += offset.template cast<PolynomialType>();
   return *this;
 }
@@ -182,7 +182,7 @@ template <typename CoefficientType>
 PiecewisePolynomial<CoefficientType>& PiecewisePolynomial<CoefficientType>::
 operator-=(const typename PiecewisePolynomial<
     CoefficientType>::CoefficientMatrix& offset) {
-  for (int i = 0; i < polynomials.size(); i++)
+  for (size_t i = 0; i < polynomials.size(); i++)
     polynomials[i] -= offset.template cast<PolynomialType>();
   return *this;
 }


### PR DESCRIPTION
- Fix sign-compare warnings in systems/trajectories.
- Stop suppressing sign-compare warnings in systems/trajectories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2716)
<!-- Reviewable:end -->
