### PR TITLE
Fix sign-compare warnings in systems/robotInterfaces

### DIFF
--- a/drake/systems/robotInterfaces/CMakeLists.txt
+++ b/drake/systems/robotInterfaces/CMakeLists.txt
@@ -1,9 +1,4 @@
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # TODO(#2372) These are warnings that we can't handle yet.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
-endif()
-
 add_library_with_exports(LIB_NAME drakeSide SOURCE_FILES Side.cpp)
 drake_install_headers(Side.h)
 pods_install_libraries(drakeSide)

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -40,8 +40,8 @@ const std::map<SupportLogicType, std::vector<bool>>
         QPLocomotionPlan::createSupportLogicMaps();
 
 std::string primaryBodyOrFrameName(const std::string& full_body_name) {
-  int i;
-  for (i = 0; i < full_body_name.size(); i++) {
+  size_t i = 0;
+  for (; i < full_body_name.size(); i++) {
     if (std::strncmp(&full_body_name[i], "+", 1) == 0) {
       break;
     }
@@ -64,7 +64,7 @@ QPLocomotionPlan::QPLocomotionPlan(RigidBodyTree& robot,
       plan_shift(Vector3d::Zero()),
       last_foot_shift_time(0.0),
       shifted_zmp_trajectory(settings.zmp_trajectory) {
-  for (int i = 1; i < settings.support_times.size(); i++) {
+  for (int i = 1; i < static_cast<int>(settings.support_times.size()); i++) {
     if (settings.support_times[i] < settings.support_times[i - 1])
       throw std::runtime_error("support times must be increasing");
   }
@@ -171,8 +171,7 @@ drake::lcmt_qp_controller_input QPLocomotionPlan::createQPControllerInput(
   qp_input.zmp_data = createZMPData(t_plan);
 
   bool pelvis_has_tracking = false;
-  for (int j = 0; j < settings.body_motions.size(); ++j) {
-    BodyMotionData& body_motion = settings.body_motions[j];
+  for (BodyMotionData& body_motion : settings.body_motions) {
     int body_or_frame_id = body_motion.getBodyOrFrameId();
     int body_id = robot.parseBodyOrFrameID(body_or_frame_id);
     int body_motion_segment_index = body_motion.findSegmentIndex(t_plan);
@@ -198,9 +197,8 @@ drake::lcmt_qp_controller_input QPLocomotionPlan::createQPControllerInput(
         bool ankle_close_to_limit = Atlas::ankleCloseToLimits(
             q[akx_index], q[aky_index], settings.ankle_limits_tolerance);
         Matrix<double, 2, Dynamic> reduced_support_pts(2, 0);
-        for (int i = 0; i < support_state.size(); ++i) {
-          RigidBodySupportStateElement& support_state_element =
-              support_state[i];
+        for (RigidBodySupportStateElement& support_state_element :
+             support_state) {
           Matrix3Xd pts;
           if (support_state_element.body == body_id) {
             // pts = settings.contact_groups[body_id].at("toe");
@@ -255,9 +253,8 @@ drake::lcmt_qp_controller_input QPLocomotionPlan::createQPControllerInput(
       }
 
       if (toe_off_active[side]) {
-        for (int i = 0; i < support_state.size(); ++i) {
-          RigidBodySupportStateElement& support_state_element =
-              support_state[i];
+        for (RigidBodySupportStateElement& support_state_element :
+             support_state) {
           if (support_state_element.body == body_id)
             support_state_element.contact_points =
                 getFrontTwoContactPoints(support_state_element.contact_points);
@@ -516,7 +513,7 @@ drake::lcmt_support_data QPLocomotionPlan::createSupportDataElement(
   support_data_element_lcm.num_contact_pts = element.contact_points.cols();
   eigenToStdVectorOfStdVectors(element.contact_points,
                                support_data_element_lcm.contact_pts);
-  for (int i = 0; i < support_logic.size(); i++)
+  for (size_t i = 0; i < support_logic.size(); i++)
     support_data_element_lcm.support_logic_map[i] = support_logic[i];
   support_data_element_lcm.mu = settings.mu;
   Vector4f support_surface_float = element.support_surface.cast<float>();
@@ -703,7 +700,7 @@ void QPLocomotionPlan::findPlannedSupportFraction(
     // Now look forwards until we find the next single support
     bool found_future_single_support = false;
     double t_next_single_support_begin;
-    for (int i = support_index + 1; i < settings.supports.size(); ++i) {
+    for (size_t i = support_index + 1; i < settings.supports.size(); ++i) {
       support_sides = this->getSupportSides(settings.supports[i]);
       if (support_sides.size() == 1) {
         found_future_single_support = true;
@@ -733,7 +730,7 @@ PiecewisePolynomial<double> firstOrderHold(
     const std::vector<Matrix<double, Dynamic, Dynamic>>& knots) {
   std::vector<PiecewisePolynomial<double>::PolynomialMatrix> polys;
   polys.reserve(segment_times.size() - 1);
-  for (int i = 0; i < segment_times.size() - 1; ++i) {
+  for (int i = 0; i < static_cast<int>(segment_times.size()) - 1; ++i) {
     Matrix<Polynomial<double>, Dynamic, Dynamic> poly_matrix(knots[0].rows(),
                                                              knots[0].cols());
     for (int j = 0; j < knots[i].rows(); ++j) {
@@ -763,7 +760,7 @@ void QPLocomotionPlan::updateZMPTrajectory(const double t_plan,
       settings.zmp_trajectory.getSegmentTimes();
   std::vector<MatrixXd> zmp_knots;
   zmp_knots.reserve(segment_times.size());
-  for (int i = 0; i < segment_times.size(); ++i) {
+  for (size_t i = 0; i < segment_times.size(); ++i) {
     zmp_knots.push_back(settings.zmp_trajectory.value(segment_times[i]));
   }
   // std::cout << "right: " << foot_shifts.at(Side::RIGHT).transpose() << "
@@ -778,13 +775,13 @@ void QPLocomotionPlan::updateZMPTrajectory(const double t_plan,
   // next_support_fraction << " transition_fraction: " << transition_fraction <<
   // std::endl;
 
-  if (segment_index + 1 < zmp_knots.size()) {
+  if ((segment_index + 1) < static_cast<int>(zmp_knots.size())) {
     zmp_knots[segment_index + 1] -=
         next_support_fraction * foot_shifts.at(Side(Side::RIGHT)).head<2>() +
         (1.0 - next_support_fraction) *
             foot_shifts.at(Side(Side::LEFT)).head<2>();
   }
-  if (segment_index + 2 < zmp_knots.size()) {
+  if ((segment_index + 2) < static_cast<int>(zmp_knots.size())) {
     if (transition_fraction >= 0.05 && transition_fraction <= 0.95) {
       // If we're in double support, then we need to update the next TWO zmp
       // knots
@@ -810,7 +807,8 @@ void QPLocomotionPlan::updateZMPController(const double t_plan,
 void QPLocomotionPlan::updatePlanShift(
     const KinematicsCache<double>& cache, double t_plan,
     const std::vector<bool>& contact_force_detected, int support_index) {
-  const bool is_last_support = support_index == settings.supports.size() - 1;
+  const bool is_last_support =
+      (support_index == (static_cast<int>(settings.supports.size()) - 1));
   const RigidBodySupportState& next_support =
       is_last_support ? settings.supports[support_index]
                       : settings.supports[support_index + 1];

--- a/drake/systems/robotInterfaces/constructQPLocomotionPlanmex.cpp
+++ b/drake/systems/robotInterfaces/constructQPLocomotionPlanmex.cpp
@@ -94,7 +94,7 @@ PiecewisePolynomial<double> matlabCoefsAndBreaksToPiecewisePolynomial(
   const int kNumDims = 3;
   mwSize dims[kNumDims];
   size_t num_dims_mex = mxGetNumberOfDimensions(mex_coefs);
-  for (int i = 0; i < num_dims_mex; i++) {
+  for (size_t i = 0; i < num_dims_mex; i++) {
     dims[i] = mxGetDimensions(mex_coefs)[i];
   }
   for (int i = num_dims_mex; i < kNumDims; i++) {
@@ -163,7 +163,7 @@ std::vector<RigidBodySupportState> setUpSupports(const mxArray* mex_supports) {
     auto body_ids = matlabToStdVector<int>(
         mxGetFieldOrPropertySafe(mex_supports, support_num, "bodies"));
     support_state.reserve(body_ids.size());
-    for (int i = 0; i < body_ids.size(); ++i) {
+    for (size_t i = 0; i < body_ids.size(); ++i) {
       RigidBodySupportStateElement support_state_element;
       support_state_element.body = body_ids[i] - 1;  // base 1 to base zero
       support_state_element.contact_points = matlabToEigenMap<3, Dynamic>(
@@ -188,7 +188,7 @@ setUpContactGroups(RigidBodyTree* robot, const mxArray* mex_contact_groups) {
   std::vector<QPLocomotionPlanSettings::ContactNameToContactPointsMap>
       contact_groups;
   contact_groups.reserve(robot->bodies.size());
-  for (int body_id = 0; body_id < robot->bodies.size(); body_id++) {
+  for (size_t body_id = 0; body_id < robot->bodies.size(); body_id++) {
     const mxArray* mex_contact_group = mxGetCell(mex_contact_groups, body_id);
     QPLocomotionPlanSettings::ContactNameToContactPointsMap contact_group;
     for (int field_number = 0;

--- a/drake/systems/robotInterfaces/footstepCollocationConstraintsMex.cpp
+++ b/drake/systems/robotInterfaces/footstepCollocationConstraintsMex.cpp
@@ -37,7 +37,7 @@ void constraints(mxArray* c_out, mxArray* ceq_out, mxArray* dc_out,
   int con_dndx;
   double dx, dy, si, co;
 
-  for (j = 2; j <= nsteps; j++) {
+  for (j = 2; j <= static_cast<int>(nsteps); j++) {
     con_ndx = (j - 1) * 2;
     con_dndx = 2;
     si = sin(steps(5, j - 2));


### PR DESCRIPTION
- Fix sign-compare warnings in systems/robotInterfaces.
- Stop suppressing sign-compare warnings in systems/robotInterfaces.

(This is a little bit of a trickier one, because we were doing subtraction on unsigned integers.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2717)
<!-- Reviewable:end -->
