### PR TITLE
A collection of additions/modifications to System 2

### DIFF
--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -13,7 +13,7 @@ using systems::VectorInterface;
 namespace examples {
 
 namespace {
-constexpr int64_t kStateSize = 2;
+constexpr int kStateSize = 3;  // position, velocity, power integral
 }  // namespace
 
 SpringMassStateVector::SpringMassStateVector(double initial_position,
@@ -21,22 +21,32 @@ SpringMassStateVector::SpringMassStateVector(double initial_position,
     : BasicStateVector<double>(kStateSize) {
   set_position(initial_position);
   set_velocity(initial_velocity);
+  set_conservative_work(0);
 }
 
 SpringMassStateVector::~SpringMassStateVector() {}
 
-// Order matters: Position (q) precedes velocity (v) in ContinuousState.
+// Order matters: Position (q) precedes velocity (v) precedes misc. (z) in
+// ContinuousState.
 double SpringMassStateVector::get_position() const { return GetAtIndex(0); }
 double SpringMassStateVector::get_velocity() const { return GetAtIndex(1); }
+double SpringMassStateVector::get_conservative_work() const {
+  return GetAtIndex(2);
+}
 void SpringMassStateVector::set_position(double q) { SetAtIndex(0, q); }
 void SpringMassStateVector::set_velocity(double v) { SetAtIndex(1, v); }
+void SpringMassStateVector::set_conservative_work(double e) {
+  SetAtIndex(2, e);
+}
 
 SpringMassStateVector* SpringMassStateVector::DoClone() const {
-  return new SpringMassStateVector(get_position(), get_velocity());
+  auto state = new SpringMassStateVector(get_position(), get_velocity());
+  state->set_conservative_work(get_conservative_work());
+  return state;
 }
 
 SpringMassOutputVector::SpringMassOutputVector()
-    : BasicVector<double>(kStateSize) {}
+    : BasicVector<double>(kStateSize-1) {}  // don't output conservative energy
 
 SpringMassOutputVector::~SpringMassOutputVector() {}
 
@@ -64,6 +74,40 @@ SpringMassSystem::SpringMassSystem(const std::string& name,
       spring_constant_N_per_m_(spring_constant_N_per_m),
       mass_kg_(mass_kg) {}
 
+double SpringMassSystem::EvalSpringForce(const MyContext& context) const {
+  const double k = spring_constant_N_per_m_,
+               x = get_position(context),
+               x0 = 0.,  // TODO(david-german-tri) should be a parameter.
+               stretch = x - x0, f = -k * stretch;
+  return f;
+}
+
+double SpringMassSystem::EvalPotentialEnergy(const MyContext& context) const {
+  const double k = spring_constant_N_per_m_,
+               x = get_position(context),
+               x0 = 0.,  // TODO(david-german-tri) should be a parameter.
+               stretch = x - x0, pe = k * stretch * stretch / 2;
+  return pe;
+}
+
+double SpringMassSystem::EvalKineticEnergy(const MyContext& context) const {
+  const double m = mass_kg_,
+               v = get_velocity(context),
+               ke = m * v * v / 2;
+  return ke;
+}
+
+double SpringMassSystem::EvalConservativePower(const MyContext& context) const {
+  const double power_c = EvalSpringForce(context) * get_velocity(context);
+  return power_c;
+}
+
+// TODO(sherm1) Make this more interesting.
+double SpringMassSystem::EvalNonConservativePower(const MyContext&) const {
+  const double power_nc = 0.;
+  return power_nc;
+}
+
 SpringMassSystem::~SpringMassSystem() {}
 
 std::string SpringMassSystem::get_name() const { return name_; }
@@ -75,7 +119,7 @@ std::unique_ptr<Context<double>> SpringMassSystem::CreateDefaultContext()
   std::unique_ptr<SpringMassStateVector> state(new SpringMassStateVector(0, 0));
   context->get_mutable_state()->continuous_state.reset(
       new ContinuousState<double>(std::move(state), 1 /* size of q */,
-                                  1 /* size of v */, 0 /* size of z */));
+                                  1 /* size of v */, 1 /* size of z */));
   return context;
 }
 
@@ -90,42 +134,46 @@ std::unique_ptr<SystemOutput<double>> SpringMassSystem::AllocateOutput() const {
   return output;
 }
 
-std::unique_ptr<StateVector<double>>
-SpringMassSystem::AllocateStateDerivatives() const {
-  return std::unique_ptr<StateVector<double>>(new SpringMassStateVector(0, 0));
+std::unique_ptr<ContinuousState<double>>
+SpringMassSystem::AllocateTimeDerivatives() const {
+  std::unique_ptr<SpringMassStateVector> derivs(
+      new SpringMassStateVector(0, 0));
+  return std::unique_ptr<ContinuousState<double>>(
+      new ContinuousState<double>(std::move(derivs), 1 /* size of q */,
+                                  1 /* size of v */, 1 /* size of z */));
 }
 
 // Assign the state to the output.
-void SpringMassSystem::Output(const Context<double>& context,
-                              SystemOutput<double>* output) const {
-  // TODO(david-german-tri): Add a cast that is dynamic_cast in Debug mode,
-  // and static_cast in Release mode.
+void SpringMassSystem::EvalOutput(const Context<double>& context,
+                                  SystemOutput<double>* output) const {
   // TODO(david-german-tri): Cache the output of this function.
-  const SpringMassStateVector& state =
-      dynamic_cast<const SpringMassStateVector&>(
-          context.get_state().continuous_state->get_state());
-  SpringMassOutputVector* output_vector = dynamic_cast<SpringMassOutputVector*>(
-      output->ports[0]->GetMutableVectorData());
+  const SpringMassStateVector& state = get_state(context);
+  SpringMassOutputVector* output_vector = get_mutable_output(output);
   output_vector->set_position(state.get_position());
   output_vector->set_velocity(state.get_velocity());
 }
 
 // Compute the actual physics.
-void SpringMassSystem::Dynamics(const Context<double>& context,
-                                StateVector<double>* derivatives) const {
+void SpringMassSystem::EvalTimeDerivatives(
+    const Context<double>& context,
+    ContinuousState<double>* derivatives) const {
   // TODO(david-german-tri): Cache the output of this function.
-  const SpringMassStateVector& state =
-      dynamic_cast<const SpringMassStateVector&>(
-          context.get_state().continuous_state->get_state());
-  SpringMassStateVector* derivative_vector =
-      dynamic_cast<SpringMassStateVector*>(derivatives);
+  const SpringMassStateVector& state = get_state(context);
+
+  SpringMassStateVector* derivative_vector = get_mutable_state(derivatives);
 
   // The derivative of position is velocity.
   derivative_vector->set_position(state.get_velocity());
 
-  // The derivative of velocity is spring force divided by mass.
-  const double spring_force = -spring_constant_N_per_m_ * state.get_position();
-  derivative_vector->set_velocity(spring_force / mass_kg_);
+  // By Newton's 2nd law, the derivative of velocity (acceleration) is f/m where
+  // f is the force applied to the body by the spring, and m is the mass of the
+  // body.
+  const double force_applied_to_body = EvalSpringForce(context);
+  derivative_vector->set_velocity(force_applied_to_body / mass_kg_);
+
+  // We are integrating conservative power to get the conservative energy, that
+  // is, the net energy transferred between the spring and the mass over time.
+  derivative_vector->set_conservative_work(EvalConservativePower(context));
 }
 
 }  // namespace examples

--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -35,8 +35,8 @@ double SpringMassStateVector::get_conservative_work() const {
 }
 void SpringMassStateVector::set_position(double q) { SetAtIndex(0, q); }
 void SpringMassStateVector::set_velocity(double v) { SetAtIndex(1, v); }
-void SpringMassStateVector::set_conservative_work(double e) {
-  SetAtIndex(2, e);
+void SpringMassStateVector::set_conservative_work(double work) {
+  SetAtIndex(2, work);
 }
 
 SpringMassStateVector* SpringMassStateVector::DoClone() const {
@@ -47,8 +47,6 @@ SpringMassStateVector* SpringMassStateVector::DoClone() const {
 
 SpringMassOutputVector::SpringMassOutputVector()
     : BasicVector<double>(kStateSize-1) {}  // don't output conservative energy
-
-SpringMassOutputVector::~SpringMassOutputVector() {}
 
 double SpringMassOutputVector::get_position() const { return get_value()[0]; }
 double SpringMassOutputVector::get_velocity() const { return get_value()[1]; }
@@ -102,14 +100,10 @@ double SpringMassSystem::EvalConservativePower(const MyContext& context) const {
   return power_c;
 }
 
-// TODO(sherm1) Make this more interesting. Russ suggests adding an Input which
-// is a horizontal force on the mass, like wind blowing on it.
 double SpringMassSystem::EvalNonConservativePower(const MyContext&) const {
   const double power_nc = 0.;
   return power_nc;
 }
-
-SpringMassSystem::~SpringMassSystem() {}
 
 std::string SpringMassSystem::get_name() const { return name_; }
 
@@ -172,8 +166,9 @@ void SpringMassSystem::EvalTimeDerivatives(
   const double force_applied_to_body = EvalSpringForce(context);
   derivative_vector->set_velocity(force_applied_to_body / mass_kg_);
 
-  // We are integrating conservative power to get the conservative energy, that
-  // is, the net energy transferred between the spring and the mass over time.
+  // We are integrating conservative power to get the work done by conservative
+  // force elements, that is, the net energy transferred between the spring and
+  // the mass over time.
   derivative_vector->set_conservative_work(EvalConservativePower(context));
 }
 

--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -102,7 +102,8 @@ double SpringMassSystem::EvalConservativePower(const MyContext& context) const {
   return power_c;
 }
 
-// TODO(sherm1) Make this more interesting.
+// TODO(sherm1) Make this more interesting. Russ suggests adding an Input which
+// is a horizontal force on the mass, like wind blowing on it.
 double SpringMassSystem::EvalNonConservativePower(const MyContext&) const {
   const double power_nc = 0.;
   return power_nc;

--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -48,7 +48,9 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassStateVector
 };
 
 /// The output of a one-dimensional spring-mass system, consisting of the
-/// position and velocity of the mass, in meters.
+/// position and velocity of the mass, in meters. Note that although this 
+/// system tracks work done as a state variable, we are not reporting that
+/// as an Output.
 class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassOutputVector
     : public systems::BasicVector<double> {
  public:
@@ -82,6 +84,8 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassOutputVector
 class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
     : public systems::ContinuousSystem<double> {
  public:
+  /// Construct a spring-mass system with a fixed spring constant and given
+  /// mass.
   SpringMassSystem(const std::string& name, double spring_constant_N_per_m,
                    double mass_kg);
 
@@ -123,52 +127,52 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
     get_mutable_state(context)->set_conservative_work(energy);
   }
 
-  /** Returns the force being applied by the spring to the mass in the given
-  Context. This force f is given by `f = -k (x-x0)`; the spring applies the
-  opposite force -f to the world attachment point at the other end. The force is
-  in newtons N (kg-m/s^2). **/
+  /// Returns the force being applied by the spring to the mass in the given
+  /// Context. This force f is given by `f = -k (x-x0)`; the spring applies the
+  /// opposite force -f to the world attachment point at the other end. The
+  /// force is in newtons N (kg-m/s^2).
   double EvalSpringForce(const MyContext& context) const;
 
-  /** Returns the potential energy currently stored in the spring in the given
-  Context. For this linear spring, `pe = k (x-x0)^2 / 2`, so that spring force
-  `f = -k (x-x0)` is the negative gradient of pe. Power that is being stored
-  as potential energy will then be @verbatim
-    power_pe = d/dt pe
-             = k (x-x0) v
-             = -f v.
-  @endverbatim
-  Energy is in joules J (N-m).**/
+  /// Returns the potential energy currently stored in the spring in the given
+  /// Context. For this linear spring, `pe = k (x-x0)^2 / 2`, so that spring
+  /// force `f = -k (x-x0)` is the negative gradient of pe. Power that is being
+  /// stored as potential energy will then be @verbatim
+  ///   power_pe = d/dt pe
+  ///            = k (x-x0) v
+  ///            = -f v.
+  /// @endverbatim
+  /// Energy is in joules J (N-m).
   double EvalPotentialEnergy(const MyContext& context) const override;
 
-  /** Returns the current kinetic energy of the moving mass in the given Context.
-  This is `ke = m v^2 / 2` for this system. The rate of change of kinetic energy
-  is @verbatim
-    d/dt ke = m v a
-            = m v (f/m)
-            = f v
-            = -power_pe
-  @endverbatim
-  (assuming the only force is due to the spring). Energy is in joules.
-  @see EvalSpringForce(), EvalPotentialEnergy() **/
+  /// Returns the current kinetic energy of the moving mass in the given Context.
+  /// This is `ke = m v^2 / 2` for this system. The rate of change of kinetic
+  /// energy is @verbatim
+  ///   d/dt ke = m v a
+  ///           = m v (f/m)
+  ///           = f v
+  ///           = -power_pe
+  /// @endverbatim
+  /// (assuming the only force is due to the spring). Energy is in joules.
+  /// @see EvalSpringForce(), EvalPotentialEnergy()
   double EvalKineticEnergy(const MyContext& context) const override;
 
-  /** Returns the rate at which mechanical energy is being converted from 
-  potential energy in the spring to kinetic energy of the mass by this 
-  spring-mass system in the given Context. For this
-  system, we have conservative power @verbatim
-    power_c = f v
-            = -power_pe
-  @endverbatim
-  That quantity is positive when the spring is accelerating the mass and 
-  negative when the spring is decelerating the mass. **/
+  /// Returns the rate at which mechanical energy is being converted from 
+  /// potential energy in the spring to kinetic energy of the mass by this 
+  /// spring-mass system in the given Context. For this
+  /// system, we have conservative power @verbatim
+  ///   power_c = f v
+  ///           = -power_pe
+  /// @endverbatim
+  /// That quantity is positive when the spring is accelerating the mass and 
+  /// negative when the spring is decelerating the mass.
   double EvalConservativePower(const MyContext& context) const override;
 
   // TODO(sherm1) Currently this is a conservative system so there is no power
   // generated or consumed. Add some kind of dissipation and/or actuation to
   // make this more interesting.
 
-  /** Returns power that doesn't involve the conservative spring element. (There
-  is none in this system.) **/
+  /// Returns power that doesn't involve the conservative spring element. (There
+  /// is none in this system.)
   double EvalNonConservativePower(const MyContext& context) const override;
 
   // Implement base class methods.

--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -179,7 +179,7 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
   // TODO(sherm1) Currently this is a conservative system so there is no power
   // generated or consumed. Add some kind of dissipation and/or actuation to
   // make this more interesting. Russ suggests adding an Input which is a
-  // horizontal force on the mass, like wind blowing on it.
+  // horizontal control force on the mass.
 
   /// Returns power that doesn't involve the conservative spring element. (There
   /// is none in this system.)

--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -91,45 +91,45 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
 
   // Provide methods specific to this System.
 
-  /// Get the current position of the mass in the given Context.
+  /// Gets the current position of the mass in the given Context.
   double get_position(const MyContext& context) const {
     return get_state(context).get_position();
   }
 
-  /// Get the current velocity of the mass in the given Context.
+  /// Gets the current velocity of the mass in the given Context.
   double get_velocity(const MyContext& context) const {
     return get_state(context).get_velocity();
   }
 
-  /// Get the current value of the conservative power integral in the given
+  /// Gets the current value of the conservative power integral in the given
   /// Context.
   double get_conservative_work(const MyContext& context) const {
     return get_state(context).get_conservative_work();
   }
 
-  /// Set the position of the mass in the given Context.
+  /// Sets the position of the mass in the given Context.
   void set_position(MyContext* context, double position) const {
     get_mutable_state(context)->set_position(position);
   }
 
-  /// Set the velocity of the mass in the given Context.
+  /// Sets the velocity of the mass in the given Context.
   void set_velocity(MyContext* context, double velocity) const {
     get_mutable_state(context)->set_velocity(velocity);
   }
 
-  /// Set the initial value of the conservative power integral in the given
+  /// Sets the initial value of the conservative power integral in the given
   /// Context.
   void set_conservative_work(MyContext* context, double energy) const {
     get_mutable_state(context)->set_conservative_work(energy);
   }
 
-  /** Return the force being applied by the spring to the mass in the given
+  /** Returns the force being applied by the spring to the mass in the given
   Context. This force f is given by `f = -k (x-x0)`; the spring applies the
   opposite force -f to the world attachment point at the other end. The force is
   in newtons N (kg-m/s^2). **/
   double EvalSpringForce(const MyContext& context) const;
 
-  /** Return the potential energy currently stored in the spring in the given
+  /** Returns the potential energy currently stored in the spring in the given
   Context. For this linear spring, `pe = k (x-x0)^2 / 2`, so that spring force
   `f = -k (x-x0)` is the negative gradient of pe. Power that is being stored
   as potential energy will then be @verbatim
@@ -140,7 +140,7 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
   Energy is in joules J (N-m).**/
   double EvalPotentialEnergy(const MyContext& context) const override;
 
-  /** Return the current kinetic energy of the moving mass in the given Context.
+  /** Returns the current kinetic energy of the moving mass in the given Context.
   This is `ke = m v^2 / 2` for this system. The rate of change of kinetic energy
   is @verbatim
     d/dt ke = m v a
@@ -152,7 +152,7 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
   @see EvalSpringForce(), EvalPotentialEnergy() **/
   double EvalKineticEnergy(const MyContext& context) const override;
 
-  /** Return the rate at which mechanical energy is being converted from 
+  /** Returns the rate at which mechanical energy is being converted from 
   potential energy in the spring to kinetic energy of the mass by this 
   spring-mass system in the given Context. For this
   system, we have conservative power @verbatim
@@ -167,7 +167,7 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
   // generated or consumed. Add some kind of dissipation and/or actuation to
   // make this more interesting.
 
-  /** Return power that doesn't involve the conservative spring element. (There
+  /** Returns power that doesn't involve the conservative spring element. (There
   is none in this system.) **/
   double EvalNonConservativePower(const MyContext& context) const override;
 

--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -48,7 +48,7 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassStateVector
 };
 
 /// The output of a one-dimensional spring-mass system, consisting of the
-/// position and velocity of the mass, in meters. Note that although this 
+/// position and velocity of the mass, in meters. Note that although this
 /// system tracks work done as a state variable, we are not reporting that
 /// as an Output.
 class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassOutputVector
@@ -164,15 +164,15 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
   /// @see EvalSpringForce(), EvalPotentialEnergy()
   double EvalKineticEnergy(const MyContext& context) const override;
 
-  /// Returns the rate at which mechanical energy is being converted from 
-  /// potential energy in the spring to kinetic energy of the mass by this 
+  /// Returns the rate at which mechanical energy is being converted from
+  /// potential energy in the spring to kinetic energy of the mass by this
   /// spring-mass system in the given Context. For this
   /// system, we have conservative power @verbatim
   ///   power_c = f v
   ///           = power_ke
   ///           = -power_pe
   /// @endverbatim
-  /// This quantity is positive when the spring is accelerating the mass and 
+  /// This quantity is positive when the spring is accelerating the mass and
   /// negative when the spring is decelerating the mass.
   double EvalConservativePower(const MyContext& context) const override;
 

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -1,12 +1,23 @@
+#ifdef _MSC_VER
+// Suppress ugly Eigen internal warning in PartialPivLU's solver, correctly
+// caught by Microsoft C++, and an irrelevant GTest warning.
+#pragma warning(disable : 4800 4275)
+#endif
+
 #include "drake/examples/spring_mass/spring_mass_system.h"
 
+#include <algorithm>
+#include <cassert>
 #include <memory>
+#include <iomanip>
+#include <iostream>
+
 
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
-#include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/context.h"
+#include "drake/systems/framework/continuous_system.h"
 #include "drake/systems/framework/leaf_state_vector.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/state_subvector.h"
@@ -15,10 +26,19 @@
 #include "drake/systems/framework/vector_interface.h"
 #include "drake/util/eigen_matrix_compare.h"
 
+using std::unique_ptr;
+using std::cout;
+using std::endl;
+
+
 namespace drake {
 
+using systems::VectorInterface;
+using systems::BasicVector;
+using systems::BasicStateVector;
 using systems::Context;
 using systems::ContinuousState;
+using systems::ContinuousSystem;
 using systems::LeafStateVector;
 using systems::StateSubvector;
 using systems::StateVector;
@@ -39,15 +59,19 @@ class SpringMassSystemTest : public ::testing::Test {
     system_.reset(new SpringMassSystem("test_system", kSpring, kMass));
     context_ = system_->CreateDefaultContext();
     system_output_ = system_->AllocateOutput();
-    erased_derivatives_ = system_->AllocateStateDerivatives();
+    system_derivatives_ = system_->AllocateTimeDerivatives();
+    const int nq = system_derivatives_->get_generalized_position().size();
+    configuration_derivatives_ = std::unique_ptr<BasicStateVector<double>>(
+        new BasicStateVector<double>(std::unique_ptr<VectorInterface<double>>(
+            new BasicVector<double>(nq))));
 
     // Set up some convenience pointers.
     state_ = dynamic_cast<SpringMassStateVector*>(
         context_->get_mutable_state()->continuous_state->get_mutable_state());
     output_ = dynamic_cast<const SpringMassOutputVector*>(
         system_output_->ports[0]->get_vector_data());
-    derivatives_ =
-        dynamic_cast<SpringMassStateVector*>(erased_derivatives_.get());
+    derivatives_ = dynamic_cast<SpringMassStateVector*>(
+        system_derivatives_->get_mutable_state());
   }
 
   void InitializeState(const double position, const double velocity) {
@@ -59,6 +83,9 @@ class SpringMassSystemTest : public ::testing::Test {
   std::unique_ptr<SpringMassSystem> system_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<SystemOutput<double>> system_output_;
+  std::unique_ptr<ContinuousState<double>> system_derivatives_;
+  std::unique_ptr<BasicStateVector<double>> configuration_derivatives_;
+
   SpringMassStateVector* state_;
   const SpringMassOutputVector* output_;
   SpringMassStateVector* derivatives_;
@@ -83,7 +110,7 @@ TEST_F(SpringMassSystemTest, CloneState) {
 
 TEST_F(SpringMassSystemTest, CloneOutput) {
   InitializeState(1.0, 2.0);
-  system_->Output(*context_, system_output_.get());
+  system_->EvalOutput(*context_, system_output_.get());
   std::unique_ptr<VectorInterface<double>> clone = output_->Clone();
 
   SpringMassOutputVector* typed_clone =
@@ -95,7 +122,7 @@ TEST_F(SpringMassSystemTest, CloneOutput) {
 // Tests that state is passed through to the output.
 TEST_F(SpringMassSystemTest, Output) {
   InitializeState(0.1, 0.0);  // Displacement 100cm, no velocity.
-  system_->Output(*context_, system_output_.get());
+  system_->EvalOutput(*context_, system_output_.get());
   ASSERT_EQ(1, system_output_->ports.size());
 
   // Check the output through the application-specific interface.
@@ -115,7 +142,7 @@ TEST_F(SpringMassSystemTest, SecondOrderStructure) {
       context_->get_mutable_state()->continuous_state.get();
   ASSERT_EQ(1, continuous_state->get_generalized_position().size());
   ASSERT_EQ(1, continuous_state->get_generalized_velocity().size());
-  ASSERT_EQ(0, continuous_state->get_misc_continuous_state().size());
+  ASSERT_EQ(1, continuous_state->get_misc_continuous_state().size());
   EXPECT_NEAR(1.2, continuous_state->get_generalized_position().GetAtIndex(0),
               1e-8);
   EXPECT_NEAR(3.4, continuous_state->get_generalized_velocity().GetAtIndex(0),
@@ -143,9 +170,9 @@ TEST_F(SpringMassSystemTest, MapVelocityToConfigurationDerivative) {
 
 TEST_F(SpringMassSystemTest, ForcesPositiveDisplacement) {
   InitializeState(0.1, 0.1);  // Displacement 0.1m, velocity 0.1m/sec.
-  system_->Dynamics(*context_, derivatives_);
+  system_->EvalTimeDerivatives(*context_, system_derivatives_.get());
 
-  ASSERT_EQ(2, derivatives_->size());
+  ASSERT_EQ(3, derivatives_->size());
   // The derivative of position is velocity.
   EXPECT_NEAR(0.1, derivatives_->get_position(), 1e-8);
   // The derivative of velocity is force over mass.
@@ -154,16 +181,284 @@ TEST_F(SpringMassSystemTest, ForcesPositiveDisplacement) {
 
 TEST_F(SpringMassSystemTest, ForcesNegativeDisplacement) {
   InitializeState(-0.1, 0.2);  // Displacement -0.1m, velocity 0.2m/sec.
-  system_->Dynamics(*context_, derivatives_);
+  system_->EvalTimeDerivatives(*context_, system_derivatives_.get());
 
-  ASSERT_EQ(2, derivatives_->size());
+  ASSERT_EQ(3, derivatives_->size());
   // The derivative of position is velocity.
   EXPECT_NEAR(0.2, derivatives_->get_position(), 1e-8);
   // The derivative of velocity is force over mass.
   EXPECT_NEAR(-kSpring * -0.1 / kMass, derivatives_->get_velocity(), 1e-8);
 }
 
-// TODO(david-german-tri, sherm1): Add test cases using integration.
+// These are helper functions for the Integrate test below.
+//
+
+/* Given a System and a Context, calculate the partial derivative matrix
+D xdot / D x. Here x has only continuous variables; in general we would have
+x=[xc,xd] in which case we'd be working with xc here.
+
+TODO(sherm1) This matrix should be calculated by templatizing the spring-mass
+System by AutoDiffScalar and by std::complex (for complex step derivatives).
+The numerical routine here should then be used in a separate test to make sure
+the autodifferentiated matrices agree with the numerical one. Also, consider
+switching to central differences here to get more decimal places. */
+MatrixX<double> CalcDxdotDx(const ContinuousSystem<double>& system,
+                            const Context<double>& context) {
+  const double perturb = 1e-7;  // roughly sqrt(precision)
+  auto derivs0 = system.AllocateTimeDerivatives();
+  system.EvalTimeDerivatives(context, derivs0.get());
+  const int nx = derivs0->get_state().size();
+  const VectorX<double> xdot0 = derivs0->get_state().CopyToVector();
+  MatrixX<double> d_xdot_dx(nx, nx);
+
+  auto temp_context = context.Clone();
+  auto x =
+      temp_context->get_mutable_state()->continuous_state->get_mutable_state();
+
+  // This is a temp that holds one column of the result as a ContinuousState.
+  auto derivs = system.AllocateTimeDerivatives();
+
+  for (int i = 0; i < x->size(); ++i) {
+    const double xi = x->GetAtIndex(i);
+    x->SetAtIndex(i, xi + perturb);
+    system.EvalTimeDerivatives(*temp_context, derivs.get());
+    d_xdot_dx.col(i) = (derivs->get_state().CopyToVector() - xdot0) / perturb;
+    x->SetAtIndex(i, xi);  // repair Context
+  }
+
+  return d_xdot_dx;
+}
+
+/* Explicit Euler (unstable): x1 = x0 + h xdot(t0,x0) */
+void StepExplicitEuler(double h,
+                       const ContinuousState<double>& derivs,
+                       Context<double>& context) {
+  const double t = context.get_time();
+  // Invalidate all xc-dependent quantities.
+  StateVector<double>* xc =
+      context.get_mutable_state()->continuous_state->get_mutable_state();
+  const auto& dxc = derivs.get_state();
+  xc->PlusEqScaled(h, dxc);  // xc += h*dxc
+  context.set_time(t + h);
+}
+
+/* Semi-explicit Euler (neutrally stable):
+    z1 = z0 + h zdot(t0,x0)
+    v1 = v0 + h vdot(t0,x0)
+    q1 = q0 + h qdot(q0,v1) */
+void StepSemiExplicitEuler(double h, const ContinuousSystem<double>& system,
+                           ContinuousState<double>& derivs,  // in/out
+                           Context<double>& context) {
+  // Allocate a temp to hold qdot. This would normally be done once per
+  // integration, not per time step!
+  // const int nq = derivs.get_generalized_position().size();
+  // auto configuration_derivatives =
+  // std::make_unique<BasicStateVector<double>>(
+  //    std::unique_ptr<VectorInterface<double>>(new BasicVector<double>(nq)));
+
+  const double t = context.get_time();
+
+  // Invalidate z-dependent quantities.
+  StateVector<double>* xz =
+      context.get_mutable_state()
+          ->continuous_state->get_mutable_misc_continuous_state();
+  const auto& dxz = derivs.get_misc_continuous_state();
+  xz->PlusEqScaled(h, dxz);  // xz += h*dxz
+
+  // Invalidate v-dependent quantities.
+  StateVector<double>* xv =
+      context.get_mutable_state()
+          ->continuous_state->get_mutable_generalized_velocity();
+  const auto& dxv = derivs.get_generalized_velocity();
+  xv->PlusEqScaled(h, dxv);  // xv += h*dxv
+
+  context.set_time(t + h);
+
+  // Invalidate q-dependent quantities.
+  StateVector<double>* xq =
+      context.get_mutable_state()
+          ->continuous_state->get_mutable_generalized_position();
+  auto dxq = derivs.get_mutable_generalized_position();
+  system.MapVelocityToConfigurationDerivatives(context, *xv,
+                                               dxq);  // qdot = N(q)*v
+  xq->PlusEqScaled(h, *dxq);                          // xq += h*qdot
+}
+
+/* Implicit Euler (unconditionally stable): x1 = x0 + h xdot(t1,x1)
+    Define err(x) = x - (x0 + h xdot(t1,x))
+          J(x) = D err / D x = 1 - h D xdot / D x
+    Guess: x1 = x0 + h xdot(t0,x0)
+    do: Solve J(x1) dx = err(x1)
+        x1 = x1 - dx
+    while (norm(dx)/norm(x0) > tol) */
+void StepImplicitEuler(double h, const ContinuousSystem<double>& system,
+                       ContinuousState<double>& derivs,  // in/out
+                       Context<double>& context) {
+  const double t = context.get_time();
+
+  // Invalidate all xc-dependent quantities.
+  StateVector<double>* x1 =
+      context.get_mutable_state()->continuous_state->get_mutable_state();
+
+  const auto vx0 = x1->CopyToVector();
+  const auto& dx0 = derivs.get_state();
+  x1->PlusEqScaled(h, dx0);  // x1 += h*dx0 (initial guess)
+  context.set_time(t + h);  // t=t1
+  const int nx = static_cast<int>(vx0.size());
+  const auto I = MatrixX<double>::Identity(nx, nx);
+
+  // Would normally iterate until convergence of dx norm as shown above.
+  // Here I'm just iterating a fixed number of time that I know is plenty!
+  for (int i = 0; i < 6; ++i) {
+    system.EvalTimeDerivatives(context, &derivs);
+    const auto& dx1 = derivs.get_state();
+    const auto vx1 = x1->CopyToVector();
+    const auto vdx1 = dx1.CopyToVector();
+    const auto err = vx1 - (vx0 + h * vdx1);
+    const auto DxdotDx = CalcDxdotDx(system, context);
+    const auto J = I - h * DxdotDx;
+    Eigen::PartialPivLU<MatrixX<double>> Jlu(J);
+    VectorX<double> dx = Jlu.solve(err);
+    x1->SetFromVector(vx1 - dx);
+  }
+}
+
+/* Calculate the total energy for this system in the given Context.
+TODO(sherm1): assuming there is only KE and PE to worry about. */
+double CalcEnergy(const SpringMassSystem& system,
+                  const Context<double>& context) {
+  return system.EvalPotentialEnergy(context) +
+         system.EvalKineticEnergy(context);
+}
+
+/* This test simulates the spring-mass system simultaneously using three first-
+order integrators with different stability properties. The system itself is
+conservative since it contains no actuation or damping. All numerical
+integrators are approximate, but differing stability properties cause
+predictably different effects on total system energy:
+  - Explicit Euler: energy should increase
+  - Implicit Euler: energy should decrease
+  - Semi-explicit Euler: energy should remain constant
+The test evaluates the initial energy and then makes sure it goes in the
+expected direction for each integration method.
+
+The primary goal of this test is to exercise the System 2.0 API by using it
+for solvers that have different API demands. */
+TEST_F(SpringMassSystemTest, Integrate) {
+  const double h = 0.001, kTfinal = 9, kNumIntegrators = 3;
+
+  // Resource indices for each of the three integrators.
+  enum { kXe = 0, kIe = 1, kSxe = 2 };
+  std::vector<unique_ptr<SpringMassSystem::MyContext>> contexts;
+  std::vector<unique_ptr<SpringMassSystem::MyOutput>> outputs;
+  std::vector<unique_ptr<SpringMassSystem::MyContinuousState>> derivs;
+
+  // Allocate resources.
+  for (int i = 0; i < kNumIntegrators; ++i) {
+    contexts.push_back(system_->CreateDefaultContext());
+    outputs.push_back(system_->AllocateOutput());
+    derivs.push_back(system_->AllocateTimeDerivatives());
+  }
+
+  // Set initial conditions in each Context.
+  for (auto& context : contexts) {
+    context->set_time(0);
+    system_->set_position(context.get(), 0.1);  // Displacement 0.1m, vel. 0m/s.
+    system_->set_velocity(context.get(), 0.);
+  }
+
+  // Save the initial energy (same in all contexts).
+  const double initial_energy = CalcEnergy(*system_, *contexts[0]);
+
+  while (true) {
+    const auto t = contexts[0]->get_time();
+
+    /* Evaluate derivatives at the beginning of a step, then generate
+    Outputs (which may depend on derivatives). Uncomment five lines below if you
+    want to get output you can plot.
+
+    TODO(david-german-tri,sherm1) Should have a way to run similar code in
+    both regression test form and as friendlier examples. */
+
+    for (int i = 0; i < kNumIntegrators; ++i) {
+      system_->EvalTimeDerivatives(*contexts[i], derivs[i].get());
+      system_->EvalOutput(*contexts[i], outputs[i].get());
+    }
+
+    // Semi-explicit Euler should keep energy roughly constant every step.
+    EXPECT_NEAR(CalcEnergy(*system_, *contexts[kSxe]), initial_energy, 1e-2);
+
+    if (t >= kTfinal) break;
+
+    // Integrate three ways.
+    StepExplicitEuler(h, *derivs[kXe], *contexts[kXe]);
+    StepImplicitEuler(h, *system_, *derivs[kIe], *contexts[kIe]);
+    StepSemiExplicitEuler(h, *system_, *derivs[kSxe], *contexts[kSxe]);
+  }
+
+  // Now verify that each integrator behaved as expected.
+  EXPECT_GT(CalcEnergy(*system_, *contexts[kXe]), 2 * initial_energy);
+  EXPECT_LT(CalcEnergy(*system_, *contexts[kIe]), initial_energy / 2);
+  EXPECT_NEAR(CalcEnergy(*system_, *contexts[kSxe]), initial_energy, 1e-2);
+}
+
+/* Test that EvalConservativePower() correctly measures the transfer of power
+from potential energy to kinetic energy. We have to integrate the power to
+calculate the net work W(t) done by the spring on the mass. If we set W(0)=0, 
+then it should always hold that 
+  PE(t) + KE(t) = PE(0) + KE(0)
+  KE(t) = KE(0) + W(t)
+  PE(t) = PE(0) - W(t)
+
+This will only be true if the system is integrated with no energy gains or
+losses from the numerical method, because those are not conservative changes.
+The semi-explicit Euler method we used above is the only method we can use for
+this test (unless we run with very small time steps). */
+TEST_F(SpringMassSystemTest, IntegrateConservativePower) {
+  const double h = 0.00001, kTfinal = 5;
+
+  // Resources.
+  unique_ptr<SpringMassSystem::MyContext> context =
+      system_->CreateDefaultContext();
+  unique_ptr<SpringMassSystem::MyContinuousState> derivs =
+      system_->AllocateTimeDerivatives();
+
+  // Set initial conditions..
+  context->set_time(0);
+  system_->set_position(context.get(), 0.1);  // Displacement 0.1m, vel. 0m/s.
+  system_->set_velocity(context.get(), 0.);
+  system_->set_conservative_work(context.get(), 0.);  // W(0)=0
+
+  // Save the initial energy.
+  const double pe0 = system_->EvalPotentialEnergy(*context);
+  const double ke0 = system_->EvalKineticEnergy(*context);
+  const double e0 = pe0 + ke0;
+
+  while (true) {
+    const auto t = context->get_time();
+
+    // Evaluate derivatives at the beginning of a step. We don't need outputs.
+    system_->EvalTimeDerivatives(*context, derivs.get());
+
+    if (t >= kTfinal) break;
+
+    const double pe = system_->EvalPotentialEnergy(*context);
+    const double ke = system_->EvalKineticEnergy(*context);
+    const double e = pe + ke;
+    EXPECT_NEAR(e, e0, 1e-3);
+
+    // Due to a quirk of semi-explicit Euler, this integral was evaluated
+    // using the previous step's q's rather than the ones current now so
+    // there is a larger discrepency than would be expected from accuracy
+    // alone.
+    const double w = system_->get_conservative_work(*context);
+    EXPECT_NEAR(ke, ke0 + w, 1e-2);
+    EXPECT_NEAR(pe, pe0 - w, 1e-2);
+
+    // Take a step of size h.
+    StepSemiExplicitEuler(h, *system_, *derivs, *context);
+  }
+}
 
 }  // namespace
 }  // namespace examples

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -196,8 +196,8 @@ TEST_F(SpringMassSystemTest, ForcesNegativeDisplacement) {
   EXPECT_NEAR(-kSpring * -0.1 / kMass, derivatives_->get_velocity(), 1e-8);
 }
 
-TEST_F(SpringMassSystemTest,ForceEnergyAndPower) {
-  InitializeState(1,2);
+TEST_F(SpringMassSystemTest, ForceEnergyAndPower) {
+  InitializeState(1, 2);
   const double m = system_->get_mass();
   const double k = system_->get_spring_constant();
   const double q0 = 0;  // TODO(david-german-tri) should be a parameter.

--- a/drake/systems/framework/basic_state_vector.h
+++ b/drake/systems/framework/basic_state_vector.h
@@ -35,7 +35,9 @@ class BasicStateVector : public LeafStateVector<T> {
   explicit BasicStateVector(std::unique_ptr<VectorInterface<T>> vector)
       : vector_(std::move(vector)) {}
 
-  int size() const override { return vector_->get_value().rows(); }
+  int size() const override {
+    return static_cast<int>(vector_->get_value().rows());
+  }
 
   const T GetAtIndex(int index) const override {
     if (index >= size()) {
@@ -61,18 +63,17 @@ class BasicStateVector : public LeafStateVector<T> {
 
   VectorX<T> CopyToVector() const override { return vector_->get_value(); }
 
-  void AddToVector(Eigen::Ref<VectorX<T>> vec) const override {
+  void ScaleAndAddToVector(const T& scale,
+                           Eigen::Ref<VectorX<T>> vec) const override {
     if (vec.rows() != size()) {
       throw std::out_of_range("Addends must be the same length.");
     }
-    vec += vector_->get_value();
+    vec += scale * vector_->get_value();
   }
 
-  BasicStateVector& operator+=(const StateVector<T>& rhs) override {
-    if (size() != rhs.size()) {
-      throw std::out_of_range("Addends must be the same length.");
-    }
-    rhs.AddToVector(vector_->get_mutable_value());
+  BasicStateVector& PlusEqScaled(const T& scale,
+                                 const StateVector<T>& rhs) override {
+    rhs.ScaleAndAddToVector(scale, vector_->get_mutable_value());
     return *this;
   }
 

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -27,8 +27,6 @@ class BasicVector : public VectorInterface<T> {
             size, std::numeric_limits<
                       typename Eigen::NumTraits<T>::Real>::quiet_NaN())) {}
 
-  ~BasicVector() override {}
-
   void set_value(const Eigen::Ref<const VectorX<T>>& value) override {
     if (value.rows() != values_.rows()) {
       throw std::out_of_range(

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -22,7 +22,7 @@ namespace systems {
 template <typename T>
 class BasicVector : public VectorInterface<T> {
  public:
-  explicit BasicVector(int size)
+  explicit BasicVector(ptrdiff_t size)
       : values_(VectorX<T>::Constant(
             size, std::numeric_limits<
                       typename Eigen::NumTraits<T>::Real>::quiet_NaN())) {}
@@ -38,7 +38,7 @@ class BasicVector : public VectorInterface<T> {
     values_ = value;
   }
 
-  int size() const override { return values_.rows(); }
+  int size() const override { return static_cast<int>(values_.rows()); }
 
   Eigen::VectorBlock<const VectorX<T>> get_value() const override {
     return values_.head(values_.rows());

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -22,7 +22,7 @@ namespace systems {
 template <typename T>
 class BasicVector : public VectorInterface<T> {
  public:
-  explicit BasicVector(ptrdiff_t size)
+  explicit BasicVector(int size)
       : values_(VectorX<T>::Constant(
             size, std::numeric_limits<
                       typename Eigen::NumTraits<T>::Real>::quiet_NaN())) {}

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -13,9 +13,9 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-struct Time {
-  /// The time, in seconds.  For typical T implementations based on
-  /// doubles, time precision will gradually degrade as time increases.
+struct TimeStep {
+  /// The time, in seconds. For typical T implementations based on
+  /// doubles, time resolution will gradually degrade as time increases.
   /// TODO(sherm1): Consider whether this is sufficiently robust.
   T time_sec{};
 };
@@ -38,8 +38,21 @@ class Context {
   Context() {}
   virtual ~Context() {}
 
-  const Time<T>& get_time() const { return time_; }
-  Time<T>* get_mutable_time() { return &time_; }
+  /// Returns the current time in seconds.
+  const T& get_time() const { return get_time_step().time_sec; }
+
+  /// Set the current time in seconds, with the side effect that all cached
+  /// time-dependent computations are invalidated.
+  void set_time(const T& time_sec) {
+    get_mutable_time_step()->time_sec = time_sec;
+  }
+
+  /// Returns a const reference to current time and step information.
+  const TimeStep<T>& get_time_step() const { return time_step_; }
+
+  /// Provides writable access to time and step information, with the side
+  /// effect of invaliding any computation that is dependent on them.
+  TimeStep<T>* get_mutable_time_step() { return &time_step_; }
 
   /// Connects the input port @p port to this Context at the given @p index.
   /// Disconnects whatever input port was previously there, and deregisters
@@ -65,7 +78,7 @@ class Context {
     inputs_.resize(n);
   }
 
-  int get_num_input_ports() const { return inputs_.size(); }
+  int get_num_input_ports() const { return static_cast<int>(inputs_.size()); }
 
   /// Returns the vector data of the input port at @p index. Returns nullptr
   /// if that port is not a vector-valued port, or if it is not connected.
@@ -81,10 +94,19 @@ class Context {
   }
 
   const State<T>& get_state() const { return state_; }
+
+  /// Returns writable access to the State. No cache invalidation occurs until
+  /// mutable access is requested for particular blocks of state variables.
   State<T>* get_mutable_state() { return &state_; }
 
+  /// Returns a const reference to the Cache, which is expected to contain
+  /// precalculated values of interest. Use this only to access known-valid
+  /// cache entries; use `get_mutable_cache()` if computations may be needed.
+  const Cache<T>& get_cache() const { return &cache_; }
+
   /// Access to the cache is always read-write, and is permitted even on
-  /// const references to the Context.
+  /// const references to the Context. No invalidation of downstream dependents
+  /// occurs until mutable access is requested for a particular cache entry.
   Cache<T>* get_mutable_cache() const { return &cache_; }
 
   /// Returns a deep copy of this Context. The clone's input ports will hold
@@ -120,7 +142,7 @@ class Context {
     }
 
     // Make deep copies of everything else using the default copy constructors.
-    *context->get_mutable_time() = this->get_time();
+    *context->get_mutable_time_step() = this->get_time_step();
     *context->get_mutable_cache() = *this->get_mutable_cache();
     return context;
   }
@@ -131,13 +153,13 @@ class Context {
   Context(Context&& other) = delete;
   Context& operator=(Context&& other) = delete;
 
-  /// The current time.
-  Time<T> time_;
+  // Current time and step information.
+  TimeStep<T> time_step_;
 
-  /// The external inputs to the System.
+  // The external inputs to the System.
   std::vector<std::unique_ptr<InputPort<T>>> inputs_;
 
-  /// The internal state of the System.
+  // The internal state of the System.
   State<T> state_;
 
   /// The cache. The System may insert arbitrary key-value pairs, and configure

--- a/drake/systems/framework/continuous_system.h
+++ b/drake/systems/framework/continuous_system.h
@@ -16,8 +16,6 @@ namespace systems {
 template <typename T>
 class ContinuousSystem : public ContinuousSystemInterface<T> {
  public:
-  ~ContinuousSystem() override {}
-
   /// Applies the identity mapping. Throws std::out_of_range if the
   /// @p generalized_velocity and @p configuration_derivatives are not the
   /// same size. Child classes should override this function if qdot != v.

--- a/drake/systems/framework/continuous_system_interface.h
+++ b/drake/systems/framework/continuous_system_interface.h
@@ -64,7 +64,7 @@ class ContinuousSystemInterface : public SystemInterface<T> {
   // zero defaults so that these don't have to be implemented in non-physical
   // systems.
 
-  /// Return the rate at which mechanical energy is being converted *from* 
+  /// Return the rate at which mechanical energy is being converted *from*
   /// potential energy *to* kinetic energy by this system in the given Context.
   /// This quantity will be positive when potential energy is decreasing. Note
   /// that kinetic energy will also be affected by non-conservative forces so we

--- a/drake/systems/framework/continuous_system_interface.h
+++ b/drake/systems/framework/continuous_system_interface.h
@@ -16,10 +16,11 @@ class ContinuousSystemInterface : public SystemInterface<T> {
  public:
   ~ContinuousSystemInterface() override {}
 
-  /// Returns a vector of the same size as the continuous_state allocated in
-  /// CreateDefaultContext. Solvers will provide this vector as the output
-  /// argument to Dynamics.
-  virtual std::unique_ptr<StateVector<T>> AllocateStateDerivatives() const = 0;
+  /// Returns a ContinuousState of the same size as the continuous_state
+  /// allocated in CreateDefaultContext. Solvers will provide this state as the
+  /// output argument to EvalTimeDerivatives.
+  virtual std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives()
+      const = 0;
 
   /// Produces the derivatives of the continuous state xc with respect to time.
   /// The @p derivatives vector will correspond elementwise with the state
@@ -28,12 +29,12 @@ class ContinuousSystemInterface : public SystemInterface<T> {
   /// the derivatives.
   ///
   /// Implementations may assume that the output is of the type constructed in
-  /// CreateDefaultStateDerivatives.
+  /// AllocateTimeDerivatives.
   ///
   /// @param derivatives The output vector. Will be the same length as the
   ///                    state vector Context.state.continuous_state.
-  virtual void Dynamics(const Context<T>& context,
-                        StateVector<T>* derivatives) const = 0;
+  virtual void EvalTimeDerivatives(const Context<T>& context,
+                                   ContinuousState<T>* derivatives) const = 0;
 
   /// Transforms the velocity (v) in the given Context state to the derivative
   /// of the configuration (qdot). The transformation must be linear
@@ -55,6 +56,37 @@ class ContinuousSystemInterface : public SystemInterface<T> {
       StateVector<T>* configuration_derivatives) const = 0;
 
   // TODO(david-german-tri): Add MapConfigurationDerivativesToVelocity.
+
+  // TODO(sherm): these two power methods should be present only for continuous
+  // systems that represent some kind of physical system that can inject or
+  // dissipate energy into the simulation. Consider whether to introduce
+  // a class like PhysicalSystemInterface that could add these methods only
+  // when appropriate; that is awkward to mix with ContinuousSystemInterface
+  // so for now I'm breaking the no-code-in-interface rule to provide
+  // zero defaults so that these don't have to be implemented in non-physical
+  // systems.
+
+  /** Return the rate at which mechanical energy is being converted *from* 
+  potential energy *to* kinetic energy by this system in the given Context. This
+  quantity will be positive when potential energy is decreasing. Note that
+  kinetic energy will also be affected by non-conservative forces so we can't
+  say which direction it is moving, only whether the conservative power is 
+  increasing or decreasing the kinetic energy. Power is in watts (J/s). This
+  method is meaningful only for physical systems; others return 0. **/
+  virtual T EvalConservativePower(const Context<T>& context) const {
+    return T(0);
+  }
+
+  /** Return the rate at which mechanical energy is being generated (positive)
+  or dissipated (negative) *other than* by conversion between potential and
+  kinetic energy (in the given Context). Integrating this quantity yields work
+  W, and the total energy `E=PE+KE-W` should be conserved by any
+  physically-correct model, to within integration accuracy of W. Power is in
+  watts (J/s). (Watts are abbreviated W but not to be confused with work!) This
+  method is meaningful only for physical systems; others return 0. **/
+  virtual T EvalNonConservativePower(const Context<T>& context) const {
+    return T(0);
+  }
 
  protected:
   ContinuousSystemInterface() {}

--- a/drake/systems/framework/continuous_system_interface.h
+++ b/drake/systems/framework/continuous_system_interface.h
@@ -14,8 +14,6 @@ namespace systems {
 template <typename T>
 class ContinuousSystemInterface : public SystemInterface<T> {
  public:
-  ~ContinuousSystemInterface() override {}
-
   /// Returns a ContinuousState of the same size as the continuous_state
   /// allocated in CreateDefaultContext. Solvers will provide this state as the
   /// output argument to EvalTimeDerivatives.
@@ -28,8 +26,8 @@ class ContinuousSystemInterface : public SystemInterface<T> {
   /// the Context has second-order structure, that same structure applies to
   /// the derivatives.
   ///
-  /// Implementations may assume that the output is of the type constructed in
-  /// AllocateTimeDerivatives.
+  /// Implementations may assume that the given @p derivatives argument has the
+  /// same constituent structure as was produced by AllocateTimeDerivatives.
   ///
   /// @param derivatives The output vector. Will be the same length as the
   ///                    state vector Context.state.continuous_state.
@@ -37,7 +35,7 @@ class ContinuousSystemInterface : public SystemInterface<T> {
                                    ContinuousState<T>* derivatives) const = 0;
 
   /// Transforms the velocity (v) in the given Context state to the derivative
-  /// of the configuration (qdot). The transformation must be linear
+  /// of the configuration (qdot). The transformation must be linear in velocity
   /// (qdot = N(q) * v), and it must require no more than O(N) time to compute
   /// in the number of generalized velocity states.
   ///

--- a/drake/systems/framework/continuous_system_interface.h
+++ b/drake/systems/framework/continuous_system_interface.h
@@ -66,24 +66,25 @@ class ContinuousSystemInterface : public SystemInterface<T> {
   // zero defaults so that these don't have to be implemented in non-physical
   // systems.
 
-  /** Return the rate at which mechanical energy is being converted *from* 
-  potential energy *to* kinetic energy by this system in the given Context. This
-  quantity will be positive when potential energy is decreasing. Note that
-  kinetic energy will also be affected by non-conservative forces so we can't
-  say which direction it is moving, only whether the conservative power is 
-  increasing or decreasing the kinetic energy. Power is in watts (J/s). This
-  method is meaningful only for physical systems; others return 0. **/
+  /// Return the rate at which mechanical energy is being converted *from* 
+  /// potential energy *to* kinetic energy by this system in the given Context.
+  /// This quantity will be positive when potential energy is decreasing. Note
+  /// that kinetic energy will also be affected by non-conservative forces so we
+  /// can't say which direction it is moving, only whether the conservative
+  /// power is increasing or decreasing the kinetic energy. Power is in watts
+  /// (J/s). This method is meaningful only for physical systems; others
+  /// return 0.
   virtual T EvalConservativePower(const Context<T>& context) const {
     return T(0);
   }
 
-  /** Return the rate at which mechanical energy is being generated (positive)
-  or dissipated (negative) *other than* by conversion between potential and
-  kinetic energy (in the given Context). Integrating this quantity yields work
-  W, and the total energy `E=PE+KE-W` should be conserved by any
-  physically-correct model, to within integration accuracy of W. Power is in
-  watts (J/s). (Watts are abbreviated W but not to be confused with work!) This
-  method is meaningful only for physical systems; others return 0. **/
+  /// Return the rate at which mechanical energy is being generated (positive)
+  /// or dissipated (negative) *other than* by conversion between potential and
+  /// kinetic energy (in the given Context). Integrating this quantity yields
+  /// work W, and the total energy `E=PE+KE-W` should be conserved by any
+  /// physically-correct model, to within integration accuracy of W. Power is in
+  /// watts (J/s). (Watts are abbreviated W but not to be confused with work!)
+  /// This method is meaningful only for physical systems; others return 0.
   virtual T EvalNonConservativePower(const Context<T>& context) const {
     return T(0);
   }

--- a/drake/systems/framework/leaf_state_vector.h
+++ b/drake/systems/framework/leaf_state_vector.h
@@ -16,8 +16,6 @@ namespace systems {
 template <typename T>
 class LeafStateVector : public StateVector<T> {
  public:
-  ~LeafStateVector() override {}
-
   /// Copies the entire state to a new LeafStateVector.
   ///
   /// Uses the Non-Virtual Interface idiom because smart pointers do not have
@@ -29,7 +27,6 @@ class LeafStateVector : public StateVector<T> {
  protected:
   LeafStateVector() {}
 
- private:
   /// Returns a new LeafStateVector containing a copy of the entire state.
   /// Caller must take ownership.
   ///
@@ -37,6 +34,7 @@ class LeafStateVector : public StateVector<T> {
   /// value and allocates only the O(N) memory that it returns.
   virtual LeafStateVector<T>* DoClone() const = 0;
 
+ private:
   // LeafStateVector objects are neither copyable nor moveable.
   LeafStateVector(const LeafStateVector& other) = delete;
   LeafStateVector& operator=(const LeafStateVector& other) = delete;

--- a/drake/systems/framework/primitives/adder.cc
+++ b/drake/systems/framework/primitives/adder.cc
@@ -35,8 +35,8 @@ std::unique_ptr<SystemOutput<T>> Adder<T>::AllocateOutput() const {
 }
 
 template <typename T>
-void Adder<T>::Output(const Context<T>& context,
-                      SystemOutput<T>* output) const {
+void Adder<T>::EvalOutput(const Context<T>& context,
+                          SystemOutput<T>* output) const {
   // Check that the single output port has the correct length, then zero it.
   // Checks on the output structure are assertions, not exceptions,
   // since failures would reflect a bug in the Adder implementation, not

--- a/drake/systems/framework/primitives/adder.h
+++ b/drake/systems/framework/primitives/adder.h
@@ -30,8 +30,8 @@ class Adder : public SystemInterface<T> {
 
   /// Sums the input ports into the output port. If the input ports are not
   /// of number num_inputs_ or size length_, std::runtime_error will be thrown.
-  void Output(const Context<T>& context,
-              SystemOutput<T>* output) const override;
+  void EvalOutput(const Context<T>& context,
+                  SystemOutput<T>* output) const override;
 
   /// TODO(david-german-tri): Make this configurable in the constructor.
   std::string get_name() const override { return "adder"; }

--- a/drake/systems/framework/primitives/adder.h
+++ b/drake/systems/framework/primitives/adder.h
@@ -19,7 +19,6 @@ class Adder : public SystemInterface<T> {
   /// @param num_inputs is the number of input ports to be added.
   /// @param length is the size of each input port.
   Adder(int num_inputs, int length);
-  ~Adder() override {}
 
   /// Allocates the number of input ports specified in the constructor.
   /// Allocates no state.

--- a/drake/systems/framework/primitives/test/adder_test.cc
+++ b/drake/systems/framework/primitives/test/adder_test.cc
@@ -44,7 +44,7 @@ TEST_F(AdderTest, AddTwoVectors) {
   context_->SetInputPort(0, MakeInput(std::move(input0_)));
   context_->SetInputPort(1, MakeInput(std::move(input1_)));
 
-  adder_->Output(*context_, output_.get());
+  adder_->EvalOutput(*context_, output_.get());
 
   ASSERT_EQ(1u, output_->ports.size());
   const BasicVector<double>* output_port =
@@ -61,7 +61,7 @@ TEST_F(AdderTest, AddTwoVectors) {
 TEST_F(AdderTest, WrongNumberOfInputPorts) {
   // Hook up just one input.
   context_->SetInputPort(0, MakeInput(std::move(input0_)));
-  EXPECT_THROW(adder_->Output(*context_, output_.get()), std::out_of_range);
+  EXPECT_THROW(adder_->EvalOutput(*context_, output_.get()), std::out_of_range);
 }
 
 // Tests that std::out_of_range is thrown when input ports of the wrong size
@@ -76,7 +76,7 @@ TEST_F(AdderTest, WrongSizeOfInputPorts) {
   context_->SetInputPort(0, MakeInput(std::move(input0_)));
   context_->SetInputPort(1, MakeInput(std::move(short_input)));
 
-  EXPECT_THROW(adder_->Output(*context_, output_.get()), std::out_of_range);
+  EXPECT_THROW(adder_->EvalOutput(*context_, output_.get()), std::out_of_range);
 }
 
 // Tests that Adder allocates no state variables in the context_.

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -44,7 +44,7 @@ class ContinuousState {
   ///
   /// @param num_q The number of position variables.
   /// @param num_v The number of velocity variables.
-  /// @param num_z  The number of other variables.
+  /// @param num_z The number of other variables.
   ContinuousState(std::unique_ptr<StateVector<T>> state, int num_q,
                   int num_v, int num_z) {
     state_ = std::move(state);

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -110,23 +110,23 @@ class ContinuousState {
   }
 
  private:
-  /// The entire state vector.  May or may not own the underlying data.
+  // The entire state vector.  May or may not own the underlying data.
   std::unique_ptr<StateVector<T>> state_;
 
-  /// Generalized coordinates representing System configuration, conventionally
-  /// denoted `q`. These are second-order state variables.
-  /// This is a subset of state_ and does not own the underlying data.
+  // Generalized coordinates representing System configuration, conventionally
+  // denoted `q`. These are second-order state variables.
+  // This is a subset of state_ and does not own the underlying data.
   std::unique_ptr<StateVector<T>> generalized_position_;
 
-  /// Generalized speeds representing System velocity. Conventionally denoted
-  /// `v`. These are first-order state variables that the System can linearly
-  /// map to time derivatives `qdot` of `q` above.
-  /// This is a subset of state_ and does not own the underlying data.
+  // Generalized speeds representing System velocity. Conventionally denoted
+  // `v`. These are first-order state variables that the System can linearly
+  // map to time derivatives `qdot` of `q` above.
+  // This is a subset of state_ and does not own the underlying data.
   std::unique_ptr<StateVector<T>> generalized_velocity_;
 
-  /// Additional continuous, first-order state variables not representing
-  /// multibody system motion.  Conventionally denoted `z`.
-  /// This is a subset of state_ and does not own the underlying data.
+  // Additional continuous, first-order state variables not representing
+  // multibody system motion.  Conventionally denoted `z`.
+  // This is a subset of state_ and does not own the underlying data.
   std::unique_ptr<StateVector<T>> misc_continuous_state_;
 };
 

--- a/drake/systems/framework/state_subvector.h
+++ b/drake/systems/framework/state_subvector.h
@@ -42,8 +42,6 @@ class StateSubvector : public StateVector<T> {
   explicit StateSubvector(StateVector<T>* vector)
       : StateSubvector(vector, 0, 0) {}
 
-  ~StateSubvector() override {}
-
   int size() const override { return num_elements_; }
 
   const T GetAtIndex(int index) const override {

--- a/drake/systems/framework/state_vector.h
+++ b/drake/systems/framework/state_vector.h
@@ -96,7 +96,6 @@ class StateVector {
       return PlusEqScaled(T(-1), rhs);
   }
 
-
  protected:
   StateVector() {}
 

--- a/drake/systems/framework/state_vector.h
+++ b/drake/systems/framework/state_vector.h
@@ -54,37 +54,48 @@ class StateVector {
   /// value and allocates only the O(N) memory that it returns.
   virtual VectorX<T> CopyToVector() const = 0;
 
-  /// Adds this vector to @p vec, which must be the same size.
+  /// Adds a scaled version of this state vector to Eigen vector @p vec, which
+  /// must be the same size.
   ///
   /// Implementations may override this default implementation with a more
-  /// efficient approach, for instance if the vector is contiguous.
+  /// efficient approach, for instance if this vector is contiguous.
   /// Implementations should ensure this operation remains O(N) in the size of
   /// the value and allocates no memory.
-  virtual void AddToVector(Eigen::Ref<VectorX<T>> vec) const {
+  virtual void ScaleAndAddToVector(const T& scale,
+                                   Eigen::Ref<VectorX<T>> vec) const {
     if (vec.rows() != size()) {
       throw std::out_of_range("Addends must be the same length.");
     }
-    for (int i = 0; i < size(); ++i) {
-      vec[i] += GetAtIndex(i);
-    }
+    for (int i = 0; i < size(); ++i)
+      vec[i] += scale * GetAtIndex(i);
   }
 
-  /// Adds the vector @p rhs to this vector. Both vectors must be the same size.
+  /// Add in scaled state vector @p rhs to this state vector. Both vectors must
+  /// be the same size.
   ///
   /// Implementations may override this default implementation with a more
-  /// efficient approach, for instance if the vector is contiguous.
+  /// efficient approach, for instance if this vector is contiguous.
   /// Implementations should ensure this operation remains O(N) in the size of
   /// the value and allocates no memory.
-  virtual StateVector& operator+=(const StateVector<T>& rhs) {
-    if (size() != rhs.size()) {
+  virtual StateVector& PlusEqScaled(const T& scale, const StateVector<T>& rhs) {
+    if (rhs.size() != size()) {
       throw std::out_of_range("Addends must be the same length.");
     }
-    DRAKE_ASSERT(size() == rhs.size());
-    for (int i = 0; i < size(); ++i) {
-      SetAtIndex(i, GetAtIndex(i) + rhs.GetAtIndex(i));
-    }
+    for (int i = 0; i < size(); ++i)
+      SetAtIndex(i, GetAtIndex(i) + scale * rhs.GetAtIndex(i));
     return *this;
   }
+
+  /// Add in state vector @p rhs to this state vector.
+  StateVector& operator+=(const StateVector<T>& rhs) {
+    return PlusEqScaled(T(1), rhs);
+  }
+
+  /// Subtract in state vector @p rhs to this state vector.
+  StateVector& operator-=(const StateVector<T>& rhs) {
+      return PlusEqScaled(T(-1), rhs);
+  }
+
 
  protected:
   StateVector() {}

--- a/drake/systems/framework/system_interface.h
+++ b/drake/systems/framework/system_interface.h
@@ -48,20 +48,38 @@ class SystemInterface : public AbstractSystemInterface {
  public:
   ~SystemInterface() override {}
 
-  // Returns a default context, initialized with the correct
-  // numbers of concrete input ports and state variables for this System.
-  // Since input port pointers are not owned by the Context, they should
-  // simply be initialized to nullptr.
+  /// Returns a default context, initialized with the correct
+  /// numbers of concrete input ports and state variables for this System.
+  /// Since input port pointers are not owned by the Context, they should
+  /// simply be initialized to nullptr.
   virtual std::unique_ptr<Context<T>> CreateDefaultContext() const = 0;
 
-  // Returns a default output, initialized with the correct number of
-  // concrete output ports for this System.
+  /// Returns a default output, initialized with the correct number of
+  /// concrete output ports for this System.
   virtual std::unique_ptr<SystemOutput<T>> AllocateOutput() const = 0;
 
-  // Computes the output for the given context, possibly updating values
-  // in the cache.
-  virtual void Output(const Context<T>& context,
-                      SystemOutput<T>* output) const = 0;
+  /// Computes the output for the given context, possibly updating values
+  /// in the cache.
+  virtual void EvalOutput(const Context<T>& context,
+                          SystemOutput<T>* output) const = 0;
+
+  // TODO(sherm): these two energy methods should be present only for systems
+  // that represent some kind of physical system that can store energy in its
+  // configuration or motion. Consider introducing a PhysicalSystemInterface
+  // class so that a simple System (for example, an adder) doesn't have these
+  // methods. For now I'm breaking the no-code-in-interface rule to provide
+  // zero defaults so that these don't have to be implemented in non-physical
+  // systems.
+
+  /// Return the potential energy currently stored in the configuration provided
+  /// in the given Context. Non-physical Systems will return 0.
+  virtual T EvalPotentialEnergy(const Context<T>& context) const {
+    return T(0);
+  }
+
+  /// Return the kinetic energy currently present in the motion provided in the
+  /// given Context. Non-physical Systems will return 0.
+  virtual T EvalKineticEnergy(const Context<T>& context) const { return T(0); }
 
  protected:
   SystemInterface() {}

--- a/drake/systems/framework/system_interface.h
+++ b/drake/systems/framework/system_interface.h
@@ -46,8 +46,6 @@ class DRAKESYSTEMFRAMEWORK_EXPORT AbstractSystemInterface {
 template <typename T>
 class SystemInterface : public AbstractSystemInterface {
  public:
-  ~SystemInterface() override {}
-
   /// Returns a default context, initialized with the correct
   /// numbers of concrete input ports and state variables for this System.
   /// Since input port pointers are not owned by the Context, they should

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -79,16 +79,16 @@ class OutputPort {
   OutputPort(OutputPort&& other) = delete;
   OutputPort& operator=(OutputPort&& other) = delete;
 
-  /// The port data, if the port is vector-valued.
-  /// TODO(david-german-tri): Add abstract-valued ports.
+  // The port data, if the port is vector-valued.
+  // TODO(sherm1): Add abstract-valued ports.
   std::unique_ptr<VectorInterface<T>> vector_data_;
 
-  /// The list of consumers that should be notified when the value on this
-  /// output port changes.
+  // The list of consumers that should be notified when the value on this
+  // output port changes.
   std::set<OutputPortListenerInterface*> dependents_;
 
-  /// The rate at which this port produces output, in seconds.
-  /// If zero, the port is continuous.
+  // The rate at which this port produces output, in seconds.
+  // If zero, the port is continuous.
   double sample_time_sec_{};
 
   int64_t version_ = 0;

--- a/drake/systems/framework/test/basic_state_vector_test.cc
+++ b/drake/systems/framework/test/basic_state_vector_test.cc
@@ -30,7 +30,7 @@ TEST_F(BasicStateVectorTest, Access) {
   EXPECT_THROW(state_vector_->GetAtIndex(2), std::out_of_range);
 }
 
-TEST_F(BasicStateVectorTest, Copy) {
+TEST_F(BasicStateVectorTest, CopyToVector) {
   Eigen::Vector2i expected;
   expected << 1, 2;
   EXPECT_EQ(expected, state_vector_->CopyToVector());
@@ -87,20 +87,14 @@ TEST_F(BasicStateVectorTest, SizeBasedConstructor) {
 }
 
 // Tests that the BasicStateVector can be added to an Eigen vector.
-TEST_F(BasicStateVectorTest, AddToVector) {
+TEST_F(BasicStateVectorTest, ScaleAndAddToVector) {
   Eigen::Vector2i target;
   target << 3, 4;
-  state_vector_->AddToVector(target);
+  state_vector_->ScaleAndAddToVector(1, target);
 
   Eigen::Vector2i expected;
   expected << 4, 6;
   EXPECT_EQ(expected, target);
-}
-
-TEST_F(BasicStateVectorTest, AddToVectorInvalidSize) {
-  Eigen::Vector3i target;
-  target << 3, 5, 7;
-  EXPECT_THROW(state_vector_->AddToVector(target), std::out_of_range);
 }
 
 // Tests that another StateVector can be added to the BasicStateVector.
@@ -112,6 +106,17 @@ TEST_F(BasicStateVectorTest, PlusEq) {
 
   EXPECT_EQ(6, state_vector_->GetAtIndex(0));
   EXPECT_EQ(8, state_vector_->GetAtIndex(1));
+}
+
+// TODO(david-german-tri): Once GMock is available in the Drake build, add a
+// test case demonstrating that the += operator on BasicStateVector calls
+// ScaleAndAddToVector on the addend.
+
+TEST_F(BasicStateVectorTest, AddToVectorInvalidSize) {
+  Eigen::Vector3i target;
+  target << 3, 5, 7;
+  EXPECT_THROW(state_vector_->ScaleAndAddToVector(1, target),
+               std::out_of_range);
 }
 
 TEST_F(BasicStateVectorTest, PlusEqInvalidSize) {

--- a/drake/systems/framework/test/context_test.cc
+++ b/drake/systems/framework/test/context_test.cc
@@ -30,8 +30,7 @@ constexpr double kTime = 12.0;
 class ContextTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    // Time
-    context_.get_mutable_time()->time_sec = kTime;
+    context_.set_time(kTime);
 
     // Input
     context_.SetNumInputPorts(kNumInputPorts);
@@ -99,7 +98,7 @@ TEST_F(ContextTest, Clone) {
   std::unique_ptr<Context<double>> clone = context_.Clone();
 
   // Verify that the time was copied.
-  EXPECT_EQ(kTime, clone->get_time().time_sec);
+  EXPECT_EQ(kTime, clone->get_time());
 
   // Verify that the cloned input ports contain the same data,
   // but are different pointers.

--- a/drake/systems/framework/test/continuous_system_test.cc
+++ b/drake/systems/framework/test/continuous_system_test.cc
@@ -26,10 +26,8 @@ class TestContinuousSystem : public ContinuousSystem<double> {
 
   std::string get_name() const override { return "TestContinuousSystem"; }
 
-  std::unique_ptr<StateVector<double>> AllocateStateDerivatives()
-      const override {
-    return nullptr;
-  }
+  std::unique_ptr<ContinuousState<double>> AllocateTimeDerivatives()
+      const override { return nullptr; }
 
   std::unique_ptr<Context<double>> CreateDefaultContext() const override {
     return nullptr;
@@ -39,11 +37,12 @@ class TestContinuousSystem : public ContinuousSystem<double> {
     return nullptr;
   }
 
-  void Output(const Context<double>& context,
-              SystemOutput<double>* output) const override {}
+  void EvalOutput(const Context<double>& context,
+                  SystemOutput<double>* output) const override {}
 
-  void Dynamics(const Context<double>& context,
-                StateVector<double>* derivatives) const override {}
+  void EvalTimeDerivatives(
+      const Context<double>& context,
+      ContinuousState<double>* derivatives) const override {}
 };
 
 class ContinuousSystemTest : public ::testing::Test {

--- a/drake/systems/framework/test/state_subvector_test.cc
+++ b/drake/systems/framework/test/state_subvector_test.cc
@@ -88,29 +88,33 @@ TEST_F(StateSubvectorTest, PlusEq) {
   EXPECT_EQ(4, state_vector_->GetAtIndex(3));
 }
 
-TEST_F(StateSubvectorTest, PlusEqInvalidSize) {
-  BasicStateVector<int> addend(1);
-  StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
-  EXPECT_THROW(subvec += addend, std::out_of_range);
-}
-
 // Tests that a StateSubvector can be added to an Eigen vector.
-TEST_F(StateSubvectorTest, AddToVector) {
+TEST_F(StateSubvectorTest, ScaleAndAddToVector) {
   VectorX<int> target(2);
   target << 100, 1000;
 
   StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
-  subvec.AddToVector(target);
+  subvec.ScaleAndAddToVector(1, target);
 
   Eigen::Vector2i expected;
   expected << 102, 1003;
   EXPECT_EQ(expected, target);
 }
 
+// TODO(david-german-tri): Once GMock is available in the Drake build, add a
+// test case demonstrating that the += operator on StateSubvector calls
+// ScaleAndAddToVector on the addend.
+
+TEST_F(StateSubvectorTest, PlusEqInvalidSize) {
+  BasicStateVector<int> addend(1);
+  StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
+  EXPECT_THROW(subvec += addend, std::out_of_range);
+}
+
 TEST_F(StateSubvectorTest, AddToVectorInvalidSize) {
   VectorX<int> target(3);
   StateSubvector<int> subvec(state_vector_.get(), 1, kSubVectorLength);
-  EXPECT_THROW(subvec.AddToVector(target), std::out_of_range);
+  EXPECT_THROW(subvec.ScaleAndAddToVector(1, target), std::out_of_range);
 }
 
 }  // namespace

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -57,8 +57,8 @@ class DRAKESYSTEMFRAMEWORK_EXPORT AbstractValue {
   }
 
  private:
-  /// Casts this class to a Value<T>*. In Debug builds, throws
-  /// std::bad_cast if the cast fails.
+  // Casts this class to a Value<T>*. In Debug builds, throws
+  // std::bad_cast if the cast fails.
   template <typename T>
   Value<T>* DownCastMutableOrMaybeThrow() {
     // We cast away const in this private non-const method so that we can reuse
@@ -67,9 +67,9 @@ class DRAKESYSTEMFRAMEWORK_EXPORT AbstractValue {
     return const_cast<Value<T>*>(DownCastOrMaybeThrow<T>());
   }
 
-  /// Casts this class to a const Value<T>*. In Debug builds, throws
-  /// std::bad_cast if the cast fails.
-  /// TODO(david-german-tri): Use static_cast in Release builds for speed.
+  // Casts this class to a const Value<T>*. In Debug builds, throws
+  // std::bad_cast if the cast fails.
+  // TODO(david-german-tri): Use static_cast in Release builds for speed.
   template <typename T>
   const Value<T>* DownCastOrMaybeThrow() const {
     const Value<T>* value = dynamic_cast<const Value<T>*>(this);
@@ -94,8 +94,6 @@ class Value : public AbstractValue {
   Value& operator=(const Value<T>& other) = default;
   Value(Value<T>&& other) = delete;
   Value& operator=(Value<T>&& other) = delete;
-
-  ~Value() override {}
 
   std::unique_ptr<AbstractValue> Clone() const override {
     return std::make_unique<Value<T>>(*this);


### PR DESCRIPTION
(This is a squashed version of PR #2513 which died due to trashed branch during the submodule cutover.)

Changes here are:
- Adds integrator test cases to the spring-mass system.
- Adds energy and power methods to the API.
- Adds power method and work integral to spring-mass system.
- Adds scaling to StateVector arithmetic.
- Renames potentially-cacheable methods to start with "Eval".
- Renames Output->EvalOutput, Dynamics->EvalTimeDerivatives.
- Renamed Time class TimeStep and adds get_time/set_time to Context.

Unfortunately reviewer comments did not survive the PR switch. I have addressed most of them. Please take a fresh look.

Feature review should be @david-german-tri but he is on vacation and I need this to go in fast so I can add the non-vector (AbstractValue) Outputs this week. So @RussTedrake you are feature reviewer. David, when you get back please feel free to undo anything you don't like here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2725)
<!-- Reviewable:end -->
