### PR TITLE
Added a System 2.0 Vector Interface for LCM messages and a Concrete Instantiation of It.

### DIFF
--- a/drake/examples/spring_mass/lcm_vector_interface.h
+++ b/drake/examples/spring_mass/lcm_vector_interface.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "drake/systems/framework/vector_interface.h"
+
+// TODO(liang.fok) Move this class into a directory that is dedicated to
+// LCM-based systems after it is mature and proven useful.
+
+namespace drake {
+namespace systems {
+
+/// This abstract class is a specialization of `drake::systems::VectorInterface`
+/// that adds support for conversion to and from LCM messages.
+template <typename ScalarType, typename LCMMessageType>
+class LCMVectorInterface :
+    public VectorInterface<ScalarType> {
+ public:
+  virtual ~LCMVectorInterface() {}
+
+  /// Converts a LCM message into a `LCMVectorInterface`.
+  ///
+  /// @param[in] message The LCM message containing the state to save within
+  /// this `LCMVectorInterface`.
+  virtual void Encode(const LCMMessageType& message) = 0;
+
+  /// Converts this `LCMVectorInterface` into a LCM message.
+  ///
+  /// @param[out] message A pointer to the LCM message in which to save this
+  /// this `LCMVectorInterface`'s state.
+  virtual void Decode(LCMMessageType* message) = 0;
+
+ protected:
+  LCMVectorInterface() {}
+};
+
+}  // namespace systems
+}  // namesapce drake

--- a/drake/examples/spring_mass/spring_mass_lcm_vector.h
+++ b/drake/examples/spring_mass/spring_mass_lcm_vector.h
@@ -22,16 +22,16 @@ class SpringMassLCMVector :
   /// be -1.
   SpringMassLCMVector() : timestamp_(-1), values_(VectorX<T>::Constant(
             kStateSize, std::numeric_limits<
-                      typename Eigen::NumTraits<T>::Real>::quiet_NaN())){}
+                      typename Eigen::NumTraits<T>::Real>::quiet_NaN())) {}
 
   /// The destructor.
   virtual ~SpringMassLCMVector() {}
 
-  virtual int size() const override {
+  int size() const override {
     return kStateSize;
   }
 
-  virtual void set_value(const Eigen::Ref<const VectorX<T>>& value) override {
+  void set_value(const Eigen::Ref<const VectorX<T>>& value) override {
     if (value.size() != 2)
       throw std::runtime_error("SpringMassLCMVector: set_value: ERROR: "
         "Attempted to set value using a vector of length not equal to two.");
@@ -42,26 +42,25 @@ class SpringMassLCMVector :
     return timestamp_;
   }
 
-  virtual Eigen::VectorBlock<const VectorX<T>> get_value() const override {
+  Eigen::VectorBlock<const VectorX<T>> get_value() const override {
     return values_.head(values_.rows());
   }
 
-  virtual Eigen::VectorBlock<VectorX<T>> get_mutable_value() override {
+  Eigen::VectorBlock<VectorX<T>> get_mutable_value() override {
     return values_.head(values_.rows());
   }
 
-  virtual std::unique_ptr<drake::systems::VectorInterface<T>> Clone() const
-      override {
+  std::unique_ptr<drake::systems::VectorInterface<T>> Clone() const override {
     return std::unique_ptr<SpringMassLCMVector<T>>(DoClone());
   }
 
-  virtual void Encode(const lcmt_spring_mass_state_t& message) override {
+  void Encode(const lcmt_spring_mass_state_t& message) override {
     timestamp_ = message.timestamp;
     values_[0] = message.position;
     values_[1] = message.velocity;
   }
 
-  virtual void Decode(lcmt_spring_mass_state_t* message) override {
+  void Decode(lcmt_spring_mass_state_t* message) override {
     message->timestamp = timestamp_;
     message->position = values_[0];
     message->velocity = values_[1];

--- a/drake/examples/spring_mass/spring_mass_lcm_vector.h
+++ b/drake/examples/spring_mass/spring_mass_lcm_vector.h
@@ -1,0 +1,84 @@
+#pragma once
+
+// TODO(liang.fok) Automatically generate this file.
+
+#include "drake/examples/spring_mass/lcm_vector_interface.h"
+#include "lcmtypes/drake/lcmt_spring_mass_state_t.hpp"
+
+namespace drake {
+namespace examples {
+namespace spring_mass {
+
+/// A concrete implementation of `drake::systems::LCMVectorInterface` that
+/// specializies it to the spring-mass LCM state message.
+template <typename T>
+class SpringMassLCMVector :
+    public drake::systems::LCMVectorInterface<T, lcmt_spring_mass_state_t> {
+ public:
+  /// The state space is size 2: [position, velocity].
+  static const int kStateSize = 2;
+
+  /// The constructor initilizes the state vector to be NaN and the timestamp to
+  /// be -1.
+  SpringMassLCMVector() : timestamp_(-1), values_(VectorX<T>::Constant(
+            kStateSize, std::numeric_limits<
+                      typename Eigen::NumTraits<T>::Real>::quiet_NaN())){}
+
+  /// The destructor.
+  virtual ~SpringMassLCMVector() {}
+
+  virtual int size() const override {
+    return kStateSize;
+  }
+
+  virtual void set_value(const Eigen::Ref<const VectorX<T>>& value) override {
+    if (value.size() != 2)
+      throw std::runtime_error("SpringMassLCMVector: set_value: ERROR: "
+        "Attempted to set value using a vector of length not equal to two.");
+    values_ = value;
+  }
+
+  virtual int64_t get_timestamp() {
+    return timestamp_;
+  }
+
+  virtual Eigen::VectorBlock<const VectorX<T>> get_value() const override {
+    return values_.head(values_.rows());
+  }
+
+  virtual Eigen::VectorBlock<VectorX<T>> get_mutable_value() override {
+    return values_.head(values_.rows());
+  }
+
+  virtual std::unique_ptr<drake::systems::VectorInterface<T>> Clone() const
+      override {
+    return std::unique_ptr<SpringMassLCMVector<T>>(DoClone());
+  }
+
+  virtual void Encode(const lcmt_spring_mass_state_t& message) override {
+    timestamp_ = message.timestamp;
+    values_[0] = message.position;
+    values_[1] = message.velocity;
+  }
+
+  virtual void Decode(lcmt_spring_mass_state_t* message) override {
+    message->timestamp = timestamp_;
+    message->position = values_[0];
+    message->velocity = values_[1];
+  }
+
+ private:
+  // Returns a new SpringMassLCMVector containing a copy of the entire state.
+  virtual SpringMassLCMVector<T>* DoClone() const {
+    SpringMassLCMVector* clone = new SpringMassLCMVector();
+    clone->values_ = values_;
+    return clone;
+  }
+
+  int64_t timestamp_{};
+  VectorX<T> values_;
+};
+
+}  // namespace spring_mass
+}  // namespace examples
+}  // namesapce drake

--- a/drake/examples/spring_mass/spring_mass_lcm_vector.h
+++ b/drake/examples/spring_mass/spring_mass_lcm_vector.h
@@ -38,7 +38,9 @@ class SpringMassLCMVector :
     values_ = value;
   }
 
-  virtual int64_t get_timestamp() {
+  // Returns the timestamp that was stored in the lcmt_spring_mass_state_t
+  // message.
+  virtual int64_t get_timestamp() const {
     return timestamp_;
   }
 

--- a/drake/examples/spring_mass/test/CMakeLists.txt
+++ b/drake/examples/spring_mass/test/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_executable(spring_mass_system_test spring_mass_system_test.cc)
 target_link_libraries(spring_mass_system_test drakeSpringMassSystem drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
 add_test(NAME spring_mass_system_test COMMAND spring_mass_system_test)
+
+add_executable(spring_mass_lcm_vector_test spring_mass_lcm_vector_test.cc)
+target_link_libraries(spring_mass_lcm_vector_test drakeSpringMassSystem drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
+add_test(NAME spring_mass_lcm_vector_test COMMAND spring_mass_lcm_vector_test)

--- a/drake/examples/spring_mass/test/spring_mass_lcm_vector_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_lcm_vector_test.cc
@@ -1,0 +1,174 @@
+#include "gtest/gtest.h"
+
+// TODO(liang.fok) Automatically generate this file.
+
+#include "drake/examples/spring_mass/spring_mass_lcm_vector.h"
+#include "drake/util/eigen_matrix_compare.h"
+
+namespace drake {
+namespace examples {
+namespace spring_mass {
+namespace {
+
+using drake::examples::spring_mass::SpringMassLCMVector;
+
+// Tests the default values in
+// drake::examples::spring_mass::SpringMassLCMVector.
+GTEST_TEST(SpringMassLCMVectorTest, InstantiateTest) {
+  // Instantiates a SpringMassLCMVector<double> and verifies that it was
+  // successfully stored in a unique_ptr. The variable is called "dut" to
+  // indicate it is the "device under test".
+  std::unique_ptr<SpringMassLCMVector<double>> dut(
+    new SpringMassLCMVector<double>());
+  EXPECT_NE(dut.get(), nullptr);
+
+  // Verifies that the default timestamp inside the SpringMassLCMVector<double>
+  // object is -1.
+  EXPECT_EQ(dut->get_timestamp(), -1);
+
+  // Obtains the size of the state vector.
+  const int state_vector_size = SpringMassLCMVector<double>::kStateSize;
+
+  // Checks method SpringMassLCMVector<double>::size().
+  EXPECT_EQ(dut->size(), state_vector_size);
+
+  // Verifies that the length of the value vector is equal to
+  // SpringMassLCMVector<double>::kStateSize and that its default values are
+  // NaN.
+  Eigen::VectorBlock<const VectorX<double>> value = dut->get_value();
+  EXPECT_EQ(value.size(), state_vector_size);
+  for (int ii = 0; ii < state_vector_size; ++ii) {
+    EXPECT_TRUE(isnan(value[ii]));
+  }
+}
+
+// Tests the following methods in
+// drake::examples::spring_mass::SpringMassLCMVector:
+//
+//  - get_mutable_value()
+//  - get_value()
+//  - set_value()
+GTEST_TEST(SpringMassLCMVectorTest, SetAndGetValueTest) {
+  // Instantiates a SpringMassLCMVector<double> and verifies that it was
+  // successfully stored in a unique_ptr. The variable is called "dut" to
+  // indicate it is the "device under test".
+  std::unique_ptr<SpringMassLCMVector<double>> dut(
+    new SpringMassLCMVector<double>());
+  EXPECT_NE(dut.get(), nullptr);
+
+  // Tests calling set_value() with a vector that's too long.
+  {
+    VectorX<double> vector;
+    vector.resize(dut->size() + 1);
+    EXPECT_THROW(dut->set_value(vector), std::runtime_error);
+  }
+
+  // Tests calling set_value() with a vector that's too short.
+  {
+    VectorX<double> vector;
+    vector.resize(dut->size() - 1);
+    EXPECT_THROW(dut->set_value(vector), std::runtime_error);
+  }
+
+  // Tests calling set_value() with a correct-length vector. Verifies that
+  // the values obtained from get_value() and get_mutable_value() are correct.
+  VectorX<double> vector;
+  vector.resize(dut->size());
+  vector[0] = 3.14;
+  vector[1] = 2.718;
+  EXPECT_NO_THROW(dut->set_value(vector));
+
+  {
+    Eigen::VectorBlock<const VectorX<double>> const_value = dut->get_value();
+    EXPECT_TRUE(drake::util::CompareMatrices(const_value, vector, 1e-10,
+      drake::util::MatrixCompareType::relative));
+
+    Eigen::VectorBlock<VectorX<double>> mutable_value = dut->get_mutable_value();
+    EXPECT_TRUE(drake::util::CompareMatrices(mutable_value, vector, 1e-10,
+      drake::util::MatrixCompareType::relative));
+  }
+
+  // Changes the values in `vector`. Then ensures the values returned by
+  // `get_value()` and `get_mutable_value()` do not match `vector` anymore.
+  vector[0] = 10;
+  vector[1] = 12.5;
+
+  {
+    Eigen::VectorBlock<const VectorX<double>> const_value = dut->get_value();
+    EXPECT_FALSE(drake::util::CompareMatrices(const_value, vector, 1e-10,
+      drake::util::MatrixCompareType::relative));
+
+    Eigen::VectorBlock<VectorX<double>> mutable_value = dut->get_mutable_value();
+    EXPECT_FALSE(drake::util::CompareMatrices(mutable_value, vector, 1e-10,
+      drake::util::MatrixCompareType::relative));
+  }
+}
+
+// Tests the following methods in
+// drake::examples::spring_mass::SpringMassLCMVector:
+//
+//  - Clone()
+//  - Decode()
+//  - Encode()
+GTEST_TEST(SpringMassLCMVectorTest, EncodeDecodeAndCloneTest) {
+  // Instantiates a SpringMassLCMVector<double> and verifies that it was
+  // successfully stored in a unique_ptr. The variable is called "dut" to
+  // indicate it is the "device under test".
+  std::unique_ptr<SpringMassLCMVector<double>> dut(
+    new SpringMassLCMVector<double>());
+  EXPECT_NE(dut.get(), nullptr);
+
+  // Initializes a lcmt_spring_mass_state_t object, then calls Encode() using it
+  // as a parameter.
+  lcmt_spring_mass_state_t message;
+  message.timestamp = 123456;
+  message.position = 0.57721;
+  message.velocity = 4.6692;
+
+  dut->Encode(message);
+
+  // Verifies that the output of Decode() is correct.
+  lcmt_spring_mass_state_t decoded_message;
+  dut->Decode(&decoded_message);
+  EXPECT_EQ(message.timestamp, decoded_message.timestamp);
+  EXPECT_EQ(message.position, decoded_message.position);
+  EXPECT_EQ(message.velocity, decoded_message.velocity);
+
+  // Verifies that the outputs of get_value(), get_mutable_value(), and
+  // get_timestamp() are correct.
+  VectorX<double> vector;
+  vector.resize(dut->size());
+  vector[0] = message.position;
+  vector[1] = message.velocity;
+
+  {
+    Eigen::VectorBlock<const VectorX<double>> const_value = dut->get_value();
+    EXPECT_TRUE(drake::util::CompareMatrices(const_value, vector, 1e-10,
+      drake::util::MatrixCompareType::relative));
+
+    Eigen::VectorBlock<VectorX<double>> mutable_value = dut->get_mutable_value();
+    EXPECT_TRUE(drake::util::CompareMatrices(mutable_value, vector, 1e-10,
+      drake::util::MatrixCompareType::relative));
+
+    EXPECT_EQ(dut->get_timestamp(), 123456);
+  }
+
+  // Verifies that Clone() is correct.
+  std::unique_ptr<drake::systems::VectorInterface<double>> clone = dut->Clone();
+
+  {
+    Eigen::VectorBlock<const VectorX<double>> const_value = clone->get_value();
+    EXPECT_TRUE(drake::util::CompareMatrices(const_value, vector, 1e-10,
+      drake::util::MatrixCompareType::relative));
+
+    Eigen::VectorBlock<VectorX<double>> mutable_value =
+      clone->get_mutable_value();
+    EXPECT_TRUE(drake::util::CompareMatrices(mutable_value, vector, 1e-10,
+      drake::util::MatrixCompareType::relative));
+  }
+}
+
+}  // namespace
+}  // namespace spring_mass
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/spring_mass/test/spring_mass_lcm_vector_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_lcm_vector_test.cc
@@ -83,7 +83,8 @@ GTEST_TEST(SpringMassLCMVectorTest, SetAndGetValueTest) {
     EXPECT_TRUE(drake::util::CompareMatrices(const_value, vector, 1e-10,
       drake::util::MatrixCompareType::relative));
 
-    Eigen::VectorBlock<VectorX<double>> mutable_value = dut->get_mutable_value();
+    Eigen::VectorBlock<VectorX<double>> mutable_value =
+      dut->get_mutable_value();
     EXPECT_TRUE(drake::util::CompareMatrices(mutable_value, vector, 1e-10,
       drake::util::MatrixCompareType::relative));
   }
@@ -98,7 +99,8 @@ GTEST_TEST(SpringMassLCMVectorTest, SetAndGetValueTest) {
     EXPECT_FALSE(drake::util::CompareMatrices(const_value, vector, 1e-10,
       drake::util::MatrixCompareType::relative));
 
-    Eigen::VectorBlock<VectorX<double>> mutable_value = dut->get_mutable_value();
+    Eigen::VectorBlock<VectorX<double>> mutable_value =
+      dut->get_mutable_value();
     EXPECT_FALSE(drake::util::CompareMatrices(mutable_value, vector, 1e-10,
       drake::util::MatrixCompareType::relative));
   }
@@ -146,7 +148,8 @@ GTEST_TEST(SpringMassLCMVectorTest, EncodeDecodeAndCloneTest) {
     EXPECT_TRUE(drake::util::CompareMatrices(const_value, vector, 1e-10,
       drake::util::MatrixCompareType::relative));
 
-    Eigen::VectorBlock<VectorX<double>> mutable_value = dut->get_mutable_value();
+    Eigen::VectorBlock<VectorX<double>> mutable_value =
+      dut->get_mutable_value();
     EXPECT_TRUE(drake::util::CompareMatrices(mutable_value, vector, 1e-10,
       drake::util::MatrixCompareType::relative));
 

--- a/drake/lcmtypes/CMakeLists.txt
+++ b/drake/lcmtypes/CMakeLists.txt
@@ -32,6 +32,7 @@ lcm_wrap_types(
   lcmt_simple_car_config_t.lcm
   lcmt_simple_car_state_t.lcm
   lcmt_simulation_command.lcm
+  lcmt_spring_mass_state_t.lcm
   lcmt_support_data.lcm
   lcmt_viewer_command.lcm
   lcmt_viewer_draw.lcm

--- a/drake/lcmtypes/lcmt_spring_mass_state_t.lcm
+++ b/drake/lcmtypes/lcmt_spring_mass_state_t.lcm
@@ -1,0 +1,10 @@
+// TODO(liang.fok) Automatically generate this file.
+
+package drake;
+
+struct lcmt_spring_mass_state_t
+{
+  int64_t timestamp;
+  double position;
+  double velocity;
+}


### PR DESCRIPTION
This is an incremental step towards supporting LCM Input and Output Systems based on the System 2.0 framework. For now I placed `lcm_vector_interface.h` inside the spring_mass demo's directory since this is still experimental code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2729)
<!-- Reviewable:end -->
