### PR TITLE
added hint so that lcm is found on my mac

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -270,7 +270,7 @@ else()
 endif()
 
 # set up and build lcm types
-find_package(lcm)
+find_package(lcm HINTS ${CMAKE_INSTALL_PREFIX}/lib/lcm/cmake)
 if(lcm_FOUND)
   add_subdirectory(lcmtypes)
   include_directories(${drake_BINARY_DIR} ${drake_BINARY_DIR}/lcmtypes)


### PR DESCRIPTION
PR #2582 broke my mac builds.  configuring in the drake directory resulted in
```
Warning:By not providing "Findlcm.cmake" in CMAKE_MODULE_PATH this project has asked CMake to find a package configuration file provided by "lcm", but CMake did not find one.
Could not find a package configuration file provided by "lcm" with any of the following names:
  lcmConfig.cmake   lcm-config.cmake
Add the installation prefix of "lcm" to CMAKE_PREFIX_PATH or set "lcm_DIR" to a directory containing one of the above files.  If "lcm" provides a separate development package or SDK, be sure it has been installed.
```
fwiw - I tried looking through the installation instructions in case there was an environment update that I needed, but didn't see anything.

I don't know how the build servers are finding the file, but had to add this path manually here.  I hate this as a solution, but will put it out there because it gets me up and running again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2730)
<!-- Reviewable:end -->
