### PR TITLE
Disallow ptrdiff_t, and remove it from the tree

### DIFF
--- a/drake/doc/code_style_guide.rst
+++ b/drake/doc/code_style_guide.rst
@@ -71,6 +71,15 @@ Clarifications
     would obscure the readability of our code, and (3) subtraction underflow
     below zero is obviously not at risk.
 
+* When using `Integer Types
+  <https://google.github.io/styleguide/cppguide.html#Integer>`_
+  within Drake, `ptrdiff_t` is forbidden, with the following exceptions
+  (per `#2514 <https://github.com/RobotLocomotion/drake/issues/2514>`_):
+
+  * ``ptrdiff_t`` is allowed when doing arithmetic on bare pointers (this is
+    very rare).  Do not use it as a generic "large signed integer" type, nor
+    as a generic "index into a matrix" type.
+
 .. _code-style-guide-cpp-exceptions:
 
 Exceptions
@@ -143,9 +152,9 @@ Additional Rules
   left uninitialized; if you want yours zero-initialized you can
   member-initialize it by passing an appropriate ``Zero``, for example:
   ``Eigen::Matrix3d mat_{Eigen::Matrix3d::Zero()};``.
-* After including ``<cstddef>``, assume that ``size_t`` and ``ptrdiff_t``
-  are defined in the global namespace. Do not preface them with ``std::``
-  and do not write ``using std::size_t`` or ``using std::ptrdiff_t`` in
+* After including ``<cstddef>``, assume that ``size_t``
+  is defined in the global namespace. Do not preface it with ``std::``
+  and do not write ``using std::size_t`` in
   your code. There is a hypothetical possibility that this won't work on
   some compiler someday but we deem the risk acceptable in trade for
   allowing this common, clutter-reducing practice. For discussion, see

--- a/drake/systems/n_ary_state.h
+++ b/drake/systems/n_ary_state.h
@@ -38,7 +38,7 @@ class NAryState {
 
   NAryState() : unit_size_(unit_size()), count_(UnitCountFromRows(0)) {}
 
-  explicit NAryState(std::ptrdiff_t count)
+  explicit NAryState(int count)
       : unit_size_(unit_size()),
         // Ensure correct internal count_ (i.e., -1 if UnitVector's size
         // is zero).
@@ -51,7 +51,7 @@ class NAryState {
   ///
   /// If UnitVector is a null vector (zero rows), then the count is
   /// indeterminate and the return value is always < 0.
-  std::ptrdiff_t count() const { return count_; }
+  int count() const { return count_; }
 
   /// Appends the @param unit to the end of the list of component
   /// @param UnitVectors.
@@ -74,13 +74,13 @@ class NAryState {
   ///
   /// @throws std::out_of_range if UnitVector is a non-NullVector type
   /// and @p pos exceeds the range [0, count()].
-  UnitVector get(std::ptrdiff_t pos) const {
+  UnitVector get(int pos) const {
     if (unit_size_ > 0) {
       if ((pos < 0) || (pos >= count_)) {
         throw std::out_of_range("Position pos exceeds range [0, count()].");
       }
     }
-    const std::size_t row0 = pos * unit_size_;
+    const int row0 = pos * unit_size_;
     return UnitVector(combined_vector_.block(row0, 0,
                                              unit_size_, 1));
   }
@@ -89,13 +89,13 @@ class NAryState {
   ///
   /// @throws std::out_of_range if UnitVector is a non-NullVector type
   /// and @p pos exceeds the range [0, count()].
-  void set(std::ptrdiff_t pos, const UnitVector& unit) {
+  void set(int pos, const UnitVector& unit) {
     if (unit_size_ > 0) {
       if ((pos < 0) || (pos >= count_)) {
         throw std::out_of_range("Position pos exceeds range [0, count()].");
       }
     }
-    const std::size_t row0 = pos * unit_size_;
+    const int row0 = pos * unit_size_;
     combined_vector_.block(row0, 0, unit_size_, 1) = toEigen(unit);
   }
 
@@ -117,7 +117,7 @@ class NAryState {
   }
 
   // Required by Drake::Vector concept.
-  std::size_t size() const { return combined_vector_.rows(); }
+  int size() const { return combined_vector_.rows(); }
 
   // Required by Drake::Vector concept.
   friend EigenType toEigen(const NAryState<UnitVector>& vec) {
@@ -126,8 +126,7 @@ class NAryState {
 
   /// Calculates the size (Eigen row count) of @p UnitVector, which is
   /// presumed to be fixed for all instances of UnitVector.
-  static
-  std::size_t unit_size() { return UnitVector().size(); }
+  static int unit_size() { return UnitVector().size(); }
 
   /// Determines how many @param UnitVector units will be decoded from
   /// an Eigen column matrix with @param rows rows.  @param rows must
@@ -138,9 +137,8 @@ class NAryState {
   ///
   /// @throws std::domain_error if UnitVector is not a null vector and
   /// rows is not a multiple of UnitVector::size().
-  static
-  std::ptrdiff_t UnitCountFromRows(std::size_t rows) {
-    const std::size_t us { unit_size() };
+  static int UnitCountFromRows(int rows) {
+    const int us { unit_size() };
     if (us > 0) {
       if ((rows % us) != 0) {
         throw std::domain_error("Row count not a multiple of non-null unit.");
@@ -156,9 +154,8 @@ class NAryState {
   /// To complement UnitCountFromRows(), if @param count is negative,
   /// the return value is zero.  However, @throws std::domain_error if
   /// count is negative and UnitVector is not a null vector.
-  static
-  std::size_t RowsFromUnitCount(std::ptrdiff_t count) {
-    const std::size_t us { unit_size() };
+  static int RowsFromUnitCount(int count) {
+    const int us { unit_size() };
     if (count >= 0) {
       return count * us;
     }
@@ -169,9 +166,9 @@ class NAryState {
   }
 
  private:
-  std::size_t unit_size_;
+  int unit_size_;
   // count_ < 0 indicates "not counted", i.e., UnitVector is a null vector.
-  std::ptrdiff_t count_;
+  int count_;
   EigenType combined_vector_;
 };
 

--- a/drake/systems/n_ary_system.h
+++ b/drake/systems/n_ary_system.h
@@ -42,16 +42,14 @@ class NArySystem {
   StateVector<ScalarType> dynamics(const ScalarType& time,
                                    const StateVector<ScalarType>& state,
                                    const InputVector<ScalarType>& input) const {
-    if ((state.count() >= 0) && (
-            state.count() != static_cast<ptrdiff_t>(systems_.size()))) {
+    if ((state.count() >= 0) && (state.count() != systems_size())) {
       throw std::invalid_argument("State count differs from systems count.");
     }
-    if ((input.count() >= 0) && (
-            input.count() != static_cast<ptrdiff_t>(systems_.size()))) {
+    if ((input.count() >= 0) && (input.count() != systems_size())) {
       throw std::invalid_argument("Input count differs from systems count.");
     }
-    StateVector<ScalarType> xdot(systems_.size());
-    for (std::size_t i = 0; i < systems_.size(); ++i) {
+    StateVector<ScalarType> xdot(systems_size());
+    for (int i = 0; i < systems_size(); ++i) {
       xdot.set(i, systems_[i]->dynamics(time, state.get(i), input.get(i)));
     }
     return xdot;
@@ -62,16 +60,14 @@ class NArySystem {
   OutputVector<ScalarType> output(const ScalarType& time,
                                   const StateVector<ScalarType>& state,
                                   const InputVector<ScalarType>& input) const {
-    if ((state.count() >= 0) && (
-            state.count() != static_cast<ptrdiff_t>(systems_.size()))) {
+    if ((state.count() >= 0) && (state.count() != systems_size())) {
       throw std::invalid_argument("State count differs from systems count.");
     }
-    if ((input.count() >= 0) && (
-            input.count() != static_cast<ptrdiff_t>(systems_.size()))) {
+    if ((input.count() >= 0) && (input.count() != systems_size())) {
       throw std::invalid_argument("Input count differs from systems count.");
     }
-    OutputVector<ScalarType> y(systems_.size());
-    for (std::size_t i = 0; i < systems_.size(); ++i) {
+    OutputVector<ScalarType> y(systems_size());
+    for (int i = 0; i < systems_size(); ++i) {
       y.set(i, systems_[i]->output(time, state.get(i), input.get(i)));
     }
     return y;
@@ -95,20 +91,22 @@ class NArySystem {
 
   // Required by Drake::System concept.
   std::size_t getNumStates() const {
-    return StateVector<double>::RowsFromUnitCount(systems_.size());
+    return StateVector<double>::RowsFromUnitCount(systems_size());
   }
 
   // Required by Drake::System concept.
   std::size_t getNumInputs() const {
-    return InputVector<double>::RowsFromUnitCount(systems_.size());
+    return InputVector<double>::RowsFromUnitCount(systems_size());
   }
 
   // Required by Drake::System concept.
   std::size_t getNumOutputs() const {
-    return OutputVector<double>::RowsFromUnitCount(systems_.size());
+    return OutputVector<double>::RowsFromUnitCount(systems_size());
   }
 
  private:
+  int systems_size() const { return systems_.size(); }
+
   std::vector<std::shared_ptr<UnitSystem> > systems_;
 };
 

--- a/drake/systems/test/n_ary_state_test.cc
+++ b/drake/systems/test/n_ary_state_test.cc
@@ -45,8 +45,8 @@ using VectorQD = VectorQ<double>;
 GTEST_TEST(TestNAryState, UnitCountFromRows) {
   NAryState<NullVector<double> >::UnitCountFromRows(0);
 
-  EXPECT_EQ((NAryState<VectorQD>::UnitCountFromRows(0)), 0u);
-  EXPECT_EQ((NAryState<VectorQD>::UnitCountFromRows(15)), 5u);
+  EXPECT_EQ((NAryState<VectorQD>::UnitCountFromRows(0)), 0);
+  EXPECT_EQ((NAryState<VectorQD>::UnitCountFromRows(15)), 5);
   EXPECT_THROW((NAryState<VectorQD>::UnitCountFromRows(17)),
                std::domain_error);
 
@@ -56,15 +56,15 @@ GTEST_TEST(TestNAryState, UnitCountFromRows) {
 
 
 GTEST_TEST(TestNAryState, RowsFromUnitCount) {
-  EXPECT_EQ((NAryState<VectorQD>::RowsFromUnitCount(0)),  0u);
-  EXPECT_EQ((NAryState<VectorQD>::RowsFromUnitCount(1)),  3u);
-  EXPECT_EQ((NAryState<VectorQD>::RowsFromUnitCount(5)), 15u);
+  EXPECT_EQ((NAryState<VectorQD>::RowsFromUnitCount(0)),  0);
+  EXPECT_EQ((NAryState<VectorQD>::RowsFromUnitCount(1)),  3);
+  EXPECT_EQ((NAryState<VectorQD>::RowsFromUnitCount(5)), 15);
   EXPECT_THROW((NAryState<VectorQD>::RowsFromUnitCount(-1)),
                std::domain_error);
 
-  EXPECT_EQ((NAryState<NullVector<double> >::RowsFromUnitCount(1)), 0u);
-  EXPECT_EQ((NAryState<NullVector<double> >::RowsFromUnitCount(5)), 0u);
-  EXPECT_EQ((NAryState<NullVector<double> >::RowsFromUnitCount(-1)), 0u);
+  EXPECT_EQ((NAryState<NullVector<double> >::RowsFromUnitCount(1)), 0);
+  EXPECT_EQ((NAryState<NullVector<double> >::RowsFromUnitCount(5)), 0);
+  EXPECT_EQ((NAryState<NullVector<double> >::RowsFromUnitCount(-1)), 0);
 }
 
 
@@ -74,21 +74,21 @@ GTEST_TEST(TestNAryState, DefaultConstructor) {
 
   // Test default-constructed instance.
   NAryState<VectorQD> dut;
-  EXPECT_EQ(dut.count(), 0u);
-  EXPECT_EQ(dut.size(), 0u);
+  EXPECT_EQ(dut.count(), 0);
+  EXPECT_EQ(dut.size(), 0);
   EXPECT_THROW(dut.get(0), std::out_of_range);
   EXPECT_THROW(dut.set(0, VectorQD()), std::out_of_range);
   EXPECT_EQ(toEigen(dut), (Eigen::Matrix<double, 0, 1>()));
 
   dut.Append(vq0);
-  EXPECT_EQ(dut.count(), 1u);
-  EXPECT_EQ(dut.size(), 3u);
+  EXPECT_EQ(dut.count(), 1);
+  EXPECT_EQ(dut.size(), 3);
   EXPECT_EQ(dut.get(0).v, vq0.v);
   EXPECT_EQ(toEigen(dut), vq0.v);
 
   dut.Append(vq1);
-  EXPECT_EQ(dut.count(), 2u);
-  EXPECT_EQ(dut.size(), 6u);
+  EXPECT_EQ(dut.count(), 2);
+  EXPECT_EQ(dut.size(), 6);
   EXPECT_EQ(dut.get(0).v, vq0.v);
   EXPECT_EQ(dut.get(1).v, vq1.v);
   EXPECT_EQ(toEigen(dut),
@@ -112,8 +112,8 @@ GTEST_TEST(TestNAryState, PreAllocated) {
 
   // Test construction with pre-allocated size.
   NAryState<VectorQD> dut(2);
-  EXPECT_EQ(dut.count(), 2u);
-  EXPECT_EQ(dut.size(), 6u);
+  EXPECT_EQ(dut.count(), 2);
+  EXPECT_EQ(dut.size(), 6);
 
   dut.set(0, vq0);
   dut.set(1, vq1);
@@ -135,8 +135,8 @@ GTEST_TEST(TestNAryState, FromEigen) {
   NAryState<VectorQD> dut((
       Eigen::VectorXd(6) << vq0.v, vq1.v).finished());
 
-  EXPECT_EQ(dut.count(), 2u);
-  EXPECT_EQ(dut.size(), 6u);
+  EXPECT_EQ(dut.count(), 2);
+  EXPECT_EQ(dut.size(), 6);
   EXPECT_EQ(dut.get(0).v, vq0.v);
   EXPECT_EQ(dut.get(1).v, vq1.v);
   EXPECT_EQ(toEigen(dut),
@@ -147,14 +147,14 @@ GTEST_TEST(TestNAryState, FromEigen) {
 
   // Test assignment from Eigen type.
   dut = vq0.v;
-  EXPECT_EQ(dut.count(), 1u);
-  EXPECT_EQ(dut.size(), 3u);
+  EXPECT_EQ(dut.count(), 1);
+  EXPECT_EQ(dut.size(), 3);
   EXPECT_EQ(dut.get(0).v, vq0.v);
   EXPECT_EQ(toEigen(dut), vq0.v);
 
   dut = Eigen::VectorXd(0);
-  EXPECT_EQ(dut.count(), 0u);
-  EXPECT_EQ(dut.size(), 0u);
+  EXPECT_EQ(dut.count(), 0);
+  EXPECT_EQ(dut.size(), 0);
   EXPECT_THROW(dut.get(0), std::out_of_range);
   EXPECT_EQ(toEigen(dut), Eigen::VectorXd(0));
 }
@@ -166,7 +166,7 @@ GTEST_TEST(TestNAryState, NullUnitVectors) {
   // Test default-constructed instance.
   NAryState<NullVector<double> > dut;
   EXPECT_EQ(dut.count(), -1);
-  EXPECT_EQ(dut.size(), 0u);
+  EXPECT_EQ(dut.size(), 0);
   EXPECT_EQ(dut.get(0), nv);
   EXPECT_EQ(dut.get(1000), nv);
   dut.set(0, nv);
@@ -176,7 +176,7 @@ GTEST_TEST(TestNAryState, NullUnitVectors) {
   // Appending nothing to nothing should not change nothing.
   dut.Append(nv);
   EXPECT_EQ(dut.count(), -1);
-  EXPECT_EQ(dut.size(), 0u);
+  EXPECT_EQ(dut.size(), 0);
   EXPECT_EQ(dut.get(0), nv);
   EXPECT_EQ(dut.get(1000), nv);
   dut.set(0, nv);
@@ -186,7 +186,7 @@ GTEST_TEST(TestNAryState, NullUnitVectors) {
   // Test assignment from Eigen type.
   dut = Eigen::Matrix<double, 0, 1>();
   EXPECT_EQ(dut.count(), -1);
-  EXPECT_EQ(dut.size(), 0u);
+  EXPECT_EQ(dut.size(), 0);
   EXPECT_EQ(dut.get(0), nv);
   EXPECT_EQ(dut.get(1000), nv);
   dut.set(0, nv);
@@ -196,7 +196,7 @@ GTEST_TEST(TestNAryState, NullUnitVectors) {
   // Test construction from Eigen type.
   NAryState<NullVector<double> > dut2(Eigen::VectorXd(0));
   EXPECT_EQ(dut2.count(), -1);
-  EXPECT_EQ(dut2.size(), 0u);
+  EXPECT_EQ(dut2.size(), 0);
   EXPECT_EQ(dut2.get(0), nv);
   EXPECT_EQ(dut2.get(1000), nv);
   dut2.set(0, nv);
@@ -206,7 +206,7 @@ GTEST_TEST(TestNAryState, NullUnitVectors) {
   // Test construction with pre-allocated size.
   NAryState<NullVector<double> > dut3(7);
   EXPECT_EQ(dut3.count(), -1);
-  EXPECT_EQ(dut3.size(), 0u);
+  EXPECT_EQ(dut3.size(), 0);
   EXPECT_EQ(dut3.get(0), nv);
   EXPECT_EQ(dut3.get(1000), nv);
   dut3.set(0, nv);
@@ -215,7 +215,7 @@ GTEST_TEST(TestNAryState, NullUnitVectors) {
 
   NAryState<NullVector<double> > dut4(-1);
   EXPECT_EQ(dut4.count(), -1);
-  EXPECT_EQ(dut4.size(), 0u);
+  EXPECT_EQ(dut4.size(), 0);
   EXPECT_EQ(dut4.get(0), nv);
   EXPECT_EQ(dut4.get(1000), nv);
   dut4.set(0, nv);

--- a/drake/util/Polynomial.cpp
+++ b/drake/util/Polynomial.cpp
@@ -558,7 +558,7 @@ string Polynomial<CoefficientType>::idToVariableName(const VarType id) {
 template <typename CoefficientType>
 void Polynomial<CoefficientType>::makeMonomialsUnique(void) {
   VarType unique_var = 0;  // also update the univariate flag
-  for (ptrdiff_t i = monomials.size() - 1; i >= 0; i--) {
+  for (int i = monomials.size() - 1; i >= 0; i--) {
     if (monomials[i].coefficient == 0) {
       monomials.erase(monomials.begin() + i);
       continue;
@@ -574,7 +574,7 @@ void Polynomial<CoefficientType>::makeMonomialsUnique(void) {
         }
       }
     }
-    for (ptrdiff_t j = 0; j < (i - 1); j++) {
+    for (int j = 0; j < (i - 1); j++) {
       Monomial& mj = monomials[j];
       if (mi.hasSameExponents(mj)) {
         // it's a match, so delete monomial i

--- a/drake/util/convexHull.cpp
+++ b/drake/util/convexHull.cpp
@@ -23,8 +23,8 @@ coord2_t cross(const Point &O, const Point &A, const Point &B) {
 // Returns a list of points on the convex hull in counter-clockwise order.
 // Note: the last point in the returned list is the same as the first one.
 vector<Point> convexHull(vector<Point> P) {
-  ptrdiff_t n = P.size();
-  ptrdiff_t k = 0;
+  int n = P.size();
+  int k = 0;
   vector<Point> H(2 * n);
 
   if (n == 2) {
@@ -39,13 +39,13 @@ vector<Point> convexHull(vector<Point> P) {
   sort(P.begin(), P.end());
 
   // Build lower hull
-  for (ptrdiff_t i = 0; i < n; ++i) {
+  for (int i = 0; i < n; ++i) {
     while (k >= 2 && cross(H[k - 2], H[k - 1], P[i]) <= 0) k--;
     H[k++] = P[i];
   }
 
   // Build upper hull
-  for (ptrdiff_t i = n - 2, t = k + 1; i >= 0; i--) {
+  for (int i = n - 2, t = k + 1; i >= 0; i--) {
     while (k >= t && cross(H[k - 2], H[k - 1], P[i]) <= 0) k--;
     H[k++] = P[i];
   }

--- a/drake/util/test/testPolynomial.cpp
+++ b/drake/util/test/testPolynomial.cpp
@@ -158,15 +158,15 @@ void testPolynomialMatrix() {
   auto sum = A + C;
 
   uniform_real_distribution<double> uniform;
-  for (std::ptrdiff_t row = 0; row < A.rows(); ++row) {
-    for (std::ptrdiff_t col = 0; col < A.cols(); ++col) {
+  for (int row = 0; row < A.rows(); ++row) {
+    for (int col = 0; col < A.cols(); ++col) {
       double t = uniform(generator);
       EXPECT_NEAR(sum(row, col).evaluateUnivariate(t),
                   A(row, col).evaluateUnivariate(t) +
                   C(row, col).evaluateUnivariate(t), 1e-8);
 
       double expected_product = 0.0;
-      for (std::ptrdiff_t i = 0; i < A.cols(); ++i) {
+      for (int i = 0; i < A.cols(); ++i) {
         expected_product += A(row, i).evaluateUnivariate(t) *
                             B(i, col).evaluateUnivariate(t);
       }


### PR DESCRIPTION
Per #2514, update `code_style_guide.rst` to limit `ptrdiff_t`, and remove all uses of it from our source tree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2746)
<!-- Reviewable:end -->
