### PR TITLE
Fix installed header for URDF

### DIFF
--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -39,7 +39,7 @@ drake_install_headers(
   RigidBodyIK.h
   RigidBodySystem.h
   RigidBodyTree.h
-  rigid_body_tree_urdf.h
+  parser_urdf.h
   xmlUtil.h)
 
 pods_install_pkg_config_file(drake-rbm


### PR DESCRIPTION
b388938c02e (#2707) changed the name of the URDF parser header, but failed to update the list of installed headers, causing CMake configure to choke due to reference to a file that does not exist. Change the installed headers list to reflect the new header set.

This should fix the complete CI breakage that exists currently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2748)
<!-- Reviewable:end -->
