### PR TITLE
cmake: Simplify implementation of build-always externals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,19 +47,6 @@ function(drake_forceupdate proj)
   endif()
 endfunction()
 
-function(drake_forcebuild proj)
-  if(CMAKE_CONFIGURATION_TYPES)
-    set(build_stamp_file "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${CMAKE_CFG_INTDIR}/${proj}-build")
-  else()
-    set(build_stamp_file "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-build")
-  endif()
-  ExternalProject_Add_Step(${proj} forcebuild
-    COMMAND ${CMAKE_COMMAND} -E remove ${build_stamp_file}
-    COMMENT "Forcing build step for '${proj}'"
-    DEPENDEES build
-    ALWAYS 1)
-endfunction()
-
 # Require Java at the super-build level since libbot cannot configure without finding Java
 find_package(Java 1.6 REQUIRED)
 include(UseJava)
@@ -372,6 +359,7 @@ foreach(proj ${EXTERNAL_PROJECTS})
         DOWNLOAD_COMMAND ${${proj}_DOWNLOAD_COMMAND}
         DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}
         UPDATE_COMMAND ${${proj}_UPDATE_COMMAND}
+        BUILD_ALWAYS 1
         INDEPENDENT_STEP_TARGETS update
         DEPENDS ${deps}
         ${COMMON_CMAKE_ARGS}
@@ -379,7 +367,6 @@ foreach(proj ${EXTERNAL_PROJECTS})
         ${${proj}_ADDITIONAL_CMAKE_CONFIGURE_ARGS}
         ${${proj}_ADDITIONAL_BUILD_ARGS})
       drake_forceupdate(${proj})
-      drake_forcebuild(${proj})
     else() # not a CMake POD
       if(NOT ${proj}_BINARY_DIR)
         # In-source build for non-CMake projects.
@@ -400,6 +387,12 @@ foreach(proj ${EXTERNAL_PROJECTS})
         endif()
       endif()
 
+      if(${proj}_BUILD_COMMAND)
+        set(${proj}_BUILD_ALWAYS 1)
+      else()
+        set(${proj}_BUILD_ALWAYS 0)
+      endif()
+
       ExternalProject_Add(${proj}
         SOURCE_DIR ${${proj}_SOURCE_DIR}
         BINARY_DIR ${${proj}_BINARY_DIR}
@@ -409,13 +402,11 @@ foreach(proj ${EXTERNAL_PROJECTS})
         INDEPENDENT_STEP_TARGETS update
         CONFIGURE_COMMAND ""
         BUILD_COMMAND "${${proj}_BUILD_COMMAND}"
+        BUILD_ALWAYS "${${proj}_BUILD_ALWAYS}"
         INSTALL_COMMAND ""
         DEPENDS ${deps}
         ${${proj}_ADDITIONAL_BUILD_ARGS})
       drake_forceupdate(${proj})
-      if(${proj}_BUILD_COMMAND)
-        drake_forcebuild(${proj})
-      endif()
       # message(STATUS "${proj}_BUILD_COMMAND: ${${proj}_BUILD_COMMAND}")
     endif()
   else()
@@ -434,12 +425,12 @@ foreach(proj ${EXTERNAL_PROJECTS})
       DOWNLOAD_COMMAND ""
       UPDATE_COMMAND ""
       BINARY_DIR ${drake_BINARY_DIR}
+      BUILD_ALWAYS 1
       DEPENDS ${deps}
       ${COMMON_CMAKE_ARGS}
       ${PODS_VERBOSE_MAKEFILE}
       ${${proj}_ADDITIONAL_CMAKE_CONFIGURE_ARGS}
       ${${proj}_ADDITIONAL_BUILD_ARGS})
-    drake_forcebuild(${proj})
   endif()
 
 endforeach()


### PR DESCRIPTION
Use the ExternalProject `BUILD_ALWAYS` option, available since CMake 3.1,
instead of a custom implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2749)
<!-- Reviewable:end -->
