### PR TITLE
Cleanup of header install for plants/CMakeLists.txt

### DIFF
--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library_with_exports(LIB_NAME drakeRBM SOURCE_FILES
 target_link_libraries(drakeRBM drakeCollision drakeJoints drakeUtil drakeXMLUtil)
 pods_install_libraries(drakeRBM)
 drake_install_headers(
-  BotVisualizer.h
   ConstraintWrappers.h
   ForceTorqueMeasurement.h
   KinematicPath.h
@@ -181,6 +180,7 @@ if(lcm_FOUND)
   add_executable(rigidBodyLCMNode rigidBodyLCMNode.cpp)
   target_link_libraries(rigidBodyLCMNode drakeRBSystem drakeLCMSystem threads)
   pods_install_executables(rigidBodyLCMNode)
+  drake_install_headers(BotVisualizer.h)
 endif()
 
 add_subdirectory(test)

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 add_library_with_exports(LIB_NAME drakeXMLUtil SOURCE_FILES xmlUtil.cpp)
 target_link_libraries(drakeXMLUtil drakeCommon tinyxml2 spruce)
 pods_install_libraries(drakeXMLUtil)
+drake_install_headers(xmlUtil.h)
 pods_install_pkg_config_file(drake-xml-util
   LIBS -ldrakeXMLUtil -ldrakeCommmon -ltinyxml2 -lspruce
   REQUIRES
@@ -28,28 +29,19 @@ drake_install_headers(
   BotVisualizer.h
   ConstraintWrappers.h
   ForceTorqueMeasurement.h
-  IKoptions.h
-  inverseKinBackend.h
   KinematicPath.h
   KinematicsCache.h
   material_map.h
   pose_map.h
   RigidBodyFrame.h
   RigidBody.h
-  RigidBodyIK.h
-  RigidBodySystem.h
   RigidBodyTree.h
-  parser_urdf.h
-  xmlUtil.h)
+  parser_urdf.h)
 
 pods_install_pkg_config_file(drake-rbm
   LIBS -ldrakeRBM -ldrakeCollision -ldrakeJoints -ldrakeUtil -ldrakeXMLUtil
   REQUIRES
   VERSION 0.0.1)
-
-drake_install_headers(
-  BotVisualizer.h
-  parser_urdf.h)
 
 pods_find_pkg_config(gurobi)
 pods_find_pkg_config(snopt_c)
@@ -148,7 +140,7 @@ if(drakeIK_SRC_FILES)
   target_link_libraries(drakeIK drakeRBM drakeOptimization drakeRigidBodyConstraint drakeIKoptions)
   pods_install_libraries(drakeIK)
   pods_install_libraries(drakeIKoptions)
-  drake_install_headers(RigidBodyIK.h IKoptions.h)
+  drake_install_headers(RigidBodyIK.h IKoptions.h inverseKinBackend.h)
   pods_install_pkg_config_file(drake-ik
     LIBS -ldrakeIK -ldrakeRigidBodyConstraint -ldrakeIKoptions
     REQUIRES drake-rbm


### PR DESCRIPTION
 * Multiple header files were listed twice
 * Moved header file install directive to near where the corresponding
   binary was built

Addresses concerns brought up post merge for #2700 and #2707

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2750)
<!-- Reviewable:end -->
