### PR TITLE
Deprecate some drakeGeometryUtil constants in favor of drake-namespaced ones.

### DIFF
--- a/drake/common/constants.h
+++ b/drake/common/constants.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace drake {
+
+constexpr int kQuaternionSize = 4;
+
+constexpr int kSpaceDimension = 3;
+
+constexpr int kRpySize = 3;
+
+/// https://en.wikipedia.org/wiki/Screw_theory#Twist
+constexpr int kTwistSize = 6;
+
+}  // namespace drake

--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -7,6 +7,8 @@
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>
 
+#include "drake/common/constants.h"
+
 namespace drake {
 
 /// A column vector of size 3, templated on scalar type.
@@ -41,9 +43,6 @@ using AutoDiffUpTo73d = Eigen::AutoDiffScalar<VectorUpTo73d>;
 
 /// An autodiff variable with a dynamic number of partials.
 using AutoDiffXd = Eigen::AutoDiffScalar<Eigen::VectorXd>;
-
-/// https://en.wikipedia.org/wiki/Screw_theory#Twist
-constexpr int kTwistSize = 6;
 
 /// A column vector consisting of one twist.
 template <typename Scalar>

--- a/drake/systems/plants/KinematicsCache.h
+++ b/drake/systems/plants/KinematicsCache.h
@@ -9,12 +9,11 @@
 #include <stdexcept>
 #include <utility>
 
+#include "drake/common/constants.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/plants/RigidBody.h"
 #include "drake/systems/plants/joints/DrakeJoint.h"
-#include "drake/util/drakeGeometryUtil.h"
-#include "drake/util/drakeGradientUtil.h"
 
 template <typename Scalar>
 class KinematicsCacheElement {
@@ -23,7 +22,8 @@ class KinematicsCacheElement {
    * Configuration dependent
    */
 
-  Eigen::Transform<Scalar, SPACE_DIMENSION, Eigen::Isometry> transform_to_world;
+  Eigen::Transform<Scalar, drake::kSpaceDimension, Eigen::Isometry>
+      transform_to_world;
   Eigen::Matrix<Scalar, drake::kTwistSize, Eigen::Dynamic, 0, drake::kTwistSize,
                 DrakeJoint::MAX_NUM_VELOCITIES>
       motion_subspace_in_body;  // gradient w.r.t. q_i only

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <unordered_map>
 
+#include "drake/common/constants.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/drakeRBM_export.h"
 #include "drake/systems/plants/ForceTorqueMeasurement.h"
@@ -18,6 +19,7 @@
 #include "drake/systems/plants/joints/DrakeJoint.h"
 #include "drake/systems/plants/pose_map.h"
 #include "drake/systems/plants/shapes/DrakeShapes.h"
+#include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeUtil.h"
 
 #define BASIS_VECTOR_HALF_COUNT \
@@ -102,18 +104,18 @@ class DRAKERBM_EXPORT RigidBodyTree {
           DrakeJoint::ROLLPITCHYAW,
       std::shared_ptr<RigidBodyFrame> weld_to_frame = nullptr);
 
-  #ifndef SWIG
+#ifndef SWIG
   DRAKE_DEPRECATED("Please use drake::parsers::urdf::AddRobotFromURDF.")
-  #endif
+#endif
   void addRobotFromURDF(
       const std::string& urdf_filename,
       const DrakeJoint::FloatingBaseType floating_base_type =
           DrakeJoint::ROLLPITCHYAW,
       std::shared_ptr<RigidBodyFrame> weld_to_frame = nullptr);
 
-  #ifndef SWIG
+#ifndef SWIG
   DRAKE_DEPRECATED("Please use drake::parsers::urdf::AddRobotFromURDF.")
-  #endif
+#endif
   void addRobotFromURDF(
       const std::string& urdf_filename,
       std::map<std::string, std::string>& package_map,
@@ -121,9 +123,9 @@ class DRAKERBM_EXPORT RigidBodyTree {
           DrakeJoint::ROLLPITCHYAW,
       std::shared_ptr<RigidBodyFrame> weld_to_frame = nullptr);
 
-  #ifndef SWIG
+#ifndef SWIG
   DRAKE_DEPRECATED("Please use drake::parsers::sdf::AddRobotFromSDF.")
-  #endif
+#endif
   void addRobotFromSDF(const std::string& sdf_filename,
                        const DrakeJoint::FloatingBaseType floating_base_type =
                            DrakeJoint::QUATERNION,
@@ -210,7 +212,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   double getMass(const std::set<int>& robotnum = default_robot_num_set) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, SPACE_DIMENSION, 1> centerOfMass(
+  Eigen::Matrix<Scalar, drake::kSpaceDimension, 1> centerOfMass(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set) const;
 
@@ -237,13 +239,14 @@ class DRAKERBM_EXPORT RigidBodyTree {
       const std::set<int>& robotnum = default_robot_num_set) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, SPACE_DIMENSION, Eigen::Dynamic> centerOfMassJacobian(
-      KinematicsCache<Scalar>& cache,
-      const std::set<int>& robotnum = default_robot_num_set,
-      bool in_terms_of_qdot = false) const;
+  Eigen::Matrix<Scalar, drake::kSpaceDimension, Eigen::Dynamic>
+  centerOfMassJacobian(KinematicsCache<Scalar>& cache,
+                       const std::set<int>& robotnum = default_robot_num_set,
+                       bool in_terms_of_qdot = false) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, SPACE_DIMENSION, 1> centerOfMassJacobianDotTimesV(
+  Eigen::Matrix<Scalar, drake::kSpaceDimension, 1>
+  centerOfMassJacobianDotTimesV(
       KinematicsCache<Scalar>& cache,
       const std::set<int>& robotnum = default_robot_num_set) const;
 
@@ -386,14 +389,18 @@ class DRAKERBM_EXPORT RigidBodyTree {
       bool in_terms_of_qdot) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, QUAT_SIZE, Eigen::Dynamic> relativeQuaternionJacobian(
-      const KinematicsCache<Scalar>& cache, int from_body_or_frame_ind,
-      int to_body_or_frame_ind, bool in_terms_of_qdot) const;
+  Eigen::Matrix<Scalar, drake::kQuaternionSize, Eigen::Dynamic>
+  relativeQuaternionJacobian(const KinematicsCache<Scalar>& cache,
+                             int from_body_or_frame_ind,
+                             int to_body_or_frame_ind,
+                             bool in_terms_of_qdot) const;
 
   template <typename Scalar>
-  Eigen::Matrix<Scalar, RPY_SIZE, Eigen::Dynamic> relativeRollPitchYawJacobian(
-      const KinematicsCache<Scalar>& cache, int from_body_or_frame_ind,
-      int to_body_or_frame_ind, bool in_terms_of_qdot) const;
+  Eigen::Matrix<Scalar, drake::kRpySize, Eigen::Dynamic>
+  relativeRollPitchYawJacobian(const KinematicsCache<Scalar>& cache,
+                               int from_body_or_frame_ind,
+                               int to_body_or_frame_ind,
+                               bool in_terms_of_qdot) const;
 
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>
@@ -444,9 +451,9 @@ class DRAKERBM_EXPORT RigidBodyTree {
       int new_body_or_frame_ind) const;
 
   template <typename Scalar>
-  Eigen::Transform<Scalar, SPACE_DIMENSION, Eigen::Isometry> relativeTransform(
-      const KinematicsCache<Scalar>& cache, int base_or_frame_ind,
-      int body_or_frame_ind) const;
+  Eigen::Transform<Scalar, drake::kSpaceDimension, Eigen::Isometry>
+  relativeTransform(const KinematicsCache<Scalar>& cache, int base_or_frame_ind,
+                    int body_or_frame_ind) const;
 
   /** computeContactJacobians
    * @brief Computes the jacobian for many points in the format currently used

--- a/drake/systems/plants/joints/QuaternionFloatingJoint.h
+++ b/drake/systems/plants/joints/QuaternionFloatingJoint.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/plants/joints/DrakeJointImpl.h"
 #include "drake/util/drakeGeometryUtil.h"
-#include "drake/util/drakeGradientUtil.h"
 
 class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
     : public DrakeJointImpl<QuaternionFloatingJoint> {
@@ -72,11 +72,13 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
 
     qdot_to_v.resize(getNumVelocities(), getNumPositions());
     typedef typename DerivedQ::Scalar Scalar;
-    auto quat = q.template middleRows<QUAT_SIZE>(SPACE_DIMENSION);
+    auto quat =
+        q.template middleRows<drake::kQuaternionSize>(drake::kSpaceDimension);
     auto R = quat2rotmat(quat);
 
     Eigen::Matrix<Scalar, 4, 1> quattilde;
-    typename drake::math::Gradient<Eigen::Matrix<Scalar, 4, 1>, QUAT_SIZE,
+    typename drake::math::Gradient<Eigen::Matrix<Scalar, 4, 1>,
+                                   drake::kQuaternionSize,
                                    1>::type dquattildedquat;
     normalizeVec(quat, quattilde, &dquattildedquat);
     auto RTransposeM = (R.transpose() * quatdot2angularvelMatrix(quat)).eval();
@@ -97,13 +99,15 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
     typedef typename DerivedQ::Scalar Scalar;
     v_to_qdot.resize(getNumPositions(), getNumVelocities());
 
-    auto quat = q.template middleRows<QUAT_SIZE>(SPACE_DIMENSION);
+    auto quat =
+        q.template middleRows<drake::kQuaternionSize>(drake::kSpaceDimension);
     auto R = quat2rotmat(quat);
 
-    Eigen::Matrix<Scalar, QUAT_SIZE, SPACE_DIMENSION> M;
+    Eigen::Matrix<Scalar, drake::kQuaternionSize, drake::kSpaceDimension> M;
     if (dv_to_qdot) {
       auto dR = dquat2rotmat(quat);
-      typename drake::math::Gradient<decltype(M), QUAT_SIZE, 1>::type dM;
+      typename drake::math::Gradient<decltype(M), drake::kQuaternionSize,
+                                     1>::type dM;
       angularvel2quatdotMatrix(quat, M, &dM);
 
       dv_to_qdot->setZero(v_to_qdot.size(), getNumPositions());
@@ -115,8 +119,9 @@ class DRAKEJOINTS_EXPORT QuaternionFloatingJoint
                               v_to_qdot.rows(), 3);
     } else {
       angularvel2quatdotMatrix(
-          quat, M, (typename drake::math::Gradient<decltype(M), QUAT_SIZE,
-                                                   1>::type*)nullptr);
+          quat, M,
+          (typename drake::math::Gradient<decltype(M), drake::kQuaternionSize,
+                                          1>::type*)nullptr);
     }
 
     v_to_qdot.template block<3, 3>(0, 0).setZero();

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.cpp
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.cpp
@@ -1,7 +1,12 @@
-#include "RollPitchYawFloatingJoint.h"
+#include "drake/systems/plants/joints/RollPitchYawFloatingJoint.h"
+
 #include <random>
 
-using namespace Eigen;
+#include <Eigen/Dense>
+
+using Eigen::Map;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
 
 std::string RollPitchYawFloatingJoint::getPositionName(int index) const {
   switch (index) {
@@ -23,7 +28,7 @@ std::string RollPitchYawFloatingJoint::getPositionName(int index) const {
 }
 
 VectorXd RollPitchYawFloatingJoint::zeroConfiguration() const {
-  return Eigen::VectorXd::Zero(getNumPositions());
+  return VectorXd::Zero(getNumPositions());
 }
 
 VectorXd RollPitchYawFloatingJoint::randomConfiguration(
@@ -32,7 +37,7 @@ VectorXd RollPitchYawFloatingJoint::randomConfiguration(
   std::normal_distribution<double> normal;
 
   Map<Vector3d> pos(&q[0]);
-  for (int i = 0; i < SPACE_DIMENSION; i++) {
+  for (int i = 0; i < drake::kSpaceDimension; i++) {
     pos(i) = normal(generator);
   }
 

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "DrakeJointImpl.h"
+#include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
 #include "drake/util/drakeGeometryUtil.h"
-#include "drake/util/drakeGradientUtil.h"
 
 class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
     : public DrakeJointImpl<RollPitchYawFloatingJoint> {
@@ -24,8 +24,9 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
   jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
     Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry> ret;
-    auto pos = q.template middleRows<SPACE_DIMENSION>(0);
-    auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
+    auto pos = q.template middleRows<drake::kSpaceDimension>(0);
+    auto rpy =
+        q.template middleRows<drake::kRpySize>(drake::kSpaceDimension);
     ret.linear() = rpy2rotmat(rpy);
     ret.translation() = pos;
     ret.makeAffine();
@@ -40,8 +41,9 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
           dmotion_subspace = nullptr) const {
     typedef typename DerivedQ::Scalar Scalar;
     motion_subspace.resize(drake::kTwistSize, getNumVelocities());
-    auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
-    Eigen::Matrix<Scalar, SPACE_DIMENSION, RPY_SIZE> E;
+    auto rpy =
+        q.template middleRows<drake::kRpySize>(drake::kSpaceDimension);
+    Eigen::Matrix<Scalar, drake::kSpaceDimension, drake::kRpySize> E;
     rpydot2angularvelMatrix(rpy, E);
     Eigen::Matrix<Scalar, 3, 3> R = rpy2rotmat(rpy);
     motion_subspace.template block<3, 3>(0, 0).setZero();
@@ -101,17 +103,19 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
           dmotion_subspace_dot_times_vdv = nullptr) const {
     typedef typename DerivedQ::Scalar Scalar;
     motion_subspace_dot_times_v.resize(drake::kTwistSize, 1);
-    auto rpy = q.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
+    auto rpy =
+        q.template middleRows<drake::kRpySize>(drake::kSpaceDimension);
     Scalar roll = rpy(0);
     Scalar pitch = rpy(1);
     Scalar yaw = rpy(2);
 
-    auto pd = v.template middleRows<SPACE_DIMENSION>(0);
+    auto pd = v.template middleRows<drake::kSpaceDimension>(0);
     Scalar xd = pd(0);
     Scalar yd = pd(1);
     Scalar zd = pd(2);
 
-    auto rpyd = v.template middleRows<RPY_SIZE>(SPACE_DIMENSION);
+    auto rpyd =
+        v.template middleRows<drake::kRpySize>(drake::kSpaceDimension);
     Scalar rolld = rpyd(0);
     Scalar pitchd = rpyd(1);
     Scalar yawd = rpyd(2);

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -9,20 +9,25 @@
 #include <cmath>
 #include <random>
 
+#include "drake/common/constants.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/drakeGeometryUtil_export.h"
 #include "drake/math/gradient.h"
 #include "drake/math/quaternion.h"
 #include "drake/util/drakeGradientUtil.h"
 
-const int QUAT_SIZE = 4;
-const int EXPMAP_SIZE = 3;
 const int HOMOGENEOUS_TRANSFORM_SIZE = 16;
-const int AXIS_ANGLE_SIZE = 4;
-const int SPACE_DIMENSION = 3;
-const int RotmatSize = SPACE_DIMENSION * SPACE_DIMENSION;
+
+DRAKE_DEPRECATED("Use drake::kQuaternionSize instead.")
+const int QUAT_SIZE = 4;
+DRAKE_DEPRECATED("Use drake::kRpySize instead.")
 const int RPY_SIZE = 3;
+DRAKE_DEPRECATED("Use drake::kSpaceDimension instead.")
+const int SPACE_DIMENSION = 3;
+
+const int RotmatSize = drake::kSpaceDimension * drake::kSpaceDimension;
 
 DRAKEGEOMETRYUTIL_EXPORT double angleDiff(double phi1, double phi2);
 
@@ -349,15 +354,15 @@ Eigen::Matrix<typename Derived::Scalar, 3, 3> rpy2rotmat(
  */
 template <typename Derived>
 typename drake::math::Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
-                               QUAT_SIZE>::type
+                               drake::kQuaternionSize>::type
 dquat2rotmat(const Eigen::MatrixBase<Derived>& q) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
-                                           QUAT_SIZE);
+                                           drake::kQuaternionSize);
 
   typename drake::math::Gradient<Eigen::Matrix<typename Derived::Scalar, 3, 3>,
-                                 QUAT_SIZE>::type ret;
+                                 drake::kQuaternionSize>::type ret;
   typename Eigen::MatrixBase<Derived>::PlainObject qtilde;
-  typename drake::math::Gradient<Derived, QUAT_SIZE>::type dqtilde;
+  typename drake::math::Gradient<Derived, drake::kQuaternionSize>::type dqtilde;
   normalizeVec(q, qtilde, &dqtilde);
 
   typedef typename Derived::Scalar Scalar;
@@ -375,22 +380,23 @@ dquat2rotmat(const Eigen::MatrixBase<Derived>& q) {
 
 template <typename DerivedR, typename DerivedDR>
 typename drake::math::Gradient<
-    Eigen::Matrix<typename DerivedR::Scalar, RPY_SIZE, 1>,
+    Eigen::Matrix<typename DerivedR::Scalar, drake::kRpySize, 1>,
     DerivedDR::ColsAtCompileTime>::type
 drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
             const Eigen::MatrixBase<DerivedDR>& dR) {
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedR>,
-                                           SPACE_DIMENSION, SPACE_DIMENSION);
+                                           drake::kSpaceDimension,
+                                           drake::kSpaceDimension);
   EIGEN_STATIC_ASSERT(
       Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == RotmatSize,
       THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE);
 
   typename DerivedDR::Index nq = dR.cols();
   typedef typename DerivedR::Scalar Scalar;
-  typedef typename drake::math::Gradient<Eigen::Matrix<Scalar, RPY_SIZE, 1>,
-                                         DerivedDR::ColsAtCompileTime>::type
-      ReturnType;
-  ReturnType drpy(RPY_SIZE, nq);
+  typedef typename drake::math::Gradient<
+      Eigen::Matrix<Scalar, drake::kRpySize, 1>,
+      DerivedDR::ColsAtCompileTime>::type ReturnType;
+  ReturnType drpy(drake::kRpySize, nq);
 
   auto dR11_dq =
       getSubMatrixGradient<DerivedDR::ColsAtCompileTime>(dR, 0, 0, R.rows());
@@ -424,20 +430,21 @@ drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
 
 template <typename DerivedR, typename DerivedDR>
 typename drake::math::Gradient<
-    Eigen::Matrix<typename DerivedR::Scalar, QUAT_SIZE, 1>,
+    Eigen::Matrix<typename DerivedR::Scalar, drake::kQuaternionSize, 1>,
     DerivedDR::ColsAtCompileTime>::type
 drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
              const Eigen::MatrixBase<DerivedDR>& dR) {
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedR>,
-                                           SPACE_DIMENSION, SPACE_DIMENSION);
+                                           drake::kSpaceDimension,
+                                           drake::kSpaceDimension);
   EIGEN_STATIC_ASSERT(
       Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == RotmatSize,
       THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE);
 
   typedef typename DerivedR::Scalar Scalar;
-  typedef typename drake::math::Gradient<Eigen::Matrix<Scalar, QUAT_SIZE, 1>,
-                                         DerivedDR::ColsAtCompileTime>::type
-      ReturnType;
+  typedef typename drake::math::Gradient<
+      Eigen::Matrix<Scalar, drake::kQuaternionSize, 1>,
+      DerivedDR::ColsAtCompileTime>::type ReturnType;
   typename DerivedDR::Index nq = dR.cols();
 
   auto dR11_dq =
@@ -468,7 +475,7 @@ drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
   typename Eigen::Matrix<Scalar, 4, 1>::Index ind, max_col;
   Scalar val = B.maxCoeff(&ind, &max_col);
 
-  ReturnType dq(QUAT_SIZE, nq);
+  ReturnType dq(drake::kQuaternionSize, nq);
   using namespace std;
   switch (ind) {
     case 0: {
@@ -571,7 +578,7 @@ template <typename Derived>
 Eigen::Matrix<typename Derived::Scalar, 3, 3> vectorToSkewSymmetric(
     const Eigen::MatrixBase<Derived>& p) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
-                                           SPACE_DIMENSION);
+                                           drake::kSpaceDimension);
   Eigen::Matrix<typename Derived::Scalar, 3, 3> ret;
   ret << 0.0, -p(2), p(1), p(2), 0.0, -p(0), -p(1), p(0), 0.0;
   return ret;
@@ -597,7 +604,7 @@ void angularvel2quatdotMatrix(const Eigen::MatrixBase<DerivedQ>& q,
                               Eigen::MatrixBase<DerivedDM>* dM = nullptr) {
   // note: not normalizing to match MATLAB implementation
   using Scalar = typename DerivedQ::Scalar;
-  M.resize(QUAT_SIZE, SPACE_DIMENSION);
+  M.resize(drake::kQuaternionSize, drake::kSpaceDimension);
   M.row(0) << -q(1), -q(2), -q(3);
   M.row(1) << q(0), q(3), -q(2);
   M.row(2) << -q(3), q(0), q(1);
@@ -624,7 +631,7 @@ void angularvel2rpydotMatrix(
     typename Eigen::MatrixBase<DerivedPhi>& phi,
     typename Eigen::MatrixBase<DerivedDPhi>* dphi = nullptr,
     typename Eigen::MatrixBase<DerivedDDPhi>* ddphi = nullptr) {
-  phi.resize(RPY_SIZE, SPACE_DIMENSION);
+  phi.resize(drake::kRpySize, drake::kSpaceDimension);
 
   typedef typename DerivedRPY::Scalar Scalar;
   Scalar p = rpy(1);
@@ -640,7 +647,7 @@ void angularvel2rpydotMatrix(
   phi << cy / cp, sy / cp, Scalar(0), -sy, cy, Scalar(0), cy * tp, tp * sy,
       Scalar(1);
   if (dphi) {
-    dphi->resize(phi.size(), RPY_SIZE);
+    dphi->resize(phi.size(), drake::kRpySize);
     Scalar sp2 = sp * sp;
     Scalar cp2 = cp * cp;
     (*dphi) << Scalar(0), (cy * sp) / cp2, -sy / cp, Scalar(0), Scalar(0), -cy,
@@ -650,7 +657,7 @@ void angularvel2rpydotMatrix(
         Scalar(0), Scalar(0), Scalar(0), Scalar(0), Scalar(0), Scalar(0);
 
     if (ddphi) {
-      ddphi->resize(dphi->size(), RPY_SIZE);
+      ddphi->resize(dphi->size(), drake::kRpySize);
       Scalar cp3 = cp2 * cp;
       (*ddphi) << Scalar(0), Scalar(0), Scalar(0), Scalar(0), Scalar(0),
           Scalar(0), Scalar(0), Scalar(0), Scalar(0), Scalar(0), Scalar(0),
@@ -676,11 +683,13 @@ void angularvel2rpydotMatrix(
 template <typename DerivedRPY, typename DerivedE>
 void rpydot2angularvelMatrix(
     const Eigen::MatrixBase<DerivedRPY>& rpy, Eigen::MatrixBase<DerivedE>& E,
-    typename drake::math::Gradient<DerivedE, RPY_SIZE, 1>::type* dE = nullptr) {
+    typename drake::math::Gradient<DerivedE, drake::kRpySize, 1>::type*
+        dE = nullptr) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedRPY>,
-                                           RPY_SIZE);
+                                           drake::kRpySize);
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedE>,
-                                           SPACE_DIMENSION, RPY_SIZE);
+                                           drake::kSpaceDimension,
+                                           drake::kRpySize);
   typedef typename DerivedRPY::Scalar Scalar;
   Scalar p = rpy(1);
   Scalar y = rpy(2);
@@ -701,7 +710,7 @@ template <typename Derived>
 Eigen::Matrix<typename Derived::Scalar, 3, 4> quatdot2angularvelMatrix(
     const Eigen::MatrixBase<Derived>& q) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
-                                           QUAT_SIZE);
+                                           drake::kQuaternionSize);
   typedef typename Derived::Scalar Scalar;
   auto qtilde = q.normalized();
   Eigen::Matrix<Scalar, 3, 4> ret;
@@ -716,14 +725,14 @@ void rpydot2angularvel(
     const Eigen::MatrixBase<DerivedRPY>& rpy,
     const Eigen::MatrixBase<DerivedRPYdot>& rpydot,
     Eigen::MatrixBase<DerivedOMEGA>& omega,
-    typename drake::math::Gradient<DerivedOMEGA, RPY_SIZE, 1>::type* domega =
-        nullptr) {
+    typename drake::math::Gradient<DerivedOMEGA, drake::kRpySize,
+                                   1>::type* domega = nullptr) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedRPY>,
-                                           RPY_SIZE);
+                                           drake::kRpySize);
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedRPYdot>,
-                                           RPY_SIZE);
+                                           drake::kRpySize);
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<DerivedOMEGA>,
-                                           RPY_SIZE, 1);
+                                           drake::kRpySize, 1);
 
   Eigen::Matrix<typename DerivedOMEGA::Scalar, 3, 3> E;
   if (domega) {
@@ -1062,7 +1071,7 @@ bool isRegularInertiaMatrix(const Eigen::MatrixBase<DerivedI>& I) {
 
 template <typename DerivedI>
 drake::SquareTwistMatrix<typename DerivedI::Scalar> transformSpatialInertia(
-    const Eigen::Transform<typename DerivedI::Scalar, SPACE_DIMENSION,
+    const Eigen::Transform<typename DerivedI::Scalar, drake::kSpaceDimension,
                            Eigen::Isometry>& T_current_to_new,
     const Eigen::MatrixBase<DerivedI>& I) {
   using namespace Eigen;


### PR DESCRIPTION
We are getting close to zapping `#include "drakeGeometryUtil.h"` from the last header files where it appears.

@sherm1 for feature and platform review, since this change is trivial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2785)
<!-- Reviewable:end -->
