### PR TITLE
Add torque values to iiwa commands

### DIFF
--- a/drake/examples/kuka_iiwa_arm/kuka_ik_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_ik_demo.cc
@@ -56,6 +56,8 @@ class TrajectoryRunner {
     lcmt_iiwa_command iiwa_command;
     iiwa_command.num_joints = kNumJoints;
     iiwa_command.joint_position.resize(kNumJoints, 0.);
+    iiwa_command.num_torques = 0;
+    iiwa_command.joint_torque.resize(kNumJoints, 0.);
 
     while (cur_step < nT_) {
       int handled  = lcm_->handleTimeout(10);  // timeout is in msec -

--- a/drake/lcmtypes/lcmt_iiwa_command.lcm
+++ b/drake/lcmtypes/lcmt_iiwa_command.lcm
@@ -5,6 +5,12 @@ struct lcmt_iiwa_command
 {
   int64_t timestamp;
 
+  // Joint positions should always be sent.
   int32_t num_joints;
   double joint_position[num_joints];
+
+  // Torque values should only be sent when the arm is in torque command mode.
+  int32_t num_torques;
+  double joint_torque[num_torques];
+
 }

--- a/drake/lcmtypes/lcmt_iiwa_command.lcm
+++ b/drake/lcmtypes/lcmt_iiwa_command.lcm
@@ -9,7 +9,9 @@ struct lcmt_iiwa_command
   int32_t num_joints;
   double joint_position[num_joints];
 
-  // Torque values should only be sent when the arm is in torque command mode.
+  // Joint torques should only be sent when the arm is in torque
+  // control mode.  When only positions are being sent, num_torques
+  // should be set to zero.
   int32_t num_torques;
   double joint_torque[num_torques];
 


### PR DESCRIPTION
Add fields to the iiwa command lcm message to (optionally) specify joint torque.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2790)
<!-- Reviewable:end -->
