### PR TITLE
Add dynamic constraints for eventual use with trajectory optimization.

### DIFF
--- a/drake/examples/Pendulum/test/CMakeLists.txt
+++ b/drake/examples/Pendulum/test/CMakeLists.txt
@@ -4,6 +4,12 @@ if(lcm_FOUND)
   add_test(NAME pendulumURDFDynamicsTest COMMAND pendulumURDFDynamicsTest)
 endif()
 
+add_executable(pendulum_dynamic_constraint_test pendulum_dynamic_constraint_test.cc)
+target_link_libraries(pendulum_dynamic_constraint_test
+  drakeDynamicConstraint ${GTEST_BOTH_LIBRARIES})
+add_test(NAME pendulum_dynamic_constraint_test
+  COMMAND pendulum_dynamic_constraint_test)
+
 add_matlab_test(NAME examples/Pendulum/test/coordinateTest COMMAND coordinateTest)
 add_matlab_test(NAME examples/Pendulum/test/dynamicsGradientsTest COMMAND dynamicsGradientsTest)
 add_matlab_test(NAME examples/Pendulum/test/polyFeedback COMMAND polyFeedback)

--- a/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
@@ -1,0 +1,47 @@
+
+#include <cmath>
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/examples/Pendulum/Pendulum.h"
+#include "drake/systems/plants/constraint/dynamic_constraint.h"
+#include "drake/util/eigen_matrix_compare.h"
+
+using drake::util::MatrixCompareType;
+
+GTEST_TEST(PendulumDynamicConstraint, PendulumDynamicConstraintTest) {
+  auto p = make_shared<Pendulum>();
+
+  Eigen::VectorXd x(1 + Drake::getNumStates(*p) * 2 +
+                        Drake::getNumInputs(*p) * 2);
+  x(0) = 0.2;          // h
+  x(1) = 0;            // x0(0)
+  x(2) = 0;            // x0(1)
+  x(3) = 0.05 * M_PI;  // x1(0)
+  x(4) = 0;            // x1(1)
+  x(5) = 0.00537668;   // u0
+  x(6) = 0.018339;     // u1
+
+  drake::systems::SystemDynamicConstraint<Pendulum> dut(p);
+
+  Drake::TaylorVecXd result;
+  dut.eval(Drake::initializeAutoDiff(x), result);
+
+  // Expected values came from running the MATLAB code for
+  // PendulumPlant through the constraint function in
+  // DircolTrajectoryOptimization.m and printing the results.
+  EXPECT_NEAR(result(0).value(), 1.1027, 1e-4);
+  EXPECT_NEAR(result(1).value(), 2.2657, 1e-4);
+
+  Eigen::VectorXd d_0_expected(x.size());
+  d_0_expected << -6.26766, -7.0095, -0.74, 7.015539, -0.76, -0.1, 0.1;
+  Eigen::VectorXd d_1_expected(x.size());
+  d_1_expected << 0.1508698, 14.488559, -6.715012, 14.818155,
+      7.315012, -2.96, -3.04;
+  EXPECT_TRUE(CompareMatrices(result(0).derivatives(), d_0_expected, 1e-4,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(result(1).derivatives(), d_1_expected, 1e-4,
+                              MatrixCompareType::absolute));
+}

--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -6,6 +6,7 @@
 #include <Eigen/SparseCore>
 
 #include "drake/common/drake_assert.h"
+#include "drake/core/Vector.h"
 #include "drake/util/Polynomial.h"
 
 namespace drake {

--- a/drake/systems/plants/constraint/CMakeLists.txt
+++ b/drake/systems/plants/constraint/CMakeLists.txt
@@ -33,6 +33,7 @@ add_test(NAME testConstraintConstructor WORKING_DIRECTORY "${CMAKE_CURRENT_SOURC
 
 add_library_with_exports(LIB_NAME drakeDynamicConstraint
   SOURCE_FILES dynamic_constraint.cc)
+target_link_libraries(drakeDynamicConstraint drakeCommon)
 drake_install_headers(dynamic_constraint.h)
 pods_install_libraries(drakeDynamicConstraint)
 pods_install_pkg_config_file(drake-dynamic-constraint

--- a/drake/systems/plants/constraint/CMakeLists.txt
+++ b/drake/systems/plants/constraint/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(drakeDynamicConstraint drakeCommon)
 drake_install_headers(dynamic_constraint.h)
 pods_install_libraries(drakeDynamicConstraint)
 pods_install_pkg_config_file(drake-dynamic-constraint
+  LIBS -ldrakeDynamicConstraint
   REQUIRES
   VERSION 0.0.0)
 

--- a/drake/systems/plants/constraint/CMakeLists.txt
+++ b/drake/systems/plants/constraint/CMakeLists.txt
@@ -31,4 +31,12 @@ add_executable(testConstraintConstructor test/testConstraintConstructor.cpp)
 target_link_libraries(testConstraintConstructor drakeRBM drakeRigidBodyConstraint)
 add_test(NAME testConstraintConstructor WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test" COMMAND testConstraintConstructor)
 
+add_library_with_exports(LIB_NAME drakeDynamicConstraint
+  SOURCE_FILES dynamic_constraint.cc)
+drake_install_headers(dynamic_constraint.h)
+pods_install_libraries(drakeDynamicConstraint)
+pods_install_pkg_config_file(drake-dynamic-constraint
+  REQUIRES
+  VERSION 0.0.0)
+
 add_subdirectory(test)

--- a/drake/systems/plants/constraint/dynamic_constraint.cc
+++ b/drake/systems/plants/constraint/dynamic_constraint.cc
@@ -1,0 +1,73 @@
+
+#include "dynamic_constraint.h"
+
+#include "drake/math/autodiff.h"
+
+namespace drake {
+namespace systems {
+namespace {
+Eigen::MatrixXd ExtractDerivativesMatrix(const Drake::TaylorVecXd& vec_in) {
+  if (!vec_in.size()) {
+    return Eigen::MatrixXd();
+  }
+
+  Eigen::MatrixXd ret(vec_in.size(), vec_in(0).derivatives().size());
+  for (int i = 0; i < ret.rows(); i++) {
+    ret.row(i) = vec_in(i).derivatives();
+  }
+  return ret;
+}
+}  // namespace
+
+DynamicConstraint::DynamicConstraint(int num_states, int num_inputs)
+    : Constraint(num_states,
+                 Eigen::VectorXd::Zero(num_states),
+                 Eigen::VectorXd::Zero(num_states)),
+      num_states_(num_states),
+      num_inputs_(num_inputs) {}
+
+DynamicConstraint::~DynamicConstraint() {}
+
+void DynamicConstraint::eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                             Eigen::VectorXd& y) const {
+  Drake::TaylorVecXd y_t;
+  eval(Drake::initializeAutoDiff(x), y_t);
+  y = math::autoDiffToValueMatrix(y_t);
+}
+
+void DynamicConstraint::eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+                             Drake::TaylorVecXd& y) const {
+  DRAKE_ASSERT(x.size() == 1 + (2 * num_states_) + (2 * num_inputs_));
+
+  // Extract our input variables:
+  // h - current time (knot) value
+  // x0, x1 state vector at time steps k, k+1
+  // u0, u1 input vector at time steps k, k+1
+  const auto h = x.segment(0, 1);
+  const auto x0 = x.segment(1, num_states_);
+  const auto x1 = x.segment(1 + num_states_, num_states_);
+  const auto u0 = x.segment(1 + (2 * num_states_), num_inputs_);
+  const auto u1 = x.segment(1 + (2 * num_states_) + num_inputs_, num_inputs_);
+
+  // TODO(sam.creasey): We should cache the dynamics outputs to avoid
+  // recalculating for every knot point as we advance.
+  Drake::TaylorVecXd xdot0;
+  dynamics(x0, u0, &xdot0);
+  Eigen::MatrixXd dxdot0 = ExtractDerivativesMatrix(xdot0);
+
+  Drake::TaylorVecXd xdot1;
+  dynamics(x1, u1, &xdot1);
+  Eigen::MatrixXd dxdot1 = ExtractDerivativesMatrix(xdot1);
+
+  // Cubic interpolation to get xcol and xdotcol.
+  const Drake::TaylorVecXd xcol = 0.5 * (x0 + x1) + h(0) / 8 * (xdot0 - xdot1);
+  const Drake::TaylorVecXd xdotcol =
+      -1.5 * (x0 - x1) / h(0) - .25 * (xdot0 + xdot1);
+
+  Drake::TaylorVecXd g;
+  dynamics(xcol, 0.5 * (u0 + u1), &g);
+  y = xdotcol - g;
+}
+
+}  // systems
+}  // drake

--- a/drake/systems/plants/constraint/dynamic_constraint.cc
+++ b/drake/systems/plants/constraint/dynamic_constraint.cc
@@ -43,7 +43,7 @@ void DynamicConstraint::eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
   // h - current time (knot) value
   // x0, x1 state vector at time steps k, k+1
   // u0, u1 input vector at time steps k, k+1
-  const auto h = x.segment(0, 1);
+  const Drake::TaylorVarXd h = x(0);
   const auto x0 = x.segment(1, num_states_);
   const auto x1 = x.segment(1 + num_states_, num_states_);
   const auto u0 = x.segment(1 + (2 * num_states_), num_inputs_);
@@ -60,9 +60,9 @@ void DynamicConstraint::eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
   Eigen::MatrixXd dxdot1 = ExtractDerivativesMatrix(xdot1);
 
   // Cubic interpolation to get xcol and xdotcol.
-  const Drake::TaylorVecXd xcol = 0.5 * (x0 + x1) + h(0) / 8 * (xdot0 - xdot1);
+  const Drake::TaylorVecXd xcol = 0.5 * (x0 + x1) + h / 8 * (xdot0 - xdot1);
   const Drake::TaylorVecXd xdotcol =
-      -1.5 * (x0 - x1) / h(0) - .25 * (xdot0 + xdot1);
+      -1.5 * (x0 - x1) / h - .25 * (xdot0 + xdot1);
 
   Drake::TaylorVecXd g;
   dynamics(xcol, 0.5 * (u0 + u1), &g);

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -4,6 +4,7 @@
 
 #include <Eigen/Core>
 
+#include <drake/drakeDynamicConstraint_export.h>
 #include <drake/core/Gradient.h>
 #include <drake/solvers/Constraint.h>
 #include <drake/systems/System.h>
@@ -19,7 +20,8 @@ namespace systems {
 ///
 /// Each evaluation of the constraint considers a pair of state
 /// vectors + input vectors along with an accompanying timestep.
-class DynamicConstraint : public solvers::Constraint {
+class DRAKEDYNAMICCONSTRAINT_EXPORT DynamicConstraint :
+      public solvers::Constraint {
  public:
   /// The format of the input to the eval() function is defined by @p
   /// num_states and @p num_inputs.  The length of the vector will be

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -55,15 +55,15 @@ template <typename System>
 class SystemDynamicConstraint : public DynamicConstraint {
  public:
   // TODO(sam.creasey) Should this be a const bare ptr?
-  SystemDynamicConstraint(std::shared_ptr<System> system)
+  SystemDynamicConstraint(explicit std::shared_ptr<System> system)
       : DynamicConstraint(Drake::getNumStates(*system),
                           Drake::getNumInputs(*system)),
         system_(system) {}
 
  private:
-  virtual void dynamics(const Drake::TaylorVecXd& state,
-                        const Drake::TaylorVecXd& input,
-                        Drake::TaylorVecXd* xdot) const override {
+  void dynamics(const Drake::TaylorVecXd& state,
+                const Drake::TaylorVecXd& input,
+                Drake::TaylorVecXd* xdot) const override {
     typename System::template StateVector<Drake::TaylorVarXd> x = state;
     typename System::template InputVector<Drake::TaylorVarXd> u = input;
     Drake::TaylorVarXd t(1);

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <memory>
+
+#include <Eigen/Core>
+
+#include <drake/core/Gradient.h>
+#include <drake/solvers/Constraint.h>
+#include <drake/systems/System.h>
+
+namespace drake {
+namespace systems {
+
+/// Provides a base implementation and interface for a dynamic
+/// constraint (which is intended to be used with trajectory
+/// optimization, but is not specific to that purpose). This
+/// implementation deliberately knows nothing about the underlying
+/// system representation.
+///
+/// Each evaluation of the constraint considers a pair of state
+/// vectors + input vectors along with an accompanying timestep.
+class DynamicConstraint : public solvers::Constraint {
+ public:
+  /// The format of the input to the eval() function is defined by @p
+  /// num_states and @p num_inputs.  The length of the vector will be
+  /// (1 + num_states * 2 + num_inputs * 2), with the format:
+  ///
+  /// (length)
+  /// 1: timestep
+  /// num_states: state 0
+  /// num_states: state 1
+  /// num_inputs: input 0
+  /// num_inputs: input 1
+  DynamicConstraint(int num_states, int num_inputs);
+  virtual ~DynamicConstraint();
+
+  virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                    Eigen::VectorXd& y) const;
+  virtual void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+                    Drake::TaylorVecXd& y) const;
+
+ protected:
+  virtual void dynamics(const Drake::TaylorVecXd& state,
+                        const Drake::TaylorVecXd& input,
+                        Drake::TaylorVecXd* xdot) const = 0;
+
+ private:
+  int num_states_;
+  int num_inputs_;
+};
+
+/// Implements a dynamic constraint which uses the dynamics function
+/// of a system.
+template <typename System>
+class SystemDynamicConstraint : public DynamicConstraint {
+ public:
+  // TODO(sam.creasey) Should this be a const bare ptr?
+  SystemDynamicConstraint(std::shared_ptr<System> system)
+      : DynamicConstraint(Drake::getNumStates(*system),
+                          Drake::getNumInputs(*system)),
+        system_(system) {}
+
+ private:
+  virtual void dynamics(const Drake::TaylorVecXd& state,
+                        const Drake::TaylorVecXd& input,
+                        Drake::TaylorVecXd* xdot) const override {
+    typename System::template StateVector<Drake::TaylorVarXd> x = state;
+    typename System::template InputVector<Drake::TaylorVarXd> u = input;
+    Drake::TaylorVarXd t(1);
+    t = 0;
+    *xdot = toEigen(system_->dynamics(t, x, u));
+  }
+
+  std::shared_ptr<System> system_;
+};
+
+}  // systems
+}  // drake

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -36,10 +36,10 @@ class DRAKEDYNAMICCONSTRAINT_EXPORT DynamicConstraint :
   DynamicConstraint(int num_states, int num_inputs);
   virtual ~DynamicConstraint();
 
-  virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-                    Eigen::VectorXd& y) const;
-  virtual void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-                    Drake::TaylorVecXd& y) const;
+  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                    Eigen::VectorXd& y) const override;
+  void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+                    Drake::TaylorVecXd& y) const override;
 
  protected:
   virtual void dynamics(const Drake::TaylorVecXd& state,

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -55,7 +55,7 @@ template <typename System>
 class SystemDynamicConstraint : public DynamicConstraint {
  public:
   // TODO(sam.creasey) Should this be a const bare ptr?
-  SystemDynamicConstraint(explicit std::shared_ptr<System> system)
+  explicit SystemDynamicConstraint(std::shared_ptr<System> system)
       : DynamicConstraint(Drake::getNumStates(*system),
                           Drake::getNumInputs(*system)),
         system_(system) {}

--- a/drake/systems/plants/constraint/test/CMakeLists.txt
+++ b/drake/systems/plants/constraint/test/CMakeLists.txt
@@ -1,3 +1,8 @@
+add_executable(dynamic_constraint_test dynamic_constraint_test.cc)
+target_link_libraries(dynamic_constraint_test drakeDynamicConstraint
+  ${GTEST_BOTH_LIBRARIES})
+add_test(NAME dynamic_constraint_test COMMAND dynamic_constraint_test)
+
 add_matlab_test(NAME systems/plants/constraint/test/AllBodiesClosestDistanceConstraintTest COMMAND AllBodiesClosestDistanceConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/RelativeGazeTargetConstraintTest COMMAND RelativeGazeTargetConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/RelativePositionConstraintTest COMMAND RelativePositionConstraintTest)

--- a/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
@@ -41,6 +41,9 @@ GTEST_TEST(DynamicConstraintPendulumDynamicsTest, DynamicConstraintTest) {
   const int kNumInputs = 1;
 
 
+  // Initial state/input and expected result values came from running
+  // the MATLAB code for PendulumPlant through the constraint function
+  // in DircolTrajectoryOptimization.m and printing the results.
   Eigen::VectorXd x(1 + 2 * kNumStates + 2 * kNumInputs);
   x(0) = 0.2;          // h
   x(1) = 0;            // x0(0)
@@ -55,9 +58,6 @@ GTEST_TEST(DynamicConstraintPendulumDynamicsTest, DynamicConstraintTest) {
   Drake::TaylorVecXd result;
   dut.eval(Drake::initializeAutoDiff(x), result);
 
-  // Expected values came from running the MATLAB code for
-  // PendulumPlant through the constraint function in
-  // DircolTrajectoryOptimization.m and printing the results.
   EXPECT_NEAR(result(0).value(), 1.1027, 1e-4);
   EXPECT_NEAR(result(1).value(), 2.2657, 1e-4);
 

--- a/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
@@ -18,9 +18,9 @@ class PendulumTestDynamicConstraint : public DynamicConstraint {
       : DynamicConstraint(num_states, num_inputs) {}
 
  protected:
-  virtual void dynamics(const Drake::TaylorVecXd& state,
-                        const Drake::TaylorVecXd& input,
-                        Drake::TaylorVecXd* xdot) const override {
+  void dynamics(const Drake::TaylorVecXd& state,
+                const Drake::TaylorVecXd& input,
+                Drake::TaylorVecXd* xdot) const override {
     // From the Pendulum example:
     const double m = 1.0;
     const double b = 0.1;
@@ -37,7 +37,6 @@ class PendulumTestDynamicConstraint : public DynamicConstraint {
 };
 
 GTEST_TEST(DynamicConstraintPendulumDynamicsTest, DynamicConstraintTest) {
-
   const int kNumStates = 2;
   const int kNumInputs = 1;
 

--- a/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
@@ -1,0 +1,78 @@
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/plants/constraint/dynamic_constraint.h"
+#include "drake/util/eigen_matrix_compare.h"
+
+using drake::util::MatrixCompareType;
+
+namespace drake {
+namespace systems {
+namespace {
+
+class PendulumTestDynamicConstraint : public DynamicConstraint {
+ public:
+  PendulumTestDynamicConstraint(int num_states, int num_inputs)
+      : DynamicConstraint(num_states, num_inputs) {}
+
+ protected:
+  virtual void dynamics(const Drake::TaylorVecXd& state,
+                        const Drake::TaylorVecXd& input,
+                        Drake::TaylorVecXd* xdot) const override {
+    // From the Pendulum example:
+    const double m = 1.0;
+    const double b = 0.1;
+    const double lc = .5;
+    const double I = 0.25;
+    const double g = 9.81;
+
+    ASSERT_EQ(state.size(), 2);
+    ASSERT_EQ(input.size(), 1);
+    xdot->resize(2);
+    (*xdot)(0) = state(1);
+    (*xdot)(1) = (input(0) - m * g * lc * sin(state(0)) - b * state(1)) / I;
+  }
+};
+
+GTEST_TEST(DynamicConstraintPendulumDynamicsTest, DynamicConstraintTest) {
+
+  const int kNumStates = 2;
+  const int kNumInputs = 1;
+
+
+  Eigen::VectorXd x(1 + 2 * kNumStates + 2 * kNumInputs);
+  x(0) = 0.2;          // h
+  x(1) = 0;            // x0(0)
+  x(2) = 0;            // x0(1)
+  x(3) = 0.05 * M_PI;  // x1(0)
+  x(4) = 0;            // x1(1)
+  x(5) = 0.00537668;   // u0
+  x(6) = 0.018339;     // u1
+
+  PendulumTestDynamicConstraint dut(kNumStates, kNumInputs);
+
+  Drake::TaylorVecXd result;
+  dut.eval(Drake::initializeAutoDiff(x), result);
+
+  // Expected values came from running the MATLAB code for
+  // PendulumPlant through the constraint function in
+  // DircolTrajectoryOptimization.m and printing the results.
+  EXPECT_NEAR(result(0).value(), 1.1027, 1e-4);
+  EXPECT_NEAR(result(1).value(), 2.2657, 1e-4);
+
+  Eigen::VectorXd d_0_expected(x.size());
+  d_0_expected << -6.26766, -7.0095, -0.74, 7.015539, -0.76, -0.1, 0.1;
+  Eigen::VectorXd d_1_expected(x.size());
+  d_1_expected << 0.1508698, 14.488559, -6.715012, 14.818155,
+      7.315012, -2.96, -3.04;
+  EXPECT_TRUE(CompareMatrices(result(0).derivatives(), d_0_expected, 1e-4,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(result(1).derivatives(), d_1_expected, 1e-4,
+                              MatrixCompareType::absolute));
+}
+
+}  // anonymous namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
As mentioned in the summary, there are no users for this functionality yet, but as it could be split into it's own PR with no additional dependencies, it seemed simpler this way (also it will make the functionality available to developers working on trajectory optimization).

The choice of systems/plants/constraint was a bit arbitrary.  The related MATLAB functionality lives in solvers/, but this PR has a (minimal) dependency on systems/, and I believe later PR's will depend on systems/ more heavily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2795)
<!-- Reviewable:end -->
