### PR TITLE
Set a CMake Default build type when one is not defined.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # Set Default build type to Release if none specified
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING
-    "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel."
+    "The type of build. Options are: Debug Release RelWithDebInfo MinSizeRel."
     FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_COMPILER_VERSION VERS
   message(FATAL_ERROR "MSVC version must be at least 14")
 endif()
 
+# Set Default build type to Release if none specified
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+    "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel."
+    FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
 # PODs out-of-source build logic
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   if(POD_BUILD)

--- a/drake/doc/from_source.rst
+++ b/drake/doc/from_source.rst
@@ -120,12 +120,15 @@ To build with ``Make``, execute::
     cd drake-distro
     mkdir build
     cd build
-    cmake ../ -DCMAKE_BUILD_TYPE:STRING=Debug
+    cmake ../
     make
 
 **Do NOT use sudo.** Just ``make`` is sufficient, and will prevent problems
 later. Feel free to use ``make -j`` if your platform supports it. Note that the
-above ``cmake`` command uses build type "Debug". Alternative build modes include
+above ``cmake`` command does not specify a build type, so drake will be built
+with ``Release`` by default. If you wish to build with a different build type,
+change the cmake command to ``cmake ../ -DCMAKE_BUILD_TYPE:STRING=Debug``
+to build with build type "Debug". Alternative build modes include
 "RelWithDebInfo" and "Release". They differ in terms of the amount of debug
 symbols included in the resulting binaries and how efficiently the code
 executes.
@@ -165,7 +168,7 @@ Ninja build.
     cd drake-distro
     mkdir build
     cd build
-    cmake ../ -G Ninja -DCMAKE_BUILD_TYPE:STRING=Debug
+    cmake ../ -G Ninja
     ninja
 
 Ninja can rebuild Drake from within ``drake-distro/build/drake/`` without


### PR DESCRIPTION
  Fixes #2803 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2807)
<!-- Reviewable:end -->
