### PR TITLE
Fix some integer size mismatch warnings on Windows.

### DIFF
--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -259,7 +259,7 @@ RigidBodySystem::OutputVector<double> RigidBodySystem::output(
   DRAKE_ASSERT(getNumInputs() == u.size());
 
   y.segment(0, getNumStates()) << x;
-  Eigen::Index index = getNumStates();
+  size_t index = getNumStates();
   for (const auto& s : sensors) {
     y.segment(index, s->getNumOutputs()) = s->output(t, kinsol, u);
     index += s->getNumOutputs();

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -55,7 +55,7 @@ size_t RigidBodySystem::getNumInputs(void) const {
 }
 
 size_t RigidBodySystem::getNumOutputs() const {
-  int n = getNumStates();
+  size_t n = getNumStates();
   for (const auto& s : sensors) {
     n += s->getNumOutputs();
   }
@@ -211,7 +211,7 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
   }
 
   if (tree->getNumPositionConstraints()) {
-    int nc = tree->getNumPositionConstraints();
+    size_t nc = tree->getNumPositionConstraints();
     const double alpha = 5.0;  // 1/time constant of position constraint
                                // satisfaction (see my latex rigid body notes)
 
@@ -259,7 +259,7 @@ RigidBodySystem::OutputVector<double> RigidBodySystem::output(
   DRAKE_ASSERT(getNumInputs() == u.size());
 
   y.segment(0, getNumStates()) << x;
-  int index = getNumStates();
+  Eigen::Index index = getNumStates();
   for (const auto& s : sensors) {
     y.segment(index, s->getNumOutputs()) = s->output(t, kinsol, u);
     index += s->getNumOutputs();

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -944,7 +944,7 @@ Eigen::Matrix<Scalar, SPACE_DIMENSION, 1> RigidBodyTree::centerOfMass(
   com.setZero();
   double m = 0.0;
 
-  for (size_t i = 0; i < bodies.size(); i++) {
+  for (int i = 0; i < (int)bodies.size(); i++) {
     RigidBody& body = *bodies[i];
     if (isBodyPartOfRobot(body, robotnum)) {
       if (body.mass > 0) {
@@ -1672,7 +1672,7 @@ RigidBody* RigidBodyTree::FindBody(const std::string& body_name,
   // indicate that no frame was found.
   int match_index = -1;
 
-  for (size_t ii = 0; ii < bodies.size(); ++ii) {
+  for (int ii = 0; ii < (int)bodies.size(); ++ii) {
     // Skips the current body if model_id is not -1 and the body's robot ID is
     // not equal to the desired model ID.
     if (model_id != -1 && model_id != bodies[ii]->get_model_id()) continue;
@@ -1738,7 +1738,7 @@ shared_ptr<RigidBodyFrame> RigidBodyTree::findFrame(
   // indicate that no matching frame was found.
   int match_index = -1;
 
-  for (size_t ii = 0; ii < frames.size(); ++ii) {
+  for (int ii = 0; ii < (int)frames.size(); ++ii) {
     // Skips the current frame if model_id is not -1 and the frame's robot ID is
     // not equal to the desired robot ID.
     if (model_id != -1 && model_id != frames[ii]->get_model_id()) continue;

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -944,7 +944,7 @@ Eigen::Matrix<Scalar, SPACE_DIMENSION, 1> RigidBodyTree::centerOfMass(
   com.setZero();
   double m = 0.0;
 
-  for (int i = 0; i < (int)bodies.size(); i++) {
+  for (int i = 0; i < static_cast<int>(bodies.size()); i++) {
     RigidBody& body = *bodies[i];
     if (isBodyPartOfRobot(body, robotnum)) {
       if (body.mass > 0) {
@@ -1672,7 +1672,7 @@ RigidBody* RigidBodyTree::FindBody(const std::string& body_name,
   // indicate that no frame was found.
   int match_index = -1;
 
-  for (int ii = 0; ii < (int)bodies.size(); ++ii) {
+  for (int ii = 0; ii < static_cast<int>(bodies.size()); ++ii) {
     // Skips the current body if model_id is not -1 and the body's robot ID is
     // not equal to the desired model ID.
     if (model_id != -1 && model_id != bodies[ii]->get_model_id()) continue;
@@ -1738,7 +1738,7 @@ shared_ptr<RigidBodyFrame> RigidBodyTree::findFrame(
   // indicate that no matching frame was found.
   int match_index = -1;
 
-  for (int ii = 0; ii < (int)frames.size(); ++ii) {
+  for (int ii = 0; ii < static_cast<int>(frames.size()); ++ii) {
     // Skips the current frame if model_id is not -1 and the frame's robot ID is
     // not equal to the desired robot ID.
     if (model_id != -1 && model_id != frames[ii]->get_model_id()) continue;

--- a/drake/systems/plants/inverseKin.cpp
+++ b/drake/systems/plants/inverseKin.cpp
@@ -48,7 +48,7 @@ IKResults inverseKinSimple(
     const IKoptions& ikoptions) {
   auto results = IKResults();
   results.q_sol.resize(q_nom.size());
-  int num_constraints = constraint_array.size();
+  int num_constraints = (int)constraint_array.size();
   RigidBodyConstraint **const constraint_array_ptr =
       (RigidBodyConstraint * *const)constraint_array.data();
   inverseKin<Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd>(

--- a/drake/systems/plants/inverseKin.cpp
+++ b/drake/systems/plants/inverseKin.cpp
@@ -48,7 +48,7 @@ IKResults inverseKinSimple(
     const IKoptions& ikoptions) {
   auto results = IKResults();
   results.q_sol.resize(q_nom.size());
-  int num_constraints = (int)constraint_array.size();
+  int num_constraints = static_cast<int>(constraint_array.size());
   RigidBodyConstraint **const constraint_array_ptr =
       (RigidBodyConstraint * *const)constraint_array.data();
   inverseKin<Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd>(


### PR DESCRIPTION
These warnings were bothering me on Windows. I made minimal changes to make the warnings go away.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2815)
<!-- Reviewable:end -->
