### PR TITLE
cmake: Sync submodule URL changes during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,18 @@ function(drake_forceupdate proj)
   endif()
 endfunction()
 
+function(drake_depend_submodule_sync proj)
+  # All targets that contain a submodule update command, or depend on a
+  # target that does, need to depend on the submodule-sync target.
+  if(AUTO_UPDATE_EXTERNALS)
+    foreach(t ${proj} ${proj}-update)
+      if(TARGET ${t})
+        add_dependencies(${t} submodule-sync)
+      endif()
+    endforeach()
+  endif()
+endfunction()
+
 # Require Java at the super-build level since libbot cannot configure without finding Java
 find_package(Java 1.6 REQUIRED)
 include(UseJava)
@@ -339,10 +351,6 @@ foreach(proj ${EXTERNAL_PROJECTS})
 
     if(AUTO_UPDATE_EXTERNALS)
       set(${proj}_UPDATE_COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${${proj}_DOWNLOAD_COMMAND})
-
-      # Synchronize the submodule url now so parallel updates do not conflict later.
-      execute_process(COMMAND ${GIT_EXECUTABLE} submodule sync -- ${${proj}_GIT_SUBMODULE_PATH}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     else()
       set(${proj}_UPDATE_COMMAND "")
     endif()
@@ -378,6 +386,7 @@ foreach(proj ${EXTERNAL_PROJECTS})
         ${${proj}_ADDITIONAL_CMAKE_CONFIGURE_ARGS}
         ${${proj}_ADDITIONAL_BUILD_ARGS})
       drake_forceupdate(${proj})
+      drake_depend_submodule_sync(${proj})
     else() # not a CMake POD
       if(NOT ${proj}_BINARY_DIR)
         # In-source build for non-CMake projects.
@@ -418,6 +427,7 @@ foreach(proj ${EXTERNAL_PROJECTS})
         DEPENDS ${deps}
         ${${proj}_ADDITIONAL_BUILD_ARGS})
       drake_forceupdate(${proj})
+      drake_depend_submodule_sync(${proj})
       # message(STATUS "${proj}_BUILD_COMMAND: ${${proj}_BUILD_COMMAND}")
     endif()
   else()
@@ -442,6 +452,7 @@ foreach(proj ${EXTERNAL_PROJECTS})
       ${PODS_VERBOSE_MAKEFILE}
       ${${proj}_ADDITIONAL_CMAKE_CONFIGURE_ARGS}
       ${${proj}_ADDITIONAL_BUILD_ARGS})
+    drake_depend_submodule_sync(${proj})
   endif()
 
 endforeach()
@@ -502,10 +513,6 @@ foreach(example IN ITEMS LittleDog)
     set(${example}_DOWNLOAD_COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- drake/examples/${example})
     if(AUTO_UPDATE_EXTERNALS)
       set(${example}_UPDATE_COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${${example}_DOWNLOAD_COMMAND})
-
-      # Synchronize the submodule url now so parallel updates do not conflict later.
-      execute_process(COMMAND ${GIT_EXECUTABLE} submodule sync -- drake/examples/${example}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     else()
       set(${example}_UPDATE_COMMAND "")
     endif()
@@ -519,10 +526,20 @@ foreach(example IN ITEMS LittleDog)
       BUILD_COMMAND ""
       INSTALL_COMMAND "")
     drake_forceupdate(download-${example})
+    drake_depend_submodule_sync(download-${example})
     add_dependencies(drake download-${example})
     add_dependencies(download-all download-${example})
   endif()
 endforeach()
+
+if(AUTO_UPDATE_EXTERNALS)
+  # Start every build by synchronizing submodule URLs.  We do this as a
+  # separate target so all URLs can be synchronized at once instead of
+  # conflicting during parallel updates later.
+  add_custom_target(submodule-sync
+    COMMAND ${GIT_EXECUTABLE} submodule --quiet sync --
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 string(REPLACE ";" " " PROJECT_LIST "${PROJECT_LIST}")
 add_custom_target(list-project-dirs COMMAND echo "${PROJECT_LIST}")


### PR DESCRIPTION
When `AUTO_UPDATE_EXTERNALS` is `ON` we are responsible for keeping external source trees up to date.  Previously we achieved this by running `git submodule sync` during CMake configuration to honor changes to the submodule URLs.  However, it is possible for an incremental update to re-build without re-running CMake.  Therefore we need to do the sync at the start of the build instead.

Fixes #2827.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2828)
<!-- Reviewable:end -->
