### PR TITLE
Add pre-commit hook to reject submodule rewinds

### DIFF
--- a/.hooks-config
+++ b/.hooks-config
@@ -1,0 +1,4 @@
+# CMake installs a pre-commit hook that reads this configuration
+# file to get the location of the real hook to run.
+[hooks "chain"]
+	pre-commit = cmake/git/pre-commit.bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ message(STATUS CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
 include(ExternalProject)
 find_package(Git REQUIRED)
 
+include(cmake/git/hooks.cmake)
+drake_setup_git_hooks()
+
 function(drake_forceupdate proj)
   # CMake < 3.6 forget to mark the update step as "ALWAYS" when an explicit
   # UPDATE_COMMAND is used.  Add our own "ALWAYS" step to force updates.

--- a/cmake/git/hooks.cmake
+++ b/cmake/git/hooks.cmake
@@ -1,0 +1,37 @@
+function(drake_setup_git_hooks)
+  set(_git_dir "${PROJECT_SOURCE_DIR}/.git")
+  if(NOT IS_DIRECTORY "${_git_dir}")
+    return()
+  endif()
+
+  # Use a comment to hold the launcher version number.
+  set(_hook_version_regex "Drake pre-commit hook launcher version '([0-9.]+)'")
+  set(_in "${PROJECT_SOURCE_DIR}/cmake/git/pre-commit.in")
+  set(_out "${_git_dir}/hooks/pre-commit")
+
+  # Extract version of our hook launcher.
+  file(STRINGS "${_in}" _in_version_line REGEX "${_hook_version_regex}" LIMIT_INPUT 1024)
+  if(_in_version_line MATCHES "${_hook_version_regex}")
+    set(_in_version "${CMAKE_MATCH_1}")
+  else()
+    message(FATAL_ERROR "Failed to extract version from '${_in}'")
+  endif()
+
+  # Extract version of hook launcher currently installed.
+  if(EXISTS "${_out}")
+    file(STRINGS "${_out}" _out_version_line REGEX "${_hook_version_regex}" LIMIT_INPUT 1024)
+    if(_out_version_line MATCHES "${_hook_version_regex}")
+      set(_out_version "${CMAKE_MATCH_1}")
+    else()
+      set(_out_version 1000000) # hook has unexpected content, do not replace it
+    endif()
+  else()
+    set(_out_version 0)
+  endif()
+
+  # Install the hook launcher, but replace an existing launcher
+  # only if it is an older version of our launcher.
+  if(_in_version VERSION_GREATER _out_version)
+    configure_file("${_in}" "${_out}" @ONLY)
+  endif()
+endfunction()

--- a/cmake/git/pre-commit.bash
+++ b/cmake/git/pre-commit.bash
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/cmake/git/pre-commit.bash
+++ b/cmake/git/pre-commit.bash
@@ -1,1 +1,104 @@
 #!/usr/bin/env bash
+# This is a local Git pre-commit hook to enforce the following:
+#
+# - Disallow submodule link updates that rewind the submodule.
+
+die() {
+  echo 'pre-commit hook failure' 1>&2
+  echo '-----------------------' 1>&2
+  echo '' 1>&2
+  echo "$@" 1>&2
+  exit 1
+}
+
+short_commit() {
+  git rev-parse --short "$1" 2>/dev/null || echo "$1"
+}
+
+index_diffs() {
+  git diff-index --cached "$1" -- |
+  sed -n '/^:[^:]/ {s/^://;p;}'
+}
+
+# Match diffs that add or change a path mode to the special
+# value that Git uses to reference submodule commit objects.
+filter_diffs_module() {
+  grep '^...... 160000'
+}
+
+# Visit the submodule's `.git` directory and compute the most recent
+# common ancestor ("merge base") between the old and new commits
+# referenced by this submodule link update.  If the new value (dst_obj)
+# is the common ancestor then we know that it has been rewound from
+# the old value (src_obj).  This is likely not intentional.
+check_module_rewind() {
+  readonly parent_name="$1"
+
+  # Check if this is a rewind in the submodule's history.
+  readonly base="$(GIT_DIR="$file/.git" \
+                   git merge-base "$src_obj" "$dst_obj" 2>/dev/null)" || base=''
+  if test "$base" != "$dst_obj"; then
+    return
+  fi
+
+  # It is a rewind.  Check for overriding configuration.
+  readonly src_short="$(GIT_DIR="$file/.git" short_commit "$src_obj")"
+  readonly dst_short="$(GIT_DIR="$file/.git" short_commit "$dst_obj")"
+  readonly override="$src_short..$dst_short"
+  if update="$(git config --get hooks."$file".update)" &&
+     test "{$update}" = "{$override}"; then
+    return
+  fi
+
+  # Produce a diagnostic.
+  readonly parent_short="$(short_commit "$parent_name")"
+  echo 'This commit would rewind a submodule link:
+
+  "'"$file"'"  '"$src_short => $dst_short"'
+
+from the newer version in '"$parent_name"' ('"$parent_short"').  Run
+
+  git reset '"$parent_name"' -- "'"$file"'"
+  git submodule update -- "'"$file"'"
+
+to checkout the newer version of the submodule in your work tree.
+Then try the commit again.
+
+If you know what you are doing, run
+  git config hooks."'"$file"'".update "'"$override"'"
+to override this hook.
+'
+  return 1
+}
+
+#----------------------------------------------------------------------------
+
+# Check diffs to first parent of commit under construction.
+readonly diffs="$(index_diffs HEAD)"
+readonly diffs_module="$(echo "$diffs" | filter_diffs_module)"
+bad="$(
+test -n "$diffs_module" && echo "$diffs_module" |
+while read src_mode dst_mode src_obj dst_obj status file; do
+  check_module_rewind HEAD ||
+  break
+done
+)"
+test -z "$bad" || die "$bad"
+
+# Check diffs to second parent of commit under construction during a
+# merge ("git commit" after "git merge" with conflicts or --no-commit).
+readonly merge_head="$(git rev-parse -q --verify MERGE_HEAD)"
+if test -n "$merge_head"; then
+  readonly merge_diffs="$(index_diffs MERGE_HEAD)"
+else
+  readonly merge_diffs=''
+fi
+readonly merge_diffs_module="$(echo "$merge_diffs" | filter_diffs_module)"
+bad="$(
+test -n "$merge_diffs_module" && echo "$merge_diffs_module" |
+while read src_mode dst_mode src_obj dst_obj status file; do
+  check_module_rewind MERGE_HEAD ||
+  break
+done
+)"
+test -z "$bad" || die "$bad"

--- a/cmake/git/pre-commit.in
+++ b/cmake/git/pre-commit.in
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Drake pre-commit hook launcher version '1'.
+
+# Look up a configured pre-commit hook to call.
+#
+# Read local configuration of a custom pre-commit hook.  Keep all our
+# hooks configuration in a single "hooks" section since .git/config
+# may have a lot of other content.
+chain="$(git config --get hooks.chain-pre-commit)" ||
+# Read project configuration from the source tree.  In this dedicated
+# file we can have more sections, so keep all "chain" hooks in one.
+chain="$(git config -f .hooks-config --get hooks.chain.pre-commit)" ||
+chain=""
+
+# Choose a prefix needed to launch the hook without searching the PATH.
+case "$chain" in
+  '') exit 0 ;;
+  '/'*) prefix="" ;;
+  '[A-Za-z]:/'*) prefix="" ;;
+  '.'*) prefix="" ;;
+  *) prefix="./" ;;
+esac
+
+# Chain to the configured hook.
+if test -x "$prefix$chain" ; then
+  exec "$prefix$chain" "$@"
+fi


### PR DESCRIPTION
Since Git does not automatically update submodule checkouts after a checkout updates recorded submodule versions it is common for the work tree to end up with submodules locally modified.  It is easy for developers to accidentally commit a submodule rewind by using `git commit -a` or `git add -u; git commit` from such a state.

Help developers avoid this by adding a pre-commit hook to reject submodule rewinds.  On rejection, print instructions about what local operations to run to resolve the condition.

Install a `.git/hooks/pre-commit` hook into the local repository during CMake configuration.  Rather than trying to do all the checks directly, make it a simple launcher that loads a configured pre-commit hook from the checkout in the work tree.  This will allow us to add checks to pre-commit over time without re-installing the hook into an unversioned location or depending on CMake re-runs to update the installation.

See issue #2757.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2834)
<!-- Reviewable:end -->
