### PR TITLE
Replaced QUAT_SIZE with kQuaternionSize since QUAT_SIZE is deprecated.

### DIFF
--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -24,6 +24,7 @@ using namespace Eigen;
 
 using drake::AutoDiffUpTo73d;
 using drake::AutoDiffXd;
+using drake::kQuaternionSize;
 using drake::kRpySize;
 using drake::kSpaceDimension;
 using drake::Matrix3X;
@@ -1468,7 +1469,7 @@ RigidBodyTree::transformPointsJacobian(
 }
 
 template <typename Scalar>
-Eigen::Matrix<Scalar, QUAT_SIZE, Eigen::Dynamic>
+Eigen::Matrix<Scalar, kQuaternionSize, Eigen::Dynamic>
 RigidBodyTree::relativeQuaternionJacobian(const KinematicsCache<Scalar>& cache,
                                           int from_body_or_frame_ind,
                                           int to_body_or_frame_ind,
@@ -1481,7 +1482,7 @@ RigidBodyTree::relativeQuaternionJacobian(const KinematicsCache<Scalar>& cache,
   auto Jomega = J_geometric.template topRows<kSpaceDimension>();
   auto quat =
       relativeQuaternion(cache, from_body_or_frame_ind, to_body_or_frame_ind);
-  Matrix<Scalar, QUAT_SIZE, kSpaceDimension> Phi;
+  Matrix<Scalar, kQuaternionSize, kSpaceDimension> Phi;
   angularvel2quatdotMatrix(
       quat, Phi,
       static_cast<typename Gradient<decltype(Phi), Dynamic>::type*>(nullptr));
@@ -1578,7 +1579,7 @@ RigidBodyTree::relativeQuaternionJacobianDotTimesV(
 
   auto quat =
       relativeQuaternion(cache, from_body_or_frame_ind, to_body_or_frame_ind);
-  Matrix<Scalar, QUAT_SIZE, kSpaceDimension> Phi;
+  Matrix<Scalar, kQuaternionSize, kSpaceDimension> Phi;
   angularvel2quatdotMatrix(
       quat, Phi,
       static_cast<typename Gradient<decltype(Phi), Dynamic>::type*>(nullptr));
@@ -1597,13 +1598,14 @@ RigidBodyTree::relativeQuaternionJacobianDotTimesV(
   // 32 bit
   auto quat_autodiff = quat.template cast<ADScalar>().eval();
   gradientMatrixToAutoDiff(quatdot, quat_autodiff);
-  Matrix<ADScalar, QUAT_SIZE, kSpaceDimension> Phi_autodiff;
+  Matrix<ADScalar, kQuaternionSize, kSpaceDimension> Phi_autodiff;
   angularvel2quatdotMatrix(
       quat_autodiff, Phi_autodiff,
       static_cast<typename Gradient<decltype(Phi_autodiff), Dynamic>::type*>(
           nullptr));
   auto Phidot_vector = autoDiffToGradientMatrix(Phi_autodiff);
-  Map<Matrix<Scalar, QUAT_SIZE, kSpaceDimension>> Phid(Phidot_vector.data());
+  Map<Matrix<Scalar, kQuaternionSize, kSpaceDimension>>
+      Phid(Phidot_vector.data());
 
   const auto J_geometric_dot_times_v = geometricJacobianDotTimesV(
       cache, to_body_or_frame_ind, from_body_or_frame_ind, expressed_in);

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -29,6 +29,7 @@ using namespace std;
 using namespace Eigen;
 using namespace Drake;
 
+using drake::kQuaternionSize;
 using drake::kSpaceDimension;
 
 using drake::math::Gradient;
@@ -550,7 +551,7 @@ void QPLocomotionPlan::updateSwingTrajectory(
       robot.relativeTwist(cache, 0, body_motion_data.getBodyOrFrameId(), 0);
 
   Vector4d x0_quat = drake::math::rotmat2quat(x0_pose.linear());
-  Matrix<double, QUAT_SIZE, kSpaceDimension> Phi;
+  Matrix<double, kQuaternionSize, kSpaceDimension> Phi;
   angularvel2quatdotMatrix(
       x0_quat, Phi,
       static_cast<Gradient<decltype(Phi), Dynamic>::type*>(nullptr));

--- a/drake/util/test/testGeometryConversionFunctionsmex.cpp
+++ b/drake/util/test/testGeometryConversionFunctionsmex.cpp
@@ -7,6 +7,7 @@
 
 using namespace Eigen;
 
+using drake::kQuaternionSize;
 using drake::kRpySize;
 using drake::kSpaceDimension;
 using drake::math::autoDiffToValueMatrix;
@@ -23,22 +24,22 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
 
   int argnum = 0;
   Isometry3d T;
-  auto q = matlabToEigen<QUAT_SIZE, 1>(prhs[argnum++]);
-  auto dq = matlabToEigen<QUAT_SIZE, Eigen::Dynamic>(prhs[argnum++]);
+  auto q = matlabToEigen<kQuaternionSize, 1>(prhs[argnum++]);
+  auto dq = matlabToEigen<kQuaternionSize, Eigen::Dynamic>(prhs[argnum++]);
 
   auto rpy = drake::math::quat2rpy(q);
 
-  Matrix<double, QUAT_SIZE, kSpaceDimension> omega2qd;
-  Gradient<Matrix<double, QUAT_SIZE, kSpaceDimension>, QUAT_SIZE, 1>::type
-      domega2qd;
+  Matrix<double, kQuaternionSize, kSpaceDimension> omega2qd;
+  Gradient<Matrix<double, kQuaternionSize, kSpaceDimension>, kQuaternionSize,
+      1>::type domega2qd;
   Matrix<double, kRpySize, kSpaceDimension> omega2rpyd;
   Gradient<Matrix<double, kRpySize, kSpaceDimension>, kRpySize, 1>::type
       domega2rpyd;
   Gradient<Matrix<double, kRpySize, kSpaceDimension>, kRpySize, 2>::type
       ddomega2rpyd;
-  Matrix<double, kSpaceDimension, QUAT_SIZE> qd2omega;
-  Gradient<Matrix<double, kSpaceDimension, QUAT_SIZE>, QUAT_SIZE, 1>::type
-      dqd2omega;
+  Matrix<double, kSpaceDimension, kQuaternionSize> qd2omega;
+  Gradient<Matrix<double, kSpaceDimension, kQuaternionSize>, kQuaternionSize,
+      1>::type dqd2omega;
 
   angularvel2quatdotMatrix(q, omega2qd, &domega2qd);
   angularvel2rpydotMatrix(rpy, omega2rpyd, &domega2rpyd, &ddomega2rpyd);


### PR DESCRIPTION
Another search-and-replace fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2838)
<!-- Reviewable:end -->
