### PR TITLE
Mod to ROS CMakeLists.txt so tests are built.

### DIFF
--- a/ros/drake_ros_systems/CMakeLists.txt
+++ b/ros/drake_ros_systems/CMakeLists.txt
@@ -15,6 +15,7 @@ if (CATKIN_ENABLE_TESTING)
   include_directories(${CMAKE_INSTALL_PREFIX}/include)
   add_rostest_gtest(ros_test test/ros_test.test test/ros_test.cc)
   target_link_libraries(ros_test ${catkin_LIBRARIES})
+  set_target_properties(ros_test PROPERTIES EXCLUDE_FROM_ALL FALSE)
 endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
 * Catkin builds tests at test run time rather than at build time
 * Modified CMakeLists.txt to set test to build at build time,
   because we are not triggerting tests to run through catkin,
   and so they would fail because they are not built.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2843)
<!-- Reviewable:end -->
