### PR TITLE
Revert "Revert "Added LcmPublisherSystem Based on System 2.0 Framework""

### DIFF
--- a/drake/systems/lcm/CMakeLists.txt
+++ b/drake/systems/lcm/CMakeLists.txt
@@ -1,6 +1,7 @@
 if(lcm_FOUND)
   add_library_with_exports(LIB_NAME drakeLCMSystem2 SOURCE_FILES
     lcm_receive_thread.cc
+    lcm_publisher_system.cc
     lcm_subscriber_system.cc
     translator_between_lcmt_drake_signal.cc)
   add_dependencies(drakeLCMSystem2 drake_lcmtypes_hpp)
@@ -15,6 +16,7 @@ if(lcm_FOUND)
   pods_install_libraries(drakeLCMSystem2)
   drake_install_headers(
     lcm_receive_thread.h
+    lcm_publisher_system.h
     lcm_subscriber_system.h
     lcm_and_vector_interface_translator.h
     translator_between_lcmt_drake_signal.h)

--- a/drake/systems/lcm/lcm_and_vector_interface_translator.h
+++ b/drake/systems/lcm/lcm_and_vector_interface_translator.h
@@ -43,8 +43,7 @@ class LcmAndVectorInterfaceTranslator {
    * @param[in] rbuf A pointer to a buffer holding the LCM message's data.
    *
    * @param[out] vector_interface A pointer to where the translation of the LCM
-   * message should be stored. This pointer must not be `nullptr` and must
-   * be valid throughout the duration of this method call.
+   * message should be stored. This pointer must not be `nullptr`.
    *
    * @throws runtime_error If a received LCM message failed to be decoded, or
    * if the decoded LCM message is incompatible with the @p vector_interface.
@@ -53,6 +52,23 @@ class LcmAndVectorInterfaceTranslator {
    */
   virtual void TranslateLcmToVectorInterface(const ::lcm::ReceiveBuffer* rbuf,
     VectorInterface<double>* vector_interface) const = 0;
+
+  /**
+   * Translates a `drake::systems::VectorInterface` object into an LCM message
+   * and publishes it on the specified LCM channel.
+   *
+   * @param[in] vector_interface A reference to the object to convert into an
+   * LCM message.
+   *
+   * @param[in] channel The name of the channel on which to publish the LCM
+   * message.
+   *
+   * @param[in] lcm A pointer to the LCM subsystem. This pointer must not be
+   * `nullptr`.
+   */
+  virtual void PublishVectorInterfaceToLCM(
+      const VectorInterface<double>& vector_interface,
+      const std::string& channel, ::lcm::LCM* lcm) const = 0;
 
  private:
   // The size of the vector in the VectorInterface.

--- a/drake/systems/lcm/lcm_publisher_system.cc
+++ b/drake/systems/lcm/lcm_publisher_system.cc
@@ -1,0 +1,54 @@
+#include "drake/systems/lcm/lcm_publisher_system.h"
+
+#include "drake/systems/framework/system_input.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+
+namespace {
+const int kNumInputPorts = 1;
+const int kPortIndex = 0;
+}  // namespace
+
+LcmPublisherSystem::LcmPublisherSystem(
+    const std::string& channel,
+    const LcmAndVectorInterfaceTranslator& translator, ::lcm::LCM* lcm)
+    : channel_(channel), translator_(translator), lcm_(lcm) {}
+
+LcmPublisherSystem::~LcmPublisherSystem() {}
+
+std::string LcmPublisherSystem::get_name() const {
+  return "LcmPublisherSystem::" + channel_;
+}
+
+std::unique_ptr<Context<double>> LcmPublisherSystem::CreateDefaultContext()
+    const {
+  std::unique_ptr<Context<double>> context(new Context<double>());
+  context->SetNumInputPorts(kNumInputPorts);
+  return context;
+}
+
+std::unique_ptr<SystemOutput<double>> LcmPublisherSystem::AllocateOutput()
+    const {
+  std::unique_ptr<SystemOutput<double>> output(new SystemOutput<double>);
+  return output;
+}
+
+// TODO(liang.fok) Move the LCM message publishing logic into another method
+// that's more appropriate once it is defined by SystemInterface. See:
+// https://github.com/RobotLocomotion/drake/issues/2836.
+void LcmPublisherSystem::EvalOutput(const Context<double>& context,
+                                    SystemOutput<double>* output) const {
+  // Obtains the input vector.
+  const VectorInterface<double>* input_vector =
+      context.get_vector_input(kPortIndex);
+
+  // Translates the input vector into an LCM message and publishes it onto the
+  // specified LCM channel.
+  translator_.PublishVectorInterfaceToLCM(*input_vector, channel_, lcm_);
+}
+
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/lcm/lcm_publisher_system.h
+++ b/drake/systems/lcm/lcm_publisher_system.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <lcm/lcm-cpp.hpp>
+
+#include "drake/drakeLCMSystem2_export.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/system_interface.h"
+#include "drake/systems/lcm/lcm_and_vector_interface_translator.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+
+/**
+ * Publishes an LCM message containing information from its input port.
+ */
+class DRAKELCMSYSTEM2_EXPORT LcmPublisherSystem :
+    public SystemInterface<double> {
+ public:
+  /**
+   * The constructor.
+   *
+   * @param[in] channel The LCM channel on which to publish.
+   *
+   * @param[in] translator The translator that converts between LCM message
+   * objects and `drake::systems::VectorInterface` objects. This reference
+   * is aliased by this constructor and thus must remain valid for the lifetime
+   * of this object.
+   *
+   * @param[in] lcm A pointer to the LCM subsystem.
+   */
+  LcmPublisherSystem(const std::string& channel,
+                     const LcmAndVectorInterfaceTranslator& translator,
+                     ::lcm::LCM* lcm);
+
+  ~LcmPublisherSystem() override;
+
+  // Disable copy and assign.
+  LcmPublisherSystem(const LcmPublisherSystem&) = delete;
+  LcmPublisherSystem& operator=(const LcmPublisherSystem&) = delete;
+
+  std::string get_name() const override;
+
+  /**
+   * The default context for this system is one that has one input port and
+   * no state.
+   */
+  std::unique_ptr<Context<double>> CreateDefaultContext() const override;
+
+  /**
+   * The output contains zero ports.
+   */
+  std::unique_ptr<SystemOutput<double>> AllocateOutput() const override;
+
+  /**
+   * Takes the VectorInterface from the input port of the context and publishes
+   * it onto an LCM channel. Note that the output is ignored since this system
+   * does not output anything.
+   */
+  void EvalOutput(const Context<double>& context,
+                  SystemOutput<double>* output) const override;
+
+ private:
+  // The channel on which to publish LCM messages.
+  const std::string channel_;
+
+  // The translator that converts between LCM messages and
+  // drake::systems::VectorInterface objects.
+  const LcmAndVectorInterfaceTranslator& translator_;
+
+  // A pointer to the LCM subsystem.
+  ::lcm::LCM* lcm_;
+};
+
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/lcm/test/CMakeLists.txt
+++ b/drake/systems/lcm/test/CMakeLists.txt
@@ -4,4 +4,10 @@ if(lcm_FOUND)
     drakeLCMSystem2
     ${GTEST_BOTH_LIBRARIES})
   add_test(NAME lcm_subscriber_system_test COMMAND lcm_subscriber_system_test)
+
+  add_executable(lcm_publisher_system_test lcm_publisher_system_test.cc)
+  target_link_libraries(lcm_publisher_system_test
+    drakeLCMSystem2
+    ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME lcm_publisher_system_test COMMAND lcm_publisher_system_test)
 endif()

--- a/drake/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/drake/systems/lcm/test/lcm_publisher_system_test.cc
@@ -1,0 +1,177 @@
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+#include "gtest/gtest.h"
+
+#include "drake/lcmt_drake_signal.hpp"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/lcm/lcm_receive_thread.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/lcm/translator_between_lcmt_drake_signal.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+namespace {
+
+const int kDim = 10;
+const int kPortNumber = 0;
+
+/**
+ * Subscribes to LCM messages of type `drake::lcmt_drake_signal`. Provides an
+ * accessor to the latest message received.
+ */
+class MessageSubscriber {
+ public:
+  MessageSubscriber(const std::string& channel_name, ::lcm::LCM* lcm)
+      : channel_name_(channel_name) {
+    // Sets up the LCM message subscriber.
+    ::lcm::Subscription* sub =
+        lcm->subscribe(channel_name, &MessageSubscriber::HandleMessage, this);
+    sub->setQueueCapacity(1);
+
+    // Initializes the fields of member variable received_message_ so that the
+    // test logic below can determine whether the desired message was received.
+    received_message_.dim = 0;
+    received_message_.val.resize(received_message_.dim);
+    received_message_.coord.resize(received_message_.dim);
+    received_message_.timestamp = 0;
+  }
+
+  drake::lcmt_drake_signal GetReceivedMessage() {
+    drake::lcmt_drake_signal message_copy;
+
+    std::lock_guard<std::mutex> lock(message_mutex_);
+    message_copy = received_message_;
+
+    return message_copy;
+  }
+
+ private:
+  void HandleMessage(const ::lcm::ReceiveBuffer* rbuf,
+                     const std::string& channel_name) {
+    if (channel_name_ == channel_name) {
+      std::lock_guard<std::mutex> lock(message_mutex_);
+      // Note: The call to decode() below returns the number of bytes decoded
+      // or a negative value indicating an error occurred. This error is
+      // ignored since the unit test below includes logic that checks every
+      // value within the received message for correctness.
+      received_message_.decode(rbuf->data, 0, rbuf->data_size);
+    }
+  }
+
+  const std::string channel_name_;
+
+  std::mutex message_mutex_;
+
+  drake::lcmt_drake_signal received_message_;
+};
+
+// Tests the functionality of LcmPublisherSystem.
+GTEST_TEST(LcmPublisherSystemTest, ReceiveTest) {
+  ::lcm::LCM lcm;
+  LcmReceiveThread lcm_receive_thread(&lcm);
+  std::string channel_name = "drake_system2_lcm_test_publisher_channel_name";
+  TranslatorBetweenLcmtDrakeSignal translator(kDim);
+
+  // Instantiates an LcmPublisherSystem that takes as input System 2.0 Vectors
+  // of type drake::systems::BasicVector and publishes LCM messages of type
+  // drake::lcmt_drake_signal.
+  //
+  // It then verifies that the LcmPublisherSystem was successfully stored
+  // in a unique_ptr. The unique_ptr variable is called "dut" to indicate it is
+  // the "device under test".
+  std::unique_ptr<LcmPublisherSystem> dut(
+      new LcmPublisherSystem(channel_name, translator, &lcm));
+
+  EXPECT_EQ(dut->get_name(), "LcmPublisherSystem::" + channel_name);
+
+  // Instantiates a receiver of lcmt_drake_signal messages.
+  MessageSubscriber subscriber(channel_name, &lcm);
+
+  std::unique_ptr<Context<double>> context = dut->CreateDefaultContext();
+  std::unique_ptr<SystemOutput<double>> output = dut->AllocateOutput();
+
+  // Verifies that the context has one input port.
+  EXPECT_EQ(context->get_num_input_ports(), 1);
+
+  // Instantiates a BasicVector with known state. This is the basic vector that
+  // we want the LcmPublisherSystem to publish as a drake::lcmt_drake_signal
+  // message.
+  std::unique_ptr<VectorInterface<double>> vector_interface(
+      new BasicVector<double>(kDim));
+
+  {
+    Eigen::VectorBlock<VectorX<double>> vector_value =
+        vector_interface->get_mutable_value();
+
+    for (int ii = 0; ii < kDim; ++ii) {
+      vector_value[ii] = ii;
+    }
+  }
+
+  // Sets the value in the context's input port to be the above-defined
+  // VectorInterface. Note that we need to overwrite the original input port
+  // created by the LcmPublisherSystem since we do not have write access to its
+  // input vector.
+  std::unique_ptr<InputPort<double>> input_port(
+      new FreestandingInputPort<double>(std::move(vector_interface)));
+
+  context->SetInputPort(kPortNumber, std::move(input_port));
+
+  // Whether the receiver received an LCM message published by the
+  // LcmPublisherSystem.
+  bool done = false;
+
+  // This is used to prevent this unit test from running indefinitely when
+  // the receiver fails to receive the LCM message published by the
+  // LcmPublisherSystem.
+  int count = 0;
+
+  const int kMaxCount = 10;
+  const int kDelayMS = 500;
+
+  // We must periodically call dut->EvalOutput(...) since we do not know when
+  // the receiver will receive the message published by the LcmPublisherSystem.
+  while (!done && count++ < kMaxCount) {
+    dut->EvalOutput(*context.get(), output.get());
+
+    // Gets the received message.
+    const drake::lcmt_drake_signal received_message =
+        subscriber.GetReceivedMessage();
+
+    // Verifies that the size of the received LCM message is correct.
+    if (received_message.dim == kDim) {
+      bool values_match = true;
+
+      for (int ii = 0; ii < kDim && values_match; ++ii) {
+        if (received_message.val[ii] != ii) values_match = false;
+      }
+
+      // At this point, if values_match is true, the received message contains
+      // the expected values, which implies that LcmPublisherSystem successfully
+      // published the VectorInterface as a drake::lcmt_drake_signal message.
+      //
+      // We cannot check whether the following member variables of
+      // drake::lcmt_drake_signal message was successfully transferred because
+      // BasicVector does not save this information:
+      //
+      //   1. coord
+      //   2. timestamp
+      //
+      // Thus, we must conclude that the experiment succeeded.
+      if (values_match) done = true;
+    }
+
+    if (!done) std::this_thread::sleep_for(std::chrono::milliseconds(kDelayMS));
+  }
+
+  EXPECT_TRUE(done);
+}
+
+}  // namespace
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/lcm/translator_between_lcmt_drake_signal.cc
+++ b/drake/systems/lcm/translator_between_lcmt_drake_signal.cc
@@ -47,6 +47,29 @@ void TranslatorBetweenLcmtDrakeSignal::TranslateLcmToVectorInterface(
   }
 }
 
+void TranslatorBetweenLcmtDrakeSignal::PublishVectorInterfaceToLCM(
+    const VectorInterface<double>& vector_interface, const std::string& channel,
+    ::lcm::LCM* lcm) const {
+
+  DRAKE_ASSERT(vector_interface.size() == get_vector_size());
+
+  // Instantiates and initializes a LCM message capturing the state of
+  // parameter vector_interface.
+  drake::lcmt_drake_signal message;
+  message.dim = vector_interface.size();
+  message.val.resize(message.dim);
+  message.coord.resize(message.dim);
+
+  Eigen::VectorBlock<const VectorX<double>> values =
+      vector_interface.get_value();
+
+  for (int ii = 0; ii < message.dim; ++ii) {
+    message.val[ii] = values[ii];
+  }
+
+  lcm->publish(channel, &message);
+}
+
 }  // namespace lcm
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/lcm/translator_between_lcmt_drake_signal.h
+++ b/drake/systems/lcm/translator_between_lcmt_drake_signal.h
@@ -33,6 +33,10 @@ class DRAKELCMSYSTEM2_EXPORT TranslatorBetweenLcmtDrakeSignal
   void TranslateLcmToVectorInterface(
       const ::lcm::ReceiveBuffer* rbuf,
       VectorInterface<double>* vector_interface) const override;
+
+  void PublishVectorInterfaceToLCM(
+      const VectorInterface<double>& vector_interface,
+          const std::string& channel, ::lcm::LCM* lcm) const override;
 };
 
 }  // namespace lcm


### PR DESCRIPTION
This reverts commit 90792bcf0f00da21545696106c5ebf9311ffa04a.

I was unable to replicate the segmentation fault on my local machine (see: https://github.com/RobotLocomotion/drake/pull/2841#issuecomment-233744324). I'm thus going to use this PR to get Jenkins to replicate the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2844)
<!-- Reviewable:end -->
