### PR TITLE
Added missing semicolon to ROS instructions. This puts the commands inside a pretty box.

### DIFF
--- a/drake/doc/from_source_ros.rst
+++ b/drake/doc/from_source_ros.rst
@@ -186,7 +186,7 @@ Finally, to run the car simulation demo, execute::
     source devel/setup.bash
     roslaunch drake_cars_examples drake_car_sim.launch
 
-To drive the vehicle around in simulation, open another terminal and execute:
+To drive the vehicle around in simulation, open another terminal and execute::
 
     cd ~/dev/drake_catkin_workspace
     source devel/setup.bash


### PR DESCRIPTION
Fixes the missing box surrounding the commands at the very bottom of this page: http://drake.mit.edu/from_source_ros.html.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2848)
<!-- Reviewable:end -->
