### PR TITLE
Revert "Update MATLAB code to support out-of-source builds."

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -315,11 +315,13 @@ add_subdirectory(bindings)
 include(cmake/matlab_pods.cmake)
 pods_configure_matlab_paths()
 
-message(STATUS "Writing path utilities to ${CMAKE_INSTALL_PREFIX}/matlab")
+file(RELATIVE_PATH relpath ${CMAKE_INSTALL_PREFIX}/matlab ${CMAKE_CURRENT_SOURCE_DIR})
+
+message(STATUS "Writing addpath_drake.m and rmpath_drake.m to ${CMAKE_INSTALL_PREFIX}/matlab")
 file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/addpath_drake.m
   "function addpath_drake()\n"
-  "  addpath(fullfile('${CMAKE_INSTALL_PREFIX}', 'matlab'));\n"
-  "  wd = cd('${CMAKE_CURRENT_SOURCE_DIR}');\n"
+  "  mfiledir = fileparts(which(mfilename));\n"
+  "  wd = cd(fullfile(mfiledir,'${relpath}'));\n"
   "  addpath_drake();\n"
   "  cd(wd);\n"
   "end\n"
@@ -327,21 +329,10 @@ file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/addpath_drake.m
 
 file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/rmpath_drake.m
   "function rmpath_drake()\n"
-  "  wd = cd('${CMAKE_CURRENT_SOURCE_DIR}');\n"
+  "  mfiledir = fileparts(which(mfilename));\n"
+  "  wd = cd(fullfile(mfiledir,'${relpath}'));\n"
   "  rmpath_drake();\n"
   "  cd(wd);\n")
-
-file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/get_drake_binary_dir.m
-  "function [binary_dir] = get_drake_binary_dir()\n"
-  "  binary_dir = '${PROJECT_BINARY_DIR}';\n"
-  "end\n"
-  "\n")
-
-file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/get_drake_install_dir.m
-  "function [install_dir] = get_drake_install_dir()\n"
-  "  install_dir = '${CMAKE_INSTALL_PREFIX}';\n"
-  "end\n"
-  "\n")
 
 find_program(avl avl PATHS ${CMAKE_INSTALL_DIR}/bin)
 find_program(xfoil xfoil PATHS ${CMAKE_INSTALL_DIR}/bin)
@@ -373,5 +364,3 @@ endif()
 if(IS_DIRECTORY doc/textbook)
   add_subdirectory(doc/textbook)
 endif()
-
-add_subdirectory(regtests)

--- a/drake/addpath_drake.m
+++ b/drake/addpath_drake.m
@@ -1,4 +1,4 @@
-function [] = addpath_drake()
+function addpath_drake
 % Checks dependencies and sets up matlab path.
 % Searches the machine for necessary support programs, and generates
 % config.mat.  If required tools aren't found, it tries to be helpful in
@@ -8,15 +8,20 @@ function [] = addpath_drake()
 root = fileparts(mfilename('fullpath'));
 
 if ~exist('pods_get_base_path','file')
-  % The Drake build process produces some MATLAB files, and those files are
-  % not already on the MATLAB path, so we need to find them first.
-  addBuildProductsToPath(root);
+  % search up to 4 directories up for a build/matlab directory
+  pfx='';
+  for i=1:4
+    if exist(fullfile(root,pfx,'build','matlab'),'file')
+      disp(['Adding ', fullfile(root,pfx,'build','matlab'), ' to the matlab path']);
+      addpath(fullfile(root,pfx,'build','matlab'));
+      break;
+    end
+    pfx = fullfile('..',pfx);
+  end
 end
 
 if ~exist('pods_get_base_path','file')
-  error(['The Drake build outputs are not on the MATLAB path, and could ' ...
-         'not be auto-detected. Please add the build output directory ' ...
-         '"matlab" to the path, then re-run addpath_drake.']);
+  error('You must run make first (and/or add your pod build/matlab directory to the matlab path)');
 end
 
 if verLessThan('matlab','7.6')
@@ -60,7 +65,7 @@ addpath(fullfile(root,'solvers','BMI','util'));
 addpath(fullfile(root,'solvers','BMI','kinematics'));
 addpath(fullfile(root,'solvers','qpSpline'));
 addpath(fullfile(root,'bindings','matlab'));
-bindings_dir = fullfile(get_drake_binary_dir(),'bindings','matlab');
+bindings_dir = fullfile(root,'pod-build','bindings','matlab');
 if exist(bindings_dir, 'dir')
   addpath(bindings_dir);
 end
@@ -87,7 +92,7 @@ if (strcmp(computer('arch'),'maci64'))
 end
 
 if ispc
-  setenv('PATH',[getenv('PATH'),';',GetFullPath(pods_get_lib_path),';',fullfile(get_drake_install_dir(),'lib','Release')]);
+  setenv('PATH',[getenv('PATH'),';',GetFullPath(pods_get_lib_path),';',fullfile(root,'pod-build','lib','Release'),';',fullfile(root,'pod-build','lib')]);
 end
 
 
@@ -121,26 +126,4 @@ function javaaddpathIfNew(p)
  if ~any(cellfun(@(x) strcmp(x, p), javaclasspath('-dynamic')))
    javaaddpathProtectGlobals(p);
  end
-end
-
-% Searches for the MATLAB outputs of the Drake build and adds them to the path.
-function addBuildProductsToPath(root)
-  % Common names for the installed MATLAB outputs directory.
-  install_dir_names = {'build/install/matlab', ...
-                       'build/matlab', ...
-                       'drake-build/install/matlab'};
-
-  % Search four directories up for an install directory.
-  pfx='';
-  for i=1:4
-    for install_dir = install_dir_names
-      full_path = fullfile(root, pfx, install_dir{1});
-      if exist(full_path, 'file')
-        disp(['Adding ', full_path, ' to the matlab path.']);
-        addpath(full_path);
-        return;
-      end
-    end
-    pfx = fullfile('..',pfx);
-  end
 end

--- a/drake/regtests/CMakeLists.txt
+++ b/drake/regtests/CMakeLists.txt
@@ -1,6 +1,0 @@
-# This directory contains black-box regression tests that operate on the
-# installed outputs of the Drake build.
-
-if(MATLAB_FOUND)
-  add_matlab_test(NAME addpath_spotless_test COMMAND "addpath_spotless;")
-endif()

--- a/drake/systems/plants/test/testURDFcollisionmex.m
+++ b/drake/systems/plants/test/testURDFcollisionmex.m
@@ -6,7 +6,7 @@ checkDependency('bullet');
   old_ros_package_path = getenv('ROS_PACKAGE_PATH');
   setenv('ROS_PACKAGE_PATH', [old_ros_package_path, ':', ....
                               fullfile(getDrakePath(), 'examples')]);
-  urdf_collision_test = fullfile(get_drake_binary_dir(), 'bin/urdfCollisionTest');
+  urdf_collision_test = '../../../pod-build/bin/urdfCollisionTest';
   if ispc
     urdf_collision_test = [urdf_collision_test,'.exe'];
   end

--- a/drake/systems/plants/test/testURDFmex.m
+++ b/drake/systems/plants/test/testURDFmex.m
@@ -1,7 +1,7 @@
 function testURDFmex(urdfs)
 
-urdf_kin_test = fullfile(get_drake_binary_dir(), '/bin/urdfKinTest');
-urdf_manipulator_dynamics_test = fullfile(get_drake_binary_dir(), '/bin/urdfManipulatorDynamicsTest');
+urdf_kin_test = '../../../pod-build/bin/urdfKinTest';
+urdf_manipulator_dynamics_test = '../../../pod-build/bin/urdfManipulatorDynamicsTest';
 if ispc
   urdf_kin_test = [urdf_kin_test,'.exe'];
   urdf_manipulator_dynamics_test = [urdf_manipulator_dynamics_test,'.exe'];

--- a/drake/util/CMakeLists.txt
+++ b/drake/util/CMakeLists.txt
@@ -128,7 +128,7 @@ if(0)  # NOT WIN32
     "# Usage:\n"
     "#   % drake_debug_mex.sh [args]\n"
     "# will set up the environment and then run:\n"
-    "#   % args drake-debug-mex\n"
+    "#   % args pod-build/bin/drake-debug-mex\n"
     "#\n"
     "# For example,\n"
     "#   % drake_debug_mex.sh\n"

--- a/drake/util/getCMakeParam.m
+++ b/drake/util/getCMakeParam.m
@@ -1,16 +1,28 @@
 function val = getCMakeParam(param)
 % Checks the cmake cache and extracts the stored parameter
 
-cache_file_name = fullfile(get_drake_binary_dir(),'CMakeCache.txt');
-if ~exist(cache_file_name, 'file')
-  error('Could not find CMakeCache.txt.')
+cache_file_name = fullfile(getDrakePath,'pod-build','CMakeCache.txt');
+if ~exist(cache_file_name,'file')
+  val = [];  % fail silently
+  return;
 end
 
-txt = fileread(cache_file_name);
+txt = fileread(fullfile(getDrakePath,'pod-build','CMakeCache.txt'));
 tokens = regexp(txt,[param,':\w+=(.*)'],'tokens','dotexceptnewline');
 if isempty(tokens)
   val = [];
 else
   val = strtrim(tokens{1}{1});
 end
+
+% Note: This was the old way of doing it.  But we found it less robust,
+% because the matlab library path might not even allow one to run cmake.
+
+%[retval,val] = system(['cmake -L -N ',fullfile(getDrakePath,'pod-build'),' | grep ', param,' | cut -d "=" -f2']);
+%if (retval)
+%  val=[];
+%else
+%  val = strtrim(val);
+%end
+
 end


### PR DESCRIPTION
Dear @david-german-tri,

The oncall build cop, @jamiesnape, believes that your PR #2599 may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration on presubmit, because additional
platforms and tests are built in postsubmit.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/job/windows-msvc-ninja-64-continuous-matlab/212/


Therefore, the build cop has created this revert PR and started a complete
postsubmit build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly Oncall Buildcop :cop:

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert