### PR TITLE
lcm: Avoid Debug compilation on Windows due to conflict with Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,17 @@ set(lcm_ADDITIONAL_CMAKE_CONFIGURE_ARGS -DBUILD_SHARED_LIBS=ON)
 if(WITH_GTK)
   set(lcm_ADDITIONAL_CMAKE_CONFIGURE_ARGS ${lcm_ADDITIONAL_CMAKE_CONFIGURE_ARGS} -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_SOURCE_DIR}/externals/gtk/gtk3)
 endif()
+if(WIN32)
+  # On Windows we always need a Release LCM for compatibility with Python libraries.
+  if(CMAKE_CONFIGURATION_TYPES)
+    # This is a multi-config generator, so we need to specify the configuration at build time.
+    set(lcm_BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release)
+    set(lcm_INSTALL_COMMAND ${CMAKE_COMMAND} --build . --config Release --target install)
+  else()
+    # This is a single-config generator, so we need to specify the configuration to CMake.
+    list(APPEND lcm_ADDITIONAL_CMAKE_CONFIGURE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release)
+  endif()
+endif()
 set(libbot_IS_CMAKE_POD TRUE)
 set(libbot_IS_PUBLIC TRUE)
 set(bot_core_lcmtypes_IS_CMAKE_POD TRUE)
@@ -372,12 +383,21 @@ foreach(proj ${EXTERNAL_PROJECTS})
       if(CMAKE_VERBOSE_MAKEFILE)
         set(PODS_VERBOSE_MAKEFILE "-DCMAKE_VERBOSE_MAKEFILE=ON")
       endif()
+      foreach(c BUILD INSTALL)
+        if(DEFINED ${proj}_${c}_COMMAND)
+          set(maybe_${c}_COMMAND ${c}_COMMAND ${${proj}_${c}_COMMAND})
+        else()
+          set(maybe_${c}_COMMAND "")
+        endif()
+      endforeach()
       ExternalProject_Add(${proj}
         SOURCE_DIR ${${proj}_SOURCE_DIR}
         BINARY_DIR ${${proj}_BINARY_DIR}
         DOWNLOAD_COMMAND ${${proj}_DOWNLOAD_COMMAND}
         DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}
         UPDATE_COMMAND ${${proj}_UPDATE_COMMAND}
+        ${maybe_BUILD_COMMAND}
+        ${maybe_INSTALL_COMMAND}
         BUILD_ALWAYS 1
         INDEPENDENT_STEP_TARGETS update
         DEPENDS ${deps}


### PR DESCRIPTION
The Debug configuration of lcm cannot compile on Windows because the Python debug library (`python27_d.lib`) is not generally available.  Always compile the lcm external in its Release configuration on Windows.

Fixes #2726.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2854)
<!-- Reviewable:end -->
