### PR TITLE
Put the DLL dependencies of MEX files on the MATLAB path on Windows.

### DIFF
--- a/drake/addpath_drake.m
+++ b/drake/addpath_drake.m
@@ -87,7 +87,7 @@ if (strcmp(computer('arch'),'maci64'))
 end
 
 if ispc
-  setenv('PATH',[getenv('PATH'),';',GetFullPath(pods_get_lib_path),';',fullfile(get_drake_install_dir(),'lib','Release')]);
+  setenv('PATH',[getenv('PATH'),';',GetFullPath(pods_get_lib_path),';',fullfile(get_drake_binary_dir(),'lib','Release'),';',fullfile(get_drake_binary_dir(),'lib')]);
 end
 
 


### PR DESCRIPTION
I believe this will resolve the post-#2599 Windows continuous build breakage.  If so, it will supersede #2853.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2857)
<!-- Reviewable:end -->
