### PR TITLE
Use CMP0054 NEW

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.5)
 
 cmake_policy(SET CMP0025 NEW)
 cmake_policy(SET CMP0042 NEW)
-cmake_policy(SET CMP0054 OLD)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
   message(FATAL_ERROR "GCC version must be at least 4.9")


### PR DESCRIPTION
Remove setting [`CMP0054`](https://cmake.org/cmake/help/v3.5/policy/CMP0054.html) (to `OLD`), which, with our `cmake_minimum_required`, gives us the `NEW` policy. `CMP0054` affects code that is almost always wrong under the `OLD` behavior. In particular, it was being tripped by `swig_add_module` in an instance where the `OLD` behavior does indeed appear to be unintended.

At this time, I'm not aware of any other effect of this policy. Any instances needing the `OLD` behavior are trivially fixed by removing quotes (that shouldn't be present anyway for such cases!), and new code won't be tripped up by the issue that `CMP0054` fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2860)
<!-- Reviewable:end -->
