### PR TITLE
Toward #2852: start to enforce -Werror=shadow.

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -91,6 +91,12 @@ include_directories(BEFORE ${PROJECT_SOURCE_DIR}/..)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all -Werror=ignored-qualifiers")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # TODO(#2852) Turn on shadow checking for g++ once we use a version that fixes
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=shadow")
+  endif()
+  set(CXX_FLAGS_NO_ERROR_SHADOW "-Wno-error=shadow -Wno-shadow")
   set(CXX_FLAGS_NO_SIGN_COMPARE "-Wno-sign-compare")
 elseif(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251")
@@ -118,6 +124,7 @@ elseif(MSVC)
 
   add_definitions(-D_USE_MATH_DEFINES) # to get math constants on MSVC (see https://msdn.microsoft.com/en-us/library/4hwaceh6.aspx)
 
+  set(CXX_FLAGS_NO_ERROR_SHADOW "/wd4456 /wd4457")
   set(CXX_FLAGS_NO_SIGN_COMPARE "/wd4018")
 endif()
 

--- a/drake/bindings/swig/CMakeLists.txt
+++ b/drake/bindings/swig/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "-w315,-401")
 set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "-w503")
 # The autodiff.i in swig has for-loop variable warnings.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_SIGN_COMPARE}")
+# SWIG output code makes expansive use of variable shadowing.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Suppresses warnings due to the existence of deprecated methods. These

--- a/drake/examples/CMakeLists.txt
+++ b/drake/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
 # TODO(#2372) These are warnings that we can't handle yet.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_SIGN_COMPARE}")
+# TODO(#2852) We can't yet handle shadowing as a compiler error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
 
 add_matlab_test(NAME examples/CubicPolynomialExample.findFixedPointTest COMMAND CubicPolynomialExample.findFixedPointTest)
 add_matlab_test(NAME examples/CubicPolynomialExample.animate COMMAND CubicPolynomialExample.animate)

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -1,3 +1,6 @@
+# TODO(#2852) We can't yet handle shadowing as a compiler error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
+
 pods_find_pkg_config(gurobi)
 
 if(gurobi_FOUND)

--- a/drake/systems/LCMSystem.h
+++ b/drake/systems/LCMSystem.h
@@ -179,7 +179,7 @@ class LCMOutputSystem<
   template <typename ScalarType>
   using OutputVector = NullVector<ScalarType>;
 
-  explicit LCMOutputSystem(std::shared_ptr<lcm::LCM> lcm) : lcm(lcm) {}
+  explicit LCMOutputSystem(std::shared_ptr<lcm::LCM> lcm) : lcm_(lcm) {}
 
   StateVector<double> dynamics(const double &t, const StateVector<double> &x,
                                const InputVector<double> &u) const {
@@ -192,12 +192,12 @@ class LCMOutputSystem<
     if (!encode(t, u, msg))
       throw std::runtime_error(std::string("failed to encode") +
                                msg.getTypeName());
-    lcm->publish(u.channel(), &msg);
+    lcm_->publish(u.channel(), &msg);
     return OutputVector<double>();
   }
 
  private:
-  const std::shared_ptr<lcm::LCM> lcm;
+  const std::shared_ptr<lcm::LCM> lcm_;
 };
 
 // todo: template specialization for the CombinedVector case

--- a/drake/systems/controllers/CMakeLists.txt
+++ b/drake/systems/controllers/CMakeLists.txt
@@ -1,3 +1,5 @@
+# TODO(#2852) We can't yet handle shadowing as a compiler error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
 
 drake_install_headers(LQR.h)
 

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -1,3 +1,6 @@
+# TODO(#2852) We can't yet handle shadowing as a compiler error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
+
 # IMPORTANT NOTE!!
 # matlab has it's own boost libraries.  DO NOT let any mex file depend
 # on the system boost (directly nor indirectly), or you're asking for trouble.

--- a/drake/systems/robotInterfaces/CMakeLists.txt
+++ b/drake/systems/robotInterfaces/CMakeLists.txt
@@ -1,3 +1,5 @@
+# TODO(#2852) We can't yet handle shadowing as a compiler error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
 
 add_library_with_exports(LIB_NAME drakeSide SOURCE_FILES Side.cpp)
 drake_install_headers(Side.h)

--- a/drake/systems/test/CMakeLists.txt
+++ b/drake/systems/test/CMakeLists.txt
@@ -1,3 +1,6 @@
+# TODO(#2852) We can't yet handle shadowing as a compiler error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
+
 add_executable(testAffineSystem testAffineSystem.cpp)
 add_test(NAME testAffineSystem COMMAND testAffineSystem)
 target_link_libraries(testAffineSystem drakeCommon)

--- a/drake/systems/trajectories/CMakeLists.txt
+++ b/drake/systems/trajectories/CMakeLists.txt
@@ -1,3 +1,5 @@
+# TODO(#2852) We can't yet handle shadowing as a compile error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
 
 if(MATLAB_FOUND)
   add_mex(PPTmex PPTmex.cpp)

--- a/drake/util/CMakeLists.txt
+++ b/drake/util/CMakeLists.txt
@@ -1,3 +1,6 @@
+# TODO(#2852) We can't yet handle shadowing as a compiler error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
+
 if(simulink_FOUND)
   add_mex(realtime realtime.cpp)
 endif()

--- a/drake/util/test/testPolynomial.cpp
+++ b/drake/util/test/testPolynomial.cpp
@@ -111,8 +111,8 @@ void testRoots() {
     Polynomial<CoefficientType> poly(coeffs);
     auto roots = poly.roots();
     valuecheck<Eigen::Index>(roots.rows(), poly.getDegree());
-    for (int i = 0; i < roots.size(); i++) {
-      auto value = poly.evaluateUnivariate(roots[i]);
+    for (int k = 0; k < roots.size(); k++) {
+      auto value = poly.evaluateUnivariate(roots[k]);
       valuecheck(std::abs(value), 0.0, 1e-8);
     }
   }


### PR DESCRIPTION
 * Enable it at the top level, with excuses for specific subtrees.
 * Do it for clang only, as the g++-4.9 implementation is broken.
 * For now, only define the disable formula for MSVC.
 * Fix a few very easy instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2867)
<!-- Reviewable:end -->
