### PR TITLE
Added dictionary of LCM translators that's indexed by channel name.

### DIFF
--- a/drake/systems/lcm/CMakeLists.txt
+++ b/drake/systems/lcm/CMakeLists.txt
@@ -3,6 +3,7 @@ if(lcm_FOUND)
     lcm_receive_thread.cc
     lcm_publisher_system.cc
     lcm_subscriber_system.cc
+    lcm_translator_dictionary.cc
     translator_between_lcmt_drake_signal.cc)
   add_dependencies(drakeLCMSystem2 drake_lcmtypes_hpp)
   target_link_libraries(drakeLCMSystem2
@@ -18,6 +19,7 @@ if(lcm_FOUND)
     lcm_receive_thread.h
     lcm_publisher_system.h
     lcm_subscriber_system.h
+    lcm_translator_dictionary.h
     lcm_and_vector_interface_translator.h
     translator_between_lcmt_drake_signal.h)
   pods_install_pkg_config_file(drake-lcm-system2

--- a/drake/systems/lcm/lcm_publisher_system.cc
+++ b/drake/systems/lcm/lcm_publisher_system.cc
@@ -19,9 +19,10 @@ LcmPublisherSystem::LcmPublisherSystem(
 LcmPublisherSystem::LcmPublisherSystem(
     const std::string& channel,
     const LcmTranslatorDictionary& translator_dictionary, ::lcm::LCM* lcm)
-    : channel_(channel),
-      translator_(translator_dictionary.GetTranslator(channel)),
-      lcm_(lcm) {}
+    : LcmPublisherSystem(
+          channel,
+          translator_dictionary.GetTranslator(channel),
+          lcm) {}
 
 LcmPublisherSystem::~LcmPublisherSystem() {}
 

--- a/drake/systems/lcm/lcm_publisher_system.cc
+++ b/drake/systems/lcm/lcm_publisher_system.cc
@@ -16,6 +16,13 @@ LcmPublisherSystem::LcmPublisherSystem(
     const LcmAndVectorInterfaceTranslator& translator, ::lcm::LCM* lcm)
     : channel_(channel), translator_(translator), lcm_(lcm) {}
 
+LcmPublisherSystem::LcmPublisherSystem(
+    const std::string& channel,
+    const LcmTranslatorDictionary& translator_dictionary, ::lcm::LCM* lcm)
+    : channel_(channel),
+      translator_(translator_dictionary.GetTranslator(channel)),
+      lcm_(lcm) {}
+
 LcmPublisherSystem::~LcmPublisherSystem() {}
 
 std::string LcmPublisherSystem::get_name() const {

--- a/drake/systems/lcm/lcm_publisher_system.h
+++ b/drake/systems/lcm/lcm_publisher_system.h
@@ -6,6 +6,7 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system_interface.h"
 #include "drake/systems/lcm/lcm_and_vector_interface_translator.h"
+#include "drake/systems/lcm/lcm_translator_dictionary.h"
 
 namespace drake {
 namespace systems {
@@ -32,6 +33,21 @@ class DRAKELCMSYSTEM2_EXPORT LcmPublisherSystem :
   LcmPublisherSystem(const std::string& channel,
                      const LcmAndVectorInterfaceTranslator& translator,
                      ::lcm::LCM* lcm);
+
+  /**
+   * The constructor.
+   *
+   * @param[in] channel The LCM channel on which to publish.
+   *
+   * @param[in] translator_dictionary A dictionary for obtaining the appropriate
+   * translator for a particular LCM channel.
+   *
+   * @param[in] lcm A pointer to the LCM subsystem.
+   */
+  LcmPublisherSystem(const std::string& channel,
+                     const LcmTranslatorDictionary& translator_dictionary,
+                     ::lcm::LCM* lcm);
+
 
   ~LcmPublisherSystem() override;
 

--- a/drake/systems/lcm/lcm_publisher_system.h
+++ b/drake/systems/lcm/lcm_publisher_system.h
@@ -19,7 +19,7 @@ class DRAKELCMSYSTEM2_EXPORT LcmPublisherSystem :
     public SystemInterface<double> {
  public:
   /**
-   * The constructor.
+   * A constructor.
    *
    * @param[in] channel The LCM channel on which to publish.
    *
@@ -35,7 +35,7 @@ class DRAKELCMSYSTEM2_EXPORT LcmPublisherSystem :
                      ::lcm::LCM* lcm);
 
   /**
-   * The constructor.
+   * A constructor.
    *
    * @param[in] channel The LCM channel on which to publish.
    *

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -25,6 +25,16 @@ LcmSubscriberSystem::LcmSubscriberSystem(
   sub->setQueueCapacity(1);
 }
 
+LcmSubscriberSystem::LcmSubscriberSystem(
+    const std::string& channel,
+    const LcmTranslatorDictionary& translator_dictionary,
+    ::lcm::LCM* lcm)
+    : LcmSubscriberSystem(
+          channel,
+          translator_dictionary.GetTranslator(channel),
+          lcm) {
+}
+
 LcmSubscriberSystem::~LcmSubscriberSystem() {}
 
 std::string LcmSubscriberSystem::get_name() const {

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -10,6 +10,7 @@
 #include "drake/systems/framework/system_interface.h"
 #include "drake/systems/lcm/lcm_and_vector_interface_translator.h"
 #include "drake/systems/lcm/lcm_receive_thread.h"
+#include "drake/systems/lcm/lcm_translator_dictionary.h"
 
 namespace drake {
 namespace systems {
@@ -24,7 +25,7 @@ class DRAKELCMSYSTEM2_EXPORT LcmSubscriberSystem :
     public SystemInterface<double> {
  public:
   /**
-   * The constructor.
+   * A constructor.
    *
    * @param[in] channel The LCM channel on which to subscribe.
    *
@@ -39,6 +40,21 @@ class DRAKELCMSYSTEM2_EXPORT LcmSubscriberSystem :
    */
   LcmSubscriberSystem(const std::string& channel,
                       const LcmAndVectorInterfaceTranslator& translator,
+                      ::lcm::LCM* lcm);
+
+  /**
+   * A constructor.
+   *
+   * @param[in] channel The LCM channel on which to subscribe.
+   *
+   * @param[in] translator_dictionary A dictionary for obtaining the appropriate
+   * translator for a particular LCM channel.
+   *
+   * @param[in] lcm A pointer to the LCM subsystem. This pointer must not be
+   * null.
+   */
+  LcmSubscriberSystem(const std::string& channel,
+                      const LcmTranslatorDictionary& translator_dictionary,
                       ::lcm::LCM* lcm);
 
   ~LcmSubscriberSystem() override;

--- a/drake/systems/lcm/lcm_translator_dictionary.cc
+++ b/drake/systems/lcm/lcm_translator_dictionary.cc
@@ -26,7 +26,7 @@ bool LcmTranslatorDictionary::HasTranslator(const std::string& channel_name)
 const LcmAndVectorInterfaceTranslator& LcmTranslatorDictionary::GetTranslator(
     const std::string& channel_name) const {
   if (HasTranslator(channel_name)) {
-    return *(dictionary_[channel_name].get());
+    return *(dictionary_.find(channel_name)->second.get());
   } else {
     throw std::runtime_error(
       "Translator for channel \"" + channel_name + "\" does not exist.");

--- a/drake/systems/lcm/lcm_translator_dictionary.cc
+++ b/drake/systems/lcm/lcm_translator_dictionary.cc
@@ -1,0 +1,38 @@
+#include "drake/systems/lcm/lcm_translator_dictionary.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+
+void LcmTranslatorDictionary::AddEntry(const std::string& channel_name,
+    std::unique_ptr<const LcmAndVectorInterfaceTranslator> translator) {
+  if (HasTranslator(channel_name)) {
+    dictionary_[channel_name] = std::move(translator);
+  } else {
+    throw std::runtime_error(
+      "Attempted to add more than one translator for channel \"" + channel_name
+      + "\".");
+  }
+}
+
+bool LcmTranslatorDictionary::HasTranslator(const std::string& channel_name)
+    const {
+  return dictionary_.find(channel_name) != dictionary_.end();
+}
+
+/**
+* Returns a reference to the translator to use with the specified channel.
+*/
+const LcmAndVectorInterfaceTranslator& LcmTranslatorDictionary::GetTranslator(
+    const std::string& channel_name) const {
+  if (HasTranslator(channel_name)) {
+    return *(dictionary_[channel_name].get());
+  } else {
+    throw std::runtime_error(
+      "Translator for channel \"" + channel_name + "\" does not exist.");
+  }
+}
+
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/lcm/lcm_translator_dictionary.cc
+++ b/drake/systems/lcm/lcm_translator_dictionary.cc
@@ -4,19 +4,20 @@ namespace drake {
 namespace systems {
 namespace lcm {
 
-void LcmTranslatorDictionary::AddEntry(const std::string& channel_name,
+void LcmTranslatorDictionary::AddEntry(
+    const std::string& channel_name,
     std::unique_ptr<const LcmAndVectorInterfaceTranslator> translator) {
   if (!HasTranslator(channel_name)) {
     dictionary_[channel_name] = std::move(translator);
   } else {
     throw std::runtime_error(
-      "Attempted to add more than one translator for channel \"" + channel_name
-      + "\".");
+        "Attempted to add more than one translator for channel \"" +
+        channel_name + "\".");
   }
 }
 
-bool LcmTranslatorDictionary::HasTranslator(const std::string& channel_name)
-    const {
+bool LcmTranslatorDictionary::HasTranslator(
+    const std::string& channel_name) const {
   return dictionary_.find(channel_name) != dictionary_.end();
 }
 
@@ -28,8 +29,8 @@ const LcmAndVectorInterfaceTranslator& LcmTranslatorDictionary::GetTranslator(
   if (HasTranslator(channel_name)) {
     return *(dictionary_.find(channel_name)->second.get());
   } else {
-    throw std::runtime_error(
-      "Translator for channel \"" + channel_name + "\" does not exist.");
+    throw std::runtime_error("Translator for channel \"" + channel_name +
+                             "\" does not exist.");
   }
 }
 

--- a/drake/systems/lcm/lcm_translator_dictionary.cc
+++ b/drake/systems/lcm/lcm_translator_dictionary.cc
@@ -6,7 +6,7 @@ namespace lcm {
 
 void LcmTranslatorDictionary::AddEntry(const std::string& channel_name,
     std::unique_ptr<const LcmAndVectorInterfaceTranslator> translator) {
-  if (HasTranslator(channel_name)) {
+  if (!HasTranslator(channel_name)) {
     dictionary_[channel_name] = std::move(translator);
   } else {
     throw std::runtime_error(

--- a/drake/systems/lcm/lcm_translator_dictionary.cc
+++ b/drake/systems/lcm/lcm_translator_dictionary.cc
@@ -21,8 +21,8 @@ bool LcmTranslatorDictionary::HasTranslator(const std::string& channel_name)
 }
 
 /**
-* Returns a reference to the translator to use with the specified channel.
-*/
+ * Returns a reference to the translator to use with the specified channel.
+ */
 const LcmAndVectorInterfaceTranslator& LcmTranslatorDictionary::GetTranslator(
     const std::string& channel_name) const {
   if (HasTranslator(channel_name)) {

--- a/drake/systems/lcm/lcm_translator_dictionary.h
+++ b/drake/systems/lcm/lcm_translator_dictionary.h
@@ -24,6 +24,11 @@ namespace lcm {
 class DRAKELCMSYSTEM2_EXPORT LcmTranslatorDictionary {
  public:
   /**
+   * The constructor. The dictionary is initially empty.
+   */
+  LcmTranslatorDictionary() {}
+
+  /**
    * Adds a translator this dictionary.
    *
    * @param[in] channel_name The name of the LCM channel. Messages sent on and

--- a/drake/systems/lcm/lcm_translator_dictionary.h
+++ b/drake/systems/lcm/lcm_translator_dictionary.h
@@ -1,15 +1,13 @@
 #pragma once
 
 #include <map>
+#include <memory>
+#include <string>
 
 #include <lcm/lcm-cpp.hpp>
 
 #include "drake/drakeLCMSystem2_export.h"
-#include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/context.h"
-#include "drake/systems/framework/system_interface.h"
 #include "drake/systems/lcm/lcm_and_vector_interface_translator.h"
-#include "drake/systems/lcm/lcm_receive_thread.h"
 
 namespace drake {
 namespace systems {
@@ -32,7 +30,7 @@ class DRAKELCMSYSTEM2_EXPORT LcmTranslatorDictionary {
    * Adds a translator this dictionary.
    *
    * @param[in] channel_name The name of the LCM channel. Messages sent on and
-   * received from this channel are assumed to be compatibl with @p translator.
+   * received from this channel are assumed to be compatible with @p translator.
    *
    * @param[in] translator A pointer to the translator to use with the LCM
    * channel.
@@ -51,6 +49,11 @@ class DRAKELCMSYSTEM2_EXPORT LcmTranslatorDictionary {
 
   /**
    * Returns a reference to the translator to use with the specified channel.
+   * This reference is guaranteed to remain valid for the lifetime of this
+   * dictionary.
+   *
+   * @throws std::runtime_error if a translator for @p channel_name does not
+   * exist in this dictionary.
    */
   const LcmAndVectorInterfaceTranslator& GetTranslator(
       const std::string& channel_name) const;

--- a/drake/systems/lcm/lcm_translator_dictionary.h
+++ b/drake/systems/lcm/lcm_translator_dictionary.h
@@ -38,8 +38,9 @@ class DRAKELCMSYSTEM2_EXPORT LcmTranslatorDictionary {
    * @throws std::runtime_error If a translator for the @p channel_name is
    * already in the dictionary.
    */
-  void AddEntry(const std::string& channel_name,
-    std::unique_ptr<const LcmAndVectorInterfaceTranslator> translator);
+  void AddEntry(
+      const std::string& channel_name,
+      std::unique_ptr<const LcmAndVectorInterfaceTranslator> translator);
 
   /**
    * Returns true if and only if a translator for @p channel_name exists in the
@@ -59,8 +60,7 @@ class DRAKELCMSYSTEM2_EXPORT LcmTranslatorDictionary {
       const std::string& channel_name) const;
 
   // Disable copy and assign.
-  LcmTranslatorDictionary(const LcmTranslatorDictionary&)
-      = delete;
+  LcmTranslatorDictionary(const LcmTranslatorDictionary&) = delete;
   LcmTranslatorDictionary& operator=(const LcmTranslatorDictionary&) = delete;
 
  private:

--- a/drake/systems/lcm/lcm_translator_dictionary.h
+++ b/drake/systems/lcm/lcm_translator_dictionary.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <map>
+
+#include <lcm/lcm-cpp.hpp>
+
+#include "drake/drakeLCMSystem2_export.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/system_interface.h"
+#include "drake/systems/lcm/lcm_and_vector_interface_translator.h"
+#include "drake/systems/lcm/lcm_receive_thread.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+
+/**
+ * A dictionary that maps between LCM channel names and translators that
+ * convert between LCM message objects and VectorInterface objects. All
+ * translators contained within the dictionary are guaranteed to remain in
+ * existence throughout the lifespan of this object.
+ */
+class DRAKELCMSYSTEM2_EXPORT LcmTranslatorDictionary {
+ public:
+  /**
+   * Adds a translator this dictionary.
+   *
+   * @param[in] channel_name The name of the LCM channel. Messages sent on and
+   * received from this channel are assumed to be compatibl with @p translator.
+   *
+   * @param[in] translator A pointer to the translator to use with the LCM
+   * channel.
+   *
+   * @throws std::runtime_error If a translator for the @p channel_name is
+   * already in the dictionary.
+   */
+  void AddEntry(const std::string& channel_name,
+    std::unique_ptr<const LcmAndVectorInterfaceTranslator> translator);
+
+  /**
+   * Returns true if and only if a translator for @p channel_name exists in the
+   * dictionary.
+   */
+  bool HasTranslator(const std::string& channel_name) const;
+
+  /**
+   * Returns a reference to the translator to use with the specified channel.
+   */
+  const LcmAndVectorInterfaceTranslator& GetTranslator(
+      const std::string& channel_name) const;
+
+  // Disable copy and assign.
+  LcmTranslatorDictionary(const LcmTranslatorDictionary&)
+      = delete;
+  LcmTranslatorDictionary& operator=(const LcmTranslatorDictionary&) = delete;
+
+ private:
+  // This is the internal data structure for holding the translators and their
+  // associated channel names.
+  std::map<std::string, std::unique_ptr<const LcmAndVectorInterfaceTranslator>>
+      dictionary_;
+};
+
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/lcm/test/CMakeLists.txt
+++ b/drake/systems/lcm/test/CMakeLists.txt
@@ -10,4 +10,12 @@ if(lcm_FOUND)
     drakeLCMSystem2
     ${GTEST_BOTH_LIBRARIES})
   add_test(NAME lcm_publisher_system_test COMMAND lcm_publisher_system_test)
+
+  add_executable(lcm_translator_dictionary_test
+    lcm_translator_dictionary_test.cc)
+  target_link_libraries(lcm_translator_dictionary_test
+    drakeLCMSystem2
+    ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME lcm_translator_dictionary_test COMMAND
+    lcm_translator_dictionary_test)
 endif()

--- a/drake/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/drake/systems/lcm/test/lcm_publisher_system_test.cc
@@ -185,8 +185,8 @@ GTEST_TEST(LcmPublisherSystemTest, PublishTest) {
 GTEST_TEST(LcmPublisherSystemTest, PublishTestUsingDictionary) {
   ::lcm::LCM lcm;
   std::string channel_name = "drake_system2_lcm_test_publisher_channel_name";
-  TranslatorBetweenLcmtDrakeSignal translator(kDim);
 
+  // Creates a dictionary with one translator.
   LcmTranslatorDictionary dictionary;
   dictionary.AddEntry(channel_name,
     std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));

--- a/drake/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/drake/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -157,9 +157,8 @@ GTEST_TEST(LcmSubscriberSystemTest, ReceiveTest) {
   // drake::lcmt_drake_signal and outputs System 2.0 Vectors of type
   // drake::systems::BasicVector.
   //
-  // It then verifies that the LcmSubscriberSystem was successfully stored
-  // in a unique_ptr. The unique_ptr variable is called "dut" to indicate it is
-  // the "device under test".
+  // The LcmSubscriberSystem is called "dut" to indicate it is the
+  // "device under test".
   LcmSubscriberSystem dut(channel_name, translator, &lcm);
 
   TestSubscriber(&lcm, channel_name, &dut);
@@ -182,9 +181,8 @@ GTEST_TEST(LcmSubscriberSystemTest, ReceiveTestUsingDictionary) {
   // drake::lcmt_drake_signal and outputs System 2.0 Vectors of type
   // drake::systems::BasicVector.
   //
-  // It then verifies that the LcmSubscriberSystem was successfully stored
-  // in a unique_ptr. The unique_ptr variable is called "dut" to indicate it is
-  // the "device under test".
+  // The LcmSubscriberSystem is called "dut" to indicate it is the
+  // "device under test".
   LcmSubscriberSystem dut(channel_name, dictionary, &lcm);
 
   TestSubscriber(&lcm, channel_name, &dut);

--- a/drake/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/drake/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -62,33 +62,13 @@ class MessagePublisher {
   std::unique_ptr<std::thread> thread_;
 };
 
-// Tests the functionality of LcmSubscriberSystem.
-GTEST_TEST(LcmSubscriberSystemTest, ReceiveTest) {
-  // Instantiates LCM.
-  ::lcm::LCM lcm;
-
-  // Defines a channel name.
-  const std::string channel_name =
-      "drake_system2_lcm_test_subscriber_channel_name";
-
-  // Instantiates a LCM-VectorInterface translator.
-  const TranslatorBetweenLcmtDrakeSignal translator(kDim);
-
-  // Instantiates an LcmSubscriberSystem that receives LCM messages of type
-  // drake::lcmt_drake_signal and outputs System 2.0 Vectors of type
-  // drake::systems::BasicVector.
-  //
-  // It then verifies that the LcmSubscriberSystem was successfully stored
-  // in a unique_ptr. The unique_ptr variable is called "dut" to indicate it is
-  // the "device under test".
-  std::unique_ptr<LcmSubscriberSystem> dut(
-      new LcmSubscriberSystem(channel_name, translator, &lcm));
-
+void TestSubscriber(::lcm::LCM* lcm, const std::string& channel_name,
+   LcmSubscriberSystem* dut) {
   EXPECT_EQ(dut->get_name(), "LcmSubscriberSystem::" + channel_name);
 
   // Instantiates a publisher of lcmt_drake_signal messages on the LCM network.
   // network.
-  MessagePublisher publisher(channel_name, &lcm);
+  MessagePublisher publisher(channel_name, lcm);
   publisher.Start();
 
   std::unique_ptr<Context<double>> context = dut->CreateDefaultContext();
@@ -99,7 +79,7 @@ GTEST_TEST(LcmSubscriberSystemTest, ReceiveTest) {
   // construction, this ensures the LCM receive thread stops before any
   // resources it uses are destroyed. If the Lcm receive thread is stopped after
   // the resources it relies on are destroyed, a segmentation fault may occur.
-  LcmReceiveThread lcm_receive_thread(&lcm);
+  LcmReceiveThread lcm_receive_thread(lcm);
 
   // Whether the LcmSubscriberSystem successfully received an LCM message and
   // outputted it as a BasicVector.
@@ -159,6 +139,55 @@ GTEST_TEST(LcmSubscriberSystemTest, ReceiveTest) {
   EXPECT_TRUE(done);
 
   publisher.Stop();
+}
+
+// Tests the functionality of LcmSubscriberSystem.
+GTEST_TEST(LcmSubscriberSystemTest, ReceiveTest) {
+  // Instantiates LCM.
+  ::lcm::LCM lcm;
+
+  // Defines a channel name.
+  const std::string channel_name =
+      "drake_system2_lcm_test_subscriber_channel_name";
+
+  // Instantiates a LCM-VectorInterface translator.
+  const TranslatorBetweenLcmtDrakeSignal translator(kDim);
+
+  // Instantiates an LcmSubscriberSystem that receives LCM messages of type
+  // drake::lcmt_drake_signal and outputs System 2.0 Vectors of type
+  // drake::systems::BasicVector.
+  //
+  // It then verifies that the LcmSubscriberSystem was successfully stored
+  // in a unique_ptr. The unique_ptr variable is called "dut" to indicate it is
+  // the "device under test".
+  LcmSubscriberSystem dut(channel_name, translator, &lcm);
+
+  TestSubscriber(&lcm, channel_name, &dut);
+}
+
+// Tests the functionality of LcmSubscriberSystem.
+GTEST_TEST(LcmSubscriberSystemTest, ReceiveTestUsingDictionary) {
+  // Instantiates LCM.
+  ::lcm::LCM lcm;
+
+  // Defines a channel name.
+  const std::string channel_name =
+      "drake_system2_lcm_test_subscriber_channel_name";
+
+  LcmTranslatorDictionary dictionary;
+  dictionary.AddEntry(channel_name,
+    std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
+
+  // Instantiates an LcmSubscriberSystem that receives LCM messages of type
+  // drake::lcmt_drake_signal and outputs System 2.0 Vectors of type
+  // drake::systems::BasicVector.
+  //
+  // It then verifies that the LcmSubscriberSystem was successfully stored
+  // in a unique_ptr. The unique_ptr variable is called "dut" to indicate it is
+  // the "device under test".
+  LcmSubscriberSystem dut(channel_name, dictionary, &lcm);
+
+  TestSubscriber(&lcm, channel_name, &dut);
 }
 
 }  // namespace

--- a/drake/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/drake/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -173,9 +173,12 @@ GTEST_TEST(LcmSubscriberSystemTest, ReceiveTestUsingDictionary) {
   const std::string channel_name =
       "drake_system2_lcm_test_subscriber_channel_name";
 
+  // Creates a dictionary with one translator.
   LcmTranslatorDictionary dictionary;
   dictionary.AddEntry(channel_name,
     std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
+
+  EXPECT_TRUE(dictionary.HasTranslator(channel_name));
 
   // Instantiates an LcmSubscriberSystem that receives LCM messages of type
   // drake::lcmt_drake_signal and outputs System 2.0 Vectors of type

--- a/drake/systems/lcm/test/lcm_translator_dictionary_test.cc
+++ b/drake/systems/lcm/test/lcm_translator_dictionary_test.cc
@@ -1,0 +1,48 @@
+#include "gtest/gtest.h"
+
+#include "drake/systems/lcm/lcm_translator_dictionary.h"
+#include "drake/systems/lcm/translator_between_lcmt_drake_signal.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+namespace {
+
+// Defines the dimension of the VectorInterface used by the translator defined
+// below.
+const int kDim = 10;
+
+// Tests the functionality of LcmSubscriberSystem.
+GTEST_TEST(LcmTranslatorDictionaryTest, BasicTests) {
+  // Defines a channel name.
+  const std::string channel_name = "_=?+pYa8J9c!Hg;V";
+
+  // Creates a dictionary with one translator for the above-defined channel
+  // name.
+  LcmTranslatorDictionary dictionary;
+  dictionary.AddEntry(channel_name,
+    std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
+
+  // Verifies that an exception is thrown when the user attempts to add a
+  // duplicate translator to the dictionary.
+  EXPECT_THROW(dictionary.AddEntry(channel_name,
+      std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim)),
+          std::runtime_error);
+
+  EXPECT_FALSE(dictionary.HasTranslator("Boo"));
+  EXPECT_TRUE(dictionary.HasTranslator(channel_name));
+
+  // Verifies that an exception is thrown if the user attempts to get a
+  // translator that does not exist in the dictionary.
+  EXPECT_THROW(dictionary.GetTranslator("Boo"), std::runtime_error);
+
+  // Verifies that no exception is thrown if the user attempts to get a
+  // translator that exists in the dictionary.
+  EXPECT_NO_THROW(dictionary.GetTranslator(channel_name));
+
+}
+
+}  // namespace
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/lcm/test/lcm_translator_dictionary_test.cc
+++ b/drake/systems/lcm/test/lcm_translator_dictionary_test.cc
@@ -12,7 +12,7 @@ namespace {
 // below.
 const int kDim = 10;
 
-// Tests the functionality of LcmSubscriberSystem.
+// Tests the functionality of LcmTranslatorDictionary.
 GTEST_TEST(LcmTranslatorDictionaryTest, BasicTests) {
   // Defines a channel name.
   const std::string channel_name = "_=?+pYa8J9c!Hg;V";

--- a/drake/systems/lcm/test/lcm_translator_dictionary_test.cc
+++ b/drake/systems/lcm/test/lcm_translator_dictionary_test.cc
@@ -20,14 +20,17 @@ GTEST_TEST(LcmTranslatorDictionaryTest, BasicTests) {
   // Creates a dictionary with one translator for the above-defined channel
   // name.
   LcmTranslatorDictionary dictionary;
-  dictionary.AddEntry(channel_name,
-    std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
+  dictionary.AddEntry(
+      channel_name,
+      std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
 
   // Verifies that an exception is thrown when the user attempts to add a
   // duplicate translator to the dictionary.
-  EXPECT_THROW(dictionary.AddEntry(channel_name,
-      std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim)),
-          std::runtime_error);
+  EXPECT_THROW(
+      dictionary.AddEntry(
+          channel_name,
+          std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim)),
+      std::runtime_error);
 
   EXPECT_FALSE(dictionary.HasTranslator("Boo"));
   EXPECT_TRUE(dictionary.HasTranslator(channel_name));

--- a/drake/systems/lcm/test/lcm_translator_dictionary_test.cc
+++ b/drake/systems/lcm/test/lcm_translator_dictionary_test.cc
@@ -39,7 +39,6 @@ GTEST_TEST(LcmTranslatorDictionaryTest, BasicTests) {
   // Verifies that no exception is thrown if the user attempts to get a
   // translator that exists in the dictionary.
   EXPECT_NO_THROW(dictionary.GetTranslator(channel_name));
-
 }
 
 }  // namespace


### PR DESCRIPTION
The translator to use can now be determined based on the channel name using a dictionary that the user defines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2871)
<!-- Reviewable:end -->
