### PR TITLE
Fix sign-compare warnings in examples

### DIFF
--- a/drake/examples/CMakeLists.txt
+++ b/drake/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
-# TODO(#2372) These are warnings that we can't handle yet.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_SIGN_COMPARE}")
 # TODO(#2852) We can't yet handle shadowing as a compiler error.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
 

--- a/drake/examples/Cars/car_simulation.cc
+++ b/drake/examples/Cars/car_simulation.cc
@@ -117,7 +117,8 @@ CreateVehicleSystem(std::shared_ptr<RigidBodySystem> rigid_body_sys) {
       tree->number_of_positions() + tree->number_of_velocities(), 3);
   map_driving_cmd_to_x_d.setZero();
 
-  for (int actuator_idx = 0; actuator_idx < tree->actuators.size();
+  for (int actuator_idx = 0;
+       actuator_idx < static_cast<int>(tree->actuators.size());
        actuator_idx++) {
     const std::string& actuator_name = tree->actuators[actuator_idx].name;
 

--- a/drake/examples/Cars/test/simple_car_test.cc
+++ b/drake/examples/Cars/test/simple_car_test.cc
@@ -112,7 +112,7 @@ GTEST_TEST(SimpleCarTest, Accelerating) {
   double step_size = Drake::default_simulation_options.initial_step_size;
   int steps = (end_time - start_time) / step_size;
 
-  EXPECT_EQ(history_system->states_.size(), steps);
+  EXPECT_EQ(static_cast<int>(history_system->states_.size()), steps);
 
   double max_time = history_system->states_.rbegin()->first;
   EXPECT_NEAR(max_time, end_time - step_size, 1e-5);
@@ -161,7 +161,7 @@ GTEST_TEST(SimpleCarTest, Braking) {
   double step_size = Drake::default_simulation_options.initial_step_size;
   int steps = (end_time - start_time) / step_size;
 
-  EXPECT_EQ(history_system->states_.size(), steps);
+  EXPECT_EQ(static_cast<int>(history_system->states_.size()), steps);
 
   double max_time = history_system->states_.rbegin()->first;
   EXPECT_NEAR(max_time, end_time - step_size, 1e-5);
@@ -202,7 +202,7 @@ GTEST_TEST(SimpleCarTest, Steering) {
   double step_size = Drake::default_simulation_options.initial_step_size;
   int steps = (end_time - start_time) / step_size;
 
-  EXPECT_EQ(history_system->states_.size(), steps);
+  EXPECT_EQ(static_cast<int>(history_system->states_.size()), steps);
 
   double max_time = history_system->states_.rbegin()->first;
   EXPECT_NEAR(max_time, end_time - step_size, 1e-5);

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
@@ -105,7 +105,8 @@ int main(int argc, char* argv[]) {
   int num_velocities = rigid_body_sys->number_of_velocities();
 
   // Ensures the size of the output is correct.
-  if (final_robot_state.size() != rigid_body_sys->getNumOutputs()) {
+  if (final_robot_state.size() !=
+      static_cast<int>(rigid_body_sys->getNumOutputs())) {
     throw std::runtime_error(
         "ERROR: Size of final robot state (" +
         std::to_string(final_robot_state.size()) +
@@ -133,7 +134,8 @@ int main(int argc, char* argv[]) {
 
   // Ensures the robot's joints are within their position limits.
   std::vector<std::unique_ptr<RigidBody>>& bodies = tree->bodies;
-  for (int robot_state_index = 0, body_index = 0; body_index < bodies.size();
+  for (int robot_state_index = 0, body_index = 0;
+       body_index < static_cast<int>(bodies.size());
        ++body_index) {
     // Skips rigid bodies without a parent (this includes the world link).
     if (!bodies[body_index]->hasParent()) continue;

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -129,7 +129,7 @@ TEST_F(SpringMassSystemTest, Output) {
   // Displacement 100cm, vel 250cm/s (.25 is exact in binary).
   InitializeState(0.1, 0.25);
   system_->EvalOutput(*context_, system_output_.get());
-  ASSERT_EQ(1, system_output_->ports.size());
+  ASSERT_EQ(1u, system_output_->ports.size());
 
   // Check the output through the application-specific interface.
   EXPECT_NEAR(0.1, output_->get_position(), 1e-14);

--- a/drake/systems/pd_control_system.h
+++ b/drake/systems/pd_control_system.h
@@ -35,12 +35,13 @@ class PDControlSystem {
   PDControlSystem(const SystemPtr& sys, const Eigen::MatrixBase<DerivedA>& Kp,
                   const Eigen::MatrixBase<DerivedB>& Kd)
       : sys(sys), Kp(Kp), Kd(Kd) {
-    DRAKE_ASSERT(Drake::getNumInputs(*sys) == Kp.rows() &&
+    DRAKE_ASSERT(static_cast<int>(Drake::getNumInputs(*sys)) == Kp.rows() &&
                  "Kp must have the same number of rows as the system has"
                  " inputs");
     DRAKE_ASSERT(Kp.rows() == Kd.rows() &&
                  "Kd must have the same number of rows as Kp");
-    DRAKE_ASSERT(Drake::getNumStates(*sys) == Kp.cols() + Kd.cols() &&
+    DRAKE_ASSERT(static_cast<int>(Drake::getNumStates(*sys)) ==
+                 (Kp.cols() + Kd.cols()) &&
                  "Kp and Kd must match the number of states");
   }
 

--- a/drake/util/drakeMexUtil.h
+++ b/drake/util/drakeMexUtil.h
@@ -232,7 +232,7 @@ mxArray* eigenToMSSPoly(const Eigen::Matrix<Polynomiald, _Rows, _Cols>& poly) {
            iter != monomials.end(); iter++) {
         sub(index, 0) = i + 1;
         sub(index, 1) = j + 1;
-        for (int k = 0; k < iter->terms.size(); k++) {
+        for (int k = 0; k < static_cast<int>(iter->terms.size()); k++) {
           var(index, k) = (double)iter->terms[k].var;
           pow(index, k) = (double)iter->terms[k].power;
         }


### PR DESCRIPTION
A portion of #2372.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2877)
<!-- Reviewable:end -->
