### PR TITLE
Toward #2852: enforce -Werror=shadow in util/.

### DIFF
--- a/drake/systems/plants/KinematicsCache.h
+++ b/drake/systems/plants/KinematicsCache.h
@@ -92,13 +92,13 @@ class KinematicsCache {
 
  public:
   explicit KinematicsCache(
-      const std::vector<std::unique_ptr<RigidBody> >& bodies)
-      : num_positions(getNumPositions(bodies)),
-        num_velocities(getNumVelocities(bodies)),
+      const std::vector<std::unique_ptr<RigidBody> >& bodies_in)
+      : num_positions(getNumPositions(bodies_in)),
+        num_velocities(getNumVelocities(bodies_in)),
         q(Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Zero(num_positions)),
         v(Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Zero(num_velocities)),
         velocity_vector_valid(false) {
-    for (const auto& body_unique_ptr : bodies) {
+    for (const auto& body_unique_ptr : bodies_in) {
       const RigidBody& body = *body_unique_ptr;
       int num_positions_joint =
           body.hasParent() ? body.getJoint().getNumPositions() : 0;
@@ -106,7 +106,7 @@ class KinematicsCache {
           body.hasParent() ? body.getJoint().getNumVelocities() : 0;
       elements.insert({&body, KinematicsCacheElement<Scalar>(
                                   num_positions_joint, num_velocities_joint)});
-      this->bodies.push_back(&body);
+      bodies.push_back(&body);
     }
     invalidate();
   }
@@ -121,25 +121,25 @@ class KinematicsCache {
   }
 
   template <typename Derived>
-  void initialize(const Eigen::MatrixBase<Derived>& q) {
+  void initialize(const Eigen::MatrixBase<Derived>& q_in) {
     static_assert(Derived::ColsAtCompileTime == 1, "q must be a vector");
     static_assert(std::is_same<typename Derived::Scalar, Scalar>::value,
                   "scalar type of q must match scalar type of KinematicsCache");
-    DRAKE_ASSERT(this->q.rows() == q.rows());
-    this->q = q;
+    DRAKE_ASSERT(q.rows() == q_in.rows());
+    q = q_in;
     invalidate();
     velocity_vector_valid = false;
   }
 
   template <typename DerivedQ, typename DerivedV>
-  void initialize(const Eigen::MatrixBase<DerivedQ>& q,
-                  const Eigen::MatrixBase<DerivedV>& v) {
-    initialize(q);  // also invalidates
+  void initialize(const Eigen::MatrixBase<DerivedQ>& q_in,
+                  const Eigen::MatrixBase<DerivedV>& v_in) {
+    initialize(q_in);  // also invalidates
     static_assert(DerivedV::ColsAtCompileTime == 1, "v must be a vector");
     static_assert(std::is_same<typename DerivedV::Scalar, Scalar>::value,
                   "scalar type of v must match scalar type of KinematicsCache");
-    DRAKE_ASSERT(this->v.rows() == v.rows());
-    this->v = v;
+    DRAKE_ASSERT(v.rows() == v_in.rows());
+    v = v_in;
     velocity_vector_valid = true;
   }
 
@@ -242,7 +242,7 @@ class KinematicsCache {
 
   void setPositionKinematicsCached() { position_kinematics_cached = true; }
 
-  void setJdotVCached(bool jdotV_cached) { this->jdotV_cached = jdotV_cached; }
+  void setJdotVCached(bool jdotV_cached_in) { jdotV_cached = jdotV_cached_in; }
 
   int getNumPositions() const { return num_positions; }
 

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -32,14 +32,15 @@ typedef Eigen::Matrix<double, 3, BASIS_VECTOR_HALF_COUNT> Matrix3kd;
 class DRAKERBM_EXPORT RigidBodyActuator {
  public:
   RigidBodyActuator(
-      const std::string& name, const RigidBody* body, double reduction = 1.0,
-      double effort_limit_min = -std::numeric_limits<double>::infinity(),
-      double effort_limit_max = std::numeric_limits<double>::infinity())
-      : name(name),
-        body(body),
-        reduction(reduction),
-        effort_limit_min(effort_limit_min),
-        effort_limit_max(effort_limit_max) {}
+      const std::string& name_in, const RigidBody* body_in,
+      double reduction_in = 1.0,
+      double effort_limit_min_in = -std::numeric_limits<double>::infinity(),
+      double effort_limit_max_in = std::numeric_limits<double>::infinity())
+      : name(name_in),
+        body(body_in),
+        reduction(reduction_in),
+        effort_limit_min(effort_limit_min_in),
+        effort_limit_max(effort_limit_max_in) {}
 
   const std::string name;
   const RigidBody* const body;

--- a/drake/systems/plants/collision/point_pair.h
+++ b/drake/systems/plants/collision/point_pair.h
@@ -12,14 +12,14 @@ namespace DrakeCollision {
 struct DRAKECOLLISION_EXPORT PointPair {
   PointPair() {}
 
-  PointPair(const Element* elementA, const Element* elementB,
-            const Eigen::Vector3d& ptA, const Eigen::Vector3d& ptB,
-            const Eigen::Vector3d& normal, double distance)
-      : elementA(elementA), elementB(elementB),
-        idA(elementA->getId()), idB(elementB->getId()),
-        ptA(ptA), ptB(ptB),
-        normal(normal),
-        distance(distance) {}
+  PointPair(const Element* elementA_in, const Element* elementB_in,
+            const Eigen::Vector3d& ptA_in, const Eigen::Vector3d& ptB_in,
+            const Eigen::Vector3d& normal_in, double distance_in)
+      : elementA(elementA_in), elementB(elementB_in),
+        idA(elementA_in->getId()), idB(elementB_in->getId()),
+        ptA(ptA_in), ptB(ptB_in),
+        normal(normal_in),
+        distance(distance_in) {}
 
   /** Element A in the pair participating in the collision. **/
   const Element* elementA{nullptr};

--- a/drake/systems/plants/shapes/Element.h
+++ b/drake/systems/plants/shapes/Element.h
@@ -13,19 +13,20 @@
 namespace DrakeShapes {
 class DRAKESHAPES_EXPORT Element {
  public:
-  Element(const Geometry& geometry, const Eigen::Isometry3d& T_element_to_local)
+  Element(const Geometry& geometry_in,
+          const Eigen::Isometry3d& T_element_to_local_in)
       : T_element_to_world(Eigen::Isometry3d::Identity()),
-        T_element_to_local(T_element_to_local),
-        geometry(geometry.clone()) {}
+        T_element_to_local(T_element_to_local_in),
+        geometry(geometry_in.clone()) {}
 
-  explicit Element(const Geometry& geometry)
+  explicit Element(const Geometry& geometry_in)
       : T_element_to_world(Eigen::Isometry3d::Identity()),
         T_element_to_local(Eigen::Isometry3d::Identity()),
-        geometry(geometry.clone()) {}
+        geometry(geometry_in.clone()) {}
 
-  explicit Element(const Eigen::Isometry3d& T_element_to_local)
+  explicit Element(const Eigen::Isometry3d& T_element_to_local_in)
       : T_element_to_world(Eigen::Isometry3d::Identity()),
-        T_element_to_local(T_element_to_local),
+        T_element_to_local(T_element_to_local_in),
         geometry() {}
 
   virtual ~Element() {}

--- a/drake/systems/plants/shapes/VisualElement.h
+++ b/drake/systems/plants/shapes/VisualElement.h
@@ -18,8 +18,8 @@ class DRAKESHAPES_EXPORT VisualElement : public Element {
 
   VisualElement(const Geometry& geometry,
                 const Eigen::Isometry3d& T_element_to_local,
-                const Eigen::Vector4d& material)
-      : Element(geometry, T_element_to_local), material(material) {}
+                const Eigen::Vector4d& material_in)
+      : Element(geometry, T_element_to_local), material(material_in) {}
 
   virtual ~VisualElement() {}
 

--- a/drake/util/CMakeLists.txt
+++ b/drake/util/CMakeLists.txt
@@ -1,6 +1,3 @@
-# TODO(#2852) We can't yet handle shadowing as a compiler error.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
-
 if(simulink_FOUND)
   add_mex(realtime realtime.cpp)
 endif()


### PR DESCRIPTION
 * Remove excuse from util/ cmake file.
 * Fix a bunch of constructors for classes with public/protected data.
   * It is madness to try to fix the public/protected fields, so:
     * Rename construct params with '_' prefixes.
     * Retire some 'this->' disambiguators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2885)
<!-- Reviewable:end -->
