### PR TITLE
Superbuild refactor, part 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
     bot_core_lcmtypes
     bullet
     cmake
+    director
     eigen
     gloptipoly3
     google_styleguide

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,50 +4,16 @@ project(drake-superbuild)
 include(CTest)
 
 include(cmake/config.cmake)
+include(cmake/externals.cmake)
+include(cmake/examples.cmake)
+include(cmake/git/hooks.cmake)
 
 drake_setup_superbuild()
 drake_setup_platform()
-
-include(ExternalProject)
-find_package(Git REQUIRED)
-
-include(cmake/git/hooks.cmake)
 drake_setup_git_hooks()
 
-function(drake_forceupdate proj)
-  # CMake < 3.6 forget to mark the update step as "ALWAYS" when an explicit
-  # UPDATE_COMMAND is used.  Add our own "ALWAYS" step to force updates.
-  if(AUTO_UPDATE_EXTERNALS AND CMAKE_VERSION VERSION_LESS 3.6)
-    ExternalProject_Add_Step(${proj} forceupdate
-      DEPENDEES download
-      DEPENDERS update
-      ALWAYS 1
-      )
-  endif()
-endfunction()
-
-function(drake_depend_submodule_sync proj)
-  # All targets that contain a submodule update command, or depend on a
-  # target that does, need to depend on the submodule-sync target.
-  if(AUTO_UPDATE_EXTERNALS)
-    foreach(t ${proj} ${proj}-update)
-      if(TARGET ${t})
-        add_dependencies(${t} submodule-sync)
-      endif()
-    endforeach()
-  endif()
-endfunction()
-
-# menu of extra examples
-option(EXAMPLES_LITTLEDOG "planning and control for a small quadruped robot" OFF)
-
-## External dependencies
-option(AUTO_UPDATE_EXTERNALS "external projects are updated to their tag revision on compile" ON)
-
-# menu of external projects
-option(WITH_ALL_PUBLIC_EXTERNALS "enable all externals available to public academic users" OFF)
-option(WITH_ALL_SUPPORTED_EXTERNALS "enable all externals available for your platform (includes private git repositories)" OFF)
-option(REMOVE_UNUSED_EXTERNALS "enable this to remove those projects from disk" OFF)
+###############################################################################
+# BEGIN options
 
 ##########################################
 # External Projects that are ON by default
@@ -122,414 +88,195 @@ if(NOT WIN32) # many of these might work on win32 with little or no work... they
   option(WITH_TEXTBOOK "pull in the Underactuated Robotics textbook and its examples")  # almost works on windows.  the update step call to git was complaining about local modifications on drake003
 endif()
 
-if(WITH_TEXTBOOK OR WITH_ALL_SUPPORTED_EXTERNALS OR WITH_ALL_PUBLIC_EXTERNALS)
-  find_package(PythonInterp)
-  if(NOT PYTHON_EXECUTABLE)
-    message(FATAL_ERROR "could not find python, which is required for the the textbook examples")
-  endif()
+# Option to skip building drake proper via the superbuild. This allows the
+# superbuild to build everything BUT drake, which can still be built separately
+# from its build directory. This is used by the dashboards to make separate
+# submissions for drake proper and the superbuild without drake. Some users may
+# also find it useful, especially to build drake with ninja using fewer than
+# the default number of jobs.
+option(SKIP_DRAKE_BUILD "Build external projects but not drake itself" OFF)
+if(SKIP_DRAKE_BUILD)
+  set(DRAKE_BUILD_COMMANDS BUILD_COMMAND : INSTALL_COMMAND :)
 endif()
 
-# list *compilation* dependencies, in alphabetical order by target (note: dependencies must come first in my foreach above)
-set(lcm_dependencies gtk)
-set(libbot_dependencies lcm)
-set(bot_core_lcmtypes_dependencies lcm)
-set(director_dependencies bot_core_lcmtypes lcm libbot)
-set(iris_dependencies eigen mosek)
-set(signalscope_dependencies director)
+# END options
+###############################################################################
+# BEGIN external projects
 
-# List compilation and runtime dependencies. Runtime dependencies are needed
-# because the drake project must configure only after any dependencies used by
-# MATLAB have been installed.
-set(drake_dependencies bertini bot_core_lcmtypes bullet cmake eigen gloptipoly3 googletest google_styleguide gurobi iris lcm libbot mosek nlopt ipopt octomap sedumi snopt spdlog spotless swig_matlab swigmake yalmip yaml_cpp)
+# External projects in order of dependencies; 'trivial' ones first
+drake_add_external(avl PUBLIC)
+drake_add_external(bertini)
+drake_add_external(bullet PUBLIC CMAKE)
+drake_add_external(eigen PUBLIC CMAKE)
+drake_add_external(gloptipoly)
+drake_add_external(gurobi)
+drake_add_external(meshconverters PUBLIC)
+drake_add_external(mosek PUBLIC)
+drake_add_external(octomap PUBLIC)
+drake_add_external(snopt CMAKE)
+drake_add_external(spdlog PUBLIC CMAKE)
+drake_add_external(spotless PUBLIC CMAKE)
+drake_add_external(swig_matlab PUBLIC CMAKE)
+drake_add_external(swigmake PUBLIC CMAKE)
+drake_add_external(xfoil PUBLIC)
+drake_add_external(yalmip PUBLIC)
 
-# download information, in alphabetical order
-set(avl_IS_PUBLIC TRUE)
-set(bertini_IS_PUBLIC FALSE)
-set(bullet_IS_PUBLIC TRUE)
-set(bullet_IS_CMAKE_POD TRUE)
-set(cmake_SOURCE_DIR "${PROJECT_SOURCE_DIR}/drake/cmake")
-set(cmake_NO_BUILD TRUE)
-set(cmake_IS_PUBLIC TRUE)
-set(director_BUILD_COMMAND_DIR distro/pods/drake-distro)
-set(director_IS_PUBLIC TRUE)
-set(drake_ADDITIONAL_CMAKE_CONFIGURE_ARGS
-  -DWITH_PYTHON_3=${WITH_PYTHON_3}
-  -DDISABLE_MATLAB=${DISABLE_MATLAB}
-  -DWITH_DIRECTOR=${WITH_DIRECTOR}
-  -DWITH_GOOGLE_STYLEGUIDE:BOOL=${WITH_GOOGLE_STYLEGUIDE})
-set(eigen_IS_CMAKE_POD TRUE)
-set(eigen_IS_PUBLIC TRUE)
-set(googletest_IS_CMAKE_POD TRUE)
-set(googletest_IS_PUBLIC TRUE)
-set(googletest_ADDITIONAL_CMAKE_CONFIGURE_ARGS -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_NAME_DIR=${CMAKE_INSTALL_PREFIX}/lib -DGTEST_CREATE_SHARED_LIBRARY=1) # The "-DGTEST_CREATE_SHARED_LIBRARY=1" is needed to support parameterized Google tests on Windows.
-set(google_styleguide_IS_PUBLIC TRUE)
-set(google_styleguide_NO_BUILD TRUE)
-set(gtk_IS_CMAKE_POD TRUE)
-set(gtk_IS_PUBLIC TRUE)
-set(gloptipoly_IS_PUBLIC FALSE)
-set(gurobi_IS_PUBLIC FALSE)
-set(ipopt_IS_PUBLIC TRUE)
-# TODO(sam.creasey) add an alternate build command for WIN32 which
-# downloads the precopiled binary and installs that.
-set(ipopt_BUILD_COMMAND ./configure  --with-blas=BUILD --with-lapack=BUILD --prefix=${CMAKE_INSTALL_PREFIX} --includedir=${CMAKE_INSTALL_PREFIX}/include/ipopt --disable-shared --with-pic && make install)
-set(iris_ADDITIONAL_BUILD_ARGS PATCH_COMMAND make configure-cdd-only)
-set(iris_IS_PUBLIC TRUE)
-set(lcm_IS_CMAKE_POD TRUE)
-set(lcm_IS_PUBLIC TRUE)
-set(lcm_ADDITIONAL_CMAKE_CONFIGURE_ARGS -DBUILD_SHARED_LIBS=ON)
-if(WITH_GTK)
-  set(lcm_ADDITIONAL_CMAKE_CONFIGURE_ARGS ${lcm_ADDITIONAL_CMAKE_CONFIGURE_ARGS} -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_SOURCE_DIR}/externals/gtk/gtk3)
-endif()
-if(WIN32)
-  # On Windows we always need a Release LCM for compatibility with Python libraries.
-  if(CMAKE_CONFIGURATION_TYPES)
-    # This is a multi-config generator, so we need to specify the configuration at build time.
-    set(lcm_BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release)
-    set(lcm_INSTALL_COMMAND ${CMAKE_COMMAND} --build . --config Release --target install)
-  else()
-    # This is a single-config generator, so we need to specify the configuration to CMake.
-    list(APPEND lcm_ADDITIONAL_CMAKE_CONFIGURE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release)
-  endif()
-endif()
-set(libbot_IS_CMAKE_POD TRUE)
-set(libbot_IS_PUBLIC TRUE)
-set(bot_core_lcmtypes_IS_CMAKE_POD TRUE)
-set(bot_core_lcmtypes_IS_PUBLIC TRUE)
-set(spdlog_IS_PUBLIC TRUE)
-set(spdlog_IS_CMAKE_POD TRUE)
-set(meshconverters_IS_PUBLIC TRUE)
-set(mosek_IS_PUBLIC TRUE)
-set(nlopt_BUILD_COMMAND ./autogen.sh --no-configure && ./configure --without-matlab --without-python --without-octave --without-guile --enable-maintainer-mode --enable-shared --prefix=${CMAKE_INSTALL_PREFIX} --includedir=${CMAKE_INSTALL_PREFIX}/include/nlopt && make install)
-set(nlopt_IS_PUBLIC TRUE)
-set(octomap_IS_PUBLIC TRUE)
-set(sedumi_IS_PUBLIC FALSE)
-set(signalscope_IS_PUBLIC TRUE)
-set(snopt_IS_CMAKE_POD TRUE)
-set(snopt_IS_PUBLIC FALSE)
-set(spotless_IS_CMAKE_POD TRUE)
-set(spotless_IS_PUBLIC TRUE)
-set(swigmake_IS_PUBLIC TRUE)
-set(swigmake_IS_CMAKE_POD TRUE)
-set(swigmake_NO_CLEAN TRUE)
-set(swig_matlab_IS_PUBLIC TRUE)
-set(swig_matlab_IS_CMAKE_POD TRUE)
-set(textbook_SOURCE_DIR "${PROJECT_SOURCE_DIR}/drake/doc/textbook")
-set(textbook_BUILD_COMMAND ${PYTHON_EXECUTABLE} extract_examples.py underactuated.html ./examples)
-set(textbook_IS_PUBLIC TRUE)
-set(yalmip_IS_PUBLIC TRUE)
-set(yaml_cpp_IS_PUBLIC TRUE)
-set(yaml_cpp_IS_CMAKE_POD TRUE)
-if(APPLE OR WIN32)
-  set(yaml_cpp_ADDITIONAL_CMAKE_CONFIGURE_ARGS -DBUILD_SHARED_LIBS=OFF)
-else()
-  set(yaml_cpp_ADDITIONAL_CMAKE_CONFIGURE_ARGS -DBUILD_SHARED_LIBS=ON)
-endif()
-set(xfoil_IS_PUBLIC TRUE)
+# cmake
+drake_add_external(cmake PUBLIC ALWAYS
+  BUILD_COMMAND :
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake/cmake)
 
-find_program(MAKE_EXECUTABLE make)
-if(NOT MAKE_EXECUTABLE)
-  message(WARNING "couldn't find gnu make")
-endif()
-if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")
-  set(PODS_MAKE_COMMAND "$(MAKE)")   # so we can pass through commandline arguments.
-else()
-  set(PODS_MAKE_COMMAND ${MAKE_EXECUTABLE})
-endif()
-
-# process optional projects
-# note: keep drake in this loop in case externals depend on drake (e.g. the director might in the near future)
-set(EXTERNAL_PROJECTS)
-foreach(proj IN ITEMS
-  cmake
-  textbook
-  eigen
-  googletest
-  google_styleguide
-  gtk
-  lcm
-  bot_core_lcmtypes
-  spdlog
-  libbot
-  bullet
-  spotless
-  director
-  signalscope
-  octomap
-  snopt
-  gurobi
-  mosek
-  iris
-  yalmip
-  gloptipoly
-  bertini
-  sedumi
-  avl
-  xfoil
-  meshconverters
-  swigmake
-  swig_matlab
-  yaml_cpp
-  ipopt
-  nlopt
-  drake)
-  string(TOUPPER ${proj} proj_upper)
-  if(${proj} STREQUAL "drake" OR
-    ${proj} STREQUAL "cmake" OR
-    WITH_${proj_upper} OR
-    (WITH_ALL_SUPPORTED_EXTERNALS AND DEFINED WITH_${proj_upper}) OR
-    (WITH_ALL_PUBLIC_EXTERNALS AND ${proj}_IS_PUBLIC AND DEFINED WITH_${proj_upper}))
-    list(APPEND EXTERNAL_PROJECTS ${proj})
-  elseif(REMOVE_UNUSED_EXTERNALS AND IS_DIRECTORY ${proj})
-    message(STATUS "removing unused project: ${proj}")
-    if(NOT ${proj}_NO_BUILD)
-      execute_process(COMMAND ${MAKE_EXECUTABLE} BUILD_PREFIX=${CMAKE_INSTALL_PREFIX} BUILD_TYPE=$<CONFIGURATION> clean
-          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${proj})
-    endif()
-    execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_SOURCE_DIR}/${proj}")
-  endif()
-endforeach()
-
-string(REPLACE ";" "!" CMAKE_JAVA_COMPILE_FLAGS "${CMAKE_JAVA_COMPILE_FLAGS}")
-set(COMMON_CMAKE_ARGS
-  CMAKE_GENERATOR ${CMAKE_GENERATOR}
-  LIST_SEPARATOR "!"
+# googletest
+drake_add_external(googletest PUBLIC CMAKE
   CMAKE_ARGS
-    -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
-    -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-    -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
-    -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
-    -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-    -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
-    -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-    -DCMAKE_EXE_LINKER_FLAGS:STRING=${CMAKE_EXE_LINKER_FLAGS}
-    -DCMAKE_MODULE_LINKER_FLAGS:STRING=${CMAKE_MODULE_LINKER_FLAGS}
-    -DCMAKE_SHARED_LINKER_FLAGS:STRING=${CMAKE_SHARED_LINKER_FLAGS}
-    -DCMAKE_STATIC_LINKER_FLAGS:STRING=${CMAKE_STATIC_LINKER_FLAGS}
-    -DJava_JAVA_EXECUTABLE:FILEPATH=${Java_JAVA_EXECUTABLE}
-    -DJava_JAVAC_EXECUTABLE:FILEPATH=${Java_JAVAC_EXECUTABLE}
-    -DJava_JAVAH_EXECUTABLE:FILEPATH=${Java_JAVAH_EXECUTABLE}
-    -DJava_VERSION_STRING:STRING=${Java_VERSION_STRING}
-    -DCMAKE_JAVA_COMPILE_FLAGS:STRING=${CMAKE_JAVA_COMPILE_FLAGS})
+    -DBUILD_SHARED_LIBS=ON
+    -DGTEST_CREATE_SHARED_LIBRARY=1 # Needed for parameterized tests on Windows
+    -DCMAKE_INSTALL_NAME_DIR=${CMAKE_INSTALL_PREFIX}/lib)
 
-set(EXTERNAL_SOURCE_DIRS)
-foreach(proj ${EXTERNAL_PROJECTS})
-  set(deps)
-  foreach(dep ${${proj}_dependencies})
-    list(FIND EXTERNAL_PROJECTS ${dep} find_result)
-    if(${dep} STREQUAL "drake" OR NOT find_result EQUAL -1)
-      list(APPEND deps ${dep})
-    endif()
-  endforeach()
+# google_styleguide
+drake_add_external(google_styleguide PUBLIC
+  BUILD_COMMAND :)
 
-  if(NOT ${proj} STREQUAL "drake")
-    if(NOT ${proj}_SOURCE_DIR)
-      set(${proj}_SOURCE_DIR "${PROJECT_SOURCE_DIR}/externals/${proj}")
-    endif()
-    set(EXTERNAL_SOURCE_DIRS ${EXTERNAL_SOURCE_DIRS} ${${proj}_SOURCE_DIR} "\n")
+# ipopt
+drake_add_external(ipopt PUBLIC
+  # TODO(sam.creasey) add an alternate build command for WIN32 which
+  # downloads the precopiled binary and installs that.
+  CONFIGURE_COMMAND ./configure
+    --with-blas=BUILD
+    --with-lapack=BUILD
+    --prefix=${CMAKE_INSTALL_PREFIX}
+    --includedir=${CMAKE_INSTALL_PREFIX}/include/ipopt
+    --disable-shared
+    --with-pic
+  INSTALL_COMMAND ${MAKE_COMMAND} install)
 
-    message(STATUS "Preparing to build ${proj} with dependencies: ${deps}")
+# nlopt
+drake_add_external(nlopt PUBLIC
+  PATCH_COMMAND ./autogen.sh --no-configure
+  CONFIGURE_COMMAND ./configure
+    --without-matlab
+    --without-python
+    --without-octave
+    --without-guile
+    --enable-maintainer-mode
+    --enable-shared
+    --prefix=${CMAKE_INSTALL_PREFIX}
+    --includedir=${CMAKE_INSTALL_PREFIX}/include/nlopt
+  INSTALL_COMMAND ${MAKE_COMMAND} install)
 
-    # Compute the path to the submodule for this external.
-    file(RELATIVE_PATH ${proj}_GIT_SUBMODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${${proj}_SOURCE_DIR})
+# textbook
+drake_add_external(textbook PUBLIC
+  REQUIRES PythonInterp
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake/doc/textbook
+  BUILD_COMMAND \@PYTHON_EXECUTABLE\@
+    extract_examples.py underactuated.html ./examples)
 
-    # Initialize the submodule configuration now so parallel downloads do not conflict later.
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule init -- ${${proj}_GIT_SUBMODULE_PATH}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-    # Download externals as Git submodules.
-    set(${proj}_DOWNLOAD_COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${${proj}_GIT_SUBMODULE_PATH})
-
-    if(AUTO_UPDATE_EXTERNALS)
-      set(${proj}_UPDATE_COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${${proj}_DOWNLOAD_COMMAND})
-    else()
-      set(${proj}_UPDATE_COMMAND "")
-    endif()
-
-    # now the actual project
-    if(${proj}_IS_CMAKE_POD)
-      if(NOT ${proj}_BINARY_DIR)
-        set(${proj}_BINARY_DIR "${PROJECT_BINARY_DIR}/externals/${proj}")
-      endif()
-      set(PODS_VERBOSE_MAKEFILE "")
-      if(CMAKE_VERBOSE_MAKEFILE)
-        set(PODS_VERBOSE_MAKEFILE "-DCMAKE_VERBOSE_MAKEFILE=ON")
-      endif()
-      foreach(c BUILD INSTALL)
-        if(DEFINED ${proj}_${c}_COMMAND)
-          set(maybe_${c}_COMMAND ${c}_COMMAND ${${proj}_${c}_COMMAND})
-        else()
-          set(maybe_${c}_COMMAND "")
-        endif()
-      endforeach()
-      ExternalProject_Add(${proj}
-        SOURCE_DIR ${${proj}_SOURCE_DIR}
-        BINARY_DIR ${${proj}_BINARY_DIR}
-        DOWNLOAD_COMMAND ${${proj}_DOWNLOAD_COMMAND}
-        DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-        UPDATE_COMMAND ${${proj}_UPDATE_COMMAND}
-        ${maybe_BUILD_COMMAND}
-        ${maybe_INSTALL_COMMAND}
-        BUILD_ALWAYS 1
-        INDEPENDENT_STEP_TARGETS update
-        DEPENDS ${deps}
-        ${COMMON_CMAKE_ARGS}
-        ${PODS_VERBOSE_MAKEFILE}
-        ${${proj}_ADDITIONAL_CMAKE_CONFIGURE_ARGS}
-        ${${proj}_ADDITIONAL_BUILD_ARGS})
-      drake_forceupdate(${proj})
-      drake_depend_submodule_sync(${proj})
-    else() # not a CMake POD
-      if(NOT ${proj}_BINARY_DIR)
-        # In-source build for non-CMake projects.
-        set(${proj}_BINARY_DIR "${${proj}_SOURCE_DIR}")
-      endif()
-      if(NOT DEFINED ${proj}_BUILD_COMMAND)
-        if(${proj}_NO_BUILD)
-          set(${proj}_BUILD_COMMAND "")
-        else() # then use the PODS gnu make system
-          set(PODS_VERBOSE_MAKEFILE "")
-          if(CMAKE_VERBOSE_MAKEFILE)
-            set(PODS_VERBOSE_MAKEFILE "V=1 VERBOSE=1")
-          endif()
-          set(${proj}_BUILD_COMMAND ${PODS_MAKE_COMMAND} ${PODS_VERBOSE_MAKEFILE} BUILD_PREFIX=${CMAKE_INSTALL_PREFIX} BUILD_TYPE=$<CONFIGURATION>)
-          if(${proj}_BUILD_COMMAND_DIR)
-            set(${proj}_BUILD_COMMAND ${CMAKE_COMMAND} -E chdir ${${proj}_BUILD_COMMAND_DIR} ${${proj}_BUILD_COMMAND})
-          endif()
-        endif()
-      endif()
-
-      if(${proj}_BUILD_COMMAND)
-        set(${proj}_BUILD_ALWAYS 1)
-      else()
-        set(${proj}_BUILD_ALWAYS 0)
-      endif()
-
-      ExternalProject_Add(${proj}
-        SOURCE_DIR ${${proj}_SOURCE_DIR}
-        BINARY_DIR ${${proj}_BINARY_DIR}
-        DOWNLOAD_COMMAND ${${proj}_DOWNLOAD_COMMAND}
-        DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-        UPDATE_COMMAND ${${proj}_UPDATE_COMMAND}
-        INDEPENDENT_STEP_TARGETS update
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND "${${proj}_BUILD_COMMAND}"
-        BUILD_ALWAYS "${${proj}_BUILD_ALWAYS}"
-        INSTALL_COMMAND ""
-        DEPENDS ${deps}
-        ${${proj}_ADDITIONAL_BUILD_ARGS})
-      drake_forceupdate(${proj})
-      drake_depend_submodule_sync(${proj})
-      # message(STATUS "${proj}_BUILD_COMMAND: ${${proj}_BUILD_COMMAND}")
-    endif()
-  else()
-    message(STATUS "Preparing to build ${proj} with dependencies: ${deps}")
-    set(PODS_VERBOSE_MAKEFILE "")
-    if(CMAKE_VERBOSE_MAKEFILE)
-      set(PODS_VERBOSE_MAKEFILE "-DCMAKE_VERBOSE_MAKEFILE=ON")
-    endif()
-    set(drake_BINARY_DIR "${PROJECT_BINARY_DIR}/drake")
-    ExternalProject_Add(${proj}
-      SOURCE_DIR "${PROJECT_SOURCE_DIR}/drake"
-      DOWNLOAD_COMMAND ""
-      UPDATE_COMMAND ""
-      BINARY_DIR ${drake_BINARY_DIR}
-      BUILD_ALWAYS 1
-      DEPENDS ${deps}
-      ${COMMON_CMAKE_ARGS}
-      ${PODS_VERBOSE_MAKEFILE}
-      ${${proj}_ADDITIONAL_CMAKE_CONFIGURE_ARGS}
-      ${${proj}_ADDITIONAL_BUILD_ARGS})
-    drake_depend_submodule_sync(${proj})
-  endif()
-
-endforeach()
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/drake_external_source_dirs.txt ${EXTERNAL_SOURCE_DIRS})
-
-# TODO: add a custom target for release_filelist
-
-add_custom_target(download-all)
-add_custom_target(clean-all)
-add_custom_target(status)
-set(PROJECT_LIST)
-foreach(proj ${EXTERNAL_PROJECTS})
-  if(NOT ${proj} STREQUAL "drake")
-    add_dependencies(download-all ${proj}-update)
-    ExternalProject_Get_Property(${proj} SOURCE_DIR)
-    add_custom_target(status-${proj}
-      COMMAND ${GIT_EXECUTABLE} status
-      WORKING_DIRECTORY ${SOURCE_DIR})
-    add_dependencies(status status-${proj})
-  endif()
-
-  ExternalProject_Get_Property(${proj} SOURCE_DIR)
-  # Handle pods-style 'make clean' cleaning of external projects/pods
-  if(NOT ${proj}_NO_BUILD)
-    if(${proj}_IS_CMAKE_POD)
-      ExternalProject_Get_Property(${proj} BINARY_DIR)
-      # if _NO_CLEAN is set, don't attempt to run `make clean`, just wipe the build folder
-      if(${proj}_NO_CLEAN)
-        add_custom_target(clean-${proj}
-          COMMAND ${CMAKE_COMMAND} -E remove_directory ${BINARY_DIR})
-      else()
-        add_custom_target(clean-${proj}
-          COMMAND ${CMAKE_COMMAND} --build ${BINARY_DIR} --target clean
-          COMMAND ${CMAKE_COMMAND} -E remove_directory ${BINARY_DIR})
-      endif()
-      add_dependencies(clean-all clean-${proj})
-    else()
-      add_custom_target(clean-${proj}
-        COMMAND ${PODS_MAKE_COMMAND} BUILD_PREFIX=${CMAKE_INSTALL_PREFIX} BUILD_TYPE=$<CONFIGURATION> clean
-        WORKING_DIRECTORY ${SOURCE_DIR})
-      add_dependencies(clean-all clean-${proj})
-    endif()
-  endif()
-  list(APPEND PROJECT_LIST ${SOURCE_DIR})
-endforeach()
-
-# process optional examples
-foreach(example IN ITEMS LittleDog)
-  string(TOUPPER ${example} example_upper)
-  if(EXAMPLES_${example_upper})
-    message(STATUS "Installation will include extra example: ${example}")
-
-    # Initialize the submodule configuration now so parallel downloads do not conflict later.
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule init -- drake/examples/${example}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-    # Download examples as Git submodules.
-    set(${example}_DOWNLOAD_COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- drake/examples/${example})
-    if(AUTO_UPDATE_EXTERNALS)
-      set(${example}_UPDATE_COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${${example}_DOWNLOAD_COMMAND})
-    else()
-      set(${example}_UPDATE_COMMAND "")
-    endif()
-
-    ExternalProject_Add(download-${example}
-      SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake/examples/${example}
-      DOWNLOAD_COMMAND ${${example}_DOWNLOAD_COMMAND}
-      DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-      UPDATE_COMMAND ${${example}_UPDATE_COMMAND}
-      CONFIGURE_COMMAND ""
-      BUILD_COMMAND ""
-      INSTALL_COMMAND "")
-    drake_forceupdate(download-${example})
-    drake_depend_submodule_sync(download-${example})
-    add_dependencies(drake download-${example})
-    add_dependencies(download-all download-${example})
-  endif()
-endforeach()
-
-if(AUTO_UPDATE_EXTERNALS)
-  # Start every build by synchronizing submodule URLs.  We do this as a
-  # separate target so all URLs can be synchronized at once instead of
-  # conflicting during parallel updates later.
-  add_custom_target(submodule-sync
-    COMMAND ${GIT_EXECUTABLE} submodule --quiet sync --
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+# yaml_cpp
+if(APPLE OR WIN32)
+  drake_add_external(yaml_cpp PUBLIC CMAKE
+    CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF)
+else()
+  drake_add_external(yaml_cpp PUBLIC CMAKE
+    CMAKE_ARGS -DBUILD_SHARED_LIBS=ON)
 endif()
 
-string(REPLACE ";" " " PROJECT_LIST "${PROJECT_LIST}")
-add_custom_target(list-project-dirs COMMAND echo "${PROJECT_LIST}")
+# iris
+drake_add_external(iris PUBLIC
+  CONFIGURE_COMMAND ${MAKE_COMMAND} configure-cdd-only
+  DEPENDS eigen mosek)
+
+# lcm (and gtk)
+if(WIN32)
+  # On Windows, always build LCM in Release mode for compatibility with the
+  # Python libraries.
+  if(CMAKE_CONFIGURATION_TYPES)
+    # If using a multi-configuration generator, replace the default build
+    # commands to force the Release configuration to be built.
+    set(lcm_BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release)
+    set(lcm_FORCE_RELEASE_BUILD_COMMANDS
+      BUILD_COMMAND ${lcm_BUILD_COMMAND}
+      INSTALL_COMMAND ${lcm_BUILD_COMMAND} --target install)
+  endif()
+
+  drake_add_external(gtk PUBLIC CMAKE)
+  drake_add_external(lcm PUBLIC CMAKE
+    ${lcm_FORCE_RELEASE_BUILD_COMMANDS}
+    CMAKE_ARGS
+      -DBUILD_SHARED_LIBS=ON # Because LCM has no ABI decoration
+      -DCMAKE_BUILD_TYPE=Release # See above
+      -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_SOURCE_DIR}/externals/gtk/gtk3
+    DEPENDS gtk)
+else()
+  drake_add_external(lcm PUBLIC CMAKE
+    CMAKE_ARGS -DBUILD_SHARED_LIBS=ON)
+endif()
+
+# bot_core_lcmtypes
+drake_add_external(bot_core_lcmtypes PUBLIC CMAKE
+  DEPENDS lcm)
+
+# libbot
+drake_add_external(libbot PUBLIC CMAKE
+  DEPENDS lcm)
+
+# director
+drake_add_external(director PUBLIC
+  BUILD_COMMAND_DIR distro/pods/drake-distro # FIXME: fix need for this
+  DEPENDS bot_core_lcmtypes lcm libbot)
+
+# signalscope
+drake_add_external(signalscope PUBLIC
+  DEPENDS director)
+
+# drake: For drake, list both compilation AND RUNTIME dependencies. Runtime
+# dependencies are needed because the drake project must configure only after
+# any dependencies used by MATLAB have been installed.
+drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake
+  BINARY_DIR ${PROJECT_BINARY_DIR}/drake
+  ${DRAKE_BUILD_COMMANDS}
+  CMAKE_ARGS
+    -DDISABLE_MATLAB:BOOL=${DISABLE_MATLAB}
+    -DWITH_DIRECTOR=${WITH_DIRECTOR}
+    -DWITH_GOOGLE_STYLEGUIDE:BOOL=${WITH_GOOGLE_STYLEGUIDE}
+    -DWITH_PYTHON_3:BOOL=${WITH_PYTHON_3}
+  DEPENDS
+    bertini
+    bot_core_lcmtypes
+    bullet
+    cmake
+    eigen
+    gloptipoly3
+    google_styleguide
+    googletest
+    gurobi
+    ipopt
+    iris
+    lcm
+    libbot
+    mosek
+    nlopt
+    octomap
+    sedumi
+    snopt
+    spdlog
+    spotless
+    swig_matlab
+    swigmake
+    yalmip
+    yaml_cpp
+)
+
+# END external projects
+###############################################################################
+# BEGIN examples
+
+# Optional examples
+drake_add_example(LittleDog OFF
+  "planning and control for a small quadruped robot")
+
+# END examples
+###############################################################################
 
 ## grab and install precompiled snopt
 
@@ -544,7 +291,9 @@ if(WITH_SNOPT_PRECOMPILED)
     URL_MD5 "7b36168cba2fb9a56b2fd6117427fc4a"
     SOURCE_DIR "${CMAKE_BINARY_DIR}/snopt-precompiled"
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND cmake -E copy_directory ${CMAKE_BINARY_DIR}/snopt-precompiled/ ${PROJECT_SOURCE_DIR}/drake/solvers/
+    BUILD_COMMAND cmake -E copy_directory
+      ${CMAKE_BINARY_DIR}/snopt-precompiled/
+      ${PROJECT_SOURCE_DIR}/drake/solvers/
     INSTALL_COMMAND "")
   add_dependencies(download-all download-snopt-precompiled)
   add_dependencies(drake download-snopt-precompiled) # just in case: make sure any compiled drake version happens after precompiled install

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -1,0 +1,44 @@
+#------------------------------------------------------------------------------
+# Add an example. Besides setting up the external project, this also creates
+# the option used to control if the example is enabled.
+#
+# Arguments:
+#   <EXAMPLE> - Name of the example.
+#   <DEFAULT_ENABLED> - Is the example enabled by default? (`ON` or `OFF`)
+#
+#   <DOCSTRING>
+#       Description of the example, to be used as the documentation string for
+#       the example's option.
+#------------------------------------------------------------------------------
+function(drake_add_example EXAMPLE DEFAULT_ENABLED DOCSTRING)
+  string(TOUPPER ${EXAMPLE} EXAMPLE_UPPER)
+
+  # Add option for example
+  option(EXAMPLES_${EXAMPLE_UPPER} ${DOCSTRING} ${DEFAULT_ENABLED})
+
+  # Set up example, if enabled
+  if(EXAMPLES_${EXAMPLE_UPPER})
+    message(STATUS "Installation will include extra example: ${EXAMPLE}")
+
+    # Set up submodule and commands for synchronizing submodule
+    drake_add_submodule(drake/examples/${EXAMPLE}
+      _ex_DOWNLOAD_COMMAND _ex_UPDATE_COMMAND)
+
+    # Add the external project
+    ExternalProject_Add(download-${EXAMPLE}
+      SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake/examples/${EXAMPLE}
+      DOWNLOAD_COMMAND ${_ex_DOWNLOAD_COMMAND}
+      DOWNLOAD_DIR ${PROJECT_SOURCE_DIR}
+      UPDATE_COMMAND ${_ex_DOWNLOAD_COMMAND}
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ""
+      INSTALL_COMMAND "")
+
+    # Set up build step to ensure project is updated before build
+    drake_forceupdate(download-${EXAMPLE})
+
+    # Add example to download dependencies
+    add_dependencies(download-all download-${EXAMPLE})
+    add_dependencies(drake download-${EXAMPLE})
+  endif()
+endfunction()

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -1,0 +1,421 @@
+include(ExternalProject)
+
+find_package(Git REQUIRED)
+
+if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")
+  set(MAKE_COMMAND "$(MAKE)") # so we can pass through command line arguments
+else()
+  find_program(MAKE_COMMAND make)
+  if(NOT MAKE_COMMAND)
+    message(WARNING "Couldn't find make; non-CMake externals may fail to build")
+  endif()
+endif()
+
+#------------------------------------------------------------------------------
+# Initialize a submodule and set the commands to download and update the same.
+#------------------------------------------------------------------------------
+function(drake_add_submodule PATH DOWNLOAD_COMMAND_VAR UPDATE_COMMAND_VAR)
+  # Initialize the submodule configuration now so parallel downloads do not
+  # conflict later
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} submodule init -- ${PATH}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+  # Download externals as Git submodules
+  set(_sm_DOWNLOAD_COMMAND
+    ${GIT_EXECUTABLE} submodule update --init --recursive -- ${PATH})
+
+  if(AUTO_UPDATE_EXTERNALS)
+    set(_sm_UPDATE_COMMAND
+      ${CMAKE_COMMAND} -E chdir ${PROJECT_SOURCE_DIR}
+      ${_sm_DOWNLOAD_COMMAND})
+  else()
+    set(_sm_UPDATE_COMMAND "")
+  endif()
+
+  set(${DOWNLOAD_COMMAND_VAR} ${_sm_DOWNLOAD_COMMAND} PARENT_SCOPE)
+  set(${UPDATE_COMMAND_VAR} ${_sm_UPDATE_COMMAND} PARENT_SCOPE)
+endfunction()
+
+#------------------------------------------------------------------------------
+# Fixup command arguments given to an external project. This expands delayed
+# expansion variables (e.g. `@VAR@) and replaces the no-op token (`:`) with a
+# suitable no-op command.
+#------------------------------------------------------------------------------
+function(drake_fixup_commands PREFIX)
+  foreach(_fc_command ${ARGN})
+    if(DEFINED ${PREFIX}_${_fc_command})
+      if(${PREFIX}_${_fc_command} STREQUAL ":")
+        set(${PREFIX}_${_fc_command} ${CMAKE_COMMAND} -E sleep 0 PARENT_SCOPE)
+      else()
+        string(CONFIGURE "${${PREFIX}_${_fc_command}}"
+               _fc_command_string @ONLY)
+        set(${PREFIX}_${_fc_command} "${_fc_command_string}" PARENT_SCOPE)
+      endif()
+    endif()
+  endforeach()
+endfunction()
+
+#------------------------------------------------------------------------------
+# Build a variable (OUTVAR) that can be expanded into the `CMAKE_ARGS` argument
+# of a call to `ExternalProject_Add` in order to propagate cache variables from
+# the parent build to the external project.
+#
+# The list separator in propagated variables is replaced with the specified
+# SEPARATOR, so that lists may be correctly passed through. The specified
+# separator must match the one given to the `LIST_SEPARATOR` argument of the
+# call to `ExternalProject_Add`.
+#------------------------------------------------------------------------------
+function(drake_build_cache_args OUTVAR SEPARATOR)
+  set(_out)
+  foreach(_var ${ARGN})
+    get_property(_type CACHE ${_var} PROPERTY TYPE)
+    string(REPLACE ";" "${SEPARATOR}" _value "${${_var}}")
+    list(APPEND _out -D${_var}:${_type}=${_value})
+  endforeach()
+  set(${OUTVAR} ${_out} PARENT_SCOPE)
+endfunction()
+
+#------------------------------------------------------------------------------
+# Determine the (enabled) dependencies of an external.
+#------------------------------------------------------------------------------
+function(drake_compute_dependencies OUTVAR)
+  set(_deps)
+  foreach(_dep ${ARGN})
+    list(FIND EXTERNAL_PROJECTS ${_dep} _index)
+    if(NOT _index EQUAL -1)
+      list(APPEND _deps ${_dep})
+    endif()
+  endforeach()
+  set(${OUTVAR} ${_deps} PARENT_SCOPE)
+endfunction()
+
+#------------------------------------------------------------------------------
+# Set up git submodule synchronization for an external project.
+#------------------------------------------------------------------------------
+function(drake_forceupdate PROJECT)
+  if(AUTO_UPDATE_EXTERNALS)
+    # CMake < 3.6 forgets to mark the update step as "ALWAYS" when an explicit
+    # UPDATE_COMMAND is used. Add our own "ALWAYS" step to force updates.
+    if(CMAKE_VERSION VERSION_LESS 3.6)
+      ExternalProject_Add_Step(${PROJECT} forceupdate
+        DEPENDEES download
+        DEPENDERS update
+        ALWAYS 1
+        )
+    endif()
+  endif()
+endfunction()
+
+#------------------------------------------------------------------------------
+# Internal helper to set up a CMake external project.
+#------------------------------------------------------------------------------
+macro(drake_add_cmake_external PROJECT)
+  # Set binary directory for external CMake project
+  if(NOT DEFINED _ext_BINARY_DIR)
+    set(_ext_BINARY_DIR ${PROJECT_BINARY_DIR}/externals/${PROJECT})
+  endif()
+
+  # Propagate build verbosity
+  if(CMAKE_VERBOSE_MAKEFILE)
+    set(_ext_VERBOSE -DCMAKE_VERBOSE_MAKEFILE=ON)
+  endif()
+
+  # Capture additional commands for the external project
+  set(_ext_EXTRA_COMMANDS)
+  foreach(_command BUILD_COMMAND INSTALL_COMMAND)
+    if(DEFINED _ext_${_command})
+      list(APPEND _ext_EXTRA_COMMANDS ${_command} "${_ext_${_command}}")
+    endif()
+  endforeach()
+
+  # Set arguments for cache propagation
+  set(_ext_LIST_SEPARATOR "!")
+  drake_build_cache_args(_ext_PROPAGATE_CACHE ${_ext_LIST_SEPARATOR}
+    CMAKE_INSTALL_PREFIX
+    CMAKE_BUILD_TYPE
+    BUILD_SHARED_LIBS
+    CMAKE_C_COMPILER
+    CMAKE_C_FLAGS
+    CMAKE_CXX_COMPILER
+    CMAKE_CXX_FLAGS
+    CMAKE_EXE_LINKER_FLAGS
+    CMAKE_MODULE_LINKER_FLAGS
+    CMAKE_SHARED_LINKER_FLAGS
+    CMAKE_STATIC_LINKER_FLAGS
+    Java_JAVA_EXECUTABLE
+    Java_JAVAC_EXECUTABLE
+    Java_JAVAH_EXECUTABLE
+    Java_VERSION_STRING
+    CMAKE_JAVA_COMPILE_FLAGS)
+
+  # Set up the external project build
+  ExternalProject_Add(${PROJECT}
+    LIST_SEPARATOR "${_ext_LIST_SEPARATOR}"
+    SOURCE_DIR ${_ext_SOURCE_DIR}
+    BINARY_DIR ${_ext_BINARY_DIR}
+    DOWNLOAD_DIR ${PROJECT_SOURCE_DIR}
+    DOWNLOAD_COMMAND ${_ext_DOWNLOAD_COMMAND}
+    UPDATE_COMMAND ${_ext_UPDATE_COMMAND}
+    ${_ext_EXTRA_COMMANDS}
+    INDEPENDENT_STEP_TARGETS update
+    BUILD_ALWAYS 1
+    DEPENDS ${_ext_deps}
+    CMAKE_GENERATOR ${CMAKE_GENERATOR}
+    CMAKE_ARGS
+      ${_ext_VERBOSE}
+      ${_ext_PROPAGATE_CACHE}
+      ${_ext_CMAKE_ARGS})
+endmacro()
+
+#------------------------------------------------------------------------------
+# Internal helper to set up a non-CMake external project.
+#------------------------------------------------------------------------------
+macro(drake_add_foreign_external PROJECT)
+  # Set binary directory (default: in-source) for external non-CMake project
+  if(NOT _ext_BINARY_DIR)
+    set(_ext_BINARY_DIR ${_ext_SOURCE_DIR})
+  endif()
+
+  # Set default build command for project
+  if(NOT DEFINED _ext_BUILD_COMMAND)
+    if(CMAKE_VERBOSE_MAKEFILE)
+      set(_ext_VERBOSE "V=1 VERBOSE=1")
+    endif()
+    set(_ext_BUILD_COMMAND ${MAKE_COMMAND}
+      ${_ext_VERBOSE}
+      BUILD_PREFIX=${CMAKE_INSTALL_PREFIX}
+      BUILD_TYPE=$<CONFIGURATION>)
+    if(_ext_BUILD_COMMAND_DIR)
+      # FIXME: This is only needed for Director due to the unusual build setup
+      #        used by the same. We should fix director to be a 'normal' CMake
+      #        project, and remove this option
+      set(_ext_BUILD_COMMAND ${CMAKE_COMMAND}
+        -E chdir ${_ext_BUILD_COMMAND_DIR}
+        ${_ext_BUILD_COMMAND})
+    endif()
+  endif()
+
+  if(NOT _ext_BUILD_COMMAND STREQUAL "")
+    set(_ext_BUILD_ALWAYS 1)
+  else()
+    set(_ext_BUILD_ALWAYS 0)
+  endif()
+
+  ExternalProject_Add(${PROJECT}
+    SOURCE_DIR ${_ext_SOURCE_DIR}
+    BINARY_DIR ${_ext_BINARY_DIR}
+    DOWNLOAD_DIR ${PROJECT_SOURCE_DIR}
+    DOWNLOAD_COMMAND "${_ext_DOWNLOAD_COMMAND}"
+    UPDATE_COMMAND "${_ext_UPDATE_COMMAND}"
+    PATCH_COMMAND "${_ext_PATCH_COMMAND}"
+    CONFIGURE_COMMAND "${_ext_CONFIGURE_COMMAND}"
+    BUILD_COMMAND "${_ext_BUILD_COMMAND}"
+    INSTALL_COMMAND "${_ext_INSTALL_COMMAND}"
+    INDEPENDENT_STEP_TARGETS update
+    BUILD_ALWAYS ${_ext_BUILD_ALWAYS}
+    DEPENDS ${_ext_deps})
+endmacro()
+
+#------------------------------------------------------------------------------
+# Add an external project.
+#
+# Arguments:
+#   LOCAL  - External is local to the source tree (i.e. not a submodule)
+#   PUBLIC - External is public
+#   CMAKE  - External uses CMake
+#   ALWAYS - External is always built
+#
+#   REQUIRES <deps...>
+#       List of packages (checked via `find_package`) that are required to
+#       build the external. Only checked if the external will be built.
+#
+#   DEPENDS <deps...>
+#       List of other external projects on which this external depends. Used to
+#       ensure correct build order. (Dependencies which are not enabled will be
+#       ignored.)
+#
+#   SOURCE_DIR <dir> - Override default SOURCE_DIR for external
+#   BINARY_DIR <dir> - Override default BINARY_DIR for external
+#
+#   PATCH_COMMAND <args...>
+#   CONFIGURE_COMMAND <args...>
+#   BUILD_COMMAND <args...>
+#   INSTALL_COMMAND <args...>
+#       Specify the corresponding command for the external project. Commands
+#       with variables like `@VAR@` will expand such variables after the
+#       project's dependencies are found (useful if `VAR` is set by finding
+#       said dependencies). The special value `:` indicates that the
+#       corresponding step should be skipped (the `:` is replaced with a no-op
+#       command).
+#
+#   CMAKE_ARGS <args...>
+#       Additional arguments to be passed to the CMake external's CONFIGURE
+#       step.
+#
+# Arguments with the same name as arguments to `ExternalProject_Add` generally
+# have the same function and are passed through.
+#------------------------------------------------------------------------------
+function(drake_add_external PROJECT)
+  # Parse arguments
+  set(_ext_extra_commands
+    PATCH_COMMAND
+    CONFIGURE_COMMAND
+    BUILD_COMMAND
+    INSTALL_COMMAND)
+  set(_ext_flags LOCAL PUBLIC CMAKE ALWAYS)
+  set(_ext_sv_args
+    SOURCE_DIR
+    BINARY_DIR
+    BUILD_COMMAND_DIR # FIXME: fix director then remove this
+  )
+  set(_ext_mv_args
+    CMAKE_ARGS
+    REQUIRES
+    DEPENDS
+    ${_ext_extra_commands}
+  )
+  cmake_parse_arguments(_ext
+    "${_ext_flags}" "${_ext_sv_args}" "${_ext_mv_args}" ${ARGN})
+
+  # Determine if this project is enabled
+  string(TOUPPER WITH_${PROJECT} _ext_project_option)
+  if(_ext_ALWAYS)
+    # Project is always enabled
+  elseif(DEFINED ${_ext_project_option})
+    if(${_ext_project_option})
+      # Project is explicitly enabled
+    elseif(WITH_ALL_PUBLIC_EXTERNALS AND DEFINED _ext_PUBLIC)
+      # Project is public and all public externals are requested
+    elseif(WITH_ALL_SUPPORTED_EXTERNALS)
+      # All supported externals are requested
+    else()
+      # Project is NOT enabled; skip it
+      return()
+    endif()
+  else()
+    # Project is not supported on this platform; skip it
+    return()
+  endif()
+
+  # Check external dependencies of project
+  set(_ext_reqs_found TRUE)
+  foreach(_ext_req IN LISTS _ext_REQUIRES)
+    find_package(${_ext_req})
+    if(NOT ${_ext_req}_FOUND)
+      message(SEND_ERROR "Could not find ${_ext_req}, required for ${PROJECT}")
+      set(_ext_reqs_found FALSE)
+    endif()
+  endforeach()
+  if(NOT _ext_reqs_found)
+    # One or more required packages was not found
+    return()
+  endif()
+
+  # Replace placeholders in commands
+  drake_fixup_commands(_ext ${_ext_extra_commands})
+
+  # Set source directory for external project
+  if(NOT DEFINED _ext_SOURCE_DIR)
+    set(_ext_SOURCE_DIR ${PROJECT_SOURCE_DIR}/externals/${PROJECT})
+  endif()
+
+  # Compute project dependencies
+  drake_compute_dependencies(_ext_deps ${_ext_DEPENDS})
+  if(NOT DEFINED _ext_deps)
+    message(STATUS
+      "Preparing to build ${PROJECT}")
+  else()
+    message(STATUS
+      "Preparing to build ${PROJECT} with dependencies ${_ext_deps}")
+  endif()
+
+  # Manage updates to the submodule
+  if(NOT _ext_LOCAL)
+    # Compute the path to the submodule for this external
+    file(RELATIVE_PATH _ext_GIT_SUBMODULE_PATH
+      ${PROJECT_SOURCE_DIR} ${_ext_SOURCE_DIR})
+
+    # Set up submodule and commands for synchronizing submodule
+    drake_add_submodule(${_ext_GIT_SUBMODULE_PATH}
+      _ext_DOWNLOAD_COMMAND _ext_UPDATE_COMMAND)
+  else()
+    # Local "externals" have no download or update step
+    set(_ext_DOWNLOAD_COMMAND "")
+    set(_ext_UPDATE_COMMAND "")
+  endif()
+
+  # Add the external project
+  set(_ext_VERBOSE)
+  if(_ext_CMAKE)
+    drake_add_cmake_external(${PROJECT})
+  else()
+    drake_add_foreign_external(${PROJECT})
+  endif()
+
+  if(NOT _ext_LOCAL)
+    # Set up build step to ensure project is updated before build
+    drake_forceupdate(${PROJECT})
+
+    # Add external to download dependencies
+    add_dependencies(download-all ${PROJECT}-update)
+  endif()
+
+  if(AUTO_UPDATE_EXTERNALS AND CMAKE_GENERATOR STREQUAL "Ninja")
+    # Due to a quirk of how the CMake Ninja generator computes dependencies,
+    # all targets that contain a submodule update command, or depend on a
+    # target that does, need to depend on the submodule-sync target, or the
+    # direct dependency will be lost.
+    #
+    # TODO(bradking) This is expected to be fixed in CMake 3.7; add a version
+    # check when that is confirmed.
+    foreach(_step_target ${PROJECT} ${PROJECT}-update)
+      if(TARGET ${_step_target})
+        add_dependencies(${_step_target} submodule-sync)
+      endif()
+    endforeach()
+  endif()
+
+  # Add extra per-project targets
+  add_custom_target(status-${PROJECT}
+    COMMAND ${GIT_EXECUTABLE} status
+    WORKING_DIRECTORY ${_ext_SOURCE_DIR})
+  add_dependencies(status status-${PROJECT})
+
+  # Register project in list of external projects
+  list(APPEND EXTERNAL_PROJECTS ${PROJECT})
+  set(EXTERNAL_PROJECTS ${EXTERNAL_PROJECTS} PARENT_SCOPE)
+endfunction()
+
+###############################################################################
+
+# Options controlling external dependencies
+option(AUTO_UPDATE_EXTERNALS
+  "Update external projects to their tag revision on compile"
+  ON)
+
+option(WITH_ALL_PUBLIC_EXTERNALS
+  "Enable all externals available to public academic users"
+  OFF)
+
+option(WITH_ALL_SUPPORTED_EXTERNALS
+  "Enable all externals available for your platform (includes private git repositories)"
+  OFF)
+
+# Special targets
+add_custom_target(download-all)
+add_custom_target(status)
+
+if(AUTO_UPDATE_EXTERNALS)
+  # Set up a special target to synchronize all submodules. We do this
+  # separately to avoid conflicting updates that could result if we tried to
+  # synchronize multiple submodules in parallel.
+  add_custom_target(submodule-sync
+    COMMAND ${GIT_EXECUTABLE} submodule --quiet sync --
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif()
+
+# TODO: add a custom target for release_filelist
+
+# List of all enabled external projects
+set(EXTERNAL_PROJECTS)

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -132,6 +132,7 @@ macro(drake_add_cmake_external PROJECT)
   # Set arguments for cache propagation
   set(_ext_LIST_SEPARATOR "!")
   drake_build_cache_args(_ext_PROPAGATE_CACHE ${_ext_LIST_SEPARATOR}
+    CMAKE_PREFIX_PATH
     CMAKE_INSTALL_PREFIX
     CMAKE_BUILD_TYPE
     BUILD_SHARED_LIBS


### PR DESCRIPTION
Continue refactoring the top-level CMakeLists.txt (i.e. 'the superbuild') into several files (see also part 1: #2820). In particular, this extracts the external project logic into functions and converts the mostly-declarative (and somewhat superfluously repetitive) logic for setting up externals into more imperative/procedural logic that is hopefully better organized and easier to read.

One particular change of note is that all special case "externals" have been removed in favor of new options `ALWAYS` and `LOCAL`, indicating, respectively, that an external is always enabled, and that an external is local to the repository (does not need download/update steps). This allows drake itself to be simply a `LOCAL`, `ALWAYS` subproject rather than having a completely separate block for setting up the subproject. The mechanism for propagating cache values from the superbuild to the external projects has also been improved.

The overall formatting and documentation (comments) of the superbuild logic has also been improved. In particular, the new functions all have at least a brief blurb describing their purpose, and similar documentation has been added to the recently added functions in `config.cmake`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2896)
<!-- Reviewable:end -->
