### PR TITLE
Made RigidBody::name_ private. Renamed accessor to be get_name()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Unreleased: changes on master, not yet released
 [//]: # "Altered functionality or APIs."
 ### Changed
 
+ - [#2900][] Made `RigidBody::name_` private. Re-named `RigidBody::name()` to be `RigidBody::get_name()`. Added `RigidBody::set_name()`.
  - [#2666][] Changed `TWIST_SIZE` to `drake::kTwistSize`
  - [#2597][] Changed `RigidBodyTree::findLink()` to be `RigidBodyTree::FindBody()`.
  - [#2426][] Changed `RigidBodyTree::findLinkId()` to be `RigidBodyTree::FindBodyIndex()`. Updated APIs of `RigidBodyTree`, `RigidBody`, `RigidBodyTree`, and `RigidBodyFrame` to support notion of a "model ID" that uniquely identifies a model within a `RigidBodySystem`. This enables the same SDF file to be loaded multiple times into the same `RigidBodySystem`.
@@ -82,3 +83,4 @@ Changes in version v0.9.11 and before are not provided.
 [#2621]: https://github.com/RobotLocomotion/drake/issues/2621
 [#2666]: https://github.com/RobotLocomotion/drake/issues/2666
 [#2779]: https://github.com/RobotLocomotion/drake/issues/2779
+[#2900]: https://github.com/RobotLocomotion/drake/issues/2990

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,4 +83,4 @@ Changes in version v0.9.11 and before are not provided.
 [#2621]: https://github.com/RobotLocomotion/drake/issues/2621
 [#2666]: https://github.com/RobotLocomotion/drake/issues/2666
 [#2779]: https://github.com/RobotLocomotion/drake/issues/2779
-[#2900]: https://github.com/RobotLocomotion/drake/issues/2990
+[#2900]: https://github.com/RobotLocomotion/drake/issues/2900

--- a/drake/bindings/python/pydrake/test/testPR2IK.py
+++ b/drake/bindings/python/pydrake/test/testPR2IK.py
@@ -16,7 +16,7 @@ robot.addFrame(
                                          np.array([0., 0, 0])))
 
 # Make sure attribute access works on bodies
-assert robot.world().name() == "world"
+assert robot.world().get_name() == "world"
 
 hand_frame_id = robot.findFrame("r_hand_frame").frame_index
 base_body_id = robot.FindBody('base_footprint').body_index

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -573,7 +573,7 @@ std::unordered_map<std::string, int> computeBodyOrFrameNameToIdMap(
     const RigidBodyTree& robot) {
   auto id_map = std::unordered_map<std::string, int>();
   for (auto it = robot.bodies.begin(); it != robot.bodies.end(); ++it) {
-    id_map[(*it)->name_] = it - robot.bodies.begin();
+    id_map[(*it)->get_name()] = it - robot.bodies.begin();
   }
 
   for (auto it = robot.frames.begin(); it != robot.frames.end(); ++it) {

--- a/drake/systems/plants/BotVisualizer.h
+++ b/drake/systems/plants/BotVisualizer.h
@@ -53,7 +53,7 @@ class BotVisualizer {
     draw_msg.num_links = tree->bodies.size();
     std::vector<float> position = {0, 0, 0}, quaternion = {0, 0, 0, 1};
     for (const auto& body : tree->bodies) {
-      draw_msg.link_name.push_back(body->name_);
+      draw_msg.link_name.push_back(body->get_name());
       draw_msg.robot_num.push_back(body->robotnum);
       draw_msg.position.push_back(position);
       draw_msg.quaternion.push_back(quaternion);
@@ -65,7 +65,7 @@ class BotVisualizer {
     vr.num_links = tree->bodies.size();
     for (const auto& body : tree->bodies) {
       drake::lcmt_viewer_link_data link;
-      link.name = body->name_;
+      link.name = body->get_name();
       link.robot_num = body->robotnum;
       link.num_geom = body->visual_elements.size();
       for (const auto& v : body->visual_elements) {

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -27,7 +27,9 @@ RigidBody::RigidBody()
   I << drake::SquareTwistMatrix<double>::Zero();
 }
 
-const std::string& RigidBody::name() const { return name_; }
+const std::string& RigidBody::get_name() const { return name_; }
+
+void RigidBody::set_name(const std::string& name) { name_ = name; }
 
 const std::string& RigidBody::model_name() const { return model_name_; }
 
@@ -121,7 +123,7 @@ RigidBody::CollisionElement::CollisionElement(
   // Collision elements should be set to static in a later Initialize() stage as
   // described in issue #2661.
   // TODO(amcastro-tri): remove this hack.
-  if (body->name() == "world") set_static();
+  if (body->get_name() == "world") set_static();
 }
 
 RigidBody::CollisionElement* RigidBody::CollisionElement::clone() const {

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -29,7 +29,12 @@ class DRAKERBM_EXPORT RigidBody {
    *
    * @return The name of the body that's modeled by this rigid body.
    */
-  const std::string& name() const;
+  const std::string& get_name() const;
+
+  /**
+   * Sets the name of this rigid body.
+   */
+  void set_name(const std::string& name);
 
   /**
    * An accessor for the name of the model or robot that this rigid body is
@@ -142,8 +147,7 @@ class DRAKERBM_EXPORT RigidBody {
       const Eigen::Isometry3d& transform_body_to_joint);
 
  public:
-  /// The name of this rigid body.
-  std::string name_;
+
 
   /// The name of the model to which this rigid body belongs.
   std::string model_name_;
@@ -216,4 +220,8 @@ class DRAKERBM_EXPORT RigidBody {
 #ifndef SWIG
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 #endif
+
+ private:
+  // The name of this rigid body.
+  std::string name_;
 };

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -147,8 +147,6 @@ class DRAKERBM_EXPORT RigidBody {
       const Eigen::Isometry3d& transform_body_to_joint);
 
  public:
-
-
   /// The name of the model to which this rigid body belongs.
   std::string model_name_;
 

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -749,7 +749,7 @@ void parseSDFLink(RigidBodySystem& sys, int model_id, XMLElement* node,
   if (pose) {
     poseValueToTransform(pose, pose_map, transform_link_to_model);
     pose_map.insert(
-        std::pair<string, Isometry3d>(body->name_, transform_link_to_model));
+        std::pair<string, Isometry3d>(body->get_name(), transform_link_to_model));
   }
 
   // Processes each sensor element within the link.

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -315,8 +315,7 @@ DRAKERBSYSTEM_EXPORT RigidBodySystem::StateVector<double> getInitialState(
       prog.AddGenericConstraint(con1wrapper, {qvar});
       constraints.push_back(RelativePositionConstraint(
           sys.tree.get(), loop.axis, loop.axis, loop.axis,
-          loop.frameA->frame_index, loop.frameB->frame_index, bTbp,
-          tspan));
+          loop.frameA->frame_index, loop.frameB->frame_index, bTbp, tspan));
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(
           new SingleTimeKinematicConstraintWrapper(&constraints.back(),
                                                    &kin_helper));
@@ -748,8 +747,8 @@ void parseSDFLink(RigidBodySystem& sys, int model_id, XMLElement* node,
   XMLElement* pose = node->FirstChildElement("pose");
   if (pose) {
     poseValueToTransform(pose, pose_map, transform_link_to_model);
-    pose_map.insert(
-        std::pair<string, Isometry3d>(body->get_name(), transform_link_to_model));
+    pose_map.insert(std::pair<string, Isometry3d>(body->get_name(),
+                                                  transform_link_to_model));
   }
 
   // Processes each sensor element within the link.
@@ -889,7 +888,7 @@ void RigidBodySystem::addRobotFromURDFString(
     const DrakeJoint::FloatingBaseType floating_base_type) {
   // first add the urdf to the rigid body tree
   drake::parsers::urdf::AddRobotFromURDFString(urdf_string, root_dir,
-    floating_base_type, tree.get());
+                                               floating_base_type, tree.get());
 
   // now parse additional tags understood by rigid body system (actuators,
   // sensors, etc)
@@ -908,7 +907,7 @@ void RigidBodySystem::addRobotFromURDF(
     std::shared_ptr<RigidBodyFrame> weld_to_frame) {
   // Adds the URDF to the rigid body tree.
   drake::parsers::urdf::AddRobotFromURDF(urdf_filename, floating_base_type,
-    weld_to_frame, tree.get());
+                                         weld_to_frame, tree.get());
 
   // Parses additional tags understood by rigid body system (e.g., actuators,
   // sensors, etc).
@@ -929,7 +928,7 @@ void RigidBodySystem::addRobotFromSDF(
     std::shared_ptr<RigidBodyFrame> weld_to_frame) {
   // Adds the robot to the rigid body tree.
   drake::parsers::sdf::AddRobotFromSDF(sdf_filename, floating_base_type,
-    weld_to_frame, tree.get());
+                                       weld_to_frame, tree.get());
 
   // Parses the additional SDF elements that are understood by RigidBodySystem,
   // namely (actuators, sensors, etc.).

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -315,7 +315,8 @@ DRAKERBSYSTEM_EXPORT RigidBodySystem::StateVector<double> getInitialState(
       prog.AddGenericConstraint(con1wrapper, {qvar});
       constraints.push_back(RelativePositionConstraint(
           sys.tree.get(), loop.axis, loop.axis, loop.axis,
-          loop.frameA->frame_index, loop.frameB->frame_index, bTbp, tspan));
+          loop.frameA->frame_index, loop.frameB->frame_index, bTbp,
+          tspan));
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(
           new SingleTimeKinematicConstraintWrapper(&constraints.back(),
                                                    &kin_helper));

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -73,7 +73,7 @@ RigidBodyTree::RigidBodyTree(void)
 
   // Adds the rigid body representing the world.
   std::unique_ptr<RigidBody> b(new RigidBody());
-  b->name_ = std::string(RigidBodyTree::kWorldLinkName);
+  b->set_name(std::string(RigidBodyTree::kWorldLinkName));
   b->robotnum = 0;
   b->body_index = 0;
   bodies.push_back(std::move(b));
@@ -290,14 +290,14 @@ void RigidBodyTree::drawKinematicTree(
   dotfile.open(graphviz_dotfile_filename);
   dotfile << "digraph {" << endl;
   for (const auto& body : bodies) {
-    dotfile << "  " << body->name_ << " [label=\"" << body->name_ << endl;
+    dotfile << "  " << body->get_name() << " [label=\"" << body->get_name() << endl;
     dotfile << "mass=" << body->mass << ", com=" << body->com.transpose()
             << endl;
     dotfile << "inertia=" << endl << body->I << endl;
     dotfile << "\"];" << endl;
     if (body->hasParent()) {
       const auto& joint = body->getJoint();
-      dotfile << "  " << body->name_ << " -> " << body->parent->name_
+      dotfile << "  " << body->get_name() << " -> " << body->parent->get_name()
               << " [label=\"" << joint.getName() << endl;
       dotfile << "transform_to_parent_body=" << endl
               << joint.getTransformToParentBody().matrix() << endl;
@@ -308,7 +308,7 @@ void RigidBodyTree::drawKinematicTree(
   for (const auto& frame : frames) {
     dotfile << "  " << frame->name << " [label=\"" << frame->name
             << " (frame)\"];" << endl;
-    dotfile << "  " << frame->name << " -> " << frame->body->name_
+    dotfile << "  " << frame->name << " -> " << frame->body->get_name()
             << " [label=\"";
     dotfile << "transform_to_body=" << endl
             << frame->transform_to_body.matrix() << endl;
@@ -316,8 +316,8 @@ void RigidBodyTree::drawKinematicTree(
   }
 
   for (const auto& loop : loops) {
-    dotfile << "  " << loop.frameA->body->name_ << " -> "
-            << loop.frameB->body->name_ << " [label=\"loop " << endl;
+    dotfile << "  " << loop.frameA->body->get_name() << " -> "
+            << loop.frameB->body->get_name() << " [label=\"loop " << endl;
     dotfile << "transform_to_parent_body=" << endl
             << loop.frameA->transform_to_body.matrix() << endl;
     dotfile << "transform_to_child_body=" << endl
@@ -1084,8 +1084,8 @@ KinematicPath RigidBodyTree::findKinematicPath(
 
   if (!least_common_ancestor_found) {
     std::ostringstream stream;
-    stream << "There is no path between " << bodies[start_body]->name_
-           << " and " << bodies[end_body]->name_ << ".";
+    stream << "There is no path between " << bodies[start_body]->get_name()
+           << " and " << bodies[end_body]->get_name() << ".";
     throw std::runtime_error(stream.str());
   }
   int least_common_ancestor = *start_body_lca_it;
@@ -1685,7 +1685,7 @@ RigidBody* RigidBodyTree::FindBody(const std::string& body_name,
       continue;
 
     // Obtains a lower case version of the current body's name.
-    string current_body_name = bodies[ii]->name_;
+    string current_body_name = bodies[ii]->get_name();
     std::transform(current_body_name.begin(), current_body_name.end(),
                    current_body_name.begin(), ::tolower);
 
@@ -1853,7 +1853,7 @@ int RigidBodyTree::findJointId(const std::string& joint_name, int robot) const {
 
 std::string RigidBodyTree::getBodyOrFrameName(int body_or_frame_id) const {
   if (body_or_frame_id >= 0) {
-    return bodies[body_or_frame_id]->name_;
+    return bodies[body_or_frame_id]->get_name();
   } else if (body_or_frame_id < -1) {
     return frames[-body_or_frame_id - 2]->name;
   } else {
@@ -2028,8 +2028,8 @@ int RigidBodyTree::AddFloatingJoint(
 
       Eigen::Isometry3d transform_to_model = Eigen::Isometry3d::Identity();
       if (pose_map != nullptr &&
-          pose_map->find(bodies[i]->name_) != pose_map->end())
-        transform_to_model = pose_map->at(bodies[i]->name_);
+          pose_map->find(bodies[i]->get_name()) != pose_map->end())
+        transform_to_model = pose_map->at(bodies[i]->get_name());
 
       switch (floating_base_type) {
         case DrakeJoint::FIXED: {

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1,4 +1,4 @@
-#include "drake/systems/plants/RigidBodyTree.h"
+  #include "drake/systems/plants/RigidBodyTree.h"
 
 #include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
@@ -73,7 +73,7 @@ RigidBodyTree::RigidBodyTree(void)
 
   // Adds the rigid body representing the world.
   std::unique_ptr<RigidBody> b(new RigidBody());
-  b->set_name(std::string(RigidBodyTree::kWorldLinkName));
+  b->set_name(RigidBodyTree::kWorldLinkName);
   b->robotnum = 0;
   b->body_index = 0;
   bodies.push_back(std::move(b));

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -63,7 +63,7 @@ RigidBodyTree::RigidBodyTree(
     const DrakeJoint::FloatingBaseType floating_base_type)
     : RigidBodyTree() {
   drake::parsers::urdf::AddRobotFromURDF(urdf_filename, floating_base_type,
-    this);
+                                         this);
 }
 
 RigidBodyTree::RigidBodyTree(void)
@@ -290,7 +290,8 @@ void RigidBodyTree::drawKinematicTree(
   dotfile.open(graphviz_dotfile_filename);
   dotfile << "digraph {" << endl;
   for (const auto& body : bodies) {
-    dotfile << "  " << body->get_name() << " [label=\"" << body->get_name() << endl;
+    dotfile << "  " << body->get_name() << " [label=\"" << body->get_name()
+            << endl;
     dotfile << "mass=" << body->mass << ", com=" << body->com.transpose()
             << endl;
     dotfile << "inertia=" << endl << body->I << endl;
@@ -483,8 +484,8 @@ bool RigidBodyTree::collisionDetect(
   for (const int& body_idx : bodies_idx) {
     if (body_idx >= 0 && body_idx < static_cast<int>(bodies.size())) {
       for (const string& group : active_element_groups) {
-        bodies[body_idx]->appendCollisionElementIdsFromThisBody(
-            group, ids_to_check);
+        bodies[body_idx]->appendCollisionElementIdsFromThisBody(group,
+                                                                ids_to_check);
       }
     }
   }
@@ -560,10 +561,8 @@ void RigidBodyTree::potentialCollisions(const KinematicsCache<double>& cache,
   bodyB_idx.clear();
 
   for (size_t i = 0; i < num_potential_collisions; i++) {
-    const DrakeCollision::Element* elementA =
-        potential_collisions[i].elementA;
-    const DrakeCollision::Element* elementB =
-        potential_collisions[i].elementB;
+    const DrakeCollision::Element* elementA = potential_collisions[i].elementA;
+    const DrakeCollision::Element* elementB = potential_collisions[i].elementB;
     xA.col(i) = potential_collisions[i].ptA;
     xB.col(i) = potential_collisions[i].ptB;
     normal.col(i) = potential_collisions[i].normal;
@@ -578,8 +577,8 @@ RigidBodyTree::ComputeMaximumDepthCollisionPoints(
     const KinematicsCache<double>& cache, bool use_margins) {
   updateDynamicCollisionElements(cache);
   vector<DrakeCollision::PointPair> contact_points;
-  collision_model->ComputeMaximumDepthCollisionPoints(
-      use_margins, contact_points);
+  collision_model->ComputeMaximumDepthCollisionPoints(use_margins,
+                                                      contact_points);
   size_t num_contact_points = contact_points.size();
 
   for (size_t i = 0; i < num_contact_points; i++) {
@@ -1593,8 +1592,8 @@ RigidBodyTree::relativeQuaternionJacobianDotTimesV(
       static_cast<typename Gradient<decltype(Phi_autodiff), Dynamic>::type*>(
           nullptr));
   auto Phidot_vector = autoDiffToGradientMatrix(Phi_autodiff);
-  Map<Matrix<Scalar, kQuaternionSize, kSpaceDimension>>
-      Phid(Phidot_vector.data());
+  Map<Matrix<Scalar, kQuaternionSize, kSpaceDimension>> Phid(
+      Phidot_vector.data());
 
   const auto J_geometric_dot_times_v = geometricJacobianDotTimesV(
       cache, to_body_or_frame_ind, from_body_or_frame_ind, expressed_in);
@@ -2076,7 +2075,8 @@ void RigidBodyTree::addRobotFromURDFString(
     std::shared_ptr<RigidBodyFrame> weld_to_frame) {
   PackageMap package_map;
   drake::parsers::urdf::AddRobotFromURDFString(xml_string, package_map,
-    root_dir, floating_base_type, weld_to_frame, this);
+                                               root_dir, floating_base_type,
+                                               weld_to_frame, this);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.
@@ -2087,7 +2087,8 @@ void RigidBodyTree::addRobotFromURDFString(
     const DrakeJoint::FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame> weld_to_frame) {
   drake::parsers::urdf::AddRobotFromURDFString(xml_string, package_map,
-    root_dir, floating_base_type, weld_to_frame, this);
+                                               root_dir, floating_base_type,
+                                               weld_to_frame, this);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.
@@ -2096,8 +2097,8 @@ void RigidBodyTree::addRobotFromURDF(
     const DrakeJoint::FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame> weld_to_frame) {
   PackageMap package_map;
-  drake::parsers::urdf::AddRobotFromURDF(urdf_filename, package_map,
-    floating_base_type, weld_to_frame, this);
+  drake::parsers::urdf::AddRobotFromURDF(
+      urdf_filename, package_map, floating_base_type, weld_to_frame, this);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.
@@ -2106,8 +2107,8 @@ void RigidBodyTree::addRobotFromURDF(
     std::map<std::string, std::string>& package_map,
     const DrakeJoint::FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame> weld_to_frame) {
-  drake::parsers::urdf::AddRobotFromURDF(urdf_filename, package_map,
-    floating_base_type, weld_to_frame, this);
+  drake::parsers::urdf::AddRobotFromURDF(
+      urdf_filename, package_map, floating_base_type, weld_to_frame, this);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.
@@ -2116,7 +2117,7 @@ void RigidBodyTree::addRobotFromSDF(
     const DrakeJoint::FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame> weld_to_frame) {
   drake::parsers::sdf::AddRobotFromSDF(sdf_filename, floating_base_type,
-                                         weld_to_frame, this);
+                                       weld_to_frame, this);
 }
 
 // Explicit template instantiations for massMatrix.
@@ -2452,7 +2453,7 @@ template DRAKERBM_EXPORT KinematicsCache<double> RigidBodyTree::doKinematics(
 template DRAKERBM_EXPORT KinematicsCache<AutoDiffXd>
 RigidBodyTree::doKinematics(
     Eigen::MatrixBase<VectorX<AutoDiffXd>> const&) const;
-template DRAKERBM_EXPORT KinematicsCache<double>RigidBodyTree::doKinematics(
+template DRAKERBM_EXPORT KinematicsCache<double> RigidBodyTree::doKinematics(
     Eigen::MatrixBase<Eigen::Block<VectorXd, -1, 1, false>> const&) const;
 
 // Explicit template instantiations for doKinematics(q, v).

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -864,8 +864,8 @@ RelativeQuatConstraint::RelativeQuatConstraint(RigidBodyTree* robot,
     : QuatConstraint(robot, tol, tspan),
       bodyA_idx_(bodyA_idx),
       bodyB_idx_(bodyB_idx),
-      bodyA_name_(robot->bodies[bodyA_idx]->name()),
-      bodyB_name_(robot->bodies[bodyB_idx]->name()) {
+      bodyA_name_(robot->bodies[bodyA_idx]->get_name()),
+      bodyB_name_(robot->bodies[bodyB_idx]->get_name()) {
   const double quat_norm = quat_des.norm();
   quat_des_ = quat_des / quat_norm;
   set_type(RigidBodyConstraint::RelativeQuatConstraintType);
@@ -1277,8 +1277,8 @@ RelativeGazeTargetConstraint::RelativeGazeTargetConstraint(
                            tspan),
       bodyA_idx_(bodyA_idx),
       bodyB_idx_(bodyB_idx),
-      bodyA_name_(robot->bodies[bodyA_idx]->name()),
-      bodyB_name_(robot->bodies[bodyB_idx]->name()) {
+      bodyA_name_(robot->bodies[bodyA_idx]->get_name()),
+      bodyB_name_(robot->bodies[bodyB_idx]->get_name()) {
   set_type(RigidBodyConstraint::RelativeGazeTargetConstraintType);
 }
 
@@ -1345,8 +1345,8 @@ RelativeGazeDirConstraint::RelativeGazeDirConstraint(
     : GazeDirConstraint(robot, axis, dir, conethreshold, tspan),
       bodyA_idx_(bodyA_idx),
       bodyB_idx_(bodyB_idx),
-      bodyA_name_(robot->bodies[bodyA_idx]->name()),
-      bodyB_name_(robot->bodies[bodyB_idx]->name()) {
+      bodyA_name_(robot->bodies[bodyA_idx]->get_name()),
+      bodyB_name_(robot->bodies[bodyB_idx]->get_name()) {
   set_type(RigidBodyConstraint::RelativeGazeDirConstraintType);
 }
 
@@ -1467,13 +1467,13 @@ void Point2PointDistanceConstraint::name(
     for (int i = 0; i < num_cnst; i++) {
       std::string bodyA_name;
       if (bodyA_ != 0) {
-        bodyA_name = this->getRobotPointer()->bodies[bodyA_]->name();
+        bodyA_name = this->getRobotPointer()->bodies[bodyA_]->get_name();
       } else {
         bodyA_name = std::string(RigidBodyTree::kWorldLinkName);
       }
       std::string bodyB_name;
       if (bodyB_ != 0) {
-        bodyB_name = this->getRobotPointer()->bodies[bodyB_]->name();
+        bodyB_name = this->getRobotPointer()->bodies[bodyB_]->get_name();
       } else {
         bodyB_name = std::string(RigidBodyTree::kWorldLinkName);
       }
@@ -1572,9 +1572,9 @@ void Point2LineSegDistConstraint::name(
   if (this->isTimeValid(t)) {
     std::string time_str = this->getTimeString(t);
     name_str.push_back(
-        "Distance from " + this->getRobotPointer()->bodies[pt_body_]->name() +
+        "Distance from " + this->getRobotPointer()->bodies[pt_body_]->get_name() +
         " pt to a line on " +
-        this->getRobotPointer()->bodies[line_body_]->name() + time_str);
+        this->getRobotPointer()->bodies[line_body_]->get_name() + time_str);
     name_str.push_back("Fraction of point projection onto line segment " +
                        time_str);
   }

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -1571,10 +1571,11 @@ void Point2LineSegDistConstraint::name(
     const double* t, std::vector<std::string>& name_str) const {
   if (this->isTimeValid(t)) {
     std::string time_str = this->getTimeString(t);
-    name_str.push_back(
-        "Distance from " + this->getRobotPointer()->bodies[pt_body_]->get_name() +
-        " pt to a line on " +
-        this->getRobotPointer()->bodies[line_body_]->get_name() + time_str);
+    name_str.push_back("Distance from " +
+                       this->getRobotPointer()->bodies[pt_body_]->get_name() +
+                       " pt to a line on " +
+                       this->getRobotPointer()->bodies[line_body_]->get_name() +
+                       time_str);
     name_str.push_back("Fraction of point projection onto line segment " +
                        time_str);
   }

--- a/drake/systems/plants/constructModelmex.cpp
+++ b/drake/systems/plants/constructModelmex.cpp
@@ -81,7 +81,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
     std::unique_ptr<RigidBody> b(new RigidBody());
     b->body_index = i;
 
-    b->name_ = mxGetStdString(mxGetPropertySafe(pBodies, i, "linkname"));
+    b->set_name(mxGetStdString(mxGetPropertySafe(pBodies, i, "linkname")));
 
     pm = mxGetPropertySafe(pBodies, i, "robotnum");
     b->robotnum = (int)mxGetScalar(pm) - 1;

--- a/drake/systems/plants/parser_sdf.cc
+++ b/drake/systems/plants/parser_sdf.cc
@@ -175,7 +175,7 @@ void parseSDFVisual(RigidBody* body, XMLElement* node, RigidBodyTree* model,
   XMLElement* geometry_node = node->FirstChildElement("geometry");
   if (!geometry_node) {
     throw runtime_error(std::string(__FILE__) + ": " + __func__ +
-                        ": ERROR: Link " + body->name_ +
+                        ": ERROR: Link " + body->get_name() +
                         " has a visual element without a geometry.");
   }
 
@@ -184,7 +184,7 @@ void parseSDFVisual(RigidBody* body, XMLElement* node, RigidBodyTree* model,
   if (!parseSDFGeometry(geometry_node, package_map, root_dir, element)) {
     throw runtime_error(std::string(__FILE__) + ": " + __func__ +
                         ": ERROR: Failed to parse visual element in link " +
-                        body->name_ + ".");
+                        body->get_name() + ".");
   }
 
   XMLElement* material_node = node->FirstChildElement("material");
@@ -225,7 +225,7 @@ void parseSDFCollision(RigidBody* body, XMLElement* node, RigidBodyTree* model,
   XMLElement* geometry_node = node->FirstChildElement("geometry");
   if (!geometry_node) {
     throw runtime_error(std::string(__FILE__) + ": " + __func__ +
-                        ": ERROR: Link " + body->name_ +
+                        ": ERROR: Link " + body->get_name() +
                         " has a collision element without a geometry.");
   }
 
@@ -247,12 +247,12 @@ void parseSDFCollision(RigidBody* body, XMLElement* node, RigidBodyTree* model,
   //  Issue 2661 was created to track this problem.
   // TODO(amcastro-tri): fix the above issue tracked by 2661. Similarly for
   // parseCollision in RigidBodyTreeURDF.cpp.
-  if (body->name().compare(std::string(RigidBodyTree::kWorldLinkName)) == 0)
+  if (body->get_name().compare(std::string(RigidBodyTree::kWorldLinkName)) == 0)
     element.set_static();
   if (!parseSDFGeometry(geometry_node, package_map, root_dir, element)) {
     throw runtime_error(std::string(__FILE__) + ": " + __func__ +
                         ": ERROR: Failed to parse collision element in link " +
-                        body->name_ + ".");
+                        body->get_name() + ".");
   }
 
   if (element.hasGeometry())
@@ -276,9 +276,9 @@ bool parseSDFLink(RigidBodyTree* model, std::string model_name,
     throw runtime_error(std::string(__FILE__) + ": " + __func__ +
                         ": ERROR: Link tag is missing a name attribute.");
   }
-  body->name_ = attr;
+  body->set_name(std::string(attr));
 
-  if (body->name_ == std::string(RigidBodyTree::kWorldLinkName)) {
+  if (body->get_name() == std::string(RigidBodyTree::kWorldLinkName)) {
     throw runtime_error(
         std::string(__FILE__) + ": " + __func__ +
         ": ERROR: Do not name a link 'world' because it is a reserved name.");
@@ -289,7 +289,7 @@ bool parseSDFLink(RigidBodyTree* model, std::string model_name,
   if (pose) {
     poseValueToTransform(pose, pose_map, transform_to_model);
     pose_map.insert(
-        std::pair<string, Isometry3d>(body->name_, transform_to_model));
+        std::pair<string, Isometry3d>(body->get_name(), transform_to_model));
   }
 
   XMLElement* inertial_node = node->FirstChildElement("inertial");

--- a/drake/systems/plants/parser_urdf.cc
+++ b/drake/systems/plants/parser_urdf.cc
@@ -530,7 +530,7 @@ bool parseLink(RigidBodyTree* tree, string robot_name, XMLElement* node,
   if (!attr) throw runtime_error("ERROR: link tag is missing name attribute");
 
   // World links are handled by parseWorldJoint().
-  body->set_name(std::string(attr));
+  body->set_name(attr);
   if (body->get_name() == string(RigidBodyTree::kWorldLinkName)) return false;
 
   XMLElement* inertial_node = node->FirstChildElement("inertial");

--- a/drake/systems/plants/parser_urdf.cc
+++ b/drake/systems/plants/parser_urdf.cc
@@ -41,7 +41,7 @@ namespace {
 int findLinkIndex(RigidBodyTree* tree, string link_name) {
   int index = -1;
   for (unsigned int i = 0; i < tree->bodies.size(); i++) {
-    if (link_name.compare(tree->bodies[i]->name_) == 0) {
+    if (link_name.compare(tree->bodies[i]->get_name()) == 0) {
       index = i;
       break;
     }
@@ -351,7 +351,7 @@ void parseVisual(RigidBody* body, XMLElement* node, RigidBodyTree* tree,
   // element, throws an exception if a geometry element does not exist.
   XMLElement* geometry_node = node->FirstChildElement("geometry");
   if (!geometry_node) {
-    throw runtime_error("ERROR: Link " + body->name_ +
+    throw runtime_error("ERROR: Link " + body->get_name() +
                         " has a visual element without geometry.");
   }
 
@@ -368,7 +368,7 @@ void parseVisual(RigidBody* body, XMLElement* node, RigidBodyTree* tree,
   // Parses the geometry specifications of the visualization.
   if (!parseGeometry(geometry_node, package_map, root_dir, element))
     throw runtime_error("ERROR: Failed to parse visual element in link " +
-                        body->name_ + ".");
+                        body->get_name() + ".");
 
   // Parses the material specification of the visualization. Note that we cannot
   // reuse the logic within ParseMaterial() here because the context is
@@ -392,7 +392,7 @@ void parseVisual(RigidBody* body, XMLElement* node, RigidBodyTree* tree,
           throw runtime_error(
               "ERROR: Failed to parse color of material for "
               "model \"" +
-              body->model_name() + "\", link \"" + body->name() + "\".");
+              body->model_name() + "\", link \"" + body->get_name() + "\".");
         }
         color_specified = true;
       }
@@ -458,7 +458,7 @@ void parseVisual(RigidBody* body, XMLElement* node, RigidBodyTree* tree,
              "be determined."
           << std::endl
           << "  - model name: " << body->model_name() << std::endl
-          << "  - body name: " << body->name() << std::endl
+          << "  - body name: " << body->get_name() << std::endl
           << "  - material name: " << material_name << std::endl;
       throw std::runtime_error(error_buff.str());
     }
@@ -485,7 +485,7 @@ void parseCollision(RigidBody* body, XMLElement* node, RigidBodyTree* tree,
 
   XMLElement* geometry_node = node->FirstChildElement("geometry");
   if (!geometry_node)
-    throw runtime_error("ERROR: Link " + body->name_ +
+    throw runtime_error("ERROR: Link " + body->get_name() +
                         " has a collision element without geometry");
 
   RigidBody::CollisionElement element(T_element_to_link, body);
@@ -505,11 +505,11 @@ void parseCollision(RigidBody* body, XMLElement* node, RigidBodyTree* tree,
   //  Issue 2661 was created to track this problem.
   // TODO(amcastro-tri): fix the above issue tracked by 2661.  Similarly for
   // parseSDFCollision in RigidBodyTreeSDF.cpp.
-  if (body->name().compare(string(RigidBodyTree::kWorldLinkName)) == 0)
+  if (body->get_name().compare(string(RigidBodyTree::kWorldLinkName)) == 0)
     element.set_static();
   if (!parseGeometry(geometry_node, package_map, root_dir, element))
     throw runtime_error("ERROR: Failed to parse collision element in link " +
-                        body->name_ + ".");
+                        body->get_name() + ".");
 
   if (element.hasGeometry()) {
     tree->addCollisionElement(element, *body, group_name);
@@ -530,8 +530,8 @@ bool parseLink(RigidBodyTree* tree, string robot_name, XMLElement* node,
   if (!attr) throw runtime_error("ERROR: link tag is missing name attribute");
 
   // World links are handled by parseWorldJoint().
-  body->name_ = attr;
-  if (body->name_ == string(RigidBodyTree::kWorldLinkName)) return false;
+  body->set_name(std::string(attr));
+  if (body->get_name() == string(RigidBodyTree::kWorldLinkName)) return false;
 
   XMLElement* inertial_node = node->FirstChildElement("inertial");
   if (inertial_node) parseInertial(body, inertial_node);

--- a/drake/systems/plants/rigid_body_loop.cc
+++ b/drake/systems/plants/rigid_body_loop.cc
@@ -8,8 +8,8 @@ RigidBodyLoop::RigidBodyLoop(std::shared_ptr<RigidBodyFrame> _frameA,
 std::ostream& operator<<(std::ostream& os, const RigidBodyLoop& obj) {
   os << "loop connects pt "
      << obj.frameA->transform_to_body.matrix().topRightCorner(3, 1).transpose()
-     << " on " << obj.frameA->body->name_ << " to pt "
+     << " on " << obj.frameA->body->get_name() << " to pt "
      << obj.frameB->transform_to_body.matrix().topRightCorner(3, 1).transpose()
-     << " on " << obj.frameB->body->name_ << std::endl;
+     << " on " << obj.frameB->body->get_name() << std::endl;
   return os;
 }

--- a/drake/systems/plants/test/load_model_test.cc
+++ b/drake/systems/plants/test/load_model_test.cc
@@ -50,7 +50,7 @@ TEST_P(LoadModelTest, TestNoOffset) {
   // Gets the link whose parent joint is called "base".
   auto link1_body = rbs.getRigidBodyTree()->findJoint("base");
   EXPECT_TRUE(link1_body != nullptr);
-  EXPECT_EQ(link1_body->name_, "link1");
+  EXPECT_EQ(link1_body->get_name(), "link1");
 
   // Verifies that the transformation from link1's frame to the world's frame
   // is correct. Since the model was not offset from the world, we expect
@@ -61,7 +61,7 @@ TEST_P(LoadModelTest, TestNoOffset) {
   // Gets the link whose parent joint is called "joint1".
   auto link2_body = rbs.getRigidBodyTree()->findJoint("joint1");
   EXPECT_TRUE(link2_body != nullptr);
-  EXPECT_EQ(link2_body->name_, "link2");
+  EXPECT_EQ(link2_body->get_name(), "link2");
 
   // Verifies that the transformation from link2's frame to link1's frame is
   // correct. From the SDF, the transformation is expected to be
@@ -101,7 +101,7 @@ TEST_P(LoadModelTest, TestVerticalOffset) {
   // Gets the link whose parent joint is called "base".
   auto link1_body = rbs.getRigidBodyTree()->findJoint("base");
   EXPECT_TRUE(link1_body != nullptr);
-  EXPECT_EQ(link1_body->name_, "link1");
+  EXPECT_EQ(link1_body->get_name(), "link1");
 
   // Verifies that the transformation from link1's frame to the world's frame
   // is correct. Since the model was offset from the world frame, we expect the
@@ -113,7 +113,7 @@ TEST_P(LoadModelTest, TestVerticalOffset) {
   // Gets the link whose parent joint is called "joint1".
   auto link2_body = rbs.getRigidBodyTree()->findJoint("joint1");
   EXPECT_TRUE(link2_body != nullptr);
-  EXPECT_EQ(link2_body->name_, "link2");
+  EXPECT_EQ(link2_body->get_name(), "link2");
 
   // Verifies that the transformation from link2's frame to link1's frame is
   // correct. From the SDF, the transformation is expected to be

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -22,19 +22,19 @@ class RigidBodyTreeTest : public ::testing::Test {
     // Defines four rigid bodies.
     r1b1 = new RigidBody();
     r1b1->model_name_ = "robot1";
-    r1b1->name_ = "body1";
+    r1b1->set_name("body1");
 
     r2b1 = new RigidBody();
     r2b1->model_name_ = "robot2";
-    r2b1->name_ = "body1";
+    r2b1->set_name("body1");
 
     r3b1 = new RigidBody();
     r3b1->model_name_ = "robot3";
-    r3b1->name_ = "body1";
+    r3b1->set_name("body1");
 
     r4b1 = new RigidBody();
     r4b1->model_name_ = "robot4";
-    r4b1->name_ = "body1";
+    r4b1->set_name("body1");
   }
 
  public:

--- a/drake/systems/plants/test/testIKtraj.cpp
+++ b/drake/systems/plants/test/testIKtraj.cpp
@@ -17,8 +17,8 @@ using Eigen::VectorXd;
 using Drake::getDrakePath;
 
 GTEST_TEST(testIKtraj, testIKtraj) {
-  RigidBodyTree model(getDrakePath() +
-                      "/examples/Atlas/urdf/atlas_minimal_contact.urdf");
+  RigidBodyTree model(
+      getDrakePath() + "/examples/Atlas/urdf/atlas_minimal_contact.urdf");
 
   int r_hand{};
   for (int i = 0; i < static_cast<int>(model.bodies.size()); i++) {
@@ -58,8 +58,8 @@ GTEST_TEST(testIKtraj, testIKtraj) {
   rhand_pos_ub(2) += 0.25;
   Vector2d tspan_end;
   tspan_end << t[nT - 1], t[nT - 1];
-  WorldPositionConstraint kc_rhand(&model, r_hand, r_hand_pt, rhand_pos_lb,
-                                   rhand_pos_ub, tspan_end);
+  WorldPositionConstraint kc_rhand(
+      &model, r_hand, r_hand_pt, rhand_pos_lb, rhand_pos_ub, tspan_end);
   std::vector<RigidBodyConstraint*> constraint_array;
   constraint_array.push_back(&com_kc);
   constraint_array.push_back(&kc_rhand);

--- a/drake/systems/plants/test/testIKtraj.cpp
+++ b/drake/systems/plants/test/testIKtraj.cpp
@@ -3,8 +3,8 @@
 
 #include "gtest/gtest.h"
 
-#include "../constraint/RigidBodyConstraint.h"
 #include "drake/Path.h"
+#include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 #include "drake/systems/plants/IKoptions.h"
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"

--- a/drake/systems/plants/test/testIKtraj.cpp
+++ b/drake/systems/plants/test/testIKtraj.cpp
@@ -3,11 +3,11 @@
 
 #include "gtest/gtest.h"
 
+#include "../constraint/RigidBodyConstraint.h"
 #include "drake/Path.h"
 #include "drake/systems/plants/IKoptions.h"
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "../constraint/RigidBodyConstraint.h"
 
 using Eigen::MatrixXd;
 using Eigen::Vector2d;
@@ -17,12 +17,12 @@ using Eigen::VectorXd;
 using Drake::getDrakePath;
 
 GTEST_TEST(testIKtraj, testIKtraj) {
-  RigidBodyTree model(
-      getDrakePath() + "/examples/Atlas/urdf/atlas_minimal_contact.urdf");
+  RigidBodyTree model(getDrakePath() +
+                      "/examples/Atlas/urdf/atlas_minimal_contact.urdf");
 
   int r_hand{};
   for (int i = 0; i < static_cast<int>(model.bodies.size()); i++) {
-    if (model.bodies[i]->name_.compare(std::string("r_hand"))) {
+    if (model.bodies[i]->get_name().compare(std::string("r_hand"))) {
       r_hand = i;
     }
   }
@@ -58,8 +58,8 @@ GTEST_TEST(testIKtraj, testIKtraj) {
   rhand_pos_ub(2) += 0.25;
   Vector2d tspan_end;
   tspan_end << t[nT - 1], t[nT - 1];
-  WorldPositionConstraint kc_rhand(
-      &model, r_hand, r_hand_pt, rhand_pos_lb, rhand_pos_ub, tspan_end);
+  WorldPositionConstraint kc_rhand(&model, r_hand, r_hand_pt, rhand_pos_lb,
+                                   rhand_pos_ub, tspan_end);
   std::vector<RigidBodyConstraint*> constraint_array;
   constraint_array.push_back(&com_kc);
   constraint_array.push_back(&kc_rhand);
@@ -70,26 +70,23 @@ GTEST_TEST(testIKtraj, testIKtraj) {
   MatrixXd qddot_sol(model.number_of_positions(), nT);
   int info = 0;
   std::vector<std::string> infeasible_constraint;
-  inverseKinTraj(&model, nT, t.data(), qdot0, q0, q0,
-                 constraint_array.size(), constraint_array.data(),
-                 ikoptions,
-                 &q_sol, &qdot_sol, &qddot_sol, &info, &infeasible_constraint);
+  inverseKinTraj(&model, nT, t.data(), qdot0, q0, q0, constraint_array.size(),
+                 constraint_array.data(), ikoptions, &q_sol, &qdot_sol,
+                 &qddot_sol, &info, &infeasible_constraint);
   EXPECT_EQ(info, 1);
 
   ikoptions.setFixInitialState(false);
   ikoptions.setMajorIterationsLimit(500);
-  inverseKinTraj(&model, nT, t.data(), qdot0, q0, q0,
-                 constraint_array.size(), constraint_array.data(),
-                 ikoptions,
-                 &q_sol, &qdot_sol, &qddot_sol, &info, &infeasible_constraint);
+  inverseKinTraj(&model, nT, t.data(), qdot0, q0, q0, constraint_array.size(),
+                 constraint_array.data(), ikoptions, &q_sol, &qdot_sol,
+                 &qddot_sol, &info, &infeasible_constraint);
   EXPECT_EQ(info, 1);
 
   Eigen::RowVectorXd t_inbetween(5);
   t_inbetween << 0.1, 0.15, 0.3, 0.4, 0.6;
   ikoptions.setAdditionaltSamples(t_inbetween);
-  inverseKinTraj(&model, nT, t.data(), qdot0, q0, q0,
-                 constraint_array.size(), constraint_array.data(),
-                 ikoptions,
-                 &q_sol, &qdot_sol, &qddot_sol, &info, &infeasible_constraint);
+  inverseKinTraj(&model, nT, t.data(), qdot0, q0, q0, constraint_array.size(),
+                 constraint_array.data(), ikoptions, &q_sol, &qdot_sol,
+                 &qddot_sol, &info, &infeasible_constraint);
   EXPECT_EQ(info, 1);
 }

--- a/drake/systems/plants/test/urdfCollisionTest.cpp
+++ b/drake/systems/plants/test/urdfCollisionTest.cpp
@@ -49,8 +49,8 @@ int main(int argc, char* argv[]) {
     for (int i = 0; i < 3; ++i) {
       cout << xB(i, j) << " ";
     }
-    cout << model->bodies[bodyA_idx.at(j)]->name_ << " ";
-    cout << model->bodies[bodyB_idx.at(j)]->name_ << endl;
+    cout << model->bodies[bodyA_idx.at(j)]->get_name() << " ";
+    cout << model->bodies[bodyB_idx.at(j)]->get_name() << endl;
   }
 
   delete model;

--- a/drake/systems/plants/test/urdfKinTest.cpp
+++ b/drake/systems/plants/test/urdfKinTest.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
     x << pt, rpy;
     //    cout << i << ": forward kin: " << model->bodies[i].name_ << " is at
     //    " << pt.transpose() << endl;
-    cout << model->bodies[i]->name_ << " ";
+    cout << model->bodies[i]->get_name() << " ";
     cout << x.transpose() << endl;
     //    for (int j=0; j<pt.size(); j++)
     //        cout << pt(j) << " ";

--- a/drake/systems/plants/test/urdfManipulatorDynamicsTest.cpp
+++ b/drake/systems/plants/test/urdfManipulatorDynamicsTest.cpp
@@ -24,7 +24,7 @@ int main(int argc, char* argv[]) {
   // here
   cout << model->bodies.size() << endl;
   for (const auto& body : model->bodies) {
-    cout << body->name_ << endl;
+    cout << body->get_name() << endl;
   }
 
   VectorXd q = model->getZeroConfiguration();

--- a/drake/util/yaml/yamlUtil.cpp
+++ b/drake/util/yaml/yamlUtil.cpp
@@ -78,21 +78,6 @@ void loadBodyMotionParams(QPControllerParams& params, const YAML::Node& config,
       throw;
     }
   }
-
-  // for (auto config_it = config.begin(); config_it != config.end();
-  // ++config_it) {
-  //   std::regex body_regex =
-  //   globToRegex((*config_it)["name"].as<std::string>());
-  //   for (auto body_it = robot.bodies.begin(); body_it != robot.bodies.end();
-  //   ++body_it) {
-  //     if (std::regex_match((*body_it)->get_name(), body_regex)) {
-  //       params.body_motion[body_it - robot.bodies.begin()] = get(*config_it,
-  //       "params").as<BodyMotionParams>();
-  //       // loadSingleBodyMotionParams(params.body_motion[body_it -
-  //       robot.bodies.begin()], (*config_it)["params"]);
-  //     }
-  //   }
-  // }
 }
 
 void loadSingleJointParams(QPControllerParams& params,
@@ -123,15 +108,12 @@ void loadSingleJointParams(QPControllerParams& params,
   if (get(soft_limits_config, "disable_when_body_in_support")
           .as<std::string>()
           .size() > 0) {
-    // std::regex disable_body_regex = globToRegex(get(soft_limits_config,
-    // "disable_when_body_in_support").as<std::string>());
     std::string disable_body_name =
         get(soft_limits_config, "disable_when_body_in_support")
             .as<std::string>();
     for (auto body_it = robot.bodies.begin(); body_it != robot.bodies.end();
          ++body_it) {
       if (disable_body_name == (*body_it)->get_name()) {
-        // if (std::regex_match((*body_it)->get_name(), disable_body_regex)) {
         params.joint_soft_limits.disable_when_body_in_support(position_index) =
             body_it - robot.bodies.begin() + 1;
         // break;

--- a/drake/util/yaml/yamlUtil.cpp
+++ b/drake/util/yaml/yamlUtil.cpp
@@ -68,13 +68,13 @@ void loadBodyMotionParams(QPControllerParams& params, const YAML::Node& config,
        ++body_it) {
     try {
       params.body_motion[body_it - robot.bodies.begin()] =
-          get(config, (*body_it)->name_).as<BodyMotionParams>();
+          get(config, (*body_it)->get_name()).as<BodyMotionParams>();
     } catch (...) {
       std::cerr << "error converting node: "
-                << get(config, (*body_it)->name_) << " to BodyMotionParams"
+                << get(config, (*body_it)->get_name()) << " to BodyMotionParams"
                 << std::endl;
       std::cerr << "config: " << config << std::endl;
-      std::cerr << "body_name: " << (*body_it)->name_ << std::endl;
+      std::cerr << "body_name: " << (*body_it)->get_name() << std::endl;
       throw;
     }
   }
@@ -85,7 +85,7 @@ void loadBodyMotionParams(QPControllerParams& params, const YAML::Node& config,
   //   globToRegex((*config_it)["name"].as<std::string>());
   //   for (auto body_it = robot.bodies.begin(); body_it != robot.bodies.end();
   //   ++body_it) {
-  //     if (std::regex_match((*body_it)->name_, body_regex)) {
+  //     if (std::regex_match((*body_it)->get_name(), body_regex)) {
   //       params.body_motion[body_it - robot.bodies.begin()] = get(*config_it,
   //       "params").as<BodyMotionParams>();
   //       // loadSingleBodyMotionParams(params.body_motion[body_it -
@@ -130,8 +130,8 @@ void loadSingleJointParams(QPControllerParams& params,
             .as<std::string>();
     for (auto body_it = robot.bodies.begin(); body_it != robot.bodies.end();
          ++body_it) {
-      if (disable_body_name == (*body_it)->name_) {
-        // if (std::regex_match((*body_it)->name_, disable_body_regex)) {
+      if (disable_body_name == (*body_it)->get_name()) {
+        // if (std::regex_match((*body_it)->get_name(), disable_body_regex)) {
         params.joint_soft_limits.disable_when_body_in_support(position_index) =
             body_it - robot.bodies.begin() + 1;
         // break;

--- a/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_joint_state.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_joint_state.h
@@ -286,8 +286,9 @@ class SensorPublisherJointState {
       if (joint.getNumPositions() > 0) {
         if (joint.isFloating()) {
           auto transform = rigid_body_tree->relativeTransform(
-              cache, rigid_body_tree->FindBodyIndex(rigid_body->parent->name()),
-              rigid_body_tree->FindBodyIndex(rigid_body->name()));
+              cache,
+              rigid_body_tree->FindBodyIndex(rigid_body->parent->get_name()),
+              rigid_body_tree->FindBodyIndex(rigid_body->get_name()));
           auto translation = transform.translation();
           auto rpy = drake::math::rotmat2rpy(transform.linear());
 

--- a/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_odometry.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_odometry.h
@@ -100,7 +100,7 @@ class SensorPublisherOdometry {
 
         std::unique_ptr<nav_msgs::Odometry> message(new nav_msgs::Odometry());
         message->header.frame_id = RigidBodyTree::kWorldLinkName;
-        message->child_frame_id = rigid_body->name();
+        message->child_frame_id = rigid_body->get_name();
 
         odometry_messages_.insert(
             std::pair<std::string, std::unique_ptr<nav_msgs::Odometry>>(
@@ -182,8 +182,8 @@ class SensorPublisherOdometry {
 
       // Updates the odometry information in the odometry message.
       auto transform = rigid_body_tree->relativeTransform(
-          cache, rigid_body_tree->FindBodyIndex(rigid_body->parent->name()),
-          rigid_body_tree->FindBodyIndex(rigid_body->name()));
+          cache, rigid_body_tree->FindBodyIndex(rigid_body->parent->get_name()),
+          rigid_body_tree->FindBodyIndex(rigid_body->get_name()));
       auto translation = transform.translation();
       auto quat = drake::math::rotmat2quat(transform.linear());
 
@@ -199,8 +199,8 @@ class SensorPublisherOdometry {
 
       // Saves the robot's linear and angular velocities in the world.
       auto twist = rigid_body_tree->relativeTwist(
-          cache, rigid_body_tree->FindBodyIndex(rigid_body->parent->name()),
-          rigid_body_tree->FindBodyIndex(rigid_body->name()),
+          cache, rigid_body_tree->FindBodyIndex(rigid_body->parent->get_name()),
+          rigid_body_tree->FindBodyIndex(rigid_body->get_name()),
           rigid_body_tree->FindBodyIndex(RigidBodyTree::kWorldLinkName));
 
       message->twist.twist.linear.x = twist(0);

--- a/ros/drake_ros_systems/include/drake_ros/ros_tf_publisher.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_tf_publisher.h
@@ -95,7 +95,7 @@ class DrakeRosTfPublisher {
       if (!PublishTfForRigidBody(rigid_body.get())) continue;
 
       // Creates a unique key for holding the transform message.
-      std::string key = rigid_body->model_name() + rigid_body->name();
+      std::string key = rigid_body->model_name() + rigid_body->get_name();
 
       // Checks whether a transform message for the current link was already
       // added to the transform_messages_ map.
@@ -109,8 +109,8 @@ class DrakeRosTfPublisher {
       std::unique_ptr<geometry_msgs::TransformStamped> message(
           new geometry_msgs::TransformStamped());
 
-      message->header.frame_id = rigid_body->parent->name();
-      message->child_frame_id = rigid_body->name();
+      message->header.frame_id = rigid_body->parent->get_name();
+      message->child_frame_id = rigid_body->get_name();
 
       // Obtains the current link's joint.
       const DrakeJoint& joint = rigid_body->getJoint();
@@ -119,7 +119,8 @@ class DrakeRosTfPublisher {
       // We can do this now since it will not change over time.
       if (joint.getNumPositions() == 0 && joint.getNumVelocities() == 0) {
         auto translation = joint.getTransformToParentBody().translation();
-        auto quat = drake::math::rotmat2quat(joint.getTransformToParentBody().linear());
+        auto quat =
+            drake::math::rotmat2quat(joint.getTransformToParentBody().linear());
 
         message->transform.translation.x = translation(0);
         message->transform.translation.y = translation(1);
@@ -151,7 +152,7 @@ class DrakeRosTfPublisher {
       std::unique_ptr<geometry_msgs::TransformStamped> message(
           new geometry_msgs::TransformStamped());
 
-      message->header.frame_id = frame->body->name();
+      message->header.frame_id = frame->body->get_name();
       message->child_frame_id = frame->name;
 
       // Frames are fixed to a particular rigid body. The following code saves
@@ -205,7 +206,7 @@ class DrakeRosTfPublisher {
       if (!PublishTfForRigidBody(rigid_body.get())) continue;
 
       // Obtains a unique key for holding the transform message.
-      std::string key = rigid_body->model_name() + rigid_body->name();
+      std::string key = rigid_body->model_name() + rigid_body->get_name();
 
       // Verifies that a geometry_msgs::TransformStamped message for the current
       // link exists in the transform_messages_ map.
@@ -226,8 +227,9 @@ class DrakeRosTfPublisher {
       // Updates the transform only if the joint is not fixed.
       if (joint.getNumPositions() != 0 || joint.getNumVelocities() != 0) {
         auto transform = rigid_body_tree_->relativeTransform(
-            cache, rigid_body_tree_->FindBodyIndex(rigid_body->parent->name()),
-            rigid_body_tree_->FindBodyIndex(rigid_body->name()));
+            cache,
+            rigid_body_tree_->FindBodyIndex(rigid_body->parent->get_name()),
+            rigid_body_tree_->FindBodyIndex(rigid_body->get_name()));
         auto translation = transform.translation();
         auto quat = drake::math::rotmat2quat(transform.linear());
 


### PR DESCRIPTION
Public access to mutable class member variables is a big no-no since it violates state encapsulation.

All accessors are being named `get_foo()`. I thus rename the accessor for consistency and increased semantic meaning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2900)
<!-- Reviewable:end -->
