### PR TITLE
Update install instructions for ros-indigo-ackermann-msgs.

### DIFF
--- a/drake/doc/from_source_ros.rst
+++ b/drake/doc/from_source_ros.rst
@@ -36,6 +36,11 @@ Install
 `ROS Indigo <http://wiki.ros.org/indigo>`_. Other versions of the OS and ROS
 may or may not work.
 
+Install package ``ros-indigo-ackermann-msgs``, which is used by
+software in `drake_ros_systems <https://github.com/RobotLocomotion/drake/tree/master/ros/drake_ros_systems>`_::
+
+    sudo apt-get install ros-indigo-ackermann-msgs
+
 Once the OS and ROS are installed, install
 `Catkin Tools <http://catkin-tools.readthedocs.io/en/latest/>`_ by following
 the instructions
@@ -168,10 +173,6 @@ To run Drake's ROS-powered cars example, first add the
     git clone git@github.com:liangfok/ackermann-drive-teleop.git ackermann_drive_teleop
     cd ackermann_drive_teleop
     git checkout feature/ackermann_drive_stamped
-
-You will also need to install the package ``ros-indigo-ackermann-msgs``::
-
-    sudo apt-get install ros-indigo-ackermann-msgs
 
 Since a new package was added to the ROS workspace, re-build the workspace
 (note that a build type of ``RelWithDebInfo`` is selected since the simulation

--- a/ros/drake_ros_systems/package.xml
+++ b/ros/drake_ros_systems/package.xml
@@ -40,12 +40,15 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>ackermann_msgs</build_depend>
+  <build_depend>drake</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>drake</build_depend>
+
+  <run_depend>ackermann_msgs</run_depend>
+  <run_depend>drake</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>drake</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Moved instructions to install `ros-indigo-ackermann-msgs` to the top of the Drake/ROS install section.

Resolves #2926.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2927)
<!-- Reviewable:end -->
