### PR TITLE
Added Missing #include to Drake/ROS car example

### DIFF
--- a/ros/drake_cars_examples/src/car_sim_lcm_and_ros.cc
+++ b/ros/drake_cars_examples/src/car_sim_lcm_and_ros.cc
@@ -1,3 +1,5 @@
+#include "ros/ros.h"
+
 #include "drake/examples/Cars/car_simulation.h"
 #include "drake/examples/Cars/gen/driving_command.h"
 #include "drake/systems/LCMSystem.h"


### PR DESCRIPTION
This is towards the "include what you use" rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2935)
<!-- Reviewable:end -->
