### PR TITLE
Toward #2852: nerf shadow errors in snopt-mex code.

### DIFF
--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -1,6 +1,3 @@
-# TODO(#2852) We can't yet handle shadowing as a compiler error.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
-
 pods_find_pkg_config(gurobi)
 
 if(gurobi_FOUND)
@@ -104,6 +101,11 @@ endif()
 if(snopt_c_FOUND AND MATLAB_FOUND)
   add_mex(NonlinearProgramSnoptmex NonlinearProgramSnoptmex.cpp)
   pods_use_pkg_config_packages(NonlinearProgramSnoptmex snopt_c)
+
+  # These warnings are not worth fixing.
+  set_target_properties(
+    NonlinearProgramSnoptmex
+    PROPERTIES COMPILE_FLAGS ${CXX_FLAGS_NO_ERROR_SHADOW})
 endif()
 
 if(mosek_FOUND)

--- a/drake/systems/trajectories/CMakeLists.txt
+++ b/drake/systems/trajectories/CMakeLists.txt
@@ -28,6 +28,11 @@ if(BLAS_LIBRARY AND snopt_c_FOUND AND bullet_FOUND AND MATLAB_FOUND)
   target_link_libraries(shiftFunnel_snopt_mex -lblas drakeMexUtil)
   target_link_libraries(isCollisionFree_mex drakeMexUtil)
   target_link_libraries(ptToPolyBullet_mex drakeMexUtil)
+
+  # These warnings are not worth fixing.
+  set_target_properties(
+    replanFunnels_mex shiftFunnel_snopt_mex 
+    PROPERTIES COMPILE_FLAGS ${CXX_FLAGS_NO_ERROR_SHADOW})
 endif()
 
 add_subdirectory(test)


### PR DESCRIPTION
 * Also, re-enable shadow errors in solvers/.
   * Effectively reverts the band-aid from PR #2920.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2943)
<!-- Reviewable:end -->
