### PR TITLE
Update Drake's cpplint documentation

### DIFF
--- a/drake/doc/code_style_tools.rst
+++ b/drake/doc/code_style_tools.rst
@@ -54,17 +54,13 @@ To run clang-format::
 cpplint
 -------
 
-Installation
-^^^^^^^^^^^^
-
-On Ubuntu::
-
-    sudo pip install cpplint
-
 Usage
 ^^^^^
 
-`cpplint <https://github.com/google/styleguide/tree/gh-pages/cpplint>`_ is a tool for finding compliance violations. Here is the command::
+`cpplint <https://github.com/google/styleguide/tree/gh-pages/cpplint>`_
+is a tool for finding compliance violations. Here is the command::
 
-    cpplint --filter="-legal/copyright" [file name]
+    drake-distro/drake/common/test/cpplint_wrapper.py
 
+By default, all files in Drake are checked using the default settings.
+Consult the program's `--help` for more detailed options.

--- a/drake/doc/fedora.rst
+++ b/drake/doc/fedora.rst
@@ -29,8 +29,6 @@ Install the prerequisites::
       devtoolset-3-valgrind
     scl enable devtoolset-3 bash
 
-    sudo pip install -U cpplint
-
 On CentOS and Red Hat Enterprise Linux, add the line::
 
     source /opt/rh/devtoolset-3/enable

--- a/drake/doc/homebrew.rst
+++ b/drake/doc/homebrew.rst
@@ -20,7 +20,7 @@ Install the prerequisites::
       jpeg libpng libtool mpfr mpich2 ninja numpy python qt qwt swig valgrind \
       wget
     brew install vtk5 --with-qt
-    pip install -U beautifulsoup4 cpplint html5lib Sphinx
+    pip install -U beautifulsoup4 html5lib Sphinx
 
 Add the line::
 

--- a/drake/doc/ubuntu.rst
+++ b/drake/doc/ubuntu.rst
@@ -95,7 +95,6 @@ Other prerequisites may be installed as follows::
       make mpich ninja-build perl pkg-config python-bs4 python-dev \
       python-gtk2 python-html5lib python-numpy python-pip python-sphinx \
       python-vtk subversion swig unzip valgrind
-    sudo pip install -U cpplint
 
 Environment
 -----------


### PR DESCRIPTION
Update Drake's cpplint documentation:
- Use the new in-tree wrapper script.
- `sudo pip install` goes away.

Everyone remember to `sudo pip uninstall cpplint` (or however it's spelled).

A portion of #2539.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2944)
<!-- Reviewable:end -->
