### PR TITLE
Add drake-distro/ros to the default cpplint target

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,43 @@
+# Copyright 2016 Robot Locomotion Group @ CSAIL. All rights reserved.
+#
+# All components of Drake are licensed under the BSD 3-Clause License.
+# See LICENSE.TXT or http://drake.mit.edu/ for details.
+
+# Stop searching for additional config files.
+set noparent
+
+# Disable a warning about C++ features that were not in the original
+# C++11 specification (and so might not be well-supported).  In the
+# case of Drake, our supported minimum platforms are new enough that
+# this warning is irrelevant.
+filter=-build/c++11
+
+# Disable header_guard warning (see Drake issue #2104).
+filter=-build/header_guard
+
+# It's not worth lint-gardening the documentation.
+exclude_files=doc
+
+# TODO(#2364) Fix this.
+filter=-build/include
+
+# TODO(#2269) Fix this.
+filter=-build/include_order
+
+# TODO(#2270) Fix this.
+filter=-build/include_what_you_use
+
+# TODO(#2271) Fix this.
+filter=-build/namespaces
+
+# TODO(#1805) Fix this.
+filter=-legal/copyright
+
+# TODO(#2272) Fix this.
+filter=-readability/casting
+
+# TODO(#2273) Fix this.
+filter=-readability/namespace
+
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/CPPLINT.cfg
+++ b/drake/CPPLINT.cfg
@@ -3,47 +3,8 @@
 # All components of Drake are licensed under the BSD 3-Clause License.
 # See LICENSE.TXT or http://drake.mit.edu/ for details.
 
-# Stop searching for additional config files.
-set noparent
-
 # Ignore built files (versus in-tree files).
 exclude_files=pod-build
 
 # Ignore code that isn't ours.
 exclude_files=thirdParty
-
-# Disable a warning about C++ features that were not in the original
-# C++11 specification (and so might not be well-supported).  In the
-# case of Drake, our supported minimum platforms are new enough that
-# this warning is irrelevant.
-filter=-build/c++11
-
-# Disable header_guard warning (see Drake issue #2104).
-filter=-build/header_guard
-
-# It's not worth lint-gardening the documentation.
-exclude_files=doc
-
-# TODO(#2364) Fix this.
-filter=-build/include
-
-# TODO(#2269) Fix this.
-filter=-build/include_order
-
-# TODO(#2270) Fix this.
-filter=-build/include_what_you_use
-
-# TODO(#2271) Fix this.
-filter=-build/namespaces
-
-# TODO(#1805) Fix this.
-filter=-legal/copyright
-
-# TODO(#2272) Fix this.
-filter=-readability/casting
-
-# TODO(#2273) Fix this.
-filter=-readability/namespace
-
-# TODO(#2274) Fix this.
-filter=-runtime/references

--- a/drake/common/test/cpplint_wrapper.py
+++ b/drake/common/test/cpplint_wrapper.py
@@ -76,6 +76,7 @@ def main():
     drake_common_test_dir = os.path.dirname(os.path.abspath(__file__))
     drake_dir = os.path.abspath(os.path.join(drake_common_test_dir, '../..'))
     drake_distro_dir = os.path.abspath(os.path.join(drake_dir, '..'))
+    drake_ros_dir = os.path.join(drake_distro_dir, 'ros')
     default_cpplint = os.path.join(
         drake_distro_dir, 'externals/google_styleguide/cpplint/cpplint.py')
 
@@ -101,7 +102,7 @@ def main():
         action='store_const', const=None,
         help='run in parallel with many threads')
     parser.add_argument(
-        'pathnames', nargs='*', default=[drake_dir],
+        'pathnames', nargs='*', default=[drake_dir, drake_ros_dir],
         help='list of files and/or directories to check'
         ' (default %(default)s)')
 


### PR DESCRIPTION
This only works for Drake's `cpplint_wrapper.py`; jenkins doesn't yet call that script, though.
- Move all `CPPLINT.cfg` settings to the superbuild, except for the pod-build and thirdParty suppressions.
- Add `drake-distro/ros` to the default cpplint path.

A portion of #2539.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2945)
<!-- Reviewable:end -->
