### PR TITLE
Moved SimulationOptions into its own file. Added some Doxygen comments.

### DIFF
--- a/drake/examples/Cars/car_simulation.cc
+++ b/drake/examples/Cars/car_simulation.cc
@@ -260,7 +260,7 @@ CreateSimpleCarVisualizationAdapter() {
 
 
 SimulationOptions GetCarSimulationDefaultOptions() {
-  SimulationOptions result = Drake::default_simulation_options;
+  SimulationOptions result;
   result.initial_step_size = 5e-3;
   result.timeout_seconds = std::numeric_limits<double>::infinity();
   return result;

--- a/drake/examples/Cars/test/simple_car_test.cc
+++ b/drake/examples/Cars/test/simple_car_test.cc
@@ -8,10 +8,12 @@
 #include "drake/core/Vector.h"
 #include "drake/systems/cascade_system.h"
 #include "drake/systems/Simulation.h"
+#include "drake/systems/simulation_options.h"
 #include "drake/util/eigen_matrix_compare.h"
 
 using drake::util::MatrixCompareType;
 using Drake::NullVector;
+using Drake::SimulationOptions;
 
 namespace drake {
 namespace examples {
@@ -109,7 +111,7 @@ GTEST_TEST(SimpleCarTest, Accelerating) {
   double end_time = 100.;
   Drake::simulate(*lead_foot, start_time, end_time, initial_state);
 
-  double step_size = Drake::default_simulation_options.initial_step_size;
+  double step_size = SimulationOptions().initial_step_size;
   int steps = (end_time - start_time) / step_size;
 
   EXPECT_EQ(static_cast<int>(history_system->states_.size()), steps);
@@ -158,7 +160,7 @@ GTEST_TEST(SimpleCarTest, Braking) {
   double end_time = 100.;
   Drake::simulate(*panic_stop, start_time, end_time, initial_state);
 
-  double step_size = Drake::default_simulation_options.initial_step_size;
+  double step_size = SimulationOptions().initial_step_size;
   int steps = (end_time - start_time) / step_size;
 
   EXPECT_EQ(static_cast<int>(history_system->states_.size()), steps);
@@ -199,7 +201,7 @@ GTEST_TEST(SimpleCarTest, Steering) {
   double end_time = 100.;
   Drake::simulate(*brickyard, start_time, end_time, initial_state);
 
-  double step_size = Drake::default_simulation_options.initial_step_size;
+  double step_size = SimulationOptions().initial_step_size;
   int steps = (end_time - start_time) / step_size;
 
   EXPECT_EQ(static_cast<int>(history_system->states_.size()), steps);

--- a/drake/systems/CMakeLists.txt
+++ b/drake/systems/CMakeLists.txt
@@ -35,6 +35,7 @@ drake_install_headers(
   n_ary_system.h
   pd_control_system.h
   Simulation.h
+  simulation_options.h
   System.h)
 
 add_subdirectory(test)

--- a/drake/systems/LCMSystem.h
+++ b/drake/systems/LCMSystem.h
@@ -227,7 +227,7 @@ template <typename System>
 void runLCM(std::shared_ptr<System> sys, std::shared_ptr<lcm::LCM> lcm,
             double t0, double tf,
             const typename System::template StateVector<double> &x0,
-            const SimulationOptions &options = default_simulation_options) {
+            const SimulationOptions &options = SimulationOptions()) {
   if (!lcm->good()) throw std::runtime_error("bad LCM reference");
 
   //    typename System::template OutputVector<double> x = 1;  // useful for

--- a/drake/systems/Simulation.h
+++ b/drake/systems/Simulation.h
@@ -143,7 +143,7 @@ double simulate(const System& sys, double ti, double tf,
 template <typename System>
 void simulate(const System& sys, double t0, double tf,
               const typename System::template StateVector<double>& x0) {
-  simulate(sys, t0, tf, x0, default_simulation_options);
+  simulate(sys, t0, tf, x0, SimulationOptions());
 }
 
 /** simulate

--- a/drake/systems/Simulation.h
+++ b/drake/systems/Simulation.h
@@ -7,6 +7,7 @@
 #include <thread>
 
 #include "drake/core/Vector.h"
+#include "drake/systems/simulation_options.h"
 
 namespace Drake {
 
@@ -15,39 +16,6 @@ namespace Drake {
 *@brief Algorithms for simulating dynamical systems
 *@}
 */
-
-// simulation options
-struct SimulationOptions {
-  double realtime_factor;  // 1 means try to run at realtime speed, 0 is run as
-                           // fast as possible, < 0 means use default
-  double initial_step_size;
-  double timeout_seconds;
-
-  /**
-   * This variable dermines what happens if the simulation's timing is delayed
-   * by more than timeout_seconds. When this occurs, a warning is printed if
-   * this variable is true, and an exception is raised if this variable is
-   * false.
-   */
-  bool warn_real_time_violation;
-
-  /**
-   * Enables a custom simulation termination condition. This function is called
-   * each cycle of the simulation loop. The input parameter of type double is
-   * the current simulation time. If the function returns true, the simulation
-   * is terminated. The default for this is a function that always returns
-   * false.
-   */
-  std::function<bool(double)> should_stop;
-
-  SimulationOptions()
-      : realtime_factor(-1.0),
-        initial_step_size(0.01),
-        timeout_seconds(1.0),
-        warn_real_time_violation(false),
-        should_stop([](double sim_time) { return false; }) {}
-};
-static const SimulationOptions default_simulation_options;
 
 typedef std::chrono::system_clock TimeClock;  // would love to use steady_clock,
                                               // but it seems to not compile on

--- a/drake/systems/plants/rigidBodyLCMNode.cpp
+++ b/drake/systems/plants/rigidBodyLCMNode.cpp
@@ -89,7 +89,7 @@ int main(int argc, char* argv[]) {
       make_shared<BotVisualizer<RigidBodySystem::StateVector>>(lcm, tree);
   auto sys = cascade(rigid_body_sys, visualizer);
 
-  SimulationOptions options = default_simulation_options;
+  SimulationOptions options;
   options.realtime_factor = 1.0;
   options.timeout_seconds = std::numeric_limits<double>::infinity();
   options.initial_step_size = 5e-3;

--- a/drake/systems/simulation_options.h
+++ b/drake/systems/simulation_options.h
@@ -60,9 +60,4 @@ struct SimulationOptions {
         should_stop([](double sim_time) { return false; }) {}
 };
 
-/**
- * Defines the default simulation options.
- */
-static const SimulationOptions default_simulation_options;
-
 }  // end namespace Drake

--- a/drake/systems/simulation_options.h
+++ b/drake/systems/simulation_options.h
@@ -1,0 +1,68 @@
+#pragma once
+
+namespace Drake {
+
+/**
+ * Defines the user-tunable simulation options.
+ */
+struct SimulationOptions {
+  /**
+   * The desired simulation real-time factor. The real-time factor is the
+   * simulation time divided by the real-world time. A value of 1 means the
+   * simulation should run in real-time. A value greater than one means the
+   * simulation should run faster than real-time. A value less than one means
+   * the simulation should run slower than real-time.
+   *
+   * A value of 0 means the simulation should run as fast as possible.
+   *
+   * Negative values indicate the default real-time factor should be used, which
+   * is to run as fast as possible.
+   *
+   * Its default value is -1.
+   */
+  double realtime_factor;
+
+  /**
+   * The initial time increment the simulator should take. It's default value
+   * is 0.01.
+   */
+  double initial_step_size;
+
+  /**
+   * The maximum difference between the current time and the desired time (as
+   * determined based on the current simulation time and real-time factor)
+   * before which an exception is thrown. Its default value is 1.0.
+   */
+  double timeout_seconds;
+
+  /**
+   * Dermines what happens if the simulation's timing is delayed by more than
+   * `timeout_seconds`. A value of `true` results in a warning being printed.
+   * A value of `false` results in an exception being raised. Its default value
+   * is false.
+   */
+  bool warn_real_time_violation;
+
+  /**
+   * Enables a custom simulation termination condition. This function is called
+   * each cycle of the simulation loop. The input parameter of type double is
+   * the current simulation time. If the function returns true, the simulation
+   * is terminated. The default for this is a function that always returns
+   * false.
+   */
+  std::function<bool(double)> should_stop;
+
+  SimulationOptions()
+      : realtime_factor(-1.0),
+        initial_step_size(0.01),
+        timeout_seconds(1.0),
+        warn_real_time_violation(false),
+        should_stop([](double sim_time) { return false; }) {}
+};
+
+/**
+ * Defines the default simulation options.
+ */
+static const SimulationOptions default_simulation_options;
+
+}  // end namespace Drake

--- a/ros/drake_ros_systems/include/drake_ros/ros_vehicle_system.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_vehicle_system.h
@@ -9,6 +9,7 @@
 #include "ackermann_msgs/AckermannDriveStamped.h"
 
 #include "drake/systems/Simulation.h"
+#include "drake/systems/simulation_options.h"
 #include "drake/systems/System.h"
 #include "drake/systems/cascade_system.h"
 
@@ -117,7 +118,7 @@ template <typename System>
 void run_ros_vehicle_sim(
     std::shared_ptr<System> sys, double t0, double tf,
     const typename System::template StateVector<double>& x0,
-    const SimulationOptions& options = Drake::default_simulation_options) {
+    const SimulationOptions& options = SimulationOptions()) {
   auto ros_ackermann_input =
       std::make_shared<internal::ROSAckermannCommandReceiverSystem<
           System::template InputVector>>();


### PR DESCRIPTION
I was motivated to do this when working with the Kuka simulation library, which defines `SimulationOptions` but does call the `simulate()` method.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2952)
<!-- Reviewable:end -->
