### PR TITLE
Text logging using spdlog as an external or stubbed-out

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -92,3 +92,6 @@
 [submodule "externals/google_styleguide"]
 	path = externals/google_styleguide
 	url = https://github.com/google/styleguide.git
+[submodule "externals/spdlog"]
+	path = externals/spdlog
+	url = git@github.com:gabime/spdlog.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ option(WITH_SWIGMAKE "helper tools to build python & MATLAB wrappers for C++ lib
 option(WITH_BULLET "used for collision detection" ON)
 option(WITH_LCM "interprocess communications protocol for visualizers, etc" ON)
 option(WITH_BOT_CORE_LCMTYPES "required LCM types library. only disable if you have it already." ON)
+option(WITH_SPDLOG "spdlog text logging facility.  required for debug logging." ON)
 if(WIN32)
   option(WITH_GTK "precompiled gtk binaries/headers for Windows" ON)  # needed for lcm on windows
 else()
@@ -139,7 +140,7 @@ set(signalscope_dependencies director)
 # List compilation and runtime dependencies. Runtime dependencies are needed
 # because the drake project must configure only after any dependencies used by
 # MATLAB have been installed.
-set(drake_dependencies bertini bot_core_lcmtypes bullet cmake eigen gloptipoly3 googletest google_styleguide gurobi iris lcm libbot mosek nlopt ipopt octomap sedumi snopt spotless swig_matlab swigmake yalmip yaml_cpp)
+set(drake_dependencies bertini bot_core_lcmtypes bullet cmake eigen gloptipoly3 googletest google_styleguide gurobi iris lcm libbot mosek nlopt ipopt octomap sedumi snopt spdlog spotless swig_matlab swigmake yalmip yaml_cpp)
 
 # download information, in alphabetical order
 set(avl_IS_PUBLIC TRUE)
@@ -193,6 +194,8 @@ set(libbot_IS_CMAKE_POD TRUE)
 set(libbot_IS_PUBLIC TRUE)
 set(bot_core_lcmtypes_IS_CMAKE_POD TRUE)
 set(bot_core_lcmtypes_IS_PUBLIC TRUE)
+set(spdlog_IS_PUBLIC TRUE)
+set(spdlog_IS_CMAKE_POD TRUE)
 set(meshconverters_IS_PUBLIC TRUE)
 set(mosek_IS_PUBLIC TRUE)
 set(nlopt_BUILD_COMMAND ./autogen.sh --no-configure && ./configure --without-matlab --without-python --without-octave --without-guile --enable-maintainer-mode --enable-shared --prefix=${CMAKE_INSTALL_PREFIX} --includedir=${CMAKE_INSTALL_PREFIX}/include/nlopt && make install)
@@ -244,6 +247,7 @@ foreach(proj IN ITEMS
   gtk
   lcm
   bot_core_lcmtypes
+  spdlog
   libbot
   bullet
   spotless

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ option(WITH_SWIGMAKE "helper tools to build python & MATLAB wrappers for C++ lib
 option(WITH_BULLET "used for collision detection" ON)
 option(WITH_LCM "interprocess communications protocol for visualizers, etc" ON)
 option(WITH_BOT_CORE_LCMTYPES "required LCM types library. only disable if you have it already." ON)
-option(WITH_SPDLOG "spdlog text logging facility.  required for debug logging." ON)
+option(WITH_SPDLOG "spdlog text logging facility; disabling will turn off text logging." ON)
 if(WIN32)
   option(WITH_GTK "precompiled gtk binaries/headers for Windows" ON)  # needed for lcm on windows
 else()

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -269,6 +269,12 @@ else()
   endif()
 endif()
 
+pods_find_pkg_config(spdlog)
+if(spdlog_FOUND)
+  pods_use_pkg_config_includes(spdlog)
+  add_definitions(-DHAVE_SPDLOG)
+endif()
+
 include_directories(thirdParty/bsd/spruce/include)
 
 add_subdirectory(common)

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(sources
   drake_assert.cc
   nice_type_name.cc
+  text_logging.cc
   )
 
 # List headers that should be installed with Drake so that they
@@ -17,6 +18,7 @@ set(installed_headers
   eigen_types.h
   nice_type_name.h
   sorted_vectors_have_intersection.h
+  text_logging.h
   )
 
 # List headers that are needed by code here but should not
@@ -28,6 +30,7 @@ set(private_headers
 # a header defining DRAKECOMMON_EXPORT for dealing with .dlls on Windows.
 add_library_with_exports(LIB_NAME drakeCommon
   SOURCE_FILES ${sources} ${installed_headers} ${private_headers})
+target_link_libraries(drakeCommon threads)
 
 # Install all externally-visible headers.
 drake_install_headers(${installed_headers})

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -32,6 +32,22 @@ endif()
 target_link_libraries(drake_assert_test_disabled drakeCommon ${GTEST_BOTH_LIBRARIES})
 add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disabled)
 
+# "text_logging.h" unit testing:  If spdlog is available, test that:
+add_executable(text_logging_test_default text_logging_test.cc)
+target_link_libraries(text_logging_test_default
+  drakeCommon ${GTEST_BOTH_LIBRARIES})
+add_test(NAME text_logging_test_default COMMAND text_logging_test_default)
+# Force spdlog to unavailable to test that the ifndef(HAVE_SPDLOG) case works.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_executable(text_logging_test_no_spdlog text_logging_test.cc)
+  target_compile_options(text_logging_test_no_spdlog
+    PRIVATE -UHAVE_SPDLOG)
+  target_link_libraries(text_logging_test_no_spdlog
+    drakeCommon ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME text_logging_test_no_spdlog COMMAND text_logging_test_no_spdlog)
+endif()
+
 # The entire block of CMake build rules and CTests exists to confirm that the
 # disarmed DRAKE_ASSERT still yields compilation errors.
 #

--- a/drake/common/test/text_logging_test.cc
+++ b/drake/common/test/text_logging_test.cc
@@ -1,0 +1,43 @@
+#include "drake/common/text_logging.h"
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+class Streamable {
+  template<typename ostream_like>
+  friend ostream_like& operator<<(ostream_like& os, const Streamable& c) {
+    return os << "OK";
+  }
+};
+
+// Call each API function and macro to ensure that all of them compile; the
+// cmake script will cause this to be compiled in both spdlog and non-spdlog
+// modes.
+GTEST_TEST(TextLoggingTest, SmokeTest) {
+  Streamable obj;
+  drake::log()->trace("drake::log()->trace test: {} {}", "OK", obj );
+  drake::log()->debug("drake::log()->debug test: {} {}", "OK", obj );
+  drake::log()->info("drake::log()->info test: {} {}", "OK", obj );
+  drake::log()->warn("drake::log()->warn test: {} {}", "OK", obj );
+  drake::log()->error("drake::log()->error test: {} {}", "OK", obj );
+  drake::log()->critical("drake::log()->critical test: {} {}", "OK", obj );
+  SPDLOG_TRACE(drake::log(), "SPDLOG_TRACE macro test: {}, {}", "OK", obj);
+  SPDLOG_DEBUG(drake::log(), "SPDLOG_DEBUG macro test: {}, {}", "OK", obj);
+}
+
+// Abuse gtest internals to verify that logging actually prints.
+#ifdef HAVE_SPDLOG
+GTEST_TEST(TextLoggingTest, CaptureOutputTest) {
+  testing::internal::CaptureStderr();
+  drake::log()->info("sentinel string");
+  std::string output = testing::internal::GetCapturedStderr();
+  EXPECT_TRUE(output.find("sentinel string") != std::string::npos);
+}
+#endif
+
+}  // anon namespace

--- a/drake/common/test/text_logging_test.cc
+++ b/drake/common/test/text_logging_test.cc
@@ -20,12 +20,12 @@ class Streamable {
 // modes.
 GTEST_TEST(TextLoggingTest, SmokeTest) {
   Streamable obj;
-  drake::log()->trace("drake::log()->trace test: {} {}", "OK", obj );
-  drake::log()->debug("drake::log()->debug test: {} {}", "OK", obj );
-  drake::log()->info("drake::log()->info test: {} {}", "OK", obj );
-  drake::log()->warn("drake::log()->warn test: {} {}", "OK", obj );
-  drake::log()->error("drake::log()->error test: {} {}", "OK", obj );
-  drake::log()->critical("drake::log()->critical test: {} {}", "OK", obj );
+  drake::log()->trace("drake::log()->trace test: {} {}", "OK", obj);
+  drake::log()->debug("drake::log()->debug test: {} {}", "OK", obj);
+  drake::log()->info("drake::log()->info test: {} {}", "OK", obj);
+  drake::log()->warn("drake::log()->warn test: {} {}", "OK", obj);
+  drake::log()->error("drake::log()->error test: {} {}", "OK", obj);
+  drake::log()->critical("drake::log()->critical test: {} {}", "OK", obj);
   SPDLOG_TRACE(drake::log(), "SPDLOG_TRACE macro test: {}, {}", "OK", obj);
   SPDLOG_DEBUG(drake::log(), "SPDLOG_DEBUG macro test: {}, {}", "OK", obj);
 }

--- a/drake/common/text_logging.cc
+++ b/drake/common/text_logging.cc
@@ -19,11 +19,11 @@ std::shared_ptr<logging::logger>* onetime_create_log() {
   }
   return result;
 }
-} // anonymous
+}  // namespace
 
 logging::logger* log() {
   // The following line creates a static shared_ptr to the logger; this
-  // guarantees the underling logger object will not be dtor'ed.
+  // guarantees the underling logger object will not be freed.
   static const std::shared_ptr<logging::logger>* const g_logger =
       onetime_create_log();
   return g_logger->get();
@@ -34,7 +34,7 @@ logging::logger* log() {
 // A do-nothing logger instance.
 namespace {
 const logger g_logger;
-}  // anon namespace
+}  // namespace
 
 logging::logger* log() {
   return &g_logger;

--- a/drake/common/text_logging.cc
+++ b/drake/common/text_logging.cc
@@ -1,0 +1,32 @@
+#include "drake/common/text_logging.h"
+
+#include <mutex>
+
+namespace drake {
+
+#ifdef HAVE_SPDLOG
+
+std::shared_ptr<logging::logger> log() {
+  static std::mutex log_mutex;
+  std::shared_ptr<logging::logger> logger = spdlog::get("console");
+  if (!logger) {
+    std::lock_guard<std::mutex> guard(log_mutex);
+    logger = spdlog::stderr_logger_st("console");
+  }
+  return logger;
+}
+
+#else  // HAVE_SPDLOG
+
+// A do-nothing logger instance.
+namespace {
+const logger g_logger;
+}  // anon namespace
+
+const std::shared_ptr<logging::logger> log() {
+  return std::shared_ptr<logging::logger>(&g_logger);
+}
+
+#endif  // HAVE_SPDLOG
+
+}  // namespace drake

--- a/drake/common/text_logging.cc
+++ b/drake/common/text_logging.cc
@@ -37,7 +37,7 @@ const logger g_logger;
 }  // anon namespace
 
 logging::logger* log() {
-  return std::shared_ptr<logging::logger>(&g_logger);
+  return &g_logger;
 }
 
 #endif  // HAVE_SPDLOG

--- a/drake/common/text_logging.h
+++ b/drake/common/text_logging.h
@@ -16,8 +16,8 @@ Similarly, it provides:
   drake::log()->error(...);
   drake::log()->critical(...);
 </pre>
-To log objects that are expensive to serialize, these macros will not be
-compiled if debug is not set:
+If you want to log objects that are expensive to serialize, these macros will
+not be compiled if debugging is turned off (-DNDEBUG is set):
 <pre>
   SPDLOG_TRACE(drake::log(), "message: {}", something_conditionally_compiled);
   SPDLOG_DEBUG(drake::log(), "message: {}", something_conditionally_compiled);

--- a/drake/common/text_logging.h
+++ b/drake/common/text_logging.h
@@ -1,16 +1,44 @@
 #pragma once
 
+/**
+@file
+This is the entry point for all text logging within Drake.
+Once you've included this file, the suggested ways you
+should write log messages include:
+<pre>
+  drake::log()->trace("Some trace message: {} {}", something, some_other);
+</pre>
+Similarly, it provides:
+<pre>
+  drake::log()->debug(...);
+  drake::log()->info(...);
+  drake::log()->warn(...);
+  drake::log()->error(...);
+  drake::log()->critical(...);
+</pre>
+To log objects that are expensive to serialize, these macros will not be
+compiled if debug is not set:
+<pre>
+  SPDLOG_TRACE(drake::log(), "message: {}", something_conditionally_compiled);
+  SPDLOG_DEBUG(drake::log(), "message: {}", something_conditionally_compiled);
+</pre>
+The format string syntax is fmtlib; see http://fmtlib.net/3.0.0/syntax.html.
+In particular, any class that overloads `operator<<` for `ostream` can be
+printed without any special handling.
+*/
+
 #include <memory>
 
 #ifdef HAVE_SPDLOG
+// Before including spdlog, activate the SPDLOG_DEBUG and SPDLOG_TRACE macros
+// if and only if Drake is being compiled in debug mode.  When not in debug
+// mode, they are no-ops and their arguments are not evaluated.
 #ifndef NDEBUG
 #define SPDLOG_DEBUG_ON 1
 #define SPDLOG_TRACE_ON 1
 #endif
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
-#undef SPDLOG_DEBUG_ON
-#undef SPDLOG_TRACE_ON
 #endif
 
 #include "drake/drakeCommon_export.h"
@@ -32,28 +60,31 @@ namespace logging {
 /// that we expect to use, as spdlog's API does change from time to time.
 class logger {
  public:
-  template <typename... Args>
-  void trace(const char* fmt, const Args&... args) {};
-  template <typename... Args>
-  void debug(const char* fmt, const Args&... args) {};
-  template <typename... Args>
-  void info(const char* fmt, const Args&... args) {};
-  template <typename... Args>
-  void warn(const char* fmt, const Args&... args) {};
-  template <typename... Args>
-  void error(const char* fmt, const Args&... args) {};
-  template <typename... Args>
-  void critical(const char* fmt, const Args&... args) {};
+  logger(const logger&) = delete;
+  logger& operator=(const logger&) = delete;
 
-  template <typename T> void trace(const T&) {};
-  template <typename T> void debug(const T&) {};
-  template <typename T> void info(const T&) {};
-  template <typename T> void warn(const T&) {};
-  template <typename T> void error(const T&) {};
-  template <typename T> void critical(const T&) {};
+  template <typename... Args>
+  void trace(const char* fmt, const Args&... args) {}
+  template <typename... Args>
+  void debug(const char* fmt, const Args&... args) {}
+  template <typename... Args>
+  void info(const char* fmt, const Args&... args) {}
+  template <typename... Args>
+  void warn(const char* fmt, const Args&... args) {}
+  template <typename... Args>
+  void error(const char* fmt, const Args&... args) {}
+  template <typename... Args>
+  void critical(const char* fmt, const Args&... args) {}
+
+  template <typename T> void trace(const T&) {}
+  template <typename T> void debug(const T&) {}
+  template <typename T> void info(const T&) {}
+  template <typename T> void warn(const T&) {}
+  template <typename T> void error(const T&) {}
+  template <typename T> void critical(const T&) {}
 };
 
-} // namespace logging
+}  // namespace logging
 
 #define SPDLOG_TRACE(logger, ...)
 #define SPDLOG_DEBUG(logger, ...)
@@ -62,6 +93,6 @@ class logger {
 
 /// Retrieve an instance of a logger to use for logging; for example:
 ///   `drake::log()->info("potato!")`
-std::shared_ptr<logging::logger> log();
+DRAKECOMMON_EXPORT logging::logger* log();
 
-} // namespace drake
+}  // namespace drake

--- a/drake/common/text_logging.h
+++ b/drake/common/text_logging.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <memory>
+
+#ifdef HAVE_SPDLOG
+#ifndef NDEBUG
+#define SPDLOG_DEBUG_ON 1
+#define SPDLOG_TRACE_ON 1
+#endif
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/ostr.h>
+#undef SPDLOG_DEBUG_ON
+#undef SPDLOG_TRACE_ON
+#endif
+
+#include "drake/drakeCommon_export.h"
+
+namespace drake {
+
+#ifdef HAVE_SPDLOG
+// If we have spdlog, just alias logger and line_logger into our namespace.
+namespace logging {
+using spdlog::logger;
+}
+
+#else  // HAVE_SPDLOG
+// If we don't have spdlog, we need to stub out logger and line_logger.
+
+namespace logging {
+
+/// A stubbed-out version of `spdlog::logger`.  Implements only those methods
+/// that we expect to use, as spdlog's API does change from time to time.
+class logger {
+ public:
+  template <typename... Args>
+  void trace(const char* fmt, const Args&... args) {};
+  template <typename... Args>
+  void debug(const char* fmt, const Args&... args) {};
+  template <typename... Args>
+  void info(const char* fmt, const Args&... args) {};
+  template <typename... Args>
+  void warn(const char* fmt, const Args&... args) {};
+  template <typename... Args>
+  void error(const char* fmt, const Args&... args) {};
+  template <typename... Args>
+  void critical(const char* fmt, const Args&... args) {};
+
+  template <typename T> void trace(const T&) {};
+  template <typename T> void debug(const T&) {};
+  template <typename T> void info(const T&) {};
+  template <typename T> void warn(const T&) {};
+  template <typename T> void error(const T&) {};
+  template <typename T> void critical(const T&) {};
+};
+
+} // namespace logging
+
+#define SPDLOG_TRACE(logger, ...)
+#define SPDLOG_DEBUG(logger, ...)
+
+#endif  // HAVE_SPDLOG
+
+/// Retrieve an instance of a logger to use for logging; for example:
+///   `drake::log()->info("potato!")`
+std::shared_ptr<logging::logger> log();
+
+} // namespace drake

--- a/drake/common/text_logging.h
+++ b/drake/common/text_logging.h
@@ -18,13 +18,13 @@
 namespace drake {
 
 #ifdef HAVE_SPDLOG
-// If we have spdlog, just alias logger and line_logger into our namespace.
+// If we have spdlog, just alias logger into our namespace.
 namespace logging {
 using spdlog::logger;
 }
 
 #else  // HAVE_SPDLOG
-// If we don't have spdlog, we need to stub out logger and line_logger.
+// If we don't have spdlog, we need to stub out logger.
 
 namespace logging {
 

--- a/drake/systems/controllers/LQR.h
+++ b/drake/systems/controllers/LQR.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 #include "drake/core/Function.h"
 #include "drake/core/Gradient.h"
 #include "drake/core/Vector.h"
@@ -44,8 +45,7 @@ timeInvariantLQR(const System& sys,
   Eigen::MatrixXd K(num_inputs, num_states), S(num_states, num_states);
   lqr(A, B, Q, R, K, S);
 
-  //    cout << "K = " << K << endl;
-  //    cout << "S = " << S << endl;
+  SPDLOG_TRACE(drake::log(), "K = {} S = {}", K, S);
 
   // todo: return the linear system with the affine transform.  But for now,
   // just give the affine controller:


### PR DESCRIPTION
This implements #1895 (and is actually just a fleshing out of @jwnimmer-tri 's proposed changeset there, complicated by spdlog deleting the API he implemented in the meantime).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2954)
<!-- Reviewable:end -->
