### PR TITLE
Toward #2852: enforce -Werror=shadow in examples/.

### DIFF
--- a/drake/examples/CMakeLists.txt
+++ b/drake/examples/CMakeLists.txt
@@ -1,6 +1,3 @@
-# TODO(#2852) We can't yet handle shadowing as a compiler error.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
-
 add_matlab_test(NAME examples/CubicPolynomialExample.findFixedPointTest COMMAND CubicPolynomialExample.findFixedPointTest)
 add_matlab_test(NAME examples/CubicPolynomialExample.animate COMMAND CubicPolynomialExample.animate)
 add_matlab_test(NAME examples/CubicPolynomialExample.sosExample COMMAND CubicPolynomialExample.sosExample REQUIRES spotless)

--- a/drake/examples/Quadrotor/Quadrotor.h
+++ b/drake/examples/Quadrotor/Quadrotor.h
@@ -27,19 +27,19 @@ class QuadrotorState {  // models the Drake::Vector concept
 
   template <typename Derived>
   QuadrotorState(  // NOLINT(runtime/explicit) per Drake::Vector.
-      const Eigen::MatrixBase<Derived>& x)
-      : x(x(0)),
-        y(x(1)),
-        z(x(2)),
-        roll(x(3)),
-        pitch(x(4)),
-        yaw(x(5)),
-        xdot(x(6)),
-        ydot(x(7)),
-        zdot(x(8)),
-        rolldot(x(9)),
-        pitchdot(x(10)),
-        yawdot(x(11)) {}
+      const Eigen::MatrixBase<Derived>& state)
+      : x(state(0)),
+        y(state(1)),
+        z(state(2)),
+        roll(state(3)),
+        pitch(state(4)),
+        yaw(state(5)),
+        xdot(state(6)),
+        ydot(state(7)),
+        zdot(state(8)),
+        rolldot(state(9)),
+        pitchdot(state(10)),
+        yawdot(state(11)) {}
 
   template <typename Derived>
   QuadrotorState& operator=(const Eigen::MatrixBase<Derived>& state) {

--- a/drake/systems/pd_control_system.h
+++ b/drake/systems/pd_control_system.h
@@ -34,7 +34,7 @@ class PDControlSystem {
   template <typename DerivedA, typename DerivedB>
   PDControlSystem(const SystemPtr& sys, const Eigen::MatrixBase<DerivedA>& Kp,
                   const Eigen::MatrixBase<DerivedB>& Kd)
-      : sys(sys), Kp(Kp), Kd(Kd) {
+      : sys_(sys), Kp_(Kp), Kd_(Kd) {
     DRAKE_ASSERT(static_cast<int>(Drake::getNumInputs(*sys)) == Kp.rows() &&
                  "Kp must have the same number of rows as the system has"
                  " inputs");
@@ -50,9 +50,9 @@ class PDControlSystem {
                                    const StateVector<ScalarType>& x,
                                    const InputVector<ScalarType>& u) const {
     typename System::template InputVector<ScalarType> system_u =
-        Kp * (toEigen(u).head(Kp.cols()) - toEigen(x).head(Kp.cols())) +
-        Kd * (toEigen(u).tail(Kd.cols()) - toEigen(x).tail(Kd.cols()));
-    return sys->dynamics(t, x, system_u);
+        Kp_ * (toEigen(u).head(Kp_.cols()) - toEigen(x).head(Kp_.cols())) +
+        Kd_ * (toEigen(u).tail(Kd_.cols()) - toEigen(x).tail(Kd_.cols()));
+    return sys_->dynamics(t, x, system_u);
   }
 
   template <typename ScalarType>
@@ -60,27 +60,27 @@ class PDControlSystem {
                                   const StateVector<ScalarType>& x,
                                   const InputVector<ScalarType>& u) const {
     typename System::template InputVector<ScalarType> system_u =
-        Kp * (toEigen(u).head(Kp.cols()) - toEigen(x).head(Kp.cols())) +
-        Kd * (toEigen(u).tail(Kd.cols()) - toEigen(x).tail(Kd.cols()));
-    return sys->output(t, x, system_u);
+        Kp_ * (toEigen(u).head(Kp_.cols()) - toEigen(x).head(Kp_.cols())) +
+        Kd_ * (toEigen(u).tail(Kd_.cols()) - toEigen(x).tail(Kd_.cols()));
+    return sys_->output(t, x, system_u);
   }
 
-  bool isTimeVarying() const { return sys->isTimeVarying(); }
-  bool isDirectFeedthrough() const { return sys->isDirectFeedthrough(); }
-  size_t getNumStates() const { return Drake::getNumStates(*sys); }
-  size_t getNumInputs() const { return Drake::getNumStates(*sys); }
-  size_t getNumOutputs() const { return Drake::getNumOutputs(*sys); }
+  bool isTimeVarying() const { return sys_->isTimeVarying(); }
+  bool isDirectFeedthrough() const { return sys_->isDirectFeedthrough(); }
+  size_t getNumStates() const { return Drake::getNumStates(*sys_); }
+  size_t getNumInputs() const { return Drake::getNumStates(*sys_); }
+  size_t getNumOutputs() const { return Drake::getNumOutputs(*sys_); }
 
  public:
-  const SystemPtr& getSys() const { return sys; }
+  const SystemPtr& getSys() const { return sys_; }
   friend StateVector<double> getInitialState(
       const PDControlSystem<System>& sys) {
     return getInitialState(*sys.sys);
   }
 
  private:
-  SystemPtr sys;
-  Eigen::MatrixXd Kp, Kd;
+  SystemPtr sys_;
+  Eigen::MatrixXd Kp_, Kd_;
 };
 
 }  // end namespace Drake


### PR DESCRIPTION
 * Remove excuse from examples/* cmake file.
 * Rename some private members with '_' suffix per style guide.
 * Fix some ctors of classes with protected/public data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2956)
<!-- Reviewable:end -->
