### PR TITLE
Guard pendulum_dynamic_constraint_test upon LCM

### DIFF
--- a/drake/examples/Pendulum/test/CMakeLists.txt
+++ b/drake/examples/Pendulum/test/CMakeLists.txt
@@ -2,13 +2,13 @@ if(lcm_FOUND)
   add_executable(pendulumURDFDynamicsTest urdfDynamicsTest.cpp)
   target_link_libraries(pendulumURDFDynamicsTest drakeRBSystem ${GTEST_BOTH_LIBRARIES})
   add_test(NAME pendulumURDFDynamicsTest COMMAND pendulumURDFDynamicsTest)
-endif()
 
-add_executable(pendulum_dynamic_constraint_test pendulum_dynamic_constraint_test.cc)
-target_link_libraries(pendulum_dynamic_constraint_test
-  drakeDynamicConstraint ${GTEST_BOTH_LIBRARIES})
-add_test(NAME pendulum_dynamic_constraint_test
-  COMMAND pendulum_dynamic_constraint_test)
+  add_executable(pendulum_dynamic_constraint_test pendulum_dynamic_constraint_test.cc)
+  target_link_libraries(pendulum_dynamic_constraint_test
+    drakeDynamicConstraint ${GTEST_BOTH_LIBRARIES})
+  add_test(NAME pendulum_dynamic_constraint_test
+    COMMAND pendulum_dynamic_constraint_test)
+endif()
 
 add_matlab_test(NAME examples/Pendulum/test/coordinateTest COMMAND coordinateTest)
 add_matlab_test(NAME examples/Pendulum/test/dynamicsGradientsTest COMMAND dynamicsGradientsTest)


### PR DESCRIPTION
Guard pendulum_dynamic_constraint_test upon LCM.  The Pendulum C++ code uses the drake lcmt signal and includes LCMSystem.h, so won't build without LCM.

This is the last bit of pendulum C++ code that was enabled without LCM; when LCM is off, now only matlab remains.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2960)
<!-- Reviewable:end -->
