### PR TITLE
Extract RigidBody::CollisionElement into its own file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Unreleased: changes on master, not yet released
  - [#2018][] Fix capitalization of `Constraint` and `OptimizationProblem` APIs to match style guide.
  - [#2415][] Require CMake 3.5 or higher to configure and build.
  - [#2779][] Move some rotation functions from drakeGeometryUtil to drake/math.
+ - [#2963][] Rename RigidBody::CollisionElement to RigidBodyCollisionElement.
 
 [//]: # "Lost functionality or APIs."
 ### Removed / Deprecated
@@ -90,3 +91,4 @@ Changes in version v0.9.11 and before are not provided.
 [#2902]: https://github.com/RobotLocomotion/drake/issues/2902
 [#2903]: https://github.com/RobotLocomotion/drake/issues/2903
 [#2923]: https://github.com/RobotLocomotion/drake/issues/2923
+[#2963]: https://github.com/RobotLocomotion/drake/issues/2963

--- a/drake/examples/Atlas/atlas_plant.cc
+++ b/drake/examples/Atlas/atlas_plant.cc
@@ -102,7 +102,7 @@ void AtlasPlant::SetUpTerrain() {
   world.addVisualElement(
       DrakeShapes::VisualElement(geom, T_element_to_link, color));
   tree->addCollisionElement(
-      RigidBody::CollisionElement(geom, T_element_to_link, &world), world,
+      RigidBodyCollisionElement(geom, T_element_to_link, &world), world,
       "terrain");
   tree->updateStaticCollisionElements();
 }

--- a/drake/examples/Cars/car_simulation.cc
+++ b/drake/examples/Cars/car_simulation.cc
@@ -93,7 +93,7 @@ void AddFlatTerrain(const std::shared_ptr<RigidBodyTree>& rigid_body_tree,
   world.addVisualElement(
       DrakeShapes::VisualElement(geom, T_element_to_link, color));
   rigid_body_tree->addCollisionElement(
-      RigidBody::CollisionElement(geom, T_element_to_link, &world), world,
+      RigidBodyCollisionElement(geom, T_element_to_link, &world), world,
       "terrain");
   rigid_body_tree->updateStaticCollisionElements();
 }

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
   world.addVisualElement(
       DrakeShapes::VisualElement(geom, T_element_to_link, color));
   tree->addCollisionElement(
-      RigidBody::CollisionElement(geom, T_element_to_link, &world), world,
+      RigidBodyCollisionElement(geom, T_element_to_link, &world), world,
       "terrain");
   tree->updateStaticCollisionElements();
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_simulation.cc
@@ -40,7 +40,7 @@ std::shared_ptr<RigidBodySystem> CreateKukaIiwaSystem(void) {
   world.addVisualElement(
       DrakeShapes::VisualElement(geom, T_element_to_link, color));
   tree->addCollisionElement(
-      RigidBody::CollisionElement(geom, T_element_to_link, &world), world,
+      RigidBodyCollisionElement(geom, T_element_to_link, &world), world,
       "terrain");
   tree->updateStaticCollisionElements();
 

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_with_exports(LIB_NAME drakeRBM SOURCE_FILES
   RigidBody.cpp
   RigidBodyTreeContact.cpp
   rigid_body_actuator.cc
+  rigid_body_collision_element.cc
   rigid_body_frame.cc
   rigid_body_loop.cc)
 target_link_libraries(drakeRBM drakeCollision drakeJoints drakeUtil drakeXMLUtil)
@@ -30,6 +31,7 @@ drake_install_headers(
   material_map.h
   pose_map.h
   rigid_body_actuator.h
+  rigid_body_collision_element.h
   RigidBodyFrame.h
   RigidBody.h
   RigidBodyTree.h

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -105,42 +105,6 @@ void RigidBody::ApplyTransformToJointFrame(
   }
 }
 
-RigidBody::CollisionElement::CollisionElement(const CollisionElement& other)
-    : DrakeCollision::Element(other) {}
-
-RigidBody::CollisionElement::CollisionElement(
-    const Isometry3d& T_element_to_link, const RigidBody* const body)
-    : DrakeCollision::Element(T_element_to_link) {
-  set_body(body);
-}
-
-RigidBody::CollisionElement::CollisionElement(
-    const DrakeShapes::Geometry& geometry, const Isometry3d& T_element_to_link,
-    const RigidBody* const body)
-    : DrakeCollision::Element(geometry, T_element_to_link) {
-  set_body(body);
-  // This is a temporary hack to avoid having the user to set collision
-  // elements to static when added to the world.
-  // Collision elements should be set to static in a later Initialize() stage as
-  // described in issue #2661.
-  // TODO(amcastro-tri): remove this hack.
-  if (body->get_name() == "world") set_static();
-}
-
-RigidBody::CollisionElement* RigidBody::CollisionElement::clone() const {
-  return new CollisionElement(*this);
-}
-
-bool RigidBody::CollisionElement::CollidesWith(
-    const DrakeCollision::Element* other) const {
-  auto other_rb = dynamic_cast<const RigidBody::CollisionElement*>(other);
-  bool collides = true;
-  if (other_rb != nullptr) {
-    collides = get_body()->CollidesWith(*other_rb->get_body());
-  }
-  return collides;
-}
-
 ostream& operator<<(ostream& out, const RigidBody& b) {
   std::string parent_joint_name =
       b.hasParent() ? b.getJoint().getName() : "no parent joint";

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -191,29 +191,6 @@ class DRAKERBM_EXPORT RigidBody {
 
   friend std::ostream& operator<<(std::ostream& out, const RigidBody& b);
 
-  // TODO(amcastro-tri): move to a better place (h + cc files).
-  class DRAKERBM_EXPORT CollisionElement : public DrakeCollision::Element {
-   public:
-    CollisionElement(const CollisionElement& other);
-    // TODO(amcastro-tri): The RigidBody should be const?
-    // TODO(amcastro-tri): It should not be possible to construct a
-    // CollisionElement without specifying a geometry. Remove this constructor.
-    CollisionElement(const Eigen::Isometry3d& T_element_to_link,
-                     const RigidBody* const body);
-    CollisionElement(const DrakeShapes::Geometry& geometry,
-                     const Eigen::Isometry3d& T_element_to_link,
-                     const RigidBody* const body);
-    virtual ~CollisionElement() {}
-
-    CollisionElement* clone() const override;
-
-    bool CollidesWith(const DrakeCollision::Element* other) const override;
-
-#ifndef SWIG
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-#endif
-  };
-
  public:
 #ifndef SWIG
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -342,7 +342,7 @@ map<string, int> RigidBodyTree::computePositionNameToIndexMap() const {
 }
 
 DrakeCollision::ElementId RigidBodyTree::addCollisionElement(
-    const RigidBody::CollisionElement& element, RigidBody& body,
+    const RigidBodyCollisionElement& element, RigidBody& body,
     const string& group_name) {
   DrakeCollision::ElementId id = collision_model->addElement(element);
   if (id != 0) {

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -15,6 +15,7 @@
 #include "drake/systems/plants/KinematicPath.h"
 #include "drake/systems/plants/KinematicsCache.h"
 #include "drake/systems/plants/RigidBody.h"
+#include "drake/systems/plants/rigid_body_collision_element.h"
 #include "drake/systems/plants/RigidBodyFrame.h"
 #include "drake/systems/plants/rigid_body_loop.h"
 #include "drake/systems/plants/collision/DrakeCollision.h"
@@ -433,7 +434,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
       Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& J) const;
 
   DrakeCollision::ElementId addCollisionElement(
-      const RigidBody::CollisionElement& element, RigidBody& body,
+      const RigidBodyCollisionElement& element, RigidBody& body,
       const std::string& group_name);
 
   template <class UnaryPredicate>

--- a/drake/systems/plants/constructModelmex.cpp
+++ b/drake/systems/plants/constructModelmex.cpp
@@ -204,7 +204,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
         auto shape = (DrakeShapes::Shape) static_cast<int>(
             mxGetScalar(mxGetPropertySafe(pShape, 0, "drake_shape_id")));
         vector<double> params_vec;
-        RigidBody::CollisionElement element(T, b.get());
+        RigidBodyCollisionElement element(T, b.get());
         switch (shape) {
           case DrakeShapes::BOX: {
             double* params = mxGetPrSafe(mxGetPropertySafe(pShape, 0, "size"));

--- a/drake/systems/plants/parser_sdf.cc
+++ b/drake/systems/plants/parser_sdf.cc
@@ -229,7 +229,7 @@ void parseSDFCollision(RigidBody* body, XMLElement* node, RigidBodyTree* model,
                         " has a collision element without a geometry.");
   }
 
-  RigidBody::CollisionElement element(
+  RigidBodyCollisionElement element(
       transform_parent_to_model.inverse() * transform_to_model, body);
   // By default all collision elements added to the world from an SDF file are
   // flagged as static.

--- a/drake/systems/plants/parser_urdf.cc
+++ b/drake/systems/plants/parser_urdf.cc
@@ -488,7 +488,7 @@ void parseCollision(RigidBody* body, XMLElement* node, RigidBodyTree* tree,
     throw runtime_error("ERROR: Link " + body->get_name() +
                         " has a collision element without geometry");
 
-  RigidBody::CollisionElement element(T_element_to_link, body);
+  RigidBodyCollisionElement element(T_element_to_link, body);
   // By default all collision elements added to the world from an URDF file are
   // flagged as static.
   // We would also like to flag as static bodies connected to the world with a

--- a/drake/systems/plants/rigidBodyLCMNode.cpp
+++ b/drake/systems/plants/rigidBodyLCMNode.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
     world.addVisualElement(
         DrakeShapes::VisualElement(geom, T_element_to_link, color));
     tree->addCollisionElement(
-        RigidBody::CollisionElement(geom, T_element_to_link, &world), world,
+        RigidBodyCollisionElement(geom, T_element_to_link, &world), world,
         "terrain");
     tree->updateStaticCollisionElements();
   }

--- a/drake/systems/plants/rigid_body_collision_element.cc
+++ b/drake/systems/plants/rigid_body_collision_element.cc
@@ -1,0 +1,38 @@
+#include "rigid_body_collision_element.h"
+
+RigidBodyCollisionElement::RigidBodyCollisionElement(
+    const RigidBodyCollisionElement& other)
+    : DrakeCollision::Element(other) {}
+
+RigidBodyCollisionElement::RigidBodyCollisionElement(
+    const Eigen::Isometry3d& T_element_to_link, const RigidBody* const body)
+    : DrakeCollision::Element(T_element_to_link) {
+  set_body(body);
+}
+
+RigidBodyCollisionElement::RigidBodyCollisionElement(
+    const DrakeShapes::Geometry& geometry,
+    const Eigen::Isometry3d& T_element_to_link, const RigidBody* const body)
+    : DrakeCollision::Element(geometry, T_element_to_link) {
+  set_body(body);
+  // This is a temporary hack to avoid having the user to set collision
+  // elements to static when added to the world.
+  // Collision elements should be set to static in a later Initialize() stage as
+  // described in issue #2661.
+  // TODO(amcastro-tri): remove this hack.
+  if (body->get_name() == "world") set_static();
+}
+
+RigidBodyCollisionElement* RigidBodyCollisionElement::clone() const {
+  return new RigidBodyCollisionElement(*this);
+}
+
+bool RigidBodyCollisionElement::CollidesWith(
+    const DrakeCollision::Element* other) const {
+  auto other_rb = dynamic_cast<const RigidBodyCollisionElement*>(other);
+  bool collides = true;
+  if (other_rb != nullptr) {
+    collides = get_body()->CollidesWith(*other_rb->get_body());
+  }
+  return collides;
+}

--- a/drake/systems/plants/rigid_body_collision_element.h
+++ b/drake/systems/plants/rigid_body_collision_element.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "drake/drakeRBM_export.h"
+#include "drake/systems/plants/RigidBody.h"
+#include "drake/systems/plants/collision/DrakeCollision.h"
+
+class DRAKERBM_EXPORT RigidBodyCollisionElement
+    : public DrakeCollision::Element {
+ public:
+  RigidBodyCollisionElement(const RigidBodyCollisionElement& other);
+  // TODO(amcastro-tri): The RigidBody should be const?
+  // TODO(amcastro-tri): It should not be possible to construct a
+  // RigidBodyCollisionElement without specifying a geometry. Remove
+  // this constructor.
+  RigidBodyCollisionElement(const Eigen::Isometry3d& T_element_to_link,
+                            const RigidBody* const body);
+  RigidBodyCollisionElement(const DrakeShapes::Geometry& geometry,
+                            const Eigen::Isometry3d& T_element_to_link,
+                            const RigidBody* const body);
+  virtual ~RigidBodyCollisionElement() {}
+
+  RigidBodyCollisionElement* clone() const override;
+
+  bool CollidesWith(const DrakeCollision::Element* other) const override;
+
+#ifndef SWIG
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+#endif
+};


### PR DESCRIPTION
This extracts `RigidBody::CollisionElement` into its own files `rigid_body_collision_element.{h,cc}` and class `RigidBodyCollisionElement`, and updates all of the call sites to match.  Since the nesting wasn't supported by SWIG anyway, I don't expect this to change the python or matlab APIs at all.

Fixes #2115.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2963)
<!-- Reviewable:end -->
