### PR TITLE
Major clean-up of method names

### DIFF
--- a/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
@@ -27,7 +27,7 @@ GTEST_TEST(PendulumDynamicConstraint, PendulumDynamicConstraintTest) {
   drake::systems::SystemDynamicConstraint<Pendulum> dut(p);
 
   Drake::TaylorVecXd result;
-    dut.Eval(Drake::initializeAutoDiff(x), result);
+  dut.Eval(Drake::initializeAutoDiff(x), result);
 
   // Expected values came from running the MATLAB code for
   // PendulumPlant through the constraint function in

--- a/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
@@ -27,7 +27,7 @@ GTEST_TEST(PendulumDynamicConstraint, PendulumDynamicConstraintTest) {
   drake::systems::SystemDynamicConstraint<Pendulum> dut(p);
 
   Drake::TaylorVecXd result;
-  dut.eval(Drake::initializeAutoDiff(x), result);
+    dut.Eval(Drake::initializeAutoDiff(x), result);
 
   // Expected values came from running the MATLAB code for
   // PendulumPlant through the constraint function in

--- a/drake/examples/QPInverseDynamicsForHumanoids/qp_controller.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/qp_controller.cc
@@ -300,7 +300,7 @@ int QPController::Control(const HumanoidStatus& rs, const QPInput& input,
   for (auto cost_b : costs) {
     VectorXd val;
     std::shared_ptr<Constraint> cost = cost_b.constraint();
-    cost->eval(VariableList2VectorXd(cost_b.variable_list()), val);
+      cost->Eval(VariableList2VectorXd(cost_b.variable_list()), val);
     std::cout << "cost term 0.5 x^T * H * x + h0 * x: " << val.transpose()
               << std::endl;
   }

--- a/drake/examples/QPInverseDynamicsForHumanoids/qp_controller.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/qp_controller.cc
@@ -300,7 +300,7 @@ int QPController::Control(const HumanoidStatus& rs, const QPInput& input,
   for (auto cost_b : costs) {
     VectorXd val;
     std::shared_ptr<Constraint> cost = cost_b.constraint();
-      cost->Eval(VariableList2VectorXd(cost_b.variable_list()), val);
+    cost->Eval(VariableList2VectorXd(cost_b.variable_list()), val);
     std::cout << "cost term 0.5 x^T * H * x + h0 * x: " << val.transpose()
               << std::endl;
   }

--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -52,13 +52,13 @@ class Constraint {
 
   // TODO(bradking): consider using a Ref for `y`.  This will require the client
   // to do allocation, but also allows it to choose stack allocation instead.
-  virtual void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-                    Eigen::VectorXd& y) const = 0;
+  virtual void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+                    Eigen::VectorXd &y) const = 0;
   // Move this to DifferentiableConstraint derived class if/when we
   // need to support non-differentiable functions (at least, if
   // DifferentiableConstraint is ever implemented).
-  virtual void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-                    Drake::TaylorVecXd& y) const = 0;
+  virtual void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+                    Drake::TaylorVecXd &y) const = 0;
 
   Eigen::VectorXd const& lower_bound() const { return lower_bound_; }
   Eigen::VectorXd const& upper_bound() const { return upper_bound_; }
@@ -86,13 +86,13 @@ class QuadraticConstraint : public Constraint {
 
   ~QuadraticConstraint() override {}
 
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-            Eigen::VectorXd& y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+            Eigen::VectorXd &y) const override {
     y.resize(num_constraints());
     y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
   }
-  void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+            Drake::TaylorVecXd &y) const override {
     y.resize(num_constraints());
     y = .5 * x.transpose() * Q_.cast<Drake::TaylorVarXd>() * x +
         b_.cast<Drake::TaylorVarXd>().transpose() * x;
@@ -129,8 +129,8 @@ class PolynomialConstraint : public Constraint {
 
   ~PolynomialConstraint() override {}
 
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-            Eigen::VectorXd& y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+            Eigen::VectorXd &y) const override {
     double_evaluation_point_.clear();
     for (size_t i = 0; i < poly_vars_.size(); i++) {
       double_evaluation_point_[poly_vars_[i]] = x[i];
@@ -141,8 +141,8 @@ class PolynomialConstraint : public Constraint {
     }
   }
 
-  void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+            Drake::TaylorVecXd &y) const override {
     taylor_evaluation_point_.clear();
     for (size_t i = 0; i < poly_vars_.size(); i++) {
       taylor_evaluation_point_[poly_vars_[i]] = x[i];
@@ -183,13 +183,13 @@ class LinearConstraint : public Constraint {
 
   ~LinearConstraint() override {}
 
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-            Eigen::VectorXd& y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+            Eigen::VectorXd &y) const override {
     y.resize(num_constraints());
     y = A_ * x;
   }
-  void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+            Drake::TaylorVecXd &y) const override {
     y.resize(num_constraints());
     y = A_.cast<Drake::TaylorVarXd>() * x;
   };
@@ -226,8 +226,8 @@ class LinearEqualityConstraint : public LinearConstraint {
    *different number of linear constraints, but on the same decision variables)
    */
   template <typename DerivedA, typename DerivedB>
-  void updateConstraint(const Eigen::MatrixBase<DerivedA>& Aeq,
-                        const Eigen::MatrixBase<DerivedB>& beq) {
+  void UpdateConstraint(const Eigen::MatrixBase<DerivedA> &Aeq,
+                        const Eigen::MatrixBase<DerivedB> &beq) {
     DRAKE_ASSERT(Aeq.rows() == beq.rows());
     if (Aeq.cols() != A_.cols())
       throw std::runtime_error("Can't change the number of decision variables");
@@ -259,13 +259,13 @@ class BoundingBoxConstraint : public LinearConstraint {
 
   ~BoundingBoxConstraint() override {}
 
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-            Eigen::VectorXd& y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+            Eigen::VectorXd &y) const override {
     y.resize(num_constraints());
     y = x;
   }
-  void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+            Drake::TaylorVecXd &y) const override {
     y.resize(num_constraints());
     y = x;
   }
@@ -281,7 +281,7 @@ class BoundingBoxConstraint : public LinearConstraint {
  * </pre>
  *
  * An implied slack variable complements any 0 component of x.  To get
- * the slack values at a given solution x, use eval(x).
+ * the slack values at a given solution x, use Eval(x).
  */
 class LinearComplementarityConstraint : public Constraint {
  public:
@@ -293,13 +293,13 @@ class LinearComplementarityConstraint : public Constraint {
   ~LinearComplementarityConstraint() override {}
 
   /** Return Mx + q (the value of the slack variable). */
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-            Eigen::VectorXd& y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+            Eigen::VectorXd &y) const override {
     y.resize(num_constraints());
     y = (M_ * x) + q_;
   }
-  void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+            Drake::TaylorVecXd &y) const override {
     y.resize(num_constraints());
     y = (M_.cast<Drake::TaylorVarXd>() * x) + q_.cast<Drake::TaylorVarXd>();
   };

--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -52,13 +52,13 @@ class Constraint {
 
   // TODO(bradking): consider using a Ref for `y`.  This will require the client
   // to do allocation, but also allows it to choose stack allocation instead.
-  virtual void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-                    Eigen::VectorXd &y) const = 0;
+  virtual void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                    Eigen::VectorXd& y) const = 0;
   // Move this to DifferentiableConstraint derived class if/when we
   // need to support non-differentiable functions (at least, if
   // DifferentiableConstraint is ever implemented).
-  virtual void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-                    Drake::TaylorVecXd &y) const = 0;
+  virtual void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+                    Drake::TaylorVecXd& y) const = 0;
 
   Eigen::VectorXd const& lower_bound() const { return lower_bound_; }
   Eigen::VectorXd const& upper_bound() const { return upper_bound_; }
@@ -86,13 +86,13 @@ class QuadraticConstraint : public Constraint {
 
   ~QuadraticConstraint() override {}
 
-  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-            Eigen::VectorXd &y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+            Eigen::VectorXd& y) const override {
     y.resize(num_constraints());
     y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
   }
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-            Drake::TaylorVecXd &y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+            Drake::TaylorVecXd& y) const override {
     y.resize(num_constraints());
     y = .5 * x.transpose() * Q_.cast<Drake::TaylorVarXd>() * x +
         b_.cast<Drake::TaylorVarXd>().transpose() * x;
@@ -129,8 +129,8 @@ class PolynomialConstraint : public Constraint {
 
   ~PolynomialConstraint() override {}
 
-  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-            Eigen::VectorXd &y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+            Eigen::VectorXd& y) const override {
     double_evaluation_point_.clear();
     for (size_t i = 0; i < poly_vars_.size(); i++) {
       double_evaluation_point_[poly_vars_[i]] = x[i];
@@ -141,8 +141,8 @@ class PolynomialConstraint : public Constraint {
     }
   }
 
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-            Drake::TaylorVecXd &y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+            Drake::TaylorVecXd& y) const override {
     taylor_evaluation_point_.clear();
     for (size_t i = 0; i < poly_vars_.size(); i++) {
       taylor_evaluation_point_[poly_vars_[i]] = x[i];
@@ -183,13 +183,13 @@ class LinearConstraint : public Constraint {
 
   ~LinearConstraint() override {}
 
-  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-            Eigen::VectorXd &y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+            Eigen::VectorXd& y) const override {
     y.resize(num_constraints());
     y = A_ * x;
   }
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-            Drake::TaylorVecXd &y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+            Drake::TaylorVecXd& y) const override {
     y.resize(num_constraints());
     y = A_.cast<Drake::TaylorVarXd>() * x;
   };
@@ -226,8 +226,8 @@ class LinearEqualityConstraint : public LinearConstraint {
    *different number of linear constraints, but on the same decision variables)
    */
   template <typename DerivedA, typename DerivedB>
-  void UpdateConstraint(const Eigen::MatrixBase<DerivedA> &Aeq,
-                        const Eigen::MatrixBase<DerivedB> &beq) {
+  void UpdateConstraint(const Eigen::MatrixBase<DerivedA>& Aeq,
+                        const Eigen::MatrixBase<DerivedB>& beq) {
     DRAKE_ASSERT(Aeq.rows() == beq.rows());
     if (Aeq.cols() != A_.cols())
       throw std::runtime_error("Can't change the number of decision variables");
@@ -259,13 +259,13 @@ class BoundingBoxConstraint : public LinearConstraint {
 
   ~BoundingBoxConstraint() override {}
 
-  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-            Eigen::VectorXd &y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+            Eigen::VectorXd& y) const override {
     y.resize(num_constraints());
     y = x;
   }
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-            Drake::TaylorVecXd &y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+            Drake::TaylorVecXd& y) const override {
     y.resize(num_constraints());
     y = x;
   }
@@ -293,13 +293,13 @@ class LinearComplementarityConstraint : public Constraint {
   ~LinearComplementarityConstraint() override {}
 
   /** Return Mx + q (the value of the slack variable). */
-  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-            Eigen::VectorXd &y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+            Eigen::VectorXd& y) const override {
     y.resize(num_constraints());
     y = (M_ * x) + q_;
   }
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-            Drake::TaylorVecXd &y) const override {
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+            Drake::TaylorVecXd& y) const override {
     y.resize(num_constraints());
     y = (M_.cast<Drake::TaylorVarXd>() * x) + q_.cast<Drake::TaylorVarXd>();
   };

--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -137,7 +137,7 @@ class PolynomialConstraint : public Constraint {
     }
     y.resize(num_constraints());
     for (size_t i = 0; i < num_constraints(); i++) {
-      y[i] = polynomials_[i].evaluateMultivariate(double_evaluation_point_);
+      y[i] = polynomials_[i].EvaluateMultivariate(double_evaluation_point_);
     }
   }
 
@@ -149,7 +149,7 @@ class PolynomialConstraint : public Constraint {
     }
     y.resize(num_constraints());
     for (size_t i = 0; i < num_constraints(); i++) {
-      y[i] = polynomials_[i].evaluateMultivariate(taylor_evaluation_point_);
+      y[i] = polynomials_[i].EvaluateMultivariate(taylor_evaluation_point_);
     }
   }
 

--- a/drake/solvers/IpoptSolver.cpp
+++ b/drake/solvers/IpoptSolver.cpp
@@ -126,7 +126,7 @@ size_t EvaluateConstraint(
   }
 
   TaylorVecXd ty(c.num_constraints());
-  c.eval(this_x, ty);
+        c.Eval(this_x, ty);
 
   // Store the results.  Since IPOPT directly knows the bounds of the
   // constraint, we don't need to apply any bounding information here.
@@ -412,7 +412,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
         index += v.size();
       }
 
-      binding.constraint()->eval(this_x, ty);
+        binding.constraint()->Eval(this_x, ty);
 
       cost_cache_->result[0] += ty(0).value();
       for (const DecisionVariableView& v : binding.variable_list()) {

--- a/drake/solvers/IpoptSolver.cpp
+++ b/drake/solvers/IpoptSolver.cpp
@@ -126,7 +126,7 @@ size_t EvaluateConstraint(
   }
 
   TaylorVecXd ty(c.num_constraints());
-        c.Eval(this_x, ty);
+  c.Eval(this_x, ty);
 
   // Store the results.  Since IPOPT directly knows the bounds of the
   // constraint, we don't need to apply any bounding information here.
@@ -412,7 +412,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
         index += v.size();
       }
 
-        binding.constraint()->Eval(this_x, ty);
+      binding.constraint()->Eval(this_x, ty);
 
       cost_cache_->result[0] += ty(0).value();
       for (const DecisionVariableView& v : binding.variable_list()) {

--- a/drake/solvers/MobyLCP.cpp
+++ b/drake/solvers/MobyLCP.cpp
@@ -183,11 +183,11 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
   const unsigned N = q.rows();
   const unsigned UINF = std::numeric_limits<unsigned>::max();
 
-        Log() << "MobyLCPSolver::SolveLcpFast() entered" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpFast() entered" << std::endl;
 
   // look for trivial solution
   if (N == 0) {
-      Log() << "MobyLCPSolver::SolveLcpFast() - empty problem" << std::endl;
+    Log() << "MobyLCPSolver::SolveLcpFast() - empty problem" << std::endl;
     z->resize(0);
     return true;
   }
@@ -204,7 +204,7 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
 
   // see whether to warm-start
   if (z->size() == q.size()) {
-      Log() << "MobyLCPSolver::SolveLcpFast() - warm starting activated"
+    Log() << "MobyLCPSolver::SolveLcpFast() - warm starting activated"
           << std::endl;
 
     for (unsigned i = 0; i < z->size(); i++) {
@@ -219,14 +219,14 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
       std::ostringstream str;
       str << " -- non-basic indices:";
       for (unsigned i = 0; i < nonbas_.size(); i++) str << " " << nonbas_[i];
-        Log() << str.str() << std::endl;
+      Log() << str.str() << std::endl;
     }
   } else {
     // get minimum element of q (really w)
     Eigen::Index minw;
     const double minw_val = q.minCoeff(&minw);
     if (minw_val > -zero_tol) {
-        Log() << "MobyLCPSolver::SolveLcpFast() - trivial solution found"
+      Log() << "MobyLCPSolver::SolveLcpFast() - trivial solution found"
             << std::endl;
       z->resize(N);
       z->fill(0);
@@ -272,7 +272,7 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
       // find the (a) minimum of z
       unsigned minz = (z_.rows() > 0) ? minCoeffIdx(z_) : UINF;
       if (log_enabled_ && z_.rows() > 0) {
-          Log() << "MobyLCPSolver::SolveLcpFast() - minimum z after pivot: "
+        Log() << "MobyLCPSolver::SolveLcpFast() - minimum z after pivot: "
               << z_[minz] << std::endl;
       }
       if (minz < UINF && z_[minz] < -zero_tol) {
@@ -293,11 +293,11 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
           (*z)[nonbas_[j]] = z_[i];
         }
 
-          Log() << "MobyLCPSolver::SolveLcpFast() - solution found!" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpFast() - solution found!" << std::endl;
         return true;
       }
     } else {
-        Log() << "(minimum w too negative)" << std::endl;
+      Log() << "(minimum w too negative)" << std::endl;
 
       // one or more components of w violating w >= 0
       // move component of w from basic set to nonbasic set
@@ -309,13 +309,13 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
       // look whether any component of z needs to move to basic set
       unsigned minz = (z_.rows() > 0) ? minCoeffIdx(z_) : UINF;
       if (log_enabled_ && z_.rows() > 0) {
-          Log() << "MobyLCPSolver::SolveLcpFast() - minimum z after pivot: "
+        Log() << "MobyLCPSolver::SolveLcpFast() - minimum z after pivot: "
               << z_[minz] << std::endl;
       }
       if (minz < UINF && z_[minz] < -zero_tol) {
         // move index to basic set and continue looping
         unsigned k = nonbas_[minz];
-          Log() << "MobyLCPSolver::SolveLcpFast() - moving index " << k
+        Log() << "MobyLCPSolver::SolveLcpFast() - moving index " << k
               << " to basic set" << std::endl;
 
         nonbas_.erase(nonbas_.begin() + minz);
@@ -325,7 +325,7 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
     }
   }
 
-        Log() << "MobyLCPSolver::SolveLcpFast() - maximum allowable pivots exceeded"
+  Log() << "MobyLCPSolver::SolveLcpFast() - maximum allowable pivots exceeded"
         << std::endl;
 
   // if we're here, then the maximum number of pivots has been exceeded
@@ -338,7 +338,7 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
                                             Eigen::VectorXd* z, int min_exp,
                                             unsigned step_exp, int max_exp,
                                             double zero_tol) const {
-        Log() << "MobyLCPSolver::SolveLcpFastRegularized() entered" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpFastRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -355,7 +355,7 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
           ? zero_tol
           : (q.size() * M.lpNorm<Eigen::Infinity>() * NEAR_ZERO);
 
-        Log() << " zero tolerance: " << ZERO_TOL << std::endl;
+  Log() << " zero tolerance: " << ZERO_TOL << std::endl;
 
   // store the total pivots
   unsigned total_piv = 0;
@@ -374,22 +374,22 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
         const double wx_max = wx_.maxCoeff();
 
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
-            Log() << "  solved with no regularization necessary!" << std::endl;
-            Log() << "  pivots / total pivots: " << pivots_ << " " << pivots_
+          Log() << "  solved with no regularization necessary!" << std::endl;
+          Log() << "  pivots / total pivots: " << pivots_ << " " << pivots_
                 << std::endl;
-            Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited"
+          Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited"
                 << std::endl;
 
           return true;
         } else {
-            Log() << "MobyLCPSolver::SolveLcpFastRegularized() - "
+          Log() << "MobyLCPSolver::SolveLcpFastRegularized() - "
                 << "'<w, z> not within tolerance(min value: " << wx_min
                 << " max value: " << wx_max << ")" << std::endl;
         }
       } else {
-          Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
+        Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
               << "'w' not solved to desired tolerance" << std::endl;
-          Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
+        Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
       }
     } else {
         Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
@@ -397,7 +397,7 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
         Log() << "  minimum z: " << z->minCoeff() << std::endl;
     }
   } else {
-      Log() << "  MobyLCPSolver::SolveLcpFastRegularized() "
+    Log() << "  MobyLCPSolver::SolveLcpFastRegularized() "
           << "- solver failed with zero regularization" << std::endl;
   }
 
@@ -411,7 +411,7 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
     double lambda =
         std::pow(static_cast<double>(10.0), static_cast<double>(rf));
 
-      Log() << "  trying to solve LCP with regularization factor: " << lambda
+    Log() << "  trying to solve LCP with regularization factor: " << lambda
           << std::endl;
 
     // regularize M
@@ -438,28 +438,28 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
           const double wx_max = wx_.maxCoeff();
 
           if (wx_min > -ZERO_TOL && wx_max < ZERO_TOL) {
-              Log() << "  solved with regularization factor: " << lambda
+            Log() << "  solved with regularization factor: " << lambda
                   << std::endl;
-              Log() << "  pivots / total pivots: " << pivots_ << " " << total_piv
+            Log() << "  pivots / total pivots: " << pivots_ << " " << total_piv
                   << std::endl;
-              Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited"
+            Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited"
                   << std::endl;
             pivots_ = total_piv;
             return true;
           } else {
-              Log() << "MobyLCPSolver::SolveLcpFastRegularized() - "
+            Log() << "MobyLCPSolver::SolveLcpFastRegularized() - "
                   << "'<w, z> not within tolerance(min value: " << wx_min
                   << " max value: " << wx_max << ")" << std::endl;
           }
         } else {
-            Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
+          Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
                 << "'w' not solved to desired tolerance" << std::endl;
-            Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
+          Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
         }
       } else {
-          Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
+        Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
               << "'z' not solved to desired tolerance" << std::endl;
-          Log() << "  minimum z: " << z->minCoeff() << std::endl;
+        Log() << "  minimum z: " << z->minCoeff() << std::endl;
       }
     }
 
@@ -467,8 +467,8 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
     rf += step_exp;
   }
 
-        Log() << "  unable to solve given any regularization!" << std::endl;
-        Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited" << std::endl;
+  Log() << "  unable to solve given any regularization!" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited" << std::endl;
 
   // store total pivots
   pivots_ = total_piv;
@@ -509,10 +509,10 @@ void MobyLCPSolver::FinishLemkeSolution(const MatrixType& M,
     wl_ = (M * (*z)) + q;
     const double minw = wl_.minCoeff();
     const double w_dot_z = std::fabs(wl_.dot(*z));
-      Log() << "  z: " << z << std::endl;
-      Log() << "  _w: " << wl_ << std::endl;
-      Log() << "  minimum w: " << minw << std::endl;
-      Log() << "  w'z: " << w_dot_z << std::endl;
+    Log() << "  z: " << z << std::endl;
+    Log() << "  _w: " << wl_ << std::endl;
+    Log() << "  minimum w: " << minw << std::endl;
+    Log() << "  w'z: " << w_dot_z << std::endl;
   }
 }
 
@@ -525,9 +525,9 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
                                   const Eigen::VectorXd& q, Eigen::VectorXd* z,
                                   double piv_tol, double zero_tol) const {
   if (log_enabled_) {
-      Log() << "MobyLCPSolver::SolveLcpLemke() entered" << std::endl;
-      Log() << "  M: " << std::endl << M;
-      Log() << "  q: " << q << std::endl;
+    Log() << "MobyLCPSolver::SolveLcpLemke() entered" << std::endl;
+    Log() << "  M: " << std::endl << M;
+    Log() << "  q: " << q << std::endl;
   }
 
   const unsigned n = q.size();
@@ -549,8 +549,8 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
   }
 
   if (CheckLemkeTrivial(n, zero_tol, q, z)) {
-      Log() << " -- trivial solution found" << std::endl;
-      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+    Log() << " -- trivial solution found" << std::endl;
+    Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
     return true;
   }
 
@@ -594,7 +594,7 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
 
   // determine initial values
   if (!bas_.empty()) {
-      Log() << "-- initial basis not empty (warmstarting)" << std::endl;
+    Log() << "-- initial basis not empty (warmstarting)" << std::endl;
 
     // start from good initial basis
     Bl_.resize(n, n);
@@ -622,7 +622,7 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
     Al_ = Bl_;
     x_ = Al_.lu().solve(q);
   } else {
-      Log() << "-- using basis of -1 (no warmstarting)" << std::endl;
+    Log() << "-- using basis of -1 (no warmstarting)" << std::endl;
 
     // use standard initial basis
     Bl_.resize(n, n);
@@ -633,9 +633,9 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
 
   // check whether initial basis provides a solution
   if (x_.minCoeff() >= 0.0) {
-      Log() << " -- initial basis provides a solution!" << std::endl;
+    Log() << " -- initial basis provides a solution!" << std::endl;
     FinishLemkeSolution(M, q, z);
-      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+    Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
     return true;
   }
 
@@ -657,8 +657,8 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
   iiter = bas_.begin();
   std::advance(iiter, lvindex);
   leaving = *iiter;
-            Log() << " -- x: " << x_ << std::endl;
-            Log() << " -- first pivot: leaving index=" << lvindex
+  Log() << " -- x: " << x_ << std::endl;
+  Log() << " -- first pivot: leaving index=" << lvindex
         << "  entering index=" << entering << " minimum value: " << tval
         << std::endl;
 
@@ -673,7 +673,7 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
   x_ += u_;
   x_[lvindex] = tval;
   Bl_.col(lvindex) = Be_;
-            Log() << "  new q: " << x_ << std::endl;
+  Log() << "  new q: " << x_ << std::endl;
 
   // main iterations begin here
   for (pivots_ = 0; pivots_ < MAXITER; pivots_++) {
@@ -682,15 +682,15 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
       for (unsigned i = 0; i < bas_.size(); i++) {
         basic << " " << bas_[i];
       }
-        Log() << "basic variables:" << basic.str() << std::endl;
-        Log() << "leaving: " << leaving << " t:" << t << std::endl;
+      Log() << "basic variables:" << basic.str() << std::endl;
+      Log() << "leaving: " << leaving << " t:" << t << std::endl;
     }
 
     // check whether done; if not, get new entering variable
     if (leaving == t) {
-        Log() << "-- solved LCP successfully!" << std::endl;
+      Log() << "-- solved LCP successfully!" << std::endl;
       FinishLemkeSolution(M, q, z);
-        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return true;
     } else if (leaving < n) {
       entering = n + leaving;
@@ -721,18 +721,18 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
 
     // check for no new pivots; ray termination
     if (j_.empty()) {
-        Log()
+      Log()
           << "MobyLCPSolver::SolveLcpLemke() - no new pivots (ray termination)"
           << std::endl;
-        Log() << "MobyLCPSolver::SolveLcpLemke() exiting" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exiting" << std::endl;
       return false;
     }
 
     if (log_enabled_) {
       std::ostringstream j;
       for (unsigned i = 0; i < j_.size(); i++) j << " " << j_[i];
-        Log() << "d: " << dl_ << std::endl;
-        Log() << "j (before min ratio):" << j.str() << std::endl;
+      Log() << "d: " << dl_ << std::endl;
+      Log() << "j (before min ratio):" << j.str() << std::endl;
     }
 
     // select elements j from x and d
@@ -767,13 +767,13 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
       for (unsigned i = 0; i < j_.size(); i++) {
         j << " " << j_[i];
       }
-        Log() << "j (after min ratio):" << j.str() << std::endl;
+      Log() << "j (after min ratio):" << j.str() << std::endl;
     }
 
     // if j is empty, then likely the zero tolerance is too low
     if (j_.empty()) {
-        Log() << "zero tolerance too low?" << std::endl;
-        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << "zero tolerance too low?" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return false;
     }
 
@@ -806,13 +806,13 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
     x_[lvindex] = ratio;
     Bl_.col(lvindex) = Be_;
     *iiter = entering;
-      Log() << " -- pivoting: leaving index=" << lvindex
+    Log() << " -- pivoting: leaving index=" << lvindex
           << "  entering index=" << entering << std::endl;
   }
 
-            Log() << " -- maximum number of iterations exceeded (n=" << n
+  Log() << " -- maximum number of iterations exceeded (n=" << n
         << ", max=" << MAXITER << ")" << std::endl;
-            Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
   return false;
 }
 
@@ -823,7 +823,7 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
                                              unsigned step_exp, int max_exp,
                                              double piv_tol,
                                              double zero_tol) const {
-            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() entered" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -840,7 +840,7 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
           ? zero_tol
           : (q.size() * M.lpNorm<Eigen::Infinity>() * NEAR_ZERO);
 
-            Log() << " zero tolerance: " << ZERO_TOL << std::endl;
+  Log() << " zero tolerance: " << ZERO_TOL << std::endl;
 
   // store the total pivots
   unsigned total_piv = 0;
@@ -858,27 +858,27 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
         const double wx_min = wx_.minCoeff();
         const double wx_max = wx_.maxCoeff();
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
-            Log() << "  solved with no regularization necessary!" << std::endl;
-            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
+          Log() << "  solved with no regularization necessary!" << std::endl;
+          Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
                 << std::endl;
 
           return true;
         } else {
-            Log() << "MobyLCPSolver::SolveLcpLemke() - "
+          Log() << "MobyLCPSolver::SolveLcpLemke() - "
                 << "'<w, z> not within tolerance(min value: " << wx_min
                 << " max value: " << wx_max << ")" << std::endl;
         }
       } else {
-          Log() << "  MobyLCPSolver::SolveLcpLemke() - 'w' not solved to desired "
+        Log() << "  MobyLCPSolver::SolveLcpLemke() - 'w' not solved to desired "
                  "tolerance"
               << std::endl;
-          Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
+        Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
       }
     } else {
-        Log() << "  MobyLCPSolver::SolveLcpLemke() - 'z' not solved to desired "
+      Log() << "  MobyLCPSolver::SolveLcpLemke() - 'z' not solved to desired "
                "tolerance"
             << std::endl;
-        Log() << "  minimum z: " << z->minCoeff() << std::endl;
+      Log() << "  minimum z: " << z->minCoeff() << std::endl;
     }
   }
 
@@ -892,7 +892,7 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
     double lambda =
         std::pow(static_cast<double>(10.0), static_cast<double>(rf));
 
-      Log() << "  trying to solve LCP with regularization factor: " << lambda
+    Log() << "  trying to solve LCP with regularization factor: " << lambda
           << std::endl;
 
     // regularize M
@@ -918,28 +918,28 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
           const double wx_min = wx_.minCoeff();
           const double wx_max = wx_.maxCoeff();
           if (wx_min > -ZERO_TOL && wx_max < ZERO_TOL) {
-              Log() << "  solved with regularization factor: " << lambda
+            Log() << "  solved with regularization factor: " << lambda
                   << std::endl;
-              Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
+            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
                   << std::endl;
             pivots_ = total_piv;
             return true;
           } else {
-              Log() << "MobyLCPSolver::SolveLcpLemke() - "
+            Log() << "MobyLCPSolver::SolveLcpLemke() - "
                   << "'<w, z> not within tolerance(min value: " << wx_min
                   << " max value: " << wx_max << ")" << std::endl;
           }
         } else {
-            Log() << "  MobyLCPSolver::SolveLcpLemke() - 'w' not solved to "
+          Log() << "  MobyLCPSolver::SolveLcpLemke() - 'w' not solved to "
                    "desired tolerance"
                 << std::endl;
-            Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
+          Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
         }
       } else {
-          Log() << "  MobyLCPSolver::SolveLcpLemke() - 'z' not solved to desired "
+        Log() << "  MobyLCPSolver::SolveLcpLemke() - 'z' not solved to desired "
                  "tolerance"
               << std::endl;
-          Log() << "  minimum z: " << z->minCoeff() << std::endl;
+        Log() << "  minimum z: " << z->minCoeff() << std::endl;
       }
     }
 
@@ -947,8 +947,8 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
     rf += step_exp;
   }
 
-            Log() << "  unable to solve given any regularization!" << std::endl;
-            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited" << std::endl;
+  Log() << "  unable to solve given any regularization!" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited" << std::endl;
 
   // store total pivots
   pivots_ = total_piv;
@@ -967,9 +967,9 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
                                   const Eigen::VectorXd& q, Eigen::VectorXd* z,
                                   double piv_tol, double zero_tol) const {
   if (log_enabled_) {
-      Log() << "MobyLCPSolver::SolveLcpLemke() entered" << std::endl;
-      Log() << "  M: " << std::endl << M;
-      Log() << "  q: " << q << std::endl;
+    Log() << "MobyLCPSolver::SolveLcpLemke() entered" << std::endl;
+    Log() << "  M: " << std::endl << M;
+    Log() << "  q: " << q << std::endl;
   }
 
   const unsigned n = q.size();
@@ -989,8 +989,8 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
   }
 
   if (CheckLemkeTrivial(n, zero_tol, q, z)) {
-      Log() << " -- trivial solution found" << std::endl;
-      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+    Log() << " -- trivial solution found" << std::endl;
+    Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
     return true;
   }
 
@@ -1064,9 +1064,9 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
 
   // check whether initial basis provides a solution
   if (x_.minCoeff() >= 0.0) {
-      Log() << " -- initial basis provides a solution!" << std::endl;
+    Log() << " -- initial basis provides a solution!" << std::endl;
     FinishLemkeSolution(M, q, z);
-      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+    Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
     return true;
   }
 
@@ -1093,15 +1093,15 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
   x_ += u_;
   x_[lvindex] = tval;
   sBl_.col(lvindex) = makeSparseVector(Be_);
-            Log() << "  new q: " << x_ << std::endl;
+  Log() << "  new q: " << x_ << std::endl;
 
   // main iterations begin here
   for (pivots_ = 0; pivots_ < MAXITER; pivots_++) {
     // check whether done; if not, get new entering variable
     if (leaving == t) {
-        Log() << "-- solved LCP successfully!" << std::endl;
+      Log() << "-- solved LCP successfully!" << std::endl;
       FinishLemkeSolution(M, q, z);
-        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return true;
     } else if (leaving < n) {
       entering = n + leaving;
@@ -1133,14 +1133,14 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
     }
     // check for no new pivots; ray termination
     if (j_.empty()) {
-        Log()
+      Log()
           << "MobyLCPSolver::SolveLcpLemke() - no new pivots (ray termination)"
           << std::endl;
-        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return false;
     }
 
-      Log() << " -- column of M': " << dl_ << std::endl;
+    Log() << " -- column of M': " << dl_ << std::endl;
 
     // select elements j from x and d
     selectSubVec(x_, j_, &xj_);
@@ -1170,8 +1170,8 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
     }
     // if j is empty, then likely the zero tolerance is too low
     if (j_.empty()) {
-        Log() << "zero tolerance too low?" << std::endl;
-        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << "zero tolerance too low?" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return false;
     }
 
@@ -1204,12 +1204,12 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
     x_[lvindex] = ratio;
     sBl_.col(lvindex) = makeSparseVector(Be_);
     *iiter = entering;
-      Log() << " -- pivoting: leaving index=" << lvindex
+    Log() << " -- pivoting: leaving index=" << lvindex
           << "  entering index=" << entering << std::endl;
   }
 
-            Log() << " -- maximum number of iterations exceeded" << std::endl;
-            Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+  Log() << " -- maximum number of iterations exceeded" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
   return false;
 }
 
@@ -1218,7 +1218,7 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
     const Eigen::SparseMatrix<double>& M, const Eigen::VectorXd& q,
     Eigen::VectorXd* z, int min_exp, unsigned step_exp, int max_exp,
     double piv_tol, double zero_tol) const {
-            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() entered" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -1246,13 +1246,13 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
         const double wx_min = wx_.minCoeff();
         const double wx_max = wx_.maxCoeff();
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
-            Log() << "  solved with no regularization necessary!" << std::endl;
-            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
+          Log() << "  solved with no regularization necessary!" << std::endl;
+          Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
                 << std::endl;
 
           return true;
         } else {
-            Log() << "MobyLCPSolver::SolveLcpLemke() - "
+          Log() << "MobyLCPSolver::SolveLcpLemke() - "
                 << "'<w, z> not within tolerance(min value: " << wx_min
                 << " max value: " << wx_max << ")"
                 << " tol " << ZERO_TOL << std::endl;
@@ -1285,9 +1285,9 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
           // check z'w
           transformVecElements(*z, &wx_, std::multiplies<double>());
           if (wx_.minCoeff() > -ZERO_TOL && wx_.maxCoeff() < ZERO_TOL) {
-              Log() << "  solved with regularization factor: " << lambda
+            Log() << "  solved with regularization factor: " << lambda
                   << std::endl;
-              Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
+            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
                   << std::endl;
 
             return true;
@@ -1300,8 +1300,8 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
     rf += step_exp;
   }
 
-            Log() << "  unable to solve given any regularization!" << std::endl;
-            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited" << std::endl;
+  Log() << "  unable to solve given any regularization!" << std::endl;
+  Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited" << std::endl;
 
   // still here?  failure...
   return false;

--- a/drake/solvers/MobyLCP.cpp
+++ b/drake/solvers/MobyLCP.cpp
@@ -87,7 +87,7 @@ MobyLCPSolver::MobyLCPSolver() : log_enabled_(false) {}
 
 void MobyLCPSolver::SetLoggingEnabled(bool enabled) { log_enabled_ = enabled; }
 
-std::ostream& MobyLCPSolver::LOG() const {
+std::ostream& MobyLCPSolver::Log() const {
   if (log_enabled_) {
     return std::cerr;
   }
@@ -96,11 +96,11 @@ std::ostream& MobyLCPSolver::LOG() const {
 
 void MobyLCPSolver::ClearIndexVectors() const {
   // clear all vectors
-  _all.clear();
-  _tlist.clear();
-  _bas.clear();
-  _nonbas.clear();
-  _j.clear();
+  all_.clear();
+  tlist_.clear();
+  bas_.clear();
+  nonbas_.clear();
+  j_.clear();
 }
 
 SolutionResult MobyLCPSolver::Solve(OptimizationProblem& prog) const {
@@ -183,11 +183,11 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
   const unsigned N = q.rows();
   const unsigned UINF = std::numeric_limits<unsigned>::max();
 
-  LOG() << "MobyLCPSolver::SolveLcpFast() entered" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpFast() entered" << std::endl;
 
   // look for trivial solution
   if (N == 0) {
-    LOG() << "MobyLCPSolver::SolveLcpFast() - empty problem" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpFast() - empty problem" << std::endl;
     z->resize(0);
     return true;
   }
@@ -199,34 +199,34 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
   }
 
   // prepare to setup basic and nonbasic variable indices for z
-  _nonbas.clear();
-  _bas.clear();
+  nonbas_.clear();
+  bas_.clear();
 
   // see whether to warm-start
   if (z->size() == q.size()) {
-    LOG() << "MobyLCPSolver::SolveLcpFast() - warm starting activated"
+      Log() << "MobyLCPSolver::SolveLcpFast() - warm starting activated"
           << std::endl;
 
     for (unsigned i = 0; i < z->size(); i++) {
       if (std::fabs((*z)[i]) < zero_tol) {
-        _bas.push_back(i);
+        bas_.push_back(i);
       } else {
-        _nonbas.push_back(i);
+        nonbas_.push_back(i);
       }
     }
 
     if (log_enabled_) {
       std::ostringstream str;
       str << " -- non-basic indices:";
-      for (unsigned i = 0; i < _nonbas.size(); i++) str << " " << _nonbas[i];
-      LOG() << str.str() << std::endl;
+      for (unsigned i = 0; i < nonbas_.size(); i++) str << " " << nonbas_[i];
+        Log() << str.str() << std::endl;
     }
   } else {
     // get minimum element of q (really w)
     Eigen::Index minw;
     const double minw_val = q.minCoeff(&minw);
     if (minw_val > -zero_tol) {
-      LOG() << "MobyLCPSolver::SolveLcpFast() - trivial solution found"
+        Log() << "MobyLCPSolver::SolveLcpFast() - trivial solution found"
             << std::endl;
       z->resize(N);
       z->fill(0);
@@ -234,11 +234,11 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
     }
 
     // setup basic and nonbasic variable indices
-    _nonbas.push_back(minw);
-    _bas.resize(N - 1);
+    nonbas_.push_back(minw);
+    bas_.resize(N - 1);
     for (unsigned i = 0, j = 0; i < N; i++) {
       if (i != minw) {
-        _bas[j++] = i;
+        bas_[j++] = i;
       }
     }
   }
@@ -246,86 +246,86 @@ bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
   // loop for maximum number of pivots
   //  const unsigned MAX_PIV = std::max(N*N, (unsigned) 1000);
   const unsigned MAX_PIV = 2 * N;
-  for (pivots = 0; pivots < MAX_PIV; pivots++) {
+  for (pivots_ = 0; pivots_ < MAX_PIV; pivots_++) {
     // select nonbasic indices
-    selectSubMat(M, _nonbas, _nonbas, &_Msub);
-    selectSubMat(M, _bas, _nonbas, &_Mmix);
-    selectSubVec(q, _nonbas, &_z);
-    selectSubVec(q, _bas, &_qbas);
+    selectSubMat(M, nonbas_, nonbas_, &Msub_);
+    selectSubMat(M, bas_, nonbas_, &Mmix_);
+    selectSubVec(q, nonbas_, &z_);
+    selectSubVec(q, bas_, &qbas_);
     // _z.negate();
-    _z = _z * -1;
+    z_ = z_ * -1;
 
     // solve for nonbasic z
-    _z = _Msub.lu().solve(_z);
+    z_ = Msub_.lu().solve(z_);
 
     // compute w and find minimum value
-    _w = _Mmix * _z;
-    _w += _qbas;
-    unsigned minw = (_w.rows() > 0) ? minCoeffIdx(_w) : UINF;
+    w_ = Mmix_ * z_;
+    w_ += qbas_;
+    unsigned minw = (w_.rows() > 0) ? minCoeffIdx(w_) : UINF;
 
     // TODO(sammy-tri) this log can't print when minw is UINF.
     // LOG() << "MobyLCPSolver::SolveLcpFast() - minimum w after pivot: "
     // << _w[minw] << std::endl;
 
     // if w >= 0, check whether any component of z < 0
-    if (minw == UINF || _w[minw] > -zero_tol) {
+    if (minw == UINF || w_[minw] > -zero_tol) {
       // find the (a) minimum of z
-      unsigned minz = (_z.rows() > 0) ? minCoeffIdx(_z) : UINF;
-      if (log_enabled_ && _z.rows() > 0) {
-        LOG() << "MobyLCPSolver::SolveLcpFast() - minimum z after pivot: "
-              << _z[minz] << std::endl;
+      unsigned minz = (z_.rows() > 0) ? minCoeffIdx(z_) : UINF;
+      if (log_enabled_ && z_.rows() > 0) {
+          Log() << "MobyLCPSolver::SolveLcpFast() - minimum z after pivot: "
+              << z_[minz] << std::endl;
       }
-      if (minz < UINF && _z[minz] < -zero_tol) {
+      if (minz < UINF && z_[minz] < -zero_tol) {
         // get the original index and remove it from the nonbasic set
-        unsigned idx = _nonbas[minz];
-        _nonbas.erase(_nonbas.begin() + minz);
+        unsigned idx = nonbas_[minz];
+        nonbas_.erase(nonbas_.begin() + minz);
 
         // move index to basic set and continue looping
-        _bas.push_back(idx);
-        std::sort(_bas.begin(), _bas.end());
+        bas_.push_back(idx);
+        std::sort(bas_.begin(), bas_.end());
       } else {
         // found the solution
         z->resize(N);
         z->fill(0);
 
         // set values of z corresponding to _z
-        for (unsigned i = 0, j = 0; j < _nonbas.size(); i++, j++) {
-          (*z)[_nonbas[j]] = _z[i];
+        for (unsigned i = 0, j = 0; j < nonbas_.size(); i++, j++) {
+          (*z)[nonbas_[j]] = z_[i];
         }
 
-        LOG() << "MobyLCPSolver::SolveLcpFast() - solution found!" << std::endl;
+          Log() << "MobyLCPSolver::SolveLcpFast() - solution found!" << std::endl;
         return true;
       }
     } else {
-      LOG() << "(minimum w too negative)" << std::endl;
+        Log() << "(minimum w too negative)" << std::endl;
 
       // one or more components of w violating w >= 0
       // move component of w from basic set to nonbasic set
-      unsigned idx = _bas[minw];
-      _bas.erase(_bas.begin() + minw);
-      _nonbas.push_back(idx);
-      std::sort(_nonbas.begin(), _nonbas.end());
+      unsigned idx = bas_[minw];
+      bas_.erase(bas_.begin() + minw);
+      nonbas_.push_back(idx);
+      std::sort(nonbas_.begin(), nonbas_.end());
 
       // look whether any component of z needs to move to basic set
-      unsigned minz = (_z.rows() > 0) ? minCoeffIdx(_z) : UINF;
-      if (log_enabled_ && _z.rows() > 0) {
-        LOG() << "MobyLCPSolver::SolveLcpFast() - minimum z after pivot: "
-              << _z[minz] << std::endl;
+      unsigned minz = (z_.rows() > 0) ? minCoeffIdx(z_) : UINF;
+      if (log_enabled_ && z_.rows() > 0) {
+          Log() << "MobyLCPSolver::SolveLcpFast() - minimum z after pivot: "
+              << z_[minz] << std::endl;
       }
-      if (minz < UINF && _z[minz] < -zero_tol) {
+      if (minz < UINF && z_[minz] < -zero_tol) {
         // move index to basic set and continue looping
-        unsigned k = _nonbas[minz];
-        LOG() << "MobyLCPSolver::SolveLcpFast() - moving index " << k
+        unsigned k = nonbas_[minz];
+          Log() << "MobyLCPSolver::SolveLcpFast() - moving index " << k
               << " to basic set" << std::endl;
 
-        _nonbas.erase(_nonbas.begin() + minz);
-        _bas.push_back(k);
-        std::sort(_bas.begin(), _bas.end());
+        nonbas_.erase(nonbas_.begin() + minz);
+        bas_.push_back(k);
+        std::sort(bas_.begin(), bas_.end());
       }
     }
   }
 
-  LOG() << "MobyLCPSolver::SolveLcpFast() - maximum allowable pivots exceeded"
+        Log() << "MobyLCPSolver::SolveLcpFast() - maximum allowable pivots exceeded"
         << std::endl;
 
   // if we're here, then the maximum number of pivots has been exceeded
@@ -338,7 +338,7 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
                                             Eigen::VectorXd* z, int min_exp,
                                             unsigned step_exp, int max_exp,
                                             double zero_tol) const {
-  LOG() << "MobyLCPSolver::SolveLcpFastRegularized() entered" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpFastRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -347,7 +347,7 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
   }
 
   // copy MM
-  _MM = M;
+  MM_ = M;
 
   // assign value for zero tolerance, if necessary
   const double ZERO_TOL =
@@ -355,54 +355,54 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
           ? zero_tol
           : (q.size() * M.lpNorm<Eigen::Infinity>() * NEAR_ZERO);
 
-  LOG() << " zero tolerance: " << ZERO_TOL << std::endl;
+        Log() << " zero tolerance: " << ZERO_TOL << std::endl;
 
   // store the total pivots
   unsigned total_piv = 0;
 
   // try non-regularized version first
-  bool result = SolveLcpFast(_MM, q, z, zero_tol);
+  bool result = SolveLcpFast(MM_, q, z, zero_tol);
   if (result) {
     // verify that solution truly is a solution -- check z
     if (z->minCoeff() >= -ZERO_TOL) {
       // check w
-      _wx = (M * (*z)) + q;
-      if (_wx.minCoeff() >= -ZERO_TOL) {
+      wx_ = (M * (*z)) + q;
+      if (wx_.minCoeff() >= -ZERO_TOL) {
         // check z'w
-        transformVecElements(*z, &_wx, std::multiplies<double>());
-        const double wx_min = _wx.minCoeff();
-        const double wx_max = _wx.maxCoeff();
+        transformVecElements(*z, &wx_, std::multiplies<double>());
+        const double wx_min = wx_.minCoeff();
+        const double wx_max = wx_.maxCoeff();
 
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
-          LOG() << "  solved with no regularization necessary!" << std::endl;
-          LOG() << "  pivots / total pivots: " << pivots << " " << pivots
+            Log() << "  solved with no regularization necessary!" << std::endl;
+            Log() << "  pivots / total pivots: " << pivots_ << " " << pivots_
                 << std::endl;
-          LOG() << "MobyLCPSolver::SolveLcpFastRegularized() exited"
+            Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited"
                 << std::endl;
 
           return true;
         } else {
-          LOG() << "MobyLCPSolver::SolveLcpFastRegularized() - "
+            Log() << "MobyLCPSolver::SolveLcpFastRegularized() - "
                 << "'<w, z> not within tolerance(min value: " << wx_min
                 << " max value: " << wx_max << ")" << std::endl;
         }
       } else {
-        LOG() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
+          Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
               << "'w' not solved to desired tolerance" << std::endl;
-        LOG() << "  minimum w: " << _wx.minCoeff() << std::endl;
+          Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
       }
     } else {
-      LOG() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
+        Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
             << "'z' not solved to desired tolerance" << std::endl;
-      LOG() << "  minimum z: " << z->minCoeff() << std::endl;
+        Log() << "  minimum z: " << z->minCoeff() << std::endl;
     }
   } else {
-    LOG() << "  MobyLCPSolver::SolveLcpFastRegularized() "
+      Log() << "  MobyLCPSolver::SolveLcpFastRegularized() "
           << "- solver failed with zero regularization" << std::endl;
   }
 
   // update the pivots
-  total_piv += pivots;
+  total_piv += pivots_;
 
   // start the regularization process
   int rf = min_exp;
@@ -411,55 +411,55 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
     double lambda =
         std::pow(static_cast<double>(10.0), static_cast<double>(rf));
 
-    LOG() << "  trying to solve LCP with regularization factor: " << lambda
+      Log() << "  trying to solve LCP with regularization factor: " << lambda
           << std::endl;
 
     // regularize M
-    _MM = M;
+    MM_ = M;
     for (unsigned i = 0; i < M.rows(); i++) {
-      _MM(i, i) += lambda;
+      MM_(i, i) += lambda;
     }
 
     // try to solve the LCP
-    result = SolveLcpFast(_MM, q, z, zero_tol);
+    result = SolveLcpFast(MM_, q, z, zero_tol);
 
     // update total pivots
-    total_piv += pivots;
+    total_piv += pivots_;
 
     if (result) {
       // verify that solution truly is a solution -- check z
       if (z->minCoeff() > -ZERO_TOL) {
         // check w
-        _wx = (_MM * (*z)) + q;
-        if (_wx.minCoeff() > -ZERO_TOL) {
+        wx_ = (MM_ * (*z)) + q;
+        if (wx_.minCoeff() > -ZERO_TOL) {
           // check z'w
-          transformVecElements(*z, &_wx, std::multiplies<double>());
-          const double wx_min = _wx.minCoeff();
-          const double wx_max = _wx.maxCoeff();
+          transformVecElements(*z, &wx_, std::multiplies<double>());
+          const double wx_min = wx_.minCoeff();
+          const double wx_max = wx_.maxCoeff();
 
           if (wx_min > -ZERO_TOL && wx_max < ZERO_TOL) {
-            LOG() << "  solved with regularization factor: " << lambda
+              Log() << "  solved with regularization factor: " << lambda
                   << std::endl;
-            LOG() << "  pivots / total pivots: " << pivots << " " << total_piv
+              Log() << "  pivots / total pivots: " << pivots_ << " " << total_piv
                   << std::endl;
-            LOG() << "MobyLCPSolver::SolveLcpFastRegularized() exited"
+              Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited"
                   << std::endl;
-            pivots = total_piv;
+            pivots_ = total_piv;
             return true;
           } else {
-            LOG() << "MobyLCPSolver::SolveLcpFastRegularized() - "
+              Log() << "MobyLCPSolver::SolveLcpFastRegularized() - "
                   << "'<w, z> not within tolerance(min value: " << wx_min
                   << " max value: " << wx_max << ")" << std::endl;
           }
         } else {
-          LOG() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
+            Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
                 << "'w' not solved to desired tolerance" << std::endl;
-          LOG() << "  minimum w: " << _wx.minCoeff() << std::endl;
+            Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
         }
       } else {
-        LOG() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
+          Log() << "  MobyLCPSolver::SolveLcpFastRegularized() - "
               << "'z' not solved to desired tolerance" << std::endl;
-        LOG() << "  minimum z: " << z->minCoeff() << std::endl;
+          Log() << "  minimum z: " << z->minCoeff() << std::endl;
       }
     }
 
@@ -467,11 +467,11 @@ bool MobyLCPSolver::SolveLcpFastRegularized(const Eigen::MatrixXd& M,
     rf += step_exp;
   }
 
-  LOG() << "  unable to solve given any regularization!" << std::endl;
-  LOG() << "MobyLCPSolver::SolveLcpFastRegularized() exited" << std::endl;
+        Log() << "  unable to solve given any regularization!" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpFastRegularized() exited" << std::endl;
 
   // store total pivots
-  pivots = total_piv;
+  pivots_ = total_piv;
 
   // still here?  failure...
   return false;
@@ -496,8 +496,8 @@ void MobyLCPSolver::FinishLemkeSolution(const MatrixType& M,
                                         Eigen::VectorXd* z) const {
   std::vector<unsigned>::iterator iiter;
   int idx;
-  for (idx = 0, iiter = _bas.begin(); iiter != _bas.end(); iiter++, idx++) {
-    (*z)(*iiter) = _x(idx);
+  for (idx = 0, iiter = bas_.begin(); iiter != bas_.end(); iiter++, idx++) {
+    (*z)(*iiter) = x_(idx);
   }
 
   // TODO(sammy-tri) Is there a more efficient way to resize and
@@ -506,13 +506,13 @@ void MobyLCPSolver::FinishLemkeSolution(const MatrixType& M,
 
   // check to see whether tolerances are satisfied
   if (log_enabled_) {
-    _wl = (M * (*z)) + q;
-    const double minw = _wl.minCoeff();
-    const double w_dot_z = std::fabs(_wl.dot(*z));
-    LOG() << "  z: " << z << std::endl;
-    LOG() << "  _w: " << _wl << std::endl;
-    LOG() << "  minimum w: " << minw << std::endl;
-    LOG() << "  w'z: " << w_dot_z << std::endl;
+    wl_ = (M * (*z)) + q;
+    const double minw = wl_.minCoeff();
+    const double w_dot_z = std::fabs(wl_.dot(*z));
+      Log() << "  z: " << z << std::endl;
+      Log() << "  _w: " << wl_ << std::endl;
+      Log() << "  minimum w: " << minw << std::endl;
+      Log() << "  w'z: " << w_dot_z << std::endl;
   }
 }
 
@@ -525,16 +525,16 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
                                   const Eigen::VectorXd& q, Eigen::VectorXd* z,
                                   double piv_tol, double zero_tol) const {
   if (log_enabled_) {
-    LOG() << "MobyLCPSolver::SolveLcpLemke() entered" << std::endl;
-    LOG() << "  M: " << std::endl << M;
-    LOG() << "  q: " << q << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() entered" << std::endl;
+      Log() << "  M: " << std::endl << M;
+      Log() << "  q: " << q << std::endl;
   }
 
   const unsigned n = q.size();
   const unsigned MAXITER = std::min((unsigned)1000, 50 * n);
 
   // update the pivots
-  pivots = 0;
+  pivots_ = 0;
 
   // look for immediate exit
   if (n == 0) {
@@ -549,8 +549,8 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
   }
 
   if (CheckLemkeTrivial(n, zero_tol, q, z)) {
-    LOG() << " -- trivial solution found" << std::endl;
-    LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << " -- trivial solution found" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
     return true;
   }
 
@@ -561,7 +561,7 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
   z->fill(0);
 
   // copy z to z0
-  _z0 = *z;
+  z0_ = *z;
 
   ClearIndexVectors();
 
@@ -572,46 +572,46 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
   unsigned entering = t;
   unsigned leaving = 0;
   for (unsigned i = 0; i < n; i++) {
-    _all.push_back(i);
+    all_.push_back(i);
   }
   unsigned lvindex;
   unsigned idx;
   std::vector<unsigned>::iterator iiter;
 
   // determine initial basis
-  if (_z0.size() != n) {
+  if (z0_.size() != n) {
     // setup the nonbasic indices
-    for (unsigned i = 0; i < n; i++) _nonbas.push_back(i);
+    for (unsigned i = 0; i < n; i++) nonbas_.push_back(i);
   } else {
     for (unsigned i = 0; i < n; i++) {
-      if (_z0[i] > 0) {
-        _bas.push_back(i);
+      if (z0_[i] > 0) {
+        bas_.push_back(i);
       } else {
-        _nonbas.push_back(i);
+        nonbas_.push_back(i);
       }
     }
   }
 
   // determine initial values
-  if (!_bas.empty()) {
-    LOG() << "-- initial basis not empty (warmstarting)" << std::endl;
+  if (!bas_.empty()) {
+      Log() << "-- initial basis not empty (warmstarting)" << std::endl;
 
     // start from good initial basis
-    _Bl.resize(n, n);
-    _Bl.setIdentity();
+    Bl_.resize(n, n);
+    Bl_.setIdentity();
     // _Bl.negate();
-    _Bl *= -1;
+    Bl_ *= -1;
 
     // select columns of M corresponding to z vars in the basis
-    selectSubMat(M, _all, _bas, &_t1);
+    selectSubMat(M, all_, bas_, &t1_);
 
     // select columns of I corresponding to z vars not in the basis
-    selectSubMat(_Bl, _all, _nonbas, &_t2);
+    selectSubMat(Bl_, all_, nonbas_, &t2_);
 
     // setup the basis matrix
-    _Bl.resize(n, _t1.cols() + _t2.cols());
-    _Bl.block(0, 0, _t1.rows(), _t1.cols()) = _t1;
-    _Bl.block(0, _t1.cols(), _t2.rows(), _t2.cols()) = _t2;
+    Bl_.resize(n, t1_.cols() + t2_.cols());
+    Bl_.block(0, 0, t1_.rows(), t1_.cols()) = t1_;
+    Bl_.block(0, t1_.cols(), t2_.rows(), t2_.cols()) = t2_;
 
     // solve B*x = -q
     //
@@ -619,23 +619,23 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
     // case where the colver failed (though only in this dense
     // implementation).  It's not obvious how to do this from Eigen,
     // so we've (sam.creasey) assumed that the solve succeeds.
-    _Al = _Bl;
-    _x = _Al.lu().solve(q);
+    Al_ = Bl_;
+    x_ = Al_.lu().solve(q);
   } else {
-    LOG() << "-- using basis of -1 (no warmstarting)" << std::endl;
+      Log() << "-- using basis of -1 (no warmstarting)" << std::endl;
 
     // use standard initial basis
-    _Bl.resize(n, n);
-    _Bl.setIdentity();
-    _Bl *= -1;
-    _x = q;
+    Bl_.resize(n, n);
+    Bl_.setIdentity();
+    Bl_ *= -1;
+    x_ = q;
   }
 
   // check whether initial basis provides a solution
-  if (_x.minCoeff() >= 0.0) {
-    LOG() << " -- initial basis provides a solution!" << std::endl;
+  if (x_.minCoeff() >= 0.0) {
+      Log() << " -- initial basis provides a solution!" << std::endl;
     FinishLemkeSolution(M, q, z);
-    LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
     return true;
   }
 
@@ -648,171 +648,171 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::MatrixXd& M,
 
   // determine initial leaving variable
   Eigen::Index min_x;
-  const double min_x_val = _x.topRows(n).minCoeff(&min_x);
+  const double min_x_val = x_.topRows(n).minCoeff(&min_x);
   double tval = -min_x_val;
-  for (size_t i = 0; i < _nonbas.size(); i++) {
-    _bas.push_back(_nonbas[i] + n);
+  for (size_t i = 0; i < nonbas_.size(); i++) {
+    bas_.push_back(nonbas_[i] + n);
   }
   lvindex = min_x;
-  iiter = _bas.begin();
+  iiter = bas_.begin();
   std::advance(iiter, lvindex);
   leaving = *iiter;
-  LOG() << " -- x: " << _x << std::endl;
-  LOG() << " -- first pivot: leaving index=" << lvindex
+            Log() << " -- x: " << x_ << std::endl;
+            Log() << " -- first pivot: leaving index=" << lvindex
         << "  entering index=" << entering << " minimum value: " << tval
         << std::endl;
 
   // pivot in the artificial variable
   *iiter = t;  // replace w var with _z0 in basic indices
-  _u.resize(n);
+  u_.resize(n);
   for (unsigned i = 0; i < n; i++) {
-    _u[i] = (_x[i] < 0.0) ? 1.0 : 0.0;
+    u_[i] = (x_[i] < 0.0) ? 1.0 : 0.0;
   }
-  _Be = (_Bl * _u) * -1;
-  _u *= tval;
-  _x += _u;
-  _x[lvindex] = tval;
-  _Bl.col(lvindex) = _Be;
-  LOG() << "  new q: " << _x << std::endl;
+  Be_ = (Bl_ * u_) * -1;
+  u_ *= tval;
+  x_ += u_;
+  x_[lvindex] = tval;
+  Bl_.col(lvindex) = Be_;
+            Log() << "  new q: " << x_ << std::endl;
 
   // main iterations begin here
-  for (pivots = 0; pivots < MAXITER; pivots++) {
+  for (pivots_ = 0; pivots_ < MAXITER; pivots_++) {
     if (log_enabled_) {
       std::ostringstream basic;
-      for (unsigned i = 0; i < _bas.size(); i++) {
-        basic << " " << _bas[i];
+      for (unsigned i = 0; i < bas_.size(); i++) {
+        basic << " " << bas_[i];
       }
-      LOG() << "basic variables:" << basic.str() << std::endl;
-      LOG() << "leaving: " << leaving << " t:" << t << std::endl;
+        Log() << "basic variables:" << basic.str() << std::endl;
+        Log() << "leaving: " << leaving << " t:" << t << std::endl;
     }
 
     // check whether done; if not, get new entering variable
     if (leaving == t) {
-      LOG() << "-- solved LCP successfully!" << std::endl;
+        Log() << "-- solved LCP successfully!" << std::endl;
       FinishLemkeSolution(M, q, z);
-      LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return true;
     } else if (leaving < n) {
       entering = n + leaving;
-      _Be.resize(n);
-      _Be.fill(0);
-      _Be[leaving] = -1;
+      Be_.resize(n);
+      Be_.fill(0);
+      Be_[leaving] = -1;
     } else {
       entering = leaving - n;
-      _Be = M.col(entering);
+      Be_ = M.col(entering);
     }
-    _dl = _Be;
+    dl_ = Be_;
 
     // Again, The original version of this code from Moby could handle
     // the case where the solver failed.  There was also some
     // commented out code related to trying to restart on finding a
     // solution.  For the reasons above, and the fact that it was
     // commented out, this functionality has not been preserved.
-    _Al = _Bl;
-    _dl = _Al.lu().solve(_dl);
+    Al_ = Bl_;
+    dl_ = Al_.lu().solve(dl_);
 
     // ** find new leaving variable
-    _j.clear();
-    for (unsigned i = 0; i < _dl.size(); i++) {
-      if (_dl[i] > PIV_TOL) {
-        _j.push_back(i);
+    j_.clear();
+    for (unsigned i = 0; i < dl_.size(); i++) {
+      if (dl_[i] > PIV_TOL) {
+        j_.push_back(i);
       }
     }
 
     // check for no new pivots; ray termination
-    if (_j.empty()) {
-      LOG()
+    if (j_.empty()) {
+        Log()
           << "MobyLCPSolver::SolveLcpLemke() - no new pivots (ray termination)"
           << std::endl;
-      LOG() << "MobyLCPSolver::SolveLcpLemke() exiting" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpLemke() exiting" << std::endl;
       return false;
     }
 
     if (log_enabled_) {
       std::ostringstream j;
-      for (unsigned i = 0; i < _j.size(); i++) j << " " << _j[i];
-      LOG() << "d: " << _dl << std::endl;
-      LOG() << "j (before min ratio):" << j.str() << std::endl;
+      for (unsigned i = 0; i < j_.size(); i++) j << " " << j_[i];
+        Log() << "d: " << dl_ << std::endl;
+        Log() << "j (before min ratio):" << j.str() << std::endl;
     }
 
     // select elements j from x and d
-    selectSubVec(_x, _j, &_xj);
-    selectSubVec(_dl, _j, &_dj);
+    selectSubVec(x_, j_, &xj_);
+    selectSubVec(dl_, j_, &dj_);
 
     // compute minimal ratios x(j) + EPS_DOUBLE ./ d(j), d > 0
-    _result.resize(_xj.size());
-    _result.fill(zero_tol);
-    transformVecElements(_xj, &_result, std::plus<double>());
-    transformVecElements(_dj, &_result,
+    result_.resize(xj_.size());
+    result_.fill(zero_tol);
+    transformVecElements(xj_, &result_, std::plus<double>());
+    transformVecElements(dj_, &result_,
                          [](double a, double b) { return b / a; });
-    double theta = _result.minCoeff();
+    double theta = result_.minCoeff();
 
     // NOTE: lexicographic ordering does not appear to be used here to prevent
     // cycling (see [Cottle 1992], pp. 340-342)
     // find indices of minimal ratios, d> 0
     //   divide _x(j) ./ d(j) -- remove elements above the minimum ratio
-    for (int i = 0; i < _result.size(); i++) {
-      _result(i) = _xj(i) / _dj(i);
+    for (int i = 0; i < result_.size(); i++) {
+      result_(i) = xj_(i) / dj_(i);
     }
 
-    for (iiter = _j.begin(), idx = 0; iiter != _j.end();) {
-      if (_result[idx++] <= theta) {
+    for (iiter = j_.begin(), idx = 0; iiter != j_.end();) {
+      if (result_[idx++] <= theta) {
         iiter++;
       } else {
-        iiter = _j.erase(iiter);
+        iiter = j_.erase(iiter);
       }
     }
     if (log_enabled_) {
       std::ostringstream j;
-      for (unsigned i = 0; i < _j.size(); i++) {
-        j << " " << _j[i];
+      for (unsigned i = 0; i < j_.size(); i++) {
+        j << " " << j_[i];
       }
-      LOG() << "j (after min ratio):" << j.str() << std::endl;
+        Log() << "j (after min ratio):" << j.str() << std::endl;
     }
 
     // if j is empty, then likely the zero tolerance is too low
-    if (_j.empty()) {
-      LOG() << "zero tolerance too low?" << std::endl;
-      LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+    if (j_.empty()) {
+        Log() << "zero tolerance too low?" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return false;
     }
 
     // check whether artificial index among these
-    _tlist.clear();
-    for (size_t i = 0; i < _j.size(); i++) {
-      _tlist.push_back(_bas[_j[i]]);
+    tlist_.clear();
+    for (size_t i = 0; i < j_.size(); i++) {
+      tlist_.push_back(bas_[j_[i]]);
     }
-    if (std::find(_tlist.begin(), _tlist.end(), t) != _tlist.end()) {
-      iiter = std::find(_bas.begin(), _bas.end(), t);
-      lvindex = iiter - _bas.begin();
+    if (std::find(tlist_.begin(), tlist_.end(), t) != tlist_.end()) {
+      iiter = std::find(bas_.begin(), bas_.end(), t);
+      lvindex = iiter - bas_.begin();
     } else {
       // several indices pass the minimum ratio test, pick one randomly
       //      lvindex = _j[rand() % _j.size()];
       // NOTE: solver seems *much* more capable of solving when we pick the
       // first
       // element rather than picking a random one
-      lvindex = _j[0];
+      lvindex = j_[0];
     }
 
     // set leaving = bas(lvindex)
-    iiter = _bas.begin();
+    iiter = bas_.begin();
     std::advance(iiter, lvindex);
     leaving = *iiter;
 
     // ** perform pivot
-    double ratio = _x[lvindex] / _dl[lvindex];
-    _dl *= ratio;
-    _x -= _dl;
-    _x[lvindex] = ratio;
-    _Bl.col(lvindex) = _Be;
+    double ratio = x_[lvindex] / dl_[lvindex];
+    dl_ *= ratio;
+    x_ -= dl_;
+    x_[lvindex] = ratio;
+    Bl_.col(lvindex) = Be_;
     *iiter = entering;
-    LOG() << " -- pivoting: leaving index=" << lvindex
+      Log() << " -- pivoting: leaving index=" << lvindex
           << "  entering index=" << entering << std::endl;
   }
 
-  LOG() << " -- maximum number of iterations exceeded (n=" << n
+            Log() << " -- maximum number of iterations exceeded (n=" << n
         << ", max=" << MAXITER << ")" << std::endl;
-  LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+            Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
   return false;
 }
 
@@ -823,7 +823,7 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
                                              unsigned step_exp, int max_exp,
                                              double piv_tol,
                                              double zero_tol) const {
-  LOG() << "MobyLCPSolver::SolveLcpLemkeRegularized() entered" << std::endl;
+            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -832,7 +832,7 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
   }
 
   // copy MM
-  _MM = M;
+  MM_ = M;
 
   // assign value for zero tolerance, if necessary
   const double ZERO_TOL =
@@ -840,50 +840,50 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
           ? zero_tol
           : (q.size() * M.lpNorm<Eigen::Infinity>() * NEAR_ZERO);
 
-  LOG() << " zero tolerance: " << ZERO_TOL << std::endl;
+            Log() << " zero tolerance: " << ZERO_TOL << std::endl;
 
   // store the total pivots
   unsigned total_piv = 0;
 
   // try non-regularized version first
-  bool result = SolveLcpLemke(_MM, q, z, piv_tol, zero_tol);
+  bool result = SolveLcpLemke(MM_, q, z, piv_tol, zero_tol);
   if (result) {
     // verify that solution truly is a solution -- check z
     if (z->minCoeff() >= -ZERO_TOL) {
       // check w
-      _wx = (M * (*z)) + q;
-      if (_wx.minCoeff() >= -ZERO_TOL) {
+      wx_ = (M * (*z)) + q;
+      if (wx_.minCoeff() >= -ZERO_TOL) {
         // check z'w
-        transformVecElements(*z, &_wx, std::multiplies<double>());
-        const double wx_min = _wx.minCoeff();
-        const double wx_max = _wx.maxCoeff();
+        transformVecElements(*z, &wx_, std::multiplies<double>());
+        const double wx_min = wx_.minCoeff();
+        const double wx_max = wx_.maxCoeff();
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
-          LOG() << "  solved with no regularization necessary!" << std::endl;
-          LOG() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
+            Log() << "  solved with no regularization necessary!" << std::endl;
+            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
                 << std::endl;
 
           return true;
         } else {
-          LOG() << "MobyLCPSolver::SolveLcpLemke() - "
+            Log() << "MobyLCPSolver::SolveLcpLemke() - "
                 << "'<w, z> not within tolerance(min value: " << wx_min
                 << " max value: " << wx_max << ")" << std::endl;
         }
       } else {
-        LOG() << "  MobyLCPSolver::SolveLcpLemke() - 'w' not solved to desired "
+          Log() << "  MobyLCPSolver::SolveLcpLemke() - 'w' not solved to desired "
                  "tolerance"
               << std::endl;
-        LOG() << "  minimum w: " << _wx.minCoeff() << std::endl;
+          Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
       }
     } else {
-      LOG() << "  MobyLCPSolver::SolveLcpLemke() - 'z' not solved to desired "
+        Log() << "  MobyLCPSolver::SolveLcpLemke() - 'z' not solved to desired "
                "tolerance"
             << std::endl;
-      LOG() << "  minimum z: " << z->minCoeff() << std::endl;
+        Log() << "  minimum z: " << z->minCoeff() << std::endl;
     }
   }
 
   // update the pivots
-  total_piv += pivots;
+  total_piv += pivots_;
 
   // start the regularization process
   int rf = min_exp;
@@ -892,54 +892,54 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
     double lambda =
         std::pow(static_cast<double>(10.0), static_cast<double>(rf));
 
-    LOG() << "  trying to solve LCP with regularization factor: " << lambda
+      Log() << "  trying to solve LCP with regularization factor: " << lambda
           << std::endl;
 
     // regularize M
-    _MM = M;
+    MM_ = M;
     for (unsigned i = 0; i < M.rows(); i++) {
-      _MM(i, i) += lambda;
+      MM_(i, i) += lambda;
     }
 
     // try to solve the LCP
-    result = SolveLcpLemke(_MM, q, z, piv_tol, zero_tol);
+    result = SolveLcpLemke(MM_, q, z, piv_tol, zero_tol);
 
     // update total pivots
-    total_piv += pivots;
+    total_piv += pivots_;
 
     if (result) {
       // verify that solution truly is a solution -- check z
       if (z->minCoeff() > -ZERO_TOL) {
         // check w
-        _wx = (_MM * (*z)) + q;
-        if (_wx.minCoeff() > -ZERO_TOL) {
+        wx_ = (MM_ * (*z)) + q;
+        if (wx_.minCoeff() > -ZERO_TOL) {
           // check z'w
-          transformVecElements(*z, &_wx, std::multiplies<double>());
-          const double wx_min = _wx.minCoeff();
-          const double wx_max = _wx.maxCoeff();
+          transformVecElements(*z, &wx_, std::multiplies<double>());
+          const double wx_min = wx_.minCoeff();
+          const double wx_max = wx_.maxCoeff();
           if (wx_min > -ZERO_TOL && wx_max < ZERO_TOL) {
-            LOG() << "  solved with regularization factor: " << lambda
+              Log() << "  solved with regularization factor: " << lambda
                   << std::endl;
-            LOG() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
+              Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
                   << std::endl;
-            pivots = total_piv;
+            pivots_ = total_piv;
             return true;
           } else {
-            LOG() << "MobyLCPSolver::SolveLcpLemke() - "
+              Log() << "MobyLCPSolver::SolveLcpLemke() - "
                   << "'<w, z> not within tolerance(min value: " << wx_min
                   << " max value: " << wx_max << ")" << std::endl;
           }
         } else {
-          LOG() << "  MobyLCPSolver::SolveLcpLemke() - 'w' not solved to "
+            Log() << "  MobyLCPSolver::SolveLcpLemke() - 'w' not solved to "
                    "desired tolerance"
                 << std::endl;
-          LOG() << "  minimum w: " << _wx.minCoeff() << std::endl;
+            Log() << "  minimum w: " << wx_.minCoeff() << std::endl;
         }
       } else {
-        LOG() << "  MobyLCPSolver::SolveLcpLemke() - 'z' not solved to desired "
+          Log() << "  MobyLCPSolver::SolveLcpLemke() - 'z' not solved to desired "
                  "tolerance"
               << std::endl;
-        LOG() << "  minimum z: " << z->minCoeff() << std::endl;
+          Log() << "  minimum z: " << z->minCoeff() << std::endl;
       }
     }
 
@@ -947,11 +947,11 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(const Eigen::MatrixXd& M,
     rf += step_exp;
   }
 
-  LOG() << "  unable to solve given any regularization!" << std::endl;
-  LOG() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited" << std::endl;
+            Log() << "  unable to solve given any regularization!" << std::endl;
+            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited" << std::endl;
 
   // store total pivots
-  pivots = total_piv;
+  pivots_ = total_piv;
 
   // still here?  failure...
   return false;
@@ -967,9 +967,9 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
                                   const Eigen::VectorXd& q, Eigen::VectorXd* z,
                                   double piv_tol, double zero_tol) const {
   if (log_enabled_) {
-    LOG() << "MobyLCPSolver::SolveLcpLemke() entered" << std::endl;
-    LOG() << "  M: " << std::endl << M;
-    LOG() << "  q: " << q << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() entered" << std::endl;
+      Log() << "  M: " << std::endl << M;
+      Log() << "  q: " << q << std::endl;
   }
 
   const unsigned n = q.size();
@@ -989,13 +989,13 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
   }
 
   if (CheckLemkeTrivial(n, zero_tol, q, z)) {
-    LOG() << " -- trivial solution found" << std::endl;
-    LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << " -- trivial solution found" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
     return true;
   }
 
   // copy z to z0
-  _z0 = *z;
+  z0_ = *z;
 
   ClearIndexVectors();
 
@@ -1006,210 +1006,210 @@ bool MobyLCPSolver::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
   unsigned entering = t;
   unsigned leaving = 0;
   for (unsigned i = 0; i < n; i++) {
-    _all.push_back(i);
+    all_.push_back(i);
   }
   unsigned lvindex;
   unsigned idx;
   std::vector<unsigned>::iterator iiter;
 
   // determine initial basis
-  if (_z0.size() != n) {
+  if (z0_.size() != n) {
     for (unsigned i = 0; i < n; i++) {
-      _nonbas.push_back(i);
+      nonbas_.push_back(i);
     }
   } else {
     for (unsigned i = 0; i < n; i++) {
-      if (_z0[i] > 0) {
-        _bas.push_back(i);
+      if (z0_[i] > 0) {
+        bas_.push_back(i);
       } else {
-        _nonbas.push_back(i);
+        nonbas_.push_back(i);
       }
     }
   }
 
   // determine initial values
-  _sBl = Eigen::SparseMatrix<double>(n, n);
-  if (!_bas.empty()) {
+  sBl_ = Eigen::SparseMatrix<double>(n, n);
+  if (!bas_.empty()) {
     typedef Eigen::Triplet<double> Triplet;
     std::vector<Triplet> triplet_list;
     for (int i = 0; i < M.outerSize(); i++) {
       for (Eigen::SparseMatrix<double>::InnerIterator it(M, i); it; ++it) {
         int j = it.col();
         std::vector<unsigned>::const_iterator j_it =
-            std::find(_bas.begin(), _bas.end(), j);
-        if (j_it == _bas.end()) {
+            std::find(bas_.begin(), bas_.end(), j);
+        if (j_it == bas_.end()) {
           continue;
         } else {
           triplet_list.push_back(Triplet(i, j, it.value()));
         }
       }
     }
-    for (size_t i = 0, j = _bas.size(); i < _nonbas.size(); i++, j++) {
-      triplet_list.push_back(Triplet(_nonbas[i], j, 1.0));
+    for (size_t i = 0, j = bas_.size(); i < nonbas_.size(); i++, j++) {
+      triplet_list.push_back(Triplet(nonbas_[i], j, 1.0));
     }
 
-    _sBl.setFromTriplets(triplet_list.begin(), triplet_list.end());
+    sBl_.setFromTriplets(triplet_list.begin(), triplet_list.end());
   } else {
-    _sBl.setIdentity();
-    _sBl *= -1;
+    sBl_.setIdentity();
+    sBl_ *= -1;
   }
 
   // solve B*x = -q
   std::unique_ptr<Eigen::SparseLU<Eigen::SparseMatrix<double>>> solver;
   solver.reset(new Eigen::SparseLU<Eigen::SparseMatrix<double>>);
-  solver->analyzePattern(_sBl);
-  solver->factorize(_sBl);
-  _x = solver->solve(q);
-  _x *= -1;
+  solver->analyzePattern(sBl_);
+  solver->factorize(sBl_);
+  x_ = solver->solve(q);
+  x_ *= -1;
 
   // check whether initial basis provides a solution
-  if (_x.minCoeff() >= 0.0) {
-    LOG() << " -- initial basis provides a solution!" << std::endl;
+  if (x_.minCoeff() >= 0.0) {
+      Log() << " -- initial basis provides a solution!" << std::endl;
     FinishLemkeSolution(M, q, z);
-    LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
     return true;
   }
 
   // determine initial leaving variable
   Eigen::Index min_x;
-  const double min_x_val = _x.topRows(n).minCoeff(&min_x);
+  const double min_x_val = x_.topRows(n).minCoeff(&min_x);
   double tval = -min_x_val;
-  for (size_t i = 0; i < _nonbas.size(); i++) {
-    _bas.push_back(_nonbas[i] + n);
+  for (size_t i = 0; i < nonbas_.size(); i++) {
+    bas_.push_back(nonbas_[i] + n);
   }
   lvindex = min_x;
-  iiter = _bas.begin();
+  iiter = bas_.begin();
   std::advance(iiter, lvindex);
   leaving = *iiter;
 
   // pivot in the artificial variable
   *iiter = t;  // replace w var with _z0 in basic indices
-  _u.resize(n);
+  u_.resize(n);
   for (unsigned i = 0; i < n; i++) {
-    _u[i] = (_x[i] < 0.0) ? 1.0 : 0.0;
+    u_[i] = (x_[i] < 0.0) ? 1.0 : 0.0;
   }
-  _Be = (_sBl * _u) * -1;
-  _u *= tval;
-  _x += _u;
-  _x[lvindex] = tval;
-  _sBl.col(lvindex) = makeSparseVector(_Be);
-  LOG() << "  new q: " << _x << std::endl;
+  Be_ = (sBl_ * u_) * -1;
+  u_ *= tval;
+  x_ += u_;
+  x_[lvindex] = tval;
+  sBl_.col(lvindex) = makeSparseVector(Be_);
+            Log() << "  new q: " << x_ << std::endl;
 
   // main iterations begin here
-  for (pivots = 0; pivots < MAXITER; pivots++) {
+  for (pivots_ = 0; pivots_ < MAXITER; pivots_++) {
     // check whether done; if not, get new entering variable
     if (leaving == t) {
-      LOG() << "-- solved LCP successfully!" << std::endl;
+        Log() << "-- solved LCP successfully!" << std::endl;
       FinishLemkeSolution(M, q, z);
-      LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return true;
     } else if (leaving < n) {
       entering = n + leaving;
-      _Be.resize(n);
-      _Be.fill(0);
-      _Be[leaving] = -1;
+      Be_.resize(n);
+      Be_.fill(0);
+      Be_[leaving] = -1;
     } else {
       entering = leaving - n;
-      _Be = M.col(entering);
+      Be_ = M.col(entering);
     }
     solver.reset(new Eigen::SparseLU<Eigen::SparseMatrix<double>>);
-    solver->analyzePattern(_sBl);
-    solver->factorize(_sBl);
-    _dl = solver->solve(_Be);
+    solver->analyzePattern(sBl_);
+    solver->factorize(sBl_);
+    dl_ = solver->solve(Be_);
 
     // use a new pivot tolerance if necessary
     const double PIV_TOL = (piv_tol > static_cast<double>(0.0))
                                ? piv_tol
                                : (std::numeric_limits<double>::epsilon() * n *
                                   std::max(static_cast<double>(1.0),
-                                           _Be.lpNorm<Eigen::Infinity>()));
+                                           Be_.lpNorm<Eigen::Infinity>()));
 
     // ** find new leaving variable
-    _j.clear();
-    for (unsigned i = 0; i < _dl.size(); i++) {
-      if (_dl[i] > PIV_TOL) {
-        _j.push_back(i);
+    j_.clear();
+    for (unsigned i = 0; i < dl_.size(); i++) {
+      if (dl_[i] > PIV_TOL) {
+        j_.push_back(i);
       }
     }
     // check for no new pivots; ray termination
-    if (_j.empty()) {
-      LOG()
+    if (j_.empty()) {
+        Log()
           << "MobyLCPSolver::SolveLcpLemke() - no new pivots (ray termination)"
           << std::endl;
-      LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return false;
     }
 
-    LOG() << " -- column of M': " << _dl << std::endl;
+      Log() << " -- column of M': " << dl_ << std::endl;
 
     // select elements j from x and d
-    selectSubVec(_x, _j, &_xj);
-    selectSubVec(_dl, _j, &_dj);
+    selectSubVec(x_, j_, &xj_);
+    selectSubVec(dl_, j_, &dj_);
 
     // compute minimal ratios x(j) + EPS_DOUBLE ./ d(j), d > 0
-    _result.resize(_xj.size());
-    _result.fill(zero_tol);
-    transformVecElements(_xj, &_result, std::plus<double>());
-    transformVecElements(_dj, &_result,
+    result_.resize(xj_.size());
+    result_.fill(zero_tol);
+    transformVecElements(xj_, &result_, std::plus<double>());
+    transformVecElements(dj_, &result_,
                          [](double a, double b) { return b / a; });
-    double theta = _result.minCoeff();
+    double theta = result_.minCoeff();
 
     // NOTE: lexicographic ordering does not appear to be used here to prevent
     // cycling (see [Cottle 1992], pp. 340-342)
     // find indices of minimal ratios, d> 0
     //   divide _x(j) ./ d(j) -- remove elements above the minimum ratio
-    for (int i = 0; i < _result.size(); i++) {
-      _result(i) = _xj(i) / _dj(i);
+    for (int i = 0; i < result_.size(); i++) {
+      result_(i) = xj_(i) / dj_(i);
     }
-    for (iiter = _j.begin(), idx = 0; iiter != _j.end();) {
-      if (_result[idx++] <= theta) {
+    for (iiter = j_.begin(), idx = 0; iiter != j_.end();) {
+      if (result_[idx++] <= theta) {
         iiter++;
       } else {
-        iiter = _j.erase(iiter);
+        iiter = j_.erase(iiter);
       }
     }
     // if j is empty, then likely the zero tolerance is too low
-    if (_j.empty()) {
-      LOG() << "zero tolerance too low?" << std::endl;
-      LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+    if (j_.empty()) {
+        Log() << "zero tolerance too low?" << std::endl;
+        Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
       return false;
     }
 
     // check whether artificial index among these
-    _tlist.clear();
-    for (size_t i = 0; i < _j.size(); i++) {
-      _tlist.push_back(_bas[_j[i]]);
+    tlist_.clear();
+    for (size_t i = 0; i < j_.size(); i++) {
+      tlist_.push_back(bas_[j_[i]]);
     }
-    if (std::find(_tlist.begin(), _tlist.end(), t) != _tlist.end()) {
-      iiter = std::find(_bas.begin(), _bas.end(), t);
-      lvindex = iiter - _bas.begin();
+    if (std::find(tlist_.begin(), tlist_.end(), t) != tlist_.end()) {
+      iiter = std::find(bas_.begin(), bas_.end(), t);
+      lvindex = iiter - bas_.begin();
     } else {
       // several indices pass the minimum ratio test, pick one randomly
       //      lvindex = _j[rand() % _j.size()];
 
       // NOTE: solver seems *much* more capable of solving when we pick the
       // first element rather than picking a random one
-      lvindex = _j[0];
+      lvindex = j_[0];
     }
 
     // set leaving = bas(lvindex)
-    iiter = _bas.begin();
+    iiter = bas_.begin();
     std::advance(iiter, lvindex);
     leaving = *iiter;
 
     // ** perform pivot
-    double ratio = _x[lvindex] / _dl[lvindex];
-    _dl *= ratio;
-    _x -= _dl;
-    _x[lvindex] = ratio;
-    _sBl.col(lvindex) = makeSparseVector(_Be);
+    double ratio = x_[lvindex] / dl_[lvindex];
+    dl_ *= ratio;
+    x_ -= dl_;
+    x_[lvindex] = ratio;
+    sBl_.col(lvindex) = makeSparseVector(Be_);
     *iiter = entering;
-    LOG() << " -- pivoting: leaving index=" << lvindex
+      Log() << " -- pivoting: leaving index=" << lvindex
           << "  entering index=" << entering << std::endl;
   }
 
-  LOG() << " -- maximum number of iterations exceeded" << std::endl;
-  LOG() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+            Log() << " -- maximum number of iterations exceeded" << std::endl;
+            Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
   return false;
 }
 
@@ -1218,7 +1218,7 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
     const Eigen::SparseMatrix<double>& M, const Eigen::VectorXd& q,
     Eigen::VectorXd* z, int min_exp, unsigned step_exp, int max_exp,
     double piv_tol, double zero_tol) const {
-  LOG() << "MobyLCPSolver::SolveLcpLemkeRegularized() entered" << std::endl;
+            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() entered" << std::endl;
 
   // look for fast exit
   if (q.size() == 0) {
@@ -1227,32 +1227,32 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
   }
 
   // copy MM
-  _MMs = M;
+  MMs_ = M;
 
   // assign value for zero tolerance, if necessary
   const double ZERO_TOL =
       (zero_tol > static_cast<double>(0.0)) ? zero_tol : q.size() * NEAR_ZERO;
 
   // try non-regularized version first
-  bool result = SolveLcpLemke(_MMs, q, z, piv_tol, zero_tol);
+  bool result = SolveLcpLemke(MMs_, q, z, piv_tol, zero_tol);
   if (result) {
     // verify that solution truly is a solution -- check z
     if (z->minCoeff() >= -ZERO_TOL) {
       // check w
-      _wx = (M * (*z)) + q;
-      if (_wx.minCoeff() >= -ZERO_TOL) {
+      wx_ = (M * (*z)) + q;
+      if (wx_.minCoeff() >= -ZERO_TOL) {
         // check z'w
-        transformVecElements(*z, &_wx, std::multiplies<double>());
-        const double wx_min = _wx.minCoeff();
-        const double wx_max = _wx.maxCoeff();
+        transformVecElements(*z, &wx_, std::multiplies<double>());
+        const double wx_min = wx_.minCoeff();
+        const double wx_max = wx_.maxCoeff();
         if (wx_min >= -ZERO_TOL && wx_max < ZERO_TOL) {
-          LOG() << "  solved with no regularization necessary!" << std::endl;
-          LOG() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
+            Log() << "  solved with no regularization necessary!" << std::endl;
+            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
                 << std::endl;
 
           return true;
         } else {
-          LOG() << "MobyLCPSolver::SolveLcpLemke() - "
+            Log() << "MobyLCPSolver::SolveLcpLemke() - "
                 << "'<w, z> not within tolerance(min value: " << wx_min
                 << " max value: " << wx_max << ")"
                 << " tol " << ZERO_TOL << std::endl;
@@ -1261,8 +1261,8 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
     }
   }
 
-  _eye.resize(M.rows(), M.cols());
-  _eye.setIdentity();
+  eye_.resize(M.rows(), M.cols());
+  eye_.setIdentity();
 
   // start the regularization process
   int rf = min_exp;
@@ -1270,24 +1270,24 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
     // setup regularization factor
     double lambda =
         std::pow(static_cast<double>(10.0), static_cast<double>(rf));
-    (_diag_lambda = _eye) *= lambda;
+    (diag_lambda_ = eye_) *= lambda;
 
     // regularize M
-    (_MMx = _MMs) += _diag_lambda;
+    (MMx_ = MMs_) += diag_lambda_;
 
     // try to solve the LCP
-    if ((result = SolveLcpLemke(_MMx, q, z, piv_tol, zero_tol))) {
+    if ((result = SolveLcpLemke(MMx_, q, z, piv_tol, zero_tol))) {
       // verify that solution truly is a solution -- check z
       if (z->minCoeff() > -ZERO_TOL) {
         // check w
-        _wx = (_MMx * (*z)) + q;
-        if (_wx.minCoeff() > -ZERO_TOL) {
+        wx_ = (MMx_ * (*z)) + q;
+        if (wx_.minCoeff() > -ZERO_TOL) {
           // check z'w
-          transformVecElements(*z, &_wx, std::multiplies<double>());
-          if (_wx.minCoeff() > -ZERO_TOL && _wx.maxCoeff() < ZERO_TOL) {
-            LOG() << "  solved with regularization factor: " << lambda
+          transformVecElements(*z, &wx_, std::multiplies<double>());
+          if (wx_.minCoeff() > -ZERO_TOL && wx_.maxCoeff() < ZERO_TOL) {
+              Log() << "  solved with regularization factor: " << lambda
                   << std::endl;
-            LOG() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
+              Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited"
                   << std::endl;
 
             return true;
@@ -1300,8 +1300,8 @@ bool MobyLCPSolver::SolveLcpLemkeRegularized(
     rf += step_exp;
   }
 
-  LOG() << "  unable to solve given any regularization!" << std::endl;
-  LOG() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited" << std::endl;
+            Log() << "  unable to solve given any regularization!" << std::endl;
+            Log() << "MobyLCPSolver::SolveLcpLemkeRegularized() exited" << std::endl;
 
   // still here?  failure...
   return false;

--- a/drake/solvers/MobyLCP.cpp
+++ b/drake/solvers/MobyLCP.cpp
@@ -136,7 +136,7 @@ SolutionResult MobyLCPSolver::Solve(OptimizationProblem& prog) const {
   for (size_t i = 0; i < prog.num_vars(); i++) {
     int coverings = 0;
     for (const auto& binding : bindings) {
-      if (binding.covers(i)) {
+      if (binding.Covers(i)) {
         coverings++;
       }
     }

--- a/drake/solvers/MobyLCP.h
+++ b/drake/solvers/MobyLCP.h
@@ -55,35 +55,35 @@ class DRAKEOPTIMIZATION_EXPORT MobyLCPSolver
                            Eigen::VectorXd* z) const;
 
   // TODO(sammy-tri) replace this with a proper logging hookup
-  std::ostream& LOG() const;
+  std::ostream& Log() const;
   bool log_enabled_;
   mutable std::ofstream null_stream_;
 
   // TODO(sammy-tri) why is this a member variable?
-  mutable unsigned pivots;
+  mutable unsigned pivots_;
 
   // NOTE:  The temporaries below are stored in the class to minimize
   // allocations; all are marked 'mutable' as they do not affect the
   // semantic const'ness of the class under its methods.
 
   // temporaries for regularized solver
-  mutable Eigen::MatrixXd _MM;
-  mutable Eigen::VectorXd _wx;
+  mutable Eigen::MatrixXd MM_;
+  mutable Eigen::VectorXd wx_;
 
   // temporaries for fast pivoting solver
-  mutable Eigen::VectorXd _z, _w, _qbas, _qprime;
-  mutable Eigen::MatrixXd _Msub, _Mmix, _M;
+  mutable Eigen::VectorXd z_, w_, qbas_;
+  mutable Eigen::MatrixXd Msub_, Mmix_;
 
   // temporaries for Lemke solver
-  mutable Eigen::VectorXd _d, _Be, _u, _z0, _x, _dl, _xj, _dj, _wl, _result;
-  mutable Eigen::MatrixXd _Bl, _Al, _t1, _t2;
+  mutable Eigen::VectorXd d_, Be_, u_, z0_, x_, dl_, xj_, dj_, wl_, result_;
+  mutable Eigen::MatrixXd Bl_, Al_, t1_, t2_;
 
   // Vectors which correspond to indices into other data.
-  mutable std::vector<unsigned> _all, _tlist, _bas, _nonbas, _j;
+  mutable std::vector<unsigned> all_, tlist_, bas_, nonbas_, j_;
 
   // temporary for sparse Lemke solver
-  mutable Eigen::SparseMatrix<double> _sBl;
-  mutable Eigen::SparseMatrix<double> _MMs, _MMx, _eye, _zero, _diag_lambda;
+  mutable Eigen::SparseMatrix<double> sBl_;
+  mutable Eigen::SparseMatrix<double> MMs_, MMx_, eye_, diag_lambda_;
 };
 
 }  // end namespace solvers

--- a/drake/solvers/MosekWrapper.h
+++ b/drake/solvers/MosekWrapper.h
@@ -79,7 +79,7 @@ class DRAKEOPTIMIZATION_EXPORT MosekWrapper {
    * to ensure ease of translation and understanding.
    */
 
-   /** Adds linear constraints to mosek environment. */
+  /** Adds linear constraints to mosek environment. */
   void AddLinearConstraintMatrix(const Eigen::MatrixXd& cons_);
 
   /** Adds linear constraints in sparse column matrix form.

--- a/drake/solvers/MosekWrapper.h
+++ b/drake/solvers/MosekWrapper.h
@@ -15,27 +15,27 @@ extern "C" {
 #include "drake/solvers/Optimization.h"
 #include "drake/solvers/MathematicalProgram.h"
 
-/**Definitions and program flow taken from
-http://docs.mosek.com/7.1/capi/Linear_optimization.html
+/** Definitions and program flow taken from
+`http://docs.mosek.com/7.1/capi/Linear_optimization.html`_
 
 For further definition of terms, see
-http://docs.mosek.com/7.1/capi/Conventions_employed_in_the_API.html
+`http://docs.mosek.com/7.1/capi/Conventions_employed_in_the_API.html`_
 */
 namespace drake {
 namespace solvers {
 
-/** MosekWrapper solves a linear program when given a correctly formatted program.
- *  Specifically, the program options:
- *  -- "maxormin" -- must be set to "max" or "min"
- *  -- "problemtype" -- must be set to "linear" or "quadratic"
+/**
+ * This class allows the creation and solution of a linear programming
+ * problem using the mosek solver.
+ *
+ * MosekLP solves a linear program when given a correctly formatted program.
+ * Specifically, the program options:
+ *  * "maxormin" -- must be set to "max" or "min"
+ *  * "problemtype" -- must be set to "linear" or "quadratic"
  *
  *  It is created by a MosekSolver object.
  */
 class DRAKEOPTIMIZATION_EXPORT MosekWrapper {
-  /** MosekWrapper
-   *  @brief this class allows the creation and solution of a linear programming
-   *  problem using the mosek solver.
-   */
  public:
   /** Create a mosek linear programming environment using a constraint matrix
   * Takes the number of variables and constraints, the linear eqn to
@@ -62,65 +62,54 @@ class DRAKEOPTIMIZATION_EXPORT MosekWrapper {
       MSK_deleteenv(&env_);
   }
 
-
-    /** Solve()
-   * @brief optimizes variables in given linear constraints, works with either
+  /** Optimizes variables in given linear constraints, works with either
    * of the two previous object declarations.
-   * */
+   */
   static SolutionResult Solve(OptimizationProblem &prog);
 
-  std::vector<double>  GetSolution() const { return solutions_; }
+  std::vector<double> GetSolution() const { return solutions_; }
 
   Eigen::VectorXd GetEigenVectorSolutions() const;
 
  private:
-  /**The following names are consistent with the example programs given by
-   *http://docs.mosek.com/7.1/capi/Linear_optimization.html
-   *and by
-   *http://docs.mosek.com/7.1/capi/Conventions_employed_in_the_API.html
-   *to ensure ease of translation and understanding.
+  /** The following names are consistent with the example programs given by
+   * http://docs.mosek.com/7.1/capi/Linear_optimization.html
+   * and by
+   * http://docs.mosek.com/7.1/capi/Conventions_employed_in_the_API.html
+   * to ensure ease of translation and understanding.
    */
 
-   /**AddLinearConstraintMatrix()
-   *@brief adds linear constraints to mosek environment
-   */
+   /** Adds linear constraints to mosek environment. */
   void AddLinearConstraintMatrix(const Eigen::MatrixXd& cons_);
 
-  /**addLinearConstraintSparseColumnMatrix()
-  *@brief adds linear constraints in sparse column matrix form
-  *just uses Eigen's sparse matrix library to implement expected format
-  */
+  /** Adds linear constraints in sparse column matrix form.
+   * Just uses Eigen's sparse matrix library to implement expected format.
+   */
   void AddLinearConstraintSparseColumnMatrix(
     const Eigen::SparseMatrix<double>& sparsecons_);
 
-  /**AddLinearConstraintBounds()
-  *@brief bounds constraints, see http://docs.mosek.com/7.1/capi/Conventions_employed_in_the_API.html
-  *for details on how to set mosek_bounds_
-  */
+  /** Bounds constraints, see:
+   * `http://docs.mosek.com/7.1/capi/Conventions_employed_in_the_API.html`_
+   * for details on how to set mosek_bounds_
+   */
   void AddLinearConstraintBounds(const std::vector<MSKboundkeye>& mosek_bounds_,
       const std::vector<double>& upper_bounds,
       const std::vector<double>& lower_bounds);
 
-  /**AddQuadraticConstraintMatrix
-  * @brief adds a single quadratic matrix to mosek constraint.
-  */
+  /** Add a single quadratic matrix to a mosek constraint. */
   void AddQuadraticConstraintMatrix(const Eigen::MatrixXd& cons);
 
-  /**AddQuadraticConstraintMatrix
-  * @brief adds a single quadratic matrix to mosek objective.
-  */
+  /** Adds a single quadratic matrix to a mosek objective. */
   void AddQuadraticObjective(const Eigen::MatrixXd& obj);
 
-  /**AddVariableBounds()
-   * @brief bounds variables, see http://docs.mosek.com/7.1/capi/Conventions_employed_in_the_API.html
+  /** Bounds variables, see http://docs.mosek.com/7.1/capi/Conventions_employed_in_the_API.html
    * for details on how to set mosek_bounds_
    */
   void AddVariableBounds(const std::vector<MSKboundkeye>& mosek_bounds,
                          const std::vector<double>& upper_bounds,
                          const std::vector<double>& lower_bounds);
 
-  /**FindMosekBounds()
-   * Given upper and lower bounds for a variable or constraint, finds the
+  /** Given upper and lower bounds for a variable or constraint, finds the
    * equivalent Mosek bound keys.
    */
   static std::vector<MSKboundkeye> FindMosekBounds(
@@ -131,11 +120,11 @@ class DRAKEOPTIMIZATION_EXPORT MosekWrapper {
                               const std::string& ptype);
 
   MSKint32t numvar_, numcon_;
-  MSKenv_t env_;       // Internal environment, used to check if problem formed
-                      // correctly
-  MSKtask_t task_;     // internal definition of task
-  MSKrescodee r_;      // used for validity checking
-  std::vector<double> solutions_;  // Contains the solutions of the system
+  MSKenv_t env_;       //< Internal environment, used to check if the problem
+                       // is well-formed.
+  MSKtask_t task_;     //< internal definition of task
+  MSKrescodee r_;      //< used for validity checking
+  std::vector<double> solutions_;  //< Contains the solutions of the system
 };
 
 }  // namespace solvers

--- a/drake/solvers/MosekWrapper.h
+++ b/drake/solvers/MosekWrapper.h
@@ -28,8 +28,8 @@ namespace solvers {
  * This class allows the creation and solution of a linear programming
  * problem using the mosek solver.
  *
- * MosekLP solves a linear program when given a correctly formatted program.
- * Specifically, the program options:
+ * MosekWrapper solves a linear program when given a correctly formatted
+ * program.  Specifically, the program options:
  *  * "maxormin" -- must be set to "max" or "min"
  *  * "problemtype" -- must be set to "linear" or "quadratic"
  *

--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -71,7 +71,7 @@ double EvaluateCosts(const std::vector<double>& x,
       index += v.size();
     }
 
-      binding.constraint()->Eval(this_x, ty);
+    binding.constraint()->Eval(this_x, ty);
 
     cost += ty(0).value();
     if (!grad.empty()) {
@@ -171,7 +171,7 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
 
   TaylorVecXd ty(num_constraints);
   TaylorVecXd this_x = MakeInputTaylorVec(xvec, *(wrapped->variable_list));
-        c->Eval(this_x, ty);
+  c->Eval(this_x, ty);
 
   const Eigen::VectorXd& lower_bound = c->lower_bound();
   const Eigen::VectorXd& upper_bound = c->upper_bound();

--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -71,7 +71,7 @@ double EvaluateCosts(const std::vector<double>& x,
       index += v.size();
     }
 
-    binding.constraint()->eval(this_x, ty);
+      binding.constraint()->Eval(this_x, ty);
 
     cost += ty(0).value();
     if (!grad.empty()) {
@@ -171,7 +171,7 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
 
   TaylorVecXd ty(num_constraints);
   TaylorVecXd this_x = MakeInputTaylorVec(xvec, *(wrapped->variable_list));
-  c->eval(this_x, ty);
+        c->Eval(this_x, ty);
 
   const Eigen::VectorXd& lower_bound = c->lower_bound();
   const Eigen::VectorXd& upper_bound = c->upper_bound();

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -502,7 +502,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     // TODO(ggould-tri) There may be other such special easy cases.
     bool all_affine = true;
     for (int i = 0; i < polynomials.rows(); i++) {
-      if (!polynomials[i].isAffine()) {
+      if (!polynomials[i].IsAffine()) {
         all_affine = false;
         break;
       }
@@ -513,7 +513,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       Eigen::VectorXd linear_constraint_lb = lb;
       Eigen::VectorXd linear_constraint_ub = ub;
       for (int poly_num = 0; poly_num < polynomials.rows(); poly_num++) {
-        for (const auto& monomial : polynomials[poly_num].getMonomials()) {
+        for (const auto& monomial : polynomials[poly_num].GetMonomials()) {
           if (monomial.terms.size() == 0) {
             linear_constraint_lb[poly_num] -= monomial.coefficient;
             linear_constraint_ub[poly_num] -= monomial.coefficient;

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -49,7 +49,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     /** covers()
      * @brief returns true iff the given @p index of the enclosing
      * OptimizationProblem is included in this Binding.*/
-    bool covers(size_t index) const {
+    bool Covers(size_t index) const {
       for (auto view : variable_list_) {
         if (view.covers(index)) {
           return true;
@@ -104,8 +104,8 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
                      std::forward<Args>(args)...),
           f_(std::forward<F>(f)) {}
 
-    void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-              Eigen::VectorXd& y) const override {
+    void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+              Eigen::VectorXd &y) const override {
       y.resize(Drake::FunctionTraits<F>::numOutputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
                    Drake::FunctionTraits<F>::numInputs(f_));
@@ -113,8 +113,8 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
                    Drake::FunctionTraits<F>::numOutputs(f_));
       Drake::FunctionTraits<F>::eval(f_, x, y);
     }
-    void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-              Drake::TaylorVecXd& y) const override {
+    void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+              Drake::TaylorVecXd &y) const override {
       y.resize(Drake::FunctionTraits<F>::numOutputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
                    Drake::FunctionTraits<F>::numInputs(f_));

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -104,8 +104,8 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
                      std::forward<Args>(args)...),
           f_(std::forward<F>(f)) {}
 
-    void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-              Eigen::VectorXd &y) const override {
+    void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd& y) const override {
       y.resize(Drake::FunctionTraits<F>::numOutputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
                    Drake::FunctionTraits<F>::numInputs(f_));
@@ -113,8 +113,8 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
                    Drake::FunctionTraits<F>::numOutputs(f_));
       Drake::FunctionTraits<F>::eval(f_, x, y);
     }
-    void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-              Drake::TaylorVecXd &y) const override {
+    void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+              Drake::TaylorVecXd& y) const override {
       y.resize(Drake::FunctionTraits<F>::numOutputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
                    Drake::FunctionTraits<F>::numInputs(f_));

--- a/drake/solvers/SnoptSolver.cpp
+++ b/drake/solvers/SnoptSolver.cpp
@@ -201,7 +201,7 @@ int snopt_userfun(snopt::integer* Status, snopt::integer* n,
       this_x.segment(index, v.size()) = tx.segment(v.index(), v.size());
       index += v.size();
     }
-    obj->eval(this_x, ty);
+    obj->Eval(this_x, ty);
 
     F[0] += static_cast<snopt::doublereal>(ty(0).value());
 
@@ -228,7 +228,7 @@ int snopt_userfun(snopt::integer* Status, snopt::integer* n,
     }
 
     ty.resize(num_constraints);
-    c->eval(this_x, ty);
+    c->Eval(this_x, ty);
 
     for (i = 0; i < static_cast<snopt::integer>(num_constraints); i++) {
       F[constraint_index++] = static_cast<snopt::doublereal>(ty(i).value());

--- a/drake/solvers/qpSpline/nWaypointCubicSplineFreeKnotTimesmex.cpp
+++ b/drake/solvers/qpSpline/nWaypointCubicSplineFreeKnotTimesmex.cpp
@@ -128,8 +128,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
                         num_coeffs_per_segment - coefficient_index -
                             1};  // Matlab's reverse coefficient indexing...
         *(mxGetPr(plhs[0]) + sub2ind(3, dims, sub)) =
-                spline.getPolynomial(static_cast<int>(segment_index))
-                        .GetCoefficients()[coefficient_index];
+            spline.getPolynomial(static_cast<int>(segment_index))
+                .GetCoefficients()[coefficient_index];
       }
     }
   }

--- a/drake/solvers/qpSpline/nWaypointCubicSplineFreeKnotTimesmex.cpp
+++ b/drake/solvers/qpSpline/nWaypointCubicSplineFreeKnotTimesmex.cpp
@@ -128,8 +128,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
                         num_coeffs_per_segment - coefficient_index -
                             1};  // Matlab's reverse coefficient indexing...
         *(mxGetPr(plhs[0]) + sub2ind(3, dims, sub)) =
-            spline.getPolynomial(static_cast<int>(segment_index))
-                .getCoefficients()[coefficient_index];
+                spline.getPolynomial(static_cast<int>(segment_index))
+                        .GetCoefficients()[coefficient_index];
       }
     }
   }

--- a/drake/solvers/qpSpline/nWaypointCubicSplinemex.cpp
+++ b/drake/solvers/qpSpline/nWaypointCubicSplinemex.cpp
@@ -53,8 +53,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
                         num_coeffs_per_segment - coefficient_index -
                             1};  // Matlab's reverse coefficient indexing...
         *(mxGetPr(plhs[0]) + sub2ind(3, dims, sub)) =
-            spline.getPolynomial(static_cast<int>(segment_index))
-                .getCoefficients()[coefficient_index];
+                spline.getPolynomial(static_cast<int>(segment_index))
+                        .GetCoefficients()[coefficient_index];
       }
     }
   }

--- a/drake/solvers/qpSpline/nWaypointCubicSplinemex.cpp
+++ b/drake/solvers/qpSpline/nWaypointCubicSplinemex.cpp
@@ -53,8 +53,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
                         num_coeffs_per_segment - coefficient_index -
                             1};  // Matlab's reverse coefficient indexing...
         *(mxGetPr(plhs[0]) + sub2ind(3, dims, sub)) =
-                spline.getPolynomial(static_cast<int>(segment_index))
-                        .GetCoefficients()[coefficient_index];
+            spline.getPolynomial(static_cast<int>(segment_index))
+                .GetCoefficients()[coefficient_index];
       }
     }
   }

--- a/drake/solvers/system_identification.cpp
+++ b/drake/solvers/system_identification.cpp
@@ -200,7 +200,7 @@ SystemIdentification<T>::RewritePolynomialWithLumpedParameters(
         // by the active vars monomial and add the resulting monomial of
         // parameters to our factor list.
         factor_monomials.push_back(
-                working_monomial.Factor(active_var_monomial));
+            working_monomial.Factor(active_var_monomial));
       } else {
         // This monomial does not match our active vars monomial; copy it
         // unchanged.
@@ -434,7 +434,7 @@ SystemIdentification<T>::LumpedSystemIdentification(
   result.partially_evaluated_polys.resize(trigpolys.rows());
   for (int i = 0; i < trigpolys.rows(); i++) {
     result.partially_evaluated_polys[i] =
-            result.lumped_polys[i].EvaluatePartial(result.lumped_parameter_values);
+        result.lumped_polys[i].EvaluatePartial(result.lumped_parameter_values);
     debug << "Estimated polynomial: "
           << result.partially_evaluated_polys[i] << std::endl;
   }

--- a/drake/solvers/system_identification.cpp
+++ b/drake/solvers/system_identification.cpp
@@ -349,8 +349,8 @@ SystemIdentification<T>::LumpedSystemIdentification(
   for (int i = 0; i < trigpolys.rows(); i++) {
     const TrigPolyd& trigpoly = trigpolys[i];
     debug << "polynomial for ID: " << trigpoly << std::endl;
-    polys.push_back(trigpoly.getPolynomial());
-    for (const auto& k_v_pair : trigpoly.getSinCosMap()) {
+    polys.push_back(trigpoly.poly());
+    for (const auto& k_v_pair : trigpoly.sin_cos_map()) {
       if (original_sin_cos_map.count(k_v_pair.first)) {
         // Make sure that different TrigPolys don't have inconsistent
         // sin_cos_maps (eg, `s = sin(x)` vs. `s = cos(y)`).  Note that
@@ -419,7 +419,7 @@ SystemIdentification<T>::LumpedSystemIdentification(
   // Estimate the lumped parameters.
   VectorXPoly polys_as_eigen(polys.size());
   for (size_t i = 0; i < polys.size(); i++) {
-    polys_as_eigen[i] = result.lumped_polys[i].getPolynomial();
+    polys_as_eigen[i] = result.lumped_polys[i].poly();
   }
   std::tie(result.lumped_parameter_values, result.rms_error) =
       EstimateParameters(polys_as_eigen, augmented_values);
@@ -434,7 +434,7 @@ SystemIdentification<T>::LumpedSystemIdentification(
   result.partially_evaluated_polys.resize(trigpolys.rows());
   for (int i = 0; i < trigpolys.rows(); i++) {
     result.partially_evaluated_polys[i] =
-        result.lumped_polys[i].evaluatePartial(result.lumped_parameter_values);
+            result.lumped_polys[i].EvaluatePartial(result.lumped_parameter_values);
     debug << "Estimated polynomial: "
           << result.partially_evaluated_polys[i] << std::endl;
   }

--- a/drake/solvers/system_identification.cpp
+++ b/drake/solvers/system_identification.cpp
@@ -17,7 +17,7 @@ SystemIdentification<T>::GetAllCombinationsOfVars(
     const std::set<VarType>& vars) {
   std::set<MonomialType> result_monomials;
   for (const PolyType& poly : polys) {
-    for (const MonomialType& monomial : poly.getMonomials()) {
+    for (const MonomialType& monomial : poly.GetMonomials()) {
       MonomialType monomial_of_vars;
       monomial_of_vars.coefficient = 1;
       // For each term in the monomial, iff that term's variable is in
@@ -42,12 +42,12 @@ bool SystemIdentification<T>::MonomialMatches(
   // which case return false) or a residue monomial (the parts of haystack not
   // in needle).  If the resuidue contains an active variable, return false.
   // Otherwise we meet the criteria and return true.
-  const MonomialType residue = haystack.factor(needle);
+  const MonomialType residue = haystack.Factor(needle);
   if (residue.coefficient == 0) {
     return false;
   }
   for (const VarType& var : active_vars) {
-    if (residue.getDegreeOf(var) > 0) {
+    if (residue.GetDegreeOf(var) > 0) {
       return false;
     }
   }
@@ -57,7 +57,7 @@ bool SystemIdentification<T>::MonomialMatches(
 template<typename T>
 std::pair<T, typename SystemIdentification<T>::PolyType>
 SystemIdentification<T>::CanonicalizePolynomial(const PolyType& poly) {
-  std::vector<MonomialType> monomials = poly.getMonomials();
+  std::vector<MonomialType> monomials = poly.GetMonomials();
   const T min_coefficient = std::min_element(
       monomials.begin(), monomials.end(),
       [&](const MonomialType& l, const MonomialType& r){
@@ -90,7 +90,7 @@ SystemIdentification<T>::GetLumpedParametersFromPolynomials(
   // variables..
   std::set<VarType> all_vars;
   for (const PolyType& poly : polys) {
-    const auto& poly_vars = poly.getVariables();
+    const auto& poly_vars = poly.GetVariables();
     all_vars.insert(poly_vars.begin(), poly_vars.end());
   }
   std::set<VarType> active_vars = all_vars;
@@ -108,14 +108,14 @@ SystemIdentification<T>::GetLumpedParametersFromPolynomials(
   for (const MonomialType& active_var_monomial : active_var_monomials) {
     for (const PolyType& poly : polys) {
       std::vector<MonomialType> lumped_parameter;
-      for (const MonomialType& monomial : poly.getMonomials()) {
+      for (const MonomialType& monomial : poly.GetMonomials()) {
         // NOTE: This may be a performance hotspot if this method is called in
         // a tight loop, due to the nested for loops here and in
         // MonomialMatches and its callees.  If so it can be sped up via loop
         // reordering and intermediate maps at some cost to readability.
         if (MonomialMatches(monomial, active_var_monomial, active_vars)) {
-          const MonomialType& candidate = monomial.factor(active_var_monomial);
-          if (candidate.getDegree() > 0) {  // Don't create lumped constants!
+          const MonomialType& candidate = monomial.Factor(active_var_monomial);
+          if (candidate.GetDegree() > 0) {  // Don't create lumped constants!
             lumped_parameter.push_back(candidate);
           }
         }
@@ -150,7 +150,7 @@ SystemIdentification<T>::CreateUnusedVar(
     const std::set<VarType>& vars_in_use) {
   int lump_index = 1;
   while (true) {
-    VarType lump_var = PolyType(prefix, lump_index).getSimpleVariable();
+    VarType lump_var = PolyType(prefix, lump_index).GetSimpleVariable();
     lump_index++;
     if (!vars_in_use.count(lump_var)) {
       return lump_var;
@@ -166,9 +166,9 @@ SystemIdentification<T>::RewritePolynomialWithLumpedParameters(
     const LumpingMapType& lumped_parameters) {
   // Reconstruct active_vars, the variables in poly that are not
   // mentioned by the lumped_parameters.
-  std::set<VarType> active_vars = poly.getVariables();
+  std::set<VarType> active_vars = poly.GetVariables();
   for (const auto& lump_name_pair : lumped_parameters) {
-    std::set<VarType> parameters_in_lump = lump_name_pair.first.getVariables();
+    std::set<VarType> parameters_in_lump = lump_name_pair.first.GetVariables();
     for (const VarType& var : parameters_in_lump) {
       active_vars.erase(var);
     }
@@ -180,7 +180,7 @@ SystemIdentification<T>::RewritePolynomialWithLumpedParameters(
   // lumped variable times the combination instead.
   std::set<MonomialType> active_var_monomials =
       GetAllCombinationsOfVars({poly}, active_vars);
-  std::vector<MonomialType> working_monomials = poly.getMonomials();
+  std::vector<MonomialType> working_monomials = poly.GetMonomials();
   for (const MonomialType& active_var_monomial : active_var_monomials) {
     // Because we must iterate over working_monomials, we cannot alter it in
     // place.  Instead we build up two lists in parallel: The updated value of
@@ -200,7 +200,7 @@ SystemIdentification<T>::RewritePolynomialWithLumpedParameters(
         // by the active vars monomial and add the resulting monomial of
         // parameters to our factor list.
         factor_monomials.push_back(
-            working_monomial.factor(active_var_monomial));
+                working_monomial.Factor(active_var_monomial));
       } else {
         // This monomial does not match our active vars monomial; copy it
         // unchanged.
@@ -292,7 +292,7 @@ SystemIdentification<T>::EstimateParameters(
     VectorXPoly constraint_polys(polys.rows(), 1);
     const PartialEvalType& partial_eval_map = active_var_values[datum_num];
     for (int poly_num = 0; poly_num < polys.rows(); poly_num++) {
-      PolyType partial_poly = polys[poly_num].evaluatePartial(partial_eval_map);
+      PolyType partial_poly = polys[poly_num].EvaluatePartial(partial_eval_map);
       PolyType constraint_poly =
           partial_poly + PolyType(1, error_vartypes[datum_num * polys.rows() +
                                                     poly_num]);
@@ -378,7 +378,7 @@ SystemIdentification<T>::LumpedSystemIdentification(
   }
   debug << "Params to estimate: ";
   for (const auto& pv : parameter_vars) {
-    debug << Polynomiald::idToVariableName(pv) << " ";
+    debug << Polynomiald::IdToVariableName(pv) << " ";
   }
   debug << std::endl;
 
@@ -387,7 +387,7 @@ SystemIdentification<T>::LumpedSystemIdentification(
       polys, parameter_vars);
   for (const auto& k_v_pair : result.lumped_parameters) {
     debug << "Lumped parameter: "
-          << Polynomiald::idToVariableName(k_v_pair.second) << " == "
+          << Polynomiald::IdToVariableName(k_v_pair.second) << " == "
           << k_v_pair.first << std::endl;
   }
 
@@ -425,7 +425,7 @@ SystemIdentification<T>::LumpedSystemIdentification(
       EstimateParameters(polys_as_eigen, augmented_values);
   for (const auto& k_v_pair : result.lumped_parameter_values) {
     debug << "Parameter estimate: "
-          << Polynomiald::idToVariableName(k_v_pair.first) << " ~= "
+          << Polynomiald::IdToVariableName(k_v_pair.first) << " ~= "
           << k_v_pair.second << std::endl;
   }
   debug << "Estimation error: " << result.rms_error << std::endl;
@@ -453,7 +453,7 @@ std::tuple<const std::set<typename SystemIdentification<T>::VarType>,
         const std::vector<PartialEvalType>& active_var_values) {
   std::set<VarType> all_vars;
   for (const auto& poly : polys) {
-    const std::set<VarType> poly_vars = poly.getVariables();
+    const std::set<VarType> poly_vars = poly.GetVariables();
     all_vars.insert(poly_vars.begin(), poly_vars.end());
   }
 

--- a/drake/solvers/test/system_identification_test.cpp
+++ b/drake/solvers/test/system_identification_test.cpp
@@ -403,17 +403,17 @@ GTEST_TEST(SystemIdentificationTest, PENDULA_TEST_NAME) {
 
   // Create convenience variables for our q/qdot/u values.  Convenience vars
   // have an underscore prefix for slightly easier understandability.
-  const TrigPolyd::VarType th1_var = theta1.getPolynomial().GetSimpleVariable();
-  const TrigPolyd::VarType th2_var = theta2.getPolynomial().GetSimpleVariable();
+  const TrigPolyd::VarType th1_var = theta1.poly().GetSimpleVariable();
+  const TrigPolyd::VarType th2_var = theta2.poly().GetSimpleVariable();
   const TrigPolyd::VarType th1d_var =
-          theta1dot.getPolynomial().GetSimpleVariable();
+          theta1dot.poly().GetSimpleVariable();
   const TrigPolyd::VarType th2d_var =
-          theta2dot.getPolynomial().GetSimpleVariable();
+          theta2dot.poly().GetSimpleVariable();
   const TrigPolyd::VarType th1dd_var =
-          theta1dotdot.getPolynomial().GetSimpleVariable();
+          theta1dotdot.poly().GetSimpleVariable();
   const TrigPolyd::VarType th2dd_var =
-          theta2dotdot.getPolynomial().GetSimpleVariable();
-  const TrigPolyd::VarType tau_var = tau.getPolynomial().GetSimpleVariable();
+          theta2dotdot.poly().GetSimpleVariable();
+  const TrigPolyd::VarType tau_var = tau.poly().GetSimpleVariable();
 
   const double kG = 9.8;
   const double kPi = 3.14159265;
@@ -457,10 +457,10 @@ GTEST_TEST(SystemIdentificationTest, PENDULA_TEST_NAME) {
       (result.lumped_parameters.size() * result.lumped_parameters.size());
 
   // Check result.lumped_parameters.
-  Polynomiald mgl1 = (m1 * gravity * l1).getPolynomial();
-  Polynomiald mgl2 = (m2 * gravity * l2).getPolynomial();
-  Polynomiald mll1 = (m1 * l1 * l1).getPolynomial();
-  Polynomiald mll2 = (m2 * l2 * l2).getPolynomial();
+  Polynomiald mgl1 = (m1 * gravity * l1).poly();
+  Polynomiald mgl2 = (m2 * gravity * l2).poly();
+  Polynomiald mll1 = (m1 * l1 * l1).poly();
+  Polynomiald mll2 = (m2 * l2 * l2).poly();
   EXPECT_EQ(result.lumped_parameters.size(), static_cast<size_t>(4));
   Polynomiald::VarType mgl1_var = result.lumped_parameters.at(mgl1);
   Polynomiald::VarType mgl2_var = result.lumped_parameters.at(mgl2);
@@ -470,10 +470,10 @@ GTEST_TEST(SystemIdentificationTest, PENDULA_TEST_NAME) {
   // Check result.lumped_polys.
   std::set<Polynomiald::VarType> expected_vars_1 = {
     mgl1_var, mll1_var, th1_var, th1dd_var, tau_var};
-  EXPECT_EQ(result.lumped_polys[0].getVariables(), expected_vars_1);
+  EXPECT_EQ(result.lumped_polys[0].GetVariables(), expected_vars_1);
   std::set<Polynomiald::VarType> expected_vars_2 = {
     mgl2_var, mll2_var, th2_var, th2dd_var, tau_var};
-  EXPECT_EQ(result.lumped_polys[1].getVariables(), expected_vars_2);
+  EXPECT_EQ(result.lumped_polys[1].GetVariables(), expected_vars_2);
 
   // Check result.lumped_parameter_values
   EXPECT_NEAR(result.lumped_parameter_values[mgl1_var], kG, max_per_term_error);

--- a/drake/solvers/test/system_identification_test.cpp
+++ b/drake/solvers/test/system_identification_test.cpp
@@ -26,7 +26,7 @@ GTEST_TEST(SystemIdentificationTest, LumpedSingle) {
   Polynomiald input = (a * x) + (b * x) + (a * c * y) + (a * c * y * y);
 
   std::set<Polynomiald::VarType> parameters = {
-          a.GetSimpleVariable(),
+    a.GetSimpleVariable(),
     b.GetSimpleVariable(),
     c.GetSimpleVariable()};
   SID::LumpingMapType lump_map =
@@ -50,7 +50,7 @@ GTEST_TEST(SystemIdentificationTest, LumpedMulti) {
     a};
 
   std::set<Polynomiald::VarType> parameters = {
-          a.GetSimpleVariable(),
+    a.GetSimpleVariable(),
     b.GetSimpleVariable(),
     c.GetSimpleVariable()};
   SID::LumpingMapType lump_map =
@@ -87,7 +87,7 @@ GTEST_TEST(SystemIdentificationTest, LumpedParameterRewrite) {
     a};
 
   std::set<Polynomiald::VarType> parameters = {
-          a.GetSimpleVariable(),
+    a.GetSimpleVariable(),
     b.GetSimpleVariable(),
     c.GetSimpleVariable()};
   SID::LumpingMapType lump_map =
@@ -107,7 +107,7 @@ GTEST_TEST(SystemIdentificationTest, LumpedParameterRewrite) {
   // rewritten polynomial).
   for (const auto& poly_var_pair : lump_map) {
     eval_point[poly_var_pair.second] =
-            poly_var_pair.first.EvaluateMultivariate(eval_point);
+        poly_var_pair.first.EvaluateMultivariate(eval_point);
   }
 
   for (const Polynomiald& poly : input) {
@@ -406,13 +406,13 @@ GTEST_TEST(SystemIdentificationTest, PENDULA_TEST_NAME) {
   const TrigPolyd::VarType th1_var = theta1.poly().GetSimpleVariable();
   const TrigPolyd::VarType th2_var = theta2.poly().GetSimpleVariable();
   const TrigPolyd::VarType th1d_var =
-          theta1dot.poly().GetSimpleVariable();
+      theta1dot.poly().GetSimpleVariable();
   const TrigPolyd::VarType th2d_var =
-          theta2dot.poly().GetSimpleVariable();
+      theta2dot.poly().GetSimpleVariable();
   const TrigPolyd::VarType th1dd_var =
-          theta1dotdot.poly().GetSimpleVariable();
+      theta1dotdot.poly().GetSimpleVariable();
   const TrigPolyd::VarType th2dd_var =
-          theta2dotdot.poly().GetSimpleVariable();
+      theta2dotdot.poly().GetSimpleVariable();
   const TrigPolyd::VarType tau_var = tau.poly().GetSimpleVariable();
 
   const double kG = 9.8;

--- a/drake/solvers/test/system_identification_test.cpp
+++ b/drake/solvers/test/system_identification_test.cpp
@@ -26,9 +26,9 @@ GTEST_TEST(SystemIdentificationTest, LumpedSingle) {
   Polynomiald input = (a * x) + (b * x) + (a * c * y) + (a * c * y * y);
 
   std::set<Polynomiald::VarType> parameters = {
-    a.getSimpleVariable(),
-    b.getSimpleVariable(),
-    c.getSimpleVariable()};
+          a.GetSimpleVariable(),
+    b.GetSimpleVariable(),
+    c.GetSimpleVariable()};
   SID::LumpingMapType lump_map =
       SID::GetLumpedParametersFromPolynomial(input, parameters);
   EXPECT_EQ(lump_map.size(), 2u);
@@ -50,9 +50,9 @@ GTEST_TEST(SystemIdentificationTest, LumpedMulti) {
     a};
 
   std::set<Polynomiald::VarType> parameters = {
-    a.getSimpleVariable(),
-    b.getSimpleVariable(),
-    c.getSimpleVariable()};
+          a.GetSimpleVariable(),
+    b.GetSimpleVariable(),
+    c.GetSimpleVariable()};
   SID::LumpingMapType lump_map =
       SID::GetLumpedParametersFromPolynomials(input, parameters);
 
@@ -87,19 +87,19 @@ GTEST_TEST(SystemIdentificationTest, LumpedParameterRewrite) {
     a};
 
   std::set<Polynomiald::VarType> parameters = {
-    a.getSimpleVariable(),
-    b.getSimpleVariable(),
-    c.getSimpleVariable()};
+          a.GetSimpleVariable(),
+    b.GetSimpleVariable(),
+    c.GetSimpleVariable()};
   SID::LumpingMapType lump_map =
       SID::GetLumpedParametersFromPolynomials(input, parameters);
 
   // A point for testing numeric stability.
   std::map<Polynomiald::VarType, double> eval_point = {
-    {x.getSimpleVariable(), 1},
-    {y.getSimpleVariable(), 2},
-    {a.getSimpleVariable(), 3},
-    {b.getSimpleVariable(), 5},
-    {c.getSimpleVariable(), 7},
+    {x.GetSimpleVariable(), 1},
+    {y.GetSimpleVariable(), 2},
+    {a.GetSimpleVariable(), 3},
+    {b.GetSimpleVariable(), 5},
+    {c.GetSimpleVariable(), 7},
   };
   // Compute the value of each lumped parameter at eval_point; store those
   // values into the eval_point (so that now it provides both lumped and
@@ -107,7 +107,7 @@ GTEST_TEST(SystemIdentificationTest, LumpedParameterRewrite) {
   // rewritten polynomial).
   for (const auto& poly_var_pair : lump_map) {
     eval_point[poly_var_pair.second] =
-        poly_var_pair.first.evaluateMultivariate(eval_point);
+            poly_var_pair.first.EvaluateMultivariate(eval_point);
   }
 
   for (const Polynomiald& poly : input) {
@@ -115,22 +115,22 @@ GTEST_TEST(SystemIdentificationTest, LumpedParameterRewrite) {
         SID::RewritePolynomialWithLumpedParameters(poly, lump_map);
 
     // No non-lumped parameters should remain in rewritten.
-    EXPECT_EQ(rewritten.getVariables().count(a.getSimpleVariable()), 0u);
-    EXPECT_EQ(rewritten.getVariables().count(b.getSimpleVariable()), 0u);
-    EXPECT_EQ(rewritten.getVariables().count(c.getSimpleVariable()), 0u);
+    EXPECT_EQ(rewritten.GetVariables().count(a.GetSimpleVariable()), 0u);
+    EXPECT_EQ(rewritten.GetVariables().count(b.GetSimpleVariable()), 0u);
+    EXPECT_EQ(rewritten.GetVariables().count(c.GetSimpleVariable()), 0u);
 
     // Rewritten has the same or smaller number of variables and terms.
-    EXPECT_LE(rewritten.getVariables().size(), poly.getVariables().size());
-    EXPECT_LE(rewritten.getMonomials().size(), poly.getMonomials().size());
+    EXPECT_LE(rewritten.GetVariables().size(), poly.GetVariables().size());
+    EXPECT_LE(rewritten.GetMonomials().size(), poly.GetMonomials().size());
 
     // Rewriting in terms of lumped parameters should never change the
     // actual value of a polynomial at a particular point.
-    EXPECT_EQ(poly.evaluateMultivariate(eval_point),
-              rewritten.evaluateMultivariate(eval_point));
+    EXPECT_EQ(poly.EvaluateMultivariate(eval_point),
+              rewritten.EvaluateMultivariate(eval_point));
 
     // TODO(ggould-tri) The above tests do not ensure that the original and
     // rewritten polys are everywhere and always structurally identical, just
-    // nearly always identical in their evaluateMultivariate behaviour.
+    // nearly always identical in their EvaluateMultivariate behaviour.
   }
 }
 
@@ -145,17 +145,17 @@ GTEST_TEST(SystemIdentificationTest, LumpedParameterRewrite) {
 
 GTEST_TEST(SystemIdentificationTest, BASIC_ESTIMATE_TEST_NAME) {
   const Polynomiald x = Polynomiald("x");
-  const auto x_var = x.getSimpleVariable();
+  const auto x_var = x.GetSimpleVariable();
   const Polynomiald y = Polynomiald("y");
-  const auto y_var = y.getSimpleVariable();
+  const auto y_var = y.GetSimpleVariable();
   const Polynomiald z = Polynomiald("z");
-  const auto z_var = z.getSimpleVariable();
+  const auto z_var = z.GetSimpleVariable();
   const Polynomiald a = Polynomiald("a");
-  const auto a_var = a.getSimpleVariable();
+  const auto a_var = a.GetSimpleVariable();
   const Polynomiald b = Polynomiald("b");
-  const auto b_var = b.getSimpleVariable();
+  const auto b_var = b.GetSimpleVariable();
   const Polynomiald c = Polynomiald("c");
-  const auto c_var = c.getSimpleVariable();
+  const auto c_var = c.GetSimpleVariable();
 
   /// Parameter estimation will try to make this Polynomial evaluate to zero:
   const Polynomiald poly = (a * x) + (b * x * x) + (c * y) - z;
@@ -276,19 +276,19 @@ std::vector<State> MakeTestData() {
 
 GTEST_TEST(SystemIdentificationTest, SPRING_MASS_TEST_NAME) {
   Polynomiald pos = Polynomiald("pos");
-  auto pos_var = pos.getSimpleVariable();
+  auto pos_var = pos.GetSimpleVariable();
   Polynomiald velocity = Polynomiald("vel");
-  auto velocity_var = velocity.getSimpleVariable();
+  auto velocity_var = velocity.GetSimpleVariable();
   Polynomiald acceleration = Polynomiald("acc");
-  auto acceleration_var = acceleration.getSimpleVariable();
+  auto acceleration_var = acceleration.GetSimpleVariable();
   Polynomiald input_force = Polynomiald("f_in");
-  auto input_force_var = input_force.getSimpleVariable();
+  auto input_force_var = input_force.GetSimpleVariable();
   Polynomiald mass = Polynomiald("m");
-  auto mass_var = mass.getSimpleVariable();
+  auto mass_var = mass.GetSimpleVariable();
   Polynomiald damping = Polynomiald("b");
-  auto damping_var = damping.getSimpleVariable();
+  auto damping_var = damping.GetSimpleVariable();
   Polynomiald spring = Polynomiald("k");
-  auto spring_var = spring.getSimpleVariable();
+  auto spring_var = spring.GetSimpleVariable();
 
   // Code style violations here:
   // * Vector initializations use two statements on one line for clarity.
@@ -403,17 +403,17 @@ GTEST_TEST(SystemIdentificationTest, PENDULA_TEST_NAME) {
 
   // Create convenience variables for our q/qdot/u values.  Convenience vars
   // have an underscore prefix for slightly easier understandability.
-  const TrigPolyd::VarType th1_var = theta1.getPolynomial().getSimpleVariable();
-  const TrigPolyd::VarType th2_var = theta2.getPolynomial().getSimpleVariable();
+  const TrigPolyd::VarType th1_var = theta1.getPolynomial().GetSimpleVariable();
+  const TrigPolyd::VarType th2_var = theta2.getPolynomial().GetSimpleVariable();
   const TrigPolyd::VarType th1d_var =
-      theta1dot.getPolynomial().getSimpleVariable();
+          theta1dot.getPolynomial().GetSimpleVariable();
   const TrigPolyd::VarType th2d_var =
-      theta2dot.getPolynomial().getSimpleVariable();
+          theta2dot.getPolynomial().GetSimpleVariable();
   const TrigPolyd::VarType th1dd_var =
-      theta1dotdot.getPolynomial().getSimpleVariable();
+          theta1dotdot.getPolynomial().GetSimpleVariable();
   const TrigPolyd::VarType th2dd_var =
-      theta2dotdot.getPolynomial().getSimpleVariable();
-  const TrigPolyd::VarType tau_var = tau.getPolynomial().getSimpleVariable();
+          theta2dotdot.getPolynomial().GetSimpleVariable();
+  const TrigPolyd::VarType tau_var = tau.getPolynomial().GetSimpleVariable();
 
   const double kG = 9.8;
   const double kPi = 3.14159265;
@@ -483,9 +483,9 @@ GTEST_TEST(SystemIdentificationTest, PENDULA_TEST_NAME) {
 
   // Check result.partially_evaluated_polys.
   for (const auto& point : pendula_data) {
-    EXPECT_NEAR(result.partially_evaluated_polys[0].evaluateMultivariate(point),
+    EXPECT_NEAR(result.partially_evaluated_polys[0].EvaluateMultivariate(point),
                 0, max_per_term_error);
-    EXPECT_NEAR(result.partially_evaluated_polys[1].evaluateMultivariate(point),
+    EXPECT_NEAR(result.partially_evaluated_polys[1].EvaluateMultivariate(point),
                 0, max_per_term_error);
   }
 }

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -1,4 +1,5 @@
 #include <typeinfo>
+#include <typeinfo>
 
 #include "drake/common/drake_assert.h"
 #include "drake/solvers/Constraint.h"
@@ -150,7 +151,7 @@ GTEST_TEST(testOptimizationProblem, trivialLinearSystem) {
   CheckSolverType(prog, "Linear System Solver");
 
   // Now modify the original constraint by its handle
-  con->updateConstraint(3 * Matrix4d::Identity(), b);
+          con->UpdateConstraint(3 * Matrix4d::Identity(), b);
   prog.Solve();
   EXPECT_TRUE(CompareMatrices(b.topRows(2) / 2, y.value(), 1e-10,
                               MatrixCompareType::absolute));
@@ -381,18 +382,18 @@ class LowerBoundTestConstraint : public Constraint {
         i2_(i2) {}
 
   // for just these two types, implementing this locally is almost cleaner...
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override {
-    evalImpl(x, y);
+    EvalImpl(x, y);
   }
-  void eval(const Eigen::Ref<const TaylorVecXd>& x,
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
             TaylorVecXd& y) const override {
-    evalImpl(x, y);
+    EvalImpl(x, y);
   }
 
  private:
   template <typename ScalarType>
-  void evalImpl(
+  void EvalImpl(
       const Eigen::Ref<const Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>>& x,
       Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>& y) const {
     y.resize(1);
@@ -480,9 +481,9 @@ GTEST_TEST(testOptimizationProblem, sixHumpCamel) {
   RunNonlinearProgram(prog, [&]() {
     // check (numerically) if it is a local minimum
     VectorXd ystar, y;
-    cost->eval(x.value(), ystar);
+      cost->Eval(x.value(), ystar);
     for (int i = 0; i < 10; i++) {
-      cost->eval(x.value() + .01 * Matrix<double, 2, 1>::Random(), y);
+        cost->Eval(x.value() + .01 * Matrix<double, 2, 1>::Random(), y);
       if (y(0) < ystar(0)) throw std::runtime_error("not a local minima!");
     }
   });
@@ -511,18 +512,18 @@ class GloptipolyConstrainedExampleConstraint
             Vector1d::Constant(std::numeric_limits<double>::infinity())) {}
 
   // for just these two types, implementing this locally is almost cleaner...
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override {
-    evalImpl(x, y);
+    EvalImpl(x, y);
   }
-  void eval(const Eigen::Ref<const TaylorVecXd>& x,
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
             TaylorVecXd& y) const override {
-    evalImpl(x, y);
+    EvalImpl(x, y);
   }
 
  private:
   template <typename ScalarType>
-  void evalImpl(const Ref<const Matrix<ScalarType, Dynamic, 1>>& x,
+  void EvalImpl(const Ref<const Matrix<ScalarType, Dynamic, 1>>& x,
                 Matrix<ScalarType, Dynamic, 1>& y) const {
     y.resize(1);
     y(0) = 24 - 20 * x(0) + 9 * x(1) - 13 * x(2) + 4 * x(0) * x(0) -
@@ -588,7 +589,7 @@ GTEST_TEST(testOptimizationProblem, gloptipolyConstrainedMinimization) {
 }
 
 /**
- * Test that the eval() method of LinearComplementarityConstraint correctly
+ * Test that the Eval() method of LinearComplementarityConstraint correctly
  * returns the slack.
  */
 GTEST_TEST(testOptimizationProblem, simpleLCPConstraintEval) {
@@ -604,11 +605,11 @@ GTEST_TEST(testOptimizationProblem, simpleLCPConstraintEval) {
 
   LinearComplementarityConstraint c(M, q);
   Eigen::VectorXd x;
-  c.eval(Eigen::Vector2d(1, 1), x);
+          c.Eval(Eigen::Vector2d(1, 1), x);
 
   EXPECT_TRUE(
       CompareMatrices(x, Vector2d(0, 0), 1e-4, MatrixCompareType::absolute));
-  c.eval(Eigen::Vector2d(1, 2), x);
+          c.Eval(Eigen::Vector2d(1, 2), x);
 
   EXPECT_TRUE(
       CompareMatrices(x, Vector2d(0, 1), 1e-4, MatrixCompareType::absolute));

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -679,7 +679,7 @@ GTEST_TEST(testOptimizationProblem, linearPolynomialConstraint) {
   static const double kEpsilon = 1e-7;
   const auto x_var = problem.AddContinuousVariables(1);
   const std::vector<Polynomiald::VarType> var_mapping = {
-    x.getSimpleVariable()};
+          x.GetSimpleVariable()};
   std::shared_ptr<Constraint> resulting_constraint =
       problem.AddPolynomialConstraint(VectorXPoly::Constant(1, x), var_mapping,
                                       Vector1d::Constant(2),
@@ -714,7 +714,7 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
     OptimizationProblem problem;
     const auto x_var = problem.AddContinuousVariables(1);
     const std::vector<Polynomiald::VarType> var_mapping = {
-        x.getSimpleVariable()};
+            x.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, x), var_mapping,
                                     Vector1d::Constant(2),
                                     Vector1d::Constant(2));
@@ -732,13 +732,13 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
     OptimizationProblem problem;
     const auto x_var = problem.AddContinuousVariables(1);
     const std::vector<Polynomiald::VarType> var_mapping = {
-        x.getSimpleVariable()};
+            x.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, poly), var_mapping,
                                     Eigen::VectorXd::Zero(1),
                                     Eigen::VectorXd::Zero(1));
     RunNonlinearProgram(problem, [&]() {
       EXPECT_NEAR(x_var.value()[0], 1, 0.2);
-      EXPECT_LE(poly.evaluateUnivariate(x_var.value()[0]), kEpsilon);
+      EXPECT_LE(poly.EvaluateUnivariate(x_var.value()[0]), kEpsilon);
     });
   }
 
@@ -750,7 +750,7 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
     OptimizationProblem problem;
     const auto xy_var = problem.AddContinuousVariables(2);
     const std::vector<Polynomiald::VarType> var_mapping = {
-        x.getSimpleVariable(), y.getSimpleVariable()};
+            x.GetSimpleVariable(), y.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, poly), var_mapping,
                                     Eigen::VectorXd::Zero(1),
                                     Eigen::VectorXd::Zero(1));
@@ -758,9 +758,9 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
       EXPECT_NEAR(xy_var.value()[0], 1, 0.2);
       EXPECT_NEAR(xy_var.value()[1], -2, 0.2);
       std::map<Polynomiald::VarType, double> eval_point = {
-          {x.getSimpleVariable(), xy_var.value()[0]},
-          {y.getSimpleVariable(), xy_var.value()[1]}};
-      EXPECT_LE(poly.evaluateMultivariate(eval_point), kEpsilon);
+          {x.GetSimpleVariable(), xy_var.value()[0]},
+          {y.GetSimpleVariable(), xy_var.value()[1]}};
+      EXPECT_LE(poly.EvaluateMultivariate(eval_point), kEpsilon);
     });
   }
 
@@ -774,7 +774,7 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
     const auto x_var = problem.AddContinuousVariables(1);
     problem.SetInitialGuess({x_var}, Vector1d::Constant(-0.1));
     const std::vector<Polynomiald::VarType> var_mapping = {
-        x.getSimpleVariable()};
+            x.GetSimpleVariable()};
     VectorXPoly polynomials_vec(2, 1);
     polynomials_vec << poly, x;
     problem.AddPolynomialConstraint(polynomials_vec, var_mapping,
@@ -782,7 +782,7 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
                                     Eigen::VectorXd::Zero(2));
     RunNonlinearProgram(problem, [&]() {
       EXPECT_NEAR(x_var.value()[0], -0.7, 0.2);
-      EXPECT_LE(poly.evaluateUnivariate(x_var.value()[0]), kEpsilon);
+      EXPECT_LE(poly.EvaluateUnivariate(x_var.value()[0]), kEpsilon);
     });
   }
 }

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -1,5 +1,4 @@
 #include <typeinfo>
-#include <typeinfo>
 
 #include "drake/common/drake_assert.h"
 #include "drake/solvers/Constraint.h"

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -151,7 +151,7 @@ GTEST_TEST(testOptimizationProblem, trivialLinearSystem) {
   CheckSolverType(prog, "Linear System Solver");
 
   // Now modify the original constraint by its handle
-          con->UpdateConstraint(3 * Matrix4d::Identity(), b);
+  con->UpdateConstraint(3 * Matrix4d::Identity(), b);
   prog.Solve();
   EXPECT_TRUE(CompareMatrices(b.topRows(2) / 2, y.value(), 1e-10,
                               MatrixCompareType::absolute));
@@ -481,9 +481,9 @@ GTEST_TEST(testOptimizationProblem, sixHumpCamel) {
   RunNonlinearProgram(prog, [&]() {
     // check (numerically) if it is a local minimum
     VectorXd ystar, y;
-      cost->Eval(x.value(), ystar);
+    cost->Eval(x.value(), ystar);
     for (int i = 0; i < 10; i++) {
-        cost->Eval(x.value() + .01 * Matrix<double, 2, 1>::Random(), y);
+      cost->Eval(x.value() + .01 * Matrix<double, 2, 1>::Random(), y);
       if (y(0) < ystar(0)) throw std::runtime_error("not a local minima!");
     }
   });
@@ -605,11 +605,11 @@ GTEST_TEST(testOptimizationProblem, simpleLCPConstraintEval) {
 
   LinearComplementarityConstraint c(M, q);
   Eigen::VectorXd x;
-          c.Eval(Eigen::Vector2d(1, 1), x);
+  c.Eval(Eigen::Vector2d(1, 1), x);
 
   EXPECT_TRUE(
       CompareMatrices(x, Vector2d(0, 0), 1e-4, MatrixCompareType::absolute));
-          c.Eval(Eigen::Vector2d(1, 2), x);
+  c.Eval(Eigen::Vector2d(1, 2), x);
 
   EXPECT_TRUE(
       CompareMatrices(x, Vector2d(0, 1), 1e-4, MatrixCompareType::absolute));
@@ -679,7 +679,7 @@ GTEST_TEST(testOptimizationProblem, linearPolynomialConstraint) {
   static const double kEpsilon = 1e-7;
   const auto x_var = problem.AddContinuousVariables(1);
   const std::vector<Polynomiald::VarType> var_mapping = {
-          x.GetSimpleVariable()};
+    x.GetSimpleVariable()};
   std::shared_ptr<Constraint> resulting_constraint =
       problem.AddPolynomialConstraint(VectorXPoly::Constant(1, x), var_mapping,
                                       Vector1d::Constant(2),
@@ -714,7 +714,7 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
     OptimizationProblem problem;
     const auto x_var = problem.AddContinuousVariables(1);
     const std::vector<Polynomiald::VarType> var_mapping = {
-            x.GetSimpleVariable()};
+      x.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, x), var_mapping,
                                     Vector1d::Constant(2),
                                     Vector1d::Constant(2));
@@ -732,7 +732,7 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
     OptimizationProblem problem;
     const auto x_var = problem.AddContinuousVariables(1);
     const std::vector<Polynomiald::VarType> var_mapping = {
-            x.GetSimpleVariable()};
+      x.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, poly), var_mapping,
                                     Eigen::VectorXd::Zero(1),
                                     Eigen::VectorXd::Zero(1));
@@ -750,7 +750,7 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
     OptimizationProblem problem;
     const auto xy_var = problem.AddContinuousVariables(2);
     const std::vector<Polynomiald::VarType> var_mapping = {
-            x.GetSimpleVariable(), y.GetSimpleVariable()};
+      x.GetSimpleVariable(), y.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, poly), var_mapping,
                                     Eigen::VectorXd::Zero(1),
                                     Eigen::VectorXd::Zero(1));
@@ -774,7 +774,7 @@ GTEST_TEST(testOptimizationProblem, POLYNOMIAL_CONSTRAINT_TEST_NAME) {
     const auto x_var = problem.AddContinuousVariables(1);
     problem.SetInitialGuess({x_var}, Vector1d::Constant(-0.1));
     const std::vector<Polynomiald::VarType> var_mapping = {
-            x.GetSimpleVariable()};
+      x.GetSimpleVariable()};
     VectorXPoly polynomials_vec(2, 1);
     polynomials_vec << poly, x;
     problem.AddPolynomialConstraint(polynomials_vec, var_mapping,

--- a/drake/systems/controllers/zmpUtil.cpp
+++ b/drake/systems/controllers/zmpUtil.cpp
@@ -50,7 +50,7 @@ ExponentialPlusPiecewisePolynomial<double> s1Trajectory(
     MatrixXd poly_coeffs = MatrixXd::Zero(nq, k);
 
     for (size_t x = 0; x < nq; x++) {
-      poly_coeffs.row(x) = poly_mat(x).getCoefficients().transpose();
+      poly_coeffs.row(x) = poly_mat(x).GetCoefficients().transpose();
     }
 
     beta[j].col(k - 1) = -A2i * B2 * poly_coeffs.col(k - 1);

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -37,7 +37,7 @@ GTEST_TEST(BasicVectorTest, IntInitiallyZero) {
 // Tests that the BasicVector<Polynomiald> is initialized to zero.
 GTEST_TEST(BasicVectorTest, PolynomialInitiallyZero) {
   BasicVector<Polynomiald> vec(1);
-  EXPECT_TRUE(vec.get_value()[0].isApprox(Polynomiald(0.0),
+  EXPECT_TRUE(vec.get_value()[0].IsApprox(Polynomiald(0.0),
                                           Eigen::NumTraits<double>::epsilon()));
 }
 

--- a/drake/systems/plants/ConstraintWrappers.h
+++ b/drake/systems/plants/ConstraintWrappers.h
@@ -57,15 +57,15 @@ class SingleTimeKinematicConstraintWrapper :
   }
   ~SingleTimeKinematicConstraintWrapper() override {}
 
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& q,
-                    Eigen::VectorXd& y) const override {
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& q,
+            Eigen::VectorXd& y) const override {
     auto& kinsol = kin_helper_->UpdateKinematics(
         q, rigid_body_constraint_->getRobotPointer());
     Eigen::MatrixXd dy;
     rigid_body_constraint_->eval(nullptr, kinsol, y, dy);
   }
-  void eval(const Eigen::Ref<const TaylorVecXd>& tq,
-                    TaylorVecXd& ty) const override {
+  void Eval(const Eigen::Ref<const TaylorVecXd>& tq,
+            TaylorVecXd& ty) const override {
     Eigen::VectorXd q = drake::math::autoDiffToValueMatrix(tq);
     auto& kinsol = kin_helper_->UpdateKinematics(
         q, rigid_body_constraint_->getRobotPointer());
@@ -99,7 +99,7 @@ class QuasiStaticConstraintWrapper :
   }
   virtual ~QuasiStaticConstraintWrapper() {}
 
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& q,
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& q,
             Eigen::VectorXd& y) const override {
     auto& kinsol = kin_helper_->UpdateKinematics(
         q.head(
@@ -109,7 +109,7 @@ class QuasiStaticConstraintWrapper :
     Eigen::MatrixXd dy;
     rigid_body_constraint_->eval(nullptr, kinsol, weights.data(), y, dy);
   }
-  void eval(const Eigen::Ref<const TaylorVecXd>& tq,
+  void Eval(const Eigen::Ref<const TaylorVecXd>& tq,
             TaylorVecXd& ty) const override {
     Eigen::VectorXd q = drake::math::autoDiffToValueMatrix(tq);
     auto& kinsol = kin_helper_->UpdateKinematics(

--- a/drake/systems/plants/constraint/dynamic_constraint.cc
+++ b/drake/systems/plants/constraint/dynamic_constraint.cc
@@ -28,15 +28,15 @@ DynamicConstraint::DynamicConstraint(int num_states, int num_inputs)
 
 DynamicConstraint::~DynamicConstraint() {}
 
-void DynamicConstraint::eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-                             Eigen::VectorXd& y) const {
+void DynamicConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+                             Eigen::VectorXd &y) const {
   Drake::TaylorVecXd y_t;
-  eval(Drake::initializeAutoDiff(x), y_t);
+  Eval(Drake::initializeAutoDiff(x), y_t);
   y = math::autoDiffToValueMatrix(y_t);
 }
 
-void DynamicConstraint::eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-                             Drake::TaylorVecXd& y) const {
+void DynamicConstraint::Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+                             Drake::TaylorVecXd &y) const {
   DRAKE_ASSERT(x.size() == 1 + (2 * num_states_) + (2 * num_inputs_));
 
   // Extract our input variables:

--- a/drake/systems/plants/constraint/dynamic_constraint.cc
+++ b/drake/systems/plants/constraint/dynamic_constraint.cc
@@ -28,15 +28,15 @@ DynamicConstraint::DynamicConstraint(int num_states, int num_inputs)
 
 DynamicConstraint::~DynamicConstraint() {}
 
-void DynamicConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-                             Eigen::VectorXd &y) const {
+void DynamicConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                             Eigen::VectorXd& y) const {
   Drake::TaylorVecXd y_t;
   Eval(Drake::initializeAutoDiff(x), y_t);
   y = math::autoDiffToValueMatrix(y_t);
 }
 
-void DynamicConstraint::Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-                             Drake::TaylorVecXd &y) const {
+void DynamicConstraint::Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+                             Drake::TaylorVecXd& y) const {
   DRAKE_ASSERT(x.size() == 1 + (2 * num_states_) + (2 * num_inputs_));
 
   // Extract our input variables:

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -36,10 +36,10 @@ class DRAKEDYNAMICCONSTRAINT_EXPORT DynamicConstraint :
   DynamicConstraint(int num_states, int num_inputs);
   virtual ~DynamicConstraint();
 
-  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
-            Eigen::VectorXd &y) const override;
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
-            Drake::TaylorVecXd &y) const override;
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+            Eigen::VectorXd& y) const override;
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
+            Drake::TaylorVecXd& y) const override;
 
  protected:
   virtual void dynamics(const Drake::TaylorVecXd& state,

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -36,10 +36,10 @@ class DRAKEDYNAMICCONSTRAINT_EXPORT DynamicConstraint :
   DynamicConstraint(int num_states, int num_inputs);
   virtual ~DynamicConstraint();
 
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-                    Eigen::VectorXd& y) const override;
-  void eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-                    Drake::TaylorVecXd& y) const override;
+  void Eval(const Eigen::Ref<const Eigen::VectorXd> &x,
+            Eigen::VectorXd &y) const override;
+  void Eval(const Eigen::Ref<const Drake::TaylorVecXd> &x,
+            Drake::TaylorVecXd &y) const override;
 
  protected:
   virtual void dynamics(const Drake::TaylorVecXd& state,

--- a/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
@@ -56,7 +56,7 @@ GTEST_TEST(DynamicConstraintPendulumDynamicsTest, DynamicConstraintTest) {
   PendulumTestDynamicConstraint dut(kNumStates, kNumInputs);
 
   Drake::TaylorVecXd result;
-  dut.eval(Drake::initializeAutoDiff(x), result);
+        dut.Eval(Drake::initializeAutoDiff(x), result);
 
   EXPECT_NEAR(result(0).value(), 1.1027, 1e-4);
   EXPECT_NEAR(result(1).value(), 2.2657, 1e-4);

--- a/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
@@ -56,7 +56,7 @@ GTEST_TEST(DynamicConstraintPendulumDynamicsTest, DynamicConstraintTest) {
   PendulumTestDynamicConstraint dut(kNumStates, kNumInputs);
 
   Drake::TaylorVecXd result;
-        dut.Eval(Drake::initializeAutoDiff(x), result);
+  dut.Eval(Drake::initializeAutoDiff(x), result);
 
   EXPECT_NEAR(result(0).value(), 1.1027, 1e-4);
   EXPECT_NEAR(result(1).value(), 2.2657, 1e-4);

--- a/drake/systems/plants/inverseKinBackend.cpp
+++ b/drake/systems/plants/inverseKinBackend.cpp
@@ -157,13 +157,13 @@ class InverseKinObjective : public Constraint {
       : Constraint(model->number_of_positions()),
         Q_(Q) {}
 
-  void eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+  void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override {
     VectorXd q_err = x - q_nom_i_;
     y(0) = q_err.transpose() * Q_ * q_err;
   }
 
-  void eval(const Eigen::Ref<const TaylorVecXd>& x,
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
             TaylorVecXd& y) const override {
     VectorXd x_val = autoDiffToValueMatrix(x);
     VectorXd q_err = x_val - q_nom_i_;
@@ -176,7 +176,7 @@ class InverseKinObjective : public Constraint {
 
 
   /// Set the nominal posture.  This should be invoked before any
-  /// calls to eval() (the output of eval() is undefined if this has
+  /// calls to Eval() (the output of Eval() is undefined if this has
   /// not been set.)
   void set_q_nom(const VectorXd& q_nom_i) {
     q_nom_i_ = q_nom_i;

--- a/drake/systems/trajectories/PiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/PiecewisePolynomial.cpp
@@ -50,7 +50,7 @@ PiecewisePolynomial<CoefficientType>::derivative(int derivative_order) const {
     PolynomialMatrix& matrix = *it;
     for (Eigen::Index row = 0; row < rows(); row++) {
       for (Eigen::Index col = 0; col < cols(); col++) {
-        matrix(row, col) = matrix(row, col).derivative(derivative_order);
+        matrix(row, col) = matrix(row, col).Derivative(derivative_order);
       }
     }
   }
@@ -78,10 +78,10 @@ PiecewisePolynomial<CoefficientType>::integral(
       for (Eigen::Index col = 0; col < cols(); col++) {
         if (segment_index == 0) {
           matrix(row, col) =
-              matrix(row, col).integral(value_at_start_time(row, col));
+              matrix(row, col).Integral(value_at_start_time(row, col));
         } else {
           matrix(row, col) =
-              matrix(row, col).integral(
+              matrix(row, col).Integral(
                   ret.segmentValueAtGlobalAbscissa(
                       segment_index - 1,
                       getStartTime(segment_index), row, col));
@@ -135,7 +135,7 @@ template <typename CoefficientType>
 int PiecewisePolynomial<CoefficientType>::getSegmentPolynomialDegree(
     int segment_index, Eigen::Index row, Eigen::Index col) const {
   segmentNumberRangeCheck(segment_index);
-  return polynomials_[segment_index](row, col).getDegree();
+  return polynomials_[segment_index](row, col).GetDegree();
 }
 
 template <typename CoefficientType>
@@ -249,7 +249,7 @@ bool PiecewisePolynomial<CoefficientType>::isApprox(
     const PolynomialMatrix& other_matrix = other.polynomials_[segment_index];
     for (Eigen::Index row = 0; row < rows(); row++) {
       for (Eigen::Index col = 0; col < cols(); col++) {
-        if (!matrix(row, col).isApprox(other_matrix(row, col), tol))
+        if (!matrix(row, col).IsApprox(other_matrix(row, col), tol))
           return false;
       }
     }
@@ -299,7 +299,7 @@ template <typename CoefficientType>
 double PiecewisePolynomial<CoefficientType>::segmentValueAtGlobalAbscissa(
     int segment_index, double t, Eigen::Index row, Eigen::Index col) const {
   return polynomials_[segment_index](row, col)
-      .evaluateUnivariate(t - getStartTime(segment_index));
+      .EvaluateUnivariate(t - getStartTime(segment_index));
 }
 
 template <typename CoefficientType>
@@ -331,8 +331,8 @@ PiecewisePolynomial<CoefficientType> PiecewisePolynomial<
   for (Eigen::Index segment_index = 0; segment_index < num_segments;
        ++segment_index) {
     polynomials.push_back(
-        PolynomialType::randomPolynomialMatrix(
-            num_coefficients_per_polynomial, rows, cols));
+            PolynomialType::RandomPolynomialMatrix(
+                    num_coefficients_per_polynomial, rows, cols));
   }
   return PiecewisePolynomial<CoefficientType>(polynomials, segment_times);
 }

--- a/drake/systems/trajectories/PiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/PiecewisePolynomial.cpp
@@ -331,8 +331,8 @@ PiecewisePolynomial<CoefficientType> PiecewisePolynomial<
   for (Eigen::Index segment_index = 0; segment_index < num_segments;
        ++segment_index) {
     polynomials.push_back(
-            PolynomialType::RandomPolynomialMatrix(
-                    num_coefficients_per_polynomial, rows, cols));
+        PolynomialType::RandomPolynomialMatrix(
+            num_coefficients_per_polynomial, rows, cols));
   }
   return PiecewisePolynomial<CoefficientType>(polynomials, segment_times);
 }

--- a/drake/systems/trajectories/test/testPiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/test/testPiecewisePolynomial.cpp
@@ -53,8 +53,8 @@ void testIntegralAndDerivative() {
   // check continuity at knot points
   for (int i = 0; i < piecewise.getNumberOfSegments() - 1; ++i) {
     valuecheck(integral.getPolynomial(i)
-               .evaluateUnivariate(integral.getDuration(i)),
-               integral.getPolynomial(i + 1).evaluateUnivariate(0.0));
+                       .EvaluateUnivariate(integral.getDuration(i)),
+               integral.getPolynomial(i + 1).EvaluateUnivariate(0.0));
   }
 }
 

--- a/drake/systems/trajectories/test/testPiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/test/testPiecewisePolynomial.cpp
@@ -53,7 +53,7 @@ void testIntegralAndDerivative() {
   // check continuity at knot points
   for (int i = 0; i < piecewise.getNumberOfSegments() - 1; ++i) {
     valuecheck(integral.getPolynomial(i)
-                       .EvaluateUnivariate(integral.getDuration(i)),
+               .EvaluateUnivariate(integral.getDuration(i)),
                integral.getPolynomial(i + 1).EvaluateUnivariate(0.0));
   }
 }

--- a/drake/util/Polynomial.cpp
+++ b/drake/util/Polynomial.cpp
@@ -9,7 +9,7 @@ using namespace Eigen;
 
 template <typename CoefficientType>
 bool Polynomial<CoefficientType>::Monomial::HasSameExponents(
-        const Monomial &other) const {
+    const Monomial &other) const {
   if (terms.size() != other.terms.size()) return false;
 
   for (typename vector<Term>::const_iterator iter = terms.begin();
@@ -212,7 +212,7 @@ Polynomial<CoefficientType>::GetVariables() const {
 
 template <typename CoefficientType>
 Polynomial<CoefficientType> Polynomial<CoefficientType>::EvaluatePartial(
-        const std::map<VarType, CoefficientType> &var_values) const {
+    const std::map<VarType, CoefficientType> &var_values) const {
   std::vector<Monomial> new_monomials;
   for (const Monomial& monomial : monomials_) {
     CoefficientType new_coefficient = monomial.coefficient;
@@ -244,7 +244,7 @@ void Polynomial<CoefficientType>::Subs(const VarType &orig,
 
 template <typename CoefficientType>
 Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
-        unsigned int derivative_order) const {
+    unsigned int derivative_order) const {
   if (!is_univariate_)
     throw runtime_error(
         "getCoefficients is only defined for univariate polynomials");
@@ -271,7 +271,7 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
 
 template <typename CoefficientType>
 Polynomial<CoefficientType> Polynomial<CoefficientType>::Integral(
-        const CoefficientType &integration_constant) const {
+    const CoefficientType &integration_constant) const {
   if (!is_univariate_)
     throw runtime_error(
         "getCoefficients is only defined for univariate polynomials");

--- a/drake/util/Polynomial.cpp
+++ b/drake/util/Polynomial.cpp
@@ -9,7 +9,7 @@ using namespace Eigen;
 
 template <typename CoefficientType>
 bool Polynomial<CoefficientType>::Monomial::HasSameExponents(
-    const Monomial &other) const {
+    const Monomial& other) const {
   if (terms.size() != other.terms.size()) return false;
 
   for (typename vector<Term>::const_iterator iter = terms.begin();
@@ -120,7 +120,7 @@ int Polynomial<CoefficientType>::Monomial::GetDegreeOf(VarType v) const {
 
 template <typename CoefficientType>
 typename Polynomial<CoefficientType>::Monomial
-Polynomial<CoefficientType>::Monomial::Factor(const Monomial &divisor) const {
+Polynomial<CoefficientType>::Monomial::Factor(const Monomial& divisor) const {
   Monomial error, result;
   error.coefficient = 0;
   result.coefficient = coefficient / divisor.coefficient;
@@ -212,7 +212,7 @@ Polynomial<CoefficientType>::GetVariables() const {
 
 template <typename CoefficientType>
 Polynomial<CoefficientType> Polynomial<CoefficientType>::EvaluatePartial(
-    const std::map<VarType, CoefficientType> &var_values) const {
+    const std::map<VarType, CoefficientType>& var_values) const {
   std::vector<Monomial> new_monomials;
   for (const Monomial& monomial : monomials_) {
     CoefficientType new_coefficient = monomial.coefficient;
@@ -231,8 +231,8 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::EvaluatePartial(
 }
 
 template <typename CoefficientType>
-void Polynomial<CoefficientType>::Subs(const VarType &orig,
-                                       const VarType &replacement) {
+void Polynomial<CoefficientType>::Subs(const VarType& orig,
+                                       const VarType& replacement) {
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
     for (typename vector<Term>::iterator t = iter->terms.begin();
@@ -271,7 +271,7 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
 
 template <typename CoefficientType>
 Polynomial<CoefficientType> Polynomial<CoefficientType>::Integral(
-    const CoefficientType &integration_constant) const {
+    const CoefficientType& integration_constant) const {
   if (!is_univariate_)
     throw runtime_error(
         "getCoefficients is only defined for univariate polynomials");
@@ -506,8 +506,8 @@ Polynomial<CoefficientType>::Roots() const {
 }
 
 template <typename CoefficientType>
-bool Polynomial<CoefficientType>::IsApprox(const Polynomial &other,
-                                           const RealScalar &tol) const {
+bool Polynomial<CoefficientType>::IsApprox(const Polynomial& other,
+                                           const RealScalar& tol) const {
   return GetCoefficients().isApprox(other.GetCoefficients(), tol);
 }
 

--- a/drake/util/Polynomial.cpp
+++ b/drake/util/Polynomial.cpp
@@ -8,8 +8,8 @@ using namespace std;
 using namespace Eigen;
 
 template <typename CoefficientType>
-bool Polynomial<CoefficientType>::Monomial::hasSameExponents(
-    const Monomial& other) const {
+bool Polynomial<CoefficientType>::Monomial::HasSameExponents(
+        const Monomial &other) const {
   if (terms.size() != other.terms.size()) return false;
 
   for (typename vector<Term>::const_iterator iter = terms.begin();
@@ -25,8 +25,8 @@ template <typename CoefficientType>
 Polynomial<CoefficientType>::Polynomial(const CoefficientType& scalar) {
   Monomial m;
   m.coefficient = scalar;
-  monomials.push_back(m);
-  is_univariate = true;
+  monomials_.push_back(m);
+  is_univariate_ = true;
 }
 
 template <typename CoefficientType>
@@ -36,10 +36,10 @@ Polynomial<CoefficientType>::Polynomial(const CoefficientType coefficient,
   m.coefficient = coefficient;
   m.terms = terms;
 
-  is_univariate = true;
+  is_univariate_ = true;
   for (int i = (int)m.terms.size() - 1; i >= 0; i--) {
     if ((i > 0) && (m.terms[i].var != m.terms[0].var)) {
-      is_univariate = false;
+      is_univariate_ = false;
     }
     for (int j = 0; j < (i - 1); j++) {  // merge any duplicate vars
       if (m.terms[i].var == m.terms[j].var) {
@@ -50,7 +50,7 @@ Polynomial<CoefficientType>::Polynomial(const CoefficientType coefficient,
     }
   }
 
-  monomials.push_back(m);
+  monomials_.push_back(m);
 }
 
 template <typename CoefficientType>
@@ -59,14 +59,14 @@ Polynomial<CoefficientType>::Polynomial(
         typename Polynomial<CoefficientType>::Monomial>::const_iterator start,
     typename vector<typename Polynomial<CoefficientType>::Monomial>::
         const_iterator finish) {
-  is_univariate = true;
+  is_univariate_ = true;
   for (
       typename vector<
           typename Polynomial<CoefficientType>::Monomial>::const_iterator iter =
           start;
       iter != finish; iter++)
-    monomials.push_back(*iter);
-  makeMonomialsUnique();
+    monomials_.push_back(*iter);
+  MakeMonomialsUnique();
 }
 
 template <typename CoefficientType>
@@ -75,11 +75,11 @@ Polynomial<CoefficientType>::Polynomial(const string varname,
   Monomial m;
   m.coefficient = (CoefficientType)1;
   Term t;
-  t.var = variableNameToId(varname, num);
+  t.var = VariableNameToId(varname, num);
   t.power = 1;
   m.terms.push_back(t);
-  monomials.push_back(m);
-  is_univariate = true;
+  monomials_.push_back(m);
+  is_univariate_ = true;
 }
 
 template <typename CoefficientType>
@@ -91,17 +91,17 @@ Polynomial<CoefficientType>::Polynomial(const CoefficientType& coeff,
   t.var = v;
   t.power = 1;
   m.terms.push_back(t);
-  monomials.push_back(m);
-  is_univariate = true;
+  monomials_.push_back(m);
+  is_univariate_ = true;
 }
 
 template <typename CoefficientType>
-int Polynomial<CoefficientType>::getNumberOfCoefficients() const {
-  return static_cast<int>(monomials.size());
+int Polynomial<CoefficientType>::GetNumberOfCoefficients() const {
+  return static_cast<int>(monomials_.size());
 }
 
 template <typename CoefficientType>
-int Polynomial<CoefficientType>::Monomial::getDegree() const {
+int Polynomial<CoefficientType>::Monomial::GetDegree() const {
   if (terms.empty()) return 0;
   int degree = terms[0].power;
   for (size_t i = 1; i < terms.size(); i++) degree *= terms[i].power;
@@ -109,7 +109,7 @@ int Polynomial<CoefficientType>::Monomial::getDegree() const {
 }
 
 template <typename CoefficientType>
-int Polynomial<CoefficientType>::Monomial::getDegreeOf(VarType v) const {
+int Polynomial<CoefficientType>::Monomial::GetDegreeOf(VarType v) const {
   for (const Term& term : terms) {
     if (term.var == v) {
       return term.power;
@@ -120,12 +120,12 @@ int Polynomial<CoefficientType>::Monomial::getDegreeOf(VarType v) const {
 
 template <typename CoefficientType>
 typename Polynomial<CoefficientType>::Monomial
-Polynomial<CoefficientType>::Monomial::factor(const Monomial& divisor) const {
+Polynomial<CoefficientType>::Monomial::Factor(const Monomial &divisor) const {
   Monomial error, result;
   error.coefficient = 0;
   result.coefficient = coefficient / divisor.coefficient;
   for (const Term& term : terms) {
-    const PowerType divisor_power = divisor.getDegreeOf(term.var);
+    const PowerType divisor_power = divisor.GetDegreeOf(term.var);
     if (term.power < divisor_power) { return error; }
     Term new_term;
     new_term.var = term.var;
@@ -135,17 +135,17 @@ Polynomial<CoefficientType>::Monomial::factor(const Monomial& divisor) const {
     }
   }
   for (const Term& divisor_term : divisor.terms) {
-    if (!getDegreeOf(divisor_term.var)) { return error; }
+    if (!GetDegreeOf(divisor_term.var)) { return error; }
   }
   return result;
 }
 
 template <typename CoefficientType>
-int Polynomial<CoefficientType>::getDegree() const {
+int Polynomial<CoefficientType>::GetDegree() const {
   int max_degree = 0;
-  for (typename vector<Monomial>::const_iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
-    int monomial_degree = iter->getDegree();
+  for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
+    int monomial_degree = iter->GetDegree();
     if (monomial_degree > max_degree) max_degree = monomial_degree;
   }
 
@@ -153,9 +153,9 @@ int Polynomial<CoefficientType>::getDegree() const {
 }
 
 template <typename CoefficientType>
-bool Polynomial<CoefficientType>::isAffine() const {
-  for (const auto& monomial : monomials) {
-    if ((monomial.terms.size() > 1) || (monomial.getDegree() > 1)) {
+bool Polynomial<CoefficientType>::IsAffine() const {
+  for (const auto& monomial : monomials_) {
+    if ((monomial.terms.size() > 1) || (monomial.GetDegree() > 1)) {
       return false;
     }
   }
@@ -164,32 +164,32 @@ bool Polynomial<CoefficientType>::isAffine() const {
 
 template <typename CoefficientType>
 typename Polynomial<CoefficientType>::VarType
-Polynomial<CoefficientType>::getSimpleVariable() const {
-  if (monomials.size() != 1) return 0;
-  if (monomials[0].terms.size() != 1) return 0;
-  if (monomials[0].terms[0].power != 1) return 0;
-  return monomials[0].terms[0].var;
+Polynomial<CoefficientType>::GetSimpleVariable() const {
+  if (monomials_.size() != 1) return 0;
+  if (monomials_[0].terms.size() != 1) return 0;
+  if (monomials_[0].terms[0].power != 1) return 0;
+  return monomials_[0].terms[0].var;
 }
 
 template <typename CoefficientType>
 const std::vector<typename Polynomial<CoefficientType>::Monomial>&
-Polynomial<CoefficientType>::getMonomials() const {
-  return monomials;
+Polynomial<CoefficientType>::GetMonomials() const {
+  return monomials_;
 }
 
 template <typename CoefficientType>
 Matrix<CoefficientType, Dynamic, 1>
-Polynomial<CoefficientType>::getCoefficients() const {
-  if (!is_univariate)
+Polynomial<CoefficientType>::GetCoefficients() const {
+  if (!is_univariate_)
     throw runtime_error(
         "getCoefficients is only defined for univariate polynomials");
 
-  int deg = getDegree();
+  int deg = GetDegree();
 
   Matrix<CoefficientType, Dynamic, 1> coefficients =
       Matrix<CoefficientType, Dynamic, 1>::Zero(deg + 1);
-  for (typename vector<Monomial>::const_iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
+  for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
     if (iter->terms.empty())
       coefficients[0] = iter->coefficient;
     else
@@ -200,9 +200,9 @@ Polynomial<CoefficientType>::getCoefficients() const {
 
 template <typename CoefficientType>
 std::set<typename Polynomial<CoefficientType>::VarType>
-Polynomial<CoefficientType>::getVariables() const {
+Polynomial<CoefficientType>::GetVariables() const {
   std::set<Polynomial<CoefficientType>::VarType> vars;
-  for (const Monomial& monomial : monomials) {
+  for (const Monomial& monomial : monomials_) {
     for (const Term& term : monomial.terms) {
       vars.insert(term.var);
     }
@@ -211,10 +211,10 @@ Polynomial<CoefficientType>::getVariables() const {
 }
 
 template <typename CoefficientType>
-Polynomial<CoefficientType> Polynomial<CoefficientType>::evaluatePartial(
-    const std::map<VarType, CoefficientType>& var_values) const {
+Polynomial<CoefficientType> Polynomial<CoefficientType>::EvaluatePartial(
+        const std::map<VarType, CoefficientType> &var_values) const {
   std::vector<Monomial> new_monomials;
-  for (const Monomial& monomial : monomials) {
+  for (const Monomial& monomial : monomials_) {
     CoefficientType new_coefficient = monomial.coefficient;
     std::vector<Term> new_terms;
     for (const Term& term : monomial.terms) {
@@ -231,10 +231,10 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::evaluatePartial(
 }
 
 template <typename CoefficientType>
-void Polynomial<CoefficientType>::subs(const VarType& orig,
-                                       const VarType& replacement) {
-  for (typename vector<Monomial>::iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
+void Polynomial<CoefficientType>::Subs(const VarType &orig,
+                                       const VarType &replacement) {
+  for (typename vector<Monomial>::iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
     for (typename vector<Term>::iterator t = iter->terms.begin();
          t != iter->terms.end(); t++) {
       if (t->var == orig) t->var = replacement;
@@ -243,16 +243,16 @@ void Polynomial<CoefficientType>::subs(const VarType& orig,
 }
 
 template <typename CoefficientType>
-Polynomial<CoefficientType> Polynomial<CoefficientType>::derivative(
-    unsigned int derivative_order) const {
-  if (!is_univariate)
+Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
+        unsigned int derivative_order) const {
+  if (!is_univariate_)
     throw runtime_error(
         "getCoefficients is only defined for univariate polynomials");
 
   Polynomial<CoefficientType> ret;
 
-  for (typename vector<Monomial>::const_iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
+  for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
     if (!iter->terms.empty() && (
             iter->terms[0].power >= static_cast<PowerType>(derivative_order))) {
       Monomial m = *iter;
@@ -262,28 +262,28 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::derivative(
         m.terms[0].power -= 1;
       }
       if (m.terms[0].power < 1) m.terms.erase(m.terms.begin());
-      ret.monomials.push_back(m);
+      ret.monomials_.push_back(m);
     }
   }
-  ret.is_univariate = true;
+  ret.is_univariate_ = true;
   return ret;
 }
 
 template <typename CoefficientType>
-Polynomial<CoefficientType> Polynomial<CoefficientType>::integral(
-    const CoefficientType& integration_constant) const {
-  if (!is_univariate)
+Polynomial<CoefficientType> Polynomial<CoefficientType>::Integral(
+        const CoefficientType &integration_constant) const {
+  if (!is_univariate_)
     throw runtime_error(
         "getCoefficients is only defined for univariate polynomials");
   Polynomial<CoefficientType> ret = *this;
 
-  for (typename vector<Monomial>::iterator iter = ret.monomials.begin();
-       iter != ret.monomials.end(); iter++) {
+  for (typename vector<Monomial>::iterator iter = ret.monomials_.begin();
+       iter != ret.monomials_.end(); iter++) {
     if (iter->terms.empty()) {
       Term t;
       t.var = 0;
-      for (typename vector<Monomial>::iterator iterB = ret.monomials.begin();
-           iterB != ret.monomials.end(); iterB++) {
+      for (typename vector<Monomial>::iterator iterB = ret.monomials_.begin();
+           iterB != ret.monomials_.end(); iterB++) {
         if (!iterB->terms.empty()) {
           t.var = iterB->terms[0].var;
           break;
@@ -299,8 +299,8 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::integral(
   }
   Monomial m;
   m.coefficient = integration_constant;
-  ret.is_univariate = true;
-  ret.monomials.push_back(m);
+  ret.is_univariate_ = true;
+  ret.monomials_.push_back(m);
   return ret;
 }
 
@@ -310,33 +310,33 @@ bool Polynomial<CoefficientType>::operator==(
   // Comparison of unsorted vectors is faster copying them into std::set
   // btrees rather than using std::is_permutation().
   // TODO(#2216) switch from multiset to set for further performance gains.
-  const std::multiset<Monomial> this_monomials(monomials.begin(),
-                                               monomials.end());
-  const std::multiset<Monomial> other_monomials(other.monomials.begin(),
-                                                other.monomials.end());
+  const std::multiset<Monomial> this_monomials(monomials_.begin(),
+                                               monomials_.end());
+  const std::multiset<Monomial> other_monomials(other.monomials_.begin(),
+                                                other.monomials_.end());
   return this_monomials == other_monomials;
 }
 
 template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
     const Polynomial<CoefficientType>& other) {
-  for (typename vector<Monomial>::const_iterator iter = other.monomials.begin();
-       iter != other.monomials.end(); iter++) {
-    monomials.push_back(*iter);
+  for (typename vector<Monomial>::const_iterator iter = other.monomials_.begin();
+       iter != other.monomials_.end(); iter++) {
+    monomials_.push_back(*iter);
   }
-  makeMonomialsUnique();  // also sets is_univariate false if necessary
+  MakeMonomialsUnique();  // also sets is_univariate false if necessary
   return *this;
 }
 
 template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator-=(
     const Polynomial<CoefficientType>& other) {
-  for (typename vector<Monomial>::const_iterator iter = other.monomials.begin();
-       iter != other.monomials.end(); iter++) {
-    monomials.push_back(*iter);
-    monomials.back().coefficient *= (CoefficientType)(-1);
+  for (typename vector<Monomial>::const_iterator iter = other.monomials_.begin();
+       iter != other.monomials_.end(); iter++) {
+    monomials_.push_back(*iter);
+    monomials_.back().coefficient *= (CoefficientType)(-1);
   }
-  makeMonomialsUnique();  // also sets is_univariate false if necessary
+  MakeMonomialsUnique();  // also sets is_univariate false if necessary
   return *this;
 }
 
@@ -345,11 +345,11 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
     const Polynomial<CoefficientType>& other) {
   vector<Monomial> new_monomials;
 
-  for (typename vector<Monomial>::const_iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
+  for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
     for (typename vector<Monomial>::const_iterator other_iter =
-             other.monomials.begin();
-         other_iter != other.monomials.end(); other_iter++) {
+             other.monomials_.begin();
+         other_iter != other.monomials_.end(); other_iter++) {
       Monomial m;
       m.coefficient = iter->coefficient * other_iter->coefficient;
       m.terms = iter->terms;
@@ -369,9 +369,9 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
       new_monomials.push_back(m);
     }
   }
-  monomials = new_monomials;
+  monomials_ = new_monomials;
 
-  makeMonomialsUnique();  // also sets is_univariate false if necessary
+  MakeMonomialsUnique();  // also sets is_univariate false if necessary
   return *this;
 }
 
@@ -379,8 +379,8 @@ template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
     const CoefficientType& scalar) {
   // add to the constant monomial if I have one
-  for (typename vector<Monomial>::iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
+  for (typename vector<Monomial>::iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
     if (iter->terms.empty()) {
       iter->coefficient += scalar;
       return *this;
@@ -390,7 +390,7 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
   // otherwise create the constant monomial
   Monomial m;
   m.coefficient = scalar;
-  monomials.push_back(m);
+  monomials_.push_back(m);
   return *this;
 }
 
@@ -398,8 +398,8 @@ template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator-=(
     const CoefficientType& scalar) {
   // add to the constant monomial if I have one
-  for (typename vector<Monomial>::iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
+  for (typename vector<Monomial>::iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
     if (iter->terms.empty()) {
       iter->coefficient -= scalar;
       return *this;
@@ -409,15 +409,15 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator-=(
   // otherwise create the constant monomial
   Monomial m;
   m.coefficient = -scalar;
-  monomials.push_back(m);
+  monomials_.push_back(m);
   return *this;
 }
 
 template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
     const CoefficientType& scalar) {
-  for (typename vector<Monomial>::iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
+  for (typename vector<Monomial>::iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
     iter->coefficient *= scalar;
   }
   return *this;
@@ -426,8 +426,8 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
 template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator/=(
     const CoefficientType& scalar) {
-  for (typename vector<Monomial>::iterator iter = monomials.begin();
-       iter != monomials.end(); iter++) {
+  for (typename vector<Monomial>::iterator iter = monomials_.begin();
+       iter != monomials_.end(); iter++) {
     iter->coefficient /= scalar;
   }
   return *this;
@@ -453,8 +453,8 @@ template <typename CoefficientType>
 const Polynomial<CoefficientType> Polynomial<CoefficientType>::operator-()
     const {
   Polynomial<CoefficientType> ret = *this;
-  for (typename vector<Monomial>::iterator iter = ret.monomials.begin();
-       iter != ret.monomials.end(); iter++) {
+  for (typename vector<Monomial>::iterator iter = ret.monomials_.begin();
+       iter != ret.monomials_.end(); iter++) {
     iter->coefficient = -iter->coefficient;
   }
   return ret;
@@ -478,12 +478,12 @@ const Polynomial<CoefficientType> Polynomial<CoefficientType>::operator/(
 
 template <typename CoefficientType>
 typename Polynomial<CoefficientType>::RootsType
-Polynomial<CoefficientType>::roots() const {
-  if (!is_univariate)
+Polynomial<CoefficientType>::Roots() const {
+  if (!is_univariate_)
     throw runtime_error(
         "getCoefficients is only defined for univariate polynomials");
 
-  auto coefficients = getCoefficients();
+  auto coefficients = GetCoefficients();
 
   // need to handle degree 0 and 1 explicitly because Eigen's polynomial solver
   // doesn't work for these
@@ -506,9 +506,9 @@ Polynomial<CoefficientType>::roots() const {
 }
 
 template <typename CoefficientType>
-bool Polynomial<CoefficientType>::isApprox(const Polynomial& other,
-                                           const RealScalar& tol) const {
-  return getCoefficients().isApprox(other.getCoefficients(), tol);
+bool Polynomial<CoefficientType>::IsApprox(const Polynomial &other,
+                                           const RealScalar &tol) const {
+  return GetCoefficients().isApprox(other.GetCoefficients(), tol);
 }
 
 const char kNameChars[] = "@#_.abcdefghijklmnopqrstuvwxyz";
@@ -517,7 +517,7 @@ const unsigned int kNameLength = 4;
 const unsigned int kMaxNamePart = 923521;  // (kNumNameChars+1)^kNameLength;
 
 template <typename CoefficientType>
-bool Polynomial<CoefficientType>::isValidVariableName(const string name) {
+bool Polynomial<CoefficientType>::IsValidVariableName(const string name) {
   size_t len = name.length();
   if (len < 1) return false;
   for (size_t i = 0; i < len; i++)
@@ -527,7 +527,7 @@ bool Polynomial<CoefficientType>::isValidVariableName(const string name) {
 
 template <typename CoefficientType>
 typename Polynomial<CoefficientType>::VarType
-Polynomial<CoefficientType>::variableNameToId(const string name,
+Polynomial<CoefficientType>::VariableNameToId(const string name,
                                               const unsigned int m) {
   unsigned int multiplier = 1;
   VarType name_part = 0;
@@ -549,7 +549,7 @@ Polynomial<CoefficientType>::variableNameToId(const string name,
 }
 
 template <typename CoefficientType>
-string Polynomial<CoefficientType>::idToVariableName(const VarType id) {
+string Polynomial<CoefficientType>::IdToVariableName(const VarType id) {
   VarType name_part = (id / 2) % kMaxNamePart;  // id/2 to be compatible w/
                                                 // msspoly, even though I'm not
                                                 // doing the trig support here
@@ -570,30 +570,30 @@ string Polynomial<CoefficientType>::idToVariableName(const VarType id) {
 }
 
 template <typename CoefficientType>
-void Polynomial<CoefficientType>::makeMonomialsUnique(void) {
+void Polynomial<CoefficientType>::MakeMonomialsUnique(void) {
   VarType unique_var = 0;  // also update the univariate flag
-  for (int i = monomials.size() - 1; i >= 0; i--) {
-    if (monomials[i].coefficient == 0) {
-      monomials.erase(monomials.begin() + i);
+  for (int i = monomials_.size() - 1; i >= 0; i--) {
+    if (monomials_[i].coefficient == 0) {
+      monomials_.erase(monomials_.begin() + i);
       continue;
     }
-    Monomial& mi = monomials[i];
+    Monomial& mi = monomials_[i];
     if (!mi.terms.empty()) {
-      if (mi.terms.size() > 1) is_univariate = false;
+      if (mi.terms.size() > 1) is_univariate_ = false;
       if (mi.terms[0].var != unique_var) {
         if (unique_var > 0) {
-          is_univariate = false;
+          is_univariate_ = false;
         } else {
           unique_var = mi.terms[0].var;
         }
       }
     }
     for (int j = 0; j < (i - 1); j++) {
-      Monomial& mj = monomials[j];
-      if (mi.hasSameExponents(mj)) {
+      Monomial& mj = monomials_[j];
+      if (mi.HasSameExponents(mj)) {
         // it's a match, so delete monomial i
-        monomials[j].coefficient += monomials[i].coefficient;
-        monomials.erase(monomials.begin() + i);
+        monomials_[j].coefficient += monomials_[i].coefficient;
+        monomials_.erase(monomials_.begin() + i);
         break;
       }
     }

--- a/drake/util/Polynomial.cpp
+++ b/drake/util/Polynomial.cpp
@@ -320,9 +320,8 @@ bool Polynomial<CoefficientType>::operator==(
 template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
     const Polynomial<CoefficientType>& other) {
-  for (typename vector<Monomial>::const_iterator iter = other.monomials_.begin();
-       iter != other.monomials_.end(); iter++) {
-    monomials_.push_back(*iter);
+  for (const auto& iter : other.monomials_) {
+    monomials_.push_back(iter);
   }
   MakeMonomialsUnique();  // also sets is_univariate false if necessary
   return *this;
@@ -331,9 +330,8 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
 template <typename CoefficientType>
 Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator-=(
     const Polynomial<CoefficientType>& other) {
-  for (typename vector<Monomial>::const_iterator iter = other.monomials_.begin();
-       iter != other.monomials_.end(); iter++) {
-    monomials_.push_back(*iter);
+  for (const auto& iter : other.monomials_) {
+    monomials_.push_back(iter);
     monomials_.back().coefficient *= (CoefficientType)(-1);
   }
   MakeMonomialsUnique();  // also sets is_univariate false if necessary
@@ -345,25 +343,22 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
     const Polynomial<CoefficientType>& other) {
   vector<Monomial> new_monomials;
 
-  for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
-       iter != monomials_.end(); iter++) {
-    for (typename vector<Monomial>::const_iterator other_iter =
-             other.monomials_.begin();
-         other_iter != other.monomials_.end(); other_iter++) {
+  for (const auto& iter : monomials_) {
+    for (const auto& other_iter : other.monomials_) {
       Monomial m;
-      m.coefficient = iter->coefficient * other_iter->coefficient;
-      m.terms = iter->terms;
-      for (size_t i = 0; i < other_iter->terms.size(); i++) {
+      m.coefficient = iter.coefficient * other_iter.coefficient;
+      m.terms = iter.terms;
+      for (size_t i = 0; i < other_iter.terms.size(); i++) {
         bool new_var = true;
         for (size_t j = 0; j < m.terms.size(); j++) {
-          if (m.terms[j].var == other_iter->terms[i].var) {
-            m.terms[j].power += other_iter->terms[i].power;
+          if (m.terms[j].var == other_iter.terms[i].var) {
+            m.terms[j].power += other_iter.terms[i].power;
             new_var = false;
             break;
           }
         }
         if (new_var) {
-          m.terms.push_back(other_iter->terms[i]);
+          m.terms.push_back(other_iter.terms[i]);
         }
       }
       new_monomials.push_back(m);

--- a/drake/util/Polynomial.h
+++ b/drake/util/Polynomial.h
@@ -93,10 +93,10 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
 
     int GetDegree() const;
     int GetDegreeOf(VarType var) const;
-    bool HasSameExponents(const Monomial &other) const;
+    bool HasSameExponents(const Monomial& other) const;
 
     /// Factors this by other; returns 0 iff other does not divide this.
-    Monomial Factor(const Monomial &divisor) const;
+    Monomial Factor(const Monomial& divisor) const;
   };
 
  private:
@@ -183,7 +183,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    */
   template <typename T>
   typename Product<CoefficientType, T>::type EvaluateUnivariate(
-      const T &x) const {
+      const T& x) const {
     typedef typename Product<CoefficientType, T>::type ProductType;
 
     if (!is_univariate_)
@@ -215,7 +215,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    */
   template <typename T>
   typename Product<CoefficientType, T>::type EvaluateMultivariate(
-      const std::map<VarType, T> &var_values) const {
+      const std::map<VarType, T>& var_values) const {
     typedef typename std::remove_const<
       typename Product<CoefficientType, T>::type>::type ProductType;
     ProductType value = 0;
@@ -243,7 +243,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * TaylorVarXd correspond to.
    */
   Drake::TaylorVarXd EvaluateMultivariate(
-      const std::map<VarType, Drake::TaylorVarXd> &var_values) const {
+      const std::map<VarType, Drake::TaylorVarXd>& var_values) const {
     Drake::TaylorVarXd value(0);
     for (const Monomial& monomial : monomials_) {
       Drake::TaylorVarXd monomial_value(monomial.coefficient);
@@ -266,10 +266,10 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * replaced with its value and constants appropriately combined.
    */
   Polynomial EvaluatePartial(
-      const std::map<VarType, CoefficientType> &var_values) const;
+      const std::map<VarType, CoefficientType>& var_values) const;
 
   /// Replaces all instances of variable orig with replacement.
-  void Subs(const VarType &orig, const VarType &replacement);
+  void Subs(const VarType& orig, const VarType& replacement);
 
   /** Takes the derivative of this (univariate) Polynomial.
    *
@@ -290,7 +290,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * If integration_constant is given, adds that constant as the constant
    * term (zeroth-order coefficient) of the resulting Polynomial.
    */
-  Polynomial Integral(const CoefficientType &integration_constant = 0.0) const;
+  Polynomial Integral(const CoefficientType& integration_constant = 0.0) const;
 
   bool operator==(const Polynomial& other) const;
 
@@ -380,7 +380,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * corresponding coefficient of this Polynomial.  Throws an exception if
    * either Polynomial is not univariate.
    */
-  bool IsApprox(const Polynomial &other, const RealScalar &tol) const;
+  bool IsApprox(const Polynomial& other, const RealScalar& tol) const;
 
   friend std::ostream& operator<<(std::ostream& os, const Monomial& m) {
     //    if (m.coefficient == 0) return os;
@@ -460,13 +460,13 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
   using enable_if_t = typename std::enable_if<B, T>::type;
   template <typename Base>
   static Base Pow(
-      const enable_if_t<std::is_arithmetic<Base>::value, Base> &base,
-      const PowerType &exponent) {
+      const enable_if_t<std::is_arithmetic<Base>::value, Base>& base,
+      const PowerType& exponent) {
     return std::pow(base, exponent);
   }
 
   template <typename Base>
-  static Base Pow(const Base &base, const PowerType &exponent) {
+  static Base Pow(const Base& base, const PowerType& exponent) {
     Base result = base;
     for (int i = 1; i < exponent; i++) {
       result = result * base;

--- a/drake/util/Polynomial.h
+++ b/drake/util/Polynomial.h
@@ -183,7 +183,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    */
   template <typename T>
   typename Product<CoefficientType, T>::type EvaluateUnivariate(
-          const T &x) const {
+      const T &x) const {
     typedef typename Product<CoefficientType, T>::type ProductType;
 
     if (!is_univariate_)
@@ -197,8 +197,8 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
         value += iter->coefficient;
       else
         value += iter->coefficient *
-                Pow((ProductType) x,
-                    (PowerType) iter->terms[0].power);
+                  Pow((ProductType) x,
+                      (PowerType) iter->terms[0].power);
     }
     return value;
   }
@@ -215,7 +215,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    */
   template <typename T>
   typename Product<CoefficientType, T>::type EvaluateMultivariate(
-          const std::map<VarType, T> &var_values) const {
+      const std::map<VarType, T> &var_values) const {
     typedef typename std::remove_const<
       typename Product<CoefficientType, T>::type>::type ProductType;
     ProductType value = 0;
@@ -243,7 +243,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * TaylorVarXd correspond to.
    */
   Drake::TaylorVarXd EvaluateMultivariate(
-          const std::map<VarType, Drake::TaylorVarXd> &var_values) const {
+      const std::map<VarType, Drake::TaylorVarXd> &var_values) const {
     Drake::TaylorVarXd value(0);
     for (const Monomial& monomial : monomials_) {
       Drake::TaylorVarXd monomial_value(monomial.coefficient);
@@ -266,7 +266,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * replaced with its value and constants appropriately combined.
    */
   Polynomial EvaluatePartial(
-          const std::map<VarType, CoefficientType> &var_values) const;
+      const std::map<VarType, CoefficientType> &var_values) const;
 
   /// Replaces all instances of variable orig with replacement.
   void Subs(const VarType &orig, const VarType &replacement);
@@ -460,8 +460,8 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
   using enable_if_t = typename std::enable_if<B, T>::type;
   template <typename Base>
   static Base Pow(
-          const enable_if_t<std::is_arithmetic<Base>::value, Base> &base,
-          const PowerType &exponent) {
+      const enable_if_t<std::is_arithmetic<Base>::value, Base> &base,
+      const PowerType &exponent) {
     return std::pow(base, exponent);
   }
 

--- a/drake/util/Polynomial.h
+++ b/drake/util/Polynomial.h
@@ -14,8 +14,8 @@
 #include "drake/core/Gradient.h"
 #include "drake/drakePolynomial_export.h"
 
-/// A scalar multi-variate polynomial, modeled after the msspoly in spotless.
-/**
+/** A scalar multi-variate polynomial, modeled after the msspoly in spotless.
+ *
  * Polynomial represents a list of additive Monomials, each one of which is a
  * product of a constant coefficient (of _CoefficientType, which by default is
  * double) and any number of distinct Terms (variables raised to positive
@@ -73,7 +73,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
     }
   };
 
-  /// \brief An additive atom of a Polynomial: The product of any number of
+  /// An additive atom of a Polynomial: The product of any number of
   /// Terms and a coefficient.
   class DRAKEPOLYNOMIAL_EXPORT Monomial {
    public:
@@ -91,24 +91,24 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
               ((coefficient == other.coefficient) && (terms < other.terms)));
     }
 
-    int getDegree() const;
-    int getDegreeOf(VarType var) const;
-    bool hasSameExponents(const Monomial& other) const;
+    int GetDegree() const;
+    int GetDegreeOf(VarType var) const;
+    bool HasSameExponents(const Monomial &other) const;
 
     /// Factors this by other; returns 0 iff other does not divide this.
-    Monomial factor(const Monomial& divisor) const;
+    Monomial Factor(const Monomial &divisor) const;
   };
 
  private:
   /// The Monomial atoms of the Polynomial.
-  std::vector<Monomial> monomials;
+  std::vector<Monomial> monomials_;
 
   /// True iff only 0 or 1 distinct variables appear in the Polynomial.
-  bool is_univariate;
+  bool is_univariate_;
 
  public:
   /// Construct the vacuous polynomial, "0".
-  Polynomial(void) : is_univariate(true) {}
+  Polynomial(void) : is_univariate_(true) {}
 
   /// Construct a Polynomial of a single constant. e.g. "5".
   // This is required for some Eigen operations when used in a
@@ -134,7 +134,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
   /// of coefficients for the constant, x, x**2, x**3... Monomials.
   template <typename Derived>
   explicit Polynomial(Eigen::MatrixBase<Derived> const& coefficients) {
-    VarType v = variableNameToId("t");
+    VarType v = VariableNameToId("t");
     for (int i = 0; i < coefficients.size(); i++) {
       Monomial m;
       m.coefficient = coefficients(i);
@@ -144,37 +144,37 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
         t.power = i;
         m.terms.push_back(t);
       }
-      monomials.push_back(m);
+      monomials_.push_back(m);
     }
-    is_univariate = true;
+    is_univariate_ = true;
   }
 
   /// Returns the number of unique Monomials (and thus the number of
   /// coefficients) in this Polynomial.
-  int getNumberOfCoefficients() const;
+  int GetNumberOfCoefficients() const;
 
-  /// Returns the highest degree of any Monomial in this Polynomial.
-  /**
+  /** Returns the highest degree of any Monomial in this Polynomial.
+   *
    * The degree of a multivariate Monomial is the product of the degrees of
    * each of its terms. */
-  int getDegree() const;
+  int GetDegree() const;
 
   /// Returns true iff this is a sum of terms of degree 1, plus a constant.
-  bool isAffine() const;
+  bool IsAffine() const;
 
   /// If the polynomial is "simple" -- e.g. just a single term with
   /// coefficient 1 -- then returns that variable; otherwise returns 0.
-  VarType getSimpleVariable() const;
+  VarType GetSimpleVariable() const;
 
-  const std::vector<Monomial>& getMonomials() const;
+  const std::vector<Monomial>& GetMonomials() const;
 
-  Eigen::Matrix<CoefficientType, Eigen::Dynamic, 1> getCoefficients() const;
+  Eigen::Matrix<CoefficientType, Eigen::Dynamic, 1> GetCoefficients() const;
 
   /// Returns a set of all of the variables present in this Polynomial.
-  std::set<VarType> getVariables() const;
+  std::set<VarType> GetVariables() const;
 
-  /// Evaluate a univariate Polynomial at a specific point.
-  /**
+  /** Evaluate a univariate Polynomial at a specific point.
+   *
    * Evaluates a univariate Polynomial at the given x.  Throws an
    * exception of this Polynomial is not univariate.
    *
@@ -182,29 +182,29 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * be different from both CoefficientsType and RealScalar)
    */
   template <typename T>
-  typename Product<CoefficientType, T>::type evaluateUnivariate(
-      const T& x) const {
+  typename Product<CoefficientType, T>::type EvaluateUnivariate(
+          const T &x) const {
     typedef typename Product<CoefficientType, T>::type ProductType;
 
-    if (!is_univariate)
+    if (!is_univariate_)
       throw std::runtime_error(
           "this method can only be used for univariate polynomials");
     ProductType value = 0;
     for (typename std::vector<Monomial>::const_iterator iter =
-             monomials.begin();
-         iter != monomials.end(); iter++) {
+             monomials_.begin();
+         iter != monomials_.end(); iter++) {
       if (iter->terms.empty())
         value += iter->coefficient;
       else
         value += iter->coefficient *
-                 pow((ProductType)x,
-                     (PowerType)iter->terms[0].power);
+                Pow((ProductType) x,
+                    (PowerType) iter->terms[0].power);
     }
     return value;
   }
 
-  /// Evaluate a multivariate Polynomial at a specific point.
-  /**
+  /** Evaluate a multivariate Polynomial at a specific point.
+   *
    * Evaluates a Polynomial with the given values for each variable.  Throws
    * std::out_of_range if the Polynomial contains variables for which values
    * were not provided.
@@ -214,12 +214,12 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * CoefficientsType or RealScalar)
    */
   template <typename T>
-  typename Product<CoefficientType, T>::type evaluateMultivariate(
-      const std::map<VarType, T>& var_values) const {
+  typename Product<CoefficientType, T>::type EvaluateMultivariate(
+          const std::map<VarType, T> &var_values) const {
     typedef typename std::remove_const<
       typename Product<CoefficientType, T>::type>::type ProductType;
     ProductType value = 0;
-    for (const Monomial& monomial : monomials) {
+    for (const Monomial& monomial : monomials_) {
       ProductType monomial_value = monomial.coefficient;
       for (const Term& term : monomial.terms) {
         monomial_value *= std::pow(
@@ -231,9 +231,9 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
     return value;
   }
 
-  /// Specialization of evaluateMultivariate on TaylorVarXd.
-  /**
-   * Specialize evaluateMultivariate on TaylorVarXd because Eigen autodiffs
+  /** Specialization of EvaluateMultivariate on TaylorVarXd.
+   *
+   * Specialize EvaluateMultivariate on TaylorVarXd because Eigen autodiffs
    * implement a confusing subset of operators and conversions that makes a
    * strictly generic approach too confusing and unreadable.
    *
@@ -242,10 +242,10 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * no knowledge of what partial derivative terms the indices of a given
    * TaylorVarXd correspond to.
    */
-  Drake::TaylorVarXd evaluateMultivariate(
-      const std::map<VarType, Drake::TaylorVarXd>& var_values) const {
+  Drake::TaylorVarXd EvaluateMultivariate(
+          const std::map<VarType, Drake::TaylorVarXd> &var_values) const {
     Drake::TaylorVarXd value(0);
-    for (const Monomial& monomial : monomials) {
+    for (const Monomial& monomial : monomials_) {
       Drake::TaylorVarXd monomial_value(monomial.coefficient);
       for (const Term& term : monomial.terms) {
         monomial_value *= pow(var_values.at(term.var), term.power);
@@ -255,34 +255,34 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
     return value;
   }
 
-  /// Substitute values for some but not necessarily all variables of a
-  /// polynomial.
-  /**
-   * Analogous to evaluateMultivariate, but:
+  /** Substitute values for some but not necessarily all variables of a
+   * Polynomial.
+   *
+   * Analogous to EvaluateMultivariate, but:
    *  (1) Restricted to CoefficientType, and
    *  (2) Need not map every variable in var_values.
    *
    * Returns a Polynomial in which each variable in var_values has been
    * replaced with its value and constants appropriately combined.
    */
-  Polynomial evaluatePartial(
-      const std::map<VarType, CoefficientType>& var_values) const;
+  Polynomial EvaluatePartial(
+          const std::map<VarType, CoefficientType> &var_values) const;
 
   /// Replaces all instances of variable orig with replacement.
-  void subs(const VarType& orig, const VarType& replacement);
+  void Subs(const VarType &orig, const VarType &replacement);
 
-  /// Takes the derivative of this (univariate) Polynomial.
-  /**
+  /** Takes the derivative of this (univariate) Polynomial.
+   *
    * Returns a new Polynomial that is the derivative of this one in its sole
    * variable.  Throws an exception of this Polynomial is not univariate.
    *
    * If derivative_order is given, takes the nth derivative of this
    * Polynomial.
    */
-  Polynomial derivative(unsigned int derivative_order = 1) const;
+  Polynomial Derivative(unsigned int derivative_order = 1) const;
 
-  /// Takes the integral of this (univariate, non-constant) Polynomial.
-  /**
+  /** Takes the integral of this (univariate, non-constant) Polynomial.
+   *
    * Returns a new Polynomial that is the indefinite integral of this one in
    * its sole variable.  Throws an exception of this Polynomial is not
    * univariate, or if it has no variables.
@@ -290,7 +290,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * If integration_constant is given, adds that constant as the constant
    * term (zeroth-order coefficient) of the resulting Polynomial.
    */
-  Polynomial integral(const CoefficientType& integration_constant = 0.0) const;
+  Polynomial Integral(const CoefficientType &integration_constant = 0.0) const;
 
   bool operator==(const Polynomial& other) const;
 
@@ -363,24 +363,24 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
   /// not reflect any sort of mathematical total order.
   bool operator<(const Polynomial& other) const {
     // Just delegate to the default vector std::lexicographical_compare.
-    return monomials < other.monomials;
+    return monomials_ < other.monomials_;
   }
 
-  /// Returns the roots of this (univariate) Polynomial.
-  /**
+  /** Returns the roots of this (univariate) Polynomial.
+   *
    * Returns the roots of a univariate Polynomial as an Eigen column vector of
    * complex numbers whose components are of the RealScalar type.  Throws an
    * exception of this Polynomial is not univariate.
    */
-  RootsType roots() const;
+  RootsType Roots() const;
 
-  /// Checks if a (univariate) Polynomial is approximately equal to this one.
-  /**
+  /** Checks if a (univariate) Polynomial is approximately equal to this one.
+   *
    * Checks that every coefficient of other is within tol of the
    * corresponding coefficient of this Polynomial.  Throws an exception if
    * either Polynomial is not univariate.
    */
-  bool isApprox(const Polynomial& other, const RealScalar& tol) const;
+  bool IsApprox(const Polynomial &other, const RealScalar &tol) const;
 
   friend std::ostream& operator<<(std::ostream& os, const Monomial& m) {
     //    if (m.coefficient == 0) return os;
@@ -399,7 +399,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
         os << '*';
       else
         print_star = true;
-      os << idToVariableName(iter->var);
+      os << IdToVariableName(iter->var);
       if (iter->power != 1) {
         os << "^" << iter->power;
       }
@@ -408,16 +408,16 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
   }
 
   friend std::ostream& operator<<(std::ostream& os, const Polynomial& poly) {
-    if (poly.monomials.empty()) {
+    if (poly.monomials_.empty()) {
       os << "0";
       return os;
     }
 
     for (typename std::vector<Monomial>::const_iterator iter =
-             poly.monomials.begin();
-         iter != poly.monomials.end(); iter++) {
+             poly.monomials_.begin();
+         iter != poly.monomials_.end(); iter++) {
       os << *iter;
-      if (iter + 1 != poly.monomials.end() && (iter + 1)->coefficient != -1)
+      if (iter + 1 != poly.monomials_.end() && (iter + 1)->coefficient != -1)
         os << '+';
     }
     return os;
@@ -425,7 +425,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
 
   /// Obtains a matrix of random unvariate Polynomials of the specified size.
   static Eigen::Matrix<Polynomial, Eigen::Dynamic, Eigen::Dynamic>
-  randomPolynomialMatrix(Eigen::Index num_coefficients_per_polynomial,
+  RandomPolynomialMatrix(Eigen::Index num_coefficients_per_polynomial,
                          Eigen::Index rows, Eigen::Index cols) {
     Eigen::Matrix<Polynomial, Eigen::Dynamic, Eigen::Dynamic> mat(rows, cols);
     for (Eigen::Index row = 0; row < mat.rows(); ++row) {
@@ -441,32 +441,32 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
 
   //@{
   /** Variable name/ID conversion facility. */
-  static bool isValidVariableName(const std::string name);
+  static bool IsValidVariableName(const std::string name);
 
-  static VarType variableNameToId(const std::string name,
+  static VarType VariableNameToId(const std::string name,
                                   const unsigned int m = 1);
 
-  static std::string idToVariableName(const VarType id);
+  static std::string IdToVariableName(const VarType id);
   //@}
 
  private:
   //@{
-  /// Local version of pow to deal with autodiff.
-  /**
+  /** Local version of pow to deal with autodiff.
+   *
    * A version of std::pow that uses std::pow for arithmetic types and
    * repeated multiplication for non-arithmetic types (e.g., autodiff).
    */
   template <bool B, typename T = void>
   using enable_if_t = typename std::enable_if<B, T>::type;
   template <typename Base>
-  static Base pow(
-      const enable_if_t<std::is_arithmetic<Base>::value, Base>& base,
-      const PowerType& exponent) {
+  static Base Pow(
+          const enable_if_t<std::is_arithmetic<Base>::value, Base> &base,
+          const PowerType &exponent) {
     return std::pow(base, exponent);
   }
 
   template <typename Base>
-  static Base pow(const Base& base, const PowerType& exponent) {
+  static Base Pow(const Base &base, const PowerType &exponent) {
     Base result = base;
     for (int i = 1; i < exponent; i++) {
       result = result * base;
@@ -476,7 +476,7 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
   //@}
 
   /// Sorts through Monomial list and merges any that have the same powers.
-  void makeMonomialsUnique(void);
+  void MakeMonomialsUnique(void);
 };
 
 template <typename CoefficientType, int Rows, int Cols>

--- a/drake/util/TrigPoly.h
+++ b/drake/util/TrigPoly.h
@@ -247,7 +247,7 @@ class TrigPoly {
    * error.
    */
   virtual TrigPoly<CoefficientType> EvaluatePartial(
-          const std::map<VarType, CoefficientType> &var_values) const {
+      const std::map<VarType, CoefficientType> &var_values) const {
     std::map<VarType, CoefficientType> var_values_with_sincos = var_values;
     for (const auto& sin_cos_item : sin_cos_map_) {
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.s));

--- a/drake/util/TrigPoly.h
+++ b/drake/util/TrigPoly.h
@@ -7,8 +7,8 @@
 #include "drake/common/drake_assert.h"
 #include "drake/util/Polynomial.h"
 
-/// A scalar multi-variate polynomial containing sines and cosines.
-/**
+/** A scalar multi-variate polynomial containing sines and cosines.
+ *
  * TrigPoly represents a Polynomial some of whose variables actually represent
  * the sines or cosines of other variables.  Sines and cosines of first-order
  * polynomials (affine combinations of variables) are decomposed into
@@ -63,20 +63,20 @@ class TrigPoly {
 
   /// Constructs a constant TrigPoly.
   // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
-  TrigPoly(const CoefficientType& scalar) : poly(scalar) {}
+  TrigPoly(const CoefficientType& scalar) : poly_(scalar) {}
 
   /**
    * Constructs a TrigPoly on the associated Polynomial p with no associated
    * trigonometric correspondences.
    */
-  explicit TrigPoly(const PolyType& p) : poly(p) {}
+  explicit TrigPoly(const PolyType& p) : poly_(p) {}
 
   /**
    * Constructs a TrigPoly on the associated Polynomial p, but with the
    * additional information about sin and cos relations in _sin_cos_map.
    */
   TrigPoly(const PolyType& p, const SinCosMap& _sin_cos_map)
-      : poly(p), sin_cos_map(_sin_cos_map) {
+      : poly_(p), sin_cos_map_(_sin_cos_map) {
     // The provided _sin_cos_map might have extraneous entries; clip them.
     std::set<VarType> vars_in_use = p.GetVariables();
     std::set<VarType> vars_seen_in_map;
@@ -84,7 +84,7 @@ class TrigPoly {
       if (!(vars_in_use.count(sin_cos_entry.first) ||
             vars_in_use.count(sin_cos_entry.second.c) ||
             vars_in_use.count(sin_cos_entry.second.s))) {
-        sin_cos_map.erase(sin_cos_entry.first);
+        sin_cos_map_.erase(sin_cos_entry.first);
       }
       DRAKE_ASSERT(!vars_seen_in_map.count(sin_cos_entry.first));
       DRAKE_ASSERT(!vars_seen_in_map.count(sin_cos_entry.second.s));
@@ -104,41 +104,41 @@ class TrigPoly {
       throw std::runtime_error(
           "q, s, and c must all be simple polynomials (in the msspoly sense)");
 
-    poly = q;
+    poly_ = q;
     SinCosVars sc;
     sc.s = s.GetSimpleVariable();
     sc.c = c.GetSimpleVariable();
-    sin_cos_map[q.GetSimpleVariable()] = sc;
+    sin_cos_map_[q.GetSimpleVariable()] = sc;
   }
 
   /// Returns the underlying Polynomial for this TrigPoly.
-  const PolyType& getPolynomial(void) const { return poly; }
+  const PolyType& poly(void) const { return poly_; }
 
   /// Returns the SinCosMap for this TrigPoly.
-  const SinCosMap& getSinCosMap(void) const { return sin_cos_map; }
+  const SinCosMap& sin_cos_map(void) const { return sin_cos_map_; }
 
-  /// A version of sin that handles TrigPoly arguments through ADL.
-  /**
+  /** A version of sin that handles TrigPoly arguments through ADL.
+   *
    * Implements sin(x) for a TrigPoly x.
    *
    * x must be of degree 0 or 1, and must contain only variables that have
    * entries in its SinCosMap.
    */
   friend TrigPoly sin(const TrigPoly& p) {
-    if (p.poly.GetDegree() > 1)
+    if (p.poly_.GetDegree() > 1)
       throw std::runtime_error(
           "sin of polynomials with degree > 1 is not supported");
 
-    const std::vector<typename PolyType::Monomial>& m = p.poly.GetMonomials();
+    const std::vector<typename PolyType::Monomial>& m = p.poly_.GetMonomials();
 
     if (m.size() == 1) {
       TrigPoly ret = p;
       if (m[0].terms.size() == 0) {  // then it's a constant
-        ret.poly = Polynomial<CoefficientType>(sin(m[0].coefficient));
+        ret.poly_ = Polynomial<CoefficientType>(sin(m[0].coefficient));
       } else {
         typename SinCosMap::iterator iter =
-            ret.sin_cos_map.find(m[0].terms[0].var);
-        if (iter == ret.sin_cos_map.end())
+            ret.sin_cos_map_.find(m[0].terms[0].var);
+        if (iter == ret.sin_cos_map_.end())
           throw std::runtime_error(
               "tried taking the sin of a variable that does not exist in my "
               "sin_cos_map");
@@ -148,7 +148,7 @@ class TrigPoly {
               "Drake:TrigPoly:PleaseImplementMe.  need to handle this case "
               "(like I do in the matlab version");
 
-        ret.poly.Subs(m[0].terms[0].var, iter->second.s);
+        ret.poly_.Subs(m[0].terms[0].var, iter->second.s);
       }
       return ret;
     }
@@ -157,7 +157,7 @@ class TrigPoly {
     // sin(a+b+...) = sin(a)cos(b+...) + cos(a)sin(b+...)
     Polynomial<CoefficientType> pa(m[0].coefficient, m[0].terms),
         pb(m.begin() + 1, m.end());
-    TrigPoly a(pa, p.sin_cos_map), b(pb, p.sin_cos_map);
+    TrigPoly a(pa, p.sin_cos_map_), b(pb, p.sin_cos_map_);
     return sin(a) * cos(b) + cos(a) * sin(b);
   }
 
@@ -169,20 +169,20 @@ class TrigPoly {
    * entries in its SinCosMap.
    */
   friend TrigPoly cos(const TrigPoly& p) {
-    if (p.poly.GetDegree() > 1)
+    if (p.poly_.GetDegree() > 1)
       throw std::runtime_error(
           "cos of polynomials with degree > 1 is not supported");
 
-    const std::vector<typename PolyType::Monomial>& m = p.poly.GetMonomials();
+    const std::vector<typename PolyType::Monomial>& m = p.poly_.GetMonomials();
 
     if (m.size() == 1) {
       TrigPoly ret = p;
       if (m[0].terms.size() == 0) {  // then it's a constant
-        ret.poly = Polynomial<CoefficientType>(cos(m[0].coefficient));
+        ret.poly_ = Polynomial<CoefficientType>(cos(m[0].coefficient));
       } else {
         typename SinCosMap::iterator iter =
-            ret.sin_cos_map.find(m[0].terms[0].var);
-        if (iter == ret.sin_cos_map.end())
+            ret.sin_cos_map_.find(m[0].terms[0].var);
+        if (iter == ret.sin_cos_map_.end())
           throw std::runtime_error(
               "tried taking the sin of a variable that does not exist in my "
               "sin_cos_map");
@@ -192,7 +192,7 @@ class TrigPoly {
               "Drake:TrigPoly:PleaseImplementMe.  need to handle this case "
               "(like I do in the matlab version");
 
-        ret.poly.Subs(m[0].terms[0].var, iter->second.c);
+        ret.poly_.Subs(m[0].terms[0].var, iter->second.c);
         if (m[0].coefficient == (CoefficientType)-1) {
           ret *= -1;
         }  // cos(-q) => cos(q) => c (instead of -c)
@@ -204,14 +204,14 @@ class TrigPoly {
     // cos(a+b+...) = cos(a)cos(b+...) - sin(a)sin(b+...)
     Polynomial<CoefficientType> pa(m[0].coefficient, m[0].terms),
         pb(m.begin() + 1, m.end());
-    TrigPoly a(pa, p.sin_cos_map), b(pb, p.sin_cos_map);
+    TrigPoly a(pa, p.sin_cos_map_), b(pb, p.sin_cos_map_);
     return cos(a) * cos(b) - sin(a) * sin(b);
   }
 
   /// Returns all of the base (non-sin/cos) variables in this TrigPoly.
-  std::set<VarType> getVariables() const {
-    std::set<VarType> vars = poly.GetVariables();
-    for (const auto& sin_cos_item : sin_cos_map) {
+  std::set<VarType> GetVariables() const {
+    std::set<VarType> vars = poly_.GetVariables();
+    for (const auto& sin_cos_item : sin_cos_map_) {
       vars.insert(sin_cos_item.first);
       vars.erase(sin_cos_item.second.s);
       vars.erase(sin_cos_item.second.c);
@@ -219,8 +219,8 @@ class TrigPoly {
     return vars;
   }
 
-  /// Given a value for every variable in this expression, evaluates it.
-  /**
+  /** Given a value for every variable in this expression, evaluates it.
+   *
    * By analogy with Polynomial::EvaluateMultivariate().  Values must be
    * supplied for all base variables; supplying values for sin/cos variables
    * is an error.
@@ -229,7 +229,7 @@ class TrigPoly {
   typename Product<CoefficientType, T>::type EvaluateMultivariate(
       const std::map<VarType, T>& var_values) const {
     std::map<VarType, T> all_var_values = var_values;
-    for (const auto& sin_cos_item : sin_cos_map) {
+    for (const auto& sin_cos_item : sin_cos_map_) {
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.s));
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.c));
       all_var_values[sin_cos_item.second.s] =
@@ -237,19 +237,19 @@ class TrigPoly {
       all_var_values[sin_cos_item.second.c] =
           std::cos(var_values.at(sin_cos_item.first));
     }
-    return poly.EvaluateMultivariate(all_var_values);
+    return poly_.EvaluateMultivariate(all_var_values);
   }
 
-  /// Partially evaluates this expression, returning the resulting expression.
-  /**
+  /** Partially evaluates this expression, returning the resulting expression.
+   *
    * By analogy with Polynomial::evaluatePartial.  Values must be supplied for
    * all base variables only; supplying values for sin/cos variables is an
    * error.
    */
-  virtual TrigPoly<CoefficientType> evaluatePartial(
-      const std::map<VarType, CoefficientType>& var_values) const {
+  virtual TrigPoly<CoefficientType> EvaluatePartial(
+          const std::map<VarType, CoefficientType> &var_values) const {
     std::map<VarType, CoefficientType> var_values_with_sincos = var_values;
-    for (const auto& sin_cos_item : sin_cos_map) {
+    for (const auto& sin_cos_item : sin_cos_map_) {
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.s));
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.c));
       if (!var_values.count(sin_cos_item.first)) {
@@ -260,7 +260,7 @@ class TrigPoly {
       var_values_with_sincos[sin_cos_item.second.c] =
           std::cos(var_values.at(sin_cos_item.first));
     }
-    return TrigPoly(poly.EvaluatePartial(var_values_with_sincos), sin_cos_map);
+    return TrigPoly(poly_.EvaluatePartial(var_values_with_sincos), sin_cos_map_);
   }
 
   /// Compares two TrigPolys for equality.
@@ -275,44 +275,44 @@ class TrigPoly {
    * future.
    */
   bool operator==(const TrigPoly& other) const {
-    return (poly == other.poly) && (sin_cos_map == other.sin_cos_map);
+    return (poly_ == other.poly_) && (sin_cos_map_ == other.sin_cos_map_);
   }
 
   TrigPoly& operator+=(const TrigPoly& other) {
-    poly += other.poly;
-    sin_cos_map.insert(other.sin_cos_map.begin(), other.sin_cos_map.end());
+    poly_ += other.poly_;
+    sin_cos_map_.insert(other.sin_cos_map_.begin(), other.sin_cos_map_.end());
     return *this;
   }
 
   TrigPoly& operator-=(const TrigPoly& other) {
-    poly -= other.poly;
-    sin_cos_map.insert(other.sin_cos_map.begin(), other.sin_cos_map.end());
+    poly_ -= other.poly_;
+    sin_cos_map_.insert(other.sin_cos_map_.begin(), other.sin_cos_map_.end());
     return *this;
   }
 
   TrigPoly& operator*=(const TrigPoly& other) {
-    poly *= other.poly;
-    sin_cos_map.insert(other.sin_cos_map.begin(), other.sin_cos_map.end());
+    poly_ *= other.poly_;
+    sin_cos_map_.insert(other.sin_cos_map_.begin(), other.sin_cos_map_.end());
     return *this;
   }
 
   TrigPoly& operator+=(const CoefficientType& scalar) {
-    poly += scalar;
+    poly_ += scalar;
     return *this;
   }
 
   TrigPoly& operator-=(const CoefficientType& scalar) {
-    poly -= scalar;
+    poly_ -= scalar;
     return *this;
   }
 
   TrigPoly& operator*=(const CoefficientType& scalar) {
-    poly *= scalar;
+    poly_ *= scalar;
     return *this;
   }
 
   TrigPoly& operator/=(const CoefficientType& scalar) {
-    poly /= scalar;
+    poly_ /= scalar;
     return *this;
   }
 
@@ -388,10 +388,10 @@ class TrigPoly {
 
   friend std::ostream& operator<<(std::ostream& os,
                                   const TrigPoly<CoefficientType>& tp) {
-    os << tp.poly;
-    if (tp.sin_cos_map.size()) {
+    os << tp.poly_;
+    if (tp.sin_cos_map_.size()) {
       os << " where ";
-      for (const auto& k_v_pair : tp.sin_cos_map) {
+      for (const auto& k_v_pair : tp.sin_cos_map_) {
         std::string var = PolyType::IdToVariableName(k_v_pair.first);
         std::string sin = PolyType::IdToVariableName(k_v_pair.second.s);
         std::string cos = PolyType::IdToVariableName(k_v_pair.second.c);
@@ -403,8 +403,8 @@ class TrigPoly {
   }
 
  private:
-  PolyType poly;
-  SinCosMap sin_cos_map;
+  PolyType poly_;
+  SinCosMap sin_cos_map_;
 };
 
 template <typename CoefficientType, int Rows, int Cols>
@@ -414,7 +414,7 @@ std::ostream& operator<<(
   Eigen::Matrix<Polynomial<CoefficientType>, Rows, Cols> poly_mat(
       tp_mat.rows(), tp_mat.cols());
   for (int i = 0; i < poly_mat.size(); i++) {
-    poly_mat(i) = tp_mat(i).getPolynomial();
+    poly_mat(i) = tp_mat(i).poly();
   }
   os << poly_mat;
   return os;

--- a/drake/util/TrigPoly.h
+++ b/drake/util/TrigPoly.h
@@ -78,7 +78,7 @@ class TrigPoly {
   TrigPoly(const PolyType& p, const SinCosMap& _sin_cos_map)
       : poly(p), sin_cos_map(_sin_cos_map) {
     // The provided _sin_cos_map might have extraneous entries; clip them.
-    std::set<VarType> vars_in_use = p.getVariables();
+    std::set<VarType> vars_in_use = p.GetVariables();
     std::set<VarType> vars_seen_in_map;
     for (const auto& sin_cos_entry : _sin_cos_map) {
       if (!(vars_in_use.count(sin_cos_entry.first) ||
@@ -100,15 +100,15 @@ class TrigPoly {
    * that the variables s and c represent the sine and cosine of q.
    */
   TrigPoly(const PolyType& q, const PolyType& s, const PolyType& c) {
-    if ((q.getDegree() != 1) || (s.getDegree() != 1) || (c.getDegree() != 1))
+    if ((q.GetDegree() != 1) || (s.GetDegree() != 1) || (c.GetDegree() != 1))
       throw std::runtime_error(
           "q, s, and c must all be simple polynomials (in the msspoly sense)");
 
     poly = q;
     SinCosVars sc;
-    sc.s = s.getSimpleVariable();
-    sc.c = c.getSimpleVariable();
-    sin_cos_map[q.getSimpleVariable()] = sc;
+    sc.s = s.GetSimpleVariable();
+    sc.c = c.GetSimpleVariable();
+    sin_cos_map[q.GetSimpleVariable()] = sc;
   }
 
   /// Returns the underlying Polynomial for this TrigPoly.
@@ -125,11 +125,11 @@ class TrigPoly {
    * entries in its SinCosMap.
    */
   friend TrigPoly sin(const TrigPoly& p) {
-    if (p.poly.getDegree() > 1)
+    if (p.poly.GetDegree() > 1)
       throw std::runtime_error(
           "sin of polynomials with degree > 1 is not supported");
 
-    const std::vector<typename PolyType::Monomial>& m = p.poly.getMonomials();
+    const std::vector<typename PolyType::Monomial>& m = p.poly.GetMonomials();
 
     if (m.size() == 1) {
       TrigPoly ret = p;
@@ -148,7 +148,7 @@ class TrigPoly {
               "Drake:TrigPoly:PleaseImplementMe.  need to handle this case "
               "(like I do in the matlab version");
 
-        ret.poly.subs(m[0].terms[0].var, iter->second.s);
+        ret.poly.Subs(m[0].terms[0].var, iter->second.s);
       }
       return ret;
     }
@@ -169,11 +169,11 @@ class TrigPoly {
    * entries in its SinCosMap.
    */
   friend TrigPoly cos(const TrigPoly& p) {
-    if (p.poly.getDegree() > 1)
+    if (p.poly.GetDegree() > 1)
       throw std::runtime_error(
           "cos of polynomials with degree > 1 is not supported");
 
-    const std::vector<typename PolyType::Monomial>& m = p.poly.getMonomials();
+    const std::vector<typename PolyType::Monomial>& m = p.poly.GetMonomials();
 
     if (m.size() == 1) {
       TrigPoly ret = p;
@@ -192,7 +192,7 @@ class TrigPoly {
               "Drake:TrigPoly:PleaseImplementMe.  need to handle this case "
               "(like I do in the matlab version");
 
-        ret.poly.subs(m[0].terms[0].var, iter->second.c);
+        ret.poly.Subs(m[0].terms[0].var, iter->second.c);
         if (m[0].coefficient == (CoefficientType)-1) {
           ret *= -1;
         }  // cos(-q) => cos(q) => c (instead of -c)
@@ -210,7 +210,7 @@ class TrigPoly {
 
   /// Returns all of the base (non-sin/cos) variables in this TrigPoly.
   std::set<VarType> getVariables() const {
-    std::set<VarType> vars = poly.getVariables();
+    std::set<VarType> vars = poly.GetVariables();
     for (const auto& sin_cos_item : sin_cos_map) {
       vars.insert(sin_cos_item.first);
       vars.erase(sin_cos_item.second.s);
@@ -221,12 +221,12 @@ class TrigPoly {
 
   /// Given a value for every variable in this expression, evaluates it.
   /**
-   * By analogy with Polynomial::evaluateMultivariate().  Values must be
+   * By analogy with Polynomial::EvaluateMultivariate().  Values must be
    * supplied for all base variables; supplying values for sin/cos variables
    * is an error.
    */
   template <typename T>
-  typename Product<CoefficientType, T>::type evaluateMultivariate(
+  typename Product<CoefficientType, T>::type EvaluateMultivariate(
       const std::map<VarType, T>& var_values) const {
     std::map<VarType, T> all_var_values = var_values;
     for (const auto& sin_cos_item : sin_cos_map) {
@@ -237,7 +237,7 @@ class TrigPoly {
       all_var_values[sin_cos_item.second.c] =
           std::cos(var_values.at(sin_cos_item.first));
     }
-    return poly.evaluateMultivariate(all_var_values);
+    return poly.EvaluateMultivariate(all_var_values);
   }
 
   /// Partially evaluates this expression, returning the resulting expression.
@@ -260,7 +260,7 @@ class TrigPoly {
       var_values_with_sincos[sin_cos_item.second.c] =
           std::cos(var_values.at(sin_cos_item.first));
     }
-    return TrigPoly(poly.evaluatePartial(var_values_with_sincos), sin_cos_map);
+    return TrigPoly(poly.EvaluatePartial(var_values_with_sincos), sin_cos_map);
   }
 
   /// Compares two TrigPolys for equality.
@@ -392,9 +392,9 @@ class TrigPoly {
     if (tp.sin_cos_map.size()) {
       os << " where ";
       for (const auto& k_v_pair : tp.sin_cos_map) {
-        std::string var = PolyType::idToVariableName(k_v_pair.first);
-        std::string sin = PolyType::idToVariableName(k_v_pair.second.s);
-        std::string cos = PolyType::idToVariableName(k_v_pair.second.c);
+        std::string var = PolyType::IdToVariableName(k_v_pair.first);
+        std::string sin = PolyType::IdToVariableName(k_v_pair.second.s);
+        std::string cos = PolyType::IdToVariableName(k_v_pair.second.c);
         os << sin << "=sin(" << var << "), "
            << cos << "=cos(" << var << "), ";
       }

--- a/drake/util/TrigPoly.h
+++ b/drake/util/TrigPoly.h
@@ -247,7 +247,7 @@ class TrigPoly {
    * error.
    */
   virtual TrigPoly<CoefficientType> EvaluatePartial(
-      const std::map<VarType, CoefficientType> &var_values) const {
+      const std::map<VarType, CoefficientType>& var_values) const {
     std::map<VarType, CoefficientType> var_values_with_sincos = var_values;
     for (const auto& sin_cos_item : sin_cos_map_) {
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.s));
@@ -260,7 +260,8 @@ class TrigPoly {
       var_values_with_sincos[sin_cos_item.second.c] =
           std::cos(var_values.at(sin_cos_item.first));
     }
-    return TrigPoly(poly_.EvaluatePartial(var_values_with_sincos), sin_cos_map_);
+    return TrigPoly(poly_.EvaluatePartial(var_values_with_sincos),
+                    sin_cos_map_);
   }
 
   /// Compares two TrigPolys for equality.

--- a/drake/util/drakeMexUtil.cpp
+++ b/drake/util/drakeMexUtil.cpp
@@ -375,9 +375,9 @@ trigPolyToEigen(const mxArray* trigpoly) {
   TrigPolyd::SinCosMap m;
   for (int i = 0; i < q.size(); i++) {
     TrigPolyd::SinCosVars sc;
-    sc.s = s(i).getSimpleVariable();
-    sc.c = c(i).getSimpleVariable();
-    m[q(i).getSimpleVariable()] = sc;
+    sc.s = s(i).GetSimpleVariable();
+    sc.c = c(i).GetSimpleVariable();
+    m[q(i).GetSimpleVariable()] = sc;
   }
 
   // todo: feels very inefficient (one copy of the sincosmap for every element

--- a/drake/util/drakeMexUtil.h
+++ b/drake/util/drakeMexUtil.h
@@ -207,7 +207,7 @@ template <int _Rows, int _Cols>
 mxArray* eigenToMSSPoly(const Eigen::Matrix<Polynomiald, _Rows, _Cols>& poly) {
   size_t num_monomials = 0, max_terms = 0;
   for (int i = 0; i < poly.size(); i++) {
-    auto monomials = poly(i).getMonomials();
+    auto monomials = poly(i).GetMonomials();
     num_monomials += monomials.size();
     for (std::vector<Polynomiald::Monomial>::const_iterator iter =
              monomials.begin();
@@ -226,7 +226,7 @@ mxArray* eigenToMSSPoly(const Eigen::Matrix<Polynomiald, _Rows, _Cols>& poly) {
   int index = 0;
   for (int i = 0; i < poly.rows(); i++) {
     for (int j = 0; j < poly.cols(); j++) {
-      auto monomials = poly(i, j).getMonomials();
+      auto monomials = poly(i, j).GetMonomials();
       for (std::vector<Polynomiald::Monomial>::const_iterator iter =
                monomials.begin();
            iter != monomials.end(); iter++) {

--- a/drake/util/drakeMexUtil.h
+++ b/drake/util/drakeMexUtil.h
@@ -263,9 +263,9 @@ mxArray* eigenToTrigPoly(
       trigpoly_mat.rows(), trigpoly_mat.cols());
   TrigPolyd::SinCosMap sin_cos_map;
   for (int i = 0; i < trigpoly_mat.size(); i++) {
-    const TrigPolyd::SinCosMap& sc = trigpoly_mat(i).getSinCosMap();
+    const TrigPolyd::SinCosMap& sc = trigpoly_mat(i).sin_cos_map();
     sin_cos_map.insert(sc.begin(), sc.end());
-    poly_mat(i) = trigpoly_mat(i).getPolynomial();
+    poly_mat(i) = trigpoly_mat(i).poly();
   }
 
   if (sin_cos_map

--- a/drake/util/lcmUtil.cpp
+++ b/drake/util/lcmUtil.cpp
@@ -5,8 +5,8 @@ using namespace Eigen;
 
 void encodePolynomial(const Polynomial<double>& polynomial,
                       drake::lcmt_polynomial& msg) {
-  eigenVectorToStdVector(polynomial.getCoefficients(), msg.coefficients);
-  msg.num_coefficients = polynomial.getNumberOfCoefficients();
+  eigenVectorToStdVector(polynomial.GetCoefficients(), msg.coefficients);
+  msg.num_coefficients = polynomial.GetNumberOfCoefficients();
 }
 
 Polynomial<double> decodePolynomial(const drake::lcmt_polynomial& msg) {

--- a/drake/util/test/testLCMUtil.cpp
+++ b/drake/util/test/testLCMUtil.cpp
@@ -15,11 +15,11 @@ void testPolynomial() {
   drake::lcmt_polynomial msg;
   encodePolynomial(poly, msg);
   auto poly_back = decodePolynomial(msg);
-  valuecheck(poly.isApprox(poly_back, 1e-8), true);
+  valuecheck(poly.IsApprox(poly_back, 1e-8), true);
 }
 
 void testPolynomialMatrix() {
-  auto poly_matrix = Polynomial<double>::randomPolynomialMatrix(6, 5, 8);
+  auto poly_matrix = Polynomial<double>::RandomPolynomialMatrix(6, 5, 8);
   drake::lcmt_polynomial_matrix msg;
   encodePolynomialMatrix<Eigen::Dynamic, Eigen::Dynamic>(poly_matrix, msg);
   valuecheck(static_cast<int>(msg.rows), static_cast<int>(poly_matrix.rows()));
@@ -30,7 +30,7 @@ void testPolynomialMatrix() {
   for (int row = 0; row < msg.rows; ++row) {
     for (int col = 0; col < msg.cols; ++col) {
       valuecheck(
-          poly_matrix(row, col).isApprox(poly_matrix_back(row, col), 1e-8),
+          poly_matrix(row, col).IsApprox(poly_matrix_back(row, col), 1e-8),
           true);
     }
   }

--- a/drake/util/test/testPolynomial.cpp
+++ b/drake/util/test/testPolynomial.cpp
@@ -28,7 +28,7 @@ void testIntegralAndDerivative() {
   Polynomial<CoefficientType> third_derivative = poly.Derivative(3);
 
   Polynomial<CoefficientType> third_derivative_check =
-          poly.Derivative().Derivative().Derivative();
+      poly.Derivative().Derivative().Derivative();
 
   EXPECT_TRUE(CompareMatrices(third_derivative.GetCoefficients(),
                               third_derivative_check.GetCoefficients(), 1e-14,
@@ -130,7 +130,7 @@ void testEvalType() {
   valuecheck(typeid(decltype(valueIntInput)) == double_type, true);
 
   auto valueComplexInput =
-          poly.EvaluateUnivariate(std::complex<double>(1.0, 2.0));
+      poly.EvaluateUnivariate(std::complex<double>(1.0, 2.0));
   valuecheck(
       typeid(decltype(valueComplexInput)) == typeid(std::complex<double>),
       true);
@@ -353,24 +353,24 @@ GTEST_TEST(PolynomialTest, EvaluatePartial) {
   // same answer.
   const double expected_result = dut.EvaluateMultivariate(eval_point_xy);
   EXPECT_EQ(
-          dut.EvaluatePartial(eval_point_null).EvaluateMultivariate(eval_point_xy),
+      dut.EvaluatePartial(eval_point_null).EvaluateMultivariate(eval_point_xy),
       expected_result);
   EXPECT_EQ(
-          dut.EvaluatePartial(eval_point_xy).EvaluateMultivariate(eval_point_null),
+      dut.EvaluatePartial(eval_point_xy).EvaluateMultivariate(eval_point_null),
       expected_result);
   EXPECT_EQ(
-          dut.EvaluatePartial(eval_point_x).EvaluateMultivariate(eval_point_y),
+      dut.EvaluatePartial(eval_point_x).EvaluateMultivariate(eval_point_y),
       expected_result);
   EXPECT_EQ(
-          dut.EvaluatePartial(eval_point_y).EvaluateMultivariate(eval_point_x),
+      dut.EvaluatePartial(eval_point_y).EvaluateMultivariate(eval_point_x),
       expected_result);
 
   // Test that zeroing out one term gives a sensible result.
   EXPECT_EQ(dut.EvaluatePartial(
-          std::map<Polynomiald::VarType, double>{{x.GetSimpleVariable(), 0}}),
+      std::map<Polynomiald::VarType, double>{{x.GetSimpleVariable(), 0}}),
             (2 * y) + 1);
   EXPECT_EQ(dut.EvaluatePartial(
-          std::map<Polynomiald::VarType, double>{{y.GetSimpleVariable(), 0}}),
+      std::map<Polynomiald::VarType, double>{{y.GetSimpleVariable(), 0}}),
             (5 * x * x * x) + 1);
 }
 

--- a/drake/util/test/testPolynomial.cpp
+++ b/drake/util/test/testPolynomial.cpp
@@ -25,26 +25,26 @@ void testIntegralAndDerivative() {
   VectorXd coefficients = VectorXd::Random(5);
   Polynomial<CoefficientType> poly(coefficients);
 
-  Polynomial<CoefficientType> third_derivative = poly.derivative(3);
+  Polynomial<CoefficientType> third_derivative = poly.Derivative(3);
 
   Polynomial<CoefficientType> third_derivative_check =
-      poly.derivative().derivative().derivative();
+          poly.Derivative().Derivative().Derivative();
 
-  EXPECT_TRUE(CompareMatrices(third_derivative.getCoefficients(),
-                              third_derivative_check.getCoefficients(), 1e-14,
+  EXPECT_TRUE(CompareMatrices(third_derivative.GetCoefficients(),
+                              third_derivative_check.GetCoefficients(), 1e-14,
                               MatrixCompareType::absolute));
 
-  Polynomial<CoefficientType> tenth_derivative = poly.derivative(10);
+  Polynomial<CoefficientType> tenth_derivative = poly.Derivative(10);
 
-  EXPECT_TRUE(CompareMatrices(tenth_derivative.getCoefficients(),
+  EXPECT_TRUE(CompareMatrices(tenth_derivative.GetCoefficients(),
                               VectorXd::Zero(1), 1e-14,
                               MatrixCompareType::absolute));
 
-  Polynomial<CoefficientType> integral = poly.integral(0.0);
-  Polynomial<CoefficientType> poly_back = integral.derivative();
+  Polynomial<CoefficientType> integral = poly.Integral(0.0);
+  Polynomial<CoefficientType> poly_back = integral.Derivative();
 
-  EXPECT_TRUE(CompareMatrices(poly_back.getCoefficients(),
-                              poly.getCoefficients(), 1e-14,
+  EXPECT_TRUE(CompareMatrices(poly_back.GetCoefficients(),
+                              poly.GetCoefficients(), 1e-14,
                               MatrixCompareType::absolute));
 }
 
@@ -76,22 +76,22 @@ void testOperators() {
     poly1_times_poly1 *= poly1_times_poly1;
 
     double t = uniform(generator);
-    valuecheck(sum.evaluateUnivariate(t),
-               poly1.evaluateUnivariate(t) + poly2.evaluateUnivariate(t), 1e-8);
-    valuecheck(difference.evaluateUnivariate(t),
-               poly2.evaluateUnivariate(t) - poly1.evaluateUnivariate(t), 1e-8);
-    valuecheck(product.evaluateUnivariate(t),
-               poly1.evaluateUnivariate(t) * poly2.evaluateUnivariate(t), 1e-8);
-    valuecheck(poly1_plus_scalar.evaluateUnivariate(t),
-               poly1.evaluateUnivariate(t) + scalar, 1e-8);
-    valuecheck(poly1_minus_scalar.evaluateUnivariate(t),
-               poly1.evaluateUnivariate(t) - scalar, 1e-8);
-    valuecheck(poly1_scaled.evaluateUnivariate(t),
-               poly1.evaluateUnivariate(t) * scalar, 1e-8);
-    valuecheck(poly1_div.evaluateUnivariate(t),
-               poly1.evaluateUnivariate(t) / scalar, 1e-8);
-    valuecheck(poly1_times_poly1.evaluateUnivariate(t),
-               poly1.evaluateUnivariate(t) * poly1.evaluateUnivariate(t), 1e-8);
+    valuecheck(sum.EvaluateUnivariate(t),
+               poly1.EvaluateUnivariate(t) + poly2.EvaluateUnivariate(t), 1e-8);
+    valuecheck(difference.EvaluateUnivariate(t),
+               poly2.EvaluateUnivariate(t) - poly1.EvaluateUnivariate(t), 1e-8);
+    valuecheck(product.EvaluateUnivariate(t),
+               poly1.EvaluateUnivariate(t) * poly2.EvaluateUnivariate(t), 1e-8);
+    valuecheck(poly1_plus_scalar.EvaluateUnivariate(t),
+               poly1.EvaluateUnivariate(t) + scalar, 1e-8);
+    valuecheck(poly1_minus_scalar.EvaluateUnivariate(t),
+               poly1.EvaluateUnivariate(t) - scalar, 1e-8);
+    valuecheck(poly1_scaled.EvaluateUnivariate(t),
+               poly1.EvaluateUnivariate(t) * scalar, 1e-8);
+    valuecheck(poly1_div.EvaluateUnivariate(t),
+               poly1.EvaluateUnivariate(t) / scalar, 1e-8);
+    valuecheck(poly1_times_poly1.EvaluateUnivariate(t),
+               poly1.EvaluateUnivariate(t) * poly1.EvaluateUnivariate(t), 1e-8);
 
     // Check the '==' operator.
     EXPECT_TRUE(poly1 + poly2 == sum);
@@ -109,10 +109,10 @@ void testRoots() {
   for (int i = 0; i < num_tests; ++i) {
     VectorXd coeffs = VectorXd::Random(int_distribution(generator));
     Polynomial<CoefficientType> poly(coeffs);
-    auto roots = poly.roots();
-    valuecheck<Eigen::Index>(roots.rows(), poly.getDegree());
+    auto roots = poly.Roots();
+    valuecheck<Eigen::Index>(roots.rows(), poly.GetDegree());
     for (int k = 0; k < roots.size(); k++) {
-      auto value = poly.evaluateUnivariate(roots[k]);
+      auto value = poly.EvaluateUnivariate(roots[k]);
       valuecheck(std::abs(value), 0.0, 1e-8);
     }
   }
@@ -125,12 +125,12 @@ void testEvalType() {
   VectorXd coeffs = VectorXd::Random(int_distribution(generator));
   Polynomial<double> poly(coeffs);
 
-  auto valueIntInput = poly.evaluateUnivariate(1);
+  auto valueIntInput = poly.EvaluateUnivariate(1);
   const auto& double_type = typeid(double);  // NOLINT(readability/function)
   valuecheck(typeid(decltype(valueIntInput)) == double_type, true);
 
   auto valueComplexInput =
-      poly.evaluateUnivariate(std::complex<double>(1.0, 2.0));
+          poly.EvaluateUnivariate(std::complex<double>(1.0, 2.0));
   valuecheck(
       typeid(decltype(valueComplexInput)) == typeid(std::complex<double>),
       true);
@@ -148,11 +148,11 @@ void testPolynomialMatrix() {
   int rows_B = cols_A;
   int cols_B = matrix_size_distribution(generator);
 
-  auto A = Polynomial<CoefficientType>::randomPolynomialMatrix(num_coefficients,
+  auto A = Polynomial<CoefficientType>::RandomPolynomialMatrix(num_coefficients,
                                                                rows_A, cols_A);
-  auto B = Polynomial<CoefficientType>::randomPolynomialMatrix(num_coefficients,
+  auto B = Polynomial<CoefficientType>::RandomPolynomialMatrix(num_coefficients,
                                                                rows_B, cols_B);
-  auto C = Polynomial<CoefficientType>::randomPolynomialMatrix(num_coefficients,
+  auto C = Polynomial<CoefficientType>::RandomPolynomialMatrix(num_coefficients,
                                                                rows_A, cols_A);
   auto product = A * B;
   auto sum = A + C;
@@ -192,16 +192,16 @@ GTEST_TEST(PolynomialTest, IsAffine) {
   Polynomiald x("x");
   Polynomiald y("y");
 
-  EXPECT_TRUE(x.isAffine());
-  EXPECT_TRUE(y.isAffine());
-  EXPECT_TRUE((2 + x).isAffine());
-  EXPECT_TRUE((2 * x).isAffine());
-  EXPECT_FALSE((x * x).isAffine());
-  EXPECT_FALSE((x * y).isAffine());
-  EXPECT_TRUE((x + y).isAffine());
-  EXPECT_TRUE((2 + x + y).isAffine());
-  EXPECT_TRUE((2 + (2 * x) + y).isAffine());
-  EXPECT_FALSE((2 + (y * x) + y).isAffine());
+  EXPECT_TRUE(x.IsAffine());
+  EXPECT_TRUE(y.IsAffine());
+  EXPECT_TRUE((2 + x).IsAffine());
+  EXPECT_TRUE((2 * x).IsAffine());
+  EXPECT_FALSE((x * x).IsAffine());
+  EXPECT_FALSE((x * y).IsAffine());
+  EXPECT_TRUE((x + y).IsAffine());
+  EXPECT_TRUE((2 + x + y).IsAffine());
+  EXPECT_TRUE((2 + (2 * x) + y).IsAffine());
+  EXPECT_FALSE((2 + (y * x) + y).IsAffine());
 }
 
 GTEST_TEST(PolynomialTest, VariableIdGeneration) {
@@ -234,27 +234,27 @@ GTEST_TEST(PolynomialTest, VariableIdGeneration) {
 
 GTEST_TEST(PolynomialTest, GetVariables) {
   Polynomiald x = Polynomiald("x");
-  Polynomiald::VarType x_var = x.getSimpleVariable();
+  Polynomiald::VarType x_var = x.GetSimpleVariable();
   Polynomiald y = Polynomiald("y");
-  Polynomiald::VarType y_var = y.getSimpleVariable();
+  Polynomiald::VarType y_var = y.GetSimpleVariable();
   Polynomiald z = Polynomiald("z");
-  Polynomiald::VarType z_var = z.getSimpleVariable();
+  Polynomiald::VarType z_var = z.GetSimpleVariable();
 
-  EXPECT_TRUE(x.getVariables().count(x_var));
-  EXPECT_FALSE(x.getVariables().count(y_var));
+  EXPECT_TRUE(x.GetVariables().count(x_var));
+  EXPECT_FALSE(x.GetVariables().count(y_var));
 
-  EXPECT_FALSE(Polynomiald().getVariables().count(x_var));
+  EXPECT_FALSE(Polynomiald().GetVariables().count(x_var));
 
-  EXPECT_TRUE((x + x).getVariables().count(x_var));
+  EXPECT_TRUE((x + x).GetVariables().count(x_var));
 
-  EXPECT_TRUE((x + y).getVariables().count(x_var));
-  EXPECT_TRUE((x + y).getVariables().count(y_var));
+  EXPECT_TRUE((x + y).GetVariables().count(x_var));
+  EXPECT_TRUE((x + y).GetVariables().count(y_var));
 
-  EXPECT_TRUE((x * y * y + z).getVariables().count(x_var));
-  EXPECT_TRUE((x * y * y + z).getVariables().count(y_var));
-  EXPECT_TRUE((x * y * y + z).getVariables().count(z_var));
+  EXPECT_TRUE((x * y * y + z).GetVariables().count(x_var));
+  EXPECT_TRUE((x * y * y + z).GetVariables().count(y_var));
+  EXPECT_TRUE((x * y * y + z).GetVariables().count(z_var));
 
-  EXPECT_FALSE(x.derivative().getVariables().count(x_var));
+  EXPECT_FALSE(x.Derivative().GetVariables().count(x_var));
 }
 
 // TODO(ggould-tri) -- This test does not pass, which is a misfeature or
@@ -285,36 +285,36 @@ GTEST_TEST(PolynomialTest, MonomialFactor) {
   Polynomiald y = Polynomiald("y");
 
   // "m_" prefix denotes monomial.
-  Polynomiald::Monomial m_one = Polynomiald(1).getMonomials()[0];
-  Polynomiald::Monomial m_two = Polynomiald(2).getMonomials()[0];
-  Polynomiald::Monomial m_x = x.getMonomials()[0];
-  Polynomiald::Monomial m_y = y.getMonomials()[0];
-  Polynomiald::Monomial m_2x = (x * 2).getMonomials()[0];
-  Polynomiald::Monomial m_x2 = (x * x).getMonomials()[0];
-  Polynomiald::Monomial m_x2y = (x * x * y).getMonomials()[0];
+  Polynomiald::Monomial m_one = Polynomiald(1).GetMonomials()[0];
+  Polynomiald::Monomial m_two = Polynomiald(2).GetMonomials()[0];
+  Polynomiald::Monomial m_x = x.GetMonomials()[0];
+  Polynomiald::Monomial m_y = y.GetMonomials()[0];
+  Polynomiald::Monomial m_2x = (x * 2).GetMonomials()[0];
+  Polynomiald::Monomial m_x2 = (x * x).GetMonomials()[0];
+  Polynomiald::Monomial m_x2y = (x * x * y).GetMonomials()[0];
 
   // Expect failures
-  EXPECT_EQ(m_x.factor(m_y).coefficient, 0);
-  EXPECT_EQ(m_x.factor(m_x2).coefficient, 0);
+  EXPECT_EQ(m_x.Factor(m_y).coefficient, 0);
+  EXPECT_EQ(m_x.Factor(m_x2).coefficient, 0);
 
   // Expect successes
-  EXPECT_EQ(m_x.factor(m_x), m_one);
-  EXPECT_EQ(m_2x.factor(m_x), m_two);
-  EXPECT_EQ(m_x2.factor(m_x), m_x);
-  EXPECT_EQ(m_x2y.factor(m_x2), m_y);
-  EXPECT_EQ(m_x2y.factor(m_y), m_x2);
+  EXPECT_EQ(m_x.Factor(m_x), m_one);
+  EXPECT_EQ(m_2x.Factor(m_x), m_two);
+  EXPECT_EQ(m_x2.Factor(m_x), m_x);
+  EXPECT_EQ(m_x2y.Factor(m_x2), m_y);
+  EXPECT_EQ(m_x2y.Factor(m_y), m_x2);
 }
 
 GTEST_TEST(PolynomialTest, MultivariateValue) {
   Polynomiald x = Polynomiald("x");
   Polynomiald y = Polynomiald("y");
   const std::map<Polynomiald::VarType, double> eval_point = {
-    {x.getSimpleVariable(), 1},
-    {y.getSimpleVariable(), 2}};
-  EXPECT_EQ((x * x + y).evaluateMultivariate(eval_point), 3);
-  EXPECT_EQ((2 * x * x + y).evaluateMultivariate(eval_point), 4);
-  EXPECT_EQ((x * x + 2 * y).evaluateMultivariate(eval_point), 5);
-  EXPECT_EQ((x * x + x * y).evaluateMultivariate(eval_point), 3);
+    {x.GetSimpleVariable(), 1},
+    {y.GetSimpleVariable(), 2}};
+  EXPECT_EQ((x * x + y).EvaluateMultivariate(eval_point), 3);
+  EXPECT_EQ((2 * x * x + y).EvaluateMultivariate(eval_point), 4);
+  EXPECT_EQ((x * x + 2 * y).EvaluateMultivariate(eval_point), 5);
+  EXPECT_EQ((x * x + x * y).EvaluateMultivariate(eval_point), 3);
 }
 
 GTEST_TEST(PolynomialTest, Conversion) {
@@ -331,16 +331,16 @@ GTEST_TEST(PolynomialTest, EvaluatePartial) {
 
   const std::map<Polynomiald::VarType, double> eval_point_null;
   const std::map<Polynomiald::VarType, double> eval_point_x = {
-    {x.getSimpleVariable(), 7}};
+    {x.GetSimpleVariable(), 7}};
   const std::map<Polynomiald::VarType, double> eval_point_y = {
-    {y.getSimpleVariable(), 11}};
+    {y.GetSimpleVariable(), 11}};
   const std::map<Polynomiald::VarType, double> eval_point_xy = {
-    {x.getSimpleVariable(), 7},
-    {y.getSimpleVariable(), 11}};
+    {x.GetSimpleVariable(), 7},
+    {y.GetSimpleVariable(), 11}};
 
   // Test a couple of straightforward explicit cases.
-  EXPECT_EQ(dut.evaluatePartial(eval_point_null).getMonomials(),
-            dut.getMonomials());
+  EXPECT_EQ(dut.EvaluatePartial(eval_point_null).GetMonomials(),
+            dut.GetMonomials());
   // TODO(#2216) These fail due to a known drake bug:
 #if 0
   EXPECT_EQ(dut.evaluatePartial(eval_point_x).getMonomials(),
@@ -351,26 +351,26 @@ GTEST_TEST(PolynomialTest, EvaluatePartial) {
 
   // Test that every order of partial and then complete evaluation gives the
   // same answer.
-  const double expected_result = dut.evaluateMultivariate(eval_point_xy);
+  const double expected_result = dut.EvaluateMultivariate(eval_point_xy);
   EXPECT_EQ(
-      dut.evaluatePartial(eval_point_null).evaluateMultivariate(eval_point_xy),
+          dut.EvaluatePartial(eval_point_null).EvaluateMultivariate(eval_point_xy),
       expected_result);
   EXPECT_EQ(
-      dut.evaluatePartial(eval_point_xy).evaluateMultivariate(eval_point_null),
+          dut.EvaluatePartial(eval_point_xy).EvaluateMultivariate(eval_point_null),
       expected_result);
   EXPECT_EQ(
-      dut.evaluatePartial(eval_point_x).evaluateMultivariate(eval_point_y),
+          dut.EvaluatePartial(eval_point_x).EvaluateMultivariate(eval_point_y),
       expected_result);
   EXPECT_EQ(
-      dut.evaluatePartial(eval_point_y).evaluateMultivariate(eval_point_x),
+          dut.EvaluatePartial(eval_point_y).EvaluateMultivariate(eval_point_x),
       expected_result);
 
   // Test that zeroing out one term gives a sensible result.
-  EXPECT_EQ(dut.evaluatePartial(
-      std::map<Polynomiald::VarType, double>{{x.getSimpleVariable(), 0}}),
+  EXPECT_EQ(dut.EvaluatePartial(
+          std::map<Polynomiald::VarType, double>{{x.GetSimpleVariable(), 0}}),
             (2 * y) + 1);
-  EXPECT_EQ(dut.evaluatePartial(
-      std::map<Polynomiald::VarType, double>{{y.getSimpleVariable(), 0}}),
+  EXPECT_EQ(dut.EvaluatePartial(
+          std::map<Polynomiald::VarType, double>{{y.GetSimpleVariable(), 0}}),
             (5 * x * x * x) + 1);
 }
 

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -68,7 +68,7 @@ GTEST_TEST(TrigPolyTest, GetVariablesTest) {
   Polynomiald c("c");
   TrigPolyd p(q, s, c);
 
-  std::set<Polynomiald::VarType> expected_vars = { q.getSimpleVariable(), };
+  std::set<Polynomiald::VarType> expected_vars = {q.GetSimpleVariable(), };
   EXPECT_EQ(p.getVariables(), expected_vars);
   EXPECT_EQ(sin(p).getVariables(), expected_vars);
   EXPECT_EQ(cos(p).getVariables(), expected_vars);
@@ -78,17 +78,17 @@ GTEST_TEST(TrigPolyTest, EvaluateMultivariateTest) {
   const TrigPolyd theta(Polynomiald("th"),
                         Polynomiald("sth"), Polynomiald("cth"));
   const TrigPolyd::VarType theta_var =
-      theta.getPolynomial().getSimpleVariable();
+          theta.getPolynomial().GetSimpleVariable();
 
   // Check some basic evaluations.
-  EXPECT_EQ(theta.evaluateMultivariate(MapType {{theta_var, 1}}), 1);
-  EXPECT_EQ(sin(theta).evaluateMultivariate(MapType {{theta_var, 0}}), 0);
-  EXPECT_EQ(cos(theta).evaluateMultivariate(MapType {{theta_var, 0}}), 1);
+  EXPECT_EQ(theta.EvaluateMultivariate(MapType {{theta_var, 1}}), 1);
+  EXPECT_EQ(sin(theta).EvaluateMultivariate(MapType {{theta_var, 0}}), 0);
+  EXPECT_EQ(cos(theta).EvaluateMultivariate(MapType {{theta_var, 0}}), 1);
 
   // Test that the pythagorean theorem is true for various angles.
   for (const double angle : {0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4}) {
     EXPECT_NEAR((sin(theta) * sin(theta) + cos(theta) * cos(theta) - 1)
-                .evaluateMultivariate(MapType {{theta_var, angle}}),
+                .EvaluateMultivariate(MapType {{theta_var, angle}}),
                 0,
                 1e-6);
   }
@@ -96,11 +96,11 @@ GTEST_TEST(TrigPolyTest, EvaluateMultivariateTest) {
   // Test an arbitrary multivariate polynomial.
   const TrigPolyd phi(Polynomiald("phi"),
                       Polynomiald("sphi"), Polynomiald("cphi"));
-  const TrigPolyd::VarType phi_var = phi.getPolynomial().getSimpleVariable();
+  const TrigPolyd::VarType phi_var = phi.getPolynomial().GetSimpleVariable();
   const TrigPolyd multivariate = theta + phi * cos(theta) + sin(phi + theta);
   for (const double theta_value : {0., 1., kPi / 4, kPi / 2, -kPi / 4}) {
     for (const double phi_value : {0., 1., kPi / 4, kPi / 2, -kPi / 4}) {
-      EXPECT_NEAR(multivariate.evaluateMultivariate(
+      EXPECT_NEAR(multivariate.EvaluateMultivariate(
           MapType {{theta_var, theta_value}, {phi_var, phi_value}}),
                   (theta_value + (phi_value * std::cos(theta_value)) +
                    std::sin(phi_value + theta_value)),
@@ -113,10 +113,10 @@ GTEST_TEST(TrigPolyTest, EvaluatePartialTest) {
   const TrigPolyd theta(Polynomiald("th"),
                         Polynomiald("sth"), Polynomiald("cth"));
   const TrigPolyd::VarType theta_var =
-      theta.getPolynomial().getSimpleVariable();
+          theta.getPolynomial().GetSimpleVariable();
   const TrigPolyd phi(Polynomiald("phi"),
                       Polynomiald("sphi"), Polynomiald("cphi"));
-  const TrigPolyd::VarType phi_var = phi.getPolynomial().getSimpleVariable();
+  const TrigPolyd::VarType phi_var = phi.getPolynomial().GetSimpleVariable();
   const TrigPolyd multivariate = theta + phi * cos(theta) + sin(phi + theta);
 
   EXPECT_EQ(multivariate.evaluatePartial(MapType {{theta_var, 0}}),

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -61,7 +61,7 @@ GTEST_TEST(TrigPolyTest, SmokeTest) {
 }
 
 GTEST_TEST(TrigPolyTest, GetVariablesTest) {
-  // Check that getVariables() correctly returns all and only the base
+  // Check that GetVariables() correctly returns all and only the base
   // variables of the expression and not the trig variables.
   Polynomiald q("q");
   Polynomiald s("s");
@@ -69,16 +69,16 @@ GTEST_TEST(TrigPolyTest, GetVariablesTest) {
   TrigPolyd p(q, s, c);
 
   std::set<Polynomiald::VarType> expected_vars = {q.GetSimpleVariable(), };
-  EXPECT_EQ(p.getVariables(), expected_vars);
-  EXPECT_EQ(sin(p).getVariables(), expected_vars);
-  EXPECT_EQ(cos(p).getVariables(), expected_vars);
+  EXPECT_EQ(p.GetVariables(), expected_vars);
+  EXPECT_EQ(sin(p).GetVariables(), expected_vars);
+  EXPECT_EQ(cos(p).GetVariables(), expected_vars);
 }
 
 GTEST_TEST(TrigPolyTest, EvaluateMultivariateTest) {
   const TrigPolyd theta(Polynomiald("th"),
                         Polynomiald("sth"), Polynomiald("cth"));
   const TrigPolyd::VarType theta_var =
-          theta.getPolynomial().GetSimpleVariable();
+          theta.poly().GetSimpleVariable();
 
   // Check some basic evaluations.
   EXPECT_EQ(theta.EvaluateMultivariate(MapType {{theta_var, 1}}), 1);
@@ -96,7 +96,7 @@ GTEST_TEST(TrigPolyTest, EvaluateMultivariateTest) {
   // Test an arbitrary multivariate polynomial.
   const TrigPolyd phi(Polynomiald("phi"),
                       Polynomiald("sphi"), Polynomiald("cphi"));
-  const TrigPolyd::VarType phi_var = phi.getPolynomial().GetSimpleVariable();
+  const TrigPolyd::VarType phi_var = phi.poly().GetSimpleVariable();
   const TrigPolyd multivariate = theta + phi * cos(theta) + sin(phi + theta);
   for (const double theta_value : {0., 1., kPi / 4, kPi / 2, -kPi / 4}) {
     for (const double phi_value : {0., 1., kPi / 4, kPi / 2, -kPi / 4}) {
@@ -113,15 +113,15 @@ GTEST_TEST(TrigPolyTest, EvaluatePartialTest) {
   const TrigPolyd theta(Polynomiald("th"),
                         Polynomiald("sth"), Polynomiald("cth"));
   const TrigPolyd::VarType theta_var =
-          theta.getPolynomial().GetSimpleVariable();
+          theta.poly().GetSimpleVariable();
   const TrigPolyd phi(Polynomiald("phi"),
                       Polynomiald("sphi"), Polynomiald("cphi"));
-  const TrigPolyd::VarType phi_var = phi.getPolynomial().GetSimpleVariable();
+  const TrigPolyd::VarType phi_var = phi.poly().GetSimpleVariable();
   const TrigPolyd multivariate = theta + phi * cos(theta) + sin(phi + theta);
 
-  EXPECT_EQ(multivariate.evaluatePartial(MapType {{theta_var, 0}}),
+  EXPECT_EQ(multivariate.EvaluatePartial(MapType {{theta_var, 0}}),
             phi + sin(phi));
-  EXPECT_EQ(multivariate.evaluatePartial(MapType {{phi_var, 0}}),
+  EXPECT_EQ(multivariate.EvaluatePartial(MapType {{phi_var, 0}}),
             theta + sin(theta));
   // TODO(#2216) This fails due to a known drake bug:
 #if 0

--- a/drake/util/test/testTrigPoly.cpp
+++ b/drake/util/test/testTrigPoly.cpp
@@ -78,7 +78,7 @@ GTEST_TEST(TrigPolyTest, EvaluateMultivariateTest) {
   const TrigPolyd theta(Polynomiald("th"),
                         Polynomiald("sth"), Polynomiald("cth"));
   const TrigPolyd::VarType theta_var =
-          theta.poly().GetSimpleVariable();
+      theta.poly().GetSimpleVariable();
 
   // Check some basic evaluations.
   EXPECT_EQ(theta.EvaluateMultivariate(MapType {{theta_var, 1}}), 1);


### PR DESCRIPTION
This PR corrects method and in some cases field naming in a number of classes that I work with frequently, as well as the formatting and syntax of nearby comments.

The change is automatic (done with clion and perlpie) for the most part.  Human intervention was limited to fixing comments near the code I touched.

The change is NOT COMPREHENSIVE.  It leaves major nearby defects untouched, and does not correct names in files other than the ones in solver and util that caught my attention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2971)
<!-- Reviewable:end -->
