### PR TITLE
Fix URI of spdlog submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,4 +94,4 @@
 	url = https://github.com/google/styleguide.git
 [submodule "externals/spdlog"]
 	path = externals/spdlog
-	url = git@github.com:gabime/spdlog.git
+	url = https://github.com/gabime/spdlog.git


### PR DESCRIPTION
Use `https` instead of `git` protocol to clone spdlog; the former works for public users, the latter requires an ssh key (and possibly write access to the repository).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2977)
<!-- Reviewable:end -->
