### PR TITLE
Downcase "Drake" namespace to "drake"

### DIFF
--- a/drake/core/Function.h
+++ b/drake/core/Function.h
@@ -11,7 +11,7 @@
 
 #include "Gradient.h"
 
-namespace Drake {
+namespace drake {
 
 /** InputOutputRelation
  * \brief Tags which can be used to inform algorithms about underlying structure

--- a/drake/core/Gradient.h
+++ b/drake/core/Gradient.h
@@ -10,7 +10,7 @@
 
 #include "drake/common/drake_assert.h"
 
-namespace Drake {
+namespace drake {
 // todo: recursive template to get arbitrary gradient order
 
 // note: tried using template default values (e.g. Eigen::Dynamic), but they

--- a/drake/core/Path.h.in
+++ b/drake/core/Path.h.in
@@ -2,7 +2,7 @@
 
 #include <string>
 
-namespace Drake {
+namespace drake {
 inline const std::string& getDrakePath() {
   static std::string root("@PROJECT_SOURCE_DIR@");
   return root;

--- a/drake/core/Path.h.in
+++ b/drake/core/Path.h.in
@@ -7,4 +7,4 @@ inline const std::string& getDrakePath() {
   static std::string root("@PROJECT_SOURCE_DIR@");
   return root;
 }
-} // end namespace Drake
+} // end namespace drake

--- a/drake/core/Vector.h
+++ b/drake/core/Vector.h
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <Eigen/Dense>
 
-namespace Drake {
+namespace drake {
 
 /** @defgroup vector_concept Vector<ScalarType> Concept
  * @ingroup concepts
@@ -170,8 +170,8 @@ class CombinedVector {
 
   template <typename Derived>
   CombinedVector &operator=(const Eigen::MatrixBase<Derived> &x) {
-    vec1 = x.topRows(Drake::size(vec1));
-    vec2 = x.bottomRows(Drake::size(vec2));
+    vec1 = x.topRows(drake::size(vec1));
+    vec2 = x.bottomRows(drake::size(vec2));
     return *this;
   }
 
@@ -194,7 +194,7 @@ class CombinedVector {
                   Vector2<ScalarType>::RowsAtCompileTime
   };
 
-  std::size_t size() const { return Drake::size(vec1) + Drake::size(vec2); }
+  std::size_t size() const { return drake::size(vec1) + drake::size(vec2); }
 
   friend Eigen::Matrix<ScalarType, RowsAtCompileTime, 1> toEigen(
       const CombinedVector<ScalarType, Vector1, Vector2> &vec) {
@@ -332,4 +332,4 @@ struct CombinedVectorUtil<
   }
 };
 
-};  // namespace Drake
+};  // namespace drake

--- a/drake/core/test/pendulum.h
+++ b/drake/core/test/pendulum.h
@@ -8,12 +8,12 @@ namespace test {
 
 /// A simple Drake state for unit testing.
 template <typename ScalarType = double>
-class PendulumState {  // models the Drake::Vector concept
+class PendulumState {  // models the drake::Vector concept
  public:
   PendulumState(void) : theta(0), thetadot(0) {}
 
   template <typename Derived>
-  PendulumState(  // NOLINT(runtime/explicit) per Drake::Vector.
+  PendulumState(  // NOLINT(runtime/explicit) per drake::Vector.
       const Eigen::MatrixBase<Derived>& x)
       : theta(x(0)), thetadot(x(1)) {}
 
@@ -44,7 +44,7 @@ class PendulumInput {
   PendulumInput(void) : tau(0) {}
 
   template <typename Derived>
-  explicit PendulumInput(  // NOLINT(runtime/explicit) per Drake::Vector.
+  explicit PendulumInput(  // NOLINT(runtime/explicit) per drake::Vector.
       const Eigen::MatrixBase<Derived>& x)
       : tau(x(0)) {}
 

--- a/drake/core/test/vector_test.cc
+++ b/drake/core/test/vector_test.cc
@@ -6,11 +6,11 @@
 #include "drake/util/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
-using Drake::CombinedVector;
-using Drake::size;
-using Drake::CombinedVectorUtil;
-using Drake::NullVector;
-using Drake::InputOutputRelation;
+using drake::CombinedVector;
+using drake::size;
+using drake::CombinedVectorUtil;
+using drake::NullVector;
+using drake::InputOutputRelation;
 using drake::util::MatrixCompareType;
 using std::is_same;
 using std::string;

--- a/drake/examples/Acrobot/Acrobot.h
+++ b/drake/examples/Acrobot/Acrobot.h
@@ -7,12 +7,12 @@
 using namespace std;
 
 template <typename ScalarType = double>
-class AcrobotState {  // models the Drake::Vector concept
+class AcrobotState {  // models the drake::Vector concept
  public:
   AcrobotState(void) : shoulder(0), elbow(0), shoulder_dot(0), elbow_dot(0) {}
 
   template <typename Derived>
-  AcrobotState(  // NOLINT(runtime/explicit) per Drake::Vector.
+  AcrobotState(  // NOLINT(runtime/explicit) per drake::Vector.
       const Eigen::MatrixBase<Derived>& x)
       : shoulder(x(0)), elbow(x(1)), shoulder_dot(x(2)), elbow_dot(x(3)) {}
 
@@ -57,7 +57,7 @@ class AcrobotInput {
   AcrobotInput(void) : tau(0) {}
 
   template <typename Derived>
-  AcrobotInput(  // NOLINT(runtime/explicit) per Drake::Vector.
+  AcrobotInput(  // NOLINT(runtime/explicit) per drake::Vector.
       const Eigen::MatrixBase<Derived>& x)
       : tau(x(0)) {}
 

--- a/drake/examples/Acrobot/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Acrobot/test/urdfDynamicsTest.cpp
@@ -4,9 +4,9 @@
 #include "drake/util/eigen_matrix_compare.h"
 #include "gtest/gtest.h"
 
-using Drake::RigidBodySystem;
-using Drake::getRandomVector;
-using Drake::getDrakePath;
+using drake::RigidBodySystem;
+using drake::getRandomVector;
+using drake::getDrakePath;
 using drake::util::MatrixCompareType;
 
 namespace drake {

--- a/drake/examples/Atlas/atlas_dynamics_demo.cc
+++ b/drake/examples/Atlas/atlas_dynamics_demo.cc
@@ -6,8 +6,8 @@
 #include "drake/systems/LCMSystem.h"
 #include "drake/util/drakeAppUtil.h"
 
-using Drake::SimulationOptions;
-using Drake::BotVisualizer;
+using drake::SimulationOptions;
+using drake::BotVisualizer;
 using drake::AtlasPlant;
 
 int main(int argc, char* argv[]) {

--- a/drake/examples/Atlas/atlas_plant.cc
+++ b/drake/examples/Atlas/atlas_plant.cc
@@ -7,9 +7,9 @@ using Eigen::Vector4d;
 using Eigen::Isometry3d;
 
 AtlasPlant::AtlasPlant() {
-  sys_.reset(new Drake::RigidBodySystem());
+  sys_.reset(new drake::RigidBodySystem());
   sys_->addRobotFromFile(
-      Drake::getDrakePath() + "/examples/Atlas/urdf/atlas_convex_hull.urdf",
+      drake::getDrakePath() + "/examples/Atlas/urdf/atlas_convex_hull.urdf",
       DrakeJoint::QUATERNION);
 
   x0_ = VectorXd::Zero(sys_->getNumStates());

--- a/drake/examples/Atlas/atlas_plant.h
+++ b/drake/examples/Atlas/atlas_plant.h
@@ -16,11 +16,11 @@ needed to simulate the Atlas robot.
 class AtlasPlant {
  public:
   template<typename T>
-  using InputVector = Drake::RigidBodySystem::InputVector<T>;
+  using InputVector = drake::RigidBodySystem::InputVector<T>;
   template<typename T>
-  using StateVector = Drake::RigidBodySystem::StateVector<T>;
+  using StateVector = drake::RigidBodySystem::StateVector<T>;
   template<typename T>
-  using OutputVector = Drake::RigidBodySystem::OutputVector<T>;
+  using OutputVector = drake::RigidBodySystem::OutputVector<T>;
 
   /** Creates a default instance of the Atlas robot as described by the URDF
   file in `drake/examples/Atlas/urdf/atlas_convex_hull.urdf`. **/
@@ -51,7 +51,7 @@ class AtlasPlant {
 
  private:
   // The underlying rigid body system
-  std::unique_ptr<Drake::RigidBodySystem> sys_;
+  std::unique_ptr<drake::RigidBodySystem> sys_;
 
   // Atlas's initial configuration.
   VectorXd x0_;

--- a/drake/examples/Cars/car_sim_lcm.cc
+++ b/drake/examples/Cars/car_sim_lcm.cc
@@ -8,9 +8,9 @@
 #include "drake/util/drakeAppUtil.h"
 #include "lcmtypes/drake/lcmt_driving_command_t.hpp"
 
-using Drake::BotVisualizer;
-using Drake::Gain;
-using Drake::SimulationOptions;
+using drake::BotVisualizer;
+using drake::Gain;
+using drake::SimulationOptions;
 
 using Eigen::VectorXd;
 
@@ -48,7 +48,7 @@ int do_main(int argc, const char* argv[]) {
   const double kStartTime = 0;
 
   // Starts the simulation.
-  Drake::runLCM(sys, lcm, kStartTime, duration,
+  drake::runLCM(sys, lcm, kStartTime, duration,
                 GetInitialState(*(rigid_body_sys.get())),
                 options);
 

--- a/drake/examples/Cars/car_simulation.cc
+++ b/drake/examples/Cars/car_simulation.cc
@@ -7,8 +7,8 @@
 #include "drake/examples/Cars/gen/simple_car_state.h"
 #include "drake/examples/Cars/trajectory_car.h"
 
-using Drake::AffineSystem;
-using Drake::NullVector;
+using drake::AffineSystem;
+using drake::NullVector;
 using Eigen::Matrix;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;

--- a/drake/examples/Cars/car_simulation.h
+++ b/drake/examples/Cars/car_simulation.h
@@ -16,11 +16,11 @@
 #include "drake/systems/pd_control_system.h"
 #include "drake/systems/plants/RigidBodySystem.h"
 
-using Drake::RigidBodySystem;
-using Drake::PDControlSystem;
-using Drake::CascadeSystem;
-using Drake::Gain;
-using Drake::SimulationOptions;
+using drake::RigidBodySystem;
+using drake::PDControlSystem;
+using drake::CascadeSystem;
+using drake::Gain;
+using drake::SimulationOptions;
 
 namespace drake {
 namespace examples {
@@ -120,8 +120,8 @@ std::shared_ptr<TrajectoryCar> CreateTrajectoryCarSystem(int index);
  * floating joint, allowing motion and steering in the x-y plane only.
  */
 DRAKECARS_EXPORT
-std::shared_ptr<Drake::AffineSystem<
-  Drake::NullVector, SimpleCarState, EulerFloatingJointState>>
+std::shared_ptr<drake::AffineSystem<
+  drake::NullVector, SimpleCarState, EulerFloatingJointState>>
 CreateSimpleCarVisualizationAdapter();
 
 /**

--- a/drake/examples/Cars/demo_multi_car.cc
+++ b/drake/examples/Cars/demo_multi_car.cc
@@ -17,10 +17,10 @@
 #include "drake/examples/Cars/gen/euler_floating_joint_state.h"
 #include "drake/examples/Cars/trajectory_car.h"
 
-using Drake::AffineSystem;
-using Drake::BotVisualizer;
-using Drake::NullVector;
-using Drake::cascade;
+using drake::AffineSystem;
+using drake::BotVisualizer;
+using drake::NullVector;
+using drake::cascade;
 
 namespace drake {
 namespace examples {
@@ -39,9 +39,9 @@ int do_main(int argc, const char* argv[]) {
 
   auto car_vis_adapter = CreateSimpleCarVisualizationAdapter();
 
-  const std::string kSedanUrdf = Drake::getDrakePath() +
+  const std::string kSedanUrdf = drake::getDrakePath() +
       "/examples/Cars/models/sedan.urdf";
-  const std::string kBreadtruckUrdf = Drake::getDrakePath() +
+  const std::string kBreadtruckUrdf = drake::getDrakePath() +
       "/examples/Cars/models/breadtruck.urdf";
 
   // RigidBodyTree for visualization.
@@ -79,16 +79,16 @@ int do_main(int argc, const char* argv[]) {
   // Add LCM support, for visualization.
   std::shared_ptr<lcm::LCM> lcm = std::make_shared<lcm::LCM>();
   auto visualizer =
-      std::make_shared<Drake::BotVisualizer<
+      std::make_shared<drake::BotVisualizer<
         decltype(cars_vis_adapter)::element_type::OutputVector>>(
             lcm, world_tree);
 
   // Compose the system together from the parts.
-  auto the_system = Drake::cascade(Drake::cascade(
+  auto the_system = drake::cascade(drake::cascade(
       cars_system, cars_vis_adapter), visualizer);
 
   decltype(the_system)::element_type::StateVector<double> initial_state;
-  Drake::SimulationOptions options;
+  drake::SimulationOptions options;
   options.realtime_factor = 0.0;
   const double t0 = 0.0;
   const double tf = std::numeric_limits<double>::infinity();

--- a/drake/examples/Cars/gen/driving_command.h
+++ b/drake/examples/Cars/gen/driving_command.h
@@ -23,7 +23,7 @@ struct DrivingCommandIndices {
   static const int kBrake = 2;
 };
 
-/// Models the Drake::LCMVector concept.
+/// Models the drake::LCMVector concept.
 template <typename ScalarType = double>
 class DrivingCommand {
  public:
@@ -44,7 +44,7 @@ class DrivingCommand {
   void set_brake(const ScalarType& brake) { value_(K::kBrake) = brake; }
   //@}
 
-  /// @name Implement the Drake::Vector concept.
+  /// @name Implement the drake::Vector concept.
   //@{
 
   // Even though in practice we have a fixed size, we declare
@@ -62,7 +62,7 @@ class DrivingCommand {
 
   /// Implicit Eigen::Matrix conversion.
   template <typename Derived>
-  // NOLINTNEXTLINE(runtime/explicit) per Drake::Vector.
+  // NOLINTNEXTLINE(runtime/explicit) per drake::Vector.
   DrivingCommand(const Eigen::MatrixBase<Derived>& value)
       : value_(value.segment(0, K::kNumCoordiates)) {}
 
@@ -79,7 +79,7 @@ class DrivingCommand {
   }
 
   /// Magic pretty names for our coordinates.  (This is an optional
-  /// part of the Drake::Vector concept, but seems worthwhile.)
+  /// part of the drake::Vector concept, but seems worthwhile.)
   friend std::string getCoordinateName(const DrivingCommand<ScalarType>& vec,
                                        unsigned int index) {
     switch (index) {

--- a/drake/examples/Cars/gen/euler_floating_joint_state.h
+++ b/drake/examples/Cars/gen/euler_floating_joint_state.h
@@ -26,7 +26,7 @@ struct EulerFloatingJointStateIndices {
   static const int kYaw = 5;
 };
 
-/// Models the Drake::LCMVector concept.
+/// Models the drake::LCMVector concept.
 template <typename ScalarType = double>
 class EulerFloatingJointState {
  public:
@@ -49,7 +49,7 @@ class EulerFloatingJointState {
   void set_yaw(const ScalarType& yaw) { value_(K::kYaw) = yaw; }
   //@}
 
-  /// @name Implement the Drake::Vector concept.
+  /// @name Implement the drake::Vector concept.
   //@{
 
   // Even though in practice we have a fixed size, we declare
@@ -67,7 +67,7 @@ class EulerFloatingJointState {
 
   /// Implicit Eigen::Matrix conversion.
   template <typename Derived>
-  // NOLINTNEXTLINE(runtime/explicit) per Drake::Vector.
+  // NOLINTNEXTLINE(runtime/explicit) per drake::Vector.
   EulerFloatingJointState(const Eigen::MatrixBase<Derived>& value)
       : value_(value.segment(0, K::kNumCoordiates)) {}
 
@@ -84,7 +84,7 @@ class EulerFloatingJointState {
   }
 
   /// Magic pretty names for our coordinates.  (This is an optional
-  /// part of the Drake::Vector concept, but seems worthwhile.)
+  /// part of the drake::Vector concept, but seems worthwhile.)
   friend std::string getCoordinateName(
       const EulerFloatingJointState<ScalarType>& vec, unsigned int index) {
     switch (index) {

--- a/drake/examples/Cars/gen/simple_car_state.h
+++ b/drake/examples/Cars/gen/simple_car_state.h
@@ -24,7 +24,7 @@ struct SimpleCarStateIndices {
   static const int kVelocity = 3;
 };
 
-/// Models the Drake::LCMVector concept.
+/// Models the drake::LCMVector concept.
 template <typename ScalarType = double>
 class SimpleCarState {
  public:
@@ -45,7 +45,7 @@ class SimpleCarState {
   }
   //@}
 
-  /// @name Implement the Drake::Vector concept.
+  /// @name Implement the drake::Vector concept.
   //@{
 
   // Even though in practice we have a fixed size, we declare
@@ -63,7 +63,7 @@ class SimpleCarState {
 
   /// Implicit Eigen::Matrix conversion.
   template <typename Derived>
-  // NOLINTNEXTLINE(runtime/explicit) per Drake::Vector.
+  // NOLINTNEXTLINE(runtime/explicit) per drake::Vector.
   SimpleCarState(const Eigen::MatrixBase<Derived>& value)
       : value_(value.segment(0, K::kNumCoordiates)) {}
 
@@ -80,7 +80,7 @@ class SimpleCarState {
   }
 
   /// Magic pretty names for our coordinates.  (This is an optional
-  /// part of the Drake::Vector concept, but seems worthwhile.)
+  /// part of the drake::Vector concept, but seems worthwhile.)
   friend std::string getCoordinateName(const SimpleCarState<ScalarType>& vec,
                                        unsigned int index) {
     switch (index) {

--- a/drake/examples/Cars/lcm_tap.h
+++ b/drake/examples/Cars/lcm_tap.h
@@ -27,7 +27,7 @@ class LcmTap {
   //@{
 
   template <typename ScalarType>
-  using StateVector = Drake::NullVector<ScalarType>;
+  using StateVector = drake::NullVector<ScalarType>;
   template <typename ScalarType>
   using InputVector = Vector<ScalarType>;
   template <typename ScalarType>

--- a/drake/examples/Cars/lcm_vector_gen.py
+++ b/drake/examples/Cars/lcm_vector_gen.py
@@ -56,7 +56,7 @@ def generate_default_ctor(context, _):
 EIGEN_CTOR = """
   /// Implicit Eigen::Matrix conversion.
   template <typename Derived>
-  // NOLINTNEXTLINE(runtime/explicit) per Drake::Vector.
+  // NOLINTNEXTLINE(runtime/explicit) per drake::Vector.
   %(camel)s(const Eigen::MatrixBase<Derived>& value)
       : value_(value.segment(0, K::kNumCoordiates)) {}
 """
@@ -96,7 +96,7 @@ def generate_to_eigen(context, _):
 
 COORD_NAMER_BEGIN = """
   /// Magic pretty names for our coordinates.  (This is an optional
-  /// part of the Drake::Vector concept, but seems worthwhile.)
+  /// part of the drake::Vector concept, but seems worthwhile.)
   friend std::string getCoordinateName(const %(camel)s<ScalarType>& vec,
                                        unsigned int index) {
     switch (index) {
@@ -208,7 +208,7 @@ namespace drake {
 """
 
 CLASS_BEGIN = """
-/// Models the Drake::LCMVector concept.
+/// Models the drake::LCMVector concept.
 template <typename ScalarType = double>
 class %(camel)s {
  public:
@@ -217,7 +217,7 @@ class %(camel)s {
 """
 
 DRAKE_VECTOR_BEGIN = """
-  /// @name Implement the Drake::Vector concept.
+  /// @name Implement the drake::Vector concept.
   //@{
 
   // Even though in practice we have a fixed size, we declare

--- a/drake/examples/Cars/multi_car_sim_lcm.cc
+++ b/drake/examples/Cars/multi_car_sim_lcm.cc
@@ -9,9 +9,9 @@
 #include "drake/util/drakeAppUtil.h"
 #include "lcmtypes/drake/lcmt_driving_command_t.hpp"
 
-using Drake::BotVisualizer;
-using Drake::Gain;
-using Drake::SimulationOptions;
+using drake::BotVisualizer;
+using drake::Gain;
+using drake::SimulationOptions;
 
 using Eigen::VectorXd;
 
@@ -54,7 +54,7 @@ int do_main(int argc, const char* argv[]) {
         // car's root link in the world's frame.
         Eigen::Vector3d(0, 0, 0));
 
-    rigid_body_sys->addRobotFromFile(Drake::getDrakePath() +
+    rigid_body_sys->addRobotFromFile(drake::getDrakePath() +
       "/examples/Cars/models/prius/prius.sdf",
       DrakeJoint::QUATERNION, car_offset);
   }
@@ -78,7 +78,7 @@ int do_main(int argc, const char* argv[]) {
       GetCarSimulationDefaultOptions();
 
   // Starts the simulation.
-  Drake::runLCM(sys, lcm, 0, duration,
+  drake::runLCM(sys, lcm, 0, duration,
                 GetInitialState(*(rigid_body_sys.get())),
                 options);
 

--- a/drake/examples/Cars/simple_car.cc
+++ b/drake/examples/Cars/simple_car.cc
@@ -34,7 +34,7 @@ SimpleCar::OutputVector<ScalarType> drake::SimpleCar::output(   \
 
 // These instantiations must match the API documentation in simple_car.h.
 DRAKE_INSTANTIATE(double)
-DRAKE_INSTANTIATE(Drake::TaylorVarXd)
+DRAKE_INSTANTIATE(drake::TaylorVarXd)
 
 #undef DRAKE_INSTANTIATE
 

--- a/drake/examples/Cars/simple_car.h
+++ b/drake/examples/Cars/simple_car.h
@@ -48,7 +48,7 @@ class DRAKECARS_EXPORT SimpleCar {
   ///
   /// Instantiated templates for the following ScalarTypes are provided:
   /// - double
-  /// - Drake::TaylorVarXd
+  /// - drake::TaylorVarXd
   /// They are already available to link against in libdrakeCars.
   ///
   /// To use other unusual ScalarType substitutions,

--- a/drake/examples/Cars/simple_car_demo.cc
+++ b/drake/examples/Cars/simple_car_demo.cc
@@ -12,10 +12,10 @@
 #include "drake/systems/plants/BotVisualizer.h"
 #include "lcmtypes/drake/lcmt_driving_command_t.hpp"
 
-using Drake::AffineSystem;
-using Drake::BotVisualizer;
-using Drake::NullVector;
-using Drake::cascade;
+using drake::AffineSystem;
+using drake::BotVisualizer;
+using drake::NullVector;
+using drake::cascade;
 
 namespace drake {
 namespace examples {
@@ -32,7 +32,7 @@ int do_main(int argc, const char* argv[]) {
   // Load a simplistic rendering from accompanying URDF file.
   //
   auto tree = std::make_shared<RigidBodyTree>(
-      Drake::getDrakePath() + "/examples/Cars/models/boxcar.urdf");
+      drake::getDrakePath() + "/examples/Cars/models/boxcar.urdf");
 
   auto viz =
       std::make_shared<BotVisualizer<EulerFloatingJointState> >(

--- a/drake/examples/Cars/test/car_simulation_test.cc
+++ b/drake/examples/Cars/test/car_simulation_test.cc
@@ -17,7 +17,7 @@ GTEST_TEST(CarSimulationTest, SimpleCarVisualizationAdapter) {
   auto dut = CreateSimpleCarVisualizationAdapter();
 
   const double time = 0.0;
-  const Drake::NullVector<double> state_vector{};
+  const drake::NullVector<double> state_vector{};
   SimpleCarState<double> input_vector{};
   EulerFloatingJointState<double> output_vector{};
   output_vector = dut->output(time, state_vector, input_vector);

--- a/drake/examples/Cars/test/simple_car_test.cc
+++ b/drake/examples/Cars/test/simple_car_test.cc
@@ -12,8 +12,8 @@
 #include "drake/util/eigen_matrix_compare.h"
 
 using drake::util::MatrixCompareType;
-using Drake::NullVector;
-using Drake::SimulationOptions;
+using drake::NullVector;
+using drake::SimulationOptions;
 
 namespace drake {
 namespace examples {
@@ -100,8 +100,8 @@ GTEST_TEST(SimpleCarTest, Accelerating) {
   SimpleCarState<double> initial_state;
   auto history_system =
       std::make_shared<HistorySystem<SimpleCarState>>(initial_state);
-  auto lead_foot = Drake::cascade(
-      Drake::cascade(
+  auto lead_foot = drake::cascade(
+      drake::cascade(
           std::make_shared<ConstantInputSystem<DrivingCommand>>(
               max_throttle),
           car),
@@ -109,7 +109,7 @@ GTEST_TEST(SimpleCarTest, Accelerating) {
 
   double start_time = 0.;
   double end_time = 100.;
-  Drake::simulate(*lead_foot, start_time, end_time, initial_state);
+  drake::simulate(*lead_foot, start_time, end_time, initial_state);
 
   double step_size = SimulationOptions().initial_step_size;
   int steps = (end_time - start_time) / step_size;
@@ -149,8 +149,8 @@ GTEST_TEST(SimpleCarTest, Braking) {
 
   auto history_system =
       std::make_shared<HistorySystem<SimpleCarState>>(initial_state);
-  auto panic_stop = Drake::cascade(
-      Drake::cascade(
+  auto panic_stop = drake::cascade(
+      drake::cascade(
           std::make_shared<ConstantInputSystem<DrivingCommand>>(
               max_brake),
           car),
@@ -158,7 +158,7 @@ GTEST_TEST(SimpleCarTest, Braking) {
 
   double start_time = 0.;
   double end_time = 100.;
-  Drake::simulate(*panic_stop, start_time, end_time, initial_state);
+  drake::simulate(*panic_stop, start_time, end_time, initial_state);
 
   double step_size = SimulationOptions().initial_step_size;
   int steps = (end_time - start_time) / step_size;
@@ -191,15 +191,15 @@ GTEST_TEST(SimpleCarTest, Steering) {
 
   auto history_system =
       std::make_shared<HistorySystem<SimpleCarState>>(initial_state);
-  auto brickyard = Drake::cascade(
-      Drake::cascade(
+  auto brickyard = drake::cascade(
+      drake::cascade(
           std::make_shared<ConstantInputSystem<DrivingCommand>>(left),
           car),
       history_system);
 
   double start_time = 0.;
   double end_time = 100.;
-  Drake::simulate(*brickyard, start_time, end_time, initial_state);
+  drake::simulate(*brickyard, start_time, end_time, initial_state);
 
   double step_size = SimulationOptions().initial_step_size;
   int steps = (end_time - start_time) / step_size;

--- a/drake/examples/Cars/test/trajectory_car_test.cc
+++ b/drake/examples/Cars/test/trajectory_car_test.cc
@@ -87,7 +87,7 @@ GTEST_TEST(TrajectoryCarTest, SegmentTest) {
           start + (heading_vector * it.distance * fractional_progress);
       const double kMaxErrorRad = 1e-6;
 
-      const Drake::NullVector<double> null_vector{};
+      const drake::NullVector<double> null_vector{};
       auto output = car_dut.output(time, null_vector, null_vector);
       EXPECT_DOUBLE_EQ(output.x(), expected_position(0));
       EXPECT_DOUBLE_EQ(output.y(), expected_position(1));

--- a/drake/examples/Cars/trajectory_car.h
+++ b/drake/examples/Cars/trajectory_car.h
@@ -44,9 +44,9 @@ class DRAKECARS_EXPORT TrajectoryCar {
   //@{
 
   template <typename ScalarType>
-  using StateVector = Drake::NullVector<ScalarType>;
+  using StateVector = drake::NullVector<ScalarType>;
   template <typename ScalarType>
-  using InputVector = Drake::NullVector<ScalarType>;
+  using InputVector = drake::NullVector<ScalarType>;
   template <typename ScalarType>
   using OutputVector = SimpleCarState<ScalarType>;
 

--- a/drake/examples/Pendulum/Pendulum.h
+++ b/drake/examples/Pendulum/Pendulum.h
@@ -7,7 +7,7 @@
 using namespace std;
 
 template <typename ScalarType = double>
-class PendulumState {  // models the Drake::Vector concept
+class PendulumState {  // models the drake::Vector concept
  public:
   typedef drake::lcmt_drake_signal LCMMessageType;
   static std::string channel() { return "PendulumState"; }
@@ -15,7 +15,7 @@ class PendulumState {  // models the Drake::Vector concept
   PendulumState(void) : theta(0), thetadot(0) {}
 
   template <typename Derived>
-  PendulumState(  // NOLINT(runtime/explicit) per Drake::Vector.
+  PendulumState(  // NOLINT(runtime/explicit) per drake::Vector.
       const Eigen::MatrixBase<Derived>& x)
       : theta(x(0)), thetadot(x(1)) {}
 
@@ -58,7 +58,7 @@ class PendulumInput {
   PendulumInput(void) : tau(0) {}
 
   template <typename Derived>
-  PendulumInput(  // NOLINT(runtime/explicit) per Drake::Vector.
+  PendulumInput(  // NOLINT(runtime/explicit) per drake::Vector.
       const Eigen::MatrixBase<Derived>& x)
       : tau(x(0)) {}
 
@@ -134,7 +134,7 @@ class PendulumEnergyShapingController {
   template <typename ScalarType>
   using InputVector = PendulumState<ScalarType>;
   template <typename ScalarType>
-  using StateVector = Drake::NullVector<ScalarType>;
+  using StateVector = drake::NullVector<ScalarType>;
   template <typename ScalarType>
   using OutputVector = PendulumInput<ScalarType>;
 

--- a/drake/examples/Pendulum/runDynamics.cpp
+++ b/drake/examples/Pendulum/runDynamics.cpp
@@ -11,7 +11,7 @@
 #include "drake/util/drakeAppUtil.h"
 
 using namespace std;
-using namespace Drake;
+using namespace drake;
 
 int main(int argc, char* argv[]) {
   shared_ptr<lcm::LCM> lcm = make_shared<lcm::LCM>();

--- a/drake/examples/Pendulum/runEnergyShaping.cpp
+++ b/drake/examples/Pendulum/runEnergyShaping.cpp
@@ -9,7 +9,7 @@
 #include "drake/util/drakeAppUtil.h"
 
 using namespace std;
-using namespace Drake;
+using namespace drake;
 
 /**
  * Runs the energy shaping controller as an LCM node or, with "-s",

--- a/drake/examples/Pendulum/runLQR.cpp
+++ b/drake/examples/Pendulum/runLQR.cpp
@@ -10,7 +10,7 @@
 #include "drake/util/drakeAppUtil.h"
 
 using namespace std;
-using namespace Drake;
+using namespace drake;
 
 int main(int argc, char* argv[]) {
   shared_ptr<lcm::LCM> lcm = make_shared<lcm::LCM>();

--- a/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
@@ -14,8 +14,8 @@ using drake::util::MatrixCompareType;
 GTEST_TEST(PendulumDynamicConstraint, PendulumDynamicConstraintTest) {
   auto p = make_shared<Pendulum>();
 
-  Eigen::VectorXd x(1 + Drake::getNumStates(*p) * 2 +
-                        Drake::getNumInputs(*p) * 2);
+  Eigen::VectorXd x(1 + drake::getNumStates(*p) * 2 +
+                        drake::getNumInputs(*p) * 2);
   x(0) = 0.2;          // h
   x(1) = 0;            // x0(0)
   x(2) = 0;            // x0(1)
@@ -26,8 +26,8 @@ GTEST_TEST(PendulumDynamicConstraint, PendulumDynamicConstraintTest) {
 
   drake::systems::SystemDynamicConstraint<Pendulum> dut(p);
 
-  Drake::TaylorVecXd result;
-  dut.Eval(Drake::initializeAutoDiff(x), result);
+  drake::TaylorVecXd result;
+  dut.Eval(drake::initializeAutoDiff(x), result);
 
   // Expected values came from running the MATLAB code for
   // PendulumPlant through the constraint function in

--- a/drake/examples/Pendulum/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Pendulum/test/urdfDynamicsTest.cpp
@@ -5,9 +5,9 @@
 #include "drake/util/testUtil.h"
 #include "gtest/gtest.h"
 
-using Drake::getDrakePath;
-using Drake::getRandomVector;
-using Drake::RigidBodySystem;
+using drake::getDrakePath;
+using drake::getRandomVector;
+using drake::RigidBodySystem;
 using drake::util::MatrixCompareType;
 
 namespace drake {

--- a/drake/examples/QPInverseDynamicsForHumanoids/test_gravity_compensation_for_valkyrie.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/test_gravity_compensation_for_valkyrie.cc
@@ -53,7 +53,7 @@ QPOutput TestGravityCompensation(const HumanoidStatus& robot_status) {
 int main() {
   // Loads model.
   std::string urdf =
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
       std::string(
           "/examples/QPInverseDynamicsForHumanoids/valkyrie_sim_drake.urdf");
   HumanoidStatus robot_status(

--- a/drake/examples/Quadrotor/Quadrotor.h
+++ b/drake/examples/Quadrotor/Quadrotor.h
@@ -9,7 +9,7 @@
 #include "drake/util/drakeGeometryUtil.h"
 
 template <typename ScalarType = double>
-class QuadrotorState {  // models the Drake::Vector concept
+class QuadrotorState {  // models the drake::Vector concept
  public:
   QuadrotorState(void)
       : x(0),
@@ -26,7 +26,7 @@ class QuadrotorState {  // models the Drake::Vector concept
         yawdot(0) {}
 
   template <typename Derived>
-  QuadrotorState(  // NOLINT(runtime/explicit) per Drake::Vector.
+  QuadrotorState(  // NOLINT(runtime/explicit) per drake::Vector.
       const Eigen::MatrixBase<Derived>& state)
       : x(state(0)),
         y(state(1)),
@@ -100,7 +100,7 @@ class QuadrotorInput {
   QuadrotorInput(void) : w1(0), w2(0), w3(0), w4(0) {}
 
   template <typename Derived>
-  QuadrotorInput(  // NOLINT(runtime/explicit) per Drake::Vector.
+  QuadrotorInput(  // NOLINT(runtime/explicit) per drake::Vector.
       const Eigen::MatrixBase<Derived>& x)
       : w1(x(0)), w2(x(1)), w3(x(2)), w4(x(3)) {}
 

--- a/drake/examples/Quadrotor/QuadrotorInput.h
+++ b/drake/examples/Quadrotor/QuadrotorInput.h
@@ -12,7 +12,7 @@ class QuadrotorInput {
     QuadrotorInput(void) : motors(Eigen::Vector4d::Zero()) {}
 
     template <typename Derived>
-    QuadrotorInput(  // NOLINT(runtime/explicit) per Drake::Vector.
+    QuadrotorInput(  // NOLINT(runtime/explicit) per drake::Vector.
         const Eigen::MatrixBase<Derived>& x) : motors(x) {}
 
     template <typename Derived>

--- a/drake/examples/Quadrotor/QuadrotorOutput.h
+++ b/drake/examples/Quadrotor/QuadrotorOutput.h
@@ -23,7 +23,7 @@ class QuadrotorOutput {
     }
 
     template <typename Derived>
-    QuadrotorOutput(  // NOLINT(runtime/explicit) per Drake::Vector.
+    QuadrotorOutput(  // NOLINT(runtime/explicit) per drake::Vector.
         const Eigen::MatrixBase<Derived>& x) {
       fromEigen<Derived>(x);
     }

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -13,7 +13,7 @@
 #include "QuadrotorOutput.h"
 
 using namespace std;
-using namespace Drake;
+using namespace drake;
 using namespace Eigen;
 
 int main(int argc, char* argv[]) {

--- a/drake/examples/Quadrotor/runLQR.cpp
+++ b/drake/examples/Quadrotor/runLQR.cpp
@@ -11,7 +11,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 int main(int argc, char* argv[]) {
   shared_ptr<lcm::LCM> lcm(new lcm::LCM);

--- a/drake/examples/Quadrotor/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Quadrotor/test/urdfDynamicsTest.cpp
@@ -7,9 +7,9 @@
 #include "drake/util/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
-using Drake::getDrakePath;
-using Drake::getRandomVector;
-using Drake::RigidBodySystem;
+using drake::getDrakePath;
+using drake::getRandomVector;
+using drake::RigidBodySystem;
 using drake::util::MatrixCompareType;
 
 namespace drake {

--- a/drake/examples/kuka_iiwa_arm/iiwa_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_simulation.cc
@@ -7,7 +7,7 @@ namespace drake {
 namespace examples {
 namespace kuka_iiwa_arm {
 
-using Drake::RigidBodySystem;
+using drake::RigidBodySystem;
 
 std::shared_ptr<RigidBodySystem> CreateKukaIiwaSystem(void) {
   // Instantiates a rigid body system and adds the robot arm to it.
@@ -15,7 +15,7 @@ std::shared_ptr<RigidBodySystem> CreateKukaIiwaSystem(void) {
       Eigen::aligned_allocator<RigidBodySystem>());
 
   rigid_body_system->addRobotFromFile(
-      Drake::getDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf",
+      drake::getDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf",
       DrakeJoint::FIXED);
 
   // Sets some simulation parameters.
@@ -47,9 +47,9 @@ std::shared_ptr<RigidBodySystem> CreateKukaIiwaSystem(void) {
   return rigid_body_system;
 }
 
-Drake::SimulationOptions SetupSimulation(void) {
+drake::SimulationOptions SetupSimulation(void) {
   // Specifies the simulation options.
-  Drake::SimulationOptions options;
+  drake::SimulationOptions options;
   options.realtime_factor = 0;  // As fast as possible.
   options.initial_step_size = 0.002;
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_simulation.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_simulation.h
@@ -23,13 +23,13 @@ namespace kuka_iiwa_arm {
  * @return A shared pointer to a rigid body system.
  */
 DRAKEKUKAIIWAARM_EXPORT
-std::shared_ptr<Drake::RigidBodySystem> CreateKukaIiwaSystem();
+std::shared_ptr<drake::RigidBodySystem> CreateKukaIiwaSystem();
 
 /**
  * Returns the simulation options for use by the Kuka IIWA simulation.
  */
 DRAKEKUKAIIWAARM_EXPORT
-Drake::SimulationOptions SetupSimulation();
+drake::SimulationOptions SetupSimulation();
 
 }  // namespace kuka_iiwa_arm
 }  // namespace examples

--- a/drake/examples/kuka_iiwa_arm/iiwa_status.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_status.h
@@ -13,7 +13,7 @@ namespace kuka_iiwa_arm {
 /// the IIWA robot (intended for use as a state vector to pass into
 /// BotVisualizer).  As a generic receiver of the `lcmt_iiwa_status`
 /// message, it could in the future be expanded to hold additional
-/// data from that message as needed.  Models the `Drake::LCMVector`
+/// data from that message as needed.  Models the `drake::LCMVector`
 /// concept.
 template <typename ScalarType = double>
 class IiwaStatus {
@@ -46,7 +46,7 @@ class IiwaStatus {
   EigenType joint_position_values_;
 };
 
-/// Implemented per the `Drake::LCMVector` concept for the encode
+/// Implemented per the `drake::LCMVector` concept for the encode
 /// function.  Currently only handles measured joint positions (since
 /// that's all `IiwaStatus` does).
 template <typename ScalarType>
@@ -67,7 +67,7 @@ bool encode(const double& t, const IiwaStatus<ScalarType>& wrap,
   return true;
 }
 
-/// Implemented per the `Drake::LCMVector` concept for the decode
+/// Implemented per the `drake::LCMVector` concept for the decode
 /// function.  Currently only handles measured joint position (since
 /// that's all `IiwaStatus` does).
 template <typename ScalarType>

--- a/drake/examples/kuka_iiwa_arm/kuka_ik_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_ik_demo.cc
@@ -17,7 +17,7 @@
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using Eigen::VectorXi;
-using Drake::Vector1d;
+using drake::Vector1d;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 
@@ -119,7 +119,7 @@ int do_main(int argc, const char* argv[]) {
   std::shared_ptr<lcm::LCM> lcm = std::make_shared<lcm::LCM>();
 
   RigidBodyTree tree(
-      Drake::getDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf",
+      drake::getDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf",
       DrakeJoint::FIXED);
 
   // Create a basic pointwise IK trajectory for moving the iiwa arm.

--- a/drake/examples/kuka_iiwa_arm/kuka_lcm_visualizer.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_lcm_visualizer.cc
@@ -19,11 +19,11 @@ template <template <typename> class Vector>
 class SinkSystem {
  public:
   template <typename ScalarType>
-  using StateVector = Drake::NullVector<ScalarType>;
+  using StateVector = drake::NullVector<ScalarType>;
   template <typename ScalarType>
   using InputVector = Vector<ScalarType>;
   template <typename ScalarType>
-  using OutputVector = Drake::NullVector<ScalarType>;
+  using OutputVector = drake::NullVector<ScalarType>;
 
   SinkSystem() {}
 
@@ -51,10 +51,10 @@ int DoMain(int argc, const char* argv[]) {
       CreateKukaIiwaSystem()->getRigidBodyTree();
 
   auto visualizer =
-      std::make_shared<Drake::BotVisualizer<IiwaStatus>>(lcm, tree);
+      std::make_shared<drake::BotVisualizer<IiwaStatus>>(lcm, tree);
   auto sink = std::make_shared<SinkSystem<IiwaStatus>>();
-  auto sys = Drake::cascade(visualizer, sink);
-  Drake::runLCM(sys, lcm, 0, 1e9);
+  auto sys = drake::cascade(visualizer, sink);
+  drake::runLCM(sys, lcm, 0, 1e9);
   return 0;
 }
 

--- a/drake/examples/kuka_iiwa_arm/robot_state_tap.h
+++ b/drake/examples/kuka_iiwa_arm/robot_state_tap.h
@@ -22,7 +22,7 @@ class RobotStateTap {
   //@{
 
   template <typename ScalarType>
-  using StateVector = Drake::NullVector<ScalarType>;
+  using StateVector = drake::NullVector<ScalarType>;
   template <typename ScalarType>
   using InputVector = Vector<ScalarType>;
   template <typename ScalarType>
@@ -35,7 +35,7 @@ class RobotStateTap {
 
   OutputVector<double> output(const double& t, const StateVector<double>& x,
                               const InputVector<double>& u) {
-    u_ = Drake::toEigen(u);
+    u_ = drake::toEigen(u);
     return u;
   }
 

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
@@ -11,9 +11,9 @@
 #include "drake/util/Polynomial.h"
 #include "drake/util/drakeAppUtil.h"
 
-using Drake::RigidBodySystem;
-using Drake::BotVisualizer;
-using Drake::cascade;
+using drake::RigidBodySystem;
+using drake::BotVisualizer;
+using drake::cascade;
 using drake::RobotStateTap;
 using Eigen::VectorXd;
 
@@ -45,7 +45,7 @@ int DoMain(int argc, char* argv[]) {
   x0.head(tree->number_of_positions()) = tree->getZeroConfiguration();
 
   // Specifies the simulation options.
-  Drake::SimulationOptions options;
+  drake::SimulationOptions options;
   options.realtime_factor = 0;  // As fast as possible.
   options.initial_step_size = 0.002;
 
@@ -72,7 +72,7 @@ int DoMain(int argc, char* argv[]) {
 
   // Starts the simulation.
   const double kStartTime = 0;
-  Drake::simulate(*sys.get(), kStartTime, duration, x0, options);
+  drake::simulate(*sys.get(), kStartTime, duration, x0, options);
 
   auto final_robot_state = robot_state_tap->get_input_vector();
   int num_positions = rigid_body_sys->number_of_positions();

--- a/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_arm_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_arm_test.cc
@@ -12,8 +12,8 @@
 #include "drake/systems/Simulation.h"
 
 
-using Drake::RigidBodySystem;
-using Drake::BotVisualizer;
+using drake::RigidBodySystem;
+using drake::BotVisualizer;
 using Eigen::VectorXd;
 using drake::RobotStateTap;
 
@@ -49,7 +49,7 @@ GTEST_TEST(testIIWAArm, iiwaArmDynamics) {
   random_initial_configuration << 0.01, -0.01, 0.01, -0.01, 0.01, -0.01, 0.01;
   x0.head(7) += random_initial_configuration;
 
-  Drake::SimulationOptions options = SetupSimulation();
+  drake::SimulationOptions options = SetupSimulation();
 
   // Starts the simulation.
   const double kStartTime = 0;
@@ -57,7 +57,7 @@ GTEST_TEST(testIIWAArm, iiwaArmDynamics) {
   // Simulation duration in seconds.
   const double kDuration = 0.5;
 
-  Drake::simulate(*sys.get(), kStartTime, kDuration, x0, options);
+  drake::simulate(*sys.get(), kStartTime, kDuration, x0, options);
 }
 
 }  // namespace

--- a/drake/math/test/expmap_test.cc
+++ b/drake/math/test/expmap_test.cc
@@ -7,7 +7,7 @@
 #include "drake/math/autodiff.h"
 #include "drake/util/eigen_matrix_compare.h"
 
-using Drake::initializeAutoDiff;
+using drake::initializeAutoDiff;
 using Eigen::AutoDiffScalar;
 using Eigen::Matrix3d;
 using Eigen::Vector4d;

--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -57,8 +57,8 @@ class Constraint {
   // Move this to DifferentiableConstraint derived class if/when we
   // need to support non-differentiable functions (at least, if
   // DifferentiableConstraint is ever implemented).
-  virtual void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-                    Drake::TaylorVecXd& y) const = 0;
+  virtual void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+                    drake::TaylorVecXd& y) const = 0;
 
   Eigen::VectorXd const& lower_bound() const { return lower_bound_; }
   Eigen::VectorXd const& upper_bound() const { return upper_bound_; }
@@ -79,8 +79,8 @@ class QuadraticConstraint : public Constraint {
   QuadraticConstraint(const Eigen::MatrixBase<DerivedQ>& Q,
                       const Eigen::MatrixBase<Derivedb>& b, double lb,
                       double ub)
-      : Constraint(kNumConstraints, Drake::Vector1d::Constant(lb),
-                   Drake::Vector1d::Constant(ub)),
+      : Constraint(kNumConstraints, drake::Vector1d::Constant(lb),
+                   drake::Vector1d::Constant(ub)),
         Q_(Q),
         b_(b) {}
 
@@ -91,11 +91,11 @@ class QuadraticConstraint : public Constraint {
     y.resize(num_constraints());
     y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
   }
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+            drake::TaylorVecXd& y) const override {
     y.resize(num_constraints());
-    y = .5 * x.transpose() * Q_.cast<Drake::TaylorVarXd>() * x +
-        b_.cast<Drake::TaylorVarXd>().transpose() * x;
+    y = .5 * x.transpose() * Q_.cast<drake::TaylorVarXd>() * x +
+        b_.cast<drake::TaylorVarXd>().transpose() * x;
   };
 
   virtual const Eigen::MatrixXd& Q() const { return Q_; }
@@ -141,8 +141,8 @@ class PolynomialConstraint : public Constraint {
     }
   }
 
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+            drake::TaylorVecXd& y) const override {
     taylor_evaluation_point_.clear();
     for (size_t i = 0; i < poly_vars_.size(); i++) {
       taylor_evaluation_point_[poly_vars_[i]] = x[i];
@@ -159,7 +159,7 @@ class PolynomialConstraint : public Constraint {
 
   /// To avoid repeated allocation, reuse a map for the evaluation point.
   mutable std::map<Polynomiald::VarType, double> double_evaluation_point_;
-  mutable std::map<Polynomiald::VarType, Drake::TaylorVarXd>
+  mutable std::map<Polynomiald::VarType, drake::TaylorVarXd>
       taylor_evaluation_point_;
 };
 
@@ -188,10 +188,10 @@ class LinearConstraint : public Constraint {
     y.resize(num_constraints());
     y = A_ * x;
   }
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+            drake::TaylorVecXd& y) const override {
     y.resize(num_constraints());
-    y = A_.cast<Drake::TaylorVarXd>() * x;
+    y = A_.cast<drake::TaylorVarXd>() * x;
   };
 
   virtual Eigen::SparseMatrix<double> GetSparseMatrix() const {
@@ -264,8 +264,8 @@ class BoundingBoxConstraint : public LinearConstraint {
     y.resize(num_constraints());
     y = x;
   }
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+            drake::TaylorVecXd& y) const override {
     y.resize(num_constraints());
     y = x;
   }
@@ -298,10 +298,10 @@ class LinearComplementarityConstraint : public Constraint {
     y.resize(num_constraints());
     y = (M_ * x) + q_;
   }
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+            drake::TaylorVecXd& y) const override {
     y.resize(num_constraints());
-    y = (M_.cast<Drake::TaylorVarXd>() * x) + q_.cast<Drake::TaylorVarXd>();
+    y = (M_.cast<drake::TaylorVarXd>() * x) + q_.cast<drake::TaylorVarXd>();
   };
 
   const Eigen::MatrixXd& M() const { return M_; }

--- a/drake/solvers/IpoptSolver.cpp
+++ b/drake/solvers/IpoptSolver.cpp
@@ -20,7 +20,7 @@ using Ipopt::IpoptData;
 using Ipopt::Number;
 using Ipopt::SolverReturn;
 
-using Drake::TaylorVecXd;
+using drake::TaylorVecXd;
 
 namespace drake {
 namespace solvers {
@@ -117,7 +117,7 @@ size_t EvaluateConstraint(
     var_count += v.size();
   }
 
-  auto tx = Drake::initializeAutoDiff(xvec);
+  auto tx = drake::initializeAutoDiff(xvec);
   TaylorVecXd this_x(var_count);
   size_t index = 0;
   for (const DecisionVariableView& v : variable_list) {
@@ -396,7 +396,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
   void EvaluateCosts(Index n, const Number* x) {
     const Eigen::VectorXd xvec = MakeEigenVector(n, x);
 
-    auto tx = Drake::initializeAutoDiff(xvec);
+    auto tx = drake::initializeAutoDiff(xvec);
     TaylorVecXd ty(1);
     TaylorVecXd this_x;
 

--- a/drake/solvers/NloptSolver.cpp
+++ b/drake/solvers/NloptSolver.cpp
@@ -10,7 +10,7 @@
 #include "drake/core/Gradient.h"
 #include "drake/solvers/Optimization.h"
 
-using Drake::TaylorVecXd;
+using drake::TaylorVecXd;
 
 namespace drake {
 namespace solvers {
@@ -31,7 +31,7 @@ TaylorVecXd MakeInputTaylorVec(const Eigen::VectorXd& xvec,
     var_count += v.size();
   }
 
-  auto tx = Drake::initializeAutoDiff(xvec);
+  auto tx = drake::initializeAutoDiff(xvec);
   TaylorVecXd this_x(var_count);
   size_t index = 0;
   for (const DecisionVariableView& v : variable_list) {
@@ -55,7 +55,7 @@ double EvaluateCosts(const std::vector<double>& x,
   double cost = 0;
   Eigen::VectorXd xvec = MakeEigenVector(x);
 
-  auto tx = Drake::initializeAutoDiff(xvec);
+  auto tx = drake::initializeAutoDiff(xvec);
   TaylorVecXd ty(1);
   TaylorVecXd this_x;
 

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -93,34 +93,34 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     // Construct by copying from an lvalue.
     template <typename... Args>
     ConstraintImpl(F const& f, Args&&... args)
-        : Constraint(Drake::FunctionTraits<F>::numOutputs(f),
+        : Constraint(drake::FunctionTraits<F>::numOutputs(f),
                      std::forward<Args>(args)...),
           f_(f) {}
 
     // Construct by moving from an rvalue.
     template <typename... Args>
     ConstraintImpl(F&& f, Args&&... args)
-        : Constraint(Drake::FunctionTraits<F>::numOutputs(f),
+        : Constraint(drake::FunctionTraits<F>::numOutputs(f),
                      std::forward<Args>(args)...),
           f_(std::forward<F>(f)) {}
 
     void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
               Eigen::VectorXd& y) const override {
-      y.resize(Drake::FunctionTraits<F>::numOutputs(f_));
+      y.resize(drake::FunctionTraits<F>::numOutputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
-                   Drake::FunctionTraits<F>::numInputs(f_));
+                   drake::FunctionTraits<F>::numInputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(y.rows()) ==
-                   Drake::FunctionTraits<F>::numOutputs(f_));
-      Drake::FunctionTraits<F>::eval(f_, x, y);
+                   drake::FunctionTraits<F>::numOutputs(f_));
+      drake::FunctionTraits<F>::eval(f_, x, y);
     }
-    void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-              Drake::TaylorVecXd& y) const override {
-      y.resize(Drake::FunctionTraits<F>::numOutputs(f_));
+    void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+              drake::TaylorVecXd& y) const override {
+      y.resize(drake::FunctionTraits<F>::numOutputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
-                   Drake::FunctionTraits<F>::numInputs(f_));
+                   drake::FunctionTraits<F>::numInputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(y.rows()) ==
-                   Drake::FunctionTraits<F>::numOutputs(f_));
-      Drake::FunctionTraits<F>::eval(f_, x, y);
+                   drake::FunctionTraits<F>::numOutputs(f_));
+      drake::FunctionTraits<F>::eval(f_, x, y);
     }
   };
 

--- a/drake/solvers/SnoptSolver.cpp
+++ b/drake/solvers/SnoptSolver.cpp
@@ -190,8 +190,8 @@ int snopt_userfun(snopt::integer* Status, snopt::integer* n,
   memset(G, 0, (*n) * sizeof(snopt::doublereal));
 
   // evaluate cost
-  auto tx = Drake::initializeAutoDiff(xvec);
-  Drake::TaylorVecXd ty(1), this_x;
+  auto tx = drake::initializeAutoDiff(xvec);
+  drake::TaylorVecXd ty(1), this_x;
 
   for (auto const& binding : current_problem->GetAllCosts()) {
     auto const& obj = binding.constraint();

--- a/drake/solvers/equality_constrained_qp_solver.cc
+++ b/drake/solvers/equality_constrained_qp_solver.cc
@@ -8,7 +8,7 @@
 #include "drake/core/Gradient.h"
 #include "drake/solvers/Optimization.h"
 
-using Drake::TaylorVecXd;
+using drake::TaylorVecXd;
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/linear_system_solver.cc
+++ b/drake/solvers/linear_system_solver.cc
@@ -8,7 +8,7 @@
 #include "drake/core/Gradient.h"
 #include "drake/solvers/Optimization.h"
 
-using Drake::TaylorVecXd;
+using drake::TaylorVecXd;
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -51,14 +51,14 @@ GTEST_TEST(testGurobi, gurobiQPExample1) {
   VectorXd constraint(3);
   constraint << 1, 2, 3;
   prog.AddLinearConstraint(
-      constraint.transpose(), Drake::Vector1d::Constant(4),
-      Drake::Vector1d::Constant(std::numeric_limits<double>::infinity()));
+      constraint.transpose(), drake::Vector1d::Constant(4),
+      drake::Vector1d::Constant(std::numeric_limits<double>::infinity()));
 
   VectorXd constraint2(3);
   constraint2 << 1, 1, 0;
   prog.AddLinearConstraint(
-      constraint2.transpose(), Drake::Vector1d::Constant(1),
-      Drake::Vector1d::Constant(std::numeric_limits<double>::infinity()));
+      constraint2.transpose(), drake::Vector1d::Constant(1),
+      drake::Vector1d::Constant(std::numeric_limits<double>::infinity()));
 
   VectorXd expected(3);
   expected << 0, 1, 2.0 / 3.0;

--- a/drake/solvers/test/testOptimizationProblem.cpp
+++ b/drake/solvers/test/testOptimizationProblem.cpp
@@ -23,10 +23,10 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::VectorXd;
 
-using Drake::TaylorVecXd;
-using Drake::VecIn;
-using Drake::Vector1d;
-using Drake::VecOut;
+using drake::TaylorVecXd;
+using drake::VecIn;
+using drake::Vector1d;
+using drake::VecOut;
 using drake::util::MatrixCompareType;
 
 namespace drake {
@@ -245,8 +245,8 @@ GTEST_TEST(testOptimizationProblem, testProblem1AsQP) {
   constraint << 20, 12, 11, 7, 4;
   prog.AddLinearConstraint(
       constraint.transpose(),
-      Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
-      Drake::Vector1d::Constant(40));
+      drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
+      drake::Vector1d::Constant(40));
   prog.AddBoundingBoxConstraint(MatrixXd::Constant(5, 1, 0),
                                 MatrixXd::Constant(5, 1, 1));
   VectorXd expected(5);
@@ -327,13 +327,13 @@ GTEST_TEST(testOptimizationProblem, testProblem2AsQP) {
   constraint1 << 6, 3, 3, 2, 1, 0;
   prog.AddLinearConstraint(
       constraint1.transpose(),
-      Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
-      Drake::Vector1d::Constant(6.5));
+      drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
+      drake::Vector1d::Constant(6.5));
   constraint2 << 10, 0, 10, 0, 0, 1;
   prog.AddLinearConstraint(
       constraint2.transpose(),
-      Drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
-      Drake::Vector1d::Constant(20));
+      drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
+      drake::Vector1d::Constant(20));
 
   Eigen::VectorXd lower(6);
   lower << 0, 0, 0, 0, 0, 0;
@@ -503,7 +503,7 @@ class GloptipolyConstrainedExampleCost {
 
 class GloptipolyConstrainedExampleConstraint
     : public Constraint {  // want to also support deriving directly from
-                           // constraint without going through Drake::Function
+                           // constraint without going through drake::Function
  public:
   GloptipolyConstrainedExampleConstraint()
       : Constraint(
@@ -872,7 +872,7 @@ OptimizationProblem prog;
   constraint1 << 1, 1;
   prog.AddLinearEqualityConstraint(
       constraint1.transpose(),
-      Drake::Vector1d::Constant(1.0));
+      drake::Vector1d::Constant(1.0));
 
   prog.Solve();
 
@@ -897,7 +897,7 @@ OptimizationProblem prog;
 
   prog.AddLinearEqualityConstraint(
       constraint2.transpose(),
-      Drake::Vector1d::Constant(0.0), vars);
+      drake::Vector1d::Constant(0.0), vars);
   prog.Solve();
   expected_answer.resize(3);
   expected_answer << 0.5, 0.5, 1.0;

--- a/drake/systems/LCMSystem.cpp
+++ b/drake/systems/LCMSystem.cpp
@@ -8,7 +8,7 @@
 #include <sys/select.h>
 #endif
 
-using namespace Drake;
+using namespace drake;
 
 bool waitForLCM(lcm::LCM& lcm, double timeout) {
   int lcmFd = lcm.getFileno();
@@ -30,7 +30,7 @@ bool waitForLCM(lcm::LCM& lcm, double timeout) {
   return (status > 0 && FD_ISSET(lcmFd, &fds));
 }
 
-void Drake::internal::LCMLoop::loopWithSelect() {
+void drake::internal::LCMLoop::loopWithSelect() {
   //    cout << "starting lcm handler thread " << this_thread::get_id() << endl;
 
   while (!this->stop) {

--- a/drake/systems/LCMSystem.h
+++ b/drake/systems/LCMSystem.h
@@ -13,7 +13,7 @@
 #include "drake/systems/System.h"
 #include "drake/systems/cascade_system.h"
 
-namespace Drake {
+namespace drake {
 
 /** @defgroup lcm_vector_concept LCMVector<ScalarType> Concept
  * @ingroup vector_concept
@@ -288,4 +288,4 @@ void runLCM(const System &sys, std::shared_ptr<lcm::LCM> lcm, double t0,
   runLCM(sys, lcm, t0, tf, getInitialState(*sys));
 }
 
-}  // end namespace Drake
+}  // end namespace drake

--- a/drake/systems/LinearSystem.h
+++ b/drake/systems/LinearSystem.h
@@ -3,7 +3,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/systems/System.h"
 
-namespace Drake {
+namespace drake {
 
 /** AffineSystem<StateVector, InputVector, OutputVector>
  * @brief Builds an affine system from it's state-space matrix coefficients
@@ -121,4 +121,4 @@ class Gain : public LinearSystem<NullVector, InputVec, OutputVec> {
             Eigen::Matrix<double, Eigen::Dynamic, 0>(D.rows(), 0), D) {}
 };
 
-}  // end namespace Drake
+}  // end namespace drake

--- a/drake/systems/Simulation.h
+++ b/drake/systems/Simulation.h
@@ -9,7 +9,7 @@
 #include "drake/core/Vector.h"
 #include "drake/systems/simulation_options.h"
 
-namespace Drake {
+namespace drake {
 
 /** @defgroup simulation Simulation
 *@{
@@ -157,4 +157,4 @@ void simulate(const System& sys, double t0, double tf) {
   simulate(sys, t0, tf, x0);
 }
 
-}  // end namespace Drake
+}  // end namespace drake

--- a/drake/systems/System.h
+++ b/drake/systems/System.h
@@ -8,7 +8,7 @@
 #include "drake/core/Gradient.h"
 #include "drake/core/Vector.h"
 
-namespace Drake {
+namespace drake {
 
 /** @defgroup modeling Modeling Dynamical Systems
  * @{
@@ -66,13 +66,13 @@ namespace Drake {
  *
  * (always try to label your methods with const if possible)
  *
- * todo: dynamics and output should be implemented as Drake::Function(s) with
+ * todo: dynamics and output should be implemented as drake::Function(s) with
  * input-output relationships defined.  then we would no longer specify
  * isTimeVarying and isDirectFeedthrough (we could extract them from the
  * input-output relationship)
  *
  * todo: move xdot and y to be arguments instead of return values, to be
- * consistent with Drake::Function.
+ * consistent with drake::Function.
  *
  * @nbsp
  *
@@ -218,7 +218,7 @@ struct CreateStateVectorDispatch<
         typename System::template StateVector<Scalar>>::value>::type> {
   static typename System::template StateVector<Scalar> eval(const System& sys) {
     return
-        typename System::template StateVector<Scalar>(Drake::getNumStates(sys));
+        typename System::template StateVector<Scalar>(drake::getNumStates(sys));
   }
 };
 
@@ -242,4 +242,4 @@ typename System::template StateVector<Scalar> createStateVector(
   return internal::CreateStateVectorDispatch<System, Scalar>::eval(sys);
 }
 
-}  // end namespace Drake
+}  // end namespace drake

--- a/drake/systems/cascade_system.h
+++ b/drake/systems/cascade_system.h
@@ -7,7 +7,7 @@
 #include "drake/core/Vector.h"
 #include "drake/systems/System.h"
 
-namespace Drake {
+namespace drake {
 
 /** CascadeSystem<System1,System2>
  * @brief Builds a new system from the cascade connection of two simpler systems
@@ -75,10 +75,10 @@ class CascadeSystem {
     return sys1->isDirectFeedthrough() && sys2->isDirectFeedthrough();
   }
   size_t getNumStates() const {
-    return Drake::getNumStates(*sys1) + Drake::getNumStates(*sys2);
+    return drake::getNumStates(*sys1) + drake::getNumStates(*sys2);
   }
-  size_t getNumInputs() const { return Drake::getNumInputs(*sys1); }
-  size_t getNumOutputs() const { return Drake::getNumOutputs(*sys2); }
+  size_t getNumInputs() const { return drake::getNumInputs(*sys1); }
+  size_t getNumOutputs() const { return drake::getNumOutputs(*sys2); }
 
  public:
   const System1Ptr& getSys1() const { return sys1; }
@@ -107,4 +107,4 @@ std::shared_ptr<CascadeSystem<System1, System2>> cascade(
   return std::make_shared<CascadeSystem<System1, System2>>(sys1, sys2);
 }
 
-}  // namespace Drake
+}  // namespace drake

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -119,7 +119,7 @@ void applyURDFModifications(std::unique_ptr<RigidBodyTree>& robot,
           "Could not find attachment frame when handling urdf modifications");
     }
     drake::parsers::urdf::AddRobotFromURDF(
-        Drake::getDrakePath() + "/" + it->urdf_filename, it->joint_type,
+        drake::getDrakePath() + "/" + it->urdf_filename, it->joint_type,
         attach_to_frame, robot.get());
   }
 

--- a/drake/systems/controllers/LQR.h
+++ b/drake/systems/controllers/LQR.h
@@ -12,7 +12,7 @@
 
 using drake::math::autoDiffToGradientMatrix;
 
-namespace Drake {
+namespace drake {
 
 template <typename System>
 std::shared_ptr<AffineSystem<NullVector, System::template StateVector,

--- a/drake/systems/feedback_system.h
+++ b/drake/systems/feedback_system.h
@@ -8,7 +8,7 @@
 #include "drake/core/Vector.h"
 #include "drake/systems/System.h"
 
-namespace Drake {
+namespace drake {
 
 /** FeedbackSystem<System1,System2>
  * @brief Builds a new system from the feedback connection of two simpler
@@ -89,10 +89,10 @@ class FeedbackSystem {
   }
   bool isDirectFeedthrough() const { return sys1->isDirectFeedthrough(); }
   size_t getNumStates() const {
-    return Drake::getNumStates(*sys1) + Drake::getNumStates(*sys2);
+    return drake::getNumStates(*sys1) + drake::getNumStates(*sys2);
   }
-  size_t getNumInputs() const { return Drake::getNumInputs(*sys1); }
-  size_t getNumOutputs() const { return Drake::getNumOutputs(*sys1); }
+  size_t getNumInputs() const { return drake::getNumInputs(*sys1); }
+  size_t getNumOutputs() const { return drake::getNumOutputs(*sys1); }
 
   const System1Ptr& getSys1() const { return sys1; }
 
@@ -155,4 +155,4 @@ std::shared_ptr<FeedbackSystem<System1, System2>> feedback(
   return std::make_shared<FeedbackSystem<System1, System2>>(sys1, sys2);
 }
 
-}  // namespace Drake
+}  // namespace drake

--- a/drake/systems/n_ary_state.h
+++ b/drake/systems/n_ary_state.h
@@ -11,12 +11,12 @@
 
 namespace drake {
 
-using Drake::toEigen;  // TODO(maddog) ...until Drake-->drake fully.
+using drake::toEigen;  // TODO(maddog) ...until Drake-->drake fully.
 
-/// NAryState is a Drake::Vector (concept implementation) which is a
-/// container of zero or more component Drake::Vector instances.  All
+/// NAryState is a drake::Vector (concept implementation) which is a
+/// container of zero or more component drake::Vector instances.  All
 /// components must be of the same type, @p UnitVector, which naturally
-/// must model the Drake::Vector concept itself.
+/// must model the drake::Vector concept itself.
 ///
 /// UnitVectors are assembled into NAryState at run-time as an ordered
 /// list with O(1) access.  The Eigen::Matrix representaion of a
@@ -25,15 +25,15 @@ using Drake::toEigen;  // TODO(maddog) ...until Drake-->drake fully.
 template <class UnitVector>
 class NAryState {
  public:
-  // The Drake::Vector concept has no explicit way of recovering the
+  // The drake::Vector concept has no explicit way of recovering the
   // ScalarType upon which the template was specialized, but through
   // the miracle of decltype(), it can be done.  std::decay<> is used
   // to strip any CV or reference qualifiers off the type.
   using UnitScalar =
       typename std::decay<decltype(toEigen(UnitVector())(0))>::type;
-  // Required by Drake::Vector concept.
+  // Required by drake::Vector concept.
   static const int RowsAtCompileTime = Eigen::Dynamic;
-  // Required by Drake::Vector concept.
+  // Required by drake::Vector concept.
   typedef Eigen::Matrix<UnitScalar, RowsAtCompileTime, 1> EigenType;
 
   NAryState() : unit_size_(unit_size()), count_(UnitCountFromRows(0)) {}
@@ -99,7 +99,7 @@ class NAryState {
     combined_vector_.block(row0, 0, unit_size_, 1) = toEigen(unit);
   }
 
-  // Required by Drake::Vector concept.
+  // Required by drake::Vector concept.
   template <typename Derived>
   // NOLINTNEXTLINE(runtime/explicit)
   NAryState(const Eigen::MatrixBase<Derived>& initial)
@@ -108,7 +108,7 @@ class NAryState {
         combined_vector_(initial) {
   }
 
-  // Required by Drake::Vector concept.
+  // Required by drake::Vector concept.
   template <typename Derived>
   NAryState& operator=(const Eigen::MatrixBase<Derived>& rhs) {
     count_ = UnitCountFromRows(rhs.rows());
@@ -116,10 +116,10 @@ class NAryState {
     return *this;
   }
 
-  // Required by Drake::Vector concept.
+  // Required by drake::Vector concept.
   int size() const { return combined_vector_.rows(); }
 
-  // Required by Drake::Vector concept.
+  // Required by drake::Vector concept.
   friend EigenType toEigen(const NAryState<UnitVector>& vec) {
     return vec.combined_vector_;
   }

--- a/drake/systems/n_ary_system.h
+++ b/drake/systems/n_ary_system.h
@@ -14,15 +14,15 @@ namespace drake {
 template <class UnitSystem>
 class NArySystem {
  public:
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   template <typename ScalarType>
   using StateVector = NAryState<
     typename UnitSystem::template StateVector<ScalarType> >;
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   template <typename ScalarType>
   using InputVector = NAryState<
     typename UnitSystem::template InputVector<ScalarType> >;
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   template <typename ScalarType>
   using OutputVector = NAryState<
     typename UnitSystem::template OutputVector<ScalarType> >;
@@ -37,7 +37,7 @@ class NArySystem {
     systems_.push_back(system);
   }
 
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   template <typename ScalarType>
   StateVector<ScalarType> dynamics(const ScalarType& time,
                                    const StateVector<ScalarType>& state,
@@ -55,7 +55,7 @@ class NArySystem {
     return xdot;
   }
 
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   template <typename ScalarType>
   OutputVector<ScalarType> output(const ScalarType& time,
                                   const StateVector<ScalarType>& state,
@@ -73,7 +73,7 @@ class NArySystem {
     return y;
   }
 
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   bool isTimeVarying() const {
     for (auto s : systems_) {
       if (s->isTimeVarying()) { return true; }
@@ -81,7 +81,7 @@ class NArySystem {
     return false;
   }
 
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   bool isDirectFeedthrough() const {
     for (auto s : systems_) {
       if (s->isDirectFeedthrough()) { return true; }
@@ -89,17 +89,17 @@ class NArySystem {
     return false;
   }
 
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   std::size_t getNumStates() const {
     return StateVector<double>::RowsFromUnitCount(systems_size());
   }
 
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   std::size_t getNumInputs() const {
     return InputVector<double>::RowsFromUnitCount(systems_size());
   }
 
-  // Required by Drake::System concept.
+  // Required by drake::System concept.
   std::size_t getNumOutputs() const {
     return OutputVector<double>::RowsFromUnitCount(systems_size());
   }

--- a/drake/systems/pd_control_system.h
+++ b/drake/systems/pd_control_system.h
@@ -8,7 +8,7 @@
 #include "drake/core/Vector.h"
 #include "drake/systems/System.h"
 
-namespace Drake {
+namespace drake {
 
 /** PDControlSystem<System>
  * @brief Wraps an existing system with a PD controller (the new system
@@ -35,12 +35,12 @@ class PDControlSystem {
   PDControlSystem(const SystemPtr& sys, const Eigen::MatrixBase<DerivedA>& Kp,
                   const Eigen::MatrixBase<DerivedB>& Kd)
       : sys_(sys), Kp_(Kp), Kd_(Kd) {
-    DRAKE_ASSERT(static_cast<int>(Drake::getNumInputs(*sys)) == Kp.rows() &&
+    DRAKE_ASSERT(static_cast<int>(drake::getNumInputs(*sys)) == Kp.rows() &&
                  "Kp must have the same number of rows as the system has"
                  " inputs");
     DRAKE_ASSERT(Kp.rows() == Kd.rows() &&
                  "Kd must have the same number of rows as Kp");
-    DRAKE_ASSERT(static_cast<int>(Drake::getNumStates(*sys)) ==
+    DRAKE_ASSERT(static_cast<int>(drake::getNumStates(*sys)) ==
                  (Kp.cols() + Kd.cols()) &&
                  "Kp and Kd must match the number of states");
   }
@@ -67,9 +67,9 @@ class PDControlSystem {
 
   bool isTimeVarying() const { return sys_->isTimeVarying(); }
   bool isDirectFeedthrough() const { return sys_->isDirectFeedthrough(); }
-  size_t getNumStates() const { return Drake::getNumStates(*sys_); }
-  size_t getNumInputs() const { return Drake::getNumStates(*sys_); }
-  size_t getNumOutputs() const { return Drake::getNumOutputs(*sys_); }
+  size_t getNumStates() const { return drake::getNumStates(*sys_); }
+  size_t getNumInputs() const { return drake::getNumStates(*sys_); }
+  size_t getNumOutputs() const { return drake::getNumOutputs(*sys_); }
 
  public:
   const SystemPtr& getSys() const { return sys_; }
@@ -83,4 +83,4 @@ class PDControlSystem {
   Eigen::MatrixXd Kp_, Kd_;
 };
 
-}  // end namespace Drake
+}  // end namespace drake

--- a/drake/systems/plants/BotVisualizer.h
+++ b/drake/systems/plants/BotVisualizer.h
@@ -11,7 +11,7 @@
 #include "lcmtypes/drake/lcmt_viewer_load_robot.hpp"
 #include "lcmtypes/drake/lcmt_viewer_draw.hpp"
 
-namespace Drake {
+namespace drake {
 
 /** BotVisualizer<RobotStateVector>
  * @brief A system which takes the robot state as input and publishes an lcm
@@ -187,4 +187,4 @@ class BotVisualizer {
   mutable drake::lcmt_viewer_draw draw_msg_;
 };
 
-}  // end namespace Drake
+}  // end namespace drake

--- a/drake/systems/plants/ConstraintWrappers.h
+++ b/drake/systems/plants/ConstraintWrappers.h
@@ -11,7 +11,7 @@
 #include "drake/systems/plants/KinematicsCache.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 
-namespace Drake {
+namespace drake {
 namespace systems {
 namespace plants {
 

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -37,15 +37,15 @@ using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 using tinyxml2::XML_SUCCESS;
 
-namespace Drake {
+namespace drake {
 
 size_t RigidBodySystem::getNumStates() const {
   return tree->number_of_positions() + tree->number_of_velocities();
 }
 
 // TODO(sam.creasey) This whole file should be in this namespace.
-using Drake::systems::plants::SingleTimeKinematicConstraintWrapper;
-using Drake::systems::plants::KinematicsCacheHelper;
+using drake::systems::plants::SingleTimeKinematicConstraintWrapper;
+using drake::systems::plants::KinematicsCacheHelper;
 
 size_t RigidBodySystem::getNumInputs(void) const {
   size_t num = tree->actuators.size();
@@ -981,4 +981,4 @@ Eigen::VectorXd spatialForceInFrameToJointTorque(
   return tau;
 }
 
-}  // namespace Drake
+}  // namespace drake

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -90,7 +90,7 @@ namespace tinyxml2 {
 class XMLElement;
 }
 
-namespace Drake {
+namespace drake {
 
 class RigidBodyForceElement;  // forward declaration
 class RigidBodySensor;        // forward declaration
@@ -729,4 +729,4 @@ class DRAKERBSYSTEM_EXPORT RigidBodyMagnetometer : public RigidBodySensor {
   std::shared_ptr<NoiseModel<double, 3, Eigen::Vector3d>> noise_model;
 };
 
-}  // end namespace Drake
+}  // end namespace drake

--- a/drake/systems/plants/collision/test/model_test.cc
+++ b/drake/systems/plants/collision/test/model_test.cc
@@ -748,7 +748,7 @@ GTEST_TEST(ModelTest, StaticMeshes) {
   DrakeShapes::Sphere sphere(0.5);
   Isometry3d pose = Isometry3d::Identity();
 
-  std::string file_name = Drake::getDrakePath() +
+  std::string file_name = drake::getDrakePath() +
       "/systems/plants/collision/test/spherical_cap.obj";
   DrakeShapes::Mesh cap(file_name, file_name);
 

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -1046,7 +1046,7 @@ GazeOrientConstraint::GazeOrientConstraint(
 void GazeOrientConstraint::eval(const double* t, KinematicsCache<double>& cache,
                                 VectorXd& c, MatrixXd& dc) const {
   using namespace std;
-  using namespace Drake;
+  using namespace drake;
 
   const int num_constraint = getNumConstraint(t);
   c.resize(num_constraint);

--- a/drake/systems/plants/constraint/dynamic_constraint.cc
+++ b/drake/systems/plants/constraint/dynamic_constraint.cc
@@ -6,7 +6,7 @@
 namespace drake {
 namespace systems {
 namespace {
-Eigen::MatrixXd ExtractDerivativesMatrix(const Drake::TaylorVecXd& vec_in) {
+Eigen::MatrixXd ExtractDerivativesMatrix(const drake::TaylorVecXd& vec_in) {
   if (!vec_in.size()) {
     return Eigen::MatrixXd();
   }
@@ -30,20 +30,20 @@ DynamicConstraint::~DynamicConstraint() {}
 
 void DynamicConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                              Eigen::VectorXd& y) const {
-  Drake::TaylorVecXd y_t;
-  Eval(Drake::initializeAutoDiff(x), y_t);
+  drake::TaylorVecXd y_t;
+  Eval(drake::initializeAutoDiff(x), y_t);
   y = math::autoDiffToValueMatrix(y_t);
 }
 
-void DynamicConstraint::Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-                             Drake::TaylorVecXd& y) const {
+void DynamicConstraint::Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+                             drake::TaylorVecXd& y) const {
   DRAKE_ASSERT(x.size() == 1 + (2 * num_states_) + (2 * num_inputs_));
 
   // Extract our input variables:
   // h - current time (knot) value
   // x0, x1 state vector at time steps k, k+1
   // u0, u1 input vector at time steps k, k+1
-  const Drake::TaylorVarXd h = x(0);
+  const drake::TaylorVarXd h = x(0);
   const auto x0 = x.segment(1, num_states_);
   const auto x1 = x.segment(1 + num_states_, num_states_);
   const auto u0 = x.segment(1 + (2 * num_states_), num_inputs_);
@@ -51,20 +51,20 @@ void DynamicConstraint::Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
 
   // TODO(sam.creasey): We should cache the dynamics outputs to avoid
   // recalculating for every knot point as we advance.
-  Drake::TaylorVecXd xdot0;
+  drake::TaylorVecXd xdot0;
   dynamics(x0, u0, &xdot0);
   Eigen::MatrixXd dxdot0 = ExtractDerivativesMatrix(xdot0);
 
-  Drake::TaylorVecXd xdot1;
+  drake::TaylorVecXd xdot1;
   dynamics(x1, u1, &xdot1);
   Eigen::MatrixXd dxdot1 = ExtractDerivativesMatrix(xdot1);
 
   // Cubic interpolation to get xcol and xdotcol.
-  const Drake::TaylorVecXd xcol = 0.5 * (x0 + x1) + h / 8 * (xdot0 - xdot1);
-  const Drake::TaylorVecXd xdotcol =
+  const drake::TaylorVecXd xcol = 0.5 * (x0 + x1) + h / 8 * (xdot0 - xdot1);
+  const drake::TaylorVecXd xdotcol =
       -1.5 * (x0 - x1) / h - .25 * (xdot0 + xdot1);
 
-  Drake::TaylorVecXd g;
+  drake::TaylorVecXd g;
   dynamics(xcol, 0.5 * (u0 + u1), &g);
   y = xdotcol - g;
 }

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -38,13 +38,13 @@ class DRAKEDYNAMICCONSTRAINT_EXPORT DynamicConstraint :
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
-  void Eval(const Eigen::Ref<const Drake::TaylorVecXd>& x,
-            Drake::TaylorVecXd& y) const override;
+  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
+            drake::TaylorVecXd& y) const override;
 
  protected:
-  virtual void dynamics(const Drake::TaylorVecXd& state,
-                        const Drake::TaylorVecXd& input,
-                        Drake::TaylorVecXd* xdot) const = 0;
+  virtual void dynamics(const drake::TaylorVecXd& state,
+                        const drake::TaylorVecXd& input,
+                        drake::TaylorVecXd* xdot) const = 0;
 
  private:
   int num_states_;
@@ -58,17 +58,17 @@ class SystemDynamicConstraint : public DynamicConstraint {
  public:
   // TODO(sam.creasey) Should this be a const bare ptr?
   explicit SystemDynamicConstraint(std::shared_ptr<System> system)
-      : DynamicConstraint(Drake::getNumStates(*system),
-                          Drake::getNumInputs(*system)),
+      : DynamicConstraint(drake::getNumStates(*system),
+                          drake::getNumInputs(*system)),
         system_(system) {}
 
  private:
-  void dynamics(const Drake::TaylorVecXd& state,
-                const Drake::TaylorVecXd& input,
-                Drake::TaylorVecXd* xdot) const override {
-    typename System::template StateVector<Drake::TaylorVarXd> x = state;
-    typename System::template InputVector<Drake::TaylorVarXd> u = input;
-    Drake::TaylorVarXd t(1);
+  void dynamics(const drake::TaylorVecXd& state,
+                const drake::TaylorVecXd& input,
+                drake::TaylorVecXd* xdot) const override {
+    typename System::template StateVector<drake::TaylorVarXd> x = state;
+    typename System::template InputVector<drake::TaylorVarXd> u = input;
+    drake::TaylorVarXd t(1);
     t = 0;
     *xdot = toEigen(system_->dynamics(t, x, u));
   }

--- a/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
@@ -18,9 +18,9 @@ class PendulumTestDynamicConstraint : public DynamicConstraint {
       : DynamicConstraint(num_states, num_inputs) {}
 
  protected:
-  void dynamics(const Drake::TaylorVecXd& state,
-                const Drake::TaylorVecXd& input,
-                Drake::TaylorVecXd* xdot) const override {
+  void dynamics(const drake::TaylorVecXd& state,
+                const drake::TaylorVecXd& input,
+                drake::TaylorVecXd* xdot) const override {
     // From the Pendulum example:
     const double m = 1.0;
     const double b = 0.1;
@@ -55,8 +55,8 @@ GTEST_TEST(DynamicConstraintPendulumDynamicsTest, DynamicConstraintTest) {
 
   PendulumTestDynamicConstraint dut(kNumStates, kNumInputs);
 
-  Drake::TaylorVecXd result;
-  dut.Eval(Drake::initializeAutoDiff(x), result);
+  drake::TaylorVecXd result;
+  dut.Eval(drake::initializeAutoDiff(x), result);
 
   EXPECT_NEAR(result(0).value(), 1.1027, 1e-4);
   EXPECT_NEAR(result(1).value(), 2.2657, 1e-4);

--- a/drake/systems/plants/constraint/test/testConstraintConstructor.cpp
+++ b/drake/systems/plants/constraint/test/testConstraintConstructor.cpp
@@ -8,7 +8,7 @@
 using namespace std;
 
 int main() {
-  RigidBodyTree* model = new RigidBodyTree(Drake::getDrakePath() +
+  RigidBodyTree* model = new RigidBodyTree(drake::getDrakePath() +
       "/examples/Atlas/urdf/atlas_minimal_contact.urdf");
   if (!model) {
     cerr << "ERROR: Failed to load model" << endl;

--- a/drake/systems/plants/contactConstraintsmex.cpp
+++ b/drake/systems/plants/contactConstraintsmex.cpp
@@ -1,4 +1,5 @@
 #include <Eigen/Sparse>
+#include "drake/common/eigen_types.h"
 #include "drake/util/mexify.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "KinematicsCache.h"
@@ -7,10 +8,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
-
-template <typename Scalar>
-using MatrixX = Matrix<Scalar, Dynamic, Dynamic>;
+using namespace drake;
 
 typedef AutoDiffScalar<VectorXd> AutoDiffDynamicSize;
 typedef DrakeJoint::AutoDiffFixedMaxSize AutoDiffFixedMaxSize;

--- a/drake/systems/plants/ik_trajectory_helper.cc
+++ b/drake/systems/plants/ik_trajectory_helper.cc
@@ -7,7 +7,7 @@
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
-namespace Drake {
+namespace drake {
 namespace systems {
 namespace plants {
 
@@ -296,4 +296,4 @@ double IKTrajectoryHelper::CalculateCost(
 
 }  // namespace plants
 }  // namespace systems
-}  // namespace Drake
+}  // namespace drake

--- a/drake/systems/plants/ik_trajectory_helper.h
+++ b/drake/systems/plants/ik_trajectory_helper.h
@@ -6,7 +6,7 @@
 
 #include "IKoptions.h"
 
-namespace Drake {
+namespace drake {
 namespace systems {
 namespace plants {
 
@@ -113,4 +113,4 @@ class IKTrajectoryHelper  {
 
 }  // namespace plants
 }  // namespace systems
-}  // namespace Drake
+}  // namespace drake

--- a/drake/systems/plants/inverseKin.cpp
+++ b/drake/systems/plants/inverseKin.cpp
@@ -5,7 +5,7 @@
 using namespace Eigen;
 using namespace std;
 
-using Drake::systems::plants::inverseKinBackend;
+using drake::systems::plants::inverseKinBackend;
 
 template <typename DerivedA, typename DerivedB, typename DerivedC>
 DRAKEIK_EXPORT void inverseKin(RigidBodyTree *model,

--- a/drake/systems/plants/inverseKinBackend.cpp
+++ b/drake/systems/plants/inverseKinBackend.cpp
@@ -34,7 +34,7 @@ using drake::solvers::SolutionResult;
 /// to C++; many methods and variables follow Matlab conventions and are
 /// documented in that file.
 
-namespace Drake {
+namespace drake {
 namespace systems {
 namespace plants {
 
@@ -298,7 +298,7 @@ void inverseKinBackend(
   if (q_seed.rows() != model->number_of_positions() || q_seed.cols() != nT ||
       q_nom.rows() != model->number_of_positions() || q_nom.cols() != nT) {
     throw std::runtime_error(
-        "Drake::inverseKinBackend: q_seed and q_nom must be of size "
+        "drake::inverseKinBackend: q_seed and q_nom must be of size "
         "nq x nT");
   }
 

--- a/drake/systems/plants/inverseKinBackend.h
+++ b/drake/systems/plants/inverseKinBackend.h
@@ -19,7 +19,7 @@ class OptimizationProblem;
 }
 }
 
-namespace Drake {
+namespace drake {
 namespace systems {
 namespace plants {
 

--- a/drake/systems/plants/inverseKinNoSnoptBackend.cpp
+++ b/drake/systems/plants/inverseKinNoSnoptBackend.cpp
@@ -7,7 +7,7 @@ using Eigen::MatrixBase;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
-namespace Drake {
+namespace drake {
 namespace systems {
 namespace plants {
 

--- a/drake/systems/plants/inverseKinPointwise.cpp
+++ b/drake/systems/plants/inverseKinPointwise.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 using namespace Eigen;
 
-using Drake::systems::plants::inverseKinBackend;
+using drake::systems::plants::inverseKinBackend;
 
 template <typename DerivedA, typename DerivedB, typename DerivedC>
 DRAKEIK_EXPORT void inverseKinPointwise(

--- a/drake/systems/plants/inverseKinSnoptBackend.cpp
+++ b/drake/systems/plants/inverseKinSnoptBackend.cpp
@@ -29,7 +29,7 @@ namespace snopt {
 using namespace Eigen;
 using namespace std;
 
-namespace Drake {
+namespace drake {
 namespace systems {
 namespace plants {
 

--- a/drake/systems/plants/inverseKinTraj.cpp
+++ b/drake/systems/plants/inverseKinTraj.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 using namespace Eigen;
 
-using Drake::systems::plants::inverseKinBackend;
+using drake::systems::plants::inverseKinBackend;
 
 template <typename DerivedA, typename DerivedB, typename DerivedC,
           typename DerivedD, typename DerivedE, typename DerivedF>

--- a/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
+++ b/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
@@ -82,7 +82,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic>* dqdot_to_v) const {
     qdot_to_v.setIdentity(getNumVelocities(), getNumPositions());
-    Drake::resizeDerivativesToMatchScalar(qdot_to_v, q(0));
+    drake::resizeDerivativesToMatchScalar(qdot_to_v, q(0));
     if (dqdot_to_v) {
       dqdot_to_v->setZero(qdot_to_v.size(), getNumPositions());
     }
@@ -96,7 +96,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic>* dv_to_qdot) const {
     v_to_qdot.setIdentity(getNumPositions(), getNumVelocities());
-    Drake::resizeDerivativesToMatchScalar(v_to_qdot, q(0));
+    drake::resizeDerivativesToMatchScalar(v_to_qdot, q(0));
     if (dv_to_qdot) {
       dv_to_qdot->setZero(v_to_qdot.size(), getNumPositions());
     }

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
@@ -230,7 +230,7 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic>* dqdot_to_v) const {
     qdot_to_v.setIdentity(getNumVelocities(), getNumPositions());
-    Drake::resizeDerivativesToMatchScalar(qdot_to_v, q(0));
+    drake::resizeDerivativesToMatchScalar(qdot_to_v, q(0));
 
     if (dqdot_to_v) {
       dqdot_to_v->setZero(qdot_to_v.size(), getNumPositions());
@@ -245,7 +245,7 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic>* dv_to_qdot) const {
     v_to_qdot.setIdentity(getNumPositions(), getNumVelocities());
-    Drake::resizeDerivativesToMatchScalar(v_to_qdot, q(0));
+    drake::resizeDerivativesToMatchScalar(v_to_qdot, q(0));
 
     if (dv_to_qdot) {
       dv_to_qdot->setZero(v_to_qdot.size(), getNumPositions());

--- a/drake/systems/plants/rigidBodyLCMNode.cpp
+++ b/drake/systems/plants/rigidBodyLCMNode.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 /** @page rigidBodyLCMNode rigidBodyLCMNode Application
  * @ingroup simulation

--- a/drake/systems/plants/rigidBodyTreeMexFunctions.cpp
+++ b/drake/systems/plants/rigidBodyTreeMexFunctions.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 typedef AutoDiffScalar<VectorXd> AutoDiffDynamicSize;
 typedef DrakeJoint::AutoDiffFixedMaxSize AutoDiffFixedMaxSize;

--- a/drake/systems/plants/test/bullet_collision_zero_rad_sphere_test.cpp
+++ b/drake/systems/plants/test/bullet_collision_zero_rad_sphere_test.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 int main(int argc, char* argv[]) {
   RigidBodyTree tree;

--- a/drake/systems/plants/test/compareRigidBodySystems.cpp
+++ b/drake/systems/plants/test/compareRigidBodySystems.cpp
@@ -9,7 +9,7 @@
 #include "drake/util/testUtil.h"
 
 using std::make_shared;
-using Drake::RigidBodySystem;
+using drake::RigidBodySystem;
 using Eigen::VectorXd;
 using drake::util::MatrixCompareType;
 

--- a/drake/systems/plants/test/lidarTest.cpp
+++ b/drake/systems/plants/test/lidarTest.cpp
@@ -10,7 +10,7 @@
 using Eigen::VectorXd;
 using std::make_shared;
 
-namespace Drake {
+namespace drake {
 namespace {
 
 int do_main(int argc, char* argv[]) {
@@ -28,7 +28,7 @@ int do_main(int argc, char* argv[]) {
   }
 
   auto lidar_sensor =
-      dynamic_cast<const Drake::RigidBodyDepthSensor*>(sensors[0]);
+      dynamic_cast<const drake::RigidBodyDepthSensor*>(sensors[0]);
   if (lidar_sensor == nullptr) {
     throw std::runtime_error(
         "ERROR: Unable to obtain pointer to the LIDAR sensor.");
@@ -129,11 +129,11 @@ int do_main(int argc, char* argv[]) {
 }
 
 }  // namespace
-}  // namespace Drake
+}  // namespace drake
 
 /**
  * This unit test sets up a LIDAR in a box room and verifies the returns.
  */
 int main(int argc, char* argv[]) {
-  return Drake::do_main(argc, argv);
+  return drake::do_main(argc, argv);
 }

--- a/drake/systems/plants/test/load_model_test.cc
+++ b/drake/systems/plants/test/load_model_test.cc
@@ -7,7 +7,7 @@
 #include "drake/systems/plants/RigidBodyFrame.h"
 #include "drake/systems/plants/RigidBodySystem.h"
 
-using Drake::RigidBodySystem;
+using drake::RigidBodySystem;
 
 namespace drake {
 namespace systems {
@@ -31,7 +31,7 @@ TEST_P(LoadModelTest, TestNoOffset) {
   // Loads the SDF model with zero offset between the model's root frame and
   // the world frame.
   rbs.addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
           "/systems/plants/test/models/cylindrical_1dof_robot." + GetParam(),
       DrakeJoint::QUATERNION);
 
@@ -94,7 +94,7 @@ TEST_P(LoadModelTest, TestVerticalOffset) {
       T_model_to_world);
 
   rbs.addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
           "/systems/plants/test/models/cylindrical_1dof_robot." + GetParam(),
       DrakeJoint::QUATERNION, weld_to_frame);
 
@@ -134,7 +134,7 @@ TEST_P(LoadModelTest, TestWeld) {
   // Loads a one-DOF SDF model with zero offset between the model's
   // root frame and the world frame.
   rbs.addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
           "/systems/plants/test/models/cylindrical_1dof_robot." + GetParam(),
       DrakeJoint::QUATERNION);
 
@@ -155,7 +155,7 @@ TEST_P(LoadModelTest, TestWeld) {
       Eigen::aligned_allocator<RigidBodyFrame>(), "joint2", link2_body,
       T_model2_to_link2);
   rbs.addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
           "/systems/plants/test/models/cylindrical_0dof_robot." + GetParam(),
       DrakeJoint::FIXED, weld_to_frame);
 
@@ -175,7 +175,7 @@ GTEST_TEST(LoadSDFTest, TestInternalOffset) {
   //   2. Zero offset between the model's world and Drake's world
   RigidBodySystem rbs;
   rbs.addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
           "/systems/plants/test/models/cylindrical_1dof_robot_offset_z1.sdf",
       DrakeJoint::QUATERNION);
 
@@ -215,7 +215,7 @@ GTEST_TEST(LoadSDFTest, TestDualOffset1) {
 
   RigidBodySystem rbs;
   rbs.addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
           "/systems/plants/test/models/cylindrical_1dof_robot_offset_z1.sdf",
       DrakeJoint::QUATERNION, weld_to_frame);
 
@@ -259,7 +259,7 @@ GTEST_TEST(LoadSDFTest, TestDualOffset2) {
       T_model_world_to_drake_world);
 
   RigidBodySystem rbs;
-  rbs.addRobotFromFile(Drake::getDrakePath() +
+  rbs.addRobotFromFile(drake::getDrakePath() +
                            "/systems/plants/test/models/"
                            "cylindrical_1dof_robot_offset_z1_r90.sdf",
                        DrakeJoint::QUATERNION, weld_to_frame);
@@ -350,7 +350,7 @@ INSTANTIATE_TEST_CASE_P(
         // Evaluates the ability to load a URDF model that's connected to the
         // world via a fixed joint.
         ModelToWorldTransformTestParams(
-            Drake::getDrakePath() +
+            drake::getDrakePath() +
                 std::string("/systems/plants/test/models/"
                             "cylindrical_1dof_robot_fixed_to_world.urdf"),
             std::string("link1"), 1, 2, 3, 0.1, 0.5, 1.8),
@@ -358,7 +358,7 @@ INSTANTIATE_TEST_CASE_P(
         // Evaluates the ability to load a URDF model that's connected to the
         // world via a floating joint.
         ModelToWorldTransformTestParams(
-            Drake::getDrakePath() +
+            drake::getDrakePath() +
                 std::string("/systems/plants/test/models/"
                             "cylindrical_1dof_robot_floating_in_world.urdf"),
             std::string("link1"), 3, 2, 1, 0.2, 0.9, -1.57)));

--- a/drake/systems/plants/test/rigid_body_system/rigid_body_system_test.cc
+++ b/drake/systems/plants/test/rigid_body_system/rigid_body_system_test.cc
@@ -13,7 +13,7 @@ namespace test {
 namespace rigid_body_system {
 namespace {
 
-using Drake::RigidBodySystem;
+using drake::RigidBodySystem;
 
 // Tests the ability to load a URDF as part of the world of a rigid body system.
 GTEST_TEST(RigidBodySystemTest, TestLoadURDFWorld) {
@@ -24,7 +24,7 @@ GTEST_TEST(RigidBodySystemTest, TestLoadURDFWorld) {
   // and is attached to the world via a fixed joint. Thus, everything in the
   // URDF becomes part of the world.
   rigid_body_sys->addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
           "/systems/plants/test/rigid_body_system/world.urdf",
       DrakeJoint::FIXED);
 
@@ -59,7 +59,7 @@ GTEST_TEST(RigidBodySystemTest, TestLoadSDFMultipleTimes) {
   // the world's coordinate frame. The second model's root frame is offset from
   // the world's coordinate frame by X = 1, Y = 1, and Z = 1.
   rigid_body_sys->addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
       "/systems/plants/test/rigid_body_system/dual_model_with_sensors.sdf");
 
   Eigen::Isometry3d T_second_model_to_world;
@@ -76,7 +76,7 @@ GTEST_TEST(RigidBodySystemTest, TestLoadSDFMultipleTimes) {
       T_second_model_to_world);
 
   rigid_body_sys->addRobotFromFile(
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
           "/systems/plants/test/rigid_body_system/dual_model_with_sensors.sdf",
       DrakeJoint::QUATERNION, weld_to_frame);
 
@@ -193,13 +193,13 @@ GTEST_TEST(RigidBodySystemTest, TestLoadURDFWithBadTransmission) {
   // verifying that an exception is thrown, and then verifying that the thrown
   // exception is the correct one.
   EXPECT_THROW(
-      rigid_body_sys->addRobotFromFile(Drake::getDrakePath() +
+      rigid_body_sys->addRobotFromFile(drake::getDrakePath() +
                                        "/systems/plants/test/rigid_body_system/"
                                        "bad_transmission_no_joint.urdf"),
       std::runtime_error);
 
   try {
-    rigid_body_sys->addRobotFromFile(Drake::getDrakePath() +
+    rigid_body_sys->addRobotFromFile(drake::getDrakePath() +
                                      "/systems/plants/test/rigid_body_system/"
                                      "bad_transmission_no_joint.urdf");
   } catch (std::runtime_error& error) {

--- a/drake/systems/plants/test/rigid_body_tree/rbt_collisions_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rbt_collisions_test.cc
@@ -47,7 +47,7 @@ class RBTCollisionTest: public ::testing::Test {
  protected:
   void SetUp() override {
     drake::parsers::sdf::AddRobotFromSDFInWorldFrame(
-        Drake::getDrakePath() +
+        drake::getDrakePath() +
         "/systems/plants/test/rigid_body_tree/small_sphere_on_large_box.sdf",
         DrakeJoint::QUATERNION, &tree_);
 

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -197,7 +197,7 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
 // https://github.com/RobotLocomotion/drake/issues/2634.
 TEST_F(RigidBodyTreeTest, TestDoKinematicsWithVectorBlocks) {
   std::string file_name =
-      Drake::getDrakePath() +
+      drake::getDrakePath() +
       "/systems/plants/test/rigid_body_tree/two_dof_robot.urdf";
   drake::parsers::urdf::AddRobotFromURDF(file_name, tree.get());
 

--- a/drake/systems/plants/test/testAccelerometer.cpp
+++ b/drake/systems/plants/test/testAccelerometer.cpp
@@ -11,10 +11,10 @@ using Eigen::Vector4d;
 using Eigen::VectorXd;
 using std::shared_ptr;
 using std::make_shared;
-using Drake::getDrakePath;
-using Drake::RigidBodySystem;
+using drake::getDrakePath;
+using drake::RigidBodySystem;
 using drake::util::MatrixCompareType;
-using Drake::RigidBodyAccelerometer;
+using drake::RigidBodyAccelerometer;
 
 namespace drake {
 namespace systems {

--- a/drake/systems/plants/test/testGyroscope.cpp
+++ b/drake/systems/plants/test/testGyroscope.cpp
@@ -10,10 +10,10 @@ using Eigen::Vector4d;
 using Eigen::VectorXd;
 using std::shared_ptr;
 using std::make_shared;
-using Drake::getDrakePath;
-using Drake::RigidBodySystem;
+using drake::getDrakePath;
+using drake::RigidBodySystem;
 using drake::util::MatrixCompareType;
-using Drake::RigidBodyGyroscope;
+using drake::RigidBodyGyroscope;
 
 namespace drake {
 namespace systems {

--- a/drake/systems/plants/test/testIK.cpp
+++ b/drake/systems/plants/test/testIK.cpp
@@ -15,7 +15,7 @@ using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 
-using Drake::getDrakePath;
+using drake::getDrakePath;
 using drake::util::CompareMatrices;
 using drake::util::MatrixCompareType;
 
@@ -82,8 +82,8 @@ GTEST_TEST(testIK, iiwaIK) {
 
   // Constrain iiwa_joint_4 between 0.9 and 1.0.
   PostureConstraint pc(&model, tspan);
-  Drake::Vector1d joint_lb(0.9);
-  Drake::Vector1d joint_ub(1.0);
+  drake::Vector1d joint_lb(0.9);
+  drake::Vector1d joint_ub(1.0);
   Eigen::VectorXi joint_idx(1);
   joint_idx(0) = model.findJoint("iiwa_joint_4")->position_num_start;
   pc.setJointLimits(joint_idx, joint_lb, joint_ub);

--- a/drake/systems/plants/test/testIKMoreConstraints.cpp
+++ b/drake/systems/plants/test/testIKMoreConstraints.cpp
@@ -16,7 +16,7 @@ using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 
-using Drake::getDrakePath;
+using drake::getDrakePath;
 using drake::util::CompareMatrices;
 using drake::util::MatrixCompareType;
 

--- a/drake/systems/plants/test/testIKpointwise.cpp
+++ b/drake/systems/plants/test/testIKpointwise.cpp
@@ -14,7 +14,7 @@ using Eigen::MatrixXd;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 
-using Drake::getDrakePath;
+using drake::getDrakePath;
 using drake::util::CompareMatrices;
 using drake::util::MatrixCompareType;
 

--- a/drake/systems/plants/test/testIKtraj.cpp
+++ b/drake/systems/plants/test/testIKtraj.cpp
@@ -14,7 +14,7 @@ using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 
-using Drake::getDrakePath;
+using drake::getDrakePath;
 
 GTEST_TEST(testIKtraj, testIKtraj) {
   RigidBodyTree model(

--- a/drake/systems/plants/test/testMagnetometer.cpp
+++ b/drake/systems/plants/test/testMagnetometer.cpp
@@ -11,9 +11,9 @@ using Eigen::Vector4d;
 using Eigen::VectorXd;
 using std::shared_ptr;
 using std::make_shared;
-using Drake::getDrakePath;
-using Drake::RigidBodyMagnetometer;
-using Drake::RigidBodySystem;
+using drake::getDrakePath;
+using drake::RigidBodyMagnetometer;
+using drake::RigidBodySystem;
 using drake::util::MatrixCompareType;
 
 namespace drake {

--- a/drake/systems/plants/test/testMassSpringDamper.cpp
+++ b/drake/systems/plants/test/testMassSpringDamper.cpp
@@ -7,10 +7,10 @@
 
 using Eigen::Matrix;
 using std::make_shared;
-using Drake::getDrakePath;
-using Drake::RigidBodySystem;
+using drake::getDrakePath;
+using drake::RigidBodySystem;
 using drake::util::MatrixCompareType;
-using Drake::toEigen;
+using drake::toEigen;
 
 namespace drake {
 namespace test {

--- a/drake/systems/plants/xmlUtil.cpp
+++ b/drake/systems/plants/xmlUtil.cpp
@@ -305,7 +305,7 @@ void populatePackageMap(map<string, string>& package_map) {
   // Since Drake's package.xml file is located at its super-build level,
   // remove the last "drake" directory from the drake path. Also omit the
   // trailing slash.
-  const std::string drake_path = Drake::getDrakePath();
+  const std::string drake_path = drake::getDrakePath();
   const std::string drake_path_parent = drake_path.substr(
       0, drake_path.find_last_of("drake") - std::string("drake").size());
 

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -27,7 +27,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 using drake::kQuaternionSize;
 using drake::kSpaceDimension;
@@ -559,7 +559,7 @@ void QPLocomotionPlan::updateSwingTrajectory(
   auto quatdot = (Phi * x0_twist.topRows<3>()).eval();
 
   auto x0_expmap_autodiff = quat2expmap(
-      Drake::initializeAutoDiffGivenGradientMatrix(x0_quat, quatdot));
+      drake::initializeAutoDiffGivenGradientMatrix(x0_quat, quatdot));
   auto x0_expmap = autoDiffToValueMatrix(x0_expmap_autodiff);
   auto xd0_expmap = autoDiffToGradientMatrix(x0_expmap_autodiff);
 

--- a/drake/systems/simulation_options.h
+++ b/drake/systems/simulation_options.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Drake {
+namespace drake {
 
 /**
  * Defines the user-tunable simulation options.
@@ -60,4 +60,4 @@ struct SimulationOptions {
         should_stop([](double sim_time) { return false; }) {}
 };
 
-}  // end namespace Drake
+}  // end namespace drake

--- a/drake/systems/test/cascade_system_test.cc
+++ b/drake/systems/test/cascade_system_test.cc
@@ -6,7 +6,7 @@
 
 using Eigen::Dynamic;
 
-namespace Drake {
+namespace drake {
 namespace {
 
 template <int NumStates1, int NumInputs1, int NumOutputs1, int NumStates2,
@@ -55,4 +55,4 @@ GTEST_TEST(CascadeSystemTest, DynamicSizes) {
 }
 
 }  // namespace
-}  // namespace Drake
+}  // namespace drake

--- a/drake/systems/test/feedback_system_test.cc
+++ b/drake/systems/test/feedback_system_test.cc
@@ -6,7 +6,7 @@
 
 using Eigen::Dynamic;
 
-namespace Drake {
+namespace drake {
 namespace {
 
 template <int NumStates1, int NumInputs1, int NumOutputs1, int NumStates2>
@@ -62,4 +62,4 @@ GTEST_TEST(FeedbackSystemTest, AlgebraicLoop) {
 }
 
 }  // namespace
-}  // namespace Drake
+}  // namespace drake

--- a/drake/systems/test/n_ary_state_test.cc
+++ b/drake/systems/test/n_ary_state_test.cc
@@ -9,8 +9,8 @@
 
 namespace {
 
-using Drake::NullVector;
-using Drake::toEigen;
+using drake::NullVector;
+using drake::toEigen;
 using drake::NAryState;
 
 // Vector-concept class for exercising composition.

--- a/drake/systems/test/n_ary_system_test.cc
+++ b/drake/systems/test/n_ary_system_test.cc
@@ -11,8 +11,8 @@
 
 namespace {
 
-using Drake::NullVector;
-using Drake::toEigen;
+using drake::NullVector;
+using drake::toEigen;
 using drake::NAryState;
 using drake::NArySystem;
 
@@ -158,7 +158,7 @@ GTEST_TEST(TestNArySystem, Cascade) {
 
   auto n1 = std::make_shared<NArySystem<SystemQ> >();
   auto n2 = std::make_shared<NArySystem<SystemQ> >();
-  auto dut = Drake::cascade(n1, n2);
+  auto dut = drake::cascade(n1, n2);
 }
 
 }  // namespace

--- a/drake/systems/test/simulation_termination_test.cc
+++ b/drake/systems/test/simulation_termination_test.cc
@@ -14,12 +14,12 @@ namespace systems {
 namespace test {
 namespace {
 
-using Drake::EigenVector;
+using drake::EigenVector;
 
 class SimulationTerminationTest : public ::testing::Test {
  public:
   void SetUp() override {
-    sys_ptr_ = Drake::system_test::CreateRandomAffineSystem<10, 10, 10>(
+    sys_ptr_ = drake::system_test::CreateRandomAffineSystem<10, 10, 10>(
       10, 10, 10);
 
     xi_.setZero();
@@ -28,31 +28,31 @@ class SimulationTerminationTest : public ::testing::Test {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   // The system to simulate.
-  std::shared_ptr<Drake::AffineSystem<EigenVector<10>::template type,
+  std::shared_ptr<drake::AffineSystem<EigenVector<10>::template type,
                              EigenVector<10>::template type,
                              EigenVector<10>::template type>> sys_ptr_;
 
   // The initial state of the system.
-  Drake::AffineSystem<EigenVector<10>::template type,
+  drake::AffineSystem<EigenVector<10>::template type,
                       EigenVector<10>::template type,
                       EigenVector<10>::template type>::StateVector<double> xi_;
 
-  Drake::SimulationOptions options_;
+  drake::SimulationOptions options_;
 
   double ti_{0};  // The initial simulation time.
   double tf_{1};  // The final simulation time.
 };
 
 
-// Tests whether Drake::simulate() can be called using default simulation
+// Tests whether drake::simulate() can be called using default simulation
 // options. Since the default termination function returns false, the simulation
 // should continue to run till the final simulation time (tf_) is reached. Thus,
 // the final simulation time should be greater than or equal to tf_.
 TEST_F(SimulationTerminationTest, TerminationConditionDefault) {
-  EXPECT_GE(Drake::simulate(*sys_ptr_, ti_, tf_, xi_, options_), tf_);
+  EXPECT_GE(drake::simulate(*sys_ptr_, ti_, tf_, xi_, options_), tf_);
 }
 
-// Tests whether Drake::simulate() can be called using simulation options
+// Tests whether drake::simulate() can be called using simulation options
 // with a custom termination function. This function returns true after the
 // simulation has advanced 0.5 seconds in simulation time. Thus, the final
 // simulation time should be greater than or equal to 0.5 seconds, and less than
@@ -62,18 +62,18 @@ TEST_F(SimulationTerminationTest, TerminationConditionAfterHalfSecond) {
   options_.should_stop = [&termination_time](double sim_time) {
     return sim_time >= termination_time;
   };
-  double final_sim_time = Drake::simulate(*sys_ptr_, ti_, tf_, xi_, options_);
+  double final_sim_time = drake::simulate(*sys_ptr_, ti_, tf_, xi_, options_);
   EXPECT_GE(final_sim_time, termination_time);
   EXPECT_LE(final_sim_time, termination_time + options_.initial_step_size);
 }
 
-// Tests whether Drake::simulate() can be called using simulation options
+// Tests whether drake::simulate() can be called using simulation options
 // with a custom termination function. This function immediately returns true
 // terminating the simulation loop. Thus, the final simulation time should be
 // equal to the initial simulation time (ti_).
 TEST_F(SimulationTerminationTest, TerminationConditionTrue) {
   options_.should_stop = [](double sim_time) { return true; };
-  EXPECT_EQ(Drake::simulate(*sys_ptr_, ti_, tf_, xi_, options_), ti_);
+  EXPECT_EQ(drake::simulate(*sys_ptr_, ti_, tf_, xi_, options_), ti_);
 }
 
 }  // namespace

--- a/drake/systems/test/system_test_util.h
+++ b/drake/systems/test/system_test_util.h
@@ -5,7 +5,7 @@
 #include "drake/systems/feedback_system.h"
 #include "drake/systems/test/system_test_util.h"
 
-namespace Drake {
+namespace drake {
 namespace system_test {
 
 template <int StatesAtCompileTime, int InputsAtCompileTime,
@@ -51,4 +51,4 @@ CreateRandomAffineSystem(size_t num_states, size_t num_inputs,
 }
 
 }  // namespace system_test
-}  // namespace Drake
+}  // namespace drake

--- a/drake/systems/test/testAffineSystem.cpp
+++ b/drake/systems/test/testAffineSystem.cpp
@@ -7,7 +7,7 @@
 #include "drake/systems/test/system_test_util.h"
 
 using namespace std;
-using namespace Drake;
+using namespace drake;
 using namespace Eigen;
 
 template <int StatesAtCompileTime, int InputsAtCompileTime,

--- a/drake/util/Polynomial.h
+++ b/drake/util/Polynomial.h
@@ -242,11 +242,11 @@ class DRAKEPOLYNOMIAL_EXPORT Polynomial {
    * no knowledge of what partial derivative terms the indices of a given
    * TaylorVarXd correspond to.
    */
-  Drake::TaylorVarXd EvaluateMultivariate(
-      const std::map<VarType, Drake::TaylorVarXd>& var_values) const {
-    Drake::TaylorVarXd value(0);
+  drake::TaylorVarXd EvaluateMultivariate(
+      const std::map<VarType, drake::TaylorVarXd>& var_values) const {
+    drake::TaylorVarXd value(0);
     for (const Monomial& monomial : monomials_) {
-      Drake::TaylorVarXd monomial_value(monomial.coefficient);
+      drake::TaylorVarXd monomial_value(monomial.coefficient);
       for (const Term& term : monomial.terms) {
         monomial_value *= pow(var_values.at(term.var), term.power);
       }

--- a/drake/util/closestExpmapmex.cpp
+++ b/drake/util/closestExpmapmex.cpp
@@ -9,7 +9,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 using drake::math::autoDiffToValueMatrix;
 using drake::math::autoDiffToGradientMatrix;

--- a/drake/util/drakeGradientUtil.h
+++ b/drake/util/drakeGradientUtil.h
@@ -307,7 +307,7 @@ void gradientMatrixToAutoDiff(
   }
 }
 
-namespace Drake {
+namespace drake {
 namespace internal {
 template <typename Derived, typename Scalar>
 struct ResizeDerivativesToMatchScalarImpl {
@@ -348,4 +348,4 @@ void resizeDerivativesToMatchScalar(Eigen::MatrixBase<Derived>& mat,
   internal::ResizeDerivativesToMatchScalarImpl<
       Derived, typename Derived::Scalar>::run(mat, scalar);
 }
-}  // namespace Drake
+}  // namespace drake

--- a/drake/util/expmap2quatImplmex.cpp
+++ b/drake/util/expmap2quatImplmex.cpp
@@ -9,7 +9,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 using drake::math::autoDiffToValueMatrix;
 using drake::math::autoDiffToGradientMatrix;

--- a/drake/util/flipExpmapmex.cpp
+++ b/drake/util/flipExpmapmex.cpp
@@ -9,7 +9,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 using drake::math::autoDiffToValueMatrix;
 using drake::math::autoDiffToGradientMatrix;

--- a/drake/util/makeFunction.h
+++ b/drake/util/makeFunction.h
@@ -2,7 +2,7 @@
 
 #include <functional>
 
-namespace Drake {
+namespace drake {
 /**
 * make_function
 * Note that a completely general make_function implementation is not possible

--- a/drake/util/quat2expmapmex.cpp
+++ b/drake/util/quat2expmapmex.cpp
@@ -9,7 +9,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 pair<Vector3d, typename Gradient<Vector3d, 4>::type> quat2expmapWithGradient(
     const MatrixBase<Map<const Vector4d>>& quat) {

--- a/drake/util/standardMexConversions.h
+++ b/drake/util/standardMexConversions.h
@@ -277,7 +277,7 @@ int toMex(const std::vector<T>& source, mxArray* dest[], int nlhs) {
   return 1;
 }
 
-namespace Drake {
+namespace drake {
 namespace internal {
 template <size_t Index>
 struct TupleToMexHelper {
@@ -304,6 +304,6 @@ struct TupleToMexHelper<0> {
 
 template <typename... Ts>
 int toMex(const std::tuple<Ts...>& source, mxArray* dest[], int nlhs) {
-  return Drake::internal::TupleToMexHelper<sizeof...(Ts)>::run(source, dest,
+  return drake::internal::TupleToMexHelper<sizeof...(Ts)>::run(source, dest,
                                                                nlhs);
 }

--- a/drake/util/test/testGeometryConversionFunctionsmex.cpp
+++ b/drake/util/test/testGeometryConversionFunctionsmex.cpp
@@ -49,7 +49,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   rpydot2angularvelMatrix(rpy, rpyd2omega, &drpyd2omega);
 
   auto qd2omega_autodiff =
-      quatdot2angularvelMatrix(Drake::initializeAutoDiff(q));
+      quatdot2angularvelMatrix(drake::initializeAutoDiff(q));
   qd2omega = autoDiffToValueMatrix(qd2omega_autodiff);
   dqd2omega = autoDiffToGradientMatrix(qd2omega_autodiff);
 

--- a/drake/util/test/testQuatmex.cpp
+++ b/drake/util/test/testQuatmex.cpp
@@ -9,7 +9,7 @@
 
 using namespace Eigen;
 using namespace std;
-using namespace Drake;
+using namespace drake;
 
 using drake::math::autoDiffToGradientMatrix;
 using drake::math::autoDiffToValueMatrix;

--- a/drake/util/unwrapExpmapmex.cpp
+++ b/drake/util/unwrapExpmapmex.cpp
@@ -9,7 +9,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace Drake;
+using namespace drake;
 
 using drake::math::autoDiffToValueMatrix;
 using drake::math::autoDiffToGradientMatrix;

--- a/ros/drake_cars_examples/src/car_sim_lcm_and_ros.cc
+++ b/ros/drake_cars_examples/src/car_sim_lcm_and_ros.cc
@@ -14,9 +14,9 @@
 #include "drake_ros/ros_sensor_publisher_lidar.h"
 #include "drake_ros/ros_sensor_publisher_odometry.h"
 
-using Drake::BotVisualizer;
-using Drake::SimulationOptions;
-using Drake::cascade;
+using drake::BotVisualizer;
+using drake::SimulationOptions;
+using drake::cascade;
 
 using Eigen::VectorXd;
 

--- a/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_joint_state.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_joint_state.h
@@ -13,10 +13,10 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/plants/RigidBodySystem.h"
 
-using Drake::NullVector;
-using Drake::RigidBodySensor;
-using Drake::RigidBodySystem;
-using Drake::RigidBodyDepthSensor;
+using drake::NullVector;
+using drake::RigidBodySensor;
+using drake::RigidBodySystem;
+using drake::RigidBodyDepthSensor;
 
 using Eigen::VectorXd;
 
@@ -234,7 +234,7 @@ class SensorPublisherJointState {
     // The input vector u contains the entire system's state. The following
     // The following code extracts the position and velocity values from it
     // and computes the kinematic properties of the system.
-    auto uvec = Drake::toEigen(u);
+    auto uvec = drake::toEigen(u);
     auto q = uvec.head(rigid_body_tree->number_of_positions());    // position
     auto v = uvec.segment(rigid_body_tree->number_of_positions(),  // velocity
                           rigid_body_tree->number_of_velocities());

--- a/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_lidar.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_lidar.h
@@ -10,10 +10,10 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/plants/RigidBodySystem.h"
 
-using Drake::NullVector;
-using Drake::RigidBodySensor;
-using Drake::RigidBodySystem;
-using Drake::RigidBodyDepthSensor;
+using drake::NullVector;
+using drake::RigidBodySensor;
+using drake::RigidBodySystem;
+using drake::RigidBodyDepthSensor;
 
 namespace drake {
 namespace ros {

--- a/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_odometry.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_odometry.h
@@ -11,10 +11,10 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/plants/RigidBodySystem.h"
 
-using Drake::NullVector;
-using Drake::RigidBodySensor;
-using Drake::RigidBodySystem;
-using Drake::RigidBodyDepthSensor;
+using drake::NullVector;
+using drake::RigidBodySensor;
+using drake::RigidBodySystem;
+using drake::RigidBodyDepthSensor;
 
 namespace drake {
 namespace ros {
@@ -134,7 +134,7 @@ class SensorPublisherOdometry {
     // The input vector u contains the entire system's state. The following
     // The following code extracts the position and velocity values from it
     // and computes the kinematic properties of the system.
-    auto uvec = Drake::toEigen(u);
+    auto uvec = drake::toEigen(u);
     auto q = uvec.head(rigid_body_tree->number_of_positions());    // position
     auto v = uvec.segment(rigid_body_tree->number_of_positions(),  // velocity
                           rigid_body_tree->number_of_velocities());

--- a/ros/drake_ros_systems/include/drake_ros/ros_tf_publisher.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_tf_publisher.h
@@ -14,10 +14,10 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/plants/RigidBodySystem.h"
 
-using Drake::NullVector;
-using Drake::RigidBodySensor;
-using Drake::RigidBodySystem;
-using Drake::RigidBodyDepthSensor;
+using drake::NullVector;
+using drake::RigidBodySensor;
+using drake::RigidBodySystem;
+using drake::RigidBodyDepthSensor;
 
 namespace drake {
 namespace ros {
@@ -196,7 +196,7 @@ class DrakeRosTfPublisher {
     // The input vector u contains the entire system's state.
     // The following code extracts the position values from it
     // and computes the kinematic properties of the system.
-    auto uvec = Drake::toEigen(u);
+    auto uvec = drake::toEigen(u);
     auto q = uvec.head(rigid_body_tree_->number_of_positions());
     KinematicsCache<double> cache = rigid_body_tree_->doKinematics(q);
 

--- a/ros/drake_ros_systems/include/drake_ros/ros_vehicle_system.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_vehicle_system.h
@@ -127,7 +127,7 @@ void run_ros_vehicle_sim(
 
   SimulationOptions sim_options = options;
   if (sim_options.realtime_factor < 0.0) sim_options.realtime_factor = 1.0;
-  Drake::simulate(*ros_sys, t0, tf, x0, sim_options);
+  drake::simulate(*ros_sys, t0, tf, x0, sim_options);
 }
 
 /**


### PR DESCRIPTION
Mechanically downcase "Drake" namespace to "drake".  Manually resolve the exactly one ambiguity that resulted (in drake/systems/plants/contactConstraintsmex.cpp).

This PR is very large but entirely the result of `perl -pi -e` commands with the exception of one disambiguation noted above.  As such the fact that this compiles demonstrates its correctness and the greater question is whether it is worth doing in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2983)
<!-- Reviewable:end -->
