### PR TITLE
Move unit test code for Function.h to its own file

### DIFF
--- a/drake/core/test/CMakeLists.txt
+++ b/drake/core/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_executable(function_test function_test.cc)
+target_link_libraries(function_test ${GTEST_BOTH_LIBRARIES})
+add_test(NAME function_test COMMAND function_test)
+
 add_executable(vector_test vector_test.cc)
 target_link_libraries(vector_test ${GTEST_BOTH_LIBRARIES})
 add_test(NAME vector_test COMMAND vector_test)

--- a/drake/core/test/function_test.cc
+++ b/drake/core/test/function_test.cc
@@ -1,0 +1,58 @@
+#include "drake/core/Function.h"
+
+#include "gtest/gtest.h"
+
+namespace drake {
+namespace {
+
+// Tests the InputOutputRelation. Verify that linear is a polynomial.
+GTEST_TEST(FunctionTest, InputOutputRelationLinearIsPolynomial) {
+  EXPECT_TRUE((InputOutputRelation::isA(InputOutputRelation::Form::LINEAR,
+                                        InputOutputRelation::Form::POLYNOMIAL)))
+      << "linear is polynomial";
+}
+
+// Tests the InputOutputRelation. Verify that zero is arbitrary.
+GTEST_TEST(FunctionTest, InputOutputRelationZeroIsArbitrary) {
+  EXPECT_TRUE((InputOutputRelation::isA(InputOutputRelation::Form::ZERO,
+                                        InputOutputRelation::Form::ARBITRARY)))
+      << "zero is arbitrary";
+}
+
+// Verifies that the least common ancestor of the I/O relations
+// AFFINE, LINEAR, AND POLYNOMIAL is polynomial.
+GTEST_TEST(FunctionTest, InputOutputRelationLeastCommonAncestor) {
+  EXPECT_TRUE((
+      InputOutputRelation::leastCommonAncestor(
+          {InputOutputRelation::Form::AFFINE, InputOutputRelation::Form::LINEAR,
+           InputOutputRelation::Form::POLYNOMIAL}) ==
+      InputOutputRelation::Form::POLYNOMIAL))
+      << "least common ancestor should be polynomial";
+}
+
+// Verifies that compositions of I/O relations are as expected
+GTEST_TEST(FunctionTest, InputOutputRelationCompositionTests) {
+  InputOutputRelation g(InputOutputRelation::Form::LINEAR);
+  InputOutputRelation f(InputOutputRelation::Form::POLYNOMIAL);
+
+  EXPECT_EQ(InputOutputRelation::composeWith(g, f).form,
+            InputOutputRelation::Form::POLYNOMIAL);
+
+  EXPECT_EQ(InputOutputRelation::composeWith(f, g).form,
+            InputOutputRelation::Form::POLYNOMIAL);
+}
+
+// Verify that combinations of I/O relations are as expected
+GTEST_TEST(FunctionTest, InputOutputRelationCombinationTests) {
+  InputOutputRelation g(InputOutputRelation::Form::LINEAR);
+  InputOutputRelation f(InputOutputRelation::Form::POLYNOMIAL);
+
+  EXPECT_EQ(InputOutputRelation::combine(g, f).form,
+            InputOutputRelation::Form::POLYNOMIAL);
+
+  EXPECT_EQ(InputOutputRelation::combine(f, g).form,
+            InputOutputRelation::Form::POLYNOMIAL);
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/core/test/vector_test.cc
+++ b/drake/core/test/vector_test.cc
@@ -1,6 +1,5 @@
 #include "gtest/gtest.h"
 
-#include "drake/core/Function.h"
 #include "drake/core/Vector.h"
 #include "drake/core/test/pendulum.h"
 #include "drake/util/eigen_matrix_compare.h"
@@ -10,7 +9,6 @@ using drake::CombinedVector;
 using drake::size;
 using drake::CombinedVectorUtil;
 using drake::NullVector;
-using drake::InputOutputRelation;
 using drake::util::MatrixCompareType;
 using std::is_same;
 using std::string;
@@ -91,55 +89,6 @@ GTEST_TEST(VectorTest, CombineVectorCornerCases) {
 GTEST_TEST(VectorTest, RowsAtCompileTime) {
   EXPECT_EQ((Eigen::Matrix<double, 2, 1>::RowsAtCompileTime), 2)
       << "failed to evaluate RowsAtCompileTime";
-}
-
-// Tests the InputOutputRelation. Verify that linear is a polynomial.
-GTEST_TEST(VectorTest, InputOutputRelationLinearIsPolynomial) {
-  EXPECT_TRUE((InputOutputRelation::isA(InputOutputRelation::Form::LINEAR,
-                                        InputOutputRelation::Form::POLYNOMIAL)))
-      << "linear is polynomial";
-}
-
-// Tests the InputOutputRelation. Verify that zero is arbitrary.
-GTEST_TEST(VectorTest, InputOutputRelationZeroIsArbitrary) {
-  EXPECT_TRUE((InputOutputRelation::isA(InputOutputRelation::Form::ZERO,
-                                        InputOutputRelation::Form::ARBITRARY)))
-      << "zero is arbitrary";
-}
-
-// Verifies that the least common ancestor of the I/O relations
-// AFFINE, LINEAR, AND POLYNOMIAL is polynomial.
-GTEST_TEST(VectorTest, InputOutputRelationLeastCommonAncestor) {
-  EXPECT_TRUE((
-      InputOutputRelation::leastCommonAncestor(
-          {InputOutputRelation::Form::AFFINE, InputOutputRelation::Form::LINEAR,
-           InputOutputRelation::Form::POLYNOMIAL}) ==
-      InputOutputRelation::Form::POLYNOMIAL))
-      << "least common ancestor should be polynomial";
-}
-
-// Verifies that compositions of I/O relations are as expected
-GTEST_TEST(VectorTest, InputOutputRelationCompositionTests) {
-  InputOutputRelation g(InputOutputRelation::Form::LINEAR);
-  InputOutputRelation f(InputOutputRelation::Form::POLYNOMIAL);
-
-  EXPECT_EQ(InputOutputRelation::composeWith(g, f).form,
-            InputOutputRelation::Form::POLYNOMIAL);
-
-  EXPECT_EQ(InputOutputRelation::composeWith(f, g).form,
-            InputOutputRelation::Form::POLYNOMIAL);
-}
-
-// Verify that combinations of I/O relations are as expected
-GTEST_TEST(VectorTest, InputOutputRelationCombinationTests) {
-  InputOutputRelation g(InputOutputRelation::Form::LINEAR);
-  InputOutputRelation f(InputOutputRelation::Form::POLYNOMIAL);
-
-  EXPECT_EQ(InputOutputRelation::combine(g, f).form,
-            InputOutputRelation::Form::POLYNOMIAL);
-
-  EXPECT_EQ(InputOutputRelation::combine(f, g).form,
-            InputOutputRelation::Form::POLYNOMIAL);
 }
 
 }  // namespace


### PR DESCRIPTION
Move the unit test cases for `Function.h` into their own file, instead of mashing them into `vector_test`.

This will help enable us to deprecate and remove `Function.h` more quickly than `Vector.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2998)
<!-- Reviewable:end -->
