### PR TITLE
Move Vector1d from Vector.h to eigen_types.h

### DIFF
--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -11,6 +11,13 @@
 
 namespace drake {
 
+/// A column vector of size 1 (that is, a scalar), templated on scalar type.
+template <typename Scalar>
+using Vector1 = Eigen::Matrix<Scalar, 1, 1>;
+
+/// A column vector of size 1 of doubles.
+using Vector1d = Eigen::Matrix<double, 1, 1>;
+
 /// A column vector of size 3, templated on scalar type.
 template <typename Scalar>
 using Vector3 = Eigen::Matrix<Scalar, 3, 1>;

--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -38,7 +38,7 @@ using VectorX = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
 template <typename Scalar>
 using Matrix3 = Eigen::Matrix<Scalar, 3, 3>;
 
-/// A matrix of 3 rows and 3 columns, templated on scalar type.
+/// A matrix of 6 rows and 6 columns, templated on scalar type.
 template <typename Scalar>
 using Matrix6 = Eigen::Matrix<Scalar, 6, 6>;
 

--- a/drake/core/Vector.h
+++ b/drake/core/Vector.h
@@ -48,8 +48,6 @@ struct EigenVector {
   using type = Eigen::Matrix<ScalarType, Rows, 1>;
 };
 
-typedef Eigen::Matrix<double, 1, 1> Vector1d;
-
 /** NullVector<ScalarType>
  * @brief provides the empty vector (templated by ScalarType)
  * @concept{vector_concept}

--- a/drake/solvers/Constraint.h
+++ b/drake/solvers/Constraint.h
@@ -6,7 +6,7 @@
 #include <Eigen/SparseCore>
 
 #include "drake/common/drake_assert.h"
-#include "drake/core/Vector.h"
+#include "drake/common/eigen_types.h"
 #include "drake/util/Polynomial.h"
 
 namespace drake {

--- a/drake/solvers/Optimization.h
+++ b/drake/solvers/Optimization.h
@@ -10,7 +10,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/core/Function.h"
 #include "drake/core/Gradient.h"
-#include "drake/core/Vector.h"
 #include "drake/drakeOptimization_export.h"
 #include "drake/solvers/Constraint.h"
 #include "drake/solvers/MathematicalProgram.h"


### PR DESCRIPTION
Move the `Vector1d` typedef from `core/Vector.h` to `common/eigen_types.h`.  This allows us to break the dependency from `solvers/` onto `core/Vector.h`, so that the _only_ remaining uses of `Vector.h` are from System1 work -- `systems` and examples' use of systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/2999)
<!-- Reviewable:end -->
