### PR TITLE
Fixed linker error caused by removing libdrakeCore

### DIFF
--- a/ros/drake_cars_examples/CMakeLists.txt
+++ b/ros/drake_cars_examples/CMakeLists.txt
@@ -32,7 +32,6 @@ link_directories("${CMAKE_INSTALL_PREFIX}/lib")
 add_executable(car_sim_lcm_and_ros src/car_sim_lcm_and_ros.cc)
 target_link_libraries(car_sim_lcm_and_ros ${catkin_LIBRARIES}
   drakeCars
-  drakeCore
   drakeCommon
   drakeRBM
   drakeRBSystem


### PR DESCRIPTION
  * PR #2993 removed drakeCore but drake_cars_example explicitly linked
    to drakeCore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3009)
<!-- Reviewable:end -->
