### PR TITLE
Test `-UHAVE_SPDLOG` case correctly

### DIFF
--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -39,7 +39,8 @@ add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disabled)
 # "text_logging.h" unit testing:  If spdlog is available, test that:
 add_executable(text_logging_test_default
                ../text_logging.cc text_logging_test.cc)
-target_link_libraries(text_logging_test_default ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(text_logging_test_default
+                      ${GTEST_BOTH_LIBRARIES} threads)
 add_test(NAME text_logging_test_default COMMAND text_logging_test_default)
 # Force spdlog to unavailable to test that the ifndef(HAVE_SPDLOG) case works.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
@@ -48,7 +49,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
                  ../text_logging.cc text_logging_test.cc)
   target_compile_options(text_logging_test_no_spdlog
     PRIVATE -UHAVE_SPDLOG)
-  target_link_libraries(text_logging_test_no_spdlog ${GTEST_BOTH_LIBRARIES})
+  target_link_libraries(text_logging_test_no_spdlog
+                        ${GTEST_BOTH_LIBRARIES} threads)
   add_test(NAME text_logging_test_no_spdlog COMMAND text_logging_test_no_spdlog)
 endif()
 

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -44,7 +44,8 @@ add_test(NAME text_logging_test_default COMMAND text_logging_test_default)
 # Force spdlog to unavailable to test that the ifndef(HAVE_SPDLOG) case works.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_executable(text_logging_test_no_spdlog ../text_logging.cc text_logging_test.cc)
+  add_executable(text_logging_test_no_spdlog
+                 ../text_logging.cc text_logging_test.cc)
   target_compile_options(text_logging_test_no_spdlog
     PRIVATE -UHAVE_SPDLOG)
   target_link_libraries(text_logging_test_no_spdlog ${GTEST_BOTH_LIBRARIES})

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -37,18 +37,17 @@ target_link_libraries(drake_assert_test_disabled drakeCommon ${GTEST_BOTH_LIBRAR
 add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disabled)
 
 # "text_logging.h" unit testing:  If spdlog is available, test that:
-add_executable(text_logging_test_default text_logging_test.cc)
-target_link_libraries(text_logging_test_default
-  drakeCommon ${GTEST_BOTH_LIBRARIES})
+add_executable(text_logging_test_default
+               ../text_logging.cc text_logging_test.cc)
+target_link_libraries(text_logging_test_default ${GTEST_BOTH_LIBRARIES})
 add_test(NAME text_logging_test_default COMMAND text_logging_test_default)
 # Force spdlog to unavailable to test that the ifndef(HAVE_SPDLOG) case works.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_executable(text_logging_test_no_spdlog text_logging_test.cc)
+  add_executable(text_logging_test_no_spdlog ../text_logging.cc text_logging_test.cc)
   target_compile_options(text_logging_test_no_spdlog
     PRIVATE -UHAVE_SPDLOG)
-  target_link_libraries(text_logging_test_no_spdlog
-    drakeCommon ${GTEST_BOTH_LIBRARIES})
+  target_link_libraries(text_logging_test_no_spdlog ${GTEST_BOTH_LIBRARIES})
   add_test(NAME text_logging_test_no_spdlog COMMAND text_logging_test_no_spdlog)
 endif()
 


### PR DESCRIPTION
Follow-on to #3012 to correctly test the case in question, and thus reproduce @siyuanfeng-tri 's error case and fail if #3012 is not present.

This PR is based of of #3012 and should not land until that one is in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3013)
<!-- Reviewable:end -->
