### PR TITLE
Python: Expose COM Jacobian and getRandomConfiguration

### DIFF
--- a/drake/bindings/python/pydrake/test/testRBTCoM.py
+++ b/drake/bindings/python/pydrake/test/testRBTCoM.py
@@ -23,6 +23,16 @@ class TestRBTCoM(unittest.TestCase):
         kinsol = r.doKinematics(q, np.zeros((7, 1)))
         J = r.centerOfMassJacobian(kinsol)
 
+        self.assertTrue(np.shape(J) == (3, 7))
+
+        q = r.getZeroConfiguration()
+        kinsol = r.doKinematics(q, np.zeros((7, 1)))
+        J = r.centerOfMassJacobian(kinsol)
+
+        self.assertTrue(np.allclose(J.flat, [1., 0., 0., 0., -0.2425, 0., -0.25,
+        0., 1., 0., 0.2425, 0., 0., 0.,
+        0., 0., 1., 0., 0., 0., 0.], atol=1e-4))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/drake/bindings/swig/rbtree.i
+++ b/drake/bindings/swig/rbtree.i
@@ -104,5 +104,9 @@
   Eigen::Matrix<double, SPACE_DIMENSION, 1> centerOfMass(KinematicsCache<double> &cache, const std::set<int> &robotnum = default_robot_num_set) const {
     return $self->centerOfMass(cache, robotnum);
   }
+
+  Eigen::Matrix<double, SPACE_DIMENSION, Eigen::Dynamic> centerOfMassJacobian(KinematicsCache<double>& cache, const std::set<int>& robotnum = default_robot_num_set, bool in_terms_of_qdot = false) const {
+    return $self->centerOfMassJacobian(cache, robotnum, in_terms_of_qdot);
+  }
 }
 

--- a/drake/bindings/swig/rbtree.i
+++ b/drake/bindings/swig/rbtree.i
@@ -108,5 +108,10 @@
   Eigen::Matrix<double, SPACE_DIMENSION, Eigen::Dynamic> centerOfMassJacobian(KinematicsCache<double>& cache, const std::set<int>& robotnum = default_robot_num_set, bool in_terms_of_qdot = false) const {
     return $self->centerOfMassJacobian(cache, robotnum, in_terms_of_qdot);
   }
+
+  Eigen::VectorXd getRandomConfiguration() const {
+    std::default_random_engine generator;
+    return $self->getRandomConfiguration(generator);
+  }
 }
 

--- a/drake/bindings/swig/rbtree.i
+++ b/drake/bindings/swig/rbtree.i
@@ -110,7 +110,7 @@
   }
 
   Eigen::VectorXd getRandomConfiguration() const {
-    std::default_random_engine generator;
+    std::default_random_engine generator(std::random_device{}());
     return $self->getRandomConfiguration(generator);
   }
 }


### PR DESCRIPTION
Exposes ``getRandomConfiguration`` and ``centerOfMassJacobian`` to Python

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3016)
<!-- Reviewable:end -->
