### PR TITLE
SWIG Python: instantiate RBT with FIXED, QUATERNION, RPY

### DIFF
--- a/drake/bindings/swig/rbtree.i
+++ b/drake/bindings/swig/rbtree.i
@@ -69,6 +69,24 @@
 %ignore RigidBodyTree::bodies;
 %include "drake/systems/plants/RigidBodyTree.h"
 %extend RigidBodyTree {
+  RigidBodyTree(const std::string& urdf_filename, const std::string& joint_type) {
+    // FIXED = 0, ROLLPITCHYAW = 1, QUATERNION = 2
+    DrakeJoint::FloatingBaseType floating_base_type;
+
+    if (joint_type == "FIXED")
+      floating_base_type = DrakeJoint::FIXED;
+    else if (joint_type == "ROLLPITCHYAW")
+      floating_base_type = DrakeJoint::ROLLPITCHYAW;
+    else if (joint_type == "QUATERNION")
+      floating_base_type = DrakeJoint::QUATERNION;
+    else {
+      std::cerr << "Joint Type not supported" << std::endl;
+      return nullptr;
+    }
+
+    return new RigidBodyTree(urdf_filename, floating_base_type);
+  }
+
   KinematicsCache<double> doKinematics(
     const Eigen::MatrixBase<Eigen::VectorXd>& q,
     const Eigen::MatrixBase<Eigen::VectorXd>& v) {


### PR DESCRIPTION
DrakeJoint is currently not exposed via SWIG Python and the default constructor for a RigidBodyTree is RPY. This addition allows setting the joint type via a string.