### PR TITLE
Fix documentation build directories

### DIFF
--- a/drake/doc/Doxyfile_CXX.in
+++ b/drake/doc/Doxyfile_CXX.in
@@ -126,7 +126,7 @@ FILE_PATTERNS          = *.c \
                          *.h++
 RECURSIVE              = YES
 EXCLUDE                = "@drake_SOURCE_DIR@/examples" \
-                         "@drake_SOURCE_DIR@/pod-build" \
+                         "@drake_BINARY_DIR@" \
                          "@drake_SOURCE_DIR@/thirdParty"
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       =

--- a/drake/doc/Doxyfile_MATLAB.in
+++ b/drake/doc/Doxyfile_MATLAB.in
@@ -117,7 +117,7 @@ INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.m
 RECURSIVE              = YES
 EXCLUDE                = "@CMAKE_SOURCE_DIR@/examples" \
-                         "@CMAKE_SOURCE_DIR@/pod-build" \
+                         "@CMAKE_BINARY_DIR@" \
                          "@CMAKE_SOURCE_DIR@/thirdParty"
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       =

--- a/drake/doc/documentation_instructions.rst
+++ b/drake/doc/documentation_instructions.rst
@@ -35,15 +35,15 @@ In-source Builds Using ``make``
 
 Execute the following commands to build the documentation::
 
-    $ cd drake-distro/drake/pod-build
+    $ cd drake-distro/build/drake
     $ make documentation
 
 To view the generated documentation, open the following files using a web
 browser:
 
-- Drake website: ``drake-distro/drake/pod-build/doc/sphinx/index.html``
-- Doxygen C++ website: ``drake-distro/drake/pod-build/doc/doxygen_cxx/html/index.html``
-- Doxygen Matlab website: ``drake-distro/drake/pod-build/doc/doxygen_matlab/html/index.html``
+- Drake website: ``drake-distro/build/drake/doc/sphinx/index.html``
+- Doxygen C++ website: ``drake-distro/build/drake/doc/doxygen_cxx/html/index.html``
+- Doxygen Matlab website: ``drake-distro/build/drake/doc/doxygen_matlab/html/index.html``
 
 .. _documentation-out-of-source-ninja:
 


### PR DESCRIPTION
Fix some spots in the documentation generation that still assumed the build directory to be `pod-build`.

@jwnimmer-tri for feature review for also recently touching the documentation :smile: (or feel free to assign someone else; also, please assign whoever is on platform review duty).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3022)
<!-- Reviewable:end -->
