### PR TITLE
Add new header common/eigen_autodiff_types.h

### DIFF
--- a/drake/common/eigen_autodiff_types.h
+++ b/drake/common/eigen_autodiff_types.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/// @file
+/// This file contains abbreviated definitions for certain uses of
+/// AutoDiffScalar that are commonly used in Drake.
+/// @see also eigen_types.h
+
+#include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+
+/// An autodiff variable with a dynamic number of partials, up to 73 maximum.
+using AutoDiffUpTo73d = Eigen::AutoDiffScalar<VectorUpTo73d>;
+
+/// An autodiff variable with a dynamic number of partials.
+using AutoDiffXd = Eigen::AutoDiffScalar<Eigen::VectorXd>;
+
+// todo: recursive template to get arbitrary gradient order
+
+// note: tried using template default values (e.g. Eigen::Dynamic), but they
+// didn't seem to work on my mac clang
+template <int num_vars>
+using TaylorVard = Eigen::AutoDiffScalar<Eigen::Matrix<double, num_vars, 1> >;
+template <int num_vars, int rows>
+using TaylorVecd = Eigen::Matrix<TaylorVard<num_vars>, rows, 1>;
+template <int num_vars, int rows, int cols>
+using TaylorMatd = Eigen::Matrix<TaylorVard<num_vars>, rows, cols>;
+
+typedef TaylorVard<Eigen::Dynamic> TaylorVarXd;
+typedef TaylorVecd<Eigen::Dynamic, Eigen::Dynamic> TaylorVecXd;
+typedef TaylorMatd<Eigen::Dynamic, Eigen::Dynamic, Eigen::Dynamic> TaylorMatXd;
+
+}  // namespace drake

--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -1,11 +1,11 @@
+#pragma once
+
 /// @file
 /// This file contains abbreviated definitions for certain specializations of
 /// Eigen::Matrix that are commonly used in Drake.
-
-#pragma once
+/// @see also eigen_autodiff_types.h
 
 #include <Eigen/Dense>
-#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/constants.h"
 
@@ -56,12 +56,6 @@ using MatrixX = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
 
 /// A column vector of dynamic size, up to a maximum of 73 elements.
 using VectorUpTo73d = Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73, 1>;
-
-/// An autodiff variable with a dynamic number of partials, up to 73 maximum.
-using AutoDiffUpTo73d = Eigen::AutoDiffScalar<VectorUpTo73d>;
-
-/// An autodiff variable with a dynamic number of partials.
-using AutoDiffXd = Eigen::AutoDiffScalar<Eigen::VectorXd>;
 
 /// A column vector consisting of one twist.
 template <typename Scalar>

--- a/drake/core/Gradient.h
+++ b/drake/core/Gradient.h
@@ -9,22 +9,9 @@
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_autodiff_types.h"
 
 namespace drake {
-// todo: recursive template to get arbitrary gradient order
-
-// note: tried using template default values (e.g. Eigen::Dynamic), but they
-// didn't seem to work on my mac clang
-template <int num_vars>
-using TaylorVard = Eigen::AutoDiffScalar<Eigen::Matrix<double, num_vars, 1> >;
-template <int num_vars, int rows>
-using TaylorVecd = Eigen::Matrix<TaylorVard<num_vars>, rows, 1>;
-template <int num_vars, int rows, int cols>
-using TaylorMatd = Eigen::Matrix<TaylorVard<num_vars>, rows, cols>;
-
-typedef TaylorVard<Eigen::Dynamic> TaylorVarXd;
-typedef TaylorVecd<Eigen::Dynamic, Eigen::Dynamic> TaylorVecXd;
-typedef TaylorMatd<Eigen::Dynamic, Eigen::Dynamic, Eigen::Dynamic> TaylorMatXd;
 
 /** \brief The appropriate AutoDiffScalar gradient type given the value type and
  * the number of derivatives at compile time

--- a/drake/examples/Cars/simple_car.cc
+++ b/drake/examples/Cars/simple_car.cc
@@ -1,6 +1,6 @@
 #include "drake/examples/Cars/simple_car-inl.h"
 
-#include "drake/core/Gradient.h"
+#include "drake/common/eigen_autodiff_types.h"
 
 namespace drake {
 

--- a/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/core/Gradient.h"
 #include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/systems/plants/constraint/dynamic_constraint.h"
 #include "drake/util/eigen_matrix_compare.h"

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -57,8 +57,8 @@ class Constraint {
   // Move this to DifferentiableConstraint derived class if/when we
   // need to support non-differentiable functions (at least, if
   // DifferentiableConstraint is ever implemented).
-  virtual void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-                    drake::TaylorVecXd& y) const = 0;
+  virtual void Eval(const Eigen::Ref<const TaylorVecXd>& x,
+                    TaylorVecXd& y) const = 0;
 
   Eigen::VectorXd const& lower_bound() const { return lower_bound_; }
   Eigen::VectorXd const& upper_bound() const { return upper_bound_; }
@@ -91,11 +91,11 @@ class QuadraticConstraint : public Constraint {
     y.resize(num_constraints());
     y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
   }
-  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-            drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
+            TaylorVecXd& y) const override {
     y.resize(num_constraints());
-    y = .5 * x.transpose() * Q_.cast<drake::TaylorVarXd>() * x +
-        b_.cast<drake::TaylorVarXd>().transpose() * x;
+    y = .5 * x.transpose() * Q_.cast<TaylorVarXd>() * x +
+        b_.cast<TaylorVarXd>().transpose() * x;
   };
 
   virtual const Eigen::MatrixXd& Q() const { return Q_; }
@@ -141,8 +141,8 @@ class PolynomialConstraint : public Constraint {
     }
   }
 
-  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-            drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
+            TaylorVecXd& y) const override {
     taylor_evaluation_point_.clear();
     for (size_t i = 0; i < poly_vars_.size(); i++) {
       taylor_evaluation_point_[poly_vars_[i]] = x[i];
@@ -159,7 +159,7 @@ class PolynomialConstraint : public Constraint {
 
   /// To avoid repeated allocation, reuse a map for the evaluation point.
   mutable std::map<Polynomiald::VarType, double> double_evaluation_point_;
-  mutable std::map<Polynomiald::VarType, drake::TaylorVarXd>
+  mutable std::map<Polynomiald::VarType, TaylorVarXd>
       taylor_evaluation_point_;
 };
 
@@ -188,10 +188,10 @@ class LinearConstraint : public Constraint {
     y.resize(num_constraints());
     y = A_ * x;
   }
-  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-            drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
+            TaylorVecXd& y) const override {
     y.resize(num_constraints());
-    y = A_.cast<drake::TaylorVarXd>() * x;
+    y = A_.cast<TaylorVarXd>() * x;
   };
 
   virtual Eigen::SparseMatrix<double> GetSparseMatrix() const {
@@ -264,8 +264,8 @@ class BoundingBoxConstraint : public LinearConstraint {
     y.resize(num_constraints());
     y = x;
   }
-  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-            drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
+            TaylorVecXd& y) const override {
     y.resize(num_constraints());
     y = x;
   }
@@ -298,10 +298,10 @@ class LinearComplementarityConstraint : public Constraint {
     y.resize(num_constraints());
     y = (M_ * x) + q_;
   }
-  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-            drake::TaylorVecXd& y) const override {
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
+            TaylorVecXd& y) const override {
     y.resize(num_constraints());
-    y = (M_.cast<drake::TaylorVarXd>() * x) + q_.cast<drake::TaylorVarXd>();
+    y = (M_.cast<TaylorVarXd>() * x) + q_.cast<TaylorVarXd>();
   };
 
   const Eigen::MatrixXd& M() const { return M_; }

--- a/drake/solvers/equality_constrained_qp_solver.cc
+++ b/drake/solvers/equality_constrained_qp_solver.cc
@@ -5,10 +5,8 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/core/Gradient.h"
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/solvers/optimization.h"
-
-using drake::TaylorVecXd;
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/ipopt_solver.cc
+++ b/drake/solvers/ipopt_solver.cc
@@ -20,8 +20,6 @@ using Ipopt::IpoptData;
 using Ipopt::Number;
 using Ipopt::SolverReturn;
 
-using drake::TaylorVecXd;
-
 namespace drake {
 namespace solvers {
 namespace {

--- a/drake/solvers/linear_system_solver.cc
+++ b/drake/solvers/linear_system_solver.cc
@@ -5,10 +5,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/core/Gradient.h"
 #include "drake/solvers/optimization.h"
-
-using drake::TaylorVecXd;
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/nlopt_solver.cc
+++ b/drake/solvers/nlopt_solver.cc
@@ -7,10 +7,9 @@
 #include <nlopt.hpp>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/core/Gradient.h"
 #include "drake/solvers/optimization.h"
-
-using drake::TaylorVecXd;
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/optimization.h
+++ b/drake/solvers/optimization.h
@@ -9,7 +9,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_assert.h"
-#include "drake/core/Gradient.h"
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/drakeOptimization_export.h"
 #include "drake/solvers/constraint.h"
 #include "drake/solvers/Function.h"
@@ -113,8 +113,8 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
                    detail::FunctionTraits<F>::numOutputs(f_));
       detail::FunctionTraits<F>::eval(f_, x, y);
     }
-    void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-              drake::TaylorVecXd& y) const override {
+    void Eval(const Eigen::Ref<const TaylorVecXd>& x,
+              TaylorVecXd& y) const override {
       y.resize(detail::FunctionTraits<F>::numOutputs(f_));
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
                    detail::FunctionTraits<F>::numInputs(f_));

--- a/drake/solvers/snopt_solver.cc
+++ b/drake/solvers/snopt_solver.cc
@@ -1,4 +1,3 @@
-
 #include "drake/solvers/snopt_solver.h"
 
 #include <cstdlib>
@@ -7,6 +6,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include "drake/core/Gradient.h"
 #include "drake/solvers/optimization.h"
 
 namespace snopt {
@@ -191,7 +191,7 @@ int snopt_userfun(snopt::integer* Status, snopt::integer* n,
 
   // evaluate cost
   auto tx = drake::initializeAutoDiff(xvec);
-  drake::TaylorVecXd ty(1), this_x;
+  TaylorVecXd ty(1), this_x;
 
   for (auto const& binding : current_problem->GetAllCosts()) {
     auto const& obj = binding.constraint();

--- a/drake/solvers/test/optimization_problem_test.cc
+++ b/drake/solvers/test/optimization_problem_test.cc
@@ -23,8 +23,6 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::VectorXd;
 
-using drake::TaylorVecXd;
-using drake::Vector1d;
 using drake::solvers::detail::VecIn;
 using drake::solvers::detail::VecOut;
 using drake::util::MatrixCompareType;

--- a/drake/systems/System.h
+++ b/drake/systems/System.h
@@ -4,7 +4,6 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
-#include "drake/core/Gradient.h"
 #include "drake/core/Vector.h"
 
 namespace drake {

--- a/drake/systems/cascade_system.h
+++ b/drake/systems/cascade_system.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/core/Gradient.h"
 #include "drake/core/Vector.h"
 #include "drake/systems/System.h"
 

--- a/drake/systems/feedback_system.h
+++ b/drake/systems/feedback_system.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "drake/common/drake_assert.h"
-#include "drake/core/Gradient.h"
 #include "drake/core/Vector.h"
 #include "drake/systems/System.h"
 

--- a/drake/systems/pd_control_system.h
+++ b/drake/systems/pd_control_system.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "drake/common/drake_assert.h"
-#include "drake/core/Gradient.h"
 #include "drake/core/Vector.h"
 #include "drake/systems/System.h"
 

--- a/drake/systems/plants/ConstraintWrappers.h
+++ b/drake/systems/plants/ConstraintWrappers.h
@@ -4,6 +4,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/core/Gradient.h"
 #include "drake/math/autodiff.h"
 #include "drake/solvers/optimization.h"

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1,6 +1,7 @@
   #include "drake/systems/plants/RigidBodyTree.h"
 
 #include "drake/common/constants.h"
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/gradient.h"

--- a/drake/systems/plants/constraint/dynamic_constraint.cc
+++ b/drake/systems/plants/constraint/dynamic_constraint.cc
@@ -1,12 +1,12 @@
-
 #include "dynamic_constraint.h"
 
+#include "drake/core/Gradient.h"
 #include "drake/math/autodiff.h"
 
 namespace drake {
 namespace systems {
 namespace {
-Eigen::MatrixXd ExtractDerivativesMatrix(const drake::TaylorVecXd& vec_in) {
+Eigen::MatrixXd ExtractDerivativesMatrix(const TaylorVecXd& vec_in) {
   if (!vec_in.size()) {
     return Eigen::MatrixXd();
   }
@@ -30,20 +30,20 @@ DynamicConstraint::~DynamicConstraint() {}
 
 void DynamicConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                              Eigen::VectorXd& y) const {
-  drake::TaylorVecXd y_t;
+  TaylorVecXd y_t;
   Eval(drake::initializeAutoDiff(x), y_t);
   y = math::autoDiffToValueMatrix(y_t);
 }
 
-void DynamicConstraint::Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-                             drake::TaylorVecXd& y) const {
+void DynamicConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
+                             TaylorVecXd& y) const {
   DRAKE_ASSERT(x.size() == 1 + (2 * num_states_) + (2 * num_inputs_));
 
   // Extract our input variables:
   // h - current time (knot) value
   // x0, x1 state vector at time steps k, k+1
   // u0, u1 input vector at time steps k, k+1
-  const drake::TaylorVarXd h = x(0);
+  const TaylorVarXd h = x(0);
   const auto x0 = x.segment(1, num_states_);
   const auto x1 = x.segment(1 + num_states_, num_states_);
   const auto u0 = x.segment(1 + (2 * num_states_), num_inputs_);
@@ -51,20 +51,20 @@ void DynamicConstraint::Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
 
   // TODO(sam.creasey): We should cache the dynamics outputs to avoid
   // recalculating for every knot point as we advance.
-  drake::TaylorVecXd xdot0;
+  TaylorVecXd xdot0;
   dynamics(x0, u0, &xdot0);
   Eigen::MatrixXd dxdot0 = ExtractDerivativesMatrix(xdot0);
 
-  drake::TaylorVecXd xdot1;
+  TaylorVecXd xdot1;
   dynamics(x1, u1, &xdot1);
   Eigen::MatrixXd dxdot1 = ExtractDerivativesMatrix(xdot1);
 
   // Cubic interpolation to get xcol and xdotcol.
-  const drake::TaylorVecXd xcol = 0.5 * (x0 + x1) + h / 8 * (xdot0 - xdot1);
-  const drake::TaylorVecXd xdotcol =
+  const TaylorVecXd xcol = 0.5 * (x0 + x1) + h / 8 * (xdot0 - xdot1);
+  const TaylorVecXd xdotcol =
       -1.5 * (x0 - x1) / h - .25 * (xdot0 + xdot1);
 
-  drake::TaylorVecXd g;
+  TaylorVecXd g;
   dynamics(xcol, 0.5 * (u0 + u1), &g);
   y = xdotcol - g;
 }

--- a/drake/systems/plants/constraint/dynamic_constraint.h
+++ b/drake/systems/plants/constraint/dynamic_constraint.h
@@ -4,10 +4,10 @@
 
 #include <Eigen/Core>
 
-#include <drake/drakeDynamicConstraint_export.h>
-#include <drake/core/Gradient.h>
-#include <drake/solvers/constraint.h>
-#include <drake/systems/System.h>
+#include "drake/drakeDynamicConstraint_export.h"
+#include "drake/common/eigen_autodiff_types.h"
+#include "drake/solvers/constraint.h"
+#include "drake/systems/System.h"
 
 namespace drake {
 namespace systems {
@@ -38,13 +38,13 @@ class DRAKEDYNAMICCONSTRAINT_EXPORT DynamicConstraint :
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
-  void Eval(const Eigen::Ref<const drake::TaylorVecXd>& x,
-            drake::TaylorVecXd& y) const override;
+  void Eval(const Eigen::Ref<const TaylorVecXd>& x,
+            TaylorVecXd& y) const override;
 
  protected:
-  virtual void dynamics(const drake::TaylorVecXd& state,
-                        const drake::TaylorVecXd& input,
-                        drake::TaylorVecXd* xdot) const = 0;
+  virtual void dynamics(const TaylorVecXd& state,
+                        const TaylorVecXd& input,
+                        TaylorVecXd* xdot) const = 0;
 
  private:
   int num_states_;
@@ -63,12 +63,12 @@ class SystemDynamicConstraint : public DynamicConstraint {
         system_(system) {}
 
  private:
-  void dynamics(const drake::TaylorVecXd& state,
-                const drake::TaylorVecXd& input,
-                drake::TaylorVecXd* xdot) const override {
-    typename System::template StateVector<drake::TaylorVarXd> x = state;
-    typename System::template InputVector<drake::TaylorVarXd> u = input;
-    drake::TaylorVarXd t(1);
+  void dynamics(const TaylorVecXd& state,
+                const TaylorVecXd& input,
+                TaylorVecXd* xdot) const override {
+    typename System::template StateVector<TaylorVarXd> x = state;
+    typename System::template InputVector<TaylorVarXd> u = input;
+    TaylorVarXd t(1);
     t = 0;
     *xdot = toEigen(system_->dynamics(t, x, u));
   }

--- a/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/dynamic_constraint_test.cc
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/core/Gradient.h"
 #include "drake/systems/plants/constraint/dynamic_constraint.h"
 #include "drake/util/eigen_matrix_compare.h"
 
@@ -18,9 +19,9 @@ class PendulumTestDynamicConstraint : public DynamicConstraint {
       : DynamicConstraint(num_states, num_inputs) {}
 
  protected:
-  void dynamics(const drake::TaylorVecXd& state,
-                const drake::TaylorVecXd& input,
-                drake::TaylorVecXd* xdot) const override {
+  void dynamics(const TaylorVecXd& state,
+                const TaylorVecXd& input,
+                TaylorVecXd* xdot) const override {
     // From the Pendulum example:
     const double m = 1.0;
     const double b = 0.1;
@@ -55,7 +56,7 @@ GTEST_TEST(DynamicConstraintPendulumDynamicsTest, DynamicConstraintTest) {
 
   PendulumTestDynamicConstraint dut(kNumStates, kNumInputs);
 
-  drake::TaylorVecXd result;
+  TaylorVecXd result;
   dut.Eval(drake::initializeAutoDiff(x), result);
 
   EXPECT_NEAR(result(0).value(), 1.1027, 1e-4);

--- a/drake/systems/plants/inverseKinBackend.cpp
+++ b/drake/systems/plants/inverseKinBackend.cpp
@@ -7,6 +7,7 @@
 #include <Eigen/Sparse>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/core/Gradient.h"
 #include "drake/math/autodiff.h"
 #include "drake/solvers/optimization.h"

--- a/drake/util/Polynomial.h
+++ b/drake/util/Polynomial.h
@@ -11,7 +11,7 @@
 #include <Eigen/Core>
 #include <unsupported/Eigen/Polynomials>
 
-#include "drake/core/Gradient.h"
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/drakePolynomial_export.h"
 
 /** A scalar multi-variate polynomial, modeled after the msspoly in spotless.

--- a/drake/util/test/testDrakeGeometryUtil.cpp
+++ b/drake/util/test/testDrakeGeometryUtil.cpp
@@ -4,7 +4,6 @@
 #include <Eigen/Core>
 
 #include "drake/common/eigen_types.h"
-#include "drake/core/Gradient.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/eigen_matrix_compare.h"


### PR DESCRIPTION
Move Eigen/AutoDiff-related typedefs into this new header, from either `common/eigen_types.h` or `core/Gradient.h`.  This removes the AutoDiff include graph penalty from code that only wants vanilla Eigen types in `common/eigen_types.h`, and gets all of the AutoDiff-related types into one place for future work.

Remove the `drake::` qualifier from many uses of TaylorFoo within Drake.

Remove unused includes and/or narrow them from all of `Gradient.h` to just the `eigen_autodiff_types.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3031)
<!-- Reviewable:end -->
