### PR TITLE
Add missing install rule for eigen_autodiff_types

### DIFF
--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -24,6 +24,7 @@ set(installed_headers
   drake_assert.h
   drake_deprecated.h
   drake_path.h
+  eigen_autodiff_types.h
   eigen_types.h
   functional_form.h
   nice_type_name.h


### PR DESCRIPTION
Fixes build errors from #3031.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3033)
<!-- Reviewable:end -->
