### PR TITLE
Split out autodiff_gradient.h from autodiff.h

### DIFF
--- a/drake/math/CMakeLists.txt
+++ b/drake/math/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Source files used to build drakeMath.
 set(sources
   autodiff.cc
+  autodiff_gradient.cc
   axis_angle.cc
   cylindrical.cc
   expmap.cc
@@ -13,6 +14,7 @@ set(sources
 # are available elsewhere via #include.
 set(installed_headers
   autodiff.h
+  autodiff_gradient.h
   axis_angle.h
   cylindrical.h
   expmap.h

--- a/drake/math/autodiff.h
+++ b/drake/math/autodiff.h
@@ -8,8 +8,6 @@
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>
 
-#include "drake/math/gradient.h"
-
 /// Overloads round to mimic std::round from <cmath>.
 /// Must appear in global namespace so that ADL can select between this
 /// implementation and the STL one.
@@ -39,60 +37,14 @@ struct AutoDiffToValueMatrix {
 template <typename Derived>
 typename AutoDiffToValueMatrix<Derived>::type autoDiffToValueMatrix(
     const Eigen::MatrixBase<Derived>& auto_diff_matrix) {
-  typename AutoDiffToValueMatrix<Derived>::type ret(auto_diff_matrix.rows(),
-                                                    auto_diff_matrix.cols());
+  typename AutoDiffToValueMatrix<Derived>::type ret(
+      auto_diff_matrix.rows(), auto_diff_matrix.cols());
   for (int i = 0; i < auto_diff_matrix.rows(); i++) {
     for (int j = 0; j < auto_diff_matrix.cols(); ++j) {
       ret(i, j) = auto_diff_matrix(i, j).value();
     }
   }
   return ret;
-}
-
-template <typename Derived>
-struct AutoDiffToGradientMatrix {
-  typedef typename Gradient<
-      Eigen::Matrix<typename Derived::Scalar::Scalar,
-                    Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>,
-      Eigen::Dynamic>::type type;
-};
-
-template <typename Derived>
-typename AutoDiffToGradientMatrix<Derived>::type autoDiffToGradientMatrix(
-    const Eigen::MatrixBase<Derived>& auto_diff_matrix,
-    int num_variables = Eigen::Dynamic) {
-  int num_variables_from_matrix = 0;
-  for (int i = 0; i < auto_diff_matrix.size(); ++i) {
-    num_variables_from_matrix =
-        std::max(num_variables_from_matrix,
-                 static_cast<int>(auto_diff_matrix(i).derivatives().size()));
-  }
-  if (num_variables == Eigen::Dynamic) {
-    num_variables = num_variables_from_matrix;
-  } else if (num_variables_from_matrix != 0 &&
-             num_variables_from_matrix != num_variables) {
-    std::stringstream buf;
-    buf << "Input matrix has derivatives w.r.t " << num_variables_from_matrix
-        << " variables, whereas num_variables is " << num_variables << ".\n";
-    buf << "Either num_variables_from_matrix should be zero, or it should "
-           "match num_variables.";
-    throw std::runtime_error(buf.str());
-  }
-
-  typename AutoDiffToGradientMatrix<Derived>::type gradient(
-      auto_diff_matrix.size(), num_variables);
-  for (int row = 0; row < auto_diff_matrix.rows(); row++) {
-    for (int col = 0; col < auto_diff_matrix.cols(); col++) {
-      auto gradient_row =
-          gradient.row(row + col * auto_diff_matrix.rows()).transpose();
-      if (auto_diff_matrix(row, col).derivatives().size() == 0) {
-        gradient_row.setZero();
-      } else {
-        gradient_row = auto_diff_matrix(row, col).derivatives();
-      }
-    }
-  }
-  return gradient;
 }
 
 }  // namespace math

--- a/drake/math/autodiff_gradient.cc
+++ b/drake/math/autodiff_gradient.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// autodiff_gradient.h is a stand-alone header.
+
+#include "drake/math/autodiff_gradient.h"

--- a/drake/math/autodiff_gradient.h
+++ b/drake/math/autodiff_gradient.h
@@ -1,0 +1,61 @@
+/// @file
+/// Utilities that relate simultaneously to both autodiff matrices and
+/// gradient matrices.
+
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "drake/math/gradient.h"
+
+namespace drake {
+namespace math {
+
+template <typename Derived>
+struct AutoDiffToGradientMatrix {
+  typedef typename Gradient<
+      Eigen::Matrix<typename Derived::Scalar::Scalar,
+                    Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>,
+      Eigen::Dynamic>::type type;
+};
+
+template <typename Derived>
+typename AutoDiffToGradientMatrix<Derived>::type autoDiffToGradientMatrix(
+    const Eigen::MatrixBase<Derived>& auto_diff_matrix,
+    int num_variables = Eigen::Dynamic) {
+  int num_variables_from_matrix = 0;
+  for (int i = 0; i < auto_diff_matrix.size(); ++i) {
+    num_variables_from_matrix =
+        std::max(num_variables_from_matrix,
+                 static_cast<int>(auto_diff_matrix(i).derivatives().size()));
+  }
+  if (num_variables == Eigen::Dynamic) {
+    num_variables = num_variables_from_matrix;
+  } else if (num_variables_from_matrix != 0 &&
+             num_variables_from_matrix != num_variables) {
+    std::stringstream buf;
+    buf << "Input matrix has derivatives w.r.t " << num_variables_from_matrix
+        << " variables, whereas num_variables is " << num_variables << ".\n";
+    buf << "Either num_variables_from_matrix should be zero, or it should "
+           "match num_variables.";
+    throw std::runtime_error(buf.str());
+  }
+
+  typename AutoDiffToGradientMatrix<Derived>::type gradient(
+      auto_diff_matrix.size(), num_variables);
+  for (int row = 0; row < auto_diff_matrix.rows(); row++) {
+    for (int col = 0; col < auto_diff_matrix.cols(); col++) {
+      auto gradient_row =
+          gradient.row(row + col * auto_diff_matrix.rows()).transpose();
+      if (auto_diff_matrix(row, col).derivatives().size() == 0) {
+        gradient_row.setZero();
+      } else {
+        gradient_row = auto_diff_matrix(row, col).derivatives();
+      }
+    }
+  }
+  return gradient;
+}
+
+}  // namespace math
+}  // namespace drake

--- a/drake/math/expmap.h
+++ b/drake/math/expmap.h
@@ -9,6 +9,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 
 namespace drake {
 namespace math {

--- a/drake/math/gradient.h
+++ b/drake/math/gradient.h
@@ -1,3 +1,6 @@
+/// @file
+/// Utilities for arithmetic on gradients.
+
 #pragma once
 
 #include <Eigen/Dense>

--- a/drake/math/test/autodiff_test.cc
+++ b/drake/math/test/autodiff_test.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/eigen_types.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/util/eigen_matrix_compare.h"
 
 using Eigen::MatrixXd;

--- a/drake/math/test/expmap_test.cc
+++ b/drake/math/test/expmap_test.cc
@@ -5,6 +5,7 @@
 
 #include "drake/core/Gradient.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/util/eigen_matrix_compare.h"
 
 using drake::initializeAutoDiff;

--- a/drake/systems/controllers/LQR.h
+++ b/drake/systems/controllers/LQR.h
@@ -4,6 +4,7 @@
 #include "drake/common/text_logging.h"
 #include "drake/core/Gradient.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/systems/LinearSystem.h"
 #include "drake/systems/vector.h"
 #include "drake/util/drakeGradientUtil.h"

--- a/drake/systems/plants/ConstraintWrappers.h
+++ b/drake/systems/plants/ConstraintWrappers.h
@@ -7,6 +7,7 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/core/Gradient.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/solvers/optimization.h"
 #include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 #include "drake/systems/plants/KinematicsCache.h"

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -4,6 +4,7 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/gradient.h"
 #include "drake/systems/plants/joints/DrakeJoints.h"
 #include "drake/systems/plants/joints/FixedJoint.h"

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -5,6 +5,7 @@
 
 #include "drake/core/Gradient.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/quaternion.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/util/drakeGeometryUtil.h"

--- a/drake/systems/plants/inverseKinBackend.cpp
+++ b/drake/systems/plants/inverseKinBackend.cpp
@@ -10,6 +10,7 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/core/Gradient.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/solvers/optimization.h"
 #include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 #include "drake/systems/plants/ConstraintWrappers.h"

--- a/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
+++ b/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
@@ -2,6 +2,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/util/testUtil.h"
 

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -11,6 +11,7 @@
 #include "drake/drakeQPLocomotionPlan_export.h"  // TODO(tkoolen): exports
 #include "drake/examples/Atlas/atlasUtil.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/expmap.h"
 #include "drake/math/gradient.h"
 #include "drake/math/quaternion.h"

--- a/drake/util/closestExpmapmex.cpp
+++ b/drake/util/closestExpmapmex.cpp
@@ -1,6 +1,7 @@
 #include <Eigen/Core>
 
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/expmap.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"

--- a/drake/util/drakeMexUtil.h
+++ b/drake/util/drakeMexUtil.h
@@ -20,6 +20,7 @@
 #include <Eigen/src/SparseCore/SparseMatrix.h>
 
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/util/drakeGradientUtil.h"
 
 using drake::math::autoDiffToValueMatrix;

--- a/drake/util/expmap2quatImplmex.cpp
+++ b/drake/util/expmap2quatImplmex.cpp
@@ -1,6 +1,7 @@
 #include <Eigen/Core>
 
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/expmap.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"

--- a/drake/util/flipExpmapmex.cpp
+++ b/drake/util/flipExpmapmex.cpp
@@ -1,6 +1,7 @@
 #include <Eigen/Core>
 
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"
 #include "drake/util/drakeGeometryUtil.h"

--- a/drake/util/quat2expmapmex.cpp
+++ b/drake/util/quat2expmapmex.cpp
@@ -1,5 +1,6 @@
 #include <Eigen/Core>
 
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/expmap.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"

--- a/drake/util/test/testGeometryConversionFunctionsmex.cpp
+++ b/drake/util/test/testGeometryConversionFunctionsmex.cpp
@@ -1,5 +1,6 @@
 #include "drake/common/constants.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/quaternion.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeMexUtil.h"

--- a/drake/util/test/testQuatmex.cpp
+++ b/drake/util/test/testQuatmex.cpp
@@ -3,6 +3,7 @@
 #include <tuple>
 
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/quaternion.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/core/Gradient.h"

--- a/drake/util/unwrapExpmapmex.cpp
+++ b/drake/util/unwrapExpmapmex.cpp
@@ -1,6 +1,7 @@
 #include <Eigen/Core>
 
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/util/mexify.h"
 #include "drake/util/standardMexConversions.h"
 #include "drake/util/drakeGeometryUtil.h"


### PR DESCRIPTION
The premise is that `autodiff.h` gets autodiff code, that `gradient.h` gets gradient code, and that `autodiff_gradient.h` gets the go-between code.

Specifically:
- Move `autoDiffToGradientMatrix` into `autodiff_gradient.h`
- Move the type-helper structs into internal namespaces (and separate files).
- Add file overview comments.
- Update the includes in downstream code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3041)
<!-- Reviewable:end -->
