### PR TITLE
Fix inclusion of textbook

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -341,6 +341,6 @@ if(ENABLE_DOCUMENTATION)
   add_subdirectory(doc)
 endif()
 
-if(IS_DIRECTORY doc/textbook)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/doc/textbook/CMakeLists.txt)
   add_subdirectory(doc/textbook)
 endif()


### PR DESCRIPTION
Fix check whether we want to build the textbook. The old check asks if the directory exists, but since we switched to submodules, the directory will *always* exist. Instead, check for a `CMakeLists.txt`.

Presumably, the only reason this is not currently causing build failures when the textbook is not enabled is because `if(IS_DIRECTORY)` "is well-defined only for full paths"<sup>[[note]](https://cmake.org/cmake/help/v3.5/command/if)</sup>, and is likely evaluating to false, even when we actually *do* want the textbook.

@bradking for feature review, @david-german-tri for platform review, or please reassign to appropriate folks; thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3042)
<!-- Reviewable:end -->
