### PR TITLE
Address libbot / bot_core_lcmtypes conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,13 +211,13 @@ else()
     CMAKE_ARGS -DBUILD_SHARED_LIBS=ON)
 endif()
 
-# bot_core_lcmtypes
-drake_add_external(bot_core_lcmtypes PUBLIC CMAKE
-  DEPENDS lcm)
-
 # libbot
 drake_add_external(libbot PUBLIC CMAKE
   DEPENDS lcm)
+
+# bot_core_lcmtypes
+drake_add_external(bot_core_lcmtypes PUBLIC CMAKE
+  DEPENDS lcm libbot) # Conflicts with libbot; ensure this is built after
 
 # director
 drake_add_external(director PUBLIC


### PR DESCRIPTION
Both libbot and bot_core_lcmtypes generate bindings for the libbot LCM types. Since this means that there is significant overlap in the output files, including the C library, this can result in odd, apparently random errors if the two externals are built in parallel. Address this by adding an artificial dependency between the two to force them to be built in serial.

(In the long run, we hope to split lcmgl from libbot, and build only that and the stand-alone types package, dropping the monolithic libbot package entirely.)

Fixes #2865, hopefully.

@jamiesnape for feature review, @david-german-tri for platform review. This isn't high priority, but it's believed/hoped it will fix a minor nuisance that's been ongoing for a while.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3058)
<!-- Reviewable:end -->
