### PR TITLE
ELF strict linking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -92,7 +92,7 @@
 	ignore = untracked
 [submodule "externals/google_styleguide"]
 	path = externals/google_styleguide
-	url = https://github.com/google/styleguide.git
+	url = https://github.com/mwoehlke-kitware/styleguide.git
 [submodule "externals/spdlog"]
 	path = externals/spdlog
 	url = https://github.com/gabime/spdlog.git

--- a/cmake/mex.cmake
+++ b/cmake/mex.cmake
@@ -324,7 +324,9 @@ function(add_mex)
     add_library(${target} ${ARGV})
     set_target_properties(${target} PROPERTIES
       COMPILE_FLAGS "${MEX_COMPILE_FLAGS}"
-      OUTPUT_NAME ${mexfilename})
+      OUTPUT_NAME ${mexfilename}
+      CXX_VISIBILITY_PRESET "default"
+      VISIBILITY_INLINES_HIDDEN 0)
     if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
       target_link_libraries(${target} liblast)
     else()
@@ -352,6 +354,8 @@ function(add_mex)
       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       OUTPUT_NAME ${mexfilename}
+      CXX_VISIBILITY_PRESET "default"
+      VISIBILITY_INLINES_HIDDEN 0
       )
     foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
       string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -81,6 +81,9 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all -Werror=ignored-qualifiers")
+  set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined ${CMAKE_SHARED_LINKER_FLAGS}")
+  set(CMAKE_MODULE_LINKER_FLAGS "-Wl,--no-undefined ${CMAKE_MODULE_LINKER_FLAGS}")
+  set(CMAKE_EXECUTABLE_LINKER_FLAGS "-Wl,--no-undefined ${CMAKE_EXECUTABLE_LINKER_FLAGS}")
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # TODO(#2852) Turn on shadow checking for g++ once we use a version that fixes
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -77,6 +77,8 @@ endfunction()
 include_directories(BEFORE ${PROJECT_BINARY_DIR}/exports/)
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/..)
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all -Werror=ignored-qualifiers")
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -89,6 +89,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=shadow")
   endif()
+  # TODO(rdeits) Remove when https://github.com/jaeandersson/swig/pull/73 is
+  # accessible from the version of swig_matlab we are using
+  set(CXX_FLAGS_NO_ERROR_MAYBE_UNINITIALIZED "-Wno-error=maybe-uninitialized")
   set(CXX_FLAGS_NO_ERROR_SHADOW "-Wno-error=shadow -Wno-shadow")
   set(CXX_FLAGS_NO_SIGN_COMPARE "-Wno-sign-compare")
 elseif(MSVC)

--- a/drake/bindings/swig/CMakeLists.txt
+++ b/drake/bindings/swig/CMakeLists.txt
@@ -11,6 +11,10 @@ set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "-w503")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_SIGN_COMPARE}")
 # SWIG output code makes expansive use of variable shadowing.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_SHADOW}")
+# SWIG output code "may" use a variable uninitialized (not really, but due to
+# bad annotation of mexErrMsgIdAndTxt, the compiler can't know that); see also
+# https://github.com/jaeandersson/swig/pull/73
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_NO_ERROR_MAYBE_UNINITIALIZED}")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Suppresses warnings due to the existence of deprecated methods. These

--- a/drake/solvers/fast_qp.h
+++ b/drake/solvers/fast_qp.h
@@ -1,18 +1,24 @@
 #pragma once
 
-#include <Eigen/Dense>
 #include <vector>
 #include <set>
 
-int fastQPThatTakesQinv(std::vector<Eigen::MatrixXd*> QinvblkDiag,
-                        const Eigen::VectorXd& f, const Eigen::MatrixXd& Aeq,
-                        const Eigen::VectorXd& beq, const Eigen::MatrixXd& Ain,
-                        const Eigen::VectorXd& bin, std::set<int>& active,
-                        Eigen::VectorXd& x);
-int fastQP(std::vector<Eigen::MatrixXd*> QblkDiag, const Eigen::VectorXd& f,
-           const Eigen::MatrixXd& Aeq, const Eigen::VectorXd& beq,
-           const Eigen::MatrixXd& Ain, const Eigen::VectorXd& bin,
-           std::set<int>& active, Eigen::VectorXd& x);
+#include <Eigen/Dense>
+
+#include "drake/drakeQP_export.h"
+
+DRAKEQP_EXPORT int fastQPThatTakesQinv(
+  std::vector<Eigen::MatrixXd*> QinvblkDiag, const Eigen::VectorXd& f,
+  const Eigen::MatrixXd& Aeq, const Eigen::VectorXd& beq,
+  const Eigen::MatrixXd& Ain, const Eigen::VectorXd& bin,
+  std::set<int>& active, Eigen::VectorXd& x);
+
+DRAKEQP_EXPORT int fastQP(
+  std::vector<Eigen::MatrixXd*> QblkDiag, const Eigen::VectorXd& f,
+  const Eigen::MatrixXd& Aeq, const Eigen::VectorXd& beq,
+  const Eigen::MatrixXd& Ain, const Eigen::VectorXd& bin,
+  std::set<int>& active, Eigen::VectorXd& x);
+
 // int fastQP(std::vector< Eigen::MatrixXd* > QblkDiag, const Eigen::VectorXd&
 // f, const Eigen::MatrixXd& Aeq, const Eigen::VectorXd& beq, const
 // Eigen::MatrixXd& Ain, const Eigen::VectorXd& bin, std::set<int>& active,

--- a/drake/solvers/gurobi_qp.h
+++ b/drake/solvers/gurobi_qp.h
@@ -1,9 +1,13 @@
 #pragma once
 
-#include <Eigen/Dense>
 #include <vector>
 #include <set>
+
+#include <Eigen/Dense>
+
 #include <gurobi_c++.h>
+
+#include "drake/drakeQP_export.h"
 
 #define CGE(call, env)                                                  \
   {                                                                     \
@@ -13,12 +17,12 @@
       std::cerr << "Gurobi error " << GRBgeterrormsg(env) << std::endl; \
   }
 
-GRBmodel* gurobiQP(GRBenv* env, std::vector<Eigen::MatrixXd*> QblkDiag,
-                   Eigen::VectorXd& f, const Eigen::MatrixXd& Aeq,
-                   const Eigen::VectorXd& beq, const Eigen::MatrixXd& Ain,
-                   const Eigen::VectorXd& bin, Eigen::VectorXd& lb,
-                   Eigen::VectorXd& ub, std::set<int>& active,
-                   Eigen::VectorXd& x, double active_set_slack_tol = 1e-4);
+DRAKEQP_EXPORT GRBmodel* gurobiQP(
+  GRBenv* env, std::vector<Eigen::MatrixXd*> QblkDiag, Eigen::VectorXd& f,
+  const Eigen::MatrixXd& Aeq, const Eigen::VectorXd& beq,
+  const Eigen::MatrixXd& Ain, const Eigen::VectorXd& bin,
+  Eigen::VectorXd& lb, Eigen::VectorXd& ub, std::set<int>& active,
+  Eigen::VectorXd& x, double active_set_slack_tol = 1e-4);
 
 // template <typename tA, typename tB, typename tC, typename tD, typename tE>
 // GRBmodel* gurobiQP(GRBenv *env, std::vector< Eigen::Map<tA> > QblkDiag,
@@ -27,10 +31,11 @@ GRBmodel* gurobiQP(GRBenv* env, std::vector<Eigen::MatrixXd*> QblkDiag,
 // Eigen::MatrixBase<tE>& bin, Eigen::VectorXd& lb, Eigen::VectorXd& ub,
 // std::set<int>& active, Eigen::VectorXd& x);
 
-GRBmodel* gurobiActiveSetQP(GRBenv* env, std::vector<Eigen::MatrixXd*> QblkDiag,
-                            Eigen::VectorXd& f, const Eigen::MatrixXd& Aeq,
-                            const Eigen::VectorXd& beq,
-                            const Eigen::MatrixXd& Ain,
-                            const Eigen::VectorXd& bin, Eigen::VectorXd& lb,
-                            Eigen::VectorXd& ub, int*& vbasis, int vbasis_len,
-                            int*& cbasis, int cbasis_len, Eigen::VectorXd& x);
+DRAKEQP_EXPORT GRBmodel* gurobiActiveSetQP(
+  GRBenv* env, std::vector<Eigen::MatrixXd*> QblkDiag, Eigen::VectorXd& f,
+  const Eigen::MatrixXd& Aeq, const Eigen::VectorXd& beq,
+  const Eigen::MatrixXd& Ain, const Eigen::VectorXd& bin,
+  Eigen::VectorXd& lb, Eigen::VectorXd& ub,
+  int*& vbasis, int vbasis_len,
+  int*& cbasis, int cbasis_len,
+  Eigen::VectorXd& x);

--- a/drake/systems/controllers/CMakeLists.txt
+++ b/drake/systems/controllers/CMakeLists.txt
@@ -16,6 +16,7 @@ pods_find_pkg_config(gurobi)
 if(gurobi_FOUND AND lcm_FOUND AND yaml-cpp_FOUND)
   add_library_with_exports(LIB_NAME drakeQPCommon SOURCE_FILES InstantaneousQPController.cpp)
   target_link_libraries(drakeQPCommon drakeControlUtil drakeQP drakeTrajectories drakeLCMUtil drakeSide drakeYAMLUtil lcm)
+  pods_use_pkg_config_packages(drakeQPCommon gurobi)
   pods_install_libraries(drakeQPCommon)
   drake_install_headers(QPCommon.h InstantaneousQPController.h)
   pods_install_pkg_config_file(drake-qp-common

--- a/drake/systems/controllers/InstantaneousQPController.h
+++ b/drake/systems/controllers/InstantaneousQPController.h
@@ -4,6 +4,7 @@
 #include "QPCommon.h"
 #include "drake/solvers/gurobi_qp.h"
 #include "lcmtypes/drake/lcmt_qp_controller_input.hpp"
+#include "drake/drakeQPCommon_export.h"
 
 #define INSTQP_USE_FASTQP 1
 #define INSTQP_GUROBI_OUTPUTFLAG 0
@@ -13,7 +14,7 @@
 #define INSTQP_GUROBI_BARHOMOGENEOUS 0
 #define INSTQP_GUROBI_BARCONVTOL (5e-4)
 
-class InstantaneousQPController {
+class DRAKEQPCOMMON_EXPORT InstantaneousQPController {
  public:
   InstantaneousQPController(
       std::unique_ptr<RigidBodyTree> robot_in,
@@ -123,7 +124,9 @@ class InstantaneousQPController {
   const QPControllerParams& FindParams(const std::string& param_set_name);
 };
 
-void applyURDFModifications(std::unique_ptr<RigidBodyTree>& robot,
-                            const KinematicModifications& modifications);
-void applyURDFModifications(std::unique_ptr<RigidBodyTree>& robot,
-                            const std::string& urdf_modifications_filename);
+DRAKEQPCOMMON_EXPORT void applyURDFModifications(
+  std::unique_ptr<RigidBodyTree>& robot,
+  const KinematicModifications& modifications);
+DRAKEQPCOMMON_EXPORT void applyURDFModifications(
+  std::unique_ptr<RigidBodyTree>& robot,
+  const std::string& urdf_modifications_filename);

--- a/drake/systems/plants/RigidBodyIK.h
+++ b/drake/systems/plants/RigidBodyIK.h
@@ -69,7 +69,7 @@ DRAKEIK_EXPORT void inverseKin(RigidBodyTree* model,
                                Eigen::MatrixBase<DerivedC>* q_sol, int* info,
                                std::vector<std::string>* infeasible_constraint);
 
-IKResults inverseKinSimple(
+DRAKEIK_EXPORT IKResults inverseKinSimple(
     RigidBodyTree* model, const Eigen::VectorXd& q_seed,
     const Eigen::VectorXd& q_nom,
     const std::vector<RigidBodyConstraint*>& constraint_array,

--- a/drake/systems/plants/approximateIK.cpp
+++ b/drake/systems/plants/approximateIK.cpp
@@ -207,13 +207,12 @@ void approximateIK(RigidBodyTree* model, const MatrixBase<DerivedA>& q_seed,
   return;
 }
 
-template void approximateIK(RigidBodyTree*, const MatrixBase<Map<VectorXd>>& ,
-                            const MatrixBase<Map<VectorXd>>& , const int,
-                            RigidBodyConstraint** const,
-                            const IKoptions&,
-                            MatrixBase<Map<VectorXd>>*, int*);
+template DRAKEIK_EXPORT void approximateIK(
+  RigidBodyTree*, const MatrixBase<Map<VectorXd>>& ,
+  const MatrixBase<Map<VectorXd>>& , const int, RigidBodyConstraint** const,
+  const IKoptions&, MatrixBase<Map<VectorXd>>*, int*);
 
-template void approximateIK(RigidBodyTree*, const MatrixBase<VectorXd>& ,
-                            const MatrixBase<VectorXd>& , const int,
-                            RigidBodyConstraint** const,
-                            const IKoptions&, MatrixBase<VectorXd>*, int*);
+template DRAKEIK_EXPORT void approximateIK(
+  RigidBodyTree*, const MatrixBase<VectorXd>& ,
+  const MatrixBase<VectorXd>& , const int, RigidBodyConstraint** const,
+  const IKoptions&, MatrixBase<VectorXd>*, int*);

--- a/drake/systems/plants/constraint/constructPtrRigidBodyConstraint.h
+++ b/drake/systems/plants/constraint/constructPtrRigidBodyConstraint.h
@@ -11,7 +11,7 @@
 #define CONSTRUCT_CONSTRAINT_DLLEXPORT __declspec(dllimport)
 #endif
 #else
-#define CONSTRUCT_CONSTRAINT_DLLEXPORT
+#define CONSTRUCT_CONSTRAINT_DLLEXPORT [[gnu::visibility("default")]]
 #endif
 
 CONSTRUCT_CONSTRAINT_DLLEXPORT mxArray* createDrakeConstraintMexPointer(

--- a/drake/systems/plants/rigidBodyTreeMexFunctions.h
+++ b/drake/systems/plants/rigidBodyTreeMexFunctions.h
@@ -10,7 +10,7 @@
 #define DLLEXPORT __declspec(dllimport)
 #endif
 #else
-#define DLLEXPORT
+#define DLLEXPORT [[gnu::visibility("default")]]
 #endif
 
 DLLEXPORT void centerOfMassJacobianDotTimesVmex(int nlhs, mxArray *plhs[],

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.h
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.h
@@ -3,16 +3,20 @@
 #include <vector>
 #include <map>
 #include <string>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+
+#include <lcm/lcm-cpp.hpp>
+
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
 #include "drake/systems/trajectories/ExponentialPlusPiecewisePolynomial.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "lcmtypes/drake/lcmt_qp_controller_input.hpp"
 #include "BodyMotionData.h"
 #include "drake/systems/robotInterfaces/Side.h"
-#include <lcm/lcm-cpp.hpp>
 #include "drake/systems/controllers/zmpUtil.h"
+#include "drake/drakeQPLocomotionPlan_export.h"
 
 class QuadraticLyapunovFunction {
   // TODO(tkoolen): move into its own file
@@ -153,7 +157,7 @@ struct QPLocomotionPlanSettings {
   }
 };
 
-class QPLocomotionPlan {
+class DRAKEQPLOCOMOTIONPLAN_EXPORT QPLocomotionPlan {
  private:
   RigidBodyTree& robot_;  // TODO(tkoolen): const correctness
   QPLocomotionPlanSettings settings_;

--- a/drake/thirdParty/bsd/spruce/include/spruce.hh
+++ b/drake/thirdParty/bsd/spruce/include/spruce.hh
@@ -22,7 +22,7 @@
     #define DLLEXPORT_spruce __declspec( dllimport )
   #endif
 #else
-    #define DLLEXPORT_spruce
+    #define DLLEXPORT_spruce [[gnu::visibility("default")]]
 #endif
 
 namespace spruce

--- a/drake/util/MexWrapper.h
+++ b/drake/util/MexWrapper.h
@@ -12,7 +12,7 @@
 #define DLLEXPORT __declspec(dllimport)
 #endif
 #else
-#define DLLEXPORT
+#define DLLEXPORT [[gnu::visibility("default")]]
 #endif
 
 class DLLEXPORT MexWrapper {

--- a/drake/util/drakeMexUtil.h
+++ b/drake/util/drakeMexUtil.h
@@ -35,7 +35,7 @@ using drake::math::Gradient;
 #define DLLEXPORT __declspec(dllimport)
 #endif
 #else
-#define DLLEXPORT
+#define DLLEXPORT [[gnu::visibility("default")]]
 #endif
 
 DLLEXPORT bool isa(const mxArray* mxa, const char* class_str);

--- a/drake/util/yaml/yamlUtil.h
+++ b/drake/util/yaml/yamlUtil.h
@@ -5,24 +5,26 @@
 #include "yaml-cpp/yaml.h"
 #include "drake/systems/controllers/QPCommon.h"
 #include "drake/systems/plants/RigidBodyTree.h"
+#include "drake/drakeYAMLUtil_export.h"
 
-YAML::Node applyDefaults(const YAML::Node& node,
-                         const YAML::Node& default_node);
-YAML::Node expandDefaults(const YAML::Node& node);
+DRAKEYAMLUTIL_EXPORT YAML::Node applyDefaults(
+  const YAML::Node& node, const YAML::Node& default_node);
+DRAKEYAMLUTIL_EXPORT YAML::Node expandDefaults(const YAML::Node& node);
 
 // yaml-cpp does not understand the DEFAULT: syntax for a default value or the
-// <<:
-// syntax to merge the contents of a node. This function wraps the map lookup
-// to provide the correct behavior.
-YAML::Node get(const YAML::Node& parent, const std::string& key);
+// <<: syntax to merge the contents of a node. This function wraps the map
+// lookup to provide the correct behavior.
+DRAKEYAMLUTIL_EXPORT YAML::Node get(
+  const YAML::Node& parent, const std::string& key);
 
-QPControllerParams loadSingleParamSet(const YAML::Node& config,
-                                      const RigidBodyTree& robot);
-std::map<std::string, QPControllerParams> loadAllParamSets(
+DRAKEYAMLUTIL_EXPORT QPControllerParams loadSingleParamSet(
+  const YAML::Node& config, const RigidBodyTree& robot);
+DRAKEYAMLUTIL_EXPORT std::map<std::string, QPControllerParams> loadAllParamSets(
     YAML::Node config, const RigidBodyTree& robot);
-std::map<std::string, QPControllerParams> loadAllParamSets(
+DRAKEYAMLUTIL_EXPORT std::map<std::string, QPControllerParams> loadAllParamSets(
     YAML::Node config, const RigidBodyTree& robot,
     std::ofstream& debug_output_file);
-RobotPropertyCache parseKinematicTreeMetadata(const YAML::Node& metadata,
-                                              const RigidBodyTree& robot);
-KinematicModifications parseKinematicModifications(const YAML::Node& mods);
+DRAKEYAMLUTIL_EXPORT RobotPropertyCache parseKinematicTreeMetadata(
+  const YAML::Node& metadata, const RigidBodyTree& robot);
+DRAKEYAMLUTIL_EXPORT KinematicModifications parseKinematicModifications(
+  const YAML::Node& mods);


### PR DESCRIPTION
Turn on ELF hidden visibility by default, and turn on link flags to disallow unresolved symbols. Among other advantages¹, this makes the behavior on other platforms closer to that of Windows, which can help catch link problems when developing on other platforms (as opposed to them showing up for the first time in a Windows build).

(¹ https://gcc.gnu.org/wiki/Visibility)

Implements #3059.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3065)
<!-- Reviewable:end -->
