### PR TITLE
Switch to using overloaded functions to add constraints/costs to an OptimizationProblem

### DIFF
--- a/drake/solvers/optimization.h
+++ b/drake/solvers/optimization.h
@@ -171,7 +171,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   }
 
   /**
-   * Add a cost to the problem which covers all decision
+   * Adds a cost to the problem which covers all decision
    * variables created at the time the cost was added.
    */
   template <typename ConstraintT>
@@ -285,7 +285,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
   }
 
   /**
-   * Add a constraint to the problem which covers all decision
+   * Adds a constraint to the problem which covers all decision
    * variables created at the time the constraint was added.
    */
   template <typename ConstraintT>

--- a/drake/solvers/optimization.h
+++ b/drake/solvers/optimization.h
@@ -170,8 +170,20 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     generic_costs_.push_back(Binding<Constraint>(obj, vars));
   }
 
-  void AddCost(std::shared_ptr<Constraint> const& obj) {
-    AddCost(obj, variable_views_);
+  /**
+   * Add a cost to the problem which covers all decision
+   * variables created at the time the cost was added.
+   */
+  template <typename ConstraintT>
+  void AddCost(std::shared_ptr<ConstraintT> constraint) {
+    AddCost(constraint, variable_views_);
+  }
+
+  template <typename F>
+  static std::shared_ptr<Constraint> MakeCost(F&& f) {
+    return std::make_shared<
+        ConstraintImpl<typename std::remove_reference<F>::type>>(
+        std::forward<F>(f));
   }
 
   template <typename F>
@@ -179,9 +191,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       !std::is_convertible<F, std::shared_ptr<Constraint>>::value,
       std::shared_ptr<Constraint>>::type
   AddCost(F&& f, VariableList const& vars) {
-    auto c = std::make_shared<
-        ConstraintImpl<typename std::remove_reference<F>::type>>(
-        std::forward<F>(f));
+    auto c = MakeCost(std::forward<F>(f));
     AddCost(c, vars);
     return c;
   }
@@ -212,6 +222,17 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     return AddCost(std::forward<std::unique_ptr<F>>(f), variable_views_);
   }
 
+  /**
+   * @brief Adds a cost term of the form 0.5*x'*Q*x + b'x
+   * Applied to subset of the variables and pushes onto
+   * the quadratic cost data structure.
+   */
+  void AddCost(std::shared_ptr<QuadraticConstraint> const& obj,
+               VariableList const& vars) {
+    problem_type_.AddQuadraticCost();
+    quadratic_costs_.push_back(Binding<QuadraticConstraint>(obj, vars));
+  }
+
   /** AddQuadraticErrorCost
    * @brief Adds a cost term of the form (x-x_desired)'*Q*(x-x_desired).
    */
@@ -222,7 +243,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     std::shared_ptr<QuadraticConstraint> cost(new QuadraticConstraint(
         2 * Q, -2 * Q * x_desired, -std::numeric_limits<double>::infinity(),
         std::numeric_limits<double>::infinity()));
-    AddQuadraticCost(cost, vars);
+    AddCost(cost, vars);
     return cost;
   }
 
@@ -236,24 +257,6 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       const Eigen::MatrixBase<Derivedb>& x_desired) {
     return AddQuadraticErrorCost(Q, x_desired, variable_views_);
   }
-  /** AddQuadraticCost
-   * @brief Adds a cost term of the form 0.5*x'*Q*x + b'x
-   * Applied to subset of the variables and pushes onto
-   * the quadratic cost data structure.
-   */
-  void AddQuadraticCost(std::shared_ptr<QuadraticConstraint> const& obj,
-                        VariableList const& vars) {
-    problem_type_.AddQuadraticCost();
-    quadratic_costs_.push_back(Binding<QuadraticConstraint>(obj, vars));
-  }
-
-  /** AddQuadraticCost
-   * @brief Adds a cost term of the form 0.5*x'*Q*x + b'x
-   * Applied to all (currently existing) variables.
-   */
-  void AddQuadraticCost(std::shared_ptr<QuadraticConstraint> const& obj) {
-    AddQuadraticCost(obj, variable_views_);
-  }
 
   /** AddQuadraticCost
    * @brief Adds a cost term of the form 0.5*x'*Q*x + b'x
@@ -266,7 +269,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     std::shared_ptr<QuadraticConstraint> cost(
         new QuadraticConstraint(Q, b, -std::numeric_limits<double>::infinity(),
                                 std::numeric_limits<double>::infinity()));
-    AddQuadraticCost(cost, vars);
+    AddCost(cost, vars);
     return cost;
   }
 
@@ -281,44 +284,38 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     return AddQuadraticCost(Q, b, variable_views_);
   }
 
-  /** AddGenericConstraint
-   *
+  /**
+   * Add a constraint to the problem which covers all decision
+   * variables created at the time the constraint was added.
+   */
+  template <typename ConstraintT>
+  void AddConstraint(std::shared_ptr<ConstraintT> constraint) {
+    AddConstraint(constraint, variable_views_);
+  }
+
+  /**
    * @brief Adds a generic constraint to the program.  This should
    * only be used if a more specific type of constraint is not
    * available, as it may require the use of a significantly more
    * expensive solver.
    */
-  void AddGenericConstraint(std::shared_ptr<Constraint> con,
-                            VariableList const& vars) {
+  void AddConstraint(std::shared_ptr<Constraint> con,
+                     VariableList const& vars) {
     problem_type_.AddGenericConstraint();
     generic_constraints_.push_back(Binding<Constraint>(con, vars));
   }
-  void AddGenericConstraint(std::shared_ptr<Constraint> con) {
-    AddGenericConstraint(con, variable_views_);
-  }
 
-  /** AddLinearConstraint
-   *
+  /**
    * @brief Adds linear constraints referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    */
-  void AddLinearConstraint(std::shared_ptr<LinearConstraint> con,
-                           VariableList const& vars) {
+  void AddConstraint(std::shared_ptr<LinearConstraint> con,
+                     VariableList const& vars) {
     problem_type_.AddLinearConstraint();
     linear_constraints_.push_back(Binding<LinearConstraint>(con, vars));
   }
 
-  /** AddLinearConstraint
-   *
-   * @brief Adds linear constraints to the program for all (currently existing)
-   * variables.
-   */
-  void AddLinearConstraint(std::shared_ptr<LinearConstraint> con) {
-    AddLinearConstraint(con, variable_views_);
-  }
-
-  /** AddLinearConstraint
-   *
+  /**
    * @brief Adds linear constraints referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    */
@@ -328,7 +325,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       const Eigen::MatrixBase<DerivedLB>& lb,
       const Eigen::MatrixBase<DerivedUB>& ub, const VariableList& vars) {
     auto constraint = std::make_shared<LinearConstraint>(A, lb, ub);
-    AddLinearConstraint(constraint, vars);
+    AddConstraint(constraint, vars);
     return constraint;
   }
 
@@ -345,26 +342,15 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     return AddLinearConstraint(A, lb, ub, variable_views_);
   }
 
-  /** AddLinearEqualityConstraint
-   *
+  /**
    * @brief Adds linear equality constraints referencing potentially a
    * subset of the decision variables (defined in the vars parameter).
    */
-  void AddLinearEqualityConstraint(
+  void AddConstraint(
       std::shared_ptr<LinearEqualityConstraint> con, VariableList const& vars) {
     problem_type_.AddLinearEqualityConstraint();
     linear_equality_constraints_.push_back(
         Binding<LinearEqualityConstraint>(con, vars));
-  }
-
-  /** AddLinearEqualityConstraint
-   *
-   * @brief Adds linear equality constraints to the program for all
-   * (currently existing) variables.
-   */
-  void AddLinearEqualityConstraint(
-      std::shared_ptr<LinearEqualityConstraint> con) {
-    AddLinearEqualityConstraint(con, variable_views_);
   }
 
   /** AddLinearEqualityConstraint
@@ -382,7 +368,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       const Eigen::MatrixBase<DerivedA>& Aeq,
       const Eigen::MatrixBase<DerivedB>& beq, const VariableList& vars) {
     auto constraint = std::make_shared<LinearEqualityConstraint>(Aeq, beq);
-    AddLinearEqualityConstraint(constraint, vars);
+    AddConstraint(constraint, vars);
     return constraint;
   }
 
@@ -398,24 +384,14 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
     return AddLinearEqualityConstraint(Aeq, beq, variable_views_);
   }
 
-  /** AddBoundingBoxConstraint
-   *
+  /**
    * @brief Adds bounding box constraints referencing potentially a subset of
    * the decision variables.
    */
-  void AddBoundingBoxConstraint(std::shared_ptr<BoundingBoxConstraint> con,
-                                VariableList const& vars) {
+  void AddConstraint(std::shared_ptr<BoundingBoxConstraint> con,
+                     VariableList const& vars) {
     problem_type_.AddLinearConstraint();
     bbox_constraints_.push_back(Binding<BoundingBoxConstraint>(con, vars));
-  }
-
-  /** AddBoundingBoxConstraint
-   *
-   * @brief Adds bounding box constraints to the program for all
-   * (currently existing) variables.
-   */
-  void AddBoundingBoxConstraint(std::shared_ptr<BoundingBoxConstraint> con) {
-    AddBoundingBoxConstraint(con, variable_views_);
   }
 
   /** AddBoundingBoxConstraint
@@ -429,7 +405,7 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
       const Eigen::MatrixBase<DerivedUB>& ub, const VariableList& vars) {
     std::shared_ptr<BoundingBoxConstraint> constraint(
         new BoundingBoxConstraint(lb, ub));
-    AddBoundingBoxConstraint(constraint, vars);
+    AddConstraint(constraint, vars);
     return constraint;
   }
 
@@ -533,20 +509,20 @@ class DRAKEOPTIMIZATION_EXPORT OptimizationProblem {
         std::shared_ptr<LinearEqualityConstraint> constraint(
             new LinearEqualityConstraint(linear_constraint_matrix,
                                          linear_constraint_ub));
-        AddLinearEqualityConstraint(constraint, vars);
+        AddConstraint(constraint, vars);
         return constraint;
       } else {
         std::shared_ptr<LinearConstraint> constraint(
             new LinearConstraint(linear_constraint_matrix,
                                  linear_constraint_lb,
-                               linear_constraint_ub));
-        AddLinearConstraint(constraint, vars);
+                                 linear_constraint_ub));
+        AddConstraint(constraint, vars);
         return constraint;
       }
     } else {
       std::shared_ptr<PolynomialConstraint> constraint(
           new PolynomialConstraint(polynomials, poly_vars, lb, ub));
-      AddGenericConstraint(constraint, vars);
+      AddConstraint(constraint, vars);
       return constraint;
     }
   }

--- a/drake/solvers/test/mosek_test.cc
+++ b/drake/solvers/test/mosek_test.cc
@@ -78,7 +78,7 @@ GTEST_TEST(testMosek, MosekQuadraticCost) {
        -1, 0, 2;
   Eigen::Vector3d c;
   c << 0, -1, 0;
-  prog2.AddQuadraticCost(std::make_shared<QuadraticConstraint>(Q, c, 0, 0));
+  prog2.AddCost(std::make_shared<QuadraticConstraint>(Q, c, 0, 0));
   // Build the constraint matrix and send it to the program.
   Eigen::Vector3d linearcon;
   linearcon << 1, 1, 1;
@@ -86,7 +86,7 @@ GTEST_TEST(testMosek, MosekQuadraticCost) {
       std::make_shared<QuadraticConstraint>(
           Eigen::Matrix3d::Constant(0), linearcon, 1,
           std::numeric_limits<double>::infinity());
-  prog2.AddGenericConstraint(ptrtocon);
+  prog2.AddConstraint(ptrtocon);
   // Create the bounding box.
   Eigen::Vector3d bboxlow, bboxhigh;
   bboxlow << 0, 0, 0;
@@ -117,7 +117,7 @@ GTEST_TEST(testMosek, MosekQuadraticConstraintAndCost) {
        -1, 0, 2;
   Eigen::Vector3d c;
   c << 0, -1, 0;
-  prog2.AddQuadraticCost(std::make_shared<QuadraticConstraint>(Q, c, 0, 0));
+  prog2.AddCost(std::make_shared<QuadraticConstraint>(Q, c, 0, 0));
   // Create the constraint matrix, and send it to the program.
   Eigen::Vector3d linearcon;
   linearcon << 1, 1, 1;
@@ -128,7 +128,7 @@ GTEST_TEST(testMosek, MosekQuadraticConstraintAndCost) {
   std::shared_ptr<QuadraticConstraint> ptrtocon =
       std::make_shared<QuadraticConstraint>(quadcon, linearcon, 1,
       std::numeric_limits<double>::infinity());
-  prog2.AddGenericConstraint(ptrtocon);
+  prog2.AddConstraint(ptrtocon);
   // Create the bounding box.
   Eigen::Vector3d bboxlow, bboxhigh;
   bboxlow << 0, 0, 0;

--- a/drake/solvers/test/optimization_problem_test.cc
+++ b/drake/solvers/test/optimization_problem_test.cc
@@ -158,7 +158,7 @@ GTEST_TEST(testOptimizationProblem, trivialLinearSystem) {
 
   std::shared_ptr<BoundingBoxConstraint> bbcon(new BoundingBoxConstraint(
       MatrixXd::Constant(2, 1, -1000.0), MatrixXd::Constant(2, 1, 1000.0)));
-  prog.AddBoundingBoxConstraint(bbcon, {x.head(2)});
+  prog.AddConstraint(bbcon, {x.head(2)});
 
   // Now solve as a nonlinear program.
   RunNonlinearProgram(prog, [&]() {
@@ -245,6 +245,9 @@ GTEST_TEST(testOptimizationProblem, testProblem1AsQP) {
       constraint.transpose(),
       drake::Vector1d::Constant(-std::numeric_limits<double>::infinity()),
       drake::Vector1d::Constant(40));
+  EXPECT_EQ(prog.linear_constraints().size(), 1);
+  EXPECT_EQ(prog.generic_constraints().size(), 0);
+
   prog.AddBoundingBoxConstraint(MatrixXd::Constant(5, 1, 0),
                                 MatrixXd::Constant(5, 1, 1));
   VectorXd expected(5);
@@ -406,9 +409,9 @@ GTEST_TEST(testOptimizationProblem, lowerBoundTest) {
   auto x = prog.AddContinuousVariables(6);
   prog.AddCost(LowerBoundTestCost());
   std::shared_ptr<Constraint> con1(new LowerBoundTestConstraint(2, 3));
-  prog.AddGenericConstraint(con1);
+  prog.AddConstraint(con1);
   std::shared_ptr<Constraint> con2(new LowerBoundTestConstraint(4, 5));
-  prog.AddGenericConstraint(con2);
+  prog.AddConstraint(con2);
 
   Eigen::VectorXd c1(6);
   c1 << 1, -3, 0, 0, 0, 0;
@@ -547,8 +550,8 @@ GTEST_TEST(testOptimizationProblem, gloptipolyConstrainedMinimization) {
   prog.AddCost(GloptipolyConstrainedExampleCost(), {y});
   std::shared_ptr<GloptipolyConstrainedExampleConstraint> qp_con(
       new GloptipolyConstrainedExampleConstraint());
-  prog.AddGenericConstraint(qp_con, {x});
-  prog.AddGenericConstraint(qp_con, {y});
+  prog.AddConstraint(qp_con, {x});
+  prog.AddConstraint(qp_con, {y});
   prog.AddLinearConstraint(
       Vector3d(1, 1, 1).transpose(),
       Vector1d::Constant(-std::numeric_limits<double>::infinity()),

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -312,7 +312,7 @@ DRAKERBSYSTEM_EXPORT RigidBodySystem::StateVector<double> getInitialState(
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con1wrapper(
           new SingleTimeKinematicConstraintWrapper(&constraints.back(),
                                                    &kin_helper));
-      prog.AddGenericConstraint(con1wrapper, {qvar});
+      prog.AddConstraint(con1wrapper, {qvar});
       constraints.push_back(RelativePositionConstraint(
           sys.tree.get(), loop.axis_, loop.axis_, loop.axis_,
           loop.frameA_->get_frame_index(), loop.frameB_->get_frame_index(),
@@ -320,7 +320,7 @@ DRAKERBSYSTEM_EXPORT RigidBodySystem::StateVector<double> getInitialState(
       std::shared_ptr<SingleTimeKinematicConstraintWrapper> con2wrapper(
           new SingleTimeKinematicConstraintWrapper(&constraints.back(),
                                                    &kin_helper));
-      prog.AddGenericConstraint(con2wrapper, {qvar});
+      prog.AddConstraint(con2wrapper, {qvar});
     }
 
     VectorXd q_guess = x0.topRows(nq);

--- a/drake/systems/plants/inverseKinBackend.cpp
+++ b/drake/systems/plants/inverseKinBackend.cpp
@@ -136,7 +136,7 @@ void AddQuasiStaticConstraint(
       prog->AddContinuousVariables(num_vars, "qsc");
   auto wrapper = std::make_shared<QuasiStaticConstraintWrapper>(
       qsc, kin_helper);
-  prog->AddGenericConstraint(wrapper, {vars, qsc_vars});
+  prog->AddConstraint(wrapper, {vars, qsc_vars});
   prog->AddBoundingBoxConstraint(VectorXd::Constant(num_vars, 0.),
                                  VectorXd::Constant(num_vars, 1.),
                                  {qsc_vars});
@@ -235,7 +235,7 @@ void inverseKinBackend(
         if (!stc->isTimeValid(&t[t_index])) { continue; }
         auto wrapper = std::make_shared<SingleTimeKinematicConstraintWrapper>(
             stc, &kin_helper);
-        prog.AddGenericConstraint(wrapper, {vars});
+        prog.AddConstraint(wrapper, {vars});
       } else if (constraint_category ==
                  RigidBodyConstraint::PostureConstraintCategory) {
         PostureConstraint* pc = static_cast<PostureConstraint*>(constraint);

--- a/drake/systems/plants/inverseKinTrajBackend.cpp
+++ b/drake/systems/plants/inverseKinTrajBackend.cpp
@@ -459,7 +459,7 @@ void inverseKinTrajBackend(
           stc, &kin_helper);
       for (int t_index = qstart_idx; t_index < nT; t_index++) {
         if (!stc->isTimeValid(&t[t_index])) { continue; }
-        prog.AddGenericConstraint(wrapper, {q.segment(nq * t_index, nq)});
+        prog.AddConstraint(wrapper, {q.segment(nq * t_index, nq)});
       }
     } else if (constraint_category ==
                RigidBodyConstraint::PostureConstraintCategory) {
@@ -518,7 +518,7 @@ void inverseKinTrajBackend(
       std::make_shared<IKInbetweenConstraint>(
           model, helper, num_constraints, constraint_array);
   if (inbetween_constraint->num_constraints() > 0) {
-    prog.AddGenericConstraint(inbetween_constraint, {q, qdot0, qdotf});
+    prog.AddConstraint(inbetween_constraint, {q, qdot0, qdotf});
   }
 
   const SolutionResult result = prog.Solve();


### PR DESCRIPTION
The intent of this change is to allow (templated) callers which have
been passed a constraint of unknown type as a parameter to add
constraints (costs) to the proper list.

Example:

  template <typename ConstraintT>
  void AddStateConstraint(std::shared_ptr<ConstraintT> constraint,
                          const std::vector<int>& time_indices) {
    for (const int i: time_indices) {
      DRAKE_ASSERT(i < N_);
      opt_problem_.AddConstraint(
          constraint, {x_vars_.segment(i * num_states_, num_states_)});
    }
  }

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3073)
<!-- Reviewable:end -->
