### PR TITLE
Renamed RigidBodyTree::kWorldLinkName to be RigidBodyTree::kWorldName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Unreleased: changes on master, not yet released
 [//]: # "Altered functionality or APIs."
 ### Changed
 
+ - [#3078][] Changed `RigidBodyTree::kWorldLinkName` to be `RigidBodyTree::kWorldName`.
  - [#3049][] Changed `AddRobotFromURDF*` to be `AddModelInstanceFromURDF*`.
  - [#3003][] Made `RigidBodyFrame` member variables private. Added accessors.
  - [#3010][] All header file names under `solvers` are now spelled with lower case and underscore names.
@@ -123,3 +124,4 @@ Changes in version v0.9.11 and before are not provided.
 [#3003]: https://github.com/RobotLocomotion/drake/issues/3003
 [#3010]: https://github.com/RobotLocomotion/drake/issues/3010
 [#3049]: https://github.com/RobotLocomotion/drake/issues/3049
+[#3078]: https://github.com/RobotLocomotion/drake/issues/3078

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -41,7 +41,7 @@ using drake::math::autoDiffToGradientMatrix;
 using drake::math::Gradient;
 
 const set<int> RigidBodyTree::default_model_instance_id_set = {0};
-const char* const RigidBodyTree::kWorldLinkName = "world";
+const char* const RigidBodyTree::kWorldName = "world";
 
 template <typename T>
 void getFiniteIndexes(T const& v, std::vector<int>& finite_indexes) {
@@ -74,7 +74,7 @@ RigidBodyTree::RigidBodyTree(void)
 
   // Adds the rigid body representing the world.
   std::unique_ptr<RigidBody> b(new RigidBody());
-  b->set_name(RigidBodyTree::kWorldLinkName);
+  b->set_name(RigidBodyTree::kWorldName);
   bodies.push_back(std::move(b));
 }
 
@@ -2044,7 +2044,7 @@ int RigidBodyTree::AddFloatingJoint(
     // use the transform_to_body variable within weld_to_frame to initialize
     // the robot at the desired location in the world.
     if (weld_to_frame->get_name()
-          == std::string(RigidBodyTree::kWorldLinkName)) {
+          == std::string(RigidBodyTree::kWorldName)) {
       if (!weld_to_frame->has_as_rigid_body(nullptr)) {
         throw std::runtime_error(
             "RigidBodyTree::AddFloatingJoint: "

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -38,9 +38,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
    * Defines the name of the rigid body within a rigid body tree that represents
    * the world.
    */
-  // TODO(amcastro-tri): Move the concept of world to an actual world
-  // abstraction. See issue #2318.
-  static const char* const kWorldLinkName;
+  static const char* const kWorldName;
 
   RigidBodyTree(const std::string& urdf_filename,
                 const DrakeJoint::FloatingBaseType floating_base_type =

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -1473,13 +1473,13 @@ void Point2PointDistanceConstraint::name(
       if (bodyA_ != 0) {
         bodyA_name = getRobotPointer()->bodies[bodyA_]->get_name();
       } else {
-        bodyA_name = std::string(RigidBodyTree::kWorldLinkName);
+        bodyA_name = std::string(RigidBodyTree::kWorldName);
       }
       std::string bodyB_name;
       if (bodyB_ != 0) {
         bodyB_name = getRobotPointer()->bodies[bodyB_]->get_name();
       } else {
-        bodyB_name = std::string(RigidBodyTree::kWorldLinkName);
+        bodyB_name = std::string(RigidBodyTree::kWorldName);
       }
       name_str.push_back("Distance from " + bodyA_name + " pt " +
                          std::to_string(i) + " to " + bodyB_name + " pt " +

--- a/drake/systems/plants/parser_sdf.cc
+++ b/drake/systems/plants/parser_sdf.cc
@@ -251,7 +251,7 @@ void parseSDFCollision(RigidBody* body, XMLElement* node, RigidBodyTree* model,
   //  Issue 2661 was created to track this problem.
   // TODO(amcastro-tri): fix the above issue tracked by 2661. Similarly for
   // parseCollision in RigidBodyTreeURDF.cpp.
-  if (body->get_name().compare(std::string(RigidBodyTree::kWorldLinkName)) == 0)
+  if (body->get_name().compare(std::string(RigidBodyTree::kWorldName)) == 0)
     element.set_static();
   if (!parseSDFGeometry(geometry_node, package_map, root_dir, element)) {
     throw runtime_error(std::string(__FILE__) + ": " + __func__ +
@@ -282,7 +282,7 @@ bool parseSDFLink(RigidBodyTree* model, std::string model_name,
   }
   body->set_name(std::string(attr));
 
-  if (body->get_name() == std::string(RigidBodyTree::kWorldLinkName)) {
+  if (body->get_name() == std::string(RigidBodyTree::kWorldName)) {
     throw runtime_error(
         std::string(__FILE__) + ": " + __func__ +
         ": ERROR: Do not name a link 'world' because it is a reserved name.");
@@ -688,7 +688,7 @@ void parseModel(RigidBodyTree* rigid_body_tree, XMLElement* node,
     if (weld_to_frame == nullptr) {
       weld_to_frame = std::allocate_shared<RigidBodyFrame>(
           Eigen::aligned_allocator<RigidBodyFrame>(),
-          std::string(RigidBodyTree::kWorldLinkName),
+          std::string(RigidBodyTree::kWorldName),
           nullptr,  // Valid since the robot is attached to the world.
           Eigen::Isometry3d::Identity());
     }
@@ -737,11 +737,11 @@ void parseSDF(RigidBodyTree* model, XMLDocument* xml_doc,
 
   // Loads the world if it is defined.
   XMLElement* world_node =
-      node->FirstChildElement(RigidBodyTree::kWorldLinkName);
+      node->FirstChildElement(RigidBodyTree::kWorldName);
   if (world_node) {
     // If we have more than one world, it is ambiguous which one the user
     // wishes to use.
-    if (world_node->NextSiblingElement(RigidBodyTree::kWorldLinkName)) {
+    if (world_node->NextSiblingElement(RigidBodyTree::kWorldName)) {
       throw runtime_error(std::string(__FILE__) + ": " + __func__ +
                           ": ERROR: Multiple worlds in one file.");
     }

--- a/drake/systems/plants/parser_urdf.cc
+++ b/drake/systems/plants/parser_urdf.cc
@@ -511,7 +511,7 @@ void parseCollision(RigidBody* body, XMLElement* node, RigidBodyTree* tree,
   //  Issue 2661 was created to track this problem.
   // TODO(amcastro-tri): fix the above issue tracked by 2661.  Similarly for
   // parseSDFCollision in RigidBodyTreeSDF.cpp.
-  if (body->get_name().compare(string(RigidBodyTree::kWorldLinkName)) == 0)
+  if (body->get_name().compare(string(RigidBodyTree::kWorldName)) == 0)
     element.set_static();
   if (!parseGeometry(geometry_node, package_map, root_dir, element))
     throw runtime_error("ERROR: Failed to parse collision element in link " +
@@ -537,7 +537,7 @@ bool parseLink(RigidBodyTree* tree, string robot_name, XMLElement* node,
 
   // World links are handled by parseWorldJoint().
   body->set_name(attr);
-  if (body->get_name() == string(RigidBodyTree::kWorldLinkName)) return false;
+  if (body->get_name() == string(RigidBodyTree::kWorldName)) return false;
 
   XMLElement* inertial_node = node->FirstChildElement("inertial");
   if (inertial_node) parseInertial(body, inertial_node);
@@ -646,7 +646,7 @@ void parseJoint(RigidBodyTree* tree, XMLElement* node) {
   // Checks if this joint connects to the world and, if so, terminates this
   // method call. This is because joints that connect to the world are processed
   // separately.
-  if (parent_name == string(RigidBodyTree::kWorldLinkName)) return;
+  if (parent_name == string(RigidBodyTree::kWorldName)) return;
 
   int parent_index = findLinkIndex(tree, parent_name);
   if (parent_index < 0)
@@ -891,7 +891,7 @@ void parseFrame(RigidBodyTree* tree, XMLElement* node) {
 
 /**
  * Searches for a joint that connects the URDF model to a link with a name equal
- * to the string defined by RigidBodyTree::kWorldLinkName. If it finds such a
+ * to the string defined by RigidBodyTree::kWorldName. If it finds such a
  * joint, it updates the weld_to_frame parameter with the offset specified by
  * the joint.
  *
@@ -926,7 +926,7 @@ void parseWorldJoint(XMLElement* node,
     parseJointKeyParams(joint_node, joint_name, joint_type, parent_name,
                         child_name);
 
-    if (parent_name == string(RigidBodyTree::kWorldLinkName)) {
+    if (parent_name == string(RigidBodyTree::kWorldName)) {
       // Ensures only one joint connects the model to the world.
       if (found_world_joint)
         throw runtime_error(
@@ -946,7 +946,7 @@ void parseWorldJoint(XMLElement* node,
       // a nullptr.
       if (weld_to_frame == nullptr) weld_to_frame.reset(new RigidBodyFrame());
 
-      weld_to_frame->set_name(string(RigidBodyTree::kWorldLinkName));
+      weld_to_frame->set_name(string(RigidBodyTree::kWorldName));
       weld_to_frame->set_transform_to_body(transform_to_parent_body);
 
       if (joint_type == "fixed") {
@@ -1009,7 +1009,7 @@ void parseRobot(RigidBodyTree* tree, XMLElement* node,
         throw runtime_error("ERROR: link tag is missing name attribute");
 
       if (string(name_attr) ==
-          string(RigidBodyTree::kWorldLinkName)) {
+          string(RigidBodyTree::kWorldName)) {
         // A world link was specified within the URDF. The following code
         // verifies that parameter weld_to_frame is not specified. It throws an
         // exception if it is since the model being added is connected to the

--- a/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_joint_state.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_joint_state.h
@@ -126,7 +126,7 @@ class SensorPublisherJointState {
 
         robot_struct->message.reset(new sensor_msgs::JointState());
 
-        robot_struct->message->header.frame_id = RigidBodyTree::kWorldLinkName;
+        robot_struct->message->header.frame_id = RigidBodyTree::kWorldName;
 
         InitJointStateStruct(robot_name, rigid_body_system->getRigidBodyTree(),
                              robot_struct.get());

--- a/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_odometry.h
+++ b/ros/drake_ros_systems/include/drake_ros/ros_sensor_publisher_odometry.h
@@ -99,7 +99,7 @@ class SensorPublisherOdometry {
             key, nh.advertise<nav_msgs::Odometry>(topic_name, 1)));
 
         std::unique_ptr<nav_msgs::Odometry> message(new nav_msgs::Odometry());
-        message->header.frame_id = RigidBodyTree::kWorldLinkName;
+        message->header.frame_id = RigidBodyTree::kWorldName;
         message->child_frame_id = rigid_body->get_name();
 
         odometry_messages_.insert(
@@ -203,7 +203,7 @@ class SensorPublisherOdometry {
           cache, rigid_body_tree->FindBodyIndex(
               rigid_body->get_parent()->get_name()),
           rigid_body_tree->FindBodyIndex(rigid_body->get_name()),
-          rigid_body_tree->FindBodyIndex(RigidBodyTree::kWorldLinkName));
+          rigid_body_tree->FindBodyIndex(RigidBodyTree::kWorldName));
 
       message->twist.twist.linear.x = twist(0);
       message->twist.twist.linear.y = twist(1);


### PR DESCRIPTION
# Motivation

1. We are no longer calling rigid bodies "links".

2. The fact that the world is represented by a `RigidBody` should not be relevant to external users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3078)
<!-- Reviewable:end -->
