### PR TITLE
Trajectory optimization input/state constraints

### DIFF
--- a/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.cc
+++ b/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.cc
@@ -112,6 +112,32 @@ std::vector<double> DirectTrajectoryOptimization::GetTimeVector() const {
   return times;
 }
 
+std::vector<Eigen::MatrixXd>
+DirectTrajectoryOptimization::GetInputVector() const {
+  std::vector<Eigen::MatrixXd> inputs;
+  inputs.reserve(N_);
+
+  const auto u_values = u_vars_.value();
+
+  for (int i = 0; i < N_; i++) {
+    inputs.push_back(u_values.segment(i * num_inputs_, num_inputs_));
+  }
+  return inputs;
+}
+
+std::vector<Eigen::MatrixXd>
+DirectTrajectoryOptimization::GetStateVector() const {
+  std::vector<Eigen::MatrixXd> states;
+  states.reserve(N_);
+
+  const auto x_values = x_vars_.value();
+
+  for (int i = 0; i < N_; i++) {
+    states.push_back(x_values.segment(i * num_states_, num_states_));
+  }
+  return states;
+}
+
 void DirectTrajectoryOptimization::GetResultSamples(
     Eigen::MatrixXd* inputs, Eigen::MatrixXd* states,
     std::vector<double>* times_out) const {
@@ -135,30 +161,14 @@ void DirectTrajectoryOptimization::GetResultSamples(
 
 PiecewisePolynomial<double>
 DirectTrajectoryOptimization::ReconstructInputTrajectory() const {
-  std::vector<Eigen::MatrixXd> inputs;
-  inputs.reserve(N_);
-
-  const auto u_values = u_vars_.value();
-
-  for (int i = 0; i < N_; i++) {
-    inputs.push_back(u_values.segment(i * num_inputs_, num_inputs_));
-  }
-
-  return PiecewisePolynomial<double>::FirstOrderHold(GetTimeVector(), inputs);
+  return PiecewisePolynomial<double>::FirstOrderHold(
+      GetTimeVector(), GetInputVector());
 }
 
 PiecewisePolynomial<double>
 DirectTrajectoryOptimization::ReconstructStateTrajectory() const {
-  std::vector<Eigen::MatrixXd> states;
-  states.reserve(N_);
-
-  const auto x_values = x_vars_.value();
-
-  for (int i = 0; i < N_; i++) {
-    states.push_back(x_values.segment(i * num_states_, num_states_));
-  }
-
-  return PiecewisePolynomial<double>::FirstOrderHold(GetTimeVector(), states);
+  return PiecewisePolynomial<double>::FirstOrderHold(
+      GetTimeVector(), GetStateVector());
 }
 
 }  // solvers

--- a/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.cc
+++ b/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.cc
@@ -63,10 +63,10 @@ DirectTrajectoryOptimization::DirectTrajectoryOptimization(
 }
 
 void DirectTrajectoryOptimization::GetInitialVars(
-    double t_init_in, const PiecewisePolynomial<double>& traj_init_u,
+    double timespan_init_in, const PiecewisePolynomial<double>& traj_init_u,
     const PiecewisePolynomial<double>& traj_init_x) {
-  VectorXd t_init{VectorXd::LinSpaced(N_, 0, t_init_in)};
-  opt_problem_.SetInitialGuess(h_vars_, VectorDiff(t_init));
+  VectorXd timespan_init{VectorXd::LinSpaced(N_, 0, timespan_init_in)};
+  opt_problem_.SetInitialGuess(h_vars_, VectorDiff(timespan_init));
 
   VectorXd guess_u(u_vars_.size());
   if (traj_init_u.empty()) {
@@ -74,7 +74,7 @@ void DirectTrajectoryOptimization::GetInitialVars(
   } else {
     for (int t = 0; t < N_; ++t) {
       guess_u.segment(num_inputs_ * t, num_inputs_) =
-          traj_init_u.value(t_init[t]);
+          traj_init_u.value(timespan_init[t]);
     }
   }
   opt_problem_.SetInitialGuess(u_vars_, guess_u);
@@ -87,16 +87,16 @@ void DirectTrajectoryOptimization::GetInitialVars(
   } else {
     for (int t = 0; t < N_; ++t) {
       guess_x.segment(num_states_ * t, num_states_) =
-          traj_init_x.value(t_init[t]);
+          traj_init_x.value(timespan_init[t]);
     }
   }
   opt_problem_.SetInitialGuess(x_vars_, guess_x);
 }
 
 SolutionResult DirectTrajectoryOptimization::SolveTraj(
-    double t_init, const PiecewisePolynomial<double>& traj_init_u,
+    double timespan_init, const PiecewisePolynomial<double>& traj_init_u,
     const PiecewisePolynomial<double>& traj_init_x) {
-  GetInitialVars(t_init, traj_init_u, traj_init_x);
+  GetInitialVars(timespan_init, traj_init_u, traj_init_x);
   SolutionResult result = opt_problem_.Solve();
   return result;
 }

--- a/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
+++ b/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
@@ -17,7 +17,7 @@ namespace solvers {
  * to trajectory optimization.
  *
  * This class assumes that there are a fixed number (N) time steps/samples, and
- * that the trajectory is discreteized into timesteps h (N-1 of these), state x
+ * that the trajectory is discretized into timesteps h (N-1 of these), state x
  * (N of these), and control input u (N of these).
  *
  * To maintain nominal sparsity in the optimization programs, this
@@ -29,6 +29,8 @@ namespace solvers {
 class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
  public:
   /**
+   * Constructor.
+   *
    * @param trajectory_time_lower_bound Bound on total time for
    *        trajectory.
    * @param trajectory_time_upper_bound Bound on total time for
@@ -79,7 +81,8 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
   /**
    * Solve the nonlinear program and return the resulting trajectory.
    *
-   * @param t_init The final time of the solution.
+   * @param timespan_init The initial guess for the timespan of
+   * the resulting trajectory.
    *
    * @param traj_init_u Initial guess for trajectory for control
    * input. The number of rows for each segment in @p traj_init_u must
@@ -89,10 +92,10 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
    * input. The number of rows for each segment in @p traj_init_x must
    * be equal to num_states (the second param of the constructor).
    */
-  SolutionResult SolveTraj(double t_init,
+  SolutionResult SolveTraj(double timespan_init,
                            const PiecewisePolynomial<double>& traj_init_u,
                            const PiecewisePolynomial<double>& traj_init_x);
-  // TODO(Lucy-tri) If t_init has any relationship to
+  // TODO(Lucy-tri) If timespan_init has any relationship to
   // trajectory_time_{lower,upper}_bound, then add doc and asserts.
 
   // Disable copy and assign.
@@ -122,17 +125,17 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
 
  protected:
   /**
-   * @return a vector containing the elapsed time at each knot point.
+   * Returns a vector containing the elapsed time at each knot point.
    */
   std::vector<double> GetTimeVector() const;
 
   /**
-   * @return a vector containing the input values at each knot point.
+   * Returns a vector containing the input values at each knot point.
    */
   std::vector<Eigen::MatrixXd> GetInputVector() const;
 
   /**
-   * @return a vector containing the state values at each knot point.
+   * Returns a vector containing the state values at each knot point.
    */
   std::vector<Eigen::MatrixXd> GetStateVector() const;
 
@@ -141,7 +144,7 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
    * Evaluate the initial trajectories at the sampled times and construct the
    * nominal initial vectors.
    *
-   * @param t_init The final time of the solution.
+   * @param timespan_init The final time of the solution.
    *
    * @param traj_init_u Initial guess for trajectory for control
    * input. The number of rows for each segment in @p traj_init_u must
@@ -151,7 +154,7 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
    * input. The number of rows for each segment in @p traj_init_x must
    * be equal to num_states (the second param of the constructor).
    */
-  void GetInitialVars(double t_init_in,
+  void GetInitialVars(double timespan_init_in,
                       const PiecewisePolynomial<double>& traj_init_u,
                       const PiecewisePolynomial<double>& traj_init_x);
 

--- a/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
+++ b/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
@@ -29,8 +29,14 @@ namespace solvers {
 class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
  public:
   /**
-   * Constructor.
+   * Construct a DirectTrajectoryOptimization object.  The dimensions
+   * of the trajectory are established at construction, though other
+   * parameters (costs, bounds, constraints, etc) can be set before
+   * calling SolveTraj.
    *
+   * @param num_inputs Number of inputs at each sample point.
+   * @param num_states Number of states at each sample point.
+   * @param num_time_samples Number of time samples.
    * @param trajectory_time_lower_bound Bound on total time for
    *        trajectory.
    * @param trajectory_time_upper_bound Bound on total time for

--- a/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
+++ b/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
@@ -44,8 +44,9 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
    * Add a constraint on the input at the specified time indices.
    *
    * @param constraint The constraint to be applied.
-   * @param time_indices The (0 offset) time indices to apply the
-   *        constraint.
+   *
+   * @param time_indices Apply the constraints only at these time
+   * indices (zero offset).
    */
   template <typename ConstraintT>
   void AddInputConstraint(std::shared_ptr<ConstraintT> constraint,
@@ -61,8 +62,9 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
    * Add a constraint on the state at the specified time indices.
    *
    * @param constraint The constraint to be applied.
-   * @param time_indices The (0 offset) time indices to apply the
-   *        constraint.
+   *
+   * @param time_indices Apply the constraints only at these time
+   * indices (zero offset).
    */
   template <typename ConstraintT>
   void AddStateConstraint(std::shared_ptr<ConstraintT> constraint,
@@ -104,8 +106,6 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
    * per column, and the number of columns is equal to the number of
    * time samples.  @p times will be populated with the times
    * corresponding to each column.
-   *
-   * @param[out] inputs
    */
   void GetResultSamples(Eigen::MatrixXd* inputs, Eigen::MatrixXd* states,
                         std::vector<double>* times) const;

--- a/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
+++ b/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <vector>
+
 #include <Eigen/Core>
 
+#include "drake/common/drake_assert.h"
 #include "drake/drakeTrajectoryOptimization_export.h"
 #include "drake/solvers/optimization.h"
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
@@ -26,8 +29,10 @@ namespace solvers {
 class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
  public:
   /**
-   * @p trajectory_time_lower_bound Bound on total time for trajectory.
-   * @p trajectory_time_upper_bound Bound on total time for trajectory.
+   * @param trajectory_time_lower_bound Bound on total time for
+   *        trajectory.
+   * @param trajectory_time_upper_bound Bound on total time for
+   *        trajectory.
    */
   DirectTrajectoryOptimization(int num_inputs, int num_states,
                                int num_time_samples,
@@ -36,17 +41,51 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
   // TODO(Lucy-tri) add param: time steps constant or independent.
 
   /**
+   * Add a constraint on the input at the specified time indices.
+   *
+   * @param constraint The constraint to be applied.
+   * @param time_indices The (0 offset) time indices to apply the
+   *        constraint.
+   */
+  template <typename ConstraintT>
+  void AddInputConstraint(std::shared_ptr<ConstraintT> constraint,
+                          const std::vector<int>& time_indices) {
+    for (const int i : time_indices) {
+      DRAKE_ASSERT(i < N_);
+      opt_problem_.AddConstraint(
+          constraint, {u_vars_.segment(i * num_inputs_, num_inputs_)});
+    }
+  }
+
+  /**
+   * Add a constraint on the state at the specified time indices.
+   *
+   * @param constraint The constraint to be applied.
+   * @param time_indices The (0 offset) time indices to apply the
+   *        constraint.
+   */
+  template <typename ConstraintT>
+  void AddStateConstraint(std::shared_ptr<ConstraintT> constraint,
+                          const std::vector<int>& time_indices) {
+    for (const int i : time_indices) {
+      DRAKE_ASSERT(i < N_);
+      opt_problem_.AddConstraint(
+          constraint, {x_vars_.segment(i * num_states_, num_states_)});
+    }
+  }
+
+  /**
    * Solve the nonlinear program and return the resulting trajectory.
    *
-   * @p t_init The final time of the solution.
+   * @param t_init The final time of the solution.
    *
-   * @p traj_init_u Initial guess for trajectory for control input. The number
-   * of rows for each segment in @p traj_init_u must be equal to num_inputs
-   * (the first param of the constructor).
+   * @param traj_init_u Initial guess for trajectory for control
+   * input. The number of rows for each segment in @p traj_init_u must
+   * be equal to num_inputs (the first param of the constructor).
    *
-   * @p traj_init_x Initial guess for trajectory for state input. The number
-   * of rows for each segment in @p traj_init_x must be equal to num_states
-   * (the second param of the constructor).
+   * @param traj_init_x Initial guess for trajectory for state
+   * input. The number of rows for each segment in @p traj_init_x must
+   * be equal to num_states (the second param of the constructor).
    */
   SolutionResult SolveTraj(double t_init,
                            const PiecewisePolynomial<double>& traj_init_u,
@@ -59,31 +98,56 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
   DirectTrajectoryOptimization& operator=(const DirectTrajectoryOptimization&) =
       delete;
 
+  /**
+   * Extract the result of the trajectory solution as a set of
+   * discrete samples.  Output matrices contain one set of input/state
+   * per column, and the number of columns is equal to the number of
+   * time samples.  @p times will be populated with the times
+   * corresponding to each column.
+   *
+   * @param[out] inputs
+   */
+  void GetResultSamples(Eigen::MatrixXd* inputs, Eigen::MatrixXd* states,
+                        std::vector<double>* times) const;
+
+  /**
+   * Get the input trajectory as a PiecewisePolynomial
+   */
+  PiecewisePolynomial<double> ReconstructInputTrajectory() const;
+
+  /**
+   * Get the state trajectory as a PiecewisePolynomial
+   */
+  PiecewisePolynomial<double> ReconstructStateTrajectory() const;
+
  private:
   /**
    * Evaluate the initial trajectories at the sampled times and construct the
    * nominal initial vectors.
    *
-   * @p t_init The final time of the solution.
+   * @param t_init The final time of the solution.
    *
-   * @p traj_init_u Initial guess for trajectory for control input. The number
-   * of rows for each segment in @p traj_init_u must be equal to num_inputs
-   * (the first param of the constructor).
+   * @param traj_init_u Initial guess for trajectory for control
+   * input. The number of rows for each segment in @p traj_init_u must
+   * be equal to num_inputs (the first param of the constructor).
    *
-   * @p traj_init_x Initial guess for trajectory for state input. The number
-   * of rows for each segment in @p traj_init_x must be equal to num_states
-   * (the second param of the constructor).
+   * @param traj_init_x Initial guess for trajectory for state
+   * input. The number of rows for each segment in @p traj_init_x must
+   * be equal to num_states (the second param of the constructor).
    */
   void GetInitialVars(double t_init_in,
                       const PiecewisePolynomial<double>& traj_init_u,
                       const PiecewisePolynomial<double>& traj_init_x);
+
+  std::vector<double> GetTimeVector() const;
 
   const int num_inputs_;
   const int num_states_;
   const int N_;  // Number of time samples
 
   OptimizationProblem opt_problem_;
-  DecisionVariableView h_vars_;
+  DecisionVariableView h_vars_;  // Time deltas between each
+                                 // input/state sample.
   DecisionVariableView u_vars_;
   DecisionVariableView x_vars_;
 };

--- a/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
+++ b/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h
@@ -120,6 +120,22 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
    */
   PiecewisePolynomial<double> ReconstructStateTrajectory() const;
 
+ protected:
+  /**
+   * @return a vector containing the elapsed time at each knot point.
+   */
+  std::vector<double> GetTimeVector() const;
+
+  /**
+   * @return a vector containing the input values at each knot point.
+   */
+  std::vector<Eigen::MatrixXd> GetInputVector() const;
+
+  /**
+   * @return a vector containing the state values at each knot point.
+   */
+  std::vector<Eigen::MatrixXd> GetStateVector() const;
+
  private:
   /**
    * Evaluate the initial trajectories at the sampled times and construct the
@@ -138,8 +154,6 @@ class DRAKETRAJECTORYOPTIMIZATION_EXPORT DirectTrajectoryOptimization {
   void GetInitialVars(double t_init_in,
                       const PiecewisePolynomial<double>& traj_init_u,
                       const PiecewisePolynomial<double>& traj_init_x);
-
-  std::vector<double> GetTimeVector() const;
 
   const int num_inputs_;
   const int num_states_;

--- a/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
+++ b/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
@@ -5,7 +5,6 @@
 #include "drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h"
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
 #include "drake/systems/vector.h"
-
 #include "drake/util/eigen_matrix_compare.h"
 
 using std::vector;

--- a/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
+++ b/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
@@ -1,13 +1,18 @@
-#include <random>
+
 #include <vector>
 
 #include "gtest/gtest.h"
 #include "drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h"
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
+#include "drake/systems/vector.h"
+
+#include "drake/util/eigen_matrix_compare.h"
 
 using std::vector;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
+
+using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace solvers {
@@ -37,10 +42,60 @@ GTEST_TEST(TrajectoryOptimizationTest, DirectTrajectoryOptimizationTest) {
   const PiecewisePolynomialType inputs_u(u_vec, times);
   const PiecewisePolynomialType states_x(y_vec, times);
 
+  const Vector1d constrained_input(30);
+  auto input_constraint = std::make_shared<LinearEqualityConstraint>(
+      Vector1d(1), constrained_input);
+  direct_traj.AddInputConstraint(input_constraint,
+                                 {1, kNumTimeSamples - 2});
+
+  const Eigen::Vector2d constrained_state(11, 22);
+  auto state_constraint = std::make_shared<LinearEqualityConstraint>(
+      Eigen::Matrix2d::Identity(), constrained_state);
+  direct_traj.AddStateConstraint(state_constraint,
+                                 {0, kNumTimeSamples - 1});
+
   SolutionResult result = SolutionResult::kUnknownError;
   result =
       direct_traj.SolveTraj(t_init_in, PiecewisePolynomialType(), states_x);
   EXPECT_EQ(result, SolutionResult::kSolutionFound) << "Result is an Error";
+
+  Eigen::MatrixXd inputs;
+  Eigen::MatrixXd states;
+  std::vector<double> times_out;
+
+  direct_traj.GetResultSamples(&inputs, &states, &times_out);
+  PiecewisePolynomial<double> input_traj =
+      direct_traj.ReconstructInputTrajectory();
+
+  EXPECT_TRUE(
+      CompareMatrices(constrained_input, inputs.col(1),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_input, input_traj.value(times_out[1]),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_input, inputs.col(kNumTimeSamples - 2),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_input,
+                      input_traj.value(times_out[kNumTimeSamples - 2]),
+                      1e-10, MatrixCompareType::absolute));
+
+  PiecewisePolynomial<double> state_traj =
+      direct_traj.ReconstructStateTrajectory();
+  EXPECT_TRUE(
+      CompareMatrices(constrained_state, states.col(0),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_state, state_traj.value(times_out[0]),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_state, states.col(kNumTimeSamples - 1),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_state,
+                      state_traj.value(times_out[kNumTimeSamples - 1]),
+                      1e-10, MatrixCompareType::absolute));
 
   result = direct_traj.SolveTraj(t_init_in, inputs_u, states_x);
   EXPECT_EQ(result, SolutionResult::kSolutionFound) << "Result is an Error";

--- a/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
+++ b/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
@@ -42,17 +42,21 @@ GTEST_TEST(TrajectoryOptimizationTest, DirectTrajectoryOptimizationTest) {
   const PiecewisePolynomialType inputs_u(u_vec, times);
   const PiecewisePolynomialType states_x(y_vec, times);
 
+  const int kInputConstraintLo = 1;
+  const int kInputConstraintHi = kNumTimeSamples - 2;
   const Vector1d constrained_input(30);
   auto input_constraint = std::make_shared<LinearEqualityConstraint>(
       Vector1d(1), constrained_input);
   direct_traj.AddInputConstraint(input_constraint,
-                                 {1, kNumTimeSamples - 2});
+                                 {kInputConstraintLo, kInputConstraintHi});
 
+  const int kStateConstraintLo = 1;
+  const int kStateConstraintHi = kNumTimeSamples - 1;
   const Eigen::Vector2d constrained_state(11, 22);
   auto state_constraint = std::make_shared<LinearEqualityConstraint>(
       Eigen::Matrix2d::Identity(), constrained_state);
   direct_traj.AddStateConstraint(state_constraint,
-                                 {0, kNumTimeSamples - 1});
+                                 {kStateConstraintLo, kStateConstraintHi});
 
   SolutionResult result = SolutionResult::kUnknownError;
   result =
@@ -68,33 +72,35 @@ GTEST_TEST(TrajectoryOptimizationTest, DirectTrajectoryOptimizationTest) {
       direct_traj.ReconstructInputTrajectory();
 
   EXPECT_TRUE(
-      CompareMatrices(constrained_input, inputs.col(1),
-                      1e-10, MatrixCompareType::absolute));
-  EXPECT_TRUE(
-      CompareMatrices(constrained_input, input_traj.value(times_out[1]),
-                      1e-10, MatrixCompareType::absolute));
-  EXPECT_TRUE(
-      CompareMatrices(constrained_input, inputs.col(kNumTimeSamples - 2),
+      CompareMatrices(constrained_input, inputs.col(kInputConstraintLo),
                       1e-10, MatrixCompareType::absolute));
   EXPECT_TRUE(
       CompareMatrices(constrained_input,
-                      input_traj.value(times_out[kNumTimeSamples - 2]),
+                      input_traj.value(times_out[kInputConstraintLo]),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_input, inputs.col(kInputConstraintHi),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_input,
+                      input_traj.value(times_out[kInputConstraintHi]),
                       1e-10, MatrixCompareType::absolute));
 
   PiecewisePolynomial<double> state_traj =
       direct_traj.ReconstructStateTrajectory();
   EXPECT_TRUE(
-      CompareMatrices(constrained_state, states.col(0),
-                      1e-10, MatrixCompareType::absolute));
-  EXPECT_TRUE(
-      CompareMatrices(constrained_state, state_traj.value(times_out[0]),
-                      1e-10, MatrixCompareType::absolute));
-  EXPECT_TRUE(
-      CompareMatrices(constrained_state, states.col(kNumTimeSamples - 1),
+      CompareMatrices(constrained_state, states.col(kStateConstraintLo),
                       1e-10, MatrixCompareType::absolute));
   EXPECT_TRUE(
       CompareMatrices(constrained_state,
-                      state_traj.value(times_out[kNumTimeSamples - 1]),
+                      state_traj.value(times_out[kStateConstraintLo]),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_state, states.col(kStateConstraintHi),
+                      1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(constrained_state,
+                      state_traj.value(times_out[kStateConstraintHi]),
                       1e-10, MatrixCompareType::absolute));
 
   result = direct_traj.SolveTraj(t_init_in, inputs_u, states_x);

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -731,27 +731,6 @@ void QPLocomotionPlan::findPlannedSupportFraction(
   // std::endl;
 }
 
-PiecewisePolynomial<double> firstOrderHold(
-    const std::vector<double>& segment_times,
-    const std::vector<Matrix<double, Dynamic, Dynamic>>& knots) {
-  std::vector<PiecewisePolynomial<double>::PolynomialMatrix> polys;
-  polys.reserve(segment_times.size() - 1);
-  for (int i = 0; i < static_cast<int>(segment_times.size()) - 1; ++i) {
-    Matrix<Polynomial<double>, Dynamic, Dynamic> poly_matrix(knots[0].rows(),
-                                                             knots[0].cols());
-    for (int j = 0; j < knots[i].rows(); ++j) {
-      for (int k = 0; k < knots[i].cols(); ++k) {
-        poly_matrix(j, k) = Polynomial<double>(
-            Vector2d(
-                knots[i](j, k), (knots[i + 1](j, k) - knots[i](j, k)) /
-                (segment_times[i + 1] - segment_times[i])));
-      }
-    }
-    polys.push_back(poly_matrix);
-  }
-  return PiecewisePolynomial<double>(polys, segment_times);
-}
-
 void QPLocomotionPlan::updateS1Trajectory() {
   ExponentialPlusPiecewisePolynomial<double> s1 = s1Trajectory(
       settings_.zmp_data, shifted_zmp_trajectory_, settings_.V.getS());
@@ -799,7 +778,8 @@ void QPLocomotionPlan::updateZMPTrajectory(const double t_plan,
     }
   }
 
-  shifted_zmp_trajectory_ = firstOrderHold(segment_times, zmp_knots);
+  shifted_zmp_trajectory_ =
+      PiecewisePolynomial<double>::FirstOrderHold(segment_times, zmp_knots);
 }
 
 void QPLocomotionPlan::updateZMPController(const double t_plan,

--- a/drake/systems/trajectories/PiecewisePolynomial.h
+++ b/drake/systems/trajectories/PiecewisePolynomial.h
@@ -71,6 +71,31 @@ class DRAKETRAJECTORIES_EXPORT PiecewisePolynomial
   PiecewisePolynomial(std::vector<PolynomialType> const& polynomials,
                       std::vector<double> const& segment_times);
 
+  /**
+   * Construct a PiecewisePolynomial using a first order hold from a
+   * series of knot points.
+   */
+  static PiecewisePolynomial<CoefficientType> FirstOrderHold(
+      const std::vector<double>& segment_times,
+      const std::vector<CoefficientMatrix>& knots) {
+  std::vector<PolynomialMatrix> polys;
+  polys.reserve(segment_times.size() - 1);
+  for (int i = 0; i < static_cast<int>(segment_times.size()) - 1; ++i) {
+    PolynomialMatrix poly_matrix(knots[0].rows(), knots[0].cols());
+
+    for (int j = 0; j < knots[i].rows(); ++j) {
+      for (int k = 0; k < knots[i].cols(); ++k) {
+        poly_matrix(j, k) = PolynomialType(
+            Eigen::Matrix<CoefficientType, 2, 1>(
+                knots[i](j, k), (knots[i + 1](j, k) - knots[i](j, k)) /
+                (segment_times[i + 1] - segment_times[i])));
+      }
+    }
+    polys.push_back(poly_matrix);
+  }
+  return PiecewisePolynomial<double>(polys, segment_times);
+}
+
   /// Takes the derivative of this PiecewisePolynomial.
   /**
    * Returns a PiecewisePolynomial where each segment is the derivative of the

--- a/drake/systems/trajectories/PiecewisePolynomial.h
+++ b/drake/systems/trajectories/PiecewisePolynomial.h
@@ -93,7 +93,7 @@ class DRAKETRAJECTORIES_EXPORT PiecewisePolynomial
     }
     polys.push_back(poly_matrix);
   }
-  return PiecewisePolynomial<double>(polys, segment_times);
+  return PiecewisePolynomial<CoefficientType>(polys, segment_times);
 }
 
   /// Takes the derivative of this PiecewisePolynomial.


### PR DESCRIPTION
Moves the (quite generic looking) FirstOrderHold method out of QPLocomotionPlan and into PiecewisePolynomial as a factory method.

Adds input/state constraints to trajectory optimization and the ability to extract the resulting (constrained) trajectory as a series of knots or as a PiecewisePolynomial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3082)
<!-- Reviewable:end -->
