### PR TITLE
Have cmake_minimum_required before project

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(drake)
 cmake_minimum_required(VERSION 3.5)
+project(drake)
 
 cmake_policy(SET CMP0025 NEW)
 cmake_policy(SET CMP0042 NEW)


### PR DESCRIPTION
I had a strange behavior using non-Apple clang (clang-3.8.1) on
OSX. Symptom: it doesn't respect `CMAKE_CXX_STANDARD=14` and
doesn't pass compiler flag `-std=c++14`.

I looked at an old CMake issue tracker[1] and found that an easy fix is
to put "cmake_minimum_required" first before adding "project". I checked
that this solved my problem. There is also a suggested CMake policy[2],
which can justify this change.

[1]: https://cmake.org/Bug/view.php?id=15943
[2]: https://gitlab.kitware.com/cmake/cmake/issues/15544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3085)
<!-- Reviewable:end -->
