### PR TITLE
Use pair<'const' Key, Value> in defining MaterialMap type

### DIFF
--- a/drake/systems/plants/material_map.h
+++ b/drake/systems/plants/material_map.h
@@ -6,4 +6,4 @@
 
 typedef std::map<std::string, Eigen::Vector4d, std::less<std::string>,
                  Eigen::aligned_allocator<
-                     std::pair<std::string, Eigen::Vector4d> > > MaterialMap;
+                     std::pair<const std::string, Eigen::Vector4d> > > MaterialMap;


### PR DESCRIPTION
Custom allocator to std::map should have std::pair<const Key, Value>
instead of pair<Key, Value>. libc++-3.8.0 actually started checking this
condition by adding static_assert. Without this patch, users (using
libc++>=3.8) see something like the following compiler error message:

/usr/local/Cellar/llvm/3.8.1/bin/../include/c++/v1/map:837:5: error: static_assert failed "Allocator::value_type must be same type as value_type"
    static_assert((is_same<typename allocator_type::value_type, value_type>::value),
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<PATH_TO_DRAKE>/drake/systems/plants/parser_urdf.cc:155:33: note: in instantiation of template class 'std::__1::map<std::__1::basic_string<char>, Eigen::Matrix<double, 4, 1, 0, 4, 1>, std::__1::less<std::__1::basic_string<char> >, Eigen::aligned_allocator<std::__1::pair<std::__1::basic_string<char>, Eigen::Matrix<double, 4, 1, 0, 4, 1> > > >' requested here
  auto material_iter = materials->find(material_name);