### PR TITLE
Tweak logic deciding if an external is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,5 +297,7 @@ if(WITH_SNOPT_PRECOMPILED)
       ${PROJECT_SOURCE_DIR}/drake/solvers/
     INSTALL_COMMAND "")
   add_dependencies(download-all download-snopt-precompiled)
-  add_dependencies(drake download-snopt-precompiled) # just in case: make sure any compiled drake version happens after precompiled install
+  if(TARGET drake)
+    add_dependencies(drake download-snopt-precompiled) # just in case: make sure any compiled drake version happens after precompiled install
+  endif()
 endif()

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -281,9 +281,7 @@ function(drake_add_external PROJECT)
 
   # Determine if this project is enabled
   string(TOUPPER WITH_${PROJECT} _ext_project_option)
-  if(_ext_ALWAYS)
-    # Project is always enabled
-  elseif(DEFINED ${_ext_project_option})
+  if(DEFINED ${_ext_project_option})
     if(${_ext_project_option})
       # Project is explicitly enabled
     elseif(WITH_ALL_PUBLIC_EXTERNALS AND DEFINED _ext_PUBLIC)
@@ -294,6 +292,8 @@ function(drake_add_external PROJECT)
       # Project is NOT enabled; skip it
       return()
     endif()
+  elseif(_ext_ALWAYS)
+    # Project is "always" enabled (unless overridden)
   else()
     # Project is not supported on this platform; skip it
     return()


### PR DESCRIPTION
Tweak the logic that decides whether or not an external project is enabled to check `WITH_<name>` before checking if the project is `ALWAYS` built. This allows users with special needs (the CI, in particular) to override `ALWAYS`.

Specifically, this allows the CI scripts to turn off the `drake` and `cmake` projects in the cpplint build, so that the only thing the build does is download `google_styleguide`.

@jamiesnape for feature review, @david-german-tri for platform review.

Note that this is "blocking" #3065. (Specifically, it is blocking setting up the CI cpplint build to use the cpplint that the superbuild provides, and #3065 needs a cpplint update.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3106)
<!-- Reviewable:end -->
