### PR TITLE
Throw possible fixes at MATLAB+Gurobi segfault.

### DIFF
--- a/drake/examples/Atlas/CMakeLists.txt
+++ b/drake/examples/Atlas/CMakeLists.txt
@@ -32,8 +32,11 @@ add_matlab_test(NAME examples/Atlas/runCOMFixedPointSearch COMMAND runCOMFixedPo
 add_matlab_test(NAME examples/Atlas/runRobotiqPDControl COMMAND runRobotiqPDControl)
 
 if(LONG_RUNNING_TESTS)
-  add_matlab_test(NAME examples/Atlas/runAtlasBalancingPerturb COMMAND runAtlasBalancingPerturb PROPERTIES TIMEOUT 1500 REQUIRES gurobi)
-  add_matlab_test(NAME examples/Atlas/runAtlasManip COMMAND runAtlasManip PROPERTIES TIMEOUT 1500 REQUIRES gurobi)
+
+  if (${CMAKE_BUILD_TYPE} EQUAL "Release" AND NOT APPLE) # FIXME: see #3147.
+    add_matlab_test(NAME examples/Atlas/runAtlasBalancingPerturb COMMAND runAtlasBalancingPerturb PROPERTIES TIMEOUT 1500 REQUIRES gurobi)
+    add_matlab_test(NAME examples/Atlas/runAtlasManip COMMAND runAtlasManip PROPERTIES TIMEOUT 1500 REQUIRES gurobi)
+  endif()
 
   # Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
   # add_matlab_test(NAME examples/Atlas/runAtlasWalking COMMAND runAtlasWalking PROPERTIES TIMEOUT 1500 REQUIRES gurobi)

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -1,6 +1,10 @@
 if(LONG_RUNNING_TESTS)
   # add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancing COMMAND runValkyrieBalancing PROPERTIES TIMEOUT 1500)  # FIXME: see #2839
-  add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancingPerturb COMMAND runValkyrieBalancingPerturb PROPERTIES TIMEOUT 1500)
+
+  if (${CMAKE_BUILD_TYPE} EQUAL "Release" AND NOT APPLE) # FIXME: see #3147.
+    add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancingPerturb COMMAND runValkyrieBalancingPerturb PROPERTIES TIMEOUT 1500)
+  endif()
+
   # Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
   # add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking COMMAND runValkyrieWalking PROPERTIES TIMEOUT 1500)
 endif()


### PR DESCRIPTION
I actually don't even know if this compiles, because Gurobi something something, and I certainly don't expect it to fix anything.  However, if I'm lucky, it might generate some more illuminating errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3113)
<!-- Reviewable:end -->
