### PR TITLE
Tweak logic deciding if an external is enabled

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -279,11 +279,18 @@ function(drake_add_external PROJECT)
   cmake_parse_arguments(_ext
     "${_ext_flags}" "${_ext_sv_args}" "${_ext_mv_args}" ${ARGN})
 
-  # Determine if this project is enabled
   string(TOUPPER WITH_${PROJECT} _ext_project_option)
   if(_ext_ALWAYS)
-    # Project is always enabled
-  elseif(DEFINED ${_ext_project_option})
+    # Project is "always" enabled, but add a hidden option to turn it off; this
+    # is useful for the CI to "build" just google_styleguide in order to run
+    # cpplint on the code.
+    cmake_dependent_option(
+      ${_ext_project_option} "Enable ${PROJECT} (internal)" ON
+      "NOT ${_ext_project_option}" ON)
+  endif()
+
+  # Determine if this project is enabled
+  if(DEFINED ${_ext_project_option})
     if(${_ext_project_option})
       # Project is explicitly enabled
     elseif(WITH_ALL_PUBLIC_EXTERNALS AND DEFINED _ext_PUBLIC)


### PR DESCRIPTION
Modify the logic that decides whether or not an external project is enabled to respond to externals marked `ALWAYS` by creating a hidden option (`ON` by default) to enable the external, rather than enabling it literally always. This allows users with special needs (e.g. the CI in particular) to have a hidden mechanism to disable such externals.

Note: `WITH_DRAKE=OFF` will result in an error unless also `WITH_SNOPT_PRECOMPILED=OFF`.

This is a competing approach as #3106, and is similarly relevant to #2539.

@jamiesnape for feature review, @david-german-tri for platform review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3124)
<!-- Reviewable:end -->
