### PR TITLE
Remove use of testUtil.h from polynomial_test

### DIFF
--- a/drake/common/test/polynomial_test.cc
+++ b/drake/common/test/polynomial_test.cc
@@ -1,14 +1,13 @@
 #include "drake/common/polynomial.h"
 
 #include <cstddef>
-#include <sstream>
 #include <map>
+#include <sstream>
 
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
 #include "drake/util/eigen_matrix_compare.h"
-#include "drake/util/testUtil.h"
 
 using drake::util::MatrixCompareType;
 using Eigen::VectorXd;
@@ -76,22 +75,26 @@ void testOperators() {
     poly1_times_poly1 *= poly1_times_poly1;
 
     double t = uniform(generator);
-    valuecheck(sum.EvaluateUnivariate(t),
-               poly1.EvaluateUnivariate(t) + poly2.EvaluateUnivariate(t), 1e-8);
-    valuecheck(difference.EvaluateUnivariate(t),
-               poly2.EvaluateUnivariate(t) - poly1.EvaluateUnivariate(t), 1e-8);
-    valuecheck(product.EvaluateUnivariate(t),
-               poly1.EvaluateUnivariate(t) * poly2.EvaluateUnivariate(t), 1e-8);
-    valuecheck(poly1_plus_scalar.EvaluateUnivariate(t),
-               poly1.EvaluateUnivariate(t) + scalar, 1e-8);
-    valuecheck(poly1_minus_scalar.EvaluateUnivariate(t),
-               poly1.EvaluateUnivariate(t) - scalar, 1e-8);
-    valuecheck(poly1_scaled.EvaluateUnivariate(t),
-               poly1.EvaluateUnivariate(t) * scalar, 1e-8);
-    valuecheck(poly1_div.EvaluateUnivariate(t),
-               poly1.EvaluateUnivariate(t) / scalar, 1e-8);
-    valuecheck(poly1_times_poly1.EvaluateUnivariate(t),
-               poly1.EvaluateUnivariate(t) * poly1.EvaluateUnivariate(t), 1e-8);
+    EXPECT_NEAR(sum.EvaluateUnivariate(t),
+                poly1.EvaluateUnivariate(t) + poly2.EvaluateUnivariate(t),
+                1e-8);
+    EXPECT_NEAR(difference.EvaluateUnivariate(t),
+                poly2.EvaluateUnivariate(t) - poly1.EvaluateUnivariate(t),
+                1e-8);
+    EXPECT_NEAR(product.EvaluateUnivariate(t),
+                poly1.EvaluateUnivariate(t) * poly2.EvaluateUnivariate(t),
+                1e-8);
+    EXPECT_NEAR(poly1_plus_scalar.EvaluateUnivariate(t),
+                poly1.EvaluateUnivariate(t) + scalar, 1e-8);
+    EXPECT_NEAR(poly1_minus_scalar.EvaluateUnivariate(t),
+                poly1.EvaluateUnivariate(t) - scalar, 1e-8);
+    EXPECT_NEAR(poly1_scaled.EvaluateUnivariate(t),
+                poly1.EvaluateUnivariate(t) * scalar, 1e-8);
+    EXPECT_NEAR(poly1_div.EvaluateUnivariate(t),
+                poly1.EvaluateUnivariate(t) / scalar, 1e-8);
+    EXPECT_NEAR(poly1_times_poly1.EvaluateUnivariate(t),
+                poly1.EvaluateUnivariate(t) * poly1.EvaluateUnivariate(t),
+                1e-8);
 
     // Check the '==' operator.
     EXPECT_TRUE(poly1 + poly2 == sum);
@@ -110,10 +113,10 @@ void testRoots() {
     VectorXd coeffs = VectorXd::Random(int_distribution(generator));
     Polynomial<CoefficientType> poly(coeffs);
     auto roots = poly.Roots();
-    valuecheck<Eigen::Index>(roots.rows(), poly.GetDegree());
+    EXPECT_EQ(roots.rows(), poly.GetDegree());
     for (int k = 0; k < roots.size(); k++) {
       auto value = poly.EvaluateUnivariate(roots[k]);
-      valuecheck(std::abs(value), 0.0, 1e-8);
+      EXPECT_NEAR(std::abs(value), 0.0, 1e-8);
     }
   }
 }
@@ -126,14 +129,11 @@ void testEvalType() {
   Polynomial<double> poly(coeffs);
 
   auto valueIntInput = poly.EvaluateUnivariate(1);
-  const auto& double_type = typeid(double);  // NOLINT(readability/function)
-  valuecheck(typeid(decltype(valueIntInput)) == double_type, true);
+  EXPECT_EQ(typeid(decltype(valueIntInput)), typeid(double));
 
   auto valueComplexInput =
       poly.EvaluateUnivariate(std::complex<double>(1.0, 2.0));
-  valuecheck(
-      typeid(decltype(valueComplexInput)) == typeid(std::complex<double>),
-      true);
+  EXPECT_EQ(typeid(decltype(valueComplexInput)), typeid(std::complex<double>));
 }
 
 template <typename CoefficientType>


### PR DESCRIPTION
Remove use of `util/testUtil.h` from `common/test/polynomial_test.cc`.  We should not let `common` depend on `util`; the lack of #1987 bites us again.  We also have to fix `CompareMatrices` but that will be a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3125)
<!-- Reviewable:end -->
