### PR TITLE
Adds simple_car-inl.h to the list of installed headers

### DIFF
--- a/drake/examples/Cars/CMakeLists.txt
+++ b/drake/examples/Cars/CMakeLists.txt
@@ -13,6 +13,7 @@ if(lcm_FOUND)
     curve2.h
     car_simulation.h
     simple_car.h
+    simple_car-inl.h
     trajectory_car.h)
   add_subdirectory(gen)
   pods_install_pkg_config_file(drake-cars


### PR DESCRIPTION
The discussion [here](https://reviewable.io/reviews/robotlocomotion/drake/3097#-) made me realize that for simple car we didn't add the `inl` header to the list of installed headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3134)
<!-- Reviewable:end -->
