### PR TITLE
Introduce System2 cache.

### DIFF
--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -88,12 +88,13 @@ double SpringMassSystem::EvalNonConservativePower(const MyContext&) const {
 // Reserve a context with no input, and a SpringMassStateVector state.
 std::unique_ptr<ContextBase<double>>
 SpringMassSystem::CreateDefaultContext() const {
-  std::unique_ptr<Context<double>> context(new Context<double>);
+  const int num_input_ports = system_is_forced_ ? 1 : 0;
+  std::unique_ptr<Context<double>> context(
+      new Context<double>(num_input_ports));
   std::unique_ptr<SpringMassStateVector> state(new SpringMassStateVector(0, 0));
   context->get_mutable_state()->continuous_state.reset(
       new ContinuousState<double>(std::move(state), 1 /* size of q */,
                                   1 /* size of v */, 1 /* size of z */));
-  if (system_is_forced_) context->SetNumInputPorts(1);
   return std::unique_ptr<ContextBase<double>>(context.release());
 }
 

--- a/drake/systems/framework/basic_state_vector.h
+++ b/drake/systems/framework/basic_state_vector.h
@@ -33,11 +33,7 @@ class BasicStateVector : public LeafStateVector<T> {
   /// Constructs a BasicStateVector that owns a generic BasicVector with the
   /// specified @p data.
   explicit BasicStateVector(const std::vector<T>& data)
-      : BasicStateVector(data.size()) {
-    for (size_t i = 0; i < data.size(); ++i) {
-      SetAtIndex(i, data[i]);
-    }
-  }
+      : BasicStateVector(std::make_unique<BasicVector<T>>(data)) {}
 
   /// Constructs a BasicStateVector that owns an arbitrary @p vector, which
   /// must not be nullptr.

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -27,6 +27,14 @@ class BasicVector : public VectorInterface<T> {
             size, std::numeric_limits<
                       typename Eigen::NumTraits<T>::Real>::quiet_NaN())) {}
 
+  /// Constructs a BasicVector with the specified @p data.
+  explicit BasicVector(const std::vector<T>& data)
+      : BasicVector(data.size()) {
+    for (size_t i = 0; i < data.size(); ++i) {
+      values_[i] = data[i];
+    }
+  }
+
   void set_value(const Eigen::Ref<const VectorX<T>>& value) override {
     if (value.rows() != values_.rows()) {
       throw std::out_of_range(

--- a/drake/systems/framework/cache.cc
+++ b/drake/systems/framework/cache.cc
@@ -1,4 +1,94 @@
-// For now, this is an empty .cc file that only serves to confirm
-// cache.h is a stand-alone header.
-
 #include "drake/systems/framework/cache.h"
+
+#include <memory>
+#include <limits>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace systems {
+
+namespace internal {
+
+CacheEntry::CacheEntry(const CacheEntry& other) {
+  *this = other;
+}
+
+CacheEntry& CacheEntry::operator=(const CacheEntry& other) {
+  is_valid_ = other.is_valid();
+  if (other.value() != nullptr) {
+    value_ = other.value()->Clone();
+  }
+  dependents_ = other.dependents();
+  return *this;
+}
+
+}  // namespace internal
+
+using internal::CacheEntry;
+
+Cache::Cache() {}
+
+Cache::~Cache() {}
+
+CacheTicket Cache::MakeCacheTicket(std::set<CacheTicket> prerequisites) {
+  // Create a new ticket.
+  CacheTicket ticket = static_cast<int>(store_.size());
+
+  // Add the ticket to the dependency map. Because prerequisites may not be
+  // added after the fact, the dependency map is guaranteed acyclic.
+  for (const CacheTicket& prerequisite : prerequisites) {
+    store_[prerequisite].add_dependent(ticket);
+  }
+
+  // Reserve a null, invalid CacheEntry for this ticket.
+  store_.emplace_back();
+  return ticket;
+}
+
+void Cache::Invalidate(CacheTicket ticket) {
+  const std::set<CacheTicket>& to_invalidate{ticket};
+  InvalidateRecursively(to_invalidate);
+}
+
+void Cache::InvalidateRecursively(const std::set<CacheTicket>& to_invalidate) {
+  for (CacheTicket ticket : to_invalidate) {
+    // Invalidate the ticket.
+    store_[ticket].set_is_valid(false);
+    // Visit all the tickets that depend on this one.
+    InvalidateRecursively(store_[ticket].dependents());
+  }
+}
+
+AbstractValue* Cache::Set(CacheTicket ticket,
+                          std::unique_ptr<AbstractValue> value) {
+  DRAKE_ABORT_UNLESS(ticket < static_cast<int>(store_.size()));
+  store_[ticket].set_is_valid(true);
+  store_[ticket].set_value(std::move(value));
+  return store_[ticket].value();
+}
+
+AbstractValue* Cache::Get(CacheTicket ticket) const {
+  DRAKE_ABORT_UNLESS(ticket < static_cast<int>(store_.size()));
+  if (store_[ticket].is_valid()) {
+    return store_[ticket].value();
+  } else {
+    return nullptr;
+  }
+}
+
+std::unique_ptr<AbstractValue> Cache::Swap(
+    CacheTicket ticket, std::unique_ptr<AbstractValue> value) {
+  std::unique_ptr<AbstractValue> old_value = store_[ticket].release_value();
+  Set(ticket, std::move(value));
+  return old_value;
+}
+
+std::unique_ptr<Cache> Cache::Clone() const {
+  auto clone = std::make_unique<Cache>();
+  clone->store_ = store_;
+  return clone;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/cache.h
+++ b/drake/systems/framework/cache.h
@@ -1,24 +1,96 @@
 #pragma once
 
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <set>
+#include <tuple>
+#include <vector>
+
+#include "drake/drakeSystemFramework_export.h"
+#include "drake/systems/framework/value.h"
+
 namespace drake {
 namespace systems {
 
-// This is a placeholder.
-// TODO(david-german-tri): Add actual functionality.
-template <typename T>
-class Cache {
- public:
-  Cache() {}
-  virtual ~Cache() {}
+typedef int CacheTicket;
 
-  // Cache objects are copyable with the default copy constructor.
-  Cache(const Cache& other) = default;
-  Cache& operator=(const Cache& other) = default;
+namespace internal {
+
+/// A single cached piece of data, its validity bit, and the set of other cache
+/// entries that depend on it.
+class CacheEntry {
+ public:
+  CacheEntry() {}
+  virtual ~CacheEntry() {}
+
+  // CacheEntry is copyable.
+  explicit CacheEntry(const CacheEntry& other);
+  CacheEntry& operator=(const CacheEntry& other);
+
+  bool is_valid() const { return is_valid_; }
+  void set_is_valid(bool valid) { is_valid_ = valid; }
+
+  AbstractValue* value() const { return value_.get(); }
+  void set_value(std::unique_ptr<AbstractValue> value) {
+    value_ = std::move(value);
+  }
+  std::unique_ptr<AbstractValue> release_value() {
+    set_is_valid(false);
+    return std::move(value_);
+  }
+
+  const std::set<CacheTicket>& dependents() const { return dependents_; }
+  void add_dependent(CacheTicket ticket) { dependents_.insert(ticket); }
 
  private:
-  // Cache objects are not moveable.
-  Cache(Cache&& other) = delete;
-  Cache& operator=(Cache&& other) = delete;
+  bool is_valid_{false};
+  std::unique_ptr<AbstractValue> value_;
+
+  // The set of cache tickets that are invalidated when the ticket corresponding
+  // to this entry is invalidated. This graph is directed and acyclic.
+  std::set<CacheTicket> dependents_;
+};
+
+}  // namespace internal
+
+/// A key-value cache that can be invalidated based on changes to fields in the
+/// Context.
+///
+/// The cache is not thread-safe.
+class DRAKESYSTEMFRAMEWORK_EXPORT Cache {
+ public:
+  Cache();
+  virtual ~Cache();
+
+  /// Creates a new cache ticket, which will be invalidated whenever any of
+  /// the dependencies are invalidated.
+  CacheTicket MakeCacheTicket(std::set<CacheTicket> prerequisites);
+
+  /// Invalidates and deletes the value for @p ticket, and all lines that
+  /// depend on it.
+  void Invalidate(CacheTicket ticket);
+
+  /// Takes ownership of a cached item, and returns a bare pointer to the item.
+  AbstractValue* Set(CacheTicket ticket, std::unique_ptr<AbstractValue> value);
+
+  /// Returns the cached item for the given ticket, or nullptr if the item
+  /// has been invalidated.
+  AbstractValue* Get(CacheTicket ticket) const;
+
+  /// Returns the cached item for the given ticket, or nullptr if the item
+  /// has been invalidated. Replaces it with @p value.
+  std::unique_ptr<AbstractValue> Swap(CacheTicket ticket,
+                                      std::unique_ptr<AbstractValue> value);
+
+  std::unique_ptr<Cache> Clone() const;
+
+ private:
+  // Invalidates all tickets that depend on the tickets in @p to_invalidate.
+  void InvalidateRecursively(const std::set<CacheTicket>& to_invalidate);
+
+  // For each cache ticket, the stored value, and its validity bit.
+  std::vector<internal::CacheEntry> store_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/context_base.h
+++ b/drake/systems/framework/context_base.h
@@ -35,6 +35,7 @@ class ContextBase {
 
   /// Set the current time in seconds.
   void set_time(const T& time_sec) {
+    InvalidateTime();
     get_mutable_step_info()->time_sec = time_sec;
   }
 
@@ -53,8 +54,8 @@ class ContextBase {
 
   virtual const State<T>& get_state() const = 0;
 
-  /// Returns writable access to the State. No cache invalidation occurs until
-  /// mutable access is requested for particular blocks of state variables.
+  /// Returns writable access to the State.
+  /// Implementations should invalidate all cache lines that depend on state.
   virtual State<T>* get_mutable_state() = 0;
 
   /// Returns a deep copy of this ContextBase. The clone's input ports will
@@ -63,6 +64,17 @@ class ContextBase {
   std::unique_ptr<ContextBase<T>> Clone() const {
     return std::unique_ptr<ContextBase<T>>(DoClone());
   }
+
+  /// Invalidates all cache lines that depend on the time.
+  virtual void InvalidateTime() = 0;
+
+  /// Invalidates all cache lines that depend on the state.
+  /// TODO(david-german-tri): Provide finer-grained invalidation on q, v, z,
+  ///                         xc, xd, and mode variables.
+  virtual void InvalidateState() = 0;
+
+  /// Invalidates all cache lines that depend on the input port @p index.
+  virtual void InvalidateInputPort(int index) = 0;
 
  protected:
   /// Contains the return-type-covariant implementation of Clone().

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -24,8 +24,8 @@ class LeafSystem : public System<T> {
   /// Returns a default context, initialized with the correct
   /// numbers of concrete input ports and state variables for this System.
   std::unique_ptr<ContextBase<T>> CreateDefaultContext() const override {
-    std::unique_ptr<Context<T>> context(new Context<T>);
-    ReserveInputs(context.get());
+    auto context = std::make_unique<Context<T>>(
+        this->get_input_ports().size());
     ReserveState(context.get());
     return std::unique_ptr<ContextBase<T>>(context.release());
   }
@@ -48,11 +48,6 @@ class LeafSystem : public System<T> {
   LeafSystem() {}
 
  private:
-  /// Reserves inputs that have already been declared.
-  void ReserveInputs(Context<T>* context) const {
-    context->SetNumInputPorts(this->get_input_ports().size());
-  }
-
   /// By default, allocates no state. Child classes that need state should
   /// override.
   virtual void ReserveState(Context<T>* context) const {}

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -15,6 +15,11 @@
 namespace drake {
 namespace systems {
 
+template <typename T>
+struct StateShape {
+  T continuous_state;
+};
+
 /// The ContinuousState is a container for all the State variables that are
 /// unique to continuous Systems, i.e. Systems that have defined dynamics at
 /// all times.
@@ -49,8 +54,8 @@ class ContinuousState {
   /// @param num_q The number of position variables.
   /// @param num_v The number of velocity variables.
   /// @param num_z The number of other variables.
-  ContinuousState(std::unique_ptr<StateVector<T>> state, int num_q,
-                  int num_v, int num_z) {
+  ContinuousState(std::unique_ptr<StateVector<T>> state, int num_q, int num_v,
+                  int num_z) {
     state_ = std::move(state);
     if (state_->size() != num_q + num_v + num_z) {
       throw std::out_of_range(

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -63,3 +63,8 @@ add_executable(diagram_context_test diagram_context_test.cc)
 target_link_libraries(diagram_context_test
                       drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
 add_test(NAME diagram_context_test COMMAND diagram_context_test)
+
+add_executable(cache_test cache_test.cc)
+target_link_libraries(cache_test
+                      drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
+add_test(NAME cache_test COMMAND cache_test)

--- a/drake/systems/framework/test/cache_test.cc
+++ b/drake/systems/framework/test/cache_test.cc
@@ -1,0 +1,105 @@
+#include "drake/systems/framework/cache.h"
+
+#include <memory>
+#include <stdexcept>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+class CacheTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ticket0_ = cache_.MakeCacheTicket({});
+    ticket1_ = cache_.MakeCacheTicket({ticket0_});
+    ticket2_ = cache_.MakeCacheTicket({ticket0_, ticket1_});
+
+    cache_.Set(ticket0_, PackValue(0));
+    cache_.Set(ticket1_, PackValue(1));
+    cache_.Set(ticket2_, PackValue(2));
+  }
+
+  std::unique_ptr<AbstractValue> PackValue(int value) {
+    return std::unique_ptr<AbstractValue>(new Value<int>(value));
+  }
+
+  int UnpackValue(const AbstractValue* value) {
+    return dynamic_cast<const Value<int>*>(value)->get_value();
+  }
+
+  Cache cache_;
+  CacheTicket ticket0_;
+  CacheTicket ticket1_;
+  CacheTicket ticket2_;
+};
+
+TEST_F(CacheTest, SetReturnsValue) {
+  CacheTicket ticket = cache_.MakeCacheTicket({});
+  AbstractValue* value = cache_.Set(ticket, PackValue(42));
+  EXPECT_EQ(42, UnpackValue(value));
+}
+
+TEST_F(CacheTest, GetReturnsValue) {
+  CacheTicket ticket = cache_.MakeCacheTicket({});
+  cache_.Set(ticket, PackValue(42));
+  AbstractValue* value = cache_.Get(ticket);
+  EXPECT_EQ(42, UnpackValue(value));
+}
+
+TEST_F(CacheTest, SwapReturnsAndSetsValue) {
+  CacheTicket ticket = cache_.MakeCacheTicket({});
+  cache_.Set(ticket, PackValue(42));
+  std::unique_ptr<AbstractValue> value = cache_.Swap(ticket, PackValue(43));
+  EXPECT_EQ(42, UnpackValue(value.get()));
+  EXPECT_EQ(43, UnpackValue(cache_.Get(ticket)));
+}
+
+TEST_F(CacheTest, InvalidationIsRecursive) {
+  cache_.Invalidate(ticket1_);
+  EXPECT_EQ(0, UnpackValue((cache_.Get(ticket0_))));
+  EXPECT_EQ(nullptr, cache_.Get(ticket1_));
+  EXPECT_EQ(nullptr, cache_.Get(ticket2_));
+}
+
+// Tests that a pointer to a cached value remains valid even after it is
+// invalidated. Only advanced, careful users should ever rely on this behavior!
+TEST_F(CacheTest, InvalidationIsNotDeletion) {
+  AbstractValue* value = cache_.Get(ticket1_);
+  cache_.Invalidate(ticket1_);
+  EXPECT_EQ(nullptr, cache_.Get(ticket1_));
+  EXPECT_EQ(1, UnpackValue(value));
+}
+
+TEST_F(CacheTest, InvalidationDoesNotStopOnNullptr) {
+  cache_.Invalidate(ticket1_);
+  cache_.Set(ticket2_, PackValue(76));
+  cache_.Invalidate(ticket1_);
+  EXPECT_EQ(nullptr, cache_.Get(ticket2_));
+}
+
+TEST_F(CacheTest, Clone) {
+  std::unique_ptr<Cache> clone = cache_.Clone();
+  // The clone should have the same values.
+  EXPECT_EQ(0, UnpackValue((clone->Get(ticket0_))));
+  EXPECT_EQ(1, UnpackValue((clone->Get(ticket1_))));
+  EXPECT_EQ(2, UnpackValue((clone->Get(ticket2_))));
+
+  // The clone should have the same invalidation topology.
+  clone->Invalidate(ticket0_);
+  EXPECT_EQ(nullptr, clone->Get(ticket0_));
+  EXPECT_EQ(nullptr, clone->Get(ticket1_));
+  EXPECT_EQ(nullptr, clone->Get(ticket2_));
+
+  // Changes to the clone should not affect the original.
+  EXPECT_EQ(0, UnpackValue((cache_.Get(ticket0_))));
+  EXPECT_EQ(1, UnpackValue((cache_.Get(ticket1_))));
+  EXPECT_EQ(2, UnpackValue((cache_.Get(ticket2_))));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/context_test.cc
+++ b/drake/systems/framework/test/context_test.cc
@@ -10,6 +10,7 @@
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
+#include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
@@ -26,16 +27,17 @@ constexpr double kTime = 12.0;
 class ContextTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    context_.set_time(kTime);
+    context_.reset(new Context<double>(kNumInputPorts));
+    context_->set_time(kTime);
 
     // Input
-    context_.SetNumInputPorts(kNumInputPorts);
     for (int i = 0; i < kNumInputPorts; ++i) {
       std::unique_ptr<VectorInterface<double>> port_data(
           new BasicVector<double>(kInputSize[i]));
       std::unique_ptr<FreestandingInputPort<double>> port(
           new FreestandingInputPort<double>(std::move(port_data)));
-      context_.SetInputPort(i, std::move(port));
+      inputs_.push_back(port.get());
+      context_->SetInputPort(i, std::move(port));
     }
 
     // State
@@ -43,7 +45,7 @@ class ContextTest : public ::testing::Test {
         new BasicVector<double>(kStateSize));
     state_data->get_mutable_value() << 1.0, 2.0, 3.0, 5.0, 8.0;
 
-    context_.get_mutable_state()->continuous_state.reset(
+    context_->get_mutable_state()->continuous_state.reset(
         new ContinuousState<double>(
             std::unique_ptr<BasicStateVector<double>>(
                 new BasicStateVector<double>(std::move(state_data))),
@@ -51,25 +53,28 @@ class ContextTest : public ::testing::Test {
             kMiscContinuousStateSize));
   }
 
-  Context<double> context_;
+  std::unique_ptr<AbstractValue> PackValue(int value) {
+    return std::unique_ptr<AbstractValue>(new Value<int>(value));
+  }
+
+  int UnpackValue(const AbstractValue* value) {
+    return dynamic_cast<const Value<int>*>(value)->get_value();
+  }
+
+  std::vector<FreestandingInputPort<double>*> inputs_;
+  std::unique_ptr<Context<double>> context_;
 };
 
 TEST_F(ContextTest, GetNumInputPorts) {
-  ASSERT_EQ(kNumInputPorts, context_.get_num_input_ports());
-}
-
-TEST_F(ContextTest, ClearInputPorts) {
-  context_.ClearInputPorts();
-  EXPECT_EQ(0, context_.get_num_input_ports());
+  ASSERT_EQ(kNumInputPorts, context_->get_num_input_ports());
 }
 
 TEST_F(ContextTest, SetOutOfBoundsInputPort) {
-  EXPECT_THROW(context_.SetInputPort(3, nullptr), std::out_of_range);
+  EXPECT_THROW(context_->SetInputPort(3, nullptr), std::out_of_range);
 }
 
 TEST_F(ContextTest, GetVectorInput) {
-  Context<int> context;
-  context.SetNumInputPorts(2);
+  Context<int> context(2);
 
   // Add input port 0 to the context, but leave input port 1 uninitialized.
   std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
@@ -90,8 +95,69 @@ TEST_F(ContextTest, GetVectorInput) {
   EXPECT_THROW(context.get_vector_input(2), std::out_of_range);
 }
 
+// Tests that, when a line of cache depends on an input port, changes to
+// that input port invalidate the line of cache.
+TEST_F(ContextTest, CacheDependsOnInput) {
+  ContextShape<bool> dependencies = context_->MakeContextShape();
+  ASSERT_EQ(kNumInputPorts, static_cast<int>(dependencies.input_ports.size()));
+  dependencies.input_ports[0] = true;
+  CacheTicket ticket = context_->CreateCacheEntry(dependencies, {});
+
+  context_->SetCachedItem(ticket, PackValue(42));
+  EXPECT_EQ(42, UnpackValue(context_->GetCachedItem(ticket)));
+
+  inputs_[0]->GetMutableVectorData()->get_mutable_value()[0] = 76.0;
+  EXPECT_EQ(nullptr, context_->GetCachedItem(ticket));
+
+  // Check that changes to some other input port do not invalidate the line.
+  context_->SetCachedItem(ticket, PackValue(128));
+  inputs_[1]->GetMutableVectorData()->get_mutable_value()[0] = 256.0;
+  EXPECT_EQ(128, UnpackValue(context_->GetCachedItem(ticket)));
+}
+
+// Tests that, when a line of cache depends on the state, changes to the
+// state invalidate the line of cache.
+TEST_F(ContextTest, CacheDependsOnState) {
+  ContextShape<bool> dependencies = context_->MakeContextShape();
+  dependencies.state.continuous_state = true;
+  CacheTicket ticket = context_->CreateCacheEntry(dependencies, {});
+
+  context_->SetCachedItem(ticket, PackValue(42));
+
+  // Changes to an input have no effect.
+  inputs_[0]->GetMutableVectorData()->get_mutable_value()[0] = 76.0;
+  inputs_[1]->GetMutableVectorData()->get_mutable_value()[0] = 256.0;
+  EXPECT_EQ(42, UnpackValue(context_->GetCachedItem(ticket)));
+
+  // Changes to the state invalidate the line.
+  ContinuousState<double>* xc =
+      context_->get_mutable_state()->continuous_state.get();
+  xc->get_mutable_state()->SetAtIndex(1, 512.0);
+  EXPECT_EQ(nullptr, context_->GetCachedItem(ticket));
+}
+
+// Tests that, when a line of cache A depends on the state, and a line of cache
+// B depends on A, and the state changes, both A and B are invalidated.
+TEST_F(ContextTest, CacheDependsOnOtherCache) {
+  ContextShape<bool> dependencies = context_->MakeContextShape();
+  dependencies.state.continuous_state = true;
+  CacheTicket ticket0 = context_->CreateCacheEntry(dependencies, {});
+  context_->SetCachedItem(ticket0, PackValue(42));
+
+  CacheTicket ticket1 =
+      context_->CreateCacheEntry(context_->MakeContextShape(), {ticket0});
+  context_->SetCachedItem(ticket1, PackValue(76));
+
+  // Changes to the state invalidate both lines.
+  ContinuousState<double>* xc =
+      context_->get_mutable_state()->continuous_state.get();
+  xc->get_mutable_state()->SetAtIndex(1, 512.0);
+  EXPECT_EQ(nullptr, context_->GetCachedItem(ticket0));
+  EXPECT_EQ(nullptr, context_->GetCachedItem(ticket1));
+}
+
 TEST_F(ContextTest, Clone) {
-  std::unique_ptr<ContextBase<double>> clone = context_.Clone();
+  std::unique_ptr<ContextBase<double>> clone = context_->Clone();
 
   // Verify that the time was copied.
   EXPECT_EQ(kTime, clone->get_time());
@@ -100,8 +166,8 @@ TEST_F(ContextTest, Clone) {
   // but are different pointers.
   EXPECT_EQ(kNumInputPorts, clone->get_num_input_ports());
   for (int i = 0; i < kNumInputPorts; ++i) {
-    EXPECT_NE(context_.get_vector_input(i), clone->get_vector_input(i));
-    EXPECT_TRUE(CompareMatrices(context_.get_vector_input(i)->get_value(),
+    EXPECT_NE(context_->get_vector_input(i), clone->get_vector_input(i));
+    EXPECT_TRUE(CompareMatrices(context_->get_vector_input(i)->get_value(),
                                 clone->get_vector_input(i)->get_value(), 1e-8,
                                 MatrixCompareType::absolute));
   }
@@ -136,7 +202,7 @@ TEST_F(ContextTest, Clone) {
   xc->get_mutable_generalized_velocity()->SetAtIndex(1, 42.0);
   EXPECT_EQ(42.0, xc_data->GetAtIndex(3));
   EXPECT_EQ(5.0,
-            context_.get_state().continuous_state->get_state().GetAtIndex(3));
+            context_->get_state().continuous_state->get_state().GetAtIndex(3));
 }
 
 }  // namespace systems

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -33,8 +33,7 @@ class TestSystem : public System<double> {
     return nullptr;
   }
 
-  std::unique_ptr<ContextBase<double>> CreateDefaultContext()
-      const override {
+  std::unique_ptr<ContextBase<double>> CreateDefaultContext() const override {
     return nullptr;
   }
 
@@ -54,7 +53,7 @@ class TestSystem : public System<double> {
 class SystemTest : public ::testing::Test {
  protected:
   TestSystem system_;
-  Context<double> context_;
+  Context<double> context_{0};
 };
 
 TEST_F(SystemTest, MapVelocityToConfigurationDerivatives) {

--- a/drake/systems/lcm/lcm_publisher_system.cc
+++ b/drake/systems/lcm/lcm_publisher_system.cc
@@ -32,8 +32,7 @@ std::string LcmPublisherSystem::get_name() const {
 
 std::unique_ptr<ContextBase<double>> LcmPublisherSystem::CreateDefaultContext()
     const {
-  std::unique_ptr<Context<double>> context(new Context<double>());
-  context->SetNumInputPorts(kNumInputPorts);
+  std::unique_ptr<Context<double>> context(new Context<double>(kNumInputPorts));
   return std::unique_ptr<ContextBase<double>>(context.release());
 }
 

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -47,8 +47,7 @@ std::unique_ptr<ContextBase<double>> LcmSubscriberSystem::CreateDefaultContext()
   // Creates a new context for this system and sets the number of input ports
   // to be zero. It leaves the context's state uninitialized since this system
   // does not use it.
-  std::unique_ptr<Context<double>> context(new Context<double>());
-  context->SetNumInputPorts(0);
+  std::unique_ptr<Context<double>> context(new Context<double>(0));
 
   // Returns this system's context.
   return std::unique_ptr<ContextBase<double>>(context.release());


### PR DESCRIPTION
Systems can use the cache to store and retrieve computed values.  The cache will automatically invalidate entries whose dependencies have changed.

Sending this out for review with slightly incomplete test coverage, since I anticipate some design back-and-forth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3135)
<!-- Reviewable:end -->
