### PR TITLE
Added missing override keyword.

### DIFF
--- a/drake/systems/framework/primitives/integrator.h
+++ b/drake/systems/framework/primitives/integrator.h
@@ -46,7 +46,7 @@ class Integrator : public System<T> {
   void EvalTimeDerivatives(const ContextBase<T>& context,
                            ContinuousState<T>* derivatives) const override;
 
-  void set_name(const std::string& name) { name_ = name; }
+  void set_name(const std::string& name) override { name_ = name; }
   std::string get_name() const override { return name_; }
 
  private:


### PR DESCRIPTION
Fixes the following compile-time warning:

```
In file included from /Users/liang/dev/drake-distro-1/drake/systems/framework/test/diagram_context_test.cc:11:
/Users/liang/dev/drake-distro-1/drake/../drake/systems/framework/primitives/integrator.h:49:8: warning: 'set_name' overrides a member
      function but is not marked 'override' [-Winconsistent-missing-override]
  void set_name(const std::string& name) { name_ = name; }
       ^
/Users/liang/dev/drake-distro-1/drake/systems/framework/test/diagram_context_test.cc:36:28: note: in instantiation of template class
      'drake::systems::Integrator<double>' requested here
    integrator0_.reset(new Integrator<double>(1 /* length */));
                           ^
/Users/liang/dev/drake-distro-1/drake/../drake/systems/framework/system.h:157:16: note: overridden virtual function is here
  virtual void set_name(const std::string& name) { name_ = name; }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3136)
<!-- Reviewable:end -->
