### PR TITLE
Add vector base type that serves as both State and Output

### DIFF
--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -4,8 +4,7 @@
 #include <string>
 
 #include "drake/drakeSpringMassSystem_export.h"
-#include "drake/systems/framework/basic_state_vector.h"
-#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/basic_state_and_output_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/state_vector.h"
 #include "drake/systems/framework/system.h"
@@ -17,11 +16,13 @@ namespace examples {
 /// The state of a one-dimensional spring-mass system, consisting of the
 /// position and velocity of the mass, in meters and meters/s.
 class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassStateVector
-    : public systems::BasicStateVector<double> {
+    : public systems::BasicStateAndOutputVector<double> {
  public:
   /// @param initial_position The position of the mass in meters.
   /// @param initial_velocity The velocity of the mass in meters / second.
   SpringMassStateVector(double initial_position, double initial_velocity);
+  /// Creates a state with position and velocity set to zero.
+  SpringMassStateVector();
   ~SpringMassStateVector() override;
 
   /// Returns the position of the mass in meters, where zero is the point
@@ -45,32 +46,6 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassStateVector
 
  private:
   SpringMassStateVector* DoClone() const override;
-};
-
-/// The output of a one-dimensional spring-mass system, consisting of the
-/// position and velocity of the mass, in meters. Note that although this
-/// system tracks work done as a state variable, we are not reporting that
-/// as an Output.
-class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassOutputVector
-    : public systems::BasicVector<double> {
- public:
-  SpringMassOutputVector();
-
-  /// Returns the position of the mass in meters, where zero is the point
-  /// where the spring exerts no force.
-  double get_position() const;
-
-  /// Sets the position of the mass in meters.
-  void set_position(double q);
-
-  /// Returns the velocity of the mass in meters per second.
-  double get_velocity() const;
-
-  /// Sets the velocity of the mass in meters per second.
-  void set_velocity(double v);
-
- private:
-  SpringMassOutputVector* DoClone() const override;
 };
 
 /// A model of a one-dimensional spring-mass system.
@@ -243,13 +218,13 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
     return dynamic_cast<SpringMassStateVector*>(cstate->get_mutable_state());
   }
 
-  static const SpringMassOutputVector& get_output(const MyOutput& output) {
-    return dynamic_cast<const SpringMassOutputVector&>(
+  static const SpringMassStateVector& get_output(const MyOutput& output) {
+    return dynamic_cast<const SpringMassStateVector&>(
         *output.get_port(0).get_vector_data());
   }
 
-  static SpringMassOutputVector* get_mutable_output(MyOutput* output) {
-    return dynamic_cast<SpringMassOutputVector*>(
+  static SpringMassStateVector* get_mutable_output(MyOutput* output) {
+    return dynamic_cast<SpringMassStateVector*>(
         output->get_mutable_port(0)->GetMutableVectorData());
   }
 

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -69,7 +69,7 @@ class SpringMassSystemTest : public ::testing::Test {
     // Set up some convenience pointers.
     state_ = dynamic_cast<SpringMassStateVector*>(
         context_->get_mutable_state()->continuous_state->get_mutable_state());
-    output_ = dynamic_cast<const SpringMassOutputVector*>(
+    output_ = dynamic_cast<const SpringMassStateVector*>(
         system_output_->get_port(0).get_vector_data());
     derivatives_ = dynamic_cast<SpringMassStateVector*>(
         system_derivatives_->get_mutable_state());
@@ -97,7 +97,7 @@ class SpringMassSystemTest : public ::testing::Test {
   std::unique_ptr<BasicStateVector<double>> configuration_derivatives_;
 
   SpringMassStateVector* state_;
-  const SpringMassOutputVector* output_;
+  const SpringMassStateVector* output_;
   SpringMassStateVector* derivatives_;
 
  private:
@@ -127,10 +127,10 @@ TEST_F(SpringMassSystemTest, CloneState) {
 TEST_F(SpringMassSystemTest, CloneOutput) {
   InitializeState(1.0, 2.0);
   system_->EvalOutput(*context_, system_output_.get());
-  std::unique_ptr<VectorInterface<double>> clone = output_->Clone();
+  std::unique_ptr<VectorInterface<double>> clone = output_->CloneVector();
 
-  SpringMassOutputVector* typed_clone =
-      dynamic_cast<SpringMassOutputVector*>(clone.get());
+  SpringMassStateVector* typed_clone =
+      dynamic_cast<SpringMassStateVector*>(clone.get());
   EXPECT_EQ(1.0, typed_clone->get_position());
   EXPECT_EQ(2.0, typed_clone->get_velocity());
 }
@@ -147,7 +147,7 @@ TEST_F(SpringMassSystemTest, Output) {
   EXPECT_EQ(0.25, output_->get_velocity());
 
   // Check the output through the VectorInterface API.
-  ASSERT_EQ(2, output_->size());
+  ASSERT_EQ(3, output_->size());
   EXPECT_NEAR(0.1, output_->get_value()[0], 1e-14);
   EXPECT_EQ(0.25, output_->get_value()[1]);
 }

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Source files used to build drakeSystemFramework.
 set(sources
+  basic_state_and_output_vector.cc
   basic_state_vector.cc
   basic_vector.cc
   cache.cc
@@ -32,6 +33,7 @@ set(sources
 # System2 framework template implementations have been moved into .cc files
 # using explicit instantiation, tighten this list.
 set(installed_headers
+  basic_state_and_output_vector.h
   basic_state_vector.h
   basic_vector.h
   cache.h

--- a/drake/systems/framework/basic_state_and_output_vector.cc
+++ b/drake/systems/framework/basic_state_and_output_vector.cc
@@ -1,6 +1,4 @@
-// For now, this is an empty .cc file that only serves to confirm
-// basic_state_and_output_vector.h is a stand-alone header.
-
 #include "drake/systems/framework/basic_state_and_output_vector.h"
 
+// Catch compile errors early, by forcing an instantiation.
 template class drake::systems::BasicStateAndOutputVector<double>;

--- a/drake/systems/framework/basic_state_and_output_vector.cc
+++ b/drake/systems/framework/basic_state_and_output_vector.cc
@@ -1,0 +1,6 @@
+// For now, this is an empty .cc file that only serves to confirm
+// basic_state_and_output_vector.h is a stand-alone header.
+
+#include "drake/systems/framework/basic_state_and_output_vector.h"
+
+template class drake::systems::BasicStateAndOutputVector<double>;

--- a/drake/systems/framework/basic_state_and_output_vector.h
+++ b/drake/systems/framework/basic_state_and_output_vector.h
@@ -13,7 +13,7 @@ namespace drake {
 namespace systems {
 
 /// BasicStateAndOutputVector is a concrete class template that implements
-/// StateVector in a convenient manner for leaf Systems, and implements
+/// StateVector in a convenient manner for LeafSystem blocks, and implements
 /// VectorInterface so that it may also be used as an output.
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
@@ -33,7 +33,7 @@ class BasicStateAndOutputVector : public BasicStateVector<T>,
   explicit BasicStateAndOutputVector(std::unique_ptr<VectorInterface<T>> vector)
       : BasicStateVector<T>(std::move(vector)) {}
 
-  // N.B. The size() method overrides both BasicStateVector and VectorInterface.
+  // The size() method overrides both BasicStateVector and VectorInterface.
   int size() const override { return this->get_wrapped_vector().size(); }
 
   // These VectorInterface overrides merely delegate to the wrapped object.

--- a/drake/systems/framework/basic_state_and_output_vector.h
+++ b/drake/systems/framework/basic_state_and_output_vector.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/basic_state_vector.h"
+#include "drake/systems/framework/vector_interface.h"
+
+namespace drake {
+namespace systems {
+
+/// BasicStateAndOutputVector is a concrete class template that implements
+/// StateVector in a convenient manner for leaf Systems, and implements
+/// VectorInterface so that it may also be used as an output.
+///
+/// @tparam T A mathematical type compatible with Eigen's Scalar.
+template <typename T>
+class BasicStateAndOutputVector : public BasicStateVector<T>,
+                                  public VectorInterface<T> {
+ public:
+  /// Constructs a BasicStateAndOutputVector of the specified @p size.
+  explicit BasicStateAndOutputVector(int size) : BasicStateVector<T>(size) {}
+
+  /// Constructs a BasicStateAndOutputVector with the specified @p data.
+  explicit BasicStateAndOutputVector(const std::vector<T>& data)
+      : BasicStateVector<T>(data) {}
+
+  /// Constructs a BasicStateAndOutputVector that owns an arbitrary @p vector,
+  /// which must not be nullptr.
+  explicit BasicStateAndOutputVector(std::unique_ptr<VectorInterface<T>> vector)
+      : BasicStateVector<T>(std::move(vector)) {}
+
+  // N.B. The size() method overrides both BasicStateVector and VectorInterface.
+  int size() const override { return this->get_wrapped_vector().size(); }
+
+  // These VectorInterface overrides merely delegate to the wrapped object.
+  void set_value(const Eigen::Ref<const VectorX<T>>& value) override {
+    this->get_wrapped_vector().set_value(value);
+  }
+  Eigen::VectorBlock<const VectorX<T>> get_value() const override {
+    return this->get_wrapped_vector().get_value();
+  }
+  Eigen::VectorBlock<VectorX<T>> get_mutable_value() override {
+    return this->get_wrapped_vector().get_mutable_value();
+  }
+
+  // This VectorInterface override must not delegate, because we need to
+  // maintain our class type (BasicStateAndOutputVector) during cloning.
+  std::unique_ptr<VectorInterface<T>> CloneVector() const override {
+    return std::unique_ptr<VectorInterface<T>>(DoClone());
+  }
+
+ protected:
+  BasicStateAndOutputVector(const BasicStateAndOutputVector& other)
+      : BasicStateVector<T>(other) {}
+
+  BasicStateAndOutputVector<T>* DoClone() const override {
+    return new BasicStateAndOutputVector<T>(*this);
+  }
+
+ private:
+  // Disable these, for consistency with parent class.
+  BasicStateAndOutputVector& operator=(const BasicStateAndOutputVector&) =
+      delete;
+  BasicStateAndOutputVector(BasicStateAndOutputVector&&) = delete;
+  BasicStateAndOutputVector& operator=(BasicStateAndOutputVector&&) = delete;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/basic_state_vector.h
+++ b/drake/systems/framework/basic_state_vector.h
@@ -13,11 +13,11 @@ namespace drake {
 namespace systems {
 
 /// BasicStateVector is a concrete class template that implements
-/// StateVector in a convenient manner for leaf Systems,
+/// StateVector in a convenient manner for LeafSystem blocks,
 /// by owning and wrapping a VectorInterface<T>.
 ///
 /// It will often be convenient to inherit from BasicStateVector, and add
-/// additional semantics specific to the leaf System. Such child classes must
+/// additional semantics specific to the LeafSystem. Such child classes must
 /// override DoClone with an implementation that returns their concrete type.
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.

--- a/drake/systems/framework/basic_state_vector.h
+++ b/drake/systems/framework/basic_state_vector.h
@@ -8,7 +8,6 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_state_vector.h"
 #include "drake/systems/framework/vector_interface.h"
-#include "leaf_state_vector.h"
 
 namespace drake {
 namespace systems {
@@ -88,16 +87,20 @@ class BasicStateVector : public LeafStateVector<T> {
   }
 
  protected:
+  // Clone other's wrapped vector, in case is it not a BasicVector.
   BasicStateVector(const BasicStateVector& other)
-      : BasicStateVector(other.size()) {
-    SetFromVector(other.vector_->get_value());
-  }
+      : BasicStateVector(other.vector_->CloneVector()) {}
 
- private:
   BasicStateVector<T>* DoClone() const override {
     return new BasicStateVector<T>(*this);
   }
 
+  /// Returns a mutable reference to the underlying VectorInterface.
+  VectorInterface<T>& get_wrapped_vector() { return *vector_; }
+  /// Returns a const reference to the underlying VectorInterface.
+  const VectorInterface<T>& get_wrapped_vector() const { return *vector_; }
+
+ private:
   // Assignment of BasicStateVectors could change size, so we forbid it.
   BasicStateVector& operator=(const BasicStateVector& other) = delete;
 

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -50,7 +50,7 @@ class BasicVector : public VectorInterface<T> {
   ///
   /// Uses the Non-Virtual Interface idiom because smart pointers do not have
   /// type covariance.
-  std::unique_ptr<VectorInterface<T>> Clone() const final {
+  std::unique_ptr<VectorInterface<T>> CloneVector() const final {
     return std::unique_ptr<VectorInterface<T>>(DoClone());
   }
 

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -99,7 +99,8 @@ class Context : public ContextBase<T> {
         context->inputs_.emplace_back(nullptr);
       } else {
         context->inputs_.emplace_back(
-            new FreestandingInputPort<T>(port->get_vector_data()->Clone()));
+            new FreestandingInputPort<T>(
+                port->get_vector_data()->CloneVector()));
       }
     }
 

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -75,7 +75,7 @@ class OutputPort {
   /// Returns a clone of this OutputPort containing a clone of the data, but
   /// without any dependents.
   std::unique_ptr<OutputPort<T>> Clone() const {
-    return std::make_unique<OutputPort<T>>(vector_data_->Clone());
+    return std::make_unique<OutputPort<T>>(vector_data_->CloneVector());
   }
 
  private:

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -12,6 +12,13 @@ target_link_libraries(basic_state_vector_test drakeSystemFramework
                       ${GTEST_BOTH_LIBRARIES})
 add_test(NAME basic_state_vector_test COMMAND basic_state_vector_test)
 
+add_executable(basic_state_and_output_vector_test
+  basic_state_and_output_vector_test.cc)
+target_link_libraries(basic_state_and_output_vector_test drakeSystemFramework
+  ${GTEST_BOTH_LIBRARIES})
+add_test(NAME basic_state_and_output_vector_test
+  COMMAND basic_state_and_output_vector_test)
+
 add_executable(state_subvector_test state_subvector_test.cc)
 target_link_libraries(state_subvector_test drakeSystemFramework
                       ${GTEST_BOTH_LIBRARIES})

--- a/drake/systems/framework/test/basic_state_and_output_vector_test.cc
+++ b/drake/systems/framework/test/basic_state_and_output_vector_test.cc
@@ -1,0 +1,103 @@
+#include "drake/systems/framework/basic_state_and_output_vector.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include <Eigen/Dense>
+
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+const int kLength = 2;
+
+// The implementation of BasicStateAndOutputVector is largely inherited from
+// BasicStateVector and BasicVector.  Here, we lightly touch most methods to
+// ensure they are sane, relying on the delegated implementations' unit tests
+// to ensure correctness.  Separate tests below cover the special cases.
+GTEST_TEST(BasicStateAndOutputVectorTest, CoverDelegatedMethods) {
+  // The device under test.
+  BasicStateAndOutputVector<int> dut(kLength);
+  EXPECT_EQ(kLength, dut.size());
+
+  // Touch most VectorInterface methods.
+  dut.set_value((Eigen::VectorXi(kLength) << 10, 11).finished());
+  EXPECT_EQ(11, dut.get_value()(1));
+  dut.get_mutable_value()(1) = 5;
+  EXPECT_EQ(5, dut.get_value()(1));
+
+  // Touch most BasicStateVector methods.
+  dut.SetFromVector((Eigen::VectorXi(kLength) << 20, 21).finished());
+  EXPECT_EQ(21, dut.GetAtIndex(1));
+  EXPECT_EQ(21, dut.CopyToVector()(1));
+  dut.SetAtIndex(1, 6);
+  EXPECT_EQ(6, dut.GetAtIndex(1));
+  Eigen::VectorXi target = (Eigen::VectorXi(kLength) << 30, 31).finished();
+  dut.ScaleAndAddToVector(3, target);
+  EXPECT_EQ(6 * 3 + 31, target(1));
+}
+
+// Touch all constructors.
+GTEST_TEST(BasicStateAndOutputVectorTest, Constructors) {
+  BasicStateAndOutputVector<int> by_size(kLength);
+  EXPECT_EQ(kLength, by_size.size());
+  EXPECT_EQ(0, by_size.get_value()(1));
+
+  BasicStateAndOutputVector<int> by_vector(std::vector<int>(kLength, 0));
+  EXPECT_EQ(kLength, by_vector.size());
+  EXPECT_EQ(0, by_vector.get_value()(1));
+
+  BasicStateAndOutputVector<int> by_interface(
+      std::make_unique<BasicVector<int>>(kLength));
+  EXPECT_EQ(kLength, by_interface.size());
+  EXPECT_EQ(0, by_interface.get_value()(1));
+}
+
+// Confirm that setting and getting are the same, no matter the API.
+GTEST_TEST(BasicStateAndOutputVectorTest, MatchingSetAndGet) {
+  // The device under test.
+  BasicStateAndOutputVector<int> dut(kLength);
+
+  // Set via VectorInterface; get via BasicStateVector.
+  dut.get_mutable_value()(1) = 5;
+  EXPECT_EQ(5, dut.GetAtIndex(1));
+
+  // Set via BasicStateVector; get via VectorInterface.
+  dut.SetAtIndex(0, 6);
+  EXPECT_EQ(6, dut.get_value()(0));
+}
+
+// Confirm that cloning via the State API preserves our type.
+GTEST_TEST(BasicStateAndOutputVectorTest, CloneState) {
+  // The device under test.
+  BasicStateAndOutputVector<int> dut(kLength);
+  dut.SetFromVector((Eigen::VectorXi(kLength) << 10, 11).finished());
+
+  std::unique_ptr<LeafStateVector<int>> clone = dut.Clone();
+  BasicStateAndOutputVector<int>* typed_clone =
+      dynamic_cast<BasicStateAndOutputVector<int>*>(clone.get());
+  ASSERT_NE(nullptr, typed_clone);
+  EXPECT_EQ(10, typed_clone->GetAtIndex(0));
+  EXPECT_EQ(11, typed_clone->GetAtIndex(1));
+}
+
+// Confirm that cloning via the Vector API preserves our type.
+GTEST_TEST(BasicStateAndOutputVectorTest, CloneVector) {
+  // The device under test.
+  BasicStateAndOutputVector<int> dut(kLength);
+  dut.set_value((Eigen::VectorXi(kLength) << 10, 11).finished());
+
+  std::unique_ptr<VectorInterface<int>> clone = dut.CloneVector();
+  BasicStateAndOutputVector<int>* typed_clone =
+      dynamic_cast<BasicStateAndOutputVector<int>*>(clone.get());
+  ASSERT_NE(nullptr, typed_clone);
+  EXPECT_EQ(10, typed_clone->get_value()(0));
+  EXPECT_EQ(11, typed_clone->get_value()(1));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -76,7 +76,7 @@ GTEST_TEST(BasicVectorTest, SetWholeVector) {
 GTEST_TEST(BasicVectorTest, Clone) {
   BasicVector<int> vec(2);
   vec.get_mutable_value() << 1, 2;
-  std::unique_ptr<VectorInterface<int>> clone = vec.Clone();
+  std::unique_ptr<VectorInterface<int>> clone = vec.CloneVector();
 
   BasicVector<int>* typed_clone = dynamic_cast<BasicVector<int>*>(clone.get());
   Eigen::Vector2i expected;

--- a/drake/systems/framework/vector_interface.h
+++ b/drake/systems/framework/vector_interface.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <cstdint>
 #include <memory>
 
-#include "drake/common/eigen_types.h"
-
 #include <Eigen/Dense>
+
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace systems {
@@ -41,7 +40,7 @@ class VectorInterface {
 
   /// Copies the entire vector to a new VectorInterface, with the same concrete
   /// implementation type.
-  virtual std::unique_ptr<VectorInterface<T>> Clone() const = 0;
+  virtual std::unique_ptr<VectorInterface<T>> CloneVector() const = 0;
 
  protected:
   VectorInterface() {}


### PR DESCRIPTION
- Add basic_state_and_output_vector with unit test.
- Rename VectorInterface::Clone to CloneVector, leaving
  the Clone/DoClone naming reserved for just the NVI pattern.
- Fix basic_state_vector copy ctor to preserve the wrapped type.
- Update spring_mass to use the new combined vector type.
- Clean up some include shrapnel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3151)
<!-- Reviewable:end -->
