### PR TITLE
Add systems/framework/primitives/CMakeLists.txt

### DIFF
--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -41,9 +41,6 @@ set(installed_headers
   diagram_context.h
   leaf_state_vector.h
   leaf_system.h
-  primitives/adder.h
-  primitives/constant_vector_source.h
-  primitives/integrator.h
   state.h
   state_subvector.h
   state_supervector.h
@@ -71,5 +68,5 @@ pods_install_pkg_config_file(drake-system-framework
   REQUIRES
   VERSION 0.0.1)
 
+add_subdirectory(primitives)
 add_subdirectory(test)
-add_subdirectory(primitives/test)

--- a/drake/systems/framework/primitives/CMakeLists.txt
+++ b/drake/systems/framework/primitives/CMakeLists.txt
@@ -1,0 +1,9 @@
+# This directory has no library targets. All the source code here is part
+# drakeSystemFramework, which is declared in systems/framework.
+
+drake_install_headers(
+  adder.h
+  constant_vector_source.h
+  integrator.h)
+
+add_subdirectory(test)


### PR DESCRIPTION
This causes the headers to be installed in `systems/framework/primitives` instead of `systems/framework`.

+@jwnimmer-tri for feature and platform review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3161)
<!-- Reviewable:end -->
