### PR TITLE
Add support for abstract-valued input and output ports to System2.

### DIFF
--- a/drake/examples/Cars/test/trajectory_car_test.cc
+++ b/drake/examples/Cars/test/trajectory_car_test.cc
@@ -101,7 +101,7 @@ GTEST_TEST(TrajectoryCarTest, SegmentTest) {
       ASSERT_EQ(1, all_output->get_num_ports());
       const SimpleCarState<double>* output =
           dynamic_cast<const SimpleCarState<double>*>(
-              all_output->get_port(0).get_vector_data());
+              all_output->get_vector_data(0));
       ASSERT_NE(nullptr, output);
 
       EXPECT_DOUBLE_EQ(expected_position(0), output->x());

--- a/drake/examples/Cars/trajectory_car.h
+++ b/drake/examples/Cars/trajectory_car.h
@@ -111,7 +111,7 @@ class TrajectoryCar : public systems::LeafSystem<T> {
     DRAKE_ASSERT(output != nullptr);
     DRAKE_ASSERT(output->get_num_ports() == 1);
     systems::VectorBase<T>* output_vector =
-        output->get_mutable_port(0)->GetMutableVectorData();
+        output->GetMutableVectorData(0);
     DRAKE_ASSERT(output_vector != nullptr);
 
     // TODO(jwninmmer-tri) Once TrajectoryCar1 is otherwise unused and can be

--- a/drake/examples/spring_mass/spring_mass_system.cc
+++ b/drake/examples/spring_mass/spring_mass_system.cc
@@ -103,8 +103,7 @@ std::unique_ptr<SystemOutput<double>> SpringMassSystem::AllocateOutput(
       new LeafSystemOutput<double>);
   {
     std::unique_ptr<VectorBase<double>> data(new SpringMassStateVector());
-    std::unique_ptr<OutputPort<double>> port(
-        new OutputPort<double>(std::move(data)));
+    std::unique_ptr<OutputPort> port(new OutputPort(std::move(data)));
     output->get_mutable_ports()->push_back(std::move(port));
   }
   return std::unique_ptr<SystemOutput<double>>(output.release());
@@ -146,8 +145,8 @@ void SpringMassSystem::EvalTimeDerivatives(
   // By Newton's 2nd law, the derivative of velocity (acceleration) is f/m where
   // f is the force applied to the body by the spring, and m is the mass of the
   // body.
-  const double force_applied_to_body = EvalSpringForce(context)
-      + external_force;
+  const double force_applied_to_body =
+      EvalSpringForce(context) + external_force;
   derivative_vector->set_velocity(force_applied_to_body / mass_kg_);
 
   // We are integrating conservative power to get the work done by conservative

--- a/drake/examples/spring_mass/spring_mass_system.h
+++ b/drake/examples/spring_mass/spring_mass_system.h
@@ -66,15 +66,15 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
   /// spring.
   /// @param[in] system_is_forced If `true`, the system has an input port for an
   /// external force. If `false`, the system has no inputs.
-  SpringMassSystem(double spring_constant_N_per_m,
-                   double mass_kg, bool system_is_forced = false);
+  SpringMassSystem(double spring_constant_N_per_m, double mass_kg,
+                   bool system_is_forced = false);
 
   using MyContext = systems::ContextBase<double>;
   using MyContinuousState = systems::ContinuousState<double>;
   using MyOutput = systems::SystemOutput<double>;
 
   /// The input force to this system is not direct feedthrough.
-  bool has_any_direct_feedthrough() const override { return false;}
+  bool has_any_direct_feedthrough() const override { return false; }
 
   // Provide methods specific to this System.
 
@@ -220,12 +220,12 @@ class DRAKESPRINGMASSSYSTEM_EXPORT SpringMassSystem
 
   static const SpringMassStateVector& get_output(const MyOutput& output) {
     return dynamic_cast<const SpringMassStateVector&>(
-        *output.get_port(0).get_vector_data());
+        *output.get_vector_data(0));
   }
 
   static SpringMassStateVector* get_mutable_output(MyOutput* output) {
     return dynamic_cast<SpringMassStateVector*>(
-        output->get_mutable_port(0)->GetMutableVectorData());
+        output->GetMutableVectorData(0));
   }
 
   static const SpringMassStateVector& get_state(const MyContext& context) {

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -48,14 +48,11 @@ const double kMass = 2.0;      // kg
 
 class SpringMassSystemTest : public ::testing::Test {
  public:
-  void SetUp() override {
-    Initialize();
-  }
+  void SetUp() override { Initialize(); }
 
   void Initialize(bool with_input_force = false) {
     // Construct the system I/O objects.
-    system_.reset(new SpringMassSystem(kSpring, kMass,
-                                       with_input_force));
+    system_.reset(new SpringMassSystem(kSpring, kMass, with_input_force));
     system_->set_name("test_system");
     context_ = system_->CreateDefaultContext();
     system_output_ = system_->AllocateOutput(*context_);
@@ -69,7 +66,7 @@ class SpringMassSystemTest : public ::testing::Test {
     state_ = dynamic_cast<SpringMassStateVector*>(
         context_->get_mutable_state()->continuous_state->get_mutable_state());
     output_ = dynamic_cast<const SpringMassStateVector*>(
-        system_output_->get_port(0).get_vector_data());
+        system_output_->get_vector_data(0));
     derivatives_ = dynamic_cast<SpringMassStateVector*>(
         system_derivatives_->get_mutable_state());
   }
@@ -83,9 +80,9 @@ class SpringMassSystemTest : public ::testing::Test {
   // Helper method to create input ports (free standing input ports) that are
   // not connected to any other output port in the system.
   // Used to test standalone systems not part of a Diagram.
-  static std::unique_ptr<FreestandingInputPort<double>> MakeInput(
+  static std::unique_ptr<FreestandingInputPort> MakeInput(
       std::unique_ptr<BasicVector<double>> data) {
-    return make_unique<FreestandingInputPort<double>>(std::move(data));
+    return make_unique<FreestandingInputPort>(std::move(data));
   }
 
  protected:

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -11,6 +11,7 @@ set(sources
   diagram_context.cc
   leaf_system.cc
   primitives/adder.cc
+  primitives/constant_value_source.cc
   primitives/constant_vector_source.cc
   primitives/gain.cc
   primitives/integrator.cc

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -27,6 +27,13 @@ class BasicVector : public VectorBase<T> {
             size, std::numeric_limits<
                       typename Eigen::NumTraits<T>::Real>::quiet_NaN())) {}
 
+  /// Constructs a BasicVector with the specified @p data.
+  explicit BasicVector(const std::vector<T>& data) : BasicVector(data.size()) {
+    for (size_t i = 0; i < data.size(); ++i) {
+      values_[i] = data[i];
+    }
+  }
+
   void set_value(const Eigen::Ref<const VectorX<T>>& value) override {
     if (value.rows() != values_.rows()) {
       throw std::out_of_range(

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -28,7 +28,7 @@ class Context : public ContextBase<T> {
   Context() {}
   virtual ~Context() {}
 
-  void SetInputPort(int index, std::unique_ptr<InputPort<T>> port) override {
+  void SetInputPort(int index, std::unique_ptr<InputPort> port) override {
     if (index < 0 || index >= get_num_input_ports()) {
       throw std::out_of_range("Input port out of range.");
     }
@@ -52,13 +52,19 @@ class Context : public ContextBase<T> {
   }
 
   const VectorBase<T>* get_vector_input(int index) const override {
-    if (index >= get_num_input_ports()) {
-      throw std::out_of_range("Input port out of range.");
-    }
+    DRAKE_ABORT_UNLESS(index >= 0 && index < get_num_input_ports());
     if (inputs_[index] == nullptr) {
       return nullptr;
     }
-    return inputs_[index]->get_vector_data();
+    return inputs_[index]->template get_vector_data<T>();
+  }
+
+  const AbstractValue* get_abstract_input(int index) const override {
+    DRAKE_ABORT_UNLESS(index >= 0 && index < get_num_input_ports());
+    if (inputs_[index] == nullptr) {
+      return nullptr;
+    }
+    return inputs_[index]->get_abstract_data();
   }
 
   const State<T>& get_state() const override { return state_; }
@@ -98,9 +104,8 @@ class Context : public ContextBase<T> {
       if (port == nullptr) {
         context->inputs_.emplace_back(nullptr);
       } else {
-        context->inputs_.emplace_back(
-            new FreestandingInputPort<T>(
-                port->get_vector_data()->CloneVector()));
+        context->inputs_.emplace_back(new FreestandingInputPort(
+            port->template get_vector_data<T>()->CloneVector()));
       }
     }
 
@@ -118,7 +123,7 @@ class Context : public ContextBase<T> {
   Context& operator=(Context&& other) = delete;
 
   // The external inputs to the System.
-  std::vector<std::unique_ptr<InputPort<T>>> inputs_;
+  std::vector<std::unique_ptr<InputPort>> inputs_;
 
   // The internal state of the System.
   State<T> state_;

--- a/drake/systems/framework/context_base.h
+++ b/drake/systems/framework/context_base.h
@@ -2,6 +2,7 @@
 
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/system_input.h"
+#include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
@@ -41,7 +42,7 @@ class ContextBase {
   /// Connects the input port @p port to this Context at the given @p index.
   /// Disconnects whatever input port was previously there, and deregisters
   /// it from the output port on which it depends.
-  virtual void SetInputPort(int index, std::unique_ptr<InputPort<T>> port) = 0;
+  virtual void SetInputPort(int index, std::unique_ptr<InputPort> port) = 0;
 
   /// Returns the number of input ports.
   virtual int get_num_input_ports() const = 0;
@@ -50,6 +51,24 @@ class ContextBase {
   /// if that port is not a vector-valued port, or if it is not connected.
   /// Throws std::out_of_range if that port does not exist.
   virtual const VectorBase<T>* get_vector_input(int index) const = 0;
+
+  /// Returns the abstract data of the input port at @p index. Returns nullptr
+  /// if that port is not connected. Throws std::out_of_range if that port
+  /// does not exist.
+  virtual const AbstractValue* get_abstract_input(int index) const = 0;
+
+  /// Returns the data of the input port at @p index, or nullptr if that port
+  /// is not connected.
+  ///
+  /// @tparam V The type of data expected.
+  template <typename V>
+  const V* get_input_value(int index) const {
+    const AbstractValue* value = get_abstract_input(index);
+    if (value == nullptr) {
+      return nullptr;
+    }
+    return &(value->GetValue<V>());
+  }
 
   virtual const State<T>& get_state() const = 0;
 

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -24,13 +24,13 @@ template <typename T>
 struct DiagramOutput : public SystemOutput<T> {
   int get_num_ports() const override { return ports_.size(); }
 
-  OutputPort<T>* get_mutable_port(int index) override { return ports_[index]; }
+  OutputPort* get_mutable_port(int index) override { return ports_[index]; }
 
-  const OutputPort<T>& get_port(int index) const override {
+  const OutputPort& get_port(int index) const override {
     return *ports_[index];
   }
 
-  std::vector<OutputPort<T>*>* get_mutable_ports() { return &ports_; }
+  std::vector<OutputPort*>* get_mutable_ports() { return &ports_; }
 
  protected:
   // Returns a clone that has the same number of output ports, set to nullptr.
@@ -41,7 +41,7 @@ struct DiagramOutput : public SystemOutput<T> {
   }
 
  private:
-  std::vector<OutputPort<T>*> ports_;
+  std::vector<OutputPort*> ports_;
 };
 
 /// Diagram is a System composed of one or more constituent Systems, arranged

--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -75,7 +75,7 @@ class DiagramContext : public ContextBase<T> {
     if (src_port_index < 0 || src_port_index >= src_ports->get_num_ports()) {
       throw std::out_of_range("Source port out of range.");
     }
-    OutputPort<T>* output_port = src_ports->get_mutable_port(src_port_index);
+    OutputPort* output_port = src_ports->get_mutable_port(src_port_index);
 
     // Validate, construct, and install the destination port.
     SystemIndex dest_system_index = dest.first;
@@ -85,7 +85,7 @@ class DiagramContext : public ContextBase<T> {
         dest_port_index >= dest_context->get_num_input_ports()) {
       throw std::out_of_range("Destination port out of range.");
     }
-    auto input_port = std::make_unique<DependentInputPort<T>>(output_port);
+    auto input_port = std::make_unique<DependentInputPort>(output_port);
     dest_context->SetInputPort(dest_port_index, std::move(input_port));
 
     // Remember the graph structure. We need it in DoClone().
@@ -148,7 +148,7 @@ class DiagramContext : public ContextBase<T> {
 
   int get_num_input_ports() const override { return input_ids_.size(); }
 
-  void SetInputPort(int index, std::unique_ptr<InputPort<T>> port) override {
+  void SetInputPort(int index, std::unique_ptr<InputPort> port) override {
     if (index < 0 || index >= get_num_input_ports()) {
       throw std::out_of_range("Input port out of range.");
     }
@@ -168,11 +168,19 @@ class DiagramContext : public ContextBase<T> {
     const PortIdentifier& id = input_ids_[index];
     SystemIndex system_index = id.first;
     PortIndex port_index = id.second;
-    const auto it = contexts_.find(system_index);
-    if (it == contexts_.end()) {
-      return nullptr;
+    const ContextBase<T>* subsystem_context = GetSubsystemContext(system_index);
+    return subsystem_context->get_vector_input(port_index);
+  }
+
+  const AbstractValue* get_abstract_input(int index) const override {
+    if (index >= get_num_input_ports()) {
+      throw std::out_of_range("Input port out of range.");
     }
-    return it->second->get_vector_input(port_index);
+    const PortIdentifier& id = input_ids_[index];
+    SystemIndex system_index = id.first;
+    PortIndex port_index = id.second;
+    const ContextBase<T>* subsystem_context = GetSubsystemContext(system_index);
+    return subsystem_context->get_abstract_input(port_index);
   }
 
   const State<T>& get_state() const override { return state_; }

--- a/drake/systems/framework/primitives/CMakeLists.txt
+++ b/drake/systems/framework/primitives/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 drake_install_headers(
   adder.h
+  constant_value_source.h
+  constant_value_source-inl.h
   constant_vector_source.h
   gain.h
   gain-inl.h

--- a/drake/systems/framework/primitives/adder.cc
+++ b/drake/systems/framework/primitives/adder.cc
@@ -22,16 +22,10 @@ Adder<T>::Adder(int num_inputs, int length) {
 template <typename T>
 void Adder<T>::EvalOutput(const ContextBase<T>& context,
                           SystemOutput<T>* output) const {
-  // Checks on the output structure are assertions, not exceptions,
-  // since failures would reflect a bug in the Adder implementation, not
-  // user error setting up the system graph. They do not require unit test
-  // coverage, and should not run in release builds.
-
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
-  VectorBase<T>* output_vector =
-      output->get_mutable_port(0)->GetMutableVectorData();
+  VectorBase<T>* output_vector = output->GetMutableVectorData(0);
 
   // Zeroes the output.
   const int n = output_vector->get_value().rows();

--- a/drake/systems/framework/primitives/constant_value_source-inl.h
+++ b/drake/systems/framework/primitives/constant_value_source-inl.h
@@ -1,0 +1,43 @@
+#pragma once
+
+/// @file
+/// Template method implementations for constant_value_source.h.
+/// Most users should only include that file, not this one.
+/// For background, see http://drake.mit.edu/cxx_inl.html.
+
+#include "drake/systems/framework/primitives/constant_value_source.h"
+
+#include <stdexcept>
+#include <string>
+
+#include "drake/common/drake_assert.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+ConstantValueSource<T>::ConstantValueSource(
+    std::unique_ptr<AbstractValue> value)
+    : source_value_(std::move(value)) {
+  this->DeclareAbstractOutputPort(kInheritedSampling);
+}
+
+template <typename T>
+std::unique_ptr<SystemOutput<T>> ConstantValueSource<T>::AllocateOutput(
+    const ContextBase<T>& context) const {
+  std::unique_ptr<LeafSystemOutput<T>> output(new LeafSystemOutput<T>);
+  output->add_port(source_value_->Clone());
+  return std::unique_ptr<SystemOutput<T>>(output.release());
+}
+
+template <typename T>
+void ConstantValueSource<T>::EvalOutput(const ContextBase<T>& context,
+                                        SystemOutput<T>* output) const {
+  DRAKE_ASSERT(output->get_num_ports() == 1);
+  AbstractValue* output_data = output->GetMutableData(0);
+  *output_data = *source_value_;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/constant_value_source.cc
+++ b/drake/systems/framework/primitives/constant_value_source.cc
@@ -1,0 +1,10 @@
+#include "drake/systems/framework/primitives/constant_value_source-inl.h"
+
+namespace drake {
+namespace systems {
+
+// Explicitly instantiates on the most common scalar types.
+template class DRAKESYSTEMFRAMEWORK_EXPORT ConstantValueSource<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/constant_value_source.h
+++ b/drake/systems/framework/primitives/constant_value_source.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "drake/systems/framework/context_base.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+
+/// A source block that always outputs a constant value.
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+template <typename T>
+class ConstantValueSource : public LeafSystem<T> {
+ public:
+  /// @p value The constant value to emit.
+  explicit ConstantValueSource(std::unique_ptr<AbstractValue> value);
+
+  std::unique_ptr<SystemOutput<T>> AllocateOutput(
+      const ContextBase<T>& context) const override;
+
+  void EvalOutput(const ContextBase<T>& context,
+                  SystemOutput<T>* output) const override;
+
+ private:
+  // TODO(david-german-tri): move source_value_ to the system's parameters.
+  const std::unique_ptr<AbstractValue> source_value_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/constant_vector_source.cc
+++ b/drake/systems/framework/primitives/constant_vector_source.cc
@@ -10,28 +10,22 @@ namespace systems {
 
 template <typename T>
 ConstantVectorSource<T>::ConstantVectorSource(
-    const Eigen::Ref<const VectorX<T>>& source_value) :
-    source_value_(source_value) {
-  this->DeclareOutputPort(
-      kVectorValued, source_value.rows(), kContinuousSampling);
+    const Eigen::Ref<const VectorX<T>>& source_value)
+    : source_value_(source_value) {
+  this->DeclareOutputPort(kVectorValued, source_value.rows(),
+                          kContinuousSampling);
 }
 
 template <typename T>
 void ConstantVectorSource<T>::EvalOutput(const ContextBase<T>& context,
                                          SystemOutput<T>* output) const {
-  // Checks on the output structure are assertions, not exceptions, since
-  // failures would reflect a bug in the ConstantVectorSource implementation,
-  // not user error setting up the system graph. They do not require unit test
-  // coverage, and should not run in release builds.
-
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   // TODO(amcastro-tri): Solve #3140 so that the next line reads:
   // auto& output_vector = this->get_output_vector(context, 0);
   // where output_vector will be an Eigen expression.
-  VectorBase<T>* output_vector =
-      output->get_mutable_port(0)->GetMutableVectorData();
+  VectorBase<T>* output_vector = output->GetMutableVectorData(0);
 
   // TODO(amcastro-tri): Solve #3140 so that the Eigen output_vector can be
   // accessed like so:

--- a/drake/systems/framework/primitives/gain-inl.h
+++ b/drake/systems/framework/primitives/gain-inl.h
@@ -19,7 +19,8 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-Gain<T>::Gain(const T& k, int length) : gain_(k) {
+Gain<T>::Gain(const T& k, int length)
+    : gain_(k) {
   // TODO(amcastro-tri): remove the length parameter from the constructor once
   // #3109 supporting automatic lengths is resolved.
   this->DeclareInputPort(kVectorValued, length, kContinuousSampling);
@@ -29,12 +30,6 @@ Gain<T>::Gain(const T& k, int length) : gain_(k) {
 template <typename T>
 void Gain<T>::EvalOutput(const ContextBase<T>& context,
                           SystemOutput<T>* output) const {
-  // Checks that the single output port has the correct length.
-  // Checks on the output structure are assertions, not exceptions,
-  // since failures would reflect a bug in the Gain implementation, not
-  // user error setting up the system graph. They do not require unit test
-  // coverage, and should not run in release builds.
-
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
@@ -43,9 +38,7 @@ void Gain<T>::EvalOutput(const ContextBase<T>& context,
   // auto& input_vector = System<T>::get_input_vector(context, 0);
   // where the return is an Eigen expression.
   const VectorBase<T>* input_vector = context.get_vector_input(0);
-
-  VectorBase<T>* output_vector =
-      output->get_mutable_port(0)->GetMutableVectorData();
+  VectorBase<T>* output_vector = output->GetMutableVectorData(0);
 
   // TODO(amcastro-tri): Solve #3140 so that we can readily access the Eigen
   // vector like so:

--- a/drake/systems/framework/primitives/integrator.cc
+++ b/drake/systems/framework/primitives/integrator.cc
@@ -54,8 +54,7 @@ void Integrator<T>::EvalOutput(const ContextBase<T>& context,
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
-  VectorBase<T>* output_port =
-      output->get_mutable_port(0)->GetMutableVectorData();
+  VectorBase<T>* output_port = output->GetMutableVectorData(0);
 
   // TODO(david-german-tri): Remove this copy by allowing output ports to be
   // mere pointers to state variables (or cache lines).

--- a/drake/systems/framework/primitives/pass_through-inl.h
+++ b/drake/systems/framework/primitives/pass_through-inl.h
@@ -23,6 +23,7 @@ PassThrough<T>::PassThrough(int length) {
   // TODO(amcastro-tri): remove the length parameter from the constructor once
   // #3109 supporting automatic lengths is resolved.
   this->DeclareInputPort(kVectorValued, length, kInheritedSampling);
+  // TODO(david-german-tri): Provide a way to infer the type.
   this->DeclareOutputPort(kVectorValued, length, kInheritedSampling);
 }
 
@@ -32,8 +33,7 @@ void PassThrough<T>::EvalOutput(const ContextBase<T>& context,
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
-  VectorBase<T>* output_vector =
-      output->get_mutable_port(0)->GetMutableVectorData();
+  VectorBase<T>* output_vector = output->GetMutableVectorData(0);
 
   // TODO(amcastro-tri): Solve #3140 so that the next line reads:
   // auto& input_vector = System<T>::get_input_vector(context, 0);

--- a/drake/systems/framework/primitives/test/CMakeLists.txt
+++ b/drake/systems/framework/primitives/test/CMakeLists.txt
@@ -14,6 +14,11 @@ target_link_libraries(integrator_test
         drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
 add_test(NAME integrator_test COMMAND integrator_test)
 
+add_executable(constant_value_source_test constant_value_source_test.cc)
+target_link_libraries(constant_value_source_test
+        drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
+add_test(NAME constant_value_source_test COMMAND constant_value_source_test)
+
 add_executable(constant_vector_source_test constant_vector_source_test.cc)
 target_link_libraries(constant_vector_source_test
         drakeSystemFramework ${GTEST_BOTH_LIBRARIES})

--- a/drake/systems/framework/primitives/test/adder_test.cc
+++ b/drake/systems/framework/primitives/test/adder_test.cc
@@ -26,9 +26,9 @@ class AdderTest : public ::testing::Test {
     input1_.reset(new BasicVector<double>(3 /* length */));
   }
 
-  static std::unique_ptr<FreestandingInputPort<double>> MakeInput(
+  static std::unique_ptr<FreestandingInputPort> MakeInput(
       std::unique_ptr<BasicVector<double>> data) {
-    return make_unique<FreestandingInputPort<double>>(std::move(data));
+    return make_unique<FreestandingInputPort>(std::move(data));
   }
 
   std::unique_ptr<System<double>> adder_;
@@ -70,8 +70,7 @@ TEST_F(AdderTest, AddTwoVectors) {
 
   ASSERT_EQ(1, output_->get_num_ports());
   const BasicVector<double>* output_port =
-      dynamic_cast<const BasicVector<double>*>(
-          output_->get_port(0).get_vector_data());
+      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
   ASSERT_NE(nullptr, output_port);
   Eigen::Vector3d expected;
   expected << 5, 7, 9;

--- a/drake/systems/framework/primitives/test/constant_value_source_test.cc
+++ b/drake/systems/framework/primitives/test/constant_value_source_test.cc
@@ -1,0 +1,63 @@
+#include "drake/systems/framework/primitives/constant_value_source.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "drake/systems/framework/system_input.h"
+#include "drake/systems/framework/value.h"
+
+#include "gtest/gtest.h"
+
+using Eigen::Matrix;
+using std::make_unique;
+
+namespace drake {
+namespace systems {
+namespace {
+
+class ConstantValueSourceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::unique_ptr<AbstractValue> value(new Value<std::string>("foo"));
+    source_ = make_unique<ConstantValueSource<double>>(std::move(value));
+    context_ = source_->CreateDefaultContext();
+    output_ = source_->AllocateOutput(*context_);
+    input_ = make_unique<BasicVector<double>>(3 /* length */);
+  }
+
+  static std::unique_ptr<FreestandingInputPort> MakeInput(
+      std::unique_ptr<BasicVector<double>> data) {
+    return make_unique<FreestandingInputPort>(std::move(data));
+  }
+
+  std::unique_ptr<System<double>> source_;
+  std::unique_ptr<ContextBase<double>> context_;
+  std::unique_ptr<SystemOutput<double>> output_;
+  std::unique_ptr<BasicVector<double>> input_;
+};
+
+TEST_F(ConstantValueSourceTest, Output) {
+  ASSERT_EQ(source_->get_num_input_ports(), context_->get_num_input_ports());
+  ASSERT_EQ(source_->get_num_output_ports(), output_->get_num_ports());
+
+  source_->EvalOutput(*context_, output_.get());
+
+  EXPECT_EQ("foo",
+            output_->get_port(0).get_abstract_data()->GetValue<std::string>());
+}
+
+// Tests that inputs cannot be set for a ConstantValueSource.
+TEST_F(ConstantValueSourceTest, ShouldNotBePossibleToConnectInputs) {
+  EXPECT_THROW(context_->SetInputPort(0, MakeInput(std::move(input_))),
+               std::out_of_range);
+}
+
+// Tests that ConstantValueSource allocates no state variables in the context_.
+TEST_F(ConstantValueSourceTest, ConstantValueSourceIsStateless) {
+  EXPECT_EQ(nullptr, context_->get_state().continuous_state);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/test/constant_vector_source_test.cc
+++ b/drake/systems/framework/primitives/test/constant_vector_source_test.cc
@@ -25,11 +25,9 @@ class ConstantVectorSourceTest : public ::testing::Test {
     input_ = make_unique<BasicVector<double>>(3 /* length */);
   }
 
-  // TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
-  // the input of the ConstantVectorSource system.
-  static std::unique_ptr<FreestandingInputPort<double>> MakeInput(
+  static std::unique_ptr<FreestandingInputPort> MakeInput(
       std::unique_ptr<BasicVector<double>> data) {
-    return make_unique<FreestandingInputPort<double>>(std::move(data));
+    return make_unique<FreestandingInputPort>(std::move(data));
   }
 
   const Matrix<double, 2, 1, Eigen::DontAlign> kConstantVectorSource{2.0, 1.5};
@@ -53,11 +51,10 @@ TEST_F(ConstantVectorSourceTest, OutputTest) {
   // auto& source_->get_output_vector(context, 0);
   // to directly get an Eigen expression.
   const BasicVector<double>* output_vector =
-      dynamic_cast<const BasicVector<double>*>(
-          output_->get_port(0).get_vector_data());
+      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
   ASSERT_NE(nullptr, output_vector);
-  EXPECT_TRUE(kConstantVectorSource.isApprox(output_vector->get_value(),
-                                        Eigen::NumTraits<double>::epsilon()));
+  EXPECT_TRUE(kConstantVectorSource.isApprox(
+      output_vector->get_value(), Eigen::NumTraits<double>::epsilon()));
 }
 
 // Tests that inputs cannot be set for a ConstantVectorSource.

--- a/drake/systems/framework/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/gain_scalartype_test.cc
@@ -23,10 +23,10 @@ namespace {
 
 // TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
 // the input of the Gain system.
-template<class T>
-std::unique_ptr<FreestandingInputPort<T>> MakeInput(
+template <class T>
+std::unique_ptr<FreestandingInputPort> MakeInput(
     std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort<T>>(std::move(data));
+  return make_unique<FreestandingInputPort>(std::move(data));
 }
 
 // Tests the ability to take derivatives of the output with respect to some
@@ -69,8 +69,8 @@ GTEST_TEST(GainScalarTypeTest, AutoDiff) {
 
   ASSERT_EQ(1, output->get_num_ports());
   const auto& output_vector =
-      dynamic_cast<const BasicVector<T> *>(
-          output->get_port(0).get_vector_data())->get_value();
+      dynamic_cast<const BasicVector<T>*>(output->get_vector_data(0))
+          ->get_value();
 
   // The expected output value is the gain times the input vector.
   VectorX<T> expected = kGain * input_vector;

--- a/drake/systems/framework/primitives/test/gain_test.cc
+++ b/drake/systems/framework/primitives/test/gain_test.cc
@@ -23,10 +23,10 @@ namespace {
 
 // TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
 // the input of the Gain system.
-template<class T>
-std::unique_ptr<FreestandingInputPort<T>> MakeInput(
+template <class T>
+std::unique_ptr<FreestandingInputPort> MakeInput(
     std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort<T>>(std::move(data));
+  return make_unique<FreestandingInputPort>(std::move(data));
 }
 
 class GainTest : public ::testing::Test {
@@ -65,8 +65,7 @@ TEST_F(GainTest, VectorThroughGainSystem) {
   ASSERT_EQ(1, output_->get_num_ports());
   ASSERT_EQ(1, gain_->get_num_output_ports());
   const BasicVector<double>* output_vector =
-      dynamic_cast<const BasicVector<double>*>(
-          output_->get_port(0).get_vector_data());
+      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
   ASSERT_NE(nullptr, output_vector);
   Eigen::Vector3d expected = kGain_ * input_vector;
   EXPECT_EQ(expected, output_vector->get_value());

--- a/drake/systems/framework/primitives/test/integrator_test.cc
+++ b/drake/systems/framework/primitives/test/integrator_test.cc
@@ -34,10 +34,10 @@ class IntegratorTest : public ::testing::Test {
     xc->get_mutable_state()->SetFromVector(Eigen::VectorXd::Zero(kLength));
   }
 
-  static std::unique_ptr<FreestandingInputPort<double>> MakeInput(
+  static std::unique_ptr<FreestandingInputPort> MakeInput(
       std::unique_ptr<BasicVector<double>> data) {
-    return std::unique_ptr<FreestandingInputPort<double>>(
-        new FreestandingInputPort<double>(std::move(data)));
+    return std::unique_ptr<FreestandingInputPort>(
+        new FreestandingInputPort(std::move(data)));
   }
 
   ContinuousState<double>* continuous_state() {
@@ -78,8 +78,7 @@ TEST_F(IntegratorTest, Output) {
 
   ASSERT_EQ(1, output_->get_num_ports());
   const BasicVector<double>* output_port =
-      dynamic_cast<const BasicVector<double>*>(
-          output_->get_port(0).get_vector_data());
+      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
   ASSERT_NE(nullptr, output_port);
 
   Eigen::Vector3d expected;

--- a/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
@@ -23,9 +23,9 @@ namespace {
 // TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
 // the input of the PassThrough system.
 template<class T>
-std::unique_ptr<FreestandingInputPort<T>> MakeInput(
+std::unique_ptr<FreestandingInputPort> MakeInput(
     std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort<T>>(std::move(data));
+  return make_unique<FreestandingInputPort>(std::move(data));
 }
 
 // Tests the ability to take derivatives of the output with respect to
@@ -58,9 +58,8 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
   buffer->EvalOutput(*context, output.get());
 
   ASSERT_EQ(1, output->get_num_ports());
-  const auto& output_vector =
-      dynamic_cast<const BasicVector<T>*>(
-          output->get_port(0).get_vector_data())->get_value();
+  const auto& output_vector = dynamic_cast<const BasicVector<T>*>(
+      output->get_vector_data(0))->get_value();
 
   // The expected output value equals the input.
   Vector3<T> expected;

--- a/drake/systems/framework/primitives/test/pass_through_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_test.cc
@@ -21,9 +21,9 @@ namespace {
 // TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
 // the input of the PassThrough system.
 template<class T>
-std::unique_ptr<FreestandingInputPort<T>> MakeInput(
+std::unique_ptr<FreestandingInputPort> MakeInput(
     std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort<T>>(std::move(data));
+  return make_unique<FreestandingInputPort>(std::move(data));
 }
 
 class PassThroughTest : public ::testing::Test {
@@ -56,8 +56,7 @@ TEST_F(PassThroughTest, VectorThroughPassThroughSystem) {
   // TODO(amcastro-tri): Check with buffer_->get_num_output_ports() after #3097.
   ASSERT_EQ(1, output_->get_num_ports());
   const BasicVector<double>* output_vector =
-      dynamic_cast<const BasicVector<double>*>(
-          output_->get_port(0).get_vector_data());
+      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
   ASSERT_NE(nullptr, output_vector);
   EXPECT_EQ(input_vector, output_vector->get_value());
 }

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -83,8 +83,7 @@ class System {
       // TODO(amcastro-tri): add appropriate checks for kAbstractValued ports
       // once abstract ports are implemented in 3164.
       if (get_output_port(i).get_data_type() == kVectorValued) {
-        const VectorBase<T>* output_vector =
-            output->get_port(i).get_vector_data();
+        const VectorBase<T>* output_vector = output->get_vector_data(i);
         DRAKE_THROW_UNLESS(output_vector != nullptr);
         DRAKE_THROW_UNLESS(output_vector->get_value().rows() ==
                            get_output_port(i).get_size());
@@ -254,7 +253,13 @@ class System {
   /// to the input topology.
   void DeclareInputPort(PortDataType type, int size, SamplingSpec sampling) {
     input_ports_.emplace_back(this, kInputPort, input_ports_.size(),
-                                 kVectorValued, size, sampling);
+                              kVectorValued, size, sampling);
+  }
+
+  /// Adds an abstract-valued port with the specified @p sampling to the
+  /// input topology.
+  void DeclareAbstractInputPort(SamplingSpec sampling) {
+    DeclareInputPort(kAbstractValued, 0 /* size */, sampling);
   }
 
   /// Adds a port with the specified @p descriptor to the output topology.
@@ -269,8 +274,15 @@ class System {
   /// to the output topology.
   void DeclareOutputPort(PortDataType type, int size, SamplingSpec sampling) {
     output_ports_.emplace_back(this, kOutputPort, output_ports_.size(),
-                                  kVectorValued, size, sampling);
+                               kVectorValued, size, sampling);
   }
+
+  /// Adds an abstract-valued port with the specified @p sampling to the
+  /// output topology.
+  void DeclareAbstractOutputPort(SamplingSpec sampling) {
+    DeclareOutputPort(kAbstractValued, 0 /* size */, sampling);
+  }
+
 
  private:
   // SystemInterface objects are neither copyable nor moveable.

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/value.h"
 #include "drake/systems/framework/vector_base.h"
 
 namespace drake {
@@ -14,9 +15,6 @@ namespace systems {
 /// The InputPort describes a single input to a System. Users should not
 /// subclass InputPort: all InputPorts are either DependentInputPorts or
 /// FreestandingInputPorts.
-///
-/// @tparam T The type of the input port. Must be a valid Eigen scalar.
-template <typename T>
 class InputPort : public OutputPortListenerInterface {
  public:
   ~InputPort() override {}
@@ -26,10 +24,19 @@ class InputPort : public OutputPortListenerInterface {
   /// that data.
   virtual int64_t get_version() const = 0;
 
+  /// Returns the data on this port, or nullptr if this port is not connected.
+  const AbstractValue* get_abstract_data() const {
+    return get_output_port()->get_abstract_data();
+  }
+
   /// Returns the vector data on this port, or nullptr if this port is not
-  /// vector-valued or not connected. Implementations must ensure that
-  /// get_vector_data is O(1) and initiates no substantive computation.
-  virtual const VectorBase<T>* get_vector_data() const = 0;
+  /// connected. Throws std::bad_cast if the port is not vector-valued.
+  ///
+  /// @tparam T The type of the input port. Must be a valid Eigen scalar.
+  template <typename T>
+  const VectorBase<T>* get_vector_data() const {
+    return get_output_port()->get_vector_data<T>();
+  }
 
   /// Registers @p callback to be called whenever the value of get_version
   /// changes. The callback should invalidate data that depends on the value
@@ -49,6 +56,8 @@ class InputPort : public OutputPortListenerInterface {
  protected:
   InputPort() {}
 
+  virtual const OutputPort* get_output_port() const = 0;
+
  private:
   std::function<void()> invalidation_callback_ = nullptr;
 };
@@ -56,14 +65,11 @@ class InputPort : public OutputPortListenerInterface {
 /// The DependentInputPort wraps a pointer to the OutputPort of a System for use
 /// as an input to another System. Many DependentInputPorts may wrap a single
 /// OutputPort.
-///
-/// @tparam T The type of the input port. Must be a valid Eigen scalar.
-template <typename T>
-class DependentInputPort : public InputPort<T> {
+class DependentInputPort : public InputPort {
  public:
   /// Creates an input port connected to the given @p output_port, which
   /// must not be nullptr. The output port must outlive this input port.
-  explicit DependentInputPort(OutputPort<T>* output_port)
+  explicit DependentInputPort(OutputPort* output_port)
       : output_port_(output_port) {
     output_port_->add_dependent(this);
   }
@@ -74,9 +80,8 @@ class DependentInputPort : public InputPort<T> {
   /// Returns the value version of the connected output port.
   int64_t get_version() const override { return output_port_->get_version(); }
 
-  const VectorBase<T>* get_vector_data() const override {
-    return output_port_->get_vector_data();
-  }
+ protected:
+  const OutputPort* get_output_port() const override { return output_port_; }
 
  private:
   // DependentInputPort objects are neither copyable nor moveable.
@@ -85,21 +90,38 @@ class DependentInputPort : public InputPort<T> {
   DependentInputPort(DependentInputPort&& other) = delete;
   DependentInputPort& operator=(DependentInputPort&& other) = delete;
 
-  OutputPort<T>* output_port_;
+  OutputPort* output_port_;
 };
 
 /// The FreestandingInputPort encapsulates a vector of data for use as an input
 /// to a System.
-///
-/// @tparam T The type of the input port. Must be a valid Eigen scalar.
-template <typename T>
-class FreestandingInputPort : public InputPort<T> {
+class FreestandingInputPort : public InputPort {
  public:
-  /// Constructs a continuous FreestandingInputPort.
-  /// Takes ownership of @p vector_data.
-  explicit FreestandingInputPort(
-      std::unique_ptr<VectorBase<T>> vector_data)
-      : output_port_(std::move(vector_data)) {
+  /// Constructs a vector-valued FreestandingInputPort.
+  /// Takes ownership of @p vec.
+  ///
+  /// @tparam T The type of the vector data. Must be a valid Eigen scalar.
+  /// @tparam V The type of @p vec itself. Must implement VectorBase<T>.
+  template <template <typename T> class V, typename T>
+  explicit FreestandingInputPort(std::unique_ptr<V<T>> vec)
+      : output_port_(std::move(vec)) {
+    output_port_.add_dependent(this);
+  }
+
+  /// Constructs an abstract-valued FreestandingInputPort.
+  /// Takes ownership of @p data.
+  explicit FreestandingInputPort(std::unique_ptr<AbstractValue> data)
+      : output_port_(std::move(data)) {
+    output_port_.add_dependent(this);
+  }
+
+  /// Constructs an abstract-valued FreestandingInputPort.
+  /// Takes ownership of @p data.
+  ///
+  /// @tparam T The type of the data.
+  template <typename T>
+  explicit FreestandingInputPort(std::unique_ptr<Value<T>> data)
+      : output_port_(std::move(data)) {
     output_port_.add_dependent(this);
   }
 
@@ -108,10 +130,6 @@ class FreestandingInputPort : public InputPort<T> {
   /// Returns a positive and monotonically increasing number that is guaranteed
   /// to change whenever GetMutableVectorData is called.
   int64_t get_version() const override { return output_port_.get_version(); }
-
-  const VectorBase<T>* get_vector_data() const override {
-    return output_port_.get_vector_data();
-  }
 
   /// Returns a pointer to the data inside this InputPort, and updates the
   /// version so that Contexts depending on this InputPort know to invalidate
@@ -122,9 +140,26 @@ class FreestandingInputPort : public InputPort<T> {
   /// particular, callers MUST NOT write on the returned pointer if there is any
   /// possibility this FreestandingInputPort has been accessed since the last
   /// time this method was called.
+  AbstractValue* GetMutableData() { return output_port_.GetMutableData(); }
+
+  /// Returns a pointer to the data inside this InputPort, and updates the
+  /// version so that Contexts depending on this InputPort know to invalidate
+  /// their caches. Throws std::bad_cast if the data is not vector data.
+  ///
+  /// To ensure invalidation notifications are delivered, callers should
+  /// call this method every time they wish to update the stored value.  In
+  /// particular, callers MUST NOT write on the returned pointer if there is any
+  /// possibility this FreestandingInputPort has been accessed since the last
+  /// time this method was called.
+  ///
+  /// @tparam T The type of the input port. Must be a valid Eigen scalar.
+  template <typename T>
   VectorBase<T>* GetMutableVectorData() {
-    return output_port_.GetMutableVectorData();
+    return output_port_.GetMutableVectorData<T>();
   }
+
+ protected:
+  const OutputPort* get_output_port() const override { return &output_port_; }
 
  private:
   // FreestandingInputPort objects are neither copyable nor moveable.
@@ -133,7 +168,7 @@ class FreestandingInputPort : public InputPort<T> {
   FreestandingInputPort(FreestandingInputPort&& other) = delete;
   FreestandingInputPort& operator=(FreestandingInputPort&& other) = delete;
 
-  OutputPort<T> output_port_;
+  OutputPort output_port_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/test/context_test.cc
+++ b/drake/systems/framework/test/context_test.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -10,6 +11,7 @@
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
+#include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
@@ -33,8 +35,8 @@ class ContextTest : public ::testing::Test {
     for (int i = 0; i < kNumInputPorts; ++i) {
       std::unique_ptr<VectorBase<double>> port_data(
           new BasicVector<double>(kInputSize[i]));
-      std::unique_ptr<FreestandingInputPort<double>> port(
-          new FreestandingInputPort<double>(std::move(port_data)));
+      std::unique_ptr<FreestandingInputPort> port(
+          new FreestandingInputPort(std::move(port_data)));
       context_.SetInputPort(i, std::move(port));
     }
 
@@ -74,8 +76,8 @@ TEST_F(ContextTest, GetVectorInput) {
   // Add input port 0 to the context, but leave input port 1 uninitialized.
   std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
   vec->get_mutable_value() << 5, 6;
-  std::unique_ptr<FreestandingInputPort<int>> port(
-      new FreestandingInputPort<int>(std::move(vec)));
+  std::unique_ptr<FreestandingInputPort> port(
+      new FreestandingInputPort(std::move(vec)));
   context.SetInputPort(0, std::move(port));
 
   // Test that port 0 is retrievable.
@@ -85,9 +87,23 @@ TEST_F(ContextTest, GetVectorInput) {
 
   // Test that port 1 is nullptr.
   EXPECT_EQ(nullptr, context.get_vector_input(1));
+}
 
-  // Test that out-of-bounds ports throw an exception.
-  EXPECT_THROW(context.get_vector_input(2), std::out_of_range);
+TEST_F(ContextTest, GetAbstractInput) {
+  Context<int> context;
+  context.SetNumInputPorts(2);
+
+  // Add input port 0 to the context, but leave input port 1 uninitialized.
+  std::unique_ptr<AbstractValue> value(new Value<std::string>("foo"));
+  std::unique_ptr<FreestandingInputPort> port(
+      new FreestandingInputPort(std::move(value)));
+  context.SetInputPort(0, std::move(port));
+
+  // Test that port 0 is retrievable.
+  EXPECT_EQ("foo", *context.get_input_value<std::string>(0));
+
+  // Test that port 1 is nullptr.
+  EXPECT_EQ(nullptr, context.get_abstract_input(1));
 }
 
 TEST_F(ContextTest, Clone) {

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -44,8 +44,7 @@ class DiagramContextTest : public ::testing::Test {
     context_->ExportInput({1 /* adder1_ */, 0 /* port 0 */});
 
     context_->MakeState();
-    ContinuousState<double>* xc =
-        context_->get_state().continuous_state.get();
+    ContinuousState<double>* xc = context_->get_state().continuous_state.get();
     xc->get_mutable_state()->SetAtIndex(0, 42.0);
     xc->get_mutable_state()->SetAtIndex(1, 43.0);
   }
@@ -63,9 +62,9 @@ class DiagramContextTest : public ::testing::Test {
     vec1->get_mutable_value() << 256;
 
     context_->SetInputPort(
-        0, std::make_unique<FreestandingInputPort<double>>(std::move(vec0)));
+        0, std::make_unique<FreestandingInputPort>(std::move(vec0)));
     context_->SetInputPort(
-        1, std::make_unique<FreestandingInputPort<double>>(std::move(vec1)));
+        1, std::make_unique<FreestandingInputPort>(std::move(vec1)));
   }
 
   std::unique_ptr<DiagramContext<double>> context_;
@@ -162,8 +161,7 @@ TEST_F(DiagramContextTest, Clone) {
   EXPECT_EQ(kTime, clone->get_time());
 
   // Verify that the state was copied.
-  ContinuousState<double>* xc =
-      context_->get_state().continuous_state.get();
+  ContinuousState<double>* xc = context_->get_state().continuous_state.get();
 
   EXPECT_EQ(42.0, xc->get_state().GetAtIndex(0));
   EXPECT_EQ(43.0, xc->get_state().GetAtIndex(1));
@@ -182,7 +180,7 @@ TEST_F(DiagramContextTest, Clone) {
   // sys0 output port 0 should be pointer-equal to the VectorBase in
   // sys1 input port 1.
   EXPECT_EQ(clone->GetSubsystemContext(1)->get_vector_input(1),
-            clone->GetSubsystemOutput(0)->get_port(0).get_vector_data());
+            clone->GetSubsystemOutput(0)->get_vector_data(0));
 }
 
 }  // namespace

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -63,26 +63,24 @@ class DiagramTest : public ::testing::Test {
     expected_output1 += expected_output0;       // A + B
 
     const BasicVector<double>* output0 =
-        dynamic_cast<const BasicVector<double>*>(
-            output_->get_port(0).get_vector_data());
+        dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
     ASSERT_NE(nullptr, output0);
     EXPECT_EQ(expected_output0[0], output0->get_value()[0]);
     EXPECT_EQ(expected_output0[1], output0->get_value()[1]);
     EXPECT_EQ(expected_output0[2], output0->get_value()[2]);
 
     const BasicVector<double>* output1 =
-        dynamic_cast<const BasicVector<double>*>(
-            output_->get_port(1).get_vector_data());
+        dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(1));
     ASSERT_NE(nullptr, output1);
     EXPECT_EQ(expected_output1[0], output1->get_value()[0]);
     EXPECT_EQ(expected_output1[1], output1->get_value()[1]);
     EXPECT_EQ(expected_output1[2], output1->get_value()[2]);
   }
 
-  static std::unique_ptr<FreestandingInputPort<double>> MakeInput(
+  static std::unique_ptr<FreestandingInputPort> MakeInput(
       std::unique_ptr<BasicVector<double>> data) {
-    return std::unique_ptr<FreestandingInputPort<double>>(
-        new FreestandingInputPort<double>(std::move(data)));
+    return std::unique_ptr<FreestandingInputPort>(
+        new FreestandingInputPort(std::move(data)));
   }
 
   std::unique_ptr<Diagram<double>> diagram_;
@@ -154,8 +152,8 @@ TEST_F(DiagramTest, Clone) {
 
   Eigen::Vector3d expected_output0;
   expected_output0 << 3 + 8 + 64, 6 + 16 + 128, 9 + 32 + 256;  // B
-  const BasicVector<double>* output0 = dynamic_cast<const BasicVector<double>*>(
-      output_->get_port(0).get_vector_data());
+  const BasicVector<double>* output0 =
+      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
   ASSERT_NE(nullptr, output0);
   EXPECT_EQ(expected_output0[0], output0->get_value()[0]);
   EXPECT_EQ(expected_output0[1], output0->get_value()[1]);
@@ -164,8 +162,8 @@ TEST_F(DiagramTest, Clone) {
   Eigen::Vector3d expected_output1;
   expected_output1 << 3 + 8, 6 + 16, 9 + 32;  // A
   expected_output1 += expected_output0;       // A + B
-  const BasicVector<double>* output1 = dynamic_cast<const BasicVector<double>*>(
-      output_->get_port(1).get_vector_data());
+  const BasicVector<double>* output1 =
+      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(1));
   ASSERT_NE(nullptr, output1);
   EXPECT_EQ(expected_output1[0], output1->get_value()[0]);
   EXPECT_EQ(expected_output1[1], output1->get_value()[1]);

--- a/drake/systems/framework/test/system_input_test.cc
+++ b/drake/systems/framework/test/system_input_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/framework/system_input.h"
 
 #include <memory>
+#include <string>
 
 #include "gtest/gtest.h"
 
@@ -9,34 +10,34 @@
 namespace drake {
 namespace systems {
 
-class FreestandingInputPortTest : public ::testing::Test {
+class FreestandingInputPortVectorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
     vec->get_mutable_value() << 5, 6;
-    port_.reset(new FreestandingInputPort<int>(std::move(vec)));
+    port_.reset(new FreestandingInputPort(std::move(vec)));
     port_->set_invalidation_callback(
-        std::bind(&FreestandingInputPortTest::Invalidate, this));
+        std::bind(&FreestandingInputPortVectorTest::Invalidate, this));
   }
 
-  std::unique_ptr<FreestandingInputPort<int>> port_;
+  std::unique_ptr<FreestandingInputPort> port_;
   int64_t latest_version_ = -1;
 
  private:
   void Invalidate() { latest_version_ = port_->get_version(); }
 };
 
-TEST_F(FreestandingInputPortTest, Access) {
+TEST_F(FreestandingInputPortVectorTest, Access) {
   VectorX<int> expected(2);
   expected << 5, 6;
-  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+  EXPECT_EQ(expected, port_->template get_vector_data<int>()->get_value());
 }
 
 // Tests that changes to the vector data are propagated to the input port
 // that wraps it.
-TEST_F(FreestandingInputPortTest, Mutation) {
+TEST_F(FreestandingInputPortVectorTest, Mutation) {
   EXPECT_EQ(0, port_->get_version());
-  port_->GetMutableVectorData()->get_mutable_value() << 7, 8;
+  port_->template GetMutableVectorData<int>()->get_mutable_value() << 7, 8;
 
   // Check that the version number was incremented.
   EXPECT_EQ(1, port_->get_version());
@@ -44,14 +45,40 @@ TEST_F(FreestandingInputPortTest, Mutation) {
   // Check that the vector contents changed.
   VectorX<int> expected(2);
   expected << 7, 8;
-  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+  EXPECT_EQ(expected, port_->template get_vector_data<int>()->get_value());
 }
 
-// Tests that the single-argument constructor for FreestandingInputPort creates
-// a continuous port.
-TEST_F(FreestandingInputPortTest, ContinouousPort) {
-  std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
-  port_.reset(new FreestandingInputPort<int>(std::move(vec)));
+class FreestandingInputPortAbstractValueTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto value = std::make_unique<Value<std::string>>("foo");
+    port_.reset(new FreestandingInputPort(std::move(value)));
+    port_->set_invalidation_callback(
+        std::bind(&FreestandingInputPortAbstractValueTest::Invalidate, this));
+  }
+
+  std::unique_ptr<FreestandingInputPort> port_;
+  int64_t latest_version_ = -1;
+
+ private:
+  void Invalidate() { latest_version_ = port_->get_version(); }
+};
+
+TEST_F(FreestandingInputPortAbstractValueTest, Access) {
+  EXPECT_EQ("foo", port_->get_abstract_data()->GetValue<std::string>());
+}
+
+// Tests that changes to the vector data are propagated to the input port
+// that wraps it.
+TEST_F(FreestandingInputPortAbstractValueTest, Mutation) {
+  EXPECT_EQ(0, port_->get_version());
+  port_->GetMutableData()->GetMutableValue<std::string>() = "bar";
+
+  // Check that the version number was incremented.
+  EXPECT_EQ(1, port_->get_version());
+
+  // Check that the contents changed.
+  EXPECT_EQ("bar", port_->get_abstract_data()->GetValue<std::string>());
 }
 
 class DependentInputPortTest : public ::testing::Test {
@@ -59,14 +86,14 @@ class DependentInputPortTest : public ::testing::Test {
   void SetUp() override {
     std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
     vec->get_mutable_value() << 5, 6;
-    output_port_.reset(new OutputPort<int>(std::move(vec)));
-    port_.reset(new DependentInputPort<int>(output_port_.get()));
+    output_port_.reset(new OutputPort(std::move(vec)));
+    port_.reset(new DependentInputPort(output_port_.get()));
     port_->set_invalidation_callback(
         std::bind(&DependentInputPortTest::Invalidate, this));
   }
 
-  std::unique_ptr<OutputPort<int>> output_port_;
-  std::unique_ptr<DependentInputPort<int>> port_;
+  std::unique_ptr<OutputPort> output_port_;
+  std::unique_ptr<DependentInputPort> port_;
   int64_t latest_version_ = -1;
 
  private:
@@ -76,14 +103,15 @@ class DependentInputPortTest : public ::testing::Test {
 TEST_F(DependentInputPortTest, Access) {
   VectorX<int> expected(2);
   expected << 5, 6;
-  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+  EXPECT_EQ(expected, port_->template get_vector_data<int>()->get_value());
 }
 
 // Tests that changes on the output port are propagated to the input port that
 // is connected to it.
 TEST_F(DependentInputPortTest, Mutation) {
   EXPECT_EQ(0, port_->get_version());
-  output_port_->GetMutableVectorData()->get_mutable_value() << 7, 8;
+  output_port_->template GetMutableVectorData<int>()->get_mutable_value() << 7,
+      8;
 
   // Check that the version number was incremented.
   EXPECT_EQ(1, port_->get_version());
@@ -94,7 +122,7 @@ TEST_F(DependentInputPortTest, Mutation) {
   // Check that the vector contents changed.
   VectorX<int> expected(2);
   expected << 7, 8;
-  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+  EXPECT_EQ(expected, port_->template get_vector_data<int>()->get_value());
 }
 
 }  // namespace systems

--- a/drake/systems/framework/test/system_output_test.cc
+++ b/drake/systems/framework/test/system_output_test.cc
@@ -1,19 +1,19 @@
 #include "drake/systems/framework/system_output.h"
 
 #include <memory>
+#include <string>
 
 #include "gtest/gtest.h"
 
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
 
 class TestOutputPortListener : public OutputPortListenerInterface {
  public:
-  void Invalidate() override {
-    invalidations_++;
-  };
+  void Invalidate() override { invalidations_++; };
 
   int get_invalidations() { return invalidations_; }
 
@@ -21,26 +21,26 @@ class TestOutputPortListener : public OutputPortListenerInterface {
   int invalidations_ = 0;
 };
 
-class OutputPortTest : public ::testing::Test {
+class OutputPortVectorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
     vec->get_mutable_value() << 5, 6;
-    port_.reset(new OutputPort<int>(std::move(vec)));
+    port_.reset(new OutputPort(std::move(vec)));
   }
 
-  std::unique_ptr<OutputPort<int>> port_;
+  std::unique_ptr<OutputPort> port_;
 };
 
-TEST_F(OutputPortTest, Access) {
+TEST_F(OutputPortVectorTest, Access) {
   VectorX<int> expected(2);
   expected << 5, 6;
-  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+  EXPECT_EQ(expected, port_->template get_vector_data<int>()->get_value());
 }
 
-TEST_F(OutputPortTest, Mutation) {
+TEST_F(OutputPortVectorTest, Mutation) {
   EXPECT_EQ(0, port_->get_version());
-  port_->GetMutableVectorData()->get_mutable_value() << 7, 8;
+  port_->template GetMutableVectorData<int>()->get_mutable_value() << 7, 8;
 
   // Check that the version number was incremented.
   EXPECT_EQ(1, port_->get_version());
@@ -48,40 +48,74 @@ TEST_F(OutputPortTest, Mutation) {
   // Check that the vector contents changed.
   VectorX<int> expected(2);
   expected << 7, 8;
-  EXPECT_EQ(expected, port_->get_vector_data()->get_value());
+  EXPECT_EQ(expected, port_->template get_vector_data<int>()->get_value());
 }
 
 // Tests that a clone of an OutputPort has a deep copy of the data.
-TEST_F(OutputPortTest, Clone) {
+TEST_F(OutputPortVectorTest, Clone) {
   auto clone = port_->Clone();
   // Changes to the original port should not affect the clone.
-  port_->GetMutableVectorData()->get_mutable_value() << 7, 8;
+  port_->template GetMutableVectorData<int>()->get_mutable_value() << 7, 8;
 
   VectorX<int> expected(2);
   expected << 5, 6;
-  EXPECT_EQ(expected, clone->get_vector_data()->get_value());
+  EXPECT_EQ(expected, clone->template get_vector_data<int>()->get_value());
 
   // The type should be preserved.
-  EXPECT_NE(nullptr,
-            dynamic_cast<const BasicVector<int>*>(clone->get_vector_data()));
+  EXPECT_NE(nullptr, dynamic_cast<const BasicVector<int>*>(
+                         clone->template get_vector_data<int>()));
 }
 
 // Tests that listeners are notified when GetMutableVectorData is called.
-TEST_F(OutputPortTest, Listeners) {
+TEST_F(OutputPortVectorTest, Listeners) {
   TestOutputPortListener a, b, c;
   port_->add_dependent(&a);
   port_->add_dependent(&b);
-  port_->GetMutableVectorData();
+  port_->template GetMutableVectorData<int>();
   EXPECT_EQ(1, a.get_invalidations());
   EXPECT_EQ(1, b.get_invalidations());
   EXPECT_EQ(0, c.get_invalidations());
 
   port_->remove_dependent(&a);
   port_->add_dependent(&c);
-  port_->GetMutableVectorData();
+  port_->template GetMutableVectorData<int>();
   EXPECT_EQ(1, a.get_invalidations());
   EXPECT_EQ(2, b.get_invalidations());
   EXPECT_EQ(1, c.get_invalidations());
+}
+
+class OutputPortAbstractValueTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto value = std::make_unique<Value<std::string>>("foo");
+    port_.reset(new OutputPort(std::move(value)));
+  }
+
+  std::unique_ptr<OutputPort> port_;
+};
+
+TEST_F(OutputPortAbstractValueTest, Access) {
+  EXPECT_EQ("foo", port_->get_abstract_data()->GetValue<std::string>());
+}
+
+TEST_F(OutputPortAbstractValueTest, Mutation) {
+  EXPECT_EQ(0, port_->get_version());
+  port_->GetMutableData()->GetMutableValue<std::string>() = "bar";
+
+  // Check that the version number was incremented.
+  EXPECT_EQ(1, port_->get_version());
+
+  // Check that the contents changed.
+  EXPECT_EQ("bar", port_->get_abstract_data()->GetValue<std::string>());
+}
+
+// Tests that a clone of an OutputPort has a deep copy of the data.
+TEST_F(OutputPortAbstractValueTest, Clone) {
+  auto clone = port_->Clone();
+  // Changes to the original port should not affect the clone.
+  clone->GetMutableData()->GetMutableValue<std::string>() = "bar";
+  EXPECT_EQ("bar", clone->get_abstract_data()->GetValue<std::string>());
+  EXPECT_EQ("foo", port_->get_abstract_data()->GetValue<std::string>());
 }
 
 class LeafSystemOutputTest : public ::testing::Test {
@@ -90,14 +124,12 @@ class LeafSystemOutputTest : public ::testing::Test {
     {
       std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
       vec->get_mutable_value() << 5, 25;
-      output_.get_mutable_ports()->emplace_back(
-          new OutputPort<int>(std::move(vec)));
+      output_.get_mutable_ports()->emplace_back(new OutputPort(std::move(vec)));
     }
     {
       std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(3));
       vec->get_mutable_value() << 125, 625, 3125;
-      output_.get_mutable_ports()->emplace_back(
-          new OutputPort<int>(std::move(vec)));
+      output_.get_mutable_ports()->emplace_back(new OutputPort(std::move(vec)));
     }
   }
 
@@ -110,21 +142,21 @@ TEST_F(LeafSystemOutputTest, Clone) {
   std::unique_ptr<SystemOutput<int>> clone = output_.Clone();
 
   {
-    const OutputPort<int>& port = clone->get_port(0);
+    const OutputPort& port = clone->get_port(0);
     VectorX<int> expected(2);
     expected << 5, 25;
-    EXPECT_EQ(expected, port.get_vector_data()->get_value());
-    EXPECT_NE(nullptr,
-              dynamic_cast<const BasicVector<int>*>(port.get_vector_data()));
+    EXPECT_EQ(expected, port.template get_vector_data<int>()->get_value());
+    EXPECT_NE(nullptr, dynamic_cast<const BasicVector<int>*>(
+                           port.template get_vector_data<int>()));
   }
 
   {
-    const OutputPort<int>& port = clone->get_port(1);
+    const OutputPort& port = clone->get_port(1);
     VectorX<int> expected(3);
     expected << 125, 625, 3125;
-    EXPECT_EQ(expected, port.get_vector_data()->get_value());
-    EXPECT_NE(nullptr,
-              dynamic_cast<const BasicVector<int>*>(port.get_vector_data()));
+    EXPECT_EQ(expected, port.template get_vector_data<int>()->get_value());
+    EXPECT_NE(nullptr, dynamic_cast<const BasicVector<int>*>(
+                           port.template get_vector_data<int>()));
   }
 }
 

--- a/drake/systems/framework/test/value_test.cc
+++ b/drake/systems/framework/test/value_test.cc
@@ -3,8 +3,10 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "drake/drakeSystemFramework_export.h"
+#include "drake/systems/framework/basic_vector.h"
 
 #include "gtest/gtest.h"
 
@@ -141,6 +143,36 @@ GTEST_TEST(ValueTest, SubclassOfValueSurvivesClone) {
       dynamic_cast<PrintInterface*>(cloned.get());
   ASSERT_NE(nullptr, printable_erased);
   EXPECT_EQ("5,6", printable_erased->print());
+}
+
+GTEST_TEST(VectorValueTest, Access) {
+  VectorValue<int> value(
+      std::make_unique<BasicVector<int>>(std::vector<int>{1, 2, 3}));
+  EXPECT_EQ(1, value.get_value()->get_value().x());
+  EXPECT_EQ(2, value.get_value()->get_value().y());
+  EXPECT_EQ(3, value.get_value()->get_value().z());
+}
+
+GTEST_TEST(VectorValueTest, CopyConstructor) {
+  VectorValue<int> value(
+      std::make_unique<BasicVector<int>>(std::vector<int>{1, 2, 3}));
+
+  VectorValue<int> other_value(value);
+  EXPECT_EQ(1, other_value.get_value()->get_value().x());
+  EXPECT_EQ(2, other_value.get_value()->get_value().y());
+  EXPECT_EQ(3, other_value.get_value()->get_value().z());
+}
+
+GTEST_TEST(VectorValueTest, AssignmentOperator) {
+  VectorValue<int> value(
+      std::make_unique<BasicVector<int>>(std::vector<int>{1, 2, 3}));
+  VectorValue<int> other_value(
+      std::make_unique<BasicVector<int>>(std::vector<int>{4, 5, 6}));
+
+  value = other_value;
+  EXPECT_EQ(4, value.get_value()->get_value().x());
+  EXPECT_EQ(5, value.get_value()->get_value().y());
+  EXPECT_EQ(6, value.get_value()->get_value().z());
 }
 
 }  // namespace

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -6,6 +6,7 @@
 #include <typeinfo>
 
 #include "drake/drakeSystemFramework_export.h"
+#include "drake/systems/framework/vector_base.h"
 
 namespace drake {
 namespace systems {
@@ -30,6 +31,9 @@ class DRAKESYSTEMFRAMEWORK_EXPORT AbstractValue {
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
   /// In Debug builds, if the types don't match, std::bad_cast will be
   /// thrown.  In Release builds, this is not guaranteed.
+  ///
+  /// TODO(david-german-tri): Once this uses static_cast under the hood in
+  /// Release builds, lower-case it.
   template <typename T>
   const T& GetValue() const {
     return DownCastOrMaybeThrow<T>()->get_value();
@@ -110,6 +114,38 @@ class Value : public AbstractValue {
 
  private:
   T value_;
+};
+
+/// A container class for VectorBase<T>.
+///
+/// @tparam T The type of the vector data. Must be a valid Eigen scalar.
+template <typename T>
+class VectorValue : public Value<VectorBase<T>*> {
+ public:
+  explicit VectorValue(std::unique_ptr<VectorBase<T>> v)
+      : Value<VectorBase<T>*>(v.get()), owned_value_(std::move(v)) {}
+
+  // VectorValues are copyable but not moveable.
+  explicit VectorValue(const VectorValue<T>& other)
+      : Value<VectorBase<T>*>(nullptr),
+        owned_value_(other.get_value()->CloneVector()) {
+    this->set_value(owned_value_.get());
+  }
+
+  VectorValue& operator=(const VectorValue<T>& other) {
+    owned_value_->set_value(other.get_value()->get_value());
+    return *this;
+  }
+
+  explicit VectorValue(Value<T>&& other) = delete;
+  VectorValue& operator=(Value<T>&& other) = delete;
+
+  std::unique_ptr<AbstractValue> Clone() const override {
+    return std::make_unique<VectorValue<T>>(*this);
+  }
+
+ private:
+  std::unique_ptr<VectorBase<T>> owned_value_;
 };
 
 }  // namespace systems

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -14,27 +14,22 @@ using std::make_unique;
 
 LcmSubscriberSystem::LcmSubscriberSystem(
     const std::string& channel,
-    const LcmAndVectorBaseTranslator& translator,
-    ::lcm::LCM* lcm)
+    const LcmAndVectorBaseTranslator& translator, ::lcm::LCM* lcm)
     : channel_(channel),
       translator_(translator),
       basic_vector_(translator_.get_vector_size()) {
   DRAKE_ABORT_UNLESS(lcm);
   // Initializes the communication layer.
-  ::lcm::Subscription* sub = lcm->subscribe(channel_,
-      &LcmSubscriberSystem::HandleMessage, this);
+  ::lcm::Subscription* sub =
+      lcm->subscribe(channel_, &LcmSubscriberSystem::HandleMessage, this);
   sub->setQueueCapacity(1);
 }
 
 LcmSubscriberSystem::LcmSubscriberSystem(
     const std::string& channel,
-    const LcmTranslatorDictionary& translator_dictionary,
-    ::lcm::LCM* lcm)
-    : LcmSubscriberSystem(
-          channel,
-          translator_dictionary.GetTranslator(channel),
-          lcm) {
-}
+    const LcmTranslatorDictionary& translator_dictionary, ::lcm::LCM* lcm)
+    : LcmSubscriberSystem(channel, translator_dictionary.GetTranslator(channel),
+                          lcm) {}
 
 LcmSubscriberSystem::~LcmSubscriberSystem() {}
 
@@ -61,8 +56,7 @@ std::unique_ptr<SystemOutput<double>> LcmSubscriberSystem::AllocateOutput(
       new BasicVector<double>(translator_.get_vector_size()));
 
   // Instantiates an OutputPort with the above BasicVector as the data type.
-  std::unique_ptr<OutputPort<double>> port(
-      new OutputPort<double>(std::move(data)));
+  std::unique_ptr<OutputPort> port(new OutputPort(std::move(data)));
 
   // Stores the above-defined OutputPort in this system output.
   auto output = std::make_unique<LeafSystemOutput<double>>();
@@ -74,8 +68,8 @@ std::unique_ptr<SystemOutput<double>> LcmSubscriberSystem::AllocateOutput(
 
 void LcmSubscriberSystem::EvalOutput(const ContextBase<double>& context,
                                      SystemOutput<double>* output) const {
-  BasicVector<double>& output_vector = dynamic_cast<BasicVector<double>&>(
-      *output->get_mutable_port(0)->GetMutableVectorData());
+  BasicVector<double>& output_vector =
+      dynamic_cast<BasicVector<double>&>(*output->GetMutableVectorData(0));
 
   std::lock_guard<std::mutex> lock(data_mutex_);
   output_vector.set_value(basic_vector_.get_value());

--- a/drake/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/drake/systems/lcm/test/lcm_publisher_system_test.cc
@@ -71,7 +71,7 @@ class MessageSubscriber {
 };
 
 void TestPublisher(::lcm::LCM* lcm, const std::string& channel_name,
-    LcmPublisherSystem* dut) {
+                   LcmPublisherSystem* dut) {
   EXPECT_EQ(dut->get_name(), "LcmPublisherSystem::" + channel_name);
 
   // Instantiates a receiver of lcmt_drake_signal messages.
@@ -102,8 +102,8 @@ void TestPublisher(::lcm::LCM* lcm, const std::string& channel_name,
   // VectorBase. Note that we need to overwrite the original input port
   // created by the LcmPublisherSystem since we do not have write access to its
   // input vector.
-  std::unique_ptr<InputPort<double>> input_port(
-      new FreestandingInputPort<double>(std::move(vector_base)));
+  std::unique_ptr<InputPort> input_port(
+      new FreestandingInputPort(std::move(vector_base)));
 
   context->SetInputPort(kPortNumber, std::move(input_port));
 
@@ -188,8 +188,9 @@ GTEST_TEST(LcmPublisherSystemTest, PublishTestUsingDictionary) {
 
   // Creates a dictionary with one translator.
   LcmTranslatorDictionary dictionary;
-  dictionary.AddEntry(channel_name,
-    std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
+  dictionary.AddEntry(
+      channel_name,
+      std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
 
   EXPECT_TRUE(dictionary.HasTranslator(channel_name));
 

--- a/drake/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/drake/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -63,7 +63,7 @@ class MessagePublisher {
 };
 
 void TestSubscriber(::lcm::LCM* lcm, const std::string& channel_name,
-   LcmSubscriberSystem* dut) {
+                    LcmSubscriberSystem* dut) {
   EXPECT_EQ(dut->get_name(), "LcmSubscriberSystem::" + channel_name);
 
   // Instantiates a publisher of lcmt_drake_signal messages on the LCM network.
@@ -100,7 +100,7 @@ void TestSubscriber(::lcm::LCM* lcm, const std::string& channel_name,
 
     // Gets the output of the LcmSubscriberSystem.
     const drake::systems::VectorBase<double>* vector =
-        output->get_port(0).get_vector_data();
+        output->get_vector_data(0);
 
     // Downcasts the output vector to be a pointer to a BasicVector.
     const BasicVector<double>& basic_vector =
@@ -175,8 +175,9 @@ GTEST_TEST(LcmSubscriberSystemTest, ReceiveTestUsingDictionary) {
 
   // Creates a dictionary with one translator.
   LcmTranslatorDictionary dictionary;
-  dictionary.AddEntry(channel_name,
-    std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
+  dictionary.AddEntry(
+      channel_name,
+      std::make_unique<const TranslatorBetweenLcmtDrakeSignal>(kDim));
 
   EXPECT_TRUE(dictionary.HasTranslator(channel_name));
 


### PR DESCRIPTION
Create ConstantValueSource as an example system that outputs abstract values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3164)
<!-- Reviewable:end -->
