### PR TITLE
Move eigen_matrix_compare from util to common

### DIFF
--- a/drake/common/eigen_matrix_compare.h
+++ b/drake/common/eigen_matrix_compare.h
@@ -4,9 +4,8 @@
 #include <cmath>
 
 namespace drake {
-namespace util {
 
-enum MatrixCompareType { absolute, relative };
+enum class MatrixCompareType { absolute, relative };
 
 /**
  * Compares two matrices to determine whether they are equal to within a certain
@@ -120,5 +119,4 @@ bool CompareMatrices(const Eigen::MatrixBase<DerivedA>& m1,
   return result;
 }
 
-}  // namespace util
 }  // namespace drake

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -23,6 +23,10 @@ add_executable(polynomial_test polynomial_test.cc)
 target_link_libraries(polynomial_test drakeCommon ${GTEST_BOTH_LIBRARIES})
 add_test(NAME polynomial_test COMMAND polynomial_test)
 
+add_executable(eigen_matrix_compare_test eigen_matrix_compare_test.cc)
+target_link_libraries(eigen_matrix_compare_test ${GTEST_BOTH_LIBRARIES})
+add_test(NAME eigen_matrix_compare_test COMMAND eigen_matrix_compare_test)
+
 # Adds "drake_assert.h" unit testing.
 add_executable(drake_assert_test_default drake_assert_test.cc)
 target_link_libraries(drake_assert_test_default drakeCommon ${GTEST_BOTH_LIBRARIES})

--- a/drake/common/test/eigen_matrix_compare_test.cc
+++ b/drake/common/test/eigen_matrix_compare_test.cc
@@ -1,10 +1,7 @@
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "gtest/gtest.h"
 
-using drake::util::MatrixCompareType;
-
 namespace drake {
-namespace util {
 namespace {
 
 // Tests the ability for two identical matrices to be compared.
@@ -143,5 +140,4 @@ GTEST_TEST(MatrixCompareTest, NoMessageParam) {
 }
 
 }  // namespace
-}  // namespace util
 }  // namespace drake

--- a/drake/common/test/polynomial_test.cc
+++ b/drake/common/test/polynomial_test.cc
@@ -7,16 +7,14 @@
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
-using drake::util::MatrixCompareType;
 using Eigen::VectorXd;
 using std::default_random_engine;
 using std::uniform_int_distribution;
 using std::uniform_real_distribution;
 
 namespace drake {
-namespace util {
 namespace {
 
 template <typename CoefficientType>
@@ -375,5 +373,4 @@ GTEST_TEST(PolynomialTest, EvaluatePartial) {
 }
 
 }  // anonymous namespace
-}  // namespace test
 }  // namespace drake

--- a/drake/examples/Acrobot/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Acrobot/test/urdfDynamicsTest.cpp
@@ -1,7 +1,7 @@
 #include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/Acrobot/Acrobot.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/common/eigen_matrix_compare.h"
 #include "gtest/gtest.h"
 
 using drake::RigidBodySystem;

--- a/drake/examples/Acrobot/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Acrobot/test/urdfDynamicsTest.cpp
@@ -1,13 +1,12 @@
 #include "drake/common/drake_path.h"
 #include "drake/examples/Acrobot/Acrobot.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "gtest/gtest.h"
 
 using drake::RigidBodySystem;
 using drake::getRandomVector;
 using drake::GetDrakePath;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace examples {

--- a/drake/examples/Cars/test/simple_car_test.cc
+++ b/drake/examples/Cars/test/simple_car_test.cc
@@ -5,12 +5,12 @@
 
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/examples/Cars/system1_cars_vectors.h"
 #include "drake/systems/Simulation.h"
 #include "drake/systems/cascade_system.h"
 #include "drake/systems/simulation_options.h"
 #include "drake/systems/vector.h"
-#include "drake/common/eigen_matrix_compare.h"
-#include "drake/examples/Cars/system1_cars_vectors.h"
 
 using drake::NullVector;
 using drake::SimulationOptions;

--- a/drake/examples/Cars/test/simple_car_test.cc
+++ b/drake/examples/Cars/test/simple_car_test.cc
@@ -9,10 +9,9 @@
 #include "drake/systems/cascade_system.h"
 #include "drake/systems/simulation_options.h"
 #include "drake/systems/vector.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/Cars/system1_cars_vectors.h"
 
-using drake::util::MatrixCompareType;
 using drake::NullVector;
 using drake::SimulationOptions;
 

--- a/drake/examples/Pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_run_swing_up.cc
@@ -4,18 +4,18 @@
 #include <stdexcept>
 
 #include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/examples/Pendulum/pendulum_swing_up.h"
 #include "drake/solvers/trajectoryOptimization/dircol_trajectory_optimization.h"
+#include "drake/systems/LCMSystem.h"
+#include "drake/systems/Simulation.h"
 #include "drake/systems/cascade_system.h"
 #include "drake/systems/controllers/simple_lqr_trajectory_controller.h"
 #include "drake/systems/feedback_system.h"
-#include "drake/systems/LCMSystem.h"
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/plants/robot_state_tap.h"
-#include "drake/systems/Simulation.h"
 #include "drake/util/drakeAppUtil.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using drake::SimpleLqrTrajectoryController;
 using drake::solvers::SolutionResult;

--- a/drake/examples/Pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_run_swing_up.cc
@@ -15,11 +15,11 @@
 #include "drake/systems/plants/robot_state_tap.h"
 #include "drake/systems/Simulation.h"
 #include "drake/util/drakeAppUtil.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using drake::SimpleLqrTrajectoryController;
 using drake::solvers::SolutionResult;
-using drake::util::MatrixCompareType;
+using drake::MatrixCompareType;
 
 typedef PiecewisePolynomial<double> PiecewisePolynomialType;
 

--- a/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
@@ -5,10 +5,10 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/math/autodiff.h"
 #include "drake/systems/plants/constraint/direct_collocation_constraint.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 GTEST_TEST(PendulumDirectCollocationConstraint,
            PendulumDirectCollocationConstraintTest) {

--- a/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
@@ -8,9 +8,7 @@
 #include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/math/autodiff.h"
 #include "drake/systems/plants/constraint/direct_collocation_constraint.h"
-#include "drake/util/eigen_matrix_compare.h"
-
-using drake::util::MatrixCompareType;
+#include "drake/common/eigen_matrix_compare.h"
 
 GTEST_TEST(PendulumDirectCollocationConstraint,
            PendulumDirectCollocationConstraintTest) {
@@ -43,7 +41,7 @@ GTEST_TEST(PendulumDirectCollocationConstraint,
   d_1_expected << 0.1508698, 14.488559, -6.715012, 14.818155,
       7.315012, -2.96, -3.04;
   EXPECT_TRUE(CompareMatrices(result(0).derivatives(), d_0_expected, 1e-4,
-                              MatrixCompareType::absolute));
+                              drake::MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(result(1).derivatives(), d_1_expected, 1e-4,
-                              MatrixCompareType::absolute));
+                              drake::MatrixCompareType::absolute));
 }

--- a/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
@@ -6,10 +6,9 @@
 #include "drake/common/eigen_types.h"
 #include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/examples/Pendulum/pendulum_swing_up.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using drake::solvers::SolutionResult;
-using drake::util::MatrixCompareType;
 
 typedef PiecewisePolynomial<double> PiecewisePolynomialType;
 

--- a/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
@@ -3,10 +3,10 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
 #include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/examples/Pendulum/pendulum_swing_up.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using drake::solvers::SolutionResult;
 

--- a/drake/examples/Pendulum/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Pendulum/test/urdfDynamicsTest.cpp
@@ -1,14 +1,13 @@
 #include "drake/common/drake_path.h"
 #include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 #include "gtest/gtest.h"
 
 using drake::GetDrakePath;
 using drake::getRandomVector;
 using drake::RigidBodySystem;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace examples {

--- a/drake/examples/Pendulum/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Pendulum/test/urdfDynamicsTest.cpp
@@ -1,7 +1,7 @@
 #include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 #include "gtest/gtest.h"
 

--- a/drake/examples/Quadrotor/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Quadrotor/test/urdfDynamicsTest.cpp
@@ -3,8 +3,8 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/drake_path.h"
-#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/util/testUtil.h"
 
 using drake::GetDrakePath;

--- a/drake/examples/Quadrotor/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Quadrotor/test/urdfDynamicsTest.cpp
@@ -4,13 +4,12 @@
 
 #include "drake/common/drake_path.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using drake::GetDrakePath;
 using drake::getRandomVector;
 using drake::RigidBodySystem;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace examples {

--- a/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_arm_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_arm_test.cc
@@ -3,11 +3,11 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_simulation.h"
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/plants/robot_state_tap.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using drake::RigidBodySystem;
 using drake::BotVisualizer;

--- a/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_arm_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_arm_test.cc
@@ -7,13 +7,12 @@
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/plants/robot_state_tap.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using drake::RigidBodySystem;
 using drake::BotVisualizer;
 using Eigen::VectorXd;
 using drake::RobotStateTap;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace examples {

--- a/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_pd_control_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_pd_control_test.cc
@@ -10,7 +10,7 @@
 #include "drake/systems/pd_control_system.h"
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/plants/robot_state_tap.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using drake::AffineSystem;
 using drake::BotVisualizer;
@@ -19,7 +19,6 @@ using drake::PDControlSystem;
 using drake::RigidBodySystem;
 using drake::RobotStateTap;
 using Eigen::VectorXd;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace examples {

--- a/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_pd_control_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/kuka_iiwa_pd_control_test.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_simulation.h"
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/LinearSystem.h"
@@ -10,7 +11,6 @@
 #include "drake/systems/pd_control_system.h"
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/plants/robot_state_tap.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using drake::AffineSystem;
 using drake::BotVisualizer;

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -20,7 +20,7 @@
 #include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/vector_interface.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using std::make_unique;
 using std::unique_ptr;
@@ -39,7 +39,6 @@ using systems::StateVector;
 using systems::System;
 using systems::SystemOutput;
 using systems::VectorInterface;
-using util::MatrixCompareType;
 
 namespace examples {
 namespace {

--- a/drake/examples/spring_mass/test/spring_mass_system_test.cc
+++ b/drake/examples/spring_mass/test/spring_mass_system_test.cc
@@ -11,6 +11,7 @@
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_state_vector.h"
 #include "drake/systems/framework/state.h"
@@ -20,7 +21,6 @@
 #include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/vector_interface.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using std::make_unique;
 using std::unique_ptr;

--- a/drake/math/test/autodiff_test.cc
+++ b/drake/math/test/autodiff_test.cc
@@ -7,15 +7,13 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/autodiff_gradient.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
 namespace drake {
 
-using util::CompareMatrices;
-using util::MatrixCompareType;
 
 namespace math {
 namespace {

--- a/drake/math/test/autodiff_test.cc
+++ b/drake/math/test/autodiff_test.cc
@@ -5,16 +5,14 @@
 
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/autodiff_gradient.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
 namespace drake {
-
-
 namespace math {
 namespace {
 

--- a/drake/math/test/expmap_test.cc
+++ b/drake/math/test/expmap_test.cc
@@ -5,7 +5,7 @@
 
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using drake::math::initializeAutoDiff;
 using Eigen::AutoDiffScalar;
@@ -14,8 +14,6 @@ using Eigen::Vector4d;
 
 namespace drake {
 
-using util::CompareMatrices;
-using util::MatrixCompareType;
 
 namespace math {
 namespace {

--- a/drake/math/test/expmap_test.cc
+++ b/drake/math/test/expmap_test.cc
@@ -3,9 +3,9 @@
 #include <unsupported/Eigen/AutoDiff>
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using drake::math::initializeAutoDiff;
 using Eigen::AutoDiffScalar;
@@ -13,8 +13,6 @@ using Eigen::Matrix3d;
 using Eigen::Vector4d;
 
 namespace drake {
-
-
 namespace math {
 namespace {
 

--- a/drake/math/test/rotation_conversion_test.cc
+++ b/drake/math/test/rotation_conversion_test.cc
@@ -7,11 +7,11 @@
 
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/axis_angle.h"
+#include "drake/math/quaternion.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
-#include "drake/math/quaternion.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::Matrix;
 using Eigen::Matrix3d;
@@ -20,8 +20,6 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 
 namespace drake {
-
-
 namespace math {
 namespace {
 

--- a/drake/math/test/rotation_conversion_test.cc
+++ b/drake/math/test/rotation_conversion_test.cc
@@ -11,7 +11,7 @@
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/math/quaternion.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::Matrix;
 using Eigen::Matrix3d;
@@ -21,8 +21,6 @@ using Eigen::Vector4d;
 
 namespace drake {
 
-using util::CompareMatrices;
-using util::MatrixCompareType;
 
 namespace math {
 namespace {

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -6,13 +6,12 @@
 
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/optimization.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -4,14 +4,13 @@
 
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/optimization.h"
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
-
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/test/moby_lcp_solver_test.cc
+++ b/drake/solvers/test/moby_lcp_solver_test.cc
@@ -2,10 +2,9 @@
 #include <memory>
 #include <vector>
 #include "drake/solvers/moby_lcp_solver.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/test/moby_lcp_solver_test.cc
+++ b/drake/solvers/test/moby_lcp_solver_test.cc
@@ -1,10 +1,12 @@
-#include <gtest/gtest.h>
+#include "drake/solvers/moby_lcp_solver.h"
+
 #include <memory>
 #include <vector>
-#include "drake/solvers/moby_lcp_solver.h"
+
+#include <gtest/gtest.h>
+
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
-
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/test/mosek_test.cc
+++ b/drake/solvers/test/mosek_test.cc
@@ -6,12 +6,11 @@
 
 #include "gtest/gtest.h"
 
-#include "drake/util/testUtil.h"
-#include "drake/solvers/mathematical_program.h"
-#include "drake/solvers/optimization.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/solvers/constraint.h"
-
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/optimization.h"
+#include "drake/util/testUtil.h"
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/test/mosek_test.cc
+++ b/drake/solvers/test/mosek_test.cc
@@ -9,11 +9,10 @@
 #include "drake/util/testUtil.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/optimization.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/solvers/constraint.h"
 
 
-using drake::util::MatrixCompareType;
 namespace drake {
 namespace solvers {
 namespace {

--- a/drake/solvers/test/optimization_problem_test.cc
+++ b/drake/solvers/test/optimization_problem_test.cc
@@ -1,14 +1,14 @@
 #include <typeinfo>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/polynomial.h"
 #include "drake/solvers/constraint.h"
 #include "drake/solvers/ipopt_solver.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/nlopt_solver.h"
 #include "drake/solvers/optimization.h"
 #include "drake/solvers/snopt_solver.h"
-#include "drake/common/polynomial.h"
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 #include "gtest/gtest.h"
 
@@ -309,7 +309,6 @@ GTEST_TEST(testOptimizationProblem, testProblem2) {
                                 MatrixCompareType::absolute));
   });
 }
-
 
 // This test is identical to testProblem2 above but the cost is
 // framed as a QP instead.

--- a/drake/solvers/test/optimization_problem_test.cc
+++ b/drake/solvers/test/optimization_problem_test.cc
@@ -8,7 +8,7 @@
 #include "drake/solvers/optimization.h"
 #include "drake/solvers/snopt_solver.h"
 #include "drake/common/polynomial.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 #include "gtest/gtest.h"
 
@@ -25,7 +25,6 @@ using Eigen::VectorXd;
 
 using drake::solvers::detail::VecIn;
 using drake::solvers::detail::VecOut;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
+++ b/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
@@ -5,13 +5,12 @@
 #include "drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h"
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
 #include "drake/systems/vector.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using std::vector;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
-using drake::util::MatrixCompareType;
 using drake::solvers::detail::VecIn;
 using drake::solvers::detail::VecOut;
 

--- a/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
+++ b/drake/solvers/trajectoryOptimization/test/trajectory_optimization_test.cc
@@ -1,11 +1,11 @@
-
 #include <vector>
 
 #include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h"
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
 #include "drake/systems/vector.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using std::vector;
 using Eigen::MatrixXd;

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -11,7 +11,7 @@
 #include "drake/solvers/fast_qp.h"
 #include "drake/systems/controllers/controlUtil.h"
 #include "drake/systems/plants/parser_urdf.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/lcmUtil.h"
 #include "drake/util/testUtil.h"
 #include "drake/util/yaml/yamlUtil.h"
@@ -23,7 +23,6 @@ const bool CHECK_CENTROIDAL_MOMENTUM_RATE_MATCHES_TOTAL_WRENCH = false;
 const bool PUBLISH_ZMP_COM_OBSERVER_STATE = true;
 
 using namespace Eigen;
-using drake::util::MatrixCompareType;
 
 #define LEG_INTEGRATOR_DEACTIVATION_MARGIN 0.07
 
@@ -563,8 +562,9 @@ void checkCentroidalMomentumMatchesTotalWrench(
       world_momentum_matrix * qdd + world_momentum_matrix_dot_times_v;
 
   std::string explanation;
-  if (!CompareMatrices(total_wrench_in_world, momentum_rate_of_change, 1e-6,
-                       MatrixCompareType::absolute, &explanation)) {
+  if (!drake::CompareMatrices(total_wrench_in_world, momentum_rate_of_change,
+                              1e-6, drake::MatrixCompareType::absolute,
+                              &explanation)) {
     throw std::runtime_error("Drake:ValueCheck ERROR:" + explanation);
   }
 }

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -4,14 +4,14 @@
 #include <map>
 #include <memory>
 
-#include "drake/common/drake_path.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/quaternion.h"
 #include "drake/solvers/fast_qp.h"
 #include "drake/systems/controllers/controlUtil.h"
 #include "drake/systems/plants/parser_urdf.h"
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/lcmUtil.h"
 #include "drake/util/testUtil.h"
 #include "drake/util/yaml/yamlUtil.h"

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -5,9 +5,9 @@
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/functional_form.h"
 #include "drake/common/polynomial.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -7,10 +7,7 @@
 
 #include "drake/common/functional_form.h"
 #include "drake/common/polynomial.h"
-#include "drake/util/eigen_matrix_compare.h"
-
-using drake::util::CompareMatrices;
-using drake::util::MatrixCompareType;
+#include "drake/common/eigen_matrix_compare.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/test/context_test.cc
+++ b/drake/systems/framework/test/context_test.cc
@@ -9,12 +9,10 @@
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 namespace drake {
 
-using util::CompareMatrices;
-using util::MatrixCompareType;
 
 namespace systems {
 

--- a/drake/systems/framework/test/context_test.cc
+++ b/drake/systems/framework/test/context_test.cc
@@ -6,14 +6,12 @@
 
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/basic_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 namespace drake {
-
-
 namespace systems {
 
 constexpr int kNumInputPorts = 2;

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -11,12 +11,10 @@
 #include "drake/systems/framework/primitives/integrator.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/framework/system_input.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 namespace drake {
 
-using util::CompareMatrices;
-using util::MatrixCompareType;
 
 namespace systems {
 namespace {

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -6,16 +6,14 @@
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/primitives/adder.h"
 #include "drake/systems/framework/primitives/integrator.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/framework/system_input.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 namespace drake {
-
-
 namespace systems {
 namespace {
 

--- a/drake/systems/plants/constraint/test/direct_collocation_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/direct_collocation_constraint_test.cc
@@ -5,9 +5,7 @@
 
 #include "drake/math/autodiff.h"
 #include "drake/systems/plants/constraint/direct_collocation_constraint.h"
-#include "drake/util/eigen_matrix_compare.h"
-
-using drake::util::MatrixCompareType;
+#include "drake/common/eigen_matrix_compare.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/plants/constraint/test/direct_collocation_constraint_test.cc
+++ b/drake/systems/plants/constraint/test/direct_collocation_constraint_test.cc
@@ -3,9 +3,9 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
 #include "drake/systems/plants/constraint/direct_collocation_constraint.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 namespace drake {
 namespace systems {
@@ -40,7 +40,6 @@ GTEST_TEST(DirectCollocationConstraintPendulumDynamicsTest,
            DirectCollocationConstraintTest) {
   const int kNumStates = 2;
   const int kNumInputs = 1;
-
 
   // Initial state/input and expected result values came from running
   // the MATLAB code for PendulumPlant through the constraint function

--- a/drake/systems/plants/parser_urdf.cc
+++ b/drake/systems/plants/parser_urdf.cc
@@ -4,12 +4,12 @@
 #include <sstream>
 #include <string>
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/plants/joints/DrakeJoints.h"
 #include "drake/systems/plants/material_map.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
 #include "drake/systems/plants/xmlUtil.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using drake::parsers::ModelInstanceIdTable;
 

--- a/drake/systems/plants/parser_urdf.cc
+++ b/drake/systems/plants/parser_urdf.cc
@@ -9,7 +9,7 @@
 #include "drake/systems/plants/material_map.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
 #include "drake/systems/plants/xmlUtil.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using drake::parsers::ModelInstanceIdTable;
 
@@ -159,9 +159,9 @@ void AddMaterialToMaterialMap(const string& material_name,
     // RGBA vectors is [0, 1], absolute and relative tolerance comparisons are
     // identical.
     auto& existing_color = material_iter->second;
-    if (!drake::util::CompareMatrices(
+    if (!drake::CompareMatrices(
             color_rgba, existing_color, 1e-10,
-            drake::util::MatrixCompareType::absolute)) {
+            drake::MatrixCompareType::absolute)) {
       // The materials map already has the material_name key but the color
       // associated with it is different.
       stringstream error_buff;

--- a/drake/systems/plants/test/compareParsersmex.cpp
+++ b/drake/systems/plants/test/compareParsersmex.cpp
@@ -6,12 +6,14 @@
 #include "drake/common/eigen_types.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/util/drakeMexUtil.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using namespace Eigen;
 using namespace std;
-using drake::util::MatrixCompareType;
+
+using drake::CompareMatrices;
+using drake::MatrixCompareType;
 
 /*
  * compares C++ robots generated via the matlab constructModelmex with the same

--- a/drake/systems/plants/test/compareParsersmex.cpp
+++ b/drake/systems/plants/test/compareParsersmex.cpp
@@ -3,10 +3,10 @@
 #include <cmath>
 #include <iostream>
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/util/drakeMexUtil.h"
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using namespace Eigen;

--- a/drake/systems/plants/test/compareRigidBodySystems.cpp
+++ b/drake/systems/plants/test/compareRigidBodySystems.cpp
@@ -4,8 +4,8 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/systems/plants/RigidBodyFrame.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/plants/RigidBodyFrame.h"
 #include "drake/util/testUtil.h"
 
 using std::make_shared;

--- a/drake/systems/plants/test/compareRigidBodySystems.cpp
+++ b/drake/systems/plants/test/compareRigidBodySystems.cpp
@@ -5,13 +5,12 @@
 #include <gtest/gtest.h>
 
 #include "drake/systems/plants/RigidBodyFrame.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using std::make_shared;
 using drake::RigidBodySystem;
 using Eigen::VectorXd;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace systems {
@@ -53,7 +52,7 @@ GTEST_TEST(CompareRigidBodySystemsTest, TestAll) {
     auto xdot2 = r2->dynamics(t, x, u);
 
     std::string explanation;
-    EXPECT_TRUE(drake::util::CompareMatrices(
+    EXPECT_TRUE(CompareMatrices(
         xdot1, xdot2, 1e-8, MatrixCompareType::relative, &explanation))
         << "Model mismatch!" << std::endl
         << "  - initial state:" << std::endl

--- a/drake/systems/plants/test/testAccelerometer.cpp
+++ b/drake/systems/plants/test/testAccelerometer.cpp
@@ -1,9 +1,9 @@
 #include "gtest/gtest.h"
 
-#include "drake/math/roll_pitch_yaw.h"
 #include "drake/common/drake_path.h"
-#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::Vector3d;

--- a/drake/systems/plants/test/testAccelerometer.cpp
+++ b/drake/systems/plants/test/testAccelerometer.cpp
@@ -3,7 +3,7 @@
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/common/drake_path.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::Vector3d;
@@ -13,7 +13,6 @@ using std::shared_ptr;
 using std::make_shared;
 using drake::GetDrakePath;
 using drake::RigidBodySystem;
-using drake::util::MatrixCompareType;
 using drake::RigidBodyAccelerometer;
 
 namespace drake {

--- a/drake/systems/plants/test/testGyroscope.cpp
+++ b/drake/systems/plants/test/testGyroscope.cpp
@@ -2,7 +2,7 @@
 
 #include "drake/common/drake_path.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::Vector3d;
@@ -12,7 +12,6 @@ using std::shared_ptr;
 using std::make_shared;
 using drake::GetDrakePath;
 using drake::RigidBodySystem;
-using drake::util::MatrixCompareType;
 using drake::RigidBodyGyroscope;
 
 namespace drake {

--- a/drake/systems/plants/test/testGyroscope.cpp
+++ b/drake/systems/plants/test/testGyroscope.cpp
@@ -1,8 +1,8 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/drake_path.h"
-#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::Vector3d;

--- a/drake/systems/plants/test/testIK.cpp
+++ b/drake/systems/plants/test/testIK.cpp
@@ -9,15 +9,14 @@
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/vector.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 
-using drake::GetDrakePath;
-using drake::util::CompareMatrices;
-using drake::util::MatrixCompareType;
+namespace drake {
+namespace {
 
 GTEST_TEST(testIK, atlasIK) {
   RigidBodyTree model(
@@ -111,3 +110,6 @@ GTEST_TEST(testIK, iiwaIK) {
       pos_end, model.relativeTransform(cache, 0, link_7_idx).translation(),
       pos_tol + 1e-6, MatrixCompareType::absolute));
 }
+
+}  // namespace
+}  // namespace drake

--- a/drake/systems/plants/test/testIK.cpp
+++ b/drake/systems/plants/test/testIK.cpp
@@ -1,15 +1,15 @@
 #include <cstdlib>
-#include <Eigen/Dense>
 
+#include <Eigen/Dense>
 #include "gtest/gtest.h"
 
 #include "drake/common/drake_path.h"
-#include "drake/systems/plants/constraint/RigidBodyConstraint.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/plants/IKoptions.h"
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
+#include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 #include "drake/systems/vector.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::Vector2d;
 using Eigen::Vector3d;

--- a/drake/systems/plants/test/testIKMoreConstraints.cpp
+++ b/drake/systems/plants/test/testIKMoreConstraints.cpp
@@ -6,11 +6,11 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/drake_path.h"
-#include "drake/systems/plants/constraint/RigidBodyConstraint.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/plants/IKoptions.h"
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 
 using Eigen::Vector2d;
 using Eigen::Vector3d;

--- a/drake/systems/plants/test/testIKMoreConstraints.cpp
+++ b/drake/systems/plants/test/testIKMoreConstraints.cpp
@@ -10,15 +10,14 @@
 #include "drake/systems/plants/IKoptions.h"
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 
-using drake::GetDrakePath;
-using drake::util::CompareMatrices;
-using drake::util::MatrixCompareType;
+namespace drake {
+namespace {
 
 // Find the joint position indices corresponding to 'name'
 std::vector<int> getJointPositionVectorIndices(const RigidBodyTree& model,
@@ -195,3 +194,6 @@ GTEST_TEST(testIKMoreConstraints, IKMoreConstraints) {
   EXPECT_TRUE(CompareMatrices(com, Vector3d(0.074890, -0.037551, 1.008913),
                               1e-4, MatrixCompareType::absolute));
 }
+
+}  // namespace
+}  // namespace drake

--- a/drake/systems/plants/test/testIKpointwise.cpp
+++ b/drake/systems/plants/test/testIKpointwise.cpp
@@ -8,15 +8,14 @@
 #include "drake/systems/plants/IKoptions.h"
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::MatrixXd;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 
-using drake::GetDrakePath;
-using drake::util::CompareMatrices;
-using drake::util::MatrixCompareType;
+namespace drake {
+namespace {
 
 GTEST_TEST(testIKpointwise, simpleIKpointwise) {
   RigidBodyTree model(
@@ -78,3 +77,6 @@ GTEST_TEST(testIKpointwise, simpleIKpointwise) {
   delete[] constraint_array;
   delete[] info;
 }
+
+}  // namespace
+}  // namespace drake

--- a/drake/systems/plants/test/testIKpointwise.cpp
+++ b/drake/systems/plants/test/testIKpointwise.cpp
@@ -1,14 +1,14 @@
 #include <cstdlib>
-#include <Eigen/Dense>
 
+#include <Eigen/Dense>
 #include "gtest/gtest.h"
 
 #include "drake/common/drake_path.h"
-#include "drake/systems/plants/constraint/RigidBodyConstraint.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/plants/IKoptions.h"
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 
 using Eigen::MatrixXd;
 using Eigen::Vector2d;

--- a/drake/systems/plants/test/testMagnetometer.cpp
+++ b/drake/systems/plants/test/testMagnetometer.cpp
@@ -3,7 +3,7 @@
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/common/drake_path.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::Vector3d;
@@ -14,7 +14,6 @@ using std::make_shared;
 using drake::GetDrakePath;
 using drake::RigidBodyMagnetometer;
 using drake::RigidBodySystem;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace systems {

--- a/drake/systems/plants/test/testMagnetometer.cpp
+++ b/drake/systems/plants/test/testMagnetometer.cpp
@@ -1,9 +1,9 @@
 #include "gtest/gtest.h"
 
-#include "drake/math/roll_pitch_yaw.h"
 #include "drake/common/drake_path.h"
-#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::Vector3d;

--- a/drake/systems/plants/test/testMassSpringDamper.cpp
+++ b/drake/systems/plants/test/testMassSpringDamper.cpp
@@ -2,14 +2,13 @@
 
 #include "drake/common/drake_path.h"
 #include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::Matrix;
 using std::make_shared;
 using drake::GetDrakePath;
 using drake::RigidBodySystem;
-using drake::util::MatrixCompareType;
 using drake::toEigen;
 
 namespace drake {

--- a/drake/systems/plants/test/testMassSpringDamper.cpp
+++ b/drake/systems/plants/test/testMassSpringDamper.cpp
@@ -1,8 +1,8 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/drake_path.h"
-#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/util/testUtil.h"
 
 using Eigen::Matrix;

--- a/drake/systems/test/simulation_trajectory_logger_test.cc
+++ b/drake/systems/test/simulation_trajectory_logger_test.cc
@@ -6,7 +6,6 @@
 
 #include "drake/common/eigen_matrix_compare.h"
 
-
 namespace drake {
 namespace systems {
 namespace test {

--- a/drake/systems/test/simulation_trajectory_logger_test.cc
+++ b/drake/systems/test/simulation_trajectory_logger_test.cc
@@ -4,10 +4,8 @@
 
 #include "gtest/gtest.h"
 
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 
-using drake::util::CompareMatrices;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace systems {

--- a/drake/systems/test/vector_test.cc
+++ b/drake/systems/test/vector_test.cc
@@ -3,14 +3,13 @@
 #include "gtest/gtest.h"
 
 #include "drake/systems/test/pendulum.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 
 using drake::CombinedVector;
 using drake::size;
 using drake::CombinedVectorUtil;
 using drake::NullVector;
-using drake::util::MatrixCompareType;
 using std::is_same;
 using std::string;
 

--- a/drake/systems/test/vector_test.cc
+++ b/drake/systems/test/vector_test.cc
@@ -2,8 +2,8 @@
 
 #include "gtest/gtest.h"
 
-#include "drake/systems/test/pendulum.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/test/pendulum.h"
 #include "drake/util/testUtil.h"
 
 using drake::CombinedVector;

--- a/drake/systems/trajectories/test/testPiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/test/testPiecewisePolynomial.cpp
@@ -1,11 +1,13 @@
-#include <Eigen/Core>
 #include <iostream>
 #include <random>
 #include <vector>
-#include "drake/systems/trajectories/PiecewisePolynomial.h"
-#include "drake/common/eigen_matrix_compare.h"
-#include "drake/util/testUtil.h"
+
+#include <Eigen/Core>
 #include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/trajectories/PiecewisePolynomial.h"
+#include "drake/util/testUtil.h"
 
 using Eigen::Matrix;
 using std::default_random_engine;
@@ -14,7 +16,6 @@ using std::vector;
 using std::runtime_error;
 using std::normal_distribution;
 using std::uniform_int_distribution;
-
 
 namespace drake {
 namespace {

--- a/drake/systems/trajectories/test/testPiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/test/testPiecewisePolynomial.cpp
@@ -3,7 +3,7 @@
 #include <random>
 #include <vector>
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 #include "gtest/gtest.h"
 
@@ -15,7 +15,6 @@ using std::runtime_error;
 using std::normal_distribution;
 using std::uniform_int_distribution;
 
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace {

--- a/drake/util/test/CMakeLists.txt
+++ b/drake/util/test/CMakeLists.txt
@@ -31,10 +31,6 @@ add_executable(testDrakeGeometryUtil testDrakeGeometryUtil.cpp)
 target_link_libraries(testDrakeGeometryUtil drakeGeometryUtil ${GTEST_BOTH_LIBRARIES})
 add_test(NAME testDrakeGeometryUtil COMMAND testDrakeGeometryUtil)
 
-add_executable(eigen_matrix_compare_test eigen_matrix_compare_test.cc)
-target_link_libraries(eigen_matrix_compare_test ${GTEST_BOTH_LIBRARIES})
-add_test(NAME eigen_matrix_compare_test COMMAND eigen_matrix_compare_test)
-
 add_matlab_test(NAME util/test/PassByValueMapTest COMMAND PassByValueMapTest)
 add_matlab_test(NAME util/test/angleDiffTest COMMAND angleDiffTest)
 add_matlab_test(NAME util/test/asintest COMMAND asintest)

--- a/drake/util/test/testDrakeGeometryUtil.cpp
+++ b/drake/util/test/testDrakeGeometryUtil.cpp
@@ -2,13 +2,13 @@
 #include <iostream>
 
 #include <Eigen/Core>
+#include "gtest/gtest.h"
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/util/drakeGeometryUtil.h"
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
-#include "gtest/gtest.h"
 
 using Eigen::Isometry3d;
 using Eigen::Vector3d;

--- a/drake/util/test/testDrakeGeometryUtil.cpp
+++ b/drake/util/test/testDrakeGeometryUtil.cpp
@@ -6,7 +6,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/util/drakeGeometryUtil.h"
-#include "drake/util/eigen_matrix_compare.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/testUtil.h"
 #include "gtest/gtest.h"
 
@@ -20,7 +20,6 @@ using Eigen::Dynamic;
 using Eigen::Quaterniond;
 using Eigen::Translation3d;
 using std::default_random_engine;
-using drake::util::MatrixCompareType;
 
 namespace drake {
 namespace util {


### PR DESCRIPTION
This is required because `common/test/polynomial_test` uses it.  (Also several items in `math` use it.)

The removed `using` statements and new `#include` paths were perl pie; the other changes were by hand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3166)
<!-- Reviewable:end -->
