### PR TITLE
System accessors returning Eigen expressions

### DIFF
--- a/drake/systems/framework/primitives/constant_vector_source.cc
+++ b/drake/systems/framework/primitives/constant_vector_source.cc
@@ -21,16 +21,7 @@ void ConstantVectorSource<T>::EvalOutput(const ContextBase<T>& context,
                                          SystemOutput<T>* output) const {
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
-  // TODO(amcastro-tri): Solve #3140 so that the next line reads:
-  // auto& output_vector = this->get_output_vector(context, 0);
-  // where output_vector will be an Eigen expression.
-  VectorBase<T>* output_vector = output->GetMutableVectorData(0);
-
-  // TODO(amcastro-tri): Solve #3140 so that the Eigen output_vector can be
-  // accessed like so:
-  // auto& output_vector = this->get_mutable_output_vector(context, 0);
-  output_vector->get_mutable_value() = source_value_;
+  System<T>::GetMutableOutputVector(output, 0) = source_value_;
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/systems/framework/primitives/gain-inl.h
+++ b/drake/systems/framework/primitives/gain-inl.h
@@ -19,8 +19,7 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-Gain<T>::Gain(const T& k, int length)
-    : gain_(k) {
+Gain<T>::Gain(const T& k, int length) : gain_(k) {
   // TODO(amcastro-tri): remove the length parameter from the constructor once
   // #3109 supporting automatic lengths is resolved.
   this->DeclareInputPort(kVectorValued, length, kContinuousSampling);
@@ -29,22 +28,12 @@ Gain<T>::Gain(const T& k, int length)
 
 template <typename T>
 void Gain<T>::EvalOutput(const ContextBase<T>& context,
-                          SystemOutput<T>* output) const {
+                         SystemOutput<T>* output) const {
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
-  // There is only one input.
-  // TODO(amcastro-tri): Solve #3140 so that the next line reads:
-  // auto& input_vector = System<T>::get_input_vector(context, 0);
-  // where the return is an Eigen expression.
-  const VectorBase<T>* input_vector = context.get_vector_input(0);
-  VectorBase<T>* output_vector = output->GetMutableVectorData(0);
-
-  // TODO(amcastro-tri): Solve #3140 so that we can readily access the Eigen
-  // vector like so:
-  // auto& output_vector = System<T>::get_output_vector(context, 0);
-  // where the return is an Eigen expression.
-  output_vector->get_mutable_value() = gain_ * input_vector->get_value();
+  auto input_vector = System<T>::get_input_vector(context, 0);
+  System<T>::GetMutableOutputVector(output, 0) = gain_ * input_vector;
 }
 
 }  // namespace systems

--- a/drake/systems/framework/primitives/integrator.cc
+++ b/drake/systems/framework/primitives/integrator.cc
@@ -57,7 +57,7 @@ void Integrator<T>::EvalOutput(const ContextBase<T>& context,
   // TODO(david-german-tri): Remove this copy by allowing output ports to be
   // mere pointers to state variables (or cache lines).
   System<T>::GetMutableOutputVector(output, 0) =
-      System<T>::GetContinuousStateVectorCopy(context);
+      System<T>::CopyContinuousStateVector(context);
 }
 
 

--- a/drake/systems/framework/primitives/integrator.cc
+++ b/drake/systems/framework/primitives/integrator.cc
@@ -54,12 +54,10 @@ void Integrator<T>::EvalOutput(const ContextBase<T>& context,
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
-  VectorBase<T>* output_port = output->GetMutableVectorData(0);
-
   // TODO(david-german-tri): Remove this copy by allowing output ports to be
   // mere pointers to state variables (or cache lines).
-  output_port->get_mutable_value() =
-      context.get_state().continuous_state->get_state().CopyToVector();
+  System<T>::GetMutableOutputVector(output, 0) =
+      System<T>::GetContinuousStateVectorCopy(context);
 }
 
 

--- a/drake/systems/framework/primitives/pass_through-inl.h
+++ b/drake/systems/framework/primitives/pass_through-inl.h
@@ -29,24 +29,13 @@ PassThrough<T>::PassThrough(int length) {
 
 template <typename T>
 void PassThrough<T>::EvalOutput(const ContextBase<T>& context,
-                          SystemOutput<T>* output) const {
+                                SystemOutput<T>* output) const {
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
-  VectorBase<T>* output_vector = output->GetMutableVectorData(0);
-
-  // TODO(amcastro-tri): Solve #3140 so that the next line reads:
-  // auto& input_vector = System<T>::get_input_vector(context, 0);
-  // where the return is an Eigen expression.
-  const VectorBase<T>* input_vector = context.get_vector_input(0);
-
-  // TODO(amcastro-tri): Solve #3140 so that we can readily access the Eigen
-  // vector like so:
-  // auto& output_vector = System<T>::get_output_vector(context, 0);
-  // where the return is an Eigen expression.
   // TODO(amcastro-tri): the output should simply reference the input port's
   // value to avoid copy.
-  output_vector->get_mutable_value() = input_vector->get_value();
+  System<T>::GetMutableOutputVector(output, 0) =
+      System<T>::get_input_vector(context, 0);
 }
 
 }  // namespace systems

--- a/drake/systems/framework/primitives/pass_through.h
+++ b/drake/systems/framework/primitives/pass_through.h
@@ -32,8 +32,6 @@ class PassThrough : public LeafSystem<T> {
   explicit PassThrough(int length);
 
   /// Sets the output port to equal the input port.
-  /// If the number of connected input or output ports is not one or the
-  /// input ports are not of size length_, `std::runtime_error` will be thrown.
   void EvalOutput(const ContextBase<T>& context,
                   SystemOutput<T>* output) const override;
 };

--- a/drake/systems/framework/primitives/test/pass_through_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_test.cc
@@ -29,13 +29,13 @@ std::unique_ptr<FreestandingInputPort> MakeInput(
 class PassThroughTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    buffer_ = make_unique<PassThrough<double>>(3 /* length */);
-    context_ = buffer_->CreateDefaultContext();
-    output_ = buffer_->AllocateOutput(*context_);
+    pass_through_ = make_unique<PassThrough<double>>(3 /* length */);
+    context_ = pass_through_->CreateDefaultContext();
+    output_ = pass_through_->AllocateOutput(*context_);
     input_ = make_unique<BasicVector<double>>(3 /* length */);
   }
 
-  std::unique_ptr<System<double>> buffer_;
+  std::unique_ptr<System<double>> pass_through_;
   std::unique_ptr<ContextBase<double>> context_;
   std::unique_ptr<SystemOutput<double>> output_;
   std::unique_ptr<BasicVector<double>> input_;
@@ -43,18 +43,22 @@ class PassThroughTest : public ::testing::Test {
 
 // Tests that the output of this system equals its input.
 TEST_F(PassThroughTest, VectorThroughPassThroughSystem) {
-  // Hook input of the expected size.
-  // TODO(amcastro-tri): Check with buffer_->get_num_input_ports() after #3097.
+  /// Checks that the number of input ports in the system and in the context
+  // are consistent.
   ASSERT_EQ(1, context_->get_num_input_ports());
+  ASSERT_EQ(1, pass_through_->get_num_input_ports());
   Eigen::Vector3d input_vector(1.0, 3.14, 2.18);
   input_->get_mutable_value() << input_vector;
 
+  // Hook input of the expected size.
   context_->SetInputPort(0, MakeInput(std::move(input_)));
 
-  buffer_->EvalOutput(*context_, output_.get());
+  pass_through_->EvalOutput(*context_, output_.get());
 
-  // TODO(amcastro-tri): Check with buffer_->get_num_output_ports() after #3097.
+  // Checks that the number of output ports in the system and in the
+  // output are consistent.
   ASSERT_EQ(1, output_->get_num_ports());
+  ASSERT_EQ(1, pass_through_->get_num_output_ports());
   const BasicVector<double>* output_vector =
       dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
   ASSERT_NE(nullptr, output_vector);

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -113,6 +113,41 @@ class System {
     }
   }
 
+  /// Returns an Eigen expression for a vector valued input port with index
+  /// @p port_index in this system.
+  Eigen::VectorBlock<const VectorX<T>> get_input_vector(
+      const ContextBase<T>& context, int port_index) const {
+    DRAKE_ASSERT(0 <= port_index && port_index < get_num_input_ports());
+    const VectorBase<T>* input_vector =
+        context.get_vector_input(port_index);
+
+    DRAKE_ASSERT(input_vector != nullptr);
+    DRAKE_ASSERT(input_vector->get_value().rows() ==
+                 get_input_port(port_index).get_size());
+
+    return input_vector->get_value();
+  }
+
+  /// Returns a mutable Eigen expression for a vector valued output port with
+  /// index @p port_index in this system. This call invalidates the cache.
+  Eigen::VectorBlock<VectorX<T>> GetMutableOutputVector(SystemOutput<T>* output,
+                                                        int port_index) const {
+    DRAKE_ASSERT(0 <= port_index && port_index < get_num_output_ports());
+
+    VectorBase<T>* output_vector = output->
+        get_mutable_port(port_index)->template GetMutableVectorData<T>();
+    DRAKE_ASSERT(output_vector != nullptr);
+    DRAKE_ASSERT(output_vector->get_value().rows() ==
+                 get_output_port(port_index).get_size());
+
+    return output_vector->get_mutable_value();
+  }
+
+  // Returns a copy of the continuous state vector into an Eigen vector.
+  VectorX<T> GetContinuousStateVectorCopy(const ContextBase<T>& context) const {
+    return context.get_state().continuous_state->get_state().CopyToVector();
+  }
+
   /// Returns a default context, initialized with the correct
   /// numbers of concrete input ports and state variables for this System.
   /// Since input port pointers are not owned by the context, they should
@@ -282,7 +317,6 @@ class System {
   void DeclareAbstractOutputPort(SamplingSpec sampling) {
     DeclareOutputPort(kAbstractValued, 0 /* size */, sampling);
   }
-
 
  private:
   // SystemInterface objects are neither copyable nor moveable.

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -128,23 +128,8 @@ class System {
     return input_vector->get_value();
   }
 
-  /// Returns a mutable Eigen expression for a vector valued output port with
-  /// index @p port_index in this system. This call invalidates the cache.
-  Eigen::VectorBlock<VectorX<T>> GetMutableOutputVector(SystemOutput<T>* output,
-                                                        int port_index) const {
-    DRAKE_ASSERT(0 <= port_index && port_index < get_num_output_ports());
-
-    VectorBase<T>* output_vector = output->
-        get_mutable_port(port_index)->template GetMutableVectorData<T>();
-    DRAKE_ASSERT(output_vector != nullptr);
-    DRAKE_ASSERT(output_vector->get_value().rows() ==
-                 get_output_port(port_index).get_size());
-
-    return output_vector->get_mutable_value();
-  }
-
   // Returns a copy of the continuous state vector into an Eigen vector.
-  VectorX<T> GetContinuousStateVectorCopy(const ContextBase<T>& context) const {
+  VectorX<T> CopyContinuousStateVector(const ContextBase<T> &context) const {
     return context.get_state().continuous_state->get_state().CopyToVector();
   }
 
@@ -316,6 +301,23 @@ class System {
   /// output topology.
   void DeclareAbstractOutputPort(SamplingSpec sampling) {
     DeclareOutputPort(kAbstractValued, 0 /* size */, sampling);
+  }
+
+  /// Returns a mutable Eigen expression for a vector valued output port with
+  /// index @p port_index in this system. All InputPorts that directly depend
+  /// on this OutputPort will be notified that upstream data has changed, and
+  /// may invalidate cache entries as a result.
+  Eigen::VectorBlock<VectorX<T>> GetMutableOutputVector(SystemOutput<T>* output,
+                                                        int port_index) const {
+    DRAKE_ASSERT(0 <= port_index && port_index < get_num_output_ports());
+
+    VectorBase<T>* output_vector = output->
+        get_mutable_port(port_index)->template GetMutableVectorData<T>();
+    DRAKE_ASSERT(output_vector != nullptr);
+    DRAKE_ASSERT(output_vector->get_value().rows() ==
+        get_output_port(port_index).get_size());
+
+    return output_vector->get_mutable_value();
   }
 
  private:


### PR DESCRIPTION
Closes #3140.

The new methods introduced in `System<T>` are:
- get_input_vector
- get_mutable_output_vector
- get_continuous_state_vector

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3175)
<!-- Reviewable:end -->
