### PR TITLE
Reduce tolerance on final position to fix open-source builds.

### DIFF
--- a/drake/examples/Pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_run_swing_up.cc
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
   PendulumState<double> x0_state = x0;
   drake::runLCM(sys, lcm, 0, kTrajectoryTimeUpperBound, x0_state, options);
   if (!CompareMatrices(toEigen(robot_state_tap->get_input_vector()), xG,
-                       1e-5, MatrixCompareType::absolute)) {
+                       1e-4, MatrixCompareType::absolute)) {
     throw std::runtime_error("Did not reach trajectory target.");
   }
 


### PR DESCRIPTION
IPOPT and NLopt both require this.  oops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3177)
<!-- Reviewable:end -->
