### PR TITLE
Remove unused includes into util

### DIFF
--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -7,7 +7,6 @@
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/optimization.h"
-#include "drake/util/testUtil.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;

--- a/drake/solvers/test/moby_lcp_solver_test.cc
+++ b/drake/solvers/test/moby_lcp_solver_test.cc
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/util/testUtil.h"
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/test/mosek_test.cc
+++ b/drake/solvers/test/mosek_test.cc
@@ -10,7 +10,6 @@
 #include "drake/solvers/constraint.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/optimization.h"
-#include "drake/util/testUtil.h"
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/test/optimization_problem_test.cc
+++ b/drake/solvers/test/optimization_problem_test.cc
@@ -1,5 +1,7 @@
 #include <typeinfo>
 
+#include "gtest/gtest.h"
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/polynomial.h"
@@ -9,8 +11,6 @@
 #include "drake/solvers/nlopt_solver.h"
 #include "drake/solvers/optimization.h"
 #include "drake/solvers/snopt_solver.h"
-#include "drake/util/testUtil.h"
-#include "gtest/gtest.h"
 
 using Eigen::Dynamic;
 using Eigen::Ref;
@@ -127,11 +127,11 @@ GTEST_TEST(testOptimizationProblem, trivialLinearSystem) {
   EXPECT_TRUE(
       CompareMatrices(b, x.value(), 1e-10, MatrixCompareType::absolute));
 
-  valuecheck(b(2), x2.value()(0), 1e-10);
+  EXPECT_NEAR(b(2), x2.value()(0), 1e-10);
   EXPECT_TRUE(CompareMatrices(b.head(3), xhead.value(), 1e-10,
                               MatrixCompareType::absolute));
 
-  valuecheck(b(2), xhead(2).value()(0), 1e-10);  // a segment of a segment.
+  EXPECT_NEAR(b(2), xhead(2).value()(0), 1e-10);  // a segment of a segment.
 
   CheckSolverType(prog, "Linear System Solver");
 


### PR DESCRIPTION
A trivial cleanup, on the path towards `solvers` C++ not depending on `util`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3179)
<!-- Reviewable:end -->
