### PR TITLE
Add gflags as a required dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -95,3 +95,6 @@
 [submodule "externals/spdlog"]
 	path = externals/spdlog
 	url = https://github.com/gabime/spdlog.git
+[submodule "externals/gflags"]
+	path = externals/gflags
+	url = https://github.com/gflags/gflags.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Unreleased: changes on master, not yet released
 [//]: # "Altered functionality or APIs."
 ### Changed
 
+ - [#3183][] The gflags library is now a required dependency from the superbuild.
  - [#3157][] Renamed `RigidBodyTree::findJoint()` to be `RigidBodyTree::FindChildBodyOfJoint()` and `RigidBodyTree::findJointId()` to be `RigidBodyTree::FindIndexOfChildBodyOfJoint()`.
  - [#3115][] Modified SDF parser method names to be style guide compliant and more meaningful.
  - [#3078][] Changed `RigidBodyTree::kWorldLinkName` to be `RigidBodyTree::kWorldName`.
@@ -130,4 +131,4 @@ Changes in version v0.9.11 and before are not provided.
 [#3056]: https://github.com/RobotLocomotion/drake/issues/3056
 [#3078]: https://github.com/RobotLocomotion/drake/issues/3078
 [#3115]: https://github.com/RobotLocomotion/drake/issues/3115
-[#3157]: https://github.com/RobotLocomotion/drake/issues/3157
+[#3183]: https://github.com/RobotLocomotion/drake/issues/3183

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ drake_setup_git_hooks()
 ##########################################
 option(WITH_EIGEN "required c++ matrix library.  only disable if you have it already." ON)
 option(WITH_GOOGLETEST "required c++ unit test library.  only disable if you have it already." ON)
+option(WITH_GFLAGS "required c++ command-line library.  only disable if you have it already." ON)
 option(WITH_GOOGLE_STYLEGUIDE "provides cpplint.py style checking" ON)
 option(WITH_SWIGMAKE "helper tools to build python & MATLAB wrappers for C++ libraries with Eigen" ON)
 option(WITH_BULLET "used for collision detection" ON)
@@ -132,6 +133,9 @@ drake_add_external(googletest PUBLIC CMAKE
     -DBUILD_SHARED_LIBS=ON
     -DGTEST_CREATE_SHARED_LIBRARY=1 # Needed for parameterized tests on Windows
     -DCMAKE_INSTALL_NAME_DIR=${CMAKE_INSTALL_PREFIX}/lib)
+
+# gflags
+drake_add_external(gflags PUBLIC CMAKE)
 
 # google_styleguide
 drake_add_external(google_styleguide PUBLIC
@@ -256,6 +260,7 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
     gloptipoly3
     google_styleguide
     googletest
+    gflags
     gurobi
     ipopt
     iris

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ drake_add_external(avl PUBLIC)
 drake_add_external(bertini)
 drake_add_external(bullet PUBLIC CMAKE)
 drake_add_external(eigen PUBLIC CMAKE)
+drake_add_external(gflags PUBLIC CMAKE)
 drake_add_external(gloptipoly)
 drake_add_external(gurobi)
 drake_add_external(meshconverters PUBLIC)
@@ -133,9 +134,6 @@ drake_add_external(googletest PUBLIC CMAKE
     -DBUILD_SHARED_LIBS=ON
     -DGTEST_CREATE_SHARED_LIBRARY=1 # Needed for parameterized tests on Windows
     -DCMAKE_INSTALL_NAME_DIR=${CMAKE_INSTALL_PREFIX}/lib)
-
-# gflags
-drake_add_external(gflags PUBLIC CMAKE)
 
 # google_styleguide
 drake_add_external(google_styleguide PUBLIC
@@ -257,10 +255,10 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
     cmake
     director
     eigen
+    gflags
     gloptipoly3
     google_styleguide
     googletest
-    gflags
     gurobi
     ipopt
     iris

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -198,6 +198,8 @@ if(WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_LINKED_AS_SHARED_LIBRARY=1")
 endif()
 
+find_package(gflags REQUIRED)
+
 set(drake_jar_javafiles util/Transform.java)
 set(drake_jar_requires)
 

--- a/drake/doc/developers.rst
+++ b/drake/doc/developers.rst
@@ -78,8 +78,8 @@ The supported version of MATLAB is R2015b.
 
 Minimal configuration is defined as the minimal required externals from
 the superbuild. This is configured by turning off all externals using
-``ccmake`` or ``cmake-gui`` except for ``WITH_EIGEN`` and ``WITH_GOOGLETEST``
-which should be set to ``ON``.
+``ccmake`` or ``cmake-gui`` except for ``WITH_EIGEN``, ``WITH_GOOGLETEST``,
+and  ``WITH_GFLAGS``, which should be set to ``ON``.
 
 +-----------------------------------------+--------------------+-------------------+---------+
 | Operating System                        | Compilers          | Superbuild Deps   | Build   |

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -190,7 +190,7 @@ pods_install_pkg_config_file(drake-rbsystem
 
 if(lcm_FOUND)
   add_executable(rigidBodyLCMNode rigidBodyLCMNode.cpp)
-  target_link_libraries(rigidBodyLCMNode drakeRBSystem drakeLCMSystem threads)
+  target_link_libraries(rigidBodyLCMNode gflags drakeRBSystem drakeLCMSystem threads)
   pods_install_executables(rigidBodyLCMNode)
   drake_install_headers(BotVisualizer.h)
 endif()

--- a/drake/systems/plants/rigidBodyLCMNode.cpp
+++ b/drake/systems/plants/rigidBodyLCMNode.cpp
@@ -49,7 +49,6 @@ int main(int argc, char* argv[]) {
     floating_base_type = DrakeJoint::FIXED;
   } else if (FLAGS_base == "RPY") {
     floating_base_type = DrakeJoint::ROLLPITCHYAW;
-    std::cout << "base RPY";
   } else if (FLAGS_base == "QUAT") {
     floating_base_type = DrakeJoint::QUATERNION;
   } else {


### PR DESCRIPTION
Add gflags as a required dependency, along with a sample use (in the only non-example program that used drakeAppUtil).

Fixes #3027.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3183)
<!-- Reviewable:end -->
