### PR TITLE
Added RigidBodyTree::FindChildrenOfbody(), RigidBodyTree::FindBaseBod…

### DIFF
--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1868,10 +1868,10 @@ std::vector<int> RigidBodyTree::FindChildrenOfBody(int parent_body_index,
     int model_instance_id) const {
   // Verifies that parameter parent_body_index is valid.
   DRAKE_ABORT_UNLESS(parent_body_index >= 0 &&
-                     parent_body_index < static_cast<int>(bodies.size()));
+                     parent_body_index < get_number_of_bodies());
 
   // Obtains a reference to the parent body.
-  const RigidBody& parent_body = *(bodies.at(parent_body_index).get());
+  const RigidBody& parent_body = get_body(parent_body_index);
 
   // Checks every rigid body in this tree. If the rigid body is a child of
   // parent_body and its model instance id matches model_instance_id, save its
@@ -1971,10 +1971,14 @@ int RigidBodyTree::FindIndexOfChildBodyOfJoint(const std::string& joint_name,
   return link->get_body_index();
 }
 
-const RigidBody* RigidBodyTree::GetBody(int body_index) const {
+const RigidBody& RigidBodyTree::get_body(int body_index) const {
   DRAKE_ABORT_UNLESS(body_index >= 0 &&
-                     body_index < static_cast<int>(bodies.size()));
-  return bodies[body_index].get();
+                     body_index < get_number_of_bodies());
+  return *bodies[body_index].get();
+}
+
+int RigidBodyTree::get_number_of_bodies() const {
+  return static_cast<int>(bodies.size());
 }
 
 // TODO(liang.fok) Remove this method prior to Release 1.0.

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1874,7 +1874,7 @@ std::vector<int> RigidBodyTree::FindChildrenOfBody(int parent_body_index,
   const RigidBody& parent_body = get_body(parent_body_index);
 
   // Checks every rigid body in this tree. If the rigid body is a child of
-  // parent_body and its model instance id matches model_instance_id, save its
+  // parent_body and its model instance ID matches model_instance_id, save its
   // index in the result vector.
   std::vector<int> children_indexes;
   for (int ii = 0; ii < static_cast<int>(bodies.size()); ++ii) {

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1864,14 +1864,14 @@ int RigidBodyTree::FindBodyIndex(const std::string& body_name,
   return body->get_body_index();
 }
 
-std::vector<int> RigidBodyTree::FindChildrenOfBody(int body_index,
+std::vector<int> RigidBodyTree::FindChildrenOfBody(int parent_body_index,
     int model_instance_id) const {
-  // Verifies that parameter body_index is valid.
-  DRAKE_ABORT_UNLESS(body_index >= 0 &&
-                     body_index < static_cast<int>(bodies.size()));
+  // Verifies that parameter parent_body_index is valid.
+  DRAKE_ABORT_UNLESS(parent_body_index >= 0 &&
+                     parent_body_index < static_cast<int>(bodies.size()));
 
   // Obtains a reference to the parent body.
-  const RigidBody& parent_body = *(bodies.at(body_index).get());
+  const RigidBody& parent_body = *(bodies.at(parent_body_index).get());
 
   // Checks every rigid body in this tree. If the rigid body is a child of
   // parent_body and its model instance id matches model_instance_id, save its

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -633,7 +633,9 @@ class DRAKERBM_EXPORT RigidBodyTree {
 
   /**
    * Obtains a vector of indexes of the bodies that are directly attached to the
-   * world via any type of joint.
+   * world via any type of joint.  This method has a time complexity of `O(N)`
+   * where `N` is the number of bodies in the tree, which can be determined by
+   * calling RigidBodyTree::get_number_of_bodies().
    */
   std::vector<int> FindBaseBodies(int model_instance_id = -1) const;
 
@@ -662,7 +664,10 @@ class DRAKERBM_EXPORT RigidBodyTree {
   /**
    * Returns a vector of indexes of bodies that are the children of the body at
    * index @p parent_body_index. The resulting list can be further filtered to
-   * be bodies that belong to model instance ID @p model_instance_id.
+   * be bodies that belong to model instance ID @p model_instance_id. This
+   * method has a time complexity of `O(N)` where `N` is the number of bodies
+   * in the tree, which can be determined by calling
+   * RigidBodyTree::get_number_of_bodies().
    */
   std::vector<int> FindChildrenOfBody(int parent_body_index,
       int model_instance_id = -1) const;
@@ -748,12 +753,14 @@ class DRAKERBM_EXPORT RigidBodyTree {
   /**
    * Returns the body at index @p body_index. Parameter @p body_index must be
    * between zero and the number of bodies in this tree, which can be determined
-   * by calling RigidBodyTree::get_number_of_bodies().
+   * by calling RigidBodyTree::get_number_of_bodies(). Note that the body at
+   * index 0 represents the world.
    */
   const RigidBody& get_body(int body_index) const;
 
   /**
-   * Returns the number of bodies in this tree.
+   * Returns the number of bodies in this tree. This includes the one body that
+   * represents the world.
    */
   int get_number_of_bodies() const;
 

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -40,6 +40,12 @@ class DRAKERBM_EXPORT RigidBodyTree {
    */
   static const char* const kWorldName;
 
+  /**
+   * Defines the body index of the body within this rigid body tree that
+   * represents the world.
+   */
+  static const int kWorldBodyIndex;
+
   RigidBodyTree(const std::string& urdf_filename,
                 const DrakeJoint::FloatingBaseType floating_base_type =
                     DrakeJoint::ROLLPITCHYAW);
@@ -613,6 +619,12 @@ class DRAKERBM_EXPORT RigidBodyTree {
                       int model_id = -1) const;
 
   /**
+   * Obtains a list of body indexes of the bodies that are the children of the
+   * world body.
+   */
+  std::vector<int> FindBaseBodies(int model_instance_id = -1) const;
+
+  /**
    * Obtains the index of a rigid body within this rigid body tree. The rigid
    * body tree maintains a vector of pointers to all rigid bodies that are part
    * of the rigid body tree. The index of a rigid body is the index within this
@@ -635,9 +647,17 @@ class DRAKERBM_EXPORT RigidBodyTree {
  * `FindBodyIndex(...)` instead.
  */
 #ifndef SWIG
-  DRAKE_DEPRECATED("Pleasse use RigidBodyTree::FindBodyIndex instead.")
+  DRAKE_DEPRECATED("Pleasse use RigidBodyTree::FindBodyIndex() instead.")
 #endif
   int findLinkId(const std::string& link_name, int model_id = -1) const;
+
+  /**
+   * Returns a vector of indexes of bodies that are the children of a body at
+   * index @p body_index. The resulting list can be further filtered to be those
+   * bodies that belong to the model instance with ID @p model_instance_id.
+   */
+  std::vector<int> FindChildrenOfBody(int body_index,
+      int model_instance_id = -1) const;
 
   // TODO(amcastro-tri): The name of this method is misleading.
   // It returns a RigidBody when the user seems to request a joint.
@@ -669,6 +689,11 @@ class DRAKERBM_EXPORT RigidBodyTree {
    */
   std::shared_ptr<RigidBodyFrame> findFrame(const std::string& frame_name,
                                             int model_id = -1) const;
+
+  /**
+   * Returns the body at index @p body_index.
+   */
+  const RigidBody* GetBody(int body_index) const;
 
   std::string getBodyOrFrameName(int body_or_frame_id) const;
   // @param body_or_frame_id the index of the body or the id of the frame.

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -632,7 +632,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
                       int model_id = -1) const;
 
   /**
-   * Obtains a list of indexes of the bodies that are directly attached to the
+   * Obtains a vector of indexes of the bodies that are directly attached to the
    * world via any type of joint.
    */
   std::vector<int> FindBaseBodies(int model_instance_id = -1) const;
@@ -746,9 +746,16 @@ class DRAKERBM_EXPORT RigidBodyTree {
                                             int model_id = -1) const;
 
   /**
-   * Returns the body at index @p body_index.
+   * Returns the body at index @p body_index. Parameter @p body_index must be
+   * between zero and the number of bodies in this tree, which can be determined
+   * by calling RigidBodyTree::get_number_of_bodies().
    */
-  const RigidBody* GetBody(int body_index) const;
+  const RigidBody& get_body(int body_index) const;
+
+  /**
+   * Returns the number of bodies in this tree.
+   */
+  int get_number_of_bodies() const;
 
   std::string getBodyOrFrameName(int body_or_frame_id) const;
   // @param body_or_frame_id the index of the body or the id of the frame.

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -41,8 +41,8 @@ class DRAKERBM_EXPORT RigidBodyTree {
   static const char* const kWorldName;
 
   /**
-   * Defines the body index of the body within this rigid body tree that
-   * represents the world.
+   * Defines the index of the body that represents the world within a
+   * RigidBodyTree.
    */
   static const int kWorldBodyIndex;
 
@@ -632,8 +632,8 @@ class DRAKERBM_EXPORT RigidBodyTree {
                       int model_id = -1) const;
 
   /**
-   * Obtains a list of body indexes of the bodies that are the children of the
-   * world body.
+   * Obtains a list of indexes of the bodies that are directly attached to the
+   * world via any type of joint.
    */
   std::vector<int> FindBaseBodies(int model_instance_id = -1) const;
 
@@ -660,11 +660,11 @@ class DRAKERBM_EXPORT RigidBodyTree {
       const;
 
   /**
-   * Returns a vector of indexes of bodies that are the children of a body at
-   * index @p body_index. The resulting list can be further filtered to be those
-   * bodies that belong to the model instance with ID @p model_instance_id.
+   * Returns a vector of indexes of bodies that are the children of the body at
+   * index @p parent_body_index. The resulting list can be further filtered to
+   * be bodies that belong to model instance ID @p model_instance_id.
    */
-  std::vector<int> FindChildrenOfBody(int body_index,
+  std::vector<int> FindChildrenOfBody(int parent_body_index,
       int model_instance_id = -1) const;
 
   /**

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -354,7 +354,7 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
   // list are called "link1".
   std::vector<int> base_body_list = tree->FindBaseBodies();
   for (int index : base_body_list) {
-    EXPECT_EQ(tree->GetBody(index)->get_name(), "link1");
+    EXPECT_EQ(tree->get_body(index).get_name(), "link1");
   }
 
   // Obtains a list of the world's children. Verifies that this list is

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -331,7 +331,8 @@ TEST_F(RigidBodyTreeTest, TestFindModelInstanceBodies) {
 }
 
 // Verifies the correct functionality of RigidBodyTree::FindChildrenOfBody()
-// and RigidBodyTree::FindBaseBodies().
+// and RigidBodyTree::FindBaseBodies(). This also tests
+// RigidBodyTree::get_body() and RigidBodyTree::get_number_of_bodies().
 TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
   // Adds kNumModelInstances instances of a particular URDF model to the tree.
   // Stores the model instance IDs in model_instance_id_list.
@@ -363,6 +364,8 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
 
   EXPECT_EQ(base_body_list.size(), children_of_world_list.size());
 
+  EXPECT_EQ(tree->get_number_of_bodies(), 3 * kNumModelInstances);
+
   for (int world_child_index : children_of_world_list) {
     bool found_child_in_base_body_list = false;
     for (int body_index : base_body_list) {
@@ -381,7 +384,7 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
       model_instance_id_list.at(0));
 
   EXPECT_EQ(base_body_specific_id_list.size(), 1);
-  EXPECT_EQ(tree->GetBody(base_body_specific_id_list.at(0))->get_name(),
+  EXPECT_EQ(tree->get_body(base_body_specific_id_list.at(0)).get_name(),
       "link1");
 
   // Obtains the children of the above "link1" body. Verify that there is only
@@ -391,14 +394,14 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
 
   EXPECT_EQ(children_of_one_base_body.size(), 1);
 
-  EXPECT_EQ(tree->GetBody(children_of_one_base_body.at(0))->get_name(),
+  EXPECT_EQ(tree->get_body(children_of_one_base_body.at(0)).get_name(),
       "link2");
 
   // Verifies that an empty list is returned if a non-matching model instance
   // ID is provided.
   int body_index = base_body_specific_id_list.at(0);
   int non_matching_model_instance_id =
-      tree->GetBody(body_index)->get_model_instance_id() + 1;
+      tree->get_body(body_index).get_model_instance_id() + 1;
 
   std::vector<int> list_of_children_bad_instance_id =
       tree->FindChildrenOfBody(body_index, non_matching_model_instance_id);

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -238,6 +238,35 @@ TEST_F(RigidBodyTreeTest, TestModelInstanceIdTable) {
   EXPECT_EQ(model_instance_id_table["two_dof_robot"], kExpectedModelInstanceId);
 }
 
+// Verifies the correct functionality of RigidBodyTree::FindChildrenOfBody()
+// and RigidBodyTree::FindBaseBodies().
+TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
+  // Defines the number of times we add a model instance as specified by a URDF
+  // to the tree.
+  const int kNumModelInstances = 10;
+
+  std::string file_name =
+      drake::GetDrakePath() +
+      "/systems/plants/test/rigid_body_tree/two_dof_robot.urdf";
+  std::vector<int> model_instance_id_list;
+
+  for (int ii = 0; ii < kNumModelInstances; ++ii) {
+    ModelInstanceIdTable model_instance_id_table =
+      drake::parsers::urdf::AddModelInstanceFromURDF(file_name, tree.get());
+    model_instance_id_list.push_back(model_instance_id_table["two_dof_robot"]);
+  }
+
+  EXPECT_EQ(static_cast<int>(model_instance_id_list.size()),
+      kNumModelInstances);
+
+  {
+    std::vector<int> base_body_list = tree->FindBaseBodies();
+    for (int index : base_body_list) {
+      EXPECT_EQ(tree->GetBody(index)->get_name(), "link1");
+    }
+  }
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace plants

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -344,7 +344,7 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
 
   std::vector<int> model_instance_id_list;
 
-  for (int ii = 0; ii < kNumModelInstances; ++ii) {
+  for (int i = 0; i < kNumModelInstances; ++i) {
     ModelInstanceIdTable model_instance_id_table =
       drake::parsers::urdf::AddModelInstanceFromUrdfFile(file_name, tree.get());
     model_instance_id_list.push_back(model_instance_id_table["two_dof_robot"]);
@@ -364,7 +364,8 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
 
   EXPECT_EQ(base_body_list.size(), children_of_world_list.size());
 
-  EXPECT_EQ(tree->get_number_of_bodies(), 3 * kNumModelInstances);
+  // There are three bodies per model instance plus one body for the world.
+  EXPECT_EQ(tree->get_number_of_bodies(), 3 * kNumModelInstances + 1);
 
   for (int world_child_index : children_of_world_list) {
     bool found_child_in_base_body_list = false;

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -333,14 +333,14 @@ TEST_F(RigidBodyTreeTest, TestFindModelInstanceBodies) {
 // Verifies the correct functionality of RigidBodyTree::FindChildrenOfBody()
 // and RigidBodyTree::FindBaseBodies().
 TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
-  // Defines the number of instances of a particular URDF model is added to the
-  // tree.
+  // Adds kNumModelInstances instances of a particular URDF model to the tree.
+  // Stores the model instance IDs in model_instance_id_list.
   const int kNumModelInstances = 10;
 
-  // Adds kNumModelInstances instances of a particular model to the tree.
   std::string file_name =
       drake::GetDrakePath() +
       "/systems/plants/test/rigid_body_tree/two_dof_robot.urdf";
+
   std::vector<int> model_instance_id_list;
 
   for (int ii = 0; ii < kNumModelInstances; ++ii) {
@@ -356,8 +356,8 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
     EXPECT_EQ(tree->GetBody(index)->get_name(), "link1");
   }
 
-  // Obtains a list of children of the world and verifies that this list is the
-  // same as base_body_list.
+  // Obtains a list of the world's children. Verifies that this list is
+  // identical to base_body_list.
   std::vector<int> children_of_world_list =
       tree->FindChildrenOfBody(RigidBodyTree::kWorldBodyIndex);
 
@@ -366,8 +366,9 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
   for (int world_child_index : children_of_world_list) {
     bool found_child_in_base_body_list = false;
     for (int body_index : base_body_list) {
-      if (body_index == world_child_index)
+      if (body_index == world_child_index) {
         found_child_in_base_body_list = true;
+      }
     }
     EXPECT_TRUE(found_child_in_base_body_list);
   }
@@ -383,8 +384,8 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
   EXPECT_EQ(tree->GetBody(base_body_specific_id_list.at(0))->get_name(),
       "link1");
 
-  // Obtains the child of the above body. Verify that this child is called
-  // "link2".
+  // Obtains the children of the above "link1" body. Verify that there is only
+  // one child and it is called "link2".
   std::vector<int> children_of_one_base_body = tree->FindChildrenOfBody(
       base_body_specific_id_list.at(0));
 
@@ -395,12 +396,12 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
 
   // Verifies that an empty list is returned if a non-matching model instance
   // ID is provided.
+  int body_index = base_body_specific_id_list.at(0);
   int non_matching_model_instance_id =
-      tree->GetBody(base_body_specific_id_list.at(0))->get_model_instance_id()
-      + 1;
+      tree->GetBody(body_index)->get_model_instance_id() + 1;
 
-  std::vector<int> list_of_children_bad_instance_id = tree->FindChildrenOfBody(
-      base_body_specific_id_list.at(0), non_matching_model_instance_id);
+  std::vector<int> list_of_children_bad_instance_id =
+      tree->FindChildrenOfBody(body_index, non_matching_model_instance_id);
 
   EXPECT_EQ(list_of_children_bad_instance_id.size(), 0);
 }


### PR DESCRIPTION
…ies(), and RigidBodyTree::GetBody().

Resolves https://github.com/RobotLocomotion/drake/issues/3142.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3184)
<!-- Reviewable:end -->
