### PR TITLE
Superbuild refactor, part 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(cmake/git/hooks.cmake)
 drake_setup_superbuild()
 drake_setup_platform()
 drake_setup_git_hooks()
+drake_setup_options()
 
 ###############################################################################
 # BEGIN external projects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,99 +6,13 @@ include(CTest)
 include(cmake/config.cmake)
 include(cmake/externals.cmake)
 include(cmake/examples.cmake)
+include(cmake/options.cmake)
 include(cmake/git/hooks.cmake)
 
 drake_setup_superbuild()
 drake_setup_platform()
 drake_setup_git_hooks()
 
-###############################################################################
-# BEGIN options
-
-##########################################
-# External Projects that are ON by default
-##########################################
-option(WITH_EIGEN "required c++ matrix library.  only disable if you have it already." ON)
-option(WITH_GOOGLETEST "required c++ unit test library.  only disable if you have it already." ON)
-option(WITH_GFLAGS "required c++ command-line library.  only disable if you have it already." ON)
-option(WITH_GOOGLE_STYLEGUIDE "provides cpplint.py style checking" ON)
-option(WITH_SWIGMAKE "helper tools to build python & MATLAB wrappers for C++ libraries with Eigen" ON)
-option(WITH_BULLET "used for collision detection" ON)
-option(WITH_BOT_CORE_LCMTYPES "required LCM types library. only disable if you have it already." ON)
-option(WITH_CCD "collision detection between convex shapes" ON)
-option(WITH_SPDLOG "spdlog text logging facility; disabling will turn off text logging." ON)
-if(NOT WIN32)
-  option(WITH_DIRECTOR "vtk-based visualization tool and robot user interface" ON) # not win32 yet.  it builds on windows, but requires manually installation of vtk, etc.  perhaps make a precompiled director pod (a bit like snopt)
-  option(WITH_LCM "interprocess communications protocol for visualizers, etc" ON)
-  option(WITH_LIBBOT "simple open-gl visualizer + lcmgl for director" ON) # there is hope, but i spent a long time cleaning up c/c++ language errors trying to make msvc happy.. and still had a long way to go.
-  option(WITH_NLOPT "nonlinear optimization solver" ON)
-  option(WITH_DREAL "nonlinear SMT solver" OFF)
-  option(WITH_MOSEK "convex optimization solver; free for academics" OFF)
-  option(WITH_OCTOMAP "provides oct-tree data structures" ON)
-  option(WITH_SWIG_MATLAB "A version of SWIG with MATLAB support" ON)
-endif()
-
-option(WITH_YAML_CPP "library for reading and writing yaml configuration files" ON)
-
-##############################################################
-# External Projects that are only needed when MATLAB is in use
-##############################################################
-include(CMakeDependentOption)
-option(DISABLE_MATLAB "Don't use MATLAB even if it is present." OFF)
-if(DISABLE_MATLAB)
-  message(STATUS "MATLAB is disabled.")
-else()
-  find_program(matlab matlab)
-  if(matlab)
-    message(STATUS "Found MATLAB at " ${matlab})
-  else()
-    message(STATUS "Looked for MATLAB but could not find it.")
-  endif()
-endif()
-
-## The following projects are default ON when MATLAB is present and enabled.
-## Otherwise, they are hidden and default OFF.
-cmake_dependent_option(WITH_SPOTLESS "polynomial optimization front-end for MATLAB" ON "NOT DISABLE_MATLAB;matlab" OFF)
-
-## The following projects are default OFF when MATLAB is present and enabled.
-## Otherwise, they are hidden and default OFF.
-## Some of them may also be hidden on Windows regardless of the status of MATLAB.
-cmake_dependent_option(WITH_IRIS "fast approximate convex segmentation" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32;WITH_MOSEK" OFF)
-cmake_dependent_option(WITH_SEDUMI "semi-definite programming solver" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
-cmake_dependent_option(WITH_YALMIP "free optimization front-end for MATLAB" OFF "NOT DISABLE_MATLAB;matlab;NOT WIN32" OFF)
-
-
-# IPOPT is currently disabled on Mac when MATLAB is enabled due to MATLAB compatibility
-# issues: https://github.com/RobotLocomotion/drake/issues/2578
-cmake_dependent_option(WITH_IPOPT "nonlinear optimization solver" ON "NOT APPLE OR DISABLE_MATLAB" OFF)
-
-
-###########################################
-# External Projects that are OFF by default
-###########################################
-option(WITH_SNOPT "nonlinear optimization solver; requires access to RobotLocomotion/snopt-pod")
-cmake_dependent_option(WITH_SIGNALSCOPE "live plotting tool for lcm messages" OFF "NOT WIN32;WITH_DIRECTOR" OFF)
-
-if(NOT WIN32) # many of these might work on win32 with little or no work... they just haven't been tried
-  option(WITH_AVL "use w/ AVL to compute aerodynamic coefficients for airfoils")
-  option(WITH_GUROBI "convex/integer optimization solver; free for academics (will prompt you for login bits)")
-  option(WITH_MESHCONVERTERS "uses vcglib to convert a few standard filetypes")
-  option(WITH_TEXTBOOK "pull in the Underactuated Robotics textbook and its examples")  # almost works on windows.  the update step call to git was complaining about local modifications on drake003
-  option(WITH_XFOIL "use w/ XFOIL to compute aerodynamic coefficients for airfoils")
-endif()
-
-# Option to skip building drake proper via the superbuild. This allows the
-# superbuild to build everything BUT drake, which can still be built separately
-# from its build directory. This is used by the dashboards to make separate
-# submissions for drake proper and the superbuild without drake. Some users may
-# also find it useful, especially to build drake with ninja using fewer than
-# the default number of jobs.
-option(SKIP_DRAKE_BUILD "Build external projects but not drake itself" OFF)
-if(SKIP_DRAKE_BUILD)
-  set(DRAKE_BUILD_COMMANDS BUILD_COMMAND : INSTALL_COMMAND :)
-endif()
-
-# END options
 ###############################################################################
 # BEGIN external projects
 
@@ -194,7 +108,7 @@ drake_add_external(sedumi CMAKE
   CMAKE_ARGS -DMatlab_ROOT_DIR=${MATLAB_ROOT_DIR})
 
 # snopt
-if(NOT DISABLE_MATLAB AND matlab)
+if(MATLAB_EXECUTABLE)
   set(SNOPT_EXTRA_CMAKE_ARGS
     -DBUILD_SNOPT_C_MEX=ON
     -DMatlab_ROOT_DIR=${MATLAB_ROOT_DIR})
@@ -230,7 +144,7 @@ drake_add_external(swig_matlab PUBLIC
   INSTALL_COMMAND ${MAKE_COMMAND} install)
 
 # textbook
-if(NOT DISABLE_MATLAB AND matlab)
+if(MATLAB_EXECUTABLE)
   set(TEXTBOOK_CMAKE_ARGS
     -DBUILD_TESTING=ON
     -DMatlab_ROOT_DIR=${MATLAB_ROOT_DIR})
@@ -297,6 +211,17 @@ drake_add_external(signalscope PUBLIC
 # xfoil
 # The Ninja generator does not support Fortran.
 drake_add_external(xfoil PUBLIC CMAKE GENERATOR "Unix Makefiles")
+
+# Option to skip building drake proper via the superbuild. This allows the
+# superbuild to build everything BUT drake, which can still be built separately
+# from its build directory. This is used by the dashboards to make separate
+# submissions for drake proper and the superbuild without drake. Some users may
+# also find it useful, especially to build drake with ninja using fewer than
+# the default number of jobs.
+option(SKIP_DRAKE_BUILD "Build external projects but not drake itself" OFF)
+if(SKIP_DRAKE_BUILD)
+  set(DRAKE_BUILD_COMMANDS BUILD_COMMAND : INSTALL_COMMAND :)
+endif()
 
 # drake: For drake, list both compilation AND RUNTIME dependencies. Runtime
 # dependencies are needed because the drake project must configure only after

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -26,16 +26,30 @@ endfunction()
 # Find MATLAB.
 #------------------------------------------------------------------------------
 function(drake_setup_matlab)
-  # Look for the MATLAB executable. This does not use find_package(Matlab)
-  # because that is "really good at finding MATLAB", and we only want to enable
-  # matlab support if the matlab executable is in the user's PATH.
-  find_program(MATLAB_EXECUTABLE matlab)
+  option(DISABLE_MATLAB "Don't use MATLAB even if it is present." OFF)
 
-  # Determine the MATLAB root.
-  get_filename_component(MATLAB_ROOT_DIR "${MATLAB_EXECUTABLE}" DIRECTORY)
-  get_filename_component(MATLAB_ROOT_DIR "${MATLAB_ROOT_DIR}" DIRECTORY CACHE)
+  if(DISABLE_MATLAB)
+    message(STATUS "MATLAB is disabled.")
+    unset(MATLAB_EXECUTABLE CACHE) # TODO unset MATLAB_FOUND instead (see below)
+  else()
+    # Look for the MATLAB executable. This does not use find_package(Matlab)
+    # because that is "really good at finding MATLAB", and we only want to
+    # enable matlab support if the matlab executable is in the user's PATH.
+    find_program(MATLAB_EXECUTABLE matlab)
+    if(MATLAB_EXECUTABLE)
+      message(STATUS "Found MATLAB: ${MATLAB_EXECUTABLE}")
 
-  # TODO find_package(Matlab) and delete mex_setup
+      # Determine the MATLAB root.
+      get_filename_component(_matlab_bindir "${MATLAB_EXECUTABLE}" DIRECTORY)
+      get_filename_component(MATLAB_ROOT_DIR
+        "${_matlab_bindir}" DIRECTORY CACHE)
+
+      # TODO find_package(Matlab) and delete mex_setup
+      # TODO change MATLAB_EXECUTABLE in options.cmake to MATLAB_FOUND
+    else()
+      message(STATUS "MATLAB was not found.")
+    endif()
+  endif()
 endfunction()
 
 #------------------------------------------------------------------------------

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -151,6 +151,8 @@ macro(drake_setup_java)
   # compile flags)
   if(MATLAB_EXECUTABLE AND NOT DISABLE_MATLAB)
     drake_setup_java_for_matlab()
+  else()
+    unset(CMAKE_JAVA_COMPILE_FLAGS CACHE)
   endif()
 endmacro()
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -40,7 +40,8 @@ function(drake_setup_matlab)
       message(STATUS "Found MATLAB: ${MATLAB_EXECUTABLE}")
 
       # Determine the MATLAB root.
-      get_filename_component(_matlab_bindir "${MATLAB_EXECUTABLE}" DIRECTORY)
+      get_filename_component(_matlab_realpath "${MATLAB_EXECUTABLE}" REALPATH)
+      get_filename_component(_matlab_bindir "${_matlab_realpath}" DIRECTORY)
       get_filename_component(MATLAB_ROOT_DIR
         "${_matlab_bindir}" DIRECTORY CACHE)
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,0 +1,197 @@
+include(CMakeDependentOption)
+
+#------------------------------------------------------------------------------
+# Add an option whether to use the system or internal version of a (required)
+# dependency.
+#------------------------------------------------------------------------------
+function(drake_system_dependency NAME DESCRIPTION)
+  # Backwards compatibility
+  set(_default OFF)
+  if(DEFINED WITH_${NAME} AND NOT WITH_${NAME})
+    set(_default ON)
+  endif()
+
+  set(_else "(If OFF, the internal version will be used.)")
+  option(USE_SYSTEM_${NAME}
+    "Use the system-provided copy of ${DESCRIPTION}. ${_else}"
+    ${_default})
+
+  # Internally, externals use WITH_<NAME> to decide if an external is enabled,
+  # so map the option value to that name.
+  if(USE_SYSTEM_${NAME})
+    set(WITH_${NAME} OFF CACHE INTERNAL "" FORCE)
+  else()
+    set(WITH_${NAME} ON CACHE INTERNAL "" FORCE)
+  endif()
+endfunction()
+
+#------------------------------------------------------------------------------
+# Add an option whether or not to build an optional component.
+#
+# Arguments:
+#   <DEFAULT_STATE> - Is the component enabled by default? (`ON` or `OFF`)
+#   DEPENDS <expression>
+#     A list of expressions which must evaluate to true for the component to
+#     be made available. (Otherwise, the component will not be enabled, and the
+#     option for the component will be hidden.)
+#
+# Extra arguments are combined (with a single space) to form the description of
+# the option.
+#------------------------------------------------------------------------------
+function(drake_optional_external NAME DEFAULT_STATE)
+  string(REPLACE "\\" "\\\\" _args "${ARGN}")
+  cmake_parse_arguments(_opt "" "DEPENDS" "" ${_args})
+
+  foreach(_snippet IN LISTS _opt_UNPARSED_ARGUMENTS)
+    set(_description "${_description} ${_snippet}")
+  endforeach()
+  string(STRIP "${_description}" _description)
+
+  if(DEFINED _opt_DEPENDS)
+    cmake_dependent_option(WITH_${NAME}
+      ${_description}
+      ${DEFAULT_STATE}
+      "${_opt_DEPENDS}" OFF)
+  else()
+    option(WITH_${NAME} ${_description} ${DEFAULT_STATE})
+  endif()
+endfunction()
+
+###############################################################################
+# BEGIN "optional" dependencies
+
+# These are packages that we require and can build, but which we allow the user
+# to use their own copy (usually provided by the system) if preferred.
+
+drake_system_dependency(
+  EIGEN
+  "the Eigen C++ matrix library")
+
+drake_system_dependency(
+  GOOGLETEST
+  "the Google testing framework")
+
+drake_system_dependency(
+  GFLAGS
+  "the Google command-line flags processing library")
+
+drake_system_dependency(
+  LCM
+  "the Lightweight Communications and Marshaling IPC suite")
+
+drake_system_dependency(
+  BOT_CORE_LCMTYPES
+  "the libbot core LCM types")
+
+# END "optional" dependencies
+###############################################################################
+# BEGIN external projects that are ON by default
+
+drake_optional_external(GOOGLE_STYLEGUIDE ON
+  "Google code style tools for cpplint.py style checking" ON)
+
+drake_optional_external(SPDLOG ON
+  "Fast C++ text logging facility\; disabling will turn off text logging")
+
+drake_optional_external(SWIGMAKE ON
+  "Helper tools to build Python & MATLAB wrappers"
+  "for C++ libraries with Eigen")
+
+drake_optional_external(BULLET ON "Bullet library for collision detection")
+
+drake_optional_external(CCD ON "Convex shape Collision Detection library")
+
+if(NOT WIN32)
+  # Not win32 yet; builds, but requires manual installation of VTKk, etc.
+  drake_optional_external(DIRECTOR ON
+    "VTK-based visualization tool and robot user interface")
+
+  # Probably not on Windows until lcmgl is split out
+  drake_optional_external(LIBBOT ON
+    "libbot2 robotics library\;"
+    "used for its simple open-gl visualizer + lcmgl for director")
+
+  drake_optional_external(NLOPT ON "Non-linear optimization solver")
+
+  # IPOPT is currently disabled on Mac when MATLAB is enabled due to MATLAB
+  # compatibility issues: https://github.com/RobotLocomotion/drake/issues/2578
+  drake_optional_external(IPOPT ON
+    DEPENDS "NOT APPLE OR NOT MATLAB_EXECUTABLE"
+    "Interior Point Optimizer, for solving non-linear optimizations")
+
+  drake_optional_external(OCTOMAP ON
+    "3D occupancy mapping library\; provides oct-tree data structures")
+
+  drake_optional_external(SWIG_MATLAB ON
+    "A version of SWIG with MATLAB support")
+endif()
+
+drake_optional_external(YAML_CPP ON
+  "C++ library for reading and writing YAML configuration files")
+
+# END external projects that are ON by default
+###############################################################################
+# BEGIN external projects that are only needed when MATLAB is in use
+
+# The following projects are default ON when MATLAB is present and enabled.
+# Otherwise, they are hidden and default OFF.
+drake_optional_external(SPOTLESS ON
+  DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE"
+  "polynomial optimization front-end for MATLAB")
+
+# The following projects are default OFF when MATLAB is present and enabled.
+# Otherwise, they are hidden and default OFF. Some of them may also be hidden
+# on Windows regardless of the status of MATLAB.
+drake_optional_external(IRIS OFF
+  DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32\;WITH_MOSEK"
+  "fast approximate convex segmentation")
+
+drake_optional_external(SEDUMI OFF
+  DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32"
+  "semi-definite programming solver")
+
+drake_optional_external(YALMIP OFF
+  DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32"
+  "free optimization front-end for MATLAB")
+
+# END external projects that are only needed when MATLAB is in use
+###############################################################################
+# BEGIN external projects that are OFF by default
+
+drake_optional_external(SNOPT OFF
+  "Sparse Non-linear Optimizer\;"
+  "requires access to RobotLocomotion/snopt-pod")
+
+drake_optional_external(SIGNALSCOPE OFF DEPENDS "NOT WIN32\;WITH_DIRECTOR"
+  "Live plotting tool for LCM messages")
+
+# Many of these might work on win32 with little or no work... they just haven't
+# been tried.
+if(NOT WIN32)
+  drake_optional_external(AVL OFF
+    "use w/ AVL to compute aerodynamic coefficients for airfoils")
+
+  drake_optional_external(DREAL OFF
+    "Non-linear SMT solver and automated reasoning tool")
+
+  drake_optional_external(GUROBI OFF
+    "Convex/integer optimization solver\;"
+    "free for academics (will prompt you for login bits)")
+
+  drake_optional_external(MESHCONVERTERS OFF
+    "uses vcglib to convert a few standard filetypes")
+
+  drake_optional_external(MOSEK OFF
+    "Convex optimization solver\; free for academics")
+
+  # Almost works on windows;  the update step call to git was complaining about
+  # local modifications on drake003
+  drake_optional_external(TEXTBOOK OFF
+    "The Underactuated Robotics textbook and its examples")
+
+  drake_optional_external(XFOIL OFF
+    "use w/ XFOIL to compute aerodynamic coefficients for airfoils")
+endif()
+
+# END external projects that are OFF by default
+###############################################################################

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -12,7 +12,11 @@ include(CMakeDependentOption)
 #     option for the component will be hidden.)
 #
 # Extra arguments are combined (with a single space) to form the description of
-# the option.
+# the option. A ';' appearing in the description text should be escaped to
+# prevent it being seen as an argument separator.
+#
+# This creates an option <NAME>, which may be either a dependent option or an
+# unconditional option.
 #------------------------------------------------------------------------------
 function(drake_option NAME DEFAULT_STATE)
   # "Fix" escaping so cmake_parse_arguments will split properly (note:
@@ -62,11 +66,14 @@ endfunction()
 #     option for the component will be hidden.)
 #
 # Extra arguments are combined (with a single space) to form the description of
-# the option.
+# the option. A ';' appearing in the description text should be escaped to
+# prevent it being seen as an argument separator.
 #
-# If the component is required, and the system version is not selected, the
-# internal version will be enabled. Otherwise, the user will be given an option
-# (defaulting to ON) if the component should be built.
+# This creates an option USE_SYSTEM_<NAME> that selects if the system version
+# of the dependency will be used. If the component is required, and the system
+# version is not selected, the internal version will be enabled. Otherwise, the
+# user will be given an option (WITH_<NAME>, defaulting to ON) if the component
+# should be built.
 #
 # Internally, this sets HAVE_<NAME> to indicate if the external is available,
 # and WITH_<NAME> to indicate if our internal version of the external should be

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -109,143 +109,150 @@ function(drake_optional_external NAME DEFAULT_STATE)
   set(HAVE_${NAME} "${WITH_${NAME}}" PARENT_SCOPE)
 endfunction()
 
-###############################################################################
-# BEGIN "system" dependencies
+#------------------------------------------------------------------------------
+# Set up options
+#------------------------------------------------------------------------------
+macro(drake_setup_options)
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # BEGIN "system" dependencies
 
-# These are packages that we can build, but which we allow the user to use
-# their own copy (usually provided by the system) if preferred. Some of these
-# may be required.
+  # These are packages that we can build, but which we allow the user to use
+  # their own copy (usually provided by the system) if preferred. Some of these
+  # may be required.
 
-drake_system_dependency(
-  EIGEN REQUIRES Eigen3 VERSION 3.2.92
-  "Eigen C++ matrix library")
+  drake_system_dependency(
+    EIGEN REQUIRES Eigen3 VERSION 3.2.92
+    "Eigen C++ matrix library")
 
-drake_system_dependency(
-  GOOGLETEST REQUIRES GTest
-  "Google testing framework")
+  drake_system_dependency(
+    GOOGLETEST REQUIRES GTest
+    "Google testing framework")
 
-drake_system_dependency(
-  GFLAGS REQUIRES gflags
-  "Google command-line flags processing library")
+  drake_system_dependency(
+    GFLAGS REQUIRES gflags
+    "Google command-line flags processing library")
 
-drake_system_dependency(
-  LCM OPTIONAL REQUIRES lcm
-  "Lightweight Communications and Marshaling IPC suite")
+  drake_system_dependency(
+    LCM OPTIONAL REQUIRES lcm
+    "Lightweight Communications and Marshaling IPC suite")
 
-drake_system_dependency(
-  BOT_CORE_LCMTYPES OPTIONAL REQUIRES bot2-core
-  DEPENDS "HAVE_LCM"
-  "libbot2 robotics suite LCM types")
+  drake_system_dependency(
+    BOT_CORE_LCMTYPES OPTIONAL REQUIRES bot2-core
+    DEPENDS "HAVE_LCM"
+    "libbot2 robotics suite LCM types")
 
-drake_system_dependency(YAML_CPP OPTIONAL REQUIRES yaml-cpp
-  "C++ library for reading and writing YAML configuration files")
+  drake_system_dependency(YAML_CPP OPTIONAL REQUIRES yaml-cpp
+    "C++ library for reading and writing YAML configuration files")
 
-# END "system" dependencies
-###############################################################################
-# BEGIN external projects that are ON by default
+  # END "system" dependencies
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # BEGIN external projects that are ON by default
 
-drake_optional_external(GOOGLE_STYLEGUIDE ON
-  "Google code style tools for cpplint.py style checking" ON)
+  drake_optional_external(GOOGLE_STYLEGUIDE ON
+    "Google code style tools for cpplint.py style checking" ON)
 
-drake_optional_external(SPDLOG ON
-  "Fast C++ text logging facility\; disabling will turn off text logging")
+  drake_optional_external(SPDLOG ON
+    "Fast C++ text logging facility\; disabling will turn off text logging")
 
-drake_optional_external(SWIGMAKE ON
-  "Helper tools to build Python & MATLAB wrappers"
-  "for C++ libraries with Eigen")
+  drake_optional_external(SWIGMAKE ON
+    "Helper tools to build Python & MATLAB wrappers"
+    "for C++ libraries with Eigen")
 
-drake_optional_external(BULLET ON "Bullet library for collision detection")
+  drake_optional_external(BULLET ON "Bullet library for collision detection")
 
-drake_optional_external(CCD ON "Convex shape Collision Detection library")
+  drake_optional_external(CCD ON "Convex shape Collision Detection library")
 
-if(NOT WIN32)
-  # Not win32 yet; builds, but requires manual installation of VTKk, etc.
-  drake_optional_external(DIRECTOR ON DEPENDS "HAVE_LCM\;HAVE_BOT_CORE_LCMTYPES"
-    "VTK-based visualization tool and robot user interface")
+  if(NOT WIN32)
+    # Not win32 yet; builds, but requires manual installation of VTKk, etc.
+    drake_optional_external(DIRECTOR ON
+      DEPENDS "HAVE_LCM\;HAVE_BOT_CORE_LCMTYPES"
+      "VTK-based visualization tool and robot user interface")
 
-  # Probably not on Windows until lcmgl is split out
-  drake_optional_external(LIBBOT ON
-    "libbot2 robotics suite\;"
-    "used for its simple open-gl visualizer + lcmgl for director")
+    # Probably not on Windows until lcmgl is split out
+    drake_optional_external(LIBBOT ON
+      "libbot2 robotics suite\;"
+      "used for its simple open-gl visualizer + lcmgl for director")
 
-  drake_optional_external(NLOPT ON "Non-linear optimization solver")
+    drake_optional_external(NLOPT ON "Non-linear optimization solver")
 
-  # IPOPT is currently disabled on Mac when MATLAB is enabled due to MATLAB
-  # compatibility issues: https://github.com/RobotLocomotion/drake/issues/2578
-  drake_optional_external(IPOPT ON
-    DEPENDS "NOT APPLE OR NOT MATLAB_EXECUTABLE"
-    "Interior Point Optimizer, for solving non-linear optimizations")
+    # IPOPT is currently disabled on Mac when MATLAB is enabled due to MATLAB
+    # compatibility issues:
+    # https://github.com/RobotLocomotion/drake/issues/2578
+    drake_optional_external(IPOPT ON
+      DEPENDS "NOT APPLE OR NOT MATLAB_EXECUTABLE"
+      "Interior Point Optimizer, for solving non-linear optimizations")
 
-  drake_optional_external(OCTOMAP ON
-    "3D occupancy mapping library\; provides oct-tree data structures")
+    drake_optional_external(OCTOMAP ON
+      "3D occupancy mapping library\; provides oct-tree data structures")
 
-  drake_optional_external(SWIG_MATLAB ON
-    "A version of SWIG with MATLAB support")
-endif()
+    drake_optional_external(SWIG_MATLAB ON
+      "A version of SWIG with MATLAB support")
+  endif()
 
-# END external projects that are ON by default
-###############################################################################
-# BEGIN external projects that are only needed when MATLAB is in use
+  # END external projects that are ON by default
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # BEGIN external projects that are only needed when MATLAB is in use
 
-# The following projects are default ON when MATLAB is present and enabled.
-# Otherwise, they are hidden and default OFF.
-drake_optional_external(SPOTLESS ON
-  DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE"
-  "polynomial optimization front-end for MATLAB")
+  # The following projects are default ON when MATLAB is present and enabled.
+  # Otherwise, they are hidden and default OFF.
+  drake_optional_external(SPOTLESS ON
+    DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE"
+    "polynomial optimization front-end for MATLAB")
 
-# The following projects are default OFF when MATLAB is present and enabled.
-# Otherwise, they are hidden and default OFF. Some of them may also be hidden
-# on Windows regardless of the status of MATLAB.
-drake_optional_external(IRIS OFF
-  DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32\;WITH_MOSEK"
-  "fast approximate convex segmentation")
+  # The following projects are default OFF when MATLAB is present and enabled.
+  # Otherwise, they are hidden and default OFF. Some of them may also be hidden
+  # on Windows regardless of the status of MATLAB.
+  drake_optional_external(IRIS OFF
+    DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32\;WITH_MOSEK"
+    "fast approximate convex segmentation")
 
-drake_optional_external(SEDUMI OFF
-  DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32"
-  "semi-definite programming solver")
+  drake_optional_external(SEDUMI OFF
+    DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32"
+    "semi-definite programming solver")
 
-drake_optional_external(YALMIP OFF
-  DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32"
-  "free optimization front-end for MATLAB")
+  drake_optional_external(YALMIP OFF
+    DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32"
+    "free optimization front-end for MATLAB")
 
-# END external projects that are only needed when MATLAB is in use
-###############################################################################
-# BEGIN external projects that are OFF by default
+  # END external projects that are only needed when MATLAB is in use
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # BEGIN external projects that are OFF by default
 
-drake_optional_external(SNOPT OFF
-  "Sparse Non-linear Optimizer\;"
-  "requires access to RobotLocomotion/snopt-pod")
+  drake_optional_external(SNOPT OFF
+    "Sparse Non-linear Optimizer\;"
+    "requires access to RobotLocomotion/snopt-pod")
 
-drake_optional_external(SIGNALSCOPE OFF DEPENDS "NOT WIN32\;WITH_DIRECTOR"
-  "Live plotting tool for LCM messages")
+  drake_optional_external(SIGNALSCOPE OFF DEPENDS "NOT WIN32\;WITH_DIRECTOR"
+    "Live plotting tool for LCM messages")
 
-# Many of these might work on win32 with little or no work... they just haven't
-# been tried.
-if(NOT WIN32)
-  drake_optional_external(AVL OFF
-    "use w/ AVL to compute aerodynamic coefficients for airfoils")
+  # Many of these might work on win32 with little or no work... they just
+  # haven't been tried.
+  if(NOT WIN32)
+    drake_optional_external(AVL OFF
+      "use w/ AVL to compute aerodynamic coefficients for airfoils")
 
-  drake_optional_external(DREAL OFF
-    "Non-linear SMT solver and automated reasoning tool")
+    drake_optional_external(DREAL OFF
+      "Non-linear SMT solver and automated reasoning tool")
 
-  drake_optional_external(GUROBI OFF
-    "Convex/integer optimization solver\;"
-    "free for academics (will prompt you for login bits)")
+    drake_optional_external(GUROBI OFF
+      "Convex/integer optimization solver\;"
+      "free for academics (will prompt you for login bits)")
 
-  drake_optional_external(MESHCONVERTERS OFF
-    "uses vcglib to convert a few standard filetypes")
+    drake_optional_external(MESHCONVERTERS OFF
+      "uses vcglib to convert a few standard filetypes")
 
-  drake_optional_external(MOSEK OFF
-    "Convex optimization solver\; free for academics")
+    drake_optional_external(MOSEK OFF
+      "Convex optimization solver\; free for academics")
 
-  # Almost works on windows;  the update step call to git was complaining about
-  # local modifications on drake003
-  drake_optional_external(TEXTBOOK OFF
-    "The Underactuated Robotics textbook and its examples")
+    # Almost works on windows;  the update step call to git was complaining
+    # about local modifications on drake003
+    drake_optional_external(TEXTBOOK OFF
+      "The Underactuated Robotics textbook and its examples")
 
-  drake_optional_external(XFOIL OFF
-    "use w/ XFOIL to compute aerodynamic coefficients for airfoils")
-endif()
+    drake_optional_external(XFOIL OFF
+      "use w/ XFOIL to compute aerodynamic coefficients for airfoils")
+  endif()
 
-# END external projects that are OFF by default
-###############################################################################
+  # END external projects that are OFF by default
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+endmacro()


### PR DESCRIPTION
...a.k.a. the Great Options Refactor. Move options for what packages to include in the build to new `options.cmake`, further simplifying the root `CMakeLists.txt`. Add helper functions to make setting up options more consistent. Add ability to specify when the system version of a package should be used instead for some packages.

Mandatory system packages expose only a `WITH_SYSTEM_<NAME>` option. If `OFF`, the internal version is automatically enabled. Otherwise the build fails if `<NAME>` is not found. The way optional system packages work is:

- If `USE_SYSTEM_<NAME>` is `ON`, `WITH_<NAME>` is hidden and `OFF`, and the build will fail if `<NAME>` is not found.
- Otherwise, a `WITH_<NAME>` option is available. If `OFF`, that external is not available. If `ON`, the internal version is built.

Internally, `WITH_<NAME>` is set for all packages to control if the external is built. Also, `HAVE_<NAME>` is set to specify if the external is available, either because the internal version is enabled, or a system version is found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3186)
<!-- Reviewable:end -->
