### PR TITLE
Rename Cars systems with "1" suffix for System1

### DIFF
--- a/drake/examples/Cars/car_simulation.cc
+++ b/drake/examples/Cars/car_simulation.cc
@@ -276,7 +276,7 @@ Curve2<double> MakeCurve(double radius, double inset) {
 }
 }  // namespace anonymous
 
-std::shared_ptr<TrajectoryCar> CreateTrajectoryCarSystem(int index) {
+std::shared_ptr<TrajectoryCar1> CreateTrajectoryCarSystem(int index) {
   // The possible curves to trace (lanes).
   const std::vector<Curve2<double>> curves{
     MakeCurve(40.0, 0.0),  // BR
@@ -288,7 +288,7 @@ std::shared_ptr<TrajectoryCar> CreateTrajectoryCarSystem(int index) {
   const auto& curve = curves[index % curves.size()];
   const double start_time = (index / curves.size()) * 0.8;
   const double kSpeed = 8.0;
-  return std::make_shared<TrajectoryCar>(curve, kSpeed, start_time);
+  return std::make_shared<TrajectoryCar1>(curve, kSpeed, start_time);
 }
 
 std::shared_ptr<

--- a/drake/examples/Cars/car_simulation.h
+++ b/drake/examples/Cars/car_simulation.h
@@ -137,7 +137,7 @@ CreateVehicleSystem(std::shared_ptr<RigidBodySystem> rigid_body_sys);
  * @param index Selects which pre-programmed trajectory to use.
  */
 DRAKECARS_EXPORT
-std::shared_ptr<TrajectoryCar> CreateTrajectoryCarSystem(int index);
+std::shared_ptr<TrajectoryCar1> CreateTrajectoryCarSystem(int index);
 
 /**
  * Creates a linear system to map NPC car state to the state vector of a

--- a/drake/examples/Cars/demo_multi_car.cc
+++ b/drake/examples/Cars/demo_multi_car.cc
@@ -50,7 +50,7 @@ int DoMain(int argc, const char* argv[]) {
   //  U: ()
   //  X: ()
   //  Y: [(xy-position, heading, velocity), ...] per SimpleCarState
-  auto cars_system = std::make_shared<NArySystem<TrajectoryCar>>();
+  auto cars_system = std::make_shared<NArySystem<TrajectoryCar1>>();
   // NarySystem for car visualization.
   // BotVisualizer:
   //  U: [(xy-position, heading, velocity), ...] per SimpleCarState

--- a/drake/examples/Cars/simple_car-inl.h
+++ b/drake/examples/Cars/simple_car-inl.h
@@ -17,7 +17,7 @@
 namespace drake {
 
 template <typename ScalarType>
-SimpleCar::StateVector<ScalarType> SimpleCar::dynamics(
+SimpleCar1::StateVector<ScalarType> SimpleCar1::dynamics(
     const ScalarType&,
     const StateVector<ScalarType>& state,
     const InputVector<ScalarType>& input) const {
@@ -54,7 +54,7 @@ SimpleCar::StateVector<ScalarType> SimpleCar::dynamics(
 }
 
 template <typename ScalarType>
-SimpleCar::OutputVector<ScalarType> SimpleCar::output(
+SimpleCar1::OutputVector<ScalarType> SimpleCar1::output(
     const ScalarType&,
     const StateVector<ScalarType>& state,
     const InputVector<ScalarType>&) const {

--- a/drake/examples/Cars/simple_car.cc
+++ b/drake/examples/Cars/simple_car.cc
@@ -8,7 +8,7 @@ const double kInchToMeter = 0.0254;
 const double kDegToRadian = 0.0174532925199;
 
 // kDefaultConfig approximates a 2010 Toyota Prius.
-const lcmt_simple_car_config_t SimpleCar::kDefaultConfig = {
+const lcmt_simple_car_config_t SimpleCar1::kDefaultConfig = {
   0,
   106.3 * kInchToMeter,
   59.9 * kInchToMeter,
@@ -22,15 +22,15 @@ const lcmt_simple_car_config_t SimpleCar::kDefaultConfig = {
 // Explicitly instantiate all ScalarType-using definitions.
 #define DRAKE_INSTANTIATE(ScalarType)                           \
 template DRAKECARS_EXPORT                                       \
-SimpleCar::StateVector<ScalarType> SimpleCar::dynamics(         \
+SimpleCar1::StateVector<ScalarType> SimpleCar1::dynamics(       \
       const ScalarType&,                                        \
-      const SimpleCar::StateVector<ScalarType>&,                \
-      const SimpleCar::InputVector<ScalarType>&) const;         \
+      const SimpleCar1::StateVector<ScalarType>&,               \
+      const SimpleCar1::InputVector<ScalarType>&) const;        \
 template DRAKECARS_EXPORT                                       \
-SimpleCar::OutputVector<ScalarType> drake::SimpleCar::output(   \
+SimpleCar1::OutputVector<ScalarType> drake::SimpleCar1::output( \
     const ScalarType&,                                          \
-    const SimpleCar::StateVector<ScalarType>&,                  \
-    const SimpleCar::InputVector<ScalarType>&) const;
+    const SimpleCar1::StateVector<ScalarType>&,                 \
+    const SimpleCar1::InputVector<ScalarType>&) const;
 
 // These instantiations must match the API documentation in simple_car.h.
 DRAKE_INSTANTIATE(double)

--- a/drake/examples/Cars/simple_car.h
+++ b/drake/examples/Cars/simple_car.h
@@ -2,6 +2,7 @@
 
 #include "drake/drakeCars_export.h"
 #include "drake/examples/Cars/system1_cars_vectors.h"
+#include "drake/systems/framework/leaf_system.h"
 #include "lcmtypes/drake/lcmt_simple_car_config_t.hpp"
 
 namespace drake {
@@ -30,11 +31,11 @@ namespace drake {
 ///
 /// output vector: same as state vector.
 ///
-class DRAKECARS_EXPORT SimpleCar {
+class DRAKECARS_EXPORT SimpleCar1 {
  public:
   static const drake::lcmt_simple_car_config_t kDefaultConfig;
 
-  explicit SimpleCar(
+  explicit SimpleCar1(
       const drake::lcmt_simple_car_config_t& config = kDefaultConfig)
       : config_(config) {}
 

--- a/drake/examples/Cars/simple_car_demo.cc
+++ b/drake/examples/Cars/simple_car_demo.cc
@@ -24,7 +24,7 @@ namespace {
 int do_main(int argc, const char* argv[]) {
   std::shared_ptr<lcm::LCM> lcm = std::make_shared<lcm::LCM>();
 
-  auto car = std::make_shared<SimpleCar>();
+  auto car = std::make_shared<SimpleCar1>();
   auto adapter = CreateSimpleCarVisualizationAdapter();
 
   //

--- a/drake/examples/Cars/test/simple_car_scalartype_test.cc
+++ b/drake/examples/Cars/test/simple_car_scalartype_test.cc
@@ -34,7 +34,7 @@ namespace test {
 namespace {
 
 GTEST_TEST(SimpleCarScalarTypeTest, CompileTest) {
-  const SimpleCar dut;
+  const SimpleCar1 dut;
 
   const MST time_zero{};
   const SimpleCarState1<MST> state_zeros{};

--- a/drake/examples/Cars/test/simple_car_test.cc
+++ b/drake/examples/Cars/test/simple_car_test.cc
@@ -80,7 +80,7 @@ class HistorySystem {
 };
 
 GTEST_TEST(SimpleCarTest, ZerosIn) {
-  SimpleCar dut;
+  SimpleCar1 dut;
   SimpleCarState1<double> state_zeros;
   DrivingCommand1<double> input_zeros;
 
@@ -96,7 +96,7 @@ GTEST_TEST(SimpleCarTest, Accelerating) {
   DrivingCommand1<double> max_throttle;
   max_throttle.set_throttle(1.);
 
-  auto car = std::make_shared<SimpleCar>();
+  auto car = std::make_shared<SimpleCar1>();
   SimpleCarState1<double> initial_state;
   auto history_system =
       std::make_shared<HistorySystem<SimpleCarState1>>(initial_state);
@@ -127,22 +127,22 @@ GTEST_TEST(SimpleCarTest, Accelerating) {
   // These clauses are deliberately broad; we don't care so much about the
   // exact values, but rather that we got somewhere.
   EXPECT_NEAR(history_system->states_[max_time].x(),
-              SimpleCar::kDefaultConfig.max_velocity *
+              SimpleCar1::kDefaultConfig.max_velocity *
               (end_time - start_time), 3e2);
   EXPECT_GT(history_system->states_[max_time].x(),
-            SimpleCar::kDefaultConfig.max_velocity *
+            SimpleCar1::kDefaultConfig.max_velocity *
             (end_time - start_time) / 2);
   EXPECT_EQ(history_system->states_[max_time].y(), 0.);
   EXPECT_EQ(history_system->states_[max_time].heading(), 0.);
   EXPECT_NEAR(history_system->states_[max_time].velocity(),
-              SimpleCar::kDefaultConfig.max_velocity, 1e-5);
+              SimpleCar1::kDefaultConfig.max_velocity, 1e-5);
 }
 
 GTEST_TEST(SimpleCarTest, Braking) {
   DrivingCommand1<double> max_brake;
   max_brake.set_brake(1.);
 
-  auto car = std::make_shared<SimpleCar>();
+  auto car = std::make_shared<SimpleCar1>();
   SimpleCarState1<double> initial_state;
   double speed = 10.;
   initial_state.set_velocity(speed);
@@ -184,7 +184,7 @@ GTEST_TEST(SimpleCarTest, Braking) {
 GTEST_TEST(SimpleCarTest, Steering) {
   DrivingCommand1<double> left(Eigen::Vector3d(M_PI / 2, 0., 0.));
 
-  auto car = std::make_shared<SimpleCar>();
+  auto car = std::make_shared<SimpleCar1>();
   SimpleCarState1<double> initial_state;
   double speed = 40.;
   initial_state.set_velocity(speed);
@@ -215,8 +215,8 @@ GTEST_TEST(SimpleCarTest, Steering) {
   EXPECT_EQ(history_system->states_[start_time].velocity(), speed);
 
   double min_turn_radius =
-      SimpleCar::kDefaultConfig.wheelbase /
-      std::tan(SimpleCar::kDefaultConfig.max_abs_steering_angle);
+      SimpleCar1::kDefaultConfig.wheelbase /
+      std::tan(SimpleCar1::kDefaultConfig.max_abs_steering_angle);
   double turn_epsilon = min_turn_radius * 1e-3;
 
   for (const auto& pair : history_system->states_) {

--- a/drake/examples/Cars/test/trajectory_car_test.cc
+++ b/drake/examples/Cars/test/trajectory_car_test.cc
@@ -23,7 +23,8 @@ GTEST_TEST(TrajectoryCarTest, StationaryTest) {
   const Curve2d empty_curve{empty_waypoints};
   const double speed{99.0};
   const double start_time{0.0};
-  EXPECT_THROW((TrajectoryCar{empty_curve, speed, start_time}), std::exception);
+  EXPECT_THROW((TrajectoryCar1{empty_curve, speed, start_time}),
+               std::exception);
 }
 
 // Check the car's progress along some simple paths.  We just want to
@@ -71,7 +72,7 @@ GTEST_TEST(TrajectoryCarTest, SegmentTest) {
     };
     const Curve2d curve{waypoints};
     // The "device under test".
-    const TrajectoryCar car_dut{curve, it.speed, it.start_time};
+    const TrajectoryCar1 car_dut{curve, it.speed, it.start_time};
 
     // Check that the systems' outputs over time are correct over the
     // entire duration of the trajectory, but also including some time

--- a/drake/examples/Cars/trajectory_car.h
+++ b/drake/examples/Cars/trajectory_car.h
@@ -8,8 +8,7 @@
 
 namespace drake {
 
-/// TrajectoryCar -- a car that follows a pre-established trajectory,
-/// neglecting all physics.
+/// A car that follows a pre-established trajectory, neglecting all physics.
 ///
 /// state vector
 /// * none
@@ -23,12 +22,12 @@ namespace drake {
 //    heading is defined around the +z axis, so positive-turn-left
 /// * velocity
 ///
-class DRAKECARS_EXPORT TrajectoryCar {
+class DRAKECARS_EXPORT TrajectoryCar1 {
  public:
   /// Constructs a TrajectoryCar system that traces the given @p curve,
   /// at the given constant @p speed, starting at the given @p start_time.
   /// Throws an error if the curve is empty (a zero @p path_length).
-  TrajectoryCar(const Curve2<double>& curve, double speed, double start_time)
+  TrajectoryCar1(const Curve2<double>& curve, double speed, double start_time)
       : curve_(curve), speed_(speed), start_time_(start_time) {
     if (curve_.path_length() == 0.0) {
       throw std::invalid_argument{"empty curve"};
@@ -36,8 +35,8 @@ class DRAKECARS_EXPORT TrajectoryCar {
   }
 
   // Noncopyable.
-  TrajectoryCar(const TrajectoryCar&) = delete;
-  TrajectoryCar& operator=(const TrajectoryCar&) = delete;
+  TrajectoryCar1(const TrajectoryCar1&) = delete;
+  TrajectoryCar1& operator=(const TrajectoryCar1&) = delete;
 
   /// @name Implement the Drake System concept.
   //@{
@@ -50,16 +49,16 @@ class DRAKECARS_EXPORT TrajectoryCar {
   using OutputVector = SimpleCarState1<ScalarType>;
 
   template <typename ScalarType>
-  StateVector<ScalarType> dynamics(const ScalarType& time,
-                                   const StateVector<ScalarType>& state,
-                                   const InputVector<ScalarType>& input) const {
+  StateVector<ScalarType> dynamics(const ScalarType&,
+                                   const StateVector<ScalarType>&,
+                                   const InputVector<ScalarType>&) const {
     // No state means no dynamics.
     return StateVector<ScalarType>{};
   }
 
   template <typename ScalarType>
   OutputVector<ScalarType> output(const ScalarType& time,
-                                  const StateVector<ScalarType>& state,
+                                  const StateVector<ScalarType>&,
                                   const InputVector<ScalarType>&) const {
     // N.B. Never use InputVector data, because we are !isDirectFeedthrough.
 


### PR DESCRIPTION
Similar to #3159, this renames the deprecated System1 blocks to have a "1" suffix, so that the new System2 versions can overtake the unadorned names.

This is a bit boring, but will really make the future PRs _much_ more readable.  They are pending under https://github.com/jwnimmer-tri/drake/commits/cars-system2, for context and the curious.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3192)
<!-- Reviewable:end -->
