### PR TITLE
Modify `cpplint_wrapper_test.py` to work on Windows

### DIFF
--- a/drake/common/test/cpplint_wrapper_test.py
+++ b/drake/common/test/cpplint_wrapper_test.py
@@ -47,7 +47,7 @@ class TestStringMethods(unittest.TestCase):
         self.run_and_expect(
             [filename],
             0,
-            [r"Checking \.+\n",
+            [r"Checking \.+\r?\n",
              r"TOTAL 1 files passed"])
         self.run_and_expect(
             ["--no-summarize", filename],
@@ -63,13 +63,13 @@ class TestStringMethods(unittest.TestCase):
         self.run_and_expect(
             [filename],
             0,
-            [r"Checking \.+\n",
+            [r"Checking \.+\r?\n",
              r"TOTAL 1 files passed"])
         # Test that pass-through arguments works.
         self.run_and_expect(
             [filename, "--", "--linelength=40"],
             1,
-            [r"Checking \.+\n",
+            [r"Checking \.+\r?\n",
              r"TOTAL 1 files checked",
              r"found [123] warnings",
              r"whitespace/line_length"])
@@ -78,7 +78,7 @@ class TestStringMethods(unittest.TestCase):
         self.run_and_expect(
             [self.get_absolute_filename('cpplint_wrapper_test.py')],
             0,
-            [r"Ignoring .*/cpplint_wrapper_test.py",
+            [r"Ignoring .*[/\\]cpplint_wrapper_test.py",
              r"TOTAL 0 files"])
 
     def test_num_processes(self):
@@ -100,7 +100,7 @@ class TestStringMethods(unittest.TestCase):
         self.run_and_expect(
             ["--num-processes=2"] + [filename] * 25,
             0,
-            [r"Checking \.+\n",
+            [r"Checking \.+\r?\n",
              r"TOTAL 25 files passed"])
 
 


### PR DESCRIPTION
`cpplint_wrapper_test.py` had some Linux-specific comparisons that failed on Windows. This PR makes it accept either Linux or Windows line endings and path separators. It does not attempt to determine which platform it is running on -- it just makes the tests more forgiving.

Resolves #3199.

+@jwnimmer-tri for feature & platform review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3201)
<!-- Reviewable:end -->
