### PR TITLE
Fix remaining ELF visivility issues on OS X

### DIFF
--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -885,14 +885,14 @@ const std::map<Side, int> QPLocomotionPlan::createJointIndicesMap(
   return joint_indices;
 }
 
-template drake::lcmt_qp_controller_input
+template DRAKEQPLOCOMOTIONPLAN_EXPORT drake::lcmt_qp_controller_input
 QPLocomotionPlan::createQPControllerInput<
   Matrix<double, -1, 1, 0, -1, 1>,
   Matrix<double, -1, 1, 0, -1, 1>>(
       double, MatrixBase<Matrix<double, -1, 1, 0, -1, 1>> const&,
       MatrixBase<Matrix<double, -1, 1, 0, -1, 1>> const&,
       std::vector<bool, std::allocator<bool>> const&);
-template drake::lcmt_qp_controller_input
+template DRAKEQPLOCOMOTIONPLAN_EXPORT drake::lcmt_qp_controller_input
 QPLocomotionPlan::createQPControllerInput<
   Map<Matrix<double, -1, 1, 0, -1, 1> const, 0, Stride<0, 0>>,
   Map<Matrix<double, -1, 1, 0, -1, 1> const, 0, Stride<0, 0>>>(

--- a/drake/util/drakeMexUtil.h
+++ b/drake/util/drakeMexUtil.h
@@ -34,8 +34,10 @@ using drake::math::Gradient;
 #else
 #define DLLEXPORT __declspec(dllimport)
 #endif
+#elif __GNUC__ >= 4
+#define DLLEXPORT __attribute__((visibility("default")))
 #else
-#define DLLEXPORT [[gnu::visibility("default")]]
+#define DLLEXPORT
 #endif
 
 DLLEXPORT bool isa(const mxArray* mxa, const char* class_str);


### PR DESCRIPTION
Fix problems with export decorations in `drakeMexUtil.{cpp,h}` (see 44bd7b0c3fec). Add some more missing export decorations.

This should fix the remaining breakage from #3065.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3210)
<!-- Reviewable:end -->
