### PR TITLE
Rename SimpleLqrTrajectoryController to SimpleFeedbackTrajectoryController

### DIFF
--- a/drake/examples/Pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_run_swing_up.cc
@@ -11,13 +11,13 @@
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/Simulation.h"
 #include "drake/systems/cascade_system.h"
-#include "drake/systems/controllers/simple_lqr_trajectory_controller.h"
+#include "drake/systems/controllers/simple_feedback_trajectory_controller.h"
 #include "drake/systems/feedback_system.h"
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/plants/robot_state_tap.h"
 #include "drake/util/drakeAppUtil.h"
 
-using drake::SimpleLqrTrajectoryController;
+using drake::SimpleFeedbackTrajectoryController;
 using drake::solvers::SolutionResult;
 using drake::MatrixCompareType;
 
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
   Eigen::MatrixXd R(1, 1);
   R << 1;  // arbitrary, taken from PendulumPlant.m
 
-  auto control = std::make_shared<SimpleLqrTrajectoryController<Pendulum>>(
+  auto control = std::make_shared<SimpleFeedbackTrajectoryController<Pendulum>>(
       p, pp_traj, pp_xtraj, Q, R);
   auto traj_sys = drake::feedback(p, control);
   auto sys = drake::cascade(drake::cascade(traj_sys, visualizer),

--- a/drake/systems/controllers/CMakeLists.txt
+++ b/drake/systems/controllers/CMakeLists.txt
@@ -1,7 +1,7 @@
 drake_install_headers(
   LQR.h
   open_loop_trajectory_controller.h
-  simple_lqr_trajectory_controller.h)
+  simple_feedback_trajectory_controller.h)
 
 add_library_with_exports(LIB_NAME drakeControlUtil SOURCE_FILES controlUtil.cpp)
 target_link_libraries(drakeControlUtil drakeRBM drakeUtil drakeTrajectories)

--- a/drake/systems/controllers/simple_feedback_trajectory_controller.h
+++ b/drake/systems/controllers/simple_feedback_trajectory_controller.h
@@ -10,13 +10,14 @@
 namespace drake {
 
 /**
- * A time varying LQR controller to play back an input+state
- * trajectory.
+ * A time varying feedback controller to play back an input+state
+ * trajectory by adjusting the input to compensate for variations from
+ * the expected state.
  *
  * @concept{system_concept}
  */
 template <typename System>
-class SimpleLqrTrajectoryController {
+class SimpleFeedbackTrajectoryController {
  public:
   template <typename ScalarType>
   using InputVector = typename System::template StateVector<ScalarType>;
@@ -26,11 +27,11 @@ class SimpleLqrTrajectoryController {
   using OutputVector = typename System::template InputVector<ScalarType>;
   typedef PiecewisePolynomial<double> PiecewisePolynomialType;
 
-  SimpleLqrTrajectoryController(std::shared_ptr<System> sys,
-                                const PiecewisePolynomialType& utraj,
-                                const PiecewisePolynomialType& xtraj,
-                                const Eigen::MatrixXd& Q,
-                                const Eigen::MatrixXd& R)
+  SimpleFeedbackTrajectoryController(std::shared_ptr<System> sys,
+                                     const PiecewisePolynomialType& utraj,
+                                     const PiecewisePolynomialType& xtraj,
+                                     const Eigen::MatrixXd& Q,
+                                     const Eigen::MatrixXd& R)
       : sys_(sys), utraj_(utraj), xtraj_(xtraj), Q_(Q), R_(R) {}
 
   template <typename ScalarType>


### PR DESCRIPTION
I've been informed that a time varying LQR controller used for
following a trajectory is a concept with a much more specific meaning,
and this controller is very much not that.  Rename to avoid confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3213)
<!-- Reviewable:end -->
