### PR TITLE
Allow Diagram subclasses to use DiagramBuilder.

### DIFF
--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -15,6 +15,8 @@
 namespace drake {
 namespace systems {
 
+template<typename T> class DiagramBuilder;
+
 /// DiagramOutput is an implementation of SystemOutput that holds unowned
 /// OutputPort pointers. It is used to expose the outputs of constituent
 /// systems as outputs of a Diagram.
@@ -47,55 +49,11 @@ struct DiagramOutput : public SystemOutput<T> {
 /// Diagram is a System composed of one or more constituent Systems, arranged
 /// in a directed graph where the vertices are the constituent Systems
 /// themselves, and the edges connect the output of one constituent System
-/// to the input of another.
+/// to the input of another. To construct a Diagram, use a DiagramBuilder.
 template <typename T>
 class Diagram : public System<T> {
  public:
-  typedef std::pair<const System<T>*, int> PortIdentifier;
-
-  /// Unless you know what you're doing, use a DiagramBuilder instead of
-  /// calling this constructor directly.
-  ///
-  /// @param dependency_graph A map from the input ports of constituent systems
-  ///                         to the output ports on which they depend. This
-  ///                         graph is possibly cyclic, but must not contain
-  ///                         an algebraic loop.
-  /// @param sorted_systems   A list of the systems in the dependency_graph in
-  ///                         a valid, sorted execution order, such that if
-  ///                         EvalOutput is called on each system in
-  ///                         succession, every system will have valid inputs
-  ///                         by the time its turn comes.
-  /// @param input_port_ids   The ordered subsystem ports that are inputs to
-  ///                         the entire diagram.
-  /// @param output_port_ids  The ordered subsystem ports that are outputs of
-  ///                         the entire diagram.
-  Diagram(const std::map<PortIdentifier, PortIdentifier>& dependency_graph,
-          const std::vector<const System<T>*>& sorted_systems,
-          const std::vector<PortIdentifier>& input_port_ids,
-          const std::vector<PortIdentifier>& output_port_ids)
-      : dependency_graph_(dependency_graph),
-        sorted_systems_(sorted_systems),
-        input_port_ids_(input_port_ids),
-        output_port_ids_(output_port_ids) {
-    // Generate a map from the System pointer to its index in the sort order.
-    for (int i = 0; i < static_cast<int>(sorted_systems_.size()); ++i) {
-      sorted_systems_map_[sorted_systems_[i]] = i;
-    }
-    // Every system must appear in the sort order exactly once.
-    DRAKE_ABORT_UNLESS(sorted_systems_.size() == sorted_systems_map_.size());
-    // Every port named in the dependency_graph_ must actually exist.
-    DRAKE_ASSERT(PortsAreValid());
-    // The sort order must square with the dependency_graph_.
-    DRAKE_ASSERT(SortOrderIsCorrect());
-
-    // Add the inputs to the Diagram topology, and check their invariants.
-    for (const PortIdentifier& id : input_port_ids) {
-      ExportInput(id);
-    }
-    for (const PortIdentifier& id : output_port_ids) {
-      ExportOutput(id);
-    }
-  }
+  typedef typename std::pair<const System<T>*, int> PortIdentifier;
 
   ~Diagram() override {}
 
@@ -200,8 +158,68 @@ class Diagram : public System<T> {
     // TODO(david-german-tri): Actually map velocity to derivatives.
   }
 
+ protected:
+  /// Constructs an uninitialized Diagram. Subclasses that use this constructor
+  /// are obligated to call DiagramBuilder::BuildInto(this).
+  Diagram() {}
+
  private:
-  // Expose the given port as an input of the Diagram.
+  // A structural outline of a Diagram, produced by DiagramBuilder.
+  struct Blueprint {
+    // The ordered subsystem ports that are inputs to the entire diagram.
+    std::vector<PortIdentifier> input_port_ids;
+    // The ordered subsystem ports that are outputs of the entire diagram.
+    std::vector<PortIdentifier> output_port_ids;
+    // A map from the input ports of constituent systems to the output ports
+    // on which they depend. This graph is possibly cyclic, but must not
+    // contain an algebraic loop.
+    std::map<PortIdentifier, PortIdentifier> dependency_graph;
+    // A list of the systems in the dependency graph in a valid, sorted
+    // execution order, such that if EvalOutput is called on each system in
+    // succession, every system will have valid inputs by the time its turn
+    // comes.
+    std::vector<const System<T>*> sorted_systems;
+  };
+
+  // Constructs a Diagram from the Blueprint that a DiagramBuilder produces.
+  // This constructor is private because only DiagramBuilder calls it.
+  explicit Diagram(const Blueprint& blueprint) { Initialize(blueprint); }
+
+  // Validates the given @p blueprint and sets up the Diagram accordingly.
+  void Initialize(const Blueprint& blueprint) {
+    // The Diagram must not already be initialized.
+    DRAKE_ABORT_UNLESS(sorted_systems_.empty());
+    // The initialization must be nontrivial.
+    DRAKE_ABORT_UNLESS(!blueprint.sorted_systems.empty());
+
+    // Copy the data from the blueprint into private member variables.
+    dependency_graph_ = blueprint.dependency_graph;
+    sorted_systems_ = blueprint.sorted_systems;
+    input_port_ids_ = blueprint.input_port_ids;
+    output_port_ids_ = blueprint.output_port_ids;
+
+    // Generate a map from the System pointer to its index in the sort order.
+    for (int i = 0; i < static_cast<int>(sorted_systems_.size()); ++i) {
+      sorted_systems_map_[sorted_systems_[i]] = i;
+    }
+
+    // Every system must appear in the sort order exactly once.
+    DRAKE_ABORT_UNLESS(sorted_systems_.size() == sorted_systems_map_.size());
+    // Every port named in the dependency_graph_ must actually exist.
+    DRAKE_ASSERT(PortsAreValid());
+    // The sort order must square with the dependency_graph_.
+    DRAKE_ASSERT(SortOrderIsCorrect());
+
+    // Add the inputs to the Diagram topology, and check their invariants.
+    for (const PortIdentifier& id : input_port_ids_) {
+      ExportInput(id);
+    }
+    for (const PortIdentifier& id : output_port_ids_) {
+      ExportOutput(id);
+    }
+  }
+
+  // Exposes the given port as an input of the Diagram.
   void ExportInput(const PortIdentifier& port) {
     const System<T>* const sys = port.first;
     const int port_index = port.second;
@@ -222,7 +240,7 @@ class Diagram : public System<T> {
     this->DeclareInputPort(descriptor);
   }
 
-  // Expose the given port as an output of the Diagram.
+  // Exposes the given port as an output of the Diagram.
   void ExportOutput(const PortIdentifier& port) {
     const System<T>* const sys = port.first;
     const int port_index = port.second;
@@ -296,18 +314,20 @@ class Diagram : public System<T> {
 
   // A map from the input ports of constituent systems, to the output ports of
   // the systems on which they depend.
-  const std::map<PortIdentifier, PortIdentifier> dependency_graph_;
+  std::map<PortIdentifier, PortIdentifier> dependency_graph_;
 
   // The topologically sorted list of Systems in this Diagram.
-  const std::vector<const System<T>*> sorted_systems_;
+  std::vector<const System<T>*> sorted_systems_;
 
   // For fast conversion queries: what is the index of this System in the
   // sorted order?
   std::map<const System<T>*, int> sorted_systems_map_;
 
   // The ordered inputs and outputs of this Diagram.
-  const std::vector<PortIdentifier> input_port_ids_;
-  const std::vector<PortIdentifier> output_port_ids_;
+  std::vector<PortIdentifier> input_port_ids_;
+  std::vector<PortIdentifier> output_port_ids_;
+
+  friend class DiagramBuilder<T>;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -3,14 +3,21 @@
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/primitives/adder.h"
+#include "drake/systems/framework/primitives/constant_vector_source.h"
 #include "drake/systems/framework/system_port_descriptor.h"
 
 namespace drake {
 namespace systems {
 namespace {
+
+std::unique_ptr<FreestandingInputPort> MakeInput(
+    std::unique_ptr<BasicVector<double>> data) {
+  return std::make_unique<FreestandingInputPort>(std::move(data));
+}
 
 /// Sets up the following diagram:
 /// adder0_: (input0_ + input1_) -> A
@@ -75,12 +82,6 @@ class DiagramTest : public ::testing::Test {
     EXPECT_EQ(expected_output1[0], output1->get_value()[0]);
     EXPECT_EQ(expected_output1[1], output1->get_value()[1]);
     EXPECT_EQ(expected_output1[2], output1->get_value()[2]);
-  }
-
-  static std::unique_ptr<FreestandingInputPort> MakeInput(
-      std::unique_ptr<BasicVector<double>> data) {
-    return std::unique_ptr<FreestandingInputPort>(
-        new FreestandingInputPort(std::move(data)));
   }
 
   std::unique_ptr<Diagram<double>> diagram_;
@@ -172,6 +173,44 @@ TEST_F(DiagramTest, Clone) {
   // Check that the context that was cloned is unaffected.
   diagram_->EvalOutput(*context_, output_.get());
   ExpectDefaultOutputs();
+}
+
+// A Diagram that adds a constant to an input, and outputs the sum.
+class AddConstantDiagram : public Diagram<double> {
+ public:
+  explicit AddConstantDiagram(double constant) : Diagram<double>() {
+    constant_.reset(new ConstantVectorSource<double>(Vector1d{constant}));
+    adder_.reset(new Adder<double>(2 /* inputs */, 1 /* length */));
+
+    DiagramBuilder<double> builder;
+    builder.Connect(constant_->get_output_port(0), adder_->get_input_port(1));
+    builder.ExportInput(adder_->get_input_port(0));
+    builder.ExportOutput(adder_->get_output_port(0));
+    builder.BuildInto(this);
+  }
+
+ private:
+  std::unique_ptr<Adder<double>> adder_;
+  std::unique_ptr<ConstantVectorSource<double>> constant_;
+};
+
+GTEST_TEST(DiagramSubclassTest, TwelvePlusSevenIsNineteen) {
+  AddConstantDiagram plus_seven(7.0);
+  auto context = plus_seven.CreateDefaultContext();
+  auto output = plus_seven.AllocateOutput(*context);
+  ASSERT_NE(nullptr, context);
+  ASSERT_NE(nullptr, output);
+
+  auto vec = std::make_unique<BasicVector<double>>(1 /* length */);
+  vec->get_mutable_value() << 12.0;
+  context->SetInputPort(0, MakeInput(std::move(vec)));
+
+  plus_seven.EvalOutput(*context, output.get());
+
+  ASSERT_EQ(1, output->get_num_ports());
+  const VectorBase<double>* output_vector = output->get_vector_data(0);
+  EXPECT_EQ(1, output_vector->get_value().rows());
+  EXPECT_EQ(19.0, output_vector->get_value().x());
 }
 
 }  // namespace


### PR DESCRIPTION
Addresses the issues raised on #3215 (but does not actually close that issue).

+@amcastro-tri for feature review.  Check out the new test case in `diagram_test.cc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3216)
<!-- Reviewable:end -->
