### PR TITLE
Make the System sanity-checks more verbose

### DIFF
--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -12,6 +12,7 @@ configure_file(drake_path.cc.in ${drake_path_cc})
 set(sources
   drake_assert.cc
   ${drake_path_cc}
+  drake_throw.cc
   functional_form.cc
   nice_type_name.cc
   polynomial.cc
@@ -25,6 +26,7 @@ set(installed_headers
   drake_assert.h
   drake_deprecated.h
   drake_path.h
+  drake_throw.h
   eigen_autodiff_types.h
   eigen_types.h
   functional_form.h

--- a/drake/common/drake_throw.cc
+++ b/drake/common/drake_throw.cc
@@ -1,0 +1,19 @@
+#include "drake/common/drake_throw.h"
+
+#include <stdexcept>
+#include <sstream>
+
+namespace drake {
+namespace detail {
+
+void Throw(const char* condition, const char* func, const char* file,
+           int line) {
+  std::stringstream message;
+  message
+      << "Failure at " << file << ":" << line << " in " << func << "(): "
+      << "condition '" << condition << "' failed.";
+  throw std::runtime_error(message.str());
+}
+
+}  // namespace detail
+}  // namespace drake

--- a/drake/common/drake_throw.h
+++ b/drake/common/drake_throw.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <type_traits>
+
+#include "drake/drakeCommon_export.h"
+
+/// @file
+/// Provides a convenient wrapper to throw an exception when a condition is
+/// unmet.  This is similar to an assertion, but uses exceptions instead of
+/// ::abort(), and cannot be disabled.
+
+namespace drake {
+namespace detail {
+// Throw an error message.
+DRAKECOMMON_EXPORT
+void Throw(const char* condition, const char* func, const char* file, int line);
+}  // namespace detail
+}  // namespace drake
+
+/// Evaluates @p condition and iff the value is false will throw an exception
+/// with a message showing at least the condition text, function name, file,
+/// and line.
+#define DRAKE_THROW_UNLESS(condition)                                   \
+  do {                                                                  \
+    static_assert(                                                      \
+        std::is_convertible<decltype(condition), bool>::value,          \
+        "Throw condition should be bool-convertible.");                 \
+    if (!(condition)) {                                                 \
+      ::drake::detail::Throw(#condition, __func__, __FILE__, __LINE__); \
+    }                                                                   \
+  } while (0)

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -27,6 +27,10 @@ add_executable(eigen_matrix_compare_test eigen_matrix_compare_test.cc)
 target_link_libraries(eigen_matrix_compare_test ${GTEST_BOTH_LIBRARIES})
 add_test(NAME eigen_matrix_compare_test COMMAND eigen_matrix_compare_test)
 
+add_executable(drake_throw_test drake_throw_test.cc)
+target_link_libraries(drake_throw_test drakeCommon ${GTEST_BOTH_LIBRARIES})
+add_test(NAME drake_throw_test COMMAND drake_throw_test)
+
 # Adds "drake_assert.h" unit testing.
 add_executable(drake_assert_test_default drake_assert_test.cc)
 target_link_libraries(drake_assert_test_default drakeCommon ${GTEST_BOTH_LIBRARIES})

--- a/drake/common/test/drake_assert_test.cc
+++ b/drake/common/test/drake_assert_test.cc
@@ -29,8 +29,9 @@ GTEST_TEST(DrakeAssertDeathTest, AssertSyntaxTest) {
   DRAKE_ASSERT(BoolConvertible());
 }
 
-// Only run this test if assertions are armed.
+// Only run these tests if assertions are armed.
 #ifdef DRAKE_ASSERT_IS_ARMED
+
 GTEST_TEST(DrakeAssertDeathTest, AssertFalseTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(
@@ -38,6 +39,14 @@ GTEST_TEST(DrakeAssertDeathTest, AssertFalseTest) {
       R"(abort: failure at .*drake_assert_test.cc:.. in TestBody\(\): )"
       R"(assertion '\(2 \+ 2\) == 5' failed)");
 }
+
+GTEST_TEST(DrakeAssertDeathTest, AssertVoidTestArmed) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH(
+      { DRAKE_ASSERT_VOID(::abort()); },
+      R"()");
+}
+
 #endif  //  DRAKE_ASSERT_IS_ARMED
 
 }  // namespace

--- a/drake/common/test/drake_throw_test.cc
+++ b/drake/common/test/drake_throw_test.cc
@@ -1,0 +1,15 @@
+#include "drake/common/drake_throw.h"
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+GTEST_TEST(DrakeThrowTest, BasicTest) {
+  EXPECT_NO_THROW(DRAKE_THROW_UNLESS(true));
+  EXPECT_THROW(DRAKE_THROW_UNLESS(false), std::runtime_error);
+}
+
+}  // namespace

--- a/drake/systems/framework/primitives/adder.cc
+++ b/drake/systems/framework/primitives/adder.cc
@@ -27,8 +27,8 @@ void Adder<T>::EvalOutput(const ContextBase<T>& context,
   // user error setting up the system graph. They do not require unit test
   // coverage, and should not run in release builds.
 
-  DRAKE_ASSERT(System<T>::IsValidOutput(output));
-  DRAKE_ASSERT(System<T>::IsValidContext(context));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   VectorBase<T>* output_vector =
       output->get_mutable_port(0)->GetMutableVectorData();

--- a/drake/systems/framework/primitives/constant_vector_source.cc
+++ b/drake/systems/framework/primitives/constant_vector_source.cc
@@ -24,8 +24,8 @@ void ConstantVectorSource<T>::EvalOutput(const ContextBase<T>& context,
   // not user error setting up the system graph. They do not require unit test
   // coverage, and should not run in release builds.
 
-  DRAKE_ASSERT(System<T>::IsValidOutput(output));
-  DRAKE_ASSERT(System<T>::IsValidContext(context));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   // TODO(amcastro-tri): Solve #3140 so that the next line reads:
   // auto& output_vector = this->get_output_vector(context, 0);

--- a/drake/systems/framework/primitives/gain-inl.h
+++ b/drake/systems/framework/primitives/gain-inl.h
@@ -35,8 +35,8 @@ void Gain<T>::EvalOutput(const ContextBase<T>& context,
   // user error setting up the system graph. They do not require unit test
   // coverage, and should not run in release builds.
 
-  DRAKE_ASSERT(System<T>::IsValidOutput(output));
-  DRAKE_ASSERT(System<T>::IsValidContext(context));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   // There is only one input.
   // TODO(amcastro-tri): Solve #3140 so that the next line reads:

--- a/drake/systems/framework/primitives/integrator.cc
+++ b/drake/systems/framework/primitives/integrator.cc
@@ -43,7 +43,7 @@ std::unique_ptr<ContinuousState<T>> Integrator<T>::AllocateContinuousState()
 template <typename T>
 void Integrator<T>::EvalTimeDerivatives(const ContextBase<T>& context,
                                         ContinuousState<T>* derivatives) const {
-  DRAKE_ASSERT(System<T>::IsValidContext(context));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
   const VectorBase<T>* input = context.get_vector_input(0);
   derivatives->get_mutable_state()->SetFromVector(input->get_value());
 }
@@ -51,8 +51,8 @@ void Integrator<T>::EvalTimeDerivatives(const ContextBase<T>& context,
 template <typename T>
 void Integrator<T>::EvalOutput(const ContextBase<T>& context,
                                SystemOutput<T>* output) const {
-  DRAKE_ASSERT(System<T>::IsValidOutput(output));
-  DRAKE_ASSERT(System<T>::IsValidContext(context));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   VectorBase<T>* output_port =
       output->get_mutable_port(0)->GetMutableVectorData();

--- a/drake/systems/framework/primitives/pass_through-inl.h
+++ b/drake/systems/framework/primitives/pass_through-inl.h
@@ -29,8 +29,8 @@ PassThrough<T>::PassThrough(int length) {
 template <typename T>
 void PassThrough<T>::EvalOutput(const ContextBase<T>& context,
                           SystemOutput<T>* output) const {
-  DRAKE_ASSERT(System<T>::IsValidOutput(output));
-  DRAKE_ASSERT(System<T>::IsValidContext(context));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   VectorBase<T>* output_vector =
       output->get_mutable_port(0)->GetMutableVectorData();

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
 #include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/context_base.h"
 #include "drake/systems/framework/cache.h"
@@ -69,14 +70,13 @@ class System {
 
   /// Checks that @p output is consistent with the number and size of output
   /// ports declared by the system.
-  /// @returns `true` if @p output is non-null and valid for this system, or
-  /// `false` otherwise.
-  bool IsValidOutput(const SystemOutput<T>* output) const {
-    if (output == nullptr) return false;
+  /// @throw exception unless `output` is non-null and valid for this system.
+  void CheckValidOutput(const SystemOutput<T>* output) const {
+    DRAKE_THROW_UNLESS(output != nullptr);
 
     // Checks that the number of output ports in the system output is consistent
     // with the number of output ports declared by the System.
-    if (output->get_num_ports() != get_num_output_ports()) return false;
+    DRAKE_THROW_UNLESS(output->get_num_ports() == get_num_output_ports());
 
     // Checks the validity of each output port.
     for (int i = 0; i < get_num_output_ports(); ++i) {
@@ -85,24 +85,20 @@ class System {
       if (get_output_port(i).get_data_type() == kVectorValued) {
         const VectorBase<T>* output_vector =
             output->get_port(i).get_vector_data();
-        if (output_vector == nullptr) return false;
-        if (output_vector->get_value().rows() !=
-            get_output_port(i).get_size()) return false;
+        DRAKE_THROW_UNLESS(output_vector != nullptr);
+        DRAKE_THROW_UNLESS(output_vector->get_value().rows() ==
+                           get_output_port(i).get_size());
       }
     }
-
-    // All checks passed.
-    return true;
   }
 
   /// Checks that @p context is consistent for this system.
-  /// @returns `true` if @p context is valid for this system and `false`
-  /// otherwise.
-  bool IsValidContext(const ContextBase<T>& context) const {
+  /// @throw exception unless `context` is valid for this system.
+  void CheckValidContext(const ContextBase<T>& context) const {
     // Checks that the number of input ports in the context is consistent with
     // the number of ports declared by the System.
-    if (context.get_num_input_ports() != this->get_num_input_ports())
-      return false;
+    DRAKE_THROW_UNLESS(context.get_num_input_ports() ==
+                       this->get_num_input_ports());
 
     // Checks that the size of the input ports in the context matches the
     // declarations made by the system.
@@ -111,14 +107,11 @@ class System {
       // once abstract ports are implemented in 3164.
       if (this->get_input_port(i).get_data_type() == kVectorValued) {
         const VectorBase<T>* input_vector = context.get_vector_input(i);
-        if (input_vector == nullptr) return false;
-        if (input_vector->get_value().rows() !=
-            get_input_port(i).get_size()) return false;
+        DRAKE_THROW_UNLESS(input_vector != nullptr);
+        DRAKE_THROW_UNLESS(input_vector->get_value().rows() ==
+                           get_input_port(i).get_size());
       }
     }
-
-    // All checks passed.
-    return true;
   }
 
   /// Returns a default context, initialized with the correct


### PR DESCRIPTION
This makes the System sanity-checks more verbose in the case of failure, using the new `DRAKE_THROW_UNLESS` and `DRAKE_ASSERT_VOID` macros.

This trades off the kind of detail -- now the specific failing condition is more specific (`num_foo != num_bar`) but the location is less specific (always says `system.h`, not e.g. `leaf_system.h` anymore).  This no problem in a debugger (just break-on-throw, or look at the core's backtrace), but is slightly worse on the command line without any extra tooling.  If folks feel strongly, I could probably add the `System::get_name` to the exception message as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3219)
<!-- Reviewable:end -->
