### PR TITLE
Add Nightly Production dashboard to build cop documentation.

### DIFF
--- a/drake/doc/buildcop.rst
+++ b/drake/doc/buildcop.rst
@@ -121,20 +121,15 @@ This section is a quick-reference manual for the on-call build cop.
 
 Monitor the Build
 ^^^^^^^^^^^^^^^^^
-Check the `post-merge <https://drake-jenkins.csail.mit.edu/view/Continuous/>`_
-build dashboard in Jenkins at least once an hour during on-call hours. If any
-continuous builds turn yellow or red, you need to act.
+Check the `Continuous <https://drake-jenkins.csail.mit.edu/view/Continuous/>`_
+build dashboard in Jenkins at least once an hour during on-call hours. These
+builds run after every merge to Drake. Also check the
+`Nightly Production <https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/>`_
+build dashboard every morning. These builds are unusually resource-intensive,
+and therefore run just once per day.
 
-Also check the `nightly <https://drake-jenkins.csail.mit.edu/view/Nightly/>`_
-build dashboard every morning. We use nightlies as a staging ground for
-builds that have known issues, but also for production-ready builds that are
-unusually resource intensive. The following nightly builds are in the latter
-category, and therefore require build cop action if they fail:
-
-* mac-clang-nightly-matlab
-* mac-clang-nightly-matlab-open-source
-* mac-clang-ninja-nightly-matlab
-* mac-clang-ninja-nightly-matlab-open-source
+If any Continuous or Nightly Production builds turn yellow or red, you need
+to act.
 
 Respond to Breakage
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Update the build cop docs to refer to the Nightly Production dashboard, which shows the subset of nightly builds that are notionally stable and require build cop policing.

+@jamiesnape for feature review, +@ggould-tri for platform review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3229)
<!-- Reviewable:end -->
