### PR TITLE
Actually fix storage and visibility for generated integer constants

### DIFF
--- a/drake/examples/Cars/gen/driving_command.cc
+++ b/drake/examples/Cars/gen/driving_command.cc
@@ -5,6 +5,7 @@
 
 namespace drake {
 
+const int DrivingCommandIndices::kNumCoordinates;
 const int DrivingCommandIndices::kSteeringAngle;
 const int DrivingCommandIndices::kThrottle;
 const int DrivingCommandIndices::kBrake;

--- a/drake/examples/Cars/gen/driving_command.h
+++ b/drake/examples/Cars/gen/driving_command.h
@@ -8,13 +8,14 @@
 
 #include <Eigen/Core>
 
+#include "drake/drakeCars_export.h"
 #include "drake/systems/framework/basic_state_and_output_vector.h"
 #include "lcmtypes/drake/lcmt_driving_command_t.hpp"
 
 namespace drake {
 
 /// Describes the row indices of a DrivingCommand.
-struct DrivingCommandIndices {
+struct DRAKECARS_EXPORT DrivingCommandIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 3;
 

--- a/drake/examples/Cars/gen/euler_floating_joint_state.cc
+++ b/drake/examples/Cars/gen/euler_floating_joint_state.cc
@@ -5,6 +5,7 @@
 
 namespace drake {
 
+const int EulerFloatingJointStateIndices::kNumCoordinates;
 const int EulerFloatingJointStateIndices::kX;
 const int EulerFloatingJointStateIndices::kY;
 const int EulerFloatingJointStateIndices::kZ;

--- a/drake/examples/Cars/gen/euler_floating_joint_state.h
+++ b/drake/examples/Cars/gen/euler_floating_joint_state.h
@@ -8,13 +8,14 @@
 
 #include <Eigen/Core>
 
+#include "drake/drakeCars_export.h"
 #include "drake/systems/framework/basic_state_and_output_vector.h"
 #include "lcmtypes/drake/lcmt_euler_floating_joint_state_t.hpp"
 
 namespace drake {
 
 /// Describes the row indices of a EulerFloatingJointState.
-struct EulerFloatingJointStateIndices {
+struct DRAKECARS_EXPORT EulerFloatingJointStateIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 6;
 

--- a/drake/examples/Cars/gen/simple_car_state.cc
+++ b/drake/examples/Cars/gen/simple_car_state.cc
@@ -5,6 +5,7 @@
 
 namespace drake {
 
+const int SimpleCarStateIndices::kNumCoordinates;
 const int SimpleCarStateIndices::kX;
 const int SimpleCarStateIndices::kY;
 const int SimpleCarStateIndices::kHeading;

--- a/drake/examples/Cars/gen/simple_car_state.h
+++ b/drake/examples/Cars/gen/simple_car_state.h
@@ -8,13 +8,14 @@
 
 #include <Eigen/Core>
 
+#include "drake/drakeCars_export.h"
 #include "drake/systems/framework/basic_state_and_output_vector.h"
 #include "lcmtypes/drake/lcmt_simple_car_state_t.hpp"
 
 namespace drake {
 
 /// Describes the row indices of a SimpleCarState.
-struct SimpleCarStateIndices {
+struct DRAKECARS_EXPORT SimpleCarStateIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 4;
 

--- a/drake/examples/Cars/lcm_vector_gen.py
+++ b/drake/examples/Cars/lcm_vector_gen.py
@@ -14,7 +14,7 @@ def put(fileobj, text, newlines_after=0):
 
 INDICES_BEGIN = """
 /// Describes the row indices of a %(camel)s.
-struct %(indices)s {
+struct DRAKECARS_EXPORT %(indices)s {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = %(nfields)d;
 
@@ -37,6 +37,7 @@ def generate_indices(context, fields):
     camel = context["camel"]
     indices = context["indices"]
     nfields = len(fields)
+    kname = "kNumCoordinates"
     put(header, INDICES_BEGIN % locals(), 1)
     for k, field in enumerate(fields):
         kname = to_kname(field)
@@ -49,6 +50,8 @@ def generate_indices_storage(context, fields):
     camel = context["camel"]
     indices = context["indices"]
     nfields = len(fields)
+    kname = "kNumCoordinates"
+    put(cc, INDICES_FIELD_STORAGE % locals(), 1)
     for k, field in enumerate(fields):
         kname = to_kname(field)
         put(cc, INDICES_FIELD_STORAGE % locals(), 1)
@@ -151,6 +154,7 @@ HEADER_PREAMBLE = """
 #include <Eigen/Core>
 
 #include "lcmtypes/drake/lcmt_%(snake)s_t.hpp"
+#include "drake/drakeCars_export.h"
 #include "drake/systems/framework/basic_state_and_output_vector.h"
 
 namespace drake {


### PR DESCRIPTION
A follow-up on #3222:
- Add a missed kConstant from the original PR (sorry!).
- Now that I've merged the visibility fixes, we need EXPORT ornaments on the struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3233)
<!-- Reviewable:end -->
