### PR TITLE
Disable tests failing due to #3149 until that issue is fixed.

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -348,10 +348,11 @@ else()
 endif()
 
 if(MATLAB_FOUND)
-  add_matlab_test(NAME "RigidBodyManipulatorMemoryTest" OPTIONAL bullet
-    COMMAND "r = RigidBodyManipulator('Acrobot.urdf'), megaclear"
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/Acrobot
-    PROPERTIES TIMEOUT 300)
+  # DISABLED due to #3149.
+  # add_matlab_test(NAME "RigidBodyManipulatorMemoryTest" OPTIONAL bullet
+  #   COMMAND "r = RigidBodyManipulator('Acrobot.urdf'), megaclear"
+  #   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/Acrobot
+  #   PROPERTIES TIMEOUT 300)
 endif()
 
 option(ENABLE_DOCUMENTATION "Enable build target for Doxygen and Sphinx documentation." ON)

--- a/drake/examples/Strandbeest/CMakeLists.txt
+++ b/drake/examples/Strandbeest/CMakeLists.txt
@@ -1,4 +1,5 @@
 if(LONG_RUNNING_TESTS)
-  add_matlab_test(NAME examples/Strandbeest/runPassiveDownhill COMMAND runPassiveDownhill PROPERTIES TIMEOUT 4500)
+# DISABLED due to #3149.
+#  add_matlab_test(NAME examples/Strandbeest/runPassiveDownhill COMMAND runPassiveDownhill PROPERTIES TIMEOUT 4500)
   add_matlab_test(NAME examples/Strandbeest/runWithMotor COMMAND runWithMotor PROPERTIES TIMEOUT 4500)
 endif()

--- a/drake/matlab/solvers/test/CMakeLists.txt
+++ b/drake/matlab/solvers/test/CMakeLists.txt
@@ -9,7 +9,9 @@ add_matlab_test(NAME matlab/solvers/test/testConstraint COMMAND testConstraint)
 add_matlab_test(NAME matlab/solvers/test/testGurobiLCP REQUIRES gurobi COMMAND testGurobiLCP)
 add_matlab_test(NAME matlab/solvers/test/testLQRmex OPTIONAL bullet COMMAND testLQRmex)
 add_matlab_test(NAME matlab/solvers/test/testMixedIntegerConvexDemo REQUIRES gurobi yalmip COMMAND testMixedIntegerConvexDemo)
-add_matlab_test(NAME matlab/solvers/test/testMultipleTaskSpaceRRTStar REQUIRES lcm OPTIONAL bullet COMMAND testMultipleTaskSpaceRRTStar PROPERTIES TIMEOUT 750)
+# DISABLED due to #3149.
+# add_matlab_test(NAME matlab/solvers/test/testMultipleTaskSpaceRRTStar REQUIRES lcm OPTIONAL bullet COMMAND testMultipleTaskSpaceRRTStar PROPERTIES TIMEOUT 750)
 add_matlab_test(NAME matlab/solvers/test/testNLP OPTIONAL ipopt snopt COMMAND testNLP)
 add_matlab_test(NAME matlab/solvers/test/testQP OPTIONAL gurobi snopt COMMAND testQP)
-add_matlab_test(NAME matlab/solvers/test/testTaskSpaceRRT REQUIRES lcm snopt OPTIONAL bullet COMMAND testTaskSpaceRRT PROPERTIES TIMEOUT 750)
+# DISABLED due to #3149.
+# add_matlab_test(NAME matlab/solvers/test/testTaskSpaceRRT REQUIRES lcm snopt OPTIONAL bullet COMMAND testTaskSpaceRRT PROPERTIES TIMEOUT 750)

--- a/drake/systems/plants/constraint/test/CMakeLists.txt
+++ b/drake/systems/plants/constraint/test/CMakeLists.txt
@@ -6,12 +6,15 @@ add_test(NAME direct_collocation_constraint_test
   COMMAND direct_collocation_constraint_test)
 
 add_matlab_test(NAME systems/plants/constraint/test/AllBodiesClosestDistanceConstraintTest REQUIRES lcm OPTIONAL bullet COMMAND AllBodiesClosestDistanceConstraintTest)
-add_matlab_test(NAME systems/plants/constraint/test/RelativeGazeTargetConstraintTest REQUIRES lcm OPTIONAL bullet COMMAND RelativeGazeTargetConstraintTest)
+# DISABLED due to #3149.
+# add_matlab_test(NAME systems/plants/constraint/test/RelativeGazeTargetConstraintTest REQUIRES lcm OPTIONAL bullet COMMAND RelativeGazeTargetConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/RelativePositionConstraintTest REQUIRES lcm OPTIONAL bullet COMMAND RelativePositionConstraintTest)
-add_matlab_test(NAME systems/plants/constraint/test/RelativeQuatConstraintTest REQUIRES lcm OPTIONAL bullet COMMAND RelativeQuatConstraintTest)
+# DISABLED due to #3149.
+# add_matlab_test(NAME systems/plants/constraint/test/RelativeQuatConstraintTest REQUIRES lcm OPTIONAL bullet COMMAND RelativeQuatConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/WorldPositionInFrameConstraintTest REQUIRES lcm OPTIONAL bullet COMMAND WorldPositionInFrameConstraintTest)
 add_matlab_test(NAME systems/plants/constraint/test/testMultipleTimeLinearPostureConstraint OPTIONAL bullet COMMAND testMultipleTimeLinearPostureConstraint)
-add_matlab_test(NAME systems/plants/constraint/test/testPostureConstraint OPTIONAL bullet COMMAND testPostureConstraint)
+# DISABLED due to #3149.
+# add_matlab_test(NAME systems/plants/constraint/test/testPostureConstraint OPTIONAL bullet COMMAND testPostureConstraint)
 add_matlab_test(NAME systems/plants/constraint/test/testQuasiStaticConstraint OPTIONAL bullet COMMAND testQuasiStaticConstraint)
 add_matlab_test(NAME systems/plants/constraint/test/testSingleTimeLinearPostureConstraint OPTIONAL bullet COMMAND testSingleTimeLinearPostureConstraint)
 


### PR DESCRIPTION
Because long-running matlab tests were just added to the continuous build, all tests that trigger #3149 must be disabled. The issue will remain open, and this disabling references it in both source comments and commit message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3238)
<!-- Reviewable:end -->
