### PR TITLE
Disable failing test; this failure is now recorded in #3224.

### DIFF
--- a/drake/util/test/CMakeLists.txt
+++ b/drake/util/test/CMakeLists.txt
@@ -61,7 +61,8 @@ add_matlab_test(NAME util/test/testDTransformSpatialForce COMMAND testDTransform
 add_matlab_test(NAME util/test/testDcross COMMAND testDcross)
 add_matlab_test(NAME util/test/testFlipExpmap COMMAND testFlipExpmap)
 add_matlab_test(NAME util/test/testGeometryConversionFunctionsComparison COMMAND testGeometryConversionFunctionsComparison)
-add_matlab_test(NAME util/test/testGeometryGradientsComparison COMMAND testGeometryGradientsComparison)
+# DISABLED due to #3224.
+# add_matlab_test(NAME util/test/testGeometryGradientsComparison COMMAND testGeometryGradientsComparison)
 add_matlab_test(NAME util/test/testMotionSubspace COMMAND testMotionSubspace)
 add_matlab_test(NAME util/test/testMotionSubspaceDotTimesV COMMAND testMotionSubspaceDotTimesV)
 add_matlab_test(NAME util/test/testOrientation COMMAND testOrientation)


### PR DESCRIPTION
Because long-running matlab tests were just added to the continuous build, the test that triggers #3224 must be disabled. The issue will remain open, and this disabling references it in both source comments and commit message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3239)
<!-- Reviewable:end -->
