### PR TITLE
RigidBodySystem 2.0

### DIFF
--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -76,6 +76,16 @@ class Context {
   /// mutable access is requested for particular blocks of state variables.
   virtual State<T>* get_mutable_state() = 0;
 
+  /// Returns a mutable pointer to the continuous component of the state.
+  ContinuousState<T>* get_mutable_continuous_state() {
+    return get_mutable_state()->continuous_state.get();
+  }
+
+  /// Returns a const reference to the continuous component of the state.
+  const ContinuousState<T>& get_continuous_state() const {
+    return *get_state().continuous_state;
+  }
+
   /// Returns a deep copy of this Context. The clone's input ports will
   /// hold deep copies of the data that appears on this context's input ports
   /// at the time the clone is created.

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -133,6 +133,17 @@ class ContinuousState {
     return misc_continuous_state_.get();
   }
 
+  /// Sets the entire continuous state vector from an Eigen expression.
+  void SetFromVector(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_ASSERT(value.size() == state_->size());
+    this->get_mutable_state()->SetFromVector(value);
+  }
+
+  /// Returns a copy of the entire continuous state vector into an Eigen vector.
+  VectorX<T> CopyToVector() const {
+    return this->get_state().CopyToVector();
+  }
+
  private:
   // The entire state vector.  May or may not own the underlying data.
   std::unique_ptr<VectorBase<T>> state_;

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -197,4 +197,5 @@ if(lcm_FOUND)
   drake_install_headers(BotVisualizer.h)
 endif()
 
+add_subdirectory(rigid_body_plant)
 add_subdirectory(test)

--- a/drake/systems/plants/rigid_body_plant/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(source_files rigid_body_plant.cc)
+
+add_library_with_exports(LIB_NAME drake_rbp SOURCE_FILES ${source_files})
+target_link_libraries(drake_rbp
+        drakeCommon drakeSystemFramework drakeRBM drakeOptimization)
+
+drake_install_headers(rigid_body_plant.h)
+pods_install_libraries(drake_rbp)
+pods_install_pkg_config_file(drake-rbs
+        CFLAGS -I${CMAKE_INSTALL_PREFIX}/include
+        LIBS -ldrake_rbp -ldrakeRBM
+        VERSION 0.0.1)
+
+add_subdirectory(test)

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -1,0 +1,342 @@
+#include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
+
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/solvers/mathematical_program.h"
+// TODO(amcastro-tri): parsers are not "plants" and should therefore be moved
+// somewhere else. Maybe inside "multibody_dynamics/parsers" when that exists.
+#include "drake/systems/plants/parser_urdf.h"
+#include "drake/systems/plants/KinematicsCache.h"
+#include "drake/common/eigen_autodiff_types.h"
+
+using std::move;
+using std::string;
+using std::vector;
+
+using drake::parsers::ModelInstanceIdTable;
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+RigidBodyPlant<T>::RigidBodyPlant(std::unique_ptr<const RigidBodyTree> tree) :
+    tree_(move(tree)) {
+  // The input to the system is the generalized forces on the actuators.
+  // TODO(amcastro-tri): add separate input ports for each model_id.
+  System<T>::DeclareInputPort(
+      kVectorValued, get_num_actuators(), kContinuousSampling);
+  // The output to the system is the state vector.
+  // TODO(amcastro-tri): add separate output ports for each model_id.
+  System<T>::DeclareOutputPort(
+      kVectorValued, get_num_states(), kContinuousSampling);
+}
+
+template <typename T>
+RigidBodyPlant<T>::~RigidBodyPlant() { }
+
+template <typename T>
+bool RigidBodyPlant<T>::has_any_direct_feedthrough() const {
+  return false;
+}
+
+template <typename T>
+const RigidBodyTree& RigidBodyPlant<T>::get_multibody_world() const {
+  return *tree_.get();
+}
+
+template <typename T>
+int RigidBodyPlant<T>::get_num_positions() const {
+  return tree_->number_of_positions();
+}
+
+template <typename T>
+int RigidBodyPlant<T>::get_num_velocities() const {
+  return tree_->number_of_velocities();
+}
+
+template <typename T>
+int RigidBodyPlant<T>::get_num_states() const {
+  return get_num_positions() + get_num_velocities();
+}
+
+template <typename T>
+int RigidBodyPlant<T>::get_num_actuators() const {
+  return tree_->actuators.size();
+}
+
+template <typename T>
+int RigidBodyPlant<T>::get_input_size() const {
+  return get_num_actuators();
+}
+
+template <typename T>
+int RigidBodyPlant<T>::get_output_size() const {
+  return get_num_states();
+}
+
+template <typename T>
+void RigidBodyPlant<T>::set_position(Context<T>* context,
+                                     int position_index, T position) const {
+  DRAKE_ASSERT(context != nullptr);
+  context->get_mutable_state()->continuous_state->
+      get_mutable_generalized_position()->SetAtIndex(position_index, position);
+}
+
+template <typename T>
+void RigidBodyPlant<T>::set_velocity(Context<T>* context,
+                                     int velocity_index, T velocity) const {
+  DRAKE_ASSERT(context != nullptr);
+  context->get_mutable_state()->continuous_state->
+      get_mutable_generalized_velocity()->SetAtIndex(velocity_index, velocity);
+}
+
+template <typename T>
+void RigidBodyPlant<T>::set_state_vector(
+    Context<T>* context, const Eigen::Ref<const VectorX<T>> x) const {
+  DRAKE_ASSERT(context != nullptr);
+  DRAKE_ASSERT(x.size() == get_num_states());
+  context->get_mutable_state()->continuous_state->
+      get_mutable_state()->SetFromVector(x);
+}
+
+template <typename T>
+std::unique_ptr<ContinuousState<T>>
+RigidBodyPlant<T>::AllocateContinuousState() const {
+  // The state is second-order.
+  DRAKE_ASSERT(System<T>::get_input_port(0).get_size() == get_num_actuators());
+  // TODO(amcastro-tri): add z state to track energy conservation.
+  return std::make_unique<ContinuousState<T>>(
+      std::make_unique<BasicVector<T>>(get_num_states()),
+      get_num_positions() /* num_q */,
+      get_num_velocities() /* num_v */, 0 /* num_z */);
+}
+
+template <typename T>
+void RigidBodyPlant<T>::EvalOutput(const Context<T>& context,
+                                   SystemOutput<T>* output) const {
+  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
+
+  BasicVector<T>* output_vector = output->GetMutableVectorData(0);
+
+  // TODO(amcastro-tri): Remove this copy by allowing output ports to be
+  // mere pointers to state variables (or cache lines).
+  output_vector->get_mutable_value() =
+      context.get_continuous_state().CopyToVector();
+}
+
+template <typename T>
+void RigidBodyPlant<T>::EvalTimeDerivatives(
+    const Context<T>& context, ContinuousState<T>* derivatives) const {
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
+  DRAKE_DEMAND(derivatives != nullptr);
+  const BasicVector<T>* input = context.get_vector_input(0);
+
+  // The input vector of actuation values.
+  auto u = input->get_value();
+
+  // TODO(amcastro-tri): provide nicer accessor to an Eigen representation for
+  // LeafSystems.
+  auto x = dynamic_cast<const BasicVector<T>&>(
+      context.get_state().continuous_state->get_state()).get_value();
+
+  const int nq = get_num_positions();
+  const int nv = get_num_velocities();
+  const int num_actuators = get_num_actuators();
+  // TODO(amcastro-tri): we would like to compile here with `auto` instead of
+  // `VectorX<T>`. However it seems we get some sort of block from a block which
+  // is not instantiated in drakeRBM.
+  VectorX<T> q = x.topRows(nq);
+  VectorX<T> v = x.bottomRows(nv);
+  // TODO(amcastro-tri): place kinematics cache in the context so it can be
+  // reused.
+  auto kinsol = tree_->doKinematics(q, v);
+
+  // TODO(amcastro-tri): preallocate the optimization problem and constraints,
+  // and simply update them then solve on each function eval.
+  // How to place something like this in the context?
+  drake::solvers::MathematicalProgram prog;
+  auto const& vdot = prog.AddContinuousVariables(nv, "vdot");
+
+  auto H = tree_->massMatrix(kinsol);
+  Eigen::MatrixXd H_and_neg_JT = H;
+
+  // f_ext here has zero size but is a required argument in dynamicsBiasTerm.
+  // TODO(amcastro-tri): f_ext should be made an optional parameter
+  // of dynamicsBiasTerm().
+  eigen_aligned_unordered_map<const RigidBody*, Vector6<T>> f_ext;
+  // right_hand_side is the right hand side of the system's equations:
+  // [H, -J^T] * [vdot; f] = -right_hand_side.
+  VectorX<T> right_hand_side = tree_->dynamicsBiasTerm(kinsol, f_ext);
+  if (num_actuators > 0) right_hand_side -= tree_->B * u;
+
+  // Applies joint limit forces.
+  // TODO(amcastro-tri): Maybe move to
+  // RBT::ComputeGeneralizedJointLimitForces(C)?
+  {
+    for (auto const& b : tree_->bodies) {
+      if (!b->hasParent()) continue;
+      auto const& joint = b->getJoint();
+      // Only for single-axis joints.
+      if (joint.getNumPositions() == 1 && joint.getNumVelocities() == 1) {
+        // Limits makes things easier/faster here.
+        T qmin = joint.getJointLimitMin()(0),
+            qmax = joint.getJointLimitMax()(0);
+        // tau = k * (qlimit-q) - b(qdot)
+        if (q(b->get_position_start_index()) < qmin)
+          right_hand_side(b->get_velocity_start_index()) -=
+              penetration_stiffness_ * (qmin - q(b->get_position_start_index()))
+                  - penetration_damping_ * v(b->get_velocity_start_index());
+        else if (q(b->get_position_start_index()) > qmax)
+          right_hand_side(b->get_velocity_start_index()) -=
+              penetration_stiffness_ * (qmax - q(b->get_position_start_index()))
+                  - penetration_damping_ * v(b->get_velocity_start_index());
+      }
+    }
+  }
+
+  // Applies contact forces.
+  // TODO(amcastro-tri): Maybe move to RBT::ComputeGeneralizedContactForces(C)?
+  {
+    VectorX<T> phi;
+    Matrix3X<T> normal, xA, xB;
+    vector<int> bodyA_idx, bodyB_idx;
+
+    // TODO(amcastro-tri): get rid of this const_cast.
+    // Unfortunately collisionDetect() modifies the collision model in the RBT
+    // when updating the collision element poses.
+    const_cast<RigidBodyTree*>(tree_.get())->collisionDetect(
+        kinsol, phi, normal, xA, xB, bodyA_idx, bodyB_idx);
+
+    for (int i = 0; i < phi.rows(); i++) {
+      if (phi(i) < 0.0) {  // There is contact.
+        auto JA = tree_->transformPointsJacobian(
+            kinsol, xA.col(i), bodyA_idx[i], 0, false);
+        auto JB = tree_->transformPointsJacobian(
+            kinsol, xB.col(i), bodyB_idx[i], 0, false);
+        Vector3<T> this_normal = normal.col(i);
+
+        // Computes a local surface coordinate frame with the local z axis
+        // aligned with the surface's normal. The other two axes are arbitrarily
+        // chosen to complete a right handed triplet.
+        Vector3<T> tangent1;
+        if (1.0 - this_normal(2) < EPSILON) {
+          // Handles the unit-normal case. Since it's unit length, just check z.
+          tangent1 << 1.0, 0.0, 0.0;
+        } else if (1 + this_normal(2) < EPSILON) {
+          tangent1 << -1.0, 0.0, 0.0;  // Same for the reflected case.
+        } else {                       // Now the general case.
+          tangent1 << this_normal(1), -this_normal(0), 0.0;
+          tangent1 /= sqrt(this_normal(1) * this_normal(1) +
+              this_normal(0) * this_normal(0));
+        }
+        Vector3<T> tangent2 = this_normal.cross(tangent1);
+        // Transformation from world frame to local surface frame.
+        Matrix3<T> R;
+        R.row(0) = tangent1;
+        R.row(1) = tangent2;
+        R.row(2) = this_normal;
+        auto J = R * (JA - JB);          // J = [ D1; D2; n ]
+        auto relative_velocity = J * v;  // [ tangent1dot; tangent2dot; phidot ]
+
+        {
+          // Spring law for normal force:  fA_normal = -k * phi - b * phidot
+          // and damping for tangential force:  fA_tangent = -b * tangentdot
+          // (bounded by the friction cone).
+          Vector3<T> fA;
+          fA(2) = std::max<T>(
+              -penetration_stiffness_ * phi(i) -
+               penetration_damping_ * relative_velocity(2), 0.0);
+          fA.head(2) =
+              -std::min<T>(
+                  penetration_damping_,
+                  friction_coefficient_ * fA(2) /
+                  (relative_velocity.head(2).norm() + EPSILON)) *
+                  relative_velocity.head(2);  // Epsilon avoids divide by zero.
+
+          // fB is equal and opposite to fA: fB = -fA.
+          // Therefore the generalized forces tau_c due to contact are:
+          // tau_c = (R * JA)^T * fA + (R * JB)^T * fB = J^T * fA.
+          // With J computed as above: J = R * (JA - JB).
+          // Since right_hand_side has a negative sign when on the RHS of the
+          // system of equations ([H,-J^T] * [vdot;f] + right_hand_side = 0),
+          // this term needs to be subtracted.
+          right_hand_side -= J.transpose() * fA;
+        }
+      }
+    }
+  }
+
+  if (tree_->getNumPositionConstraints()) {
+    size_t nc = tree_->getNumPositionConstraints();
+    // 1/time constant of position constraint satisfaction.
+    const T alpha = 5.0;
+
+    prog.AddContinuousVariables(
+        nc, "position constraint force");
+
+    auto phi = tree_->positionConstraints(kinsol);
+    auto J = tree_->positionConstraintsJacobian(kinsol, false);
+    auto Jdotv = tree_->positionConstraintsJacDotTimesV(kinsol);
+
+    // Critically damped stabilization term.
+    // phiddot = -2 * alpha * phidot - alpha^2 * phi.
+    prog.AddLinearEqualityConstraint(
+        J, -(Jdotv + 2 * alpha * J * v + alpha * alpha * phi), {vdot});
+    H_and_neg_JT.conservativeResize(
+        Eigen::NoChange, H_and_neg_JT.cols() + J.rows());
+    H_and_neg_JT.rightCols(J.rows()) = -J.transpose();
+  }
+
+  // Adds [H,-J^T] * [vdot;f] = -C.
+  prog.AddLinearEqualityConstraint(H_and_neg_JT, -right_hand_side);
+
+  prog.Solve();
+
+  VectorX<T> xdot(get_num_states());
+  xdot << kinsol.transformPositionDotMappingToVelocityMapping(
+      MatrixX<T>::Identity(nq, nq)) * v, vdot.value();
+
+  derivatives->get_mutable_state()->SetFromVector(xdot);
+}
+
+template <typename T>
+void RigidBodyPlant<T>::MapVelocityToConfigurationDerivatives(
+    const Context<T>& context,
+    const VectorBase<T>& generalized_velocity,
+    VectorBase<T>* positions_derivative) const {
+  // TODO(amcastro-tri): provide nicer accessor to an Eigen representation for
+  // LeafSystems.
+  auto x = dynamic_cast<const BasicVector<T>&>(
+      context.get_state().continuous_state->get_state()).get_value();
+
+  const int nq = get_num_positions();
+  const int nv = get_num_velocities();
+  const int nstates = get_num_states();
+
+  DRAKE_ASSERT(positions_derivative->size() == nq);
+  DRAKE_ASSERT(generalized_velocity.size() == nv);
+  DRAKE_ASSERT(x.size() == nstates);
+
+  // TODO(amcastro-tri): we would like to compile here with `auto` instead of
+  // `VectorX<T>`. However it seems we get some sort of block from a block which
+  // is not instantiated in drakeRBM.
+  VectorX<T> q = x.topRows(nq);
+  VectorX<T> v = generalized_velocity.CopyToVector();
+
+  // TODO(amcastro-tri): place kinematics cache in the context so it can be
+  // reused.
+  auto kinsol = tree_->doKinematics(q, v);
+
+  positions_derivative->SetFromVector(
+      kinsol.transformPositionDotMappingToVelocityMapping(
+          MatrixX<T>::Identity(nq, nq)) * v);
+}
+
+// Explicitly instantiates on the most common scalar types.
+template class DRAKE_RBP_EXPORT RigidBodyPlant<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "drake/drake_rbp_export.h"
+#include "drake/systems/framework/leaf_system.h"
+
+#include "drake/systems/plants/parser_model_instance_id_table.h"
+#include "drake/systems/plants/RigidBodyTree.h"
+
+namespace tinyxml2 {
+class XMLElement;
+}
+
+namespace drake {
+namespace systems {
+
+/// This class provides a System interface around a multibody dynamics model
+/// of the world represented by a RigidBodyTree.
+///
+/// <B>%System input</B>: A %RigidBodyPlant has a vector valued input port for
+/// external actuation with size equal to the number of RigidBodyActuator's in
+/// the RigidBodyTree. Each RigidBodyActuator maps to a single DOF joint
+/// (currently actuation cannot be applied to multiple DOF's joints). The units
+/// of the actuation are the same as the units of the generalized force on the
+/// joint. In addition, actuators allow for a gear box reduction factor and for
+/// actuation limits which are only used by controllers; the RigidBodyPlant
+/// does not apply these limits. The gear box factor effectively is a
+/// multiplier on the input actuation to the RigidBodyPlant.
+///
+/// <B>%System output</B>: A %RigidBodyPlant outputs the state of the system in
+/// a vector valued port.
+///
+/// The multibody model consists of a set of rigid bodies connected through
+/// joints in a tree structure. Bodies may have a collision model in which case
+/// collisions are considered. In addition the model may contain loop
+/// constraints described by RigidBodyLoop's in the multibody model. Even though
+/// loop constraints are a particular case of holonomic constrants, general
+/// holonomic constrants are not yet supported.
+///
+/// The system dynamics is given by the set of multibody equations written in
+/// generalized coordinates including loop joints as a set of holonomic
+/// constraints like so:
+/// <pre>
+///   H(q) * vdot + C(q, v) = tau_actuators + tau_constraints.
+/// </pre>
+/// where `q` is the vector of generalized coordinates (or positions), `v` is
+/// the vector of generalized velocities, `C` includes the velocity-dependent
+/// Coriolis and gyroscopic forces, `tau_actuators` is the vector of externally
+/// applied generalized forces and finally `tau_constraints` is the vector of
+/// generalized forces due to constraints.
+/// `tau_constraints` is computed as
+/// <pre>
+///   tau_constraints = -J^T * lambda
+/// </pre>
+/// where `lambda` is the vector of Lagrange multipliers representing the
+/// constraint forces and `J` is the constraint Jacobian.
+/// The time derivative of the generalized coordinates is then obtained from the
+/// generalized velocities as
+/// <pre>
+///   qdot = N(q) * v
+/// </pre>
+/// where `N(q)` is a transformation matrix only dependent on the positions.
+///
+/// @tparam T The scalar type. Must be a valid Eigen scalar.
+template <typename T>
+class DRAKE_RBP_EXPORT RigidBodyPlant : public LeafSystem<T> {
+ public:
+  /// Instantiates a %RigidBodyPlant from a Multi-Body Dynamics (MBD) model of
+  /// the world in @p tree.
+  explicit RigidBodyPlant(std::unique_ptr<const RigidBodyTree> tree);
+
+  ~RigidBodyPlant() override;
+
+  /// Returns a constant reference to the multibody dynamics model
+  /// of the world.
+  const RigidBodyTree& get_multibody_world() const;
+
+  /// Returns the number of generalized coordinates of the model.
+  int get_num_positions() const;
+
+  /// Returns the number of generalized velocities of the model.
+  int get_num_velocities() const;
+
+  /// Returns the size of the continuous state of the system which equals
+  /// get_num_positions() plus get_num_velocities().
+  int get_num_states() const;
+
+  /// Returns the number of actuators.
+  int get_num_actuators() const;
+
+  /// Returns the size of the input vector to the system. This equals the
+  /// number of actuators.
+  int get_input_size() const;
+
+  /// Returns the size of the output vector of the system. This equals the size
+  /// of the continuous state vector.
+  int get_output_size() const;
+
+  /// Sets the generalized coordinate @p position_index to the value
+  /// @p position.
+  void set_position(Context<T>* context,
+                    int position_index, T position) const;
+
+  /// Sets the generalized velocity @p velocity_index to the value
+  /// @p velocity.
+  void set_velocity(Context<T>* context,
+                    int velocity_index, T velocity) const;
+
+  /// Sets the continuous state vector of the system to be @p x.
+  void set_state_vector(Context<T>* context,
+                        const Eigen::Ref<const VectorX<T>> x) const;
+
+  /// Sets the state in @p context so that generalized positions and velocities
+  /// are zero. For quaternion based joints the quaternion is set to be the
+  /// identity (or equivalently a zero rotation).
+  void SetZeroConfiguration(Context<T> *context) const {
+    VectorX<T> x0 = VectorX<T>::Zero(get_num_states());
+    x0.head(get_num_positions()) = tree_->getZeroConfiguration();
+    context->get_mutable_continuous_state()->SetFromVector(x0);
+  }
+
+  // System<T> overrides.
+  bool has_any_direct_feedthrough() const override;
+  void EvalTimeDerivatives(const Context<T>& context,
+                           ContinuousState<T>* derivatives) const override;
+  void EvalOutput(const Context<T>& context,
+                  SystemOutput<T>* output) const override;
+
+  void MapVelocityToConfigurationDerivatives(
+      const Context<T>& context, const VectorBase<T>& generalized_velocity,
+      VectorBase<T>* positions_derivative) const override;
+
+  // System<T> overrides to track energy conservation.
+  // TODO(amcastro-tri): provide proper implementations for these methods to
+  // track energy conservation.
+  // TODO(amcastro-tri): provide a method to track applied actuator power.
+  T EvalPotentialEnergy(const Context<T>& context) const override {
+    return T(NAN);
+  }
+
+  T EvalKineticEnergy(const Context<T>& context) const override {
+    return T(NAN);
+  }
+
+  T EvalConservativePower(const Context<T>& context) const override {
+    return T(NAN);
+  }
+
+  T EvalNonConservativePower(const Context<T>& context) const override {
+    return T(NAN);
+  }
+
+ protected:
+  // LeafSystem<T> override
+  std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;
+
+ private:
+  // Some parameters defining the contact.
+  // TODO(amcastro-tri): Implement contact materials for the RBT engine.
+  T penetration_stiffness_{150.0};  // An arbitrarily large number.
+  T penetration_damping_{0};
+  T friction_coefficient_{0};
+
+  std::unique_ptr<const RigidBodyTree> tree_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/plants/rigid_body_plant/test/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(rigid_body_plant_test rigid_body_plant_test.cc)
+target_link_libraries(rigid_body_plant_test
+        drake_rbp drakeRBSystem ${GTEST_BOTH_LIBRARIES})
+add_test(NAME rigid_body_plant_test COMMAND rigid_body_plant_test)

--- a/drake/systems/plants/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/systems/plants/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -1,0 +1,356 @@
+#include <iostream>
+#include <memory>
+
+#include <Eigen/Geometry>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_types.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/systems/plants/joints/QuaternionFloatingJoint.h"
+#include "drake/systems/plants/parser_model_instance_id_table.h"
+#include "drake/systems/plants/parser_urdf.h"
+#include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/plants/RigidBodySystem.h"
+
+using Eigen::Isometry3d;
+using Eigen::Quaterniond;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+
+namespace drake {
+namespace systems {
+namespace plants {
+namespace rigid_body_system {
+namespace test {
+namespace {
+
+template <class T>
+std::unique_ptr<FreestandingInputPort> MakeInput(
+    std::unique_ptr<BasicVector<T>> data) {
+  return make_unique<FreestandingInputPort>(std::move(data));
+}
+
+// Tests the ability to load a URDF model instance into the world of a rigid
+// body system.
+GTEST_TEST(RigidBodySystemTest, TestLoadURDFWorld) {
+  // Instantiates an Multibody Dynamics (MBD) model of the world.
+  auto tree_ptr = make_unique<RigidBodyTree>();
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() +
+      "/systems/plants/rigid_body_plant/test/world.urdf",
+      drake::systems::plants::joints::kFixed, nullptr /* weld to frame */,
+      tree_ptr.get());
+
+  // Instantiates a RigidBodyPlant from an MBD model of the world.
+  RigidBodyPlant<double> rigid_body_sys(move(tree_ptr));
+
+  // Verifies that the number of states, inputs, and outputs are all zero.
+  EXPECT_EQ(rigid_body_sys.get_num_states(), 0);
+  EXPECT_EQ(rigid_body_sys.get_input_size(), 0);
+  EXPECT_EQ(rigid_body_sys.get_output_size(), 0);
+
+  // Obtains a const pointer to the underlying multibody world in the system.
+  const RigidBodyTree& tree = rigid_body_sys.get_multibody_world();
+
+  // Checks that the bodies in the multibody world can be obtained by name and
+  // that they have the correct model name.
+  for (auto& body_name :
+       {"floor", "ramp_1", "ramp_2", "box_1", "box_2", "box_3", "box_4"}) {
+    RigidBody* body = tree.FindBody(body_name);
+    EXPECT_NE(body, nullptr);
+    EXPECT_EQ(body->get_model_name(), "dual_ramps");
+  }
+}
+
+// Unit tests the generalized velocities to generalized coordinates time
+// derivatives for a free body with a quaternion base.
+GTEST_TEST(RigidBodySystemTest, MapVelocityToConfigurationDerivatives) {
+  const int kNumPositions = 7;  // One quaternion + 3d position.
+  const int kNumVelocities = 6;  // Angular velocity + linear velocity.
+  const int kNumStates = kNumPositions + kNumVelocities;
+  // Instantiates a Multibody Dynamics (MBD) model of the world.
+  auto tree = make_unique<RigidBodyTree>();
+
+  // Add a single free body with a quaternion base.
+  RigidBody* body;
+  tree->add_rigid_body(unique_ptr<RigidBody>(body = new RigidBody()));
+  body->set_name("free_body");
+  // Sets body to have a non-zero spatial inertia. Otherwise the body gets
+  // welded by a fixed joint to the world by RigidBodyTree::compile().
+  body->set_mass(1.0);
+  body->set_spatial_inertia(Matrix6<double>::Identity());
+
+  body->add_joint(
+      &tree->world(),
+      make_unique<QuaternionFloatingJoint>("base", Isometry3d::Identity()));
+
+  tree->compile();
+
+  // Verifies the correct number of DOF's.
+  EXPECT_EQ(tree->get_number_of_bodies(), 2);
+  EXPECT_EQ(tree->number_of_positions(), kNumPositions);
+  // There are two bodies: the "world" and "free_body".
+  EXPECT_EQ(tree->number_of_velocities(), kNumVelocities);
+
+  // Instantiates a RigidBodyPlant from an MBD model of the world.
+  RigidBodyPlant<double> plant(move(tree));
+  auto context = plant.CreateDefaultContext();
+
+  // Sets free_body to have zero translation and zero rotation.
+  plant.SetZeroConfiguration(context.get());
+
+  // Verifies the number of states, inputs, and outputs.
+  EXPECT_EQ(plant.get_num_states(), kNumStates);
+  EXPECT_EQ(plant.get_num_positions(), kNumPositions);
+  EXPECT_EQ(plant.get_num_velocities(), kNumVelocities);
+  EXPECT_EQ(plant.get_input_size(), 0);  // There are no actuators.
+  EXPECT_EQ(plant.get_output_size(), kNumStates);
+
+  Vector3d v0(1, 2, 3);    // Linear velocity in body's frame.
+  Vector3d w0(-1, 2, -3);  // Angular velocity in body's frame.
+  BasicVector<double> generalized_velocities(plant.get_num_velocities());
+  generalized_velocities.get_mutable_value() << w0, v0;
+  BasicVector<double> positions_derivatives(plant.get_num_positions());
+
+  ASSERT_EQ(positions_derivatives.size(), kNumPositions);
+  ASSERT_EQ(generalized_velocities.size(), kNumVelocities);
+
+  plant.MapVelocityToConfigurationDerivatives(
+      *context, generalized_velocities, &positions_derivatives);
+
+  // For zero rotation the velocity vector in the body's frame and in the
+  // world's frame is the same.
+  EXPECT_EQ(v0[0], positions_derivatives.GetAtIndex(0));
+  EXPECT_EQ(v0[1], positions_derivatives.GetAtIndex(1));
+  EXPECT_EQ(v0[2], positions_derivatives.GetAtIndex(2));
+
+  // Computes the expected value of the time derivative of the quaternion
+  // component.
+  Quaterniond quaternion = Quaterniond::Identity();
+  Quaterniond dqdt =
+      Quaterniond(0, w0[0] / 2, w0[1] / 2, w0[2] / 2) * quaternion;
+
+  EXPECT_EQ(dqdt.w(), positions_derivatives.GetAtIndex(3));
+  EXPECT_EQ(dqdt.x(), positions_derivatives.GetAtIndex(4));
+  EXPECT_EQ(dqdt.y(), positions_derivatives.GetAtIndex(5));
+  EXPECT_EQ(dqdt.z(), positions_derivatives.GetAtIndex(6));
+}
+
+class KukaArmTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Instantiates an MBD model of the world.
+    auto tree = make_unique<RigidBodyTree>();
+    drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+        drake::GetDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf",
+        drake::systems::plants::joints::kFixed, nullptr /* weld to frame */,
+        tree.get());
+
+    // Instantiates a RigidBodyPlant from an MBD model of the world.
+    kuka_system_ = make_unique<RigidBodyPlant<double>>(move(tree));
+
+    context_ = kuka_system_->CreateDefaultContext();
+    output_ = kuka_system_->AllocateOutput(*context_);
+    derivatives_ = kuka_system_->AllocateTimeDerivatives();
+  }
+
+  const int kNumPositions_{7};
+  const int kNumVelocities_{7};
+  const int kNumActuators_{kNumPositions_};
+  const int kNumStates_{kNumPositions_ + kNumVelocities_};
+
+  unique_ptr<RigidBodyPlant<double>> kuka_system_;
+  std::unique_ptr<Context<double>> context_;
+  std::unique_ptr<SystemOutput<double>> output_;
+  std::unique_ptr<ContinuousState<double>> derivatives_;
+};
+
+// Tests that the KukaArm system allocates a continuous state of the proper
+// size in the context.
+TEST_F(KukaArmTest, StateHasTheRightSizes) {
+  const VectorBase<double>& xc =
+      context_->get_state().continuous_state->get_generalized_position();
+  const VectorBase<double>& vc =
+      context_->get_state().continuous_state->get_generalized_velocity();
+  const VectorBase<double>& zc =
+      context_->get_state().continuous_state->get_misc_continuous_state();
+
+  EXPECT_EQ(kNumPositions_, xc.size());
+  EXPECT_EQ(kNumVelocities_, vc.size());
+  EXPECT_EQ(0, zc.size());
+}
+
+// Tests the method that obtains the zero configuration of the system for a
+// Kuka arm model. In this case the zero configuration corresponds to all joint
+// angles and velocities being zero.
+// The system configuration is written to a context.
+TEST_F(KukaArmTest, SetZeroConfiguration) {
+  // Connect to a "fake" free standing input.
+  // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
+  // derivatives per #3218.
+  context_->SetInputPort(0, MakeInput(
+      make_unique<BasicVector<double>>(
+          kuka_system_->get_num_actuators())));
+
+  kuka_system_->SetZeroConfiguration(context_.get());
+
+  // Asserts that for this case the zero configuration corresponds to a state
+  // vector with all entries equal to zero.
+  VectorXd xc = context_->get_continuous_state().CopyToVector();
+  ASSERT_EQ(kNumStates_, xc.size());
+  ASSERT_EQ(xc, VectorXd::Zero(xc.size()));
+}
+
+// Tests RigidBodyPlant<T>::EvalOutput() for a Kuka arm model.
+// For a RigidBodyPlant<T> the output of the system should equal the
+// state vector.
+TEST_F(KukaArmTest, EvalOutput) {
+  // Checks that the number of input and output ports in the system and context
+  // are consistent.
+  ASSERT_EQ(1, kuka_system_->get_num_input_ports());
+  ASSERT_EQ(1, context_->get_num_input_ports());
+
+  // Checks the size of the input ports to match the number of generalized
+  // forces that can be applied.
+  ASSERT_EQ(kNumPositions_, kuka_system_->get_num_positions());
+  ASSERT_EQ(kNumVelocities_, kuka_system_->get_num_velocities());
+  ASSERT_EQ(kNumStates_, kuka_system_->get_num_states());
+  ASSERT_EQ(kNumActuators_, kuka_system_->get_num_actuators());
+  ASSERT_EQ(kNumActuators_, kuka_system_->get_input_port(0).get_size());
+
+  // Connect to a "fake" free standing input.
+  // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
+  // derivatives per #3218.
+  context_->SetInputPort(0, MakeInput(
+      make_unique<BasicVector<double>>(
+          kuka_system_->get_num_actuators())));
+
+  // Zeroes the state.
+  kuka_system_->SetZeroConfiguration(context_.get());
+
+  // Sets the state to a non-zero value.
+  VectorXd desired_angles(kNumPositions_);
+  desired_angles << 0.5, 0.1, -0.1, 0.2, 0.3, -0.2, 0.15;
+  for (int i = 0; i < kNumPositions_; ++i) {
+    kuka_system_->set_position(context_.get(), i, desired_angles[i]);
+  }
+  VectorXd desired_state(kNumStates_);
+  desired_state << desired_angles, VectorXd::Zero(kNumVelocities_);
+  VectorXd xc = context_->get_continuous_state().CopyToVector();
+  ASSERT_EQ(xc, desired_state);
+
+  ASSERT_EQ(1, output_->get_num_ports());
+  const BasicVector<double>* output_port =
+      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+  ASSERT_NE(nullptr, output_port);
+
+  kuka_system_->EvalOutput(*context_, output_.get());
+
+  // Asserts the output equals the state.
+  EXPECT_EQ(desired_state, output_port->get_value());
+}
+
+// Tests RigidBodyPlant<T>::EvalTimeDerivatives() for a Kuka arm model.
+// The test is performed by comparing against the results obtained with an RBS1
+// model of the same Kuka arm.
+// "RBS1" is an abbreviation referring to version 1.0 of RigidBodySystem as
+// implemented in:
+// drake/systems/plants/RigidBodySystem.h.
+// Within this test we will refer to the implementation under test as RBS2
+// (Rigid Body System 2.0). The naming conventions for the variables in this
+// test are lower case versions of these acronyms.
+GTEST_TEST(RigidBodySystemTest, CompareWithRBS1Dynamics) {
+  //////////////////////////////////////////////////////////////////////////////
+  // Instantiates a RigidBodySystem (System 1.0) model of the Kuka arm.
+  //////////////////////////////////////////////////////////////////////////////
+  auto rbs1 = make_unique<RigidBodySystem>();
+
+  // Adds a URDF to the rigid body system. This URDF contains only fixed joints
+  // and is attached to the world via a fixed joint. Thus, everything in the
+  // URDF becomes part of the world.
+  rbs1->AddModelInstanceFromFile(
+      drake::GetDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf",
+      drake::systems::plants::joints::kFixed);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Instantiates a RigidBodyPlant (System 2.0) model of the Kuka arm.
+  //////////////////////////////////////////////////////////////////////////////
+  auto tree = make_unique<RigidBodyTree>();
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf",
+      drake::systems::plants::joints::kFixed, nullptr /* weld to frame */,
+      tree.get());
+
+  // Instantiates a RigidBodyPlant (System 2.0) from an MBD model of the world.
+  auto rbs2 = make_unique<RigidBodyPlant<double>>(move(tree));
+
+  auto context = rbs2->CreateDefaultContext();
+  auto output = rbs2->AllocateOutput(*context);
+  auto derivatives = rbs2->AllocateTimeDerivatives();
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Sets the initial condition of both systems to be the same.
+  //////////////////////////////////////////////////////////////////////////////
+  // For rbs1:
+  // Obtains an initial state of the simulation.
+  VectorXd x0 = VectorXd::Zero(rbs1->getNumStates());
+  x0.head(rbs1->number_of_positions()) =
+      rbs1->getRigidBodyTree()->getZeroConfiguration();
+
+  // Some non-zero velocities.
+  x0.tail(rbs1->number_of_velocities()) << 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0;
+
+  Eigen::VectorXd arbitrary_angles(rbs1->number_of_positions());
+  arbitrary_angles << 0.01, -0.01, 0.01, 0.5, 0.01, -0.01, 0.01;
+  x0.head(rbs1->number_of_positions()) += arbitrary_angles;
+
+  // For rbs2:
+  // Zeroes the state.
+  rbs2->SetZeroConfiguration(context.get());
+
+  // Sets the state to a non-zero value matching the configuration for rbs1.
+  rbs2->set_state_vector(context.get(), x0);
+  VectorXd xc = context->get_continuous_state().CopyToVector();
+  ASSERT_EQ(xc, x0);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Sets the inputs (generalized forces) to be the same.
+  //////////////////////////////////////////////////////////////////////////////
+  // For rbs1:
+  VectorX<double> u = VectorX<double>::Zero(rbs1->getNumInputs());
+  u << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0;
+
+  // For rbs2:
+  // Connect to a "fake" free standing input with the same values used for RBS1.
+  // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
+  // derivatives per #3218.
+  auto input_vector = std::make_unique<BasicVector<double>>(
+      rbs2->get_num_actuators());
+  input_vector->set_value(u);
+  context->SetInputPort(0, MakeInput(move(input_vector)));
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Computes time derivatives to compare against rbs1 dynamics.
+  //////////////////////////////////////////////////////////////////////////////
+  auto rbs1_xdot = rbs1->dynamics(0.0, x0, u);
+  rbs2->EvalTimeDerivatives(*context, derivatives.get());
+  auto rbs2_xdot = derivatives->get_state().CopyToVector();
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Performs the comparison.
+  //////////////////////////////////////////////////////////////////////////////
+  EXPECT_TRUE(rbs1->number_of_positions() == rbs2->get_num_positions());
+  EXPECT_TRUE(rbs1->number_of_velocities() == rbs2->get_num_velocities());
+  EXPECT_TRUE(rbs2_xdot.isApprox(rbs1_xdot));
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace rigid_body_plant
+}  // namespace plants
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/plants/rigid_body_plant/test/world.urdf
+++ b/drake/systems/plants/rigid_body_plant/test/world.urdf
@@ -1,0 +1,131 @@
+<!--
+  A simple world URDF composed of two ramps with boxes between them.
+-->
+<robot name="dual_ramps">
+  <material name="terrain">
+    <color rgba="0.93333333333 0.79607843137 0.67843137254 1"/>
+  </material>
+  <material name="ramp">
+    <color rgba="0.93333333333 0.2 0.2 1"/>
+  </material>
+
+  <link name="world_">
+  </link>
+
+  <link name="floor">
+    <visual>
+      <material name="terrain"/>
+      <geometry>
+        <origin xyz="0 0 0"/>
+        <box size="1000 1000 10"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <origin xyz="0 0 0"/>
+        <box size="1000 1000 10"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="ramp_1">
+    <visual>
+      <material name="ramp"/>
+      <origin rpy="0 -0.165148677 0"/>
+      <geometry>
+        <box size="12 8 2"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin rpy="0 -0.165148677 0"/>
+      <geometry>
+        <box size="12 8 2"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="ramp_2">
+    <visual>
+      <material name="ramp"/>
+      <origin rpy="0 0.165148677 0"/>
+      <geometry>
+        <box size="12 8 2"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin rpy="0 0.165148677 0"/>
+      <geometry>
+        <box size="12 8 2"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="box_1">
+    <visual>
+      <origin xyz="0 -2 0" rpy="0 0 1.57079632679"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+    </visual>
+  </link>
+  <link name="box_2">
+    <visual>
+      <origin xyz="0 -2 0" rpy="0 0 1.57079632679"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+    </visual>
+  </link>
+  <link name="box_3">
+    <visual>
+      <origin xyz="0 -2 0" rpy="0 0 1.57079632679"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+    </visual>
+  </link>
+  <link name="box_4">
+    <visual>
+      <origin xyz="0 -2 0" rpy="0 0 1.57079632679"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <joint name="world_to_floor" type="fixed">
+    <parent link="world_"/>
+    <child link="floor"/>
+    <origin xyz="0 0 -5"/>
+  </joint>
+  <joint name="world_to_ramp_1" type="fixed">
+    <parent link="world_"/>
+    <child link="ramp_1"/>
+    <origin xyz="40 0 0"/>
+  </joint>
+  <joint name="ramp_1_to_ramp_2" type="fixed">
+    <parent link="ramp_1"/>
+    <child link="ramp_2"/>
+    <origin xyz="24 0 0"/>
+  </joint>
+  <joint name="world_to_box_1" type="fixed">
+    <parent link="world_"/>
+    <child link="box_1"/>
+    <origin xyz="48 0 0"/>
+  </joint>
+  <joint name="world_to_box_2" type="fixed">
+    <parent link="world_"/>
+    <child link="box_2"/>
+    <origin xyz="51 0 0"/>
+  </joint>
+  <joint name="world_to_box_3" type="fixed">
+    <parent link="world_"/>
+    <child link="box_3"/>
+    <origin xyz="54 0 0"/>
+  </joint>
+  <joint name="world_to_box_4" type="fixed">
+    <parent link="world_"/>
+    <child link="box_4"/>
+    <origin xyz="57 0 0"/>
+  </joint>
+</robot>


### PR DESCRIPTION
This implements the System 2.0 version of RigidBodySystem.
I decided to call this RigidBodyPlant since per off-line discussion it seems this name more appropriately describes the concept of the object we actually want to control. 
There are two components in RBS1 not considered here yet that also justify this name change:
- Sensors.
- Force elements.

There was some discussion on whether these should be their own self-contained systems wired in a Diagram with an RigidBodyPlant. Not the subject of this PR, not needed for the sprint, and therefore I am delaying to such a decision for future work. 

There is a unit test in `rbs_test.cc` if you want to start there. PTAL!

cc'ing @naveenoid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3245)
<!-- Reviewable:end -->
