### PR TITLE
Widen the access modifiers on LeafSystem

### DIFF
--- a/drake/examples/Cars/test/trajectory_car_test.cc
+++ b/drake/examples/Cars/test/trajectory_car_test.cc
@@ -71,15 +71,13 @@ GTEST_TEST(TrajectoryCarTest, SegmentTest) {
     };
     const Curve2d curve{waypoints};
     // The "device under test".
-    std::unique_ptr<systems::System<double>> car_dut(
-        std::make_unique<TrajectoryCar<double>>(  // BR
-            curve, it.speed, it.start_time));
+    const TrajectoryCar<double> car_dut{curve, it.speed, it.start_time};
 
     // The test inputs (time) and outputs.
     std::unique_ptr<systems::ContextBase<double>> context =
-        car_dut->CreateDefaultContext();
+        car_dut.CreateDefaultContext();
     std::unique_ptr<systems::SystemOutput<double>> all_output =
-        car_dut->AllocateOutput(*context);
+        car_dut.AllocateOutput(*context);
 
     // Check that the systems' outputs over time are correct over the
     // entire duration of the trajectory, but also including some time
@@ -96,7 +94,7 @@ GTEST_TEST(TrajectoryCarTest, SegmentTest) {
       const double kMaxErrorRad = 1e-6;
 
       context->set_time(time);
-      car_dut->EvalOutput(*context, all_output.get());
+      car_dut.EvalOutput(*context, all_output.get());
 
       ASSERT_EQ(1, all_output->get_num_ports());
       const SimpleCarState<double>* output =

--- a/drake/systems/framework/primitives/integrator.h
+++ b/drake/systems/framework/primitives/integrator.h
@@ -20,16 +20,17 @@ class Integrator : public LeafSystem<T> {
   explicit Integrator(int length);
   ~Integrator() override;
 
- private:
+ public:
+  // System<T> overrides
   bool has_any_direct_feedthrough() const override;
-
-  std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;
-
+  void EvalOutput(const ContextBase<T>& context,
+                  SystemOutput<T>* output) const override;
   void EvalTimeDerivatives(const ContextBase<T>& context,
                            ContinuousState<T>* derivatives) const override;
 
-  void EvalOutput(const ContextBase<T>& context,
-                  SystemOutput<T>* output) const override;
+ protected:
+  // LeafSystem<T> override
+  std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/gain_scalartype_test.cc
@@ -46,8 +46,7 @@ GTEST_TEST(GainScalarTypeTest, AutoDiff) {
   // does not necessarily need to be the same as the size of the derivatives
   // vectors and, for this unit test, they are not equal.
   const double kGain = 2.0;
-  std::unique_ptr<System<T>> gain = make_unique<Gain<T>>(
-      kGain /* gain */, 3 /* length */);
+  auto gain = make_unique<Gain<T>>(kGain /* gain */, 3 /* length */);
   auto context = gain->CreateDefaultContext();
   auto output = gain->AllocateOutput(*context);
   auto input = make_unique<BasicVector<T>>(3 /* length */);

--- a/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
@@ -37,8 +37,7 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
   typedef AutoDiffScalar<Vector3d> T;
 
   // Set a PassThrough system with input and output of size 3.
-  std::unique_ptr<System<T>> buffer =
-      make_unique<PassThrough<T>>(3 /* length */);
+  auto buffer = make_unique<PassThrough<T>>(3 /* length */);
   auto context = buffer->CreateDefaultContext();
   auto output = buffer->AllocateOutput(*context);
   auto input = make_unique<BasicVector<T>>(3 /* length */);


### PR DESCRIPTION
Widen the access modifiers on `LeafSystem`:
- Overrides of `System`'s public methods are now public.
- Virtuals for subclasses to override are now protected.
- Fix up `Integrator` to follow suit.

This PR focuses on `LeafSystem`, but the pattern of access modifier inconsistency is wider within System 2.0 -- I'll leave those cleanups for separate PRs.  We just want to get this one fixed up earlier since so many folks use `LeafSystem`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3249)
<!-- Reviewable:end -->
