### PR TITLE
Give external visibility and linkage to System2 abstract-valued IO

### DIFF
--- a/drake/systems/framework/system_input.cc
+++ b/drake/systems/framework/system_input.cc
@@ -1,4 +1,30 @@
-// For now, this is an empty .cc file that only serves to confirm
-// system_input.h is a stand-alone header.
-
 #include "drake/systems/framework/system_input.h"
+
+namespace drake {
+namespace systems {
+
+InputPort::~InputPort() {}
+
+void InputPort::Invalidate() {
+  if (invalidation_callback_ != nullptr) {
+    invalidation_callback_();
+  }
+}
+
+DependentInputPort::~DependentInputPort() {
+  output_port_->remove_dependent(this);
+}
+
+
+FreestandingInputPort::FreestandingInputPort(
+    std::unique_ptr<AbstractValue> data)
+    : output_port_(std::move(data)) {
+  output_port_.add_dependent(this);
+}
+
+FreestandingInputPort::~FreestandingInputPort() {
+  output_port_.remove_dependent(this);
+}
+
+}  // systems
+}  // drake

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/value.h"
 #include "drake/systems/framework/vector_base.h"
@@ -15,9 +16,10 @@ namespace systems {
 /// The InputPort describes a single input to a System. Users should not
 /// subclass InputPort: all InputPorts are either DependentInputPorts or
 /// FreestandingInputPorts.
-class InputPort : public OutputPortListenerInterface {
+class DRAKESYSTEMFRAMEWORK_EXPORT InputPort
+    : public OutputPortListenerInterface {
  public:
-  ~InputPort() override {}
+  ~InputPort() override;
 
   /// Returns a positive number that increases monotonically, and changes
   /// whenever the data on this port changes, according to the source of
@@ -47,11 +49,7 @@ class InputPort : public OutputPortListenerInterface {
 
   /// Receives notification that the output port on which this InputPort
   /// depends has changed, and calls the invalidation_callback_.
-  void Invalidate() override {
-    if (invalidation_callback_ != nullptr) {
-      invalidation_callback_();
-    }
-  }
+  void Invalidate() override;
 
  protected:
   InputPort() {}
@@ -65,7 +63,7 @@ class InputPort : public OutputPortListenerInterface {
 /// The DependentInputPort wraps a pointer to the OutputPort of a System for use
 /// as an input to another System. Many DependentInputPorts may wrap a single
 /// OutputPort.
-class DependentInputPort : public InputPort {
+class DRAKESYSTEMFRAMEWORK_EXPORT DependentInputPort : public InputPort {
  public:
   /// Creates an input port connected to the given @p output_port, which
   /// must not be nullptr. The output port must outlive this input port.
@@ -75,7 +73,7 @@ class DependentInputPort : public InputPort {
   }
 
   /// Disconnects from the output port.
-  ~DependentInputPort() override { output_port_->remove_dependent(this); }
+  ~DependentInputPort() override;
 
   /// Returns the value version of the connected output port.
   int64_t get_version() const override { return output_port_->get_version(); }
@@ -95,7 +93,7 @@ class DependentInputPort : public InputPort {
 
 /// The FreestandingInputPort encapsulates a vector of data for use as an input
 /// to a System.
-class FreestandingInputPort : public InputPort {
+class DRAKESYSTEMFRAMEWORK_EXPORT FreestandingInputPort : public InputPort {
  public:
   /// Constructs a vector-valued FreestandingInputPort.
   /// Takes ownership of @p vec.
@@ -110,10 +108,7 @@ class FreestandingInputPort : public InputPort {
 
   /// Constructs an abstract-valued FreestandingInputPort.
   /// Takes ownership of @p data.
-  explicit FreestandingInputPort(std::unique_ptr<AbstractValue> data)
-      : output_port_(std::move(data)) {
-    output_port_.add_dependent(this);
-  }
+  explicit FreestandingInputPort(std::unique_ptr<AbstractValue> data);
 
   /// Constructs an abstract-valued FreestandingInputPort.
   /// Takes ownership of @p data.
@@ -121,11 +116,9 @@ class FreestandingInputPort : public InputPort {
   /// @tparam T The type of the data.
   template <typename T>
   explicit FreestandingInputPort(std::unique_ptr<Value<T>> data)
-      : output_port_(std::move(data)) {
-    output_port_.add_dependent(this);
-  }
+      : FreestandingInputPort(std::unique_ptr<AbstractValue>(data.release())) {}
 
-  ~FreestandingInputPort() override { output_port_.remove_dependent(this); }
+  ~FreestandingInputPort() override;
 
   /// Returns a positive and monotonically increasing number that is guaranteed
   /// to change whenever GetMutableVectorData is called.

--- a/drake/systems/framework/system_output.cc
+++ b/drake/systems/framework/system_output.cc
@@ -1,4 +1,27 @@
-// For now, this is an empty .cc file that only serves to confirm
-// system_output.h is a stand-alone header.
-
 #include "drake/systems/framework/system_output.h"
+
+namespace drake {
+namespace systems {
+
+OutputPortListenerInterface::~OutputPortListenerInterface() {}
+
+OutputPort::~OutputPort() {}
+
+
+std::unique_ptr<OutputPort> OutputPort::Clone() const {
+  if (data_ != nullptr) {
+    return std::make_unique<OutputPort>(data_->Clone());
+  }
+  return nullptr;
+}
+
+
+void OutputPort::InvalidateAndIncrement() {
+  ++version_;
+  for (OutputPortListenerInterface* dependent : dependents_) {
+    dependent->Invalidate();
+  }
+}
+
+}  // systems
+}  // drake

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -21,7 +21,7 @@ namespace systems {
 /// TODO(david-german-tri): Consider moving to its own file.
 class DRAKESYSTEMFRAMEWORK_EXPORT OutputPortListenerInterface {
  public:
-  virtual ~OutputPortListenerInterface() {}
+  virtual ~OutputPortListenerInterface();
 
   /// Invalidates any data that depends on the OutputPort. Called whenever
   /// the OutputPort's version number is incremented.
@@ -30,7 +30,7 @@ class DRAKESYSTEMFRAMEWORK_EXPORT OutputPortListenerInterface {
 
 /// The OutputPort represents a data output from a System. Other Systems
 /// may depend on the OutputPort.
-class OutputPort {
+class DRAKESYSTEMFRAMEWORK_EXPORT OutputPort {
  public:
   /// Constructs a vector-valued OutputPort.
   /// Takes ownership of @p vec.
@@ -39,8 +39,8 @@ class OutputPort {
   /// @tparam V The type of @p vec itself. Must implement VectorBase<T>.
   template <template <typename T> class V, typename T>
   explicit OutputPort(std::unique_ptr<V<T>> vec)
-      : data_(new VectorValue<T>(
-            std::unique_ptr<VectorBase<T>>(vec.release()))) {}
+      : data_(new VectorValue<T>(std::move(vec))) {
+  }
 
   /// Constructs an abstract-valued OutputPort.
   /// Takes ownership of @p data.
@@ -53,7 +53,9 @@ class OutputPort {
   /// @tparam T The type of the data.
   template <typename T>
   explicit OutputPort(std::unique_ptr<Value<T>> data)
-      : data_(data.release()) {}
+      : OutputPort(std::unique_ptr<AbstractValue>(data.release())) {}
+
+  virtual ~OutputPort();
 
   /// Returns the abstract value in this port.
   const AbstractValue* get_abstract_data() const { return data_.get(); }
@@ -105,20 +107,10 @@ class OutputPort {
 
   /// Returns a clone of this OutputPort containing a clone of the data, but
   /// without any dependents.
-  std::unique_ptr<OutputPort> Clone() const {
-    if (data_ != nullptr) {
-      return std::make_unique<OutputPort>(data_->Clone());
-    }
-    return nullptr;
-  }
+  std::unique_ptr<OutputPort> Clone() const;
 
  private:
-  void InvalidateAndIncrement() {
-    ++version_;
-    for (OutputPortListenerInterface* dependent : dependents_) {
-      dependent->Invalidate();
-    }
-  }
+  void InvalidateAndIncrement();
 
   // OutputPort objects are neither copyable nor moveable.
   OutputPort(const OutputPort& other) = delete;

--- a/drake/systems/framework/value.cc
+++ b/drake/systems/framework/value.cc
@@ -3,6 +3,8 @@
 namespace drake {
 namespace systems {
 
+AbstractValue::~AbstractValue() {}
+
 // Explicit instantiations for VectorValue<double>.
 template class Value<VectorBase<double>*>;
 template class VectorValue<double>;

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -22,7 +22,7 @@ class Value;
 class DRAKESYSTEMFRAMEWORK_EXPORT AbstractValue {
  public:
   AbstractValue() {}
-  virtual ~AbstractValue() {}
+  virtual ~AbstractValue();
 
   /// Returns a copy of this AbstractValue.
   virtual std::unique_ptr<AbstractValue> Clone() const = 0;
@@ -101,6 +101,7 @@ template <typename T>
 class Value : public AbstractValue {
  public:
   explicit Value(const T& v) : value_(v) {}
+  ~Value() override {}
 
   // Values are copyable but not moveable.
   Value(const Value<T>& other) = default;
@@ -133,6 +134,7 @@ class VectorValue : public Value<VectorBase<T>*> {
  public:
   explicit VectorValue(std::unique_ptr<VectorBase<T>> v)
       : Value<VectorBase<T>*>(v.get()), owned_value_(std::move(v)) {}
+  ~VectorValue() override {}
 
   // VectorValues are copyable but not moveable.
   explicit VectorValue(const VectorValue<T>& other)


### PR DESCRIPTION
A lot of this stuff stopped being templates in d2a4d0c, and therefore needs export goop.  I also filled in some missing destructors, and began moving some code into .cc files.

+@jwnimmer-tri for both levels of review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3251)
<!-- Reviewable:end -->
