### PR TITLE
Fix a bug in algebraic loop detection.

### DIFF
--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -299,6 +299,12 @@ class Diagram : public System<T> {
     for (const auto& entry : dependency_graph_) {
       const System<T>* const dest = entry.first.first;
       const System<T>* const src = entry.second.first;
+      // If the destination system has no direct feedthrough, it does not
+      // matter whether it is sorted before or after the systems on which
+      // it depends.
+      if (!dest->has_any_direct_feedthrough()) {
+        continue;
+      }
       if (GetSystemIndex(dest) <= GetSystemIndex(src)) {
         return false;
       }

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -43,6 +43,23 @@ GTEST_TEST(DiagramBuilderTest, CycleButNoAlgebraicLoop) {
   EXPECT_NO_THROW(builder.Build());
 }
 
+// Tests that multiple cascaded elements that are not direct-feedthrough
+// are sortable.
+GTEST_TEST(DiagramBuilderTest, CascadedNonDirectFeedthrough) {
+  DiagramBuilder<double> builder;
+
+  Integrator<double> integrator1(1 /* length */);
+  Integrator<double> integrator2(1 /* length */);
+
+  builder.Connect(integrator1.get_output_port(0),
+                  integrator2.get_input_port(0));
+  builder.ExportInput(integrator1.get_input_port(0));
+  builder.ExportOutput(integrator2.get_output_port(0));
+
+  // There is no algebraic loop, so we should not throw.
+  EXPECT_NO_THROW(builder.Build());
+}
+
 // Tests that an exception is thrown when building an empty diagram.
 GTEST_TEST(DiagramBuilderTest, FinalizeWhenEmpty) {
   DiagramBuilder<double> builder;


### PR DESCRIPTION
Without this fix, a non-direct-feedthrough system might be visited twice in the course of sorting: once because it has in-degree zero, and again when the last system on which it depends is visited.

+@jwnimmer-tri for both levels of review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3261)
<!-- Reviewable:end -->
