### PR TITLE
Fix inverseDynamics for nonzero joint acceleration vector

### DIFF
--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -50,6 +50,10 @@ using Matrix3X = Eigen::Matrix<Scalar, 3, Eigen::Dynamic>;
 template <typename Scalar>
 using Matrix4X = Eigen::Matrix<Scalar, 4, Eigen::Dynamic>;
 
+/// A matrix of 6 rows, dynamic columns, templated on scalar type.
+template <typename Scalar>
+using Matrix6X = Eigen::Matrix<Scalar, 6, Eigen::Dynamic>;
+
 /// A matrix of dynamic size, templated on scalar type.
 template <typename Scalar>
 using MatrixX = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;

--- a/drake/math/autodiff_gradient.h
+++ b/drake/math/autodiff_gradient.h
@@ -6,6 +6,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_assert.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/gradient.h"
 

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1432,7 +1432,7 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
 
       // Add component due to joint acceleration.
       if (include_acceleration_terms) {
-        const DrakeJoint &joint = body.getJoint();
+        const DrakeJoint& joint = body.getJoint();
         auto vd_joint = vd.middleRows(body.get_velocity_start_index(),
                                       joint.getNumVelocities());
         body_acceleration.noalias() +=
@@ -2402,15 +2402,15 @@ RigidBodyTree::relativeTwist<double>(KinematicsCache<double> const&, int, int,
 
 // Explicit template instantiations for worldMomentumMatrix.
 template DRAKERBM_EXPORT TwistMatrix<AutoDiffUpTo73d>
-RigidBodyTree::worldMomentumMatrix<
-    AutoDiffUpTo73d>(KinematicsCache<AutoDiffUpTo73d> &,
-                     set<int, less<int>, allocator<int>> const &, bool) const;
+RigidBodyTree::worldMomentumMatrix<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d>&,
+    set<int, less<int>, allocator<int>> const&, bool) const;
 template DRAKERBM_EXPORT TwistMatrix<AutoDiffXd>
-RigidBodyTree::worldMomentumMatrix<
-    AutoDiffXd>(KinematicsCache<AutoDiffXd> &,
-                set<int, less<int>, allocator<int>> const &, bool) const;
+RigidBodyTree::worldMomentumMatrix<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd>&, set<int, less<int>, allocator<int>> const&,
+    bool) const;
 template DRAKERBM_EXPORT TwistMatrix<double> RigidBodyTree::worldMomentumMatrix<
-    double>(KinematicsCache<double> &,
+    double>(KinematicsCache<double>&,
             set<int, less<int>, allocator<int>> const&, bool) const;
 
 // Explicit template instantiations for worldMomentumMatrixDotTimesV.
@@ -2427,39 +2427,36 @@ RigidBodyTree::transformSpatialAcceleration<double>(
 // Explicit template instantiations for frictionTorques
 template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
 RigidBodyTree::frictionTorques(
-    Eigen::MatrixBase<VectorX<AutoDiffUpTo73d>> const &v) const;
+    Eigen::MatrixBase<VectorX<AutoDiffUpTo73d>> const& v) const;
 template DRAKERBM_EXPORT VectorX<AutoDiffXd> RigidBodyTree::frictionTorques(
-    Eigen::MatrixBase<VectorX<AutoDiffXd>> const &v) const;
+    Eigen::MatrixBase<VectorX<AutoDiffXd>> const& v) const;
 template DRAKERBM_EXPORT VectorX<double> RigidBodyTree::frictionTorques(
-    Eigen::MatrixBase<VectorX<double>> const &v) const;
+    Eigen::MatrixBase<VectorX<double>> const& v) const;
 
 // Explicit template instantiations for inverseDynamics.
 template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
-    RigidBodyTree::inverseDynamics<AutoDiffUpTo73d>(
+RigidBodyTree::inverseDynamics<AutoDiffUpTo73d>(
     KinematicsCache<AutoDiffUpTo73d>&,
-    unordered_map<RigidBody const*, TwistVector<AutoDiffUpTo73d>,
-    hash<RigidBody const*>,
-    equal_to<RigidBody const*>,
-    Eigen::aligned_allocator<pair<RigidBody const* const,
-    TwistVector<AutoDiffUpTo73d>>>> const&,
+    unordered_map<
+        RigidBody const*, TwistVector<AutoDiffUpTo73d>, hash<RigidBody const*>,
+        equal_to<RigidBody const*>,
+        Eigen::aligned_allocator<
+            pair<RigidBody const* const, TwistVector<AutoDiffUpTo73d>>>> const&,
     VectorX<AutoDiffUpTo73d> const&, bool) const;
 template DRAKERBM_EXPORT VectorX<AutoDiffXd>
-    RigidBodyTree::inverseDynamics<AutoDiffXd>(
+RigidBodyTree::inverseDynamics<AutoDiffXd>(
     KinematicsCache<AutoDiffXd>&,
     unordered_map<RigidBody const*, TwistVector<AutoDiffXd>,
-    hash<RigidBody const*>,
-    equal_to<RigidBody const*>,
-    Eigen::aligned_allocator<pair<RigidBody const* const,
-    TwistVector<AutoDiffXd>>>> const&,
+                  hash<RigidBody const*>, equal_to<RigidBody const*>,
+                  Eigen::aligned_allocator<pair<
+                      RigidBody const* const, TwistVector<AutoDiffXd>>>> const&,
     VectorX<AutoDiffXd> const&, bool) const;
-template DRAKERBM_EXPORT VectorX<double>
-    RigidBodyTree::inverseDynamics<double>(
+template DRAKERBM_EXPORT VectorX<double> RigidBodyTree::inverseDynamics<double>(
     KinematicsCache<double>&,
-    unordered_map<RigidBody const*, TwistVector<double>,
-    hash<RigidBody const*>,
-    equal_to<RigidBody const*>,
-    Eigen::aligned_allocator<pair<RigidBody const* const,
-    TwistVector<double>>>> const&,
+    unordered_map<RigidBody const*, TwistVector<double>, hash<RigidBody const*>,
+                  equal_to<RigidBody const*>,
+                  Eigen::aligned_allocator<pair<RigidBody const* const,
+                                                TwistVector<double>>>> const&,
     VectorX<double> const&, bool) const;
 
 // Explicit template instantiations for jointLimitConstraints.

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1405,8 +1405,8 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
   // TODO(#3114) pass this in as an argument
   const bool include_acceleration_terms = true;
 
-  // compute spatial accelerations and net wrenches that should be exerted to
-  // achieve those accelerations
+  // Compute spatial accelerations and net wrenches that should be exerted to
+  // achieve those accelerations.
   // TODO(tkoolen) should preallocate:
   Matrix6X<Scalar> body_accelerations(kTwistSize, bodies.size());
   Matrix6X<Scalar> net_wrenches(kTwistSize, bodies.size());
@@ -1417,12 +1417,12 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
       const auto& cache_element = cache.getElement(body);
       auto body_acceleration = body_accelerations.col(i);
 
-      // initialize body acceleration to acceleration of parent body
+      // Initialize body acceleration to acceleration of parent body.
       auto parent_acceleration =
           body_accelerations.col(parent_body.get_body_index());
       body_acceleration = parent_acceleration;
 
-      // add bias acceleration relative to parent body
+      // Add bias acceleration relative to parent body.
       if (include_velocity_terms) {
         const auto& parent_cache_element = cache.getElement(parent_body);
         body_acceleration += cache_element.motion_subspace_in_world_dot_times_v;
@@ -1430,7 +1430,7 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
             parent_cache_element.motion_subspace_in_world_dot_times_v;
       }
 
-      // add component due to joint acceleration
+      // Add component due to joint acceleration.
       if (include_acceleration_terms) {
         const DrakeJoint &joint = body.getJoint();
         auto vd_joint = vd.middleRows(body.get_velocity_start_index(),
@@ -1439,7 +1439,7 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
             cache_element.motion_subspace_in_world * vd_joint;
       }
 
-      // compute net wrench required to achieve computed body acceleration
+      // Compute net wrench required to achieve computed body acceleration.
       auto net_wrench = net_wrenches.col(i);
       const auto& body_inertia = cache_element.inertia_in_world;
       net_wrench.noalias() = body_inertia * body_acceleration;
@@ -1462,9 +1462,9 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
     }
   }
 
-  // do a backwards pass to compute joint wrenches from net wrenches (update in
+  // Do a backwards pass to compute joint wrenches from net wrenches (update in
   // place), and project the joint wrenches onto the joint's motion subspace to
-  // find the joint torque
+  // find the joint torque.
   auto& joint_wrenches = net_wrenches;
   // the following will eliminate the need for another explicit instantiation:
   const auto& joint_wrenches_const = net_wrenches;
@@ -1477,13 +1477,13 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
       const auto& joint = body.getJoint();
       auto joint_wrench = joint_wrenches_const.col(i);
 
-      // compute joint torques associated with joint wrench
+      // Compute joint torques associated with joint wrench.
       const auto& motion_subspace = cache_element.motion_subspace_in_world;
       auto joint_torques = torques.middleRows(body.get_velocity_start_index(),
                                               joint.getNumVelocities());
       joint_torques.noalias() = motion_subspace.transpose() * joint_wrench;
 
-      // add joint wrench (exerted upon 'body') to parent joint wrench
+      // Add joint wrench (exerted upon 'body') to parent joint wrench.
       const RigidBody& parent_body = *(body.get_parent());
       auto parent_joint_wrench =
           joint_wrenches.col(parent_body.get_body_index());

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -2361,8 +2361,16 @@ RigidBodyTree::relativeTwist<double>(KinematicsCache<double> const&, int, int,
                                      int) const;
 
 // Explicit template instantiations for worldMomentumMatrix.
+template DRAKERBM_EXPORT TwistMatrix<AutoDiffUpTo73d>
+RigidBodyTree::worldMomentumMatrix<
+    AutoDiffUpTo73d>(KinematicsCache<AutoDiffUpTo73d> &,
+                     set<int, less<int>, allocator<int>> const &, bool) const;
+template DRAKERBM_EXPORT TwistMatrix<AutoDiffXd>
+RigidBodyTree::worldMomentumMatrix<
+    AutoDiffXd>(KinematicsCache<AutoDiffXd> &,
+                set<int, less<int>, allocator<int>> const &, bool) const;
 template DRAKERBM_EXPORT TwistMatrix<double> RigidBodyTree::worldMomentumMatrix<
-    double>(KinematicsCache<double>&,
+    double>(KinematicsCache<double> &,
             set<int, less<int>, allocator<int>> const&, bool) const;
 
 // Explicit template instantiations for worldMomentumMatrixDotTimesV.

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -2376,14 +2376,42 @@ RigidBodyTree::transformSpatialAcceleration<double>(
     KinematicsCache<double> const&, TwistVector<double> const&, int, int, int,
     int) const;
 
+// Explicit template instantiations for frictionTorques
+template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d> RigidBodyTree::frictionTorques(
+    Eigen::MatrixBase<VectorX<AutoDiffUpTo73d>> const& v) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffXd> RigidBodyTree::frictionTorques(
+    Eigen::MatrixBase<VectorX<AutoDiffXd>> const& v) const;
+template DRAKERBM_EXPORT VectorX<double> RigidBodyTree::frictionTorques(
+    Eigen::MatrixBase<VectorX<double>> const& v) const;
+
 // Explicit template instantiations for inverseDynamics.
-template DRAKERBM_EXPORT VectorXd RigidBodyTree::inverseDynamics<double>(
+template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
+    RigidBodyTree::inverseDynamics<AutoDiffUpTo73d>(
+    KinematicsCache<AutoDiffUpTo73d>&,
+    unordered_map<RigidBody const*, TwistVector<AutoDiffUpTo73d>,
+    hash<RigidBody const*>,
+    equal_to<RigidBody const*>,
+    Eigen::aligned_allocator<pair<RigidBody const* const,
+    TwistVector<AutoDiffUpTo73d>>>> const&,
+    VectorX<AutoDiffUpTo73d> const&, bool) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffXd>
+    RigidBodyTree::inverseDynamics<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd>&,
+    unordered_map<RigidBody const*, TwistVector<AutoDiffXd>,
+    hash<RigidBody const*>,
+    equal_to<RigidBody const*>,
+    Eigen::aligned_allocator<pair<RigidBody const* const,
+    TwistVector<AutoDiffXd>>>> const&,
+    VectorX<AutoDiffXd> const&, bool) const;
+template DRAKERBM_EXPORT VectorX<double>
+    RigidBodyTree::inverseDynamics<double>(
     KinematicsCache<double>&,
-    unordered_map<RigidBody const*, TwistVector<double>, hash<RigidBody const*>,
-                  equal_to<RigidBody const*>,
-                  Eigen::aligned_allocator<pair<RigidBody const* const,
-                                                TwistVector<double>>>> const&,
-    VectorXd const&, bool) const;
+    unordered_map<RigidBody const*, TwistVector<double>,
+    hash<RigidBody const*>,
+    equal_to<RigidBody const*>,
+    Eigen::aligned_allocator<pair<RigidBody const* const,
+    TwistVector<double>>>> const&,
+    VectorX<double> const&, bool) const;
 
 // Explicit template instantiations for jointLimitConstraints.
 template DRAKERBM_EXPORT void RigidBodyTree::jointLimitConstraints<

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1456,8 +1456,7 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
         const auto& body_to_world = cache_element.transform_to_world;
         net_wrench -= transformSpatialForce(body_to_world, external_wrench);
       }
-    }
-    else {
+    } else {
       body_accelerations.col(i) = -a_grav.cast<Scalar>();
       net_wrenches.col(i).setZero();
     }
@@ -2426,12 +2425,13 @@ RigidBodyTree::transformSpatialAcceleration<double>(
     int) const;
 
 // Explicit template instantiations for frictionTorques
-template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d> RigidBodyTree::frictionTorques(
-    Eigen::MatrixBase<VectorX<AutoDiffUpTo73d>> const& v) const;
+template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
+RigidBodyTree::frictionTorques(
+    Eigen::MatrixBase<VectorX<AutoDiffUpTo73d>> const &v) const;
 template DRAKERBM_EXPORT VectorX<AutoDiffXd> RigidBodyTree::frictionTorques(
-    Eigen::MatrixBase<VectorX<AutoDiffXd>> const& v) const;
+    Eigen::MatrixBase<VectorX<AutoDiffXd>> const &v) const;
 template DRAKERBM_EXPORT VectorX<double> RigidBodyTree::frictionTorques(
-    Eigen::MatrixBase<VectorX<double>> const& v) const;
+    Eigen::MatrixBase<VectorX<double>> const &v) const;
 
 // Explicit template instantiations for inverseDynamics.
 template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
@@ -129,21 +129,23 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
     Scalar cy = cos(yaw);
     Scalar sy = sin(yaw);
 
-    motion_subspace_dot_times_v.transpose() << -pitchd * yawd * cp,
-        rolld * yawd * cp * cr - pitchd * yawd * sp * sr - pitchd * rolld * sr,
-        -pitchd * rolld * cr - pitchd * yawd * cr * sp - rolld * yawd * cp * sr,
-        yd * (yawd * cp * cy - pitchd * sp * sy) -
-            xd * (pitchd * cy * sp + yawd * cp * sy) - pitchd * zd * cp,
-        zd * (rolld * cp * cr - pitchd * sp * sr) +
-            xd * (rolld * (sr * sy + cr * cy * sp) -
-                  yawd * (cr * cy + sp * sr * sy) + pitchd * cp * cy * sr) -
-            yd * (rolld * (cy * sr - cr * sp * sy) +
-                  yawd * (cr * sy - cy * sp * sr) - pitchd * cp * sr * sy),
-        xd * (rolld * (cr * sy - cy * sp * sr) +
-              yawd * (cy * sr - cr * sp * sy) + pitchd * cp * cr * cy) -
-            zd * (pitchd * cr * sp + rolld * cp * sr) +
-            yd * (yawd * (sr * sy + cr * cy * sp) -
-                  rolld * (cr * cy + sp * sr * sy) + pitchd * cp * cr * sy);
+    motion_subspace_dot_times_v[0] = -pitchd * yawd * cp;
+    motion_subspace_dot_times_v[1] = rolld * yawd * cp * cr - pitchd * yawd * 
+      sp * sr - pitchd * rolld * sr;
+    motion_subspace_dot_times_v[2] = -pitchd * rolld * cr - pitchd * yawd * 
+      cr * sp - rolld * yawd * cp * sr;
+    motion_subspace_dot_times_v[3] = yd * (yawd * cp * cy - pitchd * sp * sy) -
+      xd * (pitchd * cy * sp + yawd * cp * sy) - pitchd * zd * cp;
+    motion_subspace_dot_times_v[4] = zd * (rolld * cp * cr - pitchd * sp * sr) +
+      xd * (rolld * (sr * sy + cr * cy * sp) -
+        yawd * (cr * cy + sp * sr * sy) + pitchd * cp * cy * sr) -
+      yd * (rolld * (cy * sr - cr * sp * sy) +
+        yawd * (cr * sy - cy * sp * sr) - pitchd * cp * sr * sy);
+    motion_subspace_dot_times_v[5] = xd * (rolld * (cr * sy - cy * sp * sr) +
+      yawd * (cy * sr - cr * sp * sy) + pitchd * cp * cr * cy) -
+      zd * (pitchd * cr * sp + rolld * cp * sr) +
+      yd * (yawd * (sr * sy + cr * cy * sp) -
+        rolld * (cr * cy + sp * sr * sy) + pitchd * cp * cr * sy);
 
     if (dmotion_subspace_dot_times_vdq) {
       dmotion_subspace_dot_times_vdq->resize(motion_subspace_dot_times_v.rows(),

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
@@ -130,9 +130,9 @@ class DRAKEJOINTS_EXPORT RollPitchYawFloatingJoint
     Scalar sy = sin(yaw);
 
     motion_subspace_dot_times_v[0] = -pitchd * yawd * cp;
-    motion_subspace_dot_times_v[1] = rolld * yawd * cp * cr - pitchd * yawd * 
+    motion_subspace_dot_times_v[1] = rolld * yawd * cp * cr - pitchd * yawd *
       sp * sr - pitchd * rolld * sr;
-    motion_subspace_dot_times_v[2] = -pitchd * rolld * cr - pitchd * yawd * 
+    motion_subspace_dot_times_v[2] = -pitchd * rolld * cr - pitchd * yawd *
       cr * sp - rolld * yawd * cp * sr;
     motion_subspace_dot_times_v[3] = yd * (yawd * cp * cy - pitchd * sp * sy) -
       xd * (pitchd * cy * sp + yawd * cp * sy) - pitchd * zd * cp;

--- a/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
@@ -1,7 +1,7 @@
 pods_find_pkg_config(bullet)
 
 if(bullet_FOUND)
-  add_executable(rbt_collisions_test rbt_collisions_test.cc rigid_body_tree_inverse_dynamics_test.cc)
+  add_executable(rbt_collisions_test rbt_collisions_test.cc)
   target_link_libraries(rbt_collisions_test drakeRBM ${GTEST_BOTH_LIBRARIES})
   drake_add_test(NAME rbt_collisions_test COMMAND rbt_collisions_test)
 endif()

--- a/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
@@ -1,7 +1,7 @@
 pods_find_pkg_config(bullet)
 
 if(bullet_FOUND)
-  add_executable(rbt_collisions_test rbt_collisions_test.cc)
+  add_executable(rbt_collisions_test rbt_collisions_test.cc rigid_body_tree_inverse_dynamics_test.cc)
   target_link_libraries(rbt_collisions_test drakeRBM ${GTEST_BOTH_LIBRARIES})
   drake_add_test(NAME rbt_collisions_test COMMAND rbt_collisions_test)
 endif()
@@ -9,3 +9,7 @@ endif()
 add_executable(rigid_body_tree_test rigid_body_tree_test.cc)
 target_link_libraries(rigid_body_tree_test drakeRBSystem ${GTEST_BOTH_LIBRARIES})
 drake_add_test(NAME rigid_body_tree_test COMMAND rigid_body_tree_test)
+
+add_executable(rigid_body_tree_inverse_dynamics_test rigid_body_tree_inverse_dynamics_test.cc)
+target_link_libraries(rigid_body_tree_inverse_dynamics_test drakeRBSystem ${GTEST_BOTH_LIBRARIES})
+drake_add_test(NAME rigid_body_tree_inverse_dynamics_test COMMAND rigid_body_tree_inverse_dynamics_test)

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -58,7 +58,6 @@ class RigidBodyTreeInverseDynamicsTest: public ::testing::Test {
 // Robotic Manipulation" (1994). Lemma 4.2).
 // Note: property only holds true if qd = v
 TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
-
   int num_velocities = tree_rpy_->number_of_velocities();
 
   std::default_random_engine generator;

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -53,7 +53,18 @@ class RigidBodyTreeInverseDynamicsTest : public ::testing::Test {
 // Check that mass matrix derivative minus two times Coriolis matrix is skew
 // symmetric (see e.g. Murray, Li, Sastry. "A Mathematical Introduction to
 // Robotic Manipulation" (1994). Lemma 4.2).
+// http://www.cds.caltech.edu/~murray/books/MLS/pdf/mls94-complete.pdf
+// http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.671
+// .7040&rep=rep1&type=pdf
 // Note: property only holds true if qd = v.
+// The Coriolis matrix is the matrix C(q, qd) when the equations of motion
+// are written as
+//
+//    H(q) qdd + C(q, qd) qd + g(q) = tau
+//
+// with H(q) the mass matrix, g(q) the gravitational terms, and tau the joint
+// torques.
+//
 TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
   int num_velocities = tree_rpy_->number_of_velocities();
 
@@ -105,6 +116,12 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
 
 // Check that the gradient of the output of inverseDynamics with respect to
 // the joint acceleration vector is the mass matrix.
+// The equations of motion can be written as
+//
+//    H(q) vd + c(q, v) = tau
+//
+// Since inverseDynamics computes tau given q, v, and vd, the gradient of tau
+// with respect to vd should be the mass matrix H(q).
 TEST_F(RigidBodyTreeInverseDynamicsTest, TestAccelerationJacobianIsMassMatrix) {
   std::default_random_engine generator;
 
@@ -137,12 +154,21 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestAccelerationJacobianIsMassMatrix) {
   }
 }
 
-// Check that the derivatives of potential energy with respect to q match the
-// vector of generalized gravitational forces for rpy tree.
+// Check that the derivatives of gravitational potential energy with respect
+// to q match the vector of generalized gravitational forces for an rpy tree.
+// When qd = v, the equations of motion can be written as
+//
+//    H(q) qdd + C(q, qd) qd + g(q) = tau
+//
+// When qd = 0 and qdd = 0, tau = g(q), so we can compute the gravitational
+// term using the inverse dynamics algorithm.
+// Now let V(q) denote gravitational potential energy. Then, by definition,
+// g(q) = dV(q)/dq. Assert that that is indeed the case.
 TEST_F(RigidBodyTreeInverseDynamicsTest, TestGeneralizedGravitationalForces) {
   std::default_random_engine generator;
 
-  // Compute vector of generalized gravitational forces.
+  // Compute vector of generalized gravitational forces. Note that
+  // dynamicsBiasTerm simply calls inverseDynamics with vd = 0.
   auto& tree = tree_rpy_;
   auto q = tree->getRandomConfiguration(generator);
   KinematicsCache<double> kinematics_cache(tree->bodies);
@@ -152,7 +178,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestGeneralizedGravitationalForces) {
   auto gravitational_forces =
       tree->dynamicsBiasTerm(kinematics_cache, f_ext, false);
 
-  // Compute derivatives of potential energy.
+  // Compute the vector gradient of potential energy.
   auto q_autodiff = initializeAutoDiff(q);
   typedef typename decltype(q_autodiff)::Scalar ADScalar;
   KinematicsCache<ADScalar> kinematics_cache_autodiff(tree->bodies);
@@ -172,6 +198,37 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestGeneralizedGravitationalForces) {
 
 // Check that momentum rate of change is equal to the sum of all external
 // wrenches exerted upon the mechanism.
+//
+// The total (spatial) momentum of a mechanism can be written as
+//
+//    h(q, v) = A(q) v
+//
+// where A is the momentum matrix (see Orin, Goswami. "Centroidal momentum
+// matrix of a humanoid robot: Structure and properties" (2008)
+// http://www.ambarish
+// .com/paper/20080707_Orin_Goswami_momentum_matrix_IROS2008.pdf
+//
+// The rate of change of momentum, hdot, can be computed using automatic
+// differentiation, given q, v, and vdot.
+//
+// By the Newton-Euler equations, the rate of change of momentum must be
+// equal to the sum of wrenches acting externally on the mechanism:
+//
+//    hdot = W_f + W_g + sum(W_i)
+//
+// where:
+// * W_g is the wrench due to gravity
+// * W_f is the wrench across the floating joint (treating it as having an
+// actuator)
+// * the W_i are other external wrenches acting upon the bodies of the
+// mechanism.
+//
+// Given q, v, vdot, and W_i, the inverse dynamics algorithm can be used to
+// compute the required torques. For a floating mechanism with a
+// QuaternionFloatingJoint, the torque vector associated with the floating
+// joint should exactly be the wrench W_f. All other joint torques are
+// internal to the mechanism.
+// Given hdot, W_f, W_g and the W_i's, assert that Newton-Euler holds.
 TEST_F(RigidBodyTreeInverseDynamicsTest, TestMomentumRateOfChange) {
   std::default_random_engine generator;
   int world_index = 0;
@@ -188,7 +245,9 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestMomentumRateOfChange) {
   kinematics_cache.initialize(q, v);
   tree.doKinematics(kinematics_cache, true);
 
-  // Compute gravitational wrench.
+  // Compute gravitational wrench W_g.
+  // Gravitational force can be thought of as acting at center of mass. Change
+  // to world frame.
   auto gravitational_wrench_centroidal = (tree.a_grav * tree.getMass()).eval();
   Eigen::Isometry3d centroidal_to_world;
   centroidal_to_world.setIdentity();
@@ -209,7 +268,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestMomentumRateOfChange) {
     }
   }
 
-  // Compute wrench across floating joint, add to total wrench.
+  // Compute wrench across floating joint W_f, add to total wrench.
   auto tau = tree.inverseDynamics(kinematics_cache, f_ext, vd);
   auto& floating_body_ptr = tree.bodies[1];
   int floating_joint_start_index =
@@ -222,7 +281,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestMomentumRateOfChange) {
       transformSpatialForce(body_to_world, floating_joint_wrench_body);
   total_wrench_world += floating_joint_wrench_world;
 
-  // Compute rate of change of momentum.
+  // Compute rate of change of momentum hdot.
   auto identity = MatrixXd::Identity(q.size(), q.size());
   auto v_to_qd =
       kinematics_cache.transformPositionDotMappingToVelocityMapping(identity);

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -1,14 +1,16 @@
-#include <iostream>
+#include <iostream> // TODO: remove
 
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/common/drake_path.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
 #include "drake/systems/plants/parser_urdf.h"
-#include "drake/systems/plants/RigidBodyTree.h"
+
 
 namespace drake {
 namespace systems {
@@ -17,26 +19,125 @@ namespace test {
 namespace {
 
 using drake::parsers::ModelInstanceIdTable;
+using drake::math::initializeAutoDiff;
+using drake::math::autoDiffToGradientMatrix;
+using drake::math::initializeAutoDiffGivenGradientMatrix;
+using Eigen::VectorXd;
+using Eigen::MatrixXd;
+using drake::CompareMatrices;
+
+using drake::math::initializeAutoDiffTuple;
 
 class RigidBodyTreeInverseDynamicsTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    tree.reset(new RigidBodyTree());
+    tree_.reset(new RigidBodyTree());
     std::string kAtlasUrdf =
         drake::GetDrakePath() + "/examples/Atlas/urdf/atlas_convex_hull.urdf";
     drake::parsers::urdf::AddModelInstanceFromUrdfFile(
         kAtlasUrdf, DrakeJoint::ROLLPITCHYAW,
-        nullptr /* weld_to_frame */, tree.get());
+        nullptr /* weld_to_frame */, tree_.get());
   }
 
  public:
   // TODO(amcastro-tri): A stack object here (preferable to a pointer)
   // generates build issues on Windows platforms. See git-hub issue #1854.
-  std::unique_ptr<RigidBodyTree> tree;
+  std::unique_ptr<RigidBodyTree> tree_;
 };
 
+
+
+// Check that mass matrix derivative minus two times Coriolis matrix is skew
+// symmetric (see e.g. Murray, Li, Sastry. "A Mathematical Introduction to
+// Robotic Manipulation" (1994). Lemma 4.2).
+// Note: property only holds true if qd = v
+TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
+
+  int num_velocities = tree_->number_of_velocities();
+
+  //  std::default_random_engine generator;
+//  auto q = tree_->getRandomConfiguration(generator);
+  auto q = tree_->getZeroConfiguration();
+  auto qd = VectorXd::Constant(num_velocities, 1.);
+  auto qdd = VectorXd::Zero(tree_->number_of_velocities());
+
+  // compute mass matrix time derivative
+
+  // convert qd to MatrixXd to make another explicit instantiation of
+  // mass_matrix unnecessary
+  auto qd_dynamic_num_rows = MatrixXd(qd);
+  auto q_time_autodiff = initializeAutoDiffGivenGradientMatrix(q, qd_dynamic_num_rows);
+  typedef typename decltype(q_time_autodiff)::Scalar TimeADScalar;
+  auto qd_time_autodiff = qd.cast<TimeADScalar>();
+  KinematicsCache<TimeADScalar> kinematics_cache_time_autodiff(tree_->bodies);
+  kinematics_cache_time_autodiff.initialize(q_time_autodiff, qd_time_autodiff);
+  tree_->doKinematics(kinematics_cache_time_autodiff);
+  auto mass_matrix_time_autodiff = tree_->massMatrix(
+      kinematics_cache_time_autodiff);
+  auto mass_matrix_dot_vectorized = autoDiffToGradientMatrix(
+      mass_matrix_time_autodiff);
+  auto mass_matrix_dot = Eigen::Map<Eigen::MatrixXd>(
+      mass_matrix_dot_vectorized.data(), num_velocities, num_velocities);
+
+  // compute Coriolis matrix
+  auto qd_qd_autodiff = initializeAutoDiff(qd);
+  typedef typename decltype(qd_qd_autodiff)::Scalar QdADScalar;
+  auto q_qd_autodiff = q.cast<QdADScalar>().eval();
+  auto qdd_qd_autodiff = qdd.cast<QdADScalar>().eval();
+  KinematicsCache<QdADScalar> kinematics_cache_qd_autodiff(tree_->bodies);
+  kinematics_cache_qd_autodiff.initialize(q_qd_autodiff, qd_qd_autodiff);
+  tree_->doKinematics(kinematics_cache_qd_autodiff, true);
+  eigen_aligned_unordered_map<const RigidBody *, TwistVector<QdADScalar>> f_ext;
+  auto tau_autodiff = tree_->inverseDynamics(
+      kinematics_cache_qd_autodiff, f_ext, qdd_qd_autodiff, true);
+  tau_autodiff -= tree_->frictionTorques(qd_qd_autodiff);
+  auto coriolis_matrix = (autoDiffToGradientMatrix(tau_autodiff) / 2.).eval();
+
+  // assert that property holds
+  auto skew = (mass_matrix_dot - 2 * coriolis_matrix).eval();
+  EXPECT_TRUE(CompareMatrices((skew + skew.transpose()).eval(),
+                              MatrixXd::Zero(num_velocities, num_velocities),
+                              1e-10, MatrixCompareType::absolute));
+}
+
+
+// Check that the gradient of the output of inverseDynamics with respect to
+// the joint acceleration vector is the mass matrix.
 TEST_F(RigidBodyTreeInverseDynamicsTest, TestAccelerationJacobianIsMassMatrix) {
-  drake::math::initializeAutoDiff(q);
+  std::default_random_engine generator;
+
+  auto vd = VectorXd::Random(tree_->number_of_velocities());
+  auto v = VectorXd::Random(tree_->number_of_velocities());
+  auto q = tree_->getRandomConfiguration(generator);
+  KinematicsCache<double> kinematics_cache(tree_->bodies);
+  kinematics_cache.initialize(q, v);
+  tree_->doKinematics(kinematics_cache);
+  auto mass_matrix = tree_->massMatrix(kinematics_cache);
+
+  auto vd_autodiff = initializeAutoDiff(vd);
+  typedef typename decltype(vd_autodiff)::Scalar ADScalar;
+  auto v_autodiff = v.cast<ADScalar>().eval();
+  auto q_autodiff = v.cast<ADScalar>().eval();
+  KinematicsCache<ADScalar> kinematics_cache_autodiff(tree_->bodies);
+  kinematics_cache_autodiff.initialize(q_autodiff, v_autodiff);
+  tree_->doKinematics(kinematics_cache_autodiff, true);
+  eigen_aligned_unordered_map<const RigidBody *, TwistVector<ADScalar>> f_ext;
+  auto tau_autodiff = tree_->inverseDynamics(kinematics_cache_autodiff, f_ext,
+      vd_autodiff);
+  auto mass_matrix_from_inverse_dynamics = autoDiffToGradientMatrix(
+      tau_autodiff);
+
+  autoDiffToGradientMatrix(tree_->frictionTorques(v_autodiff));
+
+  double kTolerance = 1e-10;
+//  std::cout << mass_matrix << std::endl << std::endl;
+//  std::cout << mass_matrix_from_inverse_dynamics << std::endl << std::endl;
+  EXPECT_TRUE(mass_matrix.isApprox(mass_matrix_from_inverse_dynamics,
+      kTolerance));
+
+  EXPECT_TRUE(CompareMatrices(mass_matrix,
+                              mass_matrix_from_inverse_dynamics,
+                              1e-10, MatrixCompareType::absolute));
 }
 
 }  // namespace

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -39,8 +39,7 @@ class RigidBodyTreeInverseDynamicsTest : public ::testing::Test {
 
     tree_rpy_ = std::make_unique<RigidBodyTree>();
     drake::parsers::urdf::AddModelInstanceFromUrdfFile(
-        kAtlasUrdf, kRollPitchYaw, nullptr /* weld_to_frame
- * */,
+        kAtlasUrdf, kRollPitchYaw, nullptr /* weld_to_frame */,
         tree_rpy_.get());
     trees_.push_back(tree_rpy_.get());
 

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -162,11 +162,12 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestGeneralizedGravitationalForces) {
   auto gravitational_force =
       (gravitational_acceleration.cast<ADScalar>() * tree->getMass()).eval();
   auto center_of_mass = tree->centerOfMass(kinematics_cache_autodiff);
-  ADScalar gravitational_potential_energy = -center_of_mass.dot(gravitational_force);
+  ADScalar gravitational_potential_energy =
+      -center_of_mass.dot(gravitational_force);
 
   EXPECT_TRUE(CompareMatrices(gravitational_forces,
-                              gravitational_potential_energy.derivatives(), 1e-10,
-                              MatrixCompareType::absolute));
+                              gravitational_potential_energy.derivatives(),
+                              1e-10, MatrixCompareType::absolute));
 }
 
 // Check that momentum rate of change is equal to the sum of all external

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -26,7 +26,7 @@ class RigidBodyTreeInverseDynamicsTest : public ::testing::Test {
   virtual void SetUp() {
     trees_.clear();
 
-    std::string kAtlasUrdf =
+    const std::string kAtlasUrdf =
         drake::GetDrakePath() + "/examples/Atlas/urdf/atlas_convex_hull.urdf";
 
     tree_rpy_.reset(new RigidBodyTree());

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -73,7 +73,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
   auto q_time_autodiff = initializeAutoDiffGivenGradientMatrix(
       q, qd_dynamic_num_rows);
   typedef typename decltype(q_time_autodiff)::Scalar TimeADScalar;
-  auto qd_time_autodiff = qd.cast<TimeADScalar>();
+  auto qd_time_autodiff = qd.cast<TimeADScalar>().eval();
   KinematicsCache<TimeADScalar> kinematics_cache_time_autodiff(
       tree_rpy_->bodies);
   kinematics_cache_time_autodiff.initialize(q_time_autodiff, qd_time_autodiff);

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -6,6 +6,7 @@
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/systems/plants/parser_urdf.h"
+#include "drake/systems/plants/joints/floating_base_types.h"
 
 namespace drake {
 namespace systems {
@@ -20,6 +21,8 @@ using drake::math::initializeAutoDiffGivenGradientMatrix;
 using Eigen::VectorXd;
 using Eigen::MatrixXd;
 using drake::CompareMatrices;
+using drake::systems::plants::joints::kRollPitchYaw;
+using drake::systems::plants::joints::kQuaternion;
 
 class RigidBodyTreeInverseDynamicsTest : public ::testing::Test {
  protected:
@@ -31,13 +34,14 @@ class RigidBodyTreeInverseDynamicsTest : public ::testing::Test {
 
     tree_rpy_.reset(new RigidBodyTree());
     drake::parsers::urdf::AddModelInstanceFromUrdfFile(
-        kAtlasUrdf, DrakeJoint::ROLLPITCHYAW, nullptr /* weld_to_frame */,
+        kAtlasUrdf, kRollPitchYaw, nullptr /* weld_to_frame
+ * */,
         tree_rpy_.get());
     trees_.push_back(tree_rpy_.get());
 
     tree_quaternion_ = std::make_unique<RigidBodyTree>();
     drake::parsers::urdf::AddModelInstanceFromUrdfFile(
-        kAtlasUrdf, DrakeJoint::QUATERNION, nullptr /* weld_to_frame */,
+        kAtlasUrdf, kQuaternion, nullptr /* weld_to_frame */,
         tree_quaternion_.get());
     trees_.push_back(tree_quaternion_.get());
   }

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -32,7 +32,7 @@ class RigidBodyTreeInverseDynamicsTest : public ::testing::Test {
     const std::string kAtlasUrdf =
         drake::GetDrakePath() + "/examples/Atlas/urdf/atlas_convex_hull.urdf";
 
-    tree_rpy_.reset(new RigidBodyTree());
+    tree_rpy_ = std::make_unique<RigidBodyTree>();
     drake::parsers::urdf::AddModelInstanceFromUrdfFile(
         kAtlasUrdf, kRollPitchYaw, nullptr /* weld_to_frame
  * */,
@@ -72,8 +72,8 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
 
   std::default_random_engine generator;
   auto q = tree_rpy_->getRandomConfiguration(generator);
-  auto qd = VectorXd::Constant(num_velocities, 1.);
-  auto qdd = VectorXd::Zero(num_velocities);
+  auto qd = VectorXd::Random(num_velocities).eval();
+  auto qdd = VectorXd::Zero(num_velocities).eval();
 
   // Compute mass matrix time derivative
 
@@ -165,8 +165,6 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestAccelerationJacobianIsMassMatrix) {
         .rows());
     ASSERT_EQ(tree->number_of_velocities(), mass_matrix_from_inverse_dynamics
         .cols());
-
-    autoDiffToGradientMatrix(tree->frictionTorques(v_autodiff));
 
     EXPECT_TRUE(CompareMatrices(mass_matrix, mass_matrix_from_inverse_dynamics,
                                 1e-10, MatrixCompareType::absolute));

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -1,0 +1,46 @@
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/math/autodiff.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/common/drake_path.h"
+#include "drake/systems/plants/parser_model_instance_id_table.h"
+#include "drake/systems/plants/parser_urdf.h"
+#include "drake/systems/plants/RigidBodyTree.h"
+
+namespace drake {
+namespace systems {
+namespace plants {
+namespace test {
+namespace {
+
+using drake::parsers::ModelInstanceIdTable;
+
+class RigidBodyTreeInverseDynamicsTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    tree.reset(new RigidBodyTree());
+    std::string kAtlasUrdf =
+        drake::GetDrakePath() + "/examples/Atlas/urdf/atlas_convex_hull.urdf";
+    drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+        kAtlasUrdf, DrakeJoint::ROLLPITCHYAW,
+        nullptr /* weld_to_frame */, tree.get());
+  }
+
+ public:
+  // TODO(amcastro-tri): A stack object here (preferable to a pointer)
+  // generates build issues on Windows platforms. See git-hub issue #1854.
+  std::unique_ptr<RigidBodyTree> tree;
+};
+
+TEST_F(RigidBodyTreeInverseDynamicsTest, TestAccelerationJacobianIsMassMatrix) {
+  drake::math::initializeAutoDiff(q);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace plants
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -162,10 +162,10 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestGeneralizedGravitationalForces) {
   auto gravitational_force =
       (gravitational_acceleration.cast<ADScalar>() * tree->getMass()).eval();
   auto center_of_mass = tree->centerOfMass(kinematics_cache_autodiff);
-  ADScalar potential_energy = -center_of_mass.dot(gravitational_force);
+  ADScalar gravitational_potential_energy = -center_of_mass.dot(gravitational_force);
 
   EXPECT_TRUE(CompareMatrices(gravitational_forces,
-                              potential_energy.derivatives(), 1e-10,
+                              gravitational_potential_energy.derivatives(), 1e-10,
                               MatrixCompareType::absolute));
 }
 


### PR DESCRIPTION
The spatial accelerations of the bodies were wrong when joint acceleration vector was not all zeros (component due to joint acceleration was not being propagated).

Fixes https://github.com/RobotLocomotion/drake/issues/2201.

Added some new C++ tests for inverseDynamics (`rigid_body_tree_inverse_dynamics_test`). Two of the tests failed, demonstrating https://github.com/RobotLocomotion/drake/issues/2201. The fix in https://github.com/RobotLocomotion/drake/commit/f5907733fb47012c54392044dd50635d36aaeb79 makes the two failing test cases pass. Also added some comments on the algorithm and cleaned up a little.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3262)
<!-- Reviewable:end -->
