### PR TITLE
Implements a PID controller by composing a Diagram

### DIFF
--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -17,6 +17,7 @@ set(sources
   primitives/gain.cc
   primitives/integrator.cc
   primitives/pass_through.cc
+  primitives/pid_controller.cc
   state.cc
   state_subvector.cc
   state_supervector.cc

--- a/drake/systems/framework/primitives/CMakeLists.txt
+++ b/drake/systems/framework/primitives/CMakeLists.txt
@@ -10,6 +10,7 @@ drake_install_headers(
   gain-inl.h
   integrator.h
   pass_through.h
-  pass_through-inl.h)
+  pass_through-inl.h
+  pid_controller.h)
 
 add_subdirectory(test)

--- a/drake/systems/framework/primitives/gain-inl.h
+++ b/drake/systems/framework/primitives/gain-inl.h
@@ -27,6 +27,11 @@ Gain<T>::Gain(const T& k, int length) : gain_(k) {
 }
 
 template <typename T>
+const T& Gain<T>::get_gain() const {
+  return gain_;
+}
+
+template <typename T>
 void Gain<T>::EvalOutput(const ContextBase<T>& context,
                          SystemOutput<T>* output) const {
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));

--- a/drake/systems/framework/primitives/gain.h
+++ b/drake/systems/framework/primitives/gain.h
@@ -31,6 +31,9 @@ class Gain : public LeafSystem<T> {
   /// @param length is the size of the signal to be processed.
   Gain(const T& k, int length);
 
+  /// Returns the gain constant.
+  const T& get_gain() const;
+
   /// Sets the output port value to the product of the gain and the input port
   /// value. The gain is specified in the constructor.
   /// If number of connected input or output ports differs from one or, the

--- a/drake/systems/framework/primitives/integrator.cc
+++ b/drake/systems/framework/primitives/integrator.cc
@@ -21,6 +21,19 @@ Integrator<T>::Integrator(int length) {
 template <typename T>
 Integrator<T>::~Integrator() {}
 
+template <typename T>
+void Integrator<T>::set_integral_value(
+    ContextBase<T>* context, const Eigen::Ref<const VectorX<T>>& value) const {
+  // TODO(amcastro-tri): Provide simple accessors here to avoid lengthy
+  // constructions.
+  auto state_vector =
+      context->get_mutable_state()->continuous_state->get_mutable_state();
+  // Asserts that the input value is a column vector of the appropriate size.
+  DRAKE_ASSERT(value.rows() == state_vector->size() && value.cols() == 1);
+  context->get_mutable_state()->continuous_state->
+      get_mutable_state()->SetFromVector(value);
+}
+
 // TODO(amcastro-tri): we should be able to express that initial conditions
 // feed through an integrator but the dynamic signal during simulation does
 // not.

--- a/drake/systems/framework/primitives/integrator.h
+++ b/drake/systems/framework/primitives/integrator.h
@@ -26,6 +26,11 @@ class Integrator : public LeafSystem<T> {
   explicit Integrator(int length);
   ~Integrator() override;
 
+  /// Sets the value of the integral modifying the state in the context.
+  /// @p value must be a column vector of the appropriate size.
+  void set_integral_value(ContextBase<T>* context,
+                          const Eigen::Ref<const VectorX<T>>& value) const;
+
   // System<T> overrides
   bool has_any_direct_feedthrough() const override;
   void EvalOutput(const ContextBase<T>& context,

--- a/drake/systems/framework/primitives/pid_controller.cc
+++ b/drake/systems/framework/primitives/pid_controller.cc
@@ -1,0 +1,95 @@
+#include "drake/systems/framework/primitives/pid_controller.h"
+
+#include "drake/drakeSystemFramework_export.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+using std::make_unique;
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+PidController<T>::PidController(
+    const T& Kp, const T& Ki, const T& Kd, int length) : Diagram<T>() {
+  DRAKE_ASSERT(Kp >= 0);
+  DRAKE_ASSERT(Ki >= 0);
+  DRAKE_ASSERT(Kd >= 0);
+  DRAKE_ASSERT(length > 0);
+  pass_through_ = make_unique<PassThrough<T>>(length);
+  proportional_gain_ = make_unique<Gain<T>>(Kp /* gain */, length /* length */);
+  integral_gain_ = make_unique<Gain<T>>(Ki /* gain */, length /* length */);
+  derivative_gain_ = make_unique<Gain<T>>(Kd /* gain */, length /* length */);
+  integrator_ = make_unique<Integrator<T>>(length);
+  adder_ = make_unique<Adder<T>>(3 /* inputs */, length /* length */);
+
+  DiagramBuilder<T> builder;
+  // Input 0 connects to the proportional and integral components.
+  builder.ExportInput(pass_through_->get_input_port(0));
+  // Input 1 connects directly to the derivative component.
+  builder.ExportInput(derivative_gain_->get_input_port(0));
+  builder.Connect(pass_through_->get_output_port(0),
+                  proportional_gain_->get_input_port(0));
+  builder.Connect(pass_through_->get_output_port(0),
+                  integrator_->get_input_port(0));
+  builder.Connect(integrator_->get_output_port(0),
+                  integral_gain_->get_input_port(0));
+  builder.Connect(proportional_gain_->get_output_port(0),
+                  adder_->get_input_port(0));
+  builder.Connect(integral_gain_->get_output_port(0),
+                  adder_->get_input_port(1));
+  builder.Connect(derivative_gain_->get_output_port(0),
+                  adder_->get_input_port(2));
+  builder.ExportOutput(adder_->get_output_port(0));
+  builder.BuildInto(this);
+}
+
+template <typename T>
+T PidController<T>::get_Kp() const {
+  return proportional_gain_->get_gain();
+}
+
+template <typename T>
+T PidController<T>::get_Ki() const {
+  return integral_gain_->get_gain();
+}
+
+template <typename T>
+T PidController<T>::get_Kd() const {
+  return derivative_gain_->get_gain();
+}
+
+template <typename T>
+bool PidController<T>::has_any_direct_feedthrough() const {
+  if (get_Kp() == 0 && get_Kd() == 0) return false;
+  return true;
+}
+
+template <typename T>
+const SystemPortDescriptor<T>& PidController<T>::get_error_port() const {
+  return Diagram<T>::get_input_port(0);
+}
+
+template <typename T>
+const SystemPortDescriptor<T>&
+PidController<T>::get_error_derivative_port() const {
+  return Diagram<T>::get_input_port(1);
+}
+
+template <typename T>
+void PidController<T>::SetDefaultState(ContextBase<T>* context) const {
+  const int length = Diagram<T>::get_input_port(0).get_size();
+  set_integral_value(context, VectorX<T>::Zero(length));
+}
+
+template <typename T>
+void PidController<T>::set_integral_value(
+    ContextBase<T>* context, const Eigen::Ref<const VectorX<T>>& value) const {
+  ContextBase<T>* integrator_context =
+      Diagram<T>::GetMutableSubsystemContext(context, integrator_.get());
+  integrator_->set_integral_value(integrator_context, value);
+}
+
+template class DRAKESYSTEMFRAMEWORK_EXPORT PidController<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/pid_controller.h
+++ b/drake/systems/framework/primitives/pid_controller.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/systems/framework/context_base.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/primitives/adder.h"
+#include "drake/systems/framework/primitives/gain.h"
+#include "drake/systems/framework/primitives/integrator.h"
+#include "drake/systems/framework/primitives/pass_through.h"
+
+namespace drake {
+namespace systems {
+
+/// A PID controller system. Given an error signal `e` and its time derivative
+/// `edot` the output of this sytem is
+/// <pre>
+///     y = Kp * e + Ki integ(e,dt) + Kd * edot
+/// </pre>
+/// where `integ(e,dt)` is the time integral of `e`.
+/// A PID controller directly feedthroughs the error signal to the output when
+/// the proportional constant is non-zero. It feeds through the rate of change
+/// of the error signal when the derivative constant is non-zero.
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+template <typename T>
+class PidController : public Diagram<T> {
+ public:
+  /// Constructs a PID controller with proportional constant @p Kp,
+  /// integral constant @p Ki and derivative constant @p Kd.
+  /// Input/output ports are limited to have size @p length.
+  /// @param Kp the proportional constant.
+  /// @param Ki the integral constant.
+  /// @param Kd the derivative constant.
+  /// @param length is the size of the signal to be processed.
+  PidController(const T& Kp, const T& Ki, const T& Kd, int length);
+
+  ~PidController() override {}
+
+  /// Returns the proportional constant.
+  T get_Kp() const;
+
+  /// Returns the integral constant.
+  T get_Ki() const;
+
+  /// Returns the derivative constant.
+  T get_Kd() const;
+
+  // System<T> overrides
+  /// A PID controller directly feedthroughs the error signal to the output when
+  /// the proportional constant is non-zero. It feeds through the rate of change
+  /// of the error signal when the derivative constant is non-zero.
+  bool has_any_direct_feedthrough() const override;
+
+  /// Sets @p context to a default state in which the integral of the error
+  /// signal is zero.
+  void SetDefaultState(ContextBase<T>* context) const;
+
+  /// Sets the integral of the %PidController to @p value.
+  /// @p value must be a column vector of the appropriate size.
+  void set_integral_value(ContextBase<T>* context,
+                          const Eigen::Ref<const VectorX<T>>& value) const;
+
+  /// Returns the input port to the error signal.
+  const SystemPortDescriptor<T>& get_error_port() const;
+
+  /// Returns the input port to the time derivative or rate of the error signal.
+  const SystemPortDescriptor<T>& get_error_derivative_port() const;
+
+ private:
+  std::unique_ptr<Adder<T>> adder_;
+  std::unique_ptr<Integrator<T>> integrator_;
+  std::unique_ptr<PassThrough<T>> pass_through_;
+  std::unique_ptr<Gain<T>> proportional_gain_;
+  std::unique_ptr<Gain<T>> integral_gain_;
+  std::unique_ptr<Gain<T>> derivative_gain_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/test/CMakeLists.txt
+++ b/drake/systems/framework/primitives/test/CMakeLists.txt
@@ -27,3 +27,8 @@ add_test(NAME constant_vector_source_test COMMAND constant_vector_source_test)
 add_executable(gain_test gain_test.cc gain_scalartype_test.cc)
 target_link_libraries(gain_test drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
 add_test(NAME gain_test COMMAND gain_test)
+
+add_executable(pid_controller_test pid_controller_test.cc)
+target_link_libraries(pid_controller_test drakeSystemFramework
+        ${GTEST_BOTH_LIBRARIES})
+add_test(NAME pid_controller_test COMMAND pid_controller_test)

--- a/drake/systems/framework/primitives/test/pid_controller_test.cc
+++ b/drake/systems/framework/primitives/test/pid_controller_test.cc
@@ -1,0 +1,111 @@
+#include "drake/systems/framework/primitives/pid_controller.h"
+
+#include <memory>
+
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/system_input.h"
+
+#include "gtest/gtest.h"
+
+using std::make_unique;
+
+namespace drake {
+namespace systems {
+namespace {
+
+typedef Eigen::Matrix<double, 3, 1, Eigen::DontAlign> Vector3d;
+
+// TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
+// the input of the Gain system.
+template <class T>
+std::unique_ptr<FreestandingInputPort> MakeInput(
+    std::unique_ptr<BasicVector<T>> data) {
+  return make_unique<FreestandingInputPort>(std::move(data));
+}
+
+class PidControllerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    context_ = controller_.CreateDefaultContext();
+    output_ = controller_.AllocateOutput(*context_);
+    derivatives_ = controller_.AllocateTimeDerivatives();
+
+    // Error signal input port.
+    auto vec0 = std::make_unique<BasicVector<double>>(port_length_);
+    vec0->get_mutable_value() << error_signal_;
+    context_->SetInputPort(0, MakeInput(std::move(vec0)));
+
+    // Error signal rate input port.
+    auto vec1 = std::make_unique<BasicVector<double>>(port_length_);
+    vec1->get_mutable_value() << error_rate_signal_;
+    context_->SetInputPort(1, MakeInput(std::move(vec1)));
+  }
+
+  const double kp_{2.0};
+  const double ki_{3.0};
+  const double kd_{1.0};
+  const int port_length_{3};
+  PidController<double> controller_{kp_, ki_, kd_, port_length_};
+  std::unique_ptr<ContextBase<double>> context_;
+  std::unique_ptr<SystemOutput<double>> output_;
+  std::unique_ptr<ContinuousState<double>> derivatives_;
+  Vector3d error_signal_{1.0, 2.0, 3.0};
+  Vector3d error_rate_signal_{1.3, 0.9, 3.14};
+};
+
+// Tests getter methods for controller constants.
+TEST_F(PidControllerTest, Getters) {
+  ASSERT_EQ(kp_, controller_.get_Kp());
+  ASSERT_EQ(ki_, controller_.get_Ki());
+  ASSERT_EQ(kd_, controller_.get_Kd());
+}
+
+// Evaluates the output and asserts correctness.
+TEST_F(PidControllerTest, EvalOutput) {
+  ASSERT_NE(nullptr, context_);
+  ASSERT_NE(nullptr, output_);
+
+  // Initializes the controllers' context to the default value in which the
+  // integral is zero and evaluates the output.
+  controller_.SetDefaultState(context_.get());
+  controller_.EvalOutput(*context_, output_.get());
+  ASSERT_EQ(1, output_->get_num_ports());
+  const VectorBase<double>* output_vector = output_->get_vector_data(0);
+  EXPECT_EQ(3, output_vector->get_value().rows());
+  EXPECT_EQ(kp_ * error_signal_ + kd_ * error_rate_signal_,
+            output_vector->get_value());
+
+  // Initializes the integral to a non-zero value. A more interesting example.
+  VectorX<double> integral_value(port_length_);
+  integral_value << 3.0, 2.0, 1.0;
+  controller_.set_integral_value(context_.get(), integral_value);
+  controller_.EvalOutput(*context_, output_.get());
+  EXPECT_EQ(
+      kp_ * error_signal_ + ki_ * integral_value + kd_ * error_rate_signal_,
+      output_vector->get_value());
+}
+
+// Evaluates derivatives and asserts correctness.
+TEST_F(PidControllerTest, EvalTimeDerivatives) {
+  ASSERT_NE(nullptr, context_);
+  ASSERT_NE(nullptr, derivatives_);
+
+  // Initializes the controllers' context to the default value in which the
+  // integral is zero and evaluates the derivatives.
+  controller_.SetDefaultState(context_.get());
+
+  controller_.EvalTimeDerivatives(*context_, derivatives_.get());
+  ASSERT_EQ(3, derivatives_->get_state().size());
+  ASSERT_EQ(0, derivatives_->get_generalized_position().size());
+  ASSERT_EQ(0, derivatives_->get_generalized_velocity().size());
+  ASSERT_EQ(3, derivatives_->get_misc_continuous_state().size());
+
+  // The only state in the PID controller_ is the integral of the input signal.
+  // Therefore the time derivative of the state equals the input error signal.
+  EXPECT_EQ(error_signal_, derivatives_->get_state().CopyToVector());
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This PR closes #3215. It implements a PID controller by composing smaller primitives into a Diagram.

cc'ing @naveenoid because you were interested on this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3275)
<!-- Reviewable:end -->
