### PR TITLE
Implements Demultiplexer system

### DIFF
--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -14,6 +14,7 @@ set(sources
   primitives/adder.cc
   primitives/constant_value_source.cc
   primitives/constant_vector_source.cc
+  primitives/demultiplexer.cc
   primitives/gain.cc
   primitives/integrator.cc
   primitives/pass_through.cc

--- a/drake/systems/framework/primitives/CMakeLists.txt
+++ b/drake/systems/framework/primitives/CMakeLists.txt
@@ -6,6 +6,7 @@ drake_install_headers(
   constant_value_source.h
   constant_value_source-inl.h
   constant_vector_source.h
+  demultiplexer.h
   gain.h
   gain-inl.h
   integrator.h

--- a/drake/systems/framework/primitives/demultiplexer.cc
+++ b/drake/systems/framework/primitives/demultiplexer.cc
@@ -1,0 +1,34 @@
+#include "drake/systems/framework/primitives/demultiplexer.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+Demultiplexer<T>::Demultiplexer(int length) {
+  // TODO(amcastro-tri): remove the length parameter from the constructor once
+  // #3109 supporting automatic lengths is resolved.
+  this->DeclareInputPort(kVectorValued, length, kInheritedSampling);
+  // TODO(david-german-tri): Provide a way to infer the type.
+  for (int i = 0; i < length; ++i) {
+    this->DeclareOutputPort(kVectorValued, 1, kInheritedSampling);
+  }
+}
+
+template <typename T>
+void Demultiplexer<T>::EvalOutput(const ContextBase<T>& context,
+                                  SystemOutput<T>* output) const {
+  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
+  // TODO(amcastro-tri): the output should simply reference the input port's
+  // value to avoid copy.
+  auto in_vector = System<T>::get_input_vector(context, 0);
+  for (int iport = 0; iport < this->get_num_output_ports(); ++iport) {
+    auto out_vector = System<T>::GetMutableOutputVector(output, iport);
+    out_vector[0] = in_vector[iport];
+  }
+}
+
+template class DRAKESYSTEMFRAMEWORK_EXPORT Demultiplexer<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/demultiplexer.h
+++ b/drake/systems/framework/primitives/demultiplexer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/// This system splits a vector valued signal in its inputs of size `length`
+/// into `length` output scalar valued signals.
+/// The input to this system directly feeds through to its output.
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+template <typename T>
+class Demultiplexer : public LeafSystem<T> {
+ public:
+  /// Constructs %Demultiplexer with one vector valued input port of size
+  /// @p length and @p length scalar valued output ports.
+  /// @param length is the size of the input signal to be demultiplexed into its
+  /// individual components.
+  explicit Demultiplexer(int length);
+
+  /// Sets the i-th output port to the value of the i-th component of the input
+  /// port.
+  void EvalOutput(const ContextBase<T>& context,
+                  SystemOutput<T>* output) const override;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/test/CMakeLists.txt
+++ b/drake/systems/framework/primitives/test/CMakeLists.txt
@@ -32,3 +32,7 @@ add_executable(pid_controller_test pid_controller_test.cc)
 target_link_libraries(pid_controller_test drakeSystemFramework
         ${GTEST_BOTH_LIBRARIES})
 add_test(NAME pid_controller_test COMMAND pid_controller_test)
+
+add_executable(demultiplexer_test demultiplexer_test.cc)
+target_link_libraries(demultiplexer_test drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
+add_test(NAME demultiplexer_test COMMAND demultiplexer_test)

--- a/drake/systems/framework/primitives/test/demultiplexer_test.cc
+++ b/drake/systems/framework/primitives/test/demultiplexer_test.cc
@@ -1,0 +1,82 @@
+#include "drake/systems/framework/primitives/demultiplexer.h"
+
+#include <memory>
+
+#include <unsupported/Eigen/AutoDiff>
+
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/system_input.h"
+
+#include "gtest/gtest.h"
+
+using Eigen::AutoDiffScalar;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using std::make_unique;
+
+namespace drake {
+namespace systems {
+namespace {
+
+// TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
+// the input of the Demultiplexer system.
+template<class T>
+std::unique_ptr<FreestandingInputPort> MakeInput(
+    std::unique_ptr<BasicVector<T>> data) {
+  return make_unique<FreestandingInputPort>(std::move(data));
+}
+
+class DemultiplexerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    demux_ = make_unique<Demultiplexer<double>>(3 /* length */);
+    context_ = demux_->CreateDefaultContext();
+    output_ = demux_->AllocateOutput(*context_);
+    input_ = make_unique<BasicVector<double>>(3 /* length */);
+  }
+
+  std::unique_ptr<System<double>> demux_;
+  std::unique_ptr<ContextBase<double>> context_;
+  std::unique_ptr<SystemOutput<double>> output_;
+  std::unique_ptr<BasicVector<double>> input_;
+};
+
+// Tests that the input signal gets demultiplexed into its individual
+// components.
+TEST_F(DemultiplexerTest, DemultiplexVector) {
+  /// Checks that the number of input ports in the system and in the context
+  // are consistent.
+  ASSERT_EQ(1, context_->get_num_input_ports());
+  ASSERT_EQ(1, demux_->get_num_input_ports());
+  Eigen::Vector3d input_vector(1.0, 3.14, 2.18);
+  input_->get_mutable_value() << input_vector;
+
+  // Hook input of the expected size.
+  context_->SetInputPort(0, MakeInput(std::move(input_)));
+
+  demux_->EvalOutput(*context_, output_.get());
+
+  // Checks that the number of output ports in the system and in the
+  // output are consistent.
+  // The number of output ports must match the size of the input vector.
+  ASSERT_EQ(input_vector.size(), output_->get_num_ports());
+  ASSERT_EQ(input_vector.size(), demux_->get_num_output_ports());
+
+  ASSERT_EQ(1, output_->get_vector_data(0)->size());
+  ASSERT_EQ(input_vector[0], output_->get_vector_data(0)->get_value()[0]);
+
+  ASSERT_EQ(1, output_->get_vector_data(1)->size());
+  ASSERT_EQ(input_vector[1], output_->get_vector_data(1)->get_value()[0]);
+
+  ASSERT_EQ(1, output_->get_vector_data(2)->size());
+  ASSERT_EQ(input_vector[2], output_->get_vector_data(2)->get_value()[0]);
+}
+
+// Tests that Demultiplexer allocates no state variables in the context_.
+TEST_F(DemultiplexerTest, DemultiplexerIsStateless) {
+  EXPECT_EQ(nullptr, context_->get_state().continuous_state);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This PR implements a system that takes a vector valued input signal of size "length" and splits it into "length" output signals of size "1".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3279)
<!-- Reviewable:end -->
