### PR TITLE
Fix a bug that prevented the insertion of Diagrams into Diagrams.

### DIFF
--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -139,23 +139,22 @@ class DiagramContext : public ContextBase<T> {
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
   void Connect(const PortIdentifier& src, const PortIdentifier& dest) {
-    // Validate and identify the source port.
+    // Identify and validate the source port.
     SystemIndex src_system_index = src.first;
     PortIndex src_port_index = src.second;
     SystemOutput<T>* src_ports = outputs_[src_system_index].get();
-    if (src_port_index < 0 || src_port_index >= src_ports->get_num_ports()) {
-      throw std::out_of_range("Source port out of range.");
-    }
+    DRAKE_ABORT_UNLESS(src_port_index >= 0);
+    DRAKE_ABORT_UNLESS(src_port_index < src_ports->get_num_ports());
     OutputPort* output_port = src_ports->get_mutable_port(src_port_index);
 
-    // Validate, construct, and install the destination port.
+    // Identify and validate the destination port.
     SystemIndex dest_system_index = dest.first;
     PortIndex dest_port_index = dest.second;
     ContextBase<T>* dest_context = contexts_[dest_system_index].get();
-    if (dest_port_index < 0 ||
-        dest_port_index >= dest_context->get_num_input_ports()) {
-      throw std::out_of_range("Destination port out of range.");
-    }
+    DRAKE_ABORT_UNLESS(dest_port_index >= 0);
+    DRAKE_ABORT_UNLESS(dest_port_index < dest_context->get_num_input_ports());
+
+    // Construct and install the destination port.
     auto input_port = std::make_unique<DependentInputPort>(output_port);
     dest_context->SetInputPort(dest_port_index, std::move(input_port));
 
@@ -197,18 +196,14 @@ class DiagramContext : public ContextBase<T> {
     return (*it).second.get();
   }
 
-  /// Returns the state structure for a given constituent system @p sys, or
-  /// nullptr if @p sys is not a constituent system. Invalidates all entries in
-  /// that subsystem's cache that depend on State.
-  ///
-  /// TODO(david-german-tri): Provide finer-grained accessors for finer-grained
-  /// invalidation.
-  State<T>* GetMutableSubsystemState(SystemIndex sys) {
+  /// Returns the context structure for a given subsystem @p sys, or
+  /// nullptr if @p sys is not a subsystem.
+  ContextBase<T>* GetMutableSubsystemContext(SystemIndex sys) {
     auto it = contexts_.find(sys);
     if (it == contexts_.end()) {
       return nullptr;
     }
-    return (*it).second->get_mutable_state();
+    return (*it).second.get();
   }
 
   int get_num_input_ports() const override { return input_ids_.size(); }

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -69,6 +69,7 @@ class DRAKESYSTEMFRAMEWORK_EXPORT DependentInputPort : public InputPort {
   /// must not be nullptr. The output port must outlive this input port.
   explicit DependentInputPort(OutputPort* output_port)
       : output_port_(output_port) {
+    DRAKE_ABORT_UNLESS(output_port_ != nullptr);
     output_port_->add_dependent(this);
   }
 

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -196,10 +196,12 @@ struct LeafSystemOutput : public SystemOutput<T> {
   int get_num_ports() const override { return static_cast<int>(ports_.size()); }
 
   OutputPort* get_mutable_port(int index) override {
+    DRAKE_ABORT_UNLESS(index >= 0 && index < get_num_ports());
     return ports_[index].get();
   }
 
   const OutputPort& get_port(int index) const override {
+    DRAKE_ABORT_UNLESS(index >= 0 && index < get_num_ports());
     return *ports_[index];
   }
 

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -116,22 +116,6 @@ TEST_F(DiagramContextTest, ConnectValid) {
                                     {1 /* adder1_ */, 1 /* port 1 */}));
 }
 
-// Tests that an exception is thrown when connecting from a source port that
-// does not exist.
-TEST_F(DiagramContextTest, ConnectInvalidSrcPort) {
-  EXPECT_THROW(context_->Connect({0 /* adder0_ */, 1 /* port 1 */},
-                                 {1 /* adder1_ */, 1 /* port 1 */}),
-               std::out_of_range);
-}
-
-// Tests that an exception is thrown when connecting to a destination port that
-// does not exist.
-TEST_F(DiagramContextTest, ConnectInvalidDestPort) {
-  EXPECT_THROW(context_->Connect({0 /* adder0_ */, 0 /* port 0 */},
-                                 {1 /* adder1_ */, 2 /* port 2 */}),
-               std::out_of_range);
-}
-
 // Tests that input ports can be assigned to the DiagramContext and then
 // retrieved.
 TEST_F(DiagramContextTest, SetAndGetInputPorts) {


### PR DESCRIPTION
Specifically, ensure that subsystem outputs are exposed in the DiagramOutput immediately after output allocation.  This allows other systems that depend on the outputs of the diagrams to register invalidation handlers on those output ports, instead of trying to dereference `nullptr` and segfaulting.

Sprinkle some invariant checks into Diagram connection that would have provided better diagnostics for this bug.  Add a reproducing test case.

+@amcastro-tri for feature review.  This should fix the segfault you were observing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3284)
<!-- Reviewable:end -->
