### PR TITLE
Refactor LCM translator to always use byte arrays

### DIFF
--- a/drake/systems/lcm/lcm_and_vector_base_translator.h
+++ b/drake/systems/lcm/lcm_and_vector_base_translator.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <lcm/lcm-cpp.hpp>
+#include <cstdint>
+#include <vector>
 
 #include "drake/drakeLCMSystem2_export.h"
 #include "drake/systems/framework/vector_base.h"
@@ -11,7 +12,7 @@ namespace lcm {
 
 /**
  * Defines an abstract parent class of all translators that convert between
- * LCM message objects and `drake::systems::VectorBase` objects.
+ * LCM message bytes and `drake::systems::VectorBase` objects.
  */
 class LcmAndVectorBaseTranslator {
  public:
@@ -38,9 +39,13 @@ class LcmAndVectorBaseTranslator {
   }
 
   /**
-   * Translates an LCM message into a `drake::systems::VectorBase` object.
+   * Translates LCM message bytes into a `drake::systems::VectorBase` object.
    *
-   * @param[in] rbuf A pointer to a buffer holding the LCM message's data.
+   * @param[in] lcm_message_bytes A pointer to a buffer holding the LCM
+   * message's data.
+   *
+   * @param[in] lcm_message_length The number of bytes pointed to by
+   * the @p lcm_message_bytes.
    *
    * @param[out] vector_base A pointer to where the translation of the LCM
    * message should be stored. This pointer must not be `nullptr`.
@@ -50,25 +55,21 @@ class LcmAndVectorBaseTranslator {
    * This often occurs when the size of the @p vector_base does not equal
    * or is incompatible with the size of the decoded LCM message.
    */
-  virtual void TranslateLcmToVectorBase(const ::lcm::ReceiveBuffer* rbuf,
-    VectorBase<double>* vector_base) const = 0;
+  virtual void TranslateLcmToVectorBase(
+      const void* lcm_message_bytes, int lcm_message_length,
+      VectorBase<double>* vector_base) const = 0;
 
   /**
-   * Translates a `drake::systems::VectorBase` object into an LCM message
-   * and publishes it on the specified LCM channel.
+   * Translates a `drake::systems::VectorBase` object into LCM message bytes.
    *
-   * @param[in] vector_base A reference to the object to convert into an
-   * LCM message.
+   * @param[in] vector_base The object to convert into an LCM message.
    *
-   * @param[in] channel The name of the channel on which to publish the LCM
-   * message.
-   *
-   * @param[in] lcm A pointer to the LCM subsystem. This pointer must not be
-   * `nullptr`.
+   * @param[out] lcm_message_bytes The LCM message bytes.
+   * This pointer must not be `nullptr`.
    */
-  virtual void PublishVectorBaseToLCM(
+  virtual void TranslateVectorBaseToLcm(
       const VectorBase<double>& vector_base,
-      const std::string& channel, ::lcm::LCM* lcm) const = 0;
+      std::vector<uint8_t>* lcm_message_bytes) const = 0;
 
  private:
   // The size of the vector in the VectorBase.

--- a/drake/systems/lcm/lcm_publisher_system.cc
+++ b/drake/systems/lcm/lcm_publisher_system.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/lcm/lcm_publisher_system.h"
 
+#include <cstdint>
+#include <vector>
+
 #include "drake/systems/framework/system_input.h"
 
 namespace drake {
@@ -34,12 +37,15 @@ std::string LcmPublisherSystem::get_name() const {
 
 void LcmPublisherSystem::DoPublish(const ContextBase<double>& context) const {
   // Obtains the input vector.
-  const VectorBase<double>* input_vector =
+  const VectorBase<double>* const input_vector =
       context.get_vector_input(kPortIndex);
 
-  // Translates the input vector into an LCM message and publishes it onto the
-  // specified LCM channel.
-  translator_.PublishVectorBaseToLCM(*input_vector, channel_, lcm_);
+  // Translates the input vector into LCM message bytes.
+  std::vector<uint8_t> lcm_message;
+  translator_.TranslateVectorBaseToLcm(*input_vector, &lcm_message);
+
+  // Publishes onto the specified LCM channel.
+  lcm_->publish(channel_, lcm_message.data(), lcm_message.size());
 }
 
 }  // namespace lcm

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -52,7 +52,8 @@ void LcmSubscriberSystem::HandleMessage(const ::lcm::ReceiveBuffer* rbuf,
                                         const std::string& channel) {
   if (channel == channel_) {
     std::lock_guard<std::mutex> lock(data_mutex_);
-    translator_.TranslateLcmToVectorBase(rbuf, &basic_vector_);
+    translator_.TranslateLcmToVectorBase(
+        rbuf->data, rbuf->data_size, &basic_vector_);
   } else {
     std::cerr << "LcmSubscriberSystem: HandleMessage: WARNING: Received a "
               << "message for channel \"" << channel

--- a/drake/systems/lcm/translator_between_lcmt_drake_signal.h
+++ b/drake/systems/lcm/translator_between_lcmt_drake_signal.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <lcm/lcm-cpp.hpp>
+#include <cstdint>
+#include <vector>
 
 #include "drake/drakeLCMSystem2_export.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
@@ -31,12 +32,12 @@ class DRAKELCMSYSTEM2_EXPORT TranslatorBetweenLcmtDrakeSignal
       : LcmAndVectorBaseTranslator(size) {}
 
   void TranslateLcmToVectorBase(
-      const ::lcm::ReceiveBuffer* rbuf,
+      const void* lcm_message_bytes, int lcm_message_length,
       VectorBase<double>* vector_base) const override;
 
-  void PublishVectorBaseToLCM(
+  void TranslateVectorBaseToLcm(
       const VectorBase<double>& vector_base,
-          const std::string& channel, ::lcm::LCM* lcm) const override;
+      std::vector<uint8_t>* lcm_message_bytes) const override;
 };
 
 }  // namespace lcm


### PR DESCRIPTION
The main purpose is to enable unit testing without a whole `lcm::LCM` instance, in the pending #3268.

An example translator unit test isn't shown in this PR, because the one translator here is used in an acceptance test for the publisher and subscriber systems, so doesn't need a separate unit test.  All other future translators can be tested standalone, though.

A secondary purpose would be to enable LCM System blocks that simulate the network -- the same translators just produce a byte array, and then we can have a block that "sends" it over the simulated network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3285)
<!-- Reviewable:end -->
