### PR TITLE
Removed two unneeded #includes from parser.sdf.

### DIFF
--- a/drake/systems/plants/parser_sdf.h
+++ b/drake/systems/plants/parser_sdf.h
@@ -7,8 +7,6 @@
 #include "drake/systems/plants/parser_model_instance_id_table.h"
 #include "drake/systems/plants/RigidBodyFrame.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "drake/systems/plants/xmlUtil.h"
-#include "drake/thirdParty/zlib/tinyxml2/tinyxml2.h"
 
 namespace drake {
 namespace parsers {


### PR DESCRIPTION
This resolves the following build error when a downstream dependency tries to `#include "drake/systems/plants/parser_sdf.h"`.

```
/home/liang/dev/drake_catkin_workspace/install/include/drake/systems/plants/xmlUtil.h:7:21: fatal error: spruce.hh: No such file or directory
 #include "spruce.hh"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3297)
<!-- Reviewable:end -->
