### PR TITLE
Allow System2 LCM translators to specify output vector subclasses

### DIFF
--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -71,7 +71,8 @@ class LeafSystem : public System<T> {
 
   /// Given a port descriptor, allocate the vector storage.  The default
   /// implementation in this class allocates a BasicVector.  Subclasses can
-  /// override to use output vector types other than BasicVector.
+  /// override to use output vector types other than BasicVector.  The
+  /// descriptor must match a port declared via DeclareOutputPort.
   virtual std::unique_ptr<VectorBase<T>> AllocateOutputVector(
       const SystemPortDescriptor<T>& descriptor) const {
     return std::unique_ptr<VectorBase<T>>(

--- a/drake/systems/lcm/CMakeLists.txt
+++ b/drake/systems/lcm/CMakeLists.txt
@@ -1,7 +1,8 @@
 if(lcm_FOUND)
   add_library_with_exports(LIB_NAME drakeLCMSystem2 SOURCE_FILES
-    lcm_receive_thread.cc
+    lcm_and_vector_base_translator.cc
     lcm_publisher_system.cc
+    lcm_receive_thread.cc
     lcm_subscriber_system.cc
     lcm_translator_dictionary.cc
     translator_between_lcmt_drake_signal.cc)

--- a/drake/systems/lcm/lcm_and_vector_base_translator.cc
+++ b/drake/systems/lcm/lcm_and_vector_base_translator.cc
@@ -1,0 +1,18 @@
+#include "drake/systems/lcm/lcm_and_vector_base_translator.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+
+LcmAndVectorBaseTranslator::LcmAndVectorBaseTranslator(int size)
+    : size_(size) {}
+
+LcmAndVectorBaseTranslator::~LcmAndVectorBaseTranslator() {}
+
+int LcmAndVectorBaseTranslator::get_vector_size() const {
+  return size_;
+}
+
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/lcm/lcm_and_vector_base_translator.cc
+++ b/drake/systems/lcm/lcm_and_vector_base_translator.cc
@@ -13,6 +13,11 @@ int LcmAndVectorBaseTranslator::get_vector_size() const {
   return size_;
 }
 
+std::unique_ptr<VectorBase<double>>
+LcmAndVectorBaseTranslator::AllocateOutputVector() const {
+  return nullptr;
+}
+
 }  // namespace lcm
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/lcm/lcm_and_vector_base_translator.h
+++ b/drake/systems/lcm/lcm_and_vector_base_translator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "drake/drakeLCMSystem2_export.h"
@@ -29,6 +30,17 @@ class DRAKELCMSYSTEM2_EXPORT LcmAndVectorBaseTranslator {
    * object.
    */
   int get_vector_size() const;
+
+  /**
+   * Allocates the vector storage for an output port of our LCM message type,
+   * in case special storage is needed.  A result of nullptr indicates that no
+   * special vector is needed; the calling code can and should use a default
+   * vector implementation such as BasicVector.
+   *
+   * The default implementation in this class returns nullptr.  Subclasses that
+   * require custom VectorBase subtypes should override it.
+   */
+  virtual std::unique_ptr<VectorBase<double>> AllocateOutputVector() const;
 
   /**
    * Translates LCM message bytes into a `drake::systems::VectorBase` object.

--- a/drake/systems/lcm/lcm_and_vector_base_translator.h
+++ b/drake/systems/lcm/lcm_and_vector_base_translator.h
@@ -14,29 +14,21 @@ namespace lcm {
  * Defines an abstract parent class of all translators that convert between
  * LCM message bytes and `drake::systems::VectorBase` objects.
  */
-class LcmAndVectorBaseTranslator {
+class DRAKELCMSYSTEM2_EXPORT LcmAndVectorBaseTranslator {
  public:
   /**
    * The constructor.
    *
    * @param[in] size The size of the vector in the `VectorBase`.
    */
-  explicit LcmAndVectorBaseTranslator(int size) : size_(size) {
-  }
-
-  // Disable copy and assign.
-  LcmAndVectorBaseTranslator(const LcmAndVectorBaseTranslator&) =
-      delete;
-  LcmAndVectorBaseTranslator& operator=(
-      const LcmAndVectorBaseTranslator&) = delete;
+  explicit LcmAndVectorBaseTranslator(int size);
+  virtual ~LcmAndVectorBaseTranslator();
 
   /**
    * Returns the size of the vector in the `drake::systems::VectorBase`
    * object.
    */
-  int get_vector_size() const {
-    return size_;
-  }
+  int get_vector_size() const;
 
   /**
    * Translates LCM message bytes into a `drake::systems::VectorBase` object.
@@ -74,6 +66,12 @@ class LcmAndVectorBaseTranslator {
  private:
   // The size of the vector in the VectorBase.
   const int size_;
+
+  // Disable copy and assign.
+  LcmAndVectorBaseTranslator(const LcmAndVectorBaseTranslator&) =
+      delete;
+  LcmAndVectorBaseTranslator& operator=(
+      const LcmAndVectorBaseTranslator&) = delete;
 };
 
 }  // namespace lcm

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -63,6 +63,24 @@ class DRAKELCMSYSTEM2_EXPORT LcmSubscriberSystem : public LeafSystem<double> {
   void EvalOutput(const ContextBase<double>& context,
                   SystemOutput<double>* output) const override;
 
+  /**
+   * Sets the `message_bytes` that will provide the value for `EvalOutput`;
+   * typically only used for unit testing.
+   *
+   * This class's constructors subscribe to an `LCM` channel that provides the
+   * values for `EvalOutput`.  However, if `LCM` is not providing any message
+   * data (e.g., in a unit test, or if the channel is not being published
+   * during a simulation), this method can be used to provide a value.
+   *
+   * When both `LCM` and `SetMessage` are updating the output value, the most
+   * recent update wins.
+   */
+  void SetMessage(std::vector<uint8_t> message_bytes);
+
+ protected:
+  std::unique_ptr<VectorBase<double>> AllocateOutputVector(
+      const SystemPortDescriptor<double>& descriptor) const override;
+
  private:
   // Callback entry point from LCM into this class.
   void HandleMessage(const ::lcm::ReceiveBuffer* rbuf,
@@ -75,14 +93,11 @@ class DRAKELCMSYSTEM2_EXPORT LcmSubscriberSystem : public LeafSystem<double> {
   // drake::systems::VectorBase objects.
   const LcmAndVectorBaseTranslator& translator_;
 
-  // A mutex for protecting data that's shared by the LCM receive thread and
-  // the thread that calls LcmSubscriberSystem::Output().
-  mutable std::mutex data_mutex_;
+  // The mutex that guards received_message_.
+  mutable std::mutex received_message_mutex_;
 
-  // Holds the information contained with the latest LCM message. This
-  // information is copied into this system's output port when Output(...) is
-  // called.
-  BasicVector<double> basic_vector_;
+  // The bytes of the most recently received LCM message.
+  std::vector<uint8_t> received_message_;
 
   // Disable copy and assign.
   LcmSubscriberSystem(const LcmSubscriberSystem&) = delete;

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -58,23 +58,13 @@ class DRAKELCMSYSTEM2_EXPORT LcmSubscriberSystem : public LeafSystem<double> {
 
   ~LcmSubscriberSystem() override;
 
-  // Disable copy and assign.
-  LcmSubscriberSystem(const LcmSubscriberSystem&) = delete;
-  LcmSubscriberSystem& operator=(const LcmSubscriberSystem&) = delete;
-
   std::string get_name() const override;
 
-  /**
-   * Computes the output for the given context, possibly updating values
-   * in the cache. Note that the context is ignored since it contains no
-   * information.
-   */
   void EvalOutput(const ContextBase<double>& context,
                   SystemOutput<double>* output) const override;
 
  private:
-  // Translates the message contained within the receive buffer by storing its
-  // information in basic_vector_.
+  // Callback entry point from LCM into this class.
   void HandleMessage(const ::lcm::ReceiveBuffer* rbuf,
                      const std::string& channel);
 
@@ -93,6 +83,10 @@ class DRAKELCMSYSTEM2_EXPORT LcmSubscriberSystem : public LeafSystem<double> {
   // information is copied into this system's output port when Output(...) is
   // called.
   BasicVector<double> basic_vector_;
+
+  // Disable copy and assign.
+  LcmSubscriberSystem(const LcmSubscriberSystem&) = delete;
+  LcmSubscriberSystem& operator=(const LcmSubscriberSystem&) = delete;
 };
 
 }  // namespace lcm

--- a/drake/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/drake/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -1,9 +1,11 @@
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <thread>
 
 #include "gtest/gtest.h"
 
+#include "drake/systems/framework/basic_state_and_output_vector.h"
 #include "drake/systems/lcm/lcm_receive_thread.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/lcm/translator_between_lcmt_drake_signal.h"
@@ -201,6 +203,108 @@ GTEST_TEST(LcmSubscriberSystemTest, ReceiveTestUsingDictionary) {
   LcmSubscriberSystem dut(channel_name, dictionary, &lcm);
 
   TestSubscriber(&lcm, channel_name, &dut);
+}
+
+// A lcmt_drake_signal translator that preserves coordinate names.
+class CustomDrakeSignalTranslator : public LcmAndVectorBaseTranslator {
+ public:
+  // An output vector type that tests that subscribers permit non-default
+  // types.
+  class CustomVector : public BasicStateAndOutputVector<double> {
+   public:
+    CustomVector() : BasicStateAndOutputVector<double>(kDim) {}
+    void SetName(int index, std::string name) { names_.at(index) = name; }
+    std::string GetName(int index) const { return names_.at(index); }
+   private:
+    std::array<std::string, kDim> names_;
+  };
+
+  CustomDrakeSignalTranslator() : LcmAndVectorBaseTranslator(kDim) {}
+
+  std::unique_ptr<VectorBase<double>> AllocateOutputVector() const override {
+    return std::make_unique<CustomVector>();
+  }
+
+  void TranslateLcmToVectorBase(
+      const void* lcm_message_bytes, int lcm_message_length,
+      VectorBase<double>* vector_base) const override {
+    CustomVector* const custom_vector =
+        dynamic_cast<CustomVector*>(vector_base);
+    ASSERT_NE(nullptr, custom_vector);
+
+    // Decode the LCM message.
+    drake::lcmt_drake_signal message;
+    int status = message.decode(lcm_message_bytes, 0, lcm_message_length);
+    ASSERT_GE(status, 0);
+    ASSERT_EQ(kDim, message.dim);
+
+    // Copy message into our custom_vector.
+    for (int i = 0; i < kDim; ++i) {
+      custom_vector->SetAtIndex(i, message.val[i]);
+      custom_vector->SetName(i, message.coord[i]);
+    }
+  }
+
+  void TranslateVectorBaseToLcm(
+      const VectorBase<double>& vector_base,
+      std::vector<uint8_t>* lcm_message_bytes) const override {
+    const CustomVector* const custom_vector =
+        dynamic_cast<const CustomVector*>(&vector_base);
+    ASSERT_NE(nullptr, custom_vector);
+    ASSERT_NE(nullptr, lcm_message_bytes);
+
+    // Copy custom_vector into the message.
+    drake::lcmt_drake_signal message;
+    message.dim = kDim;
+    message.val.resize(kDim);
+    message.coord.resize(kDim);
+    for (int i = 0; i < kDim; ++i) {
+      message.val.at(i) = custom_vector->GetAtIndex(i);
+      message.coord.at(i) = custom_vector->GetName(i);
+    }
+
+    // Encode the LCM message.
+    const int lcm_message_length = message.getEncodedSize();
+    lcm_message_bytes->resize(lcm_message_length);
+    message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
+  }
+};
+
+// Subscribe and output a custom VectorBase type.
+GTEST_TEST(LcmSubscriberSystemTest, CustomVectorBaseTest) {
+  // The "device under test" and its prerequisites.
+  CustomDrakeSignalTranslator translator;
+  ::lcm::LCM lcm;
+  LcmSubscriberSystem dut("dummy", translator, &lcm);
+
+  // Create a data-filled vector.
+  typedef CustomDrakeSignalTranslator::CustomVector CustomVector;
+  CustomVector sample_vector;
+  for (int i = 0; i < kDim; ++i) {
+    sample_vector.SetAtIndex(i, i);
+    sample_vector.SetName(i, std::to_string(i) + "_name");
+  }
+
+  // Force a message into the dut.
+  std::vector<uint8_t> message_bytes;
+  translator.TranslateVectorBaseToLcm(sample_vector, &message_bytes);
+  dut.SetMessage(message_bytes);
+
+  // Read back the vector via EvalOutput.
+  auto context = dut.CreateDefaultContext();
+  auto output = dut.AllocateOutput(*context);
+  dut.EvalOutput(*context, output.get());
+  const VectorBase<double>* const output_vector = output->get_vector_data(0);
+  ASSERT_NE(nullptr, output_vector);
+
+  // Check that the sample values match.
+  const CustomVector* const custom_output =
+      dynamic_cast<const CustomVector*>(output_vector);
+  ASSERT_NE(nullptr, custom_output);
+  for (int i = 0; i < kDim; ++i) {
+    EXPECT_EQ(sample_vector.GetAtIndex(i), custom_output->GetAtIndex(i));
+    EXPECT_EQ(sample_vector.GetName(i), custom_output->GetName(i));
+  }
 }
 
 }  // namespace

--- a/drake/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/drake/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -34,6 +34,17 @@ class MessagePublisher {
     message_.timestamp = kTimestamp;
   }
 
+  ~MessagePublisher() {
+    EXPECT_TRUE(stop_);
+    // Test cases are required to call Stop() before completing, but sometimes
+    // fail to do so (e.g., if the test case raised an unexpected exception).
+    // If that happens, we need to join the thread here, or else its destructor
+    // will fail and confuse the gtest reporting of the earlier failures.
+    if (!stop_) {
+      Stop();
+    }
+  }
+
   void Start() {
     thread_.reset(new std::thread(&MessagePublisher::DoPublish, this));
   }


### PR DESCRIPTION
In a future PR, this will be used by the `Cars` vector classes, so that LCM message inputs such as `DrivingCommand` can be used by `SimpleCar` using `get_steering_angle` instead of `GetAtIndex(0)`.

See commit history for details of the edits.  In particular, the first two commits are functionality-neutral.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3301)
<!-- Reviewable:end -->
