### PR TITLE
Removes #include "spruce.hh" from an installed header file since spruce.hh is not actually installed.

### DIFF
--- a/drake/systems/plants/xmlUtil.cpp
+++ b/drake/systems/plants/xmlUtil.cpp
@@ -1,13 +1,16 @@
+#include "drake/systems/plants/xmlUtil.h"
+
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 
+#include "spruce.hh"
+
 #include "drake/common/drake_path.h"
 #include "drake/common/drake_assert.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/thirdParty/bsd/tinydir/tinydir.h"
-#include "xmlUtil.h"
 
 using namespace std;
 using namespace Eigen;

--- a/drake/systems/plants/xmlUtil.h
+++ b/drake/systems/plants/xmlUtil.h
@@ -4,7 +4,6 @@
 #include <string>
 
 #include <Eigen/Dense>
-#include "spruce.hh"
 
 #include "drake/drakeXMLUtil_export.h"
 #include "drake/systems/plants/pose_map.h"


### PR DESCRIPTION
This builds upon #3297.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3303)
<!-- Reviewable:end -->
