### PR TITLE
Jacobian/Hessian AutoDiff utility functions

### DIFF
--- a/drake/math/autodiff.h
+++ b/drake/math/autodiff.h
@@ -377,7 +377,7 @@ decltype(auto) jacobian(F &&f, Arg &&x) {
    called on @p f.
 
    @p MaxChunkSizeOuter and @p MaxChunkSizeInner can be used to control chunk
-   sizes (see <jacobian>"()").
+   sizes (see ::jacobian).
 
    See ::jacobian for requirements on the function @p f and the argument
    @p x.

--- a/drake/math/autodiff.h
+++ b/drake/math/autodiff.h
@@ -239,5 +239,162 @@ initializeAutoDiffTuple(const Eigen::MatrixBase<Deriveds>&... args) {
   return ret;
 }
 
+/** \brief Computes a matrix of AutoDiffScalars from which both the value and
+ * the Jacobian of a function
+ * \f[
+ * f:\mathbb{R}^{n\times m}\rightarrow\mathbb{R}^{p\times q}
+ * \f]
+ * can be extracted.
+ *
+ * The derivative vector for each AutoDiffScalar in the output contains the
+ * derivatives with respect to all components of the argument \f$ x \f$.
+ *
+ * The return type of this function is a matrix with the `best' possible
+ * AutoDiffScalar scalar type, in the following sense:
+ * * If the number of derivatives can be determined at compile time, the
+ *   AutoDiffScalar derivative vector will have that fixed size.
+ * * If the maximum number of derivatives can be determined at compile time, the
+ *   AutoDiffScalar derivative vector will have that maximum fixed size.
+ * * If neither the number, nor the maximum number of derivatives can be
+ *   determined at compile time, the output AutoDiffScalar derivative vector
+ *   will be dynamically sized.
+ *
+ * \p f should have a templated call operator that maps an Eigen matrix
+ * argument to another Eigen matrix. The scalar type of the output of \f$ f \f$
+ * need not match the scalar type of the input (useful in recursive calls to the
+ * function to determine higher order derivatives). The easiest way to create an
+ * \p f is using a C++14 generic lambda.
+ *
+ * The algorithm computes the Jacobian in chunks of up to \p MaxChunkSize
+ * derivatives at a time. This has three purposes:
+ * * It makes it so that derivative vectors can be allocated on the stack,
+ *   eliminating dynamic allocations and improving performance if the maximum
+ *   number of derivatives cannot be determined at compile time.
+ * * It gives control over, and limits the number of required
+ *   instantiations of the call operator of f and all the functions it calls.
+ * * Excessively large derivative vectors can result in CPU capacity cache
+ *   misses; even if the number of derivatives is fixed at compile time, it may
+ *   be better to break up into chunks if that means that capacity cache misses
+ *   can be prevented.
+ *
+ * \param f function
+ * \param x function argument value at which Jacobian will be evaluated
+ * \return AutoDiffScalar matrix corresponding to the Jacobian of f evaluated
+ * at x.
+ */
+template <int MaxChunkSize = 10, class F, class Arg>
+decltype(auto) jacobian(F &&f, Arg &&x) {
+  using Eigen::AutoDiffScalar;
+  using Eigen::Index;
+  using Eigen::Matrix;
+
+  using ArgNoRef = typename std::remove_reference<Arg>::type;
+
+  // Argument scalar type.
+  using ArgScalar = typename ArgNoRef::Scalar;
+
+  // Argument scalar type corresponding to return value of this function.
+  using ReturnArgDerType = Matrix<ArgScalar, ArgNoRef::SizeAtCompileTime, 1, 0,
+                                  ArgNoRef::MaxSizeAtCompileTime, 1>;
+  using ReturnArgAutoDiffScalar = AutoDiffScalar<ReturnArgDerType>;
+
+  // Return type of this function.
+  using ReturnArgAutoDiffType =
+      decltype(x.template cast<ReturnArgAutoDiffScalar>().eval());
+  using ReturnType = decltype(f(std::declval<ReturnArgAutoDiffType>()));
+
+  // Scalar type of chunk arguments.
+  using ChunkArgDerType =
+      Matrix<ArgScalar, Eigen::Dynamic, 1, 0, MaxChunkSize, 1>;
+  using ChunkArgAutoDiffScalar = AutoDiffScalar<ChunkArgDerType>;
+
+  // Allocate output.
+  ReturnType ret;
+
+  // Compute derivatives chunk by chunk.
+  constexpr Index kMaxChunkSize = MaxChunkSize;
+  Index num_derivs = x.size();
+  bool values_initialized = false;
+  for (Index deriv_num_start = 0; deriv_num_start < num_derivs;
+       deriv_num_start += kMaxChunkSize) {
+    // Compute chunk size.
+    Index num_derivs_to_go = num_derivs - deriv_num_start;
+    Index chunk_size = std::min(kMaxChunkSize, num_derivs_to_go);
+
+    // Initialize chunk argument.
+    auto chunk_arg = x.template cast<ChunkArgAutoDiffScalar>().eval();
+    for (Index i = 0; i < x.size(); i++) {
+      chunk_arg(i).derivatives().setZero(chunk_size);
+    }
+    for (Index i = 0; i < chunk_size; i++) {
+      Index deriv_num = deriv_num_start + i;
+      chunk_arg(deriv_num).derivatives()(i) = ArgScalar(1);
+    }
+
+    // Compute Jacobian chunk.
+    auto chunk_result = f(chunk_arg);
+
+    // On first chunk, resize output to match chunk and copy values from chunk
+    // to result.
+    if (!values_initialized) {
+      ret.resize(chunk_result.rows(), chunk_result.cols());
+
+      for (Index i = 0; i < chunk_result.size(); i++) {
+        ret(i).value() = chunk_result(i).value();
+        ret(i).derivatives().resize(num_derivs);
+      }
+      values_initialized = true;
+    }
+
+    // Copy derivatives from chunk to result.
+    for (Index i = 0; i < chunk_result.size(); i++) {
+      // intuitive thing to do, but results in problems with non-matching scalar
+      // types for recursive jacobian calls:
+      // ret(i).derivatives().segment(deriv_num_start, chunk_size) =
+      // chunk_result(i).derivatives();
+
+      // instead, assign each element individually, making use of conversion
+      // constructors
+      for (Index j = 0; j < chunk_size; j++) {
+        ret(i).derivatives()(deriv_num_start + j) =
+            chunk_result(i).derivatives()(j);
+      }
+    }
+  }
+
+  return ret;
+}
+
+/** \brief Computes a matrix of AutoDiffScalars from which the value, Jacobian,
+ * and Hessian of a function
+ * \f[
+ * f:\mathbb{R}^{n\times m}\rightarrow\mathbb{R}^{p\times q}
+ * \f]
+ * can be extracted.
+ *
+ * The output is a matrix of nested AutoDiffScalars, being the result of calling
+ * <jacobian>"()" on a function that returns the output of <jacobian>"()",
+ * called on \p f.
+ *
+ * \p MaxChunkSizeOuter and \p MaxChunkSizeInner can be used to control chunk
+ * sizes (see <jacobian>"()").
+ *
+ * See <jacobian>"()" for requirements on the function \p f and the argument
+ * \p x.
+ *
+ * \param f function
+ * \param x function argument value at which Hessian will be evaluated
+ * \return AutoDiffScalar matrix corresponding to the Hessian of f evaluated at
+ * x
+ */
+template <int MaxChunkSizeOuter = 10, int MaxChunkSizeInner = 10, class F,
+          class Arg>
+decltype(auto) hessian(F &&f, Arg &&x) {
+  auto jac_fun = [&](const auto &x_inner) {
+    return jacobian<MaxChunkSizeInner>(f, x_inner);
+  };
+  return jacobian<MaxChunkSizeOuter>(jac_fun, x);
+}
+
 }  // namespace math
 }  // namespace drake

--- a/drake/math/autodiff.h
+++ b/drake/math/autodiff.h
@@ -239,48 +239,48 @@ initializeAutoDiffTuple(const Eigen::MatrixBase<Deriveds>&... args) {
   return ret;
 }
 
-/** \brief Computes a matrix of AutoDiffScalars from which both the value and
- * the Jacobian of a function
- * \f[
- * f:\mathbb{R}^{n\times m}\rightarrow\mathbb{R}^{p\times q}
- * \f]
- * can be extracted.
- *
- * The derivative vector for each AutoDiffScalar in the output contains the
- * derivatives with respect to all components of the argument \f$ x \f$.
- *
- * The return type of this function is a matrix with the `best' possible
- * AutoDiffScalar scalar type, in the following sense:
- * * If the number of derivatives can be determined at compile time, the
- *   AutoDiffScalar derivative vector will have that fixed size.
- * * If the maximum number of derivatives can be determined at compile time, the
- *   AutoDiffScalar derivative vector will have that maximum fixed size.
- * * If neither the number, nor the maximum number of derivatives can be
- *   determined at compile time, the output AutoDiffScalar derivative vector
- *   will be dynamically sized.
- *
- * \p f should have a templated call operator that maps an Eigen matrix
- * argument to another Eigen matrix. The scalar type of the output of \f$ f \f$
- * need not match the scalar type of the input (useful in recursive calls to the
- * function to determine higher order derivatives). The easiest way to create an
- * \p f is using a C++14 generic lambda.
- *
- * The algorithm computes the Jacobian in chunks of up to \p MaxChunkSize
- * derivatives at a time. This has three purposes:
- * * It makes it so that derivative vectors can be allocated on the stack,
- *   eliminating dynamic allocations and improving performance if the maximum
- *   number of derivatives cannot be determined at compile time.
- * * It gives control over, and limits the number of required
- *   instantiations of the call operator of f and all the functions it calls.
- * * Excessively large derivative vectors can result in CPU capacity cache
- *   misses; even if the number of derivatives is fixed at compile time, it may
- *   be better to break up into chunks if that means that capacity cache misses
- *   can be prevented.
- *
- * \param f function
- * \param x function argument value at which Jacobian will be evaluated
- * \return AutoDiffScalar matrix corresponding to the Jacobian of f evaluated
- * at x.
+/** Computes a matrix of AutoDiffScalars from which both the value and
+   the Jacobian of a function
+   @f[
+   f:\mathbb{R}^{n\times m}\rightarrow\mathbb{R}^{p\times q}
+   @f]
+   (f: R^n*m -> R^p*q) can be extracted.
+
+   The derivative vector for each AutoDiffScalar in the output contains the
+   derivatives with respect to all components of the argument @f$ x @f$.
+
+   The return type of this function is a matrix with the `best' possible
+   AutoDiffScalar scalar type, in the following sense:
+   - If the number of derivatives can be determined at compile time, the
+     AutoDiffScalar derivative vector will have that fixed size.
+   - If the maximum number of derivatives can be determined at compile time, the
+     AutoDiffScalar derivative vector will have that maximum fixed size.
+   - If neither the number, nor the maximum number of derivatives can be
+     determined at compile time, the output AutoDiffScalar derivative vector
+     will be dynamically sized.
+
+   @p f should have a templated call operator that maps an Eigen matrix
+   argument to another Eigen matrix. The scalar type of the output of @f$ f @f$
+   need not match the scalar type of the input (useful in recursive calls to the
+   function to determine higher order derivatives). The easiest way to create an
+   @p f is using a C++14 generic lambda.
+
+   The algorithm computes the Jacobian in chunks of up to @p MaxChunkSize
+   derivatives at a time. This has three purposes:
+   - It makes it so that derivative vectors can be allocated on the stack,
+     eliminating dynamic allocations and improving performance if the maximum
+     number of derivatives cannot be determined at compile time.
+   - It gives control over, and limits the number of required
+     instantiations of the call operator of f and all the functions it calls.
+   - Excessively large derivative vectors can result in CPU capacity cache
+     misses; even if the number of derivatives is fixed at compile time, it may
+     be better to break up into chunks if that means that capacity cache misses
+     can be prevented.
+
+   @param f function
+   @param x function argument value at which Jacobian will be evaluated
+   @return AutoDiffScalar matrix corresponding to the Jacobian of f evaluated
+   at x.
  */
 template <int MaxChunkSize = 10, class F, class Arg>
 decltype(auto) jacobian(F &&f, Arg &&x) {
@@ -348,13 +348,13 @@ decltype(auto) jacobian(F &&f, Arg &&x) {
 
     // Copy derivatives from chunk to result.
     for (Index i = 0; i < chunk_result.size(); i++) {
-      // intuitive thing to do, but results in problems with non-matching scalar
+      // Intuitive thing to do, but results in problems with non-matching scalar
       // types for recursive jacobian calls:
       // ret(i).derivatives().segment(deriv_num_start, chunk_size) =
       // chunk_result(i).derivatives();
 
-      // instead, assign each element individually, making use of conversion
-      // constructors
+      // Instead, assign each element individually, making use of conversion
+      // constructors.
       for (Index j = 0; j < chunk_size; j++) {
         ret(i).derivatives()(deriv_num_start + j) =
             chunk_result(i).derivatives()(j);
@@ -365,27 +365,27 @@ decltype(auto) jacobian(F &&f, Arg &&x) {
   return ret;
 }
 
-/** \brief Computes a matrix of AutoDiffScalars from which the value, Jacobian,
- * and Hessian of a function
- * \f[
- * f:\mathbb{R}^{n\times m}\rightarrow\mathbb{R}^{p\times q}
- * \f]
- * can be extracted.
- *
- * The output is a matrix of nested AutoDiffScalars, being the result of calling
- * <jacobian>"()" on a function that returns the output of <jacobian>"()",
- * called on \p f.
- *
- * \p MaxChunkSizeOuter and \p MaxChunkSizeInner can be used to control chunk
- * sizes (see <jacobian>"()").
- *
- * See <jacobian>"()" for requirements on the function \p f and the argument
- * \p x.
- *
- * \param f function
- * \param x function argument value at which Hessian will be evaluated
- * \return AutoDiffScalar matrix corresponding to the Hessian of f evaluated at
- * x
+/** Computes a matrix of AutoDiffScalars from which the value, Jacobian,
+   and Hessian of a function
+   @f[
+   f:\mathbb{R}^{n\times m}\rightarrow\mathbb{R}^{p\times q}
+   @f]
+   (f: R^n*m -> R^p*q) can be extracted.
+
+   The output is a matrix of nested AutoDiffScalars, being the result of calling
+   ::jacobian on a function that returns the output of ::jacobian,
+   called on @p f.
+
+   @p MaxChunkSizeOuter and @p MaxChunkSizeInner can be used to control chunk
+   sizes (see <jacobian>"()").
+
+   See ::jacobian for requirements on the function @p f and the argument
+   @p x.
+
+   @param f function
+   @param x function argument value at which Hessian will be evaluated
+   @return AutoDiffScalar matrix corresponding to the Hessian of f evaluated at
+   x
  */
 template <int MaxChunkSizeOuter = 10, int MaxChunkSizeInner = 10, class F,
           class Arg>

--- a/drake/math/test/autodiff_test.cc
+++ b/drake/math/test/autodiff_test.cc
@@ -87,22 +87,29 @@ TEST_F(AutodiffTest, ToGradientMatrix) {
       << gradients;
 }
 
+template <typename Derived>
+void FillWithNumbersIncreasingFromZero(Eigen::MatrixBase<Derived>& matrix) {
+  for (Eigen::Index i = 0; i < matrix.size(); i++) {
+    matrix(i) = i;
+  }
+}
+
 class AutodiffJacobianTest : public ::testing::Test {};
 
 TEST_F(AutodiffJacobianTest, QuadraticForm) {
   using Eigen::Matrix3d;
   using Eigen::Vector3d;
 
-  srand(1);
   Matrix3d A;
-  A.setRandom();
+  FillWithNumbersIncreasingFromZero(A);
 
   auto quadratic_form = [&](const auto& x) {
     using Scalar = typename std::remove_reference<decltype(x)>::type::Scalar;
     return (x.transpose() * A.cast<Scalar>().eval() * x).eval();
   };
 
-  Vector3d x = Vector3d::Random();
+  Vector3d x;
+  FillWithNumbersIncreasingFromZero(x);
   auto jac_chunk_size_default = jacobian(quadratic_form, x);
   auto jac_chunk_size_1 = jacobian<1>(quadratic_form, x);
   auto jac_chunk_size_3 = jacobian<3>(quadratic_form, x);
@@ -147,14 +154,20 @@ TEST_F(AutoDiffHessianTest, QuadraticFunction) {
   using Eigen::VectorXd;
   using Eigen::Index;
 
-  srand(1);
   Index n = 4;
   Index m = 5;
-  MatrixXd A = MatrixXd::Random(n, m);
-  VectorXd b = VectorXd::Random(n);
-  MatrixXd C = MatrixXd::Random(n, n);
-  MatrixXd D = MatrixXd::Random(n, m);
-  VectorXd e = VectorXd::Random(n);
+
+  MatrixXd A(n, m);
+  VectorXd b(n);
+  MatrixXd C(n, n);
+  MatrixXd D(n, m);
+  VectorXd e(n);
+
+  FillWithNumbersIncreasingFromZero(A);
+  FillWithNumbersIncreasingFromZero(b);
+  FillWithNumbersIncreasingFromZero(C);
+  FillWithNumbersIncreasingFromZero(D);
+  FillWithNumbersIncreasingFromZero(e);
 
   auto quadratic_function = [&](const auto& x) {
     using Scalar = typename std::remove_reference<decltype(x)>::type::Scalar;
@@ -163,7 +176,8 @@ TEST_F(AutoDiffHessianTest, QuadraticFunction) {
         .eval();
   };
 
-  VectorXd x = VectorXd::Random(m);
+  VectorXd x(m);
+  FillWithNumbersIncreasingFromZero(x);
 
   auto hess_chunk_size_default = hessian(quadratic_function, x);
   auto hess_chunk_size_2_4 = hessian<2, 4>(quadratic_function, x);

--- a/drake/math/test/autodiff_test.cc
+++ b/drake/math/test/autodiff_test.cc
@@ -60,8 +60,9 @@ TEST_F(AutodiffTest, ToValueMatrix) {
   VectorXd expected(2);
   expected[1] = sin(1.0) + 10.0;
   expected[0] = (cos(1.0) / 10.0) * expected[1];
-  EXPECT_TRUE(CompareMatrices(expected, values, 1e-10,
-                              MatrixCompareType::absolute)) << values;
+  EXPECT_TRUE(
+      CompareMatrices(expected, values, 1e-10, MatrixCompareType::absolute))
+      << values;
 }
 
 // Tests that ToGradientMatrix extracts the gradients from the autodiff.
@@ -81,8 +82,124 @@ TEST_F(AutodiffTest, ToGradientMatrix) {
   // The derivative of y1 with respect to v1 is 1.
   expected(1, 1) = 1.0;
 
-  EXPECT_TRUE(CompareMatrices(expected, gradients, 1e-10,
-                              MatrixCompareType::absolute)) << gradients;
+  EXPECT_TRUE(
+      CompareMatrices(expected, gradients, 1e-10, MatrixCompareType::absolute))
+      << gradients;
+}
+
+class AutodiffJacobianTest : public ::testing::Test {};
+
+TEST_F(AutodiffJacobianTest, QuadraticForm) {
+  using Eigen::Matrix3d;
+  using Eigen::Vector3d;
+
+  Matrix3d A;
+  A.setRandom();
+
+  auto quadratic_form = [&](const auto& x) {
+    using Scalar = typename std::remove_reference<decltype(x)>::type::Scalar;
+    return (x.transpose() * A.cast<Scalar>().eval() * x).eval();
+  };
+
+  Vector3d x = Vector3d::Random();
+  auto jac_chunk_size_default = jacobian(quadratic_form, x);
+  auto jac_chunk_size_1 = jacobian<1>(quadratic_form, x);
+  auto jac_chunk_size_3 = jacobian<3>(quadratic_form, x);
+  auto jac_chunk_size_6 = jacobian<6>(quadratic_form, x);
+
+  // Ensure that chunk size has no effect on output type.
+  static_assert(std::is_same<decltype(jac_chunk_size_default),
+                             decltype(jac_chunk_size_1)>::value,
+                "jacobian output type mismatch");
+  static_assert(std::is_same<decltype(jac_chunk_size_default),
+                             decltype(jac_chunk_size_3)>::value,
+                "jacobian output type mismatch");
+  static_assert(std::is_same<decltype(jac_chunk_size_default),
+                             decltype(jac_chunk_size_6)>::value,
+                "jacobian output type mismatch");
+
+  // Ensure that the results are the same.
+  EXPECT_TRUE(jac_chunk_size_default == jac_chunk_size_1);
+  EXPECT_TRUE(jac_chunk_size_default == jac_chunk_size_3);
+  EXPECT_TRUE(jac_chunk_size_default == jac_chunk_size_6);
+
+  // Ensure that value is correct.
+  auto value_expected = quadratic_form(x);
+  auto value = autoDiffToValueMatrix(jac_chunk_size_default);
+  EXPECT_TRUE(CompareMatrices(value_expected, value, 1e-12,
+                              MatrixCompareType::absolute));
+
+  // Ensure that Jacobian is correct.
+  auto jac = autoDiffToGradientMatrix(jac_chunk_size_default);
+  auto jac_expected = (x.transpose() * (A + A.transpose())).eval();
+  EXPECT_TRUE(
+      CompareMatrices(jac_expected, jac, 1e-12, MatrixCompareType::absolute));
+}
+
+class AutoDiffHessianTest : public ::testing::Test {};
+
+// Example: quadratic function
+// (A x + b)^T C (D x + e)
+// from http://www.ee.ic.ac.uk/hp/staff/dmb/matrix/calculus.html#Hessian.
+TEST_F(AutoDiffHessianTest, QuadraticFunction) {
+  using Eigen::MatrixXd;
+  using Eigen::VectorXd;
+  using Eigen::Index;
+
+  Index n = 4;
+  Index m = 5;
+  MatrixXd A = MatrixXd::Random(n, m);
+  VectorXd b = VectorXd::Random(n);
+  MatrixXd C = MatrixXd::Random(n, n);
+  MatrixXd D = MatrixXd::Random(n, m);
+  VectorXd e = VectorXd::Random(n);
+
+  auto quadratic_function = [&](const auto& x) {
+    using Scalar = typename std::remove_reference<decltype(x)>::type::Scalar;
+    return ((A.cast<Scalar>() * x + b.cast<Scalar>()).transpose() *
+            C.cast<Scalar>() * (D.cast<Scalar>() * x + e.cast<Scalar>()))
+        .eval();
+  };
+
+  VectorXd x = VectorXd::Random(m);
+
+  auto hess_chunk_size_default = hessian(quadratic_function, x);
+  auto hess_chunk_size_2_4 = hessian<2, 4>(quadratic_function, x);
+
+  // Ensure that chunk size has no effect on output type.
+  static_assert(std::is_same<decltype(hess_chunk_size_default),
+                             decltype(hess_chunk_size_2_4)>::value,
+                "hessian output type mismatch");
+
+  // Ensure that the results are the same.
+  EXPECT_TRUE(hess_chunk_size_default == hess_chunk_size_2_4);
+
+  // Ensure that value is correct.
+  auto value_expected = quadratic_function(x);
+  auto value_autodiff = autoDiffToValueMatrix(hess_chunk_size_default);
+  auto value = autoDiffToValueMatrix(value_autodiff);
+  EXPECT_TRUE(CompareMatrices(value_expected, value, 1e-12,
+                              MatrixCompareType::absolute));
+
+  // Ensure that the two ways of computing the Jacobian from AutoDiff match.
+  auto jac_autodiff = autoDiffToGradientMatrix(hess_chunk_size_default);
+  auto jac1 = autoDiffToValueMatrix(jac_autodiff);
+  auto jac2 = autoDiffToGradientMatrix(value_autodiff);
+  EXPECT_TRUE(jac1 == jac2);
+
+  // Ensure that the Jacobian is correct.
+  auto jac_expected = ((A * x + b).transpose() * C * D +
+                       (D * x + e).transpose() * C.transpose() * A)
+                          .eval();
+  EXPECT_TRUE(
+      CompareMatrices(jac_expected, jac1, 1e-12, MatrixCompareType::absolute));
+
+  // Ensure that the Hessian is correct.
+  auto hess_expected =
+      (A.transpose() * C * D + D.transpose() * C.transpose() * A).eval();
+  auto hess = autoDiffToGradientMatrix(jac_autodiff);
+  EXPECT_TRUE(
+      CompareMatrices(hess_expected, hess, 1e-12, MatrixCompareType::absolute));
 }
 
 }  // namespace

--- a/drake/math/test/autodiff_test.cc
+++ b/drake/math/test/autodiff_test.cc
@@ -93,6 +93,7 @@ TEST_F(AutodiffJacobianTest, QuadraticForm) {
   using Eigen::Matrix3d;
   using Eigen::Vector3d;
 
+  srand(1);
   Matrix3d A;
   A.setRandom();
 
@@ -146,6 +147,7 @@ TEST_F(AutoDiffHessianTest, QuadraticFunction) {
   using Eigen::VectorXd;
   using Eigen::Index;
 
+  srand(1);
   Index n = 4;
   Index m = 5;
   MatrixXd A = MatrixXd::Random(n, m);


### PR DESCRIPTION
Wrote some handy AutoDiff utility functions (`jacobian` and `hessian`) last night. These implement the chunking idea (https://github.com/RobotLocomotion/drake/issues/2619). 

The `jacobian` algorithm computes the Jacobian in chunks of up to a specified maximum number of derivatives at a time. This has three purposes:
* It makes it so that derivative vectors can be allocated on the stack, eliminating dynamic allocations and improving performance if the (maximum) number of derivatives cannot be determined at compile time.
* It gives control over and limits the number of required instantiations of the call operator of the input functor and all the functions it calls.
* Excessively large derivative vectors can result in CPU cache capacity misses; even if the number of derivatives is fixed at compile time, it may be better to break up into chunks if that means that cache capacity misses can be prevented.

The `hessian` algorithm is super simple: it just calls `jacobian` recursively.

See documentation and tests for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3321)
<!-- Reviewable:end -->
