### PR TITLE
Diagrambuilder connect sugar

### DIFF
--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/framework/system_port_descriptor.h"
@@ -32,6 +33,26 @@ class DiagramBuilder {
     Register(src.get_system());
     Register(dest.get_system());
     dependency_graph_[dest_id] = src_id;
+  }
+
+  /// Declares that sole input port on the @p dest system is connected to sole
+  /// output port on the @p src system.  Throws an exception if the sole-port
+  /// precondition is not met (i.e., if @p dest has no input ports, or @p dest
+  /// has more than one input port, or @p src has no output ports, or @p src
+  /// has more than one output port).
+  void Connect(const System<T>& src, const System<T>& dest) {
+    DRAKE_THROW_UNLESS(src.get_num_output_ports() == 1);
+    DRAKE_THROW_UNLESS(dest.get_num_input_ports() == 1);
+    Connect(src.get_output_port(0), dest.get_input_port(0));
+  }
+
+  /// Cascades @p src and @p dest.  The sole input port on the @p dest system
+  /// is connected to sole output port on the @p src system.  Throws an
+  /// exception if the sole-port precondition is not met (i.e., if @p dest has
+  /// no input ports, or @p dest has more than one input port, or @p src has no
+  /// output ports, or @p src has more than one output port).
+  void Cascade(const System<T>& src, const System<T>& dest) {
+    Connect(src, dest);
   }
 
   /// Declares that the given @p input port of a constituent system is an input

--- a/drake/systems/framework/primitives/pid_controller.cc
+++ b/drake/systems/framework/primitives/pid_controller.cc
@@ -27,12 +27,9 @@ PidController<T>::PidController(
   builder.ExportInput(pass_through_->get_input_port(0));
   // Input 1 connects directly to the derivative component.
   builder.ExportInput(derivative_gain_->get_input_port(0));
-  builder.Connect(pass_through_->get_output_port(0),
-                  proportional_gain_->get_input_port(0));
-  builder.Connect(pass_through_->get_output_port(0),
-                  integrator_->get_input_port(0));
-  builder.Connect(integrator_->get_output_port(0),
-                  integral_gain_->get_input_port(0));
+  builder.Connect(*pass_through_, *proportional_gain_);
+  builder.Connect(*pass_through_, *integrator_);
+  builder.Connect(*integrator_, *integral_gain_);
   builder.Connect(proportional_gain_->get_output_port(0),
                   adder_->get_input_port(0));
   builder.Connect(integral_gain_->get_output_port(0),


### PR DESCRIPTION
FYI, this will also be used in my port of Cars to Simulator 2.0: https://github.com/jwnimmer-tri/drake/tree/cars-simulator2

I'd prefer to have three sample uses before generalizing, but it seems like a no-brainer that this method should exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3323)
<!-- Reviewable:end -->
