### PR TITLE
Removes Eigen::DontAlign from gain_test

### DIFF
--- a/drake/systems/framework/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/gain_scalartype_test.cc
@@ -14,7 +14,6 @@
 
 using Eigen::AutoDiffScalar;
 using Eigen::Vector2d;
-using Eigen::Vector3d;
 using std::make_unique;
 
 namespace drake {
@@ -35,12 +34,7 @@ std::unique_ptr<FreestandingInputPort> MakeInput(
 // input variables. The second input is set to be a constant and therefore
 // derivatives with respect to this input are zero.
 GTEST_TEST(GainScalarTypeTest, AutoDiff) {
-  // There are only two independent variables in this problem with respect to
-  // which we want to take derivatives. Therefore Vector2d_unaligned is the
-  // template argument of AutoDiffScalar.
-  // TODO(amcastro-tri): change to Vector2d once #3145 is fixed.
-  typedef Eigen::Matrix<double, 2, 1, Eigen::DontAlign> Vector2d_unaligned;
-  typedef AutoDiffScalar<Vector2d_unaligned> T;
+  typedef AutoDiffScalar<Vector2d> T;
 
   // Set a Gain system with input and output of size 3. Notice that this size
   // does not necessarily need to be the same as the size of the derivatives


### PR DESCRIPTION
With #3300 fixing #3211 removing the hack `Eigen::DontAlign` from the `gain_test` should not break Windows CI.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3340)

<!-- Reviewable:end -->
