### PR TITLE
Use std::vector instead of std::map to store DiagramContext constituents.

### DIFF
--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -41,14 +41,16 @@ class DiagramContinuousState : public ContinuousState<T> {
   int get_num_substates() const { return static_cast<int>(substates_.size()); }
 
   /// Returns the continuous state at the given @p index, or nullptr if that
-  /// system is stateless.
+  /// system is stateless. Aborts if @p index is out-of-bounds.
   const ContinuousState<T>* get_substate(int index) const {
+    DRAKE_ABORT_UNLESS(index >= 0 && index < get_num_substates());
     return substates_[index];
   }
 
   /// Returns the continuous state at the given @p index, or nullptr if that
-  /// system is stateless.
+  /// system is stateless. Aborts if @p index is out-of-bounds.
   ContinuousState<T>* get_mutable_substate(int index) {
+    DRAKE_ABORT_UNLESS(index >= 0 && index < get_num_substates());
     return substates_[index];
   }
 
@@ -90,8 +92,10 @@ class DiagramContinuousState : public ContinuousState<T> {
 /// The DiagramContext is a container for all of the data necessary to uniquely
 /// determine the computations performed by a Diagram. Specifically, a
 /// DiagramContext contains contexts and outputs for all the constituent
-/// Systems,
-/// wired up as specified by calls to `DiagramContext::Connect`.
+/// Systems, wired up as specified by calls to `DiagramContext::Connect`.
+///
+/// In general, users should not need to interact with a DiagramContext
+/// directly. Use the accessors on Diagram instead.
 ///
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
@@ -102,34 +106,34 @@ class DiagramContext : public ContextBase<T> {
   typedef int PortIndex;
   typedef std::pair<SystemIndex, PortIndex> PortIdentifier;
 
-  DiagramContext() {}
+  /// Constructs a DiagramContext with the given @p num_subsystems, which is
+  /// final: you cannot resize a DiagramContext after construction.
+  explicit DiagramContext(const int num_subsystems)
+      : outputs_(num_subsystems),
+        contexts_(num_subsystems) {}
 
   /// Declares a new subsystem in the DiagramContext. Subsystems are identified
-  /// by number.
+  /// by number. If the subsystem has already been declared, aborts.
   ///
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
-  void AddSystem(SystemIndex sys, std::unique_ptr<ContextBase<T>> context,
+  void AddSystem(SystemIndex index, std::unique_ptr<ContextBase<T>> context,
                  std::unique_ptr<SystemOutput<T>> output) {
-    DRAKE_ASSERT(contexts_.find(sys) == contexts_.end());
-    contexts_[sys] = std::move(context);
-
-    DRAKE_ASSERT(outputs_.find(sys) == outputs_.end());
-    outputs_[sys] = std::move(output);
+    DRAKE_ABORT_UNLESS(contexts_[index] == nullptr);
+    DRAKE_ABORT_UNLESS(outputs_[index] == nullptr);
+    contexts_[index] = std::move(context);
+    outputs_[index] = std::move(output);
   }
 
   /// Declares that a particular input port of a particular subsystem is an
-  /// input to the entire Diagram that allocates this Context.
+  /// input to the entire Diagram that allocates this Context. Aborts if the
+  /// subsystem has not been added to the DiagramContext.
   ///
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
   void ExportInput(const PortIdentifier& id) {
     const SystemIndex system_index = id.first;
-    if (contexts_.find(system_index) == contexts_.end()) {
-      throw std::runtime_error(
-          "Cannot add a System as an input until the "
-          "System itself has been added.");
-    }
+    DRAKE_ABORT_UNLESS(contexts_[system_index] != nullptr);
     input_ids_.emplace_back(id);
   }
 
@@ -142,7 +146,7 @@ class DiagramContext : public ContextBase<T> {
     // Identify and validate the source port.
     SystemIndex src_system_index = src.first;
     PortIndex src_port_index = src.second;
-    SystemOutput<T>* src_ports = outputs_[src_system_index].get();
+    SystemOutput<T>* src_ports = GetSubsystemOutput(src_system_index);
     DRAKE_ABORT_UNLESS(src_port_index >= 0);
     DRAKE_ABORT_UNLESS(src_port_index < src_ports->get_num_ports());
     OutputPort* output_port = src_ports->get_mutable_port(src_port_index);
@@ -150,7 +154,8 @@ class DiagramContext : public ContextBase<T> {
     // Identify and validate the destination port.
     SystemIndex dest_system_index = dest.first;
     PortIndex dest_port_index = dest.second;
-    ContextBase<T>* dest_context = contexts_[dest_system_index].get();
+    ContextBase<T>* dest_context =
+        GetMutableSubsystemContext(dest_system_index);
     DRAKE_ABORT_UNLESS(dest_port_index >= 0);
     DRAKE_ABORT_UNLESS(dest_port_index < dest_context->get_num_input_ports());
 
@@ -169,48 +174,47 @@ class DiagramContext : public ContextBase<T> {
   /// context allocation only.
   void MakeState() {
     std::vector<ContinuousState<T>*> substates;
-    for (auto& it : contexts_) {
+    for (auto& context : contexts_) {
       substates.push_back(
-          it.second->get_mutable_state()->continuous_state.get());
+          context->get_mutable_state()->continuous_state.get());
     }
     state_.continuous_state.reset(new DiagramContinuousState<T>(substates));
   }
 
-  /// Returns the output structure for a given constituent system @p sys, or
-  /// nullptr if @p sys is not a constituent system.
-  SystemOutput<T>* GetSubsystemOutput(SystemIndex sys) const {
-    auto it = outputs_.find(sys);
-    if (it == outputs_.end()) {
-      return nullptr;
-    }
-    return (*it).second.get();
+  /// Returns the output structure for a given constituent system at @p index.
+  /// Aborts if @p index is out of bounds, or if no system has been added to the
+  /// DiagramContext at that index.
+  SystemOutput<T>* GetSubsystemOutput(SystemIndex index) const {
+    const int num_outputs = static_cast<int>(outputs_.size());
+    DRAKE_ABORT_UNLESS(index >= 0 && index < num_outputs);
+    DRAKE_ABORT_UNLESS(outputs_[index] != nullptr);
+    return outputs_[index].get();
   }
 
-  /// Returns the context structure for a given constituent system @p sys, or
-  /// nullptr if @p sys is not a constituent system.
-  const ContextBase<T>* GetSubsystemContext(SystemIndex sys) const {
-    auto it = contexts_.find(sys);
-    if (it == contexts_.end()) {
-      return nullptr;
-    }
-    return (*it).second.get();
+  /// Returns the context structure for a given constituent system @p index.
+  /// Aborts if @p index is out of bounds, or if no system has been added to the
+  /// DiagramContext at that index.
+  const ContextBase<T>* GetSubsystemContext(SystemIndex index) const {
+    const int num_contexts = static_cast<int>(contexts_.size());
+    DRAKE_ABORT_UNLESS(index >= 0 && index < num_contexts);
+    DRAKE_ABORT_UNLESS(contexts_[index] != nullptr);
+    return contexts_[index].get();
   }
 
-  /// Returns the context structure for a given subsystem @p sys, or
-  /// nullptr if @p sys is not a subsystem.
-  ContextBase<T>* GetMutableSubsystemContext(SystemIndex sys) {
-    auto it = contexts_.find(sys);
-    if (it == contexts_.end()) {
-      return nullptr;
-    }
-    return (*it).second.get();
+  /// Returns the context structure for a given subsystem @p index.
+  /// Aborts if @p index is out of bounds, or if no system has been added to the
+  /// DiagramContext at that index.
+  ContextBase<T>* GetMutableSubsystemContext(SystemIndex index) {
+    const int num_contexts = static_cast<int>(contexts_.size());
+    DRAKE_ABORT_UNLESS(index >= 0 && index < num_contexts);
+    DRAKE_ABORT_UNLESS(contexts_[index] != nullptr);
+    return contexts_[index].get();
   }
 
   /// Recursively sets the time on this context and all subcontexts.
   void set_time(const T& time_sec) override {
     ContextBase<T>::set_time(time_sec);
-    for (auto& kv : contexts_) {
-      ContextBase<T>* subcontext = kv.second.get();
+    for (auto& subcontext : contexts_) {
       if (subcontext != nullptr) {
         subcontext->set_time(time_sec);
       }
@@ -228,9 +232,8 @@ class DiagramContext : public ContextBase<T> {
     const PortIdentifier& id = input_ids_[index];
     SystemIndex system_index = id.first;
     PortIndex port_index = id.second;
-    const auto it = contexts_.find(system_index);
-    DRAKE_ASSERT(it != contexts_.end());
-    it->second->SetInputPort(port_index, std::move(port));
+    GetMutableSubsystemContext(system_index)->SetInputPort(port_index,
+                                                           std::move(port));
     // TODO(david-german-tri): Set invalidation callbacks.
   }
 
@@ -241,8 +244,7 @@ class DiagramContext : public ContextBase<T> {
     const PortIdentifier& id = input_ids_[index];
     SystemIndex system_index = id.first;
     PortIndex port_index = id.second;
-    const ContextBase<T>* subsystem_context = GetSubsystemContext(system_index);
-    return subsystem_context->get_vector_input(port_index);
+    return GetSubsystemContext(system_index)->get_vector_input(port_index);
   }
 
   const AbstractValue* get_abstract_input(int index) const override {
@@ -252,8 +254,7 @@ class DiagramContext : public ContextBase<T> {
     const PortIdentifier& id = input_ids_[index];
     SystemIndex system_index = id.first;
     PortIndex port_index = id.second;
-    const ContextBase<T>* subsystem_context = GetSubsystemContext(system_index);
-    return subsystem_context->get_abstract_input(port_index);
+    return GetSubsystemContext(system_index)->get_abstract_input(port_index);
   }
 
   const State<T>& get_state() const override { return state_; }
@@ -262,16 +263,18 @@ class DiagramContext : public ContextBase<T> {
 
  protected:
   DiagramContext<T>* DoClone() const override {
-    DiagramContext<T>* clone = new DiagramContext();
+    DRAKE_ASSERT(contexts_.size() == outputs_.size());
+    const int num_subsystems = static_cast<int>(contexts_.size());
+    DiagramContext<T>* clone = new DiagramContext(num_subsystems);
 
     // Clone all the subsystem contexts and outputs.
-    for (const auto& subcontext : contexts_) {
+    for (int i = 0; i < num_subsystems; ++i) {
+      DRAKE_ABORT_UNLESS(contexts_[i] != nullptr);
+      DRAKE_ABORT_UNLESS(outputs_[i] != nullptr);
       // When a leaf context is cloned, it will clone the data that currently
       // appears on each of its input ports into a FreestandingInputPort.
-      clone->contexts_[subcontext.first] = subcontext.second->Clone();
-    }
-    for (const auto& suboutput : outputs_) {
-      clone->outputs_[suboutput.first] = suboutput.second->Clone();
+      clone->contexts_[i] = contexts_[i]->Clone();
+      clone->outputs_[i] = outputs_[i]->Clone();
     }
 
     // Build a superstate over the subsystem contexts.
@@ -300,8 +303,8 @@ class DiagramContext : public ContextBase<T> {
  private:
   std::vector<PortIdentifier> input_ids_;
 
-  std::map<SystemIndex, std::unique_ptr<SystemOutput<T>>> outputs_;
-  std::map<SystemIndex, std::unique_ptr<ContextBase<T>>> contexts_;
+  std::vector<std::unique_ptr<SystemOutput<T>>> outputs_;
+  std::vector<std::unique_ptr<ContextBase<T>>> contexts_;
 
   // A map from the input ports of constituent systems, to the output ports of
   // the systems on which they depend.

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -27,13 +27,11 @@ class DiagramContextTest : public ::testing::Test {
     adder0_->set_name("adder0");
     adder1_.reset(new Adder<double>(2 /* inputs */, 1 /* length */));
     adder1_->set_name("adder1");
-    adder2_.reset(new Adder<double>(2 /* inputs */, 1 /* length */));
-    adder2_->set_name("adder2");
 
     integrator0_.reset(new Integrator<double>(1 /* length */));
     integrator1_.reset(new Integrator<double>(1 /* length */));
 
-    context_.reset(new DiagramContext<double>());
+    context_.reset(new DiagramContext<double>(kNumSystems));
     context_->set_time(kTime);
 
     AddSystem(*adder0_, 0);
@@ -71,21 +69,22 @@ class DiagramContextTest : public ::testing::Test {
   std::unique_ptr<DiagramContext<double>> context_;
   std::unique_ptr<Adder<double>> adder0_;
   std::unique_ptr<Adder<double>> adder1_;
-  std::unique_ptr<Adder<double>> adder2_;
   std::unique_ptr<Integrator<double>> integrator0_;
   std::unique_ptr<Integrator<double>> integrator1_;
 };
 
-// Tests that systems do not have outputs or contexts in the DiagramContext
-// until they are added as constituent systems.
-TEST_F(DiagramContextTest, AddAndRetrieveConstituents) {
-  EXPECT_EQ(nullptr, context_->GetSubsystemOutput(4));
-  EXPECT_EQ(nullptr, context_->GetSubsystemContext(4));
+// Tests that subsystems have outputs and contexts in the DiagramContext.
+TEST_F(DiagramContextTest, RetrieveConstituents) {
+  // All of the subsystems should be leaf Systems.
+  for (int i = 0; i < kNumSystems; ++i) {
+    auto context = dynamic_cast<const Context<double>*>(
+        context_->GetSubsystemContext(i));
+    EXPECT_TRUE(context != nullptr);
 
-  AddSystem(*adder2_, 4 /* index */);
-
-  EXPECT_NE(nullptr, context_->GetSubsystemOutput(4));
-  EXPECT_NE(nullptr, context_->GetSubsystemContext(4));
+    auto output = dynamic_cast<const LeafSystemOutput<double>*>(
+        context_->GetSubsystemOutput(i));
+    EXPECT_TRUE(output != nullptr);
+  }
 }
 
 // Tests that the time writes through to the subsystem contexts.
@@ -149,7 +148,7 @@ TEST_F(DiagramContextTest, Clone) {
 
   std::unique_ptr<DiagramContext<double>> clone(
       dynamic_cast<DiagramContext<double>*>(context_->Clone().release()));
-  ASSERT_NE(nullptr, clone);
+  ASSERT_TRUE(clone != nullptr);
 
   // Verify that the time was copied.
   EXPECT_EQ(kTime, clone->get_time());

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -62,6 +62,7 @@ class ExampleDiagram : public Diagram<double> {
     builder.BuildInto(this);
   }
 
+  Adder<double>* adder0() { return adder0_.get(); }
   Integrator<double>* integrator0() { return integrator0_.get(); }
   Integrator<double>* integrator1() { return integrator1_.get(); }
 
@@ -89,13 +90,13 @@ class DiagramTest : public ::testing::Test {
 
     // Initialize the integrator states.
     auto integrator0_xc = GetMutableContinuousState(integrator0());
-    ASSERT_NE(nullptr, integrator0_xc);
+    ASSERT_TRUE(integrator0_xc != nullptr);
     integrator0_xc->get_mutable_state()->SetAtIndex(0, 3);
     integrator0_xc->get_mutable_state()->SetAtIndex(1, 9);
     integrator0_xc->get_mutable_state()->SetAtIndex(2, 27);
 
     auto integrator1_xc = GetMutableContinuousState(integrator1());
-    ASSERT_NE(nullptr, integrator1_xc);
+    ASSERT_TRUE(integrator1_xc != nullptr);
     integrator1_xc->get_mutable_state()->SetAtIndex(0, 81);
     integrator1_xc->get_mutable_state()->SetAtIndex(1, 243);
     integrator1_xc->get_mutable_state()->SetAtIndex(2, 729);
@@ -123,21 +124,21 @@ class DiagramTest : public ::testing::Test {
 
     const BasicVector<double>* output0 =
         dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
-    ASSERT_NE(nullptr, output0);
+    ASSERT_TRUE(output0 != nullptr);
     EXPECT_EQ(expected_output0[0], output0->get_value()[0]);
     EXPECT_EQ(expected_output0[1], output0->get_value()[1]);
     EXPECT_EQ(expected_output0[2], output0->get_value()[2]);
 
     const BasicVector<double>* output1 =
         dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(1));
-    ASSERT_NE(nullptr, output1);
+    ASSERT_TRUE(output1 != nullptr);
     EXPECT_EQ(expected_output1[0], output1->get_value()[0]);
     EXPECT_EQ(expected_output1[1], output1->get_value()[1]);
     EXPECT_EQ(expected_output1[2], output1->get_value()[2]);
 
     const BasicVector<double>* output2 =
         dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(2));
-    ASSERT_NE(nullptr, output2);
+    ASSERT_TRUE(output2 != nullptr);
     EXPECT_EQ(expected_output2[0], output2->get_value()[0]);
     EXPECT_EQ(expected_output2[1], output2->get_value()[1]);
     EXPECT_EQ(expected_output2[2], output2->get_value()[2]);
@@ -149,6 +150,7 @@ class DiagramTest : public ::testing::Test {
     context_->SetInputPort(2, MakeInput(std::move(input2_)));
   }
 
+  Adder<double>* adder0() { return diagram_->adder0(); }
   Integrator<double>* integrator0() { return diagram_->integrator0(); }
   Integrator<double>* integrator1() { return diagram_->integrator1(); }
 
@@ -213,18 +215,20 @@ TEST_F(DiagramTest, EvalTimeDerivatives) {
   ASSERT_EQ(6, derivatives->get_misc_continuous_state().size());
 
   // The derivative of the first integrator is A.
-  const ContinuousState<double>& integrator0_xcdot =
+  const ContinuousState<double>* integrator0_xcdot =
       diagram_->GetSubsystemDerivatives(*derivatives, integrator0());
-  EXPECT_EQ(1 + 8, integrator0_xcdot.get_state().GetAtIndex(0));
-  EXPECT_EQ(2 + 16, integrator0_xcdot.get_state().GetAtIndex(1));
-  EXPECT_EQ(4 + 32, integrator0_xcdot.get_state().GetAtIndex(2));
+  ASSERT_TRUE(integrator0_xcdot != nullptr);
+  EXPECT_EQ(1 + 8, integrator0_xcdot->get_state().GetAtIndex(0));
+  EXPECT_EQ(2 + 16, integrator0_xcdot->get_state().GetAtIndex(1));
+  EXPECT_EQ(4 + 32, integrator0_xcdot->get_state().GetAtIndex(2));
 
   // The derivative of the second integrator is the state of the first.
-  const ContinuousState<double>& integrator1_xcdot =
+  const ContinuousState<double>* integrator1_xcdot =
       diagram_->GetSubsystemDerivatives(*derivatives, integrator1());
-  EXPECT_EQ(3, integrator1_xcdot.get_state().GetAtIndex(0));
-  EXPECT_EQ(9, integrator1_xcdot.get_state().GetAtIndex(1));
-  EXPECT_EQ(27, integrator1_xcdot.get_state().GetAtIndex(2));
+  ASSERT_TRUE(integrator1_xcdot != nullptr);
+  EXPECT_EQ(3, integrator1_xcdot->get_state().GetAtIndex(0));
+  EXPECT_EQ(9, integrator1_xcdot->get_state().GetAtIndex(1));
+  EXPECT_EQ(27, integrator1_xcdot->get_state().GetAtIndex(2));
 }
 
 // Tests that the same diagram can be evaluated into the same output with
@@ -252,7 +256,7 @@ TEST_F(DiagramTest, Clone) {
   expected_output0 << 3 + 8 + 64, 6 + 16 + 128, 9 + 32 + 256;  // B
   const BasicVector<double>* output0 =
       dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
-  ASSERT_NE(nullptr, output0);
+  ASSERT_TRUE(output0 != nullptr);
   EXPECT_EQ(expected_output0[0], output0->get_value()[0]);
   EXPECT_EQ(expected_output0[1], output0->get_value()[1]);
   EXPECT_EQ(expected_output0[2], output0->get_value()[2]);
@@ -262,7 +266,7 @@ TEST_F(DiagramTest, Clone) {
   expected_output1 += expected_output0;       // A + B
   const BasicVector<double>* output1 =
       dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(1));
-  ASSERT_NE(nullptr, output1);
+  ASSERT_TRUE(output1 != nullptr);
   EXPECT_EQ(expected_output1[0], output1->get_value()[0]);
   EXPECT_EQ(expected_output1[1], output1->get_value()[1]);
   EXPECT_EQ(expected_output1[2], output1->get_value()[2]);
@@ -270,6 +274,15 @@ TEST_F(DiagramTest, Clone) {
   // Check that the context that was cloned is unaffected.
   diagram_->EvalOutput(*context_, output_.get());
   ExpectDefaultOutputs();
+}
+
+// Tests that, when asked for the state derivatives of Systems that are
+// stateless, Diagram returns nullptr.
+TEST_F(DiagramTest, DerivativesOfStatelessSystemAreNullptr) {
+  std::unique_ptr<ContinuousState<double>> derivatives =
+      diagram_->AllocateTimeDerivatives();
+  EXPECT_EQ(nullptr,
+            diagram_->GetSubsystemDerivatives(*derivatives, adder0()));
 }
 
 class DiagramOfDiagramsTest : public ::testing::Test {
@@ -377,8 +390,8 @@ GTEST_TEST(DiagramSubclassTest, TwelvePlusSevenIsNineteen) {
   AddConstantDiagram plus_seven(7.0);
   auto context = plus_seven.CreateDefaultContext();
   auto output = plus_seven.AllocateOutput(*context);
-  ASSERT_NE(nullptr, context);
-  ASSERT_NE(nullptr, output);
+  ASSERT_TRUE(context != nullptr);
+  ASSERT_TRUE(output != nullptr);
 
   auto vec = std::make_unique<BasicVector<double>>(1 /* length */);
   vec->get_mutable_value() << 12.0;


### PR DESCRIPTION
Clarify the cases in which subcontext/suboutput retrieval aborts, and the cases in which it returns nullptr.  Resolves #3319.

+@liangfok for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3348)
<!-- Reviewable:end -->
