### PR TITLE
Fix for diagram-of-diagram destructor memory violation

### DIFF
--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -300,10 +300,6 @@ class DiagramContext : public ContextBase<T> {
  private:
   std::vector<PortIdentifier> input_ids_;
 
-  // Order is critical: Output ports must outlive the DependentInputPorts that
-  // depend on them, because the input ports unregister themselves from output
-  // port change notifications at destruction time. Thus, outputs_ must be
-  // declared before contexts_, so that contexts_ is destroyed before outputs_.
   std::map<SystemIndex, std::unique_ptr<SystemOutput<T>>> outputs_;
   std::map<SystemIndex, std::unique_ptr<ContextBase<T>>> contexts_;
 

--- a/drake/systems/framework/system_input.cc
+++ b/drake/systems/framework/system_input.cc
@@ -11,10 +11,21 @@ void InputPort::Invalidate() {
   }
 }
 
-DependentInputPort::~DependentInputPort() {
-  output_port_->remove_dependent(this);
+DependentInputPort::DependentInputPort(OutputPort* output_port)
+    : output_port_(output_port) {
+  DRAKE_ABORT_UNLESS(output_port_ != nullptr);
+  output_port_->add_dependent(this);
 }
 
+DependentInputPort::~DependentInputPort() {
+  if (output_port_ != nullptr) {
+    output_port_->remove_dependent(this);
+  }
+}
+
+void DependentInputPort::Disconnect() {
+  output_port_ = nullptr;
+}
 
 FreestandingInputPort::FreestandingInputPort(
     std::unique_ptr<AbstractValue> data)

--- a/drake/systems/framework/system_output.cc
+++ b/drake/systems/framework/system_output.cc
@@ -5,7 +5,13 @@ namespace systems {
 
 OutputPortListenerInterface::~OutputPortListenerInterface() {}
 
-OutputPort::~OutputPort() {}
+OutputPort::~OutputPort() {
+  // Notify any input ports that are still connected to this output port that
+  // this output port no longer exists.
+  for (OutputPortListenerInterface* dependent : dependents_) {
+    dependent->Disconnect();
+  }
+}
 
 
 std::unique_ptr<OutputPort> OutputPort::Clone() const {

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -26,10 +26,16 @@ class DRAKESYSTEMFRAMEWORK_EXPORT OutputPortListenerInterface {
   /// Invalidates any data that depends on the OutputPort. Called whenever
   /// the OutputPort's version number is incremented.
   virtual void Invalidate() = 0;
+
+  /// Notifies the consumer that the OutputPort is no longer valid and should
+  /// not be read.
+  virtual void Disconnect() = 0;
 };
 
 /// The OutputPort represents a data output from a System. Other Systems
-/// may depend on the OutputPort.
+/// may depend on the OutputPort. When an OutputPort is deleted, it will
+/// automatically notify the listeners that depend on it to disconnect,
+/// meaning those ports will resolve to nullptr.
 class DRAKESYSTEMFRAMEWORK_EXPORT OutputPort {
  public:
   /// Constructs a vector-valued OutputPort.

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -9,6 +9,7 @@
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/primitives/adder.h"
 #include "drake/systems/framework/primitives/constant_vector_source.h"
+#include "drake/systems/framework/primitives/gain.h"
 #include "drake/systems/framework/primitives/integrator.h"
 #include "drake/systems/framework/system_port_descriptor.h"
 
@@ -185,6 +186,9 @@ TEST_F(DiagramTest, Topology) {
   EXPECT_EQ(kInheritedSampling, diagram_->get_output_port(1).get_sampling());
   // The integrator output port has continuous sampling.
   EXPECT_EQ(kContinuousSampling, diagram_->get_output_port(2).get_sampling());
+
+  // The diagram has direct feedthrough.
+  EXPECT_TRUE(diagram_->has_any_direct_feedthrough());
 }
 
 // Tests that the diagram computes the correct sum.
@@ -439,6 +443,52 @@ GTEST_TEST(DiagramPublishTest, Publish) {
   auto context = publishing_diagram.CreateDefaultContext();
   publishing_diagram.Publish(*context);
   EXPECT_EQ(42.0, publishing_diagram.get());
+}
+
+// FeedbackDiagram is a diagram containing a feedback loop of two
+// constituent diagrams, an Integrator and a Gain. The Integrator is not
+// direct-feedthrough, so there is no algebraic loop.
+class FeedbackDiagram : public Diagram<double> {
+ public:
+  FeedbackDiagram() : Diagram<double>() {
+    integrator_ = std::make_unique<Integrator<double>>(1 /* length */);
+    gain_ = std::make_unique<Gain<double>>(1.0 /* gain */, 1 /* length */);
+
+    DiagramBuilder<double> integrator_builder;
+    integrator_builder.ExportInput(integrator_->get_input_port(0));
+    integrator_builder.ExportOutput(integrator_->get_output_port(0));
+    integrator_diagram_ = integrator_builder.Build();
+
+    DiagramBuilder<double> gain_builder;
+    gain_builder.ExportInput(gain_->get_input_port(0));
+    gain_builder.ExportOutput(gain_->get_output_port(0));
+    gain_diagram_ = gain_builder.Build();
+
+    DiagramBuilder<double> builder;
+    builder.Connect(*integrator_diagram_, *gain_diagram_);
+    builder.Connect(*gain_diagram_, *integrator_diagram_);
+    builder.BuildInto(this);
+  }
+
+ private:
+  std::unique_ptr<Integrator<double>> integrator_;
+  std::unique_ptr<Gain<double>> gain_;
+  std::unique_ptr<Diagram<double>> integrator_diagram_;
+  std::unique_ptr<Diagram<double>> gain_diagram_;
+};
+
+// Tests that since there are no outputs, there is no direct feedthrough.
+GTEST_TEST(FeedbackDiagramTest, HasDirectFeedthrough) {
+  FeedbackDiagram diagram;
+  EXPECT_FALSE(diagram.has_any_direct_feedthrough());
+}
+
+// Tests that a FeedbackDiagram's context can be deleted without accessing
+// already-freed memory. https://github.com/RobotLocomotion/drake/issues/3349
+GTEST_TEST(FeedbackDiagramTest, DeletionIsMemoryClean) {
+  FeedbackDiagram diagram;
+  auto context = diagram.CreateDefaultContext();
+  EXPECT_NO_THROW(context.reset());
 }
 
 }  // namespace


### PR DESCRIPTION
The reproducing test case also required implementing Diagram<T>::has_any_direct_feedthrough. 

Resolves #3349, unblocks #3348.

+@bradking or +@liangfok for feature review.  +@ggould-tri for platform review.  cc @sherm1, @jwnimmer-tri FYI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3350)
<!-- Reviewable:end -->
