### PR TITLE
Use upstream swig_matlab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,7 +76,7 @@
 	url = https://github.com/rdeits/swigmake.git
 [submodule "externals/swig_matlab"]
 	path = externals/swig_matlab
-	url = https://github.com/rdeits/swig-matlab-pod.git
+	url = https://github.com/jaeandersson/swig.git
 [submodule "externals/yaml_cpp"]
 	path = externals/yaml_cpp
 	url = https://github.com/jbeder/yaml-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,6 @@ drake_add_external(sedumi)
 drake_add_external(snopt CMAKE)
 drake_add_external(spdlog PUBLIC CMAKE)
 drake_add_external(spotless PUBLIC CMAKE)
-drake_add_external(swig_matlab PUBLIC CMAKE)
 drake_add_external(swigmake PUBLIC CMAKE)
 drake_add_external(xfoil PUBLIC)
 drake_add_external(yalmip PUBLIC)
@@ -129,6 +128,11 @@ drake_add_external(yalmip PUBLIC)
 drake_add_external(cmake PUBLIC ALWAYS
   BUILD_COMMAND :
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake/cmake)
+
+# dreal
+drake_add_external(dreal PUBLIC CMAKE
+  CMAKE_ARGS -DUSE_NLOPT=OFF
+  SOURCE_SUBDIR src)
 
 # googletest
 drake_add_external(googletest PUBLIC CMAKE
@@ -168,10 +172,13 @@ drake_add_external(nlopt PUBLIC
     --includedir=${CMAKE_INSTALL_PREFIX}/include/nlopt
   INSTALL_COMMAND ${MAKE_COMMAND} install)
 
-# dreal
-drake_add_external(dreal PUBLIC CMAKE
-  CMAKE_ARGS -DUSE_NLOPT=OFF
-  SOURCE_SUBDIR src)
+# swig_matlab
+drake_add_external(swig_matlab PUBLIC
+  PATCH_COMMAND ./autogen.sh
+  CONFIGURE_COMMAND ./configure
+    --prefix=${CMAKE_INSTALL_PREFIX}
+    --with-matlab
+  INSTALL_COMMAND ${MAKE_COMMAND} install)
 
 # textbook
 drake_add_external(textbook PUBLIC

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -100,9 +100,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=shadow")
   endif()
-  # TODO(rdeits) Remove when https://github.com/jaeandersson/swig/pull/73 is
-  # accessible from the version of swig_matlab we are using
-  set(CXX_FLAGS_NO_ERROR_MAYBE_UNINITIALIZED -Wno-error=maybe-uninitialized)
   set(CXX_FLAGS_NO_ERROR_SHADOW -Wno-error=shadow -Wno-shadow)
   set(CXX_FLAGS_NO_SIGN_COMPARE -Wno-sign-compare)
 elseif(MSVC)

--- a/drake/bindings/swig/CMakeLists.txt
+++ b/drake/bindings/swig/CMakeLists.txt
@@ -13,11 +13,6 @@ set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY
 # SWIG output code makes expansive use of variable shadowing.
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY
   COMPILE_OPTIONS ${CXX_FLAGS_NO_ERROR_SHADOW})
-# SWIG output code "may" use a variable uninitialized (not really, but due to
-# bad annotation of mexErrMsgIdAndTxt, the compiler can't know that); see also
-# https://github.com/jaeandersson/swig/pull/73
-set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY
-  COMPILE_OPTIONS ${CXX_FLAGS_NO_ERROR_MAYBE_UNINITIALIZED})
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Suppresses warnings due to the existence of deprecated methods. These


### PR DESCRIPTION
Use upstream swig_matlab instead of PODS wrapper. Update to latest upstream so that we can remove suppression of `-Wmaybe-uninitialized` (upstream contains a fix so that the generated code does not trip this).

Fixes #3335.

@jamiesnape for feature review (or please punt to someone appropriate), @david-german-tri for platform review (likewise).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3356)
<!-- Reviewable:end -->
