### PR TITLE
Use upstream octomap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,7 @@
 	url = https://github.com/mitdrc/signal-scope.git
 [submodule "externals/octomap"]
 	path = externals/octomap
-	url = https://github.com/RobotLocomotion/octomap-pod.git
+	url = https://github.com/OctoMap/octomap
 [submodule "externals/snopt"]
 	path = externals/snopt
 	url = git@github.com:RobotLocomotion/snopt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ drake_add_external(gloptipoly)
 drake_add_external(gurobi)
 drake_add_external(meshconverters PUBLIC)
 drake_add_external(mosek PUBLIC)
-drake_add_external(octomap PUBLIC)
+drake_add_external(octomap PUBLIC CMAKE SOURCE_SUBDIR octomap)
 drake_add_external(sedumi)
 drake_add_external(snopt CMAKE)
 drake_add_external(spdlog PUBLIC CMAKE)
@@ -167,7 +167,7 @@ else()
   drake_add_external(gflags PUBLIC CMAKE
     CMAKE_ARGS -DBUILD_SHARED_LIBS=ON)
 endif()
-  
+
 # googletest
 drake_add_external(googletest PUBLIC CMAKE
   CMAKE_ARGS


### PR DESCRIPTION
The PODS wrapper doesn't seem to have done anything useful; use upstream instead.

Fixes #3333.

I'm going to throw this at CI and see what happens. It doesn't build on my machine, but then, octomap has issues, and apparently they don't affect CI... (From the `Makefile` wrapper, there *might* be issues on OS X. If so, we should try to get fixes upstreamed...)

Usual suspects for usual roles, with usual caveat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3375)
<!-- Reviewable:end -->
