### PR TITLE
Implement drake::systems::Cache.

### DIFF
--- a/drake/systems/framework/cache.cc
+++ b/drake/systems/framework/cache.cc
@@ -1,4 +1,81 @@
-// For now, this is an empty .cc file that only serves to confirm
-// cache.h is a stand-alone header.
-
 #include "drake/systems/framework/cache.h"
+
+#include <memory>
+
+namespace drake {
+namespace systems {
+
+namespace internal {
+
+CacheEntry::CacheEntry() {}
+CacheEntry::~CacheEntry() {}
+
+CacheEntry::CacheEntry(const CacheEntry& other) {
+  *this = other;
+}
+
+CacheEntry& CacheEntry::operator=(const CacheEntry& other) {
+  is_valid_ = other.is_valid();
+  if (other.value() != nullptr) {
+    value_ = other.value()->Clone();
+  }
+  dependents_ = other.dependents();
+  return *this;
+}
+
+}  // namespace internal
+
+using internal::CacheEntry;
+
+Cache::Cache() {}
+
+Cache::~Cache() {}
+
+CacheTicket Cache::MakeCacheTicket(const std::set<CacheTicket>& prerequisites) {
+  // Create a new ticket.
+  CacheTicket ticket = static_cast<int>(store_.size());
+
+  // Add the ticket to the dependency map. Because prerequisites may not be
+  // added after the fact, the dependency map is guaranteed acyclic.
+  for (const CacheTicket& prerequisite : prerequisites) {
+    store_[prerequisite].add_dependent(ticket);
+  }
+
+  // Reserve a null, invalid CacheEntry for this ticket.
+  store_.emplace_back();
+  return ticket;
+}
+
+void Cache::Invalidate(CacheTicket ticket) {
+  InvalidateRecursively({ticket});
+}
+
+void Cache::InvalidateRecursively(const std::set<CacheTicket>& to_invalidate) {
+  for (CacheTicket ticket : to_invalidate) {
+    // Invalidate the ticket.
+    store_[ticket].set_is_valid(false);
+    // Visit all the tickets that depend on this one.
+    InvalidateRecursively(store_[ticket].dependents());
+  }
+}
+
+AbstractValue* Cache::Init(CacheTicket ticket,
+                           std::unique_ptr<AbstractValue> value) {
+  DRAKE_DEMAND(ticket < static_cast<int>(store_.size()));
+  store_[ticket].set_is_valid(true);
+  store_[ticket].set_value(std::move(value));
+  InvalidateRecursively(store_[ticket].dependents());
+  return store_[ticket].value();
+}
+
+const AbstractValue* Cache::Get(CacheTicket ticket) const {
+  DRAKE_DEMAND(ticket < static_cast<int>(store_.size()));
+  if (store_[ticket].is_valid()) {
+    return store_[ticket].value();
+  } else {
+    return nullptr;
+  }
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/cache.h
+++ b/drake/systems/framework/cache.h
@@ -1,24 +1,135 @@
 #pragma once
 
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <set>
+#include <tuple>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/drakeSystemFramework_export.h"
+#include "drake/systems/framework/value.h"
+
 namespace drake {
 namespace systems {
 
-// This is a placeholder.
-// TODO(david-german-tri): Add actual functionality.
-template <typename T>
-class Cache {
- public:
-  Cache() {}
-  virtual ~Cache() {}
+typedef int CacheTicket;
 
-  // Cache objects are copyable with the default copy constructor.
-  Cache(const Cache& other) = default;
-  Cache& operator=(const Cache& other) = default;
+namespace internal {
+
+/// A single cached piece of data, its validity bit, and the set of other cache
+/// entries that depend on it.
+class DRAKESYSTEMFRAMEWORK_EXPORT CacheEntry {
+ public:
+  CacheEntry();
+  ~CacheEntry();
+
+  // CacheEntry is copyable.
+  CacheEntry(const CacheEntry& other);
+  CacheEntry& operator=(const CacheEntry& other);
+
+  bool is_valid() const { return is_valid_; }
+  void set_is_valid(bool valid) { is_valid_ = valid; }
+
+  AbstractValue* value() const { return value_.get(); }
+
+  void set_value(std::unique_ptr<AbstractValue> value) {
+    value_ = std::move(value);
+  }
+
+  std::unique_ptr<AbstractValue> release_value() {
+    set_is_valid(false);
+    return std::move(value_);
+  }
+
+  const std::set<CacheTicket>& dependents() const { return dependents_; }
+  void add_dependent(CacheTicket ticket) { dependents_.insert(ticket); }
 
  private:
-  // Cache objects are not moveable.
-  Cache(Cache&& other) = delete;
-  Cache& operator=(Cache&& other) = delete;
+  bool is_valid_{false};
+  std::unique_ptr<AbstractValue> value_;
+
+  // The set of cache tickets that are invalidated when the ticket corresponding
+  // to this entry is invalidated. This graph is directed and acyclic.
+  std::set<CacheTicket> dependents_;
+};
+
+}  // namespace internal
+
+/// Cache is a key-value store used within the System2 framework to avoid
+/// computing intermediate data multiple times during simulation or analysis.
+/// It is not a general-purpose caching layer.
+///
+/// Every Cache will be private to a System, stored within and accessible via
+/// the System's Context. Its function is to return a previously-computed
+/// value X, so long as no other value upon which X depends has changed.
+/// The System declares the expensive values it will compute, and their
+/// dependencies, by calling MakeCacheTicket.  It provides type-erased
+/// storage for the value using Init - typically just once - and thereafter
+/// sets the value using Set, or retrieves it using Get.
+///
+/// Whenever Init or Set is called, all entries which depend on the
+/// ticket being written are "invalidated". Once a ticket is invalidated,
+/// calls to Get for that ticket will return nullptr until it itself is
+/// written again.  For this reason, a System must call Get whenever it
+/// needs access to a cached value; it must not hold the returned pointer.
+///
+/// Cache is not thread-safe. It is copyable, assignable, and movable.
+class DRAKESYSTEMFRAMEWORK_EXPORT Cache {
+ public:
+  Cache();
+  ~Cache();
+
+  /// Creates a new cache ticket, which will be invalidated whenever any of
+  /// the @p prerequisites are invalidated.
+  CacheTicket MakeCacheTicket(const std::set<CacheTicket>& prerequisites);
+
+  /// Invalidates the value for @p ticket, and all entries that depend on it.
+  void Invalidate(CacheTicket ticket);
+
+  /// Takes ownership of a cached item, and returns a bare pointer to the item.
+  /// Marks the entry itself as valid, and invalidates all entries that depend
+  /// on it.
+  ///
+  /// The bare pointer may be used to modify the entry immediately, but should
+  /// not be held, because it may become invalid if the ticket's prerequisites
+  /// are modified.  It will only actually be deleted on subsequent calls to
+  /// Init for this ticket, or on the deletion of the Cache itself;
+  /// however, only advanced, careful users should rely on that behavior.
+  AbstractValue* Init(CacheTicket ticket,
+                      std::unique_ptr<AbstractValue> value);
+
+  /// Sets a cache entry to the given @p value. Aborts if the value has not
+  /// already been initialized. May throw std::bad_cast if the value has been
+  /// initialized with a different type. Marks the entry itself as valid, and
+  /// invalidates all entries that depend on it.
+  ///
+  /// @tparam T The type of the value.
+  template <typename T>
+  void Set(CacheTicket ticket, const T& value) {
+    DRAKE_DEMAND(ticket >= 0 && ticket < static_cast<int>(store_.size()));
+
+    AbstractValue* entry = store_[ticket].value();
+    DRAKE_DEMAND(entry != nullptr);
+    entry->SetValue<T>(value);
+    store_[ticket].set_is_valid(true);
+    InvalidateRecursively(store_[ticket].dependents());
+  }
+
+  /// Returns the cached item for the given @p ticket, or nullptr if the item
+  /// has been invalidated.
+  ///
+  /// The bare pointer should not be held, because the data may become invalid
+  /// if the ticket's prerequisites are modified.
+  const AbstractValue* Get(CacheTicket ticket) const;
+
+ private:
+  // Invalidates all tickets that depend on the tickets in @p to_invalidate.
+  void InvalidateRecursively(const std::set<CacheTicket>& to_invalidate);
+
+  // For each cache ticket, the stored value, and its validity bit.
+  std::vector<internal::CacheEntry> store_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/leaf_context.h
+++ b/drake/systems/framework/leaf_context.h
@@ -71,15 +71,50 @@ class LeafContext : public Context<T> {
 
   State<T>* get_mutable_state() override { return &state_; }
 
-  /// Returns a const reference to the Cache, which is expected to contain
-  /// precalculated values of interest. Use this only to access known-valid
-  /// cache entries; use `get_mutable_cache()` if computations may be needed.
-  const Cache<T>& get_cache() const { return cache_; }
+  /// Reserves a cache entry with the given @p prerequisites on which it
+  /// depends. Returns a ticket to identify the entry.
+  CacheTicket CreateCacheEntry(
+      const std::set<CacheTicket>& prerequisites) const {
+    // TODO(david-german-tri): Provide a notation for specifying context
+    // dependencies as well, and provide automatic invalidation when the
+    // context dependencies change.
+    return cache_.MakeCacheTicket(prerequisites);
+  }
 
-  /// Access to the cache is always read-write, and is permitted even on
-  /// const references to the Context. No invalidation of downstream dependents
-  /// occurs until mutable access is requested for a particular cache entry.
-  Cache<T>* get_mutable_cache() const { return &cache_; }
+  /// Stores the given @p value in the cache entry for the given @p ticket,
+  /// and returns a bare pointer to @p value.  That pointer will be invalidated
+  /// whenever any of the @p ticket's declared prerequisites change, and
+  /// possibly also at other times which are not defined.
+  ///
+  /// Systems MUST NOT depend on a particular value being present or valid
+  /// in the Cache, and MUST check the validity of cached values using
+  /// the GetCachedValue interface.
+  //
+  /// The Cache is useful to avoid recomputing expensive intermediate data. It
+  /// is not a scratch space for arbitrary state. If you cannot derive a value
+  /// from other fields in the Context, do not put that value in the Cache.
+  /// If you violate this rule, you may be devoured by a horror from another
+  /// universe, and forced to fill out paperwork in triplicate for all eternity.
+  /// You have been warned.
+  AbstractValue* InitCachedValue(CacheTicket ticket,
+                                 std::unique_ptr<AbstractValue> value) const {
+    return cache_.Init(ticket, std::move(value));
+  }
+
+  /// Copies the given @p value into the cache entry for the given @p ticket.
+  /// May throw std::bad_cast if the type of the existing value is not V.
+  ///
+  /// @tparam V The type of the value to store.
+  template <typename V>
+  void SetCachedValue(CacheTicket ticket, const V& value) const {
+    cache_.Set<V>(ticket, value);
+  }
+
+  // Returns the cached value for the given @p ticket, or nullptr if the
+  // cache entry has been invalidated.
+  const AbstractValue* GetCachedValue(CacheTicket ticket) const {
+    return cache_.Get(ticket);
+  }
 
  protected:
   /// The caller owns the returned memory.
@@ -111,7 +146,7 @@ class LeafContext : public Context<T> {
 
     // Make deep copies of everything else using the default copy constructors.
     *context->get_mutable_step_info() = this->get_step_info();
-    *context->get_mutable_cache() = this->get_cache();
+    context->cache_ = this->cache_;
     return context;
   }
 
@@ -129,8 +164,8 @@ class LeafContext : public Context<T> {
   State<T> state_;
 
   // The cache. The System may insert arbitrary key-value pairs, and configure
-  // invalidation on a per-line basis.
-  mutable Cache<T> cache_;
+  // invalidation on a per-entry basis.
+  mutable Cache cache_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -56,3 +56,8 @@ add_executable(diagram_context_test diagram_context_test.cc)
 target_link_libraries(diagram_context_test
                       drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
 drake_add_test(NAME diagram_context_test COMMAND diagram_context_test)
+
+add_executable(cache_test cache_test.cc)
+target_link_libraries(cache_test
+                      drakeSystemFramework ${GTEST_BOTH_LIBRARIES})
+add_test(NAME cache_test COMMAND cache_test)

--- a/drake/systems/framework/test/cache_test.cc
+++ b/drake/systems/framework/test/cache_test.cc
@@ -1,0 +1,115 @@
+#include "drake/systems/framework/cache.h"
+
+#include <memory>
+#include <stdexcept>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+class CacheTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ticket0_ = cache_.MakeCacheTicket({});
+    ticket1_ = cache_.MakeCacheTicket({ticket0_});
+    ticket2_ = cache_.MakeCacheTicket({ticket0_, ticket1_});
+
+    cache_.Init(ticket0_, PackValue(0));
+    cache_.Init(ticket1_, PackValue(1));
+    cache_.Init(ticket2_, PackValue(2));
+  }
+
+  std::unique_ptr<AbstractValue> PackValue(int value) {
+    return std::unique_ptr<AbstractValue>(new Value<int>(value));
+  }
+
+  int UnpackValue(const AbstractValue* value) {
+    return dynamic_cast<const Value<int>*>(value)->get_value();
+  }
+
+  Cache cache_;
+  CacheTicket ticket0_;
+  CacheTicket ticket1_;
+  CacheTicket ticket2_;
+};
+
+TEST_F(CacheTest, InitReturnsValue) {
+  CacheTicket ticket = cache_.MakeCacheTicket({});
+  AbstractValue* value = cache_.Init(ticket, PackValue(42));
+  EXPECT_EQ(42, UnpackValue(value));
+}
+
+TEST_F(CacheTest, GetReturnsValue) {
+  CacheTicket ticket = cache_.MakeCacheTicket({});
+  cache_.Init(ticket, PackValue(42));
+  const AbstractValue* value = cache_.Get(ticket);
+  EXPECT_EQ(42, UnpackValue(value));
+}
+
+TEST_F(CacheTest, InvalidationIsRecursive) {
+  cache_.Invalidate(ticket1_);
+  EXPECT_EQ(0, UnpackValue((cache_.Get(ticket0_))));
+  EXPECT_EQ(nullptr, cache_.Get(ticket1_));
+  EXPECT_EQ(nullptr, cache_.Get(ticket2_));
+}
+
+// Tests that all entries which depend on an entry that is Init are
+// invalidated.
+TEST_F(CacheTest, InitInvalidates) {
+  cache_.Init(ticket1_, PackValue(76));
+  EXPECT_EQ(0, UnpackValue((cache_.Get(ticket0_))));
+  EXPECT_EQ(76, UnpackValue(cache_.Get(ticket1_)));
+  EXPECT_EQ(nullptr, cache_.Get(ticket2_));
+}
+
+// Tests that all entries which depend on an entry that is Set are
+// invalidated.
+TEST_F(CacheTest, SetInvalidates) {
+  cache_.Set(ticket1_, 1024);
+  EXPECT_EQ(0, UnpackValue((cache_.Get(ticket0_))));
+  EXPECT_EQ(1024, UnpackValue(cache_.Get(ticket1_)));
+  EXPECT_EQ(nullptr, cache_.Get(ticket2_));
+}
+
+// Tests that a pointer to a cached value remains valid even after it is
+// invalidated. Only advanced, careful users should ever rely on this behavior!
+TEST_F(CacheTest, InvalidationIsNotDeletion) {
+  const AbstractValue* value = cache_.Get(ticket1_);
+  cache_.Invalidate(ticket1_);
+  EXPECT_EQ(nullptr, cache_.Get(ticket1_));
+  EXPECT_EQ(1, UnpackValue(value));
+}
+
+TEST_F(CacheTest, InvalidationDoesNotStopOnNullptr) {
+  cache_.Invalidate(ticket1_);
+  cache_.Init(ticket2_, PackValue(76));
+  cache_.Invalidate(ticket1_);
+  EXPECT_EQ(nullptr, cache_.Get(ticket2_));
+}
+
+TEST_F(CacheTest, Copy) {
+  Cache clone(cache_);
+  // The clone should have the same values.
+  EXPECT_EQ(0, UnpackValue((clone.Get(ticket0_))));
+  EXPECT_EQ(1, UnpackValue((clone.Get(ticket1_))));
+  EXPECT_EQ(2, UnpackValue((clone.Get(ticket2_))));
+
+  // The clone should have the same invalidation topology.
+  clone.Invalidate(ticket0_);
+  EXPECT_EQ(nullptr, clone.Get(ticket0_));
+  EXPECT_EQ(nullptr, clone.Get(ticket1_));
+  EXPECT_EQ(nullptr, clone.Get(ticket2_));
+
+  // Changes to the clone should not affect the original.
+  EXPECT_EQ(0, UnpackValue((cache_.Get(ticket0_))));
+  EXPECT_EQ(1, UnpackValue((cache_.Get(ticket1_))));
+  EXPECT_EQ(2, UnpackValue((cache_.Get(ticket2_))));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Systems can use the Cache (via their Context) to store and retrieve values that are expensive to compute, but must never rely on a particular value being present or valid in the Cache. This PR does not include any logic that actually invalidates Cache entries based on changes to the Context.

This is a partial resurrection of #3135.  Invalidation has been deferred to keep the delta manageable.  +@sherm1 for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3376)
<!-- Reviewable:end -->
