### PR TITLE
Return const SystemPortDescriptor<T>& from Declare*Port methods.

### DIFF
--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -340,15 +340,21 @@ class System {
 
   /// Adds a port with the specified @p type, @p size, and @p sampling
   /// to the input topology.
-  void DeclareInputPort(PortDataType type, int size, SamplingSpec sampling) {
-    input_ports_.emplace_back(this, kInputPort, get_num_input_ports(),
-                              kVectorValued, size, sampling);
+  /// @return descriptor of declared port.
+  const SystemPortDescriptor<T>& DeclareInputPort(PortDataType type, int size,
+                                                  SamplingSpec sampling) {
+    int port_number = get_num_input_ports();
+    input_ports_.emplace_back(this, kInputPort, port_number, kVectorValued,
+                              size, sampling);
+    return input_ports_.at(static_cast<size_t>(port_number));
   }
 
   /// Adds an abstract-valued port with the specified @p sampling to the
   /// input topology.
-  void DeclareAbstractInputPort(SamplingSpec sampling) {
-    DeclareInputPort(kAbstractValued, 0 /* size */, sampling);
+  /// @return descriptor of declared port.
+  const SystemPortDescriptor<T>& DeclareAbstractInputPort(
+      SamplingSpec sampling) {
+    return DeclareInputPort(kAbstractValued, 0 /* size */, sampling);
   }
 
   /// Adds a port with the specified @p descriptor to the output topology.
@@ -360,15 +366,21 @@ class System {
 
   /// Adds a port with the specified @p type, @p size, and @p sampling
   /// to the output topology.
-  void DeclareOutputPort(PortDataType type, int size, SamplingSpec sampling) {
-    output_ports_.emplace_back(this, kOutputPort, get_num_output_ports(),
-                               kVectorValued, size, sampling);
+  /// @return descriptor of declared port.
+  const SystemPortDescriptor<T>& DeclareOutputPort(PortDataType type, int size,
+                                                   SamplingSpec sampling) {
+    int port_number = get_num_output_ports();
+    output_ports_.emplace_back(this, kOutputPort, port_number, kVectorValued,
+                               size, sampling);
+    return output_ports_.at(static_cast<size_t>(port_number));
   }
 
   /// Adds an abstract-valued port with the specified @p sampling to the
   /// output topology.
-  void DeclareAbstractOutputPort(SamplingSpec sampling) {
-    DeclareOutputPort(kAbstractValued, 0 /* size */, sampling);
+  /// @return descriptor of declared port.
+  const SystemPortDescriptor<T>& DeclareAbstractOutputPort(
+      SamplingSpec sampling) {
+    return DeclareOutputPort(kAbstractValued, 0 /* size */, sampling);
   }
 
   /// Returns a mutable Eigen expression for a vector valued output port with

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -346,7 +346,7 @@ class System {
     int port_number = get_num_input_ports();
     input_ports_.emplace_back(this, kInputPort, port_number, kVectorValued,
                               size, sampling);
-    return input_ports_.at(static_cast<size_t>(port_number));
+    return input_ports_.back();
   }
 
   /// Adds an abstract-valued port with the specified @p sampling to the
@@ -372,7 +372,7 @@ class System {
     int port_number = get_num_output_ports();
     output_ports_.emplace_back(this, kOutputPort, port_number, kVectorValued,
                                size, sampling);
-    return output_ports_.at(static_cast<size_t>(port_number));
+    return output_ports_.back();
   }
 
   /// Adds an abstract-valued port with the specified @p sampling to the


### PR DESCRIPTION
Will allow simplifying the following pattern
```C++
int port_num = 0;
DeclareInputPort(...);
foo_port_ = get_input_port(port_num++);
DeclareInputPort(...);
bar_port_ = get_input_port(port_num);
```
to:
```C++
foo_port_ = DeclareInputPort(...);
bar_port_ = DeclareInputPort(...);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3378)
<!-- Reviewable:end -->
