### PR TITLE
Remove the deprecated contiguity assumption from VectorBase.

### DIFF
--- a/drake/examples/Cars/idm_with_trajectory_agent-inl.h
+++ b/drake/examples/Cars/idm_with_trajectory_agent-inl.h
@@ -35,7 +35,8 @@ void IdmWithTrajectoryAgent<T>::EvalOutput(
   DRAKE_ASSERT_VOID(systems::System<T>::CheckValidOutput(output));
 
   // Obtain the structure we need to write into.
-  systems::VectorBase<T>* const output_vector = output->GetMutableVectorData(0);
+  systems::BasicVector<T>* const output_vector =
+      output->GetMutableVectorData(0);
   DRAKE_ASSERT(output_vector != nullptr);
 
   // TODO(david-german-tri): Remove this copy by allowing output ports to be

--- a/drake/examples/Cars/simple_car-inl.h
+++ b/drake/examples/Cars/simple_car-inl.h
@@ -116,7 +116,8 @@ void SimpleCar<T>::EvalOutput(const systems::Context<T>& context,
   std::tie(state, input) = detail::ConvertContextToSystem1(context);
 
   // Obtain the structure we need to write into.
-  systems::VectorBase<T>* const output_vector = output->GetMutableVectorData(0);
+  systems::BasicVector<T>* const output_vector =
+      output->GetMutableVectorData(0);
   DRAKE_ASSERT(output_vector != nullptr);
 
   // Delegate to the System1 version of this block.

--- a/drake/examples/Cars/trajectory_car.h
+++ b/drake/examples/Cars/trajectory_car.h
@@ -111,7 +111,7 @@ class TrajectoryCar : public systems::LeafSystem<T> {
                   systems::SystemOutput<T>* output) const override {
     DRAKE_ASSERT(output != nullptr);
     DRAKE_ASSERT(output->get_num_ports() == 1);
-    systems::VectorBase<T>* output_vector =
+    systems::BasicVector<T>* output_vector =
         output->GetMutableVectorData(0);
     DRAKE_ASSERT(output_vector != nullptr);
 

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -41,7 +41,12 @@ class BasicVector : public VectorBase<T> {
     return vec;
   }
 
-  void set_value(const Eigen::Ref<const VectorX<T>>& value) override {
+  int size() const override { return static_cast<int>(values_.rows()); }
+
+  /// Sets the vector to the given value. After a.set_value(b.get_value()), a
+  /// must be identical to b.
+  /// Throws std::out_of_range if the new value has different dimensions.
+  void set_value(const Eigen::Ref<const VectorX<T>>& value) {
     if (value.rows() != values_.rows()) {
       throw std::out_of_range(
           "Cannot set a BasicVector of size " + std::to_string(values_.rows()) +
@@ -50,13 +55,14 @@ class BasicVector : public VectorBase<T> {
     values_ = value;
   }
 
-  int size() const override { return static_cast<int>(values_.rows()); }
-
-  Eigen::VectorBlock<const VectorX<T>> get_value() const override {
+  /// Returns the entire vector as a const Eigen::VectorBlock.
+  Eigen::VectorBlock<const VectorX<T>> get_value() const {
     return values_.head(values_.rows());
   }
 
-  Eigen::VectorBlock<VectorX<T>> get_mutable_value() override {
+  /// Returns the entire vector as a mutable Eigen::VectorBlock, which allows
+  /// mutation of the values, but does not allow resizing the vector itself.
+  Eigen::VectorBlock<VectorX<T>> get_mutable_value() {
     return values_.head(values_.rows());
   }
 

--- a/drake/systems/framework/primitives/test/pid_controller_test.cc
+++ b/drake/systems/framework/primitives/test/pid_controller_test.cc
@@ -71,8 +71,8 @@ TEST_F(PidControllerTest, EvalOutput) {
   controller_.SetDefaultState(context_.get());
   controller_.EvalOutput(*context_, output_.get());
   ASSERT_EQ(1, output_->get_num_ports());
-  const VectorBase<double>* output_vector = output_->get_vector_data(0);
-  EXPECT_EQ(3, output_vector->get_value().rows());
+  const BasicVector<double>* output_vector = output_->get_vector_data(0);
+  EXPECT_EQ(3, output_vector->size());
   EXPECT_EQ(kp_ * error_signal_ + kd_ * error_rate_signal_,
             output_vector->get_value());
 

--- a/drake/systems/framework/state_subvector.h
+++ b/drake/systems/framework/state_subvector.h
@@ -16,7 +16,7 @@ namespace systems {
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
 template <typename T>
-class StateSubvector : public StateVector<T> {
+class StateSubvector : public VectorBase<T> {
  public:
   /// Constructs a subvector of vector that consists of num_elements starting
   /// at first_element.

--- a/drake/systems/framework/state_supervector.h
+++ b/drake/systems/framework/state_supervector.h
@@ -19,7 +19,7 @@ namespace systems {
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
 template <typename T>
-class StateSupervector : public StateVector<T> {
+class StateSupervector : public VectorBase<T> {
  public:
   /// Constructs a supervector consisting of all the vectors in
   /// subvectors, which must live at least as long as this supervector.

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -134,7 +134,7 @@ class System {
   Eigen::VectorBlock<const VectorX<T>> get_input_vector(
       const Context<T>& context, int port_index) const {
     DRAKE_ASSERT(0 <= port_index && port_index < get_num_input_ports());
-    const VectorBase<T>* input_vector =
+    const BasicVector<T>* input_vector =
         context.get_vector_input(port_index);
 
     DRAKE_ASSERT(input_vector != nullptr);
@@ -379,8 +379,7 @@ class System {
                                                         int port_index) const {
     DRAKE_ASSERT(0 <= port_index && port_index < get_num_output_ports());
 
-    VectorBase<T>* output_vector = output->
-        get_mutable_port(port_index)->template GetMutableVectorData<T>();
+    BasicVector<T>* output_vector = output->GetMutableVectorData(port_index);
     DRAKE_ASSERT(output_vector != nullptr);
     DRAKE_ASSERT(output_vector->size() ==
         get_output_port(port_index).get_size());

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -400,8 +400,8 @@ GTEST_TEST(DiagramSubclassTest, TwelvePlusSevenIsNineteen) {
   plus_seven.EvalOutput(*context, output.get());
 
   ASSERT_EQ(1, output->get_num_ports());
-  const VectorBase<double>* output_vector = output->get_vector_data(0);
-  EXPECT_EQ(1, output_vector->get_value().rows());
+  const BasicVector<double>* output_vector = output->get_vector_data(0);
+  EXPECT_EQ(1, output_vector->size());
   EXPECT_EQ(19.0, output_vector->get_value().x());
 }
 

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -12,32 +12,19 @@ namespace drake {
 namespace systems {
 
 /// VectorBase is a pure abstract interface that real-valued signals
-/// between Systems must satisfy. Classes that inherit from VectorBase
-/// will typically provide names for the elements of the vector, and may also
-/// provide other computations for the convenience of Systems handling the
-/// signal. The vector is always a column vector.
+/// between Systems and real-valued System state vectors must satisfy.
+/// Classes that inherit from VectorBase will typically provide names
+/// for the elements of the vector, and may also provide other
+/// computations for the convenience of Systems handling the
+/// signal. The vector is always a column vector. It may or may not
+/// be contiguous in memory. Contiguous subclasses should typically
+/// inherit from BasicVector, not from VectorBase directly.
 ///
 /// @tparam T Must be a Scalar compatible with Eigen.
 template <typename T>
 class VectorBase : public StateVector<T> {
  public:
   virtual ~VectorBase() {}
-
-  /// Sets the vector to the given value. After a.set_value(b.get_value()), a
-  /// must be identical to b.
-  /// May throw std::out_of_range if the new value has different dimensions
-  /// than expected by the concrete class implementing VectorBase.
-  DRAKE_DEPRECATED("Use SetFromVector instead.")
-  virtual void set_value(const Eigen::Ref<const VectorX<T>>& value) = 0;
-
-  /// Returns a column vector containing the entire value of the signal.
-  DRAKE_DEPRECATED("Use a narrower accessor, or BasicVector if you can.")
-  virtual Eigen::VectorBlock<const VectorX<T>> get_value() const = 0;
-
-  /// Returns a reference that allows mutation of the values in this vector, but
-  /// does not allow resizing the vector itself.
-  DRAKE_DEPRECATED("Use SetAtIndex instead, or add a new operator.")
-  virtual Eigen::VectorBlock<VectorX<T>> get_mutable_value() = 0;
 
   // VectorBase objects are neither copyable nor moveable.
   VectorBase(const VectorBase<T>& other) = delete;

--- a/drake/systems/lcm/translator_between_lcmt_drake_signal.cc
+++ b/drake/systems/lcm/translator_between_lcmt_drake_signal.cc
@@ -40,13 +40,11 @@ void TranslatorBetweenLcmtDrakeSignal::TranslateLcmToVectorBase(
       ") is not equal to the size of the vector vector (" +
       std::to_string(vector_base->size()) + ").");
   }
-  Eigen::VectorBlock<VectorX<double>> vector_base_value =
-    vector_base->get_mutable_value();
 
   // Saves the values in from the LCM message into the basic vector.
   // Assumes that the order of the values in both vectors are identical.
   for (int ii = 0; ii < message.dim; ++ii) {
-    vector_base_value[ii] = message.val[ii];
+    vector_base->SetAtIndex(ii, message.val[ii]);
   }
 }
 
@@ -63,11 +61,8 @@ void TranslatorBetweenLcmtDrakeSignal::TranslateVectorBaseToLcm(
   message.val.resize(message.dim);
   message.coord.resize(message.dim);
 
-  Eigen::VectorBlock<const VectorX<double>> values =
-      vector_base.get_value();
-
   for (int ii = 0; ii < message.dim; ++ii) {
-    message.val[ii] = values[ii];
+    message.val[ii] = vector_base.GetAtIndex(ii);
   }
 
   const int lcm_message_length = message.getEncodedSize();


### PR DESCRIPTION
Update Subvector and Supervector to inherit from VectorBase.  Contributes to #3208.

+@jwnimmer-tri for both levels of review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3390)
<!-- Reviewable:end -->
