### PR TITLE
Don't use GTK POD wrapper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "externals/googletest"]
 	path = externals/googletest
 	url = https://github.com/google/googletest.git
-[submodule "externals/gtk"]
-	path = externals/gtk
-	url = https://github.com/RobotLocomotion/gtk-pod.git
 [submodule "externals/lcm"]
 	path = externals/lcm
 	url = https://github.com/lcm-proj/lcm.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,12 +216,17 @@ if(WIN32)
 
  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(gtk_build 3.6.4-20131201_win64)
+    set(gtk_sha
+      97440094ceb6c42258637e75d6d576a12c173bae19a581901f7f053156c9ccbf)
   else()
     set(gtk_build 3.6.4-20130921_win32)
+    set(gtk_sha
+      1c1a6019746ae58c6a112e59c6b50463b838900d2244c494d94dea8ebea0f715)
   endif()
 
   drake_add_external(gtk PUBLIC
     URL http://win32builder.gnome.org/gtk+-bundle_${gtk_build}.zip
+    URL_SHA 256=${gtk_sha}
     BUILD_COMMAND :
     INSTALL_COMMAND :)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,13 +214,23 @@ if(WIN32)
       INSTALL_COMMAND ${lcm_BUILD_COMMAND} --target install)
   endif()
 
-  drake_add_external(gtk PUBLIC CMAKE)
+ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(gtk_build 3.6.4-20131201_win64)
+  else()
+    set(gtk_build 3.6.4-20130921_win32)
+  endif()
+
+  drake_add_external(gtk PUBLIC
+    URL http://win32builder.gnome.org/gtk+-bundle_${gtk_build}.zip
+    BUILD_COMMAND :
+    INSTALL_COMMAND :)
+
   drake_add_external(lcm PUBLIC CMAKE
     ${lcm_FORCE_RELEASE_BUILD_COMMANDS}
     CMAKE_ARGS
       -DBUILD_SHARED_LIBS=ON # Because LCM has no ABI decoration
       -DCMAKE_BUILD_TYPE=Release # See above
-      -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_SOURCE_DIR}/externals/gtk/gtk3
+      -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_SOURCE_DIR}/externals/gtk
     DEPENDS gtk)
 else()
   drake_add_external(lcm PUBLIC CMAKE

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -239,6 +239,9 @@ endmacro()
 #       Specifies a URL of a source package (zip file, tarball) to be
 #       downloaded. Implies that the external is not a submodule.
 #
+#  URL_SHA <size>=<hash>
+#       Specifies the expected SHA hash of the downloaded package.
+#
 #   REQUIRES <deps...>
 #       List of packages (checked via `find_package`) that are required to
 #       build the external. Only checked if the external will be built.
@@ -283,6 +286,7 @@ function(drake_add_external PROJECT)
     SOURCE_DIR
     BINARY_DIR
     URL
+    URL_SHA
   )
   set(_ext_mv_args
     CMAKE_ARGS
@@ -358,6 +362,10 @@ function(drake_add_external PROJECT)
   if(DEFINED _ext_URL)
     set(_ext_DOWNLOAD_AND_UPDATE_COMMANDS
       URL "${_ext_URL}")
+    if(DEFINED _ext_URL_SHA)
+      list(APPEND _ext_DOWNLOAD_AND_UPDATE_COMMANDS
+        URL_HASH "SHA${_ext_URL_SHA}")
+    endif()
   else()
     # Manage updates to the submodule
     if(NOT _ext_LOCAL)

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -174,8 +174,7 @@ macro(drake_add_cmake_external PROJECT)
     SOURCE_DIR ${_ext_SOURCE_DIR}
     BINARY_DIR ${_ext_BINARY_DIR}
     DOWNLOAD_DIR ${PROJECT_SOURCE_DIR}
-    DOWNLOAD_COMMAND ${_ext_DOWNLOAD_COMMAND}
-    UPDATE_COMMAND ${_ext_UPDATE_COMMAND}
+    ${_ext_DOWNLOAD_AND_UPDATE_COMMANDS}
     ${_ext_EXTRA_COMMANDS}
     INDEPENDENT_STEP_TARGETS update
     BUILD_ALWAYS 1
@@ -217,8 +216,7 @@ macro(drake_add_foreign_external PROJECT)
     SOURCE_DIR ${_ext_SOURCE_DIR}
     BINARY_DIR ${_ext_BINARY_DIR}
     DOWNLOAD_DIR ${PROJECT_SOURCE_DIR}
-    DOWNLOAD_COMMAND "${_ext_DOWNLOAD_COMMAND}"
-    UPDATE_COMMAND "${_ext_UPDATE_COMMAND}"
+    ${_ext_DOWNLOAD_AND_UPDATE_COMMANDS}
     PATCH_COMMAND "${_ext_PATCH_COMMAND}"
     CONFIGURE_COMMAND "${_ext_CONFIGURE_COMMAND}"
     BUILD_COMMAND "${_ext_BUILD_COMMAND}"
@@ -236,6 +234,10 @@ endmacro()
 #   PUBLIC - External is public
 #   CMAKE  - External uses CMake
 #   ALWAYS - External is always built
+#
+#   URL <url>
+#       Specifies a URL of a source package (zip file, tarball) to be
+#       downloaded. Implies that the external is not a submodule.
 #
 #   REQUIRES <deps...>
 #       List of packages (checked via `find_package`) that are required to
@@ -280,6 +282,7 @@ function(drake_add_external PROJECT)
     SOURCE_SUBDIR
     SOURCE_DIR
     BINARY_DIR
+    URL
   )
   set(_ext_mv_args
     CMAKE_ARGS
@@ -352,19 +355,28 @@ function(drake_add_external PROJECT)
       "Preparing to build ${PROJECT} with dependencies ${_ext_deps}")
   endif()
 
-  # Manage updates to the submodule
-  if(NOT _ext_LOCAL)
-    # Compute the path to the submodule for this external
-    file(RELATIVE_PATH _ext_GIT_SUBMODULE_PATH
-      ${PROJECT_SOURCE_DIR} ${_ext_SOURCE_DIR})
-
-    # Set up submodule and commands for synchronizing submodule
-    drake_add_submodule(${_ext_GIT_SUBMODULE_PATH}
-      _ext_DOWNLOAD_COMMAND _ext_UPDATE_COMMAND)
+  if(DEFINED _ext_URL)
+    set(_ext_DOWNLOAD_AND_UPDATE_COMMANDS
+      URL "${_ext_URL}")
   else()
-    # Local "externals" have no download or update step
-    set(_ext_DOWNLOAD_COMMAND "")
-    set(_ext_UPDATE_COMMAND "")
+    # Manage updates to the submodule
+    if(NOT _ext_LOCAL)
+      # Compute the path to the submodule for this external
+      file(RELATIVE_PATH _ext_GIT_SUBMODULE_PATH
+        ${PROJECT_SOURCE_DIR} ${_ext_SOURCE_DIR})
+
+      # Set up submodule and commands for synchronizing submodule
+      drake_add_submodule(${_ext_GIT_SUBMODULE_PATH}
+        _ext_DOWNLOAD_COMMAND _ext_UPDATE_COMMAND)
+    else()
+      # Local "externals" have no download or update step
+      set(_ext_DOWNLOAD_COMMAND "")
+      set(_ext_UPDATE_COMMAND "")
+    endif()
+
+    set(_ext_DOWNLOAD_AND_UPDATE_COMMANDS
+      DOWNLOAD_COMMAND "${_ext_DOWNLOAD_COMMAND}"
+      UPDATE_COMMAND "${_ext_UPDATE_COMMAND}")
   endif()
 
   # Add the external project
@@ -375,7 +387,7 @@ function(drake_add_external PROJECT)
     drake_add_foreign_external(${PROJECT})
   endif()
 
-  if(NOT _ext_LOCAL)
+  if(NOT _ext_LOCAL AND NOT DEFINED _ext_URL)
     # Set up build step to ensure project is updated before build
     drake_forceupdate(${PROJECT})
 


### PR DESCRIPTION
Teach `drake_add_external` to support externals downloaded from packages, and hash checking of same, in addition to submodules. Leverage this to directly download and unpack GTK rather than using the "POD" wrapper.

Fixes #3330.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3392)
<!-- Reviewable:end -->
