### PR TITLE
Add spdlog tracing to lcm publish and subscribe

### DIFF
--- a/drake/common/text_logging.cc
+++ b/drake/common/text_logging.cc
@@ -15,7 +15,10 @@ std::shared_ptr<logging::logger>* onetime_create_log() {
   std::shared_ptr<logging::logger>* result =
       new std::shared_ptr<logging::logger>(spdlog::get("console"));
   if (!*result) {
-    *result = spdlog::stderr_logger_st("console");
+    // We use the logger_mt (instead of logger_st) so more than one thread can
+    // use this logger and have their messages be staggered by line, instead of
+    // co-mingling their character bytes.
+    *result = spdlog::stderr_logger_mt("console");
   }
   return result;
 }

--- a/drake/systems/lcm/lcm_publisher_system.cc
+++ b/drake/systems/lcm/lcm_publisher_system.cc
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "drake/common/text_logging.h"
 #include "drake/systems/framework/system_input.h"
 
 namespace drake {
@@ -36,6 +37,8 @@ std::string LcmPublisherSystem::get_name() const {
 }
 
 void LcmPublisherSystem::DoPublish(const Context<double>& context) const {
+  SPDLOG_TRACE(drake::log(), "Publishing LCM {} message", channel_);
+
   // Obtains the input vector.
   const VectorBase<double>* const input_vector =
       context.get_vector_input(kPortIndex);

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_output.h"
 
@@ -65,6 +66,8 @@ std::unique_ptr<BasicVector<double>> LcmSubscriberSystem::AllocateOutputVector(
 
 void LcmSubscriberSystem::HandleMessage(const ::lcm::ReceiveBuffer* rbuf,
                                         const std::string& channel) {
+  SPDLOG_TRACE(drake::log(), "Receiving LCM {} message", channel);
+
   if (channel == channel_) {
     const uint8_t* const rbuf_begin =
         reinterpret_cast<const uint8_t*>(rbuf->data);


### PR DESCRIPTION
This was useful in debugging Simulator 2.0 for Cars work.

In general, I think logging into structured channels (LCM is what we have, for now) is vastly better than logging to the console.  But when the LCM channel isn't working, the console is a nice fallback.  Thus, I think we should have tracing of LCM on master for everyone to use.  More "_trace all the things_" statements in non-LCM code are _not_ something I'd recommend, although YMMV.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3395)
<!-- Reviewable:end -->
