### PR TITLE
Fixed Center Of Mass modeling of Extra Heavy Duty Table

### DIFF
--- a/drake/examples/kuka_iiwa_arm/models/README.md
+++ b/drake/examples/kuka_iiwa_arm/models/README.md
@@ -1,9 +1,9 @@
 # How To Load Models into Gazebo
 
 The models in this folder contain `model.config` files that allow you to easily
-load the them into Gazebo. This is useful for viewing and debugging purposes. To
-do this, first add the directory containing this README to environment variable
-`GAZEBO_MODEL_PATH`.
+load them into Gazebo. This is useful for viewing and debugging purposes. To do
+this, first add the directory containing this README to environment variable
+`GAZEBO_MODEL_PATH`. This can be done by executing the following commands:
 
     $ cd drake-distro/drake/examples/kuka_iiwa_arm/models
     $ export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:`pwd`
@@ -12,6 +12,6 @@ Next start Gazebo:
 
     $ gazebo
 
-Finally, in the left panel of Gazebo's GUI, click on the "Insert" tab, then
-left-click on the model you want to add, then left-click on the location in the
+Finally, in the left panel of Gazebo's GUI, click on the "Insert" tab.
+Left-click on the model you want to add, then left-click on the location in the
 simulated world where you would like the model to be placed.

--- a/drake/examples/kuka_iiwa_arm/models/README.md
+++ b/drake/examples/kuka_iiwa_arm/models/README.md
@@ -1,0 +1,17 @@
+# How To Load Models into Gazebo
+
+The models in this folder contain `model.config` files that allow you to easily
+load the them into Gazebo. This is useful for viewing and debugging purposes. To
+do this, first add the directory containing this README to environment variable
+`GAZEBO_MODEL_PATH`.
+
+    $ cd drake-distro/drake/examples/kuka_iiwa_arm/models
+    $ export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:`pwd`
+
+Next start Gazebo:
+
+    $ gazebo
+
+Finally, in the left panel of Gazebo's GUI, click on the "Insert" tab, then
+left-click on the model you want to add, then left-click on the location in the
+simulated world where you would like the model to be placed.

--- a/drake/examples/kuka_iiwa_arm/models/desk/model.config
+++ b/drake/examples/kuka_iiwa_arm/models/desk/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Transcendesk Standing Desk - 55"</name>
+  <version>1.0</version>
+  <sdf version="1.6">transcendesk55inch.sdf</sdf>
+
+  <author>
+    <name>Lucy</name>
+    <email>drake-users@mit.edu</email>
+  </author>
+
+  <description>
+    A model of the Transcendesk® Standing Desk - 55 inch Long.
+  </description>
+</model>

--- a/drake/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table.sdf
+++ b/drake/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table.sdf
@@ -1,22 +1,39 @@
 <?xml version='1.0'?>
 <sdf version='1.6'>
+  <!--
+  This is a model of the following table: http://www.mcmaster.com/#8020T32.
+
+  The table is oriented such that its X axis is parallel with the table's depth,
+  the Y axis is parallel with the table's width, and its Z axis is parallel with
+  the table's height.
+
+  Its dimensions are:
+    - width (length along Y axis):  30" (0.762 m)
+    - depth (length along X axis):  28" (0.7112 m)
+    - height (length along Z axis): 30" (0.762 m)
+  -->
   <model name='extra_heavy_duty_table'>
     <link name='link'>
-      <pose frame=''>-0.243716 -0.625087 0 0 -0 0</pose>
+      <pose>-0.243716 -0.625087 0.381 0 0 0</pose>
       <inertial>
         <mass>53.5</mass>
-        <pose frame=''>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <!--
         The spatial inertia values given below were derived based on the
         equation for a cuboid:
 
         https://en.wikipedia.org/wiki/List_of_moments_of_inertia#List_of_3D_inertia_tensors.
 
-        Obviously, the table is not a cuboid, meaning the inertia matrix is
-        imperfect. Having an accurate spatial inertia specification may be
-        important for us to know when / if a robot mounted on top of the
-        table will cause the table to tip over. It will also be necessary to
-        model what happens when a mobile robot bumps into the table.
+        It can be computed by executing the following commands:
+
+        $ cd drake-distro/drake/common/spatial_inertia_calculators
+        $ ./spatial_inertia_solid_cuboid.py 0.7112 0.762 0.762 53.5
+
+        Obviously, the table is not a cuboid meaning the spatial inertia matrix
+        is imperfect. Having accurate spatial inertia information may be
+        important for us to know when a robot mounted on top of the table will
+        cause the table to tip over. It will also be necessary to model what
+        happens when a mobile robot bumps into the table.
 
         TODO(lucy-tri): Compute a more accurate spatial inertia of this table.
         -->
@@ -32,7 +49,7 @@
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name='back_right_leg'>
-        <pose frame=''>-0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 -0.35 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -55,7 +72,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name='front_left_leg'>
-        <pose frame=''>0.33 0.35 0.381 0 -0 0</pose>
+        <pose>0.33 0.35 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -78,7 +95,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name='left_crossbar'>
-        <pose frame=''>0.33 0 0.13335 0 -0 0</pose>
+        <pose>0.33 0 -0.24765 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -101,7 +118,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name='right_crossbar'>
-        <pose frame=''>-0.33 0 0.13335 0 -0 0</pose>
+        <pose>-0.33 0 -0.24765 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -124,7 +141,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name='back_left_leg'>
-        <pose frame=''>-0.33 0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 0.35 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -147,7 +164,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name='front_right_leg'>
-        <pose frame=''>0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>0.33 -0.35 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -170,7 +187,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name='back_crossbar'>
-        <pose frame=''>0 0.35 0.13335 0 -0 0</pose>
+        <pose>0 0.35 -0.24765 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -193,7 +210,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name='front_crossbar'>
-        <pose frame=''>0 -0.35 0.13335 0 -0 0</pose>
+        <pose>0 -0.35 -0.24765 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -216,7 +233,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name='visual1'>
-        <pose frame=''>0 0 0.736 0 -0 0</pose>
+        <pose>0 0 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.7112 0.762 0.057</size>
@@ -241,7 +258,7 @@
       <collision name='front_crossbar'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>0 -0.35 0.13335 0 -0 0</pose>
+        <pose>0 -0.35 -0.24765 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -296,7 +313,7 @@
       <collision name='back_crossbar'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>0 0.35 0.13335 0 -0 0</pose>
+        <pose>0 0.35 -0.24765 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -351,7 +368,7 @@
       <collision name='left_crossbar'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>0.33 0 0.13335 0 -0 0</pose>
+        <pose>0.33 0 -0.24765 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -406,7 +423,7 @@
       <collision name='right_crossbar'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>-0.33 0 0.13335 0 -0 0</pose>
+        <pose>-0.33 0 -0.24765 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -461,7 +478,7 @@
       <collision name='back_right_leg'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>-0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 -0.35 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -516,7 +533,7 @@
       <collision name='front_left_leg'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>0.33 0.35 0.381 0 -0 0</pose>
+        <pose>0.33 0.35 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -571,7 +588,7 @@
       <collision name='back_left_leg'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>-0.33 0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 0.35 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -626,7 +643,7 @@
       <collision name='front_right_leg'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>0.33 -0.35 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -681,7 +698,7 @@
       <collision name='surface'>
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame=''>0 0 0.736 0 -0 0</pose>
+        <pose>0 0 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.7112 0.762 0.057</size>

--- a/drake/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table.sdf
+++ b/drake/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table.sdf
@@ -3,9 +3,10 @@
   <!--
   This is a model of the following table: http://www.mcmaster.com/#8020T32.
 
-  The table is oriented such that its X axis is parallel with the table's depth,
-  the Y axis is parallel with the table's width, and its Z axis is parallel with
-  the table's height.
+  The table model's frame is oriented such that Z is positive up. Suppose you're
+  facing the "front" edge of the table that is 28" wide with its positive Z axis
+  pointing up, the positive X axis will be pointing towards you and the
+  positive Y axis will be pointing to your right.
 
   Its dimensions are:
     - width (length along Y axis):  30" (0.762 m)
@@ -23,11 +24,6 @@
         equation for a cuboid:
 
         https://en.wikipedia.org/wiki/List_of_moments_of_inertia#List_of_3D_inertia_tensors.
-
-        It can be computed by executing the following commands:
-
-        $ cd drake-distro/drake/common/spatial_inertia_calculators
-        $ ./spatial_inertia_solid_cuboid.py 0.7112 0.762 0.762 53.5
 
         Obviously, the table is not a cuboid meaning the spatial inertia matrix
         is imperfect. Having accurate spatial inertia information may be

--- a/drake/examples/kuka_iiwa_arm/models/table/model.config
+++ b/drake/examples/kuka_iiwa_arm/models/table/model.config
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Extra Heavy Duty Table</name>
+  <version>1.0</version>
+  <sdf version="1.6">extra_heavy_duty_table.sdf</sdf>
+
+  <author>
+    <name>Lucy</name>
+    <email>drake-users@mit.edu</email>
+  </author>
+
+  <description>
+    A model of the following table:
+    http://www.mcmaster.com/#8020T32
+  </description>
+</model>


### PR DESCRIPTION
This fixes the center of mass modeling of the extra heavy duty table. The version in master has the center of mass sitting on the ground:

![screenshot from 2016-09-08 20 42 04](https://cloud.githubusercontent.com/assets/1388098/18371726/c027c158-7604-11e6-8b74-7728ea048a7a.png)

The version in this PR has the center of mass in the middle of the table, which is expected given the spatial inertia equation that was employed.

![table_collision_model_and_com](https://cloud.githubusercontent.com/assets/1388098/18371691/589e817a-7604-11e6-99e6-35c7cc6ddb46.png)

I also added `model.config` files and a README that informs users of how to load the models into Gazebo, which is useful for testing and debugging purposes.

This PR requires that #3387 be merged first since it references the cuboid spatial inertia calculator.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3396)

<!-- Reviewable:end -->
