### PR TITLE
Fix up lots and lots of broken paths in Cars demo

### DIFF
--- a/drake/examples/Cars/README.md
+++ b/drake/examples/Cars/README.md
@@ -19,7 +19,7 @@ To run the Drake Visualizer, open a terminal and execute the following commands:
 
 ```
 $ cd [drake-distro]/drake/examples/Cars
-$ ../../../build/bin/drake-visualizer
+$ ../../../build/install/bin/drake-visualizer
 ```
 
 The Drake Visualizer window should appear.
@@ -44,13 +44,6 @@ $ brew install pygame
 $ apt-get install python-pygame
 ```
 
-To run the Steering Command Driver, first update your `PYTHONPATH` environment
-variable to include Drake's libraries:
-
-```
-$ export PYTHONPATH="[path to drake-distro]/build/lib/python2.7/dist-packages:[path to drake-distro]/build/lib/python2.7/site-packages:$PYTHONPATH"
-```
-
 Then execute:
 
 ```
@@ -72,7 +65,7 @@ To start the simulation, open a new terminal and execute the following:
 
 ```
 $ cd [drake-distro]/drake/examples/Cars
-$ ../../pod-build/bin/car_sim_lcm models/prius/prius.urdf models/stata_garage_p1.sdf
+$ ../../../build/drake/bin/car_sim_lcm models/prius/prius.urdf models/stata_garage_p1.sdf
 ```
 
 ### Simulation Using Drake + LCM + ROS
@@ -101,7 +94,7 @@ If you are unable to run the Steering Command Driver, you can generate simple
 throttle and steering commands using the command line:
 
 ```
-$ cd [path to drake-distro]/drake/examples/Cars
+$ cd [drake-distro]/drake/examples/Cars
 $ python steering_command_driver.py --mode=one-time --throttle=[throttle_value] --steering-angle=[steering_value]
 ```
 where the values in square brackets should be replaced with desired values.
@@ -109,7 +102,7 @@ where the values in square brackets should be replaced with desired values.
 For example:
 
 ```
-$ cd [path to drake-distro]/drake/examples/Cars
+$ cd [drake-distro]/drake/examples/Cars
 $ python steering_command_driver.py --mode=one-time --throttle=1.0 --steering-angle=0.4
 ```
 

--- a/drake/examples/Cars/run_demo_multi_car.sh
+++ b/drake/examples/Cars/run_demo_multi_car.sh
@@ -23,12 +23,16 @@ me=$(readlink -f $0)
 mydir=$(dirname $0)
 DRAKE=$(readlink -f $mydir/../..)
 DRAKE_DIST=$(readlink -f $DRAKE/..)
-DRAKE_BUILD=${DRAKE_BUILD:-$DRAKE_DIST/build}
+DRAKE_DIST_BUILD=${DRAKE_DIST_BUILD:-$DRAKE_DIST/build}
+if ! [ -d $DRAKE_DIST_BUILD/install/bin ]; then
+    echo "error: $0: cannot find DRAKE_DIST_BUILD at '$DRAKE_DIST_BUILD'"
+    exit 1
+fi
 
-$DRAKE_BUILD/install/bin/bot-spy &
-$DRAKE_BUILD/install/bin/drake-visualizer &
+$DRAKE_DIST_BUILD/install/bin/bot-spy &
+$DRAKE_DIST_BUILD/install/bin/drake-visualizer &
 sleep 1  # Wait, to be sure drake-visualizer sees the load_robot message.
-$DRAKE_BUILD/drake/bin/demo_multi_car $1 &
+$DRAKE_DIST_BUILD/drake/bin/demo_multi_car $1 &
 
 wait
 

--- a/drake/examples/Cars/simple_car_demo.sh
+++ b/drake/examples/Cars/simple_car_demo.sh
@@ -21,13 +21,17 @@ me=$(readlink -f $0)
 mydir=$(dirname $0)
 DRAKE=$(readlink -f $mydir/../..)
 DRAKE_DIST=$(readlink -f $DRAKE/..)
-DRAKE_BUILD=${DRAKE_BUILD:-$DRAKE_DIST/build}
+DRAKE_DIST_BUILD=${DRAKE_DIST_BUILD:-$DRAKE_DIST/build}
+if ! [ -d $DRAKE_DIST_BUILD/install/bin ]; then
+    echo "error: $0: cannot find DRAKE_DIST_BUILD at '$DRAKE_DIST_BUILD'"
+    exit 1
+fi
 
-$DRAKE_BUILD/install/bin/lcm-logger &
-$DRAKE_BUILD/install/bin/bot-spy &
-$DRAKE_BUILD/install/bin/drake-visualizer &
+$DRAKE_DIST_BUILD/install/bin/lcm-logger &
+$DRAKE_DIST_BUILD/install/bin/bot-spy &
+$DRAKE_DIST_BUILD/install/bin/drake-visualizer &
 sleep 1  # Wait, to be sure drake-visualizer sees the load_robot message.
-$DRAKE_BUILD/drake/bin/simple_car_demo &
+$DRAKE_DIST_BUILD/drake/bin/simple_car_demo &
 $mydir/steering_command_driver.py &
 
 wait

--- a/drake/examples/Cars/steering_command_driver.py
+++ b/drake/examples/Cars/steering_command_driver.py
@@ -7,6 +7,7 @@ import argparse
 import copy
 import math
 import os
+import subprocess
 import sys
 
 try:
@@ -19,15 +20,35 @@ THIS_FILE = os.path.abspath(__file__)
 THIS_DIR = os.path.dirname(THIS_FILE)
 DRAKE_DIR = os.path.dirname(os.path.dirname(THIS_DIR))
 DRAKE_DIST_DIR = os.path.dirname(DRAKE_DIR)
+DRAKE_DIST_BUILD_DIR = os.getenv(
+    'DRAKE_DIST_BUILD',
+    os.path.join(DRAKE_DIST_DIR, 'build'))
 DRAKE_LCMTYPES_DIR = os.path.join(
-    DRAKE_DIR, "pod-build/lcmgen/lcmtypes")
-DRAKE_PYTHON_DIR = os.path.join(DRAKE_DIST_DIR, "build/lib/python2.7")
+    DRAKE_DIST_BUILD_DIR, 'drake/lcmtypes')
+DRAKE_PYTHON_DIR = os.path.join(DRAKE_DIST_BUILD_DIR, 'install/lib/python2.7')
 sys.path.extend([
     DRAKE_LCMTYPES_DIR,  # First (to pick up local edits to messages).
-    os.path.join(DRAKE_PYTHON_DIR, "dist-packages"),
-    os.path.join(DRAKE_PYTHON_DIR, "site-packages")])
+    os.path.join(DRAKE_PYTHON_DIR, 'dist-packages'),
+    os.path.join(DRAKE_PYTHON_DIR, 'site-packages')])
 
-import lcm
+try:
+    import lcm
+except ImportError as e:
+    # TODO(#3397) This whole mess shouldn't be necessary.
+    disable_retry_flag = 'IMPORT_LCM_DISABLE_RETRY'
+    if ('cannot open shared object file' in e.message and
+        disable_retry_flag not in os.environ):
+        print 'warning:', e.message, '(will retry now)'
+        LD_LIBRARY_PATH = ':'.join([
+            os.path.join(DRAKE_DIST_BUILD_DIR, 'install/lib'),
+            os.getenv('LD_LIBRARY_PATH', default='')])
+        new_env = dict(os.environ)
+        new_env['LD_LIBRARY_PATH'] = LD_LIBRARY_PATH
+        new_env[disable_retry_flag] = '1'
+        sys.exit(subprocess.call(
+            [sys.executable] + sys.argv,
+            env=new_env))
+    raise
 
 from drake.lcmt_driving_command_t import lcmt_driving_command_t as lcm_msg
 


### PR DESCRIPTION
The build system evolved out from underneath the Cars demos.  I believe this restores the documentation and tools to working order.

Of course we should soon add better tests to catch this earlier next time, but for now this is just "recover the ground you've lost" and not "hold your ground for the future".

This also contains a work-around for #3397.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3403)
<!-- Reviewable:end -->
