### PR TITLE
Add eigen_stl_types.h and BodyToWrenchMap

### DIFF
--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -28,6 +28,7 @@ set(installed_headers
   drake_path.h
   drake_throw.h
   eigen_autodiff_types.h
+  eigen_stl_types.h
   eigen_types.h
   functional_form.h
   nice_type_name.h

--- a/drake/common/eigen_stl_types.h
+++ b/drake/common/eigen_stl_types.h
@@ -1,0 +1,20 @@
+#pragma once
+
+/// @file
+/// This file contains definitions for using Eigen with the STL.
+/// @see eigen_types.h
+
+#include <unordered_map>
+
+#include <Eigen/Core>
+
+namespace drake {
+
+/// A std::unordered_map that uses Eigen::aligned_allocator, so that the
+/// contained types may be fixed-size Eigen values.
+template <typename Key, typename T>
+using eigen_aligned_std_unordered_map =
+    std::unordered_map<Key, T, std::hash<Key>, std::equal_to<Key>,
+                       Eigen::aligned_allocator<std::pair<Key const, T>>>;
+
+}  // namespace drake

--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -73,4 +73,8 @@ using TwistMatrix = Eigen::Matrix<Scalar, kTwistSize, Eigen::Dynamic>;
 template <typename Scalar>
 using SquareTwistMatrix = Eigen::Matrix<Scalar, kTwistSize, kTwistSize>;
 
+/// A column vector consisting of one wrench.
+template <typename Scalar>
+using WrenchVector = Eigen::Matrix<Scalar, 6, 1>;
+
 }  // namespace drake

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -27,6 +27,10 @@ add_executable(eigen_matrix_compare_test eigen_matrix_compare_test.cc)
 target_link_libraries(eigen_matrix_compare_test ${GTEST_BOTH_LIBRARIES})
 drake_add_test(NAME eigen_matrix_compare_test COMMAND eigen_matrix_compare_test)
 
+add_executable(eigen_stl_types_test eigen_stl_types_test.cc)
+target_link_libraries(eigen_stl_types_test ${GTEST_BOTH_LIBRARIES})
+add_test(NAME eigen_stl_types_test COMMAND eigen_stl_types_test)
+
 add_executable(drake_throw_test drake_throw_test.cc)
 target_link_libraries(drake_throw_test drakeCommon ${GTEST_BOTH_LIBRARIES})
 drake_add_test(NAME drake_throw_test COMMAND drake_throw_test)

--- a/drake/common/test/eigen_stl_types_test.cc
+++ b/drake/common/test/eigen_stl_types_test.cc
@@ -1,0 +1,35 @@
+#include "drake/common/eigen_stl_types.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+using Eigen::Vector2d;
+using Eigen::Vector4d;
+
+namespace drake {
+namespace {
+
+template <typename T>
+using MapType = eigen_aligned_std_unordered_map<int, T>;
+
+// Confirm that nothing asserts nor segfaults.
+GTEST_TEST(EigenStlTypesTest, UnorderedMapTest) {
+  // The device under test is abbreviated "dut".
+  MapType<Vector2d> dut0;
+  dut0[0] = Vector2d::Zero();
+
+  auto dut1 = std::make_unique<MapType<Vector2d>>();
+  dut1->insert(std::make_pair(1, Vector2d::Ones()));
+
+  MapType<Vector4d> dut2;
+  dut2[2] = Vector4d::Ones();
+
+  auto dut3 = std::make_unique<MapType<Vector4d>>();
+  dut3->insert(std::make_pair(3, Vector4d::Zero()));
+
+  EXPECT_TRUE(true);
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/examples/Acrobot/test/urdfDynamicsTest.cpp
+++ b/drake/examples/Acrobot/test/urdfDynamicsTest.cpp
@@ -54,11 +54,13 @@ GTEST_TEST(AcrobotDynamicsTest, ValueAssignment) {
     x0_rb.bottomRows(2));
     cout << "H_sdf = " << r_sdf.getRigidBodyTree()->massMatrix(kinsol_sdf) <<
     endl;
-    eigen_aligned_unordered_map<const RigidBody *, Matrix<double, 6, 1> > f_ext;
+    const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
     cout << "C_urdf = " <<
-    r_urdf.getRigidBodyTree()->dynamicsBiasTerm(kinsol_urdf, f_ext) << endl;
+    r_urdf.getRigidBodyTree()->dynamicsBiasTerm(
+        kinsol_urdf, no_external_wrenches) << endl;
     cout << "C_sdf = " <<
-    r_sdf.getRigidBodyTree()->dynamicsBiasTerm(kinsol_sdf, f_ext) << endl;
+    r_sdf.getRigidBodyTree()->dynamicsBiasTerm(
+        kinsol_sdf, no_external_wrenches) << endl;
     */
 
     auto xdot = toEigen(r.dynamics(0.0, x0, u0));

--- a/drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.cc
@@ -36,9 +36,8 @@ void HumanoidStatus::Update(double t, const VectorXd& q, const VectorXd& v,
   robot_->doKinematics(cache_, true);
 
   M_ = robot_->massMatrix(cache_);
-  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-      f_ext;
-  bias_term_ = robot_->dynamicsBiasTerm(cache_, f_ext);
+  const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
+  bias_term_ = robot_->dynamicsBiasTerm(cache_, no_external_wrenches);
 
   // com
   com_ = robot_->centerOfMass(cache_);

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -797,7 +797,7 @@ int InstantaneousQPController::setupAndSolveQP(
     const drake::lcmt_body_wrench_data& body_wrench_data = *it;
     int body_id = body_or_frame_name_to_id.at(body_wrench_data.body_name);
     auto f_ext_i =
-        Map<const drake::TwistVector<double>>(body_wrench_data.wrench);
+        Map<const drake::WrenchVector<double>>(body_wrench_data.wrench);
     external_wrenches.insert({robot->bodies[body_id].get(), f_ext_i});
   }
 

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -791,19 +791,18 @@ int InstantaneousQPController::setupAndSolveQP(
   }
 
   // handle external wrenches to compensate for
-  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-      f_ext;
+  RigidBodyTree::BodyToWrenchMap<double> external_wrenches;
   for (auto it = qp_input.body_wrench_data.begin();
        it != qp_input.body_wrench_data.end(); ++it) {
     const drake::lcmt_body_wrench_data& body_wrench_data = *it;
     int body_id = body_or_frame_name_to_id.at(body_wrench_data.body_name);
     auto f_ext_i =
         Map<const drake::TwistVector<double>>(body_wrench_data.wrench);
-    f_ext.insert({robot->bodies[body_id].get(), f_ext_i});
+    external_wrenches.insert({robot->bodies[body_id].get(), f_ext_i});
   }
 
   H = robot->massMatrix(cache);
-  C = robot->dynamicsBiasTerm(cache, f_ext);
+  C = robot->dynamicsBiasTerm(cache, external_wrenches);
 
   H_float = H.topRows(6);
   H_act = H.bottomRows(nu);

--- a/drake/systems/gravity_compensated_pd_position_control_system.h
+++ b/drake/systems/gravity_compensated_pd_position_control_system.h
@@ -56,12 +56,11 @@ class GravityCompensatedPDPositionControlSystem {
     size_t num_DoF = Kp_.cols();
     KinematicsCache<double> cache_ = sys_tree_->doKinematics(
         toEigen(x).head(num_DoF), toEigen(x).tail(num_DoF));
-    eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-        f_ext;
-    f_ext.clear();
+    const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
     Eigen::VectorXd vd(num_DoF);
     vd.setZero();
-    auto G = sys_tree_->inverseDynamics(cache_, f_ext, vd, false);
+    auto G = sys_tree_->inverseDynamics(cache_, no_external_wrenches, vd,
+                                        false);
 
     typename System::template InputVector<ScalarType> system_u =
         Kp_ * (toEigen(u).head(Kp_.cols()) - toEigen(x).head(Kp_.cols())) +
@@ -76,9 +75,7 @@ class GravityCompensatedPDPositionControlSystem {
     size_t num_DoF = Kp_.cols();
     KinematicsCache<double> cache_ = sys_tree_->doKinematics(
         toEigen(x).head(num_DoF), toEigen(x).tail(num_DoF));
-    eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-        f_ext;
-    f_ext.clear();
+    const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
     Eigen::VectorXd vd(num_DoF);
     vd.setZero();
 
@@ -86,7 +83,8 @@ class GravityCompensatedPDPositionControlSystem {
     // with 0 external forces, 0 velocities and 0 accelerations.
     // TODO(naveenoid): Update to use simpler API once issue #3114 is
     // resolved.
-    auto G = sys_tree_->inverseDynamics(cache_, f_ext, vd, false);
+    auto G = sys_tree_->inverseDynamics(cache_, no_external_wrenches, vd,
+                                        false);
 
     typename System::template InputVector<ScalarType> system_u =
         Kp_ * (toEigen(u).head(Kp_.cols()) - toEigen(x).head(Kp_.cols())) +

--- a/drake/systems/gravity_compensated_system.h
+++ b/drake/systems/gravity_compensated_system.h
@@ -81,9 +81,7 @@ class GravityCompensatedSystem {
     int num_DoF = sys_->number_of_positions();
     KinematicsCache<double> cache = sys_tree_->doKinematics(
         toEigen(x).head(num_DoF), toEigen(x).tail(num_DoF));
-    eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-        f_ext;
-    f_ext.clear();
+    const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
     Eigen::VectorXd vd(num_DoF);
     vd.setZero();
 
@@ -91,7 +89,8 @@ class GravityCompensatedSystem {
     // with 0 external forces, 0 velocities and 0 accelerations.
     // TODO(naveenoid): Update to use simpler API once issue #3114 is
     // resolved.
-    Eigen::VectorXd G = sys_tree_->inverseDynamics(cache, f_ext, vd, false);
+    Eigen::VectorXd G = sys_tree_->inverseDynamics(cache, no_external_wrenches,
+                                                   vd, false);
     InputVector<ScalarType> system_u = toEigen(u) + G;
     return system_u;
   }

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -87,7 +87,6 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
     const RigidBodySystem::InputVector<double>& u) const {
   using namespace std;
   using namespace Eigen;
-  eigen_aligned_unordered_map<const RigidBody*, Matrix<double, 6, 1>> f_ext;
 
   // todo: make kinematics cache once and re-use it (but have to make one per
   // type)
@@ -109,7 +108,8 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
   auto H = tree->massMatrix(kinsol);
   Eigen::MatrixXd H_and_neg_JT = H;
 
-  VectorXd C = tree->dynamicsBiasTerm(kinsol, f_ext);
+  const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
+  VectorXd C = tree->dynamicsBiasTerm(kinsol, no_external_wrenches);
   if (num_actuators > 0) C -= tree->B * u.topRows(num_actuators);
 
   // loop through rigid body force elements

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1382,7 +1382,7 @@ Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyTree::massMatrix(
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::dynamicsBiasTerm(
     KinematicsCache<Scalar>& cache,
-    const eigen_aligned_unordered_map<
+    const drake::eigen_aligned_std_unordered_map<
         RigidBody const*, TwistVector<Scalar>>& external_wrenches,
     bool include_velocity_terms) const {
   Matrix<Scalar, Eigen::Dynamic, 1> vd(num_velocities_, 1);
@@ -1393,7 +1393,7 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::dynamicsBiasTerm(
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
     KinematicsCache<Scalar>& cache,
-    const eigen_aligned_unordered_map<
+    const drake::eigen_aligned_std_unordered_map<
         RigidBody const*, TwistVector<Scalar>>& external_wrenches,
     const Matrix<Scalar, Eigen::Dynamic, 1>& vd,
     bool include_velocity_terms) const {

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1382,19 +1382,19 @@ Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyTree::massMatrix(
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::dynamicsBiasTerm(
     KinematicsCache<Scalar>& cache,
-    const eigen_aligned_unordered_map<RigidBody const*, TwistVector<Scalar>>&
-        f_ext,
+    const eigen_aligned_unordered_map<
+        RigidBody const*, TwistVector<Scalar>>& external_wrenches,
     bool include_velocity_terms) const {
   Matrix<Scalar, Eigen::Dynamic, 1> vd(num_velocities_, 1);
   vd.setZero();
-  return inverseDynamics(cache, f_ext, vd, include_velocity_terms);
+  return inverseDynamics(cache, external_wrenches, vd, include_velocity_terms);
 }
 
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
     KinematicsCache<Scalar>& cache,
-    const eigen_aligned_unordered_map<RigidBody const*, TwistVector<Scalar>>&
-        f_ext,
+    const eigen_aligned_unordered_map<
+        RigidBody const*, TwistVector<Scalar>>& external_wrenches,
     const Matrix<Scalar, Eigen::Dynamic, 1>& vd,
     bool include_velocity_terms) const {
   cache.checkCachedKinematicsSettings(
@@ -1517,8 +1517,8 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
 
       // Subtract off any external wrench that may be acting on body (and
       // hence contributing to the achievement of the net wrench).
-      auto external_wrench_it = f_ext.find(&body);
-      if (external_wrench_it != f_ext.end()) {
+      auto external_wrench_it = external_wrenches.find(&body);
+      if (external_wrench_it != external_wrenches.end()) {
         const auto& external_wrench = external_wrench_it->second;
         const auto& body_to_world = cache_element.transform_to_world;
         net_wrench -= transformSpatialForce(body_to_world, external_wrench);

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -26,9 +26,6 @@ using namespace Eigen;
 
 using drake::AutoDiffUpTo73d;
 using drake::AutoDiffXd;
-using drake::kQuaternionSize;
-using drake::kRpySize;
-using drake::kSpaceDimension;
 using drake::Matrix3X;
 using drake::Matrix4X;
 using drake::Matrix6X;
@@ -37,6 +34,10 @@ using drake::TwistMatrix;
 using drake::TwistVector;
 using drake::Vector3;
 using drake::VectorX;
+using drake::WrenchVector;
+using drake::kQuaternionSize;
+using drake::kRpySize;
+using drake::kSpaceDimension;
 using drake::kTwistSize;
 
 using drake::math::autoDiffToGradientMatrix;
@@ -1383,7 +1384,7 @@ template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::dynamicsBiasTerm(
     KinematicsCache<Scalar>& cache,
     const drake::eigen_aligned_std_unordered_map<
-        RigidBody const*, TwistVector<Scalar>>& external_wrenches,
+        RigidBody const*, WrenchVector<Scalar>>& external_wrenches,
     bool include_velocity_terms) const {
   Matrix<Scalar, Eigen::Dynamic, 1> vd(num_velocities_, 1);
   vd.setZero();
@@ -1394,7 +1395,7 @@ template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree::inverseDynamics(
     KinematicsCache<Scalar>& cache,
     const drake::eigen_aligned_std_unordered_map<
-        RigidBody const*, TwistVector<Scalar>>& external_wrenches,
+        RigidBody const*, WrenchVector<Scalar>>& external_wrenches,
     const Matrix<Scalar, Eigen::Dynamic, 1>& vd,
     bool include_velocity_terms) const {
   cache.checkCachedKinematicsSettings(
@@ -2335,25 +2336,26 @@ template DRAKERBM_EXPORT VectorX<AutoDiffUpTo73d>
 RigidBodyTree::dynamicsBiasTerm<AutoDiffUpTo73d>(
     KinematicsCache<AutoDiffUpTo73d>&,
     unordered_map<
-        RigidBody const*, TwistVector<AutoDiffUpTo73d>, hash<RigidBody const*>,
+        RigidBody const*, WrenchVector<AutoDiffUpTo73d>, hash<RigidBody const*>,
         equal_to<RigidBody const*>,
-        Eigen::aligned_allocator<
-            pair<RigidBody const* const, TwistVector<AutoDiffUpTo73d>>>> const&,
+        Eigen::aligned_allocator<pair<RigidBody const* const,
+                                      WrenchVector<AutoDiffUpTo73d>>>> const&,
     bool) const;
 template DRAKERBM_EXPORT VectorX<AutoDiffXd>
 RigidBodyTree::dynamicsBiasTerm<AutoDiffXd>(
     KinematicsCache<AutoDiffXd>&,
-    unordered_map<RigidBody const*, TwistVector<AutoDiffXd>,
-                  hash<RigidBody const*>, equal_to<RigidBody const*>,
-                  Eigen::aligned_allocator<pair<
-                      RigidBody const* const, TwistVector<AutoDiffXd>>>> const&,
+    unordered_map<
+        RigidBody const*, WrenchVector<AutoDiffXd>, hash<RigidBody const*>,
+        equal_to<RigidBody const*>,
+        Eigen::aligned_allocator<
+            pair<RigidBody const* const, WrenchVector<AutoDiffXd>>>> const&,
     bool) const;
 template DRAKERBM_EXPORT VectorXd RigidBodyTree::dynamicsBiasTerm<double>(
     KinematicsCache<double>&,
-    unordered_map<RigidBody const*, TwistVector<double>, hash<RigidBody const*>,
-                  equal_to<RigidBody const*>,
+    unordered_map<RigidBody const*, WrenchVector<double>,
+                  hash<RigidBody const*>, equal_to<RigidBody const*>,
                   Eigen::aligned_allocator<pair<RigidBody const* const,
-                                                TwistVector<double>>>> const&,
+                                                WrenchVector<double>>>> const&,
     bool) const;
 
 // Explicit template instantiations for geometricJacobian.
@@ -2530,10 +2532,10 @@ RigidBodyTree::inverseDynamics<AutoDiffXd>(
     VectorX<AutoDiffXd> const&, bool) const;
 template DRAKERBM_EXPORT VectorX<double> RigidBodyTree::inverseDynamics<double>(
     KinematicsCache<double>&,
-    unordered_map<RigidBody const*, TwistVector<double>, hash<RigidBody const*>,
-                  equal_to<RigidBody const*>,
+    unordered_map<RigidBody const*, WrenchVector<double>,
+                  hash<RigidBody const*>, equal_to<RigidBody const*>,
                   Eigen::aligned_allocator<pair<RigidBody const* const,
-                                                TwistVector<double>>>> const&,
+                                                WrenchVector<double>>>> const&,
     VectorX<double> const&, bool) const;
 
 // Explicit template instantiations for jointLimitConstraints.

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -348,8 +348,8 @@ class DRAKERBM_EXPORT RigidBodyTree {
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(
       KinematicsCache<Scalar>& cache,
-      const eigen_aligned_unordered_map<RigidBody const*,
-                                        drake::TwistVector<Scalar>>& f_ext,
+      const eigen_aligned_unordered_map<
+          RigidBody const*, drake::TwistVector<Scalar>>& external_wrenches,
       bool include_velocity_terms = true) const;
 
   /** \brief Compute
@@ -371,7 +371,8 @@ class DRAKERBM_EXPORT RigidBodyTree {
   *
   * Algorithm: recursive Newton-Euler. Does not explicitly compute mass matrix.
   * \param cache a KinematicsCache constructed given \f$ q \f$ and \f$ v \f$
-  * \param f_ext external wrenches exerted upon bodies. Expressed in body frame.
+  * \param external_wrenches external wrenches exerted upon bodies
+  * (\f$ f_\text{ext} \f$). Expressed in body frame.
   * \param vd \f$ \dot{v} \f$
   * \param include_velocity_terms whether to include velocity-dependent terms in
   *\f$ C(q, v, f_\text{ext}) \f$. Setting \a include_velocity_terms to false is
@@ -381,8 +382,8 @@ class DRAKERBM_EXPORT RigidBodyTree {
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> inverseDynamics(
       KinematicsCache<Scalar>& cache,
-      const eigen_aligned_unordered_map<RigidBody const*,
-                                        drake::TwistVector<Scalar>>& f_ext,
+      const eigen_aligned_unordered_map<
+          RigidBody const*, drake::TwistVector<Scalar>>& external_wrenches,
       const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& vd,
       bool include_velocity_terms = true) const;
 

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -335,6 +335,14 @@ class DRAKERBM_EXPORT RigidBodyTree {
   Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> massMatrix(
       KinematicsCache<Scalar>& cache) const;
 
+#ifndef SWIG
+  /// Convenience alias for rigid body to external wrench map, for use with
+  /// inverseDynamics and dynamicsBiasTerm.
+  template <typename Scalar>
+  using BodyToWrenchMap = eigen_aligned_unordered_map<
+    RigidBody const*, drake::TwistVector<Scalar>>;
+#endif
+
   /** \brief Compute the term \f$ C(q, v, f_\text{ext}) \f$ in the manipulator
   *equations
   *  \f[

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -340,7 +340,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   /// inverseDynamics and dynamicsBiasTerm.
   template <typename Scalar>
   using BodyToWrenchMap = drake::eigen_aligned_std_unordered_map<
-    RigidBody const*, drake::TwistVector<Scalar>>;
+    RigidBody const*, drake::WrenchVector<Scalar>>;
 #endif
 
   /** \brief Compute the term \f$ C(q, v, f_\text{ext}) \f$ in the manipulator
@@ -357,7 +357,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(
       KinematicsCache<Scalar>& cache,
       const drake::eigen_aligned_std_unordered_map<
-          RigidBody const*, drake::TwistVector<Scalar>>& external_wrenches,
+          RigidBody const*, drake::WrenchVector<Scalar>>& external_wrenches,
       bool include_velocity_terms = true) const;
 
   /** \brief Compute
@@ -391,7 +391,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> inverseDynamics(
       KinematicsCache<Scalar>& cache,
       const drake::eigen_aligned_std_unordered_map<
-          RigidBody const*, drake::TwistVector<Scalar>>& external_wrenches,
+          RigidBody const*, drake::WrenchVector<Scalar>>& external_wrenches,
       const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& vd,
       bool include_velocity_terms = true) const;
 

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -9,6 +9,7 @@
 
 #include "drake/common/constants.h"
 #include "drake/common/drake_deprecated.h"
+#include "drake/common/eigen_stl_types.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/drakeRBM_export.h"
 #include "drake/systems/plants/ForceTorqueMeasurement.h"
@@ -24,7 +25,6 @@
 #include "drake/systems/plants/rigid_body_loop.h"
 #include "drake/systems/plants/shapes/DrakeShapes.h"
 #include "drake/util/drakeGeometryUtil.h"
-#include "drake/util/drakeUtil.h"
 
 #define BASIS_VECTOR_HALF_COUNT \
   2  // number of basis vectors over 2 (i.e. 4 basis vectors in this case)
@@ -339,7 +339,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   /// Convenience alias for rigid body to external wrench map, for use with
   /// inverseDynamics and dynamicsBiasTerm.
   template <typename Scalar>
-  using BodyToWrenchMap = eigen_aligned_unordered_map<
+  using BodyToWrenchMap = drake::eigen_aligned_std_unordered_map<
     RigidBody const*, drake::TwistVector<Scalar>>;
 #endif
 
@@ -356,7 +356,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(
       KinematicsCache<Scalar>& cache,
-      const eigen_aligned_unordered_map<
+      const drake::eigen_aligned_std_unordered_map<
           RigidBody const*, drake::TwistVector<Scalar>>& external_wrenches,
       bool include_velocity_terms = true) const;
 
@@ -390,7 +390,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   template <typename Scalar>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> inverseDynamics(
       KinematicsCache<Scalar>& cache,
-      const eigen_aligned_unordered_map<
+      const drake::eigen_aligned_std_unordered_map<
           RigidBody const*, drake::TwistVector<Scalar>>& external_wrenches,
       const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& vd,
       bool include_velocity_terms = true) const;

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -2296,10 +2296,9 @@ void GravityCompensationTorqueConstraint::eval(const double* t,
       q);
   KinematicsCache<Scalar> cache_with_gradients =
       getRobotPointer()->doKinematics(q);
-  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<Scalar>>
-      f_ext;
-  auto G_autodiff =
-      getRobotPointer()->dynamicsBiasTerm(cache_with_gradients, f_ext, false);
+  const RigidBodyTree::BodyToWrenchMap<Scalar> no_external_wrenches;
+  auto G_autodiff = getRobotPointer()->dynamicsBiasTerm(
+      cache_with_gradients, no_external_wrenches, false);
   auto G = autoDiffToValueMatrix(G_autodiff);
   auto dG = autoDiffToGradientMatrix(G_autodiff);
 

--- a/drake/systems/plants/rigidBodyTreeMexFunctions.cpp
+++ b/drake/systems/plants/rigidBodyTreeMexFunctions.cpp
@@ -327,16 +327,15 @@ Matrix<Scalar, Dynamic, 1> dynamicsBiasTermTemp(
     const MatrixBase<DerivedF>& f_ext_value) {
   // temporary solution.
 
-  eigen_aligned_unordered_map<const RigidBody*, Matrix<Scalar, 6, 1>> f_ext;
-
+  RigidBodyTree::BodyToWrenchMap<Scalar> external_wrenches;
   if (f_ext_value.size() > 0) {
     DRAKE_ASSERT(f_ext_value.cols() == model.bodies.size());
     for (Eigen::Index i = 0; i < f_ext_value.cols(); i++) {
-      f_ext.insert({model.bodies[i].get(), f_ext_value.col(i)});
+      external_wrenches.insert({model.bodies[i].get(), f_ext_value.col(i)});
     }
   }
 
-  return model.dynamicsBiasTerm(cache, f_ext);
+  return model.dynamicsBiasTerm(cache, external_wrenches);
 }
 
 void dynamicsBiasTermmex(int nlhs, mxArray* plhs[], int nrhs,

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -163,13 +163,15 @@ void RigidBodyPlant<T>::EvalTimeDerivatives(
   auto H = tree_->massMatrix(kinsol);
   Eigen::MatrixXd H_and_neg_JT = H;
 
-  // f_ext here has zero size but is a required argument in dynamicsBiasTerm.
-  // TODO(amcastro-tri): f_ext should be made an optional parameter
+  // There are no external wrenches, but it is a required argument in
+  // dynamicsBiasTerm.
+  // TODO(amcastro-tri): external_wrenches should be made an optional parameter
   // of dynamicsBiasTerm().
-  eigen_aligned_unordered_map<const RigidBody*, Vector6<T>> f_ext;
+  const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
   // right_hand_side is the right hand side of the system's equations:
   // [H, -J^T] * [vdot; f] = -right_hand_side.
-  VectorX<T> right_hand_side = tree_->dynamicsBiasTerm(kinsol, f_ext);
+  VectorX<T> right_hand_side = tree_->dynamicsBiasTerm(kinsol,
+                                                       no_external_wrenches);
   if (num_actuators > 0) right_hand_side -= tree_->B * u;
 
   // Applies joint limit forces.

--- a/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
+++ b/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
@@ -60,13 +60,12 @@ void scenario2(
   default_random_engine generator;
   uniform_real_distribution<> uniform(0, 1);
 
-  const eigen_aligned_unordered_map<RigidBody const*,
-                                    drake::TwistVector<Scalar>> f_ext;
+  const RigidBodyTree::BodyToWrenchMap<Scalar> no_external_wrenches;
   for (const auto& state : states) {
     cache.initialize(state.first, state.second);
     model.doKinematics(cache, true);
     auto H = model.massMatrix(cache);
-    auto C = model.dynamicsBiasTerm(cache, f_ext);
+    auto C = model.dynamicsBiasTerm(cache, no_external_wrenches);
     if (uniform(generator) <
         1e-15) {  // print with some probability to avoid optimizing away
       printMatrix<decltype(H)::RowsAtCompileTime,

--- a/drake/systems/plants/test/compareParsersmex.cpp
+++ b/drake/systems/plants/test/compareParsersmex.cpp
@@ -111,9 +111,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
         cpp_model->doKinematics(cpp_q, cpp_v, true);
 
     {  // compare H, C, and B
-      eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-          f_ext;
-
       auto matlab_H = matlab_model->massMatrix(matlab_cache);
       auto cpp_H = cpp_model->massMatrix(cpp_cache);
 
@@ -124,8 +121,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
             "Drake: CompareParserMex: ERROR: H doesn't match: " + explanation);
       }
 
-      auto matlab_C = matlab_model->dynamicsBiasTerm(matlab_cache, f_ext);
-      auto cpp_C = cpp_model->dynamicsBiasTerm(cpp_cache, f_ext);
+      const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
+      auto matlab_C = matlab_model->dynamicsBiasTerm(matlab_cache,
+                                                     no_external_wrenches);
+      auto cpp_C = cpp_model->dynamicsBiasTerm(cpp_cache, no_external_wrenches);
 
       if (!CompareMatrices(matlab_C, cpp_C, 1e-8, MatrixCompareType::absolute,
                            &explanation)) {

--- a/drake/systems/plants/test/debugManipulatorDynamics.cpp
+++ b/drake/systems/plants/test/debugManipulatorDynamics.cpp
@@ -26,16 +26,15 @@ int main() {
   auto M = model.massMatrix<double>(cache);
   cout << M << endl << endl;
 
-  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-      f_ext;
+  RigidBodyTree::BodyToWrenchMap<double> external_wrenches;
   drake::TwistVector<double> f_ext_r_foot;
   f_ext_r_foot.setRandom();
-  f_ext.insert({model.FindBody("r_foot"), f_ext_r_foot});
+  external_wrenches.insert({model.FindBody("r_foot"), f_ext_r_foot});
 
   VectorXd vd(model.number_of_velocities());
   vd.setRandom();
 
-  auto C = model.inverseDynamics(cache, f_ext, vd);
+  auto C = model.inverseDynamics(cache, external_wrenches, vd);
   cout << C << endl << endl;
   return 0;
 }

--- a/drake/systems/plants/test/debugManipulatorDynamics.cpp
+++ b/drake/systems/plants/test/debugManipulatorDynamics.cpp
@@ -27,7 +27,7 @@ int main() {
   cout << M << endl << endl;
 
   RigidBodyTree::BodyToWrenchMap<double> external_wrenches;
-  drake::TwistVector<double> f_ext_r_foot;
+  drake::WrenchVector<double> f_ext_r_foot;
   f_ext_r_foot.setRandom();
   external_wrenches.insert({model.FindBody("r_foot"), f_ext_r_foot});
 

--- a/drake/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/drake/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -50,8 +50,7 @@ void performChecks(RigidBodyTree& model, KinematicsCache<double>& cache,
   int npoints = 3;
   drake::TwistVector<double> spatial_acceleration;
   spatial_acceleration.setRandom();
-  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-      f_ext;
+  const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
 
   checkForErrors(settings.expect_error_on_configuration_methods, model,
                  &RigidBodyTree::centerOfMass<double>, cache,
@@ -132,9 +131,11 @@ void performChecks(RigidBodyTree& model, KinematicsCache<double>& cache,
                  old_expressed_in_body_or_frame_ind,
                  new_expressed_in_body_or_frame_ind);
   checkForErrors(settings.expect_error_on_jdot_times_v_methods, model,
-                 &RigidBodyTree::dynamicsBiasTerm<double>, cache, f_ext, true);
+                 &RigidBodyTree::dynamicsBiasTerm<double>, cache,
+                 no_external_wrenches, true);
   checkForErrors(settings.expect_error_on_configuration_methods, model,
-                 &RigidBodyTree::dynamicsBiasTerm<double>, cache, f_ext, false);
+                 &RigidBodyTree::dynamicsBiasTerm<double>, cache,
+                 no_external_wrenches, false);
 }
 
 int main() {

--- a/drake/systems/plants/test/urdfManipulatorDynamicsTest.cpp
+++ b/drake/systems/plants/test/urdfManipulatorDynamicsTest.cpp
@@ -47,9 +47,8 @@ int main(int argc, char* argv[]) {
   auto H = model->massMatrix(cache);
   cout << H << endl;
 
-  eigen_aligned_unordered_map<RigidBody const*, drake::TwistVector<double>>
-      f_ext;
-  auto C = model->dynamicsBiasTerm(cache, f_ext);
+  const RigidBodyTree::BodyToWrenchMap<double> no_external_wrenches;
+  auto C = model->dynamicsBiasTerm(cache, no_external_wrenches);
   cout << C << endl;
 
   cout << model->B << endl;

--- a/drake/util/drakeUtil.h
+++ b/drake/util/drakeUtil.h
@@ -12,15 +12,18 @@
 #include <utility>
 #include <Eigen/Core>
 #include <Eigen/Dense>
-#include <unordered_map>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/eigen_stl_types.h"
 #include "drake/drakeUtil_export.h"
 
 template <typename Key, typename T>
-using eigen_aligned_unordered_map =
-    std::unordered_map<Key, T, std::hash<Key>, std::equal_to<Key>,
-                       Eigen::aligned_allocator<std::pair<Key const, T> > >;
+using eigen_aligned_unordered_map
+#ifndef _MSC_VER
+    DRAKE_DEPRECATED("Use drake::eigen_aligned_std_unordered_map")
+#endif
+    = drake::eigen_aligned_std_unordered_map<Key, T>;
 
 template <typename Derived>
 inline void sizecheck(const Eigen::MatrixBase<Derived>& mat, size_t rows,


### PR DESCRIPTION
Two clean-ups related to external wrenches:
- Rename f_ext to to external_wrenches and add BodyToWrenchMap alias.
- Extract eigen_aligned_std_unordered_map into common.

... which contributes to #3278.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3405)
<!-- Reviewable:end -->
