### PR TITLE
Added gfortran to pre-requisite install to fix build

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -29,6 +29,7 @@ flex \
 g++-5 \
 g++-5-multilib \
 gdb \
+gfortran \
 gfortran-5 \
 git \
 graphviz \


### PR DESCRIPTION
This installs gfortran (over and above gfortran-5) to fix a build problem on Ubuntu 16.04

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3420)
<!-- Reviewable:end -->
