### PR TITLE
Prevent CMake from consulting the User Package Registry

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -155,6 +155,13 @@ endfunction()
 # Set up basic platform properties for building Drake.
 #------------------------------------------------------------------------------
 macro(drake_setup_platform)
+  # Disable finding out-of-tree packages in the registry.
+  # This doesn't exactly make find_package hermetic, but it's a useful step
+  # in that direction. We should also consider adding the Drake superbuild
+  # to the CMAKE_PREFIX_PATH.
+  set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON)
+  set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON)
+
   drake_setup_compiler()
   drake_setup_matlab()
   drake_setup_java()


### PR DESCRIPTION
This helps `find_package(gflags)` find gflags in the current tree, not some other random tree.  Fixes #3433, though builds that have already been bitten will need to scrub `gflags_DIR` from `CMakeCache.txt` manually.

https://gflags.github.io/gflags/#cmake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3440)
<!-- Reviewable:end -->
