### PR TITLE
Group cross product

### DIFF
--- a/drake/bindings/swig/rbtree.i
+++ b/drake/bindings/swig/rbtree.i
@@ -37,9 +37,9 @@
 
 %eigen_typemaps(Eigen::VectorXd)
 %eigen_typemaps(Eigen::Vector3d)
-%eigen_typemaps(Eigen::Matrix<double, SPACE_DIMENSION, 1>)
+%eigen_typemaps(Eigen::Matrix<double, drake::kSpaceDimension, 1>)
 %eigen_typemaps(Eigen::Matrix3Xd)
-%eigen_typemaps(Eigen::Matrix<double, SPACE_DIMENSION, Eigen::Dynamic>)
+%eigen_typemaps(Eigen::Matrix<double, drake::kSpaceDimension, Eigen::Dynamic>)
 %eigen_typemaps(Eigen::MatrixXd)
 %eigen_typemaps(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>)
 %eigen_typemaps(Eigen::VectorXi)
@@ -48,8 +48,8 @@
 %template(KinematicsCache_d) KinematicsCache<double>;
 %template(KinematicsCache_adVectorDynamic) KinematicsCache<Eigen::AutoDiffScalar<Eigen::VectorXd> >;
 %template(KinematicsCache_adVectorMax73) KinematicsCache<Eigen::AutoDiffScalar<Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73> > >;
-%template(AutoDiff3XDynamic) AutoDiffWrapper<Eigen::VectorXd, SPACE_DIMENSION, Eigen::Dynamic>;
-%template(AutoDiff3XMax73) AutoDiffWrapper<Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73>, SPACE_DIMENSION, Eigen::Dynamic>;
+%template(AutoDiff3XDynamic) AutoDiffWrapper<Eigen::VectorXd, drake::kSpaceDimension, Eigen::Dynamic>;
+%template(AutoDiff3XMax73) AutoDiffWrapper<Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73>, drake::kSpaceDimension, Eigen::Dynamic>;
 
 // unique_ptr confuses SWIG, so we'll ignore it for now
 %ignore RigidBody::setJoint(std::unique_ptr<DrakeJoint> joint);
@@ -102,29 +102,29 @@
     return $self->doKinematics(q, v);
   }
 
-  Eigen::Matrix<double, SPACE_DIMENSION, Eigen::Dynamic> transformPoints(
-      const KinematicsCache<double> &cache, const Eigen::Matrix<double, SPACE_DIMENSION, Eigen::Dynamic> &points, int current_body_or_frame_ind, int new_body_or_frame_ind) const
+  Eigen::Matrix<double, drake::kSpaceDimension, Eigen::Dynamic> transformPoints(
+      const KinematicsCache<double> &cache, const Eigen::Matrix<double, drake::kSpaceDimension, Eigen::Dynamic> &points, int current_body_or_frame_ind, int new_body_or_frame_ind) const
   {
     return $self->transformPoints(cache, points, current_body_or_frame_ind, new_body_or_frame_ind);
   }
 
-  AutoDiffWrapper<Eigen::VectorXd, SPACE_DIMENSION, Eigen::Dynamic> transformPoints(
-      const KinematicsCache<Eigen::AutoDiffScalar<Eigen::VectorXd> > &cache, const Eigen::Matrix<double, SPACE_DIMENSION, Eigen::Dynamic> &points, int current_body_or_frame_ind, int new_body_or_frame_ind) const
+  AutoDiffWrapper<Eigen::VectorXd, drake::kSpaceDimension, Eigen::Dynamic> transformPoints(
+      const KinematicsCache<Eigen::AutoDiffScalar<Eigen::VectorXd> > &cache, const Eigen::Matrix<double, drake::kSpaceDimension, Eigen::Dynamic> &points, int current_body_or_frame_ind, int new_body_or_frame_ind) const
   {
     return $self->transformPoints(cache, points, current_body_or_frame_ind, new_body_or_frame_ind);
   }
 
-  AutoDiffWrapper<Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73>, SPACE_DIMENSION, Eigen::Dynamic> transformPoints(
-      const KinematicsCache<Eigen::AutoDiffScalar<Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73> > > &cache, const Eigen::Matrix<double, SPACE_DIMENSION, Eigen::Dynamic> &points, int current_body_or_frame_ind, int new_body_or_frame_ind) const
+  AutoDiffWrapper<Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73>, drake::kSpaceDimension, Eigen::Dynamic> transformPoints(
+      const KinematicsCache<Eigen::AutoDiffScalar<Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 73> > > &cache, const Eigen::Matrix<double, drake::kSpaceDimension, Eigen::Dynamic> &points, int current_body_or_frame_ind, int new_body_or_frame_ind) const
   {
     return $self->transformPoints(cache, points, current_body_or_frame_ind, new_body_or_frame_ind);
   }
 
-  Eigen::Matrix<double, SPACE_DIMENSION, 1> centerOfMass(KinematicsCache<double> &cache, const std::set<int> &model_instance_id = default_model_instance_id_set) const {
+  Eigen::Matrix<double, drake::kSpaceDimension, 1> centerOfMass(KinematicsCache<double> &cache, const std::set<int> &model_instance_id = default_model_instance_id_set) const {
     return $self->centerOfMass(cache, model_instance_id);
   }
 
-  Eigen::Matrix<double, SPACE_DIMENSION, Eigen::Dynamic> centerOfMassJacobian(KinematicsCache<double>& cache, const std::set<int>& model_instance_ids = default_model_instance_id_set, bool in_terms_of_qdot = false) const {
+  Eigen::Matrix<double, drake::kSpaceDimension, Eigen::Dynamic> centerOfMassJacobian(KinematicsCache<double>& cache, const std::set<int>& model_instance_ids = default_model_instance_id_set, bool in_terms_of_qdot = false) const {
     return $self->centerOfMassJacobian(cache, model_instance_ids, in_terms_of_qdot);
   }
 

--- a/drake/common/constants.h
+++ b/drake/common/constants.h
@@ -11,7 +11,7 @@ constexpr int kRpySize = 3;
 /// https://en.wikipedia.org/wiki/Screw_theory#Twist
 constexpr int kTwistSize = 6;
 
-constexpr int kHomogeneousTransform = 16;
+constexpr int kHomogeneousTransformSize = 16;
 
 const int kRotmatSize = kSpaceDimension * kSpaceDimension;
 }  // namespace drake

--- a/drake/common/constants.h
+++ b/drake/common/constants.h
@@ -11,4 +11,7 @@ constexpr int kRpySize = 3;
 /// https://en.wikipedia.org/wiki/Screw_theory#Twist
 constexpr int kTwistSize = 6;
 
+constexpr int kHomogeneousTransform = 16;
+
+const int kRotmatSize = kSpaceDimension * kSpaceDimension;
 }  // namespace drake

--- a/drake/common/constants.h
+++ b/drake/common/constants.h
@@ -11,6 +11,7 @@ constexpr int kRpySize = 3;
 /// https://en.wikipedia.org/wiki/Screw_theory#Twist
 constexpr int kTwistSize = 6;
 
+/// http://www.euclideanspace.com/maths/geometry/affine/matrix4x4/
 constexpr int kHomogeneousTransformSize = 16;
 
 const int kRotmatSize = kSpaceDimension * kSpaceDimension;

--- a/drake/math/CMakeLists.txt
+++ b/drake/math/CMakeLists.txt
@@ -7,6 +7,7 @@ set(sources
   expmap.cc
   gradient.cc
   quaternion.cc
+  random_rotation.cc
   roll_pitch_yaw.cc
   rotation_matrix.cc)
 
@@ -20,6 +21,7 @@ set(installed_headers
   expmap.h
   gradient.h
   quaternion.h
+  random_rotation.h
   roll_pitch_yaw.h
   rotation_matrix.h)
 

--- a/drake/math/CMakeLists.txt
+++ b/drake/math/CMakeLists.txt
@@ -3,6 +3,7 @@ set(sources
   autodiff.cc
   autodiff_gradient.cc
   axis_angle.cc
+  cross_product.cc
   cylindrical.cc
   expmap.cc
   gradient.cc
@@ -17,6 +18,7 @@ set(installed_headers
   autodiff.h
   autodiff_gradient.h
   axis_angle.h
+  cross_product.h
   cylindrical.h
   expmap.h
   gradient.h

--- a/drake/math/cross_product.cc
+++ b/drake/math/cross_product.cc
@@ -1,0 +1,4 @@
+// For now, this is an empty .cc file that only serves to confirm
+// cross_product.h is a stand-alone header.
+
+#include "drake/math/cross_product.h"

--- a/drake/math/cross_product.h
+++ b/drake/math/cross_product.h
@@ -3,16 +3,16 @@
 #include <Eigen/Dense>
 
 #include "drake/common/constants.h"
-#include "drake/math/gradient.h"
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace math {
 template <typename Derived>
-Eigen::Matrix<typename Derived::Scalar, 3, 3> VectorToSkewSymmetric(
+drake::Matrix3<typename Derived::Scalar> VectorToSkewSymmetric(
     const Eigen::MatrixBase<Derived>& p) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
                                            drake::kSpaceDimension);
-  Eigen::Matrix<typename Derived::Scalar, 3, 3> ret;
+  drake::Matrix3<typename Derived::Scalar> ret;
   ret << 0.0, -p(2), p(1), p(2), 0.0, -p(0), -p(1), p(0), 0.0;
   return ret;
 }

--- a/drake/math/cross_product.h
+++ b/drake/math/cross_product.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "drake/common/constants.h"
+#include "drake/math/gradient.h"
+
+namespace drake {
+namespace math {
+template <typename Derived>
+Eigen::Matrix<typename Derived::Scalar, 3, 3> VectorToSkewSymmetric(
+    const Eigen::MatrixBase<Derived>& p) {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>,
+                                           drake::kSpaceDimension);
+  Eigen::Matrix<typename Derived::Scalar, 3, 3> ret;
+  ret << 0.0, -p(2), p(1), p(2), 0.0, -p(0), -p(1), p(0), 0.0;
+  return ret;
+}
+
+}  // namespace math
+}  // namespace drake

--- a/drake/math/random_rotation.cc
+++ b/drake/math/random_rotation.cc
@@ -6,7 +6,7 @@ using namespace Eigen;
 
 namespace drake {
 namespace math {
-Vector4d uniformlyRandomAxisAngle(std::default_random_engine& generator) {
+Vector4d UniformlyRandomAxisAngle(std::default_random_engine& generator) {
   std::normal_distribution<double> normal;
   std::uniform_real_distribution<double> uniform(-M_PI, M_PI);
   double angle = uniform(generator);
@@ -18,16 +18,16 @@ Vector4d uniformlyRandomAxisAngle(std::default_random_engine& generator) {
   return a;
 }
 
-Vector4d uniformlyRandomQuat(std::default_random_engine& generator) {
-  return drake::math::axis2quat(uniformlyRandomAxisAngle(generator));
+Vector4d UniformlyRandomQuat(std::default_random_engine& generator) {
+  return drake::math::axis2quat(UniformlyRandomAxisAngle(generator));
 }
 
-Eigen::Matrix3d uniformlyRandomRotmat(std::default_random_engine& generator) {
-  return drake::math::axis2rotmat(uniformlyRandomAxisAngle(generator));
+Eigen::Matrix3d UniformlyRandomRotmat(std::default_random_engine& generator) {
+  return drake::math::axis2rotmat(UniformlyRandomAxisAngle(generator));
 }
 
-Eigen::Vector3d uniformlyRandomRPY(std::default_random_engine& generator) {
-  return drake::math::axis2rpy(uniformlyRandomAxisAngle(generator));
+Eigen::Vector3d UniformlyRandomRPY(std::default_random_engine& generator) {
+  return drake::math::axis2rpy(UniformlyRandomAxisAngle(generator));
 }
 }  // namespace math
 }  // namespace drake

--- a/drake/math/random_rotation.cc
+++ b/drake/math/random_rotation.cc
@@ -1,0 +1,33 @@
+#include "drake/math/random_rotation.h"
+
+#include "drake/math/axis_angle.h"
+
+using namespace Eigen;
+
+namespace drake {
+namespace math {
+Vector4d uniformlyRandomAxisAngle(std::default_random_engine& generator) {
+  std::normal_distribution<double> normal;
+  std::uniform_real_distribution<double> uniform(-M_PI, M_PI);
+  double angle = uniform(generator);
+  Vector3d axis =
+      Vector3d(normal(generator), normal(generator), normal(generator));
+  axis.normalize();
+  Vector4d a;
+  a << axis, angle;
+  return a;
+}
+
+Vector4d uniformlyRandomQuat(std::default_random_engine& generator) {
+  return drake::math::axis2quat(uniformlyRandomAxisAngle(generator));
+}
+
+Eigen::Matrix3d uniformlyRandomRotmat(std::default_random_engine& generator) {
+  return drake::math::axis2rotmat(uniformlyRandomAxisAngle(generator));
+}
+
+Eigen::Vector3d uniformlyRandomRPY(std::default_random_engine& generator) {
+  return drake::math::axis2rpy(uniformlyRandomAxisAngle(generator));
+}
+}  // namespace math
+}  // namespace drake

--- a/drake/math/random_rotation.h
+++ b/drake/math/random_rotation.h
@@ -11,13 +11,13 @@
 
 namespace drake {
 namespace math {
-DRAKEMATH_EXPORT Eigen::Vector4d uniformlyRandomAxisAngle(
+DRAKEMATH_EXPORT Eigen::Vector4d UniformlyRandomAxisAngle(
     std::default_random_engine& generator);
-DRAKEMATH_EXPORT Eigen::Vector4d uniformlyRandomQuat(
+DRAKEMATH_EXPORT Eigen::Vector4d UniformlyRandomQuat(
     std::default_random_engine& generator);
-DRAKEMATH_EXPORT Eigen::Matrix3d uniformlyRandomRotmat(
+DRAKEMATH_EXPORT Eigen::Matrix3d UniformlyRandomRotmat(
     std::default_random_engine& generator);
-DRAKEMATH_EXPORT Eigen::Vector3d uniformlyRandomRPY(
+DRAKEMATH_EXPORT Eigen::Vector3d UniformlyRandomRPY(
     std::default_random_engine& generator);
 }  // namespace math
 }  // namespace drake

--- a/drake/math/random_rotation.h
+++ b/drake/math/random_rotation.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <Eigen/Dense>
-#include <cmath>
 #include <random>
+
+#include <Eigen/Dense>
 
 #include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
 #include "drake/drakeMath_export.h"
-#include "drake/math/quaternion.h"
 
 namespace drake {
 namespace math {

--- a/drake/math/random_rotation.h
+++ b/drake/math/random_rotation.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <cmath>
+#include <random>
+
+#include "drake/common/constants.h"
+#include "drake/common/eigen_types.h"
+#include "drake/drakeMath_export.h"
+#include "drake/math/quaternion.h"
+
+namespace drake {
+namespace math {
+DRAKEMATH_EXPORT Eigen::Vector4d uniformlyRandomAxisAngle(
+    std::default_random_engine& generator);
+DRAKEMATH_EXPORT Eigen::Vector4d uniformlyRandomQuat(
+    std::default_random_engine& generator);
+DRAKEMATH_EXPORT Eigen::Matrix3d uniformlyRandomRotmat(
+    std::default_random_engine& generator);
+DRAKEMATH_EXPORT Eigen::Vector3d uniformlyRandomRPY(
+    std::default_random_engine& generator);
+}  // namespace math
+}  // namespace drake

--- a/drake/math/test/CMakeLists.txt
+++ b/drake/math/test/CMakeLists.txt
@@ -9,3 +9,7 @@ drake_add_test(NAME expmap_test COMMAND expmap_test)
 add_executable(rotation_conversion_test rotation_conversion_test.cc)
 target_link_libraries(rotation_conversion_test ${GTEST_BOTH_LIBRARIES})
 drake_add_test(NAME rotation_conversion_test COMMAND rotation_conversion_test)
+
+add_executable(cross_product_test cross_product_test.cc)
+target_link_libraries(cross_product_test ${GTEST_BOTH_LIBRARIES})
+drake_add_test(NAME cross_product_test COMMAND cross_product_test)

--- a/drake/math/test/cross_product_test.cc
+++ b/drake/math/test/cross_product_test.cc
@@ -11,13 +11,13 @@ namespace drake {
 namespace math {
 namespace {
 void SkewSymMatTestFun(const Vector3d& x) {
-  // manually computes the skew symmetric matrix.
+  // Manually computes the skew symmetric matrix.
   Matrix3d x_skew_mat_expected;
   x_skew_mat_expected << 0, -x(2), x(1), x(2), 0, -x(0), -x(1), x(0), 0;
   auto x_skew_mat = VectorToSkewSymmetric(x);
   EXPECT_TRUE(CompareMatrices(x_skew_mat_expected, x_skew_mat, 1E-10,
                               MatrixCompareType::absolute));
-  // checks the skew-symmetric property A' = -A
+  // Checks the skew-symmetric property A' = -A.
   EXPECT_TRUE(CompareMatrices(x_skew_mat, -x_skew_mat.transpose(), 1E-10,
                               MatrixCompareType::absolute));
 }

--- a/drake/math/test/cross_product_test.cc
+++ b/drake/math/test/cross_product_test.cc
@@ -11,11 +11,13 @@ namespace drake {
 namespace math {
 namespace {
 void SkewSymMatTestFun(const Vector3d& x) {
+  // manually computes the skew symmetric matrix.
   Matrix3d x_skew_mat_expected;
   x_skew_mat_expected << 0, -x(2), x(1), x(2), 0, -x(0), -x(1), x(0), 0;
   auto x_skew_mat = VectorToSkewSymmetric(x);
   EXPECT_TRUE(CompareMatrices(x_skew_mat_expected, x_skew_mat, 1E-10,
                               MatrixCompareType::absolute));
+  // checks the skew-symmetric property A' = -A
   EXPECT_TRUE(CompareMatrices(x_skew_mat, -x_skew_mat.transpose(), 1E-10,
                               MatrixCompareType::absolute));
 }

--- a/drake/math/test/cross_product_test.cc
+++ b/drake/math/test/cross_product_test.cc
@@ -16,6 +16,8 @@ void SkewSymMatTestFun(const Vector3d& x) {
   auto x_skew_mat = VectorToSkewSymmetric(x);
   EXPECT_TRUE(CompareMatrices(x_skew_mat_expected, x_skew_mat, 1E-10,
                               MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(x_skew_mat, -x_skew_mat.transpose(), 1E-10,
+                              MatrixCompareType::absolute));
 }
 
 GTEST_TEST(CrossProductTest, SkewSymMatTest) {
@@ -23,6 +25,7 @@ GTEST_TEST(CrossProductTest, SkewSymMatTest) {
   SkewSymMatTestFun(Vector3d(1.0, 0.0, 0.0));
   SkewSymMatTestFun(Vector3d(0.0, 1.0, 0.0));
   SkewSymMatTestFun(Vector3d(0.0, 0.0, 1.0));
+  SkewSymMatTestFun(Vector3d(1.0, 2.0, 3.0));
 }
 }  // namespace
 }  // namespace math

--- a/drake/math/test/cross_product_test.cc
+++ b/drake/math/test/cross_product_test.cc
@@ -1,0 +1,29 @@
+#include "drake/math/cross_product.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/math/autodiff.h"
+
+using namespace Eigen;
+
+namespace drake {
+namespace math {
+namespace {
+void SkewSymMatTestFun(const Vector3d& x) {
+  Matrix3d x_skew_mat_expected;
+  x_skew_mat_expected << 0, -x(2), x(1), x(2), 0, -x(0), -x(1), x(0), 0;
+  auto x_skew_mat = VectorToSkewSymmetric(x);
+  EXPECT_TRUE(CompareMatrices(x_skew_mat_expected, x_skew_mat, 1E-10,
+                              MatrixCompareType::absolute));
+}
+
+GTEST_TEST(CrossProductTest, SkewSymMatTest) {
+  SkewSymMatTestFun(Vector3d(0.0, 0.0, 0.0));
+  SkewSymMatTestFun(Vector3d(1.0, 0.0, 0.0));
+  SkewSymMatTestFun(Vector3d(0.0, 1.0, 0.0));
+  SkewSymMatTestFun(Vector3d(0.0, 0.0, 1.0));
+}
+}  // namespace
+}  // namespace math
+}  // namespace drake

--- a/drake/systems/plants/joints/QuaternionFloatingJoint.cpp
+++ b/drake/systems/plants/joints/QuaternionFloatingJoint.cpp
@@ -63,7 +63,7 @@ VectorXd QuaternionFloatingJoint::randomConfiguration(
   q[2] = normal(generator);
 
   // orientation
-  Vector4d quat = drake::math::uniformlyRandomQuat(generator);
+  Vector4d quat = drake::math::UniformlyRandomQuat(generator);
   q[3] = quat(0);
   q[4] = quat(1);
   q[5] = quat(2);

--- a/drake/systems/plants/joints/QuaternionFloatingJoint.cpp
+++ b/drake/systems/plants/joints/QuaternionFloatingJoint.cpp
@@ -1,6 +1,8 @@
 #include "QuaternionFloatingJoint.h"
 #include <random>
 
+#include "drake/math/random_rotation.h"
+
 using namespace Eigen;
 using namespace std;
 
@@ -61,7 +63,7 @@ VectorXd QuaternionFloatingJoint::randomConfiguration(
   q[2] = normal(generator);
 
   // orientation
-  Vector4d quat = uniformlyRandomQuat(generator);
+  Vector4d quat = drake::math::uniformlyRandomQuat(generator);
   q[3] = quat(0);
   q[4] = quat(1);
   q[5] = quat(2);

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.cpp
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.cpp
@@ -44,6 +44,6 @@ VectorXd RollPitchYawFloatingJoint::randomConfiguration(
   }
 
   Map<Vector3d> rpy(&q[3]);
-  rpy = drake::math::uniformlyRandomRPY(generator);
+  rpy = drake::math::UniformlyRandomRPY(generator);
   return q;
 }

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.cpp
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.cpp
@@ -4,6 +4,8 @@
 
 #include <Eigen/Dense>
 
+#include "drake/math/random_rotation.h"
+
 using Eigen::Map;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
@@ -42,6 +44,6 @@ VectorXd RollPitchYawFloatingJoint::randomConfiguration(
   }
 
   Map<Vector3d> rpy(&q[3]);
-  rpy = uniformlyRandomRPY(generator);
+  rpy = drake::math::uniformlyRandomRPY(generator);
   return q;
 }

--- a/drake/util/CMakeLists.txt
+++ b/drake/util/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 drake_install_headers(drakeGradientUtil.h)
 
 add_library_with_exports(LIB_NAME drakeGeometryUtil SOURCE_FILES drakeGeometryUtil.cpp)
-target_link_libraries(drakeGeometryUtil drakeCommon)
+target_link_libraries(drakeGeometryUtil drakeCommon drakeMath)
 pods_install_libraries(drakeGeometryUtil)
 drake_install_headers(drakeGeometryUtil.h)
 pods_install_pkg_config_file(drake-geometry-util

--- a/drake/util/drakeGeometryUtil.cpp
+++ b/drake/util/drakeGeometryUtil.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 
 #include "drake/math/axis_angle.h"
+#include "drake/math/random_rotation.h"
 
 using namespace Eigen;
 
@@ -18,27 +19,19 @@ double angleDiff(double phi1, double phi2) {
 }
 
 Vector4d uniformlyRandomAxisAngle(std::default_random_engine& generator) {
-  std::normal_distribution<double> normal;
-  std::uniform_real_distribution<double> uniform(-M_PI, M_PI);
-  double angle = uniform(generator);
-  Vector3d axis =
-      Vector3d(normal(generator), normal(generator), normal(generator));
-  axis.normalize();
-  Vector4d a;
-  a << axis, angle;
-  return a;
+  return drake::math::uniformlyRandomAxisAngle(generator);
 }
 
 Vector4d uniformlyRandomQuat(std::default_random_engine& generator) {
-  return drake::math::axis2quat(uniformlyRandomAxisAngle(generator));
+  return drake::math::uniformlyRandomQuat(generator);
 }
 
 Eigen::Matrix3d uniformlyRandomRotmat(std::default_random_engine& generator) {
-  return drake::math::axis2rotmat(uniformlyRandomAxisAngle(generator));
+  return drake::math::uniformlyRandomRotmat(generator);
 }
 
 Eigen::Vector3d uniformlyRandomRPY(std::default_random_engine& generator) {
-  return drake::math::axis2rpy(uniformlyRandomAxisAngle(generator));
+  return drake::math::uniformlyRandomRPY(generator);
 }
 
 DRAKEGEOMETRYUTIL_EXPORT int rotationRepresentationSize(int rotation_type) {

--- a/drake/util/drakeGeometryUtil.cpp
+++ b/drake/util/drakeGeometryUtil.cpp
@@ -18,22 +18,6 @@ double angleDiff(double phi1, double phi2) {
   return d;
 }
 
-Vector4d uniformlyRandomAxisAngle(std::default_random_engine& generator) {
-  return drake::math::UniformlyRandomAxisAngle(generator);
-}
-
-Vector4d uniformlyRandomQuat(std::default_random_engine& generator) {
-  return drake::math::UniformlyRandomQuat(generator);
-}
-
-Eigen::Matrix3d uniformlyRandomRotmat(std::default_random_engine& generator) {
-  return drake::math::UniformlyRandomRotmat(generator);
-}
-
-Eigen::Vector3d uniformlyRandomRPY(std::default_random_engine& generator) {
-  return drake::math::UniformlyRandomRPY(generator);
-}
-
 DRAKEGEOMETRYUTIL_EXPORT int rotationRepresentationSize(int rotation_type) {
   switch (rotation_type) {
     case 0:

--- a/drake/util/drakeGeometryUtil.cpp
+++ b/drake/util/drakeGeometryUtil.cpp
@@ -19,19 +19,19 @@ double angleDiff(double phi1, double phi2) {
 }
 
 Vector4d uniformlyRandomAxisAngle(std::default_random_engine& generator) {
-  return drake::math::uniformlyRandomAxisAngle(generator);
+  return drake::math::UniformlyRandomAxisAngle(generator);
 }
 
 Vector4d uniformlyRandomQuat(std::default_random_engine& generator) {
-  return drake::math::uniformlyRandomQuat(generator);
+  return drake::math::UniformlyRandomQuat(generator);
 }
 
 Eigen::Matrix3d uniformlyRandomRotmat(std::default_random_engine& generator) {
-  return drake::math::uniformlyRandomRotmat(generator);
+  return drake::math::UniformlyRandomRotmat(generator);
 }
 
 Eigen::Vector3d uniformlyRandomRPY(std::default_random_engine& generator) {
-  return drake::math::uniformlyRandomRPY(generator);
+  return drake::math::UniformlyRandomRPY(generator);
 }
 
 DRAKEGEOMETRYUTIL_EXPORT int rotationRepresentationSize(int rotation_type) {

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -32,12 +32,16 @@ const int RotmatSize = drake::kSpaceDimension * drake::kSpaceDimension;
 
 DRAKEGEOMETRYUTIL_EXPORT double angleDiff(double phi1, double phi2);
 
+DRAKE_DEPRECATED("Use drake::math::uniformlyRandomAxisAngle instead.")
 DRAKEGEOMETRYUTIL_EXPORT Eigen::Vector4d uniformlyRandomAxisAngle(
     std::default_random_engine& generator);
+DRAKE_DEPRECATED("Use drake::math::uniformlyRandomQuat instead.")
 DRAKEGEOMETRYUTIL_EXPORT Eigen::Vector4d uniformlyRandomQuat(
     std::default_random_engine& generator);
+DRAKE_DEPRECATED("Use drake::math::uniformlyRandomRotmat instead.")
 DRAKEGEOMETRYUTIL_EXPORT Eigen::Matrix3d uniformlyRandomRotmat(
     std::default_random_engine& generator);
+DRAKE_DEPRECATED("Use drake::math::uniformlyRandomRPY instead.")
 DRAKEGEOMETRYUTIL_EXPORT Eigen::Vector3d uniformlyRandomRPY(
     std::default_random_engine& generator);
 

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -759,7 +759,7 @@ drake::TwistMatrix<typename DerivedA::Scalar> dCrossSpatialForce(
 template <typename DerivedQdotToV>
 struct DHomogTrans {
   typedef typename Eigen::Matrix<typename DerivedQdotToV::Scalar,
-                                 drake::kHomogeneousTransform,
+                                 drake::kHomogeneousTransformSize,
                                  DerivedQdotToV::ColsAtCompileTime>
       type;
 };
@@ -774,7 +774,7 @@ typename DHomogTrans<DerivedQdotToV>::type dHomogTrans(
   typename DerivedQdotToV::Index nq = qdot_to_v.cols();
   auto qdot_to_twist = (S * qdot_to_v).eval();
 
-  const int numel = drake::kHomogeneousTransform;
+  const int numel = drake::kHomogeneousTransformSize;
   Eigen::Matrix<typename DerivedQdotToV::Scalar, numel, nq_at_compile_time> ret(
       numel, nq);
 
@@ -820,7 +820,7 @@ typename DHomogTrans<DerivedDT>::type dHomogTransInv(
   auto dinvT_R = transposeGrad(dR, R.rows());
   auto dinvT_p = (-R.transpose() * dp - matGradMult(dinvT_R, p)).eval();
 
-  const int numel = drake::kHomogeneousTransform;
+  const int numel = drake::kHomogeneousTransformSize;
   Eigen::Matrix<typename DerivedDT::Scalar, numel, DerivedDT::ColsAtCompileTime>
       ret(numel, nq);
   setSubMatrixGradient<Eigen::Dynamic>(ret, dinvT_R, rows, R_cols, T.Rows);

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -33,19 +33,6 @@ const int RotmatSize = drake::kSpaceDimension * drake::kSpaceDimension;
 
 DRAKEGEOMETRYUTIL_EXPORT double angleDiff(double phi1, double phi2);
 
-DRAKE_DEPRECATED("Use drake::math::uniformlyRandomAxisAngle instead.")
-DRAKEGEOMETRYUTIL_EXPORT Eigen::Vector4d uniformlyRandomAxisAngle(
-    std::default_random_engine& generator);
-DRAKE_DEPRECATED("Use drake::math::uniformlyRandomQuat instead.")
-DRAKEGEOMETRYUTIL_EXPORT Eigen::Vector4d uniformlyRandomQuat(
-    std::default_random_engine& generator);
-DRAKE_DEPRECATED("Use drake::math::uniformlyRandomRotmat instead.")
-DRAKEGEOMETRYUTIL_EXPORT Eigen::Matrix3d uniformlyRandomRotmat(
-    std::default_random_engine& generator);
-DRAKE_DEPRECATED("Use drake::math::uniformlyRandomRPY instead.")
-DRAKEGEOMETRYUTIL_EXPORT Eigen::Vector3d uniformlyRandomRPY(
-    std::default_random_engine& generator);
-
 // NOTE: not reshaping second derivative to Matlab geval output format!
 template <typename Derived>
 void normalizeVec(
@@ -276,16 +263,6 @@ drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
     }
   }
   return dq;
-}
-
-/*
- * cross product related
- */
-template <typename Derived>
-DRAKE_DEPRECATED("Use drake::math::VectorToSkewSymmetric instead.")
-Eigen::Matrix<typename Derived::Scalar, 3, 3> vectorToSkewSymmetric(
-    const Eigen::MatrixBase<Derived>& p) {
-  return drake::math::VectorToSkewSymmetric(p);
 }
 
 /*

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -18,6 +18,7 @@
 #include "drake/math/quaternion.h"
 #include "drake/util/drakeGradientUtil.h"
 
+DRAKE_DEPRECATED("Use drake::kHomogeneousTransformSize instead.")
 const int HOMOGENEOUS_TRANSFORM_SIZE = 16;
 
 DRAKE_DEPRECATED("Use drake::kQuaternionSize instead.")
@@ -26,7 +27,7 @@ DRAKE_DEPRECATED("Use drake::kRpySize instead.")
 const int RPY_SIZE = 3;
 DRAKE_DEPRECATED("Use drake::kSpaceDimension instead.")
 const int SPACE_DIMENSION = 3;
-
+DRAKE_DEPRECATED("Use drake::kRotmatSize instead.")
 const int RotmatSize = drake::kSpaceDimension * drake::kSpaceDimension;
 
 DRAKEGEOMETRYUTIL_EXPORT double angleDiff(double phi1, double phi2);
@@ -117,7 +118,7 @@ drotmat2rpy(const Eigen::MatrixBase<DerivedR>& R,
                                            drake::kSpaceDimension,
                                            drake::kSpaceDimension);
   EIGEN_STATIC_ASSERT(
-      Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == RotmatSize,
+      Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == drake::kRotmatSize,
       THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE);
 
   typename DerivedDR::Index nq = dR.cols();
@@ -167,7 +168,7 @@ drotmat2quat(const Eigen::MatrixBase<DerivedR>& R,
                                            drake::kSpaceDimension,
                                            drake::kSpaceDimension);
   EIGEN_STATIC_ASSERT(
-      Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == RotmatSize,
+      Eigen::MatrixBase<DerivedDR>::RowsAtCompileTime == drake::kRotmatSize,
       THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE);
 
   typedef typename DerivedR::Scalar Scalar;
@@ -763,7 +764,7 @@ drake::TwistMatrix<typename DerivedA::Scalar> dCrossSpatialForce(
 template <typename DerivedQdotToV>
 struct DHomogTrans {
   typedef typename Eigen::Matrix<typename DerivedQdotToV::Scalar,
-                                 HOMOGENEOUS_TRANSFORM_SIZE,
+                                 drake::kHomogeneousTransform,
                                  DerivedQdotToV::ColsAtCompileTime> type;
 };
 
@@ -777,7 +778,7 @@ typename DHomogTrans<DerivedQdotToV>::type dHomogTrans(
   typename DerivedQdotToV::Index nq = qdot_to_v.cols();
   auto qdot_to_twist = (S * qdot_to_v).eval();
 
-  const int numel = HOMOGENEOUS_TRANSFORM_SIZE;
+  const int numel = drake::kHomogeneousTransform;
   Eigen::Matrix<typename DerivedQdotToV::Scalar, numel, nq_at_compile_time> ret(
       numel, nq);
 
@@ -823,7 +824,7 @@ typename DHomogTrans<DerivedDT>::type dHomogTransInv(
   auto dinvT_R = transposeGrad(dR, R.rows());
   auto dinvT_p = (-R.transpose() * dp - matGradMult(dinvT_R, p)).eval();
 
-  const int numel = HOMOGENEOUS_TRANSFORM_SIZE;
+  const int numel = drake::kHomogeneousTransform;
   Eigen::Matrix<typename DerivedDT::Scalar, numel, DerivedDT::ColsAtCompileTime>
       ret(numel, nq);
   setSubMatrixGradient<Eigen::Dynamic>(ret, dinvT_R, rows, R_cols, T.Rows);

--- a/drake/util/test/testDrakeGeometryUtil.cpp
+++ b/drake/util/test/testDrakeGeometryUtil.cpp
@@ -31,7 +31,7 @@ GTEST_TEST(DrakeGeometryUtilTest, DHomogTrans) {
   std::default_random_engine generator;
 
   for (int testnr = 0; testnr < ntests; testnr++) {
-    Vector4d q = drake::math::uniformlyRandomQuat(generator);
+    Vector4d q = drake::math::UniformlyRandomQuat(generator);
     T = Quaterniond(q(0), q(1), q(2), q(3));
     //  T.setIdentity();
     //  T = AngleAxisd(M_PI_2, Vector3d(1.0, 0.0, 0.0));
@@ -60,7 +60,7 @@ GTEST_TEST(DrakeGeometryUtilTest, DHomogTransInv) {
   Isometry3d T;
   std::default_random_engine generator;
   for (int testnr = 0; testnr < ntests; testnr++) {
-    Vector4d q = drake::math::uniformlyRandomQuat(generator);
+    Vector4d q = drake::math::UniformlyRandomQuat(generator);
     //    T = Quaterniond(q(0), q(1), q(2), q(3)) *
     //    Translation3d(Vector3d::Random());
     T = Quaterniond(q(0), q(1), q(2), q(3));
@@ -100,7 +100,7 @@ GTEST_TEST(DrakeGeometryUtilTest, DTransformAdjoint) {
   std::default_random_engine generator;
 
   for (int testnr = 0; testnr < ntests; testnr++) {
-    Vector4d q = drake::math::uniformlyRandomQuat(generator);
+    Vector4d q = drake::math::UniformlyRandomQuat(generator);
     T = Quaterniond(q(0), q(1), q(2), q(3)) * Translation3d(Vector3d::Random());
     auto S = Matrix<double, 6, Dynamic>::Random(6, nv).eval();
     auto qdot_to_v = MatrixXd::Random(nv, nq).eval();
@@ -123,7 +123,7 @@ GTEST_TEST(DrakeGeometryUtilTest, DTransformAdjointTranspose) {
   std::default_random_engine generator;
 
   for (int testnr = 0; testnr < ntests; testnr++) {
-    Vector4d q = drake::math::uniformlyRandomQuat(generator);
+    Vector4d q = drake::math::UniformlyRandomQuat(generator);
     T = Quaterniond(q(0), q(1), q(2), q(3)) * Translation3d(Vector3d::Random());
     auto S = Matrix<double, 6, Dynamic>::Random(6, nv).eval();
     auto qdot_to_v = MatrixXd::Random(nv, nq).eval();

--- a/drake/util/test/testDrakeGeometryUtil.cpp
+++ b/drake/util/test/testDrakeGeometryUtil.cpp
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
+#include "drake/math/random_rotation.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/util/drakeGeometryUtil.h"
 
@@ -30,7 +31,7 @@ GTEST_TEST(DrakeGeometryUtilTest, DHomogTrans) {
   std::default_random_engine generator;
 
   for (int testnr = 0; testnr < ntests; testnr++) {
-    Vector4d q = uniformlyRandomQuat(generator);
+    Vector4d q = drake::math::uniformlyRandomQuat(generator);
     T = Quaterniond(q(0), q(1), q(2), q(3));
     //  T.setIdentity();
     //  T = AngleAxisd(M_PI_2, Vector3d(1.0, 0.0, 0.0));
@@ -59,7 +60,7 @@ GTEST_TEST(DrakeGeometryUtilTest, DHomogTransInv) {
   Isometry3d T;
   std::default_random_engine generator;
   for (int testnr = 0; testnr < ntests; testnr++) {
-    Vector4d q = uniformlyRandomQuat(generator);
+    Vector4d q = drake::math::uniformlyRandomQuat(generator);
     //    T = Quaterniond(q(0), q(1), q(2), q(3)) *
     //    Translation3d(Vector3d::Random());
     T = Quaterniond(q(0), q(1), q(2), q(3));
@@ -99,7 +100,7 @@ GTEST_TEST(DrakeGeometryUtilTest, DTransformAdjoint) {
   std::default_random_engine generator;
 
   for (int testnr = 0; testnr < ntests; testnr++) {
-    Vector4d q = uniformlyRandomQuat(generator);
+    Vector4d q = drake::math::uniformlyRandomQuat(generator);
     T = Quaterniond(q(0), q(1), q(2), q(3)) * Translation3d(Vector3d::Random());
     auto S = Matrix<double, 6, Dynamic>::Random(6, nv).eval();
     auto qdot_to_v = MatrixXd::Random(nv, nq).eval();
@@ -122,7 +123,7 @@ GTEST_TEST(DrakeGeometryUtilTest, DTransformAdjointTranspose) {
   std::default_random_engine generator;
 
   for (int testnr = 0; testnr < ntests; testnr++) {
-    Vector4d q = uniformlyRandomQuat(generator);
+    Vector4d q = drake::math::uniformlyRandomQuat(generator);
     T = Quaterniond(q(0), q(1), q(2), q(3)) * Translation3d(Vector3d::Random());
     auto S = Matrix<double, 6, Dynamic>::Random(6, nv).eval();
     auto qdot_to_v = MatrixXd::Random(nv, nq).eval();

--- a/drake/util/test/testGeometryConversionFunctionsmex.cpp
+++ b/drake/util/test/testGeometryConversionFunctionsmex.cpp
@@ -57,7 +57,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
 
   auto R = drake::math::quat2rotmat(q);
   auto dq2R = dquat2rotmat(q);
-  Matrix<double, RotmatSize, Dynamic> dR = dq2R * dq;
+  Matrix<double, drake::kRotmatSize, Dynamic> dR = dq2R * dq;
   auto drpydR = drotmat2rpy(R, dR);
   auto dqdR = drotmat2quat(R, dR);
 

--- a/drake/util/test/testGeometryGradientsmex.cpp
+++ b/drake/util/test/testGeometryGradientsmex.cpp
@@ -1,5 +1,6 @@
 #include <mex.h>
 
+#include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeMexUtil.h"
@@ -18,7 +19,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   int argnum = 0;
   Isometry3d T;
   memcpy(T.data(), mxGetPr(prhs[argnum++]),
-         sizeof(double) * HOMOGENEOUS_TRANSFORM_SIZE);
+         sizeof(double) * drake::kHomogeneousTransform);
   auto S = matlabToEigen<drake::kTwistSize, Eigen::Dynamic>(prhs[argnum++]);
   auto qdot_to_v =
       matlabToEigen<Eigen::Dynamic, Eigen::Dynamic>(prhs[argnum++]);

--- a/drake/util/test/testGeometryGradientsmex.cpp
+++ b/drake/util/test/testGeometryGradientsmex.cpp
@@ -19,7 +19,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
   int argnum = 0;
   Isometry3d T;
   memcpy(T.data(), mxGetPr(prhs[argnum++]),
-         sizeof(double) * drake::kHomogeneousTransform);
+         sizeof(double) * drake::kHomogeneousTransformSize);
   auto S = matlabToEigen<drake::kTwistSize, Eigen::Dynamic>(prhs[argnum++]);
   auto qdot_to_v =
       matlabToEigen<Eigen::Dynamic, Eigen::Dynamic>(prhs[argnum++]);


### PR DESCRIPTION
This is the first PR to clean `drakeGeometryUtil`. This PR contains three changes

1. Put the constants such as `SPACE_DIMENSION` into `drake/common/constants`.
2. Pull the functions to generate random orientation into a separate file `drake/math/random_orientation.h`
3. Pull the functions on cross product into `drake/math/cross_product.h`.

I would expect subsequent PRs to continue clean up `drakeGeometryUtil`. Like this PR, it would make following changes.

1. If a function is dead (like `dcrossProduct`), then delete it.
2. If a function should continue to live, then pull it out to a separate file; deprecate the function in `drakeGeometryUtil`.
3. Write a test function (`cross_product_test` in this PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3441)
<!-- Reviewable:end -->
