### PR TITLE
Fix submodule sync for AVL and XFOIL during Ninja builds of drake

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -387,7 +387,7 @@ function(drake_add_external PROJECT)
 
     # Add external to download dependencies
     add_dependencies(download-all ${PROJECT}-update)
-  elseif(_ext_GENERATOR STREQUAL "Ninja" AND CMAKE_VERSION VERSION_LESS 3.7)
+  elseif(CMAKE_GENERATOR STREQUAL "Ninja" AND CMAKE_VERSION VERSION_LESS 3.7)
     # Due to a quirk of how the CMake Ninja generator computes dependencies,
     # all targets that contain a submodule update command, or depend on a
     # target that does, need to depend on the submodule-sync target, or the


### PR DESCRIPTION
Not sure this actually broke anything at present, but @mwoehlke-kitware points out that it is incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3448)
<!-- Reviewable:end -->
