### PR TITLE
Add eigen_aligned_std_vector helper

### DIFF
--- a/drake/common/eigen_stl_types.h
+++ b/drake/common/eigen_stl_types.h
@@ -7,14 +7,20 @@
 #include <unordered_map>
 
 #include <Eigen/Core>
+#include <Eigen/StdVector>
 
 namespace drake {
 
-/// A std::unordered_map that uses Eigen::aligned_allocator, so that the
+/// A std::unordered_map that uses Eigen::aligned_allocator so that the
 /// contained types may be fixed-size Eigen values.
 template <typename Key, typename T>
 using eigen_aligned_std_unordered_map =
     std::unordered_map<Key, T, std::hash<Key>, std::equal_to<Key>,
                        Eigen::aligned_allocator<std::pair<Key const, T>>>;
+
+/// A std::vector that uses Eigen::aligned_allocator so that the contained
+/// types may be fixed-size Eigen values.
+template <typename T>
+using eigen_aligned_std_vector = std::vector<T, Eigen::aligned_allocator<T>>;
 
 }  // namespace drake

--- a/drake/systems/controllers/controlUtil.h
+++ b/drake/systems/controllers/controlUtil.h
@@ -4,11 +4,11 @@
 #include <set>
 #include <vector>
 #include <Eigen/Dense>
-#include <Eigen/StdVector>
 
+#include "drake/common/eigen_stl_types.h"
+#include "drake/drakeControlUtil_export.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
-#include "drake/drakeControlUtil_export.h"
 
 const int m_surface_tangents =
     2;  // number of faces in the friction cone approx
@@ -20,8 +20,7 @@ typedef Eigen::Matrix<double, 7, 1> Vector7d;
 
 typedef struct _support_state_element {
   int body_idx;
-  std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d>>
-      contact_pts;
+  drake::eigen_aligned_std_vector<Eigen::Vector3d> contact_pts;
   bool support_logic_map[4];
   Eigen::Vector4d support_surface;  // 4-vector describing a support surface:
                                     // [v; b] such that v' * [x;y;z] + b == 0
@@ -42,20 +41,15 @@ DRAKECONTROLUTIL_EXPORT bool isSupportElementActive(
 DRAKECONTROLUTIL_EXPORT Eigen::Matrix<bool, Eigen::Dynamic, 1>
 getActiveSupportMask(
     RigidBodyTree *r, Eigen::VectorXd q, Eigen::VectorXd qd,
-    std::vector<SupportStateElement,
-                Eigen::aligned_allocator<SupportStateElement>> &
-        available_supports,
+    drake::eigen_aligned_std_vector<SupportStateElement>& available_supports,
     const Eigen::Ref<const Eigen::Matrix<bool, Eigen::Dynamic, 1>> &
         contact_force_detected,
     double contact_threshold);
 
-DRAKECONTROLUTIL_EXPORT std::vector<
-    SupportStateElement, Eigen::aligned_allocator<SupportStateElement>>
+DRAKECONTROLUTIL_EXPORT drake::eigen_aligned_std_vector<SupportStateElement>
 getActiveSupports(
     const RigidBodyTree &r, const Eigen::VectorXd &q, const Eigen::VectorXd &qd,
-    std::vector<SupportStateElement,
-                Eigen::aligned_allocator<SupportStateElement>> &
-        available_supports,
+    drake::eigen_aligned_std_vector<SupportStateElement>& available_supports,
     const Eigen::Ref<const Eigen::Matrix<bool, Eigen::Dynamic, 1>> &
         contact_force_detected,
     double contact_threshold);
@@ -76,8 +70,7 @@ DRAKECONTROLUTIL_EXPORT void angleDiff(
     Eigen::MatrixBase<DerivedPhi2> const &phi2, Eigen::MatrixBase<DerivedD> &d);
 
 DRAKECONTROLUTIL_EXPORT bool inSupport(
-    const std::vector<SupportStateElement,
-                      Eigen::aligned_allocator<SupportStateElement>> &supports,
+    const drake::eigen_aligned_std_vector<SupportStateElement>& supports,
     int body_idx);
 DRAKECONTROLUTIL_EXPORT void surfaceTangents(
     const Eigen::Vector3d &normal,
@@ -89,15 +82,12 @@ DRAKECONTROLUTIL_EXPORT int contactPhi(const RigidBodyTree &r,
 DRAKECONTROLUTIL_EXPORT int contactConstraintsBV(
     const RigidBodyTree &r, const KinematicsCache<double> &cache, int nc,
     std::vector<double> support_mus,
-    std::vector<SupportStateElement,
-                Eigen::aligned_allocator<SupportStateElement>> &supp,
+    drake::eigen_aligned_std_vector<SupportStateElement>& supp,
     Eigen::MatrixXd &B, Eigen::MatrixXd &JB, Eigen::MatrixXd &Jp,
     Eigen::VectorXd &Jpdotv, Eigen::MatrixXd &normals);
 DRAKECONTROLUTIL_EXPORT Eigen::MatrixXd individualSupportCOPs(
     const RigidBodyTree &r, const KinematicsCache<double> &cache,
-    const std::vector<SupportStateElement,
-                      Eigen::aligned_allocator<SupportStateElement>> &
-        active_supports,
+    const drake::eigen_aligned_std_vector<SupportStateElement>& active_supports,
     const Eigen::MatrixXd &normals, const Eigen::MatrixXd &B,
     const Eigen::VectorXd &beta);
 DRAKECONTROLUTIL_EXPORT Vector6d bodySpatialMotionPD(

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <Eigen/Dense>
-#include <Eigen/StdVector>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
+
+#include <Eigen/Dense>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_deprecated.h"

--- a/drake/systems/plants/RigidBodyIK.h
+++ b/drake/systems/plants/RigidBodyIK.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <string>
+
 #include <Eigen/Dense>
-#include <Eigen/StdVector>
+
+#include "drake/drakeIK_export.h"
 #include "drake/systems/plants/constraint/RigidBodyConstraint.h"
 #include "drake/systems/plants/IKoptions.h"
-#include "drake/drakeIK_export.h"
 
 class RigidBodyTree;
 

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -1,11 +1,9 @@
 #pragma once
 
+#include <set>
+
 #include <Eigen/Dense>
 #include <Eigen/LU>
-#include <Eigen/StdVector>
-#include <set>
-#include <stdexcept>
-#include <unordered_map>
 
 #include "drake/common/constants.h"
 #include "drake/common/drake_deprecated.h"

--- a/drake/systems/plants/collision/DrakeCollision.h
+++ b/drake/systems/plants/collision/DrakeCollision.h
@@ -1,16 +1,10 @@
 #pragma once
 
-#include <memory>
-#include <set>
-#include <Eigen/Dense>
-#include <Eigen/StdVector>
-
-#include <stdexcept>
 #include <bitset>
+#include <memory>
 
-#include "drake/systems/plants/collision/Element.h"
-#include "drake/systems/plants/collision/Model.h"
 #include "drake/drakeCollision_export.h"
+#include "drake/systems/plants/collision/Model.h"
 
 static const int MAX_NUM_COLLISION_FILTER_GROUPS = 128;
 

--- a/drake/systems/plants/collision/Element.h
+++ b/drake/systems/plants/collision/Element.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include <utility>
 
 #include <Eigen/Dense>
-#include <Eigen/StdVector>
 
 #include "drake/drakeCollision_export.h"
 #include "drake/systems/plants/shapes/DrakeShapes.h"

--- a/drake/systems/plants/collision/Model.h
+++ b/drake/systems/plants/collision/Model.h
@@ -4,10 +4,9 @@
 #include <unordered_map>
 
 #include <Eigen/Dense>
-#include <Eigen/StdVector>
 
-#include "drake/systems/plants/collision/Element.h"
 #include "drake/drakeCollision_export.h"
+#include "drake/systems/plants/collision/Element.h"
 #include "drake/systems/plants/collision/point_pair.h"
 
 namespace DrakeCollision {

--- a/drake/systems/plants/collision/point_pair.h
+++ b/drake/systems/plants/collision/point_pair.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <Eigen/Dense>
-#include <Eigen/StdVector>
 
-#include "drake/systems/plants/collision/Element.h"
 #include "drake/drakeCollision_export.h"
+#include "drake/systems/plants/collision/Element.h"
 
 namespace DrakeCollision {
 

--- a/drake/systems/plants/constraint/RigidBodyConstraint.h
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.h
@@ -6,7 +6,6 @@
 
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
-#include <Eigen/StdVector>
 
 #include "drake/drakeRigidBodyConstraint_export.h"
 #include "drake/systems/plants/KinematicsCache.h"

--- a/drake/systems/plants/inverseKinBackend.h
+++ b/drake/systems/plants/inverseKinBackend.h
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include <Eigen/StdVector>
 #include <Eigen/Dense>
 
 #include "drake/solvers/decision_variable.h"

--- a/drake/systems/plants/shapes/Element.h
+++ b/drake/systems/plants/shapes/Element.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <stdint.h>
 #include <memory>
-#include <utility>
 
 #include <Eigen/Dense>
-#include <Eigen/StdVector>
 
-#include "Geometry.h"
 #include "drake/drakeShapes_export.h"
+#include "drake/systems/plants/shapes/Geometry.h"
 
 namespace DrakeShapes {
 class DRAKESHAPES_EXPORT Element {

--- a/drake/systems/plants/shapes/Geometry.h
+++ b/drake/systems/plants/shapes/Geometry.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
-#include <Eigen/StdVector>
+#include <Eigen/Dense>
 
 #include "drake/drakeShapes_export.h"
 
@@ -17,10 +18,8 @@ enum DRAKESHAPES_EXPORT Shape {
   CAPSULE = 6
 };
 
-typedef std::vector<Eigen::Vector3d,
-                    Eigen::aligned_allocator<Eigen::Vector3d>> PointsVector;
-typedef std::vector<Eigen::Vector3i,
-                    Eigen::aligned_allocator<Eigen::Vector3i>> TrianglesVector;
+typedef std::vector<Eigen::Vector3d> PointsVector;
+typedef std::vector<Eigen::Vector3i> TrianglesVector;
 
 std::string ShapeToString(Shape ss);
 

--- a/drake/systems/plants/shapes/VisualElement.h
+++ b/drake/systems/plants/shapes/VisualElement.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <memory>
-
 #include <Eigen/Dense>
-#include <Eigen/StdVector>
 
-#include "Element.h"
+#include "drake/systems/plants/shapes/Element.h"
 
+#include "drake/common/eigen_stl_types.h"
 #include "drake/drakeShapes_export.h"
 
 namespace DrakeShapes {
@@ -36,6 +34,5 @@ class DRAKESHAPES_EXPORT VisualElement : public Element {
 
 // See http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html
 // for why this is necessary.
-typedef std::vector<VisualElement, Eigen::aligned_allocator<VisualElement> >
-    VectorOfVisualElements;
+typedef drake::eigen_aligned_std_vector<VisualElement> VectorOfVisualElements;
 }


### PR DESCRIPTION
As promised in #3405, the follow-on cleanup to `std::vector` for 16-byte-aligned Eigen types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3452)
<!-- Reviewable:end -->
