### PR TITLE
Make System2 output evaluation "pull" instead of "push".

### DIFF
--- a/drake/automotive/automotive_demo.cc
+++ b/drake/automotive/automotive_demo.cc
@@ -45,7 +45,7 @@ class BotVisualizerHack : public systems::LeafSystem<T> {
     DRAKE_DEMAND(sent_load_robot_);
 
     const systems::VectorBase<double>* const input_base =
-        context.get_vector_input(0);
+        this->EvalVectorInput(context, 0);
     DRAKE_DEMAND(input_base != nullptr);
     const EulerFloatingJointState<double>* const input =
         dynamic_cast<const EulerFloatingJointState<double>*>(input_base);

--- a/drake/automotive/simple_car-inl.h
+++ b/drake/automotive/simple_car-inl.h
@@ -92,7 +92,7 @@ void SimpleCar<T>::EvalTimeDerivatives(
 
   // Obtain the input.
   const systems::VectorBase<T>* const vector_input =
-      context.get_vector_input(0);
+      this->EvalVectorInput(context, 0);
   DRAKE_ASSERT(vector_input);
   const DrivingCommand<T>* const input =
       dynamic_cast<const DrivingCommand<T>*>(vector_input);

--- a/drake/automotive/simple_car_to_euler_floating_joint.h
+++ b/drake/automotive/simple_car_to_euler_floating_joint.h
@@ -27,7 +27,7 @@ class SimpleCarToEulerFloatingJoint : public systems::LeafSystem<T> {
     DRAKE_ASSERT_VOID(systems::System<T>::CheckValidOutput(output));
 
     typedef systems::VectorBase<T> Base;
-    const Base* const input_vector = context.get_vector_input(0);
+    const Base* const input_vector = this->EvalVectorInput(context, 0);
     DRAKE_ASSERT(input_vector != nullptr);
     const SimpleCarState<T>* const input_data =
         dynamic_cast<const SimpleCarState<T>*>(input_vector);

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -10,6 +10,7 @@ set(sources
   examples/spring_mass_system.cc
   leaf_context.cc
   leaf_system.cc
+  input_port_evaluator_interface.cc
   output_port_listener_interface.cc
   primitives/adder.cc
   primitives/constant_value_source.cc
@@ -48,6 +49,7 @@ set(installed_headers
   diagram_context.h
   leaf_context.h
   leaf_system.h
+  input_port_evaluator_interface.h
   output_port_listener_interface.h
   state.h
   state_subvector.h

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/value.h"
@@ -41,34 +42,21 @@ class Context {
 
   /// Connects the input port @p port to this Context at the given @p index.
   /// Disconnects whatever input port was previously there, and deregisters
-  /// it from the output port on which it depends.
+  /// it from the output port on which it depends.  In some Context
+  /// implementations, may require a recursive search through a tree of
+  /// subcontexts.
+  /// Throws std::out_of_range if @p index is out of range.
   virtual void SetInputPort(int index, std::unique_ptr<InputPort> port) = 0;
+
+  /// Returns the InputPort at the given @p index, which may be nullptr if
+  /// it has never been set with SetInputPort.
+  /// Throws std::out_of_range if @p index is out of range.
+  ///
+  /// This is a framework implementation detail. User code should not call it.
+  virtual const InputPort* GetInputPort(int index) const = 0;
 
   /// Returns the number of input ports.
   virtual int get_num_input_ports() const = 0;
-
-  /// Returns the vector data of the input port at @p index. Returns nullptr
-  /// if that port is not a vector-valued port, or if it is not connected.
-  /// Throws std::out_of_range if that port does not exist.
-  virtual const BasicVector<T>* get_vector_input(int index) const = 0;
-
-  /// Returns the abstract data of the input port at @p index. Returns nullptr
-  /// if that port is not connected. Throws std::out_of_range if that port
-  /// does not exist.
-  virtual const AbstractValue* get_abstract_input(int index) const = 0;
-
-  /// Returns the data of the input port at @p index, or nullptr if that port
-  /// is not connected.
-  ///
-  /// @tparam V The type of data expected.
-  template <typename V>
-  const V* get_input_value(int index) const {
-    const AbstractValue* value = get_abstract_input(index);
-    if (value == nullptr) {
-      return nullptr;
-    }
-    return &(value->GetValue<V>());
-  }
 
   virtual const State<T>& get_state() const = 0;
   virtual State<T>* get_mutable_state() = 0;
@@ -97,6 +85,96 @@ class Context {
     return std::unique_ptr<Context<T>>(DoClone());
   }
 
+  /// Evaluates and returns the input port identified by @p descriptor,
+  /// using the given @p evaluator, which should be the Diagram containing
+  /// the System that allocated this Context. The evaluation will be performed
+  /// in this Context's parent. It is a recursive operation that may invoke
+  /// long chains of evaluation through all the Systems that are prerequisites
+  /// to the specified port.
+  ///
+  /// Returns nullptr if the port is not connected. Aborts if the port does
+  /// not exist.
+  ///
+  /// This is a framework implementation detail.  User code should not call it.
+  const InputPort* EvalInputPort(
+      const detail::InputPortEvaluatorInterface<T>* evaluator,
+      const SystemPortDescriptor<T>& descriptor) const {
+    const InputPort* port = GetInputPort(descriptor.get_index());
+    if (port == nullptr) return nullptr;
+    if (port->requires_evaluation()) {
+      DRAKE_DEMAND(evaluator != nullptr);
+      evaluator->EvaluateSubsystemInputPort(parent_, descriptor);
+    }
+    return port;
+  }
+
+  /// Evaluates and returns the vector data of the input port with the given
+  /// @p descriptor. This is a recursive operation that may invoke long chains
+  /// of evaluation through all the Systems that are prerequisite to the
+  /// specified port.
+  ///
+  /// Returns nullptr if the port is not connected.
+  /// Throws std::bad_cast if the port is not vector-valued.
+  /// Aborts if the port does not exist.
+  ///
+  /// This is a framework implementation detail.  User code should not call it.
+  const BasicVector<T>* EvalVectorInput(
+      const detail::InputPortEvaluatorInterface<T>* evaluator,
+      const SystemPortDescriptor<T>& descriptor) const {
+    const InputPort* port = EvalInputPort(evaluator, descriptor);
+    if (port == nullptr) return nullptr;
+    return port->template get_vector_data<T>();
+  }
+
+  /// Evaluates and returns the abstract data of the input port at @p index.
+  /// This is a recursive operation that may invoke long chains of evaluation
+  /// through all the Systems that are prerequisite to the specified port.
+  ///
+  /// Returns nullptr if the port is not connected.
+  /// Aborts if the port does not exist.
+  ///
+  /// This is a framework implementation detail.  User code should not call it.
+  const AbstractValue* EvalAbstractInput(
+      const detail::InputPortEvaluatorInterface<T>* evaluator,
+      const SystemPortDescriptor<T>& descriptor) const {
+    const InputPort* port = EvalInputPort(evaluator, descriptor);
+    if (port == nullptr) return nullptr;
+    return port->get_abstract_data();
+  }
+
+  /// Evaluates and returns the data of the input port at @p index.
+  /// This is a recursive operation that may invoke long chains of evaluation
+  /// through all the Systems that are prerequisite to the specified port.
+  ///
+  /// Returns nullptr if the port is not connected.
+  /// Throws std::bad_cast if the port does not have type V.
+  /// Aborts if the port does not exist.
+  ///
+  /// This is a framework implementation detail.  User code should not call it.
+  ///
+  /// @tparam V The type of data expected.
+  template <typename V>
+  const V* EvalInputValue(
+      const detail::InputPortEvaluatorInterface<T>* evaluator,
+      const SystemPortDescriptor<T>& descriptor) const {
+    const AbstractValue* value = EvalAbstractInput(evaluator, descriptor);
+    if (value == nullptr) return nullptr;
+    return &(value->GetValue<V>());
+  }
+
+  /// Declares that @p parent is the context of the enclosing Diagram. The
+  /// enclosing Diagram context is needed to evaluate inputs recursively.
+  /// Aborts if the parent has already been set to something else.
+  ///
+  /// This is a dangerous implementation detail. Conceptually, a Context
+  /// ought to be completely ignorant of its parent Context. However, we
+  /// need this pointer so that we can cause our inputs to be evaluated in
+  /// EvalInputPort.  See https://github.com/RobotLocomotion/drake/pull/3455.
+  void set_parent(const Context<T>* parent) {
+    DRAKE_DEMAND(parent_ == nullptr || parent_ == parent);
+    parent_ = parent;
+  }
+
  protected:
   /// Contains the return-type-covariant implementation of Clone().
   virtual Context<T>* DoClone() const = 0;
@@ -113,6 +191,11 @@ class Context {
  private:
   // Current time and step information.
   StepInfo<T> step_info_;
+
+  // The context of the enclosing Diagram, used in EvalInputPort.
+  // This pointer MUST be treated as a black box. If you call any substantive
+  // methods on it, you are probably making a mistake.
+  const Context<T>* parent_ = nullptr;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 #include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/diagram_context.h"
 #include "drake/systems/framework/leaf_context.h"
@@ -89,7 +90,8 @@ class DiagramTimeDerivatives : public DiagramContinuousState<T> {
 /// themselves, and the edges connect the output of one constituent System
 /// to the input of another. To construct a Diagram, use a DiagramBuilder.
 template <typename T>
-class Diagram : public System<T> {
+class Diagram : public System<T>,
+                public detail::InputPortEvaluatorInterface<T> {
  public:
   typedef typename std::pair<const System<T>*, int> PortIdentifier;
 
@@ -178,11 +180,11 @@ class Diagram : public System<T> {
     ExposeSubsystemOutputs(*diagram_context, diagram_output);
 
     // Since the diagram output now contains pointers to the subsystem outputs,
-    // all we need to do is compute all the subsystem outputs in sorted order.
-    //
-    // TODO(david-german-tri): This can be made less conservative. We don't need
-    // to compute intermediate outputs that don't affect the diagram outputs.
-    ComputeAllSubsystemOutputs(diagram_context);
+    // all we need to do is ask those subsystem outputs to evaluate themselves.
+    // They will recursively evaluate any intermediate inputs that they need.
+    for (const PortIdentifier& id : output_port_ids_) {
+      EvaluateOutputPort(*diagram_context, id);
+    }
   }
 
   std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const override {
@@ -196,13 +198,8 @@ class Diagram : public System<T> {
 
   void EvalTimeDerivatives(const Context<T>& context,
                            ContinuousState<T>* derivatives) const override {
-    // Freshen all the subsystem inputs to match the provided context.
-    //
-    // TODO(david-german-tri): This can be made less conservative: we don't
-    // need to freshen inputs to subsystems with no state.
     auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
     DRAKE_DEMAND(diagram_context != nullptr);
-    ComputeAllSubsystemOutputs(diagram_context);
 
     auto diagram_derivatives =
         dynamic_cast<DiagramContinuousState<T>*>(derivatives);
@@ -266,19 +263,53 @@ class Diagram : public System<T> {
     return subcontext->get_mutable_state();
   }
 
+  /// Returns the full path of this Diagram in the tree of Diagrams. Implemented
+  /// here to satisfy InputPortEvaluatorInterface, although we want the exact
+  /// same behavior as in System.
+  void GetPath(std::stringstream* output) const override {
+    return System<T>::GetPath(output);
+  }
+
+  /// Evaluates the value of the subsystem input port with the given @p id
+  /// in the given @p context. Satisfies InputPortEvaluatorInterface.
+  ///
+  /// This is a framework implementation detail. User code should not call
+  /// this function.
+  void EvaluateSubsystemInputPort(
+      const Context<T>* context,
+      const SystemPortDescriptor<T>& descriptor) const override {
+    // Find the output port connected to the given input port.
+    const PortIdentifier id{descriptor.get_system(), descriptor.get_index()};
+    const auto upstream_it = dependency_graph_.find(id);
+
+    auto diagram_context = dynamic_cast<const DiagramContext<T>*>(context);
+
+    // If the upstream output port exists in this Diagram, evaluate it.
+    // TODO(david-german-tri): Add online algebraic loop detection here.
+    if (upstream_it != dependency_graph_.end()) {
+      DRAKE_DEMAND(diagram_context != nullptr);
+      const PortIdentifier& prerequisite = upstream_it->second;
+      this->EvaluateOutputPort(*diagram_context, prerequisite);
+    }
+
+    // If the upstream output port is an input of this whole Diagram, ask our
+    // parent to evaluate it.
+    const auto external_it =
+        std::find(input_port_ids_.begin(), input_port_ids_.end(), id);
+    if (external_it != input_port_ids_.end()) {
+      const int i = external_it - input_port_ids_.begin();
+      this->EvalInputPort(*diagram_context, i);
+    }
+  }
+
  protected:
   /// Constructs an uninitialized Diagram. Subclasses that use this constructor
   /// are obligated to call DiagramBuilder::BuildInto(this).
   Diagram() {}
 
   void DoPublish(const Context<T>& context) const override {
-    // Freshen all the subsystem inputs to match the provided context.
-    //
-    // TODO(david-german-tri): This can be made less conservative: we don't
-    // need to freshen inputs to subsystems that don't Publish.
     auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
     DRAKE_DEMAND(diagram_context != nullptr);
-    ComputeAllSubsystemOutputs(diagram_context);
 
     for (const System<T>* const system : sorted_systems_) {
       const int i = GetSystemIndexOrAbort(system);
@@ -306,7 +337,9 @@ class Diagram : public System<T> {
 
   // Constructs a Diagram from the Blueprint that a DiagramBuilder produces.
   // This constructor is private because only DiagramBuilder calls it.
-  explicit Diagram(const Blueprint& blueprint) { Initialize(blueprint); }
+  explicit Diagram(const Blueprint& blueprint) {
+    Initialize(blueprint);
+  }
 
   // Validates the given @p blueprint and sets up the Diagram accordingly.
   void Initialize(const Blueprint& blueprint) {
@@ -357,6 +390,10 @@ class Diagram : public System<T> {
     }
     // All of those checks having passed, take ownership of the subsystems.
     registered_systems_ = std::move(registered_systems);
+    // Inform the constituent system it's bound to this Diagram.
+    for (auto& system : registered_systems_) {
+      system->set_parent(this);
+    }
   }
 
   // Exposes the given port as an input of the Diagram.
@@ -401,6 +438,28 @@ class Diagram : public System<T> {
     this->DeclareOutputPort(descriptor);
   }
 
+  // Evaluates the value of the output port with the given @p id in the given
+  // @p context.
+  //
+  // TODO(david-german-tri): Add Diagram-level cache entries to keep track of
+  // whether a given output port has already been evaluated.  Right now, we
+  // are recomputing every intermediate output to satisfy every system that
+  // depends on it, recursively. This is O(N^2 * M), where M is the number of
+  // output ports the Diagram exposes, and N is the number of intermediate
+  // output ports the Diagram contains.
+  void EvaluateOutputPort(const DiagramContext<T>& context,
+                          const PortIdentifier& id) const {
+    const System<T>* const system = id.first;
+    const int i = GetSystemIndexOrAbort(system);
+    log()->trace("Evaluating output for subsystem {}, port {}",
+                 system->GetPath(), id.second);
+    const Context<T>* subsystem_context = context.GetSubsystemContext(i);
+    SystemOutput<T>* subsystem_output = context.GetSubsystemOutput(i);
+    // TODO(david-german-tri): Once #2890 is resolved, only evaluate the
+    // particular port specified in id.second.
+    system->EvalOutput(*subsystem_context, subsystem_output);
+  }
+
   // Returns the index of the given @p sys in the sorted order of this diagram,
   // or aborts if @p sys is not a member of the diagram.
   int GetSystemIndexOrAbort(const System<T>* sys) const {
@@ -440,21 +499,6 @@ class Diagram : public System<T> {
 
       // Then, put a pointer to that OutputPort in the DiagramOutput.
       (*output->get_mutable_ports())[i] = output_port;
-    }
-  }
-
-  // In sorted order, compute the outputs for all subsystems. This is also a
-  // blunt way to update the inputs for all subsystems to match the given
-  // @p context.
-  void ComputeAllSubsystemOutputs(const DiagramContext<T>* context) const {
-    DRAKE_DEMAND(context != nullptr);
-    // TODO(david-german-tri): Use the diagram-level cache to skip systems that
-    // are already fresh.
-    for (const System<T>* const system : sorted_systems_) {
-      const int i = GetSystemIndexOrAbort(system);
-      const Context<T>* subsystem_context = context->GetSubsystemContext(i);
-      SystemOutput<T>* subsystem_output = context->GetSubsystemOutput(i);
-      system->EvalOutput(*subsystem_context, subsystem_output);
     }
   }
 

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -268,8 +268,12 @@ class DiagramBuilder {
     if (registered_systems_.size() == 0) {
       throw std::logic_error("Cannot Compile an empty DiagramBuilder.");
     }
-    return typename Diagram<T>::Blueprint{
-        input_port_ids_, output_port_ids_, dependency_graph_, SortSystems()};
+    typename Diagram<T>::Blueprint blueprint;
+    blueprint.input_port_ids = input_port_ids_;
+    blueprint.output_port_ids = output_port_ids_;
+    blueprint.dependency_graph = dependency_graph_;
+    blueprint.sorted_systems = SortSystems();
+    return blueprint;
   }
 
   // DiagramBuilder objects are neither copyable nor moveable.

--- a/drake/systems/framework/examples/spring_mass_system.h
+++ b/drake/systems/framework/examples/spring_mass_system.h
@@ -101,7 +101,7 @@ class DRAKESYSTEMFRAMEWORK_EXPORT SpringMassSystem : public System<double> {
     double external_force = 0;
     DRAKE_ASSERT(system_is_forced_ == (context.get_num_input_ports() == 1));
     if (system_is_forced_) {
-      external_force = context.get_vector_input(0)->GetAtIndex(0);
+      external_force = this->EvalVectorInput(context, 0)->GetAtIndex(0);
     }
     return external_force;
   }

--- a/drake/systems/framework/input_port_evaluator_interface.cc
+++ b/drake/systems/framework/input_port_evaluator_interface.cc
@@ -1,0 +1,1 @@
+#include "drake/systems/framework/input_port_evaluator_interface.h"

--- a/drake/systems/framework/input_port_evaluator_interface.h
+++ b/drake/systems/framework/input_port_evaluator_interface.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <sstream>
+
+#include "drake/drakeSystemFramework_export.h"
+#include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T> class Context;
+
+namespace detail {
+
+/// InputPortEvaluatorInterface is implemented by classes that are able to
+/// evaluate the OutputPort connected to a particular InputPort.
+///
+/// This interface is a Drake-internal detail. Users should never implement
+/// it. In fact, only Diagram should implement it. It exists primarily to
+/// narrow the methods Systems can invoke on their parent pointer, and
+/// secondarily to break circular includes between the System hierarchy and
+/// the Context hierarchy.
+///
+/// @tparam T A mathematical type that is a valid Eigen scalar.
+template <typename T>
+class DRAKESYSTEMFRAMEWORK_EXPORT InputPortEvaluatorInterface {
+ public:
+  virtual ~InputPortEvaluatorInterface() {}
+
+  /// Evaluates the input port with the given @p id in the given @p context.
+  /// The subsystem having the input port must be owned by this Diagram.
+  /// Aborts if @p context is nullptr and there is any evaluation to do.
+  virtual void EvaluateSubsystemInputPort(
+      const Context<T>* context, const SystemPortDescriptor<T>& id) const = 0;
+
+  /// Writes the full path of the evaluator in the tree of Systems to @p output.
+  /// The path has the form (::ancestor_system_name)*::this_system_name.
+  ///
+  /// TODO(david-german-tri): Instead return a stringstream, once Drake no
+  /// longer supports old compilers that suffer from
+  /// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54316
+  virtual void GetPath(std::stringstream* output) const = 0;
+};
+
+}  // namespace detail
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/leaf_context.h
+++ b/drake/systems/framework/leaf_context.h
@@ -6,6 +6,7 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/cache.h"
+#include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/vector_base.h"
@@ -28,6 +29,13 @@ class LeafContext : public Context<T> {
   LeafContext() {}
   virtual ~LeafContext() {}
 
+  const InputPort* GetInputPort(int index) const override {
+    if (index < 0 || index >= get_num_input_ports()) {
+      throw std::out_of_range("Input port out of range.");
+    }
+    return inputs_[index].get();
+  }
+
   void SetInputPort(int index, std::unique_ptr<InputPort> port) override {
     if (index < 0 || index >= get_num_input_ports()) {
       throw std::out_of_range("Input port out of range.");
@@ -49,22 +57,6 @@ class LeafContext : public Context<T> {
 
   int get_num_input_ports() const override {
     return static_cast<int>(inputs_.size());
-  }
-
-  const BasicVector<T>* get_vector_input(int index) const override {
-    DRAKE_DEMAND(index >= 0 && index < get_num_input_ports());
-    if (inputs_[index] == nullptr) {
-      return nullptr;
-    }
-    return inputs_[index]->template get_vector_data<T>();
-  }
-
-  const AbstractValue* get_abstract_input(int index) const override {
-    DRAKE_DEMAND(index >= 0 && index < get_num_input_ports());
-    if (inputs_[index] == nullptr) {
-      return nullptr;
-    }
-    return inputs_[index]->get_abstract_data();
   }
 
   const State<T>& get_state() const override { return state_; }

--- a/drake/systems/framework/primitives/adder.cc
+++ b/drake/systems/framework/primitives/adder.cc
@@ -34,7 +34,7 @@ void Adder<T>::EvalOutput(const Context<T>& context,
   // Sum each input port into the output, after checking that it has the
   // expected size.
   for (int i = 0; i < context.get_num_input_ports(); i++) {
-    const BasicVector<T>* input_vector = context.get_vector_input(i);
+    const BasicVector<T>* input_vector = this->EvalVectorInput(context, i);
     output_vector->get_mutable_value() += input_vector->get_value();
   }
 }

--- a/drake/systems/framework/primitives/demultiplexer.cc
+++ b/drake/systems/framework/primitives/demultiplexer.cc
@@ -21,7 +21,7 @@ void Demultiplexer<T>::EvalOutput(const Context<T>& context,
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
   // TODO(amcastro-tri): the output should simply reference the input port's
   // value to avoid copy.
-  auto in_vector = System<T>::get_input_vector(context, 0);
+  auto in_vector = System<T>::EvalEigenVectorInput(context, 0);
   for (int iport = 0; iport < this->get_num_output_ports(); ++iport) {
     auto out_vector = System<T>::GetMutableOutputVector(output, iport);
     out_vector[0] = in_vector[iport];

--- a/drake/systems/framework/primitives/gain-inl.h
+++ b/drake/systems/framework/primitives/gain-inl.h
@@ -37,7 +37,7 @@ void Gain<T>::EvalOutput(const Context<T>& context,
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
-  auto input_vector = System<T>::get_input_vector(context, 0);
+  auto input_vector = this->EvalEigenVectorInput(context, 0);
   System<T>::GetMutableOutputVector(output, 0) = gain_ * input_vector;
 }
 

--- a/drake/systems/framework/primitives/integrator.cc
+++ b/drake/systems/framework/primitives/integrator.cc
@@ -55,7 +55,7 @@ template <typename T>
 void Integrator<T>::EvalTimeDerivatives(const Context<T>& context,
                                         ContinuousState<T>* derivatives) const {
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-  const BasicVector<T>* input = context.get_vector_input(0);
+  const BasicVector<T>* input = this->EvalVectorInput(context, 0);
   derivatives->get_mutable_state()->SetFromVector(input->get_value());
 }
 

--- a/drake/systems/framework/primitives/pass_through-inl.h
+++ b/drake/systems/framework/primitives/pass_through-inl.h
@@ -36,7 +36,7 @@ void PassThrough<T>::EvalOutput(const Context<T>& context,
   // TODO(amcastro-tri): the output should simply reference the input port's
   // value to avoid copy.
   System<T>::GetMutableOutputVector(output, 0) =
-      System<T>::get_input_vector(context, 0);
+      System<T>::EvalEigenVectorInput(context, 0);
 }
 
 }  // namespace systems

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -9,6 +9,7 @@
 #include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/context.h"
+#include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/system_port_descriptor.h"
 
@@ -138,25 +139,13 @@ class System {
       // TODO(amcastro-tri): add appropriate checks for kAbstractValued ports
       // once abstract ports are implemented in 3164.
       if (this->get_input_port(i).get_data_type() == kVectorValued) {
-        const VectorBase<T>* input_vector = context.get_vector_input(i);
+        const BasicVector<T>* input_vector =
+            context.GetInputPort(i)->template get_vector_data<T>();
         DRAKE_THROW_UNLESS(input_vector != nullptr);
         DRAKE_THROW_UNLESS(input_vector->size() ==
                            get_input_port(i).get_size());
       }
     }
-  }
-
-  /// Returns an Eigen expression for a vector valued input port with index
-  /// @p port_index in this system.
-  Eigen::VectorBlock<const VectorX<T>> get_input_vector(
-      const Context<T>& context, int port_index) const {
-    DRAKE_ASSERT(0 <= port_index && port_index < get_num_input_ports());
-    const BasicVector<T>* input_vector = context.get_vector_input(port_index);
-
-    DRAKE_ASSERT(input_vector != nullptr);
-    DRAKE_ASSERT(input_vector->size() == get_input_port(port_index).get_size());
-
-    return input_vector->get_value();
   }
 
   // Returns a copy of the continuous state vector into an Eigen vector.
@@ -339,8 +328,42 @@ class System {
   // TODO(david-german-tri): Add MapConfigurationDerivativesToVelocity
   // and MapAccelerationToConfigurationSecondDerivatives.
 
+  // Sets the name of the system. It is recommended that the name not include
+  // the character ':', since that the path delimiter. is "::".
   virtual void set_name(const std::string& name) { name_ = name; }
   virtual std::string get_name() const { return name_; }
+
+  /// Writes the full path of this System in the tree of Systems to @p output.
+  /// The path has the form (::ancestor_system_name)*::this_system_name.
+  virtual void GetPath(std::stringstream* output) const {
+    // If this System has a parent, that parent's path is a prefix to this
+    // System's path. Otherwise, this is the root system and there is no prefix.
+    if (parent_ != nullptr) {
+      parent_->GetPath(output);
+    }
+    *output << "::";
+    *output << (get_name().empty() ? "<unnamed System>" : get_name());
+  }
+
+  // Returns the full path of the System in the tree of Systems.
+  std::string GetPath() const {
+    std::stringstream path;
+    GetPath(&path);
+    return path.str();
+  }
+
+  /// Declares that @p parent is the immediately enclosing Diagram. The
+  /// enclosing Diagram is needed to evaluate inputs recursively. Aborts if
+  /// the parent has already been set to something else.
+  ///
+  /// This is a dangerous implementation detail. Conceptually, a System
+  /// ought to be completely ignorant of its parent Diagram. However, we
+  /// need this pointer so that we can cause our inputs to be evaluated.
+  /// See https://github.com/RobotLocomotion/drake/pull/3455.
+  void set_parent(const detail::InputPortEvaluatorInterface<T>* parent) {
+    DRAKE_DEMAND(parent_ == nullptr || parent_ == parent);
+    parent_ = parent;
+  }
 
  protected:
   System() {}
@@ -397,6 +420,29 @@ class System {
     return DeclareOutputPort(kAbstractValued, 0 /* size */, sampling);
   }
 
+  /// Causes the vector-valued port with the given @p port_index to become
+  /// up-to-date, delegating to our parent Diagram if necessary. Returns
+  /// the port's value, or nullptr if the port is not connected.
+  ///
+  /// Throws std::bad_cast if the port is not vector-valued.
+  /// Aborts if the port does not exist.
+  const BasicVector<T>* EvalVectorInput(const Context<T>& context,
+                                        int port_index) const {
+    DRAKE_ASSERT(0 <= port_index && port_index < get_num_input_ports());
+    return context.EvalVectorInput(parent_, get_input_port(port_index));
+  }
+
+  /// Causes the vector-valued port with the given @p port_index to become
+  /// up-to-date, delegating to our parent Diagram if necessary. Returns
+  /// the port's value as an Eigen expression.
+  Eigen::VectorBlock<const VectorX<T>> EvalEigenVectorInput(
+      const Context<T>& context, int port_index) const {
+    const BasicVector<T>* input_vector = EvalVectorInput(context, port_index);
+    DRAKE_ASSERT(input_vector != nullptr);
+    DRAKE_ASSERT(input_vector->size() == get_input_port(port_index).get_size());
+    return input_vector->get_value();
+  }
+
   /// Returns a mutable Eigen expression for a vector valued output port with
   /// index @p port_index in this system. All InputPorts that directly depend
   /// on this OutputPort will be notified that upstream data has changed, and
@@ -438,6 +484,15 @@ class System {
     actions->time = std::numeric_limits<double>::infinity();
   }
 
+  /// Causes an InputPort in the @p context to become up-to-date, delegating to
+  /// the parent Diagram if necessary.
+  ///
+  /// This is a framework implementation detail. User code should never call it.
+  void EvalInputPort(const Context<T>& context, int port_index) const {
+    DRAKE_ASSERT(0 <= port_index && port_index < get_num_input_ports());
+    context.EvalInputPort(parent_, get_input_port(port_index));
+  }
+
  private:
   // SystemInterface objects are neither copyable nor moveable.
   System(const System<T>& other) = delete;
@@ -448,6 +503,7 @@ class System {
   std::string name_;
   std::vector<SystemPortDescriptor<T>> input_ports_;
   std::vector<SystemPortDescriptor<T>> output_ports_;
+  const detail::InputPortEvaluatorInterface<T>* parent_ = nullptr;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/system_input.cc
+++ b/drake/systems/framework/system_input.cc
@@ -26,7 +26,6 @@ DependentInputPort::~DependentInputPort() {
 void DependentInputPort::Disconnect() {
   output_port_ = nullptr;
 }
-
 FreestandingInputPort::FreestandingInputPort(
     std::unique_ptr<AbstractValue> data)
     : output_port_(std::move(data)) {

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -7,6 +7,7 @@
 
 #include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/output_port_listener_interface.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/value.h"
@@ -26,6 +27,9 @@ class DRAKESYSTEMFRAMEWORK_EXPORT InputPort
   /// whenever the data on this port changes, according to the source of
   /// that data.
   virtual int64_t get_version() const = 0;
+
+  /// Returns true if this InputPort is not in control of its own data.
+  virtual bool requires_evaluation() const = 0;
 
   /// Returns the data on this port, or nullptr if this port is not connected.
   const AbstractValue* get_abstract_data() const {
@@ -75,11 +79,15 @@ class DRAKESYSTEMFRAMEWORK_EXPORT DependentInputPort : public InputPort {
   /// Disconnects from the output port.
   ~DependentInputPort() override;
 
-  /// Sets the OutputPort to nullptr.
+  /// Sets the output port to nullptr.
   void Disconnect() override;
 
   /// Returns the value version of the connected output port.
   int64_t get_version() const override { return output_port_->get_version(); }
+
+  /// A DependentInputPort must be evaluated in a Context, because it does not
+  /// control its own data.
+  bool requires_evaluation() const override { return true; }
 
  protected:
   const OutputPort* get_output_port() const override { return output_port_; }
@@ -126,6 +134,10 @@ class DRAKESYSTEMFRAMEWORK_EXPORT FreestandingInputPort : public InputPort {
   /// Returns a positive and monotonically increasing number that is guaranteed
   /// to change whenever GetMutableVectorData is called.
   int64_t get_version() const override { return output_port_.get_version(); }
+
+  /// A FreestandingInputPort does not require evaluation, because it controls
+  /// its own data.
+  bool requires_evaluation() const override { return false; }
 
   /// Returns a pointer to the data inside this InputPort, and updates the
   /// version so that Contexts depending on this InputPort know to invalidate

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -27,8 +27,7 @@ class DRAKESYSTEMFRAMEWORK_EXPORT OutputPort {
   /// @tparam V The type of @p vec itself. Must implement BasicVector<T>.
   template <template <typename T> class V, typename T>
   explicit OutputPort(std::unique_ptr<V<T>> vec)
-      : data_(new VectorValue<T>(std::move(vec))) {
-  }
+      : data_(new VectorValue<T>(std::move(vec))) {}
 
   /// Constructs an abstract-valued OutputPort.
   /// Takes ownership of @p data.

--- a/drake/systems/lcm/lcm_publisher_system.cc
+++ b/drake/systems/lcm/lcm_publisher_system.cc
@@ -50,7 +50,7 @@ void LcmPublisherSystem::DoPublish(const Context<double>& context) const {
 
   // Obtains the input vector.
   const VectorBase<double>* const input_vector =
-      context.get_vector_input(kPortIndex);
+      this->EvalVectorInput(context, kPortIndex);
 
   // Translates the input vector into LCM message bytes.
   translator_.Serialize(context.get_time(), *input_vector, &message_bytes_);

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -132,7 +132,7 @@ void RigidBodyPlant<T>::EvalTimeDerivatives(
     const Context<T>& context, ContinuousState<T>* derivatives) const {
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
   DRAKE_DEMAND(derivatives != nullptr);
-  const BasicVector<T>* input = context.get_vector_input(0);
+  const BasicVector<T>* input = this->EvalVectorInput(context, 0);
 
   // The input vector of actuation values.
   auto u = input->get_value();

--- a/drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.cc
@@ -42,7 +42,8 @@ void RigidBodyTreeLcmPublisher::DoPublish(const Context<double>& context)
 
   // Obtains the input vector, which contains the generalized q,v state of the
   // RigidBodyTree.
-  const VectorBase<double>* input_vector = context.get_vector_input(kPortIndex);
+  const BasicVector<double>* input_vector = EvalVectorInput(context,
+                                                            kPortIndex);
 
   // Translates the input vector into an array of bytes representing an LCM
   // message.


### PR DESCRIPTION
Before this PR, System2 observed the "push invariant": if a System is asked to compute a given value, then all of the inputs required for that computation are already available in the Context.

After this PR, System2 does not observe that invariant.  Instead, it uses a pull model: when a System needs a given input, it asks its containing Diagram to make that input ready in the current Context.

@sherm1 advocated for this design change.  I opposed it.  In an escalation meeting on 2016-09-14, @RussTedrake determined that we should move forward with it.

I've done my best here to implement that decision in a safe and legible way.  Nonetheless, this PR degrades encapsulation by giving Systems and Contexts pointers to their parents.  It makes the code less readable because no simple invariants hold, and harder to debug because there are deep recursive call graphs.

+@sherm1 for feature review.  Hopefully we can find a way to make this better.  I will assign Russ as platform reviewer once Sherm and are done iterating on it, and will keep the "do not merge" label until it has Russ's LGTM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3455)
<!-- Reviewable:end -->
