### PR TITLE
Fix bug in zmpUtil

### DIFF
--- a/drake/systems/controllers/zmpUtil.cpp
+++ b/drake/systems/controllers/zmpUtil.cpp
@@ -1,6 +1,7 @@
 #include "drake/systems/controllers/zmpUtil.h"
 #include <Eigen/Dense>
 #include <unsupported/Eigen/MatrixFunctions>
+#include <iostream>
 
 #include "drake/common/drake_assert.h"
 
@@ -50,7 +51,16 @@ ExponentialPlusPiecewisePolynomial<double> s1Trajectory(
     MatrixXd poly_coeffs = MatrixXd::Zero(nq, k);
 
     for (size_t x = 0; x < nq; x++) {
-      poly_coeffs.row(x) = poly_mat(x).GetCoefficients().transpose();
+      auto element_coeffs = poly_mat(x).GetCoefficients();
+
+      // note that the number of coefficients of poly_mat(x) may not be k due to
+      // erasure of zero coefficients. It should always be less than or equal to
+      // k though.
+      DRAKE_ASSERT(poly_coeffs.cols() >= element_coeffs.size());
+      poly_coeffs.row(x).setZero();
+      for (Index i = 0; i < element_coeffs.size(); i++) {
+        poly_coeffs.row(x)(i) = element_coeffs(i);
+      }
     }
 
     beta[j].col(k - 1) = -A2i * B2 * poly_coeffs.col(k - 1);

--- a/drake/systems/controllers/zmpUtil.cpp
+++ b/drake/systems/controllers/zmpUtil.cpp
@@ -1,7 +1,6 @@
 #include "drake/systems/controllers/zmpUtil.h"
 #include <Eigen/Dense>
 #include <unsupported/Eigen/MatrixFunctions>
-#include <iostream>
 
 #include "drake/common/drake_assert.h"
 
@@ -9,8 +8,8 @@ using namespace Eigen;
 using namespace std;
 
 ExponentialPlusPiecewisePolynomial<double> s1Trajectory(
-    const TVLQRData &sys, const PiecewisePolynomial<double> &zmp_trajectory,
-    const Ref<const MatrixXd> &S) {
+    const TVLQRData& sys, const PiecewisePolynomial<double>& zmp_trajectory,
+    const Ref<const MatrixXd>& S) {
   size_t n = static_cast<size_t>(zmp_trajectory.getNumberOfSegments());
   int d = zmp_trajectory.getSegmentPolynomialDegree(0);
   int k = d + 1;
@@ -53,9 +52,9 @@ ExponentialPlusPiecewisePolynomial<double> s1Trajectory(
     for (size_t x = 0; x < nq; x++) {
       auto element_coeffs = poly_mat(x).GetCoefficients();
 
-      // note that the number of coefficients of poly_mat(x) may not be k due to
+      // Note that the number of coefficients of poly_mat(x) may not be k due to
       // erasure of zero coefficients. It should always be less than or equal to
-      // k though.
+      // k though. See #2165.
       DRAKE_ASSERT(poly_coeffs.cols() >= element_coeffs.size());
       poly_coeffs.row(x).setZero();
       for (Index i = 0; i < element_coeffs.size(); i++) {


### PR DESCRIPTION
Part of addressing https://github.com/RobotLocomotion/drake/issues/2165.

In Debug mode, running `runAtlasWalking.m` resulted in a Matlab crash with
```
[...]
[ 11] 0x00000001b988c557 /Users/twan/Library/Caches/CLion2016.2/cmake/generated/drake-8d5e0e9a/8d5e0e9a/Debug/systems/controllers/libdrakeZMPUtil.dylib+00267607 _ZN5Eigen9DenseBaseINS_5BlockINS_6MatrixIdLin1ELin1ELi0ELin1ELin1EEELi1ELin1ELb0EEEE6resizeEll+00000167
[...]
```

in the matlab dump and
```
Assertion failed: (rows == this->rows() && cols == this->cols() && "DenseBase::resize() does not actually allow to resize."), function resize, file /Users/twan/code/drake-distro/build/install/include/eigen3/Eigen/src/Core/DenseBase.h, line 257.
```
on the command line.

This was due to a bug in `zmpUtil.cpp` (that may have crept in after the Release configuration bug that #2165 started with). We check that the degree of all of the segments of the `PiecewisePolynomial` `zmp_trajectory` is `d` (so all its segments have `k = d + 1` coefficients), which is good. Then we compute
```C++
PiecewisePolynomial<double> zbar_pp = zmp_trajectory - zmp_tf;
```
where `zmp_tf` is a constant matrix. One would think that the degrees of the segments of `zbar_pp` would be the same as those of `zmp_trajectory`, but the `operator-=` for `Polynomial` calls `MakeMonomialsUnique`, which erases monomials with coefficients equal to zero, so it actually *can* change the degree of the polynomial as returned by the `GetDegree` method, as well as the size of the vector of coefficients. Later on we were doing the following:
```C++
MatrixXd poly_coeffs = MatrixXd::Zero(nq, k);
...
auto poly_mat = zbar_pp.getPolynomialMatrix(j);
...
poly_coeffs.row(x) = poly_mat(x).GetCoefficients().transpose();
```

But the left hand side was a bigger row vector than the right hand side in that assignment due to the erased monomials.

cc: @manuelli, @siyuanfeng-tri.

After this pull request `runAtlasWalking` works again **in Debug mode, but not in Release mode**. I'll PR the fix for Release mode separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3457)
<!-- Reviewable:end -->
