### PR TITLE
Move OutputPortListenerInterface into its own file.

### DIFF
--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -9,6 +9,7 @@ set(sources
   examples/spring_mass_system.cc
   leaf_context.cc
   leaf_system.cc
+  output_port_listener_interface.cc
   primitives/adder.cc
   primitives/constant_value_source.cc
   primitives/constant_vector_source.cc
@@ -45,6 +46,7 @@ set(installed_headers
   diagram_context.h
   leaf_context.h
   leaf_system.h
+  output_port_listener_interface.h
   state.h
   state_subvector.h
   state_supervector.h

--- a/drake/systems/framework/output_port_listener_interface.cc
+++ b/drake/systems/framework/output_port_listener_interface.cc
@@ -1,0 +1,11 @@
+#include "drake/systems/framework/output_port_listener_interface.h"
+
+namespace drake {
+namespace systems {
+namespace detail {
+
+OutputPortListenerInterface::~OutputPortListenerInterface() {}
+
+}  // namespace detail
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/output_port_listener_interface.h
+++ b/drake/systems/framework/output_port_listener_interface.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "drake/drakeSystemFramework_export.h"
+
+namespace drake {
+namespace systems {
+namespace detail {
+
+/// OutputPortListenerInterface is an interface that consumers of an output
+/// port must satisfy to receive notifications when the value on that output
+/// port's version number is incremented.
+class DRAKESYSTEMFRAMEWORK_EXPORT OutputPortListenerInterface {
+ public:
+  virtual ~OutputPortListenerInterface();
+
+  /// Invalidates any data that depends on the OutputPort. Called whenever
+  /// the OutputPort's version number is incremented.
+  virtual void Invalidate() = 0;
+
+  /// Notifies the consumer that the OutputPort is no longer valid and should
+  /// not be read.
+  virtual void Disconnect() = 0;
+};
+
+}  // namespace detail
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -7,6 +7,7 @@
 
 #include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/output_port_listener_interface.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/value.h"
 
@@ -17,7 +18,7 @@ namespace systems {
 /// subclass InputPort: all InputPorts are either DependentInputPorts or
 /// FreestandingInputPorts.
 class DRAKESYSTEMFRAMEWORK_EXPORT InputPort
-    : public OutputPortListenerInterface {
+    : public detail::OutputPortListenerInterface {
  public:
   ~InputPort() override;
 

--- a/drake/systems/framework/system_output.cc
+++ b/drake/systems/framework/system_output.cc
@@ -3,12 +3,10 @@
 namespace drake {
 namespace systems {
 
-OutputPortListenerInterface::~OutputPortListenerInterface() {}
-
 OutputPort::~OutputPort() {
   // Notify any input ports that are still connected to this output port that
   // this output port no longer exists.
-  for (OutputPortListenerInterface* dependent : dependents_) {
+  for (detail::OutputPortListenerInterface* dependent : dependents_) {
     dependent->Disconnect();
   }
 }
@@ -24,7 +22,7 @@ std::unique_ptr<OutputPort> OutputPort::Clone() const {
 
 void OutputPort::InvalidateAndIncrement() {
   ++version_;
-  for (OutputPortListenerInterface* dependent : dependents_) {
+  for (detail::OutputPortListenerInterface* dependent : dependents_) {
     dependent->Invalidate();
   }
 }

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -8,29 +8,11 @@
 #include "drake/common/drake_assert.h"
 #include "drake/drakeSystemFramework_export.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/output_port_listener_interface.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
-
-/// OutputPortListenerInterface is an interface that consumers of an output
-/// port must satisfy to receive notifications when the value on that output
-/// port's version number is incremented.
-///
-/// This interface is a Drake-internal detail. Users should not implement it.
-/// TODO(david-german-tri): Consider moving to its own file.
-class DRAKESYSTEMFRAMEWORK_EXPORT OutputPortListenerInterface {
- public:
-  virtual ~OutputPortListenerInterface();
-
-  /// Invalidates any data that depends on the OutputPort. Called whenever
-  /// the OutputPort's version number is incremented.
-  virtual void Invalidate() = 0;
-
-  /// Notifies the consumer that the OutputPort is no longer valid and should
-  /// not be read.
-  virtual void Disconnect() = 0;
-};
 
 /// The OutputPort represents a data output from a System. Other Systems
 /// may depend on the OutputPort. When an OutputPort is deleted, it will
@@ -79,12 +61,12 @@ class DRAKESYSTEMFRAMEWORK_EXPORT OutputPort {
 
   /// Registers @p dependent to receive invalidation notifications whenever this
   /// port's version number is incremented.
-  void add_dependent(OutputPortListenerInterface* dependent) {
+  void add_dependent(detail::OutputPortListenerInterface* dependent) {
     dependents_.insert(dependent);
   }
 
   /// Unregisters @p dependent from invalidation notifications.
-  void remove_dependent(OutputPortListenerInterface* dependent) {
+  void remove_dependent(detail::OutputPortListenerInterface* dependent) {
     dependents_.erase(dependent);
   }
 
@@ -129,7 +111,7 @@ class DRAKESYSTEMFRAMEWORK_EXPORT OutputPort {
 
   // The list of consumers that should be notified when the value on this
   // output port changes.
-  std::set<OutputPortListenerInterface*> dependents_;
+  std::set<detail::OutputPortListenerInterface*> dependents_;
 
   int64_t version_ = 0;
 };

--- a/drake/systems/framework/test/system_output_test.cc
+++ b/drake/systems/framework/test/system_output_test.cc
@@ -6,12 +6,13 @@
 #include "gtest/gtest.h"
 
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/output_port_listener_interface.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
 
-class TestOutputPortListener : public OutputPortListenerInterface {
+class TestOutputPortListener : public detail::OutputPortListenerInterface {
  public:
   void Invalidate() override { invalidations_++; }
   void Disconnect() override { disconnections_++; }


### PR DESCRIPTION
Also move it into the drake::systems::detail namespace.

+@jwnimmer-tri for both levels of review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3458)
<!-- Reviewable:end -->
