### PR TITLE
Bumped version of `clang-format` from 3.6 to 3.7.

### DIFF
--- a/drake/automotive/gen/README.md
+++ b/drake/automotive/gen/README.md
@@ -5,3 +5,11 @@ To re-generate the code, run ./simple_car_gen.sh in the parent directory:
   $ cd drake-distro/drake/automotive
   $ ./simple_car_gen.sh
 
+Note that the above script searches for environment variable `CLANG_FORMAT` to
+determine which version of `clang-format` to use. If this variable is not set,
+it will default to a particular version that is hard-coded within the script.
+To specify a different version, execute:
+
+    $ env CLANG_FORMAT=clang-format-x.x ./simple_car_gen.sh
+
+where `x.x` matches the version of your choice.

--- a/drake/automotive/simple_car_gen.sh
+++ b/drake/automotive/simple_car_gen.sh
@@ -6,7 +6,7 @@ me=$(readlink -f $0)
 mydir=$(dirname $me)
 drake=$(dirname $mydir)
 
-CLANG_FORMAT=${CLANG_FORMAT:-clang-format-3.6}
+CLANG_FORMAT=${CLANG_FORMAT:-clang-format-3.7}
 
 # Call the code generator with common configuration.
 # @param1 title -- used to create class/type names

--- a/drake/automotive/simple_car_gen.sh
+++ b/drake/automotive/simple_car_gen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Generate the source files for LCM Vector concept classes used in SimpleCar.
+# Generates the source files for LCM Vector concept classes used in SimpleCar.
 
 me=$(readlink -f $0)
 mydir=$(dirname $me)


### PR DESCRIPTION
We're now using `clang` version 3.7 based on these instructions:

http://drake.mit.edu/ubuntu_trusty.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3461)
<!-- Reviewable:end -->
