### PR TITLE
Fix runAtlasWalking on OSX in Release mode (#2165)

### DIFF
--- a/drake/common/eigen_stl_types.h
+++ b/drake/common/eigen_stl_types.h
@@ -2,14 +2,23 @@
 
 /// @file
 /// This file contains definitions for using Eigen with the STL.
+/// See http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html.
 /// @see eigen_types.h
 
+#include <map>
 #include <unordered_map>
 
 #include <Eigen/Core>
 #include <Eigen/StdVector>
 
 namespace drake {
+
+/// A std::map that uses Eigen::aligned_allocator so that the
+/// contained types may be fixed-size Eigen values.
+template <typename Key, typename T>
+using eigen_aligned_std_map =
+    std::map<Key, T, std::less<Key>,
+             Eigen::aligned_allocator<std::pair<Key const, T>>>;
 
 /// A std::unordered_map that uses Eigen::aligned_allocator so that the
 /// contained types may be fixed-size Eigen values.

--- a/drake/common/test/eigen_stl_types_test.cc
+++ b/drake/common/test/eigen_stl_types_test.cc
@@ -11,10 +11,31 @@ namespace drake {
 namespace {
 
 template <typename T>
-using MapType = eigen_aligned_std_unordered_map<int, T>;
+using UnorderedMapType = eigen_aligned_std_unordered_map<int, T>;
 
 // Confirm that nothing asserts nor segfaults.
 GTEST_TEST(EigenStlTypesTest, UnorderedMapTest) {
+  // The device under test is abbreviated "dut".
+  UnorderedMapType<Vector2d> dut0;
+  dut0[0] = Vector2d::Zero();
+
+  auto dut1 = std::make_unique<UnorderedMapType<Vector2d>>();
+  dut1->insert(std::make_pair(1, Vector2d::Ones()));
+
+  UnorderedMapType<Vector4d> dut2;
+  dut2[2] = Vector4d::Ones();
+
+  auto dut3 = std::make_unique<UnorderedMapType<Vector4d>>();
+  dut3->insert(std::make_pair(3, Vector4d::Zero()));
+
+  EXPECT_TRUE(true);
+}
+
+template <typename T>
+using MapType = eigen_aligned_std_map<int, T>;
+
+// Confirm that nothing asserts nor segfaults.
+GTEST_TEST(EigenStlTypesTest, MapTest) {
   // The device under test is abbreviated "dut".
   MapType<Vector2d> dut0;
   dut0[0] = Vector2d::Zero();

--- a/drake/examples/Atlas/CMakeLists.txt
+++ b/drake/examples/Atlas/CMakeLists.txt
@@ -38,7 +38,7 @@ if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX AND NOT APPLE) # FIXME: se
 endif()
 
 if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX) # FIXME: see #3147.
-  drake_add_matlab_test(NAME examples/Atlas/runAtlasWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasWalking)
+  drake_add_matlab_test(NAME examples/Atlas/runAtlasWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasWalking SIZE large)
 endif()
 
 # drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancing REQUIRES gurobi COMMAND runAtlasBalancing)  # FIXME: see #2839

--- a/drake/examples/Atlas/CMakeLists.txt
+++ b/drake/examples/Atlas/CMakeLists.txt
@@ -25,18 +25,17 @@ drake_add_matlab_test(NAME examples/Atlas/runAtlasSagittalDynamics OPTIONAL bull
 drake_add_matlab_test(NAME examples/Atlas/runAtlasWalkingPlanning REQUIRES gurobi lcm libbot OPTIONAL bullet snopt COMMAND runAtlasWalkingPlanning)
 drake_add_matlab_test(NAME examples/Atlas/runCOMFixedPointSearch OPTIONAL bullet gurobi COMMAND runCOMFixedPointSearch)
 
-# Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
-# drake_add_matlab_test(NAME examples/Atlas/runDRCDoorTask REQUIRES iris mosek COMMAND runDRCDoorTask)
+drake_add_matlab_test(NAME examples/Atlas/runDRCDoorTask REQUIRES iris mosek COMMAND runDRCDoorTask)
 
 drake_add_matlab_test(NAME examples/Atlas/runRobotiqPDControl OPTIONAL bullet gurobi snopt COMMAND runRobotiqPDControl)
 
+drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasBalancingPerturb)
+
 if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX AND NOT APPLE) # FIXME: see #3147.
-  drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasBalancingPerturb)
   drake_add_matlab_test(NAME examples/Atlas/runAtlasManip REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasManip)
 endif()
 
-# Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
-# drake_add_matlab_test(NAME examples/Atlas/runAtlasWalking REQUIRES gurobi lcm COMMAND runAtlasWalking)
+drake_add_matlab_test(NAME examples/Atlas/runAtlasWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasWalking)
 
 # drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancing REQUIRES gurobi COMMAND runAtlasBalancing)  # FIXME: see #2839
 # drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancingWithContactSensor REQUIRES gurobi COMMAND runAtlasBalancingWithContactSensor)  # FIXME: see #2839

--- a/drake/examples/Atlas/CMakeLists.txt
+++ b/drake/examples/Atlas/CMakeLists.txt
@@ -29,13 +29,17 @@ drake_add_matlab_test(NAME examples/Atlas/runDRCDoorTask REQUIRES iris mosek COM
 
 drake_add_matlab_test(NAME examples/Atlas/runRobotiqPDControl OPTIONAL bullet gurobi snopt COMMAND runRobotiqPDControl)
 
-drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasBalancingPerturb)
+if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX) # FIXME: see #3147.
+  drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasBalancingPerturb)
+endif()
 
 if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX AND NOT APPLE) # FIXME: see #3147.
   drake_add_matlab_test(NAME examples/Atlas/runAtlasManip REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasManip)
 endif()
 
-drake_add_matlab_test(NAME examples/Atlas/runAtlasWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasWalking)
+if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX) # FIXME: see #3147.
+  drake_add_matlab_test(NAME examples/Atlas/runAtlasWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runAtlasWalking)
+endif()
 
 # drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancing REQUIRES gurobi COMMAND runAtlasBalancing)  # FIXME: see #2839
 # drake_add_matlab_test(NAME examples/Atlas/runAtlasBalancingWithContactSensor REQUIRES gurobi COMMAND runAtlasBalancingWithContactSensor)  # FIXME: see #2839

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX) # FIXME: see #3147.
 endif()
 
 if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX) # FIXME: see #3147.
-  drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieWalking)
+  drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieWalking SIZE large)
 endif()
 
 drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieVisualize OPTIONAL bullet gurobi snopt COMMAND runValkyrieVisualize)

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -1,11 +1,8 @@
 # drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancing REQUIRES gurobi COMMAND runValkyrieBalancing)  # FIXME: see #2839
 
-if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX AND NOT APPLE) # FIXME: see #3147.
-  drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieBalancingPerturb)
-endif()
+drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieBalancingPerturb)
 
-# Deactivated due to memory flakiness in instantaneousQP; see #2165, #2376.
-# drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking REQUIRES gurobi lcm libbot COMMAND runValkyrieWalking)
+drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieWalking)
 
 drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieVisualize OPTIONAL bullet gurobi snopt COMMAND runValkyrieVisualize)
 

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -1,8 +1,12 @@
 # drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancing REQUIRES gurobi COMMAND runValkyrieBalancing)  # FIXME: see #2839
 
-drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieBalancingPerturb)
+if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX) # FIXME: see #3147.
+  drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieBalancingPerturb)
+endif()
 
-drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieWalking)
+if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX) # FIXME: see #3147.
+  drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieWalking REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieWalking)
+endif()
 
 drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieVisualize OPTIONAL bullet gurobi snopt COMMAND runValkyrieVisualize)
 

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -281,13 +281,12 @@ VectorXd InstantaneousQPController::velocityReference(
   return qd_ref;
 }
 
-std::vector<SupportStateElement, Eigen::aligned_allocator<SupportStateElement>>
+drake::eigen_aligned_std_vector<SupportStateElement>
 InstantaneousQPController::loadAvailableSupports(
     const drake::lcmt_qp_controller_input& qp_input) {
   // Parse a qp_input LCM message to extract its available supports as a vector
   // of SupportStateElements
-  std::vector<SupportStateElement,
-              Eigen::aligned_allocator<SupportStateElement>> available_supports;
+  drake::eigen_aligned_std_vector<SupportStateElement> available_supports;
   available_supports.resize(qp_input.num_support_data);
   for (int i = 0; i < qp_input.num_support_data; i++) {
     available_supports[i].body_idx =
@@ -389,7 +388,7 @@ double averageContactPointHeight(
 
 Vector2d computeCoP(const RigidBodyTree& robot,
                     const KinematicsCache<double>& cache,
-                    const std::map<Side, ForceTorqueMeasurement>&
+                    const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
                         foot_force_torque_measurements,
                     Vector3d point_on_contact_plane, Eigen::Vector3d normal) {
   std::vector<ForceTorqueMeasurement> force_torque_measurements;
@@ -406,10 +405,10 @@ Vector2d computeCoP(const RigidBodyTree& robot,
 
 void InstantaneousQPController::estimateCoMBasedOnMeasuredZMP(
     const QPControllerParams& params,
-    std::vector<SupportStateElement,
-                Eigen::aligned_allocator<SupportStateElement>>& active_supports,
-    int num_contact_points, const std::map<Side, ForceTorqueMeasurement>&
-                                foot_force_torque_measurements,
+    drake::eigen_aligned_std_vector <SupportStateElement>& active_supports,
+    int num_contact_points,
+    const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
+        foot_force_torque_measurements,
     double dt, Vector3d& xcom, Vector3d& xcomdot) {
   /*
    * Derivation:
@@ -589,8 +588,7 @@ std::unordered_map<std::string, int> computeBodyOrFrameNameToIdMap(
 const QPControllerParams& InstantaneousQPController::FindParams(
     const std::string& param_set_name) {
   // look up the param set by name
-  std::map<std::string, QPControllerParams>::iterator it;
-  it = param_sets.find(param_set_name);
+  auto it = param_sets.find(param_set_name);
   if (it == param_sets.end()) {
     std::cout
         << "Got a param set I don't recognize! Using standing params instead";
@@ -611,7 +609,7 @@ int InstantaneousQPController::setupAndSolveQP(
     const drake::lcmt_qp_controller_input& qp_input,
     const DrakeRobotState& robot_state,
     const Ref<const Matrix<bool, Dynamic, 1>>& contact_detected,
-    const std::map<Side, ForceTorqueMeasurement>&
+    const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
         foot_force_torque_measurements,
     QPControllerOutput& qp_output, QPControllerDebugData* debug) {
   // The primary solve loop for our controller. This constructs and solves a
@@ -651,11 +649,9 @@ int InstantaneousQPController::setupAndSolveQP(
   std::vector<SupportStateElement,
               Eigen::aligned_allocator<SupportStateElement>>
       available_supports = loadAvailableSupports(qp_input);
-  std::vector<SupportStateElement,
-              Eigen::aligned_allocator<SupportStateElement>> active_supports =
-      getActiveSupports(*robot, robot_state.q, robot_state.qd,
-                        available_supports, contact_detected,
-                        params.contact_threshold);
+  drake::eigen_aligned_std_vector<SupportStateElement> active_supports = getActiveSupports(*robot, robot_state.q, robot_state.qd,
+                                          available_supports, contact_detected,
+                                          params.contact_threshold);
 
   // // whole_body_data
   if (qp_input.whole_body_data.num_positions != nq)

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -99,8 +99,13 @@ void InstantaneousQPController::loadConfigurationFromYAML(
     const std::string& control_config_filename) {
   YAML::Node control_config = YAML::LoadFile(control_config_filename);
   std::ofstream debug_file(control_config_filename + ".debug.yaml");
-  param_sets = loadAllParamSets(control_config["qp_controller_params"], *robot,
-                                debug_file);
+  // Important note: assigning the result of loadAllParamSets to a local
+  // variable before assigning to the param_sets field is to make it so that the
+  // copy assignment operator is used instead of the move assignment operator.
+  // See #2165 for details.
+  auto param_sets_local = loadAllParamSets(
+      control_config["qp_controller_params"], *robot, debug_file);
+  param_sets = param_sets_local;
   rpc = parseKinematicTreeMetadata(control_config["kinematic_tree_metadata"],
                                    *robot);
 }

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -386,11 +386,11 @@ double averageContactPointHeight(
   return average_contact_point_height;
 }
 
-Vector2d computeCoP(const RigidBodyTree& robot,
-                    const KinematicsCache<double>& cache,
-                    const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
-                        foot_force_torque_measurements,
-                    Vector3d point_on_contact_plane, Eigen::Vector3d normal) {
+Vector2d computeCoP(
+    const RigidBodyTree& robot, const KinematicsCache<double>& cache,
+    const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
+        foot_force_torque_measurements,
+    Vector3d point_on_contact_plane, Eigen::Vector3d normal) {
   std::vector<ForceTorqueMeasurement> force_torque_measurements;
   for (auto it = foot_force_torque_measurements.begin();
        it != foot_force_torque_measurements.end(); ++it) {
@@ -405,7 +405,7 @@ Vector2d computeCoP(const RigidBodyTree& robot,
 
 void InstantaneousQPController::estimateCoMBasedOnMeasuredZMP(
     const QPControllerParams& params,
-    drake::eigen_aligned_std_vector <SupportStateElement>& active_supports,
+    drake::eigen_aligned_std_vector<SupportStateElement>& active_supports,
     int num_contact_points,
     const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
         foot_force_torque_measurements,
@@ -649,9 +649,10 @@ int InstantaneousQPController::setupAndSolveQP(
   std::vector<SupportStateElement,
               Eigen::aligned_allocator<SupportStateElement>>
       available_supports = loadAvailableSupports(qp_input);
-  drake::eigen_aligned_std_vector<SupportStateElement> active_supports = getActiveSupports(*robot, robot_state.q, robot_state.qd,
-                                          available_supports, contact_detected,
-                                          params.contact_threshold);
+  drake::eigen_aligned_std_vector<SupportStateElement> active_supports =
+      getActiveSupports(*robot, robot_state.q, robot_state.qd,
+                        available_supports, contact_detected,
+                        params.contact_threshold);
 
   // // whole_body_data
   if (qp_input.whole_body_data.num_positions != nq)

--- a/drake/systems/controllers/InstantaneousQPController.h
+++ b/drake/systems/controllers/InstantaneousQPController.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/eigen_stl_types.h"
 #include <memory>
 #include "QPCommon.h"
 #include "drake/solvers/gurobi_qp.h"
@@ -18,7 +19,7 @@ class DRAKEQPCOMMON_EXPORT InstantaneousQPController {
  public:
   InstantaneousQPController(
       std::unique_ptr<RigidBodyTree> robot_in,
-      const std::map<std::string, QPControllerParams>& param_sets_in,
+      const drake::eigen_aligned_std_map<std::string, QPControllerParams>& param_sets_in,
       const RobotPropertyCache& rpc_in)
       : robot(std::move(robot_in)),
         param_sets(param_sets_in),
@@ -51,7 +52,7 @@ class DRAKEQPCOMMON_EXPORT InstantaneousQPController {
       const DrakeRobotState& robot_state,
       const Eigen::Ref<const Eigen::Matrix<bool, Eigen::Dynamic, 1>>&
           contact_detected,
-      const std::map<Side, ForceTorqueMeasurement>&
+      const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
           foot_force_torque_measurements,
       QPControllerOutput& qp_output, QPControllerDebugData* debug = NULL);
 
@@ -59,10 +60,12 @@ class DRAKEQPCOMMON_EXPORT InstantaneousQPController {
 
   std::unordered_map<std::string, int> body_or_frame_name_to_id;
 
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
  private:
   GRBenv* env;
   std::unique_ptr<RigidBodyTree> robot;
-  std::map<std::string, QPControllerParams> param_sets;
+  drake::eigen_aligned_std_map<std::string, QPControllerParams> param_sets;
   RobotPropertyCache rpc;
   Eigen::VectorXd umin, umax;
   int use_fast_qp;
@@ -103,16 +106,13 @@ class DRAKEQPCOMMON_EXPORT InstantaneousQPController {
       const Eigen::Ref<const Eigen::VectorXd>& qdd, bool foot_contact[2],
       const VRefIntegratorParams& params);
 
-  std::vector<SupportStateElement,
-              Eigen::aligned_allocator<SupportStateElement>>
+  drake::eigen_aligned_std_vector<SupportStateElement>
   loadAvailableSupports(const drake::lcmt_qp_controller_input& qp_input);
 
   void estimateCoMBasedOnMeasuredZMP(
       const QPControllerParams& params,
-      std::vector<SupportStateElement,
-                  Eigen::aligned_allocator<SupportStateElement>>&
-          active_supports,
-      int num_contact_points, const std::map<Side, ForceTorqueMeasurement>&
+      drake::eigen_aligned_std_vector<SupportStateElement>& active_supports,
+      int num_contact_points, const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
                                   foot_force_torque_measurements,
       double dt, Eigen::Vector3d& xcom, Eigen::Vector3d& xcomdot);
 

--- a/drake/systems/controllers/InstantaneousQPController.h
+++ b/drake/systems/controllers/InstantaneousQPController.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "drake/common/eigen_stl_types.h"
 #include <memory>
 #include "QPCommon.h"
+#include "drake/common/eigen_stl_types.h"
+#include "drake/drakeQPCommon_export.h"
 #include "drake/solvers/gurobi_qp.h"
 #include "lcmtypes/drake/lcmt_qp_controller_input.hpp"
-#include "drake/drakeQPCommon_export.h"
 
 #define INSTQP_USE_FASTQP 1
 #define INSTQP_GUROBI_OUTPUTFLAG 0
@@ -19,7 +19,8 @@ class DRAKEQPCOMMON_EXPORT InstantaneousQPController {
  public:
   InstantaneousQPController(
       std::unique_ptr<RigidBodyTree> robot_in,
-      const drake::eigen_aligned_std_map<std::string, QPControllerParams>& param_sets_in,
+      const drake::eigen_aligned_std_map<std::string, QPControllerParams>&
+          param_sets_in,
       const RobotPropertyCache& rpc_in)
       : robot(std::move(robot_in)),
         param_sets(param_sets_in),
@@ -106,14 +107,15 @@ class DRAKEQPCOMMON_EXPORT InstantaneousQPController {
       const Eigen::Ref<const Eigen::VectorXd>& qdd, bool foot_contact[2],
       const VRefIntegratorParams& params);
 
-  drake::eigen_aligned_std_vector<SupportStateElement>
-  loadAvailableSupports(const drake::lcmt_qp_controller_input& qp_input);
+  drake::eigen_aligned_std_vector<SupportStateElement> loadAvailableSupports(
+      const drake::lcmt_qp_controller_input& qp_input);
 
   void estimateCoMBasedOnMeasuredZMP(
       const QPControllerParams& params,
       drake::eigen_aligned_std_vector<SupportStateElement>& active_supports,
-      int num_contact_points, const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
-                                  foot_force_torque_measurements,
+      int num_contact_points,
+      const drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>&
+          foot_force_torque_measurements,
       double dt, Eigen::Vector3d& xcom, Eigen::Vector3d& xcomdot);
 
   void initialize();
@@ -125,8 +127,8 @@ class DRAKEQPCOMMON_EXPORT InstantaneousQPController {
 };
 
 DRAKEQPCOMMON_EXPORT void applyURDFModifications(
-  std::unique_ptr<RigidBodyTree>& robot,
-  const KinematicModifications& modifications);
+    std::unique_ptr<RigidBodyTree>& robot,
+    const KinematicModifications& modifications);
 DRAKEQPCOMMON_EXPORT void applyURDFModifications(
-  std::unique_ptr<RigidBodyTree>& robot,
-  const std::string& urdf_modifications_filename);
+    std::unique_ptr<RigidBodyTree>& robot,
+    const std::string& urdf_modifications_filename);

--- a/drake/systems/controllers/QPCommon.h
+++ b/drake/systems/controllers/QPCommon.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/eigen_stl_types.h"
 #include "drake/systems/controllers/controlUtil.h"
 #include "drake/systems/plants/ForceTorqueMeasurement.h"
 #include "drake/systems/plants/RigidBodyTree.h"
@@ -28,6 +28,8 @@ struct QPControllerState {
   int* cbasis;
   int vbasis_len;
   int cbasis_len;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 struct PositionIndices {
@@ -166,6 +168,8 @@ struct BodyMotionParams {
     return lhs.Kp.isApprox(rhs.Kp) && lhs.Kd.isApprox(rhs.Kd) &&
            lhs.accel_bounds == rhs.accel_bounds && lhs.weight == rhs.weight;
   }
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 struct HardwareGains {
@@ -238,7 +242,7 @@ struct QPControllerParams {
         center_of_mass_observer_gain(Eigen::Matrix4d::Zero()) {}
 
   WholeBodyParams whole_body;
-  std::vector<BodyMotionParams> body_motion;
+  drake::eigen_aligned_std_vector<BodyMotionParams> body_motion;
   VRefIntegratorParams vref_integrator;
   JointSoftLimitParams joint_soft_limits;
   HardwareParams hardware;
@@ -271,6 +275,8 @@ struct QPControllerParams {
             rhs.center_of_mass_observer_gain);
     return is_equal;
   }
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 std::unordered_map<std::string, int> computeBodyOrFrameNameToIdMap(
@@ -289,6 +295,8 @@ struct DesiredBodyAcceleration {
   KinematicPath body_path;
   Eigen::Isometry3d T_task_to_world;
   Vector6d weight_multiplier;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 struct QPControllerOutput {
@@ -299,9 +307,7 @@ struct QPControllerOutput {
 };
 
 struct QPControllerDebugData {
-  std::vector<SupportStateElement,
-              Eigen::aligned_allocator<SupportStateElement>>
-      active_supports;
+  drake::eigen_aligned_std_vector<SupportStateElement> active_supports;
   int nc;
   Eigen::MatrixXd normals;
   Eigen::MatrixXd B;
@@ -323,6 +329,8 @@ struct QPControllerDebugData {
   Eigen::MatrixXd Jcom;
   Eigen::VectorXd Jcomdotv;
   Eigen::VectorXd beta;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 struct PIDOutput {

--- a/drake/systems/controllers/controlUtil.cpp
+++ b/drake/systems/controllers/controlUtil.cpp
@@ -106,9 +106,8 @@ int contactPhi(const RigidBodyTree& r, const KinematicsCache<double>& cache,
 int contactConstraintsBV(
     const RigidBodyTree& r, const KinematicsCache<double>& cache, int nc,
     std::vector<double> support_mus,
-    drake::eigen_aligned_std_vector<SupportStateElement>& supp,
-    MatrixXd& B, MatrixXd& JB, MatrixXd& Jp, VectorXd& Jpdotv,
-    MatrixXd& normals) {
+    drake::eigen_aligned_std_vector<SupportStateElement>& supp, MatrixXd& B,
+    MatrixXd& JB, MatrixXd& Jp, VectorXd& Jpdotv, MatrixXd& normals) {
   int j, k = 0, nq = r.number_of_positions();
 
   B.resize(3, nc * 2 * m_surface_tangents);
@@ -246,8 +245,7 @@ bool isSupportElementActive(SupportStateElement* se,
 
 Matrix<bool, Dynamic, 1> getActiveSupportMask(
     const RigidBodyTree& r, VectorXd q, VectorXd qd,
-    drake::eigen_aligned_std_vector<SupportStateElement>&
-        available_supports,
+    drake::eigen_aligned_std_vector<SupportStateElement>& available_supports,
     const Ref<const Matrix<bool, Dynamic, 1>>& contact_force_detected,
     double contact_threshold) {
   KinematicsCache<double> cache = r.doKinematics(q, qd);
@@ -297,8 +295,7 @@ Matrix<bool, Dynamic, 1> getActiveSupportMask(
 
 drake::eigen_aligned_std_vector<SupportStateElement> getActiveSupports(
     const RigidBodyTree& r, const VectorXd& q, const VectorXd& qd,
-    drake::eigen_aligned_std_vector<SupportStateElement>&
-        available_supports,
+    drake::eigen_aligned_std_vector<SupportStateElement>& available_supports,
     const Ref<const Matrix<bool, Dynamic, 1>>& contact_force_detected,
     double contact_threshold) {
   Matrix<bool, Dynamic, 1> active_supp_mask = getActiveSupportMask(

--- a/drake/systems/controllers/controlUtil.cpp
+++ b/drake/systems/controllers/controlUtil.cpp
@@ -53,8 +53,7 @@ void angleDiff(MatrixBase<DerivedPhi1> const& phi1,
 }
 
 bool inSupport(
-    const std::vector<SupportStateElement,
-                      Eigen::aligned_allocator<SupportStateElement>>& supports,
+    const drake::eigen_aligned_std_vector<SupportStateElement>& supports,
     int body_idx) {
   // HANDLE IF BODY_IDX IS A FRAME ID?
   for (size_t i = 0; i < supports.size(); i++) {
@@ -107,8 +106,7 @@ int contactPhi(const RigidBodyTree& r, const KinematicsCache<double>& cache,
 int contactConstraintsBV(
     const RigidBodyTree& r, const KinematicsCache<double>& cache, int nc,
     std::vector<double> support_mus,
-    std::vector<SupportStateElement,
-                Eigen::aligned_allocator<SupportStateElement>>& supp,
+    drake::eigen_aligned_std_vector<SupportStateElement>& supp,
     MatrixXd& B, MatrixXd& JB, MatrixXd& Jp, VectorXd& Jpdotv,
     MatrixXd& normals) {
   int j, k = 0, nq = r.number_of_positions();
@@ -123,10 +121,7 @@ int contactConstraintsBV(
   MatrixXd J(3, nq);
   Matrix<double, 3, m_surface_tangents> d;
 
-  for (std::vector<SupportStateElement,
-                   Eigen::aligned_allocator<SupportStateElement>>::iterator
-           iter = supp.begin();
-       iter != supp.end(); iter++) {
+  for (auto iter = supp.begin(); iter != supp.end(); iter++) {
     double mu = support_mus[iter - supp.begin()];
     double norm = sqrt(1 + mu * mu);  // because normals and ds are orthogonal,
                                       // the norm has a simple form
@@ -169,9 +164,7 @@ int contactConstraintsBV(
 
 MatrixXd individualSupportCOPs(
     const RigidBodyTree& r, const KinematicsCache<double>& cache,
-    const std::vector<SupportStateElement,
-                      Eigen::aligned_allocator<SupportStateElement>>&
-        active_supports,
+    const drake::eigen_aligned_std_vector<SupportStateElement>& active_supports,
     const MatrixXd& normals, const MatrixXd& B, const VectorXd& beta) {
   const int n_basis_vectors_per_contact =
       static_cast<int>(B.cols() / normals.cols());
@@ -253,8 +246,7 @@ bool isSupportElementActive(SupportStateElement* se,
 
 Matrix<bool, Dynamic, 1> getActiveSupportMask(
     const RigidBodyTree& r, VectorXd q, VectorXd qd,
-    std::vector<SupportStateElement,
-                Eigen::aligned_allocator<SupportStateElement>>&
+    drake::eigen_aligned_std_vector<SupportStateElement>&
         available_supports,
     const Ref<const Matrix<bool, Dynamic, 1>>& contact_force_detected,
     double contact_threshold) {
@@ -303,19 +295,16 @@ Matrix<bool, Dynamic, 1> getActiveSupportMask(
   return active_supp_mask;
 }
 
-std::vector<SupportStateElement, Eigen::aligned_allocator<SupportStateElement>>
-getActiveSupports(
+drake::eigen_aligned_std_vector<SupportStateElement> getActiveSupports(
     const RigidBodyTree& r, const VectorXd& q, const VectorXd& qd,
-    std::vector<SupportStateElement,
-                Eigen::aligned_allocator<SupportStateElement>>&
+    drake::eigen_aligned_std_vector<SupportStateElement>&
         available_supports,
     const Ref<const Matrix<bool, Dynamic, 1>>& contact_force_detected,
     double contact_threshold) {
   Matrix<bool, Dynamic, 1> active_supp_mask = getActiveSupportMask(
       r, q, qd, available_supports, contact_force_detected, contact_threshold);
 
-  std::vector<SupportStateElement,
-              Eigen::aligned_allocator<SupportStateElement>> active_supports;
+  drake::eigen_aligned_std_vector<SupportStateElement> active_supports;
 
   for (size_t i = 0; i < available_supports.size(); i++) {
     if (active_supp_mask(i)) {

--- a/drake/systems/controllers/controlUtil.h
+++ b/drake/systems/controllers/controlUtil.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <math.h>
+#include <Eigen/Dense>
 #include <set>
 #include <vector>
-#include <Eigen/Dense>
 
 #include "drake/common/eigen_stl_types.h"
 #include "drake/drakeControlUtil_export.h"
@@ -35,73 +35,73 @@ struct DrakeRobotState {
 };
 
 DRAKECONTROLUTIL_EXPORT bool isSupportElementActive(
-    SupportStateElement *se, bool contact_force_detected,
+    SupportStateElement* se, bool contact_force_detected,
     bool kinematic_contact_detected);
 
 DRAKECONTROLUTIL_EXPORT Eigen::Matrix<bool, Eigen::Dynamic, 1>
 getActiveSupportMask(
-    RigidBodyTree *r, Eigen::VectorXd q, Eigen::VectorXd qd,
+    RigidBodyTree* r, Eigen::VectorXd q, Eigen::VectorXd qd,
     drake::eigen_aligned_std_vector<SupportStateElement>& available_supports,
-    const Eigen::Ref<const Eigen::Matrix<bool, Eigen::Dynamic, 1>> &
+    const Eigen::Ref<const Eigen::Matrix<bool, Eigen::Dynamic, 1>>&
         contact_force_detected,
     double contact_threshold);
 
 DRAKECONTROLUTIL_EXPORT drake::eigen_aligned_std_vector<SupportStateElement>
 getActiveSupports(
-    const RigidBodyTree &r, const Eigen::VectorXd &q, const Eigen::VectorXd &qd,
+    const RigidBodyTree& r, const Eigen::VectorXd& q, const Eigen::VectorXd& qd,
     drake::eigen_aligned_std_vector<SupportStateElement>& available_supports,
-    const Eigen::Ref<const Eigen::Matrix<bool, Eigen::Dynamic, 1>> &
+    const Eigen::Ref<const Eigen::Matrix<bool, Eigen::Dynamic, 1>>&
         contact_force_detected,
     double contact_threshold);
 
 template <typename DerivedA, typename DerivedB>
-DRAKECONTROLUTIL_EXPORT void getRows(std::set<int> &rows,
-                                     Eigen::MatrixBase<DerivedA> const &M,
-                                     Eigen::MatrixBase<DerivedB> &Msub);
+DRAKECONTROLUTIL_EXPORT void getRows(std::set<int>& rows,
+                                     Eigen::MatrixBase<DerivedA> const& M,
+                                     Eigen::MatrixBase<DerivedB>& Msub);
 
 template <typename DerivedA, typename DerivedB>
-DRAKECONTROLUTIL_EXPORT void getCols(std::set<int> &cols,
-                                     Eigen::MatrixBase<DerivedA> const &M,
-                                     Eigen::MatrixBase<DerivedB> &Msub);
+DRAKECONTROLUTIL_EXPORT void getCols(std::set<int>& cols,
+                                     Eigen::MatrixBase<DerivedA> const& M,
+                                     Eigen::MatrixBase<DerivedB>& Msub);
 
 template <typename DerivedPhi1, typename DerivedPhi2, typename DerivedD>
 DRAKECONTROLUTIL_EXPORT void angleDiff(
-    Eigen::MatrixBase<DerivedPhi1> const &phi1,
-    Eigen::MatrixBase<DerivedPhi2> const &phi2, Eigen::MatrixBase<DerivedD> &d);
+    Eigen::MatrixBase<DerivedPhi1> const& phi1,
+    Eigen::MatrixBase<DerivedPhi2> const& phi2, Eigen::MatrixBase<DerivedD>& d);
 
 DRAKECONTROLUTIL_EXPORT bool inSupport(
     const drake::eigen_aligned_std_vector<SupportStateElement>& supports,
     int body_idx);
 DRAKECONTROLUTIL_EXPORT void surfaceTangents(
-    const Eigen::Vector3d &normal,
-    Eigen::Matrix<double, 3, m_surface_tangents> &d);
-DRAKECONTROLUTIL_EXPORT int contactPhi(const RigidBodyTree &r,
-                                       const KinematicsCache<double> &cache,
-                                       SupportStateElement &supp,
-                                       Eigen::VectorXd &phi);
+    const Eigen::Vector3d& normal,
+    Eigen::Matrix<double, 3, m_surface_tangents>& d);
+DRAKECONTROLUTIL_EXPORT int contactPhi(const RigidBodyTree& r,
+                                       const KinematicsCache<double>& cache,
+                                       SupportStateElement& supp,
+                                       Eigen::VectorXd& phi);
 DRAKECONTROLUTIL_EXPORT int contactConstraintsBV(
-    const RigidBodyTree &r, const KinematicsCache<double> &cache, int nc,
+    const RigidBodyTree& r, const KinematicsCache<double>& cache, int nc,
     std::vector<double> support_mus,
     drake::eigen_aligned_std_vector<SupportStateElement>& supp,
-    Eigen::MatrixXd &B, Eigen::MatrixXd &JB, Eigen::MatrixXd &Jp,
-    Eigen::VectorXd &Jpdotv, Eigen::MatrixXd &normals);
+    Eigen::MatrixXd& B, Eigen::MatrixXd& JB, Eigen::MatrixXd& Jp,
+    Eigen::VectorXd& Jpdotv, Eigen::MatrixXd& normals);
 DRAKECONTROLUTIL_EXPORT Eigen::MatrixXd individualSupportCOPs(
-    const RigidBodyTree &r, const KinematicsCache<double> &cache,
+    const RigidBodyTree& r, const KinematicsCache<double>& cache,
     const drake::eigen_aligned_std_vector<SupportStateElement>& active_supports,
-    const Eigen::MatrixXd &normals, const Eigen::MatrixXd &B,
-    const Eigen::VectorXd &beta);
+    const Eigen::MatrixXd& normals, const Eigen::MatrixXd& B,
+    const Eigen::VectorXd& beta);
 DRAKECONTROLUTIL_EXPORT Vector6d bodySpatialMotionPD(
-    const RigidBodyTree &r, const DrakeRobotState &robot_state,
-    const int body_index, const Eigen::Isometry3d &body_pose_des,
-    const Eigen::Ref<const Vector6d> &body_v_des,
-    const Eigen::Ref<const Vector6d> &body_vdot_des,
-    const Eigen::Ref<const Vector6d> &Kp, const Eigen::Ref<const Vector6d> &Kd,
-    const Eigen::Isometry3d &T_task_to_world = Eigen::Isometry3d::Identity());
+    const RigidBodyTree& r, const DrakeRobotState& robot_state,
+    const int body_index, const Eigen::Isometry3d& body_pose_des,
+    const Eigen::Ref<const Vector6d>& body_v_des,
+    const Eigen::Ref<const Vector6d>& body_vdot_des,
+    const Eigen::Ref<const Vector6d>& Kp, const Eigen::Ref<const Vector6d>& Kd,
+    const Eigen::Isometry3d& T_task_to_world = Eigen::Isometry3d::Identity());
 
 DRAKECONTROLUTIL_EXPORT void evaluateXYZExpmapCubicSpline(
-    double t, const PiecewisePolynomial<double> &spline,
-    Eigen::Isometry3d &body_pose_des, Vector6d &xyzdot_angular_vel,
-    Vector6d &xyzddot_angular_accel);
+    double t, const PiecewisePolynomial<double>& spline,
+    Eigen::Isometry3d& body_pose_des, Vector6d& xyzdot_angular_vel,
+    Vector6d& xyzddot_angular_accel);
 
 struct RobotJointIndexMap {
   Eigen::VectorXi drake_to_robot;
@@ -115,5 +115,4 @@ struct JointNames {
 };
 
 DRAKECONTROLUTIL_EXPORT void getRobotJointIndexMap(
-    JointNames *joint_names, RobotJointIndexMap *joint_map);
-
+    JointNames* joint_names, RobotJointIndexMap* joint_map);

--- a/drake/systems/controllers/controlUtil.h
+++ b/drake/systems/controllers/controlUtil.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <math.h>
-#include <Eigen/Dense>
 #include <set>
 #include <vector>
+
+#include <Eigen/Dense>
 
 #include "drake/common/eigen_stl_types.h"
 #include "drake/drakeControlUtil_export.h"

--- a/drake/systems/controllers/controlUtil.h
+++ b/drake/systems/controllers/controlUtil.h
@@ -24,7 +24,7 @@ typedef struct _support_state_element {
   bool support_logic_map[4];
   Eigen::Vector4d support_surface;  // 4-vector describing a support surface:
                                     // [v; b] such that v' * [x;y;z] + b == 0
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } SupportStateElement;
 
 struct DrakeRobotState {
@@ -106,7 +106,7 @@ DRAKECONTROLUTIL_EXPORT void evaluateXYZExpmapCubicSpline(
 struct RobotJointIndexMap {
   Eigen::VectorXi drake_to_robot;
   Eigen::VectorXi robot_to_drake;
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 struct JointNames {

--- a/drake/systems/controllers/instantaneousQPControllermex.cpp
+++ b/drake/systems/controllers/instantaneousQPControllermex.cpp
@@ -13,8 +13,8 @@
 
 #include "InstantaneousQPController.h"
 
-#include <limits>
 #include <cmath>
+#include <limits>
 
 #include "drake/common/eigen_types.h"
 #include "drake/util/drakeMexUtil.h"

--- a/drake/systems/controllers/instantaneousQPControllermex.cpp
+++ b/drake/systems/controllers/instantaneousQPControllermex.cpp
@@ -85,7 +85,8 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
     debug.reset(new QPControllerDebugData());
   }
 
-  std::map<Side, ForceTorqueMeasurement> foot_force_torque_measurements;
+  drake::eigen_aligned_std_map<Side, ForceTorqueMeasurement>
+      foot_force_torque_measurements;
   if (nrhs > 5) {
     const mxArray* mex_foot_force_torque_measurements = prhs[narg++];
     if (!mxIsEmpty(mex_foot_force_torque_measurements)) {

--- a/drake/systems/controllers/supportDetectmex.cpp
+++ b/drake/systems/controllers/supportDetectmex.cpp
@@ -88,8 +88,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
 
   //---------------------------------------------------------------------
   // Compute active support from desired supports -----------------------
-  vector<SupportStateElement, Eigen::aligned_allocator<SupportStateElement>>
-      active_supports;
+  drake::eigen_aligned_std_vector<SupportStateElement> active_supports;
   set<int> contact_bodies;  // redundant, clean up later
   int num_active_contact_pts = 0;
   if (!mxIsEmpty(prhs[desired_support_argid])) {
@@ -159,9 +158,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
                                    mxREAL);
     pr = mxGetPr(plhs[0]);
     int i = 0;
-    for (vector<SupportStateElement,
-                Eigen::aligned_allocator<SupportStateElement>>::iterator iter =
-             active_supports.begin();
+    for (auto iter = active_supports.begin();
          iter != active_supports.end(); iter++) {
       pr[i++] = (double)(iter->body_idx + 1);
     }

--- a/drake/systems/plants/ForceTorqueMeasurement.h
+++ b/drake/systems/plants/ForceTorqueMeasurement.h
@@ -6,4 +6,5 @@ struct ForceTorqueMeasurement {
   int frame_idx;
   Eigen::Matrix<double, 6, 1> wrench;  // [torque; force], expressed in frame
                                        // corresponding to frame_idx;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/drake/util/yaml/yamlUtil.cpp
+++ b/drake/util/yaml/yamlUtil.cpp
@@ -323,8 +323,9 @@ QPControllerParams loadSingleParamSet(const YAML::Node& config,
   return params;
 }
 
-drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSetsFromExpandedConfig(
-    YAML::Node config, const RigidBodyTree& robot) {
+drake::eigen_aligned_std_map<std::string, QPControllerParams>
+loadAllParamSetsFromExpandedConfig(YAML::Node config,
+                                   const RigidBodyTree& robot) {
   drake::eigen_aligned_std_map<std::string, QPControllerParams> param_sets;
   for (auto config_it = config.begin(); config_it != config.end();
        ++config_it) {
@@ -383,9 +384,10 @@ RobotPropertyCache parseKinematicTreeMetadata(const YAML::Node& metadata,
     ret.position_indices.legs[side] = findPositionIndices(
         robot, joint_group_names["legs"][side_id].as<vector<string>>());
     ret.position_indices.knees[side] =
-        robot.FindChildBodyOfJoint(
-            joint_group_names["knees"][side_id].as<string>())->
-                get_position_start_index();
+        robot
+            .FindChildBodyOfJoint(
+                joint_group_names["knees"][side_id].as<string>())
+            ->get_position_start_index();
     ret.position_indices.ankles[side] = findPositionIndices(
         robot, joint_group_names["ankles"][side_id].as<vector<string>>());
     ret.position_indices.arms[side] = findPositionIndices(
@@ -394,11 +396,11 @@ RobotPropertyCache parseKinematicTreeMetadata(const YAML::Node& metadata,
   ret.position_indices.neck = findPositionIndices(
       robot, joint_group_names["neck"].as<vector<string>>());
   ret.position_indices.back_bkz =
-      robot.FindChildBodyOfJoint(joint_group_names["back_bkz"].as<string>())->
-          get_position_start_index();
+      robot.FindChildBodyOfJoint(joint_group_names["back_bkz"].as<string>())
+          ->get_position_start_index();
   ret.position_indices.back_bky =
-      robot.FindChildBodyOfJoint(joint_group_names["back_bky"].as<string>())->
-          get_position_start_index();
+      robot.FindChildBodyOfJoint(joint_group_names["back_bky"].as<string>())
+          ->get_position_start_index();
 
   return ret;
 }

--- a/drake/util/yaml/yamlUtil.cpp
+++ b/drake/util/yaml/yamlUtil.cpp
@@ -323,9 +323,9 @@ QPControllerParams loadSingleParamSet(const YAML::Node& config,
   return params;
 }
 
-std::map<std::string, QPControllerParams> loadAllParamSetsFromExpandedConfig(
+drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSetsFromExpandedConfig(
     YAML::Node config, const RigidBodyTree& robot) {
-  auto param_sets = std::map<std::string, QPControllerParams>();
+  drake::eigen_aligned_std_map<std::string, QPControllerParams> param_sets;
   for (auto config_it = config.begin(); config_it != config.end();
        ++config_it) {
     std::cout << "loading param set: " << config_it->first << std::endl;
@@ -336,13 +336,13 @@ std::map<std::string, QPControllerParams> loadAllParamSetsFromExpandedConfig(
   return param_sets;
 }
 
-std::map<std::string, QPControllerParams> loadAllParamSets(
+drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSets(
     YAML::Node config, const RigidBodyTree& robot) {
   config = expandDefaults(config);
   return loadAllParamSetsFromExpandedConfig(config, robot);
 }
 
-std::map<std::string, QPControllerParams> loadAllParamSets(
+drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSets(
     YAML::Node config, const RigidBodyTree& robot,
     std::ofstream& debug_output_file) {
   config = expandDefaults(config);

--- a/drake/util/yaml/yamlUtil.h
+++ b/drake/util/yaml/yamlUtil.h
@@ -3,11 +3,12 @@
 #include <fstream>
 #include <map>
 
+#include "yaml-cpp/yaml.h"
+
 #include "drake/common/eigen_stl_types.h"
 #include "drake/drakeYAMLUtil_export.h"
 #include "drake/systems/controllers/QPCommon.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "yaml-cpp/yaml.h"
 
 DRAKEYAMLUTIL_EXPORT YAML::Node applyDefaults(const YAML::Node& node,
                                               const YAML::Node& default_node);
@@ -22,12 +23,12 @@ DRAKEYAMLUTIL_EXPORT YAML::Node get(const YAML::Node& parent,
 DRAKEYAMLUTIL_EXPORT QPControllerParams
 loadSingleParamSet(const YAML::Node& config, const RigidBodyTree& robot);
 DRAKEYAMLUTIL_EXPORT
-    drake::eigen_aligned_std_map<std::string, QPControllerParams>
-    loadAllParamSets(YAML::Node config, const RigidBodyTree& robot);
+drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSets(
+    YAML::Node config, const RigidBodyTree& robot);
 DRAKEYAMLUTIL_EXPORT
-    drake::eigen_aligned_std_map<std::string, QPControllerParams>
-    loadAllParamSets(YAML::Node config, const RigidBodyTree& robot,
-                     std::ofstream& debug_output_file);
+drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSets(
+    YAML::Node config, const RigidBodyTree& robot,
+    std::ofstream& debug_output_file);
 DRAKEYAMLUTIL_EXPORT RobotPropertyCache parseKinematicTreeMetadata(
     const YAML::Node& metadata, const RigidBodyTree& robot);
 DRAKEYAMLUTIL_EXPORT KinematicModifications

--- a/drake/util/yaml/yamlUtil.h
+++ b/drake/util/yaml/yamlUtil.h
@@ -1,32 +1,34 @@
 #pragma once
 
-#include <map>
 #include <fstream>
+#include <map>
 
 #include "drake/common/eigen_stl_types.h"
-#include "yaml-cpp/yaml.h"
+#include "drake/drakeYAMLUtil_export.h"
 #include "drake/systems/controllers/QPCommon.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "drake/drakeYAMLUtil_export.h"
+#include "yaml-cpp/yaml.h"
 
-DRAKEYAMLUTIL_EXPORT YAML::Node applyDefaults(
-  const YAML::Node& node, const YAML::Node& default_node);
+DRAKEYAMLUTIL_EXPORT YAML::Node applyDefaults(const YAML::Node& node,
+                                              const YAML::Node& default_node);
 DRAKEYAMLUTIL_EXPORT YAML::Node expandDefaults(const YAML::Node& node);
 
 // yaml-cpp does not understand the DEFAULT: syntax for a default value or the
 // <<: syntax to merge the contents of a node. This function wraps the map
 // lookup to provide the correct behavior.
-DRAKEYAMLUTIL_EXPORT YAML::Node get(
-  const YAML::Node& parent, const std::string& key);
+DRAKEYAMLUTIL_EXPORT YAML::Node get(const YAML::Node& parent,
+                                    const std::string& key);
 
-DRAKEYAMLUTIL_EXPORT QPControllerParams loadSingleParamSet(
-  const YAML::Node& config, const RigidBodyTree& robot);
-DRAKEYAMLUTIL_EXPORT drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSets(
-    YAML::Node config, const RigidBodyTree& robot);
-DRAKEYAMLUTIL_EXPORT drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSets(
-    YAML::Node config, const RigidBodyTree& robot,
-    std::ofstream& debug_output_file);
+DRAKEYAMLUTIL_EXPORT QPControllerParams
+loadSingleParamSet(const YAML::Node& config, const RigidBodyTree& robot);
+DRAKEYAMLUTIL_EXPORT
+    drake::eigen_aligned_std_map<std::string, QPControllerParams>
+    loadAllParamSets(YAML::Node config, const RigidBodyTree& robot);
+DRAKEYAMLUTIL_EXPORT
+    drake::eigen_aligned_std_map<std::string, QPControllerParams>
+    loadAllParamSets(YAML::Node config, const RigidBodyTree& robot,
+                     std::ofstream& debug_output_file);
 DRAKEYAMLUTIL_EXPORT RobotPropertyCache parseKinematicTreeMetadata(
-  const YAML::Node& metadata, const RigidBodyTree& robot);
-DRAKEYAMLUTIL_EXPORT KinematicModifications parseKinematicModifications(
-  const YAML::Node& mods);
+    const YAML::Node& metadata, const RigidBodyTree& robot);
+DRAKEYAMLUTIL_EXPORT KinematicModifications
+parseKinematicModifications(const YAML::Node& mods);

--- a/drake/util/yaml/yamlUtil.h
+++ b/drake/util/yaml/yamlUtil.h
@@ -2,6 +2,8 @@
 
 #include <map>
 #include <fstream>
+
+#include "drake/common/eigen_stl_types.h"
 #include "yaml-cpp/yaml.h"
 #include "drake/systems/controllers/QPCommon.h"
 #include "drake/systems/plants/RigidBodyTree.h"
@@ -19,9 +21,9 @@ DRAKEYAMLUTIL_EXPORT YAML::Node get(
 
 DRAKEYAMLUTIL_EXPORT QPControllerParams loadSingleParamSet(
   const YAML::Node& config, const RigidBodyTree& robot);
-DRAKEYAMLUTIL_EXPORT std::map<std::string, QPControllerParams> loadAllParamSets(
+DRAKEYAMLUTIL_EXPORT drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSets(
     YAML::Node config, const RigidBodyTree& robot);
-DRAKEYAMLUTIL_EXPORT std::map<std::string, QPControllerParams> loadAllParamSets(
+DRAKEYAMLUTIL_EXPORT drake::eigen_aligned_std_map<std::string, QPControllerParams> loadAllParamSets(
     YAML::Node config, const RigidBodyTree& robot,
     std::ofstream& debug_output_file);
 DRAKEYAMLUTIL_EXPORT RobotPropertyCache parseKinematicTreeMetadata(


### PR DESCRIPTION
Fixes https://github.com/RobotLocomotion/drake/issues/2165.
~~Hopefully also fixes https://github.com/RobotLocomotion/drake/issues/3147 (pending CI build results). Note that `runAtlasManip` still doesn't pass on OSX Release (don't know about other configurations), but that's because the robot flips out, not because of a crash, so I think a new issue should be opened for that.~~

Crash happened when `param_sets` got move-assigned (i.e. assigned from an rvalue), but not when it was copy-assigned from an lvalue (as demonstrated by https://github.com/rdeits/drake/commit/6de25e992a321521af21cb75ac90314e248409e4). There are real differences between the implementation of a `std::map`'s move assignment operator and its copy assignment operator, so it's not that weird that there is a difference in behavior.

StackOverflow question that describes the same behavior: https://stackoverflow.com/questions/38403189/move-assigning-a-stdmap-with-an-aligned-value-type-segfaults. I was able to reproduce their minimal example on my machine, and it only results in a segfault in release mode, not in debug, consistent with what we're seeing. This example runs fine with O0, but segfaults with O1, O2 and O3.

Here's a modified version of that example that includes Eigen:

```C++
#include <iostream>
#include <map>
#include <Eigen/Core>

using Eigen::Vector4d;

struct Foo {
  double a;
  Vector4d b; // fixed size vectorizable type
  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
};

template <typename Key, typename T>
using eigen_aligned_map =
std::map<Key, T, std::less<Key>, Eigen::aligned_allocator<std::pair<Key const, T> > >;

int main() {
//  std::map<int, Foo> m{{0, {1., Vector4d::Random()}}};
//  std::map<int, Foo> n{{1, {1., Vector4d::Random()}}};

  eigen_aligned_map<int, Foo> m{{0, {1., Vector4d::Random()}}};
  eigen_aligned_map<int, Foo> n{{1, {1., Vector4d::Random()}}};

  std::cout << "GOT HERE" << std::endl;
  m = std::move(n);  //  segfault happens here
  std::cout << "GOT HERE TOO" << std::endl;
}
```

Strangely enough, for this second example, things are fine for O0 *and* O1, but bad for O2 and O3, regardless of whether I use `std::map` or `eigen_aligned_map`. So following Eigen's standard rules for using fixed-size vectorizable types in STL containers (https://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html) does not work for this case.

I'm not sure whose bug this is (Eigen's or Clang's). I'll file a bug report with Eigen first, see what they say about it.

This PR works around the issue by using the copy-assignment operator instead, as @rdeits noticed already.

In addition, there were some pretty pervasive Eigen alignment issues. These may have contributed to #3147 as well.

Also adds `drake::eigen_aligned_std_map`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3462)
<!-- Reviewable:end -->
