### PR TITLE
Removes redundant dynamic casts

### DIFF
--- a/drake/systems/framework/primitives/test/adder_test.cc
+++ b/drake/systems/framework/primitives/test/adder_test.cc
@@ -69,8 +69,7 @@ TEST_F(AdderTest, AddTwoVectors) {
   adder_->EvalOutput(*context_, output_.get());
 
   ASSERT_EQ(1, output_->get_num_ports());
-  const BasicVector<double>* output_port =
-      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+  const BasicVector<double>* output_port = output_->get_vector_data(0);
   ASSERT_NE(nullptr, output_port);
   Eigen::Vector3d expected;
   expected << 5, 7, 9;

--- a/drake/systems/framework/primitives/test/constant_vector_source_test.cc
+++ b/drake/systems/framework/primitives/test/constant_vector_source_test.cc
@@ -50,8 +50,7 @@ TEST_F(ConstantVectorSourceTest, OutputTest) {
   // TODO(amcastro-tri): Solve #3140 so that the next line reads:
   // auto& source_->get_output_vector(context, 0);
   // to directly get an Eigen expression.
-  const BasicVector<double>* output_vector =
-      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+  const BasicVector<double>* output_vector = output_->get_vector_data(0);
   ASSERT_NE(nullptr, output_vector);
   EXPECT_TRUE(kConstantVectorSource.isApprox(
       output_vector->get_value(), Eigen::NumTraits<double>::epsilon()));

--- a/drake/systems/framework/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/gain_scalartype_test.cc
@@ -67,9 +67,7 @@ GTEST_TEST(GainScalarTypeTest, AutoDiff) {
   gain->EvalOutput(*context, output.get());
 
   ASSERT_EQ(1, output->get_num_ports());
-  const auto& output_vector =
-      dynamic_cast<const BasicVector<T>*>(output->get_vector_data(0))
-          ->get_value();
+  const auto& output_vector = output->get_vector_data(0)->get_value();
 
   // The expected output value is the gain times the input vector.
   VectorX<T> expected = kGain * input_vector;

--- a/drake/systems/framework/primitives/test/gain_test.cc
+++ b/drake/systems/framework/primitives/test/gain_test.cc
@@ -64,8 +64,7 @@ TEST_F(GainTest, VectorThroughGainSystem) {
   // SystemOutput are consistent.
   ASSERT_EQ(1, output_->get_num_ports());
   ASSERT_EQ(1, gain_->get_num_output_ports());
-  const BasicVector<double>* output_vector =
-      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+  const BasicVector<double>* output_vector = output_->get_vector_data(0);
   ASSERT_NE(nullptr, output_vector);
   Eigen::Vector3d expected = kGain_ * input_vector;
   EXPECT_EQ(expected, output_vector->get_value());

--- a/drake/systems/framework/primitives/test/integrator_test.cc
+++ b/drake/systems/framework/primitives/test/integrator_test.cc
@@ -77,8 +77,7 @@ TEST_F(IntegratorTest, Output) {
   integrator_->EvalOutput(*context_, output_.get());
 
   ASSERT_EQ(1, output_->get_num_ports());
-  const BasicVector<double>* output_port =
-      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+  const BasicVector<double>* output_port = output_->get_vector_data(0);
   ASSERT_NE(nullptr, output_port);
 
   Eigen::Vector3d expected;

--- a/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
@@ -57,7 +57,7 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
   buffer->EvalOutput(*context, output.get());
 
   ASSERT_EQ(1, output->get_num_ports());
-  const BasicVector<T>* output_vector = output->get_vector_data(0)->get_value();
+  auto output_vector = output->get_vector_data(0)->get_value();
 
   // The expected output value equals the input.
   Vector3<T> expected;

--- a/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
@@ -57,8 +57,7 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
   buffer->EvalOutput(*context, output.get());
 
   ASSERT_EQ(1, output->get_num_ports());
-  const auto& output_vector = dynamic_cast<const BasicVector<T>*>(
-      output->get_vector_data(0))->get_value();
+  const BasicVector<T>* output_vector = output->get_vector_data(0)->get_value();
 
   // The expected output value equals the input.
   Vector3<T> expected;

--- a/drake/systems/framework/primitives/test/pass_through_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_test.cc
@@ -59,8 +59,7 @@ TEST_F(PassThroughTest, VectorThroughPassThroughSystem) {
   // output are consistent.
   ASSERT_EQ(1, output_->get_num_ports());
   ASSERT_EQ(1, pass_through_->get_num_output_ports());
-  const BasicVector<double>* output_vector =
-      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+  const BasicVector<double>* output_vector = output_->get_vector_data(0);
   ASSERT_NE(nullptr, output_vector);
   EXPECT_EQ(input_vector, output_vector->get_value());
 }

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -122,22 +122,19 @@ class DiagramTest : public ::testing::Test {
     Eigen::Vector3d expected_output2;
     expected_output2 << 81, 243, 729;  // state of integrator1_
 
-    const BasicVector<double>* output0 =
-        dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+    const BasicVector<double>* output0 = output_->get_vector_data(0);
     ASSERT_TRUE(output0 != nullptr);
     EXPECT_EQ(expected_output0[0], output0->get_value()[0]);
     EXPECT_EQ(expected_output0[1], output0->get_value()[1]);
     EXPECT_EQ(expected_output0[2], output0->get_value()[2]);
 
-    const BasicVector<double>* output1 =
-        dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(1));
+    const BasicVector<double>* output1 = output_->get_vector_data(1);
     ASSERT_TRUE(output1 != nullptr);
     EXPECT_EQ(expected_output1[0], output1->get_value()[0]);
     EXPECT_EQ(expected_output1[1], output1->get_value()[1]);
     EXPECT_EQ(expected_output1[2], output1->get_value()[2]);
 
-    const BasicVector<double>* output2 =
-        dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(2));
+    const BasicVector<double>* output2 = output_->get_vector_data(2);
     ASSERT_TRUE(output2 != nullptr);
     EXPECT_EQ(expected_output2[0], output2->get_value()[0]);
     EXPECT_EQ(expected_output2[1], output2->get_value()[1]);
@@ -254,8 +251,7 @@ TEST_F(DiagramTest, Clone) {
 
   Eigen::Vector3d expected_output0;
   expected_output0 << 3 + 8 + 64, 6 + 16 + 128, 9 + 32 + 256;  // B
-  const BasicVector<double>* output0 =
-      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+  const BasicVector<double>* output0 = output_->get_vector_data(0);
   ASSERT_TRUE(output0 != nullptr);
   EXPECT_EQ(expected_output0[0], output0->get_value()[0]);
   EXPECT_EQ(expected_output0[1], output0->get_value()[1]);
@@ -264,8 +260,7 @@ TEST_F(DiagramTest, Clone) {
   Eigen::Vector3d expected_output1;
   expected_output1 << 3 + 8, 6 + 16, 9 + 32;  // A
   expected_output1 += expected_output0;       // A + B
-  const BasicVector<double>* output1 =
-      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(1));
+  const BasicVector<double>* output1 = output_->get_vector_data(1);
   ASSERT_TRUE(output1 != nullptr);
   EXPECT_EQ(expected_output1[0], output1->get_value()[0]);
   EXPECT_EQ(expected_output1[1], output1->get_value()[1]);

--- a/drake/systems/framework/test/system_output_test.cc
+++ b/drake/systems/framework/test/system_output_test.cc
@@ -66,8 +66,7 @@ TEST_F(OutputPortVectorTest, Clone) {
   EXPECT_EQ(expected, clone->template get_vector_data<int>()->get_value());
 
   // The type should be preserved.
-  EXPECT_NE(nullptr, dynamic_cast<const BasicVector<int>*>(
-                         clone->template get_vector_data<int>()));
+  EXPECT_NE(nullptr, clone->template get_vector_data<int>());
 }
 
 // Tests that listeners are notified when GetMutableVectorData is called, and
@@ -158,8 +157,7 @@ TEST_F(LeafSystemOutputTest, Clone) {
     VectorX<int> expected(2);
     expected << 5, 25;
     EXPECT_EQ(expected, port.template get_vector_data<int>()->get_value());
-    EXPECT_NE(nullptr, dynamic_cast<const BasicVector<int>*>(
-                           port.template get_vector_data<int>()));
+    EXPECT_NE(nullptr, port.template get_vector_data<int>());
   }
 
   {
@@ -167,8 +165,7 @@ TEST_F(LeafSystemOutputTest, Clone) {
     VectorX<int> expected(3);
     expected << 125, 625, 3125;
     EXPECT_EQ(expected, port.template get_vector_data<int>()->get_value());
-    EXPECT_NE(nullptr, dynamic_cast<const BasicVector<int>*>(
-                           port.template get_vector_data<int>()));
+    EXPECT_NE(nullptr, port.template get_vector_data<int>());
   }
 }
 

--- a/drake/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/drake/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -111,12 +111,7 @@ void TestSubscriber(::lcm::LCM* lcm, const std::string& channel_name,
     dut->EvalOutput(*context.get(), output.get());
 
     // Gets the output of the LcmSubscriberSystem.
-    const drake::systems::VectorBase<double>* vector =
-        output->get_vector_data(0);
-
-    // Downcasts the output vector to be a pointer to a BasicVector.
-    const BasicVector<double>& basic_vector =
-        dynamic_cast<const BasicVector<double>&>(*vector);
+    const BasicVector<double>& basic_vector = *output->get_vector_data(0);
 
     // Verifies that the size of the basic vector is correct.
     if (basic_vector.size() == kDim) {

--- a/drake/systems/plants/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/systems/plants/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -244,8 +244,7 @@ TEST_F(KukaArmTest, EvalOutput) {
   ASSERT_EQ(xc, desired_state);
 
   ASSERT_EQ(1, output_->get_num_ports());
-  const BasicVector<double>* output_port =
-      dynamic_cast<const BasicVector<double>*>(output_->get_vector_data(0));
+  const BasicVector<double>* output_port = output_->get_vector_data(0);
   ASSERT_NE(nullptr, output_port);
 
   kuka_system_->EvalOutput(*context_, output_.get());


### PR DESCRIPTION
This PR simply removes unnecessary `dynamic_cast`'s now that @david-german-tri has been working on #3208.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3484)
<!-- Reviewable:end -->
