### PR TITLE
Fixes SystemOutput::get_data(int port) method

### DIFF
--- a/drake/systems/framework/primitives/test/constant_value_source_test.cc
+++ b/drake/systems/framework/primitives/test/constant_value_source_test.cc
@@ -45,6 +45,8 @@ TEST_F(ConstantValueSourceTest, Output) {
 
   EXPECT_EQ("foo",
             output_->get_port(0).get_abstract_data()->GetValue<std::string>());
+  EXPECT_EQ("foo",
+            output_->get_data(0)->GetValue<std::string>());
 }
 
 // Tests that inputs cannot be set for a ConstantValueSource.

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -136,7 +136,7 @@ class SystemOutput {
   /// Returns the abstract value in the port at @p index.
   const AbstractValue* get_data(int index) const {
     DRAKE_ASSERT(index >= 0 && index < get_num_ports());
-    return get_port(index).get_data();
+    return get_port(index).get_abstract_data();
   }
 
   /// Returns the vector value in the port at @p index. Throws std::bad_cast if


### PR DESCRIPTION
This PR fixes a bug in `SystemOutput`'s API. I think introduced when removing `<T>` from `SystemOutput`?.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3485)
<!-- Reviewable:end -->
