### PR TITLE
Fixes #3487:  add a 'noreturn' attribute to drake's Abort() function

### DIFF
--- a/drake/common/drake_assert.h
+++ b/drake/common/drake_assert.h
@@ -71,7 +71,8 @@ namespace drake {
 namespace detail {
 // Abort the program with an error message.
 DRAKECOMMON_EXPORT
-void Abort(const char* condition, const char* func, const char* file, int line);
+[[ noreturn ]] void Abort(const char* condition,
+                          const char* func, const char* file, int line);
 }  // namespace detail
 }  // namespace drake
 

--- a/drake/common/drake_assert.h
+++ b/drake/common/drake_assert.h
@@ -71,8 +71,12 @@ namespace drake {
 namespace detail {
 // Abort the program with an error message.
 DRAKECOMMON_EXPORT
-[[ noreturn ]] void Abort(const char* condition,
-                          const char* func, const char* file, int line);
+#if _MSC_VER
+__declspec(noreturn)
+#else /* gcc or clang --- gcc is ok with [[noreturn]], too; clang is not. */
+__attribute__((noreturn))
+#endif
+void Abort(const char* condition, const char* func, const char* file, int line);
 }  // namespace detail
 }  // namespace drake
 


### PR DESCRIPTION
Fixes #3487:  adding a 'noreturn' attribute to drake's Abort() function
declaration lets the compiler know that there is no coming back from
this function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3488)
<!-- Reviewable:end -->
