### PR TITLE
Push runtime/references suppressions to the leaves

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -38,6 +38,3 @@ filter=-readability/casting
 
 # TODO(#2273) Fix this.
 filter=-readability/namespace
-
-# TODO(#2274) Fix this.
-filter=-runtime/references

--- a/drake/common/CPPLINT.cfg
+++ b/drake/common/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/examples/@VanDerPolCpp/CPPLINT.cfg
+++ b/drake/examples/@VanDerPolCpp/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/examples/Acrobot/CPPLINT.cfg
+++ b/drake/examples/Acrobot/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/examples/Pendulum/CPPLINT.cfg
+++ b/drake/examples/Pendulum/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/examples/Quadrotor/CPPLINT.cfg
+++ b/drake/examples/Quadrotor/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/math/CPPLINT.cfg
+++ b/drake/math/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/solvers/CPPLINT.cfg
+++ b/drake/solvers/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/systems/CPPLINT.cfg
+++ b/drake/systems/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/drake/util/CPPLINT.cfg
+++ b/drake/util/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# TODO(#2274) Fix this.
+filter=-runtime/references

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_vehicle_system.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_vehicle_system.h
@@ -19,6 +19,7 @@ namespace ros {
 namespace systems {
 
 bool decode(const ackermann_msgs::AckermannDriveStamped& msg,
+            // NOLINTNEXTLINE(runtime/references) due to LCMSystem.
             drake::automotive::DrivingCommand<double>& x) {
   x.set_steering_angle(msg.drive.steering_angle);
   if (msg.drive.speed > 0) {
@@ -119,6 +120,7 @@ class ROSAckermannCommandReceiverSystem {
 template <typename System>
 void run_ros_vehicle_sim(
     std::shared_ptr<System> sys, double t0, double tf,
+    // NOLINTNEXTLINE(runtime/references) False positive.
     const typename System::template StateVector<double>& x0,
     const SimulationOptions& options = SimulationOptions()) {
   auto ros_ackermann_input =


### PR DESCRIPTION
This is a first piece of #2274 that should make it easier to finish the rest bit by bit (subdirectory by subdirectory.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3490)
<!-- Reviewable:end -->
