### PR TITLE
Fix sign mismatch in SimpleCarStateTranslatorTest

### DIFF
--- a/drake/automotive/test/simple_car_state_translator_test.cc
+++ b/drake/automotive/test/simple_car_state_translator_test.cc
@@ -26,7 +26,7 @@ GTEST_TEST(SimpleCarStateTranslatorTest, RoundtripTest) {
   double time = 0;
   std::vector<uint8_t> lcm_message_bytes;
   dut.Serialize(time, publish_state_vector, &lcm_message_bytes);
-  EXPECT_GT(lcm_message_bytes.size(), 0);
+  EXPECT_GT(lcm_message_bytes.size(), 0u);
 
   // Decode the message.
   SimpleCarState<double> subscribe_state_vector;


### PR DESCRIPTION
Fix a signed/unsigned comparison warning (which gets promoted to an error) in `simple_car_state_translator_test.cc`.

See also 0854bc3a8186 and fe4790765811.

@liangfok for feature review. I don't have access to slack ATM; who's on deck for platform review?