### PR TITLE
Split out drakeAutomotoveLcm from drakeAutomotive

### DIFF
--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -1,62 +1,79 @@
+add_subdirectory(gen)
 add_subdirectory(test)
+
+add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
+  car_simulation.cc
+  curve2.cc
+  gen/driving_command.cc
+  gen/euler_floating_joint_state.cc
+  gen/idm_with_trajectory_agent_state.cc
+  gen/simple_car_state.cc
+  idm_with_trajectory_agent.cc
+  simple_car.cc
+  trajectory_car.cc
+  )
+target_link_libraries(drakeAutomotive
+  drakeCommon
+  drakeRBSystem
+  drakeShapes
+  drakeSystemAnalysis
+  drakeSystemFramework
+  )
+pods_install_libraries(drakeAutomotive)
+drake_install_headers(
+  curve2.h
+  car_simulation.h
+  simple_car.h
+  simple_car-inl.h
+  trajectory_car.h
+  system1_vector.h
+  # N.B. The gen/*.h headers are installed by gen/CMakeLists.txt.
+  )
+pods_install_pkg_config_file(drake-automotive
+  LIBS -ldrakeAutomotive
+  REQUIRES
+  VERSION 0.0.1)
+
 if(lcm_FOUND)
   include_directories(${PROJECT_SOURCE_DIR}/pod-build/lcmgen)
 
-  add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
+  add_library_with_exports(LIB_NAME drakeAutomotiveLcm SOURCE_FILES
     automotive_simulator.cc
-    car_simulation.cc
-    curve2.cc
-    gen/driving_command.cc
     gen/driving_command_translator.cc
-    gen/euler_floating_joint_state.cc
     gen/euler_floating_joint_state_translator.cc
-    gen/idm_with_trajectory_agent_state.cc
     gen/idm_with_trajectory_agent_state_translator.cc
-    gen/simple_car_state.cc
     gen/simple_car_state_translator.cc
-    idm_with_trajectory_agent.cc
-    simple_car.cc
-    trajectory_car.cc
     )
-  target_link_libraries(drakeAutomotive
-    drakeCommon
-    drakeLCMSystem
+  target_link_libraries(drakeAutomotiveLcm
+    drakeAutomotive
     drakeLCMSystem2
-    drakeRBSystem
-    drakeShapes
-    drakeSystemAnalysis
-    drakeSystemFramework
     )
-  pods_install_libraries(drakeAutomotive)
+  pods_install_libraries(drakeAutomotiveLcm)
   drake_install_headers(
     automotive_simulator.h
-    curve2.h
-    car_simulation.h
-    simple_car.h
-    simple_car-inl.h
-    trajectory_car.h
-    system1_vector.h
+    # N.B. The gen/*.h headers are installed by gen/CMakeLists.txt.
     )
-  add_subdirectory(gen)
-  pods_install_pkg_config_file(drake-automotive
-    LIBS -ldrakeAutomotive
+  pods_install_pkg_config_file(drake-automotive-lcm
+    LIBS -ldrakeAutomotiveLcm
     REQUIRES
     VERSION 0.0.1)
 
-  add_dependencies(drakeAutomotive drake_lcmtypes_hpp)
+  add_dependencies(drakeAutomotiveLcm drake_lcmtypes_hpp)
   add_executable(simple_car_demo simple_car_demo.cc)
-  target_link_libraries(simple_car_demo drakeAutomotive)
+  target_link_libraries(simple_car_demo drakeAutomotiveLcm)
 
   add_executable(car_sim_lcm car_sim_lcm.cc)
   add_dependencies(car_sim_lcm drake_lcmtypes_hpp)
-  target_link_libraries(car_sim_lcm drakeAutomotive)
+  # TODO(jwnimmer-tri) Remove drakeLCMSystem once System 1 is gone.
+  target_link_libraries(car_sim_lcm drakeAutomotiveLcm drakeLCMSystem)
 
   add_executable(multi_car_sim_lcm multi_car_sim_lcm.cc)
   add_dependencies(multi_car_sim_lcm drake_lcmtypes_hpp)
-  target_link_libraries(multi_car_sim_lcm drakeAutomotive)
+  # TODO(jwnimmer-tri) Remove drakeLCMSystem once System 1 is gone.
+  target_link_libraries(multi_car_sim_lcm drakeAutomotiveLcm drakeLCMSystem)
 
   drake_add_test(NAME multi_car_sim_lcm COMMAND multi_car_sim_lcm --duration 0.05)
 
   add_executable(demo_multi_car demo_multi_car.cc)
-  target_link_libraries(demo_multi_car drakeAutomotive)
+  target_link_libraries(demo_multi_car drakeAutomotiveLcm)
 endif()

--- a/drake/automotive/gen/driving_command_translator.h
+++ b/drake/automotive/gen/driving_command_translator.h
@@ -4,7 +4,7 @@
 // See drake/automotive/lcm_vector_gen.py.
 
 #include "drake/automotive/gen/driving_command.h"
-#include "drake/drakeAutomotive_export.h"
+#include "drake/drakeAutomotiveLcm_export.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "lcmtypes/drake/lcmt_driving_command_t.hpp"
 
@@ -15,7 +15,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * DrivingCommand type.
  */
-class DRAKEAUTOMOTIVE_EXPORT DrivingCommandTranslator
+class DRAKEAUTOMOTIVELCM_EXPORT DrivingCommandTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   DrivingCommandTranslator()

--- a/drake/automotive/gen/euler_floating_joint_state_translator.h
+++ b/drake/automotive/gen/euler_floating_joint_state_translator.h
@@ -4,7 +4,7 @@
 // See drake/automotive/lcm_vector_gen.py.
 
 #include "drake/automotive/gen/euler_floating_joint_state.h"
-#include "drake/drakeAutomotive_export.h"
+#include "drake/drakeAutomotiveLcm_export.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "lcmtypes/drake/lcmt_euler_floating_joint_state_t.hpp"
 
@@ -15,7 +15,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * EulerFloatingJointState type.
  */
-class DRAKEAUTOMOTIVE_EXPORT EulerFloatingJointStateTranslator
+class DRAKEAUTOMOTIVELCM_EXPORT EulerFloatingJointStateTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   EulerFloatingJointStateTranslator()

--- a/drake/automotive/gen/idm_with_trajectory_agent_state_translator.h
+++ b/drake/automotive/gen/idm_with_trajectory_agent_state_translator.h
@@ -4,7 +4,7 @@
 // See drake/automotive/lcm_vector_gen.py.
 
 #include "drake/automotive/gen/idm_with_trajectory_agent_state.h"
-#include "drake/drakeAutomotive_export.h"
+#include "drake/drakeAutomotiveLcm_export.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "lcmtypes/drake/lcmt_idm_with_trajectory_agent_state_t.hpp"
 
@@ -15,7 +15,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * IdmWithTrajectoryAgentState type.
  */
-class DRAKEAUTOMOTIVE_EXPORT IdmWithTrajectoryAgentStateTranslator
+class DRAKEAUTOMOTIVELCM_EXPORT IdmWithTrajectoryAgentStateTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   IdmWithTrajectoryAgentStateTranslator()

--- a/drake/automotive/gen/simple_car_state_translator.h
+++ b/drake/automotive/gen/simple_car_state_translator.h
@@ -4,7 +4,7 @@
 // See drake/automotive/lcm_vector_gen.py.
 
 #include "drake/automotive/gen/simple_car_state.h"
-#include "drake/drakeAutomotive_export.h"
+#include "drake/drakeAutomotiveLcm_export.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "lcmtypes/drake/lcmt_simple_car_state_t.hpp"
 
@@ -15,7 +15,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * SimpleCarState type.
  */
-class DRAKEAUTOMOTIVE_EXPORT SimpleCarStateTranslator
+class DRAKEAUTOMOTIVELCM_EXPORT SimpleCarStateTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   SimpleCarStateTranslator()

--- a/drake/automotive/lcm_vector_gen.py
+++ b/drake/automotive/lcm_vector_gen.py
@@ -162,7 +162,7 @@ TRANSLATOR_HH_PREAMBLE = """
 // See %(generator)s.
 
 #include "drake/automotive/gen/%(snake)s.h"
-#include "drake/drakeAutomotive_export.h"
+#include "drake/drakeAutomotiveLcm_export.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "lcmtypes/drake/lcmt_%(snake)s_t.hpp"
 
@@ -175,7 +175,7 @@ TRANSLATOR_CLASS_DECL = """
  * Translates between LCM message objects and VectorBase objects for the
  * %(camel)s type.
  */
-class DRAKEAUTOMOTIVE_EXPORT %(camel)sTranslator
+class DRAKEAUTOMOTIVELCM_EXPORT %(camel)sTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   %(camel)sTranslator()

--- a/drake/automotive/test/CMakeLists.txt
+++ b/drake/automotive/test/CMakeLists.txt
@@ -1,43 +1,43 @@
+add_executable(curve2_test curve2_test.cc)
+target_link_libraries(curve2_test ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
+drake_add_test(NAME curve2_test COMMAND curve2_test)
+
+add_executable(simple_car_test simple_car_test.cc
+  simple_car_scalartype_test.cc)
+target_link_libraries(simple_car_test ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
+drake_add_test(NAME simple_car_test COMMAND simple_car_test)
+
+add_executable(idm_with_trajectory_agent_test
+  idm_with_trajectory_agent_test.cc
+  idm_with_trajectory_agent_scalartype_test.cc)
+target_link_libraries(idm_with_trajectory_agent_test
+  ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
+drake_add_test(NAME idm_with_trajectory_agent_test
+  COMMAND idm_with_trajectory_agent_test)
+
+add_executable(simple_car_to_euler_floating_joint_test
+  simple_car_to_euler_floating_joint_test.cc)
+target_link_libraries(simple_car_to_euler_floating_joint_test
+  ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
+add_test(NAME simple_car_to_euler_floating_joint_test
+  COMMAND simple_car_to_euler_floating_joint_test)
+
+add_executable(trajectory_car_test trajectory_car_test.cc)
+target_link_libraries(trajectory_car_test
+  ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
+drake_add_test(NAME trajectory_car_test COMMAND trajectory_car_test)
+
 if(lcm_FOUND)
-  add_executable(curve2_test curve2_test.cc)
-  target_link_libraries(curve2_test ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
-  drake_add_test(NAME curve2_test COMMAND curve2_test)
-
-  add_executable(simple_car_test simple_car_test.cc
-    simple_car_scalartype_test.cc)
-  target_link_libraries(simple_car_test ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
-  drake_add_test(NAME simple_car_test COMMAND simple_car_test)
-
   add_executable(simple_car_state_translator_test
     simple_car_state_translator_test.cc)
   target_link_libraries(simple_car_state_translator_test
-    ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
+    ${GTEST_BOTH_LIBRARIES} drakeAutomotiveLcm)
   add_test(NAME simple_car_state_translator_test
     COMMAND simple_car_state_translator_test)
 
-  add_executable(idm_with_trajectory_agent_test
-    idm_with_trajectory_agent_test.cc
-    idm_with_trajectory_agent_scalartype_test.cc)
-  target_link_libraries(idm_with_trajectory_agent_test
-    ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
-  drake_add_test(NAME idm_with_trajectory_agent_test
-    COMMAND idm_with_trajectory_agent_test)
-
-  add_executable(simple_car_to_euler_floating_joint_test
-    simple_car_to_euler_floating_joint_test.cc)
-  target_link_libraries(simple_car_to_euler_floating_joint_test
-    ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
-  add_test(NAME simple_car_to_euler_floating_joint_test
-    COMMAND simple_car_to_euler_floating_joint_test)
-  
-  add_executable(trajectory_car_test trajectory_car_test.cc)
-  target_link_libraries(trajectory_car_test
-    ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
-  drake_add_test(NAME trajectory_car_test COMMAND trajectory_car_test)
-
   add_executable(automotive_simulator_test automotive_simulator_test.cc)
   target_link_libraries(automotive_simulator_test
-    ${GTEST_BOTH_LIBRARIES} drakeAutomotive)
+    ${GTEST_BOTH_LIBRARIES} drakeAutomotiveLcm)
   drake_add_test(NAME automotive_simulator_test
     COMMAND automotive_simulator_test)
 endif()


### PR DESCRIPTION
Split out a `drakeAutomotoveLcm` library from the `drakeAutomotive` library.  This allows using and unit testing most of the systems, even if LCM is absent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3520)
<!-- Reviewable:end -->
