### PR TITLE
Refactor library name drake_rbp to drakeRigidBodyPlant 

### DIFF
--- a/drake/systems/plants/rigid_body_plant/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/CMakeLists.txt
@@ -1,14 +1,15 @@
 set(source_files rigid_body_plant.cc)
 
-add_library_with_exports(LIB_NAME drake_rbp SOURCE_FILES ${source_files})
-target_link_libraries(drake_rbp
+add_library_with_exports(LIB_NAME drakeRigidBodyPlant
+        SOURCE_FILES ${source_files})
+target_link_libraries(drakeRigidBodyPlant
         drakeCommon drakeSystemFramework drakeRBM drakeOptimization)
 
 drake_install_headers(rigid_body_plant.h)
-pods_install_libraries(drake_rbp)
+pods_install_libraries(drakeRigidBodyPlant)
 pods_install_pkg_config_file(drake-rbs
         CFLAGS -I${CMAKE_INSTALL_PREFIX}/include
-        LIBS -ldrake_rbp -ldrakeRBM
+        LIBS -ldrakeRigidBodyPlant -ldrakeRBM
         VERSION 0.0.1)
 
 add_subdirectory(test)

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -338,7 +338,7 @@ void RigidBodyPlant<T>::MapVelocityToConfigurationDerivatives(
 }
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_RBP_EXPORT RigidBodyPlant<double>;
+template class DRAKERIGIDBODYPLANT_EXPORT RigidBodyPlant<double>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <string>
 
-#include "drake/drake_rbp_export.h"
+#include "drake/drakeRigidBodyPlant_export.h"
 #include "drake/systems/framework/leaf_system.h"
 
 #include "drake/systems/plants/parser_model_instance_id_table.h"
@@ -65,7 +65,7 @@ namespace systems {
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T>
-class DRAKE_RBP_EXPORT RigidBodyPlant : public LeafSystem<T> {
+class DRAKERIGIDBODYPLANT_EXPORT RigidBodyPlant : public LeafSystem<T> {
  public:
   /// Instantiates a %RigidBodyPlant from a Multi-Body Dynamics (MBD) model of
   /// the world in @p tree.

--- a/drake/systems/plants/rigid_body_plant/test/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/test/CMakeLists.txt
@@ -3,6 +3,6 @@ find_package(Bullet)
 if(BULLET_FOUND)
   add_executable(rigid_body_plant_test rigid_body_plant_test.cc)
   target_link_libraries(rigid_body_plant_test
-      drake_rbp drakeRBSystem ${GTEST_BOTH_LIBRARIES})
+      drakeRigidBodyPlant drakeRBSystem ${GTEST_BOTH_LIBRARIES})
   add_test(NAME rigid_body_plant_test COMMAND rigid_body_plant_test)
 endif()


### PR DESCRIPTION
This PR refactors the library name `drake_rbp` to `drakeRigidBodyPlant` in order to be consistent with Drake's naming convention for libraries. Per comment [here](https://github.com/RobotLocomotion/drake/pull/3245#issuecomment-248109740).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3523)
<!-- Reviewable:end -->
