### PR TITLE
Collision clique

### DIFF
--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -256,7 +256,7 @@ ostream& operator<<(ostream& out, const RigidBody& b) {
 }
 
 int RigidBody::SetSelfCollisionClique(int clique_id) {
-  if (collision_elements_.size() > 1 ) {
+  if (collision_elements_.size() > 1) {
     AddCollisionElementsToClique(clique_id++);
   }
   return clique_id;

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -255,9 +255,10 @@ ostream& operator<<(ostream& out, const RigidBody& b) {
   return out;
 }
 
-int RigidBody::SetSelfCollisionClique(int clique_id) {
+bool RigidBody::SetSelfCollisionClique(int clique_id) {
   if (collision_elements_.size() > 1) {
-    AddCollisionElementsToClique(clique_id++);
+    AddCollisionElementsToClique(clique_id);
+    return true;
   }
-  return clique_id;
+  return false;
 }

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -82,8 +82,8 @@ void RigidBody::AddVisualElement(const DrakeShapes::VisualElement& element) {
   visual_elements_.push_back(element);
 }
 
-void RigidBody::AddToCollisionClique(int clique_id) {
-  for (auto &&element : collision_elements_) {
+void RigidBody::AddCollisionElementsToClique(int clique_id) {
+  for (const auto& element : collision_elements_) {
     element->AddToCollisionClique(clique_id);
   }
 }
@@ -94,7 +94,7 @@ const DrakeShapes::VectorOfVisualElements& RigidBody::get_visual_elements()
 }
 
 void RigidBody::AddCollisionElement(const std::string& group_name,
-                                         DrakeCollision::Element* element) {
+                                    DrakeCollision::Element* element) {
   DrakeCollision::ElementId id = element->getId();
   collision_element_ids_.push_back(id);
   collision_element_groups_[group_name].push_back(id);
@@ -161,7 +161,7 @@ bool RigidBody::adjacentTo(const RigidBody& other) const {
            !(other.joint_ && other.joint_->isFloating())));
 }
 
-bool RigidBody::CanCollideWith(const RigidBody &other) const {
+bool RigidBody::CanCollideWith(const RigidBody& other) const {
   bool ignored =
       this == &other || adjacentTo(other) ||
       (collision_filter_group_ & other.getCollisionFilterIgnores()).any() ||
@@ -253,4 +253,11 @@ ostream& operator<<(ostream& out, const RigidBody& b) {
       << "  - Collision elements IDs: " << collision_element_str.str();
 
   return out;
+}
+
+int RigidBody::SetSelfCollisionClique(int clique_id) {
+  if (collision_elements_.size() > 1 ) {
+    AddCollisionElementsToClique(clique_id++);
+  }
+  return clique_id;
 }

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -93,13 +93,12 @@ const DrakeShapes::VectorOfVisualElements& RigidBody::get_visual_elements()
   return visual_elements_;
 }
 
-void RigidBody::AddCollisionElement(DrakeCollision::ElementId id) {
+void RigidBody::AddCollisionElement(const std::string& group_name,
+                                         DrakeCollision::Element* element) {
+  DrakeCollision::ElementId id = element->getId();
   collision_element_ids_.push_back(id);
-}
-
-void RigidBody::AddCollisionElementToGroup(const std::string& group_name,
-    DrakeCollision::ElementId id) {
   collision_element_groups_[group_name].push_back(id);
+  collision_elements_.push_back(element);
 }
 
 const std::vector<DrakeCollision::ElementId>&

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -82,6 +82,13 @@ void RigidBody::AddVisualElement(const DrakeShapes::VisualElement& element) {
   visual_elements_.push_back(element);
 }
 
+void RigidBody::AddToCollisionClique(int clique_id) {
+  for (auto eit = CollisionElementsBegin();
+       eit != CollisionElementsEnd(); ++eit) {
+    (*eit)->AddToCollisionClique(clique_id);
+  }
+}
+
 const DrakeShapes::VectorOfVisualElements& RigidBody::get_visual_elements()
     const {
   return visual_elements_;

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -156,7 +156,7 @@ bool RigidBody::adjacentTo(const RigidBody& other) const {
            !(other.joint_ && other.joint_->isFloating())));
 }
 
-bool RigidBody::CollidesWith(const RigidBody& other) const {
+bool RigidBody::CanCollideWith(const RigidBody &other) const {
   bool ignored =
       this == &other || adjacentTo(other) ||
       (collision_filter_group_ & other.getCollisionFilterIgnores()).any() ||

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -83,9 +83,8 @@ void RigidBody::AddVisualElement(const DrakeShapes::VisualElement& element) {
 }
 
 void RigidBody::AddToCollisionClique(int clique_id) {
-  for (auto eit = CollisionElementsBegin();
-       eit != CollisionElementsEnd(); ++eit) {
-    (*eit)->AddToCollisionClique(clique_id);
+  for (auto &&element : collision_elements_) {
+    element->AddToCollisionClique(clique_id);
   }
 }
 

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -260,21 +260,21 @@ class DRAKERBM_EXPORT RigidBody {
   // calculation.  Maybe it would be better if the name reflected this: e.g.,
   // is_collision_adjacent(), or some such thing.
   /**
-   * Report if this body is considered "adjacent" to the given body.
+   * Reports if this body is considered "adjacent" to the given body.
    *
    * "Adjacency" refers to the idea that the bodies are connected to each other
    * in the rigid body tree by a non-floating joint.
-   * @param other The body to test agasint this body.
-   * @return `true` if the bodies are "adjacent".
+   * @param[in] other The body to test against this body.
+   * @returns `true` if the bodies are "adjacent".
    */
   bool adjacentTo(const RigidBody& other) const;
 
   /**
    * Returns `true` if this body should be checked for collisions
-   * with the other body.  CanCollidesWith should be symmetric: if
-   * A can collide with B, B can collide with A.
+   * with the @p other body.  CanCollideWith should be commutative: A can
+   * collide with B implies B can collide with A.
    * @param other   The body to query against.
-   * @return `true` if collision between this and other should be tested.
+   * @returns `true` if collision between this and other should be tested.
    */
   bool CanCollideWith(const RigidBody &other) const;
 
@@ -350,8 +350,7 @@ class DRAKERBM_EXPORT RigidBody {
 
    This call adds each of the collision elements in this body to the provided
    collision clique.
-   @param[in] clique_id Collision clique id. Collision elements in this clique
-   do not interact.
+   @param[in] clique_id Collision clique id.
    @see CollisionElement::AddToCollisionClique. **/
   void AddToCollisionClique(int clique_id);
 
@@ -429,14 +428,12 @@ class DRAKERBM_EXPORT RigidBody {
 
   typedef std::vector<DrakeCollision::Element*> CollisionElementsVector;
   typedef typename CollisionElementsVector::iterator CollisionElementsIterator;
-  typedef typename CollisionElementsVector::const_iterator
-      CollisionElementsConstIterator;
 
-  CollisionElementsIterator CollisionElementsBegin() {
+  CollisionElementsIterator collision_elements_begin() {
     return collision_elements_.begin();
   }
 
-  CollisionElementsIterator CollisionElementsEnd() {
+  CollisionElementsIterator collision_elements_end() {
     return collision_elements_.end();
   }
 

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -190,17 +190,12 @@ class DRAKERBM_EXPORT RigidBody {
   /**
    * Sets the rigid body's self-collision logic.
    *
-   * Given the next available clique id, the body will do whatever work is
-   * necessary to prevent self collision.  If no work is necessary, none will be
-   * done.
-   *
-   * The return value will be the next available clique.  If the input clique
-   * is not consumed, the input value will be returned.
-   *
-   * @param[in] clique_id  The next available clique id to use.
-   * @returns The next available clique id.
+   * The body may or may not require a self-collision clique. If not, the
+   * provided clique id will remain unused.
+   * @param[in] clique_id  An available clique id.
+   * @returns true if the clique id was used.
    */
-  int SetSelfCollisionClique(int clique_id);
+  bool SetSelfCollisionClique(int clique_id);
 
   /**
    * Adds the given collision @p element to the body with the given group name.

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -351,11 +351,12 @@ class DRAKERBM_EXPORT RigidBody {
       const Eigen::Isometry3d& transform_body_to_joint);
 
   /** Adds body to a given collision clique by clique id.
-
-   This call adds each of the collision elements in this body to the provided
-   collision clique.
-   @param[in] clique_id Collision clique id.
-   @see CollisionElement::AddToCollisionClique. **/
+   *
+   * This call adds each of the collision elements in this body to the provided
+   * collision clique.
+   * @param[in] clique_id Collision clique id.
+   * @see Element::AddToCollisionClique.
+   */
   void AddCollisionElementsToClique(int clique_id);
 
  public:

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -265,7 +265,14 @@ class DRAKERBM_EXPORT RigidBody {
    * Reports if this body is considered "adjacent" to the given body.
    *
    * "Adjacency" refers to the idea that the bodies are connected to each other
-   * in the rigid body tree by a non-floating joint.
+   * in the rigid body tree by a non-floating joint. By this definition,
+   * a rigid body is *not* adjacent to itself.
+   *
+   * In the degenerate case where one rigid body is a parent of the other, but
+   * with no joint assigned, the rigid bodies will be considered adjacent.
+   * Conversely, the degenerate case where a joint is assigned, but the parent
+   * relationship is not set, the rigid bodies will *not* be considered
+   * adjacent.
    * @param[in] other The body to test against this body.
    * @returns `true` if the bodies are "adjacent".
    */
@@ -278,7 +285,7 @@ class DRAKERBM_EXPORT RigidBody {
    * @param[in] other   The body to query against.
    * @returns `true` if collision between this and other should be tested.
    */
-  bool CanCollideWith(const RigidBody &other) const;
+  bool CanCollideWith(const RigidBody& other) const;
 
   bool appendCollisionElementIdsFromThisBody(
       const std::string& group_name,

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -400,6 +400,34 @@ class DRAKERBM_EXPORT RigidBody {
   std::map<std::string, std::vector<DrakeCollision::ElementId>>
       collision_element_groups_;
 
+  typedef std::vector<DrakeCollision::Element*> CollisionElementsVector;
+  typedef typename CollisionElementsVector::iterator CollisionElementsIterator;
+  typedef typename CollisionElementsVector::const_iterator
+      CollisionElementsConstIterator;
+
+  CollisionElementsIterator CollisionElementsBegin() {
+    return collision_elements_.begin();
+  }
+
+  CollisionElementsIterator CollisionElementsEnd() {
+    return collision_elements_.end();
+  }
+
+  /** Adds collision element `e` to this rigid body.
+   @param e The collision element being added to this body. **/
+  void AddCollisionElement(DrakeCollision::Element* e) {
+    collision_elements_.push_back(e);
+  }
+
+  /** Adds body to a given collision clique by clique id.
+
+   This call adds each of the collision elements in this body to the provided
+   collision clique.
+   @param[in] clique_id Collision clique id. Collision elements in this clique
+   do not interact.
+   @see CollisionElement::AddToCollisionClique. **/
+  void AddToCollisionClique(int clique_id);
+
   // The contact points this rigid body has with its environment.
   Eigen::Matrix3Xd contact_points_;
 
@@ -411,4 +439,9 @@ class DRAKERBM_EXPORT RigidBody {
 
   // The spatial inertia of this rigid body.
   drake::SquareTwistMatrix<double> spatial_inertia_;
+
+  // TODO(SeanCurtis-TRI): This data is only used in the compilation of the
+  // body.  As such, it should be moved into a factory so that the runtime
+  // class only has runtime data.
+  CollisionElementsVector collision_elements_;
 };

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -355,6 +355,13 @@ class DRAKERBM_EXPORT RigidBody {
    @see CollisionElement::AddToCollisionClique. **/
   void AddToCollisionClique(int clique_id);
 
+  /** Adds collision element `e` to this rigid body.
+   @param e The collision element being added to this body.
+   **/
+  void AddCollisionElement(DrakeCollision::Element* e) {
+    collision_elements_.push_back(e);
+  }
+
  public:
   friend std::ostream& operator<<(std::ostream& out, const RigidBody& b);
 
@@ -433,11 +440,6 @@ class DRAKERBM_EXPORT RigidBody {
     return collision_elements_.end();
   }
 
-  /** Adds collision element `e` to this rigid body.
-   @param e The collision element being added to this body. **/
-  void AddCollisionElement(DrakeCollision::Element* e) {
-    collision_elements_.push_back(e);
-  }
   // The contact points this rigid body has with its environment.
   Eigen::Matrix3Xd contact_points_;
 

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -258,7 +258,14 @@ class DRAKERBM_EXPORT RigidBody {
   // TODO(amcastro-tri): Change to is_adjacent_to().
   bool adjacentTo(const RigidBody& other) const;
 
-  bool CollidesWith(const RigidBody& other) const;
+  /**
+   * Returns `true` if this body should be checked for collisions
+   * with the other body.  CanCollidesWith should be symmetric: if
+   * A can collide with B, B can collide with A.
+   * @param other   The body to query against.
+   * @return `true` if collision between this and other should be tested.
+   */
+  bool CanCollideWith(const RigidBody &other) const;
 
   bool appendCollisionElementIdsFromThisBody(
       const std::string& group_name,

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -188,6 +188,21 @@ class DRAKERBM_EXPORT RigidBody {
   const DrakeShapes::VectorOfVisualElements& get_visual_elements() const;
 
   /**
+   * Sets the rigid body's self-collision logic.
+   *
+   * Given the next available clique id, the body will do whatever work is
+   * necessary to prevent self collision.  If no work is necessary, none will be
+   * done.
+   *
+   * The return value will be the next available clique.  If the input clique
+   * is not consumed, the input value will be returned.
+   *
+   * @param[in] clique_id  The next available clique id to use.
+   * @returns The next available clique id.
+   */
+  int SetSelfCollisionClique(int clique_id);
+
+  /**
    * Adds the given collision @p element to the body with the given group name.
    * @param[in] group_name The collision element's group name.
    * @param[in] element The element to associate with the rigid body.
@@ -260,7 +275,7 @@ class DRAKERBM_EXPORT RigidBody {
    * Returns `true` if this body should be checked for collisions
    * with the @p other body.  CanCollideWith should be commutative: A can
    * collide with B implies B can collide with A.
-   * @param other   The body to query against.
+   * @param[in] other   The body to query against.
    * @returns `true` if collision between this and other should be tested.
    */
   bool CanCollideWith(const RigidBody &other) const;
@@ -339,7 +354,7 @@ class DRAKERBM_EXPORT RigidBody {
    collision clique.
    @param[in] clique_id Collision clique id.
    @see CollisionElement::AddToCollisionClique. **/
-  void AddToCollisionClique(int clique_id);
+  void AddCollisionElementsToClique(int clique_id);
 
  public:
   friend std::ostream& operator<<(std::ostream& out, const RigidBody& b);

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -256,6 +256,17 @@ class DRAKERBM_EXPORT RigidBody {
   void collideWithCollisionFilterGroup(const DrakeCollision::bitmask& group);
 
   // TODO(amcastro-tri): Change to is_adjacent_to().
+  // TODO(SeanCurtis-TRI): This method is only used by the collision clique
+  // calculation.  Maybe it would be better if the name reflected this: e.g.,
+  // is_collision_adjacent(), or some such thing.
+  /**
+   * Report if this body is considered "adjacent" to the given body.
+   *
+   * "Adjacency" refers to the idea that the bodies are connected to each other
+   * in the rigid body tree by a non-floating joint.
+   * @param other The body to test agasint this body.
+   * @return `true` if the bodies are "adjacent".
+   */
   bool adjacentTo(const RigidBody& other) const;
 
   /**

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -188,25 +188,12 @@ class DRAKERBM_EXPORT RigidBody {
   const DrakeShapes::VectorOfVisualElements& get_visual_elements() const;
 
   /**
-   * Adds a collision element to this rigid body by collision element @p id.
-   * This effectively defines the collision geometry of this rigid body. If more
-   * than one collision element is added, the resulting collision geometry is
-   * the union of the individual geometries of each collision element.
+   * Adds the given collision @p element to the body with the given group name.
+   * @param[in] group_name The collision element's group name.
+   * @param[in] element The element to associate with the rigid body.
    */
-  void AddCollisionElement(DrakeCollision::ElementId id);
-
-  /**
-   * Adds a collision element represented by its @p id to the collision group
-   * @p group_name. Collision groups are just a convenient way to group a
-   * collection of collision elements so that they can be referenced by the name
-   * of the group they belong to. There is no implication on whether these
-   * elements can collide between them or not.
-   *
-   * Note that the collision element @p id must have already been passed to
-   * RigidBody::AddCollisionElement().
-   */
-  void AddCollisionElementToGroup(const std::string& group_name,
-      DrakeCollision::ElementId id);
+  void AddCollisionElement(const std::string& group_name,
+                           DrakeCollision::Element* element);
 
   /**
    * @returns A reference to an `std::vector` of collision elements that
@@ -353,13 +340,6 @@ class DRAKERBM_EXPORT RigidBody {
    @param[in] clique_id Collision clique id.
    @see CollisionElement::AddToCollisionClique. **/
   void AddToCollisionClique(int clique_id);
-
-  /** Adds collision element `e` to this rigid body.
-   @param e The collision element being added to this body.
-   **/
-  void AddCollisionElement(DrakeCollision::Element* e) {
-    collision_elements_.push_back(e);
-  }
 
  public:
   friend std::ostream& operator<<(std::ostream& out, const RigidBody& b);

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -277,7 +277,7 @@ class DRAKERBM_EXPORT RigidBody {
    * Returns `true` if this body should be checked for collisions
    * with the @p other body.  CanCollideWith should be commutative: A can
    * collide with B implies B can collide with A.
-   * @param[in] other   The body to query against.
+   * @param[in] other The body to query against.
    * @returns `true` if collision between this and other should be tested.
    */
   bool CanCollideWith(const RigidBody& other) const;

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -335,6 +335,15 @@ class DRAKERBM_EXPORT RigidBody {
   void ApplyTransformToJointFrame(
       const Eigen::Isometry3d& transform_body_to_joint);
 
+  /** Adds body to a given collision clique by clique id.
+
+   This call adds each of the collision elements in this body to the provided
+   collision clique.
+   @param[in] clique_id Collision clique id. Collision elements in this clique
+   do not interact.
+   @see CollisionElement::AddToCollisionClique. **/
+  void AddToCollisionClique(int clique_id);
+
  public:
   friend std::ostream& operator<<(std::ostream& out, const RigidBody& b);
 
@@ -418,16 +427,6 @@ class DRAKERBM_EXPORT RigidBody {
   void AddCollisionElement(DrakeCollision::Element* e) {
     collision_elements_.push_back(e);
   }
-
-  /** Adds body to a given collision clique by clique id.
-
-   This call adds each of the collision elements in this body to the provided
-   collision clique.
-   @param[in] clique_id Collision clique id. Collision elements in this clique
-   do not interact.
-   @see CollisionElement::AddToCollisionClique. **/
-  void AddToCollisionClique(int clique_id);
-
   // The contact points this rigid body has with its environment.
   Eigen::Matrix3Xd contact_points_;
 

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -266,7 +266,7 @@ void RigidBodyTree::CreateCollisionCliques() {
   int clique_id = get_next_clique_id();
   // 1) For collision elements in the same body
   for (auto& body : bodies) {
-    if ( body->SetSelfCollisionClique(clique_id)) {
+    if (body->SetSelfCollisionClique(clique_id)) {
       clique_id = get_next_clique_id();
     }
   }

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -272,10 +272,11 @@ void RigidBodyTree::CreateCollisionCliques() {
   int ncol_groups = 0;
   // 1) For collision elements in the same body
   for (auto& body : bodies) {
-    // TODO(SeanCurtis-TRI): If the body contains only a single collision
-    // element, than this step provides no value.  Only apply a per-body
-    // clique if the body has multiple collision elements.
-    body->AddToCollisionClique(ncol_groups++);
+    // No point in adding a body-derived clique if the body has only a single
+    // collision element.
+    if ( body->get_collision_element_ids().size() > 1) {
+      body->AddToCollisionClique(ncol_groups++);
+    }
   }
 
   // 2) For collision elements in different bodies

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -263,10 +263,12 @@ void RigidBodyTree::compile(void) {
 }
 
 void RigidBodyTree::CreateCollisionCliques() {
-  int ncol_cliques = 0;
+  int clique_id = get_next_clique_id();
   // 1) For collision elements in the same body
   for (auto& body : bodies) {
-    ncol_cliques = body->SetSelfCollisionClique(ncol_cliques);
+    if ( body->SetSelfCollisionClique(clique_id)) {
+      clique_id = get_next_clique_id();
+    }
   }
 
   // 2) For collision elements in different bodies
@@ -274,13 +276,15 @@ void RigidBodyTree::CreateCollisionCliques() {
   //
   // If this proves to be too expensive, walking the tree would be O(N)
   // and still capture all of the adjacency.
-  for (size_t i = 0; i < bodies.size(); ++i)
-    for (size_t j = i + 1; j < bodies.size(); ++j)
+  for (size_t i = 0; i < bodies.size(); ++i) {
+    for (size_t j = i + 1; j < bodies.size(); ++j) {
       if (!bodies[i]->CanCollideWith(*bodies[j])) {
-        bodies[i]->AddCollisionElementsToClique(ncol_cliques);
-        bodies[j]->AddCollisionElementsToClique(ncol_cliques);
-        ++ncol_cliques;
+        bodies[i]->AddCollisionElementsToClique(clique_id);
+        bodies[j]->AddCollisionElementsToClique(clique_id);
+        clique_id = get_next_clique_id();
       }
+    }
+  }
 }
 
 Eigen::VectorXd RigidBodyTree::getZeroConfiguration() const {

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -410,9 +410,8 @@ DrakeCollision::ElementId RigidBodyTree::addCollisionElement(
     const string& group_name) {
   DrakeCollision::ElementId id = collision_model_->addElement(element);
   if (id != 0) {
-    body.AddCollisionElement(id);
-    body.AddCollisionElementToGroup(group_name, id);
-    body.AddCollisionElement(collision_model_->FindMutableElement(id));
+    body.AddCollisionElement(group_name,
+                             collision_model_->FindMutableElement(id));
   }
   return id;
 }

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -268,7 +268,7 @@ void RigidBodyTree::CreateCollisionCliques() {
   for (auto& body : bodies) {
     // No point in adding a body-derived clique if the body has only a single
     // collision element.
-    if ( body->get_collision_element_ids().size() > 1) {
+    if (body->get_collision_element_ids().size() > 1) {
       body->AddToCollisionClique(ncol_groups++);
     }
   }

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -257,12 +257,6 @@ void RigidBodyTree::compile(void) {
     body.set_contact_points(contact_points);
   }
 
-  // Create collision cliques for the DrakeCollision::Model according to the
-  // policy imposed by RigidBody::CollidesWith.
-  // These cliques include:
-  //   * CollisionElement's in the same RigidBody.
-  //   * CollisionElement's in adjacent RigidBody's.
-  // For details on this policy see RigidBody::CollidesWith.
   CreateCollisionCliques();
 
   initialized_ = true;
@@ -418,6 +412,7 @@ DrakeCollision::ElementId RigidBodyTree::addCollisionElement(
   if (id != 0) {
     body.AddCollisionElement(id);
     body.AddCollisionElementToGroup(group_name, id);
+    body.AddCollisionElement(collision_model_->FindMutableElement(id));
   }
   return id;
 }

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -263,23 +263,23 @@ void RigidBodyTree::compile(void) {
 }
 
 void RigidBodyTree::CreateCollisionCliques() {
-  int ncol_groups = 0;
+  int ncol_cliques = 0;
   // 1) For collision elements in the same body
   for (auto& body : bodies) {
-    // No point in adding a body-derived clique if the body has only a single
-    // collision element.
-    if (body->get_collision_element_ids().size() > 1) {
-      body->AddToCollisionClique(ncol_groups++);
-    }
+    ncol_cliques = body->SetSelfCollisionClique(ncol_cliques);
   }
 
   // 2) For collision elements in different bodies
+  // This is an O(N^2) loop -- but only happens at initialization.
+  //
+  // If this proves to be too expensive, walking the tree would be O(N)
+  // and still capture all of the adjacency.
   for (size_t i = 0; i < bodies.size(); ++i)
     for (size_t j = i + 1; j < bodies.size(); ++j)
       if (!bodies[i]->CanCollideWith(*bodies[j])) {
-        bodies[i]->AddToCollisionClique(ncol_groups);
-        bodies[j]->AddToCollisionClique(ncol_groups);
-        ++ncol_groups;
+        bodies[i]->AddCollisionElementsToClique(ncol_cliques);
+        bodies[j]->AddCollisionElementsToClique(ncol_cliques);
+        ++ncol_cliques;
       }
 }
 

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -142,6 +142,9 @@ class DRAKERBM_EXPORT RigidBodyTree {
   // This method is not thread safe!
   int add_model_instance();
 
+  // This method is not thread safe
+  int get_next_clique_id() { return next_available_clique_++; }
+
   /**
    * Returns the number of model instances in the tree.
    */
@@ -1046,4 +1049,6 @@ class DRAKERBM_EXPORT RigidBodyTree {
 
   std::set<std::string> already_printed_warnings;
   bool initialized_{false};
+
+  int next_available_clique_ = 0;
 };

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -1016,14 +1016,12 @@ class DRAKERBM_EXPORT RigidBodyTree {
   // collide. These are determined according to the policy provided by
   // RigidBody::CanCollideWith.
   //
-  // Collision cliques provide a very general way to specify which collision
-  // elements should (or should not) be checked for collisions.
-  // This particular method provides a default heuristics to create cliques for
-  // RigidBodyTree which are in accordance to the policy implemented by
-  // RigidBody::CanCollideWith.
-  // If this heuristics needs to be changed/updated this can be done by either:
-  // 1. Overwriting this method.
-  // 2. Implementing a new policy in RigidBody::CanCollideWith.
+  // Collision cliques provide a simple mechanism to omit pairs of collision
+  // elements from collision tests. The collision element pair (A, B) will not
+  // be tested for collision if A and B belong to the same clique.
+  // This particular method implements a default heuristics to create cliques
+  // for a RigidBodyTree which are in accordance to the policy implemented by
+  // RigidBody::CanCollideWith().
   //
   // @see RigidBody::CanCollideWith.
   void CreateCollisionCliques();

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -142,7 +142,7 @@ class DRAKERBM_EXPORT RigidBodyTree {
   // This method is not thread safe!
   int add_model_instance();
 
-  // This method is not thread safe
+  // This method is not thread safe.
   int get_next_clique_id() { return next_available_clique_++; }
 
   /**

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -1008,6 +1008,26 @@ class DRAKERBM_EXPORT RigidBodyTree {
   // See RigidBodyTree::compile
   void SortTree();
 
+  // Defines a number of collision cliques to be used by DrakeCollision::Model.
+  // Collision cliques are defined so that:
+  // - There is one clique per RigidBody: and so CollisionElement's attached to
+  // a RigidBody do not collide.
+  // - There is one clique per pair of RigidBodies that are not meant to
+  // collide. These are determined according to the policy provided by
+  // RigidBody::CanCollideWith.
+  //
+  // Collision cliques provide a very general way to specify which collision
+  // elements should (or should not) be checked for collisions.
+  // This particular method provides a default heuristics to create cliques for
+  // RigidBodyTree which are in accordance to the policy implemented by
+  // RigidBody::CanCollideWith.
+  // If this heuristics needs to be changed/updated this can be done by either:
+  // 1. Overwriting this method.
+  // 2. Implementing a new policy in RigidBody::CanCollideWith.
+  //
+  // @see RigidBody::CanCollideWith.
+  void CreateCollisionCliques();
+
   // collision_model maintains a collection of the collision geometry in the
   // RBM for use in collision detection of different kinds. Small margins are
   // applied to all collision geometry when that geometry is added, to improve

--- a/drake/systems/plants/collision/Element.cpp
+++ b/drake/systems/plants/collision/Element.cpp
@@ -8,7 +8,6 @@ using namespace Eigen;
 using namespace std;
 using drake::SortedVectorsHaveIntersection;
 
-
 namespace DrakeCollision {
 Element::Element(const Isometry3d& T_element_to_local)
     : DrakeShapes::Element(T_element_to_local) {
@@ -47,9 +46,11 @@ bool Element::CanCollideWith(const Element *other) const {
 
 void Element::AddToCollisionClique(int clique_id) {
   // Order(N) insertion.
-  // Member CollisionElement::collision_cliques_ is sorted so that checking if
-  // two collision elements belong to a same group can be performed in order N.
-  // See CollisionElement::CanCollideWith
+  // Member Element::collision_cliques_ is a sorted vector so that checking if
+  // two collision elements belong to a same group can be performed
+  // efficiently in order N.
+  // See Element::CanCollideWith() and Element::collision_cliques_ for
+  // explanation.
   auto it = std::lower_bound(collision_cliques_.begin(),
                              collision_cliques_.end(), clique_id);
   if (it == collision_cliques_.end() || clique_id < *it)

--- a/drake/systems/plants/collision/Element.cpp
+++ b/drake/systems/plants/collision/Element.cpp
@@ -28,7 +28,7 @@ Element::Element(const Element& other)
       // Issue #2662 tracks the resolution of these problems.
       id(reinterpret_cast<ElementId>(this)),
       is_static_(other.is_static_), body_(other.body_),
-      collision_cliques_(other.collision_cliques_){}
+      collision_cliques_(other.collision_cliques_) {}
 
 Element* Element::clone() const { return new Element(*this); }
 
@@ -47,8 +47,8 @@ bool Element::CanCollideWith(const Element *other) const {
 
 void Element::AddToCollisionClique(int clique_id) {
   // Order(N) insertion.
-  // Member CollisionElement::collision_cliques_ is sorted so that checking if two
-  // collision elements belong to a same group can be performed in order N.
+  // Member CollisionElement::collision_cliques_ is sorted so that checking if
+  // two collision elements belong to a same group can be performed in order N.
   // See CollisionElement::CanCollideWith
   auto it = std::lower_bound(collision_cliques_.begin(),
                              collision_cliques_.end(), clique_id);

--- a/drake/systems/plants/collision/Element.cpp
+++ b/drake/systems/plants/collision/Element.cpp
@@ -2,8 +2,12 @@
 
 #include <iostream>
 
+#include "drake/common/sorted_vectors_have_intersection.h"
+
 using namespace Eigen;
 using namespace std;
+using drake::SortedVectorsHaveIntersection;
+
 
 namespace DrakeCollision {
 Element::Element(const Isometry3d& T_element_to_local)
@@ -23,7 +27,8 @@ Element::Element(const Element& other)
       // In addition casting to an int is a bad idea.
       // Issue #2662 tracks the resolution of these problems.
       id(reinterpret_cast<ElementId>(this)),
-      is_static_(other.is_static_), body_(other.body_) {}
+      is_static_(other.is_static_), body_(other.body_),
+      collision_cliques_(other.collision_cliques_){}
 
 Element* Element::clone() const { return new Element(*this); }
 
@@ -32,6 +37,32 @@ ElementId Element::getId() const { return id; }
 const RigidBody* Element::get_body() const { return body_; }
 
 void Element::set_body(const RigidBody *body) { body_ = body; }
+
+bool Element::CanCollideWith(const Element *other) const {
+  // If collision_cliques_.size() = N and other->collision_cliques_.size() = M
+  // The worst case (overlapping elements without intersection) is O(N+M).
+  return !SortedVectorsHaveIntersection(collision_cliques_,
+                                        other->collision_cliques_);
+}
+
+void Element::AddToCollisionClique(int clique_id) {
+  // Order(N) insertion.
+  // Member CollisionElement::collision_cliques_ is sorted so that checking if two
+  // collision elements belong to a same group can be performed in order N.
+  // See CollisionElement::CanCollideWith
+  auto it = std::lower_bound(collision_cliques_.begin(),
+                             collision_cliques_.end(), clique_id);
+  if (it == collision_cliques_.end() || clique_id < *it)
+    collision_cliques_.insert(it, clique_id);
+}
+
+int Element::number_of_cliques() const {
+  return collision_cliques_.size();
+}
+
+const std::vector<int>& Element::collision_cliques() const {
+  return collision_cliques_;
+}
 
 ostream& operator<<(ostream& out, const Element& ee) {
   out << "DrakeCollision::Element:\n"

--- a/drake/systems/plants/collision/Element.cpp
+++ b/drake/systems/plants/collision/Element.cpp
@@ -56,7 +56,7 @@ void Element::AddToCollisionClique(int clique_id) {
     collision_cliques_.insert(it, clique_id);
 }
 
-int Element::number_of_cliques() const {
+int Element::get_num_cliques() const {
   return collision_cliques_.size();
 }
 

--- a/drake/systems/plants/collision/Element.h
+++ b/drake/systems/plants/collision/Element.h
@@ -51,15 +51,27 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
 
   /**
    * Returns true if this element should be checked for collisions
-   * with the other object.  CanCollidesWith should be symmetric: if
-   * A can collide with B, B can collide with A.
+   * with the @p other object.  CanCollideWith is commutative;
+   * A can collide with B implies B can collide with A.
    */
   virtual bool CanCollideWith(const Element *other) const;
 
+  /**
+   * Adds this element to the clique specified by the given clique id.
+   * @param[in] clique_id   The clique to which this element will belong to.
+   */
   void AddToCollisionClique(int clique_id);
 
+  /**
+   * Reports the number of cliques to which this element belongs.
+   * @returns The number of cliques.
+   */
   int number_of_cliques() const;
 
+  /**
+   * Provides access to the set of cliques to which this element belongs.
+   * @return    A reference to the clique set (as an ordered list).
+   */
   const std::vector<int>& collision_cliques() const;
 
   /** Returns a pointer to the const RigidBody to which this CollisionElement

--- a/drake/systems/plants/collision/Element.h
+++ b/drake/systems/plants/collision/Element.h
@@ -54,7 +54,13 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
    * with the other object.  CanCollidesWith should be symmetric: if
    * A can collide with B, B can collide with A.
    */
-  virtual bool CanCollideWith(const Element *other) const { return true; }
+  virtual bool CanCollideWith(const Element *other) const;
+
+  void AddToCollisionClique(int clique_id);
+
+  int number_of_cliques() const;
+
+  const std::vector<int>& collision_cliques() const;
 
   /** Returns a pointer to the const RigidBody to which this CollisionElement
   is attached. **/
@@ -76,6 +82,23 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
   ElementId id;
   bool is_static_{false};
   const RigidBody* body_{};
+
+  // Collision cliques are defined as a group of collision elements that do not
+  // collide.
+  // Collision cliques in Drake are represented simply by an integer.
+  // A collision element can belong to more than one clique.
+  // Conceptually it would seem like std::set is the right fit for
+  // CollisionElement::collision_cliques_. However, std::set is really good for
+  // dynamically adding elements to a set that needs to change.
+  // Once you are done adding elements to your set, access time is poor when
+  // compared to a simple std::vector (nothing faster than scanning a vector of
+  // adjacent entries in memory).
+  // Here adding elements to the cliques vector only happens during problem
+  // setup by the user or from a URDF/SDF file. What we really want is that once
+  // this vector is setup, we can query it very fast during simulation.
+  // This is done in CollisionElement::CanCollideWith which to be Order(N)
+  // requires the entries in CollisionElement::collision_cliques_ to be sorted.
+  std::vector<int> collision_cliques_;
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/systems/plants/collision/Element.h
+++ b/drake/systems/plants/collision/Element.h
@@ -74,7 +74,7 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
 
   /**
    * Provides access to the set of cliques to which this element belongs.
-   * @returns A reference to the clique set (as an montonically increasing
+   * @returns A reference to the clique set (as a montonically increasing
    * ordered list).
    */
   const std::vector<int>& collision_cliques() const;

--- a/drake/systems/plants/collision/Element.h
+++ b/drake/systems/plants/collision/Element.h
@@ -70,7 +70,7 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
    * Reports the number of cliques to which this element belongs.
    * @returns The number of cliques.
    */
-  int number_of_cliques() const;
+  int get_num_cliques() const;
 
   /**
    * Provides access to the set of cliques to which this element belongs.

--- a/drake/systems/plants/collision/Element.h
+++ b/drake/systems/plants/collision/Element.h
@@ -51,10 +51,10 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
 
   /**
    * Returns true if this element should be checked for collisions
-   * with the other object.  CollidesWith should be symmetric: if
-   * A collides with B, B collides with A.
+   * with the other object.  CanCollidesWith should be symmetric: if
+   * A can collide with B, B can collide with A.
    */
-  virtual bool CollidesWith(const Element* other) const { return true; }
+  virtual bool CanCollideWith(const Element *other) const { return true; }
 
   /** Returns a pointer to the const RigidBody to which this CollisionElement
   is attached. **/

--- a/drake/systems/plants/collision/Element.h
+++ b/drake/systems/plants/collision/Element.h
@@ -51,14 +51,18 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
 
   /**
    * Returns true if this element should be checked for collisions
-   * with the @p other object.  CanCollideWith is commutative;
+   * with the @p other object.  CanCollideWith() is commutative;
    * A can collide with B implies B can collide with A.
    */
   virtual bool CanCollideWith(const Element *other) const;
 
   /**
    * Adds this element to the clique specified by the given clique id.
-   * @param[in] clique_id   The clique to which this element will belong to.
+   *
+   * The clique may be a previously existing clique or a new clique. If the
+   * element already belongs to the clique, there will be no change.
+   *
+   * @param[in] clique_id The clique to which this element will belong to.
    */
   void AddToCollisionClique(int clique_id);
 
@@ -70,7 +74,8 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
 
   /**
    * Provides access to the set of cliques to which this element belongs.
-   * @return    A reference to the clique set (as an ordered list).
+   * @returns A reference to the clique set (as an montonically increasing
+   * ordered list).
    */
   const std::vector<int>& collision_cliques() const;
 
@@ -95,21 +100,23 @@ class DRAKECOLLISION_EXPORT Element : public DrakeShapes::Element {
   bool is_static_{false};
   const RigidBody* body_{};
 
-  // Collision cliques are defined as a group of collision elements that do not
+  // Collision cliques are defined as a set of collision elements that do not
   // collide.
   // Collision cliques in Drake are represented simply by an integer.
   // A collision element can belong to more than one clique.
+  //
   // Conceptually it would seem like std::set is the right fit for
-  // CollisionElement::collision_cliques_. However, std::set is really good for
+  // Element::collision_cliques_. However, std::set is really good for
   // dynamically adding elements to a set that needs to change.
   // Once you are done adding elements to your set, access time is poor when
   // compared to a simple std::vector (nothing faster than scanning a vector of
   // adjacent entries in memory).
   // Here adding elements to the cliques vector only happens during problem
   // setup by the user or from a URDF/SDF file. What we really want is that once
-  // this vector is setup, we can query it very fast during simulation.
-  // This is done in CollisionElement::CanCollideWith which to be Order(N)
+  // this vector is setup, we can query it very quickly during simulation.
+  // This is done in Element::CanCollideWith() which to be Order(N)
   // requires the entries in CollisionElement::collision_cliques_ to be sorted.
+  // By arbitrary convention, the ordering is monotonically increasing.
   std::vector<int> collision_cliques_;
 
  public:

--- a/drake/systems/plants/collision/Model.cpp
+++ b/drake/systems/plants/collision/Model.cpp
@@ -26,6 +26,15 @@ const Element* Model::FindElement(ElementId id) const {
   }
 }
 
+Element* Model::FindMutableElement(ElementId id) {
+  auto element_iter = elements.find(id);
+  if (element_iter != elements.end()) {
+    return element_iter->second.get();
+  } else {
+    return nullptr;
+  }
+}
+
 void Model::getTerrainContactPoints(ElementId id0,
                                     Eigen::Matrix3Xd& terrain_points) {
   auto element_iter = elements.find(id0);

--- a/drake/systems/plants/collision/Model.cpp
+++ b/drake/systems/plants/collision/Model.cpp
@@ -17,7 +17,7 @@ bool Model::removeElement(const ElementId& id) {
   return elements.erase(id) > 0;
 }
 
-const Element* Model::readElement(ElementId id) const {
+const Element* Model::FindElement(ElementId id) const {
   auto element_iter = elements.find(id);
   if (element_iter != elements.end()) {
     return element_iter->second.get();

--- a/drake/systems/plants/collision/Model.h
+++ b/drake/systems/plants/collision/Model.h
@@ -33,7 +33,7 @@ class DRAKECOLLISION_EXPORT Model {
    * the given id or nullptr if no such collision element is present in the
    * model.
    */
-  virtual const Element* readElement(ElementId id) const;
+  virtual const Element* FindElement(ElementId id) const;
 
   virtual void getTerrainContactPoints(ElementId id0,
                                        Eigen::Matrix3Xd& terrain_points);

--- a/drake/systems/plants/collision/Model.h
+++ b/drake/systems/plants/collision/Model.h
@@ -35,6 +35,15 @@ class DRAKECOLLISION_EXPORT Model {
    */
   virtual const Element* FindElement(ElementId id) const;
 
+/** Get a pointer to a mutable collision element in this model.
+ * @param id an CollisionElementId corresponding to the desired collision
+ * element.
+ * @returns a pointer to a mutable collision element corresponding to
+ * the given id or nullptr if no such collision element is present in the
+ * model.
+ **/
+virtual Element* FindMutableElement(ElementId id);
+
   virtual void getTerrainContactPoints(ElementId id0,
                                        Eigen::Matrix3Xd& terrain_points);
 

--- a/drake/systems/plants/collision/Model.h
+++ b/drake/systems/plants/collision/Model.h
@@ -35,14 +35,14 @@ class DRAKECOLLISION_EXPORT Model {
    */
   virtual const Element* FindElement(ElementId id) const;
 
-/** Get a pointer to a mutable collision element in this model.
- * @param id an CollisionElementId corresponding to the desired collision
- * element.
- * @returns a pointer to a mutable collision element corresponding to
- * the given id or nullptr if no such collision element is present in the
- * model.
- **/
-virtual Element* FindMutableElement(ElementId id);
+  /** Get a pointer to a mutable collision element in this model.
+   * @param id an CollisionElementId corresponding to the desired collision
+   * element.
+   * @returns a pointer to a mutable collision element corresponding to
+   * the given id or nullptr if no such collision element is present in the
+   * model.
+   **/
+  virtual Element* FindMutableElement(ElementId id);
 
   virtual void getTerrainContactPoints(ElementId id0,
                                        Eigen::Matrix3Xd& terrain_points);

--- a/drake/systems/plants/collision/Model.h
+++ b/drake/systems/plants/collision/Model.h
@@ -35,8 +35,8 @@ class DRAKECOLLISION_EXPORT Model {
    */
   virtual const Element* FindElement(ElementId id) const;
 
-  /** Get a pointer to a mutable collision element in this model.
-   * @param id an CollisionElementId corresponding to the desired collision
+  /** Gets a pointer to a mutable collision element in this model.
+   * @param[in] id an ElementId corresponding to the desired collision
    * element.
    * @returns a pointer to a mutable collision element corresponding to
    * the given id or nullptr if no such collision element is present in the

--- a/drake/systems/plants/collision/bullet_model.cc
+++ b/drake/systems/plants/collision/bullet_model.cc
@@ -808,11 +808,11 @@ bool BulletModel::closestPointsAllToAll(
   std::vector<ElementIdPair> id_pairs;
   for (size_t i = 0; i < ids_to_check.size(); ++i) {
     ElementId id_a = ids_to_check[i];
-    const Element* element_a = readElement(id_a);
+    const Element* element_a = FindElement(id_a);
     if (element_a != nullptr) {
       for (size_t j = i + 1; j < ids_to_check.size(); ++j) {
         ElementId id_b = ids_to_check[j];
-        const Element* element_b = readElement(id_b);
+        const Element* element_b = FindElement(id_b);
         if (element_b != nullptr && element_a->CanCollideWith(element_b)) {
           id_pairs.push_back(std::make_pair(id_a, id_b));
         }

--- a/drake/systems/plants/collision/bullet_model.cc
+++ b/drake/systems/plants/collision/bullet_model.cc
@@ -64,7 +64,7 @@ bool OverlapFilterCallback::needBroadphaseCollision(
           static_cast<Element*>(bt_collision_object0->getUserPointer());
       auto element1 =
           static_cast<Element*>(bt_collision_object1->getUserPointer());
-      collides = collides && element0->CollidesWith(element1);
+      collides = collides && element0->CanCollideWith(element1);
     }
   }
   return collides;
@@ -813,7 +813,7 @@ bool BulletModel::closestPointsAllToAll(
       for (size_t j = i + 1; j < ids_to_check.size(); ++j) {
         ElementId id_b = ids_to_check[j];
         const Element* element_b = readElement(id_b);
-        if (element_b != nullptr && element_a->CollidesWith(element_b)) {
+        if (element_b != nullptr && element_a->CanCollideWith(element_b)) {
           id_pairs.push_back(std::make_pair(id_a, id_b));
         }
       }

--- a/drake/systems/plants/collision/test/model_test.cc
+++ b/drake/systems/plants/collision/test/model_test.cc
@@ -187,6 +187,67 @@ GTEST_TEST(ModelTest, closestPointsAllToAll) {
   EXPECT_TRUE(points[2].ptB.isApprox(Vector3d(-0.5, 0, 0)));
 }
 
+GTEST_TEST(ModelTest, CollisionCliques) {
+  Element element_1, element_2, element_3;
+
+  // Adds element 1 to its own set of groups.
+  element_1.AddToCollisionClique(2);
+  element_1.AddToCollisionClique(23);
+  element_1.AddToCollisionClique(11);
+  element_1.AddToCollisionClique(15);
+  element_1.AddToCollisionClique(9);
+
+  // Tests the situation where the same collision cliques are added to a
+  // collision element multiple times.
+  // If a collision element is added to a clique it already belongs to, the
+  // addition has no effect. This is tested by asserting the total number of
+  // elements in the test below.
+  element_1.AddToCollisionClique(11);
+  element_1.AddToCollisionClique(23);
+
+  // Cliques cannot be repeated. Therefore expect 5 cliques instead of 7.
+  ASSERT_EQ(5, element_1.number_of_cliques());
+  // Checks the correctness of the entire set.
+  EXPECT_EQ(std::vector<int>({2, 9, 11, 15, 23}),
+            element_1.collision_cliques());
+
+  // Adds element 2 to its own set of cliques.
+  element_2.AddToCollisionClique(11);
+  element_2.AddToCollisionClique(9);
+  element_2.AddToCollisionClique(13);
+  element_2.AddToCollisionClique(13);
+  element_2.AddToCollisionClique(11);
+
+  // Cliques cannot be repeated. Therefore expect 3 cliques instead of 5.
+  ASSERT_EQ(3, element_2.number_of_cliques());
+  // Checks the correctness of the entire set.
+  EXPECT_EQ(std::vector<int>({9, 11, 13}), element_2.collision_cliques());
+
+  // Adds element 3 to its own set of cliques.
+  element_3.AddToCollisionClique(1);
+  element_3.AddToCollisionClique(13);
+  element_3.AddToCollisionClique(13);
+  element_3.AddToCollisionClique(8);
+  element_3.AddToCollisionClique(1);
+
+  // Cliques cannot be repeated. Therefore expect 3 cliques instead of 5.
+  ASSERT_EQ(3, element_3.number_of_cliques());
+  // Checks the correctness of the entire set.
+  EXPECT_EQ(std::vector<int>({1, 8, 13}), element_3.collision_cliques());
+
+  // element_2 does not collide with element_1 (cliques 9 and 11 in common).
+  EXPECT_FALSE(element_2.CanCollideWith(&element_1));
+
+  // element_2 does not collide with element_3 (clique 13 in common).
+  EXPECT_FALSE(element_2.CanCollideWith(&element_3));
+
+  // element_3 does collide with element_1 (no cliques in common).
+  EXPECT_TRUE(element_3.CanCollideWith(&element_1));
+
+  // element_3 does not collide with element_2 (clique 13 in common).
+  EXPECT_FALSE(element_3.CanCollideWith(&element_2));
+}
+
 // A sphere of diameter 1.0 is placed on top of a box with sides of length 1.0.
 // The sphere overlaps with the box with its deepest penetration point (the
 // bottom) 0.25 units into the box (negative distance). Only one contact point

--- a/drake/systems/plants/collision/test/model_test.cc
+++ b/drake/systems/plants/collision/test/model_test.cc
@@ -190,7 +190,7 @@ GTEST_TEST(ModelTest, closestPointsAllToAll) {
 GTEST_TEST(ModelTest, CollisionCliques) {
   Element element_1, element_2, element_3;
 
-  // Adds element 1 to its own set of groups.
+  // Adds element 1 to its own set of cliques.
   element_1.AddToCollisionClique(2);
   element_1.AddToCollisionClique(23);
   element_1.AddToCollisionClique(11);

--- a/drake/systems/plants/collision/test/model_test.cc
+++ b/drake/systems/plants/collision/test/model_test.cc
@@ -206,7 +206,7 @@ GTEST_TEST(ModelTest, CollisionCliques) {
   element_1.AddToCollisionClique(23);
 
   // Cliques cannot be repeated. Therefore expect 5 cliques instead of 7.
-  ASSERT_EQ(5, element_1.number_of_cliques());
+  ASSERT_EQ(5, element_1.get_num_cliques());
   // Checks the correctness of the entire set.
   EXPECT_EQ(std::vector<int>({2, 9, 11, 15, 23}),
             element_1.collision_cliques());
@@ -219,7 +219,7 @@ GTEST_TEST(ModelTest, CollisionCliques) {
   element_2.AddToCollisionClique(11);
 
   // Cliques cannot be repeated. Therefore expect 3 cliques instead of 5.
-  ASSERT_EQ(3, element_2.number_of_cliques());
+  ASSERT_EQ(3, element_2.get_num_cliques());
   // Checks the correctness of the entire set.
   EXPECT_EQ(std::vector<int>({9, 11, 13}), element_2.collision_cliques());
 
@@ -231,7 +231,7 @@ GTEST_TEST(ModelTest, CollisionCliques) {
   element_3.AddToCollisionClique(1);
 
   // Cliques cannot be repeated. Therefore expect 3 cliques instead of 5.
-  ASSERT_EQ(3, element_3.number_of_cliques());
+  ASSERT_EQ(3, element_3.get_num_cliques());
   // Checks the correctness of the entire set.
   EXPECT_EQ(std::vector<int>({1, 8, 13}), element_3.collision_cliques());
 

--- a/drake/systems/plants/rigid_body_collision_element.cc
+++ b/drake/systems/plants/rigid_body_collision_element.cc
@@ -26,13 +26,3 @@ RigidBodyCollisionElement::RigidBodyCollisionElement(
 RigidBodyCollisionElement* RigidBodyCollisionElement::clone() const {
   return new RigidBodyCollisionElement(*this);
 }
-
-bool RigidBodyCollisionElement::CanCollideWith(
-    const DrakeCollision::Element *other) const {
-  auto other_rb = dynamic_cast<const RigidBodyCollisionElement*>(other);
-  bool collides = true;
-  if (other_rb != nullptr) {
-    collides = get_body()->CanCollideWith(*other_rb->get_body());
-  }
-  return collides;
-}

--- a/drake/systems/plants/rigid_body_collision_element.cc
+++ b/drake/systems/plants/rigid_body_collision_element.cc
@@ -27,12 +27,12 @@ RigidBodyCollisionElement* RigidBodyCollisionElement::clone() const {
   return new RigidBodyCollisionElement(*this);
 }
 
-bool RigidBodyCollisionElement::CollidesWith(
-    const DrakeCollision::Element* other) const {
+bool RigidBodyCollisionElement::CanCollideWith(
+    const DrakeCollision::Element *other) const {
   auto other_rb = dynamic_cast<const RigidBodyCollisionElement*>(other);
   bool collides = true;
   if (other_rb != nullptr) {
-    collides = get_body()->CollidesWith(*other_rb->get_body());
+    collides = get_body()->CanCollideWith(*other_rb->get_body());
   }
   return collides;
 }

--- a/drake/systems/plants/rigid_body_collision_element.h
+++ b/drake/systems/plants/rigid_body_collision_element.h
@@ -21,7 +21,7 @@ class DRAKERBM_EXPORT RigidBodyCollisionElement
 
   RigidBodyCollisionElement* clone() const override;
 
-  bool CollidesWith(const DrakeCollision::Element* other) const override;
+  bool CanCollideWith(const DrakeCollision::Element *other) const override;
 
 #ifndef SWIG
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/systems/plants/rigid_body_collision_element.h
+++ b/drake/systems/plants/rigid_body_collision_element.h
@@ -21,7 +21,6 @@ class DRAKERBM_EXPORT RigidBodyCollisionElement
 
   RigidBodyCollisionElement* clone() const override;
 
-  bool CanCollideWith(const DrakeCollision::Element *other) const override;
 
 #ifndef SWIG
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/systems/plants/test/rigid_body_test.cc
+++ b/drake/systems/plants/test/rigid_body_test.cc
@@ -4,7 +4,7 @@
 
 #include "drake/systems/plants/RigidBody.h"
 #include "drake/systems/plants/joints/FixedJoint.h"
-#include <drake/systems/plants/joints/QuaternionFloatingJoint.h>
+#include "drake/systems/plants/joints/QuaternionFloatingJoint.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/plants/test/rigid_body_test.cc
+++ b/drake/systems/plants/test/rigid_body_test.cc
@@ -57,8 +57,7 @@ GTEST_TEST(RigidBodyTest, TestAdjacency) {
   rigid_body_ptrC->set_parent(rigid_body_ptrD.get());
   std::unique_ptr<DrakeJoint> floating_joint(new QuaternionFloatingJoint(
       "",
-      transform_to_world
-  ));
+      transform_to_world));
   rigid_body_ptrC->setJoint(move(floating_joint));
   EXPECT_FALSE(rigid_body_ptrC->adjacentTo(*rigid_body_ptrD));
   EXPECT_FALSE(rigid_body_ptrD->adjacentTo(*rigid_body_ptrC));

--- a/drake/systems/plants/test/rigid_body_test.cc
+++ b/drake/systems/plants/test/rigid_body_test.cc
@@ -12,10 +12,12 @@ namespace plants {
 namespace test {
 namespace {
 
+using std::make_unique;
+
 // Tests whether an exception is thrown if RigidBody::getJoint() is called prior
 // to a joint being set.
 GTEST_TEST(RigidBodyTest, TestGetJointThatIsNotSet) {
-  std::unique_ptr<RigidBody> rigid_body_ptr(new RigidBody());
+  auto rigid_body_ptr = make_unique<RigidBody>();
   EXPECT_THROW(rigid_body_ptr->getJoint(), std::runtime_error);
 }
 
@@ -23,11 +25,11 @@ GTEST_TEST(RigidBodyTest, TestGetJointThatIsNotSet) {
 // RigidBody::adjacentTo for details
 GTEST_TEST(RigidBodyTest, TestAdjacency) {
   // self adjacency
-  std::unique_ptr<RigidBody> rigid_body_ptrA(new RigidBody());
+  auto rigid_body_ptrA = make_unique<RigidBody>();
   EXPECT_FALSE(rigid_body_ptrA->adjacentTo(*rigid_body_ptrA));
 
   // unconnected rigid bodies
-  std::unique_ptr<RigidBody> rigid_body_ptrB(new RigidBody());
+  auto rigid_body_ptrB = make_unique<RigidBody>();
   EXPECT_FALSE(rigid_body_ptrA->adjacentTo(*rigid_body_ptrB));
   EXPECT_FALSE(rigid_body_ptrB->adjacentTo(*rigid_body_ptrA));
 
@@ -52,8 +54,8 @@ GTEST_TEST(RigidBodyTest, TestAdjacency) {
   EXPECT_TRUE(rigid_body_ptrB->adjacentTo(*rigid_body_ptrA));
 
   // connected by floating link
-  std::unique_ptr<RigidBody> rigid_body_ptrC(new RigidBody());
-  std::unique_ptr<RigidBody> rigid_body_ptrD(new RigidBody());
+  auto rigid_body_ptrC = make_unique<RigidBody>();
+  auto rigid_body_ptrD = make_unique<RigidBody>();
   rigid_body_ptrC->set_parent(rigid_body_ptrD.get());
   std::unique_ptr<DrakeJoint> floating_joint(new QuaternionFloatingJoint(
       "",

--- a/drake/systems/plants/test/rigid_body_test.cc
+++ b/drake/systems/plants/test/rigid_body_test.cc
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 
 #include "drake/systems/plants/RigidBody.h"
+#include "drake/systems/plants/joints/FixedJoint.h"
+#include <drake/systems/plants/joints/QuaternionFloatingJoint.h>
 
 namespace drake {
 namespace systems {
@@ -17,6 +19,50 @@ GTEST_TEST(RigidBodyTest, TestGetJointThatIsNotSet) {
   EXPECT_THROW(rigid_body_ptr->getJoint(), std::runtime_error);
 }
 
+// Confirms that the adjacency of bodies is evaluated correctly.  See
+// RigidBody::adjacentTo for details
+GTEST_TEST(RigidBodyTest, TestAdjacency) {
+  // self adjacency
+  std::unique_ptr<RigidBody> rigid_body_ptrA(new RigidBody());
+  EXPECT_FALSE(rigid_body_ptrA->adjacentTo(*rigid_body_ptrA));
+
+  // unconnected rigid bodies
+  std::unique_ptr<RigidBody> rigid_body_ptrB(new RigidBody());
+  EXPECT_FALSE(rigid_body_ptrA->adjacentTo(*rigid_body_ptrB));
+  EXPECT_FALSE(rigid_body_ptrB->adjacentTo(*rigid_body_ptrA));
+
+  // rigid bodies with parent relationship but no link
+  rigid_body_ptrA->set_parent(rigid_body_ptrB.get());
+  EXPECT_TRUE(rigid_body_ptrA->adjacentTo(*rigid_body_ptrB));
+  EXPECT_TRUE(rigid_body_ptrB->adjacentTo(*rigid_body_ptrA));
+
+  Eigen::Isometry3d transform_to_world;
+  std::unique_ptr<DrakeJoint> joint( new FixedJoint("testJoint",
+                                                    transform_to_world));
+  rigid_body_ptrA->setJoint(move(joint));
+
+  // rigid body has joint, but no parent relationship
+  rigid_body_ptrA->set_parent(nullptr);
+  EXPECT_FALSE(rigid_body_ptrA->adjacentTo(*rigid_body_ptrB));
+  EXPECT_FALSE(rigid_body_ptrB->adjacentTo(*rigid_body_ptrA));
+
+  // rigid bodies which *are* properly adjacent
+  rigid_body_ptrA->set_parent(rigid_body_ptrB.get());
+  EXPECT_TRUE(rigid_body_ptrA->adjacentTo(*rigid_body_ptrB));
+  EXPECT_TRUE(rigid_body_ptrB->adjacentTo(*rigid_body_ptrA));
+
+  // connected by floating link
+  std::unique_ptr<RigidBody> rigid_body_ptrC(new RigidBody());
+  std::unique_ptr<RigidBody> rigid_body_ptrD(new RigidBody());
+  rigid_body_ptrC->set_parent(rigid_body_ptrD.get());
+  std::unique_ptr<DrakeJoint> floating_joint(new QuaternionFloatingJoint(
+      "",
+      transform_to_world
+  ));
+  rigid_body_ptrC->setJoint(move(floating_joint));
+  EXPECT_FALSE(rigid_body_ptrC->adjacentTo(*rigid_body_ptrD));
+  EXPECT_FALSE(rigid_body_ptrD->adjacentTo(*rigid_body_ptrC));
+};
 }  // namespace
 }  // namespace test
 }  // namespace plants

--- a/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
@@ -10,3 +10,6 @@ target_link_libraries(rigid_body_tree_test drakeRBSystem)
 
 drake_add_cc_test(rigid_body_tree_inverse_dynamics_test)
 target_link_libraries(rigid_body_tree_inverse_dynamics_test drakeRBSystem)
+
+drake_add_cc_test(rigid_body_collision_clique_test)
+target_link_libraries(rigid_body_collision_clique_test drakeRBSystem)

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -38,7 +38,8 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
     c1b = new Element();
     r1b1->AddCollisionElement("default", c1b);
     // assign inertia to avoid the welding code in RigidBodyTree::compile
-    drake::SquareTwistMatrix<double> I = drake::SquareTwistMatrix<double>::Zero();
+    drake::SquareTwistMatrix<double> I =
+        drake::SquareTwistMatrix<double>::Zero();
     I.block(3, 3, 3, 3) << Matrix3d::Identity();
     r1b1->set_spatial_inertia(I);
 

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -1,0 +1,103 @@
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include <drake/systems/plants/parser_model_instance_id_table.h>
+#include <drake/systems/plants/parser_common.h>
+#include <drake/systems/plants/collision/Element.h>
+#include <drake/systems/plants/joints/FixedJoint.h>
+#include "drake/systems/plants/RigidBodyTree.h"
+
+
+namespace drake {
+namespace systems {
+namespace plants {
+namespace test {
+namespace {
+
+using drake::parsers::ModelInstanceIdTable;
+using drake::parsers::AddFloatingJoint;
+using drake::systems::plants::joints::kQuaternion;
+using DrakeCollision::Element;
+using Eigen::Isometry3d;
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
+
+class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    tree.reset(new RigidBodyTree());
+
+    // Defines four rigid bodies.
+    r1b1 = new RigidBody();
+    r1b1->set_model_name("robot1");
+    r1b1->set_name("body1");
+    c1a = new Element();
+    r1b1->AddCollisionElement("default", c1a);
+    c1b = new Element();
+    r1b1->AddCollisionElement("default", c1b);
+    // assign inertia to avoid the welding code in RigidBodyTree::compile
+    drake::SquareTwistMatrix<double> I = drake::SquareTwistMatrix<double>::Zero();
+    I.block(3, 3, 3, 3) << Matrix3d::Identity();
+    r1b1->set_spatial_inertia(I);
+
+    r2b1 = new RigidBody();
+    r2b1->set_model_name("robot2");
+    r2b1->set_name("body1");
+    c2 = new Element();
+    r2b1->AddCollisionElement("default", c2);
+    r2b1->set_spatial_inertia(I);
+
+    r3b1 = new RigidBody();
+    r3b1->set_model_name("robot3");
+    r3b1->set_name("body1");
+    r3b1->set_spatial_inertia(I);
+
+    tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1));
+    tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1));
+    tree->add_rigid_body(std::unique_ptr<RigidBody>(r3b1));
+
+    // add joints
+
+
+    tree->compile();
+  }
+
+ public:
+  std::unique_ptr<RigidBodyTree> tree;
+
+  RigidBody* r1b1{};
+  RigidBody* r2b1{};
+  RigidBody* r3b1{};
+
+  Element * c1a{};
+  Element * c1b{};
+  Element * c2{};
+};
+
+// Confirms that only rigid bodies with multiple collision elements get self-
+// collision cliques.
+TEST_F(RigidBodyTreeCollisionCliqueTest, SelfCollisionClique) {
+  EXPECT_EQ(c1a->get_num_cliques(), 1);
+  EXPECT_EQ(c1b->get_num_cliques(), 1);
+  EXPECT_EQ(c2->get_num_cliques(), 0);
+}
+
+// Confirms that joints that cannot collide (i.e., RigidBody::CanCollideWith
+// returns false) form a clique.
+TEST_F(RigidBodyTreeCollisionCliqueTest, CantCollideClique) {
+  Eigen::Isometry3d transform_to_world;
+  std::unique_ptr<DrakeJoint> joint( new FixedJoint("testJoint",
+                                                    transform_to_world));
+  r2b1->set_parent(r3b1);
+  r2b1->setJoint(move(joint));
+  EXPECT_EQ(c1a->get_num_cliques(), 1);
+  EXPECT_EQ(c1b->get_num_cliques(), 1);
+  EXPECT_EQ(c2->get_num_cliques(), 0);
+}
+}  // namespace
+}  // namespace test
+}  // namespace plants
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -26,15 +26,15 @@ using std::unique_ptr;
 class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    tree = make_unique<RigidBodyTree>();
+    tree_ = make_unique<RigidBodyTree>();
 
     drake::SquareTwistMatrix<double> I =
         drake::SquareTwistMatrix<double>::Zero();
     I.block(3, 3, 3, 3) << Matrix3d::Identity();
 
     // This body requires a self-collision clique
-    RigidBody * temp_body;
-    tree->add_rigid_body(unique_ptr<RigidBody>(temp_body = new RigidBody()));
+    RigidBody* temp_body;
+    tree_->add_rigid_body(unique_ptr<RigidBody>(temp_body = new RigidBody()));
     temp_body->set_model_name("robot1");
     temp_body->set_name("body1");
     temp_body->set_spatial_inertia(I);
@@ -44,21 +44,21 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
     temp_body->AddCollisionElement("default", body1_collision_element_2_.get());
 
     // These next bodies will *not* require self-collision clique
-    tree->add_rigid_body(unique_ptr<RigidBody>(body2_ = new RigidBody()));
+    tree_->add_rigid_body(unique_ptr<RigidBody>(body2_ = new RigidBody()));
     body2_->set_model_name("robot2");
     body2_->set_name("body2");
     body2_->set_spatial_inertia(I);
     body2_collision_element_ = make_unique<Element>();
     body2_->AddCollisionElement("default", body2_collision_element_.get());
 
-    tree->add_rigid_body(unique_ptr<RigidBody>(body3_ = new RigidBody()));
+    tree_->add_rigid_body(unique_ptr<RigidBody>(body3_ = new RigidBody()));
     body3_->set_model_name("robot3");
     body3_->set_name("body3");
     body3_->set_spatial_inertia(I);
   }
 
  protected:
-  std::unique_ptr<RigidBodyTree> tree;
+  std::unique_ptr<RigidBodyTree> tree_;
 
   // Bodies are owned by the tree. These raw pointers allow post-hoc
   // manipulation.
@@ -75,7 +75,7 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
 // Confirms that only rigid bodies with multiple collision elements get self-
 // collision cliques.
 TEST_F(RigidBodyTreeCollisionCliqueTest, SelfCollisionClique) {
-  tree->compile();
+  tree_->compile();
   EXPECT_EQ(body1_collision_element_1_->get_num_cliques(), 1);
   EXPECT_EQ(body1_collision_element_2_->get_num_cliques(), 1);
   EXPECT_EQ(body2_collision_element_->get_num_cliques(), 0);
@@ -92,7 +92,7 @@ TEST_F(RigidBodyTreeCollisionCliqueTest, CantCollideClique) {
   body2_->set_parent(body3_);
   body2_->setJoint(move(joint));
 
-  tree->compile();
+  tree_->compile();
 
   // Confirm that collision elements on body 1 are *still* only self-collision
   // cliques, determined by a single clique.

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -65,7 +65,7 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
   RigidBody* body2_{};
   RigidBody* body3_{};
 
-  // The collision elements are owned by the test class, the bodes receive
+  // The collision elements are owned by the test class, the bodies receive
   // raw pointers which they do *not* own.
   std::unique_ptr<Element> body1_collision_element_1_{};
   std::unique_ptr<Element> body1_collision_element_2_{};

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -2,18 +2,14 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/eigen_types.h"
-#include <drake/systems/plants/parser_model_instance_id_table.h>
-#include <drake/systems/plants/parser_common.h>
-#include <drake/systems/plants/collision/Element.h>
 #include <drake/systems/plants/joints/FixedJoint.h>
-#include "drake/systems/plants/RigidBodyTree.h"
-
+#include <drake/systems/plants/parser_common.h>
+#include <drake/systems/plants/parser_model_instance_id_table.h>
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace systems {
 namespace plants {
-namespace test {
 namespace {
 
 using drake::parsers::ModelInstanceIdTable;
@@ -98,7 +94,6 @@ TEST_F(RigidBodyTreeCollisionCliqueTest, CantCollideClique) {
   EXPECT_EQ(c2->get_num_cliques(), 0);
 }
 }  // namespace
-}  // namespace test
 }  // namespace plants
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -28,7 +28,7 @@ using Eigen::Vector3d;
 class RigidBodyTreeTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    tree.reset(new RigidBodyTree());
+    tree_.reset(new RigidBodyTree());
 
     // Defines four rigid bodies.
     r1b1_ = new RigidBody();
@@ -47,11 +47,10 @@ class RigidBodyTreeTest : public ::testing::Test {
     r4b1_->set_model_name("robot4");
     r4b1_->set_name("body1");
   }
-
- public:
+  
   // TODO(amcastro-tri): A stack object here (preferable to a pointer)
   // generates build issues on Windows platforms. See git-hub issue #1854.
-  std::unique_ptr<RigidBodyTree> tree;
+  std::unique_ptr<RigidBodyTree> tree_;
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's.
   RigidBody* r1b1_{};
@@ -66,29 +65,29 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointNoOffset) {
 
   // RigidBodyTree takes ownership of these bodies.
   // User still has access to these bodies through the raw pointers.
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
+  tree_->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
+  tree_->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
 
-  EXPECT_TRUE(tree->FindBody("body1", "robot1") != nullptr);
-  EXPECT_TRUE(tree->FindBody("body1", "robot2") != nullptr);
-  EXPECT_THROW(tree->FindBody("body2", "robot1"), std::logic_error);
-  EXPECT_THROW(tree->FindBody("body2", "robot2"), std::logic_error);
+  EXPECT_TRUE(tree_->FindBody("body1", "robot1") != nullptr);
+  EXPECT_TRUE(tree_->FindBody("body1", "robot2") != nullptr);
+  EXPECT_THROW(tree_->FindBody("body2", "robot1"), std::logic_error);
+  EXPECT_THROW(tree_->FindBody("body2", "robot2"), std::logic_error);
 
   // Adds floating joints that connect r1b1_ and r2b1_ to the rigid body tree's
   // world at zero offset.
-  r1b1_->add_joint(&tree->world(), std::make_unique<QuaternionFloatingJoint>(
+  r1b1_->add_joint(&tree_->world(), std::make_unique<QuaternionFloatingJoint>(
       "Base", Isometry3d::Identity()));
 
   r2b1_->add_joint(r1b1_, std::make_unique<RevoluteJoint>(
       "Joint1", Isometry3d::Identity(), Vector3d::UnitZ()));
 
   // Verfies that the two rigid bodies are located in the correct place.
-  const DrakeJoint& jointR1B1 = tree->FindBody("body1", "robot1")->getJoint();
+  const DrakeJoint& jointR1B1 = tree_->FindBody("body1", "robot1")->getJoint();
   EXPECT_TRUE(jointR1B1.isFloating());
   EXPECT_TRUE(jointR1B1.getTransformToParentBody().matrix() ==
               Eigen::Isometry3d::Identity().matrix());
 
-  const DrakeJoint& jointR2B1 = tree->FindBody("body1", "robot2")->getJoint();
+  const DrakeJoint& jointR2B1 = tree_->FindBody("body1", "robot2")->getJoint();
   EXPECT_FALSE(jointR2B1.isFloating());
   EXPECT_TRUE(jointR2B1.getTransformToParentBody().matrix() ==
               Eigen::Isometry3d::Identity().matrix());
@@ -97,8 +96,8 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointNoOffset) {
 TEST_F(RigidBodyTreeTest, TestAddFloatingJointWithOffset) {
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
+  tree_->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
+  tree_->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
 
   // Adds floating joints that connect r1b1_ and r2b1_ to the rigid body tree's
   // world at offset x = 1, y = 1, z = 1.
@@ -117,15 +116,15 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWithOffset) {
 
   AddFloatingJoint(kQuaternion,
                    {r1b1_->get_body_index(), r2b1_->get_body_index()},
-                   weld_to_frame, nullptr /* pose_map */, tree.get());
+                   weld_to_frame, nullptr /* pose_map */, tree_.get());
 
   // Verfies that the two rigid bodies are located in the correct place.
-  const DrakeJoint& jointR1B1 = tree->FindBody("body1", "robot1")->getJoint();
+  const DrakeJoint& jointR1B1 = tree_->FindBody("body1", "robot1")->getJoint();
   EXPECT_TRUE(jointR1B1.isFloating());
   EXPECT_TRUE(jointR1B1.getTransformToParentBody().matrix() ==
               T_r1and2_to_world.matrix());
 
-  const DrakeJoint& jointR2B1 = tree->FindBody("body1", "robot2")->getJoint();
+  const DrakeJoint& jointR2B1 = tree_->FindBody("body1", "robot2")->getJoint();
   EXPECT_TRUE(jointR2B1.isFloating());
   EXPECT_TRUE(jointR2B1.getTransformToParentBody().matrix() ==
               T_r1and2_to_world.matrix());
@@ -136,17 +135,17 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
   // zero offset. Verifies that it is in the correct place.
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
+  tree_->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
 
   AddFloatingJoint(kQuaternion, {r1b1_->get_body_index()},
                    nullptr /* weld_to_frame */, nullptr /* pose_map */,
-                   tree.get());
+                   tree_.get());
 
   // Adds rigid body r2b1_ to the rigid body tree and welds it to r1b1_ with
   // offset x = 1, y = 1, z = 1. Verifies that it is in the correct place.
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
+  tree_->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
 
   Eigen::Isometry3d T_r2_to_r1;
   {
@@ -158,18 +157,18 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
 
   auto r2b1_weld = std::allocate_shared<RigidBodyFrame>(
       Eigen::aligned_allocator<RigidBodyFrame>(), "body1",
-      tree->FindBody("body1", "robot1"), T_r2_to_r1);
+      tree_->FindBody("body1", "robot1"), T_r2_to_r1);
 
   AddFloatingJoint(kQuaternion, {r2b1_->get_body_index()},
-      r2b1_weld, nullptr /* pose_map */, tree.get());
+      r2b1_weld, nullptr /* pose_map */, tree_.get());
 
   // Adds rigid body r1b3_ and r4b1_ to the rigid body tree and welds it to
   // r2b1_ with offset x = 2, y = 2, z = 2. Verifies that it is in the correct
   // place.
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r3b1_));
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r4b1_));
+  tree_->add_rigid_body(std::unique_ptr<RigidBody>(r3b1_));
+  tree_->add_rigid_body(std::unique_ptr<RigidBody>(r4b1_));
 
   Eigen::Isometry3d T_r3_and_r4_to_r2;
   {
@@ -182,29 +181,29 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
 
   auto r3b1_and_r4b1_weld = std::allocate_shared<RigidBodyFrame>(
       Eigen::aligned_allocator<RigidBodyFrame>(), "body1",
-      tree->FindBody("body1", "robot2"), T_r3_and_r4_to_r2);
+      tree_->FindBody("body1", "robot2"), T_r3_and_r4_to_r2);
 
   AddFloatingJoint(kQuaternion,
                    {r3b1_->get_body_index(), r4b1_->get_body_index()},
                    r3b1_and_r4b1_weld, nullptr /* pose_map */,
-                   tree.get());
+                   tree_.get());
 
-  EXPECT_TRUE(tree->FindBody("body1", "robot1")
+  EXPECT_TRUE(tree_->FindBody("body1", "robot1")
                   ->getJoint()
                   .getTransformToParentBody()
                   .matrix() == Eigen::Isometry3d::Identity().matrix());
 
-  EXPECT_TRUE(tree->FindBody("body1", "robot2")
+  EXPECT_TRUE(tree_->FindBody("body1", "robot2")
                   ->getJoint()
                   .getTransformToParentBody()
                   .matrix() == T_r2_to_r1.matrix());
 
-  EXPECT_TRUE(tree->FindBody("body1", "robot3")
+  EXPECT_TRUE(tree_->FindBody("body1", "robot3")
                   ->getJoint()
                   .getTransformToParentBody()
                   .matrix() == T_r3_and_r4_to_r2.matrix());
 
-  EXPECT_TRUE(tree->FindBody("body1", "robot4")
+  EXPECT_TRUE(tree_->FindBody("body1", "robot4")
                   ->getJoint()
                   .getTransformToParentBody()
                   .matrix() == T_r3_and_r4_to_r2.matrix());
@@ -217,19 +216,19 @@ TEST_F(RigidBodyTreeTest, TestDoKinematicsWithVectorBlocks) {
   std::string filename =
       drake::GetDrakePath() +
       "/systems/plants/test/rigid_body_tree/two_dof_robot.urdf";
-  drake::parsers::urdf::AddModelInstanceFromUrdfFile(filename, tree.get());
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(filename, tree_.get());
 
   VectorX<double> q;
   VectorX<double> v;
-  q.resize(tree->get_num_positions());
-  v.resize(tree->get_num_velocities());
+  q.resize(tree_->get_num_positions());
+  v.resize(tree_->get_num_velocities());
   q.setZero();
   v.setZero();
 
   Eigen::VectorBlock<VectorX<double>> q_block = q.head(q.size());
   Eigen::VectorBlock<VectorX<double>> v_block = v.head(v.size());
 
-  KinematicsCache<double> cache = tree->doKinematics(q_block, v_block);
+  KinematicsCache<double> cache = tree_->doKinematics(q_block, v_block);
   EXPECT_TRUE(cache.hasV());
 }
 
@@ -243,7 +242,7 @@ TEST_F(RigidBodyTreeTest, TestModelInstanceIdTable) {
       "/systems/plants/test/rigid_body_tree/two_dof_robot.urdf";
 
   ModelInstanceIdTable model_instance_id_table =
-      drake::parsers::urdf::AddModelInstanceFromUrdfFile(filename, tree.get());
+      drake::parsers::urdf::AddModelInstanceFromUrdfFile(filename, tree_.get());
 
   const int kExpectedTableSize = 1;
   const int kExpectedModelInstanceId = 0;
@@ -282,15 +281,15 @@ TEST_F(RigidBodyTreeTest, TestFindModelInstanceBodies) {
 
   ModelInstanceIdTable model_instance_id_table_1 =
       drake::parsers::urdf::AddModelInstanceFromUrdfFile(
-          filename_2dof_robot, tree.get());
+          filename_2dof_robot, tree_.get());
 
   ModelInstanceIdTable model_instance_id_table_2 =
       drake::parsers::urdf::AddModelInstanceFromUrdfFile(
-          filename_3dof_robot, tree.get());
+          filename_3dof_robot, tree_.get());
 
   ModelInstanceIdTable model_instance_id_table_3 =
       drake::parsers::urdf::AddModelInstanceFromUrdfFile(
-          filename_4dof_robot, tree.get());
+          filename_4dof_robot, tree_.get());
 
   const std::string kTwoDofModelName = "two_dof_robot";
   const std::string kThreeDofModelName = "three_dof_robot";
@@ -306,13 +305,13 @@ TEST_F(RigidBodyTreeTest, TestFindModelInstanceBodies) {
 
   // Gets the rigid bodies belonging to each model instance.
   std::vector<const RigidBody*> two_dof_robot_bodies =
-      tree->FindModelInstanceBodies(two_dof_model_instance_id);
+      tree_->FindModelInstanceBodies(two_dof_model_instance_id);
 
   std::vector<const RigidBody*> three_dof_robot_bodies =
-      tree->FindModelInstanceBodies(three_dof_model_instance_id);
+      tree_->FindModelInstanceBodies(three_dof_model_instance_id);
 
   std::vector<const RigidBody*> four_dof_robot_bodies =
-      tree->FindModelInstanceBodies(four_dof_model_instance_id);
+      tree_->FindModelInstanceBodies(four_dof_model_instance_id);
 
   // Verifies the sizes of the vectors of rigid bodies are correct.
   EXPECT_EQ(two_dof_robot_bodies.size(), 3u);
@@ -361,26 +360,26 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
 
   for (int i = 0; i < kNumModelInstances; ++i) {
     ModelInstanceIdTable model_instance_id_table =
-      drake::parsers::urdf::AddModelInstanceFromUrdfFile(file_name, tree.get());
+      drake::parsers::urdf::AddModelInstanceFromUrdfFile(file_name, tree_.get());
     model_instance_id_list.push_back(model_instance_id_table["two_dof_robot"]);
   }
 
   // Obtains a list of base bodies and verifies that all of the bodies in this
   // list are called "link1".
-  std::vector<int> base_body_list = tree->FindBaseBodies();
+  std::vector<int> base_body_list = tree_->FindBaseBodies();
   for (int index : base_body_list) {
-    EXPECT_EQ(tree->get_body(index).get_name(), "link1");
+    EXPECT_EQ(tree_->get_body(index).get_name(), "link1");
   }
 
   // Obtains a list of the world's children. Verifies that this list is
   // identical to base_body_list.
   std::vector<int> children_of_world_list =
-      tree->FindChildrenOfBody(RigidBodyTree::kWorldBodyIndex);
+      tree_->FindChildrenOfBody(RigidBodyTree::kWorldBodyIndex);
 
   EXPECT_EQ(base_body_list.size(), children_of_world_list.size());
 
   // There are three bodies per model instance plus one body for the world.
-  EXPECT_EQ(tree->get_num_bodies(), 3 * kNumModelInstances + 1);
+  EXPECT_EQ(tree_->get_num_bodies(), 3 * kNumModelInstances + 1);
 
   for (int world_child_index : children_of_world_list) {
     bool found_child_in_base_body_list = false;
@@ -396,31 +395,31 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
   // Verifies that this list has only one element, which is expected since, in
   // this case, each model instance only has one connection to the world. Also
   // verify that the name of this body is "link1".
-  std::vector<int> base_body_specific_id_list = tree->FindBaseBodies(
+  std::vector<int> base_body_specific_id_list = tree_->FindBaseBodies(
       model_instance_id_list.at(0));
 
   EXPECT_EQ(base_body_specific_id_list.size(), 1u);
-  EXPECT_EQ(tree->get_body(base_body_specific_id_list.at(0)).get_name(),
+  EXPECT_EQ(tree_->get_body(base_body_specific_id_list.at(0)).get_name(),
       "link1");
 
   // Obtains the children of the above "link1" body. Verify that there is only
   // one child and it is called "link2".
-  std::vector<int> children_of_one_base_body = tree->FindChildrenOfBody(
+  std::vector<int> children_of_one_base_body = tree_->FindChildrenOfBody(
       base_body_specific_id_list.at(0));
 
   EXPECT_EQ(children_of_one_base_body.size(), 1u);
 
-  EXPECT_EQ(tree->get_body(children_of_one_base_body.at(0)).get_name(),
+  EXPECT_EQ(tree_->get_body(children_of_one_base_body.at(0)).get_name(),
       "link2");
 
   // Verifies that an empty list is returned if a non-matching model instance
   // ID is provided.
   int body_index = base_body_specific_id_list.at(0);
   int non_matching_model_instance_id =
-      tree->get_body(body_index).get_model_instance_id() + 1;
+      tree_->get_body(body_index).get_model_instance_id() + 1;
 
   std::vector<int> list_of_children_bad_instance_id =
-      tree->FindChildrenOfBody(body_index, non_matching_model_instance_id);
+      tree_->FindChildrenOfBody(body_index, non_matching_model_instance_id);
 
   EXPECT_EQ(list_of_children_bad_instance_id.size(), 0u);
 }

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -31,21 +31,21 @@ class RigidBodyTreeTest : public ::testing::Test {
     tree.reset(new RigidBodyTree());
 
     // Defines four rigid bodies.
-    r1b1 = new RigidBody();
-    r1b1->set_model_name("robot1");
-    r1b1->set_name("body1");
+    r1b1_ = new RigidBody();
+    r1b1_->set_model_name("robot1");
+    r1b1_->set_name("body1");
 
-    r2b1 = new RigidBody();
-    r2b1->set_model_name("robot2");
-    r2b1->set_name("body1");
+    r2b1_ = new RigidBody();
+    r2b1_->set_model_name("robot2");
+    r2b1_->set_name("body1");
 
-    r3b1 = new RigidBody();
-    r3b1->set_model_name("robot3");
-    r3b1->set_name("body1");
+    r3b1_ = new RigidBody();
+    r3b1_->set_model_name("robot3");
+    r3b1_->set_name("body1");
 
-    r4b1 = new RigidBody();
-    r4b1->set_model_name("robot4");
-    r4b1->set_name("body1");
+    r4b1_ = new RigidBody();
+    r4b1_->set_model_name("robot4");
+    r4b1_->set_name("body1");
   }
 
  public:
@@ -54,32 +54,32 @@ class RigidBodyTreeTest : public ::testing::Test {
   std::unique_ptr<RigidBodyTree> tree;
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's.
-  RigidBody* r1b1{};
-  RigidBody* r2b1{};
-  RigidBody* r3b1{};
-  RigidBody* r4b1{};
+  RigidBody* r1b1_{};
+  RigidBody* r2b1_{};
+  RigidBody* r3b1_{};
+  RigidBody* r4b1_{};
 };
 
 TEST_F(RigidBodyTreeTest, TestAddFloatingJointNoOffset) {
-  // Adds rigid bodies r1b1 and r2b1 to the rigid body tree and verify they can
-  // be found.
+  // Adds rigid bodies r1b1_ and r2b1_ to the rigid body tree and verify they
+  // can be found.
 
   // RigidBodyTree takes ownership of these bodies.
   // User still has access to these bodies through the raw pointers.
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1));
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1));
+  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
+  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
 
   EXPECT_TRUE(tree->FindBody("body1", "robot1") != nullptr);
   EXPECT_TRUE(tree->FindBody("body1", "robot2") != nullptr);
   EXPECT_THROW(tree->FindBody("body2", "robot1"), std::logic_error);
   EXPECT_THROW(tree->FindBody("body2", "robot2"), std::logic_error);
 
-  // Adds floating joints that connect r1b1 and r2b1 to the rigid body tree's
+  // Adds floating joints that connect r1b1_ and r2b1_ to the rigid body tree's
   // world at zero offset.
-  r1b1->add_joint(&tree->world(), std::make_unique<QuaternionFloatingJoint>(
+  r1b1_->add_joint(&tree->world(), std::make_unique<QuaternionFloatingJoint>(
       "Base", Isometry3d::Identity()));
 
-  r2b1->add_joint(r1b1, std::make_unique<RevoluteJoint>(
+  r2b1_->add_joint(r1b1_, std::make_unique<RevoluteJoint>(
       "Joint1", Isometry3d::Identity(), Vector3d::UnitZ()));
 
   // Verfies that the two rigid bodies are located in the correct place.
@@ -97,10 +97,10 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointNoOffset) {
 TEST_F(RigidBodyTreeTest, TestAddFloatingJointWithOffset) {
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1));
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1));
+  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
+  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
 
-  // Adds floating joints that connect r1b1 and r2b1 to the rigid body tree's
+  // Adds floating joints that connect r1b1_ and r2b1_ to the rigid body tree's
   // world at offset x = 1, y = 1, z = 1.
   Eigen::Isometry3d T_r1and2_to_world;
   {
@@ -116,7 +116,7 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWithOffset) {
       T_r1and2_to_world);
 
   AddFloatingJoint(kQuaternion,
-                   {r1b1->get_body_index(), r2b1->get_body_index()},
+                   {r1b1_->get_body_index(), r2b1_->get_body_index()},
                    weld_to_frame, nullptr /* pose_map */, tree.get());
 
   // Verfies that the two rigid bodies are located in the correct place.
@@ -132,21 +132,21 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWithOffset) {
 }
 
 TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
-  // Adds rigid body r1b1 to the rigid body tree and welds it to the world with
+  // Adds rigid body r1b1_ to the rigid body tree and welds it to the world with
   // zero offset. Verifies that it is in the correct place.
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1));
+  tree->add_rigid_body(std::unique_ptr<RigidBody>(r1b1_));
 
-  AddFloatingJoint(kQuaternion, {r1b1->get_body_index()},
+  AddFloatingJoint(kQuaternion, {r1b1_->get_body_index()},
                    nullptr /* weld_to_frame */, nullptr /* pose_map */,
                    tree.get());
 
-  // Adds rigid body r2b1 to the rigid body tree and welds it to r1b1 with
+  // Adds rigid body r2b1_ to the rigid body tree and welds it to r1b1_ with
   // offset x = 1, y = 1, z = 1. Verifies that it is in the correct place.
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1));
+  tree->add_rigid_body(std::unique_ptr<RigidBody>(r2b1_));
 
   Eigen::Isometry3d T_r2_to_r1;
   {
@@ -160,15 +160,16 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
       Eigen::aligned_allocator<RigidBodyFrame>(), "body1",
       tree->FindBody("body1", "robot1"), T_r2_to_r1);
 
-  AddFloatingJoint(kQuaternion, {r2b1->get_body_index()},
+  AddFloatingJoint(kQuaternion, {r2b1_->get_body_index()},
       r2b1_weld, nullptr /* pose_map */, tree.get());
 
-  // Adds rigid body r3b1 and r4b1 to the rigid body tree and welds it to r2b1
-  // with offset x = 2, y = 2, z = 2. Verifies that it is in the correct place.
+  // Adds rigid body r1b3_ and r4b1_ to the rigid body tree and welds it to
+  // r2b1_ with offset x = 2, y = 2, z = 2. Verifies that it is in the correct
+  // place.
   // TODO(amcastro-tri): these pointers will be replaced by Sherm's
   // unique_ptr_reference's
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r3b1));
-  tree->add_rigid_body(std::unique_ptr<RigidBody>(r4b1));
+  tree->add_rigid_body(std::unique_ptr<RigidBody>(r3b1_));
+  tree->add_rigid_body(std::unique_ptr<RigidBody>(r4b1_));
 
   Eigen::Isometry3d T_r3_and_r4_to_r2;
   {
@@ -184,7 +185,7 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
       tree->FindBody("body1", "robot2"), T_r3_and_r4_to_r2);
 
   AddFloatingJoint(kQuaternion,
-                   {r3b1->get_body_index(), r4b1->get_body_index()},
+                   {r3b1_->get_body_index(), r4b1_->get_body_index()},
                    r3b1_and_r4b1_weld, nullptr /* pose_map */,
                    tree.get());
 


### PR DESCRIPTION
This remaps the collision clique logic from a previous (and subsequently reverted) PR  #2299.  Although  reverted, many of its changes were eventually rolled into master through other PRs.  This includes the remaining "collision clique" logic.

Collision clique is a mechanism for omitting pairs of rigid bodies (more particularly their corresponding collision elements) from being included the the collision detection pass.  A _collision clique_ defines a set of elements which will not be tested against each other.  This is implemented in the following way:

- Each element maintains a list of cliques to which it belongs.
- During collision detection, (see bullet_model.cc) `Element::CanCollideWith(Element)` is invoked for a candidate pair; if they belong to any common cliques, false is returned.

Clicks are _currently_ automatically generated based on simple rules:
- If a body is represented in collision by multiple collision elements, those elements all belong to the same clique.
- The collision elements of two bodies will belong to the same clique if one is a parent to the other (in the rigid body tree) and the joint connecting them is *not* a floating joint.

The cliques are created while the rigid body tree is compiled.  ** This is somewhat unfortunate.  This introduces members into the `RigidBody` class which are only meaningful during initialization and are unused during simulation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3536)
<!-- Reviewable:end -->
