### PR TITLE
doc/from_source_ros: use catkin config to set build type

### DIFF
--- a/drake/doc/from_source_ros.rst
+++ b/drake/doc/from_source_ros.rst
@@ -91,16 +91,19 @@ Execute the following commands to build the workspace::
     cd ~/dev/drake_catkin_workspace
     source /opt/ros/indigo/setup.bash
     catkin init
-    catkin build --cmake-args -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
+    catkin config --cmake-args -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
+    catkin build
 
-There are numerous optional flags that can be included after the ``catkin build``
-command listed above. For a full list, execute::
+There are numerous optional build flags that can be specified with the
+``catkin config`` command listed above. These options can also be passed
+directly to ``catkin build``, though they will not persist.
+For a full list, execute::
 
-    catkin build --help
+    catkin config --help
 
-The example above includes the build type flag that specifies a build type of
+The example above includes the ``cmake`` flag that specifies a build type of
 ``RelWithDebInfo``. Alternatives include ``Release`` and ``Debug``. Another
-flag is ``-DDISABLE_MATLAB=TRUE``, which
+``cmake`` flag is ``-DDISABLE_MATLAB=TRUE``, which
 disables MATLAB support. This may be useful if you have MATLAB installed but
 don't have access to a license server. There are many additional command line
 flags that, for example, enables support for certain optimizers like
@@ -110,7 +113,7 @@ in ``~/dev/drake_catkin_workspace/src/drake/CMakeLists.txt``.
 
 Note also that Catkin by default performs a multi-threaded build.
 If your computer does not have sufficient computational resources to support
-this, you can add a ``-j1`` flag after the ``catkin build`` command to force a
+this, you can add a ``-j1`` flag after the ``catkin config`` command to force a
 single-threaded build, which uses fewer resources.
 
 Later, if you want to do a clean build, you can execute::
@@ -219,7 +222,8 @@ Since a new package was added to the ROS workspace, re-build the workspace
 runs too slowly when compiled in the default ``Debug`` mode)::
 
     cd ~/dev/drake_catkin_workspace
-    catkin build --cmake-args -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
+    catkin config --cmake-args -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
+    catkin build
 
 Finally, to run the car simulation demo, execute::
 


### PR DESCRIPTION
Using `catkin config` to specify cmake build flags causes those flags to persist across repeated calls to `catkin build`, which I find more convenient that passing the flags to `catkin build` every time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3562)
<!-- Reviewable:end -->
