### PR TITLE
Add ParameterizedTypeMap

### DIFF
--- a/drake/common/parameterized_type_map.h
+++ b/drake/common/parameterized_type_map.h
@@ -22,7 +22,7 @@ class ParameterizedTypeMap {
   }
 
   template <class Key>
-  std::shared_ptr<ValueType<Key>> at() {
+  std::shared_ptr<ValueType<Key>> get() {
     return std::static_pointer_cast<ValueType<Key>>(map_.at(typeid(Key)));
   }
 

--- a/drake/common/parameterized_type_map.h
+++ b/drake/common/parameterized_type_map.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+
+template <template <class> class ValueType>
+class ParameterizedTypeMap {
+ public:
+  typedef std::unordered_map<std::type_index, std::shared_ptr<void>>
+      InternalMap;
+
+  template <class Key, class... Args>
+  void emplace(Args&&... args) {
+    map_[typeid(Key)] =
+        std::make_shared<ValueType<Key>>(std::forward<Args>(args)...);
+  }
+
+  template <class Key>
+  bool has_key() {
+    return map_.count(typeid(Key)) > 0;
+  }
+
+  template <class Key>
+  std::shared_ptr<ValueType<Key>> at() {
+    return std::static_pointer_cast<ValueType<Key>>(map_.at(typeid(Key)));
+  }
+
+ private:
+  InternalMap map_;
+};

--- a/drake/common/parameterized_type_map.h
+++ b/drake/common/parameterized_type_map.h
@@ -1,26 +1,45 @@
 #pragma once
 
+#include <memory>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
 
+/**
+ * A map from a type Key to (a shared_ptr to) an instance of ValueType<Key>.
+ */
 template <template <class> class ValueType>
 class ParameterizedTypeMap {
  public:
   typedef std::unordered_map<std::type_index, std::shared_ptr<void>>
       InternalMap;
 
+  /**
+   * Construct a new value type in place.
+   *
+   * @param args constructor arguments.
+   */
   template <class Key, class... Args>
   void emplace(Args&&... args) {
     map_[typeid(Key)] =
         std::make_shared<ValueType<Key>>(std::forward<Args>(args)...);
   }
 
+  /**
+   * Returns true iff the key @tparam Key exists.
+   *
+   * @return whether key @tparam Key exists.
+   */
   template <class Key>
   bool has_key() {
     return map_.count(typeid(Key)) > 0;
   }
 
+  /**
+   * Value access. Throws if key @tparam Key is not found.
+   *
+   * @return shared_ptr to the value type associated with @tparam Key.
+   */
   template <class Key>
   std::shared_ptr<ValueType<Key>> get() {
     return std::static_pointer_cast<ValueType<Key>>(map_.at(typeid(Key)));

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -6,6 +6,8 @@ target_link_libraries(functional_form_test drakeCommon)
 drake_add_cc_test(nice_type_name_test)
 target_link_libraries(nice_type_name_test drakeCommon)
 
+drake_add_cc_test(parameterized_type_map_test)
+
 drake_add_cc_test(sorted_vectors_have_intersection_test)
 target_link_libraries(sorted_vectors_have_intersection_test drakeCommon)
 

--- a/drake/common/test/parameterized_type_map_test.cc
+++ b/drake/common/test/parameterized_type_map_test.cc
@@ -56,6 +56,9 @@ class DestructorTestType {
 
 }  // parameterized_type_map_test
 
+/*
+ * Ensure that values get destructed properly.
+ */
 GTEST_TEST(ParameterizedTypeMapTest, TestLifeTime) {
   using parameterized_type_map_test::DestructorTestType;
 

--- a/drake/common/test/parameterized_type_map_test.cc
+++ b/drake/common/test/parameterized_type_map_test.cc
@@ -25,9 +25,9 @@ GTEST_TEST(ParameterizedTypeMapTest, TestBasics) {
   auto vec_double = Vector3<double>(2., 3., 4.);
   map.emplace<double>(vec_double);
 
-  ASSERT_TRUE(
-      CompareMatrices(*map.at<int>(), vec_int, 0, MatrixCompareType::absolute));
-  ASSERT_TRUE(CompareMatrices(*map.at<double>(), vec_double, 0.0,
+  ASSERT_TRUE(CompareMatrices(*map.get<int>(), vec_int, 0,
+                              MatrixCompareType::absolute));
+  ASSERT_TRUE(CompareMatrices(*map.get<double>(), vec_double, 0.0,
                               MatrixCompareType::absolute));
 
   ASSERT_TRUE(map.has_key<int>());
@@ -72,10 +72,10 @@ GTEST_TEST(ParameterizedTypeMapTest, TestLifeTime) {
     map.emplace<double>(double_value, double_destructed);
 
     ASSERT_FALSE(bool_destructed);
-    ASSERT_EQ(bool_value, map.at<bool>()->get_value());
+    ASSERT_EQ(bool_value, map.get<bool>()->get_value());
 
     ASSERT_FALSE(double_destructed);
-    ASSERT_EQ(double_value, map.at<double>()->get_value());
+    ASSERT_EQ(double_value, map.get<double>()->get_value());
   }
   ASSERT_TRUE(bool_destructed);
   ASSERT_TRUE(double_destructed);
@@ -96,7 +96,7 @@ GTEST_TEST(ParameterizedTypeMapTest, TestIntendedUseCase) {
     if (!map.has_key<Scalar>()) {
       map.emplace<Scalar>(vec.cast<Scalar>());
     }
-    const auto& vec_of_correct_type = *map.at<Scalar>();
+    const auto& vec_of_correct_type = *map.get<Scalar>();
     return vec_of_correct_type * x;
   };
 

--- a/drake/common/test/parameterized_type_map_test.cc
+++ b/drake/common/test/parameterized_type_map_test.cc
@@ -25,10 +25,8 @@ GTEST_TEST(ParameterizedTypeMapTest, TestBasics) {
   auto vec_double = Vector3<double>(2., 3., 4.);
   map.emplace<double>(vec_double);
 
-  ASSERT_TRUE(CompareMatrices(*map.get<int>(), vec_int, 0,
-                              MatrixCompareType::absolute));
-  ASSERT_TRUE(CompareMatrices(*map.get<double>(), vec_double, 0.0,
-                              MatrixCompareType::absolute));
+  ASSERT_EQ(*map.get<int>(), vec_int);
+  ASSERT_EQ(*map.get<double>(), vec_double);
 
   ASSERT_TRUE(map.has_key<int>());
   ASSERT_TRUE(map.has_key<double>());
@@ -91,7 +89,7 @@ using remove_const_and_reference =
 GTEST_TEST(ParameterizedTypeMapTest, TestIntendedUseCase) {
   int n = 10;
 
-  VectorX<int> vec = VectorX<int>::Constant(n, 3);
+  VectorX<float> vec = VectorX<float>::LinSpaced(n, 0, n - 1);
   ParameterizedTypeMap<VectorX> map;
 
   auto fun = [&](const auto& x) {
@@ -103,22 +101,22 @@ GTEST_TEST(ParameterizedTypeMapTest, TestIntendedUseCase) {
     return vec_of_correct_type * x;
   };
 
-  int x_int_1 = 2;
-  ASSERT_TRUE(CompareMatrices(fun(x_int_1), vec * x_int_1, 0.,
+  float x_float_1(2);
+  ASSERT_TRUE(CompareMatrices(fun(x_float_1), vec * x_float_1, 0.,
                               MatrixCompareType::absolute));
 
   double x_double_1 = 3.;
   ASSERT_TRUE(CompareMatrices(fun(x_double_1), vec.cast<double>() * x_double_1,
                               1e-12, MatrixCompareType::absolute));
 
-  int x_int_2 = 5;
-  VectorX<int> expected_int_2 = vec * x_int_2;
+  float x_float_2(5);
+  VectorX<float> expected_float_2 = vec * x_float_2;
 
   double x_double_2 = 15.;
   VectorX<double> expected_double_2 = vec.cast<double>() * x_double_2;
 
   Eigen::internal::set_is_malloc_allowed(false);
-  ASSERT_TRUE(CompareMatrices(fun(x_int_2), expected_int_2, 0.,
+  ASSERT_TRUE(CompareMatrices(fun(x_float_2), expected_float_2, 0.,
                               MatrixCompareType::absolute));
   ASSERT_TRUE(CompareMatrices(fun(x_double_2), expected_double_2, 0.,
                               MatrixCompareType::absolute));

--- a/drake/common/test/parameterized_type_map_test.cc
+++ b/drake/common/test/parameterized_type_map_test.cc
@@ -1,0 +1,125 @@
+#include <memory>
+
+// See https://eigen.tuxfamily.org/dox-devel/TopicPreprocessorDirectives.html.
+#define EIGEN_RUNTIME_NO_MALLOC
+#include <Eigen/Dense>
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/parameterized_type_map.h"
+
+namespace drake {
+
+namespace {
+
+using drake::CompareMatrices;
+using drake::MatrixCompareType;
+
+GTEST_TEST(ParameterizedTypeMapTest, TestBasics) {
+  ParameterizedTypeMap<Vector3> map;
+
+  auto vec_int = Vector3<int>(1, 2, 3);
+  map.emplace<int>(vec_int);
+
+  auto vec_double = Vector3<double>(2., 3., 4.);
+  map.emplace<double>(vec_double);
+
+  ASSERT_TRUE(
+      CompareMatrices(*map.at<int>(), vec_int, 0, MatrixCompareType::absolute));
+  ASSERT_TRUE(CompareMatrices(*map.at<double>(), vec_double, 0.0,
+                              MatrixCompareType::absolute));
+
+  ASSERT_TRUE(map.has_key<int>());
+  ASSERT_TRUE(map.has_key<double>());
+  ASSERT_FALSE(map.has_key<float>());
+}
+
+namespace parameterized_type_map_test {
+
+template <typename T>
+class DestructorTestType {
+ public:
+  DestructorTestType(T value, bool& destructed_flag)
+      : value_(value), destructed_flag_(destructed_flag) {
+    destructed_flag_ = false;
+  };
+  ~DestructorTestType() { destructed_flag_ = true; }
+
+  const T& get_value() const { return value_; }
+
+ private:
+  T value_;
+  bool& destructed_flag_;
+};
+
+}  // parameterized_type_map_test
+
+GTEST_TEST(ParameterizedTypeMapTest, TestLifeTime) {
+  using parameterized_type_map_test::DestructorTestType;
+
+  bool bool_destructed;
+  bool double_destructed;
+
+  {
+    ParameterizedTypeMap<DestructorTestType> map;
+
+    bool bool_value = true;
+    map.emplace<bool>(bool_value, bool_destructed);
+
+    double double_value = 5.9;
+    map.emplace<double>(double_value, double_destructed);
+
+    ASSERT_FALSE(bool_destructed);
+    ASSERT_EQ(bool_value, map.at<bool>()->get_value());
+
+    ASSERT_FALSE(double_destructed);
+    ASSERT_EQ(double_value, map.at<double>()->get_value());
+  }
+  ASSERT_TRUE(bool_destructed);
+  ASSERT_TRUE(double_destructed);
+}
+
+template <typename T>
+using remove_const_and_reference =
+    typename std::remove_const<typename std::remove_reference<T>::type>::type;
+
+GTEST_TEST(ParameterizedTypeMapTest, TestIntendedUseCase) {
+  int n = 10;
+
+  VectorX<int> vec = VectorX<int>::Constant(n, 3);
+  ParameterizedTypeMap<VectorX> map;
+
+  auto fun = [&](const auto& x) {
+    using Scalar = remove_const_and_reference<decltype(x)>;
+    if (!map.has_key<Scalar>()) {
+      map.emplace<Scalar>(vec.cast<Scalar>());
+    }
+    const auto& vec_of_correct_type = *map.at<Scalar>();
+    return vec_of_correct_type * x;
+  };
+
+  int x_int_1 = 2;
+  ASSERT_TRUE(CompareMatrices(fun(x_int_1), vec * x_int_1, 0.,
+                              MatrixCompareType::absolute));
+
+  double x_double_1 = 3.;
+  ASSERT_TRUE(CompareMatrices(fun(x_double_1), vec.cast<double>() * x_double_1,
+                              1e-12, MatrixCompareType::absolute));
+
+  int x_int_2 = 5;
+  VectorX<int> expected_int_2 = vec * x_int_2;
+
+  double x_double_2 = 15.;
+  VectorX<double> expected_double_2 = vec.cast<double>() * x_double_2;
+
+  Eigen::internal::set_is_malloc_allowed(false);
+  ASSERT_TRUE(CompareMatrices(fun(x_int_2), expected_int_2, 0.,
+                              MatrixCompareType::absolute));
+  ASSERT_TRUE(CompareMatrices(fun(x_double_2), expected_double_2, 0.,
+                              MatrixCompareType::absolute));
+  Eigen::internal::set_is_malloc_allowed(true);
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/common/test/parameterized_type_map_test.cc
+++ b/drake/common/test/parameterized_type_map_test.cc
@@ -43,7 +43,8 @@ class DestructorTestType {
   DestructorTestType(T value, bool& destructed_flag)
       : value_(value), destructed_flag_(destructed_flag) {
     destructed_flag_ = false;
-  };
+  }
+
   ~DestructorTestType() { destructed_flag_ = true; }
 
   const T& get_value() const { return value_; }

--- a/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
@@ -11,5 +11,5 @@ target_link_libraries(rigid_body_tree_test drakeRBSystem ${GTEST_BOTH_LIBRARIES}
 drake_add_test(NAME rigid_body_tree_test COMMAND rigid_body_tree_test)
 
 add_executable(rigid_body_tree_inverse_dynamics_test rigid_body_tree_inverse_dynamics_test.cc)
-target_link_libraries(rigid_body_tree_inverse_dynamics_test drakeRBSystem ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(rigid_body_tree_inverse_dynamics_test drakeRBM ${GTEST_BOTH_LIBRARIES})
 drake_add_test(NAME rigid_body_tree_inverse_dynamics_test COMMAND rigid_body_tree_inverse_dynamics_test)

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -4,6 +4,7 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/parameterized_type_map.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/systems/plants/joints/floating_base_types.h"
@@ -107,10 +108,14 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
   }
 
   // Compute Coriolis matrix (see Murray et al., eq. (4.23)).
+  ParameterizedTypeMap<KinematicsCache> cache_map;
   auto qd_to_coriolis_term = [&](const auto& qd_arg) {
     using Scalar =
         typename std::remove_reference<decltype(qd_arg)>::type::Scalar;
-    KinematicsCache<Scalar> kinematics_cache_coriolis(tree_rpy_->bodies);
+    if (!cache_map.has_key<Scalar>()) {
+      cache_map.emplace<Scalar>(tree_rpy_->bodies);
+    }
+    auto& kinematics_cache_coriolis = *cache_map.at<Scalar>();
     kinematics_cache_coriolis.initialize(q.cast<Scalar>(), qd_arg);
     tree_rpy_->doKinematics(kinematics_cache_coriolis, true);
 

--- a/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
+++ b/drake/systems/plants/test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc
@@ -115,7 +115,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
     if (!cache_map.has_key<Scalar>()) {
       cache_map.emplace<Scalar>(tree_rpy_->bodies);
     }
-    auto& kinematics_cache_coriolis = *cache_map.at<Scalar>();
+    auto& kinematics_cache_coriolis = *cache_map.get<Scalar>();
     kinematics_cache_coriolis.initialize(q.cast<Scalar>(), qd_arg);
     tree_rpy_->doKinematics(kinematics_cache_coriolis, true);
 


### PR DESCRIPTION
Adds ParameterizedTypeMap, basically a map from a type `T` to (a `shared_ptr` to) an instance of `ValueType<T>`. This will come in very handy when using the `jacobian`/`hessian` functionality introduced in https://github.com/RobotLocomotion/drake/pull/3321. It may also be useful for https://github.com/RobotLocomotion/drake/issues/1763 and https://github.com/RobotLocomotion/drake/issues/2235.

See the change in `rigid_body_tree_inverse_dynamics_test.cc` for an example use case. The point is that if lambda `qd_to_coriolis_term` is called a second time with an argument that has the same scalar type, then the preexisting `KinematicsCache` is used instead of a new one, greatly reducing allocations. This will be important to achieve efficient trajectory optimization, for example.

If anyone has a better name for this map, let me know.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3567)

<!-- Reviewable:end -->
