### PR TITLE
Removed unneccesary NOLINT command.

### DIFF
--- a/drake/systems/plants/rigid_body_plant/test/rigid_body_tree_lcm_publisher_test.cc
+++ b/drake/systems/plants/rigid_body_plant/test/rigid_body_tree_lcm_publisher_test.cc
@@ -1,4 +1,3 @@
-// NOLINT(whitespace/line_length)
 #include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
 
 #include <memory>


### PR DESCRIPTION
This is shrapnel left over from a time when the file name was much longer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3577)
<!-- Reviewable:end -->
