### PR TITLE
Xvfb on linux maybe

### DIFF
--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -61,9 +61,9 @@ Other prerequisites may be installed as follows::
       graphviz libgtk2.0-dev libhtml-form-perl libjpeg-dev libmpfr-dev \
       libwww-perl libpng-dev libqt4-dev libqt4-opengl-dev libqwt-dev \
       libterm-readkey-perl libtool libvtk-java libvtk5-dev libvtk5-qt4-dev \
-      make mpich ninja-build perl pkg-config python-bs4 python-dev \
+      make mesa-utils mpich ninja-build perl pkg-config python-bs4 python-dev \
       python-gtk2 python-html5lib python-numpy python-pip python-sphinx \
-      python-vtk subversion swig unzip valgrind
+      python-vtk subversion swig unzip valgrind xvfb
 
 Environment
 -----------

--- a/drake/regtests/CMakeLists.txt
+++ b/drake/regtests/CMakeLists.txt
@@ -1,15 +1,45 @@
 # This directory contains black-box regression tests that operate on the
 # installed outputs of the Drake build.
 
-# Xvfb is a virtual framebuffer for Linux. We use it if no native display is
-# available. On other supported platforms (Windows and OS X), a native display
-# is always available.
+# Xvfb is a virtual framebuffer for X11, typically only available on Linux. We
+# attempt to use it here because a display is not always available, and to
+# prevent window appearing on-screen during the test.  On other supported
+# platforms (Windows and OS X), a native display is always available, and
+# always used.
 find_program(xvfb-run xvfb-run)
 
-if(APPLE OR WIN32 OR DEFINED ENV{DISPLAY})
-  set(hasDisplay TRUE)
+set(haveXvfb FALSE)
+if(xvfb-run)
+  execute_process(
+    COMMAND xvfb-run -s "-screen 0 1024x768x24" glxinfo -B
+    COMMAND grep -i glx
+    RESULT_VARIABLE xvfbGlxReturnCode
+    OUTPUT_QUIET
+    ERROR_QUIET
+    )
+  if(xvfbGlxReturnCode EQUAL 0)
+    set(haveXvfb TRUE)
+  endif()
+endif()
+
+set(haveDisplay FALSE)
+if(APPLE OR WIN32)
+  set(haveDisplay TRUE)
+elseif(DEFINED ENV{DISPLAY})
+  set(haveDisplay TRUE)
+endif()
+
+set(displayMethod "none")
+if(APPLE OR WIN32)
+  # Never use xvfb; always use display.
+  set(displayMethod "primaryDisplay")
 else()
-  set(hasDisplay FALSE)
+  # On linux: prefer xvfb, fall back to primary display.
+  if(haveXvfb)
+    set(displayMethod "xvfbDisplay")
+  elseif(haveDisplay)
+    set(displayMethod "primaryDisplay")
+  endif()
 endif()
 
 if(WITH_DIRECTOR)
@@ -17,15 +47,18 @@ if(WITH_DIRECTOR)
   set(visualizerStartupTestCommand
       ${CMAKE_INSTALL_PREFIX}/bin/directorPython
       ${CMAKE_CURRENT_SOURCE_DIR}/visualizer_startup_test.py)
-  if(hasDisplay)
+  if(displayMethod STREQUAL "primaryDisplay")
     drake_add_test(NAME visualizer_startup_test_default_display
              COMMAND ${visualizerStartupTestCommand}
              SIZE medium)
-  elseif(xvfb-run)
+  elseif(displayMethod STREQUAL "xvfbDisplay")
     drake_add_test(NAME visualizer_startup_test_xvfb
              COMMAND xvfb-run -s "-screen 0 1024x768x24"
              ${visualizerStartupTestCommand}
              SIZE medium)
+  else()
+    message(STATUS "visualizer_startup_test is disabled"
+      " (no display and xvfb-run is either absent or does not support GLX)")
   endif()
 endif()
 

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -52,6 +52,7 @@ libvtk5-qt4-dev
 libwww-perl
 libxmu-dev
 make
+mesa-utils
 ninja-build
 perl
 pkg-config
@@ -66,6 +67,7 @@ subversion
 swig
 unzip
 valgrind
+xvfb
 
 EOF
     )


### PR DESCRIPTION
This PR is a revival and elaboration of #3539.  The goal is to isolate cases where xvfb has adequate support for OpenGL apps (e.g. drake-visualizer), and use xvfb only in those cases.

A further goal (perhaps a separate PR) will be to encapsulate the support checks so that xvfb-enabled testing is not limited to the regtests directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3579)
<!-- Reviewable:end -->
