### PR TITLE
Removed "make options" from homebrew instructions

### DIFF
--- a/drake/doc/homebrew.rst
+++ b/drake/doc/homebrew.rst
@@ -28,10 +28,4 @@ Add the line::
 
 to your ``.bash_profile`` or ``.bashrc``.
 
-Download the external dependencies::
-
-    cd drake-distro
-    make options  # use the GUI to choose which externals you want, then press 'c' to configure, then 'g' to generate makefiles and exit
-    make download-all
-
 When you are done with these platform-specific steps, return to :doc:`from_source` to complete and test your installation.


### PR DESCRIPTION
Fixes https://github.com/RobotLocomotion/drake/issues/3581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3582)
<!-- Reviewable:end -->
