### PR TITLE
Adds Support for Default Ros Parameters

### DIFF
--- a/ros/drake_ros_common/include/drake/ros/parameter_server.h
+++ b/ros/drake_ros_common/include/drake/ros/parameter_server.h
@@ -7,8 +7,7 @@ namespace ros {
 
 /**
  * Waits up to @p max_wait_time for parameter @p parameter_name to exist on the
- * ROS parameter server. Throws an `std::runtime_error` exception if the
- * parameter does not show up prior to @p max_wait_time elapsing.
+ * ROS parameter server.
  *
  * Note that this method calls `ros::Time::now()` and thus requires that either
  * a node handle be created  or `ros::start()` be called prior to this method
@@ -18,8 +17,12 @@ void WaitForParameter(const std::string& parameter_name,
     double max_wait_time = 1.0);
 
 /**
- * Returns a parameter from the ROS parameter server. Throws an
- *`std::runtime_error` exception if it fails to obtain the parameter.
+ * Returns a parameter from the ROS parameter server. Throws a
+ *`std::runtime_error` exception if the parameter is not found after
+ * @p max_wait_time or is not the correct type.
+ *
+ * @tparam T The parameter type. Valid types are available here:
+ * http://wiki.ros.org/Parameter%20Server#Parameter_Types.
  *
  * @param[in] parameter_name The name of the parameter to obtain.
  *
@@ -28,21 +31,49 @@ void WaitForParameter(const std::string& parameter_name,
  *
  * @returns The value of the parameter.
  *
- * @throws std::runtime_error If the parameter is not available on the ROS
- * parameter server even after waiting @p max_wait_time seconds, or if the
- * parameter is not of the correct type.
+ * @throws std::runtime_error If the parameter does not exist after
+ * @p max_wait_time or it exists but is not of a compatible type.
  */
 template<typename T>
-T GetROSParameter(const std::string& parameter_name,
+T GetRosParameterOrThrow(const std::string& parameter_name,
     double max_wait_time = 5.0) {
   WaitForParameter(parameter_name, max_wait_time);
-  T parameter;
+  T parameter{};
   if (!::ros::param::get(parameter_name, parameter)) {
     throw std::runtime_error(
-      "ERROR: Failed to obtain parameter \"" + parameter_name + "\" from "
-      "the ROS parameter server.");
+        "ERROR: Failed to obtain parameter \"" + parameter_name + "\" from "
+        "the ROS parameter server.");
   }
+  return parameter;
+}
 
+/**
+ * Returns a parameter from the ROS parameter server. Returns @p default_value
+ * if the parameter does not exist after @p max_wait_time or if the parameter
+ * exists but is not a type that can be converted into `T`.
+ *
+ * @tparam T The parameter type. Valid types are available here:
+ * http://wiki.ros.org/Parameter%20Server#Parameter_Types.
+ *
+ * @param[in] parameter_name The name of the parameter to obtain.
+ *
+ * @param[in] default_value The value that is returned if the parameter does not
+ * exist after waiting @p max_wait_time.
+ *
+ * @param[in] max_wait_time The maximum time to wait for the parameter to
+ * become available on the ROS parameter server.
+ *
+ * @returns The value of the parameter, or @p default_value if there was any
+ * problem obtaining the parameter.
+ */
+template<typename T>
+T GetRosParameterOrDefault(const std::string& parameter_name, T default_value,
+    double max_wait_time = 5.0) {
+  WaitForParameter(parameter_name, max_wait_time);
+  T parameter = default_value;
+  if (::ros::ok() && ::ros::param::has(parameter_name)) {
+    ::ros::param::param<T>(parameter_name, parameter, default_value);
+  }
   return parameter;
 }
 

--- a/ros/drake_ros_common/include/drake/ros/parameter_server.h
+++ b/ros/drake_ros_common/include/drake/ros/parameter_server.h
@@ -12,17 +12,30 @@ namespace ros {
  * Note that this method calls `ros::Time::now()` and thus requires that either
  * a node handle be created  or `ros::start()` be called prior to this method
  * being called.
+ *
+ * @param[in] parameter_name The name of the parameter to obtain from the ROS
+ * parameter server.
+ *
+ * @param[in] max_wait_time The maximum amount of time to wait for the parameter
+ * to become available before aborting.
+ *
+ * @return This method returns true if the parameter comes into existence prior
+ * to @p max_wait_time and false otherwise.
  */
-void WaitForParameter(const std::string& parameter_name,
+bool WaitForParameter(const std::string& parameter_name,
     double max_wait_time = 1.0);
 
 /**
  * Returns a parameter from the ROS parameter server. Throws a
  *`std::runtime_error` exception if the parameter is not found after
- * @p max_wait_time or is not the correct type.
+ * @p max_wait_time or if the parameter exists but is not a type that can be
+ * converted into `T`.
  *
- * @tparam T The parameter type. Valid types are available here:
- * http://wiki.ros.org/Parameter%20Server#Parameter_Types.
+ * @tparam T The parameter type. A full list of types supported by ROS are
+ * available here: http://wiki.ros.org/Parameter%20Server#Parameter_Types.
+ * Currently this method only has test coverage for the following types:
+ * `double`, `int`, `bool`, and `std::string`. Notably, the following types
+ * are not tested yet: iso8601 dates, lists, and base64-encoded binary data.
  *
  * @param[in] parameter_name The name of the parameter to obtain.
  *
@@ -52,8 +65,11 @@ T GetRosParameterOrThrow(const std::string& parameter_name,
  * if the parameter does not exist after @p max_wait_time or if the parameter
  * exists but is not a type that can be converted into `T`.
  *
- * @tparam T The parameter type. Valid types are available here:
- * http://wiki.ros.org/Parameter%20Server#Parameter_Types.
+ * @tparam T The parameter type. A full list of types supported by ROS are
+ * available here: http://wiki.ros.org/Parameter%20Server#Parameter_Types.
+ * Currently this method only has test coverage for the following types:
+ * `double`, `int`, `bool`, and `std::string`. Notably, the following types
+ * are not tested yet: iso8601 dates, lists, and base64-encoded binary data.
  *
  * @param[in] parameter_name The name of the parameter to obtain.
  *

--- a/ros/drake_ros_common/src/parameter_server.cc
+++ b/ros/drake_ros_common/src/parameter_server.cc
@@ -5,15 +5,9 @@ namespace ros {
 
 void WaitForParameter(const std::string& parameter_name, double max_wait_time) {
   ::ros::Time begin_time = ::ros::Time::now();
-
   while (::ros::ok() && !::ros::param::has(parameter_name)
       && (::ros::Time::now() - begin_time).toSec() < max_wait_time) {
-    ::ros::Duration(0.5).sleep();  // Sleeps for half a second.
-  }
-
-  if (!::ros::param::has(parameter_name)) {
-    throw std::runtime_error("ERROR: Failed to obtain parameter \"" +
-        parameter_name + "\" from the ROS parameter server.");
+    ::ros::Duration(0.1).sleep();  // Sleeps for 1/10 of a second.
   }
 }
 

--- a/ros/drake_ros_common/src/parameter_server.cc
+++ b/ros/drake_ros_common/src/parameter_server.cc
@@ -3,12 +3,13 @@
 namespace drake {
 namespace ros {
 
-void WaitForParameter(const std::string& parameter_name, double max_wait_time) {
+bool WaitForParameter(const std::string& parameter_name, double max_wait_time) {
   ::ros::Time begin_time = ::ros::Time::now();
   while (::ros::ok() && !::ros::param::has(parameter_name)
       && (::ros::Time::now() - begin_time).toSec() < max_wait_time) {
     ::ros::Duration(0.1).sleep();  // Sleeps for 1/10 of a second.
   }
+  return ::ros::param::has(parameter_name);
 }
 
 }  // namespace ros

--- a/ros/drake_ros_common_test/test/parameter_server_test.cc
+++ b/ros/drake_ros_common_test/test/parameter_server_test.cc
@@ -8,48 +8,233 @@ namespace drake {
 namespace ros {
 namespace {
 
-// Verifies that an exception is thrown if the requested parameter does not
-// exist.
-GTEST_TEST(DrakeRosParameterServerTest, TestGetNonExistentParameter) {
-  EXPECT_THROW(GetROSParameter<double>("non_existent_parameter"),
-    std::runtime_error);
-}
+double short_timeout = 0.1;
 
-// Verifies that a double can be obtained from the ROS parameter server.
-GTEST_TEST(DrakeRosParameterServerTest, TestGetDouble) {
-  double value = 0;
-  value = GetROSParameter<double>("double_parameter_name");
-  EXPECT_NO_THROW(
-      value = GetROSParameter<double>("double_parameter_name"));
+// Tests GetRosParameterOrThrow<double>().
+GTEST_TEST(DrakeRosParameterServerTest, TestGetOrThrowDouble) {
+  double value{};
+
+  // Verifies a double can be obtained from the ROS parameter server.
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrThrow<double>("double_parameter_name"));
   EXPECT_EQ(3.14159265359, value);
+
+  // Verifies an exception is thrown if the parameter does not exist.
+  EXPECT_THROW(
+      GetRosParameterOrThrow<double>("bad_parameter", short_timeout),
+      std::runtime_error);
+
+  // Verifies no exception is thrown if the parameter's type is an int since an
+  // int can be coverted into a double.
+  value = 0;
+  EXPECT_NO_THROW(value = GetRosParameterOrThrow<double>("int_parameter_name"));
+  EXPECT_EQ(1729.0, value);
+
+  // Verifies an exception is thrown if the parameter's type is incorrect.
+  EXPECT_THROW(
+      GetRosParameterOrThrow<double>("string_parameter_name"),
+      std::runtime_error);
 }
 
-// Verifies that a string can be obtained from the ROS parameter server.
-GTEST_TEST(DrakeRosParameterServerTest, TestGetString) {
+// Tests GetRosParameterOrThrow<std::string>().
+GTEST_TEST(DrakeRosParameterServerTest, TestGetOrThrowString) {
   std::string value{};
-  EXPECT_NO_THROW(
-      value = GetROSParameter<std::string>("string_parameter_name"));
+
+  // Verifies a string can be obtained from the ROS parameter server.
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrThrow<std::string>("string_parameter_name"));
   EXPECT_EQ("In teaching others we teach ourselves.", value);
+
+  // Verifies an exception is thrown if the parameter does not exist.
+  EXPECT_THROW(
+      GetRosParameterOrThrow<std::string>("bad_parameter", short_timeout),
+      std::runtime_error);
+
+  // Verifies an exception is thrown if the parameter's type is incorrect.
+  EXPECT_THROW(
+      GetRosParameterOrThrow<std::string>("double_parameter_name"),
+      std::runtime_error);
 }
 
-// Verifies that an integer can be obtained from the ROS parameter server.
-GTEST_TEST(DrakeRosParameterServerTest, TestGetInt) {
+// Tests GetRosParameterOrThrow<int>().
+GTEST_TEST(DrakeRosParameterServerTest, TestGetOrThrowInt) {
   int value{};
+
+  // Verifies an integer can be obtained from the ROS parameter server.
   EXPECT_NO_THROW(
-      value = GetROSParameter<int>("int_parameter_name"));
+      value = GetRosParameterOrThrow<int>("int_parameter_name"));
   EXPECT_EQ(1729, value);
+
+  // Verifies an exception is thrown if the parameter does not exist.
+  EXPECT_THROW(
+      GetRosParameterOrThrow<int>("bad_parameter", short_timeout),
+      std::runtime_error);
+
+  // Verifies no exception is thrown if the parameter's type is a double.  The
+  // parameter's value is 3.14159265359. When this is converted into an int, it
+  // becomes 3.
+  value = 0;
+  EXPECT_NO_THROW(value = GetRosParameterOrThrow<int>("double_parameter_name"));
+  EXPECT_EQ(3, value);
+
+  // Verifies an exception is thrown if the parameter's type is not compatible.
+  EXPECT_THROW(
+      GetRosParameterOrThrow<int>("string_parameter_name"), std::runtime_error);
 }
 
-// Verifies that a boolean can be obtained from the ROS parameter server.
-GTEST_TEST(DrakeRosParameterServerTest, TestGetBool) {
-  bool true_value = false;
-  bool false_value = true;
+// Tests GetRosParameterOrThrow<bool>().
+GTEST_TEST(DrakeRosParameterServerTest, TestGetOrThrowBool) {
+  bool true_value{false};
+  bool false_value{true};
+
+  // Note that an incorrect default value is used to ensure the correct value
+  // was obtained from the ROS parameter server.
   EXPECT_NO_THROW(
-      true_value = GetROSParameter<bool>("bool_parameter_name_true"));
+      true_value = GetRosParameterOrThrow<bool>(
+          "bool_parameter_name_true", false));
   EXPECT_NO_THROW(
-      false_value = GetROSParameter<bool>("bool_parameter_name_false"));
+      false_value = GetRosParameterOrThrow<bool>(
+          "bool_parameter_name_false", true));
   EXPECT_TRUE(true_value);
   EXPECT_FALSE(false_value);
+
+  // Verifies an exception is thrown if the parameter's type is incorrect.
+  EXPECT_THROW(GetRosParameterOrThrow<bool>("double_parameter_name"),
+      std::runtime_error);
+}
+
+// Tests GetRosParameterOrDefault<double>().
+GTEST_TEST(DrakeRosParameterServerTest, TestGetOrDefaultDouble) {
+  const int default_value = 1980;
+  double value = 0;
+
+  // Verifies a double can be obtained from the ROS parameter server.
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<double>("double_parameter_name", default_value));
+  EXPECT_EQ(3.14159265359, value);
+
+  // Verifies the default value is returned when the parameter does not exist.
+  value = 0;
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<double>("bad_parameter", default_value,
+          short_timeout));
+  EXPECT_EQ(default_value, value);
+
+  // Verifies no exception is thrown if the parameter's type is an int since an
+  // int can be coverted into a double.
+  value = 0;
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<double>("int_parameter_name", default_value));
+  EXPECT_EQ(1729.0, value);
+
+  // Verifies the default value is returned if the parameter's type is not
+  // convertable into a double.
+  value = 0;
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<double>("string_parameter_name", default_value));
+  EXPECT_EQ(default_value, value);
+}
+
+// Tests GetRosParameterOrDefault<std::string>().
+GTEST_TEST(DrakeRosParameterServerTest, TestGetOrDefaultString) {
+  const std::string default_value =
+      "All things in moderation,  including moderation.";
+  std::string value{};
+
+  // Verifies that a string can be obtained from the ROS parameter server.
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<std::string>(
+          "string_parameter_name", default_value));
+  EXPECT_EQ("In teaching others we teach ourselves.", value);
+
+  // Verifies the default value is returned when the parameter does not exist.
+  value = "";
+  EXPECT_NO_THROW(
+      value = GetRosParameterOrDefault<std::string>("bad_parameter",
+          default_value, short_timeout));
+  EXPECT_EQ(default_value, value);
+
+  // Verifies the default value is returned if the parameter's type is not
+  // convertable into a string.
+  value = "";
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<std::string>("double_parameter_name",
+          default_value));
+  EXPECT_EQ(default_value, value);
+}
+
+// Tests GetRosParameterOrDefault<int>().
+GTEST_TEST(DrakeRosParameterServerTest, TestGetOrDefaultInt) {
+  const int default_value = 617;
+  int value{};
+
+  // Verifies that an integer can be obtained from the ROS parameter server.
+  EXPECT_NO_THROW(
+      value = GetRosParameterOrDefault<int>("int_parameter_name",
+          default_value));
+  EXPECT_EQ(1729, value);
+
+  // Verifies the default value is returned when the parameter does not exist.
+  value = 0;
+  EXPECT_NO_THROW(
+      value = GetRosParameterOrDefault<int>("bad_parameter", default_value,
+          short_timeout));
+  EXPECT_EQ(default_value, value);
+
+  // Verifies a `double` is cast into an `int` when accessed as an integer.
+  value = 0;
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<int>("double_parameter_name", default_value));
+  EXPECT_EQ(3, value);
+
+  // Verifies the default value is returned when the parameter is a type that
+  // cannot be converted into an int.
+  value = 0;
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<int>("string_parameter_name", default_value));
+  EXPECT_EQ(default_value, value);
+}
+
+// Tests GetRosParameterOrDefault<bool>().
+GTEST_TEST(DrakeRosParameterServerTest, TestGetOrDefaultBool) {
+  bool true_value = false;
+  bool false_value = true;
+
+  // An incorrect default value is used to ensure the correct value was obtained
+  // from the ROS parameter server.
+  EXPECT_NO_THROW(
+      true_value = GetRosParameterOrDefault<bool>(
+          "bool_parameter_name_true", false));
+  EXPECT_NO_THROW(
+      false_value = GetRosParameterOrDefault<bool>(
+          "bool_parameter_name_false", true));
+  EXPECT_TRUE(true_value);
+  EXPECT_FALSE(false_value);
+
+  // Verifies the default value is returned when the parameter does not exist.
+  const bool default_value = true;
+  bool value = false;
+  EXPECT_NO_THROW(
+      value = GetRosParameterOrDefault<bool>("bad_parameter", default_value,
+        short_timeout));
+  EXPECT_EQ(default_value, value);
+
+  // Verifies the default value is returned when the parameter's type is
+  // incompatible with a bool.
+  value = false;
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<bool>("double_parameter_name", default_value));
+  EXPECT_TRUE(value);
+
+  value = false;
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<bool>("double_zero", default_value));
+  EXPECT_TRUE(value);
+
+  value = false;
+  EXPECT_NO_THROW(value =
+      GetRosParameterOrDefault<bool>("int_zero", default_value));
+  EXPECT_TRUE(value);
 }
 
 }  // namespace

--- a/ros/drake_ros_common_test/test/parameter_server_test.cc
+++ b/ros/drake_ros_common_test/test/parameter_server_test.cc
@@ -30,7 +30,8 @@ GTEST_TEST(DrakeRosParameterServerTest, TestGetOrThrowDouble) {
   EXPECT_NO_THROW(value = GetRosParameterOrThrow<double>("int_parameter_name"));
   EXPECT_EQ(1729.0, value);
 
-  // Verifies an exception is thrown if the parameter's type is incorrect.
+  // Verifies an exception is thrown if the parameter's type is not convertible
+  // into a `double`.
   EXPECT_THROW(
       GetRosParameterOrThrow<double>("string_parameter_name"),
       std::runtime_error);
@@ -50,7 +51,8 @@ GTEST_TEST(DrakeRosParameterServerTest, TestGetOrThrowString) {
       GetRosParameterOrThrow<std::string>("bad_parameter", short_timeout),
       std::runtime_error);
 
-  // Verifies an exception is thrown if the parameter's type is incorrect.
+  // Verifies an exception is thrown if the parameter's type is not convertible
+  // into a `std::string`.
   EXPECT_THROW(
       GetRosParameterOrThrow<std::string>("double_parameter_name"),
       std::runtime_error);
@@ -77,7 +79,8 @@ GTEST_TEST(DrakeRosParameterServerTest, TestGetOrThrowInt) {
   EXPECT_NO_THROW(value = GetRosParameterOrThrow<int>("double_parameter_name"));
   EXPECT_EQ(3, value);
 
-  // Verifies an exception is thrown if the parameter's type is not compatible.
+  // Verifies an exception is thrown if the parameter's type is not convertible
+  // into an `int`.
   EXPECT_THROW(
       GetRosParameterOrThrow<int>("string_parameter_name"), std::runtime_error);
 }
@@ -98,7 +101,8 @@ GTEST_TEST(DrakeRosParameterServerTest, TestGetOrThrowBool) {
   EXPECT_TRUE(true_value);
   EXPECT_FALSE(false_value);
 
-  // Verifies an exception is thrown if the parameter's type is incorrect.
+  // Verifies an exception is thrown if the parameter's type is not convertible
+  // into a `bool`.
   EXPECT_THROW(GetRosParameterOrThrow<bool>("double_parameter_name"),
       std::runtime_error);
 }
@@ -128,7 +132,7 @@ GTEST_TEST(DrakeRosParameterServerTest, TestGetOrDefaultDouble) {
   EXPECT_EQ(1729.0, value);
 
   // Verifies the default value is returned if the parameter's type is not
-  // convertable into a double.
+  // convertable into a `double`.
   value = 0;
   EXPECT_NO_THROW(value =
       GetRosParameterOrDefault<double>("string_parameter_name", default_value));
@@ -155,7 +159,7 @@ GTEST_TEST(DrakeRosParameterServerTest, TestGetOrDefaultString) {
   EXPECT_EQ(default_value, value);
 
   // Verifies the default value is returned if the parameter's type is not
-  // convertable into a string.
+  // convertable into a `string`.
   value = "";
   EXPECT_NO_THROW(value =
       GetRosParameterOrDefault<std::string>("double_parameter_name",
@@ -188,7 +192,7 @@ GTEST_TEST(DrakeRosParameterServerTest, TestGetOrDefaultInt) {
   EXPECT_EQ(3, value);
 
   // Verifies the default value is returned when the parameter is a type that
-  // cannot be converted into an int.
+  // is not convertible into an `int`.
   value = 0;
   EXPECT_NO_THROW(value =
       GetRosParameterOrDefault<int>("string_parameter_name", default_value));
@@ -220,7 +224,7 @@ GTEST_TEST(DrakeRosParameterServerTest, TestGetOrDefaultBool) {
   EXPECT_EQ(default_value, value);
 
   // Verifies the default value is returned when the parameter's type is
-  // incompatible with a bool.
+  // not convertible into a `bool`.
   value = false;
   EXPECT_NO_THROW(value =
       GetRosParameterOrDefault<bool>("double_parameter_name", default_value));

--- a/ros/drake_ros_common_test/test/parameter_server_test.test
+++ b/ros/drake_ros_common_test/test/parameter_server_test.test
@@ -6,6 +6,9 @@
   <param name="bool_parameter_name_true" type="bool" value="true" />
   <param name="bool_parameter_name_false" type="bool" value="false" />
 
+  <param name="int_zero" type="int" value="0" />
+  <param name="double_zero" type="double" value="0" />
+
   <test pkg="drake_ros_common_test" test-name="parameter_server_test"
         type="parameter_server_test" />
 </launch>


### PR DESCRIPTION
# Changes
* Modified ROS parameter accessor API to be style guide compliant.
* Modified ROS parameter accessor API to support two versions, one that throws an exception if it fails to obtain the desired parameter, and one that returns a default value.

# Motivation
This is split out of #3103. We need a version of the ROS parameter accessor method that returns a default value to better support unit tests. When running a simulation as a unit test, the duration should be limited so the unit test can stop in a timely manner. When running the same simulation as a stand alone application, a default duration of infinity should be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3583)
<!-- Reviewable:end -->
