### PR TITLE
Introduce discrete state for Systems

### DIFF
--- a/drake/automotive/test/idm_with_trajectory_agent_scalartype_test.cc
+++ b/drake/automotive/test/idm_with_trajectory_agent_scalartype_test.cc
@@ -32,6 +32,13 @@ MST operator*(double, const MST&) { return MST{}; }
 }  // namespace
 
 namespace drake {
+
+// Override the is_numeric trait, since there are no rounding operations
+// on the minimal ScalarType declared above.
+template<> struct DRAKEAUTOMOTIVE_EXPORT is_numeric<MST> {
+  static constexpr bool value = false;
+};
+
 namespace automotive {
 template class DRAKEAUTOMOTIVE_EXPORT IdmWithTrajectoryAgent<MST>;
 namespace {

--- a/drake/automotive/test/simple_car_scalartype_test.cc
+++ b/drake/automotive/test/simple_car_scalartype_test.cc
@@ -5,7 +5,10 @@
 
 #include "gtest/gtest.h"
 
+#include "drake/common/drake_assert.h"
+#include "drake/common/number_traits.h"
 #include "drake/drakeAutomotive_export.h"
+#include "drake/systems/framework/leaf_system.h"
 
 namespace {
 /// An expression of the minimal ScalarType (MST) concept for SimpleCar.
@@ -30,10 +33,20 @@ MST tan(const MST&) { return MST{}; }
 }  // namespace
 
 namespace drake {
+
+// Override the is_numeric trait, since there are no rounding operations
+// on MST.
+template<> struct DRAKEAUTOMOTIVE_EXPORT is_numeric<MST> {
+  static constexpr bool value = false;
+};
+
 namespace automotive {
+
 template class DRAKEAUTOMOTIVE_EXPORT SimpleCar<MST>;
+
 namespace {
 
+// Tests that we can compile a SimpleCar based on the MST.
 GTEST_TEST(SimpleCarScalarTypeTest, CompileTest) {
   const SimpleCar<MST> dut;
 

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -32,6 +32,7 @@ set(installed_headers
   eigen_types.h
   functional_form.h
   nice_type_name.h
+  number_traits.h
   polynomial.h
   sorted_vectors_have_intersection.h
   text_logging.h

--- a/drake/common/number_traits.h
+++ b/drake/common/number_traits.h
@@ -1,0 +1,35 @@
+#pragma once
+
+/// @file
+/// This file contains traits for number (scalar) types. Drake libraries that
+/// are templated on a scalar type may consult these traits to perform
+/// appropriate conditional compilation.
+///
+/// This file will also contain trait specializations for officially-supported
+/// Drake scalar types, as we decide what those types are. Other scalar types,
+/// such as experimental, test, and example types within Drake, or custom types
+/// outside of Drake, may specialize the traits locally.
+
+namespace drake {
+
+/// is_numeric is true for types that are on the real line. The exact list
+/// of operations that Drake requires numeric types to satisfy is not yet a
+/// hard API commitment; we expect it to expand slowly over time. However, it
+/// will only include operations that real numbers can implement.
+///
+/// By default, is_numeric is true. It should be specialized to false as
+/// needed to avoid compiling Drake features that don't make sense for
+/// non-real types.
+///
+/// Examples:
+///
+/// is_numeric should be true for types like double, int, and AutoDiffScalar.
+///
+/// is_numeric should be false for types like std::complex, Polynomial, and
+/// FunctionalForm.
+template <typename T>
+struct is_numeric {
+  static constexpr bool value = true;
+};
+
+}  // namespace drake

--- a/drake/math/autodiff.h
+++ b/drake/math/autodiff.h
@@ -24,6 +24,14 @@ double floor(const Eigen::AutoDiffScalar<DerType>& x) {
   return floor(x.value());
 }
 
+/// Overloads ceil to mimic std::ceil from <cmath>.
+/// Must appear in global namespace so that ADL can select between this
+/// implementation and the STL one.
+template <typename DerType>
+double ceil(const Eigen::AutoDiffScalar<DerType>& x) {
+  return ceil(x.value());
+}
+
 namespace drake {
 namespace math {
 

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -5,6 +5,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/text_logging.h"
 #include "drake/drakeSystemAnalysis_export.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"
@@ -256,7 +257,7 @@ class Simulator {
       IntegratorType::RungeKutta2;
   static constexpr double kDefaultInitialStepSizeAttempt = 1e-3;
 
-  const System<T>& system_;                  // Just a reference; not owned.
+  const System<T>& system_;              // Just a reference; not owned.
   std::unique_ptr<Context<T>> context_;  // The trajectory Context.
 
   // TODO(sherm1) These are pre-allocated temporaries for use by Integrators;
@@ -264,6 +265,9 @@ class Simulator {
   // needed varies for different integrators.
   std::unique_ptr<ContinuousState<T>> derivs0_;
   std::unique_ptr<ContinuousState<T>> derivs1_;
+
+  // Pre-allocated temporaries for updated difference states.
+  std::unique_ptr<DifferenceState<T>> discrete_updates_;
 
   // These are the caller's requests, if any.
   IntegratorType req_integrator_{IntegratorType::UseDefault};
@@ -312,6 +316,8 @@ Simulator<T>::Simulator(const System<T>& system,
   // there are more of them.
   derivs0_ = system_.AllocateTimeDerivatives();
   derivs1_ = system_.AllocateTimeDerivatives();
+
+  discrete_updates_ = system_.AllocateDifferenceVariables();
 }
 
 template <typename T>
@@ -346,17 +352,42 @@ void Simulator<T>::StepTo(const T& final_time) {
       context_->get_mutable_continuous_state()->get_mutable_state();
 
   // TODO(sherm1) Invoke selected integrator.
-  SampleActions sample_actions;
+  UpdateActions<T> update_actions;
   bool sample_time_hit = false;
   while (context_->get_time() <= final_time) {
     // Starting a new step on the trajectory.
     const T step_start_time = context_->get_time();
+    SPDLOG_TRACE(log(), "Starting a simulation step at {}", step_start_time);
 
-    // First make any necessary discrete updates.
+    // First take any necessary discrete actions.
     if (sample_time_hit) {
-      system_.Update(context_.get(), sample_actions);
+      for (const DiscreteEvent<T>& event : update_actions.events) {
+        switch (event.action) {
+          case DiscreteEvent<T>::kPublishAction: {
+            system_.Publish(*context_, event);
+            break;
+          }
+          case DiscreteEvent<T>::kUpdateAction: {
+            DifferenceState<T>* xd = context_->get_mutable_difference_state();
+            // Systems with discrete update events must have difference state.
+            DRAKE_DEMAND(xd != nullptr);
+            // First, compute the discrete updates into a temporary buffer.
+            system_.EvalDifferenceUpdates(*context_, event,
+                                         discrete_updates_.get());
+            // Then, write them back into the context.
+            xd->CopyFrom(*discrete_updates_);
+            break;
+          }
+          default: {
+            DRAKE_ABORT_MSG("Unknown DiscreteEvent action.");
+            break;
+          }
+        }
+      }
       ++num_samples_taken_;
     }
+    // Once the discrete updates have been made, clean them up.
+    update_actions.events.clear();
 
     // Now we can calculate start-of-step time derivatives.
 
@@ -375,7 +406,7 @@ void Simulator<T>::StepTo(const T& final_time) {
 
     // How far can we go before we have to take a sampling break?
     const T next_sample_time =
-        system_.CalcNextSampleTime(*context_, &sample_actions);
+        system_.CalcNextUpdateTime(*context_, &update_actions);
     DRAKE_ASSERT(next_sample_time >= step_start_time);
 
     // Figure out the largest step we can reasonably take, and whether we had
@@ -447,8 +478,7 @@ std::pair<T, bool> Simulator<T>::ProposeStepEndTime(const T& step_start_time,
       sample_time_hit = true;
     }
   } else {  // final_time < next_sample_time.
-    if (final_time <= step_stretch_time)
-      step_end_time = final_time;
+    if (final_time <= step_stretch_time) step_end_time = final_time;
   }
 
   return std::make_pair(step_end_time, sample_time_hit);

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -22,11 +22,19 @@ class MySpringMassSystem : public SpringMassSystem<double> {
  public:
   // Pass through to SpringMassSystem, except add sample rate in samples/s.
   MySpringMassSystem(double stiffness, double mass, double sample_rate)
-      : SpringMassSystem<double>(stiffness, mass, false /*no input force*/),
-        sample_rate_(sample_rate) {}
+      : SpringMassSystem<double>(stiffness, mass, false /*no input force*/) {
+    this->DeclareUpdatePeriodSec(1.0 / sample_rate);
+  }
 
   int get_publish_count() const { return publish_count_; }
   int get_update_count() const { return update_count_; }
+
+ protected:
+  // Returns an empty difference state so that updates are possible.
+  std::unique_ptr<DifferenceState<double>> AllocateDifferenceState()
+      const override {
+    return std::make_unique<DifferenceState<double>>();
+  }
 
  private:
   // Publish t q u to standard output.
@@ -34,36 +42,11 @@ class MySpringMassSystem : public SpringMassSystem<double> {
     ++publish_count_;
   }
 
-  void DoUpdate(Context<double>* context,
-                const SampleActions& actions) const override {
+  void DoEvalDifferenceUpdates(
+      const Context<double>& context,
+      DifferenceState<double>* difference_state) const override {
     ++update_count_;
   }
-
-  // Force a sample at the next multiple of the sample rate. If the current
-  // time is exactly at a sample time, we assume the sample has already been
-  // done and return the following sample time. That means we don't get a
-  // sample at 0 but will get one at the end.
-  void DoCalcNextSampleTime(const Context<double>& context,
-                            SampleActions* actions) const override {
-    if (sample_rate_ <= 0.) {
-      actions->time = std::numeric_limits<double>::infinity();
-      return;
-    }
-
-    // For reliable behavior, convert floating point times into integer
-    // sample counts. We want the ceiling unless it is the same as the floor.
-    const int prev =
-        static_cast<int>(std::floor(context.get_time() * sample_rate_));
-    const int next =
-        static_cast<int>(std::ceil(context.get_time() * sample_rate_));
-    const int which = next == prev ? next + 1 : next;
-
-    // Convert the next sample count back to a time to return.
-    const double next_sample = which / sample_rate_;
-    actions->time = next_sample;
-  }
-
-  double sample_rate_{0.};  // Default is "don't sample".
 
   mutable int publish_count_{0};
   mutable int update_count_{0};
@@ -197,8 +180,8 @@ GTEST_TEST(SimulatorTest, ControlledSpringMass) {
   const double kd = 2.0 * kMass * w0 * zeta;
   const double x_target = 0.0;
 
-  PidControlledSpringMassSystem<double> spring_mass(
-      kSpring, kMass, kp, ki, kd, x_target);
+  PidControlledSpringMassSystem<double> spring_mass(kSpring, kMass, kp, ki, kd,
+                                                    x_target);
   Simulator<double> simulator(spring_mass);  // Use default Context.
 
   // Sets initial conditions to zero.
@@ -212,14 +195,14 @@ GTEST_TEST(SimulatorTest, ControlledSpringMass) {
   simulator.Initialize();
 
   EXPECT_TRUE(simulator.get_integrator_type_in_use() ==
-      IntegratorType::RungeKutta2);
+              IntegratorType::RungeKutta2);
 
   // Computes analytical solution.
   // 1) Roots of the characteristic equation.
   complexd lambda1 = -zeta * w0 + w0 * std::sqrt(complexd(zeta * zeta - 1));
   complexd lambda2 = -zeta * w0 - w0 * std::sqrt(complexd(zeta * zeta - 1));
 
-  // Roots should be the complex conjugate of each other.
+// Roots should be the complex conjugate of each other.
 #ifdef __APPLE__
   // The factor of 20 is needed for OS X builds where the comparison needs a
   // looser tolerance, see #3636.
@@ -227,7 +210,7 @@ GTEST_TEST(SimulatorTest, ControlledSpringMass) {
 #else
   auto abs_error = NumTraits<double>::epsilon();
 #endif
-  EXPECT_NEAR(lambda1.real(),  lambda2.real(), abs_error);
+  EXPECT_NEAR(lambda1.real(), lambda2.real(), abs_error);
   EXPECT_NEAR(lambda1.imag(), -lambda2.imag(), abs_error);
 
   // The damped frequency corresponds to the absolute value of the imaginary
@@ -242,14 +225,15 @@ GTEST_TEST(SimulatorTest, ControlledSpringMass) {
   // Velocity is computed using AutoDiffScalar.
   double final_time = 0.2;
   double x_final{}, v_final{};
-  { // At the end of this local scope x_final and v_final are properly
+  {
+    // At the end of this local scope x_final and v_final are properly
     // initialized.
     // Auxiliary AutoDiffScalar variables are confined to this local scope so
     // that we don't pollute the test's scope with them.
     SingleVarAutoDiff time(final_time);
     time.derivatives() << 1.0;
-    auto x = exp(-zeta * w0 * time) * (
-        C1 * cos(wd * time) + C2 * sin(wd * time));
+    auto x =
+        exp(-zeta * w0 * time) * (C1 * cos(wd * time) + C2 * sin(wd * time));
     x_final = x.value();
     v_final = x.derivatives()[0];
   }

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sources
   cache.cc
   context.cc
   continuous_state.cc
+  difference_state.cc
   diagram.cc
   diagram_builder.cc
   diagram_context.cc
@@ -23,6 +24,7 @@ set(sources
   primitives/pass_through.cc
   primitives/pid_controller.cc
   primitives/time_varying_polynomial_source.cc
+  primitives/zero_order_hold.cc
   state.cc
   subvector.cc
   supervector.cc
@@ -50,6 +52,7 @@ set(installed_headers
   diagram.h
   diagram_builder.h
   diagram_context.h
+  difference_state.h
   leaf_context.h
   leaf_system.h
   input_port_evaluator_interface.h

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -72,6 +72,33 @@ class Context {
     return get_mutable_state()->get_mutable_continuous_state();
   }
 
+  /// Returns a mutable pointer to the difference component of the state, or
+  /// nullptr if there is no difference state.
+  DifferenceState<T>* get_mutable_difference_state() {
+    return get_mutable_state()->get_mutable_difference_state();
+  }
+
+  /// Returns a mutable pointer to element @p index of the difference state.
+  /// Asserts if there is no difference state, or if @p index doesn't exist.
+  BasicVector<T>* get_mutable_difference_state(int index) {
+    DifferenceState<T>* xd = get_mutable_difference_state();
+    DRAKE_ASSERT(xd != nullptr);
+    return xd->get_mutable_difference_state(index);
+  }
+
+  /// Sets the discrete state to @p xd, deleting whatever was there before.
+  void set_difference_state(std::unique_ptr<DifferenceState<T>> xd) {
+    get_mutable_state()->set_difference_state(std::move(xd));
+  }
+
+  /// Returns a const pointer to the discrete difference component of the
+  /// state at @p index.
+  const VectorBase<T>* get_difference_state(int index) const {
+    const DifferenceState<T>* xd = get_state().get_difference_state();
+    if (xd == nullptr) return nullptr;
+    return xd->get_difference_state(index);
+  }
+
   /// Returns a const pointer to the continuous component of the state,
   /// or nullptr if there is no continuous state.
   const ContinuousState<T>* get_continuous_state() const {

--- a/drake/systems/framework/difference_state.cc
+++ b/drake/systems/framework/difference_state.cc
@@ -1,0 +1,13 @@
+#include "drake/systems/framework/difference_state.h"
+
+
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace systems {
+
+template class DifferenceState<double>;
+template class DifferenceState<AutoDiffXd>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/difference_state.h
+++ b/drake/systems/framework/difference_state.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+
+/// The DifferenceState is a container for the numerical state values that are
+/// updated discontinuously on time or state based triggers.
+///
+/// DifferenceState owns its state, and is therefore suitable for leaf Systems
+/// but not for Diagrams.
+///
+/// @tparam T A mathematical type compatible with Eigen's Scalar.
+template <typename T>
+class DifferenceState {
+ public:
+  DifferenceState() {}
+
+  explicit DifferenceState(
+      std::vector<std::unique_ptr<BasicVector<T>>> difference_state)
+      : difference_state_(std::move(difference_state)) {}
+
+  virtual ~DifferenceState() {}
+
+  int size() const {
+    return static_cast<int>(difference_state_.size());
+  }
+
+  const BasicVector<T>* get_difference_state(int index) const {
+    DRAKE_ASSERT(index >= 0 && index < size());
+    return difference_state_[index].get();
+  }
+
+  BasicVector<T>* get_mutable_difference_state(int index) {
+    DRAKE_ASSERT(index >= 0 && index < size());
+    return difference_state_[index].get();
+  }
+
+  void CopyFrom(const DifferenceState<T>& other) {
+    DRAKE_DEMAND(size() == other.size());
+    for (int i = 0; i < size(); i++) {
+      difference_state_[i]->set_value(
+          other.get_difference_state(i)->get_value());
+    }
+  }
+
+  // DifferenceState is not copyable or moveable.
+  DifferenceState(const DifferenceState& other) = delete;
+  DifferenceState& operator=(const DifferenceState& other) = delete;
+  DifferenceState(DifferenceState&& other) = delete;
+  DifferenceState& operator=(DifferenceState&& other) = delete;
+
+ private:
+  std::vector<std::unique_ptr<BasicVector<T>>> difference_state_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -1,17 +1,38 @@
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/number_traits.h"
+#include "drake/math/autodiff.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/difference_state.h"
 #include "drake/systems/framework/leaf_context.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
+
+/// A token describing an event that recurs on a fixed period.
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+template <typename T>
+struct PeriodicEvent {
+  /// The period with which this event should recur.
+  T period_sec = 0.0;
+  /// The time after zero when this event should first occur.
+  T offset_sec = 0.0;
+  /// The action that should be taken when this event occurs.
+  DiscreteEvent<T> event;
+};
 
 /// A superclass template that extends System with some convenience utilities
 /// that are not applicable to Diagrams.
@@ -32,7 +53,7 @@ class LeafSystem : public System<T> {
     // Reserve continuous state via delegation to subclass.
     context->set_continuous_state(this->AllocateContinuousState());
     // Reserve discrete state via delegation to subclass.
-    ReserveDiscreteState(context.get());
+    context->set_difference_state(this->AllocateDifferenceState());
     return std::unique_ptr<Context<T>>(context.release());
   }
 
@@ -51,8 +72,31 @@ class LeafSystem : public System<T> {
     return AllocateContinuousState();
   }
 
+  /// Returns the AllocateDifferenceState value, which may be nullptr.
+  std::unique_ptr<DifferenceState<T>> AllocateDifferenceVariables()
+      const override {
+    return AllocateDifferenceState();
+  }
+
+  // LeafSystem objects are neither copyable nor moveable.
+  explicit LeafSystem(const System<T>& other) = delete;
+  LeafSystem& operator=(const System<T>& other) = delete;
+  explicit LeafSystem(System<T>&& other) = delete;
+  LeafSystem& operator=(System<T>&& other) = delete;
+
  protected:
   LeafSystem() {}
+
+  // =========================================================================
+  // Implementations of System<T> methods.
+
+  /// Computes the next update time based on the configured periodic events, for
+  /// scalar types that are arithmetic, or aborts for scalar types that are not
+  /// arithmetic. Subclasses that require aperiodic events should override.
+  void DoCalcNextUpdateTime(const Context<T>& context,
+                            UpdateActions<T>* events) const override {
+    DoCalcNextUpdateTimeImpl(context, events);
+  }
 
   // =========================================================================
   // New methods for subclasses to override
@@ -64,11 +108,13 @@ class LeafSystem : public System<T> {
     return nullptr;
   }
 
-  /// Reserves the discrete state as required by CreateDefaultContext.  By
-  /// default, reserves no state. Systems with discrete state should override.
-  virtual void ReserveDiscreteState(LeafContext<T>* context) const {}
+  /// Reserves the difference state as required by CreateDefaultContext.  By
+  /// default, reserves no state. Systems with difference state should override.
+  virtual std::unique_ptr<DifferenceState<T>> AllocateDifferenceState() const {
+    return {};
+  }
 
-  /// Given a port descriptor, allocate the vector storage.  The default
+  /// Given a port descriptor, allocates the vector storage.  The default
   /// implementation in this class allocates a BasicVector.  Subclasses can
   /// override to use output vector types other than BasicVector.  The
   /// descriptor must match a port declared via DeclareOutputPort.
@@ -77,12 +123,107 @@ class LeafSystem : public System<T> {
     return std::make_unique<BasicVector<T>>(descriptor.get_size());
   }
 
+  /// Declares that this System has a simple, fixed-period discrete update.
+  /// The first tick will be at t = period_sec, and it will recur at every
+  /// period_sec thereafter. On the discrete tick, the system may update
+  /// the discrete state. Clobbers any other periodic behaviors previously
+  /// declared.
+  /// TODO(david-german-tri): Add more sophisticated mutators for more complex
+  /// periodic behaviors.
+  void DeclareUpdatePeriodSec(const T& period_sec) {
+    DeclarePeriodicUpdate(period_sec, 0.0);
+  }
+
+  /// Declares that this System has a simple, fixed-period discrete update.
+  /// The first tick will be at t= offset_sec, and it will recur at every
+  /// period_sec thereafter. On the discrete tick, the system may update the
+  /// discrete state. Clobbers any other periodc behaviors previously declared.
+  void DeclarePeriodicUpdate(const T& period_sec, const T& offset_sec) {
+    PeriodicEvent<T> event;
+    event.period_sec = period_sec;
+    event.offset_sec = offset_sec;
+    event.event.recipient = this;
+    event.event.action = DiscreteEvent<T>::kUpdateAction;
+    periodic_events_ = {event};
+  }
+
  private:
-  // SystemInterface objects are neither copyable nor moveable.
-  explicit LeafSystem(const System<T>& other) = delete;
-  LeafSystem& operator=(const System<T>& other) = delete;
-  explicit LeafSystem(System<T>&& other) = delete;
-  LeafSystem& operator=(System<T>&& other) = delete;
+  // Aborts for scalar types that are not numeric, since there is no reasonable
+  // definition of "next update time" outside of the real line.
+  //
+  // @tparam T1 SFINAE boilerplate for the scalar type. Do not set.
+  template <typename T1 = T>
+  typename std::enable_if<!is_numeric<T1>::value>::type
+  DoCalcNextUpdateTimeImpl(const Context<T1>& context,
+                           UpdateActions<T1>* events) const {
+    DRAKE_ABORT_MSG(
+        "The default implementation of LeafSystem<T>::DoCalcNextUpdateTime "
+        "only works with types that are drake::is_numeric.");
+  }
+
+  // Computes the next update time across all the scheduled events, for
+  // scalar types that are numeric.
+  //
+  // @tparam T1 SFINAE boilerplate for the scalar type. Do not set.
+  template <typename T1 = T>
+  typename std::enable_if<is_numeric<T1>::value>::type DoCalcNextUpdateTimeImpl(
+      const Context<T1>& context, UpdateActions<T1>* actions) const {
+    T1 min_time =
+        std::numeric_limits<typename Eigen::NumTraits<T1>::Real>::infinity();
+    if (periodic_events_.empty()) {
+      // No discrete update.
+      actions->time = min_time;
+      return;
+    }
+
+    // Find the minimum next sample time across all registered events, and
+    // the set of registered events that will occur at that time.
+    std::vector<const PeriodicEvent<T>*> next_events;
+    for (const PeriodicEvent<T>& event : periodic_events_) {
+      T1 t = GetNextSampleTime(event, context.get_time());
+      if (t < min_time) {
+        min_time = t;
+        next_events = {&event};
+      } else if (t == min_time) {
+        next_events.push_back(&event);
+      }
+    }
+
+    // Write out the events that fire at min_time.
+    actions->time = min_time;
+    for (const PeriodicEvent<T>* event : next_events) {
+      actions->events.push_back(event->event);
+    }
+  }
+
+  // Returns the next sample time for the given @p event.
+  static T GetNextSampleTime(const PeriodicEvent<T>& event,
+                             const T& current_time_sec) {
+    const T& period = event.period_sec;
+    DRAKE_ASSERT(period > 0);
+    const T& offset = event.offset_sec;
+    DRAKE_ASSERT(offset >= 0);
+
+    // If the first sample time hasn't arrived yet, then that is the next
+    // sample time.
+    if (current_time_sec < offset) {
+      return offset;
+    }
+
+    // NOLINTNEXTLINE(build/namespaces): Needed for ADL of floor and ceil.
+    using namespace std;
+
+    // Compute the index in the sequence of samples for the next time to sample.
+    // If the current time is exactly a sample time, use the next index.
+    const T offset_time = current_time_sec - offset;
+    const int64_t prev_k = static_cast<int64_t>(floor(offset_time / period));
+    const int64_t next_k = static_cast<int64_t>(ceil(offset_time / period));
+    const int64_t k = (prev_k == next_k) ? next_k + 1 : next_k;
+    return offset + (k * period);
+  }
+
+  // Periodic Update or Publish events registered on this system.
+  std::vector<PeriodicEvent<T>> periodic_events_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/primitives/CMakeLists.txt
+++ b/drake/systems/framework/primitives/CMakeLists.txt
@@ -14,6 +14,7 @@ drake_install_headers(
   pass_through.h
   pass_through-inl.h
   pid_controller.h
-  time_varying_polynomial_source.h)
+  time_varying_polynomial_source.h
+  zero_order_hold.h)
 
 add_subdirectory(test)

--- a/drake/systems/framework/primitives/test/CMakeLists.txt
+++ b/drake/systems/framework/primitives/test/CMakeLists.txt
@@ -33,3 +33,6 @@ target_link_libraries(multiplexer_test drakeSystemFramework)
 
 drake_add_cc_test(time_varying_polynomial_source_test)
 target_link_libraries(time_varying_polynomial_source_test drakeSystemFramework)
+
+drake_add_cc_test(zero_order_hold_test)
+target_link_libraries(zero_order_hold_test drakeSystemFramework)

--- a/drake/systems/framework/primitives/test/zero_order_hold_test.cc
+++ b/drake/systems/framework/primitives/test/zero_order_hold_test.cc
@@ -1,0 +1,135 @@
+#include "drake/systems/framework/primitives/zero_order_hold.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/system_input.h"
+#include "drake/systems/framework/system_output.h"
+
+#include "gtest/gtest.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+const double kTenHertz = 0.1;
+const int kLength = 3;
+
+template <class T>
+std::unique_ptr<FreestandingInputPort> MakeInput(
+    std::unique_ptr<BasicVector<T>> data) {
+  return std::make_unique<FreestandingInputPort>(std::move(data));
+}
+
+class ZeroOrderHoldTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    hold_ = std::make_unique<ZeroOrderHold<double>>(kTenHertz, kLength);
+    context_ = hold_->CreateDefaultContext();
+    output_ = hold_->AllocateOutput(*context_);
+    context_->SetInputPort(
+        0, MakeInput(BasicVector<double>::Make({1.0, 1.0, 3.0})));
+  }
+
+  std::unique_ptr<System<double>> hold_;
+  std::unique_ptr<Context<double>> context_;
+  std::unique_ptr<SystemOutput<double>> output_;
+};
+
+// Tests that the zero-order hold has one input and one output.
+TEST_F(ZeroOrderHoldTest, Topology) {
+  EXPECT_EQ(1, hold_->get_num_input_ports());
+  EXPECT_EQ(1, context_->get_num_input_ports());
+
+  EXPECT_EQ(1, output_->get_num_ports());
+  EXPECT_EQ(1, hold_->get_num_output_ports());
+
+  EXPECT_FALSE(hold_->has_any_direct_feedthrough());
+}
+
+// Tests that the zero-order hold has difference state.
+TEST_F(ZeroOrderHoldTest, ReservesState) {
+  const VectorBase<double>* xd = context_->get_difference_state(0);
+  ASSERT_NE(nullptr, xd);
+  EXPECT_EQ(kLength, xd->size());
+}
+
+// Tests that the output is the state.
+TEST_F(ZeroOrderHoldTest, Output) {
+  BasicVector<double>* xd = dynamic_cast<BasicVector<double>*>(
+      context_->get_mutable_difference_state(0));
+  xd->get_mutable_value() << 1.0, 3.14, 2.18;
+
+  hold_->EvalOutput(*context_, output_.get());
+
+  const BasicVector<double>* output_vector = output_->get_vector_data(0);
+  ASSERT_NE(nullptr, output_vector);
+  EXPECT_EQ(1.0, output_vector->GetAtIndex(0));
+  EXPECT_EQ(3.14, output_vector->GetAtIndex(1));
+  EXPECT_EQ(2.18, output_vector->GetAtIndex(2));
+}
+
+// Tests that when the current time is exactly on the sampling period, a update
+// is requested in the future.
+TEST_F(ZeroOrderHoldTest, NextUpdateTimeMustNotBeCurrentTime) {
+  // Calculate the next update time.
+  context_->set_time(0.0);
+  UpdateActions<double> actions;
+  double next_t = hold_->CalcNextUpdateTime(*context_, &actions);
+
+  // Check that the time is correct.
+  EXPECT_NEAR(0.1, next_t, 10e-8);
+  EXPECT_EQ(next_t, actions.time);
+
+  // Check that the action is to update.
+  ASSERT_EQ(1, actions.events.size());
+  const DiscreteEvent<double>& event = actions.events[0];
+  EXPECT_EQ(hold_.get(), event.recipient);
+  EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, event.action);
+}
+
+// Tests that when the current time is between updates, a update is requested
+// at the appropriate time in the future.
+TEST_F(ZeroOrderHoldTest, NextUpdateTimeIsInTheFuture) {
+  // Calculate the next update time.
+  context_->set_time(76.32);
+  UpdateActions<double> actions;
+
+  // Check that the time is correct.
+  double next_t = hold_->CalcNextUpdateTime(*context_, &actions);
+  EXPECT_NEAR(76.4, next_t, 10e-8);
+  EXPECT_EQ(next_t, actions.time);
+
+  // Check that the action is to update.
+  ASSERT_EQ(1, actions.events.size());
+  const DiscreteEvent<double>& event = actions.events[0];
+  EXPECT_EQ(hold_.get(), event.recipient);
+  EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, event.action);
+}
+
+// Tests that discrete updates update the state.
+TEST_F(ZeroOrderHoldTest, Update) {
+  // Fire off an update event.
+  DiscreteEvent<double> update_event;
+  update_event.recipient = hold_.get();
+  update_event.action = DiscreteEvent<double>::kUpdateAction;
+
+  std::unique_ptr<DifferenceState<double>> update =
+      hold_->AllocateDifferenceVariables();
+  hold_->EvalDifferenceUpdates(*context_, {update_event}, update.get());
+
+  // Check that the state has been updated to the input.
+  const VectorBase<double>* xd = update->get_difference_state(0);
+  EXPECT_EQ(1.0, xd->GetAtIndex(0));
+  EXPECT_EQ(1.0, xd->GetAtIndex(1));
+  EXPECT_EQ(3.0, xd->GetAtIndex(2));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/zero_order_hold-inl.h
+++ b/drake/systems/framework/primitives/zero_order_hold-inl.h
@@ -1,0 +1,64 @@
+#pragma once
+
+/// @file
+/// Template method implementations for zero_order_hold.h.
+/// Most users should only include that file, not this one.
+/// For background, see http://drake.mit.edu/cxx_inl.html.
+
+#include "drake/systems/framework/primitives/zero_order_hold.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "drake/common/drake_assert.h"
+#include "drake/drakeSystemFramework_export.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/difference_state.h"
+#include "drake/systems/framework/leaf_context.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+ZeroOrderHold<T>::ZeroOrderHold(const T& period_sec, int size) {
+  // TODO(david-german-tri): remove the size parameter from the constructor
+  // once #3109 supporting automatic sizes is resolved.
+  this->DeclareInputPort(kVectorValued, size, kContinuousSampling);
+  this->DeclareOutputPort(kVectorValued, size, kDiscreteSampling);
+  this->DeclareUpdatePeriodSec(period_sec);
+}
+
+template <typename T>
+void ZeroOrderHold<T>::EvalOutput(const Context<T>& context,
+                                  SystemOutput<T>* output) const {
+  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
+  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
+
+  System<T>::GetMutableOutputVector(output, 0) =
+      context.get_difference_state(0)->CopyToVector();
+}
+
+template <typename T>
+void ZeroOrderHold<T>::DoEvalDifferenceUpdates(
+    const Context<T>& context, DifferenceState<T>* difference_state) const {
+  DRAKE_DEMAND(difference_state->size() == 1);
+  difference_state->get_mutable_difference_state(0)->SetFromVector(
+      this->EvalVectorInput(context, 0)->get_value());
+}
+
+template <typename T>
+std::unique_ptr<DifferenceState<T>> ZeroOrderHold<T>::AllocateDifferenceState()
+    const {
+  // The zero-order hold's state is first-order. Its state vector size is the
+  // same as the input (and output) vector size.
+  const int size = System<T>::get_output_port(0).get_size();
+  DRAKE_DEMAND(System<T>::get_input_port(0).get_size() == size);
+  std::vector<std::unique_ptr<BasicVector<T>>> xd;
+  xd.push_back(std::make_unique<BasicVector<T>>(size));
+  return std::make_unique<DifferenceState<T>>(std::move(xd));
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/zero_order_hold.cc
+++ b/drake/systems/framework/primitives/zero_order_hold.cc
@@ -1,0 +1,12 @@
+#include "drake/systems/framework/primitives/zero_order_hold-inl.h"
+
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace systems {
+
+template class DRAKESYSTEMFRAMEWORK_EXPORT ZeroOrderHold<double>;
+template class DRAKESYSTEMFRAMEWORK_EXPORT ZeroOrderHold<AutoDiffXd>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/zero_order_hold.h
+++ b/drake/systems/framework/primitives/zero_order_hold.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/// A ZeroOrderHold block with input `u`, which may be discrete or continuous,
+/// and discrete output `y`, where the y is sampled from u with a fixed period.
+template <typename T>
+class ZeroOrderHold : public LeafSystem<T> {
+ public:
+  /// Constructs a ZeroOrderHold system with the given @p period_sec, over a
+  /// vector-valued input of size @p size.
+  ZeroOrderHold(const T& period_sec, int size);
+
+  // In a zero-order hold, the output depends only on the state, so there is
+  // no direct-feedthrough.
+  bool has_any_direct_feedthrough() const override { return false; }
+
+  /// Sets the output port value to the value that is currently latched in the
+  /// zero-order hold.
+  void EvalOutput(const Context<T>& context,
+                  SystemOutput<T>* output) const override;
+
+ protected:
+  /// Latches the input port into the discrete state.
+  void DoEvalDifferenceUpdates(
+      const Context<T>& context,
+      DifferenceState<T>* difference_state) const override;
+
+  std::unique_ptr<DifferenceState<T>> AllocateDifferenceState() const override;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <vector>
+
 #include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/difference_state.h"
 
 namespace drake {
 namespace systems {
@@ -29,6 +32,18 @@ class State {
     return continuous_state_.get();
   }
 
+  void set_difference_state(std::unique_ptr<DifferenceState<T>> xd) {
+    difference_state_ = std::move(xd);
+  }
+
+  const DifferenceState<T>* get_difference_state() const {
+    return difference_state_.get();
+  }
+
+  DifferenceState<T>* get_mutable_difference_state() {
+    return difference_state_.get();
+  }
+
   // State is not copyable or moveable.
   State(const State& other) = delete;
   State& operator=(const State& other) = delete;
@@ -37,7 +52,7 @@ class State {
 
  private:
   std::unique_ptr<ContinuousState<T>> continuous_state_;
-  // TODO(david-german-tri): Add discrete state variables.
+  std::unique_ptr<DifferenceState<T>> difference_state_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <limits>
 #include <string>
 #include <vector>
@@ -16,7 +17,6 @@
 namespace drake {
 namespace systems {
 
-
 /** @defgroup systems Modeling Dynamical Systems
  * @{
  * @brief Drake uses a Simulink-inspired description of dynamical systems.
@@ -31,17 +31,41 @@ namespace systems {
  * @}
  */
 
+/// A description of a discrete-time event, which is passed from the simulator
+/// to the recipient System's HandleEvent method.
+template <typename T>
+struct DiscreteEvent {
+  enum ActionType {
+    kUnknownAction = 0,  // A default value that causes the handler to abort.
+    kPublishAction = 1,  // On a publish action, state does not change.
+    kUpdateAction = 2,   // On an update action, discrete state may change.
+  };
 
+  /// The system that receives the event.
+  const System<T>* recipient = nullptr;
+  /// The type of action the system must take in response to the event.
+  ActionType action = kUnknownAction;
 
-/// This information is returned along with the next update/sample/event time
-/// and is provided back to the System when that time is reached to ensure that
-/// the correct sampling actions are taken.
-struct SampleActions {
-  /// When the next discrete action is required.
-  double time{std::numeric_limits<double>::quiet_NaN()};
-  // TODO(sherm1) Record (subsystem,eventlist) pairs indicating what is
-  // supposed to happen at that time and providing O(1) access to the
-  // appropriate update/sampler/event handler method.
+  /// An optional callback, supplied by the recipient, to carry out a
+  /// kPublishAction. If nullptr, Publish will be used.
+  std::function<void(const Context<T>&)> do_publish = nullptr;
+
+  /// An optional callback, supplied by the recipient, to carry out a
+  /// kUpdateAction. If nullptr, DoEvalDifferenceUpdates will be used.
+  std::function<void(const Context<T>&, DifferenceState<T>*)> do_update =
+      nullptr;
+};
+
+/// A token that identifies the next sample time at which a System must
+/// perform some actions, and the actions that must be performed.
+template <typename T>
+struct UpdateActions {
+  /// When the System next requires a discrete action. If the System is
+  /// not discrete, time should be set to infinity.
+  T time{std::numeric_limits<T>::quiet_NaN()};
+
+  /// The events that should occur when the sample time arrives.
+  std::vector<DiscreteEvent<T>> events;
 };
 
 /// A superclass template for systems that receive input, maintain state, and
@@ -169,19 +193,25 @@ class System {
   virtual std::unique_ptr<SystemOutput<T>> AllocateOutput(
       const Context<T>& context) const = 0;
 
-  /// This method is invoked by a Simulator at designated meaningful points
-  /// along a trajectory, to allow the executing System a chance to take some
-  /// kind of output action. Typical actions may include terminal output,
-  /// visualization, logging, plotting, and sending messages. Other than
-  /// computational cost, publishing has no effect on the progress of a
-  /// simulation (but see note below).
+  /// Generates side-effect outputs such as terminal output, visualization,
+  /// logging, plotting, and network messages. Other than computational cost,
+  /// publishing has no effect on the progress of a simulation.
+  /// Dispatches to DoPublish.
   ///
-  /// By default Publish() will be called at the start of each continuous
+  /// This method is invoked by the Simulator at the start of each continuous
   /// integration step, after discrete variables have been updated to the values
-  /// they will hold throughout the step. However, a Simulator may allow control
-  /// over the publication rate. Publish() will always be called at the start of
-  /// the first step of a simulation (after initialization) and after the final
-  /// simulation step (after a final update to discrete variables).
+  /// they will hold throughout the step. It will always be called at the start
+  /// of the first step of a simulation (after initialization) and after the
+  /// final simulation step (after a final update to discrete variables).
+  void Publish(const Context<T>& context) const {
+    DiscreteEvent<T> event;
+    event.action = DiscreteEvent<T>::kPublishAction;
+    Publish(context, event);
+  }
+
+  /// Generates the particular side-effect outputs requested by @p event,
+  /// because the sample time requested by @p event has arrived. Dispatches to
+  /// DoPublish by default, or to `event.do_publish` if provided.
   ///
   /// @note When publishing is scheduled at particular times, those times likely
   /// will not coincide with integrator step times. A Simulator may interpolate
@@ -189,37 +219,44 @@ class System {
   /// so that a step begins exactly at the next publication time. In the latter
   /// case the change in step size may affect the numerical result somewhat
   /// since a smaller integrator step produces a more accurate solution.
-  // TODO(sherm1) Provide sample rate option for Publish().
-  void Publish(const Context<T>& context) const {
+  void Publish(const Context<T>& context, const DiscreteEvent<T>& event) const {
     DRAKE_ASSERT_VOID(CheckValidContext(context));
-    DoPublish(context);
+    DRAKE_DEMAND(event.action == DiscreteEvent<T>::kPublishAction);
+    if (event.do_publish == nullptr) {
+      DoPublish(context);
+    } else {
+      event.do_publish(context);
+    }
   }
 
-  /// This method is called to perform discrete updates to the Context, with
-  /// the particular actions to take supplied in `actions`.
-  // TODO(sherm1) Per great suggestion from David German in #3202, this method
-  // should be modified to take a const context and provide a non-const
-  // reference to only the part that is allowed to change. This will likely
-  // require splitting into several APIs since different sample/update/event
-  // actions permit different modifications.
-  void Update(Context<T>* context, const SampleActions& actions) const {
-    DRAKE_ASSERT_VOID(CheckValidContext(*context));
-    DoUpdate(context, actions);
+  /// This method is called to update discrete variables in the @p context
+  /// because the given @p event has arrived.  Dispatches to
+  /// DoEvalDifferenceUpdates by default, or to `event.do_update` if provided.
+  void EvalDifferenceUpdates(const Context<T>& context,
+                            const DiscreteEvent<T>& event,
+                            DifferenceState<T>* difference_state) const {
+    DRAKE_ASSERT_VOID(CheckValidContext(context));
+    DRAKE_DEMAND(event.action == DiscreteEvent<T>::kUpdateAction);
+    if (event.do_update == nullptr) {
+      DoEvalDifferenceUpdates(context, difference_state);
+    } else {
+      event.do_update(context, difference_state);
+    }
   }
 
   /// This method is called by a Simulator during its calculation of the size of
   /// the next continuous step to attempt. The System returns the next time at
   /// which some discrete action must be taken, and records what those actions
-  /// ought to be in the given SampleActions object, which must not be null.
+  /// ought to be in the given UpdateActions object, which must not be null.
   /// Upon reaching that time, the Simulator invokes either a publication
   /// action (with a const Context) or an update action (with a mutable
-  /// Context). The SampleAction object is retained and returned to the System
+  /// Context). The UpdateAction object is retained and returned to the System
   /// when it is time to take the action.
-  double CalcNextSampleTime(const Context<T>& context,
-                            SampleActions* actions) const {
-    // TODO(sherm1) Validate context (at least in Debug).
+  T CalcNextUpdateTime(const Context<T>& context,
+                       UpdateActions<T>* actions) const {
+    DRAKE_ASSERT_VOID(CheckValidContext(context));
     DRAKE_ASSERT(actions != nullptr);
-    DoCalcNextSampleTime(context, actions);
+    DoCalcNextUpdateTime(context, actions);
     return actions->time;
   }
 
@@ -265,12 +302,22 @@ class System {
   }
 
   /// Returns a ContinuousState of the same size as the continuous_state
-  /// allocated in CreateDefaultContext. Solvers will provide this state as the
-  /// output argument to EvalTimeDerivatives.
+  /// allocated in CreateDefaultContext. The simulator will provide this state
+  /// as the output argument to EvalTimeDerivatives.
   ///
   /// By default, allocates no derivatives. Systems with continuous state
   /// variables should override.
   virtual std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const {
+    return nullptr;
+  }
+
+  /// Returns a DifferenceState of the same dimensions as the difference_state
+  /// allocated in CreateDefaultContext. The simulator will provide this state
+  /// as the output argument to Update.
+  /// By default, allocates nothing. Systems with discrete state variables
+  /// should override.
+  virtual std::unique_ptr<DifferenceState<T>> AllocateDifferenceVariables()
+      const {
     return nullptr;
   }
 
@@ -383,8 +430,8 @@ class System {
   const SystemPortDescriptor<T>& DeclareInputPort(PortDataType type, int size,
                                                   SamplingSpec sampling) {
     int port_number = get_num_input_ports();
-    input_ports_.emplace_back(this, kInputPort, port_number, type,
-                              size, sampling);
+    input_ports_.emplace_back(this, kInputPort, port_number, type, size,
+                              sampling);
     return input_ports_.back();
   }
 
@@ -409,8 +456,8 @@ class System {
   const SystemPortDescriptor<T>& DeclareOutputPort(PortDataType type, int size,
                                                    SamplingSpec sampling) {
     int port_number = get_num_output_ports();
-    output_ports_.emplace_back(
-        this, kOutputPort, port_number, type, size, sampling);
+    output_ports_.emplace_back(this, kOutputPort, port_number, type, size,
+                               sampling);
     return output_ports_.back();
   }
 
@@ -468,22 +515,30 @@ class System {
   /// been validated before it is passed to you here.
   virtual void DoPublish(const Context<T>& context) const {}
 
-  /// Implement this method if your System has any difference variables xd,
-  /// mode variables, or sampled input or output ports. The `actions` argument
-  /// specifies what to do and may include difference variable updates, port
-  /// sampling, or execution of event handlers that may make arbitrary changes
-  /// to the Context.
-  virtual void DoUpdate(Context<T>* context,
-                        const SampleActions& actions) const {}
+  /// Updates the @p difference_state on sample events.
+  /// Override it, along with DoCalcNextUpdateTime, if your System has any
+  /// difference variables.
+  ///
+  /// @p difference_state is not a pointer into @p context. It is a separate
+  /// buffer, which the Simulator is responsible for writing back to the @p
+  /// context later.
+  virtual void DoEvalDifferenceUpdates(
+      const Context<T>& context, DifferenceState<T>* difference_state) const {}
 
-  /// Implement this method if your System has any discrete actions which must
+  /// Computes the next time at which this System must perform a discrete
+  /// action.
+  ///
+  /// Override this method if your System has any discrete actions which must
   /// interrupt the continuous simulation. You may assume that the context
-  /// has already been validated and the `actions` pointer is not null.
-  /// The default implemention returns with `actions` having a next sample
-  /// time of Infinity and no actions to take.
-  virtual void DoCalcNextSampleTime(const Context<T>& context,
-                                    SampleActions* actions) const {
-    actions->time = std::numeric_limits<double>::infinity();
+  /// has already been validated and the `actions` pointer is not nullptr.
+  ///
+  /// The default implementation returns with `actions` having a next sample
+  /// time of Infinity and no actions to take.  If you declare actions, you may
+  /// specify custom do_publish and do_update handlers.  If you do not,
+  /// DoPublish and DoEvalDifferenceUpdates will be used by default.
+  virtual void DoCalcNextUpdateTime(const Context<T>& context,
+                                    UpdateActions<T>* actions) const {
+    actions->time = std::numeric_limits<T>::infinity();
   }
 
   /// Causes an InputPort in the @p context to become up-to-date, delegating to

--- a/drake/systems/framework/system_port_descriptor.h
+++ b/drake/systems/framework/system_port_descriptor.h
@@ -13,23 +13,23 @@ class System;
 
 constexpr int kAutoSize = -1;
 
-struct SamplingSpec {
-  typedef enum {
-    kInherited = 0,
-    kContinuous = 1,
-  } Type;
+/// SamplingSpec describes whether a port has inherited, continuous, or
+/// discrete sampling. Since ports in Drake are not actually sampled, this is
+/// only potentially useful for detecting unintended connections at Diagram
+/// connection time.
+// TODO(david-german-tri, sherm1): Consider just getting rid of this.
+typedef enum {
+  kInherited = 0,
+  kContinuous = 1,
+  kDiscrete = 2,
+} SamplingSpec;
 
-  Type type;
-  double period;
+constexpr SamplingSpec kInheritedSampling = SamplingSpec::kInherited;
+constexpr SamplingSpec kContinuousSampling = SamplingSpec::kContinuous;
+constexpr SamplingSpec kDiscreteSampling = SamplingSpec::kDiscrete;
 
-  bool operator==(const SamplingSpec& other) const {
-    return type == other.type && period == other.period;
-  }
-};
-
-constexpr SamplingSpec kInheritedSampling = {SamplingSpec::kInherited, 0.0};
-constexpr SamplingSpec kContinuousSampling = {SamplingSpec::kContinuous, 0.0};
-
+// TODO(david-german-tri): Create separate InputPortDescriptor and
+// OutputPortDescriptor, then get rid of this enum.
 typedef enum {
   kInputPort = 0,
   kOutputPort = 1,

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -36,3 +36,6 @@ target_link_libraries(diagram_context_test drakeSystemFramework)
 
 drake_add_cc_test(cache_test)
 target_link_libraries(cache_test drakeSystemFramework)
+
+drake_add_cc_test(leaf_system_test)
+target_link_libraries(leaf_system_test drakeSystemFramework)

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -1,0 +1,110 @@
+#include "drake/systems/framework/leaf_system.h"
+
+#include <memory>
+#include <stdexcept>
+
+#include <Eigen/Dense>
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_context.h"
+#include "drake/systems/framework/system.h"
+#include "drake/systems/framework/system_output.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+// A shell System to test the default implementations.
+class TestSystem : public LeafSystem<double> {
+ public:
+  TestSystem() {}
+  ~TestSystem() override {}
+
+  std::string get_name() const override { return "TestSystem"; }
+
+  void AddPeriodicUpdate() {
+    const double period = 10.0;
+    const double offset = 5.0;
+    this->DeclarePeriodicUpdate(period, offset);
+  }
+
+  void EvalOutput(const Context<double>& context,
+                  SystemOutput<double>* output) const override {}
+
+  void EvalTimeDerivatives(
+      const Context<double>& context,
+      ContinuousState<double>* derivatives) const override {}
+};
+
+class LeafSystemTest : public ::testing::Test {
+ protected:
+  TestSystem system_;
+  LeafContext<double> context_;
+};
+
+// Tests that if no update events are configured, none are reported.
+TEST_F(LeafSystemTest, NoUpdateEvents) {
+  context_.set_time(25.0);
+  UpdateActions<double> actions;
+  system_.CalcNextUpdateTime(context_, &actions);
+  EXPECT_EQ(std::numeric_limits<double>::infinity(), actions.time);
+  EXPECT_EQ(0, actions.events.size());
+}
+
+// Tests that if the current time is smaller than the offset, the next
+// update time is the offset.
+TEST_F(LeafSystemTest, OFfsetHasNotArrivedYet) {
+  context_.set_time(2.0);
+  UpdateActions<double> actions;
+  system_.AddPeriodicUpdate();
+  system_.CalcNextUpdateTime(context_, &actions);
+
+  EXPECT_EQ(5.0, actions.time);
+  ASSERT_EQ(1, actions.events.size());
+  EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, actions.events[0].action);
+}
+
+// Tests that if the current time is exactly the offset, the next
+// update time is in the future.
+TEST_F(LeafSystemTest, ExactlyAtOffset) {
+  context_.set_time(5.0);
+  UpdateActions<double> actions;
+  system_.AddPeriodicUpdate();
+  system_.CalcNextUpdateTime(context_, &actions);
+
+  EXPECT_EQ(15.0, actions.time);
+  ASSERT_EQ(1, actions.events.size());
+  EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, actions.events[0].action);
+}
+
+// Tests that if the current time is larger than the offset, the next
+// update time is determined by the period.
+TEST_F(LeafSystemTest, OffsetIsInThePast) {
+  context_.set_time(23.0);
+  UpdateActions<double> actions;
+  system_.AddPeriodicUpdate();
+  system_.CalcNextUpdateTime(context_, &actions);
+
+  EXPECT_EQ(25.0, actions.time);
+  ASSERT_EQ(1, actions.events.size());
+  EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, actions.events[0].action);
+}
+
+// Tests that if the current time is exactly an update time, the next update
+// time is in the future.
+TEST_F(LeafSystemTest, ExactlyOnUpdateTime) {
+  context_.set_time(25.0);
+  UpdateActions<double> actions;
+  system_.AddPeriodicUpdate();
+  system_.CalcNextUpdateTime(context_, &actions);
+
+  EXPECT_EQ(35.0, actions.time);
+  ASSERT_EQ(1, actions.events.size());
+  EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, actions.events[0].action);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This includes both difference (numeric) and modal (arbitrary) state.  Add support to LeafSystem for fixed periodic state updates.  Add the ZeroOrderHold primitive as an example use case.

This commit does not add support to the simulator for actually updating discrete state.  It also does not add support to Diagrams for exposing the discrete state of their constituents.

There are a few interesting design points to discuss here.  +@edrumwri for feature review and +@sherm1 for platform review, but we should probably chat f2f before you dive deep into the code.

Fixes #3544 along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3587)
<!-- Reviewable:end -->
