### PR TITLE
Fix more test sign mismatches

### DIFF
--- a/drake/systems/plants/rigid_body_plant/test/rigid_body_tree_lcm_publisher_test.cc
+++ b/drake/systems/plants/rigid_body_plant/test/rigid_body_tree_lcm_publisher_test.cc
@@ -272,8 +272,8 @@ void VerifyDrawMessage(const std::vector<uint8_t>& message_bytes) {
   }
 
   // Ensures both messages have the same length.
-  EXPECT_EQ(expected_message.getEncodedSize(), message_bytes.size());
   int byte_count = expected_message.getEncodedSize();
+  EXPECT_EQ(byte_count, static_cast<int>(message_bytes.size()));
 
   // Serializes the expected message.
   std::vector<uint8_t> expected_message_bytes(byte_count);

--- a/drake/systems/plants/rigid_body_plant/test/viewer_draw_translator_test.cc
+++ b/drake/systems/plants/rigid_body_plant/test/viewer_draw_translator_test.cc
@@ -67,7 +67,7 @@ GTEST_TEST(ViewerDrawTranslatorTests, BasicTest) {
   double time = 0;
   std::vector<uint8_t> message_bytes;
   viewer_draw_translator.Serialize(time, generalized_state, &message_bytes);
-  EXPECT_GT(message_bytes.size(), 0);
+  EXPECT_GT(message_bytes.size(), 0u);
 
   // Verifies that the serialized message is correct. This entails:
   //     (1) manually creating a the correct `drake::lcmt_viewer_draw`
@@ -107,7 +107,7 @@ GTEST_TEST(ViewerDrawTranslatorTests, BasicTest) {
   expected_message.quaternion.push_back(zero_quaternion);
 
   const int byte_count = expected_message.getEncodedSize();
-  EXPECT_EQ(byte_count, message_bytes.size());
+  EXPECT_EQ(byte_count, static_cast<int>(message_bytes.size()));
 
   std::vector<uint8_t> expected_bytes(byte_count);
   expected_message.encode(expected_bytes.data(), 0, byte_count);


### PR DESCRIPTION
Fix some signed/unsigned comparison warnings in `viewer_draw_translator_test.cc` and `rigid_body_tree_lcm_publisher_test.cc`.

See also 0b696701ab06, 0854bc3a8186 and fe4790765811.

@liangfok for feature review, @sherm1 for platform review. (And no, I don't know why these trip on my machine but not CI. AFAICT, gtest should be considered a system header on my machine, so it seems specific to `gcc-4.9.2-6.fc21.x86_64`.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3589)
<!-- Reviewable:end -->
