### PR TITLE
Updated KinematicsCache to provide get_num_positions() and get_num_velocities().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Unreleased: changes on master, not yet released
 
 [//]: # "Altered functionality or APIs."
 ### Changed
+ - [#3605][] Deprecated `KinematicsCache::getNumPositions()` and `KinematicsCache::getNumVelocities()` in favor of `KinematicsCache::get_num_positions()` and `KinematicsCache::get_num_velocities()`.
  - [#3566][] Replaced `number_of_foo()` with `get_num_foo()`.
  - [#3276][] The `measure::execution()` function has been replaced by `MeasureExecutionTime()`.
  - [#3246][] Replaced `RigidBody::hasParent()` with `RigidBody::has_mobilizer_joint()`.

--- a/drake/systems/plants/KinematicsCache.h
+++ b/drake/systems/plants/KinematicsCache.h
@@ -93,8 +93,8 @@ class KinematicsCache {
  public:
   explicit KinematicsCache(
       const std::vector<std::unique_ptr<RigidBody> >& bodies_in)
-      : num_positions(getNumPositions(bodies_in)),
-        num_velocities(getNumVelocities(bodies_in)),
+      : num_positions(get_num_positions(bodies_in)),
+        num_velocities(get_num_velocities(bodies_in)),
         q(Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Zero(num_positions)),
         v(Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Zero(num_velocities)),
         velocity_vector_valid(false) {
@@ -171,7 +171,7 @@ class KinematicsCache {
   transformVelocityMappingToPositionDotMapping(
       const Eigen::MatrixBase<Derived>& mat) const {
     Eigen::Matrix<typename Derived::Scalar, Derived::RowsAtCompileTime,
-                  Eigen::Dynamic> ret(mat.rows(), getNumPositions());
+                  Eigen::Dynamic> ret(mat.rows(), get_num_positions());
     int ret_col_start = 0;
     int mat_col_start = 0;
     for (auto it = bodies.begin(); it != bodies.end(); ++it) {
@@ -195,7 +195,7 @@ class KinematicsCache {
   transformPositionDotMappingToVelocityMapping(
       const Eigen::MatrixBase<Derived>& mat) const {
     Eigen::Matrix<typename Derived::Scalar, Derived::RowsAtCompileTime,
-                  Eigen::Dynamic> ret(mat.rows(), getNumVelocities());
+                  Eigen::Dynamic> ret(mat.rows(), get_num_velocities());
     int ret_col_start = 0;
     int mat_col_start = 0;
     for (auto it = bodies.begin(); it != bodies.end(); ++it) {
@@ -225,8 +225,8 @@ class KinematicsCache {
 
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> getX() const {
     if (hasV()) {
-      Eigen::Matrix<Scalar, Eigen::Dynamic, 1> x(getNumPositions() +
-                                                 getNumVelocities());
+      Eigen::Matrix<Scalar, Eigen::Dynamic, 1> x(get_num_positions() +
+                                                 get_num_velocities());
       x << q, v;
       return x;
     } else {
@@ -244,9 +244,21 @@ class KinematicsCache {
 
   void setJdotVCached(bool jdotV_cached_in) { jdotV_cached = jdotV_cached_in; }
 
-  int getNumPositions() const { return num_positions; }
+  int get_num_positions() const { return num_positions; }
 
-  int getNumVelocities() const { return num_velocities; }
+  // TODO(liang.fok): Remove this deprecated method prior to Release 1.0.
+#ifndef SWIG
+  DRAKE_DEPRECATED("Please use get_num_positions().")
+#endif
+  int getNumPositions() const { return get_num_positions(); }
+
+  int get_num_velocities() const { return num_velocities; }
+
+  // TODO(liang.fok): Remove this deprecated method prior to Release 1.0.
+#ifndef SWIG
+  DRAKE_DEPRECATED("Please use get_num_velocities().")
+#endif
+  int getNumVelocities() const { return get_num_velocities(); }
 
  private:
   void invalidate() {
@@ -260,7 +272,7 @@ class KinematicsCache {
   // that KinematicsCache can request it when needed. See the KinematicsCache
   // constructor where this request is made.
   // See TODO for getNumVelocities.
-  static int getNumPositions(
+  static int get_num_positions(
       const std::vector<std::unique_ptr<RigidBody> >& bodies) {
     auto add_num_positions = [](
         int result, const std::unique_ptr<RigidBody>& body_ptr) -> int {
@@ -271,8 +283,8 @@ class KinematicsCache {
     return std::accumulate(bodies.begin(), bodies.end(), 0, add_num_positions);
   }
 
-  // TODO(amcastro-tri): See TODO for getNumPositions.
-  static int getNumVelocities(
+  // TODO(amcastro-tri): See TODO for get_num_positions.
+  static int get_num_velocities(
       const std::vector<std::unique_ptr<RigidBody> >& bodies) {
     auto add_num_velocities = [](
         int result, const std::unique_ptr<RigidBody>& body_ptr) -> int {

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -452,7 +452,7 @@ Eigen::VectorXd RigidBodyAccelerometer::output(
   VectorXd x = rigid_body_state.getX();
   auto xdd = get_rigid_body_system().dynamics(t, x, u);
   auto const& tree = get_rigid_body_system().getRigidBodyTree();
-  auto v_dot = xdd.bottomRows(rigid_body_state.getNumVelocities());
+  auto v_dot = xdd.bottomRows(rigid_body_state.get_num_velocities());
 
   Vector3d sensor_origin =
       Vector3d::Zero();  // assumes sensor coincides with the frame's origin;

--- a/drake/systems/plants/rigid_body_plant/kinematics_results.cc
+++ b/drake/systems/plants/rigid_body_plant/kinematics_results.cc
@@ -18,12 +18,12 @@ int KinematicsResults<T>::get_num_bodies() const {
 
 template<typename T>
 int KinematicsResults<T>::get_num_positions() const {
-  return kinematics_cache_.getNumPositions();
+  return kinematics_cache_.get_num_positions();
 }
 
 template<typename T>
 int KinematicsResults<T>::get_num_velocities() const {
-  return kinematics_cache_.getNumVelocities();
+  return kinematics_cache_.get_num_velocities();
 }
 
 template<typename T>


### PR DESCRIPTION
The old methods are still present but marked deprecated so all existing downstream code should still compile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3605)
<!-- Reviewable:end -->
