### PR TITLE
Update CLion instructions: how to run clang-format on the current selection

### DIFF
--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -82,10 +82,14 @@ Code formatter settings
 3. Add an entry for clang-format with
 
    * Program: ``clang-format``
-   * Parameters: ``-i $FilePath$``
-   * Working directory : ``$ProjectFileDir$/..``
+   * Parameters (whole file): ``-i $FileName$``
+   * Parameters (current selection only): 
+     ``-lines $SelectionStartLine$:$SelectionEndLine$ -i $FileName$``
+   * Working directory : ``$FileDir$``
 
-Now you can run this (manually) on any file using Tools > External Tools in the drop down menu.
+Choose one or the other of the parameter settings. Now you can run this
+(manually) on any file using Tools > External Tools in the drop down menu. You
+can also add a keyboard shortcut.
 
 You can also set the coding style through the following steps
 


### PR DESCRIPTION
Provides instructions for making an "external tool" in CLion that runs clang-format just on the current selection rather than the whole file. Also simplified the whole-file version a little.

Thanks to @SeanCurtis-TRI for figuring out the selection magic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3607)
<!-- Reviewable:end -->
