### PR TITLE
Updated Drake-ROS System 1.0 Systems To Use model_instance_id

### DIFF
--- a/drake/automotive/car_simulation.h
+++ b/drake/automotive/car_simulation.h
@@ -132,16 +132,43 @@ void AddFlatTerrainToWorld(
 /**
  * Creates a vehicle system by instantiating PD controllers for the actuators
  * in the model and cascading it with a rigid body system. The expected names
- * of the actuators are "steering", "right_wheel_joint", "left_wheel_joint".
+ * of the actuators are "steering", "right_wheel_joint", and "left_wheel_joint".
+ *
+ * Here's a system block diagram:
+ *
+ * <pre>
+ * --------------       ------------------------------------------
+ * |            |       |                  --------------------- |
+ * | Gain Block |  -->  | PD Control Block | Rigid Body System | |
+ * |            |       |                  --------------------- |
+ * --------------       ------------------------------------------
+ * </pre>
+ *
+ * The following gains are hard-coded:
+ *  - Kp steering = 400
+ *  - Kd steering = 80
+ *  - Kp wheel joint = 0
+ *  - Kd wheel joint = 100
+ *
+ * Note that the wheel joint controllers have `Kp = 0`, meaning they are
+ * effectively velocity controllers.
  *
  * @param[in] rigid_body_sys The rigid body system.
+ *
+ * @param[in] steering_kp The desired Kp gain used by the steering controller.
+ *
+ * @param[in] steering_kd The desired Kd gain used by the steering controller.
+ *
+ * @param[in] throttle_k The desired gain used by the throttle controller.
+ *
  * @return The resulting vehicle system.
  */
 DRAKEAUTOMOTIVE_EXPORT
 std::shared_ptr<CascadeSystem<
     Gain<DrivingCommand1, PDControlSystem<RigidBodySystem>::InputVector>,
     PDControlSystem<RigidBodySystem>>>
-CreateVehicleSystem(std::shared_ptr<RigidBodySystem> rigid_body_sys);
+CreateVehicleSystem(std::shared_ptr<RigidBodySystem> rigid_body_sys,
+    double steering_kp = 400, double steering_kd = 80, double throttle_k = 100);
 
 /**
  * Returns the default simulation options for car simulations. The default

--- a/drake/automotive/models/prius/prius_with_lidar.sdf
+++ b/drake/automotive/models/prius/prius_with_lidar.sdf
@@ -1,7 +1,7 @@
 <?xml version='1.0' ?>
 
 <sdf version='1.6'>
-  <model name='prius_1'>
+  <model name='Prius'>
     <pose>0 0 0 0 0 0</pose>
 
     <link name='chassis_floor'>
@@ -417,7 +417,7 @@
         <geometry>
           <mesh>
             <!-- <uri>prius.dae</uri> -->
-            <uri>prius.dae</uri>
+            <uri>package://drake/drake/automotive/models/prius/prius.dae</uri>
           </mesh>
         </geometry>
         <material>

--- a/drake/doc/from_source_ros.rst
+++ b/drake/doc/from_source_ros.rst
@@ -235,4 +235,4 @@ To drive the vehicle around in simulation, open another terminal and execute::
 
     cd ~/dev/drake_catkin_workspace
     source devel/setup.bash
-    rosrun ackermann_drive_teleop ackermann_drive_keyop.py 1.0 0.7
+    rosrun ackermann_drive_teleop ackermann_drive_keyop.py 1.0 0.7 /drake/ackermann_cmd

--- a/ros/drake_cars_examples/CMakeLists.txt
+++ b/ros/drake_cars_examples/CMakeLists.txt
@@ -4,7 +4,13 @@ project(drake_cars_examples)
 set(CMAKE_CXX_STANDARD 14)
 
 ## Finds the required macros and libraries.
-find_package(catkin REQUIRED COMPONENTS roscpp tf sensor_msgs drake_ros_systems)
+find_package(catkin REQUIRED COMPONENTS
+  drake_ros_common
+  drake_ros_systems
+  roscpp
+  tf
+  rosgraph_msgs
+  sensor_msgs)
 
 
 # Assuming drake is being built in the same workspace, which builds eigen into
@@ -41,3 +47,13 @@ target_link_libraries(single_car_in_stata_garage
   drakeJoints
   drakeRigidBodyConstraint
   lcm)
+
+if (CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  include_directories(${CMAKE_INSTALL_PREFIX}/include)
+  add_rostest_gtest(single_car_in_stata_garage_test
+      test/single_car_in_stata_garage_test.test
+      test/single_car_in_stata_garage_test.cc)
+  target_link_libraries(single_car_in_stata_garage_test ${catkin_LIBRARIES})
+  set_target_properties(single_car_in_stata_garage_test PROPERTIES EXCLUDE_FROM_ALL FALSE)
+endif()

--- a/ros/drake_cars_examples/README.md
+++ b/ros/drake_cars_examples/README.md
@@ -8,7 +8,7 @@ workspace](http://drake.mit.edu/from_source_ros.html).
 Demo 1: Single Car in MIT Stata Garage
 ======================================
 
-To run this demo, open two termainals. In the first terminal, execute the
+To run this demo, open two terminals. In the first terminal, execute the
 following command to launch Drake and RViz. The simulation runs in
 Drake while RViz serves as the visualizer.
 
@@ -26,8 +26,17 @@ $ rosrun ackermann_drive_teleop ackermann_drive_keyop.py 1.0 0.7 /drake/ackerman
 You can now type arrow keys in your second terminal to issue driving commands to
 the simulated vehicle.
 
+Unit Tests
+----------
+
+To run a unit tests for Demo 1:
+
+```
+$ rostest drake_cars_examples single_car_in_stata_garage_test.test
+```
+
 Tuning Tips
------------
+===========
 
 There are several parameters that impact the stability of the vehicle and
 simulation. These parameters are loaded onto the ROS parameter server and can

--- a/ros/drake_cars_examples/README.md
+++ b/ros/drake_cars_examples/README.md
@@ -1,0 +1,47 @@
+Drake / ROS Car Simulation README
+=================================
+
+This README provides details about and instructions on how to run Drake's car
+demonstrations. It assumes you have [installed Drake within a ROS Catkin
+workspace](http://drake.mit.edu/from_source_ros.html).
+
+Demo 1: Single Car in MIT Stata Garage
+======================================
+
+To run this demo, open two termainals. In the first terminal, execute the
+following command to launch Drake and RViz. The simulation runs in
+Drake while RViz serves as the visualizer.
+
+```
+$ roslaunch drake_cars_examples single_car_in_stata_garage.launch
+```
+
+In the second terminal, execute the following command to launch an application
+that allows you to issue driving commands to the simulated vehicle:
+
+```
+$ rosrun ackermann_drive_teleop ackermann_drive_keyop.py 1.0 0.7 /drake/ackermann_cmd
+```
+
+You can now type arrow keys in your second terminal to issue driving commands to
+the simulated vehicle.
+
+Tuning Tips
+-----------
+
+There are several parameters that impact the stability of the vehicle and
+simulation. These parameters are loaded onto the ROS parameter server and can
+be changed in
+`drake_cars_examples/launch/single_car_in_stata_garage.launch`. Below are
+descriptions of these parameters.
+
+Contacts are modeled using virtual springs. The stiffness and damping gains of
+these springs can be set by modifying parameters "penetration_stiffness" and
+"penetration_damping".
+
+The steering and throttle of the vehicle are PD controlled. The gains of these
+controllers can be tweaked using parameters "steering_kp", "steering_kd", and
+"throttle_k".
+
+The initial time step using by the simulation's "solver" is set by parameter
+"initial_step_size".

--- a/ros/drake_cars_examples/launch/rviz.xml
+++ b/ros/drake_cars_examples/launch/rviz.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" ?>
 <launch>
-	<!-- declare arg to be passed in -->
-  	<arg name="RVizConfigFile" />
+    <!-- declare arg to be passed in -->
+    <arg name="RVizConfigFile" />
+
+    <!-- This tells RViz to use simulation time rather than wall clock time. -->
+    <param name="use_sim_time" type="bool" value="true" />
 
     <!-- Set parameters used by the joint state publisher. -->
     <!--  <param name="use_gui" value="True"/> -->
-    <!-- <param name="use_sim_time" value="false"/> -->
 
     <!-- <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" /> -->
     <!-- <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" /> -->

--- a/ros/drake_cars_examples/launch/single_car_in_stata_garage.launch
+++ b/ros/drake_cars_examples/launch/single_car_in_stata_garage.launch
@@ -6,13 +6,6 @@ To run it:
   $ roslaunch drake_cars_examples single_car_in_stata_garage.launch
 -->
 <launch>
-  <include file="$(find drake_cars_examples)/launch/drake_common.xml" />
-  <include file="$(find drake_cars_examples)/launch/single_car_in_stata_garage_desc.xml" />
+  <include file="$(find drake_cars_examples)/launch/single_car_in_stata_garage_drake.xml" />
   <include file="$(find drake_cars_examples)/launch/single_car_in_stata_garage_rviz.xml" />
-
-  <node name="single_car_in_stata_garage" pkg="drake_cars_examples"
-    type="single_car_in_stata_garage" output="screen"
-    args="$(find drake)/drake/automotive/models/prius/prius_with_lidar.sdf $(find drake)/drake/automotive/models/stata_garage_p1.sdf"/>
-
-  <include file="$(find drake_cars_examples)/launch/golfcart_adapter.launch" />
 </launch>

--- a/ros/drake_cars_examples/launch/single_car_in_stata_garage_drake.xml
+++ b/ros/drake_cars_examples/launch/single_car_in_stata_garage_drake.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<!--
+This is the main launch file for the single car in MIT Stata garage demo.
+To run it:
+
+  $ roslaunch drake_cars_examples single_car_in_stata_garage.launch
+-->
+<launch>
+  <include file="$(find drake_cars_examples)/launch/drake_common.xml" />
+  <include file="$(find drake_cars_examples)/launch/single_car_in_stata_garage_desc.xml" />
+
+  <group ns="drake">
+    <param name="penetration_stiffness" type="double" value="5000" />
+    <param name="penetration_damping" type="double" value="500" />
+    <param name="steering_kp" type="double" value="1000" />
+    <param name="steering_kd" type="double" value="250" />
+    <param name="throttle_k" type="double" value="100" />
+    <param name="initial_step_size" type="double" value="0.005" />
+
+    <param
+        name="car_filename"
+        type="string"
+        value="$(find drake)/drake/automotive/models/prius/prius_with_lidar.sdf" />
+    <param
+        name="world_filename"
+        type="string"
+        value="$(find drake)/drake/automotive/models/stata_garage_p1.sdf" />
+
+    <node
+        name="single_car_in_stata_garage"
+        pkg="drake_cars_examples"
+        type="single_car_in_stata_garage"
+        output="screen"
+    />
+  </group>
+
+  <!-- <include file="$(find drake_cars_examples)/launch/golfcart_adapter.launch" /> -->
+</launch>

--- a/ros/drake_cars_examples/package.xml
+++ b/ros/drake_cars_examples/package.xml
@@ -28,9 +28,13 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>drake_ros_common</build_depend>
   <build_depend>drake_ros_systems</build_depend>
+
   <exec_depend>drake_ros_systems</exec_depend>
 </package>

--- a/ros/drake_cars_examples/rviz/single_car_in_stata_garage.rviz
+++ b/ros/drake_cars_examples/rviz/single_car_in_stata_garage.rviz
@@ -6,7 +6,6 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
-        - /RobotModel1
         - /RobotModel1/Links1
         - /Axes1
         - /LaserScan2
@@ -15,8 +14,9 @@ Panels:
         - /Odometry1
         - /TF1/Frames1
         - /WorldModel1
-      Splitter Ratio: 0.631791
-    Tree Height: 1093
+        - /WorldModel1/Status1
+      Splitter Ratio: 0.64658
+    Tree Height: 905
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -134,7 +134,7 @@ Visualization Manager:
           Value: true
       Name: RobotModel
       Robot Description: robot_description
-      TF Prefix: ""
+      TF Prefix: prius
       Update Interval: 0
       Value: true
       Visual Enabled: true
@@ -178,8 +178,8 @@ Visualization Manager:
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
-        Max Value: 1.42027
-        Min Value: -0.00832754
+        Max Value: 1.42044
+        Min Value: -0.00809033
         Value: true
       Axis: Z
       Channel Name: intensity
@@ -200,7 +200,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.25
       Style: Spheres
-      Topic: /drake/prius_1/lidar/top_laser
+      Topic: /drake/prius/lidar/top_laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -208,8 +208,8 @@ Visualization Manager:
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
-        Max Value: 0.510779
-        Min Value: 0.430399
+        Max Value: 0.510609
+        Min Value: 0.431049
         Value: true
       Axis: Z
       Channel Name: intensity
@@ -230,7 +230,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.25
       Style: Flat Squares
-      Topic: /drake/prius_1/lidar/rear_left_laser
+      Topic: /drake/prius/lidar/rear_left_laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -238,8 +238,8 @@ Visualization Manager:
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
-        Max Value: 0.502356
-        Min Value: 0.43039
+        Max Value: 0.50296
+        Min Value: 0.431042
         Value: true
       Axis: Z
       Channel Name: intensity
@@ -260,7 +260,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.25
       Style: Flat Squares
-      Topic: /drake/prius_1/lidar/rear_right_laser
+      Topic: /drake/prius/lidar/rear_right_laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -273,82 +273,68 @@ Visualization Manager:
       Length: 1
       Name: Odometry
       Position Tolerance: 0.1
-      Topic: /drake/prius_1/odometry
+      Topic: /drake/prius/odometry
       Value: true
     - Class: rviz/TF
       Enabled: true
       Frame Timeout: 15
       Frames:
         All Enabled: false
-        body:
+        prius/body:
           Value: true
-        chassis_floor:
+        prius/chassis_floor:
           Value: true
-        front_axle:
+        prius/front_axle:
           Value: true
-        front_laser:
+        prius/front_laser:
           Value: true
-        front_lidar:
+        prius/front_lidar_link:
           Value: true
-        front_lidar_link:
+        prius/left_hub:
           Value: true
-        front_top_lidar:
+        prius/left_tie_rod_arm:
           Value: true
-        golfcartdj/base_link:
+        prius/left_wheel:
           Value: true
-        golfcartdj/map:
+        prius/left_wheel_rear:
           Value: true
-        golfcartdj/odom:
+        prius/rear_axle:
           Value: true
-        ground:
+        prius/rear_left_laser:
           Value: true
-        left_hub:
+        prius/rear_left_lidar_link:
           Value: true
-        left_tie_rod_arm:
+        prius/rear_right_laser:
           Value: true
-        left_wheel:
+        prius/rear_right_lidar_link:
           Value: true
-        left_wheel_rear:
+        prius/right_hub:
           Value: true
-        outer_wall:
+        prius/right_pinFrameA:
           Value: true
-        rear_axle:
+        prius/right_pinFrameB:
           Value: true
-        rear_left_laser:
+        prius/right_tie_rod_arm:
           Value: true
-        rear_left_lidar:
+        prius/right_wheel:
           Value: true
-        rear_left_lidar_link:
+        prius/right_wheel_rear:
           Value: true
-        rear_right_laser:
+        prius/tie_rod:
           Value: true
-        rear_right_lidar:
+        prius/top_laser:
           Value: true
-        rear_right_lidar_link:
+        prius/top_lidar_link:
           Value: true
-        right_hub:
+        stata_garage/ground:
           Value: true
-        right_pinFrameA:
+        stata_garage/outer_wall:
           Value: true
-        right_pinFrameB:
+        stata_garage/stairs:
           Value: true
-        right_tie_rod_arm:
+        stata_garage/stairs_groundFrameA:
           Value: true
-        right_wheel:
-          Value: true
-        right_wheel_rear:
-          Value: true
-        stairs:
-          Value: true
-        stairs_groundFrameA:
-          Value: true
-        stairs_groundFrameB:
-          Value: true
-        tie_rod:
-          Value: true
-        top_laser:
-          Value: true
-        top_lidar_link:
+        stata_garage/stairs_groundFrameB:
           Value: true
         world:
           Value: true
@@ -359,57 +345,46 @@ Visualization Manager:
       Show Names: true
       Tree:
         world:
-          chassis_floor:
-            body:
+          prius/chassis_floor:
+            prius/body:
               {}
-            front_axle:
-              left_tie_rod_arm:
-                left_hub:
-                  left_wheel:
+            prius/front_axle:
+              prius/left_tie_rod_arm:
+                prius/left_hub:
+                  prius/left_wheel:
                     {}
-                tie_rod:
-                  right_pinFrameB:
+                prius/tie_rod:
+                  prius/right_pinFrameB:
                     {}
-              right_tie_rod_arm:
-                right_hub:
-                  right_wheel:
+              prius/right_tie_rod_arm:
+                prius/right_hub:
+                  prius/right_wheel:
                     {}
-                right_pinFrameA:
+                prius/right_pinFrameA:
                   {}
-            front_lidar_link:
-              front_laser:
+            prius/front_lidar_link:
+              prius/front_laser:
                 {}
-            rear_axle:
-              left_wheel_rear:
+            prius/rear_axle:
+              prius/left_wheel_rear:
                 {}
-              right_wheel_rear:
+              prius/right_wheel_rear:
                 {}
-            rear_left_lidar_link:
-              rear_left_laser:
+            prius/rear_left_lidar_link:
+              prius/rear_left_laser:
                 {}
-            rear_right_lidar_link:
-              rear_right_laser:
+            prius/rear_right_lidar_link:
+              prius/rear_right_laser:
                 {}
-            top_lidar_link:
-              top_laser:
+            prius/top_lidar_link:
+              prius/top_laser:
                 {}
-          golfcartdj/map:
-            golfcartdj/odom:
-              golfcartdj/base_link:
-                front_lidar:
-                  {}
-                front_top_lidar:
-                  {}
-                rear_left_lidar:
-                  {}
-                rear_right_lidar:
-                  {}
-          ground:
-            outer_wall:
-              stairs_groundFrameB:
+          stata_garage/ground:
+            stata_garage/outer_wall:
+              stata_garage/stairs_groundFrameB:
                 {}
-          stairs:
-            stairs_groundFrameA:
+          stata_garage/stairs:
+            stata_garage/stairs_groundFrameA:
               {}
       Update Interval: 0
       Value: true
@@ -444,7 +419,7 @@ Visualization Manager:
           Show Trail: false
       Name: WorldModel
       Robot Description: world_description
-      TF Prefix: ""
+      TF Prefix: stata_garage
       Update Interval: 0
       Value: true
       Visual Enabled: true
@@ -492,10 +467,10 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1388
+  Height: 1200
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd000000040000000000000238000004d4fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000004d4000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000582fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002800000582000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000a1e0000004cfc0100000002fb0000000800540069006d0065010000000000000a1e000002f600fffffffb0000000800540069006d00650100000000000004500000000000000000000007e0000004d400000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000027800000418fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000418000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000582fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002800000582000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006db0000004cfc0100000002fb0000000800540069006d00650100000000000006db000002f600fffffffb0000000800540069006d006501000000000000045000000000000000000000045d0000041800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -504,6 +479,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 2590
-  X: 220
-  Y: 14
+  Width: 1755
+  X: 55
+  Y: 209

--- a/ros/drake_cars_examples/src/single_car_in_stata_garage.cc
+++ b/ros/drake_cars_examples/src/single_car_in_stata_garage.cc
@@ -1,12 +1,19 @@
+#include <cmath>
+
 #include "ros/ros.h"
+#include "ros/console.h"
+
+#include "rosgraph_msgs/Clock.h"
 
 #include "drake/automotive/car_simulation.h"
 #include "drake/automotive/gen/driving_command.h"
-#include "drake/ros/systems/ros_tf_publisher.h"
-#include "drake/ros/systems/ros_vehicle_system.h"
+#include "drake/ros/simulation_abort_function.h"
+#include "drake/ros/systems/ros_clock_publisher.h"
 #include "drake/ros/systems/ros_sensor_publisher_joint_state.h"
 #include "drake/ros/systems/ros_sensor_publisher_lidar.h"
 #include "drake/ros/systems/ros_sensor_publisher_odometry.h"
+#include "drake/ros/systems/ros_tf_publisher.h"
+#include "drake/ros/systems/ros_vehicle_system.h"
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/LinearSystem.h"
 #include "drake/systems/pd_control_system.h"
@@ -25,60 +32,137 @@ namespace ros {
 namespace automotive {
 namespace {
 
-using drake::automotive::CreateRigidBodySystem;
 using drake::automotive::CreateVehicleSystem;
 using drake::automotive::GetCarSimulationDefaultOptions;
 using drake::automotive::ParseDuration;
+using drake::automotive::SetRigidBodySystemParameters;
 
-using drake::ros::systems::DrakeRosTfPublisher;
+using drake::parsers::ModelInstanceIdTable;
+
+using drake::ros::systems::RosTfPublisher;
+using drake::ros::systems::RosClockPublisher;
+using drake::ros::systems::RosSensorPublisherJointState;
+using drake::ros::systems::RosSensorPublisherLidar;
+using drake::ros::systems::RosSensorPublisherOdometry;
+
 using drake::ros::systems::run_ros_vehicle_sim;
-using drake::ros::systems::SensorPublisherJointState;
-using drake::ros::systems::SensorPublisherLidar;
-using drake::ros::systems::SensorPublisherOdometry;
 
-/** Driving Simulator
- * Usage:  car_sim_lcm_and_ros vehicle_model_file [world_model files ...]
- */
+using drake::systems::plants::joints::kFixed;
+using drake::systems::plants::joints::kQuaternion;
+
+
+// Initializes the RigidBodySystem by setting the collision gains, adding the
+// vehicle model, and adding the world model to @p rigid_body_system.
+ModelInstanceIdTable InitRigidBodySystem(RigidBodySystem* rigid_body_system) {
+  // Sets the desired contact penetration stiffness and damping gains in the
+  // RigidBodySystem. This is done by first setting them to be the default
+  // values and then reading the values off the ROS parameter server.
+  SetRigidBodySystemParameters(rigid_body_system);
+  rigid_body_system->penetration_stiffness =
+      GetRosParameterOrThrow<double>("penetration_stiffness");
+  rigid_body_system->penetration_damping =
+      GetRosParameterOrThrow<double>("penetration_damping");
+
+  // Adds the vehicle model instance to the RigidBodySystem.
+  std::string vehicle_filename =
+      GetRosParameterOrThrow<std::string>("car_filename");
+
+  ModelInstanceIdTable vehicle_instance_id_table =
+      rigid_body_system->AddModelInstanceFromFile(vehicle_filename,
+          kQuaternion);
+
+  // Verifies that only one vehicle was added to the world.
+  if (vehicle_instance_id_table.size() != 1) {
+    throw std::runtime_error(
+        "More than one vehicle model was added to the world.");
+  }
+
+  // Instantiates a model_instance_id_table and saves the vehicle's model
+  // instance ID in the table.
+  ModelInstanceIdTable model_instance_id_table = vehicle_instance_id_table;
+
+  // Adds the world to the RigidBodySystem. Updates model_instance_id_table
+  // with the ID of the world model.
+  std::string world_filename =
+      GetRosParameterOrThrow<std::string>("world_filename");
+  ModelInstanceIdTable world_instance_id_table =
+      rigid_body_system->AddModelInstanceFromFile(world_filename,
+          kFixed);
+  drake::parsers::AddModelInstancesToTable(world_instance_id_table,
+      &model_instance_id_table);
+
+  return model_instance_id_table;
+}
+
+// This implements the main method of the single car simulation. The vehicle
+// resides within the Stata garage.
 int do_main(int argc, const char* argv[]) {
   ::ros::init(argc, const_cast<char**>(argv), "single_car_in_stata_garage");
+  ::ros::start();
 
-  // Initializes the communication layer.
-  std::shared_ptr<lcm::LCM> lcm = std::make_shared<lcm::LCM>();
-
-  // Instantiates a duration variable that will be set by the call to
-  // CreateRigidBodySystem() below.
-  double duration = std::numeric_limits<double>::infinity();
-
-  // Instantiates a data structure that maps model instance names to their model
-  // instance IDs.
-  drake::parsers::ModelInstanceIdTable model_instances;
+  // Sets the log level to be INFO.
+  if (::ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME,
+                                       ::ros::console::levels::Info)) {
+    ::ros::console::notifyLoggerLevelsChanged();
+  }
 
   // Initializes the rigid body system.
-  auto rigid_body_sys = CreateRigidBodySystem(argc, argv, &duration,
-      &model_instances);
+  auto rigid_body_sys = std::allocate_shared<RigidBodySystem>(
+      Eigen::aligned_allocator<RigidBodySystem>());
+
+  ModelInstanceIdTable model_instance_id_table =
+      InitRigidBodySystem(rigid_body_sys.get());
 
   auto const& tree = rigid_body_sys->getRigidBodyTree();
 
-  // Initializes and cascades all of the other systems.
-  auto vehicle_sys = CreateVehicleSystem(rigid_body_sys);
+  // Instantiates a map that converts model instance IDs to model instance
+  // names.
+  std::map<int, std::string> model_instance_name_table;
+  // TODO(liang.fok): Once #3088 is resolved, include the model instance ID and
+  // name of the world in model_instance_name_table.
+  model_instance_name_table[model_instance_id_table["prius_1"]] = "prius";
+  model_instance_name_table[model_instance_id_table["P1"]] = "stata_garage";
 
+  std::map<int, std::string> model_instance_name_table_odometry;
+  model_instance_name_table_odometry[model_instance_id_table["prius_1"]]
+      = "prius";
+
+  // Obtains the gains to be used by the steering and throttle controllers.
+  double steering_kp = GetRosParameterOrThrow<double>("steering_kp");
+  double steering_kd = GetRosParameterOrThrow<double>("steering_kd");
+  double throttle_k = GetRosParameterOrThrow<double>("throttle_k");
+
+  // Initializes and cascades all of the other systems.
+
+  // Wraps the RigidBodySystem within a PD control system that adds PD
+  // controllers for each actuator within the RigidBodySystem. It then cascades
+  // the PD control system block behind a gain block and returns the resulting
+  // cascade.
+  auto vehicle_sys = CreateVehicleSystem(rigid_body_sys, steering_kp,
+      steering_kd, throttle_k);
+
+  std::shared_ptr<lcm::LCM> lcm = std::make_shared<lcm::LCM>();
   auto visualizer =
       std::make_shared<BotVisualizer<RigidBodySystem::StateVector>>(lcm, tree);
 
   auto lidar_publisher = std::make_shared<
-      SensorPublisherLidar<RigidBodySystem::StateVector>>(
-      rigid_body_sys);
+      RosSensorPublisherLidar<RigidBodySystem::StateVector>>(
+      rigid_body_sys, model_instance_name_table);
 
   auto odometry_publisher = std::make_shared<
-      SensorPublisherOdometry<RigidBodySystem::StateVector>>(
-      rigid_body_sys);
+      RosSensorPublisherOdometry<RigidBodySystem::StateVector>>(
+      rigid_body_sys, model_instance_name_table_odometry);
 
   auto tf_publisher = std::make_shared<
-      DrakeRosTfPublisher<RigidBodySystem::StateVector>>(tree);
+      RosTfPublisher<RigidBodySystem::StateVector>>(tree,
+          model_instance_name_table);
 
   auto joint_state_publisher = std::make_shared<
-      SensorPublisherJointState<RigidBodySystem::StateVector>>(
-      rigid_body_sys);
+      RosSensorPublisherJointState<RigidBodySystem::StateVector>>(
+      rigid_body_sys, model_instance_name_table);
+
+  auto clock_publisher =
+      std::make_shared<RosClockPublisher<RigidBodySystem::StateVector>>();
 
   auto sys =
       cascade(
@@ -86,17 +170,20 @@ int do_main(int argc, const char* argv[]) {
           cascade(
             cascade(
               cascade(
-                vehicle_sys, visualizer),
-              lidar_publisher),
-            odometry_publisher),
-          tf_publisher),
-        joint_state_publisher);
+                cascade(
+                  vehicle_sys, visualizer),
+                lidar_publisher),
+              odometry_publisher),
+            tf_publisher),
+          joint_state_publisher),
+        clock_publisher);
 
   // Initializes the simulation options.
   SimulationOptions options = GetCarSimulationDefaultOptions();
-  options.should_stop = [](double sim_time) {
-    return !::ros::ok();
-  };
+  AddAbortFunction(&options);
+
+  options.initial_step_size =
+      GetRosParameterOrThrow<double>("initial_step_size");
 
   // Obtains a valid zero configuration for the vehicle.
   VectorXd x0 = VectorXd::Zero(rigid_body_sys->getNumStates());
@@ -104,6 +191,28 @@ int do_main(int argc, const char* argv[]) {
 
   // Defines the start time of the simulation.
   const double kStartTime = 0;
+
+  ROS_INFO("Obtaining duration...");
+
+  // Instantiates a duration variable. This specifies how long the simulation
+  // will run.
+  double duration = GetRosParameterOrDefault<double>(
+      "simulation_duration", std::numeric_limits<double>::infinity(), 1);
+
+  ROS_INFO_STREAM("Using:" << std::endl
+      << " - duration = " << duration
+      << std::endl
+      << " - penetration_stiffness = " << rigid_body_sys->penetration_stiffness
+      << std::endl
+      << " - penetration_damping = " << rigid_body_sys->penetration_damping
+      << std::endl
+      << "  - steering_kp = " << steering_kp
+      << std::endl
+      << "  - steering_kd = " << steering_kd
+      << std::endl
+      << "  - throttle_k = " << throttle_k
+      << std::endl
+      << "  - initial_step_size = " << options.initial_step_size);
 
   // Starts the simulation.
   run_ros_vehicle_sim(sys, kStartTime, duration, x0, options);

--- a/ros/drake_cars_examples/test/README.md
+++ b/ros/drake_cars_examples/test/README.md
@@ -1,0 +1,11 @@
+To run the single_car_in_stata_garage unit test:
+
+   $ rostest drake_cars_examples single_car_in_stata_garage_test.test
+
+The above will store output in a log file and use a roscore on a random port
+making it difficult to debug.
+
+To debug the unit test:
+
+  $ roscore
+  $ rostest drake_cars_examples single_car_in_stata_garage_test.test --text --reuse-master

--- a/ros/drake_cars_examples/test/single_car_in_stata_garage_test.cc
+++ b/ros/drake_cars_examples/test/single_car_in_stata_garage_test.cc
@@ -54,7 +54,7 @@ GTEST_TEST(DrakeSingleCarInStataGarageTest, BasicTest) {
     ::ros::V_string node_list;
     EXPECT_TRUE(::ros::master::getNodes(node_list));
 
-    for(auto it : node_list) {
+    for (auto it : node_list) {
       std::string node_name = it;
       if (node_name == "/drake/single_car_in_stata_garage")
         drake_node_found = true;

--- a/ros/drake_cars_examples/test/single_car_in_stata_garage_test.cc
+++ b/ros/drake_cars_examples/test/single_car_in_stata_garage_test.cc
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+#include "ros/ros.h"
+#include "sensor_msgs/JointState.h"
+
+namespace drake {
+namespace ros {
+namespace automotive {
+namespace {
+
+typedef std::chrono::milliseconds TimeDuration;
+
+using std::this_thread::sleep_for;
+
+class JointStateCallback {
+ public:
+  JointStateCallback() { }
+
+  void Callback(const sensor_msgs::JointState& msg) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    received_joint_state_ = true;
+  }
+
+  bool received_state() const {
+    bool result{false};
+    std::lock_guard<std::mutex> lock(mutex_);
+    result = received_joint_state_;
+    return result;
+  }
+
+ private:
+  bool received_joint_state_{false};
+  mutable std::mutex mutex_;
+};
+
+
+GTEST_TEST(DrakeSingleCarInStataGarageTest, BasicTest) {
+  EXPECT_TRUE(::ros::master::check());
+
+  // Verifies that the ROS node running the Drake simulation exists. It loops
+  // searching for the a ROS node called "/drake/single_car_in_stata_garage".
+  // If it fails to find such a node, it sleeps for 100 milliseconds of wall
+  // clock time before trying again. Wall clock time is used to prevent the
+  // following loop from live locking when the simulation fails to start and
+  // does not publish the simulated clock time.
+  bool drake_node_found{false};
+  int num_tries = 0;
+
+  while (!drake_node_found && num_tries++ < 10) {
+    ::ros::V_string node_list;
+    EXPECT_TRUE(::ros::master::getNodes(node_list));
+
+    for(auto it : node_list) {
+      std::string node_name = it;
+      if (node_name == "/drake/single_car_in_stata_garage")
+        drake_node_found = true;
+    }
+
+    if (!drake_node_found)
+      sleep_for(TimeDuration(100));  // Sleeps for 100 milliseconds.
+    ::ros::spinOnce();
+  }
+
+  EXPECT_TRUE(drake_node_found);
+
+  // Verifies that the Drake simulator is publishing `sensor_msgs::JointState`
+  // messages on ROS topic `/drake/prius/joint_state`. This is used as an
+  // indicator that the simulation is running.
+  JointStateCallback callback;
+  ::ros::NodeHandle node_handle;
+  ::ros::Subscriber subscriber =
+      node_handle.subscribe("/drake/prius/joint_state", 100 /* queue size */,
+                            &JointStateCallback::Callback, &callback);
+
+  int num_publishers{0};
+  while (num_publishers == 0 && num_tries++ < 5) {
+    num_publishers = subscriber.getNumPublishers();
+    if (num_publishers == 0)
+      sleep_for(TimeDuration(1000));  // Sleeps for 1000 milliseconds.
+  }
+  EXPECT_EQ(subscriber.getNumPublishers(), 1);
+
+  bool received_state{false};
+  num_tries = 0;
+  while (!received_state && num_tries++ < 5) {
+    ::ros::spinOnce();
+    received_state = callback.received_state();
+    if (!received_state)
+      sleep_for(TimeDuration(1000));  // Sleeps for 1000 milliseconds.
+  }
+
+  EXPECT_TRUE(received_state);
+}
+
+}  // namespace
+}  // namespace automotive
+}  // namespace ros
+}  // namespace drake
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "single_car_in_stata_garage_test");
+  return RUN_ALL_TESTS();
+}

--- a/ros/drake_cars_examples/test/single_car_in_stata_garage_test.test
+++ b/ros/drake_cars_examples/test/single_car_in_stata_garage_test.test
@@ -1,0 +1,5 @@
+<launch>
+  <param name="drake/simulation_duration" type="double" value="10" />
+  <include file="$(find drake_cars_examples)/launch/single_car_in_stata_garage_drake.xml" />
+  <test pkg="drake_cars_examples" test-name="single_car_in_stata_garage_test" type="single_car_in_stata_garage_test" />
+</launch>

--- a/ros/drake_ros_common/include/drake/ros/parameter_server.h
+++ b/ros/drake_ros_common/include/drake/ros/parameter_server.h
@@ -16,8 +16,8 @@ namespace ros {
  * @param[in] parameter_name The name of the parameter to obtain from the ROS
  * parameter server.
  *
- * @param[in] max_wait_time The maximum amount of time to wait for the parameter
- * to become available before aborting.
+ * @param[in] max_wait_time The maximum amount of wall clock time to wait for
+ * the parameter to become available before returning.
  *
  * @return This method returns true if the parameter comes into existence prior
  * to @p max_wait_time and false otherwise.
@@ -35,12 +35,12 @@ bool WaitForParameter(const std::string& parameter_name,
  * available here: http://wiki.ros.org/Parameter%20Server#Parameter_Types.
  * Currently this method only has test coverage for the following types:
  * `double`, `int`, `bool`, and `std::string`. Notably, the following types
- * are not tested yet: iso8601 dates, lists, and base64-encoded binary data.
+ * are untested: iso8601 dates, lists, and base64-encoded binary data.
  *
  * @param[in] parameter_name The name of the parameter to obtain.
  *
- * @param[in] max_wait_time The maximum time to wait for the parameter to
- * become available on the ROS parameter server.
+ * @param[in] max_wait_time The maximum wall clock time to wait for the
+ * parameter to become available on the ROS parameter server.
  *
  * @returns The value of the parameter.
  *
@@ -69,15 +69,15 @@ T GetRosParameterOrThrow(const std::string& parameter_name,
  * available here: http://wiki.ros.org/Parameter%20Server#Parameter_Types.
  * Currently this method only has test coverage for the following types:
  * `double`, `int`, `bool`, and `std::string`. Notably, the following types
- * are not tested yet: iso8601 dates, lists, and base64-encoded binary data.
+ * are untested: iso8601 dates, lists, and base64-encoded binary data.
  *
  * @param[in] parameter_name The name of the parameter to obtain.
  *
  * @param[in] default_value The value that is returned if the parameter does not
  * exist after waiting @p max_wait_time.
  *
- * @param[in] max_wait_time The maximum time to wait for the parameter to
- * become available on the ROS parameter server.
+ * @param[in] max_wait_time The maximum wall clock time to wait for the
+ * parameter to become available on the ROS parameter server.
  *
  * @returns The value of the parameter, or @p default_value if there was any
  * problem obtaining the parameter.

--- a/ros/drake_ros_common/src/parameter_server.cc
+++ b/ros/drake_ros_common/src/parameter_server.cc
@@ -4,10 +4,12 @@ namespace drake {
 namespace ros {
 
 bool WaitForParameter(const std::string& parameter_name, double max_wait_time) {
-  ::ros::Time begin_time = ::ros::Time::now();
-  while (::ros::ok() && !::ros::param::has(parameter_name)
-      && (::ros::Time::now() - begin_time).toSec() < max_wait_time) {
-    ::ros::Duration(0.1).sleep();  // Sleeps for 1/10 of a second.
+  ::ros::WallTime begin_time = ::ros::WallTime::now();
+  while (::ros::ok() && !::ros::param::has(parameter_name)) {
+    ::ros::WallDuration elapsed_time = ::ros::WallTime::now() - begin_time;
+    if (elapsed_time.toSec() >= max_wait_time)
+      break;
+    ::ros::WallDuration(0.1).sleep();  // Sleeps for 0.1 seconds.
   }
   return ::ros::param::has(parameter_name);
 }

--- a/ros/drake_ros_common_test/package.xml
+++ b/ros/drake_ros_common_test/package.xml
@@ -20,4 +20,5 @@
   <run_depend>drake</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
+
 </package>

--- a/ros/drake_ros_systems/CMakeLists.txt
+++ b/ros/drake_ros_systems/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(drake_ros_systems)
 
-find_package(catkin REQUIRED COMPONENTS roscpp)
+find_package(catkin REQUIRED COMPONENTS
+  drake_ros_common
+  roscpp)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_clock_publisher.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_clock_publisher.h
@@ -1,0 +1,91 @@
+#pragma once
+
+// #include <stdexcept>
+
+// #include <Eigen/Dense>
+
+#include "ros/ros.h"
+#include "rosgraph_msgs/Clock.h"
+
+// #include "drake/systems/System.h"
+// #include "drake/systems/plants/KinematicsCache.h"
+// #include "drake/systems/plants/RigidBodySystem.h"
+// #include "drake/systems/plants/RigidBodyTree.h"
+// #include "drake/systems/vector.h"
+
+using drake::NullVector;
+using drake::RigidBodySensor;
+using drake::RigidBodySystem;
+using drake::RigidBodyDepthSensor;
+
+using Eigen::VectorXd;
+
+namespace drake {
+namespace ros {
+namespace systems {
+
+/**
+ * @brief A system that publishes the current simulation time on ROS topic
+ * /clock.takes the system state as the input and publishes
+ * joint state information onto ROS topics.
+ *
+ * For convenience, the input is passed directly through as an output. This
+ * enables other systems to be cascaded after this system.
+ *
+ * @concept{system_concept}
+ */
+template <template <typename> class RobotStateVector>
+class RosClockPublisher {
+ public:
+  template <typename ScalarType>
+  using StateVector = NullVector<ScalarType>;
+  template <typename ScalarType>
+  using OutputVector = RobotStateVector<ScalarType>;
+  template <typename ScalarType>
+  using InputVector = RobotStateVector<ScalarType>;
+
+  /**
+   * The constructor, which initializes the clock publisher.
+   */
+  RosClockPublisher() {
+    // Instantiates a ROS node handle. For more information, see:
+    // http://wiki.ros.org/rosgraph_msgscpp/Overview/NodeHandles.
+    ::ros::NodeHandle node_handle;
+
+    // Instantiates a ROS topic publisher for publishing clock information. For
+    // more information, see: http://wiki.ros.org/Clock.
+    clock_publisher_ =
+        node_handle.advertise<rosgraph_msgs::Clock>("/clock", 1);
+  }
+
+  StateVector<double> dynamics(const double& t, const StateVector<double>& x,
+                               const InputVector<double>& u) const {
+    return StateVector<double>();
+  }
+
+  OutputVector<double> output(const double& t, const StateVector<double>& x,
+                              const InputVector<double>& u) {
+    // Computes the whole-second portion and the fractional-second portion of
+    // the current simulatoin time @p t.
+    double whole_part, fractional_part;
+    fractional_part = modf(t, &whole_part);
+
+    // Saves the time in the clock message.
+    rosgraph_msgs::Clock clock_msg;
+    clock_msg.clock.sec = static_cast<int>(whole_part);
+    clock_msg.clock.nsec = static_cast<int>(fractional_part * 1e9);
+    clock_publisher_.publish(clock_msg);
+
+    return u;  // Passes the output through to the next system in the cascade.
+  }
+
+  bool isTimeVarying() const { return true; }
+  bool isDirectFeedthrough() const { return true; }
+
+ private:
+  ::ros::Publisher clock_publisher_;
+};
+
+}  // namespace systems
+}  // namespace ros
+}  // namespace drake

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_joint_state.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_joint_state.h
@@ -24,22 +24,22 @@ namespace drake {
 namespace ros {
 namespace systems {
 
-// Holds the objects and data used to extract and publish joint state
-// information for a particular robot.
-struct RobotJointStateStruct {
-  // The name of the robot.
-  std::string robot_name;
+/**
+ * Holds the objects and data needed to extract and publish joint state
+ * information for a particular model instance.
+ */
+struct ModelStateStruct {
+  std::string model_instance_name;
 
-  // The ROS topic publisher for publishing the robot's joint state
-  // information.
+  // The ROS topic publisher for publishing the model instance's joint state
   ::ros::Publisher publisher;
 
-  // The joint state message for the robot.
+  // This message holds the model instance's joint state and is periodically
+  // published.
   std::unique_ptr<sensor_msgs::JointState> message;
 
-  // An index into the message that remembers where in the message
-  // we are saving data.
-  int message_index;
+  // The rigid bodies belonging to this struct's model instance.
+  std::vector<const RigidBody*> rigid_body_list;
 };
 
 /**
@@ -59,7 +59,7 @@ struct RobotJointStateStruct {
  * enables other systems to be cascaded after this system.
  */
 template <template <typename> class RobotStateVector>
-class SensorPublisherJointState {
+class RosSensorPublisherJointState {
  private:
   // Specifies that the odometry messages should be transmitted with a minimum
   // period of 0.05 seconds.
@@ -74,142 +74,44 @@ class SensorPublisherJointState {
   using InputVector = RobotStateVector<ScalarType>;
 
   /**
-   * The constructor.
+   * The constructor, which initializes all internal data structures necessary
+   * to publish joint state information for each model instance in @p
+   * rigid_body_system.
    *
    * @param[in] rigid_body_system The rigid body system whose output contains
    * the joint state information.
+   *
+   * @param[in] model_instance_name_table A mapping from model instance IDs to
+   * model instance names. The instance names are used to name space the ROS
+   * topics on which the `sensor_msgs::JointState` messages are published. This
+   * is necessary since multiple model instances may be simultaneously
+   * simulated.
    */
-  explicit SensorPublisherJointState(
-      std::shared_ptr<RigidBodySystem> rigid_body_system)
+  explicit RosSensorPublisherJointState(
+      std::shared_ptr<RigidBodySystem> rigid_body_system,
+      const std::map<int, std::string>& model_instance_name_table)
       : rigid_body_system_(rigid_body_system) {
     // Initializes the time stamp of the previous transmission to be zero.
     previous_send_time_.sec = 0;
     previous_send_time_.nsec = 0;
 
-    // Instantiates a ROS node handle through which we can interact with ROS.
-    // For more information, see:
-    // http://wiki.ros.org/roscpp/Overview/NodeHandles
-    ::ros::NodeHandle nh;
-
     // Obtains a reference to the world link in the rigid body tree.
     const RigidBody& world = rigid_body_system->getRigidBodyTree()->world();
 
-    // Creates a ROS topic publisher for each robot in the rigid body system.
-    // A robot is defined by any link that's connected to the world via a
-    // non-fixed joint.
-    for (auto const& rigid_body :
-         rigid_body_system->getRigidBodyTree()->bodies) {
-      // Skips the current rigid body if it does not have the world as the
-      // parent.
-      if (!rigid_body->has_as_parent(world)) continue;
+    // Creates a ROS topic publisher and a message for each model instance in
+    // `model_instance_table`.
+    for (const auto& entry : model_instance_name_table) {
+      // Obtains the current model instance's ID, instance name, and list of
+      // rigid bodies.
+      int model_instance_id = entry.first;
+      std::string model_instance_name = entry.second;
+      std::vector<const RigidBody*> rigid_body_list =
+          rigid_body_system->getRigidBodyTree()->FindModelInstanceBodies(
+              model_instance_id);
 
-      // Skips the current rigid body if it's not connected to the world via a
-      // floating joint.
-      if (!rigid_body->getJoint().isFloating()) continue;
-
-      // Creates a joint state message and publisher for the current robot if
-      // they have not already been created. Stores them in
-      // joint_state_publishers_ and joint_state_messages_.
-
-      // Obtains the robot name. The robot's name is used to as the key into the
-      // maps that hold the joint state messages and publishers.
-      const std::string& robot_name = rigid_body->get_model_name();
-
-      if (robot_structs_.find(robot_name) == robot_structs_.end()) {
-        std::unique_ptr<RobotJointStateStruct> robot_struct(
-            new RobotJointStateStruct());
-
-        robot_struct->robot_name = robot_name;
-
-        const std::string topic_name = "drake/" + robot_name + "/joint_state";
-        robot_struct->publisher =
-            nh.advertise<sensor_msgs::JointState>(topic_name, 1);
-
-        robot_struct->message.reset(new sensor_msgs::JointState());
-
-        robot_struct->message->header.frame_id = RigidBodyTree::kWorldName;
-
-        InitJointStateStruct(robot_name, rigid_body_system->getRigidBodyTree(),
-                             robot_struct.get());
-
-        robot_structs_[robot_name] = std::move(robot_struct);
-      } else {
-        throw std::runtime_error(
-            "ERROR: Rigid Body System contains multiple models named \"" +
-            robot_name + "\".");
-      }
-    }
-  }
-
-  /**
-   * Initializes a RobotJointStateStruct for a particular robot.
-   *
-   * @param[in] robot_name The name of the robot.
-   * @param[in] tree The rigid body tree containing the information needed to
-   * initialize the joint state message.
-   * @param[out] robot_struct The struct to initialize.
-   */
-  void InitJointStateStruct(const std::string& robot_name,
-                            const std::shared_ptr<RigidBodyTree>& tree,
-                            RobotJointStateStruct* robot_struct) {
-    if (robot_struct == nullptr) {
-      throw std::runtime_error(
-          "ERROR: InitJointStateMessage: robot_struct "
-          "parameter is nullptr!");
-    }
-
-    // robot_struct->num_positions_ = 0;
-    // robot_struct->num_velocities_ = 0;
-
-    // Iterates through the rigid bodies in the rigid body tree searching for
-    // those that belong to the specified robot. Updates the
-    // RobotJointStateStruct using the robot's rigid bodies.
-    for (auto const& rigid_body : tree->bodies) {
-      if (rigid_body->get_model_name() == robot_name) {
-        const DrakeJoint& joint = rigid_body->getJoint();
-
-        if (joint.getNumPositions() > 0) {
-          // robot_struct->num_positions_ += joint.getNumPositions();
-          // robot_struct->num_velocities_ += joint.getNumVelocities();
-
-          if (joint.isFloating()) {
-            robot_struct->message->name.push_back("floating_x");
-            robot_struct->message->name.push_back("floating_y");
-            robot_struct->message->name.push_back("floating_z");
-            robot_struct->message->name.push_back("floating_roll");
-            robot_struct->message->name.push_back("floating_pitch");
-            robot_struct->message->name.push_back("floating_yaw");
-          } else {
-            // Verifies that the joint has the same number of position versus
-            // velocity DOFs. Throws an exception if this is not true.
-            if (joint.getNumPositions() != joint.getNumVelocities()) {
-              throw std::runtime_error(
-                  "ERROR: Joint \"" + joint.getName() + "\" in robot \"" +
-                  robot_name +
-                  "\" has a different number of positions and velocities.");
-            }
-
-            // Adds the names of the DOFs that belong to the joint to the
-            // message.
-            for (int ii = 0; ii < joint.getNumPositions(); ii++) {
-              robot_struct->message->name.push_back(joint.getPositionName(ii));
-            }
-          }
-        }
-
-        // Resizes the vectors in the message and initialize them to have zero
-        // state.
-        int num_states = robot_struct->message->name.size();
-
-        robot_struct->message->position.resize(num_states);
-        robot_struct->message->velocity.resize(num_states);
-        robot_struct->message->effort.resize(num_states);
-
-        for (int ii = 0; ii < num_states; ii++) {
-          robot_struct->message->position[ii] = 0;
-          robot_struct->message->velocity[ii] = 0;
-          robot_struct->message->effort[ii] = 0;
-        }
+      if (ShouldPublishState(rigid_body_list)) {
+        model_instance_structs_.push_back(
+            CreateJointStateStruct(model_instance_name, rigid_body_list));
       }
     }
   }
@@ -232,112 +134,27 @@ class SensorPublisherJointState {
     const std::shared_ptr<RigidBodyTree>& rigid_body_tree =
         rigid_body_system_->getRigidBodyTree();
 
-    // The input vector u contains the entire system's state. The following
-    // The following code extracts the position and velocity values from it
-    // and computes the kinematic properties of the system.
-    auto uvec = drake::toEigen(u);
-    auto q = uvec.head(rigid_body_tree->get_num_positions());    // position
-    auto v = uvec.segment(rigid_body_tree->get_num_positions(),  // velocity
-                          rigid_body_tree->get_num_velocities());
-    KinematicsCache<double> cache = rigid_body_tree->doKinematics(q, v);
+    // The input vector `u` contains the entire system's state. The following
+    // line of code converts it into an Eigen vector.
+    auto system_state_vector = drake::toEigen(u);
 
-    int q_index = 0;
-    int v_index = 0;
+    // The following code extracts the position and velocity vectors from
+    // system_state_vector and computes the kinematic properties of the system.
+    // These kinematic properties are stored in `cache`, which is then used to
+    // compute the 6-DoF position and velocity states of floating joints.
+    auto position_state_vector =
+        system_state_vector.head(rigid_body_tree->get_num_positions());
 
-    // Resets the message_index variable in each of the RobotJointStateStruct
-    // objects in the robot_structs_ map. This is so we can keep track of where
-    // in the joint state message we are saving.
-    for (auto const& map_entry : robot_structs_) {
-      RobotJointStateStruct* robot_struct = map_entry.second.get();
-      robot_struct->message_index = 0;
-    }
+    auto velocity_state_vector =
+        system_state_vector.segment(rigid_body_tree->get_num_positions(),
+                                    rigid_body_tree->get_num_velocities());
 
-    // Obtains a reference to the world link in the rigid body tree.
-    // const RigidBody& world = rigid_body_tree->world();
+    KinematicsCache<double> kinematics_cache = rigid_body_tree->doKinematics(
+        position_state_vector, velocity_state_vector);
 
-    // Saves the joint state information
-    for (auto const& rigid_body : rigid_body_tree->bodies) {
-      // Skips rigid bodies without a mobilizer joint. This includes the
-      // RigidBody that represents the world.
-      if (!rigid_body->has_parent_body()) continue;
-
-      const DrakeJoint& joint = rigid_body->getJoint();
-
-      // Skips the current rigid body if is connected to another rigid body
-      // via a fixed joint.
-      if (joint.getNumPositions() == 0) continue;
-
-      // Defines the key that can be used to obtain the RobotJointStateStruct
-      // object for the current robot. The key is simply the model name since
-      // there should only be one RobotJointStateStruct per robot.
-      const std::string& key = rigid_body->get_model_name();
-
-      // Verifies that a RobotJointStateStruct for the current robot
-      // exists in the robot_structs_ map.
-      auto robot_struct_in_map = robot_structs_.find(key);
-      if (robot_struct_in_map == robot_structs_.end()) {
-        throw std::runtime_error(
-            "ERROR: SensorPublisherJointState: Unable to find"
-            "robot struct using key " +
-            key);
-      }
-
-      RobotJointStateStruct* robot_struct = robot_struct_in_map->second.get();
-
-      if (joint.getNumPositions() > 0) {
-        if (joint.isFloating()) {
-          auto transform = rigid_body_tree->relativeTransform(
-              cache,
-              rigid_body_tree->FindBodyIndex(
-                  rigid_body->get_parent()->get_name()),
-              rigid_body_tree->FindBodyIndex(rigid_body->get_name()));
-          auto translation = transform.translation();
-          auto rpy = drake::math::rotmat2rpy(transform.linear());
-
-          size_t index = robot_struct->message_index;
-
-          robot_struct->message->position[index++] = translation(0);
-          robot_struct->message->position[index++] = translation(1);
-          robot_struct->message->position[index++] = translation(2);
-
-          robot_struct->message->position[index++] = rpy(0);
-          robot_struct->message->position[index++] = rpy(1);
-          robot_struct->message->position[index++] = rpy(2);
-
-          q_index += joint.getNumPositions();
-          index = robot_struct->message_index;
-
-          for (size_t ii = 0; ii < joint.getNumVelocities(); ii++) {
-            robot_struct->message->velocity[index++] = v[v_index++];
-          }
-
-          robot_struct->message_index = index;
-        } else {
-          // Verifies that the joint has the same number of position versus
-          // velocity DOFs. Throws an exception if this is not true.
-          if (joint.getNumPositions() != joint.getNumVelocities()) {
-            throw std::runtime_error(
-                "ERROR: Joint \"" + joint.getName() + "\" in robot \"" +
-                robot_struct->robot_name +
-                "\" has a different number of positions and velocities.");
-          }
-
-          // Adds the names of the DOFs that belong to the joint to the
-          // message.
-          for (int ii = 0; ii < joint.getNumPositions(); ii++) {
-            size_t index = robot_struct->message_index++;
-            robot_struct->message->position[index] = q[q_index++];
-            robot_struct->message->velocity[index] = v[v_index++];
-          }
-        }
-      }
-    }
-
-    // Publishes the joint state messages.
-    for (auto const& map_entry : robot_structs_) {
-      RobotJointStateStruct* robot_struct = map_entry.second.get();
-      robot_struct->message->header.stamp = current_time;
-      robot_struct->publisher.publish(*(robot_struct->message.get()));
+    for (auto& current_model_info : model_instance_structs_) {
+      UpdateAndPublishJointStateMessage(system_state_vector, kinematics_cache,
+          current_model_info.get());
     }
 
     return u;  // Passes the output through to the next system in the cascade.
@@ -347,14 +164,238 @@ class SensorPublisherJointState {
   bool isDirectFeedthrough() const { return true; }
 
  private:
+  /* Determines whether joint state messages should be published for the
+   * model instance that owns the rigid bodies in @p rigid_body_list. It should
+   * if the model instance contains one or more joints that isn't fixed.
+   */
+  bool ShouldPublishState(
+      const std::vector<const RigidBody*>& rigid_body_list) {
+    bool result = false;
+    for (const auto& rigid_body : rigid_body_list) {
+      if (!rigid_body->getJoint().is_fixed()) {
+        result = true;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Creates and returns a `ModelStateStruct` for a model instance named
+   * @p model_instance_name. The `ModelStateStruct` contains a ROS topic
+   * publisher for publishing the model instance's joint state, a message for
+   * holding the jont state, and a list of rigid bodies that belong to the
+   * model instance.
+   *
+   * @param[in] model_instance_name The model instance's name.
+   *
+   * @param[in] rigid_body_list A list of pointers to `RigidBody` objects that
+   * are part of the model instance specified by @p model_instance_id.
+   *
+   * @returns The newly created `ModelStateStruct` for the model instance
+   * specified by @p model_instance_id.
+   */
+  std::unique_ptr<ModelStateStruct> CreateJointStateStruct(
+      const std::string& model_instance_name,
+      const std::vector<const RigidBody*>& rigid_body_list) {
+    // Instantiates a ModelStateStruct for the current model instance.
+    std::unique_ptr<ModelStateStruct> model_state_info(new ModelStateStruct());
+
+    model_state_info->model_instance_name = model_instance_name;
+    model_state_info->rigid_body_list = rigid_body_list;
+
+    // Instantiates a ROS node handle through which we can interact with ROS.
+    // For more information, see:
+    // http://wiki.ros.org/roscpp/Overview/NodeHandles
+    ::ros::NodeHandle node_handle;
+
+    // Instantiates a ROS topic publisher for publishing the joint state of the
+    // model instance.
+    model_state_info->publisher =
+        node_handle.advertise<sensor_msgs::JointState>(
+            model_instance_name + "/joint_state", 1);
+
+    // Instantiates a message for holding the joint state of the model instance.
+    model_state_info->message.reset(new sensor_msgs::JointState());
+
+    // The message contains information in joint space. Thus it is unclear
+    // what "frame" should be specified here. Perhaps the "frame" should be
+    // "joint"? For now, let's just use the name given to the world.
+    // TODO(liang.fok) Figure out what's the appropriate frame name to use.
+    model_state_info->message->header.frame_id = RigidBodyTree::kWorldName;
+
+    // Iterates through the rigid bodies that belong to the model instance.
+    // For each rigid body, allocate space within the message.
+    for (auto const& rigid_body : rigid_body_list) {
+      const DrakeJoint& joint = rigid_body->getJoint();
+
+      if (joint.getNumPositions() > 0) {
+        if (joint.isFloating()) {
+          // Floating joints have unequal numbers of position (4) vs.
+          // velocity (3) state. Thus, handle them in a special manner.
+          model_state_info->message->name.push_back("floating_x");
+          model_state_info->message->name.push_back("floating_y");
+          model_state_info->message->name.push_back("floating_z");
+          model_state_info->message->name.push_back("floating_roll");
+          model_state_info->message->name.push_back("floating_pitch");
+          model_state_info->message->name.push_back("floating_yaw");
+        } else {
+          // Verifies that the joint has the same number of position and
+          // velocity DOFs. Throws an exception if this is not true.
+          if (joint.getNumPositions() != joint.getNumVelocities()) {
+            throw std::runtime_error(
+                "RosSensorPublisherJointState: ERROR: Joint \"" +
+                joint.getName() + "\" in model instance \"" +
+                model_instance_name +
+                "\" has a different number of positions (" +
+                std::to_string(joint.getNumPositions()) +
+                ") and velocities (" +
+                std::to_string(joint.getNumVelocities())
+                + ").");
+          }
+
+          // Adds the names of the joint's DOFs to the message.
+          for (int ii = 0; ii < joint.getNumPositions(); ++ii) {
+            model_state_info->message->name.push_back(
+                joint.getPositionName(ii));
+          }
+        }
+
+        // Resizes the position, velocity, and effort vectors in the message.
+        // Then initialize them to have zero state.
+        int num_states = model_state_info->message->name.size();
+
+        model_state_info->message->position.resize(num_states);
+        model_state_info->message->velocity.resize(num_states);
+        model_state_info->message->effort.resize(num_states);
+
+        for (int ii = 0; ii < num_states; ++ii) {
+          model_state_info->message->position[ii] = 0;
+          model_state_info->message->velocity[ii] = 0;
+          model_state_info->message->effort[ii] = 0;
+        }
+      }
+    }
+
+    return std::move(model_state_info);
+  }
+
+  /*
+   * Updates the joint state message of a particular model instance, then
+   * publishes it.
+   *
+   * @param[in] system_state_vector The current generalized state of the system.
+   *
+   * @param[in] kinematics_cache The cache of the system's kinematic properties.
+   *
+   * @param[out] current_model_info The structure that contains the publisher
+   * and message for the current model instance.
+   */
+  template <typename ScalarType, int Rows>
+  void UpdateAndPublishJointStateMessage(
+      const Eigen::Matrix<ScalarType, Rows, 1>& system_state_vector,
+      const KinematicsCache<double>& kinematics_cache,
+      ModelStateStruct* current_model_info) {
+    // Defines an index into the joint state message.
+    int joint_state_index = 0;
+
+    // Obtains a pointer to the rigid body tree.
+    const std::shared_ptr<RigidBodyTree>& rigid_body_tree =
+        rigid_body_system_->getRigidBodyTree();
+
+    // Iterates through each of the current model instance's rigid bodies.
+    for (auto& rigid_body : current_model_info->rigid_body_list) {
+      const DrakeJoint& joint = rigid_body->getJoint();
+      if (joint.getNumPositions() > 0) {
+        if (joint.isFloating()) {
+          // The generalized position state of floating joints need to be
+          // converted from quaternion values into roll/pitch/yaw values. The
+          // following code does this.
+          auto transform = rigid_body_tree->relativeTransform(
+              kinematics_cache,
+              rigid_body_tree->FindBodyIndex(
+                  rigid_body->get_parent()->get_name(),
+                  rigid_body->get_parent()->get_model_instance_id()),
+              rigid_body_tree->FindBodyIndex(
+                  rigid_body->get_name(),
+                  rigid_body->get_model_instance_id()));
+          auto translation = transform.translation();
+          auto rpy = drake::math::rotmat2rpy(transform.linear());
+
+          // Saves the floating joint's position state.
+          {
+            int index = joint_state_index;
+
+            current_model_info->message->position[index++] =
+                translation(0);
+            current_model_info->message->position[index++] =
+                translation(1);
+            current_model_info->message->position[index++] =
+                translation(2);
+
+            current_model_info->message->position[index++] = rpy(0);
+            current_model_info->message->position[index++] = rpy(1);
+            current_model_info->message->position[index++] = rpy(2);
+          }
+
+          // Saves the floating joint's velocity state. The velocity state can
+          // be determined directly from the system state vector.
+          {
+            int index = joint_state_index;
+
+            int system_state_velocity_index =
+                rigid_body->get_velocity_start_index();
+
+            for (size_t ii = 0; ii < joint.getNumVelocities(); ++ii) {
+              current_model_info->message->velocity[index++] =
+                  system_state_vector[system_state_velocity_index++];
+            }
+          }
+
+          // Updates joint_state_index to point to the position in the joint
+          // state message after the portion that stores this floating joint's
+          // state.
+          joint_state_index += joint.getNumVelocities();
+        } else {
+          // Verifies that the joint has the same number of position versus
+          // velocity DOFs. Throws an exception if this is not true.
+          if (joint.getNumPositions() != joint.getNumVelocities()) {
+            throw std::runtime_error(
+                "ERROR: Joint \"" + joint.getName() +
+                "\" in model instance \"" +
+                current_model_info->model_instance_name +
+                "\" has a different number of positions and velocities.");
+          }
+
+          int system_state_position_index =
+            rigid_body->get_position_start_index();
+          int system_state_velocity_index =
+            rigid_body->get_velocity_start_index();
+
+          // Adds the names of the DOFs that belong to the joint to the
+          // message.
+          for (int ii = 0; ii < joint.getNumPositions(); ++ii) {
+            current_model_info->message->position[joint_state_index] =
+                system_state_vector[system_state_position_index++];
+            current_model_info->message->velocity[joint_state_index] =
+                system_state_vector[system_state_velocity_index++];
+            ++joint_state_index;
+          }
+        }
+      }
+    }
+
+    // Publishes the joint state message for the current model instance.
+    current_model_info->message->header.stamp = ::ros::Time::now();
+    current_model_info->publisher.publish(*(current_model_info->message.get()));
+  }
+
   // A local reference to the rigid body system.
   std::shared_ptr<RigidBodySystem> rigid_body_system_;
 
-  // Maintains a set of RobotJointStateStruct structs, one for each robot.
-  // The key is the robot's name.
-  std::map<std::string, std::unique_ptr<RobotJointStateStruct>> robot_structs_;
+  // A set of ModelStateStruct structs, one for each model instance.
+  std::vector<std::unique_ptr<ModelStateStruct>> model_instance_structs_;
 
-  // The previous time the LIDAR messages were sent.
+  // The previous time the joint state messages were sent.
   ::ros::Time previous_send_time_;
 };
 

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_lidar.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_lidar.h
@@ -20,11 +20,21 @@ namespace ros {
 namespace systems {
 
 /**
- * @brief A system that takes the system state as the input,
- * saves LIDAR data in to a sensor_msgs::LaserScan message,
- * and then publishes the message onto a ROS topic.
- *
- * @concept{system_concept}
+ * Holds the objects and data needed to extract and publish joint state
+ * information for a particular model instance.
+ */
+struct LidarSensorStruct {
+  // The ROS topic publisher for publishing the LIDAR data.
+  ::ros::Publisher publisher;
+
+  // This holds LIDAR sensor's measurements and is periodically published.
+  std::unique_ptr<sensor_msgs::LaserScan> message;
+};
+
+/**
+ * Takes the system's state vector and publishes `sensor_msgs::LaserScan`
+ * messages on ROS topics. The ROS topics are namespaced by the model instance
+ * names.
  *
  * The resulting system has no internal state; the publish command is throttled
  * by kMinTransmitPeriod_.
@@ -33,14 +43,9 @@ namespace systems {
  * enables other systems to be cascaded after this system.
  */
 template <template <typename> class RobotStateVector>
-class SensorPublisherLidar {
+class RosSensorPublisherLidar {
  private:
-  // Specifies that the LIDAR messages should be transmitted with a minimum
-  // period of 0.05 seconds.
-  //
-  // TODO(liangfok): Modify sensor model to include scan frequency and time
-  // between scan measurements. See:
-  // https://github.com/RobotLocomotion/drake/issues/2210
+  // Specifies the minimum period at which to publish LIDAR messages.
   static constexpr double kMinTransmitPeriod_ = 0.05;
 
  public:
@@ -52,18 +57,21 @@ class SensorPublisherLidar {
   using InputVector = RobotStateVector<ScalarType>;
 
   /**
-   * The constructor. It takes a rigid body system as an input parameter to get
-   * semantic information about the output from the rigid body system,
-   * specifically about the sensor state.
-   *
-   * Ideally, the output of the rigid body system should be self-descriptive.
-   * See: https://github.com/RobotLocomotion/drake/issues/2152
+   * The constructor, which initializes all internal data structures necessary
+   * to publish LIDAR state information for each model instance in @p
+   * rigid_body_system.
    *
    * @param[in] rigid_body_system The rigid body system whose output contains
-   * the odometry information.
+   * the LIDAR information.
+   *
+   * @param[in] model_instance_names A mapping from model instance IDs to model
+   * instance names. These names are used to prefix the names of the frames in
+   * the `sensor_msgs::LaserScan` messages, which is necessary for RViz to
+   * simultaneously visualize the sensors belonging to multiple models.
    */
-  explicit SensorPublisherLidar(
-      std::shared_ptr<RigidBodySystem> rigid_body_system)
+  explicit RosSensorPublisherLidar(
+      std::shared_ptr<RigidBodySystem> rigid_body_system,
+      const std::map<int, std::string>& model_instance_names)
       : rigid_body_system_(rigid_body_system) {
     // Initializes the time stamp of the previous transmission to be zero.
     previous_send_time_.sec = 0;
@@ -77,92 +85,103 @@ class SensorPublisherLidar {
     // Creates a ROS topic publisher for each LIDAR sensor in the rigid body
     // system.
     for (auto sensor : rigid_body_system->GetSensors()) {
-      // Attempts to cast the RigidBodySensor pointer to a RigidBodyDepthSensor
-      // pointer. This actually does two things simultaneously. First it
-      // determines whether the pointer in fact points to a
-      // RigidBodyDepthSensor. Second, if true, it also povides a pointer to the
-      // RigidBodyDepthSensor that can be used later in this method.
+      // Attempts to cast the pointer to a `RigidBodySensor` to be a pointer to
+      // a `RigidBodyDepthSensor`. This actually does two things simultaneously.
+      // First it determines whether the pointer in fact points to a
+      // `RigidBodyDepthSensor`. Second, if true, it also povides a pointer to
+      // the `RigidBodyDepthSensor`.
       const RigidBodyDepthSensor* depth_sensor =
           dynamic_cast<const RigidBodyDepthSensor*>(sensor);
 
       if (depth_sensor != nullptr) {
-        // If the dynamic cast is successful, the sensor is in fact a
-        // RigidBodyDepthSensor. The following code creates a ROS topic
+        // If the dynamic cast is successful, the sensor is a
+        // `RigidBodyDepthSensor`. The following code creates a ROS topic
         // publisher that will be used to publish the data contained in the
-        // sensor's output. The ROS topic is
-        // "drake/lidar/[name of robot]/[name of sensor]/".
-        // It then creates a sensor_msgs::LaserScan message for each publisher.
+        // sensor's output. The ROS topic is:
+        //
+        //     [model instance name]/lidar/[sensor name]/.
+        //
+        // It then creates a `sensor_msgs::LaserScan` message for each
+        // publisher.
         const std::string model_name = depth_sensor->get_model_name();
-        const std::string key = model_name + "_" + depth_sensor->get_name();
+        int model_instance_id = depth_sensor->get_frame()
+            .get_model_instance_id();
 
-        // Creates the ROS topic publisher for the current LIDAR sensor.
-        if (lidar_publishers_.find(key) == lidar_publishers_.end()) {
-          const std::string topic_name =
-              "drake/" + model_name + "/lidar/" + depth_sensor->get_name();
-
-          lidar_publishers_.insert(std::pair<std::string, ::ros::Publisher>(
-              key, nh.advertise<sensor_msgs::LaserScan>(topic_name, 1)));
-        } else {
-          throw std::runtime_error(
-              "ERROR: Multiple sensors with name " + depth_sensor->get_name() +
-              " found when creating a ROS topic publisher for the sensor!");
+        // Verifies that the model instance name can be determined.
+        // Throws an error if it cannot.
+        if (model_instance_names.find(model_instance_id) ==
+            model_instance_names.end()) {
+          throw std::runtime_error("RosSensorPublisherLidar: ERROR: Unable to "
+              "determine model instance name of model with instance ID " +
+              std::to_string(model_instance_id) + ".");
         }
 
-        // Creates the ROS message for the current LIDAR sensor.
-        if (lidar_messages_.find(depth_sensor->get_name()) ==
-            lidar_messages_.end()) {
-          std::unique_ptr<sensor_msgs::LaserScan> message(
-              new sensor_msgs::LaserScan());
-          message->header.frame_id = depth_sensor->get_name();
+        // Instantiates a LidarSensorStruct for the current sensor and
+        // initializes various member variables within it.
+        std::unique_ptr<LidarSensorStruct> sensor_struct(
+            new LidarSensorStruct());
 
-          // The rigid body depth sensor scans either horizontally or
-          // vertically.
-          bool is_horizontal_scanner = depth_sensor->is_horizontal_scanner();
-          bool is_vertical_scanner = depth_sensor->is_vertical_scanner();
+        const std::string model_instance_name =
+            model_instance_names.at(model_instance_id);
 
-          if (is_horizontal_scanner && is_vertical_scanner)
-            throw std::runtime_error(
-                "ERROR: Rigid body depth sensor " + depth_sensor->get_name() +
-                " has both horizontal and vertical dimensions. Expecting it to "
-                "only scan within a 2D plane!");
+        const std::string sensor_name = depth_sensor->get_name();
 
-          if (is_horizontal_scanner) {
-            message->angle_min = depth_sensor->min_yaw();
-            message->angle_max = depth_sensor->max_yaw();
-            message->angle_increment =
-                (depth_sensor->max_yaw() - depth_sensor->min_yaw()) /
-                depth_sensor->num_pixel_cols();
-          } else {
-            message->angle_min = depth_sensor->min_pitch();
-            message->angle_max = depth_sensor->max_pitch();
-            message->angle_increment =
-                (depth_sensor->max_pitch() - depth_sensor->min_pitch()) /
-                depth_sensor->num_pixel_rows();
-          }
+        const std::string topic_name = model_instance_name + "/lidar/" +
+            sensor_name;
 
-          // Since the RigidBodyDepthSensor does not include this information
-          // in the output and it is difficult to obtain this information
-          // from other variables within this method's scope, set this value
-          // to be zero.
-          //
-          // See:
-          // https://github.com/RobotLocomotion/drake/issues/2210
-          message->time_increment = 0;
-          message->scan_time = 0;
+        // ROS_INFO_STREAM("Creating LIDAR sensor publisher on topic "
+        //     << topic_name);
+        sensor_struct->publisher =
+            nh.advertise<sensor_msgs::LaserScan>(topic_name, 1);
 
-          message->range_min = depth_sensor->min_range();
-          message->range_max = depth_sensor->max_range();
-          message->ranges.resize(depth_sensor->getNumOutputs());
-          message->intensities.resize(depth_sensor->getNumOutputs());
+        sensor_struct->message.reset(new sensor_msgs::LaserScan());
+        sensor_struct->message->header.frame_id = model_instance_name +
+            "/" + sensor_name;
 
-          lidar_messages_.insert(
-              std::pair<std::string, std::unique_ptr<sensor_msgs::LaserScan>>(
-                  key, std::move(message)));
-        } else {
+        // The rigid body depth sensor scans either horizontally or
+        // vertically.
+        bool is_horizontal_scanner = depth_sensor->is_horizontal_scanner();
+        bool is_vertical_scanner = depth_sensor->is_vertical_scanner();
+
+        // Throws an error if the sensor scans both horizontally and vertically.
+        if (is_horizontal_scanner && is_vertical_scanner) {
           throw std::runtime_error(
-              "ERROR: Multiple sensors with name " + depth_sensor->get_name() +
-              " found when creating a sensor_msgs::LaserScan message!");
+              "ERROR: Rigid body depth sensor " + depth_sensor->get_name() +
+              " has both horizontal and vertical dimensions. Expecting it to "
+              "only scan within a 2D plane!");
         }
+
+        if (is_horizontal_scanner) {
+          sensor_struct->message->angle_min = depth_sensor->min_yaw();
+          sensor_struct->message->angle_max = depth_sensor->max_yaw();
+          sensor_struct->message->angle_increment =
+              (depth_sensor->max_yaw() - depth_sensor->min_yaw()) /
+              depth_sensor->num_pixel_cols();
+        } else {
+          sensor_struct->message->angle_min = depth_sensor->min_pitch();
+          sensor_struct->message->angle_max = depth_sensor->max_pitch();
+          sensor_struct->message->angle_increment =
+              (depth_sensor->max_pitch() - depth_sensor->min_pitch()) /
+              depth_sensor->num_pixel_rows();
+        }
+
+        // Since the RigidBodyDepthSensor does not include this information
+        // in the output and it is difficult to obtain this information
+        // from other variables within this method's scope, set this value
+        // to be zero.
+        //
+        // See:
+        // https://github.com/RobotLocomotion/drake/issues/2210
+        sensor_struct->message->time_increment = 0;
+        sensor_struct->message->scan_time = 0;
+
+        sensor_struct->message->range_min = depth_sensor->min_range();
+        sensor_struct->message->range_max = depth_sensor->max_range();
+        sensor_struct->message->ranges.resize(depth_sensor->getNumOutputs());
+        sensor_struct->message->intensities.resize(
+            depth_sensor->getNumOutputs());
+
+        lidar_table_.push_back(std::move(sensor_struct));
       }
     }
   }
@@ -187,8 +206,13 @@ class SensorPublisherLidar {
 
     // This variable is for tracking where in the output of rigid body system
     // we are currently processing. We initialize it to be the number of states
-    // of the rigid body system to start past the joint state information.
+    // of the rigid body system to start immediately after the joint states in
+    // in the state vector.
     size_t output_index = rigid_body_system_->getNumStates();
+
+    // For keeping track of which LidarSesnorStruct we are processing in the
+    // for loop below.
+    int lidar_table_index = 0;
 
     // Iterates through each sensor in the rigid body system. If the sensor is
     // a LIDAR sensor, store the range measurements in a ROS message and publish
@@ -212,31 +236,15 @@ class SensorPublisherLidar {
 
       if (depth_sensor != nullptr) {
         size_t sensor_data_index_ = output_index;
-
-        const std::string& model_name = depth_sensor->get_model_name();
-        const std::string key = model_name + "_" + depth_sensor->get_name();
-
-        auto message_in_map = lidar_messages_.find(key);
-        if (message_in_map == lidar_messages_.end())
-          throw std::runtime_error(
-              "Could not find ROS message for LIDAR sensor " +
-              depth_sensor->get_name() + " in robot " + model_name + ".");
-
-        sensor_msgs::LaserScan* message = message_in_map->second.get();
+        std::unique_ptr<LidarSensorStruct>& sensor_struct =
+            lidar_table_[lidar_table_index++];
 
         // Saves the new range measurements in the ROS message.
         for (size_t ii = 0; ii < depth_sensor->getNumOutputs(); ii++) {
-          message->ranges[ii] = u[sensor_data_index_++];
+          sensor_struct->message->ranges[ii] = u[sensor_data_index_++];
         }
 
-        // Publishes the ROS message containing the new range measurements.
-        auto publisher_in_map = lidar_publishers_.find(key);
-        if (publisher_in_map == lidar_publishers_.end())
-          throw std::runtime_error(
-              "ERROR: Failed to find ROS topic publisher for LIDAR sensor " +
-              depth_sensor->get_name() + " in robot " + model_name + ".");
-
-        publisher_in_map->second.publish(*message);
+        sensor_struct->publisher.publish(*(sensor_struct->message.get()));
       }
 
       // Shifts the output index variable forward by one sensor.
@@ -252,19 +260,13 @@ class SensorPublisherLidar {
  private:
   std::shared_ptr<RigidBodySystem> rigid_body_system_;
 
-  /**
-   * Maintains a set of ROS topic publishers for publishing LIDAR messages.
-   * The key is the name of the sensor. The value is the ROS topic publisher.
-   */
-  std::map<std::string, ::ros::Publisher> lidar_publishers_;
 
   /**
    * Maintains a set of ROS sensor_msgs::LaserScan messages for use by the
    * publishers. This is used to avoid having to allocate a new message
    * each time one needs to be sent.
    */
-  std::map<std::string, std::unique_ptr<sensor_msgs::LaserScan>>
-      lidar_messages_;
+  std::vector<std::unique_ptr<LidarSensorStruct>> lidar_table_;
 
   /**
    * The previous time the LIDAR messages were sent.

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_tf_publisher.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_tf_publisher.h
@@ -8,11 +8,13 @@
 #include "tf/transform_broadcaster.h"
 
 #include "drake/math/rotation_matrix.h"
+#include "drake/ros/parameter_server.h"
 #include "drake/systems/System.h"
 #include "drake/systems/plants/KinematicsCache.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/plants/RigidBodySystem.h"
 #include "drake/systems/vector.h"
+
 
 using drake::NullVector;
 using drake::RigidBodySensor;
@@ -23,19 +25,14 @@ namespace drake {
 namespace ros {
 namespace systems {
 
-/** DrakeRosTfPublisher<RobotStateVector>
- * @brief A system that takes the current state of Drake and publishes the
- * transform messages on ROS topic /tf.
- *
- * @concept{system_concept}
- *
- * The resulting system has no internal state; the publish command is executed
- * on every call to the output method.
+/**
+ * Publishes transforms for every rigid body in a `RigidBodyTree`. The transform
+ * names are prefixed by the model instance names.
  *
  * For convenience, the input is passed directly through as an output.
  */
 template <template <typename> class RobotStateVector>
-class DrakeRosTfPublisher {
+class RosTfPublisher {
  private:
   // Specifies the minimum period in seconds between successive transmissions of
   // of tf transforms. This is to prevent flooding the tf ROS topic.
@@ -55,127 +52,34 @@ class DrakeRosTfPublisher {
    * The constructor. It takes a rigid body tree as an input parameter to get
    * semantic information about the input values.
    *
-   * @param rigid_body_tree The rigid body tree being modeled. This parameter
-   * is necessary to understand the meaning of the input data to this system.
+   * It checks the ROS parameter server for a boolean parameter called
+   * "enable_tf_publisher". If this parameter exists and is false, this
+   * class disables itself. Otherwise, this class is enabled.
+   *
+   * @param[in] rigid_body_tree Contains the rigid bodies whose transforms are
+   * to be published. This reference must remain valid for the lifetime of this
+   * object.
+   *
+   * @param[in] model_instance_name_table A table mapping model instance IDs to
+   * model instance names. These names are used to prefix the transform names,
+   * which is necessary for RViz to simultaneously visualize multiple robots.
    */
-  explicit DrakeRosTfPublisher(
-      const std::shared_ptr<RigidBodyTree> rigid_body_tree)
-      : rigid_body_tree_(rigid_body_tree), enable_tf_publisher_(true) {
-    // Queries the ROS parameter server for a boolean parameter in
-    // "/drake/enable_tf_publisher". This parameter is used to control whether
+  explicit RosTfPublisher(
+      const std::shared_ptr<RigidBodyTree> rigid_body_tree,
+      const std::map<int, std::string>& model_instance_name_table) :
+          rigid_body_tree_(rigid_body_tree) {
+    ::ros::NodeHandle node_handle;
+    // Queries the ROS parameter server for a boolean parameter called
+    // "enable_tf_publisher". This parameter is used to control whether
     // this class publishes /tf messages.
-    {
-      int num_get_attempts = 0;
-      bool continue_query = true;
-      while (continue_query &&
-             !::ros::param::get("/drake/enable_tf_publisher",
-                                enable_tf_publisher_)) {
-        if (++num_get_attempts > 10) {
-          ROS_WARN(
-              "Failed to get parameter /drake/enable_tf_publisher. "
-              "Assuming publisher is enabled.");
-          continue_query = false;
-        }
-      }
-
-      if (enable_tf_publisher_) {
-        ROS_INFO("Enabling TF publisher!");
-      } else {
-        ROS_INFO("Disabling TF publisher!");
-      }
-    }
+    enable_tf_publisher_ = GetRosParameterOrThrow<bool>("enable_tf_publisher");
 
     // Initializes the time stamp of the previous transmission to be zero.
     previous_send_time_.sec = 0;
     previous_send_time_.nsec = 0;
 
-    // Instantiates a geometry_msgs::TransformStamped message for each rigid
-    // body in the rigid body tree.
-    for (auto const& rigid_body : rigid_body_tree->bodies) {
-      // Skips the current rigid body if it should be skipped.
-      if (!PublishTfForRigidBody(rigid_body.get())) continue;
-
-      // Creates a unique key for holding the transform message.
-      std::string key = rigid_body->get_model_name() + rigid_body->get_name();
-
-      // Checks whether a transform message for the current link was already
-      // added to the transform_messages_ map.
-      if (transform_messages_.find(key) != transform_messages_.end())
-        throw std::runtime_error(
-            "ERROR: Multiple model/links named " + key +
-            " found when creating a geometry_msgs::TransformStamped message!");
-
-      // Instantiates a geometry_msgs::TransformStamped message for the
-      // current rigid body.
-      std::unique_ptr<geometry_msgs::TransformStamped> message(
-          new geometry_msgs::TransformStamped());
-
-      message->header.frame_id = rigid_body->get_parent()->get_name();
-      message->child_frame_id = rigid_body->get_name();
-
-      // Obtains the current link's joint.
-      const DrakeJoint& joint = rigid_body->getJoint();
-
-      // Initializes the transformation if the joint is fixed.
-      // We can do this now since it will not change over time.
-      if (joint.getNumPositions() == 0 && joint.getNumVelocities() == 0) {
-        auto translation = joint.getTransformToParentBody().translation();
-        auto quat =
-            drake::math::rotmat2quat(joint.getTransformToParentBody().linear());
-
-        message->transform.translation.x = translation(0);
-        message->transform.translation.y = translation(1);
-        message->transform.translation.z = translation(2);
-
-        message->transform.rotation.w = quat(0);
-        message->transform.rotation.x = quat(1);
-        message->transform.rotation.y = quat(2);
-        message->transform.rotation.z = quat(3);
-      }
-
-      transform_messages_[key] = std::move(message);
-    }
-
-    // Instantiates a geometry_msgs::TransformStamped message for each frame
-    // in the rigid body tree.
-    for (auto const& frame : rigid_body_tree->frames) {
-      std::string key = frame->get_rigid_body().get_model_name() +
-          frame->get_name();
-
-      // Checks whether a transform message for the current frame was already
-      // added to the transform_messages_ map.
-      if (transform_messages_.find(key) != transform_messages_.end())
-        throw std::runtime_error(
-            "ERROR: Multiple models/frames named " + key +
-            " found when creating a geometry_msgs::TransformStamped message!");
-
-      // Instantiates a geometry_msgs::TransformStamped message for the
-      // current frame.
-      std::unique_ptr<geometry_msgs::TransformStamped> message(
-          new geometry_msgs::TransformStamped());
-
-      message->header.frame_id = frame->get_rigid_body().get_name();
-      message->child_frame_id = frame->get_name();
-
-      // Frames are fixed to a particular rigid body. The following code saves
-      // the transformation in the frame's geometry_msgs::TransformStamped
-      // message. This can be done once during initialization since it will
-      // not change over time.
-      auto translation = frame->get_transform_to_body().translation();
-      auto quat = drake::math::rotmat2quat(
-          frame->get_transform_to_body().linear());
-
-      message->transform.translation.x = translation(0);
-      message->transform.translation.y = translation(1);
-      message->transform.translation.z = translation(2);
-
-      message->transform.rotation.w = quat(0);
-      message->transform.rotation.x = quat(1);
-      message->transform.rotation.y = quat(2);
-      message->transform.rotation.z = quat(3);
-
-      transform_messages_[key] = std::move(message);
-    }
+    CreateBodyTransformMessages(rigid_body_tree, model_instance_name_table);
+    CreateFrameTransformMessages(rigid_body_tree, model_instance_name_table);
   }
 
   StateVector<double> dynamics(const double& t, const StateVector<double>& x,
@@ -185,16 +89,17 @@ class DrakeRosTfPublisher {
 
   OutputVector<double> output(const double& t, const StateVector<double>& x,
                               const InputVector<double>& u) {
+    // Aborts publishing tf messages if enable_tf_publisher_ is false.
+    if (!enable_tf_publisher_) return u;
+
     // Aborts if insufficient time has passed since the last transmission. This
     // is to avoid flooding the ROS topics.
     ::ros::Time current_time = ::ros::Time::now();
     if ((current_time - previous_send_time_).toSec() < kMinTransmitPeriod_)
       return u;
 
+    // Updates the previous send time.
     previous_send_time_ = current_time;
-
-    // Aborts publishing tf messages if enable_tf_publisher_ is true.
-    if (!enable_tf_publisher_) return u;
 
     // The input vector u contains the entire system's state.
     // The following code extracts the position values from it
@@ -206,19 +111,19 @@ class DrakeRosTfPublisher {
     // Publishes the transform for each rigid body in the rigid body tree.
     for (auto const& rigid_body : rigid_body_tree_->bodies) {
       // Skips the current rigid body if it should be skipped.
-      if (!PublishTfForRigidBody(rigid_body.get())) continue;
+      if (!ShouldPublishTfForRigidBody(*rigid_body.get())) continue;
 
-      // Obtains a unique key for holding the transform message.
-      std::string key = rigid_body->get_model_name() + rigid_body->get_name();
+      std::string key = DeriveKey(rigid_body);
 
       // Verifies that a geometry_msgs::TransformStamped message for the current
       // link exists in the transform_messages_ map.
       auto message_in_map = transform_messages_.find(key);
-      if (message_in_map == transform_messages_.end())
+      if (message_in_map == transform_messages_.end()) {
         throw std::runtime_error(
-            "ERROR: DrakeRosTfPublisher: Unable to find"
-            "transform message with key " +
-            key);
+            "ERROR: RosTfPublisher: Unable to obtain transform message "
+            "for rigid body \"" + rigid_body->get_name() + "\" using key \"" +
+            key + "\"");
+      }
 
       // Obtains a pointer to the geometry_msgs::TransformStamped message for
       // the current link.
@@ -232,8 +137,11 @@ class DrakeRosTfPublisher {
         auto transform = rigid_body_tree_->relativeTransform(
             cache,
             rigid_body_tree_->FindBodyIndex(
-                rigid_body->get_parent()->get_name()),
-            rigid_body_tree_->FindBodyIndex(rigid_body->get_name()));
+                rigid_body->get_parent()->get_name(),
+                rigid_body->get_parent()->get_model_instance_id()),
+            rigid_body_tree_->FindBodyIndex(
+                rigid_body->get_name(),
+                rigid_body->get_model_instance_id()));
         auto translation = transform.translation();
         auto quat = drake::math::rotmat2quat(transform.linear());
 
@@ -256,17 +164,17 @@ class DrakeRosTfPublisher {
 
     // Publishes the transform for each frame in the rigid body tree.
     for (auto const& frame : rigid_body_tree_->frames) {
-      std::string key = frame->get_rigid_body().get_model_name() +
-          frame->get_name();
+      std::string key = DeriveKey(frame);
 
       // Verifies that a geometry_msgs::TransformStamped message for the current
       // link exists in the transform_messages_ map.
       auto message_in_map = transform_messages_.find(key);
-      if (message_in_map == transform_messages_.end())
+      if (message_in_map == transform_messages_.end()) {
         throw std::runtime_error(
-            "ERROR: DrakeRosTfPublisher: Unable to find"
-            "transform message with key " +
-            key);
+            "ERROR: RosTfPublisher: Unable to obtain transform message "
+            "for frame \"" + frame->get_name() + "\" using key \"" +
+            key + "\"");
+      }
 
       // Obtains a pointer to the geometry_msgs::TransformStamped message for
       // the current link.
@@ -288,14 +196,240 @@ class DrakeRosTfPublisher {
   bool isDirectFeedthrough() const { return true; }
 
  private:
-  // Determines whether a transform should be published for the specified
-  // rigid body. A rigid body should be skipped if it is the world link or if
-  // it is connected to the world via a fixed joint.
-  bool PublishTfForRigidBody(const RigidBody* rigid_body) {
-    // Skips rigid bodies without a mobilizer joint. This includes the RigidBody
-    // that represents the world.
-    if (!rigid_body->has_parent_body()) return false;
-    return true;
+  /* Determines whether a transform should be published for @p rigid_body. A
+   * rigid body should be skipped if it is the world link or does not have a
+   * parent link.
+   */
+  bool ShouldPublishTfForRigidBody(const RigidBody& rigid_body) {
+    // Skips parent-less bodies. This includes the world.
+    return rigid_body.has_parent_body();
+  }
+
+  /* Derives a key for obtaining the transform message for @p rigid_body
+   * from transform_messages_. The key is a concatenation of the string
+   * "Rigidbody_", the rigid body's name, and the ID of the model instance to
+   * which the rigid body belongs.
+   */
+  std::string DeriveKey(const std::unique_ptr<RigidBody>& rigid_body) {
+    std::string key = "RigidBody_" + rigid_body->get_name() +
+        std::to_string(rigid_body->get_model_instance_id());
+    return key;
+  }
+
+  /* Derives a key for obtaining the transform message for @p frame
+   * from transform_messages_. The key is a concatenation of the string
+   * "Frame_", the frame's name, and the ID of the model instance to which the
+   * frame belongs.
+   */
+  std::string DeriveKey(const std::shared_ptr<RigidBodyFrame>& frame) {
+    std::string key = "Frame_" + frame->get_name() +
+        std::to_string(frame->get_model_instance_id());
+    return key;
+  }
+
+  /* Determines the name of the frame belonging to @p rigid_body in the /tf
+   * tree. If @p rigid_body is the world, use the world's name. Otherwise,
+   * prefix the name of @p rigid_body with its model instance name. This is
+   * necessary for the /tf tree to support multiple models.
+   *
+   * @param[in] rigid_body The rigid body whose /tf tree frame name is being
+   * derived.
+   *
+   * @param[in] model_instance_name A mapping from model instance IDs to model
+   * instance names. The instance names are used to prefix the frame name so
+   * that multiple models can be supported.
+   *
+   * @return The frame name of @p rigid_body.
+   */
+  std::string DeriveBodyTfFrameName(const RigidBody& rigid_body,
+      const std::map<int, std::string>& model_instance_name_table) {
+    // Obtains the rigid body's name.
+    std::string name = rigid_body.get_name();
+    std::string frame_name;
+
+    if (name == RigidBodyTree::kWorldName) {
+      // If the rigid body is the world, just use the world's name. Since there
+      // is only one world, there is no need for a prefix.
+       frame_name = name;
+    } else {
+      // Obtains the rigid body's model instance ID.
+      int model_instance_id = rigid_body.get_model_instance_id();
+
+      // Verifies that the model instance ID has a model instance name.
+      // Throws an exception if it does not have an instance name.
+      if (model_instance_name_table.find(model_instance_id) ==
+          model_instance_name_table.end()) {
+        throw std::runtime_error("RosTfPublisher: Could not find model "
+          "instance ID " + std::to_string(model_instance_id) + " in "
+          "model_instance_name_table. Expected it to be of model type \"" +
+          rigid_body.get_model_name() + "\".");
+      }
+
+      // Prefixes the rigid body's name with the model instance name.
+      // This is the name of the rigid body's frame in the /tf tree.
+      frame_name =
+          model_instance_name_table.at(model_instance_id) + "/" + name;
+    }
+
+    return frame_name;
+  }
+
+  /* Determines the name of the frame belonging to @p frame in the /tf
+   * tree. This is done by prefixing the name of @p frame with its model
+   * instance name. A prefix is necessary for the /tf tree to support multiple
+   * models.
+   *
+   * @param[in] frame The rigid body frame whose /tf tree frame name is being
+   * derived.
+   *
+   * @param[in] model_instance_name A mapping from model instance IDs to model
+   * instance names. The instance names are used to prefix the frame name so
+   * that multiple models can be supported.
+   *
+   * @return The frame name of @p rigid_body.
+   */
+  std::string DeriveFrameTfFrameName(const RigidBodyFrame& frame,
+      const std::map<int, std::string>& model_instance_name_table) {
+    // Obtains the frame's model instance ID.
+    int model_instance_id = frame.get_model_instance_id();
+
+    // Verifies that the model instance ID has a model instance name.
+    // Throws an exception if it does not have an instance name.
+    if (model_instance_name_table.find(model_instance_id) ==
+        model_instance_name_table.end()) {
+      throw std::runtime_error(
+          "ERROR: RosTfPublisher: Model instance with ID " +
+          std::to_string(model_instance_id) + " does not have a name.");
+    }
+    std::string model_instance_name =
+        model_instance_name_table.at(model_instance_id);
+
+    // Prefixes the rigid body frame's name with the model instance name.
+    // This is the name of the rigid body's frame in the /tf tree.
+    return model_instance_name + "/" + frame.get_name();
+  }
+
+  /* Creates a transform message for each rigid body in the rigid body tree
+   * except for the world, which does not need such a transform message. Stores
+   * these messages in class member variable `transform_messages_`.
+   */
+  void CreateBodyTransformMessages(
+      const std::shared_ptr<RigidBodyTree> rigid_body_tree,
+      const std::map<int, std::string>& model_instance_name_table) {
+    for (auto const& rigid_body : rigid_body_tree->bodies) {
+      if (!ShouldPublishTfForRigidBody(*rigid_body.get())) continue;
+
+      // Derives the key for storing the geometry_msgs::TransformStamped for
+      // the current rigid body in transform_messages_.
+      std::string key = DeriveKey(rigid_body);
+
+      // Checks whether a transform message for the current link was already
+      // added to the transform_messages_ map. Throws an `std::runtime_error`
+      // exception if a key collision occurs.
+      if (transform_messages_.find(key) != transform_messages_.end()) {
+        throw std::runtime_error(
+            "ERROR: Duplicate key \"" + key + " encountered when creating a "
+            "geometry_msgs::TransformStamped message for rigid body \"" +
+            rigid_body->get_name() + "\".");
+      }
+
+      // By now we know that transforms should be sent for the current rigid
+      // body and that a transform message for the current rigid body does not
+      // exist in transform_messages_. Thus, the following code instantiates a
+      // geometry_msgs::TransformStamped message for the current rigid body.
+      std::unique_ptr<geometry_msgs::TransformStamped> message(
+          new geometry_msgs::TransformStamped());
+
+      // Sets the frame names in the transform message.
+      message->header.frame_id =
+          DeriveBodyTfFrameName(*(rigid_body->get_parent()),
+              model_instance_name_table);
+
+      message->child_frame_id =
+          DeriveBodyTfFrameName(*(rigid_body.get()),
+              model_instance_name_table);
+
+      // Obtains the current link's joint. If it is fixed, initialize the
+      // transforms within it. This is possible since these transforms are not
+      // dependent on the current state of the model, i.e., they do not change
+      // over time.
+      const DrakeJoint& joint = rigid_body->getJoint();
+
+      if (joint.getNumPositions() == 0 && joint.getNumVelocities() == 0) {
+        auto translation = joint.getTransformToParentBody().translation();
+        auto quat =
+            drake::math::rotmat2quat(joint.getTransformToParentBody().linear());
+
+        message->transform.translation.x = translation(0);
+        message->transform.translation.y = translation(1);
+        message->transform.translation.z = translation(2);
+
+        message->transform.rotation.w = quat(0);
+        message->transform.rotation.x = quat(1);
+        message->transform.rotation.y = quat(2);
+        message->transform.rotation.z = quat(3);
+      }
+
+      transform_messages_[key] = std::move(message);
+    }
+  }
+
+  /* Creates a transform message for each rigid body frame in the rigid body
+   * tree. Stores these messages in class member variable `transform_messages_`.
+   */
+  void CreateFrameTransformMessages(
+      const std::shared_ptr<RigidBodyTree> rigid_body_tree,
+      const std::map<int, std::string>& model_instance_name_table) {
+    for (auto const& frame : rigid_body_tree->frames) {
+      // Derives the key for storing the geometry_msgs::TransformStamped for
+      // the current frame in transform_messages_.
+      std::string key = DeriveKey(frame);
+
+      // Checks whether a transform message for the current frame was already
+      // added to the transform_messages_ map.
+      if (transform_messages_.find(key) != transform_messages_.end()) {
+        throw std::runtime_error(
+            "ERROR: Duplicate key \"" + key + "\" encountered when creating a "
+            "geometry_msgs::TransformStamped message for rigid body frame \"" +
+            frame->get_name() + "\", model name \"" +
+            frame->get_rigid_body().get_model_name() +
+            "\", and model_instance_id " +
+            std::to_string(frame->get_model_instance_id()) + ".");
+      }
+
+      // Instantiates a geometry_msgs::TransformStamped message for the
+      // current frame.
+      std::unique_ptr<geometry_msgs::TransformStamped> message(
+          new geometry_msgs::TransformStamped());
+
+      // Sets the frame names in the transform message.
+      message->header.frame_id =
+          DeriveBodyTfFrameName(frame->get_rigid_body(),
+              model_instance_name_table);
+
+      message->child_frame_id =
+          DeriveFrameTfFrameName(*(frame.get()),
+              model_instance_name_table);
+
+      // Frames are fixed to a particular rigid body. The following code saves
+      // the transformation in the frame's geometry_msgs::TransformStamped
+      // message. This can be done once during initialization since it will
+      // not change over time.
+      auto translation = frame->get_transform_to_body().translation();
+      auto quat = drake::math::rotmat2quat(
+          frame->get_transform_to_body().linear());
+
+      message->transform.translation.x = translation(0);
+      message->transform.translation.y = translation(1);
+      message->transform.translation.z = translation(2);
+
+      message->transform.rotation.w = quat(0);
+      message->transform.rotation.x = quat(1);
+      message->transform.rotation.y = quat(2);
+      message->transform.rotation.z = quat(3);
+
+      transform_messages_[key] = std::move(message);
+    }
   }
 
   // The rigid body tree being used by Drake's rigid body dynamics engine.
@@ -317,7 +451,7 @@ class DrakeRosTfPublisher {
   ::ros::Time previous_send_time_;
 
   // Determines whether tf messages should be published.
-  bool enable_tf_publisher_;
+  bool enable_tf_publisher_{true};
 };
 
 }  // namespace systems

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_vehicle_system.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_vehicle_system.h
@@ -18,6 +18,7 @@ namespace drake {
 namespace ros {
 namespace systems {
 
+// Decodes @p msg into @p x.
 bool decode(const ackermann_msgs::AckermannDriveStamped& msg,
             // NOLINTNEXTLINE(runtime/references) due to LCMSystem.
             drake::automotive::DrivingCommand<double>& x) {
@@ -42,7 +43,7 @@ bool decode(const ackermann_msgs::AckermannDriveStamped& msg,
 namespace internal {
 
 template <template <typename> class Vector>
-class ROSAckermannCommandReceiverSystem {
+class RosAckermannCommandReceiverSystem {
  private:
   static const int kSubscriberQueueSize = 100;
 
@@ -54,20 +55,20 @@ class ROSAckermannCommandReceiverSystem {
   template <typename ScalarType>
   using OutputVector = Vector<ScalarType>;
 
-  ROSAckermannCommandReceiverSystem() : spinner_(1) {
+  RosAckermannCommandReceiverSystem() : spinner_(1) {
     ::ros::NodeHandle nh;
 
     // Instantiates a ROS topic subscriber that receives vehicle driving
     // commands.
     subscriber_ =
         nh.subscribe("ackermann_cmd", kSubscriberQueueSize,
-                     &ROSAckermannCommandReceiverSystem::commandCallback, this);
+                     &RosAckermannCommandReceiverSystem::commandCallback, this);
 
     // Instantiates a child thread for receiving ROS messages.
     spinner_.start();
   }
 
-  virtual ~ROSAckermannCommandReceiverSystem() {}
+  virtual ~RosAckermannCommandReceiverSystem() {}
 
   void commandCallback(const ackermann_msgs::AckermannDriveStamped& msg) {
     data_mutex_.lock();
@@ -124,7 +125,7 @@ void run_ros_vehicle_sim(
     const typename System::template StateVector<double>& x0,
     const SimulationOptions& options = SimulationOptions()) {
   auto ros_ackermann_input =
-      std::make_shared<internal::ROSAckermannCommandReceiverSystem<
+      std::make_shared<internal::RosAckermannCommandReceiverSystem<
           System::template InputVector>>();
 
   auto ros_sys = cascade(ros_ackermann_input, sys);

--- a/ros/drake_ros_systems/package.xml
+++ b/ros/drake_ros_systems/package.xml
@@ -40,8 +40,10 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>ackermann_msgs</build_depend>
   <build_depend>drake</build_depend>
+  <build_depend>drake_ros_common</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
 
@@ -49,11 +51,4 @@
   <run_depend>drake</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
-
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>


### PR DESCRIPTION
# Motivation

The `model_instance_id` abstraction within `RigidBodyTree` enables (1) less bookkeeping in Drake-ROS System 1.0 systems, and (2) better support for simulations that involve multiple vehicles. I'd like these to go into master so we can use them as a reference as we transition them into System 2.0 variants.

In addition to updated System 1.0 systems, this PR also includes an update to the previously existing `single_car_in_stata_garage` demo since it uses the new Drake-ROS system 1.0 systems. A unit test called `single_car_in_stata_garage_test.test` is included lock in the functional state of the demo. I didn't think it was necessary to include an individual unit test for each system since these are System 1.0 systems that will soon be deprecated by System 2.0 variants. Each System 2.0 version of these Drake-ROS systems will have dedicated unit test coverage.

This PR includes elements extracted from #3103.

# Usage Instructions

For instructions on how to run the `single_car_in_stata_garage` demo and unit test, see: https://github.com/liangfok/drake/tree/feature/multi_car_sim_2_8/ros/drake_cars_examples

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3609)
<!-- Reviewable:end -->
