### PR TITLE
Ensure MATLAB tests that use yaml-cpp run

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -205,6 +205,7 @@ function(drake_add_matlab_test)
   if(_REQUIRES)
     foreach(_require ${_REQUIRES})
       string(TOUPPER ${_require} _require_upper)
+      string(REPLACE - _ _require_upper ${_require_upper})
       if(NOT WITH_${_require_upper} AND NOT ${_require}_FOUND AND NOT EXISTS "${CMAKE_INSTALL_PREFIX}/matlab/addpath_${_require}.m")
         message(STATUS
           "Not running ${_NAME} because ${_require} was not installed")


### PR DESCRIPTION
`WITH_*` option names are using an underscore in place of anything non-alphanumeric, which leads to a problem with a package name of `yaml-cpp`, and a comparison between `WITH_YAML-CPP` and `WITH_YAML_CPP` that will never pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3627)
<!-- Reviewable:end -->
