### PR TITLE
Revert "Simulation of a PID controlled second order plant."

### DIFF
--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -1,18 +1,10 @@
 #include "drake/systems/analysis/simulator.h"
 
 #include <cmath>
-#include <complex>
-
-#include <unsupported/Eigen/AutoDiff>
 
 #include "gtest/gtest.h"
 
-#include "drake/systems/framework/examples/controlled_spring_mass_system.h"
 #include "drake/systems/framework/examples/spring_mass_system.h"
-
-using Eigen::AutoDiffScalar;
-using Eigen::NumTraits;
-using std::complex;
 
 namespace drake {
 namespace systems {
@@ -167,100 +159,6 @@ GTEST_TEST(SimulatorTest, SpringMass) {
   // require more than one extra step per sample though.
   EXPECT_LE(spring_mass.get_publish_count(), 1030);
   EXPECT_EQ(spring_mass.get_update_count(), 30);
-}
-
-// Tests Simulator for a Diagram system consisting of a tree of systems.
-// In this case the System is a PidControlledSpringMassSystem which is a
-// Diagram containing a SpringMassSystem (the plant) and a PidController which
-// in turn is a Diagram composed of primitives such as Gain and Adder systems.
-GTEST_TEST(SimulatorTest, ControlledSpringMass) {
-  typedef complex<double> complexd;
-  typedef AutoDiffScalar<Vector1d> SingleVarAutoDiff;
-
-  // SpringMassSystem parameters.
-  const double kSpring = 300.0;  // N/m
-  const double kMass = 2.0;      // kg
-  // System's open loop frequency.
-  const double wol = sqrt(kSpring / kMass);
-
-  // Initial conditions.
-  const double x0 = 0.1;
-  const double v0 = 0.0;
-
-  // Choose some controller constants.
-  const double kp = kSpring;
-  const double ki = 0.0;
-  // System's undamped frequency (when kd = 0).
-  const double w0 = sqrt(wol * wol + kp / kMass);
-  // Damping ratio (underdamped).
-  const double zeta = 0.5;
-  const double kd = 2.0 * kMass * w0 * zeta;
-  const double x_target = 0.0;
-
-  PidControlledSpringMassSystem<double> spring_mass(
-      kSpring, kMass, kp, ki, kd, x_target);
-  Simulator<double> simulator(spring_mass);  // Use default Context.
-
-  // Sets initial conditions to zero.
-  spring_mass.SetDefaultState(simulator.get_mutable_context());
-
-  // Sets initial condition using the Simulator's internal Context.
-  spring_mass.set_position(simulator.get_mutable_context(), x0);
-  spring_mass.set_velocity(simulator.get_mutable_context(), v0);
-
-  // Takes all the defaults for the simulator.
-  simulator.Initialize();
-
-  EXPECT_TRUE(simulator.get_integrator_type_in_use() ==
-      IntegratorType::RungeKutta2);
-
-  // Computes analytical solution.
-  // 1) Roots of the characteristic equation.
-  complexd lambda1 = -zeta * w0 + w0 * sqrt(complexd(zeta * zeta - 1));
-  complexd lambda2 = -zeta * w0 - w0 * sqrt(complexd(zeta * zeta - 1));
-
-  // Roots should be the complex conjugate of each other.
-  EXPECT_NEAR(lambda1.real(),  lambda2.real(), NumTraits<double>::epsilon());
-  EXPECT_NEAR(lambda1.imag(), -lambda2.imag(), NumTraits<double>::epsilon());
-
-  // The damped frequency corresponds to the absolute value of the imaginary
-  // part of any of the roots.
-  double wd = abs(lambda1.imag());
-
-  // 2) Differential equation's constants of integration.
-  double C1 = x0;
-  double C2 = (zeta * w0 * x0 + v0) / wd;
-
-  // 3) Computes analytical solution at time final_time.
-  // Velocity is computed using AutoDiffScalar.
-  double final_time = 0.2;
-  double x_final{}, v_final{};
-  { // At the end of this local scope x_final and v_final are properly
-    // initialized.
-    // Auxiliary AutoDiffScalar variables are confined to this local scope so
-    // that we don't pollute the test's scope with them.
-    SingleVarAutoDiff time(final_time);
-    time.derivatives() << 1.0;
-    auto x = exp(-zeta * w0 * time) * (
-        C1 * cos(wd * time) + C2 * sin(wd * time));
-    x_final = x.value();
-    v_final = x.derivatives()[0];
-  }
-
-  // Simulates to final_time.
-  simulator.StepTo(final_time);
-
-  EXPECT_EQ(simulator.get_num_steps_taken(), 200);
-  EXPECT_NEAR(simulator.get_smallest_step_size_taken(),
-              simulator.get_largest_step_size_taken(),
-              NumTraits<double>::epsilon());
-
-  const auto& context = simulator.get_context();
-  EXPECT_EQ(context.get_time(), final_time);  // Should be exact.
-
-  // Compares with analytical solution (to numerical integration error).
-  EXPECT_NEAR(spring_mass.get_position(context), x_final, 3.0e-6);
-  EXPECT_NEAR(spring_mass.get_velocity(context), v_final, 1.0e-5);
 }
 
 }  // namespace

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -236,22 +236,9 @@ class Diagram : public System<T>,
     return diagram_derivatives->get_substate(i);
   }
 
-  /// Returns a constant reference to the subcontext that corresponds to the
-  /// system @p subsystem.
-  /// Classes inheriting from %Diagram need access to this method in order to
-  /// pass their constituent subsystems the apropriate subcontext. Aborts if
-  /// @p subsystem is not actually a subsystem of this diagram.
-  const Context<T>& GetSubsystemContext(const Context<T>& context,
-                                        const System<T>* subsystem) const {
-    DRAKE_DEMAND(subsystem != nullptr);
-    auto& diagram_context = dynamic_cast<const DiagramContext<T>&>(context);
-    const int i = GetSystemIndexOrAbort(subsystem);
-    return *diagram_context.GetSubsystemContext(i);
-  }
-
   /// Returns the subcontext that corresponds to the system @p subsystem.
   /// Classes inheriting from %Diagram need access to this method in order to
-  /// pass their constituent subsystems the apropriate subcontext. Aborts if
+  /// pass their constituent subsystem's the apropriate subcontext. Aborts if
   /// @p subsystem is not actually a subsystem of this diagram.
   Context<T>* GetMutableSubsystemContext(Context<T>* context,
                                          const System<T>* subsystem) const {

--- a/drake/systems/framework/examples/controlled_spring_mass_system.cc
+++ b/drake/systems/framework/examples/controlled_spring_mass_system.cc
@@ -92,30 +92,6 @@ void PidControlledSpringMassSystem<T>::SetDefaultState(
 }
 
 template <typename T>
-T PidControlledSpringMassSystem<T>::get_position(
-    const Context<T>& context) const {
-  const Context<T>& plant_context =
-      Diagram<T>::GetSubsystemContext(context, plant_);
-  return plant_->get_position(plant_context);
-}
-
-template <typename T>
-T PidControlledSpringMassSystem<T>::get_velocity(
-    const Context<T>& context) const {
-  const Context<T>& plant_context =
-      Diagram<T>::GetSubsystemContext(context, plant_);
-  return plant_->get_velocity(plant_context);
-}
-
-template <typename T>
-T PidControlledSpringMassSystem<T>::get_conservative_work(
-    const Context<T>& context) const {
-  const Context<T>& plant_context =
-      Diagram<T>::GetSubsystemContext(context, plant_);
-  return plant_->get_conservative_work(plant_context);
-}
-
-template <typename T>
 void PidControlledSpringMassSystem<T>::set_position(
     Context<T>* context, const T& position) const {
   Context<T>* plant_context =

--- a/drake/systems/framework/examples/controlled_spring_mass_system.h
+++ b/drake/systems/framework/examples/controlled_spring_mass_system.h
@@ -44,12 +44,6 @@ class PidControlledSpringMassSystem : public Diagram<T> {
 
   ~PidControlledSpringMassSystem() override {}
 
-  T get_position(const Context<T>& context) const;
-
-  T get_velocity(const Context<T>& context) const;
-
-  T get_conservative_work(const Context<T>& context) const;
-
   /// Sets the position of the mass in the given Context.
   void set_position(Context<T>* context, const T& position) const;
 


### PR DESCRIPTION
Dear @amcastro-tri ,

The on-call build cop, @betsymcphail , believes that your PR #3288 may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration pre-merge, because additional
platforms and tests are built post-merge.

The specific build failures under investigation are:
mac-continuous, such as https://drake-jenkins.csail.mit.edu/view/Continuous/job/mac-clang-continuous-release/796/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3636)
<!-- Reviewable:end -->
