### PR TITLE
Renamed "drake-rbs" to be "drake-rigid-body-plant".

### DIFF
--- a/drake/systems/plants/rigid_body_plant/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/CMakeLists.txt
@@ -36,7 +36,7 @@ drake_install_headers(
     ${lcm_dependent_header_files}
     kinematics_results.h rigid_body_plant.h)
 pods_install_libraries(drakeRigidBodyPlant)
-pods_install_pkg_config_file(drake-rbs
+pods_install_pkg_config_file(drake-rigid-body-plant
     CFLAGS -I${CMAKE_INSTALL_PREFIX}/include
     LIBS -ldrakeRigidBodyPlant -ldrakeRBM
     VERSION 0.0.1)


### PR DESCRIPTION
I believe "rbs" stands for "Rigid Body System" which does not exist in System 2.0. Thus, I believe "drake-rigid-body-plant" is more correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3638)
<!-- Reviewable:end -->
