### PR TITLE
Add in-tree support for running valgrind

### DIFF
--- a/drake/doc/unit_testing_instructions.rst
+++ b/drake/doc/unit_testing_instructions.rst
@@ -82,6 +82,16 @@ To run every enabled unit test, execute::
     cd drake-distro/build/drake
     ctest -VV
 
+To run tests in parallel, either add the ``-j`` option to the command line,
+e.g., ``ctest -VV -j$(nproc)``, or set the ``CTEST_PARALLEL_LEVEL`` environment
+variable, e.g., ``export CTEST_PARALLEL_LEVEL=$(nproc)``.  (Testing in parallel
+can be applied to any of the ``ctest`` command lines in this document.)
+
+To run every valgrind-enabled test, execute::
+
+    cd drake-distro/build/drake
+    ctest -C valgrind -R ^valgrind
+
 .. _list-all-unit-tests:
 
 Finding a Specific Unit Test
@@ -97,6 +107,9 @@ If you have a clue about a particular unit test's name, you can pipe the output
 of the `ctest -N` command to `grep`. One way to learn the name of a unit test is
 to look at the ``CMakeLists.txt`` that adds the unit test to the build system.
 
+To include the valgrind variants of tests, add ``-C valgrind`` to the command,
+e.g., ``ctest -C valgrind -N``.
+
 .. _running-a-specific-test:
 
 Running a Specific Test
@@ -105,12 +118,13 @@ Running a Specific Test
 Once you know the unit tests' name, you can run it by executing::
 
   cd drake-distro/build/drake
-  ctest -VV -C [build mode] -R [test name]
+  ctest -VV -R [test name]
 
-where: ``[build mode]`` is the build mode, e.g., ``Debug``, ``RelWithDebInfo``,
-or ``Release``, and ``[test name]`` is the name of the test exactly as printed
-by ``ctest -N`` including, if any, the entire path to the test as printed on the
-screen.
+where: ``[test name]`` is the name of the test exactly as printed by ``ctest
+-N`` including, if any, the entire path to the test as printed on the screen.
+
+To run the test in both non-valgrind and valgrind modes (highly recommended!),
+add ``-C valgrind`` to the command: ``ctest -VV -C valgrind -R [test name]``.
 
 .. _example-running-unit-test:
 
@@ -124,7 +138,7 @@ Find test::
 
 Run the test::
 
-  ctest -VV -C RelWithDebInfo -R cascade_system_test
+  ctest -VV -R cascade_system_test
 
 .. _enabling-assertions:
 

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-drake_add_cc_test(mathematical_program_test)
+# TODO(jwnimmer-tri) Get valgrind passing again.
+drake_add_cc_test(NAME mathematical_program_test NO_VALGRIND)
 target_link_libraries(mathematical_program_test drakeOptimization)
 
 if(mosek_FOUND)
@@ -20,6 +21,8 @@ if(gurobi_FOUND)
 endif()
 
 if(dreal_FOUND)
-  drake_add_cc_test(dreal_solver_test)
+  # TODO(jwnimmer-tri) Xenial valgrind has a broken RDRAND.  Find a way to turn
+  # valgrind on again here.  (See https://bugs.kde.org/show_bug.cgi?id=353370.)
+  drake_add_cc_test(NAME dreal_solver_test NO_VALGRIND)
   target_link_libraries(dreal_solver_test drakeOptimization)
 endif()

--- a/drake/systems/plants/collision/test/CMakeLists.txt
+++ b/drake/systems/plants/collision/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(Bullet)
 
 if(BULLET_FOUND)
-  drake_add_cc_test(model_test)
+  # TODO(jwnimmer-tri) Get valgrind passing again.
+  drake_add_cc_test(NAME model_test NO_VALGRIND)
   target_link_libraries(model_test drakeCollision)
 endif()
 

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -95,7 +95,8 @@ if(lcm_FOUND)
     drake_add_test(NAME comparePriusURDFtoSDF COMMAND compareRigidBodySystems prius.sdf prius.urdf WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/automotive/models/prius")
   endif()
 
-  drake_add_cc_test(load_model_test)
+  # TODO(jwnimmer-tri) Get valgrind passing again.
+  drake_add_cc_test(NAME load_model_test NO_VALGRIND)
   target_link_libraries(load_model_test drakeRBSystem)
 endif()
 

--- a/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
@@ -5,7 +5,8 @@ if(BULLET_FOUND)
   target_link_libraries(rbt_collisions_test drakeRBM)
 endif()
 
-drake_add_cc_test(rigid_body_tree_test)
+# TODO(jwnimmer-tri) Get valgrind passing again.
+drake_add_cc_test(NAME rigid_body_tree_test NO_VALGRIND)
 target_link_libraries(rigid_body_tree_test drakeRBSystem)
 
 drake_add_cc_test(rigid_body_tree_inverse_dynamics_test)


### PR DESCRIPTION
Add in-tree support for running valgrind, including a first pass at supporting documentation.

Currently passes for me with release builds; some debug builds hit a timeout.

I'm not sure yet what else I want to add here before merging, but I wanted to post this as a starting point FYI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3656)
<!-- Reviewable:end -->
