### PR TITLE
Move clique test into bullet buffer - fixes betsy problem for PR #3659

### DIFF
--- a/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
@@ -3,6 +3,9 @@ find_package(Bullet)
 if(BULLET_FOUND)
   drake_add_cc_test(rbt_collisions_test)
   target_link_libraries(rbt_collisions_test drakeRBM)
+
+  drake_add_cc_test(rigid_body_collision_clique_test)
+  target_link_libraries(rigid_body_collision_clique_test drakeRBSystem)
 endif()
 
 drake_add_cc_test(rigid_body_tree_test)
@@ -10,6 +13,3 @@ target_link_libraries(rigid_body_tree_test drakeRBSystem)
 
 drake_add_cc_test(rigid_body_tree_inverse_dynamics_test)
 target_link_libraries(rigid_body_tree_inverse_dynamics_test drakeRBSystem)
-
-drake_add_cc_test(rigid_body_collision_clique_test)
-target_link_libraries(rigid_body_collision_clique_test drakeRBSystem)


### PR DESCRIPTION
This puts the collision clique test behind the "bullet" wall; if bullet is not present, the test will not compile.  Previously, it was on the wrong side of the wall and was being executed in an invalid context.  Thanks @jamiesnape  for the solution.

See PR #3659 @BetsyMcPhail

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3661)
<!-- Reviewable:end -->
