### PR TITLE
Make Context<T>::GetInputPort protected.

### DIFF
--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -227,18 +227,6 @@ class DiagramContext : public Context<T> {
     return static_cast<int>(input_ids_.size());
   }
 
-  /// Returns the input port at the given @p index, which of course belongs
-  /// to the subsystem whose input was exposed at that index.
-  const InputPort* GetInputPort(int index) const override {
-    if (index < 0 || index >= get_num_input_ports()) {
-      throw std::out_of_range("Input port out of range.");
-    }
-    const PortIdentifier& id = input_ids_[index];
-    SystemIndex system_index = id.first;
-    PortIndex port_index = id.second;
-    return GetSubsystemContext(system_index)->GetInputPort(port_index);
-  }
-
   void SetInputPort(int index, std::unique_ptr<InputPort> port) override {
     if (index < 0 || index >= get_num_input_ports()) {
       throw std::out_of_range("Input port out of range.");
@@ -291,6 +279,19 @@ class DiagramContext : public Context<T> {
     *clone->get_mutable_step_info() = this->get_step_info();
 
     return clone;
+  }
+
+  /// Returns the input port at the given @p index, which of course belongs
+  /// to the subsystem whose input was exposed at that index.
+  const InputPort* GetInputPort(int index) const override {
+    if (index < 0 || index >= get_num_input_ports()) {
+      throw std::out_of_range("Input port out of range.");
+    }
+    const PortIdentifier& id = input_ids_[index];
+    SystemIndex system_index = id.first;
+    PortIndex port_index = id.second;
+    return Context<T>::GetInputPort(*GetSubsystemContext(system_index),
+                                    port_index);
   }
 
  private:

--- a/drake/systems/framework/leaf_context.h
+++ b/drake/systems/framework/leaf_context.h
@@ -29,13 +29,6 @@ class LeafContext : public Context<T> {
   LeafContext() {}
   virtual ~LeafContext() {}
 
-  const InputPort* GetInputPort(int index) const override {
-    if (index < 0 || index >= get_num_input_ports()) {
-      throw std::out_of_range("Input port out of range.");
-    }
-    return inputs_[index].get();
-  }
-
   void SetInputPort(int index, std::unique_ptr<InputPort> port) override {
     if (index < 0 || index >= get_num_input_ports()) {
       throw std::out_of_range("Input port out of range.");
@@ -140,6 +133,13 @@ class LeafContext : public Context<T> {
     *context->get_mutable_step_info() = this->get_step_info();
     context->cache_ = this->cache_;
     return context;
+  }
+
+  const InputPort* GetInputPort(int index) const override {
+    if (index < 0 || index >= get_num_input_ports()) {
+      throw std::out_of_range("Input port out of range.");
+    }
+    return inputs_[index].get();
   }
 
  private:

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -160,17 +160,7 @@ class System {
     // Checks that the size of the input ports in the context matches the
     // declarations made by the system.
     for (int i = 0; i < this->get_num_input_ports(); ++i) {
-      // TODO(amcastro-tri): add appropriate checks for kAbstractValued ports
-      // once abstract ports are implemented in 3164.
-      if (this->get_input_port(i).get_data_type() == kVectorValued) {
-        const InputPort* input_port = context.GetInputPort(i);
-        DRAKE_THROW_UNLESS(input_port != nullptr);
-        const BasicVector<T>* input_vector =
-            input_port->template get_vector_data<T>();
-        DRAKE_THROW_UNLESS(input_vector != nullptr);
-        DRAKE_THROW_UNLESS(input_vector->size() ==
-                           get_input_port(i).get_size());
-      }
+      context.VerifyInputPort(this->get_input_port(i));
     }
   }
 

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -179,19 +179,6 @@ TEST_F(DiagramContextTest, Clone) {
     EXPECT_TRUE(CompareMatrices(orig_port->get_value(), clone_port->get_value(),
                                 1e-8, MatrixCompareType::absolute));
   }
-
-  // Verify that the graph structure was preserved: the VectorBase in
-  // sys0 output port 0 should be pointer-equal to the VectorBase in
-  // sys1 input port 1.
-  //
-  // This assertion abuses the GetInputPort implementation detail to fish out
-  // a pointer to the input vector without triggering an evaluation.
-  // An evaluation is not possible in this test fixture because there is no
-  // Diagram for context_ that can be asked to eval the input.
-  auto sys1_context = clone->GetSubsystemContext(1);
-  auto sys0_output = clone->GetSubsystemOutput(0);
-  EXPECT_EQ(sys1_context->GetInputPort(1)->get_vector_data<double>(),
-            sys0_output->get_vector_data(0));
 }
 
 }  // namespace


### PR DESCRIPTION
This prevents System authors from accessing an input port that has not been `Eval`ed.

@siyuanfeng-tri for feature review, @sammy-tri for platform review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3672)
<!-- Reviewable:end -->
