### PR TITLE
Fix a bunch of sign-compare warnings

### DIFF
--- a/drake/systems/framework/primitives/test/zero_order_hold_test.cc
+++ b/drake/systems/framework/primitives/test/zero_order_hold_test.cc
@@ -87,7 +87,7 @@ TEST_F(ZeroOrderHoldTest, NextUpdateTimeMustNotBeCurrentTime) {
   EXPECT_EQ(next_t, actions.time);
 
   // Check that the action is to update.
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
   const DiscreteEvent<double>& event = actions.events[0];
   EXPECT_EQ(hold_.get(), event.recipient);
   EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, event.action);
@@ -106,7 +106,7 @@ TEST_F(ZeroOrderHoldTest, NextUpdateTimeIsInTheFuture) {
   EXPECT_EQ(next_t, actions.time);
 
   // Check that the action is to update.
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
   const DiscreteEvent<double>& event = actions.events[0];
   EXPECT_EQ(hold_.get(), event.recipient);
   EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, event.action);

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -50,7 +50,7 @@ TEST_F(LeafSystemTest, NoUpdateEvents) {
   UpdateActions<double> actions;
   system_.CalcNextUpdateTime(context_, &actions);
   EXPECT_EQ(std::numeric_limits<double>::infinity(), actions.time);
-  EXPECT_EQ(0, actions.events.size());
+  EXPECT_EQ(0u, actions.events.size());
 }
 
 // Tests that if the current time is smaller than the offset, the next
@@ -62,7 +62,7 @@ TEST_F(LeafSystemTest, OFfsetHasNotArrivedYet) {
   system_.CalcNextUpdateTime(context_, &actions);
 
   EXPECT_EQ(5.0, actions.time);
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
   EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, actions.events[0].action);
 }
 
@@ -75,7 +75,7 @@ TEST_F(LeafSystemTest, ExactlyAtOffset) {
   system_.CalcNextUpdateTime(context_, &actions);
 
   EXPECT_EQ(15.0, actions.time);
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
   EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, actions.events[0].action);
 }
 
@@ -88,7 +88,7 @@ TEST_F(LeafSystemTest, OffsetIsInThePast) {
   system_.CalcNextUpdateTime(context_, &actions);
 
   EXPECT_EQ(25.0, actions.time);
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
   EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, actions.events[0].action);
 }
 
@@ -101,7 +101,7 @@ TEST_F(LeafSystemTest, ExactlyOnUpdateTime) {
   system_.CalcNextUpdateTime(context_, &actions);
 
   EXPECT_EQ(35.0, actions.time);
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
   EXPECT_EQ(DiscreteEvent<double>::kUpdateAction, actions.events[0].action);
 }
 

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -154,7 +154,7 @@ TEST_F(SystemTest, DiscretePublish) {
   UpdateActions<double> actions;
 
   system_.CalcNextUpdateTime(context_, &actions);
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
 
   system_.Publish(context_, actions.events[0]);
   EXPECT_EQ(1, system_.get_publish_count());
@@ -168,7 +168,7 @@ TEST_F(SystemTest, DiscreteUpdate) {
   UpdateActions<double> actions;
 
   system_.CalcNextUpdateTime(context_, &actions);
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
 
   std::unique_ptr<DifferenceState<double>> update =
       system_.AllocateDifferenceVariables();
@@ -183,10 +183,10 @@ TEST_F(SystemTest, CustomDiscretePublish) {
   UpdateActions<double> actions;
 
   system_.CalcNextUpdateTime(context_, &actions);
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
 
   system_.Publish(context_, actions.events[0]);
-  ASSERT_EQ(1, system_.get_published_numbers().size());
+  ASSERT_EQ(1u, system_.get_published_numbers().size());
   EXPECT_EQ(kNumberToPublish, system_.get_published_numbers()[0]);
 }
 
@@ -197,12 +197,12 @@ TEST_F(SystemTest, CustomDiscreteUpdate) {
   UpdateActions<double> actions;
 
   system_.CalcNextUpdateTime(context_, &actions);
-  ASSERT_EQ(1, actions.events.size());
+  ASSERT_EQ(1u, actions.events.size());
 
   std::unique_ptr<DifferenceState<double>> update =
       system_.AllocateDifferenceVariables();
   system_.EvalDifferenceUpdates(context_, actions.events[0], update.get());
-  ASSERT_EQ(1, system_.get_updated_numbers().size());
+  ASSERT_EQ(1u, system_.get_updated_numbers().size());
   EXPECT_EQ(kNumberToUpdate, system_.get_updated_numbers()[0]);
 }
 


### PR DESCRIPTION
I don't know why CI isn't hitting these, but all of my local builds are failing because of this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3677)
<!-- Reviewable:end -->
