### PR TITLE
Ubuntu 16.04 set-up script installs Clang 3.9

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -17,12 +17,23 @@ me="The Drake prerequisite set-up script"
 
 [[ $DISTRIB_RELEASE == "16.04" ]] || die "$me only supports Ubuntu 16.04."
 
-# Clang 3.9
-apt-get install --no-install-recommends lsb-core software-properties-common wget
-wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-add-apt-repository -y "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main"
-apt-get update
-apt-get upgrade
+# Install Clang 3.9
+while true; do
+  echo "Adding repository 'deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main'"
+  read -p "Do you want to continue? [Y/n] " yn
+  case $yn in
+    [Yy]*)
+      apt-get install --no-install-recommends lsb-core software-properties-common wget
+      wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+      add-apt-repository -y "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main"
+      apt-get update
+      apt install --no-install-recommends clang-3.9
+      break
+      ;;
+    [Nn]*) break ;;
+    *) echo "Please answer yes or no." ;;
+  esac
+done
 
 # Install the APT dependencies.
 # TODO(david-german-tri): Can we remove libvtk-java, subversion?
@@ -31,7 +42,6 @@ apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 autoconf
 automake
 bison
-clang-3.9
 cmake
 cmake-curses-gui
 default-jdk

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -19,7 +19,10 @@ me="The Drake prerequisite set-up script"
 
 # Install Clang 3.9
 while true; do
-  echo "Adding repository 'deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main'"
+  echo "The Ubuntu 16.04 distribution includes Clang 3.8 by default. To install \
+  Clang 3.9 it is necessary to add a Personal Package Archive (PPA)."
+  echo "This script will add the repository
+    'deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main'"
   read -p "Do you want to continue? [Y/n] " yn
   case $yn in
     [Yy]*)

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -17,6 +17,13 @@ me="The Drake prerequisite set-up script"
 
 [[ $DISTRIB_RELEASE == "16.04" ]] || die "$me only supports Ubuntu 16.04."
 
+# Clang 3.9
+apt-get install --no-install-recommends lsb-core software-properties-common wget
+wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+add-apt-repository -y "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main"
+apt-get update
+apt-get upgrade
+
 # Install the APT dependencies.
 # TODO(david-german-tri): Can we remove libvtk-java, subversion?
 apt install --no-install-recommends $(tr '\n' ' ' <<EOF
@@ -24,7 +31,7 @@ apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 autoconf
 automake
 bison
-clang
+clang-3.9
 cmake
 cmake-curses-gui
 default-jdk


### PR DESCRIPTION
As noted in #3641, Clang 3.9 is needed on Ubuntu 16.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3697)
<!-- Reviewable:end -->
