### PR TITLE
Add a sanity-check assertion to SetZeroConfiguration.

### DIFF
--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
@@ -121,10 +121,16 @@ class DRAKE_EXPORT RigidBodyPlant : public LeafSystem<T> {
   /// Sets the state in @p context so that generalized positions and velocities
   /// are zero. For quaternion based joints the quaternion is set to be the
   /// identity (or equivalently a zero rotation).
-  void SetZeroConfiguration(Context<T> *context) const {
+  void SetZeroConfiguration(Context<T>* context) const {
+    // Extract a pointer to continuous state from the context.
+    DRAKE_DEMAND(context != nullptr);
+    ContinuousState<T>* xc = context->get_mutable_continuous_state();
+    DRAKE_DEMAND(xc != nullptr);
+
+    // Write the zero configuration into the continuous state.
     VectorX<T> x0 = VectorX<T>::Zero(get_num_states());
     x0.head(get_num_positions()) = tree_->getZeroConfiguration();
-    context->get_mutable_continuous_state()->SetFromVector(x0);
+    xc->SetFromVector(x0);
   }
 
   // System<T> overrides.


### PR DESCRIPTION
I still don't fully understand how @ggould-tri's WIP branch violated this assertion, but since it happened, we should check it.

+@ggould-tri for both levels of review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3705)
<!-- Reviewable:end -->
