### PR TITLE
Temporary Fail Fast if Leaf System Non-Vector-Valued Port.

### DIFF
--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -61,6 +61,9 @@ class LeafSystem : public System<T> {
       const Context<T>& context) const override {
     std::unique_ptr<LeafSystemOutput<T>> output(new LeafSystemOutput<T>);
     for (const auto& descriptor : this->get_output_ports()) {
+      // TODO(liang.fok) Generalize this method to support ports of type
+      // kAbstractValued.
+      DRAKE_DEMAND(descriptor.get_data_type() == kVectorValued);
       output->get_mutable_ports()->emplace_back(
           new OutputPort(AllocateOutputVector(descriptor)));
     }


### PR DESCRIPTION
Added a fail-fast if a leaf system attempts to allocate an output port that's not of type `kVectorValued`. I left a TODO saying the `AllocateOutput()` method should be generalized to support `kAbstractValued` ports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3707)
<!-- Reviewable:end -->
