### PR TITLE
Fix CMake policy CMP0054 warnings

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -275,9 +275,9 @@ file(WRITE ${CMAKE_INSTALL_PREFIX}/matlab/get_drake_install_dir.m
   "end\n"
   "\n")
 
-find_program(avl avl PATHS ${CMAKE_INSTALL_DIR}/bin)
-find_program(xfoil xfoil PATHS ${CMAKE_INSTALL_DIR}/bin)
-find_program(ffmpeg ffmpeg)
+find_program(AVL_EXECUTABLE avl PATHS "${CMAKE_INSTALL_PREFIX}/bin")
+find_program(XFOIL_EXECUTABLE xfoil PATHS "${CMAKE_INSTALL_PREFIX}/bin")
+find_program(FFMPEG_EXECUTABLE ffmpeg)
 
 if(APPLE)
   set(DYLD_LIBRARY_PATH "$ENV{DYLD_LIBRARY_PATH}" CACHE STRING "Environment variable used to launch processes from Matlab")

--- a/drake/systems/plants/@RigidBodyWing/RigidBodyWing.m
+++ b/drake/systems/plants/@RigidBodyWing/RigidBodyWing.m
@@ -168,7 +168,7 @@ classdef RigidBodyWing < RigidBodyForceElement
       
       function runAvl()
         checkDependency('avl');
-        avlpath = deblank(getCMakeParam('avl'));
+        avlpath = deblank(getCMakeParam('AVL_EXECUTABLE'));
 
         avlfile = fileread(which('avlblank.avl'));
         avlfile = regexprep(avlfile, '\$airfoil', avlprofile);
@@ -257,8 +257,8 @@ classdef RigidBodyWing < RigidBodyForceElement
       
       function runXfoil()
         checkDependency('xfoil');
-        xfoilpath = deblank(getCMakeParam('xfoil'));
-        
+        xfoilpath = deblank(getCMakeParam('XFOIL_EXECUTABLE'));
+
         % Reads template Xfoil commands file and fills in appropriate values
         xfoilfile = fileread(which('xfoilblank.txt'));
         filename = tempname;

--- a/drake/systems/plants/BotVisualizer.m
+++ b/drake/systems/plants/BotVisualizer.m
@@ -219,7 +219,7 @@ classdef BotVisualizer < RigidBodyVisualizer
     end
     
     function playbackMovie(obj,xtraj,filename,options)
-      ffmpeg = getCMakeParam('ffmpeg');
+      ffmpeg = getCMakeParam('FFMPEG_EXECUTABLE');
       if isempty(ffmpeg)
         error('need ffmpeg.  rerun make configure from the prompt to help find it');
       end

--- a/drake/util/checkDependency.m
+++ b/drake/util/checkDependency.m
@@ -336,8 +336,8 @@ else % then try to evaluate the dependency now...
 
     case 'avl'
       if ~isfield(conf,'avl') || isempty(conf.avl)
-        path_to_avl = getCMakeParam('avl');
-        if isempty(path_to_avl) || strcmp(path_to_avl,'avl-NOTFOUND')
+        path_to_avl = getCMakeParam('AVL_EXECUTABLE');
+        if isempty(path_to_avl) || strcmp(path_to_avl,'AVL_EXECUTABLE-NOTFOUND')
           if nargout<1
             disp(' ');
             disp(' AVL support is disabled.  To enable it, install AVL from here: http://web.mit.edu/drela/Public/web/avl/, then add it to the matlab path or set the path to the avl executable explicitly using editDrakeConfig(''avl'',path_to_avl_executable) and rerun make');
@@ -352,8 +352,8 @@ else % then try to evaluate the dependency now...
 
     case 'xfoil'
       if ~isfield(conf,'xfoil') || isempty(conf.xfoil)
-        path_to_xfoil = getCMakeParam('xfoil');
-        if isempty(path_to_xfoil) || strcmp(path_to_xfoil,'xfoil-NOTFOUND')
+        path_to_xfoil = getCMakeParam('XFOIL_EXECUTABLE');
+        if isempty(path_to_xfoil) || strcmp(path_to_xfoil,'XFOIL_EXECUTABLE-NOTFOUND')
           if nargout<1
             disp(' ');
             disp(' XFOIL support is disabled.  To enable it, install XFOIL from here: http://web.mit.edu/drela/Public/web/xfoil/, then add it to the matlab path or set the path to the xfoil executable explicitly using editDrakeConfig(''xfoil'',path_to_avl_executable) and rerun addpath_drake');


### PR DESCRIPTION
Fixes warnings such as these (and preempts one involving `ffmpeg`):
```
Make Warning (dev) at drake/build/install/share/avl/avl-targets.cmake:28 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "avl" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.

CMake Warning (dev) at drake/build/install/share/xfoil/xfoil-targets.cmake:28 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "xfoil" will no longer be dereferenced when the
  policy is set to NEW.  Since the policy is not set the OLD behavior will be
  used.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3725)
<!-- Reviewable:end -->
