### PR TITLE
Fixed pendulum_run_energy_shaping Example.

### DIFF
--- a/drake/examples/Pendulum/pendulum_run_energy_shaping.cc
+++ b/drake/examples/Pendulum/pendulum_run_energy_shaping.cc
@@ -4,6 +4,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"
 #include "drake/examples/Pendulum/pendulum_system.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -57,7 +58,7 @@ class PendulumEnergyShapingController : public systems::LeafSystem<T> {
 };
 
 int do_main(int argc, char* argv[]) {
-  lcm::LCM lcm;
+  lcm::DrakeLcm lcm;
   RigidBodyTree tree(GetDrakePath() + "/examples/Pendulum/Pendulum.urdf",
                      systems::plants::joints::kFixed);
 


### PR DESCRIPTION
This is a fix-forward of the problem described here: https://github.com/RobotLocomotion/drake/pull/3712#issuecomment-252422873.

I labeled it "emergency" because all of CI is broken without this patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3728)
<!-- Reviewable:end -->
