### PR TITLE
Add PidControlledSystem, and convert pendulum_run_swing_up to use it

### DIFF
--- a/drake/examples/Pendulum/CMakeLists.txt
+++ b/drake/examples/Pendulum/CMakeLists.txt
@@ -1,21 +1,13 @@
 if(lcm_FOUND)
-  add_library_with_exports(LIB_NAME drakePendulum SOURCE_FILES
-    pendulum_swing_up.cc
-    )
-  target_link_libraries(drakePendulum drakeDynamicConstraint
-    drakeTrajectoryOptimization drakeLCMTypes)
-  pods_install_libraries(drakePendulum)
-  drake_install_headers(Pendulum.h pendulum_swing_up.h)
-  pods_install_pkg_config_file(drake-pendulum
-    LIBS -ldrakePendulum
-    REQUIRES
-    VERSION 0.0.1)
+  drake_install_headers(Pendulum.h)
 
   add_library_with_exports(LIB_NAME drakePendulumSystem
-    SOURCE_FILES pendulum_system.cc)
-  target_link_libraries(drakePendulumSystem drakeSystemFramework)
+    SOURCE_FILES pendulum_swing_up.cc pendulum_system.cc)
+  target_link_libraries(drakePendulumSystem drakeSystemFramework
+    drakeDynamicConstraint
+    drakeTrajectoryOptimization)
   pods_install_libraries(drakePendulumSystem)
-  drake_install_headers(pendulum_system.h)
+  drake_install_headers(pendulum_system.h pendulum_swing_up.h)
   pods_install_pkg_config_file(drake-pendulum-system
     LIBS -ldrakePendulumSystem
     REQUIRES
@@ -44,9 +36,10 @@ if(lcm_FOUND)
 
   add_executable(pendulum_run_swing_up pendulum_run_swing_up.cc)
   target_link_libraries(pendulum_run_swing_up
-    drakePendulum
-    drakeRBM
-    drakeLCMSystem)
+    drakePendulumSystem
+    drakeRigidBodyPlant
+    drakeSystemControllers
+    drakeSystemAnalysis)
   # TODO(sam.creasey) There is currently no non-linear solver on Windows: see
   # issues #2352, #2569.
   find_package(NLopt)

--- a/drake/examples/Pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_run_swing_up.cc
@@ -1,31 +1,41 @@
 
-#include <cmath>
+#include <iostream>
 #include <memory>
-#include <stdexcept>
 
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/examples/Pendulum/pendulum_swing_up.h"
+#include "drake/examples/Pendulum/pendulum_system.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/solvers/trajectoryOptimization/dircol_trajectory_optimization.h"
-#include "drake/systems/LCMSystem.h"
-#include "drake/systems/Simulation.h"
-#include "drake/systems/cascade_system.h"
-#include "drake/systems/controllers/simple_feedback_trajectory_controller.h"
-#include "drake/systems/feedback_system.h"
-#include "drake/systems/plants/BotVisualizer.h"
-#include "drake/systems/plants/robot_state_tap.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/controllers/pid_controlled_system.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/primitives/time_varying_polynomial_source.h"
+#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
 #include "drake/util/drakeAppUtil.h"
 
-using drake::SimpleFeedbackTrajectoryController;
 using drake::solvers::SolutionResult;
 using drake::MatrixCompareType;
 
 typedef PiecewisePolynomial<double> PiecewisePolynomialType;
 
-int main(int argc, char* argv[]) {
-  auto p = make_shared<Pendulum>();
+namespace drake {
+namespace examples {
+namespace pendulum {
+namespace {
 
+int do_main(int argc, char* argv[]) {
+  systems::DiagramBuilder<double> builder;
+  auto pendulum = std::make_unique<PendulumSystem<double>>();
+  PendulumSystem<double>* pendulum_p = pendulum.get();
+
+  // This is a fairly small number of time samples for this system,
+  // and it winds up making the controller do a lot of the work when
+  // getting to the target state.  I (sam.creasey) suspect that a
+  // different interpolation strategy (not linear interpolation of a
+  // non-linear system, basically) would reduce this effect.
   const int kNumTimeSamples = 21;
   const int kTrajectoryTimeLowerBound = 2;
   const int kTrajectoryTimeUpperBound = 6;
@@ -34,11 +44,12 @@ int main(int argc, char* argv[]) {
   const Eigen::Vector2d xG(M_PI, 0);
 
   drake::solvers::DircolTrajectoryOptimization dircol_traj(
-      drake::getNumInputs(*p), drake::getNumStates(*p),
+      pendulum->get_tau_port().get_size(),
+      pendulum->get_output_port().get_size(),
       kNumTimeSamples,  kTrajectoryTimeLowerBound,
       kTrajectoryTimeUpperBound);
   drake::examples::pendulum::AddSwingUpTrajectoryParams(
-      p, kNumTimeSamples, x0, xG, &dircol_traj);
+      kNumTimeSamples, x0, xG, &dircol_traj);
 
   const double timespan_init = 4;
   auto traj_init_x = PiecewisePolynomialType::FirstOrderHold(
@@ -55,39 +66,55 @@ int main(int argc, char* argv[]) {
       dircol_traj.ReconstructInputTrajectory();
   const PiecewisePolynomialType pp_xtraj =
       dircol_traj.ReconstructStateTrajectory();
+  auto input_source = builder.AddSystem<
+    systems::TimeVaryingPolynomialSource>(pp_traj);
+  auto state_source = builder.AddSystem<
+    systems::TimeVaryingPolynomialSource>(pp_xtraj);
 
-  shared_ptr<lcm::LCM> lcm = make_shared<lcm::LCM>();
-  if (!lcm->good()) return 1;
+  lcm::DrakeLcm lcm;
+  RigidBodyTree tree(GetDrakePath() + "/examples/Pendulum/Pendulum.urdf",
+                     systems::plants::joints::kFixed);
+  auto publisher =
+      builder.AddSystem<systems::RigidBodyTreeLcmPublisher>(tree, &lcm);
 
-  auto visualizer = std::make_shared<drake::BotVisualizer<PendulumState>>(
-      lcm, drake::GetDrakePath() + "/examples/Pendulum/Pendulum.urdf",
-      drake::systems::plants::joints::kFixed);
-  auto robot_state_tap =
-      std::make_shared<drake::RobotStateTap<PendulumState>>();
+  // The choices of PidController constants here are fairly arbitrary,
+  // but seem to effectively swing up the pendulum and hold it.
+  auto controller = builder.AddSystem<systems::PidControlledSystem>(
+      std::move(pendulum), 10., 0., 1.);
 
-  Eigen::MatrixXd Q(2, 2);
-  Q << 10, 0, 0, 1;  // arbitrary, taken from PendulumPlant.m
-  Eigen::MatrixXd R(1, 1);
-  R << 1;  // arbitrary, taken from PendulumPlant.m
+  builder.Connect(input_source->get_output_port(0),
+                  controller->get_input_port(0));
+  builder.Connect(state_source->get_output_port(0),
+                  controller->get_input_port(1));
+  builder.Connect(controller->get_output_port(0),
+                  publisher->get_input_port(0));
 
-  auto control = std::make_shared<SimpleFeedbackTrajectoryController<Pendulum>>(
-      p, pp_traj, pp_xtraj, Q, R);
-  auto traj_sys = drake::feedback(p, control);
-  auto sys = drake::cascade(drake::cascade(traj_sys, visualizer),
-                            robot_state_tap);
+  auto diagram = builder.Build();
 
-  drake::SimulationOptions options;
-  options.realtime_factor = 1.0;
-  if (commandLineOptionExists(argv, argv + argc, "--non-realtime")) {
-    options.warn_real_time_violation = true;
-  }
+  systems::Simulator<double> simulator(*diagram);
+  systems::Context<double>* controller_context =
+      diagram->GetMutableSubsystemContext(
+          simulator.get_mutable_context(), controller);
+  controller->SetDefaultState(controller_context);
 
-  PendulumState<double> x0_state = x0;
-  drake::runLCM(sys, lcm, 0, kTrajectoryTimeUpperBound, x0_state, options);
-  if (!CompareMatrices(toEigen(robot_state_tap->get_input_vector()), xG,
-                       1e-4, MatrixCompareType::absolute)) {
+  simulator.Initialize();
+  simulator.StepTo(kTrajectoryTimeUpperBound);
+
+  systems::Context<double>* pendulum_context =
+      controller->GetMutableSubsystemContext(controller_context, pendulum_p);
+  auto state_vec =
+      pendulum_context->get_continuous_state()->CopyToVector();
+  if (!CompareMatrices(state_vec, xG, 1e-3, MatrixCompareType::absolute)) {
     throw std::runtime_error("Did not reach trajectory target.");
   }
-
   return 0;
+}
+
+}  // namespace
+}  // namespace pendulum
+}  // namespace examples
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  return drake::examples::pendulum::do_main(argc, argv);
 }

--- a/drake/examples/Pendulum/pendulum_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_swing_up.cc
@@ -3,8 +3,11 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
+#include "drake/examples/Pendulum/gen/pendulum_state_vector.h"
 #include "drake/examples/Pendulum/pendulum_swing_up.h"
+#include "drake/examples/Pendulum/pendulum_system.h"
 #include "drake/solvers/Function.h"
 #include "drake/systems/plants/constraint/direct_collocation_constraint.h"
 
@@ -25,9 +28,8 @@ namespace {
 class PendulumRunningCost {
  public:
   static size_t numInputs() {
-    DRAKE_ASSERT(PendulumState<double>::RowsAtCompileTime !=
-                 Eigen::Dynamic);
-    return PendulumState<double>::RowsAtCompileTime + 2; }
+    return PendulumStateVectorIndices::kNumCoordinates + 2;
+  }
   static size_t numOutputs() { return 1; }
 
   template <typename ScalarType>
@@ -51,9 +53,8 @@ class PendulumRunningCost {
 class PendulumFinalCost {
  public:
   static size_t numInputs() {
-    DRAKE_ASSERT(PendulumState<double>::RowsAtCompileTime !=
-                 Eigen::Dynamic);
-    return PendulumState<double>::RowsAtCompileTime + 1; }
+    return PendulumStateVectorIndices::kNumCoordinates + 1;
+  }
   static size_t numOutputs() { return 1; }
 
   template <typename ScalarType>
@@ -67,7 +68,6 @@ class PendulumFinalCost {
 }  // anon namespace
 
 void AddSwingUpTrajectoryParams(
-    std::shared_ptr<Pendulum> pendulum,
     int num_time_samples,
     const Eigen::Vector2d& x0, const Eigen::Vector2d& xG,
     solvers::DircolTrajectoryOptimization* dircol_traj) {
@@ -88,7 +88,8 @@ void AddSwingUpTrajectoryParams(
   dircol_traj->AddFinalCostFunc(PendulumFinalCost());
   dircol_traj->AddDynamicConstraint(
       std::make_shared<
-      drake::systems::SystemDirectCollocationConstraint<Pendulum>>(pendulum));
+      drake::systems::System2DirectCollocationConstraint>(
+          std::make_unique<PendulumSystem<AutoDiffXd>>()));
 }
 
 }  // pendulum

--- a/drake/examples/Pendulum/pendulum_swing_up.h
+++ b/drake/examples/Pendulum/pendulum_swing_up.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "drake/common/drake_export.h"
-#include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/solvers/trajectoryOptimization/dircol_trajectory_optimization.h"
 
 namespace drake {
@@ -19,7 +18,6 @@ namespace pendulum {
  * between @p x0 and @p xG).
  */
 void DRAKE_EXPORT AddSwingUpTrajectoryParams(
-    std::shared_ptr<Pendulum>,
     int num_time_samples,
     const Eigen::Vector2d& x0, const Eigen::Vector2d& xG,
     solvers::DircolTrajectoryOptimization*);

--- a/drake/examples/Pendulum/test/CMakeLists.txt
+++ b/drake/examples/Pendulum/test/CMakeLists.txt
@@ -9,7 +9,7 @@ if(lcm_FOUND)
   add_executable(pendulum_trajectory_optimization_test
     pendulum_trajectory_optimization_test.cc)
   target_link_libraries(pendulum_trajectory_optimization_test
-    drakePendulum drakeTrajectoryOptimization GTest::GTest GTest::Main)
+    drakePendulumSystem drakeTrajectoryOptimization GTest::GTest GTest::Main)
   # TODO(sam.creasey) There is currently no non-linear solver on Windows: see
   # issues #2352, #2569.
   find_package(NLopt)

--- a/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
@@ -5,7 +5,6 @@
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
-#include "drake/examples/Pendulum/Pendulum.h"
 #include "drake/examples/Pendulum/pendulum_swing_up.h"
 
 using drake::solvers::SolutionResult;
@@ -19,8 +18,6 @@ namespace {
 
 GTEST_TEST(PendulumTrajectoryOptimization,
            PendulumTrajectoryOptimizationTest) {
-  auto p = make_shared<Pendulum>();
-
   const int kNumTimeSamples = 21;
   const int kTrajectoryTimeLowerBound = 2;
   const int kTrajectoryTimeUpperBound = 6;
@@ -29,10 +26,10 @@ GTEST_TEST(PendulumTrajectoryOptimization,
   const Eigen::Vector2d xG(M_PI, 0);
 
   solvers::DircolTrajectoryOptimization dircol_traj(
-      getNumInputs(*p), getNumStates(*p),
+      1 /* num inputs */, 2 /* num_states */,
       kNumTimeSamples, kTrajectoryTimeLowerBound,
       kTrajectoryTimeUpperBound);
-  AddSwingUpTrajectoryParams(p, kNumTimeSamples, x0, xG, &dircol_traj);
+  AddSwingUpTrajectoryParams(kNumTimeSamples, x0, xG, &dircol_traj);
 
   const double timespan_init = 4;
   auto traj_init_x = PiecewisePolynomialType::FirstOrderHold(

--- a/drake/systems/controllers/CMakeLists.txt
+++ b/drake/systems/controllers/CMakeLists.txt
@@ -65,11 +65,13 @@ pods_install_pkg_config_file(drake-zmp-util
 
 # System 2 controllers
 set(system2_sources
-    gravity_compensator.cc
-    pid_controller.cc)
+  gravity_compensator.cc
+  pid_controlled_system.cc
+  pid_controller.cc)
 set(system2_installed_headers
-    gravity_compensator.h
-    pid_controller.h)
+  gravity_compensator.h
+  pid_controlled_system.h
+  pid_controller.h)
 add_library_with_exports(LIB_NAME drakeSystemControllers
     SOURCE_FILES ${system2_sources} ${system2_installed_headers})
 add_dependencies(drakeSystemControllers drakeCommon drakeRBM drakeSystemFramework)
@@ -86,4 +88,3 @@ pods_install_pkg_config_file(drake-system2-controllers
     REQUIRES
     VERSION 0.0.1)
 add_subdirectory(test)
-

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -1,0 +1,90 @@
+#include "pid_controlled_system.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_autodiff_types.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+PidControlledSystem<T>::PidControlledSystem(
+    std::unique_ptr<System<T>> system,
+    const T& Kp, const T& Ki, const T& Kd) {
+  DiagramBuilder<T> builder;
+  system_ = builder.template AddSystem(std::move(system));
+
+  DRAKE_ASSERT(system_->get_num_input_ports() >= 1);
+  DRAKE_ASSERT(system_->get_num_output_ports() >= 1);
+  const int num_positions = system_->get_input_port(0).get_size();
+  const int num_states = num_positions * 2;
+  DRAKE_ASSERT(system_->get_output_port(0).get_size() >= num_states);
+
+  state_minus_target_ = builder.template AddSystem<Adder<T>>(
+      2, num_states);
+  controller_ = builder.template AddSystem<PidController<T>>(
+      Kp, Ki, Kd, num_positions);
+
+  // Split the input into two signals one with the positions and one
+  // with the velocities.
+  error_demux_ = builder.template AddSystem<Demultiplexer<T>>(
+      num_states, num_positions);
+
+  controller_inverter_ = builder.template AddSystem<Gain<T>>(
+      -1.0, num_positions);
+  error_inverter_ = builder.template AddSystem<Gain<T>>(
+      -1.0, num_states);
+
+  // Create an adder to sum the provided input with the output of the
+  // controller.
+  system_input_ = builder.template AddSystem<Adder<T>>(
+      2, num_positions);
+
+  builder.Connect(error_inverter_->get_output_port(),
+                  state_minus_target_->get_input_port(0));
+  builder.Connect(system_->get_output_port(0),
+                  state_minus_target_->get_input_port(1));
+
+  // Splits the error signal into positions and velocities components.
+  builder.Connect(state_minus_target_->get_output_port(),
+                  error_demux_->get_input_port(0));
+
+  // Connects PID controller.
+  builder.Connect(error_demux_->get_output_port(0),
+                  controller_->get_error_port());
+  builder.Connect(error_demux_->get_output_port(1),
+                  controller_->get_error_derivative_port());
+  // Adds feedback.
+  builder.Connect(controller_->get_output_port(0),
+                  controller_inverter_->get_input_port());
+  builder.Connect(controller_inverter_->get_output_port(),
+                  system_input_->get_input_port(0));
+
+  builder.Connect(system_input_->get_output_port(),
+                  system_->get_input_port(0));
+
+  builder.ExportInput(system_input_->get_input_port(1));
+  builder.ExportInput(error_inverter_->get_input_port());
+  builder.ExportOutput(system_->get_output_port(0));
+  builder.BuildInto(this);
+}
+
+
+template <typename T>
+PidControlledSystem<T>::~PidControlledSystem() {}
+
+template <typename T>
+void PidControlledSystem<T>::SetDefaultState(
+    Context<T>* context) const {
+  Context<T>* controller_context =
+      Diagram<T>::GetMutableSubsystemContext(context, controller_);
+  controller_->set_integral_value(
+      controller_context,
+      VectorX<T>::Zero(system_->get_input_port(0).get_size()));
+}
+
+template class DRAKE_EXPORT PidControlledSystem<double>;
+template class DRAKE_EXPORT PidControlledSystem<AutoDiffXd>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/controllers/pid_controlled_system.h
+++ b/drake/systems/controllers/pid_controlled_system.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_export.h"
+#include "drake/systems/controllers/pid_controller.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/system.h"
+#include "drake/systems/framework/primitives/adder.h"
+#include "drake/systems/framework/primitives/constant_vector_source.h"
+#include "drake/systems/framework/primitives/demultiplexer.h"
+#include "drake/systems/framework/primitives/gain.h"
+
+namespace drake {
+namespace systems {
+
+/// A system which encapsulates a PidController and a controlled
+/// System.
+///
+/// The passed in system must meet the following properties:
+///
+/// * The first input port must be all of the control inputs to the
+/// * system (size N).
+///
+/// * The first output port must be of at least size N * 2, where the
+/// * first N elements are the positions of the elements of the
+/// * controlled system, and the second N elements are the velocities.
+/// * Additional elements will be ignored.
+///
+/// The resulting PidControlledSystem has two input ports and one
+/// output port with the following properties:
+///
+/// * The first input port is the feed forward control input to the
+/// * system.
+///
+/// * The second input port is the desired state of the system.
+///
+/// * The output port is the current state of the system that is being
+/// * controlled (direct passthrough of the controlled system's output
+/// * port).
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+///
+/// @ingroup control_systems
+template <typename T>
+class DRAKE_EXPORT PidControlledSystem : public Diagram<T> {
+ public:
+  /// @param[in] system The system to be controlled.
+  /// @param[in] Kp the proportional constant.
+  /// @param[in] Ki the integral constant.
+  /// @param[in] Kd the derivative constant.
+  PidControlledSystem(std::unique_ptr<System<T>> system,
+                      const T& Kp, const T& Ki, const T& Kd);
+  ~PidControlledSystem() override;
+
+  System<T>* system() { return system_; }
+
+  /// Sets @p context to a default state in which the positions and
+  /// velocities are all zero.  The integral of the controller is also
+  /// set to zero.
+  void SetDefaultState(Context<T>* context) const;
+
+ private:
+  System<T>* system_;
+  PidController<T>* controller_;
+  Demultiplexer<T>* error_demux_;
+  Gain<T>* controller_inverter_;
+  Gain<T>* error_inverter_;
+  Adder<T>* state_minus_target_;
+  Adder<T>* system_input_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/controllers/test/CMakeLists.txt
+++ b/drake/systems/controllers/test/CMakeLists.txt
@@ -5,6 +5,9 @@ target_link_libraries(gravity_compensator_test
     drakeRBSystem GTest::GTest GTest::Main)
 add_test(NAME gravity_compensator_test COMMAND gravity_compensator_test)
 
-
+drake_add_cc_test(pid_controlled_system_test pid_controlled_system_test.cc)
+target_link_libraries(pid_controlled_system_test
+    drakeSystemControllers
+    drakeSystemFramework)
 drake_add_cc_test(pid_controller_test)
 target_link_libraries(pid_controller_test drakeSystemControllers drakeSystemFramework)

--- a/drake/systems/controllers/test/pid_controlled_system_test.cc
+++ b/drake/systems/controllers/test/pid_controlled_system_test.cc
@@ -1,0 +1,79 @@
+#include "drake/systems/controllers/pid_controlled_system.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/primitives/constant_vector_source.h"
+#include "drake/systems/framework/primitives/gain.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+class TestSystem : public LeafSystem<double> {
+ public:
+  TestSystem() {
+    DeclareInputPort(kVectorValued, 1, kContinuousSampling);
+    DeclareOutputPort(kVectorValued, 2, kContinuousSampling);
+  }
+
+  double GetInputValue(const Context<double>& context) {
+    return EvalEigenVectorInput(context, 0)(0);
+  }
+
+  void EvalOutput(const Context<double>& context,
+                  SystemOutput<double>* output) const override {
+    auto output_vector = GetMutableOutputVector(output, 0);
+    output_vector[0] = 1.;
+    output_vector[1] = 0.1;
+  }
+
+  bool has_any_direct_feedthrough() const override { return false; }
+};
+
+GTEST_TEST(PidControlledSystemTest, SimplePidControlledSystem) {
+  DiagramBuilder<double> builder;
+  const Vector1d input(1.);
+  const Eigen::Vector2d state(1.1, 0.2);
+  auto input_source = builder.AddSystem<ConstantVectorSource>(input);
+  auto state_source = builder.AddSystem<ConstantVectorSource>(state);
+
+  // Our test "system" is just a multiplexer which takes the input and
+  // outputs it twice.
+  auto test_sys = std::make_unique<TestSystem>();
+  TestSystem* test_p = test_sys.get();
+  const double Kp = 2.;
+  const double Kd = .1;
+  auto controller = builder.AddSystem<PidControlledSystem>(
+      std::move(test_sys), Kp, 0., Kd);
+  builder.Connect(input_source->get_output_port(),
+                  controller->get_input_port(0));
+  builder.Connect(state_source->get_output_port(),
+                  controller->get_input_port(1));
+  builder.ExportOutput(controller->get_output_port(0));
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+  auto output = diagram->AllocateOutput(*context);
+
+  systems::Context<double>* controller_context =
+      diagram->GetMutableSubsystemContext(context.get(), controller);
+  controller->SetDefaultState(controller_context);
+  systems::Context<double>* test_context =
+      controller->GetMutableSubsystemContext(
+          controller_context, test_p);
+
+  diagram->EvalOutput(*context, output.get());
+  const BasicVector<double>* output_vec = output->get_vector_data(0);
+  const double pid_input = test_p->GetInputValue(*test_context);
+  EXPECT_EQ(pid_input, input[0] + (state[0] - output_vec->get_value()[0]) * Kp +
+            (state[1] - output_vec->get_value()[1]) * Kd);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
It's come up in conversation a few times that creating a PidController and using it in System2 is a bit complicated.  This PR proposes one wrapped to make using PidController easier, and converts a pendulum example to use it.

It's of course possible that there might be a significantly better API/implementation than this which I didn't manage to come up with, feedback very much welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3742)
<!-- Reviewable:end -->
