### PR TITLE
Load joint limit parameters from SDF

### DIFF
--- a/drake/systems/plants/joints/DrakeJoint.cpp
+++ b/drake/systems/plants/joints/DrakeJoint.cpp
@@ -12,6 +12,10 @@ DrakeJoint::DrakeJoint(const std::string& _name,
           _num_positions, -std::numeric_limits<double>::infinity())),
       joint_limit_max(VectorXd::Constant(
           _num_positions, std::numeric_limits<double>::infinity())),
+      joint_limit_stiffness_(VectorXd::Constant(
+          _num_positions, 150. /* Historic default from RigidBodyPlant. */)),
+      joint_limit_dissipation_(VectorXd::Constant(
+          _num_positions, 15. /* Historic default from RigidBodyPlant. */)),
       transform_to_parent_body(_transform_to_parent_body),
       num_positions(_num_positions),
       num_velocities(_num_velocities) {
@@ -68,4 +72,12 @@ const Eigen::VectorXd& DrakeJoint::getJointLimitMin() const {
 
 const Eigen::VectorXd& DrakeJoint::getJointLimitMax() const {
   return joint_limit_max;
+}
+
+const Eigen::VectorXd& DrakeJoint::get_joint_limit_stiffness() const {
+  return joint_limit_stiffness_;
+}
+
+const Eigen::VectorXd& DrakeJoint::get_joint_limit_dissipation() const {
+  return joint_limit_dissipation_;
 }

--- a/drake/systems/plants/joints/DrakeJoint.cpp
+++ b/drake/systems/plants/joints/DrakeJoint.cpp
@@ -15,7 +15,7 @@ DrakeJoint::DrakeJoint(const std::string& _name,
       joint_limit_stiffness_(VectorXd::Constant(
           _num_positions, 150. /* Historic default from RigidBodyPlant. */)),
       joint_limit_dissipation_(VectorXd::Constant(
-          _num_positions, 15. /* Historic default from RigidBodyPlant. */)),
+          _num_positions, 1. /* Arbitrary, reasonable default. */)),
       transform_to_parent_body(_transform_to_parent_body),
       num_positions(_num_positions),
       num_velocities(_num_velocities) {

--- a/drake/systems/plants/joints/DrakeJoint.h
+++ b/drake/systems/plants/joints/DrakeJoint.h
@@ -206,6 +206,10 @@ class DRAKE_EXPORT DrakeJoint {
 
   virtual const Eigen::VectorXd& getJointLimitMax() const;
 
+  virtual const Eigen::VectorXd& get_joint_limit_stiffness() const;
+
+  virtual const Eigen::VectorXd& get_joint_limit_dissipation() const;
+
   POSITION_AND_VELOCITY_DEPENDENT_METHODS(double)
 
   POSITION_AND_VELOCITY_DEPENDENT_METHODS(AutoDiffFixedMaxSize)
@@ -219,6 +223,8 @@ class DRAKE_EXPORT DrakeJoint {
   const std::string name;
   Eigen::VectorXd joint_limit_min;
   Eigen::VectorXd joint_limit_max;
+  Eigen::VectorXd joint_limit_stiffness_;
+  Eigen::VectorXd joint_limit_dissipation_;
 
  private:
   const Eigen::Isometry3d transform_to_parent_body;

--- a/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
+++ b/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
@@ -128,6 +128,12 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
     DrakeJoint::joint_limit_max[0] = joint_limit_max;
   }
 
+  void SetJointLimitDynamics(double joint_limit_stiffness,
+                             double joint_limit_dissipation) {
+    DrakeJoint::joint_limit_stiffness_[0] = joint_limit_stiffness;
+    DrakeJoint::joint_limit_dissipation_[0] = joint_limit_dissipation;
+  }
+
   Eigen::VectorXd zeroConfiguration() const override {
     return Eigen::VectorXd::Zero(1);
   }

--- a/drake/systems/plants/parser_sdf.cc
+++ b/drake/systems/plants/parser_sdf.cc
@@ -348,6 +348,12 @@ void setSDFLimits(XMLElement* node, FixedAxisOneDoFJoint<JointType>* fjoint) {
     parseScalarValue(limit_node, "lower", lower);
     parseScalarValue(limit_node, "upper", upper);
     fjoint->setJointLimits(lower, upper);
+
+    double stiffness = fjoint->get_joint_limit_stiffness()(0);
+    double dissipation = fjoint->get_joint_limit_dissipation()(0);
+    parseScalarValue(limit_node, "stiffness", stiffness);
+    parseScalarValue(limit_node, "dissipation", dissipation);
+    fjoint->SetJointLimitDynamics(stiffness, dissipation);
   }
 }
 

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -373,8 +373,6 @@ void RigidBodyPlant<T>::MapVelocityToConfigurationDerivatives(
 template <typename T>
 T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint,
                                      const T& position, const T& velocity) {
-  // Joint stop formula (and definition of "dissipation") from:
-  // https://simtk.org/api_docs/simbody/latest/classSimTK_1_1Force_1_1MobilityLinearStop.html#details
   const T qmin = joint.getJointLimitMin()(0);
   const T qmax = joint.getJointLimitMax()(0);
   const T joint_stiffness = joint.get_joint_limit_stiffness()(0);

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -222,30 +222,10 @@ void RigidBodyPlant<T>::EvalTimeDerivatives(
     for (auto const& b : tree_->bodies) {
       if (!b->has_parent_body()) continue;
       auto const& joint = b->getJoint();
-      // Only for single-axis joints.
-      if (joint.get_num_positions() == 1 && joint.get_num_velocities() == 1) {
-        // Joint stop formula (and definition of "dissipation") from:
-        // https://simtk.org/api_docs/simbody/latest/classSimTK_1_1Force_1_1MobilityLinearStop.html#details
-        const T qmin = joint.getJointLimitMin()(0);
-        const T qmax = joint.getJointLimitMax()(0);
-        const T joint_stiffness = joint.get_joint_limit_stiffness()(0);
-        const T joint_dissipation = joint.get_joint_limit_dissipation()(0);
-        const T position = q(b->get_position_start_index());
-        const T velocity = v(b->get_velocity_start_index());
-        T limit_force = 0.;
-        if (position > qmax) {
-          const T violation = position - qmax;
-          const T raw_limit_force = (-joint_stiffness * violation *
-                                     (1 + joint_dissipation * velocity));
-          if (raw_limit_force < 0) limit_force = raw_limit_force;
-        } else if (position < qmin) {
-          const T violation = position - qmin;
-          const T raw_limit_force = (-joint_stiffness * violation *
-                                     (1 - joint_dissipation * velocity));
-          if (raw_limit_force > 0) limit_force = raw_limit_force;
-        }
-        right_hand_side(b->get_velocity_start_index()) += limit_force;
-      }
+      const T limit_force = JointLimitForce(joint,
+                                            q(b->get_position_start_index()),
+                                            v(b->get_velocity_start_index()));
+      right_hand_side(b->get_velocity_start_index()) += limit_force;
     }
   }
 
@@ -386,6 +366,33 @@ void RigidBodyPlant<T>::MapVelocityToConfigurationDerivatives(
       kinsol.transformPositionDotMappingToVelocityMapping(
           MatrixX<T>::Identity(nq, nq)) * v);
 }
+
+template <typename T>
+T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint,
+                                     const T& position, const T& velocity) {
+  // Joint limit forces are only implemented for single-axis joints.
+  if (joint.get_num_positions() == 1 && joint.get_num_velocities() == 1) {
+    // Joint stop formula (and definition of "dissipation") from:
+    // https://simtk.org/api_docs/simbody/latest/classSimTK_1_1Force_1_1MobilityLinearStop.html#details
+    const T qmin = joint.getJointLimitMin()(0);
+    const T qmax = joint.getJointLimitMax()(0);
+    const T joint_stiffness = joint.get_joint_limit_stiffness()(0);
+    const T joint_dissipation = joint.get_joint_limit_dissipation()(0);
+    if (position > qmax) {
+      const T violation = position - qmax;
+      const T limit_force = (-joint_stiffness * violation *
+                             (1 + joint_dissipation * velocity));
+      if (limit_force < 0) return limit_force;
+    } else if (position < qmin) {
+      const T violation = position - qmin;
+      const T limit_force = (-joint_stiffness * violation *
+                             (1 - joint_dissipation * velocity));
+      if (limit_force > 0) return limit_force;
+    }
+  }
+  return 0;
+}
+
 
 // Explicitly instantiates on the most common scalar types.
 template class DRAKE_EXPORT RigidBodyPlant<double>;

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -228,14 +228,16 @@ void RigidBodyPlant<T>::EvalTimeDerivatives(
         T qmin = joint.getJointLimitMin()(0),
             qmax = joint.getJointLimitMax()(0);
         // tau = k * (qlimit-q) - b(qdot)
+        const double joint_stiffness = joint.get_joint_limit_stiffness()(0);
+        const double joint_damping = joint.get_joint_limit_dissipation()(0);
         if (q(b->get_position_start_index()) < qmin)
           right_hand_side(b->get_velocity_start_index()) -=
-              penetration_stiffness_ * (qmin - q(b->get_position_start_index()))
-                  - penetration_damping_ * v(b->get_velocity_start_index());
+              joint_stiffness * (qmin - q(b->get_position_start_index()))
+                  - joint_damping * v(b->get_velocity_start_index());
         else if (q(b->get_position_start_index()) > qmax)
           right_hand_side(b->get_velocity_start_index()) -=
-              penetration_stiffness_ * (qmax - q(b->get_position_start_index()))
-                  - penetration_damping_ * v(b->get_velocity_start_index());
+              joint_stiffness * (qmax - q(b->get_position_start_index()))
+                  - joint_damping * v(b->get_velocity_start_index());
       }
     }
   }

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -375,18 +375,21 @@ T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint,
                                      const T& position, const T& velocity) {
   const T qmin = joint.getJointLimitMin()(0);
   const T qmax = joint.getJointLimitMax()(0);
+  DRAKE_DEMAND(qmin < qmax);
   const T joint_stiffness = joint.get_joint_limit_stiffness()(0);
+  DRAKE_DEMAND(joint_stiffness >= 0);
   const T joint_dissipation = joint.get_joint_limit_dissipation()(0);
+  DRAKE_DEMAND(joint_dissipation >= 0);
   if (position > qmax) {
     const T violation = position - qmax;
     const T limit_force = (-joint_stiffness * violation *
                            (1 + joint_dissipation * velocity));
-    if (limit_force < 0) return limit_force;
+    return std::min(limit_force, 0.);
   } else if (position < qmin) {
     const T violation = position - qmin;
     const T limit_force = (-joint_stiffness * violation *
                            (1 - joint_dissipation * velocity));
-    if (limit_force > 0) return limit_force;
+    return std::max(limit_force, 0.);
   }
   return 0;
 }

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
@@ -169,8 +169,11 @@ class DRAKE_EXPORT RigidBodyPlant : public LeafSystem<T> {
     return T(NAN);
   }
 
-  /// Compute the force exerted by a joint limit.  Exposed for unit testing of
-  /// the formula.
+  /// Computes the force exerted by the stop when a joint hits its limit.
+  /// Exposed for unit testing of the formula.
+  ///
+  /// Joint stop formula (and definition of "dissipation") from:
+  /// https://simtk.org/api_docs/simbody/latest/classSimTK_1_1Force_1_1MobilityLinearStop.html#details
   static T JointLimitForce(const DrakeJoint& joint,
                            const T& position, const T& velocity);
 

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
@@ -169,6 +169,11 @@ class DRAKE_EXPORT RigidBodyPlant : public LeafSystem<T> {
     return T(NAN);
   }
 
+  /// Compute the force exerted by a joint limit.  Exposed for unit testing of
+  /// the formula.
+  static T JointLimitForce(const DrakeJoint& joint,
+                           const T& position, const T& velocity);
+
  protected:
   // LeafSystem<T> override
   std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.h
@@ -169,10 +169,11 @@ class DRAKE_EXPORT RigidBodyPlant : public LeafSystem<T> {
     return T(NAN);
   }
 
-  /// Computes the force exerted by the stop when a joint hits its limit.
+  /// Computes the force exerted by the stop when a joint hits its limit,
+  /// using a linear stiffness model.
   /// Exposed for unit testing of the formula.
   ///
-  /// Joint stop formula (and definition of "dissipation") from:
+  /// Linear stiffness formula (and definition of "dissipation") from:
   /// https://simtk.org/api_docs/simbody/latest/classSimTK_1_1Force_1_1MobilityLinearStop.html#details
   static T JointLimitForce(const DrakeJoint& joint,
                            const T& position, const T& velocity);

--- a/drake/systems/plants/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/systems/plants/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -399,8 +399,12 @@ GTEST_TEST(rigid_body_plant_test, TestJointLimitForces) {
             0);
   EXPECT_NEAR(RBP::JointLimitForce(joint, lower_limit - delta, 0),
               0, epsilon);
+  EXPECT_GT(RBP::JointLimitForce(joint, lower_limit - delta, 0),
+            0);
   EXPECT_NEAR(RBP::JointLimitForce(joint, upper_limit + delta, 0),
               0, epsilon);
+  EXPECT_LT(RBP::JointLimitForce(joint, upper_limit + delta, 0),
+            0);
   EXPECT_EQ(RBP::JointLimitForce(joint, upper_limit, 0),
             0);
   EXPECT_EQ(RBP::JointLimitForce(joint, upper_limit - delta, 0),

--- a/drake/systems/plants/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/systems/plants/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -379,55 +379,55 @@ GTEST_TEST(RigidBodySystemTest, CompareWithRBS1Dynamics) {
 
 GTEST_TEST(rigid_body_plant_test, TestJointLimitForces) {
   typedef RigidBodyPlant<double> RBP;
-  const double left_limit = 10.;
-  const double right_limit = 20.;
+  const double lower_limit = 10.;
+  const double upper_limit = 20.;
   const double stiffness = 10.;
   const double dissipation = 0.5;
-  const double delta = 1e-6;  // Perturbation used for continuity tests.
+  const double delta = 1e-6;  // Perturbation used for continuity test.
   const double epsilon = 1e-4;
 
   // The joint limit force formula is quite complex.  This test checks each of
   // its modes, to ensure that we didn't flip a sign somewhere.
   PrismaticJoint joint("test_joint", Isometry3d::Identity(), Vector3d(1, 0, 0));
-  joint.setJointLimits(left_limit, right_limit);
+  joint.setJointLimits(lower_limit, upper_limit);
   joint.SetJointLimitDynamics(stiffness, dissipation);
 
   // Force should be continuously near zero at the limit.
-  EXPECT_EQ(RBP::JointLimitForce(joint, left_limit + delta, 0),
+  EXPECT_EQ(RBP::JointLimitForce(joint, lower_limit + delta, 0),
             0);
-  EXPECT_EQ(RBP::JointLimitForce(joint, left_limit, 0),
+  EXPECT_EQ(RBP::JointLimitForce(joint, lower_limit, 0),
             0);
-  EXPECT_NEAR(RBP::JointLimitForce(joint, left_limit - delta, 0),
+  EXPECT_NEAR(RBP::JointLimitForce(joint, lower_limit - delta, 0),
               0, epsilon);
-  EXPECT_NEAR(RBP::JointLimitForce(joint, right_limit + delta, 0),
+  EXPECT_NEAR(RBP::JointLimitForce(joint, upper_limit + delta, 0),
               0, epsilon);
-  EXPECT_EQ(RBP::JointLimitForce(joint, right_limit, 0),
+  EXPECT_EQ(RBP::JointLimitForce(joint, upper_limit, 0),
             0);
-  EXPECT_EQ(RBP::JointLimitForce(joint, right_limit - delta, 0),
+  EXPECT_EQ(RBP::JointLimitForce(joint, upper_limit - delta, 0),
             0);
 
   // At zero velocity, expect a spring force law.
-  EXPECT_NEAR(RBP::JointLimitForce(joint, left_limit - 1, 0),
+  EXPECT_NEAR(RBP::JointLimitForce(joint, lower_limit - 1, 0),
               stiffness, epsilon);
-  EXPECT_NEAR(RBP::JointLimitForce(joint, right_limit + 1, 0),
+  EXPECT_NEAR(RBP::JointLimitForce(joint, upper_limit + 1, 0),
               -stiffness, epsilon);
 
   // At outward velocity, a much stiffer counterforce (ie, not "squishy").
-  EXPECT_NEAR(RBP::JointLimitForce(joint, left_limit - 1, -1),
+  EXPECT_NEAR(RBP::JointLimitForce(joint, lower_limit - 1, -1),
               stiffness * (1 + dissipation), epsilon);
-  EXPECT_NEAR(RBP::JointLimitForce(joint, right_limit + 1, 1),
+  EXPECT_NEAR(RBP::JointLimitForce(joint, upper_limit + 1, 1),
               -stiffness * (1 + dissipation), epsilon);
 
   // At inward velocity, a looser counterforce (ie, not "bouncy").
-  EXPECT_NEAR(RBP::JointLimitForce(joint, left_limit - 1, 1),
+  EXPECT_NEAR(RBP::JointLimitForce(joint, lower_limit - 1, 1),
               stiffness * (1 - dissipation), epsilon);
-  EXPECT_NEAR(RBP::JointLimitForce(joint, right_limit + 1, -1),
+  EXPECT_NEAR(RBP::JointLimitForce(joint, upper_limit + 1, -1),
               -stiffness * (1 - dissipation), epsilon);
 
   // At rapid inward velocity, no negative counterforce (ie, not "sticky").
-  EXPECT_EQ(RBP::JointLimitForce(joint, left_limit - 1, 10),
+  EXPECT_EQ(RBP::JointLimitForce(joint, lower_limit - 1, 10),
             0);
-  EXPECT_EQ(RBP::JointLimitForce(joint, right_limit + 1, -10),
+  EXPECT_EQ(RBP::JointLimitForce(joint, upper_limit + 1, -10),
             0);
 }
 

--- a/drake/systems/plants/test/load_model_test.cc
+++ b/drake/systems/plants/test/load_model_test.cc
@@ -280,6 +280,21 @@ GTEST_TEST(LoadSDFTest, TestDualOffset2) {
       << "Expected:\n" << Eigen::Isometry3d::Identity().matrix();
 }
 
+GTEST_TEST(LoadSDFTest, TestJointLimitParams) {
+  // Test that joint limit parameters are correctly loaded from an SDF file.
+  RigidBodySystem rbs;
+  rbs.AddModelInstanceFromFile(drake::GetDrakePath() +
+                               "/systems/plants/test/models/"
+                               "cylindrical_1dof_robot.sdf",
+                               kFixed);
+  const DrakeJoint& joint =
+      rbs.getRigidBodyTree()->FindChildBodyOfJoint("joint1")->getJoint();
+  EXPECT_NEAR(joint.getJointLimitMin()(0), -1.5708, 1e-6);
+  EXPECT_NEAR(joint.getJointLimitMax()(0), 1.5708, 1e-6);
+  EXPECT_NEAR(joint.get_joint_limit_stiffness()(0), 1, 1e-6);
+  EXPECT_NEAR(joint.get_joint_limit_dissipation()(0), 1, 1e-6);
+}
+
 class ModelToWorldTransformTestParams {
  public:
   ModelToWorldTransformTestParams(std::string urdf_path,

--- a/drake/systems/plants/test/models/cylindrical_1dof_robot.sdf
+++ b/drake/systems/plants/test/models/cylindrical_1dof_robot.sdf
@@ -76,6 +76,8 @@
           <upper>1.5708</upper>
           <effort>30</effort>
           <velocity>1</velocity>
+          <stiffness>1</stiffness>
+          <dissipation>1</dissipation>
         </limit>
         <dynamics>
           <spring_reference>0</spring_reference>


### PR DESCRIPTION
Load limit penetration parameters from SDF (`joint::axis::limit::stiffness` and `joint::axis::limit::dissipation` in the XML) and apply them in `RigidBodyPlant::EvalTimeDerivatives`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3746)
<!-- Reviewable:end -->
