### PR TITLE
Use Threads::Threads imported target from upstream CMake

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -160,10 +160,7 @@ set(drake_jar_requires)
 
 include(../cmake/procman.cmake)  # helper script for writing procman files
 
-# set up pseudo-target for threads
-find_package(Threads)
-add_library(threads INTERFACE)
-target_link_libraries(threads INTERFACE ${CMAKE_THREAD_LIBS_INIT})
+find_package(Threads REQUIRED)
 
 # set up and build lcm types
 find_package(lcm)

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -49,7 +49,7 @@ set(private_headers
 # Create the library target and note its dependencies.
 add_library_with_exports(LIB_NAME drakeCommon
   SOURCE_FILES ${sources} ${installed_headers} ${private_headers})
-target_link_libraries(drakeCommon threads)
+target_link_libraries(drakeCommon Threads::Threads)
 if(NOT WIN32)
   target_link_libraries(drakeCommon gflags)
 endif()

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -46,7 +46,7 @@ drake_add_test(NAME drake_assert_test_disabled COMMAND drake_assert_test_disable
 add_executable(text_logging_test_default
                ../text_logging.cc text_logging_test.cc)
 target_link_libraries(text_logging_test_default
-                      ${GTEST_BOTH_LIBRARIES} gflags threads)
+                      ${GTEST_BOTH_LIBRARIES} gflags Threads::Threads)
 drake_add_test(NAME text_logging_test_default COMMAND text_logging_test_default)
 # Force spdlog to unavailable to test that the ifndef(HAVE_SPDLOG) case works.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
@@ -56,7 +56,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
   target_compile_options(text_logging_test_no_spdlog
     PRIVATE -UHAVE_SPDLOG)
   target_link_libraries(text_logging_test_no_spdlog
-                        ${GTEST_BOTH_LIBRARIES} gflags threads)
+                        ${GTEST_BOTH_LIBRARIES} gflags Threads::Threads)
   drake_add_test(NAME text_logging_test_no_spdlog COMMAND text_logging_test_no_spdlog)
 endif()
 

--- a/drake/examples/Quadrotor/CMakeLists.txt
+++ b/drake/examples/Quadrotor/CMakeLists.txt
@@ -2,7 +2,7 @@
 # due to a bug in Eigen; see issue #2106 and PR #2107.
 if(lcm_FOUND AND NOT (WIN32 AND (CMAKE_SIZEOF_VOID_P EQUAL 4)))
   add_executable(runQuadrotorDynamics runDynamics.cpp)
-  target_link_libraries(runQuadrotorDynamics drakeRBSystem drakeLCMSystem drakeLCMTypes threads)
+  target_link_libraries(runQuadrotorDynamics drakeRBSystem drakeLCMSystem drakeLCMTypes Threads::Threads)
   drake_add_test(NAME runQuadrotorDynamics COMMAND runQuadrotorDynamics 5.0 1.0 --non-realtime SIZE medium)
 
   add_executable(runQuadrotorLQR runLQR.cpp)

--- a/drake/examples/kuka_iiwa_arm/CMakeLists.txt
+++ b/drake/examples/kuka_iiwa_arm/CMakeLists.txt
@@ -26,7 +26,7 @@ if(lcm_FOUND)
   target_link_libraries(kuka_lcm_visualizer
     drakeKukaIiwaArm
     drake_lcmtypes
-    threads)
+    Threads::Threads)
   add_executable(kuka_ik_demo kuka_ik_demo.cc)
   target_link_libraries(kuka_ik_demo drakeIK
     drakeTrajectories

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -192,7 +192,7 @@ pods_install_pkg_config_file(drake-rbsystem
 
 if(lcm_FOUND)
   add_executable(rigidBodyLCMNode rigidBodyLCMNode.cpp)
-  target_link_libraries(rigidBodyLCMNode gflags drakeRBSystem drakeLCMSystem threads)
+  target_link_libraries(rigidBodyLCMNode gflags drakeRBSystem drakeLCMSystem Threads::Threads)
   pods_install_executables(rigidBodyLCMNode)
   drake_install_headers(BotVisualizer.h)
 endif()


### PR DESCRIPTION
CMake already sets up an imported target, so we do not need to create our own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3747)
<!-- Reviewable:end -->
