### PR TITLE
Prevent installing to the cmake package registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,16 +143,10 @@ drake_add_external(dreal PUBLIC CMAKE
   SOURCE_SUBDIR src)
 
 # gflags
-if(WIN32)
-  # We can't figure out how to get gflags shared libraries working on Windows
-  # (see #3345), so here we build it with static libraries only.  Code that
-  # lives in Drake's shared libraries must be conditionalized to avoid using
-  # gflags on Windows.
-  drake_add_external(gflags PUBLIC CMAKE)
-else()
-  drake_add_external(gflags PUBLIC CMAKE
-    CMAKE_ARGS -DBUILD_SHARED_LIBS=ON)
-endif()
+drake_add_external(gflags PUBLIC CMAKE
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=ON
+    -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON)
 
 # googletest
 drake_add_external(googletest PUBLIC CMAKE
@@ -215,7 +209,9 @@ drake_add_external(spotless PUBLIC CMAKE
 
 # octomap
 drake_add_external(octomap PUBLIC CMAKE
-  CMAKE_ARGS -DBUILD_TESTING=OFF
+  CMAKE_ARGS
+    -DBUILD_TESTING=OFF
+    -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON
   SOURCE_SUBDIR octomap)
 
 # swig_matlab
@@ -242,13 +238,10 @@ drake_add_external(textbook PUBLIC CMAKE
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake/doc/textbook)
 
 # yaml_cpp
-if(WIN32)
-  drake_add_external(yaml_cpp PUBLIC CMAKE
-    CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF)
-else()
-  drake_add_external(yaml_cpp PUBLIC CMAKE
-    CMAKE_ARGS -DBUILD_SHARED_LIBS=ON)
-endif()
+drake_add_external(yaml_cpp PUBLIC CMAKE
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=ON
+    -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON)
 
 # iris
 drake_add_external(iris PUBLIC CMAKE

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -165,6 +165,9 @@ macro(drake_setup_platform)
   set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON)
   set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON)
 
+  # Disable adding packages to the registry.
+  set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
+
   # Ensure that find_package() searches in the install directory first.
   list(APPEND CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}")
 

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -149,6 +149,8 @@ macro(drake_add_cmake_external PROJECT)
   # Set arguments for cache propagation
   set(_ext_LIST_SEPARATOR "!")
   drake_build_cache_args(_ext_PROPAGATE_CACHE ${_ext_LIST_SEPARATOR}
+    CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY
+    CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY
     CMAKE_PREFIX_PATH
     CMAKE_INSTALL_PREFIX
     CMAKE_BUILD_TYPE


### PR DESCRIPTION
Makes `export(PACKAGE)` a no-op.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3754)
<!-- Reviewable:end -->
