### PR TITLE
Avoid preprocessor continuation in C++ comment

### DIFF
--- a/drake/examples/simple_continuous_time_system.cc
+++ b/drake/examples/simple_continuous_time_system.cc
@@ -11,7 +11,7 @@
 
 /// Simple Continuous Time System
 /// \begin{gather*}
-///     \dot{x} = -x + x^3 \\
+///     \dot{x} = -x + x^3 \newline
 ///     y = x
 /// \end{gather*}
 class SimpleContinuousTimeSystem : public drake::systems::LeafSystem<double> {


### PR DESCRIPTION
Apparently, Xenial GCC catches this but our CI didn't.  Totally broken build on Xenial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3760)
<!-- Reviewable:end -->
