### PR TITLE
Add bison back to installation docs/script

### DIFF
--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -56,13 +56,13 @@ Other Prerequisites
 Other prerequisites may be installed as follows::
 
     sudo apt-get update
-    sudo apt-get install --no-install-recommends autoconf automake default-jdk \
-      doxygen freeglut3-dev git graphviz libgtk2.0-dev libhtml-form-perl \
-      libjpeg-dev libmpfr-dev libpng-dev libqt4-dev libqt4-opengl-dev \
-      libqwt-dev libterm-readkey-perl libtool libvtk-java libvtk5-dev \
-      libvtk5-qt4-dev libwww-perl make ninja-build perl pkg-config python-bs4 \
-      python-dev python-gtk2 python-html5lib python-numpy python-pip \
-      python-sphinx python-vtk unzip valgrind
+    sudo apt-get install --no-install-recommends autoconf automake bison \
+      default-jdk doxygen freeglut3-dev git graphviz libgtk2.0-dev \
+      libhtml-form-perl libjpeg-dev libmpfr-dev libpng-dev libqt4-dev \
+      libqt4-opengl-dev libqwt-dev libterm-readkey-perl libtool libvtk-java \
+      libvtk5-dev libvtk5-qt4-dev libwww-perl make ninja-build perl pkg-config \
+      python-bs4 python-dev python-gtk2 python-html5lib python-numpy
+      python-pip python-sphinx python-vtk unzip valgrind
 
 Environment
 -----------

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -44,6 +44,7 @@ apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 
 autoconf
 automake
+bison
 cmake
 cmake-curses-gui
 default-jdk


### PR DESCRIPTION
SWIG needs a `yacc`-compatible parser generator, which means `bison` in the case of Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3764)
<!-- Reviewable:end -->
