### PR TITLE
Removed LcmPublisherSystem::GetMessage() method.

### DIFF
--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -66,12 +66,9 @@ GTEST_TEST(AutomotiveSimulatorTest, SimpleCarTest) {
   // Shortly after starting, we should have not have moved much.
   simulator->StepBy(0.01);
   EulerFloatingJointState<double> joint_value;
-
   GetLastPublishedJointValue(kJointStateChannelName,
       state_pub.get_translator(),
       dynamic_cast<lcm::DrakeMockLcm*>(simulator->get_lcm()), &joint_value);
-
-  // state_pub.GetMessage(&joint_value);
   EXPECT_GT(joint_value.x(), 0.0);
   EXPECT_LT(joint_value.x(), 0.001);
 
@@ -83,7 +80,6 @@ GTEST_TEST(AutomotiveSimulatorTest, SimpleCarTest) {
   GetLastPublishedJointValue(kJointStateChannelName,
       state_pub.get_translator(),
       dynamic_cast<lcm::DrakeMockLcm*>(simulator->get_lcm()), &joint_value);
-  // state_pub.GetMessage(&joint_value);
   EXPECT_GT(joint_value.x(), 1.0);
 
   // Confirm that appropriate draw messages are coming out. Just a few of the

--- a/drake/systems/lcm/lcm_publisher_system.cc
+++ b/drake/systems/lcm/lcm_publisher_system.cc
@@ -56,20 +56,15 @@ void LcmPublisherSystem::DoPublish(const Context<double>& context) const {
       this->EvalVectorInput(context, kPortIndex);
 
   // Translates the input vector into LCM message bytes.
-  translator_.Serialize(context.get_time(), *input_vector, &message_bytes_);
+  std::vector<uint8_t> message_bytes;
+  translator_.Serialize(context.get_time(), *input_vector, &message_bytes);
 
   // Publishes onto the specified LCM channel.
-  lcm_->Publish(channel_, message_bytes_.data(), message_bytes_.size());
+  lcm_->Publish(channel_, message_bytes.data(), message_bytes.size());
 }
 
-std::vector<uint8_t> LcmPublisherSystem::GetMessage() const {
-  return message_bytes_;
-}
-
-void LcmPublisherSystem::GetMessage(BasicVector<double>* message_vector) const {
-  // We use GetMessage() here to ensure we stay in sync with its implementation.
-  const std::vector<uint8_t> bytes = GetMessage();
-  translator_.Deserialize(bytes.data(), bytes.size(), message_vector);
+const LcmAndVectorBaseTranslator& LcmPublisherSystem::get_translator() const {
+  return translator_;
 }
 
 }  // namespace lcm

--- a/drake/systems/lcm/lcm_publisher_system.h
+++ b/drake/systems/lcm/lcm_publisher_system.h
@@ -72,19 +72,10 @@ class DRAKE_EXPORT LcmPublisherSystem : public LeafSystem<double> {
   void EvalOutput(const Context<double>& context,
                   SystemOutput<double>* output) const override {}
 
-  // TODO(liang.fok) Remove this method once #3643 is merged.
   /**
-   * Gets the most recently published message bytes; typically only used for
-   * unit testing.
+   * Returns the translator used by this publisher.
    */
-  std::vector<uint8_t> GetMessage() const;
-
-  // TODO(liang.fok) Remove this method once #3643 is merged.
-  /**
-   * Gets the most recently published message bytes, and converts them to into
-   * vector form using the translator; typically only used for unit testing.
-   */
-  void GetMessage(BasicVector<double>* message_vector) const;
+  const LcmAndVectorBaseTranslator& get_translator() const;
 
  private:
   // The channel on which to publish LCM messages.
@@ -96,10 +87,6 @@ class DRAKE_EXPORT LcmPublisherSystem : public LeafSystem<double> {
 
   // A pointer to the LCM subsystem.
   drake::lcm::DrakeLcmInterface* const lcm_;
-
-  // The most recent message bytes; mutable is ok because it only affects the
-  // GetMessage() results, which are not part of the System contract.
-  mutable std::vector<uint8_t> message_bytes_;
 };
 
 }  // namespace lcm


### PR DESCRIPTION
This is possible now that we have an LCM mocking framework (see #3643).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3779)
<!-- Reviewable:end -->
