### PR TITLE
Make some long-running tests explicitly depend on snopt

### DIFF
--- a/drake/examples/Quadrotor/CMakeLists.txt
+++ b/drake/examples/Quadrotor/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 # drake_add_matlab_test(NAME examples/Quadrotor/Quadrotor.runOpenLoop COMMAND Quadrotor.runOpenLoop)  # FIXME: see #3313
 drake_add_matlab_test(NAME examples/Quadrotor/runDircol OPTIONAL bullet snopt COMMAND runDircol)
-drake_add_matlab_test(NAME examples/Quadrotor/runDircolWObs REQUIRES bullet lcm libbot OPTIONAL snopt COMMAND runDircolWObs SIZE large)
+drake_add_matlab_test(NAME examples/Quadrotor/runDircolWObs REQUIRES bullet lcm libbot snopt COMMAND runDircolWObs SIZE large)
 drake_add_matlab_test(NAME examples/Quadrotor/runLQR OPTIONAL bullet COMMAND runLQR)
 drake_add_matlab_test(NAME examples/Quadrotor/runMixedIntegerSimpleForest REQUIRES iris lcm libbot mosek yalmip OPTIONAL bullet snopt COMMAND runMixedIntegerSimpleForest SIZE large)
 

--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -129,7 +129,7 @@ drake_add_matlab_test(NAME systems/plants/test/contactNormalsTest OPTIONAL bulle
 drake_add_matlab_test(NAME systems/plants/test/contactSensorTest OPTIONAL gurobi snopt COMMAND contactSensorTest)
 drake_add_matlab_test(NAME systems/plants/test/coordinateSystemTest OPTIONAL bullet gurobi COMMAND coordinateSystemTest SIZE large)
 drake_add_matlab_test(NAME systems/plants/test/fallingBrickLCP OPTIONAL bullet gurobi snopt COMMAND fallingBrickLCP)
-drake_add_matlab_test(NAME systems/plants/test/fallingCapsulesTest OPTIONAL bullet gurobi snopt COMMAND fallingCapsulesTest SIZE large)
+drake_add_matlab_test(NAME systems/plants/test/fallingCapsulesTest REQUIRES snopt OPTIONAL bullet gurobi COMMAND fallingCapsulesTest SIZE large)
 drake_add_matlab_test(NAME systems/plants/test/ignoreSelfCollisionsTest OPTIONAL bullet COMMAND ignoreSelfCollisionsTest)
 drake_add_matlab_test(NAME systems/plants/test/linearize_test COMMAND linearize_test)
 drake_add_matlab_test(NAME systems/plants/test/momentumTest OPTIONAL gurobi COMMAND momentumTest)


### PR DESCRIPTION
PTAL build cops @jonathan-owens and @mwoehlke-kitware. See #3767 for context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3780)
<!-- Reviewable:end -->
