### PR TITLE
Do not build gflags_nothreads library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,8 @@ drake_add_external(dreal PUBLIC CMAKE
 drake_add_external(gflags PUBLIC CMAKE
   CMAKE_ARGS
     -DBUILD_SHARED_LIBS=ON
-    -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON)
+    -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON
+    -DGFLAGS_BUILD_gflags_nothreads_LIB=OFF)
 
 # googletest
 drake_add_external(googletest PUBLIC CMAKE


### PR DESCRIPTION
We only use the `gflags` library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3781)
<!-- Reviewable:end -->
