### PR TITLE
Respell some things in a GCC 4.8-compatible way

### DIFF
--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -77,7 +77,7 @@ class DiagramTimeDerivatives : public DiagramContinuousState<T> {
   std::vector<U*> Unpack(const std::vector<std::unique_ptr<U>>& in) {
     std::vector<U*> out(in.size());
     std::transform(in.begin(), in.end(), out.begin(),
-                   [](auto& p) { return p.get(); });
+                   [](const std::unique_ptr<U>& p) { return p.get(); });
     return out;
   }
 

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -27,9 +27,9 @@ namespace systems {
 template <typename T>
 struct PeriodicEvent {
   /// The period with which this event should recur.
-  T period_sec = 0.0;
+  T period_sec{0.0};
   /// The time after zero when this event should first occur.
-  T offset_sec = 0.0;
+  T offset_sec{0.0};
   /// The action that should be taken when this event occurs.
   DiscreteEvent<T> event;
 };

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -42,18 +42,18 @@ struct DiscreteEvent {
   };
 
   /// The system that receives the event.
-  const System<T>* recipient = nullptr;
+  const System<T>* recipient{nullptr};
   /// The type of action the system must take in response to the event.
-  ActionType action = kUnknownAction;
+  ActionType action{kUnknownAction};
 
   /// An optional callback, supplied by the recipient, to carry out a
   /// kPublishAction. If nullptr, Publish will be used.
-  std::function<void(const Context<T>&)> do_publish = nullptr;
+  std::function<void(const Context<T>&)> do_publish{nullptr};
 
   /// An optional callback, supplied by the recipient, to carry out a
   /// kUpdateAction. If nullptr, DoEvalDifferenceUpdates will be used.
-  std::function<void(const Context<T>&, DifferenceState<T>*)> do_update =
-      nullptr;
+  std::function<void(const Context<T>&, DifferenceState<T>*)> do_update{
+    nullptr};
 };
 
 /// A token that identifies the next sample time at which a System must
@@ -593,7 +593,7 @@ class System {
   std::string name_;
   std::vector<SystemPortDescriptor<T>> input_ports_;
   std::vector<SystemPortDescriptor<T>> output_ports_;
-  const detail::InputPortEvaluatorInterface<T>* parent_ = nullptr;
+  const detail::InputPortEvaluatorInterface<T>* parent_{nullptr};
 };
 
 }  // namespace systems


### PR DESCRIPTION
The code is essentially just a good, but this lets GCC 4.8 parse it correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3784)
<!-- Reviewable:end -->
