### PR TITLE
Fix gurobi solver

### DIFF
--- a/drake/math/test/eigen_sparse_triplet_test.cc
+++ b/drake/math/test/eigen_sparse_triplet_test.cc
@@ -6,6 +6,13 @@ namespace drake {
 namespace math {
 namespace {
 
+/**
+ * Given a sparse matrix, call SparseMatrixToTriplets or
+ * SparseMatrixToRowColumnValueVectors to get the triplets
+ * (row_index, column_index, value) of the non-zero entries. Then reconstruct
+ * the sparse matrix using setFromTriplets, anch check if the reconstructed
+ * sparse matrix is the same as the original one
+ */
 template <typename T, int options>
 void checkTriplet(const Eigen::SparseMatrix<T, options>& sp_mat) {
   auto triplets1 = SparseMatrixToTriplets(sp_mat);
@@ -32,14 +39,20 @@ void checkTriplet(const Eigen::SparseMatrix<T, options>& sp_mat) {
   EXPECT_TRUE(sp_mat.isApprox(sp_mat_expected2));
 }
 
+/**
+ * Test if the SparseMatrixToTriplets and SparseMatrixToRowColumnValueVectors
+ * get the correct triplets (row_index, column_index, value) of the non-zero
+ * entries.
+ */
 GTEST_TEST(testEigenSparseTriplet, sparseToTriplet) {
-  std::vector<Eigen::Triplet<double>> triplet;
-  triplet.push_back(Eigen::Triplet<double>(0, 0, 1.0));
-  triplet.push_back(Eigen::Triplet<double>(0, 1, 2.0));
-  triplet.push_back(Eigen::Triplet<double>(1, 1, 3.0));
+  std::vector<Eigen::Triplet<double>> triplets;
+  triplets.push_back(Eigen::Triplet<double>(0, 0, 1.0));
+  triplets.push_back(Eigen::Triplet<double>(0, 1, 2.0));
+  triplets.push_back(Eigen::Triplet<double>(1, 1, 3.0));
 
+  // Test a row major sparse matrix.
   Eigen::SparseMatrix<double, Eigen::RowMajor> sp_mat1(2, 3);
-  sp_mat1.setFromTriplets(triplet.begin(), triplet.end());
+  sp_mat1.setFromTriplets(triplets.begin(), triplets.end());
   checkTriplet(sp_mat1);
 
   // Insert a value to the sparse matrix, it should be uncompressed now.
@@ -50,8 +63,14 @@ GTEST_TEST(testEigenSparseTriplet, sparseToTriplet) {
 
   // Check column major sparse matrix.
   Eigen::SparseMatrix<double, Eigen::ColMajor> sp_mat3(2, 3);
-  sp_mat3.setFromTriplets(triplet.begin(), triplet.end());
+  sp_mat3.setFromTriplets(triplets.begin(), triplets.end());
   checkTriplet(sp_mat3);
+
+  // Check a dense matrix
+  triplets.push_back(Eigen::Triplet<double>(1, 0, 4.0));
+  Eigen::SparseMatrix<double, Eigen::RowMajor> sp_mat4(2, 2);
+  sp_mat4.setFromTriplets(triplets.begin(), triplets.end());
+  checkTriplet(sp_mat4);
 }
 }  // namespace
 }  // namespace math

--- a/drake/math/test/eigen_sparse_triplet_test.cc
+++ b/drake/math/test/eigen_sparse_triplet_test.cc
@@ -10,8 +10,8 @@ namespace {
  * Given a sparse matrix, call SparseMatrixToTriplets or
  * SparseMatrixToRowColumnValueVectors to get the triplets
  * (row_index, column_index, value) of the non-zero entries. Then reconstruct
- * the sparse matrix using setFromTriplets, anch check if the reconstructed
- * sparse matrix is the same as the original one
+ * the sparse matrix using setFromTriplets, and check if the reconstructed
+ * sparse matrix is the same as the original one.
  */
 template <typename T, int options>
 void checkTriplet(const Eigen::SparseMatrix<T, options>& sp_mat) {
@@ -29,7 +29,7 @@ void checkTriplet(const Eigen::SparseMatrix<T, options>& sp_mat) {
   EXPECT_TRUE(row_indices.size() == col_indices.size());
   EXPECT_TRUE(row_indices.size() == val.size());
   std::vector<Eigen::Triplet<T>> triplets_from_vectors;
-  for (int i = 0; i < static_cast<int>(row_indices.size()); i++) {
+  for (int i = 0; i < static_cast<int>(row_indices.size()); ++i) {
     triplets_from_vectors.push_back(
         Eigen::Triplet<T>(row_indices[i], col_indices[i], val[i]));
   }

--- a/drake/math/test/eigen_sparse_triplet_test.cc
+++ b/drake/math/test/eigen_sparse_triplet_test.cc
@@ -15,11 +15,11 @@ namespace {
  */
 template <typename T, int options>
 void checkTriplet(const Eigen::SparseMatrix<T, options>& sp_mat) {
-  auto triplets1 = SparseMatrixToTriplets(sp_mat);
-  Eigen::SparseMatrix<T, options> sp_mat_expected1(sp_mat.rows(),
-                                                   sp_mat.cols());
-  sp_mat_expected1.setFromTriplets(triplets1.begin(), triplets1.end());
-  EXPECT_TRUE(sp_mat.isApprox(sp_mat_expected1));
+  auto triplets = SparseMatrixToTriplets(sp_mat);
+  Eigen::SparseMatrix<T, options> sp_mat_from_triplets(sp_mat.rows(),
+                                                       sp_mat.cols());
+  sp_mat_from_triplets.setFromTriplets(triplets.begin(), triplets.end());
+  EXPECT_TRUE(sp_mat.isApprox(sp_mat_from_triplets));
 
   std::vector<Eigen::Index> row_indices;
   std::vector<Eigen::Index> col_indices;
@@ -28,15 +28,16 @@ void checkTriplet(const Eigen::SparseMatrix<T, options>& sp_mat) {
   EXPECT_TRUE(static_cast<int>(row_indices.size()) == sp_mat.nonZeros());
   EXPECT_TRUE(row_indices.size() == col_indices.size());
   EXPECT_TRUE(row_indices.size() == val.size());
-  std::vector<Eigen::Triplet<T>> triplets2;
+  std::vector<Eigen::Triplet<T>> triplets_from_vectors;
   for (int i = 0; i < static_cast<int>(row_indices.size()); i++) {
-    triplets2.push_back(
+    triplets_from_vectors.push_back(
         Eigen::Triplet<T>(row_indices[i], col_indices[i], val[i]));
   }
-  Eigen::SparseMatrix<T, options> sp_mat_expected2(sp_mat.rows(),
-                                                   sp_mat.cols());
-  sp_mat_expected2.setFromTriplets(triplets2.begin(), triplets2.end());
-  EXPECT_TRUE(sp_mat.isApprox(sp_mat_expected2));
+  Eigen::SparseMatrix<T, options> sp_mat_from_vectors(sp_mat.rows(),
+                                                      sp_mat.cols());
+  sp_mat_from_vectors.setFromTriplets(triplets_from_vectors.begin(),
+                                      triplets_from_vectors.end());
+  EXPECT_TRUE(sp_mat.isApprox(sp_mat_from_vectors));
 }
 
 /**

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -161,53 +161,6 @@ int AddCosts(GRBmodel* model, MathematicalProgram& prog,
       return kError;
     }
   }
-  /*
-  int start_row = 0;
-  for (const auto& binding : prog.quadratic_costs()) {
-    const auto& constraint = binding.constraint();
-    const int constraint_variable_dimension = binding.GetNumElements();
-
-    Eigen::MatrixXd Q = 0.5 * (constraint->Q());
-    Eigen::VectorXd b = constraint->b();
-
-    // Check for square matrices.
-    DRAKE_ASSERT(Q.rows() == Q.cols());
-    // Check for symmetric matrices.
-    DRAKE_ASSERT(Q.transpose() == Q);
-    // Check for Quadratic and Linear Cost dimensions.
-    DRAKE_ASSERT(Q.rows() == constraint_variable_dimension);
-    DRAKE_ASSERT(b.cols() == 1);
-    DRAKE_ASSERT(b.rows() == constraint_variable_dimension);
-
-    // adding each Q term (only upper triangular).
-    for (int i = 0; i < constraint_variable_dimension; i++) {
-      for (int j = i; j < constraint_variable_dimension; j++) {
-        if (std::abs(Q(i, j)) > sparseness_threshold) {
-          int row_ind = i + start_row;
-          int col_ind = j + start_row;
-          // TODO(naveenoid) : Port to batch addition mode of this function
-          // by utilising the Upper right (or lower left) triangular matrix.
-          // The single element addition method used below is recommended
-          // initially by Gurobi since it has a low cost.
-          double individual_quadratic_cost_value = Q(i, j);
-          const int error = GRBaddqpterms(model, 1, &row_ind, &col_ind,
-                                          &individual_quadratic_cost_value);
-          if (error) {
-            return (error);
-          }
-        }
-      }
-    }
-    const int error = GRBsetdblattrarray(
-        model, "Obj", start_row, constraint_variable_dimension, b.data());
-    if (error) {
-      return error;
-    }
-    start_row += Q.rows();
-    // Verify that the start_row does not exceed the total possible
-    // dimension of the decision variable.
-    DRAKE_ASSERT(start_row <= static_cast<int>(prog.num_vars()));
-  }*/
   // If loop completes, no errors exist so the value '0' must be returned.
   return 0;
 }

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -148,11 +148,11 @@ int AddCosts(GRBmodel* model, MathematicalProgram& prog,
     linear_row_indices_int[i] = static_cast<int>(linear_row[i]);
   }
 
-  const int kError1 = GRBaddqpterms(
+  const int kQPtermsError = GRBaddqpterms(
       model, static_cast<int>(Q_all_row.size()), Q_all_row_indices_int.data(),
       Q_all_col_indices_int.data(), Q_all_val.data());
-  if (kError1) {
-    return kError1;
+  if (kQPtermsError) {
+    return kQPtermsError;
   }
   for (int i = 0; i < static_cast<int>(linear_row.size()); i++) {
     const int kError = GRBsetdblattrarray(

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -96,17 +96,17 @@ int AddCosts(GRBmodel* model, MathematicalProgram& prog,
       }
     }
     for (int i = 0; i < Q.rows(); i++) {
-      const double kQii = 0.5 * Q(i, i);
-      if (abs(kQii) > sparseness_threshold) {
+      const double Qii = 0.5 * Q(i, i);
+      if (abs(Qii) > sparseness_threshold) {
         Q_nonzero_coefs.push_back(Eigen::Triplet<double>(
-            constraint_variable_index[i], constraint_variable_index[i], kQii));
+            constraint_variable_index[i], constraint_variable_index[i], Qii));
       }
       for (int j = i + 1; j < Q.cols(); j++) {
-        const double kQij = 0.5 * (Q(i, j) + Q(j, i));
-        if (abs(kQij) > sparseness_threshold) {
+        const double Qij = 0.5 * (Q(i, j) + Q(j, i));
+        if (abs(Qij) > sparseness_threshold) {
           Q_nonzero_coefs.push_back(
               Eigen::Triplet<double>(constraint_variable_index[i],
-                                     constraint_variable_index[j], kQij));
+                                     constraint_variable_index[j], Qij));
         }
       }
     }
@@ -148,17 +148,17 @@ int AddCosts(GRBmodel* model, MathematicalProgram& prog,
     linear_row_indices_int[i] = static_cast<int>(linear_row[i]);
   }
 
-  const int kQPtermsError = GRBaddqpterms(
+  const int QPtermsError = GRBaddqpterms(
       model, static_cast<int>(Q_all_row.size()), Q_all_row_indices_int.data(),
       Q_all_col_indices_int.data(), Q_all_val.data());
-  if (kQPtermsError) {
-    return kQPtermsError;
+  if (QPtermsError) {
+    return QPtermsError;
   }
   for (int i = 0; i < static_cast<int>(linear_row.size()); i++) {
-    const int kError = GRBsetdblattrarray(
+    const int LinearTermError = GRBsetdblattrarray(
         model, "Obj", linear_row_indices_int[i], 1, linear_val.data() + i);
-    if (kError) {
-      return kError;
+    if (LinearTermError) {
+      return LinearTermError;
     }
   }
   // If loop completes, no errors exist so the value '0' must be returned.

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -7,8 +7,7 @@
 namespace drake {
 namespace solvers {
 
-class DRAKE_EXPORT GurobiSolver
-    : public MathematicalProgramSolverInterface {
+class DRAKE_EXPORT GurobiSolver : public MathematicalProgramSolverInterface {
  public:
   // This solver is implemented in various pieces depending on if
   // Gurobi was available during compilation.

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -15,11 +15,9 @@ target_link_libraries(system_identification_test drakeOptimization)
 drake_add_cc_test(NAME fastqp_solver_test)
 target_link_libraries(fastqp_solver_test drakeOptimization)
 
-add_executable(gurobi_solver_test gurobi_solver_test.cc)
-target_link_libraries(gurobi_solver_test drakeOptimization
-  GTest::GTest GTest::Main)
 if(gurobi_FOUND)
-  drake_add_test(NAME gurobi_solver_test COMMAND gurobi_solver_test)
+  drake_add_cc_test(gurobi_solver_test)
+  target_link_libraries(gurobi_solver_test drakeOptimization)
 endif()
 
 if(dreal_FOUND)

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -1,11 +1,8 @@
 #include "drake/solvers/gurobi_solver.h"
 
-#include <typeinfo>
-
 #include "gtest/gtest.h"
 
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/solvers/mathematical_program.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
@@ -26,7 +23,7 @@ void RunQuadraticProgram(MathematicalProgram* prog) {
 //  subj to  x + 2 y + 3 z >= 4
 //           x +   y       >= 1
 GTEST_TEST(testGurobi, gurobiQPExample1) {
-      MathematicalProgram prog;
+  MathematicalProgram prog;
   auto x = prog.AddContinuousVariables(3);
 
   Eigen::MatrixXd Q = 2 * Eigen::Matrix<double, 3, 3>::Identity();
@@ -70,13 +67,13 @@ GTEST_TEST(testGurobi, gurobiQPExample1) {
 // The values were chosen at random but were hardcoded
 // to enable test reproducibility.
 GTEST_TEST(testGurobi, convexQPExample) {
-      MathematicalProgram prog;
+  MathematicalProgram prog;
   auto x = prog.AddContinuousVariables(5);
   MatrixXd Q = MatrixXd::Constant(5, 5, 0.0);
   VectorXd Qdiag = VectorXd::Constant(5, 0.0);
   Qdiag << 5.5, 6.5, 6.0, 5.3, 7.5;
   Q = Qdiag.asDiagonal();
-  Q(2,3) = 0.2;
+  Q(2, 3) = 0.2;
 
   Eigen::VectorXd b = VectorXd::Constant(5, 0.0);
 
@@ -100,50 +97,51 @@ GTEST_TEST(testGurobi, convexQPExample) {
 // min 0.5x'Qx + bx = -Q^(-1) * b
 // The values were chosen at random but were hardcoded
 // to enable test reproducibility.
+// We impose the cost
+//   0.5 * x.head<4>()'*Q1 * x.head<4>() + b1'*x.head<4>()
+// + 0.5 * x.tail<4>()'*Q2 * x.tail<4>() + b2'*x.tail<4>()
+// This is to test that we can add multiple costs for the same variables (in
+// this case, the quadratic costs on x(2), x(3) are added for twice).
 GTEST_TEST(testGurobi, convexQPMultiCostExample) {
-      MathematicalProgram prog;
-  const DecisionVariableView x1 = prog.AddContinuousVariables(3, "x1");
-  MatrixXd Q1 = MatrixXd::Constant(3, 3, 0.0);
-  VectorXd Q1diag = VectorXd::Constant(3, 0.0);
-  Q1diag << 5.5, 6.5, 6.0;
+  MathematicalProgram prog;
+  const DecisionVariableView x = prog.AddContinuousVariables(6, "x");
+  MatrixXd Q1 = MatrixXd::Constant(4, 4, 0.0);
+  VectorXd Q1diag = VectorXd::Constant(4, 0.0);
+  Q1diag << 5.5, 6.5, 6.0, 7.0;
   Q1 = Q1diag.asDiagonal();
   Q1(1, 2) = 0.1;
 
-  const DecisionVariableView x2 = prog.AddContinuousVariables(3, "x2");
-  MatrixXd Q2 = MatrixXd::Constant(3, 3, 0.0);
-  VectorXd Q2diag = VectorXd::Constant(3, 0.0);
-  Q2diag << 7.0, 2.2, 1.1;
+  MatrixXd Q2 = MatrixXd::Constant(4, 4, 0.0);
+  VectorXd Q2diag = VectorXd::Constant(4, 0.0);
+  Q2diag << 7.0, 2.2, 1.1, 1.3;
   Q2 = Q2diag.asDiagonal();
   Q2(0, 2) = -0.02;
 
-  VectorXd b1 = VectorXd::Constant(3, 0.0);
-  b1 << 3.1, -1.4, -5.6;
-  VectorXd b2 = VectorXd::Constant(3, 0.0);
-  b2 << 2.3, -5.8, 6.7;
+  VectorXd b1 = VectorXd::Constant(4, 0.0);
+  b1 << 3.1, -1.4, -5.6, 0.6;
+  VectorXd b2 = VectorXd::Constant(4, 0.0);
+  b2 << 2.3, -5.8, 6.7, 2.3;
 
-  prog.AddQuadraticCost(Q1, b1, {x1});
-  prog.AddQuadraticCost(Q2, b2, {x2});
+  prog.AddQuadraticCost(Q1, b1, {x.head(2), x.segment(2, 2)});
+  prog.AddQuadraticCost(Q2, b2, {x.segment(2, 2), x.segment(4, 2)});
 
   MatrixXd Q = Eigen::MatrixXd::Constant(6, 6, 0.0);
-  Q.topLeftCorner(3, 3) = Q1;
-  Q.bottomRightCorner(3, 3) = Q2;
+  Q.topLeftCorner(4, 4) = Q1;
+  Q.bottomRightCorner(4, 4) += Q2;
   MatrixXd Q_transpose = Q;
   Q_transpose.transposeInPlace();
   Q = 0.5 * (Q + Q_transpose);
 
   VectorXd b = VectorXd::Constant(6, 0.0);
-  b.topRows(3) = b1;
-  b.bottomRows(3) = b2;
+  b.topRows(4) = b1;
+  b.bottomRows(4) += b2;
 
   // Exact solution.
   VectorXd expected = -Q.ldlt().solve(b);
 
   RunQuadraticProgram(&prog);
-  VectorXd composed_solution = VectorXd::Constant(6, 0.0);
-  composed_solution.topRows(3) = x1.value();
-  composed_solution.bottomRows(3) = x2.value();
-  EXPECT_TRUE(CompareMatrices(composed_solution, expected, 1e-8,
-                              MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(x.value(), expected, 1e-8, MatrixCompareType::absolute));
 }
 
 }  // close namespace

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -29,7 +29,7 @@ GTEST_TEST(testGurobi, gurobiQPExample1) {
       MathematicalProgram prog;
   auto x = prog.AddContinuousVariables(3);
 
-  Eigen::MatrixXd Q = Eigen::Matrix<double, 3, 3>::Identity();
+  Eigen::MatrixXd Q = 2 * Eigen::Matrix<double, 3, 3>::Identity();
   Q(0, 1) = 1;
   Q(1, 2) = 1;
   Q(1, 0) = 1;

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/solvers/ipopt_solver.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
@@ -66,6 +67,8 @@ GTEST_TEST(testGurobi, gurobiQPExample1) {
 // min 0.5x'Qx + bx = -Q^(-1) * b
 // The values were chosen at random but were hardcoded
 // to enable test reproducibility.
+// The test also verifies the quadratic program works when
+// matrix Q has off-diagonal terms.
 GTEST_TEST(testGurobi, convexQPExample) {
   MathematicalProgram prog;
   auto x = prog.AddContinuousVariables(5);
@@ -142,6 +145,13 @@ GTEST_TEST(testGurobi, convexQPMultiCostExample) {
   RunQuadraticProgram(&prog);
   EXPECT_TRUE(
       CompareMatrices(x.value(), expected, 1e-8, MatrixCompareType::absolute));
+
+  IpoptSolver ipopt_solver;
+  if (ipopt_solver.available()) {
+    ipopt_solver.Solve(prog);
+    EXPECT_TRUE(CompareMatrices(x.value(), expected, 1e-8,
+                                MatrixCompareType::absolute));
+  }
 }
 
 }  // close namespace

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -3,7 +3,6 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/solvers/ipopt_solver.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
@@ -145,13 +144,6 @@ GTEST_TEST(testGurobi, convexQPMultiCostExample) {
   RunQuadraticProgram(&prog);
   EXPECT_TRUE(
       CompareMatrices(x.value(), expected, 1e-8, MatrixCompareType::absolute));
-
-  IpoptSolver ipopt_solver;
-  if (ipopt_solver.available()) {
-    ipopt_solver.Solve(prog);
-    EXPECT_TRUE(CompareMatrices(x.value(), expected, 1e-8,
-                                MatrixCompareType::absolute));
-  }
 }
 
 }  // close namespace

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -202,7 +202,7 @@ GTEST_TEST(testMathematicalProgram, QuadraticCost) {
   Vector4d expected = -Q_symmetric.ldlt().solve(b);
   prog.SetInitialGuess({x}, Vector4d::Zero());
   RunNonlinearProgram(prog, [&]() {
-    EXPECT_TRUE(CompareMatrices(x.value(), expected, 1e-9,
+    EXPECT_TRUE(CompareMatrices(x.value(), expected, 1e-6,
                                 MatrixCompareType::absolute));
   });
 }

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -181,6 +181,31 @@ GTEST_TEST(testMathematicalProgram, trivialLinearEquality) {
     EXPECT_DOUBLE_EQ(vars.value()(1), 1);
   });
 }
+// Tests a quadratic optimization problem, with only quadratic cost
+// 0.5 *x'*Q*x + b'*x
+// The optimal solution is -inverse(Q)*b
+GTEST_TEST(testMathematicalProgram, QuadraticCost) {
+  MathematicalProgram prog;
+  auto x = prog.AddContinuousVariables(4);
+
+  Vector4d Qdiag(1.0, 2.0, 3.0, 4.0);
+  Matrix4d Q = Qdiag.asDiagonal();
+  Q(1, 2) = 0.1;
+  Q(2, 3) = -0.02;
+
+  Vector4d b(1.0, -0.5, 1.3, 2.5);
+  prog.AddQuadraticCost(Q, b);
+
+  Matrix4d Q_transpose = Q;
+  Q_transpose.transposeInPlace();
+  Matrix4d Q_symmetric = 0.5 * (Q + Q_transpose);
+  Vector4d expected = -Q_symmetric.ldlt().solve(b);
+  prog.SetInitialGuess({x}, Vector4d::Zero());
+  RunNonlinearProgram(prog, [&]() {
+    EXPECT_TRUE(CompareMatrices(x.value(), expected, 1e-9,
+                                MatrixCompareType::absolute));
+  });
+}
 
 // This test comes from Section 2.2 of "Handbook of Test Problems in
 // Local and Global Optimization."


### PR DESCRIPTION
1. Fix the off-diagnoal bug in gurobi_solver, that when adding quadratic costs `0.5 *x'*Q*x+b'*x`, if there exists off-diagonal terms in quadratic cost `Q`, there was a factor of 2 missing.
2. Now `gurobi_solver` can take multiple costs for the same variables, like
`0.5*x'*Q1*x+b1'*x + 0.5*x'*Q2*x+b2'*x`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3792)
<!-- Reviewable:end -->
