### PR TITLE
Split out spdlog gflags handling to separate header

### DIFF
--- a/drake/automotive/automotive_demo.cc
+++ b/drake/automotive/automotive_demo.cc
@@ -3,6 +3,7 @@
 
 #include <gflags/gflags.h>
 
+#include "drake/common/text_logging_gflags.h"
 #include "drake/automotive/automotive_simulator.h"
 #include "drake/automotive/create_trajectory_params.h"
 
@@ -15,6 +16,7 @@ namespace {
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  logging::HandleSpdlogGflags();
 
   // TODO(jwnimmer-tri) Allow for multiple simple cars.
   if (FLAGS_num_simple_car > 1) {

--- a/drake/common/text_logging.cc
+++ b/drake/common/text_logging.cc
@@ -3,50 +3,6 @@
 #include <mutex>
 #include <stdexcept>
 
-#ifndef _MSC_VER
-#include <gflags/gflags.h>
-
-// Declare the --spdlog_level gflags option.
-namespace {
-constexpr const char kUnchanged[] = "unchanged";
-constexpr const char kTrace[] = "trace";
-constexpr const char kDebug[] = "debug";
-}  // namespace
-DEFINE_string(spdlog_level, kUnchanged,
-              "sets the spdlog output threshold; "
-              "possible values are 'unchanged', 'trace', 'debug'");
-
-// Check the gflags settings for validity.  If spdlog is enabled, update its
-// configuration to match the flags.
-namespace {
-void maybe_process_gflags(drake::logging::logger* logger_to_update) {
-  const bool want_unchanged = (FLAGS_spdlog_level == kUnchanged);
-  const bool want_trace = (FLAGS_spdlog_level == kTrace);
-  const bool want_debug = (FLAGS_spdlog_level == kDebug);
-  if (!want_unchanged && !want_trace && !want_debug) {
-    logger_to_update->critical("Unknown spdlog_level {}", FLAGS_spdlog_level);
-    throw std::runtime_error("Unknown spdlog level");
-  }
-#ifdef HAVE_SPDLOG
-  if (want_trace) {
-    logger_to_update->set_level(spdlog::level::trace);
-  } else if (want_debug) {
-    logger_to_update->set_level(spdlog::level::debug);
-  }
-#endif
-}
-}  // namespace
-
-#else  // _MSC_VER
-
-// For the moment, we can't get libgflags.dll working within Drake.
-// Thus, we have to omit the gflags integration glue on windows.
-namespace {
-void maybe_process_gflags(drake::logging::logger*) {}
-}  // namespace
-
-#endif
-
 namespace drake {
 
 #ifdef HAVE_SPDLOG
@@ -64,7 +20,6 @@ std::shared_ptr<logging::logger>* onetime_create_log() {
     // use this logger and have their messages be staggered by line, instead of
     // co-mingling their character bytes.
     *result = spdlog::stderr_logger_mt("console");
-    maybe_process_gflags(result->get());
   }
   return result;
 }
@@ -80,9 +35,7 @@ logging::logger* log() {
 
 #else  // HAVE_SPDLOG
 
-logging::logger::logger() {
-  maybe_process_gflags(this);
-}
+logging::logger::logger() {}
 
 logging::logger* log() {
   // A do-nothing logger instance.

--- a/drake/common/text_logging_gflags.h
+++ b/drake/common/text_logging_gflags.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/// @file
+/// This file defines gflags settings to control spdlog levels.
+/// Only include this from translation units that declare a `main` function.
+
+#include <gflags/gflags.h>
+
+#include "drake/common/text_logging.h"
+
+// Declare the --spdlog_level gflags option.
+DEFINE_string(spdlog_level, "unchanged",
+              "sets the spdlog output threshold; "
+              "possible values are 'unchanged', 'trace', 'debug'");
+
+namespace drake {
+namespace logging {
+
+/// Check the gflags settings for validity.  If spdlog is enabled, update its
+/// configuration to match the flags.
+inline void HandleSpdlogGflags() {
+  const bool want_unchanged = (FLAGS_spdlog_level == "unchanged");
+  const bool want_trace = (FLAGS_spdlog_level == "trace");
+  const bool want_debug = (FLAGS_spdlog_level == "debug");
+  if (!want_unchanged && !want_trace && !want_debug) {
+    log()->critical("Unknown spdlog_level {}", FLAGS_spdlog_level);
+    throw std::runtime_error("Unknown spdlog level");
+  }
+#ifdef HAVE_SPDLOG
+  if (want_trace) {
+    log()->set_level(spdlog::level::trace);
+  } else if (want_debug) {
+    log()->set_level(spdlog::level::debug);
+  }
+#endif
+}
+
+}  // namespace logging
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
@@ -1,6 +1,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_path.h"
+#include "drake/common/text_logging_gflags.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
@@ -107,6 +108,7 @@ class KukaIiwaArmDynamicsSim : public systems::Diagram<T> {
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  logging::HandleSpdlogGflags();
 
   KukaIiwaArmDynamicsSim<double> model;
   Simulator<double> simulator(model);

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_gravity_compensated_position_control.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_gravity_compensated_position_control.cc
@@ -1,6 +1,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_path.h"
+#include "drake/common/text_logging_gflags.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_simulation.h"
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/LinearSystem.h"
@@ -33,6 +34,7 @@ int main(int argc, char* argv[]) {
   double kDuration = 0.75;
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  logging::HandleSpdlogGflags();
   kDuration = FLAGS_duration;
 
   const int kNumDof = 7;

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_gravity_compensated_torque_control.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_gravity_compensated_torque_control.cc
@@ -1,6 +1,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_path.h"
+#include "drake/common/text_logging_gflags.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_simulation.h"
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/LinearSystem.h"
@@ -36,6 +37,7 @@ int main(int argc, char* argv[]) {
   double kInputTorqueMagnitude = 1.75;
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  logging::HandleSpdlogGflags();
   kDuration = FLAGS_duration;
   kInputTorqueMagnitude = FLAGS_magnitude;
 

--- a/drake/systems/plants/rigidBodyLCMNode.cpp
+++ b/drake/systems/plants/rigidBodyLCMNode.cpp
@@ -1,6 +1,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/text_logging.h"
+#include "drake/common/text_logging_gflags.h"
 #include "drake/systems/LCMSystem.h"
 #include "drake/systems/cascade_system.h"
 #include "drake/systems/plants/BotVisualizer.h"
@@ -56,6 +57,7 @@ int main(int argc, char* argv[]) {
     gflags::ShowUsageWithFlags(argv[0]);
     return 1;
   }
+  logging::HandleSpdlogGflags();
 
   // todo: consider moving this logic into the RigidBodySystem class so it can
   // be reused


### PR DESCRIPTION
Libraries that depend on gflags are frustrating for downstream builds, as discussed in #build today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3798)
<!-- Reviewable:end -->
