### PR TITLE
Introduce System2 modal state, and clean up state generally.

### DIFF
--- a/drake/systems/controllers/test/gravity_compensator_test.cc
+++ b/drake/systems/controllers/test/gravity_compensator_test.cc
@@ -102,7 +102,7 @@ TEST_F(GravityCompensatorTest, OutputTest) {
 
 // Tests that Gain allocates no state variables in the context.
 TEST_F(GravityCompensatorTest, GravityCompensatorIsStateless) {
-  EXPECT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 }  // namespace

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -9,9 +9,10 @@ set(sources
   diagram_builder.cc
   diagram_context.cc
   diagram_continuous_state.cc
+  input_port_evaluator_interface.cc
   leaf_context.cc
   leaf_system.cc
-  input_port_evaluator_interface.cc
+  modal_state.cc
   output_port_listener_interface.cc
   primitives/adder.cc
   primitives/constant_value_source.cc
@@ -52,9 +53,10 @@ set(installed_headers
   diagram_context.h
   diagram_continuous_state.h
   difference_state.h
+  input_port_evaluator_interface.h
   leaf_context.h
   leaf_system.h
-  input_port_evaluator_interface.h
+  modal_state.h
   output_port_listener_interface.h
   state.h
   subvector.h

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -33,6 +33,9 @@ class Context {
  public:
   virtual ~Context() {}
 
+  // =========================================================================
+  // Accessors and Mutators for Time.
+
   /// Returns the current time in seconds.
   const T& get_time() const { return get_step_info().time_sec; }
 
@@ -41,16 +44,8 @@ class Context {
     get_mutable_step_info()->time_sec = time_sec;
   }
 
-  /// Connects the input port @p port to this Context at the given @p index.
-  /// Disconnects whatever input port was previously there, and deregisters
-  /// it from the output port on which it depends.  In some Context
-  /// implementations, may require a recursive search through a tree of
-  /// subcontexts.
-  /// Throws std::out_of_range if @p index is out of range.
-  virtual void SetInputPort(int index, std::unique_ptr<InputPort> port) = 0;
-
-  /// Returns the number of input ports.
-  virtual int get_num_input_ports() const = 0;
+  // =========================================================================
+  // Accessors and Mutators for State.
 
   virtual const State<T>& get_state() const = 0;
   virtual State<T>* get_mutable_state() = 0;
@@ -61,22 +56,27 @@ class Context {
   }
 
   /// Returns a mutable pointer to the continuous component of the state,
-  /// or nullptr if there is no continuous state.
+  /// which may be of size zero.
   ContinuousState<T>* get_mutable_continuous_state() {
     return get_mutable_state()->get_mutable_continuous_state();
   }
 
-  /// Returns a mutable pointer to the difference component of the state, or
-  /// nullptr if there is no difference state.
+  /// Returns a const pointer to the continuous component of the state,
+  /// which may be of size zero.
+  const ContinuousState<T>* get_continuous_state() const {
+    return get_state().get_continuous_state();
+  }
+
+  /// Returns a mutable pointer to the difference component of the state,
+  /// which may be of size zero.
   DifferenceState<T>* get_mutable_difference_state() {
     return get_mutable_state()->get_mutable_difference_state();
   }
 
   /// Returns a mutable pointer to element @p index of the difference state.
-  /// Asserts if there is no difference state, or if @p index doesn't exist.
+  /// Asserts if @p index doesn't exist.
   BasicVector<T>* get_mutable_difference_state(int index) {
     DifferenceState<T>* xd = get_mutable_difference_state();
-    DRAKE_ASSERT(xd != nullptr);
     return xd->get_mutable_difference_state(index);
   }
 
@@ -86,25 +86,51 @@ class Context {
   }
 
   /// Returns a const pointer to the discrete difference component of the
-  /// state at @p index.
+  /// state at @p index.  Asserts if @p index doesn't exist.
   const VectorBase<T>* get_difference_state(int index) const {
     const DifferenceState<T>* xd = get_state().get_difference_state();
-    if (xd == nullptr) return nullptr;
     return xd->get_difference_state(index);
   }
 
-  /// Returns a const pointer to the continuous component of the state,
-  /// or nullptr if there is no continuous state.
-  const ContinuousState<T>* get_continuous_state() const {
-    return get_state().get_continuous_state();
+  /// Returns a mutable pointer to the modal component of the state,
+  /// which may be of size zero.
+  ModalState* get_mutable_modal_state() {
+    return get_mutable_state()->get_mutable_modal_state();
   }
 
-  /// Returns a deep copy of this Context. The clone's input ports will
-  /// hold deep copies of the data that appears on this context's input ports
-  /// at the time the clone is created.
-  std::unique_ptr<Context<T>> Clone() const {
-    return std::unique_ptr<Context<T>>(DoClone());
+  /// Returns a mutable pointer to element @p index of the modal state.
+  /// Asserts if @p index doesn't exist.
+  template <typename U>
+  U& get_mutable_modal_state(int index) {
+    ModalState* xm = get_mutable_modal_state();
+    return xm->get_mutable_modal_state(index).GetMutableValue<U>();
   }
+
+  /// Sets the modal state to @p xm, deleting whatever was there before.
+  void set_modal_state(std::unique_ptr<ModalState> xm) {
+    get_mutable_state()->set_modal_state(std::move(xm));
+  }
+
+  /// Returns a const pointer to the discrete modal component of the
+  /// state at @p index.  Asserts if @p index doesn't exist.
+  template <typename U>
+  const U& get_modal_state(int index) const {
+    const ModalState* xm = get_state().get_modal_state();
+    return xm->get_modal_state(index).GetValue<U>();
+  }
+
+  // =========================================================================
+  // Accessors and Mutators for Input.
+
+  /// Connects the input port @p port to this Context at the given @p index.
+  /// Disconnects whatever input port was previously there, and deregisters
+  /// it from the output port on which it depends.  In some Context
+  /// implementations, may require a recursive search through a tree of
+  /// subcontexts. Asserts if @p index is out of range.
+  virtual void SetInputPort(int index, std::unique_ptr<InputPort> port) = 0;
+
+  /// Returns the number of input ports.
+  virtual int get_num_input_ports() const = 0;
 
   /// Evaluates and returns the input port identified by @p descriptor,
   /// using the given @p evaluator, which should be the Diagram containing
@@ -183,6 +209,16 @@ class Context {
     return &(value->GetValue<V>());
   }
 
+  // =========================================================================
+  // Miscellaneous Public Methods
+
+  /// Returns a deep copy of this Context. The clone's input ports will
+  /// hold deep copies of the data that appears on this context's input ports
+  /// at the time the clone is created.
+  std::unique_ptr<Context<T>> Clone() const {
+    return std::unique_ptr<Context<T>>(DoClone());
+  }
+
   /// Declares that @p parent is the context of the enclosing Diagram. The
   /// enclosing Diagram context is needed to evaluate inputs recursively.
   /// Aborts if the parent has already been set to something else.
@@ -227,12 +263,12 @@ class Context {
 
   /// Returns the InputPort at the given @p index, which may be nullptr if
   /// it has never been set with SetInputPort.
-  /// Throws std::out_of_range if @p index is out of range.
+  /// Asserts if @p index is out of range.
   virtual const InputPort* GetInputPort(int index) const = 0;
 
   /// Returns the InputPort at the given @p index from the given @p context.
   /// Returns nullptr if the given port has never been set with SetInputPort.
-  /// Throws std::out_of_range if @p index is out of range.
+  /// Asserts if @p index is out of range.
   static const InputPort* GetInputPort(const Context<T>& context, int index) {
     return context.GetInputPort(index);
   }

--- a/drake/systems/framework/continuous_state.h
+++ b/drake/systems/framework/continuous_state.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "drake/common/drake_assert.h"
+#include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/subvector.h"
 #include "drake/systems/framework/vector_base.h"
 
@@ -88,12 +89,20 @@ class ContinuousState {
     DRAKE_ASSERT(num_v <= num_q);
   }
 
+  /// Constructs a zero-length ContinuousState.
+  ContinuousState()
+      : ContinuousState(std::make_unique<BasicVector<T>>(0)) {}
+
   virtual ~ContinuousState() {}
 
-  /// Returns the entire state vector.
+  /// Returns the size of the entire continuous state vector.
+  int size() const { return get_state().size(); }
+
+  /// Returns the entire continuous state vector.
   const VectorBase<T>& get_state() const { return *state_; }
 
-  /// Returns a mutable pointer to the entire state vector, never null.
+  /// Returns a mutable pointer to the entire continuous state vector, which
+  /// is never nullptr.
   VectorBase<T>* get_mutable_state() { return state_.get(); }
 
   /// Returns the subset of the state vector that is generalized position `q`.
@@ -107,24 +116,26 @@ class ContinuousState {
     return generalized_position_.get();
   }
 
-  /// Returns the subset of the state vector that is generalized velocity `v`.
+  /// Returns the subset of the continuous state vector that is generalized
+  /// velocity `v`.
   const VectorBase<T>& get_generalized_velocity() const {
     return *generalized_velocity_;
   }
 
-  /// Returns a mutable pointer to the subset of the state vector that is
-  /// generalized velocity `v`.
+  /// Returns a mutable pointer to the subset of the continuous state vector
+  /// that is generalized velocity `v`.
   VectorBase<T>* get_mutable_generalized_velocity() {
     return generalized_velocity_.get();
   }
 
-  /// Returns the subset of the state vector that is other continuous state `z`.
+  /// Returns the subset of the continuous state vector that is other
+  /// continuous state `z`.
   const VectorBase<T>& get_misc_continuous_state() const {
     return *misc_continuous_state_;
   }
 
-  /// Returns a mutable pointer to the subset of the state vector that is
-  /// other continuous state `z`.
+  /// Returns a mutable pointer to the subset of the continuous state vector
+  /// that is other continuous state `z`.
   VectorBase<T>* get_mutable_misc_continuous_state() {
     return misc_continuous_state_.get();
   }
@@ -145,7 +156,8 @@ class ContinuousState {
   ContinuousState& operator=(ContinuousState&& other) = delete;
 
  private:
-  // The entire state vector.  May or may not own the underlying data.
+  // The entire continuous state vector.  May or may not own the underlying
+  // data.
   std::unique_ptr<VectorBase<T>> state_;
 
   // Generalized coordinates representing System configuration, conventionally

--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -157,9 +157,7 @@ class DiagramContext : public Context<T> {
   }
 
   void SetInputPort(int index, std::unique_ptr<InputPort> port) override {
-    if (index < 0 || index >= get_num_input_ports()) {
-      throw std::out_of_range("Input port out of range.");
-    }
+    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
     const PortIdentifier& id = input_ids_[index];
     SystemIndex system_index = id.first;
     PortIndex port_index = id.second;
@@ -213,9 +211,7 @@ class DiagramContext : public Context<T> {
   /// Returns the input port at the given @p index, which of course belongs
   /// to the subsystem whose input was exposed at that index.
   const InputPort* GetInputPort(int index) const override {
-    if (index < 0 || index >= get_num_input_ports()) {
-      throw std::out_of_range("Input port out of range.");
-    }
+    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
     const PortIdentifier& id = input_ids_[index];
     SystemIndex system_index = id.first;
     PortIndex port_index = id.second;

--- a/drake/systems/framework/diagram_continuous_state.h
+++ b/drake/systems/framework/diagram_continuous_state.h
@@ -14,8 +14,7 @@ template <typename T>
 class DiagramContinuousState : public ContinuousState<T> {
  public:
   /// Constructs a ContinuousState that is composed of other ContinuousStates,
-  /// which are not owned by this object and must outlive it. Some of the
-  /// subsystem states may be nullptr if the system is stateless.
+  /// which are not owned by this object and must outlive it.
   ///
   /// The DiagramContinuousState vector xc = [q v z] will have the same
   /// ordering as the @p substates parameter, which should be the sort order of
@@ -32,15 +31,15 @@ class DiagramContinuousState : public ContinuousState<T> {
 
   int get_num_substates() const { return static_cast<int>(substates_.size()); }
 
-  /// Returns the continuous state at the given @p index, or nullptr if that
-  /// system is stateless. Aborts if @p index is out-of-bounds.
+  /// Returns the continuous state at the given @p index. Aborts if @p index is
+  /// out-of-bounds.
   const ContinuousState<T>* get_substate(int index) const {
     DRAKE_DEMAND(index >= 0 && index < get_num_substates());
     return substates_[index];
   }
 
-  /// Returns the continuous state at the given @p index, or nullptr if that
-  /// system is stateless. Aborts if @p index is out-of-bounds.
+  /// Returns the continuous state at the given @p index. Aborts if @p index is
+  /// out-of-bounds.
   ContinuousState<T>* get_mutable_substate(int index) {
     DRAKE_DEMAND(index >= 0 && index < get_num_substates());
     return substates_[index];
@@ -54,9 +53,8 @@ class DiagramContinuousState : public ContinuousState<T> {
       std::function<VectorBase<T>*(ContinuousState<T>&)> selector) {
     std::vector<VectorBase<T>*> sub_xs;
     for (const auto& substate : substates) {
-      if (substate != nullptr) {
-        sub_xs.push_back(selector(*substate));
-      }
+      DRAKE_DEMAND(substate != nullptr);
+      sub_xs.push_back(selector(*substate));
     }
     return std::make_unique<Supervector<T>>(sub_xs);
   }

--- a/drake/systems/framework/difference_state.h
+++ b/drake/systems/framework/difference_state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
@@ -10,43 +11,74 @@ namespace drake {
 namespace systems {
 
 /// The DifferenceState is a container for the numerical state values that are
-/// updated discontinuously on time or state based triggers.
+/// updated discontinuously on time or state based triggers. It may own its
+/// underlying data, for use with leaf Systems, or not, for use with Diagrams.
 ///
-/// DifferenceState owns its state, and is therefore suitable for leaf Systems
-/// but not for Diagrams.
+/// DifferenceState is an ordered collection of vectors xd = [xd0, xd1...].
+/// Requesting a specific index from this collection is the most granular way
+/// to retrieve difference state from the Context, and thus is the unit of
+/// cache invalidation. System authors are encouraged to partition their
+/// DifferenceState such that each cacheable computation within the System may
+/// depend on only the elements of DifferenceState that it needs.
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
 template <typename T>
 class DifferenceState {
  public:
+  /// Constructs an empty difference state.
   DifferenceState() {}
 
-  explicit DifferenceState(
-      std::vector<std::unique_ptr<BasicVector<T>>> difference_state)
-      : difference_state_(std::move(difference_state)) {}
+  /// Constructs a difference state that does not own the underlying @p data.
+  /// The data must outlive this DifferenceState.
+  explicit DifferenceState(const std::vector<BasicVector<T>*>& data)
+      : data_(data) {}
+
+  /// Constructs a difference state that owns the underlying @p data.
+  explicit DifferenceState(std::vector<std::unique_ptr<BasicVector<T>>>&& data)
+      : owned_data_(std::move(data)) {
+    // Initialize the unowned pointers.
+    for (auto& datum : owned_data_) {
+      data_.push_back(datum.get());
+    }
+  }
 
   virtual ~DifferenceState() {}
 
   int size() const {
-    return static_cast<int>(difference_state_.size());
+    return static_cast<int>(data_.size());
   }
 
   const BasicVector<T>* get_difference_state(int index) const {
     DRAKE_ASSERT(index >= 0 && index < size());
-    return difference_state_[index].get();
+    return data_[index];
   }
 
   BasicVector<T>* get_mutable_difference_state(int index) {
     DRAKE_ASSERT(index >= 0 && index < size());
-    return difference_state_[index].get();
+    return data_[index];
   }
 
+  /// Writes the values from @p other into this DifferenceState, possibly
+  /// writing through to unowned data. Aborts if the dimensions don't match.
   void CopyFrom(const DifferenceState<T>& other) {
     DRAKE_DEMAND(size() == other.size());
     for (int i = 0; i < size(); i++) {
-      difference_state_[i]->set_value(
-          other.get_difference_state(i)->get_value());
+      DRAKE_DEMAND(other.get_difference_state(i) != nullptr);
+      DRAKE_DEMAND(data_[i] != nullptr);
+      data_[i]->set_value(other.get_difference_state(i)->get_value());
     }
+  }
+
+  /// Returns a deep copy of all the data in this DifferenceState. The clone
+  /// will own its own data. This is true regardless of whether the state being
+  /// cloned had ownership of its data or not.
+  std::unique_ptr<DifferenceState> Clone() const {
+    std::vector<std::unique_ptr<BasicVector<T>>> cloned_data;
+    cloned_data.reserve(data_.size());
+    for (const BasicVector<T>* datum : data_) {
+      cloned_data.push_back(datum->Clone());
+    }
+    return std::make_unique<DifferenceState>(std::move(cloned_data));
   }
 
   // DifferenceState is not copyable or moveable.
@@ -56,7 +88,13 @@ class DifferenceState {
   DifferenceState& operator=(DifferenceState&& other) = delete;
 
  private:
-  std::vector<std::unique_ptr<BasicVector<T>>> difference_state_;
+  // Pointers to the data comprising the state. If the data is owned, these
+  // pointers are equal to the pointers in owned_data_.
+  std::vector<BasicVector<T>*> data_;
+  // Owned pointers to the data comprising the state. The only purpose of these
+  // pointers is to maintain ownership. They may be populated at construction
+  // time, and are never accessed thereafter.
+  std::vector<std::unique_ptr<BasicVector<T>>> owned_data_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -14,6 +14,7 @@
 #include "drake/systems/framework/continuous_state.h"
 #include "drake/systems/framework/difference_state.h"
 #include "drake/systems/framework/leaf_context.h"
+#include "drake/systems/framework/modal_state.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/value.h"
@@ -54,6 +55,7 @@ class LeafSystem : public System<T> {
     context->set_continuous_state(this->AllocateContinuousState());
     // Reserve discrete state via delegation to subclass.
     context->set_difference_state(this->AllocateDifferenceState());
+    context->set_modal_state(this->AllocateModalState());
     return std::unique_ptr<Context<T>>(context.release());
   }
 
@@ -70,12 +72,12 @@ class LeafSystem : public System<T> {
     return std::unique_ptr<SystemOutput<T>>(output.release());
   }
 
-  /// Returns the AllocateContinuousState value, which may be nullptr.
+  /// Returns the AllocateContinuousState value, which must not be nullptr.
   std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const override {
     return AllocateContinuousState();
   }
 
-  /// Returns the AllocateDifferenceState value, which may be nullptr.
+  /// Returns the AllocateDifferenceState value, which must not be nullptr.
   std::unique_ptr<DifferenceState<T>> AllocateDifferenceVariables()
       const override {
     return AllocateDifferenceState();
@@ -108,13 +110,19 @@ class LeafSystem : public System<T> {
   /// AllocateTimeDerivatives. By default, allocates no state. Systems with
   /// continuous state variables should override.
   virtual std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const {
-    return nullptr;
+    return  std::make_unique<ContinuousState<T>>();
   }
 
-  /// Reserves the difference state as required by CreateDefaultContext.  By
+  /// Reserves the difference state as required by CreateDefaultContext. By
   /// default, reserves no state. Systems with difference state should override.
   virtual std::unique_ptr<DifferenceState<T>> AllocateDifferenceState() const {
-    return {};
+    return std::make_unique<DifferenceState<T>>();
+  }
+
+  /// Reserves the modal state as required by CreateDefaultContext. By
+  /// default, reserves no state. Systems with modal state should override.
+  virtual std::unique_ptr<ModalState> AllocateModalState() const {
+    return std::make_unique<ModalState>();
   }
 
   /// Given a port descriptor, allocates the vector storage.  The default

--- a/drake/systems/framework/modal_state.cc
+++ b/drake/systems/framework/modal_state.cc
@@ -1,0 +1,55 @@
+#include "drake/systems/framework/modal_state.h"
+
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace systems {
+
+ModalState::~ModalState() {}
+
+ModalState::ModalState() {}
+
+ModalState::ModalState(std::vector<std::unique_ptr<AbstractValue>>&& data)
+    : owned_data_(std::move(data)) {
+  for (auto& datum : owned_data_) {
+    data_.push_back(datum.get());
+  }
+}
+
+ModalState::ModalState(const std::vector<AbstractValue*>& data)
+      : data_(data) {}
+
+int ModalState::size() const {
+  return static_cast<int>(data_.size());
+}
+
+const AbstractValue& ModalState::get_modal_state(int index) const {
+  DRAKE_ASSERT(index >= 0 && index < size());
+  DRAKE_ASSERT(data_[index] != nullptr);
+  return *data_[index];
+}
+
+AbstractValue& ModalState::get_mutable_modal_state(int index) {
+  DRAKE_ASSERT(index >= 0 && index < size());
+  DRAKE_ASSERT(data_[index] != nullptr);
+  return *data_[index];
+}
+
+void ModalState::CopyFrom(const ModalState& other) {
+  DRAKE_DEMAND(size() == other.size());
+  for (int i = 0; i < size(); i++) {
+    data_[i]->SetFrom(other.get_modal_state(i));
+  }
+}
+
+std::unique_ptr<ModalState> ModalState::Clone() const {
+  std::vector<std::unique_ptr<AbstractValue>> cloned_data;
+  cloned_data.reserve(data_.size());
+  for (const AbstractValue* datum : data_) {
+    cloned_data.push_back(datum->Clone());
+  }
+  return std::make_unique<ModalState>(std::move(cloned_data));
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/modal_state.h
+++ b/drake/systems/framework/modal_state.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_export.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+
+/// The ModalState is a container for the non-numerical state values that are
+/// updated discontinuously on time or state based triggers. It may or may not
+/// own the underlying data, and therefore is suitable for both leaf Systems
+/// and diagrams.
+///
+/// @tparam T A mathematical type compatible with Eigen's Scalar.
+class DRAKE_EXPORT ModalState {
+ public:
+  // Constructs an empty modal state.
+  ModalState();
+
+  /// Constructs a modal state that owns the underlying data.
+  explicit ModalState(std::vector<std::unique_ptr<AbstractValue>>&& data);
+
+  /// Constructs a modal state that does not own the underlying data.
+  explicit ModalState(const std::vector<AbstractValue*>& data);
+
+  virtual ~ModalState();
+
+  /// Returns the number of elements of modal state.
+  int size() const;
+
+  /// Returns the element of modal state at the given @p index, or aborts if
+  /// the index is out-of-bounds.
+  const AbstractValue& get_modal_state(int index) const;
+
+  /// Returns the element of modal state at the given @p index, or aborts if
+  /// the index is out-of-bounds.
+  AbstractValue& get_mutable_modal_state(int index);
+
+  /// Copies all of the modal state in @p other into this state. Aborts if the
+  /// two states are not equal in size. Throws if any of the elements are of
+  /// incompatible type.
+  void CopyFrom(const ModalState& other);
+
+  /// Returns a deep copy of all the data in this DifferenceState. The clone
+  /// will own its own data. This is true regardless of whether the state being
+  /// cloned had ownership of its data or not.
+  std::unique_ptr<ModalState> Clone() const;
+
+  // ModalState is not copyable or moveable.
+  ModalState(const ModalState& other) = delete;
+  ModalState& operator=(const ModalState& other) = delete;
+  ModalState(ModalState&& other) = delete;
+  ModalState& operator=(ModalState&& other) = delete;
+
+ private:
+  // Pointers to the data comprising the state. If the data is owned, these
+  // pointers are equal to the pointers in owned_data_.
+  std::vector<AbstractValue*> data_;
+  // Owned pointers to the data comprising the state. The only purpose of these
+  // pointers is to maintain ownership. They may be populated at construction
+  // time, and are never accessed thereafter.
+  std::vector<std::unique_ptr<AbstractValue>> owned_data_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/test/adder_test.cc
+++ b/drake/systems/framework/primitives/test/adder_test.cc
@@ -78,7 +78,7 @@ TEST_F(AdderTest, AddTwoVectors) {
 
 // Tests that Adder allocates no state variables in the context_.
 TEST_F(AdderTest, AdderIsStateless) {
-  EXPECT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 // Asserts that adders are systems with direct feedthrough inputs.

--- a/drake/systems/framework/primitives/test/constant_value_source_test.cc
+++ b/drake/systems/framework/primitives/test/constant_value_source_test.cc
@@ -49,15 +49,9 @@ TEST_F(ConstantValueSourceTest, Output) {
             output_->get_data(0)->GetValue<std::string>());
 }
 
-// Tests that inputs cannot be set for a ConstantValueSource.
-TEST_F(ConstantValueSourceTest, ShouldNotBePossibleToConnectInputs) {
-  EXPECT_THROW(context_->SetInputPort(0, MakeInput(std::move(input_))),
-               std::out_of_range);
-}
-
 // Tests that ConstantValueSource allocates no state variables in the context_.
 TEST_F(ConstantValueSourceTest, ConstantValueSourceIsStateless) {
-  EXPECT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 }  // namespace

--- a/drake/systems/framework/primitives/test/constant_vector_source_test.cc
+++ b/drake/systems/framework/primitives/test/constant_vector_source_test.cc
@@ -56,15 +56,9 @@ TEST_F(ConstantVectorSourceTest, OutputTest) {
       output_vector->get_value(), Eigen::NumTraits<double>::epsilon()));
 }
 
-// Tests that inputs cannot be set for a ConstantVectorSource.
-TEST_F(ConstantVectorSourceTest, ShouldNotBePossibleToConnectInputs) {
-  EXPECT_THROW(context_->SetInputPort(0, MakeInput(std::move(input_))),
-               std::out_of_range);
-}
-
 // Tests that ConstantVectorSource allocates no state variables in the context_.
 TEST_F(ConstantVectorSourceTest, ConstantVectorSourceIsStateless) {
-  EXPECT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 }  // namespace

--- a/drake/systems/framework/primitives/test/demultiplexer_test.cc
+++ b/drake/systems/framework/primitives/test/demultiplexer_test.cc
@@ -116,7 +116,7 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
 
 // Tests that Demultiplexer allocates no state variables in the context_.
 TEST_F(DemultiplexerTest, DemultiplexerIsStateless) {
-  EXPECT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 }  // namespace

--- a/drake/systems/framework/primitives/test/gain_test.cc
+++ b/drake/systems/framework/primitives/test/gain_test.cc
@@ -72,7 +72,7 @@ TEST_F(GainTest, VectorThroughGainSystem) {
 
 // Tests that Gain allocates no state variables in the context_.
 TEST_F(GainTest, GainIsStateless) {
-  EXPECT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 }  // namespace

--- a/drake/systems/framework/primitives/test/multiplexer_test.cc
+++ b/drake/systems/framework/primitives/test/multiplexer_test.cc
@@ -83,7 +83,7 @@ TEST_F(MultiplexerTest, ScalarConstructor) {
 
 TEST_F(MultiplexerTest, IsStateless) {
   Reset({1});
-  ASSERT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 }  // namespace

--- a/drake/systems/framework/primitives/test/pass_through_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_test.cc
@@ -66,7 +66,7 @@ TEST_F(PassThroughTest, VectorThroughPassThroughSystem) {
 
 // Tests that PassThrough allocates no state variables in the context_.
 TEST_F(PassThroughTest, PassThroughIsStateless) {
-  EXPECT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 }  // namespace

--- a/drake/systems/framework/primitives/test/time_varying_polynomial_source_test.cc
+++ b/drake/systems/framework/primitives/test/time_varying_polynomial_source_test.cc
@@ -58,15 +58,9 @@ TEST_F(TimeVaryingPolynomialSourceTest, OutputTest) {
   EXPECT_EQ(pp_value, output_vector->get_value());
 }
 
-// Tests that inputs cannot be set for a ConstantVectorSource.
-TEST_F(TimeVaryingPolynomialSourceTest, ShouldNotBePossibleToConnectInputs) {
-  EXPECT_THROW(context_->SetInputPort(0, MakeInput(std::move(input_))),
-               std::out_of_range);
-}
-
 // Tests that ConstantVectorSource allocates no state variables in the context_.
 TEST_F(TimeVaryingPolynomialSourceTest, ConstantVectorSourceIsStateless) {
-  EXPECT_EQ(nullptr, context_->get_continuous_state());
+  EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
 }  // namespace

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -4,6 +4,7 @@
 
 #include "drake/systems/framework/continuous_state.h"
 #include "drake/systems/framework/difference_state.h"
+#include "drake/systems/framework/modal_state.h"
 
 namespace drake {
 namespace systems {
@@ -17,10 +18,14 @@ namespace systems {
 template <typename T>
 class State {
  public:
-  State() {}
+  State()
+      : continuous_state_(std::make_unique<ContinuousState<T>>()),
+        difference_state_(std::make_unique<DifferenceState<T>>()),
+        modal_state_(std::make_unique<ModalState>()) {}
   virtual ~State() {}
 
   void set_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
+    DRAKE_DEMAND(xc != nullptr);
     continuous_state_ = std::move(xc);
   }
 
@@ -33,6 +38,7 @@ class State {
   }
 
   void set_difference_state(std::unique_ptr<DifferenceState<T>> xd) {
+    DRAKE_DEMAND(xd != nullptr);
     difference_state_ = std::move(xd);
   }
 
@@ -44,6 +50,19 @@ class State {
     return difference_state_.get();
   }
 
+  void set_modal_state(std::unique_ptr<ModalState> xm) {
+    DRAKE_DEMAND(xm != nullptr);
+    modal_state_ = std::move(xm);
+  }
+
+  const ModalState* get_modal_state() const {
+    return modal_state_.get();
+  }
+
+  ModalState* get_mutable_modal_state() {
+    return modal_state_.get();
+  }
+
   // State is not copyable or moveable.
   State(const State& other) = delete;
   State& operator=(const State& other) = delete;
@@ -53,6 +72,7 @@ class State {
  private:
   std::unique_ptr<ContinuousState<T>> continuous_state_;
   std::unique_ptr<DifferenceState<T>> difference_state_;
+  std::unique_ptr<ModalState> modal_state_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -13,6 +13,12 @@ target_link_libraries(supervector_test drakeSystemFramework)
 drake_add_cc_test(continuous_state_test)
 target_link_libraries(continuous_state_test drakeSystemFramework)
 
+drake_add_cc_test(difference_state_test)
+target_link_libraries(difference_state_test drakeSystemFramework)
+
+drake_add_cc_test(modal_state_test)
+target_link_libraries(modal_state_test drakeSystemFramework)
+
 drake_add_cc_test(system_test)
 target_link_libraries(system_test drakeSystemFramework)
 

--- a/drake/systems/framework/test/continuous_state_test.cc
+++ b/drake/systems/framework/test/continuous_state_test.cc
@@ -1,4 +1,4 @@
-#include "drake/systems/framework/state.h"
+#include "drake/systems/framework/continuous_state.h"
 
 #include <memory>
 

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -144,13 +144,6 @@ TEST_F(DiagramContextTest, SetAndGetInputPorts) {
   EXPECT_EQ(256, ReadVectorInputPort(*context_, 1)->get_value()[0]);
 }
 
-// Tests that an exception is thrown when setting or getting input ports that
-// don't exist.
-TEST_F(DiagramContextTest, InvalidInputPorts) {
-  EXPECT_THROW(context_->SetInputPort(2, nullptr), std::out_of_range);
-  EXPECT_THROW(ReadVectorInputPort(*context_, 2), std::out_of_range);
-}
-
 TEST_F(DiagramContextTest, Clone) {
   context_->Connect({0 /* adder0_ */, 0 /* port 0 */},
                     {1 /* adder1_ */, 1 /* port 1 */});

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -283,11 +283,12 @@ TEST_F(DiagramTest, Clone) {
 }
 
 // Tests that, when asked for the state derivatives of Systems that are
-// stateless, Diagram returns nullptr.
-TEST_F(DiagramTest, DerivativesOfStatelessSystemAreNullptr) {
+// stateless, Diagram returns an empty state.
+TEST_F(DiagramTest, DerivativesOfStatelessSystemAreEmpty) {
   std::unique_ptr<ContinuousState<double>> derivatives =
       diagram_->AllocateTimeDerivatives();
-  EXPECT_EQ(nullptr, diagram_->GetSubsystemDerivatives(*derivatives, adder0()));
+  EXPECT_EQ(0,
+            diagram_->GetSubsystemDerivatives(*derivatives, adder0())->size());
 }
 
 class DiagramOfDiagramsTest : public ::testing::Test {

--- a/drake/systems/framework/test/difference_state_test.cc
+++ b/drake/systems/framework/test/difference_state_test.cc
@@ -1,0 +1,53 @@
+#include "drake/systems/framework/difference_state.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+class DifferenceStateTest : public ::testing::Test {
+ public:
+  DifferenceStateTest() {
+    data_.push_back(BasicVector<double>::Make({1.0, 1.0}));
+    data_.push_back(BasicVector<double>::Make({2.0, 3.0}));
+  }
+
+ protected:
+  std::vector<std::unique_ptr<BasicVector<double>>> data_;
+};
+
+TEST_F(DifferenceStateTest, OwnedState) {
+  DifferenceState<double> xd(std::move(data_));
+  EXPECT_EQ(1.0, xd.get_difference_state(0)->GetAtIndex(0));
+  EXPECT_EQ(1.0, xd.get_difference_state(0)->GetAtIndex(1));
+  EXPECT_EQ(2.0, xd.get_difference_state(1)->GetAtIndex(0));
+  EXPECT_EQ(3.0, xd.get_difference_state(1)->GetAtIndex(1));
+}
+
+TEST_F(DifferenceStateTest, UnownedState) {
+  DifferenceState<double> xd(
+      std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
+  EXPECT_EQ(1.0, xd.get_difference_state(0)->GetAtIndex(0));
+  EXPECT_EQ(1.0, xd.get_difference_state(0)->GetAtIndex(1));
+  EXPECT_EQ(2.0, xd.get_difference_state(1)->GetAtIndex(0));
+  EXPECT_EQ(3.0, xd.get_difference_state(1)->GetAtIndex(1));
+}
+
+TEST_F(DifferenceStateTest, Clone) {
+  DifferenceState<double> xd(
+      std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
+  std::unique_ptr<DifferenceState<double>> clone = xd.Clone();
+  EXPECT_EQ(1.0, clone->get_difference_state(0)->GetAtIndex(0));
+  EXPECT_EQ(1.0, clone->get_difference_state(0)->GetAtIndex(1));
+  EXPECT_EQ(2.0, clone->get_difference_state(1)->GetAtIndex(0));
+  EXPECT_EQ(3.0, clone->get_difference_state(1)->GetAtIndex(1));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/modal_state_test.cc
+++ b/drake/systems/framework/test/modal_state_test.cc
@@ -1,0 +1,55 @@
+#include "drake/systems/framework/modal_state.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+
+class ModalStateTest : public ::testing::Test {
+ public:
+  ModalStateTest() {
+    data_.push_back(PackValue(42));
+    data_.push_back(PackValue(76));
+  }
+
+ protected:
+  std::unique_ptr<AbstractValue> PackValue(int value) {
+    return std::unique_ptr<AbstractValue>(new Value<int>(value));
+  }
+
+  int UnpackValue(const AbstractValue& value) {
+    return dynamic_cast<const Value<int>*>(&value)->get_value();
+  }
+
+  std::vector<std::unique_ptr<AbstractValue>> data_;
+};
+
+
+TEST_F(ModalStateTest, OwnedState) {
+  ModalState xm(std::move(data_));
+  EXPECT_EQ(42, UnpackValue(xm.get_modal_state(0)));
+  EXPECT_EQ(76, UnpackValue(xm.get_modal_state(1)));
+}
+
+TEST_F(ModalStateTest, UnownedState) {
+  ModalState xm(std::vector<AbstractValue*>{data_[0].get(), data_[1].get()});
+  EXPECT_EQ(42, UnpackValue(xm.get_modal_state(0)));
+  EXPECT_EQ(76, UnpackValue(xm.get_modal_state(1)));
+}
+
+TEST_F(ModalStateTest, Clone) {
+  ModalState xm(std::move(data_));
+  std::unique_ptr<ModalState> clone = xm.Clone();
+  EXPECT_EQ(42, UnpackValue(clone->get_modal_state(0)));
+  EXPECT_EQ(76, UnpackValue(clone->get_modal_state(1)));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -27,6 +27,10 @@ class DRAKE_EXPORT AbstractValue {
   /// Returns a copy of this AbstractValue.
   virtual std::unique_ptr<AbstractValue> Clone() const = 0;
 
+  /// Copies the value in @p other to this value, or throws if the types
+  /// are incompatible.
+  virtual void SetFrom(const AbstractValue& other) = 0;
+
   /// Returns the value wrapped in this AbstractValue, which must be of
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
   /// In Debug builds, if the types don't match, std::bad_cast will be
@@ -89,7 +93,7 @@ class DRAKE_EXPORT AbstractValue {
 /// A container class for an arbitrary type T. User-defined classes that
 /// require additional type-erased features should subclass Value<T>, taking
 /// care to define the copy constructors and override Clone().
-/// @tparam T Must be copy-constructible, and therefore not abstract.
+/// @tparam T Must be copy-constructible and assignable.
 template <typename T>
 class Value : public AbstractValue {
  public:
@@ -104,6 +108,10 @@ class Value : public AbstractValue {
 
   std::unique_ptr<AbstractValue> Clone() const override {
     return std::make_unique<Value<T>>(*this);
+  }
+
+  void SetFrom(const AbstractValue& other) override {
+    value_ = other.GetValue<T>();
   }
 
   /// Returns a const reference to the stored value.

--- a/drake/systems/plants/KinematicsCache.h
+++ b/drake/systems/plants/KinematicsCache.h
@@ -81,8 +81,8 @@ class KinematicsCache {
 
   RigidBodyToKCacheElementMap elements;
   std::vector<RigidBody const*> bodies;
-  const int num_positions;
-  const int num_velocities;
+  int num_positions;
+  int num_velocities;
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> q;
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> v;
   bool velocity_vector_valid;

--- a/drake/systems/plants/rigid_body_plant/kinematics_results.cc
+++ b/drake/systems/plants/rigid_body_plant/kinematics_results.cc
@@ -7,13 +7,13 @@ namespace drake {
 namespace systems {
 
 template<typename T>
-KinematicsResults<T>::KinematicsResults(const RigidBodyTree &tree) :
-    tree_(tree), kinematics_cache_(tree_.bodies) {
+KinematicsResults<T>::KinematicsResults(const RigidBodyTree* tree) :
+    tree_(tree), kinematics_cache_(tree_->bodies) {
 }
 
 template<typename T>
 int KinematicsResults<T>::get_num_bodies() const {
-  return tree_.get_num_bodies();
+  return tree_->get_num_bodies();
 }
 
 template<typename T>
@@ -29,7 +29,7 @@ int KinematicsResults<T>::get_num_velocities() const {
 template<typename T>
 Quaternion<T> KinematicsResults<T>::get_body_orientation(int body_index) const {
   Isometry3<T>
-      pose = tree_.relativeTransform(kinematics_cache_, 0, body_index);
+      pose = tree_->relativeTransform(kinematics_cache_, 0, body_index);
   Vector4<T> quat_vector = drake::math::rotmat2quat(pose.linear());
   // Note that Eigen quaternion elements are not laid out in memory in the
   // same way Drake currently aligns them. See issue #3470.
@@ -40,7 +40,7 @@ Quaternion<T> KinematicsResults<T>::get_body_orientation(int body_index) const {
 template<typename T>
 Vector3<T> KinematicsResults<T>::get_body_position(int body_index) const {
   Isometry3<T>
-      pose = tree_.relativeTransform(kinematics_cache_, 0, body_index);
+      pose = tree_->relativeTransform(kinematics_cache_, 0, body_index);
   return pose.translation();
 }
 
@@ -51,8 +51,8 @@ void KinematicsResults<T>::UpdateFromContext(const Context<T> &context) {
   auto x = dynamic_cast<const BasicVector<T> &>(
       context.get_continuous_state()->get_state()).get_value();
 
-  const int nq = tree_.get_num_positions();
-  const int nv = tree_.get_num_velocities();
+  const int nq = tree_->get_num_positions();
+  const int nv = tree_->get_num_velocities();
 
   // TODO(amcastro-tri): We would like to compile here with `auto` instead of
   // `VectorX<T>`. However it seems we get some sort of block from a block which
@@ -61,7 +61,7 @@ void KinematicsResults<T>::UpdateFromContext(const Context<T> &context) {
   VectorX<T> v = x.bottomRows(nv);
 
   kinematics_cache_.initialize(q, v);
-  tree_.doKinematics(kinematics_cache_, false);
+  tree_->doKinematics(kinematics_cache_, false);
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/systems/plants/rigid_body_plant/kinematics_results.h
+++ b/drake/systems/plants/rigid_body_plant/kinematics_results.h
@@ -45,7 +45,7 @@ class DRAKE_EXPORT KinematicsResults {
   // RigidBodyTree.
   // An alias to @tree is maintained so that the tree's lifetime must exceed
   // this object's lifetime.
-  explicit KinematicsResults(const RigidBodyTree& tree);
+  explicit KinematicsResults(const RigidBodyTree* tree);
 
   // Updates KinematicsResults from a context provided by RigidBodyPlant.
   // Only RigidBodyPlant has access to this method since it is a friend.
@@ -53,7 +53,7 @@ class DRAKE_EXPORT KinematicsResults {
   // cache this method won't be needed.
   void UpdateFromContext(const Context<T>& context);
 
-  const RigidBodyTree& tree_;
+  const RigidBodyTree* tree_;
   KinematicsCache<T> kinematics_cache_;
 };
 

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -139,7 +139,7 @@ std::unique_ptr<SystemOutput<T>> RigidBodyPlant<T>::AllocateOutput(
   {
     auto kinematics_results =
         make_unique<Value<KinematicsResults<T>>>(
-            KinematicsResults<T>(*tree_));
+            KinematicsResults<T>(tree_.get()));
     output->add_port(move(kinematics_results));
   }
 


### PR DESCRIPTION
Provide a uniform set of Context accessors for xd, xc, and xm, using indices to support fine-grained cache invalidation in the future.  Ensure that xd and xm are included in `LeafSystem::Clone`.  Phrase xd and xm generally, so that they may be used for Diagrams as well as leaf Systems, but do not actually implement discrete state on Diagrams yet.

Require the contents of an AbstractValue to be assignable as well as copyable, to support set without allocation. Update KinematicsCache and KinematicsResults to comply.  (Unfortunately, this required stripping `const` off some member data.)

Fixes #3765, but doesn't update signatures and call sites to take advantage of the fact that `x{c,d,m}` are never nullptr.

Initial CI run here, not quite ready for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3810)
<!-- Reviewable:end -->
