### PR TITLE
Mark python as required in Drake build

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -32,9 +32,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(WITH_PYTHON_3)
   set(Python_ADDITIONAL_VERSIONS 3.5)
-  find_package(PythonInterp 3)
+  find_package(PythonInterp 3 REQUIRED)
 else()
-  find_package(PythonInterp)
+  find_package(PythonInterp REQUIRED)
 endif()
 
 # set up pods

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -147,7 +147,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
 endif()
 
 # Rules for cpplint_wrapper.py.
-if(PYTHONINTERP_FOUND AND WITH_GOOGLE_STYLEGUIDE)
+if(WITH_GOOGLE_STYLEGUIDE)
   drake_add_test(NAME cpplint_wrapper_test COMMAND
     ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/cpplint_wrapper_test.py)
 endif()

--- a/drake/lcmtypes/CMakeLists.txt
+++ b/drake/lcmtypes/CMakeLists.txt
@@ -1,8 +1,6 @@
 include(${LCM_USE_FILE})
 
-if(PYTHONINTERP_FOUND)
-  set(python_args PYTHON_SOURCES python_install_sources)
-endif()
+set(python_args PYTHON_SOURCES python_install_sources)
 if(JAVA_FOUND AND TARGET lcm-java)
   set(java_args JAVA_SOURCES java_sources)
 endif()
@@ -69,9 +67,7 @@ install(TARGETS drake_lcmtypes
   INCLUDES DESTINATION include
 )
 
-if(PYTHONINTERP_FOUND)
-  lcm_install_python(${python_install_sources})
-endif()
+lcm_install_python(${python_install_sources})
 
 if(JAVA_FOUND)
   if(NOT TARGET lcm-java)


### PR DESCRIPTION
All of the required `from_source.rst` variants have it, and much of our development either requires it now, or will soon require it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3820)
<!-- Reviewable:end -->
