### PR TITLE
Do not require CC, CXX, FC, F77 to be constantly set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,17 +83,43 @@ drake_add_external(google_styleguide PUBLIC
   BUILD_COMMAND :)
 
 # ipopt
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # Work around horrific clang* = clang, */cl* = msvc bug in BuildTools/coin.m4
+  get_filename_component(IPOPT_C_COMPILER "${CMAKE_C_COMPILER}" NAME)
+  get_filename_component(IPOPT_CXX_COMPILER "${CMAKE_CXX_COMPILER}" NAME)
+else()
+  set(IPOPT_C_COMPILER "${CMAKE_C_COMPILER}")
+  set(IPOPT_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
+endif()
+
 drake_add_external(ipopt PUBLIC
-  # TODO(sam.creasey) add an alternate build command for WIN32 which
-  # downloads the precopiled binary and installs that.
-  CONFIGURE_COMMAND ./configure
+  CONFIGURE_COMMAND
+    ${CMAKE_COMMAND} -E env
+      CC=${IPOPT_C_COMPILER}
+      CFLAGS=${CMAKE_C_FLAGS}
+      CXX=${IPOPT_CXX_COMPILER}
+      CXXFLAGS=${CMAKE_CXX_FLAGS}
+      F77=${CMAKE_Fortran_COMPILER}
+      FC=${CMAKE_Fortran_COMPILER}
+      FFLAGS=${CMAKE_Fortran_FLAGS}
+   ./configure
     --with-blas=BUILD
     --with-lapack=BUILD
     --prefix=${CMAKE_INSTALL_PREFIX}
     --includedir=${CMAKE_INSTALL_PREFIX}/include/ipopt
     --disable-shared
     --with-pic
-  INSTALL_COMMAND ${MAKE_COMMAND} install)
+  INSTALL_COMMAND
+    # TODO(jamiesnape): Check whether environment variables are actually used
+    ${CMAKE_COMMAND} -E env
+      CC=${IPOPT_C_COMPILER}
+      CFLAGS=${CMAKE_C_FLAGS}
+      CXX=${IPOPT_CXX_COMPILER}
+      CXXFLAGS=${CMAKE_CXX_FLAGS}
+      F77=${CMAKE_Fortran_COMPILER}
+      FC=${CMAKE_Fortran_COMPILER}
+      FFLAGS=${CMAKE_Fortran_FLAGS}
+    ${MAKE_COMMAND} install)
 
 # nlopt
 drake_add_external(nlopt PUBLIC CMAKE
@@ -140,10 +166,23 @@ drake_add_external(octomap PUBLIC CMAKE
 # swig_matlab
 drake_add_external(swig_matlab PUBLIC
   PATCH_COMMAND ./autogen.sh
-  CONFIGURE_COMMAND ./configure
-    --prefix=${CMAKE_INSTALL_PREFIX}
-    --with-matlab
-  INSTALL_COMMAND ${MAKE_COMMAND} install)
+  CONFIGURE_COMMAND
+    ${CMAKE_COMMAND} -E env
+      CC=${CMAKE_C_COMPILER}
+      CFLAGS=${CMAKE_C_FLAGS}
+      CXX=${CMAKE_CXX_COMPILER}
+      CXXFLAGS=${CMAKE_CXX_FLAGS}
+    ./configure
+      --prefix=${CMAKE_INSTALL_PREFIX}
+      --with-matlab
+  INSTALL_COMMAND
+    # TODO(jamiesnape): Check whether environment variables are actually used
+    ${CMAKE_COMMAND} -E env
+      CC=${CMAKE_C_COMPILER}
+      CFLAGS=${CMAKE_C_FLAGS}
+      CXX=${CMAKE_CXX_COMPILER}
+      CXXFLAGS=${CMAKE_CXX_FLAGS}
+    ${MAKE_COMMAND} install)
 
 # textbook
 if(MATLAB_EXECUTABLE)

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -2,7 +2,16 @@ include(ExternalProject)
 
 find_package(Git REQUIRED)
 
-if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")
+if(CMAKE_GENERATOR STREQUAL "Ninja")
+  # The Ninja generator does not support Fortran
+  find_program(CMAKE_Fortran_COMPILER "$ENV{FC}" DOC "Fortran compiler")
+  set(CMAKE_Fortran_FLAGS "$ENV{FFLAGS}" CACHE STRING
+    "Flags for Fortran compiler")
+else()
+  enable_language(Fortran)
+endif()
+
+if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
   set(MAKE_COMMAND "$(MAKE)") # so we can pass through command line arguments
 else()
   find_program(MAKE_COMMAND make)
@@ -159,6 +168,8 @@ macro(drake_add_cmake_external PROJECT)
     CMAKE_C_FLAGS
     CMAKE_CXX_COMPILER
     CMAKE_CXX_FLAGS
+    CMAKE_Fortran_COMPILER
+    CMAKE_Fortran_FLAGS
     CMAKE_EXE_LINKER_FLAGS
     CMAKE_MODULE_LINKER_FLAGS
     CMAKE_SHARED_LINKER_FLAGS

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -3,7 +3,8 @@ include(ExternalProject)
 find_package(Git REQUIRED)
 
 if(CMAKE_GENERATOR STREQUAL "Ninja")
-  # The Ninja generator does not support Fortran
+  # The Ninja generator does not support Fortran, so manually find the Fortran
+  # compiler and set any flags passed in by environment variable
   find_program(CMAKE_Fortran_COMPILER "$ENV{FC}" DOC "Fortran compiler")
   set(CMAKE_Fortran_FLAGS "$ENV{FFLAGS}" CACHE STRING
     "Flags for Fortran compiler")

--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -49,7 +49,6 @@ directory as described in the :ref:`installation instructions <getting_drake>`.
    * ``CC=gcc-4.9``
    * ``CXX=g++-4.9``
    * ``FC=gfortran-4.9``
-   * ``F77=gfortran-4.9``      
 
 9. Click OK. CLion will take about a minute to reload the CMake Project. If
    everything is in order, there should be no errors or warnings. For fun,

--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -75,26 +75,26 @@ Compiler Environment Variables
 
 Since Drake does not use the system default compiler, the desired compiler
 must be manually specified. One way to do this is to set the ``CC``, ``CXX``,
-``FC``, and ``F77`` environment variables. This can be done by executing the command
+and ``FC``, environment variables. This can be done by executing the command
 below. To avoid needing to run this command each time a new terminal is opened,
 the command below can also be added to the ``~/.bashrc`` file::
 
-    export CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9 F77=gfortran-4.9
+    export CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9
 
-Alternatively, every call to ``make`` or ``cmake`` can be preceded with
+Alternatively, the initial call to ``cmake`` can be preceded with
 environment variable settings that specify the correct compiler. For example::
 
-    env CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9 F77=gfortran-4.9 make ...
+    env CC=gcc-4.9 CXX=g++-4.9 FC=gfortran-4.9 cmake ...
 
 The above examples result in the use of ``gcc`` as the compiler. If you want to
 use ``clang`` as the compiler, place the following in your ``~/.bashrc`` file::
 
-    export CC=clang-3.7 CXX=clang++-3.7 FC=gfortran-4.9 F77=gfortran-4.9
+    export CC=clang-3.7 CXX=clang++-3.7 FC=gfortran-4.9
 
-Or precede every call to ``make`` or ``cmake`` with compiler specifications.
+Or precede the initial call to ``cmake`` with compiler specifications.
 For example::
 
-    env CC=clang-3.7 CXX=clang++-3.7 FC=gfortran-4.9 F77=gfortran-4.9 make ...
+    env CC=clang-3.7 CXX=clang++-3.7 FC=gfortran-4.9 cmake ...
 
 MATLAB
 ======


### PR DESCRIPTION
The current situation is that `CC`, `CXX`, `FC`, `F77` always have to be set because the flags are not passed down to Autotools projects. This is also undesirable because CMake projects could use different compilers if `CC`, `CXX`, `FC`, `F77` were changed after the initial configuration. This also removes the need to ever set `F77`. Additionally, compiler flags were not being passed down.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3835)
<!-- Reviewable:end -->
