### PR TITLE
Make director depend on drake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,8 +270,8 @@ drake_add_external(director PUBLIC CMAKE
   SOURCE_SUBDIR distro/superbuild
   CMAKE_ARGS
     -DUSE_DRAKE=ON
-    -DUSE_LCM=ON # TODO: predicate on whether we have LCM enabled?
-    -DUSE_LCMGL=ON
+    -DUSE_LCM=${HAVE_LCM}
+    -DUSE_LCMGL=${HAVE_LIBBOT}
     -DUSE_SYSTEM_LCM=ON
     -DUSE_EXTERNAL_INSTALL=ON
   INSTALL_COMMAND :

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,21 +195,6 @@ drake_add_external(libbot PUBLIC CMAKE
 drake_add_external(bot_core_lcmtypes PUBLIC CMAKE
   DEPENDS lcm libbot) # Conflicts with libbot; ensure this is built after
 
-# director
-drake_add_external(director PUBLIC CMAKE
-  SOURCE_SUBDIR distro/superbuild
-  CMAKE_ARGS
-    -DUSE_LCM=ON # TODO: predicate on whether we have LCM enabled?
-    -DUSE_LCMGL=ON
-    -DUSE_SYSTEM_LCM=ON
-    -DUSE_EXTERNAL_INSTALL=ON
-  INSTALL_COMMAND :
-  DEPENDS bot_core_lcmtypes lcm libbot)
-
-# signalscope
-drake_add_external(signalscope PUBLIC
-  DEPENDS director)
-
 # xfoil
 # The Ninja generator does not support Fortran.
 drake_add_external(xfoil PUBLIC CMAKE GENERATOR "Unix Makefiles")
@@ -255,7 +240,6 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
     bot_core_lcmtypes
     bullet
     ccd
-    director
     dreal
     eigen
     gflags
@@ -280,6 +264,22 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
     yaml_cpp
     xfoil
 )
+
+# director
+drake_add_external(director PUBLIC CMAKE
+  SOURCE_SUBDIR distro/superbuild
+  CMAKE_ARGS
+    -DUSE_DRAKE=ON
+    -DUSE_LCM=ON # TODO: predicate on whether we have LCM enabled?
+    -DUSE_LCMGL=ON
+    -DUSE_SYSTEM_LCM=ON
+    -DUSE_EXTERNAL_INSTALL=ON
+  INSTALL_COMMAND :
+  DEPENDS bot_core_lcmtypes drake lcm libbot)
+
+# signalscope
+drake_add_external(signalscope PUBLIC
+  DEPENDS director)
 
 # END external projects
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,9 +221,6 @@ drake_add_external(xfoil PUBLIC CMAKE GENERATOR "Unix Makefiles")
 # also find it useful, especially to build drake with ninja using fewer than
 # the default number of jobs.
 option(SKIP_DRAKE_BUILD "Build external projects but not drake itself" OFF)
-if(SKIP_DRAKE_BUILD)
-  set(DRAKE_BUILD_COMMANDS BUILD_COMMAND : INSTALL_COMMAND :)
-endif()
 
 # drake: For drake, list both compilation AND RUNTIME dependencies. Runtime
 # dependencies are needed because the drake project must configure only after
@@ -231,7 +228,6 @@ endif()
 drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake
   BINARY_DIR ${PROJECT_BINARY_DIR}/drake
-  ${DRAKE_BUILD_COMMANDS}
   CMAKE_ARGS
     -DDISABLE_MATLAB:BOOL=${DISABLE_MATLAB}
     -DWITH_AVL:BOOL=${WITH_AVL}

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -179,6 +179,7 @@ macro(drake_add_cmake_external PROJECT)
     DOWNLOAD_COMMAND ${_ext_DOWNLOAD_COMMAND}
     UPDATE_COMMAND ${_ext_UPDATE_COMMAND}
     ${_ext_EXTRA_COMMANDS}
+    STEP_TARGETS configure build install
     INDEPENDENT_STEP_TARGETS update
     BUILD_ALWAYS 1
     DEPENDS ${_ext_deps}
@@ -225,6 +226,7 @@ macro(drake_add_foreign_external PROJECT)
     CONFIGURE_COMMAND "${_ext_CONFIGURE_COMMAND}"
     BUILD_COMMAND "${_ext_BUILD_COMMAND}"
     INSTALL_COMMAND "${_ext_INSTALL_COMMAND}"
+    STEP_TARGETS configure build install
     INDEPENDENT_STEP_TARGETS update
     BUILD_ALWAYS ${_ext_BUILD_ALWAYS}
     DEPENDS ${_ext_deps})
@@ -398,6 +400,35 @@ function(drake_add_external PROJECT)
     # TODO remove when we require CMake 3.7
     drake_add_submodule_sync_dependency(${PROJECT})
   endif()
+
+  # Check if project is build-skipped
+  string(TOUPPER SKIP_${PROJECT}_BUILD _ext_project_skip_build)
+  if(${_ext_project_skip_build})
+    # Remove project from ALL, but add configure step to ALL
+    set_target_properties(${PROJECT}
+      PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    set_target_properties(${PROJECT}-configure
+      PROPERTIES EXCLUDE_FROM_ALL FALSE)
+  endif()
+
+  # Check if project should be skipped due to skipped dependencies
+  foreach(_ext_dep ${_ext_deps})
+    string(TOUPPER SKIP_${_ext_dep}_BUILD _ext_dep_skip_build)
+    if(${_ext_dep_skip_build})
+      message(STATUS
+        "Excluding ${PROJECT} from ALL because build of dependency "
+        "${_ext_dep} is skipped or excluded")
+
+      # Remove project from ALL
+      set_target_properties(${PROJECT} ${PROJECT}-configure
+        PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+      # Mark project as skipped for this build only (not cached) so downstream
+      # dependencies (if any) will also be skipped
+      set(${_ext_project_skip_build} ON PARENT_SCOPE)
+      break()
+    endif()
+  endforeach()
 
   # Add extra per-project targets
   add_custom_target(status-${PROJECT}


### PR DESCRIPTION
Change how `SKIP_<PROJECT>_BUILD` is implemented to exclude the project and dependees from ALL rather than hacking the build/install commands for the project to be no-ops. Switch dependency order between drake and director so that director depends on drake.

Note that this means that CI will not build director until an update happens.

Supersedes #3825.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3838)
<!-- Reviewable:end -->
