### PR TITLE
Fix generation of URDF documentation

### DIFF
--- a/drake/doc/CMakeLists.txt
+++ b/drake/doc/CMakeLists.txt
@@ -63,18 +63,21 @@ else()
   message(STATUS "DOXYGEN_EXECUTABLE (doxygen) not found. C++ and MATLAB Doxygen will be excluded from the documentation build.")
 endif()
 
-if(ENV{OXYGEN_DIR})
+set(OXYGEN_DIR "$ENV{OXYGEN_DIR}" CACHE PATH
+  "Path to the directory containing the oXygen XML Editor")
+
+if(OXYGEN_DIR AND EXISTS "${OXYGEN_DIR}")
   if(APPLE)
     set(OXYGEN_SCHEMA_DOCUMENTATION_EXECUTABLE
-      $ENV{OXYGEN_DIR}/schemaDocumentationMac.sh)
+      "${OXYGEN_DIR}/schemaDocumentationMac.sh")
   else()
     set(OXYGEN_SCHEMA_DOCUMENTATION_EXECUTABLE
-      $ENV{OXYGEN_DIR}/schemaDocumentation.sh)
+      "${OXYGEN_DIR}/schemaDocumentation.sh")
   endif()
   configure_file(oxygen_cfg.xml.in oxygen_cfg.xml @ONLY)
   add_custom_command(
     COMMAND ${OXYGEN_SCHEMA_DOCUMENTATION_EXECUTABLE}
-            ${CMAKE_CURRENT_BINARY_DIR}/drakeURDF.xsd
+            ${CMAKE_CURRENT_SOURCE_DIR}/drakeURDF.xsd
             -cfg:${CMAKE_CURRENT_BINARY_DIR}/oxygen_cfg.xml
     COMMENT "Building URDF documentation..."
     OUTPUT urdf_output
@@ -83,6 +86,8 @@ if(ENV{OXYGEN_DIR})
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/urdf
     DESTINATION ${DRAKE_DOCUMENTATION_DIR} OPTIONAL)
   list(APPEND DRAKE_DOCUMENTATION_OUTPUTS urdf_output)
+else()
+  message(STATUS "OXYGEN_DIR (oXygen XML Editor) not found. URDF documentation will be excluded from the documentation build.")
 endif()
 
 if(DRAKE_DOCUMENTATION_OUTPUTS)

--- a/drake/doc/index.rst
+++ b/drake/doc/index.rst
@@ -120,7 +120,7 @@ Next steps
    developers
    Doxygen (C++) <doxygen_cxx/index.html#://>
    Doxygen (MATLAB) <doxygen_matlab/index.html#://>
-   URDF Reference <http://drake002.csail.mit.edu/drake/urdf/drakeURDF.html>
+   URDF Reference <urdf/drakeURDF.html#://>
    faq
    issues
    video_tutorials


### PR DESCRIPTION
Toward #3476.

oXygen XML Editor is on the latest CI image, but it cannot be enabled on pull requests due to licensing limitations. The job that generates and uploads the documentation to GitHub pages will have it enabled, but it cannot be enabled until after this merges.

FYI @RussTedrake.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3840)
<!-- Reviewable:end -->