### PR TITLE
FunctionalForm: Add max and min binary functions

### DIFF
--- a/drake/common/functional_form.cc
+++ b/drake/common/functional_form.cc
@@ -54,6 +54,7 @@ class FunctionalForm::Internal {
   static Form const kCos[kSize];
   static Form const kExp[kSize];
   static Form const kLog[kSize];
+  static Form const kMax[kSize][kSize];
   static Form const kSin[kSize];
   static Form const kSqrt[kSize];
 
@@ -198,6 +199,42 @@ FunctionalForm exp(FunctionalForm const& x) {
 FunctionalForm log(FunctionalForm const& x) {
   return FunctionalForm(FunctionalForm::Internal::kLog[IndexOf(x.form_)],
                         FunctionalForm::Variables(x.vars_));
+}
+
+FunctionalForm max(FunctionalForm const& l, FunctionalForm const& r) {
+  FunctionalForm::Form f =
+      FunctionalForm::Internal::kMax[IndexOf(l.form_)][IndexOf(r.form_)];
+  FunctionalForm::Variables vars;
+  if (FunctionalForm::Internal::need_vars(f)) {
+    vars = FunctionalForm::Variables::Union(l.vars_, r.vars_);
+  }
+  return FunctionalForm(f, std::move(vars));
+}
+
+FunctionalForm max(FunctionalForm const& l, double r) {
+  return max(l, FunctionalForm(r));
+}
+
+FunctionalForm max(double l, FunctionalForm const& r) {
+  return max(FunctionalForm(l), r);
+}
+
+FunctionalForm min(FunctionalForm const& l, FunctionalForm const& r) {
+  FunctionalForm::Form f =
+      FunctionalForm::Internal::kMax[IndexOf(l.form_)][IndexOf(r.form_)];
+  FunctionalForm::Variables vars;
+  if (FunctionalForm::Internal::need_vars(f)) {
+    vars = FunctionalForm::Variables::Union(l.vars_, r.vars_);
+  }
+  return FunctionalForm(f, std::move(vars));
+}
+
+FunctionalForm min(FunctionalForm const& l, double r) {
+  return min(l, FunctionalForm(r));
+}
+
+FunctionalForm min(double l, FunctionalForm const& r) {
+  return min(FunctionalForm(l), r);
 }
 
 FunctionalForm sin(FunctionalForm const& x) {
@@ -607,6 +644,21 @@ FunctionalForm::Form const FunctionalForm::Internal::kLog[kSize] = {
     /* ZERO  CONS   LIN   AFF  POLY  DIFF   ARB  UNDF */
     /* ----  ----  ----  ----  ----  ----  ----  ---- */
        UNDF, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF,
+    /* clang-format on */
+};
+
+FunctionalForm::Form const FunctionalForm::Internal::kMax[kSize][kSize] = {
+    /* clang-format off */
+    /*    \ r:  ZERO  CONS   LIN   AFF  POLY  DIFF   ARB  UNDF */
+    /*  l: \    ----  ----  ----  ----  ----  ----  ----  ---- */
+    /* ZERO */ {ZERO, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF},
+    /* CONS */ {CONS, CONS, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF},
+    /* LIN  */ {DIFF, DIFF, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF},
+    /* AFF  */ {DIFF, DIFF, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF},
+    /* POLY */ {DIFF, DIFF, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF},
+    /* DIFF */ {DIFF, DIFF, DIFF, DIFF, DIFF, DIFF,  ARB, UNDF},
+    /* ARB  */ { ARB,  ARB,  ARB,  ARB,  ARB,  ARB,  ARB, UNDF},
+    /* UNDF */ {UNDF, UNDF, UNDF, UNDF, UNDF, UNDF, UNDF, UNDF},
     /* clang-format on */
 };
 

--- a/drake/common/functional_form.h
+++ b/drake/common/functional_form.h
@@ -321,6 +321,42 @@ class DRAKE_EXPORT FunctionalForm {
       FunctionalForm
       log(FunctionalForm const& x);
 
+  /** Return the form of the \c max function applied to forms
+      \p lhs and \p rhs.  */
+  friend DRAKE_EXPORT
+      FunctionalForm
+      max(FunctionalForm const& lhs, FunctionalForm const& rhs);
+
+  /** Return the form of the \c max function applied to form
+      \p lhs and a \ref constant or \ref zero.  */
+  friend DRAKE_EXPORT
+      FunctionalForm
+      max(FunctionalForm const& lhs, double rhs);
+
+  /** Return the form of the \c max function applied to form
+      \p rhs and a \ref constant or \ref zero.  */
+  friend DRAKE_EXPORT
+      FunctionalForm
+      max(double lhs, FunctionalForm const& rhs);
+
+  /** Return the form of the \c min function applied to forms
+      \p lhs and \p rhs.  */
+  friend DRAKE_EXPORT
+      FunctionalForm
+      min(FunctionalForm const& lhs, FunctionalForm const& rhs);
+
+  /** Return the form of the \c min function applied to form
+      \p lhs and a \ref constant or \ref zero.  */
+  friend DRAKE_EXPORT
+      FunctionalForm
+      min(FunctionalForm const& lhs, double rhs);
+
+  /** Return the form of the \c min function applied to form
+      \p rhs and a \ref constant or \ref zero.  */
+  friend DRAKE_EXPORT
+      FunctionalForm
+      min(double lhs, FunctionalForm const& rhs);
+
   /** Return a copy of \p x updated to record application of a
       \c sin function.  */
   friend DRAKE_EXPORT

--- a/drake/common/test/functional_form_test.cc
+++ b/drake/common/test/functional_form_test.cc
@@ -568,7 +568,7 @@ GTEST_TEST(FunctionalFormTest, Divide) {
   }
 }
 
-GTEST_TEST(FunctionalFormTest, Functions) {
+GTEST_TEST(FunctionalFormTest, UnaryFunctions) {
   {
     FunctionalForm f = abs(FunctionalForm::Linear({"x"}));
     EXPECT_TRUE(f.IsDifferentiable());
@@ -607,6 +607,46 @@ GTEST_TEST(FunctionalFormTest, Functions) {
 
   {
     FunctionalForm f = sqrt(FunctionalForm::Linear({"x"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+}
+
+GTEST_TEST(FunctionalFormTest, BinaryFunctions) {
+  {
+    FunctionalForm f = max(FunctionalForm::Linear({"x"}),
+                           FunctionalForm::Linear({"y"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+
+  {
+    FunctionalForm f = max(FunctionalForm::Linear({"x"}), 1);
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = max(1, FunctionalForm::Linear({"x"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = min(FunctionalForm::Linear({"x"}),
+                           FunctionalForm::Linear({"y"}));
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x", "y"}));
+  }
+
+  {
+    FunctionalForm f = min(FunctionalForm::Linear({"x"}), 1);
+    EXPECT_TRUE(f.IsDifferentiable());
+    EXPECT_EQ(f.GetVariables(), Vars({"x"}));
+  }
+
+  {
+    FunctionalForm f = min(1, FunctionalForm::Linear({"x"}));
     EXPECT_TRUE(f.IsDifferentiable());
     EXPECT_EQ(f.GetVariables(), Vars({"x"}));
   }


### PR DESCRIPTION
These compute the forms of `max(l,r)` and `min(l,r)`, respectively, given the forms of `l` and `r`.  Note that `FunctionalForm` defines "differentiable" to mean "differentiable almost everywhere", so the piecewise combination of two differentiable forms is also differentiable under this definition even though there may be points with undefined derivative.

Issue: #3845

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3851)
<!-- Reviewable:end -->
