### PR TITLE
Updated c++ inline documentation to reflect class focus

### DIFF
--- a/drake/doc/cxx_inl.rst
+++ b/drake/doc/cxx_inl.rst
@@ -113,7 +113,7 @@ The implementation file explicitly instantiates the templates
 
   #include "my_class-inl.h"
 
-  template MyClass<double>;
+  template class MyClass<double>;
 
 ``main.cc``
 -----------


### PR DESCRIPTION
The documentation at http://drake.mit.edu/cxx_inl.html#my-class-cc results in a hard-to-diagnose build error when applied (as expected) to a class. This PR addresses it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3859)
<!-- Reviewable:end -->
