### PR TITLE
Added error controlled integrator

### DIFF
--- a/drake/systems/analysis/CMakeLists.txt
+++ b/drake/systems/analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Source files used to build drakeSystemAnalysis
 set(sources
   simulator.cc
+  runge_kutta3_integrator.cc
 )
 
 # Headers that should be installed with Drake so that they
@@ -9,6 +10,7 @@ set(installed_headers
     integrator_base.h
     explicit_euler_integrator.h
     runge_kutta2_integrator.h
+    runge_kutta3_integrator.h
     simulator.h
 )
 

--- a/drake/systems/analysis/explicit_euler_integrator.h
+++ b/drake/systems/analysis/explicit_euler_integrator.h
@@ -46,8 +46,11 @@ class ExplicitEulerIntegrator : public IntegratorBase<T> {
    */
   bool supports_error_control() const override { return false; }
 
+  /// Integrator does not provide an error estimate.
+  int64_t get_error_order() const override { return 0; }
+
  private:
-  bool DoStep(const T& dt) override;
+  void Integrate(const T& dt) override;
 
   // These are pre-allocated temporaries for use by integration
   std::unique_ptr<ContinuousState<T>> derivs_;
@@ -58,7 +61,7 @@ class ExplicitEulerIntegrator : public IntegratorBase<T> {
  * by IntegratorBase::Step().
  */
 template <class T>
-bool ExplicitEulerIntegrator<T>::DoStep(const T& dt) {
+void ExplicitEulerIntegrator<T>::Integrate(const T& dt) {
   // Find the continuous state xc within the Context, just once.
   auto context = IntegratorBase<T>::get_mutable_context();
   VectorBase<T>* xc = context->get_mutable_continuous_state()->
@@ -74,11 +77,6 @@ bool ExplicitEulerIntegrator<T>::DoStep(const T& dt) {
   const auto& xcdot = derivs_->get_state();
   xc->PlusEqScaled(dt, xcdot);  // xc += dt * xcdot
   context->set_time(context->get_time() + dt);
-
-  IntegratorBase<T>::UpdateStatistics(dt);
-
-  // Fixed step integrator always returns true
-  return true;
 }
 }  // systems
 }  // drake

--- a/drake/systems/analysis/explicit_euler_integrator.h
+++ b/drake/systems/analysis/explicit_euler_integrator.h
@@ -50,7 +50,7 @@ class ExplicitEulerIntegrator : public IntegratorBase<T> {
   int64_t get_error_order() const override { return 0; }
 
  private:
-  void Integrate(const T& dt) override;
+  void DoIntegrate(const T& dt) override;
 
   // These are pre-allocated temporaries for use by integration
   std::unique_ptr<ContinuousState<T>> derivs_;
@@ -61,7 +61,7 @@ class ExplicitEulerIntegrator : public IntegratorBase<T> {
  * by IntegratorBase::Step().
  */
 template <class T>
-void ExplicitEulerIntegrator<T>::Integrate(const T& dt) {
+void ExplicitEulerIntegrator<T>::DoIntegrate(const T& dt) {
   // Find the continuous state xc within the Context, just once.
   auto context = IntegratorBase<T>::get_mutable_context();
   VectorBase<T>* xc = context->get_mutable_continuous_state()->

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -574,7 +574,6 @@ class IntegratorBase {
 
   // Vectors used in error norm calculations.
   std::unique_ptr<VectorBase<T>> Ndq_;
-  VectorX<T> WvNdq_;
   VectorX<T> scaled_err_;
   std::unique_ptr<VectorBase<T>> scaled_q_err_;
 
@@ -671,7 +670,6 @@ double IntegratorBase<T>::CalcErrorNorm(IntegratorBase<T>* integrator) {
   auto& scaled_err = integrator->scaled_err_;
   auto& Ndq = integrator->Ndq_;
   auto& scaled_q_err = integrator->scaled_q_err_;
-  auto& WvNdq = integrator->WvNdq_;
 
   // Get scaling matrices.
   const auto& v_scal = integrator->get_generalized_state_scaling_matrix();
@@ -699,8 +697,8 @@ double IntegratorBase<T>::CalcErrorNorm(IntegratorBase<T>* integrator) {
   // Compute W_q*dq = N'*W_v*N*dq.
   scaled_err = gc.CopyToVector();
   system.MapConfigurationDerivativesToVelocity(context, scaled_err, Ndq.get());
-  WvNdq = v_scal * Ndq->CopyToVector();
-  system.MapVelocityToConfigurationDerivatives(context, WvNdq,
+  system.MapVelocityToConfigurationDerivatives(context, 
+                                               v_scal * Ndq->CopyToVector(), 
                                                scaled_q_err.get());
   double q_nrm =
       scaled_q_err->CopyToVector().template lpNorm<Eigen::Infinity>();

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -627,8 +627,10 @@ void IntegratorBase<T>::StepErrorControlled(const T& dt_max,
       // dt_max much smaller than current step size.
       dt_was_artificially_limited = true;
       current_step_size = dt_max;
-    } else if (dt_max < DT_GROWTH * current_step_size)
-      current_step_size = dt_max;  // dt_max is roughly current step.
+    } else {
+      if (dt_max < DT_GROWTH * current_step_size)
+        current_step_size = dt_max;  // dt_max is roughly current step.
+    }
 
     // Attempt to take the step.
     integrator->Integrate(current_step_size);
@@ -697,8 +699,8 @@ double IntegratorBase<T>::CalcErrorNorm(IntegratorBase<T>* integrator) {
   // Compute W_q*dq = N'*W_v*N*dq.
   scaled_err = gc.CopyToVector();
   system.MapConfigurationDerivativesToVelocity(context, scaled_err, Ndq.get());
-  system.MapVelocityToConfigurationDerivatives(context, 
-                                               v_scal * Ndq->CopyToVector(), 
+  system.MapVelocityToConfigurationDerivatives(context,
+                                               v_scal * Ndq->CopyToVector(),
                                                scaled_q_err.get());
   double q_nrm =
       scaled_q_err->CopyToVector().template lpNorm<Eigen::Infinity>();

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -413,7 +413,7 @@ class IntegratorBase {
    * unit quaternions.
    *
    * Assume the existence of a m x n matrix N and its pseudo-inverse N+ such
-   * that N * N+ = I (the identity matrix), v = N * qdot, and qdot = N+ * v,
+   * that N * N+ = I (the identity matrix), v = N+ * qdot, and qdot = N * v,
    * where qdot represents the time derivatives of the configuration variables
    * and v represents the velocity variables. qdot and v may generally be
    * distinct, as in the case where q corresponds to unit quaternions and v
@@ -424,12 +424,12 @@ class IntegratorBase {
    * errors in generalized configuration (x), as the following derivation shows:
    *
    * <pre>
-   * v = N * qdot
-   * dx/dt = N * dq/dt                  Use synonyms for qdot and v
-   * dx = N * dq                        Change time derivatives to differentials
-   * W_v * dx = W_v * N * dq            Pre-multiply both sides by W_v
-   * N+ * W_v * dx = N+ * W_v * N * dq  Pre-multiply both sides by N+
-   * N+ * W_v * dx = W_q * dq           Assign W_q := N+*W_v*N
+   * v = N+ * qdot
+   * dx/dt = N+ * dq/dt                 Use synonyms for qdot and v
+   * dx = N+ * dq                       Change time derivatives to differentials
+   * W_v * dx = W_v * N+ * dq           Pre-multiply both sides by W_v
+   * N * W_v * dx = N * W_v * N+ * dq   Pre-multiply both sides by N
+   * N * W_v * dx = W_q * dq            Assign W_q := N*W_v*N+
    * </pre>
    *
    * - [Nikravesh 1988] P. Nikravesh. Computer-Aided  Analysis of Mechanical

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -345,7 +345,8 @@ class IntegratorBase {
   /** Gets the error estimate (used only for integrators that support accuracy
    * estimation).
    */
-  const ContinuousState<T>* get_error_estimate() const { return err_est_.get(); }
+  const ContinuousState<T>* get_error_estimate() const {
+    return err_est_.get(); }
 
   /**
    *  Gets the scaling matrix for generalized coordinate and velocity
@@ -533,7 +534,7 @@ class IntegratorBase {
 
  private:
   // Calls DoIntegrate and does necessary pre-initialization and post-cleanup.
-  void Integrate(const T& dt){
+  void Integrate(const T& dt) {
     DoIntegrate(dt);
     last_step_size_ = dt;
   }

--- a/drake/systems/analysis/runge_kutta2_integrator.h
+++ b/drake/systems/analysis/runge_kutta2_integrator.h
@@ -46,7 +46,7 @@ class RungeKutta2Integrator : public IntegratorBase<T> {
   bool supports_error_control() const override { return false; }
 
  private:
-  void Integrate(const T& dt) override;
+  void DoIntegrate(const T& dt) override;
 
   // These are pre-allocated temporaries for use by integration
   std::unique_ptr<ContinuousState<T>> derivs0_, derivs1_;
@@ -57,7 +57,7 @@ class RungeKutta2Integrator : public IntegratorBase<T> {
  * by IntegratorBase::Step().
  */
 template <class T>
-void RungeKutta2Integrator<T>::Integrate(const T& dt) {
+void RungeKutta2Integrator<T>::DoIntegrate(const T& dt) {
   // Find the continuous state xc within the Context, just once.
   auto context = IntegratorBase<T>::get_mutable_context();
   VectorBase<T>* xc = context->get_mutable_continuous_state()->

--- a/drake/systems/analysis/runge_kutta2_integrator.h
+++ b/drake/systems/analysis/runge_kutta2_integrator.h
@@ -37,13 +37,16 @@ class RungeKutta2Integrator : public IntegratorBase<T> {
    */
   bool supports_accuracy_estimation() const override { return false; }
 
+  /// Integrator does not provide an error estimate.
+  int64_t get_error_order() const override { return 0; }
+
   /**
    * The RK2 integrator does not support error control.
    */
   bool supports_error_control() const override { return false; }
 
  private:
-  bool DoStep(const T& dt) override;
+  void Integrate(const T& dt) override;
 
   // These are pre-allocated temporaries for use by integration
   std::unique_ptr<ContinuousState<T>> derivs0_, derivs1_;
@@ -54,7 +57,7 @@ class RungeKutta2Integrator : public IntegratorBase<T> {
  * by IntegratorBase::Step().
  */
 template <class T>
-bool RungeKutta2Integrator<T>::DoStep(const T& dt) {
+void RungeKutta2Integrator<T>::Integrate(const T& dt) {
   // Find the continuous state xc within the Context, just once.
   auto context = IntegratorBase<T>::get_mutable_context();
   VectorBase<T>* xc = context->get_mutable_continuous_state()->
@@ -80,11 +83,6 @@ bool RungeKutta2Integrator<T>::DoStep(const T& dt) {
   // TODO(sherm1) Use better operators when available.
   xc->PlusEqScaled(dt * 0.5, xcdot1);
   xc->PlusEqScaled(-dt * 0.5, xcdot0);
-
-  IntegratorBase<T>::UpdateStatistics(dt);
-
-  // Fixed step integrator always returns true
-  return true;
 }
 }  // systems
 }  // drake

--- a/drake/systems/analysis/runge_kutta3_integrator-inl.h
+++ b/drake/systems/analysis/runge_kutta3_integrator-inl.h
@@ -35,7 +35,7 @@ bool RungeKutta3Integrator<T>::DoStep(const T& dt_max) {
 }
 
 template <class T>
-void RungeKutta3Integrator<T>::Integrate(const T& dt) {
+void RungeKutta3Integrator<T>::DoIntegrate(const T& dt) {
   // Find the continuous state xc within the Context, just once.
   VectorBase<T>* xc = IntegratorBase<T>::get_mutable_context()
       ->get_mutable_state()

--- a/drake/systems/analysis/runge_kutta3_integrator-inl.h
+++ b/drake/systems/analysis/runge_kutta3_integrator-inl.h
@@ -1,0 +1,89 @@
+#pragma once
+
+/// @file
+/// Template method implementations for runge_kutta_3_integrator.h.
+/// Most users should only include that file, not this one.
+/// For background, see http://drake.mit.edu/cxx_inl.html.
+
+#include "runge_kutta3_integrator.h"
+
+namespace drake {
+namespace systems {
+
+template <class T>
+void RungeKutta3Integrator<T>::DoInitialize() {
+  // Set an artificial step size target, if not set already.
+  if (!(IntegratorBase<T>::get_initial_step_size_target() <
+      IntegratorBase<T>::get_maximum_step_size()))
+    IntegratorBase<T>::request_initial_step_size_target(
+        IntegratorBase<T>::get_maximum_step_size());
+}
+
+template <class T>
+bool RungeKutta3Integrator<T>::DoStep(const T& dt_max) {
+  // TODO(edrumwri): move derivative evaluation at t0 to the simulator where
+  // it can be used for efficient guard function zero finding.
+  auto& system = IntegratorBase<T>::get_system();
+  auto& context = IntegratorBase<T>::get_context();
+  system.EvalTimeDerivatives(context, derivs0_.get());
+
+  // Call the generic error controlled stepper.
+  IntegratorBase<T>::StepErrorControlled(dt_max, this, derivs0_.get());
+
+  const T& dt = IntegratorBase<T>::get_last_integration_step_size();
+  return (dt == dt_max);
+}
+
+template <class T>
+void RungeKutta3Integrator<T>::Integrate(const T& dt) {
+  // Find the continuous state xc within the Context, just once.
+  VectorBase<T>* xc = IntegratorBase<T>::get_mutable_context()
+      ->get_mutable_state()
+      ->get_mutable_continuous_state()
+      ->get_mutable_state();
+
+  // Setup ta and tb.
+  T ta = IntegratorBase<T>::get_context().get_time();
+  T tb = ta + dt;
+
+  // Get the derivative at the current state (x0) and time (t0).
+  const auto& xcdot0 = derivs0_->get_state();
+
+  // Get the system and the context.
+  auto& system = IntegratorBase<T>::get_system();
+  auto& context = IntegratorBase<T>::get_context();
+
+  // Compute the first intermediate state and derivative (at t=0.5, x(0.5)).
+  IntegratorBase<T>::get_mutable_context()->set_time(ta + dt * 0.5);
+  xc->PlusEqScaled(dt * 0.5, xcdot0);
+  system.EvalTimeDerivatives(context, derivs1_.get());
+  const auto& xcdot1 = derivs1_->get_state();
+
+  // Compute the second intermediate state and derivative (at t=1, x(1)).
+  IntegratorBase<T>::get_mutable_context()->set_time(tb);
+  xc->SetFromVector(IntegratorBase<T>::get_interval_start_state());
+  xc->PlusEqScaled({{dt * -1.0, xcdot0}, {dt * 2.0, xcdot1}});
+  system.EvalTimeDerivatives(context, derivs2_.get());
+  const auto& xcdot2 = derivs2_->get_state();
+
+  // calculate the state at dt.
+  const double ONE_SIXTH = 1.0/6.0;
+  xc->SetFromVector(IntegratorBase<T>::get_interval_start_state());
+  xc->PlusEqScaled({{dt * ONE_SIXTH, xcdot0}, {4.0 * dt * ONE_SIXTH, xcdot1},
+                    {dt * ONE_SIXTH, xcdot2}});
+
+  // Calculate the error estimate using an Eigen vector then copy it to the
+  // continuous state vector, where the various state components can be
+  // analyzed.
+  auto& err_est = IntegratorBase<T>::get_mutable_error_estimate();
+  err_est_vec_ = -IntegratorBase<T>::get_interval_start_state();
+  xcdot0.ScaleAndAddToVector(-dt, err_est_vec_);
+  xc->ScaleAndAddToVector(1.0, err_est_vec_);
+  const int sz = err_est_vec_.size();
+  for (int i=0; i< sz; ++i)                         // Eigen does not currently
+    err_est_vec_[i] = std::abs(err_est_vec_[i]);    // support iterators.
+  err_est.SetFromVector(err_est_vec_);
+}
+
+}  // systems
+}  // drake

--- a/drake/systems/analysis/runge_kutta3_integrator.cc
+++ b/drake/systems/analysis/runge_kutta3_integrator.cc
@@ -1,0 +1,4 @@
+#include "runge_kutta3_integrator-inl.h"
+
+template class drake::systems::RungeKutta3Integrator<double>;
+

--- a/drake/systems/analysis/runge_kutta3_integrator.cc
+++ b/drake/systems/analysis/runge_kutta3_integrator.cc
@@ -1,4 +1,4 @@
 #include "runge_kutta3_integrator-inl.h"
 
-template class drake::systems::RungeKutta3Integrator<double>;
+template class DRAKE_EXPORT drake::systems::RungeKutta3Integrator<double>;
 

--- a/drake/systems/analysis/runge_kutta3_integrator.h
+++ b/drake/systems/analysis/runge_kutta3_integrator.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "drake/systems/analysis/integrator_base.h"
+
+namespace drake {
+namespace systems {
+
+/**
+ * A third-order Runge Kutta integrator with a third order error estimate.
+ * @tparam T A double or autodiff type.
+ *
+ * This class uses Drake's `-inl.h` pattern.  When seeing linker errors from
+ * this class, please refer to http://drake.mit.edu/cxx_inl.html.
+ *
+ * Instantiated templates for the following kinds of T's are provided:
+ * - double
+ *
+ * For a discussion of this Runge-Kutta method, see [Butcher, 1987]. The
+ * embedded error estimate was derived using the method mentioned in
+ * [Hairer, 1993].
+ *
+ * The Butcher tableaux for this integrator follows:
+ * <pre>
+ *        |
+ * 0      |
+ * 1/2    | 1/2
+ * 1      | -1          2
+ * ---------------------------------------------------------------------------
+ *          1/6         2/3       1/6
+ *          0           1         0
+ * </pre>
+ * where the second to last row is the 3rd-order propagated solution and
+ * the last row is the 2nd-order midpoint used for the error estimate.
+ *
+ * The following documentation is pulled from Simbody's implementation
+ * of this integrator:
+ * "This is a 3-stage, first-same-as-last (FSAL) 3rd order method which
+ * gives us an embedded 2nd order method as well, so we can extract
+ * a 3rd-order error estimate for the 2nd-order result, which error
+ * estimate can then be used for step size control, since it will
+ * behave as h^3. We then propagate the 3rd order result (whose error
+ * is unknown), which Hairer calls 'local extrapolation'.
+ * We call the initial state (t0,y0) and want (t0+h,y1). We are
+ * given the initial derivative f0=f(t0,y0), which most likely
+ * is left over from an evaluation at the end of the last step."
+ *
+ * - [Butcher, 1987] J. C. Butcher. The Numerical Analysis of Ordinary
+ *   Differential Equations. John Wiley & Sons, 1987. p. 325.
+ * - [Hairer, 1993] E. Hairer, S. Noersett, and G. Wanner. Solving ODEs I. 2nd
+ *   rev. ed. Springer, 1993. p. 166.
+ */
+template <class T>
+class RungeKutta3Integrator : public IntegratorBase<T> {
+ public:
+  virtual ~RungeKutta3Integrator() {}
+
+  RungeKutta3Integrator(const System <T>& system,
+                               Context <T>* context = nullptr)
+      : IntegratorBase<T>(system, context) {
+    derivs0_ = system.AllocateTimeDerivatives();
+    derivs1_ = system.AllocateTimeDerivatives();
+    derivs2_ = system.AllocateTimeDerivatives();
+  }
+
+  /**
+ * The integrator supports accuracy estimation.
+ */
+  bool supports_accuracy_estimation() const override { return true; }
+
+  /**
+   * The integrator supports error control.
+   */
+  bool supports_error_control() const override { return true; }
+
+  /// This integrator provides third order error estimates.
+  int64_t get_error_order() const override { return 3; }
+
+ private:
+  void DoInitialize() override;
+  bool DoStep(const T& dt) override;
+  void Integrate(const T& dt) override;
+
+  // Vector used in error estimate calculations.
+  VectorX<T> err_est_vec_;
+
+  // These are pre-allocated temporaries for use by integration.
+  std::unique_ptr <ContinuousState<T>> derivs0_, derivs1_, derivs2_;
+};
+}  // systems
+}  // drake

--- a/drake/systems/analysis/runge_kutta3_integrator.h
+++ b/drake/systems/analysis/runge_kutta3_integrator.h
@@ -78,7 +78,7 @@ class RungeKutta3Integrator : public IntegratorBase<T> {
  private:
   void DoInitialize() override;
   bool DoStep(const T& dt) override;
-  void Integrate(const T& dt) override;
+  void DoIntegrate(const T& dt) override;
 
   // Vector used in error estimate calculations.
   VectorX<T> err_est_vec_;

--- a/drake/systems/analysis/runge_kutta3_integrator.h
+++ b/drake/systems/analysis/runge_kutta3_integrator.h
@@ -88,3 +88,4 @@ class RungeKutta3Integrator : public IntegratorBase<T> {
 };
 }  // systems
 }  // drake
+

--- a/drake/systems/analysis/test/CMakeLists.txt
+++ b/drake/systems/analysis/test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(controlled_spring_mass_system)
 add_executable(simulator_test simulator_test.cc)
 add_executable(explicit_euler_integrator_test explicit_euler_integrator_test.cc)
 add_executable(runge_kutta2_integrator_test runge_kutta2_integrator_test.cc)
+add_executable(runge_kutta3_integrator_test runge_kutta3_integrator_test.cc)
 target_link_libraries(simulator_test
   drakeSystemAnalysis drakeSystemFramework drakeCommon
         drakeSpringMassSystemPlant drakeControlledSpringMassSystemPlant
@@ -13,6 +14,10 @@ target_link_libraries(explicit_euler_integrator_test
 target_link_libraries(runge_kutta2_integrator_test
         drakeSystemAnalysis drakeSystemFramework drakeCommon
         drakeSpringMassSystemPlant GTest::GTest GTest::Main)
+target_link_libraries(runge_kutta3_integrator_test
+        drakeSystemAnalysis drakeSystemFramework drakeCommon
+        drakeSpringMassSystemPlant GTest::GTest GTest::Main)
 drake_add_test(NAME simulator_test COMMAND simulator_test)
 drake_add_test(NAME explicit_euler_integrator_test COMMAND explicit_euler_integrator_test)
 drake_add_test(NAME runge_kutta2_integrator_test COMMAND runge_kutta2_integrator_test)
+drake_add_test(NAME runge_kutta3_integrator_test COMMAND runge_kutta3_integrator_test)

--- a/drake/systems/analysis/test/runge_kutta2_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta2_integrator_test.cc
@@ -43,6 +43,23 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
   EXPECT_EQ(context->get_time(), 3.);
 }
 
+/// Verifies accuracy estimation and error control are unsupported.
+GTEST_TEST(IntegratorTest, AccuracyEstAndErrorControl) {
+  // Spring-mass system is necessary only to setup the problem.
+  SpringMassSystem<double> spring_mass(1., 1., 0.);
+  const double DT = 1e-3;
+  auto context = spring_mass.CreateDefaultContext();
+  RungeKutta2Integrator<double> integrator(
+      spring_mass, DT, context.get());
+
+  EXPECT_EQ(integrator.get_error_order(), 0);
+  EXPECT_EQ(integrator.supports_accuracy_estimation(), false);
+  EXPECT_EQ(integrator.supports_error_control(), false);
+  EXPECT_THROW(integrator.set_target_accuracy(1e-1), std::logic_error);
+  EXPECT_THROW(integrator.request_initial_step_size_target(DT),
+               std::logic_error);
+}
+
 // Try a purely continuous system with no sampling.
 // d^2x/dt^2 = -kx/m
 // solution to this ODE: x(t) = c1*cos(omega*t) + c2*sin(omega*t)
@@ -95,6 +112,13 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
   // Check the solution.
   double true_sol = C1 * std::cos(kOmega * t) + C2 * std::sin(kOmega * t);
   EXPECT_NEAR(true_sol, kXFinal, 1e-5);
+
+  // Verify that integrator statistics are valid
+  EXPECT_GE(integrator.get_last_integration_step_size(), 0.0);
+  EXPECT_GE(integrator.get_largest_step_size_taken(), 0.0);
+  EXPECT_GE(integrator.get_smallest_step_size_taken(), 0.0);
+  EXPECT_GE(integrator.get_num_steps_taken(), 0);
+  EXPECT_EQ(integrator.get_error_estimate(), nullptr);
 }
 
 }  // namespace

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -1,8 +1,5 @@
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
 
-// TODO(edrumwri): Remove this and fix corresponding build errors.
-#include "drake/systems/analysis/runge_kutta3_integrator-inl.h"
-
 #include <cmath>
 
 #include "gtest/gtest.h"
@@ -14,7 +11,7 @@ namespace systems {
 namespace {
 
 GTEST_TEST(IntegratorTest, MiscAPI) {
-  MySpringMassSystem<double> spring_mass(1., 1., 0.);
+  analysis_test::MySpringMassSystem<double> spring_mass(1., 1., 0.);
 
   // Setup the integration step size.
   const double DT = 1e-3;
@@ -33,7 +30,7 @@ GTEST_TEST(IntegratorTest, MiscAPI) {
 
 GTEST_TEST(IntegratorTest, ContextAccess) {
   // Create the mass spring system
-  MySpringMassSystem<double> spring_mass(1., 1., 0.);
+  analysis_test::MySpringMassSystem<double> spring_mass(1., 1., 0.);
 
   // Create a context
   auto context = spring_mass.CreateDefaultContext();
@@ -59,7 +56,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
   const double kMass = 2.0;      // kg
 
   // Create the spring-mass system
-  MySpringMassSystem<double> spring_mass(kSpring, kMass, 0.);
+  analysis_test::MySpringMassSystem<double> spring_mass(kSpring, kMass, 0.);
 
   // Create a context
   auto context = spring_mass.CreateDefaultContext();
@@ -113,7 +110,7 @@ GTEST_TEST(IntegratorTest, SpringMassStepEC) {
   const double kMass = 2.0;      // kg
 
   // Create the spring-mass system
-  MySpringMassSystem<double> spring_mass(kSpring, kMass, 0.);
+  analysis_test::MySpringMassSystem<double> spring_mass(kSpring, kMass, 0.);
 
   // Create a context
   auto context = spring_mass.CreateDefaultContext();

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -1,0 +1,164 @@
+#include "drake/systems/analysis/runge_kutta3_integrator.h"
+
+// TODO(edrumwri): Remove this and fix corresponding build errors.
+#include "drake/systems/analysis/runge_kutta3_integrator-inl.h"
+
+#include <cmath>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/analysis/test/my_spring_mass_system.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(IntegratorTest, MiscAPI) {
+  MySpringMassSystem<double> spring_mass(1., 1., 0.);
+
+  // Setup the integration step size.
+  const double DT = 1e-3;
+
+  // Create a context.
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Create the integrator.
+  RungeKutta3Integrator<double> integrator(spring_mass, context.get());
+
+  // Set the accuracy.
+  integrator.request_initial_step_size_target(DT);
+
+  EXPECT_EQ(integrator.get_initial_step_size_target(), DT);
+}
+
+GTEST_TEST(IntegratorTest, ContextAccess) {
+  // Create the mass spring system
+  MySpringMassSystem<double> spring_mass(1., 1., 0.);
+
+  // Create a context
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Create the integrator
+  RungeKutta3Integrator<double> integrator(
+      spring_mass, context.get());  // Use default Context.
+
+  integrator.get_mutable_context()->set_time(3.);
+  EXPECT_EQ(integrator.get_context().get_time(), 3.);
+
+  EXPECT_EQ(context->get_time(), 3.);
+}
+
+// Try a purely continuous system with no sampling.
+// d^2x/dt^2 = -kx/m
+// solution to this ODE: x(t) = c1*cos(omega*t) + c2*sin(omega*t)
+// where omega = sqrt(k/m)
+// x'(t) = -c1*sin(omega*t)*omega + c2*cos(omega*t)*omega
+// for t = 0, x(0) = c1, x'(0) = c2*omega
+GTEST_TEST(IntegratorTest, SpringMassStep) {
+  const double kSpring = 300.0;  // N/m
+  const double kMass = 2.0;      // kg
+
+  // Create the spring-mass system
+  MySpringMassSystem<double> spring_mass(kSpring, kMass, 0.);
+
+  // Create a context
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Create the integrator.
+  RungeKutta3Integrator<double> integrator(
+      spring_mass, context.get());  // Use default Context.
+
+  // Set integrator parameters.
+  const double DT = 1e-3;
+  integrator.set_maximum_step_size(DT);
+  integrator.set_minimum_step_size(DT);
+  integrator.set_target_accuracy(1e-5);
+
+  // Setup the initial position and initial velocity
+  const double kInitialPosition = 0.1;
+  const double kInitialVelocity = 0.0;
+  const double kOmega = std::sqrt(kSpring / kMass);
+
+  // Set initial condition using the Simulator's internal Context.
+  spring_mass.set_position(integrator.get_mutable_context(), kInitialPosition);
+
+  // Take all the defaults.
+  integrator.Initialize();
+
+  // Setup c1 and c2 for ODE constants.
+  const double C1 = kInitialPosition;
+  const double C2 = kInitialVelocity / kOmega;
+
+  // Integrate for 1 second.
+  const double T_FINAL = 1.0;
+  for (double t = 0.0; t < T_FINAL; t += DT) integrator.Step(DT, DT);
+
+  // Get the final position.
+  const double kXFinal =
+      context->get_state().get_continuous_state()->get_state().GetAtIndex(0);
+
+  // Check the solution.
+  EXPECT_NEAR(C1 * std::cos(kOmega * T_FINAL) + C2 * std::sin(kOmega * T_FINAL),
+              kXFinal, 1e-5);
+}
+
+// Integrate a purely continuous system with no sampling using error control.
+// d^2x/dt^2 = -kx/m
+// solution to this ODE: x(t) = c1*cos(omega*t) + c2*sin(omega*t)
+// where omega = sqrt(k/m)
+// x'(t) = -c1*sin(omega*t)*omega + c2*cos(omega*t)*omega
+// for t = 0, x(0) = c1, x'(0) = c2*omega
+GTEST_TEST(IntegratorTest, SpringMassStepEC) {
+  const double kSpring = 300.0;  // N/m
+  const double kMass = 2.0;      // kg
+
+  // Create the spring-mass system
+  MySpringMassSystem<double> spring_mass(kSpring, kMass, 0.);
+
+  // Create a context
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Create the integrator.
+  RungeKutta3Integrator<double> integrator(
+      spring_mass, context.get());  // Use default Context.
+
+  // Set reasonable integrator parameters.
+  integrator.set_maximum_step_size(0.1);
+  integrator.set_minimum_step_size(1e-6);
+  integrator.set_target_accuracy(1e-5);
+
+  // Setup the initial position and initial velocity
+  const double kInitialPosition = 0.1;
+  const double kInitialVelocity = 0.0;
+  const double kOmega = std::sqrt(kSpring / kMass);
+
+  // Set initial condition using the Simulator's internal Context.
+  spring_mass.set_position(integrator.get_mutable_context(), kInitialPosition);
+
+  // Take all the defaults.
+  integrator.Initialize();
+
+  // Setup c1 and c2 for ODE constants.
+  const double C1 = kInitialPosition;
+  const double C2 = kInitialVelocity / kOmega;
+
+  // Integrate for 1 second.
+  const double T_FINAL = 1.0;
+  double t_remaining = T_FINAL - context->get_time();
+  do {
+    integrator.Step(t_remaining, t_remaining);
+    t_remaining = T_FINAL - context->get_time();
+  } while (t_remaining > 0.0);
+
+  // Get the final position.
+  const double kXFinal =
+      context->get_state().get_continuous_state()->get_state().GetAtIndex(0);
+
+  // Check the solution.
+  EXPECT_NEAR(C1 * std::cos(kOmega * T_FINAL) + C2 * std::sin(kOmega * T_FINAL),
+              kXFinal, 1e-5);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -100,6 +100,11 @@ class BasicVector : public VectorBase<T> {
 
   void SetZero() override { values_.setZero(); }
 
+  /// Computes the infinity norm for this vector.
+  T NormInf() const override {
+    return values_.template lpNorm<Eigen::Infinity>();
+  }
+
   /// Copies the entire vector to a new BasicVector, with the same concrete
   /// implementation type.
   ///

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -53,7 +53,7 @@ struct DiscreteEvent {
   /// An optional callback, supplied by the recipient, to carry out a
   /// kUpdateAction. If nullptr, DoEvalDifferenceUpdates will be used.
   std::function<void(const Context<T>&, DifferenceState<T>*)> do_update{
-    nullptr};
+      nullptr};
 };
 
 /// A token that identifies the next sample time at which a System must
@@ -332,7 +332,7 @@ class System {
   /// Transforms the velocity (v) in the given @p context to the derivative
   /// of the configuration (qdot). The transformation must be linear in velocity
   /// (qdot = N(q) * v), and it must require no more than O(N) time to compute
-  /// in the number of generalized velocity states.
+  /// in the dimension of the generalized velocity.
   void MapVelocityToConfigurationDerivatives(
       const Context<T>& context, const VectorBase<T>& generalized_velocity,
       VectorBase<T>* configuration_derivatives) const {
@@ -344,7 +344,7 @@ class System {
   /// Transforms the velocity (v) in the given @p context to the derivative
   /// of the configuration (qdot). The transformation must be linear in velocity
   /// (qdot = N(q) * v), and it must require no more than O(N) time to compute
-  /// in the number of generalized velocity states.
+  /// in the dimension of the generalized velocity.
   void MapVelocityToConfigurationDerivatives(
       const Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& generalized_velocity,
@@ -353,8 +353,31 @@ class System {
                                             configuration_derivatives);
   }
 
-  // TODO(david-german-tri): Add MapConfigurationDerivativesToVelocity
-  // and MapAccelerationToConfigurationSecondDerivatives.
+  /// Transforms the derivative of the configuration (qdot) in the given @p
+  /// context to the velocity (v). The transformation must be linear in velocity
+  /// (v = L(q) * qdot), and it must require no more than O(N) time to compute
+  /// in the dimension of the generalized configuration.
+  void MapConfigurationDerivativesToVelocity(
+      const Context<T>& context, const VectorBase<T>& configuration_derivatives,
+      VectorBase<T>* generalized_velocity) const {
+    MapConfigurationDerivativesToVelocity(
+        context, configuration_derivatives.CopyToVector(),
+        generalized_velocity);
+  }
+
+  /// Transforms the derivative of the configuration (qdot) in the given @p
+  /// context to the velocity (v). The transformation must be linear in velocity
+  /// (v = L(q) * qdot), and it must require no more than O(N) time to compute
+  /// in the dimension of the generalized configuration.
+  void MapConfigurationDerivativesToVelocity(
+      const Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& configuration_derivatives,
+      VectorBase<T>* generalized_velocity) const {
+    DoMapConfigurationDerivativesToVelocity(context, configuration_derivatives,
+                                            generalized_velocity);
+  }
+
+  // TODO(david-german-tri): MapAccelerationToConfigurationSecondDerivatives.
 
   // Sets the name of the system. It is recommended that the name not include
   // the character ':', since that the path delimiter. is "::".
@@ -540,6 +563,37 @@ class System {
   virtual void DoCalcNextUpdateTime(const Context<T>& context,
                                     UpdateActions<T>* actions) const {
     actions->time = std::numeric_limits<T>::infinity();
+  }
+
+  /// Provides the substantive implementation of
+  /// MapConfigurationDerivativesToVelocity.
+  ///
+  /// The default implementation uses the identity mapping. It throws
+  /// std::runtime_error if the @p generalized_velocity and
+  /// @p configuration_derivatives are not the same size. Child classes must
+  /// override this function if qdot != v (even if they are the same size).
+  ///
+  /// Implementations may assume that @p generalized_velocity is of
+  /// the same size as the generalized velocity allocated in
+  /// AllocateTimeDerivatives(). Implementations that are not
+  /// second-order systems may simply do nothing.
+  virtual void DoMapConfigurationDerivativesToVelocity(
+      const Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& configuration_derivatives,
+      VectorBase<T>* generalized_velocity) const {
+    // If a concrete subclass of System<T> has a generalized velocity and a
+    // generalized configuration such that the derivatives of configuration
+    // are not exactly the velocity, that subclass must override
+    // MapVelocityToConfigurationDerivatives. In the particular case where
+    // generalized velocity and generalized configuration are not even the
+    // same size, we detect this error and abort.
+    const int n = configuration_derivatives.size();
+    // You need to override System<T>::MapVelocityToConfigurationDerivatives!
+    DRAKE_THROW_UNLESS(generalized_velocity->size() == n);
+    for (int i = 0; i < n; ++i) {
+      const T value = configuration_derivatives[i];
+      generalized_velocity->SetAtIndex(i, value);
+    }
   }
 
   /// Provides the substantive implementation of

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -120,6 +120,28 @@ class VectorBase {
     return PlusEqScaled(T(-1), rhs);
   }
 
+  /// Computes the infinity norm for this vector.
+  ///
+  /// You should override this method if possible with a more efficient
+  /// approach that leverages structure; the default implementation performs
+  /// element-by-element computations that are likely inefficient. If the
+  /// vector is contiguous, for example, Eigen implementations should be far
+  /// more efficient. Overriding implementations should
+  /// ensure that this operation remains O(N) in the size of
+  /// the value and allocates no memory.
+  virtual T NormInf() const {
+    using std::abs;
+    using std::max;
+    T nrm(0);
+    const int sz = size();
+    for (int i=0; i< sz; ++i) {
+      T val = abs(GetAtIndex(i));
+      nrm = max(nrm, val);
+    }
+
+    return nrm;
+  }
+
   // VectorBase objects are neither copyable nor moveable.
   VectorBase(const VectorBase<T>& other) = delete;
   VectorBase& operator=(const VectorBase<T>& other) = delete;


### PR DESCRIPTION
Adds a third order accurate Runge Kutta integrator with a third order error estimator, an error controlled stepping scheme, and a state variable error norm calculation method. 

Also adds trivial implementation of System::MapVelocityToConfigurationDerivatives().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3860)
<!-- Reviewable:end -->
