### PR TITLE
Use FindMatlab in drake_setup_matlab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,13 +133,13 @@ drake_add_external(nlopt PUBLIC CMAKE
 
 # sedumi
 drake_add_external(sedumi CMAKE
-  CMAKE_ARGS -DMatlab_ROOT_DIR=${MATLAB_ROOT_DIR})
+  CMAKE_ARGS -DMatlab_ROOT_DIR=${Matlab_ROOT_DIR})
 
 # snopt
-if(MATLAB_EXECUTABLE)
+if(Matlab_FOUND)
   set(SNOPT_EXTRA_CMAKE_ARGS
     -DBUILD_SNOPT_C_MEX=ON
-    -DMatlab_ROOT_DIR=${MATLAB_ROOT_DIR})
+    -DMatlab_ROOT_DIR=${Matlab_ROOT_DIR})
 else()
   set(SNOPT_EXTRA_CMAKE_ARGS
     -DBUILD_SNOPT_C_MEX=OFF)
@@ -154,7 +154,7 @@ drake_add_external(snopt CMAKE
 
 # spotless
 drake_add_external(spotless PUBLIC CMAKE
-  CMAKE_ARGS -DMatlab_ROOT_DIR=${MATLAB_ROOT_DIR})
+  CMAKE_ARGS -DMatlab_ROOT_DIR=${Matlab_ROOT_DIR})
 
 # octomap
 drake_add_external(octomap PUBLIC CMAKE
@@ -185,10 +185,10 @@ drake_add_external(swig_matlab PUBLIC
     ${MAKE_COMMAND} install)
 
 # textbook
-if(MATLAB_EXECUTABLE)
+if(Matlab_FOUND)
   set(TEXTBOOK_CMAKE_ARGS
     -DBUILD_TESTING=ON
-    -DMatlab_ROOT_DIR=${MATLAB_ROOT_DIR})
+    -DMatlab_ROOT_DIR=${Matlab_ROOT_DIR})
 else()
   set(TEXTBOOK_CMAKE_ARGS -DBUILD_TESTING=OFF)
 endif()
@@ -214,7 +214,7 @@ drake_add_external(iris PUBLIC CMAKE
     -DIRIS_WITH_CDD=ON
     -DIRIS_WITH_EIGEN=OFF
     -DIRIS_WITH_MOSEK=OFF
-    -DMatlab_ROOT_DIR=${MATLAB_ROOT_DIR}
+    -DMatlab_ROOT_DIR=${Matlab_ROOT_DIR}
   DEPENDS eigen mosek)
 
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -45,7 +45,8 @@ function(drake_setup_matlab)
         "${_matlab_bindir}" DIRECTORY CACHE)
 
       if(MATLAB_EXECUTABLE)
-        # MATLAB 7.12 (R2011a) introduced the rng() function
+        # MATLAB 7.12 (R2011a) introduced the rng() function so it is a lower
+        # bound on the oldest MATLAB version that Drake can support
         find_package(Matlab 7.12 MODULE
           COMPONENTS
             MAIN_PROGRAM

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -233,7 +233,7 @@ macro(drake_setup_options)
     # compatibility issues:
     # https://github.com/RobotLocomotion/drake/issues/2578
     drake_optional_external(IPOPT ON
-      DEPENDS "NOT APPLE OR NOT MATLAB_EXECUTABLE"
+      DEPENDS "NOT APPLE OR NOT Matlab_FOUND"
       "Interior Point Optimizer, for solving non-linear optimizations")
 
     drake_optional_external(OCTOMAP ON
@@ -250,22 +250,22 @@ macro(drake_setup_options)
   # The following projects are default ON when MATLAB is present and enabled.
   # Otherwise, they are hidden and default OFF.
   drake_optional_external(SPOTLESS ON
-    DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE"
+    DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND"
     "polynomial optimization front-end for MATLAB")
 
   # The following projects are default OFF when MATLAB is present and enabled.
   # Otherwise, they are hidden and default OFF. Some of them may also be hidden
   # on Windows regardless of the status of MATLAB.
   drake_optional_external(IRIS OFF
-    DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32\;WITH_MOSEK"
+    DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND\;WITH_MOSEK"
     "fast approximate convex segmentation")
 
   drake_optional_external(SEDUMI OFF
-    DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32"
+    DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND"
     "semi-definite programming solver")
 
   drake_optional_external(YALMIP OFF
-    DEPENDS "NOT DISABLE_MATLAB\;MATLAB_EXECUTABLE\;NOT WIN32"
+    DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND"
     "free optimization front-end for MATLAB")
 
   # END external projects that are only needed when MATLAB is in use

--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -126,19 +126,10 @@ endif()
 
 # set up matlab build
 include(../cmake/mex.cmake)
-if(MATLAB_EXECUTABLE) # Set by drake_setup_platform
-  if(DISABLE_MATLAB)
-    message(STATUS "MATLAB is disabled because the CMake option DISABLE_MATLAB is set to ON.")
-  else()
-    # Use find_package to find "all of matlab" along with what is needed to use
-    # matlab_add_unit_test and matlab_add_mex
-    find_package(Matlab MODULE REQUIRED
-      COMPONENTS
-        MAIN_PROGRAM
-        MEX_COMPILER
-        MX_LIBRARY
-        SIMULINK)
-  endif()
+if(DISABLE_MATLAB AND Matlab_FOUND) # Set by drake_setup_platform
+  message(STATUS "MATLAB is disabled because the CMake option DISABLE_MATLAB is set to ON.")
+  unset(MATLAB_EXECUTABLE CACHE)
+  unset(Matlab_FOUND CACHE)
 endif()
 
 enable_testing()


### PR DESCRIPTION
Also do not start known versions of MATLAB just to find JVM version. The version is immutable and it takes forever to use MATLAB. If you happen to be time traveling and using R2017a or above, you still have to wait (or time travel another few minutes, I guess).

Incidentally, we had an implicit minimum MATLAB version of 7.12 (R2011a). We only support 8.6 (R2015b), but it is probably not worthwhile here to break everything for people using interim versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3868)
<!-- Reviewable:end -->
