### PR TITLE
Fix an issue where some tests wouldn't be built without MATLAB.

### DIFF
--- a/drake/systems/plants/test/CMakeLists.txt
+++ b/drake/systems/plants/test/CMakeLists.txt
@@ -32,12 +32,13 @@ if(gurobi_FOUND)
 endif()
 
 pods_find_pkg_config(ipopt)
+drake_find_package(snopt_c CONFIG)
 
 if(snopt_c_FOUND OR ipopt_FOUND)
   add_ik_gtest(testIK)
   add_ik_gtest(testIKpointwise)
 endif()
-if (snopt_c_FOUND)
+if(snopt_c_FOUND)
   add_ik_gtest(testIKMoreConstraints)
   add_ik_gtest(testIKtraj)
 endif()
@@ -204,4 +205,3 @@ drake_add_matlab_test(NAME systems/plants/test/testInertiasInWorldFrame COMMAND 
 drake_add_matlab_test(NAME systems/plants/test/testMassSpringDamperThrust COMMAND testMassSpringDamperThrust)
 
 # ==== Below this line is C++ and MATLAB shared code ====
-


### PR DESCRIPTION
This is because the drake_find_package() for snopt_c in the parent
CMakeLists.txt was conditional on MATLAB, causing the test subdir to
not find snopt when MATLAB wasn't present.

I think this was introduced in 8a3a41e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3874)
<!-- Reviewable:end -->
