### PR TITLE
Fix an off-by-one error in inverseKinTraj

### DIFF
--- a/drake/systems/plants/inverseKinTrajBackend.cpp
+++ b/drake/systems/plants/inverseKinTrajBackend.cpp
@@ -288,7 +288,9 @@ class IKInbetweenConstraint : public drake::solvers::Constraint {
       for (int j = 0; j < nT; j++) {
         mtkc_dc_dx.block(0, j * nq, nc, nq) =
             mtkc_dc.block(0, mtkc_dc_off * nq, nc, nq);
-        mtkc_dc_off += 1 + t_inbetween[j].size();
+        if (j != nT - 1) {
+          mtkc_dc_off += 1 + t_inbetween[j].size();
+        }
       }
 
       // Iterate over each intermediate timestamp again, integrating


### PR DESCRIPTION
Fortunately the junk data being added to mtkc_dc_off wasn't ever being
used...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3875)
<!-- Reviewable:end -->
