### PR TITLE
Added USE_SYSTEM_VTK configure flag to director.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,7 @@ drake_add_external(director PUBLIC CMAKE
     -DUSE_LCM=${HAVE_LCM}
     -DUSE_LCMGL=${HAVE_LIBBOT}
     -DUSE_SYSTEM_LCM=ON
-    -DUSE_SYSTEM_VTK=ON  # If OFF, Directory will build VTK5 from source.
+    -DUSE_SYSTEM_VTK=ON  # If OFF, Director will build VTK5 from source.
     -DUSE_EXTERNAL_INSTALL=ON
   INSTALL_COMMAND :
   DEPENDS bot_core_lcmtypes drake lcm libbot)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,7 @@ drake_add_external(director PUBLIC CMAKE
     -DUSE_LCM=${HAVE_LCM}
     -DUSE_LCMGL=${HAVE_LIBBOT}
     -DUSE_SYSTEM_LCM=ON
+    -DUSE_SYSTEM_VTK=ON  # If OFF, Directory will build VTK5 from source.
     -DUSE_EXTERNAL_INSTALL=ON
   INSTALL_COMMAND :
   DEPENDS bot_core_lcmtypes drake lcm libbot)


### PR DESCRIPTION
This flag must be modified by users who wish to install Drake on Ubuntu 16.04 with ROS Kinetic installed. For more context, see: https://github.com/RobotLocomotion/drake/issues/2624#issuecomment-251937730.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3881)
<!-- Reviewable:end -->
