### PR TITLE
Fixes dependency on drakeRBSystem by dependency on drakeRBM.

### DIFF
--- a/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/systems/plants/test/rigid_body_tree/CMakeLists.txt
@@ -3,11 +3,11 @@ if(Bullet_FOUND)
   target_link_libraries(rbt_collisions_test drakeRBM)
 
   drake_add_cc_test(rigid_body_collision_clique_test)
-  target_link_libraries(rigid_body_collision_clique_test drakeRBSystem)
+  target_link_libraries(rigid_body_collision_clique_test drakeRBM)
 endif()
 
 drake_add_cc_test(rigid_body_tree_test)
-target_link_libraries(rigid_body_tree_test drakeRBSystem)
+target_link_libraries(rigid_body_tree_test drakeRBM)
 
 drake_add_cc_test(rigid_body_tree_inverse_dynamics_test)
-target_link_libraries(rigid_body_tree_inverse_dynamics_test drakeRBSystem)
+target_link_libraries(rigid_body_tree_inverse_dynamics_test drakeRBM)


### PR DESCRIPTION
This PR simply fixes a dependency on `drakeRBSystem` (System 1) when it should actually be on `drakeRBM` (RigidBodyTree).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3911)
<!-- Reviewable:end -->
