### PR TITLE
Overload pow for AutoDiffScalar.

### DIFF
--- a/drake/math/autodiff.h
+++ b/drake/math/autodiff.h
@@ -8,30 +8,6 @@
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>
 
-/// Overloads round to mimic std::round from <cmath>.
-/// Must appear in global namespace so that ADL can select between this
-/// implementation and the STL one.
-template <typename DerType>
-double round(const Eigen::AutoDiffScalar<DerType>& x) {
-  return round(x.value());
-}
-
-/// Overloads floor to mimic std::floor from <cmath>.
-/// Must appear in global namespace so that ADL can select between this
-/// implementation and the STL one.
-template <typename DerType>
-double floor(const Eigen::AutoDiffScalar<DerType>& x) {
-  return floor(x.value());
-}
-
-/// Overloads ceil to mimic std::ceil from <cmath>.
-/// Must appear in global namespace so that ADL can select between this
-/// implementation and the STL one.
-template <typename DerType>
-double ceil(const Eigen::AutoDiffScalar<DerType>& x) {
-  return ceil(x.value());
-}
-
 namespace drake {
 namespace math {
 

--- a/drake/math/autodiff_overloads.h
+++ b/drake/math/autodiff_overloads.h
@@ -1,0 +1,68 @@
+/// @file
+/// Overloads for STL mathematical operations on AutoDiffScalar.
+///
+/// Used via argument-dependent lookup (ADL). These functions appear
+/// in the global namespace so that ADL can automatically choose between
+/// the STL version and the overloaded version to match the type of the
+/// arguments. We could alternatively have placed them in the Eigen
+/// namespace, but since we don't own that, we don't wish to pollute it.
+
+#pragma once
+
+#include <cmath>
+
+#include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+
+/// Overloads round to mimic std::round from <cmath>.
+template <typename DerType>
+double round(const Eigen::AutoDiffScalar<DerType>& x) {
+  using std::round;
+  return round(x.value());
+}
+
+/// Overloads floor to mimic std::floor from <cmath>.
+template <typename DerType>
+double floor(const Eigen::AutoDiffScalar<DerType>& x) {
+  using std::floor;
+  return floor(x.value());
+}
+
+/// Overloads ceil to mimic std::ceil from <cmath>.
+template <typename DerType>
+double ceil(const Eigen::AutoDiffScalar<DerType>& x) {
+  using std::ceil;
+  return ceil(x.value());
+}
+
+/// Overloads pow for an AutoDiffScalar base and exponent, implementing the
+/// chain rule.
+template <typename DerTypeA, typename DerTypeB>
+Eigen::AutoDiffScalar<typename DerTypeA::PlainObject> pow(
+    const Eigen::AutoDiffScalar<DerTypeA>& base,
+    const Eigen::AutoDiffScalar<DerTypeB>& exponent) {
+  // The two AutoDiffScalars being exponentiated must have the same matrix
+  // type. This includes, but is not limited to, the same scalar type and
+  // the same dimension.
+  static_assert(std::is_same<typename DerTypeA::PlainObject,
+                             typename DerTypeB::PlainObject>::value,
+                "The derivative types must match.");
+
+  const auto& x = base.value();
+  const auto& xgrad = base.derivatives();
+  const auto& y = exponent.value();
+  const auto& ygrad = exponent.derivatives();
+
+  using std::pow;
+  using std::log;
+  const auto x_to_the_y = pow(x, y);
+  return Eigen::MakeAutoDiffScalar(
+      // The value is x ^ y.
+      x_to_the_y,
+      // The multivariable chain rule states:
+      // df/dv_i = (∂f/∂x * dx/dv_i) + (∂f/∂y * dy/dv_i)
+      // ∂f/∂x is y*x^(y-1)
+      y * pow(x, y - 1) * xgrad +
+      // ∂f/∂y is (x^y)*ln(x)
+      x_to_the_y * log(x) * ygrad);
+}

--- a/drake/math/expmap.h
+++ b/drake/math/expmap.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
+#include "drake/math/autodiff_overloads.h"
 
 namespace drake {
 namespace math {

--- a/drake/math/test/CMakeLists.txt
+++ b/drake/math/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 drake_add_cc_test(autodiff_test)
+drake_add_cc_test(autodiff_overloads_test)
 drake_add_cc_test(cross_product_test)
 drake_add_cc_test(eigen_sparse_triplet_test)
 drake_add_cc_test(expmap_test)

--- a/drake/math/test/autodiff_overloads_test.cc
+++ b/drake/math/test/autodiff_overloads_test.cc
@@ -1,0 +1,48 @@
+#include "drake/math/autodiff_overloads.h"
+
+#include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_types.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace math {
+namespace {
+
+// Tests that pow(AutoDiffScalar, AutoDiffScalar) applies the chain rule.
+GTEST_TEST(AutodiffOverloadsTest, Pow) {
+  Eigen::AutoDiffScalar<Eigen::Vector2d> x;
+  x.value() = 1.1;
+  x.derivatives() = Eigen::VectorXd::Unit(2, 0);
+  Eigen::AutoDiffScalar<Eigen::Vector2d> y;
+  y.value() = 2.5;
+  y.derivatives() = Eigen::VectorXd::Unit(2, 1);
+
+  x = x * (y + 2);
+  EXPECT_DOUBLE_EQ(4.95, x.value());
+
+  // The derivative of x with respect to its original value is y + 2 = 4.5.
+  EXPECT_DOUBLE_EQ(4.5, x.derivatives()[0]);
+  // The derivative of x with respect to y is x = 1.1.
+  EXPECT_DOUBLE_EQ(1.1, x.derivatives()[1]);
+
+  auto z = pow(x, y);
+  // z is x^y = 4.95^2.5 ~= 54.51.
+  EXPECT_DOUBLE_EQ(std::pow(4.95, 2.5), z.value());
+  // ∂z/∂x is y*x^(y-1) = 2.5 * 4.95^1.5 ~= 27.53.
+  const double dzdx = 2.5 * std::pow(4.95, 1.5);
+  // ∂z/∂y is (x^y)*ln(x) = (4.95^2.5)*ln(4.95) ~= 87.19.
+  const double dzdy = std::pow(4.95, 2.5) * std::log(4.95);
+  // By the chain rule, dz/dv is 27.53 * xgrad + 87.19 * ygrad
+  EXPECT_DOUBLE_EQ(dzdx * 4.5 + dzdy * 0.0, z.derivatives()[0]);
+  EXPECT_DOUBLE_EQ(dzdx * 1.1 + dzdy * 1.0, z.derivatives()[1]);
+}
+
+}  // namespace
+}  // namespace math
+}  // namespace drake

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -9,7 +9,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/number_traits.h"
-#include "drake/math/autodiff.h"
+#include "drake/math/autodiff_overloads.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/continuous_state.h"
 #include "drake/systems/framework/difference_state.h"

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -11,6 +11,7 @@
 #include "drake/examples/Atlas/atlasUtil.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
+#include "drake/math/autodiff_overloads.h"
 #include "drake/math/expmap.h"
 #include "drake/math/gradient.h"
 #include "drake/math/quaternion.h"


### PR DESCRIPTION
Eigen provides an overload for the case where the base is AutoDiffScalar, and the exponent is just a scalar.  This overload handles the case where both the base and the exponent are AutoDiffScalars.  

@tkoolen for feature review, @jwnimmer-tri for platform review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3918)
<!-- Reviewable:end -->
