### PR TITLE
Use std::isinf to fix compile error on Xenial builds

### DIFF
--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -1,5 +1,6 @@
 #include "gurobi_solver.h"
 
+#include <cmath>
 #include <vector>
 
 #include <Eigen/Core>

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -335,7 +335,7 @@ int ProcessLinearConstraints(GRBmodel* model, MathematicalProgram& prog,
           linear_coeff_row_i.push_back(A(i, j));
         }
       }
-      if (!isinf(lb(i))) {
+      if (!std::isinf(lb(i))) {
         int error = GRBaddconstr(model, variable_indices_row_i.size(),
         variable_indices_row_i.data(), linear_coeff_row_i.data(),
                                  GRB_GREATER_EQUAL, lb(i), nullptr);
@@ -343,7 +343,7 @@ int ProcessLinearConstraints(GRBmodel* model, MathematicalProgram& prog,
           return error;
         }
       }
-      if (!isinf(ub(i))) {
+      if (!std::isinf(ub(i))) {
         int error = GRBaddconstr(model, variable_indices_row_i.size(),
                      variable_indices_row_i.data(), linear_coeff_row_i.data(),
                                  GRB_LESS_EQUAL, ub(i), nullptr);


### PR DESCRIPTION
Example of failing build: https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=159748

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3926)
<!-- Reviewable:end -->
