### PR TITLE
Revert "update director external and enable USE_DRAKE in director build"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,7 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
 drake_add_external(director PUBLIC CMAKE
   SOURCE_SUBDIR distro/superbuild
   CMAKE_ARGS
-    -DUSE_DRAKE=ON
+    -DUSE_DRAKE=OFF
     -DUSE_LCM=${HAVE_LCM}
     -DUSE_LCMGL=${HAVE_LIBBOT}
     -DUSE_SYSTEM_LCM=ON


### PR DESCRIPTION
Dear @patmarion,

The on-call build cop, @betsymcphail, believes that your PR #3900 may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration pre-merge, because additional
platforms and tests are built post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Continuous/job/mac-clang-continuous-debug/993/
https://drake-jenkins.csail.mit.edu/view/Continuous/job/mac-clang-ninja-continuous-debug/765/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3932)
<!-- Reviewable:end -->
