### PR TITLE
Added signature and implementation of DoMapVelocityToConfigurationDerivatives()

### DIFF
--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -593,11 +593,11 @@ class System {
     // If a concrete subclass of System<T> has a generalized velocity and a
     // generalized configuration such that the derivatives of configuration
     // are not exactly the velocity, that subclass must override
-    // MapVelocityToConfigurationDerivatives. In the particular case where
+    // MapConfigurationDerivativesToVelocity. In the particular case where
     // generalized velocity and generalized configuration are not even the
     // same size, we detect this error and abort.
     const int n = configuration_derivatives.size();
-    // You need to override System<T>::MapVelocityToConfigurationDerivatives!
+    // You need to override System<T>::DoMapConfigurationDerivativestoVelocity!
     DRAKE_THROW_UNLESS(generalized_velocity->size() == n);
     generalized_velocity->SetFromVector(configuration_derivatives);
   }
@@ -608,9 +608,6 @@ class System {
    * directly with an Eigen vector object for faster performance. See
    * the other DoMapVelocityToConfigurationDerivatives() signature for
    * additional information.
-   * @param context
-   * @param generalized_velocity
-   * @param configuration_derivatives
    */
   virtual void DoMapVelocityToConfigurationDerivatives(
       const Context<T>& context,
@@ -623,7 +620,7 @@ class System {
     // generalized velocity and generalized configuration are not even the
     // same size, we detect this error and abort.
     const int n = generalized_velocity.size();
-    // You need to override System<T>::MapVelocityToConfigurationDerivatives!
+    // You need to override System<T>::DoMapVelocityToConfigurationDerivatives!
     DRAKE_THROW_UNLESS(configuration_derivatives->size() == n);
     configuration_derivatives->SetFromVector(generalized_velocity);
   }

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -136,6 +136,14 @@ TEST_F(SystemTest, MapVelocityToConfigurationDerivatives) {
   EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
   EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
   EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+
+  // Test Eigen specialized function specially.
+  system_.MapVelocityToConfigurationDerivatives(context_,
+                                                state_vec1->CopyToVector(),
+                                                &state_vec2);
+  EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
+  EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
+  EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
 }
 
 TEST_F(SystemTest, MapConfigurationDerivativesToVelocity) {
@@ -147,6 +155,15 @@ TEST_F(SystemTest, MapConfigurationDerivativesToVelocity) {
   EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
   EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
   EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+
+  // Test Eigen specialized function specially.
+  system_.MapConfigurationDerivativesToVelocity(context_,
+                                                state_vec1->CopyToVector(),
+                                                &state_vec2);
+  EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
+  EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
+  EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+
 }
 
 TEST_F(SystemTest, ConfigurationDerivativeVelocitySizeMismatch) {

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -138,6 +138,26 @@ TEST_F(SystemTest, MapVelocityToConfigurationDerivatives) {
   EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
 }
 
+TEST_F(SystemTest, MapConfigurationDerivativesToVelocity) {
+  auto state_vec1 = BasicVector<double>::Make({1.0, 2.0, 3.0});
+  BasicVector<double> state_vec2(kSize);
+
+  system_.MapConfigurationDerivativesToVelocity(context_, *state_vec1,
+                                                &state_vec2);
+  EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
+  EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
+  EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+}
+
+TEST_F(SystemTest, ConfigurationDerivativeVelocitySizeMismatch) {
+  auto state_vec1 = BasicVector<double>::Make({1.0, 2.0, 3.0});
+  BasicVector<double> state_vec2(kSize + 1);
+
+  EXPECT_THROW(system_.MapConfigurationDerivativesToVelocity(
+      context_, *state_vec1, &state_vec2),
+               std::runtime_error);
+}
+
 TEST_F(SystemTest, VelocityConfigurationDerivativeSizeMismatch) {
   auto state_vec1 = BasicVector<double>::Make({1.0, 2.0, 3.0});
   BasicVector<double> state_vec2(kSize + 1);

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -163,7 +163,6 @@ TEST_F(SystemTest, MapConfigurationDerivativesToVelocity) {
   EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
   EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
   EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
-
 }
 
 TEST_F(SystemTest, ConfigurationDerivativeVelocitySizeMismatch) {


### PR DESCRIPTION
Also streamlined comments for DoMapConfigurationToVelocityDerivatives() and removed for loop from DoMapConfigurationToVelocityDerivatives() version that takes an Eigen vector as input (for speed purposes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3934)
<!-- Reviewable:end -->
