### PR TITLE
Use upstream (public) SeDuMi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = https://github.com/RobotLocomotion/yalmip.git
 [submodule "externals/sedumi"]
 	path = externals/sedumi
-	url = git@github.com:RobotLocomotion/sedumi.git
+	url = https://github.com/RobotLocomotion/sedumi.git
 [submodule "externals/avl"]
 	path = externals/avl
 	url = https://github.com/RobotLocomotion/avl.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ drake_add_external(nlopt PUBLIC CMAKE
     -DUSE_SWIG=OFF)
 
 # sedumi
-drake_add_external(sedumi CMAKE
+drake_add_external(sedumi PUBLIC CMAKE
   CMAKE_ARGS -DMatlab_ROOT_DIR=${Matlab_ROOT_DIR})
 
 # snopt

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -254,6 +254,10 @@ macro(drake_setup_options)
 
   # The following projects are default ON when MATLAB is present and enabled.
   # Otherwise, they are hidden and default OFF.
+  drake_optional_external(SEDUMI ON
+    DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND"
+    "semi-definite programming solver")
+
   drake_optional_external(SPOTLESS ON
     DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND"
     "polynomial optimization front-end for MATLAB")
@@ -264,10 +268,6 @@ macro(drake_setup_options)
   drake_optional_external(IRIS OFF
     DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND\;WITH_MOSEK"
     "fast approximate convex segmentation")
-
-  drake_optional_external(SEDUMI OFF
-    DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND"
-    "semi-definite programming solver")
 
   drake_optional_external(YALMIP OFF
     DEPENDS "NOT DISABLE_MATLAB\;Matlab_FOUND"


### PR DESCRIPTION
Integrates RobotLocomotion/sedumi#4 which switches the wrapper to using the now-public and open-source upstream SeDuMi repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3939)
<!-- Reviewable:end -->
