### PR TITLE
Add more tests to prove that assertions work

### DIFF
--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -109,6 +109,51 @@ drake_add_test(NAME
 set_tests_properties(
   drake_assert_test_nocompile
   PROPERTIES WILL_FAIL TRUE)
+# Same, but with assertions forced enabled.
+add_executable(
+  drake_assert_test_nocompile_enabled
+  drake_assert_test_compile.cc)
+target_compile_definitions(
+  drake_assert_test_nocompile_enabled PRIVATE DRAKE_ASSERT_TEST_COMPILE_ERROR)
+set_target_properties(
+  drake_assert_test_nocompile_enabled
+  PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+drake_add_test(NAME
+  drake_assert_test_nocompile_enabled
+  COMMAND ${CMAKE_COMMAND} --build . --target
+  drake_assert_test_nocompile_enabled --config $<CONFIGURATION>
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_tests_properties(
+  drake_assert_test_nocompile_enabled
+  PROPERTIES WILL_FAIL TRUE)
+target_compile_definitions(
+  drake_assert_test_nocompile_enabled PRIVATE DRAKE_ENABLE_ASSERTS)
+target_compile_options(
+  drake_assert_test_nocompile_enabled
+  PRIVATE -UDRAKE_DISABLE_ASSERTS)
+# Same, but with assertions forced disabled.
+add_executable(
+  drake_assert_test_nocompile_disabled
+  drake_assert_test_compile.cc)
+target_compile_definitions(
+  drake_assert_test_nocompile_disabled PRIVATE DRAKE_ASSERT_TEST_COMPILE_ERROR)
+set_target_properties(
+  drake_assert_test_nocompile_disabled
+  PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+drake_add_test(NAME
+  drake_assert_test_nocompile_disabled
+  COMMAND ${CMAKE_COMMAND} --build . --target
+  drake_assert_test_nocompile_disabled --config $<CONFIGURATION>
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_tests_properties(
+  drake_assert_test_nocompile_disabled
+  PROPERTIES WILL_FAIL TRUE)
+target_compile_definitions(
+  drake_assert_test_nocompile_disabled
+  PRIVATE DRAKE_DISABLE_ASSERTS)
+target_compile_options(
+  drake_assert_test_nocompile_disabled
+  PRIVATE -UDRAKE_ENABLE_ASSERTS)
 
 # Adds "drake_deprecated.h" unit testing.
 drake_add_cc_test(drake_deprecated_test)


### PR DESCRIPTION
This is extra CMake and CTest logic that helped me isolate and debug #3912 as I was developing it.

It is a _whole lot_ of copypasta.  I apologize!  My gut feeling is that rewriting it as CMake macros would not be a net win in terms of hours lost, but I am open to suggestions to the contrary.  My hope is that #3129 comes along and rewrites this all soon enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3944)
<!-- Reviewable:end -->
