### PR TITLE
Renames RigidBodyTreeLcmPublisher to be DrakeVisualizer.

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -21,7 +21,7 @@
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
 #include "drake/systems/plants/parser_urdf.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 
 namespace drake {
 namespace automotive {
@@ -192,11 +192,11 @@ void AutomotiveSimulator<T>::Start() {
   DRAKE_DEMAND(!started_);
 
   if (!rigid_body_tree_publisher_inputs_.empty()) {
-    // Arithmetic for RigidBodyTreeLcmPublisher input sizing.  We have systems
-    // that output an Euler floating joint state.  We want to mux them together
-    // to feed RigidBodyTreeLcmPublisher.  We stack them up in joint order as
-    // the position input to the publisher, and then also need to feed zeros
-    // for all of the joint velocities.
+    // Arithmetic for DrakeVisualizer input sizing.  We have systems that output
+    // an Euler floating joint state.  We want to mux them together to feed
+    // DrakeVisualizer.  We stack them up in joint order as the position input
+    // to the publisher, and then also need to feed zeros for all of the joint
+    // velocities.
     const int num_joints = rigid_body_tree_publisher_inputs_.size();
     const int num_ports_into_mux = 2 * num_joints;  // For position + velocity.
     const int num_elements_per_joint =
@@ -206,7 +206,7 @@ void AutomotiveSimulator<T>::Start() {
     auto multiplexer = builder_->template AddSystem<systems::Multiplexer<T>>(
         std::vector<int>(num_ports_into_mux, num_elements_per_joint));
     auto rigid_body_tree_publisher =
-        builder_->template AddSystem<systems::RigidBodyTreeLcmPublisher>(
+        builder_->template AddSystem<systems::DrakeVisualizer>(
             *rigid_body_tree_, lcm_.get());
     builder_->Connect(*multiplexer, *rigid_body_tree_publisher);
 

--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -108,7 +108,7 @@ void AutomotiveSimulator<T>::AddBoxcar(
   const std::vector<const RigidBody*> bodies =
       rigid_body_tree_->FindModelInstanceBodies(model_instance_id);
   DRAKE_DEMAND(bodies.size() == 1);
-  rigid_body_tree_publisher_inputs_.push_back(
+  drake_visualizer_inputs_.push_back(
       std::make_pair(bodies[0], coord_transform));
 }
 
@@ -191,13 +191,13 @@ template <typename T>
 void AutomotiveSimulator<T>::Start() {
   DRAKE_DEMAND(!started_);
 
-  if (!rigid_body_tree_publisher_inputs_.empty()) {
+  if (!drake_visualizer_inputs_.empty()) {
     // Arithmetic for DrakeVisualizer input sizing.  We have systems that output
     // an Euler floating joint state.  We want to mux them together to feed
     // DrakeVisualizer.  We stack them up in joint order as the position input
     // to the publisher, and then also need to feed zeros for all of the joint
     // velocities.
-    const int num_joints = rigid_body_tree_publisher_inputs_.size();
+    const int num_joints = drake_visualizer_inputs_.size();
     const int num_ports_into_mux = 2 * num_joints;  // For position + velocity.
     const int num_elements_per_joint =
         EulerFloatingJointStateIndices::kNumCoordinates;
@@ -220,7 +220,7 @@ void AutomotiveSimulator<T>::Start() {
     for (int input_index = 0; input_index < num_joints; ++input_index) {
       const RigidBody* body{};
       const systems::System<T>* system{};
-      std::tie(body, system) = rigid_body_tree_publisher_inputs_[input_index];
+      std::tie(body, system) = drake_visualizer_inputs_[input_index];
       // The 0'th index is the world, so our bodies start at number 1.
       DRAKE_DEMAND(body->get_body_index() == (1 + input_index));
       // Ensure the Publisher inputs correspond to the joints we have.

--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -118,7 +118,7 @@ class AutomotiveSimulator {
   std::unique_ptr<systems::DiagramBuilder<T>> builder_{
     std::make_unique<systems::DiagramBuilder<T>>()};
   std::vector<std::pair<const RigidBody*, const systems::System<T>*>>
-      rigid_body_tree_publisher_inputs_;
+      drake_visualizer_inputs_;
   int next_vehicle_number_{0};
   bool started_{false};
 

--- a/drake/examples/Pendulum/pendulum_run_dynamics.cc
+++ b/drake/examples/Pendulum/pendulum_run_dynamics.cc
@@ -6,7 +6,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/primitives/constant_vector_source.h"
 #include "drake/systems/plants/joints/floating_base_types.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 
 namespace drake {
@@ -24,7 +24,7 @@ int do_main(int argc, char* argv[]) {
   auto source = builder.AddSystem<systems::ConstantVectorSource>(tau);
   auto pendulum = builder.AddSystem<PendulumSystem>();
   auto publisher =
-      builder.AddSystem<systems::RigidBodyTreeLcmPublisher>(tree, &lcm);
+      builder.AddSystem<systems::DrakeVisualizer>(tree, &lcm);
   builder.Connect(source->get_output_port(), pendulum->get_tau_port());
   builder.Connect(pendulum->get_output_port(), publisher->get_input_port(0));
   auto diagram = builder.Build();

--- a/drake/examples/Pendulum/pendulum_run_energy_shaping.cc
+++ b/drake/examples/Pendulum/pendulum_run_energy_shaping.cc
@@ -10,7 +10,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/plants/joints/floating_base_types.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 
 namespace drake {
 namespace examples {
@@ -70,7 +70,7 @@ int do_main(int argc, char* argv[]) {
   builder.Connect(controller->get_output_port(0), pendulum->get_tau_port());
 
   auto publisher =
-      builder.AddSystem<systems::RigidBodyTreeLcmPublisher>(tree, &lcm);
+      builder.AddSystem<systems::DrakeVisualizer>(tree, &lcm);
   builder.Connect(pendulum->get_output_port(), publisher->get_input_port(0));
 
   auto diagram = builder.Build();

--- a/drake/examples/Pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_run_swing_up.cc
@@ -13,7 +13,7 @@
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/primitives/trajectory_source.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 #include "drake/util/drakeAppUtil.h"
 
 using drake::solvers::SolutionResult;
@@ -75,7 +75,7 @@ int do_main(int argc, char* argv[]) {
   RigidBodyTree tree(GetDrakePath() + "/examples/Pendulum/Pendulum.urdf",
                      systems::plants::joints::kFixed);
   auto publisher =
-      builder.AddSystem<systems::RigidBodyTreeLcmPublisher>(tree, &lcm);
+      builder.AddSystem<systems::DrakeVisualizer>(tree, &lcm);
 
   // The choices of PidController constants here are fairly arbitrary,
   // but seem to effectively swing up the pendulum and hold it.

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo.cc
@@ -17,7 +17,7 @@
 #include "drake/systems/framework/primitives/trajectory_source.h"
 #include "drake/systems/plants/parser_urdf.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/trajectories/piecewise_polynomial_trajectory.h"
 
 // Includes for the planner.
@@ -44,7 +44,7 @@ using systems::DiagramBuilder;
 using systems::GravityCompensator;
 using systems::PidControlledSystem;
 using systems::RigidBodyPlant;
-using systems::RigidBodyTreeLcmPublisher;
+using systems::DrakeVisualizer;
 using systems::Simulator;
 using systems::TrajectorySource;
 
@@ -237,7 +237,7 @@ class KukaDemo : public systems::Diagram<T> {
         *poly_trajectory_);
 
     // Creates and adds LCM publisher for visualization.
-    viz_publisher_ = builder.template AddSystem<RigidBodyTreeLcmPublisher>(
+    viz_publisher_ = builder.template AddSystem<DrakeVisualizer>(
         plant_->get_rigid_body_tree(), &lcm_);
 
     // Generates an error signal for the PID controller by subtracting the
@@ -288,7 +288,7 @@ class KukaDemo : public systems::Diagram<T> {
   GravityCompensator<T>* gravity_compensator_{nullptr};
   TrajectorySource<T>* desired_plan_{nullptr};
   std::unique_ptr<PiecewisePolynomialTrajectory> poly_trajectory_;
-  RigidBodyTreeLcmPublisher* viz_publisher_{nullptr};
+  DrakeVisualizer* viz_publisher_{nullptr};
   drake::lcm::DrakeLcm lcm_;
 };
 

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo.cc
@@ -16,8 +16,8 @@
 #include "drake/systems/framework/primitives/demultiplexer.h"
 #include "drake/systems/framework/primitives/trajectory_source.h"
 #include "drake/systems/plants/parser_urdf.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
 #include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
+#include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
 #include "drake/systems/trajectories/piecewise_polynomial_trajectory.h"
 
 // Includes for the planner.
@@ -41,10 +41,10 @@ using systems::Context;
 using systems::Demultiplexer;
 using systems::Diagram;
 using systems::DiagramBuilder;
+using systems::DrakeVisualizer;
 using systems::GravityCompensator;
 using systems::PidControlledSystem;
 using systems::RigidBodyPlant;
-using systems::DrakeVisualizer;
 using systems::Simulator;
 using systems::TrajectorySource;
 

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
@@ -15,7 +15,6 @@
 #include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
 
-
 using std::make_unique;
 using std::move;
 using std::unique_ptr;

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
@@ -13,7 +13,7 @@
 #include "drake/systems/plants/parser_urdf.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 
 using std::make_unique;
 using std::move;
@@ -31,7 +31,7 @@ using systems::ContinuousState;
 using systems::Diagram;
 using systems::DiagramBuilder;
 using systems::RigidBodyPlant;
-using systems::RigidBodyTreeLcmPublisher;
+using systems::DrakeVisualizer;
 using systems::Simulator;
 using systems::VectorBase;
 using systems::plants::joints::kFixed;
@@ -72,7 +72,7 @@ class KukaIiwaArmDynamicsSim : public systems::Diagram<T> {
         constant_value);
 
     // Creates and adds LCM publisher for visualization.
-    viz_publisher_ = builder.template AddSystem<RigidBodyTreeLcmPublisher>(
+    viz_publisher_ = builder.template AddSystem<DrakeVisualizer>(
         plant_->get_rigid_body_tree(), &lcm_);
 
     // Connects the constant source output port to the RigidBodyPlant's input
@@ -100,7 +100,7 @@ class KukaIiwaArmDynamicsSim : public systems::Diagram<T> {
 
  private:
   RigidBodyPlant<T>* plant_;
-  RigidBodyTreeLcmPublisher* viz_publisher_;
+  DrakeVisualizer* viz_publisher_;
   DrakeLcm lcm_;
 
   ConstantVectorSource<T>* const_source_;

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
@@ -12,8 +12,9 @@
 #include "drake/systems/framework/primitives/constant_vector_source.h"
 #include "drake/systems/plants/parser_urdf.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
 #include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
+#include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
+
 
 using std::make_unique;
 using std::move;
@@ -30,8 +31,8 @@ using systems::Context;
 using systems::ContinuousState;
 using systems::Diagram;
 using systems::DiagramBuilder;
-using systems::RigidBodyPlant;
 using systems::DrakeVisualizer;
+using systems::RigidBodyPlant;
 using systems::Simulator;
 using systems::VectorBase;
 using systems::plants::joints::kFixed;

--- a/drake/examples/schunk_gripper/test/simulated_schunk_system_test.cc
+++ b/drake/examples/schunk_gripper/test/simulated_schunk_system_test.cc
@@ -12,7 +12,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/primitives/constant_vector_source.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 
 namespace drake {
 namespace examples {
@@ -81,7 +81,7 @@ GTEST_TEST(SimulatedSchunkSystemTest, OpenGripper) {
   // require `drake_visualizer` but it is convenient to have when debugging.
   drake::lcm::DrakeLcm lcm;
   const auto viz_publisher =
-      builder.template AddSystem<systems::RigidBodyTreeLcmPublisher>(
+      builder.template AddSystem<systems::DrakeVisualizer>(
           schunk->get_rigid_body_tree(), &lcm);
   builder.Connect(schunk->get_output_port(0),
                   viz_publisher->get_input_port(0));

--- a/drake/systems/plants/rigid_body_plant/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/CMakeLists.txt
@@ -5,14 +5,14 @@ set(source_files kinematics_results.cc rigid_body_plant.cc)
 set(lcm_dependent_header_files)
 if (lcm_FOUND)
   set(lcm_dependent_header_files
-      rigid_body_tree_lcm_publisher.h
+      drake_visualizer.h
       viewer_draw_translator.h)
 endif()
 
 set(lcm_dependent_source_files)
 if (lcm_FOUND)
   set(lcm_dependent_source_files
-      rigid_body_tree_lcm_publisher.cc
+      drake_visualizer.cc
       viewer_draw_translator.cc)
 endif()
 

--- a/drake/systems/plants/rigid_body_plant/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/CMakeLists.txt
@@ -4,15 +4,15 @@ set(source_files kinematics_results.cc rigid_body_plant.cc)
 # RigidBodyTreeLcmPublisher in libdrakeRigidBodyPlant.so if LCM exists.
 set(lcm_dependent_header_files)
 if (lcm_FOUND)
-  set(drake_visualizer.h
-      lcm_dependent_header_files
+  set(lcm_dependent_header_files
+      drake_visualizer.h
       viewer_draw_translator.h)
 endif()
 
 set(lcm_dependent_source_files)
 if (lcm_FOUND)
-  set(drake_visualizer.cc
-      lcm_dependent_source_files
+  set(lcm_dependent_source_files
+      drake_visualizer.cc
       viewer_draw_translator.cc)
 endif()
 

--- a/drake/systems/plants/rigid_body_plant/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/CMakeLists.txt
@@ -4,15 +4,15 @@ set(source_files kinematics_results.cc rigid_body_plant.cc)
 # RigidBodyTreeLcmPublisher in libdrakeRigidBodyPlant.so if LCM exists.
 set(lcm_dependent_header_files)
 if (lcm_FOUND)
-  set(lcm_dependent_header_files
-      drake_visualizer.h
+  set(drake_visualizer.h
+      lcm_dependent_header_files
       viewer_draw_translator.h)
 endif()
 
 set(lcm_dependent_source_files)
 if (lcm_FOUND)
-  set(lcm_dependent_source_files
-      drake_visualizer.cc
+  set(drake_visualizer.cc
+      lcm_dependent_source_files
       viewer_draw_translator.cc)
 endif()
 

--- a/drake/systems/plants/rigid_body_plant/drake_visualizer.cc
+++ b/drake/systems/plants/rigid_body_plant/drake_visualizer.cc
@@ -1,34 +1,34 @@
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 
 namespace drake {
 namespace systems {
 
 namespace {
-// Defines the index of the port that the RigidBodyTreeLcmPublisher uses.
+// Defines the index of the port that the DrakeVisualizer uses.
 const int kPortIndex = 0;
 }  // namespace
 
-RigidBodyTreeLcmPublisher::RigidBodyTreeLcmPublisher(
+DrakeVisualizer::DrakeVisualizer(
     const RigidBodyTree& tree, drake::lcm::DrakeLcmInterface* lcm) :
     lcm_(lcm), load_message_(CreateLoadMessage(tree)),
     draw_message_translator_(tree) {
-  set_name("rigid_body_tree_visualizer_lcm");
+  set_name("drake_visualizer");
   const int vector_size =
       tree.get_num_positions() + tree.get_num_velocities();
   DeclareInputPort(kVectorValued, vector_size, kContinuousSampling);
 }
 
 const lcmt_viewer_load_robot&
-RigidBodyTreeLcmPublisher::get_load_message() const {
+DrakeVisualizer::get_load_message() const {
   return load_message_;
 }
 
 const std::vector<uint8_t>&
-RigidBodyTreeLcmPublisher::get_draw_message_bytes() const {
+DrakeVisualizer::get_draw_message_bytes() const {
   return draw_message_bytes_;
 }
 
-void RigidBodyTreeLcmPublisher::DoPublish(const Context<double>& context)
+void DrakeVisualizer::DoPublish(const Context<double>& context)
     const {
   // TODO(liang.fok): Replace the following code once System 2.0's API allows
   // systems to declare that they need a certain action to be performed at
@@ -55,7 +55,7 @@ void RigidBodyTreeLcmPublisher::DoPublish(const Context<double>& context)
       draw_message_bytes_.size());
 }
 
-void RigidBodyTreeLcmPublisher::PublishLoadRobot() const {
+void DrakeVisualizer::PublishLoadRobot() const {
   const int lcm_message_length = load_message_.getEncodedSize();
   std::vector<uint8_t> lcm_message_bytes{};
   lcm_message_bytes.resize(lcm_message_length);
@@ -66,7 +66,7 @@ void RigidBodyTreeLcmPublisher::PublishLoadRobot() const {
   sent_load_robot_ = true;
 }
 
-lcmt_viewer_load_robot RigidBodyTreeLcmPublisher::CreateLoadMessage(
+lcmt_viewer_load_robot DrakeVisualizer::CreateLoadMessage(
     const RigidBodyTree& tree) {
   lcmt_viewer_load_robot load_message;
   load_message.num_links = tree.bodies.size();

--- a/drake/systems/plants/rigid_body_plant/drake_visualizer.h
+++ b/drake/systems/plants/rigid_body_plant/drake_visualizer.h
@@ -18,10 +18,10 @@ namespace systems {
 // t_0.
 /**
  * This is a Drake System 2.0 block that takes a RigidBodyTree and publishes LCM
- * messages that are intended for the Drake Visualizer, but can also be used by
- * other consumers. It does this in two phases: initialization, which runs when
- * `DoPublish()` is called with `Context::get_time()` equal to zero, and
- * run-time, which runs every time `doPublish()` is called.
+ * messages that are intended for the Drake Visualizer. It does this in two
+ * phases: initialization, which runs when DoPublish() is called with
+ * Context::get_time() equal to zero, and run-time, which runs every time
+ * DoPublish() is called.
  *
  * During initialization, this system block analyzes the RigidBodyTree and tells
  * Drake Visualizer what it will be visualizing. For example, these include the
@@ -37,14 +37,14 @@ namespace systems {
  *
  * @ingroup rigid_body_systems
  */
-class DRAKE_EXPORT RigidBodyTreeLcmPublisher
+class DRAKE_EXPORT DrakeVisualizer
     : public LeafSystem<double> {
  public:
   /**
-   * A constructor that prepares for the transmission of `lcmt_viewer_load_robot`
-   * and `lcmt_viewer_draw` messages, but does not actually publish anything.
-   * LCM message publications occur each time
-   * RigidBodyTreeLcmPublisher::Publish() is called.
+   * A constructor that prepares for the transmission of `lcmt_viewer_draw` and
+   * `lcmt_viewer_load_robot` messages, but does not actually publish anything.
+   * LCM message publications occur each time DrakeVisualizer::Publish() is
+   * called.
    *
    * @param[in] tree A reference to the rigid body tree that should be
    * visualized by Drake Visualizer. This reference must remain valid for the
@@ -53,7 +53,7 @@ class DRAKE_EXPORT RigidBodyTreeLcmPublisher
    * @param[in] lcm A pointer to the object through which LCM messages can be
    * published. This pointer must remain valid for the duration of this object.
    */
-  RigidBodyTreeLcmPublisher(const RigidBodyTree& tree,
+  DrakeVisualizer(const RigidBodyTree& tree,
       drake::lcm::DrakeLcmInterface* lcm);
 
   void EvalOutput(const systems::Context<double>& context,

--- a/drake/systems/plants/rigid_body_plant/test/CMakeLists.txt
+++ b/drake/systems/plants/rigid_body_plant/test/CMakeLists.txt
@@ -8,8 +8,8 @@ if(Bullet_FOUND)
     drake_add_cc_test(viewer_draw_translator_test)
     target_link_libraries(viewer_draw_translator_test drakeRigidBodyPlant)
 
-    drake_add_cc_test(rigid_body_tree_lcm_publisher_test)
-    target_link_libraries(rigid_body_tree_lcm_publisher_test
+    drake_add_cc_test(drake_visualizer_test)
+    target_link_libraries(drake_visualizer_test
       drakeRigidBodyPlant)
   endif()
 endif()

--- a/drake/systems/plants/rigid_body_plant/test/drake_visualizer_test.cc
+++ b/drake/systems/plants/rigid_body_plant/test/drake_visualizer_test.cc
@@ -1,4 +1,4 @@
-#include "drake/systems/plants/rigid_body_plant/rigid_body_tree_lcm_publisher.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 
 #include <memory>
 #include <vector>
@@ -457,13 +457,13 @@ unique_ptr<RigidBodyTree> CreateRigidBodyTree() {
   return tree;
 }
 
-// Tests the basic functionality of the RigidBodyTreeLcmPublisher.
-GTEST_TEST(RigidBodyTreeLcmPublisherTests, BasicTest) {
+// Tests the basic functionality of the DrakeVisualizer.
+GTEST_TEST(DrakeVisualizerTests, BasicTest) {
   unique_ptr<RigidBodyTree> tree = CreateRigidBodyTree();
   drake::lcm::DrakeMockLcm lcm;
-  RigidBodyTreeLcmPublisher dut(*tree, &lcm);
+  DrakeVisualizer dut(*tree, &lcm);
 
-  EXPECT_EQ("rigid_body_tree_visualizer_lcm", dut.get_name());
+  EXPECT_EQ("drake_visualizer", dut.get_name());
 
   auto context = dut.CreateDefaultContext();
 


### PR DESCRIPTION
Currently, the messages published by this system are only used by `drake-visualizer`. Thus, it makes sense for the system's name to include the word "Visualizer".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3954)
<!-- Reviewable:end -->
