### PR TITLE
do not template AffineSystem coefficients on scalar type

### DIFF
--- a/drake/systems/framework/primitives/affine_system.cc
+++ b/drake/systems/framework/primitives/affine_system.cc
@@ -13,12 +13,12 @@ namespace systems {
 using std::make_unique;
 
 template <typename T>
-AffineSystem<T>::AffineSystem(const Eigen::Ref<const MatrixX<T>>& A,
-                              const Eigen::Ref<const MatrixX<T>>& B,
-                              const Eigen::Ref<const VectorX<T>>& xDot0,
-                              const Eigen::Ref<const MatrixX<T>>& C,
-                              const Eigen::Ref<const MatrixX<T>>& D,
-                              const Eigen::Ref<const VectorX<T>>& y0)
+AffineSystem<T>::AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                              const Eigen::Ref<const Eigen::MatrixXd>& B,
+                              const Eigen::Ref<const Eigen::VectorXd>& xDot0,
+                              const Eigen::Ref<const Eigen::MatrixXd>& C,
+                              const Eigen::Ref<const Eigen::MatrixXd>& D,
+                              const Eigen::Ref<const Eigen::VectorXd>& y0)
     : A_(A),
       B_(B),
       xDot0_(xDot0),

--- a/drake/systems/framework/primitives/affine_system.h
+++ b/drake/systems/framework/primitives/affine_system.h
@@ -64,12 +64,12 @@ class AffineSystem : public LeafSystem<T> {
                            ContinuousState<T>* derivatives) const override;
 
   // Helper getter methods.
-  const Eigen::MatrixXd A(void) const { return A_; }
-  const Eigen::MatrixXd B(void) const { return B_; }
-  const Eigen::MatrixXd C(void) const { return C_; }
-  const Eigen::MatrixXd D(void) const { return D_; }
-  const Eigen::VectorXd xDot0(void) const { return xDot0_; }
-  const Eigen::VectorXd y0(void) const { return y0_; }
+  const Eigen::MatrixXd& A(void) const { return A_; }
+  const Eigen::MatrixXd& B(void) const { return B_; }
+  const Eigen::MatrixXd& C(void) const { return C_; }
+  const Eigen::MatrixXd& D(void) const { return D_; }
+  const Eigen::VectorXd& xDot0(void) const { return xDot0_; }
+  const Eigen::VectorXd& y0(void) const { return y0_; }
 
  private:
   const Eigen::MatrixXd A_;

--- a/drake/systems/framework/primitives/affine_system.h
+++ b/drake/systems/framework/primitives/affine_system.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "drake/systems/framework/leaf_system.h"
 #include "drake/common/eigen_types.h"
+#include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/primitives/affine_system.h
+++ b/drake/systems/framework/primitives/affine_system.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/systems/framework/leaf_system.h"
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace systems {
@@ -40,12 +41,12 @@ class AffineSystem : public LeafSystem<T> {
   /// | B       | num states  | num inputs  |
   /// | C       | num outputs | num states  |
   /// | D       | num outputs | num inputs  |
-  AffineSystem(const Eigen::Ref<const MatrixX<T>>& A,
-               const Eigen::Ref<const MatrixX<T>>& B,
-               const Eigen::Ref<const VectorX<T>>& xDot0,
-               const Eigen::Ref<const MatrixX<T>>& C,
-               const Eigen::Ref<const MatrixX<T>>& D,
-               const Eigen::Ref<const VectorX<T>>& y0);
+  AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
+               const Eigen::Ref<const Eigen::MatrixXd>& B,
+               const Eigen::Ref<const Eigen::VectorXd>& xDot0,
+               const Eigen::Ref<const Eigen::MatrixXd>& C,
+               const Eigen::Ref<const Eigen::MatrixXd>& D,
+               const Eigen::Ref<const Eigen::VectorXd>& y0);
   /// The input to this system is direct feedthrough only if the coefficient
   /// matrix `D` is non-zero.
   bool has_any_direct_feedthrough() const override { return !D_.isZero(); }
@@ -63,20 +64,20 @@ class AffineSystem : public LeafSystem<T> {
                            ContinuousState<T>* derivatives) const override;
 
   // Helper getter methods.
-  const MatrixX<T> GetA(void) const { return A_; }
-  const MatrixX<T> GetB(void) const { return B_; }
-  const MatrixX<T> GetC(void) const { return C_; }
-  const MatrixX<T> GetD(void) const { return D_; }
-  const VectorX<T> GetxDot0(void) const { return xDot0_; }
-  const VectorX<T> Gety0(void) const { return y0_; }
+  const Eigen::MatrixXd A(void) const { return A_; }
+  const Eigen::MatrixXd B(void) const { return B_; }
+  const Eigen::MatrixXd C(void) const { return C_; }
+  const Eigen::MatrixXd D(void) const { return D_; }
+  const Eigen::VectorXd xDot0(void) const { return xDot0_; }
+  const Eigen::VectorXd y0(void) const { return y0_; }
 
  private:
-  const MatrixX<T> A_;
-  const MatrixX<T> B_;
-  const VectorX<T> xDot0_;
-  const MatrixX<T> C_;
-  const MatrixX<T> D_;
-  const VectorX<T> y0_;
+  const Eigen::MatrixXd A_;
+  const Eigen::MatrixXd B_;
+  const Eigen::VectorXd xDot0_;
+  const Eigen::MatrixXd C_;
+  const Eigen::MatrixXd D_;
+  const Eigen::VectorXd y0_;
   const int num_inputs_;
   const int num_outputs_;
   const int num_states_;

--- a/drake/systems/framework/primitives/linear_system.cc
+++ b/drake/systems/framework/primitives/linear_system.cc
@@ -7,12 +7,12 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-LinearSystem<T>::LinearSystem(const Eigen::Ref<const MatrixX<T>>& A,
-                              const Eigen::Ref<const MatrixX<T>>& B,
-                              const Eigen::Ref<const MatrixX<T>>& C,
-                              const Eigen::Ref<const MatrixX<T>>& D)
-    : AffineSystem<T>(A, B, VectorX<T>::Zero(A.rows()), C, D,
-                      VectorX<T>::Zero(C.rows())) {}
+LinearSystem<T>::LinearSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                              const Eigen::Ref<const Eigen::MatrixXd>& B,
+                              const Eigen::Ref<const Eigen::MatrixXd>& C,
+                              const Eigen::Ref<const Eigen::MatrixXd>& D)
+    : AffineSystem<T>(A, B, Eigen::VectorXd::Zero(A.rows()), C, D,
+                      Eigen::VectorXd::Zero(C.rows())) {}
 // TODO(naveenoid): Modify constructor to accommodate 0 dimension systems;
 // i.e. in initializing xDot0 and y0 with a zero matrix.
 template class DRAKE_EXPORT LinearSystem<double>;

--- a/drake/systems/framework/primitives/linear_system.h
+++ b/drake/systems/framework/primitives/linear_system.h
@@ -38,10 +38,10 @@ class LinearSystem : public AffineSystem<T> {
   /// | B       | num states  | num inputs  |
   /// | C       | num outputs | num states  |
   /// | D       | num outputs | num inputs  |
-  LinearSystem(const Eigen::Ref<const MatrixX<T>>& A,
-               const Eigen::Ref<const MatrixX<T>>& B,
-               const Eigen::Ref<const MatrixX<T>>& C,
-               const Eigen::Ref<const MatrixX<T>>& D);
+  LinearSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
+               const Eigen::Ref<const Eigen::MatrixXd>& B,
+               const Eigen::Ref<const Eigen::MatrixXd>& C,
+               const Eigen::Ref<const Eigen::MatrixXd>& D);
 };
 
 }  // namespace systems

--- a/drake/systems/framework/primitives/matrix_gain.cc
+++ b/drake/systems/framework/primitives/matrix_gain.cc
@@ -12,13 +12,13 @@ const int kNumStates{0};
 
 template <typename T>
 MatrixGain<T>::MatrixGain(int size)
-    : MatrixGain<T>(MatrixX<T>::Identity(size, size)) {}
+    : MatrixGain<T>(Eigen::MatrixXd::Identity(size, size)) {}
 
 template <typename T>
-MatrixGain<T>::MatrixGain(const MatrixX<T>& D)
-    : LinearSystem<T>(MatrixX<T>::Zero(kNumStates, kNumStates),  // A
-                      MatrixX<T>::Zero(kNumStates, D.cols()),    // B
-                      MatrixX<T>::Zero(D.rows(), kNumStates),    // C
+MatrixGain<T>::MatrixGain(const Eigen::MatrixXd& D)
+    : LinearSystem<T>(Eigen::MatrixXd::Zero(kNumStates, kNumStates),  // A
+                      Eigen::MatrixXd::Zero(kNumStates, D.cols()),    // B
+                      Eigen::MatrixXd::Zero(D.rows(), kNumStates),    // C
                       D) {}
 
 template class DRAKE_EXPORT MatrixGain<double>;

--- a/drake/systems/framework/primitives/matrix_gain.h
+++ b/drake/systems/framework/primitives/matrix_gain.h
@@ -28,7 +28,7 @@ namespace systems {
 /// @see AffineSystem
 /// @see LinearSystem
 template <typename T>
-class MatrixGain: public LinearSystem<T> {
+class MatrixGain : public LinearSystem<T> {
  public:
   /**
    * A constructor where the gain matrix `D` is a square identity matrix of size

--- a/drake/systems/framework/primitives/matrix_gain.h
+++ b/drake/systems/framework/primitives/matrix_gain.h
@@ -39,7 +39,7 @@ class MatrixGain: public LinearSystem<T> {
   /**
    * A constructor where the gain matrix `D` is @p D.
    */
-  explicit MatrixGain(const MatrixX<T>& D);
+  explicit MatrixGain(const Eigen::MatrixXd& D);
 };
 
 }  // namespace systems

--- a/drake/systems/framework/primitives/test/affine_system_test.cc
+++ b/drake/systems/framework/primitives/test/affine_system_test.cc
@@ -33,12 +33,12 @@ class AffineSystemTest : public AffineLinearSystemTest {
 TEST_F(AffineSystemTest, Construction) {
   EXPECT_EQ(1, context_->get_num_input_ports());
   EXPECT_EQ("test_affine_system", dut_->get_name());
-  EXPECT_EQ(dut_->GetA(), A_);
-  EXPECT_EQ(dut_->GetB(), B_);
-  EXPECT_EQ(dut_->GetC(), C_);
-  EXPECT_EQ(dut_->GetD(), D_);
-  EXPECT_EQ(dut_->GetxDot0(), xDot0_);
-  EXPECT_EQ(dut_->Gety0(), y0_);
+  EXPECT_EQ(dut_->A(), A_);
+  EXPECT_EQ(dut_->B(), B_);
+  EXPECT_EQ(dut_->C(), C_);
+  EXPECT_EQ(dut_->D(), D_);
+  EXPECT_EQ(dut_->xDot0(), xDot0_);
+  EXPECT_EQ(dut_->y0(), y0_);
   EXPECT_EQ(dut_->get_num_output_ports(), 1);
   EXPECT_EQ(dut_->get_num_input_ports(), 1);
 }

--- a/drake/systems/framework/primitives/test/linear_system_test.cc
+++ b/drake/systems/framework/primitives/test/linear_system_test.cc
@@ -33,12 +33,12 @@ class LinearSystemTest : public AffineLinearSystemTest {
 TEST_F(LinearSystemTest, Construction) {
   EXPECT_EQ(1, context_->get_num_input_ports());
   EXPECT_EQ("test_linear_system", dut_->get_name());
-  EXPECT_EQ(dut_->GetA(), A_);
-  EXPECT_EQ(dut_->GetB(), B_);
-  EXPECT_EQ(dut_->GetxDot0(), xDot0_);
-  EXPECT_EQ(dut_->GetC(), C_);
-  EXPECT_EQ(dut_->GetD(), D_);
-  EXPECT_EQ(dut_->Gety0(), y0_);
+  EXPECT_EQ(dut_->A(), A_);
+  EXPECT_EQ(dut_->B(), B_);
+  EXPECT_EQ(dut_->xDot0(), xDot0_);
+  EXPECT_EQ(dut_->C(), C_);
+  EXPECT_EQ(dut_->D(), D_);
+  EXPECT_EQ(dut_->y0(), y0_);
   EXPECT_EQ(1, dut_->get_num_output_ports());
   EXPECT_EQ(1, dut_->get_num_input_ports());
 }

--- a/drake/systems/framework/primitives/test/matrix_gain_test.cc
+++ b/drake/systems/framework/primitives/test/matrix_gain_test.cc
@@ -36,12 +36,12 @@ class MatrixGainTest : public AffineLinearSystemTest {
 TEST_F(MatrixGainTest, Construction) {
   EXPECT_EQ(context_->get_num_input_ports(), 1);
   EXPECT_EQ(dut_->get_name(), "test_matrix_gain_system");
-  EXPECT_EQ(dut_->GetA(), MatrixX<double>::Zero(kNumStates, kNumStates));
-  EXPECT_EQ(dut_->GetB(), MatrixX<double>::Zero(kNumStates, D_.cols()));
-  EXPECT_EQ(dut_->GetxDot0(), Eigen::VectorXd::Zero(kNumStates));
-  EXPECT_EQ(dut_->GetC(), MatrixX<double>::Zero(D_.rows(), kNumStates));
-  EXPECT_EQ(dut_->GetD(), D_);
-  EXPECT_EQ(dut_->Gety0(), Eigen::VectorXd::Zero(2));
+  EXPECT_EQ(dut_->A(), MatrixX<double>::Zero(kNumStates, kNumStates));
+  EXPECT_EQ(dut_->B(), MatrixX<double>::Zero(kNumStates, D_.cols()));
+  EXPECT_EQ(dut_->xDot0(), Eigen::VectorXd::Zero(kNumStates));
+  EXPECT_EQ(dut_->C(), MatrixX<double>::Zero(D_.rows(), kNumStates));
+  EXPECT_EQ(dut_->D(), D_);
+  EXPECT_EQ(dut_->y0(), Eigen::VectorXd::Zero(2));
   EXPECT_EQ(dut_->get_num_output_ports(), 1);
   EXPECT_EQ(dut_->get_num_input_ports(), 1);
 }


### PR DESCRIPTION
resolves defect:  at least until AffineSystem implements parameters, the coefficient matrices only make sense as doubles.  They should not be templated on the scalar type.

also replaces GetA() with A() etc, as allowed by the style guide and used elsewhere in the code (e.g. PendulumPlant.theta()).

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3957)

<!-- Reviewable:end -->
