### PR TITLE
LCM types build updates

### DIFF
--- a/drake/lcm/CMakeLists.txt
+++ b/drake/lcm/CMakeLists.txt
@@ -40,10 +40,6 @@ add_library_with_exports(LIB_NAME drakeLcm SOURCE_FILES
     ${lcm_dependent_source_files}
     ${lcm_independent_source_files})
 
-if (lcm_FOUND)
-  add_dependencies(drakeLcm drake_lcmtypes_hpp)
-endif()
-
 target_link_libraries(drakeLcm
     ${lcm_dependent_link_libraries}
     ${lcm_independent_link_libraries})

--- a/drake/lcmtypes/CMakeLists.txt
+++ b/drake/lcmtypes/CMakeLists.txt
@@ -1,15 +1,16 @@
+include(GenerateExportHeader)
 include(${LCM_USE_FILE})
 
-set(python_args PYTHON_SOURCES python_install_sources)
-if(JAVA_FOUND AND TARGET lcm-java)
+if(JAVA_FOUND)
   set(java_args JAVA_SOURCES java_sources)
 endif()
 
 lcm_wrap_types(
-  C_SOURCES sources
+  C_EXPORT drake_lcmtypes
+  C_SOURCES c_sources
   C_HEADERS c_install_headers
   CPP_HEADERS cpp_install_headers
-  ${python_args}
+  PYTHON_SOURCES python_install_sources
   ${java_args}
   lcmt_body_motion_data.lcm
   lcmt_body_wrench_data.lcm
@@ -46,25 +47,28 @@ lcm_wrap_types(
   lcmt_zmp_data.lcm
 )
 
-add_custom_target(drake_lcmtypes_hpp DEPENDS ${cpp_install_headers})
-
-add_library(drake_lcmtypes STATIC ${sources})
-target_link_libraries(drake_lcmtypes lcm)
+lcm_add_library(drake_lcmtypes C ${c_sources} ${c_install_headers})
+generate_export_header(drake_lcmtypes)
 target_include_directories(drake_lcmtypes INTERFACE
-  ${CMAKE_CURRENT_BINARY_DIR})
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-add_library(drakeLCMTypes INTERFACE)
-add_dependencies(drakeLCMTypes drake_lcmtypes_hpp)
-target_link_libraries(drakeLCMTypes INTERFACE lcm-coretypes)
+lcm_add_library(drakeLCMTypes CPP ${cpp_install_headers})
 target_include_directories(drakeLCMTypes INTERFACE
-  ${CMAKE_CURRENT_BINARY_DIR})
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-install(FILES ${c_install_headers} DESTINATION include/lcmtypes)
-install(FILES ${cpp_install_headers} DESTINATION include/lcmtypes/drake)
+lcm_install_headers(
+  ${CMAKE_CURRENT_BINARY_DIR}/drake_lcmtypes_export.h
+  ${c_install_headers}
+  ${cpp_install_headers}
+  DESTINATION include/lcmtypes
+)
 
-install(TARGETS drake_lcmtypes
+install(TARGETS drake_lcmtypes drakeLCMTypes
+  EXPORT ${PROJECT_NAME}Targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib${LIB_SUFFIX}
   ARCHIVE DESTINATION lib${LIB_SUFFIX}
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION include/lcmtypes
 )
 
 lcm_install_python(${python_install_sources})

--- a/drake/systems/lcm/CMakeLists.txt
+++ b/drake/systems/lcm/CMakeLists.txt
@@ -6,7 +6,6 @@ if(lcm_FOUND)
     lcm_translator_dictionary.cc
     lcmt_drake_signal_translator.cc
     serializer.cc)
-  add_dependencies(drakeLCMSystem2 drake_lcmtypes_hpp)
   target_link_libraries(drakeLCMSystem2
     drakeSystemFramework
     drakeLCMTypes


### PR DESCRIPTION
Remove superfluous dependencies on `drake_lcmtypes_hpp` (which no longer exists). Update how we build our LCM types library to use all the shiny new stuff from LCM upstream.

Fixes #3683.

@liangfok for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3962)
<!-- Reviewable:end -->
