### PR TITLE
Defines RigidBodyTreed

### DIFF
--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -1194,3 +1194,5 @@ class DRAKE_EXPORT RigidBodyTree {
 
   int next_available_clique_ = 0;
 };
+
+typedef RigidBodyTree RigidBodyTreed;


### PR DESCRIPTION
This is a very simple PR defining typedefing `RigidBodyTreed` soon to become a typedef of `RigidBodyTree<double>` in #3940.

This is a first step taken in order to make a future PR for `Director` using `RigidBodyTreed` instead `RigidBodyTree` to avoid breaking Director's master branch when #3940 lands.

Thanks to @jwnimmer-tri for this idea and to @liangfok on how to test this locally (now BodyToWrenchMap typdef needed for Director).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3969)
<!-- Reviewable:end -->
