### PR TITLE
Fix build/include lint errors

### DIFF
--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "drake/automotive/curve2.h"

--- a/drake/automotive/car_simulation.cc
+++ b/drake/automotive/car_simulation.cc
@@ -1,6 +1,7 @@
 #include "drake/automotive/car_simulation.h"
 
 #include <cstdlib>
+#include <limits>
 
 #include "drake/systems/plants/joints/floating_base_types.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"

--- a/drake/automotive/create_trajectory_params.cc
+++ b/drake/automotive/create_trajectory_params.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/create_trajectory_params.h"
 
+#include <algorithm>
 #include <vector>
 
 namespace drake {

--- a/drake/automotive/curve2.h
+++ b/drake/automotive/curve2.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 #include <vector>

--- a/drake/automotive/idm_with_trajectory_agent-inl.h
+++ b/drake/automotive/idm_with_trajectory_agent-inl.h
@@ -5,7 +5,7 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
-#include "idm_with_trajectory_agent.h"
+#include "drake/automotive/idm_with_trajectory_agent.h"
 
 #include <algorithm>
 #include <cmath>

--- a/drake/automotive/simple_car-inl.h
+++ b/drake/automotive/simple_car-inl.h
@@ -5,7 +5,7 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
-#include "simple_car.h"
+#include "drake/automotive/simple_car.h"
 
 #include <algorithm>
 #include <cmath>

--- a/drake/common/eigen_matrix_compare.h
+++ b/drake/common/eigen_matrix_compare.h
@@ -1,7 +1,11 @@
 #pragma once
 
-#include <Eigen/Dense>
+#include <algorithm>
 #include <cmath>
+#include <limits>
+#include <string>
+
+#include <Eigen/Dense>
 
 #include "drake/common/drake_gcc48.h"
 

--- a/drake/common/eigen_stl_types.h
+++ b/drake/common/eigen_stl_types.h
@@ -5,8 +5,11 @@
 /// See http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html.
 /// @see eigen_types.h
 
+#include <functional>
 #include <map>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/StdVector>

--- a/drake/common/functional_form.h
+++ b/drake/common/functional_form.h
@@ -2,6 +2,7 @@
 
 #include "drake/common/drake_export.h"
 
+#include <algorithm>  // for cpplint only
 #include <cstddef>
 #include <initializer_list>
 #include <iosfwd>

--- a/drake/common/polynomial.cc
+++ b/drake/common/polynomial.cc
@@ -1,6 +1,7 @@
 #include "drake/common/polynomial.h"
 
 #include <cstring>
+#include <limits>
 #include <set>
 #include <stdexcept>
 

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>  // for cpplint only
 #include <cstddef>
 #include <functional>
 #include <memory>

--- a/drake/common/trig_poly.h
+++ b/drake/common/trig_poly.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <map>
+#include <set>
+#include <string>
+#include <vector>
 
 #include <Eigen/Core>
 

--- a/drake/examples/Acrobot/Acrobot.h
+++ b/drake/examples/Acrobot/Acrobot.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
+#include <string>
+
 #include <Eigen/Core>
 
 using namespace std;

--- a/drake/examples/Atlas/atlas_dynamics_demo.cc
+++ b/drake/examples/Atlas/atlas_dynamics_demo.cc
@@ -1,9 +1,9 @@
 
 #include <iostream>
 
-#include "atlas_plant.h"
-#include "drake/systems/plants/BotVisualizer.h"
+#include "drake/examples/Atlas/atlas_plant.h"
 #include "drake/system1/LCMSystem.h"
+#include "drake/systems/plants/BotVisualizer.h"
 #include "drake/util/drakeAppUtil.h"
 
 using drake::SimulationOptions;

--- a/drake/examples/Pendulum/Pendulum.h
+++ b/drake/examples/Pendulum/Pendulum.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
+#include <string>
+
 #include "drake/system1/LCMSystem.h"
 
 using namespace std;

--- a/drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "drake/examples/QPInverseDynamicsForHumanoids/rigid_body_tree_utils.h"
 #include "drake/systems/robotInterfaces/Side.h"
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/qp_controller.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/qp_controller.h
@@ -1,7 +1,10 @@
 #pragma once
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
 #include "drake/solvers/mathematical_program.h"

--- a/drake/examples/QPInverseDynamicsForHumanoids/rigid_body_tree_utils.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/rigid_body_tree_utils.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/QPInverseDynamicsForHumanoids/rigid_body_tree_utils.h"
 
+#include <vector>
+
 namespace drake {
 namespace examples {
 namespace qp_inverse_dynamics {

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_system.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller.h"
 #include "drake/systems/framework/diagram.h"

--- a/drake/examples/Quadrotor/QuadrotorInput.h
+++ b/drake/examples/Quadrotor/QuadrotorInput.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include <Eigen/Dense>
+
 #include "drake/lcmt_quadrotor_input_t.hpp"
 
 template <typename ScalarType = double>

--- a/drake/examples/Quadrotor/QuadrotorOutput.h
+++ b/drake/examples/Quadrotor/QuadrotorOutput.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <vector>
 
 #include <Eigen/Dense>

--- a/drake/examples/Quadrotor/runDynamics.cpp
+++ b/drake/examples/Quadrotor/runDynamics.cpp
@@ -1,5 +1,6 @@
 
 #include <iostream>
+#include <limits>
 
 #include "drake/common/drake_path.h"
 #include "drake/examples/Quadrotor/QuadrotorInput.h"

--- a/drake/examples/bouncing_ball/bouncing_ball-inl.h
+++ b/drake/examples/bouncing_ball/bouncing_ball-inl.h
@@ -7,6 +7,8 @@
 
 #include "drake/examples/bouncing_ball/bouncing_ball.h"
 
+#include <algorithm>
+
 #include "drake/common/drake_assert.h"
 #include "drake/systems/framework/basic_vector.h"
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_simulation.cc
@@ -1,4 +1,6 @@
-#include "iiwa_simulation.h"
+#include "drake/examples/kuka_iiwa_arm/iiwa_simulation.h"
+
+#include <vector>
 
 #include "drake/common/drake_path.h"
 #include "drake/systems/plants/joints/floating_base_types.h"

--- a/drake/lcm/drake_lcm.h
+++ b/drake/lcm/drake_lcm.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "lcm/lcm-cpp.hpp"
 

--- a/drake/lcm/drake_lcm_interface.h
+++ b/drake/lcm/drake_lcm_interface.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "drake/common/drake_export.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
 

--- a/drake/lcm/drake_mock_lcm.h
+++ b/drake/lcm/drake_mock_lcm.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "drake/common/drake_export.h"

--- a/drake/math/autodiff.h
+++ b/drake/math/autodiff.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cmath>
+#include <tuple>
 
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>

--- a/drake/math/autodiff_gradient.h
+++ b/drake/math/autodiff_gradient.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <Eigen/Dense>
 
 #include "drake/common/drake_assert.h"

--- a/drake/math/jacobian.h
+++ b/drake/math/jacobian.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 #include <Eigen/Dense>

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <limits>
+#include <map>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/SparseCore>

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -1,6 +1,8 @@
-#include "gurobi_solver.h"
+#include "drake/solvers/gurobi_solver.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include <Eigen/Core>

--- a/drake/solvers/ipopt_solver.cc
+++ b/drake/solvers/ipopt_solver.cc
@@ -1,6 +1,8 @@
 #include "drake/solvers/ipopt_solver.h"
 
+#include <algorithm>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1,12 +1,16 @@
 #pragma once
 
-#include <Eigen/Core>
 #include <algorithm>
 #include <initializer_list>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <map>
 #include <memory>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_export.h"

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -1,13 +1,15 @@
 // Adapted with permission from code by Evan Drumwright
 // (https://github.com/edrumwri).
 
-#include "moby_lcp_solver.h"
+#include "drake/solvers/moby_lcp_solver.h"
 
 #include <Eigen/LU>
 #include <Eigen/SparseCore>
 #include <Eigen/SparseLU>
 
+#include <algorithm>
 #include <cmath>
+#include <functional>
 #include <iostream>
 #include <limits>
 #include <memory>

--- a/drake/solvers/moby_lcp_solver.h
+++ b/drake/solvers/moby_lcp_solver.h
@@ -4,11 +4,12 @@
 #pragma once
 
 #include <fstream>
+#include <vector>
+
 #include <Eigen/SparseCore>
 
 #include "drake/common/drake_export.h"
-
-#include "mathematical_program.h"
+#include "drake/solvers/mathematical_program.h"
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/mosek_solver.cc
+++ b/drake/solvers/mosek_solver.cc
@@ -3,7 +3,11 @@
 
 #include "drake/solvers/mosek_solver.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
+#include <list>
+#include <vector>
 
 #include <mosek/mosek.h>
 

--- a/drake/solvers/nlopt_solver.cc
+++ b/drake/solvers/nlopt_solver.cc
@@ -1,6 +1,9 @@
 #include "drake/solvers/nlopt_solver.h"
 
+#include <algorithm>
+#include <limits>
 #include <list>
+#include <set>
 #include <stdexcept>
 #include <vector>
 

--- a/drake/solvers/no_gurobi.cc
+++ b/drake/solvers/no_gurobi.cc
@@ -1,4 +1,4 @@
-#include "gurobi_solver.h"
+#include "drake/solvers/gurobi_solver.h"
 
 #include <stdexcept>
 

--- a/drake/solvers/qpSpline/ContinuityConstraint.cpp
+++ b/drake/solvers/qpSpline/ContinuityConstraint.cpp
@@ -1,4 +1,4 @@
-#include "ContinuityConstraint.h"
+#include "drake/solvers/qpSpline/ContinuityConstraint.h"
 
 #include "drake/common/drake_assert.h"
 

--- a/drake/solvers/qpSpline/SplineInformation.cpp
+++ b/drake/solvers/qpSpline/SplineInformation.cpp
@@ -1,4 +1,6 @@
-#include "SplineInformation.h"
+#include "drake/solvers/qpSpline/SplineInformation.h"
+
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 

--- a/drake/solvers/qpSpline/ValueConstraint.cpp
+++ b/drake/solvers/qpSpline/ValueConstraint.cpp
@@ -1,4 +1,4 @@
-#include "ValueConstraint.h"
+#include "drake/solvers/qpSpline/ValueConstraint.h"
 
 #include "drake/common/drake_assert.h"
 

--- a/drake/solvers/qpSpline/splineGeneration.h
+++ b/drake/solvers/qpSpline/splineGeneration.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "SplineInformation.h"
-#include "drake/systems/trajectories/PiecewisePolynomial.h"
 #include <stdexcept>
+#include <vector>
+
 #include "drake/common/drake_export.h"
+#include "drake/solvers/qpSpline/SplineInformation.h"
+#include "drake/systems/trajectories/PiecewisePolynomial.h"
 
 class ConstraintMatrixSingularError : public std::runtime_error {
  public:

--- a/drake/solvers/qpSpline/test/testSplineGeneration.cpp
+++ b/drake/solvers/qpSpline/test/testSplineGeneration.cpp
@@ -1,5 +1,7 @@
 #include "drake/solvers/qpSpline/splineGeneration.h"
 
+#include <vector>
+
 #include "gtest/gtest.h"
 
 namespace drake {

--- a/drake/solvers/snopt_solver.cc
+++ b/drake/solvers/snopt_solver.cc
@@ -4,7 +4,11 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
+#include <list>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "drake/math/autodiff.h"
 

--- a/drake/solvers/system_identification.cpp
+++ b/drake/solvers/system_identification.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>  // For LUMPED_SYSTEM_IDENTIFICATION_VERBOSE below.
+#include <list>
 
 #include "drake/common/drake_assert.h"
 #include "drake/solvers/mathematical_program.h"

--- a/drake/solvers/system_identification.h
+++ b/drake/solvers/system_identification.h
@@ -3,6 +3,9 @@
 #include <map>
 #include <set>
 #include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "drake/common/polynomial.h"

--- a/drake/solvers/test/mathematical_program_test_util.h
+++ b/drake/solvers/test/mathematical_program_test_util.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <list>
+#include <string>
+
 #include "gtest/gtest.h"
 
 #include "drake/solvers/mathematical_program.h"

--- a/drake/solvers/trajectoryOptimization/dircol_trajectory_optimization.cc
+++ b/drake/solvers/trajectoryOptimization/dircol_trajectory_optimization.cc
@@ -1,4 +1,4 @@
-#include "dircol_trajectory_optimization.h"
+#include "drake/solvers/trajectoryOptimization/dircol_trajectory_optimization.h"
 
 #include <stdexcept>
 

--- a/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.cc
+++ b/drake/solvers/trajectoryOptimization/direct_trajectory_optimization.cc
@@ -1,5 +1,6 @@
-#include "direct_trajectory_optimization.h"
+#include "drake/solvers/trajectoryOptimization/direct_trajectory_optimization.h"
 
+#include <limits>
 #include <stdexcept>
 
 using Eigen::MatrixXd;

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include "drake/common/drake_assert.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <tuple>
 #include <utility>
 

--- a/drake/systems/analysis/test/my_spring_mass_system.h
+++ b/drake/systems/analysis/test/my_spring_mass_system.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include "drake/systems/plants/spring_mass_system/spring_mass_system.h"
 
 namespace drake {

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -1,8 +1,14 @@
 #include "drake/systems/controllers/InstantaneousQPController.h"
 
-#include <lcm/lcm-cpp.hpp>
+#include <algorithm>
+#include <limits>
 #include <map>
 #include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <lcm/lcm-cpp.hpp>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"

--- a/drake/systems/controllers/InstantaneousQPController.h
+++ b/drake/systems/controllers/InstantaneousQPController.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+
 #include "QPCommon.h"
 #include "drake/common/eigen_stl_types.h"
 #include "drake/common/drake_export.h"

--- a/drake/systems/controllers/QPCommon.h
+++ b/drake/systems/controllers/QPCommon.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
 
 #include <Eigen/Core>
 

--- a/drake/systems/controllers/controlUtil.cpp
+++ b/drake/systems/controllers/controlUtil.cpp
@@ -1,5 +1,8 @@
 #include "drake/systems/controllers/controlUtil.h"
 
+#include <limits>
+#include <utility>
+
 #include "drake/math/autodiff.h"
 #include "drake/math/expmap.h"
 #include "drake/math/quaternion.h"

--- a/drake/systems/controllers/controlUtil.h
+++ b/drake/systems/controllers/controlUtil.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <math.h>
+#include <cmath>
 #include <set>
+#include <string>
 #include <vector>
 
 #include <Eigen/Dense>

--- a/drake/systems/controllers/gravity_compensator.cc
+++ b/drake/systems/controllers/gravity_compensator.cc
@@ -1,4 +1,4 @@
-#include "./gravity_compensator.h"
+#include "drake/systems/controllers/gravity_compensator.h"
 
 #include "drake/systems/plants/KinematicsCache.h"
 #include "drake/systems/plants/RigidBodyTree.h"

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -1,4 +1,4 @@
-#include "pid_controlled_system.h"
+#include "drake/systems/controllers/pid_controlled_system.h"
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"

--- a/drake/systems/controllers/zmpUtil.cpp
+++ b/drake/systems/controllers/zmpUtil.cpp
@@ -1,5 +1,7 @@
 #include "drake/systems/controllers/zmpUtil.h"
 
+#include <vector>
+
 #include <Eigen/Dense>
 #include <unsupported/Eigen/MatrixFunctions>
 

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -6,6 +6,7 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <utility>
 
 #include "drake/common/drake_throw.h"
 #include "drake/systems/framework/vector_base.h"

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <set>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "drake/common/drake_assert.h"

--- a/drake/systems/framework/leaf_context.h
+++ b/drake/systems/framework/leaf_context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "drake/systems/framework/basic_vector.h"

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/drake/systems/framework/primitives/multiplexer.h
+++ b/drake/systems/framework/primitives/multiplexer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "drake/systems/framework/leaf_system.h"
 

--- a/drake/systems/framework/primitives/trajectory_source.cc
+++ b/drake/systems/framework/primitives/trajectory_source.cc
@@ -1,4 +1,4 @@
-#include "trajectory_source.h"
+#include "drake/systems/framework/primitives/trajectory_source.h"
 
 #include "drake/common/drake_assert.h"
 #include "drake/systems/framework/context.h"

--- a/drake/systems/framework/primitives/zero_order_hold-inl.h
+++ b/drake/systems/framework/primitives/zero_order_hold-inl.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_export.h"

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "drake/systems/framework/vector_base.h"

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -9,7 +9,6 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_context.h"
-#include "drake/systems/framework/system.h"
 #include "drake/systems/framework/system_output.h"
 
 namespace drake {

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include <Eigen/Dense>
 

--- a/drake/systems/lcm/lcm_publisher_system.h
+++ b/drake/systems/lcm/lcm_publisher_system.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "drake/common/drake_export.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/framework/leaf_context.h"

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <mutex>
+#include <string>
+#include <vector>
 
 #include "drake/common/drake_export.h"
 #include "drake/lcm/drake_lcm_interface.h"

--- a/drake/systems/plants/BotVisualizer.h
+++ b/drake/systems/plants/BotVisualizer.h
@@ -2,6 +2,9 @@
 // it are gone. It is being replaced by rigid_body_tree_visualizer_lcm.h.
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include <lcm/lcm-cpp.hpp>
 #include <Eigen/Dense>
 

--- a/drake/systems/plants/ConstraintWrappers.h
+++ b/drake/systems/plants/ConstraintWrappers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <Eigen/Core>
 

--- a/drake/systems/plants/IKoptions.cpp
+++ b/drake/systems/plants/IKoptions.cpp
@@ -1,3 +1,5 @@
+#include <set>
+
 #include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/plants/IKoptions.h"
 

--- a/drake/systems/plants/KinematicsCache.h
+++ b/drake/systems/plants/KinematicsCache.h
@@ -1,13 +1,16 @@
 #pragma once
 
+#include <functional>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <unordered_map>
-#include <vector>
-#include <numeric>
-#include <type_traits>
-#include <stdexcept>
-#include <utility>
 
 #include "drake/common/constants.h"
 #include "drake/common/drake_assert.h"

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 

--- a/drake/systems/plants/RigidBodyFrame.h
+++ b/drake/systems/plants/RigidBodyFrame.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include <Eigen/Dense>
 
 #include "drake/common/drake_export.h"

--- a/drake/systems/plants/RigidBodyIK.h
+++ b/drake/systems/plants/RigidBodyIK.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 

--- a/drake/systems/plants/RigidBodySystem.cpp
+++ b/drake/systems/plants/RigidBodySystem.cpp
@@ -1,7 +1,10 @@
 #include "drake/systems/plants/RigidBodySystem.h"
 
+#include <algorithm>
+#include <limits>
 #include <list>
 #include <stdexcept>
+#include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/math/quaternion.h"

--- a/drake/systems/plants/RigidBodySystem.h
+++ b/drake/systems/plants/RigidBodySystem.h
@@ -1,12 +1,15 @@
 #pragma once
 
-#include "KinematicsCache.h"
+#include <string>
+#include <vector>
+
 #include "drake/common/drake_export.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/system1/System.h"
+#include "drake/systems/plants/KinematicsCache.h"
+#include "drake/systems/plants/RigidBodyTree.h"
 #include "drake/systems/plants/joints/floating_base_types.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
-#include "drake/systems/plants/RigidBodyTree.h"
 
 using drake::systems::plants::joints::FloatingBaseType;
 using drake::systems::plants::joints::kQuaternion;

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -1,5 +1,13 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 
+#include <algorithm>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+
 #include "drake/common/constants.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
@@ -14,12 +22,6 @@
 #include "drake/systems/plants/parser_urdf.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeUtil.h"
-
-#include <algorithm>
-#include <fstream>
-#include <iostream>
-#include <limits>
-#include <string>
 
 using Eigen::AutoDiffScalar;
 using Eigen::Dynamic;

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <map>
 #include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <Eigen/LU>

--- a/drake/systems/plants/RigidBodyTreeContact.cpp
+++ b/drake/systems/plants/RigidBodyTreeContact.cpp
@@ -1,6 +1,9 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 
+#include <algorithm>
 #include <iostream>
+#include <set>
+#include <vector>
 
 using Eigen::Dynamic;
 using Eigen::Map;

--- a/drake/systems/plants/collision/Element.h
+++ b/drake/systems/plants/collision/Element.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <Eigen/Dense>
 

--- a/drake/systems/plants/collision/Model.h
+++ b/drake/systems/plants/collision/Model.h
@@ -2,6 +2,8 @@
 
 #include <memory>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <Eigen/Dense>
 

--- a/drake/systems/plants/constraint/direct_collocation_constraint.cc
+++ b/drake/systems/plants/constraint/direct_collocation_constraint.cc
@@ -1,4 +1,4 @@
-#include "direct_collocation_constraint.h"
+#include "drake/systems/plants/constraint/direct_collocation_constraint.h"
 
 #include "drake/common/drake_throw.h"
 #include "drake/math/autodiff.h"

--- a/drake/systems/plants/inverseKin.cpp
+++ b/drake/systems/plants/inverseKin.cpp
@@ -1,6 +1,9 @@
+#include <string>
+#include <vector>
+
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "inverseKinBackend.h"
+#include "drake/systems/plants/inverseKinBackend.h"
 
 using Eigen::Map;
 using Eigen::MatrixBase;

--- a/drake/systems/plants/inverseKinBackend.h
+++ b/drake/systems/plants/inverseKinBackend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 

--- a/drake/systems/plants/inverseKinPointwise.cpp
+++ b/drake/systems/plants/inverseKinPointwise.cpp
@@ -1,3 +1,6 @@
+#include <string>
+#include <vector>
+
 #include "drake/common/drake_assert.h"
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"

--- a/drake/systems/plants/inverseKinTraj.cpp
+++ b/drake/systems/plants/inverseKinTraj.cpp
@@ -1,6 +1,9 @@
+#include <string>
+#include <vector>
+
 #include "drake/systems/plants/RigidBodyIK.h"
 #include "drake/systems/plants/RigidBodyTree.h"
-#include "inverseKinBackend.h"
+#include "drake/systems/plants/inverseKinBackend.h"
 
 using Eigen::Map;
 using Eigen::MatrixBase;

--- a/drake/systems/plants/inverseKinTrajBackend.cpp
+++ b/drake/systems/plants/inverseKinTrajBackend.cpp
@@ -1,7 +1,7 @@
-
-#include "inverseKinBackend.h"
+#include "drake/systems/plants/inverseKinBackend.h"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <Eigen/Core>
@@ -17,7 +17,7 @@
 #include <drake/systems/plants/IKoptions.h>
 #include <drake/systems/plants/RigidBodyTree.h>
 
-#include "ik_trajectory_helper.h"
+#include "drake/systems/plants/ik_trajectory_helper.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;

--- a/drake/systems/plants/joints/DrakeJoint.cpp
+++ b/drake/systems/plants/joints/DrakeJoint.cpp
@@ -1,5 +1,7 @@
 #include "drake/systems/plants/joints/DrakeJoint.h"
 
+#include <limits>
+
 #include "drake/common/drake_assert.h"
 
 using Eigen::Isometry3d;

--- a/drake/systems/plants/joints/DrakeJoint.h
+++ b/drake/systems/plants/joints/DrakeJoint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <random>
+#include <string>
 
 #include <Eigen/Dense>
 #include <Eigen/Geometry>

--- a/drake/systems/plants/joints/DrakeJointImpl.h
+++ b/drake/systems/plants/joints/DrakeJointImpl.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "drake/systems/plants/joints/DrakeJoint.h"
+#include <string>
 
 #include "drake/math/gradient.h"
+#include "drake/systems/plants/joints/DrakeJoint.h"
 
 /// @cond
 

--- a/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
+++ b/drake/systems/plants/joints/FixedAxisOneDoFJoint.h
@@ -1,16 +1,18 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <exception>
 #include <limits>
 #include <stdexcept>
+#include <string>
 
 #include <Eigen/Core>
 
-#include "DrakeJointImpl.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/gradient.h"
+#include "drake/systems/plants/joints/DrakeJointImpl.h"
 
 template <typename Derived>
 class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {

--- a/drake/systems/plants/joints/FixedJoint.h
+++ b/drake/systems/plants/joints/FixedJoint.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "DrakeJointImpl.h"
+#include <string>
 
 #include "drake/common/eigen_types.h"
+#include "drake/systems/plants/joints/DrakeJointImpl.h"
 
 class DRAKE_EXPORT FixedJoint : public DrakeJointImpl<FixedJoint> {
  public:

--- a/drake/systems/plants/joints/HelicalJoint.cpp
+++ b/drake/systems/plants/joints/HelicalJoint.cpp
@@ -1,4 +1,4 @@
-#include "HelicalJoint.h"
+#include "drake/systems/plants/joints/HelicalJoint.h"
 
 using Eigen::Vector3d;
 

--- a/drake/systems/plants/joints/HelicalJoint.h
+++ b/drake/systems/plants/joints/HelicalJoint.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "FixedAxisOneDoFJoint.h"
+#include <string>
 
 #include "drake/common/eigen_types.h"
+#include "drake/systems/plants/joints/FixedAxisOneDoFJoint.h"
 
 class DRAKE_EXPORT HelicalJoint
     : public FixedAxisOneDoFJoint<HelicalJoint> {

--- a/drake/systems/plants/joints/PrismaticJoint.cpp
+++ b/drake/systems/plants/joints/PrismaticJoint.cpp
@@ -1,4 +1,4 @@
-#include "PrismaticJoint.h"
+#include "drake/systems/plants/joints/PrismaticJoint.h"
 
 using Eigen::Vector3d;
 

--- a/drake/systems/plants/joints/PrismaticJoint.h
+++ b/drake/systems/plants/joints/PrismaticJoint.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <string>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
-#include "FixedAxisOneDoFJoint.h"
+#include "drake/systems/plants/joints/FixedAxisOneDoFJoint.h"
 
 /**
  * A prismatic joint moves linearly along one axis.

--- a/drake/systems/plants/joints/QuaternionFloatingJoint.cpp
+++ b/drake/systems/plants/joints/QuaternionFloatingJoint.cpp
@@ -1,4 +1,4 @@
-#include "QuaternionFloatingJoint.h"
+#include "drake/systems/plants/joints/QuaternionFloatingJoint.h"
 
 #include <random>
 

--- a/drake/systems/plants/joints/QuaternionFloatingJoint.h
+++ b/drake/systems/plants/joints/QuaternionFloatingJoint.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/quaternion.h"

--- a/drake/systems/plants/joints/RevoluteJoint.cpp
+++ b/drake/systems/plants/joints/RevoluteJoint.cpp
@@ -1,4 +1,4 @@
-#include "RevoluteJoint.h"
+#include "drake/systems/plants/joints/RevoluteJoint.h"
 
 using Eigen::Vector3d;
 

--- a/drake/systems/plants/joints/RevoluteJoint.h
+++ b/drake/systems/plants/joints/RevoluteJoint.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <string>
+
+#include <Eigen/Geometry>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
-#include "FixedAxisOneDoFJoint.h"
-#include <Eigen/Geometry>
+#include "drake/systems/plants/joints/FixedAxisOneDoFJoint.h"
 
 class DRAKE_EXPORT RevoluteJoint
     : public FixedAxisOneDoFJoint<RevoluteJoint> {

--- a/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
+++ b/drake/systems/plants/joints/RollPitchYawFloatingJoint.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "DrakeJointImpl.h"
+#include <string>
+
 #include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/roll_pitch_yaw.h"
+#include "drake/systems/plants/joints/DrakeJointImpl.h"
 #include "drake/util/drakeGeometryUtil.h"
 
 class DRAKE_EXPORT RollPitchYawFloatingJoint

--- a/drake/systems/plants/material_map.h
+++ b/drake/systems/plants/material_map.h
@@ -1,7 +1,10 @@
 #pragma once
 
-#include <string>
+#include <functional>
 #include <map>
+#include <string>
+#include <utility>
+
 #include <Eigen/Dense>
 
 /**

--- a/drake/systems/plants/parser_common.cc
+++ b/drake/systems/plants/parser_common.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/plants/parser_common.h"
 
+#include <string>
+
 #include "drake/systems/plants/joints/DrakeJoint.h"
 #include "drake/systems/plants/joints/QuaternionFloatingJoint.h"
 #include "drake/systems/plants/joints/RollPitchYawFloatingJoint.h"

--- a/drake/systems/plants/parser_common.h
+++ b/drake/systems/plants/parser_common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "drake/common/drake_export.h"
 #include "drake/systems/plants/RigidBodyFrame.h"
 #include "drake/systems/plants/RigidBodyTree.h"

--- a/drake/systems/plants/parser_sdf.cc
+++ b/drake/systems/plants/parser_sdf.cc
@@ -1,8 +1,12 @@
 #include "drake/systems/plants/parser_sdf.h"
 
+#include <algorithm>
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "spruce.hh"
 

--- a/drake/systems/plants/parser_urdf.cc
+++ b/drake/systems/plants/parser_urdf.cc
@@ -1,8 +1,11 @@
 #include "drake/systems/plants/parser_urdf.h"
 
+#include <algorithm>
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"

--- a/drake/systems/plants/pose_map.h
+++ b/drake/systems/plants/pose_map.h
@@ -1,7 +1,10 @@
 #pragma once
 
-#include <string>
+#include <functional>
 #include <map>
+#include <string>
+#include <utility>
+
 #include <Eigen/Dense>
 
 typedef std::map<

--- a/drake/systems/plants/rigidBodyLCMNode.cpp
+++ b/drake/systems/plants/rigidBodyLCMNode.cpp
@@ -1,3 +1,6 @@
+#include <limits>
+#include <string>
+
 #include <gflags/gflags.h>
 
 #include "drake/common/text_logging.h"

--- a/drake/systems/plants/rigid_body_plant/drake_visualizer.h
+++ b/drake/systems/plants/rigid_body_plant/drake_visualizer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "drake/common/drake_export.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/drake/systems/plants/shapes/Element.cpp
+++ b/drake/systems/plants/shapes/Element.cpp
@@ -1,4 +1,4 @@
-#include "Element.h"
+#include "drake/systems/plants/shapes/Element.h"
 
 using Eigen::Isometry3d;
 

--- a/drake/systems/plants/shapes/Geometry.cpp
+++ b/drake/systems/plants/shapes/Geometry.cpp
@@ -1,5 +1,6 @@
-#include "Geometry.h"
+#include "drake/systems/plants/shapes/Geometry.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <fstream>
 #include <stdexcept>

--- a/drake/systems/plants/shapes/VisualElement.cpp
+++ b/drake/systems/plants/shapes/VisualElement.cpp
@@ -1,4 +1,4 @@
-#include "VisualElement.h"
+#include "drake/systems/plants/shapes/VisualElement.h"
 
 namespace DrakeShapes {
 // VisualElement::VisualElement(unique_ptr<Geometry> geometry,

--- a/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
+++ b/drake/systems/plants/test/benchmarkRigidBodyTree.cpp
@@ -1,4 +1,8 @@
 #include <cmath>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test/measure_execution.h"

--- a/drake/systems/plants/test/compareRigidBodySystems.cpp
+++ b/drake/systems/plants/test/compareRigidBodySystems.cpp
@@ -1,6 +1,7 @@
 #include "drake/systems/plants/RigidBodySystem.h"
 
 #include <iostream>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/drake/systems/plants/test/drake_joint/drake_joint_test.cc
+++ b/drake/systems/plants/test/drake_joint/drake_joint_test.cc
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include "drake/common/eigen_types.h"
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"

--- a/drake/systems/plants/test/lidarTest.cpp
+++ b/drake/systems/plants/test/lidarTest.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <limits>
 
 #include "gtest/gtest.h"
 

--- a/drake/systems/plants/test/testIK.cpp
+++ b/drake/systems/plants/test/testIK.cpp
@@ -1,4 +1,6 @@
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 #include "gtest/gtest.h"

--- a/drake/systems/plants/test/testIKMoreConstraints.cpp
+++ b/drake/systems/plants/test/testIKMoreConstraints.cpp
@@ -1,5 +1,7 @@
 #include <cstdlib>
-#include <numeric>  // for iota
+#include <numeric>
+#include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 

--- a/drake/systems/plants/test/testIKpointwise.cpp
+++ b/drake/systems/plants/test/testIKpointwise.cpp
@@ -1,4 +1,7 @@
 #include <cstdlib>
+#include <limits>
+#include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 #include "gtest/gtest.h"

--- a/drake/systems/plants/test/testIKtraj.cpp
+++ b/drake/systems/plants/test/testIKtraj.cpp
@@ -1,5 +1,7 @@
 #include <cstdlib>
 #include <limits>
+#include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/drake/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/drake/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -1,11 +1,13 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 
-#include <iostream>
 #include <cstdlib>
-#include <random>
-#include <memory>
-#include <stdexcept>
+#include <iostream>
 #include <map>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "drake/common/eigen_types.h"
 #include "drake/util/drakeGeometryUtil.h"

--- a/drake/systems/plants/test/testXmlUtil.cpp
+++ b/drake/systems/plants/test/testXmlUtil.cpp
@@ -1,6 +1,7 @@
 #include <list>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/drake/systems/plants/test/urdfCollisionTest.cpp
+++ b/drake/systems/plants/test/urdfCollisionTest.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cstdlib>
+#include <vector>
 
 #include "drake/systems/plants/RigidBodyTree.h"
 

--- a/drake/systems/robotInterfaces/BodyMotionData.cpp
+++ b/drake/systems/robotInterfaces/BodyMotionData.cpp
@@ -1,4 +1,4 @@
-#include "BodyMotionData.h"
+#include "drake/systems/robotInterfaces/BodyMotionData.h"
 
 int BodyMotionData::findSegmentIndex(double t) const {
   return trajectory.getSegmentIndex(t);

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <string>
 

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.h
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <vector>
 #include <map>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/drake/systems/trajectories/PiecewiseFunction.cpp
+++ b/drake/systems/trajectories/PiecewiseFunction.cpp
@@ -1,5 +1,6 @@
-#include "PiecewiseFunction.h"
+#include "drake/systems/trajectories/PiecewiseFunction.h"
 
+#include <algorithm>
 #include <stdexcept>
 
 using std::uniform_real_distribution;

--- a/drake/systems/trajectories/PiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/PiecewisePolynomial.cpp
@@ -1,5 +1,7 @@
 #include "drake/systems/trajectories/PiecewisePolynomial.h"
 
+#include <algorithm>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/test/random_polynomial_matrix.h"
 

--- a/drake/systems/trajectories/PiecewisePolynomial.h
+++ b/drake/systems/trajectories/PiecewisePolynomial.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <Eigen/Core>
-#include "drake/systems/trajectories/PiecewisePolynomialBase.h"
-#include "drake/common/polynomial.h"
-#include <vector>
-#include <random>
 #include <limits>
+#include <random>
+#include <vector>
+
+#include <Eigen/Core>
+
 #include "drake/common/drake_export.h"
+#include "drake/common/polynomial.h"
+#include "drake/systems/trajectories/PiecewisePolynomialBase.h"
 
 /// A scalar multi-variate piecewise polynomial.
 /**

--- a/ros/drake_ros_common/include/drake/ros/parameter_server.h
+++ b/ros/drake_ros_common/include/drake/ros/parameter_server.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "ros/ros.h"
 
 namespace drake {

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_joint_state.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_joint_state.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <map>
 #include <stdexcept>
+#include <string>
 
 #include <Eigen/Dense>
 

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_lidar.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_lidar.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <Eigen/Dense>
 
 #include "ros/ros.h"

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_odometry.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_sensor_publisher_odometry.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <map>
+#include <string>
+#include <utility>
+
 #include <Eigen/Dense>
 
 #include "ros/ros.h"

--- a/ros/drake_ros_systems/include/drake/ros/systems/ros_tf_publisher.h
+++ b/ros/drake_ros_systems/include/drake/ros/systems/ros_tf_publisher.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <map>
+#include <string>
+
 #include <Eigen/Dense>
 
 #include "ros/ros.h"


### PR DESCRIPTION
This is all of the bog-standard boilerplate fixes, as suggested by cpplint (that is, a first large portion of #2364).  This only fixes ~95% of the warnings, so does _not_ globally enable this warning.  A follow-up PR will have the final 5% of interesting fixes and the global warning toggle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3974)
<!-- Reviewable:end -->
