### PR TITLE
Revert "Turn off hidden visibility on Linux"

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -64,6 +64,13 @@ endfunction()
 # This makes all of our #include "drake/..." statemenets work.
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/..)
 
+if(NOT APPLE)
+  # The linker on OS X likes to hide the typeinfo for template classes unless
+  # they are explicitly instantiated and exported, which causes dynamic_cast to
+  # fail across library boundaries.
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=all -Werror=ignored-qualifiers")
   if(APPLE)


### PR DESCRIPTION
Dear @david-german-tri ,

The on-call build cop, @betsy.mcphail, believes that your PR #3965  may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration pre-merge, because additional
platforms and tests are built post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Continuous/job/linux-gcc-continuous-matlab-open-source-debug/45/
https://drake-jenkins.csail.mit.edu/view/Continuous/job/linux-gcc-ninja-continuous-matlab-open-source-debug/41/


Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3981)
<!-- Reviewable:end -->
