### PR TITLE
Adds Check Verifying Port Sizes Match When Connecting Them

### DIFF
--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -115,6 +115,7 @@ class DiagramBuilder {
                const SystemPortDescriptor<T>& dest) {
     DRAKE_DEMAND(src.get_face() == kOutputPort);
     DRAKE_DEMAND(dest.get_face() == kInputPort);
+    DRAKE_DEMAND(src.get_size() == dest.get_size());
     PortIdentifier dest_id{dest.get_system(), dest.get_index()};
     PortIdentifier src_id{src.get_system(), src.get_index()};
     ThrowIfInputAlreadyWired(dest_id);

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -149,6 +149,18 @@ GTEST_TEST(DiagramBuilderTest, GetMutableSystems) {
             builder.GetMutableSystems());
 }
 
+// Tests that ports of different sizes cannot be connected.
+GTEST_TEST(DiagramBuilderTest, ConnectPortSizeMismatch) {
+  DiagramBuilder<double> builder;
+
+  auto sys1 = builder.AddSystem<Adder>(2 /* inputs */, 1 /* size */);
+  auto sys2 = builder.AddSystem<Integrator>(2 /* size */);
+
+  EXPECT_DEATH(
+    builder.Connect(sys1->get_output_port(), sys2->get_input_port(0)), ".*");
+}
+
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -157,7 +157,7 @@ GTEST_TEST(DiagramBuilderTest, ConnectPortSizeMismatch) {
   auto sys2 = builder.AddSystem<Integrator>(2 /* size */);
 
   EXPECT_DEATH(
-    builder.Connect(sys1->get_output_port(), sys2->get_input_port(0)), ".*");
+      builder.Connect(sys1->get_output_port(), sys2->get_input_port(0)), ".*");
 }
 
 

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -149,18 +149,6 @@ GTEST_TEST(DiagramBuilderTest, GetMutableSystems) {
             builder.GetMutableSystems());
 }
 
-// Tests that ports of different sizes cannot be connected.
-GTEST_TEST(DiagramBuilderTest, ConnectPortSizeMismatch) {
-  DiagramBuilder<double> builder;
-
-  auto sys1 = builder.AddSystem<Adder>(2 /* inputs */, 1 /* size */);
-  auto sys2 = builder.AddSystem<Integrator>(2 /* size */);
-
-  EXPECT_DEATH(
-      builder.Connect(sys1->get_output_port(), sys2->get_input_port(0)), ".*");
-}
-
-
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Added a DEMAND to DiagramBuilder::Connect() insisting that the source and destination ports have the same size().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3992)
<!-- Reviewable:end -->
