### PR TITLE
Added missing override keyword.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -118,7 +118,7 @@ class IiwaStatusSender : public systems::LeafSystem<double> {
   }
 
   void EvalOutput(const Context<double>& context,
-                  SystemOutput<double>* output) const {
+                  SystemOutput<double>* output) const override {
     systems::AbstractValue* mutable_data = output->GetMutableData(0);
     lcmt_iiwa_status& status =
         mutable_data->GetMutableValue<lcmt_iiwa_status>();


### PR DESCRIPTION
This addresses the following compile-time warning:

```
[427/573] Building CXX object examples/kuka_iiwa_arm/CMakeFiles/kuka_simulation.dir/kuka_simulation.cc.o
/Users/liang/dev/drake-distro-5/drake/examples/kuka_iiwa_arm/kuka_simulation.cc:120:8: warning: 'EvalOutput' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void EvalOutput(const Context<double>& context,
       ^
/Users/liang/dev/drake-distro-5/drake/../drake/systems/framework/system.h:255:16: note: overridden virtual function is here
  virtual void EvalOutput(const Context<T>& context,
               ^
1 warning generated.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3993)
<!-- Reviewable:end -->
