### PR TITLE
Fixed comment describing PID units in KUKA Demo.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_gravity_compensated_position_control.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_gravity_compensated_position_control.cc
@@ -41,8 +41,8 @@ int main(int argc, char* argv[]) {
 
   // Smaller gains intentionally used for demo. Gravity compensation enables
   // the usage of small feedback gains and this example demonstrates that.
-  const double Kp_common = 10.0;  // Units : Nm/rad
-  const double Kd_common = 0.30;  // Units : Nm/rad/sec
+  const double Kp_common = 10.0;  // Units : Nm / rad
+  const double Kd_common = 0.30;  // Units : Nm / (rad / sec)
   VectorXd Kpdiag = VectorXd::Constant(kNumDof, Kp_common);
   VectorXd Kddiag = VectorXd::Constant(kNumDof, Kd_common);
 


### PR DESCRIPTION
I know these demos still need to be converted to System 2.0, but I figured might as well submit this comment fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/3999)
<!-- Reviewable:end -->
