### PR TITLE
Add Valkyrie simulation with LCM communication

### DIFF
--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -47,6 +47,17 @@ if (lcm_FOUND)
   pods_install_libraries(drakeRobotStateEncoder)
   drake_install_headers(robot_state_encoder.h)
 
+  add_library_with_exports(LIB_NAME drakeRobotStateDecoder SOURCE_FILES
+      robot_state_decoder.cc)
+  target_link_libraries(drakeRobotStateDecoder
+      drakeLCMSystem2
+      drakeLCMUtil
+      drakeRigidBodyPlant
+      drakeRobotStateLcmTypeUtil
+      )
+  pods_install_libraries(drakeRobotStateDecoder)
+  drake_install_headers(robot_state_decoder.h)
+
   add_executable(valkyrie_simulation valkyrie_simulation.cc)
   target_link_libraries(valkyrie_simulation
       drakeRigidBodyPlant

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -20,6 +20,13 @@ if (lcm_FOUND)
   pods_install_libraries(drakeRobotCommandToDesiredEffortConverter)
   drake_install_headers(robot_command_to_desired_effort_converter.h)
 
+  add_library_with_exports(LIB_NAME drakeActuatorEffortToRigidBodyPlantInputConverter SOURCE_FILES
+      actuator_effort_to_rigid_body_plant_input_converter.cc)
+  target_link_libraries(drakeActuatorEffortToRigidBodyPlantInputConverter
+      drakeLCMSystem2)
+  pods_install_libraries(drakeActuatorEffortToRigidBodyPlantInputConverter)
+  drake_install_headers(actuator_effort_to_rigid_body_plant_input_converter.h)
+
   add_library_with_exports(LIB_NAME drakeRobotStateLcmTypeUtil SOURCE_FILES
       robot_state_lcmtype_util.cc)
   target_link_libraries(drakeRobotStateLcmTypeUtil

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -10,4 +10,13 @@ endif()
 
 drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieVisualize OPTIONAL bullet gurobi snopt COMMAND runValkyrieVisualize)
 
+if (lcm_FOUND)
+  add_library_with_exports(LIB_NAME drakeRobotCommandToDesiredEffortConverter SOURCE_FILES
+      robot_command_to_desired_effort_converter.cc)
+  target_link_libraries(drakeRobotCommandToDesiredEffortConverter
+      drakeLCMSystem2)
+  pods_install_libraries(drakeRobotCommandToDesiredEffortConverter)
+  drake_install_headers(robot_command_to_desired_effort_converter.h)
+endif()
+
 add_subdirectory(test)

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -46,6 +46,16 @@ if (lcm_FOUND)
       )
   pods_install_libraries(drakeRobotStateEncoder)
   drake_install_headers(robot_state_encoder.h)
+
+  add_executable(valkyrie_simulation valkyrie_simulation.cc)
+  target_link_libraries(valkyrie_simulation
+      drakeRigidBodyPlant
+      drakeLCMSystem2
+      drakeRobotStateEncoder
+      drakeSystemAnalysis
+      drakeSystemFramework
+      drakeActuatorEffortToRigidBodyPlantInputConverter
+      drakeRobotCommandToDesiredEffortConverter)
 endif()
 
 add_subdirectory(test)

--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -1,5 +1,7 @@
 # drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancing REQUIRES gurobi COMMAND runValkyrieBalancing)  # FIXME: see #2839
 
+# TODO: if lcm found?
+
 if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND UNIX) # FIXME: see #3147.
   drake_add_matlab_test(NAME examples/Valkyrie/runValkyrieBalancingPerturb REQUIRES gurobi lcm libbot yaml-cpp COMMAND runValkyrieBalancingPerturb)
 endif()
@@ -17,6 +19,26 @@ if (lcm_FOUND)
       drakeLCMSystem2)
   pods_install_libraries(drakeRobotCommandToDesiredEffortConverter)
   drake_install_headers(robot_command_to_desired_effort_converter.h)
+
+  add_library_with_exports(LIB_NAME drakeRobotStateLcmTypeUtil SOURCE_FILES
+      robot_state_lcmtype_util.cc)
+  target_link_libraries(drakeRobotStateLcmTypeUtil
+      drakeRigidBodyPlant
+      )
+  pods_install_libraries(drakeRobotStateLcmTypeUtil)
+  drake_install_headers(robot_state_lcmtype_util.h)
+
+  add_library_with_exports(LIB_NAME drakeRobotStateEncoder SOURCE_FILES
+      robot_state_encoder.cc)
+  target_link_libraries(drakeRobotStateEncoder
+      drakeLCMSystem2
+      drakeLCMUtil
+      drakeRigidBodyPlant
+      drakeSide
+      drakeRobotStateLcmTypeUtil
+      )
+  pods_install_libraries(drakeRobotStateEncoder)
+  drake_install_headers(robot_state_encoder.h)
 endif()
 
 add_subdirectory(test)

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.cc
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.cc
@@ -1,0 +1,59 @@
+#include "drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+ActuatorEffortToRigidBodyPlantInputConverter<T>::
+    ActuatorEffortToRigidBodyPlantInputConverter(
+        const std::vector<const RigidBodyActuator*>& ordered_actuators)
+    : ordered_actuators_(ordered_actuators),
+      effort_ports_indices_(DeclareEffortInputPorts(ordered_actuators)),
+      rigid_body_plant_input_port_index_(
+          DeclareOutputPort(kVectorValued,
+                            static_cast<int>(ordered_actuators.size()),
+                            kContinuousSampling)
+              .get_index()) {
+  set_name("ActuatorEffortToRigidBodyPlantInputConverter");
+}
+
+template <typename T>
+void ActuatorEffortToRigidBodyPlantInputConverter<T>::EvalOutput(
+    const Context<T>& context, SystemOutput<T>* output) const {
+  int index = 0;
+  for (const auto& actuator : ordered_actuators_) {
+    int port_index = effort_ports_indices_.at(actuator);
+    T effort = EvalVectorInput(context, port_index)->get_value()[0];
+    output->GetMutableVectorData(rigid_body_plant_input_port_index_)
+        ->SetAtIndex(index++, effort);
+  }
+}
+
+template <typename T>
+std::map<const RigidBodyActuator*, int>
+ActuatorEffortToRigidBodyPlantInputConverter<T>::DeclareEffortInputPorts(
+    const std::vector<const RigidBodyActuator*>& ordered_actuators) {
+  std::map<const RigidBodyActuator*, int> ret;
+
+  // Currently, all RigidBodyActuators are assumed to be one-dimensional.
+  const int effort_length = 1;
+  for (const auto& actuator : ordered_actuators) {
+    ret[actuator] =
+        DeclareInputPort(kVectorValued, effort_length, kContinuousSampling)
+            .get_index();
+  }
+  return ret;
+}
+
+template <typename T>
+const SystemPortDescriptor<T>& ActuatorEffortToRigidBodyPlantInputConverter<
+    T>::effort_input_port(const RigidBodyActuator& actuator) {
+  return get_input_port(effort_ports_indices_.at(&actuator));
+}
+
+// Explicit instantiations.
+template class DRAKE_EXPORT
+    ActuatorEffortToRigidBodyPlantInputConverter<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <vector>
+#include <map>
+
+#include "drake/common/drake_export.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/multibody/rigid_body_actuator.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+class DRAKE_EXPORT ActuatorEffortToRigidBodyPlantInputConverter
+    : public LeafSystem<T> {
+ public:
+  using System<T>::DeclareInputPort;
+  using System<T>::DeclareOutputPort;
+  using System<T>::set_name;
+  using System<T>::EvalVectorInput;
+  using System<T>::get_input_port;
+
+  ActuatorEffortToRigidBodyPlantInputConverter(
+      const std::vector<const RigidBodyActuator*>& ordered_actuators);
+
+  ~ActuatorEffortToRigidBodyPlantInputConverter() override {}
+
+  // Disable copy and assign.
+  ActuatorEffortToRigidBodyPlantInputConverter(
+      const ActuatorEffortToRigidBodyPlantInputConverter&) = delete;
+
+  ActuatorEffortToRigidBodyPlantInputConverter& operator=(
+      const ActuatorEffortToRigidBodyPlantInputConverter&) = delete;
+
+  void EvalOutput(const Context<T>& context,
+                  SystemOutput<T>* output) const override;
+
+  /// Returns the descriptor of the effort input port corresponding for
+  /// @param actuator
+  const SystemPortDescriptor<T>& effort_input_port(
+      const RigidBodyActuator& actuator);
+
+ private:
+  std::vector<const RigidBodyActuator*> ordered_actuators_;
+  const std::map<const RigidBodyActuator*, int> effort_ports_indices_;
+  int rigid_body_plant_input_port_index_;
+  std::map<const RigidBodyActuator*, int> DeclareEffortInputPorts(
+      const std::vector<const RigidBodyActuator*>& vector);
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.cc
+++ b/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.cc
@@ -1,0 +1,84 @@
+#include "drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h"
+
+#include "lcmtypes/bot_core/atlas_command_t.hpp"
+
+namespace drake {
+namespace systems {
+
+RobotCommandToDesiredEffortConverter::RobotCommandToDesiredEffortConverter(
+    const std::vector<const RigidBodyActuator*>& actuators)
+    : robot_command_port_index_(
+      DeclareAbstractInputPort(kContinuousSampling).get_index()),
+      desired_effort_port_indices_(DeclareDesiredEffortOutputPorts(actuators)),
+      name_to_actuator_(CreateNameToActuatorMap(actuators)) {
+  set_name("RobotCommandToDesiredEffortConverter");
+}
+
+void RobotCommandToDesiredEffortConverter::EvalOutput(
+    const systems::Context<double>& context,
+    systems::SystemOutput<double>* output) const {
+  using bot_core::atlas_command_t;
+
+  const AbstractValue* input =
+      EvalAbstractInput(context, robot_command_port_index_);
+  const atlas_command_t& message = input->GetValue<atlas_command_t>();
+
+  // Note: currently, all RigidBodyActuators are assumed to be one-dimensional.
+  // The following code is written based on that assumption.
+
+  // First, zero all the desired efforts to handle missing values in the
+  // robot_command message. Notably, this happens on the first few ticks of a
+  // simulation, before we've received a command message from the controller,
+  // in which case the subscriber system returns a default-constructed message
+  // (with empty std::vectors for the efforts and such).
+  for (const auto& actuator_and_port_index : desired_effort_port_indices_) {
+    int port_index = actuator_and_port_index.second;
+    output->get_mutable_port(port_index)
+        ->GetMutableVectorData<double>()
+        ->SetAtIndex(0, 0.0);
+  }
+
+  // Copy effort information from LCM message to appropriate output port.
+  for (size_t i = 0; i < message.joint_names.size(); i++) {
+    const std::string& joint_name = message.joint_names[i];
+    const double& effort = message.effort[i];
+    const RigidBodyActuator* actuator = name_to_actuator_.at(joint_name);
+    int port_index = desired_effort_port_indices_.at(actuator);
+    output->get_mutable_port(port_index)
+        ->GetMutableVectorData<double>()
+        ->SetAtIndex(0, effort);
+  }
+}
+
+const SystemPortDescriptor<double>&
+RobotCommandToDesiredEffortConverter::desired_effort_output_port(
+    const RigidBodyActuator& actuator) const {
+  return get_output_port(desired_effort_port_indices_.at(&actuator));
+}
+
+std::map<const RigidBodyActuator*, int>
+RobotCommandToDesiredEffortConverter::DeclareDesiredEffortOutputPorts(
+    const std::vector<const RigidBodyActuator*>& actuators) {
+  // Currently, all RigidBodyActuators are assumed to be one-dimensional.
+  const int desired_effort_length = 1;
+  std::map<const RigidBodyActuator*, int> ret;
+  for (const auto& actuator : actuators) {
+    ret[actuator] = DeclareOutputPort(kVectorValued, desired_effort_length,
+                                      kContinuousSampling)
+                        .get_index();
+  }
+  return ret;
+}
+
+std::map<std::string, const RigidBodyActuator*>
+RobotCommandToDesiredEffortConverter::CreateNameToActuatorMap(
+    const std::vector<const RigidBodyActuator*>& actuators) {
+  std::map<std::string, const RigidBodyActuator*> ret;
+  for (const auto& actuator : actuators) {
+    ret[actuator->name_] = actuator;
+  }
+  return ret;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h
+++ b/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h
@@ -22,6 +22,9 @@ namespace systems {
 /**
  * Converts an atlas_command_t message into desired efforts, presented on one
  * output port per actuator.
+ *
+ * Note that a RobotCommandToDesiredEffortConverter simply ignores commands for
+ * actuators that it doesn't know about.
  */
 class DRAKE_EXPORT RobotCommandToDesiredEffortConverter
     : public LeafSystem<double> {

--- a/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h
+++ b/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_export.h"
+#include "drake/multibody/rigid_body_actuator.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+// TODO(tkoolen): Currently just takes the effort part of the
+// atlas_command_t message, without considering the PID control parts.
+// This functionality exists in
+// https://github.com/openhumanoids/valkyrie_translator/blob/7068e846c9595b0b518755692db63b5f75a10520/src/LCM2ROSControl.cpp
+// and should probably be put in a library exported by Drake and used both here
+// and in LCM2ROSControl.
+
+/**
+ * Converts an atlas_command_t message into desired efforts, presented on one
+ * output port per actuator.
+ */
+class DRAKE_EXPORT RobotCommandToDesiredEffortConverter
+    : public LeafSystem<double> {
+ public:
+  RobotCommandToDesiredEffortConverter(
+      const std::vector<const RigidBodyActuator*>& actuators);
+
+  ~RobotCommandToDesiredEffortConverter() override {}
+
+  // Disable copy and assign.
+  RobotCommandToDesiredEffortConverter(
+      const RobotCommandToDesiredEffortConverter&) = delete;
+
+  RobotCommandToDesiredEffortConverter& operator=(
+      const RobotCommandToDesiredEffortConverter&) = delete;
+
+  void EvalOutput(const Context<double>& context,
+                  SystemOutput<double>* output) const override;
+
+  /// Descriptor of output port that presents desired effort for @param
+  /// actuator.
+  const SystemPortDescriptor<double>& desired_effort_output_port(
+      const RigidBodyActuator& actuator) const;
+
+ private:
+  int robot_command_port_index_;
+  const std::map<const RigidBodyActuator*, int> desired_effort_port_indices_;
+  const std::map<std::string, const RigidBodyActuator*> name_to_actuator_;
+
+  // Declare one output port for each RigidBodyActuator and store their
+  // descriptors in a map.
+  std::map<const RigidBodyActuator*, int> DeclareDesiredEffortOutputPorts(
+      const std::vector<const RigidBodyActuator*>& actuators);
+
+  // Map from actuator name to actuator.
+  std::map<std::string, const RigidBodyActuator*> CreateNameToActuatorMap(
+      const std::vector<const RigidBodyActuator*>& actuators);
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/robot_state_decoder.cc
+++ b/drake/examples/Valkyrie/robot_state_decoder.cc
@@ -118,12 +118,14 @@ void RobotStateDecoder::EvalOutput(const Context<double>& context,
   // Non-floating joints.
   for (size_t i = 0; i < message.joint_name.size(); i++) {
     const auto& name = message.joint_name[i];
-    const RigidBody& body = *joint_name_to_body_.at(name);
-    double position = message.joint_position[i];
-    double velocity = message.joint_velocity[i];
-
-    q[body.get_position_start_index()] = position;
-    v[body.get_velocity_start_index()] = velocity;
+    const auto& it = joint_name_to_body_.find(name);
+    if (it != joint_name_to_body_.end()) {
+      const RigidBody& body = *(it->second);
+      double position = message.joint_position[i];
+      double velocity = message.joint_velocity[i];
+      q[body.get_position_start_index()] = position;
+      v[body.get_velocity_start_index()] = velocity;
+    }
   }
 
   kinematics_cache.initialize(q, v);

--- a/drake/examples/Valkyrie/robot_state_decoder.cc
+++ b/drake/examples/Valkyrie/robot_state_decoder.cc
@@ -1,0 +1,160 @@
+#include "drake/examples/Valkyrie/robot_state_decoder.h"
+
+#include "lcmtypes/bot_core/robot_state_t.hpp"
+
+#include "drake/examples/Valkyrie/robot_state_lcmtype_util.h"
+#include "drake/util/lcmUtil.h"
+
+namespace drake {
+namespace systems {
+
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+using std::map;
+using std::string;
+
+using Eigen::VectorXd;
+using Eigen::Matrix;
+using Eigen::Dynamic;
+using Eigen::Isometry3d;
+
+using bot_core::robot_state_t;
+
+using drake::math::rotmat2rpy;
+using drake::math::rotmat2quat;
+using drake::math::Gradient;
+
+RobotStateDecoder::RobotStateDecoder(const RigidBodyTree<double>& tree)
+    : tree_(CheckTreeIsRobotStateLcmTypeCompatible(tree)),
+      floating_body_(tree.bodies[1]->getJoint().is_floating()
+                         ? tree.bodies[1].get()
+                         : nullptr),
+      robot_state_message_port_index_(
+          DeclareAbstractInputPort(kContinuousSampling).get_index()),
+      kinematics_cache_port_index_(
+          DeclareAbstractOutputPort(kContinuousSampling).get_index()),
+      joint_name_to_body_(CreateJointNameToBodyMap(tree)) {
+  set_name("RobotStateDecoder");
+}
+void RobotStateDecoder::EvalOutput(const Context<double>& context,
+                                   SystemOutput<double>* output) const {
+  // Input: robot_state_t message.
+  const auto& message =
+      EvalAbstractInput(context, robot_state_message_port_index_)
+          ->GetValue<robot_state_t>();
+
+  // Output: KinematicsCache.
+  auto& kinematics_cache = output->GetMutableData(kinematics_cache_port_index_)
+                               ->GetMutableValue<KinematicsCache<double>>();
+
+  VectorXd q(tree_.get_num_positions());  // TODO(tkoolen): don't allocate anew.
+  VectorXd v(
+      tree_.get_num_velocities());  // TODO(tkoolen): don't allocate anew.
+
+  // Floating joint.
+  if (floating_body_) {
+    auto floating_body_to_world = DecodePose(message.pose);
+    auto floating_body_twist_in_in_world_aligned_body =
+        DecodeTwist(message.twist);
+    const DrakeJoint& floating_joint = floating_body_->getJoint();
+    int position_start = floating_body_->get_position_start_index();
+    int velocity_start = floating_body_->get_velocity_start_index();
+
+    // TODO(tkoolen): kind of a crude check:
+    if (floating_joint.get_num_positions() == kRpySize + kSpaceDimension) {
+      // RPY-parameterized floating joint.
+
+      // Translation.
+      q.segment<kSpaceDimension>(position_start) =
+          floating_body_to_world.translation();
+
+      // Orientation.
+      auto rpy = rotmat2rpy(floating_body_to_world.linear());
+      q.segment<kRpySize>(position_start + kSpaceDimension) = rpy;
+
+      // Translational velocity.
+      auto translationdot =
+          floating_body_twist_in_in_world_aligned_body.tail<kSpaceDimension>();
+      v.segment<kSpaceDimension>(velocity_start) = translationdot;
+
+      // Rotational velocity.
+      Matrix<double, kRpySize, kSpaceDimension> phi;
+      typename Gradient<decltype(phi), Dynamic>::type* dphi = nullptr;
+      typename Gradient<decltype(phi), Dynamic, 2>::type* ddphi = nullptr;
+      angularvel2rpydotMatrix(rpy, phi, dphi, ddphi);
+      auto angular_velocity_world =
+          floating_body_twist_in_in_world_aligned_body.head<kSpaceDimension>();
+      auto rpydot = (phi * angular_velocity_world).eval();
+      v.segment<kRpySize>(velocity_start + kSpaceDimension) = rpydot;
+    } else if (floating_joint.get_num_positions() ==
+               kQuaternionSize + kSpaceDimension) {
+      // Quaternion-parameterized floating joint.
+
+      // Translation.
+      q.segment<kSpaceDimension>(position_start) =
+          floating_body_to_world.translation();
+
+      // Orientation.
+      auto quat = rotmat2quat(floating_body_to_world.linear());
+      q.segment<kQuaternionSize>(position_start + kSpaceDimension) = quat;
+
+      // Twist.
+      // Transform twist from world-aligned body frame to body frame.
+      Isometry3d world_aligned_body_to_body;
+      world_aligned_body_to_body.linear() =
+          floating_body_to_world.linear().transpose();
+      world_aligned_body_to_body.translation().setZero();
+      world_aligned_body_to_body.makeAffine();
+      TwistVector<double> floating_body_twist_in_body =
+          transformSpatialMotion(world_aligned_body_to_body,
+                                 floating_body_twist_in_in_world_aligned_body);
+      v.segment<kTwistSize>(velocity_start) = floating_body_twist_in_body;
+    } else {
+      DRAKE_ABORT();
+    }
+  }
+
+  // Non-floating joints.
+  for (size_t i = 0; i < message.joint_name.size(); i++) {
+    const auto& name = message.joint_name[i];
+    const RigidBody& body = *joint_name_to_body_.at(name);
+    double position = message.joint_position[i];
+    double velocity = message.joint_velocity[i];
+
+    q[body.get_position_start_index()] = position;
+    v[body.get_velocity_start_index()] = velocity;
+  }
+
+  kinematics_cache.initialize(q, v);
+  tree_.doKinematics(kinematics_cache, true);
+}
+
+std::unique_ptr<SystemOutput<double>> RobotStateDecoder::AllocateOutput(
+    const Context<double>& context) const {
+  auto output = make_unique<LeafSystemOutput<double>>();
+  auto kinematics_cache = std::make_unique<Value<KinematicsCache<double>>>(
+      KinematicsCache<double>(tree_.bodies));
+  output->add_port(move(kinematics_cache));
+  return unique_ptr<SystemOutput<double>>(output.release());
+}
+
+std::map<std::string, const RigidBody*>
+RobotStateDecoder::CreateJointNameToBodyMap(const RigidBodyTree<double>& tree) {
+  map<string, const RigidBody*> ret;
+  for (const auto& body : tree.bodies) {
+    if (body->has_parent_body()) {
+      const auto& joint = body->getJoint();
+      if (!joint.is_fixed() && !joint.is_floating()) {
+        // To match usage of robot_state_t throughout OpenHumanoids code, use
+        // position coordinate name as joint name.
+        int position_index = body->get_position_start_index();
+        ret[tree_.get_position_name(position_index)] = body.get();
+      }
+    }
+  }
+  return ret;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/robot_state_decoder.h
+++ b/drake/examples/Valkyrie/robot_state_decoder.h
@@ -13,7 +13,12 @@ namespace systems {
 // TODO(tkoolen): currently doesn't do anything with the efforts or wrenches in
 // the robot_state_t message.
 
-/// Converts a robot_state_t LCM message into a KinematicsCache object.
+/**
+ * Converts a robot_state_t LCM message into a KinematicsCache object.
+ *
+ * Note that a RobotStateDecoder simply ignores state information for joints
+ * that it doesn't know about.
+ */
 class DRAKE_EXPORT RobotStateDecoder : public LeafSystem<double> {
  public:
   explicit RobotStateDecoder(const RigidBodyTree<double>& tree);

--- a/drake/examples/Valkyrie/robot_state_decoder.h
+++ b/drake/examples/Valkyrie/robot_state_decoder.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "drake/common/drake_export.h"
+#include "drake/multibody/RigidBodyTree.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+// TODO(tkoolen): currently doesn't do anything with the efforts or wrenches in
+// the robot_state_t message.
+
+/// Converts a robot_state_t LCM message into a KinematicsCache object.
+class DRAKE_EXPORT RobotStateDecoder : public LeafSystem<double> {
+ public:
+  explicit RobotStateDecoder(const RigidBodyTree<double>& tree);
+
+  ~RobotStateDecoder() override {}
+
+  // Disable copy and assign.
+  RobotStateDecoder(const RobotStateDecoder&) = delete;
+
+  RobotStateDecoder& operator=(const RobotStateDecoder&) = delete;
+
+  void EvalOutput(const Context<double>& context,
+                  SystemOutput<double>* output) const override;
+
+  std::unique_ptr<SystemOutput<double>> AllocateOutput(
+      const Context<double>& context) const override;
+
+ private:
+  std::map<std::string, const RigidBody*> CreateJointNameToBodyMap(
+      const RigidBodyTree<double>& tree);
+
+  const RigidBodyTree<double>& tree_;
+  const RigidBody* const floating_body_;
+  const int robot_state_message_port_index_;
+  const int kinematics_cache_port_index_;
+  const std::map<std::string, const RigidBody*> joint_name_to_body_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -43,8 +43,8 @@ void RobotStateEncoder::EvalOutput(const Context<double>& context,
   auto& message = output->GetMutableData(lcm_message_port_index_)
                       ->GetMutableValue<robot_state_t>();
   message.utime = static_cast<int64_t>(context.get_time() * 1e6);
-  SetStateAndEfforts(&message, context);
-  SetForceTorque(&message, context);
+  SetStateAndEfforts(context, &message);
+  SetForceTorque(context, &message);
 }
 
 std::unique_ptr<SystemOutput<double>> RobotStateEncoder::AllocateOutput(
@@ -105,8 +105,8 @@ std::map<Side, int> RobotStateEncoder::DeclareWrenchInputPorts() {
   return ret;
 }
 
-void RobotStateEncoder::SetStateAndEfforts(
-    robot_state_t* message, const Context<double>& context) const {
+void RobotStateEncoder::SetStateAndEfforts(const Context<double>& context,
+                                           robot_state_t* message) const {
   const auto& kinematics_results =
       EvalAbstractInput(context, kinematics_results_port_index_)
           ->GetValue<KinematicsResults<double>>();
@@ -166,8 +166,8 @@ void RobotStateEncoder::SetStateAndEfforts(
   message->utime = static_cast<int64_t>(1e6 * context.get_time());
 }
 
-void RobotStateEncoder::SetForceTorque(robot_state_t* message,
-                                       const Context<double>& context) const {
+void RobotStateEncoder::SetForceTorque(const Context<double>& context,
+                                       bot_core::robot_state_t* message) const {
   auto& force_torque = message->force_torque;
   const int kTorqueXIndex = 0;
   const int kTorqueYIndex = 1;

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -118,17 +118,13 @@ void RobotStateEncoder::SetStateAndEfforts(const Context<double>& context,
     EncodePose(floating_body_to_world, message->pose);
 
     // Twist of floating body with respect to world.
-    TwistVector<double> floating_body_twist_in_world =
-        kinematics_results.get_twist_with_respect_to_world(*floating_body_);
-    // To match usage of robot_state_t throughout OpenHumanoids code, transform
-    // twist in body frame to a frame that has the same orientation as world
+    // To match usage of robot_state_t throughout OpenHumanoids code, use
+    // twist frame that has the same orientation as world
     // frame, but the same origin as the floating body frame.
-    Isometry3d world_to_world_aligned_body(
-        Translation3d(-floating_body_to_world.translation()));
-    TwistVector<double> floating_body_twist_in_in_world_aligned_body =
-        transformSpatialMotion(world_to_world_aligned_body,
-                               floating_body_twist_in_world);
-    EncodeTwist(floating_body_twist_in_in_world_aligned_body, message->twist);
+    TwistVector<double> floating_body_twist =
+        kinematics_results.get_twist_in_world_aligned_body_frame(
+            *floating_body_);
+    EncodeTwist(floating_body_twist, message->twist);
   } else {
     EncodePose(Isometry3d::Identity(), message->pose);
     EncodeTwist(Vector6<double>::Zero(), message->twist);

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -169,9 +169,6 @@ void RobotStateEncoder::SetStateAndEfforts(const Context<double>& context,
 void RobotStateEncoder::SetForceTorque(const Context<double>& context,
                                        bot_core::robot_state_t* message) const {
   auto& force_torque = message->force_torque;
-  const int kTorqueXIndex = 0;
-  const int kTorqueYIndex = 1;
-  const int kForceZIndex = 5;
   {
     auto left_foot_wrench =
         EvalVectorInput(context, foot_wrench_port_indices_.at(Side::LEFT))

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -1,0 +1,218 @@
+#include "drake/examples/Valkyrie/robot_state_encoder.h"
+#include "drake/common/constants.h"
+#include "drake/examples/Valkyrie/robot_state_lcmtype_util.h"
+#include "drake/multibody/rigid_body_plant/kinematics_results.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/util/drakeUtil.h"
+#include "drake/util/lcmUtil.h"
+
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+
+using bot_core::robot_state_t;
+
+using Eigen::Dynamic;
+using Eigen::Index;
+using Eigen::Matrix;
+using Eigen::Isometry3d;
+using Eigen::Translation3d;
+
+namespace drake {
+namespace systems {
+
+RobotStateEncoder::RobotStateEncoder(const RigidBodyTree<double>& tree)
+    : tree_(CheckTreeIsRobotStateLcmTypeCompatible(tree)),
+      floating_body_(tree.bodies[1]->getJoint().is_floating()
+                         ? tree.bodies[1].get()
+                         : nullptr),
+      lcm_message_port_index_(
+          DeclareAbstractOutputPort(kContinuousSampling).get_index()),
+      kinematics_results_port_index_(
+          DeclareAbstractInputPort(kContinuousSampling).get_index()),
+      effort_port_indices_(DeclareEffortInputPorts()),
+      foot_wrench_port_indices_(DeclareWrenchInputPorts()),
+      hand_wrench_port_indices_(DeclareWrenchInputPorts()) {
+  set_name("RobotStateEncoder");
+}
+
+RobotStateEncoder::~RobotStateEncoder() {}
+
+void RobotStateEncoder::EvalOutput(const Context<double>& context,
+                                   SystemOutput<double>* output) const {
+  auto& message = output->GetMutableData(lcm_message_port_index_)
+                      ->GetMutableValue<robot_state_t>();
+  message.utime = static_cast<int64_t>(context.get_time() * 1e6);
+  SetStateAndEfforts(&message, context);
+  SetForceTorque(&message, context);
+}
+
+std::unique_ptr<SystemOutput<double>> RobotStateEncoder::AllocateOutput(
+    const Context<double>& context) const {
+  auto output = make_unique<LeafSystemOutput<double>>();
+
+  auto data = make_unique<Value<robot_state_t>>(robot_state_t());
+  output->add_port(move(data));
+
+  return std::unique_ptr<SystemOutput<double>>(output.release());
+}
+
+const SystemPortDescriptor<double>& RobotStateEncoder::lcm_message_port()
+    const {
+  return get_output_port(lcm_message_port_index_);
+}
+
+const SystemPortDescriptor<double>& RobotStateEncoder::kinematics_results_port()
+    const {
+  return get_input_port(kinematics_results_port_index_);
+}
+
+const SystemPortDescriptor<double>& RobotStateEncoder::effort_port(
+    const RigidBodyActuator& actuator) const {
+  return get_input_port(effort_port_indices_.at(&actuator));
+}
+
+const SystemPortDescriptor<double>& RobotStateEncoder::foot_contact_wrench_port(
+    const Side& side) const {
+  return get_input_port(foot_wrench_port_indices_.at(side));
+}
+
+const SystemPortDescriptor<double>& RobotStateEncoder::hand_contact_wrench_port(
+    const Side& side) const {
+  return get_input_port(hand_wrench_port_indices_.at(side));
+}
+
+std::map<const RigidBodyActuator*, int>
+RobotStateEncoder::DeclareEffortInputPorts() {
+  std::map<const RigidBodyActuator*, int> ret;
+
+  // Currently, all RigidBodyActuators are assumed to be one-dimensional.
+  const int actuator_effort_length = 1;
+  for (const auto& actuator : tree_.actuators) {
+    ret[&actuator] = DeclareInputPort(kVectorValued, actuator_effort_length,
+                                      kContinuousSampling)
+                         .get_index();
+  }
+  return ret;
+}
+
+std::map<Side, int> RobotStateEncoder::DeclareWrenchInputPorts() {
+  std::map<Side, int> ret;
+  for (const auto& side : Side::values) {
+    ret[side] = DeclareInputPort(kVectorValued, kTwistSize, kContinuousSampling)
+                    .get_index();
+  }
+  return ret;
+}
+
+void RobotStateEncoder::SetStateAndEfforts(
+    robot_state_t* message, const Context<double>& context) const {
+  const auto& kinematics_results =
+      EvalAbstractInput(context, kinematics_results_port_index_)
+          ->GetValue<KinematicsResults<double>>();
+
+  if (floating_body_) {
+    // Pose of floating body with respect to world.
+    Isometry3d floating_body_to_world =
+        kinematics_results.get_pose_in_world(*floating_body_);
+    EncodePose(floating_body_to_world, message->pose);
+
+    // Twist of floating body with respect to world.
+    TwistVector<double> floating_body_twist_in_world =
+        kinematics_results.get_twist_with_respect_to_world(*floating_body_);
+    // To match usage of robot_state_t throughout OpenHumanoids code, transform
+    // twist in body frame to a frame that has the same orientation as world
+    // frame, but the same origin as the floating body frame.
+    Isometry3d world_to_world_aligned_body(
+        Translation3d(-floating_body_to_world.translation()));
+    TwistVector<double> floating_body_twist_in_in_world_aligned_body =
+        transformSpatialMotion(world_to_world_aligned_body,
+                               floating_body_twist_in_world);
+    EncodeTwist(floating_body_twist_in_in_world_aligned_body, message->twist);
+  } else {
+    EncodePose(Isometry3d::Identity(), message->pose);
+    EncodeTwist(Vector6<double>::Zero(), message->twist);
+  }
+
+  // Joint names, positions, velocities, and efforts.
+  // Note: the order of the actuators in the rigid body tree determines the
+  // order of the joint_name, joint_position, joint_velocity, and
+  // joint_effort fields.
+  message->joint_name.clear();
+  message->joint_position.clear();
+  message->joint_velocity.clear();
+  message->joint_effort.clear();
+  for (const auto& actuator : tree_.actuators) {
+    const auto& body = *actuator.body_;
+    int effort_port_index = effort_port_indices_.at(&actuator);
+
+    // To match usage of robot_state_t throughout OpenHumanoids code, set
+    // joint_names field to position coordinate names.
+    int position_index = body.get_position_start_index();
+    message->joint_name.push_back(tree_.get_position_name(position_index));
+
+    auto position =
+        static_cast<float>(kinematics_results.get_joint_position(body)[0]);
+    auto velocity =
+        static_cast<float>(kinematics_results.get_joint_velocity(body)[0]);
+    auto effort = static_cast<float>(
+        EvalVectorInput(context, effort_port_index)->GetAtIndex(0));
+
+    message->joint_position.push_back(position);
+    message->joint_velocity.push_back(velocity);
+    message->joint_effort.push_back(effort);
+  }
+  message->num_joints = static_cast<int16_t>(message->joint_name.size());
+  message->utime = static_cast<int64_t>(1e6 * context.get_time());
+}
+
+void RobotStateEncoder::SetForceTorque(robot_state_t* message,
+                                       const Context<double>& context) const {
+  auto& force_torque = message->force_torque;
+  const int kTorqueXIndex = 0;
+  const int kTorqueYIndex = 1;
+  const int kForceZIndex = 5;
+  {
+    auto left_foot_wrench =
+        EvalVectorInput(context, foot_wrench_port_indices_.at(Side::LEFT))
+            ->get_value();
+    force_torque.l_foot_force_z =
+        static_cast<float>(left_foot_wrench[kForceZIndex]);
+    force_torque.l_foot_torque_x =
+        static_cast<float>(left_foot_wrench[kTorqueXIndex]);
+    force_torque.l_foot_torque_y =
+        static_cast<float>(left_foot_wrench[kTorqueYIndex]);
+  }
+  {
+    auto right_foot_wrench =
+        EvalVectorInput(context, foot_wrench_port_indices_.at(Side::RIGHT))
+            ->get_value();
+    force_torque.r_foot_force_z =
+        static_cast<float>(right_foot_wrench[kForceZIndex]);
+    force_torque.r_foot_torque_x =
+        static_cast<float>(right_foot_wrench[kTorqueXIndex]);
+    force_torque.r_foot_torque_y =
+        static_cast<float>(right_foot_wrench[kTorqueYIndex]);
+  }
+  {
+    auto left_hand_wrench =
+        EvalVectorInput(context, hand_wrench_port_indices_.at(Side::LEFT))
+            ->get_value();
+    eigenVectorToCArray(left_hand_wrench.head<kSpaceDimension>(),
+                        force_torque.l_hand_torque);
+    eigenVectorToCArray(left_hand_wrench.tail<kSpaceDimension>(),
+                        force_torque.l_hand_force);
+  }
+  {
+    auto right_hand_wrench =
+        EvalVectorInput(context, hand_wrench_port_indices_.at(Side::RIGHT))
+            ->get_value();
+    eigenVectorToCArray(right_hand_wrench.head<kSpaceDimension>(),
+                        force_torque.r_hand_torque);
+    eigenVectorToCArray(right_hand_wrench.tail<kSpaceDimension>(),
+                        force_torque.r_hand_force);
+  }
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -17,6 +17,10 @@ namespace systems {
 /// message, presented on an output port.
 class DRAKE_EXPORT RobotStateEncoder final : public LeafSystem<double> {
  public:
+  static const size_t kTorqueXIndex = 0;
+  static const size_t kTorqueYIndex = 1;
+  static const size_t kForceZIndex = 5;
+
   explicit RobotStateEncoder(const RigidBodyTree<double>& tree);
 
   ~RobotStateEncoder() override;

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -55,11 +55,11 @@ class DRAKE_EXPORT RobotStateEncoder final : public LeafSystem<double> {
 
   std::map<Side, int> DeclareWrenchInputPorts();
 
-  void SetStateAndEfforts(bot_core::robot_state_t* message,
-                          const Context<double>& context) const;
+  void SetStateAndEfforts(const Context<double>& context,
+                          bot_core::robot_state_t* message) const;
 
-  void SetForceTorque(bot_core::robot_state_t* message,
-                      const Context<double>& context) const;
+  void SetForceTorque(const Context<double>& context,
+                      bot_core::robot_state_t* message) const;
 
   // Tree to which message corresponds.
   const RigidBodyTree<double>& tree_;

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <map>
+
+#include "lcmtypes/bot_core/robot_state_t.hpp"
+
+#include "drake/common/drake_export.h"
+#include "drake/multibody/RigidBodyTree.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/robotInterfaces/Side.h"
+
+namespace drake {
+namespace systems {
+
+/// Assembles information from various input ports into a robot_state_t LCM
+/// message, presented on an output port.
+class DRAKE_EXPORT RobotStateEncoder final : public LeafSystem<double> {
+ public:
+  explicit RobotStateEncoder(const RigidBodyTree<double>& tree);
+
+  ~RobotStateEncoder() override;
+
+  // Disable copy and assign.
+  RobotStateEncoder(const RobotStateEncoder&) = delete;
+
+  RobotStateEncoder& operator=(const RobotStateEncoder&) = delete;
+
+  void EvalOutput(const Context<double>& context,
+                  SystemOutput<double>* output) const override;
+
+  std::unique_ptr<SystemOutput<double>> AllocateOutput(
+      const Context<double>& context) const override;
+
+  /// Returns descriptor of output port on which the LCM message is presented.
+  const SystemPortDescriptor<double>& lcm_message_port() const;
+
+  /// Returns descriptor of kinematics result input port.
+  const SystemPortDescriptor<double>& kinematics_results_port() const;
+
+  /// Returns descriptor of effort input port corresponding to @param actuator.
+  const SystemPortDescriptor<double>& effort_port(
+      const RigidBodyActuator& actuator) const;
+
+  /// Returns descriptor of foot wrench input port for side @param side.
+  const SystemPortDescriptor<double>& foot_contact_wrench_port(
+      const Side& side) const;
+
+  /// Returns descriptor of hand wrench input port for side @param side.
+  const SystemPortDescriptor<double>& hand_contact_wrench_port(
+      const Side& side) const;
+
+ private:
+  std::map<const RigidBodyActuator*, int> DeclareEffortInputPorts();
+
+  std::map<Side, int> DeclareWrenchInputPorts();
+
+  void SetStateAndEfforts(bot_core::robot_state_t* message,
+                          const Context<double>& context) const;
+
+  void SetForceTorque(bot_core::robot_state_t* message,
+                      const Context<double>& context) const;
+
+  // Tree to which message corresponds.
+  const RigidBodyTree<double>& tree_;
+
+  // Pointer to the body in @p tree_ that is attached to the world with a
+  // floating joint. Null if there is no such body.
+  const RigidBody* const floating_body_;
+
+  // Output port.
+  const int lcm_message_port_index_;
+
+  // Input ports.
+  const int kinematics_results_port_index_;
+  const std::map<const RigidBodyActuator*, int> effort_port_indices_;
+  const std::map<Side, int> foot_wrench_port_indices_;
+  const std::map<Side, int> hand_wrench_port_indices_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/robot_state_lcmtype_util.cc
+++ b/drake/examples/Valkyrie/robot_state_lcmtype_util.cc
@@ -1,0 +1,48 @@
+#include "drake/examples/Valkyrie/robot_state_lcmtype_util.h"
+
+namespace drake {
+namespace systems {
+
+const RigidBodyTree<double>& CheckTreeIsRobotStateLcmTypeCompatible(
+    const RigidBodyTree<double>& tree) {
+  if (tree.get_num_bodies() < 2) {
+    DRAKE_ABORT_MSG("This class assumes at least one non-world body.");
+  }
+
+  bool floating_joint_found = false;
+  for (const auto& body_ptr : tree.bodies) {
+    if (body_ptr->has_parent_body()) {
+      const auto& joint = body_ptr->getJoint();
+      if (joint.is_floating()) {
+        if (floating_joint_found) {
+          DRAKE_ABORT_MSG("robot_state_t assumes at most one floating joint.");
+        }
+        floating_joint_found = true;
+
+        if (body_ptr != tree.bodies[1]) {
+          DRAKE_ABORT_MSG(
+              "This class assumes that the first non-world body is the "
+              "floating body.");
+        }
+
+        if (body_ptr->get_position_start_index() != 0 ||
+            body_ptr->get_velocity_start_index() != 0) {
+          DRAKE_ABORT_MSG(
+              "This class assumes that floating joint positions and are at the "
+              "head of the position and velocity vectors.");
+        }
+      } else {
+        if (joint.get_num_positions() > 1 || joint.get_num_velocities() > 1) {
+          DRAKE_ABORT_MSG(
+              "robot_state_t assumes non-floating joints to be "
+              "1-DoF or fixed.");
+        }
+      }
+    }
+  }
+
+  return tree;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/robot_state_lcmtype_util.h
+++ b/drake/examples/Valkyrie/robot_state_lcmtype_util.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "drake/common/drake_export.h"
+#include "drake/multibody/RigidBodyTree.h"
+
+namespace drake {
+namespace systems {
+
+/// Check that robot_state_t can unambiguously represent the RigidBodyTree's
+/// state. This method is intended to check preconditions inside a constructor's
+/// intitializer list.
+/// Aborts when the tree is not compatible with robot_state_t.
+/// @param tree a RigidBodyTree.
+/// @return the same RigidBodyTree that was passed in.
+const DRAKE_EXPORT RigidBodyTree<double>&
+CheckTreeIsRobotStateLcmTypeCompatible(const RigidBodyTree<double>& tree);
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/test/CMakeLists.txt
+++ b/drake/examples/Valkyrie/test/CMakeLists.txt
@@ -2,3 +2,10 @@
 # drake_add_matlab_test(NAME examples/Valkyrie/test/runValkyrieFastWalking REQUIRES gurobi lcm COMMAND runValkyrieFastWalking)
 # drake_add_matlab_test(NAME examples/Valkyrie/test/runValkyrieTurning REQUIRES gurobi lcm COMMAND runValkyrieTurning)
 # drake_add_matlab_test(NAME examples/Valkyrie/test/runValkyrieTurning270 REQUIRES gurobi lcm COMMAND runValkyrieTurning270)
+
+if(lcm_FOUND)
+  drake_add_cc_test(robot_state_encoder_decoder_test)
+  target_link_libraries(robot_state_encoder_decoder_test
+      drakeRobotStateEncoder
+      drakeRobotStateDecoder)
+endif()

--- a/drake/examples/Valkyrie/test/CMakeLists.txt
+++ b/drake/examples/Valkyrie/test/CMakeLists.txt
@@ -8,4 +8,9 @@ if(lcm_FOUND)
   target_link_libraries(robot_state_encoder_decoder_test
       drakeRobotStateEncoder
       drakeRobotStateDecoder)
+
+  drake_add_cc_test(robot_command_to_desired_effort_converter_test)
+  target_link_libraries(robot_command_to_desired_effort_converter_test
+      drakeRobotCommandToDesiredEffortConverter
+      drakeRBM)
 endif()

--- a/drake/examples/Valkyrie/test/robot_command_to_desired_effort_converter_test.cc
+++ b/drake/examples/Valkyrie/test/robot_command_to_desired_effort_converter_test.cc
@@ -1,0 +1,110 @@
+#include "drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h"
+
+#include "gtest/gtest.h"
+
+#include "lcmtypes/bot_core/atlas_command_t.hpp"
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/multibody/parser_urdf.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/primitives/constant_value_source.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using std::make_unique;
+using std::move;
+
+using multibody::joints::FloatingBaseType;
+
+void TestCommandToDesiredEffortConverter(
+    const RigidBodyTree<double>& tree, const bot_core::atlas_command_t& message,
+    const std::map<const RigidBodyActuator*, double>& expected_efforts) {
+  DiagramBuilder<double> builder;
+
+  std::vector<const RigidBodyActuator*> actuators;
+  for (const auto& actuator : tree.actuators) {
+    actuators.push_back(&actuator);
+  }
+
+  // Constant LCM message source.
+  auto robot_command = make_unique<Value<bot_core::atlas_command_t>>(message);
+  auto& robot_command_source =
+      *builder.AddSystem<ConstantValueSource<double>>(move(robot_command));
+
+  // Device under test.
+  auto& converter =
+      *builder.AddSystem<RobotCommandToDesiredEffortConverter>(actuators);
+
+  // Connect LCM message source to converter.
+  builder.Connect(robot_command_source, converter);
+
+  // Define outputs.
+  for (const auto& actuator : tree.actuators) {
+    builder.ExportOutput(converter.desired_effort_output_port(actuator));
+  }
+
+  auto diagram = builder.Build();
+
+  auto context = diagram->CreateDefaultContext();
+  auto output = diagram->AllocateOutput(*context);
+  diagram->EvalOutput(*context, output.get());
+
+  // TODO(tkoolen): assumption about ordering of exported output ports.
+  int output_port_id = 0;
+  for (const auto& actuator : tree.actuators) {
+    EXPECT_NEAR(output->get_vector_data(output_port_id++)->GetAtIndex(0),
+                expected_efforts.at(&actuator), 1e-10);
+  }
+}
+
+GTEST_TEST(EffortToInputConverterTest, TestEmptyMessage) {
+  bot_core::atlas_command_t message({});
+
+  RigidBodyTree<double> tree;
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() +
+          "/examples/Valkyrie/urdf/urdf/"
+          "valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf",
+      FloatingBaseType::kRollPitchYaw, nullptr /* weld to frame */, &tree);
+
+  std::map<const RigidBodyActuator*, double> expected_efforts;
+  for (const auto& actuator : tree.actuators) {
+    expected_efforts[&actuator] = 0.0;
+  }
+
+  TestCommandToDesiredEffortConverter(tree, message, expected_efforts);
+}
+
+GTEST_TEST(EffortToInputConverterTest, TestNonEmptyMessage) {
+  bot_core::atlas_command_t message;
+
+  RigidBodyTree<double> tree;
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() +
+          "/examples/Valkyrie/urdf/urdf/"
+          "valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf",
+      FloatingBaseType::kRollPitchYaw, nullptr /* weld to frame */, &tree);
+
+  std::map<const RigidBodyActuator*, double> expected_efforts;
+  double effort = 0.;
+
+  // Reverse iterate to test ordering.
+
+  for (auto it = tree.actuators.rbegin(); it != tree.actuators.rend(); ++it) {
+    const auto& actuator = *it;
+    message.joint_names.push_back(actuator.name_);
+    message.effort.push_back(effort);
+    expected_efforts[&actuator] = effort;
+    effort += 1.;
+  }
+  message.num_joints = static_cast<int32_t>(message.joint_names.size());
+
+  TestCommandToDesiredEffortConverter(tree, message, expected_efforts);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -37,7 +37,6 @@ void TestEncodeThenDecode(FloatingBaseType floating_base_type) {
   // KinematicsResults source.
   auto kinematics_results = make_unique<Value<KinematicsResults<double>>>(
       KinematicsResults<double>(&tree));
-  //  auto kinematics_results = make_unique<KinematicsResults>(&tree);
   std::default_random_engine generator;  // Same seed every time, but that's OK.
   std::normal_distribution<double> distribution;
   auto q = tree.getRandomConfiguration(generator);

--- a/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -148,10 +148,12 @@ void TestEncodeThenDecode(FloatingBaseType floating_base_type) {
 
   // Check left foot wrench.
   const auto& left_foot_wrench = foot_wrenches.at(Side::LEFT);
-  EXPECT_NEAR(force_torque.l_foot_torque_x, left_foot_wrench[0], tolerance);
-  EXPECT_NEAR(force_torque.l_foot_torque_y, left_foot_wrench[1], tolerance);
+  EXPECT_NEAR(force_torque.l_foot_torque_x,
+              left_foot_wrench[RobotStateEncoder::kTorqueXIndex], tolerance);
+  EXPECT_NEAR(force_torque.l_foot_torque_y,
+              left_foot_wrench[RobotStateEncoder::kTorqueYIndex], tolerance);
   EXPECT_NEAR(force_torque.l_foot_force_z,
-              left_foot_wrench[kSpaceDimension + 2], tolerance);
+              left_foot_wrench[RobotStateEncoder::kForceZIndex], tolerance);
 
   // Check left hand wrench.
   const auto& left_hand_wrench = hand_wrenches.at(Side::LEFT);
@@ -163,10 +165,12 @@ void TestEncodeThenDecode(FloatingBaseType floating_base_type) {
 
   // Check right foot wrench.
   const auto& right_foot_wrench = foot_wrenches.at(Side::RIGHT);
-  EXPECT_NEAR(force_torque.r_foot_torque_x, right_foot_wrench[0], tolerance);
-  EXPECT_NEAR(force_torque.r_foot_torque_y, right_foot_wrench[1], tolerance);
+  EXPECT_NEAR(force_torque.r_foot_torque_x,
+              right_foot_wrench[RobotStateEncoder::kTorqueXIndex], tolerance);
+  EXPECT_NEAR(force_torque.r_foot_torque_y,
+              right_foot_wrench[RobotStateEncoder::kTorqueYIndex], tolerance);
   EXPECT_NEAR(force_torque.r_foot_force_z,
-              right_foot_wrench[kSpaceDimension + 2], tolerance);
+              right_foot_wrench[RobotStateEncoder::kForceZIndex], tolerance);
 
   // Check right hand wrench.
   const auto& right_hand_wrench = hand_wrenches.at(Side::RIGHT);

--- a/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -1,0 +1,234 @@
+#include "drake/examples/Valkyrie/robot_state_encoder.h"
+#include "drake/examples/Valkyrie/robot_state_decoder.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/multibody/parser_urdf.h"
+#include "drake/multibody/rigid_body_plant/kinematics_results.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/primitives/constant_value_source.h"
+#include "drake/systems/framework/primitives/constant_vector_source.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using std::make_unique;
+using std::move;
+using std::make_pair;
+using std::map;
+
+using bot_core::robot_state_t;
+
+using multibody::joints::FloatingBaseType;
+
+void TestEncodeThenDecode(FloatingBaseType floating_base_type) {
+  RigidBodyTree<double> tree;
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() +
+          "/examples/Valkyrie/urdf/urdf/"
+          "valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf",
+      floating_base_type, nullptr /* weld to frame */, &tree);
+
+  DiagramBuilder<double> builder;
+
+  // KinematicsResults source.
+  auto kinematics_results = make_unique<Value<KinematicsResults<double>>>(
+      KinematicsResults<double>(&tree));
+  //  auto kinematics_results = make_unique<KinematicsResults>(&tree);
+  std::default_random_engine generator;  // Same seed every time, but that's OK.
+  std::normal_distribution<double> distribution;
+  auto q = tree.getRandomConfiguration(generator);
+  VectorX<double> v(tree.get_num_velocities());
+  for (int i = 0; i < tree.get_num_velocities(); i++) {
+    v[i] = distribution(generator);
+  }
+  kinematics_results->GetMutableValue<KinematicsResults<double>>().Update(q, v);
+  auto& kinematics_results_source =
+      *builder.AddSystem<ConstantValueSource<double>>(move(kinematics_results));
+
+  // Effort sources.
+  VectorX<double> efforts = VectorX<double>::LinSpaced(
+      tree.actuators.size(), 0.0, tree.actuators.size() - 1);
+  std::map<const RigidBodyActuator*, const System<double>*> effort_sources;
+  for (size_t i = 0; i < tree.actuators.size(); i++) {
+    const auto& actuator = tree.actuators[i];
+    auto effort = efforts.segment(i, 1);
+    const auto& effort_source =
+        builder.AddSystem<ConstantVectorSource<double>>(effort);
+    effort_sources.emplace(make_pair(&actuator, effort_source));
+  }
+
+  // Wrench sources.
+  map<Side, System<double>*> hand_wrench_sensors;
+  map<Side, System<double>*> foot_wrench_sensors;
+  eigen_aligned_std_map<Side, Vector6<double>> hand_wrenches;
+  eigen_aligned_std_map<Side, Vector6<double>> foot_wrenches;
+  double wrenches_start = 0.0;
+  for (Side side : Side::values) {
+    // Hand.
+    Vector6<double> hand_wrench;
+    hand_wrench.setLinSpaced(wrenches_start,
+                             wrenches_start + hand_wrench.size() - 1.0);
+    wrenches_start += hand_wrench.size();
+    hand_wrench_sensors[side] =
+        builder.AddSystem<ConstantVectorSource>(hand_wrench);
+    hand_wrenches[side] = hand_wrench;
+
+    // Foot.
+    Vector6<double> foot_wrench;
+    foot_wrench.setLinSpaced(wrenches_start,
+                             wrenches_start + foot_wrench.size() - 1.0);
+    wrenches_start += foot_wrench.size();
+    foot_wrench_sensors[side] =
+        builder.AddSystem<ConstantVectorSource>(foot_wrench);
+    foot_wrenches[side] = foot_wrench;
+  }
+
+  // RobotStateEncoder and RobotStateDecoder.
+  auto& robot_state_encoder = *builder.AddSystem<RobotStateEncoder>(tree);
+  auto& robot_state_decoder = *builder.AddSystem<RobotStateDecoder>(tree);
+
+  // Connections.
+  for (const auto& actuator_and_effort_source : effort_sources) {
+    const auto& actuator = actuator_and_effort_source.first;
+    const auto& effort_source = actuator_and_effort_source.second;
+    builder.Connect(effort_source->get_output_port(0),
+                    robot_state_encoder.effort_port(*actuator));
+  }
+
+  for (Side side : Side::values) {
+    builder.Connect(hand_wrench_sensors.at(side)->get_output_port(0),
+                    robot_state_encoder.hand_contact_wrench_port(side));
+    builder.Connect(foot_wrench_sensors.at(side)->get_output_port(0),
+                    robot_state_encoder.foot_contact_wrench_port(side));
+  }
+
+  builder.Connect(kinematics_results_source.get_output_port(0),
+                  robot_state_encoder.kinematics_results_port());
+  builder.Connect(robot_state_encoder, robot_state_decoder);
+
+  // Diagram outputs.
+  builder.ExportOutput(robot_state_decoder.get_output_port(0));
+  builder.ExportOutput(robot_state_encoder.get_output_port(0));
+
+  auto diagram = builder.Build();
+
+  auto context = diagram->CreateDefaultContext();
+  auto output = diagram->AllocateOutput(*context);
+  diagram->EvalOutput(*context, output.get());
+
+  // TODO(tkoolen): magic numbers.
+  auto cache_output = output->get_data(0)->GetValue<KinematicsCache<double>>();
+  auto msg_output = output->get_data(1)->GetValue<robot_state_t>();
+
+  // Tolerance because we're converting to float and back:
+  double tolerance = 10. * std::numeric_limits<float>::epsilon();
+
+  // Test message contents.
+  for (size_t i = 0; i < tree.actuators.size(); i++) {
+    const auto& actuator = tree.actuators[i];
+    const auto& body = *actuator.body_;
+
+    // Ensure that joint names are correct, and match the order of
+    // tree.actuators.
+    EXPECT_EQ(tree.get_position_name(body.get_position_start_index()),
+              msg_output.joint_name[i]);
+
+    // Ensure that joint position, joint velocity, and joint effort are correct.
+    EXPECT_NEAR(efforts[i], msg_output.joint_effort[i], tolerance);
+    EXPECT_NEAR(q[body.get_position_start_index()],
+                msg_output.joint_position[i], tolerance);
+    EXPECT_NEAR(v[body.get_velocity_start_index()],
+                msg_output.joint_velocity[i], tolerance);
+  }
+
+  const auto& force_torque = msg_output.force_torque;
+
+  // Check left foot wrench.
+  const auto& left_foot_wrench = foot_wrenches.at(Side::LEFT);
+  EXPECT_NEAR(force_torque.l_foot_torque_x, left_foot_wrench[0], tolerance);
+  EXPECT_NEAR(force_torque.l_foot_torque_y, left_foot_wrench[1], tolerance);
+  EXPECT_NEAR(force_torque.l_foot_force_z,
+              left_foot_wrench[kSpaceDimension + 2], tolerance);
+
+  // Check left hand wrench.
+  const auto& left_hand_wrench = hand_wrenches.at(Side::LEFT);
+  for (int i = 0; i < kSpaceDimension; i++) {
+    EXPECT_NEAR(force_torque.l_hand_torque[i], left_hand_wrench[i], tolerance);
+    EXPECT_NEAR(force_torque.l_hand_force[i],
+                left_hand_wrench[kSpaceDimension + i], tolerance);
+  }
+
+  // Check right foot wrench.
+  const auto& right_foot_wrench = foot_wrenches.at(Side::RIGHT);
+  EXPECT_NEAR(force_torque.r_foot_torque_x, right_foot_wrench[0], tolerance);
+  EXPECT_NEAR(force_torque.r_foot_torque_y, right_foot_wrench[1], tolerance);
+  EXPECT_NEAR(force_torque.r_foot_force_z,
+              right_foot_wrench[kSpaceDimension + 2], tolerance);
+
+  // Check right hand wrench.
+  const auto& right_hand_wrench = hand_wrenches.at(Side::RIGHT);
+  for (int i = 0; i < kSpaceDimension; i++) {
+    EXPECT_NEAR(force_torque.r_hand_torque[i], right_hand_wrench[i], tolerance);
+    EXPECT_NEAR(force_torque.r_hand_force[i],
+                right_hand_wrench[kSpaceDimension + i], tolerance);
+  }
+
+  // Test conversion back to KinematicsCache.
+  auto q_back = cache_output.getQ();
+  auto v_back = cache_output.getV();
+
+  // Can't compare q vectors directly due to quaternion floating joints, hence
+  // the following:
+  for (const auto& body : tree.bodies) {
+    if (body->has_parent_body()) {
+      const auto& joint = body->getJoint();
+      if (!joint.is_fixed()) {
+        auto q_joint_expected = q.segment(body->get_position_start_index(),
+                                          joint.get_num_positions());
+        auto q_joint_back = q_back.segment(body->get_position_start_index(),
+                                           joint.get_num_positions());
+        if (joint.is_floating() &&
+            floating_base_type == FloatingBaseType::kQuaternion) {
+          auto pos_expected = q_joint_expected.head<kSpaceDimension>();
+          auto pos_back = q_joint_back.head<kSpaceDimension>();
+          EXPECT_TRUE(CompareMatrices(pos_expected, pos_back, tolerance,
+                                      MatrixCompareType::absolute));
+
+          auto quat_expected = q_joint_expected.tail<kQuaternionSize>();
+          auto quat_back = q_joint_back.tail<kQuaternionSize>();
+          auto quat_diff = math::quatDiff(quat_expected, quat_back);
+          auto angle_axis = math::quat2axis(quat_diff);
+          // TODO(hongkai.dai): fix magic number once we use Eigen's AngleAxis:
+          auto angle = angle_axis[3];
+          EXPECT_NEAR(angle, 0.0, tolerance);
+        } else {
+          EXPECT_TRUE(CompareMatrices(q_joint_expected, q_joint_back, tolerance,
+                                      MatrixCompareType::absolute));
+        }
+      }
+    }
+  }
+
+  EXPECT_TRUE(CompareMatrices(v, cache_output.getV(), tolerance,
+                              MatrixCompareType::absolute));
+}
+
+GTEST_TEST(RobotStateEncoderDecoderTest, Fixed) {
+  TestEncodeThenDecode(FloatingBaseType::kFixed);
+}
+
+GTEST_TEST(RobotStateEncoderDecoderTest, RollPitchYaw) {
+  TestEncodeThenDecode(FloatingBaseType::kRollPitchYaw);
+}
+
+GTEST_TEST(RobotStateEncoderDecoderTest, Quaternion) {
+  TestEncodeThenDecode(FloatingBaseType::kQuaternion);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/examples/Valkyrie/valkyrie_simulation.cc
+++ b/drake/examples/Valkyrie/valkyrie_simulation.cc
@@ -1,0 +1,232 @@
+#include <memory>
+
+#include "lcmtypes/bot_core/atlas_command_t.hpp"
+#include "lcmtypes/bot_core/robot_state_t.hpp"
+
+#include "drake/common/drake_path.h"
+#include "drake/common/text_logging.h"
+#include "drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h"
+#include "drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h"
+#include "drake/examples/Valkyrie/robot_state_encoder.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/multibody/parser_urdf.h"
+#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/analysis/explicit_euler_integrator.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/primitives/constant_vector_source.h"
+#include "drake/systems/framework/primitives/pass_through.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/lcm/lcm_subscriber_system.h"
+#include "drake/systems/lcm/lcmt_drake_signal_translator.h"
+
+namespace drake {
+namespace systems {
+
+using std::move;
+using std::unique_ptr;
+using std::make_unique;
+using std::map;
+
+using bot_core::atlas_command_t;
+using bot_core::robot_state_t;
+
+using drake::lcm::DrakeLcm;
+using lcm::LcmSubscriberSystem;
+using lcm::LcmPublisherSystem;
+using multibody::joints::kRollPitchYaw;
+
+// TODO(tkoolen) copied from car_simulation.cc. Where should this live?
+void AddFlatTerrainToWorld(RigidBodyTree<double>* rigid_body_tree,
+                           double box_size, double box_depth) {
+  DrakeShapes::Box geom(Eigen::Vector3d(box_size, box_size, box_depth));
+  Eigen::Isometry3d T_element_to_link = Eigen::Isometry3d::Identity();
+  T_element_to_link.translation() << 0, 0,
+      -box_depth / 2;  // top of the box is at z=0
+  RigidBody& world = rigid_body_tree->world();
+  Eigen::Vector4d color;
+  color << 0.9297, 0.7930, 0.6758,
+      1;  // was hex2dec({'ee','cb','ad'})'/256 in matlab
+  world.AddVisualElement(
+      DrakeShapes::VisualElement(geom, T_element_to_link, color));
+  rigid_body_tree->addCollisionElement(
+      DrakeCollision::Element(geom, T_element_to_link, &world), world,
+      "terrain");
+  rigid_body_tree->updateStaticCollisionElements();
+}
+
+// TODO(tkoolen) shouldn't hard-code. Copied from fixed point file for Valkyrie.
+// Need C++ equivalent of resolveConstraints.
+VectorX<double> RPYValkyrieFixedPointState() {
+  VectorX<double> ret(72);
+  ret << 0, 0, 1.025, 0, 0, 0, 0, 0, 0, 0, 0.300196631343025, 1.25, 0,
+      0.785398163397448, 1.571, 0, 0, 0.300196631343025, -1.25, 0,
+      -0.785398163397448, 1.571, 0, 0, 0, 0, -0.49, 1.205, -0.71, 0, 0, 0,
+      -0.49, 1.205, -0.71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+  return ret;
+}
+
+int main(int argc, const char** argv) {
+  //  drake::log()->set_level(spdlog::level::trace);
+  DiagramBuilder<double> builder;
+
+  // Create RigidBodyTree.
+  auto tree_ptr = make_unique<RigidBodyTree<double>>();
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() +
+          "/examples/Valkyrie/urdf/urdf/"
+          "valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf",
+      kRollPitchYaw, nullptr /* weld to frame */, tree_ptr.get());
+  AddFlatTerrainToWorld(tree_ptr.get(), 100., 10.);
+
+  // Instantiate a RigidBodyPlant from the RigidBodyTree.
+  auto& plant = *builder.AddSystem<RigidBodyPlant<double>>(move(tree_ptr));
+  plant.set_contact_parameters(10000., 100., 10.);
+  const auto& tree = plant.get_rigid_body_tree();
+
+  // RigidBodyActuators.
+  std::vector<const RigidBodyActuator*> actuators;
+  for (const auto& actuator : tree.actuators) {
+    actuators.push_back(&actuator);
+  }
+  // Currently, all RigidBodyActuators are assumed to be one-dimensional.
+  const int actuator_effort_length = 1;
+
+  // LCM communication.
+  DrakeLcm lcm;
+
+  // LCM inputs.
+  auto& atlas_command_subscriber = *builder.AddSystem(
+      LcmSubscriberSystem::Make<atlas_command_t>("ROBOT_COMMAND", &lcm));
+  auto& robot_command_to_desired_effort_converter =
+      *builder.AddSystem<RobotCommandToDesiredEffortConverter>(actuators);
+
+  // Placeholder for actuator dynamics.
+  map<const RigidBodyActuator*, System<double>*> actuator_dynamics;
+  for (const auto& actuator : actuators) {
+    actuator_dynamics.emplace(std::make_pair(
+        actuator,
+        builder.AddSystem<PassThrough<double>>(actuator_effort_length)));
+  }
+
+  // Conversion from desired efforts to RigidBodyPlant input vector.
+  auto& actuator_effort_to_rigid_body_plant_input_converter =
+      *builder.AddSystem<ActuatorEffortToRigidBodyPlantInputConverter>(
+          actuators);
+
+  // Placeholder for effort sensors.
+  map<const RigidBodyActuator*, System<double>*> effort_sensors;
+  for (const auto& actuator : actuators) {
+    effort_sensors.emplace(std::make_pair(
+        actuator,
+        builder.AddSystem<PassThrough<double>>(actuator_effort_length)));
+  }
+
+  // LCM outputs.
+  auto& robot_state_encoder =
+      *builder.AddSystem<RobotStateEncoder>(plant.get_rigid_body_tree());
+  auto& robot_state_publisher = *builder.AddSystem(
+      LcmPublisherSystem::Make<robot_state_t>("EST_ROBOT_STATE", &lcm));
+
+  // TODO(tkoolen): Force/torque sensors. Zero for now.
+  map<Side, System<double>*> hand_wrench_sensors;
+  map<Side, System<double>*> foot_wrench_sensors;
+  for (Side side : Side::values) {
+    hand_wrench_sensors[side] =
+        builder.AddSystem<ConstantVectorSource>(Vector6<double>::Zero().eval());
+    foot_wrench_sensors[side] =
+        builder.AddSystem<ConstantVectorSource>(Vector6<double>::Zero().eval());
+  }
+
+  // Visualizer.
+  const DrakeVisualizer& visualizer_publisher =
+      *builder.template AddSystem<DrakeVisualizer>(tree, &lcm);
+
+  // Connections.
+  // LCM message to desired effort conversion.
+  builder.Connect(atlas_command_subscriber,
+                  robot_command_to_desired_effort_converter);
+
+  for (const auto& actuator : actuators) {
+    // Desired effort inputs to actuator dynamics.
+    auto desired_effort_output =
+        robot_command_to_desired_effort_converter.desired_effort_output_port(
+            *actuator);
+    auto desired_effort_input =
+        actuator_dynamics.at(actuator)->get_input_port(0);
+    builder.Connect(desired_effort_output, desired_effort_input);
+
+    // Efforts to effort sensors.
+    const auto& effort_output_port =
+        actuator_dynamics.at(actuator)->get_output_port(0);
+    const auto& measured_effort_input_port =
+        effort_sensors.at(actuator)->get_input_port(0);
+    builder.Connect(effort_output_port, measured_effort_input_port);
+
+    // Efforts to rigid body plant input
+    builder.Connect(
+        effort_output_port,
+        actuator_effort_to_rigid_body_plant_input_converter.effort_input_port(
+            *actuator));
+
+    // Effort sensors to robot state encoder.
+    const auto& measured_effort_output_port =
+        effort_sensors.at(actuator)->get_output_port(0);
+    const auto& state_encoder_effort_input_port =
+        robot_state_encoder.effort_port(*actuator);
+    builder.Connect(measured_effort_output_port,
+                    state_encoder_effort_input_port);
+  }
+
+  // Plant input to plant.
+  builder.Connect(actuator_effort_to_rigid_body_plant_input_converter, plant);
+
+  // Raw state vector to visualizer.
+  builder.Connect(plant.state_output_port(),
+                  visualizer_publisher.get_input_port(0));
+
+  // Kinematics results to robot state encoder.
+  builder.Connect(plant.kinematics_results_output_port(),
+                  robot_state_encoder.kinematics_results_port());
+
+  for (Side side : Side::values) {
+    builder.Connect(hand_wrench_sensors.at(side)->get_output_port(0),
+                    robot_state_encoder.hand_contact_wrench_port(side));
+    builder.Connect(foot_wrench_sensors.at(side)->get_output_port(0),
+                    robot_state_encoder.foot_contact_wrench_port(side));
+  }
+
+  // Robot state encoder to robot state publisher.
+  builder.Connect(robot_state_encoder, robot_state_publisher);
+
+  auto diagram = builder.Build();
+
+  // Create simulator.
+  auto simulator = std::make_unique<Simulator<double>>(*diagram);
+  auto context = simulator->get_mutable_context();
+  simulator->reset_integrator<ExplicitEulerIntegrator<double>>(*diagram, 1e-3,
+                                                               context);
+
+  // Set initial state.
+  auto plant_context = diagram->GetMutableSubsystemContext(context, &plant);
+
+  // TODO(tkoolen): make it easy to specify a different initial configuration.
+  VectorX<double> initial_state = RPYValkyrieFixedPointState();
+  plant.set_state_vector(plant_context, initial_state);
+  lcm.StartReceiveThread();
+
+  while (true) {
+    const double time = context->get_time();
+    SPDLOG_TRACE(drake::log(), "Time is now {}", time);
+    simulator->StepTo(time + 0.01);
+  }
+}
+
+}  // namespace systems
+}  // namespace drake
+
+int main(int argc, const char* argv[]) {
+  return drake::systems::main(argc, argv);
+}

--- a/drake/multibody/rigid_body_plant/kinematics_results.cc
+++ b/drake/multibody/rigid_body_plant/kinematics_results.cc
@@ -60,11 +60,21 @@ Isometry3<T> KinematicsResults<T>::get_pose_in_world(
 }
 
 template <typename T>
-TwistVector<T> KinematicsResults<T>::get_twist_with_respect_to_world(
-    const RigidBody& body) const {
+TwistVector<T> KinematicsResults<T>::get_twist_in_world_frame(
+    const RigidBody &body) const {
   const auto& world = tree_->world();
   return tree_->relativeTwist(kinematics_cache_, world.get_body_index(),
                              body.get_body_index(), 0);
+}
+
+template <typename T>
+TwistVector<T> KinematicsResults<T>::get_twist_in_world_aligned_body_frame(
+    const RigidBody &body) const {
+  auto twist_in_world = get_twist_in_world_frame(body);
+  auto body_to_world = get_pose_in_world(body);
+  Eigen::Isometry3d world_to_world_aligned_body(
+      Eigen::Translation3d(-body_to_world.translation()));
+  return transformSpatialMotion(world_to_world_aligned_body, twist_in_world);
 }
 
 template <typename T>

--- a/drake/multibody/rigid_body_plant/kinematics_results.cc
+++ b/drake/multibody/rigid_body_plant/kinematics_results.cc
@@ -11,7 +11,14 @@ KinematicsResults<T>::KinematicsResults(const RigidBodyTree<T>* tree) :
     tree_(tree), kinematics_cache_(tree_->bodies) {
 }
 
-template<typename T>
+template <typename T>
+void KinematicsResults<T>::Update(const Eigen::Ref<const VectorX<T>>& q,
+                                  const Eigen::Ref<const VectorX<T>>& v) {
+  this->kinematics_cache_.initialize(q, v);
+  this->tree_->doKinematics(this->kinematics_cache_, false);
+}
+
+template <typename T>
 int KinematicsResults<T>::get_num_bodies() const {
   return tree_->get_num_bodies();
 }

--- a/drake/multibody/rigid_body_plant/kinematics_results.h
+++ b/drake/multibody/rigid_body_plant/kinematics_results.h
@@ -10,7 +10,8 @@ namespace drake {
 namespace systems {
 
 // Forward declaration for KinematicsResults.
-template <typename T> class RigidBodyPlant;
+template <typename T>
+class RigidBodyPlant;
 
 /// A class containing the kinematics results from a RigidBodyPlant system.
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
@@ -33,6 +34,27 @@ class DRAKE_EXPORT KinematicsResults {
   /// Returns the three dimensional position of body @p body_index in world's
   /// frame.
   Vector3<T> get_body_position(int body_index) const;
+
+  /// Returns the pose of body @p body with respect to the world.
+  Isometry3<T> get_pose_in_world(const RigidBody& body) const;
+
+  /// Returns the twist of @p body with respect to the world, expressed in world
+  /// frame.
+  TwistVector<T> get_twist_with_respect_to_world(const RigidBody& body) const;
+
+  /// Returns the joint position vector associated with the joint between
+  /// @p body and @p body's parent.
+  /// TODO(tkoolen) should pass in joint instead of body, but that's currently
+  /// not convenient.
+  Eigen::VectorBlock<const VectorX<T>> get_joint_position(
+      const RigidBody& body) const;
+
+  /// Returns the joint velocity vector associated with the joint between
+  /// @p body and @p body's parent.
+  /// TODO(tkoolen) should pass in joint instead of body, but that's currently
+  /// not convenient.
+  Eigen::VectorBlock<const VectorX<T>> get_joint_velocity(
+      const RigidBody& body) const;
 
  private:
   // RigidBodyPlant is the only class allowed to update KinematicsResults

--- a/drake/multibody/rigid_body_plant/kinematics_results.h
+++ b/drake/multibody/rigid_body_plant/kinematics_results.h
@@ -18,6 +18,16 @@ class RigidBodyPlant;
 template <typename T>
 class DRAKE_EXPORT KinematicsResults {
  public:
+  /// Constructs a KinematicsResults object associated with @param tree.
+  /// An alias to @param tree is maintained so that the tree's lifetime must
+  /// exceed this object's lifetime.
+  explicit KinematicsResults(const RigidBodyTree<T>* tree);
+
+  /// Updates the KinematicsResults object given the configuration vector
+  /// @param q and velocity vector @param v.
+  void Update(const Eigen::Ref<const VectorX<T>>& q,
+              const Eigen::Ref<const VectorX<T>>& v);
+
   /// Returns the number of bodies in the kinematics results.
   int get_num_bodies() const;
 
@@ -62,12 +72,6 @@ class DRAKE_EXPORT KinematicsResults {
   // TODO(amcastro-tri): when KinematicsResults can reference entries in the
   // cache this friendship and the method UpdateFromContext() won't be needed.
   friend class RigidBodyPlant<T>;
-
-  // Only RigidBodyPlant can construct a KinematicsResults from the underlying
-  // RigidBodyTree.
-  // An alias to @tree is maintained so that the tree's lifetime must exceed
-  // this object's lifetime.
-  explicit KinematicsResults(const RigidBodyTree<T>* tree);
 
   // Updates KinematicsResults from a context provided by RigidBodyPlant.
   // Only RigidBodyPlant has access to this method since it is a friend.

--- a/drake/multibody/rigid_body_plant/kinematics_results.h
+++ b/drake/multibody/rigid_body_plant/kinematics_results.h
@@ -50,7 +50,12 @@ class DRAKE_EXPORT KinematicsResults {
 
   /// Returns the twist of @p body with respect to the world, expressed in world
   /// frame.
-  TwistVector<T> get_twist_with_respect_to_world(const RigidBody& body) const;
+  TwistVector<T> get_twist_in_world_frame(const RigidBody& body) const;
+
+  /// Returns the twist of @p body with respect to the world, expressed in world
+  /// frame.
+  TwistVector<T> get_twist_in_world_aligned_body_frame(
+      const RigidBody& body) const;
 
   /// Returns the joint position vector associated with the joint between
   /// @p body and @p body's parent.

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -180,6 +180,16 @@ class DRAKE_EXPORT RigidBodyPlant : public LeafSystem<T> {
   static T JointLimitForce(const DrakeJoint& joint,
                            const T& position, const T& velocity);
 
+  /// Returns descriptor of state output port.
+  const SystemPortDescriptor<T>& state_output_port() const {
+    return System<T>::get_output_port(state_output_port_id_);
+  }
+
+  /// Returns descriptor of KinematicsResults output port.
+  const SystemPortDescriptor<T>& kinematics_results_output_port() const {
+    return System<T>::get_output_port(kinematics_output_port_id_);
+  }
+
  protected:
   // LeafSystem<T> override.
   std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;


### PR DESCRIPTION
Adds a `valkyrie_simulation` executable, which implements the following block diagram:
https://www.dropbox.com/s/ub1mn7ft0v855ju/val%20sim%20no%20state%20estimator.pdf?dl=0

This version is for simulation *without* a state estimator, i.e. directly publishing a `robot_state_t` message on the `EST_ROBOT_STATE` channel.

Here's a video of the simulator in action (at the actual speed of the simulation, in Release mode), with zero joint torques:
https://www.dropbox.com/s/4zo7wjb7mqexwdz/val_sim.mp4?dl=0

Obviously, the ground contact model needs a lot of work; see https://github.com/RobotLocomotion/drake/issues/1978 and https://github.com/RobotLocomotion/drake/issues/1594.

Contact wrenches aren't hooked up yet, pending https://github.com/RobotLocomotion/drake/pull/3821. The force/torque sensors in the diagram are currently just `ConstantVectorSource`s that output zero vectors.

It's quite a bit of code. I've structured my commits so that it would be possible to PR parts at a time, so if that is strongly preferred, let me know.

Note that the `RobotStateDecoder` isn't used for anything except testing `RobotStateEncoder` yet, but it should be useful pretty soon. Note also that `RobotStateDecoder` and `RobotStateEncoder` don't make as many assumptions as similar functionality in https://github.com/RobotLocomotion/drake/pull/3907: they work for fixed and quaternion-parameterized `RigidBodyTree`s as well.

Some questions:
* a lot of this stuff is not Valkyrie-specific. Where should it live?
* in what namespace should everything be? I initially chose `drake::systems` out of convenience.
* any ideas on testing the main in `valkyrie_simulation` (i.e. the whole shebang including LCM inputs and outputs)?

@siyuanfeng-tri for feature review.

Fixes https://github.com/RobotLocomotion/drake/issues/1595.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4004)
<!-- Reviewable:end -->
