### PR TITLE
Added isinf() and isnan() overloads to AutoDiffScalar 

### DIFF
--- a/drake/math/autodiff_overloads.h
+++ b/drake/math/autodiff_overloads.h
@@ -21,6 +21,20 @@ double round(const Eigen::AutoDiffScalar<DerType>& x) {
   return round(x.value());
 }
 
+/// Overloads isinf to mimic std::isinf from <cmath>.
+template <typename DerType>
+double isinf(const Eigen::AutoDiffScalar<DerType>& x) {
+  using std::isinf;
+  return isinf(x.value());
+}
+
+/// Overloads isnan to mimic std::isnan from <cmath>.
+template <typename DerType>
+double isnan(const Eigen::AutoDiffScalar<DerType>& x) {
+  using std::isnan;
+  return isnan(x.value());
+}
+
 /// Overloads floor to mimic std::floor from <cmath>.
 template <typename DerType>
 double floor(const Eigen::AutoDiffScalar<DerType>& x) {

--- a/drake/math/autodiff_overloads.h
+++ b/drake/math/autodiff_overloads.h
@@ -23,14 +23,14 @@ double round(const Eigen::AutoDiffScalar<DerType>& x) {
 
 /// Overloads isinf to mimic std::isinf from <cmath>.
 template <typename DerType>
-double isinf(const Eigen::AutoDiffScalar<DerType>& x) {
+bool isinf(const Eigen::AutoDiffScalar<DerType>& x) {
   using std::isinf;
   return isinf(x.value());
 }
 
 /// Overloads isnan to mimic std::isnan from <cmath>.
 template <typename DerType>
-double isnan(const Eigen::AutoDiffScalar<DerType>& x) {
+bool isnan(const Eigen::AutoDiffScalar<DerType>& x) {
   using std::isnan;
   return isnan(x.value());
 }

--- a/drake/math/test/autodiff_overloads_test.cc
+++ b/drake/math/test/autodiff_overloads_test.cc
@@ -19,6 +19,8 @@ GTEST_TEST(AutodiffOverloadsTest, IsInf) {
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;
   x.value() = 1.0 / 0.0;
   EXPECT_EQ(isinf(x), true);
+  x.value() = 0.0;
+  EXPECT_EQ(isinf(x), false);
 }
 
 // Tests correctness of isnan
@@ -26,6 +28,8 @@ GTEST_TEST(AutodiffOverloadsTest, IsNaN) {
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;
   x.value() = 0.0 / 0.0;
   EXPECT_EQ(isnan(x), true);
+  x.value() = 0.0;
+  EXPECT_EQ(isnan(x), false);
 }
 
 // Tests that pow(AutoDiffScalar, AutoDiffScalar) applies the chain rule.

--- a/drake/math/test/autodiff_overloads_test.cc
+++ b/drake/math/test/autodiff_overloads_test.cc
@@ -14,6 +14,20 @@ namespace drake {
 namespace math {
 namespace {
 
+// Tests correctness of isinf
+GTEST_TEST(AutodiffOverloadsTest, IsInf) {
+  Eigen::AutoDiffScalar<Eigen::Vector2d> x;
+  x.value() = 1.0 / 0.0;
+  EXPECT_EQ(isinf(x), true);
+}
+
+// Tests correctness of isnan
+GTEST_TEST(AutodiffOverloadsTest, IsNaN) {
+  Eigen::AutoDiffScalar<Eigen::Vector2d> x;
+  x.value() = 0.0 / 0.0;
+  EXPECT_EQ(isnan(x), true);
+}
+
 // Tests that pow(AutoDiffScalar, AutoDiffScalar) applies the chain rule.
 GTEST_TEST(AutodiffOverloadsTest, Pow) {
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;


### PR DESCRIPTION
Addresses issue #4005

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4008)
<!-- Reviewable:end -->
