### PR TITLE
Ported car_sim_lcm to System 2.0 (Attempt 2)

### DIFF
--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(gen)
 add_subdirectory(test)
 
 add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
+  automotive_common.cc
   create_trajectory_params.cc
   curve2.cc
   gen/driving_command.cc
@@ -22,6 +23,7 @@ target_link_libraries(drakeAutomotive
   )
 pods_install_libraries(drakeAutomotive)
 drake_install_headers(
+  automotive_common.h
   create_trajectory_params.h
   curve2.h
   simple_car.h
@@ -64,13 +66,19 @@ if(lcm_FOUND)
   add_executable(automotive_demo automotive_demo.cc)
   target_link_libraries(automotive_demo drakeAutomotiveLcm drakeLCMTypes)
 
-  add_executable(car_sim_lcm car_sim_lcm.cc)
-  # TODO(jwnimmer-tri) Remove drakeLCMSystem once System 1 is gone.
-  target_link_libraries(car_sim_lcm drakeAutomotiveLcm drakeLCMSystem drakeLCMTypes)
-
   add_executable(multi_car_sim_lcm multi_car_sim_lcm.cc)
   # TODO(jwnimmer-tri) Remove drakeLCMSystem once System 1 is gone.
   target_link_libraries(multi_car_sim_lcm drakeAutomotiveLcm drakeLCMSystem drakeLCMTypes)
 
   drake_add_test(NAME multi_car_sim_lcm COMMAND multi_car_sim_lcm --duration 0.05)
+
+  add_executable(car_sim_lcm car_sim_lcm.cc)
+  target_link_libraries(car_sim_lcm
+      drakeAutomotiveLcm
+      drakeRigidBodyPlant
+      drakeSystemAnalysis
+      drakeSystemControllers
+      drakeLCMSystem2)
+
+  add_test(NAME car_sim_lcm COMMAND car_sim_lcm -simulation_sec 0.1)
 endif()

--- a/drake/automotive/README.md
+++ b/drake/automotive/README.md
@@ -2,27 +2,22 @@ Car Simulation Instructions
 ===========================
 
 This README file provides instructions on how to run Drake's car simulations.
-
-The instructions are written for Ubuntu Linux and OS X users. Windows users will
-need to adjust the instructions slightly. See the notes at the end of this
-section.
  
-Start the Drake Visualizer
---------------------------
+Start Drake's Visualizer
+------------------------
 
-The Drake Visualizer displays the current state of the simulation. It is a
-separate process that communicates with the Drake simulation process via the
+Drake's visualizer displays the current state of the simulation. It is a
+separate process that communicates with Drake's simulation via the
 [Lightweight Communications and Marshalling (LCM)](https://lcm-proj.github.io/)
 middleware.
 
-To run the Drake Visualizer, open a terminal and execute the following commands:
+To run Drake's visualizer, open a terminal and execute the following commands:
 
 ```
-$ cd drake-distro/drake/automotive
-$ ../../build/install/bin/drake-visualizer
+$ drake-distro/build/install/bin/drake-visualizer
 ```
 
-The Drake Visualizer window should appear.
+Drake's visualizer should appear.
 
 Start the Steering Command Driver
 ---------------------------------
@@ -51,26 +46,14 @@ $ cd drake-distro/drake/automotive
 $ python steering_command_driver.py
 ```
 
-Start the Drake Simulator
--------------------------
+Start Drake's Simulator
+-----------------------
 
-There is currently one version of Drake's cars simulator. It integrates only
-LCM-based components (e.g., the Drake Visualizer). In the future, a second version
-will be added that integrates both LCM-based components and ROS-based components
-(e.g., RViz).
-
-### Simulation Using Drake + LCM
-
-To start the simulation, open a new terminal and execute the following:
+Open a new terminal and execute the following:
 
 ```
-$ cd drake-distro/drake/automotive
-$ ../../build/drake/bin/car_sim_lcm models/prius/prius.urdf models/stata_garage_p1.sdf
+$ drake-distro/build/drake/bin/car_sim_lcm
 ```
-
-### Simulation Using Drake + LCM + ROS
-
-See: https://github.com/liangfok/drake/tree/feature/multi_car_sim_2/ros/drake_cars_examples
 
 Additional Simulation Notes
 ---------------------------
@@ -108,21 +91,8 @@ $ python steering_command_driver.py --mode=one-time --throttle=1.0 --steering-an
 
 Every time that you run the command above, it sends one LCM message.
 
-
-Adjustments for Windows
------------------------
-- Insert the configuration directory (e.g. `Release/`) after `bin/` in paths to
-the executables.
-- When running from the Windows Command Prompt you'll need to use backslashes in
-place of forward slashes.
-- To run a command in the background use `start cmdline` in place of `cmdline &`.
-
-Running the simple car simulator
+Running the Simple Car Simulator
 --------------------------------
-
-The following notes are for Ubuntu Linux and OS X users.
-This is not supported under Windows (though you can probably cobble
-together some workarounds by hand if you are motivated).
 
 Run:
 ```

--- a/drake/automotive/automotive_common.cc
+++ b/drake/automotive/automotive_common.cc
@@ -1,0 +1,27 @@
+#include "drake/automotive/automotive_common.h"
+
+namespace drake {
+namespace automotive {
+
+void AddFlatTerrainToWorld(RigidBodyTree* tree, double box_size,
+                           double box_depth) {
+  DrakeShapes::Box geom(Eigen::Vector3d(box_size, box_size, box_depth));
+  Eigen::Isometry3d T_element_to_link = Eigen::Isometry3d::Identity();
+  T_element_to_link.translation() << 0, 0,
+      -box_depth / 2;  // Top of the box is at z = 0.
+  RigidBody& world = tree->world();
+
+  // Defines a color called "desert sand" according to htmlcsscolor.com.
+  Eigen::Vector4d color;
+  color << 0.9297, 0.7930, 0.6758, 1;
+
+  world.AddVisualElement(
+      DrakeShapes::VisualElement(geom, T_element_to_link, color));
+  tree->addCollisionElement(
+      DrakeCollision::Element(geom, T_element_to_link, &world), world,
+      "terrain");
+  tree->updateStaticCollisionElements();
+}
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/automotive_common.cc
+++ b/drake/automotive/automotive_common.cc
@@ -3,7 +3,7 @@
 namespace drake {
 namespace automotive {
 
-void AddFlatTerrainToWorld(RigidBodyTree* tree, double box_size,
+void AddFlatTerrainToWorld(RigidBodyTreed* tree, double box_size,
                            double box_depth) {
   DrakeShapes::Box geom(Eigen::Vector3d(box_size, box_size, box_depth));
   Eigen::Isometry3d T_element_to_link = Eigen::Isometry3d::Identity();

--- a/drake/automotive/automotive_common.h
+++ b/drake/automotive/automotive_common.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "drake/systems/plants/RigidBodyTree.h"
+
+namespace drake {
+namespace automotive {
+
+/**
+ * Adds a box-shaped terrain to the specified rigid body tree. This directly
+ * modifies the existing world rigid body within @p rigid_body_tree and thus
+ * does not need to return a model name or model_instance_id value.
+ *
+ * Two opposite corners of the resulting axis aligned box are:
+ * `(box_size / 2, box_size / 2, 0)` and
+ * `(-box_size / 2, -box_size / 2, -box_depth)`.
+ *
+ * @param[in] tree The RigidBodyTree to which to add the terrain.
+ *
+ * @param[in] box_size The length and width of the terrain aligned with the
+ * world's X and Y axes.
+ *
+ * @param[in] box_depth The depth of the terrain aligned with the world's Z
+ * axis. Note that regardless of how deep the terrain is, the top surface of the
+ * terrain will be at Z = 0.
+ */
+void AddFlatTerrainToWorld(RigidBodyTree* tree,
+                           double box_size = 1000, double box_depth = 10);
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/automotive_common.h
+++ b/drake/automotive/automotive_common.h
@@ -23,7 +23,7 @@ namespace automotive {
  * axis. Note that regardless of how deep the terrain is, the top surface of the
  * terrain will be at Z = 0.
  */
-void AddFlatTerrainToWorld(RigidBodyTree* tree,
+void AddFlatTerrainToWorld(RigidBodyTreed* tree,
                            double box_size = 1000, double box_depth = 10);
 
 }  // namespace automotive

--- a/drake/automotive/car_sim_lcm.cc
+++ b/drake/automotive/car_sim_lcm.cc
@@ -1,54 +1,364 @@
-#include "drake/automotive/car_simulation.h"
-#include "drake/system1/LCMSystem.h"
-#include "drake/system1/LinearSystem.h"
-#include "drake/system1/pd_control_system.h"
-#include "drake/systems/plants/BotVisualizer.h"
-#include "drake/systems/plants/parser_model_instance_id_table.h"
-#include "drake/systems/plants/RigidBodySystem.h"
-#include "drake/util/drakeAppUtil.h"
-#include "drake/lcmt_driving_command_t.hpp"
+#include <gflags/gflags.h>
 
-using Eigen::VectorXd;
+#include "drake/automotive/automotive_common.h"
+#include "drake/automotive/car_simulation.h"
+#include "drake/automotive/gen/driving_command_translator.h"
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/text_logging_gflags.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/controllers/pid_controlled_system.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/primitives/constant_vector_source.h"
+#include "drake/systems/framework/primitives/matrix_gain.h"
+#include "drake/systems/lcm/lcm_subscriber_system.h"
+#include "drake/systems/plants/parser_sdf.h"
+#include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
+
+DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
+    "Number of seconds to simulate.");
+
+using std::make_unique;
+using std::move;
 
 namespace drake {
+
+using parsers::sdf::AddModelInstancesFromSdfFile;
+using lcm::DrakeLcm;
+using systems::ConstantVectorSource;
+using systems::Context;
+using systems::DiagramBuilder;
+using systems::DrakeVisualizer;
+using systems::MatrixGain;
+using systems::PidControlledSystem;
+using systems::RigidBodyPlant;
+using systems::Simulator;
+
 namespace automotive {
 namespace {
 
-int main(int argc, const char* argv[]) {
-  // Initializes the communication layer.
-  std::shared_ptr<lcm::LCM> lcm = std::make_shared<lcm::LCM>();
+// Verifies that the order of rigid body names and actuator names within the
+// provided tree are as expected.
+void VerifyCarSimLcmTree(const RigidBodyTree& tree) {
+  DRAKE_DEMAND(tree.get_num_bodies() == 18);
 
-  // Instantiates a duration variable that will be set by the call to
-  // CreateRigidBodySystem() below.
-  double duration = std::numeric_limits<double>::infinity();
+  std::map<std::string, int> name_to_idx =
+      tree.computePositionNameToIndexMap();
 
-  drake::parsers::ModelInstanceIdTable model_instances;
+  int joint_idx = 0;
+  DRAKE_DEMAND(name_to_idx.count("base_x"));
+  DRAKE_DEMAND(name_to_idx["base_x"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("base_y"));
+  DRAKE_DEMAND(name_to_idx["base_y"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("base_z"));
+  DRAKE_DEMAND(name_to_idx["base_z"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("base_qw"));
+  DRAKE_DEMAND(name_to_idx["base_qw"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("base_qx"));
+  DRAKE_DEMAND(name_to_idx["base_qx"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("base_qy"));
+  DRAKE_DEMAND(name_to_idx["base_qy"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("base_qz"));
+  DRAKE_DEMAND(name_to_idx["base_qz"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("steering"));
+  DRAKE_DEMAND(name_to_idx["steering"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("left_pin"));
+  DRAKE_DEMAND(name_to_idx["left_pin"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("left_wheel_joint"));
+  DRAKE_DEMAND(name_to_idx["left_wheel_joint"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("axle_tie_rod_arm"));
+  DRAKE_DEMAND(name_to_idx["axle_tie_rod_arm"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("right_wheel_joint"));
+  DRAKE_DEMAND(name_to_idx["right_wheel_joint"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("rear_left_wheel_joint"));
+  DRAKE_DEMAND(name_to_idx["rear_left_wheel_joint"] == joint_idx++);
+  DRAKE_DEMAND(name_to_idx.count("rear_right_wheel_joint"));
+  DRAKE_DEMAND(name_to_idx["rear_right_wheel_joint"] == joint_idx++);
 
-  // Initializes the rigid body system.
-  auto rigid_body_sys = CreateRigidBodySystem(argc, argv, &duration,
-      &model_instances);
+  DRAKE_DEMAND(tree.actuators.size() == 3);
+  DRAKE_DEMAND(tree.actuators.at(0).name_ == "steering");
+  DRAKE_DEMAND(tree.actuators.at(1).name_ == "left_wheel_joint");
+  DRAKE_DEMAND(tree.actuators.at(2).name_ == "right_wheel_joint");
+}
 
-  // Initializes and cascades all of the other systems.
-  auto vehicle_sys = CreateVehicleSystem(rigid_body_sys);
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  logging::HandleSpdlogGflags();
 
-  auto const& tree = rigid_body_sys->getRigidBodyTree();
-  auto visualizer =
-      std::make_shared<BotVisualizer<RigidBodySystem::StateVector>>(lcm, tree);
+  DRAKE_DEMAND(FLAGS_simulation_sec > 0);
+  DiagramBuilder<double> builder;
 
-  auto sys = cascade(vehicle_sys, visualizer);
+  // Instantiates a model of the world.
+  auto rigid_body_tree = make_unique<RigidBodyTree>();
+  AddModelInstancesFromSdfFile(
+      drake::GetDrakePath() + "/automotive/models/prius/prius_with_lidar.sdf",
+      systems::plants::joints::kQuaternion, nullptr /* weld to frame */,
+      rigid_body_tree.get());
+  AddFlatTerrainToWorld(rigid_body_tree.get());
+  VerifyCarSimLcmTree(*rigid_body_tree);
 
-  // Initializes the simulation options.
-  SimulationOptions options =
-      GetCarSimulationDefaultOptions();
+  // Instantiates a RigidBodyPlant to simulate the model.
+  auto plant = make_unique<RigidBodyPlant<double>>(move(rigid_body_tree));
+  plant->set_contact_parameters(5000.0 /* penetration_stiffness */,
+      500 /* penetration_damping */, 10 /* friction_coefficient */);
 
-  // Defines the start time of the simulation.
-  const double kStartTime = 0;
+  // Instantiates a PID controller for controlling the actuators in the
+  // RigidBodyPlant. The vector order is [steering, left wheel, right wheel].
+  const Vector3<double> Kp(400,   0,   0);  // Units: Nm / radians
+  const Vector3<double> Ki(0,     0,   0);  // Units: Nm / radians
+  const Vector3<double> Kd(80,  700, 700);  // Units: Nm / (radians / sec).
 
-  // Starts the simulation.
-  drake::runLCM(sys, lcm, kStartTime, duration,
-                GetInitialState(*(rigid_body_sys.get())),
-                options);
+  // TODO(liang.fok) Automatically initialize `feedback_selector_matrix` based
+  // on the simulation model, actuators, etc.
+  MatrixX<double> feedback_selector_matrix;
+  feedback_selector_matrix.setZero(plant->get_input_size() * 2,
+                                   plant->get_output_size());
 
+  // The feedback selector should output six values:
+  //
+  //   Index | Description                 | Units
+  //   ----- | --------------------------- | --------
+  //     0   |   steering angle position   | radians
+  //     1   |   left wheel position       | radians
+  //     2   |   right wheel position      | radians
+  //     3   |   steering angle speed      | radians / sec
+  //     4   |   left wheel speed          | radians / sec
+  //     5   |   right wheel speed         | radians / sec
+  DRAKE_DEMAND(feedback_selector_matrix.rows() == 6);
+  const int kFeedbackIndexSteeringAnglePosition = 0;
+  const int kFeedbackIndexLeftWheelPosition     = 1;
+  const int kFeedbackIndexRightWheelPosition    = 2;
+  const int kFeedbackIndexSteeringAngleSpeed = 3;
+  const int kFeedbackIndexLeftWheelSpeed     = 4;
+  const int kFeedbackIndexRightWheelSpeed    = 5;
+
+  // The feedback selector should input 27 values:
+  //
+  //   Index   Description
+  //   ----- | -----------
+  //     0   |   base_x
+  //     1   |   base_y
+  //     2   |   base_z
+  //     3   |   base_qw
+  //     4   |   base_qx
+  //     5   |   base_qy
+  //     6   |   base_qz
+  //     7   |   steering
+  //     8   |   left_pin
+  //     9   |   left_wheel_joint
+  //     10  |   axle_tie_rod_arm
+  //     11  |   right_wheel_joint
+  //     12  |   rear_left_wheel_joint
+  //     13  |   rear_right_wheel_joint
+  //     14  |   base_wx
+  //     15  |   base_wy
+  //     16  |   base_wz
+  //     17  |   base_vx
+  //     18  |   base_vy
+  //     19  |   base_vz
+  //     20  |   steeringdot
+  //     21  |   left_pindot
+  //     22  |   left_wheel_jointdot
+  //     23  |   axle_tie_rod_armdot
+  //     24  |   right_wheel_jointdot
+  //     25  |   rear_left_wheel_jointdot
+  //     26  |   rear_right_wheel_jointdot
+  DRAKE_DEMAND(feedback_selector_matrix.cols() == 27);
+  const int kStateIndexSteeringAnglePosition = 7;
+  const int kStateIndexLeftWheelPosition     = 9;
+  const int kStateIndexRightWheelPosition    = 11;
+  const int kStateIndexSteeringAngleSpeed = 20;
+  const int kStateIndexLeftWheelSpeed     = 22;
+  const int kStateIndexRightWheelSpeed    = 24;
+  feedback_selector_matrix(kFeedbackIndexSteeringAnglePosition,
+                           kStateIndexSteeringAnglePosition) = 1;
+  feedback_selector_matrix(kFeedbackIndexLeftWheelPosition,
+                           kStateIndexLeftWheelPosition) = 1;
+  feedback_selector_matrix(kFeedbackIndexRightWheelPosition,
+                           kStateIndexRightWheelPosition) = 1;
+  feedback_selector_matrix(kFeedbackIndexSteeringAngleSpeed,
+                           kStateIndexSteeringAngleSpeed) = 1;
+  feedback_selector_matrix(kFeedbackIndexLeftWheelSpeed,
+                           kStateIndexLeftWheelSpeed) = 1;
+  feedback_selector_matrix(kFeedbackIndexRightWheelSpeed,
+                           kStateIndexRightWheelSpeed) = 1;
+  auto feedback_selector =
+      std::make_unique<MatrixGain<double>>(feedback_selector_matrix);
+
+  auto controller = builder.AddSystem<systems::PidControlledSystem>(
+      std::move(plant), std::move(feedback_selector), Kp, Ki, Kd);
+
+  // Instantiates a system for visualizing the model.
+  lcm::DrakeLcm lcm;
+  const RigidBodyTree& tree =
+      dynamic_cast<const RigidBodyPlant<double>*>(controller->plant())->
+          get_rigid_body_tree();
+  auto publisher = builder.AddSystem<DrakeVisualizer>(tree, &lcm);
+
+  // Instantiates a system for receiving user commands. The user command
+  // consists of the following three-vector:
+  //
+  // [steering angle position, throttle speed, brake speed]
+  //
+  // The throttle and brake speeds are with respect to the vehicle's
+  // longitudinal position.
+  //
+  const DrivingCommandTranslator driving_command_translator;
+  auto command_subscriber =
+      builder.template AddSystem<systems::lcm::LcmSubscriberSystem>(
+          "DRIVING_COMMAND", driving_command_translator, &lcm);
+
+  // Computes the gain necessary to convert from vehicle speed (m / s) to
+  // wheel rotational speed (rad / sec). Let:
+  //
+  //  - v be the vehicle speed (m / sec)
+  //  - w be the wheel rotational speed (rad / sec)
+  //  - r be the wheel's radius in (m)
+  //
+  // Let c be the number of meters the vehicle travels longitudinally per wheel
+  // rotation:
+  //
+  //    c = 2 * pi * r (m / wheel rev)
+  //
+  // Since there are 2 * pi (rad / wheel rev), the equation for w in terms of v
+  // is:
+  //
+  //    w = v / c * (2 * pi)
+  //
+  // Thus:
+  //
+  //    w / v = (2 * pi) / c
+  //          = (2 * pi) / (2 * pi * r)
+  //          = 1 / r
+  //
+  // Note that the unit of w / v is (rad / sec) / (m / sec) = (rad / m).
+  //
+  // TODO(liang.fok): Obtain the following hard-coded radius from RigidBodyTree.
+  // It is currently hard-coded to match the wheel radius specified in
+  // drake-distro/drake/automotive/models/prius/prius_with_lidar.sdf.
+  const double kWheelRadius = 0.323342;
+
+  // Instantiates a MatrixGain system to covert from user command space to
+  // actuator command space. As mentioned above, the user command space consists
+  // of the following three-vector:
+  //
+  // [steering angle position, throttle speed, brake speed]
+  //
+  // The actuator command space consists of a six-vector:
+  //
+  // [steering angle position, left wheel position, right wheel position,
+  //  steering angle speed, left wheel speed, right wheel speed]
+  //
+  // The MatrixGain system computes the following equation where `y` is the
+  // actuator command, `D` is the gain`, and `u` is the user command:
+  //
+  //   y = Du
+  //
+  // The user's steering angle position command can be passed straight
+  // through using a gain of 1. The user's throttle and brake commands need to
+  // be multiplied by a gain of 1 / kWheelRadius and -1. / kWheelRadius to get
+  // the reference rotational velocities for the left and right wheels,
+  // respectively (see calculations above that relate vehicle longitudinal speed
+  // with wheel rotational speed). Thus, the gain (`D`) should be:
+  //
+  // ---------------------------------------------------------------------
+  // Index |   kSteeringAngle   |   kThrottle         |    kBrake
+  // ---------------------------------------------------------------------
+  //   0   |         1          |       0             |      0
+  //   1   |         0          |       0             |      0
+  //   2   |         0          |       0             |      0
+  //   3   |         0          |       0             |      0
+  //   4   |         0          |  1. / kWheelRadius  | -1. / kWheelRadius
+  //   5   |         0          |  1. / kWheelRadius  | -1. / kWheelRadius
+  // ---------------------------------------------------------------------
+  //
+  // TODO(liang.fok): Add a system that accounts for the difference in reference
+  // wheel rotational velocities necessary in vehicles with Ackermann steering.
+  // When such a vehicle turns, the kinematics of the vehicle require that the
+  // wheels on the inner side of the turn rotate slower than the wheels on the
+  // outer side of the turn.
+  //
+  MatrixX<double> matrix_gain(
+      controller->get_input_port(1).get_size(),
+      command_subscriber->get_output_port(0).get_size());
+  matrix_gain <<
+      1,                 0,                  0,
+      0,                 0,                  0,
+      0,                 0,                  0,
+      0,                 0,                  0,
+      0, 1. / kWheelRadius, -1. / kWheelRadius,
+      0, 1. / kWheelRadius, -1. / kWheelRadius;
+  DRAKE_ASSERT(matrix_gain.rows() == controller->get_input_port(1).get_size());
+  DRAKE_ASSERT(matrix_gain.cols() ==
+      command_subscriber->get_output_port(0).get_size());
+
+  // TODO(liang.fok): Consider replacing the the MatrixGain system below with a
+  // custom system that converts the user's commands to the vehicle's actuator's
+  // commands. Such a system would eliminate the long explanation above about
+  // how matrix_gain was derived and instead provide named getters and setters
+  // with immediately-relevant units and scale comments.
+  auto user_to_actuator_cmd_sys =
+      builder.template AddSystem<MatrixGain<double>>(matrix_gain);
+
+  // Instantiates a constant vector source for the feed-forward torque command.
+  // The feed-forward torque is zero.
+  VectorX<double> constant_vector(controller->get_input_port(0).get_size());
+  constant_vector.setZero();
+  auto constant_zero_source =
+      builder.template AddSystem<ConstantVectorSource<double>>(constant_vector);
+
+  // TODO(liang.fok): Modify controller to provide named accessors to these
+  // ports.
+  const int kControllerFeedforwardInputPort = 0;
+  const int kControllerFeedbackInputPort = 1;
+
+  // Connects the feed-forward torque command.
+  builder.Connect(constant_zero_source->get_output_port(),
+                  controller->get_input_port(kControllerFeedforwardInputPort));
+
+  // Connects the system that converts from user commands to actuator commands.
+  builder.Connect(command_subscriber->get_output_port(0),
+                  user_to_actuator_cmd_sys->get_input_port());
+
+  // Connects the controller, which includes the plant being controlled.
+  builder.Connect(user_to_actuator_cmd_sys->get_output_port(),
+                  controller->get_input_port(kControllerFeedbackInputPort));
+
+  // Connects the LCM publisher, which is used for visualization.
+  builder.Connect(controller->get_output_port(0),
+                  publisher->get_input_port(0));
+
+  auto diagram = builder.Build();
+  lcm.StartReceiveThread();
+
+  Simulator<double> simulator(*diagram);
+
+  // TODO(liangfok): Modify System 2.0 to not require the following
+  // initialization.
+  //
+  // Zeros the state and initializes controller state.
+  systems::Context<double>* controller_context =
+      diagram->GetMutableSubsystemContext(
+          simulator.get_mutable_context(), controller);
+  controller->SetDefaultState(controller_context);
+
+  // TODO(liang.fok): Modify System 2.0 to not require the following
+  // initialization.
+  //
+  // Zeros the rigid body plant's state. This is necessary because it is by
+  // default initialized to a vector a NaN values.
+  RigidBodyPlant<double>* rigid_body_plant =
+      dynamic_cast<RigidBodyPlant<double>*>(controller->plant());
+  Context<double>* plant_context =
+      controller->GetMutableSubsystemContext(controller_context,
+                                             rigid_body_plant);
+  rigid_body_plant->SetZeroConfiguration(plant_context);
+
+  simulator.Initialize();
+  simulator.StepTo(FLAGS_simulation_sec);
   return 0;
 }
 
@@ -56,6 +366,6 @@ int main(int argc, const char* argv[]) {
 }  // namespace automotive
 }  // namespace drake
 
-int main(int argc, const char* argv[]) {
+int main(int argc, char* argv[]) {
   return drake::automotive::main(argc, argv);
 }

--- a/drake/automotive/car_sim_lcm.cc
+++ b/drake/automotive/car_sim_lcm.cc
@@ -42,7 +42,7 @@ namespace {
 
 // Verifies that the order of rigid body names and actuator names within the
 // provided tree are as expected.
-void VerifyCarSimLcmTree(const RigidBodyTree& tree) {
+void VerifyCarSimLcmTree(const RigidBodyTreed& tree) {
   DRAKE_DEMAND(tree.get_num_bodies() == 18);
 
   std::map<std::string, int> name_to_idx =
@@ -92,7 +92,7 @@ int main(int argc, char* argv[]) {
   DiagramBuilder<double> builder;
 
   // Instantiates a model of the world.
-  auto rigid_body_tree = make_unique<RigidBodyTree>();
+  auto rigid_body_tree = make_unique<RigidBodyTreed>();
   AddModelInstancesFromSdfFile(
       drake::GetDrakePath() + "/automotive/models/prius/prius_with_lidar.sdf",
       systems::plants::joints::kQuaternion, nullptr /* weld to frame */,
@@ -193,7 +193,7 @@ int main(int argc, char* argv[]) {
 
   // Instantiates a system for visualizing the model.
   lcm::DrakeLcm lcm;
-  const RigidBodyTree& tree =
+  const RigidBodyTreed& tree =
       dynamic_cast<const RigidBodyPlant<double>*>(controller->plant())->
           get_rigid_body_tree();
   auto publisher = builder.AddSystem<DrakeVisualizer>(tree, &lcm);
@@ -236,8 +236,8 @@ int main(int argc, char* argv[]) {
   //
   // Note that the unit of w / v is (rad / sec) / (m / sec) = (rad / m).
   //
-  // TODO(liang.fok): Obtain the following hard-coded radius from RigidBodyTree.
-  // It is currently hard-coded to match the wheel radius specified in
+  // TODO(liang.fok): Obtain the following hard-coded radius from tree. It is
+  // currently hard-coded to match the wheel radius specified in
   // drake-distro/drake/automotive/models/prius/prius_with_lidar.sdf.
   const double kWheelRadius = 0.323342;
 

--- a/drake/automotive/car_simulation.cc
+++ b/drake/automotive/car_simulation.cc
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <limits>
 
+#include "drake/automotive/automotive_common.h"
 #include "drake/systems/plants/joints/floating_base_types.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
 
@@ -103,7 +104,7 @@ std::shared_ptr<RigidBodySystem> CreateRigidBodySystem(
   if (argc < 3) {
     const std::shared_ptr<RigidBodyTree<double>>& tree =
         rigid_body_sys->getRigidBodyTree();
-    AddFlatTerrainToWorld(tree);
+    AddFlatTerrainToWorld(tree.get());
   }
 
   // Sets various simulation parameters.
@@ -134,24 +135,14 @@ double ParseDuration(int argc, const char* argv[]) {
   return std::numeric_limits<double>::infinity();
 }
 
+// TODO(liang.fok) Remove this method once System 1.0 is removed.
 void AddFlatTerrainToWorld(
     const std::shared_ptr<RigidBodyTree<double>>& rigid_body_tree,
     double box_size, double box_depth) {
-  DrakeShapes::Box geom(Eigen::Vector3d(box_size, box_size, box_depth));
-  Eigen::Isometry3d T_element_to_link = Eigen::Isometry3d::Identity();
-  T_element_to_link.translation() << 0, 0,
-      -box_depth / 2;  // top of the box is at z=0
-  RigidBody& world = rigid_body_tree->world();
-  Eigen::Vector4d color;
-  color << 0.9297, 0.7930, 0.6758,
-      1;  // was hex2dec({'ee','cb','ad'})'/256 in matlab
-  world.AddVisualElement(
-      DrakeShapes::VisualElement(geom, T_element_to_link, color));
-  rigid_body_tree->addCollisionElement(
-      DrakeCollision::Element(geom, T_element_to_link, &world), world,
-      "terrain");
-  rigid_body_tree->updateStaticCollisionElements();
+  AddFlatTerrainToWorld(rigid_body_tree.get(), box_size, box_depth);
 }
+
+
 
 std::shared_ptr<CascadeSystem<
     Gain<DrivingCommand1, PDControlSystem<RigidBodySystem>::InputVector>,

--- a/drake/automotive/car_simulation.h
+++ b/drake/automotive/car_simulation.h
@@ -105,6 +105,7 @@ double ParseDuration(int argc, const char* argv[]);
 DRAKE_EXPORT
 void SetRigidBodySystemParameters(RigidBodySystem* rigid_body_sys);
 
+// TODO(liang.fok) Remove this method once System 1.0 is removed.
 /**
  * Adds a box-shaped terrain to the specified rigid body tree. This directly
  * modifies the existing world rigid body within @p rigid_body_tree and thus


### PR DESCRIPTION
This is a revert of #4015, which updates the code to use the new `RigidBodyTree<T>` API.

The original PR that this is based on is #3886.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4016)
<!-- Reviewable:end -->
