### PR TITLE
Add option to drive tests from superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ option(SKIP_DRAKE_BUILD "Build external projects but not drake itself" OFF)
 # drake: For drake, list both compilation AND RUNTIME dependencies. Runtime
 # dependencies are needed because the drake project must configure only after
 # any dependencies used by MATLAB have been installed.
-drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
+drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS TEST
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake
   BINARY_DIR ${PROJECT_BINARY_DIR}/drake
   CMAKE_ARGS
@@ -328,7 +328,7 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS
 )
 
 # director
-drake_add_external(director PUBLIC CMAKE
+drake_add_external(director PUBLIC CMAKE TEST
   SOURCE_SUBDIR distro/superbuild
   CMAKE_ARGS
     -DUSE_DRAKE=ON

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -219,6 +219,11 @@ endmacro()
 # Set up properties for the Drake superbuild.
 #------------------------------------------------------------------------------
 macro(drake_setup_superbuild)
+  enable_testing()
+  set_property(DIRECTORY PROPERTY TEST_INCLUDE_FILE
+    ${CMAKE_BINARY_DIR}/CTestExternals.cmake)
+  file(REMOVE ${CMAKE_BINARY_DIR}/CTestExternals.cmake)
+
   # Set default install prefix
   if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE STRING

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -207,6 +207,11 @@ macro(drake_add_cmake_external PROJECT)
       ${_ext_VERBOSE}
       ${_ext_PROPAGATE_CACHE}
       ${_ext_CMAKE_ARGS})
+
+  if(_ext_TEST)
+    file(APPEND ${CMAKE_BINARY_DIR}/CTestExternals.cmake
+      "subdirs(\"${_ext_BINARY_DIR}\")\n")
+  endif()
 endmacro()
 
 #------------------------------------------------------------------------------
@@ -259,6 +264,7 @@ endmacro()
 #   PUBLIC - External is public
 #   CMAKE  - External uses CMake
 #   ALWAYS - External is always built
+#   TEST   - External's tests should be included in the superbuild's tests
 #
 #   REQUIRES <deps...>
 #       List of packages (checked via `find_package`) that are required to
@@ -299,7 +305,7 @@ function(drake_add_external PROJECT)
     CONFIGURE_COMMAND
     BUILD_COMMAND
     INSTALL_COMMAND)
-  set(_ext_flags LOCAL PUBLIC CMAKE ALWAYS)
+  set(_ext_flags LOCAL PUBLIC CMAKE ALWAYS TEST)
   set(_ext_sv_args
     SOURCE_SUBDIR
     SOURCE_DIR


### PR DESCRIPTION
Add machinery to optionally add tests for an external to the superbuild's tests. This will enable us to drive tests using subprojects, once that is set up for the dashboards.

This must be explicitly requested when setting up the external. For now, only `drake` and `director` use this.

@billhoffman for feature review, @jwnimmer-tri for plaform review (nominally... given it's late in the day, I suspect though you'll punt to someone else, which is fine)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4022)
<!-- Reviewable:end -->
