### PR TITLE
Set GCC-only warnings properly in SWIG

### DIFF
--- a/drake/bindings/swig/CMakeLists.txt
+++ b/drake/bindings/swig/CMakeLists.txt
@@ -14,12 +14,12 @@ set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY
   COMPILE_OPTIONS ${CXX_FLAGS_NO_ERROR_SHADOW})
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # Suppresses warnings due to the existence of deprecated methods. These
-  # deprecated methods should still be made available through the SWIG-generated
-  # APIs until they are actually removed from the original C++ APIs.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+# Suppresses warnings due to the existence of deprecated methods. These
+# deprecated methods should still be made available through the SWIG-generated
+# APIs until they are actually removed from the original C++ APIs.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # Swig sometimes emits code which appears to have uninitialized
   # variables.  Err on the side of swig being correct.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")


### PR DESCRIPTION
 - Remove 'if clang or gcc' since it's always the case.
 - maybe-uninitialized and misleading-indentation are GCC-only warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4024)
<!-- Reviewable:end -->
