### PR TITLE
Update drake instructions to include cpp lint integration with CLion

### DIFF
--- a/drake/common/test/cpplint_wrapper.py
+++ b/drake/common/test/cpplint_wrapper.py
@@ -89,9 +89,6 @@ def multiprocess_cpplint(cmdline, files, args):
 
     # Act on the results.
     num_errors = len(errors)
-    err_dest = sys.stderr
-    if args.allstdout is True:
-        err_dest = sys.stdout
     if num_errors == 0:
         print ' TOTAL %d files passed' % len(files)
         return 0
@@ -99,7 +96,7 @@ def multiprocess_cpplint(cmdline, files, args):
         print ' TOTAL %d files checked, found %d warnings' % (
             len(files), num_errors)
         for line in errors:
-            print >>err_dest, line
+            print >>sys.stdout, line
         return 1
 
 
@@ -132,10 +129,6 @@ def main():
     parser.add_argument(
         '--num-processes', metavar='N', type=int, default=None,
         help='limit to this number of processes (default all CPUs)')
-    parser.add_argument(
-        '--allstdout', action='store_true',
-        dest='allstdout', default='False',
-        help='Writes error messages to std out, otherwise written to std err' )
     parser.add_argument(
         'pathnames', nargs='*', default=[drake_dir, drake_ros_dir],
         help='list of files and/or directories to check'

--- a/drake/common/test/cpplint_wrapper.py
+++ b/drake/common/test/cpplint_wrapper.py
@@ -89,6 +89,9 @@ def multiprocess_cpplint(cmdline, files, args):
 
     # Act on the results.
     num_errors = len(errors)
+    err_dest = sys.stderr
+    if args.allstdout is True:
+        err_dest = sys.stdout
     if num_errors == 0:
         print ' TOTAL %d files passed' % len(files)
         return 0
@@ -96,7 +99,7 @@ def multiprocess_cpplint(cmdline, files, args):
         print ' TOTAL %d files checked, found %d warnings' % (
             len(files), num_errors)
         for line in errors:
-            print >>sys.stderr, line
+            print >>err_dest, line
         return 1
 
 
@@ -129,6 +132,10 @@ def main():
     parser.add_argument(
         '--num-processes', metavar='N', type=int, default=None,
         help='limit to this number of processes (default all CPUs)')
+    parser.add_argument(
+        '--allstdout', action='store_true',
+        dest='allstdout', default='False',
+        help='Writes error messages to std out, otherwise written to std err' )
     parser.add_argument(
         'pathnames', nargs='*', default=[drake_dir, drake_ros_dir],
         help='list of files and/or directories to check'

--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -110,20 +110,20 @@ Creating the External Tools
 .. role:: raw-html(raw)
    :format: html
 
-Run Cpp Lint on Single File
+Run Cpplint on Single File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 1. Open the Settings (File > Settings) or `Alt+Ctrl+S`.
 2. Navigate to Tools > External Tools.
 3. Click the :raw-html:`<font size="5" color="green">+</font>` sign to add a new tool.
 4. Add the following values in the following fields:
 
-   :Name: Cpp Lint File
-   :Description: Apply cpp lint to the current file.
+   :Name: Cpplint File
+   :Description: Apply cpplint to the current file.
    :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
    :Parameters: --allstdout $FilePath$
    :Working directory: $ProjectFileDir$
 5. Make sure that *only* the following Options are checked (the "Synchronize files
-   after execution" is unnecessary because cpp lint is a read-only operation):
+   after execution" is unnecessary because cpplint is a read-only operation):
 
    - Open Console 
    - Main Menu
@@ -139,15 +139,15 @@ Run Cpp Lint on Single File
 9. Click "Ok" on the "Edit filter" dialog.
 10. Click "OK" on the "Output Filters" dialog.
 
-Run Cpp Lint on Full Project
+Run CppLint on Full Project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Repeat the steps from creating the single-file version with the following
 differences:
 
 4. Set the fields as follows:
 
-    :Name: Cpp Lint Project
-    :Description: Apply cpp lint to the entire project.
+    :Name: Cpplint Project
+    :Description: Apply cpplint to the entire project.
     :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
     :Parameters: --allstdout 
     :Working directory: $ProjectFileDir$

--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -120,9 +120,10 @@ Run Cpp Lint on Single File
    :Name: Cpp Lint File
    :Description: Apply cpp lint to the current file.
    :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
-   :Parameters: $FilePath$
+   :Parameters: --allstdout $FilePath$
    :Working directory: $ProjectFileDir$
-5. Make sure that *only* the following Options are checked (the "Synchronize files after execution" is unnecessary because cpp lint is a read-only operation):
+5. Make sure that *only* the following Options are checked (the "Synchronize files
+   after execution" is unnecessary because cpp lint is a read-only operation):
 
    - Open Console 
    - Main Menu
@@ -148,26 +149,13 @@ differences:
     :Name: Cpp Lint Project
     :Description: Apply cpp lint to the entire project.
     :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
-    :Parameters: <leave empty>
+    :Parameters: --allstdout 
     :Working directory: $ProjectFileDir$
 Continue on with steps 5 to the end.
 
 Executing
 ^^^^^^^^^
 The external tools can be executed by going to Tools > External Tools > [Tool Name].
-
-Notes
-^^^^^
-There appears to be a race condition. If the python program prints the
-results before it lists the summary (e.g., `Total X files checked, found Y 
-warnings`), then the first warning will not be properly extracted.  This happens
-occasionally when running on individual files.  It is less likely when running
-cpp lint on the full project, but it is still possible.  So, confirm that the
-console reports zero warnings. This is particularly important when evaluating
-the full project; cpplint wil print hundreds of "." characters which the 
-console does *not* wrap.  If the race condition affects you, the warning will
-be appended to this very long string, out of view. The summary will let you
-know if this has happened.
 
 Running a C++ executable
 ========================

--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -98,9 +98,10 @@ You can also set the coding style through the following steps
 3. Go to File > Settings > Editor > Code Style > C/C++
 4. On the right panel, choose Set from > Predefined Style > Google
 
+.. _integrating_cpplint_with_clion:
 Integrating Cpplint in CLion
 ============================
-This will give you the ability to execute cpplint on a single file or the full
+This will give you the ability to execute ``cpplint`` on a single file or the full
 project and have the result presented in the CLion console with each warning
 a clickable hyperlink.
 
@@ -110,7 +111,7 @@ Creating the External Tools
 .. role:: raw-html(raw)
    :format: html
 
-Run Cpplint on Single File
+Run ``Cpplint`` on Single File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 1. Open the Settings dialog (``File`` > ``Settings``) or ``Alt+Ctrl+S``.
 2. Navigate to ``Tools`` > ``External Tools``.
@@ -140,7 +141,7 @@ Run Cpplint on Single File
 9. Click ``OK`` on the ``Edit filter`` dialog.
 10. Click ``OK`` on the ``Output Filters`` dialog.
 
-Run CppLint on Full Project
+Run ``CppLint`` on Full Project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Repeat the steps from creating the single-file version with the following
 differences:
@@ -172,8 +173,8 @@ in two ways:
 2. in the menu bar, select ``Tools`` > ``External Tools`` > ``Cpplint File``
 
 To check the whole project, in the menu bar, select ``Tools`` > 
-``External Tools`` > ``Cpplint Project`` (alternatively, this can also be
-done through the right-click context menu.)
+``External Tools`` > ``Cpplint Project``. Alternatively, this can also be
+done through the right-click context menu.
 
 Running a C++ executable
 ========================

--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -98,6 +98,67 @@ You can also set the coding style through the following steps
 3. Go to File > Settings > Editor > Code Style > C/C++
 4. On the right panel, choose Set from > Predefined Style > Google
 
+Integrating Cpplint in CLion
+============================
+This will give you the ability to execute cpplint on a single file or the full
+project and have the result presented in the CLion console with each warning
+a clickable hyperlink.
+
+Creating the External Tools
+--------------------------
+
+.. role:: raw-html(raw)
+   :format: html
+
+Run Cpp Lint on Single File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1. Open the Settings (File > Settings) or `Alt+Ctrl+S`.
+2. Navigate to Tools > External Tools.
+3. Click the :raw-html:`<font size="5" color="green">+</font>` sign to add a new tool.
+4. Add the following values in the following fields:
+
+   :Name: Cpp Lint File
+   :Description: Apply cpp lint to the current file.
+   :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
+   :Parameters: $FilePath$
+   :Working directory: $ProjectFileDir$
+5. Make sure that *only* the following Options are checked:
+
+   - Open Console 
+   - Main Menu
+   - Editor Menu
+   - Project views
+6. Click the "Output Filters..." button.
+7. Click the :raw-html:`<font size="5" color="green">+</font>` sign to add a filter.
+8. Add the following values in the following fields (and click "OK):
+
+   :Name: Extract Links
+   :Description: Convert file/line references into clickable links.
+   :Regular expression to match output: $FILE_PATH$:$LINE$
+
+Run Cpp Lint on Full Project
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Repeat the steps from creating the single-file version with the following
+differences:
+
+4. Set the fields as follows:
+    :Name: Cpp Lint Project
+    :Description: Apply cpp lint to the entire project.
+    :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
+    :Parameters: <leave empty>
+    :Working directory: $ProjectFileDir$
+
+Executing
+^^^^^^^^^
+The external tools can be executed by going to Tools > External Tools > [Tool Name].
+
+Notes
+^^^^^
+There appears to be a race condition. If the python program prints the
+results before it lists the summary (e.g., `Total X files checked, found Y 
+warnings`), then the first warning will not be properly extracted.  This happens
+occasionally when running on individual files.  It is less likely when running
+cpp lint on the full project.
 
 Running a C++ executable
 ========================

--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -122,7 +122,7 @@ Run Cpp Lint on Single File
    :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
    :Parameters: $FilePath$
    :Working directory: $ProjectFileDir$
-5. Make sure that *only* the following Options are checked:
+5. Make sure that *only* the following Options are checked (the "Synchronize files after execution" is unnecessary because cpp lint is a read-only operation):
 
    - Open Console 
    - Main Menu
@@ -135,6 +135,8 @@ Run Cpp Lint on Single File
    :Name: Extract Links
    :Description: Convert file/line references into clickable links.
    :Regular expression to match output: $FILE_PATH$:$LINE$
+9. Click "Ok" on the "Edit filter" dialog.
+10. Click "OK" on the "Output Filters" dialog.
 
 Run Cpp Lint on Full Project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -142,11 +144,13 @@ Repeat the steps from creating the single-file version with the following
 differences:
 
 4. Set the fields as follows:
+
     :Name: Cpp Lint Project
     :Description: Apply cpp lint to the entire project.
     :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
     :Parameters: <leave empty>
     :Working directory: $ProjectFileDir$
+Continue on with steps 5 to the end.
 
 Executing
 ^^^^^^^^^
@@ -158,7 +162,12 @@ There appears to be a race condition. If the python program prints the
 results before it lists the summary (e.g., `Total X files checked, found Y 
 warnings`), then the first warning will not be properly extracted.  This happens
 occasionally when running on individual files.  It is less likely when running
-cpp lint on the full project.
+cpp lint on the full project, but it is still possible.  So, confirm that the
+console reports zero warnings. This is particularly important when evaluating
+the full project; cpplint wil print hundreds of "." characters which the 
+console does *not* wrap.  If the race condition affects you, the warning will
+be appended to this very long string, out of view. The summary will let you
+know if this has happened.
 
 Running a C++ executable
 ========================

--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -112,32 +112,33 @@ Creating the External Tools
 
 Run Cpplint on Single File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-1. Open the Settings (File > Settings) or `Alt+Ctrl+S`.
-2. Navigate to Tools > External Tools.
+1. Open the Settings dialog (``File`` > ``Settings``) or ``Alt+Ctrl+S``.
+2. Navigate to ``Tools`` > ``External Tools``.
 3. Click the :raw-html:`<font size="5" color="green">+</font>` sign to add a new tool.
 4. Add the following values in the following fields:
 
-   :Name: Cpplint File
-   :Description: Apply cpplint to the current file.
-   :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
-   :Parameters: --allstdout $FilePath$
-   :Working directory: $ProjectFileDir$
-5. Make sure that *only* the following Options are checked (the "Synchronize files
-   after execution" is unnecessary because cpplint is a read-only operation):
+   :Name: ``Cpplint File``
+   :Description: ``Apply cpplint to the current file.``
+   :Program: ``$ProjectFileDir$/common/test/cpplint_wrapper.py``
+   :Parameters: ``$FilePath$``
+   :Working directory: ``$ProjectFileDir$``
+5. Make sure that *only* the following Options are checked (the 
+   ``Synchronize files after execution`` is unnecessary because cpplint is
+   a read-only operation):
 
-   - Open Console 
-   - Main Menu
-   - Editor Menu
-   - Project views
-6. Click the "Output Filters..." button.
+   - ``Open Console``
+   - ``Main Menu``
+   - ``Editor Menu``
+   - ``Project views``
+6. Click the ``Output Filters...`` button.
 7. Click the :raw-html:`<font size="5" color="green">+</font>` sign to add a filter.
 8. Add the following values in the following fields (and click "OK):
 
-   :Name: Extract Links
-   :Description: Convert file/line references into clickable links.
-   :Regular expression to match output: $FILE_PATH$:$LINE$
-9. Click "Ok" on the "Edit filter" dialog.
-10. Click "OK" on the "Output Filters" dialog.
+   :Name: ``Extract Links``
+   :Description: ``Convert file/line references into clickable links.``
+   :Regular expression to match output: ``$FILE_PATH$:$LINE$``
+9. Click ``OK`` on the ``Edit filter`` dialog.
+10. Click ``OK`` on the ``Output Filters`` dialog.
 
 Run CppLint on Full Project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -146,16 +147,33 @@ differences:
 
 4. Set the fields as follows:
 
-    :Name: Cpplint Project
-    :Description: Apply cpplint to the entire project.
-    :Program: $ProjectFileDir$/common/test/cpplint_wrapper.py
-    :Parameters: --allstdout 
-    :Working directory: $ProjectFileDir$
+    :Name: ``Cpplint Project``
+    :Description: ``Apply cpplint to the entire project.``
+    :Program: ``$ProjectFileDir$/common/test/cpplint_wrapper.py``
+    :Parameters: <empty>
+    :Working directory: ``$ProjectFileDir$``
 Continue on with steps 5 to the end.
 
 Executing
 ^^^^^^^^^
-The external tools can be executed by going to Tools > External Tools > [Tool Name].
+The external tools you've created can be exercised in one of several ways, 
+depending on whether you're doing a single-file or full-project operation.
+
+To check a single file, select the file that you want to be worked on to be
+"active".  This can be done by clicking on the file so the cursor lies in
+the file, or by clicking on the file's tab.  The path to the active file
+will be displayed in the title bar.
+
+Once the file is "active", the ``Cpplint File`` External Tool can be invoked
+in two ways:
+
+1. Right-click on the document (or tab) and select ``External Tools`` > 
+   ``Cpplint File``, or
+2. in the menu bar, select ``Tools`` > ``External Tools`` > ``Cpplint File``
+
+To check the whole project, in the menu bar, select ``Tools`` > 
+``External Tools`` > ``Cpplint Project`` (alternatively, this can also be
+done through the right-click context menu.)
 
 Running a C++ executable
 ========================


### PR DESCRIPTION
This gives instructions (and appropriate user warnings) for setting up cpp lint to run within CLion such that the warning messages become clickable links.  The instructions have been run through by one independent part so far with success (@sherm1).

+@sammy-tri for platform review and +@amcastro-tri for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4027)
<!-- Reviewable:end -->
