### PR TITLE
Backfill another old-Eigen bug

### DIFF
--- a/drake/math/autodiff_overloads.h
+++ b/drake/math/autodiff_overloads.h
@@ -82,3 +82,16 @@ Eigen::AutoDiffScalar<typename DerTypeA::PlainObject> pow(
       x_to_the_y * log(x) * ygrad);
 }
 #endif  // EIGEN_VERSION...
+
+#if !EIGEN_VERSION_AT_LEAST(3, 2, 93)  // False when built via Drake superbuild.
+namespace Eigen {
+/// Overloads max to mimic std::max from <algorithm>.
+/// Required for old, broken Eigen versions.
+template <typename DerType>
+const Eigen::AutoDiffScalar<DerType>& max(
+    const Eigen::AutoDiffScalar<DerType>& x,
+    const Eigen::AutoDiffScalar<DerType>& y) {
+  return (x > y) ? x : y;
+}
+}
+#endif  // EIGEN_VERSION...

--- a/drake/systems/analysis/simulator.cc
+++ b/drake/systems/analysis/simulator.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/analysis/simulator.h"
 
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/math/autodiff_overloads.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/difference_state.cc
+++ b/drake/systems/framework/difference_state.cc
@@ -1,7 +1,7 @@
 #include "drake/systems/framework/difference_state.h"
 
-
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/math/autodiff_overloads.h"
 
 namespace drake {
 namespace systems {


### PR DESCRIPTION
It is looking like I won't be able to stay on old-Eigen for long.  I'll work on prioritizing porting the other project to bleeding-edge Eigen, but for now this patch gets me compiling again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4032)
<!-- Reviewable:end -->
