### PR TITLE
Do not build swig_matlab examples and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ drake_add_external(swig_matlab PUBLIC
       LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}
     ./configure
       --prefix=${CMAKE_INSTALL_PREFIX}
-      --with-matlab
+      --without-alllang
   INSTALL_COMMAND
     # TODO(jamiesnape): Check whether environment variables are actually used
     ${CMAKE_COMMAND} -E env


### PR DESCRIPTION
The `--with-` and `--without-` options actually refer to examples and the test suite. All the necessary files to create bindings in any supported language (including MATLAB and Python 2/3) are always installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4036)
<!-- Reviewable:end -->
