### PR TITLE
Use override in drake/systems/trajectories

### DIFF
--- a/drake/systems/trajectories/ExponentialPlusPiecewisePolynomial.h
+++ b/drake/systems/trajectories/ExponentialPlusPiecewisePolynomial.h
@@ -59,9 +59,9 @@ class DRAKE_EXPORT ExponentialPlusPiecewisePolynomial
 
   ExponentialPlusPiecewisePolynomial derivative(int derivative_order = 1) const;
 
-  virtual Eigen::Index rows() const;
+  Eigen::Index rows() const override;
 
-  virtual Eigen::Index cols() const;
+  Eigen::Index cols() const override;
 
   void shiftRight(double offset);
 };

--- a/drake/systems/trajectories/PiecewisePolynomial.h
+++ b/drake/systems/trajectories/PiecewisePolynomial.h
@@ -148,13 +148,13 @@ class DRAKE_EXPORT PiecewisePolynomial
   const PolynomialType& getPolynomial(int segment_index, Eigen::Index row = 0,
                                       Eigen::Index col = 0) const;
 
-  virtual int getSegmentPolynomialDegree(int segment_index,
-                                         Eigen::Index row = 0,
-                                         Eigen::Index col = 0) const;
+  int getSegmentPolynomialDegree(int segment_index,
+                                 Eigen::Index row = 0,
+                                 Eigen::Index col = 0) const override;
 
-  virtual Eigen::Index rows() const;
+  Eigen::Index rows() const override;
 
-  virtual Eigen::Index cols() const;
+  Eigen::Index cols() const override;
 
   PiecewisePolynomial& operator+=(const PiecewisePolynomial& other);
 


### PR DESCRIPTION
I had hoped to turn on `-Werror=suggest-override` on GCC.  However, turns out it was only added in GCC 5.1, and we still support GCC < 5.

+@jwnimmer-tri for both levels of review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4046)
<!-- Reviewable:end -->
