### PR TITLE
Added text_logging_gflags.h as an installed header for downstream projects to use.

### DIFF
--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -49,6 +49,7 @@ set(installed_headers
   symbolic_variable.h
   symbolic_variables.h
   text_logging.h
+  text_logging_gflags.h
   trig_poly.h
   )
 


### PR DESCRIPTION
I discovered this while working on a project that depends on Drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4047)
<!-- Reviewable:end -->
