### PR TITLE
Remove DRAKE_EXPORT from template class instantiations

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -333,7 +333,7 @@ int AutomotiveSimulator<T>::allocate_vehicle_number() {
   return next_vehicle_number_++;
 }
 
-template class DRAKE_EXPORT AutomotiveSimulator<double>;
+template class AutomotiveSimulator<double>;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/idm_with_trajectory_agent.cc
+++ b/drake/automotive/idm_with_trajectory_agent.cc
@@ -115,9 +115,9 @@ IdmWithTrajectoryAgent<T>::AllocateOutputVector(
 
 // These instantiations must match the API documentation in
 // idm_with_trajectory_agent.h.
-template class DRAKE_EXPORT IdmWithTrajectoryAgent<double>;
-template class DRAKE_EXPORT IdmWithTrajectoryAgent<drake::TaylorVarXd>;
-template class DRAKE_EXPORT IdmWithTrajectoryAgent<drake::symbolic::Expression>;
+template class IdmWithTrajectoryAgent<double>;
+template class IdmWithTrajectoryAgent<drake::TaylorVarXd>;
+template class IdmWithTrajectoryAgent<drake::symbolic::Expression>;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/simple_car.cc
+++ b/drake/automotive/simple_car.cc
@@ -157,11 +157,11 @@ std::unique_ptr<systems::BasicVector<T>> SimpleCar<T>::AllocateOutputVector(
 }
 
 // These instantiations must match the API documentation in simple_car.h.
-template class DRAKE_EXPORT SimpleCar<double>;
+template class SimpleCar<double>;
 #if EIGEN_VERSION_AT_LEAST(3, 2, 93)  // True when built via Drake superbuild.
-template class DRAKE_EXPORT SimpleCar<drake::TaylorVarXd>;
+template class SimpleCar<drake::TaylorVarXd>;
 #endif
-template class DRAKE_EXPORT SimpleCar<drake::symbolic::Expression>;
+template class SimpleCar<drake::symbolic::Expression>;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/common/polynomial.cc
+++ b/drake/common/polynomial.cc
@@ -606,7 +606,7 @@ void Polynomial<CoefficientType>::MakeMonomialsUnique(void) {
   }
 }
 
-template class DRAKE_EXPORT Polynomial<double>;
+template class Polynomial<double>;
 
-// template class DRAKE_EXPORT Polynomial<std::complex<double>>;
+// template class Polynomial<std::complex<double>>;
 // doesn't work yet because the roots solver can't handle it

--- a/drake/examples/Pendulum/pendulum_plant.cc
+++ b/drake/examples/Pendulum/pendulum_plant.cc
@@ -84,8 +84,8 @@ PendulumPlant<AutoDiffXd>* PendulumPlant<T>::DoToAutoDiffXd() const {
   return new PendulumPlant<AutoDiffXd>();
 }
 
-template class DRAKE_EXPORT PendulumPlant<double>;
-template class DRAKE_EXPORT PendulumPlant<AutoDiffXd>;
+template class PendulumPlant<double>;
+template class PendulumPlant<AutoDiffXd>;
 
 }  // namespace pendulum
 }  // namespace examples

--- a/drake/examples/bouncing_ball/ball.cc
+++ b/drake/examples/bouncing_ball/ball.cc
@@ -7,8 +7,8 @@
 namespace drake {
 namespace bouncing_ball {
 
-template class DRAKE_EXPORT Ball<double>;
-template class DRAKE_EXPORT Ball<AutoDiffXd>;
+template class Ball<double>;
+template class Ball<AutoDiffXd>;
 
 }  // namespace bouncing_ball
 }  // namespace drake

--- a/drake/examples/bouncing_ball/bouncing_ball.cc
+++ b/drake/examples/bouncing_ball/bouncing_ball.cc
@@ -7,8 +7,8 @@
 namespace drake {
 namespace bouncing_ball {
 
-template class DRAKE_EXPORT BouncingBall<double>;
-template class DRAKE_EXPORT BouncingBall<AutoDiffXd>;
+template class BouncingBall<double>;
+template class BouncingBall<AutoDiffXd>;
 
 }  // namespace bouncing_ball
 }  // namespace drake

--- a/drake/solvers/system_identification.cpp
+++ b/drake/solvers/system_identification.cpp
@@ -479,5 +479,5 @@ std::tuple<const std::set<typename SystemIdentification<T>::VarType>,
 }  // namespace solvers
 }  // namespace drake
 
-template class DRAKE_EXPORT
+template class
 drake::solvers::SystemIdentification<double>;

--- a/drake/solvers/system_identification.cpp
+++ b/drake/solvers/system_identification.cpp
@@ -479,5 +479,4 @@ std::tuple<const std::set<typename SystemIdentification<T>::VarType>,
 }  // namespace solvers
 }  // namespace drake
 
-template class
-drake::solvers::SystemIdentification<double>;
+template class drake::solvers::SystemIdentification<double>;

--- a/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.cc
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.cc
@@ -136,12 +136,8 @@ const {
   return *plant_;
 }
 
-template class
-DRAKE_EXPORT
-PidControlledSpringMassSystem<double>;
-template class
-DRAKE_EXPORT
-PidControlledSpringMassSystem<AutoDiffXd>;
+template class PidControlledSpringMassSystem<double>;
+template class PidControlledSpringMassSystem<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/controllers/gravity_compensator.cc
+++ b/drake/systems/controllers/gravity_compensator.cc
@@ -34,9 +34,9 @@ void GravityCompensator<T>::EvalOutput(const Context<T>& context,
   System<T>::GetMutableOutputVector(output, 0) = g;
 }
 
-template class DRAKE_EXPORT GravityCompensator<double>;
+template class GravityCompensator<double>;
 // TODO(naveenoid): Get the AutoDiff working as in the line below.
-// template class DRAKE_EXPORT GravityCompensator<AutoDiffXd>;
+// template class GravityCompensator<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -132,8 +132,8 @@ void PidControlledSystem<T>::SetDefaultState(
       VectorX<T>::Zero(plant_->get_input_port(0).get_size()));
 }
 
-template class DRAKE_EXPORT PidControlledSystem<double>;
-template class DRAKE_EXPORT PidControlledSystem<AutoDiffXd>;
+template class PidControlledSystem<double>;
+template class PidControlledSystem<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -121,8 +121,8 @@ void PidController<T>::set_integral_value(
   integrator_->set_integral_value(integrator_context, value);
 }
 
-template class DRAKE_EXPORT PidController<double>;
-template class DRAKE_EXPORT PidController<AutoDiffXd>;
+template class PidController<double>;
+template class PidController<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/adder.cc
+++ b/drake/systems/framework/primitives/adder.cc
@@ -46,8 +46,8 @@ void Adder<T>::EvalOutput(const Context<T>& context,
 }
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_EXPORT Adder<double>;
-template class DRAKE_EXPORT Adder<AutoDiffXd>;
+template class Adder<double>;
+template class Adder<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/affine_system.cc
+++ b/drake/systems/framework/primitives/affine_system.cc
@@ -94,8 +94,8 @@ void AffineSystem<T>::EvalTimeDerivatives(
   derivatives->SetFromVector(A_ * x + B_ * u + xDot0_);
 }
 
-template class DRAKE_EXPORT AffineSystem<double>;
-template class DRAKE_EXPORT AffineSystem<AutoDiffXd>;
+template class AffineSystem<double>;
+template class AffineSystem<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/constant_value_source.cc
+++ b/drake/systems/framework/primitives/constant_value_source.cc
@@ -5,7 +5,7 @@ namespace drake {
 namespace systems {
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_EXPORT ConstantValueSource<double>;
+template class ConstantValueSource<double>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/constant_vector_source.cc
+++ b/drake/systems/framework/primitives/constant_vector_source.cc
@@ -39,8 +39,8 @@ void ConstantVectorSource<T>::EvalOutput(const Context<T>& context,
 }
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_EXPORT ConstantVectorSource<double>;
-template class DRAKE_EXPORT ConstantVectorSource<AutoDiffXd>;
+template class ConstantVectorSource<double>;
+template class ConstantVectorSource<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/demultiplexer.cc
+++ b/drake/systems/framework/primitives/demultiplexer.cc
@@ -40,8 +40,8 @@ void Demultiplexer<T>::EvalOutput(const Context<T>& context,
   }
 }
 
-template class DRAKE_EXPORT Demultiplexer<double>;
-template class DRAKE_EXPORT Demultiplexer<AutoDiffXd>;
+template class Demultiplexer<double>;
+template class Demultiplexer<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/gain.cc
+++ b/drake/systems/framework/primitives/gain.cc
@@ -6,8 +6,8 @@
 namespace drake {
 namespace systems {
 
-template class DRAKE_EXPORT Gain<double>;
-template class DRAKE_EXPORT Gain<AutoDiffXd>;
+template class Gain<double>;
+template class Gain<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/integrator.cc
+++ b/drake/systems/framework/primitives/integrator.cc
@@ -74,8 +74,8 @@ void Integrator<T>::EvalOutput(const Context<T>& context,
 
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_EXPORT Integrator<double>;
-template class DRAKE_EXPORT Integrator<AutoDiffXd>;
+template class Integrator<double>;
+template class Integrator<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/linear_system.cc
+++ b/drake/systems/framework/primitives/linear_system.cc
@@ -15,8 +15,8 @@ LinearSystem<T>::LinearSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
                       Eigen::VectorXd::Zero(C.rows())) {}
 // TODO(naveenoid): Modify constructor to accommodate 0 dimension systems;
 // i.e. in initializing xDot0 and y0 with a zero matrix.
-template class DRAKE_EXPORT LinearSystem<double>;
-template class DRAKE_EXPORT LinearSystem<AutoDiffXd>;
+template class LinearSystem<double>;
+template class LinearSystem<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/matrix_gain.cc
+++ b/drake/systems/framework/primitives/matrix_gain.cc
@@ -21,8 +21,8 @@ MatrixGain<T>::MatrixGain(const Eigen::MatrixXd& D)
                       Eigen::MatrixXd::Zero(D.rows(), kNumStates),    // C
                       D) {}
 
-template class DRAKE_EXPORT MatrixGain<double>;
-template class DRAKE_EXPORT MatrixGain<AutoDiffXd>;
+template class MatrixGain<double>;
+template class MatrixGain<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/multiplexer.cc
+++ b/drake/systems/framework/primitives/multiplexer.cc
@@ -36,7 +36,7 @@ void Multiplexer<T>::EvalOutput(const Context<T>& context,
   }
 }
 
-template class DRAKE_EXPORT Multiplexer<double>;
+template class Multiplexer<double>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/pass_through.cc
+++ b/drake/systems/framework/primitives/pass_through.cc
@@ -6,8 +6,8 @@
 namespace drake {
 namespace systems {
 
-template class DRAKE_EXPORT PassThrough<double>;
-template class DRAKE_EXPORT PassThrough<AutoDiffXd>;
+template class PassThrough<double>;
+template class PassThrough<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/trajectory_source.cc
+++ b/drake/systems/framework/primitives/trajectory_source.cc
@@ -26,7 +26,7 @@ void TrajectorySource<T>::EvalOutput(
 }
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_EXPORT TrajectorySource<double>;
+template class TrajectorySource<double>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/zero_order_hold.cc
+++ b/drake/systems/framework/primitives/zero_order_hold.cc
@@ -6,8 +6,8 @@
 namespace drake {
 namespace systems {
 
-template class DRAKE_EXPORT ZeroOrderHold<double>;
-template class DRAKE_EXPORT ZeroOrderHold<AutoDiffXd>;
+template class ZeroOrderHold<double>;
+template class ZeroOrderHold<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/plants/RigidBodyTree.cpp
+++ b/drake/systems/plants/RigidBodyTree.cpp
@@ -3015,4 +3015,4 @@ template DRAKE_EXPORT int RigidBodyTree<double>::parseBodyOrFrameID(
     Eigen::Transform<double, 3, Eigen::Isometry>* Tframe) const;
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_EXPORT RigidBodyTree<double>;
+template class RigidBodyTree<double>;

--- a/drake/systems/plants/rigid_body_plant/kinematics_results.cc
+++ b/drake/systems/plants/rigid_body_plant/kinematics_results.cc
@@ -65,7 +65,7 @@ void KinematicsResults<T>::UpdateFromContext(const Context<T> &context) {
 }
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_EXPORT KinematicsResults<double>;
+template class KinematicsResults<double>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/systems/plants/rigid_body_plant/rigid_body_plant.cc
@@ -409,7 +409,7 @@ T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint,
 
 
 // Explicitly instantiates on the most common scalar types.
-template class DRAKE_EXPORT RigidBodyPlant<double>;
+template class RigidBodyPlant<double>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -186,13 +186,13 @@ void SpringMassSystem<T>::EvalTimeDerivatives(
   derivative_vector->set_conservative_work(EvalConservativePower(context));
 }
 
-template class DRAKE_EXPORT
+template class
 SpringMassStateVector<double>;
-template class DRAKE_EXPORT
+template class
 SpringMassStateVector<AutoDiffXd>;
-template class DRAKE_EXPORT
+template class
 SpringMassSystem<double>;
-template class DRAKE_EXPORT
+template class
 SpringMassSystem<AutoDiffXd>;
 
 }  // namespace systems

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -186,14 +186,10 @@ void SpringMassSystem<T>::EvalTimeDerivatives(
   derivative_vector->set_conservative_work(EvalConservativePower(context));
 }
 
-template class
-SpringMassStateVector<double>;
-template class
-SpringMassStateVector<AutoDiffXd>;
-template class
-SpringMassSystem<double>;
-template class
-SpringMassSystem<AutoDiffXd>;
+template class SpringMassStateVector<double>;
+template class SpringMassStateVector<AutoDiffXd>;
+template class SpringMassSystem<double>;
+template class SpringMassSystem<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/trajectories/ExponentialPlusPiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/ExponentialPlusPiecewisePolynomial.cpp
@@ -75,5 +75,5 @@ void ExponentialPlusPiecewisePolynomial<CoefficientType>::shiftRight(
   piecewise_polynomial_part_.shiftRight(offset);
 }
 
-template class DRAKE_EXPORT
+template class
     ExponentialPlusPiecewisePolynomial<double>;

--- a/drake/systems/trajectories/ExponentialPlusPiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/ExponentialPlusPiecewisePolynomial.cpp
@@ -75,5 +75,4 @@ void ExponentialPlusPiecewisePolynomial<CoefficientType>::shiftRight(
   piecewise_polynomial_part_.shiftRight(offset);
 }
 
-template class
-    ExponentialPlusPiecewisePolynomial<double>;
+template class ExponentialPlusPiecewisePolynomial<double>;

--- a/drake/systems/trajectories/PiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/PiecewisePolynomial.cpp
@@ -344,5 +344,5 @@ PiecewisePolynomial<CoefficientType> PiecewisePolynomial<
 }
 
 template class PiecewisePolynomial<double>;
-// template class
-// PiecewisePolynomial<std::complex<double>>; // doesn't work yet
+// doesn't work yet
+// template class PiecewisePolynomial<std::complex<double>>;

--- a/drake/systems/trajectories/PiecewisePolynomial.cpp
+++ b/drake/systems/trajectories/PiecewisePolynomial.cpp
@@ -343,6 +343,6 @@ PiecewisePolynomial<CoefficientType> PiecewisePolynomial<
   return PiecewisePolynomial<CoefficientType>(polynomials, segment_times);
 }
 
-template class DRAKE_EXPORT PiecewisePolynomial<double>;
-// template class DRAKE_EXPORT
+template class PiecewisePolynomial<double>;
+// template class
 // PiecewisePolynomial<std::complex<double>>; // doesn't work yet


### PR DESCRIPTION
This is the portion of #3973 that is actively generating warnings.

Note that some include statements may be vestigial now.  Trust that a future PR will remove all includes of drake_export.h from within the project.

See prior discussion in #3668.

Label "curate" because this PR should squash-and-merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4048)
<!-- Reviewable:end -->
