### PR TITLE
Remove DRAKE_EXPORT from automotive

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -6,7 +6,6 @@
 #include "drake/automotive/simple_car.h"
 #include "drake/automotive/simple_car_to_euler_floating_joint.h"
 #include "drake/automotive/trajectory_car.h"
-#include "drake/common/drake_export.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/text_logging.h"
 #include "drake/lcm/drake_lcm.h"

--- a/drake/automotive/car_simulation.h
+++ b/drake/automotive/car_simulation.h
@@ -7,7 +7,6 @@
 
 #include "drake/automotive/gen/driving_command.h"
 #include "drake/automotive/system1_vector.h"
-#include "drake/common/drake_export.h"
 #include "drake/system1/LinearSystem.h"
 #include "drake/system1/Simulation.h"
 #include "drake/system1/cascade_system.h"
@@ -22,8 +21,7 @@ namespace automotive {
 /// Compatibility class for System 1 code.
 // TODO(jwnimmer-tri) Remove me.
 template <typename T>
-class DRAKE_EXPORT DrivingCommand1 :
-    public System1Vector<DrivingCommand<T>, T> {
+class DrivingCommand1 : public System1Vector<DrivingCommand<T>, T> {
  public:
   DrivingCommand1() {}
 
@@ -41,7 +39,6 @@ class DRAKE_EXPORT DrivingCommand1 :
 /**
  * Prints the usage instructions to std::cout.
  */
-DRAKE_EXPORT
 void PrintUsageInstructions(const std::string& executable_name);
 
 /**
@@ -77,7 +74,6 @@ void PrintUsageInstructions(const std::string& executable_name);
  *
  * @return A shared pointer to a rigid body system.
  */
-DRAKE_EXPORT
 std::shared_ptr<RigidBodySystem> CreateRigidBodySystem(
     int argc, const char* argv[], double* duration,
     drake::parsers::ModelInstanceIdTable* model_instance_id_table);
@@ -94,7 +90,6 @@ std::shared_ptr<RigidBodySystem> CreateRigidBodySystem(
  * @throws std::runtime_error if "--duration" exists in @p argv but is not
  * followed by a double value.
  */
-DRAKE_EXPORT
 double ParseDuration(int argc, const char* argv[]);
 
 /**
@@ -102,7 +97,6 @@ double ParseDuration(int argc, const char* argv[]);
  *
  * @param[in] rigid_body_sys The rigid body system to modify.
  */
-DRAKE_EXPORT
 void SetRigidBodySystemParameters(RigidBodySystem* rigid_body_sys);
 
 // TODO(liang.fok) Remove this method once System 1.0 is removed.
@@ -125,7 +119,6 @@ void SetRigidBodySystemParameters(RigidBodySystem* rigid_body_sys);
  * axis. Note that regardless of how deep the terrain is, the top surface of the
  * terrain will be at Z = 0.
  */
-DRAKE_EXPORT
 void AddFlatTerrainToWorld(
     const std::shared_ptr<RigidBodyTree<double>>& rigid_body_tree,
     double box_size = 1000, double box_depth = 10);
@@ -138,7 +131,6 @@ void AddFlatTerrainToWorld(
  * @param[in] rigid_body_sys The rigid body system.
  * @return The resulting vehicle system.
  */
-DRAKE_EXPORT
 std::shared_ptr<CascadeSystem<
     Gain<DrivingCommand1, PDControlSystem<RigidBodySystem>::InputVector>,
     PDControlSystem<RigidBodySystem>>>
@@ -150,7 +142,6 @@ CreateVehicleSystem(std::shared_ptr<RigidBodySystem> rigid_body_sys);
  *
  * @return The default car simulation options.
  */
-DRAKE_EXPORT
 SimulationOptions GetCarSimulationDefaultOptions();
 
 /**
@@ -159,7 +150,6 @@ SimulationOptions GetCarSimulationDefaultOptions();
  * @param[in] rigid_body_sys The rigid body system being simulated.
  * @return The initial state of the system.
  */
-DRAKE_EXPORT
 Eigen::VectorXd GetInitialState(const RigidBodySystem& rigid_body_sys);
 
 /// Compatibility function for System 1 code.

--- a/drake/automotive/create_trajectory_params.cc
+++ b/drake/automotive/create_trajectory_params.cc
@@ -54,7 +54,6 @@ Curve2<double> MakeCurve(double radius, double inset) {
 }
 }  // anonymous namespace
 
-DRAKE_EXPORT
 std::tuple<Curve2<double>, double, double> CreateTrajectoryParams(int index) {
   // The possible curves to trace (lanes).
   static const std::vector<Curve2<double>> curves{

--- a/drake/automotive/create_trajectory_params.h
+++ b/drake/automotive/create_trajectory_params.h
@@ -8,7 +8,6 @@
 
 #include "drake/automotive/curve2.h"
 #include "drake/automotive/trajectory_car.h"
-#include "drake/common/drake_export.h"
 
 namespace drake {
 namespace automotive {
@@ -20,7 +19,6 @@ namespace automotive {
  * @param index Selects which pre-programmed trajectory to use.
  * @return tuple of curve, speed, start_time
  */
-DRAKE_EXPORT
 std::tuple<Curve2<double>, double, double> CreateTrajectoryParams(int index);
 
 }  // namespace automotive

--- a/drake/automotive/gen/driving_command.h
+++ b/drake/automotive/gen/driving_command.h
@@ -8,14 +8,13 @@
 
 #include <Eigen/Core>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
 namespace automotive {
 
 /// Describes the row indices of a DrivingCommand.
-struct DRAKE_EXPORT DrivingCommandIndices {
+struct DrivingCommandIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 3;
 

--- a/drake/automotive/gen/driving_command_translator.h
+++ b/drake/automotive/gen/driving_command_translator.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "drake/automotive/gen/driving_command.h"
-#include "drake/common/drake_export.h"
 #include "drake/lcmt_driving_command_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
@@ -17,7 +16,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * DrivingCommand type.
  */
-class DRAKE_EXPORT DrivingCommandTranslator
+class DrivingCommandTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   DrivingCommandTranslator()

--- a/drake/automotive/gen/euler_floating_joint_state.h
+++ b/drake/automotive/gen/euler_floating_joint_state.h
@@ -8,14 +8,13 @@
 
 #include <Eigen/Core>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
 namespace automotive {
 
 /// Describes the row indices of a EulerFloatingJointState.
-struct DRAKE_EXPORT EulerFloatingJointStateIndices {
+struct EulerFloatingJointStateIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 6;
 

--- a/drake/automotive/gen/euler_floating_joint_state_translator.h
+++ b/drake/automotive/gen/euler_floating_joint_state_translator.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "drake/automotive/gen/euler_floating_joint_state.h"
-#include "drake/common/drake_export.h"
 #include "drake/lcmt_euler_floating_joint_state_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
@@ -17,7 +16,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * EulerFloatingJointState type.
  */
-class DRAKE_EXPORT EulerFloatingJointStateTranslator
+class EulerFloatingJointStateTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   EulerFloatingJointStateTranslator()

--- a/drake/automotive/gen/idm_with_trajectory_agent_parameters.h
+++ b/drake/automotive/gen/idm_with_trajectory_agent_parameters.h
@@ -8,14 +8,13 @@
 
 #include <Eigen/Core>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
 namespace automotive {
 
 /// Describes the row indices of a IdmWithTrajectoryAgentParameters.
-struct DRAKE_EXPORT IdmWithTrajectoryAgentParametersIndices {
+struct IdmWithTrajectoryAgentParametersIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 7;
 

--- a/drake/automotive/gen/idm_with_trajectory_agent_state.h
+++ b/drake/automotive/gen/idm_with_trajectory_agent_state.h
@@ -8,14 +8,13 @@
 
 #include <Eigen/Core>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
 namespace automotive {
 
 /// Describes the row indices of a IdmWithTrajectoryAgentState.
-struct DRAKE_EXPORT IdmWithTrajectoryAgentStateIndices {
+struct IdmWithTrajectoryAgentStateIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 5;
 

--- a/drake/automotive/gen/idm_with_trajectory_agent_state_translator.h
+++ b/drake/automotive/gen/idm_with_trajectory_agent_state_translator.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "drake/automotive/gen/idm_with_trajectory_agent_state.h"
-#include "drake/common/drake_export.h"
 #include "drake/lcmt_idm_with_trajectory_agent_state_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
@@ -17,7 +16,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * IdmWithTrajectoryAgentState type.
  */
-class DRAKE_EXPORT IdmWithTrajectoryAgentStateTranslator
+class IdmWithTrajectoryAgentStateTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   IdmWithTrajectoryAgentStateTranslator()

--- a/drake/automotive/gen/simple_car_config.h
+++ b/drake/automotive/gen/simple_car_config.h
@@ -8,14 +8,13 @@
 
 #include <Eigen/Core>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
 namespace automotive {
 
 /// Describes the row indices of a SimpleCarConfig.
-struct DRAKE_EXPORT SimpleCarConfigIndices {
+struct SimpleCarConfigIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 7;
 

--- a/drake/automotive/gen/simple_car_config_translator.h
+++ b/drake/automotive/gen/simple_car_config_translator.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "drake/automotive/gen/simple_car_config.h"
-#include "drake/common/drake_export.h"
 #include "drake/lcmt_simple_car_config_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
@@ -17,7 +16,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * SimpleCarConfig type.
  */
-class DRAKE_EXPORT SimpleCarConfigTranslator
+class SimpleCarConfigTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   SimpleCarConfigTranslator()

--- a/drake/automotive/gen/simple_car_state.h
+++ b/drake/automotive/gen/simple_car_state.h
@@ -8,14 +8,13 @@
 
 #include <Eigen/Core>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
 namespace automotive {
 
 /// Describes the row indices of a SimpleCarState.
-struct DRAKE_EXPORT SimpleCarStateIndices {
+struct SimpleCarStateIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 4;
 

--- a/drake/automotive/gen/simple_car_state_translator.h
+++ b/drake/automotive/gen/simple_car_state_translator.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "drake/automotive/gen/simple_car_state.h"
-#include "drake/common/drake_export.h"
 #include "drake/lcmt_simple_car_state_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
@@ -17,7 +16,7 @@ namespace automotive {
  * Translates between LCM message objects and VectorBase objects for the
  * SimpleCarState type.
  */
-class DRAKE_EXPORT SimpleCarStateTranslator
+class SimpleCarStateTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   SimpleCarStateTranslator()

--- a/drake/automotive/idm_with_trajectory_agent.cc
+++ b/drake/automotive/idm_with_trajectory_agent.cc
@@ -7,7 +7,6 @@
 
 #include "drake/automotive/gen/idm_with_trajectory_agent_parameters.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/math/autodiff_overloads.h"

--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -3,7 +3,6 @@
 #include "drake/automotive/gen/driving_command.h"
 #include "drake/automotive/gen/simple_car_config.h"
 #include "drake/automotive/gen/simple_car_state.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {

--- a/drake/automotive/trajectory_car.h
+++ b/drake/automotive/trajectory_car.h
@@ -5,7 +5,6 @@
 #include "drake/automotive/curve2.h"
 #include "drake/automotive/gen/driving_command.h"
 #include "drake/automotive/gen/simple_car_state.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {

--- a/drake/tools/lcm_vector_gen.py
+++ b/drake/tools/lcm_vector_gen.py
@@ -15,7 +15,7 @@ def put(fileobj, text, newlines_after=0):
 
 INDICES_BEGIN = """
 /// Describes the row indices of a %(camel)s.
-struct DRAKE_EXPORT %(indices)s {
+struct %(indices)s {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = %(nfields)d;
 
@@ -116,7 +116,6 @@ VECTOR_HH_PREAMBLE = """
 
 #include <Eigen/Core>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 %(opening_namespace)s
@@ -160,7 +159,6 @@ TRANSLATOR_HH_PREAMBLE = """
 #include <vector>
 
 #include "%(relative_cxx_dir)s/%(snake)s.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "drake/lcmt_%(snake)s_t.hpp"
 
@@ -172,7 +170,7 @@ TRANSLATOR_CLASS_DECL = """
  * Translates between LCM message objects and VectorBase objects for the
  * %(camel)s type.
  */
-class DRAKE_EXPORT %(camel)sTranslator
+class %(camel)sTranslator
     : public systems::lcm::LcmAndVectorBaseTranslator {
  public:
   %(camel)sTranslator()


### PR DESCRIPTION
Remove DRAKE_EXPORT from automotive, including lcm_vector_gen.

This is a portion of #3973.  See prior discussion in #3668.

Label "curate" because this PR should squash-and-merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4049)
<!-- Reviewable:end -->
