### PR TITLE
Remove DRAKE_EXPORT from common

### DIFF
--- a/drake/common/drake_assert.h
+++ b/drake/common/drake_assert.h
@@ -2,7 +2,6 @@
 
 #include <type_traits>
 
-#include "drake/common/drake_export.h"
 #include "drake/common/drake_gcc48.h"
 
 /// @file
@@ -71,7 +70,6 @@
 namespace drake {
 namespace detail {
 // Abort the program with an error message.
-DRAKE_EXPORT
 __attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
 void Abort(const char* condition, const char* func, const char* file, int line);
 }  // namespace detail

--- a/drake/common/drake_path.h
+++ b/drake/common/drake_path.h
@@ -2,17 +2,16 @@
 
 #include <string>
 
-#include "drake/common/drake_export.h"
 #include "drake/common/drake_deprecated.h"
 
 namespace drake {
 
 /// Returns the fully-qualified path to the root of the `drake` source tree.
 /// N.B: <em>not</em> the `drake-distro` source tree.
-DRAKE_EXPORT std::string GetDrakePath();
+std::string GetDrakePath();
 
 /// Legacy compatibility alias for GetDrakePath.
 DRAKE_DEPRECATED("Use GetDrakePath instead")
-DRAKE_EXPORT std::string getDrakePath();
+std::string getDrakePath();
 
 }  // namespace drake

--- a/drake/common/drake_throw.h
+++ b/drake/common/drake_throw.h
@@ -3,7 +3,6 @@
 #include <type_traits>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 
 /// @file
 /// Provides a convenient wrapper to throw an exception when a condition is
@@ -13,7 +12,6 @@
 namespace drake {
 namespace detail {
 // Throw an error message.
-DRAKE_EXPORT
 void Throw(const char* condition, const char* func, const char* file, int line);
 }  // namespace detail
 }  // namespace drake

--- a/drake/common/functional_form.h
+++ b/drake/common/functional_form.h
@@ -183,198 +183,146 @@ class FunctionalForm {
    * where "x,..." represents a comma-separated list of the variables
    * combined by the form.
    */
-  friend
-      std::ostream&
-      operator<<(std::ostream& os, FunctionalForm const& f);
+  friend std::ostream& operator<<(std::ostream& os, FunctionalForm const& f);
 
   /** Return a copy of @p lhs updated to record addition of form @p rhs.  */
-  friend
-      FunctionalForm
-      operator+(FunctionalForm const& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm operator+(FunctionalForm const& lhs,
+                                  FunctionalForm const& rhs);
 
   /** Return a copy of @p lhs updated to record addition of a @ref constant
       or @ref zero.  */
-  friend
-      FunctionalForm
-      operator+(FunctionalForm const& lhs, double rhs);
+  friend FunctionalForm operator+(FunctionalForm const& lhs, double rhs);
 
   /** Return a copy of @p rhs updated to record its addition to a
       @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      operator+(double lhs, FunctionalForm const& rhs);
+  friend FunctionalForm operator+(double lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record addition of form @p rhs.  */
-  friend
-      FunctionalForm&
-      // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-      operator+=(FunctionalForm& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm&
+  // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+  operator+=(FunctionalForm& lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record addition of a @ref constant or @ref zero.  */
-  friend
-      FunctionalForm&
-      // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-      operator+=(FunctionalForm& lhs, double rhs);
+  friend FunctionalForm&
+  // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+  operator+=(FunctionalForm& lhs, double rhs);
 
   /** Return a copy of @p lhs updated to record subtraction of form @p rhs.  */
-  friend
-      FunctionalForm
-      operator-(FunctionalForm const& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm operator-(FunctionalForm const& lhs,
+                                  FunctionalForm const& rhs);
 
   /** Return a copy of @p lhs updated to record subtraction of a
       @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      operator-(FunctionalForm const& lhs, double rhs);
+  friend FunctionalForm operator-(FunctionalForm const& lhs, double rhs);
 
   /** Return a copy of @p rhs updated to record its subtraction from a
       @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      operator-(double lhs, FunctionalForm const& rhs);
+  friend FunctionalForm operator-(double lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record subtraction of form @p rhs.  */
-  friend
-      FunctionalForm&
-      // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-      operator-=(FunctionalForm& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm&
+  // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+  operator-=(FunctionalForm& lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record subtraction of a @ref constant or @ref zero.  */
-  friend
-      FunctionalForm&
-      // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-      operator-=(FunctionalForm& lhs, double rhs);
+  friend FunctionalForm&
+  // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+  operator-=(FunctionalForm& lhs, double rhs);
 
   /** Return a copy of @p lhs updated to record multiplication by @p rhs.  */
-  friend
-      FunctionalForm
-      operator*(FunctionalForm const& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm operator*(FunctionalForm const& lhs,
+                                  FunctionalForm const& rhs);
 
   /** Return a copy of @p lhs updated to record multiplication by a
       @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      operator*(FunctionalForm const& lhs, double rhs);
+  friend FunctionalForm operator*(FunctionalForm const& lhs, double rhs);
 
   /** Return a copy of @p rhs updated to record its multiplication of a
       @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      operator*(double lhs, FunctionalForm const& rhs);
+  friend FunctionalForm operator*(double lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record multiplication by @p rhs.  */
-  friend
-      FunctionalForm&
-      // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-      operator*=(FunctionalForm& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm&
+  // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+  operator*=(FunctionalForm& lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record multiplication by a @ref constant
       or @ref zero.  */
-  friend
-      FunctionalForm&
-      // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-      operator*=(FunctionalForm& lhs, double rhs);
+  friend FunctionalForm&
+  // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+  operator*=(FunctionalForm& lhs, double rhs);
 
   /** Return a copy of @p lhs updated to record division by @p rhs.  */
-  friend
-      FunctionalForm
-      operator/(FunctionalForm const& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm operator/(FunctionalForm const& lhs,
+                                  FunctionalForm const& rhs);
 
   /** Return a copy of @p lhs updated to record division by a @ref constant
       or @ref zero.  */
-  friend
-      FunctionalForm
-      operator/(FunctionalForm const& lhs, double rhs);
+  friend FunctionalForm operator/(FunctionalForm const& lhs, double rhs);
 
   /** Return a copy of @p rhs updated to record its division of a
       @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      operator/(double lhs, FunctionalForm const& rhs);
+  friend FunctionalForm operator/(double lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record division by @p rhs.  */
-  friend
-      FunctionalForm&
-      // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-      operator/=(FunctionalForm& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm&
+  // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+  operator/=(FunctionalForm& lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record division by a @ref constant or @ref zero.  */
-  friend
-      FunctionalForm&
-      // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-      operator/=(FunctionalForm& lhs, double rhs);
+  friend FunctionalForm&
+  // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+  operator/=(FunctionalForm& lhs, double rhs);
 
   /** Return a copy of @p x updated to record application of an
       @c abs function.  */
-  friend
-      FunctionalForm
-      abs(FunctionalForm const& x);
+  friend FunctionalForm abs(FunctionalForm const& x);
 
   /** Return a copy of @p x updated to record application of a
       @c cos function.  */
-  friend
-      FunctionalForm
-      cos(FunctionalForm const& x);
+  friend FunctionalForm cos(FunctionalForm const& x);
 
   /** Return a copy of @p x updated to record application of a
       @c exp function.  */
-  friend
-      FunctionalForm
-      exp(FunctionalForm const& x);
+  friend FunctionalForm exp(FunctionalForm const& x);
 
   /** Return a copy of @p x updated to record application of a
       @c log function.  */
-  friend
-      FunctionalForm
-      log(FunctionalForm const& x);
+  friend FunctionalForm log(FunctionalForm const& x);
 
   /** Return the form of the @c max function applied to forms
       @p lhs and @p rhs.  */
-  friend
-      FunctionalForm
-      max(FunctionalForm const& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm max(FunctionalForm const& lhs,
+                            FunctionalForm const& rhs);
 
   /** Return the form of the @c max function applied to form
       @p lhs and a @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      max(FunctionalForm const& lhs, double rhs);
+  friend FunctionalForm max(FunctionalForm const& lhs, double rhs);
 
   /** Return the form of the @c max function applied to form
       @p rhs and a @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      max(double lhs, FunctionalForm const& rhs);
+  friend FunctionalForm max(double lhs, FunctionalForm const& rhs);
 
   /** Return the form of the @c min function applied to forms
       @p lhs and @p rhs.  */
-  friend
-      FunctionalForm
-      min(FunctionalForm const& lhs, FunctionalForm const& rhs);
+  friend FunctionalForm min(FunctionalForm const& lhs,
+                            FunctionalForm const& rhs);
 
   /** Return the form of the @c min function applied to form
       @p lhs and a @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      min(FunctionalForm const& lhs, double rhs);
+  friend FunctionalForm min(FunctionalForm const& lhs, double rhs);
 
   /** Return the form of the @c min function applied to form
       @p rhs and a @ref constant or @ref zero.  */
-  friend
-      FunctionalForm
-      min(double lhs, FunctionalForm const& rhs);
+  friend FunctionalForm min(double lhs, FunctionalForm const& rhs);
 
   /** Return a copy of @p x updated to record application of a
       @c sin function.  */
-  friend
-      FunctionalForm
-      sin(FunctionalForm const& x);
+  friend FunctionalForm sin(FunctionalForm const& x);
 
   /** Return a copy of @p x updated to record application of a
       @c sqrt function.  */
-  friend
-      FunctionalForm
-      sqrt(FunctionalForm const& x);
+  friend FunctionalForm sqrt(FunctionalForm const& x);
 
   /** Represent a set of Variable instances.
    *
@@ -427,14 +375,10 @@ class FunctionalForm {
     size_t size() const;
 
     /** Return @c true if @c lhs and @c rhs represent the same set.  */
-    friend
-        bool
-        operator==(const Variables& lhs, const Variables& rhs);
+    friend bool operator==(const Variables& lhs, const Variables& rhs);
 
     /** Return @c false if @c lhs and @c rhs represent the same set.  */
-    friend
-        bool
-        operator!=(const Variables& lhs, const Variables& rhs);
+    friend bool operator!=(const Variables& lhs, const Variables& rhs);
 
    private:
     explicit Variables(std::vector<Variable>&& vars);
@@ -539,43 +483,29 @@ class FunctionalForm::Variable {
   std::string const& name() const;
 
   /** Print the variable's identifier, if any, to the given stream.  */
-  friend
-      std::ostream&
-      operator<<(std::ostream& os, Variable const& v);
+  friend std::ostream& operator<<(std::ostream& os, Variable const& v);
 
   /** Return true if both variables have the same identifier type and value.  */
-  friend
-      bool
-      operator==(Variable const& lhs, Variable const& rhs);
+  friend bool operator==(Variable const& lhs, Variable const& rhs);
 
   /** Return false if both variables have the same identifier type and value. */
-  friend
-      bool
-      operator!=(Variable const& lhs, Variable const& rhs);
+  friend bool operator!=(Variable const& lhs, Variable const& rhs);
 
   /** Return true if @p lhs comes before @p rhs in the @ref VariableOrdering
    * "Variable Ordering".  */
-  friend
-      bool
-      operator<(Variable const& lhs, Variable const& rhs);
+  friend bool operator<(Variable const& lhs, Variable const& rhs);
 
   /** Return true if @p lhs does not come after @p rhs in the @ref
    * VariableOrdering "Variable Ordering".  */
-  friend
-      bool
-      operator<=(Variable const& lhs, Variable const& rhs);
+  friend bool operator<=(Variable const& lhs, Variable const& rhs);
 
   /** Return true if @p lhs comes after @p rhs in the @ref VariableOrdering
    * "Variable Ordering".  */
-  friend
-      bool
-      operator>(Variable const& lhs, Variable const& rhs);
+  friend bool operator>(Variable const& lhs, Variable const& rhs);
 
   /** Return true if @p lhs does not come before @p rhs in the @ref
    * VariableOrdering "Variable Ordering".  */
-  friend
-      bool
-      operator>=(Variable const& lhs, Variable const& rhs);
+  friend bool operator>=(Variable const& lhs, Variable const& rhs);
 
  private:
   void Destruct() noexcept;

--- a/drake/common/functional_form.h
+++ b/drake/common/functional_form.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "drake/common/drake_export.h"
-
 #include <algorithm>  // for cpplint only
 #include <cstddef>
 #include <initializer_list>
@@ -102,7 +100,7 @@ namespace drake {
  * FunctionalForm may also be used as the scalar type of an @c Eigen::Matrix<>.
  * Basic matrix and vector expressions are supported.
  */
-class DRAKE_EXPORT FunctionalForm {
+class FunctionalForm {
  public:
   class Variable;
   class Variables;
@@ -185,196 +183,196 @@ class DRAKE_EXPORT FunctionalForm {
    * where "x,..." represents a comma-separated list of the variables
    * combined by the form.
    */
-  friend DRAKE_EXPORT
+  friend
       std::ostream&
       operator<<(std::ostream& os, FunctionalForm const& f);
 
   /** Return a copy of @p lhs updated to record addition of form @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator+(FunctionalForm const& lhs, FunctionalForm const& rhs);
 
   /** Return a copy of @p lhs updated to record addition of a @ref constant
       or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator+(FunctionalForm const& lhs, double rhs);
 
   /** Return a copy of @p rhs updated to record its addition to a
       @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator+(double lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record addition of form @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm&
       // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
       operator+=(FunctionalForm& lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record addition of a @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm&
       // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
       operator+=(FunctionalForm& lhs, double rhs);
 
   /** Return a copy of @p lhs updated to record subtraction of form @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator-(FunctionalForm const& lhs, FunctionalForm const& rhs);
 
   /** Return a copy of @p lhs updated to record subtraction of a
       @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator-(FunctionalForm const& lhs, double rhs);
 
   /** Return a copy of @p rhs updated to record its subtraction from a
       @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator-(double lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record subtraction of form @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm&
       // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
       operator-=(FunctionalForm& lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record subtraction of a @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm&
       // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
       operator-=(FunctionalForm& lhs, double rhs);
 
   /** Return a copy of @p lhs updated to record multiplication by @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator*(FunctionalForm const& lhs, FunctionalForm const& rhs);
 
   /** Return a copy of @p lhs updated to record multiplication by a
       @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator*(FunctionalForm const& lhs, double rhs);
 
   /** Return a copy of @p rhs updated to record its multiplication of a
       @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator*(double lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record multiplication by @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm&
       // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
       operator*=(FunctionalForm& lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record multiplication by a @ref constant
       or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm&
       // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
       operator*=(FunctionalForm& lhs, double rhs);
 
   /** Return a copy of @p lhs updated to record division by @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator/(FunctionalForm const& lhs, FunctionalForm const& rhs);
 
   /** Return a copy of @p lhs updated to record division by a @ref constant
       or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator/(FunctionalForm const& lhs, double rhs);
 
   /** Return a copy of @p rhs updated to record its division of a
       @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       operator/(double lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record division by @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm&
       // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
       operator/=(FunctionalForm& lhs, FunctionalForm const& rhs);
 
   /** Update @p lhs to record division by a @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm&
       // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
       operator/=(FunctionalForm& lhs, double rhs);
 
   /** Return a copy of @p x updated to record application of an
       @c abs function.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       abs(FunctionalForm const& x);
 
   /** Return a copy of @p x updated to record application of a
       @c cos function.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       cos(FunctionalForm const& x);
 
   /** Return a copy of @p x updated to record application of a
       @c exp function.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       exp(FunctionalForm const& x);
 
   /** Return a copy of @p x updated to record application of a
       @c log function.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       log(FunctionalForm const& x);
 
   /** Return the form of the @c max function applied to forms
       @p lhs and @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       max(FunctionalForm const& lhs, FunctionalForm const& rhs);
 
   /** Return the form of the @c max function applied to form
       @p lhs and a @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       max(FunctionalForm const& lhs, double rhs);
 
   /** Return the form of the @c max function applied to form
       @p rhs and a @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       max(double lhs, FunctionalForm const& rhs);
 
   /** Return the form of the @c min function applied to forms
       @p lhs and @p rhs.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       min(FunctionalForm const& lhs, FunctionalForm const& rhs);
 
   /** Return the form of the @c min function applied to form
       @p lhs and a @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       min(FunctionalForm const& lhs, double rhs);
 
   /** Return the form of the @c min function applied to form
       @p rhs and a @ref constant or @ref zero.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       min(double lhs, FunctionalForm const& rhs);
 
   /** Return a copy of @p x updated to record application of a
       @c sin function.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       sin(FunctionalForm const& x);
 
   /** Return a copy of @p x updated to record application of a
       @c sqrt function.  */
-  friend DRAKE_EXPORT
+  friend
       FunctionalForm
       sqrt(FunctionalForm const& x);
 
@@ -384,7 +382,7 @@ class DRAKE_EXPORT FunctionalForm {
    * to the @ref VariableOrdering "Variable Ordering" without duplicates.
    * The contained set is immutable.
    */
-  class DRAKE_EXPORT Variables {
+  class Variables {
    public:
     /** Construct an empty set.  */
     Variables() = default;
@@ -429,12 +427,12 @@ class DRAKE_EXPORT FunctionalForm {
     size_t size() const;
 
     /** Return @c true if @c lhs and @c rhs represent the same set.  */
-    friend DRAKE_EXPORT
+    friend
         bool
         operator==(const Variables& lhs, const Variables& rhs);
 
     /** Return @c false if @c lhs and @c rhs represent the same set.  */
-    friend DRAKE_EXPORT
+    friend
         bool
         operator!=(const Variables& lhs, const Variables& rhs);
 
@@ -489,7 +487,7 @@ bool operator>=(FunctionalForm const&, FunctionalForm const&) = delete;
  * We define a Variable Ordering first by type (in the above order) and then by
  * the natural order of values within each type.
  */
-class DRAKE_EXPORT FunctionalForm::Variable {
+class FunctionalForm::Variable {
  public:
   /** Construct the nil variable.  */
   Variable();
@@ -541,41 +539,41 @@ class DRAKE_EXPORT FunctionalForm::Variable {
   std::string const& name() const;
 
   /** Print the variable's identifier, if any, to the given stream.  */
-  friend DRAKE_EXPORT
+  friend
       std::ostream&
       operator<<(std::ostream& os, Variable const& v);
 
   /** Return true if both variables have the same identifier type and value.  */
-  friend DRAKE_EXPORT
+  friend
       bool
       operator==(Variable const& lhs, Variable const& rhs);
 
   /** Return false if both variables have the same identifier type and value. */
-  friend DRAKE_EXPORT
+  friend
       bool
       operator!=(Variable const& lhs, Variable const& rhs);
 
   /** Return true if @p lhs comes before @p rhs in the @ref VariableOrdering
    * "Variable Ordering".  */
-  friend DRAKE_EXPORT
+  friend
       bool
       operator<(Variable const& lhs, Variable const& rhs);
 
   /** Return true if @p lhs does not come after @p rhs in the @ref
    * VariableOrdering "Variable Ordering".  */
-  friend DRAKE_EXPORT
+  friend
       bool
       operator<=(Variable const& lhs, Variable const& rhs);
 
   /** Return true if @p lhs comes after @p rhs in the @ref VariableOrdering
    * "Variable Ordering".  */
-  friend DRAKE_EXPORT
+  friend
       bool
       operator>(Variable const& lhs, Variable const& rhs);
 
   /** Return true if @p lhs does not come before @p rhs in the @ref
    * VariableOrdering "Variable Ordering".  */
-  friend DRAKE_EXPORT
+  friend
       bool
       operator>=(Variable const& lhs, Variable const& rhs);
 

--- a/drake/common/nice_type_name.h
+++ b/drake/common/nice_type_name.h
@@ -6,8 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/drake_export.h"
-
 namespace drake {
 
 /** @brief Obtains canonicalized, platform-independent, human-readable names for
@@ -55,7 +53,6 @@ class NiceTypeName {
   name as returned by `typeid(T).name()`, with the result hopefully suitable for
   meaningful display to a human. The result is compiler-dependent.
   @see Canonicalize() **/
-  DRAKE_EXPORT
   static std::string Demangle(const char* typeid_name);
 
   /** Given a compiler-dependent demangled type name string as returned by
@@ -64,7 +61,6 @@ class NiceTypeName {
   "class" and "struct" are removed. The NiceTypeName::Get<T>() method
   uses this function to produce a human-friendly type name that is the same on
   any platform. **/
-  DRAKE_EXPORT
   static std::string Canonicalize(const std::string& demangled_name);
 
  private:

--- a/drake/common/polynomial.h
+++ b/drake/common/polynomial.h
@@ -12,7 +12,6 @@
 #include <unsupported/Eigen/Polynomials>
 
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/drake_export.h"
 
 /** A scalar multi-variate polynomial, modeled after the msspoly in spotless.
  *
@@ -39,7 +38,7 @@
  * under division.
  */
 template <typename _CoefficientType = double>
-class DRAKE_EXPORT Polynomial {
+class Polynomial {
  public:
   typedef _CoefficientType CoefficientType;
   typedef unsigned int VarType;
@@ -56,7 +55,7 @@ class DRAKE_EXPORT Polynomial {
   };
 
   /// An individual variable raised to an integer power; e.g. x**2.
-  class DRAKE_EXPORT Term {
+  class Term {
    public:
     VarType var;
     PowerType power;
@@ -75,7 +74,7 @@ class DRAKE_EXPORT Polynomial {
 
   /// An additive atom of a Polynomial: The product of any number of
   /// Terms and a coefficient.
-  class DRAKE_EXPORT Monomial {
+  class Monomial {
    public:
     CoefficientType coefficient;
     std::vector<Term> terms;  // a list of N variable ids

--- a/drake/common/text_logging.h
+++ b/drake/common/text_logging.h
@@ -41,8 +41,6 @@ printed without any special handling.
 #include <spdlog/fmt/ostr.h>
 #endif
 
-#include "drake/common/drake_export.h"
-
 namespace drake {
 
 #ifdef HAVE_SPDLOG
@@ -58,7 +56,7 @@ namespace logging {
 
 /// A stubbed-out version of `spdlog::logger`.  Implements only those methods
 /// that we expect to use, as spdlog's API does change from time to time.
-class DRAKE_EXPORT logger {
+class logger {
  public:
   logger();
 
@@ -95,6 +93,6 @@ class DRAKE_EXPORT logger {
 
 /// Retrieve an instance of a logger to use for logging; for example:
 ///   `drake::log()->info("potato!")`
-DRAKE_EXPORT logging::logger* log();
+logging::logger* log();
 
 }  // namespace drake


### PR DESCRIPTION
Remove DRAKE_EXPORT from common, except for _symbolic_ classes for now (a feature branch is open on them).

This is a portion of #3973. See prior discussion in #3668.

Label "curate" because this PR should squash-and-merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4050)
<!-- Reviewable:end -->
