### PR TITLE
Change the continuous link

### DIFF
--- a/drake/doc/buildcop.rst
+++ b/drake/doc/buildcop.rst
@@ -120,7 +120,8 @@ This section is a quick-reference manual for the on-call build cop.
 
 Monitor the Build
 ^^^^^^^^^^^^^^^^^
-Check the `Continuous <https://drake-jenkins.csail.mit.edu/view/Continuous/>`_
+Check the `Continuous Production <https://drake-
+jenkins.csail.mit.edu/view/Continuous%20Production/>`_ 
 build dashboard in Jenkins at least once an hour during on-call hours. These
 builds run after every merge to Drake. Also check the
 `Nightly Production <https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/>`_

--- a/drake/doc/buildcop.rst
+++ b/drake/doc/buildcop.rst
@@ -120,8 +120,7 @@ This section is a quick-reference manual for the on-call build cop.
 
 Monitor the Build
 ^^^^^^^^^^^^^^^^^
-Check the `Continuous Production <https://drake-
-jenkins.csail.mit.edu/view/Continuous%20Production/>`_ 
+Check the `Continuous Production <https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/>`_
 build dashboard in Jenkins at least once an hour during on-call hours. These
 builds run after every merge to Drake. Also check the
 `Nightly Production <https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/>`_


### PR DESCRIPTION
The overview links to "Continuous Production".  The body links to
"Continuous".  Now they both link to "Continuous Production".  This will
help new build cops to acclimate better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4051)
<!-- Reviewable:end -->
