### PR TITLE
Adds autodiff_overloads.h as an installed header.

### DIFF
--- a/drake/math/CMakeLists.txt
+++ b/drake/math/CMakeLists.txt
@@ -20,6 +20,7 @@ set(sources
 set(installed_headers
   autodiff.h
   autodiff_gradient.h
+  autodiff_overloads.h
   axis_angle.h
   cross_product.h
   eigen_sparse_triplet.h


### PR DESCRIPTION
I discovered this while working on a project that depends on Drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4054)
<!-- Reviewable:end -->
