### PR TITLE
Extracts AddFlatTerrainToWorld() into a single shared source file.

### DIFF
--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -2,7 +2,6 @@ add_subdirectory(gen)
 add_subdirectory(test)
 
 add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
-  automotive_common.cc
   create_trajectory_params.cc
   curve2.cc
   gen/driving_command.cc
@@ -23,7 +22,6 @@ target_link_libraries(drakeAutomotive
   )
 pods_install_libraries(drakeAutomotive)
 drake_install_headers(
-  automotive_common.h
   create_trajectory_params.h
   curve2.h
   simple_car.h

--- a/drake/automotive/car_sim_lcm.cc
+++ b/drake/automotive/car_sim_lcm.cc
@@ -1,8 +1,8 @@
 #include <gflags/gflags.h>
 
-#include "drake/automotive/automotive_common.h"
 #include "drake/automotive/car_simulation.h"
 #include "drake/automotive/gen/driving_command_translator.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/text_logging_gflags.h"
@@ -17,6 +17,7 @@
 #include "drake/systems/plants/parser_sdf.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
 #include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
+#include "drake/systems/plants/rigid_body_tree_construction.h"
 
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
     "Number of seconds to simulate.");
@@ -97,7 +98,7 @@ int main(int argc, char* argv[]) {
       drake::GetDrakePath() + "/automotive/models/prius/prius_with_lidar.sdf",
       systems::plants::joints::kQuaternion, nullptr /* weld to frame */,
       rigid_body_tree.get());
-  AddFlatTerrainToWorld(rigid_body_tree.get());
+  systems::plants::AddFlatTerrainToWorld(rigid_body_tree.get());
   VerifyCarSimLcmTree(*rigid_body_tree);
 
   // Instantiates a RigidBodyPlant to simulate the model.

--- a/drake/automotive/car_simulation.cc
+++ b/drake/automotive/car_simulation.cc
@@ -3,9 +3,9 @@
 #include <cstdlib>
 #include <limits>
 
-#include "drake/automotive/automotive_common.h"
 #include "drake/systems/plants/joints/floating_base_types.h"
 #include "drake/systems/plants/parser_model_instance_id_table.h"
+#include "drake/systems/plants/rigid_body_tree_construction.h"
 
 namespace drake {
 namespace automotive {
@@ -18,6 +18,7 @@ using drake::NullVector;
 using drake::parsers::ModelInstanceIdTable;
 using drake::systems::plants::joints::kFixed;
 using drake::systems::plants::joints::kQuaternion;
+using drake::systems::plants::AddFlatTerrainToWorld;
 
 const char kDurationFlag[] = "--duration";
 
@@ -141,8 +142,6 @@ void AddFlatTerrainToWorld(
     double box_size, double box_depth) {
   AddFlatTerrainToWorld(rigid_body_tree.get(), box_size, box_depth);
 }
-
-
 
 std::shared_ptr<CascadeSystem<
     Gain<DrivingCommand1, PDControlSystem<RigidBodySystem>::InputVector>,

--- a/drake/examples/Quadrotor/run_quadrotor_dynamics.cc
+++ b/drake/examples/Quadrotor/run_quadrotor_dynamics.cc
@@ -11,6 +11,7 @@
 #include "drake/systems/plants/parser_urdf.h"
 #include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/plants/rigid_body_tree_construction.h"
 
 namespace drake {
 namespace examples {
@@ -35,7 +36,7 @@ class Quadrotor : public systems::Diagram<T> {
         drake::GetDrakePath() + "/examples/Quadrotor/warehouse.sdf",
         systems::plants::joints::kFixed, nullptr, tree.get());
 
-    AddGround(tree.get());
+    drake::systems::plants::AddFlatTerrainToWorld(tree.get());
 
     systems::DiagramBuilder<T> builder;
 
@@ -56,26 +57,6 @@ class Quadrotor : public systems::Diagram<T> {
     builder.Connect(plant_->get_output_port(0), publisher->get_input_port(0));
 
     builder.BuildInto(this);
-  }
-
-  // TODO(foehnph): duplicated, refactor into single location.
-  void AddGround(RigidBodyTree<T>* tree) {
-    double kBoxWidth = 1000;
-    double kBoxDepth = 10;
-    DrakeShapes::Box geom(Eigen::Vector3d(kBoxWidth, kBoxWidth, kBoxDepth));
-    Eigen::Isometry3d T_element_to_link = Eigen::Isometry3d::Identity();
-    T_element_to_link.translation() << 0, 0,
-        -kBoxDepth / 2.0;  // Top of the box is at z = 0.
-
-    RigidBody& world = tree->world();
-    Eigen::Vector4d color;
-    color << 0.9297, 0.7930, 0.6758, 1;
-    world.AddVisualElement(
-        DrakeShapes::VisualElement(geom, T_element_to_link, color));
-    tree->addCollisionElement(
-        DrakeCollision::Element(geom, T_element_to_link, &world), world,
-        "terrain");
-    tree->updateStaticCollisionElements();
   }
 
   void SetDefaultState(systems::Context<T>* context) const {

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo.cc
@@ -18,6 +18,7 @@
 #include "drake/systems/plants/parser_urdf.h"
 #include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/plants/rigid_body_tree_construction.h"
 #include "drake/systems/trajectories/piecewise_polynomial_trajectory.h"
 
 // Includes for the planner.
@@ -197,7 +198,7 @@ class KukaDemo : public systems::Diagram<T> {
         drake::systems::plants::joints::kFixed,
         nullptr /* weld to frame */, rigid_body_tree.get());
 
-    AddGround(rigid_body_tree.get());
+    drake::systems::plants::AddFlatTerrainToWorld(rigid_body_tree.get());
     VerifyIiwaTree(*rigid_body_tree);
 
     DiagramBuilder<T> builder;

--- a/drake/examples/kuka_iiwa_arm/iiwa_common.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_common.cc
@@ -9,25 +9,6 @@ namespace drake {
 namespace examples {
 namespace kuka_iiwa_arm {
 
-void AddGround(RigidBodyTree<double>* tree) {
-  double kBoxWidth = 3;
-  double kBoxDepth = 0.2;
-  DrakeShapes::Box geom(Eigen::Vector3d(kBoxWidth, kBoxWidth, kBoxDepth));
-  Eigen::Isometry3d T_element_to_link = Eigen::Isometry3d::Identity();
-  T_element_to_link.translation() << 0, 0,
-      -kBoxDepth / 2.0;  // top of the box is at z = 0
-
-  RigidBody& world = tree->world();
-  Eigen::Vector4d color;
-  color << 0.9297, 0.7930, 0.6758, 1;
-  world.AddVisualElement(
-      DrakeShapes::VisualElement(geom, T_element_to_link, color));
-  tree->addCollisionElement(
-      DrakeCollision::Element(geom, T_element_to_link, &world), world,
-      "terrain");
-  tree->updateStaticCollisionElements();
-}
-
 void VerifyIiwaTree(const RigidBodyTree<double>& tree) {
   std::map<std::string, int> name_to_idx =
       tree.computePositionNameToIndexMap();

--- a/drake/examples/kuka_iiwa_arm/iiwa_common.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_common.h
@@ -8,15 +8,6 @@ namespace examples {
 namespace kuka_iiwa_arm {
 
 /**
- * Adds a ground plane to @p tree. The ground is represented as a box-shaped
- * visual and collision element.
- *
- * @param[in] tree The RigidBodyTree to which to add the ground plane.
- */
-DRAKE_EXPORT
-void AddGround(RigidBodyTree<double>* tree);
-
-/**
  * Verify that @p tree matches assumptions about joint indices.
  * Aborts if the tree isn't as expected.
  */

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -27,6 +27,7 @@
 #include "drake/systems/plants/parser_urdf.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
 #include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
+#include "drake/systems/plants/rigid_body_tree_construction.h"
 
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
@@ -153,7 +154,7 @@ class SimulatedKuka : public systems::Diagram<T> {
         drake::systems::plants::joints::kFixed,
         nullptr /* weld to frame */, rigid_body_tree.get());
 
-    AddGround(rigid_body_tree.get());
+    drake::systems::plants::AddFlatTerrainToWorld(rigid_body_tree.get());
 
     DiagramBuilder<T> builder;
 

--- a/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
+++ b/drake/examples/kuka_iiwa_arm/run_kuka_iiwa_arm_dynamics.cc
@@ -14,6 +14,7 @@
 #include "drake/systems/plants/parser_model_instance_id_table.h"
 #include "drake/systems/plants/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/plants/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/plants/rigid_body_tree_construction.h"
 
 using std::make_unique;
 using std::move;
@@ -56,7 +57,7 @@ class KukaIiwaArmDynamicsSim : public systems::Diagram<T> {
             drake::GetDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf",
             kFixed, nullptr /* weld to frame */, tree.get());
 
-    AddGround(tree.get());
+    drake::systems::plants::AddFlatTerrainToWorld(tree.get());
 
     DiagramBuilder<T> builder;
 

--- a/drake/systems/plants/CMakeLists.txt
+++ b/drake/systems/plants/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_with_exports(LIB_NAME drakeRBM SOURCE_FILES
   rigid_body_actuator.cc
   rigid_body_frame.cc
   rigid_body_loop.cc
+  rigid_body_tree_construction.cc
   $<TARGET_OBJECTS:drakeUtil>)
 target_link_libraries(drakeRBM
         drakeCollision drakeCommon drakeJoints drakeXMLUtil)
@@ -37,7 +38,8 @@ drake_install_headers(
   parser_common.h
   parser_sdf.h
   parser_urdf.h
-  rigid_body_loop.h)
+  rigid_body_loop.h
+  rigid_body_tree_construction.h)
 
 pods_install_pkg_config_file(drake-rbm
   LIBS -ldrakeRBM -ldrakeCollision -ldrakeJoints -ldrakeXMLUtil

--- a/drake/systems/plants/rigid_body_tree_construction.cc
+++ b/drake/systems/plants/rigid_body_tree_construction.cc
@@ -1,7 +1,8 @@
-#include "drake/automotive/automotive_common.h"
+#include "drake/systems/plants/rigid_body_tree_construction.h"
 
 namespace drake {
-namespace automotive {
+namespace systems {
+namespace plants {
 
 void AddFlatTerrainToWorld(RigidBodyTreed* tree, double box_size,
                            double box_depth) {
@@ -23,5 +24,6 @@ void AddFlatTerrainToWorld(RigidBodyTreed* tree, double box_size,
   tree->updateStaticCollisionElements();
 }
 
-}  // namespace automotive
+}  // namespace plants
+}  // namespace systems
 }  // namespace drake

--- a/drake/systems/plants/rigid_body_tree_construction.h
+++ b/drake/systems/plants/rigid_body_tree_construction.h
@@ -3,18 +3,19 @@
 #include "drake/systems/plants/RigidBodyTree.h"
 
 namespace drake {
-namespace automotive {
+namespace systems {
+namespace plants {
 
 /**
- * Adds a box-shaped terrain to the specified rigid body tree. This directly
- * modifies the existing world rigid body within @p rigid_body_tree and thus
- * does not need to return a model name or model_instance_id value.
+ * Adds a box-shaped terrain to @p tree. This directly modifies the existing
+ * world rigid body within @p tree and thus does not need to return a
+ * `model_instance_id` value.
  *
- * Two opposite corners of the resulting axis aligned box are:
+ * Two opposite corners of the resulting axis-aligned box are:
  * `(box_size / 2, box_size / 2, 0)` and
  * `(-box_size / 2, -box_size / 2, -box_depth)`.
  *
- * @param[in] tree The RigidBodyTree to which to add the terrain.
+ * @param[in] tree The RigidBodyTreed to which to add the terrain.
  *
  * @param[in] box_size The length and width of the terrain aligned with the
  * world's X and Y axes.
@@ -26,5 +27,6 @@ namespace automotive {
 void AddFlatTerrainToWorld(RigidBodyTreed* tree,
                            double box_size = 1000, double box_depth = 10);
 
-}  // namespace automotive
+}  // namespace plants
+}  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
As enabled by the rule-of-three, this was being used by automotive, iiwa, and quadrotor demos. It's also being used by another demo I'm working on that is a user of Drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4056)
<!-- Reviewable:end -->
