### PR TITLE
Remove DRAKE_EXPORT from lcm, math, systems1

### DIFF
--- a/drake/lcm/drake_lcm.cc
+++ b/drake/lcm/drake_lcm.cc
@@ -9,7 +9,7 @@ namespace lcm {
 // serialized LCM message and passes it to the `DrakeLcmMessageHandlerInterface`
 // object. A single type of subscriber is used to avoid DrakeLcm from being
 // templated on the subscriber type.
-class DRAKE_EXPORT DrakeLcm::Subscriber {
+class DrakeLcm::Subscriber {
  public:
   explicit Subscriber(DrakeLcmMessageHandlerInterface* drake_handler)
       : drake_handler_(drake_handler) {}

--- a/drake/lcm/drake_lcm.h
+++ b/drake/lcm/drake_lcm.h
@@ -6,7 +6,6 @@
 
 #include "lcm/lcm-cpp.hpp"
 
-#include "drake/common/drake_export.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
 #include "drake/lcm/lcm_receive_thread.h"
@@ -17,7 +16,7 @@ namespace lcm {
 /**
  * A wrapper around a *real* LCM instance.
  */
-class DRAKE_EXPORT DrakeLcm : public DrakeLcmInterface {
+class DrakeLcm : public DrakeLcmInterface {
  public:
   DrakeLcm();
 

--- a/drake/lcm/drake_lcm_interface.h
+++ b/drake/lcm/drake_lcm_interface.h
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "drake/common/drake_export.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
 
 namespace drake {
@@ -11,7 +10,7 @@ namespace lcm {
 /**
  * A pure virtual interface that enables LCM to be mocked.
  */
-class DRAKE_EXPORT DrakeLcmInterface {
+class DrakeLcmInterface {
  public:
   virtual ~DrakeLcmInterface() {}
 

--- a/drake/lcm/drake_lcm_message_handler_interface.h
+++ b/drake/lcm/drake_lcm_message_handler_interface.h
@@ -3,8 +3,6 @@
 #include <cstdint>
 #include <string>
 
-#include "drake/common/drake_export.h"
-
 namespace drake {
 namespace lcm {
 
@@ -14,7 +12,7 @@ namespace lcm {
  *
  * @see DrakeLcmInterface::Subscribe().
  */
-class DRAKE_EXPORT DrakeLcmMessageHandlerInterface {
+class DrakeLcmMessageHandlerInterface {
  public:
   virtual ~DrakeLcmMessageHandlerInterface() {}
 

--- a/drake/lcm/drake_mock_lcm.h
+++ b/drake/lcm/drake_mock_lcm.h
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "drake/common/drake_export.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
 
@@ -17,7 +16,7 @@ namespace lcm {
  * messages. It contains additional methods for accessing the most recent
  * message that was "published," and faking a callback.
  */
-class DRAKE_EXPORT DrakeMockLcm : public DrakeLcmInterface {
+class DrakeMockLcm : public DrakeLcmInterface {
  public:
   DrakeMockLcm();
 

--- a/drake/lcm/lcm_receive_thread.h
+++ b/drake/lcm/lcm_receive_thread.h
@@ -5,8 +5,6 @@
 
 #include <lcm/lcm-cpp.hpp>
 
-#include "drake/common/drake_export.h"
-
 namespace drake {
 namespace lcm {
 
@@ -14,7 +12,7 @@ namespace lcm {
  * Maintains a thread that receives LCM messages and dispatches the messages to
  * the appropriate message handlers.
  */
-class DRAKE_EXPORT LcmReceiveThread {
+class LcmReceiveThread {
  public:
   /**
    * A constructor that instantiates the thread.

--- a/drake/lcm/lcmt_drake_signal_utils.h
+++ b/drake/lcm/lcmt_drake_signal_utils.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "drake/common/drake_export.h"
 #include "drake/lcmt_drake_signal.hpp"
 
 namespace drake {
@@ -17,7 +16,7 @@ namespace lcm {
  *
  * @return `true` if @p actual_message and @p expected_message are equal.
  */
-bool DRAKE_EXPORT
+bool
 CompareLcmtDrakeSignalMessages(const lcmt_drake_signal& actual_message,
                                const lcmt_drake_signal& expected_message);
 

--- a/drake/math/random_rotation.h
+++ b/drake/math/random_rotation.h
@@ -6,20 +6,19 @@
 
 #include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/drake_export.h"
 
 namespace drake {
 namespace math {
-DRAKE_EXPORT Eigen::Vector4d UniformlyRandomAxisAngle(
+Eigen::Vector4d UniformlyRandomAxisAngle(
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
     std::default_random_engine& generator);
-DRAKE_EXPORT Eigen::Vector4d UniformlyRandomQuat(
+Eigen::Vector4d UniformlyRandomQuat(
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
     std::default_random_engine& generator);
-DRAKE_EXPORT Eigen::Matrix3d UniformlyRandomRotmat(
+Eigen::Matrix3d UniformlyRandomRotmat(
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
     std::default_random_engine& generator);
-DRAKE_EXPORT Eigen::Vector3d UniformlyRandomRPY(
+Eigen::Vector3d UniformlyRandomRPY(
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
     std::default_random_engine& generator);
 }  // namespace math

--- a/drake/system1/LCMSystem.h
+++ b/drake/system1/LCMSystem.h
@@ -8,7 +8,6 @@
 #include <lcm/lcm-cpp.hpp>
 #include "drake/lcmt_drake_signal.hpp"
 
-#include "drake/common/drake_export.h"
 #include "drake/system1/Simulation.h"
 #include "drake/system1/System.h"
 #include "drake/system1/cascade_system.h"
@@ -203,7 +202,7 @@ class LCMOutputSystem<
 
 // todo: template specialization for the CombinedVector case
 
-class DRAKE_EXPORT LCMLoop {
+class LCMLoop {
  public:
   bool stop;
   lcm::LCM &lcm;


### PR DESCRIPTION
Remove DRAKE_EXPORT from a few directories. This is a portion of #3973.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4070)
<!-- Reviewable:end -->
