### PR TITLE
Remove DRAKE_EXPORT from systems/{analysis,framework,lcm}

### DIFF
--- a/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.h
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/controllers/pid_controller.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/primitives/adder.h"
@@ -28,8 +27,7 @@ namespace systems {
 /// No other values for T are currently supported.
 /// @ingroup rigid_body_systems
 template <typename T>
-class DRAKE_EXPORT
-PidControlledSpringMassSystem : public Diagram<T> {
+class PidControlledSpringMassSystem : public Diagram<T> {
  public:
   /// Constructs a spring-mass system with a fixed spring constant and given
   /// mass controlled by a PID controller to achieve a specified target

--- a/drake/systems/framework/cache.h
+++ b/drake/systems/framework/cache.h
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
@@ -20,7 +19,7 @@ namespace internal {
 
 /// A single cached piece of data, its validity bit, and the set of other cache
 /// entries that depend on it.
-class DRAKE_EXPORT CacheEntry {
+class CacheEntry {
  public:
   CacheEntry();
   ~CacheEntry();
@@ -76,7 +75,7 @@ class DRAKE_EXPORT CacheEntry {
 /// needs access to a cached value; it must not hold the returned pointer.
 ///
 /// Cache is not thread-safe. It is copyable, assignable, and movable.
-class DRAKE_EXPORT Cache {
+class Cache {
  public:
   Cache();
   ~Cache();

--- a/drake/systems/framework/input_port_evaluator_interface.h
+++ b/drake/systems/framework/input_port_evaluator_interface.h
@@ -2,7 +2,6 @@
 
 #include <sstream>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/system_port_descriptor.h"
 
@@ -24,7 +23,7 @@ namespace detail {
 ///
 /// @tparam T A mathematical type that is a valid Eigen scalar.
 template <typename T>
-class DRAKE_EXPORT InputPortEvaluatorInterface {
+class InputPortEvaluatorInterface {
  public:
   virtual ~InputPortEvaluatorInterface() {}
 

--- a/drake/systems/framework/modal_state.h
+++ b/drake/systems/framework/modal_state.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
@@ -16,7 +15,7 @@ namespace systems {
 /// and diagrams.
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
-class DRAKE_EXPORT ModalState {
+class ModalState {
  public:
   // Constructs an empty modal state.
   ModalState();

--- a/drake/systems/framework/output_port_listener_interface.h
+++ b/drake/systems/framework/output_port_listener_interface.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "drake/common/drake_export.h"
-
 namespace drake {
 namespace systems {
 namespace detail {
@@ -9,7 +7,7 @@ namespace detail {
 /// OutputPortListenerInterface is an interface that consumers of an output
 /// port must satisfy to receive notifications when the value on that output
 /// port's version number is incremented.
-class DRAKE_EXPORT OutputPortListenerInterface {
+class OutputPortListenerInterface {
  public:
   virtual ~OutputPortListenerInterface();
 

--- a/drake/systems/framework/primitives/adder.cc
+++ b/drake/systems/framework/primitives/adder.cc
@@ -5,7 +5,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_context.h"
 

--- a/drake/systems/framework/primitives/constant_vector_source.cc
+++ b/drake/systems/framework/primitives/constant_vector_source.cc
@@ -3,7 +3,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_context.h"
 

--- a/drake/systems/framework/primitives/gain-inl.h
+++ b/drake/systems/framework/primitives/gain-inl.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_context.h"
 

--- a/drake/systems/framework/primitives/integrator.cc
+++ b/drake/systems/framework/primitives/integrator.cc
@@ -5,7 +5,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_context.h"
 

--- a/drake/systems/framework/primitives/pass_through-inl.h
+++ b/drake/systems/framework/primitives/pass_through-inl.h
@@ -11,7 +11,6 @@
 #include <string>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_context.h"
 

--- a/drake/systems/framework/primitives/zero_order_hold-inl.h
+++ b/drake/systems/framework/primitives/zero_order_hold-inl.h
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/difference_state.h"
 #include "drake/systems/framework/leaf_context.h"

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/systems/framework/cache.h"

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <vector>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/output_port_listener_interface.h"
@@ -18,8 +17,7 @@ namespace systems {
 /// The InputPort describes a single input to a System. Users should not
 /// subclass InputPort: all InputPorts are either DependentInputPorts or
 /// FreestandingInputPorts.
-class DRAKE_EXPORT InputPort
-    : public detail::OutputPortListenerInterface {
+class InputPort : public detail::OutputPortListenerInterface {
  public:
   ~InputPort() override;
 
@@ -70,7 +68,7 @@ class DRAKE_EXPORT InputPort
 /// The DependentInputPort wraps a pointer to the OutputPort of a System for use
 /// as an input to another System. Many DependentInputPorts may wrap a single
 /// OutputPort.
-class DRAKE_EXPORT DependentInputPort : public InputPort {
+class DependentInputPort : public InputPort {
  public:
   /// Creates an input port connected to the given @p output_port, which
   /// must not be nullptr. The output port must outlive this input port.
@@ -104,7 +102,7 @@ class DRAKE_EXPORT DependentInputPort : public InputPort {
 
 /// The FreestandingInputPort encapsulates a vector of data for use as an input
 /// to a System.
-class DRAKE_EXPORT FreestandingInputPort : public InputPort {
+class FreestandingInputPort : public InputPort {
  public:
   /// Constructs a vector-valued FreestandingInputPort.
   /// Takes ownership of @p vec.

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/output_port_listener_interface.h"
 #include "drake/systems/framework/value.h"
@@ -18,7 +17,7 @@ namespace systems {
 /// may depend on the OutputPort. When an OutputPort is deleted, it will
 /// automatically notify the listeners that depend on it to disconnect,
 /// meaning those ports will resolve to nullptr.
-class DRAKE_EXPORT OutputPort {
+class OutputPort {
  public:
   /// Constructs a vector-valued OutputPort.
   /// Takes ownership of @p vec.

--- a/drake/systems/framework/test/value_test.cc
+++ b/drake/systems/framework/test/value_test.cc
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 #include "gtest/gtest.h"

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -5,7 +5,6 @@
 #include <string>
 #include <typeinfo>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -26,7 +25,7 @@ class Value;
 /// latter variants are guaranteed to throw on mismatched types, but may be
 /// slower at runtime.  Prefer using the faster version only in performance-
 /// sensitive code (e.g., inner loops), and the safer version otherwise.
-class DRAKE_EXPORT AbstractValue {
+class AbstractValue {
  public:
   AbstractValue() {}
   virtual ~AbstractValue();

--- a/drake/systems/lcm/lcm_and_vector_base_translator.h
+++ b/drake/systems/lcm/lcm_and_vector_base_translator.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <vector>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -15,7 +14,7 @@ namespace lcm {
  * Defines an abstract parent class of all translators that convert between
  * LCM message bytes and `drake::systems::VectorBase` objects.
  */
-class DRAKE_EXPORT LcmAndVectorBaseTranslator {
+class LcmAndVectorBaseTranslator {
  public:
   /**
    * The constructor.

--- a/drake/systems/lcm/lcm_publisher_system.h
+++ b/drake/systems/lcm/lcm_publisher_system.h
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "drake/common/drake_export.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/framework/leaf_context.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -17,7 +16,7 @@ namespace lcm {
 /**
  * Publishes an LCM message containing information from its input port.
  */
-class DRAKE_EXPORT LcmPublisherSystem : public LeafSystem<double> {
+class LcmPublisherSystem : public LeafSystem<double> {
  public:
   /**
    * Factory method that returns a publisher System that takes

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-#include "drake/common/drake_export.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -23,7 +22,7 @@ namespace lcm {
  * System<double>'s port. The output port value is the most recently
  * decoded message, modulo any network or threading delays.
  */
-class DRAKE_EXPORT LcmSubscriberSystem : public LeafSystem<double>,
+class LcmSubscriberSystem : public LeafSystem<double>,
     public drake::lcm::DrakeLcmMessageHandlerInterface  {
  public:
   /**

--- a/drake/systems/lcm/lcm_translator_dictionary.h
+++ b/drake/systems/lcm/lcm_translator_dictionary.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <string>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
 namespace drake {
@@ -17,7 +16,7 @@ namespace lcm {
  * translators contained within the dictionary are guaranteed to remain in
  * existence throughout the lifespan of this object.
  */
-class DRAKE_EXPORT LcmTranslatorDictionary {
+class LcmTranslatorDictionary {
  public:
   /**
    * The constructor. The dictionary is initially empty.

--- a/drake/systems/lcm/lcmt_drake_signal_translator.h
+++ b/drake/systems/lcm/lcmt_drake_signal_translator.h
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <vector>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/vector_base.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
@@ -18,8 +17,7 @@ namespace lcm {
  * Assumes the number and order of values in the LCM message and the
  * drake::systems::VectorBase are identical.
  */
-class DRAKE_EXPORT LcmtDrakeSignalTranslator
-    : public LcmAndVectorBaseTranslator {
+class LcmtDrakeSignalTranslator : public LcmAndVectorBaseTranslator {
  public:
   /**
    * A constructor that sets the expected sizes of the LCM message and the

--- a/drake/systems/lcm/serializer.h
+++ b/drake/systems/lcm/serializer.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_export.h"
 #include "drake/common/drake_throw.h"
 #include "drake/systems/framework/value.h"
 
@@ -19,7 +18,7 @@ namespace lcm {
  * Value<lcmt_drake_signal>.  See Serializer for a message-specific concrete
  * subclass.
  */
-class DRAKE_EXPORT SerializerInterface {
+class SerializerInterface {
  public:
   virtual ~SerializerInterface();
 


### PR DESCRIPTION
Remove DRAKE_EXPORT from a few directories. This is a portion of #3973.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4071)
<!-- Reviewable:end -->
