### PR TITLE
Remove DRAKE_EXPORT from examples

### DIFF
--- a/drake/examples/Atlas/atlasUtil.h
+++ b/drake/examples/Atlas/atlasUtil.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "drake/common/drake_export.h"
-
 namespace Atlas {
 /*
  * The ankle limits is specified by a set of halfspace constraint
@@ -9,6 +7,6 @@ namespace Atlas {
  * ankleCloseToLimits will return true if any row of
  * A*[akx;aky]-b is greater than -tol
  */
-DRAKE_EXPORT bool ankleCloseToLimits(double akx, double aky,
-                                              double tol);
-}
+bool ankleCloseToLimits(double akx, double aky, double tol);
+
+}  // namespace Atlas

--- a/drake/examples/Pendulum/gen/pendulum_state_vector.h
+++ b/drake/examples/Pendulum/gen/pendulum_state_vector.h
@@ -8,7 +8,6 @@
 
 #include <Eigen/Core>
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -16,7 +15,7 @@ namespace examples {
 namespace pendulum {
 
 /// Describes the row indices of a PendulumStateVector.
-struct DRAKE_EXPORT PendulumStateVectorIndices {
+struct PendulumStateVectorIndices {
   /// The total number of rows (coordinates).
   static const int kNumCoordinates = 2;
 
@@ -39,8 +38,10 @@ class PendulumStateVector : public systems::BasicVector<T> {
 
   /// @name Getters and Setters
   //@{
+  // theta
   const T theta() const { return this->GetAtIndex(K::kTheta); }
   void set_theta(const T& theta) { this->SetAtIndex(K::kTheta, theta); }
+  // thetadot
   const T thetadot() const { return this->GetAtIndex(K::kThetadot); }
   void set_thetadot(const T& thetadot) {
     this->SetAtIndex(K::kThetadot, thetadot);

--- a/drake/examples/Pendulum/pendulum_plant.h
+++ b/drake/examples/Pendulum/pendulum_plant.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/drake_export.h"
 #include "drake/examples/Pendulum/gen/pendulum_state_vector.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_system.h"

--- a/drake/examples/Pendulum/pendulum_swing_up.h
+++ b/drake/examples/Pendulum/pendulum_swing_up.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/drake_export.h"
 #include "drake/solvers/trajectoryOptimization/dircol_trajectory_optimization.h"
 
 namespace drake {
@@ -17,7 +16,7 @@ namespace pendulum {
  * the DircolTrajectoryOptimization (and is the number of samples
  * between @p x0 and @p xG).
  */
-void DRAKE_EXPORT AddSwingUpTrajectoryParams(
+void AddSwingUpTrajectoryParams(
     int num_time_samples,
     const Eigen::Vector2d& x0, const Eigen::Vector2d& xG,
     solvers::DircolTrajectoryOptimization*);

--- a/drake/examples/bouncing_ball/ball.cc
+++ b/drake/examples/bouncing_ball/ball.cc
@@ -2,7 +2,6 @@
 #include "drake/examples/bouncing_ball/ball-inl.h"
 
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/drake_export.h"
 
 namespace drake {
 namespace bouncing_ball {

--- a/drake/examples/bouncing_ball/bouncing_ball.cc
+++ b/drake/examples/bouncing_ball/bouncing_ball.cc
@@ -2,7 +2,6 @@
 #include "drake/examples/bouncing_ball/bouncing_ball-inl.h"
 
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/drake_export.h"
 
 namespace drake {
 namespace bouncing_ball {

--- a/drake/examples/kuka_iiwa_arm/iiwa_common.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_common.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/plants/RigidBodyTree.h"
 
 namespace drake {
@@ -11,7 +10,6 @@ namespace kuka_iiwa_arm {
  * Verify that @p tree matches assumptions about joint indices.
  * Aborts if the tree isn't as expected.
  */
-DRAKE_EXPORT
 void VerifyIiwaTree(const RigidBodyTree<double>& tree);
 
 }  // namespace kuka_iiwa_arm

--- a/drake/examples/kuka_iiwa_arm/iiwa_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_simulation.cc
@@ -64,7 +64,6 @@ std::shared_ptr<BotVisualizer<RigidBodySystem::StateVector>>
   return visualizer;
 }
 
-DRAKE_EXPORT
 Eigen::VectorXd GenerateArbitraryIiwaInitialState() {
   const int kStateDimension = 14;  // Fixed for the IIWA Arm.
   const int kNumDof = 7;  // Fixed for the IIWA Arm.

--- a/drake/examples/kuka_iiwa_arm/iiwa_simulation.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_simulation.h
@@ -5,7 +5,6 @@
 #include <Eigen/Geometry>
 #include <lcm/lcm-cpp.hpp>
 
-#include "drake/common/drake_export.h"
 #include "drake/system1/LinearSystem.h"
 #include "drake/systems/plants/BotVisualizer.h"
 #include "drake/systems/plants/RigidBodySystem.h"
@@ -25,14 +24,12 @@ namespace kuka_iiwa_arm {
  *
  * @return A shared pointer to a rigid body system.
  */
-DRAKE_EXPORT
 std::shared_ptr<drake::RigidBodySystem> CreateKukaIiwaSystem();
 
 /**
  * Creates a Bot Visualizer that can be cascaded with @p iiwa_system and
  * publishes LCM visualization messages using @p lcm.
  */
-DRAKE_EXPORT
 std::shared_ptr<BotVisualizer<RigidBodySystem::StateVector>>
     CreateKukaIiwaVisualizer(
     const std::shared_ptr<drake::RigidBodySystem> iiwa_system,
@@ -44,20 +41,17 @@ std::shared_ptr<BotVisualizer<RigidBodySystem::StateVector>>
  * corresponds to an arbitrary initial joint configuration and with the
  * system at rest (0 velocities).
  */
-DRAKE_EXPORT
 Eigen::VectorXd GenerateArbitraryIiwaInitialState();
 
 /**
  * Returns the simulation options for use by the Kuka IIWA simulation.
  */
-DRAKE_EXPORT
 drake::SimulationOptions SetupSimulation(double initial_step_size = 0.002);
 
 /**
  * Checks for joint position and velocity limit violations.
  * `std::runtime_error` is thrown if any limits are violated.
  */
-DRAKE_EXPORT
 void CheckLimitViolations(
     const std::shared_ptr<drake::RigidBodySystem> rigid_body_system,
     const Eigen::VectorXd& final_robot_state);

--- a/drake/examples/schunk_gripper/simulated_schunk_system.cc
+++ b/drake/examples/schunk_gripper/simulated_schunk_system.cc
@@ -1,6 +1,5 @@
 #include "drake/examples/schunk_gripper/simulated_schunk_system.h"
 
-#include "drake/common/drake_export.h"
 #include "drake/systems/plants/parser_sdf.h"
 #include "drake/common/drake_path.h"
 
@@ -22,7 +21,7 @@ CreateSimulatedSchunkSystem() {
       std::move(rigid_body_tree));
 }
 
-template DRAKE_EXPORT std::unique_ptr<drake::systems::RigidBodyPlant<double>>
+template std::unique_ptr<drake::systems::RigidBodyPlant<double>>
 CreateSimulatedSchunkSystem();
 
 }  // namespace schunk_gripper


### PR DESCRIPTION
Remove DRAKE_EXPORT from a examples. This is a portion of #3973.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4073)
<!-- Reviewable:end -->
