### PR TITLE
Set EIGEN_MPL2_ONLY

### DIFF
--- a/tools/eigen.BUILD
+++ b/tools/eigen.BUILD
@@ -6,4 +6,5 @@ cc_library(
                  "unsupported/Eigen/*", "unsupported/Eigen/**/*.h"]),
     visibility = ["//visibility:public"],
     includes = ["."],
+    defines = ["EIGEN_MPL2_ONLY"],
 )


### PR DESCRIPTION
A portion of #4065, for Bazel model only.

I also tried to get this define set in the Drake superbuild via CMake but failed after three attempts at spelling / quoting it correctly.  :i_am_but_an_egg:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4078)
<!-- Reviewable:end -->
