### PR TITLE
Adds USE_SYSTEM_VTK Option to Drake's Superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,8 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS TEST
     yaml_cpp
 )
 
+option(USE_SYSTEM_VTK "Whether to use the system's VTK." ON)
+
 # director
 drake_add_external(director PUBLIC CMAKE TEST
   SOURCE_SUBDIR distro/superbuild
@@ -334,6 +336,7 @@ drake_add_external(director PUBLIC CMAKE TEST
     -DUSE_LCM=${HAVE_LCM}
     -DUSE_LCMGL=${HAVE_LIBBOT}
     -DUSE_SYSTEM_LCM=ON
+    -DUSE_SYSTEM_VTK=${USE_SYSTEM_VTK}
     -DUSE_EXTERNAL_INSTALL=ON
   INSTALL_COMMAND :
   DEPENDS bot_core_lcmtypes drake lcm libbot)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,8 +326,6 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS TEST
     yaml_cpp
 )
 
-option(USE_SYSTEM_VTK "Whether to use the system's VTK." ON)
-
 # director
 drake_add_external(director PUBLIC CMAKE TEST
   SOURCE_SUBDIR distro/superbuild

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -200,6 +200,10 @@ macro(drake_setup_options)
     DEPENDS "HAVE_BOT_CORE_LCMTYPES"
     "robotlocomotion LCM types")
 
+  drake_system_dependency(VTK REQUIRES VTK VERSION 5.8
+    DEPENDS "WITH_DIRECTOR"
+    "Visualization ToolKit")
+
   drake_system_dependency(YAML_CPP OPTIONAL REQUIRES yaml-cpp
     "C++ library for reading and writing YAML configuration files")
 


### PR DESCRIPTION
This CMake variable is used when building Director. It needs to be set to `OFF` when building Drake on Ubuntu 16.04 with ROS Kinetic installed. Otherwise, Director will be built against the wrong version of VTK and a failure will occur. It can be set by executing:

```
$ cd drake-distro/build
$ cmake .. -DUSE_SYSTEM_VTK:BOOL=OFF
```

Per discussion with @jwnimmer-tri, I decided to allow the user to decide whether the system's VTK is used when building Director. This is as opposed to modifying `drake-distro/CMakeLists.txt` to automatically decide whether to use the system's VTK based on whether it is version 5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4089)
<!-- Reviewable:end -->
