### PR TITLE
Fix "absolute-value" warnings in multibody/rigid_body_plant/contact_force.cc

### DIFF
--- a/drake/multibody/rigid_body_plant/contact_force.cc
+++ b/drake/multibody/rigid_body_plant/contact_force.cc
@@ -1,8 +1,13 @@
 #include "drake/multibody/rigid_body_plant/contact_force.h"
-#include <drake/common/drake_assert.h>
+
+#include <cmath>
+
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace systems {
+
+using std::abs;
 
 template <typename T>
 ContactForce<T>::ContactForce(const Vector3<T>& application_point,


### PR DESCRIPTION
Previously, it caused the following warnings:

```
drake-distro/drake/multibody/rigid_body_plant/contact_force.cc:26:16: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
  DRAKE_ASSERT(abs(normal.norm() - 1.0) <
               ^
drake-distro/drake/multibody/rigid_body_plant/contact_force.cc:26:16: note: use function 'std::abs' instead
  DRAKE_ASSERT(abs(normal.norm() - 1.0) <
               ^~~
               std::abs
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4103)
<!-- Reviewable:end -->
