### PR TITLE
Fix missing link in drakeQPControllerLcmTranslator

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/CMakeLists.txt
+++ b/drake/examples/QPInverseDynamicsForHumanoids/CMakeLists.txt
@@ -7,7 +7,7 @@ set(qp_inverse_dynamics_controller_src
 add_library(drakeQPController ${qp_inverse_dynamics_controller_src})
 target_link_libraries(drakeQPController
   drakeOptimization
-  drakeRBSystem
+  drakeRBM
   drakeSide)
 
 if(lcm_FOUND)

--- a/drake/examples/QPInverseDynamicsForHumanoids/CMakeLists.txt
+++ b/drake/examples/QPInverseDynamicsForHumanoids/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(drakeQPController
 if(lcm_FOUND)
   add_library(drakeQPControllerLcmTranslator lcm_utils.cc)
   target_link_libraries(drakeQPControllerLcmTranslator
+    drakeRBM
     drakeLCMTypes
     drakeLCMUtil
     lcmtypes_bot2-core-cpp)


### PR DESCRIPTION
Since @63c53c22276a (#4042), `drakeQPControllerLcmTranslator` uses `RigidBodyTree`, but was not linking to `drakeRBSystem`, resulting in a link error. Add the missing link.

+@jamiesnape (CMake), +@siyuanfeng-tri (for breaking it :smile:) for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4130)
<!-- Reviewable:end -->
