### PR TITLE
remove clipping of the commanded joint position from kuka_plan_runner

### DIFF
--- a/drake/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -90,21 +90,8 @@ class RobotPlanRunner {
 
         iiwa_command.utime = iiwa_status_.utime;
 
-        // This is totally arbitrary.  There's no good reason to
-        // implement this as a maximum delta to submit per tick.  What
-        // we actually need is something like a proper
-        // planner/interpolater which spreads the motion out over the
-        // entire duration from current_t to next_t, and commands the
-        // next position taking into account the velocity of the joints
-        // and the distance remaining.
-        const double max_joint_delta = 0.1;
         for (int joint = 0; joint < kNumJoints; joint++) {
-          double joint_delta =
-              desired_next(joint) - iiwa_status_.joint_position_measured[joint];
-          joint_delta = std::max(-max_joint_delta,
-                                 std::min(max_joint_delta, joint_delta));
-          iiwa_command.joint_position[joint] =
-              iiwa_status_.joint_position_measured[joint] + joint_delta;
+          iiwa_command.joint_position[joint] = desired_next(joint);
         }
 
         lcm_.publish(kLcmCommandChannel, &iiwa_command);


### PR DESCRIPTION
The command clipping was not the desired behavior.  A low-level safety
check could be added to the hardware driver if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4154)
<!-- Reviewable:end -->
