### PR TITLE
Add missing autodiff_overloads_test

### DIFF
--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Build tests for Drake common utilities.
 
+drake_add_cc_test(autodiff_overloads_test)
+target_link_libraries(autodiff_overloads_test drakeCommon)
+
 drake_add_cc_test(functional_form_test)
 target_link_libraries(functional_form_test drakeCommon)
 


### PR DESCRIPTION
This corrects a defect in #4101 where I removed the test from CMakeLists.txt in `math`, but neglected to add it back in `common`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4161)
<!-- Reviewable:end -->
