### PR TITLE
Make the drake_gcc48 toggle more well-phrased

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -15,14 +15,14 @@ cc_library(
         "text_logging.cc",
     ],
     hdrs = [
-        "drake_assert.h",
-        "drake_throw.h",
-        "text_logging.h",
         "constants.h",
+        "drake_assert.h",
+        "drake_compat.h",
         "drake_deprecated.h",
-        "drake_gcc48.h",
+        "drake_throw.h",
         "eigen_stl_types.h",
         "eigen_types.h",
+        "text_logging.h",
     ],
     deps = ["@eigen//:eigen", "@spdlog//:spdlog"],
     linkstatic = 1)

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -32,9 +32,9 @@ set(installed_headers
   autodiff_overloads.h
   constants.h
   drake_assert.h
+  drake_compat.h
   drake_deprecated.h
   drake_export.h
-  drake_gcc48.h
   drake_path.h
   drake_throw.h
   eigen_autodiff_types.h

--- a/drake/common/constants.h
+++ b/drake/common/constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "drake/common/drake_gcc48.h"
+#include "drake/common/drake_compat.h"
 
 namespace drake {
 

--- a/drake/common/drake_assert.h
+++ b/drake/common/drake_assert.h
@@ -2,7 +2,7 @@
 
 #include <type_traits>
 
-#include "drake/common/drake_gcc48.h"
+#include "drake/common/drake_compat.h"
 
 /// @file
 /// Provides Drake's assertion implementation.  This is intended to be used

--- a/drake/common/drake_compat.h
+++ b/drake/common/drake_compat.h
@@ -1,15 +1,14 @@
 #pragma once
 
 /// @file
-/// This header provides a std::make_unique implementation if and only if the
-/// compiler identifies as GCC with a version prior to 4.9.  This file is
+/// This header provides a std::make_unique implementation to be used when the
+/// compiler does not support C++14, or is not in C++14 mode.  This file is
 /// included from a few basic headers within the drake/common subdirectory,
 /// such that almost every file in Drake is exposed to it.  This allows us to
 /// write code using the std::make_unique phrasing, but still support GCC 4.8.
 
 #ifndef DRAKE_DOXYGEN_CXX
-#if defined(__GNUG__) && !defined(__clang__)
-#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
+#if __cplusplus <= 201103L  // If C++11 or earlier, we need our own make_unique.
 
 #include <memory>
 
@@ -21,5 +20,4 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 }  // namespace std
 
 #endif  // version check
-#endif  // compiler check
 #endif  // doxygen check

--- a/drake/common/eigen_matrix_compare.h
+++ b/drake/common/eigen_matrix_compare.h
@@ -7,7 +7,7 @@
 
 #include <Eigen/Dense>
 
-#include "drake/common/drake_gcc48.h"
+#include "drake/common/drake_compat.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {

--- a/drake/common/eigen_stl_types.h
+++ b/drake/common/eigen_stl_types.h
@@ -14,7 +14,7 @@
 #include <Eigen/Core>
 #include <Eigen/StdVector>
 
-#include "drake/common/drake_gcc48.h"
+#include "drake/common/drake_compat.h"
 
 namespace drake {
 


### PR DESCRIPTION
Rename `drake_gcc48.h` to `drake_compat.h`, and make the _"Does the compiler support make_unique?"_ check look at the `__cplusplus` setting instead of the compiler version.  This is more robust for e.g. `clang++-3.8` when run in `-std=c++11` mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4176)
<!-- Reviewable:end -->
