### PR TITLE
Adds Missing Call to include_directories() in drake_ros_systems's CMakeLists.txt.

### DIFF
--- a/ros/drake_ros_systems/CMakeLists.txt
+++ b/ros/drake_ros_systems/CMakeLists.txt
@@ -10,6 +10,12 @@ catkin_package(
   #DEPENDS
 )
 
+## Specifies additional locations of header files.
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   include_directories(${CMAKE_INSTALL_PREFIX}/include)


### PR DESCRIPTION
Without this fix, the following error is observed on Ubuntu 16.04 / ROS Kinetic:

```
Errors     << drake_ros_systems:make /home/liang/dev/drake_catkin_workspace/logs/drake_ros_systems/build.make.000.log                                                                                       
/home/liang/dev/drake_catkin_workspace/src/drake_ros_integration/drake_ros_systems/test/ros_test.cc:3:21: fatal error: ros/ros.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/ros_test.dir/test/ros_test.cc.o] Error 1
make[1]: *** [CMakeFiles/ros_test.dir/all] Error 2
make: *** [all] Error 2
cd /home/liang/dev/drake_catkin_workspace/build/drake_ros_systems; catkin build --get-env drake_ros_systems | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4178)
<!-- Reviewable:end -->
