### PR TITLE
Adds missing installed header - contact_force.h.

### DIFF
--- a/drake/multibody/rigid_body_plant/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/CMakeLists.txt
@@ -45,6 +45,7 @@ drake_install_headers(
     ${lcm_dependent_header_files}
     kinematics_results.h rigid_body_plant.h
     contact_detail.h
+    contact_force.h
     contact_results.h
     contact_info.h
     )


### PR DESCRIPTION
I discovered this while working on a project that depends on Drake.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4182)
<!-- Reviewable:end -->
