### PR TITLE
Toward #4188: fix code-gen scripts portability and usability.

### DIFF
--- a/drake/automotive/simple_car_gen.sh
+++ b/drake/automotive/simple_car_gen.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Generates the source files for LCM messages and BasicVectors used in 
+# Generates the source files for LCM messages and BasicVectors used in
 # SimpleCar.
 
-me=$(readlink -f "$0")
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 drake=$(dirname "$mydir")
 

--- a/drake/examples/Pendulum/pendulum_gen.sh
+++ b/drake/examples/Pendulum/pendulum_gen.sh
@@ -2,7 +2,7 @@
 
 # Generates the source files for the PendulumStateVector.
 
-me=$(readlink -f "$0")
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 examples=$(dirname "$mydir")
 drake=$(dirname "$examples")

--- a/drake/tools/lcm_vector_gen.sh
+++ b/drake/tools/lcm_vector_gen.sh
@@ -22,6 +22,13 @@ mkdir -p $drake/lcmtypes
 mkdir -p $mydir/gen
 
 CLANG_FORMAT=${CLANG_FORMAT:-clang-format}
+if ! type -p $CLANG_FORMAT > /dev/null ; then
+    cat <<EOF
+Cannot find $CLANG_FORMAT ; see installation instructions at:
+http://drake.mit.edu/code_style_tools.html
+EOF
+    exit 1
+fi
 
 # Call the code generator to produce an LCM message, a translator, and
 # a Drake BasicVector.

--- a/drake/tools/lcm_vector_gen.sh
+++ b/drake/tools/lcm_vector_gen.sh
@@ -18,7 +18,10 @@ then
   exit 1
 fi
 
-CLANG_FORMAT=${CLANG_FORMAT:-clang-format-3.7}
+mkdir -p $drake/lcmtypes
+mkdir -p $mydir/gen
+
+CLANG_FORMAT=${CLANG_FORMAT:-clang-format}
 
 # Call the code generator to produce an LCM message, a translator, and
 # a Drake BasicVector.


### PR DESCRIPTION
 * Use python's os.path.realpath() for portable canonicalization.
 * Ensure output directories exist.
 * default to un-versioned clang-format if not provided in environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4200)
<!-- Reviewable:end -->
