### PR TITLE
Improve collision detection for contact - initial hack for speed

### DIFF
--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -421,8 +421,8 @@ VectorX<T> RigidBodyPlant<T>::ComputeContactForce(
   // TODO(amcastro-tri): get rid of this const_cast.
   // Unfortunately collisionDetect() modifies the collision model in the RBT
   // when updating the collision element poses.
-  const_cast<RigidBodyTree<T>*>(tree_.get())
-      ->AllPairsClosestPoints(kinsol, &pairs);
+  pairs = const_cast<RigidBodyTree<T>*>(tree_.get())
+      ->ComputeMaximumDepthCollisionPoints(kinsol, true);
 
   VectorX<T> contact_force(kinsol.getV().rows(), 1);
   contact_force.setZero();

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -773,6 +773,7 @@ RigidBodyTree<T>::ComputeMaximumDepthCollisionPoints(
   // information for pairs that shouldn't be considered. This code filters the
   // results into `valid_pairs` with the expectation of removal after drake
   // collision filters are fully integrated into the collision model.
+  // See issue #4204 (https://github.com/RobotLocomotion/drake/issues/4204).
   std::vector<DrakeCollision::PointPair> valid_pairs;
   valid_pairs.reserve(contact_points.size());
   for (size_t i = 0; i < num_contact_points; ++i) {

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -780,48 +780,6 @@ class RigidBodyTree {
       std::vector<int>& bodyB_idx,
       bool use_margins = true);
 
-  // TODO(SeanCurtis-TRI): Properly classify the use_margins parameter so it
-  // can be meaningfully documented.
-  /**
-   * This performs all-pairs collision detection (excepting those filtered out)
-   * across all of the bodies in the tree.  One result is provided for each
-   * tested pair (colliding or not).
-   *
-   * @param[in]  cache          The dynamic pose data for the tree.
-   * @param[out] pairs          A vector that will be populated with the query
-   *                            data.  There will be one entry per pair of
-   *                            tested collision elements. The contact
-   *                            points are each expressed in their corresponding
-   *                            body's frame and the normal is expressed in the
-   *                            world frame.
-   * @param use_margins         Unclear purpose; requires investigation.
-   * @returns                   The same bool as RigidBodyTree::collisionDetect.
-   */
-  bool AllPairsClosestPoints(const KinematicsCache<double>& cache,
-                             std::vector<DrakeCollision::PointPair>* pairs,
-                             bool use_margins = true);
-
-  /**
-   * This performs all-pairs collision detection (excepting those filtered out)
-   * across the provided set of collision elements (named by id).  One result is
-   * provided for each tested pair (colliding or not).
-   *
-   * @param[in]  cache          The dynamic pose data for the tree.
-   * @param[in]  ids_to_check   The set of collision element ids to test.
-   * @param[out] pairs          A vector that will be populated with the query
-   *                            data.  There will be one entry per pair of
-   *                            tested collision elements. The the contact
-   *                            points are each expressed in their corresponding
-   *                            body's frame and the normal is expressed in the
-   *                            world frame.
-   * @param use_margins         Unclear purpose; requires investigation.
-   * @returns                   The same bool as RigidBodyTree::collisionDetect.
-   */
-  bool AllPairsClosestPointsInSet(
-      const KinematicsCache<double>& cache,
-      const std::vector<DrakeCollision::ElementId>& ids_to_check,
-      std::vector<DrakeCollision::PointPair>* pairs, bool use_margins);
-
   /** Computes the point of closest approach between bodies in the
    RigidBodyTree that are in contact.
 

--- a/drake/multibody/test/rigid_body_tree/linked_spheres_on_large_box.sdf
+++ b/drake/multibody/test/rigid_body_tree/linked_spheres_on_large_box.sdf
@@ -1,0 +1,67 @@
+<?xml version='1.0' ?>
+<sdf version='1.6'>
+  <model name='simple_collision_world'>
+    <pose>0 0 0 0 0 0</pose>
+    <link name='large_box'>
+      <pose>0 2.5 0 0 0 0</pose>
+      <visual name='box'>
+        <geometry>
+          <box>
+            <size>5.0 5.0 5.0</size>
+          </box>
+        </geometry>
+      </visual>
+      <collision name='box'>
+        <geometry>
+          <box>
+            <size>5.0 5.0 5.0</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+
+    <link name='small_sphere_1'>
+      <pose>0 5.4 0 0 0 0</pose>
+      <visual name='box'>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+      </visual>
+      <collision name='sphere'>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+
+    <link name='small_sphere_2'>
+      <pose>0 6.3 0 0.5 0 0</pose>
+      <visual name='box'>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+      </visual>
+      <collision name='sphere'>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="sphere_joint" type="revolute">
+      <parent>small_sphere_1</parent>
+      <child>small_sphere_2</child>
+      <pose>0 0.5 0 0 0 0</pose>
+      <axis> <xyz>0 1 0</xyz> </axis>
+    </joint>
+
+  </model>
+</sdf>

--- a/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
@@ -185,6 +185,9 @@ TEST_F(RBTCollisionCliqueTest, ComputeContactPointsWithCliques) {
   const RigidBody<double>* bodyA = collision_pairs[0].elementA->get_body();
   const RigidBody<double>* bodyB = collision_pairs[0].elementB->get_body();
 
+  EXPECT_EQ(bodyA, large_box_);
+  EXPECT_EQ(bodyB, small_sphere_1_);
+
   EXPECT_NEAR(-0.1, collision_pairs[0].distance, tolerance_);
   EXPECT_TRUE(collision_pairs[0].normal.isApprox(Vector3d(0.0, -1.0, 0.0)));
 

--- a/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
@@ -162,7 +162,7 @@ TEST_F(RBTCollisionCliqueTest, ComputeContactPointsWithCliques) {
   // Numerical precision tolerance to perform floating point comparisons.
   // Its magnitude was chosen to be the minimum value for which these tests can
   // successfully pass.
-  tolerance_ = 4.0*Eigen::NumTraits<double>::epsilon();
+  tolerance_ = 4.0 * Eigen::NumTraits<double>::epsilon();
 
   int nq = tree_.get_num_positions();
   int nv = tree_.get_num_velocities();

--- a/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
@@ -187,9 +187,6 @@ TEST_F(RBTCollisionCliqueTest, ComputeContactPointsWithCliques) {
   const RigidBody<double>* bodyA = collision_pairs[0].elementA->get_body();
   const RigidBody<double>* bodyB = collision_pairs[0].elementB->get_body();
 
-  EXPECT_EQ(bodyA, large_box_);
-  EXPECT_EQ(bodyB, small_sphere_1_);
-
   EXPECT_NEAR(-0.1, collision_pairs[0].distance, tolerance_);
   EXPECT_TRUE(collision_pairs[0].normal.isApprox(Vector3d(0.0, -1.0, 0.0)));
 

--- a/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
@@ -117,6 +117,84 @@ TEST_F(RBTCollisionTest, FindAndComputeContactPoints) {
       solution_[bodyB].body_frame, tolerance_));
 }
 
+// Tests that the RigidBodyTree::ComputeMaximumDepthCollisionPoints correctly
+// handles collision clique information. This scene uses *three* objects.
+// A large box with a single sphere on top of it (penetrating into the box).
+// A second sphere lies on top of the first (also penetrating.)  However, the
+// two spheres are connected by a joint, so their penetration is *not* reported.
+class RBTCollisionCliqueTest: public ::testing::Test {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ protected:
+  void SetUp() override {
+    drake::parsers::sdf::AddModelInstancesFromSdfFileInWorldFrame(
+        drake::GetDrakePath() +
+            "/multibody/test/rigid_body_tree/linked_spheres_on_large_box.sdf",
+        drake::multibody::joints::kQuaternion, &tree_);
+
+    small_sphere_1_ = tree_.FindBody("small_sphere_1");
+    small_sphere_2_ = tree_.FindBody("small_sphere_2");
+    large_box_ = tree_.FindBody("large_box");
+
+    // Access the analytical solution to the contact point on the surface of
+    // each collision element by element id.
+    // Solutions are expressed in world and body frames.
+    solution_ = {
+        /*              world frame    , body frame  */
+        {large_box_,    {{0.0, 5.0, 0.0}, {0.0, 2.5, 0.0}}},
+        {small_sphere_1_, {{0.0, 4.9, 0.0}, {0.0, -0.5, 0.0}}}};
+  }
+
+  double tolerance_;
+  RigidBodyTree<double> tree_;
+  const RigidBody<double> *small_sphere_1_, *small_sphere_2_, *large_box_;
+  BodyToSurfacePointMap solution_;
+};
+
+// This unit test assesses the correct return from
+// RigidBodyTree::ComputeMaximumDepthCollisionPoints.
+// This evaluates the results of a box and two penetrating but linked spheres.
+// Should produce a single contact.
+TEST_F(RBTCollisionCliqueTest, ComputeContactPointsWithCliques) {
+  // Numerical precision tolerance to perform floating point comparisons.
+  // Its magnitude was chosen to be the minimum value for which these tests can
+  // successfully pass.
+  tolerance_ = 4.0*Eigen::NumTraits<double>::epsilon();
+
+  int nq = tree_.get_num_positions();
+  int nv = tree_.get_num_velocities();
+  int num_states = nq + nv;
+  VectorXd x = VectorXd::Zero(num_states);
+  x.head(nq) = tree_.getZeroConfiguration();
+
+  auto q = x.topRows(nq);
+  auto v = x.bottomRows(nv);
+
+  KinematicsCache<double> kinsol = tree_.doKinematics(q, v);
+
+  std::vector<DrakeCollision::PointPair> collision_pairs =
+      tree_.ComputeMaximumDepthCollisionPoints(
+          kinsol, false);
+
+  // RigidBodyTree::ComputeMaximumDepthCollisionPoints returns only one point,
+  // the maximum depth collision point. The overlapping spheres should be
+  // ignored because they are linked by a joint.
+  ASSERT_EQ(1u, collision_pairs.size());
+
+  const RigidBody<double>* bodyA = collision_pairs[0].elementA->get_body();
+  const RigidBody<double>* bodyB = collision_pairs[0].elementB->get_body();
+
+  EXPECT_NEAR(-0.1, collision_pairs[0].distance, tolerance_);
+  EXPECT_TRUE(collision_pairs[0].normal.isApprox(Vector3d(0.0, -1.0, 0.0)));
+
+  // Collision points are reported on each of the respective bodies' frames.
+  EXPECT_TRUE(collision_pairs[0].ptA.isApprox(
+      solution_[bodyA].body_frame, tolerance_));
+  EXPECT_TRUE(collision_pairs[0].ptB.isApprox(
+      solution_[bodyB].body_frame, tolerance_));
+}
+
 }  // namespace
 }  // namespace rigid_body_tree
 }  // namespace test

--- a/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
@@ -122,6 +122,9 @@ TEST_F(RBTCollisionTest, FindAndComputeContactPoints) {
 // A large box with a single sphere on top of it (penetrating into the box).
 // A second sphere lies on top of the first (also penetrating.)  However, the
 // two spheres are connected by a joint, so their penetration is *not* reported.
+// By convention, any links/bodies that are connected by a joint cannot be
+// considered for collision because their collision geometry will typically
+// overlap in a physically meaningless manner.
 class RBTCollisionCliqueTest: public ::testing::Test {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -155,7 +158,6 @@ class RBTCollisionCliqueTest: public ::testing::Test {
 // This unit test assesses the correct return from
 // RigidBodyTree::ComputeMaximumDepthCollisionPoints.
 // This evaluates the results of a box and two penetrating but linked spheres.
-// Should produce a single contact.
 TEST_F(RBTCollisionCliqueTest, ComputeContactPointsWithCliques) {
   // Numerical precision tolerance to perform floating point comparisons.
   // Its magnitude was chosen to be the minimum value for which these tests can


### PR DESCRIPTION
This is the implementation of the first step listed in #4204. 

It replaces the old `AllPairs` O(N^2) algorithm for computing contact forces with one that exploits Bullet's broadphase collision culling.  Due to architectural issues between Drake and Bullet, the results of Bullet are now filtered *post hoc* to remove results that Bullet should *not* have computed.  This is neither the "correct" nor final solution, but it introduces improved practical functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4206)
<!-- Reviewable:end -->
