### PR TITLE
Add realtime slowdown feature to Simulator

### DIFF
--- a/drake/examples/Quadrotor/CMakeLists.txt
+++ b/drake/examples/Quadrotor/CMakeLists.txt
@@ -2,7 +2,11 @@
 # due to a bug in Eigen; see issue #2106 and PR #2107.
 if(lcm_FOUND AND NOT (WIN32 AND (CMAKE_SIZEOF_VOID_P EQUAL 4)))
   add_executable(run_quadrotor_dynamics run_quadrotor_dynamics.cc)
-  target_link_libraries(run_quadrotor_dynamics drakeRigidBodyPlant drakeLCMSystem2 gflags)
+  target_link_libraries(run_quadrotor_dynamics
+    drakeRigidBodyPlant
+    drakeSystemAnalysis
+    drakeLCMSystem2
+    gflags)
   drake_add_test(NAME run_quadrotor_dynamics COMMAND run_quadrotor_dynamics --duration=1.0 SIZE medium)
 
 # TODO(russt): port this to System2.0 and re-enable

--- a/drake/systems/analysis/simulator.cc
+++ b/drake/systems/analysis/simulator.cc
@@ -36,7 +36,7 @@ struct TtoDouble<double> {
   static double convert(const double& scalar) { return scalar; }
 };
 
-}
+}  // namespace
 
 template <typename T>
 void Simulator<T>::PauseIfTooFast() const {

--- a/drake/systems/analysis/simulator.cc
+++ b/drake/systems/analysis/simulator.cc
@@ -35,12 +35,7 @@ template <>
 struct TtoDouble<double> {
   static double convert(const double& scalar) { return scalar; }
 };
-template <>
-struct TtoDouble<float> {
-  static double convert(const float& scalar) {
-    return static_cast<double>(scalar);
-  }
-};
+
 }
 
 template <typename T>

--- a/drake/systems/analysis/simulator.cc
+++ b/drake/systems/analysis/simulator.cc
@@ -1,10 +1,80 @@
-#include "drake/systems/analysis/simulator.h"
+#include <chrono>
+#include <limits>
+#include <thread>
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/systems/analysis/simulator.h"
 
 namespace drake {
 namespace systems {
+
+namespace {
+
+// This struct converts an object of type T to a double. The default
+// implementation returns NaN. Overloads provide sensible conversions.
+// Note that we do not expect to be running simulations while instantiated
+// with non-numerical scalar types!
+// (We're using a struct here because partial instantiation does not work
+// with function templates.)
+template <typename T>
+struct TtoDouble {
+  static double convert(const T&) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+};
+// Partial specialization for AutoDiffScalar.
+template <typename DerType>
+struct TtoDouble<Eigen::AutoDiffScalar<DerType>> {
+  static double convert(const Eigen::AutoDiffScalar<DerType>& scalar) {
+    return static_cast<double>(scalar.value());
+  }
+};
+// Specializations for floating types.
+template <>
+struct TtoDouble<double> {
+  static double convert(const double& scalar) { return scalar; }
+};
+template <>
+struct TtoDouble<float> {
+  static double convert(const float& scalar) {
+    return static_cast<double>(scalar);
+  }
+};
+}
+
+template <typename T>
+void Simulator<T>::PauseIfTooFast() const {
+  if (target_realtime_rate_ <= 0) return;  // Run at full speed.
+  const double simtime_now = TtoDouble<T>::convert(get_context().get_time());
+  const double simtime_passed = simtime_now - initial_simtime_;
+  const TimePoint desired_realtime =
+      initial_realtime_ + Duration(simtime_passed / target_realtime_rate_);
+  // TODO(sherm1): Could add some slop to now() and not sleep if
+  // we are already close enough. But what is a reasonable value?
+  if (desired_realtime > Clock::now())
+    std::this_thread::sleep_until(desired_realtime);
+}
+
+template <typename T>
+double Simulator<T>::get_actual_realtime_rate() const {
+  const double simtime_now = TtoDouble<T>::convert(get_context().get_time());
+  const double simtime_passed = simtime_now - initial_simtime_;
+  const Duration realtime_passed = Clock::now() - initial_realtime_;
+  const double rate = (simtime_passed / realtime_passed.count());
+  return rate;
+}
+
+template <typename T>
+void Simulator<T>::ResetStatistics() {
+  integrator_->ResetStatistics();
+  num_steps_taken_ = 0;
+  num_updates_ = 0;
+  num_publishes_ = 0;
+
+  initial_simtime_ = TtoDouble<T>::convert(get_context().get_time());
+  initial_realtime_ = Clock::now();
+}
 
 template class Simulator<double>;
 template class Simulator<AutoDiffXd>;

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <chrono>
 #include <limits>
 #include <tuple>
@@ -102,10 +103,18 @@ class Simulator {
    */
   void StepTo(const T& boundary_time);
 
-  /** Slow the simulation down to synchronize with real time when it would
-   * otherwise run too fast. Normally the %Simulator takes steps as quickly as
-   * it can. You can request that it slow down to synchronize with real time by
-   * providing a realtime rate greater than zero here.
+  /** Slow the simulation down to *approximately* synchronize with real time
+   * when it would otherwise run too fast. Normally the %Simulator takes steps
+   * as quickly as it can. You can request that it slow down to synchronize with
+   * real time by providing a realtime rate greater than zero here.
+   *
+   * @warning No guarantees can be made about how accurately the simulation
+   * can be made to track real time, even if computation is fast enough. That's
+   * because the system utilities used to implement this do not themselves
+   * provide such guarantees. So this is likely to work nicely for visualization
+   * purposes where human perception is the only concern. For any other uses
+   * you should consider whether approximate real time is adequate for your
+   * purposes.
    *
    * @note If the full-speed simulation is already slower than real time you
    * can't speed it up with this call! Instead consider requesting less

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <limits>
 #include <tuple>
 #include <utility>
@@ -101,6 +102,58 @@ class Simulator {
    */
   void StepTo(const T& boundary_time);
 
+  /** Slow the simulation down to synchronize with real time when it would
+   * otherwise run too fast. Normally the %Simulator takes steps as quickly as
+   * it can. You can request that it slow down to synchronize with real time by
+   * providing a realtime rate greater than zero here.
+   *
+   * @note If the full-speed simulation is already slower than real time you
+   * can't speed it up with this call! Instead consider requesting less
+   * integration accuracy, using a faster integration method or fixed time
+   * step, or using a simpler model.
+   *
+   * @param realtime_rate
+   *   Desired rate relative to real time. Set to 1 to track real time, 2 to
+   *   run twice as fast as real time, 0.5 for half speed, etc. Zero or
+   *   negative restores the rate to its default of 0, meaning the simulation
+   *   will proceed as fast as possible.
+   */
+  // TODO(sherm1): Provide options for issuing a warning or aborting the
+  // simulation if the desired rate cannot be achieved.
+  void set_target_realtime_rate(double realtime_rate) {
+    target_realtime_rate_ = std::max(realtime_rate, 0.);
+  }
+
+  /** Return the real time rate target currently in effect. The default is
+   * zero, meaning the %Simulator runs as fast as possible. You can change the
+   * target with set_target_realtime_rate().
+   */
+  double get_target_realtime_rate() const {
+    return target_realtime_rate_;
+  }
+
+  /** Return the rate that simulated time has progressed relative to real time.
+   * A return of 1 means the simulation just matched real
+   * time, 2 means the simulation was twice as fast as real time, 0.5 means
+   * it was running in 2X slow motion, etc.
+   *
+   * The value returned here is calculated as follows: <pre>
+   *
+   *          simulated_time_now - initial_simulated_time
+   *   rate = -------------------------------------------
+   *                realtime_now - initial_realtime
+   * </pre>
+   * The `initial` times are recorded when Initialize() or ResetStatistics()
+   * is called. The returned rate is undefined if Initialize() has not yet
+   * been called.
+   *
+   * @returns The rate achieved since the last Initialize() or ResetStatistics()
+   *          call.
+   *
+   * @see set_target_realtime_rate()
+   */
+  double get_actual_realtime_rate() const;
+
   /** Returns a const reference to the internally-maintained Context holding the
    * most recent step in the trajectory. This is suitable for publishing or
    * extracting information about this trajectory step.
@@ -142,12 +195,7 @@ class Simulator {
   /** Forget accumulated statistics. Statistics are reset to the values they
    * have post construction or immediately after `Initialize()`.
    */
-  void ResetStatistics() {
-    integrator_->ResetStatistics();
-    num_steps_taken_ = 0;
-    num_updates_ = 0;
-    num_publishes_ = 0;
-  }
+  void ResetStatistics();
 
   /**
    * Gets the number of publishes made since the last Initialize() or
@@ -162,25 +210,25 @@ class Simulator {
   Initialize() call? */
   int64_t get_num_updates() const { return num_updates_; }
 
-  /**
-   *   Gets a pointer to the integrator used to advance the continuous aspects
-   *   of the system.
+  /** Gets a pointer to the integrator used to advance the continuous aspects
+   *  of the system.
    */
   const IntegratorBase<T>* get_integrator() const { return integrator_.get(); }
 
-  /**
-   *   Gets a pointer to the mutable integrator used to advance the continuous
-   *   aspects of the system.
+  /** Gets a pointer to the mutable integrator used to advance the continuous
+   * aspects of the system.
    */
   IntegratorBase<T>* get_mutable_integrator() { return integrator_.get(); }
 
-  /**
-   *   Resets the integrator with a new one. An example usage is:
-   *   simulator.reset_integrator<ExplicitEulerIntegrator<double>>(sys, context,
-   *   DT). The integrator must be initialized (via
-   *   IntegratorBase::Initialize() function)
-   *   before being used. The simulator will call that function automatically
-   *   in its own Initialize() function.
+  /** Resets the integrator with a new one. An example usage is:
+   * @code
+   * simulator.reset_integrator<ExplicitEulerIntegrator<double>>
+   *               (sys, context, DT).
+   * @endcode
+   * The %Simulator must be reinitialized after resetting the integrator to
+   * ensure the integrator is properly initialized. You can do that explicitly
+   * with the Initialize() method or it will be done implicitly at the first
+   * time step.
    */
   template <class U, typename... Args>
   U* reset_integrator(Args&&... args) {
@@ -190,6 +238,12 @@ class Simulator {
   }
 
  private:
+  // The steady_clock is immune to system clock changes so increases
+  // monotonically. We'll work in fractional seconds.
+  using Clock = std::chrono::steady_clock;
+  using Duration = std::chrono::duration<double>;
+  using TimePoint = std::chrono::time_point<Clock, Duration>;
+
   Simulator(const Simulator& s) = delete;
   Simulator& operator=(const Simulator& s) = delete;
 
@@ -199,6 +253,10 @@ class Simulator {
                                                const T& ideal_step_size,
                                                const T& next_update_time,
                                                const T& final_time);
+
+  // If the simulated time in the context is ahead of real time, pause long
+  // enough to let real time catch up (approximately).
+  void PauseIfTooFast() const;
 
   // A pointer to the integrator.
   std::unique_ptr<IntegratorBase<T>> integrator_;
@@ -217,6 +275,13 @@ class Simulator {
   const System<T>& system_;              // Just a reference; not owned.
   std::unique_ptr<Context<T>> context_;  // The trajectory Context.
 
+  // Slow down to this rate if possible (user settable).
+  double target_realtime_rate_{0.};
+
+  // These are recorded at initialization or statistics reset.
+  double initial_simtime_{nan()};  // Simulated time at start of period.
+  TimePoint initial_realtime_;     // Real time at start of period.
+
   // The number of updates since the last call to Initialize().
   int64_t num_updates_{0};
 
@@ -225,6 +290,7 @@ class Simulator {
 
   // The number of integration steps since the last call to Initialize().
   int64_t num_steps_taken_{0};
+
 
   // Set by Initialize() and reset by various traumas.
   bool initialization_done_{false};
@@ -295,6 +361,9 @@ void Simulator<T>::StepTo(const T& boundary_time) {
     // Starting a new step on the trajectory.
     const T step_start_time = context_->get_time();
     SPDLOG_TRACE(log(), "Starting a simulation step at {}", step_start_time);
+
+    // Delay to match target realtime rate if requested and possible.
+    PauseIfTooFast();
 
     // First take any necessary discrete actions.
     if (update_hit) {

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -23,7 +23,7 @@ GTEST_TEST(SimulatorTest, SecondConstructor) {
   analysis_test::MySpringMassSystem<double> spring_mass(1., 1., 0.);
   auto context = spring_mass.CreateDefaultContext();
 
-  // Mark the context with an arbitrary value
+  // Mark the context with an arbitrary value.
   context->set_time(3.);
 
   /// Construct the simulator with the created context.
@@ -46,13 +46,13 @@ GTEST_TEST(SimulatorTest, MiscAPI) {
   EXPECT_TRUE(std::isnan(simulator.get_actual_realtime_rate()));
 
   // Set the integrator default step size.
-  const double DT = 1e-3;
+  const double dt = 1e-3;
 
   // Create a context.
   auto context = simulator.get_mutable_context();
 
   // Create the integrator.
-  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, DT,
+  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, dt,
                                                               context);
 
   // Initialize the simulator first.
@@ -63,27 +63,27 @@ GTEST_TEST(SimulatorTest, ContextAccess) {
   analysis_test::MySpringMassSystem<double> spring_mass(1., 1., 0.);
   Simulator<double> simulator(spring_mass);  // Use default Context.
 
-  // set the integrator default step size
-  const double DT = 1e-3;
+  // Set the integrator default step size.
+  const double dt = 1e-3;
 
-  // get the context
+  // Get the context.
   auto context = simulator.get_mutable_context();
 
-  // create the integrator
-  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, DT,
+  // Create the integrator.
+  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, dt,
                                                               context);
 
-  // initialize the simulator first
+  // Initialize the simulator first.
   simulator.Initialize();
 
-  // try some other context stuff
+  // Try some other context stuff.
   simulator.get_mutable_context()->set_time(3.);
   EXPECT_EQ(simulator.get_context().get_time(), 3.);
   simulator.release_context();
   EXPECT_TRUE(simulator.get_mutable_context() == nullptr);
   EXPECT_THROW(simulator.Initialize(), std::logic_error);
 
-  // create another context
+  // Create another context.
   auto ucontext = spring_mass.CreateDefaultContext();
   ucontext->set_time(3.);
   simulator.reset_context(std::move(ucontext));
@@ -97,8 +97,8 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   const double kSpring = 300.0;  // N/m
   const double kMass = 2.0;      // kg
 
-  // set the integrator default step size
-  const double DT = 1e-3;
+  // Set the integrator default step size.
+  const double dt = 1e-3;
 
   analysis_test::MySpringMassSystem<double> spring_mass(kSpring, kMass, 0.);
   Simulator<double> simulator(spring_mass);  // Use default Context.
@@ -106,15 +106,15 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   // Set initial condition using the Simulator's internal Context.
   spring_mass.set_position(simulator.get_mutable_context(), 0.1);
 
-  // get the context
+  // Get the context.
   auto context = simulator.get_mutable_context();
 
-  // create the integrator
-  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, DT,
+  // Create the integrator.
+  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, dt,
                                                               context);
 
   simulator.set_target_realtime_rate(0.5);
-  // set the integrator and initialize the simulator
+  // Set the integrator and initialize the simulator.
   simulator.Initialize();
 
   // Simulate for 1 second.
@@ -138,16 +138,16 @@ GTEST_TEST(SimulatorTest, RealtimeRate) {
   analysis_test::MySpringMassSystem<double> spring_mass(1., 1., 0.);
   Simulator<double> simulator(spring_mass);  // Use default Context.
 
-  simulator.set_target_realtime_rate(1.); // No faster than 1X real time.
+  simulator.set_target_realtime_rate(1.);  // No faster than 1X real time.
   simulator.get_mutable_context()->set_time(0.);
   simulator.Initialize();
-  simulator.StepTo(1.); // Simulate for 1 simulated second.
+  simulator.StepTo(1.);  // Simulate for 1 simulated second.
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 1.1);
 
-  simulator.set_target_realtime_rate(5.); // No faster than 5X real time.
+  simulator.set_target_realtime_rate(5.);  // No faster than 5X real time.
   simulator.get_mutable_context()->set_time(0.);
   simulator.Initialize();
-  simulator.StepTo(1.); // Simulate for 1 more simulated second.
+  simulator.StepTo(1.);  // Simulate for 1 more simulated second.
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 5.1);
 }
 
@@ -158,33 +158,33 @@ GTEST_TEST(SimulatorTest, SpringMass) {
   const double kSpring = 300.0;  // N/m
   const double kMass = 2.0;      // kg
 
-  // set the integrator default step size
-  const double DT = 1e-3;
+  // Set the integrator default step size.
+  const double dt = 1e-3;
 
-  // create the mass spring system and the simulator
+  // Create the mass spring system and the simulator.
   analysis_test::MySpringMassSystem<double> spring_mass(kSpring, kMass, 30.);
   Simulator<double> simulator(spring_mass);  // Use default Context.
 
-  // get the context
+  // Get the context.
   auto context = simulator.get_mutable_context();
 
-  // TODO(edrumwri): remove this when discrete state has been created
-  // automatically
-  // Create the discrete state
+  // TODO(edrumwri): Remove this when discrete state has been created
+  // automatically.
+  // Create the discrete state.
   context->set_difference_state(std::make_unique<DifferenceState<double>>());
 
   // Set initial condition using the Simulator's internal Context.
   spring_mass.set_position(simulator.get_mutable_context(), 0.1);
 
-  // create the integrator and initialize it
+  // Create the integrator and initialize it.
   auto integrator = simulator.reset_integrator<ExplicitEulerIntegrator<double>>(
-      spring_mass, DT, context);
+      spring_mass, dt, context);
   integrator->Initialize();
 
-  // set the integrator and initialize the simulator
+  // Set the integrator and initialize the simulator.
   simulator.Initialize();
 
-  // simulate up to one second
+  // Simulate up to one second.
   simulator.StepTo(1.);
 
   EXPECT_GT(simulator.get_num_steps_taken(), 1000);


### PR DESCRIPTION
Adds `Simulator::set_target_realtime_rate()` to slow down a too-fast simulation. Let's hope we have this problem a lot!

Fixes #3952.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4209)
<!-- Reviewable:end -->
