### PR TITLE
Fix for accuracy of feedthrough affine systems (#4192 fix)

### DIFF
--- a/drake/systems/framework/primitives/affine_system.h
+++ b/drake/systems/framework/primitives/affine_system.h
@@ -53,7 +53,7 @@ class AffineSystem : public LeafSystem<T> {
 
   /// The input to this system is direct feedthrough only if the coefficient
   /// matrix `D` is non-zero.
-  bool has_any_direct_feedthrough() const override { return !D_.isZero(); }
+  bool has_any_direct_feedthrough() const override { return !D_.isZero(0.0); }
 
   /// Returns the input port containing the externally applied input.
   const SystemPortDescriptor<T>& get_input_port() const;

--- a/drake/systems/framework/primitives/test/affine_linear_test.h
+++ b/drake/systems/framework/primitives/test/affine_linear_test.h
@@ -38,7 +38,8 @@ class AffineLinearSystemTest : public ::testing::Test {
     return std::make_unique<FreestandingInputPort>(std::move(data));
   }
 
-  static Eigen::MatrixXd make_2x2_matrix(double a, double b, double c, double d) {
+  static Eigen::MatrixXd make_2x2_matrix(
+      double a, double b, double c, double d) {
     Eigen::MatrixXd m(2, 2);
     m << a, b, c, d;
     return m;
@@ -65,7 +66,6 @@ class AffineLinearSystemTest : public ::testing::Test {
   const Eigen::MatrixXd C_;
   const Eigen::MatrixXd D_;
   const Eigen::VectorXd y0_;
-
 };
 
 }  // namespace systems

--- a/drake/systems/framework/primitives/test/affine_linear_test.h
+++ b/drake/systems/framework/primitives/test/affine_linear_test.h
@@ -38,6 +38,18 @@ class AffineLinearSystemTest : public ::testing::Test {
     return std::make_unique<FreestandingInputPort>(std::move(data));
   }
 
+  static Eigen::MatrixXd make_2x2_matrix(double a, double b, double c, double d) {
+    Eigen::MatrixXd m(2, 2);
+    m << a, b, c, d;
+    return m;
+  }
+
+  static Eigen::VectorXd make_2x1_vector(double a, double b) {
+    Eigen::VectorXd v(2);
+    v << a, b;
+    return v;
+  }
+
  protected:
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<SystemOutput<double>> system_output_;
@@ -54,17 +66,6 @@ class AffineLinearSystemTest : public ::testing::Test {
   const Eigen::MatrixXd D_;
   const Eigen::VectorXd y0_;
 
-  Eigen::MatrixXd make_2x2_matrix(double a, double b, double c, double d) {
-    Eigen::MatrixXd m(2, 2);
-    m << a, b, c, d;
-    return m;
-  }
-
-  Eigen::VectorXd make_2x1_vector(double a, double b) {
-    Eigen::VectorXd v(2);
-    v << a, b;
-    return v;
-  }
 };
 
 }  // namespace systems

--- a/drake/systems/framework/primitives/test/affine_system_test.cc
+++ b/drake/systems/framework/primitives/test/affine_system_test.cc
@@ -82,7 +82,6 @@ TEST_F(AffineSystemTest, Output) {
 
 class FeedthroughAffineSystemTest : public ::testing::Test {
  public:
-
   void SetDCornerElement(double d_1_1_element) {
     d_1_1_element_ = d_1_1_element;
   }
@@ -105,6 +104,7 @@ class FeedthroughAffineSystemTest : public ::testing::Test {
     dut_ = make_unique<AffineSystem<double>>(A_, B_, xDot0_, C_, D_, y0_);
     dut_->set_name("test_feedtroughaffine_system");
   }
+
  protected:
   // The Device Under Test is an AffineSystem<double>.
   unique_ptr<AffineSystem<double>> dut_;

--- a/drake/systems/framework/primitives/test/affine_system_test.cc
+++ b/drake/systems/framework/primitives/test/affine_system_test.cc
@@ -79,6 +79,58 @@ TEST_F(AffineSystemTest, Output) {
   EXPECT_EQ(expected_output, system_output_->get_vector_data(0)->get_value());
 }
 
+
+class FeedthroughAffineSystemTest : public ::testing::Test {
+ public:
+
+  FeedthroughAffineSystemTest() {}
+  void SetUp()  {}
+
+  void SetDCornerElement(double d_1_1_element) {
+    d_1_1_element_ = d_1_1_element;
+  }
+
+  void InitialiseSystem() {
+    // Setup an arbitrary AffineSystem which is feedthrough if and only if
+    // the elements of D matrix are exactly 0.
+    Eigen::MatrixXd A_(
+        AffineLinearSystemTest::make_2x2_matrix(1.5, 2.7, 3.5, -4.9));
+    Eigen::MatrixXd B_(
+        AffineLinearSystemTest::make_2x2_matrix(4.9, -5.1, 6.8, 7.2));
+    Eigen::VectorXd xDot0_(
+        AffineLinearSystemTest::make_2x1_vector(0, 0));
+    Eigen::MatrixXd C_(
+        AffineLinearSystemTest::make_2x2_matrix(1.1, 2.5, -3.8, 4.6));
+    Eigen::MatrixXd D_(
+        AffineLinearSystemTest::make_2x2_matrix(d_1_1_element_, 0, 0, 0));
+    Eigen::VectorXd y0_(
+        AffineLinearSystemTest::make_2x1_vector(0, 0));
+    dut_ = make_unique<AffineSystem<double>>(A_, B_, xDot0_, C_, D_, y0_);
+    dut_->set_name("test_feedtroughaffine_system");
+  }
+ protected:
+  // The Device Under Test is an AffineSystem<double>.
+  unique_ptr<AffineSystem<double>> dut_;
+  double d_1_1_element_{0.0};
+};
+
+// Tests that the system does not render as a direct feedthrough
+// when all elements of D are exactly 0.
+TEST_F(FeedthroughAffineSystemTest, NoFeedthroughTest) {
+  SetDCornerElement(0.0);
+  InitialiseSystem();
+  EXPECT_FALSE(dut_->has_any_direct_feedthrough());
+}
+
+// Tests that the system renders as a direct feedthrough
+// when a single element of D is set to 1e-12.
+TEST_F(FeedthroughAffineSystemTest, FeedthroughTest) {
+  SetDCornerElement(1e-12);
+  InitialiseSystem();
+  EXPECT_TRUE(dut_->has_any_direct_feedthrough());
+}
+
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/primitives/test/affine_system_test.cc
+++ b/drake/systems/framework/primitives/test/affine_system_test.cc
@@ -83,9 +83,6 @@ TEST_F(AffineSystemTest, Output) {
 class FeedthroughAffineSystemTest : public ::testing::Test {
  public:
 
-  FeedthroughAffineSystemTest() {}
-  void SetUp()  {}
-
   void SetDCornerElement(double d_1_1_element) {
     d_1_1_element_ = d_1_1_element;
   }


### PR DESCRIPTION
Fixes https://github.com/RobotLocomotion/drake/issues/4192 

Adds additional unit tests that verify the desired behaviour. 

+@jwnimmer-tri for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4219)
<!-- Reviewable:end -->
