### PR TITLE
Suppress unused-const-variable warnings in gtest for Bazel

### DIFF
--- a/tools/gtest.BUILD
+++ b/tools/gtest.BUILD
@@ -14,4 +14,5 @@ cc_library(
     linkopts = ["-pthread"],
     linkstatic = 1,
     visibility = ["//visibility:public"],
+    copts = ["-Wno-unused-const-variable"],
 )


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4229)
<!-- Reviewable:end -->
