### PR TITLE
Add BUILD target for automotive_simulator and its deps

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -90,3 +90,20 @@ cc_library(
     hdrs = ["trajectory_car.h"],
     deps = DEPS + [":curve2"],
     linkstatic = 1)
+
+cc_library(
+    name = "automotive_simulator",
+    srcs = ["automotive_simulator.cc"],
+    hdrs = ["automotive_simulator.h"],
+    deps = DEPS + [
+        "//drake/lcm",
+        "//drake/multibody:drake_visualizer",
+        "//drake/systems/analysis",
+        "//drake/systems/lcm",
+        "//drake/systems/framework/primitives:constant_vector_source",
+        "//drake/systems/framework/primitives:multiplexer",
+        ":generated_translators",
+        ":simple_car",
+        ":trajectory_car",
+    ],
+    linkstatic = 1)

--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -13,6 +13,18 @@ lcm_cc_library(
     linkstatic = 1)
 
 lcm_cc_library(
+    name = "viewer",
+    lcm_package = "drake",
+    lcm_srcs = [
+        "lcmt_viewer_command.lcm",
+        "lcmt_viewer_draw.lcm",
+        "lcmt_viewer_geometry_data.lcm",
+        "lcmt_viewer_link_data.lcm",
+        "lcmt_viewer_load_robot.lcm",
+    ],
+    linkstatic = 1)
+
+lcm_cc_library(
     name = "automotive",
     lcm_package = "drake",
     lcm_srcs = [

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -1,0 +1,78 @@
+# -*- python -*-
+
+# This file contains rules for the Bazel build system.
+# See http://bazel.io/ .
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "rigid_body_tree",
+    srcs = [
+        "parser_model_instance_id_table.cc",
+        "parser_common.cc",
+        "parser_sdf.cc",
+        "parser_urdf.cc",
+        "rigid_body.cc",
+        "rigid_body_actuator.cc",
+        "rigid_body_frame.cc",
+        "rigid_body_loop.cc",
+        "rigid_body_tree.cc",
+        "xml_util.cc",
+        # N.B. Not yet "collision/bullet_model.cc",
+        "collision/drake_collision.cc",
+        "collision/element.cc",
+        "collision/model.cc",
+        "collision/unusable_model.cc",
+    ] + glob([
+        "joints/*.cc",
+        "shapes/*.cc",
+    ]),
+    hdrs = [
+        "force_torque_measurement.h",
+        "kinematic_path.h",
+        "kinematics_cache.h",
+        "material_map.h",
+        "parser_common.h",
+        "parser_model_instance_id_table.h",
+        "parser_sdf.h",
+        "parser_urdf.h",
+        "pose_map.h",
+        "rigid_body.h",
+        "rigid_body_actuator.h",
+        "rigid_body_frame.h",
+        "rigid_body_loop.h",
+        "rigid_body_tree.h",
+        "xml_util.h",
+    ] + glob([
+        "collision/*.h",
+        "joints/*.h",
+        "shapes/*.h",
+    ]),
+    deps = [
+        "//drake/common:drake_path",
+        "//drake/common:sorted_vectors_have_intersection",
+        "//drake/math:geometric_transform",
+        "//drake/math:gradient",
+        "//drake/thirdParty:spruce",
+        "//drake/thirdParty:tinydir",
+        "//drake/thirdParty:tinyxml2",
+        "//drake/util",
+    ],
+    linkstatic = 1)
+
+cc_library(
+    name = "drake_visualizer",
+    srcs = [
+        "rigid_body_plant/drake_visualizer.cc",
+        "rigid_body_plant/viewer_draw_translator.cc",
+    ],
+    hdrs = [
+        "rigid_body_plant/drake_visualizer.h",
+        "rigid_body_plant/viewer_draw_translator.h",
+    ],
+    deps = [
+        "//drake/lcmtypes:viewer",
+        "//drake/systems/lcm",
+        ":rigid_body_tree",
+    ],
+    linkstatic = 1)

--- a/drake/systems/framework/primitives/BUILD
+++ b/drake/systems/framework/primitives/BUILD
@@ -44,6 +44,15 @@ cc_library(
     linkstatic=1)
 
 cc_library(
+    name = "multiplexer",
+    hdrs = ["multiplexer.h"],
+    srcs = ["multiplexer.cc"],
+    deps = [
+        "//drake/systems/framework",
+    ],
+    linkstatic=1)
+
+cc_library(
     name = "zero_order_hold",
     hdrs = ["zero_order_hold.h",
             "zero_order_hold-inl.h"],

--- a/drake/thirdParty/BUILD
+++ b/drake/thirdParty/BUILD
@@ -1,0 +1,24 @@
+# -*- python -*
+
+# This file contains rules for the Bazel build system.
+# See http://bazel.io/ .
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "spruce",
+    srcs = ["bsd/spruce/src/spruce.cc"],
+    hdrs = ["bsd/spruce/include/spruce.hh"],
+    includes = ["bsd/spruce/include"],
+    linkstatic = 1)
+
+cc_library(
+    name = "tinydir",
+    hdrs = ["bsd/tinydir/tinydir.h"],
+    linkstatic = 1)
+
+cc_library(
+    name = "tinyxml2",
+    srcs = ["zlib/tinyxml2/tinyxml2.cpp"],
+    hdrs = ["zlib/tinyxml2/tinyxml2.h"],
+    linkstatic = 1)

--- a/drake/util/BUILD
+++ b/drake/util/BUILD
@@ -1,0 +1,17 @@
+# -*- python -*
+
+package(default_visibility = ["//visibility:public"])
+DEPS = ["//drake/common:common"]
+
+cc_library(
+    name = "util",
+    srcs = [
+         "drakeGeometryUtil.cpp",
+         "drakeUtil.cpp",
+    ],
+    hdrs = [
+         "drakeGeometryUtil.h",
+         "drakeUtil.h",
+    ],
+    deps = DEPS + ["//drake/math:geometric_transform", "//drake/math:gradient"],
+    linkstatic = 1)


### PR DESCRIPTION
The deps additions are:
- Add BUILD for spruce, tinydir, tinyxml2
- Add BUILD for util (only some)
- Add BUILD for lcmt_viewer
- Add BUILD for multiplexer
- Add BUILD for drake/multibody (RBT only)

~~Note that this won't actually build until #4230 is merged first, but certainly can be reviewed now.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4233)
<!-- Reviewable:end -->
