### PR TITLE
Add BUILD for automotive simulator and demo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,12 @@ new_http_archive(
     strip_prefix = "googletest-release-1.7.0",
 )
 
+git_repository(
+    name   = "gflags",
+    commit = "a69b2544d613b4bee404988710503720c487119a",
+    remote = "https://github.com/gflags/gflags.git"
+)
+
 new_git_repository(
     name = "eigen",
     remote = "https://github.com/RobotLocomotion/eigen-mirror.git",

--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -88,3 +88,37 @@ cc_library(
     hdrs = ["trajectory_car.h"],
     deps = DEPS + [":curve2"],
     linkstatic = 1)
+
+cc_library(
+    name = "automotive_simulator",
+    srcs = ["automotive_simulator.cc"],
+    hdrs = ["automotive_simulator.h"],
+    deps = DEPS + [
+        "//drake/lcm",
+        "//drake/multibody:drake_visualizer",
+        "//drake/systems/analysis",
+        "//drake/systems/lcm",
+        "//drake/systems/framework/primitives:constant_vector_source",
+        "//drake/systems/framework/primitives:multiplexer",
+        ":generated_translators",
+        ":simple_car",
+        ":trajectory_car",
+    ],
+    linkstatic = 1)
+
+cc_binary(
+    name = "automotive_demo",
+    srcs = [
+        "automotive_demo.cc",
+        "create_trajectory_params.cc",
+        "create_trajectory_params.h"
+    ],
+    deps = [
+        "//drake/common:text_logging_gflags",
+        ":automotive_simulator",
+    ],
+    linkstatic = 1)
+
+filegroup(
+    name = "models",
+    srcs = glob(["models/**"]))

--- a/drake/automotive/test/BUILD
+++ b/drake/automotive/test/BUILD
@@ -6,6 +6,13 @@ package(default_visibility = ["//visibility:public"])
 DEPS = ["@gtest//:main"]
 
 cc_test(
+    name = "automotive_simulator_test",
+    srcs = ["automotive_simulator_test.cc"],
+    deps = DEPS + ["//drake/automotive:automotive_simulator", "//drake/lcm:mock"],
+    data = ["//drake/automotive:models"],
+    size = "small")
+
+cc_test(
     name = "curve2_test",
     srcs = ["curve2_test.cc"],
     deps = DEPS + ["//drake/automotive:curve2"],

--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -7,7 +7,6 @@
 #include "drake/lcmt_viewer_draw.hpp"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
-#include "drake/systems/lcm/lcmt_drake_signal_translator.h"
 
 namespace drake {
 namespace automotive {
@@ -161,7 +160,8 @@ void TestTrajectoryCarWithSdf(const std::string& sdf_file_1, int num_bodies_1,
   const Curve2d curve{waypoints};
 
   // Set up a basic simulation with just some TrajectoryCars.
-  auto simulator = std::make_unique<AutomotiveSimulator<double>>();
+  auto simulator = std::make_unique<AutomotiveSimulator<double>>(
+      std::make_unique<lcm::DrakeMockLcm>());
   const int model_instance_id_1 =
       simulator->AddTrajectoryCarFromSdf(sdf_file_1, curve, 1.0, 0.0);
   const int model_instance_id_2 =

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -90,10 +90,24 @@ cc_library(
 # Miscellaneous utilities.
 cc_library(
     name = "drake_path",
+    srcs = ["drake_path.cc"],
     hdrs = ["drake_path.h"],
     testonly = 1,
     deps = [":common"],
     linkstatic = 1)
+# TODO(jwnimmer-tri) GetDrakePath has a long and storied history (#1471, #2174).
+# It serves multiple purposes (unit tests loading their models; installed demos
+# loading their models; etc.) but doesn't really do any of them well.  The rule
+# here in Bazel is intended as a temporary shim, in order to support Bazel and
+# CMake build systems concurrently.  We should endeavor to remove this rule (in
+# lieu of properly-declared data dependencies) once we are unchained from CMake.
+genrule(
+    name = "drake_path_genrule",
+    srcs = ["drake_path.cc.in"],
+    outs = ["drake_path.cc"],
+    # TODO(jwnimmer-tri) This should be an abspath, not relpath.
+    cmd = "sed 's#@PROJECT_SOURCE_DIR@#drake#g' $< > $@",
+)
 
 cc_library(
     name = "eigen_matrix_compare",
@@ -115,13 +129,12 @@ cc_library(
     deps = [":common"],
     linkstatic = 1)
 
-# TODO(jwnimmer-tri) Re-test and get this working.  Approxmate answer:
-# genrule(
-#     name = "generate_drake_path_cc",
-#     srcs = ["drake_path.cc.in"],
-#     outs = ["drake_path.cc"],
-#     cmd = "sed 's#@PROJECT_SOURCE_DIR@#???#g' $< > $@",
-# )
-
-# TODO(jwnimmer-tri) These source files are not yet part of Bazel:
-# text_logging_gflags.h ... need to add gflags dependency first.
+cc_library(
+    name = "text_logging_gflags",
+    hdrs = ["text_logging_gflags.h"],
+    deps = [":common", "@gflags//:gflags"],
+    # TODO(jwnimmer-tri) Ideally, gflags BUILD would do this for us.  Figure
+    # out what's going on.  Definitely don't let "-pthread" get copy-pasta'd
+    # throughout our code.
+    linkopts = ["-pthread"],
+    linkstatic = 1)

--- a/drake/common/test/BUILD
+++ b/drake/common/test/BUILD
@@ -15,7 +15,7 @@ cc_library(
 cc_test(
     name = "autodiff_overloads_test",
     srcs = ["autodiff_overloads_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:autodiff"])
+    size = "small", deps = DEPS + ["//drake/common:autodiff", "//drake/common:eigen_matrix_compare"])
 
 cc_test(
     name = "double_overloads_test",

--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -11,6 +11,18 @@ lcm_cc_library(
     linkstatic = 1)
 
 lcm_cc_library(
+    name = "viewer",
+    lcm_package = "drake",
+    lcm_srcs = [
+        "lcmt_viewer_command.lcm",
+        "lcmt_viewer_draw.lcm",
+        "lcmt_viewer_geometry_data.lcm",
+        "lcmt_viewer_link_data.lcm",
+        "lcmt_viewer_load_robot.lcm",
+    ],
+    linkstatic = 1)
+
+lcm_cc_library(
     name = "automotive",
     lcm_package = "drake",
     lcm_srcs = [

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -1,0 +1,81 @@
+# -*- python -*-
+
+# This file contains rules for the Bazel build system.
+# See http://bazel.io/ .
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "rigid_body_tree",
+    srcs = [
+        "parser_model_instance_id_table.cc",
+        "parser_common.cc",
+        "parser_sdf.cc",
+        "parser_urdf.cc",
+        "rigid_body.cc",
+        "rigid_body_actuator.cc",
+        "rigid_body_frame.cc",
+        "rigid_body_loop.cc",
+        "rigid_body_tree.cc",
+        "xml_util.cc",
+        "collision/drake_collision.cc",
+        "collision/element.cc",
+        "collision/model.cc",
+        "collision/unusable_model.cc",
+    ] + glob([
+        "joints/*.cc",
+        "shapes/*.cc",
+    ]),
+    hdrs = [
+        "force_torque_measurement.h",
+        "kinematic_path.h",
+        "kinematics_cache.h",
+        "material_map.h",
+        "parser_common.h",
+        "parser_model_instance_id_table.h",
+        "parser_sdf.h",
+        "parser_urdf.h",
+        "pose_map.h",
+        "rigid_body.h",
+        "rigid_body_actuator.h",
+        "rigid_body_frame.h",
+        "rigid_body_loop.h",
+        "rigid_body_tree.h",
+        "xml_util.h",
+        "collision/drake_collision.h",
+        "collision/element.h",
+        "collision/model.h",
+        "collision/point_pair.h",
+        "collision/unusable_model.h",
+    ] + glob([
+        "joints/*.h",
+        "shapes/*.h",
+    ]),
+    deps = [
+        "//drake/common:drake_path",
+        "//drake/common:sorted_vectors_have_intersection",
+        "//drake/math:geometric_transform",
+        "//drake/math:gradient",
+        "//drake/thirdParty:spruce",
+        "//drake/thirdParty:tinydir",
+        "//drake/thirdParty:tinyxml2",
+        "//drake/util",
+    ],
+    linkstatic = 1)
+
+cc_library(
+    name = "drake_visualizer",
+    srcs = [
+        "rigid_body_plant/drake_visualizer.cc",
+        "rigid_body_plant/viewer_draw_translator.cc",
+    ],
+    hdrs = [
+        "rigid_body_plant/drake_visualizer.h",
+        "rigid_body_plant/viewer_draw_translator.h",
+    ],
+    deps = [
+        "//drake/lcmtypes:viewer",
+        "//drake/systems/lcm",
+        ":rigid_body_tree",
+    ],
+    linkstatic = 1)

--- a/drake/systems/framework/primitives/BUILD
+++ b/drake/systems/framework/primitives/BUILD
@@ -42,6 +42,15 @@ cc_library(
     linkstatic=1)
 
 cc_library(
+    name = "multiplexer",
+    hdrs = ["multiplexer.h"],
+    srcs = ["multiplexer.cc"],
+    deps = [
+        "//drake/systems/framework",
+    ],
+    linkstatic=1)
+
+cc_library(
     name = "zero_order_hold",
     hdrs = ["zero_order_hold.h",
             "zero_order_hold-inl.h"],

--- a/drake/thirdParty/BUILD
+++ b/drake/thirdParty/BUILD
@@ -1,0 +1,24 @@
+# -*- python -*
+
+# This file contains rules for the Bazel build system.
+# See http://bazel.io/ .
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "spruce",
+    srcs = ["bsd/spruce/src/spruce.cc"],
+    hdrs = ["bsd/spruce/include/spruce.hh"],
+    includes = ["bsd/spruce/include"],
+    linkstatic = 1)
+
+cc_library(
+    name = "tinydir",
+    hdrs = ["bsd/tinydir/tinydir.h"],
+    linkstatic = 1)
+
+cc_library(
+    name = "tinyxml2",
+    srcs = ["zlib/tinyxml2/tinyxml2.cpp"],
+    hdrs = ["zlib/tinyxml2/tinyxml2.h"],
+    linkstatic = 1)

--- a/drake/util/BUILD
+++ b/drake/util/BUILD
@@ -1,0 +1,17 @@
+# -*- python -*
+
+package(default_visibility = ["//visibility:public"])
+DEPS = ["//drake/common:common"]
+
+cc_library(
+    name = "util",
+    srcs = [
+         "drakeGeometryUtil.cpp",
+         "drakeUtil.cpp",
+    ],
+    hdrs = [
+         "drakeGeometryUtil.h",
+         "drakeUtil.h",
+    ],
+    deps = DEPS + ["//drake/math:geometric_transform", "//drake/math:gradient"],
+    linkstatic = 1)


### PR DESCRIPTION
Specific items:
- Remove spurious include
- Use DrakeMockLcm for TestTrajectoryCarWithSdf tests
- Add BUILD for gflags
- Add BUILD for spruce, tinydir, tinyxml2
- Add BUILD for util (only some)
- Add BUILD for lcmt_viewer
- Add BUILD for multiplexer
- Add BUILD for drake/multibody (RBT only)
- Add BUILD for automotive_demo
- Add BUILD for automotive_simulator_test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4235)
<!-- Reviewable:end -->
