### PR TITLE
Connect ContactResults from RigidBodyPlant to RobotStateEncoder.

### DIFF
--- a/drake/examples/Valkyrie/CMakeLists.txt
+++ b/drake/examples/Valkyrie/CMakeLists.txt
@@ -36,6 +36,7 @@ if (lcm_FOUND)
   add_library_with_exports(LIB_NAME drakeRobotStateEncoder SOURCE_FILES
       robot_state_encoder.cc)
   target_link_libraries(drakeRobotStateEncoder
+      drakeGeometryUtil
       drakeLCMSystem2
       drakeLCMUtil
       drakeRigidBodyPlant

--- a/drake/examples/Valkyrie/robot_state_decoder.h
+++ b/drake/examples/Valkyrie/robot_state_decoder.h
@@ -9,8 +9,8 @@
 namespace drake {
 namespace systems {
 
-// TODO(tkoolen): currently doesn't do anything with the efforts or wrenches in
-// the robot_state_t message.
+// TODO(tkoolen): currently doesn't do anything with the efforts or spatial
+// forces in the robot_state_t message.
 
 /**
  * Converts a robot_state_t LCM message into a KinematicsCache object.

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -1,8 +1,14 @@
-#include "drake/examples/Valkyrie/robot_state_encoder.h"
+#include <list>
+
 #include "drake/common/constants.h"
+#include "drake/examples/Valkyrie/robot_state_encoder.h"
 #include "drake/examples/Valkyrie/robot_state_lcmtype_util.h"
+#include "drake/multibody/rigid_body_plant/contact_force.h"
+#include "drake/multibody/rigid_body_plant/contact_resultant_force_calculator.h"
+#include "drake/multibody/rigid_body_plant/contact_results.h"
 #include "drake/multibody/rigid_body_plant/kinematics_results.h"
 #include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeUtil.h"
 #include "drake/util/lcmUtil.h"
 
@@ -21,7 +27,9 @@ using Eigen::Translation3d;
 namespace drake {
 namespace systems {
 
-RobotStateEncoder::RobotStateEncoder(const RigidBodyTree<double>& tree)
+RobotStateEncoder::RobotStateEncoder(
+    const RigidBodyTree<double>& tree,
+    const std::vector<RigidBodyFrame>& ft_sensor_info)
     : tree_(CheckTreeIsRobotStateLcmTypeCompatible(tree)),
       floating_body_(tree.bodies[1]->getJoint().is_floating()
                          ? tree.bodies[1].get()
@@ -30,9 +38,23 @@ RobotStateEncoder::RobotStateEncoder(const RigidBodyTree<double>& tree)
           DeclareAbstractOutputPort(kContinuousSampling).get_index()),
       kinematics_results_port_index_(
           DeclareAbstractInputPort(kContinuousSampling).get_index()),
+      contact_results_port_index_(
+          DeclareAbstractInputPort(kContinuousSampling).get_index()),
       effort_port_indices_(DeclareEffortInputPorts()),
-      foot_wrench_port_indices_(DeclareWrenchInputPorts()),
-      hand_wrench_port_indices_(DeclareWrenchInputPorts()) {
+      force_torque_sensor_info_(ft_sensor_info) {
+  int sensor_idx = 0;
+  for (const auto& sensor : force_torque_sensor_info_) {
+    const std::string& name = sensor.get_rigid_body().get_name();
+
+    // TODO(siyuan.feng): this needs to not be hard coded.
+    if (name.compare("leftFoot") == 0) l_foot_ft_sensor_idx_ = sensor_idx;
+    if (name.compare("rightFoot") == 0) r_foot_ft_sensor_idx_ = sensor_idx;
+    if (name.compare("leftPalm") == 0) l_hand_ft_sensor_idx_ = sensor_idx;
+    if (name.compare("rightPalm") == 0) r_hand_ft_sensor_idx_ = sensor_idx;
+
+    sensor_idx++;
+  }
+
   set_name("RobotStateEncoder");
 }
 
@@ -43,8 +65,20 @@ void RobotStateEncoder::EvalOutput(const Context<double>& context,
   auto& message = output->GetMutableData(lcm_message_port_index_)
                       ->GetMutableValue<robot_state_t>();
   message.utime = static_cast<int64_t>(context.get_time() * 1e6);
-  SetStateAndEfforts(context, &message);
-  SetForceTorque(context, &message);
+
+  // TODO(siyuan.feng): I explicitly evaluated kinematics and contacts
+  // separately here to avoid excessive calls given the same context.
+  // This shouldn't be necessary when cache is correctly implemented.
+  const auto& contact_results =
+      EvalAbstractInput(context, contact_results_port_index_)
+          ->GetValue<ContactResults<double>>();
+
+  const auto& kinematics_results =
+      EvalAbstractInput(context, kinematics_results_port_index_)
+          ->GetValue<KinematicsResults<double>>();
+
+  SetStateAndEfforts(kinematics_results, context, &message);
+  SetForceTorque(kinematics_results, contact_results, &message);
 }
 
 std::unique_ptr<SystemOutput<double>> RobotStateEncoder::AllocateOutput(
@@ -67,19 +101,14 @@ const SystemPortDescriptor<double>& RobotStateEncoder::kinematics_results_port()
   return get_input_port(kinematics_results_port_index_);
 }
 
+const SystemPortDescriptor<double>& RobotStateEncoder::contact_results_port()
+    const {
+  return get_input_port(contact_results_port_index_);
+}
+
 const SystemPortDescriptor<double>& RobotStateEncoder::effort_port(
     const RigidBodyActuator& actuator) const {
   return get_input_port(effort_port_indices_.at(&actuator));
-}
-
-const SystemPortDescriptor<double>& RobotStateEncoder::foot_contact_wrench_port(
-    const Side& side) const {
-  return get_input_port(foot_wrench_port_indices_.at(side));
-}
-
-const SystemPortDescriptor<double>& RobotStateEncoder::hand_contact_wrench_port(
-    const Side& side) const {
-  return get_input_port(hand_wrench_port_indices_.at(side));
 }
 
 std::map<const RigidBodyActuator*, int>
@@ -105,12 +134,9 @@ std::map<Side, int> RobotStateEncoder::DeclareWrenchInputPorts() {
   return ret;
 }
 
-void RobotStateEncoder::SetStateAndEfforts(const Context<double>& context,
-                                           robot_state_t* message) const {
-  const auto& kinematics_results =
-      EvalAbstractInput(context, kinematics_results_port_index_)
-          ->GetValue<KinematicsResults<double>>();
-
+void RobotStateEncoder::SetStateAndEfforts(
+    const KinematicsResults<double>& kinematics_results,
+    const Context<double>& context, robot_state_t* message) const {
   if (floating_body_) {
     // Pose of floating body with respect to world.
     Isometry3d floating_body_to_world =
@@ -162,47 +188,103 @@ void RobotStateEncoder::SetStateAndEfforts(const Context<double>& context,
   message->utime = static_cast<int64_t>(1e6 * context.get_time());
 }
 
-void RobotStateEncoder::SetForceTorque(const Context<double>& context,
-                                       bot_core::robot_state_t* message) const {
+SpatialForce<double>
+RobotStateEncoder::GetSpatialForceActingOnBody1ByBody2InBody1Frame(
+    const KinematicsResults<double>& kinematics_results,
+    const ContactResults<double>& contact_results,
+    const RigidBody<double>& body1, const RigidBody<double>& body2) const {
+  std::list<ContactForce<double>> contact_forces;
+  for (int i = 0; i < contact_results.get_num_contacts(); ++i) {
+    const ContactInfo<double>& contact_info =
+        contact_results.get_contact_info(i);
+    const RigidBody<double>* b1 =
+        tree_.FindBody(contact_info.get_element_id_1());
+    const RigidBody<double>* b2 =
+        tree_.FindBody(contact_info.get_element_id_2());
+    // These are point forces in the world frame, and are applied at points
+    // in the world frame.
+    // TODO(siyuan.feng): replace pointer comparison with a proper one that
+    // compares rigid bodies.
+    if (b1 == &body1 && b2 == &body2) {
+      contact_forces.push_back(contact_info.get_resultant_force());
+    } else if (b2 == &body1 && b1 == &body2) {
+      contact_forces.push_back(
+          contact_info.get_resultant_force().get_reaction_force());
+    }
+  }
+
+  ContactResultantForceCalculator<double> calc;
+  const Vector3<double>& reference_point =
+      kinematics_results.get_pose_in_world(body1).translation();
+
+  for (const ContactForce<double>& f : contact_forces) {
+    calc.AddForce(f);
+  }
+
+  SpatialForce<double> spatial_force_in_world_aligned_body_frame =
+      calc.ComputeResultant(reference_point).get_spatial_force();
+  Isometry3<double> world_aligned_to_body_frame(Isometry3<double>::Identity());
+  world_aligned_to_body_frame.linear() =
+      kinematics_results.get_pose_in_world(body1).linear().transpose();
+  return transformSpatialForce(world_aligned_to_body_frame,
+                               spatial_force_in_world_aligned_body_frame);
+}
+
+void RobotStateEncoder::SetForceTorque(
+    const KinematicsResults<double>& kinematics_results,
+    const ContactResults<double>& contact_results,
+    bot_core::robot_state_t* message) const {
+  std::vector<SpatialForce<double>> spatial_force_in_sensor_frame(
+      force_torque_sensor_info_.size());
+
+  for (size_t i = 0; i < force_torque_sensor_info_.size(); ++i) {
+    const RigidBody<double>& body =
+        force_torque_sensor_info_[i].get_rigid_body();
+    SpatialForce<double> spatial_force =
+        GetSpatialForceActingOnBody1ByBody2InBody1Frame(
+            kinematics_results, contact_results, body, tree_.world());
+    Isometry3<double> body_to_sensor =
+        force_torque_sensor_info_[i].get_transform_to_body().inverse();
+    spatial_force_in_sensor_frame[i] =
+        transformSpatialForce(body_to_sensor, spatial_force);
+  }
+
   auto& force_torque = message->force_torque;
-  {
-    auto left_foot_wrench =
-        EvalVectorInput(context, foot_wrench_port_indices_.at(Side::LEFT))
-            ->get_value();
+
+  if (l_foot_ft_sensor_idx_ != -1) {
+    const SpatialForce<double>& spatial_force =
+        spatial_force_in_sensor_frame.at(l_foot_ft_sensor_idx_);
     force_torque.l_foot_force_z =
-        static_cast<float>(left_foot_wrench[kForceZIndex]);
+        static_cast<float>(spatial_force[kForceZIndex]);
     force_torque.l_foot_torque_x =
-        static_cast<float>(left_foot_wrench[kTorqueXIndex]);
+        static_cast<float>(spatial_force[kTorqueXIndex]);
     force_torque.l_foot_torque_y =
-        static_cast<float>(left_foot_wrench[kTorqueYIndex]);
+        static_cast<float>(spatial_force[kTorqueYIndex]);
   }
-  {
-    auto right_foot_wrench =
-        EvalVectorInput(context, foot_wrench_port_indices_.at(Side::RIGHT))
-            ->get_value();
+  if (r_foot_ft_sensor_idx_ != -1) {
+    const SpatialForce<double>& spatial_force =
+        spatial_force_in_sensor_frame.at(r_foot_ft_sensor_idx_);
     force_torque.r_foot_force_z =
-        static_cast<float>(right_foot_wrench[kForceZIndex]);
+        static_cast<float>(spatial_force[kForceZIndex]);
     force_torque.r_foot_torque_x =
-        static_cast<float>(right_foot_wrench[kTorqueXIndex]);
+        static_cast<float>(spatial_force[kTorqueXIndex]);
     force_torque.r_foot_torque_y =
-        static_cast<float>(right_foot_wrench[kTorqueYIndex]);
+        static_cast<float>(spatial_force[kTorqueYIndex]);
   }
-  {
-    auto left_hand_wrench =
-        EvalVectorInput(context, hand_wrench_port_indices_.at(Side::LEFT))
-            ->get_value();
-    eigenVectorToCArray(left_hand_wrench.head<kSpaceDimension>(),
+  if (l_hand_ft_sensor_idx_ != -1) {
+    const SpatialForce<double>& spatial_force =
+        spatial_force_in_sensor_frame.at(l_hand_ft_sensor_idx_);
+    eigenVectorToCArray(spatial_force.head<kSpaceDimension>(),
                         force_torque.l_hand_torque);
-    eigenVectorToCArray(left_hand_wrench.tail<kSpaceDimension>(),
+    eigenVectorToCArray(spatial_force.tail<kSpaceDimension>(),
                         force_torque.l_hand_force);
   }
-  {
-    auto right_hand_wrench =
-        EvalVectorInput(context, hand_wrench_port_indices_.at(Side::RIGHT))
-            ->get_value();
-    eigenVectorToCArray(right_hand_wrench.head<kSpaceDimension>(),
+  if (r_hand_ft_sensor_idx_ != -1) {
+    const SpatialForce<double>& spatial_force =
+        spatial_force_in_sensor_frame.at(r_hand_ft_sensor_idx_);
+    eigenVectorToCArray(spatial_force.head<kSpaceDimension>(),
                         force_torque.r_hand_torque);
-    eigenVectorToCArray(right_hand_wrench.tail<kSpaceDimension>(),
+    eigenVectorToCArray(spatial_force.tail<kSpaceDimension>(),
                         force_torque.r_hand_force);
   }
 }

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -1,9 +1,15 @@
 #pragma once
 
 #include <map>
+#include <string>
+#include <vector>
+#include <utility>
 
 #include "lcmtypes/bot_core/robot_state_t.hpp"
 
+#include "drake/multibody/rigid_body_plant/contact_results.h"
+#include "drake/multibody/rigid_body_plant/kinematics_results.h"
+#include "drake/multibody/rigid_body_frame.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -11,6 +17,10 @@
 
 namespace drake {
 namespace systems {
+
+// TODO(siyuan.feng): I am hard coding force torque between certain bodies
+// with only the "world", not the environment, because the current
+// implementation of collision groups doesn't work properly.
 
 /// Assembles information from various input ports into a robot_state_t LCM
 /// message, presented on an output port.
@@ -20,7 +30,8 @@ class RobotStateEncoder final : public LeafSystem<double> {
   static const size_t kTorqueYIndex = 1;
   static const size_t kForceZIndex = 5;
 
-  explicit RobotStateEncoder(const RigidBodyTree<double>& tree);
+  RobotStateEncoder(const RigidBodyTree<double>& tree,
+                    const std::vector<RigidBodyFrame>& ft_sensor_info);
 
   ~RobotStateEncoder() override;
 
@@ -41,28 +52,32 @@ class RobotStateEncoder final : public LeafSystem<double> {
   /// Returns descriptor of kinematics result input port.
   const SystemPortDescriptor<double>& kinematics_results_port() const;
 
+  /// Returns descriptor of contact results input port.
+  const SystemPortDescriptor<double>& contact_results_port() const;
+
   /// Returns descriptor of effort input port corresponding to @param actuator.
   const SystemPortDescriptor<double>& effort_port(
       const RigidBodyActuator& actuator) const;
-
-  /// Returns descriptor of foot wrench input port for side @param side.
-  const SystemPortDescriptor<double>& foot_contact_wrench_port(
-      const Side& side) const;
-
-  /// Returns descriptor of hand wrench input port for side @param side.
-  const SystemPortDescriptor<double>& hand_contact_wrench_port(
-      const Side& side) const;
 
  private:
   std::map<const RigidBodyActuator*, int> DeclareEffortInputPorts();
 
   std::map<Side, int> DeclareWrenchInputPorts();
 
-  void SetStateAndEfforts(const Context<double>& context,
+  void SetStateAndEfforts(const KinematicsResults<double>& kinematics_results,
+                          const Context<double>& context,
                           bot_core::robot_state_t* message) const;
 
-  void SetForceTorque(const Context<double>& context,
+  void SetForceTorque(const KinematicsResults<double>& kinematics_results,
+                      const ContactResults<double>& contact_results,
                       bot_core::robot_state_t* message) const;
+
+  // Computes the spatial force applied at the origin of Body1 by Body2,
+  // expressed in Body1's local frame.
+  SpatialForce<double> GetSpatialForceActingOnBody1ByBody2InBody1Frame(
+      const KinematicsResults<double>& kinematics_results,
+      const ContactResults<double>& contact_results,
+      const RigidBody<double>& body1, const RigidBody<double>& body2) const;
 
   // Tree to which message corresponds.
   const RigidBodyTree<double>& tree_;
@@ -76,9 +91,19 @@ class RobotStateEncoder final : public LeafSystem<double> {
 
   // Input ports.
   const int kinematics_results_port_index_;
+  const int contact_results_port_index_;
   const std::map<const RigidBodyActuator*, int> effort_port_indices_;
-  const std::map<Side, int> foot_wrench_port_indices_;
-  const std::map<Side, int> hand_wrench_port_indices_;
+
+  // These are used for force torque sensors.
+  // The first part is the body that the sensor is attached to, and the second
+  // part is local offset within the body frame.
+  const std::vector<RigidBodyFrame> force_torque_sensor_info_;
+
+  // Index into force_torque_sensor_info_
+  int l_foot_ft_sensor_idx_ = -1;
+  int r_foot_ft_sensor_idx_ = -1;
+  int l_hand_ft_sensor_idx_ = -1;
+  int r_hand_ft_sensor_idx_ = -1;
 };
 
 }  // namespace systems

--- a/drake/examples/Valkyrie/test/CMakeLists.txt
+++ b/drake/examples/Valkyrie/test/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 if(lcm_FOUND)
   drake_add_cc_test(robot_state_encoder_decoder_test)
+  add_definitions(-g)
   target_link_libraries(robot_state_encoder_decoder_test
     drakeRobotStateEncoder
     drakeRobotStateDecoder)

--- a/drake/multibody/rigid_body_plant/contact_force.h
+++ b/drake/multibody/rigid_body_plant/contact_force.h
@@ -60,6 +60,14 @@ class ContactForce {
   ContactForce(const Vector3<T>& application_point, const Vector3<T>& normal,
                const Vector3<T>& force);
 
+  /**
+   Returns a spatial force applied at the same application point with negative
+   force and torque.
+   */
+  ContactForce get_reaction_force() const {
+    return ContactForce(application_point_, -normal_, -force_, -torque_);
+  }
+
   // Contact force is copyable and movable
   ContactForce(const ContactForce& other) = default;
   ContactForce& operator=(const ContactForce& other) = default;

--- a/drake/multibody/rigid_body_plant/contact_resultant_force_calculator.cc
+++ b/drake/multibody/rigid_body_plant/contact_resultant_force_calculator.cc
@@ -163,6 +163,36 @@ ContactForce<T> ContactResultantForceCalculator<T>::ComputeResultant() const {
 }
 
 template <typename T>
+ContactForce<T> ContactResultantForceCalculator<T>::ComputeResultant(
+    const Vector3<T>& reference_point) const {
+  Vector3<T> result_torque = Vector3<T>::Zero();
+  Vector3<T> tangent_component_sum = Vector3<T>::Zero();
+  Vector3<T> normal_component_sum = Vector3<T>::Zero();
+  Vector3<T> arm;
+
+  for (const auto& force : forces_) {
+    normal_component_sum += force.get_normal_force();
+    result_torque += force.get_torque();
+    tangent_component_sum += force.get_tangent_force();
+
+    arm = force.get_application_point() - reference_point;
+    result_torque += arm.cross(force.get_force());
+  }
+
+  Vector3<T> normal;
+  T denom = normal_component_sum.squaredNorm();
+  if (denom > Eigen::NumTraits<T>::dummy_precision()) {
+    normal = normal_component_sum.normalized();
+  } else {
+    normal << 0, 0, 1;
+  }
+
+  return ContactForce<T>(reference_point, normal,
+                         normal_component_sum + tangent_component_sum,
+                         result_torque);
+}
+
+template <typename T>
 void ContactResultantForceCalculator<T>::AccumulateForce(
     const ContactForce<T>& force) {
   if (detail_accumulator_ != nullptr) {

--- a/drake/multibody/rigid_body_plant/contact_resultant_force_calculator.h
+++ b/drake/multibody/rigid_body_plant/contact_resultant_force_calculator.h
@@ -227,6 +227,19 @@ class ContactResultantForceCalculator {
    */
   ContactForce<T> ComputeResultant() const;
 
+  /**
+   Computes the resultant contact spatial force with respect to a given
+   reference point.
+
+   The force part is the summation of all f_i, where f_i is the individual
+   force.
+   The torque part is the summation of all tau_i + (p_i - r) X f_i, where
+   tau_i is the ith pure torque, f_i is applied at p_i, and r is the given
+   reference point.
+   @param reference_point is in the same frame as all the individual forces.
+   */
+  ContactForce<T> ComputeResultant(const Vector3<T>& reference_point) const;
+
   // Neither movable or copyable.
   ContactResultantForceCalculator(
       const ContactResultantForceCalculator& other) = delete;

--- a/drake/multibody/rigid_body_plant/contact_results.h
+++ b/drake/multibody/rigid_body_plant/contact_results.h
@@ -14,8 +14,7 @@ class RigidBodyPlant;
 
 /**
  A class containg the contact results (contact points and response spatial
- forces for each colliding pair of collision elements) produced by a
- RigidBodyPlant system.
+ forces for each colliding pair of collision elements).
 
  @tparam T      The scalar type. It must be a valid Eigen scalar.
 
@@ -25,6 +24,8 @@ class RigidBodyPlant;
 template <typename T>
 class ContactResults {
  public:
+  ContactResults();
+
   ContactResults(const ContactResults<T>& other) = default;
   ContactResults<T>& operator=(const ContactResults<T>& other) = default;
   ContactResults(ContactResults<T>&& other) = delete;
@@ -39,18 +40,6 @@ class ContactResults {
    */
   const ContactInfo<T>& get_contact_info(int i) const;
 
-  // TODO(SeanCurtis-TRI): Explore additional interfaces for accessing collision
-  // information (e.g, query by body, etc.)
- private:
-  // RigidBodyPlant is the only class allowed to instantiate/update this class
-  // through Clear and AddContact().
-  // TODO(SeanCurtis-TRI): when ContactResults can reference entries in the
-  // cache this friendship and the method UpdateFromContext() won't be needed.
-  friend class RigidBodyPlant<T>;
-
-  // Only RigidBodyPlant can construct a ContactResults.
-  ContactResults();
-
   // Clears the set of contact information for when the old data becomes
   // invalid.
   void Clear();
@@ -60,6 +49,7 @@ class ContactResults {
   ContactInfo<T>& AddContact(DrakeCollision::ElementId element_a,
                              DrakeCollision::ElementId element_b);
 
+ private:
   std::vector<ContactInfo<T>> contacts_;
 };
 

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -192,6 +192,11 @@ class RigidBodyPlant : public LeafSystem<T> {
     return System<T>::get_output_port(kinematics_output_port_id_);
   }
 
+  /// Returns descriptor of ContactResults output port.
+  const SystemPortDescriptor<T>& contact_results_output_port() const {
+    return System<T>::get_output_port(contact_output_port_id_);
+  }
+
   /// Creates a right-handed local basis from a z-axis. Defines an arbitrary x-
   /// and y-axis such that the basis is orthonormal.  The basis is R_WL, where W
   /// is the frame in which the z-axis is expressed and L is a local basis such

--- a/drake/multibody/rigid_body_plant/test/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/test/CMakeLists.txt
@@ -19,6 +19,9 @@ if(Bullet_FOUND)
   endif()
 endif()
 
+drake_add_cc_test(contact_force_test)
+target_link_libraries(contact_force_test drakeRigidBodyPlant)
+
 drake_add_cc_test(contact_resultant_force_test)
 target_link_libraries(contact_resultant_force_test drakeRigidBodyPlant)
 

--- a/drake/multibody/rigid_body_plant/test/contact_force_test.cc
+++ b/drake/multibody/rigid_body_plant/test/contact_force_test.cc
@@ -1,0 +1,65 @@
+#include "drake/multibody/rigid_body_plant/contact_force.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_matrix_compare.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+// Tests the getter methods in ContactForce.
+GTEST_TEST(ContactForceTests, GetterTests) {
+  Vector3<double> point(0, 1, 2);
+  Vector3<double> normal(0, 0, 1);
+  Vector3<double> force(6, 7, 8);
+  Vector3<double> torque(9, 10, 11);
+
+  ContactForce<double> contact_force(point, normal, force, torque);
+
+  Vector3<double> normal_force(0, 0, 8);
+  Vector3<double> tangent_force(6, 7, 0);
+
+  EXPECT_TRUE(CompareMatrices(
+        point, contact_force.get_application_point(),
+        1e-20, MatrixCompareType::absolute));
+
+  EXPECT_TRUE(CompareMatrices(
+        normal, contact_force.get_normal(),
+        1e-20, MatrixCompareType::absolute));
+
+  EXPECT_TRUE(CompareMatrices(
+        normal_force, contact_force.get_normal_force(),
+        1e-20, MatrixCompareType::absolute));
+
+  EXPECT_TRUE(CompareMatrices(
+        tangent_force, contact_force.get_tangent_force(),
+        1e-20, MatrixCompareType::absolute));
+
+  EXPECT_TRUE(CompareMatrices(
+        torque, contact_force.get_torque(),
+        1e-20, MatrixCompareType::absolute));
+
+  ContactForce<double> react_contact_force =
+      contact_force.get_reaction_force();
+
+  EXPECT_TRUE(CompareMatrices(
+        point, react_contact_force.get_application_point(),
+        1e-20, MatrixCompareType::absolute));
+
+  EXPECT_TRUE(CompareMatrices(
+        -normal, react_contact_force.get_normal(),
+        1e-20, MatrixCompareType::absolute));
+
+  EXPECT_TRUE(CompareMatrices(
+        -force, react_contact_force.get_force(),
+        1e-20, MatrixCompareType::absolute));
+
+  EXPECT_TRUE(CompareMatrices(
+        -torque, react_contact_force.get_torque(),
+        1e-20, MatrixCompareType::absolute));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Instead of having separate ports for each force torque sensor, I decided
to connect the RBP's ContactResults output directly to
RobotStateEncoder.
I left the RobotStateDecoder unchanged, because I haven't decided if I
want to keep force torque information together with kinematics
information.
The other reason is that I can't construct ContactResults, since it's
mutable functions are only callable from RBP.
This also makes it very hard to write unit tests for RobotStateEncoder
to test encoding / decoding of force torque information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4238)
<!-- Reviewable:end -->
