### PR TITLE
Add non-test matrix compare routine

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -147,6 +147,12 @@ cc_library(
 )
 
 cc_library(
+    name = "is_approx_equal_abstol",
+    hdrs = ["is_approx_equal_abstol.h"],
+    deps = [":common"],
+    linkstatic = 1)
+
+cc_library(
     name = "nice_type_name",
     srcs = ["nice_type_name.cc"],
     hdrs = ["nice_type_name.h"],

--- a/drake/common/is_approx_equal_abstol.h
+++ b/drake/common/is_approx_equal_abstol.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_compat.h"
+
+namespace drake {
+
+/// Returns true if and only if the two matrices are equal to within a certain
+/// absolute elementwise @p tolerance.  Special values (infinities, NaN, etc.)
+/// do not compare as equal elements.
+template <typename DerivedA, typename DerivedB>
+bool is_approx_equal_abstol(const Eigen::MatrixBase<DerivedA>& m1,
+                            const Eigen::MatrixBase<DerivedB>& m2,
+                            double tolerance) {
+  return (
+      (m1.rows() == m2.rows()) &&
+      (m1.cols() == m2.cols()) &&
+      ((m1 - m2).template lpNorm<Eigen::Infinity>() <= tolerance));
+}
+
+}  // namespace drake

--- a/drake/common/test/BUILD
+++ b/drake/common/test/BUILD
@@ -88,6 +88,11 @@ cc_test(
 )
 
 cc_test(
+    name = "is_approx_equal_abstol_test",
+    srcs = ["is_approx_equal_abstol_test.cc"],
+    size = "small", deps = DEPS + ["//drake/common:is_approx_equal_abstol"])
+
+cc_test(
     name = "nice_type_name_test",
     size = "small",
     srcs = ["nice_type_name_test.cc"],

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -9,6 +9,9 @@ target_link_libraries(double_overloads_test drakeCommon)
 drake_add_cc_test(functional_form_test)
 target_link_libraries(functional_form_test drakeCommon)
 
+drake_add_cc_test(is_approx_equal_abstol_test)
+target_link_libraries(is_approx_equal_abstol_test drakeCommon)
+
 drake_add_cc_test(nice_type_name_test)
 target_link_libraries(nice_type_name_test drakeCommon)
 

--- a/drake/common/test/is_approx_equal_abstol_test.cc
+++ b/drake/common/test/is_approx_equal_abstol_test.cc
@@ -1,0 +1,64 @@
+#include "drake/common/is_approx_equal_abstol.h"
+
+#include <Eigen/Dense>
+#include "gtest/gtest.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace {
+
+GTEST_TEST(IsApproxEqualMatrixTest, BasicTest) {
+  const VectorXd ones1 = VectorXd::Ones(1);
+  const VectorXd ones2 = VectorXd::Ones(2);
+  const MatrixXd id22 = MatrixXd::Identity(2, 2);
+  const MatrixXd id33 = MatrixXd::Identity(3, 3);
+
+  const double lit_nudge = 1e-12;
+  const double big_nudge = 1e-4;
+  const VectorXd ones1_lit = ones1 + VectorXd::Constant(1, lit_nudge);
+  const VectorXd ones1_big = ones1 + VectorXd::Constant(1, big_nudge);
+  const VectorXd ones2_lit = ones2 + VectorXd::Constant(2, lit_nudge);
+  const VectorXd ones2_big = ones2 + VectorXd::Constant(2, big_nudge);
+  const MatrixXd id22_lit = id22 + MatrixXd::Constant(2, 2, lit_nudge);
+  const MatrixXd id22_big = id22 + MatrixXd::Constant(2, 2, big_nudge);
+  const MatrixXd id33_lit = id33 + MatrixXd::Constant(3, 3, lit_nudge);
+  const MatrixXd id33_big = id33 + MatrixXd::Constant(3, 3, big_nudge);
+
+  // Compare same-size matrices, within tolerances.
+  const double tolerance = 1e-8;
+  EXPECT_TRUE(is_approx_equal_abstol(ones1, ones1, tolerance));
+  EXPECT_TRUE(is_approx_equal_abstol(ones1, ones1_lit, tolerance));
+  EXPECT_FALSE(is_approx_equal_abstol(ones1, ones1_big, tolerance));
+  EXPECT_TRUE(is_approx_equal_abstol(ones2, ones2, tolerance));
+  EXPECT_TRUE(is_approx_equal_abstol(ones2, ones2_lit, tolerance));
+  EXPECT_FALSE(is_approx_equal_abstol(ones2, ones2_big, tolerance));
+  EXPECT_TRUE(is_approx_equal_abstol(id22, id22, tolerance));
+  EXPECT_TRUE(is_approx_equal_abstol(id22, id22_lit, tolerance));
+  EXPECT_FALSE(is_approx_equal_abstol(id22, id22_big, tolerance));
+  EXPECT_TRUE(is_approx_equal_abstol(id33, id33, tolerance));
+  EXPECT_TRUE(is_approx_equal_abstol(id33, id33_lit, tolerance));
+  EXPECT_FALSE(is_approx_equal_abstol(id33, id33_big, tolerance));
+
+  // Compare different-size matrices.
+  EXPECT_FALSE(is_approx_equal_abstol(ones1, ones2, tolerance));
+  EXPECT_FALSE(is_approx_equal_abstol(id22, id33, tolerance));
+
+  // Special values do not compare equal.
+  const double inf = std::numeric_limits<double>::infinity();
+  const VectorXd inf2 = VectorXd::Constant(2, inf);
+  EXPECT_FALSE(is_approx_equal_abstol(inf2, inf2, tolerance));
+  EXPECT_FALSE(is_approx_equal_abstol(inf2, ones2, tolerance));
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const VectorXd nan2 = VectorXd::Constant(2, nan);
+  EXPECT_FALSE(is_approx_equal_abstol(nan2, nan2, tolerance));
+  EXPECT_FALSE(is_approx_equal_abstol(nan2, inf2, tolerance));
+  EXPECT_FALSE(is_approx_equal_abstol(nan2, ones2, tolerance));
+}
+
+
+}  // namespace
+}  // namespace drake
+
+

--- a/drake/multibody/parser_urdf.cc
+++ b/drake/multibody/parser_urdf.cc
@@ -116,9 +116,7 @@ void AddMaterialToMaterialMap(const string& material_name,
     // the same as the new material.  The range of values in the RGBA vectors
     // is [0, 1].
     const auto& existing_color = material_iter->second;
-    double delta_infinity_norm =
-        (color_rgba - existing_color).lpNorm<Eigen::Infinity>();
-    if (abort_if_name_clash || delta_infinity_norm > 1e-10) {
+    if (abort_if_name_clash || (color_rgba != existing_color)) {
       // The materials map already has the material_name key but the color
       // associated with it is different.
       stringstream error_buff;
@@ -127,8 +125,6 @@ void AddMaterialToMaterialMap(const string& material_name,
                  << "  - existing RGBA values: " << existing_color.transpose()
                  << std::endl
                  << "  - new RGBA values: " << color_rgba.transpose()
-                 << std::endl
-                 << "  - infinity norm of delta: " << delta_infinity_norm
                  << std::endl;
       DRAKE_ABORT_MSG(error_buff.str().c_str());
     }

--- a/drake/systems/controllers/InstantaneousQPController.cpp
+++ b/drake/systems/controllers/InstantaneousQPController.cpp
@@ -14,6 +14,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/is_approx_equal_abstol.h"
 #include "drake/math/quaternion.h"
 #include "drake/solvers/fast_qp.h"
 #include "drake/systems/controllers/controlUtil.h"
@@ -581,8 +582,8 @@ void checkCentroidalMomentumMatchesTotalWrench(
   Vector6d momentum_rate_of_change =
       world_momentum_matrix * qdd + world_momentum_matrix_dot_times_v;
 
-  if ((total_wrench_in_world - momentum_rate_of_change)
-          .lpNorm<Eigen::Infinity>() > 1e-6) {
+  if (!drake::is_approx_equal_abstol(total_wrench_in_world,
+                                     momentum_rate_of_change, 1e-6)) {
     std::stringstream message;
     message << "ERROR in checkCentroidalMomentumMatchesTotalWrench:"
             << " total_wrench_in_world = " << total_wrench_in_world

--- a/drake/systems/controllers/linear_optimal_control.cc
+++ b/drake/systems/controllers/linear_optimal_control.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/controllers/linear_optimal_control.h"
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/is_approx_equal_abstol.h"
 #include "drake/systems/framework/primitives/linear_system.h"
 
 namespace drake {
@@ -72,8 +73,8 @@ Eigen::MatrixXd ContinuousAlgebraicRiccatiEquation(
   DRAKE_DEMAND(A.rows() == n && A.cols() == n);
   DRAKE_DEMAND(Q.rows() == n && Q.cols() == n);
   DRAKE_DEMAND(R.rows() == m && R.cols() == m);
-  DRAKE_DEMAND((Q - Q.transpose()).lpNorm<Eigen::Infinity>() < 1e-10);
-  DRAKE_DEMAND((R - R.transpose()).lpNorm<Eigen::Infinity>() < 1e-10);
+  DRAKE_DEMAND(is_approx_equal_abstol(Q, Q.transpose(), 1e-10));
+  DRAKE_DEMAND(is_approx_equal_abstol(R, R.transpose(), 1e-10));
 
   Eigen::LLT<Eigen::MatrixXd> R_cholesky(R);
 


### PR DESCRIPTION
Following up on #4221, make a good name for a matrix comparison check that is more appropriate for production code that the prior `MatrixCompare` helper (which is great for tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4240)
<!-- Reviewable:end -->
