### PR TITLE
Remove PODS output dealing with library outputs

### DIFF
--- a/cmake/pods.cmake
+++ b/cmake/pods.cmake
@@ -205,22 +205,11 @@ endfunction()
 # manually.
 macro(pods_config_search_paths)
     if(NOT DEFINED __pods_setup)
-      # set where files should be output locally
-      set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
-      foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
-        string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
-        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${LIBRARY_OUTPUT_PATH})
-      endforeach()
-
       # set where files should be installed to
       set(LIBRARY_INSTALL_PATH "${DRAKE_LIBRARY_DIR}")
 
       # add build/lib/pkgconfig to the pkg-config search path
       set(ENV{PKG_CONFIG_PATH} "${DRAKE_PKGCONFIG_DIR}:$ENV{PKG_CONFIG_PATH}")
-
-      # add build/lib to the link path
-      link_directories(${LIBRARY_OUTPUT_PATH})
-      link_directories(${LIBRARY_INSTALL_PATH})
 
       # abuse RPATH
       if(CMAKE_INSTALL_RPATH)

--- a/cmake/pods.cmake
+++ b/cmake/pods.cmake
@@ -208,8 +208,10 @@ macro(pods_config_search_paths)
       # set where files should be installed to
       set(LIBRARY_INSTALL_PATH "${DRAKE_LIBRARY_DIR}")
 
-      # add build/lib/pkgconfig to the pkg-config search path
-      set(ENV{PKG_CONFIG_PATH} "${DRAKE_PKGCONFIG_DIR}:$ENV{PKG_CONFIG_PATH}")
+      # add install/lib/pkgconfig to the pkg-config search path so we find
+      # .pc files installed by externals (use both the correct library dir, and
+      # plain 'lib', as some externals may not use the correct library dir)
+      set(ENV{PKG_CONFIG_PATH} "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig:${CMAKE_INSTALL_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 
       # abuse RPATH
       if(CMAKE_INSTALL_RPATH)


### PR DESCRIPTION
Remove PODS logic to force libraries to be written to a particular (and sometimes wrong) directory. Remove logic to add this location to the global link directories and pkg-config search path. The second part should never have been done; anything that actually needed that logic was doing something very wrong.

Fixes #4225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4245)
<!-- Reviewable:end -->
