### PR TITLE
Poor man's RigidBodyPlant caching

### DIFF
--- a/drake/multibody/rigid_body_plant/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/CMakeLists.txt
@@ -6,7 +6,8 @@ set(source_files
     contact_results.cc
     kinematics_results.cc
     point_contact_detail.cc
-    rigid_body_plant.cc)
+    rigid_body_plant.cc
+    rigid_body_plant_context.cc)
 
 # The following variables are necessary to conditionally include
 # DrakeVisualizer and ViewerDrawTranslator in libdrakeRigidBodyPlant.so if LCM
@@ -49,7 +50,8 @@ drake_install_headers(
     contact_info.h
     contact_results.h
     kinematics_results.h
-    rigid_body_plant.h)
+    rigid_body_plant.h
+    rigid_body_plant_context.h)
 
 drake_install_libraries(drakeRigidBodyPlant)
 drake_install_pkg_config_file(drake-rigid-body-plant

--- a/drake/multibody/rigid_body_plant/contact_results.cc
+++ b/drake/multibody/rigid_body_plant/contact_results.cc
@@ -17,9 +17,6 @@ const ContactInfo<T>& ContactResults<T>::get_contact_info(int i) const {
 }
 
 template <typename T>
-ContactResults<T>::ContactResults() : contacts_() {}
-
-template <typename T>
 void ContactResults<T>::Clear() {
   contacts_.clear();
 }

--- a/drake/multibody/rigid_body_plant/contact_results.h
+++ b/drake/multibody/rigid_body_plant/contact_results.h
@@ -25,6 +25,7 @@ class RigidBodyPlant;
 template <typename T>
 class ContactResults {
  public:
+  ContactResults() = default;
   ContactResults(const ContactResults<T>& other) = default;
   ContactResults<T>& operator=(const ContactResults<T>& other) = default;
   ContactResults(ContactResults<T>&& other) = delete;
@@ -47,9 +48,6 @@ class ContactResults {
   // TODO(SeanCurtis-TRI): when ContactResults can reference entries in the
   // cache this friendship and the method UpdateFromContext() won't be needed.
   friend class RigidBodyPlant<T>;
-
-  // Only RigidBodyPlant can construct a ContactResults.
-  ContactResults();
 
   // Clears the set of contact information for when the old data becomes
   // invalid.

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -142,6 +142,10 @@ class RigidBodyPlant : public LeafSystem<T> {
   }
 
   // System<T> overrides.
+
+  /// Creates a specific RigidBodyPlantContext with cached entries.
+  std::unique_ptr<Context<T>> CreateDefaultContext() const override;
+
   /// Allocates two output ports, one for the RigidBodyPlant state and one for
   /// KinematicsResults.
   std::unique_ptr<SystemOutput<T>> AllocateOutput(
@@ -209,9 +213,9 @@ void DoMapQDotToVelocity(
       VectorBase<T> *generalized_velocity) const override;
 
  private:
-  // Computes the contact results for feeding the corresponding output port.
-  void ComputeContactResults(const Context<T>& context,
-                             ContactResults<T>* contacts) const;
+  // Updates cached context results in the context. This call might also trigger
+  // the update of kinematics if they are invalid in the context.
+  void UpdateCachedContactResults(const Context<T> &context) const;
 
   // Computes the generalized forces on all bodies due to contact.
   //
@@ -224,6 +228,24 @@ void DoMapQDotToVelocity(
   //                       contact response.
   VectorX<T> ComputeContactForce(const KinematicsCache<T>& kinsol,
                                  ContactResults<T>* contacts = nullptr) const;
+
+  // Returns a constant reference to the KinematicsCache object cached in the
+  // context.
+  // The cached kinematics are recomputed if invalid and thus re-validated.
+  const KinematicsCache<T>& GetKinematicsCache(const Context<T>& context) const;
+
+  // Returns a constant references to the ContactResults object cached in the
+  // context.
+  // The cached contact results are updated if they are invalid and thus
+  // re-validated
+  const ContactResults<T>& GetContactResults(const Context<T>& context) const;
+
+  // Returns a constant references to the ContactResults object cached in the
+  // context.
+  // The cached contact results are updated if they are invalid and thus
+  // re-validated
+  const VectorX<T>& GetGeneralizedContactForces(
+      const Context<T>& context) const;
 
   // Some parameters defining the contact.
   // TODO(amcastro-tri): Implement contact materials for the RBT engine.

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_context.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_context.cc
@@ -1,0 +1,14 @@
+#include "drake/multibody/rigid_body_plant/rigid_body_plant_context.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+RigidBodyPlantContext<T>::RigidBodyPlantContext(const RigidBodyPlant<T>& rbp) :
+    kinematics_cache_(rbp.get_rigid_body_tree().bodies) {
+}
+
+template class RigidBodyPlantContext<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_context.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_context.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "drake/systems/framework/leaf_context.h"
+#include "drake/multibody/kinematics_cache.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+
+namespace drake {
+namespace systems {
+
+/// %RigidBodyPlantContext is a temporary fix providing a caching like
+/// capability to RigidBodyPlant.
+/// %RigidBodyPlantContext allows to save in the RigidBodyPlant context a number
+/// of expensive to compute calculations. These include contact results,
+/// kinematics and generalized forces.
+///
+/// @tparam T The mathematical type of the context, which must be a valid Eigen
+///           scalar.
+// TODO(amcastro-tri): Replace this hacky implementation by one actually
+// using System 2.0's Cache.
+template <typename T>
+class RigidBodyPlantContext : public LeafContext<T> {
+ public:
+  explicit RigidBodyPlantContext(const RigidBodyPlant<T>& rbp);
+  virtual ~RigidBodyPlantContext() {}
+
+  // Context<T> overrides.
+  void InvalidateContinuousStateVectorDependents() const final {
+    is_kinematics_cache_valid_ = false;
+    is_contact_results_valid_ = false;
+  }
+
+ private:
+  // RigidBodyPlantContext objects are neither copyable nor moveable.
+  RigidBodyPlantContext(const RigidBodyPlantContext& other) = delete;
+  RigidBodyPlantContext& operator=(const RigidBodyPlantContext& other) = delete;
+  RigidBodyPlantContext(RigidBodyPlantContext&& other) = delete;
+  RigidBodyPlantContext& operator=(RigidBodyPlantContext&& other) = delete;
+
+ public:
+  // "Cached" entries in the RigidBodyPlantContext.
+  mutable bool is_kinematics_cache_valid_{false};
+  mutable KinematicsCache<T> kinematics_cache_;
+
+  mutable bool is_contact_results_valid_{false};
+  mutable ContactResults<T> contact_results_;
+  mutable VectorX<T> generalized_contact_forces_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/analysis/explicit_euler_integrator.h
+++ b/drake/systems/analysis/explicit_euler_integrator.h
@@ -61,7 +61,6 @@ template <class T>
 bool ExplicitEulerIntegrator<T>::DoStep(const T& dt) {
   // Find the continuous state xc within the Context, just once.
   auto context = IntegratorBase<T>::get_mutable_context();
-  VectorBase<T>* xc = context->get_mutable_continuous_state_vector();
 
   // TODO(sherm1) This should be calculating into the cache so that
   // Publish() doesn't have to recalculate if it wants to output derivatives.
@@ -71,6 +70,7 @@ bool ExplicitEulerIntegrator<T>::DoStep(const T& dt) {
   // Compute derivative and update configuration and velocity.
   // xc(t+h) = xc(t) + dt * xcdot(t, xc(t), u(t))
   const auto& xcdot = derivs_->get_vector();
+  VectorBase<T>* xc = context->get_mutable_continuous_state_vector();
   xc->PlusEqScaled(dt, xcdot);  // xc += dt * xcdot
   context->set_time(context->get_time() + dt);
 

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -58,12 +58,14 @@ class Context {
   /// Returns a mutable pointer to the continuous component of the state,
   /// which may be of size zero.
   ContinuousState<T>* get_mutable_continuous_state() {
+    InvalidateContinuousStateVectorDependents();
     return get_mutable_state()->get_mutable_continuous_state();
   }
 
   /// Returns a mutable pointer to the continuous state, devoid of second-order
   /// structure. The vector may be of size zero.
   VectorBase<T>* get_mutable_continuous_state_vector() {
+    InvalidateContinuousStateVectorDependents();
     return get_mutable_continuous_state()->get_mutable_vector();
   }
 
@@ -288,6 +290,10 @@ class Context {
     }
     // In the abstract-valued case, there is nothing else to check.
   }
+
+  /// Invalidates values dependent on the continuous state of the system.
+  /// No-op by default.
+  virtual void InvalidateContinuousStateVectorDependents() const {}
 
  protected:
   /// Contains the return-type-covariant implementation of Clone().

--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -183,6 +183,12 @@ class DiagramContext : public Context<T> {
 
   State<T>* get_mutable_state() override { return &state_; }
 
+  void InvalidateContinuousStateVectorDependents() const final {
+    for (auto& context : contexts_) {
+      context->InvalidateContinuousStateVectorDependents();
+    }
+  }
+
  protected:
   DiagramContext<T>* DoClone() const override {
     DRAKE_ASSERT(contexts_.size() == outputs_.size());


### PR DESCRIPTION
Since we still don't have System 2.0 caching this PR implements a temporary fix that substantially speeds up simulations.
The solution implemented is a `RigidBodyPlantContext` that inherits from `LeafContext` and where we place a number of `mutable` expensive to compute quantities (the "cache" entries).

In addition the PR identifies some possible design issues regarding the proper notification to the context when states are changed. Take a look at `*_integrator.h` where these notifications are triggered by the calls to `context->get_mutable_continuous_state_vector()`.

Speed up results for Valkyrie with full urdf model: from 24.0 secs to 9.0 secs to simulate 1.0 secs.

Speed up results for Valkyrie without grids, only spheres and boxes at the feet and head: from 10.0 secs to 7.5 secs to simulate 5.0 secs.

Most of the time was spent by the RBT collision detection methods that were unnecessarily being called 3 times per time step (for Euler, 6 for RK2).

cc'ing @sherm1, @SeanCurtis-TRI, @siyuanfeng-tri  

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4249)
<!-- Reviewable:end -->
