### PR TITLE
Implements a simple system that logs its inputs to memory ...

### DIFF
--- a/drake/common/eigen_matrix_compare.h
+++ b/drake/common/eigen_matrix_compare.h
@@ -40,7 +40,7 @@ bool CompareMatrices(
   if (m1.rows() != m2.rows() || m1.cols() != m2.cols()) {
     std::stringstream msg;
     msg << "Matrix size mismatch: (" << m1.rows() << " x " << m1.cols()
-        << " vs. " << m2.rows() << " x " << m2.rows() << ")";
+        << " vs. " << m2.rows() << " x " << m2.cols() << ")";
     error_message = msg.str();
     result = false;
   }

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -334,11 +334,12 @@ void Simulator<T>::Initialize() {
   // Initialize the integrator.
   integrator_->Initialize();
 
-  // Do a publish before the simulation starts.
-  system_.Publish(*context_);
-
   // Restore default values.
   ResetStatistics();
+
+  // Do a publish before the simulation starts.
+  system_.Publish(*context_);
+  ++num_publishes_;
 
   // Initialize runtime variables.
   initialization_done_ = true;
@@ -380,6 +381,7 @@ void Simulator<T>::StepTo(const T& boundary_time) {
         switch (event.action) {
           case DiscreteEvent<T>::kPublishAction: {
             system_.Publish(*context_, event);
+            ++num_publishes_;
             break;
           }
           case DiscreteEvent<T>::kUpdateAction: {
@@ -403,7 +405,10 @@ void Simulator<T>::StepTo(const T& boundary_time) {
     }
 
     // Allow System a chance to produce some output.
-    if (publish_hit) system_.Publish(*context_);
+    if (publish_hit) {
+      system_.Publish(*context_);
+      ++num_publishes_;
+    }
 
     // Remove old events
     update_actions.events.clear();
@@ -451,6 +456,7 @@ void Simulator<T>::StepTo(const T& boundary_time) {
 
   // publish at the end of the step
   system_.Publish(*context_);
+  ++num_publishes_;
 }
 
 // TODO(edrumwri): Prepare to remove

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -26,6 +26,7 @@ set(sources
   primitives/matrix_gain.cc
   primitives/multiplexer.cc
   primitives/pass_through.cc
+  primitives/signal_logger.cc
   primitives/trajectory_source.cc
   primitives/zero_order_hold.cc
   state.cc

--- a/drake/systems/framework/primitives/CMakeLists.txt
+++ b/drake/systems/framework/primitives/CMakeLists.txt
@@ -16,6 +16,7 @@ drake_install_headers(
   multiplexer.h
   pass_through.h
   pass_through-inl.h
+  signal_logger.h
   trajectory_source.h
   zero_order_hold.h
   zero_order_hold-inl.h

--- a/drake/systems/framework/primitives/affine_system.cc
+++ b/drake/systems/framework/primitives/affine_system.cc
@@ -38,10 +38,12 @@ AffineSystem<T>::AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
   DRAKE_DEMAND(num_outputs_ == D.rows());
 
   // Declares input port for u.
-  this->DeclareInputPort(kVectorValued, num_inputs_, kContinuousSampling);
+  if (num_inputs_ > 0)
+    this->DeclareInputPort(kVectorValued, num_inputs_, kContinuousSampling);
 
   // Declares output port for y.
-  this->DeclareOutputPort(kVectorValued, num_outputs_, kContinuousSampling);
+  if (num_outputs_ > 0)
+    this->DeclareOutputPort(kVectorValued, num_outputs_, kContinuousSampling);
 
   // Declares the number of continuous state variables. This is needed for
   // EvalTimeDerivaties() to work.
@@ -56,17 +58,21 @@ AffineSystem<AutoDiffXd>* AffineSystem<T>::DoToAutoDiffXd() const {
 
 template <typename T>
 const SystemPortDescriptor<T>& AffineSystem<T>::get_input_port() const {
+  DRAKE_DEMAND(num_inputs_ > 0);
   return System<T>::get_input_port(0);
 }
 
 template <typename T>
 const SystemPortDescriptor<T>& AffineSystem<T>::get_output_port() const {
+  DRAKE_DEMAND(num_outputs_ > 0);
   return System<T>::get_output_port(0);
 }
 
 template <typename T>
 void AffineSystem<T>::EvalOutput(const Context<T>& context,
                                  SystemOutput<T>* output) const {
+  if (num_outputs_ == 0) return;
+
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
@@ -77,27 +83,37 @@ void AffineSystem<T>::EvalOutput(const Context<T>& context,
       dynamic_cast<const BasicVector<T>&>(context.get_continuous_state_vector())
           .get_value();
 
-  const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-  DRAKE_DEMAND(input);
-  auto u = input->get_value();
+  auto y = output_vector->get_mutable_value();
+  y = C_ * x + y0_;
 
-  output_vector->get_mutable_value() = C_ * x + D_ * u + y0_;
+  if (num_inputs_) {
+    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
+    DRAKE_DEMAND(input);
+    auto u = input->get_value();
+    y += D_ * u;
+  }
 }
 
 template <typename T>
 void AffineSystem<T>::EvalTimeDerivatives(
     const Context<T>& context, ContinuousState<T>* derivatives) const {
+  if (num_states_ == 0) return;
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   auto x =
       dynamic_cast<const BasicVector<T>&>(context.get_continuous_state_vector())
           .get_value();
 
-  const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-  DRAKE_DEMAND(input);
-  auto u = input->get_value();
+  VectorX<T> xdot = A_ * x + xDot0_;
 
-  derivatives->SetFromVector(A_ * x + B_ * u + xDot0_);
+  if (num_inputs_ > 0) {
+    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
+    DRAKE_DEMAND(input);
+    auto u = input->get_value();
+
+    xdot += B_ * u;
+  }
+  derivatives->SetFromVector(xdot);
 }
 
 template class AffineSystem<double>;

--- a/drake/systems/framework/primitives/affine_system.cc
+++ b/drake/systems/framework/primitives/affine_system.cc
@@ -79,7 +79,7 @@ void AffineSystem<T>::EvalOutput(const Context<T>& context,
   // Evaluates the state output port.
   BasicVector<T>* output_vector = output->GetMutableVectorData(0);
 
-  auto x =
+  const auto& x =
       dynamic_cast<const BasicVector<T>&>(context.get_continuous_state_vector())
           .get_value();
 
@@ -89,7 +89,7 @@ void AffineSystem<T>::EvalOutput(const Context<T>& context,
   if (num_inputs_) {
     const BasicVector<T>* input = this->EvalVectorInput(context, 0);
     DRAKE_DEMAND(input);
-    auto u = input->get_value();
+    const auto& u = input->get_value();
     y += D_ * u;
   }
 }
@@ -100,7 +100,7 @@ void AffineSystem<T>::EvalTimeDerivatives(
   if (num_states_ == 0) return;
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
-  auto x =
+  const auto& x =
       dynamic_cast<const BasicVector<T>&>(context.get_continuous_state_vector())
           .get_value();
 
@@ -109,7 +109,7 @@ void AffineSystem<T>::EvalTimeDerivatives(
   if (num_inputs_ > 0) {
     const BasicVector<T>* input = this->EvalVectorInput(context, 0);
     DRAKE_DEMAND(input);
-    auto u = input->get_value();
+    const auto& u = input->get_value();
 
     xdot += B_ * u;
   }

--- a/drake/systems/framework/primitives/signal_logger.cc
+++ b/drake/systems/framework/primitives/signal_logger.cc
@@ -1,0 +1,44 @@
+#include "drake/systems/framework/primitives/signal_logger.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+SignalLogger<T>::SignalLogger(int input_size, int batch_allocation_size)
+    : batch_allocation_size_(batch_allocation_size),
+      sample_times_(batch_allocation_size_),
+      data_(input_size, batch_allocation_size_) {
+  DRAKE_DEMAND(input_size >= 0);
+  this->DeclareInputPort(kVectorValued, input_size, kInherited);
+  DRAKE_DEMAND(batch_allocation_size_ >= 0);
+}
+
+template <typename T>
+void SignalLogger<T>::DoPublish(const Context<T>& context) const {
+  T current_time = context.get_time();
+
+  if (num_samples_ == 0 || current_time >= sample_times_(num_samples_ - 1))
+    ++num_samples_;
+
+  // If num_samples exceeds the current allocation, then do a conservative
+  // resize (ouch!).
+  if (num_samples_ > sample_times_.size()) {
+    sample_times_.conservativeResize(sample_times_.size() +
+                                     batch_allocation_size_);
+    data_.conservativeResize(data_.rows(),
+                             data_.cols() + batch_allocation_size_);
+  }
+
+  // Record time and input to the num_samples position.
+  sample_times_(num_samples_ - 1) = current_time;
+  data_.col(num_samples_ - 1) = this->EvalVectorInput(context, 0)->get_value();
+}
+
+template class SignalLogger<double>;
+template class SignalLogger<AutoDiffXd>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/signal_logger.cc
+++ b/drake/systems/framework/primitives/signal_logger.cc
@@ -11,9 +11,9 @@ SignalLogger<T>::SignalLogger(int input_size, int batch_allocation_size)
     : batch_allocation_size_(batch_allocation_size),
       sample_times_(batch_allocation_size_),
       data_(input_size, batch_allocation_size_) {
-  DRAKE_DEMAND(input_size >= 0);
+  DRAKE_DEMAND(input_size > 0);
   this->DeclareInputPort(kVectorValued, input_size, kInherited);
-  DRAKE_DEMAND(batch_allocation_size_ >= 0);
+  DRAKE_DEMAND(batch_allocation_size_ > 0);
 }
 
 template <typename T>
@@ -25,6 +25,9 @@ void SignalLogger<T>::DoPublish(const Context<T>& context) const {
 
   // If num_samples exceeds the current allocation, then do a conservative
   // resize (ouch!).
+  // TODO(russt): change to allocating on a std::vector here and moving into a
+  // single block of contiguous memory on the (first) data access, to avoid the
+  // O(n^2) complexity.
   if (num_samples_ > sample_times_.size()) {
     sample_times_.conservativeResize(sample_times_.size() +
                                      batch_allocation_size_);

--- a/drake/systems/framework/primitives/signal_logger.h
+++ b/drake/systems/framework/primitives/signal_logger.h
@@ -20,25 +20,28 @@ namespace systems {
 template <typename T>
 class SignalLogger : public LeafSystem<T> {
  public:
+  /// Construct the signal logger system.
   /// @param input_size Dimension of the (single) input port.
   /// @param batch_allocation_size Storage is (re)allocated in blocks of
   /// input_size-by-batch_allocation_size.
   explicit SignalLogger(int input_size, int batch_allocation_size = 1000);
 
-  /// Non-copyable.
+  // Non-copyable.
   SignalLogger(const SignalLogger<T>&) = delete;
   SignalLogger& operator=(const SignalLogger<T>&) = delete;
 
   /// No output.
   void EvalOutput(const Context<T>& context,
-                  SystemOutput<T>* output) const override{};
+                  SystemOutput<T>* output) const override {}
 
-  /// Accessor methods for the logged data.
-  const Eigen::VectorBlock<VectorX<T>> sample_times(void) const {
+  /// Access the (simulation) time of the logged data.
+  Eigen::VectorBlock<VectorX<T>> sample_times() const {
     return sample_times_.head(num_samples_);
   }
-  const Eigen::Block<MatrixX<T>, Eigen::Dynamic, Eigen::Dynamic, true> data(
-      void) const {
+
+  /// Access the logged data.
+  Eigen::Block<MatrixX<T>, Eigen::Dynamic, Eigen::Dynamic, true> data()
+      const {
     return data_.leftCols(num_samples_);
   }
 

--- a/drake/systems/framework/primitives/signal_logger.h
+++ b/drake/systems/framework/primitives/signal_logger.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <forward_list>
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/// A sink block which logs its input to memory.  This data is then retrievable
+/// (e.g. after a simulation) via a handful of accessor methods.
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+///
+/// @ingroup primitive_systems
+template <typename T>
+class SignalLogger : public LeafSystem<T> {
+ public:
+  /// @param input_size Dimension of the (single) input port.
+  /// @param batch_allocation_size Storage is (re)allocated in blocks of
+  /// input_size-by-batch_allocation_size.
+  explicit SignalLogger(int input_size, int batch_allocation_size = 1000);
+
+  /// Non-copyable.
+  SignalLogger(const SignalLogger<T>&) = delete;
+  SignalLogger& operator=(const SignalLogger<T>&) = delete;
+
+  /// No output.
+  void EvalOutput(const Context<T>& context,
+                  SystemOutput<T>* output) const override{};
+
+  /// Accessor methods for the logged data.
+  const Eigen::VectorBlock<VectorX<T>> sample_times(void) const {
+    return sample_times_.head(num_samples_);
+  }
+  const Eigen::Block<MatrixX<T>, Eigen::Dynamic, Eigen::Dynamic, true> data(
+      void) const {
+    return data_.leftCols(num_samples_);
+  }
+
+ private:
+  // Logging is done in this method.
+  void DoPublish(const Context<T>& context) const override;
+
+  const int batch_allocation_size_{1000};
+
+  // Use mutable variables to hold the logged data.
+  mutable int num_samples_{0};
+  mutable VectorX<T> sample_times_;
+  mutable MatrixX<T> data_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/primitives/test/CMakeLists.txt
+++ b/drake/systems/framework/primitives/test/CMakeLists.txt
@@ -37,6 +37,9 @@ target_link_libraries(pass_through_test drakeSystemFramework)
 drake_add_cc_test(pass_through_scalartype_test)
 target_link_libraries(pass_through_scalartype_test drakeSystemFramework)
 
+drake_add_cc_test(signal_logger_test)
+target_link_libraries(signal_logger_test drakeSystemFramework drakeSystemAnalysis)
+
 drake_add_cc_test(trajectory_source_test)
 target_link_libraries(trajectory_source_test drakeSystemFramework)
 

--- a/drake/systems/framework/primitives/test/affine_system_test.cc
+++ b/drake/systems/framework/primitives/test/affine_system_test.cc
@@ -1,3 +1,5 @@
+
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/primitives/affine_system.h"
 #include "drake/systems/framework/primitives/test/affine_linear_test.h"
 
@@ -57,7 +59,7 @@ TEST_F(AffineSystemTest, Derivatives) {
   Eigen::VectorXd expected_derivatives(2);
   expected_derivatives = A_ * x + B_ * u + xDot0_;
 
-  EXPECT_EQ(expected_derivatives, derivatives_->get_vector().CopyToVector());
+  EXPECT_TRUE(CompareMatrices(expected_derivatives, derivatives_->get_vector().CopyToVector(), 1e-10));
 }
 
 // Tests that the outputs are correctly computed.
@@ -76,7 +78,7 @@ TEST_F(AffineSystemTest, Output) {
 
   expected_output = C_ * x + D_ * u + y0_;
 
-  EXPECT_EQ(expected_output, system_output_->get_vector_data(0)->get_value());
+  EXPECT_TRUE(CompareMatrices(expected_output, system_output_->get_vector_data(0)->get_value(), 1e-10));
 }
 
 

--- a/drake/systems/framework/primitives/test/affine_system_test.cc
+++ b/drake/systems/framework/primitives/test/affine_system_test.cc
@@ -1,6 +1,6 @@
 
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/primitives/affine_system.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/primitives/test/affine_linear_test.h"
 
 using std::make_unique;
@@ -59,7 +59,8 @@ TEST_F(AffineSystemTest, Derivatives) {
   Eigen::VectorXd expected_derivatives(2);
   expected_derivatives = A_ * x + B_ * u + xDot0_;
 
-  EXPECT_TRUE(CompareMatrices(expected_derivatives, derivatives_->get_vector().CopyToVector(), 1e-10));
+  EXPECT_TRUE(CompareMatrices(
+      expected_derivatives, derivatives_->get_vector().CopyToVector(), 1e-10));
 }
 
 // Tests that the outputs are correctly computed.
@@ -78,9 +79,9 @@ TEST_F(AffineSystemTest, Output) {
 
   expected_output = C_ * x + D_ * u + y0_;
 
-  EXPECT_TRUE(CompareMatrices(expected_output, system_output_->get_vector_data(0)->get_value(), 1e-10));
+  EXPECT_TRUE(CompareMatrices(
+      expected_output, system_output_->get_vector_data(0)->get_value(), 1e-10));
 }
-
 
 class FeedthroughAffineSystemTest : public ::testing::Test {
  public:
@@ -95,14 +96,12 @@ class FeedthroughAffineSystemTest : public ::testing::Test {
         AffineLinearSystemTest::make_2x2_matrix(1.5, 2.7, 3.5, -4.9));
     Eigen::MatrixXd B_(
         AffineLinearSystemTest::make_2x2_matrix(4.9, -5.1, 6.8, 7.2));
-    Eigen::VectorXd xDot0_(
-        AffineLinearSystemTest::make_2x1_vector(0, 0));
+    Eigen::VectorXd xDot0_(AffineLinearSystemTest::make_2x1_vector(0, 0));
     Eigen::MatrixXd C_(
         AffineLinearSystemTest::make_2x2_matrix(1.1, 2.5, -3.8, 4.6));
     Eigen::MatrixXd D_(
         AffineLinearSystemTest::make_2x2_matrix(d_1_1_element_, 0, 0, 0));
-    Eigen::VectorXd y0_(
-        AffineLinearSystemTest::make_2x1_vector(0, 0));
+    Eigen::VectorXd y0_(AffineLinearSystemTest::make_2x1_vector(0, 0));
     dut_ = make_unique<AffineSystem<double>>(A_, B_, xDot0_, C_, D_, y0_);
     dut_->set_name("test_feedtroughaffine_system");
   }
@@ -128,7 +127,6 @@ TEST_F(FeedthroughAffineSystemTest, FeedthroughTest) {
   InitialiseSystem();
   EXPECT_TRUE(dut_->has_any_direct_feedthrough());
 }
-
 
 }  // namespace
 }  // namespace systems

--- a/drake/systems/framework/primitives/test/affine_system_test.cc
+++ b/drake/systems/framework/primitives/test/affine_system_test.cc
@@ -1,6 +1,5 @@
-
-#include "drake/systems/framework/primitives/affine_system.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/framework/primitives/affine_system.h"
 #include "drake/systems/framework/primitives/test/affine_linear_test.h"
 
 using std::make_unique;

--- a/drake/systems/framework/primitives/test/signal_logger_test.cc
+++ b/drake/systems/framework/primitives/test/signal_logger_test.cc
@@ -1,0 +1,53 @@
+#include <drake/systems/framework/diagram_builder.h>
+#include <stdexcept>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/eigen_types.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/primitives/linear_system.h"
+#include "drake/systems/framework/primitives/signal_logger.h"
+
+namespace drake {
+namespace {
+
+// Log the output of a simple linear system (with a known solution).
+GTEST_TEST(TestSignalLogger, LinearSystemTest) {
+  systems::DiagramBuilder<double> builder;
+
+  // xdot = -x.  y = x.  (No inputs).
+  auto plant = builder.AddSystem<systems::LinearSystem<double>>(
+      Vector1d::Constant(-1.0),      // A.
+      Eigen::MatrixXd::Zero(1, 0),   // B.
+      Vector1d::Constant(1.0),       // C.
+      Eigen::MatrixXd::Zero(1, 0));  // D.
+
+  auto logger = builder.AddSystem<systems::SignalLogger<double>>(1);
+  builder.Cascade(*plant, *logger);
+
+  auto diagram = builder.Build();
+
+  // Simulate the simple system from x(0) = 1.0.
+  systems::Simulator<double> simulator(*diagram);
+  systems::Context<double>* context = simulator.get_mutable_context();
+  context->get_mutable_continuous_state_vector()->SetAtIndex(0, 1.0);
+
+  simulator.Initialize();
+  simulator.StepTo(3);
+
+  const auto& t = logger->sample_times();
+  EXPECT_EQ(t.size(), simulator.get_num_publishes());
+
+  // Now check the data (against the known solution to the diff eq).
+  const auto& x = logger->data();
+  EXPECT_EQ(x.cols(), t.size());
+
+  const Eigen::MatrixXd desired_x = exp(-t.transpose().array());
+
+  double tol = 1e-6;  // Not bad for numerical integration!
+  EXPECT_TRUE(CompareMatrices(desired_x, x, tol));
+}
+
+}  // namespace
+}  // namespace drake


### PR DESCRIPTION
which can be retreived after a simulation.  Simplest (but incomplete) workaround to #3734.

Also fixes a few bugs/style issues in other places, including:
- simulator was not counting publish events
- affine system was allocating input/output ports even if their dimension was zero (thereby requiring users to attach an empty port to use the system)
- eigen_matrix_compare was printing out rows x rows !!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4257)
<!-- Reviewable:end -->
