### PR TITLE
lcm_vector_gen should return variable references 

### DIFF
--- a/drake/automotive/gen/driving_command.h
+++ b/drake/automotive/gen/driving_command.h
@@ -39,17 +39,19 @@ class DrivingCommand : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // steering_angle
-  const T steering_angle() const { return this->GetAtIndex(K::kSteeringAngle); }
+  const T& steering_angle() const {
+    return this->GetAtIndex(K::kSteeringAngle);
+  }
   void set_steering_angle(const T& steering_angle) {
     this->SetAtIndex(K::kSteeringAngle, steering_angle);
   }
   // throttle
-  const T throttle() const { return this->GetAtIndex(K::kThrottle); }
+  const T& throttle() const { return this->GetAtIndex(K::kThrottle); }
   void set_throttle(const T& throttle) {
     this->SetAtIndex(K::kThrottle, throttle);
   }
   // brake
-  const T brake() const { return this->GetAtIndex(K::kBrake); }
+  const T& brake() const { return this->GetAtIndex(K::kBrake); }
   void set_brake(const T& brake) { this->SetAtIndex(K::kBrake, brake); }
   //@}
 };

--- a/drake/automotive/gen/euler_floating_joint_state.h
+++ b/drake/automotive/gen/euler_floating_joint_state.h
@@ -42,22 +42,22 @@ class EulerFloatingJointState : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // x
-  const T x() const { return this->GetAtIndex(K::kX); }
+  const T& x() const { return this->GetAtIndex(K::kX); }
   void set_x(const T& x) { this->SetAtIndex(K::kX, x); }
   // y
-  const T y() const { return this->GetAtIndex(K::kY); }
+  const T& y() const { return this->GetAtIndex(K::kY); }
   void set_y(const T& y) { this->SetAtIndex(K::kY, y); }
   // z
-  const T z() const { return this->GetAtIndex(K::kZ); }
+  const T& z() const { return this->GetAtIndex(K::kZ); }
   void set_z(const T& z) { this->SetAtIndex(K::kZ, z); }
   // roll
-  const T roll() const { return this->GetAtIndex(K::kRoll); }
+  const T& roll() const { return this->GetAtIndex(K::kRoll); }
   void set_roll(const T& roll) { this->SetAtIndex(K::kRoll, roll); }
   // pitch
-  const T pitch() const { return this->GetAtIndex(K::kPitch); }
+  const T& pitch() const { return this->GetAtIndex(K::kPitch); }
   void set_pitch(const T& pitch) { this->SetAtIndex(K::kPitch, pitch); }
   // yaw
-  const T yaw() const { return this->GetAtIndex(K::kYaw); }
+  const T& yaw() const { return this->GetAtIndex(K::kYaw); }
   void set_yaw(const T& yaw) { this->SetAtIndex(K::kYaw, yaw); }
   //@}
 };

--- a/drake/automotive/gen/idm_planner_parameters.h
+++ b/drake/automotive/gen/idm_planner_parameters.h
@@ -43,27 +43,27 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // desired velocity in free traffic
-  const T v_ref() const { return this->GetAtIndex(K::kVRef); }
+  const T& v_ref() const { return this->GetAtIndex(K::kVRef); }
   void set_v_ref(const T& v_ref) { this->SetAtIndex(K::kVRef, v_ref); }
   // max acceleration
-  const T a() const { return this->GetAtIndex(K::kA); }
+  const T& a() const { return this->GetAtIndex(K::kA); }
   void set_a(const T& a) { this->SetAtIndex(K::kA, a); }
   // comfortable braking deceleration
-  const T b() const { return this->GetAtIndex(K::kB); }
+  const T& b() const { return this->GetAtIndex(K::kB); }
   void set_b(const T& b) { this->SetAtIndex(K::kB, b); }
   // minimum desired net distance
-  const T s_0() const { return this->GetAtIndex(K::kS0); }
+  const T& s_0() const { return this->GetAtIndex(K::kS0); }
   void set_s_0(const T& s_0) { this->SetAtIndex(K::kS0, s_0); }
   // desired time headway to vehicle in front
-  const T time_headway() const { return this->GetAtIndex(K::kTimeHeadway); }
+  const T& time_headway() const { return this->GetAtIndex(K::kTimeHeadway); }
   void set_time_headway(const T& time_headway) {
     this->SetAtIndex(K::kTimeHeadway, time_headway);
   }
   // free-road exponent
-  const T delta() const { return this->GetAtIndex(K::kDelta); }
+  const T& delta() const { return this->GetAtIndex(K::kDelta); }
   void set_delta(const T& delta) { this->SetAtIndex(K::kDelta, delta); }
   // length of leading car
-  const T l_a() const { return this->GetAtIndex(K::kLA); }
+  const T& l_a() const { return this->GetAtIndex(K::kLA); }
   void set_l_a(const T& l_a) { this->SetAtIndex(K::kLA, l_a); }
   //@}
 };

--- a/drake/automotive/gen/simple_car_config.h
+++ b/drake/automotive/gen/simple_car_config.h
@@ -43,41 +43,41 @@ class SimpleCarConfig : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // wheelbase
-  const T wheelbase() const { return this->GetAtIndex(K::kWheelbase); }
+  const T& wheelbase() const { return this->GetAtIndex(K::kWheelbase); }
   void set_wheelbase(const T& wheelbase) {
     this->SetAtIndex(K::kWheelbase, wheelbase);
   }
   // track
-  const T track() const { return this->GetAtIndex(K::kTrack); }
+  const T& track() const { return this->GetAtIndex(K::kTrack); }
   void set_track(const T& track) { this->SetAtIndex(K::kTrack, track); }
   // max_abs_steering_angle
-  const T max_abs_steering_angle() const {
+  const T& max_abs_steering_angle() const {
     return this->GetAtIndex(K::kMaxAbsSteeringAngle);
   }
   void set_max_abs_steering_angle(const T& max_abs_steering_angle) {
     this->SetAtIndex(K::kMaxAbsSteeringAngle, max_abs_steering_angle);
   }
   // max_velocity
-  const T max_velocity() const { return this->GetAtIndex(K::kMaxVelocity); }
+  const T& max_velocity() const { return this->GetAtIndex(K::kMaxVelocity); }
   void set_max_velocity(const T& max_velocity) {
     this->SetAtIndex(K::kMaxVelocity, max_velocity);
   }
   // max_acceleration
-  const T max_acceleration() const {
+  const T& max_acceleration() const {
     return this->GetAtIndex(K::kMaxAcceleration);
   }
   void set_max_acceleration(const T& max_acceleration) {
     this->SetAtIndex(K::kMaxAcceleration, max_acceleration);
   }
   // velocity_lookahead_time
-  const T velocity_lookahead_time() const {
+  const T& velocity_lookahead_time() const {
     return this->GetAtIndex(K::kVelocityLookaheadTime);
   }
   void set_velocity_lookahead_time(const T& velocity_lookahead_time) {
     this->SetAtIndex(K::kVelocityLookaheadTime, velocity_lookahead_time);
   }
   // velocity_kp
-  const T velocity_kp() const { return this->GetAtIndex(K::kVelocityKp); }
+  const T& velocity_kp() const { return this->GetAtIndex(K::kVelocityKp); }
   void set_velocity_kp(const T& velocity_kp) {
     this->SetAtIndex(K::kVelocityKp, velocity_kp);
   }

--- a/drake/automotive/gen/simple_car_state.h
+++ b/drake/automotive/gen/simple_car_state.h
@@ -40,16 +40,16 @@ class SimpleCarState : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // x
-  const T x() const { return this->GetAtIndex(K::kX); }
+  const T& x() const { return this->GetAtIndex(K::kX); }
   void set_x(const T& x) { this->SetAtIndex(K::kX, x); }
   // y
-  const T y() const { return this->GetAtIndex(K::kY); }
+  const T& y() const { return this->GetAtIndex(K::kY); }
   void set_y(const T& y) { this->SetAtIndex(K::kY, y); }
   // heading
-  const T heading() const { return this->GetAtIndex(K::kHeading); }
+  const T& heading() const { return this->GetAtIndex(K::kHeading); }
   void set_heading(const T& heading) { this->SetAtIndex(K::kHeading, heading); }
   // velocity
-  const T velocity() const { return this->GetAtIndex(K::kVelocity); }
+  const T& velocity() const { return this->GetAtIndex(K::kVelocity); }
   void set_velocity(const T& velocity) {
     this->SetAtIndex(K::kVelocity, velocity);
   }

--- a/drake/examples/Acrobot/gen/acrobot_input_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_input_vector.h
@@ -38,7 +38,7 @@ class AcrobotInputVector : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // tau
-  const T tau() const { return this->GetAtIndex(K::kTau); }
+  const T& tau() const { return this->GetAtIndex(K::kTau); }
   void set_tau(const T& tau) { this->SetAtIndex(K::kTau, tau); }
   //@}
 };

--- a/drake/examples/Acrobot/gen/acrobot_output_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_output_vector.h
@@ -39,10 +39,10 @@ class AcrobotOutputVector : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // theta1
-  const T theta1() const { return this->GetAtIndex(K::kTheta1); }
+  const T& theta1() const { return this->GetAtIndex(K::kTheta1); }
   void set_theta1(const T& theta1) { this->SetAtIndex(K::kTheta1, theta1); }
   // theta2
-  const T theta2() const { return this->GetAtIndex(K::kTheta2); }
+  const T& theta2() const { return this->GetAtIndex(K::kTheta2); }
   void set_theta2(const T& theta2) { this->SetAtIndex(K::kTheta2, theta2); }
   //@}
 };

--- a/drake/examples/Acrobot/gen/acrobot_state_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_state_vector.h
@@ -41,18 +41,18 @@ class AcrobotStateVector : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // theta1
-  const T theta1() const { return this->GetAtIndex(K::kTheta1); }
+  const T& theta1() const { return this->GetAtIndex(K::kTheta1); }
   void set_theta1(const T& theta1) { this->SetAtIndex(K::kTheta1, theta1); }
   // theta2
-  const T theta2() const { return this->GetAtIndex(K::kTheta2); }
+  const T& theta2() const { return this->GetAtIndex(K::kTheta2); }
   void set_theta2(const T& theta2) { this->SetAtIndex(K::kTheta2, theta2); }
   // theta1dot
-  const T theta1dot() const { return this->GetAtIndex(K::kTheta1dot); }
+  const T& theta1dot() const { return this->GetAtIndex(K::kTheta1dot); }
   void set_theta1dot(const T& theta1dot) {
     this->SetAtIndex(K::kTheta1dot, theta1dot);
   }
   // theta2dot
-  const T theta2dot() const { return this->GetAtIndex(K::kTheta2dot); }
+  const T& theta2dot() const { return this->GetAtIndex(K::kTheta2dot); }
   void set_theta2dot(const T& theta2dot) {
     this->SetAtIndex(K::kTheta2dot, theta2dot);
   }

--- a/drake/examples/Pendulum/gen/pendulum_state_vector.h
+++ b/drake/examples/Pendulum/gen/pendulum_state_vector.h
@@ -39,10 +39,10 @@ class PendulumStateVector : public systems::BasicVector<T> {
   /// @name Getters and Setters
   //@{
   // theta
-  const T theta() const { return this->GetAtIndex(K::kTheta); }
+  const T& theta() const { return this->GetAtIndex(K::kTheta); }
   void set_theta(const T& theta) { this->SetAtIndex(K::kTheta, theta); }
   // thetadot
-  const T thetadot() const { return this->GetAtIndex(K::kThetadot); }
+  const T& thetadot() const { return this->GetAtIndex(K::kThetadot); }
   void set_thetadot(const T& thetadot) {
     this->SetAtIndex(K::kThetadot, thetadot);
   }

--- a/drake/tools/lcm_vector_gen.py
+++ b/drake/tools/lcm_vector_gen.py
@@ -86,7 +86,7 @@ ACCESSOR_BEGIN = """
 """
 ACCESSOR = """
     // %(doc)s
-    const T %(field)s() const { return this->GetAtIndex(K::%(kname)s); }
+    const T& %(field)s() const { return this->GetAtIndex(K::%(kname)s); }
     void set_%(field)s(const T& %(field)s) {
       this->SetAtIndex(K::%(kname)s, %(field)s);
     }


### PR DESCRIPTION
as is, it was spewing Eigen dynamic allocation when using AutoDiffXd.

I've updated the generator script, and re-generated all of the instances in master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4264)
<!-- Reviewable:end -->
