### PR TITLE
Fix doxygen comment error that caused system.h to be ignored by doxygen.

### DIFF
--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -457,7 +457,7 @@ class System {
   ///   MySystem<double> plant;
   ///   std::unique_ptr<MySystem<AutoDiffXd>> ad_plant =
   ///       systems::System<double>::ToAutoDiffXd<MySystem>(plant);
-  /// @p endcode
+  /// @endcode
   ///
   /// @tparam S The specific System pointer type to return.
   template <template <typename> class S = ::drake::systems::System>


### PR DESCRIPTION
A missing `@endcode` caused Doxygen to ignore the whole `framework/system.h` file.

Fixes #4253.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4268)
<!-- Reviewable:end -->
