### PR TITLE
Fix automotive_demo paths to work again

### DIFF
--- a/drake/automotive/automotive_demo.py
+++ b/drake/automotive/automotive_demo.py
@@ -22,7 +22,7 @@ import sys
 import time
 
 from drake_paths import (add_module_search_paths, DRAKE_DIST_BUILD_DIR,
-                         DRAKE_INSTALL_BIN_DIR, DRAKE_DRAKE_BIN_DIR)
+                         DRAKE_INSTALL_BIN_DIR, DRAKE_DRAKE_BUILD_DIR)
 
 add_module_search_paths()  # so we can find lcm stuff.
 
@@ -172,8 +172,8 @@ def wait_for_lcm_message_on_channel(channel):
 
 
 def main():
-    demo_name = "automotive_demo"
-    demo_path = os.path.join(DRAKE_DRAKE_BIN_DIR, demo_name)
+    demo_name = "automotive/automotive_demo"
+    demo_path = os.path.join(DRAKE_DRAKE_BUILD_DIR, demo_name)
 
     parser = argparse.ArgumentParser(
         add_help=False, description=__doc__, epilog=_epilog % demo_name,

--- a/drake/automotive/drake_paths.py
+++ b/drake/automotive/drake_paths.py
@@ -19,12 +19,12 @@ if not os.path.exists(DRAKE_INSTALL_BIN_DIR):
     raise RuntimeError(
         "cannot find DRAKE_DIST_BUILD_DIR at " + DRAKE_DIST_BUILD_DIR)
 
-DRAKE_DRAKE_BIN_DIR = os.path.join(DRAKE_DIST_BUILD_DIR, "drake", "bin")
+DRAKE_DRAKE_BUILD_DIR = os.path.join(DRAKE_DIST_BUILD_DIR, "drake")
 
 DRAKE_LCMTYPES_DIR = os.path.join(
     DRAKE_DIST_BUILD_DIR, 'drake', 'lcmtypes')
-LCM_PYTHON_DIR = os.path.join(
-    DRAKE_DIST_BUILD_DIR, 'externals', 'lcm', 'lib', 'python2.7')
+DRAKE_DIST_PYTHON_INSTALL_DIR = os.path.join(
+    DRAKE_DIST_BUILD_DIR, 'install', 'lib', 'python2.7')
 
 
 def _add_path(apath):
@@ -34,5 +34,5 @@ def _add_path(apath):
 
 def add_module_search_paths():
     _add_path(DRAKE_LCMTYPES_DIR)  # First, to pick up local edits to messages.
-    _add_path(os.path.join(LCM_PYTHON_DIR, 'dist-packages'))
-    _add_path(os.path.join(LCM_PYTHON_DIR, 'site-packages'))
+    _add_path(os.path.join(DRAKE_DIST_PYTHON_INSTALL_DIR, 'dist-packages'))
+    _add_path(os.path.join(DRAKE_DIST_PYTHON_INSTALL_DIR, 'site-packages'))


### PR DESCRIPTION
- Fix binary executable paths to work again (regression from a few weeks ago when bindir changed).
- Remove the hack that works around #3397 break (thus; this fixes #3397) now that our LCM sha is new enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4271)
<!-- Reviewable:end -->
