### PR TITLE
Modify the definition of the contact frame - make it more robust

### DIFF
--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -435,8 +435,8 @@ Matrix3<T> RigidBodyPlant<T>::ComputeBasisFromZ(const Vector3<T>& z_axis_W) {
   // Projects the z-axis into the first quadrant in order to identify the
   // *smallest* component of the normal.
   const Vector3<T> u(z_axis_W.cwiseAbs());
-  const int minAxis =
-      u[0] <= u[1] ? (u[0] <= u[2] ? 0 : 2) : (u[1] <= u[2] ? 1 : 2);
+  int minAxis;
+  u.minCoeff(&minAxis);
   // The world axis corresponding to the smallest component of the local z-axis
   // will be *most* perpendicular.
   Vector3<T> perpAxis;

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -478,7 +478,8 @@ VectorX<T> RigidBodyPlant<T>::ComputeContactForce(
                                                0, false);
       Vector3<T> this_normal = pair.normal;
 
-      // rotation from world (W) to contact frame (C), e.g., q_C = R_CW * q_W.
+      // R_CW is a rotation from world (W) to contact frame (C),
+      // e.g., q_C = R_CW * q_W.
       Matrix3<T> R_CW;
       ComputeBasisFromZ(this_normal, &R_CW);
       auto J = R_CW * (JA - JB);  // J = [ D1; D2; n ]

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -192,13 +192,14 @@ class RigidBodyPlant : public LeafSystem<T> {
     return System<T>::get_output_port(kinematics_output_port_id_);
   }
 
-  /// Creates a basis from a z-axis. Defines an arbitrary x- and y-axis
-  /// such that the basis is orthonormal.  The basis is R_LW, where W is
-  /// the frame in which the z-axis is expressed and L is a local basis such
-  /// that q_L = R_LW * q_W.
-  /// @param[in]  z_axis    The vector defining the basis's z-axis.
-  /// @param[out] R_LW      The final basis.
-  void ComputeBasisFromZ(const Vector3<T>& z_axis, Matrix3<T>* R_LW) const;
+  /// Creates a right-handed local basis from a z-axis. Defines an arbitrary x-
+  /// and y-axis such that the basis is orthonormal.  The basis is R_WL, where W
+  /// is the frame in which the z-axis is expressed and L is a local basis such
+  /// that v_W = R_WL * v_L.
+  /// @param[in] z_axis_W   The vector defining the basis's z-axis expressed
+  ///                       in frame W.
+  /// @retval R_WL          The computed basis.
+  static Matrix3<T> ComputeBasisFromZ(const Vector3<T>& z_axis_W);
 
  protected:
   // LeafSystem<T> override.

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -192,6 +192,14 @@ class RigidBodyPlant : public LeafSystem<T> {
     return System<T>::get_output_port(kinematics_output_port_id_);
   }
 
+  /// Creates a basis from a z-axis. Defines an arbitrary x- and y-axis
+  /// such that the basis is orthonormal.  The basis is R_LW, where W is
+  /// the frame in which the z-axis is expressed and L is a local basis such
+  /// that q_L = R_LW * q_W.
+  /// @param[in]  z_axis    The vector defining the basis's z-axis.
+  /// @param[out] R_LW      The final basis.
+  void ComputeBasisFromZ(const Vector3<T>& z_axis, Matrix3<T>* R_LW) const;
+
  protected:
   // LeafSystem<T> override.
   std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -433,10 +433,14 @@ void ExpectOrthonormal(const Matrix3<double>& R) {
   EXPECT_NEAR(0.0, R.col(0).dot(R.col(1)), kEpsilon);
   EXPECT_NEAR(0.0, R.col(0).dot(R.col(2)), kEpsilon);
   EXPECT_NEAR(0.0, R.col(1).dot(R.col(2)), kEpsilon);
+  // Test right-handedness.
+  EXPECT_TRUE(R.col(0).isApprox(R.col(1).cross(R.col(2))));
+  EXPECT_TRUE(R.col(1).isApprox(R.col(2).cross(R.col(0))));
+  EXPECT_TRUE(R.col(2).isApprox(R.col(0).cross(R.col(1))));
 }
 
-// Tests the contact frame to confirm that a robust orthonormal frame
-// is generated.
+// Tests the contact frame to confirm that a robust, right-handed orthonormal
+// frame is generated.
 GTEST_TEST(rigid_body_plant_test, TestContactFrameCreation) {
   // NOTE: This RigidBodyTree is unpopulated and *not* compiled; the method
   // being tested does not actually require a valid RigidBodyTree.  So, this
@@ -446,31 +450,30 @@ GTEST_TEST(rigid_body_plant_test, TestContactFrameCreation) {
 
   // Case 1: z-axis is simply world aligned.
   z << 1, 0, 0;
-  Matrix3<double> R_LW;
-  plant.ComputeBasisFromZ(z, &R_LW);
-  ExpectOrthonormal(R_LW);
-  EXPECT_EQ(z, R_LW.row(2).transpose());
+  Matrix3<double> R_WL = RigidBodyPlant<double>::ComputeBasisFromZ(z);
+  ExpectOrthonormal(R_WL);
+  EXPECT_EQ(z, R_WL.col(2));
 
   // Case 2: z-axis is *slightly* off of z-axis.
   z << 1, 0.01, 0.01;
   z = z.normalized();
-  plant.ComputeBasisFromZ(z, &R_LW);
-  ExpectOrthonormal(R_LW);
-  EXPECT_EQ(z, R_LW.row(2).transpose());
+  R_WL = RigidBodyPlant<double>::ComputeBasisFromZ(z);
+  ExpectOrthonormal(R_WL);
+  EXPECT_EQ(z, R_WL.col(2));
 
   // Case 3: z-axis points into the "middle" of the "first" quadrant.
   z << 1, 1, 1;
   z = z.normalized();
-  plant.ComputeBasisFromZ(z, &R_LW);
-  ExpectOrthonormal(R_LW);
-  EXPECT_EQ(z, R_LW.row(2).transpose());
+  R_WL = RigidBodyPlant<double>::ComputeBasisFromZ(z);
+  ExpectOrthonormal(R_WL);
+  EXPECT_EQ(z, R_WL.col(2));
 
   // Case 4: z-axis points in direction with negative components.
   z << -1, -1, 1;
   z = z.normalized();
-  plant.ComputeBasisFromZ(z, &R_LW);
-  ExpectOrthonormal(R_LW);
-  EXPECT_EQ(z, R_LW.row(2).transpose());
+  R_WL = RigidBodyPlant<double>::ComputeBasisFromZ(z);
+  ExpectOrthonormal(R_WL);
+  EXPECT_EQ(z, R_WL.col(2));
 }
 
 }  // namespace

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -442,10 +442,6 @@ void ExpectOrthonormal(const Matrix3<double>& R) {
 // Tests the contact frame to confirm that a robust, right-handed orthonormal
 // frame is generated.
 GTEST_TEST(rigid_body_plant_test, TestContactFrameCreation) {
-  // NOTE: This RigidBodyTree is unpopulated and *not* compiled; the method
-  // being tested does not actually require a valid RigidBodyTree.  So, this
-  // uninitialized tree is sufficient.
-  RigidBodyPlant<double> plant(make_unique<RigidBodyTree<double>>());
   Vector3<double> z;
 
   // Case 1: z-axis is simply world aligned.

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -435,7 +435,7 @@ void ExpectOrthonormal(const Matrix3<double>& R) {
   EXPECT_NEAR(0.0, R.col(1).dot(R.col(2)), kEpsilon);
 }
 
-// This tests the contact frame to confirm that a robust orthonormal frame
+// Tests the contact frame to confirm that a robust orthonormal frame
 // is generated.
 GTEST_TEST(rigid_body_plant_test, TestContactFrameCreation) {
   // NOTE: This RigidBodyTree is unpopulated and *not* compiled; the method


### PR DESCRIPTION
The old contact frame suffered from robustness issues.  Normals that were
close to the z-axis would lead to robustness issues in the required
cross products.

This approach maximizes the perpendicularity of the vectors that are
being crossed leading to a more generally robust calculation.

Based on issue #4126

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4272)
<!-- Reviewable:end -->
