### PR TITLE
Run buildifier to autoformat all BUILD files

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -4,6 +4,7 @@
 package(default_visibility = ["//visibility:public"])
 
 DEPS = ["//drake/systems/framework"]
+
 cc_library(
     name = "generated_vectors",
     srcs = [
@@ -20,8 +21,9 @@ cc_library(
         "gen/simple_car_config.h",
         "gen/simple_car_state.h",
     ],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic = 1)
+)
 
 cc_library(
     name = "generated_translators",
@@ -37,62 +39,76 @@ cc_library(
         "gen/simple_car_config_translator.h",
         "gen/simple_car_state_translator.h",
     ],
+    linkstatic = 1,
     deps = DEPS + [
         ":generated_vectors",
         "//drake/systems/lcm:translator",
         "//drake/lcmtypes:automotive",
     ],
-    linkstatic = 1)
+)
 
 DEPS = [":generated_vectors"]
+
 cc_library(
     name = "curve2",
     srcs = ["curve2.cc"],
     hdrs = ["curve2.h"],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic = 1)
+)
 
 cc_library(
     name = "linear_car",
     srcs = ["linear_car.cc"],
     hdrs = ["linear_car.h"],
+    linkstatic = 1,
     deps = DEPS + ["//drake/common:symbolic"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "idm_planner",
     srcs = ["idm_planner.cc"],
     hdrs = ["idm_planner.h"],
+    linkstatic = 1,
     deps = DEPS + ["//drake/common:symbolic"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "simple_car",
     srcs = ["simple_car.cc"],
-    hdrs = ["simple_car.h", "simple_car_to_euler_floating_joint.h"],
+    hdrs = [
+        "simple_car.h",
+        "simple_car_to_euler_floating_joint.h",
+    ],
+    linkstatic = 1,
     deps = DEPS + ["//drake/common:symbolic"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "single_lane_ego_and_agent",
     srcs = ["single_lane_ego_and_agent.cc"],
     hdrs = ["single_lane_ego_and_agent.h"],
+    linkstatic = 1,
     deps = DEPS + [
         "//drake/systems/framework/primitives:constant_vector_source",
-        ":linear_car", ":idm_planner"],
-    linkstatic = 1)
+        ":linear_car",
+        ":idm_planner",
+    ],
+)
 
 cc_library(
     name = "trajectory_car",
     srcs = ["trajectory_car.cc"],
     hdrs = ["trajectory_car.h"],
+    linkstatic = 1,
     deps = DEPS + [":curve2"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "automotive_simulator",
     srcs = ["automotive_simulator.cc"],
     hdrs = ["automotive_simulator.h"],
+    linkstatic = 1,
     deps = DEPS + [
         "//drake/lcm",
         "//drake/multibody:drake_visualizer",
@@ -104,21 +120,23 @@ cc_library(
         ":simple_car",
         ":trajectory_car",
     ],
-    linkstatic = 1)
+)
 
 cc_binary(
     name = "automotive_demo",
     srcs = [
         "automotive_demo.cc",
         "create_trajectory_params.cc",
-        "create_trajectory_params.h"
+        "create_trajectory_params.h",
     ],
+    linkstatic = 1,
     deps = [
-        "//drake/common:text_logging_gflags",
         ":automotive_simulator",
+        "//drake/common:text_logging_gflags",
     ],
-    linkstatic = 1)
+)
 
 filegroup(
     name = "models",
-    srcs = glob(["models/**"]))
+    srcs = glob(["models/**"]),
+)

--- a/drake/automotive/test/BUILD
+++ b/drake/automotive/test/BUILD
@@ -7,55 +7,67 @@ DEPS = ["@gtest//:main"]
 
 cc_test(
     name = "automotive_simulator_test",
+    size = "small",
     srcs = ["automotive_simulator_test.cc"],
-    deps = DEPS + ["//drake/automotive:automotive_simulator", "//drake/lcm:mock"],
     data = ["//drake/automotive:models"],
-    size = "small")
+    deps = DEPS + [
+        "//drake/automotive:automotive_simulator",
+        "//drake/lcm:mock",
+    ],
+)
 
 cc_test(
     name = "curve2_test",
+    size = "small",
     srcs = ["curve2_test.cc"],
     deps = DEPS + ["//drake/automotive:curve2"],
-    size = "small")
+)
 
 cc_test(
     name = "simple_car_test",
+    size = "small",
     srcs = ["simple_car_test.cc"],
     deps = DEPS + ["//drake/automotive:simple_car"],
-    size = "small")
+)
 
 cc_test(
     name = "idm_planner_test",
+    size = "small",
     srcs = ["idm_planner_test.cc"],
     deps = DEPS + ["//drake/automotive:idm_planner"],
-    size = "small")
+)
 
 cc_test(
     name = "linear_car_test",
+    size = "small",
     srcs = ["linear_car_test.cc"],
     deps = DEPS + ["//drake/automotive:linear_car"],
-    size = "small")
+)
 
 cc_test(
     name = "simple_car_to_euler_floating_joint_test",
+    size = "small",
     srcs = ["simple_car_to_euler_floating_joint_test.cc"],
     deps = DEPS + ["//drake/automotive:simple_car"],
-    size = "small")
+)
 
 cc_test(
     name = "single_lane_ego_and_agent_test",
+    size = "small",
     srcs = ["single_lane_ego_and_agent_test.cc"],
     deps = DEPS + ["//drake/automotive:single_lane_ego_and_agent"],
-    size = "small")
+)
 
 cc_test(
     name = "trajectory_car_test",
+    size = "small",
     srcs = ["trajectory_car_test.cc"],
     deps = DEPS + ["//drake/automotive:trajectory_car"],
-    size = "small")
+)
 
 cc_test(
     name = "simple_car_state_translator_test",
+    size = "small",
     srcs = ["simple_car_state_translator_test.cc"],
     deps = DEPS + ["//drake/automotive:generated_translators"],
-    size = "small")
+)

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -22,46 +22,68 @@ cc_library(
         "eigen_types.h",
         "text_logging.h",
     ],
-    deps = ["@eigen//:eigen", "@spdlog//:spdlog"],
-    linkstatic = 1)
+    linkstatic = 1,
+    deps = [
+        "@eigen//:eigen",
+        "@spdlog//:spdlog",
+    ],
+)
 
 # Specific traits and operators that are relevant to all ScalarTypes.
 cc_library(
     name = "cond",
     hdrs = ["cond.h"],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 cc_library(
     name = "number_traits",
     hdrs = ["number_traits.h"],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 # Drake's specific ScalarType-providing libraries.
 cc_library(
     name = "double",
     srcs = ["double_overloads.cc"],
     hdrs = ["double_overloads.h"],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 cc_library(
     name = "autodiff",
-    hdrs = ["autodiff_overloads.h", "eigen_autodiff_types.h"],
-    deps = [":common", ":cond"],
-    linkstatic = 1)
+    hdrs = [
+        "autodiff_overloads.h",
+        "eigen_autodiff_types.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":common",
+        ":cond",
+    ],
+)
 
 cc_library(
     name = "functional_form",
     srcs = ["functional_form.cc"],
     hdrs = ["functional_form.h"],
+    linkstatic = 1,
     deps = [":common"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "polynomial",
     srcs = ["polynomial.cc"],
-    hdrs = ["polynomial.h", "trig_poly.h"],
-    deps = [":common", ":autodiff"],
-    linkstatic = 1)
+    hdrs = [
+        "polynomial.h",
+        "trig_poly.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":autodiff",
+        ":common",
+    ],
+)
 
 cc_library(
     name = "symbolic",
@@ -84,17 +106,24 @@ cc_library(
         "symbolic_variable.h",
         "symbolic_variables.h",
     ],
-    deps = [":common", ":cond", ":number_traits"],
-    linkstatic = 1)
+    linkstatic = 1,
+    deps = [
+        ":common",
+        ":cond",
+        ":number_traits",
+    ],
+)
 
 # Miscellaneous utilities.
 cc_library(
     name = "drake_path",
+    testonly = 1,
     srcs = ["drake_path.cc"],
     hdrs = ["drake_path.h"],
-    testonly = 1,
+    linkstatic = 1,
     deps = [":common"],
-    linkstatic = 1)
+)
+
 # TODO(jwnimmer-tri) GetDrakePath has a long and storied history (#1471, #2174).
 # It serves multiple purposes (unit tests loading their models; installed demos
 # loading their models; etc.) but doesn't really do any of them well.  The rule
@@ -111,30 +140,37 @@ genrule(
 
 cc_library(
     name = "eigen_matrix_compare",
-    hdrs = ["eigen_matrix_compare.h"],
     testonly = 1,
+    hdrs = ["eigen_matrix_compare.h"],
+    linkstatic = 1,
     deps = [":common"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "nice_type_name",
     srcs = ["nice_type_name.cc"],
     hdrs = ["nice_type_name.h"],
+    linkstatic = 1,
     deps = [":common"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "sorted_vectors_have_intersection",
     hdrs = ["sorted_vectors_have_intersection.h"],
+    linkstatic = 1,
     deps = [":common"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "text_logging_gflags",
     hdrs = ["text_logging_gflags.h"],
-    deps = [":common", "@gflags//:gflags"],
     # TODO(jwnimmer-tri) Ideally, gflags BUILD would do this for us.  Figure
     # out what's going on.  Definitely don't let "-pthread" get copy-pasta'd
     # throughout our code.
     linkopts = ["-pthread"],
-    linkstatic = 1)
+    linkstatic = 1,
+    deps = [
+        ":common",
+        "@gflags//:gflags",
+    ],
+)

--- a/drake/common/test/BUILD
+++ b/drake/common/test/BUILD
@@ -3,111 +3,162 @@
 
 package(default_visibility = ["//visibility:public"])
 
-DEPS = ["//drake/common:common", "@gtest//:main"]
+DEPS = [
+    "//drake/common:common",
+    "@gtest//:main",
+]
 
 cc_library(
     name = "random_polynomial_matrix",
-    hdrs = ["random_polynomial_matrix.h"],
-    deps = ["//drake/common:polynomial"],
     testonly = 1,
-    linkstatic = 1)
+    hdrs = ["random_polynomial_matrix.h"],
+    linkstatic = 1,
+    deps = ["//drake/common:polynomial"],
+)
 
 cc_test(
     name = "autodiff_overloads_test",
+    size = "small",
     srcs = ["autodiff_overloads_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:autodiff", "//drake/common:eigen_matrix_compare"])
+    deps = DEPS + [
+        "//drake/common:autodiff",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
 
 cc_test(
     name = "double_overloads_test",
+    size = "small",
     srcs = ["double_overloads_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:double", "//drake/common:cond"])
+    deps = DEPS + [
+        "//drake/common:double",
+        "//drake/common:cond",
+    ],
+)
 
 cc_test(
     name = "drake_assert_test",
+    size = "small",
     srcs = ["drake_assert_test.cc"],
-    size = "small", deps = DEPS)
+    deps = DEPS,
+)
 
 cc_test(
     name = "drake_assert_test_compile",
+    size = "small",
     srcs = ["drake_assert_test_compile.cc"],
-    size = "small", deps = DEPS)
+    deps = DEPS,
+)
 
 cc_test(
     name = "drake_deprecated_test",
+    size = "small",
     srcs = ["drake_deprecated_test.cc"],
-    size = "small", deps = DEPS,
     # Remove spurious warnings from the default build output.
-    copts = ["-Wno-deprecated-declarations"])
+    copts = ["-Wno-deprecated-declarations"],
+    deps = DEPS,
+)
 
 cc_test(
     name = "drake_throw_test",
+    size = "small",
     srcs = ["drake_throw_test.cc"],
-    size = "small", deps = DEPS)
+    deps = DEPS,
+)
 
 cc_test(
     name = "eigen_matrix_compare_test",
+    size = "small",
     srcs = ["eigen_matrix_compare_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:eigen_matrix_compare"])
+    deps = DEPS + ["//drake/common:eigen_matrix_compare"],
+)
 
 cc_test(
     name = "eigen_stl_types_test",
+    size = "small",
     srcs = ["eigen_stl_types_test.cc"],
-    size = "small", deps = DEPS)
+    deps = DEPS,
+)
 
 cc_test(
     name = "functional_form_test",
+    size = "small",
     srcs = ["functional_form_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:functional_form"])
+    deps = DEPS + ["//drake/common:functional_form"],
+)
 
 cc_test(
     name = "nice_type_name_test",
+    size = "small",
     srcs = ["nice_type_name_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:nice_type_name"])
+    deps = DEPS + ["//drake/common:nice_type_name"],
+)
 
 cc_test(
     name = "polynomial_test",
+    size = "small",
     srcs = ["polynomial_test.cc"],
-    size = "small", deps = DEPS + [":random_polynomial_matrix", "//drake/common:eigen_matrix_compare"])
+    deps = DEPS + [
+        ":random_polynomial_matrix",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
 
 cc_test(
     name = "sorted_vectors_have_intersection_test",
+    size = "small",
     srcs = ["sorted_vectors_have_intersection_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:sorted_vectors_have_intersection"])
+    deps = DEPS + ["//drake/common:sorted_vectors_have_intersection"],
+)
 
 cc_test(
     name = "symbolic_environment_test",
+    size = "small",
     srcs = ["symbolic_environment_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:symbolic"])
+    deps = DEPS + ["//drake/common:symbolic"],
+)
 
 cc_test(
     name = "symbolic_expression_test",
+    size = "small",
     srcs = ["symbolic_expression_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:symbolic"])
+    deps = DEPS + ["//drake/common:symbolic"],
+)
 
 cc_test(
     name = "symbolic_formula_test",
+    size = "small",
     srcs = ["symbolic_formula_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:symbolic"])
+    deps = DEPS + ["//drake/common:symbolic"],
+)
 
 cc_test(
     name = "symbolic_variable_test",
+    size = "small",
     srcs = ["symbolic_variable_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:symbolic"])
+    deps = DEPS + ["//drake/common:symbolic"],
+)
 
 cc_test(
     name = "symbolic_variables_test",
+    size = "small",
     srcs = ["symbolic_variables_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:symbolic"])
+    deps = DEPS + ["//drake/common:symbolic"],
+)
 
 cc_test(
     name = "text_logging_test",
+    size = "small",
     srcs = ["text_logging_test.cc"],
-    size = "small", deps = DEPS)
+    deps = DEPS,
+)
 
 cc_test(
     name = "trig_poly_test",
+    size = "small",
     srcs = ["trig_poly_test.cc"],
-    size = "small", deps = DEPS + ["//drake/common:polynomial"])
+    deps = DEPS + ["//drake/common:polynomial"],
+)
 
 # TODO(jwnimmer-tri) These tests are currently missing...
 # - drake_assert_test in fancy variants

--- a/drake/common/trajectories/BUILD
+++ b/drake/common/trajectories/BUILD
@@ -8,29 +8,35 @@ DEPS = ["//drake/common:common"]
 cc_library(
     name = "trajectory",
     hdrs = ["trajectory.h"],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic = 1)
+)
 
 cc_library(
     name = "piecewise_polynomial",
     srcs = [
         "exponential_plus_piecewise_polynomial.cc",
         "piecewise_function.cc",
-        "piecewise_polynomial_base.cc",
         "piecewise_polynomial.cc",
+        "piecewise_polynomial_base.cc",
     ],
     hdrs = [
         "exponential_plus_piecewise_polynomial.h",
         "piecewise_function.h",
-        "piecewise_polynomial_base.h",
         "piecewise_polynomial.h",
+        "piecewise_polynomial_base.h",
     ],
+    linkstatic = 1,
     deps = DEPS + ["//drake/common:polynomial"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "piecewise_polynomial_trajectory",
     srcs = ["piecewise_polynomial_trajectory.cc"],
     hdrs = ["piecewise_polynomial_trajectory.h"],
-    deps = DEPS + [":trajectory", ":piecewise_polynomial"],
-    linkstatic = 1)
+    linkstatic = 1,
+    deps = DEPS + [
+        ":trajectory",
+        ":piecewise_polynomial",
+    ],
+)

--- a/drake/common/trajectories/test/BUILD
+++ b/drake/common/trajectories/test/BUILD
@@ -11,28 +11,32 @@ DEPS = [
 
 cc_library(
     name = "random_piecewise_polynomial",
-    hdrs = ["random_piecewise_polynomial.h"],
-    deps = ["//drake/common/test:random_polynomial_matrix"],
     testonly = 1,
-    linkstatic = 1)
+    hdrs = ["random_piecewise_polynomial.h"],
+    linkstatic = 1,
+    deps = ["//drake/common/test:random_polynomial_matrix"],
+)
 
 cc_test(
     name = "piecewise_polynomial_test",
+    size = "small",
     srcs = ["piecewise_polynomial_test.cc"],
     deps = DEPS + ["//drake/common/trajectories:piecewise_polynomial"],
-    size = "small")
+)
 
 cc_test(
     name = "exponential_plus_piecewise_polynomial_test",
-    srcs = ["exponential_plus_piecewise_polynomial_test.cc", "random_piecewise_polynomial.h"],
+    size = "small",
+    srcs = [
+        "exponential_plus_piecewise_polynomial_test.cc",
+        "random_piecewise_polynomial.h",
+    ],
     deps = DEPS + ["//drake/common/trajectories:piecewise_polynomial"],
-    size = "small")
+)
 
 cc_test(
     name = "piecewise_polynomial_trajectory_test",
+    size = "small",
     srcs = ["piecewise_polynomial_trajectory_test.cc"],
     deps = DEPS + ["//drake/common/trajectories:piecewise_polynomial_trajectory"],
-    size = "small")
-
-
-
+)

--- a/drake/lcm/BUILD
+++ b/drake/lcm/BUILD
@@ -2,6 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 package(default_visibility = ["//visibility:public"])
+
 DEPS = ["//drake/common:common"]
 
 cc_library(
@@ -10,16 +11,18 @@ cc_library(
         "drake_lcm_interface.h",
         "drake_lcm_message_handler_interface.h",
     ],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic = 1)
+)
 
 cc_library(
     name = "mock",
+    testonly = 1,
     srcs = ["drake_mock_lcm.cc"],
     hdrs = ["drake_mock_lcm.h"],
-    deps = DEPS + [":interface"],
     linkstatic = 1,
-    testonly = 1)
+    deps = DEPS + [":interface"],
+)
 
 cc_library(
     name = "lcm",
@@ -31,13 +34,18 @@ cc_library(
         "drake_lcm.h",
         "lcm_receive_thread.h",
     ],
-    deps = DEPS + [":interface", "@lcm//:lcm"],
-    linkstatic = 1)
+    linkstatic = 1,
+    deps = DEPS + [
+        ":interface",
+        "@lcm//:lcm",
+    ],
+)
 
 cc_library(
     name = "lcmt_drake_signal_utils",
+    testonly = 1,
     srcs = ["lcmt_drake_signal_utils.cc"],
     hdrs = ["lcmt_drake_signal_utils.h"],
-    deps = DEPS + ["//drake/lcmtypes:drake_signal"],
     linkstatic = 1,
-    testonly = 1)
+    deps = DEPS + ["//drake/lcmtypes:drake_signal"],
+)

--- a/drake/lcm/test/BUILD
+++ b/drake/lcm/test/BUILD
@@ -3,20 +3,29 @@
 
 package(default_visibility = ["//visibility:public"])
 
-DEPS = ["//drake/lcm:lcmt_drake_signal_utils", "@gtest//:main"]
+DEPS = [
+    "//drake/lcm:lcmt_drake_signal_utils",
+    "@gtest//:main",
+]
 
 cc_test(
     name = "drake_lcm_test",
+    size = "small",
     srcs = ["drake_lcm_test.cc"],
-    size = "small", deps = DEPS + ["//drake/lcm:lcm"],
-    local = 1)
+    local = 1,
+    deps = DEPS + ["//drake/lcm:lcm"],
+)
 
 cc_test(
     name = "drake_mock_lcm_test",
+    size = "small",
     srcs = ["drake_mock_lcm_test.cc"],
-    size = "small", deps = DEPS + ["//drake/lcm:mock"])
+    deps = DEPS + ["//drake/lcm:mock"],
+)
 
 cc_test(
     name = "lcmt_drake_signal_utils_test",
+    size = "small",
     srcs = ["lcmt_drake_signal_utils_test.cc"],
-    size = "small", deps = DEPS)
+    deps = DEPS,
+)

--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -2,13 +2,15 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 package(default_visibility = ["//visibility:public"])
+
 load("//tools:lcm.bzl", "lcm_cc_library")
 
 lcm_cc_library(
     name = "drake_signal",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_drake_signal.lcm"],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 lcm_cc_library(
     name = "viewer",
@@ -20,7 +22,8 @@ lcm_cc_library(
         "lcmt_viewer_link_data.lcm",
         "lcmt_viewer_load_robot.lcm",
     ],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 lcm_cc_library(
     name = "automotive",
@@ -31,7 +34,8 @@ lcm_cc_library(
         "lcmt_simple_car_config_t.lcm",
         "lcmt_simple_car_state_t.lcm",
     ],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 lcm_cc_library(
     name = "iiwa",
@@ -40,6 +44,7 @@ lcm_cc_library(
         "lcmt_iiwa_command.lcm",
         "lcmt_iiwa_status.lcm",
     ],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 # TODO(jwnimmer-tri) Many more messages are missing ...

--- a/drake/math/BUILD
+++ b/drake/math/BUILD
@@ -2,14 +2,16 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 package(default_visibility = ["//visibility:public"])
+
 DEPS = ["//drake/common:common"]
 
 cc_library(
     name = "autodiff",
     srcs = ["autodiff.cc"],
     hdrs = ["autodiff.h"],
+    linkstatic = 1,
     deps = DEPS + ["//drake/common:autodiff"],
-    linkstatic = 1)
+)
 
 # TODO(jwnimmer-tri) Improved name for this library, "pose_representations"?
 cc_library(
@@ -30,28 +32,30 @@ cc_library(
         "roll_pitch_yaw_using_quaternion.h",
         "rotation_matrix.h",
     ],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic = 1)
+)
 
 cc_library(
     name = "gradient",
     srcs = [
-         "autodiff_gradient.cc",
-         "cross_product.cc",
-         "gradient.cc",
-         "normalize_vector.cc",
-         "rotation_conversion_gradient.cc",
+        "autodiff_gradient.cc",
+        "cross_product.cc",
+        "gradient.cc",
+        "normalize_vector.cc",
+        "rotation_conversion_gradient.cc",
     ],
     hdrs = [
-         "autodiff_gradient.h",
-         "cross_product.h",
-         "gradient.h",
-         "gradient_util.h",
-         "normalize_vector.h",
-         "rotation_conversion_gradient.h",
+        "autodiff_gradient.h",
+        "cross_product.h",
+        "gradient.h",
+        "gradient_util.h",
+        "normalize_vector.h",
+        "rotation_conversion_gradient.h",
     ],
+    linkstatic = 1,
     deps = DEPS + [":autodiff"],
-    linkstatic = 1)
+)
 
 # These all require bleeding-edge Eigen, so please don't fold them into any
 # other important labels until we get all workspaces on newer-Eigen.
@@ -59,19 +63,22 @@ cc_library(
     name = "eigen_sparse_triplet",
     srcs = ["eigen_sparse_triplet.cc"],
     hdrs = ["eigen_sparse_triplet.h"],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic = 1)
+)
 
 cc_library(
     name = "expmap",
     srcs = ["expmap.cc"],
     hdrs = ["expmap.h"],
+    linkstatic = 1,
     deps = DEPS + [":gradient"],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "jacobian",
     srcs = ["jacobian.cc"],
     hdrs = ["jacobian.h"],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic = 1)
+)

--- a/drake/math/test/BUILD
+++ b/drake/math/test/BUILD
@@ -3,43 +3,72 @@
 
 package(default_visibility = ["//visibility:public"])
 
-DEPS = ["//drake/common:eigen_matrix_compare", "@gtest//:main"]
+DEPS = [
+    "//drake/common:eigen_matrix_compare",
+    "@gtest//:main",
+]
+
 cc_test(
     name = "autodiff_test",
+    size = "small",
     srcs = ["autodiff_test.cc"],
-    size = "small", deps = DEPS + ["//drake/math:autodiff", "//drake/math:gradient"])
+    deps = DEPS + [
+        "//drake/math:autodiff",
+        "//drake/math:gradient",
+    ],
+)
 
 cc_test(
     name = "cross_product_test",
+    size = "small",
     srcs = ["cross_product_test.cc"],
-    size = "small", deps = DEPS + ["//drake/math:gradient"])
+    deps = DEPS + ["//drake/math:gradient"],
+)
 
 cc_test(
     name = "expmap_test",
+    size = "small",
     srcs = ["expmap_test.cc"],
-    size = "small", deps = DEPS + ["//drake/math:expmap"])
+    deps = DEPS + ["//drake/math:expmap"],
+)
 
 cc_test(
     name = "eigen_sparse_triplet_test",
+    size = "small",
     srcs = ["eigen_sparse_triplet_test.cc"],
-    size = "small", deps = DEPS + ["//drake/math:eigen_sparse_triplet"])
+    deps = DEPS + ["//drake/math:eigen_sparse_triplet"],
+)
 
 cc_test(
     name = "jacobian_test",
+    size = "small",
     srcs = ["jacobian_test.cc"],
-    size = "small", deps = DEPS + ["//drake/math:jacobian", "//drake/math:gradient"])
+    deps = DEPS + [
+        "//drake/math:jacobian",
+        "//drake/math:gradient",
+    ],
+)
 
 cc_test(
     name = "gradient_util_test",
+    size = "small",
     srcs = ["gradient_util_test.cc"],
-    size = "small", deps = DEPS + ["//drake/math:gradient"])
+    deps = DEPS + ["//drake/math:gradient"],
+)
 
 cc_test(
     name = "normalize_vector_test",
+    size = "small",
     srcs = ["normalize_vector_test.cc"],
-    size = "small", deps = DEPS + ["//drake/math:gradient"])
+    deps = DEPS + ["//drake/math:gradient"],
+)
 
 cc_test(
     name = "rotation_conversion_test",
+    size = "small",
     srcs = ["rotation_conversion_test.cc"],
-    size = "small", deps = DEPS + ["//drake/math:gradient", "//drake/math:geometric_transform"])
+    deps = DEPS + [
+        "//drake/math:gradient",
+        "//drake/math:geometric_transform",
+    ],
+)

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -51,6 +51,7 @@ cc_library(
         "joints/*.h",
         "shapes/*.h",
     ]),
+    linkstatic = 1,
     deps = [
         "//drake/common:drake_path",
         "//drake/common:sorted_vectors_have_intersection",
@@ -61,7 +62,7 @@ cc_library(
         "//drake/thirdParty:tinyxml2",
         "//drake/util",
     ],
-    linkstatic = 1)
+)
 
 cc_library(
     name = "drake_visualizer",
@@ -73,9 +74,10 @@ cc_library(
         "rigid_body_plant/drake_visualizer.h",
         "rigid_body_plant/viewer_draw_translator.h",
     ],
+    linkstatic = 1,
     deps = [
+        ":rigid_body_tree",
         "//drake/lcmtypes:viewer",
         "//drake/systems/lcm",
-        ":rigid_body_tree",
     ],
-    linkstatic = 1)
+)

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -36,18 +36,20 @@ cc_library(
         "snopt_solver.h",
     ],
     hdrs = [
-        "function.h",
         "constraint.h",
         "decision_variable.h",
+        "function.h",
         "mathematical_program.h",
         "solution_result.h",
     ],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic = 1)
+)
 
 cc_library(
     name = "system_identification",
     srcs = ["system_identification.cc"],
     hdrs = ["system_identification.h"],
+    linkstatic = 1,
     deps = DEPS + [":mathematical_program"],
-    linkstatic = 1)
+)

--- a/drake/solvers/test/BUILD
+++ b/drake/solvers/test/BUILD
@@ -3,58 +3,68 @@
 
 package(default_visibility = ["//visibility:public"])
 
-DEPS = ["@gtest//:main", "//drake/common:eigen_matrix_compare"]
+DEPS = [
+    "@gtest//:main",
+    "//drake/common:eigen_matrix_compare",
+]
 
 cc_test(
     name = "constraint_test",
+    size = "small",
     srcs = ["constraint_test.cc"],
     deps = DEPS + [
         "//drake/math:gradient",
         "//drake/solvers:mathematical_program",
     ],
-    size = "small")
+)
 
 cc_test(
     name = "convex_optimization_test",
+    size = "small",
     srcs = [
         "convex_optimization_test.cc",
         "mathematical_program_test_util.h",
     ],
     deps = DEPS + ["//drake/solvers:mathematical_program"],
-    size = "small")
+)
 
 cc_test(
     name = "fastqp_solver_test",
+    size = "small",
     srcs = ["fastqp_solver_test.cc"],
     deps = DEPS + ["//drake/solvers:mathematical_program"],
-    size = "small")
+)
 
 cc_test(
     name = "mathematical_program_test",
+    size = "small",
     srcs = [
         "mathematical_program_test.cc",
         "mathematical_program_test_util.h",
     ],
     deps = DEPS + ["//drake/solvers:mathematical_program"],
-    size = "small")
+)
 
 cc_test(
     name = "mixed_integer_optimization_test",
+    size = "small",
     srcs = [
         "mathematical_program_test_util.h",
         "mixed_integer_optimization_test.cc",
     ],
     deps = DEPS + ["//drake/solvers:mathematical_program"],
-    size = "small")
+)
 
 cc_test(
     name = "moby_lcp_solver_test",
+    size = "small",
     srcs = ["moby_lcp_solver_test.cc"],
     deps = DEPS + ["//drake/solvers:mathematical_program"],
-    size = "small")
+)
 
 cc_test(
     name = "system_identification_test",
+    size = "medium",
     srcs = ["system_identification_test.cc"],
     deps = DEPS + ["//drake/solvers:system_identification"],
-    size = "medium")
+)

--- a/drake/systems/analysis/BUILD
+++ b/drake/systems/analysis/BUILD
@@ -5,7 +5,8 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "analysis",
-    hdrs = glob(["*.h"]),
     srcs = glob(["*.cc"]),
+    hdrs = glob(["*.h"]),
+    linkstatic = 1,
     deps = ["//drake/systems/framework"],
-    linkstatic = 1)
+)

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -5,11 +5,12 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "framework",
-    hdrs = glob(["*.h"]),
     srcs = glob(["*.cc"]),
+    hdrs = glob(["*.h"]),
+    linkstatic = 1,
     deps = [
+        "//drake/common",
         "//drake/common:autodiff",
-        "//drake/common:common",
         "//drake/common:number_traits",
     ],
-    linkstatic=1)
+)

--- a/drake/systems/framework/primitives/BUILD
+++ b/drake/systems/framework/primitives/BUILD
@@ -5,57 +5,67 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "adder",
-    hdrs = ["adder.h"],
     srcs = ["adder.cc"],
+    hdrs = ["adder.h"],
+    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
-    linkstatic=1)
+)
 
 cc_library(
     name = "constant_vector_source",
-    hdrs = ["constant_vector_source.h"],
     srcs = ["constant_vector_source.cc"],
+    hdrs = ["constant_vector_source.h"],
+    linkstatic = 1,
     deps = [
-        "//drake/systems/framework",
         "//drake/common:symbolic",
+        "//drake/systems/framework",
     ],
-    linkstatic=1)
+)
 
 cc_library(
     name = "gain",
-    hdrs = ["gain.h",
-            "gain-inl.h"],
     srcs = ["gain.cc"],
+    hdrs = [
+        "gain.h",
+        "gain-inl.h",
+    ],
+    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
-    linkstatic=1)
+)
 
 cc_library(
     name = "integrator",
-    hdrs = ["integrator.h"],
     srcs = ["integrator.cc"],
+    hdrs = ["integrator.h"],
+    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
-    linkstatic=1)
+)
 
 cc_library(
     name = "multiplexer",
-    hdrs = ["multiplexer.h"],
     srcs = ["multiplexer.cc"],
+    hdrs = ["multiplexer.h"],
+    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
-    linkstatic=1)
+)
 
 cc_library(
     name = "zero_order_hold",
-    hdrs = ["zero_order_hold.h",
-            "zero_order_hold-inl.h"],
     srcs = ["zero_order_hold.cc"],
+    hdrs = [
+        "zero_order_hold.h",
+        "zero_order_hold-inl.h",
+    ],
+    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
-    linkstatic=1)
+)

--- a/drake/systems/framework/test/BUILD
+++ b/drake/systems/framework/test/BUILD
@@ -5,7 +5,10 @@ package(default_visibility = ["//visibility:public"])
 
 cc_test(
     name = "leaf_context_test",
+    size = "small",
+    testonly = 1,
     srcs = ["leaf_context_test.cc"],
+    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/common:eigen_matrix_compare",
@@ -13,52 +16,56 @@ cc_test(
         "//drake/systems/framework/test_utilities",
         "@gtest//:main",
     ],
-    size = "small",
-    linkstatic=1,
-    testonly=1)
+)
 
 cc_test(
     name = "modal_state_test",
+    size = "small",
+    testonly = 1,
     srcs = ["modal_state_test.cc"],
+    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/systems/framework",
         "//drake/systems/framework/test_utilities",
         "@gtest//:main",
     ],
-    size = "small",
-    linkstatic=1,
-    testonly=1)
+)
 
 cc_test(
     name = "cache_test",
+    size = "small",
+    testonly = 1,
     srcs = ["cache_test.cc"],
+    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/systems/framework",
         "//drake/systems/framework/test_utilities",
         "@gtest//:main",
     ],
-    size = "small",
-    linkstatic=1,
-    testonly=1)
+)
 
 cc_test(
     name = "parameters_test",
+    size = "small",
+    testonly = 1,
     srcs = ["parameters_test.cc"],
+    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/systems/framework",
         "//drake/systems/framework/test_utilities",
         "@gtest//:main",
     ],
-    size = "small",
-    linkstatic=1,
-    testonly=1)
+)
 
 cc_test(
     name = "diagram_test",
+    size = "small",
+    testonly = 1,
     srcs = ["diagram_test.cc"],
+    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/systems/framework",
@@ -69,13 +76,14 @@ cc_test(
         "//drake/systems/framework/primitives:zero_order_hold",
         "@gtest//:main",
     ],
-    size = "small",
-    linkstatic=1,
-    testonly=1)
+)
 
 cc_test(
     name = "diagram_context_test",
+    size = "small",
+    testonly = 1,
     srcs = ["diagram_context_test.cc"],
+    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/common:eigen_matrix_compare",
@@ -86,6 +94,4 @@ cc_test(
         "//drake/systems/framework/primitives:zero_order_hold",
         "@gtest//:main",
     ],
-    size = "small",
-    linkstatic=1,
-    testonly=1)
+)

--- a/drake/systems/framework/test_utilities/BUILD
+++ b/drake/systems/framework/test_utilities/BUILD
@@ -5,10 +5,11 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "test_utilities",
-    hdrs = glob(["*.h"]),
+    testonly = 1,
     srcs = glob(["*.cc"]),
+    hdrs = glob(["*.h"]),
+    linkstatic = 1,
     deps = [
-        "//drake/systems/framework"
+        "//drake/systems/framework",
     ],
-    linkstatic=1,
-    testonly=1)
+)

--- a/drake/systems/lcm/BUILD
+++ b/drake/systems/lcm/BUILD
@@ -4,6 +4,7 @@
 package(default_visibility = ["//visibility:public"])
 
 DEPS = ["//drake/systems/framework"]
+
 cc_library(
     name = "translator",
     srcs = [
@@ -12,10 +13,11 @@ cc_library(
     ],
     hdrs = [
         "lcm_and_vector_base_translator.h",
-        "lcm_translator_dictionary.h"
+        "lcm_translator_dictionary.h",
     ],
+    linkstatic = 1,
     deps = DEPS,
-    linkstatic=1)
+)
 
 cc_library(
     name = "lcm",
@@ -29,12 +31,20 @@ cc_library(
         "lcm_subscriber_system.h",
         "serializer.h",
     ],
-    deps = DEPS + [":translator", "//drake/lcm:interface"],
-    linkstatic = 1)
+    linkstatic = 1,
+    deps = DEPS + [
+        ":translator",
+        "//drake/lcm:interface",
+    ],
+)
 
 cc_library(
     name = "lcmt_drake_signal_translator",
     srcs = ["lcmt_drake_signal_translator.cc"],
     hdrs = ["lcmt_drake_signal_translator.h"],
-    deps = DEPS + [":translator", "//drake/lcmtypes:drake_signal"],
-    linkstatic = 1)
+    linkstatic = 1,
+    deps = DEPS + [
+        ":translator",
+        "//drake/lcmtypes:drake_signal",
+    ],
+)

--- a/drake/systems/lcm/test/BUILD
+++ b/drake/systems/lcm/test/BUILD
@@ -7,24 +7,33 @@ DEPS = [
     "//drake/lcm:mock",
     "//drake/lcm:lcmt_drake_signal_utils",
     "//drake/systems/lcm:lcmt_drake_signal_translator",
-    "@gtest//:main"]
+    "@gtest//:main",
+]
 
 cc_test(
     name = "lcm_publisher_system_test",
+    size = "small",
     srcs = ["lcm_publisher_system_test.cc"],
-    size = "small", deps = DEPS + ["//drake/systems/lcm:lcm"])
+    deps = DEPS + ["//drake/systems/lcm:lcm"],
+)
 
 cc_test(
     name = "lcm_subscriber_system_test",
+    size = "small",
     srcs = ["lcm_subscriber_system_test.cc"],
-    size = "small", deps = DEPS + ["//drake/systems/lcm:lcm"])
+    deps = DEPS + ["//drake/systems/lcm:lcm"],
+)
 
 cc_test(
     name = "lcm_translator_dictionary_test",
+    size = "small",
     srcs = ["lcm_translator_dictionary_test.cc"],
-    size = "small", deps = DEPS + ["//drake/systems/lcm:translator"])
+    deps = DEPS + ["//drake/systems/lcm:translator"],
+)
 
 cc_test(
     name = "serializer_test",
+    size = "small",
     srcs = ["serializer_test.cc"],
-    size = "small", deps = DEPS + ["//drake/systems/lcm:lcm"])
+    deps = DEPS + ["//drake/systems/lcm:lcm"],
+)

--- a/drake/thirdParty/BUILD
+++ b/drake/thirdParty/BUILD
@@ -10,15 +10,18 @@ cc_library(
     srcs = ["bsd/spruce/src/spruce.cc"],
     hdrs = ["bsd/spruce/include/spruce.hh"],
     includes = ["bsd/spruce/include"],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 cc_library(
     name = "tinydir",
     hdrs = ["bsd/tinydir/tinydir.h"],
-    linkstatic = 1)
+    linkstatic = 1,
+)
 
 cc_library(
     name = "tinyxml2",
     srcs = ["zlib/tinyxml2/tinyxml2.cpp"],
     hdrs = ["zlib/tinyxml2/tinyxml2.h"],
-    linkstatic = 1)
+    linkstatic = 1,
+)

--- a/drake/util/BUILD
+++ b/drake/util/BUILD
@@ -1,17 +1,22 @@
 # -*- python -*
 
 package(default_visibility = ["//visibility:public"])
+
 DEPS = ["//drake/common:common"]
 
 cc_library(
     name = "util",
     srcs = [
-         "drakeGeometryUtil.cpp",
-         "drakeUtil.cpp",
+        "drakeGeometryUtil.cpp",
+        "drakeUtil.cpp",
     ],
     hdrs = [
-         "drakeGeometryUtil.h",
-         "drakeUtil.h",
+        "drakeGeometryUtil.h",
+        "drakeUtil.h",
     ],
-    deps = DEPS + ["//drake/math:geometric_transform", "//drake/math:gradient"],
-    linkstatic = 1)
+    linkstatic = 1,
+    deps = DEPS + [
+        "//drake/math:geometric_transform",
+        "//drake/math:gradient",
+    ],
+)


### PR DESCRIPTION
This uses https://github.com/bazelbuild/buildifier to standard our BUILD formatting.  This PR is only machine changes, nothing edited by hand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4283)
<!-- Reviewable:end -->
