### PR TITLE
Remove Unnecessary call to RigidBodyTree::compile() in AutomotiveSimulator

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -304,8 +304,9 @@ void AutomotiveSimulator<T>::ConnectJointStateSourcesToVisualizer() {
 template <typename T>
 void AutomotiveSimulator<T>::Start() {
   DRAKE_DEMAND(!started_);
-  // By this time, all model instances should have been added to the tree. Thus,
-  // it should be safe to compile the tree.
+  // By this time, all model instances should have been added to the tree.
+  // While the parsers have already called `compile()` on the `RigidBodyTree`,
+  // in an abundance of caution, the following line calls `compile()` again.
   rigid_body_tree_->compile();
 
   ConnectJointStateSourcesToVisualizer();

--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -304,9 +304,6 @@ void AutomotiveSimulator<T>::ConnectJointStateSourcesToVisualizer() {
 template <typename T>
 void AutomotiveSimulator<T>::Start() {
   DRAKE_DEMAND(!started_);
-  // By this time, all model instances should have been added to the tree. Thus,
-  // it should be safe to compile the tree.
-  rigid_body_tree_->compile();
 
   ConnectJointStateSourcesToVisualizer();
 

--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -304,6 +304,9 @@ void AutomotiveSimulator<T>::ConnectJointStateSourcesToVisualizer() {
 template <typename T>
 void AutomotiveSimulator<T>::Start() {
   DRAKE_DEMAND(!started_);
+  // By this time, all model instances should have been added to the tree. Thus,
+  // it should be safe to compile the tree.
+  rigid_body_tree_->compile();
 
   ConnectJointStateSourcesToVisualizer();
 


### PR DESCRIPTION
The only ways to add model instances to `AutomotiveSimulator` is via `AutomotiveSimulator::AddSimpleCarFromSdf()` and `AutomotiveSimulator::AddTrajectoryCarFromSdf()`. Both of these methods use the SDF parser, which calls `RigidBodyTree::compile()` internally. Thus, `AutomotiveSimulator` does not need to call `RigidBodyTree::compile()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4285)
<!-- Reviewable:end -->
