### PR TITLE
Make SignalLogger::sample_time const-correct

### DIFF
--- a/drake/systems/framework/primitives/BUILD
+++ b/drake/systems/framework/primitives/BUILD
@@ -14,6 +14,17 @@ cc_library(
 )
 
 cc_library(
+    name = "affine_system",
+    srcs = ["affine_system.cc"],
+    hdrs = ["affine_system.h"],
+    linkstatic = 1,
+    deps = [
+        "//drake/systems/framework",
+    ],
+)
+
+
+cc_library(
     name = "constant_vector_source",
     srcs = ["constant_vector_source.cc"],
     hdrs = ["constant_vector_source.h"],
@@ -48,6 +59,19 @@ cc_library(
 )
 
 cc_library(
+    name = "linear_system",
+    srcs = ["linear_system.cc"],
+    hdrs = ["linear_system.h"],
+    linkstatic = 1,
+    deps = [
+        ":affine_system",
+        "//drake/math:autodiff",
+        "//drake/math:gradient",
+        "//drake/systems/framework",
+    ],
+)
+
+cc_library(
     name = "multiplexer",
     srcs = ["multiplexer.cc"],
     hdrs = ["multiplexer.h"],
@@ -56,6 +80,17 @@ cc_library(
         "//drake/systems/framework",
     ],
 )
+
+cc_library(
+    name = "signal_logger",
+    srcs = ["signal_logger.cc"],
+    hdrs = ["signal_logger.h"],
+    linkstatic = 1,
+    deps = [
+        "//drake/systems/framework",
+    ],
+)
+
 
 cc_library(
     name = "zero_order_hold",

--- a/drake/systems/framework/primitives/signal_logger.h
+++ b/drake/systems/framework/primitives/signal_logger.h
@@ -35,8 +35,8 @@ class SignalLogger : public LeafSystem<T> {
                   SystemOutput<T>* output) const override {}
 
   /// Access the (simulation) time of the logged data.
-  Eigen::VectorBlock<VectorX<T>> sample_times() const {
-    return sample_times_.head(num_samples_);
+  Eigen::VectorBlock<const VectorX<T>> sample_times() const {
+    return const_cast<const VectorX<T>&>(sample_times_).head(num_samples_);
   }
 
   /// Access the logged data.

--- a/drake/systems/framework/primitives/test/BUILD
+++ b/drake/systems/framework/primitives/test/BUILD
@@ -1,0 +1,22 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+package(default_visibility = ["//visibility:public"])
+
+DEPS = [
+    "//drake/systems/framework",
+    "@gtest//:main",
+]
+
+cc_test(
+    name = "signal_logger_test",
+    size = "small",
+    srcs = ["signal_logger_test.cc"],
+    deps = DEPS + [
+        "//drake/systems/analysis",
+        "//drake/systems/framework/primitives:affine_system",
+        "//drake/systems/framework/primitives:linear_system",
+        "//drake/systems/framework/primitives:signal_logger",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)

--- a/drake/systems/framework/primitives/test/signal_logger_test.cc
+++ b/drake/systems/framework/primitives/test/signal_logger_test.cc
@@ -1,3 +1,5 @@
+#include "drake/systems/framework/primitives/signal_logger.h"
+
 #include <stdexcept>
 
 #include "gtest/gtest.h"
@@ -7,7 +9,6 @@
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/primitives/linear_system.h"
-#include "drake/systems/framework/primitives/signal_logger.h"
 
 namespace drake {
 namespace {

--- a/drake/systems/framework/primitives/test/signal_logger_test.cc
+++ b/drake/systems/framework/primitives/test/signal_logger_test.cc
@@ -1,4 +1,3 @@
-#include <drake/systems/framework/diagram_builder.h>
 #include <stdexcept>
 
 #include "gtest/gtest.h"
@@ -6,6 +5,7 @@
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/primitives/linear_system.h"
 #include "drake/systems/framework/primitives/signal_logger.h"
 


### PR DESCRIPTION
Burned by the `Eigen::VectorBlock` CRTP!  The `Derived` part of the return type must have exactly the same `const`-qualification as the vector from which the block was segmented, and a `mutable` class member is non-const even inside a const method.

This is the first time I've ever used `const_cast` to add a `const`.

Also add SignalLogger to the Bazel build.  This change developed without CMake!

@RussTedrake for both levels of review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4295)
<!-- Reviewable:end -->
