### PR TITLE
Remove redundant pods_find_pkg_config calls

### DIFF
--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -32,13 +32,12 @@ list(APPEND optimization_files
   moby_lcp_solver.cc
   system_identification.cc
   )
-pods_find_pkg_config(ipopt)
-if (ipopt_FOUND)
+if(ipopt_FOUND)
  list(APPEND optimization_files ipopt_solver.cc)
  list(APPEND optimization_requires ipopt)
 else()
   list(APPEND optimization_files no_ipopt.cc)
-endif(ipopt_FOUND)
+endif()
 if(NLopt_FOUND)
   list(APPEND optimization_files nlopt_solver.cc)
   list(APPEND optimization_requires nlopt)

--- a/drake/systems/controllers/CMakeLists.txt
+++ b/drake/systems/controllers/CMakeLists.txt
@@ -35,7 +35,6 @@ if(gurobi_FOUND AND lcm_FOUND AND yaml-cpp_FOUND)
       eigen3
       lcm)
 
-  pods_find_pkg_config(bot2-lcmgl-client)
   if(bot2-lcmgl-client_FOUND)
     add_executable(zmpCoMObserverStateVisualizer zmpCoMObserverStateVisualizer.cpp)
     pods_use_pkg_config_packages(zmpCoMObserverStateVisualizer bot2-lcmgl-client)


### PR DESCRIPTION
Already called here: https://github.com/RobotLocomotion/drake/blob/master/drake/CMakeLists.txt#L43-L45

These do need to be changed to `drake_find_package` calls eventually. IIRC these were causing problems during the initial migration, so I deferred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4301)
<!-- Reviewable:end -->
