### PR TITLE
Add missing virtual dtor on IntegratorBase

### DIFF
--- a/drake/systems/analysis/explicit_euler_integrator.h
+++ b/drake/systems/analysis/explicit_euler_integrator.h
@@ -15,7 +15,12 @@ namespace systems {
 template <class T>
 class ExplicitEulerIntegrator : public IntegratorBase<T> {
  public:
-  virtual ~ExplicitEulerIntegrator() {}
+  ~ExplicitEulerIntegrator() override = default;
+
+  // Disable copy, assign, and move.
+  ExplicitEulerIntegrator(const ExplicitEulerIntegrator<T>& other) = delete;
+  ExplicitEulerIntegrator& operator=(const ExplicitEulerIntegrator<T>& other) =
+      delete;
 
   /**
    * Constructs a fixed-step integrator for a given system using the given

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -82,6 +82,13 @@ class IntegratorBase {
     initialization_done_ = false;
   }
 
+  /** Destructor. */
+  virtual ~IntegratorBase() = default;
+
+  // Disable copy, assign, and move.
+  IntegratorBase(const IntegratorBase<T>& other) = delete;
+  IntegratorBase& operator=(const IntegratorBase<T>& other) = delete;
+
   /**
    * Indicates whether an integrator supports error estimation.
    * Without error estimation, target accuracy will be unused.

--- a/drake/systems/analysis/runge_kutta2_integrator.h
+++ b/drake/systems/analysis/runge_kutta2_integrator.h
@@ -11,7 +11,12 @@ namespace systems {
 template <class T>
 class RungeKutta2Integrator : public IntegratorBase<T> {
  public:
-  virtual ~RungeKutta2Integrator() {}
+  ~RungeKutta2Integrator() override = default;
+
+  // Disable copy, assign, and move.
+  RungeKutta2Integrator(const RungeKutta2Integrator<T>& other) = delete;
+  RungeKutta2Integrator& operator=(const RungeKutta2Integrator<T>& other) =
+      delete;
 
   /**
  * Constructs fixed-step integrator for a given system using the given

--- a/drake/systems/analysis/runge_kutta3_integrator.h
+++ b/drake/systems/analysis/runge_kutta3_integrator.h
@@ -52,7 +52,12 @@ namespace systems {
 template <class T>
 class RungeKutta3Integrator : public IntegratorBase<T> {
  public:
-  virtual ~RungeKutta3Integrator() {}
+  ~RungeKutta3Integrator() override = default;
+
+  // Disable copy, assign, and move.
+  RungeKutta3Integrator(const RungeKutta3Integrator<T>& other) = delete;
+  RungeKutta3Integrator& operator=(const RungeKutta3Integrator<T>& other) =
+      delete;
 
   explicit RungeKutta3Integrator(const System<T>& system,
                                  Context<T>* context = nullptr)

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -19,5 +19,6 @@ build:asan --linkopt -fsanitize=address
 
 # Memcheck build.
 build:memcheck --strip=never
+build:memcheck --copt -g
 build:memcheck --run_under="valgrind --leak-check=full --error-exitcode=1"
 


### PR DESCRIPTION
Its lack meant we got slicing when the simulator used integrators, which means they leaked their, e.g. continuous time derivatives.

While we're here, might as well fix up the lack of copy, assign, move, etc. verbiage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4323)
<!-- Reviewable:end -->
