### PR TITLE
Add suppression file support for Bazel memcheck

### DIFF
--- a/drake/thirdParty/bsd/spruce/src/spruce.cc
+++ b/drake/thirdParty/bsd/spruce/src/spruce.cc
@@ -244,7 +244,11 @@ void spruce::path::setAsTemp() {
 /*-------------------------------------------------------
     class path.setAsCurrent
 ---------------------------------------------------------*/
-void spruce::path::setAsCurrent() { setStr(SPRUCE_GETCWD(NULL, 0)); }
+void spruce::path::setAsCurrent() {
+  char* cwd = SPRUCE_GETCWD(NULL, 0);
+  setStr(cwd);
+  free(cwd);
+}
 
 /*-------------------------------------------------------
     class path.normalize

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,4 +1,10 @@
 # -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-# This file contains rules for the Bazel build system.
-# See http://bazel.io/ .
+package(default_visibility = ["//visibility:public"])
+
+sh_binary(
+    name = "valgrind",
+    srcs = ["valgrind.sh"],
+    data = ["valgrind.supp"],
+)

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -20,5 +20,4 @@ build:asan --linkopt -fsanitize=address
 # Memcheck build.
 build:memcheck --strip=never
 build:memcheck --copt -g
-build:memcheck --run_under="valgrind --leak-check=full --error-exitcode=1"
-
+build:memcheck --run_under=//tools:valgrind

--- a/tools/valgrind.sh
+++ b/tools/valgrind.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+valgrind \
+    --leak-check=full \
+    --suppressions="tools/valgrind.supp" \
+    --error-exitcode=1 \
+    "$@"

--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -1,0 +1,14 @@
+# This is the valgrind.supp used by `bazel test --config memcheck`.
+
+# LCM (via glib) leaks a few hundred bytes in some global handler allocation.
+{
+   lcm_glib_leak
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:g_slice_alloc
+   ...
+   fun:g_static_rec_mutex_lock
+   fun:lcm_handle
+   ...
+}


### PR DESCRIPTION
... and also suppress an LCM false positive (a less-specific form of the suppression was already in `drake/valgrind.supp`, which is the file that CMake uses for suppressions).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4329)
<!-- Reviewable:end -->
