### PR TITLE
Removes MakeInput().

### DIFF
--- a/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -36,13 +36,6 @@ namespace rigid_body_plant {
 namespace test {
 namespace {
 
-// Utility function to create an input port.
-template <class T>
-unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 // Utility function to facilitate comparing matrices for equivalency.
 template <typename DerivedA, typename DerivedB>
 bool CompareMatrices(const Eigen::MatrixBase<DerivedA>& m1,
@@ -93,7 +86,7 @@ class ContactResultTest : public ::testing::Test {
     plant_ = make_unique<RigidBodyPlant<double>>(move(unique_tree));
     context_ = plant_->CreateDefaultContext();
     output_ = plant_->AllocateOutput(*context_);
-    context_->SetInputPort(0, MakeInput(make_unique<BasicVector<double>>(0)));
+    context_->FixInputPort(0, make_unique<BasicVector<double>>(0));
     plant_->SetZeroConfiguration(context_.get());
     plant_->EvalOutput(*context_.get(), output_.get());
 

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_system1_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_system1_test.cc
@@ -20,12 +20,6 @@ namespace rigid_body_plant {
 namespace test {
 namespace {
 
-template <class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 // Tests RigidBodyPlant<T>::EvalTimeDerivatives() for a Kuka arm model.
 // The test is performed by comparing against the results obtained with an RBS1
 // model of the same Kuka arm.
@@ -103,7 +97,7 @@ GTEST_TEST(RigidBodySystemTest, CompareWithRBS1Dynamics) {
   auto input_vector = std::make_unique<BasicVector<double>>(
       rbs2->get_num_actuators());
   input_vector->set_value(u);
-  context->SetInputPort(0, MakeInput(move(input_vector)));
+  context->FixInputPort(0, move(input_vector));
 
   //////////////////////////////////////////////////////////////////////////////
   // Computes time derivatives to compare against rbs1 dynamics.

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -30,12 +30,6 @@ namespace rigid_body_plant {
 namespace test {
 namespace {
 
-template <class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 // Tests the ability to load an instance of a URDF model into a RigidBodyPlant.
 GTEST_TEST(RigidBodyPlantTest, TestLoadUrdf) {
   auto tree_ptr = make_unique<RigidBodyTree<double>>();
@@ -233,8 +227,8 @@ TEST_F(KukaArmTest, SetZeroConfiguration) {
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
   // derivatives per #3218.
-  context_->SetInputPort(0, MakeInput(make_unique<BasicVector<double>>(
-                                kuka_plant_->get_num_actuators())));
+  context_->FixInputPort(0, make_unique<BasicVector<double>>(
+                                kuka_plant_->get_num_actuators()));
 
   kuka_plant_->SetZeroConfiguration(context_.get());
 
@@ -269,8 +263,8 @@ TEST_F(KukaArmTest, EvalOutput) {
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
   // derivatives per #3218.
-  context_->SetInputPort(0, MakeInput(make_unique<BasicVector<double>>(
-                                kuka_plant_->get_num_actuators())));
+  context_->FixInputPort(0, make_unique<BasicVector<double>>(
+                                kuka_plant_->get_num_actuators()));
 
   // Zeroes the state.
   kuka_plant_->SetZeroConfiguration(context_.get());
@@ -392,7 +386,7 @@ double GetPrismaticJointLimitAccel(double position, double applied_force) {
   input << applied_force;
   auto input_vector = std::make_unique<BasicVector<double>>(1);
   input_vector->set_value(input);
-  context->SetInputPort(0, MakeInput(move(input_vector)));
+  context->FixInputPort(0, move(input_vector));
 
   // Obtain the time derivatives; test that speed is zero, return acceleration.
   auto derivatives = plant.AllocateTimeDerivatives();

--- a/drake/systems/controllers/test/gravity_compensator_test.cc
+++ b/drake/systems/controllers/test/gravity_compensator_test.cc
@@ -35,12 +35,6 @@ VectorXd ComputeGravityTorque(const RigidBodyTree<double>& rigid_body_tree,
   return rigid_body_tree.dynamicsBiasTerm(cache, f_ext, false);
 }
 
-template <class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 class GravityCompensatorTest : public ::testing::Test {
  protected:
   void Init(std::unique_ptr<RigidBodyTree<double>> tree) {
@@ -70,7 +64,7 @@ class GravityCompensatorTest : public ::testing::Test {
     input->get_mutable_value() << position_vector;
 
     // Hook input of the expected size.
-    context_->SetInputPort(0, MakeInput(std::move(input)));
+    context_->FixInputPort(0, std::move(input));
     gravity_compensator_->EvalOutput(*context_, output_.get());
 
     VectorXd expected_gravity_vector =

--- a/drake/systems/controllers/test/pid_controller_test.cc
+++ b/drake/systems/controllers/test/pid_controller_test.cc
@@ -16,14 +16,6 @@ namespace {
 
 typedef Eigen::Matrix<double, 3, 1, Eigen::DontAlign> Vector3d;
 
-// TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
-// the input of the Gain system.
-template <class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 class PidControllerTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -34,12 +26,12 @@ class PidControllerTest : public ::testing::Test {
     // Error signal input port.
     auto vec0 = std::make_unique<BasicVector<double>>(port_size_);
     vec0->get_mutable_value() << error_signal_;
-    context_->SetInputPort(0, MakeInput(std::move(vec0)));
+    context_->FixInputPort(0, std::move(vec0));
 
     // Error signal rate input port.
     auto vec1 = std::make_unique<BasicVector<double>>(port_size_);
     vec1->get_mutable_value() << error_rate_signal_;
-    context_->SetInputPort(1, MakeInput(std::move(vec1)));
+    context_->FixInputPort(1, std::move(vec1));
   }
 
   const int port_size_{3};

--- a/drake/systems/framework/primitives/test/adder_test.cc
+++ b/drake/systems/framework/primitives/test/adder_test.cc
@@ -26,11 +26,6 @@ class AdderTest : public ::testing::Test {
     input1_.reset(new BasicVector<double>(3 /* size */));
   }
 
-  static std::unique_ptr<FreestandingInputPort> MakeInput(
-      std::unique_ptr<BasicVector<double>> data) {
-    return make_unique<FreestandingInputPort>(std::move(data));
-  }
-
   std::unique_ptr<System<double>> adder_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<SystemOutput<double>> output_;
@@ -63,8 +58,8 @@ TEST_F(AdderTest, AddTwoVectors) {
   ASSERT_EQ(2, context_->get_num_input_ports());
   input0_->get_mutable_value() << 1, 2, 3;
   input1_->get_mutable_value() << 4, 5, 6;
-  context_->SetInputPort(0, MakeInput(std::move(input0_)));
-  context_->SetInputPort(1, MakeInput(std::move(input1_)));
+  context_->FixInputPort(0, std::move(input0_));
+  context_->FixInputPort(1, std::move(input1_));
 
   adder_->EvalOutput(*context_, output_.get());
 

--- a/drake/systems/framework/primitives/test/affine_linear_test.h
+++ b/drake/systems/framework/primitives/test/affine_linear_test.h
@@ -26,16 +26,7 @@ class AffineLinearSystemTest : public ::testing::Test {
 
   void SetInput(const Eigen::Ref<const VectorX<double>>& u) {
     input_vector_->get_mutable_value() << u;
-    context_->SetInputPort(
-        0, std::make_unique<FreestandingInputPort>(std::move(input_vector_)));
-  }
-
-  // Helper method to create free standing input ports, i.e., those that are
-  // not connected to any other output port in the system.
-  // Used to test standalone systems not part of a Diagram.
-  static std::unique_ptr<FreestandingInputPort> MakeInput(
-      std::unique_ptr<BasicVector<double>> data) {
-    return std::make_unique<FreestandingInputPort>(std::move(data));
+    context_->FixInputPort(0, std::move(input_vector_));
   }
 
   static Eigen::MatrixXd make_2x2_matrix(

--- a/drake/systems/framework/primitives/test/constant_value_source_test.cc
+++ b/drake/systems/framework/primitives/test/constant_value_source_test.cc
@@ -26,11 +26,6 @@ class ConstantValueSourceTest : public ::testing::Test {
     input_ = make_unique<BasicVector<double>>(3 /* size */);
   }
 
-  static std::unique_ptr<FreestandingInputPort> MakeInput(
-      std::unique_ptr<BasicVector<double>> data) {
-    return make_unique<FreestandingInputPort>(std::move(data));
-  }
-
   std::unique_ptr<System<double>> source_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<SystemOutput<double>> output_;

--- a/drake/systems/framework/primitives/test/constant_vector_source_test.cc
+++ b/drake/systems/framework/primitives/test/constant_vector_source_test.cc
@@ -25,11 +25,6 @@ class ConstantVectorSourceTest : public ::testing::Test {
     input_ = make_unique<BasicVector<double>>(3 /* size */);
   }
 
-  static std::unique_ptr<FreestandingInputPort> MakeInput(
-      std::unique_ptr<BasicVector<double>> data) {
-    return make_unique<FreestandingInputPort>(std::move(data));
-  }
-
   const Matrix<double, 2, 1, Eigen::DontAlign> kConstantVectorSource{2.0, 1.5};
   std::unique_ptr<System<double>> source_;
   std::unique_ptr<Context<double>> context_;

--- a/drake/systems/framework/primitives/test/demultiplexer_test.cc
+++ b/drake/systems/framework/primitives/test/demultiplexer_test.cc
@@ -18,14 +18,6 @@ namespace drake {
 namespace systems {
 namespace {
 
-// TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
-// the input of the Demultiplexer system.
-template<class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 class DemultiplexerTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -52,7 +44,7 @@ TEST_F(DemultiplexerTest, DemultiplexVector) {
   input_->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
-  context_->SetInputPort(0, MakeInput(std::move(input_)));
+  context_->FixInputPort(0, std::move(input_));
 
   demux_->EvalOutput(*context_, output_.get());
 
@@ -95,7 +87,7 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
   input->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
-  context->SetInputPort(0, MakeInput(std::move(input)));
+  context->FixInputPort(0, std::move(input));
 
   demux->EvalOutput(*context, output.get());
 

--- a/drake/systems/framework/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/gain_scalartype_test.cc
@@ -23,14 +23,6 @@ namespace drake {
 namespace systems {
 namespace {
 
-// TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
-// the input of the Gain system.
-template <class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 // Tests the ability to take derivatives of the output with respect to some
 // (not all) of the inputs.
 // In this unit test derivatives are taken with respect to the first and third
@@ -64,7 +56,7 @@ GTEST_TEST(GainScalarTypeTest, AutoDiff) {
 
   input->get_mutable_value() << input_vector;
 
-  context->SetInputPort(0, MakeInput(std::move(input)));
+  context->FixInputPort(0, std::move(input));
 
   gain->EvalOutput(*context, output.get());
 
@@ -120,7 +112,7 @@ TEST_F(SymbolicGainTest, VectorThroughGainSystem) {
   input0_->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
-  context_->SetInputPort(0, MakeInput(move(input0_)));
+  context_->FixInputPort(0, move(input0_));
   gain_->EvalOutput(*context_, output_.get());
 
   // Checks that the number of output ports in the Gain system and the

--- a/drake/systems/framework/primitives/test/gain_test.cc
+++ b/drake/systems/framework/primitives/test/gain_test.cc
@@ -16,14 +16,6 @@ namespace drake {
 namespace systems {
 namespace {
 
-// TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
-// the input of the Gain system.
-template <class T>
-unique_ptr<FreestandingInputPort> MakeInput(
-    unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 template <typename T>
 void TestGainSystem(const Gain<T>& gain_system,
                     const Eigen::VectorXd& input_vector,
@@ -44,7 +36,7 @@ void TestGainSystem(const Gain<T>& gain_system,
   input->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
-  context->SetInputPort(0, MakeInput(std::move(input)));
+  context->FixInputPort(0, std::move(input));
 
   gain_system.EvalOutput(*context, output.get());
 

--- a/drake/systems/framework/primitives/test/integrator_test.cc
+++ b/drake/systems/framework/primitives/test/integrator_test.cc
@@ -34,12 +34,6 @@ class IntegratorTest : public ::testing::Test {
     xc->SetFromVector(Eigen::VectorXd::Zero(kLength));
   }
 
-  static std::unique_ptr<FreestandingInputPort> MakeInput(
-      std::unique_ptr<BasicVector<double>> data) {
-    return std::unique_ptr<FreestandingInputPort>(
-        new FreestandingInputPort(std::move(data)));
-  }
-
   ContinuousState<double>* continuous_state() {
     return context_->get_mutable_continuous_state();
   }
@@ -72,7 +66,7 @@ TEST_F(IntegratorTest, Topology) {
 TEST_F(IntegratorTest, Output) {
   ASSERT_EQ(1, context_->get_num_input_ports());
   input_->get_mutable_value() << 1.0, 2.0, 3.0;
-  context_->SetInputPort(0, MakeInput(std::move(input_)));
+  context_->FixInputPort(0, std::move(input_));
 
   integrator_->EvalOutput(*context_, output_.get());
 
@@ -94,7 +88,7 @@ TEST_F(IntegratorTest, Output) {
 TEST_F(IntegratorTest, Derivatives) {
   ASSERT_EQ(1, context_->get_num_input_ports());
   input_->get_mutable_value() << 1.0, 2.0, 3.0;
-  context_->SetInputPort(0, MakeInput(std::move(input_)));
+  context_->FixInputPort(0, std::move(input_));
 
   integrator_->EvalTimeDerivatives(*context_, derivatives_.get());
   Eigen::Vector3d expected;

--- a/drake/systems/framework/primitives/test/multiplexer_test.cc
+++ b/drake/systems/framework/primitives/test/multiplexer_test.cc
@@ -13,12 +13,6 @@ namespace drake {
 namespace systems {
 namespace {
 
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::initializer_list<double> values) {
-  return make_unique<FreestandingInputPort>(
-      BasicVector<double>::Make(values));
-}
-
 class MultiplexerTest : public ::testing::Test {
  protected:
   void Reset(std::vector<int> input_sizes) {
@@ -47,9 +41,9 @@ TEST_F(MultiplexerTest, Basic) {
   ASSERT_EQ(6, output_->get_vector_data(0)->size());
 
   // Provide input data.
-  context_->SetInputPort(0, MakeInput({11.0, 22.0}));
-  context_->SetInputPort(1, MakeInput({21.0}));
-  context_->SetInputPort(2, MakeInput({31.0, 32.0, 33.0}));
+  context_->FixInputPort(0, BasicVector<double>::Make({11.0, 22.0}));
+  context_->FixInputPort(1, BasicVector<double>::Make({21.0}));
+  context_->FixInputPort(2, BasicVector<double>::Make({31.0, 32.0, 33.0}));
 
   // Confirm output data.
   mux_->EvalOutput(*context_, output_.get());

--- a/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_scalartype_test.cc
@@ -20,14 +20,6 @@ namespace drake {
 namespace systems {
 namespace {
 
-// TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
-// the input of the PassThrough system.
-template<class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 // Tests the ability to take derivatives of the output with respect to
 // the input. Since `y = u` the derivative in this case is the identity matrix.
 GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
@@ -52,7 +44,7 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
 
   input->get_mutable_value() << input_vector;
 
-  context->SetInputPort(0, MakeInput(std::move(input)));
+  context->FixInputPort(0, std::move(input));
 
   buffer->EvalOutput(*context, output.get());
 

--- a/drake/systems/framework/primitives/test/pass_through_test.cc
+++ b/drake/systems/framework/primitives/test/pass_through_test.cc
@@ -18,14 +18,6 @@ namespace drake {
 namespace systems {
 namespace {
 
-// TODO(amcastro-tri): Create a diagram with a ConstantVectorSource feeding
-// the input of the PassThrough system.
-template<class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return make_unique<FreestandingInputPort>(std::move(data));
-}
-
 class PassThroughTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -51,7 +43,7 @@ TEST_F(PassThroughTest, VectorThroughPassThroughSystem) {
   input_->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
-  context_->SetInputPort(0, MakeInput(std::move(input_)));
+  context_->FixInputPort(0, std::move(input_));
 
   pass_through_->EvalOutput(*context_, output_.get());
 

--- a/drake/systems/framework/primitives/test/trajectory_source_test.cc
+++ b/drake/systems/framework/primitives/test/trajectory_source_test.cc
@@ -30,11 +30,6 @@ class TrajectorySourceTest : public ::testing::Test {
     input_ = make_unique<BasicVector<double>>(3 /* length */);
   }
 
-  static std::unique_ptr<FreestandingInputPort> MakeInput(
-      std::unique_ptr<BasicVector<double>> data) {
-    return make_unique<FreestandingInputPort>(std::move(data));
-  }
-
   const PiecewisePolynomialTrajectory kppTraj;
   std::unique_ptr<System<double>> source_;
   std::unique_ptr<Context<double>> context_;

--- a/drake/systems/framework/primitives/test/zero_order_hold_test.cc
+++ b/drake/systems/framework/primitives/test/zero_order_hold_test.cc
@@ -20,20 +20,13 @@ namespace {
 const double kTenHertz = 0.1;
 const int kLength = 3;
 
-template <class T>
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<T>> data) {
-  return std::make_unique<FreestandingInputPort>(std::move(data));
-}
-
 class ZeroOrderHoldTest : public ::testing::Test {
  protected:
   void SetUp() override {
     hold_ = std::make_unique<ZeroOrderHold<double>>(kTenHertz, kLength);
     context_ = hold_->CreateDefaultContext();
     output_ = hold_->AllocateOutput(*context_);
-    context_->SetInputPort(
-        0, MakeInput(BasicVector<double>::Make({1.0, 1.0, 3.0})));
+    context_->FixInputPort(0, BasicVector<double>::Make({1.0, 1.0, 3.0}));
   }
 
   std::unique_ptr<System<double>> hold_;

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -18,11 +18,6 @@ namespace drake {
 namespace systems {
 namespace {
 
-std::unique_ptr<FreestandingInputPort> MakeInput(
-    std::unique_ptr<BasicVector<double>> data) {
-  return std::make_unique<FreestandingInputPort>(std::move(data));
-}
-
 /// ExampleDiagram has the following structure:
 /// adder0_: (input0_ + input1_) -> A
 /// adder1_: (A + input2_)       -> B, output 0
@@ -147,9 +142,9 @@ class DiagramTest : public ::testing::Test {
   }
 
   void AttachInputs() {
-    context_->SetInputPort(0, MakeInput(std::move(input0_)));
-    context_->SetInputPort(1, MakeInput(std::move(input1_)));
-    context_->SetInputPort(2, MakeInput(std::move(input2_)));
+    context_->FixInputPort(0, std::move(input0_));
+    context_->FixInputPort(1, std::move(input1_));
+    context_->FixInputPort(2, std::move(input2_));
   }
 
   Adder<double>* adder0() { return diagram_->adder0(); }
@@ -304,9 +299,9 @@ TEST_F(DiagramTest, ToAutoDiffXd) {
 // Tests that the same diagram can be evaluated into the same output with
 // different contexts interchangeably.
 TEST_F(DiagramTest, Clone) {
-  context_->SetInputPort(0, MakeInput(std::move(input0_)));
-  context_->SetInputPort(1, MakeInput(std::move(input1_)));
-  context_->SetInputPort(2, MakeInput(std::move(input2_)));
+  context_->FixInputPort(0, std::move(input0_));
+  context_->FixInputPort(1, std::move(input1_));
+  context_->FixInputPort(2, std::move(input2_));
 
   // Compute the output with the default inputs and sanity-check it.
   diagram_->EvalOutput(*context_, output_.get());
@@ -317,7 +312,7 @@ TEST_F(DiagramTest, Clone) {
 
   auto next_input_0 = std::make_unique<BasicVector<double>>(kSize);
   next_input_0->get_mutable_value() << 3, 6, 9;
-  clone->SetInputPort(0, MakeInput(std::move(next_input_0)));
+  clone->FixInputPort(0, std::move(next_input_0));
 
   // Recompute the output and check the values.
   diagram_->EvalOutput(*clone, output_.get());
@@ -380,9 +375,9 @@ class DiagramOfDiagramsTest : public ::testing::Test {
     input1_ = BasicVector<double>::Make({64});
     input2_ = BasicVector<double>::Make({512});
 
-    context_->SetInputPort(0, MakeInput(std::move(input0_)));
-    context_->SetInputPort(1, MakeInput(std::move(input1_)));
-    context_->SetInputPort(2, MakeInput(std::move(input2_)));
+    context_->FixInputPort(0, std::move(input0_));
+    context_->FixInputPort(1, std::move(input1_));
+    context_->FixInputPort(2, std::move(input2_));
 
     // Initialize the integrator states.
     Context<double>* d0_context =
@@ -471,7 +466,7 @@ GTEST_TEST(DiagramSubclassTest, TwelvePlusSevenIsNineteen) {
 
   auto vec = std::make_unique<BasicVector<double>>(1 /* size */);
   vec->get_mutable_value() << 12.0;
-  context->SetInputPort(0, MakeInput(std::move(vec)));
+  context->FixInputPort(0, std::move(vec));
 
   plus_seven.EvalOutput(*context, output.get());
 

--- a/drake/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
+++ b/drake/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
@@ -54,14 +54,6 @@ class SpringMassSystemTest : public ::testing::Test {
     state_->set_conservative_work(0);
   }
 
-  // Helper method to create input ports (free standing input ports) that are
-  // not connected to any other output port in the system.
-  // Used to test standalone systems not part of a Diagram.
-  static std::unique_ptr<FreestandingInputPort> MakeInput(
-      std::unique_ptr<BasicVector<double>> data) {
-    return make_unique<FreestandingInputPort>(std::move(data));
-  }
-
  protected:
   std::unique_ptr<SpringMassSystem<double>> system_;
   std::unique_ptr<Context<double>> context_;
@@ -197,7 +189,7 @@ TEST_F(SpringMassSystemTest, DynamicsWithExternalForce) {
   // Creates a free standing input port not actually connected to the output of
   // another system but that has its own data in force_vector.
   // This is done in order to be able to test this system standalone.
-  context_->SetInputPort(0, MakeInput(std::move(force_vector)));
+  context_->FixInputPort(0, std::move(force_vector));
 
   InitializeState(0.1, 0.1);  // Displacement 0.1m, velocity 0.1m/sec.
   system_->EvalTimeDerivatives(*context_, system_derivatives_.get());


### PR DESCRIPTION
Instead of using a `MakeInput()` helper function, this PR switches to use `drake::systems::Context::FixInputPort()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4346)
<!-- Reviewable:end -->
