### PR TITLE
Update statistics bugfix

### DIFF
--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -1239,7 +1239,7 @@ typename IntegratorBase<T>::StepResult IntegratorBase<T>::StepOnceAtMost(
   T actual_dt;
   std::tie(step_size_was_dt, actual_dt) = DoStepOnceAtMost(dt);
 
-  // Update generic statistics. 
+  // Update generic statistics.
   UpdateStatistics(actual_dt);
 
   if (step_size_was_dt) {

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -252,7 +252,7 @@ class IntegratorBase {
     if (!context_) throw std::logic_error("Context has not been set.");
 
     // Verify that user settings are reasonable.
-    if (max_step_size < min_step_size) {
+    if (max_step_size_ < min_step_size_) {
       throw std::logic_error("Integrator maximum step size is less than the "
                              "minimum step size");
     }

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -249,9 +249,10 @@ class IntegratorBase {
     if (!context_) throw std::logic_error("Context has not been set.");
 
     // Verify that user settings are reasonable.
-    if (max_step_size < min_step_size)
+    if (max_step_size < min_step_size) {
       throw std::logic_error("Integrator maximum step size is less than the "
                              "minimum step size");
+    }
 
     // TODO(edrumwri): Compute qbar_weight_, z_weight_ automatically.
     // Set error weighting vectors if not already done.

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -819,7 +819,7 @@ class IntegratorBase {
    * @returns a std::pair<bool, T>, with the first element corresponding to
    *          `false` if the integrator does not take the full step of @p max_dt
    *           (and `true` otherwise) and the second element corresponding to
-   *           the step size actually taken by the integrator. 
+   *           the step size actually taken by the integrator.
    */
   virtual std::pair<bool, T> DoStepOnceAtMost(const T& max_dt);
 

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -248,6 +248,11 @@ class IntegratorBase {
   void Initialize() {
     if (!context_) throw std::logic_error("Context has not been set.");
 
+    // Verify that user settings are reasonable.
+    if (max_step_size < min_step_size)
+      throw std::logic_error("Integrator maximum step size is less than the "
+                             "minimum step size");
+
     // TODO(edrumwri): Compute qbar_weight_, z_weight_ automatically.
     // Set error weighting vectors if not already done.
     if (supports_error_estimation()) {

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -252,7 +252,7 @@ class IntegratorBase {
     if (!context_) throw std::logic_error("Context has not been set.");
 
     // Verify that user settings are reasonable.
-    if (max_step_size < min_step_size) { 
+    if (max_step_size < min_step_size) {
       throw std::logic_error("Integrator maximum step size is less than the "
                              "minimum step size");
     }

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -239,19 +239,30 @@ class IntegratorBase {
    * will be thrown). If Initialize() is not called, an exception will be
    * thrown when attempting to call StepOnceAtMost(). To reinitialize the
    * integrator, Reset() should be called followed by Initialize().
-   * @throws std::logic_error If the context has not been set or one of the
-   *         weighting matrix coefficients is set to a negative value (this
+   * @throws std::logic_error If the context has not been set or a user-set
+   *         parameter has been set illogically (i.e., one of the
+   *         weighting matrix coefficients is set to a negative value- this
    *         check is only performed for integrators that support error
-   *         estimation).
+   *         estimation; the maximum step size is smaller than the minimum
+   *         step size; the requested initial step size is outside of the
+   *         interval [minimum step size, maximum step size]).
    * @sa Reset()
    */
   void Initialize() {
     if (!context_) throw std::logic_error("Context has not been set.");
 
     // Verify that user settings are reasonable.
-    if (max_step_size < min_step_size) {
+    if (max_step_size < min_step_size) { 
       throw std::logic_error("Integrator maximum step size is less than the "
                              "minimum step size");
+    }
+    if (req_initial_step_size > max_step_size_) {
+      throw std::logic_error("Requested integrator initial step size is larger "
+                             "than the maximum step size.");
+    }
+    if (req_initial_step_size < min_step_size_) {
+      throw std::logic_error("Requested integrator initial step size is smaller"
+                             " than the minimum step size.");
     }
 
     // TODO(edrumwri): Compute qbar_weight_, z_weight_ automatically.

--- a/drake/systems/analysis/runge_kutta3_integrator-inl.h
+++ b/drake/systems/analysis/runge_kutta3_integrator-inl.h
@@ -5,6 +5,8 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+#include <utility>
+
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
 
 namespace drake {

--- a/drake/systems/analysis/runge_kutta3_integrator.h
+++ b/drake/systems/analysis/runge_kutta3_integrator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "drake/systems/analysis/integrator_base.h"
 
 namespace drake {

--- a/drake/systems/analysis/runge_kutta3_integrator.h
+++ b/drake/systems/analysis/runge_kutta3_integrator.h
@@ -77,7 +77,7 @@ class RungeKutta3Integrator : public IntegratorBase<T> {
 
  private:
   void DoInitialize() override;
-  bool DoStepOnceAtMost(const T& dt) override;
+  std::pair<bool, T> DoStepOnceAtMost(const T& max_dt) override;
   void DoStepOnceFixedSize(const T& dt) override;
 
   // Vector used in error estimate calculations.

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -108,12 +108,12 @@ TEST_F(RK3IntegratorTest, BulletProofSetup) {
   // neither maximum step size nor target accuracy has been set.
   EXPECT_THROW(integrator_->Initialize(), std::logic_error);
 
-  // Attempt to initialize the integrator: should throw logic error because 
+  // Attempt to initialize the integrator: should throw logic error because
   // maximum step size smaller than minimum step size.
   integrator_->set_maximum_step_size(kDT);
   integrator_->set_minimum_step_size(kBigDT);
   EXPECT_THROW(integrator_->Initialize(), std::logic_error);
- 
+
   // Set step sizes to cogent values and try to initialize again but now using
   // bad requested initial step sizes.
   integrator_->set_minimum_step_size(1e-8);

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -287,6 +287,38 @@ TEST_F(RK3IntegratorTest, SpringMassStepEC) {
   EXPECT_LT(integrator_->get_num_steps_taken(), fixed_steps);
 }
 
+// Verifies statistics validity for error controlled integrator.
+TEST_F(RK3IntegratorTest, CheckStat) {
+  // Set integrator parameters: do error control.
+  integrator_->set_maximum_step_size(kDT);
+  integrator_->set_fixed_step_mode(false);
+
+  // Set accuracy to a really small value so that the step is guaranteed to be
+  // small.
+  integrator_->set_target_accuracy(1e-8);
+
+  // Initialize the integrator.
+  integrator_->Initialize();
+
+  // Setup the initial position and initial velocity
+  const double kInitialPosition = 0.1;
+  const double kInitialVelocity = 0.01;
+
+  // Set initial condition using the Simulator's internal Context.
+  spring_mass_->set_position(integrator_->get_mutable_context(),
+                             kInitialPosition);
+  spring_mass_->set_velocity(integrator_->get_mutable_context(),
+                             kInitialVelocity);
+
+  // Integrate just one step.
+  integrator_->StepOnceAtMost(kDT, kDT);
+
+  // Verify that integrator statistics are valid
+  EXPECT_GE(integrator_->get_previous_integration_step_size(), 0.0);
+  EXPECT_LE(integrator_->get_previous_integration_step_size(), kDT);
+  EXPECT_LE(integrator_->get_smallest_adapted_step_size_taken(), kDT);
+}
+
 // Tests accuracy when generalized velocity is not the time derivative of
 // generalized configuration (using a rigid body).
 GTEST_TEST(RK3RK2IntegratorTest, RigidBody) {

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -104,13 +104,29 @@ TEST_F(RK3IntegratorTest, BulletProofSetup) {
   const double c1 = kInitialPosition;
   const double c2 = kInitialVelocity / kOmega;
 
-  // Initialize the integrator.
+  // Attempt to initialize the integrator: should throw logic error because
+  // neither maximum step size nor target accuracy has been set.
   EXPECT_THROW(integrator_->Initialize(), std::logic_error);
 
-  // Set the accuracy to something too loose, set the maximum step size and
-  // try again.
-  integrator_->set_target_accuracy(10.0);
+  // Attempt to initialize the integrator: should throw logic error because 
+  // maximum step size smaller than minimum step size.
+  integrator_->set_maximum_step_size(kDT);
+  integrator_->set_minimum_step_size(kBigDT);
+  EXPECT_THROW(integrator_->Initialize(), std::logic_error);
+ 
+  // Set step sizes to cogent values and try to initialize again but now using
+  // bad requested initial step sizes.
+  integrator_->set_minimum_step_size(1e-8);
   integrator_->set_maximum_step_size(kBigDT);
+  integrator_->request_initial_step_size_target(1e-10);
+  EXPECT_THROW(integrator_->Initialize(), std::logic_error);
+  integrator_->request_initial_step_size_target(kBigDT*2.0);
+
+  // Set the accuracy to something too loose, set the maximum step size and
+  // try again. Integrator should now silently adjust the target accuracy to
+  // the in-use accuracy.
+  integrator_->request_initial_step_size_target(kDT);
+  integrator_->set_target_accuracy(10.0);
   integrator_->Initialize();
   EXPECT_LE(integrator_->get_accuracy_in_use(),
             integrator_->get_target_accuracy());


### PR DESCRIPTION
This PR addresses issue #4336, where UpdateStatistics() could be called with the wrong step size for variable step integrators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4347)
<!-- Reviewable:end -->
