### PR TITLE
Clion 3 puts its build directory in the source tree where it should be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ drake.jar
 *.out
 pod-build
 build
-cmake-build*
+cmake-build-*
 mlint_output.html
 .#*
 VALGRIND_OUTPUT.xml

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ drake.jar
 *.out
 pod-build
 build
+cmake-build*
 mlint_output.html
 .#*
 VALGRIND_OUTPUT.xml


### PR DESCRIPTION
The default names are "cmake-build-debug" and "cmake-build-release" depending on configuration, in `drake-distro/drake/`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4350)
<!-- Reviewable:end -->
