### PR TITLE
change the decision variable name 

### DIFF
--- a/drake/solvers/decision_variable.cc
+++ b/drake/solvers/decision_variable.cc
@@ -13,8 +13,7 @@ size_t DecisionVariableScalarHash::operator()(
 }
 
 std::ostream& operator<<(std::ostream& os, const DecisionVariableScalar& var) {
-  os << var.name();
-  return os;
+  return os << var.name();
 }
 
 VariableList::VariableList(const VariableListRef& variable_list) {

--- a/drake/solvers/decision_variable.cc
+++ b/drake/solvers/decision_variable.cc
@@ -12,6 +12,11 @@ size_t DecisionVariableScalarHash::operator()(
   return var.index();
 }
 
+std::ostream& operator<<(std::ostream& os, const DecisionVariableScalar& var) {
+  os << var.name();
+  return os;
+}
+
 VariableList::VariableList(const VariableListRef& variable_list) {
   variables_.resize(variable_list.size());
   size_ = 0;

--- a/drake/solvers/decision_variable.h
+++ b/drake/solvers/decision_variable.h
@@ -92,6 +92,9 @@ class DecisionVariableScalar {
 
   friend class MathematicalProgram;
 
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const DecisionVariableScalar& var);
+
  private:
   /*
    * Constructs a decision variable. We make this constructor private so that
@@ -124,11 +127,10 @@ namespace Eigen {
 /// Eigen scalar type traits for Matrix<DecisionVariableScalar>.
 template <>
 struct NumTraits<drake::solvers::DecisionVariableScalar> {
+  static inline int digits10() { return 0; }
   enum {
-    // Our set of allowed values is discrete, and no epsilon is allowed during
-    // equality comparison, so treat this as an unsigned integer type.
     IsInteger = 0,
-    IsSigned = 0,
+    IsSigned = 1,
     IsComplex = 0,
     RequireInitialization = 1,
     ReadCost = 1,

--- a/drake/solvers/decision_variable.h
+++ b/drake/solvers/decision_variable.h
@@ -118,8 +118,7 @@ class DecisionVariableScalar {
  * Prints out the DecisionVariableScalar's name.
  * @relates DecisionVariableScalar.
  */
-std::ostream& operator<<(std::ostream& os,
-                                const DecisionVariableScalar& var);
+std::ostream& operator<<(std::ostream& os, const DecisionVariableScalar& var);
 
 struct DecisionVariableScalarHash {
   size_t operator()(const DecisionVariableScalar& var) const;

--- a/drake/solvers/decision_variable.h
+++ b/drake/solvers/decision_variable.h
@@ -92,8 +92,6 @@ class DecisionVariableScalar {
 
   friend class MathematicalProgram;
 
-  friend std::ostream& operator<<(std::ostream& os,
-                                  const DecisionVariableScalar& var);
 
  private:
   /*
@@ -115,6 +113,12 @@ class DecisionVariableScalar {
   double* value_;
   size_t index_;
 };
+
+/**
+ * @relates DecisionVariableScalar.
+ */
+std::ostream& operator<<(std::ostream& os,
+                                const DecisionVariableScalar& var);
 
 struct DecisionVariableScalarHash {
   size_t operator()(const DecisionVariableScalar& var) const;

--- a/drake/solvers/decision_variable.h
+++ b/drake/solvers/decision_variable.h
@@ -115,6 +115,7 @@ class DecisionVariableScalar {
 };
 
 /**
+ * Prints out the DecisionVariableScalar's name.
  * @relates DecisionVariableScalar.
  */
 std::ostream& operator<<(std::ostream& os,

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -100,7 +100,7 @@ DecisionVariableVectorX MathematicalProgram::AddContinuousVariables(
     std::size_t rows, const std::string& name) {
   std::vector<std::string> names(rows);
   for (int i = 0; i < static_cast<int>(rows); ++i) {
-    names[i] = name + std::to_string(num_vars_ + i);
+    names[i] = name + std::to_string(i);
   }
   return AddContinuousVariables(rows, names);
 }
@@ -108,8 +108,13 @@ DecisionVariableVectorX MathematicalProgram::AddContinuousVariables(
 const DecisionVariableMatrixX MathematicalProgram::AddContinuousVariables(
     std::size_t rows, std::size_t cols, const std::string& name) {
   std::vector<std::string> names(rows * cols);
-  for (int i = 0; i < static_cast<int>(names.size()); ++i) {
-    names[i] = name + std::to_string(num_vars_ + i);
+  int count = 0;
+  for (int j = 0; j < static_cast<int>(cols); ++j) {
+    for (int i = 0; i < static_cast<int>(rows); ++i) {
+      names[count] =
+          name + "(" + std::to_string(i) + "," + std::to_string(j) + ")";
+      ++count;
+    }
   }
   return AddContinuousVariables(rows, cols, names);
 }
@@ -124,7 +129,7 @@ DecisionVariableMatrixX MathematicalProgram::AddBinaryVariables(
     size_t rows, size_t cols, const std::string& name) {
   std::vector<std::string> names = std::vector<std::string>(rows * cols);
   for (int i = 0; i < static_cast<int>(names.size()); ++i) {
-    names[i] = name + std::to_string(num_vars_ + i);
+    names[i] = name + std::to_string(i);
   }
   return AddBinaryVariables(rows, cols, names);
 }
@@ -138,10 +143,12 @@ DecisionVariableMatrixX MathematicalProgram::AddSymmetricContinuousVariables(
 DecisionVariableMatrixX MathematicalProgram::AddSymmetricContinuousVariables(
     size_t rows, const std::string& name) {
   std::vector<std::string> names(rows * (rows + 1) / 2);
+  int count = 0;
   for (int j = 0; j < static_cast<int>(rows); ++j) {
     for (int i = j; i < static_cast<int>(rows); ++i) {
-      names.push_back(name + "(" + std::to_string(i) + "," + std::to_string(j) +
-                      ")");
+      names[count] =
+          name + "(" + std::to_string(i) + "," + std::to_string(j) + ")";
+      ++count;
     }
   }
   return AddVariables(DecisionVariableScalar::VarType::CONTINUOUS, rows, rows,
@@ -152,7 +159,7 @@ DecisionVariableVectorX MathematicalProgram::AddBinaryVariables(
     size_t rows, const std::string& name) {
   std::vector<std::string> names = std::vector<std::string>(rows);
   for (int i = 0; i < static_cast<int>(rows); ++i) {
-    names[i] = name + std::to_string(num_vars_ + i);
+    names[i] = name + std::to_string(i);
   }
   return AddVariables(DecisionVariableScalar::VarType::BINARY, rows, names);
 }

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -671,41 +671,43 @@ class MathematicalProgram {
       size_t rows, const std::vector<std::string>& names);
 
   /**
+   * @brief Adds a runtime sized symmetric matrix as decision variables.
    * Adds a symmetric matrix as decision variables to this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param name The name of the matrix. It is only used the for user to
-   * understand the optimization program. The default name is "symmetric", and
+   * understand the optimization program. The default name is "Symmetric", and
    * each variable will be named as
    * <pre>
-   * symmetric(0, 0)     symmetric(1, 0)     ... symmetric(rows-1, 0)
-   * symmetric(1, 0)     symmetric(1, 1)     ... symmetric(rows-1, 1)
+   * Symmetric(0, 0)     Symmetric(1, 0)     ... Symmetric(rows-1, 0)
+   * Symmetric(1, 0)     Symmetric(1, 1)     ... Symmetric(rows-1, 1)
    *            ...
-   * symmetric(rows-1,0) symmetric(rows-1,1) ... symmetric(rows-1, rows-1)
+   * Symmetric(rows-1,0) Symmetric(rows-1,1) ... Symmetric(rows-1, rows-1)
    * </pre>
    * Notice that the (i,j)'th entry and (j,i)'th entry has the same name.
    */
   DecisionVariableMatrixX AddSymmetricContinuousVariables(
-      size_t rows, const std::string& name = "symmetric");
+      size_t rows, const std::string& name = "Symmetric");
 
   /**
+   * @brief Adds a compile time sized symmetric matrix as decision variables.
    * Adds a symmetric matrix as decision variables to this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param name The name of the matrix. It is only used the for user to
-   * understand the optimization program. The default name is "symmetric", and
+   * understand the optimization program. The default name is "Symmetric", and
    * each variable will be named as
    * <pre>
-   * symmetric(0, 0)     symmetric(1, 0)     ... symmetric(rows-1, 0)
-   * symmetric(1, 0)     symmetric(1, 1)     ... symmetric(rows-1, 1)
+   * Symmetric(0, 0)     Symmetric(1, 0)     ... Symmetric(rows-1, 0)
+   * Symmetric(1, 0)     Symmetric(1, 1)     ... Symmetric(rows-1, 1)
    *            ...
-   * symmetric(rows-1,0) symmetric(rows-1,1) ... symmetric(rows-1, rows-1)
+   * Symmetric(rows-1,0) Symmetric(rows-1,1) ... Symmetric(rows-1, rows-1)
    * </pre>
    * Notice that the (i,j)'th entry and (j,i)'th entry has the same name.
    */
   template <int rows>
   DecisionVariableMatrix<rows, rows> AddSymmetricContinuousVariables(
-      const std::string& name = "symmetric") {
+      const std::string& name = "Symmetric") {
     std::array<std::string, rows*(rows + 1) / 2> names;
     int var_count = 0;
     for (int j = 0; j < static_cast<int>(rows); ++j) {

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -319,7 +319,7 @@ class MathematicalProgram {
   MathematicalProgram();
 
   /**
-   * Add variables to MathematicalProgram.
+   * Adds variables to MathematicalProgram.
    * Appending new variables to an internal vector of any existing vars.
    * The new variables are initialized to zero.
    * Callers are expected to add costs
@@ -354,7 +354,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add column vector variables to the optimization program.
+   * Adds column vector variables to the optimization program.
    */
   template <int rows>
   DecisionVariableVector<rows> AddVariables(
@@ -364,7 +364,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add symmetric matrix variables to optimization program. Only the lower
+   * Adds symmetric matrix variables to optimization program. Only the lower
    * triangular
    * part of the matrix is used as decision variables.
    * @param names The names of the stacked columns of the lower triangular part
@@ -380,7 +380,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add continuous variables to this MathematicalProgram.
+   * Adds continuous variables to this MathematicalProgram.
    * @see AddContinuousVariables(size_t rows, size_t cols, const
    * std::vector<std::string>& names);
    */
@@ -388,7 +388,7 @@ class MathematicalProgram {
       std::size_t rows, const std::vector<std::string>& names);
 
   /**
-   * Add continuous variables to this MathematicalProgram, with default name
+   * Adds continuous variables to this MathematicalProgram, with default name
    * "x".
    * @see AddContinuousVariables(size_t rows, size_t cols, const
    * std::vector<std::string>& names);
@@ -396,9 +396,9 @@ class MathematicalProgram {
   DecisionVariableVectorX AddContinuousVariables(std::size_t rows,
                                                  const std::string& name = "x");
 
-  /// Add continuous variables to this MathematicalProgram.
+  /// Adds continuous variables to this MathematicalProgram.
   /**
-   * Add continuous variables, appending them to an internal vector of any
+   * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
    * The new variables are initialized to zero.
    * Callers are expected to add costs
@@ -426,7 +426,7 @@ class MathematicalProgram {
       const std::vector<std::string>& names);
 
   /**
-   * Add continuous variables to this MathematicalProgram, with default name
+   * Adds continuous variables to this MathematicalProgram, with default name
    * "X". The new variables are returned and viewed as a matrix, with size
    * @p rows x @p cols.
    * @see AddContinuousVariables(size_t rows, size_t cols, const
@@ -435,9 +435,9 @@ class MathematicalProgram {
   const DecisionVariableMatrixX AddContinuousVariables(
       std::size_t rows, std::size_t cols, const std::string& name = "X");
 
-  /// Add continuous variables to this MathematicalProgram.
+  /// Adds continuous variables to this MathematicalProgram.
   /**
-   * Add continuous variables, appending them to an internal vector of any
+   * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
    * The new variables are initialized to zero.
    * Callers are expected to add costs
@@ -467,9 +467,9 @@ class MathematicalProgram {
                                     names);
   }
 
-  /// Add continuous variables to this MathematicalProgram.
+  /// Adds continuous variables to this MathematicalProgram.
   /**
-   * Add continuous variables, appending them to an internal vector of any
+   * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
    * The new variables are initialized to zero.
    * Callers are expected to add costs
@@ -505,9 +505,9 @@ class MathematicalProgram {
                                     names);
   }
 
-  /// Add continuous variables to this MathematicalProgram.
+  /// Adds continuous variables to this MathematicalProgram.
   /**
-   * Add continuous variables, appending them to an internal vector of any
+   * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
    * The new variables are initialized to zero.
    * Callers are expected to add costs
@@ -536,7 +536,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add continuous variables to the program.
+   * Adds continuous variables to the program.
    * The name for all newly added variables are set to "name". The default name
    * is "x"
    * @see AddContinuousVariables(const std::array<std::string, rows>& names)
@@ -551,9 +551,9 @@ class MathematicalProgram {
     return AddContinuousVariables<rows>(names);
   }
 
-  /// Add binary variables to this MathematicalProgram.
+  /// Adds binary variables to this MathematicalProgram.
   /**
-   * Add binary variables, appending them to an internal vector of any
+   * Adds binary variables, appending them to an internal vector of any
    * existing vars.
    * The new variables are initialized to zero.
    * Callers are expected to add costs
@@ -612,9 +612,9 @@ class MathematicalProgram {
     return AddBinaryVariables<rows, 1>(names);
   }
 
-  /// Add binary variables to this MathematicalProgram.
+  /// Adds binary variables to this MathematicalProgram.
   /**
-   * Add binary variables, appending them to an internal vector of any
+   * Adds binary variables, appending them to an internal vector of any
    * existing vars.
    * The new variables are initialized to zero.
    * Callers are expected to add costs
@@ -641,7 +641,7 @@ class MathematicalProgram {
       size_t rows, size_t cols, const std::vector<std::string>& names);
 
   /**
-   * Add binary variables to this MathematicalProgram, with default name "b".
+   * Adds binary variables to this MathematicalProgram, with default name "b".
    * The new variables are returned and viewed as a matrix, with size
    * \param rows x \param cols.
    * @see AddBinaryVariables(size_t rows, size_t cols, const
@@ -651,7 +651,7 @@ class MathematicalProgram {
                                              const std::string& name = "b");
 
   /**
-   * Add binary variables to this MathematicalProgram. The new variables are
+   * Adds binary variables to this MathematicalProgram. The new variables are
    * viewed as a column vector, with size @p rows x 1.
    * @see AddBinaryVariables(size_t rows, size_t cols, const
    * std::vector<std::string>& names);
@@ -660,7 +660,7 @@ class MathematicalProgram {
                                              const std::string& name = "b");
 
   /**
-   * Add a symmetric matrix as decision variables to this MathematicalProgram.
+   * Adds a symmetric matrix as decision variables to this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param names A std::vector containing the names of each entry in the lower
@@ -671,37 +671,41 @@ class MathematicalProgram {
       size_t rows, const std::vector<std::string>& names);
 
   /**
-   * Add a symmetric matrix as decision variables to this MathematicalProgram.
+   * Adds a symmetric matrix as decision variables to this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param name The name of the matrix. It is only used the for user to
-   * understand the optimization program. The default name is "S", and each
-   * variable will be named as
-   * S(0, 0)     S(1, 0)     ... S(rows-1, 0)
-   * S(1, 0)     S(1, 1)     ... S(rows-1, 1)
+   * understand the optimization program. The default name is "symmetric", and
+   * each variable will be named as
+   * <pre>
+   * symmetric(0, 0)     symmetric(1, 0)     ... symmetric(rows-1, 0)
+   * symmetric(1, 0)     symmetric(1, 1)     ... symmetric(rows-1, 1)
    *            ...
-   * S(rows-1,0) S(rows-1,1) ... S(rows-1, rows-1)
+   * symmetric(rows-1,0) symmetric(rows-1,1) ... symmetric(rows-1, rows-1)
+   * </pre>
    * Notice that the (i,j)'th entry and (j,i)'th entry has the same name.
    */
   DecisionVariableMatrixX AddSymmetricContinuousVariables(
-      size_t rows, const std::string& name = "S");
+      size_t rows, const std::string& name = "symmetric");
 
   /**
-   * Add a symmetric matrix as decision variables to this MathematicalProgram.
+   * Adds a symmetric matrix as decision variables to this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param name The name of the matrix. It is only used the for user to
-   * understand the optimization program. The default name is "S", and each
-   * variable will be named as
-   * S(0, 0)     S(1, 0)     ... S(rows-1, 0)
-   * S(1, 0)     S(1, 1)     ... S(rows-1, 1)
+   * understand the optimization program. The default name is "symmetric", and
+   * each variable will be named as
+   * <pre>
+   * symmetric(0, 0)     symmetric(1, 0)     ... symmetric(rows-1, 0)
+   * symmetric(1, 0)     symmetric(1, 1)     ... symmetric(rows-1, 1)
    *            ...
-   * S(rows-1,0) S(rows-1,1) ... S(rows-1, rows-1)
+   * symmetric(rows-1,0) symmetric(rows-1,1) ... symmetric(rows-1, rows-1)
+   * </pre>
    * Notice that the (i,j)'th entry and (j,i)'th entry has the same name.
    */
   template <int rows>
   DecisionVariableMatrix<rows, rows> AddSymmetricContinuousVariables(
-      const std::string& name = "S") {
+      const std::string& name = "symmetric") {
     std::array<std::string, rows*(rows + 1) / 2> names;
     int var_count = 0;
     for (int j = 0; j < static_cast<int>(rows); ++j) {
@@ -716,7 +720,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add a generic cost to the optimization program.
+   * Adds a generic cost to the optimization program.
    * @param obj The added objective.
    * @param vars The decision variables on which the cost depend.
    */
@@ -925,7 +929,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add one row of linear constraint referencing potentially a
+   * Adds one row of linear constraint referencing potentially a
    * subset of the decision variables (defined in the vars parameter).
    * lb <= a*vars <= ub
    * @param a A row vector.
@@ -945,7 +949,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add one row of linear constraint on all variables.
+   * Adds one row of linear constraint on all variables.
    * lb <= a*vars <= ub
    * @param a A row vector.
    * @param lb A scalar, the lower bound.
@@ -1007,7 +1011,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add one row of linear equality constraint referencing potentially a subset
+   * Adds one row of linear equality constraint referencing potentially a subset
    * of decision variables.
    * @f[
    * ax = beq
@@ -1025,7 +1029,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add one row of linear equality constraint referencing all
+   * Adds one row of linear equality constraint referencing all
    * decision variables.
    * @f[
    * ax = beq
@@ -1080,7 +1084,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add bounds for a single variable.
+   * Adds bounds for a single variable.
    * @param lb Lower bound.
    * @param ub Upper bound.
    * @param var The decision variable.
@@ -1252,7 +1256,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Add a positive semidefinite constraint on a symmetric matrix.
+   * Adds a positive semidefinite constraint on a symmetric matrix.
    * @param symmetric_matrix_var A symmetric DecisionVariableMatrix object.
    */
   void AddConstraint(
@@ -1260,7 +1264,7 @@ class MathematicalProgram {
       const Eigen::Ref<const DecisionVariableMatrixX> symmetric_matrix_var);
 
   /**
-   * Add a positive semidefinite constraint on a symmetric matrix.
+   * Adds a positive semidefinite constraint on a symmetric matrix.
    * In Debug mode, @throws error if
    * @p symmetric_matrix_var is not symmetric.
    * @param symmetric_matrix_var A symmetric DecisionVariableMatrix object.
@@ -1270,13 +1274,13 @@ class MathematicalProgram {
       const Eigen::Ref<const DecisionVariableMatrixX> symmetric_matrix_var);
 
   /**
-   * Add a linear matrix inequality constraint to the program.
+   * Adds a linear matrix inequality constraint to the program.
    */
   void AddConstraint(std::shared_ptr<LinearMatrixInequalityConstraint> con,
                      const VariableListRef& vars);
 
   /**
-   * Add a linear matrix inequality constraint to the program.
+   * Adds a linear matrix inequality constraint to the program.
    */
   std::shared_ptr<LinearMatrixInequalityConstraint>
   AddLinearMatrixInequalityConstraint(

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -427,13 +427,13 @@ class MathematicalProgram {
 
   /**
    * Add continuous variables to this MathematicalProgram, with default name
-   * "x". The new variables are returned and viewed as a matrix, with size
+   * "X". The new variables are returned and viewed as a matrix, with size
    * @p rows x @p cols.
    * @see AddContinuousVariables(size_t rows, size_t cols, const
    * std::vector<std::string>& names);
    */
   const DecisionVariableMatrixX AddContinuousVariables(
-      std::size_t rows, std::size_t cols, const std::string& name = "x");
+      std::size_t rows, std::size_t cols, const std::string& name = "X");
 
   /// Add continuous variables to this MathematicalProgram.
   /**
@@ -497,7 +497,8 @@ class MathematicalProgram {
     std::array<std::string, rows * cols> names;
     for (int j = 0; j < cols; ++j) {
       for (int i = 0; i < rows; ++i) {
-        names[j * rows + i] = name + std::to_string(num_vars_ + j * rows + i);
+        names[j * rows + i] =
+            name + "(" + std::to_string(i) + "," + std::to_string(j) + ")";
       }
     }
     return AddVariables<rows, cols>(DecisionVariableScalar::VarType::CONTINUOUS,
@@ -606,7 +607,7 @@ class MathematicalProgram {
       const std::string& name = "b") {
     std::array<std::string, rows> names;
     for (int i = 0; i < rows; ++i) {
-      names[i] = name + std::to_string(num_vars_ + i);
+      names[i] = name + std::to_string(i);
     }
     return AddBinaryVariables<rows, 1>(names);
   }
@@ -674,7 +675,13 @@ class MathematicalProgram {
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param name The name of the matrix. It is only used the for user to
-   * understand the optimization program.
+   * understand the optimization program. The default name is "S", and each
+   * variable will be named as
+   * S(0, 0)     S(1, 0)     ... S(rows-1, 0)
+   * S(1, 0)     S(1, 1)     ... S(rows-1, 1)
+   *            ...
+   * S(rows-1,0) S(rows-1,1) ... S(rows-1, rows-1)
+   * Notice that the (i,j)'th entry and (j,i)'th entry has the same name.
    */
   DecisionVariableMatrixX AddSymmetricContinuousVariables(
       size_t rows, const std::string& name = "S");
@@ -684,7 +691,13 @@ class MathematicalProgram {
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param name The name of the matrix. It is only used the for user to
-   * understand the optimization program.
+   * understand the optimization program. The default name is "S", and each
+   * variable will be named as
+   * S(0, 0)     S(1, 0)     ... S(rows-1, 0)
+   * S(1, 0)     S(1, 1)     ... S(rows-1, 1)
+   *            ...
+   * S(rows-1,0) S(rows-1,1) ... S(rows-1, rows-1)
+   * Notice that the (i,j)'th entry and (j,i)'th entry has the same name.
    */
   template <int rows>
   DecisionVariableMatrix<rows, rows> AddSymmetricContinuousVariables(

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -196,8 +196,8 @@ class MathematicalProgramSolverInterface {
 };
 
 class MathematicalProgram {
-  /** Binding
-   * @brief A binding on constraint type C is a mapping of the decision
+  /**
+   * A binding on constraint type C is a mapping of the decision
    * variables onto the inputs of C.  This allows the constraint to operate
    * on a vector made up of different elements of the decision variables.
    */
@@ -237,7 +237,7 @@ class MathematicalProgram {
     }
 
     /**
-     * @brief returns true iff the given @p index of the enclosing
+     * Returns true iff the given @p index of the enclosing
      * MathematicalProgram is included in this Binding.*/
     bool ContainsVariableIndex(size_t index) const {
       for (const auto& view : variable_list_.variables()) {
@@ -254,8 +254,8 @@ class MathematicalProgram {
       return variable_list_.size();
     }
 
-    /** WriteThrough()
-     * @brief Writes the elements of @p solution to the bound elements of
+    /**
+     * Writes the elements of @p solution to the bound elements of
      * the @p output vector.
      */
     void WriteThrough(const Eigen::VectorXd& solution,
@@ -671,7 +671,6 @@ class MathematicalProgram {
       size_t rows, const std::vector<std::string>& names);
 
   /**
-   * @brief Adds a runtime sized symmetric matrix as decision variables.
    * Adds a symmetric matrix as decision variables to this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
@@ -690,7 +689,6 @@ class MathematicalProgram {
       size_t rows, const std::string& name = "Symmetric");
 
   /**
-   * @brief Adds a compile time sized symmetric matrix as decision variables.
    * Adds a symmetric matrix as decision variables to this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
@@ -889,7 +887,7 @@ class MathematicalProgram {
   }
 
   /**
-   * @brief Adds a generic constraint to the program.  This should
+   * Adds a generic constraint to the program.  This should
    * only be used if a more specific type of constraint is not
    * available, as it may require the use of a significantly more
    * expensive solver.
@@ -898,7 +896,7 @@ class MathematicalProgram {
                      const VariableListRef& vars);
 
   /**
-   * @brief Adds linear constraints referencing potentially a subset
+   * Adds linear constraints referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    */
   void AddConstraint(std::shared_ptr<LinearConstraint> con,
@@ -966,7 +964,7 @@ class MathematicalProgram {
   }
 
   /**
-   * @brief Adds linear equality constraints referencing potentially a
+   * Adds linear equality constraints referencing potentially a
    * subset of the decision variables (defined in the vars parameter).
    */
   void AddConstraint(std::shared_ptr<LinearEqualityConstraint> con,
@@ -974,7 +972,7 @@ class MathematicalProgram {
 
   /** AddLinearEqualityConstraint
    *
-   * @brief Adds linear equality constraints referencing potentially a subset of
+   * Adds linear equality constraints referencing potentially a subset of
    * the decision variables.
    *
    * Example: to add two equality constraints which only depend on two of the
@@ -1002,7 +1000,7 @@ class MathematicalProgram {
 
   /** AddLinearEqualityConstraint
    *
-   * @brief Adds linear equality constraints to the program for all
+   * Adds linear equality constraints to the program for all
    * (currently existing) variables.
    */
   template <typename DerivedA, typename DerivedB>
@@ -1046,7 +1044,7 @@ class MathematicalProgram {
     return AddLinearEqualityConstraint(a, drake::Vector1d(beq), {variables_});
   }
   /**
-   * @brief Adds bounding box constraints referencing potentially a subset of
+   * Adds bounding box constraints referencing potentially a subset of
    * the decision variables.
    */
   void AddConstraint(std::shared_ptr<BoundingBoxConstraint> con,
@@ -1061,7 +1059,7 @@ class MathematicalProgram {
 
   /** AddBoundingBoxConstraint
    *
-   * @brief Adds bounding box constraints referencing potentially a
+   * Adds bounding box constraints referencing potentially a
    * subset of the decision variables (defined in the vars parameter).
    */
   template <typename DerivedLB, typename DerivedUB>
@@ -1075,7 +1073,7 @@ class MathematicalProgram {
 
   /** AddBoundingBoxConstraint
    *
-   * @brief Adds bounding box constraints to the program for all
+   * Adds bounding box constraints to the program for all
    * (currently existing) variables.
    */
   template <typename DerivedLB, typename DerivedUB>
@@ -1187,9 +1185,8 @@ class MathematicalProgram {
     return AddRotatedLorentzConeConstraint({variables_});
   }
 
-  /** AddLinearComplementarityConstraint
-   *
-   * @brief Adds a linear complementarity constraints referencing a subset of
+  /**
+   * Adds a linear complementarity constraints referencing a subset of
    * the decision variables.
    */
   template <typename DerivedM, typename Derivedq>
@@ -1221,9 +1218,8 @@ class MathematicalProgram {
     return constraint;
   }
 
-  /** AddLinearComplementarityConstraint
-   *
-   * @brief Adds a linear complementarity constraint to the program for all
+  /**
+   * Adds a linear complementarity constraint to the program for all
    * (currently existing) variables.
    */
   template <typename DerivedM, typename Derivedq>
@@ -1233,9 +1229,8 @@ class MathematicalProgram {
     return AddLinearComplementarityConstraint(M, q, {variables_});
   }
 
-  /** AddPolynomialConstraint
-   *
-   * @brief Adds a polynomial constraint to the program referencing a subset
+  /**
+   * Adds a polynomial constraint to the program referencing a subset
    * of the decision variables (defined in the vars parameter).
    */
   std::shared_ptr<Constraint> AddPolynomialConstraint(
@@ -1244,9 +1239,8 @@ class MathematicalProgram {
       const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
       const VariableListRef& vars);
 
-  /** AddPolynomialConstraint
-   *
-   * @brief Adds a polynomial constraint to the program referencing all of the
+  /**
+   * Adds a polynomial constraint to the program referencing all of the
    * decision variables.
    */
   std::shared_ptr<Constraint> AddPolynomialConstraint(
@@ -1481,9 +1475,8 @@ class MathematicalProgram {
     return linear_matrix_inequality_constraint_;
   }
 
-  /** GetAllCosts
-   *
-   * @brief Getter returning all costs (for now linear costs appended to
+  /**
+   * Getter returning all costs (for now linear costs appended to
    * generic costs, then quadratic costs appended to
    * generic costs).
    */

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -671,7 +671,8 @@ class MathematicalProgram {
       size_t rows, const std::vector<std::string>& names);
 
   /**
-   * Adds a symmetric matrix as decision variables to this MathematicalProgram.
+   * Adds a runtime sized symmetric matrix as decision variables to
+   * this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param name The name of the matrix. It is only used the for user to
@@ -689,7 +690,8 @@ class MathematicalProgram {
       size_t rows, const std::string& name = "Symmetric");
 
   /**
-   * Adds a symmetric matrix as decision variables to this MathematicalProgram.
+   * Adds a static sized symmetric matrix as decision variables to
+   * this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
    * @param name The name of the matrix. It is only used the for user to

--- a/drake/solvers/test/decision_variable_test.cc
+++ b/drake/solvers/test/decision_variable_test.cc
@@ -3,7 +3,6 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/common/text_logging.h"
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/mathematical_program.h"
 
@@ -21,7 +20,6 @@ GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
                 "should be a dynamic sized matrix");
   std::stringstream msg_buff1;
   msg_buff1 << X1 << std::endl;
-  drake::log()->debug(msg_buff1.str());
   EXPECT_EQ(msg_buff1.str(), "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n");
   EXPECT_EQ(prog.num_vars(), 6);
   EXPECT_FALSE(math::IsSymmetric(X1));
@@ -31,7 +29,6 @@ GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
                 "should be a dynamic sized matrix");
   std::stringstream msg_buff2;
   msg_buff2 << S1 << std::endl;
-  drake::log()->debug(msg_buff2.str());
   EXPECT_EQ(
       msg_buff2.str(),
       "S(0,0) S(1,0) S(2,0)\nS(1,0) S(1,1) S(2,1)\nS(2,0) S(2,1) S(2,2)\n");
@@ -43,7 +40,6 @@ GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
                 "should be a dynamic sized matrix");
   std::stringstream msg_buff3;
   msg_buff3 << x1 << std::endl;
-  drake::log()->debug(msg_buff3.str());
   EXPECT_EQ(msg_buff3.str(), "x0\nx1\nx2\nx3\nx4\nx5\n");
   EXPECT_EQ(prog.num_vars(), 18);
   EXPECT_FALSE(math::IsSymmetric(x1));
@@ -51,7 +47,6 @@ GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
   auto X2 = prog.AddContinuousVariables<2, 3>(X_name);
   std::stringstream msg_buff4;
   msg_buff4 << X2 << std::endl;
-  drake::log()->debug(msg_buff4.str());
   EXPECT_EQ(msg_buff4.str(), "X1 X3 X5\nX2 X4 X6\n");
   static_assert(decltype(X2)::RowsAtCompileTime == 2 &&
                     decltype(X2)::ColsAtCompileTime == 3,

--- a/drake/solvers/test/decision_variable_test.cc
+++ b/drake/solvers/test/decision_variable_test.cc
@@ -14,21 +14,24 @@ namespace solvers {
  */
 GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
   MathematicalProgram prog;
-  auto X1 = prog.AddContinuousVariables(2, 3, std::vector<std::string>(6, "X"));
+  auto X1 = prog.AddContinuousVariables(2, 3, "X");
+  std::cout << X1 << std::endl;
   EXPECT_EQ(prog.num_vars(), 6);
   EXPECT_FALSE(math::IsSymmetric(X1));
-  auto S1 =
-      prog.AddSymmetricContinuousVariables(3, std::vector<std::string>(6, "S"));
+  auto S1 = prog.AddSymmetricContinuousVariables(3, "S");
+  std::cout << S1 << std::endl;
   EXPECT_EQ(prog.num_vars(), 12);
   EXPECT_TRUE(math::IsSymmetric(S1));
   auto x1 = prog.AddContinuousVariables(6, "x");
+  std::cout << x1 << std::endl;
   EXPECT_EQ(prog.num_vars(), 18);
   EXPECT_FALSE(math::IsSymmetric(x1));
-  std::array<std::string, 6> X_name = {{"X", "X", "X", "X", "X", "X"}};
+  std::array<std::string, 6> X_name = {{"X1", "X2", "X3", "X4", "X5", "X6"}};
   auto X2 = prog.AddContinuousVariables<2, 3>(X_name);
+  std::cout << X2 << std::endl;
   static_assert(decltype(X2)::RowsAtCompileTime == 2 &&
-      decltype(X2)::ColsAtCompileTime == 3,
-      "should be a static matrix of type 2 x 3");
+                    decltype(X2)::ColsAtCompileTime == 3,
+                "should be a static matrix of type 2 x 3");
   EXPECT_EQ(prog.num_vars(), 24);
   EXPECT_FALSE(math::IsSymmetric(X2));
   Eigen::Matrix<double, 6, 1> x_value;
@@ -79,8 +82,7 @@ GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
 
   for (int i = 0; i < 2; ++i) {
     for (int j = 0; j < 3; ++j) {
-      EXPECT_TRUE(
-          X_assembled(i, j) ==  X1(i, j));
+      EXPECT_TRUE(X_assembled(i, j) == X1(i, j));
       EXPECT_TRUE(X_assembled(i, j + 3) == X2(i, j));
     }
   }

--- a/drake/solvers/test/decision_variable_test.cc
+++ b/drake/solvers/test/decision_variable_test.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/mathematical_program.h"
 
@@ -15,20 +16,28 @@ namespace solvers {
 GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
   MathematicalProgram prog;
   auto X1 = prog.AddContinuousVariables(2, 3, "X");
-  std::cout << X1 << std::endl;
+  std::stringstream msg_buff1;
+  msg_buff1 << X1 << std::endl;
+  drake::log()->debug(msg_buff1.str());
   EXPECT_EQ(prog.num_vars(), 6);
   EXPECT_FALSE(math::IsSymmetric(X1));
   auto S1 = prog.AddSymmetricContinuousVariables(3, "S");
-  std::cout << S1 << std::endl;
+  std::stringstream msg_buff2;
+  msg_buff2 << S1 << std::endl;
+  drake::log()->debug(msg_buff2.str());
   EXPECT_EQ(prog.num_vars(), 12);
   EXPECT_TRUE(math::IsSymmetric(S1));
   auto x1 = prog.AddContinuousVariables(6, "x");
-  std::cout << x1 << std::endl;
+  std::stringstream msg_buff3;
+  msg_buff1 << x1 << std::endl;
+  drake::log()->debug(msg_buff3.str());
   EXPECT_EQ(prog.num_vars(), 18);
   EXPECT_FALSE(math::IsSymmetric(x1));
   std::array<std::string, 6> X_name = {{"X1", "X2", "X3", "X4", "X5", "X6"}};
   auto X2 = prog.AddContinuousVariables<2, 3>(X_name);
-  std::cout << X2 << std::endl;
+  std::stringstream msg_buff4;
+  msg_buff4 << X2 << std::endl;
+  drake::log()->debug(msg_buff4.str());
   static_assert(decltype(X2)::RowsAtCompileTime == 2 &&
                     decltype(X2)::ColsAtCompileTime == 3,
                 "should be a static matrix of type 2 x 3");

--- a/drake/solvers/test/decision_variable_test.cc
+++ b/drake/solvers/test/decision_variable_test.cc
@@ -16,21 +16,35 @@ namespace solvers {
 GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
   MathematicalProgram prog;
   auto X1 = prog.AddContinuousVariables(2, 3, "X");
+  static_assert(decltype(X1)::RowsAtCompileTime == Eigen::Dynamic &&
+                    decltype(X1)::ColsAtCompileTime == Eigen::Dynamic,
+                "should be a dynamic sized matrix");
   std::stringstream msg_buff1;
   msg_buff1 << X1 << std::endl;
   drake::log()->debug(msg_buff1.str());
+  EXPECT_EQ(msg_buff1.str(), "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n");
   EXPECT_EQ(prog.num_vars(), 6);
   EXPECT_FALSE(math::IsSymmetric(X1));
   auto S1 = prog.AddSymmetricContinuousVariables(3, "S");
+  static_assert(decltype(S1)::RowsAtCompileTime == Eigen::Dynamic &&
+                    decltype(S1)::ColsAtCompileTime == Eigen::Dynamic,
+                "should be a dynamic sized matrix");
   std::stringstream msg_buff2;
   msg_buff2 << S1 << std::endl;
   drake::log()->debug(msg_buff2.str());
+  EXPECT_EQ(
+      msg_buff2.str(),
+      "S(0,0) S(1,0) S(2,0)\nS(1,0) S(1,1) S(2,1)\nS(2,0) S(2,1) S(2,2)\n");
   EXPECT_EQ(prog.num_vars(), 12);
   EXPECT_TRUE(math::IsSymmetric(S1));
   auto x1 = prog.AddContinuousVariables(6, "x");
+  static_assert(decltype(x1)::RowsAtCompileTime == Eigen::Dynamic &&
+                    decltype(x1)::ColsAtCompileTime == 1,
+                "should be a dynamic sized matrix");
   std::stringstream msg_buff3;
-  msg_buff1 << x1 << std::endl;
+  msg_buff3 << x1 << std::endl;
   drake::log()->debug(msg_buff3.str());
+  EXPECT_EQ(msg_buff3.str(), "x0\nx1\nx2\nx3\nx4\nx5\n");
   EXPECT_EQ(prog.num_vars(), 18);
   EXPECT_FALSE(math::IsSymmetric(x1));
   std::array<std::string, 6> X_name = {{"X1", "X2", "X3", "X4", "X5", "X6"}};
@@ -38,6 +52,7 @@ GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
   std::stringstream msg_buff4;
   msg_buff4 << X2 << std::endl;
   drake::log()->debug(msg_buff4.str());
+  EXPECT_EQ(msg_buff4.str(), "X1 X3 X5\nX2 X4 X6\n");
   static_assert(decltype(X2)::RowsAtCompileTime == 2 &&
                     decltype(X2)::ColsAtCompileTime == 3,
                 "should be a static matrix of type 2 x 3");


### PR DESCRIPTION
Now when we add decision variables to mathematical program, there are two options to specify the names of the newly added variables.

1. Specify each variable name explicitly, as
   ```
   AddContinuousVariable(rows, cols, std::vector<string> names);
   ```
   where `names` should be a vector of size `rows * cols`, containing the name of each new variable.
2. Specify the shared name of all newly added decision variables. For each individual decision variable, the program appends an index to its name.
   ```
   AddContinuousDecisionVariables(2, 3, "X")
   ```
   will add a matrix of decision variables, with names
   ```
   X(0, 0), X(0, 1), X(0, 2)
   X(1, 0), X(1, 1), X(1, 2)
   ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4362)
<!-- Reviewable:end -->
