### PR TITLE
[Bazel] Bullet prep

### DIFF
--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -45,8 +45,8 @@ cc_library(
     name = "rigid_body_tree",
     srcs = [
         "kinematics_cache.cc",
-        "parser_model_instance_id_table.cc",
         "parser_common.cc",
+        "parser_model_instance_id_table.cc",
         "parser_sdf.cc",
         "parser_urdf.cc",
         "rigid_body.cc",
@@ -56,14 +56,7 @@ cc_library(
         "rigid_body_tree.cc",
         "rigid_body_tree_contact.cc",
         "xml_util.cc",
-        "collision/drake_collision.cc",
-        "collision/element.cc",
-        "collision/model.cc",
-        "collision/unusable_model.cc",
-    ] + glob([
-        "joints/*.cc",
-        "shapes/*.cc",
-    ]),
+    ],
     hdrs = [
         "force_torque_measurement.h",
         "kinematic_path.h",
@@ -81,21 +74,15 @@ cc_library(
         "rigid_body_loop.h",
         "rigid_body_tree.h",
         "xml_util.h",
-        "collision/drake_collision.h",
-        "collision/element.h",
-        "collision/model.h",
-        "collision/point_pair.h",
-        "collision/unusable_model.h",
-    ] + glob([
-        "joints/*.h",
-        "shapes/*.h",
-    ]),
+    ],
     linkstatic = 1,
     deps = [
         "//drake/common:drake_path",
-        "//drake/common:sorted_vectors_have_intersection",
         "//drake/math:geometric_transform",
         "//drake/math:gradient",
+        "//drake/multibody/collision",
+        "//drake/multibody/joints",
+        "//drake/multibody/shapes",
         "//drake/thirdParty:spruce",
         "//drake/thirdParty:tinydir",
         "//drake/thirdParty:tinyxml2",
@@ -166,17 +153,6 @@ cc_binary(
 cc_binary(
     name = "urdf_manipulator_dynamics_test",
     srcs = ["test/urdf_manipulator_dynamics_test.cc"],
-    linkstatic = 1,
-    deps = [
-        ":rigid_body_tree",
-        "@gtest//:main",
-    ],
-)
-
-cc_test(
-    name = "joint_test",
-    size = "small",
-    srcs = ["joints/test/joint_test.cc"],
     linkstatic = 1,
     deps = [
         ":rigid_body_tree",
@@ -264,9 +240,5 @@ filegroup(
         "test/**/*.sdf",
         "test/**/*.urdf",
         "test/**/*.xml",
-        "collision/test/**/*.obj",
-        "collision/test/**/*.sdf",
-        "collision/test/**/*.urdf",
-        "collision/test/**/*.xml",
     ]),
 )

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -1,7 +1,5 @@
 # -*- python -*-
-
-# This file contains rules for the Bazel build system.
-# See http://bazel.io/ .
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -1,0 +1,47 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "model",
+    srcs = [
+        "element.cc",
+        "model.cc",
+    ],
+    hdrs = [
+        "element.h",
+        "model.h",
+        "point_pair.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//drake/common",
+        "//drake/common:sorted_vectors_have_intersection",
+        "//drake/multibody/shapes",
+    ],
+)
+
+# TODO(jwnimmer-tri) Need to add bullet support.
+# Right now this library is only "unusuable collision".
+cc_library(
+    name = "collision",
+    srcs = [
+        "drake_collision.cc",
+        "unusable_model.cc",
+        "unusable_model.h",
+    ],
+    hdrs = ["drake_collision.h"],
+    linkstatic = 1,
+    deps = [":model"],
+)
+
+filegroup(
+    name = "test_models",
+    srcs = glob([
+        "test/**/*.obj",
+        "test/**/*.sdf",
+        "test/**/*.urdf",
+        "test/**/*.xml",
+    ]),
+)

--- a/drake/multibody/collision/drake_collision.cc
+++ b/drake/multibody/collision/drake_collision.cc
@@ -2,8 +2,9 @@
 
 #ifdef BULLET_COLLISION
 #include "drake/multibody/collision/bullet_model.h"
-#endif
+#else
 #include "drake/multibody/collision/unusable_model.h"
+#endif
 
 using std::unique_ptr;
 
@@ -16,8 +17,9 @@ const bitmask DEFAULT_GROUP(1);
 unique_ptr<Model> newModel() {
 #ifdef BULLET_COLLISION
   return unique_ptr<Model>(new BulletModel());
-#endif
+#else
   return unique_ptr<Model>(new UnusableModel());
+#endif
 }
 
 }  // namespace DrakeCollision

--- a/drake/multibody/joints/BUILD
+++ b/drake/multibody/joints/BUILD
@@ -1,0 +1,48 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "joints",
+    srcs = [
+        "drake_joint.cc",
+        "fixed_joint.cc",
+        "helical_joint.cc",
+        "prismatic_joint.cc",
+        "quaternion_floating_joint.cc",
+        "revolute_joint.cc",
+        "roll_pitch_yaw_floating_joint.cc",
+    ],
+    hdrs = [
+        "drake_joint.h",
+        "drake_joint_impl.h",
+        "drake_joints.h",
+        "fixed_axis_one_dof_joint.h",
+        "fixed_joint.h",
+        "floating_base_types.h",
+        "helical_joint.h",
+        "prismatic_joint.h",
+        "quaternion_floating_joint.h",
+        "revolute_joint.h",
+        "roll_pitch_yaw_floating_joint.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//drake/common",
+        "//drake/math:geometric_transform",
+        "//drake/math:gradient",
+        "//drake/util",
+    ],
+)
+
+cc_test(
+    name = "joint_test",
+    size = "small",
+    srcs = ["test/joint_test.cc"],
+    linkstatic = 1,
+    deps = [
+        ":joints",
+        "@gtest//:main",
+    ],
+)

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -1,7 +1,5 @@
 # -*- python -*-
-
-# This file contains rules for the Bazel build system.
-# See http://bazel.io/ .
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -101,7 +101,7 @@ cc_test(
     name = "drake_visualizer_test",
     size = "small",
     srcs = ["test/drake_visualizer_test.cc"],
-    data = ["//drake/multibody:test_models"],
+    data = ["//drake/multibody/collision:test_models"],
     linkstatic = 1,
     deps = [
         ":drake_visualizer",

--- a/drake/multibody/shapes/BUILD
+++ b/drake/multibody/shapes/BUILD
@@ -1,0 +1,24 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "shapes",
+    srcs = [
+        "element.cc",
+        "geometry.cc",
+        "visual_element.cc",
+    ],
+    hdrs = [
+        "drake_shapes.h",
+        "element.h",
+        "geometry.h",
+        "visual_element.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//drake/common",
+        "//drake/thirdParty:spruce",
+    ],
+)


### PR DESCRIPTION
Break out collision & joints & shapes into separate libraries, and other small fixes.  This makes the add-bullet work easer to develop & perceive (and is generally better / cleaner anyway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4367)
<!-- Reviewable:end -->
