### PR TITLE
Increase test time for tests that fail overnight.

### DIFF
--- a/drake/matlab/systems/plants/test/CMakeLists.txt
+++ b/drake/matlab/systems/plants/test/CMakeLists.txt
@@ -21,7 +21,7 @@ drake_add_matlab_test(NAME systems/plants/test/collisionDetectCHullTest REQUIRES
 drake_add_matlab_test(NAME systems/plants/test/collisionDetectCapsuleTest REQUIRES bullet lcm libbot COMMAND collisionDetectCapsuleTest)
 drake_add_matlab_test(NAME systems/plants/test/collisionDetectGradTest REQUIRES lcm libbot OPTIONAL bullet COMMAND collisionDetectGradTest)
 drake_add_matlab_test(NAME systems/plants/test/collisionDetectSphereTest REQUIRES bullet lcm libbot COMMAND collisionDetectSphereTest)
-drake_add_matlab_test(NAME systems/plants/test/compareParsers REQUIRES avl spotless xfoil OPTIONAL bullet COMMAND compareParsers)
+drake_add_matlab_test(NAME systems/plants/test/compareParsers REQUIRES avl spotless xfoil OPTIONAL bullet COMMAND compareParsers SIZE large)
 drake_add_matlab_test(NAME systems/plants/test/contactNormalsTest OPTIONAL bullet COMMAND contactNormalsTest)
 drake_add_matlab_test(NAME systems/plants/test/contactSensorTest REQUIRES snopt OPTIONAL gurobi COMMAND contactSensorTest)
 drake_add_matlab_test(NAME systems/plants/test/coordinateSystemTest OPTIONAL bullet gurobi COMMAND coordinateSystemTest SIZE large)

--- a/drake/multibody/rigid_body_system1/test/CMakeLists.txt
+++ b/drake/multibody/rigid_body_system1/test/CMakeLists.txt
@@ -24,7 +24,7 @@ if (lcm_FOUND)
     drake_add_test(NAME comparePriusURDFtoSDF COMMAND compareRigidBodySystems prius.sdf prius.urdf WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/automotive/models/prius")
   endif ()
 
-  drake_add_cc_test(load_model_test)
+  drake_add_cc_test(NAME load_model_test SIZE medium)
   target_link_libraries(load_model_test drakeRBSystem)
 endif ()
 

--- a/drake/multibody/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/multibody/test/rigid_body_tree/CMakeLists.txt
@@ -6,7 +6,7 @@ if(Bullet_FOUND)
   target_link_libraries(rigid_body_collision_clique_test drakeRBM)
 endif()
 
-drake_add_cc_test(rigid_body_tree_test)
+drake_add_cc_test(NAME rigid_body_tree_test SIZE medium)
 target_link_libraries(rigid_body_tree_test drakeRBM)
 
 drake_add_cc_test(rigid_body_tree_inverse_dynamics_test)


### PR DESCRIPTION
Increase the time for a few tests that are timing out in overnight builds (noticed it on a Mac, which is our slowest type of machine).  Matlab tests default to medium size (length of test time), so increase that to large.  C++ test default to small, so increase to medium.

You can see the trends of failures here:
https://drake-cdash.csail.mit.edu/buildSummary.php?buildid=235450 (click on “Show Build History”).
Or view the build history of the machine elcapitan.
This won't fix everything that fails overnight, but it will make Mac tests fail less often.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4375)
<!-- Reviewable:end -->
