### PR TITLE
Removes Parser Logic From RigidBodyTree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/RobotLocomotion/spotless-pod.git
 [submodule "externals/director"]
 	path = externals/director
-	url = https://github.com/liangfok/director.git
+	url = https://github.com/RobotLocomotion/director.git
 [submodule "externals/signalscope"]
 	path = externals/signalscope
 	url = https://github.com/mitdrc/signal-scope.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/RobotLocomotion/spotless-pod.git
 [submodule "externals/director"]
 	path = externals/director
-	url = https://github.com/RobotLocomotion/director.git
+	url = https://github.com/liangfok/director.git
 [submodule "externals/signalscope"]
 	path = externals/signalscope
 	url = https://github.com/mitdrc/signal-scope.git

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -18,11 +18,6 @@
 #include "drake/multibody/joints/drake_joint.h"
 #include "drake/multibody/joints/fixed_joint.h"
 #include "drake/multibody/joints/floating_base_types.h"
-#include "drake/multibody/parser_sdf.h"
-#include "drake/multibody/parser_urdf.h"
-// TODO(liang.fok) Remove the following include once this file no longer
-// references `PackageMap`.
-#include "drake/multibody/xml_util.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/drakeUtil.h"
 
@@ -2612,64 +2607,6 @@ int RigidBodyTree<T>::number_of_velocities() const {
 template <typename T>
 int RigidBodyTree<T>::get_num_actuators() const {
   return static_cast<int>(actuators.size());
-}
-
-// TODO(liang.fok) Remove this deprecated method prior to release 1.0.
-template <typename T>
-void RigidBodyTree<T>::addRobotFromURDFString(
-    const std::string& xml_string, const std::string& root_dir,
-    const FloatingBaseType floating_base_type,
-    std::shared_ptr<RigidBodyFrame> weld_to_frame) {
-  PackageMap ros_package_map;
-  drake::parsers::urdf::AddModelInstanceFromUrdfStringSearchingInRosPackages(
-      xml_string, ros_package_map, root_dir, floating_base_type, weld_to_frame,
-      this);
-}
-
-// TODO(liang.fok) Remove this deprecated method prior to release 1.0.
-template <typename T>
-void RigidBodyTree<T>::addRobotFromURDFString(
-    const std::string& xml_string,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    std::map<std::string, std::string>& ros_package_map,
-    const std::string& root_dir, const FloatingBaseType floating_base_type,
-    std::shared_ptr<RigidBodyFrame> weld_to_frame) {
-  drake::parsers::urdf::AddModelInstanceFromUrdfStringSearchingInRosPackages(
-      xml_string, ros_package_map, root_dir, floating_base_type, weld_to_frame,
-      this);
-}
-
-// TODO(liang.fok) Remove this deprecated method prior to release 1.0.
-template <typename T>
-void RigidBodyTree<T>::addRobotFromURDF(
-    const std::string& filename,
-    const FloatingBaseType floating_base_type,
-    std::shared_ptr<RigidBodyFrame> weld_to_frame) {
-  PackageMap ros_package_map;
-  drake::parsers::urdf::AddModelInstanceFromUrdfFileSearchingInRosPackages(
-      filename, ros_package_map, floating_base_type, weld_to_frame, this);
-}
-
-// TODO(liang.fok) Remove this deprecated method prior to release 1.0.
-template <typename T>
-void RigidBodyTree<T>::addRobotFromURDF(
-    const std::string& filename,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    std::map<std::string, std::string>& ros_package_map,
-    const FloatingBaseType floating_base_type,
-    std::shared_ptr<RigidBodyFrame> weld_to_frame) {
-  drake::parsers::urdf::AddModelInstanceFromUrdfFileSearchingInRosPackages(
-      filename, ros_package_map, floating_base_type, weld_to_frame, this);
-}
-
-// TODO(liang.fok) Remove this deprecated method prior to release 1.0.
-template <typename T>
-void RigidBodyTree<T>::addRobotFromSDF(
-    const std::string& filename,
-    const FloatingBaseType floating_base_type,
-    std::shared_ptr<RigidBodyFrame> weld_to_frame) {
-  drake::parsers::sdf::AddModelInstancesFromSdfFile(
-      filename, floating_base_type, weld_to_frame, this);
 }
 
 template <typename T>

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -91,56 +91,6 @@ class RigidBodyTree {
 
   virtual ~RigidBodyTree(void);
 
-#ifndef SWIG
-  DRAKE_DEPRECATED("Please use AddModelInstanceFromURDFString.")
-#endif
-  void addRobotFromURDFString(
-      const std::string& xml_string, const std::string& root_dir = ".",
-      const drake::multibody::joints::FloatingBaseType
-          floating_base_type = drake::multibody::joints::kRollPitchYaw,
-      std::shared_ptr<RigidBodyFrame> weld_to_frame = nullptr);
-
-#ifndef SWIG
-  DRAKE_DEPRECATED("Please use AddModelInstanceFromURDFString.")
-#endif
-  void addRobotFromURDFString(
-      const std::string& xml_string,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      std::map<std::string, std::string>& ros_package_map,
-      const std::string& root_dir = ".",
-      const drake::multibody::joints::FloatingBaseType
-          floating_base_type = drake::multibody::joints::kRollPitchYaw,
-      std::shared_ptr<RigidBodyFrame> weld_to_frame = nullptr);
-
-#ifndef SWIG
-  DRAKE_DEPRECATED("Please use AddModelInstanceFromURDF.")
-#endif
-  void addRobotFromURDF(
-      const std::string& urdf_filename,
-      const drake::multibody::joints::FloatingBaseType
-          floating_base_type = drake::multibody::joints::kRollPitchYaw,
-      std::shared_ptr<RigidBodyFrame> weld_to_frame = nullptr);
-
-#ifndef SWIG
-  DRAKE_DEPRECATED("Please use AddModelInstanceFromURDF.")
-#endif
-  void addRobotFromURDF(
-      const std::string& urdf_filename,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      std::map<std::string, std::string>& ros_package_map,
-      const drake::multibody::joints::FloatingBaseType
-          floating_base_type = drake::multibody::joints::kRollPitchYaw,
-      std::shared_ptr<RigidBodyFrame> weld_to_frame = nullptr);
-
-#ifndef SWIG
-  DRAKE_DEPRECATED("Please use AddModelInstancesFromSdfFile.")
-#endif
-  void addRobotFromSDF(const std::string& sdf_filename,
-                       const drake::multibody::joints::FloatingBaseType
-                           floating_base_type =
-                               drake::multibody::joints::kQuaternion,
-                       std::shared_ptr<RigidBodyFrame> weld_to_frame = nullptr);
-
   /**
    * Adds a new model instance to this `RigidBodyTree`. The model instance is
    * identified by a unique model instance ID, which is the return value of


### PR DESCRIPTION
This extracts from #4363 the changes to `RigidBodyTree`. It removes the parsing code from RigidBodyTree, which paves the way for moving the parsers into their own libraries, which will be done in a subsequent PR. This subsequent PR wil also move the parsers into their own directories per #4091.

I'm labeling this high priority because being able to decouple the parsers from the `RigidBodyTree` will enable @amcastro-tri to make faster progress renovating the `RigidBodyTree`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4386)
<!-- Reviewable:end -->
