### PR TITLE
Fixes signed / unsigned compare error.

### DIFF
--- a/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc
+++ b/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc
@@ -152,7 +152,7 @@ void VerifyDrawMessage(const std::vector<uint8_t>& message_bytes) {
   drake::lcmt_viewer_draw expected_message;
   ASSERT_EQ(
       expected_message.decode(message_bytes.data(), 0, message_bytes.size()),
-      message_bytes.size());
+      static_cast<int>(message_bytes.size()));
   ASSERT_EQ(expected_message.num_links, 3);
   EXPECT_EQ(expected_message.timestamp, 0);
   EXPECT_EQ(expected_message.link_name.at(0), "world");


### PR DESCRIPTION
This fixes the following error, which was detected by @jamiesnape using Xcode:

```
In file included from /Users/snape/Repositories/drake/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc:9:
/Users/snape/Repositories/drake/build/install/include/gtest/gtest.h:1392:11: error: comparison of integers of different signs: 'const int' and 'const unsigned long' [-Werror,-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
/Users/snape/Repositories/drake/build/install/include/gtest/gtest.h:1421:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<int, unsigned long>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
/Users/snape/Repositories/drake/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc:153:3: note: in instantiation of function template specialization 'testing::internal::EqHelper<false>::Compare<int, unsigned long>' requested here
  ASSERT_EQ(
  ^
In file included from /Users/snape/Repositories/drake/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc:9:
/Users/snape/Repositories/drake/build/install/include/gtest/gtest.h:1956:32: note: expanded from macro 'ASSERT_EQ'
# define ASSERT_EQ(val1, val2) GTEST_ASSERT_EQ(val1, val2)
                               ^
/Users/snape/Repositories/drake/build/install/include/gtest/gtest.h:1939:63: note: expanded from macro 'GTEST_ASSERT_EQ'
                      EqHelper<GTEST_IS_NULL_LITERAL_(val1)>::Compare, \
                                                              ^
1 error generated.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4392)
<!-- Reviewable:end -->
