### PR TITLE
Disable delete-non-virtual-dtor warning for Xcode builds

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -88,6 +88,11 @@ else()
 endif()
 set(CXX_FLAGS_NO_ERROR_SHADOW -Wno-error=shadow -Wno-shadow)
 set(CXX_FLAGS_NO_SIGN_COMPARE -Wno-sign-compare)
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  # TODO(jamiesnape): Remove when the Xcode CMake generator supports
+  # include_directories(SYSTEM) or when the warning is fixed in Eigen.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-delete-non-virtual-dtor")
+endif()
 
 # set up matlab build
 include(../cmake/mex.cmake)


### PR DESCRIPTION
The Xcode CMake generator does not currently support include_directories(SYSTEM), so builds were failing on a delete-non-virtual-dtor warning-as-error in Eigen.

FYI @RussTedrake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4393)
<!-- Reviewable:end -->
