### PR TITLE
Make Constraint not movable nor copyable.

### DIFF
--- a/drake/solvers/constraint.cc
+++ b/drake/solvers/constraint.cc
@@ -4,6 +4,10 @@
 
 namespace drake {
 namespace solvers {
+Constraint::Constraint(Constraint&& rhs) : Constraint(rhs.num_constraints(), std::move(rhs.lower_bound()), std::move(rhs.upper_bound())) {
+  description_ = std::move(rhs.get_description());
+}
+
 void PositiveSemidefiniteConstraint::Eval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {
   DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==

--- a/drake/solvers/constraint.cc
+++ b/drake/solvers/constraint.cc
@@ -4,108 +4,165 @@
 
 namespace drake {
 namespace solvers {
-Constraint::Constraint(Constraint&& rhs) : Constraint(rhs.num_constraints(), std::move(rhs.lower_bound()), std::move(rhs.upper_bound()), std::move(rhs.get_description())) {}
+Constraint::Constraint(Constraint&& rhs)
+    : Constraint(rhs.num_constraints(), std::move(rhs.lower_bound()),
+                 std::move(rhs.upper_bound()),
+                 std::move(rhs.get_description())) {}
+
+Constraint& Constraint::operator=(Constraint&& rhs) {
+  lower_bound_ = std::move(rhs.lower_bound());
+  upper_bound_ = std::move(rhs.upper_bound());
+  description_ = std::move(rhs.get_description());
+  return *this;
+}
 
 void QuadraticConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-          Eigen::VectorXd& y) const {
-y.resize(num_constraints());
-y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
+                               Eigen::VectorXd& y) const {
+  y.resize(num_constraints());
+  y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
 }
 
 void QuadraticConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
-          TaylorVecXd& y) const {
-y.resize(num_constraints());
-y = .5 * x.transpose() * Q_.cast<TaylorVarXd>() * x +
-    b_.cast<TaylorVarXd>().transpose() * x;
+                               TaylorVecXd& y) const {
+  y.resize(num_constraints());
+  y = .5 * x.transpose() * Q_.cast<TaylorVarXd>() * x +
+      b_.cast<TaylorVarXd>().transpose() * x;
 };
 
+QuadraticConstraint& QuadraticConstraint::operator=(QuadraticConstraint&& rhs) {
+  Constraint::operator=(std::move(rhs));
+  Q_ = std::move(rhs.Q());
+  b_ = std::move(rhs.b());
+  return *this;
+}
+
 void LorentzConeConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-          Eigen::VectorXd& y) const {
-y.resize(num_constraints());
-y(0) = x(0);
-y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
+                                 Eigen::VectorXd& y) const {
+  y.resize(num_constraints());
+  y(0) = x(0);
+  y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
 }
 
 void LorentzConeConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
-          TaylorVecXd& y) const  {
-y.resize(num_constraints());
-y(0) = x(0);
-y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
+                                 TaylorVecXd& y) const {
+  y.resize(num_constraints());
+  y(0) = x(0);
+  y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
 }
 
-void RotatedLorentzConeConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-          Eigen::VectorXd& y) const {
-y.resize(num_constraints());
-y(0) = x(0);
-y(1) = x(1);
-y(2) = x(0) * x(1) - x.tail(x.size() - 2).squaredNorm();
+LorentzConeConstraint& LorentzConeConstraint::operator=(
+    LorentzConeConstraint&& rhs) {
+  Constraint::operator=(std::move(rhs));
+  return *this;
+}
+
+RotatedLorentzConeConstraint& RotatedLorentzConeConstraint::operator=(
+    RotatedLorentzConeConstraint&& rhs) {
+  Constraint::operator=(std::move(rhs));
+  return *this;
+}
+
+void RotatedLorentzConeConstraint::Eval(
+    const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {
+  y.resize(num_constraints());
+  y(0) = x(0);
+  y(1) = x(1);
+  y(2) = x(0) * x(1) - x.tail(x.size() - 2).squaredNorm();
 }
 
 void RotatedLorentzConeConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
-          TaylorVecXd& y) const {
-y.resize(num_constraints());
-y(0) = x(0);
-y(1) = x(1);
-y(2) = x(0) * x(1) - x.tail(x.size() - 2).squaredNorm();
+                                        TaylorVecXd& y) const {
+  y.resize(num_constraints());
+  y(0) = x(0);
+  y(1) = x(1);
+  y(2) = x(0) * x(1) - x.tail(x.size() - 2).squaredNorm();
 }
 
 void PolynomialConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-          Eigen::VectorXd& y) const {
-double_evaluation_point_.clear();
-for (size_t i = 0; i < poly_vars_.size(); i++) {
-double_evaluation_point_[poly_vars_[i]] = x[i];
-}
-y.resize(num_constraints());
-for (size_t i = 0; i < num_constraints(); i++) {
-y[i] = polynomials_[i].EvaluateMultivariate(double_evaluation_point_);
-}
+                                Eigen::VectorXd& y) const {
+  double_evaluation_point_.clear();
+  for (size_t i = 0; i < poly_vars_.size(); i++) {
+    double_evaluation_point_[poly_vars_[i]] = x[i];
+  }
+  y.resize(num_constraints());
+  for (size_t i = 0; i < num_constraints(); i++) {
+    y[i] = polynomials_[i].EvaluateMultivariate(double_evaluation_point_);
+  }
 }
 
 void PolynomialConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
-          TaylorVecXd& y) const {
-taylor_evaluation_point_.clear();
-for (size_t i = 0; i < poly_vars_.size(); i++) {
-taylor_evaluation_point_[poly_vars_[i]] = x[i];
+                                TaylorVecXd& y) const {
+  taylor_evaluation_point_.clear();
+  for (size_t i = 0; i < poly_vars_.size(); i++) {
+    taylor_evaluation_point_[poly_vars_[i]] = x[i];
+  }
+  y.resize(num_constraints());
+  for (size_t i = 0; i < num_constraints(); i++) {
+    y[i] = polynomials_[i].EvaluateMultivariate(taylor_evaluation_point_);
+  }
 }
-y.resize(num_constraints());
-for (size_t i = 0; i < num_constraints(); i++) {
-y[i] = polynomials_[i].EvaluateMultivariate(taylor_evaluation_point_);
-}
+
+LinearConstraint& LinearConstraint::operator=(LinearConstraint&& rhs) {
+  Constraint::operator=(std::move(rhs));
+  A_ = std::move(rhs.A_);
+  return *this;
 }
 
 void LinearConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-          Eigen::VectorXd& y) const {
-y.resize(num_constraints());
-y = A_ * x;
+                            Eigen::VectorXd& y) const {
+  y.resize(num_constraints());
+  y = A_ * x;
 }
 void LinearConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
-          TaylorVecXd& y) const {
-y.resize(num_constraints());
-y = A_.cast<TaylorVarXd>() * x;
+                            TaylorVecXd& y) const {
+  y.resize(num_constraints());
+  y = A_.cast<TaylorVarXd>() * x;
 };
+
+LinearEqualityConstraint& LinearEqualityConstraint::operator=(LinearEqualityConstraint&& rhs) {
+  LinearConstraint::operator=(std::move(rhs));
+  return *this;
+}
+
+BoundingBoxConstraint& BoundingBoxConstraint::operator=(BoundingBoxConstraint&& rhs) {
+  LinearConstraint::operator=(std::move(rhs));
+  return *this;
+}
 
 void BoundingBoxConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-          Eigen::VectorXd& y) const {
-y.resize(num_constraints());
-y = x;
+                                 Eigen::VectorXd& y) const {
+  y.resize(num_constraints());
+  y = x;
 }
 void BoundingBoxConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
-          TaylorVecXd& y) const {
-y.resize(num_constraints());
-y = x;
+                                 TaylorVecXd& y) const {
+  y.resize(num_constraints());
+  y = x;
 }
 
-void LinearComplementarityConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
-          Eigen::VectorXd& y) const {
-y.resize(num_constraints());
-y = (M_ * x) + q_;
+LinearComplementarityConstraint& LinearComplementarityConstraint::operator=(LinearComplementarityConstraint&& rhs) {
+  Constraint::operator=(std::move(rhs));
+  M_ = std::move(rhs.M_);
+  q_ = std::move(rhs.q_);
+  return *this;
 }
 
-void LinearComplementarityConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
-          TaylorVecXd& y) const {
-y.resize(num_constraints());
-y = (M_.cast<TaylorVarXd>() * x) + q_.cast<TaylorVarXd>();
+void LinearComplementarityConstraint::Eval(
+    const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {
+  y.resize(num_constraints());
+  y = (M_ * x) + q_;
+}
+
+void LinearComplementarityConstraint::Eval(
+    const Eigen::Ref<const TaylorVecXd>& x, TaylorVecXd& y) const {
+  y.resize(num_constraints());
+  y = (M_.cast<TaylorVarXd>() * x) + q_.cast<TaylorVarXd>();
 };
+
+PositiveSemidefiniteConstraint& PositiveSemidefiniteConstraint::operator=(PositiveSemidefiniteConstraint&& rhs) {
+  Constraint::operator=(std::move(rhs));
+  return *this;
+}
 
 void PositiveSemidefiniteConstraint::Eval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {

--- a/drake/solvers/constraint.cc
+++ b/drake/solvers/constraint.cc
@@ -4,9 +4,108 @@
 
 namespace drake {
 namespace solvers {
-Constraint::Constraint(Constraint&& rhs) : Constraint(rhs.num_constraints(), std::move(rhs.lower_bound()), std::move(rhs.upper_bound())) {
-  description_ = std::move(rhs.get_description());
+Constraint::Constraint(Constraint&& rhs) : Constraint(rhs.num_constraints(), std::move(rhs.lower_bound()), std::move(rhs.upper_bound()), std::move(rhs.get_description())) {}
+
+void QuadraticConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+          Eigen::VectorXd& y) const {
+y.resize(num_constraints());
+y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
 }
+
+void QuadraticConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
+          TaylorVecXd& y) const {
+y.resize(num_constraints());
+y = .5 * x.transpose() * Q_.cast<TaylorVarXd>() * x +
+    b_.cast<TaylorVarXd>().transpose() * x;
+};
+
+void LorentzConeConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+          Eigen::VectorXd& y) const {
+y.resize(num_constraints());
+y(0) = x(0);
+y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
+}
+
+void LorentzConeConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
+          TaylorVecXd& y) const  {
+y.resize(num_constraints());
+y(0) = x(0);
+y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
+}
+
+void RotatedLorentzConeConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+          Eigen::VectorXd& y) const {
+y.resize(num_constraints());
+y(0) = x(0);
+y(1) = x(1);
+y(2) = x(0) * x(1) - x.tail(x.size() - 2).squaredNorm();
+}
+
+void RotatedLorentzConeConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
+          TaylorVecXd& y) const {
+y.resize(num_constraints());
+y(0) = x(0);
+y(1) = x(1);
+y(2) = x(0) * x(1) - x.tail(x.size() - 2).squaredNorm();
+}
+
+void PolynomialConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+          Eigen::VectorXd& y) const {
+double_evaluation_point_.clear();
+for (size_t i = 0; i < poly_vars_.size(); i++) {
+double_evaluation_point_[poly_vars_[i]] = x[i];
+}
+y.resize(num_constraints());
+for (size_t i = 0; i < num_constraints(); i++) {
+y[i] = polynomials_[i].EvaluateMultivariate(double_evaluation_point_);
+}
+}
+
+void PolynomialConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
+          TaylorVecXd& y) const {
+taylor_evaluation_point_.clear();
+for (size_t i = 0; i < poly_vars_.size(); i++) {
+taylor_evaluation_point_[poly_vars_[i]] = x[i];
+}
+y.resize(num_constraints());
+for (size_t i = 0; i < num_constraints(); i++) {
+y[i] = polynomials_[i].EvaluateMultivariate(taylor_evaluation_point_);
+}
+}
+
+void LinearConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+          Eigen::VectorXd& y) const {
+y.resize(num_constraints());
+y = A_ * x;
+}
+void LinearConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
+          TaylorVecXd& y) const {
+y.resize(num_constraints());
+y = A_.cast<TaylorVarXd>() * x;
+};
+
+void BoundingBoxConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+          Eigen::VectorXd& y) const {
+y.resize(num_constraints());
+y = x;
+}
+void BoundingBoxConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
+          TaylorVecXd& y) const {
+y.resize(num_constraints());
+y = x;
+}
+
+void LinearComplementarityConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
+          Eigen::VectorXd& y) const {
+y.resize(num_constraints());
+y = (M_ * x) + q_;
+}
+
+void LinearComplementarityConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
+          TaylorVecXd& y) const {
+y.resize(num_constraints());
+y = (M_.cast<TaylorVarXd>() * x) + q_.cast<TaylorVarXd>();
+};
 
 void PositiveSemidefiniteConstraint::Eval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {

--- a/drake/solvers/constraint.cc
+++ b/drake/solvers/constraint.cc
@@ -27,7 +27,7 @@ void QuadraticConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
   y.resize(num_constraints());
   y = .5 * x.transpose() * Q_.cast<TaylorVarXd>() * x +
       b_.cast<TaylorVarXd>().transpose() * x;
-};
+}
 
 QuadraticConstraint& QuadraticConstraint::operator=(QuadraticConstraint&& rhs) {
   Constraint::operator=(std::move(rhs));
@@ -117,14 +117,16 @@ void LinearConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
                             TaylorVecXd& y) const {
   y.resize(num_constraints());
   y = A_.cast<TaylorVarXd>() * x;
-};
+}
 
-LinearEqualityConstraint& LinearEqualityConstraint::operator=(LinearEqualityConstraint&& rhs) {
+LinearEqualityConstraint& LinearEqualityConstraint::operator=(
+    LinearEqualityConstraint&& rhs) {
   LinearConstraint::operator=(std::move(rhs));
   return *this;
 }
 
-BoundingBoxConstraint& BoundingBoxConstraint::operator=(BoundingBoxConstraint&& rhs) {
+BoundingBoxConstraint& BoundingBoxConstraint::operator=(
+    BoundingBoxConstraint&& rhs) {
   LinearConstraint::operator=(std::move(rhs));
   return *this;
 }
@@ -140,7 +142,8 @@ void BoundingBoxConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
   y = x;
 }
 
-LinearComplementarityConstraint& LinearComplementarityConstraint::operator=(LinearComplementarityConstraint&& rhs) {
+LinearComplementarityConstraint& LinearComplementarityConstraint::operator=(
+    LinearComplementarityConstraint&& rhs) {
   Constraint::operator=(std::move(rhs));
   M_ = std::move(rhs.M_);
   q_ = std::move(rhs.q_);
@@ -157,9 +160,10 @@ void LinearComplementarityConstraint::Eval(
     const Eigen::Ref<const TaylorVecXd>& x, TaylorVecXd& y) const {
   y.resize(num_constraints());
   y = (M_.cast<TaylorVarXd>() * x) + q_.cast<TaylorVarXd>();
-};
+}
 
-PositiveSemidefiniteConstraint& PositiveSemidefiniteConstraint::operator=(PositiveSemidefiniteConstraint&& rhs) {
+PositiveSemidefiniteConstraint& PositiveSemidefiniteConstraint::operator=(
+    PositiveSemidefiniteConstraint&& rhs) {
   Constraint::operator=(std::move(rhs));
   return *this;
 }

--- a/drake/solvers/constraint.cc
+++ b/drake/solvers/constraint.cc
@@ -4,18 +4,6 @@
 
 namespace drake {
 namespace solvers {
-Constraint::Constraint(Constraint&& rhs)
-    : Constraint(rhs.num_constraints(), std::move(rhs.lower_bound()),
-                 std::move(rhs.upper_bound()),
-                 std::move(rhs.get_description())) {}
-
-Constraint& Constraint::operator=(Constraint&& rhs) {
-  lower_bound_ = std::move(rhs.lower_bound());
-  upper_bound_ = std::move(rhs.upper_bound());
-  description_ = std::move(rhs.get_description());
-  return *this;
-}
-
 void QuadraticConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                Eigen::VectorXd& y) const {
   y.resize(num_constraints());
@@ -27,13 +15,6 @@ void QuadraticConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
   y.resize(num_constraints());
   y = .5 * x.transpose() * Q_.cast<TaylorVarXd>() * x +
       b_.cast<TaylorVarXd>().transpose() * x;
-}
-
-QuadraticConstraint& QuadraticConstraint::operator=(QuadraticConstraint&& rhs) {
-  Constraint::operator=(std::move(rhs));
-  Q_ = std::move(rhs.Q());
-  b_ = std::move(rhs.b());
-  return *this;
 }
 
 void LorentzConeConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -48,18 +29,6 @@ void LorentzConeConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
   y.resize(num_constraints());
   y(0) = x(0);
   y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
-}
-
-LorentzConeConstraint& LorentzConeConstraint::operator=(
-    LorentzConeConstraint&& rhs) {
-  Constraint::operator=(std::move(rhs));
-  return *this;
-}
-
-RotatedLorentzConeConstraint& RotatedLorentzConeConstraint::operator=(
-    RotatedLorentzConeConstraint&& rhs) {
-  Constraint::operator=(std::move(rhs));
-  return *this;
 }
 
 void RotatedLorentzConeConstraint::Eval(
@@ -102,12 +71,6 @@ void PolynomialConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
   }
 }
 
-LinearConstraint& LinearConstraint::operator=(LinearConstraint&& rhs) {
-  Constraint::operator=(std::move(rhs));
-  A_ = std::move(rhs.A_);
-  return *this;
-}
-
 void LinearConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                             Eigen::VectorXd& y) const {
   y.resize(num_constraints());
@@ -117,18 +80,6 @@ void LinearConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
                             TaylorVecXd& y) const {
   y.resize(num_constraints());
   y = A_.cast<TaylorVarXd>() * x;
-}
-
-LinearEqualityConstraint& LinearEqualityConstraint::operator=(
-    LinearEqualityConstraint&& rhs) {
-  LinearConstraint::operator=(std::move(rhs));
-  return *this;
-}
-
-BoundingBoxConstraint& BoundingBoxConstraint::operator=(
-    BoundingBoxConstraint&& rhs) {
-  LinearConstraint::operator=(std::move(rhs));
-  return *this;
 }
 
 void BoundingBoxConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -142,14 +93,6 @@ void BoundingBoxConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
   y = x;
 }
 
-LinearComplementarityConstraint& LinearComplementarityConstraint::operator=(
-    LinearComplementarityConstraint&& rhs) {
-  Constraint::operator=(std::move(rhs));
-  M_ = std::move(rhs.M_);
-  q_ = std::move(rhs.q_);
-  return *this;
-}
-
 void LinearComplementarityConstraint::Eval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {
   y.resize(num_constraints());
@@ -160,12 +103,6 @@ void LinearComplementarityConstraint::Eval(
     const Eigen::Ref<const TaylorVecXd>& x, TaylorVecXd& y) const {
   y.resize(num_constraints());
   y = (M_.cast<TaylorVarXd>() * x) + q_.cast<TaylorVarXd>();
-}
-
-PositiveSemidefiniteConstraint& PositiveSemidefiniteConstraint::operator=(
-    PositiveSemidefiniteConstraint&& rhs) {
-  Constraint::operator=(std::move(rhs));
-  return *this;
 }
 
 void PositiveSemidefiniteConstraint::Eval(

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -152,7 +152,7 @@ class QuadraticConstraint : public Constraint {
 
   QuadraticConstraint& operator=(const QuadraticConstraint& rhs) = default;
 
-  QuadraticConstraint(QuadraticConstraint&& rhs) : Constraint(std::move(rhs)), Q_(rhs.Q()), b_(rhs.b()) {}
+  QuadraticConstraint(QuadraticConstraint&& rhs) : Constraint(std::move(rhs)), Q_(rhs.Q()), b_(rhs.b()) {std::cout<<"move"<<std::endl;}
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -31,6 +31,8 @@ namespace solvers {
  * should also be some notion of parameterized constraints:  e.g. the
  * acceleration constraints in the rigid body dynamics are constraints
  * on vdot and f, but are "parameterized" by q and v.
+ *
+ * Constraint is not copyable, nor movable.
  */
 class Constraint {
   void check(size_t num_constraints) {
@@ -49,13 +51,13 @@ class Constraint {
     upper_bound_.setConstant(std::numeric_limits<double>::infinity());
   }
 
-  Constraint(const Constraint& rhs) = default;
+  Constraint(const Constraint& rhs) = delete;
 
-  Constraint& operator=(const Constraint& rhs) = default;
+  Constraint& operator=(const Constraint& rhs) = delete;
 
-  Constraint(Constraint&& rhs);
+  Constraint(Constraint&& rhs) = delete;
 
-  Constraint& operator=(Constraint&& rhs);
+  Constraint& operator=(Constraint&& rhs) = delete;
 
   template <typename DerivedLB, typename DerivedUB>
   Constraint(size_t num_constraints, Eigen::MatrixBase<DerivedLB> const& lb,
@@ -147,15 +149,6 @@ class QuadraticConstraint : public Constraint {
 
   ~QuadraticConstraint() override {}
 
-  QuadraticConstraint(const QuadraticConstraint& rhs) = default;
-
-  QuadraticConstraint& operator=(const QuadraticConstraint& rhs) = default;
-
-  QuadraticConstraint(QuadraticConstraint&& rhs)
-      : Constraint(std::move(rhs)), Q_(rhs.Q()), b_(rhs.b()) {}
-
-  QuadraticConstraint& operator=(QuadraticConstraint&& rhs);
-
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
 
@@ -216,15 +209,6 @@ class LorentzConeConstraint : public Constraint {
                    Eigen::Vector2d::Constant(
                        std::numeric_limits<double>::infinity())) {}
 
-  LorentzConeConstraint(const LorentzConeConstraint& rhs) = default;
-
-  LorentzConeConstraint& operator=(const LorentzConeConstraint& rhs) = default;
-
-  LorentzConeConstraint(LorentzConeConstraint&& rhs)
-      : Constraint(std::move(rhs)) {}
-
-  LorentzConeConstraint& operator=(LorentzConeConstraint&& rhs);
-
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
 
@@ -249,17 +233,6 @@ class RotatedLorentzConeConstraint : public Constraint {
       : Constraint(3, Eigen::Vector3d::Constant(0.0),
                    Eigen::Vector3d::Constant(
                        std::numeric_limits<double>::infinity())) {}
-
-  RotatedLorentzConeConstraint(const RotatedLorentzConeConstraint& rhs) =
-      default;
-
-  RotatedLorentzConeConstraint& operator=(
-      const RotatedLorentzConeConstraint& rhs) = default;
-
-  RotatedLorentzConeConstraint(RotatedLorentzConeConstraint&& rhs)
-      : Constraint(std::move(rhs)) {}
-
-  RotatedLorentzConeConstraint& operator=(RotatedLorentzConeConstraint&& rhs);
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
@@ -289,23 +262,6 @@ class PolynomialConstraint : public Constraint {
         poly_vars_(poly_vars) {}
 
   ~PolynomialConstraint() override {}
-
-  PolynomialConstraint(const PolynomialConstraint& rhs) = default;
-
-  /// PolynomialConstraint object cannot be assigned, since it contains const
-  /// data members.
-  PolynomialConstraint& operator=(const PolynomialConstraint& rhs) = delete;
-
-  PolynomialConstraint(PolynomialConstraint&& rhs)
-      : Constraint(std::move(rhs)),
-        polynomials_(std::move(rhs.polynomials_)),
-        poly_vars_(std::move(rhs.poly_vars_)),
-        double_evaluation_point_(std::move(rhs.double_evaluation_point_)),
-        taylor_evaluation_point_(std::move(rhs.taylor_evaluation_point_)) {}
-
-  /// PolynomialConstraint object cannot be assigned, since it contains const
-  /// data members.
-  PolynomialConstraint& operator=(PolynomialConstraint&& rhs) = delete;
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
@@ -339,15 +295,6 @@ class LinearConstraint : public Constraint {
       : Constraint(a.rows(), lb, ub), A_(a) {
     DRAKE_ASSERT(a.rows() == lb.rows());
   }
-
-  LinearConstraint(const LinearConstraint& rhs) = default;
-
-  LinearConstraint& operator=(const LinearConstraint& rhs) = default;
-
-  LinearConstraint(LinearConstraint&& rhs)
-      : Constraint(std::move(rhs)), A_(std::move(rhs.A())) {}
-
-  LinearConstraint& operator=(LinearConstraint&& rhs);
 
   ~LinearConstraint() override {}
 
@@ -406,16 +353,6 @@ class LinearEqualityConstraint : public LinearConstraint {
                            const Eigen::MatrixBase<DerivedB>& beq)
       : LinearConstraint(Aeq, beq, beq) {}
 
-  LinearEqualityConstraint(const LinearEqualityConstraint& rhs) = default;
-
-  LinearEqualityConstraint& operator=(const LinearEqualityConstraint& rhs) =
-      default;
-
-  LinearEqualityConstraint(LinearEqualityConstraint&& rhs)
-      : LinearConstraint(std::move(rhs)) {}
-
-  LinearEqualityConstraint& operator=(LinearEqualityConstraint&& rhs);
-
   ~LinearEqualityConstraint() override {}
 
   /*
@@ -449,15 +386,6 @@ class BoundingBoxConstraint : public LinearConstraint {
       : LinearConstraint(Eigen::MatrixXd::Identity(lb.rows(), lb.rows()), lb,
                          ub) {}
 
-  BoundingBoxConstraint(const BoundingBoxConstraint& rhs) = default;
-
-  BoundingBoxConstraint& operator=(const BoundingBoxConstraint& rhs) = default;
-
-  BoundingBoxConstraint(BoundingBoxConstraint&& rhs)
-      : LinearConstraint(std::move(rhs)) {}
-
-  BoundingBoxConstraint& operator=(BoundingBoxConstraint&& rhs);
-
   ~BoundingBoxConstraint() override {}
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -485,20 +413,6 @@ class LinearComplementarityConstraint : public Constraint {
   LinearComplementarityConstraint(const Eigen::MatrixBase<DerivedM>& M,
                                   const Eigen::MatrixBase<Derivedq>& q)
       : Constraint(q.rows()), M_(M), q_(q) {}
-
-  LinearComplementarityConstraint(const LinearComplementarityConstraint& rhs) =
-      default;
-
-  LinearComplementarityConstraint& operator=(
-      const LinearComplementarityConstraint& rhs) = default;
-
-  LinearComplementarityConstraint(LinearComplementarityConstraint&& rhs)
-      : Constraint(std::move(rhs)),
-        M_(std::move(rhs.M_)),
-        q_(std::move(rhs.q_)) {}
-
-  LinearComplementarityConstraint& operator=(
-      LinearComplementarityConstraint&& rhs);
 
   ~LinearComplementarityConstraint() override {}
 
@@ -585,18 +499,6 @@ class PositiveSemidefiniteConstraint : public Constraint {
                    Eigen::VectorXd::Constant(
                        rows, std::numeric_limits<double>::infinity())) {}
 
-  PositiveSemidefiniteConstraint(const PositiveSemidefiniteConstraint& rhs) =
-      default;
-
-  PositiveSemidefiniteConstraint& operator=(
-      const PositiveSemidefiniteConstraint& rhs) = default;
-
-  PositiveSemidefiniteConstraint(PositiveSemidefiniteConstraint&& rhs)
-      : Constraint(std::move(rhs)) {}
-
-  PositiveSemidefiniteConstraint& operator=(
-      PositiveSemidefiniteConstraint&& rhs);
-
   /**
    * Evaluate the eigen values of the symmetric matrix.
    * @param x The stacked columns of the symmetric matrix.
@@ -634,24 +536,6 @@ class LinearMatrixInequalityConstraint : public Constraint {
   LinearMatrixInequalityConstraint(
       const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
       double symmetry_tolerance = 1E-10);
-
-  LinearMatrixInequalityConstraint(
-      const LinearMatrixInequalityConstraint& rhs) = default;
-
-  /// LinearMatrixInequalityConstraint is not assignable since it has const
-  /// data members.
-  LinearMatrixInequalityConstraint& operator=(
-      const LinearMatrixInequalityConstraint& rhs) = delete;
-
-  LinearMatrixInequalityConstraint(LinearMatrixInequalityConstraint&& rhs)
-      : Constraint(std::move(rhs)),
-        F_(std::move(rhs.F_)),
-        matrix_rows_(std::move(rhs.matrix_rows_)) {}
-
-  /// LinearMatrixInequalityConstraint is not assignable since it has const
-  /// data members.
-  LinearMatrixInequalityConstraint& operator=(
-      LinearMatrixInequalityConstraint&& rhs) = delete;
 
   /* Getter for all given matrices F */
   const std::vector<Eigen::MatrixXd>& F() const { return F_; }

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -67,7 +67,8 @@ class Constraint {
   template <typename DerivedLB, typename DerivedUB>
   Constraint(size_t num_constraints, const Eigen::MatrixBase<DerivedLB>& lb,
              const Eigen::MatrixBase<DerivedUB>& ub,
-             const std::string& description) : lower_bound_(lb), upper_bound_(ub), description_(description) {
+             const std::string& description)
+      : lower_bound_(lb), upper_bound_(ub), description_(description) {
     check(num_constraints);
   }
 
@@ -152,7 +153,8 @@ class QuadraticConstraint : public Constraint {
 
   QuadraticConstraint& operator=(const QuadraticConstraint& rhs) = default;
 
-  QuadraticConstraint(QuadraticConstraint&& rhs) : Constraint(std::move(rhs)), Q_(rhs.Q()), b_(rhs.b()) {}
+  QuadraticConstraint(QuadraticConstraint&& rhs)
+      : Constraint(std::move(rhs)), Q_(rhs.Q()), b_(rhs.b()) {}
 
   QuadraticConstraint& operator=(QuadraticConstraint&& rhs);
 
@@ -220,7 +222,8 @@ class LorentzConeConstraint : public Constraint {
 
   LorentzConeConstraint& operator=(const LorentzConeConstraint& rhs) = default;
 
-  LorentzConeConstraint(LorentzConeConstraint&& rhs) : Constraint(std::move(rhs)) {}
+  LorentzConeConstraint(LorentzConeConstraint&& rhs)
+      : Constraint(std::move(rhs)) {}
 
   LorentzConeConstraint& operator=(LorentzConeConstraint&& rhs);
 
@@ -249,11 +252,14 @@ class RotatedLorentzConeConstraint : public Constraint {
                    Eigen::Vector3d::Constant(
                        std::numeric_limits<double>::infinity())) {}
 
-  RotatedLorentzConeConstraint(const RotatedLorentzConeConstraint& rhs) = default;
+  RotatedLorentzConeConstraint(const RotatedLorentzConeConstraint& rhs) =
+      default;
 
-  RotatedLorentzConeConstraint& operator=(const RotatedLorentzConeConstraint& rhs) = default;
+  RotatedLorentzConeConstraint& operator=(
+      const RotatedLorentzConeConstraint& rhs) = default;
 
-  RotatedLorentzConeConstraint(RotatedLorentzConeConstraint&& rhs) : Constraint(std::move(rhs)) {}
+  RotatedLorentzConeConstraint(RotatedLorentzConeConstraint&& rhs)
+      : Constraint(std::move(rhs)) {}
 
   RotatedLorentzConeConstraint& operator=(RotatedLorentzConeConstraint&& rhs);
 
@@ -292,11 +298,12 @@ class PolynomialConstraint : public Constraint {
   /// data members.
   PolynomialConstraint& operator=(const PolynomialConstraint& rhs) = delete;
 
-  PolynomialConstraint(PolynomialConstraint&& rhs) :
-      Constraint(std::move(rhs)), polynomials_(std::move(rhs.polynomials_)),
-      poly_vars_(std::move(rhs.poly_vars_)),
-      double_evaluation_point_(std::move(rhs.double_evaluation_point_)),
-      taylor_evaluation_point_(std::move(rhs.taylor_evaluation_point_)) {}
+  PolynomialConstraint(PolynomialConstraint&& rhs)
+      : Constraint(std::move(rhs)),
+        polynomials_(std::move(rhs.polynomials_)),
+        poly_vars_(std::move(rhs.poly_vars_)),
+        double_evaluation_point_(std::move(rhs.double_evaluation_point_)),
+        taylor_evaluation_point_(std::move(rhs.taylor_evaluation_point_)) {}
 
   /// PolynomialConstraint object cannot be assigned, since it contains const
   /// data members.
@@ -339,7 +346,8 @@ class LinearConstraint : public Constraint {
 
   LinearConstraint& operator=(const LinearConstraint& rhs) = default;
 
-  LinearConstraint(LinearConstraint&& rhs) : Constraint(std::move(rhs)), A_(std::move(rhs.A())) {}
+  LinearConstraint(LinearConstraint&& rhs)
+      : Constraint(std::move(rhs)), A_(std::move(rhs.A())) {}
 
   LinearConstraint& operator=(LinearConstraint&& rhs);
 
@@ -402,9 +410,11 @@ class LinearEqualityConstraint : public LinearConstraint {
 
   LinearEqualityConstraint(const LinearEqualityConstraint& rhs) = default;
 
-  LinearEqualityConstraint& operator=(const LinearEqualityConstraint& rhs) = default;
+  LinearEqualityConstraint& operator=(const LinearEqualityConstraint& rhs) =
+      default;
 
-  LinearEqualityConstraint(LinearEqualityConstraint&& rhs) : LinearConstraint(std::move(rhs)) {};
+  LinearEqualityConstraint(LinearEqualityConstraint&& rhs)
+      : LinearConstraint(std::move(rhs)) {}
 
   LinearEqualityConstraint& operator=(LinearEqualityConstraint&& rhs);
 
@@ -445,7 +455,8 @@ class BoundingBoxConstraint : public LinearConstraint {
 
   BoundingBoxConstraint& operator=(const BoundingBoxConstraint& rhs) = default;
 
-  BoundingBoxConstraint(BoundingBoxConstraint&& rhs) : LinearConstraint(std::move(rhs)) {};
+  BoundingBoxConstraint(BoundingBoxConstraint&& rhs)
+      : LinearConstraint(std::move(rhs)) {}
 
   BoundingBoxConstraint& operator=(BoundingBoxConstraint&& rhs);
 
@@ -477,13 +488,19 @@ class LinearComplementarityConstraint : public Constraint {
                                   const Eigen::MatrixBase<Derivedq>& q)
       : Constraint(q.rows()), M_(M), q_(q) {}
 
-  LinearComplementarityConstraint(const LinearComplementarityConstraint& rhs) = default;
+  LinearComplementarityConstraint(const LinearComplementarityConstraint& rhs) =
+      default;
 
-  LinearComplementarityConstraint& operator=(const LinearComplementarityConstraint& rhs) = default;
+  LinearComplementarityConstraint& operator=(
+      const LinearComplementarityConstraint& rhs) = default;
 
-  LinearComplementarityConstraint(LinearComplementarityConstraint&& rhs) : Constraint(std::move(rhs)), M_(std::move(rhs.M_)), q_(std::move(rhs.q_)) {};
+  LinearComplementarityConstraint(LinearComplementarityConstraint&& rhs)
+      : Constraint(std::move(rhs)),
+        M_(std::move(rhs.M_)),
+        q_(std::move(rhs.q_)) {}
 
-  LinearComplementarityConstraint& operator=(LinearComplementarityConstraint&& rhs);
+  LinearComplementarityConstraint& operator=(
+      LinearComplementarityConstraint&& rhs);
 
   ~LinearComplementarityConstraint() override {}
 
@@ -576,9 +593,11 @@ class PositiveSemidefiniteConstraint : public Constraint {
   PositiveSemidefiniteConstraint& operator=(
       const PositiveSemidefiniteConstraint& rhs) = default;
 
-  PositiveSemidefiniteConstraint(PositiveSemidefiniteConstraint&& rhs) : Constraint(std::move(rhs)) {};
+  PositiveSemidefiniteConstraint(PositiveSemidefiniteConstraint&& rhs)
+      : Constraint(std::move(rhs)) {}
 
-  PositiveSemidefiniteConstraint& operator=(PositiveSemidefiniteConstraint&& rhs);
+  PositiveSemidefiniteConstraint& operator=(
+      PositiveSemidefiniteConstraint&& rhs);
 
   /**
    * Evaluate the eigen values of the symmetric matrix.
@@ -626,11 +645,15 @@ class LinearMatrixInequalityConstraint : public Constraint {
   LinearMatrixInequalityConstraint& operator=(
       const LinearMatrixInequalityConstraint& rhs) = delete;
 
-  LinearMatrixInequalityConstraint(LinearMatrixInequalityConstraint&& rhs) : Constraint(std::move(rhs)), F_(std::move(rhs.F_)), matrix_rows_(std::move(rhs.matrix_rows_)) {}
+  LinearMatrixInequalityConstraint(LinearMatrixInequalityConstraint&& rhs)
+      : Constraint(std::move(rhs)),
+        F_(std::move(rhs.F_)),
+        matrix_rows_(std::move(rhs.matrix_rows_)) {}
 
   /// LinearMatrixInequalityConstraint is not assignable since it has const
   /// data members.
-  LinearMatrixInequalityConstraint& operator=(LinearMatrixInequalityConstraint&& rhs) = delete;
+  LinearMatrixInequalityConstraint& operator=(
+      LinearMatrixInequalityConstraint&& rhs) = delete;
 
   /* Getter for all given matrices F */
   const std::vector<Eigen::MatrixXd>& F() const { return F_; }

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -60,9 +60,7 @@ class Constraint {
   template <typename DerivedLB, typename DerivedUB>
   Constraint(size_t num_constraints, Eigen::MatrixBase<DerivedLB> const& lb,
              Eigen::MatrixBase<DerivedUB> const& ub)
-      : lower_bound_(lb), upper_bound_(ub), description_() {
-    check(num_constraints);
-  }
+      : Constraint(num_constraints, lb, ub, "") {}
 
   template <typename DerivedLB, typename DerivedUB>
   Constraint(size_t num_constraints, const Eigen::MatrixBase<DerivedLB>& lb,

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <iostream>
+
 #include <limits>
 #include <list>
 #include <map>
@@ -152,7 +152,9 @@ class QuadraticConstraint : public Constraint {
 
   QuadraticConstraint& operator=(const QuadraticConstraint& rhs) = default;
 
-  QuadraticConstraint(QuadraticConstraint&& rhs) : Constraint(std::move(rhs)), Q_(rhs.Q()), b_(rhs.b()) {std::cout<<"move"<<std::endl;}
+  QuadraticConstraint(QuadraticConstraint&& rhs) : Constraint(std::move(rhs)), Q_(rhs.Q()), b_(rhs.b()) {}
+
+  QuadraticConstraint& operator=(QuadraticConstraint&& rhs);
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
@@ -214,6 +216,14 @@ class LorentzConeConstraint : public Constraint {
                    Eigen::Vector2d::Constant(
                        std::numeric_limits<double>::infinity())) {}
 
+  LorentzConeConstraint(const LorentzConeConstraint& rhs) = default;
+
+  LorentzConeConstraint& operator=(const LorentzConeConstraint& rhs) = default;
+
+  LorentzConeConstraint(LorentzConeConstraint&& rhs) : Constraint(std::move(rhs)) {}
+
+  LorentzConeConstraint& operator=(LorentzConeConstraint&& rhs);
+
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
 
@@ -238,6 +248,14 @@ class RotatedLorentzConeConstraint : public Constraint {
       : Constraint(3, Eigen::Vector3d::Constant(0.0),
                    Eigen::Vector3d::Constant(
                        std::numeric_limits<double>::infinity())) {}
+
+  RotatedLorentzConeConstraint(const RotatedLorentzConeConstraint& rhs) = default;
+
+  RotatedLorentzConeConstraint& operator=(const RotatedLorentzConeConstraint& rhs) = default;
+
+  RotatedLorentzConeConstraint(RotatedLorentzConeConstraint&& rhs) : Constraint(std::move(rhs)) {}
+
+  RotatedLorentzConeConstraint& operator=(RotatedLorentzConeConstraint&& rhs);
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
@@ -267,6 +285,22 @@ class PolynomialConstraint : public Constraint {
         poly_vars_(poly_vars) {}
 
   ~PolynomialConstraint() override {}
+
+  PolynomialConstraint(const PolynomialConstraint& rhs) = default;
+
+  /// PolynomialConstraint object cannot be assigned, since it contains const
+  /// data members.
+  PolynomialConstraint& operator=(const PolynomialConstraint& rhs) = delete;
+
+  PolynomialConstraint(PolynomialConstraint&& rhs) :
+      Constraint(std::move(rhs)), polynomials_(std::move(rhs.polynomials_)),
+      poly_vars_(std::move(rhs.poly_vars_)),
+      double_evaluation_point_(std::move(rhs.double_evaluation_point_)),
+      taylor_evaluation_point_(std::move(rhs.taylor_evaluation_point_)) {}
+
+  /// PolynomialConstraint object cannot be assigned, since it contains const
+  /// data members.
+  PolynomialConstraint& operator=(PolynomialConstraint&& rhs) = delete;
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
@@ -300,6 +334,14 @@ class LinearConstraint : public Constraint {
       : Constraint(a.rows(), lb, ub), A_(a) {
     DRAKE_ASSERT(a.rows() == lb.rows());
   }
+
+  LinearConstraint(const LinearConstraint& rhs) = default;
+
+  LinearConstraint& operator=(const LinearConstraint& rhs) = default;
+
+  LinearConstraint(LinearConstraint&& rhs) : Constraint(std::move(rhs)), A_(std::move(rhs.A())) {}
+
+  LinearConstraint& operator=(LinearConstraint&& rhs);
 
   ~LinearConstraint() override {}
 
@@ -358,6 +400,14 @@ class LinearEqualityConstraint : public LinearConstraint {
                            const Eigen::MatrixBase<DerivedB>& beq)
       : LinearConstraint(Aeq, beq, beq) {}
 
+  LinearEqualityConstraint(const LinearEqualityConstraint& rhs) = default;
+
+  LinearEqualityConstraint& operator=(const LinearEqualityConstraint& rhs) = default;
+
+  LinearEqualityConstraint(LinearEqualityConstraint&& rhs) : LinearConstraint(std::move(rhs)) {};
+
+  LinearEqualityConstraint& operator=(LinearEqualityConstraint&& rhs);
+
   ~LinearEqualityConstraint() override {}
 
   /*
@@ -391,6 +441,14 @@ class BoundingBoxConstraint : public LinearConstraint {
       : LinearConstraint(Eigen::MatrixXd::Identity(lb.rows(), lb.rows()), lb,
                          ub) {}
 
+  BoundingBoxConstraint(const BoundingBoxConstraint& rhs) = default;
+
+  BoundingBoxConstraint& operator=(const BoundingBoxConstraint& rhs) = default;
+
+  BoundingBoxConstraint(BoundingBoxConstraint&& rhs) : LinearConstraint(std::move(rhs)) {};
+
+  BoundingBoxConstraint& operator=(BoundingBoxConstraint&& rhs);
+
   ~BoundingBoxConstraint() override {}
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -418,6 +476,14 @@ class LinearComplementarityConstraint : public Constraint {
   LinearComplementarityConstraint(const Eigen::MatrixBase<DerivedM>& M,
                                   const Eigen::MatrixBase<Derivedq>& q)
       : Constraint(q.rows()), M_(M), q_(q) {}
+
+  LinearComplementarityConstraint(const LinearComplementarityConstraint& rhs) = default;
+
+  LinearComplementarityConstraint& operator=(const LinearComplementarityConstraint& rhs) = default;
+
+  LinearComplementarityConstraint(LinearComplementarityConstraint&& rhs) : Constraint(std::move(rhs)), M_(std::move(rhs.M_)), q_(std::move(rhs.q_)) {};
+
+  LinearComplementarityConstraint& operator=(LinearComplementarityConstraint&& rhs);
 
   ~LinearComplementarityConstraint() override {}
 
@@ -509,6 +575,11 @@ class PositiveSemidefiniteConstraint : public Constraint {
 
   PositiveSemidefiniteConstraint& operator=(
       const PositiveSemidefiniteConstraint& rhs) = default;
+
+  PositiveSemidefiniteConstraint(PositiveSemidefiniteConstraint&& rhs) : Constraint(std::move(rhs)) {};
+
+  PositiveSemidefiniteConstraint& operator=(PositiveSemidefiniteConstraint&& rhs);
+
   /**
    * Evaluate the eigen values of the symmetric matrix.
    * @param x The stacked columns of the symmetric matrix.
@@ -550,8 +621,16 @@ class LinearMatrixInequalityConstraint : public Constraint {
   LinearMatrixInequalityConstraint(
       const LinearMatrixInequalityConstraint& rhs) = default;
 
+  /// LinearMatrixInequalityConstraint is not assignable since it has const
+  /// data members.
   LinearMatrixInequalityConstraint& operator=(
-      const LinearMatrixInequalityConstraint& rhs) = default;
+      const LinearMatrixInequalityConstraint& rhs) = delete;
+
+  LinearMatrixInequalityConstraint(LinearMatrixInequalityConstraint&& rhs) : Constraint(std::move(rhs)), F_(std::move(rhs.F_)), matrix_rows_(std::move(rhs.matrix_rows_)) {}
+
+  /// LinearMatrixInequalityConstraint is not assignable since it has const
+  /// data members.
+  LinearMatrixInequalityConstraint& operator=(LinearMatrixInequalityConstraint&& rhs) = delete;
 
   /* Getter for all given matrices F */
   const std::vector<Eigen::MatrixXd>& F() const { return F_; }

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -147,6 +147,14 @@ class QuadraticConstraint : public Constraint {
     DRAKE_ASSERT(Q_.cols() == b_.rows());
   }
 
+  QuadraticConstraint(const QuadraticConstraint& rhs) = delete;
+
+  QuadraticConstraint& operator=(const QuadraticConstraint& rhs) = delete;
+
+  QuadraticConstraint(QuadraticConstraint&& rhs) = delete;
+
+  QuadraticConstraint& operator=(QuadraticConstraint&& rhs) = delete;
+
   ~QuadraticConstraint() override {}
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -209,6 +217,16 @@ class LorentzConeConstraint : public Constraint {
                    Eigen::Vector2d::Constant(
                        std::numeric_limits<double>::infinity())) {}
 
+  LorentzConeConstraint(const LorentzConeConstraint& rhs) = delete;
+
+  LorentzConeConstraint& operator=(const LorentzConeConstraint& rhs) = delete;
+
+  LorentzConeConstraint(LorentzConeConstraint&& rhs) = delete;
+
+  LorentzConeConstraint& operator=(LorentzConeConstraint&& rhs) = delete;
+
+  ~LorentzConeConstraint() override {}
+
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
 
@@ -233,6 +251,19 @@ class RotatedLorentzConeConstraint : public Constraint {
       : Constraint(3, Eigen::Vector3d::Constant(0.0),
                    Eigen::Vector3d::Constant(
                        std::numeric_limits<double>::infinity())) {}
+
+  RotatedLorentzConeConstraint(const RotatedLorentzConeConstraint& rhs) =
+      delete;
+
+  RotatedLorentzConeConstraint& operator=(
+      const RotatedLorentzConeConstraint& rhs) = delete;
+
+  RotatedLorentzConeConstraint(RotatedLorentzConeConstraint&& rhs) = delete;
+
+  RotatedLorentzConeConstraint& operator=(RotatedLorentzConeConstraint&& rhs) =
+      delete;
+
+  ~RotatedLorentzConeConstraint() override {}
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
@@ -260,6 +291,14 @@ class PolynomialConstraint : public Constraint {
       : Constraint(polynomials.rows(), lb, ub),
         polynomials_(polynomials),
         poly_vars_(poly_vars) {}
+
+  PolynomialConstraint(const PolynomialConstraint& rhs) = delete;
+
+  PolynomialConstraint& operator=(const PolynomialConstraint& rhs) = delete;
+
+  PolynomialConstraint(PolynomialConstraint&& rhs) = delete;
+
+  PolynomialConstraint& operator=(PolynomialConstraint&& rhs) = delete;
 
   ~PolynomialConstraint() override {}
 
@@ -295,6 +334,14 @@ class LinearConstraint : public Constraint {
       : Constraint(a.rows(), lb, ub), A_(a) {
     DRAKE_ASSERT(a.rows() == lb.rows());
   }
+
+  LinearConstraint(const LinearConstraint& rhs) = delete;
+
+  LinearConstraint& operator=(const LinearConstraint& rhs) = delete;
+
+  LinearConstraint(LinearConstraint&& rhs) = delete;
+
+  LinearConstraint& operator=(LinearConstraint&& rhs) = delete;
 
   ~LinearConstraint() override {}
 
@@ -353,6 +400,15 @@ class LinearEqualityConstraint : public LinearConstraint {
                            const Eigen::MatrixBase<DerivedB>& beq)
       : LinearConstraint(Aeq, beq, beq) {}
 
+  LinearEqualityConstraint(const LinearEqualityConstraint& rhs) = delete;
+
+  LinearEqualityConstraint& operator=(const LinearEqualityConstraint& rhs) =
+      delete;
+
+  LinearEqualityConstraint(LinearEqualityConstraint&& rhs) = delete;
+
+  LinearEqualityConstraint& operator=(LinearEqualityConstraint&& rhs) = delete;
+
   ~LinearEqualityConstraint() override {}
 
   /*
@@ -386,6 +442,14 @@ class BoundingBoxConstraint : public LinearConstraint {
       : LinearConstraint(Eigen::MatrixXd::Identity(lb.rows(), lb.rows()), lb,
                          ub) {}
 
+  BoundingBoxConstraint(const BoundingBoxConstraint& rhs) = delete;
+
+  BoundingBoxConstraint& operator=(const BoundingBoxConstraint& rhs) = delete;
+
+  BoundingBoxConstraint(BoundingBoxConstraint&& rhs) = delete;
+
+  BoundingBoxConstraint& operator=(BoundingBoxConstraint&& rhs) = delete;
+
   ~BoundingBoxConstraint() override {}
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -413,6 +477,18 @@ class LinearComplementarityConstraint : public Constraint {
   LinearComplementarityConstraint(const Eigen::MatrixBase<DerivedM>& M,
                                   const Eigen::MatrixBase<Derivedq>& q)
       : Constraint(q.rows()), M_(M), q_(q) {}
+
+  LinearComplementarityConstraint(const LinearComplementarityConstraint& rhs) =
+      delete;
+
+  LinearComplementarityConstraint& operator=(
+      const LinearComplementarityConstraint& rhs) = delete;
+
+  LinearComplementarityConstraint(LinearComplementarityConstraint&& rhs) =
+      delete;
+
+  LinearComplementarityConstraint& operator=(
+      LinearComplementarityConstraint&& rhs) = delete;
 
   ~LinearComplementarityConstraint() override {}
 
@@ -499,6 +575,19 @@ class PositiveSemidefiniteConstraint : public Constraint {
                    Eigen::VectorXd::Constant(
                        rows, std::numeric_limits<double>::infinity())) {}
 
+  PositiveSemidefiniteConstraint(const PositiveSemidefiniteConstraint& rhs) =
+      delete;
+
+  PositiveSemidefiniteConstraint& operator=(
+      const PositiveSemidefiniteConstraint& rhs) = delete;
+
+  PositiveSemidefiniteConstraint(PositiveSemidefiniteConstraint&& rhs) = delete;
+
+  PositiveSemidefiniteConstraint& operator=(
+      PositiveSemidefiniteConstraint&& rhs) = delete;
+
+  ~PositiveSemidefiniteConstraint() override {}
+
   /**
    * Evaluate the eigen values of the symmetric matrix.
    * @param x The stacked columns of the symmetric matrix.
@@ -536,6 +625,20 @@ class LinearMatrixInequalityConstraint : public Constraint {
   LinearMatrixInequalityConstraint(
       const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
       double symmetry_tolerance = 1E-10);
+
+  LinearMatrixInequalityConstraint(
+      const LinearMatrixInequalityConstraint& rhs) = delete;
+
+  LinearMatrixInequalityConstraint& operator=(
+      const LinearMatrixInequalityConstraint& rhs) = delete;
+
+  LinearMatrixInequalityConstraint(LinearMatrixInequalityConstraint&& rhs) =
+      delete;
+
+  LinearMatrixInequalityConstraint& operator=(
+      LinearMatrixInequalityConstraint&& rhs) = delete;
+
+  ~LinearMatrixInequalityConstraint() override {}
 
   /* Getter for all given matrices F */
   const std::vector<Eigen::MatrixXd>& F() const { return F_; }

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -50,6 +50,14 @@ class Constraint {
     upper_bound_.setConstant(std::numeric_limits<double>::infinity());
   }
 
+  Constraint(const Constraint& rhs) = default;
+
+  Constraint& operator=(const Constraint& rhs) = default;
+
+  Constraint(Constraint&& rhs);
+
+  Constraint& operator=(Constraint&& rhs);
+
   template <typename DerivedLB, typename DerivedUB>
   Constraint(size_t num_constraints, Eigen::MatrixBase<DerivedLB> const& lb,
              Eigen::MatrixBase<DerivedUB> const& ub)

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -663,9 +663,11 @@ class MathematicalProgram {
    * Adds a symmetric matrix as decision variables to this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
+   * @param rows The rows of the symmetric matrix.
    * @param names A std::vector containing the names of each entry in the lower
    * triagular part of the symmetric matrix. The length of @p names is
    * @p rows * (rows+1) / 2.
+   * @return The newly added decision variables.
    */
   DecisionVariableMatrixX AddSymmetricContinuousVariables(
       size_t rows, const std::vector<std::string>& names);
@@ -675,6 +677,7 @@ class MathematicalProgram {
    * this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
+   * @param rows The number of rows in the symmetric matrix.
    * @param name The name of the matrix. It is only used the for user to
    * understand the optimization program. The default name is "Symmetric", and
    * each variable will be named as
@@ -685,6 +688,7 @@ class MathematicalProgram {
    * Symmetric(rows-1,0) Symmetric(rows-1,1) ... Symmetric(rows-1, rows-1)
    * </pre>
    * Notice that the (i,j)'th entry and (j,i)'th entry has the same name.
+   * @return The newly added decision variables.
    */
   DecisionVariableMatrixX AddSymmetricContinuousVariables(
       size_t rows, const std::string& name = "Symmetric");
@@ -694,6 +698,7 @@ class MathematicalProgram {
    * this MathematicalProgram.
    * The optimization will only use the stacked columns of the
    * lower triangular part of the symmetric matrix as decision variables.
+   * @tparam rows The number of rows in the symmetric matrix.
    * @param name The name of the matrix. It is only used the for user to
    * understand the optimization program. The default name is "Symmetric", and
    * each variable will be named as
@@ -704,6 +709,7 @@ class MathematicalProgram {
    * Symmetric(rows-1,0) Symmetric(rows-1,1) ... Symmetric(rows-1, rows-1)
    * </pre>
    * Notice that the (i,j)'th entry and (j,i)'th entry has the same name.
+   * @return The newly added decision variables.
    */
   template <int rows>
   DecisionVariableMatrix<rows, rows> AddSymmetricContinuousVariables(

--- a/drake/solvers/test/constraint_test.cc
+++ b/drake/solvers/test/constraint_test.cc
@@ -1,7 +1,5 @@
 #include "drake/solvers/constraint.h"
 
-#include <type_traits>
-
 #include "gtest/gtest.h"
 
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/solvers/test/constraint_test.cc
+++ b/drake/solvers/test/constraint_test.cc
@@ -19,21 +19,28 @@ namespace solvers {
 namespace {
 // This function is used to return a temporary object, so that we
 // can test move constructor.
-template<typename T>
+template <typename T>
 T pipe(T constraint) {
   return constraint;
 }
 
 // Tests if the copied and moved constraints behaves the same as the original
 // constraint.
-// is_copyable is true if the constraint can be constructed using T(const T& rhs).
+// is_copyable is true if the constraint can be constructed using T(const T&
+// rhs).
 // is_movable is true if the constraint can be constructed using T(T&& rhs).
-// is_copy_assignable is true if T can be copy-assigned from an lvalue expression.
-// is_move_assignable is true if T can be move-assigned from an rvalue expression.
-template<typename T>
-void TestMovableCopyableAssignableFun(const T &constraint,
-                                      const Eigen::Ref<const Eigen::VectorXd> x, bool is_copyable, bool is_movable, bool is_copy_assignable, bool is_move_assignable) {
-  static_assert(std::is_base_of<Constraint, T>::value, "T should be a Constraint type");
+// is_copy_assignable is true if T can be copy-assigned from an lvalue
+// expression.
+// is_move_assignable is true if T can be move-assigned from an rvalue
+// expression.
+template <typename T>
+void TestMovableCopyableAssignableFun(const T& constraint,
+                                      const Eigen::Ref<const Eigen::VectorXd> x,
+                                      bool is_copyable, bool is_movable,
+                                      bool is_copy_assignable,
+                                      bool is_move_assignable) {
+  static_assert(std::is_base_of<Constraint, T>::value,
+                "T should be a Constraint type");
   std::vector<T> constraints;
   if (is_copyable) {
     EXPECT_TRUE(std::is_copy_constructible<T>::value);
@@ -73,36 +80,52 @@ void TestMovableCopyableAssignableFun(const T &constraint,
 }
 
 GTEST_TEST(TestConstraint, TestMovableCopyable) {
-  QuadraticConstraint quadratic_constraint(Eigen::Matrix2d::Identity(), Eigen::Vector2d::Ones(), -1, 1);
-  TestMovableCopyableAssignableFun(quadratic_constraint,
-                                   Eigen::Vector2d(1.2, 0.2), true, true, true, true);
+  QuadraticConstraint quadratic_constraint(Eigen::Matrix2d::Identity(),
+                                           Eigen::Vector2d::Ones(), -1, 1);
+  TestMovableCopyableAssignableFun(
+      quadratic_constraint, Eigen::Vector2d(1.2, 0.2), true, true, true, true);
   LorentzConeConstraint lorentz_cone_constraint;
   TestMovableCopyableAssignableFun(lorentz_cone_constraint,
-                                   Eigen::Vector3d(1.2, 0.3, 0.3), true, true, true, true);
+                                   Eigen::Vector3d(1.2, 0.3, 0.3), true, true,
+                                   true, true);
   RotatedLorentzConeConstraint rotated_lorentz_cone_constraint;
   TestMovableCopyableAssignableFun(rotated_lorentz_cone_constraint,
-                                   Eigen::Vector4d(2.0, 3.0, 1.2, 0.3), true, true, true, true);
+                                   Eigen::Vector4d(2.0, 3.0, 1.2, 0.3), true,
+                                   true, true, true);
   Polynomiald x("x");
   std::vector<Polynomiald::VarType> var_mapping = {x.GetSimpleVariable()};
-  PolynomialConstraint polynomial_constraint(VectorXPoly::Constant(1, x), var_mapping, Vector1d::Constant(2), Vector1d::Constant(2));
-  TestMovableCopyableAssignableFun(polynomial_constraint, Vector1d::Constant(1), true, true, false, false);
-  LinearConstraint linear_constraint(Eigen::RowVector2d(1, 2), Vector1d(0), Vector1d(1));
-  TestMovableCopyableAssignableFun(linear_constraint,
-                                   Eigen::Vector2d(2, 3), true, true, true, true);
-  LinearEqualityConstraint linear_equality_constraint(Eigen::RowVector2d(1, 2), Vector1d(0));
+  PolynomialConstraint polynomial_constraint(VectorXPoly::Constant(1, x),
+                                             var_mapping, Vector1d::Constant(2),
+                                             Vector1d::Constant(2));
+  TestMovableCopyableAssignableFun(polynomial_constraint, Vector1d::Constant(1),
+                                   true, true, false, false);
+  LinearConstraint linear_constraint(Eigen::RowVector2d(1, 2), Vector1d(0),
+                                     Vector1d(1));
+  TestMovableCopyableAssignableFun(linear_constraint, Eigen::Vector2d(2, 3),
+                                   true, true, true, true);
+  LinearEqualityConstraint linear_equality_constraint(Eigen::RowVector2d(1, 2),
+                                                      Vector1d(0));
   TestMovableCopyableAssignableFun(linear_equality_constraint,
-                                   Eigen::Vector2d(2, 3), true, true, true, true);
-  BoundingBoxConstraint bounding_box_constraint(Eigen::Vector2d(0, 1), Eigen::Vector2d(1, 2));
+                                   Eigen::Vector2d(2, 3), true, true, true,
+                                   true);
+  BoundingBoxConstraint bounding_box_constraint(Eigen::Vector2d(0, 1),
+                                                Eigen::Vector2d(1, 2));
   TestMovableCopyableAssignableFun(bounding_box_constraint,
-                                   Eigen::Vector2d(0.5, 1.5), true, true, true, true);
-  LinearComplementarityConstraint linear_complementarity_constraint(Eigen::Matrix2d::Identity(), Eigen::Vector2d::Ones());
+                                   Eigen::Vector2d(0.5, 1.5), true, true, true,
+                                   true);
+  LinearComplementarityConstraint linear_complementarity_constraint(
+      Eigen::Matrix2d::Identity(), Eigen::Vector2d::Ones());
   TestMovableCopyableAssignableFun(linear_complementarity_constraint,
-                                   Eigen::Vector2d(2, 3), true, true, true, true);
+                                   Eigen::Vector2d(2, 3), true, true, true,
+                                   true);
   PositiveSemidefiniteConstraint positive_semidefinite_constraint(2);
   TestMovableCopyableAssignableFun(positive_semidefinite_constraint,
-                                   Eigen::Vector4d(1, 0, 0, 1), true, true, true, true);
-  LinearMatrixInequalityConstraint linear_matrix_inequality_constraint({Eigen::Matrix2d::Identity(), Eigen::Matrix2d::Ones()});
-  TestMovableCopyableAssignableFun(linear_matrix_inequality_constraint, Vector1d(1), true, true, false, false);
+                                   Eigen::Vector4d(1, 0, 0, 1), true, true,
+                                   true, true);
+  LinearMatrixInequalityConstraint linear_matrix_inequality_constraint(
+      {Eigen::Matrix2d::Identity(), Eigen::Matrix2d::Ones()});
+  TestMovableCopyableAssignableFun(linear_matrix_inequality_constraint,
+                                   Vector1d(1), true, true, false, false);
 }
 
 // Tests if the Lorentz Cone constraint is imposed correctly.

--- a/drake/solvers/test/constraint_test.cc
+++ b/drake/solvers/test/constraint_test.cc
@@ -15,6 +15,9 @@ using Eigen::Vector3d;
 namespace drake {
 namespace solvers {
 namespace {
+GTEST_TEST(TestConstraint, TestMovableCopyable) {
+
+}
 
 // Tests if the Lorentz Cone constraint is imposed correctly.
 void TestLorentzConeEval(const VectorXd& x_test, bool is_in_cone) {

--- a/drake/solvers/test/constraint_test.cc
+++ b/drake/solvers/test/constraint_test.cc
@@ -15,8 +15,18 @@ using Eigen::Vector3d;
 namespace drake {
 namespace solvers {
 namespace {
-GTEST_TEST(TestConstraint, TestMovableCopyable) {
+// This function is used to return a temporary object, so that we
+// can test move constructor.
+template<typename T>
+T pipe(T constraint) {
+  return constraint;
+}
 
+GTEST_TEST(TestConstraint, TestMovableCopyable) {
+  QuadraticConstraint constraint(Eigen::Matrix2d::Identity(), Eigen::Vector2d::Ones(), -1, 1);
+  QuadraticConstraint constraint_copy(constraint);
+  QuadraticConstraint constraint_assign = constraint;
+  QuadraticConstraint constraint_move(pipe(constraint));
 }
 
 // Tests if the Lorentz Cone constraint is imposed correctly.

--- a/drake/solvers/test/constraint_test.cc
+++ b/drake/solvers/test/constraint_test.cc
@@ -42,25 +42,26 @@ void TestMovableCopyableAssignableFun(const T& constraint,
   static_assert(std::is_base_of<Constraint, T>::value,
                 "T should be a Constraint type");
   std::vector<T> constraints;
+  EXPECT_EQ(std::is_copy_constructible<T>::value, is_copyable);
   if (is_copyable) {
-    EXPECT_TRUE(std::is_copy_constructible<T>::value);
     T constraint_copied(constraint);
     constraints.push_back(constraint_copied);
   }
+
+  EXPECT_EQ(std::is_move_constructible<T>::value, is_movable);
   if (is_movable) {
-    EXPECT_TRUE(std::is_move_constructible<T>::value);
     T constraint_moved(pipe(constraint));
     constraints.push_back(constraint_moved);
   }
 
+  EXPECT_EQ(std::is_copy_assignable<T>::value, is_copy_assignable);
   if (is_copy_assignable) {
-    EXPECT_TRUE(std::is_copy_assignable<T>::value);
     T constraint_assigned_copy = constraint;
     constraints.push_back(constraint_assigned_copy);
   }
 
+  EXPECT_EQ(std::is_move_assignable<T>::value, is_move_assignable);
   if (is_move_assignable) {
-    EXPECT_TRUE(std::is_move_assignable<T>::value);
     T constraint_assigned_move = pipe(constraint);
     constraints.push_back(constraint_assigned_move);
   }


### PR DESCRIPTION
@jwnimmer-tri comments that we should add the copy and move constructor to the `Constraint` class. I think that makes a lot of sense, since `Constraint` class has the method to update a constraint. So we should be able to do
```
Constraint c;
Constraint c_copy(c);
c_copy.UpdateConstraint(Blah);
```
as a easy way to get a slightly different constraint, without changing the original constraint.

@jwnimmer-tri could you take a look at the tests in `constraint_test` about copyable, movable, etc? I am not sure how to test if my movable constructor has called the right move constructor of all data members.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4395)
<!-- Reviewable:end -->
