### PR TITLE
Move iiwa and WSG lcm handlers

### DIFF
--- a/drake/examples/kuka_iiwa_arm/CMakeLists.txt
+++ b/drake/examples/kuka_iiwa_arm/CMakeLists.txt
@@ -1,16 +1,17 @@
 if(lcm_FOUND)
   # Defines a shared library for use by KUKA iiwa demos based on System 2.0.
   add_library_with_exports(LIB_NAME drakeKukaIiwaArmCommon SOURCE_FILES
-      iiwa_common.cc)
+      iiwa_common.cc iiwa_lcm.cc)
   target_link_libraries(drakeKukaIiwaArmCommon
-      drakeRBM)
+    drakeLCMSystem2
+    drakeRBM)
   drake_install_libraries(drakeKukaIiwaArmCommon)
   drake_install_headers(
-      iiwa_common.h)
+      iiwa_common.h iiwa_lcm.h)
   drake_install_pkg_config_file(drake-kuka-iiwa-arm-common
       TARGET drakeKukaIiwaArmCommon
       LIBS -ldrakeKukaIiwaArmCommon
-      REQUIRES drake-rbm)
+      REQUIRES drake-lcm-system drake-lcmtypes-cpp drake-rbm)
 
   add_executable(run_kuka_iiwa_arm_dynamics run_kuka_iiwa_arm_dynamics.cc)
   target_link_libraries(run_kuka_iiwa_arm_dynamics

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -1,0 +1,87 @@
+#include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
+
+#include "drake/lcmt_iiwa_command.hpp"
+#include "drake/lcmt_iiwa_status.hpp"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+
+using systems::Context;
+using systems::SystemOutput;
+
+static const int kNumJoints = 7;
+
+IiwaCommandReceiver::IiwaCommandReceiver() {
+  this->DeclareAbstractInputPort();
+  this->DeclareOutputPort(systems::kVectorValued, kNumJoints);
+}
+
+void IiwaCommandReceiver::EvalOutput(const Context<double>& context,
+                                     SystemOutput<double>* output) const {
+  const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
+  DRAKE_ASSERT(input != nullptr);
+  const auto& command = input->GetValue<lcmt_iiwa_command>();
+  auto output_vec = this->GetMutableOutputVector(output, 0);
+
+  // If we're using a default constructed message (haven't received
+  // a command yet), just return zeros.
+  if (command.num_joints == 0) {
+    output_vec.fill(0);
+  } else {
+    DRAKE_ASSERT(command.num_joints == kNumJoints);
+    for (int i = 0; i < command.num_joints; ++i) {
+      output_vec(i) = command.joint_position[i];
+    }
+  }
+
+  // TODO(sam.creasey) Support torque control.
+  DRAKE_ASSERT(command.num_torques == 0);
+}
+
+IiwaStatusSender::IiwaStatusSender() {
+  this->DeclareInputPort(systems::kVectorValued, kNumJoints);
+  this->DeclareInputPort(systems::kVectorValued, kNumJoints * 2);
+  this->DeclareAbstractOutputPort();
+}
+
+std::unique_ptr<systems::SystemOutput<double>>
+IiwaStatusSender::AllocateOutput(
+    const systems::Context<double>& context) const {
+  auto output = std::make_unique<systems::LeafSystemOutput<double>>();
+  lcmt_iiwa_status msg{};
+  msg.num_joints = kNumJoints;
+  msg.joint_position_measured.resize(msg.num_joints, 0);
+  msg.joint_position_commanded.resize(msg.num_joints, 0);
+  msg.joint_position_ipo.resize(msg.num_joints, 0);
+  msg.joint_torque_measured.resize(msg.num_joints, 0);
+  msg.joint_torque_commanded.resize(msg.num_joints, 0);
+  msg.joint_torque_external.resize(msg.num_joints, 0);
+
+  output->get_mutable_ports()->emplace_back(
+      std::make_unique<systems::OutputPort>(
+          std::make_unique<systems::Value<lcmt_iiwa_status>>(msg)));
+  return std::unique_ptr<SystemOutput<double>>(output.release());
+}
+
+void IiwaStatusSender::EvalOutput(
+    const Context<double>& context, SystemOutput<double>* output) const {
+  systems::AbstractValue* mutable_data = output->GetMutableData(0);
+  lcmt_iiwa_status& status =
+      mutable_data->GetMutableValue<lcmt_iiwa_status>();
+
+  status.utime = context.get_time() * 1e6;
+  const systems::BasicVector<double>* command =
+      this->EvalVectorInput(context, 0);
+  const systems::BasicVector<double>* state =
+      this->EvalVectorInput(context, 1);
+  for (int i = 0; i < kNumJoints; ++i) {
+    status.joint_position_measured[i] = state->GetAtIndex(i);
+    status.joint_position_commanded[i] = command->GetAtIndex(i);
+  }
+}
+
+
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
@@ -1,0 +1,50 @@
+#pragma once
+
+/// @file This file contains classes dealing with sending/receiving
+/// LCM messages related to the iiwa arm.
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+
+/// Handles lcmt_iiwa_command messages from a LcmSubscriberSystem.
+/// Has a single output port which publishes the commanded position
+/// for each joint.  All values on the output port will be zero if no
+/// LCM message has arrived with a command yet.
+class IiwaCommandReceiver : public systems::LeafSystem<double> {
+ public:
+  IiwaCommandReceiver();
+
+  void EvalOutput(const systems::Context<double>& context,
+                  systems::SystemOutput<double>* output) const override;
+};
+
+/// Sends lcmt_iiwa_status messages.  This system has two input ports,
+/// one for the current state of the plant and one for the most
+/// recently received command.  The input port for the state of the
+/// plant will be twice the size of the command (position and velocity
+/// state for each joint vs. commanded position for each joint).
+class IiwaStatusSender : public systems::LeafSystem<double> {
+ public:
+  IiwaStatusSender();
+
+  const systems::SystemPortDescriptor<double>& get_command_input_port() const {
+    return this->get_input_port(0);
+  }
+
+  const systems::SystemPortDescriptor<double>& get_state_input_port() const {
+    return this->get_input_port(1);
+  }
+
+  std::unique_ptr<systems::SystemOutput<double>> AllocateOutput(
+      const systems::Context<double>& context) const override;
+
+  void EvalOutput(const systems::Context<double>& context,
+                  systems::SystemOutput<double>* output) const override;
+};
+
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/schunk_wsg/CMakeLists.txt
+++ b/drake/examples/schunk_wsg/CMakeLists.txt
@@ -1,16 +1,20 @@
 if(lcm_FOUND)
   add_library_with_exports(LIB_NAME drakeSchunkWsg SOURCE_FILES
     gen/schunk_wsg_trajectory_generator_state_vector.cc
+    schunk_wsg_lcm.cc
     simulated_schunk_wsg_system.cc)
-  target_link_libraries(drakeSchunkWsg drakeRigidBodyPlant)
+  target_link_libraries(drakeSchunkWsg
+    drakeLCMSystem2
+    drakeRigidBodyPlant)
   drake_install_libraries(drakeSchunkWsg)
   drake_install_headers(
     # N.B. The gen/*.h headers are installed by gen/CMakeLists.txt.
+    schunk_wsg_lcm.cc
     simulated_schunk_wsg_system.h)
   drake_install_pkg_config_file(drake-schunk-wsg
     TARGET drakeSchunkWsg
     LIBS -ldrakeSchunkWsg
-    REQUIRES drake-rigid-body-plant)
+    REQUIRES drake-lcm-system drake-lcmtypes-cpp drake-rigid-body-plant)
 
   add_executable(schunk_wsg_simulation schunk_wsg_simulation.cc)
   target_link_libraries(schunk_wsg_simulation

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
@@ -1,0 +1,201 @@
+#include "drake/examples/schunk_wsg/schunk_wsg_lcm.h"
+
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
+
+#include "drake/lcmt_schunk_wsg_command.hpp"
+#include "drake/lcmt_schunk_wsg_status.hpp"
+
+namespace drake {
+namespace examples {
+namespace schunk_wsg {
+
+using systems::Context;
+using systems::DifferenceState;
+using systems::SystemOutput;
+using systems::SystemPortDescriptor;
+
+SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(
+    int input_size, int position_index)
+    : position_index_(position_index) {
+  this->set_name("SchunkWsgTrajectoryGenerator");
+  this->DeclareAbstractInputPort();
+  this->DeclareInputPort(systems::kVectorValued, input_size);
+  this->DeclareOutputPort(systems::kVectorValued, 2);
+  // The update period below matches the polling rate from
+  // drake-schunk-driver.
+  this->DeclareUpdatePeriodSec(0.05);
+}
+
+void SchunkWsgTrajectoryGenerator::EvalOutput(
+    const Context<double>& context,
+    SystemOutput<double>* output) const {
+  const systems::BasicVector<double>* state =
+      this->EvalVectorInput(context, 1);
+  const double cur_position = state->GetAtIndex(position_index_);
+
+  const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
+      dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
+          context.get_difference_state(0));
+
+  if (trajectory_) {
+    this->GetMutableOutputVector(output, 0) = trajectory_->value(
+        context.get_time() - traj_state->trajectory_start_time());
+  } else {
+    this->GetMutableOutputVector(output, 0) =
+        Eigen::Vector2d(cur_position, 0);
+  }
+}
+
+void SchunkWsgTrajectoryGenerator::DoEvalDifferenceUpdates(
+    const Context<double>& context,
+    DifferenceState<double>* difference_state) const {
+  const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
+  DRAKE_ASSERT(input != nullptr);
+  const auto& command = input->GetValue<lcmt_schunk_wsg_command>();
+  // The target_position_mm field represents the distance between
+  // the two fingers. The fingers are connected by a mechanical
+  // linkage, so the relative movement between the two fingers is
+  // twice the actuator's movement (and what we want to calcuate
+  // here is the value for the actuator).
+  double target_position = -(command.target_position_mm / 1e3) / 2.;
+  if (std::isnan(target_position)) {
+    target_position = 0;
+  }
+
+  const systems::BasicVector<double>* state =
+      this->EvalVectorInput(context, 1);
+  const double cur_position = state->GetAtIndex(position_index_);
+
+  const SchunkWsgTrajectoryGeneratorStateVector<double>* last_traj_state =
+      dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
+          context.get_difference_state(0));
+  SchunkWsgTrajectoryGeneratorStateVector<double>* new_traj_state =
+      dynamic_cast<SchunkWsgTrajectoryGeneratorStateVector<double>*>(
+          difference_state->get_mutable_difference_state(0));
+
+  if (std::abs(last_traj_state->last_target_position() - target_position) >
+      kTargetEpsilon) {
+    UpdateTrajectory(cur_position, target_position);
+    new_traj_state->set_last_target_position(target_position);
+    new_traj_state->set_trajectory_start_time(context.get_time());
+  } else {
+    new_traj_state->set_last_target_position(
+        last_traj_state->last_target_position());
+    new_traj_state->set_trajectory_start_time(
+        last_traj_state->trajectory_start_time());
+  }
+}
+
+std::unique_ptr<DifferenceState<double>>
+SchunkWsgTrajectoryGenerator::AllocateDifferenceState() const {
+  return std::make_unique<DifferenceState<double>>(
+      std::make_unique<SchunkWsgTrajectoryGeneratorStateVector<double>>());
+}
+
+void SchunkWsgTrajectoryGenerator::UpdateTrajectory(
+    double cur_position, double target_position) const {
+  // The acceleration and velocity limits correspond to the maximum
+  // values available for manual control through the gripper's web
+  // interface.
+  const double kMaxVelocity = 0.42;  // m/s
+  const double kMaxAccel = 5.;  // m/s^2
+  const double kTimeToMaxVelocity = kMaxVelocity / kMaxAccel;
+  // TODO(sam.creasey) this should probably consider current speed
+  // if the gripper is already moving.
+  const double kDistanceToMaxVelocity =
+      0.5 * kMaxAccel * kTimeToMaxVelocity * kTimeToMaxVelocity;
+
+  std::vector<Eigen::MatrixXd> knots;
+  std::vector<double> times;
+  knots.push_back(Eigen::Vector2d(cur_position, 0));
+  times.push_back(0);
+
+  const double direction = (cur_position < target_position) ? 1  : -1;
+  const double delta = std::abs(target_position - cur_position);
+
+  // The trajectory creation code below is, to say the best, a bit
+  // primitive.  I (sam.creasey) would not be surprised if it could
+  // be significantly improved.  It's also based only on the
+  // configurable constants for the WSG 50, not on analysis of the
+  // actual motion of the gripper.
+  if (delta < kDistanceToMaxVelocity * 2) {
+    // If we can't accelerate to our maximum (and decelerate again)
+    // within the target travel distance, calculate the peak velocity
+    // we will reach and create a trajectory which ramps to that
+    // velocity and back down.
+    const double mid_distance = delta / 2;
+    const double mid_velocity =
+        kMaxVelocity * (mid_distance / kDistanceToMaxVelocity);
+    const double mid_time = mid_velocity / kMaxAccel;
+    knots.push_back(Eigen::Vector2d(cur_position + mid_distance * direction,
+                                    mid_velocity * direction));
+    times.push_back(mid_time);
+    knots.push_back(Eigen::Vector2d(target_position, 0));
+    times.push_back(mid_time * 2);
+  } else {
+    knots.push_back(Eigen::Vector2d(
+        cur_position + (kDistanceToMaxVelocity * direction),
+        kMaxVelocity * direction));
+    times.push_back(kTimeToMaxVelocity);
+
+    const double time_at_max =
+        (delta - 2 * kDistanceToMaxVelocity) / kMaxVelocity;
+    knots.push_back(Eigen::Vector2d(
+        target_position - (kDistanceToMaxVelocity * direction),
+        kMaxVelocity * direction));
+    times.push_back(kTimeToMaxVelocity + time_at_max);
+
+    knots.push_back(Eigen::Vector2d(target_position, 0));
+    times.push_back(kTimeToMaxVelocity + time_at_max + kTimeToMaxVelocity);
+  }
+  trajectory_.reset(new PiecewisePolynomialTrajectory(
+      PiecewisePolynomial<double>::FirstOrderHold(times, knots)));
+}
+
+SchunkWsgStatusSender::
+SchunkWsgStatusSender(int input_size,
+                      int position_index, int velocity_index)
+    : position_index_(position_index), velocity_index_(velocity_index) {
+  this->set_name("SchunkWsgStatusSender");
+  this->DeclareInputPort(systems::kVectorValued, input_size);
+  this->DeclareAbstractOutputPort();
+}
+
+std::unique_ptr<SystemOutput<double>> SchunkWsgStatusSender::AllocateOutput(
+    const Context<double>& context) const {
+  auto output = std::make_unique<systems::LeafSystemOutput<double>>();
+  lcmt_schunk_wsg_status msg{};
+  output->add_port(
+      std::make_unique<systems::Value<lcmt_schunk_wsg_status>>(msg));
+  return std::unique_ptr<SystemOutput<double>>(output.release());
+}
+
+void SchunkWsgStatusSender::EvalOutput(const Context<double>& context,
+                                       SystemOutput<double>* output) const {
+  systems::AbstractValue* mutable_data = output->GetMutableData(0);
+  lcmt_schunk_wsg_status& status =
+      mutable_data->GetMutableValue<lcmt_schunk_wsg_status>();
+
+  status.utime = context.get_time() * 1e6;
+  const systems::BasicVector<double>* state =
+      this->EvalVectorInput(context, 0);
+  // The position and speed reported in this message are between the
+  // two fingers rather than the position/speed of a single finger
+  // (so effectively doubled).
+  status.actual_position_mm = -2 * state->GetAtIndex(position_index_) * 1e3;
+  // TODO(sam.creasey) Figure out how to get the actual force from
+  // the plant so that we can populate this field.
+  status.actual_force = 0;
+  status.actual_speed_mm_per_s =
+      -2 * state->GetAtIndex(velocity_index_) * 1e3;
+}
+
+
+}  // namespace schunk_wsg
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.h
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.h
@@ -1,0 +1,90 @@
+#pragma once
+
+/// @file This file contains classes dealing with sending/receiving
+/// LCM messages related to the Schunk WSG gripper.
+
+#include "drake/common/trajectories/trajectory.h"
+#include "drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace schunk_wsg {
+
+// TODO(sam.creasey) Right now this class just outputs a position
+// which is not going to be sufficient to capture the entire control
+// state of the gripper (particularly the maximum force).
+
+/// Receives lcmt_schunk_wsg_command for a Schunk WSG (input port 0)
+/// along with the current state of the simulated WSG (input port 1),
+/// and emits target position/velocity for the actuated finger to
+/// reach the commanded target.
+class SchunkWsgTrajectoryGenerator : public systems::LeafSystem<double> {
+ public:
+  /// @param input_size The size of the state input port to create
+  /// (one reason this may vary is passing in the entire state of a
+  /// rigid body tree vs. having already demultiplexed the actuated
+  /// finger).
+  /// @param position_index The index in the state input vector
+  /// which contains the position of the actuated finger.
+  SchunkWsgTrajectoryGenerator(int input_size, int position_index);
+
+  const systems::SystemPortDescriptor<double>& get_command_input_port() const {
+    return this->get_input_port(0);
+  }
+
+  const systems::SystemPortDescriptor<double>& get_state_input_port() const {
+    return this->get_input_port(1);
+  }
+
+  void EvalOutput(const systems::Context<double>& context,
+                  systems::SystemOutput<double>* output) const override;
+
+ protected:
+  /// Latches the input port into the discrete state.
+  void DoEvalDifferenceUpdates(
+      const systems::Context<double>& context,
+      systems::DifferenceState<double>* difference_state) const override;
+
+  std::unique_ptr<systems::DifferenceState<double>> AllocateDifferenceState()
+      const override;
+
+ private:
+  void UpdateTrajectory(double cur_position, double target_position) const;
+
+  /// The minimum change between the last received command and the
+  /// current command to trigger a trajectory update.  Based on
+  /// manually driving the actual gripper using the web interface, it
+  /// appears that it will at least attempt to respond to commands as
+  /// small as 0.1mm.
+  const double kTargetEpsilon = 0.0001;
+
+  const int position_index_{};
+  // TODO(sam.creasey) I'd prefer to store the trajectory as
+  // difference state, but unfortunately that's not currently possible
+  // as DifferenceState may only contain BasicVector.
+  mutable std::unique_ptr<Trajectory> trajectory_;
+};
+
+/// Sends lcmt_schunk_wsg_status messages for a Schunk WSG.  This
+/// system has one input port for the current state of the simulated
+/// WSG (probably a RigidBodyPlant).
+class SchunkWsgStatusSender : public systems::LeafSystem<double> {
+ public:
+  SchunkWsgStatusSender(int input_size,
+                        int position_index, int velocity_index);
+
+  std::unique_ptr<systems::SystemOutput<double>> AllocateOutput(
+      const systems::Context<double>& context) const override;
+
+  void EvalOutput(const systems::Context<double>& context,
+                  systems::SystemOutput<double>* output) const override;
+
+ private:
+  const int position_index_{};
+  const int velocity_index_{};
+};
+
+}  // namespace schunk_wsg
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/schunk_wsg/schunk_wsg_simulation.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_simulation.cc
@@ -12,8 +12,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
-#include "drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h"
+#include "drake/examples/schunk_wsg/schunk_wsg_lcm.h"
 #include "drake/examples/schunk_wsg/simulated_schunk_wsg_system.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
@@ -44,241 +43,12 @@ using systems::ConstantVectorSource;
 using systems::Context;
 using systems::Diagram;
 using systems::DiagramBuilder;
-using systems::DifferenceState;
 using systems::DrakeVisualizer;
 using systems::MatrixGain;
 using systems::Multiplexer;
 using systems::PidControlledSystem;
 using systems::RigidBodyPlant;
 using systems::Simulator;
-using systems::SystemOutput;
-using systems::SystemPortDescriptor;
-
-// TODO(sam.creasey) Right now this class just outputs a position
-// which is not going to be sufficient to capture the entire control
-// state of the gripper (particularly the maximum force).
-
-/// Recieves commands for a Schunk WSG (input port 0) along with the
-/// current state of the simulated WSG (input port 1), and emits
-/// target position/velocity for the actuated finger to reach the
-/// commanded target.
-class SchunkWsgTrajectoryGenerator : public systems::LeafSystem<double> {
- public:
-  explicit SchunkWsgTrajectoryGenerator(const RigidBodyTree<double>& tree,
-                                    int position_index)
-      : position_index_(position_index) {
-    DRAKE_ASSERT(position_index_ < tree.get_num_positions());
-
-    this->set_name("SchunkWsgTrajectoryGenerator");
-    this->DeclareAbstractInputPort();
-    this->DeclareInputPort(
-        systems::kVectorValued,
-        tree.get_num_positions() + tree.get_num_velocities());
-    this->DeclareOutputPort(systems::kVectorValued, 2);
-    // The update period below matches the polling rate from
-    // drake-schunk-driver.
-    this->DeclareUpdatePeriodSec(0.05);
-  }
-
-  const SystemPortDescriptor<double>& get_command_input_port() const {
-    return this->get_input_port(0);
-  }
-
-  const SystemPortDescriptor<double>& get_state_input_port() const {
-    return this->get_input_port(1);
-  }
-
-  void EvalOutput(const Context<double>& context,
-                  SystemOutput<double>* output) const override {
-    const systems::BasicVector<double>* state =
-          this->EvalVectorInput(context, 1);
-    const double cur_position = state->GetAtIndex(position_index_);
-
-    const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
-        dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-            context.get_difference_state(0));
-
-    if (trajectory_) {
-      this->GetMutableOutputVector(output, 0) = trajectory_->value(
-          context.get_time() - traj_state->trajectory_start_time());
-    } else {
-      this->GetMutableOutputVector(output, 0) =
-          Eigen::Vector2d(cur_position, 0);
-    }
-  }
-
- protected:
-  /// Latches the input port into the discrete state.
-  void DoEvalDifferenceUpdates(
-      const Context<double>& context,
-      DifferenceState<double>* difference_state) const override {
-    const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
-    DRAKE_ASSERT(input != nullptr);
-    const auto& command = input->GetValue<lcmt_schunk_wsg_command>();
-    // The target_position_mm field represents the distance between
-    // the two fingers. The fingers are connected by a mechanical
-    // linkage, so the relative movement between the two fingers is
-    // twice the actuator's movement (and what we want to calcuate
-    // here is the value for the actuator).
-    double target_position = -(command.target_position_mm / 1e3) / 2.;
-    if (std::isnan(target_position)) {
-      target_position = 0;
-    }
-
-    const systems::BasicVector<double>* state =
-        this->EvalVectorInput(context, 1);
-    const double cur_position = state->GetAtIndex(position_index_);
-
-    const SchunkWsgTrajectoryGeneratorStateVector<double>* last_traj_state =
-        dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-            context.get_difference_state(0));
-    SchunkWsgTrajectoryGeneratorStateVector<double>* new_traj_state =
-        dynamic_cast<SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-            difference_state->get_mutable_difference_state(0));
-
-    if (std::abs(last_traj_state->last_target_position() - target_position) >
-        kTargetEpsilon) {
-      UpdateTrajectory(cur_position, target_position);
-      new_traj_state->set_last_target_position(target_position);
-      new_traj_state->set_trajectory_start_time(context.get_time());
-    } else {
-      new_traj_state->set_last_target_position(
-          last_traj_state->last_target_position());
-      new_traj_state->set_trajectory_start_time(
-          last_traj_state->trajectory_start_time());
-    }
-  }
-
-  std::unique_ptr<DifferenceState<double>>
-  AllocateDifferenceState() const override {
-    return std::make_unique<systems::DifferenceState<double>>(
-        std::make_unique<SchunkWsgTrajectoryGeneratorStateVector<double>>());
-  }
-
- private:
-  void UpdateTrajectory(double cur_position, double target_position) const {
-    // The acceleration and velocity limits correspond to the maximum
-    // values available for manual control through the gripper's web
-    // interface.
-    const double kMaxVelocity = 0.42;  // m/s
-    const double kMaxAccel = 5.;  // m/s^2
-    const double kTimeToMaxAccel = kMaxVelocity / kMaxAccel;
-    // TODO(sam.creasey) this should probably consider current speed
-    // if the gripper is already moving.
-    const double kDistanceToMaxAccel =
-        0.5 * kMaxAccel * kTimeToMaxAccel * kTimeToMaxAccel;
-
-    std::vector<Eigen::MatrixXd> knots;
-    std::vector<double> times;
-    knots.push_back(Eigen::Vector2d(cur_position, 0));
-    times.push_back(0);
-
-    const double direction = (cur_position < target_position) ? 1  : -1;
-    const double delta = std::abs(target_position - cur_position);
-
-    // The trajectory creation code below is, to say the best, a bit
-    // primitive.  I (sam.creasey) would not be surprised if it could
-    // be significantly improved.  It's also based only on the
-    // configurable constants for the WSG 50, not on analysis of the
-    // actual motion of the gripper.
-    if (delta < kDistanceToMaxAccel * 2) {
-      // If we can't accelerate to our maximum (and decelerate again)
-      // within the target travel distance, calculate a the peak
-      // velocity we will reach and create a trajectory which ramps to
-      // that velocity and back down.
-      const double mid_distance = delta / 2;
-      const double mid_velocity =
-          kMaxVelocity * (mid_distance / kDistanceToMaxAccel);
-      const double mid_time = mid_velocity / kMaxAccel;
-      knots.push_back(Eigen::Vector2d(cur_position + mid_distance * direction,
-                                      mid_velocity * direction));
-      times.push_back(mid_time);
-      knots.push_back(Eigen::Vector2d(target_position, 0));
-      times.push_back(mid_time * 2);
-    } else {
-      knots.push_back(Eigen::Vector2d(
-          cur_position + (kDistanceToMaxAccel * direction),
-          kMaxVelocity * direction));
-      times.push_back(kTimeToMaxAccel);
-
-      const double time_at_max =
-          (delta - 2 * kDistanceToMaxAccel) / kMaxVelocity;
-      knots.push_back(Eigen::Vector2d(
-          target_position - (kDistanceToMaxAccel * direction),
-          kMaxVelocity * direction));
-      times.push_back(kTimeToMaxAccel + time_at_max);
-
-      knots.push_back(Eigen::Vector2d(target_position, 0));
-      times.push_back(kTimeToMaxAccel + time_at_max + kTimeToMaxAccel);
-    }
-    trajectory_.reset(new PiecewisePolynomialTrajectory(
-        PiecewisePolynomial<double>::FirstOrderHold(times, knots)));
-  }
-
-  /// The minimum change between the last received command and the
-  /// current command to trigger a trajectory update.  Based on
-  /// manually driving the actual gripper using the web interface, it
-  /// appears that it will at least attempt to respond to commands as
-  /// small as 0.1mm.
-  const double kTargetEpsilon = 0.0001;
-
-  const int position_index_{};
-  // TODO(sam.creasey) I'd prefer to store the trajectory as
-  // difference state, but unfortunately that's not currently possible
-  // as DifferenceState may only contain BasicVector.
-  mutable std::unique_ptr<Trajectory> trajectory_;
-};
-
-/// Sends status messages for a Schunk WSG.  This system has one input
-/// port for the current state of the plant.
-class SchunkWsgStatusSender : public systems::LeafSystem<double> {
- public:
-  SchunkWsgStatusSender(const RigidBodyTree<double>& tree,
-                        int position_index, int velocity_index)
-      : position_index_(position_index), velocity_index_(velocity_index) {
-    DRAKE_ASSERT(position_index_ < tree.get_num_positions());
-    DRAKE_ASSERT(velocity_index_ <
-                 tree.get_num_positions() + tree.get_num_velocities());
-    this->set_name("SchunkWsgStatusSender");
-    this->DeclareInputPort(
-        systems::kVectorValued,
-        tree.get_num_positions() + tree.get_num_velocities());
-    this->DeclareAbstractOutputPort();
-  }
-
-  std::unique_ptr<SystemOutput<double>> AllocateOutput(
-      const Context<double>& context) const override {
-    auto output = std::make_unique<systems::LeafSystemOutput<double>>();
-    lcmt_schunk_wsg_status msg{};
-    output->add_port(
-        std::make_unique<systems::Value<lcmt_schunk_wsg_status>>(msg));
-    return std::unique_ptr<SystemOutput<double>>(output.release());
-  }
-
-  void EvalOutput(const Context<double>& context,
-                  SystemOutput<double>* output) const override {
-    systems::AbstractValue* mutable_data = output->GetMutableData(0);
-    lcmt_schunk_wsg_status& status =
-        mutable_data->GetMutableValue<lcmt_schunk_wsg_status>();
-
-    status.utime = context.get_time() * 1e6;
-    const systems::BasicVector<double>* state =
-        this->EvalVectorInput(context, 0);
-    // The position and speed reported in this message are between the
-    // two fingers rather than the position/speed of a single finger
-    // (so effectively doubled).
-    status.actual_position_mm = -2 * state->GetAtIndex(position_index_) * 1e3;
-    // TODO(sam.creasey) Figure out how to get the actual force from
-    // the plant so that we can populate this field.
-    status.actual_force = 0;
-    status.actual_speed_mm_per_s =
-        -2 * state->GetAtIndex(velocity_index_) * 1e3;
-  }
-
- private:
-  const int position_index_{};
-  const int velocity_index_{};
-};
 
 template <typename T>
 class PidControlledSchunkWsg : public systems::Diagram<T> {
@@ -357,13 +127,15 @@ int DoMain() {
       systems::lcm::LcmSubscriberSystem::Make<lcmt_schunk_wsg_command>(
           "SCHUNK_WSG_COMMAND", &lcm));
   auto trajectory_generator = builder.AddSystem<SchunkWsgTrajectoryGenerator>(
-      tree, model->position_index());
+      tree.get_num_positions() + tree.get_num_velocities(),
+      model->position_index());
 
   auto status_pub = builder.AddSystem(
       systems::lcm::LcmPublisherSystem::Make<lcmt_schunk_wsg_status>(
           "SCHUNK_WSG_STATUS", &lcm));
   auto status_sender = builder.AddSystem<SchunkWsgStatusSender>(
-      tree, model->position_index(), model->velocity_index());
+      tree.get_num_positions() + tree.get_num_velocities(),
+      model->position_index(), model->velocity_index());
 
   builder.Connect(command_sub->get_output_port(0),
                   trajectory_generator->get_command_input_port());

--- a/drake/examples/schunk_wsg/test/CMakeLists.txt
+++ b/drake/examples/schunk_wsg/test/CMakeLists.txt
@@ -2,4 +2,8 @@ if(lcm_FOUND)
   drake_add_cc_test(simulated_schunk_wsg_system_test)
   target_link_libraries(simulated_schunk_wsg_system_test
     drakeSchunkWsg drakeSystemAnalysis)
+
+  drake_add_cc_test(schunk_wsg_lcm_test)
+  target_link_libraries(schunk_wsg_lcm_test
+    drakeSchunkWsg drakeSystemAnalysis)
 endif()

--- a/drake/examples/schunk_wsg/test/schunk_wsg_lcm_test.cc
+++ b/drake/examples/schunk_wsg/test/schunk_wsg_lcm_test.cc
@@ -1,0 +1,54 @@
+#include "drake/examples/schunk_wsg/schunk_wsg_lcm.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/lcmt_schunk_wsg_command.hpp"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/system_input.h"
+#include "drake/systems/framework/system_output.h"
+
+namespace drake {
+namespace examples {
+namespace schunk_wsg {
+namespace {
+
+GTEST_TEST(SchunkWsgLcmTest, SchunkWsgTrajectoryGeneratorTest) {
+  SchunkWsgTrajectoryGenerator dut(1, 0);
+  std::unique_ptr<systems::Context<double>> context =
+      dut.CreateDefaultContext();
+  std::unique_ptr<systems::SystemOutput<double>> output =
+      dut.AllocateOutput(*context);
+
+  // Start off with the gripper closed (zero) and a command to open to
+  // 100mm.
+  lcmt_schunk_wsg_command initial_command{};
+  initial_command.target_position_mm = 100;
+  initial_command.force = 40;
+  std::unique_ptr<systems::FreestandingInputPort> input_command =
+      std::make_unique<systems::FreestandingInputPort>(
+          std::make_unique<systems::Value<lcmt_schunk_wsg_command>>(
+              initial_command));
+  context->SetInputPort(0, std::move(input_command));
+  context->FixInputPort(1, Eigen::VectorXd::Zero(1));
+
+  // Step a little bit. We should be commanding a point on the
+  // trajectory wider than zero, but not to the target yet.
+  const double expected_target = -0.05;  // 50mm
+  systems::Simulator<double> simulator(dut, std::move(context));
+  simulator.StepTo(0.1);
+  dut.EvalOutput(simulator.get_context(), output.get());
+  EXPECT_LT(output->get_vector_data(0)->GetAtIndex(0), 0);
+  EXPECT_GT(output->get_vector_data(0)->GetAtIndex(0), expected_target);
+
+  // Step quite a bit longer and see that we get there.
+  simulator.StepTo(2.0);
+  dut.EvalOutput(simulator.get_context(), output.get());
+  EXPECT_FLOAT_EQ(output->get_vector_data(0)->GetAtIndex(0), expected_target);
+}
+
+}  // namespace
+}  // namespace schunk_wsg
+}  // namespace examples
+}  // namespace drake


### PR DESCRIPTION
Split the LCM-related stuff for the iiwa and the WSG into their own files instead of living with the rest of the simulation.

This is in support of an upcoming PR to create a combined LCM controlled iiwa+WSG simulation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4405)
<!-- Reviewable:end -->
