### PR TITLE
Method for converting a type to double.

### DIFF
--- a/drake/common/autodiff_overloads.h
+++ b/drake/common/autodiff_overloads.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
 
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>
@@ -135,6 +136,33 @@ const Eigen::AutoDiffScalar<DerType>& max(
 }  // namespace Eigen
 
 namespace drake {
+
+/// This struct converts an object of type T to a double. The default
+/// implementation returns NaN. Overloads provide sensible conversions.
+/// Note that we do not expect to be running simulations while instantiated
+/// with non-numerical scalar types!
+/// (We're using a struct here because partial instantiation does not work
+/// with function templates.)
+template <typename T>
+struct TtoDouble {
+  static double convert(const T&) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+};
+
+/// Partial specialization for AutoDiffScalar.
+template <typename DerType>
+struct TtoDouble<Eigen::AutoDiffScalar<DerType>> {
+  static double convert(const Eigen::AutoDiffScalar<DerType>& scalar) {
+    return static_cast<double>(scalar.value());
+  }
+};
+
+// Specializations for floating types.
+template <>
+struct TtoDouble<double> {
+  static double convert(const double& scalar) { return scalar; }
+};
 
 /// Provides if-then-else expression for Eigen::AutoDiffScalar type. To support
 /// Eigen's generic expressions, we use casting to the plain object after

--- a/drake/common/autodiff_overloads.h
+++ b/drake/common/autodiff_overloads.h
@@ -26,6 +26,7 @@
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/cond.h"
+#include "drake/common/drake_assert.h"
 
 namespace Eigen {
 
@@ -138,14 +139,14 @@ const Eigen::AutoDiffScalar<DerType>& max(
 namespace drake {
 
 /// This struct converts an object of type T to a double. The default
-/// implementation returns NaN. Overloads provide sensible conversions.
-/// Note that we do not expect to be running simulations while instantiated
-/// with non-numerical scalar types!
+/// implementation does a DRAKE_ABORT (and returns NaN, to make compilers
+/// happy). Overloads provide sensible conversions.
 /// (We're using a struct here because partial instantiation does not work
 /// with function templates.)
 template <typename T>
 struct TtoDouble {
   static double convert(const T&) {
+    DRAKE_ABORT();
     return std::numeric_limits<double>::quiet_NaN();
   }
 };

--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -28,7 +28,7 @@ GTEST_TEST(AutodiffOverloadsTest, TtoDouble) {
 
   // Test an arbitrary symbolic expression.
   drake::symbolic::Expression e;
-  EXPECT_TRUE(std::isnan(TtoDouble<drake::symbolic::Expression>::convert(e)));
+  EXPECT_DEATH(TtoDouble<drake::symbolic::Expression>::convert(e), ".");
 }
 
 // Tests correctness of isinf

--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/cond.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/symbolic_expression.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
@@ -15,6 +16,20 @@ using Eigen::VectorXd;
 namespace drake {
 namespace common {
 namespace {
+
+// Test correctness of TtoDouble
+GTEST_TEST(AutodiffOverloadsTest, TtoDouble) {
+  Eigen::AutoDiffScalar<Eigen::Vector2d> x;
+  x.value() = 0.0;
+  EXPECT_EQ(TtoDouble<Eigen::AutoDiffScalar<Eigen::Vector2d>>::convert(x), 0.0);
+
+  double y = 0.0;
+  EXPECT_EQ(TtoDouble<double>::convert(y), 0.0);
+
+  // Test an arbitrary symbolic expression.
+  drake::symbolic::Expression e;
+  EXPECT_TRUE(std::isnan(TtoDouble<drake::symbolic::Expression>::convert(e)));
+}
 
 // Tests correctness of isinf
 GTEST_TEST(AutodiffOverloadsTest, IsInf) {

--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -20,11 +20,11 @@ namespace {
 // Test correctness of TtoDouble
 GTEST_TEST(AutodiffOverloadsTest, TtoDouble) {
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;
-  x.value() = 0.0;
-  EXPECT_EQ(TtoDouble<Eigen::AutoDiffScalar<Eigen::Vector2d>>::convert(x), 0.0);
+  x.value() = 1.0;
+  EXPECT_EQ(TtoDouble<Eigen::AutoDiffScalar<Eigen::Vector2d>>::convert(x), 1.0);
 
-  double y = 0.0;
-  EXPECT_EQ(TtoDouble<double>::convert(y), 0.0);
+  double y = 1.0;
+  EXPECT_EQ(TtoDouble<double>::convert(y), 1.0);
 
   // Test an arbitrary symbolic expression.
   drake::symbolic::Expression e;

--- a/drake/systems/analysis/simulator.cc
+++ b/drake/systems/analysis/simulator.cc
@@ -9,35 +9,6 @@
 namespace drake {
 namespace systems {
 
-namespace {
-
-// This struct converts an object of type T to a double. The default
-// implementation returns NaN. Overloads provide sensible conversions.
-// Note that we do not expect to be running simulations while instantiated
-// with non-numerical scalar types!
-// (We're using a struct here because partial instantiation does not work
-// with function templates.)
-template <typename T>
-struct TtoDouble {
-  static double convert(const T&) {
-    return std::numeric_limits<double>::quiet_NaN();
-  }
-};
-// Partial specialization for AutoDiffScalar.
-template <typename DerType>
-struct TtoDouble<Eigen::AutoDiffScalar<DerType>> {
-  static double convert(const Eigen::AutoDiffScalar<DerType>& scalar) {
-    return static_cast<double>(scalar.value());
-  }
-};
-// Specializations for floating types.
-template <>
-struct TtoDouble<double> {
-  static double convert(const double& scalar) { return scalar; }
-};
-
-}  // namespace
-
 template <typename T>
 void Simulator<T>::PauseIfTooFast() const {
   if (target_realtime_rate_ <= 0) return;  // Run at full speed.


### PR DESCRIPTION
Using @sherm1's beautiful piece of code, this PR permits converting an arbitrary type to double, if possible, thereby avoiding compiler errors. Autodiff's and doubles are converted to double types; all other types are currently converted to NaN's, allowing undesirable conversions to be identified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4414)
<!-- Reviewable:end -->
