### PR TITLE
Add ExtractDoubleOrThrow and use it in Simulator

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -64,6 +64,17 @@ cc_library(
 )
 
 cc_library(
+    name = "extract_double",
+    hdrs = ["extract_double.h"],
+    linkstatic = 1,
+    deps = [
+        ":common",
+        ":nice_type_name",
+        ":number_traits",
+    ],
+)
+
+cc_library(
     name = "functional_form",
     srcs = ["functional_form.cc"],
     hdrs = ["functional_form.h"],

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -43,6 +43,7 @@ set(installed_headers
   eigen_matrix_compare.h
   eigen_stl_types.h
   eigen_types.h
+  extract_double.h
   functional_form.h
   hash.h
   is_approx_equal_abstol.h

--- a/drake/common/autodiff_overloads.h
+++ b/drake/common/autodiff_overloads.h
@@ -138,32 +138,12 @@ const Eigen::AutoDiffScalar<DerType>& max(
 
 namespace drake {
 
-/// This struct converts an object of type T to a double. The default
-/// implementation does a DRAKE_ABORT (and returns NaN, to make compilers
-/// happy). Overloads provide sensible conversions.
-/// (We're using a struct here because partial instantiation does not work
-/// with function templates.)
-template <typename T>
-struct TtoDouble {
-  static double convert(const T&) {
-    DRAKE_ABORT();
-    return std::numeric_limits<double>::quiet_NaN();
-  }
-};
-
-/// Partial specialization for AutoDiffScalar.
+/// Returns the autodiff scalar's value() as a double.  Never throws.
+/// Overloads ExtractDoubleOrThrow from common/extract_double.h.
 template <typename DerType>
-struct TtoDouble<Eigen::AutoDiffScalar<DerType>> {
-  static double convert(const Eigen::AutoDiffScalar<DerType>& scalar) {
-    return static_cast<double>(scalar.value());
-  }
-};
-
-// Specializations for floating types.
-template <>
-struct TtoDouble<double> {
-  static double convert(const double& scalar) { return scalar; }
-};
+double ExtractDoubleOrThrow(const Eigen::AutoDiffScalar<DerType>& scalar) {
+  return static_cast<double>(scalar.value());
+}
 
 /// Provides if-then-else expression for Eigen::AutoDiffScalar type. To support
 /// Eigen's generic expressions, we use casting to the plain object after

--- a/drake/common/extract_double.h
+++ b/drake/common/extract_double.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <stdexcept>
+
+#include "drake/common/nice_type_name.h"
+#include "drake/common/number_traits.h"
+
+namespace drake {
+
+/// Converts a ScalarType value to a double, failing at runtime (not compile
+/// time) if the type cannot be converted to a double.
+///
+/// This function is useful for writing ScalarType-generic code that (1) is
+/// only intended to be used on numeric types, (2) can reasonably discard any
+/// supplemental scalar data, e.g., the derivatives of an AutoDiffScalar, and
+/// (3) is reasonable to fail at runtime if called with a non-numeric
+/// ScalarType.
+///
+/// The default implementation throws an exception.  ScalarTypes that are
+/// numeric must overload this method to provide an appropriate extraction.
+/// An overload for `double` is already provided.
+///
+/// See autodiff_overloads.h to use this with Eigen's AutoDiffScalar.
+/// See number_traits.h for specifying which ScalarTypes are numeric.
+template <typename T>
+double ExtractDoubleOrThrow(const T& scalar) {
+  static_assert(!is_numeric<T>::value,
+                "Numeric scalar types should overload this function");
+  throw std::runtime_error(NiceTypeName::Get<T>() +
+                           " cannot be converted to a double");
+}
+
+/// Returns the @p scalar a double.  Never throws.
+inline double ExtractDoubleOrThrow(double scalar) { return scalar; }
+
+}  // namespace drake

--- a/drake/common/test/BUILD
+++ b/drake/common/test/BUILD
@@ -23,6 +23,7 @@ cc_test(
     deps = DEPS + [
         "//drake/common:autodiff",
         "//drake/common:eigen_matrix_compare",
+        "//drake/common:extract_double",
     ],
 )
 
@@ -78,6 +79,15 @@ cc_test(
     size = "small",
     srcs = ["eigen_stl_types_test.cc"],
     deps = DEPS,
+)
+
+cc_test(
+    name = "extract_double_test",
+    size = "small",
+    srcs = ["extract_double_test.cc"],
+    deps = DEPS + [
+        "//drake/common:extract_double",
+    ],
 )
 
 cc_test(

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -6,6 +6,9 @@ target_link_libraries(autodiff_overloads_test drakeCommon)
 drake_add_cc_test(double_overloads_test)
 target_link_libraries(double_overloads_test drakeCommon)
 
+drake_add_cc_test(extract_double_test)
+target_link_libraries(extract_double_test drakeCommon)
+
 drake_add_cc_test(functional_form_test)
 target_link_libraries(functional_form_test drakeCommon)
 

--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -8,7 +8,7 @@
 #include "drake/common/cond.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/symbolic_expression.h"
+#include "drake/common/extract_double.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
@@ -17,18 +17,16 @@ namespace drake {
 namespace common {
 namespace {
 
-// Test correctness of TtoDouble
-GTEST_TEST(AutodiffOverloadsTest, TtoDouble) {
+// Test ExtractDoubleOrThrow on autodiff.
+GTEST_TEST(AutodiffOverloadsTest, ExtractDouble) {
+  // On autodiff.
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;
   x.value() = 1.0;
-  EXPECT_EQ(TtoDouble<Eigen::AutoDiffScalar<Eigen::Vector2d>>::convert(x), 1.0);
+  EXPECT_EQ(ExtractDoubleOrThrow(x), 1.0);
 
+  // A double still works, too.
   double y = 1.0;
-  EXPECT_EQ(TtoDouble<double>::convert(y), 1.0);
-
-  // Test an arbitrary symbolic expression.
-  drake::symbolic::Expression e;
-  EXPECT_DEATH(TtoDouble<drake::symbolic::Expression>::convert(e), ".");
+  EXPECT_EQ(ExtractDoubleOrThrow(y), 1.0);
 }
 
 // Tests correctness of isinf

--- a/drake/common/test/extract_double_test.cc
+++ b/drake/common/test/extract_double_test.cc
@@ -1,0 +1,36 @@
+#include "drake/common/extract_double.h"
+
+#include <stdexcept>
+
+#include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+#include "gtest/gtest.h"
+
+// A non-numeric ScalarType for testing.
+namespace { struct NonNumericScalar { }; }
+namespace drake {
+template <>
+struct is_numeric<NonNumericScalar> {
+  static constexpr bool value = false;
+};
+}  // namespace drake
+
+namespace drake {
+namespace {
+
+GTEST_TEST(ExtractDoubleTest, BasicTest) {
+  // A double works.
+  double x = 1.0;
+  EXPECT_EQ(ExtractDoubleOrThrow(x), 1.0);
+
+  // A const double works.
+  const double y = 2.0;
+  EXPECT_EQ(ExtractDoubleOrThrow(y), 2.0);
+
+  // A non-numeric throws.
+  NonNumericScalar non_numeric;
+  EXPECT_THROW(ExtractDoubleOrThrow(non_numeric), std::exception);
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/systems/analysis/BUILD
+++ b/drake/systems/analysis/BUILD
@@ -8,5 +8,8 @@ cc_library(
     srcs = glob(["*.cc"]),
     hdrs = glob(["*.h"]),
     linkstatic = 1,
-    deps = ["//drake/systems/framework"],
+    deps = [
+        "//drake/common:extract_double",
+        "//drake/systems/framework",
+    ],
 )

--- a/drake/systems/analysis/simulator.cc
+++ b/drake/systems/analysis/simulator.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/extract_double.h"
 #include "drake/systems/analysis/simulator.h"
 
 namespace drake {
@@ -12,7 +13,7 @@ namespace systems {
 template <typename T>
 void Simulator<T>::PauseIfTooFast() const {
   if (target_realtime_rate_ <= 0) return;  // Run at full speed.
-  const double simtime_now = TtoDouble<T>::convert(get_context().get_time());
+  const double simtime_now = ExtractDoubleOrThrow(get_context().get_time());
   const double simtime_passed = simtime_now - initial_simtime_;
   const TimePoint desired_realtime =
       initial_realtime_ + Duration(simtime_passed / target_realtime_rate_);
@@ -24,7 +25,7 @@ void Simulator<T>::PauseIfTooFast() const {
 
 template <typename T>
 double Simulator<T>::get_actual_realtime_rate() const {
-  const double simtime_now = TtoDouble<T>::convert(get_context().get_time());
+  const double simtime_now = ExtractDoubleOrThrow(get_context().get_time());
   const double simtime_passed = simtime_now - initial_simtime_;
   const Duration realtime_passed = Clock::now() - initial_realtime_;
   const double rate = (simtime_passed / realtime_passed.count());
@@ -38,7 +39,7 @@ void Simulator<T>::ResetStatistics() {
   num_updates_ = 0;
   num_publishes_ = 0;
 
-  initial_simtime_ = TtoDouble<T>::convert(get_context().get_time());
+  initial_simtime_ = ExtractDoubleOrThrow(get_context().get_time());
   initial_realtime_ = Clock::now();
 }
 

--- a/drake/systems/analysis/test/my_spring_mass_system.h
+++ b/drake/systems/analysis/test/my_spring_mass_system.h
@@ -32,7 +32,7 @@ class MySpringMassSystem : public SpringMassSystem<T> {
 
  private:
   // Publish t q u to standard output.
-  void DoPublish(const Context<double> &context) const override {
+  void DoPublish(const Context<T>& context) const override {
     ++publish_count_;
   }
 
@@ -48,8 +48,8 @@ class MySpringMassSystem : public SpringMassSystem<T> {
   // time is exactly at a update time, we assume the update has been
   // done and return the following update time. That means we don't get a
   // sample at 0 but will get one at the end.
-  void DoCalcNextUpdateTime(const Context<double> &context,
-                            UpdateActions<T> *actions) const override {
+  void DoCalcNextUpdateTime(const Context<T>& context,
+                            UpdateActions<T>* actions) const override {
     if (update_rate_ <= 0.) {
       actions->time = std::numeric_limits<double>::infinity();
       return;

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -495,7 +495,7 @@ GTEST_TEST(SimulatorTest, UpdateThenPublishThenIntegrate) {
 GTEST_TEST(SimulatorTest, AutodiffBasic) {
   SpringMassSystem<AutoDiffXd> spring_mass(1., 1., 0.);
   Simulator<AutoDiffXd> simulator(spring_mass);
-  simulator.StepTo(1.0);
+  simulator.Initialize();
 }
 
 }  // namespace

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -491,6 +491,13 @@ GTEST_TEST(SimulatorTest, UpdateThenPublishThenIntegrate) {
   }
 }
 
+// A basic sanity check that AutoDiff works at all.
+GTEST_TEST(SimulatorTest, AutodiffBasic) {
+  SpringMassSystem<AutoDiffXd> spring_mass(1., 1., 0.);
+  Simulator<AutoDiffXd> simulator(spring_mass);
+  simulator.StepTo(1.0);
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Improvements over TtoDouble:
- Calling code mnemonic is simpler.
- Runtime failure is made clear by function name "OrThrow".
- Upon failure, the typename is printed in a nice exception message.
- Hopefully clearer documentation for users.
- Compile-time error if used on a numeric type that lacks a specialization.
- No more DeathTest for testing a user API.

Also adds Simulator unit test coverage.

Also fixes a few typos in MySpringMassSystem that showed up while testing an earlier, discarded spike.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4422)
<!-- Reviewable:end -->
