### PR TITLE
Don't export drake tests to superbuild (temporary)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,8 @@ option(SKIP_DRAKE_BUILD "Build external projects but not drake itself" OFF)
 # drake: For drake, list both compilation AND RUNTIME dependencies. Runtime
 # dependencies are needed because the drake project must configure only after
 # any dependencies used by MATLAB have been installed.
-drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS TEST MATLAB PYTHON
+# TODO: re-add TEST to drake flags when subprojects arrive
+drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS MATLAB PYTHON
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/drake
   BINARY_DIR ${PROJECT_BINARY_DIR}/drake
   CMAKE_ARGS


### PR DESCRIPTION
Temporarily remove the flag to export the tests from Drake proper to the superbuild. This will allow us, as a stop-gap until we get subprojects working, to submit the tests for everything else to CDash while still keeping at least "Drake" and "everything else" separated, and without running Drake's tests twice.

Once subprojects are working, we'll want to revert this change...

This doesn't get us director tests by itself, which will still need CI changes, but allows us to make the CI changes without running into either of the issues mentioned above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4428)
<!-- Reviewable:end -->
