### PR TITLE
add a piecewise quaternion trajectory based on slerp.

### DIFF
--- a/drake/common/trajectories/CMakeLists.txt
+++ b/drake/common/trajectories/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_with_exports(LIB_NAME drakeTrajectories SOURCE_FILES
     piecewise_polynomial.cc
     piecewise_polynomial_base.cc
     piecewise_polynomial_trajectory.cc
+    piecewise_quaternion.cc
     )
 target_link_libraries(drakeTrajectories drakeCommon)
 drake_install_libraries(drakeTrajectories)
@@ -14,6 +15,7 @@ drake_install_headers(
     piecewise_polynomial_base.h
     piecewise_polynomial_trajectory.h
     trajectory.h
+    piecewise_quaternion.h
     )
 drake_install_pkg_config_file(drake-trajectories
   TARGET drakeTrajectories

--- a/drake/common/trajectories/piecewise_function.h
+++ b/drake/common/trajectories/piecewise_function.h
@@ -51,4 +51,7 @@ class PiecewiseFunction {
   void checkScalarValued() const;
 
   PiecewiseFunction();
+
+ private:
+  int GetSegmentIndexRecursive(double time, int start, int end) const;
 };

--- a/drake/common/trajectories/piecewise_quaternion.cc
+++ b/drake/common/trajectories/piecewise_quaternion.cc
@@ -1,0 +1,121 @@
+#include "drake/common/trajectories/piecewise_quaternion.h"
+
+#include <algorithm>
+
+#include "drake/math/quaternion.h"
+
+namespace drake {
+
+template <typename Scalar>
+void PiecewiseQuaternionSlerp<Scalar>::ComputeAngularVelocities() {
+  if (quaternions_.empty()) return;
+
+  angular_velocities_.resize(quaternions_.size() - 1);
+
+  AngleAxis<Scalar> angle_axis_diff;
+  // Computes q[t+1] = q_delta * q[t] first, turn q_delta into an axis, which
+  // turns into an angular velocity.
+  for (size_t i = 1; i < quaternions_.size(); ++i) {
+    angle_axis_diff =
+        AngleAxis<Scalar>(quaternions_[i] * quaternions_[i - 1].inverse());
+    angular_velocities_[i - 1] =
+        angle_axis_diff.axis() * angle_axis_diff.angle() / getDuration(i - 1);
+  }
+}
+
+template <typename Scalar>
+void PiecewiseQuaternionSlerp<Scalar>::Initialize(
+    const std::vector<double>& breaks,
+    const eigen_aligned_std_vector<Quaternion<Scalar>>& quaternions) {
+  if (quaternions.size() != breaks.size()) {
+    throw std::runtime_error("Quaternions and breaks length mismatch.");
+  }
+  if (quaternions.size() < 2) {
+    throw std::runtime_error("Not enough quaternions for slerp.");
+  }
+  quaternions_.resize(breaks.size());
+
+  // Set to the closest wrt to the previous, also normalize.
+  for (size_t i = 0; i < quaternions.size(); ++i) {
+    if (i == 0) {
+      quaternions_[i] = quaternions[i].normalized();
+    } else {
+      quaternions_[i] =
+          math::ClosestQuaternion(quaternions_[i - 1], quaternions[i]);
+    }
+  }
+  ComputeAngularVelocities();
+}
+
+template <typename Scalar>
+PiecewiseQuaternionSlerp<Scalar>::PiecewiseQuaternionSlerp(
+    const std::vector<double>& breaks,
+    const eigen_aligned_std_vector<Quaternion<Scalar>>& quaternions)
+    : PiecewiseFunction(breaks) {
+  Initialize(breaks, quaternions);
+}
+
+template <typename Scalar>
+PiecewiseQuaternionSlerp<Scalar>::PiecewiseQuaternionSlerp(
+    const std::vector<double>& breaks,
+    const eigen_aligned_std_vector<Matrix3<Scalar>>& rot_matrices)
+    : PiecewiseFunction(breaks) {
+  eigen_aligned_std_vector<Quaternion<Scalar>> quaternions(rot_matrices.size());
+  for (size_t i = 0; i < rot_matrices.size(); ++i) {
+    quaternions[i] = Quaternion<Scalar>(rot_matrices[i]);
+  }
+  Initialize(breaks, quaternions);
+}
+
+template <typename Scalar>
+PiecewiseQuaternionSlerp<Scalar>::PiecewiseQuaternionSlerp(
+    const std::vector<double>& breaks,
+    const eigen_aligned_std_vector<AngleAxis<Scalar>>& ang_axes)
+    : PiecewiseFunction(breaks) {
+  eigen_aligned_std_vector<Quaternion<Scalar>> quaternions(ang_axes.size());
+  for (size_t i = 0; i < ang_axes.size(); ++i) {
+    quaternions[i] = Quaternion<Scalar>(ang_axes[i]);
+  }
+  Initialize(breaks, quaternions);
+}
+
+template <typename Scalar>
+double PiecewiseQuaternionSlerp<Scalar>::ComputeInterpTime(int segment_index,
+                                                           double time) const {
+  time = (time - getStartTime(segment_index)) / getDuration(segment_index);
+  time = std::max(time, 0.0);
+  time = std::min(time, 1.0);
+  return time;
+}
+
+template <typename Scalar>
+Quaternion<Scalar> PiecewiseQuaternionSlerp<Scalar>::orientation(
+    double t) const {
+  int segment_index = getSegmentIndex(t);
+  t = ComputeInterpTime(segment_index, t);
+
+  Quaternion<Scalar> q1 = quaternions_.at(segment_index)
+                              .slerp(t, quaternions_.at(segment_index + 1));
+
+  q1.normalize();
+
+  return q1;
+}
+
+template <typename Scalar>
+Vector3<Scalar> PiecewiseQuaternionSlerp<Scalar>::angular_velocity(
+    double t) const {
+  int segment_index = getSegmentIndex(t);
+
+  return angular_velocities_.at(segment_index);
+}
+
+template <typename Scalar>
+Vector3<Scalar> PiecewiseQuaternionSlerp<Scalar>::angular_acceleration(
+    double t) const {
+  return Vector3<Scalar>::Zero();
+}
+
+template class PiecewiseQuaternionSlerp<double>;
+
+}  // namespace drake

--- a/drake/common/trajectories/piecewise_quaternion.h
+++ b/drake/common/trajectories/piecewise_quaternion.h
@@ -12,9 +12,9 @@ namespace drake {
  * A class representing a trajectory for quaternions that are interpolated
  * using piecewise slerp (spherical linear interpolation).
  * All the orientation knots are expected to be with respect to the same
- * parent reference frame, i.e. q_i represents the rotation R^p_i,
- * where p is the parent frame. The world frame is a common choice for the
- * parent frame.
+ * parent reference frame, i.e. q_i represents the rotation R_PBi for the
+ * orientation of frame B at the ith knot in a fixed parent frame P.
+ * The world frame is a common choice for the parent frame.
  * The angular velocity and acceleration are also relative to the parent frame
  * and expressed in the parent frame.
  * Since there is a sign ambiguity when using quaternions to represent
@@ -25,8 +25,8 @@ namespace drake {
  *
  * @tparam Scalar, double.
  *
- * TODO(siyuan.feng): check if this works for AutoDiffScalar.
  */
+// TODO(siyuan.feng): check if this works for AutoDiffScalar.
 template <typename Scalar = double>
 class PiecewiseQuaternionSlerp : public PiecewiseFunction {
  public:

--- a/drake/common/trajectories/piecewise_quaternion.h
+++ b/drake/common/trajectories/piecewise_quaternion.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/eigen_stl_types.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/trajectories/piecewise_function.h"
+
+namespace drake {
+
+/**
+ * A class representing a trajectory for quaternions that are interpolated
+ * using piecewise slerp (spherical linear interpolation).
+ * All the orientation knots are expected to be with respect to the same
+ * parent reference frame, i.e. q_i represents the rotation R^p_i,
+ * where p is the parent frame. The world frame is a common choice for the
+ * parent frame.
+ * The angular velocity and acceleration are also relative to the parent frame
+ * and expressed in the parent frame.
+ * Since there is a sign ambiguity when using quaternions to represent
+ * orientation, namely q and -q represent the same orientation, the internal
+ * quaternion representations ensure that q_n.dot(q_{n+1}) >= 0.
+ * Another intuitive way to think about this is that consecutive quaternions
+ * have the shortest geodesic distance on the unit sphere.
+ *
+ * @tparam Scalar, double.
+ *
+ * TODO(siyuan.feng): check if this works for AutoDiffScalar.
+ */
+template <typename Scalar = double>
+class PiecewiseQuaternionSlerp : public PiecewiseFunction {
+ public:
+  PiecewiseQuaternionSlerp() {}
+
+  /*
+   * Builds a PiecewiseQuaternionSlerp.
+   * @throw if breaks and quaternions have different length,
+   * or breaks have length < 2.
+   */
+  PiecewiseQuaternionSlerp(
+      const std::vector<double>& breaks,
+      const eigen_aligned_std_vector<Quaternion<Scalar>>& quaternions);
+
+  /*
+   * Builds a PiecewiseQuaternionSlerp.
+   * @throw if breaks and rot_matrices have different length,
+   * or breaks have length < 2.
+   */
+  PiecewiseQuaternionSlerp(
+      const std::vector<double>& breaks,
+      const eigen_aligned_std_vector<Matrix3<Scalar>>& rot_matrices);
+
+  /*
+   * Builds a PiecewiseQuaternionSlerp.
+   * @throw if breaks and ang_axes have different length,
+   * or breaks have length < 2.
+   */
+  PiecewiseQuaternionSlerp(
+      const std::vector<double>& breaks,
+      const eigen_aligned_std_vector<AngleAxis<Scalar>>& ang_axes);
+
+  Eigen::Index rows() const override { return 4; }
+  Eigen::Index cols() const override { return 1; }
+
+  /**
+   * Interpolates orientation.
+   * @param t Time for interpolation.
+   * @return The interpolated quaternion at `t`.
+   */
+  Quaternion<Scalar> orientation(double t) const;
+
+  /**
+   * Interpolates angular velocity.
+   * @param t Time for interpolation.
+   * @return The interpolated angular velocity at `t`,
+   * which is constant per segment.
+   */
+  Vector3<Scalar> angular_velocity(double t) const;
+
+  /**
+   * Interpolates angular acceleration.
+   * @param t Time for interpolation.
+   * @return The interpolated angular acceleration at `t`,
+   * which is always zero for slerp.
+   */
+  Vector3<Scalar> angular_acceleration(double t) const;
+
+  /**
+   * Getter for the internal quaternion knots.
+   * Note: the returned quaternions might be different from the ones used for
+   * construction because the internal representations are set to always be
+   * the "closest" w.r.t to the previous one.
+   *
+   * @return the internal knot points.
+   */
+  const eigen_aligned_std_vector<Quaternion<Scalar>>& get_quaternion_knots()
+      const {
+    return quaternions_;
+  }
+
+ private:
+  // Initialize quaternions_ and computes angular velocity for each segment.
+  void Initialize(
+      const std::vector<double>& breaks,
+      const eigen_aligned_std_vector<Quaternion<Scalar>>& quaternions);
+
+  // Computes angular velocity for each segment.
+  void ComputeAngularVelocities();
+
+  // Computes the interpolation time within each segment. Result is in [0, 1].
+  double ComputeInterpTime(int segment_index, double time) const;
+
+  eigen_aligned_std_vector<Quaternion<Scalar>> quaternions_;
+  eigen_aligned_std_vector<Vector3<Scalar>> angular_velocities_;
+};
+
+}  // namespace drake

--- a/drake/common/trajectories/test/CMakeLists.txt
+++ b/drake/common/trajectories/test/CMakeLists.txt
@@ -1,3 +1,6 @@
+drake_add_cc_test(piecewise_function_test)
+target_link_libraries(piecewise_function_test drakeTrajectories)
+
 drake_add_cc_test(piecewise_polynomial_test)
 target_link_libraries(piecewise_polynomial_test drakeTrajectories)
 
@@ -9,3 +12,6 @@ target_link_libraries(piecewise_polynomial_trajectory_test drakeTrajectories)
 
 drake_add_cc_test(piecewise_polynomial_generation_test)
 target_link_libraries(piecewise_polynomial_generation_test drakeTrajectories)
+
+drake_add_cc_test(piecewise_quaternion_test)
+target_link_libraries(piecewise_quaternion_test drakeTrajectories drakeGeometryUtil)

--- a/drake/common/trajectories/test/piecewise_function_test.cc
+++ b/drake/common/trajectories/test/piecewise_function_test.cc
@@ -1,0 +1,89 @@
+#include "drake/common/trajectories/piecewise_function.h"
+
+#include <random>
+
+#include "drake/common/drake_assert.h"
+#include "gtest/gtest.h"
+
+// Dummy implementation of PiecewiseFunction to test the basic indexing
+// functions.
+class PiecewiseFunctionTester : public PiecewiseFunction {
+ public:
+  explicit PiecewiseFunctionTester(const std::vector<double>& times)
+      : PiecewiseFunction(times) { }
+  Eigen::Index rows() const { return 0; }
+  Eigen::Index cols() const { return 0; }
+};
+
+void TestPiecewiseFunctionTimeRelatedGetters(
+    const PiecewiseFunctionTester& traj,
+    const std::vector<double>& time) {
+  EXPECT_EQ(traj.getNumberOfSegments(), time.size() - 1);
+
+  EXPECT_EQ(traj.getStartTime(), time.front());
+  EXPECT_EQ(traj.getEndTime(), time.back());
+
+  // Check start / end / duration for each segment.
+  for (size_t i = 0; i < time.size() - 1; i++) {
+    EXPECT_EQ(traj.getStartTime(i), time[i]);
+    EXPECT_EQ(traj.getEndTime(i), time[i + 1]);
+    EXPECT_EQ(traj.getDuration(i), time[i + 1] - time[i]);
+  }
+
+  // Check returned segment times == given.
+  const std::vector<double>& ret_seg_times = traj.getSegmentTimes();
+  EXPECT_EQ(ret_seg_times.size(), time.size());
+  for (size_t i = 0; i < time.size(); i++) {
+    EXPECT_EQ(time[i], ret_seg_times[i]);
+  }
+
+  // Check getSegmentIndex works at the breaks, also epsilon from the
+  // breaks.
+  for (int i = 0; i < static_cast<int>(time.size()); i++) {
+    int idx = traj.getSegmentIndex(time[i]);
+    if (i == static_cast<int>(time.size()) - 1) {
+      EXPECT_EQ(idx, i - 1);
+    } else {
+      EXPECT_EQ(idx, i);
+    }
+
+    if (i != 0) {
+      double t_minus_eps = time[i] - 1e-10;
+      idx = traj.getSegmentIndex(t_minus_eps);
+      EXPECT_TRUE(t_minus_eps <= time[i]);
+      EXPECT_EQ(idx, i - 1);
+      EXPECT_TRUE(traj.getStartTime(idx) < t_minus_eps);
+    }
+  }
+
+  // Dense sample the time, and make sure the returned index is valid.
+  for (double t = time.front() - 0.1; t < time.back() + 0.1; t += 0.01) {
+    int idx = traj.getSegmentIndex(t);
+    EXPECT_GE(idx, 0);
+    EXPECT_LT(idx, traj.getNumberOfSegments());
+
+    if (t >= traj.getStartTime() && t <= traj.getEndTime()) {
+      EXPECT_TRUE(t >= traj.getStartTime(idx));
+      EXPECT_TRUE(t <= traj.getEndTime(idx));
+    }
+  }
+}
+
+GTEST_TEST(PiecewiseFunctionTest, RandomizedGetIndexTest) {
+  int N = 100000;
+  std::default_random_engine generator(123);
+  std::vector<double> time =
+      PiecewiseFunction::randomSegmentTimes(N - 1, generator);
+
+  PiecewiseFunctionTester traj(time);
+
+  TestPiecewiseFunctionTimeRelatedGetters(traj, time);
+}
+
+GTEST_TEST(PiecewiseFunctionTest, GetIndexTest) {
+  std::vector<double> time = {0, 1, 2, 3.5};
+
+  PiecewiseFunctionTester traj(time);
+
+  TestPiecewiseFunctionTimeRelatedGetters(traj, time);
+}

--- a/drake/common/trajectories/test/piecewise_quaternion_test.cc
+++ b/drake/common/trajectories/test/piecewise_quaternion_test.cc
@@ -1,0 +1,169 @@
+#include "drake/common/trajectories/piecewise_quaternion.h"
+
+#include <random>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/util/drakeGeometryUtil.h"
+#include "gtest/gtest.h"
+
+namespace drake {
+namespace {
+
+// Returns q1 = quat(omega * dt) * q0
+template <typename Scalar>
+Quaternion<double> EulerIntegrateQuaternion(const Quaternion<Scalar>& q0,
+                                            const Vector3<Scalar>& omega,
+                                            double dt) {
+  Vector3<Scalar> delta = omega * dt;
+  Quaternion<Scalar> q1;
+
+  if (delta.norm() < Eigen::NumTraits<Scalar>::epsilon()) {
+    q1 = q0;
+  } else {
+    Quaternion<Scalar> q_delta =
+        Quaternion<Scalar>(AngleAxis<Scalar>(delta.norm(), delta.normalized()));
+    q1 = q_delta * q0;
+  }
+  q1.normalize();
+  return q1;
+}
+
+// Checks q[n].dot(q[n-1]) >= 0
+template <typename Scalar>
+bool CheckClosest(
+    const eigen_aligned_std_vector<Quaternion<Scalar>>& quaternions) {
+  if (quaternions.size() <= 1) return true;
+  for (size_t i = 1; i < quaternions.size(); ++i) {
+    if (quaternions[i].dot(quaternions[i - 1]) < 0) return false;
+  }
+  return true;
+}
+
+// Let i be the head of the segment where t falls in.
+// Checks spline.orientation(t) = quat(omega_i * (t - t_i)) * q_i
+template <typename Scalar>
+bool CheckSlerpInterpolation(const PiecewiseQuaternionSlerp<Scalar>& spline,
+                             double t) {
+  t = std::min(t, spline.getEndTime());
+  t = std::max(t, spline.getStartTime());
+
+  int i = spline.getSegmentIndex(t);
+  double t0 = spline.getStartTime(i);
+  double t1 = spline.getEndTime(i);
+  t = std::min(t, t1);
+  t = std::max(t, t0);
+  double dt = t - t0;
+  DRAKE_DEMAND(dt <= spline.getDuration(i));
+
+  Quaternion<Scalar> q_spline = spline.orientation(t);
+
+  Quaternion<Scalar> q0 = spline.orientation(t0);
+  Vector3<Scalar> w0 = spline.angular_velocity(t0);
+  Quaternion<Scalar> q1 = EulerIntegrateQuaternion(q0, w0, dt);
+
+  if (q_spline.isApprox(q1, 1e-10))
+    return true;
+  else
+    return false;
+}
+
+// Generates a vector of random orientation using randomized axis angles.
+template <typename Scalar>
+eigen_aligned_std_vector<Quaternion<Scalar>> GenerateRandomQuaternions(
+    int size, std::default_random_engine* generator) {
+  DRAKE_DEMAND(size >= 0);
+  eigen_aligned_std_vector<Quaternion<Scalar>> ret(size);
+  std::uniform_real_distribution<double> uniform(-10, 10);
+  for (int i = 0; i < size; ++i) {
+    ret[i] = Quaternion<Scalar>(AngleAxis<Scalar>(
+        uniform(*generator),
+        Vector3<Scalar>(uniform(*generator), uniform(*generator),
+                        uniform(*generator))));
+  }
+  return ret;
+}
+
+// Tests CheckSlerpInterpolation and "closestness" for PiecewiseQuaternionSlerp
+// generated from random breaks and knots.
+GTEST_TEST(TestPiecewiseQuaternionSlerp,
+           TestRandomizedPiecewiseQuaternionSlerp) {
+  std::default_random_engine generator(123);
+  int N = 10000;
+  std::vector<double> time =
+      PiecewiseFunction::randomSegmentTimes(N - 1, generator);
+  eigen_aligned_std_vector<Quaternion<double>> quat =
+      GenerateRandomQuaternions<double>(N, &generator);
+
+  PiecewiseQuaternionSlerp<double> rot_spline(time, quat);
+
+  // Check dense interpolated quaternions.
+  for (double t = time.front(); t < time.back(); t += 0.01) {
+    EXPECT_TRUE(CheckSlerpInterpolation(rot_spline, t));
+  }
+
+  EXPECT_TRUE(CheckClosest(rot_spline.get_quaternion_knots()));
+}
+
+// Tests when the given quaternions are not "closest" to the previous one.
+// Also tests the returned angular velocity against known values.
+GTEST_TEST(TestPiecewiseQuaternionSlerp,
+           TestShortestQuaternionPiecewiseQuaternionSlerp) {
+  std::vector<double> time = {0, 1.6, 2.32};
+  std::vector<double> ang = {1, 2.4 - 2 * M_PI, 5.3};
+  Vector3<double> axis = Vector3<double>(1, 2, 3).normalized();
+  eigen_aligned_std_vector<Quaternion<double>> quat(ang.size());
+  for (size_t i = 0; i < ang.size(); ++i) {
+    quat[i] = Quaternion<double>(AngleAxis<double>(ang[i], axis));
+  }
+
+  PiecewiseQuaternionSlerp<double> rot_spline(time, quat);
+  const eigen_aligned_std_vector<Quaternion<double>>& internal_quat =
+      rot_spline.get_quaternion_knots();
+
+  EXPECT_TRUE(CheckClosest(internal_quat));
+  EXPECT_FALSE(CheckClosest(quat));
+
+  for (size_t i = 0; i < time.size() - 1; ++i) {
+    EXPECT_TRUE(CompareMatrices(rot_spline.orientation(time[i]).coeffs(),
+                                internal_quat[i].coeffs(), 1e-10,
+                                MatrixCompareType::absolute));
+    double omega = angleDiff(ang[i], ang[i + 1]) / (time[i + 1] - time[i]);
+    EXPECT_TRUE(CompareMatrices(rot_spline.angular_velocity(time[i]),
+                                omega * axis, 1e-10,
+                                MatrixCompareType::absolute));
+  }
+
+  // Check dense interpolated quaternions.
+  for (double t = time.front(); t < time.back(); t += 0.01) {
+    EXPECT_TRUE(CheckSlerpInterpolation(rot_spline, t));
+  }
+}
+
+GTEST_TEST(TestPiecewiseQuaternionSlerp,
+           TestIdenticalPiecewiseQuaternionSlerp) {
+  std::vector<double> time = {0, 1.6};
+  std::vector<double> ang = {-1.3, -1.3 + 2 * M_PI};
+  Vector3<double> axis = Vector3<double>(1, 2, 3).normalized();
+  eigen_aligned_std_vector<Quaternion<double>> quat(ang.size());
+  for (size_t i = 0; i < ang.size(); ++i) {
+    quat[i] = Quaternion<double>(AngleAxis<double>(ang[i], axis));
+  }
+  PiecewiseQuaternionSlerp<double> rot_spline(time, quat);
+
+  double t = 0.3 * time[0] + 0.7 * time[1];
+
+  const eigen_aligned_std_vector<Quaternion<double>>& internal_quats =
+      rot_spline.get_quaternion_knots();
+  EXPECT_TRUE(CompareMatrices(
+      rot_spline.orientation(t).coeffs(),
+      internal_quats[0].coeffs(), 1e-10,
+      MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(
+      rot_spline.orientation(t).coeffs(),
+      internal_quats[1].coeffs(), 1e-10,
+      MatrixCompareType::absolute));
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/math/quaternion.h
+++ b/drake/math/quaternion.h
@@ -14,6 +14,21 @@
 
 namespace drake {
 namespace math {
+
+/**
+ * Returns a unit quaternion that represents the same orientation as `q1`,
+ * and has the "shortest" geodesic distance on the unit sphere to `q0`.
+ */
+template <typename Scalar> Eigen::Quaternion<Scalar> ClosestQuaternion(
+    const Eigen::Quaternion<Scalar>& q0,
+    const Eigen::Quaternion<Scalar>& q1) {
+  Eigen::Quaternion<Scalar> q = q1;
+  if (q0.dot(q) < 0)
+    q.coeffs() *= -1;
+  q.normalize();
+  return q;
+}
+
 template <typename Derived>
 Vector4<typename Derived::Scalar> quatConjugate(
     const Eigen::MatrixBase<Derived>& q) {


### PR DESCRIPTION
1. add a piecewise quaternion trajectory based on slerp.
2. also changed the getSegmentIndex to binary search on time instead of
linear serach.

@hongkai-dai for feature review, @tkoolen for opinions. thanks guys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4432)
<!-- Reviewable:end -->
