### PR TITLE
Revert "Use NumTraits::Literal rather than ::Real"

### DIFF
--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -1,7 +1,5 @@
 #include "drake/common/autodiff_overloads.h"
 
-#include <type_traits>
-
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>
 
@@ -305,23 +303,6 @@ GTEST_TEST(AutodiffOverloadsTest, Cond9) {
   EXPECT_DOUBLE_EQ(z.value(), x.value() * x.value());
   EXPECT_DOUBLE_EQ(z.derivatives()[0], 2 * 2 * x.value());
   EXPECT_DOUBLE_EQ(z.derivatives()[1], 2 * x.value());
-}
-
-// This is just a sanity check to make sure that Eigen::NumTraits::Literal
-// is the right way to dig through an AutoDiffScalar to find the underlying
-// floating point type. If this compiles it succeeds.
-GTEST_TEST(AutodiffOverloadsTest, CheckEigenLiteral) {
-  using DerTyped = Eigen::Vector2d;
-  using DerTypef = Eigen::Vector2f;
-  using Td = Eigen::AutoDiffScalar<DerTyped>;
-  using Tf = Eigen::AutoDiffScalar<DerTypef>;
-
-  using Literald = typename Eigen::NumTraits<Td>::Literal;
-  using Literalf = typename Eigen::NumTraits<Tf>::Literal;
-
-  static_assert(std::is_same<Literald, double>::value &&
-                    std::is_same<Literalf, float>::value,
-                "Eigen::NumTraits<T>::Literal didn't behave as expected.");
 }
 
 }  // namespace

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -434,7 +434,7 @@ void Simulator<T>::StepTo(const T& boundary_time) {
     // How far can we go before we have to take a sampling break?
     const T next_sample_time =
         system_.CalcNextUpdateTime(*context_, &update_actions);
-    DRAKE_DEMAND(next_sample_time >= step_start_time);
+    DRAKE_ASSERT(next_sample_time >= step_start_time);
 
     // Determine whether the DiscreteEvent requested by the System at
     // next_sample_time includes an Update action, a Publish action, or both.

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -496,7 +496,6 @@ GTEST_TEST(SimulatorTest, AutodiffBasic) {
   SpringMassSystem<AutoDiffXd> spring_mass(1., 1., 0.);
   Simulator<AutoDiffXd> simulator(spring_mass);
   simulator.Initialize();
-  simulator.StepTo(1);
 }
 
 }  // namespace

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -29,7 +29,7 @@ class BasicVector : public VectorBase<T> {
   explicit BasicVector(int size)
       : values_(VectorX<T>::Constant(
             size, std::numeric_limits<
-                      typename Eigen::NumTraits<T>::Literal>::quiet_NaN())) {}
+                      typename Eigen::NumTraits<T>::Real>::quiet_NaN())) {}
 
   /// Constructs a BasicVector with the specified @p data.
   explicit BasicVector(const VectorX<T>& data) : values_(data) {}

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -290,7 +290,7 @@ class LeafSystem : public System<T> {
   typename std::enable_if<is_numeric<T1>::value>::type DoCalcNextUpdateTimeImpl(
       const Context<T1>& context, UpdateActions<T1>* actions) const {
     T1 min_time =
-        std::numeric_limits<typename Eigen::NumTraits<T1>::Literal>::infinity();
+        std::numeric_limits<typename Eigen::NumTraits<T1>::Real>::infinity();
     if (periodic_events_.empty()) {
       // No discrete update.
       actions->time = min_time;


### PR DESCRIPTION
Reverts RobotLocomotion/drake#4431

This may have broken OS X nightly debug builds.  Reverting to test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4438)
<!-- Reviewable:end -->
