### PR TITLE
clean up adding lorentz cone in gurobi

### DIFF
--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -94,7 +94,7 @@ int AddSecondOrderConeConstraints(
         GRBsetdblattrelement(model, GRB_DBL_ATTR_LB, variable_indices[0], 0.0);
     if (error) return error;
     if (is_rotated_cone) {
-      int error = GRBsetdblattrelement(model, GRB_DBL_ATTR_LB,
+      error = GRBsetdblattrelement(model, GRB_DBL_ATTR_LB,
                                        variable_indices[1], 0.0);
       if (error) return error;
     }

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -73,7 +73,7 @@ int AddLinearConstraint(GRBmodel* model, const Eigen::MatrixBase<DerivedA>& A,
 template <typename Binding>
 int AddSecondOrderConeConstraints(
     const std::vector<Binding>& second_order_cone_constraints,
-    bool is_rotated_cone, double sparseness_threshold, GRBmodel* model) {
+    bool is_rotated_cone, GRBmodel* model) {
   for (const auto& binding : second_order_cone_constraints) {
     int num_constraint_variable = static_cast<int>(binding.GetNumElements());
     std::vector<int> variable_indices;
@@ -424,14 +424,14 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   // Add Lorentz cone constraints.
   if (!error) {
     error = AddSecondOrderConeConstraints(prog.lorentz_cone_constraints(),
-                                          false, sparseness_threshold, model);
+                                          false, model);
   }
 
   // Add rotated Lorentz cone constraints.
   if (!error) {
     error =
         AddSecondOrderConeConstraints(prog.rotated_lorentz_cone_constraints(),
-                                      true, sparseness_threshold, model);
+                                      true, model);
   }
 
   SolutionResult result = SolutionResult::kUnknownError;

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -86,6 +86,7 @@ int AddSecondOrderConeConstraints(
       }
     }
     int num_x = static_cast<int>(variable_indices.size());
+    DRAKE_DEMAND(num_x >= (is_rotated_cone ? 3 : 2));
 
     // Set the lower bound for the second order conic variables.
     // If using Lorentz cone, x(0) >= 0

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -225,6 +225,7 @@ void MathematicalProgram::AddConstraint(
     std::shared_ptr<LorentzConeConstraint> con, const VariableListRef& vars) {
   VariableList var_list(vars);
   DRAKE_ASSERT(var_list.column_vectors_only());
+  DRAKE_ASSERT(var_list.size() >= 2);
   required_capabilities_ |= kLorentzConeConstraint;
   lorentz_cone_constraint_.push_back(
       Binding<LorentzConeConstraint>(con, var_list));
@@ -242,6 +243,7 @@ void MathematicalProgram::AddConstraint(
     const VariableListRef& vars) {
   VariableList var_list(vars);
   DRAKE_ASSERT(var_list.column_vectors_only());
+  DRAKE_ASSERT(var_list.size() >= 3);
   required_capabilities_ |= kRotatedLorentzConeConstraint;
   rotated_lorentz_cone_constraint_.push_back(
       Binding<RotatedLorentzConeConstraint>(con, var_list));


### PR DESCRIPTION
Add a function in `gurobi_solver`, to remove the duplicated code when adding Lorentz cone and rotated Lorentz cone constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4444)
<!-- Reviewable:end -->
