### PR TITLE
fix a end slope = 0 edge case for pchip

### DIFF
--- a/drake/common/trajectories/piecewise_function.cc
+++ b/drake/common/trajectories/piecewise_function.cc
@@ -1,6 +1,7 @@
 #include "drake/common/trajectories/piecewise_function.h"
 
 #include <algorithm>
+#include <cmath>
 #include <stdexcept>
 
 using std::uniform_real_distribution;
@@ -10,8 +11,8 @@ PiecewiseFunction::PiecewiseFunction(
     std::vector<double> const& segment_times_in)
     : segment_times(segment_times_in) {
   for (int i = 1; i < getNumberOfSegments() + 1; i++) {
-    if (segment_times[i] < segment_times[i - 1])
-      throw std::runtime_error("times must be increasing");
+    if (segment_times[i] - segment_times[i - 1] < kEpsilonTime)
+      throw std::runtime_error("times must be increasing.");
   }
 }
 

--- a/drake/common/trajectories/piecewise_function.h
+++ b/drake/common/trajectories/piecewise_function.h
@@ -9,6 +9,8 @@ class PiecewiseFunction {
   std::vector<double> segment_times;
 
  public:
+  static constexpr double kEpsilonTime = 1e-10;
+
   explicit PiecewiseFunction(std::vector<double> const& segment_times);
 
   virtual ~PiecewiseFunction();

--- a/drake/common/trajectories/piecewise_function.h
+++ b/drake/common/trajectories/piecewise_function.h
@@ -9,8 +9,11 @@ class PiecewiseFunction {
   std::vector<double> segment_times;
 
  public:
+  /// Minimum delta quantity used for comparing time.
   static constexpr double kEpsilonTime = 1e-10;
 
+  /// @throws std::runtime_exception if `segment_times`'s increments are
+  /// smaller than kEpsilonTime.
   explicit PiecewiseFunction(std::vector<double> const& segment_times);
 
   virtual ~PiecewiseFunction();
@@ -42,7 +45,8 @@ class PiecewiseFunction {
       int num_segments, std::default_random_engine& generator);
 
  protected:
-  bool segmentTimesEqual(const PiecewiseFunction& b, double tol) const;
+  bool segmentTimesEqual(const PiecewiseFunction& b,
+      double tol = kEpsilonTime) const;
 
   void checkScalarValued() const;
 

--- a/drake/common/trajectories/piecewise_polynomial.h
+++ b/drake/common/trajectories/piecewise_polynomial.h
@@ -281,6 +281,8 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
                                       Eigen::Index row, Eigen::Index col) const;
 
  private:
+  static constexpr CoefficientType kSlopeEpsilon = 1e-10;
+
   // a PolynomialMatrix for each piece (segment)
   std::vector<PolynomialMatrix> polynomials_;
 

--- a/drake/common/trajectories/piecewise_polynomial.h
+++ b/drake/common/trajectories/piecewise_polynomial.h
@@ -240,24 +240,44 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
 
   Eigen::Index cols() const override;
 
+  /// @throws std::runtime_error if other.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   PiecewisePolynomial& operator+=(const PiecewisePolynomial& other);
 
+  /// @throws std::runtime_error if other.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   PiecewisePolynomial& operator-=(const PiecewisePolynomial& other);
 
+  /// @throws std::runtime_error if other.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   PiecewisePolynomial& operator*=(const PiecewisePolynomial& other);
 
+  /// @throws std::runtime_error if offset.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   PiecewisePolynomial& operator+=(const CoefficientMatrix& offset);
 
+  /// @throws std::runtime_error if offset.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   PiecewisePolynomial& operator-=(const CoefficientMatrix& offset);
 
+  /// @throws std::runtime_error if other.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   const PiecewisePolynomial operator+(const PiecewisePolynomial& other) const;
 
+  /// @throws std::runtime_error if other.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   const PiecewisePolynomial operator-(const PiecewisePolynomial& other) const;
 
+  /// @throws std::runtime_error if other.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   const PiecewisePolynomial operator*(const PiecewisePolynomial& other) const;
 
+  /// @throws std::runtime_error if offset.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   const PiecewisePolynomial operator+(const CoefficientMatrix& offset) const;
 
+  /// @throws std::runtime_error if offset.segment_times is not within
+  /// PiecewiseFunction::kEpsilonTime from this->segment_times.
   const PiecewisePolynomial operator-(const CoefficientMatrix& offset) const;
 
   /// Checks if a PiecewisePolynomial is approximately equal to this one.

--- a/drake/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -288,6 +288,22 @@ GTEST_TEST(SplineTests, PchipAndCubicSplineCompareWithMatlabTest) {
   EXPECT_TRUE(CheckContinuity(spline, 1e-12, 2));
   EXPECT_TRUE(CheckValues(spline, {Y}, 1e-12));
   EXPECT_TRUE(CheckInterpolatedValuesAtBreakTime(spline, T, Y, 1e-12));
+
+  // Add special case for pchip to test for the last two knots being the same.
+  // There was a sign comparison bug in ComputePchipEndSlope when the end
+  // slope = 0.
+  T = {0, 1, 2};
+  Y.resize(T.size(), MatrixX<double>::Zero(1, 1));
+  Y[0](0, 0) = 1;
+  Y[1](0, 0) = 3;
+  Y[2](0, 0) = 3;
+  spline = PiecewisePolynomial<double>::Pchip(T, Y);
+  EXPECT_TRUE(CompareMatrices(
+      spline.getPolynomialMatrix(0)(0, 0).GetCoefficients(),
+      Vector4<double>(1, 3, 0, -1), 1e-12, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(
+      spline.getPolynomialMatrix(1)(0, 0).GetCoefficients(),
+      Vector4<double>(3, 0, 0, 0), 1e-12, MatrixCompareType::absolute));
 }
 
 GTEST_TEST(SplineTests, RandomizedLinearSplineTest) {

--- a/drake/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -291,7 +291,7 @@ GTEST_TEST(SplineTests, PchipAndCubicSplineCompareWithMatlabTest) {
 
   // Add special case for pchip to test for the last two knots being the same.
   // There was a sign comparison bug in ComputePchipEndSlope when the end
-  // slope = 0.
+  // slope = 0. See issue #4450.
   T = {0, 1, 2};
   Y.resize(T.size(), MatrixX<double>::Zero(1, 1));
   Y[0](0, 0) = 1;


### PR DESCRIPTION
there was a sign comparison bug in 
ComputePchipEndSlope, which would cause undesired behavior when the last two knots, but not the second to last are the same (i.e. 1 2 2). The correct behavior is to have the end slope = 0, which the previous code violated. 

also changed magic number for dt comparison to 1e-10 defined in piecewise_function. 

@hongkai-dai for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4450)
<!-- Reviewable:end -->
