### PR TITLE
Fix memcheck issues as noted by Bazel

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -138,7 +138,11 @@ cc_binary(
 
 cc_binary(
     name = "car_sim_lcm",
-    srcs = ["car_sim_lcm.cc"],
+    srcs = [
+        "car_sim_lcm.cc",
+        "car_sim_lcm_common.cc",
+        "car_sim_lcm_common.h",
+    ],
     linkstatic = 1,
     deps = [
         ":automotive_simulator",

--- a/drake/automotive/test/BUILD
+++ b/drake/automotive/test/BUILD
@@ -10,6 +10,7 @@ cc_test(
     size = "small",
     srcs = ["automotive_simulator_test.cc"],
     data = ["//drake/automotive:models"],
+    local = 1,
     deps = DEPS + [
         "//drake/automotive:automotive_simulator",
         "//drake/lcm:mock",

--- a/drake/lcm/test/BUILD
+++ b/drake/lcm/test/BUILD
@@ -34,5 +34,6 @@ cc_test(
     name = "lcm_call_matlab_test",
     size = "small",
     srcs = ["lcm_call_matlab_test.cc"],
+    local = 1,
     deps = DEPS + ["//drake/lcm:lcm_call_matlab"],
 )

--- a/drake/systems/controllers/test/linear_quadratic_regulator_test.cc
+++ b/drake/systems/controllers/test/linear_quadratic_regulator_test.cc
@@ -8,13 +8,12 @@
 namespace drake {
 
 GTEST_TEST(TestLQR, TestException) {
-  Eigen::Matrix2d A;
-  Eigen::Vector2d B;
+  Eigen::Matrix2d A = Eigen::Matrix2d::Zero();
+  Eigen::Vector2d B = Eigen::Vector2d::Zero();
 
   Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
-  Eigen::Matrix<double, 1, 1> R;
+  Eigen::Matrix<double, 1, 1> R = Eigen::MatrixXd::Identity(1, 1);
   Eigen::Vector2d N = Eigen::Vector2d::Zero();
-  R << 1;
 
   EXPECT_NO_THROW(systems::LinearQuadraticRegulator(A, B, Q, R, N));
   EXPECT_NO_THROW(systems::LinearQuadraticRegulator(A, B, Q, R));

--- a/tools/valgrind.sh
+++ b/tools/valgrind.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Disable GTest death test use of clone() because it confuses valgrind.
+export GTEST_DEATH_TEST_USE_FORK=1
+
 valgrind \
     --leak-check=full \
     --suppressions="tools/valgrind.supp" \


### PR DESCRIPTION
Tests that use real LCM require real network, and fail memcheck if they don't have it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4453)
<!-- Reviewable:end -->
