### PR TITLE
fixes SteeringCommandDriver.py throttle not being able to decrease

### DIFF
--- a/drake/automotive/README.md
+++ b/drake/automotive/README.md
@@ -52,7 +52,7 @@ Start Drake's Simulator
 Open a new terminal and execute the following:
 
 ```
-$ drake-distro/build/drake/automotive/car_sim_lcm
+$ drake-distro/build/drake/bin/car_sim_lcm
 ```
 
 Additional Simulation Notes

--- a/drake/automotive/README.md
+++ b/drake/automotive/README.md
@@ -52,7 +52,7 @@ Start Drake's Simulator
 Open a new terminal and execute the following:
 
 ```
-$ drake-distro/build/drake/bin/car_sim_lcm
+$ drake-distro/build/drake/automotive/car_sim_lcm
 ```
 
 Additional Simulation Notes

--- a/drake/automotive/steering_command_driver.py
+++ b/drake/automotive/steering_command_driver.py
@@ -45,8 +45,7 @@ def _limit_steering(requested_value):
     else:
         return math.copysign(MAX_STEERING_ANGLE, requested_value)
 
-# since there are both throttle and brake values, both of them should be 
-# non-negative
+# Since there are both throttle and brake values, they should be non-negative.
 def _limit_throttle(requested_value):
     if 0 <= requested_value <= MAX_VELOCITY:
         return requested_value
@@ -76,7 +75,6 @@ class KeyboardEventProcessor:
         new_msg = copy.copy(last_msg)
 
         if (event.type == pygame.KEYUP) and not self.keepCurrentThrottleBrake:
-            # if the KEYUP event is trigured by a real key releasing
             if hasattr(event, 'key'):
                 if (event.key == pygame.K_SPACE):
                     self.keepCurrentThrottleBrake = True
@@ -84,10 +82,11 @@ class KeyboardEventProcessor:
                 if (event.key == pygame.K_UP):
                     self.throttle_gradient = -1
                 elif (event.key == pygame.K_DOWN):
-                    self.brake_gradient = -1
-            # if there is not a KEYDOWN event waiting in the queue
+                    self.brake_gradient = -1 
+            # Post a fake KEYUP event so that the throttle/brake can keep 
+            # decreasing in the absence of real (and impossible) successive 
+            # key releasing. Yield to any KEYDOWN event waiting in the queue. 
             if not pygame.event.peek(pygame.KEYDOWN): 
-                # creates a fake KEYUP event to force the loop
                 dummyKeyUpEvent = pygame.event.Event(pygame.KEYUP)
                 pygame.event.post(dummyKeyUpEvent)
 
@@ -166,7 +165,8 @@ class SteeringCommandPublisher:
             self.event_processor = KeyboardEventProcessor()
             print bcolors.OKBLUE + '--- Keyboard Control Instruction --- '\
                     + bcolors.ENDC
-            print 'To increase the throttle/brake: press and hold the Up/Down Arrow'
+            print 'To increase the throttle/brake: press and hold the Up/Down'\
+                    + ' Arrow'
             print 'To decrease the throttle/brake: release the Up/Down Arrow'
             print 'To keep the the current throttle/brake: press the Space Bar'
             print 'To increase left/right steering: press the Left/Right Arrow'

--- a/drake/automotive/steering_command_driver.py
+++ b/drake/automotive/steering_command_driver.py
@@ -150,6 +150,11 @@ class JoystickEventProcessor:
         return new_msg
 
 
+
+class bcolors:
+    OKBLUE = '\033[94m'
+    ENDC = '\033[0m'
+
 class SteeringCommandPublisher:
     def __init__(self, input_method, lcm_tag, joy_name):
         print 'Initializing...'
@@ -159,6 +164,14 @@ class SteeringCommandPublisher:
         self.font = pygame.font.SysFont('Courier', 20)
         if input_method == 'keyboard':
             self.event_processor = KeyboardEventProcessor()
+            print bcolors.OKBLUE + '--- Keyboard Control Instruction --- '\
+                    + bcolors.ENDC
+            print 'To increase the throttle/brake: press and hold the Up/Down Arrow'
+            print 'To decrease the throttle/brake: release the Up/Down Arrow'
+            print 'To keep the the current throttle/brake: press the Space Bar'
+            print 'To increase left/right steering: press the Left/Right Arrow'
+            print bcolors.OKBLUE + '------------------------------------ ' \
+                    + bcolors.ENDC
         else:
             self.event_processor = JoystickEventProcessor(joy_name)
         self.last_msg = lcm_msg()
@@ -237,7 +250,6 @@ def main():
     if 'pygame' not in sys.modules:
         print >>sys.stderr, 'error: missing pygame; see README.md for help.'
         return 1
-    print 'Instruction: keep'
     publisher = SteeringCommandPublisher(
       args.input_method, args.lcm_tag, args.joy_name)
     publisher.start()

--- a/drake/automotive/steering_command_driver.py
+++ b/drake/automotive/steering_command_driver.py
@@ -250,7 +250,7 @@ def main():
     if 'pygame' not in sys.modules:
         print >>sys.stderr, 'error: missing pygame; see README.md for help.'
         return 1
-        
+
     publisher = SteeringCommandPublisher(
       args.input_method, args.lcm_tag, args.joy_name)
     publisher.start()

--- a/drake/automotive/steering_command_driver.py
+++ b/drake/automotive/steering_command_driver.py
@@ -66,14 +66,8 @@ def _limit_brake(requested_value):
 class KeyboardEventProcessor:
     def __init__(self):
         pygame.event.set_allowed(None)
-        # pygame.KEYDOWN corresponds to any key pressed, and pygame.KEYUP 
-        # corresponds to any key releasing
         pygame.event.set_allowed([pygame.QUIT, pygame.KEYUP, pygame.KEYDOWN])
         pygame.key.set_repeat(100, 10)
-        # self.throttle_gradient/self.brake_gradient takes 3 possible values,
-        # 0, 1, and -1. The values determine if the corresponding lcm msg stay
-         # the same, increasing, or decreaisng
-        # initialize them as neutral
         self.throttle_gradient = 0; 
         self.brake_gradient = 0;
         self.keepCurrentThrottleBrake = False;
@@ -152,7 +146,7 @@ class JoystickEventProcessor:
         elif event.axis == ACCEL_AXIS:
             new_msg.throttle = _limit_throttle(-0.5 * event.value + 0.5)
         elif event.axis == BRAKE_AXIS:
-            new_msg.brake = _limit_throttle(-0.5 * event.value + 0.5)
+            new_msg.brake = _limit_brake(-0.5 * event.value + 0.5)
         return new_msg
 
 
@@ -256,6 +250,7 @@ def main():
     if 'pygame' not in sys.modules:
         print >>sys.stderr, 'error: missing pygame; see README.md for help.'
         return 1
+        
     publisher = SteeringCommandPublisher(
       args.input_method, args.lcm_tag, args.joy_name)
     publisher.start()

--- a/drake/automotive/steering_command_driver.py
+++ b/drake/automotive/steering_command_driver.py
@@ -55,16 +55,33 @@ def _limit_throttle_step(requested_value):
 class KeyboardEventProcessor:
     def __init__(self):
         pygame.event.set_allowed(None)
+        # pygame.KEYDOWN corresponds to any key pressed, and pygame.KEYUP 
+        # corresponds to any key releasing 
         pygame.event.set_allowed([pygame.QUIT, pygame.KEYUP, pygame.KEYDOWN])
         pygame.key.set_repeat(100, 10)
 
     def processEvent(self, event, last_msg):
         new_msg = copy.copy(last_msg)
+        # when up arrow is pressed
         if (event.key == pygame.K_UP) and (event.type == pygame.KEYDOWN):
             new_msg.throttle = _limit_throttle_step(
-                last_msg.throttle + (
-                    (event.type == pygame.KEYDOWN) * THROTTLE_SCALE))
-        elif event.key == pygame.K_DOWN:
+                last_msg.throttle + THROTTLE_SCALE)
+        # when up arrow is released
+        elif (event.key == pygame.K_UP) and (event.type == pygame.KEYUP):
+            # pygame.time.delay(pygame.key.get_repeat()[1])
+            new_msg.throttle = _limit_throttle_step(
+                last_msg.throttle - (THROTTLE_SCALE))
+            # if there is no other key being pressed
+            if not pygame.event.peek(pygame.KEYDOWN): 
+                # creates a dummy key releasing event 
+                dummyKeyUpEvent = pygame.event.Event(pygame.KEYUP)
+                # sets the dummy key releasing mappping to up arrow key so to
+                # come back to this if branch
+                dummyKeyUpEvent.key = pygame.K_UP
+                # posts the dummy key releasing event 
+                pygame.event.post(dummyKeyUpEvent)
+
+        elif (event.key == pygame.K_DOWN) and (event.type == pygame.KEYDOWN):
             new_msg.brake = (
                 (event.type == pygame.KEYDOWN) * BRAKE_SCALE)
         elif (event.key == pygame.K_LEFT) and (event.type == pygame.KEYDOWN):


### PR DESCRIPTION
This fixes #4434, and adds the option of keeping the current throttle/brake. It also adds keyboard control instruction for better usability. 

+@liangfok for feature review, thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4458)
<!-- Reviewable:end -->
