### PR TITLE
Rigid body plant mux + PidControlledSystem without plant ownership

### DIFF
--- a/drake/examples/kuka_iiwa_arm/CMakeLists.txt
+++ b/drake/examples/kuka_iiwa_arm/CMakeLists.txt
@@ -1,13 +1,16 @@
 if(lcm_FOUND)
   # Defines a shared library for use by KUKA iiwa demos based on System 2.0.
   add_library_with_exports(LIB_NAME drakeKukaIiwaArmCommon SOURCE_FILES
-      iiwa_common.cc iiwa_lcm.cc)
+    iiwa_common.cc
+    iiwa_lcm.cc
+    rigid_body_plant_mux.cc)
   target_link_libraries(drakeKukaIiwaArmCommon
     drakeLCMSystem2
     drakeRBM)
   drake_install_libraries(drakeKukaIiwaArmCommon)
   drake_install_headers(
-      iiwa_common.h iiwa_lcm.h)
+    iiwa_common.h iiwa_lcm.h
+    rigid_body_plant_mux.h)
   drake_install_pkg_config_file(drake-kuka-iiwa-arm-common
       TARGET drakeKukaIiwaArmCommon
       LIBS -ldrakeKukaIiwaArmCommon

--- a/drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.cc
+++ b/drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.cc
@@ -1,0 +1,165 @@
+#include "drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.h"
+
+#include <map>
+#include <set>
+
+#include "drake/common/drake_assert.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+
+template <typename T>
+class RigidBodyPlantMux<T>::InputMux : public systems::LeafSystem<T> {
+ public:
+  explicit InputMux(const RigidBodyTree<T>& tree) {
+    // Input ports will be declared when requested.
+    this->DeclareOutputPort(systems::kVectorValued, tree.get_num_actuators());
+
+    for (int i = 0; i < tree.get_num_actuators(); i++) {
+      actuator_map_[tree.actuators[i].name_] = i;
+    }
+  }
+
+  const systems::SystemPortDescriptor<T>& AddInput(
+      const std::vector<std::string>& actuator_names) {
+    port_actuators_.push_back(std::vector<int>());
+    auto& port_ids = port_actuators_.back();
+    port_ids.reserve(actuator_names.size());
+
+    for (const std::string& name : actuator_names) {
+      DRAKE_DEMAND(actuator_map_.count(name) > 0);
+      const int id = actuator_map_[name];
+      DRAKE_DEMAND(used_actuators_.count(id) == 0);
+      // Don't allow two input ports to map to the same actuator.
+      used_actuators_.insert(id);
+      port_ids.push_back(id);
+    }
+    return this->DeclareInputPort(systems::kVectorValued, port_ids.size());
+  }
+
+  void EvalOutput(const systems::Context<T>& context,
+                  systems::SystemOutput<T>* output) const {
+    DRAKE_ASSERT(static_cast<int>(port_actuators_.size()) ==
+                 this->get_num_input_ports());
+    auto output_vec = this->GetMutableOutputVector(output, 0);
+    output_vec.fill(0);
+    for (size_t i = 0; i < port_actuators_.size(); i++) {
+      const auto input = this->EvalVectorInput(context, i);
+      DRAKE_ASSERT(input->size() ==
+                   static_cast<int>(port_actuators_[i].size()));
+      for (size_t j = 0; j < port_actuators_[i].size(); j++) {
+        output_vec(port_actuators_[i][j]) = input->GetAtIndex(j);
+        DRAKE_DEMAND(!(input->GetAtIndex(j) != input->GetAtIndex(j)));
+      }
+    }
+  }
+
+ private:
+  std::map<std::string, int> actuator_map_;
+  std::set<int> used_actuators_;
+  std::vector<std::vector<int>> port_actuators_;
+};
+
+template <typename T>
+class RigidBodyPlantMux<T>::OutputMux : public systems::LeafSystem<T> {
+ public:
+  explicit OutputMux(const RigidBodyTree<T>& tree)
+      : num_positions_(tree.get_num_positions()) {
+    // Output ports will be declared when requested.
+    this->DeclareInputPort(
+        systems::kVectorValued,
+        tree.get_num_positions() + tree.get_num_velocities());
+
+    position_map_ = tree.computePositionNameToIndexMap();
+    for (int i = 0; i < tree.get_num_velocities(); i++) {
+      velocity_map_[tree.get_velocity_name(i)] = i;
+    }
+  }
+
+  const systems::SystemPortDescriptor<T>& AddOutput(
+      const std::vector<std::string>& position_names,
+      const std::vector<std::string>& velocity_names) {
+    port_states_.push_back(std::vector<int>());
+    auto& port_ids = port_states_.back();
+    port_ids.reserve(position_names.size() + velocity_names.size());
+
+    for (const std::string& name : position_names) {
+      DRAKE_DEMAND(position_map_.count(name) > 0);
+      const int id = position_map_[name];
+      port_ids.push_back(id);
+    }
+    for (const std::string& name : velocity_names) {
+      DRAKE_DEMAND(velocity_map_.count(name) > 0);
+      const int id = velocity_map_[name] + num_positions_;
+      port_ids.push_back(id);
+    }
+    return this->DeclareOutputPort(systems::kVectorValued, port_ids.size());
+  }
+
+  void EvalOutput(const systems::Context<T>& context,
+                  systems::SystemOutput<T>* output) const {
+    DRAKE_ASSERT(static_cast<int>(port_states_.size()) ==
+                 this->get_num_output_ports());
+    const auto input_vec = this->EvalVectorInput(context, 0);
+    for (size_t i = 0; i < port_states_.size(); i++) {
+      auto output_vec = this->GetMutableOutputVector(output, i);
+      for (size_t j = 0; j < port_states_[i].size(); j++) {
+        output_vec(j) = input_vec->GetAtIndex(port_states_[i][j]);
+      }
+    }
+  }
+
+ private:
+  const int num_positions_;
+  std::map<std::string, int> position_map_;
+  std::map<std::string, int> velocity_map_;
+  std::vector<std::vector<int>> port_states_;
+};
+
+template <typename T>
+RigidBodyPlantMux<T>::RigidBodyPlantMux(const RigidBodyTree<T>& tree) {
+  input_mux_ = std::make_unique<InputMux>(tree);
+  output_mux_ = std::make_unique<OutputMux>(tree);
+}
+
+template <typename T>
+RigidBodyPlantMux<T>::~RigidBodyPlantMux() {}
+
+template <typename T>
+const systems::SystemPortDescriptor<T>& RigidBodyPlantMux<T>::AddInput(
+    const std::vector<std::string>& actuator_names) {
+  DRAKE_DEMAND(static_cast<bool>(input_mux_));
+  return input_mux_->AddInput(actuator_names);
+}
+
+template <typename T>
+const systems::SystemPortDescriptor<T>& RigidBodyPlantMux<T>::AddOutput(
+      const std::vector<std::string>& position_names,
+      const std::vector<std::string>& velocity_names) {
+  DRAKE_DEMAND(static_cast<bool>(output_mux_));
+  return output_mux_->AddOutput(position_names, velocity_names);
+}
+
+template <typename T>
+void RigidBodyPlantMux<T>::ConnectPlant(
+    const systems::System<T>& plant, systems::DiagramBuilder<T>* builder) {
+  DRAKE_DEMAND(static_cast<bool>(input_mux_));
+  DRAKE_DEMAND(input_mux_->get_output_port(0).get_size() ==
+               plant.get_input_port(0).get_size());
+  DRAKE_DEMAND(static_cast<bool>(output_mux_));
+  DRAKE_DEMAND(output_mux_->get_input_port(0).get_size() ==
+               plant.get_output_port(0).get_size());
+
+  auto input_mux = builder->template AddSystem(std::move(input_mux_));
+  auto output_mux = builder->template AddSystem(std::move(output_mux_));
+  builder->Connect(input_mux->get_output_port(0), plant.get_input_port(0));
+  builder->Connect(plant.get_output_port(0), output_mux->get_input_port(0));
+}
+
+template class RigidBodyPlantMux<double>;
+
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.cc
+++ b/drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.cc
@@ -17,20 +17,22 @@ class RigidBodyPlantMux<T>::InputMux : public systems::LeafSystem<T> {
     // Input ports will be declared when requested.
     this->DeclareOutputPort(systems::kVectorValued, tree.get_num_actuators());
 
-    for (int i = 0; i < tree.get_num_actuators(); i++) {
-      actuator_map_[tree.actuators[i].name_] = i;
+    for (int i = 0; i < tree.get_num_actuators(); ++i) {
+      const RigidBody<double>* body = tree.actuators[i].body_;
+      actuator_map_[{tree.actuators[i].name_,
+              body->get_model_instance_id()}] = i;
     }
   }
 
   const systems::SystemPortDescriptor<T>& AddInput(
-      const std::vector<std::string>& actuator_names) {
+      const std::vector<std::pair<std::string, int>>& actuators) {
     port_actuators_.push_back(std::vector<int>());
     auto& port_ids = port_actuators_.back();
-    port_ids.reserve(actuator_names.size());
+    port_ids.reserve(actuators.size());
 
-    for (const std::string& name : actuator_names) {
-      DRAKE_DEMAND(actuator_map_.count(name) > 0);
-      const int id = actuator_map_[name];
+    for (const auto& actuator : actuators) {
+      DRAKE_DEMAND(actuator_map_.count(actuator) > 0);
+      const int id = actuator_map_[actuator];
       DRAKE_DEMAND(used_actuators_.count(id) == 0);
       // Don't allow two input ports to map to the same actuator.
       used_actuators_.insert(id);
@@ -45,11 +47,11 @@ class RigidBodyPlantMux<T>::InputMux : public systems::LeafSystem<T> {
                  this->get_num_input_ports());
     auto output_vec = this->GetMutableOutputVector(output, 0);
     output_vec.fill(0);
-    for (size_t i = 0; i < port_actuators_.size(); i++) {
+    for (size_t i = 0; i < port_actuators_.size(); ++i) {
       const auto input = this->EvalVectorInput(context, i);
       DRAKE_ASSERT(input->size() ==
                    static_cast<int>(port_actuators_[i].size()));
-      for (size_t j = 0; j < port_actuators_[i].size(); j++) {
+      for (size_t j = 0; j < port_actuators_[i].size(); ++j) {
         output_vec(port_actuators_[i][j]) = input->GetAtIndex(j);
         DRAKE_DEMAND(!(input->GetAtIndex(j) != input->GetAtIndex(j)));
       }
@@ -57,7 +59,7 @@ class RigidBodyPlantMux<T>::InputMux : public systems::LeafSystem<T> {
   }
 
  private:
-  std::map<std::string, int> actuator_map_;
+  std::map<std::pair<std::string, int>, int> actuator_map_;
   std::set<int> used_actuators_;
   std::vector<std::vector<int>> port_actuators_;
 };
@@ -72,27 +74,43 @@ class RigidBodyPlantMux<T>::OutputMux : public systems::LeafSystem<T> {
         systems::kVectorValued,
         tree.get_num_positions() + tree.get_num_velocities());
 
-    position_map_ = tree.computePositionNameToIndexMap();
-    for (int i = 0; i < tree.get_num_velocities(); i++) {
-      velocity_map_[tree.get_velocity_name(i)] = i;
+    for (int body_index = 0; body_index < tree.get_num_bodies();
+         ++body_index) {
+      const RigidBody<T>& body = tree.get_body(body_index);
+      if (!body.has_parent_body()) { continue; }
+      const int instance_id = body.get_model_instance_id();
+      const DrakeJoint& joint = body.getJoint();
+      const int position_start_index = body.get_position_start_index();
+      const int num_positions = joint.get_num_positions();
+      for (int i = 0; i < num_positions; ++i) {
+        position_map_[{joint.get_position_name(i), instance_id}] =
+            position_start_index + i;
+      }
+
+      const int velocity_start_index = body.get_velocity_start_index();
+      const int num_velocities = joint.get_num_velocities();
+      for (int i = 0; i < num_velocities; ++i) {
+        velocity_map_[{joint.get_velocity_name(i), instance_id}] =
+            velocity_start_index + i;
+      }
     }
   }
 
   const systems::SystemPortDescriptor<T>& AddOutput(
-      const std::vector<std::string>& position_names,
-      const std::vector<std::string>& velocity_names) {
+      const std::vector<std::pair<std::string, int>>& positions,
+      const std::vector<std::pair<std::string, int>>& velocities) {
     port_states_.push_back(std::vector<int>());
     auto& port_ids = port_states_.back();
-    port_ids.reserve(position_names.size() + velocity_names.size());
+    port_ids.reserve(positions.size() + velocities.size());
 
-    for (const std::string& name : position_names) {
-      DRAKE_DEMAND(position_map_.count(name) > 0);
-      const int id = position_map_[name];
+    for (const auto& position : positions) {
+      DRAKE_DEMAND(position_map_.count(position) > 0);
+      const int id = position_map_[position];
       port_ids.push_back(id);
     }
-    for (const std::string& name : velocity_names) {
-      DRAKE_DEMAND(velocity_map_.count(name) > 0);
-      const int id = velocity_map_[name] + num_positions_;
+    for (const auto& velocity : velocities) {
+      DRAKE_DEMAND(velocity_map_.count(velocity) > 0);
+      const int id = velocity_map_[velocity] + num_positions_;
       port_ids.push_back(id);
     }
     return this->DeclareOutputPort(systems::kVectorValued, port_ids.size());
@@ -103,9 +121,9 @@ class RigidBodyPlantMux<T>::OutputMux : public systems::LeafSystem<T> {
     DRAKE_ASSERT(static_cast<int>(port_states_.size()) ==
                  this->get_num_output_ports());
     const auto input_vec = this->EvalVectorInput(context, 0);
-    for (size_t i = 0; i < port_states_.size(); i++) {
+    for (size_t i = 0; i < port_states_.size(); ++i) {
       auto output_vec = this->GetMutableOutputVector(output, i);
-      for (size_t j = 0; j < port_states_[i].size(); j++) {
+      for (size_t j = 0; j < port_states_[i].size(); ++j) {
         output_vec(j) = input_vec->GetAtIndex(port_states_[i][j]);
       }
     }
@@ -113,8 +131,8 @@ class RigidBodyPlantMux<T>::OutputMux : public systems::LeafSystem<T> {
 
  private:
   const int num_positions_;
-  std::map<std::string, int> position_map_;
-  std::map<std::string, int> velocity_map_;
+  std::map<std::pair<std::string, int>, int> position_map_;
+  std::map<std::pair<std::string, int>, int> velocity_map_;
   std::vector<std::vector<int>> port_states_;
 };
 
@@ -129,17 +147,17 @@ RigidBodyPlantMux<T>::~RigidBodyPlantMux() {}
 
 template <typename T>
 const systems::SystemPortDescriptor<T>& RigidBodyPlantMux<T>::AddInput(
-    const std::vector<std::string>& actuator_names) {
+    const std::vector<std::pair<std::string, int>>& actuators) {
   DRAKE_DEMAND(static_cast<bool>(input_mux_));
-  return input_mux_->AddInput(actuator_names);
+  return input_mux_->AddInput(actuators);
 }
 
 template <typename T>
 const systems::SystemPortDescriptor<T>& RigidBodyPlantMux<T>::AddOutput(
-      const std::vector<std::string>& position_names,
-      const std::vector<std::string>& velocity_names) {
+    const std::vector<std::pair<std::string, int>>& positions,
+    const std::vector<std::pair<std::string, int>>& velocities) {
   DRAKE_DEMAND(static_cast<bool>(output_mux_));
-  return output_mux_->AddOutput(position_names, velocity_names);
+  return output_mux_->AddOutput(positions, velocities);
 }
 
 template <typename T>

--- a/drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.h
+++ b/drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/system.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+
+/// Creates multiplexers to wrap the input/output ports of a
+/// RigidBodyPlant to allow for multiple controllers to operate on
+/// different parts of the plant.
+template <typename T>
+class RigidBodyPlantMux {
+ public:
+  explicit RigidBodyPlantMux(const RigidBodyTree<T>& tree);
+  ~RigidBodyPlantMux();
+
+  /// Creates a new vector valued input port where the values of the
+  /// port correspond to the actuators from the rigid boty tree
+  /// provided in @p actuator_names.
+  const systems::SystemPortDescriptor<T>& AddInput(
+      const std::vector<std::string>& actuator_names);
+
+  /// Creates a new vector values output port where the values of the
+  /// port correspond to the positions/velocities from the rigid body
+  /// tree provided in @p position_names followed by @p
+  /// velocity_names.
+  const systems::SystemPortDescriptor<T>& AddOutput(
+      const std::vector<std::string>& position_names,
+      const std::vector<std::string>& velocity_names);
+
+  /// Using @p builder, connect the ports previously created with
+  /// AddInput and AddOutput to @p plant.  It is an error to call
+  /// AddInput or AddOutput after ConnectPlant.
+  void ConnectPlant(const systems::System<T>& plant,
+                    systems::DiagramBuilder<T>* builder);
+
+  RigidBodyPlantMux(const RigidBodyPlantMux&) = delete;
+  RigidBodyPlantMux& operator=(const RigidBodyPlantMux&) = delete;
+
+ private:
+  class InputMux;
+  class OutputMux;
+
+  std::unique_ptr<InputMux> input_mux_;
+  std::unique_ptr<OutputMux> output_mux_;
+};
+
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.h
+++ b/drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "drake/multibody/rigid_body_tree.h"
@@ -21,19 +22,23 @@ class RigidBodyPlantMux {
   explicit RigidBodyPlantMux(const RigidBodyTree<T>& tree);
   ~RigidBodyPlantMux();
 
-  /// Creates a new vector valued input port where the values of the
-  /// port correspond to the actuators from the rigid boty tree
-  /// provided in @p actuator_names.
-  const systems::SystemPortDescriptor<T>& AddInput(
-      const std::vector<std::string>& actuator_names);
+  // TODO(liangfok) Generalize to support multi-DOF actuators once
+  // #4153 is resolved.
 
-  /// Creates a new vector values output port where the values of the
-  /// port correspond to the positions/velocities from the rigid body
-  /// tree provided in @p position_names followed by @p
-  /// velocity_names.
+  /// Creates a new vector valued input port where the values of the
+  /// port correspond to the actuators from the RigidBodyTree provided
+  /// in @p actuators which consists of {name, model_instance_id}
+  /// pairs.
+  const systems::SystemPortDescriptor<T>& AddInput(
+      const std::vector<std::pair<std::string, int>>& actuators);
+
+  /// Creates a new vector valued output port where the values of the
+  /// port correspond to the positions/velocities from the
+  /// RigidBodyTree provided in @p positions followed by @p velocities
+  /// which consist of {name, model_instance_id} pairs.
   const systems::SystemPortDescriptor<T>& AddOutput(
-      const std::vector<std::string>& position_names,
-      const std::vector<std::string>& velocity_names);
+      const std::vector<std::pair<std::string, int>>& positions,
+      const std::vector<std::pair<std::string, int>>& velocities);
 
   /// Using @p builder, connect the ports previously created with
   /// AddInput and AddOutput to @p plant.  It is an error to call

--- a/drake/examples/kuka_iiwa_arm/test/CMakeLists.txt
+++ b/drake/examples/kuka_iiwa_arm/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+if(lcm_FOUND)
+  drake_add_cc_test(rigid_body_plant_mux_test)
+  target_link_libraries(rigid_body_plant_mux_test
+    drakeKukaIiwaArmCommon
+    drakeSystemPrimitives)
+endif()

--- a/drake/examples/kuka_iiwa_arm/test/rigid_body_plant_mux_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/rigid_body_plant_mux_test.cc
@@ -1,0 +1,94 @@
+#include "drake/examples/kuka_iiwa_arm/rigid_body_plant_mux.h"
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/multibody/parser_urdf.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/primitives/constant_vector_source.h"
+#include "drake/systems/primitives/gain.h"
+#include "drake/systems/primitives/multiplexer.h"
+#include "drake/systems/primitives/pass_through.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace {
+
+using drake::parsers::urdf::AddModelInstanceFromUrdfFile;
+
+GTEST_TEST(RigidBodyPlantMuxTest, SimpleMuxTest) {
+  // Create a tree with 4 actuators and 4 joints.
+  RigidBodyTree<double> tree;
+  AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() +
+      "/multibody/test/rigid_body_tree/four_dof_robot.urdf",
+      drake::multibody::joints::kFixed, nullptr /* weld to frame */,
+      &tree);
+
+  // Create our mux under test, and make two inputs and two outputs.
+  RigidBodyPlantMux<double> dut(tree);
+  auto input_one = dut.AddInput({"joint1", "joint2"});
+  auto input_two = dut.AddInput({"joint3", "joint4"});
+  auto output_one = dut.AddOutput({"joint1", "joint2"},
+                                  {"joint1dot", "joint2dot"});
+  auto output_two = dut.AddOutput({"joint3", "joint4"},
+                                  {"joint3dot", "joint4dot"});
+
+  // Build up a diagram with a multiplexer and a couple of gain blocks
+  // to simulate a plant with 4 inputs and 8 outputs.
+  systems::DiagramBuilder<double> plant_builder;
+  auto pass = plant_builder.AddSystem<systems::PassThrough<double>>(4);
+  auto position_gain = plant_builder.AddSystem<systems::Gain<double>>(10, 4);
+  auto velocity_gain = plant_builder.AddSystem<systems::Gain<double>>(100, 4);
+  auto plant_mux = plant_builder.AddSystem<systems::Multiplexer<double>>(
+      std::vector<int>({4, 4}));
+
+  plant_builder.Connect(*pass, *position_gain);
+  plant_builder.Connect(*pass, *velocity_gain);
+  plant_builder.Connect(position_gain->get_output_port(),
+                        plant_mux->get_input_port(0));
+  plant_builder.Connect(velocity_gain->get_output_port(),
+                        plant_mux->get_input_port(1));
+  plant_builder.ExportInput(pass->get_input_port(0));
+  plant_builder.ExportOutput(plant_mux->get_output_port(0));
+
+  systems::DiagramBuilder<double> builder;
+  auto plant = builder.AddSystem(plant_builder.Build());
+  dut.ConnectPlant(*plant, &builder);
+  builder.ExportInput(input_one);
+  builder.ExportInput(input_two);
+  builder.ExportOutput(output_one);
+  builder.ExportOutput(output_two);
+  auto sys = builder.Build();
+
+  auto context = sys->CreateDefaultContext();
+  auto output = sys->AllocateOutput(*context);
+  context->FixInputPort(0, Eigen::Vector2d(1, 2));
+  context->FixInputPort(1, Eigen::Vector2d(3, 4));
+  sys->EvalOutput(*context, output.get());
+
+  auto output_one_vec = output->get_vector_data(0);
+  auto output_two_vec = output->get_vector_data(1);
+  ASSERT_EQ(output_one_vec->size(), 4);
+  ASSERT_EQ(output_two_vec->size(), 4);
+
+  Eigen::VectorXd expected_output_one(4);
+  expected_output_one << 10, 20, 100, 200;
+
+  Eigen::VectorXd expected_output_two(4);
+  expected_output_two << 30, 40, 300, 400;
+
+  EXPECT_TRUE(CompareMatrices(output_one_vec->get_value(), expected_output_one,
+                              1e-10));
+  EXPECT_TRUE(CompareMatrices(output_two_vec->get_value(), expected_output_two,
+                              1e-10));
+}
+
+}  // namespace
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -3,7 +3,6 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
 namespace systems {
@@ -52,72 +51,94 @@ void PidControlledSystem<T>::Initialize(
   DRAKE_DEMAND(plant != nullptr);
   DiagramBuilder<T> builder;
   plant_ = builder.template AddSystem(std::move(plant));
+  DRAKE_ASSERT(plant_->get_num_input_ports() >= 1);
+  DRAKE_ASSERT(plant_->get_num_output_ports() >= 1);
+
+  auto input_ports = ConnectController(
+      plant_->get_input_port(0), plant_->get_output_port(0),
+      std::move(feedback_selector), Kp, Ki, Kd, &builder, &controller_);
+
+  builder.ExportInput(input_ports.first);
+  builder.ExportInput(input_ports.second);
+  builder.ExportOutput(plant_->get_output_port(0));
+  builder.BuildInto(this);
+}
+
+template <typename T>
+std::pair<const SystemPortDescriptor<T>,
+          const SystemPortDescriptor<T>>
+    PidControlledSystem<T>::ConnectController(
+        const SystemPortDescriptor<T>& plant_input,
+        const SystemPortDescriptor<T>& plant_output,
+        std::unique_ptr<MatrixGain<T>> feedback_selector,
+        const VectorX<T>& Kp, const VectorX<T>& Ki,
+        const VectorX<T>& Kd,
+        DiagramBuilder<T>* builder,
+        PidController<T>** controller) {
   if (feedback_selector == nullptr) {
     // No feedback selector was provided. Create a GainMatrix containing an
     // identity matrix, which results in every element of the plant's output
     // port zero being used as the feedback signal to the PID controller.
     feedback_selector =
-        std::make_unique<MatrixGain<T>>(plant_->get_output_port(0).get_size());
+        std::make_unique<MatrixGain<T>>(plant_output.get_size());
   }
-  feedback_selector_ = builder.template AddSystem(std::move(feedback_selector));
+  auto feedback_selector_p =
+      builder->template AddSystem(std::move(feedback_selector));
 
-  DRAKE_ASSERT(plant_->get_num_input_ports() >= 1);
-  DRAKE_ASSERT(plant_->get_num_output_ports() >= 1);
-  DRAKE_ASSERT(plant_->get_output_port(0).get_size() ==
-               feedback_selector_->get_input_port().get_size());
-  const int num_effort_commands = plant_->get_input_port(0).get_size();
+  DRAKE_ASSERT(plant_output.get_size() ==
+               feedback_selector_p->get_input_port().get_size());
+  const int num_effort_commands = plant_input.get_size();
   const int num_states = num_effort_commands * 2;
 
-  DRAKE_ASSERT(feedback_selector_->get_output_port().get_size() == num_states);
+  DRAKE_ASSERT(feedback_selector_p->get_output_port().get_size() == num_states);
 
-  state_minus_target_ = builder.template AddSystem<Adder<T>>(
+  auto state_minus_target = builder->template AddSystem<Adder<T>>(
       2, num_states);
-  controller_ = builder.template AddSystem<PidController<T>>(
+  (*controller) = builder->template AddSystem<PidController<T>>(
       Kp, Ki, Kd);
 
   // Split the input into two signals one with the positions and one
   // with the velocities.
-  error_demux_ = builder.template AddSystem<Demultiplexer<T>>(
+  auto error_demux = builder->template AddSystem<Demultiplexer<T>>(
       num_states, num_effort_commands);
 
-  controller_inverter_ = builder.template AddSystem<Gain<T>>(
+  auto controller_inverter = builder->template AddSystem<Gain<T>>(
       -1.0, num_effort_commands);
-  error_inverter_ = builder.template AddSystem<Gain<T>>(
+  auto error_inverter = builder->template AddSystem<Gain<T>>(
       -1.0, num_states);
 
   // Create an adder to sum the provided input with the output of the
   // controller.
-  plant_input_ = builder.template AddSystem<Adder<T>>(2, num_effort_commands);
+  auto plant_input_adder =
+      builder->template AddSystem<Adder<T>>(2, num_effort_commands);
 
-  builder.Connect(error_inverter_->get_output_port(),
-                  state_minus_target_->get_input_port(0));
-  builder.Connect(plant_->get_output_port(0),
-                  feedback_selector_->get_input_port());
-  builder.Connect(feedback_selector_->get_output_port(),
-                  state_minus_target_->get_input_port(1));
+  builder->Connect(error_inverter->get_output_port(),
+                   state_minus_target->get_input_port(0));
+  builder->Connect(plant_output,
+                   feedback_selector_p->get_input_port());
+  builder->Connect(feedback_selector_p->get_output_port(),
+                   state_minus_target->get_input_port(1));
 
   // Splits the error signal into positions and velocities components.
-  builder.Connect(state_minus_target_->get_output_port(),
-                  error_demux_->get_input_port(0));
+  builder->Connect(state_minus_target->get_output_port(),
+                   error_demux->get_input_port(0));
 
   // Connects PID controller.
-  builder.Connect(error_demux_->get_output_port(0),
-                  controller_->get_error_port());
-  builder.Connect(error_demux_->get_output_port(1),
-                  controller_->get_error_derivative_port());
+  builder->Connect(error_demux->get_output_port(0),
+                   (*controller)->get_error_port());
+  builder->Connect(error_demux->get_output_port(1),
+                   (*controller)->get_error_derivative_port());
   // Adds feedback.
-  builder.Connect(controller_->get_output_port(0),
-                  controller_inverter_->get_input_port());
-  builder.Connect(controller_inverter_->get_output_port(),
-                  plant_input_->get_input_port(0));
+  builder->Connect((*controller)->get_output_port(0),
+                   controller_inverter->get_input_port());
+  builder->Connect(controller_inverter->get_output_port(),
+                   plant_input_adder->get_input_port(0));
 
-  builder.Connect(plant_input_->get_output_port(),
-                  plant_->get_input_port(0));
+  builder->Connect(plant_input_adder->get_output_port(),
+                   plant_input);
 
-  builder.ExportInput(plant_input_->get_input_port(1));
-  builder.ExportInput(error_inverter_->get_input_port());
-  builder.ExportOutput(plant_->get_output_port(0));
-  builder.BuildInto(this);
+  return std::make_pair(plant_input_adder->get_input_port(1),
+                        error_inverter->get_input_port());
 }
 
 template <typename T>

--- a/drake/systems/controllers/pid_controlled_system.h
+++ b/drake/systems/controllers/pid_controlled_system.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "drake/systems/controllers/pid_controller.h"
 #include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/primitives/adder.h"
 #include "drake/systems/primitives/constant_vector_source.h"
@@ -138,6 +140,22 @@ class PidControlledSystem : public Diagram<T> {
     return this->get_input_port(1);
   }
 
+  /// Creates a PidController and connects to an existing plant and
+  /// DiagramBuilder, adding additional systems (adders, multiplexers,
+  /// gains, etc.) as needed.  Returns a pair of port descriptors.
+  /// The first is the feed forward control input, the second is the
+  /// feedback state input.  @p controller will be populated with a
+  /// pointer to the newly created PidController.
+  static std::pair<const SystemPortDescriptor<T>,
+                   const SystemPortDescriptor<T>> ConnectController(
+                       const SystemPortDescriptor<T>& plant_input,
+                       const SystemPortDescriptor<T>& plant_output,
+                       std::unique_ptr<MatrixGain<T>> feedback_selector,
+                       const VectorX<T>& Kp, const VectorX<T>& Ki,
+                       const VectorX<T>& Kd,
+                       DiagramBuilder<T>* builder,
+                       PidController<T>** controller);
+
  private:
   // A helper function for the constructors. This is necessary to avoid seg
   // faults caused by simultaneously moving the plant and calling methods on the
@@ -149,28 +167,6 @@ class PidControlledSystem : public Diagram<T> {
 
   System<T>* plant_{nullptr};
   PidController<T>* controller_{nullptr};
-  MatrixGain<T>* feedback_selector_{nullptr};
-
-  // Takes as input the plant's error state vector and outputs separate position
-  // and velocity state error vectors. These outputs are then inputted into the
-  // PID controller.
-  Demultiplexer<T>* error_demux_{nullptr};
-
-  // Inverts the PID controller's output command. The output of this system is
-  // inputted into plant_input_.
-  Gain<T>* controller_inverter_{nullptr};
-
-  // Inverts the PidControlledSystem input containing the desired state of the
-  // plant. The output is inputted into state_minus_target_.
-  Gain<T>* error_inverter_{nullptr};
-
-  // Subtracts the desired state of the plant from the current state of the
-  // plant. The resulting vector is inputted into error_demux_.
-  Adder<T>* state_minus_target_{nullptr};
-
-  // Adds the PID controller's output command with the provided feed forward
-  // command. The resulting command is then inputted into plant_.
-  Adder<T>* plant_input_{nullptr};
 };
 
 }  // namespace systems


### PR DESCRIPTION
This PR combines some prerequisites to my combined LCM controlled iiwa+Schunk work, namely having multiple LCM command sources and controllers operating on the same RigidBodyPlant.

It's possible RigidBodyPlantMux is generic enough (and good enough in this implementation) to move outside of the kuka_iiwa_arm example.  It's also possible the idea is so ill-conceived that it shouldn't be merged at all.  Feedback appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4475)
<!-- Reviewable:end -->
