### PR TITLE
Always build snopt_c as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,9 +130,10 @@ drake_add_external(sedumi PUBLIC CMAKE MATLAB)
 drake_add_external(snopt CMAKE MATLAB
   CMAKE_ARGS
     -DBUILD_SNOPT_CPP=OFF
-    -DBUILD_SHARED_LIBS=ON
+    -DBUILD_SHARED_LIBS=OFF  # For licensing reasons
     -DBUILD_TESTING=OFF
-    -DBUILD_SNOPT_C_MEX=${Matlab_FOUND})
+    -DBUILD_SNOPT_C_MEX=${Matlab_FOUND}
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
 
 # spotless
 drake_add_external(spotless PUBLIC CMAKE MATLAB)


### PR DESCRIPTION
For licensing reasons. I thought about making this dependent on packaging, but we probably do not want to start distributing a configuration that is rarely tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4479)
<!-- Reviewable:end -->
