### PR TITLE
Add BUILD macros for brevity

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -1,7 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,32 +50,23 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "curve2",
-    srcs = ["curve2.cc"],
-    hdrs = ["curve2.h"],
-    linkstatic = 1,
     deps = [
         ":generated_vectors",
     ],
 )
 
-cc_library(
+cc_component(
     name = "linear_car",
-    srcs = ["linear_car.cc"],
-    hdrs = ["linear_car.h"],
-    linkstatic = 1,
     deps = [
         ":generated_vectors",
         "//drake/common:symbolic",
     ],
 )
 
-cc_library(
+cc_component(
     name = "idm_planner",
-    srcs = ["idm_planner.cc"],
-    hdrs = ["idm_planner.h"],
-    linkstatic = 1,
     deps = [
         ":generated_vectors",
         "//drake/common:symbolic",
@@ -96,11 +87,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "single_lane_ego_and_agent",
-    srcs = ["single_lane_ego_and_agent.cc"],
-    hdrs = ["single_lane_ego_and_agent.h"],
-    linkstatic = 1,
     deps = [
         ":idm_planner",
         ":linear_car",
@@ -108,22 +96,16 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "trajectory_car",
-    srcs = ["trajectory_car.cc"],
-    hdrs = ["trajectory_car.h"],
-    linkstatic = 1,
     deps = [
         ":curve2",
         ":generated_vectors",
     ],
 )
 
-cc_library(
+cc_component(
     name = "automotive_simulator",
-    srcs = ["automotive_simulator.cc"],
-    hdrs = ["automotive_simulator.h"],
-    linkstatic = 1,
     deps = [
         ":generated_translators",
         ":generated_vectors",

--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -179,95 +181,68 @@ filegroup(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "automotive_simulator_test",
-    size = "small",
-    srcs = ["test/automotive_simulator_test.cc"],
     data = ["//drake/automotive:models"],
     local = 1,
     deps = [
         "//drake/automotive:automotive_simulator",
         "//drake/lcm:mock",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "curve2_test",
-    size = "small",
-    srcs = ["test/curve2_test.cc"],
     deps = [
         "//drake/automotive:curve2",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "simple_car_test",
-    size = "small",
-    srcs = ["test/simple_car_test.cc"],
     deps = [
         "//drake/automotive:simple_car",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "idm_planner_test",
-    size = "small",
-    srcs = ["test/idm_planner_test.cc"],
     deps = [
         "//drake/automotive:idm_planner",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "linear_car_test",
-    size = "small",
-    srcs = ["test/linear_car_test.cc"],
     deps = [
         "//drake/automotive:linear_car",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "simple_car_to_euler_floating_joint_test",
-    size = "small",
-    srcs = ["test/simple_car_to_euler_floating_joint_test.cc"],
     deps = [
         "//drake/automotive:simple_car",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "single_lane_ego_and_agent_test",
-    size = "small",
-    srcs = ["test/single_lane_ego_and_agent_test.cc"],
     deps = [
         "//drake/automotive:single_lane_ego_and_agent",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "trajectory_car_test",
-    size = "small",
-    srcs = ["test/trajectory_car_test.cc"],
     deps = [
         "//drake/automotive:trajectory_car",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "simple_car_state_translator_test",
-    size = "small",
-    srcs = ["test/simple_car_state_translator_test.cc"],
     deps = [
         "//drake/automotive:generated_translators",
-        "@gtest//:main",
     ],
 )

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 # A library of things that EVERYONE should want and MUST EAT.
@@ -228,234 +230,171 @@ cc_library(
     linkstatic = 1,
 )
 
-cc_test(
+cc_unit_test(
     name = "autodiff_overloads_test",
-    size = "small",
-    srcs = ["test/autodiff_overloads_test.cc"],
     deps = [
         ":autodiff",
         ":common",
         ":eigen_matrix_compare",
         ":extract_double",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "double_overloads_test",
-    size = "small",
-    srcs = ["test/double_overloads_test.cc"],
     deps = [
         ":common",
         ":cond",
         ":double",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "drake_assert_test",
-    size = "small",
-    srcs = ["test/drake_assert_test.cc"],
     deps = [
         ":common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "drake_assert_test_compile",
-    size = "small",
-    srcs = ["test/drake_assert_test_compile.cc"],
     deps = [
         ":common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "drake_deprecated_test",
-    size = "small",
-    srcs = ["test/drake_deprecated_test.cc"],
     # Remove spurious warnings from the default build output.
     copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "drake_throw_test",
-    size = "small",
-    srcs = ["test/drake_throw_test.cc"],
     deps = [
         ":common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "eigen_matrix_compare_test",
-    size = "small",
-    srcs = ["test/eigen_matrix_compare_test.cc"],
     deps = [
         ":common",
         ":eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "eigen_stl_types_test",
-    size = "small",
-    srcs = ["test/eigen_stl_types_test.cc"],
     deps = [
         ":common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "extract_double_test",
-    size = "small",
-    srcs = ["test/extract_double_test.cc"],
     deps = [
         ":common",
         ":extract_double",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "functional_form_test",
-    size = "small",
-    srcs = ["test/functional_form_test.cc"],
     deps = [
         ":common",
         ":functional_form",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "is_approx_equal_abstol_test",
-    size = "small",
-    srcs = ["test/is_approx_equal_abstol_test.cc"],
     deps = [
         ":common",
         ":is_approx_equal_abstol",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "nice_type_name_test",
-    size = "small",
-    srcs = ["test/nice_type_name_test.cc"],
     deps = [
         ":common",
         ":nice_type_name",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "polynomial_test",
-    size = "small",
-    srcs = ["test/polynomial_test.cc"],
     deps = [
         ":common",
         ":eigen_matrix_compare",
         ":random_polynomial_matrix",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "sorted_vectors_have_intersection_test",
-    size = "small",
-    srcs = ["test/sorted_vectors_have_intersection_test.cc"],
     deps = [
         ":common",
         ":sorted_vectors_have_intersection",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "symbolic_environment_test",
-    size = "small",
-    srcs = ["test/symbolic_environment_test.cc"],
     deps = [
         ":common",
         ":symbolic",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "symbolic_expression_test",
-    size = "small",
-    srcs = ["test/symbolic_expression_test.cc"],
     deps = [
         ":common",
         ":symbolic",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "symbolic_formula_test",
-    size = "small",
-    srcs = ["test/symbolic_formula_test.cc"],
     deps = [
         ":common",
         ":symbolic",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "symbolic_variable_test",
-    size = "small",
-    srcs = ["test/symbolic_variable_test.cc"],
     deps = [
         ":common",
         ":symbolic",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "symbolic_variables_test",
-    size = "small",
-    srcs = ["test/symbolic_variables_test.cc"],
     deps = [
         ":common",
         ":symbolic",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "text_logging_test",
-    size = "small",
-    srcs = ["test/text_logging_test.cc"],
     deps = [
         ":common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "trig_poly_test",
-    size = "small",
-    srcs = ["test/trig_poly_test.cc"],
     deps = [
         ":common",
         ":polynomial",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/common/trajectories/BUILD
+++ b/drake/common/trajectories/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 # TODO(jwnimmer-tri) Move code to a trajectory.cc file
@@ -79,74 +81,54 @@ cc_library(
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "piecewise_function_test",
-    size = "small",
-    srcs = ["test/piecewise_function_test.cc"],
     deps = [
         ":piecewise_function",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "piecewise_generation_test",
-    size = "small",
     srcs = ["test/piecewise_polynomial_generation_test.cc"],
     deps = [
         ":piecewise_polynomial",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "piecewise_polynomial_test",
-    size = "small",
-    srcs = ["test/piecewise_polynomial_test.cc"],
     deps = [
         ":piecewise_polynomial",
         ":random_piecewise_polynomial",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "exponential_plus_piecewise_polynomial_test",
-    size = "small",
-    srcs = [
-        "test/exponential_plus_piecewise_polynomial_test.cc",
-        "test/random_piecewise_polynomial.h",
-    ],
     deps = [
         ":piecewise_polynomial",
         ":random_piecewise_polynomial",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "piecewise_polynomial_trajectory_test",
-    size = "small",
-    srcs = ["test/piecewise_polynomial_trajectory_test.cc"],
     deps = [
         ":piecewise_polynomial_trajectory",
         ":random_piecewise_polynomial",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "piecewise_quaternion_test",
-    size = "small",
-    srcs = ["test/piecewise_quaternion_test.cc"],
     deps = [
         ":piecewise_quaternion",
         "//drake/common:eigen_matrix_compare",
         "//drake/util",
-        "@gtest//:main",
     ],
 )

--- a/drake/common/trajectories/BUILD
+++ b/drake/common/trajectories/BUILD
@@ -1,15 +1,14 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
 # TODO(jwnimmer-tri) Move code to a trajectory.cc file
-cc_library(
+cc_component(
     name = "trajectory",
-    hdrs = ["trajectory.h"],
-    linkstatic = 1,
+    srcs = [],
     deps = [
         "//drake/common",
     ],
@@ -45,11 +44,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "piecewise_polynomial_trajectory",
-    srcs = ["piecewise_polynomial_trajectory.cc"],
-    hdrs = ["piecewise_polynomial_trajectory.h"],
-    linkstatic = 1,
     deps = [
         ":piecewise_polynomial",
         ":trajectory",

--- a/drake/common/trajectories/qp_spline/BUILD
+++ b/drake/common/trajectories/qp_spline/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -48,12 +50,9 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "spline_generation_test",
-    size = "small",
-    srcs = ["test/spline_generation_test.cc"],
     deps = [
         ":spline_generation",
-        "@gtest//:main",
     ],
 )

--- a/drake/common/trajectories/qp_spline/BUILD
+++ b/drake/common/trajectories/qp_spline/BUILD
@@ -1,36 +1,27 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+cc_component(
     name = "continuity_constraint",
-    srcs = ["continuity_constraint.cc"],
-    hdrs = ["continuity_constraint.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
     ],
 )
 
-cc_library(
+cc_component(
     name = "spline_generation",
-    srcs = ["spline_generation.cc"],
-    hdrs = ["spline_generation.h"],
-    linkstatic = 1,
     deps = [
         ":spline_information",
         "//drake/common/trajectories:piecewise_polynomial",
     ],
 )
 
-cc_library(
+cc_component(
     name = "spline_information",
-    srcs = ["spline_information.cc"],
-    hdrs = ["spline_information.h"],
-    linkstatic = 1,
     deps = [
         ":continuity_constraint",
         ":value_constraint",
@@ -38,11 +29,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "value_constraint",
-    srcs = ["value_constraint.cc"],
-    hdrs = ["value_constraint.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
     ],

--- a/drake/examples/bouncing_ball/BUILD
+++ b/drake/examples/bouncing_ball/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -33,22 +35,16 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "ball_test",
-    size = "small",
-    srcs = ["test/ball_test.cc"],
     deps = [
         ":ball",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "bouncing_ball_test",
-    size = "small",
-    srcs = ["test/bouncing_ball_test.cc"],
     deps = [
         ":bouncing_ball",
-        "@gtest//:main",
     ],
 )

--- a/drake/lcm/BUILD
+++ b/drake/lcm/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -70,47 +72,35 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "drake_lcm_test",
-    size = "small",
-    srcs = ["test/drake_lcm_test.cc"],
     local = 1,
     deps = [
         ":lcm",
         ":lcmt_drake_signal_utils",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "drake_mock_lcm_test",
-    size = "small",
-    srcs = ["test/drake_mock_lcm_test.cc"],
     deps = [
         ":lcmt_drake_signal_utils",
         ":mock",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "lcmt_drake_signal_utils_test",
-    size = "small",
-    srcs = ["test/lcmt_drake_signal_utils_test.cc"],
     deps = [
         ":lcmt_drake_signal_utils",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "lcm_call_matlab_test",
-    size = "small",
-    srcs = ["test/lcm_call_matlab_test.cc"],
     local = 1,
     deps = [
         ":lcm_call_matlab",
         ":lcmt_drake_signal_utils",
-        "@gtest//:main",
     ],
 )

--- a/drake/lcm/BUILD
+++ b/drake/lcm/BUILD
@@ -1,7 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -46,24 +46,18 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "lcmt_drake_signal_utils",
     testonly = 1,
-    srcs = ["lcmt_drake_signal_utils.cc"],
-    hdrs = ["lcmt_drake_signal_utils.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/lcmtypes:drake_signal",
     ],
 )
 
-cc_library(
+cc_component(
     name = "lcm_call_matlab",
     testonly = 1,
-    srcs = ["lcm_call_matlab.cc"],
-    hdrs = ["lcm_call_matlab.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/lcmtypes:call_matlab",

--- a/drake/math/BUILD
+++ b/drake/math/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -120,105 +122,78 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "autodiff_test",
-    size = "small",
-    srcs = ["test/autodiff_test.cc"],
     deps = [
         ":autodiff",
         ":gradient",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "cross_product_test",
-    size = "small",
-    srcs = ["test/cross_product_test.cc"],
     deps = [
         ":gradient",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "expmap_test",
-    size = "small",
-    srcs = ["test/expmap_test.cc"],
     deps = [
         ":expmap",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "eigen_sparse_triplet_test",
-    size = "small",
-    srcs = ["test/eigen_sparse_triplet_test.cc"],
     deps = [
         ":eigen_sparse_triplet",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "jacobian_test",
-    size = "small",
-    srcs = ["test/jacobian_test.cc"],
     deps = [
         ":gradient",
         ":jacobian",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "gradient_util_test",
-    size = "small",
-    srcs = ["test/gradient_util_test.cc"],
     deps = [
         ":gradient",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "matrix_util_test",
-    size = "small",
-    srcs = ["test/matrix_util_test.cc"],
     deps = [
         ":matrix_util",
         "//drake/common:eigen_matrix_compare",
         "//drake/common:symbolic",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "normalize_vector_test",
-    size = "small",
-    srcs = ["test/normalize_vector_test.cc"],
     deps = [
         ":gradient",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "rotation_conversion_test",
-    size = "small",
-    srcs = ["test/rotation_conversion_test.cc"],
     deps = [
         ":geometric_transform",
         ":gradient",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )

--- a/drake/math/BUILD
+++ b/drake/math/BUILD
@@ -1,26 +1,20 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+cc_component(
     name = "autodiff",
-    srcs = ["autodiff.cc"],
-    hdrs = ["autodiff.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/common:autodiff",
     ],
 )
 
-cc_library(
+cc_component(
     name = "continuous_algebraic_ricatti_equation",
-    srcs = ["continuous_algebraic_ricatti_equation.cc"],
-    hdrs = ["continuous_algebraic_ricatti_equation.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/common:is_approx_equal_abstol",
@@ -76,11 +70,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "matrix_util",
-    srcs = ["matrix_util.cc"],
-    hdrs = ["matrix_util.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/common:number_traits",
@@ -89,32 +80,23 @@ cc_library(
 
 # These all require bleeding-edge Eigen, so please don't fold them into any
 # other important labels until we get all workspaces on newer-Eigen.
-cc_library(
+cc_component(
     name = "eigen_sparse_triplet",
-    srcs = ["eigen_sparse_triplet.cc"],
-    hdrs = ["eigen_sparse_triplet.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
     ],
 )
 
-cc_library(
+cc_component(
     name = "expmap",
-    srcs = ["expmap.cc"],
-    hdrs = ["expmap.h"],
-    linkstatic = 1,
     deps = [
         ":gradient",
         "//drake/common",
     ],
 )
 
-cc_library(
+cc_component(
     name = "jacobian",
-    srcs = ["jacobian.cc"],
-    hdrs = ["jacobian.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
     ],

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -113,97 +115,73 @@ cc_binary(
     deps = [
         ":rigid_body_tree",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "rbt_collisions_test",
-    size = "small",
     srcs = ["test/rigid_body_tree/rbt_collisions_test.cc"],
     data = [":test_models"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_tree",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "rigid_body_collision_clique_test",
-    size = "small",
     srcs = ["test/rigid_body_tree/rigid_body_collision_clique_test.cc"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_tree",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "rigid_body_constraint_test",
-    size = "small",
     srcs = ["constraint/test/rigid_body_constraint_test.cc"],
     data = ["//drake/examples/Atlas:models"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_constraint",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "rigid_body_tree_inverse_dynamics_test",
-    size = "small",
     srcs = ["test/rigid_body_tree/rigid_body_tree_inverse_dynamics_test.cc"],
     data = ["//drake/examples/Atlas:models"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_tree",
         "//drake/common:eigen_matrix_compare",
         "//drake/math:jacobian",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "rigid_body_tree_test",
-    size = "small",
     srcs = ["test/rigid_body_tree/rigid_body_tree_test.cc"],
     data = glob(["test/rigid_body_tree/*.urdf"]),
-    linkstatic = 1,
     deps = [
         ":rigid_body_tree",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "test_kinematics_cache_checks",
-    size = "small",
-    srcs = ["test/test_kinematics_cache_checks.cc"],
     data = ["//drake/examples/Atlas:models"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_tree",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "rigid_body_test",
-    size = "small",
-    srcs = ["test/rigid_body_test.cc"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_tree",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -1,7 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -82,11 +82,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "rigid_body_tree_construction",
-    srcs = ["rigid_body_tree_construction.cc"],
-    hdrs = ["rigid_body_tree_construction.h"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_tree",
     ],

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -69,15 +71,12 @@ alias(
     actual = ":bullet_collision",
 )
 
-cc_test(
+cc_unit_test(
     name = "model_test",
-    size = "small",
-    srcs = ["test/model_test.cc"],
-    data = ["test_models"],
+    data = [":test_models"],
     deps = [
         ":collision",
         "//drake/common:drake_path",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/multibody/joints/BUILD
+++ b/drake/multibody/joints/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -36,13 +38,9 @@ cc_library(
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "joint_test",
-    size = "small",
-    srcs = ["test/joint_test.cc"],
-    linkstatic = 1,
     deps = [
         ":joints",
-        "@gtest//:main",
     ],
 )

--- a/drake/multibody/parsers/BUILD
+++ b/drake/multibody/parsers/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -65,22 +67,19 @@ cc_binary(
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "package_map_test",
-    size = "small",
     srcs = ["test/package_map_test/package_map_test.cc"],
     data = [
         ":test_models",
     ],
     deps = [
         ":parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "urdf_parser_test",
-    size = "small",
     srcs = ["test/urdf_parser_test/urdf_parser_test.cc"],
     data = [
         ":test_models",
@@ -88,17 +87,13 @@ cc_test(
     ],
     deps = [
         ":parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "xml_util_test",
-    size = "small",
-    srcs = ["test/xml_util_test.cc"],
     deps = [
         ":parsers",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -51,117 +53,81 @@ cc_library(
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "compute_contact_result_test",
-    size = "small",
-    srcs = ["test/compute_contact_result_test.cc"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_plant",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "contact_detail_test",
-    size = "small",
-    srcs = ["test/contact_detail_test.cc"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_plant",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "contact_force_test",
-    size = "small",
-    srcs = ["test/contact_force_test.cc"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_plant",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "contact_info_test",
-    size = "small",
-    srcs = ["test/contact_info_test.cc"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_plant",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "contact_resultant_force_test",
-    size = "small",
-    srcs = ["test/contact_resultant_force_test.cc"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_plant",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "drake_visualizer_test",
-    size = "small",
-    srcs = ["test/drake_visualizer_test.cc"],
     data = ["//drake/multibody/collision:test_models"],
-    linkstatic = 1,
     deps = [
         ":drake_visualizer",
         "//drake/lcm:mock",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "kinematics_results_test",
-    size = "small",
-    srcs = ["test/kinematics_results_test.cc"],
     data = ["//drake/multibody:test_models"],
-    linkstatic = 1,
     deps = [
         ":rigid_body_plant",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "rigid_body_plant_test",
-    size = "small",
-    srcs = ["test/rigid_body_plant_test.cc"],
     data = [
         ":test_models",
         "//drake/examples/kuka_iiwa_arm:models",
     ],
-    linkstatic = 1,
     deps = [
         ":rigid_body_plant",
         "//drake/common:drake_path",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "viewer_draw_translator_test",
-    size = "small",
-    srcs = ["test/viewer_draw_translator_test.cc"],
-    linkstatic = 1,
     deps = [
         ":drake_visualizer",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 # TODO(jwnimmer-tri) This BUILD file only compiles the in-tree solvers.
@@ -76,21 +78,17 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "constraint_test",
-    size = "small",
-    srcs = ["test/constraint_test.cc"],
     deps = [
         ":mathematical_program",
         "//drake/common:eigen_matrix_compare",
         "//drake/math:gradient",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "convex_optimization_test",
-    size = "small",
     srcs = [
         "test/convex_optimization_test.cc",
         "test/mathematical_program_test_util.h",
@@ -98,24 +96,19 @@ cc_test(
     deps = [
         ":mathematical_program",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "decision_variable_test",
-    size = "small",
-    srcs = ["test/decision_variable_test.cc"],
     deps = [
         ":mathematical_program",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "mathematical_program_test",
-    size = "small",
     srcs = [
         "test/mathematical_program_test.cc",
         "test/mathematical_program_test_util.h",
@@ -123,13 +116,11 @@ cc_test(
     deps = [
         ":mathematical_program",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "mixed_integer_optimization_test",
-    size = "small",
     srcs = [
         "test/mathematical_program_test_util.h",
         "test/mixed_integer_optimization_test.cc",
@@ -137,28 +128,21 @@ cc_test(
     deps = [
         ":mathematical_program",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "moby_lcp_solver_test",
-    size = "small",
-    srcs = ["test/moby_lcp_solver_test.cc"],
     deps = [
         ":mathematical_program",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "system_identification_test",
-    size = "medium",
-    srcs = ["test/system_identification_test.cc"],
     deps = [
         ":system_identification",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -1,18 +1,15 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
 # TODO(jwnimmer-tri) This BUILD file only compiles the in-tree solvers.
 # External solvers are not yet supported.
 
-cc_library(
+cc_component(
     name = "constraint",
-    srcs = ["constraint.cc"],
-    hdrs = ["constraint.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/common:autodiff",
@@ -63,11 +60,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "system_identification",
-    srcs = ["system_identification.cc"],
-    hdrs = ["system_identification.h"],
-    linkstatic = 1,
     deps = [
         ":mathematical_program",
         "//drake/common",

--- a/drake/systems/analysis/BUILD
+++ b/drake/systems/analysis/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -23,52 +25,36 @@ cc_library(
     linkstatic = 1,
     deps = [
         "//drake/systems/plants/spring_mass_system",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "simulator_test",
-    size = "small",
-    srcs = ["test/simulator_test.cc"],
-    linkstatic = 1,
     deps = [
         ":analysis",
         ":my_spring_mass_system",
         "//drake/systems/analysis/test/controlled_spring_mass_system",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "explicit_euler_integrator_test",
-    size = "small",
-    srcs = ["test/explicit_euler_integrator_test.cc"],
-    linkstatic = 1,
     deps = [
         ":analysis",
         ":my_spring_mass_system",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "runge_kutta2_integrator_test",
-    size = "small",
-    srcs = ["test/runge_kutta2_integrator_test.cc"],
-    linkstatic = 1,
     deps = [
         ":analysis",
         ":my_spring_mass_system",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "runge_kutta3_integrator_test",
-    size = "small",
-    srcs = ["test/runge_kutta3_integrator_test.cc"],
-    linkstatic = 1,
     deps = [
         ":analysis",
         ":my_spring_mass_system",
@@ -76,6 +62,5 @@ cc_test(
         "//drake/math:geometric_transform",
         "//drake/multibody/parsers",
         "//drake/multibody/rigid_body_plant",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -20,13 +22,10 @@ cc_library(
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "controlled_spring_mass_system_test",
-    size = "small",
     srcs = ["controlled_spring_mass_system_test.cc"],
-    linkstatic = 1,
     deps = [
         ":controlled_spring_mass_system",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
@@ -1,16 +1,13 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+cc_component(
     name = "controlled_spring_mass_system",
     testonly = 1,
-    srcs = ["controlled_spring_mass_system.cc"],
-    hdrs = ["controlled_spring_mass_system.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/controllers:pid_controller",
         "//drake/systems/framework",

--- a/drake/systems/controllers/BUILD
+++ b/drake/systems/controllers/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -57,54 +59,38 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "gravity_compensator_test",
-    size = "small",
-    srcs = ["test/gravity_compensator_test.cc"],
     data = [
         "//drake/examples/SimpleFourBar:models",
         "//drake/examples/kuka_iiwa_arm:models",
     ],
-    linkstatic = 1,
     deps = [
         ":gravity_compensator",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "linear_quadratic_regulator_test",
-    size = "small",
-    srcs = ["test/linear_quadratic_regulator_test.cc"],
-    linkstatic = 1,
     deps = [
         ":linear_quadratic_regulator",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "pid_controlled_system_test",
-    size = "small",
-    srcs = ["test/pid_controlled_system_test.cc"],
-    linkstatic = 1,
     deps = [
         ":pid_controlled_system",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "pid_controller_test",
-    size = "small",
-    srcs = ["test/pid_controller_test.cc"],
-    linkstatic = 1,
     deps = [
         ":pid_controller",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/controllers/BUILD
+++ b/drake/systems/controllers/BUILD
@@ -1,15 +1,12 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+cc_component(
     name = "gravity_compensator",
-    srcs = ["gravity_compensator.cc"],
-    hdrs = ["gravity_compensator.h"],
-    linkstatic = 1,
     deps = [
         "//drake/multibody:rigid_body_tree",
         "//drake/multibody/parsers",
@@ -17,11 +14,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "linear_quadratic_regulator",
-    srcs = ["linear_quadratic_regulator.cc"],
-    hdrs = ["linear_quadratic_regulator.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common:is_approx_equal_abstol",
         "//drake/math:continuous_algebraic_ricatti_equation",
@@ -30,11 +24,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "pid_controller",
-    srcs = ["pid_controller.cc"],
-    hdrs = ["pid_controller.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
         "//drake/systems/primitives:adder",
@@ -44,11 +35,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "pid_controlled_system",
-    srcs = ["pid_controlled_system.cc"],
-    hdrs = ["pid_controlled_system.h"],
-    linkstatic = 1,
     deps = [
         ":pid_controller",
         "//drake/systems/primitives:constant_vector_source",

--- a/drake/systems/estimators/BUILD
+++ b/drake/systems/estimators/BUILD
@@ -1,15 +1,12 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+cc_component(
     name = "kalman_filter",
-    srcs = ["kalman_filter.cc"],
-    hdrs = ["kalman_filter.h"],
-    linkstatic = 1,
     deps = [
         ":luenberger_observer",
         "//drake/systems/controllers:linear_quadratic_regulator",
@@ -18,11 +15,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "luenberger_observer",
-    srcs = ["luenberger_observer.cc"],
-    hdrs = ["luenberger_observer.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],

--- a/drake/systems/estimators/BUILD
+++ b/drake/systems/estimators/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -28,27 +30,19 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "kalman_filter_test",
-    size = "small",
-    srcs = ["test/kalman_filter_test.cc"],
-    linkstatic = 1,
     deps = [
         ":kalman_filter",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "luenberger_observer_test",
-    size = "small",
-    srcs = ["test/luenberger_observer_test.cc"],
-    linkstatic = 1,
     deps = [
         ":luenberger_observer",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/primitives:linear_system",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -292,55 +294,36 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "basic_vector_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/basic_vector_test.cc"],
-    linkstatic = 1,
     deps = [
         ":vector",
         "//drake/common",
         "//drake/common:autodiff",
         "//drake/common:eigen_matrix_compare",
         "//drake/common:functional_form",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "cache_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/cache_test.cc"],
-    linkstatic = 1,
     deps = [
         ":cache",
         "//drake/common",
         "//drake/systems/framework/test_utilities",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "continuous_state_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/continuous_state_test.cc"],
-    linkstatic = 1,
     deps = [
         ":continuous_state",
         "//drake/common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "diagram_builder_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/diagram_builder_test.cc"],
-    linkstatic = 1,
     deps = [
         ":diagram_builder",
         "//drake/common",
@@ -349,16 +332,11 @@ cc_test(
         "//drake/systems/primitives:demultiplexer",
         "//drake/systems/primitives:gain",
         "//drake/systems/primitives:integrator",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "diagram_context_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/diagram_context_test.cc"],
-    linkstatic = 1,
     deps = [
         ":diagram_context",
         "//drake/common",
@@ -367,16 +345,11 @@ cc_test(
         "//drake/systems/primitives:constant_vector_source",
         "//drake/systems/primitives:integrator",
         "//drake/systems/primitives:zero_order_hold",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "diagram_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/diagram_test.cc"],
-    linkstatic = 1,
     deps = [
         ":diagram",
         "//drake/common",
@@ -385,155 +358,99 @@ cc_test(
         "//drake/systems/primitives:gain",
         "//drake/systems/primitives:integrator",
         "//drake/systems/primitives:zero_order_hold",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "discrete_state_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/discrete_state_test.cc"],
-    linkstatic = 1,
     deps = [
         ":discrete_state",
         "//drake/common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "leaf_context_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/leaf_context_test.cc"],
-    linkstatic = 1,
     deps = [
         ":leaf_context",
         "//drake/common",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework/test_utilities",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "leaf_system_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/leaf_system_test.cc"],
-    linkstatic = 1,
     deps = [
         ":leaf_system",
         "//drake/common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "abstract_state_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/abstract_state_test.cc"],
-    linkstatic = 1,
     deps = [
         ":abstract_state",
         "//drake/common",
         "//drake/systems/framework/test_utilities",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "parameters_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/parameters_test.cc"],
-    linkstatic = 1,
     deps = [
         ":parameters",
         "//drake/common",
         "//drake/systems/framework/test_utilities",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "subvector_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/subvector_test.cc"],
-    linkstatic = 1,
     deps = [
         ":vector",
         "//drake/common",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "supervector_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/supervector_test.cc"],
-    linkstatic = 1,
     deps = [
         ":vector",
         "//drake/common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "system_input_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/system_input_test.cc"],
-    linkstatic = 1,
     deps = [
         ":system_input",
         "//drake/common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "system_output_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/system_output_test.cc"],
-    linkstatic = 1,
     deps = [
         ":system_output",
         "//drake/common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "system_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/system_test.cc"],
-    linkstatic = 1,
     deps = [
         ":leaf_context",
         ":system",
         "//drake/common",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "value_test",
-    size = "small",
-    testonly = 1,
-    srcs = ["test/value_test.cc"],
-    linkstatic = 1,
     deps = [
         ":value",
         "//drake/common",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/lcm/BUILD
+++ b/drake/systems/lcm/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -53,54 +55,42 @@ cc_library(
 
 # === test ===
 
-cc_test(
+cc_unit_test(
     name = "lcm_publisher_system_test",
-    size = "small",
-    srcs = ["test/lcm_publisher_system_test.cc"],
     deps = [
         ":lcm",
         ":lcmt_drake_signal_translator",
         "//drake/lcm:lcmt_drake_signal_utils",
         "//drake/lcm:mock",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "lcm_subscriber_system_test",
-    size = "small",
-    srcs = ["test/lcm_subscriber_system_test.cc"],
     deps = [
         ":lcm",
         ":lcmt_drake_signal_translator",
         "//drake/lcm:lcmt_drake_signal_utils",
         "//drake/lcm:mock",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "lcm_translator_dictionary_test",
-    size = "small",
-    srcs = ["test/lcm_translator_dictionary_test.cc"],
     deps = [
         ":lcmt_drake_signal_translator",
         ":translator",
         "//drake/lcm:lcmt_drake_signal_utils",
         "//drake/lcm:mock",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "serializer_test",
-    size = "small",
-    srcs = ["test/serializer_test.cc"],
     deps = [
         ":lcm",
         ":lcmt_drake_signal_translator",
         "//drake/lcm:lcmt_drake_signal_utils",
         "//drake/lcm:mock",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/lcm/BUILD
+++ b/drake/systems/lcm/BUILD
@@ -1,7 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -41,11 +41,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "lcmt_drake_signal_translator",
-    srcs = ["lcmt_drake_signal_translator.cc"],
-    hdrs = ["lcmt_drake_signal_translator.h"],
-    linkstatic = 1,
     deps = [
         ":translator",
         "//drake/lcmtypes:drake_signal",

--- a/drake/systems/plants/spring_mass_system/BUILD
+++ b/drake/systems/plants/spring_mass_system/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -15,14 +17,10 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "spring_mass_system_test",
-    size = "small",
-    srcs = ["test/spring_mass_system_test.cc"],
-    linkstatic = 1,
     deps = [
         ":spring_mass_system",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/plants/spring_mass_system/BUILD
+++ b/drake/systems/plants/spring_mass_system/BUILD
@@ -1,15 +1,12 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+cc_component(
     name = "spring_mass_system",
-    srcs = ["spring_mass_system.cc"],
-    hdrs = ["spring_mass_system.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -1,92 +1,62 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+cc_component(
     name = "adder",
-    srcs = ["adder.cc"],
-    hdrs = ["adder.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "affine_system",
-    srcs = ["affine_system.cc"],
-    hdrs = ["affine_system.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "constant_value_source",
-    srcs = ["constant_value_source.cc"],
-    hdrs = [
-        "constant_value_source.h",
-        "constant_value_source-inl.h",
-    ],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "constant_vector_source",
-    srcs = ["constant_vector_source.cc"],
-    hdrs = ["constant_vector_source.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common:symbolic",
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "demultiplexer",
-    srcs = ["demultiplexer.cc"],
-    hdrs = ["demultiplexer.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "gain",
-    srcs = ["gain.cc"],
-    hdrs = [
-        "gain.h",
-        "gain-inl.h",
-    ],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "integrator",
-    srcs = ["integrator.cc"],
-    hdrs = ["integrator.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "linear_system",
-    srcs = ["linear_system.cc"],
-    hdrs = ["linear_system.h"],
-    linkstatic = 1,
     deps = [
         ":affine_system",
         "//drake/math:autodiff",
@@ -95,79 +65,52 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "matrix_gain",
-    srcs = ["matrix_gain.cc"],
-    hdrs = ["matrix_gain.h"],
-    linkstatic = 1,
     deps = [
         ":linear_system",
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "multiplexer",
-    srcs = ["multiplexer.cc"],
-    hdrs = ["multiplexer.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "pass_through",
-    srcs = ["pass_through.cc"],
-    hdrs = [
-        "pass_through.h",
-        "pass_through-inl.h",
-    ],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "random_source",
-    srcs = ["random_source.cc"],
-    hdrs = ["random_source.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "signal_logger",
-    srcs = ["signal_logger.cc"],
-    hdrs = ["signal_logger.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "trajectory_source",
-    srcs = ["trajectory_source.cc"],
-    hdrs = ["trajectory_source.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common/trajectories:trajectory",
         "//drake/systems/framework",
     ],
 )
 
-cc_library(
+cc_component(
     name = "zero_order_hold",
-    srcs = ["zero_order_hold.cc"],
-    hdrs = [
-        "zero_order_hold.h",
-        "zero_order_hold-inl.h",
-    ],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -180,70 +182,54 @@ cc_library(
     linkstatic = 1,
 )
 
-cc_test(
+cc_unit_test(
     name = "adder_test",
-    size = "small",
-    srcs = ["test/adder_test.cc"],
     deps = [
         ":adder",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "affine_system_test",
-    size = "small",
-    srcs = ["test/affine_system_test.cc"],
     deps = [
         ":affine_linear_test",
         ":affine_system",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "constant_value_source_test",
-    size = "small",
-    srcs = ["test/constant_value_source_test.cc"],
     deps = [
         ":constant_value_source",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "constant_vector_source_test",
-    size = "small",
-    srcs = ["test/constant_vector_source_test.cc"],
     deps = [
         ":constant_vector_source",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "demultiplexer_test",
-    size = "small",
-    srcs = ["test/demultiplexer_test.cc"],
     deps = [
         ":demultiplexer",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "gain_test",
-    size = "small",
     srcs = [
         "test/gain_scalartype_test.cc",
         "test/gain_test.cc",
@@ -253,63 +239,49 @@ cc_test(
         "//drake/common:eigen_matrix_compare",
         "//drake/common:symbolic",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "integrator_test",
-    size = "small",
-    srcs = ["test/integrator_test.cc"],
     deps = [
         ":integrator",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "linear_system_test",
-    size = "small",
-    srcs = ["test/linear_system_test.cc"],
     deps = [
         ":affine_linear_test",
         ":linear_system",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "matrix_gain_test",
-    size = "small",
-    srcs = ["test/matrix_gain_test.cc"],
     deps = [
         ":affine_linear_test",
         ":matrix_gain",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "multiplexer_test",
-    size = "small",
-    srcs = ["test/multiplexer_test.cc"],
     deps = [
         ":multiplexer",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "pass_through_test",
-    size = "small",
     srcs = [
         "test/pass_through_scalartype_test.cc",
         "test/pass_through_test.cc",
@@ -318,27 +290,21 @@ cc_test(
         ":pass_through",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "random_source_test",
-    size = "small",
-    srcs = ["test/random_source_test.cc"],
     deps = [
         ":random_source",
         ":signal_logger",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/analysis",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "signal_logger_test",
-    size = "small",
-    srcs = ["test/signal_logger_test.cc"],
     deps = [
         ":affine_system",
         ":linear_system",
@@ -346,31 +312,24 @@ cc_test(
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/analysis",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "trajectory_source_test",
-    size = "small",
-    srcs = ["test/trajectory_source_test.cc"],
     deps = [
         ":trajectory_source",
         "//drake/common:eigen_matrix_compare",
         "//drake/common/trajectories:piecewise_polynomial_trajectory",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )
 
-cc_test(
+cc_unit_test(
     name = "zero_order_hold_test",
-    size = "small",
-    srcs = ["test/zero_order_hold_test.cc"],
     deps = [
         ":zero_order_hold",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -15,14 +17,10 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "rotary_encoders_test",
-    size = "small",
-    srcs = ["test/rotary_encoders_test.cc"],
-    linkstatic = 1,
     deps = [
         ":rotary_encoders",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -1,15 +1,12 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+cc_component(
     name = "rotary_encoders",
-    srcs = ["rotary_encoders.cc"],
-    hdrs = ["rotary_encoders.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],

--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:drake.bzl", "cc_unit_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -37,14 +39,10 @@ cc_library(
 
 # === test/ ===
 
-cc_test(
+cc_unit_test(
     name = "direct_collocation_constraint_test",
-    size = "small",
-    srcs = ["test/direct_collocation_constraint_test.cc"],
-    linkstatic = 1,
     deps = [
         ":direct_collocation",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )

--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -1,7 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:drake.bzl", "cc_unit_test")
+load("//tools:drake.bzl", "cc_component", "cc_unit_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -23,12 +23,8 @@ cc_library(
     ],
 )
 
-cc_library(
+cc_component(
     name = "direct_trajectory_optimization",
-    testonly = 1,
-    srcs = ["direct_trajectory_optimization.cc"],
-    hdrs = ["direct_trajectory_optimization.h"],
-    linkstatic = 1,
     deps = [
         "//drake/common",
         "//drake/common/trajectories:piecewise_polynomial_trajectory",

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -1,6 +1,37 @@
 # -*- python -*-
 # This file contains macros for Bazel; see drake/doc/bazel.rst.
 
+def cc_component(
+        name,
+        srcs=None,
+        hdrs=None,
+        linkstatic=None,
+        **kwargs):
+    """Creates a rule to build a single C++ component (one header file, its
+    associated cc file, and the -inl.h iff such a file exists).
+
+    The default srcs and hdrs can be overridden by supplying an alternative
+    list in the srcs= and/or hdrs= args; any user-supplied value replaces the
+    default for that arg.  (The most comment use for this is marking header-
+    only components as srcs=[].)
+
+    By default, the component is marked linkstatic=1.
+
+    """
+    if srcs == None:
+        srcs = [name + ".cc"]
+    if hdrs == None:
+        hdrs = [name + ".h"]
+        hdrs.extend(native.glob([name + "-inl.h"]))
+    if linkstatic == None:
+        linkstatic = 1
+    native.cc_library(
+        name=name,
+        srcs=srcs,
+        hdrs=hdrs,
+        linkstatic=linkstatic,
+        **kwargs)
+
 def cc_unit_test(
         name,
         size=None,

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -1,0 +1,29 @@
+# -*- python -*-
+# This file contains macros for Bazel; see drake/doc/bazel.rst.
+
+def cc_unit_test(
+        name,
+        size=None,
+        srcs=None,
+        deps=None,
+        **kwargs):
+    """Creates a rule to build a C++ unit test using googletest.  Always adds a
+    deps= entry for googletest main.
+
+    By default, sets name="test/${name}.cc" per Drake's filename convention.
+    By default, sets size="small" because that indicates a unit test.
+
+    """
+    if size == None:
+        size = "small"
+    if srcs == None:
+        srcs = ["test/%s.cc" % name]
+    if deps == None:
+        deps = []
+    deps.append("@gtest//:main")
+    native.cc_test(
+        name=name,
+        size=size,
+        srcs=srcs,
+        deps=deps,
+        **kwargs)

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -5,5 +5,6 @@ cc_library(
     hdrs = glob(["include/spdlog/**"]),
     defines = ["HAVE_SPDLOG"],
     includes = ["include"],
+    linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This proposes some BUILD macros, ~and also removes uses of the `DEPS = ...` pattern~.  I think both would be helpful improvements before bringing Bazel to the masses pre-merge.

@david-german-tri and @rpoyner-tri (and anyone), I am looking for general design feedback on this.  I've tagged it DNR because I don't want a detailed line-by-line review, but rather a skim and then discussion (possibly in-person)?  But I wanted to put code on the table first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4480)
<!-- Reviewable:end -->
