### PR TITLE
moves model_name out of RigidBody and into RigidBodyTree

### DIFF
--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -67,7 +67,7 @@ void TestSimpleCarWithSdf(const std::string& sdf_filename,
 
   // Confirm that the RigidBodyTree has been appropriately amended.
   const auto& tree = simulator->get_rigid_body_tree();
-  EXPECT_EQ(1, tree.get_num_model_instances());
+  EXPECT_EQ(2, tree.get_num_model_instances());
   // One body belongs to the world, the rest belong to the car.
   ASSERT_EQ(1 + num_vehicle_bodies, tree.get_num_bodies());
 
@@ -182,7 +182,7 @@ void TestTrajectoryCarWithSdf(const std::string& sdf_file_1, int num_bodies_1,
 
   // Confirm that the RigidBodyTree has been appropriately amended.
   const auto& tree = simulator->get_rigid_body_tree();
-  EXPECT_EQ(2, tree.get_num_model_instances());
+  EXPECT_EQ(3, tree.get_num_model_instances());
   // One body belongs to the world, the rest belong to two car models.
   ASSERT_EQ(1 + num_bodies_1 + num_bodies_2, tree.get_num_bodies());
 

--- a/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc
+++ b/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc
@@ -141,8 +141,8 @@ void VerifyLoadMessage(const std::vector<uint8_t>& message_bytes) {
   EXPECT_EQ(message.link.at(1).name, "link1");
   EXPECT_EQ(message.link.at(2).name, "link2");
   EXPECT_EQ(message.link.at(0).robot_num, 0);
-  EXPECT_EQ(message.link.at(1).robot_num, 0);
-  EXPECT_EQ(message.link.at(2).robot_num, 0);
+  EXPECT_EQ(message.link.at(1).robot_num, 1);
+  EXPECT_EQ(message.link.at(2).robot_num, 1);
   EXPECT_EQ(message.link.at(0).num_geom, 1);
   EXPECT_EQ(message.link.at(1).num_geom, 1);
   EXPECT_EQ(message.link.at(2).num_geom, 1);
@@ -162,8 +162,8 @@ void VerifyDrawMessage(const std::vector<uint8_t>& message_bytes) {
   EXPECT_EQ(expected_message.link_name.at(1), "link1");
   EXPECT_EQ(expected_message.link_name.at(2), "link2");
   EXPECT_EQ(expected_message.robot_num.at(0), 0);
-  EXPECT_EQ(expected_message.robot_num.at(1), 0);
-  EXPECT_EQ(expected_message.robot_num.at(2), 0);
+  EXPECT_EQ(expected_message.robot_num.at(1), 1);
+  EXPECT_EQ(expected_message.robot_num.at(2), 1);
 }
 
 void VerifyDiagram(const Diagram<double>& dut, const VectorXd& desired_state,

--- a/drake/multibody/constraint/rigid_body_constraint.cc
+++ b/drake/multibody/constraint/rigid_body_constraint.cc
@@ -64,7 +64,7 @@ std::string RigidBodyConstraint::getTimeString(const double* t) const {
 }
 
 namespace {
-const int QuasiStaticDefaultRobotNum[1] = {0};
+const int QuasiStaticDefaultRobotNum[1] = {1};
 }
 
 const std::set<int> QuasiStaticConstraint::defaultRobotNumSet(
@@ -724,12 +724,8 @@ void WorldPositionConstraint::evalNames(
   }
 }
 
-namespace {
-const int WorldCoMDefaultRobotNum[1] = {0};
-}
 
-const std::set<int> WorldCoMConstraint::defaultRobotNumSet(
-    WorldCoMDefaultRobotNum, WorldCoMDefaultRobotNum + 1);
+const std::set<int> WorldCoMConstraint::defaultRobotNumSet({1});
 
 WorldCoMConstraint::WorldCoMConstraint(
     RigidBodyTree<double>* robot,

--- a/drake/multibody/parser_sdf.cc
+++ b/drake/multibody/parser_sdf.cc
@@ -12,8 +12,8 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/text_logging.h"
-#include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/joints/drake_joints.h"
+#include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parser_common.h"
 #include "drake/multibody/parser_model_instance_id_table.h"
 #include "drake/multibody/rigid_body_tree.h"
@@ -57,11 +57,10 @@ using tinyxml2::XMLDocument;
 
 using drake::multibody::joints::FloatingBaseType;
 
-void ParseSdfInertial(
-    RigidBody<double>* body, XMLElement* node, RigidBodyTree<double>* model,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    PoseMap& pose_map,
-    const Isometry3d& T_link) {
+void ParseSdfInertial(RigidBody<double>* body, XMLElement* node,
+                      RigidBodyTree<double>* model,
+                      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+                      PoseMap& pose_map, const Isometry3d& T_link) {
   Isometry3d T = T_link;
   XMLElement* pose = node->FirstChildElement("pose");
   if (pose) poseValueToTransform(pose, pose_map, T, T_link);
@@ -169,9 +168,11 @@ bool ParseSdfGeometry(XMLElement* node, const PackageMap& package_map,
     string resolved_filename = ResolveFilename(uri, package_map, root_dir);
 
     if (resolved_filename.empty()) {
-      throw runtime_error(string(__FILE__) + ": " + __func__ +
+      throw runtime_error(
+          string(__FILE__) + ": " + __func__ +
           ": ERROR: Mesh file name could not be resolved from the "
-          "provided uri \"" + uri + "\".");
+          "provided uri \"" +
+          uri + "\".");
     }
     DrakeShapes::Mesh mesh(uri, resolved_filename);
 
@@ -189,8 +190,8 @@ bool ParseSdfGeometry(XMLElement* node, const PackageMap& package_map,
 }
 
 void ParseSdfVisual(RigidBody<double>* body, XMLElement* node,
-                    RigidBodyTree<double>* model,
-                    const PackageMap& package_map, const string& root_dir,
+                    RigidBodyTree<double>* model, const PackageMap& package_map,
+                    const string& root_dir,
                     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
                     PoseMap& pose_map,
                     const Isometry3d& transform_parent_to_model) {
@@ -209,8 +210,8 @@ void ParseSdfVisual(RigidBody<double>* body, XMLElement* node,
   */
   XMLElement* geometry_node = node->FirstChildElement("geometry");
   if (!geometry_node) {
-    throw runtime_error(string(__FILE__) + ": " + __func__ +
-                        ": ERROR: Link " + body->get_name() +
+    throw runtime_error(string(__FILE__) + ": " + __func__ + ": ERROR: Link " +
+                        body->get_name() +
                         " has a visual element without a geometry.");
   }
 
@@ -262,8 +263,8 @@ void ParseSdfCollision(RigidBody<double>* body, XMLElement* node,
 
   XMLElement* geometry_node = node->FirstChildElement("geometry");
   if (!geometry_node) {
-    throw runtime_error(string(__FILE__) + ": " + __func__ +
-                        ": ERROR: Link " + body->get_name() +
+    throw runtime_error(string(__FILE__) + ": " + __func__ + ": ERROR: Link " +
+                        body->get_name() +
                         " has a collision element without a geometry.");
   }
 
@@ -285,8 +286,7 @@ void ParseSdfCollision(RigidBody<double>* body, XMLElement* node,
   //  Issue 2661 was created to track this problem.
   // TODO(amcastro-tri): fix the above issue tracked by 2661. Similarly for
   // parseCollision in RigidBodyTreeURDF.cpp.
-  if (body->get_name().compare(
-      string(RigidBodyTree<double>::kWorldName)) == 0)
+  if (body->get_name().compare(string(RigidBodyTree<double>::kWorldName)) == 0)
     element.set_static();
 
   if (!ParseSdfGeometry(geometry_node, package_map, root_dir, element)) {
@@ -299,18 +299,16 @@ void ParseSdfCollision(RigidBody<double>* body, XMLElement* node,
     model->addCollisionElement(element, *body, group_name);
 }
 
-bool ParseSdfLink(RigidBodyTree<double>* model, string model_name,
-                  XMLElement* node, const PackageMap& package_map,
+bool ParseSdfLink(RigidBodyTree<double>* model, XMLElement* node,
+                  const PackageMap& package_map,
                   // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-                  PoseMap& pose_map,
-                  const string& root_dir, int* index,
+                  PoseMap& pose_map, const string& root_dir, int* index,
                   int model_instance_id) {
   const char* attr = node->Attribute("drake_ignore");
   if (attr && strcmp(attr, "true") == 0) return false;
 
   RigidBody<double>* body{nullptr};
   std::unique_ptr<RigidBody<double>> owned_body(body = new RigidBody<double>());
-  body->set_model_name(model_name);
   body->set_model_instance_id(model_instance_id);
 
   attr = node->Attribute("name");
@@ -432,17 +430,16 @@ void ParseSdfFrame(RigidBodyTree<double>* rigid_body_tree, XMLElement* node,
   // Create the frame
   std::shared_ptr<RigidBodyFrame<double>> frame =
       allocate_shared<RigidBodyFrame<double>>(
-          Eigen::aligned_allocator<RigidBodyFrame<double>>(),
-          name, link, xyz, rpy);
+          Eigen::aligned_allocator<RigidBodyFrame<double>>(), name, link, xyz,
+          rpy);
 
   rigid_body_tree->addFrame(frame);
 }
 
 void ParseSdfJoint(RigidBodyTree<double>* model, string model_name,
                    XMLElement* node,
-                  // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-                   PoseMap& pose_map,
-                   int model_instance_id) {
+                   // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+                   PoseMap& pose_map, int model_instance_id) {
   const char* attr = node->Attribute("drake_ignore");
   if (attr && strcmp(attr, "true") == 0) return;
 
@@ -577,14 +574,12 @@ void ParseSdfJoint(RigidBodyTree<double>* model, string model_name,
         transform_parent_to_model.inverse() * loop_point_model;
 
     auto frameA = allocate_shared<RigidBodyFrame<double>>(
-        Eigen::aligned_allocator<RigidBodyFrame<double>>(),
-        name + "FrameA", parent,
-        loop_point_parent, Vector3d::Zero());
+        Eigen::aligned_allocator<RigidBodyFrame<double>>(), name + "FrameA",
+        parent, loop_point_parent, Vector3d::Zero());
 
     auto frameB = allocate_shared<RigidBodyFrame<double>>(
-        Eigen::aligned_allocator<RigidBodyFrame<double>>(),
-        name + "FrameB", child,
-        loop_point_child, Vector3d::Zero());
+        Eigen::aligned_allocator<RigidBodyFrame<double>>(), name + "FrameB",
+        child, loop_point_child, Vector3d::Zero());
 
     model->addFrame(frameA);
     model->addFrame(frameB);
@@ -736,12 +731,13 @@ void ParseModel(RigidBodyTree<double>* tree, XMLElement* node,
   if (model_instance_id_table != nullptr &&
       model_instance_id_table->find(model_name) !=
           model_instance_id_table->end()) {
-    throw std::runtime_error("Model named \"" + model_name + "\" already "
-        "exists in model_instance_id_table.");
+    throw std::runtime_error("Model named \"" + model_name +
+                             "\" already "
+                             "exists in model_instance_id_table.");
   }
 
   // Obtains and adds a new model instance ID into model_instance_id_table.
-  int model_instance_id = tree->add_model_instance();
+  int model_instance_id = tree->add_model_instance(model_name);
   if (model_instance_id_table != nullptr) {
     (*model_instance_id_table)[model_name] = model_instance_id;
   }
@@ -755,8 +751,8 @@ void ParseModel(RigidBodyTree<double>* tree, XMLElement* node,
   for (XMLElement* link_node = node->FirstChildElement("link"); link_node;
        link_node = link_node->NextSiblingElement("link")) {
     int index;
-    if (ParseSdfLink(tree, model_name, link_node, package_map,
-                     pose_map, root_dir, &index, model_instance_id)) {
+    if (ParseSdfLink(tree, link_node, package_map, pose_map, root_dir, &index,
+                     model_instance_id)) {
       link_indices.push_back(index);
     }
   }
@@ -794,13 +790,13 @@ void ParseModel(RigidBodyTree<double>* tree, XMLElement* node,
     // from model world to Drake's world.
     weld_to_frame->set_transform_to_body(
         weld_to_frame->get_transform_to_body() *
-            transform_model_root_to_model_world);
+        transform_model_root_to_model_world);
   }
 
   // Adds the floating joint that connects the newly added robot model to the
   // rest of the rigid body tree.
-  AddFloatingJoint(floating_base_type, link_indices, weld_to_frame,
-                   &pose_map, tree);
+  AddFloatingJoint(floating_base_type, link_indices, weld_to_frame, &pose_map,
+                   tree);
 }
 
 void ParseWorld(RigidBodyTree<double>* model, XMLElement* node,
@@ -815,8 +811,8 @@ void ParseWorld(RigidBodyTree<double>* model, XMLElement* node,
   }
 }
 
-ModelInstanceIdTable ParseSdf(XMLDocument* xml_doc,
-    const PackageMap& package_map, const string& root_dir,
+ModelInstanceIdTable ParseSdf(
+    XMLDocument* xml_doc, const PackageMap& package_map, const string& root_dir,
     const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* model) {
@@ -863,18 +859,18 @@ ModelInstanceIdTable AddModelInstancesFromSdfFileToWorld(
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   PackageMap package_map;
   package_map.PopulateUpstreamToDrake(filename);
-  return AddModelInstancesFromSdfFileSearchingInRosPackages(filename,
-      package_map, floating_base_type, nullptr /* weld_to_frame */, tree);
+  return AddModelInstancesFromSdfFileSearchingInRosPackages(
+      filename, package_map, floating_base_type, nullptr /* weld_to_frame */,
+      tree);
 }
 
-ModelInstanceIdTable
-AddModelInstancesFromSdfFileToWorldSearchingInRosPackages(
+ModelInstanceIdTable AddModelInstancesFromSdfFileToWorldSearchingInRosPackages(
     const string& filename, const PackageMap& package_map,
-    const FloatingBaseType floating_base_type,
-    RigidBodyTree<double>* tree) {
+    const FloatingBaseType floating_base_type, RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
-  return AddModelInstancesFromSdfFileSearchingInRosPackages(filename,
-      package_map, floating_base_type, nullptr /* weld_to_frame */, tree);
+  return AddModelInstancesFromSdfFileSearchingInRosPackages(
+      filename, package_map, floating_base_type, nullptr /* weld_to_frame */,
+      tree);
 }
 
 ModelInstanceIdTable AddModelInstancesFromSdfFile(
@@ -884,8 +880,8 @@ ModelInstanceIdTable AddModelInstancesFromSdfFile(
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   PackageMap package_map;
   package_map.PopulateUpstreamToDrake(filename);
-  return AddModelInstancesFromSdfFileSearchingInRosPackages(filename,
-      package_map, floating_base_type, weld_to_frame, tree);
+  return AddModelInstancesFromSdfFileSearchingInRosPackages(
+      filename, package_map, floating_base_type, weld_to_frame, tree);
 }
 
 ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
@@ -910,7 +906,7 @@ ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
   }
 
   return ParseSdf(&xml_doc, package_map, root_dir, floating_base_type,
-           weld_to_frame, tree);
+                  weld_to_frame, tree);
 }
 
 ModelInstanceIdTable AddModelInstancesFromSdfString(
@@ -919,8 +915,8 @@ ModelInstanceIdTable AddModelInstancesFromSdfString(
     RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   const PackageMap package_map;
-  return AddModelInstancesFromSdfStringSearchingInRosPackages(sdf_string,
-      package_map, floating_base_type, weld_to_frame, tree);
+  return AddModelInstancesFromSdfStringSearchingInRosPackages(
+      sdf_string, package_map, floating_base_type, weld_to_frame, tree);
 }
 
 ModelInstanceIdTable AddModelInstancesFromSdfStringSearchingInRosPackages(
@@ -941,10 +937,9 @@ ModelInstanceIdTable AddModelInstancesFromSdfStringSearchingInRosPackages(
   string root_dir = ".";
 
   return ParseSdf(&xml_doc, package_map, root_dir, floating_base_type,
-      weld_to_frame, tree);
+                  weld_to_frame, tree);
 }
 
 }  // namespace sdf
 }  // namespace parsers
 }  // namespace drake
-

--- a/drake/multibody/rigid_body.cc
+++ b/drake/multibody/rigid_body.cc
@@ -24,21 +24,19 @@ RigidBody<T>::RigidBody()
 }
 
 template <typename T>
-const std::string& RigidBody<T>::get_name() const { return name_; }
-
-template <typename T>
-void RigidBody<T>::set_name(const std::string& name) { name_ = name; }
-
-template <typename T>
-const std::string& RigidBody<T>::get_model_name() const { return model_name_; }
-
-template <typename T>
-void RigidBody<T>::set_model_name(const std::string& name) {
-    model_name_ = name;
+const std::string& RigidBody<T>::get_name() const {
+  return name_;
 }
 
 template <typename T>
-int RigidBody<T>::get_model_instance_id() const { return model_instance_id_; }
+void RigidBody<T>::set_name(const std::string& name) {
+  name_ = name;
+}
+
+template <typename T>
+int RigidBody<T>::get_model_instance_id() const {
+  return model_instance_id_;
+}
 
 template <typename T>
 void RigidBody<T>::set_model_instance_id(int model_instance_id) {
@@ -56,29 +54,42 @@ const DrakeJoint& RigidBody<T>::getJoint() const {
     return (*joint_);
   } else {
     throw runtime_error("ERROR: RigidBody<T>::getJoint(): Rigid body \"" +
-                        name_ + "\" in model " + model_name_ +
+                        name_ + "\" in model " +
+                        std::to_string(model_instance_id_) +
                         " does not have a joint!");
   }
 }
 
 template <typename T>
-void RigidBody<T>::set_parent(RigidBody* parent) { parent_ = parent; }
+void RigidBody<T>::set_parent(RigidBody* parent) {
+  parent_ = parent;
+}
 
 template <typename T>
-const RigidBody<T>* RigidBody<T>::get_parent() const { return parent_; }
+const RigidBody<T>* RigidBody<T>::get_parent() const {
+  return parent_;
+}
 
 template <typename T>
-bool RigidBody<T>::has_parent_body() const { return parent_ != nullptr; }
+bool RigidBody<T>::has_parent_body() const {
+  return parent_ != nullptr;
+}
 
 // TODO(liang.fok): Remove this deprecated method prior to Release 1.0.
 template <typename T>
-bool RigidBody<T>::hasParent() const { return has_parent_body(); }
+bool RigidBody<T>::hasParent() const {
+  return has_parent_body();
+}
 
 template <typename T>
-void RigidBody<T>::set_body_index(int body_index) { body_index_ = body_index; }
+void RigidBody<T>::set_body_index(int body_index) {
+  body_index_ = body_index;
+}
 
 template <typename T>
-int RigidBody<T>::get_body_index() const { return body_index_; }
+int RigidBody<T>::get_body_index() const {
+  return body_index_;
+}
 
 template <typename T>
 void RigidBody<T>::set_position_start_index(int position_start_index) {
@@ -120,7 +131,7 @@ const DrakeShapes::VectorOfVisualElements& RigidBody<T>::get_visual_elements()
 
 template <typename T>
 void RigidBody<T>::AddCollisionElement(const std::string& group_name,
-                                    DrakeCollision::Element* element) {
+                                       DrakeCollision::Element* element) {
   DrakeCollision::ElementId id = element->getId();
   collision_element_ids_.push_back(id);
   collision_element_groups_[group_name].push_back(id);
@@ -129,31 +140,31 @@ void RigidBody<T>::AddCollisionElement(const std::string& group_name,
 
 template <typename T>
 const std::vector<DrakeCollision::ElementId>&
-    RigidBody<T>::get_collision_element_ids() const {
+RigidBody<T>::get_collision_element_ids() const {
   return collision_element_ids_;
 }
 
 template <typename T>
 std::vector<DrakeCollision::ElementId>&
-    RigidBody<T>::get_mutable_collision_element_ids() {
+RigidBody<T>::get_mutable_collision_element_ids() {
   return collision_element_ids_;
 }
 
 template <typename T>
 const std::map<std::string, std::vector<DrakeCollision::ElementId>>&
-    RigidBody<T>::get_group_to_collision_ids_map() const {
+RigidBody<T>::get_group_to_collision_ids_map() const {
   return collision_element_groups_;
 }
 
 template <typename T>
 std::map<std::string, std::vector<DrakeCollision::ElementId>>&
-    RigidBody<T>::get_mutable_group_to_collision_ids_map() {
+RigidBody<T>::get_mutable_group_to_collision_ids_map() {
   return collision_element_groups_;
 }
 
 template <typename T>
 void RigidBody<T>::setCollisionFilter(const DrakeCollision::bitmask& group,
-                                   const DrakeCollision::bitmask& ignores) {
+                                      const DrakeCollision::bitmask& ignores) {
   setCollisionFilterGroup(group);
   setCollisionFilterIgnores(ignores);
 }
@@ -165,7 +176,7 @@ const DrakeCollision::bitmask& RigidBody<T>::getCollisionFilterGroup() const {
 
 template <typename T>
 void RigidBody<T>::setCollisionFilterGroup(
-  const DrakeCollision::bitmask& group) {
+    const DrakeCollision::bitmask& group) {
   collision_filter_group_ = group;
 }
 
@@ -175,27 +186,26 @@ const DrakeCollision::bitmask& RigidBody<T>::getCollisionFilterIgnores() const {
 }
 
 template <typename T>
-void RigidBody<T>::setCollisionFilterIgnores(const DrakeCollision::bitmask&
-    ignores) {
+void RigidBody<T>::setCollisionFilterIgnores(
+    const DrakeCollision::bitmask& ignores) {
   collision_filter_ignores_ = ignores;
 }
 
 template <typename T>
-void RigidBody<T>::addToCollisionFilterGroup(const DrakeCollision::bitmask&
-    group) {
+void RigidBody<T>::addToCollisionFilterGroup(
+    const DrakeCollision::bitmask& group) {
   collision_filter_group_ |= group;
 }
 
 template <typename T>
-void RigidBody<T>::ignoreCollisionFilterGroup(const DrakeCollision::bitmask&
-    group) {
+void RigidBody<T>::ignoreCollisionFilterGroup(
+    const DrakeCollision::bitmask& group) {
   collision_filter_ignores_ |= group;
 }
 
 template <typename T>
 void RigidBody<T>::collideWithCollisionFilterGroup(
-  const DrakeCollision::bitmask&
-    group) {
+    const DrakeCollision::bitmask& group) {
   collision_filter_ignores_ &= ~group;
 }
 
@@ -244,8 +254,8 @@ bool RigidBody<T>::appendCollisionElementIdsFromThisBody(
 template <typename T>
 void RigidBody<T>::ApplyTransformToJointFrame(
     const Eigen::Isometry3d& transform_body_to_joint) {
-  spatial_inertia_ = transformSpatialInertia(transform_body_to_joint,
-      spatial_inertia_);
+  spatial_inertia_ =
+      transformSpatialInertia(transform_body_to_joint, spatial_inertia_);
   for (auto& v : visual_elements_) {
     v.SetLocalTransform(transform_body_to_joint * v.getLocalTransform());
   }
@@ -282,8 +292,8 @@ const Eigen::Vector3d& RigidBody<T>::get_center_of_mass() const {
 }
 
 template <typename T>
-void RigidBody<T>::set_spatial_inertia(const drake::SquareTwistMatrix<double>&
-    spatial_inertia) {
+void RigidBody<T>::set_spatial_inertia(
+    const drake::SquareTwistMatrix<double>& spatial_inertia) {
   spatial_inertia_ = spatial_inertia;
 }
 

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -31,16 +31,6 @@ class RigidBody {
   void set_name(const std::string& name);
 
   /**
-   * Returns the name of the model defining this rigid body.
-   */
-  const std::string& get_model_name() const;
-
-  /**
-   * Sets the name of the model defining this rigid body.
-   */
-  void set_model_name(const std::string& name);
-
-  /**
    * Returns the ID of the model instance to which this rigid body belongs.
    */
   int get_model_instance_id() const;
@@ -393,11 +383,6 @@ class RigidBody {
 
   // The name of this rigid body.
   std::string name_;
-
-  // TODO(liang.fok) Remove this member variable, see:
-  // https://github.com/RobotLocomotion/drake/issues/3053
-  // The name of the model that defined this rigid body.
-  std::string model_name_;
 
   // A unique ID for the model instance to which this body belongs.
   int model_instance_id_{0};

--- a/drake/multibody/rigid_body_plant/test/drake_visualizer_test.cc
+++ b/drake/multibody/rigid_body_plant/test/drake_visualizer_test.cc
@@ -3,8 +3,8 @@
 #include <memory>
 #include <vector>
 
-#include <Eigen/Dense>
 #include <gtest/gtest.h>
+#include <Eigen/Dense>
 
 #include "drake/common/drake_path.h"
 #include "drake/lcm/drake_mock_lcm.h"
@@ -62,7 +62,7 @@ void VerifyLoadMessage(const std::vector<uint8_t>& message_bytes) {
 
     lcmt_viewer_link_data link_data;
     link_data.name = "box_body";
-    link_data.robot_num = 0;
+    link_data.robot_num = 1;
     link_data.num_geom = 1;
     link_data.geom.push_back(geometry_data);
 
@@ -90,7 +90,7 @@ void VerifyLoadMessage(const std::vector<uint8_t>& message_bytes) {
 
     lcmt_viewer_link_data link_data;
     link_data.name = "capsule_body";
-    link_data.robot_num = 1;
+    link_data.robot_num = 2;
     link_data.num_geom = 1;
     link_data.geom.push_back(geometry_data);
 
@@ -118,7 +118,7 @@ void VerifyLoadMessage(const std::vector<uint8_t>& message_bytes) {
 
     lcmt_viewer_link_data link_data;
     link_data.name = "cylinder_body";
-    link_data.robot_num = 2;
+    link_data.robot_num = 3;
     link_data.num_geom = 1;
     link_data.geom.push_back(geometry_data);
 
@@ -140,8 +140,8 @@ void VerifyLoadMessage(const std::vector<uint8_t>& message_bytes) {
     geometry_data.color[1] = 0.7;
     geometry_data.color[2] = 0.3;
     geometry_data.color[3] = 1.0;
-    geometry_data.string_data = drake::GetDrakePath() +
-        "/multibody/collision/test/spherical_cap.obj";
+    geometry_data.string_data =
+        drake::GetDrakePath() + "/multibody/collision/test/spherical_cap.obj";
     geometry_data.num_float_data = 3;
     geometry_data.float_data.push_back(1);
     geometry_data.float_data.push_back(1);
@@ -149,7 +149,7 @@ void VerifyLoadMessage(const std::vector<uint8_t>& message_bytes) {
 
     lcmt_viewer_link_data link_data;
     link_data.name = "mesh_body";
-    link_data.robot_num = 3;
+    link_data.robot_num = 4;
     link_data.num_geom = 1;
     link_data.geom.push_back(geometry_data);
 
@@ -176,7 +176,7 @@ void VerifyLoadMessage(const std::vector<uint8_t>& message_bytes) {
 
     lcmt_viewer_link_data link_data;
     link_data.name = "sphere_body";
-    link_data.robot_num = 4;
+    link_data.robot_num = 5;
     link_data.num_geom = 1;
     link_data.geom.push_back(geometry_data);
 
@@ -223,7 +223,7 @@ void VerifyDrawMessage(const std::vector<uint8_t>& message_bytes) {
     position[0] = 1;
 
     expected_message.link_name.push_back("box_body");
-    expected_message.robot_num.push_back(0);
+    expected_message.robot_num.push_back(1);
     expected_message.position.push_back(position);
     expected_message.quaternion.push_back(zero_quaternion);
   }
@@ -234,7 +234,7 @@ void VerifyDrawMessage(const std::vector<uint8_t>& message_bytes) {
     position[0] = 2;
 
     expected_message.link_name.push_back("capsule_body");
-    expected_message.robot_num.push_back(1);
+    expected_message.robot_num.push_back(2);
     expected_message.position.push_back(position);
     expected_message.quaternion.push_back(zero_quaternion);
   }
@@ -245,7 +245,7 @@ void VerifyDrawMessage(const std::vector<uint8_t>& message_bytes) {
     position[0] = -1;
 
     expected_message.link_name.push_back("cylinder_body");
-    expected_message.robot_num.push_back(2);
+    expected_message.robot_num.push_back(3);
     expected_message.position.push_back(position);
     expected_message.quaternion.push_back(zero_quaternion);
   }
@@ -256,7 +256,7 @@ void VerifyDrawMessage(const std::vector<uint8_t>& message_bytes) {
     position[1] = -2;
 
     expected_message.link_name.push_back("mesh_body");
-    expected_message.robot_num.push_back(3);
+    expected_message.robot_num.push_back(4);
     expected_message.position.push_back(position);
     expected_message.quaternion.push_back(zero_quaternion);
   }
@@ -264,7 +264,7 @@ void VerifyDrawMessage(const std::vector<uint8_t>& message_bytes) {
   // Adds the sphere body.
   {
     expected_message.link_name.push_back("sphere_body");
-    expected_message.robot_num.push_back(4);
+    expected_message.robot_num.push_back(5);
     expected_message.position.push_back(zero_position);
     expected_message.quaternion.push_back(zero_quaternion);
   }
@@ -292,7 +292,7 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
   {
     auto body = make_unique<RigidBody<double>>();
     body->set_name("box_body");
-    body->set_model_instance_id(tree->add_model_instance());
+    body->set_model_instance_id(tree->add_model_instance("box"));
     body->set_mass(1.0);
     body->set_spatial_inertia(Matrix6<double>::Identity());
 
@@ -313,8 +313,8 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
       joint_transform.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
     }
 
-    auto joint = make_unique<RollPitchYawFloatingJoint>(
-        "box_joint", joint_transform);
+    auto joint =
+        make_unique<RollPitchYawFloatingJoint>("box_joint", joint_transform);
     body->add_joint(&tree->world(), std::move(joint));
 
     tree->bodies.push_back(std::move(body));
@@ -325,7 +325,7 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
   {
     auto body = make_unique<RigidBody<double>>();
     body->set_name("capsule_body");
-    body->set_model_instance_id(tree->add_model_instance());
+    body->set_model_instance_id(tree->add_model_instance("capsule"));
     body->set_mass(1.0);
     body->set_spatial_inertia(Matrix6<double>::Identity());
 
@@ -345,8 +345,8 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
       joint_transform.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
     }
 
-    auto joint = make_unique<RollPitchYawFloatingJoint>(
-        "capsule_joint", joint_transform);
+    auto joint = make_unique<RollPitchYawFloatingJoint>("capsule_joint",
+                                                        joint_transform);
     body->add_joint(&tree->world(), std::move(joint));
 
     tree->bodies.push_back(std::move(body));
@@ -357,7 +357,7 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
   {
     auto body = make_unique<RigidBody<double>>();
     body->set_name("cylinder_body");
-    body->set_model_instance_id(tree->add_model_instance());
+    body->set_model_instance_id(tree->add_model_instance("cylinder"));
     body->set_mass(1.0);
     body->set_spatial_inertia(Matrix6<double>::Identity());
 
@@ -377,8 +377,8 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
       joint_transform.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
     }
 
-    auto joint = make_unique<RollPitchYawFloatingJoint>(
-        "cylinder_joint", joint_transform);
+    auto joint = make_unique<RollPitchYawFloatingJoint>("cylinder_joint",
+                                                        joint_transform);
     body->add_joint(&tree->world(), std::move(joint));
 
     tree->bodies.push_back(std::move(body));
@@ -390,13 +390,13 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
   {
     auto body = make_unique<RigidBody<double>>();
     body->set_name("mesh_body");
-    body->set_model_instance_id(tree->add_model_instance());
+    body->set_model_instance_id(tree->add_model_instance("mesh"));
     body->set_mass(1.0);
     body->set_spatial_inertia(Matrix6<double>::Identity());
 
-    Mesh shape("spherical_cap.obj",
-        drake::GetDrakePath() +
-        "/multibody/collision/test/spherical_cap.obj");
+    Mesh shape(
+        "spherical_cap.obj",
+        drake::GetDrakePath() + "/multibody/collision/test/spherical_cap.obj");
     Eigen::Vector4d material(0.2, 0.7, 0.3, 1.0);
 
     DrakeShapes::VisualElement visual_element(
@@ -412,8 +412,8 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
       joint_transform.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
     }
 
-    auto joint = make_unique<RollPitchYawFloatingJoint>(
-        "mesh_joint", joint_transform);
+    auto joint =
+        make_unique<RollPitchYawFloatingJoint>("mesh_joint", joint_transform);
     body->add_joint(&tree->world(), std::move(joint));
 
     tree->bodies.push_back(std::move(body));
@@ -424,7 +424,7 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
   {
     auto body = make_unique<RigidBody<double>>();
     body->set_name("sphere_body");
-    body->set_model_instance_id(tree->add_model_instance());
+    body->set_model_instance_id(tree->add_model_instance("sphere"));
     body->set_mass(1.0);
     body->set_spatial_inertia(Matrix6<double>::Identity());
 
@@ -443,8 +443,8 @@ unique_ptr<RigidBodyTree<double>> CreateRigidBodyTree() {
       joint_transform.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
     }
 
-    auto joint = make_unique<RollPitchYawFloatingJoint>(
-        "sphere_joint", joint_transform);
+    auto joint =
+        make_unique<RollPitchYawFloatingJoint>("sphere_joint", joint_transform);
     body->add_joint(&tree->world(), std::move(joint));
     tree->bodies.push_back(std::move(body));
   }
@@ -478,8 +478,8 @@ GTEST_TEST(DrakeVisualizerTests, BasicTest) {
   auto input_data = make_unique<BasicVector<double>>(vector_size);
   input_data->set_value(Eigen::VectorXd::Zero(vector_size));
 
-  context->SetInputPort(0,
-      std::make_unique<systems::FreestandingInputPort>(std::move(input_data)));
+  context->SetInputPort(0, std::make_unique<systems::FreestandingInputPort>(
+                               std::move(input_data)));
 
   // Publishes the `RigidBodyTree` visualization messages.
   dut.Publish(*context.get());

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -59,7 +59,7 @@ GTEST_TEST(RigidBodyPlantTest, TestLoadUrdf) {
        {"floor", "ramp_1", "ramp_2", "box_1", "box_2", "box_3", "box_4"}) {
     RigidBody<double>* body = tree.FindBody(body_name);
     EXPECT_NE(body, nullptr);
-    EXPECT_EQ(body->get_model_name(), "dual_ramps");
+    EXPECT_EQ(tree.get_model_name(body->get_model_instance_id()), "dual_ramps");
   }
 }
 
@@ -134,8 +134,8 @@ GTEST_TEST(RigidBodyPlantTest, MapVelocityToConfigurationDerivativesAndBack) {
       for (double yaw = 0; yaw <= M_PI_2; yaw += kAngleInc) {
         // Get the mutable state.
         VectorBase<double>* xc = context->get_mutable_state()
-                                        ->get_mutable_continuous_state()
-                                        ->get_mutable_generalized_position();
+                                     ->get_mutable_continuous_state()
+                                     ->get_mutable_generalized_position();
 
         // Update the orientation.
         const Quaterniond q = Eigen::AngleAxisd(roll, Vector3d::UnitZ()) *
@@ -228,8 +228,8 @@ TEST_F(KukaArmTest, SetDefaultState) {
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
   // derivatives per #3218.
-  context_->FixInputPort(0, make_unique<BasicVector<double>>(
-                                kuka_plant_->get_num_actuators()));
+  context_->FixInputPort(
+      0, make_unique<BasicVector<double>>(kuka_plant_->get_num_actuators()));
 
   // Asserts that for this case the zero configuration corresponds to a state
   // vector with all entries equal to zero.
@@ -262,8 +262,8 @@ TEST_F(KukaArmTest, EvalOutput) {
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
   // derivatives per #3218.
-  context_->FixInputPort(0, make_unique<BasicVector<double>>(
-                                kuka_plant_->get_num_actuators()));
+  context_->FixInputPort(
+      0, make_unique<BasicVector<double>>(kuka_plant_->get_num_actuators()));
 
   // Sets the state to a non-zero value.
   VectorXd desired_angles(kNumPositions_);
@@ -364,8 +364,9 @@ GTEST_TEST(rigid_body_plant_test, TestJointLimitForcesFormula) {
 double GetPrismaticJointLimitAccel(double position, double applied_force) {
   // Build two links connected by a limited prismatic joint.
   auto tree = std::make_unique<RigidBodyTree<double>>();
-  AddModelInstancesFromSdfFile(drake::GetDrakePath() +
-      "/multibody/rigid_body_plant/test/limited_prismatic.sdf",
+  AddModelInstancesFromSdfFile(
+      drake::GetDrakePath() +
+          "/multibody/rigid_body_plant/test/limited_prismatic.sdf",
       kFixed, nullptr /* weld to frame */, tree.get());
   RigidBodyPlant<double> plant(move(tree));
 

--- a/drake/multibody/rigid_body_plant/test/viewer_draw_translator_test.cc
+++ b/drake/multibody/rigid_body_plant/test/viewer_draw_translator_test.cc
@@ -8,9 +8,9 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
+#include "drake/multibody/joints/roll_pitch_yaw_floating_joint.h"
 #include "drake/multibody/rigid_body.h"
 #include "drake/multibody/rigid_body_tree.h"
-#include "drake/multibody/joints/roll_pitch_yaw_floating_joint.h"
 
 namespace drake {
 namespace systems {
@@ -29,7 +29,8 @@ GTEST_TEST(ViewerDrawTranslatorTests, BasicTest) {
   for (int i = 0; i < kNumBodies; ++i) {
     auto body = make_unique<RigidBody<double>>();
     body->set_name("body" + std::to_string(i));
-    body->set_model_instance_id(tree->add_model_instance());
+    body->set_model_instance_id(
+        tree->add_model_instance("body" + std::to_string(i)));
 
     // The inertia model must be set to prevent RigidBodyTree::compile() from
     // replacing the body's joint with a FixedJoint.

--- a/drake/multibody/rigid_body_system1/test/rigid_body_system/rigid_body_system_test.cc
+++ b/drake/multibody/rigid_body_system1/test/rigid_body_system/rigid_body_system_test.cc
@@ -2,8 +2,8 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/math/roll_pitch_yaw.h"
 #include "drake/common/drake_path.h"
+#include "drake/math/roll_pitch_yaw.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/rigid_body_system1/RigidBodySystem.h"
 
@@ -41,7 +41,8 @@ GTEST_TEST(RigidBodySystemTest, TestLoadURDFWorld) {
        {"floor", "ramp_1", "ramp_2", "box_1", "box_2", "box_3", "box_4"}) {
     RigidBody<double>* body = tree->FindBody(body_name);
     EXPECT_NE(body, nullptr);
-    EXPECT_EQ(body->get_model_name(), "dual_ramps");
+    EXPECT_EQ(tree->get_model_name(body->get_model_instance_id()),
+              "dual_ramps");
   }
 }
 
@@ -65,8 +66,8 @@ GTEST_TEST(RigidBodySystemTest, TestLoadSDFMultipleTimes) {
     Eigen::Vector3d xyz, rpy;
     xyz << 1, 1, 1;
     rpy = Eigen::Vector3d::Zero();
-    T_second_model_to_world.matrix()
-        << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
+    T_second_model_to_world.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0,
+        0, 1;
   }
 
   auto weld_to_frame = std::allocate_shared<RigidBodyFrame<double>>(
@@ -132,37 +133,37 @@ GTEST_TEST(RigidBodySystemTest, TestLoadSDFMultipleTimes) {
 
   // Checks that a body can be obtained when we specify the body's name and
   // model instance ID.
-  EXPECT_NE(tree->FindBody("link_1", "", 0), nullptr);
   EXPECT_NE(tree->FindBody("link_1", "", 1), nullptr);
   EXPECT_NE(tree->FindBody("link_1", "", 2), nullptr);
   EXPECT_NE(tree->FindBody("link_1", "", 3), nullptr);
-  EXPECT_NE(tree->FindBody("link_2", "", 0), nullptr);
+  EXPECT_NE(tree->FindBody("link_1", "", 4), nullptr);
   EXPECT_NE(tree->FindBody("link_2", "", 1), nullptr);
   EXPECT_NE(tree->FindBody("link_2", "", 2), nullptr);
   EXPECT_NE(tree->FindBody("link_2", "", 3), nullptr);
-  EXPECT_NE(tree->FindBody("link_3", "", 0), nullptr);
+  EXPECT_NE(tree->FindBody("link_2", "", 4), nullptr);
   EXPECT_NE(tree->FindBody("link_3", "", 1), nullptr);
   EXPECT_NE(tree->FindBody("link_3", "", 2), nullptr);
   EXPECT_NE(tree->FindBody("link_3", "", 3), nullptr);
+  EXPECT_NE(tree->FindBody("link_3", "", 4), nullptr);
 
   // Checks that a body can be obtained when we specify the body's name, model
   // name, and model instance ID.
-  EXPECT_NE(tree->FindBody("link_1", "model_1", 0), nullptr);
-  EXPECT_NE(tree->FindBody("link_1", "model_2", 1), nullptr);
-  EXPECT_NE(tree->FindBody("link_1", "model_1", 2), nullptr);
-  EXPECT_NE(tree->FindBody("link_1", "model_2", 3), nullptr);
-  EXPECT_NE(tree->FindBody("link_2", "model_1", 0), nullptr);
-  EXPECT_NE(tree->FindBody("link_2", "model_2", 1), nullptr);
-  EXPECT_NE(tree->FindBody("link_2", "model_1", 2), nullptr);
-  EXPECT_NE(tree->FindBody("link_2", "model_2", 3), nullptr);
-  EXPECT_NE(tree->FindBody("link_3", "model_1", 0), nullptr);
-  EXPECT_NE(tree->FindBody("link_3", "model_2", 1), nullptr);
-  EXPECT_NE(tree->FindBody("link_3", "model_1", 2), nullptr);
-  EXPECT_NE(tree->FindBody("link_3", "model_2", 3), nullptr);
+  EXPECT_NE(tree->FindBody("link_1", "model_1", 1), nullptr);
+  EXPECT_NE(tree->FindBody("link_1", "model_2", 2), nullptr);
+  EXPECT_NE(tree->FindBody("link_1", "model_1", 3), nullptr);
+  EXPECT_NE(tree->FindBody("link_1", "model_2", 4), nullptr);
+  EXPECT_NE(tree->FindBody("link_2", "model_1", 1), nullptr);
+  EXPECT_NE(tree->FindBody("link_2", "model_2", 2), nullptr);
+  EXPECT_NE(tree->FindBody("link_2", "model_1", 3), nullptr);
+  EXPECT_NE(tree->FindBody("link_2", "model_2", 4), nullptr);
+  EXPECT_NE(tree->FindBody("link_3", "model_1", 1), nullptr);
+  EXPECT_NE(tree->FindBody("link_3", "model_2", 2), nullptr);
+  EXPECT_NE(tree->FindBody("link_3", "model_1", 3), nullptr);
+  EXPECT_NE(tree->FindBody("link_3", "model_2", 4), nullptr);
 
   // Checks that we cannot access a non-existent joint.
   EXPECT_THROW(tree->FindChildBodyOfJoint("non-existent-joint"),
-      std::runtime_error);
+               std::runtime_error);
 
   // Checks that we cannot access a joint using just the joint name.
   // This is impossible because there are multiple joints with the same name.
@@ -171,14 +172,14 @@ GTEST_TEST(RigidBodySystemTest, TestLoadSDFMultipleTimes) {
 
   // Checks that we can access a joint using the joint name and model instance
   // ID.
-  EXPECT_NE(tree->FindChildBodyOfJoint("joint_1", 0), nullptr);
   EXPECT_NE(tree->FindChildBodyOfJoint("joint_1", 1), nullptr);
   EXPECT_NE(tree->FindChildBodyOfJoint("joint_1", 2), nullptr);
   EXPECT_NE(tree->FindChildBodyOfJoint("joint_1", 3), nullptr);
-  EXPECT_NE(tree->FindChildBodyOfJoint("joint_2", 0), nullptr);
+  EXPECT_NE(tree->FindChildBodyOfJoint("joint_1", 4), nullptr);
   EXPECT_NE(tree->FindChildBodyOfJoint("joint_2", 1), nullptr);
   EXPECT_NE(tree->FindChildBodyOfJoint("joint_2", 2), nullptr);
   EXPECT_NE(tree->FindChildBodyOfJoint("joint_2", 3), nullptr);
+  EXPECT_NE(tree->FindChildBodyOfJoint("joint_2", 4), nullptr);
 }
 
 // Tests whether the URDF parser is robust against an improperly specified
@@ -193,14 +194,15 @@ GTEST_TEST(RigidBodySystemTest, TestLoadURDFWithBadTransmission) {
   // transmission that specifies a non-existent joint. This is done by first
   // verifying that an exception is thrown, and then verifying that the thrown
   // exception is the correct one.
-  EXPECT_THROW(
-      rigid_body_sys->AddModelInstanceFromFile(drake::GetDrakePath() +
-          "/multibody/rigid_body_system1/test/rigid_body_system/"
-          "bad_transmission_no_joint.urdf"),
-      std::runtime_error);
+  EXPECT_THROW(rigid_body_sys->AddModelInstanceFromFile(
+                   drake::GetDrakePath() +
+                   "/multibody/rigid_body_system1/test/rigid_body_system/"
+                   "bad_transmission_no_joint.urdf"),
+               std::runtime_error);
 
   try {
-    rigid_body_sys->AddModelInstanceFromFile(drake::GetDrakePath() +
+    rigid_body_sys->AddModelInstanceFromFile(
+        drake::GetDrakePath() +
         "/multibody/rigid_body_system1/test/rigid_body_system/"
         "bad_transmission_no_joint.urdf");
   } catch (std::runtime_error& error) {

--- a/drake/multibody/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -3,9 +3,9 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/joints/fixed_joint.h"
 #include "drake/multibody/parser_common.h"
 #include "drake/multibody/parser_model_instance_id_table.h"
-#include "drake/multibody/joints/fixed_joint.h"
 
 namespace drake {
 namespace systems {
@@ -36,7 +36,7 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
     RigidBody<double>* temp_body;
     tree_->add_rigid_body(
         unique_ptr<RigidBody<double>>(temp_body = new RigidBody<double>()));
-    temp_body->set_model_name("robot1");
+    temp_body->set_model_instance_id(tree_->add_model_instance("robot1"));
     temp_body->set_name("body1");
     temp_body->set_spatial_inertia(I);
     body1_collision_element_1_ = make_unique<Element>();
@@ -47,7 +47,7 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
     // These next bodies will *not* require self-collision clique
     tree_->add_rigid_body(
         unique_ptr<RigidBody<double>>(body2_ = new RigidBody<double>()));
-    body2_->set_model_name("robot2");
+    body2_->set_model_instance_id(tree_->add_model_instance("robot2"));
     body2_->set_name("body2");
     body2_->set_spatial_inertia(I);
     body2_collision_element_ = make_unique<Element>();
@@ -55,7 +55,7 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
 
     tree_->add_rigid_body(
         unique_ptr<RigidBody<double>>(body3_ = new RigidBody<double>()));
-    body3_->set_model_name("robot3");
+    body3_->set_model_instance_id(tree_->add_model_instance("robot3"));
     body3_->set_name("body3");
     body3_->set_spatial_inertia(I);
   }

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_test.cc
@@ -5,12 +5,12 @@
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/joints/quaternion_floating_joint.h"
+#include "drake/multibody/joints/revolute_joint.h"
 #include "drake/multibody/parser_model_instance_id_table.h"
 #include "drake/multibody/parser_urdf.h"
 #include "drake/multibody/rigid_body_tree.h"
-#include "drake/multibody/joints/quaternion_floating_joint.h"
-#include "drake/multibody/joints/revolute_joint.h"
-#include "drake/multibody/joints/floating_base_types.h"
 
 namespace drake {
 namespace systems {
@@ -31,19 +31,23 @@ class RigidBodyTreeTest : public ::testing::Test {
 
     // Defines four rigid bodies.
     r1b1_ = std::make_unique<RigidBody<double>>();
-    r1b1_->set_model_name("robot1");
+    int r1id = tree_->add_model_instance("robot1");
+    r1b1_->set_model_instance_id(r1id);
     r1b1_->set_name("body1");
 
     r2b1_ = std::make_unique<RigidBody<double>>();
-    r2b1_->set_model_name("robot2");
+    int r2id = tree_->add_model_instance("robot2");
+    r2b1_->set_model_instance_id(r2id);
     r2b1_->set_name("body1");
 
     r3b1_ = std::make_unique<RigidBody<double>>();
-    r3b1_->set_model_name("robot3");
+    int r3id = tree_->add_model_instance("robot3");
+    r3b1_->set_model_instance_id(r3id);
     r3b1_->set_name("body1");
 
     r4b1_ = std::make_unique<RigidBody<double>>();
-    r4b1_->set_model_name("robot4");
+    int r4id = tree_->add_model_instance("robot4");
+    r4b1_->set_model_instance_id(r4id);
     r4b1_->set_name("body1");
   }
 
@@ -71,7 +75,7 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointNoOffset) {
   // Adds floating joints that connect r1b1_ and r2b1_ to the rigid body tree's
   // world at zero offset.
   r1b1->add_joint(&tree_->world(), std::make_unique<QuaternionFloatingJoint>(
-                                        "base", Isometry3d::Identity()));
+                                       "base", Isometry3d::Identity()));
 
   r2b1->add_joint(
       r1b1, std::make_unique<RevoluteJoint>("Joint1", Isometry3d::Identity(),
@@ -103,13 +107,11 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWithOffset) {
     T_r1and2_to_world.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
   }
 
-  r1b1->add_joint(&tree_->world(),
-                  std::make_unique<QuaternionFloatingJoint>(
-                      "base", T_r1and2_to_world));
+  r1b1->add_joint(&tree_->world(), std::make_unique<QuaternionFloatingJoint>(
+                                       "base", T_r1and2_to_world));
 
-  r2b1->add_joint(&tree_->world(),
-                  std::make_unique<QuaternionFloatingJoint>(
-                      "base", T_r1and2_to_world));
+  r2b1->add_joint(&tree_->world(), std::make_unique<QuaternionFloatingJoint>(
+                                       "base", T_r1and2_to_world));
 
   // Verfies that the two rigid bodies are located in the correct place.
   const DrakeJoint& jointR1B1 = tree_->FindBody("body1", "robot1")->getJoint();
@@ -128,9 +130,8 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
   // zero offset. Verifies that it is in the correct place.
   RigidBody<double>* r1b1 = tree_->add_rigid_body(std::move(r1b1_));
 
-  r1b1->add_joint(&tree_->world(),
-                  std::make_unique<QuaternionFloatingJoint>(
-                      "base", Isometry3d::Identity()));
+  r1b1->add_joint(&tree_->world(), std::make_unique<QuaternionFloatingJoint>(
+                                       "base", Isometry3d::Identity()));
 
   // Adds rigid body r2b1_ to the rigid body tree and welds it to r1b1_ with
   // offset x = 1, y = 1, z = 1. Verifies that it is in the correct place.
@@ -144,9 +145,8 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
     T_r2_to_r1.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
   }
 
-  r2b1->add_joint(&tree_->world(),
-                  std::make_unique<QuaternionFloatingJoint>(
-                      "base", T_r2_to_r1));
+  r2b1->add_joint(&tree_->world(), std::make_unique<QuaternionFloatingJoint>(
+                                       "base", T_r2_to_r1));
 
   // Adds rigid body r3b1 and r4b1 to the rigid body tree and welds it to r2b1
   // with offset x = 2, y = 2, z = 2. Verifies that it is in the correct place.
@@ -165,13 +165,11 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
       Eigen::aligned_allocator<RigidBodyFrame<double>>(), "body1",
       tree_->FindBody("body1", "robot2"), T_r3_and_r4_to_r2);
 
-  r3b1->add_joint(&tree_->world(),
-                  std::make_unique<QuaternionFloatingJoint>(
-                      "base", T_r3_and_r4_to_r2));
+  r3b1->add_joint(&tree_->world(), std::make_unique<QuaternionFloatingJoint>(
+                                       "base", T_r3_and_r4_to_r2));
 
-  r4b1->add_joint(&tree_->world(),
-                  std::make_unique<QuaternionFloatingJoint>(
-                      "base", T_r3_and_r4_to_r2));
+  r4b1->add_joint(&tree_->world(), std::make_unique<QuaternionFloatingJoint>(
+                                       "base", T_r3_and_r4_to_r2));
 
   EXPECT_TRUE(tree_->FindBody("body1", "robot1")
                   ->getJoint()
@@ -198,9 +196,8 @@ TEST_F(RigidBodyTreeTest, TestAddFloatingJointWeldToLink) {
 // with vector block input parameters. For more information, see:
 // https://github.com/RobotLocomotion/drake/issues/2634.
 TEST_F(RigidBodyTreeTest, TestDoKinematicsWithVectorBlocks) {
-  std::string filename =
-      drake::GetDrakePath() +
-      "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
+  std::string filename = drake::GetDrakePath() +
+                         "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
   AddModelInstanceFromUrdfFileWithRpyJointToWorld(filename, tree_.get());
 
   VectorX<double> q;
@@ -222,15 +219,14 @@ TEST_F(RigidBodyTreeTest, TestDoKinematicsWithVectorBlocks) {
 // model in the table. Furthermore, it should be called "two_dof_robot" and
 // the model instance ID should be 1 (zero was assigned to the world model).
 TEST_F(RigidBodyTreeTest, TestModelInstanceIdTable) {
-  std::string filename =
-      drake::GetDrakePath() +
-      "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
+  std::string filename = drake::GetDrakePath() +
+                         "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
 
   ModelInstanceIdTable model_instance_id_table =
       AddModelInstanceFromUrdfFileWithRpyJointToWorld(filename, tree_.get());
 
   const int kExpectedTableSize = 1;
-  const int kExpectedModelInstanceId = 0;
+  const int kExpectedModelInstanceId = 5;
   EXPECT_EQ(static_cast<int>(model_instance_id_table.size()),
             kExpectedTableSize);
   EXPECT_NE(model_instance_id_table.find("two_dof_robot"),
@@ -308,17 +304,20 @@ TEST_F(RigidBodyTreeTest, TestFindModelInstanceBodies) {
   // Verifies that the model instance IDs and model names are correct.
   for (const RigidBody<double>* body : two_dof_robot_bodies) {
     EXPECT_EQ(body->get_model_instance_id(), two_dof_model_instance_id);
-    EXPECT_EQ(body->get_model_name(), kTwoDofModelName);
+    EXPECT_EQ(tree_->get_model_name(body->get_model_instance_id()),
+              kTwoDofModelName);
   }
 
   for (const RigidBody<double>* body : three_dof_robot_bodies) {
     EXPECT_EQ(body->get_model_instance_id(), three_dof_model_instance_id);
-    EXPECT_EQ(body->get_model_name(), kThreeDofModelName);
+    EXPECT_EQ(tree_->get_model_name(body->get_model_instance_id()),
+              kThreeDofModelName);
   }
 
   for (const RigidBody<double>* body : four_dof_robot_bodies) {
     EXPECT_EQ(body->get_model_instance_id(), four_dof_model_instance_id);
-    EXPECT_EQ(body->get_model_name(), kFourDofModelName);
+    EXPECT_EQ(tree_->get_model_name(body->get_model_instance_id()),
+              kFourDofModelName);
   }
 
   // Verifies that the names of the RigidBodies fall into the expected range of
@@ -338,9 +337,8 @@ TEST_F(RigidBodyTreeTest, TestFindChildrenOfBodyAndFindBaseBodies) {
   // Stores the model instance IDs in model_instance_id_list.
   const int kNumModelInstances = 10;
 
-  std::string file_name =
-      drake::GetDrakePath() +
-      "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
+  std::string file_name = drake::GetDrakePath() +
+                          "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
 
   std::vector<int> model_instance_id_list;
 
@@ -432,7 +430,7 @@ TEST_F(RigidBodyTreeTest, TestGetNumActuators) {
       drake::GetDrakePath() +
       "/multibody/test/rigid_body_tree/four_dof_robot.urdf";
   AddModelInstanceFromUrdfFileWithRpyJointToWorld(filename_4dof_robot,
-                                                    tree_.get());
+                                                  tree_.get());
   EXPECT_EQ(tree_->get_num_actuators(), 4);
 }
 


### PR DESCRIPTION
(where it belongs).

related to #3053
resolves #3088

unfortunately contains a lot of clang-format changes, in addition to the few essential changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4492)
<!-- Reviewable:end -->
