### PR TITLE
Update eigen submodule SHA

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,7 +24,7 @@ git_repository(
 new_git_repository(
     name = "eigen",
     remote = "https://github.com/RobotLocomotion/eigen-mirror.git",
-    commit = "1b7acef29a4c53b5867e5d9da7e97bde436219f9",
+    commit = "d3ee2bc648be3d8be8c596a9a0aefef656ff8637",
     build_file = "tools/eigen.BUILD",
 )
 


### PR DESCRIPTION
Mostly for the purposes of packaging drake and consuming it locally. Eigen now exports a target `Eigen3::Eigen`, which avoids having to manually specify include directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4495)
<!-- Reviewable:end -->
