### PR TITLE
Bump LCM sha

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,7 +38,7 @@ new_git_repository(
 new_git_repository(
     name = "lcm",
     remote = "https://github.com/lcm-proj/lcm.git",
-    commit = "a8cda6a64b31739a781b67408c63bec08b15ab32",
+    commit = "9015dce5defd3902b1725bd091b80c0517774e40",
     build_file = "tools/lcm.BUILD",
 )
 

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -88,10 +88,6 @@ cc_binary(
         "-Wno-all",
         "-Wno-format-zero-length",
         "-std=gnu11",
-        # TODO(jwnimmer-tri) This hack should be removed when we ugprade
-        # to the latest LCM.
-        "-include",
-        "unistd.h",
     ],
     includes = ["."],
     deps = [":lcm"],


### PR DESCRIPTION
This removes a Bazel include nit, and possibly gives us some new Java-isn't-broken-anymore hotness.

Manual testing of `automotive_demo.py` went fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4509)
<!-- Reviewable:end -->
