### PR TITLE
Add missing dep from spdlog to pthreads

### DIFF
--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -5,5 +5,6 @@ cc_library(
     hdrs = glob(["include/spdlog/**"]),
     defines = ["HAVE_SPDLOG"],
     includes = ["include"],
+    linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This shows up from one of my future PRs that adds more stuff to Bazel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4547)
<!-- Reviewable:end -->
