### PR TITLE
Correct reference to iiwa arm in kuka simulation

### DIFF
--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -75,7 +75,7 @@ class SimulatedKuka : public systems::Diagram<T> {
       auto rigid_body_tree = std::make_unique<RigidBodyTree<double>>();
       drake::parsers::urdf::AddModelInstanceFromUrdfFile(
           drake::GetDrakePath() +
-          "/examples/kuka_iiwa_arm/urdf/iiwa14_no_collision.urdf",
+          "/examples/kuka_iiwa_arm/urdf/iiwa14_simplified_collision.urdf",
           drake::multibody::joints::kFixed,
           nullptr /* weld to frame */, rigid_body_tree.get());
 


### PR DESCRIPTION
PR #4511 made a number of changes to the iiwa specification.  Unfortunately, the reference to the iiwa arm in `kuka_simulation.cc` wasn't brought up to date.  This corrects that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4561)
<!-- Reviewable:end -->
