### PR TITLE
Add required test timeout; mistakenly removed in #4549

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -238,6 +238,10 @@ cc_googletest(
 
 cc_googletest(
     name = "system_identification_test",
+    # The test takes ~20 sec in opt mode but ~140 sec in dbg mode.
+    # To avoid timeouts in dbg or valgrind, we need "moderate" here.
+    # TODO(bazelbuild/bazel#1748) This produces a spurious complaint.
+    timeout = "moderate",
     deps = [
         ":system_identification",
         "//drake/common:eigen_matrix_compare",


### PR DESCRIPTION
Fixes CI break from #4549 in `linux-gcc-bazel-continuous-debug`.

Sadly, this produces a spurious complaint in all configurations now, per bazelbuild/bazel#1748.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4586)
<!-- Reviewable:end -->
