### PR TITLE
Move declaration of fcl option

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -219,10 +219,6 @@ macro(drake_setup_options)
     DEPENDS "HAVE_LCM\;HAVE_BOT_CORE_LCMTYPES\;NOT DISABLE_PYTHON"
     "VTK-based visualization tool and robot user interface")
 
-  drake_optional_external(FCL ON
-    DEPENDS "WITH_CCD\;WITH_OCTOMAP"
-    "Flexible collision detection library")
-
   drake_optional_external(GOOGLE_STYLEGUIDE ON
     DEPENDS "NOT DISABLE_PYTHON"
     "Google code style tools for cpplint.py style checking" ON)
@@ -246,6 +242,11 @@ macro(drake_setup_options)
 
   drake_optional_external(OCTOMAP ON
     "3D occupancy mapping library\; provides oct-tree data structures")
+
+  # Needs to be below ccd and octomap.
+  drake_optional_external(FCL ON
+    DEPENDS "WITH_CCD\;WITH_OCTOMAP"
+    "Flexible collision detection library")
 
   drake_optional_external(SPDLOG ON
     "Fast C++ text logging facility\; disabling will turn off text logging")


### PR DESCRIPTION
Needs to be below `ccd` and `octomap` otherwise CMake may need to be run twice if not called explicitly with `-DWITH_FCL=ON`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4598)
<!-- Reviewable:end -->
