### PR TITLE
Separate InputPortDescriptor from OutputPortDescriptor

### DIFF
--- a/drake/automotive/car_sim_lcm_common.cc
+++ b/drake/automotive/car_sim_lcm_common.cc
@@ -208,8 +208,8 @@ std::unique_ptr<systems::Diagram<double>> CreatCarSimLcmDiagram(
   // outer side of the turn.
   //
   MatrixX<double> matrix_gain(
-      controller->get_input_port(1).get_size(),
-      command_subscriber->get_output_port(0).get_size());
+      controller->get_input_port(1).size(),
+      command_subscriber->get_output_port(0).size());
   matrix_gain <<
       1,                 0,                  0,
       0,                 0,                  0,
@@ -217,9 +217,9 @@ std::unique_ptr<systems::Diagram<double>> CreatCarSimLcmDiagram(
       0,                 0,                  0,
       0, 1. / kWheelRadius, -1. / kWheelRadius,
       0, 1. / kWheelRadius, -1. / kWheelRadius;
-  DRAKE_ASSERT(matrix_gain.rows() == controller->get_input_port(1).get_size());
+  DRAKE_ASSERT(matrix_gain.rows() == controller->get_input_port(1).size());
   DRAKE_ASSERT(matrix_gain.cols() ==
-      command_subscriber->get_output_port(0).get_size());
+      command_subscriber->get_output_port(0).size());
 
   // TODO(liang.fok): Consider replacing the the MatrixGain system below with a
   // custom system that converts the user's commands to the vehicle's actuator's
@@ -231,7 +231,7 @@ std::unique_ptr<systems::Diagram<double>> CreatCarSimLcmDiagram(
 
   // Instantiates a constant vector source for the feed-forward torque command.
   // The feed-forward torque is zero.
-  VectorX<double> constant_vector(controller->get_input_port(0).get_size());
+  VectorX<double> constant_vector(controller->get_input_port(0).size());
   constant_vector.setZero();
   auto constant_zero_source =
       builder.template AddSystem<ConstantVectorSource<double>>(constant_vector);

--- a/drake/automotive/idm_planner.cc
+++ b/drake/automotive/idm_planner.cc
@@ -33,12 +33,12 @@ template <typename T>
 IdmPlanner<T>::~IdmPlanner() {}
 
 template <typename T>
-const systems::SystemPortDescriptor<T>& IdmPlanner<T>::get_ego_port() const {
+const systems::InputPortDescriptor<T>& IdmPlanner<T>::get_ego_port() const {
   return systems::System<T>::get_input_port(0);
 }
 
 template <typename T>
-const systems::SystemPortDescriptor<T>& IdmPlanner<T>::get_agent_port() const {
+const systems::InputPortDescriptor<T>& IdmPlanner<T>::get_agent_port() const {
   return systems::System<T>::get_input_port(1);
 }
 

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -34,10 +34,10 @@ class IdmPlanner : public systems::LeafSystem<T> {
   ~IdmPlanner() override;
 
   /// Returns the port to the ego car input subvector.
-  const systems::SystemPortDescriptor<T>& get_ego_port() const;
+  const systems::InputPortDescriptor<T>& get_ego_port() const;
 
   /// Returns the port to the agent car input subvector.
-  const systems::SystemPortDescriptor<T>& get_agent_port() const;
+  const systems::InputPortDescriptor<T>& get_agent_port() const;
 
   // System<T> overrides.
   // The output of this system is an algebraic relation of its inputs.

--- a/drake/automotive/linear_car.cc
+++ b/drake/automotive/linear_car.cc
@@ -28,12 +28,12 @@ template <typename T>
 LinearCar<T>::~LinearCar() {}
 
 template <typename T>
-const systems::SystemPortDescriptor<T>& LinearCar<T>::get_input_port() const {
+const systems::InputPortDescriptor<T>& LinearCar<T>::get_input_port() const {
   return systems::System<T>::get_input_port(0);
 }
 
 template <typename T>
-const systems::SystemPortDescriptor<T>& LinearCar<T>::get_output_port() const {
+const systems::OutputPortDescriptor<T>& LinearCar<T>::get_output_port() const {
   return systems::System<T>::get_output_port(0);
 }
 

--- a/drake/automotive/linear_car.h
+++ b/drake/automotive/linear_car.h
@@ -31,10 +31,10 @@ class LinearCar : public systems::LeafSystem<T> {
   ~LinearCar() override;
 
   /// Returns the input port.
-  const systems::SystemPortDescriptor<T>& get_input_port() const;
+  const systems::InputPortDescriptor<T>& get_input_port() const;
 
   /// Returns the output port.
-  const systems::SystemPortDescriptor<T>& get_output_port() const;
+  const systems::OutputPortDescriptor<T>& get_output_port() const;
 
   /// Sets the continuous states in @p context to default values.
   void SetDefaultState(const systems::Context<T>& context,

--- a/drake/automotive/simple_car.cc
+++ b/drake/automotive/simple_car.cc
@@ -151,7 +151,7 @@ SimpleCar<T>::AllocateContinuousState() const {
 
 template <typename T>
 std::unique_ptr<systems::BasicVector<T>> SimpleCar<T>::AllocateOutputVector(
-    const systems::SystemPortDescriptor<T>& descriptor) const {
+    const systems::OutputPortDescriptor<T>& descriptor) const {
   return std::make_unique<SimpleCarState<T>>();
 }
 

--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -62,7 +62,7 @@ class SimpleCar : public systems::LeafSystem<T> {
   std::unique_ptr<systems::ContinuousState<T>> AllocateContinuousState()
       const override;
   std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::SystemPortDescriptor<T>& descriptor) const override;
+      const systems::OutputPortDescriptor<T>& descriptor) const override;
 
  private:
   void ImplCalcOutput(const SimpleCarState<T>&, SimpleCarState<T>*) const;

--- a/drake/automotive/simple_car_to_euler_floating_joint.h
+++ b/drake/automotive/simple_car_to_euler_floating_joint.h
@@ -44,7 +44,7 @@ class SimpleCarToEulerFloatingJoint : public systems::LeafSystem<T> {
 
  protected:
   std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::SystemPortDescriptor<T>& descriptor) const override {
+      const systems::OutputPortDescriptor<T>& descriptor) const override {
     return std::make_unique<EulerFloatingJointState<T>>();
   }
 };

--- a/drake/automotive/test/idm_planner_test.cc
+++ b/drake/automotive/test/idm_planner_test.cc
@@ -21,7 +21,7 @@ class IdmPlannerTest : public ::testing::Test {
 
   void SetInputValue(const std::vector<double>& state) {
     int state_size =
-        dut_->get_ego_port().get_size() + dut_->get_ego_port().get_size();
+        dut_->get_ego_port().size() + dut_->get_ego_port().size();
     DRAKE_DEMAND(state_size == (int) state.size());
     // Get the state values.
     const double x_ego = state[0];
@@ -56,7 +56,7 @@ TEST_F(IdmPlannerTest, Topology) {
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_descriptor = dut_->get_output_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(1, output_descriptor.get_size());
+  EXPECT_EQ(1, output_descriptor.size());
 }
 
 // Set the initial states such that the agent and ego start at the

--- a/drake/automotive/test/idm_planner_test.cc
+++ b/drake/automotive/test/idm_planner_test.cc
@@ -52,13 +52,10 @@ TEST_F(IdmPlannerTest, Topology) {
   const auto& input_agent = dut_->get_agent_port();
   EXPECT_EQ(systems::kVectorValued, input_ego.get_data_type());
   EXPECT_EQ(systems::kVectorValued, input_agent.get_data_type());
-  EXPECT_EQ(systems::kInputPort, input_ego.get_face());
-  EXPECT_EQ(systems::kInputPort, input_agent.get_face());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_descriptor = dut_->get_output_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(systems::kOutputPort, output_descriptor.get_face());
   EXPECT_EQ(1, output_descriptor.get_size());
 }
 

--- a/drake/automotive/test/linear_car_test.cc
+++ b/drake/automotive/test/linear_car_test.cc
@@ -43,13 +43,11 @@ TEST_F(LinearCarTest, Topology) {
   ASSERT_EQ(1, dut_->get_num_input_ports());
   const auto& input_descriptor = dut_->get_input_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(systems::kInputPort, input_descriptor.get_face());
   EXPECT_EQ(1 /* one input: vdot */, input_descriptor.get_size());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_descriptor = dut_->get_output_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(systems::kOutputPort, output_descriptor.get_face());
   EXPECT_EQ(2 /* two outputs: x, v */, output_descriptor.get_size());
 }
 

--- a/drake/automotive/test/linear_car_test.cc
+++ b/drake/automotive/test/linear_car_test.cc
@@ -43,12 +43,12 @@ TEST_F(LinearCarTest, Topology) {
   ASSERT_EQ(1, dut_->get_num_input_ports());
   const auto& input_descriptor = dut_->get_input_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(1 /* one input: vdot */, input_descriptor.get_size());
+  EXPECT_EQ(1 /* one input: vdot */, input_descriptor.size());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_descriptor = dut_->get_output_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(2 /* two outputs: x, v */, output_descriptor.get_size());
+  EXPECT_EQ(2 /* two outputs: x, v */, output_descriptor.size());
 }
 
 TEST_F(LinearCarTest, Output) {

--- a/drake/automotive/test/simple_car_test.cc
+++ b/drake/automotive/test/simple_car_test.cc
@@ -46,13 +46,13 @@ TEST_F(SimpleCarTest, Topology) {
   const auto& input_descriptor = dut_->get_input_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, input_descriptor.get_data_type());
   EXPECT_EQ(DrivingCommandIndices::kNumCoordinates,
-            input_descriptor.get_size());
+            input_descriptor.size());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_descriptor = dut_->get_output_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
   EXPECT_EQ(SimpleCarStateIndices::kNumCoordinates,
-            output_descriptor.get_size());
+            output_descriptor.size());
 }
 
 TEST_F(SimpleCarTest, Output) {

--- a/drake/automotive/test/simple_car_test.cc
+++ b/drake/automotive/test/simple_car_test.cc
@@ -45,14 +45,12 @@ TEST_F(SimpleCarTest, Topology) {
   ASSERT_EQ(1, dut_->get_num_input_ports());
   const auto& input_descriptor = dut_->get_input_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(systems::kInputPort, input_descriptor.get_face());
   EXPECT_EQ(DrivingCommandIndices::kNumCoordinates,
             input_descriptor.get_size());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_descriptor = dut_->get_output_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(systems::kOutputPort, output_descriptor.get_face());
   EXPECT_EQ(SimpleCarStateIndices::kNumCoordinates,
             output_descriptor.get_size());
 }

--- a/drake/automotive/test/single_lane_ego_and_agent_test.cc
+++ b/drake/automotive/test/single_lane_ego_and_agent_test.cc
@@ -57,8 +57,6 @@ TEST_F(SingleLaneEgoAndAgentTest, Topology) {
 
   EXPECT_EQ(systems::kVectorValued, output_ego_car_pos.get_data_type());
   EXPECT_EQ(systems::kVectorValued, output_agent_car_pos.get_data_type());
-  EXPECT_EQ(systems::kOutputPort, output_ego_car_pos.get_face());
-  EXPECT_EQ(systems::kOutputPort, output_agent_car_pos.get_face());
   EXPECT_EQ(2 /* two outputs: x, v */, output_ego_car_pos.get_size());
   EXPECT_EQ(2 /* two outputs: x, v */, output_agent_car_pos.get_size());
 }

--- a/drake/automotive/test/single_lane_ego_and_agent_test.cc
+++ b/drake/automotive/test/single_lane_ego_and_agent_test.cc
@@ -57,8 +57,8 @@ TEST_F(SingleLaneEgoAndAgentTest, Topology) {
 
   EXPECT_EQ(systems::kVectorValued, output_ego_car_pos.get_data_type());
   EXPECT_EQ(systems::kVectorValued, output_agent_car_pos.get_data_type());
-  EXPECT_EQ(2 /* two outputs: x, v */, output_ego_car_pos.get_size());
-  EXPECT_EQ(2 /* two outputs: x, v */, output_agent_car_pos.get_size());
+  EXPECT_EQ(2 /* two outputs: x, v */, output_ego_car_pos.size());
+  EXPECT_EQ(2 /* two outputs: x, v */, output_agent_car_pos.size());
 }
 
 TEST_F(SingleLaneEgoAndAgentTest, EvalOutput) {

--- a/drake/automotive/trajectory_car.h
+++ b/drake/automotive/trajectory_car.h
@@ -51,7 +51,7 @@ class TrajectoryCar : public systems::LeafSystem<T> {
   }
 
   std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::SystemPortDescriptor<T>& descriptor) const override {
+      const systems::OutputPortDescriptor<T>& descriptor) const override {
     return std::make_unique<SimpleCarState<T>>();
   }
 

--- a/drake/examples/Acrobot/acrobot_plant.cc
+++ b/drake/examples/Acrobot/acrobot_plant.cc
@@ -93,7 +93,7 @@ AcrobotPlant<T>::AllocateContinuousState() const {
 template <typename T>
 std::unique_ptr<systems::BasicVector<T>> AcrobotPlant<T>::AllocateOutputVector(
     const systems::OutputPortDescriptor<T>& descriptor) const {
-  DRAKE_THROW_UNLESS(descriptor.get_size() == kNumDOF * 2);
+  DRAKE_THROW_UNLESS(descriptor.size() == kNumDOF * 2);
   return std::make_unique<AcrobotStateVector<T>>();
 }
 

--- a/drake/examples/Acrobot/acrobot_plant.cc
+++ b/drake/examples/Acrobot/acrobot_plant.cc
@@ -92,7 +92,7 @@ AcrobotPlant<T>::AllocateContinuousState() const {
 
 template <typename T>
 std::unique_ptr<systems::BasicVector<T>> AcrobotPlant<T>::AllocateOutputVector(
-    const systems::SystemPortDescriptor<T>& descriptor) const {
+    const systems::OutputPortDescriptor<T>& descriptor) const {
   DRAKE_THROW_UNLESS(descriptor.get_size() == kNumDOF * 2);
   return std::make_unique<AcrobotStateVector<T>>();
 }

--- a/drake/examples/Acrobot/acrobot_plant.h
+++ b/drake/examples/Acrobot/acrobot_plant.h
@@ -49,7 +49,7 @@ class AcrobotPlant : public systems::LeafSystem<T> {
 
   // LeafSystem<T> override.
   std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::SystemPortDescriptor<T>& descriptor) const override;
+      const systems::OutputPortDescriptor<T>& descriptor) const override;
 
   // System<T> override.
   AcrobotPlant<AutoDiffXd>* DoToAutoDiffXd() const override;

--- a/drake/examples/Pendulum/pendulum_plant.cc
+++ b/drake/examples/Pendulum/pendulum_plant.cc
@@ -21,13 +21,13 @@ template <typename T>
 PendulumPlant<T>::~PendulumPlant() {}
 
 template <typename T>
-const systems::SystemPortDescriptor<T>&
+const systems::InputPortDescriptor<T>&
 PendulumPlant<T>::get_tau_port() const {
   return this->get_input_port(0);
 }
 
 template <typename T>
-const systems::SystemPortDescriptor<T>&
+const systems::OutputPortDescriptor<T>&
 PendulumPlant<T>::get_output_port() const {
   return systems::System<T>::get_output_port(0);
 }
@@ -35,7 +35,7 @@ PendulumPlant<T>::get_output_port() const {
 template <typename T>
 std::unique_ptr<systems::BasicVector<T>>
 PendulumPlant<T>::AllocateOutputVector(
-    const systems::SystemPortDescriptor<T>& descriptor) const {
+    const systems::OutputPortDescriptor<T>& descriptor) const {
   DRAKE_THROW_UNLESS(descriptor.get_size() == kStateSize);
   return std::make_unique<PendulumStateVector<T>>();
 }

--- a/drake/examples/Pendulum/pendulum_plant.cc
+++ b/drake/examples/Pendulum/pendulum_plant.cc
@@ -36,7 +36,7 @@ template <typename T>
 std::unique_ptr<systems::BasicVector<T>>
 PendulumPlant<T>::AllocateOutputVector(
     const systems::OutputPortDescriptor<T>& descriptor) const {
-  DRAKE_THROW_UNLESS(descriptor.get_size() == kStateSize);
+  DRAKE_THROW_UNLESS(descriptor.size() == kStateSize);
   return std::make_unique<PendulumStateVector<T>>();
 }
 

--- a/drake/examples/Pendulum/pendulum_plant.h
+++ b/drake/examples/Pendulum/pendulum_plant.h
@@ -32,10 +32,10 @@ class PendulumPlant : public systems::LeafSystem<T> {
   bool has_any_direct_feedthrough() const override { return false; }
 
   /// Returns the input port to the externally applied force.
-  const systems::SystemPortDescriptor<T>& get_tau_port() const;
+  const systems::InputPortDescriptor<T>& get_tau_port() const;
 
   /// Returns the port to output state.
-  const systems::SystemPortDescriptor<T>& get_output_port() const;
+  const systems::OutputPortDescriptor<T>& get_output_port() const;
 
   void set_theta(MyContext* context, const T& theta) const {
     get_mutable_state(context)->set_theta(theta);
@@ -65,7 +65,7 @@ class PendulumPlant : public systems::LeafSystem<T> {
   AllocateContinuousState() const override;
 
   std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::SystemPortDescriptor<T>& descriptor) const override;
+      const systems::OutputPortDescriptor<T>& descriptor) const override;
 
   // System<T> override.
   PendulumPlant<AutoDiffXd>* DoToAutoDiffXd() const override;

--- a/drake/examples/Pendulum/pendulum_run_energy_shaping.cc
+++ b/drake/examples/Pendulum/pendulum_run_energy_shaping.cc
@@ -27,9 +27,9 @@ class PendulumEnergyShapingController : public systems::LeafSystem<T> {
         b_(pendulum.b()),
         g_(pendulum.g()) {
     this->DeclareInputPort(systems::kVectorValued,
-                           pendulum.get_output_port().get_size());
+                           pendulum.get_output_port().size());
     this->DeclareOutputPort(systems::kVectorValued,
-                            pendulum.get_tau_port().get_size());
+                            pendulum.get_tau_port().size());
   }
 
  private:

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h
@@ -12,7 +12,8 @@ namespace qp_inverse_dynamics {
 
 using systems::Context;
 using systems::SystemOutput;
-using systems::SystemPortDescriptor;
+using systems::InputPortDescriptor;
+using systems::OutputPortDescriptor;
 using systems::LeafSystemOutput;
 using systems::AbstractValue;
 using systems::BasicVector;
@@ -127,7 +128,7 @@ class JointLevelControllerSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: HumanoidStatus.
    */
-  inline const SystemPortDescriptor<double>& get_input_port_humanoid_status()
+  inline const InputPortDescriptor<double>& get_input_port_humanoid_status()
       const {
     return get_input_port(in_port_idx_humanoid_status_);
   }
@@ -135,14 +136,14 @@ class JointLevelControllerSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: QPOutput.
    */
-  inline const SystemPortDescriptor<double>& get_input_port_qp_output() const {
+  inline const InputPortDescriptor<double>& get_input_port_qp_output() const {
     return get_input_port(in_port_idx_qp_output_);
   }
 
   /**
    * @return Port for the output: bot_core::atlas_command_t message
    */
-  inline const SystemPortDescriptor<double>& get_output_port_atlas_command()
+  inline const OutputPortDescriptor<double>& get_output_port_atlas_command()
       const {
     return get_output_port(out_port_index_atlas_cmd_);
   }

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_system.h
@@ -112,7 +112,7 @@ class PlanEvalSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: HumanoidStatus.
    */
-  inline const SystemPortDescriptor<double>& get_input_port_humanoid_status()
+  inline const InputPortDescriptor<double>& get_input_port_humanoid_status()
       const {
     return get_input_port(input_port_index_humanoid_status_);
   }
@@ -120,7 +120,7 @@ class PlanEvalSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the output: QPInput.
    */
-  inline const SystemPortDescriptor<double>& get_output_port_qp_input() const {
+  inline const OutputPortDescriptor<double>& get_output_port_qp_input() const {
     return get_output_port(output_port_index_qp_input_);
   }
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h
@@ -67,7 +67,7 @@ class QPControllerSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: HumanoidStatus.
    */
-  inline const SystemPortDescriptor<double>& get_input_port_humanoid_status()
+  inline const InputPortDescriptor<double>& get_input_port_humanoid_status()
       const {
     return get_input_port(input_port_index_humanoid_status_);
   }
@@ -75,14 +75,14 @@ class QPControllerSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: QPInput.
    */
-  inline const SystemPortDescriptor<double>& get_input_port_qp_input() const {
+  inline const InputPortDescriptor<double>& get_input_port_qp_input() const {
     return get_input_port(input_port_index_qp_input_);
   }
 
   /**
    * @return Port for the output: QPOutput.
    */
-  inline const SystemPortDescriptor<double>& get_output_port_qp_output() const {
+  inline const OutputPortDescriptor<double>& get_output_port_qp_output() const {
     return get_output_port(output_port_index_qp_input_);
   }
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/robot_state_decoder_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/robot_state_decoder_system.h
@@ -10,7 +10,8 @@ namespace qp_inverse_dynamics {
 
 using systems::Context;
 using systems::SystemOutput;
-using systems::SystemPortDescriptor;
+using systems::InputPortDescriptor;
+using systems::OutputPortDescriptor;
 using systems::LeafSystemOutput;
 using systems::AbstractValue;
 using systems::Value;
@@ -69,7 +70,7 @@ class RobotStateDecoderSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: lcm message bot_core::robot_state_t
    */
-  inline const SystemPortDescriptor<double>& get_input_port_robot_state_msg()
+  inline const InputPortDescriptor<double>& get_input_port_robot_state_msg()
       const {
     return get_input_port(input_port_index_lcm_msg_);
   }
@@ -77,7 +78,7 @@ class RobotStateDecoderSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the output: HumanoidStatus.
    */
-  inline const SystemPortDescriptor<double>& get_output_port_humanoid_status()
+  inline const OutputPortDescriptor<double>& get_output_port_humanoid_status()
       const {
     return get_output_port(output_port_index_humanoid_status_);
   }

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.cc
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.cc
@@ -43,7 +43,7 @@ ActuatorEffortToRigidBodyPlantInputConverter<T>::DeclareEffortInputPorts(
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& ActuatorEffortToRigidBodyPlantInputConverter<
+const InputPortDescriptor<T>& ActuatorEffortToRigidBodyPlantInputConverter<
     T>::effort_input_port(const RigidBodyActuator& actuator) {
   return get_input_port(effort_ports_indices_.at(&actuator));
 }

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
@@ -33,7 +33,7 @@ class ActuatorEffortToRigidBodyPlantInputConverter : public LeafSystem<T> {
 
   /// Returns the descriptor of the effort input port corresponding for
   /// @param actuator
-  const SystemPortDescriptor<T>& effort_input_port(
+  const InputPortDescriptor<T>& effort_input_port(
       const RigidBodyActuator& actuator);
 
  private:

--- a/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.cc
+++ b/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.cc
@@ -49,7 +49,7 @@ void RobotCommandToDesiredEffortConverter::DoCalcOutput(
   }
 }
 
-const SystemPortDescriptor<double>&
+const OutputPortDescriptor<double>&
 RobotCommandToDesiredEffortConverter::desired_effort_output_port(
     const RigidBodyActuator& actuator) const {
   return get_output_port(desired_effort_port_indices_.at(&actuator));

--- a/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h
+++ b/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h
@@ -42,7 +42,7 @@ class RobotCommandToDesiredEffortConverter
 
   /// Descriptor of output port that presents desired effort for @param
   /// actuator.
-  const SystemPortDescriptor<double>& desired_effort_output_port(
+  const OutputPortDescriptor<double>& desired_effort_output_port(
       const RigidBodyActuator& actuator) const;
 
  private:

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -88,22 +88,22 @@ std::unique_ptr<SystemOutput<double>> RobotStateEncoder::AllocateOutput(
   return std::unique_ptr<SystemOutput<double>>(output.release());
 }
 
-const SystemPortDescriptor<double>& RobotStateEncoder::lcm_message_port()
+const OutputPortDescriptor<double>& RobotStateEncoder::lcm_message_port()
     const {
   return get_output_port(lcm_message_port_index_);
 }
 
-const SystemPortDescriptor<double>& RobotStateEncoder::kinematics_results_port()
+const InputPortDescriptor<double>& RobotStateEncoder::kinematics_results_port()
     const {
   return get_input_port(kinematics_results_port_index_);
 }
 
-const SystemPortDescriptor<double>& RobotStateEncoder::contact_results_port()
+const InputPortDescriptor<double>& RobotStateEncoder::contact_results_port()
     const {
   return get_input_port(contact_results_port_index_);
 }
 
-const SystemPortDescriptor<double>& RobotStateEncoder::effort_port(
+const InputPortDescriptor<double>& RobotStateEncoder::effort_port(
     const RigidBodyActuator& actuator) const {
   return get_input_port(effort_port_indices_.at(&actuator));
 }

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -44,16 +44,16 @@ class RobotStateEncoder final : public LeafSystem<double> {
       const Context<double>& context) const override;
 
   /// Returns descriptor of output port on which the LCM message is presented.
-  const SystemPortDescriptor<double>& lcm_message_port() const;
+  const OutputPortDescriptor<double>& lcm_message_port() const;
 
   /// Returns descriptor of kinematics result input port.
-  const SystemPortDescriptor<double>& kinematics_results_port() const;
+  const InputPortDescriptor<double>& kinematics_results_port() const;
 
   /// Returns descriptor of contact results input port.
-  const SystemPortDescriptor<double>& contact_results_port() const;
+  const InputPortDescriptor<double>& contact_results_port() const;
 
   /// Returns descriptor of effort input port corresponding to @param actuator.
-  const SystemPortDescriptor<double>& effort_port(
+  const InputPortDescriptor<double>& effort_port(
       const RigidBodyActuator& actuator) const;
 
  private:

--- a/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
+++ b/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
@@ -24,12 +24,12 @@ class ValkyriePDAndFeedForwardController : public systems::LeafSystem<double> {
     return std::move(output);
   }
 
-  inline const SystemPortDescriptor<double>& get_input_port_kinematics_result()
+  inline const InputPortDescriptor<double>& get_input_port_kinematics_result()
       const {
     return get_input_port(input_port_index_kinematics_result_);
   }
 
-  inline const SystemPortDescriptor<double>& get_output_port_atlas_command()
+  inline const OutputPortDescriptor<double>& get_output_port_atlas_command()
       const {
     return get_output_port(output_port_index_atlas_command_);
   }

--- a/drake/examples/bouncing_ball/test/ball_test.cc
+++ b/drake/examples/bouncing_ball/test/ball_test.cc
@@ -41,7 +41,6 @@ TEST_F(BallTest, Topology) {
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_descriptor = dut_->get_output_ports().at(0);
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(systems::kOutputPort, output_descriptor.get_face());
 }
 
 TEST_F(BallTest, Output) {

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo.cc
@@ -181,7 +181,7 @@ class KukaDemo : public systems::Diagram<T> {
         make_unique<RigidBodyPlant<T>>(move(tree));
     plant_ = plant.get();
 
-    DRAKE_ASSERT(plant_->get_input_port(0).get_size() ==
+    DRAKE_ASSERT(plant_->get_input_port(0).size() ==
                  plant_->get_num_positions());
 
     // Create and add PID controller.

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
@@ -30,11 +30,11 @@ class IiwaStatusSender : public systems::LeafSystem<double> {
  public:
   IiwaStatusSender();
 
-  const systems::SystemPortDescriptor<double>& get_command_input_port() const {
+  const systems::InputPortDescriptor<double>& get_command_input_port() const {
     return this->get_input_port(0);
   }
 
-  const systems::SystemPortDescriptor<double>& get_state_input_port() const {
+  const systems::InputPortDescriptor<double>& get_state_input_port() const {
     return this->get_input_port(1);
   }
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
@@ -68,7 +68,7 @@ PassiveVisualizedPlant<T>::PassiveVisualizedPlant(
   // Sets up a builder for the demo.
   DiagramBuilder<T> builder;
 
-  const int num_inputs = visualized_plant->get_input_port(0).get_size();
+  const int num_inputs = visualized_plant->get_input_port(0).size();
   visualized_plant_ = builder.template AddSystem<VisualizedPlant<T>>(
       std::move(visualized_plant));
 

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -86,7 +86,7 @@ class SimulatedKuka : public systems::Diagram<T> {
           std::move(rigid_body_tree));
       plant_ = plant.get();
 
-      DRAKE_ASSERT(plant_->get_input_port(0).get_size() ==
+      DRAKE_ASSERT(plant_->get_input_port(0).size() ==
                    plant_->get_num_positions());
 
       // Constants are chosen by trial and error to qualitatively match

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
@@ -17,7 +17,6 @@ namespace schunk_wsg {
 using systems::Context;
 using systems::DiscreteState;
 using systems::SystemOutput;
-using systems::SystemPortDescriptor;
 
 SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(
     int input_size, int position_index)

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.h
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.h
@@ -29,11 +29,11 @@ class SchunkWsgTrajectoryGenerator : public systems::LeafSystem<double> {
   /// which contains the position of the actuated finger.
   SchunkWsgTrajectoryGenerator(int input_size, int position_index);
 
-  const systems::SystemPortDescriptor<double>& get_command_input_port() const {
+  const systems::InputPortDescriptor<double>& get_command_input_port() const {
     return this->get_input_port(0);
   }
 
-  const systems::SystemPortDescriptor<double>& get_state_input_port() const {
+  const systems::InputPortDescriptor<double>& get_state_input_port() const {
     return this->get_input_port(1);
   }
 

--- a/drake/examples/toyota_hsrb/hsrb_diagram_factories.cc
+++ b/drake/examples/toyota_hsrb/hsrb_diagram_factories.cc
@@ -91,7 +91,7 @@ std::unique_ptr<Diagram<double>> BuildConstantSourceToPlantDiagram(
   Diagram<double>* plant_diagram_ptr =
       builder.AddSystem(std::move(plant_diagram));
   VectorX<double> constant_vector(
-      plant_diagram_ptr->get_input_port(0).get_size());
+      plant_diagram_ptr->get_input_port(0).size());
   constant_vector.setZero();
   auto constant_zero_source =
       builder.template AddSystem<ConstantVectorSource<double>>(constant_vector);

--- a/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc
+++ b/drake/examples/toyota_hsrb/test/hsrb_system_factories_test.cc
@@ -232,7 +232,7 @@ TEST_F(ToyotaHsrbTests, TestBuildPlantAndVisualizerDiagram) {
   ASSERT_EQ(plant_->get_num_velocities(), kNumVelocities);
   ASSERT_EQ(plant_->get_num_states(), kNumStates);
   ASSERT_EQ(plant_->get_num_actuators(), kNumActuators);
-  ASSERT_EQ(dut->get_input_port(0).get_size(), kNumActuators);
+  ASSERT_EQ(dut->get_input_port(0).size(), kNumActuators);
 
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
@@ -267,7 +267,7 @@ TEST_F(ToyotaHsrbTests, TestBuildConstantSourceToPlantDiagram) {
   EXPECT_EQ(dut->get_num_input_ports(), 0);
   EXPECT_EQ(dut->get_num_output_ports(), plant_->get_num_output_ports());
 
-  EXPECT_EQ(dut->get_output_port(0).get_size(), kNumStates);
+  EXPECT_EQ(dut->get_output_port(0).size(), kNumStates);
 
   // Verifies all expected systems exist.
   std::vector<const System<double>*> systems = dut->GetSystems();

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -286,7 +286,7 @@ template <typename T>
 std::unique_ptr<ContinuousState<T>> RigidBodyPlant<T>::AllocateContinuousState()
     const {
   // The state is second-order.
-  DRAKE_ASSERT(System<T>::get_input_port(0).get_size() == get_num_actuators());
+  DRAKE_ASSERT(System<T>::get_input_port(0).size() == get_num_actuators());
   // TODO(amcastro-tri): add z state to track energy conservation.
   return std::make_unique<ContinuousState<T>>(
       std::make_unique<BasicVector<T>>(get_num_states()),

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -194,17 +194,17 @@ class RigidBodyPlant : public LeafSystem<T> {
   static T JointLimitForce(const DrakeJoint& joint,
                            const T& position, const T& velocity);
 
-  /// Returns a descriptor of state output port.
+  /// Returns a descriptor of the state output port.
   const OutputPortDescriptor<T>& state_output_port() const {
     return System<T>::get_output_port(state_output_port_id_);
   }
 
-  /// Returns a descriptor of KinematicsResults output port.
+  /// Returns a descriptor of the KinematicsResults output port.
   const OutputPortDescriptor<T>& kinematics_results_output_port() const {
     return System<T>::get_output_port(kinematics_output_port_id_);
   }
 
-  /// Returns a descriptor of ContactResults output port.
+  /// Returns a descriptor of the ContactResults output port.
   const OutputPortDescriptor<T>& contact_results_output_port() const {
     return System<T>::get_output_port(contact_output_port_id_);
   }

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -195,30 +195,30 @@ class RigidBodyPlant : public LeafSystem<T> {
                            const T& position, const T& velocity);
 
   /// Returns a descriptor of state output port.
-  const SystemPortDescriptor<T>& state_output_port() const {
+  const OutputPortDescriptor<T>& state_output_port() const {
     return System<T>::get_output_port(state_output_port_id_);
   }
 
   /// Returns a descriptor of KinematicsResults output port.
-  const SystemPortDescriptor<T>& kinematics_results_output_port() const {
+  const OutputPortDescriptor<T>& kinematics_results_output_port() const {
     return System<T>::get_output_port(kinematics_output_port_id_);
   }
 
   /// Returns a descriptor of ContactResults output port.
-  const SystemPortDescriptor<T>& contact_results_output_port() const {
+  const OutputPortDescriptor<T>& contact_results_output_port() const {
     return System<T>::get_output_port(contact_output_port_id_);
   }
 
   /// Returns a descriptor of the input port for a specific model
   /// instance.
-  const SystemPortDescriptor<T>& model_input_port(
+  const InputPortDescriptor<T>& model_input_port(
       int model_instance_id) const {
     return System<T>::get_input_port(input_map_.at(model_instance_id));
   }
 
   /// Returns a descriptor of the output port for a specific model
   /// instance.
-  const SystemPortDescriptor<T>& model_state_output_port(
+  const OutputPortDescriptor<T>& model_state_output_port(
       int model_instance_id) const {
     return System<T>::get_output_port(output_map_.at(model_instance_id));
   }

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -262,8 +262,8 @@ TEST_F(KukaArmTest, EvalOutput) {
   ASSERT_EQ(kNumStates_, kuka_plant_->get_num_states(0));
   ASSERT_EQ(kNumActuators_, kuka_plant_->get_num_actuators());
   ASSERT_EQ(kNumActuators_, kuka_plant_->get_num_actuators(0));
-  ASSERT_EQ(kNumActuators_, kuka_plant_->get_input_port(0).get_size());
-  ASSERT_EQ(kNumActuators_, kuka_plant_->model_input_port(0).get_size());
+  ASSERT_EQ(kNumActuators_, kuka_plant_->get_input_port(0).size());
+  ASSERT_EQ(kNumActuators_, kuka_plant_->model_input_port(0).size());
 
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have

--- a/drake/systems/controllers/gravity_compensator.cc
+++ b/drake/systems/controllers/gravity_compensator.cc
@@ -36,7 +36,7 @@ void GravityCompensator<T>::DoCalcOutput(const Context<T>& context,
   Eigen::VectorXd g = tree_.dynamicsBiasTerm(
       cache, f_ext, false /* include velocity terms */);
 
-  DRAKE_ASSERT(g.size() == System<T>::get_output_port(0).get_size());
+  DRAKE_ASSERT(g.size() == System<T>::get_output_port(0).size());
   System<T>::GetMutableOutputVector(output, 0) = g;
 }
 

--- a/drake/systems/controllers/linear_quadratic_regulator.cc
+++ b/drake/systems/controllers/linear_quadratic_regulator.cc
@@ -74,7 +74,7 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
   // but note that it will be a full quadratic form (x'S2x + s1'x + s0).
 
   DRAKE_DEMAND(system.get_num_input_ports() == 1);
-  const int num_inputs = system.get_input_port(0).get_size(),
+  const int num_inputs = system.get_input_port(0).size(),
             num_states = context.get_continuous_state()->size();
   DRAKE_DEMAND(num_states > 0);
   DRAKE_DEMAND(context.has_only_continuous_state());

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -65,11 +65,11 @@ void PidControlledSystem<T>::Initialize(
 }
 
 template <typename T>
-std::pair<const SystemPortDescriptor<T>,
-          const SystemPortDescriptor<T>>
+std::pair<const InputPortDescriptor<T>,
+          const InputPortDescriptor<T>>
     PidControlledSystem<T>::ConnectController(
-        const SystemPortDescriptor<T>& plant_input,
-        const SystemPortDescriptor<T>& plant_output,
+        const InputPortDescriptor<T>& plant_input,
+        const OutputPortDescriptor<T>& plant_output,
         std::unique_ptr<MatrixGain<T>> feedback_selector,
         const VectorX<T>& Kp, const VectorX<T>& Ki,
         const VectorX<T>& Kd,

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -27,11 +27,11 @@ PidControlledSystem<T>::PidControlledSystem(
     std::unique_ptr<MatrixGain<T>> feedback_selector,
     const T& Kp, const T& Ki, const T& Kd) {
   const VectorX<T> Kp_v =
-      VectorX<T>::Ones(plant->get_input_port(0).get_size()) * Kp;
+      VectorX<T>::Ones(plant->get_input_port(0).size()) * Kp;
   const VectorX<T> Ki_v =
-      VectorX<T>::Ones(plant->get_input_port(0).get_size()) * Ki;
+      VectorX<T>::Ones(plant->get_input_port(0).size()) * Ki;
   const VectorX<T> Kd_v =
-      VectorX<T>::Ones(plant->get_input_port(0).get_size()) * Kd;
+      VectorX<T>::Ones(plant->get_input_port(0).size()) * Kd;
   Initialize(std::move(plant), std::move(feedback_selector), Kp_v, Ki_v, Kd_v);
 }
 
@@ -79,17 +79,17 @@ std::pair<const InputPortDescriptor<T>,
     // identity matrix, which results in every element of the plant's output
     // port zero being used as the feedback signal to the PID controller.
     feedback_selector =
-        std::make_unique<MatrixGain<T>>(plant_output.get_size());
+        std::make_unique<MatrixGain<T>>(plant_output.size());
   }
   auto feedback_selector_p =
       builder->template AddSystem(std::move(feedback_selector));
 
-  DRAKE_ASSERT(plant_output.get_size() ==
-               feedback_selector_p->get_input_port().get_size());
-  const int num_effort_commands = plant_input.get_size();
+  DRAKE_ASSERT(plant_output.size() ==
+               feedback_selector_p->get_input_port().size());
+  const int num_effort_commands = plant_input.size();
   const int num_states = num_effort_commands * 2;
 
-  DRAKE_ASSERT(feedback_selector_p->get_output_port().get_size() == num_states);
+  DRAKE_ASSERT(feedback_selector_p->get_output_port().size() == num_states);
 
   auto state_minus_target = builder->template AddSystem<Adder<T>>(
       2, num_states);

--- a/drake/systems/controllers/pid_controlled_system.h
+++ b/drake/systems/controllers/pid_controlled_system.h
@@ -131,12 +131,12 @@ class PidControlledSystem : public Diagram<T> {
   System<T>* plant() { return plant_; }
 
   /// @return the input port for the feed forward control input.
-  const SystemPortDescriptor<T>& get_control_input_port() const {
+  const InputPortDescriptor<T>& get_control_input_port() const {
     return this->get_input_port(0);
   }
 
   /// @return the input port for the desired position/velocity state.
-  const SystemPortDescriptor<T>& get_state_input_port() const {
+  const InputPortDescriptor<T>& get_state_input_port() const {
     return this->get_input_port(1);
   }
 
@@ -147,10 +147,10 @@ class PidControlledSystem : public Diagram<T> {
   /// feed forward control input, the second is the feedback state
   /// input.  @p controller will be populated with a pointer to the
   /// newly created PidController.
-  static std::pair<const SystemPortDescriptor<T>,
-                   const SystemPortDescriptor<T>> ConnectController(
-                       const SystemPortDescriptor<T>& plant_input,
-                       const SystemPortDescriptor<T>& plant_output,
+  static std::pair<const InputPortDescriptor<T>,
+                   const InputPortDescriptor<T>> ConnectController(
+                       const InputPortDescriptor<T>& plant_input,
+                       const OutputPortDescriptor<T>& plant_output,
                        std::unique_ptr<MatrixGain<T>> feedback_selector,
                        const VectorX<T>& Kp, const VectorX<T>& Ki,
                        const VectorX<T>& Kd,

--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -90,19 +90,19 @@ bool PidController<T>::has_any_direct_feedthrough() const {
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& PidController<T>::get_error_port() const {
+const InputPortDescriptor<T>& PidController<T>::get_error_port() const {
   return Diagram<T>::get_input_port(0);
 }
 
 template <typename T>
-const SystemPortDescriptor<T>&
+const InputPortDescriptor<T>&
 PidController<T>::get_error_derivative_port() const {
   return Diagram<T>::get_input_port(1);
 }
 
 
 template <typename T>
-const SystemPortDescriptor<T>&
+const OutputPortDescriptor<T>&
 PidController<T>::get_control_output_port() const {
   return System<T>::get_output_port(0);
 }

--- a/drake/systems/controllers/pid_controller.h
+++ b/drake/systems/controllers/pid_controller.h
@@ -96,13 +96,13 @@ class PidController : public Diagram<T> {
                           const Eigen::Ref<const VectorX<T>>& value) const;
 
   /// Returns the input port to the error signal.
-  const SystemPortDescriptor<T>& get_error_port() const;
+  const InputPortDescriptor<T>& get_error_port() const;
 
   /// Returns the input port to the time derivative or rate of the error signal.
-  const SystemPortDescriptor<T>& get_error_derivative_port() const;
+  const InputPortDescriptor<T>& get_error_derivative_port() const;
 
   /// Returns the output port to the control output.
-  const SystemPortDescriptor<T>& get_control_output_port() const;
+  const OutputPortDescriptor<T>& get_control_output_port() const;
 
  private:
   Adder<T>* adder_ = nullptr;

--- a/drake/systems/controllers/test/pid_controlled_system_test.cc
+++ b/drake/systems/controllers/test/pid_controlled_system_test.cc
@@ -148,7 +148,7 @@ GTEST_TEST(PidControlledSystemTest, SimplePidControlledSystem) {
   auto plant = std::make_unique<TestPlantWithMinOutputs>();
   auto feedback_selector =
       std::make_unique<MatrixGain<double>>(
-          plant->get_output_port(0).get_size());
+          plant->get_output_port(0).size());
   DoPidControlledSystemTest(std::move(plant), std::move(feedback_selector));
 }
 
@@ -157,8 +157,8 @@ GTEST_TEST(PidControlledSystemTest, SimplePidControlledSystem) {
 // of input port zero.
 GTEST_TEST(PidControlledSystemTest, PlantWithMoreOutputs) {
   auto plant = std::make_unique<TestPlantWithMoreOutputs>();
-  const int plant_output_size = plant->get_output_port(0).get_size();
-  const int controller_feedback_size = plant->get_input_port(0).get_size() * 2;
+  const int plant_output_size = plant->get_output_port(0).size();
+  const int controller_feedback_size = plant->get_input_port(0).size() * 2;
 
   // Selects the first two signals from the plant's output port zero as the
   // feedback for the controller.

--- a/drake/systems/estimators/luenberger_observer.cc
+++ b/drake/systems/estimators/luenberger_observer.cc
@@ -42,17 +42,17 @@ LuenbergerObserver<T>::LuenbergerObserver(
 
   // First input port is the output of the observed system.
   this->DeclareInputPort(systems::kVectorValued,
-                         observed_system_->get_output_port(0).get_size());
+                         observed_system_->get_output_port(0).size());
 
   // Check the size of the gain matrix.
   DRAKE_DEMAND(observer_gain_.rows() == x->size());
   DRAKE_DEMAND(observer_gain_.cols() ==
-               observed_system_->get_output_port(0).get_size());
+               observed_system_->get_output_port(0).size());
 
   // Second input port is the input to the observed system (if it exists).
   if (observed_system_->get_num_input_ports() > 0) {
     this->DeclareInputPort(systems::kVectorValued,
-                           observed_system_->get_input_port(0).get_size());
+                           observed_system_->get_input_port(0).size());
   }
 
   // State has the same dimensions as the system being observed.

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -326,7 +326,7 @@ class Context {
     if (descriptor.get_data_type() == kVectorValued) {
       const BasicVector<T>* input_vector = port->template get_vector_data<T>();
       DRAKE_THROW_UNLESS(input_vector != nullptr);
-      DRAKE_THROW_UNLESS(input_vector->size() == descriptor.get_size());
+      DRAKE_THROW_UNLESS(input_vector->size() == descriptor.size());
     }
     // In the abstract-valued case, there is nothing else to check.
   }

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -213,7 +213,7 @@ class Context {
   /// This is a framework implementation detail.  User code should not call it.
   const InputPort* EvalInputPort(
       const detail::InputPortEvaluatorInterface<T>* evaluator,
-      const SystemPortDescriptor<T>& descriptor) const {
+      const InputPortDescriptor<T>& descriptor) const {
     const InputPort* port = GetInputPort(descriptor.get_index());
     if (port == nullptr) return nullptr;
     if (port->requires_evaluation()) {
@@ -235,7 +235,7 @@ class Context {
   /// This is a framework implementation detail.  User code should not call it.
   const BasicVector<T>* EvalVectorInput(
       const detail::InputPortEvaluatorInterface<T>* evaluator,
-      const SystemPortDescriptor<T>& descriptor) const {
+      const InputPortDescriptor<T>& descriptor) const {
     const InputPort* port = EvalInputPort(evaluator, descriptor);
     if (port == nullptr) return nullptr;
     return port->template get_vector_data<T>();
@@ -251,7 +251,7 @@ class Context {
   /// This is a framework implementation detail.  User code should not call it.
   const AbstractValue* EvalAbstractInput(
       const detail::InputPortEvaluatorInterface<T>* evaluator,
-      const SystemPortDescriptor<T>& descriptor) const {
+      const InputPortDescriptor<T>& descriptor) const {
     const InputPort* port = EvalInputPort(evaluator, descriptor);
     if (port == nullptr) return nullptr;
     return port->get_abstract_data();
@@ -271,7 +271,7 @@ class Context {
   template <typename V>
   const V* EvalInputValue(
       const detail::InputPortEvaluatorInterface<T>* evaluator,
-      const SystemPortDescriptor<T>& descriptor) const {
+      const InputPortDescriptor<T>& descriptor) const {
     const AbstractValue* value = EvalAbstractInput(evaluator, descriptor);
     if (value == nullptr) return nullptr;
     return &(value->GetValue<V>());
@@ -315,7 +315,7 @@ class Context {
   }
 
   // Throws an exception unless the given @p descriptor matches this context.
-  void VerifyInputPort(const SystemPortDescriptor<T>& descriptor) const {
+  void VerifyInputPort(const InputPortDescriptor<T>& descriptor) const {
     const int i = descriptor.get_index();
     const InputPort* port = GetInputPort(i);
     // If the port isn't connected, we don't have anything else to check.

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -807,7 +807,7 @@ class Diagram : public System<T>,
     const auto& subsystem_descriptor = subsystem_ports[port_index];
     InputPortDescriptor<T> descriptor(
         this, this->get_num_input_ports(),
-        subsystem_descriptor.get_data_type(), subsystem_descriptor.get_size());
+        subsystem_descriptor.get_data_type(), subsystem_descriptor.size());
     this->DeclareInputPort(descriptor);
   }
 
@@ -827,7 +827,7 @@ class Diagram : public System<T>,
     const auto& subsystem_descriptor = subsystem_ports[port_index];
     OutputPortDescriptor<T> descriptor(
         this, this->get_num_output_ports(),
-        subsystem_descriptor.get_data_type(), subsystem_descriptor.get_size());
+        subsystem_descriptor.get_data_type(), subsystem_descriptor.size());
     this->DeclareOutputPort(descriptor);
   }
 

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -106,19 +106,19 @@ template <typename T>
 class DiagramDiscreteVariables : public DiscreteState<T> {
  public:
   explicit DiagramDiscreteVariables(
-      std::vector<std::unique_ptr<DiscreteState<T>>>&& subdifferences)
-      : DiscreteState<T>(Flatten(Unpack(subdifferences))),
-        subdifferences_(std::move(subdifferences)) {}
+      std::vector<std::unique_ptr<DiscreteState<T>>>&& subdiscretes)
+      : DiscreteState<T>(Flatten(Unpack(subdiscretes))),
+        subdiscretes_(std::move(subdiscretes)) {}
 
   ~DiagramDiscreteVariables() override {}
 
   int num_subdifferences() const {
-    return static_cast<int>(subdifferences_.size());
+    return static_cast<int>(subdiscretes_.size());
   }
 
   DiscreteState<T>* get_mutable_subdifference(int index) {
     DRAKE_DEMAND(index >= 0 && index < num_subdifferences());
-    return subdifferences_[index].get();
+    return subdiscretes_[index].get();
   }
 
  private:
@@ -132,7 +132,7 @@ class DiagramDiscreteVariables : public DiscreteState<T> {
     return out;
   }
 
-  std::vector<std::unique_ptr<DiscreteState<T>>> subdifferences_;
+  std::vector<std::unique_ptr<DiscreteState<T>>> subdiscretes_;
 };
 
 }  // namespace internal
@@ -391,7 +391,7 @@ class Diagram : public System<T>,
   /// this function.
   void EvaluateSubsystemInputPort(
       const Context<T>* context,
-      const SystemPortDescriptor<T>& descriptor) const override {
+      const InputPortDescriptor<T>& descriptor) const override {
     // Find the output port connected to the given input port.
     const PortIdentifier id{descriptor.get_system(), descriptor.get_index()};
     const auto upstream_it = dependency_graph_.find(id);
@@ -805,8 +805,8 @@ class Diagram : public System<T>,
       throw std::out_of_range("Input port out of range.");
     }
     const auto& subsystem_descriptor = subsystem_ports[port_index];
-    SystemPortDescriptor<T> descriptor(
-        this, kInputPort, this->get_num_input_ports(),
+    InputPortDescriptor<T> descriptor(
+        this, this->get_num_input_ports(),
         subsystem_descriptor.get_data_type(), subsystem_descriptor.get_size());
     this->DeclareInputPort(descriptor);
   }
@@ -825,8 +825,8 @@ class Diagram : public System<T>,
       throw std::out_of_range("Output port out of range.");
     }
     const auto& subsystem_descriptor = subsystem_ports[port_index];
-    SystemPortDescriptor<T> descriptor(
-        this, kOutputPort, this->get_num_output_ports(),
+    OutputPortDescriptor<T> descriptor(
+        this, this->get_num_output_ports(),
         subsystem_descriptor.get_data_type(), subsystem_descriptor.get_size());
     this->DeclareOutputPort(descriptor);
   }

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -111,10 +111,8 @@ class DiagramBuilder {
   }
 
   /// Declares that input port @p dest is connected to output port @p src.
-  void Connect(const SystemPortDescriptor<T>& src,
-               const SystemPortDescriptor<T>& dest) {
-    DRAKE_DEMAND(src.get_face() == kOutputPort);
-    DRAKE_DEMAND(dest.get_face() == kInputPort);
+  void Connect(const OutputPortDescriptor<T>& src,
+               const InputPortDescriptor<T>& dest) {
     DRAKE_DEMAND(src.get_size() == dest.get_size());
     PortIdentifier dest_id{dest.get_system(), dest.get_index()};
     PortIdentifier src_id{src.get_system(), src.get_index()};
@@ -146,8 +144,7 @@ class DiagramBuilder {
 
   /// Declares that the given @p input port of a constituent system is an input
   /// to the entire Diagram.
-  void ExportInput(const SystemPortDescriptor<T>& input) {
-    DRAKE_DEMAND(input.get_face() == kInputPort);
+  void ExportInput(const InputPortDescriptor<T>& input) {
     PortIdentifier id{input.get_system(), input.get_index()};
     ThrowIfInputAlreadyWired(id);
     ThrowIfSystemNotRegistered(input.get_system());
@@ -157,8 +154,7 @@ class DiagramBuilder {
 
   /// Declares that the given @p output port of a constituent system is an
   /// output of the entire diagram.
-  void ExportOutput(const SystemPortDescriptor<T>& output) {
-    DRAKE_DEMAND(output.get_face() == kOutputPort);
+  void ExportOutput(const OutputPortDescriptor<T>& output) {
     ThrowIfSystemNotRegistered(output.get_system());
     output_port_ids_.push_back(
         PortIdentifier{output.get_system(), output.get_index()});

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -113,7 +113,7 @@ class DiagramBuilder {
   /// Declares that input port @p dest is connected to output port @p src.
   void Connect(const OutputPortDescriptor<T>& src,
                const InputPortDescriptor<T>& dest) {
-    DRAKE_DEMAND(src.get_size() == dest.get_size());
+    DRAKE_DEMAND(src.size() == dest.size());
     PortIdentifier dest_id{dest.get_system(), dest.get_index()};
     PortIdentifier src_id{src.get_system(), src.get_index()};
     ThrowIfInputAlreadyWired(dest_id);

--- a/drake/systems/framework/input_port_evaluator_interface.h
+++ b/drake/systems/framework/input_port_evaluator_interface.h
@@ -31,7 +31,7 @@ class InputPortEvaluatorInterface {
   /// The subsystem having the input port must be owned by this Diagram.
   /// Aborts if @p context is nullptr and there is any evaluation to do.
   virtual void EvaluateSubsystemInputPort(
-      const Context<T>* context, const SystemPortDescriptor<T>& id) const = 0;
+      const Context<T>* context, const InputPortDescriptor<T>& id) const = 0;
 
   /// Writes the full path of the evaluator in the tree of Systems to @p output.
   /// The path has the form (::ancestor_system_name)*::this_system_name.

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -209,7 +209,7 @@ class LeafSystem : public System<T> {
   /// descriptor must match a port declared via DeclareOutputPort.
   virtual std::unique_ptr<BasicVector<T>> AllocateOutputVector(
       const OutputPortDescriptor<T>& descriptor) const {
-    return std::make_unique<BasicVector<T>>(descriptor.get_size());
+    return std::make_unique<BasicVector<T>>(descriptor.size());
   }
 
   // =========================================================================

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -208,7 +208,7 @@ class LeafSystem : public System<T> {
   /// override to use output vector types other than BasicVector.  The
   /// descriptor must match a port declared via DeclareOutputPort.
   virtual std::unique_ptr<BasicVector<T>> AllocateOutputVector(
-      const SystemPortDescriptor<T>& descriptor) const {
+      const OutputPortDescriptor<T>& descriptor) const {
     return std::make_unique<BasicVector<T>>(descriptor.get_size());
   }
 

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -259,7 +259,7 @@ class System {
       const Context<T>& context, int port_index) const {
     const BasicVector<T>* input_vector = EvalVectorInput(context, port_index);
     DRAKE_ASSERT(input_vector != nullptr);
-    DRAKE_ASSERT(input_vector->size() == get_input_port(port_index).get_size());
+    DRAKE_ASSERT(input_vector->size() == get_input_port(port_index).size());
     return input_vector->get_value();
   }
 
@@ -575,7 +575,7 @@ class System {
   /// muxed).
   int get_num_total_inputs() const {
     int count = 0;
-    for (const auto& in : input_ports_) count += in.get_size();
+    for (const auto& in : input_ports_) count += in.size();
     return count;
   }
 
@@ -583,7 +583,7 @@ class System {
   /// muxed).
   int get_num_total_outputs() const {
     int count = 0;
-    for (const auto& out : output_ports_) count += out.get_size();
+    for (const auto& out : output_ports_) count += out.size();
     return count;
   }
 
@@ -605,7 +605,7 @@ class System {
         const VectorBase<T>* output_vector = output->get_vector_data(i);
         DRAKE_THROW_UNLESS(output_vector != nullptr);
         DRAKE_THROW_UNLESS(output_vector->size() ==
-            get_output_port(i).get_size());
+            get_output_port(i).size());
       }
     }
   }
@@ -962,7 +962,7 @@ class System {
     BasicVector<T>* output_vector = output->GetMutableVectorData(port_index);
     DRAKE_ASSERT(output_vector != nullptr);
     DRAKE_ASSERT(output_vector->size() ==
-        get_output_port(port_index).get_size());
+        get_output_port(port_index).size());
 
     return output_vector->get_mutable_value();
   }

--- a/drake/systems/framework/system_port_descriptor.h
+++ b/drake/systems/framework/system_port_descriptor.h
@@ -13,13 +13,6 @@ class System;
 
 constexpr int kAutoSize = -1;
 
-// TODO(david-german-tri): Create separate InputPortDescriptor and
-// OutputPortDescriptor, then get rid of this enum.
-typedef enum {
-  kInputPort = 0,
-  kOutputPort = 1,
-} PortFaceType;
-
 /// All system ports are either vectors of Eigen scalars, or black-box
 /// AbstractValues which may contain any type.
 typedef enum {
@@ -27,34 +20,30 @@ typedef enum {
   kAbstractValued = 1,
 } PortDataType;
 
-/// SystemPortDescriptor is a notation for specifying the kind of output a
-/// System produces, or the kind of input it accepts, on a given port. It is
-/// not a mechanism for handling any actual input or output data.
+/// InputPortDescriptor is a notation for specifying the kind of input a
+/// System accepts, on a given port. It is not a mechanism for handling any
+/// actual input data.
 ///
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
 template <typename T>
-class SystemPortDescriptor {
+class InputPortDescriptor {
  public:
   /// @param system The system to which this descriptor belongs.
-  /// @param face Whether an input or output port is described.
-  /// @param index The index of the port described. Input and output ports
-  ///              are indexed separately. They both start from zero and
-  ///              increment by one per port.
+  /// @param index The index of the input port described, starting from zero and
+  ///              incrementing by one per port.
   /// @param data_type Whether the port described is vector or abstract valued.
   /// @param size If the port described is vector-valued, the number of
   ///             elements, or kAutoSize if determined by connections.
-  SystemPortDescriptor(const System<T>* system, PortFaceType face, int index,
-                       PortDataType data_type, int size)
+  InputPortDescriptor(const System<T>* system, int index,
+                      PortDataType data_type, int size)
       : system_(system),
-        face_(face),
         index_(index),
         data_type_(data_type),
         size_(size) {}
-  virtual ~SystemPortDescriptor() {}
+  virtual ~InputPortDescriptor() {}
 
   const System<T>* get_system() const { return system_; }
-  PortFaceType get_face() const { return face_; }
   int get_index() const { return index_; }
   PortDataType get_data_type() const { return data_type_; }
   int get_size() const {
@@ -66,7 +55,47 @@ class SystemPortDescriptor {
 
  private:
   const System<T>* const system_;
-  const PortFaceType face_;
+  const int index_;
+  const PortDataType data_type_;
+  const int size_;
+};
+
+
+/// OutputPortDescriptor is a notation for specifying the kind of output a
+/// System produces, on a given port. It is not a mechanism for handling any
+/// actual output data.
+///
+/// @tparam T The mathematical type of the context, which must be a valid Eigen
+///           scalar.
+template <typename T>
+class OutputPortDescriptor {
+ public:
+  /// @param system The system to which this descriptor belongs.
+  /// @param index The index of the output port described, starting from zero
+  ///              and incrementing by one per port.
+  /// @param data_type Whether the port described is vector or abstract valued.
+  /// @param size If the port described is vector-valued, the number of
+  ///             elements, or kAutoSize if determined by connections.
+  OutputPortDescriptor(const System<T>* system, int index,
+                       PortDataType data_type, int size)
+      : system_(system),
+        index_(index),
+        data_type_(data_type),
+        size_(size) {}
+  virtual ~OutputPortDescriptor() {}
+
+  const System<T>* get_system() const { return system_; }
+  int get_index() const { return index_; }
+  PortDataType get_data_type() const { return data_type_; }
+  int get_size() const {
+    if (size_ == kAutoSize) {
+      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+    }
+    return size_;
+  }
+
+ private:
+  const System<T>* const system_;
   const int index_;
   const PortDataType data_type_;
   const int size_;

--- a/drake/systems/framework/system_port_descriptor.h
+++ b/drake/systems/framework/system_port_descriptor.h
@@ -37,21 +37,17 @@ class InputPortDescriptor {
   ///             elements, or kAutoSize if determined by connections.
   InputPortDescriptor(const System<T>* system, int index,
                       PortDataType data_type, int size)
-      : system_(system),
-        index_(index),
-        data_type_(data_type),
-        size_(size) {}
+      : system_(system), index_(index), data_type_(data_type), size_(size) {
+    if (size_ == kAutoSize) {
+      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+    }
+  }
   virtual ~InputPortDescriptor() {}
 
   const System<T>* get_system() const { return system_; }
   int get_index() const { return index_; }
   PortDataType get_data_type() const { return data_type_; }
-  int get_size() const {
-    if (size_ == kAutoSize) {
-      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
-    }
-    return size_;
-  }
+  int size() const { return size_; }
 
  private:
   const System<T>* const system_;
@@ -59,7 +55,6 @@ class InputPortDescriptor {
   const PortDataType data_type_;
   const int size_;
 };
-
 
 /// OutputPortDescriptor is a notation for specifying the kind of output a
 /// System produces, on a given port. It is not a mechanism for handling any
@@ -78,21 +73,17 @@ class OutputPortDescriptor {
   ///             elements, or kAutoSize if determined by connections.
   OutputPortDescriptor(const System<T>* system, int index,
                        PortDataType data_type, int size)
-      : system_(system),
-        index_(index),
-        data_type_(data_type),
-        size_(size) {}
+      : system_(system), index_(index), data_type_(data_type), size_(size) {
+    if (size_ == kAutoSize) {
+      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+    }
+  }
   virtual ~OutputPortDescriptor() {}
 
   const System<T>* get_system() const { return system_; }
   int get_index() const { return index_; }
   PortDataType get_data_type() const { return data_type_; }
-  int get_size() const {
-    if (size_ == kAutoSize) {
-      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
-    }
-    return size_;
-  }
+  int size() const { return size_; }
 
  private:
   const System<T>* const system_;

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -91,8 +91,7 @@ class DiagramContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const BasicVector<double>* ReadVectorInputPort(
       const Context<double>& context, int index) {
-    SystemPortDescriptor<double> descriptor(nullptr, kInputPort, index,
-                                            kVectorValued, 0);
+    InputPortDescriptor<double> descriptor(nullptr, index, kVectorValued, 0);
     return context.EvalVectorInput(nullptr, descriptor);
   }
 

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -169,7 +169,6 @@ TEST_F(DiagramTest, Topology) {
   for (const auto& descriptor : diagram_->get_input_ports()) {
     EXPECT_EQ(diagram_.get(), descriptor.get_system());
     EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(kInputPort, descriptor.get_face());
     EXPECT_EQ(kSize, descriptor.get_size());
   }
 
@@ -177,7 +176,6 @@ TEST_F(DiagramTest, Topology) {
   for (const auto& descriptor : diagram_->get_output_ports()) {
     EXPECT_EQ(diagram_.get(), descriptor.get_system());
     EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(kOutputPort, descriptor.get_face());
     EXPECT_EQ(kSize, descriptor.get_size());
   }
 

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -169,14 +169,14 @@ TEST_F(DiagramTest, Topology) {
   for (const auto& descriptor : diagram_->get_input_ports()) {
     EXPECT_EQ(diagram_.get(), descriptor.get_system());
     EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(kSize, descriptor.get_size());
+    EXPECT_EQ(kSize, descriptor.size());
   }
 
   ASSERT_EQ(kSize, diagram_->get_num_output_ports());
   for (const auto& descriptor : diagram_->get_output_ports()) {
     EXPECT_EQ(diagram_.get(), descriptor.get_system());
     EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(kSize, descriptor.get_size());
+    EXPECT_EQ(kSize, descriptor.size());
   }
 
   // The diagram has direct feedthrough.

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -71,8 +71,7 @@ class LeafContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const BasicVector<double>* ReadVectorInputPort(
       const Context<double>& context, int index) {
-    SystemPortDescriptor<double> descriptor(nullptr, kInputPort, index,
-                                            kVectorValued, 0);
+    InputPortDescriptor<double> descriptor(nullptr, index, kVectorValued, 0);
     return context.EvalVectorInput(nullptr, descriptor);
   }
 
@@ -80,8 +79,7 @@ class LeafContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const std::string* ReadStringInputPort(
       const Context<double>& context, int index) {
-    SystemPortDescriptor<double> descriptor(nullptr, kInputPort, index,
-                                            kAbstractValued, 0);
+    InputPortDescriptor<double> descriptor(nullptr, index, kAbstractValued, 0);
     return context.EvalInputValue<std::string>(nullptr, descriptor);
   }
 
@@ -89,8 +87,7 @@ class LeafContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const AbstractValue* ReadAbstractInputPort(
       const Context<double>& context, int index) {
-    SystemPortDescriptor<double> descriptor(nullptr, kInputPort, index,
-                                            kAbstractValued, 0);
+    InputPortDescriptor<double> descriptor(nullptr, index, kAbstractValued, 0);
     return context.EvalAbstractInput(nullptr, descriptor);
   }
 

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -116,7 +116,7 @@ LcmSubscriberSystem::AllocateOutput(const Context<double>& context) const {
 
 // This is only called if our output port is vector-valued.
 std::unique_ptr<BasicVector<double>> LcmSubscriberSystem::AllocateOutputVector(
-    const SystemPortDescriptor<double>& descriptor) const {
+    const OutputPortDescriptor<double>& descriptor) const {
   DRAKE_DEMAND(descriptor.get_index() == 0);
   DRAKE_DEMAND(translator_ != nullptr);
   DRAKE_DEMAND(serializer_.get() == nullptr);

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -121,7 +121,7 @@ class LcmSubscriberSystem : public LeafSystem<double>,
                     SystemOutput<double>* output) const override;
 
   std::unique_ptr<BasicVector<double>> AllocateOutputVector(
-      const SystemPortDescriptor<double>& descriptor) const override;
+      const OutputPortDescriptor<double>& descriptor) const override;
 
  private:
   // All constructors delegate to here.

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -75,7 +75,7 @@ SpringMassSystem<T>::SpringMassSystem(const T& spring_constant_N_per_m,
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& SpringMassSystem<T>::get_force_port() const {
+const InputPortDescriptor<T>& SpringMassSystem<T>::get_force_port() const {
   if (system_is_forced_) {
     return this->get_input_port(0);
   } else {
@@ -86,7 +86,7 @@ const SystemPortDescriptor<T>& SpringMassSystem<T>::get_force_port() const {
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& SpringMassSystem<T>::get_output_port() const {
+const OutputPortDescriptor<T>& SpringMassSystem<T>::get_output_port() const {
   return System<T>::get_output_port(0);
 }
 

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.h
@@ -94,10 +94,10 @@ class SpringMassSystem : public LeafSystem<T> {
   // Provide methods specific to this System.
 
   /// Returns the input port to the externally applied force.
-  const SystemPortDescriptor<T>& get_force_port() const;
+  const InputPortDescriptor<T>& get_force_port() const;
 
   /// Returns the port to output state.
-  const SystemPortDescriptor<T>& get_output_port() const;
+  const OutputPortDescriptor<T>& get_output_port() const;
 
   /// Returns the spring constant k that was provided at construction, in N/m.
   const T& get_spring_constant() const { return spring_constant_N_per_m_; }

--- a/drake/systems/primitives/adder.cc
+++ b/drake/systems/primitives/adder.cc
@@ -48,7 +48,7 @@ void Adder<T>::DoCalcOutput(const Context<T>& context,
 template <typename T>
 Adder<AutoDiffXd>* Adder<T>::DoToAutoDiffXd() const {
   return new Adder<AutoDiffXd>(this->get_num_input_ports(),
-                               this->get_input_port(0).get_size());
+                               this->get_input_port(0).size());
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/systems/primitives/adder.cc
+++ b/drake/systems/primitives/adder.cc
@@ -21,7 +21,7 @@ Adder<T>::Adder(int num_inputs, int size) {
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& Adder<T>::get_output_port() const {
+const OutputPortDescriptor<T>& Adder<T>::get_output_port() const {
   return System<T>::get_output_port(0);
 }
 

--- a/drake/systems/primitives/adder.h
+++ b/drake/systems/primitives/adder.h
@@ -34,7 +34,7 @@ class Adder : public LeafSystem<T> {
   bool has_any_direct_feedthrough() const override { return true; }
 
   /// Returns the output port.
-  const SystemPortDescriptor<T>& get_output_port() const;
+  const OutputPortDescriptor<T>& get_output_port() const;
 
   /// Returns an Adder<AutoDiffXd> with the same dimensions as this Adder.
   std::unique_ptr<Adder<AutoDiffXd>> ToAutoDiffXd() const {

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -63,13 +63,13 @@ AffineSystem<AutoDiffXd>* AffineSystem<T>::DoToAutoDiffXd() const {
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& AffineSystem<T>::get_input_port() const {
+const InputPortDescriptor<T>& AffineSystem<T>::get_input_port() const {
   DRAKE_DEMAND(num_inputs_ > 0);
   return System<T>::get_input_port(0);
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& AffineSystem<T>::get_output_port() const {
+const OutputPortDescriptor<T>& AffineSystem<T>::get_output_port() const {
   DRAKE_DEMAND(num_outputs_ > 0);
   return System<T>::get_output_port(0);
 }

--- a/drake/systems/primitives/affine_system.h
+++ b/drake/systems/primitives/affine_system.h
@@ -63,10 +63,10 @@ class AffineSystem : public LeafSystem<T> {
   bool has_any_direct_feedthrough() const override { return !D_.isZero(0.0); }
 
   /// Returns the input port containing the externally applied input.
-  const SystemPortDescriptor<T>& get_input_port() const;
+  const InputPortDescriptor<T>& get_input_port() const;
 
   /// Returns the port containing the output state.
-  const SystemPortDescriptor<T>& get_output_port() const;
+  const OutputPortDescriptor<T>& get_output_port() const;
 
   // Helper getter methods.
   const Eigen::MatrixXd& A() const { return A_; }

--- a/drake/systems/primitives/constant_vector_source.cc
+++ b/drake/systems/primitives/constant_vector_source.cc
@@ -26,7 +26,7 @@ ConstantVectorSource<T>::ConstantVectorSource(const T& source_value)
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& ConstantVectorSource<T>::get_output_port()
+const OutputPortDescriptor<T>& ConstantVectorSource<T>::get_output_port()
     const {
   return System<T>::get_output_port(0);
 }

--- a/drake/systems/primitives/constant_vector_source.h
+++ b/drake/systems/primitives/constant_vector_source.h
@@ -40,7 +40,7 @@ class ConstantVectorSource : public LeafSystem<T> {
 
 
   /// Returns the output port to the constant source.
-  const SystemPortDescriptor<T>& get_output_port() const;
+  const OutputPortDescriptor<T>& get_output_port() const;
 
  private:
   // Outputs a signal with a fixed value as specified by the user.

--- a/drake/systems/primitives/demultiplexer.cc
+++ b/drake/systems/primitives/demultiplexer.cc
@@ -29,7 +29,7 @@ void Demultiplexer<T>::DoCalcOutput(const Context<T>& context,
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   // All output ports have the same size as defined in the constructor.
-  const int out_size = this->get_output_port(0).get_size();
+  const int out_size = this->get_output_port(0).size();
 
   // TODO(amcastro-tri): the output should simply reference the input port's
   // value to avoid copy.

--- a/drake/systems/primitives/gain-inl.h
+++ b/drake/systems/primitives/gain-inl.h
@@ -47,12 +47,12 @@ const VectorX<T>& Gain<T>::get_gain_vector() const {
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& Gain<T>::get_input_port() const {
+const InputPortDescriptor<T>& Gain<T>::get_input_port() const {
   return System<T>::get_input_port(0);
 }
 
 template <typename T>
-const SystemPortDescriptor<T>& Gain<T>::get_output_port() const {
+const OutputPortDescriptor<T>& Gain<T>::get_output_port() const {
   return System<T>::get_output_port(0);
 }
 

--- a/drake/systems/primitives/gain.h
+++ b/drake/systems/primitives/gain.h
@@ -53,10 +53,10 @@ class Gain : public LeafSystem<T> {
 
 
   /// Returns the input port.
-  const SystemPortDescriptor<T>& get_input_port() const;
+  const InputPortDescriptor<T>& get_input_port() const;
 
   /// Returns the output port.
-  const SystemPortDescriptor<T>& get_output_port() const;
+  const OutputPortDescriptor<T>& get_output_port() const;
 
  private:
   // Sets the output port value to the product of the gain and the input port

--- a/drake/systems/primitives/integrator.cc
+++ b/drake/systems/primitives/integrator.cc
@@ -45,8 +45,8 @@ std::unique_ptr<ContinuousState<T>> Integrator<T>::AllocateContinuousState()
     const {
   // The integrator's state is first-order; its state vector size is the
   // same as the input (and output) vector size.
-  const int size = System<T>::get_output_port(0).get_size();
-  DRAKE_ASSERT(System<T>::get_input_port(0).get_size() == size);
+  const int size = System<T>::get_output_port(0).size();
+  DRAKE_ASSERT(System<T>::get_input_port(0).size() == size);
   return std::make_unique<ContinuousState<T>>(
       std::make_unique<BasicVector<T>>(size));
 }
@@ -73,7 +73,7 @@ void Integrator<T>::DoCalcOutput(const Context<T>& context,
 
 template <typename T>
 Integrator<AutoDiffXd>* Integrator<T>::DoToAutoDiffXd() const {
-  return new Integrator<AutoDiffXd>(this->get_input_port(0).get_size());
+  return new Integrator<AutoDiffXd>(this->get_input_port(0).size());
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/systems/primitives/linear_system.cc
+++ b/drake/systems/primitives/linear_system.cc
@@ -38,10 +38,10 @@ std::unique_ptr<LinearSystem<double>> Linearize(
   DRAKE_DEMAND(system.get_num_output_ports() <= 1);
 
   const int num_inputs = (system.get_num_input_ports() > 0)
-                             ? system.get_input_port(0).get_size()
+                             ? system.get_input_port(0).size()
                              : 0,
             num_outputs = (system.get_num_output_ports() > 0)
-                              ? system.get_output_port(0).get_size()
+                              ? system.get_output_port(0).size()
                               : 0;
 
   // Create an autodiff version of the system.

--- a/drake/systems/primitives/test/adder_test.cc
+++ b/drake/systems/primitives/test/adder_test.cc
@@ -38,14 +38,12 @@ TEST_F(AdderTest, Topology) {
   ASSERT_EQ(2u, adder_->get_input_ports().size());
   for (const auto& descriptor : adder_->get_input_ports()) {
     EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(kInputPort, descriptor.get_face());
     EXPECT_EQ(3, descriptor.get_size());
   }
 
   ASSERT_EQ(1u, adder_->get_output_ports().size());
   for (const auto& descriptor : adder_->get_output_ports()) {
     EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(kOutputPort, descriptor.get_face());
     EXPECT_EQ(3, descriptor.get_size());
   }
 }

--- a/drake/systems/primitives/test/adder_test.cc
+++ b/drake/systems/primitives/test/adder_test.cc
@@ -38,13 +38,13 @@ TEST_F(AdderTest, Topology) {
   ASSERT_EQ(2u, adder_->get_input_ports().size());
   for (const auto& descriptor : adder_->get_input_ports()) {
     EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(3, descriptor.get_size());
+    EXPECT_EQ(3, descriptor.size());
   }
 
   ASSERT_EQ(1u, adder_->get_output_ports().size());
   for (const auto& descriptor : adder_->get_output_ports()) {
     EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(3, descriptor.get_size());
+    EXPECT_EQ(3, descriptor.size());
   }
 }
 

--- a/drake/systems/primitives/test/integrator_test.cc
+++ b/drake/systems/primitives/test/integrator_test.cc
@@ -50,13 +50,11 @@ TEST_F(IntegratorTest, Topology) {
   ASSERT_EQ(1u, integrator_->get_input_ports().size());
   const auto& input_descriptor = integrator_->get_input_ports()[0];
   EXPECT_EQ(kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(kInputPort, input_descriptor.get_face());
   EXPECT_EQ(kLength, input_descriptor.get_size());
 
   ASSERT_EQ(1u, integrator_->get_output_ports().size());
   const auto& output_descriptor = integrator_->get_output_ports()[0];
   EXPECT_EQ(kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(kOutputPort, output_descriptor.get_face());
   EXPECT_EQ(kLength, output_descriptor.get_size());
 }
 

--- a/drake/systems/primitives/test/integrator_test.cc
+++ b/drake/systems/primitives/test/integrator_test.cc
@@ -50,12 +50,12 @@ TEST_F(IntegratorTest, Topology) {
   ASSERT_EQ(1u, integrator_->get_input_ports().size());
   const auto& input_descriptor = integrator_->get_input_ports()[0];
   EXPECT_EQ(kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(kLength, input_descriptor.get_size());
+  EXPECT_EQ(kLength, input_descriptor.size());
 
   ASSERT_EQ(1u, integrator_->get_output_ports().size());
   const auto& output_descriptor = integrator_->get_output_ports()[0];
   EXPECT_EQ(kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(kLength, output_descriptor.get_size());
+  EXPECT_EQ(kLength, output_descriptor.size());
 }
 
 // Tests that the output of an integrator is its state.

--- a/drake/systems/primitives/test/multiplexer_test.cc
+++ b/drake/systems/primitives/test/multiplexer_test.cc
@@ -31,12 +31,12 @@ TEST_F(MultiplexerTest, Basic) {
 
   // Confirm the shape.
   ASSERT_EQ(3, mux_->get_num_input_ports());
-  ASSERT_EQ(2, mux_->get_input_port(0).get_size());
-  ASSERT_EQ(1, mux_->get_input_port(1).get_size());
-  ASSERT_EQ(3, mux_->get_input_port(2).get_size());
+  ASSERT_EQ(2, mux_->get_input_port(0).size());
+  ASSERT_EQ(1, mux_->get_input_port(1).size());
+  ASSERT_EQ(3, mux_->get_input_port(2).size());
   ASSERT_EQ(3, context_->get_num_input_ports());
   ASSERT_EQ(1, mux_->get_num_output_ports());
-  ASSERT_EQ(6, mux_->get_output_port(0).get_size());
+  ASSERT_EQ(6, mux_->get_output_port(0).size());
   ASSERT_EQ(1, output_->get_num_ports());
   ASSERT_EQ(6, output_->get_vector_data(0)->size());
 
@@ -64,13 +64,13 @@ TEST_F(MultiplexerTest, ScalarConstructor) {
 
   // Confirm the shape.
   ASSERT_EQ(4, mux_->get_num_input_ports());
-  ASSERT_EQ(1, mux_->get_input_port(0).get_size());
-  ASSERT_EQ(1, mux_->get_input_port(1).get_size());
-  ASSERT_EQ(1, mux_->get_input_port(2).get_size());
-  ASSERT_EQ(1, mux_->get_input_port(3).get_size());
+  ASSERT_EQ(1, mux_->get_input_port(0).size());
+  ASSERT_EQ(1, mux_->get_input_port(1).size());
+  ASSERT_EQ(1, mux_->get_input_port(2).size());
+  ASSERT_EQ(1, mux_->get_input_port(3).size());
   ASSERT_EQ(4, context_->get_num_input_ports());
   ASSERT_EQ(1, mux_->get_num_output_ports());
-  ASSERT_EQ(4, mux_->get_output_port(0).get_size());
+  ASSERT_EQ(4, mux_->get_output_port(0).size());
   ASSERT_EQ(1, output_->get_num_ports());
   ASSERT_EQ(4, output_->get_vector_data(0)->size());
 }

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -53,8 +53,8 @@ std::unique_ptr<DiscreteState<T>> ZeroOrderHold<T>::AllocateDiscreteState()
     const {
   // The zero-order hold's state is first-order. Its state vector size is the
   // same as the input (and output) vector size.
-  const int size = System<T>::get_output_port(0).get_size();
-  DRAKE_DEMAND(System<T>::get_input_port(0).get_size() == size);
+  const int size = System<T>::get_output_port(0).size();
+  DRAKE_DEMAND(System<T>::get_input_port(0).size() == size);
   std::vector<std::unique_ptr<BasicVector<T>>> xd;
   xd.push_back(std::make_unique<BasicVector<T>>(size));
   return std::make_unique<DiscreteState<T>>(std::move(xd));

--- a/drake/systems/sensors/rotary_encoders.cc
+++ b/drake/systems/sensors/rotary_encoders.cc
@@ -115,7 +115,7 @@ Eigen::VectorBlock<const VectorX<T>> RotaryEncoders<T>::get_calibration_offsets(
 
 template <typename T>
 RotaryEncoders<AutoDiffXd>* RotaryEncoders<T>::DoToAutoDiffXd() const {
-  return new RotaryEncoders<AutoDiffXd>(this->get_input_port(0).get_size(),
+  return new RotaryEncoders<AutoDiffXd>(this->get_input_port(0).size(),
                                         indices_, ticks_per_revolution_);
 }
 

--- a/drake/systems/trajectory_optimization/direct_collocation.cc
+++ b/drake/systems/trajectory_optimization/direct_collocation.cc
@@ -26,7 +26,7 @@ DircolTrajectoryOptimization::DircolTrajectoryOptimization(
   // Allocate the input port and keep an alias around.
   input_port_ =
       new FreestandingInputPort(std::make_unique<BasicVector<double>>(
-          system_->get_input_port(0).get_size()));
+          system_->get_input_port(0).size()));
   std::unique_ptr<InputPort> input_port(input_port_);
   context_->SetInputPort(0, std::move(input_port));
 

--- a/drake/systems/trajectory_optimization/direct_collocation_constraint.cc
+++ b/drake/systems/trajectory_optimization/direct_collocation_constraint.cc
@@ -72,7 +72,7 @@ SystemDirectCollocationConstraint::SystemDirectCollocationConstraint(
     const systems::System<double>& system,
     const systems::Context<double>& context)
     : DirectCollocationConstraint(context.get_continuous_state()->size(),
-                                  system.get_input_port(0).get_size()),
+                                  system.get_input_port(0).size()),
       system_(systems::System<double>::ToAutoDiffXd(system)),
       context_(system_->CreateDefaultContext()),
       // Don't allocate the input port until we're past the point
@@ -85,7 +85,7 @@ SystemDirectCollocationConstraint::SystemDirectCollocationConstraint(
   // Allocate the input port and keep an alias around.
   input_port_ =
       new FreestandingInputPort(std::make_unique<BasicVector<AutoDiffXd>>(
-          system_->get_input_port(0).get_size()));
+          system_->get_input_port(0).size()));
   std::unique_ptr<InputPort> input_port(input_port_);
   context_->SetInputPort(0, std::move(input_port));
 }

--- a/ros/drake_ros_systems/test/ros_tf_publisher_test.cc
+++ b/ros/drake_ros_systems/test/ros_tf_publisher_test.cc
@@ -38,7 +38,7 @@ GTEST_TEST(RosTfPublisherTest, TestRosTfPublisher) {
 
   EXPECT_EQ(publisher->get_num_output_ports(), 0);
   EXPECT_EQ(input->size(), 4);
-  EXPECT_EQ(publisher->get_input_port(0).get_size(), input->size());
+  EXPECT_EQ(publisher->get_input_port(0).size(), input->size());
 
   Eigen::VectorXd robot_position = Eigen::VectorXd::Zero(input->size());
   robot_position << 1.0, -0.5, 0, 0;


### PR DESCRIPTION
This is another name change in support of caching in #4364. We had to make this change anyway (see #3189). Changes `SystemPortDescriptor` to `InputPortDescriptor` or `OutputPortDescriptor` as appropriate.

Fixes #3189.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4602)
<!-- Reviewable:end -->
