### PR TITLE
add botcore and robotlocomotion lcmtypes externals to bazel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/lcm-proj/lcm.git
 [submodule "externals/bot_core_lcmtypes"]
 	path = externals/bot_core_lcmtypes
-	url = https://github.com/mwoehlke-kitware/bot_core_lcmtypes
+	url = https://github.com/RussTedrake/bot_core_lcmtypes
 [submodule "externals/libbot"]
 	path = externals/libbot
 	url = https://github.com/RobotLocomotion/libbot.git

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,6 +53,20 @@ new_git_repository(
 )
 
 new_git_repository(
+    name = "bot_core_lcmtypes",
+    remote = "https://github.com/RussTedrake/bot_core_lcmtypes",
+    commit = "58d335c6e4c07766e0016a9d4ee3f30fc10fb3f3",
+    build_file = "tools/bot_core_lcmtypes.BUILD",
+)
+
+new_git_repository(
+    name = "robotlocomotion_lcmtypes",
+    remote = "https://github.com/RobotLocomotion/lcmtypes",
+    commit = "b9ce3faa864ce98c496a1581c9157de6d27f33eb",
+    build_file = "tools/robotlocomotion_lcmtypes.BUILD",
+)
+
+new_git_repository(
     name = "bullet",
     remote = "https://github.com/RobotLocomotion/bullet3.git",
     commit = "ae2c4ca0618d55c6a29900aed75b958604149fdb",
@@ -92,4 +106,3 @@ gurobi_repository(
     workspace_dir = __workspace_dir__,
     build_file = "tools/gurobi.BUILD",
 )
-

--- a/drake/examples/kuka_iiwa_arm/BUILD
+++ b/drake/examples/kuka_iiwa_arm/BUILD
@@ -12,3 +12,18 @@ filegroup(
         "**/*.xml",
     ]),
 )
+
+cc_binary(
+    name = "kuka_ik_demo",
+    srcs = ["kuka_ik_demo.cc"],
+    linkstatic = 1,
+    deps = [
+        "//drake/lcm",
+        "//drake/multibody:inverse_kinematics",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/parsers",
+        "//drake/solvers:mathematical_program",
+        "@bot_core_lcmtypes//:lib",
+        "@robotlocomotion_lcmtypes//:lib",
+    ],
+)

--- a/tools/bot_core_lcmtypes.BUILD
+++ b/tools/bot_core_lcmtypes.BUILD
@@ -1,0 +1,13 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+package(default_visibility = ["//visibility:public"])
+
+load("@//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")
+
+lcm_cc_library(
+    name = "lib",
+    lcm_package = "bot_core",
+    lcm_srcs = glob(["lcmtypes/*.lcm"]),
+    linkstatic = 1,
+)

--- a/tools/buildifier.sh
+++ b/tools/buildifier.sh
@@ -33,7 +33,7 @@ else
        \( -name BUILD -o \
           -name '*.BUILD' -o \
           -name '*.bzl' \) -print |
-      xargs --verbose "$buildifier" -mode=fix
+      xargs "$buildifier" -mode=fix
 fi
 
 echo "... done"

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -73,7 +73,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "lcmgen",
+    name = "lcm-gen",
     srcs = [
         "lcmgen/emit_c.c",
         "lcmgen/emit_cpp.c",

--- a/tools/lcm.bzl
+++ b/tools/lcm.bzl
@@ -7,47 +7,50 @@
 # https://bazel.build/versions/master/docs/skylark/concepts.html
 
 def _lcm_srcs_to_outs(lcm_package, lcm_srcs, extension):
-    """Return the list of filenames (prefixed by the package directory and
-    switched to a new extension), based on the lcm_package= and lcm_srcs=
-    parameters (see lcm_cc_library below for a description of what those
-    parameters mean).
-    """
-    result = []
-    for item in lcm_srcs:
-        if not item.endswith(".lcm"):
-            fail(item + " does not end with .lcm")
-        result.append(lcm_package + "/" + item[:-len(".lcm")] + extension)
-    return result
+	"""Return the list of filenames (prefixed by the package directory and
+	switched to a new extension), based on the lcm_package= and lcm_srcs=
+	parameters (see lcm_cc_library below for a description of what those
+	parameters mean).
+	"""
+	result = []
+	for item in lcm_srcs:
+		index = item.rfind("/");
+		pathname = item[:index+1];
+		filename = item[index+1:];
+		if not filename.endswith(".lcm"):
+			fail(item + " does not end with .lcm")
+		result.append(pathname + lcm_package + "/" + filename[:-len(".lcm")] + extension)
+	return result
 
 def _lcmgen_impl(ctx):
-    """The implementation actions to invoke lcmgen.
+	"""The implementation actions to invoke lcmgen.
 
-    The ctx parameter comes from Skylark:
-    https://bazel.build/versions/master/docs/skylark/lib/ctx.html
-    """
-    # We are given ctx.outputs.outs, which is the full path and file name of
-    # the generated file we want to create.  However, the lcmgen tool places
-    # its outputs into a subdirectory of the path we ask for, based on the LCM
-    # message's package name.  To set the correct path, we need to both remove
-    # the filename from outs (which we do via ".dirname"), as well as the
-    # package-name-derived directory name (which we do via slicing off striplen
-    # characters), including the '/' right before it (thus the "+ 1" below).
-    striplen = len(ctx.attr.lcm_package) + 1
-    for lcm_src, output in zip(ctx.files.lcm_srcs, ctx.outputs.outs):
-        outpath = output.dirname[:-striplen]
-        if ctx.attr.language == "cc":
-            arguments = ["--cpp", "--cpp-std=c++11", "--cpp-hpath=" + outpath]
-        elif ctx.attr.language == "py":
-            arguments = ["--python", "--ppath=" + outpath]
-        else:
-            fail("Unknown language")
-        ctx.action(
-            inputs = [lcm_src],
-            outputs = [output],
-            arguments = arguments + [lcm_src.path],
-            executable = ctx.executable.lcmgen,
-            )
-    return struct()
+	The ctx parameter comes from Skylark:
+	https://bazel.build/versions/master/docs/skylark/lib/ctx.html
+	"""
+	# We are given ctx.outputs.outs, which is the full path and file name of
+	# the generated file we want to create.	 However, the lcmgen tool places
+	# its outputs into a subdirectory of the path we ask for, based on the LCM
+	# message's package name.  To set the correct path, we need to both remove
+	# the filename from outs (which we do via ".dirname"), as well as the
+	# package-name-derived directory name (which we do via slicing off striplen
+	# characters), including the '/' right before it (thus the "+ 1" below).
+	striplen = len(ctx.attr.lcm_package) + 1
+	for lcm_src, output in zip(ctx.files.lcm_srcs, ctx.outputs.outs):
+		outpath = output.dirname[:-striplen]
+		if ctx.attr.language == "cc":
+			arguments = ["--cpp", "--cpp-std=c++11", "--cpp-hpath=" + outpath]
+		elif ctx.attr.language == "py":
+			arguments = ["--python", "--ppath=" + outpath]
+		else:
+			fail("Unknown language")
+		ctx.action(
+			inputs = [lcm_src],
+			outputs = [output],
+			arguments = arguments + [lcm_src.path],
+			executable = ctx.executable.lcmgen,
+			)
+	return struct()
 
 # Create rule to invoke lcmgen on some lcm_srcs.
 # https://www.bazel.io/versions/master/docs/skylark/rules.html
@@ -58,7 +61,7 @@ _lcm_library_gen = rule(
         "lcmgen": attr.label(
             cfg = "host",
             executable = True,
-            default = Label("@lcm//:lcmgen"),
+            default = Label("@lcm//:lcm-gen"),
         ),
         "outs": attr.output_list(),
         "language": attr.string(),
@@ -68,91 +71,91 @@ _lcm_library_gen = rule(
 )
 
 def lcm_cc_library(
-        name,
-        lcm_package=None,
-        lcm_srcs=None,
-        includes=None,
-        deps=None,
-        **kwargs):
-    """Declares a cc_library target based on C++ message classes generated from
-    `*.lcm` files.  The lcm_srcs= list parameter specifies the `*.lcm` sources.
-    The lcm_package= string parameter must match the `package ...;` statement
-    in all of the `*.lcm` files in lcm_srcs.  The Bazel-standard includes= and
-    deps= parameters are passed through to cc_library after adding the items
-    required by the generated code.
+		name,
+		lcm_package=None,
+		lcm_srcs=None,
+		includes=None,
+		deps=None,
+		**kwargs):
+	"""Declares a cc_library target based on C++ message classes generated from
+	`*.lcm` files.	The lcm_srcs= list parameter specifies the `*.lcm` sources.
+	The lcm_package= string parameter must match the `package ...;` statement
+	in all of the `*.lcm` files in lcm_srcs.  The Bazel-standard includes= and
+	deps= parameters are passed through to cc_library after adding the items
+	required by the generated code.
 
-    """
-    if lcm_package == None:
-        fail("lcm_package must be provided")
-    if not lcm_srcs:
-        fail("lcm_srcs must be provided")
+	"""
+	if lcm_package == None:
+		fail("lcm_package must be provided")
+	if not lcm_srcs:
+		fail("lcm_srcs must be provided")
 
-    outs = _lcm_srcs_to_outs(lcm_package, lcm_srcs, ".hpp")
-    _lcm_library_gen(
-        name=name + "_lcm_library_gen",
-        language="cc",
-        lcm_package=lcm_package,
-        lcm_srcs=lcm_srcs,
-        outs=outs)
+	outs = _lcm_srcs_to_outs(lcm_package, lcm_srcs, ".hpp")
+	_lcm_library_gen(
+		name=name + "_lcm_library_gen",
+		language="cc",
+		lcm_package=lcm_package,
+		lcm_srcs=lcm_srcs,
+		outs=outs)
 
-    newdep = "@lcm//:lcm"
-    deps = list(deps or [])
-    if newdep not in deps:
-        deps.append(newdep)
+	newdep = "@lcm//:lcm"
+	deps = list(deps or [])
+	if newdep not in deps:
+		deps.append(newdep)
 
-    newinclude = "."
-    includes = list(includes or [])
-    if newinclude not in includes:
-        includes.append(newinclude)
+	newinclude = "."
+	includes = list(includes or [])
+	if newinclude not in includes:
+		includes.append(newinclude)
 
-    native.cc_library(
-        name=name,
-        hdrs=outs,
-        deps=deps,
-        includes=includes,
-        **kwargs)
+	native.cc_library(
+		name=name,
+		hdrs=outs,
+		deps=deps,
+		includes=includes,
+		**kwargs)
 
 def lcm_py_library(
-        name,
-        lcm_package=None,
-        lcm_srcs=None,
-        deps=None,
-        imports=None,
-        **kwargs):
-    """Declares a py_library target based on python message classes generated
-    from `*.lcm` files.  The lcm_src= list parameter specifies the `*.lcm`
-    sources.  The lcm_package= string parameter must match the `package ...;`
-    statement in all of the `*.lcm` files in lcm_srcs.  The Bazel-standard
-    deps= and imports= parameters are passed through to py_library after
-    adding the items required by the generated code.
+		name,
+		lcm_package=None,
+		lcm_srcs=None,
+		deps=None,
+		imports=None,
+		**kwargs):
+	"""Declares a py_library target based on python message classes generated
+	from `*.lcm` files.	 The lcm_src= list parameter specifies the `*.lcm`
+	sources.  The lcm_package= string parameter must match the `package ...;`
+	statement in all of the `*.lcm` files in lcm_srcs.	The Bazel-standard
+	deps= and imports= parameters are passed through to py_library after
+	adding the items required by the generated code.
 
-    """
-    if lcm_package == None:
-        fail("lcm_package must be provided")
-    if not lcm_srcs:
-        fail("lcm_srcs must be provided")
+	"""
+	if lcm_package == None:
+		fail("lcm_package must be provided")
+	if not lcm_srcs:
+		fail("lcm_srcs must be provided")
 
-    outs = _lcm_srcs_to_outs(lcm_package, lcm_srcs, ".py")
-    _lcm_library_gen(
-        name=name + "_lcm_library_gen",
-        language="py",
-        lcm_package=lcm_package,
-        lcm_srcs=lcm_srcs,
-        outs=outs)
+	outs = _lcm_srcs_to_outs(lcm_package, lcm_srcs, ".py")
+	_lcm_library_gen(
+		name=name + "_lcm_library_gen",
+		language="py",
+		lcm_package=lcm_package,
+		lcm_srcs=lcm_srcs,
+		outs=outs)
 
-    newdep = "@lcm//:lcm-python"
-    deps = list(deps or [])
-    if newdep not in deps:
-        deps.append(newdep)
+	newdep = "@lcm//:lcm-python"
+	deps = list(deps or [])
+	if newdep not in deps:
+		deps.append(newdep)
 
-    newimport = "."
-    imports = list(imports or [])
-    if newimport not in imports:
-        imports.append(newimport)
+	newimport = "."
+	imports = list(imports or [])
+	if newimport not in imports:
+		imports.append(newimport)
 
-    native.py_library(
-        name=name,
-        srcs=outs,
-        deps=deps,
-        imports=imports,
-        **kwargs)
+	native.py_library(
+		name=name,
+		srcs=outs,
+		deps=deps,
+		imports=imports,
+		**kwargs)

--- a/tools/robotlocomotion_lcmtypes.BUILD
+++ b/tools/robotlocomotion_lcmtypes.BUILD
@@ -1,0 +1,13 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+package(default_visibility = ["//visibility:public"])
+
+load("@//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")
+
+lcm_cc_library(
+    name = "lib",
+    lcm_package = "robotlocomotion",
+    lcm_srcs = glob(["lcmtypes/*.lcm"]),
+    linkstatic = 1,
+)


### PR DESCRIPTION
and kuka_ik_demo for coverage

required some work on the lcm.bzl and a rename of the files in bot_core_lcmtypes (currently pointing to my fork instead of @mwoehlke-kitware 's fork(!) pending that PR landing).

also fixed inconsistency - bazel was building `lcmgen` instead of `lcm-gen` executable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4608)
<!-- Reviewable:end -->
