### PR TITLE
Port descriptors are concrete and copyable

### DIFF
--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -35,6 +35,7 @@ class Context {
 
   Context() = default;
   Context(const Context&) = delete;
+  Context& operator=(const Context&) = delete;
 
   // =========================================================================
   // Accessors and Mutators for Time.

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -33,6 +33,9 @@ class Context {
  public:
   virtual ~Context() {}
 
+  Context() = default;
+  Context(const Context&) = delete;
+
   // =========================================================================
   // Accessors and Mutators for Time.
 

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -178,6 +178,7 @@ template <typename T>
 struct LeafSystemOutput : public SystemOutput<T> {
   LeafSystemOutput() = default;
   LeafSystemOutput(const LeafSystemOutput&) = delete;
+  LeafSystemOutput& operator=(const LeafSystemOutput&) = delete;
   ~LeafSystemOutput() override {}
 
   int get_num_ports() const override { return static_cast<int>(ports_.size()); }

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -176,7 +176,8 @@ class SystemOutput {
 /// @tparam T The type of the output data. Must be a valid Eigen scalar.
 template <typename T>
 struct LeafSystemOutput : public SystemOutput<T> {
-  LeafSystemOutput() {}
+  LeafSystemOutput() = default;
+  LeafSystemOutput(const LeafSystemOutput&) = delete;
   ~LeafSystemOutput() override {}
 
   int get_num_ports() const override { return static_cast<int>(ports_.size()); }

--- a/drake/systems/framework/system_port_descriptor.h
+++ b/drake/systems/framework/system_port_descriptor.h
@@ -24,6 +24,8 @@ typedef enum {
 /// System accepts, on a given port. It is not a mechanism for handling any
 /// actual input data.
 ///
+/// This class is `CopyConstructible` but not `CopyAssignable`.
+///
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
 template <typename T>
@@ -42,7 +44,8 @@ class InputPortDescriptor {
       DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
     }
   }
-  virtual ~InputPortDescriptor() {}
+
+  InputPortDescriptor(const InputPortDescriptor&) = default;
 
   const System<T>* get_system() const { return system_; }
   int get_index() const { return index_; }
@@ -59,6 +62,8 @@ class InputPortDescriptor {
 /// OutputPortDescriptor is a notation for specifying the kind of output a
 /// System produces, on a given port. It is not a mechanism for handling any
 /// actual output data.
+///
+/// This class is `CopyConstructible` but not `CopyAssignable`.
 ///
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
@@ -78,7 +83,8 @@ class OutputPortDescriptor {
       DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
     }
   }
-  virtual ~OutputPortDescriptor() {}
+
+  OutputPortDescriptor(const OutputPortDescriptor&) = default;
 
   const System<T>* get_system() const { return system_; }
   int get_index() const { return index_; }


### PR DESCRIPTION
Removes virtual destructor and clarifies CopyConstructible concept for Input/OutputPortDescriptor classes.

Fixes #4614.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4616)
<!-- Reviewable:end -->
