### PR TITLE
Enforce the invariant the that RigidBodyTree is a proper path

### DIFF
--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -100,7 +100,7 @@ class RigidBody {
   const DrakeJoint& getJoint() const;
 
   /**
-   * Reports if the body has a joint.
+   * Reports if the body has a parent joint.
    */
   bool has_joint() const { return joint_ != nullptr; }
 

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -100,6 +100,11 @@ class RigidBody {
   const DrakeJoint& getJoint() const;
 
   /**
+   * Reports if the body has a joint.
+   */
+  bool has_joint() const { return joint_ != nullptr; }
+
+  /**
    * Sets the parent rigid body. This is the rigid body that is connected to
    * this rigid body's joint.
    *

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1216,6 +1216,23 @@ class RigidBodyTree {
   // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
   void updateCompositeRigidBodyInertias(KinematicsCache<Scalar>& cache) const;
 
+  // Examines the state of the tree, and confirms that all nodes (i.e,
+  // RigidBody instances) have a kinematics path to the root.  In other words,
+  // there should only be a single body that has no parent: the world.
+  // Throws an exception if it is *not* a complete tree.
+  void ConfirmCompleteTree() const;
+
+  // Given the body, tests to see if it has a kinematic path to the world node.
+  // Uses a cache of known "connected" bodies to accelerate the computation.
+  // The connected set consist of the body indices (see
+  // RigidBody::get_body_index) which are known to be connected to the world.
+  // This function has a side-effect of updating the set of known connected.
+  // This assumes that the connected set has been initialized with the value
+  // 0 (the world body).
+  // If not connected, throws an exception.
+  void TestConnectedToWorld(const RigidBody<T>& body,
+                            std::set<int>* connected) const;
+
   // Reorder body list to ensure parents are before children in the list
   // RigidBodyTree::bodies.
   //

--- a/drake/multibody/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/multibody/test/rigid_body_tree/CMakeLists.txt
@@ -13,3 +13,7 @@ drake_add_cc_test(rigid_body_tree_inverse_dynamics_test)
 target_link_libraries(rigid_body_tree_inverse_dynamics_test
     drakeMultibodyParsers
     drakeRBM)
+
+drake_add_cc_test(rigid_body_tree_completeness_test)
+target_link_libraries(rigid_body_tree_completeness_test
+    drakeRBM)

--- a/drake/multibody/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/joints/fixed_joint.h"
+#include "drake/multibody/joints/quaternion_floating_joint.h"
 #include "drake/multibody/parsers/model_instance_id_table.h"
 #include "drake/multibody/parsers/parser_common.h"
 
@@ -29,14 +30,15 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
   void SetUp() override {
     tree_ = make_unique<RigidBodyTree<double>>();
 
+    RigidBody<double>& world = tree_->world();
+
     drake::SquareTwistMatrix<double> I =
         drake::SquareTwistMatrix<double>::Zero();
     I.block(3, 3, 3, 3) << Matrix3d::Identity();
 
     // This body requires a self-collision clique
-    RigidBody<double>* temp_body;
-    tree_->add_rigid_body(
-        unique_ptr<RigidBody<double>>(temp_body = new RigidBody<double>()));
+    RigidBody<double>* temp_body = tree_->add_rigid_body(
+        make_unique<RigidBody<double>>());
     temp_body->set_model_name("robot1");
     temp_body->set_name("body1");
     temp_body->set_spatial_inertia(I);
@@ -44,6 +46,10 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
     body1_collision_element_2_ = make_unique<Element>();
     temp_body->AddCollisionElement("default", body1_collision_element_1_.get());
     temp_body->AddCollisionElement("default", body1_collision_element_2_.get());
+    unique_ptr<DrakeJoint> j(
+        new QuaternionFloatingJoint("j1", Isometry3d::Identity()));
+    temp_body->setJoint(move(j));
+    temp_body->set_parent(&world);
 
     // These next bodies will *not* require self-collision clique
     tree_->add_rigid_body(
@@ -53,12 +59,18 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
     body2_->set_spatial_inertia(I);
     body2_collision_element_ = make_unique<Element>();
     body2_->AddCollisionElement("default", body2_collision_element_.get());
+    j.reset(new QuaternionFloatingJoint("j1", Isometry3d::Identity()));
+    body2_->setJoint(move(j));
+    body2_->set_parent(&world);
 
     tree_->add_rigid_body(
         unique_ptr<RigidBody<double>>(body3_ = new RigidBody<double>()));
     body3_->set_model_name("robot3");
     body3_->set_name("body3");
     body3_->set_spatial_inertia(I);
+    j.reset(new QuaternionFloatingJoint("j1", Isometry3d::Identity()));
+    body3_->setJoint(move(j));
+    body3_->set_parent(&world);
   }
 
  protected:

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_completeness_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_completeness_test.cc
@@ -1,0 +1,150 @@
+#include "drake/multibody/rigid_body_tree.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/joints/fixed_joint.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Isometry3d;
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+
+// This tests the functionality responsible for determining that a rigid
+// body is "complete" -- all bodies in the tree have a kinematic path
+// back to the world.
+
+unique_ptr<RigidBody<double>> MakeBody(int id, RigidBody<double>* parent) {
+  auto rb1 = make_unique<RigidBody<double>>();
+  rb1->set_model_name("robot");
+  rb1->set_name("body" + std::to_string(id));
+  unique_ptr<DrakeJoint> j(
+      new FixedJoint("j" + std::to_string(id), Isometry3d::Identity()));
+  rb1->setJoint(move(j));
+  rb1->set_parent(parent);
+  return rb1;
+}
+
+// Tests the simple case where the tree *is* properly connected.
+GTEST_TEST(RigidBodyTreeCompleteness, FullyConnected) {
+  RigidBodyTreed tree;
+
+  RigidBody<double>& world = tree.world();
+
+  auto rb1 = MakeBody(1, &world);
+  auto rb2 = MakeBody(2, &world);
+  auto rb3 = MakeBody(3, rb1.get());
+
+  tree.add_rigid_body(move(rb1));
+  tree.add_rigid_body(move(rb2));
+  tree.add_rigid_body(move(rb3));
+
+  // Expect no exception to be thrown.
+  tree.compile();
+}
+
+// Tests the simple case where a body is missing a parent.
+GTEST_TEST(RigidBodyTreeCompleteness, MissingParent) {
+  RigidBodyTreed tree;
+
+  RigidBody<double>& world = tree.world();
+
+  auto rb1 = MakeBody(1, &world);
+  auto rb2 = MakeBody(2, &world);
+  auto rb3 = MakeBody(3, rb1.get());
+  auto rb4 = MakeBody(4, nullptr);
+
+  tree.add_rigid_body(move(rb1));
+  tree.add_rigid_body(move(rb2));
+  tree.add_rigid_body(move(rb3));
+  tree.add_rigid_body(move(rb4));
+
+  // Using try/catch to test the exception message, confirming that the right
+  // information is being returned about the error.
+  try {
+    tree.compile();
+    GTEST_FAIL();
+  } catch (std::runtime_error& e) {
+    std::string msg =
+        "ERROR: RigidBodyTree::TestConnectedToWorld(): Rigid body \"body4\" in "
+        "model robot is not connected to the world!";
+    ASSERT_EQ(e.what(), msg);
+  }
+}
+
+// Tests the simple case where a body is missing a joint and is caught during
+// the "welding" stage.
+GTEST_TEST(RigidBodyTreeCompleteness, MissingJointWeldingError) {
+  RigidBodyTreed tree;
+
+  RigidBody<double>& world = tree.world();
+
+  auto rb1 = MakeBody(1, &world);
+  auto rb2 = MakeBody(2, &world);
+  auto rb3 = make_unique<RigidBody<double>>();
+  rb3->set_name("body3");
+  rb3->set_model_name("robot");
+  rb3->set_parent(rb2.get());
+
+  tree.add_rigid_body(move(rb1));
+  tree.add_rigid_body(move(rb2));
+  tree.add_rigid_body(move(rb3));
+
+  // Using try/catch to test the exception message, confirming that the right
+  // information is being returned about the error.
+  // NOTE: This error message arises from the the welding work done by the
+  // compile method.  The body rb3 has no inertia matrix and no children
+  // so it will be "welded" to the world -- the missing joint throws the
+  // given exception at that point.
+  try {
+    tree.compile();
+    GTEST_FAIL();
+  } catch (std::runtime_error& e) {
+    std::string msg =
+        "ERROR: RigidBody<T>::getJoint(): Rigid body \"body3\" in "
+            "model robot does not have a joint!";
+    ASSERT_EQ(e.what(), msg);
+  }
+}
+
+// Tests the simple case where a body is missing a joint and it is caught in
+// the setup of configuration space.
+GTEST_TEST(RigidBodyTreeCompleteness, MissingJointConfigurationError) {
+  RigidBodyTreed tree;
+
+  RigidBody<double>& world = tree.world();
+
+  auto rb1 = MakeBody(1, &world);
+  auto rb2 = MakeBody(2, &world);
+  auto rb3 = make_unique<RigidBody<double>>();
+  rb3->set_name("body3");
+  rb3->set_model_name("robot");
+  rb3->set_parent(rb2.get());
+  rb3->set_spatial_inertia(SquareTwistMatrix<double>::Identity());
+
+  tree.add_rigid_body(move(rb1));
+  tree.add_rigid_body(move(rb2));
+  tree.add_rigid_body(move(rb3));
+
+  // Using try/catch to test the exception message, confirming that the right
+  // information is being returned about the error.
+  // NOTE: This error message arises from the
+  try {
+    tree.compile();
+    GTEST_FAIL();
+  } catch (std::runtime_error& e) {
+    std::string msg =
+        "ERROR: RigidBody<T>::getJoint(): Rigid body \"body3\" in "
+            "model robot does not have a joint!";
+    ASSERT_EQ(e.what(), msg);
+  }
+}
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_completeness_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_completeness_test.cc
@@ -134,7 +134,8 @@ GTEST_TEST(RigidBodyTreeCompleteness, MissingJointConfigurationError) {
 
   // Using try/catch to test the exception message, confirming that the right
   // information is being returned about the error.
-  // NOTE: This error message arises from the
+  // NOTE: This error message arises from the process of creating the
+  // configuration vector.
   try {
     tree.compile();
     GTEST_FAIL();


### PR DESCRIPTION
At the conclusion of RigidBodyTree::compile (after all structural changes
are affected), the RBT evaluates all the bodies and confirms that there
is a kinetic path from each body to the world.  See issue #3293.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4632)
<!-- Reviewable:end -->
