### PR TITLE
Add a more general version of RobotPropertyCache. 

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -15,6 +15,17 @@ cc_library(
 )
 
 cc_library(
+    name = "rigid_body_tree_alias_groups",
+    srcs = ["param_parsers/rigid_body_tree_alias_groups.cc"],
+    hdrs = ["param_parsers/rigid_body_tree_alias_groups.h"],
+    linkstatic = 1,
+    deps = [
+        "@yaml_cpp//:lib",
+        "//drake/multibody:rigid_body_tree",
+    ],
+)
+
+cc_library(
     name = "example_qp_input_for_valkyrie",
     srcs = ["example_qp_input_for_valkyrie.cc"],
     hdrs = ["example_qp_input_for_valkyrie.h"],
@@ -77,6 +88,24 @@ cc_test(
         ":control_utils",
         ":example_qp_input_for_valkyrie",
         ":qp_controller",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/multibody/parsers",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "rigid_body_tree_alias_groups_test",
+    srcs = ["param_parsers/test/rigid_body_tree_alias_groups_test.cc"],
+    data = [
+        "param_parsers/test/full.yaml",
+        "param_parsers/test/no_body_groups.yaml",
+        "param_parsers/test/no_joint_groups.yaml",
+        "param_parsers/test/parse_fails.yaml",
+        "//drake/multibody:test_models",
+    ],
+    deps = [
+        ":rigid_body_tree_alias_groups",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody/parsers",
         "@gtest//:main",

--- a/drake/examples/QPInverseDynamicsForHumanoids/CMakeLists.txt
+++ b/drake/examples/QPInverseDynamicsForHumanoids/CMakeLists.txt
@@ -19,6 +19,9 @@ if(lcm_FOUND)
     lcmtypes_bot2-core-cpp)
 endif()
 
+add_subdirectory(param_parsers)
+
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
+

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/CMakeLists.txt
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/CMakeLists.txt
@@ -1,0 +1,10 @@
+if (yaml-cpp_FOUND)
+  add_library(drakeRigidBodyAliasGroups rigid_body_tree_alias_groups.cc)
+  target_link_libraries(drakeRigidBodyAliasGroups
+    drakeRBM
+    yaml-cpp)
+endif()
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.cc
@@ -1,0 +1,159 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.h"
+
+#include <set>
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+namespace param_parsers {
+
+template <typename T>
+constexpr char RigidBodyTreeAliasGroups<T>::kBodyGroupsKeyword[];
+template <typename T>
+constexpr char RigidBodyTreeAliasGroups<T>::kJointGroupsKeyword[];
+
+namespace {
+// Inserts @p vec into @p mapping if @p key does not exist, or append @p vec
+// to the existing vector in @p map. This function also guarantees the newly
+// inserted elements do no introduce duplicates.
+template <typename Type>
+void InsertOrMergeVectorWithoutDuplicates(const std::string key,
+    const std::vector<Type>& vec,
+    std::unordered_map<std::string, std::vector<Type>>* mapping) {
+  DRAKE_DEMAND(mapping);
+  std::set<Type> inserted;
+
+  typename std::unordered_map<std::string, std::vector<Type>>::iterator it =
+      mapping->find(key);
+  if (it != mapping->end()) {
+    inserted = std::set<Type>(it->second.begin(), it->second.end());
+  }
+
+  std::vector<Type> unique_vec;
+  unique_vec.reserve(vec.size());
+  for (auto const& element : vec) {
+    if (inserted.find(element) == inserted.end()) {
+      unique_vec.push_back(element);
+      inserted.emplace(element);
+    }
+  }
+
+  if (it == mapping->end()) {
+    mapping->emplace(key, unique_vec);
+  } else {
+    it->second.insert(it->second.end(), unique_vec.begin(), unique_vec.end());
+  }
+}
+
+// Returns a std::vector representation of a YAML::Node. This function tries to
+// cast the node as a std::vector<Type> or as a single Type. If both casts
+// fail, it throws an exception.
+template <typename Type>
+std::vector<Type> ParseYAMLNodeAsVector(const YAML::Node& node) {
+  std::vector<Type> values;
+
+  if (node.IsNull())
+    return values;
+
+  // Tries to cast the YAML node as a vector of strings.
+  try {
+    values = node.as<std::vector<Type>>();
+  } catch (std::runtime_error e) {
+    // If casting to a vector of strings fails, tries to cast it as a single
+    // string.
+    try {
+      values.push_back(node.as<Type>());
+    } catch (std::runtime_error e1) {
+      // Throws if both attempts fail.
+      throw e1;
+    }
+  }
+
+  return values;
+}
+}  // namespace
+
+template <typename T>
+void RigidBodyTreeAliasGroups<T>::AddBodyGroup(
+    const std::string& group_name, const std::vector<std::string>& body_names) {
+  std::vector<const RigidBody<T>*> bodies;
+  bodies.reserve(body_names.size());
+  for (const std::string& name : body_names) {
+    bodies.push_back(tree_.FindBody(name));
+  }
+
+  InsertOrMergeVectorWithoutDuplicates(group_name, bodies, &body_groups_);
+}
+
+template <typename T>
+void RigidBodyTreeAliasGroups<T>::AddJointGroup(
+    const std::string& group_name,
+    const std::vector<std::string>& joint_names) {
+  std::vector<const RigidBody<T>*> bodies;
+  std::vector<const DrakeJoint*> joints;
+  bodies.reserve(joint_names.size());
+  joints.reserve(joint_names.size());
+  int q_size = 0;
+  int v_size = 0;
+  for (const std::string& name : joint_names) {
+    bodies.push_back(tree_.FindChildBodyOfJoint(name));
+    joints.push_back(&(bodies.back()->getJoint()));
+
+    q_size += joints.back()->get_num_positions();
+    v_size += joints.back()->get_num_velocities();
+  }
+
+  InsertOrMergeVectorWithoutDuplicates(group_name, joints, &joint_groups_);
+
+  std::vector<int> q_indices, v_indices;
+  q_indices.reserve(q_size);
+  v_indices.reserve(v_size);
+
+  for (const RigidBody<T>* body : bodies) {
+    int q_start = body->get_position_start_index();
+    int q_end = q_start + body->getJoint().get_num_positions();
+    for (int i = q_start; i < q_end; ++i) q_indices.push_back(i);
+
+    int v_start = body->get_velocity_start_index();
+    int v_end = v_start + body->getJoint().get_num_velocities();
+    for (int i = v_start; i < v_end; ++i) v_indices.push_back(i);
+  }
+
+  InsertOrMergeVectorWithoutDuplicates(
+      group_name, q_indices, &position_groups_);
+  InsertOrMergeVectorWithoutDuplicates(
+      group_name, v_indices, &velocity_groups_);
+}
+
+template <typename T>
+void RigidBodyTreeAliasGroups<T>::LoadFromYAMLFile(
+    const YAML::Node& config) {
+  // Parse body groups.
+  YAML::Node body_groups = config[kBodyGroupsKeyword];
+  for (auto group_it = body_groups.begin(); group_it != body_groups.end();
+       ++group_it) {
+    std::string group_name = group_it->first.as<std::string>();
+    std::vector<std::string> body_names =
+        ParseYAMLNodeAsVector<std::string>(group_it->second);
+
+    AddBodyGroup(group_name, body_names);
+  }
+
+  // Parse joint groups
+  YAML::Node joint_groups = config[kJointGroupsKeyword];
+  for (auto group_it = joint_groups.begin(); group_it != joint_groups.end();
+       ++group_it) {
+    std::string group_name = group_it->first.as<std::string>();
+    std::vector<std::string> joint_names =
+        ParseYAMLNodeAsVector<std::string>(group_it->second);
+
+    AddJointGroup(group_name, joint_names);
+  }
+}
+
+template class RigidBodyTreeAliasGroups<double>;
+
+}  // namespace param_parsers
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.h
@@ -1,0 +1,228 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "yaml-cpp/yaml.h"
+
+#include "drake/multibody/rigid_body_tree.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+namespace param_parsers {
+
+/**
+ * This class provides a way to create aliases to groups of RigidBody or
+ * DrakeJoint objects. The creation of these groups can be done either
+ * programmatically or via a YAML file.
+ *
+ * For example, suppose we have a RigidBodyTree with 6 links named
+ * [link0 ~ link5], and 6 joints [base, joint0 ~ joint4]. We can "rename"
+ * `link0` to be `robot_base` by creating a body group named `robot_base`
+ * with one entry `link0`, and accessing the first element in this body group.
+ * Alias names for groups of joints can also be similarly created. Furthermore,
+ * the corresponding indices to the generalized position and velocity are
+ * computed and accessible through an instance of this class.
+ *
+ * Body groups and joint groups are independent, so a body group can have the
+ * same name of a joint group. However, all body groups have unique group
+ * names, and so do all joint groups. For each body or joint group, its
+ * members are unique. A body or joint can belong to many groups. When adding
+ * new members to an existing group, the new members will be appended to the
+ * existing group.
+ */
+template <typename T>
+class RigidBodyTreeAliasGroups {
+ public:
+  static constexpr char kBodyGroupsKeyword[] = "body_groups";
+  static constexpr char kJointGroupsKeyword[] = "joint_groups";
+
+  /**
+   * Constructor for RigidBodyTreeAliasGroups.
+   * @param tree Reference to the RigidBodyTree. A pointer to this RigidBodyTree
+   * is stored, so @p tree needs to outlive this object.
+   */
+  explicit RigidBodyTreeAliasGroups(const RigidBodyTree<T>& tree)
+      : tree_(tree) {}
+
+  RigidBodyTreeAliasGroups(const RigidBodyTreeAliasGroups&) = delete;
+  RigidBodyTreeAliasGroups& operator=(const RigidBodyTreeAliasGroups&) = delete;
+
+
+  /**
+   * Parses body groups and joint groups from a config file.
+   * This function looks for optional top level keywords kBodyGroupsKeyword and
+   * kJointGroupsKeyword in @p config.
+   * An example config file looks like:
+   * <pre>
+   * ...
+   * body_groups:
+   *   body_group_name1:
+   *     [body_name1, body_name2, ...]
+   *   body_group_name2:
+   *     [body_name1, body_name3, ...]
+   *   body_group_name3:
+   *
+   *   body_group_name4:
+   *     body_name4
+   *   ...
+   * ...
+   * joint_groups:
+   *   joint_group_name1:
+   *     [joint_name1, joint_name2, ...]
+   *   joint_group_name2:
+   *     [joint_name1, joint_name3, ...]
+   *   joint_group_name3:
+   *
+   *   joint_group_name4:
+   *     joint_name4
+   *   ...
+   * ...
+   * </pre>
+   * body_namei and joint_namei need to match a link's name and joint's
+   * name respectively in the RigidBodyTree provided at construction time.
+   * body_namei and joint_namei can appear in multiple groups. Multiple body
+   * groups with the same group name will be merged, and the same applies to
+   * joint groups. For each group, there will be no duplicated elements.
+   * body_groups or joint_groups can be absent or empty.
+   * The above example shows all valid formats for specifying body and joint
+   * names.
+   *
+   * @param config YAML node specifying joint and body groups.
+   *
+   * @throws std::logic_error if body_namei or joint_namei cannot be found in
+   * the RigidBodyTree provided at construction time.
+   * @throws std::runtime_error if joint names or body names cannot be parsed
+   * correctly.
+   */
+  void LoadFromYAMLFile(const YAML::Node& config);
+
+  /**
+   * Creates a body group named @p group_name whose elements have names from
+   * @p body_names. If a group named @p group_name already exists, @p body_names
+   * is appended to the end of the existing group. The resulting group will not
+   * have duplicated elements.
+   * @param group_name Name of the body group, can be arbitrary.
+   * @param body_names Vector of body names, must be present in the
+   * RigidBodyTree passed to the constructor.
+   *
+   * @throws std::logic_error if elements in @p body_names cannot be found in
+   * the RigidBodyTree referenced at construction time.
+   */
+  void AddBodyGroup(const std::string& group_name,
+                    const std::vector<std::string>& body_names);
+
+  /**
+   * Creates a joint group named @p group_name whose elements have names from
+   * @p joint_names. If a group named @p group_name already exists,
+   * @p joint_names is appended to the end of the existing group. The resulting
+   * group will not have duplicated elements.
+   * @param group_name Name of the joint group, can be arbitrary.
+   * @param joint_names Vector of joint names, must be present in the
+   * RigidBodyTree passed to the constructor.
+   *
+   * @throws std::logic_error if elements in @p joint_names cannot be found in
+   * the RigidBodyTree referenced at construction time.
+   */
+  void AddJointGroup(const std::string& group_name,
+                     const std::vector<std::string>& joint_names);
+
+  bool has_body_group(const std::string& group_name) const {
+    return body_groups_.find(group_name) != body_groups_.end();
+  }
+
+  bool has_joint_group(const std::string& group_name) const {
+    return joint_groups_.find(group_name) != joint_groups_.end();
+  }
+
+  bool has_position_group(const std::string& group_name) const {
+    return position_groups_.find(group_name) !=
+           position_groups_.end();
+  }
+
+  bool has_velocity_group(const std::string& group_name) const {
+    return velocity_groups_.find(group_name) !=
+           velocity_groups_.end();
+  }
+
+  /**
+   * Returns the body group identified by @p group_name.
+   *
+   * @throws std::out_of_range if @p group_name is not found.
+   */
+  const std::vector<const RigidBody<T>*>& get_body_group(
+      const std::string& group_name) const {
+    return body_groups_.at(group_name);
+  }
+
+  /**
+   * Returns the joint group identified by @p group_name.
+   *
+   * @throws std::out_of_range if @p group_name is not found.
+   */
+  const std::vector<const DrakeJoint*>& get_joint_group(
+      const std::string& group_name) const {
+    return joint_groups_.at(group_name);
+  }
+
+  /**
+   * Returns the generalized position indices associated with the joint group
+   * identified by @p group_name.
+   *
+   * @throws std::out_of_range if @p group_name is not found.
+   */
+  const std::vector<int>& get_position_group(
+      const std::string& group_name) const {
+    return position_groups_.at(group_name);
+  }
+
+  /**
+   * Returns the generalized velocity indices associated with the joint group
+   * identified by @p group_name.
+   *
+   * @throws std::out_of_range if @p group_name is not found.
+   */
+  const std::vector<int>& get_velocity_group(
+      const std::string& group_name) const {
+    return velocity_groups_.at(group_name);
+  }
+
+  const std::unordered_map<std::string, std::vector<const RigidBody<T>*>>&
+  get_body_groups() const {
+    return body_groups_;
+  }
+
+  const std::unordered_map<std::string, std::vector<const DrakeJoint*>>&
+  get_joint_groups() const {
+    return joint_groups_;
+  }
+
+  const std::unordered_map<std::string, std::vector<int>>&
+  get_position_groups() const {
+    return position_groups_;
+  }
+
+  const std::unordered_map<std::string, std::vector<int>>&
+  get_velocity_groups() const {
+    return velocity_groups_;
+  }
+
+  const RigidBodyTree<T>& get_tree() const { return tree_; }
+
+ private:
+  const RigidBodyTree<T>& tree_;
+
+  std::unordered_map<std::string, std::vector<const RigidBody<T>*>>
+      body_groups_;
+  std::unordered_map<std::string, std::vector<const DrakeJoint*>> joint_groups_;
+
+  std::unordered_map<std::string, std::vector<int>> position_groups_;
+  std::unordered_map<std::string, std::vector<int>> velocity_groups_;
+};
+
+}  // namespace param_parsers
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/CMakeLists.txt
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+if (yaml-cpp_FOUND)
+  drake_add_cc_test(rigid_body_tree_alias_groups_test)
+  target_link_libraries(rigid_body_tree_alias_groups_test
+    drakeMultibodyParsers
+    drakeRigidBodyAliasGroups)
+endif()

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/full.yaml
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/full.yaml
@@ -1,0 +1,19 @@
+body_groups:
+  b_group1:
+    []
+
+  b_group2:
+    [link1]
+
+  b_group2:
+    [link3]
+
+  b_group3:
+    [world]
+
+joint_groups:
+  j_group1:
+    []
+
+  j_group2:
+    [base, joint1]

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/no_body_groups.yaml
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/no_body_groups.yaml
@@ -1,0 +1,11 @@
+joint_groups:
+  j_group1:
+    []
+
+  j_group2:
+    [joint1]
+
+  j_group3:
+
+  j_group2:
+    [joint2]

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/no_joint_groups.yaml
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/no_joint_groups.yaml
@@ -1,0 +1,12 @@
+body_groups:
+  b_group1:
+    []
+
+  b_group2:
+    [link3]
+
+  b_group3:
+    link1
+
+  b_group2:
+    [link2, link3]

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/parse_fails.yaml
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/parse_fails.yaml
@@ -1,0 +1,13 @@
+joint_groups:
+  j_group1:
+    []
+
+  j_group2:
+    [joint1]
+
+  j_group3:
+    # map is not a valid format for this.
+    key: map
+
+  j_group2:
+    [joint2]

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/rigid_body_tree_alias_groups_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/rigid_body_tree_alias_groups_test.cc
@@ -1,0 +1,264 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_path.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+namespace param_parsers {
+
+// The test YAML config looks like this:
+//
+//    body_groups:
+//      b_group1:
+//        []
+//
+//      b_group2:
+//        [link1]
+//
+//      b_group2:
+//        [link3]
+//
+//      b_group3:
+//        [world]
+//
+//    joint_groups:
+//      j_group1:
+//        []
+//
+//      j_group2:
+//        [base, joint1]
+//
+// Please refer to the full config file for more details.
+void TestFullConfig(multibody::joints::FloatingBaseType type) {
+  std::string urdf = drake::GetDrakePath()
+      + "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
+  std::string config = drake::GetDrakePath()
+      + "/examples/QPInverseDynamicsForHumanoids/param_parsers/test/full.yaml";
+
+  auto robot = std::make_unique<RigidBodyTree<double>>();
+  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(urdf, type, robot.get());
+
+  RigidBodyTreeAliasGroups<double> alias(*robot);
+
+  YAML::Node file = YAML::LoadFile(config);
+  alias.LoadFromYAMLFile(file);
+
+  EXPECT_TRUE(alias.has_position_group("j_group1"));
+  EXPECT_TRUE(alias.has_position_group("j_group2"));
+  EXPECT_TRUE(alias.has_velocity_group("j_group1"));
+  EXPECT_TRUE(alias.has_velocity_group("j_group2"));
+  EXPECT_FALSE(alias.has_position_group("j_non_existant_group"));
+  EXPECT_FALSE(alias.has_velocity_group("j_non_existant_group"));
+
+  EXPECT_TRUE(alias.has_body_group("b_group1"));
+  EXPECT_TRUE(alias.has_body_group("b_group2"));
+  EXPECT_TRUE(alias.has_body_group("b_group3"));
+  EXPECT_FALSE(alias.has_body_group("b_non_existant_group"));
+
+  EXPECT_EQ(alias.get_position_group("j_group1").size(), 0);
+  EXPECT_EQ(alias.get_velocity_group("j_group1").size(), 0);
+
+  EXPECT_EQ(alias.get_body_group("b_group1").size(), 0);
+  EXPECT_EQ(alias.get_body_group("b_group2").size(), 2);
+  EXPECT_EQ(alias.get_body_group("b_group2")[0]->get_name(), "link1");
+  EXPECT_EQ(alias.get_body_group("b_group2")[1]->get_name(), "link3");
+  EXPECT_EQ(alias.get_body_group("b_group3").size(), 1);
+  EXPECT_EQ(alias.get_body_group("b_group3")[0]->get_name(), "world");
+
+  EXPECT_EQ(alias.get_joint_group("j_group1").size(), 0);
+  EXPECT_EQ(alias.get_joint_group("j_group2").size(), 2);
+  EXPECT_EQ(alias.get_joint_group("j_group2")[0]->get_name(), "base");
+  EXPECT_EQ(alias.get_joint_group("j_group2")[1]->get_name(), "joint1");
+
+  const std::vector<int>& q_indices = alias.get_position_group("j_group2");
+  const std::vector<int>& v_indices = alias.get_velocity_group("j_group2");
+  switch (type) {
+    case drake::multibody::joints::kQuaternion:
+      EXPECT_EQ(q_indices.size(), 8);
+      EXPECT_EQ(v_indices.size(), 7);
+      EXPECT_EQ(robot->get_position_name(q_indices[0]), "base_x");
+      EXPECT_EQ(robot->get_position_name(q_indices[1]), "base_y");
+      EXPECT_EQ(robot->get_position_name(q_indices[2]), "base_z");
+      EXPECT_EQ(robot->get_position_name(q_indices[3]), "base_qw");
+      EXPECT_EQ(robot->get_position_name(q_indices[4]), "base_qx");
+      EXPECT_EQ(robot->get_position_name(q_indices[5]), "base_qy");
+      EXPECT_EQ(robot->get_position_name(q_indices[6]), "base_qz");
+
+      EXPECT_EQ(robot->get_velocity_name(v_indices[0]), "base_wx");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[1]), "base_wy");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[2]), "base_wz");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[3]), "base_vx");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[4]), "base_vy");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[5]), "base_vz");
+      break;
+    case multibody::joints::kRollPitchYaw:
+      EXPECT_EQ(q_indices.size(), 7);
+      EXPECT_EQ(v_indices.size(), 7);
+      EXPECT_EQ(robot->get_position_name(q_indices[0]), "base_x");
+      EXPECT_EQ(robot->get_position_name(q_indices[1]), "base_y");
+      EXPECT_EQ(robot->get_position_name(q_indices[2]), "base_z");
+      EXPECT_EQ(robot->get_position_name(q_indices[3]), "base_roll");
+      EXPECT_EQ(robot->get_position_name(q_indices[4]), "base_pitch");
+      EXPECT_EQ(robot->get_position_name(q_indices[5]), "base_yaw");
+
+      EXPECT_EQ(robot->get_velocity_name(v_indices[0]), "base_xdot");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[1]), "base_ydot");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[2]), "base_zdot");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[3]), "base_rolldot");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[4]), "base_pitchdot");
+      EXPECT_EQ(robot->get_velocity_name(v_indices[5]), "base_yawdot");
+      break;
+    case multibody::joints::kFixed:
+      EXPECT_EQ(q_indices.size(), 1);
+      EXPECT_EQ(v_indices.size(), 1);
+      break;
+  }
+
+  EXPECT_EQ(robot->get_position_name(q_indices.back()), "joint1");
+  EXPECT_EQ(robot->get_velocity_name(v_indices.back()), "joint1dot");
+}
+
+// The test YAML config looks like this:
+//
+//    joint_groups:
+//      j_group1:
+//        []
+//
+//      j_group2:
+//        [joint1]
+//
+//      j_group3:
+//
+//      j_group2:
+//        [joint2]
+//
+// Please refer to the full config file for more details.
+void TestNoBodyGroupsConfig(multibody::joints::FloatingBaseType type) {
+  std::string urdf = drake::GetDrakePath() +
+                     "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
+  std::string config = drake::GetDrakePath()
+      + "/examples/QPInverseDynamicsForHumanoids/param_parsers/test"
+      + "/no_body_groups.yaml";
+
+  auto robot = std::make_unique<RigidBodyTree<double>>();
+  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(urdf, type, robot.get());
+
+  RigidBodyTreeAliasGroups<double> alias(*robot);
+
+  YAML::Node file = YAML::LoadFile(config);
+  alias.LoadFromYAMLFile(file);
+
+  EXPECT_TRUE(alias.has_position_group("j_group1"));
+  EXPECT_TRUE(alias.has_velocity_group("j_group1"));
+  EXPECT_TRUE(alias.has_position_group("j_group2"));
+  EXPECT_TRUE(alias.has_velocity_group("j_group2"));
+  EXPECT_TRUE(alias.has_position_group("j_group3"));
+  EXPECT_TRUE(alias.has_velocity_group("j_group3"));
+  EXPECT_FALSE(alias.has_position_group("j_non_existant_group"));
+  EXPECT_FALSE(alias.has_velocity_group("j_non_existant_group"));
+
+  EXPECT_EQ(alias.get_position_group("j_group1").size(), 0);
+  EXPECT_EQ(alias.get_velocity_group("j_group1").size(), 0);
+  EXPECT_EQ(alias.get_position_group("j_group2").size(), 2);
+  EXPECT_EQ(alias.get_velocity_group("j_group2").size(), 2);
+  EXPECT_EQ(alias.get_position_group("j_group3").size(), 0);
+  EXPECT_EQ(alias.get_velocity_group("j_group3").size(), 0);
+
+  EXPECT_EQ(robot->get_position_name(
+        alias.get_position_group("j_group2")[0]), "joint1");
+  EXPECT_EQ(robot->get_velocity_name(
+        alias.get_velocity_group("j_group2")[0]), "joint1dot");
+  EXPECT_EQ(robot->get_position_name(
+        alias.get_position_group("j_group2")[1]), "joint2");
+  EXPECT_EQ(robot->get_velocity_name(
+        alias.get_velocity_group("j_group2")[1]), "joint2dot");
+
+  EXPECT_EQ(alias.get_joint_group("j_group1").size(), 0);
+  EXPECT_EQ(alias.get_joint_group("j_group2").size(), 2);
+  EXPECT_EQ(alias.get_joint_group("j_group2")[0]->get_name(), "joint1");
+  EXPECT_EQ(alias.get_joint_group("j_group2")[1]->get_name(), "joint2");
+}
+
+// The test YAML config looks like this:
+//
+//    body_groups:
+//      b_group1:
+//        []
+//
+//      b_group2:
+//        [link3]
+//
+//      b_group3:
+//        link1
+//
+// Please refer to the full config file for more details.
+void TestNoJointGroupsConfig(multibody::joints::FloatingBaseType type) {
+  std::string urdf = drake::GetDrakePath() +
+                     "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
+  std::string config = drake::GetDrakePath()
+      + "/examples/QPInverseDynamicsForHumanoids/param_parsers/test"
+      + "/no_joint_groups.yaml";
+
+  auto robot = std::make_unique<RigidBodyTree<double>>();
+  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(urdf, type, robot.get());
+
+  RigidBodyTreeAliasGroups<double> alias(*robot);
+
+  YAML::Node file = YAML::LoadFile(config);
+  alias.LoadFromYAMLFile(file);
+
+  EXPECT_TRUE(alias.has_body_group("b_group1"));
+  EXPECT_TRUE(alias.has_body_group("b_group2"));
+  EXPECT_TRUE(alias.has_body_group("b_group3"));
+  EXPECT_FALSE(alias.has_body_group("b_non_existant_group"));
+
+  EXPECT_EQ(alias.get_body_group("b_group1").size(), 0);
+  EXPECT_EQ(alias.get_body_group("b_group2").size(), 2);
+  EXPECT_EQ(alias.get_body_group("b_group2")[0]->get_name(), "link3");
+  EXPECT_EQ(alias.get_body_group("b_group2")[1]->get_name(), "link2");
+  EXPECT_EQ(alias.get_body_group("b_group3").size(), 1);
+  EXPECT_EQ(alias.get_body_group("b_group3")[0]->get_name(), "link1");
+}
+
+GTEST_TEST(RigidBodyTreeYAMLParsingTest, TestFull) {
+  TestFullConfig(multibody::joints::kRollPitchYaw);
+  TestFullConfig(multibody::joints::kQuaternion);
+  TestFullConfig(multibody::joints::kFixed);
+}
+
+GTEST_TEST(RigidBodyTreeYAMLParsingTest, TestNoJoint) {
+  TestNoJointGroupsConfig(multibody::joints::kRollPitchYaw);
+  TestNoJointGroupsConfig(multibody::joints::kQuaternion);
+  TestNoJointGroupsConfig(multibody::joints::kFixed);
+}
+
+GTEST_TEST(RigidBodyTreeYAMLParsingTest, TestNoBody) {
+  TestNoBodyGroupsConfig(multibody::joints::kRollPitchYaw);
+  TestNoBodyGroupsConfig(multibody::joints::kQuaternion);
+  TestNoBodyGroupsConfig(multibody::joints::kFixed);
+}
+
+GTEST_TEST(RigidBodyTreeYAMLParsingTest, TestParseException) {
+  std::string urdf = drake::GetDrakePath() +
+                     "/multibody/test/rigid_body_tree/two_dof_robot.urdf";
+  std::string config = drake::GetDrakePath()
+      + "/examples/QPInverseDynamicsForHumanoids/param_parsers/test"
+      + "/parse_fails.yaml";
+
+  auto robot = std::make_unique<RigidBodyTree<double>>();
+  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(urdf,
+      multibody::joints::kQuaternion, robot.get());
+
+  RigidBodyTreeAliasGroups<double> alias(*robot);
+
+  YAML::Node file = YAML::LoadFile(config);
+  EXPECT_THROW(alias.LoadFromYAMLFile(file), std::runtime_error);
+}
+
+}  // namespace param_parsers
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake


### PR DESCRIPTION
The idea is to have a common identifier that points the right RigidBody for different RBTs. For example, suppose I have two RBT for two different robot arms. RBT1 has link names "link0" ~ "link5", and RBT2 has link names "Link1" ~ "Link6". And for both arm, I know the last link is where the gripper is attached to. So I want to create an alias, "gripper_attached_body", for both arms that point to "link5" and "Link6". This is useful because the source code is not model specific as long as that alias exists for the model.  

In open humanoids, this was done with a separate yaml file, and there is a separate custom yaml based parser to generate the mapping from the alias name to RigidBody*. For each urdf model, there is a separate yaml file that contains a list of associations. For example, we have
l_foot: leftFoot
r_foot: rightFoot
...

The left hand side is the alias name, and the rhs is the body name in the urdf file. In the code, we lookup using the lhs identifier. 

These live in /home/sfeng/code/drake1/drake/systems/controllers/QPCommon.h in RobotPropertyCache. However they are very specific to humanoids. This PR attempts to make the same idea a bit more generic. 

@liangfok for feature review. thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4638)
<!-- Reviewable:end -->
