### PR TITLE
Re-enable LCM for sanitizers and add more TSan suppressions

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -191,7 +191,6 @@ macro(drake_setup_options)
 
   drake_system_dependency(
     LCM OPTIONAL REQUIRES lcm
-    DEPENDS "NOT USE_SANITIZER"
     "Lightweight Communications and Marshaling IPC suite")
 
   drake_system_dependency(

--- a/tools/blacklist.txt
+++ b/tools/blacklist.txt
@@ -1,0 +1,5 @@
+# Sanitizer special case list
+# http://clang.llvm.org/docs/SanitizerSpecialCaseList.html
+
+# AddressSanitizer: global-buffer-overflow (libsnopt_c.*) in lc_auth_data
+fun:snprnt_

--- a/tools/tsan.supp
+++ b/tools/tsan.supp
@@ -1,5 +1,17 @@
+# lock-order-inversion (libmosek64.*) in lc_auth_data
+deadlock:lc_auth_data
+
 # unlock of an unlocked mutex (libmosek64.*) in l_mt_unlock
 mutex:l_mt_unlock
+
+# unlock of an unlocked mutex (libmosek64.*) in lc_checkout
+mutex:lc_checkout
+
+# data race (libiomp5.*) in __kmp_resume
+race:__kmp_resume
+
+# data race (libglib-2.0.*) in g_static_rec_mutex_lock
+race:g_static_rec_mutex_lock
 
 # thread leak (libiomp5.*) in __kmp_create_worker
 thread:__kmp_create_worker


### PR DESCRIPTION
Note that TSan suppressions are of un-instrumented libraries that we receive (only) in binary form. Therefore, the errors could potentially be false positives, but, in any case, we have no way of fixing them.

LCM was previously disabled for sanitizer builds due to issues with `lcm-gen`, but apparently those issues were either fixed or imagined (by me, I guess).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4645)
<!-- Reviewable:end -->
