### PR TITLE
Generalize lorentz cone

### DIFF
--- a/drake/solvers/constraint.cc
+++ b/drake/solvers/constraint.cc
@@ -19,32 +19,36 @@ void QuadraticConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
 
 void LorentzConeConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                  Eigen::VectorXd& y) const {
+  Eigen::VectorXd z = A_*x + b_;
   y.resize(num_constraints());
-  y(0) = x(0);
-  y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
+  y(0) = z(0);
+  y(1) = pow(z(0), 2) - z.tail(z.size() - 1).squaredNorm();
 }
 
 void LorentzConeConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
                                  TaylorVecXd& y) const {
+  TaylorVecXd z = A_.cast<TaylorVarXd>()*x + b_.cast<TaylorVarXd>();
   y.resize(num_constraints());
-  y(0) = x(0);
-  y(1) = pow(x(0), 2) - x.tail(x.size() - 1).squaredNorm();
+  y(0) = z(0);
+  y(1) = pow(z(0), 2) - z.tail(z.size() - 1).squaredNorm();
 }
 
 void RotatedLorentzConeConstraint::Eval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {
+  Eigen::VectorXd z = A_ * x + b_;
   y.resize(num_constraints());
-  y(0) = x(0);
-  y(1) = x(1);
-  y(2) = x(0) * x(1) - x.tail(x.size() - 2).squaredNorm();
+  y(0) = z(0);
+  y(1) = z(1);
+  y(2) = z(0) * z(1) - z.tail(z.size() - 2).squaredNorm();
 }
 
 void RotatedLorentzConeConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
                                         TaylorVecXd& y) const {
+  TaylorVecXd z = A_.cast<TaylorVarXd>() * x + b_.cast<TaylorVarXd>();
   y.resize(num_constraints());
-  y(0) = x(0);
-  y(1) = x(1);
-  y(2) = x(0) * x(1) - x.tail(x.size() - 2).squaredNorm();
+  y(0) = z(0);
+  y(1) = z(1);
+  y(2) = z(0) * z(1) - z.tail(z.size() - 2).squaredNorm();
 }
 
 void PolynomialConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/drake/solvers/constraint.cc
+++ b/drake/solvers/constraint.cc
@@ -19,7 +19,7 @@ void QuadraticConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
 
 void LorentzConeConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                  Eigen::VectorXd& y) const {
-  Eigen::VectorXd z = A_*x + b_;
+  Eigen::VectorXd z = A_ * x + b_;
   y.resize(num_constraints());
   y(0) = z(0);
   y(1) = pow(z(0), 2) - z.tail(z.size() - 1).squaredNorm();
@@ -27,7 +27,7 @@ void LorentzConeConstraint::Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
 
 void LorentzConeConstraint::Eval(const Eigen::Ref<const TaylorVecXd>& x,
                                  TaylorVecXd& y) const {
-  TaylorVecXd z = A_.cast<TaylorVarXd>()*x + b_.cast<TaylorVarXd>();
+  TaylorVecXd z = A_.cast<TaylorVarXd>() * x + b_.cast<TaylorVarXd>();
   y.resize(num_constraints());
   y(0) = z(0);
   y(1) = pow(z(0), 2) - z.tail(z.size() - 1).squaredNorm();

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -195,8 +195,10 @@ class QuadraticConstraint : public Constraint {
 };
 
 /**
- A LorentzConeConstraint takes a vector @f$ x\in\mathbb{R}^m @f$, and impose the
- constraint
+ This constraint taks a vector @f$ x\in\mathbb{R}^m @f$, defines a
+ linear expression \f$ z\equiv Ax+b \f$, and imposes that
+ @f$ z @f$ is in the Lorentz cone.
+ Namely
  @f[
  z = Ax+b\\
  z_1 \ge \sqrt{z_2^2+...+z_n^2}
@@ -236,6 +238,12 @@ class LorentzConeConstraint : public Constraint {
 
   ~LorentzConeConstraint() override {}
 
+  /// Getter for A.
+  const Eigen::MatrixXd& A() {return A_;}
+
+  /// Getter for b.
+  const Eigen::VectorXd& b() {return b_;}
+
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
 
@@ -248,8 +256,10 @@ class LorentzConeConstraint : public Constraint {
 };
 
 /**
- * A rotated Lorentz cone constraint that taks a vector
- * @f$ x\in\mathbb{R}^m @f$, and imposes the constraint
+ * This constraint taks a vector @f$ x\in\mathbb{R}^m @f$, defines a
+ * linear expression @f$ z\equiv Ax+b @f$, and imposes that
+ * @f$ z @f$ is in the rotated Lorentz cone.
+ * Namely
  * @f[
  * z = Ax+b\\
  * z_1 \ge 0\\
@@ -275,6 +285,12 @@ class RotatedLorentzConeConstraint : public Constraint {
                        std::numeric_limits<double>::infinity())), A_(A), b_(b) {
     DRAKE_ASSERT(A_.rows() == b_.rows());
   }
+
+  /// Getter for A.
+  const Eigen::MatrixXd& A() {return A_;}
+
+  /// Getter for b.
+  const Eigen::VectorXd& b() {return b_;}
 
   RotatedLorentzConeConstraint(const RotatedLorentzConeConstraint& rhs) =
       delete;

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -242,10 +242,10 @@ class LorentzConeConstraint : public Constraint {
   ~LorentzConeConstraint() override {}
 
   /// Getter for A.
-  const Eigen::MatrixXd& A() { return A_; }
+  const Eigen::MatrixXd& A() const { return A_; }
 
   /// Getter for b.
-  const Eigen::VectorXd& b() { return b_; }
+  const Eigen::VectorXd& b() const { return b_; }
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
@@ -293,10 +293,10 @@ class RotatedLorentzConeConstraint : public Constraint {
   }
 
   /// Getter for A.
-  const Eigen::MatrixXd& A() { return A_; }
+  const Eigen::MatrixXd& A() const { return A_; }
 
   /// Getter for b.
-  const Eigen::VectorXd& b() { return b_; }
+  const Eigen::VectorXd& b() const { return b_; }
 
   RotatedLorentzConeConstraint(const RotatedLorentzConeConstraint& rhs) =
       delete;

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -228,6 +228,7 @@ class LorentzConeConstraint : public Constraint {
             Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity())),
         A_(A),
         b_(b) {
+    DRAKE_DEMAND(A_.rows() >= 2);
     DRAKE_ASSERT(A_.rows() == b_.rows());
   }
 
@@ -289,6 +290,7 @@ class RotatedLorentzConeConstraint : public Constraint {
             Eigen::Vector3d::Constant(std::numeric_limits<double>::infinity())),
         A_(A),
         b_(b) {
+    DRAKE_DEMAND(A_.rows() >= 3);
     DRAKE_ASSERT(A_.rows() == b_.rows());
   }
 

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -195,14 +195,14 @@ class QuadraticConstraint : public Constraint {
 };
 
 /**
- This constraint taks a vector @f$ x\in\mathbb{R}^m @f$, defines a
- linear expression \f$ z\equiv Ax+b \f$, and imposes that
- @f$ z @f$ is in the Lorentz cone.
- Namely
+ Constraining the linear expression \f$ Ax+b \f$ lies within the Lorentz cone.
+ A vector \f$ z \in \mathbb{R}^n \f$ lies within Lorentz cone if
  @f[
- z = Ax+b\\
  z_1 \ge \sqrt{z_2^2+...+z_n^2}
  @f]
+ <!-->
+ z1 >= sqrt(z2^2 + ... + zn^2)
+ <-->
  where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^{n}@f$ are given matrices.
  Ideally this constraint should be handled by a second-order cone solver.
  In case the user wants to enforce this constraint through general nonlinear
@@ -212,7 +212,7 @@ class QuadraticConstraint : public Constraint {
  a_1^Tx+b_1\ge 0\\
  (a_1^Tx+b_1)^2-(a_2^Tx+b_2)^2-...-(a_n^Tx+b_n)^2 \ge 0
  @f]
- where @f$ a_i@f$ is the i'th row of matrix @f$ A@f$. @f$ b_i @f$ is the i'th
+ where @f$ a_i^T@f$ is the i'th row of matrix @f$ A@f$. @f$ b_i @f$ is the i'th
  entry of vector @f$ b @f$.
 
  For more information and visualization, please refer to
@@ -220,9 +220,8 @@ class QuadraticConstraint : public Constraint {
  */
 class LorentzConeConstraint : public Constraint {
  public:
-  template <typename DerivedA, typename DerivedB>
-  LorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
-                        const Eigen::MatrixBase<DerivedB>& b)
+  LorentzConeConstraint(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                        const Eigen::Ref<const Eigen::VectorXd>& b)
       : Constraint(
             2, Eigen::Vector2d::Constant(0.0),
             Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity())),
@@ -255,24 +254,20 @@ class LorentzConeConstraint : public Constraint {
             TaylorVecXd& y) const override;
 
  private:
-  Eigen::MatrixXd A_;
-  Eigen::VectorXd b_;
+  const Eigen::MatrixXd A_;
+  const Eigen::VectorXd b_;
 };
 
 /**
- * This constraint taks a vector @f$ x\in\mathbb{R}^m @f$, defines a
- * linear expression @f$ z\equiv Ax+b @f$, and imposes that
- * @f$ z @f$ is in the rotated Lorentz cone.
- * Namely
+ * Constraining that the linear expression \f$ Ax+b \f$ lies within rotated Lorentz cone.
+ * A vector \f$ z \in\mathbb{R}^n \f$ lies within rotated Lorentz cone, if
  * @f[
- * z = Ax+b\\
  * z_1 \ge 0\\
  * z_2 \ge 0\\
  * z_1  z_2 \ge z_3^2 + z_4^2 + ... + z_n^2
  * @f]
  * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given matrices.
  * <!-->
- * z = A*x+b
  * z1 >= 0
  * z2 >= 0
  * z1 * z2 >= z3^2 + z4^2 + ... + zn^2
@@ -282,9 +277,8 @@ class LorentzConeConstraint : public Constraint {
  */
 class RotatedLorentzConeConstraint : public Constraint {
  public:
-  template <typename DerivedA, typename DerivedB>
-  RotatedLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
-                               const Eigen::MatrixBase<DerivedB>& b)
+  RotatedLorentzConeConstraint(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                               const Eigen::Ref<const Eigen::VectorXd>& b)
       : Constraint(
             3, Eigen::Vector3d::Constant(0.0),
             Eigen::Vector3d::Constant(std::numeric_limits<double>::infinity())),
@@ -320,8 +314,8 @@ class RotatedLorentzConeConstraint : public Constraint {
             TaylorVecXd& y) const override;
 
  private:
-  Eigen::MatrixXd A_;
-  Eigen::VectorXd b_;
+  const Eigen::MatrixXd A_;
+  const Eigen::VectorXd b_;
 };
 
 /**

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -195,13 +195,13 @@ class QuadraticConstraint : public Constraint {
 };
 
 /**
- Constraining the linear expression \f$ Ax+b \f$ lies within the Lorentz cone.
+ Constraining the linear expression \f$ z=Ax+b \f$ lies within the Lorentz cone.
  A vector \f$ z \in \mathbb{R}^n \f$ lies within Lorentz cone if
  @f[
- z_1 \ge \sqrt{z_2^2+...+z_n^2}
+ z_0 \ge \sqrt{z_1^2+...+z_{n-1}^2}
  @f]
  <!-->
- z1 >= sqrt(z2^2 + ... + zn^2)
+ z(0) >= sqrt(z(1)^2 + ... + z(n-1)^2)
  <-->
  where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^{n}@f$ are given matrices.
  Ideally this constraint should be handled by a second-order cone solver.
@@ -209,8 +209,8 @@ class QuadraticConstraint : public Constraint {
  optimization, with smooth gradient, we alternatively impose the following
  constraint, with smooth gradient everywhere
  @f[
- a_1^Tx+b_1\ge 0\\
- (a_1^Tx+b_1)^2-(a_2^Tx+b_2)^2-...-(a_n^Tx+b_n)^2 \ge 0
+ a_0^Tx+b_0\ge 0\\
+ (a_0^Tx+b_0)^2-(a_1^Tx+b_1)^2-...-(a_{n-1}^Tx+b_{n-1})^2 \ge 0
  @f]
  where @f$ a_i^T@f$ is the i'th row of matrix @f$ A@f$. @f$ b_i @f$ is the i'th
  entry of vector @f$ b @f$.
@@ -259,18 +259,18 @@ class LorentzConeConstraint : public Constraint {
 };
 
 /**
- * Constraining that the linear expression \f$ Ax+b \f$ lies within rotated Lorentz cone.
+ * Constraining that the linear expression \f$ z=Ax+b \f$ lies within rotated Lorentz cone.
  * A vector \f$ z \in\mathbb{R}^n \f$ lies within rotated Lorentz cone, if
  * @f[
+ * z_0 \ge 0\\
  * z_1 \ge 0\\
- * z_2 \ge 0\\
- * z_1  z_2 \ge z_3^2 + z_4^2 + ... + z_n^2
+ * z_0  z_1 \ge z_2^2 + z_3^2 + ... + z_{n-1}^2
  * @f]
  * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given matrices.
  * <!-->
- * z1 >= 0
- * z2 >= 0
- * z1 * z2 >= z3^2 + z4^2 + ... + zn^2
+ * z(0) >= 0
+ * z(1) >= 0
+ * z(0) * z(1) >= z(2)^2 + z(3)^2 + ... + z(n-1)^2
  * <-->
  * For more information and visualization, please refer to
  * https://inst.eecs.berkeley.edu/~ee127a/book/login/l_socp_soc.html

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -220,11 +220,14 @@ class QuadraticConstraint : public Constraint {
  */
 class LorentzConeConstraint : public Constraint {
  public:
-  template<typename DerivedA, typename DerivedB>
-  LorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A, const Eigen::MatrixBase<DerivedB>& b)
-      : Constraint(2, Eigen::Vector2d::Constant(0.0),
-                   Eigen::Vector2d::Constant(
-                       std::numeric_limits<double>::infinity())), A_(A), b_(b){
+  template <typename DerivedA, typename DerivedB>
+  LorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
+                        const Eigen::MatrixBase<DerivedB>& b)
+      : Constraint(
+            2, Eigen::Vector2d::Constant(0.0),
+            Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity())),
+        A_(A),
+        b_(b) {
     DRAKE_ASSERT(A_.rows() == b_.rows());
   }
 
@@ -239,10 +242,10 @@ class LorentzConeConstraint : public Constraint {
   ~LorentzConeConstraint() override {}
 
   /// Getter for A.
-  const Eigen::MatrixXd& A() {return A_;}
+  const Eigen::MatrixXd& A() { return A_; }
 
   /// Getter for b.
-  const Eigen::VectorXd& b() {return b_;}
+  const Eigen::VectorXd& b() { return b_; }
 
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd& y) const override;
@@ -278,19 +281,22 @@ class LorentzConeConstraint : public Constraint {
  */
 class RotatedLorentzConeConstraint : public Constraint {
  public:
-  template<typename DerivedA, typename DerivedB>
-  RotatedLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A, const Eigen::MatrixBase<DerivedB>& b)
-      : Constraint(3, Eigen::Vector3d::Constant(0.0),
-                   Eigen::Vector3d::Constant(
-                       std::numeric_limits<double>::infinity())), A_(A), b_(b) {
+  template <typename DerivedA, typename DerivedB>
+  RotatedLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
+                               const Eigen::MatrixBase<DerivedB>& b)
+      : Constraint(
+            3, Eigen::Vector3d::Constant(0.0),
+            Eigen::Vector3d::Constant(std::numeric_limits<double>::infinity())),
+        A_(A),
+        b_(b) {
     DRAKE_ASSERT(A_.rows() == b_.rows());
   }
 
   /// Getter for A.
-  const Eigen::MatrixXd& A() {return A_;}
+  const Eigen::MatrixXd& A() { return A_; }
 
   /// Getter for b.
-  const Eigen::VectorXd& b() {return b_;}
+  const Eigen::VectorXd& b() { return b_; }
 
   RotatedLorentzConeConstraint(const RotatedLorentzConeConstraint& rhs) =
       delete;

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -155,13 +155,17 @@ int AddSecondOrderConeConstraints(
     std::vector<int> qcol(num_Q_nonzero);
     std::vector<double> qval(num_Q_nonzero);
     for (int i = 0; i < num_z - 2; ++i) {
-      int zi_index = second_order_cone_new_variable_indices[second_order_cone_count][i + 2];
+      int zi_index =
+          second_order_cone_new_variable_indices[second_order_cone_count]
+                                                [i + 2];
       qrow[i] = zi_index;
       qcol[i] = zi_index;
       qval[i] = 1.0;
     }
-    int z0_index = second_order_cone_new_variable_indices[second_order_cone_count][0];
-    int z1_index = second_order_cone_new_variable_indices[second_order_cone_count][1];
+    int z0_index =
+        second_order_cone_new_variable_indices[second_order_cone_count][0];
+    int z1_index =
+        second_order_cone_new_variable_indices[second_order_cone_count][1];
     if (is_rotated_cone) {
       qrow[num_z - 2] = z0_index;
       qcol[num_z - 2] = z1_index;

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -21,7 +21,7 @@ namespace {
 // operation can be EXPENSIVE, since it requires calling GRBupdatemodel
 // (Gurobi typically adopts lazy update, where it does not update the model
 // until calling the optimize function).
-static bool HasCorrectNumberOfVariables(GRBmodel* model,
+inline bool HasCorrectNumberOfVariables(GRBmodel* model,
                                         int num_vars_expected) {
   int error = GRBupdatemodel(model);
   if (error) return false;

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -26,7 +26,6 @@ bool IsNumberOfVariablesAsExpected(GRBmodel* model, int num_vars_expected) {
   return (num_vars == num_vars_expected);
 }
 
-
 /**
  * Adds a constraint of one of the following forms :
  * Ax>=b, Ax<=b, or Ax==b,
@@ -73,16 +72,19 @@ int AddLinearConstraint(GRBmodel* model, const Eigen::MatrixBase<DerivedA>& A,
 }
 
 /*
- * Add (rotated) Lorentz cone constraints, that A*x+b is in the (rotated) Lorentz cone.
+ * Add (rotated) Lorentz cone constraints, that A*x+b is in the (rotated)
+ * Lorentz cone.
  * A vector z is in the Lorentz cone, if
  * z(0) >= sqrt(z(1)^2 + ... + z(N-1)^2)
  * A vector z is in the rotated Lorentz cone, if
  * z(0)*z(1) >= z(2)^2 + ... + z(N-1)^2
  * z(0) >= 0, z(1) >= 0
  */
-template<typename Binding>
-int AddSecondOrderConeConstraints(const std::vector<Binding>& second_order_cone_constraints,
-bool is_rotated_cone, double sparseness_threshold, GRBmodel* model, std::vector<bool>* is_new_variable) {
+template <typename Binding>
+int AddSecondOrderConeConstraints(
+    const std::vector<Binding>& second_order_cone_constraints,
+    bool is_rotated_cone, double sparseness_threshold, GRBmodel* model,
+    std::vector<bool>* is_new_variable) {
   for (const auto& binding : second_order_cone_constraints) {
     int num_constraint_variable = static_cast<int>(binding.GetNumElements());
     std::vector<int> variable_indices;
@@ -102,13 +104,18 @@ bool is_rotated_cone, double sparseness_threshold, GRBmodel* model, std::vector<
     // First add new decision variables z, with the constraints z - A*x = b
     int num_new_variables = A.rows();
     std::vector<char> new_variable_types(num_new_variables, GRB_CONTINUOUS);
-    std::vector<double> new_variable_lb(num_new_variables, -std::numeric_limits<double>::infinity());
+    std::vector<double> new_variable_lb(
+        num_new_variables, -std::numeric_limits<double>::infinity());
     new_variable_lb[0] = 0.0;
     if (is_rotated_cone) {
       new_variable_lb[1] = 0.0;
     }
-    int error = GRBaddvars(model, A.rows(), 0, nullptr, nullptr, nullptr, nullptr, new_variable_lb.data(), nullptr, new_variable_types.data(), nullptr);
-    if (error) {return error;}
+    int error = GRBaddvars(model, A.rows(), 0, nullptr, nullptr, nullptr,
+                           nullptr, new_variable_lb.data(), nullptr,
+                           new_variable_types.data(), nullptr);
+    if (error) {
+      return error;
+    }
     // Append the newly added variable indices to variable_indices.
     variable_indices.reserve(variable_indices.size() + num_new_variables);
     is_new_variable->reserve(is_new_variable->size() + num_new_variables);
@@ -120,9 +127,11 @@ bool is_rotated_cone, double sparseness_threshold, GRBmodel* model, std::vector<
     // TODO(hongkai.dai): Use a sparse A_lorentz matrix.
     Eigen::MatrixXd A_lorentz(A.rows(), A.rows() + A.cols());
     A_lorentz << -A, Eigen::MatrixXd::Identity(A.rows(), A.rows());
-    error = AddLinearConstraint(model, A_lorentz, b, variable_indices, GRB_EQUAL, sparseness_threshold);
+    error = AddLinearConstraint(model, A_lorentz, b, variable_indices,
+                                GRB_EQUAL, sparseness_threshold);
 
-    // Mosek uses a matrix Q to differentiate Lorentz cone and rotated Lorentz cone constraint.
+    // Mosek uses a matrix Q to differentiate Lorentz cone and rotated Lorentz
+    // cone constraint.
     // For Lorentz cone constraint,
     // Q = [-1 0 0 ... 0]
     //     [ 0 1 0 ... 0]
@@ -141,9 +150,10 @@ bool is_rotated_cone, double sparseness_threshold, GRBmodel* model, std::vector<
     // qrow stores the row    indices of the non-zero entries of Q.
     // qcol stores the column indices of the non-zero entries of Q.
     // qval stores the value          of the non-zero entries of Q.
-    size_t num_Q_nonzero = is_rotated_cone ? num_new_variables - 1 : num_new_variables;
-    std::vector<int>    qrow(num_Q_nonzero);
-    std::vector<int>    qcol(num_Q_nonzero);
+    size_t num_Q_nonzero =
+        is_rotated_cone ? num_new_variables - 1 : num_new_variables;
+    std::vector<int> qrow(num_Q_nonzero);
+    std::vector<int> qcol(num_Q_nonzero);
     std::vector<double> qval(num_Q_nonzero);
     for (int i = 0; i < num_new_variables - 2; ++i) {
       qrow[i] = variable_indices[num_x_variables + i + 2];
@@ -154,8 +164,7 @@ bool is_rotated_cone, double sparseness_threshold, GRBmodel* model, std::vector<
       qrow[num_new_variables - 2] = variable_indices[num_x_variables];
       qcol[num_new_variables - 2] = variable_indices[num_x_variables + 1];
       qval[num_new_variables - 2] = -1;
-    }
-    else {
+    } else {
       qrow[num_new_variables - 2] = variable_indices[num_x_variables];
       qcol[num_new_variables - 2] = variable_indices[num_x_variables];
       qval[num_new_variables - 2] = -1;
@@ -163,10 +172,12 @@ bool is_rotated_cone, double sparseness_threshold, GRBmodel* model, std::vector<
       qcol[num_new_variables - 1] = variable_indices[num_x_variables + 1];
       qval[num_new_variables - 1] = 1;
     }
-    error = GRBaddqconstr(model, 0, nullptr, nullptr,
-                          num_Q_nonzero, qrow.data(), qcol.data(),
-                          qval.data(), GRB_LESS_EQUAL, 0.0, NULL);
-    if (error) {return error;}
+    error =
+        GRBaddqconstr(model, 0, nullptr, nullptr, num_Q_nonzero, qrow.data(),
+                      qcol.data(), qval.data(), GRB_LESS_EQUAL, 0.0, NULL);
+    if (error) {
+      return error;
+    }
   }
   return 0;
 }
@@ -389,7 +400,8 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
 
   const int num_prog_vars = prog.num_vars();
 
-  // Potentially Gurobi can add variables on top of the variables in MathematicalProgram prog.
+  // Potentially Gurobi can add variables on top of the variables in
+  // MathematicalProgram prog.
   // is_new_variable[i] is true if the i'th variable in Gurobi environment is
   // not stored in MathematicalProgram, but added by the GurobiSolver.
   // For example, for Lorentz cone and rotated Lorentz cone constraint,to impose
@@ -398,8 +410,10 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   std::vector<bool> is_new_variable(num_prog_vars, false);
 
   // Bound constraints.
-  std::vector<double> xlow(num_prog_vars, -std::numeric_limits<double>::infinity());
-  std::vector<double> xupp(num_prog_vars, std::numeric_limits<double>::infinity());
+  std::vector<double> xlow(num_prog_vars,
+                           -std::numeric_limits<double>::infinity());
+  std::vector<double> xupp(num_prog_vars,
+                           std::numeric_limits<double>::infinity());
 
   const std::vector<MathematicalProgram::VarType>& var_type =
       prog.DecisionVariableTypes();
@@ -450,12 +464,16 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
 
   // Add Lorentz cone constraints.
   if (!error) {
-    error = AddSecondOrderConeConstraints(prog.lorentz_cone_constraints(), false, sparseness_threshold, model, &is_new_variable);
+    error = AddSecondOrderConeConstraints(prog.lorentz_cone_constraints(),
+                                          false, sparseness_threshold, model,
+                                          &is_new_variable);
   }
 
   // Add rotated Lorentz cone constraints.
   if (!error) {
-    error = AddSecondOrderConeConstraints(prog.rotated_lorentz_cone_constraints(), true, sparseness_threshold, model, &is_new_variable);
+    error = AddSecondOrderConeConstraints(
+        prog.rotated_lorentz_cone_constraints(), true, sparseness_threshold,
+        model, &is_new_variable);
   }
 
   DRAKE_ASSERT(IsNumberOfVariablesAsExpected(model, is_new_variable.size()));
@@ -504,9 +522,11 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
       // solver_sol_vector includes the potentially newly added variables, i.e.,
       // variables not in MathematicalProgram prog, but added to Gurobi by
       // GurobiSolver.
-      // prog_sol_vector only includes the original variables in MathematicalProgram prog.
+      // prog_sol_vector only includes the original variables in
+      // MathematicalProgram prog.
       std::vector<double> solver_sol_vector(num_total_variables);
-      GRBgetdblattrarray(model, GRB_DBL_ATTR_X, 0, num_total_variables, solver_sol_vector.data());
+      GRBgetdblattrarray(model, GRB_DBL_ATTR_X, 0, num_total_variables,
+                         solver_sol_vector.data());
       Eigen::VectorXd prog_sol_vector(num_prog_vars);
       int prog_var_count = 0;
       for (int i = 0; i < num_total_variables; ++i) {

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -62,20 +62,38 @@ int AddLinearConstraint(GRBmodel* model, const Eigen::MatrixBase<DerivedA>& A,
 }
 
 /*
- * Add (rotated) Lorentz cone constraints, that x is in the (rotated)
- * Lorentz cone.
- * A vector x is in the Lorentz cone, if
- * x(0) >= sqrt(x(1)^2 + ... + x(N-1)^2)
- * A vector x is in the rotated Lorentz cone, if
- * x(0)*x(1) >= x(2)^2 + ... + x(N-1)^2
- * x(0) >= 0, z(1) >= 0
+ * Add (rotated) Lorentz cone constraints, that A*x+b is in the (rotated) Lorentz cone.
+ * A vector z is in the Lorentz cone, if
+ * z(0) >= sqrt(z(1)^2 + ... + z(N-1)^2)
+ * A vector z is in the rotated Lorentz cone, if
+ * z(0)*z(1) >= z(2)^2 + ... + z(N-1)^2
+ * z(0) >= 0, z(1) >= 0
  */
-template <typename Binding>
-int AddSecondOrderConeConstraints(
-    const MathematicalProgram& prog,
-    const std::vector<Binding>& second_order_cone_constraints,
-    bool is_rotated_cone, GRBmodel* model) {
+template<typename Binding>
+int AddSecondOrderConeConstraints(const std::vector<Binding>& second_order_cone_constraints,
+bool is_rotated_cone, GRBmodel& model, std::vector<bool>* is_new_variable) {
   for (const auto& binding : second_order_cone_constraints) {
+    int num_constraint_variable = static_cast<int>(binding.GetNumElements());
+    std::vector<int> variable_indices;
+    variable_indices.reserve(static_cast<size_t>(num_constraint_variable));
+    auto variable_list = binding.variable_list();
+    for (const DecisionVariableMatrixX& var : variable_list.variables()) {
+      DRAKE_ASSERT(var.cols() == 1);
+      for (int i = 0; i < static_cast<int>(var.rows()); ++i) {
+        variable_indices.push_back(static_cast<int>(var(i, 0).index()));
+      }
+    }
+
+    const auto& A = binding.constraint()->A();
+    const auto& b = binding.constraint()->b();
+    // First add new decision variables z, with the constraints A*x-z = b
+    int error = 0;
+    error = GRBaddvars(model, )
+  }
+}
+int AddLorentzConeConstraints(GRBmodel* model,
+                              const MathematicalProgram& prog) {
+  for (const auto& binding : prog.lorentz_cone_constraints()) {
     int num_constraint_variable = static_cast<int>(binding.GetNumElements());
     std::vector<int> variable_indices;
     variable_indices.reserve(static_cast<size_t>(num_constraint_variable));

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -155,20 +155,23 @@ int AddSecondOrderConeConstraints(
     std::vector<int> qcol(num_Q_nonzero);
     std::vector<double> qval(num_Q_nonzero);
     for (int i = 0; i < num_z - 2; ++i) {
-      qrow[i] = variable_indices[num_x + i + 2];
-      qcol[i] = variable_indices[num_x + i + 2];
+      int zi_index = second_order_cone_new_variable_indices[second_order_cone_count][i + 2];
+      qrow[i] = zi_index;
+      qcol[i] = zi_index;
       qval[i] = 1.0;
     }
+    int z0_index = second_order_cone_new_variable_indices[second_order_cone_count][0];
+    int z1_index = second_order_cone_new_variable_indices[second_order_cone_count][1];
     if (is_rotated_cone) {
-      qrow[num_z - 2] = variable_indices[num_x];
-      qcol[num_z - 2] = variable_indices[num_x + 1];
+      qrow[num_z - 2] = z0_index;
+      qcol[num_z - 2] = z1_index;
       qval[num_z - 2] = -1;
     } else {
-      qrow[num_z - 2] = variable_indices[num_x];
-      qcol[num_z - 2] = variable_indices[num_x];
+      qrow[num_z - 2] = z0_index;
+      qcol[num_z - 2] = z0_index;
       qval[num_z - 2] = -1;
-      qrow[num_z - 1] = variable_indices[num_x + 1];
-      qcol[num_z - 1] = variable_indices[num_x + 1];
+      qrow[num_z - 1] = z1_index;
+      qcol[num_z - 1] = z1_index;
       qval[num_z - 1] = 1;
     }
     error =

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -136,13 +136,15 @@ int AddSecondOrderConeConstraints(
 
     // Gurobi uses a matrix Q to differentiate Lorentz cone and rotated Lorentz
     // cone constraint.
+    // https://www.gurobi.com/documentation/7.0/refman/c_grbaddqconstr.html
     // For Lorentz cone constraint,
     // Q = [-1 0 0 ... 0]
     //     [ 0 1 0 ... 0]
     //     [ 0 0 1 ... 0]
     //          ...
     //     [ 0 0 0 ... 1]
-    // namely Q = diag([-1; 1; 1; ...; 1]
+    // namely Q = diag([-1; 1; 1; ...; 1], so
+    // z' * Q * z = z(1)^2 + ... + z(n-1)^2 - z(0)^2.
     // For rotated Lorentz cone constraint
     // Q = [0 -1 0 0 ... 0]
     //     [0  0 0 0 ... 0]
@@ -150,6 +152,7 @@ int AddSecondOrderConeConstraints(
     //     [0  0 0 1 ... 0]
     //           ...
     //     [0  0 0 0 ... 1]
+    // so z' * Q * z = z(2)^2 + ... + z(n-1)^2 - z(0) * z(1).
     // We will store Q in a sparse format.
     // qrow stores the row    indices of the non-zero entries of Q.
     // qcol stores the column indices of the non-zero entries of Q.

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -21,7 +21,7 @@ namespace {
 // operation can be EXPENSIVE, since it requires calling GRBupdatemodel
 // (Gurobi typically adopts lazy update, where it does not update the model
 // until calling the optimize function).
-inline bool HasCorrectNumberOfVariables(GRBmodel* model,
+[[maybe_unused]] bool HasCorrectNumberOfVariables(GRBmodel* model,
                                         int num_vars_expected) {
   int error = GRBupdatemodel(model);
   if (error) return false;

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -234,13 +234,6 @@ void MathematicalProgram::AddConstraint(
       Binding<LorentzConeConstraint>(con, var_list));
 }
 
-std::shared_ptr<LorentzConeConstraint>
-MathematicalProgram::AddLorentzConeConstraint(const VariableListRef& vars) {
-  auto constraint = std::make_shared<LorentzConeConstraint>();
-  AddConstraint(constraint, vars);
-  return constraint;
-}
-
 void MathematicalProgram::AddConstraint(
     std::shared_ptr<RotatedLorentzConeConstraint> con,
     const VariableListRef& vars) {
@@ -250,14 +243,6 @@ void MathematicalProgram::AddConstraint(
   required_capabilities_ |= kRotatedLorentzConeConstraint;
   rotated_lorentz_cone_constraint_.push_back(
       Binding<RotatedLorentzConeConstraint>(con, var_list));
-}
-
-std::shared_ptr<RotatedLorentzConeConstraint>
-MathematicalProgram::AddRotatedLorentzConeConstraint(
-    const VariableListRef& vars) {
-  auto constraint = std::make_shared<RotatedLorentzConeConstraint>();
-  AddConstraint(constraint, vars);
-  return constraint;
 }
 
 std::shared_ptr<Constraint> MathematicalProgram::AddPolynomialConstraint(

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -234,6 +234,17 @@ void MathematicalProgram::AddConstraint(
       Binding<LorentzConeConstraint>(con, var_list));
 }
 
+std::shared_ptr<LorentzConeConstraint>
+    MathematicalProgram::AddLorentzConeConstraint(const VariableListRef& vars) {
+  int num_vars = 0;
+  for (const auto& var : vars) {
+    num_vars += var.rows();
+  }
+  Eigen::MatrixXd A = Eigen::MatrixXd::Identity(num_vars, num_vars);
+  Eigen::MatrixXd b = Eigen::VectorXd::Zero(num_vars);
+  return AddLorentzConeConstraint(A, b, vars);
+}
+
 void MathematicalProgram::AddConstraint(
     std::shared_ptr<RotatedLorentzConeConstraint> con,
     const VariableListRef& vars) {
@@ -243,6 +254,17 @@ void MathematicalProgram::AddConstraint(
   required_capabilities_ |= kRotatedLorentzConeConstraint;
   rotated_lorentz_cone_constraint_.push_back(
       Binding<RotatedLorentzConeConstraint>(con, var_list));
+}
+
+std::shared_ptr<RotatedLorentzConeConstraint>
+    MathematicalProgram::AddRotatedLorentzConeConstraint(const VariableListRef& vars) {
+  int num_vars = 0;
+  for (const auto& var : vars) {
+    num_vars += var.rows();
+  }
+  Eigen::MatrixXd A = Eigen::MatrixXd::Identity(num_vars, num_vars);
+  Eigen::MatrixXd b = Eigen::VectorXd::Zero(num_vars);
+  return AddRotatedLorentzConeConstraint(A, b, vars);
 }
 
 std::shared_ptr<Constraint> MathematicalProgram::AddPolynomialConstraint(

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -235,7 +235,7 @@ void MathematicalProgram::AddConstraint(
 }
 
 std::shared_ptr<LorentzConeConstraint>
-    MathematicalProgram::AddLorentzConeConstraint(const VariableListRef& vars) {
+MathematicalProgram::AddLorentzConeConstraint(const VariableListRef& vars) {
   int num_vars = 0;
   for (const auto& var : vars) {
     num_vars += var.rows();
@@ -257,7 +257,8 @@ void MathematicalProgram::AddConstraint(
 }
 
 std::shared_ptr<RotatedLorentzConeConstraint>
-    MathematicalProgram::AddRotatedLorentzConeConstraint(const VariableListRef& vars) {
+MathematicalProgram::AddRotatedLorentzConeConstraint(
+    const VariableListRef& vars) {
   int num_vars = 0;
   for (const auto& var : vars) {
     num_vars += var.rows();

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1150,23 +1150,24 @@ class MathematicalProgram {
    * The linear expression @f$ Ax+b @f$ is in the Lorentz cone. Namely
    * <!--
    * z = A * x + b
-   * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
+   * z(0) >= sqrt{z(1)^2 + ... + z(n-1)^2}
    * -->
    * @f[
    * z = A x + b\\
-   * z_0 \ge \sqrt{z_1^2 + ... + z_{N-1}^2}
+   * z_0 \ge \sqrt{z_1^2 + ... + z_{n-1}^2}
    * @f]
-   * @param A A matrix whose number of columns equals to the size of the
-   * decision variables.
-   * @param b A vector whose number of rows equals to the size fo the decision
-   * variables.
+   * @param A A @f$\mathbb{R}^{n\times m}@f$ matrix, whose number of columns
+   * equals to the size of the decision variables.
+   * @param b A @f$\mathbb{R}^n@f$ vector, whose number of rows equals to the
+   * size of the decision variables.
+   * @param vars The list of containing @f$ m @f$ decision variables.
+   * @return The newly added Lorentz cone constraint.
    */
 
-  template<typename DerivedA, typename DerivedB>
-  std::shared_ptr<LorentzConeConstraint>
-  AddLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
-                           const Eigen::MatrixBase<DerivedB>& b,
-                           const VariableListRef& vars) {
+  template <typename DerivedA, typename DerivedB>
+  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
+      const Eigen::MatrixBase<DerivedA>& A,
+      const Eigen::MatrixBase<DerivedB>& b, const VariableListRef& vars) {
     auto constraint = std::make_shared<LorentzConeConstraint>(A, b);
     AddConstraint(constraint, vars);
     return constraint;
@@ -1178,21 +1179,20 @@ class MathematicalProgram {
    * The linear expression @f$ Ax+b @f$ is in the Lorentz cone. Namely
    * <!--
    * z = A * x + b
-   * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
+   * z(0) >= sqrt{z(1)^2 + ... + z(n-1)^2}
    * -->
    * @f[
    * z = A x + b\\
-   * z_0 \ge \sqrt{z_1^2 + ... + z_{N-1}^2}
+   * z_0 \ge \sqrt{z_1^2 + ... + z_{n-1}^2}
    * @f]
-   * @param A A matrix whose number of columns equals to the size of the
-   * decision variables.
-   * @param b A vector whose number of rows equals to the size fo the decision
-   * variables.
+   * @param A A @f$\mathbb{R}^{n \times m}@f$ matrix.
+   * @param b A @f$ \mathbb{R}^{n} @f$ vector.
+   * @return The newly added Lorentz cone constraint.
    */
-  template<typename DerivedA, typename DerivedB>
-  std::shared_ptr<LorentzConeConstraint>
-      AddLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
-                               const Eigen::MatrixBase<DerivedB>& b) {
+  template <typename DerivedA, typename DerivedB>
+  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
+      const Eigen::MatrixBase<DerivedA>& A,
+      const Eigen::MatrixBase<DerivedB>& b) {
     return AddLorentzConeConstraint(A, b, {decision_variables_});
   }
 
@@ -1207,8 +1207,8 @@ class MathematicalProgram {
    * @param vars The stacked column of vars should lie within the Lorentz cone.
    * @return The newly added Lorentz cone constraint.
    */
-  std::shared_ptr<LorentzConeConstraint>
-      AddLorentzConeConstraint(const VariableListRef& vars);
+  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
+      const VariableListRef& vars);
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
@@ -1219,7 +1219,8 @@ class MathematicalProgram {
    * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
    * z_0\ge 0, z_1\ge 0
    * @f]
-   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given matrices.
+   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given
+   * matrices.
    *
    * <!--
    * z = A * x + b
@@ -1241,7 +1242,8 @@ class MathematicalProgram {
    * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
    * z_0\ge 0, z_1\ge 0
    * @f]
-   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given matrices.
+   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given
+   * matrices.
    *
    * <!--
    * z = A * x + b
@@ -1261,11 +1263,10 @@ class MathematicalProgram {
    * @param vars The decision variables on which the constraint is imposed.
    * Each DecisionVariableMatrix object should have only one column.
    */
-  template<typename DerivedA, typename DerivedB>
-  std::shared_ptr<RotatedLorentzConeConstraint>
-  AddRotatedLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
-                                  const Eigen::MatrixBase<DerivedB>& b,
-                                  const VariableListRef& vars) {
+  template <typename DerivedA, typename DerivedB>
+  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
+      const Eigen::MatrixBase<DerivedA>& A,
+      const Eigen::MatrixBase<DerivedB>& b, const VariableListRef& vars) {
     auto constraint = std::make_shared<RotatedLorentzConeConstraint>(A, b);
     AddConstraint(constraint, vars);
     return constraint;
@@ -1280,7 +1281,8 @@ class MathematicalProgram {
    * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
    * z_0\ge 0, z_1\ge 0
    * @f]
-   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given matrices.
+   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given
+   * matrices.
    *
    * <!--
    * z = A * x + b
@@ -1292,10 +1294,10 @@ class MathematicalProgram {
    * @param b A vector whose number of rows equals to the size fo the decision
    * variables.
    */
-  template<typename DerivedA, typename DerivedB>
-  std::shared_ptr<RotatedLorentzConeConstraint>
-      AddRotatedLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
-                                      const Eigen::MatrixBase<DerivedB>& b) {
+  template <typename DerivedA, typename DerivedB>
+  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
+      const Eigen::MatrixBase<DerivedA>& A,
+      const Eigen::MatrixBase<DerivedB>& b) {
     return AddRotatedLorentzConeConstraint(A, b, {decision_variables_});
   }
 
@@ -1313,8 +1315,8 @@ class MathematicalProgram {
    * @param vars The stacked column of vars lies in the rotated Lorentz cone.
    * @return The newly added rotated Lorentz cone constraint.
    */
-  std::shared_ptr<RotatedLorentzConeConstraint>
-      AddRotatedLorentzConeConstraint(const VariableListRef& vars);
+  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
+      const VariableListRef& vars);
 
   /**
    * Adds a linear complementarity constraints referencing a subset of

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1131,6 +1131,7 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
+   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone. Namely
    * <!--
    * z = A * x + b
    * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
@@ -1146,6 +1147,7 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint referencing potentially a subset of the
    * decision variables (defined in the vars parameter).
+   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone. Namely
    * <!--
    * z = A * x + b
    * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
@@ -1172,7 +1174,8 @@ class MathematicalProgram {
 
   /**
    * Adds Lorentz cone constraint to the program for all
-   * (currently existing) variables
+   * (currently existing) variables.
+   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone. Namely
    * <!--
    * z = A * x + b
    * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
@@ -1195,7 +1198,8 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
-   * of decision variables, such that
+   * of decision variables, that the linear expression @f$ Ax+b @f$ is in the
+   * rotated Lorentz cone. Namely
    * @f[
    * z = Ax+b\\
    * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
@@ -1215,14 +1219,9 @@ class MathematicalProgram {
                      const VariableListRef& vars);
 
   /**
-   * @param A A matrix whose number of columns equals to the size of the
-   * decision variables.
-   * @param b A vector whose number of rows equals to the size fo the decision
-   * variables.
-   * @param vars The decision variables on which the constraint is imposed.
-   * Each DecisionVariableMatrix object should have only one column.
-   * Example: if you want to add the rotated Lorentz cone constraint on vector
-   * @f$ x\in\mathbb{R}^m @f$
+   * Adds a rotated Lorentz cone constraint referencing potentially a subset
+   * of decision variables, that the linear expression @f$ Ax+b @f$ for
+   * @f$ x\in\mathbb{R}^m @f$ is in the rotated Lorentz cone. Namely
    * @f[
    * z = Ax+b\\
    * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
@@ -1240,6 +1239,13 @@ class MathematicalProgram {
    *   auto x = prog.NewContinuousVariables(n,'x');
    *   auto con = prog.AddRotatedLorentzConeConstraint(A, b, {x});
    * @endcode
+   *
+   * @param A A matrix whose number of columns equals to the size of the
+   * decision variables.
+   * @param b A vector whose number of rows equals to the size fo the decision
+   * variables.
+   * @param vars The decision variables on which the constraint is imposed.
+   * Each DecisionVariableMatrix object should have only one column.
    */
   template<typename DerivedA, typename DerivedB>
   std::shared_ptr<RotatedLorentzConeConstraint>
@@ -1253,11 +1259,8 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz constraint to the program for all
-   * (currently existing) variables.
-   * @param A A matrix whose number of columns equals to the size of the
-   * decision variables.
-   * @param b A vector whose number of rows equals to the size fo the decision
-   * variables.
+   * (currently existing) variables, that the linear expression @f$ Ax+b @f$ for
+   * @f$ x\in\mathbb{R}^m @f$ is in the rotated Lorentz cone. Namely
    * @f[
    * z = Ax+b\\
    * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
@@ -1270,6 +1273,10 @@ class MathematicalProgram {
    * z(0) * z(1) >= z(2)^2 + ...z(n-1)^2
    * z(0) >= 0, z(1) >= 0
    * -->
+   * @param A A matrix whose number of columns equals to the size of the
+   * decision variables.
+   * @param b A vector whose number of rows equals to the size fo the decision
+   * variables.
    */
   template<typename DerivedA, typename DerivedB>
   std::shared_ptr<RotatedLorentzConeConstraint>

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1191,10 +1191,24 @@ class MathematicalProgram {
    */
   template<typename DerivedA, typename DerivedB>
   std::shared_ptr<LorentzConeConstraint>
-  AddLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
-                           const Eigen::MatrixBase<DerivedB>& b) {
+      AddLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
+                               const Eigen::MatrixBase<DerivedB>& b) {
     return AddLorentzConeConstraint(A, b, {decision_variables_});
   }
+
+  /**
+   * Imposes that a vector @f$ x\in\mathbb{R}^m @f$ lies in Lorentz cone. Namely
+   * @f[
+   * x_0 \ge \sqrt{x_1^2 + .. + x_{m-1}^2}
+   * @f]
+   * <!-->
+   * x(0) >= sqrt(x(1)^2 + ... + x(m-1)^2)
+   * <-->
+   * @param vars The stacked column of vars should lie within the Lorentz cone.
+   * @return The newly added Lorentz cone constraint.
+   */
+  std::shared_ptr<LorentzConeConstraint>
+      AddLorentzConeConstraint(const VariableListRef& vars);
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
@@ -1284,6 +1298,23 @@ class MathematicalProgram {
                                       const Eigen::MatrixBase<DerivedB>& b) {
     return AddRotatedLorentzConeConstraint(A, b, {decision_variables_});
   }
+
+  /**
+   * Impose that a vector @f$ x\in\mathbb{R}^m @f$ is in rotated Lorentz cone.
+   * Namely
+   * @f[
+   * x_0 x_1 \ge x_2^2 + ... + x_{m-1}^2\\
+   * x_0 \ge 0, x_1 \ge 0
+   * @f]
+   * <!-->
+   * x(0)*x(1) >= x(2)^2 + ... x(m-1)^2
+   * x(0) >= 0, x(1) >= 0
+   * <-->
+   * @param vars The stacked column of vars lies in the rotated Lorentz cone.
+   * @return The newly added rotated Lorentz cone constraint.
+   */
+  std::shared_ptr<RotatedLorentzConeConstraint>
+      AddRotatedLorentzConeConstraint(const VariableListRef& vars);
 
   /**
    * Adds a linear complementarity constraints referencing a subset of

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1206,7 +1206,8 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
-   * of decision variables. The linear expression @f$ z=Ax+b @f$ is in rotated the Lorentz cone.
+   * of decision variables. The linear expression @f$ z=Ax+b @f$ is in rotated
+   * Lorentz cone.
    * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
    * <!--
    * z(0)*z(1) >= z(2)^2 + ... + z(n-1)^2

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1131,7 +1131,7 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
-   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone.
+   * The linear expression @f$ z=Ax+b @f$ is in the Lorentz cone.
    * A vector \f$ z \in\mathbb{R}^n \f$ is in the Lorentz cone, if
    * <!--
    * z(0) >= sqrt{z(1)^2 + ... + z(n-1)^2}
@@ -1146,7 +1146,7 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint referencing potentially a subset of the
    * decision variables (defined in the vars parameter).
-   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone.
+   * The linear expression @f$ z=Ax+b @f$ is in the Lorentz cone.
    * A vector \f$ z \in\mathbb{R}^n \f$ is in the Lorentz cone, if
    * <!--
    * z(0) >= sqrt{z(1)^2 + ... + z(n-1)^2}
@@ -1172,7 +1172,7 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint to the program for all
    * (currently existing) variables.
-   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone.
+   * The linear expression @f$ z=Ax+b @f$ is in the Lorentz cone.
    * A vector \f$ z \in\mathbb{R}^n \f$ is in the Lorentz cone, if
    * <!--
    * z(0) >= sqrt{z(1)^2 + ... + z(n-1)^2}
@@ -1206,7 +1206,7 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
-   * of decision variables. The linear expression @f$ Ax+b @f$ is in rotated the Lorentz cone.
+   * of decision variables. The linear expression @f$ z=Ax+b @f$ is in rotated the Lorentz cone.
    * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
    * <!--
    * z(0)*z(1) >= z(2)^2 + ... + z(n-1)^2
@@ -1222,7 +1222,8 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
-   * of decision variables, The linear expression @f$ Ax+b @f$ is in rotated the Lorentz cone.
+   * of decision variables, The linear expression @f$ Ax+b @f$ is in rotated
+   * Lorentz cone.
    * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
    * <!--
    * z(0)*z(1) >= z(2)^2 + ... + z(n-1)^2
@@ -1256,7 +1257,8 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz constraint to the program for all
-   * (currently existing) variables, the linear expression @f$ Ax+b @f$ is in rotated the Lorentz cone.
+   * (currently existing) variables, the linear expression @f$ z=Ax+b @f$ is in
+   * rotated Lorentz cone.
    * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
    * <!--
    * z(0)*z(1) >= z(2)^2 + ... + z(n-1)^2

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1131,14 +1131,13 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
-   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone. Namely
+   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone.
+   * A vector \f$ z \in\mathbb{R}^n \f$ is in the Lorentz cone, if
    * <!--
-   * z = A * x + b
-   * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
+   * z(0) >= sqrt{z(1)^2 + ... + z(n-1)^2}
    * -->
    * @f[
-   * z = A x + b\\
-   * z_0 \ge \sqrt{z_1^2 + ... + z_{N-1}^2}
+   * z_0 \ge \sqrt{z_1^2 + ... + z_{n-1}^2}
    * @f]
    */
   void AddConstraint(std::shared_ptr<LorentzConeConstraint> con,
@@ -1147,13 +1146,12 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint referencing potentially a subset of the
    * decision variables (defined in the vars parameter).
-   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone. Namely
+   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone.
+   * A vector \f$ z \in\mathbb{R}^n \f$ is in the Lorentz cone, if
    * <!--
-   * z = A * x + b
    * z(0) >= sqrt{z(1)^2 + ... + z(n-1)^2}
    * -->
    * @f[
-   * z = A x + b\\
    * z_0 \ge \sqrt{z_1^2 + ... + z_{n-1}^2}
    * @f]
    * @param A A @f$\mathbb{R}^{n\times m}@f$ matrix, whose number of columns
@@ -1163,11 +1161,9 @@ class MathematicalProgram {
    * @param vars The list of containing @f$ m @f$ decision variables.
    * @return The newly added Lorentz cone constraint.
    */
-
-  template <typename DerivedA, typename DerivedB>
   std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
-      const Eigen::MatrixBase<DerivedA>& A,
-      const Eigen::MatrixBase<DerivedB>& b, const VariableListRef& vars) {
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b, const VariableListRef& vars) {
     auto constraint = std::make_shared<LorentzConeConstraint>(A, b);
     AddConstraint(constraint, vars);
     return constraint;
@@ -1176,23 +1172,21 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint to the program for all
    * (currently existing) variables.
-   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone. Namely
+   * The linear expression @f$ Ax+b @f$ is in the Lorentz cone.
+   * A vector \f$ z \in\mathbb{R}^n \f$ is in the Lorentz cone, if
    * <!--
-   * z = A * x + b
    * z(0) >= sqrt{z(1)^2 + ... + z(n-1)^2}
    * -->
    * @f[
-   * z = A x + b\\
    * z_0 \ge \sqrt{z_1^2 + ... + z_{n-1}^2}
    * @f]
    * @param A A @f$\mathbb{R}^{n \times m}@f$ matrix.
    * @param b A @f$ \mathbb{R}^{n} @f$ vector.
    * @return The newly added Lorentz cone constraint.
    */
-  template <typename DerivedA, typename DerivedB>
   std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
-      const Eigen::MatrixBase<DerivedA>& A,
-      const Eigen::MatrixBase<DerivedB>& b) {
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b) {
     return AddLorentzConeConstraint(A, b, {decision_variables_});
   }
 
@@ -1212,21 +1206,14 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
-   * of decision variables, such that the linear expression @f$ Ax+b @f$ is in
-   * the rotated Lorentz cone. Namely
-   * @f[
-   * z = Ax+b\\
-   * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
-   * z_0\ge 0, z_1\ge 0
-   * @f]
-   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given
-   * matrices.
-   *
+   * of decision variables. The linear expression @f$ Ax+b @f$ is in rotated the Lorentz cone.
+   * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
    * <!--
-   * z = A * x + b
-   * z(0) * z(1) >= z(2)^2 + ...z(n-1)^2
-   * z(0) >= 0, z(1) >= 0
+   * z(0)*z(1) >= z(2)^2 + ... + z(n-1)^2
    * -->
+   * @f[
+   * z_0z_1 \ge z_2^2 + ... + z_{n-1}^2
+   * @f]
    * @param con A pointer to a RotatedLorentzConeConstraint object.
    * @param vars The decision variables on which the constraint is imposed.
    */
@@ -1235,21 +1222,17 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
-   * of decision variables, that the linear expression @f$ Ax+b @f$ for
-   * @f$ x\in\mathbb{R}^m @f$ is in the rotated Lorentz cone. Namely
+   * of decision variables, The linear expression @f$ Ax+b @f$ is in rotated the Lorentz cone.
+   * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
+   * <!--
+   * z(0)*z(1) >= z(2)^2 + ... + z(n-1)^2
+   * -->
    * @f[
-   * z = Ax+b\\
-   * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
-   * z_0\ge 0, z_1\ge 0
+   * z_0z_1 \ge z_2^2 + ... + z_{n-1}^2
    * @f]
    * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given
    * matrices.
    *
-   * <!--
-   * z = A * x + b
-   * z(0) * z(1) >= z(2)^2 + ...z(n-1)^2
-   * z(0) >= 0, z(1) >= 0
-   * -->
    * you can call
    * @code{.cc}
    *   auto x = prog.NewContinuousVariables(n,'x');
@@ -1263,10 +1246,9 @@ class MathematicalProgram {
    * @param vars The decision variables on which the constraint is imposed.
    * Each DecisionVariableMatrix object should have only one column.
    */
-  template <typename DerivedA, typename DerivedB>
   std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
-      const Eigen::MatrixBase<DerivedA>& A,
-      const Eigen::MatrixBase<DerivedB>& b, const VariableListRef& vars) {
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b, const VariableListRef& vars) {
     auto constraint = std::make_shared<RotatedLorentzConeConstraint>(A, b);
     AddConstraint(constraint, vars);
     return constraint;
@@ -1274,30 +1256,24 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz constraint to the program for all
-   * (currently existing) variables, that the linear expression @f$ Ax+b @f$ for
-   * @f$ x\in\mathbb{R}^m @f$ is in the rotated Lorentz cone. Namely
+   * (currently existing) variables, the linear expression @f$ Ax+b @f$ is in rotated the Lorentz cone.
+   * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
+   * <!--
+   * z(0)*z(1) >= z(2)^2 + ... + z(n-1)^2
+   * -->
    * @f[
-   * z = Ax+b\\
-   * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
-   * z_0\ge 0, z_1\ge 0
+   * z_0z_1 \ge z_2^2 + ... + z_{n-1}^2
    * @f]
    * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given
    * matrices.
-   *
-   * <!--
-   * z = A * x + b
-   * z(0) * z(1) >= z(2)^2 + ...z(n-1)^2
-   * z(0) >= 0, z(1) >= 0
-   * -->
    * @param A A matrix whose number of columns equals to the size of the
    * decision variables.
    * @param b A vector whose number of rows equals to the size fo the decision
    * variables.
    */
-  template <typename DerivedA, typename DerivedB>
   std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
-      const Eigen::MatrixBase<DerivedA>& A,
-      const Eigen::MatrixBase<DerivedB>& b) {
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b) {
     return AddRotatedLorentzConeConstraint(A, b, {decision_variables_});
   }
 

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1212,8 +1212,8 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
-   * of decision variables, that the linear expression @f$ Ax+b @f$ is in the
-   * rotated Lorentz cone. Namely
+   * of decision variables, such that the linear expression @f$ Ax+b @f$ is in
+   * the rotated Lorentz cone. Namely
    * @f[
    * z = Ax+b\\
    * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1132,10 +1132,12 @@ class MathematicalProgram {
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    * <!--
-   * x(0) >= sqrt{x(1)^2 + ... + x(N-1)^2}
+   * z = A * x + b
+   * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
    * -->
    * @f[
-   * x_0 \ge \sqrt{x_1^2 + ... + x_{N-1}^2}
+   * z = A x + b\\
+   * z_0 \ge \sqrt{z_1^2 + ... + z_{N-1}^2}
    * @f]
    */
   void AddConstraint(std::shared_ptr<LorentzConeConstraint> con,
@@ -1145,38 +1147,67 @@ class MathematicalProgram {
    * Adds Lorentz cone constraint referencing potentially a subset of the
    * decision variables (defined in the vars parameter).
    * <!--
-   * x(0) >= sqrt{x(1)^2 + ... + x(N-1)^2}
+   * z = A * x + b
+   * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
    * -->
    * @f[
-   * x_0 \ge \sqrt{x_1^2 + ... + x_{N-1}^2}
+   * z = A x + b\\
+   * z_0 \ge \sqrt{z_1^2 + ... + z_{N-1}^2}
    * @f]
+   * @param A A matrix whose number of columns equals to the size of the
+   * decision variables.
+   * @param b A vector whose number of rows equals to the size fo the decision
+   * variables.
    */
-  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
-      const VariableListRef& vars);
+
+  template<typename DerivedA, typename DerivedB>
+  std::shared_ptr<LorentzConeConstraint>
+  AddLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
+                           const Eigen::MatrixBase<DerivedB>& b,
+                           const VariableListRef& vars) {
+    auto constraint = std::make_shared<LorentzConeConstraint>(A, b);
+    AddConstraint(constraint, vars);
+    return constraint;
+  }
 
   /**
    * Adds Lorentz cone constraint to the program for all
    * (currently existing) variables
    * <!--
-   * x(0) >= sqrt{x(1)^2 + ... + x(N-1)^2}
+   * z = A * x + b
+   * z(0) >= sqrt{z(1)^2 + ... + z(N-1)^2}
    * -->
    * @f[
-   * x_0 \ge \sqrt{x_1^2 + ... + x_{N-1}^2}
+   * z = A x + b\\
+   * z_0 \ge \sqrt{z_1^2 + ... + z_{N-1}^2}
    * @f]
+   * @param A A matrix whose number of columns equals to the size of the
+   * decision variables.
+   * @param b A vector whose number of rows equals to the size fo the decision
+   * variables.
    */
-  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint() {
-    return AddLorentzConeConstraint({decision_variables_});
+  template<typename DerivedA, typename DerivedB>
+  std::shared_ptr<LorentzConeConstraint>
+  AddLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
+                           const Eigen::MatrixBase<DerivedB>& b) {
+    return AddLorentzConeConstraint(A, b, {decision_variables_});
   }
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
    * of decision variables, such that
+   * @f[
+   * z = Ax+b\\
+   * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
+   * z_0\ge 0, z_1\ge 0
+   * @f]
+   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given matrices.
+   *
    * <!--
-   * x(0) * x(1) >= x(2)^2 + ...x(N-1)^2
-   * x(0) >= 0, x(1) >= 0
+   * z = A * x + b
+   * z(0) * z(1) >= z(2)^2 + ...z(n-1)^2
+   * z(0) >= 0, z(1) >= 0
    * -->
-   * @f[ x_0 x_1 \ge x_2^2 + x_3^2 + ... + x_{N-1}^2 @f]
-   * @f[ x_0\ge 0, x_1\ge 0 @f]
    * @param con A pointer to a RotatedLorentzConeConstraint object.
    * @param vars The decision variables on which the constraint is imposed.
    */
@@ -1184,37 +1215,67 @@ class MathematicalProgram {
                      const VariableListRef& vars);
 
   /**
+   * @param A A matrix whose number of columns equals to the size of the
+   * decision variables.
+   * @param b A vector whose number of rows equals to the size fo the decision
+   * variables.
    * @param vars The decision variables on which the constraint is imposed.
    * Each DecisionVariableMatrix object should have only one column.
-   * Example: if you want to add the rotated Lorentz cone constraint
+   * Example: if you want to add the rotated Lorentz cone constraint on vector
+   * @f$ x\in\mathbb{R}^m @f$
+   * @f[
+   * z = Ax+b\\
+   * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
+   * z_0\ge 0, z_1\ge 0
+   * @f]
+   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given matrices.
+   *
    * <!--
-   * x(0) * x(1) >= x(2)^2 + ...x(N-1)^2
-   * x(0) >= 0, x(1) >= 0
+   * z = A * x + b
+   * z(0) * z(1) >= z(2)^2 + ...z(n-1)^2
+   * z(0) >= 0, z(1) >= 0
    * -->
-   * @f[ x_0 x_1 \ge x_2^2 + x_3^2 + ... + x_{N-1}^2 @f]
-   * @f[ x_0\ge 0, x_1\ge 0 @f]
    * you can call
    * @code{.cc}
-   *   auto x = prog.NewContinuousVariables(N,'x');
-   *   auto con = prog.AddRotatedLorentzConeConstraint(x);
+   *   auto x = prog.NewContinuousVariables(n,'x');
+   *   auto con = prog.AddRotatedLorentzConeConstraint(A, b, {x});
    * @endcode
    */
-  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
-      const VariableListRef& vars);
+  template<typename DerivedA, typename DerivedB>
+  std::shared_ptr<RotatedLorentzConeConstraint>
+  AddRotatedLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
+                                  const Eigen::MatrixBase<DerivedB>& b,
+                                  const VariableListRef& vars) {
+    auto constraint = std::make_shared<RotatedLorentzConeConstraint>(A, b);
+    AddConstraint(constraint, vars);
+    return constraint;
+  }
 
   /**
    * Adds a rotated Lorentz constraint to the program for all
    * (currently existing) variables.
+   * @param A A matrix whose number of columns equals to the size of the
+   * decision variables.
+   * @param b A vector whose number of rows equals to the size fo the decision
+   * variables.
+   * @f[
+   * z = Ax+b\\
+   * z_0 z_1 \ge z_2^2 + x_3^2 + ... + z_{n-1}^2\\
+   * z_0\ge 0, z_1\ge 0
+   * @f]
+   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given matrices.
+   *
    * <!--
-   * x(0) * x(1) >= x(2)^2 + ...x(N-1)^2
-   * x(0) >= 0, x(1) >= 0
+   * z = A * x + b
+   * z(0) * z(1) >= z(2)^2 + ...z(n-1)^2
+   * z(0) >= 0, z(1) >= 0
    * -->
-   * @f[ x_0 x_1 \ge x_2^2 + x_3^2 + ... + x_{N-1}^2 @f]
-   * @f[ x_0\ge 0, x_1\ge 0 @f]
    */
+  template<typename DerivedA, typename DerivedB>
   std::shared_ptr<RotatedLorentzConeConstraint>
-  AddRotatedLorentzConeConstraint() {
-    return AddRotatedLorentzConeConstraint({decision_variables_});
+      AddRotatedLorentzConeConstraint(const Eigen::MatrixBase<DerivedA>& A,
+                                      const Eigen::MatrixBase<DerivedB>& b) {
+    return AddRotatedLorentzConeConstraint(A, b, {decision_variables_});
   }
 
   /**

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1223,7 +1223,7 @@ class MathematicalProgram {
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
-   * of decision variables, The linear expression @f$ Ax+b @f$ is in rotated
+   * of decision variables, The linear expression @f$ z=Ax+b @f$ is in rotated
    * Lorentz cone.
    * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
    * <!--

--- a/drake/solvers/mosek_solver.cc
+++ b/drake/solvers/mosek_solver.cc
@@ -148,20 +148,15 @@ MSKrescodee AddBoundingBoxConstraints(const MathematicalProgram& prog,
 /*
  * This is the helper function to add two types of second order cone
  * constraints:
- * A Lorentz cone constraint: x0 >= sqrt(x1^2 + .. xN^2)
- * A rotated Lorentz cone constraint: x0*x1 >= x2^2 + .. + xN^2, x0 >= 0, x1 >=0
+ * 1. A Lorentz cone constraint:
+ *    z = A*x+b
+ *    z0 >= sqrt(z1^2 + .. zN^2)
+ * 2. A rotated Lorentz cone constraint:
+ *    z = A*x+b
+ *    z0*z1 >= z2^2 + .. + zN^2,
+ *    z0 >= 0, z1 >=0
  * Mosek does not allow two cones to share variables. To overcome this,
- * for every lorentz cone x0 >= sqrt(x1^2 + ... + xN^2),
- * we will add a new set of variable (y0, ..., yN), with the constraint
- * y0 >= sqrt(y1^2 + ... + yN^2)
- * y0 = x0, ..., yN = xN
- * for every rotated lorentz
- * cone x0 * x1>= x2^2 + ... + xN^2, x0 >= 0, x1 >=0
- * we will add a new set of variable (y0, ..., yN), with the constraint
- * 2*y0*y1 >= y2^2 + ... + yN^2, y0 >= 0, y1 >=0
- * y0 = x0 / 2, y1 = x1, ..., yN = xN
- * The reason for a factor of 2 in y0 is because Mosek's rotated lorentz cone is
- * 2*y0*y1 >= y2^2 + ... + yN^2, y0 >= 0, y1 >=0
+ * we will add a new set of variable (z0, ..., zN)
  * @param is_new_variable  Refer to the documentation on is_new_variable in
  * MosekSolver::Solve() function
  */
@@ -171,9 +166,8 @@ MSKrescodee AddSecondOrderConeConstraints(
     const std::vector<Bindings>& second_order_cone_constraints,
     bool is_rotated_cone, MSKtask_t* task, std::vector<bool>* is_new_variable) {
   MSKrescodee rescode = MSK_RES_OK;
-
   for (auto const& binding : second_order_cone_constraints) {
-    std::vector<int> cone_var_indices(binding.GetNumElements());
+    std::vector<MSKint32t> cone_var_indices(binding.GetNumElements());
     int var_count = 0;
     for (const DecisionVariableMatrixX& var :
          binding.variable_list().variables()) {
@@ -183,83 +177,63 @@ MSKrescodee AddSecondOrderConeConstraints(
         ++var_count;
       }
     }
-    const int num_cone_vars = static_cast<int>(cone_var_indices.size());
+
+    const auto& A = binding.constraint()->A();
+    const auto& b = binding.constraint()->b();
+    const int num_new_vars = A.rows();
     MSKint32t num_total_vars = 0;
     rescode = MSK_getnumvar(*task, &num_total_vars);
-    if (rescode != MSK_RES_OK) {
-      return rescode;
-    }
-    rescode = MSK_appendvars(*task, num_cone_vars);
-    if (rescode != MSK_RES_OK) {
-      return rescode;
-    }
-    is_new_variable->resize(num_total_vars + num_cone_vars);
-    std::vector<MSKint32t> new_cone_var_indices(num_cone_vars);
-    for (int i = 0; i < num_cone_vars; ++i) {
+    if (rescode != MSK_RES_OK) { return rescode;}
+    rescode = MSK_appendvars(*task, num_new_vars);
+    if (rescode != MSK_RES_OK) { return rescode;}
+    is_new_variable->resize(num_total_vars + num_new_vars);
+    std::vector<MSKint32t> new_var_indices(num_new_vars);
+    for (int i = 0; i < num_new_vars; ++i) {
       is_new_variable->at(num_total_vars + i) = true;
-      new_cone_var_indices[i] = num_total_vars + i;
-      rescode = MSK_putvarbound(*task, new_cone_var_indices[i], MSK_BK_FR,
+      new_var_indices[i] = num_total_vars + i;
+      rescode = MSK_putvarbound(*task, new_var_indices[i], MSK_BK_FR,
                                 -MSK_INFINITY, MSK_INFINITY);
-      if (rescode != MSK_RES_OK) {
-        return rescode;
-      }
+      if (rescode != MSK_RES_OK) {return rescode;}
     }
     MSKconetypee cone_type = is_rotated_cone ? MSK_CT_RQUAD : MSK_CT_QUAD;
-    rescode = MSK_appendcone(*task, cone_type, 0.0, cone_var_indices.size(),
-                             new_cone_var_indices.data());
-    if (rescode != MSK_RES_OK) {
-      return rescode;
-    }
+    rescode = MSK_appendcone(*task, cone_type, 0.0, num_new_vars,
+                             new_var_indices.data());
+    if (rescode != MSK_RES_OK) {return rescode;}
 
-    // Unfortunately Mosek's definition of rotated Lorentz cone is different
-    // from ours. The rotated Lorentz cone in Mosek is defined as
-    // 2*y(0) * y(1) >= y(2)^2 + ... + y(n-1)^2
-    // Our definition of rotated Lorentz cone is
-    //   y(0) * y(1) >= y(2)^2 + ... + y(n-1)^2
-    // So there is a factor of 2 for rotated Lorentz cone.
-    // With this difference in rotated Lorentz cone,
-    // if using Lorentz cone, adds the linear constraint
-    //   y(0)   = x(0),
-    //   y(1)   = x(1),
-    //        ...
-    //   y(n-1) = x(n-1)
-    // If using rotated Lorentz cone, add the linear constraint
-    // 2*y(0)   = x(0),
-    //   y(1)   = x(1),
-    //     ...
-    //   y(n-1) = x(n-1)
+    // Add the linear constraint
+    // z = A*x+b
+    // The first row of this constraint needs special treatment.
+    // If using Lorentz cone,
+    // Add the linear constraint z0 = a0^T*x+b0
+    // otherwise, add the linear constraint 2*z0 = a0^T*x0 + b0
     int num_lin_cons;
     rescode = MSK_getnumcon(*task, &num_lin_cons);
-    if (rescode != MSK_RES_OK) {
-      return rescode;
-    }
-    rescode = MSK_appendcons(*task, num_cone_vars);
-    if (rescode != MSK_RES_OK) {
-      return rescode;
-    }
-    MSKint32t var_indices0[2] = {cone_var_indices[0], new_cone_var_indices[0]};
+    if (rescode != MSK_RES_OK) {return rescode;}
+    rescode = MSK_appendcons(*task, num_new_vars);
+    if (rescode != MSK_RES_OK) {return rescode;}
+    std::vector<MSKint32t> var_indices(cone_var_indices);
+    var_indices.push_back(new_var_indices[0]);
     double y0_factor = is_rotated_cone ? -2 : -1;
-    double val0[2] = {1, y0_factor};
-    rescode = MSK_putarow(*task, num_lin_cons, 2, var_indices0, val0);
-    if (rescode != MSK_RES_OK) {
-      return rescode;
-    }
-    rescode = MSK_putconbound(*task, num_lin_cons, MSK_BK_FX, 0.0, 0.0);
-    if (rescode != MSK_RES_OK) {
-      return rescode;
-    }
-    for (int i = 1; i < num_cone_vars; ++i) {
-      MSKint32t var_indices_i[2] = {cone_var_indices[i],
-                                    new_cone_var_indices[i]};
-      double val_i[2] = {1, -1};
-      rescode = MSK_putarow(*task, num_lin_cons + i, 2, var_indices_i, val_i);
-      if (rescode != MSK_RES_OK) {
-        return rescode;
-      }
-      rescode = MSK_putconbound(*task, num_lin_cons + i, MSK_BK_FX, 0.0, 0.0);
-      if (rescode != MSK_RES_OK) {
-        return rescode;
-      }
+    Eigen::RowVectorXd val0(1 + cone_var_indices.size());
+    val0.head(cone_var_indices.size()) = A.row(0);
+    val0(cone_var_indices.size()) = y0_factor;
+    rescode = MSK_putarow(*task, num_lin_cons, 1 + cone_var_indices.size(), var_indices.data(), val0.data());
+    if (rescode != MSK_RES_OK) {return rescode;}
+    rescode = MSK_putconbound(*task, num_lin_cons, MSK_BK_FX, -b(0), -b(0));
+    if (rescode != MSK_RES_OK) {return rescode;}
+    for (int i = 1; i < num_new_vars; ++i) {
+      // In every row of the linear constraint z = A*x+b, the only changed
+      // decision variable is z(i), so pop the last variable (z(i-1)), and
+      // push back z(i)
+      var_indices.pop_back();
+      var_indices.push_back(new_var_indices[i]);
+      Eigen::RowVectorXd val(1 + cone_var_indices.size());
+      val.head(cone_var_indices.size()) = A.row(i);
+      val(cone_var_indices.size()) = -1;
+      rescode = MSK_putarow(*task, num_lin_cons + i, 1 + cone_var_indices.size(), var_indices.data(), val.data());
+      if (rescode != MSK_RES_OK) {return rescode; }
+      rescode = MSK_putconbound(*task, num_lin_cons + i, MSK_BK_FX, -b(i), -b(i));
+      if (rescode != MSK_RES_OK) {return rescode;}
     }
   }
   // Expect rescode == MSK_RES_OK.

--- a/drake/solvers/mosek_solver.cc
+++ b/drake/solvers/mosek_solver.cc
@@ -202,8 +202,8 @@ MSKrescodee AddSecondOrderConeConstraints(
       }
     }
     MSKconetypee cone_type = is_rotated_cone ? MSK_CT_RQUAD : MSK_CT_QUAD;
-    rescode = MSK_appendcone(*task, cone_type, 0.0, num_z,
-                             new_var_indices.data());
+    rescode =
+        MSK_appendcone(*task, cone_type, 0.0, num_z, new_var_indices.data());
     if (rescode != MSK_RES_OK) {
       return rescode;
     }
@@ -248,9 +248,10 @@ MSKrescodee AddSecondOrderConeConstraints(
       return rescode;
     }
     for (int i = 1; i < num_z; ++i) {
-      // In every row of the linear constraint z = A*x+b, the only changed
-      // decision variable is z(i), so pop the last variable (z(i-1)), and
-      // push back z(i)
+      // In row i of the linear constraint z = A*x+b, the decision variables are
+      // [x z(i)]. So compared to the previous row of the constraint, the only
+      // changed decision variable is z(i). We can thus pop the last variable
+      // (z(i-1)), and push back z(i).
       var_indices.pop_back();
       var_indices.push_back(new_var_indices[i]);
       Eigen::RowVectorXd val(1 + cone_var_indices.size());
@@ -474,10 +475,10 @@ MSKrescodee AddCosts(const MathematicalProgram& prog, MSKtask_t* task) {
         if (std::abs(Qij) > Eigen::NumTraits<double>::epsilon()) {
           if (var_index_i > var_indices[j]) {
             Q_lower_triplets.push_back(
-              Eigen::Triplet<double>(var_index_i, var_indices[j], Qij));
+                Eigen::Triplet<double>(var_index_i, var_indices[j], Qij));
           } else {
             Q_lower_triplets.push_back(
-              Eigen::Triplet<double>(var_indices[j], var_index_i, Qij));
+                Eigen::Triplet<double>(var_indices[j], var_index_i, Qij));
           }
         }
       }

--- a/drake/solvers/mosek_solver.cc
+++ b/drake/solvers/mosek_solver.cc
@@ -183,9 +183,13 @@ MSKrescodee AddSecondOrderConeConstraints(
     const int num_new_vars = A.rows();
     MSKint32t num_total_vars = 0;
     rescode = MSK_getnumvar(*task, &num_total_vars);
-    if (rescode != MSK_RES_OK) { return rescode;}
+    if (rescode != MSK_RES_OK) {
+      return rescode;
+    }
     rescode = MSK_appendvars(*task, num_new_vars);
-    if (rescode != MSK_RES_OK) { return rescode;}
+    if (rescode != MSK_RES_OK) {
+      return rescode;
+    }
     is_new_variable->resize(num_total_vars + num_new_vars);
     std::vector<MSKint32t> new_var_indices(num_new_vars);
     for (int i = 0; i < num_new_vars; ++i) {
@@ -193,12 +197,16 @@ MSKrescodee AddSecondOrderConeConstraints(
       new_var_indices[i] = num_total_vars + i;
       rescode = MSK_putvarbound(*task, new_var_indices[i], MSK_BK_FR,
                                 -MSK_INFINITY, MSK_INFINITY);
-      if (rescode != MSK_RES_OK) {return rescode;}
+      if (rescode != MSK_RES_OK) {
+        return rescode;
+      }
     }
     MSKconetypee cone_type = is_rotated_cone ? MSK_CT_RQUAD : MSK_CT_QUAD;
     rescode = MSK_appendcone(*task, cone_type, 0.0, num_new_vars,
                              new_var_indices.data());
-    if (rescode != MSK_RES_OK) {return rescode;}
+    if (rescode != MSK_RES_OK) {
+      return rescode;
+    }
 
     // Add the linear constraint
     // z = A*x+b
@@ -208,19 +216,28 @@ MSKrescodee AddSecondOrderConeConstraints(
     // otherwise, add the linear constraint 2*z0 = a0^T*x0 + b0
     int num_lin_cons;
     rescode = MSK_getnumcon(*task, &num_lin_cons);
-    if (rescode != MSK_RES_OK) {return rescode;}
+    if (rescode != MSK_RES_OK) {
+      return rescode;
+    }
     rescode = MSK_appendcons(*task, num_new_vars);
-    if (rescode != MSK_RES_OK) {return rescode;}
+    if (rescode != MSK_RES_OK) {
+      return rescode;
+    }
     std::vector<MSKint32t> var_indices(cone_var_indices);
     var_indices.push_back(new_var_indices[0]);
     double y0_factor = is_rotated_cone ? -2 : -1;
     Eigen::RowVectorXd val0(1 + cone_var_indices.size());
     val0.head(cone_var_indices.size()) = A.row(0);
     val0(cone_var_indices.size()) = y0_factor;
-    rescode = MSK_putarow(*task, num_lin_cons, 1 + cone_var_indices.size(), var_indices.data(), val0.data());
-    if (rescode != MSK_RES_OK) {return rescode;}
+    rescode = MSK_putarow(*task, num_lin_cons, 1 + cone_var_indices.size(),
+                          var_indices.data(), val0.data());
+    if (rescode != MSK_RES_OK) {
+      return rescode;
+    }
     rescode = MSK_putconbound(*task, num_lin_cons, MSK_BK_FX, -b(0), -b(0));
-    if (rescode != MSK_RES_OK) {return rescode;}
+    if (rescode != MSK_RES_OK) {
+      return rescode;
+    }
     for (int i = 1; i < num_new_vars; ++i) {
       // In every row of the linear constraint z = A*x+b, the only changed
       // decision variable is z(i), so pop the last variable (z(i-1)), and
@@ -230,10 +247,17 @@ MSKrescodee AddSecondOrderConeConstraints(
       Eigen::RowVectorXd val(1 + cone_var_indices.size());
       val.head(cone_var_indices.size()) = A.row(i);
       val(cone_var_indices.size()) = -1;
-      rescode = MSK_putarow(*task, num_lin_cons + i, 1 + cone_var_indices.size(), var_indices.data(), val.data());
-      if (rescode != MSK_RES_OK) {return rescode; }
-      rescode = MSK_putconbound(*task, num_lin_cons + i, MSK_BK_FX, -b(i), -b(i));
-      if (rescode != MSK_RES_OK) {return rescode;}
+      rescode =
+          MSK_putarow(*task, num_lin_cons + i, 1 + cone_var_indices.size(),
+                      var_indices.data(), val.data());
+      if (rescode != MSK_RES_OK) {
+        return rescode;
+      }
+      rescode =
+          MSK_putconbound(*task, num_lin_cons + i, MSK_BK_FX, -b(i), -b(i));
+      if (rescode != MSK_RES_OK) {
+        return rescode;
+      }
     }
   }
   // Expect rescode == MSK_RES_OK.

--- a/drake/solvers/test/constraint_test.cc
+++ b/drake/solvers/test/constraint_test.cc
@@ -31,7 +31,7 @@ void TestLorentzConeEval(const Eigen::Ref<const Eigen::MatrixXd> A,
       CompareMatrices(y, y_expected, 1E-10, MatrixCompareType::absolute));
 
   bool is_in_cone_expected = (y(0) >= 0) & (y(1) >= 0);
-  EXPECT_TRUE(is_in_cone == is_in_cone_expected);
+  EXPECT_EQ(is_in_cone, is_in_cone_expected);
 
   auto tx = drake::math::initializeAutoDiff(x_test);
   TaylorVecXd x_taylor = tx;
@@ -58,7 +58,7 @@ void TestRotatedLorentzConeEval(const Eigen::Ref<const Eigen::MatrixXd> A,
 
   bool is_in_cone_expected =
       (z(0) >= 0) & (z(1) >= 0) & (z(0) * z(1) >= z.tail(z.size() - 2).norm());
-  EXPECT_TRUE(is_in_cone == is_in_cone_expected);
+  EXPECT_EQ(is_in_cone, is_in_cone_expected);
 
   // Eval with taylor var.
   auto tx = drake::math::initializeAutoDiff(x_test);

--- a/drake/solvers/test/constraint_test.cc
+++ b/drake/solvers/test/constraint_test.cc
@@ -16,15 +16,18 @@ namespace drake {
 namespace solvers {
 namespace {
 // Tests if the Lorentz Cone constraint is imposed correctly.
-void TestLorentzConeEval(const VectorXd& x_test, bool is_in_cone) {
-  LorentzConeConstraint cnstr;
+void TestLorentzConeEval(const Eigen::Ref<const Eigen::MatrixXd> A,
+                         const Eigen::Ref<const Eigen::VectorXd> b,
+                         const VectorXd& x_test, bool is_in_cone) {
+  LorentzConeConstraint cnstr(A, b);
   VectorXd y;
   // Test Eval with VectorXd.
   cnstr.Eval(x_test, y);
   Vector2d y_expected;
-  y_expected(0) = x_test(0);
+  VectorXd z = A * x_test + b;
+  y_expected(0) = z(0);
   y_expected(1) =
-      x_test(0) * x_test(0) - x_test.tail(x_test.size() - 1).squaredNorm();
+      z(0) * z(0) - z.tail(z.size() - 1).squaredNorm();
   EXPECT_TRUE(
       CompareMatrices(y, y_expected, 1E-10, MatrixCompareType::absolute));
 
@@ -37,34 +40,26 @@ void TestLorentzConeEval(const VectorXd& x_test, bool is_in_cone) {
   // Test Eval with TaylorVar.
   cnstr.Eval(x_taylor, y_taylor);
 
-  // Check if the gradient is correct.
-  Eigen::Matrix<double, 2, Eigen::Dynamic> y_grad_expected(2, x_test.size());
-  y_grad_expected.setZero();
-  y_grad_expected(0, 0) = 1.0;
-  y_grad_expected(1, 0) = 2 * x_test(0);
-  for (int i = 1; i < x_test.size(); i++) {
-    y_grad_expected(1, i) = -2 * x_test(i);
-  }
-  EXPECT_TRUE(CompareMatrices(y_grad_expected,
-                              drake::math::autoDiffToGradientMatrix(y_taylor),
-                              1E-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(y, math::autoDiffToValueMatrix(y_taylor)));
 }
 
-void TestRotatedLorentzConeEval(const VectorXd& x_test, bool is_in_cone) {
-  RotatedLorentzConeConstraint cnstr;
+void TestRotatedLorentzConeEval(const Eigen::Ref<const Eigen::MatrixXd> A,
+                                const Eigen::Ref<const Eigen::VectorXd> b,
+                                const VectorXd& x_test, bool is_in_cone) {
+  RotatedLorentzConeConstraint cnstr(A, b);
   VectorXd y;
   cnstr.Eval(x_test, y);
+  Eigen::VectorXd z = A * x_test + b;
   Vector3d y_expected;
-  y_expected(0) = x_test(0);
-  y_expected(1) = x_test(1);
-  y_expected(2) =
-      x_test(0) * x_test(1) - x_test.tail(x_test.size() - 2).squaredNorm();
+  y_expected(0) = z(0);
+  y_expected(1) = z(1);
+  y_expected(2) = z(0) * z(1) - z.tail(z.size() - 2).squaredNorm();
   EXPECT_TRUE(
       CompareMatrices(y, y_expected, 1E-10, MatrixCompareType::absolute));
 
   bool is_in_cone_expected =
-      (x_test(0) >= 0) & (x_test(1) >= 0) &
-      (x_test(0) * x_test(1) >= x_test.tail(x_test.size() - 2).norm());
+      (z(0) >= 0) & (z(1) >= 0) &
+      (z(0) * z(1) >= z.tail(z.size() - 2).norm());
   EXPECT_TRUE(is_in_cone == is_in_cone_expected);
 
   // Eval with taylor var.
@@ -73,69 +68,78 @@ void TestRotatedLorentzConeEval(const VectorXd& x_test, bool is_in_cone) {
   TaylorVecXd y_taylor;
   cnstr.Eval(x_taylor, y_taylor);
 
-  // Check if the gradient is correct.
-  Eigen::Matrix<double, 3, Eigen::Dynamic> y_grad_expected(3, x_test.size());
-  y_grad_expected.setZero();
-  y_grad_expected(0, 0) = 1.0;
-  y_grad_expected(1, 1) = 1.0;
-  y_grad_expected(2, 0) = x_test(1);
-  y_grad_expected(2, 1) = x_test(0);
-  for (int i = 2; i < x_test.size(); ++i) {
-    y_grad_expected(2, i) = -2 * x_test(i);
-  }
-  EXPECT_TRUE(CompareMatrices(y_grad_expected,
-                              drake::math::autoDiffToGradientMatrix(y_taylor),
-                              1E-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(y, math::autoDiffToValueMatrix(y_taylor)));
 }
 
 GTEST_TEST(testConstraint, testLorentzConeConstraint) {
-  LorentzConeConstraint cnstr;
-  auto lb = cnstr.lower_bound();
-  auto ub = cnstr.upper_bound();
-  EXPECT_TRUE(CompareMatrices(Eigen::Vector2d(0.0, 0.0), lb, 1E-10,
-                              MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(
-      Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity()), ub,
-      1e-10, MatrixCompareType::absolute));
-
   // [3;1;1] is in the interior of the Lorentz cone.
   Eigen::Vector3d x1(3.0, 1.0, 1.0);
-  TestLorentzConeEval(x1, true);
+  TestLorentzConeEval(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Zero(),
+                      x1, true);
 
   // [3;2;2;1] is on the boundary of the Lorentz cone.
-  Eigen::Vector4d x2(3.0, 2.0, 2.0, 1.0);
-  TestLorentzConeEval(x2, true);
+  Eigen::Vector2d x2(1, 3);
+  Eigen::Matrix<double, 4, 2> A2;
+  // clang-format off
+  A2 << 1, 0,
+       1, 1,
+       -1, 1,
+       1, -2;
+  // clang-format on
+  Eigen::Vector4d b2(2, -2, 0, 6);
+  TestLorentzConeEval(A2, b2, x2, true);
 
   // [3; 3; 1] is outside of the Lorentz cone.
-  Eigen::Vector3d x3(3.0, 3.0, 1.0);
-  TestLorentzConeEval(x3, false);
+  Eigen::Vector4d x3(1, -1, 2, 3);
+  Eigen::Matrix<double, 3, 4> A3;
+  // clang-format off
+  A3 << 1, 0, -1, 2,
+        -1, 2, 0, 1,
+        0, -2, 3, 1;
+  // clang-format on
+  Eigen::Vector3d b3 = Eigen::Vector3d(3, 3, 1) - A3 * x3;
+  TestLorentzConeEval(A3, b3, x3, false);
 
   // [-3; 1; 1] is outside of the Lorentz cone.
-  Eigen::Vector3d x4(-3.0, 1.0, 1.0);
-  TestLorentzConeEval(x4, false);
+  Vector1d x4 = Vector1d::Constant(4);
+  Eigen::Vector3d A4(-1, 3, 2);
+  Eigen::Vector3d b4 = Eigen::Vector3d(-3, 1, 1) - A4 * x4;
+  TestLorentzConeEval(A4, b4, x4, false);
 }
 
 GTEST_TEST(testConstraint, testRotatedLorentzConeConstraint) {
-  RotatedLorentzConeConstraint cnstr;
-  auto lb = cnstr.lower_bound();
-  auto ub = cnstr.upper_bound();
-  EXPECT_TRUE(CompareMatrices(Eigen::Vector3d::Zero(), lb, 1E-10,
-                              MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(
-      Eigen::Vector3d::Constant(std::numeric_limits<double>::infinity()), ub,
-      1e-10, MatrixCompareType::absolute));
-
   // [1;2;1] is in the interior of the rotated lorentz cone.
-  TestRotatedLorentzConeEval(Vector3d(1, 2, 1), true);
+  TestRotatedLorentzConeEval(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Zero(), Vector3d(1, 2, 1), true);
 
   // [1;2;1;1] is on the boundary of the rotated Lorentz cone.
-  TestRotatedLorentzConeEval(Eigen::Vector4d(1, 2, 1, 1), true);
+  Eigen::Vector2d x2(1, 2);
+  Eigen::Matrix<double, 4, 2> A2;
+  // clang-format off
+  A2 << 1, -1,
+        0, 2,
+        -1, 3,
+        -2, 4;
+  // clang-format on
+  Eigen::Vector4d b2 = Eigen::Vector4d(1, 2, 1, 1) - A2 * x2;
+  TestRotatedLorentzConeEval(A2, b2, x2, true);
 
   // [1;2;2;2] is outside of the rotated Lorentz cone.
-  TestRotatedLorentzConeEval(Eigen::Vector4d(1, 2, 2, 2), false);
+  Eigen::Vector4d x3(1, 3, -1, 2);
+  Eigen::Matrix4d A3;
+  // clang-format off
+  A3 << 1, 2, 3, 4,
+        -1, 2, 4, 2,
+        -3, 2, 1, 4,
+        2, 1, 3, 2;
+  // clang-format on
+  Eigen::Vector4d b3 = Eigen::Vector4d(1, 2, 2, 2) - A3 * x3;
+  TestRotatedLorentzConeEval(A3, b3, x3, false);
 
   // [-1; -2; 1] is outside of the rotated Lorentz cone.
-  TestRotatedLorentzConeEval(Vector3d(-1, -2, 1), false);
+  Vector1d x4 = Vector1d::Constant(10);
+  Eigen::Vector3d A4(1, 3, 2);
+  Eigen::Vector3d b4 = Eigen::Vector3d(-1, -2, 1) - A4 * x4;
+  TestRotatedLorentzConeEval(A4, b4, x4, false);
 }
 
 GTEST_TEST(testConstraint, testPositiveSemidefiniteConstraint) {

--- a/drake/solvers/test/constraint_test.cc
+++ b/drake/solvers/test/constraint_test.cc
@@ -26,8 +26,7 @@ void TestLorentzConeEval(const Eigen::Ref<const Eigen::MatrixXd> A,
   Vector2d y_expected;
   VectorXd z = A * x_test + b;
   y_expected(0) = z(0);
-  y_expected(1) =
-      z(0) * z(0) - z.tail(z.size() - 1).squaredNorm();
+  y_expected(1) = z(0) * z(0) - z.tail(z.size() - 1).squaredNorm();
   EXPECT_TRUE(
       CompareMatrices(y, y_expected, 1E-10, MatrixCompareType::absolute));
 
@@ -58,8 +57,7 @@ void TestRotatedLorentzConeEval(const Eigen::Ref<const Eigen::MatrixXd> A,
       CompareMatrices(y, y_expected, 1E-10, MatrixCompareType::absolute));
 
   bool is_in_cone_expected =
-      (z(0) >= 0) & (z(1) >= 0) &
-      (z(0) * z(1) >= z.tail(z.size() - 2).norm());
+      (z(0) >= 0) & (z(1) >= 0) & (z(0) * z(1) >= z.tail(z.size() - 2).norm());
   EXPECT_TRUE(is_in_cone == is_in_cone_expected);
 
   // Eval with taylor var.
@@ -74,8 +72,8 @@ void TestRotatedLorentzConeEval(const Eigen::Ref<const Eigen::MatrixXd> A,
 GTEST_TEST(testConstraint, testLorentzConeConstraint) {
   // [3;1;1] is in the interior of the Lorentz cone.
   Eigen::Vector3d x1(3.0, 1.0, 1.0);
-  TestLorentzConeEval(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Zero(),
-                      x1, true);
+  TestLorentzConeEval(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Zero(), x1,
+                      true);
 
   // [3;2;2;1] is on the boundary of the Lorentz cone.
   Eigen::Vector2d x2(1, 3);
@@ -109,7 +107,8 @@ GTEST_TEST(testConstraint, testLorentzConeConstraint) {
 
 GTEST_TEST(testConstraint, testRotatedLorentzConeConstraint) {
   // [1;2;1] is in the interior of the rotated lorentz cone.
-  TestRotatedLorentzConeEval(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Zero(), Vector3d(1, 2, 1), true);
+  TestRotatedLorentzConeEval(Eigen::Matrix3d::Identity(),
+                             Eigen::Vector3d::Zero(), Vector3d(1, 2, 1), true);
 
   // [1;2;1;1] is on the boundary of the rotated Lorentz cone.
   Eigen::Vector2d x2(1, 2);

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -189,7 +189,6 @@ void TestLinearProgram2(const MathematicalProgramSolverInterface& solver) {
 /////////// Quadratic Program ///////////
 /////////////////////////////////////////
 
-
 // Test a simple Quadratic Program.
 // The example is taken from
 // http://cvxopt.org/examples/tutorial/qp.html
@@ -551,8 +550,10 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
   // clang-format on
   Eigen::VectorXd b1 = Eigen::VectorXd::Zero(1 + R1.cols());
   Eigen::VectorXd b2 = Eigen::VectorXd::Zero(1 + R2.cols());
-  auto lorentz_cone1 = prog.AddLorentzConeConstraint(A1, b1, {t.segment<1>(0), a});
-  auto lorentz_cone2 = prog.AddLorentzConeConstraint(A2, b2, {t.segment<1>(1), a});
+  auto lorentz_cone1 =
+      prog.AddLorentzConeConstraint(A1, b1, {t.segment<1>(0), a});
+  auto lorentz_cone2 =
+      prog.AddLorentzConeConstraint(A2, b2, {t.segment<1>(1), a});
   // a'*(x2 - x1) = 1
   prog.AddLinearEqualityConstraint((x2 - x1).transpose(), 1.0, {a});
 
@@ -564,8 +565,8 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
   // Check the solution.
   // First check if each constraint is satisfied.
   const auto& a_value = prog.GetSolution(a);
-  const auto& R1a_value = R1.transpose()*a_value;
-  const auto& R2a_value = R2.transpose()*a_value;
+  const auto& R1a_value = R1.transpose() * a_value;
+  const auto& R2a_value = R2.transpose() * a_value;
   EXPECT_NEAR(t(0).value(), R1a_value.norm(), 1e-6);
   EXPECT_NEAR(t(1).value(), R2a_value.norm(), 1e-6);
   EXPECT_TRUE(CompareMatrices((x2 - x1).transpose() * a_value,
@@ -601,7 +602,6 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
     auto u2 = prog_intersect.NewContinuousVariables(R2.cols(), "u2");
     auto y = prog_intersect.NewContinuousVariables(kXdim, "y");
 
-
     // Add the constraint that both
     // A_lorentz1 * u1 + b_lorentz1
     // and
@@ -613,8 +613,10 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
     Eigen::MatrixXd A_lorentz2(R2.cols() + 1, R2.cols());
     Eigen::VectorXd b_lorentz1(R1.cols() + 1);
     Eigen::VectorXd b_lorentz2(R2.cols() + 1);
-    A_lorentz1 << Eigen::RowVectorXd::Zero(R1.cols()), Eigen::MatrixXd::Identity(R1.cols(), R1.cols());
-    A_lorentz2 << Eigen::RowVectorXd::Zero(R2.cols()), Eigen::MatrixXd::Identity(R2.cols(), R1.cols());
+    A_lorentz1 << Eigen::RowVectorXd::Zero(R1.cols()),
+        Eigen::MatrixXd::Identity(R1.cols(), R1.cols());
+    A_lorentz2 << Eigen::RowVectorXd::Zero(R2.cols()),
+        Eigen::MatrixXd::Identity(R2.cols(), R1.cols());
     b_lorentz1 << 1, Eigen::VectorXd::Zero(R1.cols());
     b_lorentz2 << 1, Eigen::VectorXd::Zero(R2.cols());
     prog_intersect.AddLorentzConeConstraint(A_lorentz1, b_lorentz1, {u1});
@@ -647,7 +649,6 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
                                 MatrixCompareType::absolute));
   }
 }
-
 
 // This example is taken from
 // https://inst.eecs.berkeley.edu/~ee127a/book/login/exa_qp_as_socp.html
@@ -691,8 +692,9 @@ void SolveQPasSOCP(const Eigen::MatrixBase<DerivedQ>& Q,
   auto y = prog_socp.NewContinuousVariables<1>("y");
   auto w = prog_socp.NewContinuousVariables(kXdim, "w");
 
-  Eigen::MatrixXd A_lorentz(2 + kXdim, 1+kXdim);
-  A_lorentz << Eigen::RowVectorXd::Zero(1 + kXdim), Eigen::MatrixXd::Identity(1 + kXdim, 1+kXdim);
+  Eigen::MatrixXd A_lorentz(2 + kXdim, 1 + kXdim);
+  A_lorentz << Eigen::RowVectorXd::Zero(1 + kXdim),
+      Eigen::MatrixXd::Identity(1 + kXdim, 1 + kXdim);
   Eigen::VectorXd b_lorentz(2 + kXdim);
   b_lorentz << 2, Eigen::VectorXd::Zero(1 + kXdim);
   prog_socp.AddRotatedLorentzConeConstraint(A_lorentz, b_lorentz, {y, w});
@@ -824,7 +826,8 @@ void FindSpringEquilibrium(const Eigen::VectorXd& weight,
   prog.AddBoundingBoxConstraint(
       Eigen::VectorXd::Zero(num_nodes - 1),
       Eigen::VectorXd::Constant(num_nodes - 1,
-                                std::numeric_limits<double>::infinity()), {t});
+                                std::numeric_limits<double>::infinity()),
+      {t});
 
   // sqrt((x(i)-x(i+1))^2 + (y(i) - y(i+1))^2) <= ti + spring_rest_length
   for (int i = 0; i < num_nodes - 1; ++i) {
@@ -838,13 +841,16 @@ void FindSpringEquilibrium(const Eigen::VectorXd& weight,
     A_lorentz1(2, 2) = 1;
     A_lorentz1(2, 3) = -1;
     Eigen::Vector3d b_lorentz1(spring_rest_length, 0, 0);
-    prog.AddLorentzConeConstraint(A_lorentz1, b_lorentz1, {x.segment<2>(i), y.segment<2>(i), t.segment<1>(i)});
+    prog.AddLorentzConeConstraint(
+        A_lorentz1, b_lorentz1,
+        {x.segment<2>(i), y.segment<2>(i), t.segment<1>(i)});
   }
 
   // Add constraint z >= t_1^2 + .. + t_(N-1)^2
   auto z = prog.NewContinuousVariables<1>("z");
   Eigen::MatrixXd A_lorentz2(1 + num_nodes, num_nodes);
-  A_lorentz2 << Eigen::RowVectorXd::Zero(num_nodes), Eigen::MatrixXd::Identity(num_nodes, num_nodes);
+  A_lorentz2 << Eigen::RowVectorXd::Zero(num_nodes),
+      Eigen::MatrixXd::Identity(num_nodes, num_nodes);
   Eigen::VectorXd b_lorentz2(1 + num_nodes);
   b_lorentz2 << 1, Eigen::VectorXd::Zero(num_nodes);
   prog.AddRotatedLorentzConeConstraint(A_lorentz2, b_lorentz2, {z, t});

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -857,7 +857,7 @@ void FindSpringEquilibrium(const Eigen::VectorXd& weight,
   prog.AddRotatedLorentzConeConstraint(A_lorentz2, b_lorentz2, {z, t});
 
   prog.AddLinearCost(drake::Vector1d(spring_stiffness / 2), {z});
-  prog.AddLinearCost(weight.transpose(), {y});
+  prog.AddLinearCost(weight, {y});
 
   RunSolver(&prog, solver);
 

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -28,7 +28,7 @@ void GetQuadraticProgramSolvers(
 
 void GetSecondOrderConicProgramSolvers(
     std::list<std::unique_ptr<MathematicalProgramSolverInterface>>* solvers) {
-  AddSolverIfAvailable("Gurobi", solvers);
+  //AddSolverIfAvailable("Gurobi", solvers);
   AddSolverIfAvailable("Mosek", solvers);
 }
 
@@ -36,6 +36,7 @@ void GetSemidefiniteProgramSolvers(
     std::list<std::unique_ptr<MathematicalProgramSolverInterface>>* solvers) {
   AddSolverIfAvailable("Mosek", solvers);
 }
+/*
 /////////////////////////
 ///// Linear Program ////
 /////////////////////////
@@ -188,15 +189,14 @@ void TestLinearProgram2(const MathematicalProgramSolverInterface& solver) {
 /////////// Quadratic Program ///////////
 /////////////////////////////////////////
 
-/*
- * Test a simple Quadratic Program.
- * The example is taken from
- * http://cvxopt.org/examples/tutorial/qp.html
- * min 2x1^2 + x2^2 + x1x2 + x1 + x2
- * s.t x1 >= 0
- *     x2 >= 0
- *     x1 + x2 = 1
- */
+
+// Test a simple Quadratic Program.
+// The example is taken from
+// http://cvxopt.org/examples/tutorial/qp.html
+// min 2x1^2 + x2^2 + x1x2 + x1 + x2
+// s.t x1 >= 0
+//     x2 >= 0
+//     x1 + x2 = 1
 void TestQuadraticProgram0(const MathematicalProgramSolverInterface& solver) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
@@ -412,10 +412,10 @@ void TestQuadraticProgram4(const MathematicalProgramSolverInterface& solver) {
                               MatrixCompareType::absolute));
 }
 
-/// Solve a series of QPs with the objective being the Euclidean distance
-/// from a point which moves along the unit circle (L2 ball), but
-/// constrained to lie inside the L1 ball.  Implemented in 2D, so that the
-/// active set moves along 4 faces of the L1 ball.
+// Solve a series of QPs with the objective being the Euclidean distance
+// from a point which moves along the unit circle (L2 ball), but
+// constrained to lie inside the L1 ball.  Implemented in 2D, so that the
+// active set moves along 4 faces of the L1 ball.
 void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables(2);
@@ -487,32 +487,31 @@ void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
     EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1e-5,
                                 MatrixCompareType::absolute));
   }
-}
+}*/
 
 ////////////////////////////////////////
 //// Second order conic program ////////
 ////////////////////////////////////////
 
-/*
- * This test is taken from
- * https://inst.eecs.berkeley.edu/~ee127a/book/login/exa_ell_sep.html
- * The goal is to find a hyperplane, that separates two ellipsoids
- * E1 = x1 + R1 * u1, u1' * u1<=1
- * E2 = x2 + R2 * u2, u2' * u2<=1
- * A hyperplane a' * x = b separates these two ellipsoids, if and only if for
- * SOCP p* = min t1 + t2
- *           s.t t1 >= |R1' * a|
- *               t2 >= |R2' * a|
- *               a'*(x2-x1) = 1
- * the optimal solution p* is no larger than 1. In that case, an approppriate
- * value of b is b = 0.5 * (b1 + b2), where
- * b1 = a' * x1 + |R1' * a|
- * b2 = a' * x2 - |R2' * a|
- * @param x1  the center of ellipsoid 1
- * @param x2  the center of ellipsoid 2
- * @param R1  the shape of ellipsoid 1
- * @param R2  the shape of ellipsoid 2
- */
+//
+// This test is taken from
+// https://inst.eecs.berkeley.edu/~ee127a/book/login/exa_ell_sep.html
+// The goal is to find a hyperplane, that separates two ellipsoids
+// E1 = x1 + R1 * u1, u1' * u1<=1
+// E2 = x2 + R2 * u2, u2' * u2<=1
+// A hyperplane a' * x = b separates these two ellipsoids, if and only if for
+// SOCP p* = min t1 + t2
+//           s.t t1 >= |R1' * a|
+//               t2 >= |R2' * a|
+//               a'*(x2-x1) = 1
+// the optimal solution p* is no larger than 1. In that case, an approppriate
+// value of b is b = 0.5 * (b1 + b2), where
+// b1 = a' * x1 + |R1' * a|
+// b2 = a' * x2 - |R2' * a|
+// @param x1  the center of ellipsoid 1
+// @param x2  the center of ellipsoid 2
+// @param R1  the shape of ellipsoid 1
+// @param R2  the shape of ellipsoid 2
 template <typename DerivedX1, typename DerivedX2, typename DerivedR1,
           typename DerivedR2>
 void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
@@ -530,48 +529,45 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
   const int kXdim = x1.rows();
   auto t = prog.NewContinuousVariables(2, "t");
   auto a = prog.NewContinuousVariables(kXdim, "a");
-  // R1a = R1' * a
-  // R2a = R2' * a
-  auto R1a = prog.NewContinuousVariables(R1.cols(), "R1a");
-  auto R2a = prog.NewContinuousVariables(R2.cols(), "R2a");
-  Eigen::MatrixXd R1_transpose = R1.transpose();
-  Eigen::MatrixXd R2_transpose = R2.transpose();
-  Eigen::MatrixXd A_R1a(R1.cols(), R1.cols() + R1.rows());
-  A_R1a.block(0, 0, R1.cols(), R1.cols()) =
-      Eigen::MatrixXd::Identity(R1.cols(), R1.cols());
-  A_R1a.block(0, R1.cols(), R1.cols(), R1.rows()) = -R1_transpose;
-  Eigen::MatrixXd A_R2a(R2.cols(), R2.cols() + R2.rows());
-  A_R2a.block(0, 0, R2.cols(), R2.cols()) =
-      Eigen::MatrixXd::Identity(R2.cols(), R2.cols());
-  A_R2a.block(0, R2.cols(), R2.cols(), R2.rows()) = -R2_transpose;
-  Eigen::VectorXd b_R1a = Eigen::VectorXd::Zero(R1.cols());
-  Eigen::VectorXd b_R2a = Eigen::VectorXd::Zero(R2.cols());
-  prog.AddLinearEqualityConstraint(A_R1a, b_R1a, {R1a, a});
-  prog.AddLinearEqualityConstraint(A_R2a, b_R2a, {R2a, a});
 
+  // Add Lorentz cone constraints
+  // t1 >= |R1'*a|
+  // t2 >= |R2'*a|
+  // Introduce matrices
+  // A1 = [1 0;0 R1']
+  // A2 = [1 0;0 R2']
+  // b1 = 0;
+  // b2 = 0;
+  // And both A1*[t;a]+b1, A2*[t;a]+b2 are in the Lorentz cone.
+  Eigen::MatrixXd A1(1 + R1.cols(), 1 + R1.rows());
+  Eigen::MatrixXd A2(1 + R2.cols(), 1 + R2.rows());
+  A1.setZero();
+  A2.setZero();
+  // clang-format off
+  A1 << 1, Eigen::RowVectorXd::Zero(R1.rows()),
+        Eigen::VectorXd::Zero(R1.cols()), R1.transpose();
+  A2 << 1, Eigen::RowVectorXd::Zero(R2.rows()),
+      Eigen::VectorXd::Zero(R2.cols()), R2.transpose();
+  // clang-format on
+  Eigen::VectorXd b1 = Eigen::VectorXd::Zero(1 + R1.cols());
+  Eigen::VectorXd b2 = Eigen::VectorXd::Zero(1 + R2.cols());
+  auto lorentz_cone1 = prog.AddLorentzConeConstraint(A1, b1, {t.segment<1>(0), a});
+  auto lorentz_cone2 = prog.AddLorentzConeConstraint(A2, b2, {t.segment<1>(1), a});
   // a'*(x2 - x1) = 1
   prog.AddLinearEqualityConstraint((x2 - x1).transpose(), 1.0, {a});
 
   // Add cost
   auto cost = prog.AddLinearCost(Eigen::Vector2d(1.0, 1.0), {t});
 
-  // Add Lorentz cones
-  auto lorentz_cone1 = prog.AddLorentzConeConstraint({t.segment<1>(0), R1a});
-  auto lorentz_cone2 = prog.AddLorentzConeConstraint({t.segment<1>(1), R2a});
-
   RunSolver(&prog, solver);
 
   // Check the solution.
   // First check if each constraint is satisfied.
-  const auto& R1a_value = prog.GetSolution(R1a);
-  const auto& R2a_value = prog.GetSolution(R2a);
   const auto& a_value = prog.GetSolution(a);
-  EXPECT_TRUE(CompareMatrices(R1a_value, R1_transpose * a_value, 1e-7,
-                              MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(R2a_value, R2_transpose * a_value, 1e-7,
-                              MatrixCompareType::absolute));
-  EXPECT_NEAR(prog.GetSolution(t(0)), R1a_value.norm(), 1e-6);
-  EXPECT_NEAR(prog.GetSolution(t(1)), R2a_value.norm(), 1e-6);
+  const auto& R1a_value = R1.transpose()*a_value;
+  const auto& R2a_value = R2.transpose()*a_value;
+  EXPECT_NEAR(t(0).value(), R1a_value.norm(), 1e-6);
+  EXPECT_NEAR(t(1).value(), R2a_value.norm(), 1e-6);
   EXPECT_TRUE(CompareMatrices((x2 - x1).transpose() * a_value,
                               drake::Vector1d(1.0), 1e-8,
                               MatrixCompareType::absolute));
@@ -591,9 +587,9 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
     // Verify that b - a'*x1 >= |R1' * a|
     //             a'*x2 - b >= |R2' * a|
     EXPECT_TRUE(b - a_value.transpose() * x1 >=
-                (R1_transpose * a_value).norm());
+                (R1.transpose() * a_value).norm());
     EXPECT_TRUE(a_value.transpose() * x2 - b >=
-                (R2_transpose * a_value).norm());
+                (R2.transpose() * a_value).norm());
   } else {
     // Now solve another SOCP to find a point y in the intersecting region
     // y = x1 + R1*u1
@@ -605,11 +601,24 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
     auto u2 = prog_intersect.NewContinuousVariables(R2.cols(), "u2");
     auto y = prog_intersect.NewContinuousVariables(kXdim, "y");
 
-    auto slack = prog_intersect.NewContinuousVariables<1>("slack");
-    prog_intersect.AddBoundingBoxConstraint(1, 1, slack(0));
 
-    prog_intersect.AddLorentzConeConstraint({slack, u1});
-    prog_intersect.AddLorentzConeConstraint({slack, u2});
+    // Add the constraint that both
+    // A_lorentz1 * u1 + b_lorentz1
+    // and
+    // A_lorentz2 * u2 + b_lorentz2
+    // are in the Lorentz cone.
+    // A_lorentz1 = [0; I], b_lorentz1 = [1; 0]
+    // A_lorentz2 = [0; I], b_lorentz2 = [1; 0]
+    Eigen::MatrixXd A_lorentz1(R1.cols() + 1, R1.cols());
+    Eigen::MatrixXd A_lorentz2(R2.cols() + 1, R2.cols());
+    Eigen::VectorXd b_lorentz1(R1.cols() + 1);
+    Eigen::VectorXd b_lorentz2(R2.cols() + 1);
+    A_lorentz1 << Eigen::RowVectorXd::Zero(R1.cols()), Eigen::MatrixXd::Identity(R1.cols(), R1.cols());
+    A_lorentz2 << Eigen::RowVectorXd::Zero(R2.cols()), Eigen::MatrixXd::Identity(R2.cols(), R1.cols());
+    b_lorentz1 << 1, Eigen::VectorXd::Zero(R1.cols());
+    b_lorentz2 << 1, Eigen::VectorXd::Zero(R2.cols());
+    prog_intersect.AddLorentzConeConstraint(A_lorentz1, b_lorentz1, {u1});
+    prog_intersect.AddLorentzConeConstraint(A_lorentz2, b_lorentz2, {u2});
 
     // Add constraint y = x1 + R1*u1
     //                y = x2 + R2*u2
@@ -639,26 +648,24 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
   }
 }
 
-/*
- * This example is taken from
- * https://inst.eecs.berkeley.edu/~ee127a/book/login/exa_qp_as_socp.html
- * For a quadratic program
- * 0.5 * x' * Q * x + c' * x
- * s.t b_lb <= A * x <= b_ub
- * It can be casted as an SOCP, as follows
- * By introducing a new variable w = Q^{1/2}*x and y, z
- * The equivalent SOCP is
- * min c'x + y
- * s.t y * z >= w' * w
- *     z = 2
- *     w = Q^{1/2} * x
- *     b_lb <= A * x <= b_ub
- * @param Q A positive definite matrix
- * @param c A column vector
- * @param A A matrix
- * @param b_lb A column vector
- * @param b_ub A column vector
- */
+
+// This example is taken from
+// https://inst.eecs.berkeley.edu/~ee127a/book/login/exa_qp_as_socp.html
+// For a quadratic program
+// 0.5 * x' * Q * x + c' * x
+// s.t b_lb <= A * x <= b_ub
+// It can be casted as an SOCP, as follows
+// By introducing a new variable w = Q^{1/2}*x and y, z
+// The equivalent SOCP is
+// min c'x + y
+// s.t 2 * y >= w' * w
+//     w = Q^{1/2} * x
+//     b_lb <= A * x <= b_ub
+// @param Q A positive definite matrix
+// @param c A column vector
+// @param A A matrix
+// @param b_lb A column vector
+// @param b_ub A column vector
 template <typename DerivedQ, typename DerivedC, typename DerivedA,
           typename DerivedBlower, typename DerivedBupper>
 void SolveQPasSOCP(const Eigen::MatrixBase<DerivedQ>& Q,
@@ -682,11 +689,13 @@ void SolveQPasSOCP(const Eigen::MatrixBase<DerivedQ>& Q,
 
   auto x_socp = prog_socp.NewContinuousVariables(kXdim, "x");
   auto y = prog_socp.NewContinuousVariables<1>("y");
-  auto z = prog_socp.NewContinuousVariables<1>("z");
   auto w = prog_socp.NewContinuousVariables(kXdim, "w");
 
-  prog_socp.AddBoundingBoxConstraint(2.0, 2.0, z(0));
-  prog_socp.AddRotatedLorentzConeConstraint({y, z, w});
+  Eigen::MatrixXd A_lorentz(2 + kXdim, 1+kXdim);
+  A_lorentz << Eigen::RowVectorXd::Zero(1 + kXdim), Eigen::MatrixXd::Identity(1 + kXdim, 1+kXdim);
+  Eigen::VectorXd b_lorentz(2 + kXdim);
+  b_lorentz << 2, Eigen::VectorXd::Zero(1 + kXdim);
+  prog_socp.AddRotatedLorentzConeConstraint(A_lorentz, b_lorentz, {y, w});
 
   Eigen::LLT<Eigen::MatrixXd, Eigen::Upper> lltOfQ(Q_symmetric);
   Eigen::MatrixXd Q_sqrt = lltOfQ.matrixU();
@@ -771,36 +780,33 @@ void TestQPasSOCP(const MathematicalProgramSolverInterface& solver) {
   SolveQPasSOCP(Q, c, A, b_lb, b_ub, solver);
 }
 
-/*
- * This example is taken from the paper
- * Applications of second-order cone programming
- * By M.S.Lobo, L.Vandenberghe, S.Boyd and H.Lebret,
- * Section 3.6
- * http://www.seas.ucla.edu/~vandenbe/publications/socp.pdf
- * The problem tries to find the equilibrium state of a mechanical
- * system, which consists of N nodes at position (x1,y1), (x2,y2), ..., (xN,yN)
- * in R2.
- * The nodes are connected by springs with given coefficient.
- * The spring generate force when it is stretched,
- * but not when it is compressed.
- * Namely, the spring force is
- * (spring_length - spring_rest_length) * spring_stiffness,
- * if spring_length >= spring_rest_length;
- * otherwise the spring force is zero.
- * weight_i is the mass * gravity_acceleration
- * of the i'th link.
- * The equilibrium point is obtained when the total energy is minimized
- * namely min sum_i weight_i * yi + stiffness/2 * t_i^2
- *        s.t  sqrt((x(i) - x(i+1))^2 + (y(i) - y(i+1))^2) - spring_rest_length
- * <= t_i
- *             0 <= t_i
- *             (x1,y1) = end_pos1
- *             (xN,yN) = end_pos2
- * By introducing a slack variable z >= t_1^2 + ... + t_(N-1)^2, the problem
- * becomes
- * an SOCP, with both Lorentz cone and rotated Lorentz cone constraints
- *
- */
+// This example is taken from the paper
+// Applications of second-order cone programming
+// By M.S.Lobo, L.Vandenberghe, S.Boyd and H.Lebret,
+// Section 3.6
+// http://www.seas.ucla.edu/~vandenbe/publications/socp.pdf
+// The problem tries to find the equilibrium state of a mechanical
+// system, which consists of N nodes at position (x1,y1), (x2,y2), ..., (xN,yN)
+// in R2.
+// The nodes are connected by springs with given coefficient.
+// The spring generate force when it is stretched,
+// but not when it is compressed.
+// Namely, the spring force is
+// (spring_length - spring_rest_length) * spring_stiffness,
+// if spring_length >= spring_rest_length;
+// otherwise the spring force is zero.
+// weight_i is the mass * gravity_acceleration
+// of the i'th link.
+// The equilibrium point is obtained when the total energy is minimized
+// namely min sum_i weight_i * yi + stiffness/2 * t_i^2
+//        s.t  sqrt((x(i) - x(i+1))^2 + (y(i) - y(i+1))^2) - spring_rest_length
+// <= t_i
+//             0 <= t_i
+//             (x1,y1) = end_pos1
+//             (xN,yN) = end_pos2
+// By introducing a slack variable z >= t_1^2 + ... + t_(N-1)^2, the problem
+// becomes
+// an SOCP, with both Lorentz cone and rotated Lorentz cone constraints
 void FindSpringEquilibrium(const Eigen::VectorXd& weight,
                            double spring_rest_length, double spring_stiffness,
                            const Eigen::Vector2d& end_pos1,
@@ -818,47 +824,33 @@ void FindSpringEquilibrium(const Eigen::VectorXd& weight,
   prog.AddBoundingBoxConstraint(
       Eigen::VectorXd::Zero(num_nodes - 1),
       Eigen::VectorXd::Constant(num_nodes - 1,
-                                std::numeric_limits<double>::infinity()),
-      {t});
-  auto t_plus_l0 = prog.NewContinuousVariables(
-      num_nodes - 1,
-      "t_plus_l0");  // The slack variable equals to t_i + spring_rest_length
-  Eigen::MatrixXd A1(num_nodes - 1, 2 * (num_nodes - 1));
-  A1 << Eigen::MatrixXd::Identity(num_nodes - 1, num_nodes - 1),
-      -Eigen::MatrixXd::Identity(num_nodes - 1, num_nodes - 1);
-  prog.AddLinearEqualityConstraint(
-      A1, Eigen::VectorXd::Constant(num_nodes - 1, spring_rest_length),
-      {t_plus_l0, t});
-  // x_diff(i) = x(i+1) - x(i)
-  // y_diff(i) = y(i+1) - y(i)
-  auto x_diff = prog.NewContinuousVariables(num_nodes - 1, "xd");
-  auto y_diff = prog.NewContinuousVariables(num_nodes - 1, "yd");
-  Eigen::MatrixXd A2(num_nodes - 1, 2 * num_nodes - 1);
-  A2.setZero();
-  A2.block(0, 0, num_nodes - 1, num_nodes - 1) =
-      -Eigen::MatrixXd::Identity(num_nodes - 1, num_nodes - 1);
-  A2.block(0, 1, num_nodes - 1, num_nodes - 1) +=
-      Eigen::MatrixXd::Identity(num_nodes - 1, num_nodes - 1);
-  A2.block(0, num_nodes, num_nodes - 1, num_nodes - 1) =
-      -Eigen::MatrixXd::Identity(num_nodes - 1, num_nodes - 1);
-  prog.AddLinearEqualityConstraint(A2, Eigen::VectorXd::Zero(num_nodes - 1),
-                                   {x, x_diff});
-  prog.AddLinearEqualityConstraint(A2, Eigen::VectorXd::Zero(num_nodes - 1),
-                                   {y, y_diff});
+                                std::numeric_limits<double>::infinity()), {t});
 
   // sqrt((x(i)-x(i+1))^2 + (y(i) - y(i+1))^2) <= ti + spring_rest_length
   for (int i = 0; i < num_nodes - 1; ++i) {
-    prog.AddLorentzConeConstraint(
-        {t_plus_l0.segment<1>(i), x_diff.segment<1>(i), y_diff.segment<1>(i)});
+    // A_lorentz1 * [x(i); x(i+1); y(i); y(i+1); t(i)] + b_lorentz1
+    //     = [ti + spring_rest_length; x(i) - x(i+1); y(i) - y(i+1)]
+    Eigen::Matrix<double, 3, 5> A_lorentz1;
+    A_lorentz1.setZero();
+    A_lorentz1(0, 4) = 1;
+    A_lorentz1(1, 0) = 1;
+    A_lorentz1(1, 1) = -1;
+    A_lorentz1(2, 2) = 1;
+    A_lorentz1(2, 3) = -1;
+    Eigen::Vector3d b_lorentz1(spring_rest_length, 0, 0);
+    prog.AddLorentzConeConstraint(A_lorentz1, b_lorentz1, {x.segment<2>(i), y.segment<2>(i), t.segment<1>(i)});
   }
 
   // Add constraint z >= t_1^2 + .. + t_(N-1)^2
-  auto z = prog.NewContinuousVariables(2, "z");
-  prog.AddBoundingBoxConstraint(1, 1, z(0));
-  prog.AddRotatedLorentzConeConstraint({z, t});
+  auto z = prog.NewContinuousVariables<1>("z");
+  Eigen::MatrixXd A_lorentz2(1 + num_nodes, num_nodes);
+  A_lorentz2 << Eigen::RowVectorXd::Zero(num_nodes), Eigen::MatrixXd::Identity(num_nodes, num_nodes);
+  Eigen::VectorXd b_lorentz2(1 + num_nodes);
+  b_lorentz2 << 1, Eigen::VectorXd::Zero(num_nodes);
+  prog.AddRotatedLorentzConeConstraint(A_lorentz2, b_lorentz2, {z, t});
 
-  prog.AddLinearCost(drake::Vector1d(spring_stiffness / 2), {z.segment<1>(1)});
-  prog.AddLinearCost(weight, {y});
+  prog.AddLinearCost(drake::Vector1d(spring_stiffness / 2), {z});
+  prog.AddLinearCost(weight.transpose(), {y});
 
   RunSolver(&prog, solver);
 
@@ -883,7 +875,7 @@ void FindSpringEquilibrium(const Eigen::VectorXd& weight,
     }
   }
   const auto& t_value = prog.GetSolution(t);
-  EXPECT_TRUE(std::abs(prog.GetSolution(z(1)) - t_value.squaredNorm()) < 1E-3);
+  EXPECT_TRUE(std::abs(z(0).value() - t_value.squaredNorm()) < 1E-3);
   // Now test equilibrium.
   for (int i = 1; i < num_nodes - 1; i++) {
     Eigen::Vector2d left_spring(
@@ -930,7 +922,7 @@ void TestFindSpringEquilibrium(
                         solver);
 }
 }  // namespace
-
+/*
 GTEST_TEST(TestConvexOptimization, TestLinearProgramFeasibility) {
   std::list<std::unique_ptr<MathematicalProgramSolverInterface>> solvers;
   GetLinearProgramSolvers(&solvers);
@@ -1105,7 +1097,7 @@ GTEST_TEST(TestConvexOptimization, TestQuadraticProgram5) {
       get_solution = true;
     }
   }
-}
+}*/
 
 GTEST_TEST(TestConvexOptimization, TestEllipsoidsSeparation0) {
   std::list<std::unique_ptr<MathematicalProgramSolverInterface>> solvers;
@@ -1179,7 +1171,7 @@ GTEST_TEST(TestConvexOptimization, TestFindSpringEquilibrium) {
     TestFindSpringEquilibrium(*solver);
   }
 }
-
+/*
 // Test a trivial semidefinite problem.
 // min S(0, 0) + S(1, 1)
 // s.t S(1, 0) = 1
@@ -1350,7 +1342,7 @@ GTEST_TEST(TestConvexOptimization, TestEigenvalueProblem) {
     // default feasibility tolerance 1E-8.
     EXPECT_NEAR(z_value, eigen_solver_xF.eigenvalues().maxCoeff(), 1E-7);
   }
-}
+}*/
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -526,7 +526,7 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
 
   MathematicalProgram prog;
   const int kXdim = x1.rows();
-  auto t = prog.NewContinuousVariables(2, "t");
+  auto t = prog.NewContinuousVariables<2>("t");
   auto a = prog.NewContinuousVariables(kXdim, "a");
 
   // Add Lorentz cone constraints
@@ -568,8 +568,8 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
   const auto& a_value = prog.GetSolution(a);
   const auto& R1a_value = R1.transpose() * a_value;
   const auto& R2a_value = R2.transpose() * a_value;
-  EXPECT_NEAR(t(0).value(), R1a_value.norm(), 1e-6);
-  EXPECT_NEAR(t(1).value(), R2a_value.norm(), 1e-6);
+  EXPECT_NEAR(prog.GetSolution((t(0))), R1a_value.norm(), 1e-6);
+  EXPECT_NEAR(prog.GetSolution((t(1))), R2a_value.norm(), 1e-6);
   EXPECT_TRUE(CompareMatrices((x2 - x1).transpose() * a_value,
                               drake::Vector1d(1.0), 1e-8,
                               MatrixCompareType::absolute));
@@ -882,7 +882,7 @@ void FindSpringEquilibrium(const Eigen::VectorXd& weight,
     }
   }
   const auto& t_value = prog.GetSolution(t);
-  EXPECT_TRUE(std::abs(z(0).value() - t_value.squaredNorm()) < 1E-3);
+  EXPECT_TRUE(std::abs(prog.GetSolution(z(0)) - t_value.squaredNorm()) < 1E-3);
   // Now test equilibrium.
   for (int i = 1; i < num_nodes - 1; i++) {
     Eigen::Vector2d left_spring(

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -28,7 +28,7 @@ void GetQuadraticProgramSolvers(
 
 void GetSecondOrderConicProgramSolvers(
     std::list<std::unique_ptr<MathematicalProgramSolverInterface>>* solvers) {
-  //AddSolverIfAvailable("Gurobi", solvers);
+  AddSolverIfAvailable("Gurobi", solvers);
   AddSolverIfAvailable("Mosek", solvers);
 }
 
@@ -36,7 +36,7 @@ void GetSemidefiniteProgramSolvers(
     std::list<std::unique_ptr<MathematicalProgramSolverInterface>>* solvers) {
   AddSolverIfAvailable("Mosek", solvers);
 }
-/*
+
 /////////////////////////
 ///// Linear Program ////
 /////////////////////////
@@ -487,7 +487,7 @@ void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
     EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1e-5,
                                 MatrixCompareType::absolute));
   }
-}*/
+}
 
 ////////////////////////////////////////
 //// Second order conic program ////////
@@ -922,7 +922,7 @@ void TestFindSpringEquilibrium(
                         solver);
 }
 }  // namespace
-/*
+
 GTEST_TEST(TestConvexOptimization, TestLinearProgramFeasibility) {
   std::list<std::unique_ptr<MathematicalProgramSolverInterface>> solvers;
   GetLinearProgramSolvers(&solvers);
@@ -1097,7 +1097,7 @@ GTEST_TEST(TestConvexOptimization, TestQuadraticProgram5) {
       get_solution = true;
     }
   }
-}*/
+}
 
 GTEST_TEST(TestConvexOptimization, TestEllipsoidsSeparation0) {
   std::list<std::unique_ptr<MathematicalProgramSolverInterface>> solvers;
@@ -1171,7 +1171,7 @@ GTEST_TEST(TestConvexOptimization, TestFindSpringEquilibrium) {
     TestFindSpringEquilibrium(*solver);
   }
 }
-/*
+
 // Test a trivial semidefinite problem.
 // min S(0, 0) + S(1, 1)
 // s.t S(1, 0) = 1
@@ -1342,7 +1342,7 @@ GTEST_TEST(TestConvexOptimization, TestEigenvalueProblem) {
     // default feasibility tolerance 1E-8.
     EXPECT_NEAR(z_value, eigen_solver_xF.eigenvalues().maxCoeff(), 1E-7);
   }
-}*/
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Support the second order cone
`Ax+b is in (rotated) Lorentz cone`.

This should make writing second-order conic programming a bit easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4650)
<!-- Reviewable:end -->
