### PR TITLE
Fix Trusty / GCC 4.7 build errors

### DIFF
--- a/drake/common/drake_compat.h
+++ b/drake/common/drake_compat.h
@@ -8,16 +8,22 @@
 /// write code using the std::make_unique phrasing, but still support GCC 4.8.
 
 #ifndef DRAKE_DOXYGEN_CXX
-#if __cplusplus <= 201103L  // If C++11 or earlier, we need our own make_unique.
+#if __cplusplus <= 201103L  // If C++11 or earlier, we need our own helpers.
 
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 namespace std {
+
 template<typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+
+template<bool B, class T = void>
+using enable_if_t = typename enable_if<B, T>::type;
+
 }  // namespace std
 
 #endif  // version check

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -550,10 +550,13 @@ class Diagram : public System<T>,
   /// more specific covariant type.
   /// This is the NVI implementation of ToAutoDiffXd.
   Diagram<AutoDiffXd>* DoToAutoDiffXd() const override {
-    return ConvertScalarType<AutoDiffXd>([](const System<double>& subsystem) {
-             return subsystem.ToAutoDiffXd();
-           })
-        .release();
+    using FromType = System<double>;
+    using ToType = std::unique_ptr<System<AutoDiffXd>>;
+    std::function<ToType(const FromType&)> subsystem_converter{
+      [](const FromType& subsystem) {
+        return subsystem.ToAutoDiffXd();
+      }};
+    return ConvertScalarType<AutoDiffXd>(subsystem_converter).release();
   }
 
  private:

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -325,8 +325,7 @@ class LeafSystem : public System<T> {
   template <typename T1 = T>
   typename std::enable_if<is_numeric<T1>::value>::type DoCalcNextUpdateTimeImpl(
       const Context<T1>& context, UpdateActions<T1>* actions) const {
-    T1 min_time =
-        std::numeric_limits<typename Eigen::NumTraits<T1>::Literal>::infinity();
+    T1 min_time = std::numeric_limits<double>::infinity();
     if (periodic_events_.empty()) {
       // No discrete update.
       actions->time = min_time;

--- a/drake/systems/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/primitives/test/gain_scalartype_test.cc
@@ -89,16 +89,14 @@ class SymbolicGainTest : public ::testing::Test {
                                                     3 /* length */);
     context_ = gain_->CreateDefaultContext();
     output_ = gain_->AllocateOutput(*context_);
-    input0_ = make_unique<BasicVector<symbolic::Expression>>(3 /* length */);
-    input1_ = make_unique<BasicVector<symbolic::Expression>>(3 /* length */);
+    input_ = make_unique<BasicVector<symbolic::Expression>>(3 /* length */);
   }
 
   const symbolic::Expression kGain_{2.0};
   unique_ptr<System<symbolic::Expression>> gain_;
   unique_ptr<Context<symbolic::Expression>> context_;
   unique_ptr<SystemOutput<symbolic::Expression>> output_;
-  unique_ptr<BasicVector<symbolic::Expression>> input0_;
-  unique_ptr<BasicVector<symbolic::Expression>> input1_;
+  unique_ptr<BasicVector<symbolic::Expression>> input_;
 };
 
 TEST_F(SymbolicGainTest, VectorThroughGainSystem) {
@@ -109,10 +107,10 @@ TEST_F(SymbolicGainTest, VectorThroughGainSystem) {
   Eigen::Matrix<symbolic::Expression, 3, 1> input_vector(
       drake::symbolic::Expression{1.0}, drake::symbolic::Expression{3.14},
       drake::symbolic::Expression{2.18});
-  input0_->get_mutable_value() << input_vector;
+  input_->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
-  context_->FixInputPort(0, move(input0_));
+  context_->FixInputPort(0, move(input_));
   gain_->CalcOutput(*context_, output_.get());
 
   // Checks that the number of output ports in the Gain system and the


### PR DESCRIPTION
- Add definition of `std::enable_if_t` in `drake_compat.h` and spell out `Diagram` transmogrification types for GCC 4.7 to understand (broken in #4210).
- Say `double` instead of `NumTraits::Literal` (broken in #4431).  The latter doesn't exist in Eigen 3.2, and we require that all of our `ScalarType`s are convertible from `double` already.  (This PR only fixes one of the two cases; the other one is fixed in #4657).
- Remove some dead code noticed while testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4652)
<!-- Reviewable:end -->
