### PR TITLE
Fix Trusty build errors

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -40,6 +40,12 @@ cc_library(
 )
 
 cc_library(
+    name = "dummy_value",
+    hdrs = ["dummy_value.h"],
+    linkstatic = 1,
+)
+
+cc_library(
     name = "number_traits",
     hdrs = ["number_traits.h"],
     linkstatic = 1,
@@ -63,6 +69,7 @@ cc_library(
     deps = [
         ":common",
         ":cond",
+        ":dummy_value",
     ],
 )
 
@@ -84,6 +91,7 @@ cc_library(
     linkstatic = 1,
     deps = [
         ":common",
+        ":dummy_value",
     ],
 )
 
@@ -126,6 +134,7 @@ cc_library(
     deps = [
         ":common",
         ":cond",
+        ":dummy_value",
         ":number_traits",
     ],
 )
@@ -277,6 +286,13 @@ cc_googletest(
     name = "drake_throw_test",
     deps = [
         ":common",
+    ],
+)
+
+cc_googletest(
+    name = "dummy_value_test",
+    deps = [
+        ":dummy_value",
     ],
 )
 

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -41,6 +41,7 @@ set(installed_headers
   drake_deprecated.h
   drake_path.h
   drake_throw.h
+  dummy_value.h
   eigen_autodiff_types.h
   eigen_matrix_compare.h
   eigen_stl_types.h

--- a/drake/common/autodiff_overloads.h
+++ b/drake/common/autodiff_overloads.h
@@ -26,6 +26,7 @@
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/cond.h"
+#include "drake/common/dummy_value.h"
 #include "drake/common/drake_assert.h"
 
 namespace Eigen {
@@ -144,6 +145,17 @@ template <typename DerType>
 double ExtractDoubleOrThrow(const Eigen::AutoDiffScalar<DerType>& scalar) {
   return static_cast<double>(scalar.value());
 }
+
+/// Specializes common/dummy_value.h.
+template <typename DerType>
+struct dummy_value<Eigen::AutoDiffScalar<DerType>> {
+  static constexpr Eigen::AutoDiffScalar<DerType> get() {
+    constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+    DerType derivatives;
+    derivatives.fill(kNaN);
+    return Eigen::AutoDiffScalar<DerType>(kNaN, derivatives);
+  }
+};
 
 /// Provides if-then-else expression for Eigen::AutoDiffScalar type. To support
 /// Eigen's generic expressions, we use casting to the plain object after

--- a/drake/common/dummy_value.h
+++ b/drake/common/dummy_value.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <limits>
+
+namespace drake {
+
+/// Provides a "dummy" value for a ScalarType -- a value that is unlikely to be
+/// mistaken for a purposefully-computed value, useful for initializing a value
+/// before the true result is available.
+///
+/// Defaults to using std::numeric_limits::quiet_NaN when available; it is a
+/// compile-time error to call the unspecialized dummy_value::get() when
+/// quiet_NaN is unavailable.
+///
+/// See autodiff_overloads.h to use this with Eigen's AutoDiffScalar.
+template <typename T>
+struct dummy_value {
+  static constexpr T get() {
+    static_assert(std::numeric_limits<T>::has_quiet_NaN,
+                  "Custom scalar types should specialize this struct");
+    return std::numeric_limits<T>::quiet_NaN();
+  }
+};
+
+template <>
+struct dummy_value<int> {
+  static constexpr int get() {
+    // D is for "Dummy".  We assume as least 32 bits (per cppguide) -- if `int`
+    // is larger than 32 bits, this will leave some fraction of the bytes zero
+    // instead of 0xDD, but that's okay.
+    return 0xDDDDDDDD;
+  }
+};
+
+}  // namespace drake

--- a/drake/common/functional_form.h
+++ b/drake/common/functional_form.h
@@ -11,6 +11,8 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/dummy_value.h"
+
 namespace drake {
 
 /** Represent an abstract form of a function of zero or more variables.
@@ -713,6 +715,12 @@ typename std::enable_if<
 operator/=(MatrixL& lhs, double rhs) {
   return lhs /= FunctionalForm(rhs);
 }
+
+template <>
+struct dummy_value<FunctionalForm> {
+  // The default constructor provides an "Undefined" placeholder.
+  static FunctionalForm get() { return FunctionalForm(); }
+};
 
 }  // namespace drake
 

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -13,6 +13,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/cond.h"
+#include "drake/common/dummy_value.h"
 #include "drake/common/hash.h"
 #include "drake/common/number_traits.h"
 #include "drake/common/symbolic_environment.h"
@@ -502,6 +503,16 @@ symbolic::Expression cond(const symbolic::Formula& f_cond, double v_then,
                           Rest... rest) {
   return if_then_else(f_cond, symbolic::Expression{v_then}, cond(rest...));
 }
+
+/// Specializes common/dummy_value.h.
+template <>
+struct dummy_value<symbolic::Expression> {
+  static symbolic::Expression get() {
+    // TODO(jwnimmer-tri) It would be nice to have a Cell type like 'undefined'
+    // (or null) here, so that we could fail-faster.
+    return symbolic::Expression{};
+  }
+};
 
 /** Computes the hash value of a symbolic expression. */
 template <>

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -6,6 +6,9 @@ target_link_libraries(autodiff_overloads_test drakeCommon)
 drake_add_cc_test(double_overloads_test)
 target_link_libraries(double_overloads_test drakeCommon)
 
+drake_add_cc_test(dummy_value_test)
+target_link_libraries(dummy_value_test drakeCommon)
+
 drake_add_cc_test(extract_double_test)
 target_link_libraries(extract_double_test drakeCommon)
 

--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -19,7 +19,7 @@ namespace drake {
 namespace common {
 namespace {
 
-// Test ExtractDoubleOrThrow on autodiff.
+// Tests ExtractDoubleOrThrow on autodiff.
 GTEST_TEST(AutodiffOverloadsTest, ExtractDouble) {
   // On autodiff.
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;
@@ -31,7 +31,7 @@ GTEST_TEST(AutodiffOverloadsTest, ExtractDouble) {
   EXPECT_EQ(ExtractDoubleOrThrow(y), 1.0);
 }
 
-// Tests correctness of isinf
+// Tests correctness of isinf.
 GTEST_TEST(AutodiffOverloadsTest, IsInf) {
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;
   x.value() = 1.0 / 0.0;
@@ -40,7 +40,7 @@ GTEST_TEST(AutodiffOverloadsTest, IsInf) {
   EXPECT_EQ(isinf(x), false);
 }
 
-// Tests correctness of isnan
+// Tests correctness of isnan.
 GTEST_TEST(AutodiffOverloadsTest, IsNaN) {
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;
   x.value() = 0.0 / 0.0;
@@ -322,6 +322,26 @@ GTEST_TEST(AutodiffOverloadsTest, CheckEigenLiteral) {
   static_assert(std::is_same<Literald, double>::value &&
                     std::is_same<Literalf, float>::value,
                 "Eigen::NumTraits<T>::Literal didn't behave as expected.");
+}
+
+GTEST_TEST(AutodiffOverloadsTest, DummyValueX) {
+  using T = Eigen::AutoDiffScalar<Eigen::VectorXd>;
+  const T dummy_xd = dummy_value<T>::get();
+  const double value = dummy_xd.value();
+  EXPECT_TRUE(std::isnan(value));
+  const Eigen::VectorXd derivatives = dummy_xd.derivatives();
+  EXPECT_EQ(derivatives.rows(), 0);
+}
+
+GTEST_TEST(AutodiffOverloadsTest, DummyValue2) {
+  using T = Eigen::AutoDiffScalar<Eigen::Vector2d>;
+  const T dummy_2d = dummy_value<T>::get();
+  const double value = dummy_2d.value();
+  EXPECT_TRUE(std::isnan(value));
+  const Eigen::Vector2d derivatives = dummy_2d.derivatives();
+  EXPECT_EQ(derivatives.rows(), 2);
+  EXPECT_TRUE(std::isnan(derivatives(0)));
+  EXPECT_TRUE(std::isnan(derivatives(1)));
 }
 
 }  // namespace

--- a/drake/common/test/dummy_value_test.cc
+++ b/drake/common/test/dummy_value_test.cc
@@ -1,0 +1,19 @@
+#include "drake/common/dummy_value.h"
+
+#include <cmath>
+
+#include "gtest/gtest.h"
+
+namespace drake {
+namespace {
+
+GTEST_TEST(DummyValueTest, Double) {
+  EXPECT_TRUE(std::isnan(dummy_value<double>::get()));
+}
+
+GTEST_TEST(DummyValueTest, Int) {
+  EXPECT_NE(dummy_value<int>::get(), 0);
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/common/test/functional_form_test.cc
+++ b/drake/common/test/functional_form_test.cc
@@ -264,6 +264,8 @@ GTEST_TEST(FunctionalFormTest, Construct) {
   FunctionalForm default_constructed;
   EXPECT_TRUE(default_constructed.IsUndefined());
 
+  EXPECT_TRUE(dummy_value<FunctionalForm>::get().IsUndefined());
+
   FunctionalForm double_zero(0.0);
   EXPECT_TRUE(double_zero.IsZero());
 

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -144,6 +144,11 @@ class SymbolicExpressionTest : public ::testing::Test {
       e_sinh_,     e_cosh_, e_tanh_, e_min_,  e_max_,  e_ite_};
 };
 
+TEST_F(SymbolicExpressionTest, Dummy) {
+  // TODO(jwnimmer-tri) We'd prefer 'undefined' instead of zero.
+  EXPECT_TRUE(is_zero(dummy_value<Expression>::get()));
+}
+
 TEST_F(SymbolicExpressionTest, IsConstant1) {
   EXPECT_TRUE(is_constant(e_constant_));
   const vector<Expression>::difference_type cnt{

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -43,6 +43,7 @@ cc_library(
     linkstatic = 1,
     deps = [
         "//drake/common",
+        "//drake/common:dummy_value",
     ],
 )
 

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/dummy_value.h"
 #include "drake/systems/framework/vector_base.h"
 
 #include <Eigen/Dense>
@@ -18,18 +19,15 @@ namespace systems {
 
 /// BasicVector is a semantics-free wrapper around an Eigen vector that
 /// satisfies VectorBase. Once constructed, its size is fixed.
-/// The BasicVector is initialized to the quiet_NaN of the Eigen scalar.
-/// If numeric_limits is not specialized on the Eigen scalar, the BasicVector
-/// will be initialized with the scalar's default constructor.
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 template <typename T>
 class BasicVector : public VectorBase<T> {
  public:
+  /// Initializes with the given @p size using the drake::dummy_value<T>, which
+  /// is NaN when T = double.
   explicit BasicVector(int size)
-      : values_(VectorX<T>::Constant(
-            size, std::numeric_limits<
-                      typename Eigen::NumTraits<T>::Literal>::quiet_NaN())) {}
+      : values_(VectorX<T>::Constant(size, dummy_value<T>::get())) {}
 
   /// Constructs a BasicVector with the specified @p data.
   explicit BasicVector(const VectorX<T>& data) : values_(data) {}

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -6,9 +6,10 @@
 #include <Eigen/Dense>
 #include "gtest/gtest.h"
 
+#include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/eigen_types.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/eigen_types.h"
 #include "drake/common/functional_form.h"
 
 namespace drake {
@@ -43,12 +44,17 @@ GTEST_TEST(BasicVectorTest, AutodiffInitiallyNaN) {
   EXPECT_TRUE(std::isnan(vec.GetAtIndex(2).value()));
 }
 
-// Tests that the BasicVector<int> is initialized to zero.
-GTEST_TEST(BasicVectorTest, IntInitiallyZero) {
+// Tests that the BasicVector<int> is initialized to non-zero dummy that is the
+// same for all elements.
+GTEST_TEST(BasicVectorTest, IntInitiallyDummy) {
   BasicVector<int> vec(3);
-  Eigen::Vector3i expected;
-  expected << 0, 0, 0;
-  EXPECT_EQ(expected, vec.get_value());
+
+  EXPECT_NE(vec.GetAtIndex(0), 0);
+  EXPECT_NE(vec.GetAtIndex(1), 0);
+  EXPECT_NE(vec.GetAtIndex(2), 0);
+
+  EXPECT_EQ(vec.GetAtIndex(0), vec.GetAtIndex(1));
+  EXPECT_EQ(vec.GetAtIndex(0), vec.GetAtIndex(2));
 }
 
 // Tests that the BasicVector<FunctionalForm> is initialized to undefined.

--- a/drake/systems/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/primitives/test/gain_scalartype_test.cc
@@ -4,8 +4,8 @@
 #include <stdexcept>
 #include <string>
 
-#include <unsupported/Eigen/AutoDiff>
-
+#include "drake/common/autodiff_overloads.h"
+#include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/systems/framework/basic_vector.h"


### PR DESCRIPTION
Use `dummy_value<T>` instead of `NumTraits::Literal` mashed into `numeric_limits::quiet_NaN` (broken in #4431). The latter doesn't exist in Eigen 3.2.  (This PR only fixes one of the two cases; #4652 fixed the other one).

This dummy approach is anyway superior, because we can actually dummy out things like integers (which don't have NaN!) and fixed-size AutoDiffScalars (whose derivatives default to zero, but here we make them NaN).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4657)
<!-- Reviewable:end -->
