### PR TITLE
Make bazel query work without gurobi

### DIFF
--- a/tools/gurobi.bzl
+++ b/tools/gurobi.bzl
@@ -1,15 +1,16 @@
+# -*- python -*-
 # This is a Bazel repository_rule for the Gurobi solver.  See
 # https://www.bazel.io/versions/master/docs/skylark/repository_rules.html
 
 # GUROBI_PATH should be the linux64 directory in the Gurobi 6.05 release.
 # TODO(david-german-tri): Add support for OS X.
 def _gurobi_impl(repository_ctx):
-    gurobi_path = repository_ctx.os.environ.get('GUROBI_PATH')
-    if gurobi_path:
-        repository_ctx.symlink(gurobi_path, "gurobi-distro")
-        repository_ctx.symlink(getattr(repository_ctx.attr, "workspace_dir") +
-                               "/" + getattr(repository_ctx.attr, "build_file"),
-                               "BUILD")
+    gurobi_path = repository_ctx.os.environ.get(
+        "GUROBI_PATH", "/MISSING_GUROBI_PATH")
+    repository_ctx.symlink(gurobi_path, "gurobi-distro")
+    repository_ctx.symlink(getattr(repository_ctx.attr, "workspace_dir") +
+                           "/" + getattr(repository_ctx.attr, "build_file"),
+                           "BUILD")
 
 gurobi_repository = repository_rule(
     attrs = {


### PR DESCRIPTION
A `bazel query` will fail and scream if the repository wasn't created by our skylark rule.  A broken link is fine, but a missing directory is not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4659)
<!-- Reviewable:end -->
