### PR TITLE
Integrator without simulator

### DIFF
--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <utility>
 
 #include "drake/common/drake_assert.h"

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -353,10 +353,28 @@ class IntegratorBase {
    *                          of publish_dt, update_dt, or boundary_dt is
    *                          negative.
    * @return The reason for the integration step ending.
+   * @warning Users should generally not call this function directly; within
+   *          simulation circumstances, users will typically call
+   *          `Simulator::StepTo()`. In other circumstances, users will
+   *          typically call `IntegratorBase::StepOnceExactly()`.
    */
   // TODO(edrumwri): Make the stretch size configurable.
   StepResult StepOnceAtMost(const T& publish_dt, const T& update_dt,
                             const T& boundary_dt);
+
+  /// Stepping function for integrators operating outside of simulation
+  /// circumstances. This method simply calls
+  /// `StepOnceAtMost(inf, inf, boundary_dt)` and is designed for integrator
+  /// users that do not wish to consider publishing or discontinuous,
+  /// mid-interval updates. One such example application is that of direct
+  /// collocation for trajectory optimization.
+  /// @warning Users
+  /// @throws std::logic_error If the integrator has not been initialized or
+  ///                          boundary_dt is negative.
+  void StepOnceExactly(const T& boundary_dt) {
+    const T inf = std::numeric_limits<T>::infinity();
+    StepOnceAtMost(inf, inf, boundary_dt);
+  }
 
   /**
    * @name Integrator statistics methods.

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -378,7 +378,7 @@ class IntegratorBase {
   void StepOnceExactly(const T& boundary_dt) {
     if (!this->get_fixed_step_mode())
       throw std::logic_error("StepOnceExactly() requires fixed stepping.");
-    const T inf = std::numeric_limits<T>::infinity();
+    const T inf = std::numeric_limits<double>::infinity();
     StepOnceAtMost(inf, inf, boundary_dt);
   }
 

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -365,7 +365,7 @@ class IntegratorBase {
   /// circumstances. This method is designed for integrator
   /// users that do not wish to consider publishing or discontinuous,
   /// mid-interval updates. One such example application is that of direct
-  /// collocation for trajectory optimization. In keeping with the naming
+  /// transcription for trajectory optimization. In keeping with the naming
   /// semantics of this function, error controlled integration is not supported
   /// (though error estimates will be computed for integrators that support that
   /// feature).

--- a/drake/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -197,6 +197,14 @@ GTEST_TEST(IntegratorTest, StepSize) {
     t = context->get_time();
   }
 
+  // The step ends on the simulation end time.
+  {
+    const double boundary_dt = 0.0009;
+    integrator.StepOnceExactly(boundary_dt);
+    EXPECT_EQ(t + boundary_dt, context->get_time());
+    t = context->get_time();
+  }
+
   // The step ends on the simulation end time because it's shortest.
   {
     const double publish_dt = 0.0013;

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -287,6 +287,22 @@ TEST_F(RK3IntegratorTest, SpringMassStepEC) {
   EXPECT_LT(integrator_->get_num_steps_taken(), fixed_steps);
 }
 
+// Verify that attempting to take a single fixed step throws an exception.
+TEST_F(RK3IntegratorTest, IllegalFixedStep) {
+  // Set integrator parameters: do error control.
+  integrator_->set_maximum_step_size(dt);
+  integrator_->set_fixed_step_mode(false);
+
+  // Set accuracy to a really small value so that the step is guaranteed to be
+  // small.
+  integrator_->set_target_accuracy(1e-8);
+
+  // Initialize the integrator.
+  integrator_->Initialize();
+
+  EXPECT_THROW(integrator_->StepOnceExactly(1e-8), std::logic_error);
+}
+
 // Verifies statistics validity for error controlled integrator.
 TEST_F(RK3IntegratorTest, CheckStat) {
   // Set integrator parameters: do error control.


### PR DESCRIPTION
This PR adds a little syntactic sugar for the user who would like to use an integrator outside of the context (not Context) of a simulation and would be confused by the `publish_dt` and `update_dt` parameters to `StepOnceAtMost()`. It adds the `StepOnceExactly()` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4667)
<!-- Reviewable:end -->
