### PR TITLE
replace the name for the decision variables

### DIFF
--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -101,7 +101,7 @@ DecisionVariableVectorX MathematicalProgram::NewContinuousVariables(
     std::size_t rows, const std::string& name) {
   std::vector<std::string> names(rows);
   for (int i = 0; i < static_cast<int>(rows); ++i) {
-    names[i] = name + std::to_string(i);
+    names[i] = name + "(" + std::to_string(i) + ")";
   }
   return NewContinuousVariables(rows, names);
 }
@@ -162,7 +162,7 @@ DecisionVariableVectorX MathematicalProgram::NewBinaryVariables(
     size_t rows, const std::string& name) {
   std::vector<std::string> names = std::vector<std::string>(rows);
   for (int i = 0; i < static_cast<int>(rows); ++i) {
-    names[i] = name + std::to_string(i);
+    names[i] = name + "(" + std::to_string(i) + ")";
   }
   return NewVariables(VarType::BINARY, rows, names);
 }

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -526,7 +526,7 @@ class MathematicalProgram {
     std::array<std::string, rows> names;
     int offset = (name.compare("x") == 0) ? num_vars_ : 0;
     for (int i = 0; i < rows; ++i) {
-      names[i] = name + std::to_string(offset + i);
+      names[i] = name + "(" + std::to_string(offset + i) + ")";
     }
     return NewContinuousVariables<rows>(names);
   }
@@ -587,7 +587,7 @@ class MathematicalProgram {
     std::array<std::string, rows> names;
     int offset = (name.compare("b") == 0) ? num_vars_ : 0;
     for (int i = 0; i < rows; ++i) {
-      names[i] = name + std::to_string(offset + i);
+      names[i] = name + "(" + std::to_string(offset + i) + ")";
     }
     return NewBinaryVariables<rows, 1>(names);
   }

--- a/drake/solvers/test/decision_variable_test.cc
+++ b/drake/solvers/test/decision_variable_test.cc
@@ -77,7 +77,7 @@ GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
                 "should be a dynamic sized matrix");
   std::stringstream msg_buff3;
   msg_buff3 << x1 << std::endl;
-  EXPECT_EQ(msg_buff3.str(), "x0\nx1\nx2\nx3\nx4\nx5\n");
+  EXPECT_EQ(msg_buff3.str(), "x(0)\nx(1)\nx(2)\nx(3)\nx(4)\nx(5)\n");
   EXPECT_EQ(prog.num_vars(), 18u);
   EXPECT_FALSE(math::IsSymmetric(x1));
   std::array<std::string, 6> X_name = {{"X1", "X2", "X3", "X4", "X5", "X6"}};
@@ -93,7 +93,7 @@ GTEST_TEST(TestDecisionVariable, TestDecisionVariableValue) {
   auto b1 = prog.NewBinaryVariables(6, "b1");
   std::stringstream msg_buff5;
   msg_buff5 << b1 << std::endl;
-  EXPECT_EQ(msg_buff5.str(), "b10\nb11\nb12\nb13\nb14\nb15\n");
+  EXPECT_EQ(msg_buff5.str(), "b1(0)\nb1(1)\nb1(2)\nb1(3)\nb1(4)\nb1(5)\n");
 
   Eigen::Matrix<double, 6, 1> x_value;
   x_value << 0, 2, 4, 6, 8, 10;


### PR DESCRIPTION
Previously when calling `NewDecisionVariable` with a `std::string name`, the name for each variable is `name1`, `name2`, `name3`, ..., etc. This causes the problem that in the following code
```C++
auto x1 = prog.NewContinuousDecisionVariable(2, "x1");
auto x = prog.NewContinuousDecisionVariable(11, "x");
```
now both `x(10)` and `x1(0)` have the same name `x10`. This PR changes the name of `x(10)` to be `x(10)`, and `x1(0)`'s name to be `x1(0)`, so that the user can differentiate them when printing out the variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4668)
<!-- Reviewable:end -->
