### PR TITLE
Fix the bug in Binding::WriteThrough

### DIFF
--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1634,16 +1634,17 @@ class MathematicalProgram {
   }
 
   /**
-   * Set the values of the decision variables, bound by the elements in @p
+   * Sets the values of the decision variables, bound by the elements in @p
    * binding.
    * @tparam _Binding should be MathematicalProgram::Binding class
    * @param binding_solution The value of the variables bound in the @p binding.
-   * @param binding
+   * @param binding A binding containing the constraint and bound variables.
+   * The value of the bound variable will be changed by calling this function.
    */
   template <typename _Binding>
-  void SetSolutionFromBinding(
-      const Eigen::Ref<const Eigen::VectorXd>& binding_solution,
-      const _Binding& binding) {
+  void SetDecisionVariableValueFromBinding(
+      const Eigen::Ref<const Eigen::VectorXd> &binding_solution,
+      const _Binding &binding) {
     DRAKE_ASSERT(static_cast<size_t>(binding_solution.rows()) ==
                  binding.GetNumElements());
 

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -169,7 +169,7 @@ SolutionResult MobyLCPSolver::Solve(MathematicalProgram& prog) const {
     if (!solved) {
       return SolutionResult::kUnknownError;
     }
-    prog.SetSolutionFromBinding(constraint_solution, binding);
+    prog.SetDecisionVariableValueFromBinding(constraint_solution, binding);
   }
   return SolutionResult::kSolutionFound;
 }

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -156,7 +156,6 @@ SolutionResult MobyLCPSolver::Solve(MathematicalProgram& prog) const {
   // Ms and qs into the appropriate places.  That would be equivalent to this
   // implementation but might perform better if the solver were to parallelize
   // internally.
-  Eigen::VectorXd solution(prog.num_vars());
 
   // We don't actually indicate different results.
   prog.SetSolverResult(SolverName(), 0);
@@ -170,13 +169,12 @@ SolutionResult MobyLCPSolver::Solve(MathematicalProgram& prog) const {
     if (!solved) {
       return SolutionResult::kUnknownError;
     }
-    binding.WriteThrough(constraint_solution, prog, &solution);
+    prog.SetSolutionFromBinding(constraint_solution, binding);
   }
-  prog.SetDecisionVariableValues(solution);
   return SolutionResult::kSolutionFound;
 }
 
-/// Fast pivoting algorithm for denerate, monotone LCPs with few nonzero,
+/// Fast pivoting algorithm for degenerate, monotone LCPs with few nonzero,
 /// nonbasic variables
 bool MobyLCPSolver::SolveLcpFast(const Eigen::MatrixXd& M,
                                  const Eigen::VectorXd& q, Eigen::VectorXd* z,

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -112,7 +112,7 @@ void RunNonlinearProgram(MathematicalProgram& prog,
 }
 
 GTEST_TEST(testMathematicalProgram, SetSolutionFromBindingTest) {
-  // Test if SetDecisionVariableValueFromBinding sets correct solution.
+  // Test if SetDecisionVariableValueFromBinding sets the correct solution.
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
   auto y = prog.NewContinuousVariables<3>("y");

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -112,7 +112,7 @@ void RunNonlinearProgram(MathematicalProgram& prog,
 }
 
 GTEST_TEST(testMathematicalProgram, SetSolutionFromBindingTest) {
-  // Test if SetSolutionFromBinding sets the solution correctly.
+  // Test if SetDecisionVariableValueFromBinding sets correct solution.
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
   auto y = prog.NewContinuousVariables<3>("y");
@@ -131,9 +131,10 @@ GTEST_TEST(testMathematicalProgram, SetSolutionFromBindingTest) {
 
   Eigen::Vector2d x_expected(0.1, 0.3);
   Eigen::Vector3d y_expected(0.2, 0.7, -1);
-  prog.SetSolutionFromBinding(Eigen::Vector2d(x_expected(0), y_expected(1)),
-                              prog.bounding_box_constraints().front());
-  prog.SetSolutionFromBinding(
+  prog.SetDecisionVariableValueFromBinding(
+      Eigen::Vector2d(x_expected(0), y_expected(1)),
+      prog.bounding_box_constraints().front());
+  prog.SetDecisionVariableValueFromBinding(
       Eigen::Vector3d(y_expected(2), y_expected(0), x_expected(1)),
       prog.linear_equality_constraints().front());
 

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -119,11 +119,15 @@ GTEST_TEST(testMathematicalProgram, SetSolutionFromBindingTest) {
 
   // TODO(hongkai.dai): rewrite this test when Binding class is moved out from
   // MathematicalProgram class
+  // Tests when the bounded variables in each Binding object are not contiguous
+  // variables in MathematicalProgram.
+  DecisionVariableVector<2> var1;
+  var1 << x(0), y(1);
   prog.AddBoundingBoxConstraint(Eigen::Vector2d(0, 0), Eigen::Vector2d(1, 1),
-                                {x.segment<1>(0), y.segment<1>(1)});
-  prog.AddLinearEqualityConstraint(
-      Eigen::RowVector3d(1, 2, 3), 1,
-      {y.segment<1>(2), y.segment<1>(0), x.segment<1>(1)});
+                                {var1});
+  DecisionVariableVector<3> var2;
+  var2 << y(2), y(0), x(1);
+  prog.AddLinearEqualityConstraint(Eigen::RowVector3d(1, 2, 3), 1, {var2});
 
   Eigen::Vector2d x_expected(0.1, 0.3);
   Eigen::Vector3d y_expected(0.2, 0.7, -1);


### PR DESCRIPTION
`Binding::WriteThrough` function has a bug, that it still supposes the decision variable indices are contiguous; I forgot to change the code in my previous PR.

Also  `Binding::WriteThrough` needs `MathematicalProgram` as its input argument. But `Binding` class will be used in cases other than `MathematicalProgram`, for example, in Russ' "Requirement" class. So I moved this method inside `MathematicalProgram` class instead, and add its test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4669)
<!-- Reviewable:end -->
