### PR TITLE
Add integrated cpplint checking

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,6 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+exports_files([
+    "CPPLINT.cfg",
+])

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,13 @@ git_repository(
 )
 
 new_git_repository(
+    name = "google_styleguide",
+    remote = "https://github.com/google/styleguide.git",
+    commit = "159b4c81bbca97a9ca00f1195a37174388398a67",
+    build_file = "tools/google_styleguide.BUILD",
+)
+
+new_git_repository(
     name = "eigen",
     remote = "https://github.com/RobotLocomotion/eigen-mirror.git",
     commit = "d3ee2bc648be3d8be8c596a9a0aefef656ff8637",

--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -257,3 +258,5 @@ cc_googletest(
         "//drake/automotive:generated_translators",
     ],
 )
+
+cpplint()

--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -21,3 +23,5 @@ cc_library(
         "//drake/common",
     ],
 )
+
+cpplint()

--- a/drake/automotive/maliput/monolane/BUILD
+++ b/drake/automotive/maliput/monolane/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -120,3 +122,5 @@ py_test(
         ":yamls",
     ],
 )
+
+cpplint()

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -428,3 +429,5 @@ cc_googletest(
 # - text_logging_test in fancy variants
 # - drake_deprecated_test in fancy variants
 # - cpplint_wrapper_test.py
+
+cpplint()

--- a/drake/common/trajectories/BUILD
+++ b/drake/common/trajectories/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -132,3 +133,5 @@ cc_googletest(
         "//drake/util",
     ],
 )
+
+cpplint()

--- a/drake/common/trajectories/qp_spline/BUILD
+++ b/drake/common/trajectories/qp_spline/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -56,3 +57,5 @@ cc_googletest(
         ":spline_generation",
     ],
 )
+
+cpplint()

--- a/drake/doc/code_style_tools.rst
+++ b/drake/doc/code_style_tools.rst
@@ -45,7 +45,7 @@ You can check whether you've installed it correctly by executing::
     clang-format --help
 
 Usage
-^^^^^^^^^
+^^^^^
 
 To run clang-format::
 
@@ -54,11 +54,28 @@ To run clang-format::
 cpplint
 -------
 
-Usage
-^^^^^
-
 `cpplint <https://github.com/google/styleguide/tree/gh-pages/cpplint>`_
-is a tool for finding compliance violations. Here is the command::
+is a tool for finding compliance violations.
+
+Using via Bazel
+^^^^^^^^^^^^^^^
+
+When using the Bazel build system, cpplint is run by default during ``bazel
+test`` and its results are cached so that only edited files are re-checked.
+In other words, no special action is required to use the tool.
+However, you may still invoke cpplint directly if desired, as follows::
+
+  cd /path/to/drake-distro
+  bazel test --config cpplint ...                  # Only run cpplint; don't build or test anything else.
+  bazel test --config cpplint //drake/common/...   # Check common/ and its child subdirectories.
+
+  cd drake/systems/framework
+  bazel test --config cpplint ...                  # Check systems/framework/ and its child subdirectories.
+
+Using without Bazel
+^^^^^^^^^^^^^^^^^^^
+
+Here is the command::
 
     drake-distro/drake/common/test/cpplint_wrapper.py
 

--- a/drake/examples/Atlas/BUILD
+++ b/drake/examples/Atlas/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -12,3 +14,5 @@ filegroup(
         "**/*.xml",
     ]),
 )
+
+cpplint()

--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -1,3 +1,8 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:cpplint.bzl", "cpplint")
+
 cc_library(
     name = "control_utils",
     srcs = [],
@@ -55,7 +60,8 @@ cc_library(
     ],
 )
 
-#test/
+# === test/ ===
+
 cc_test(
     name = "valkyrie_balancing_test",
     srcs = ["test/valkyrie_balancing_test.cc"],
@@ -76,3 +82,5 @@ cc_test(
         "@gtest//:main",
     ],
 )
+
+cpplint()

--- a/drake/examples/SimpleFourBar/BUILD
+++ b/drake/examples/SimpleFourBar/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -12,3 +14,5 @@ filegroup(
         "**/*.xml",
     ]),
 )
+
+cpplint()

--- a/drake/examples/Valkyrie/BUILD
+++ b/drake/examples/Valkyrie/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -13,3 +15,5 @@ filegroup(
         "**/*.xml",
     ]),
 )
+
+cpplint()

--- a/drake/examples/bouncing_ball/BUILD
+++ b/drake/examples/bouncing_ball/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -49,3 +50,5 @@ cc_googletest(
         "//drake/systems/analysis",
     ],
 )
+
+cpplint()

--- a/drake/examples/kuka_iiwa_arm/BUILD
+++ b/drake/examples/kuka_iiwa_arm/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -12,3 +14,5 @@ filegroup(
         "**/*.xml",
     ]),
 )
+
+cpplint()

--- a/drake/lcm/BUILD
+++ b/drake/lcm/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -104,3 +105,5 @@ cc_googletest(
         ":lcmt_drake_signal_utils",
     ],
 )
+
+cpplint()

--- a/drake/math/BUILD
+++ b/drake/math/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -197,3 +198,5 @@ cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+cpplint()

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -195,3 +196,7 @@ filegroup(
         "test/**/*.xml",
     ]),
 )
+
+cpplint(data = [
+    "constraint/CPPLINT.cfg",
+])

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -112,3 +113,5 @@ filegroup(
         "test/**/*.xml",
     ]),
 )
+
+cpplint()

--- a/drake/multibody/joints/BUILD
+++ b/drake/multibody/joints/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -44,3 +45,5 @@ cc_googletest(
         ":joints",
     ],
 )
+
+cpplint()

--- a/drake/multibody/parsers/BUILD
+++ b/drake/multibody/parsers/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -116,3 +117,5 @@ filegroup(
         "test/**/*.xml",
     ]),
 )
+
+cpplint()

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -142,3 +143,5 @@ filegroup(
         "test/**/*.xml",
     ]),
 )
+
+cpplint()

--- a/drake/multibody/shapes/BUILD
+++ b/drake/multibody/shapes/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -22,3 +24,5 @@ cc_library(
         "//drake/thirdParty:spruce",
     ],
 )
+
+cpplint()

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -249,3 +250,11 @@ cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+# The extra_srcs are required here because cpplint() doesn't understand how to
+# extract labels from select() functions yet.
+cpplint(extra_srcs = [
+    "gurobi_solver.cc",
+    "gurobi_solver.h",
+    "no_gurobi.cc",
+])

--- a/drake/systems/analysis/BUILD
+++ b/drake/systems/analysis/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -124,3 +125,5 @@ cc_googletest(
         "//drake/multibody/rigid_body_plant",
     ],
 )
+
+cpplint()

--- a/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -29,3 +30,5 @@ cc_googletest(
         ":controlled_spring_mass_system",
     ],
 )
+
+cpplint()

--- a/drake/systems/controllers/BUILD
+++ b/drake/systems/controllers/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -94,3 +95,5 @@ cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+cpplint()

--- a/drake/systems/estimators/BUILD
+++ b/drake/systems/estimators/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -46,3 +47,5 @@ cc_googletest(
         "//drake/systems/primitives:linear_system",
     ],
 )
+
+cpplint()

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -457,3 +458,5 @@ cc_googletest(
         "//drake/common",
     ],
 )
+
+cpplint()

--- a/drake/systems/framework/test_utilities/BUILD
+++ b/drake/systems/framework/test_utilities/BUILD
@@ -1,6 +1,8 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -24,3 +26,5 @@ cc_library(
         "//drake/systems/framework:value",
     ],
 )
+
+cpplint()

--- a/drake/systems/lcm/BUILD
+++ b/drake/systems/lcm/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -94,3 +95,5 @@ cc_googletest(
         "//drake/lcm:mock",
     ],
 )
+
+cpplint()

--- a/drake/systems/plants/spring_mass_system/BUILD
+++ b/drake/systems/plants/spring_mass_system/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -24,3 +25,5 @@ cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+cpplint()

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -333,3 +334,5 @@ cc_googletest(
         "//drake/systems/framework",
     ],
 )
+
+cpplint()

--- a/drake/systems/robotInterfaces/BUILD
+++ b/drake/systems/robotInterfaces/BUILD
@@ -1,3 +1,8 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:cpplint.bzl", "cpplint")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -7,3 +12,5 @@ cc_library(
     linkstatic = 1,
     deps = [],
 )
+
+cpplint()

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -59,3 +60,5 @@ cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+cpplint()

--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
@@ -46,3 +47,5 @@ cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+cpplint()

--- a/drake/util/BUILD
+++ b/drake/util/BUILD
@@ -1,4 +1,7 @@
 # -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -19,3 +22,5 @@ cc_library(
         "//drake/math:gradient",
     ],
 )
+
+cpplint()

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -42,6 +42,13 @@ build:everything --define=WITH_GUROBI=ON
 test:everything --test_env=HOME
 test:everything --test_env=GRB_LICENSE_FILE
 
+### Cpplint. ###
+# By default, cpplint tests are run as part of `bazel test` alongside all of
+# the other compilation and test targets.  This is a convenience shortcut to
+# only do the cpplint testing and nothing else.
+test:cpplint --build_tests_only
+test:cpplint --test_tag_filters=cpplint
+
 ### Clang. ###
 build:clang --compiler=clang-3.9
 build:clang --crosstool_top=//tools:default-toolchain

--- a/tools/cpplint.bzl
+++ b/tools/cpplint.bzl
@@ -1,0 +1,115 @@
+# -*- python -*-
+
+# From https://bazel.build/versions/master/docs/be/c-cpp.html#cc_library.srcs
+_SOURCE_EXTENSIONS = [source_ext for source_ext in """
+.c
+.cc
+.cpp
+.cxx
+.c++.C
+.h
+.hh
+.hpp
+.hxx
+.inc
+""".split("\n") if len(source_ext)]
+
+# The cpplint.py command-line argument so it doesn't skip our files!
+_EXTENSIONS_ARGS = ["--extensions=" + ",".join([
+  ext[1:] for ext in _SOURCE_EXTENSIONS]
+)]
+
+# From https://bazel.build/versions/master/docs/be/c-cpp.html#cc_library.srcs
+_NON_SOURCE_EXTENSIONS = [non_source_ext for non_source_ext in """
+.S
+.a
+.lo
+.o
+.pic.a
+.pic.lo
+.pic.o
+.so
+""".split("\n") if len(non_source_ext)]
+
+def _extract_labels(srcs):
+  """Convert a srcs= or hdrs= value to its set of labels."""
+  # Tuples are already labels.
+  if type(srcs) == type(()):
+    return list(srcs)
+  # The select() syntax returns an object we (apparently) can't inspect.
+  # TODO(jwnimmer-tri) Figure out how to cpplint these files.  For now,
+  # folks will have to pass extra_srcs when calling cpplint() macro.
+  return []
+
+def _is_source_label(label):
+  for extention in _SOURCE_EXTENSIONS:
+      if label.endswith(extention):
+        return True
+  for extention in _NON_SOURCE_EXTENSIONS:
+      if label.endswith(extention):
+        return False
+  fail("Unknown extension for source " + label)
+
+def cpplint(data=None, extra_srcs=None):
+  """For every C++ rule in the BUILD file so far, adds a test rule that runs
+  cpplint over the C++ sources listed in that rule.  Thus, BUILD file authors
+  should call this function at the *end* of every C++-related BUILD file.
+
+  By default, only the CPPLINT.cfg from the project root and the current
+  directory are used.  Additional configs can be passed in as data labels.
+
+  Sources that are not discoverable through the "sources so far" heuristic can
+  be passed in as extra_srcs=[].
+
+  """
+  # Common attributes for all of our py_test invocations.
+  srcs = ["@google_styleguide//:cpplint"]
+  data = ["//:CPPLINT.cfg"] + native.glob(['CPPLINT.cfg']) + (data or [])
+  main = "cpplint.py"
+  size = "small"
+  tags = ["cpplint"]
+
+  # Iterate over all C++ rules.
+  for rule in native.existing_rules().values():
+    if not rule["kind"].startswith("cc_"):
+      continue
+
+    # Extract the list of source code labels and convert to filenames.
+    candidate_labels = (
+      _extract_labels(rule.get("srcs", ())) +
+      _extract_labels(rule.get("hdrs", ()))
+    )
+    source_labels = [
+      label for label in candidate_labels
+      if _is_source_label(label)
+    ]
+    if len(source_labels) == 0:
+      if len(candidate_labels) == 0:
+        continue
+      fail("No sources found in " + rule["name"])
+    source_filenames = ["$(location %s)" % x for x in source_labels]
+
+    # Run the cpplint checker as a unit test.
+    native.py_test(
+      name = rule["name"] + "_cpplint",
+      srcs = srcs,
+      data = data + source_labels,
+      args = _EXTENSIONS_ARGS + source_filenames,
+      main = main,
+      size = size,
+      tags = tags,
+    )
+
+  # Lint all of the extra_srcs separately in a single rule.
+  if extra_srcs:
+    source_labels = extra_srcs
+    source_filenames = ["$(location %s)" % x for x in source_labels]
+    native.py_test(
+      name = "extra_srcs_cpplint",
+      srcs = srcs,
+      data = data + source_labels,
+      args = _EXTENSIONS_ARGS + source_filenames,
+      main = main,
+      size = size,
+      tags = tags,
+    )

--- a/tools/dev/check_missing_sources.sh
+++ b/tools/dev/check_missing_sources.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+# Files in git.
+git ls-files |
+    egrep '\.(h|cc)$' |
+    sort > /tmp/git_files.txt
+
+# Files covered by cc_ something.
+bazel query 'kind("source file", deps(kind("cc_.* rule", //...)))' |
+    grep -v '^@' | grep -v '^//externals' | grep -v '/thirdParty' |
+    egrep '\.(h|cc)$' |
+    perl -pe 's#^//:?##g; s#:#/#g;' |
+    sort > /tmp/cc_files.txt
+
+# Files covered by cpplint.
+bazel query 'kind("source file", deps(attr(tags, cpplint, tests(//...))))' |
+    grep -v '^@' | grep -v '^//externals' | grep -v '/thirdParty' |
+    egrep '\.(h|cc)$' |
+    perl -pe 's#^//:?##g; s#:#/#g;'|
+    sort > /tmp/cpplint_files.txt
+
+echo "Files missed by cpplint() in BUILD files ..."
+diff -u /tmp/cc_files.txt /tmp/cpplint_files.txt
+echo
+
+echo "Files unknown to Bazel ..."
+diff -u /tmp/git_files.txt /tmp/cc_files.txt

--- a/tools/google_styleguide.BUILD
+++ b/tools/google_styleguide.BUILD
@@ -1,0 +1,28 @@
+# -*- python -*-
+
+package(default_visibility = ["//visibility:public"])
+
+# We can't set name="cpplint" here because that's the directory name so the
+# sandbox gets confused.  We'll give it a private name with a public alias.
+py_binary(
+    name = "cpplint_binary",
+    srcs = ["cpplint/cpplint.py"],
+    imports = ["cpplint"],
+    main = "cpplint/cpplint.py",
+    visibility = [],
+)
+
+alias(
+    name = "cpplint",
+    actual = ":cpplint_binary",
+)
+
+py_test(
+    name = "cpplint_unittest",
+    size = "small",
+    srcs = ["cpplint/cpplint_unittest.py"],
+    data = ["cpplint/cpplint_test_header.h"],
+    deps = [
+        ":cpplint_py",
+    ],
+)


### PR DESCRIPTION
By default, `bazel test` will run cpplint on the labels that matched, which is most always the thing you want.  Check the `drake/doc/` updates for details.  Results are cached, hermetic, etc.  Basically you get to ignore it until it yells at you.  You don't have to opt-in or wait for CI to notice.

The cpplint checks have `tags=["cpplint"]` so they can be filtered in or out, and there's sugar to run only cpplint:
```
jwnimmer@call-cc:~/jwnimmer-tri/drake-distro$ bazel test --config cpplint ... | tail
...
INFO: Elapsed time: 0.330s, Critical Path: 0.00s
INFO: Build completed successfully, 1 total action
//drake/systems/primitives:zero_order_hold_test_cpplint         (cached) PASSED in 0.1s
//drake/systems/robotInterfaces:side_cpplint                    (cached) PASSED in 0.2s
//drake/systems/sensors:rotary_encoders_cpplint                 (cached) PASSED in 0.1s
//drake/systems/sensors:rotary_encoders_test_cpplint            (cached) PASSED in 0.1s
//drake/util:util_cpplint                                       (cached) PASSED in 0.1s

Executed 0 out of 288 tests: 288 tests pass.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4670)
<!-- Reviewable:end -->
