### PR TITLE
Updates SpringMassSystem to override AllocateOutputVector instead of AllocateOutput.

### DIFF
--- a/drake/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -127,16 +127,9 @@ T SpringMassSystem<T>::DoCalcNonConservativePower(const MyContext&) const {
 }
 
 template <typename T>
-std::unique_ptr<SystemOutput<T>> SpringMassSystem<T>::AllocateOutput(
-    const Context<T>& context) const {
-  std::unique_ptr<LeafSystemOutput<T>> output(
-      new LeafSystemOutput<T>);
-  {
-    std::unique_ptr<BasicVector<T>> data(new SpringMassStateVector<T>());
-    std::unique_ptr<OutputPort> port(new OutputPort(std::move(data)));
-    output->get_mutable_ports()->push_back(std::move(port));
-  }
-  return std::unique_ptr<SystemOutput<T>>(output.release());
+std::unique_ptr<BasicVector<T>> SpringMassSystem<T>::AllocateOutputVector(
+    const OutputPortDescriptor<T>& descriptor) const {
+  return std::make_unique<SpringMassStateVector<T>>();
 }
 
 template <typename T>

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.h
@@ -201,9 +201,9 @@ class SpringMassSystem : public LeafSystem<T> {
   T DoCalcNonConservativePower(const MyContext& context) const override;
 
   // System<T> overrides.
-  /// Allocates a single output port of type SpringMassStateVector<T>.
-  std::unique_ptr<MyOutput> AllocateOutput(
-      const MyContext& context) const override;
+  /// Allocates an output vector of type SpringMassStateVector<T>.
+  std::unique_ptr<BasicVector<T>> AllocateOutputVector(
+      const OutputPortDescriptor<T>& descriptor) const override;
 
   void DoCalcOutput(const MyContext& context, MyOutput* output) const override;
 


### PR DESCRIPTION
Might as well make use of the API sugar now that it exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4674)
<!-- Reviewable:end -->
