### PR TITLE
Update libbot, use new repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/mwoehlke-kitware/bot_core_lcmtypes
 [submodule "externals/libbot"]
 	path = externals/libbot
-	url = https://github.com/RobotLocomotion/libbot.git
+	url = https://github.com/RobotLocomotion/libbot2.git
 [submodule "externals/spotless"]
 	path = externals/spotless
 	url = https://github.com/RobotLocomotion/spotless-pod.git


### PR DESCRIPTION
Update libbot to bring in RobotLocomotion/libbot2#2, which fixes the last remaining bits of #3231. This also switches us to the new repository which shares history with upstream. (The old repository was separately copied from the old subversion repository, and had the same content but not the same SHA's.)

Fixes #3231.

@david-german-tri for feature and platform review (due to having reviewed the libbot PR).

Note: the old submodule SHA (RobotLocomotion/libbot@6d932c813e6e) corresponds to RobotLocomotion/libbot2@807d17220dc6. The effective changes can be seen [here](https://github.com/RobotLocomotion/libbot2/compare/807d17220dc6a51fc0125e2836dac301d1d2f36f...495ae366d5e380b58254368217fc5c798e72aadd).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4680)
<!-- Reviewable:end -->
