### PR TITLE
Add support for lcm-java, lcm-spy, and custom lcm_structs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,6 +52,12 @@ new_git_repository(
     build_file = "tools/spdlog.BUILD",
 )
 
+maven_jar(
+    name = "net_sf_jchart2d_jchart2d",
+    artifact = "net.sf.jchart2d:jchart2d:3.3.2",
+    sha1 = "4950821eefe4c204903e68b4d45a558b5ebdd6fa",
+)
+
 new_git_repository(
     name = "lcm",
     remote = "https://github.com/lcm-proj/lcm.git",

--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -181,7 +181,7 @@ py_binary(
     srcs = ["steering_command_driver.py"],
     deps = [
         ":drake_paths",
-        "//drake/lcmtypes:py_automotive",
+        "//drake/lcmtypes:automotive-py",
         "@lcm//:lcm-python",
     ],
 )

--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")
+load("//tools:lcm.bzl", "lcm_cc_library", "lcm_java_library", "lcm_py_library")
 
 lcm_cc_library(
     name = "drake_signal",
@@ -13,45 +13,56 @@ lcm_cc_library(
 )
 
 lcm_py_library(
-    name = "py_drake_signal",
+    name = "drake_signal-py",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_drake_signal.lcm"],
 )
 
+_VIEWER_LCM_SRCS = [
+    "lcmt_viewer_command.lcm",
+    "lcmt_viewer_draw.lcm",
+    "lcmt_viewer_geometry_data.lcm",
+    "lcmt_viewer_link_data.lcm",
+    "lcmt_viewer_load_robot.lcm",
+]
+
 lcm_cc_library(
     name = "viewer",
     lcm_package = "drake",
-    lcm_srcs = [
-        "lcmt_viewer_command.lcm",
-        "lcmt_viewer_draw.lcm",
-        "lcmt_viewer_geometry_data.lcm",
-        "lcmt_viewer_link_data.lcm",
-        "lcmt_viewer_load_robot.lcm",
-    ],
+    lcm_srcs = _VIEWER_LCM_SRCS,
     linkstatic = 1,
 )
+
+lcm_java_library(
+    name = "viewer-java",
+    lcm_package = "drake",
+    lcm_srcs = _VIEWER_LCM_SRCS,
+)
+
+_AUTOMOTIVE_LCM_SRCS = [
+    "lcmt_driving_command_t.lcm",
+    "lcmt_euler_floating_joint_state_t.lcm",
+    "lcmt_simple_car_config_t.lcm",
+    "lcmt_simple_car_state_t.lcm",
+]
 
 lcm_cc_library(
     name = "automotive",
     lcm_package = "drake",
-    lcm_srcs = [
-        "lcmt_driving_command_t.lcm",
-        "lcmt_euler_floating_joint_state_t.lcm",
-        "lcmt_simple_car_config_t.lcm",
-        "lcmt_simple_car_state_t.lcm",
-    ],
+    lcm_srcs = _AUTOMOTIVE_LCM_SRCS,
     linkstatic = 1,
 )
 
-lcm_py_library(
-    name = "py_automotive",
+lcm_java_library(
+    name = "automotive-java",
     lcm_package = "drake",
-    lcm_srcs = [
-        "lcmt_driving_command_t.lcm",
-        "lcmt_euler_floating_joint_state_t.lcm",
-        "lcmt_simple_car_config_t.lcm",
-        "lcmt_simple_car_state_t.lcm",
-    ],
+    lcm_srcs = _AUTOMOTIVE_LCM_SRCS,
+)
+
+lcm_py_library(
+    name = "automotive-py",
+    lcm_package = "drake",
+    lcm_srcs = _AUTOMOTIVE_LCM_SRCS,
 )
 
 lcm_cc_library(

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -90,7 +90,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "lcmgen",
+    name = "lcm-gen",
     srcs = [
         "lcmgen/emit_c.c",
         "lcmgen/emit_cpp.c",
@@ -159,4 +159,29 @@ py_library(
         "lcm-python/lcm/__init__.py",  # Actual code from upstream.
     ],
     data = [":_lcm.so"],
+)
+
+java_library(
+    name = "lcm-java",
+    srcs = glob(["lcm-java/lcm/**/*.java"]),
+    javacopts = [
+        # Suppressed until lcm-proj/lcm#159 is fixed.
+        "-extra_checks:off",
+    ],
+    deps = [
+        "@net_sf_jchart2d_jchart2d//jar",
+    ],
+)
+
+java_binary(
+    name = "lcm-spy",
+    jvm_flags = [
+        # These flags are copied from the lcm/lcm-java/lcm-spy.sh.in.
+        "-Djava.net.preferIPv4Stack=true",
+        "-ea",
+    ],
+    main_class = "lcm.spy.Spy",
+    runtime_deps = [
+        ":lcm-java",
+    ],
 )

--- a/tools/lcm.bzl
+++ b/tools/lcm.bzl
@@ -1,26 +1,39 @@
 # -*- python -*-
 
-def _lcm_srcs_to_outs(lcm_package, lcm_srcs, extension):
-    """Return the list of filenames (prefixed by the package directory and
-    switched to a new extension), based on the lcm_package= and lcm_srcs=
-    parameters (see lcm_cc_library below for a description of what those
-    parameters mean).
+def _lcm_outs(lcm_srcs, lcm_package, lcm_structs, extension):
+    """Return the list of lcm-gen output filenames (derived from the lcm_srcs,
+    lcm_package, and lcm_struct parameters as documented in lcm_cc_library
+    below).  The filenames will use the given extension.
+
     """
-    result = []
+    # Find and remove the dirname and extension shared by all lcm_srcs.
+    # For srcs in the current directory, the dirname will be empty.
+    basename_start_index = lcm_srcs[0].rfind("/") + 1
+    dirname = lcm_srcs[0][:basename_start_index]
+    lcm_basenames = []
     for item in lcm_srcs:
-        if not item.endswith(".lcm"):
-            fail(item + " does not end with .lcm")
-        result.append(lcm_package + "/" + item[:-len(".lcm")] + extension)
-    return result
+        if not item[:item.rfind("/") + 1] == dirname:
+            fail(item + " doesn't share a dirname with " + lcm_srcs[0])
+        basename_with_ext = item[basename_start_index:]
+        if not basename_with_ext.endswith(".lcm"):
+            fail(item + " doesn't end with .lcm")
+        basename = basename_with_ext[:-len(".lcm")]
+        lcm_basenames.append(basename)
+
+    # Assemble the expected output paths, inferring struct names from what we
+    # got in lcm_srcs, if necessary.
+    return [
+        dirname + lcm_package + "/" + lcm_struct + extension
+        for lcm_struct in (lcm_structs or lcm_basenames)]
 
 def _lcmgen_impl(ctx):
-    """The implementation actions to invoke lcmgen.
+    """The implementation actions to invoke lcm-gen.
 
     The ctx parameter comes from Skylark:
     https://bazel.build/versions/master/docs/skylark/lib/ctx.html
     """
     # We are given ctx.outputs.outs, which is the full path and file name of
-    # the generated file we want to create.  However, the lcmgen tool places
+    # the generated file we want to create.  However, the lcm-gen tool places
     # its outputs into a subdirectory of the path we ask for, based on the LCM
     # message's package name.  To set the correct path, we need to both remove
     # the filename from outs (which we do via ".dirname"), as well as the
@@ -33,6 +46,8 @@ def _lcmgen_impl(ctx):
             arguments = ["--cpp", "--cpp-std=c++11", "--cpp-hpath=" + outpath]
         elif ctx.attr.language == "py":
             arguments = ["--python", "--ppath=" + outpath]
+        elif ctx.attr.language == "java":
+            arguments = ["--java", "--jpath=" + outpath]
         else:
             fail("Unknown language")
         ctx.action(
@@ -43,16 +58,16 @@ def _lcmgen_impl(ctx):
             )
     return struct()
 
-# Create rule to invoke lcmgen on some lcm_srcs.
+# Create rule to invoke lcm-gen on some lcm_srcs.
 # https://www.bazel.io/versions/master/docs/skylark/rules.html
 _lcm_library_gen = rule(
     attrs = {
-        "lcm_package": attr.string(),
         "lcm_srcs": attr.label_list(allow_files = True),
+        "lcm_package": attr.string(),
         "lcmgen": attr.label(
             cfg = "host",
             executable = True,
-            default = Label("@lcm//:lcmgen"),
+            default = Label("@lcm//:lcm-gen"),
         ),
         "outs": attr.output_list(),
         "language": attr.string(),
@@ -63,42 +78,40 @@ _lcm_library_gen = rule(
 
 def lcm_cc_library(
         name,
-        lcm_package=None,
         lcm_srcs=None,
-        includes=None,
-        deps=None,
+        lcm_package=None,
+        lcm_structs=None,
         **kwargs):
-    """Declares a cc_library target based on C++ message classes generated from
-    `*.lcm` files.  The lcm_srcs= list parameter specifies the `*.lcm` sources.
-    The lcm_package= string parameter must match the `package ...;` statement
-    in all of the `*.lcm` files in lcm_srcs.  The Bazel-standard includes= and
-    deps= parameters are passed through to cc_library after adding the items
-    required by the generated code.
+    """Declares a cc_library on message classes generated from `*.lcm` files.
+
+    The required lcm_srcs list parameter specifies the `*.lcm` source files.
+    All lcm_srcs must reside in the same subdirectory.
+
+    The required lcm_package string parameter must match the `package ...;`
+    statement in all of the files in lcm_srcs.
+
+    The lcm_structs list parameter is optional; if unset, it defaults to the
+    basenames of the files given in lcm_srcs.  If the struct names within the
+    lcm_srcs do not match the basenames, or if the lcm_srcs declare multiple
+    structs per file, then the parameter is required and must list every
+    `struct ...;` declared by lcm_srcs.
 
     """
-    if lcm_package == None:
-        fail("lcm_package must be provided")
     if not lcm_srcs:
-        fail("lcm_srcs must be provided")
+        fail("lcm_srcs is required")
+    if not lcm_package:
+        fail("lcm_package is required")
 
-    outs = _lcm_srcs_to_outs(lcm_package, lcm_srcs, ".hpp")
+    outs = _lcm_outs(lcm_srcs, lcm_package, lcm_structs, ".hpp")
     _lcm_library_gen(
         name=name + "_lcm_library_gen",
         language="cc",
-        lcm_package=lcm_package,
         lcm_srcs=lcm_srcs,
+        lcm_package=lcm_package,
         outs=outs)
 
-    newdep = "@lcm//:lcm"
-    deps = list(deps or [])
-    if newdep not in deps:
-        deps.append(newdep)
-
-    newinclude = "."
-    includes = list(includes or [])
-    if newinclude not in includes:
-        includes.append(newinclude)
-
+    deps = set(kwargs.pop('deps', [])) | ["@lcm//:lcm"]
+    includes = set(kwargs.pop('includes', [])) | ["."]
     native.cc_library(
         name=name,
         hdrs=outs,
@@ -108,38 +121,64 @@ def lcm_cc_library(
 
 def lcm_py_library(
         name,
-        lcm_package=None,
         lcm_srcs=None,
-        imports=None,
+        lcm_package=None,
+        lcm_structs=None,
         **kwargs):
-    """Declares a py_library target based on python message classes generated
-    from `*.lcm` files.  The lcm_src= list parameter specifies the `*.lcm`
-    sources.  The lcm_package= string parameter must match the `package ...;`
-    statement in all of the `*.lcm` files in lcm_srcs.  The Bazel-standard
-    imports= parameter is passed through to py_library after adding the items
-    required by the generated code.
+    """Declares a py_library on message classes generated from `*.lcm` files.
+
+    The standard parameters (lcm_srcs, lcm_package, lcm_structs) are documented
+    in lcm_cc_library.
 
     """
-    if lcm_package == None:
-        fail("lcm_package must be provided")
     if not lcm_srcs:
-        fail("lcm_srcs must be provided")
+        fail("lcm_srcs is required")
+    if not lcm_package:
+        fail("lcm_package is required")
 
-    outs = _lcm_srcs_to_outs(lcm_package, lcm_srcs, ".py")
+    outs = _lcm_outs(lcm_srcs, lcm_package, lcm_structs, ".py")
     _lcm_library_gen(
         name=name + "_lcm_library_gen",
         language="py",
-        lcm_package=lcm_package,
         lcm_srcs=lcm_srcs,
+        lcm_package=lcm_package,
         outs=outs)
 
-    newimport = "."
-    imports = list(imports or [])
-    if newimport not in imports:
-        imports.append(newimport)
-
+    imports = set(kwargs.pop('imports', [])) | ["."]
     native.py_library(
         name=name,
         srcs=outs,
         imports=imports,
+        **kwargs)
+
+def lcm_java_library(
+        name,
+        lcm_srcs=None,
+        lcm_package=None,
+        lcm_structs=None,
+        **kwargs):
+    """Declares a java_library on message classes generated from `*.lcm` files.
+
+    The standard parameters (lcm_srcs, lcm_package, lcm_structs) are documented
+    in lcm_cc_library.
+
+    """
+    if not lcm_srcs:
+        fail("lcm_srcs is required")
+    if not lcm_package:
+        fail("lcm_package is required")
+
+    outs = _lcm_outs(lcm_srcs, lcm_package, lcm_structs, ".java")
+    _lcm_library_gen(
+        name=name + "_lcm_library_gen",
+        language="java",
+        lcm_srcs=lcm_srcs,
+        lcm_package=lcm_package,
+        outs=outs)
+
+    deps = set(kwargs.pop('deps', [])) | ["@lcm//:lcm-java"]
+    native.java_library(
+        name=name,
+        srcs=outs,
+        deps=deps,
         **kwargs)


### PR DESCRIPTION
This is a checkpoint of working, incremental progress, and I think will meet the need for quite a while. Down the road, the lcm_foo_library calls in particular could be done more elegantly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4684)
<!-- Reviewable:end -->
