### PR TITLE
Correct mac clang warning about shadows for PR 4554

### DIFF
--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1315,10 +1315,10 @@ class RigidBodyTree {
  private:
   // Utility class for storing body collision data during RBT instantiation.
   struct BodyCollisionItem {
-    BodyCollisionItem(const std::string& group_name,
-                      size_t element) {
-      this->group_name = group_name;
-      this->element = element;
+    BodyCollisionItem(const std::string& grp_name,
+                      size_t element_index) {
+      group_name = grp_name;
+      element = element_index;
     }
     std::string group_name;
     size_t element;


### PR DESCRIPTION
This makes sure the constructor paramters are *not* the same as the
struct members.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4690)
<!-- Reviewable:end -->
