### PR TITLE
Modify path of tet.obj

### DIFF
--- a/drake/multibody/test/rigid_body_tree/contact_points_generation.urdf
+++ b/drake/multibody/test/rigid_body_tree/contact_points_generation.urdf
@@ -54,7 +54,7 @@
       <!-- This should *not* generate a contact points. -->
       <origin xyz="0 0 5" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="/tet.obj"/>
+        <mesh filename="tet.obj"/>
       </geometry>
 
     </collision>


### PR DESCRIPTION
Addresses the `compareParsers` matlab tests that fail due to being unable to locate the tet.obj file.  In response to revert PR #4689.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4695)
<!-- Reviewable:end -->
