### PR TITLE
Handle mixed scalar-types in Eigen for symbolic classes

### DIFF
--- a/drake/common/symbolic_expression.cc
+++ b/drake/common/symbolic_expression.cc
@@ -413,9 +413,8 @@ Expression operator-(const Variable& lhs, const Variable& rhs) {
   return Expression{lhs} - Expression{rhs};
 }
 Expression operator-(Expression lhs, const Variable& rhs) { return lhs -= rhs; }
-Expression operator-(const Variable& lhs, Expression rhs) {
-  rhs -= lhs;   // rhs - lhs
-  return -rhs;  // lhs - rhs
+Expression operator-(const Variable& lhs, const Expression& rhs) {
+  return Expression(lhs) - rhs;
 }
 
 // NOLINTNEXTLINE(runtime/references) per C++ standard signature.

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -491,6 +491,85 @@ double get_constant_factor_in_multiplication(const Expression& e);
 */
 const std::map<Expression, Expression>& get_products_in_multiplication(
     const Expression& e);
+
+// Matrix<Expression> * Matrix<Variable> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Expression>::value &&
+        std::is_same<typename MatrixR::Scalar, Variable>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs * rhs.template cast<Expression>();
+}
+
+// Matrix<Variable> * Matrix<Expression> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Variable>::value &&
+        std::is_same<typename MatrixR::Scalar, Expression>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs;
+}
+
+// Matrix<Expression> * Matrix<double> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Expression>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+}
+
+// Matrix<double> * Matrix<Expression> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, double>::value &&
+        std::is_same<typename MatrixR::Scalar, Expression>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+}
+
+// Matrix<Variable> * Matrix<double> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Variable>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+}
+
+// Matrix<double> * Matrix<Variable> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, double>::value &&
+        std::is_same<typename MatrixR::Scalar, Variable>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+}
+
 }  // namespace symbolic
 
 /** Provides specialization of @c cond function defined in drake/common/cond.h
@@ -563,6 +642,7 @@ struct NumTraits<drake::symbolic::Expression>
 template <typename BinaryOp>
 struct ScalarBinaryOpTraits<drake::symbolic::Variable,
                             drake::symbolic::Variable, BinaryOp> {
+  enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
 
@@ -570,6 +650,7 @@ struct ScalarBinaryOpTraits<drake::symbolic::Variable,
 template <typename BinaryOp>
 struct ScalarBinaryOpTraits<drake::symbolic::Variable,
                             drake::symbolic::Expression, BinaryOp> {
+  enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
 
@@ -577,19 +658,37 @@ struct ScalarBinaryOpTraits<drake::symbolic::Variable,
 template <typename BinaryOp>
 struct ScalarBinaryOpTraits<drake::symbolic::Expression,
                             drake::symbolic::Variable, BinaryOp> {
+  enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
 
 // Informs Eigen that Variable op double gets Expression.
 template <typename BinaryOp>
 struct ScalarBinaryOpTraits<drake::symbolic::Variable, double, BinaryOp> {
+  enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
 
 // Informs Eigen that double op Variable gets Expression.
 template <typename BinaryOp>
 struct ScalarBinaryOpTraits<double, drake::symbolic::Variable, BinaryOp> {
+  enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
+
+// Informs Eigen that Expression op double gets Expression.
+template <typename BinaryOp>
+struct ScalarBinaryOpTraits<drake::symbolic::Expression, double, BinaryOp> {
+  enum { Defined = 1 };
+  typedef drake::symbolic::Expression ReturnType;
+};
+
+// Informs Eigen that double op Expression gets Expression.
+template <typename BinaryOp>
+struct ScalarBinaryOpTraits<double, drake::symbolic::Expression, BinaryOp> {
+  enum { Defined = 1 };
+  typedef drake::symbolic::Expression ReturnType;
+};
+
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -346,7 +346,7 @@ Expression operator+(const Variable& lhs, Expression rhs);
 Expression& operator-=(Expression& lhs, const Variable& rhs);
 Expression operator-(const Variable& lhs, const Variable& rhs);
 Expression operator-(Expression lhs, const Variable& rhs);
-Expression operator-(const Variable& lhs, Expression rhs);
+Expression operator-(const Variable& lhs, const Expression& rhs);
 
 // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
 Expression& operator*=(Expression& lhs, const Variable& rhs);

--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -65,6 +65,15 @@ The following simple simplifications are implemented:
     F1 ∧ F2        ->  False   (if either F1 or F2 is False)
     F1 ∨ F2        ->  True    (if either F1 or F2 is True)
 \endverbatim
+
+\note Formula class has an explicit conversion operator to bool. It evaluates a
+symbolic formula under an empty environment. If a symbolic formula includes
+symbolic variables, the conversion operator throws an exception. This operator
+is only intended for third-party code doing things like
+<tt>(imag(SymbolicExpression(0)) == SymbolicExpression(0)) { ... };<tt> that we
+found in Eigen3 codebase. In general, a user of this class should explicitly
+call \c Evaluate from within Drake for readability.
+
 */
 class Formula {
  public:

--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -123,6 +123,9 @@ class Formula {
   static Formula True();
   static Formula False();
 
+  /** Conversion to bool. */
+  explicit operator bool() const { return Evaluate(); }
+
   friend Formula operator&&(const Formula& f1, const Formula& f2);
   friend Formula operator||(const Formula& f1, const Formula& f2);
   friend Formula operator!(const Formula& f);

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -1626,9 +1626,9 @@ class SymbolicExpressionMatrixTest : public ::testing::Test {
   const Expression neg_pi_{-3.141592};
   const Expression e_{2.718};
 
-  Eigen::Matrix<Expression, 3, 2> A_;
-  Eigen::Matrix<Expression, 2, 3> B_;
-  Eigen::Matrix<Expression, 3, 2> C_;
+  Eigen::Matrix<Expression, 3, 2, Eigen::DontAlign> A_;
+  Eigen::Matrix<Expression, 2, 3, Eigen::DontAlign> B_;
+  Eigen::Matrix<Expression, 3, 2, Eigen::DontAlign> C_;
 
   void SetUp() override {
     // clang-format off
@@ -1739,9 +1739,9 @@ class SymbolicVariableTest : public ::testing::Test {
   const Variable z_{"z"};
   const Variable w_{"w"};
 
-  Eigen::Matrix<double, 2, 2> double_mat_;
-  Eigen::Matrix<symbolic::Variable, 2, 2> var_mat_;
-  Eigen::Matrix<symbolic::Expression, 2, 2> expr_mat_;
+  Eigen::Matrix<double, 2, 2, Eigen::DontAlign> double_mat_;
+  Eigen::Matrix<symbolic::Variable, 2, 2, Eigen::DontAlign> var_mat_;
+  Eigen::Matrix<symbolic::Expression, 2, 2, Eigen::DontAlign> expr_mat_;
 
   void SetUp() override {
     // clang-format off
@@ -2039,6 +2039,11 @@ TEST_F(SymbolicVariableTest, EigenExpressionMatrixOutput) {
 }
 
 class SymbolicMixingScalarTypesTest : public ::testing::Test {
+  template <typename Scalar>
+  using Matrix2DontAlign = Eigen::Matrix<Scalar, 2, 2, Eigen::DontAlign>;
+  template <typename Scalar>
+  using Vector2DontAlign = Eigen::Matrix<Scalar, 2, 1, Eigen::DontAlign>;
+
  protected:
   const Variable var_x_{"x"};
   const Variable var_y_{"y"};
@@ -2049,19 +2054,19 @@ class SymbolicMixingScalarTypesTest : public ::testing::Test {
   const Expression z_{var_z_};
   const Expression w_{var_w_};
 
-  Matrix2<Expression> M_expr_fixed_;
+  Matrix2DontAlign<Expression> M_expr_fixed_;
   MatrixX<Expression> M_expr_dyn_{2, 2};
-  Vector2<Expression> V_expr_fixed_;
+  Vector2DontAlign<Expression> V_expr_fixed_;
   VectorX<Expression> V_expr_dyn_{2};
 
-  Matrix2<Variable> M_var_fixed_;
+  Matrix2DontAlign<Variable> M_var_fixed_;
   MatrixX<Variable> M_var_dyn_{2, 2};
-  Vector2<Variable> V_var_fixed_;
+  Vector2DontAlign<Variable> V_var_fixed_;
   VectorX<Variable> V_var_dyn_{2};
 
-  Matrix2<double> M_double_fixed_;
+  Matrix2DontAlign<double> M_double_fixed_;
   MatrixX<double> M_double_dyn_{2, 2};
-  Vector2<double> V_double_fixed_;
+  Vector2DontAlign<double> V_double_fixed_;
   VectorX<double> V_double_dyn_{2};
 
   void SetUp() override {

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -8,12 +8,14 @@
 #include <set>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "gtest/gtest.h"
 
+#include "drake/common/eigen_types.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_formula.h"
@@ -27,6 +29,7 @@ using std::map;
 using std::ostringstream;
 using std::runtime_error;
 using std::set;
+using std::string;
 using std::unordered_map;
 using std::unordered_set;
 using std::vector;
@@ -2033,6 +2036,545 @@ TEST_F(SymbolicVariableTest, EigenExpressionMatrixOutput) {
        << "      (y + z)       (y + w)";
 
   EXPECT_EQ(oss1.str(), oss2.str());
+}
+
+class SymbolicMixingScalarTypesTest : public ::testing::Test {
+ protected:
+  const Variable var_x_{"x"};
+  const Variable var_y_{"y"};
+  const Variable var_z_{"z"};
+  const Variable var_w_{"w"};
+  const Expression x_{var_x_};
+  const Expression y_{var_y_};
+  const Expression z_{var_z_};
+  const Expression w_{var_w_};
+
+  Matrix2<Expression> M_expr_fixed_;
+  MatrixX<Expression> M_expr_dyn_{2, 2};
+  Vector2<Expression> V_expr_fixed_;
+  VectorX<Expression> V_expr_dyn_{2};
+
+  Matrix2<Variable> M_var_fixed_;
+  MatrixX<Variable> M_var_dyn_{2, 2};
+  Vector2<Variable> V_var_fixed_;
+  VectorX<Variable> V_var_dyn_{2};
+
+  Matrix2<double> M_double_fixed_;
+  MatrixX<double> M_double_dyn_{2, 2};
+  Vector2<double> V_double_fixed_;
+  VectorX<double> V_double_dyn_{2};
+
+  void SetUp() override {
+    // clang-format off
+    M_expr_fixed_ << x_, y_,
+                     z_, w_;
+    M_expr_dyn_   << x_, y_,
+                     z_, w_;
+    V_expr_fixed_ << x_,
+                     y_;
+    V_expr_dyn_   << x_,
+                     y_;
+    // clang-format on
+
+    // clang-format off
+    M_var_fixed_ << var_x_, var_y_,
+                    var_z_, var_w_;
+    M_var_dyn_   << var_x_, var_y_,
+                    var_z_, var_w_;
+    V_var_fixed_ << var_x_,
+                    var_y_;
+    V_var_dyn_   << var_x_,
+                    var_y_;
+    // clang-format on
+
+    // clang-format off
+    M_double_fixed_ << 1, 2,
+                       3, 4;
+    M_double_dyn_   << 1, 2,
+                       3, 4;
+    V_double_fixed_ << 1,
+                       2;
+    V_double_dyn_   << 1,
+                       2;
+    // clang-format on
+  }
+
+  template <typename Scalar>
+  string to_string(const Eigen::MatrixBase<Scalar>& m) {
+    ostringstream oss;
+    oss << m;
+    return oss.str();
+  }
+};
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixAdditionExprVar) {
+  const MatrixX<Expression> M1{M_expr_fixed_ + M_var_fixed_};
+  const MatrixX<Expression> M2{M_expr_fixed_ + M_var_dyn_};
+  const MatrixX<Expression> M3{M_expr_dyn_ + M_var_fixed_};
+  const MatrixX<Expression> M4{M_expr_dyn_ + M_var_dyn_};
+  const string expected{
+      "      (2 * x)       (2 * y)\n      (2 * z)       (2 * w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixAdditionExprDouble) {
+  const MatrixX<Expression> M1{M_expr_fixed_ + M_double_fixed_};
+  const MatrixX<Expression> M2{M_expr_fixed_ + M_double_dyn_};
+  const MatrixX<Expression> M3{M_expr_dyn_ + M_double_fixed_};
+  const MatrixX<Expression> M4{M_expr_dyn_ + M_double_dyn_};
+  const string expected{
+      "      (1 + x)       (2 + y)\n      (3 + z)       (4 + w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixAdditionVarExpr) {
+  const MatrixX<Expression> M1{M_var_fixed_ + M_expr_fixed_};
+  const MatrixX<Expression> M2{M_var_fixed_ + M_expr_dyn_};
+  const MatrixX<Expression> M3{M_var_dyn_ + M_expr_fixed_};
+  const MatrixX<Expression> M4{M_var_dyn_ + M_expr_dyn_};
+  const string expected{
+      "      (2 * x)       (2 * y)\n      (2 * z)       (2 * w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixAdditionVarDouble) {
+  const MatrixX<Expression> M1{M_var_fixed_ + M_double_fixed_};
+  const MatrixX<Expression> M2{M_var_fixed_ + M_double_dyn_};
+  const MatrixX<Expression> M3{M_var_dyn_ + M_double_fixed_};
+  const MatrixX<Expression> M4{M_var_dyn_ + M_double_dyn_};
+  const string expected{
+      "      (1 + x)       (2 + y)\n      (3 + z)       (4 + w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixAdditionDoubleExpr) {
+  const MatrixX<Expression> M1{M_double_fixed_ + M_expr_fixed_};
+  const MatrixX<Expression> M2{M_double_fixed_ + M_expr_dyn_};
+  const MatrixX<Expression> M3{M_double_dyn_ + M_expr_fixed_};
+  const MatrixX<Expression> M4{M_double_dyn_ + M_expr_dyn_};
+  const string expected{
+      "      (1 + x)       (2 + y)\n      (3 + z)       (4 + w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixAdditionDoubleVar) {
+  const MatrixX<Expression> M1{M_double_fixed_ + M_var_fixed_};
+  const MatrixX<Expression> M2{M_double_fixed_ + M_var_dyn_};
+  const MatrixX<Expression> M3{M_double_dyn_ + M_var_fixed_};
+  const MatrixX<Expression> M4{M_double_dyn_ + M_var_dyn_};
+  const string expected{
+      "      (1 + x)       (2 + y)\n      (3 + z)       (4 + w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixSubtractionExprVar) {
+  const MatrixX<Expression> M1{M_expr_fixed_ - M_var_fixed_};
+  const MatrixX<Expression> M2{M_expr_fixed_ - M_var_dyn_};
+  const MatrixX<Expression> M3{M_expr_dyn_ - M_var_fixed_};
+  const MatrixX<Expression> M4{M_expr_dyn_ - M_var_dyn_};
+  const string expected{"0 0\n0 0"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixSubtractionExprDouble) {
+  const MatrixX<Expression> M1{M_expr_fixed_ - M_double_fixed_};
+  const MatrixX<Expression> M2{M_expr_fixed_ - M_double_dyn_};
+  const MatrixX<Expression> M3{M_expr_dyn_ - M_double_fixed_};
+  const MatrixX<Expression> M4{M_expr_dyn_ - M_double_dyn_};
+  const string expected{
+      "       (-1 + x)        (-2 + y)\n       (-3 + z)        (-4 + w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixSubtractionVarExpr) {
+  const MatrixX<Expression> M1{M_var_fixed_ - M_expr_fixed_};
+  const MatrixX<Expression> M2{M_var_fixed_ - M_expr_dyn_};
+  const MatrixX<Expression> M3{M_var_dyn_ - M_expr_fixed_};
+  const MatrixX<Expression> M4{M_var_dyn_ - M_expr_dyn_};
+  const string expected{"0 0\n0 0"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixSubtractionVarDouble) {
+  const MatrixX<Expression> M1{M_var_fixed_ - M_double_fixed_};
+  const MatrixX<Expression> M2{M_var_fixed_ - M_double_dyn_};
+  const MatrixX<Expression> M3{M_var_dyn_ - M_double_fixed_};
+  const MatrixX<Expression> M4{M_var_dyn_ - M_double_dyn_};
+  const string expected{
+      "       (-1 + x)        (-2 + y)\n       (-3 + z)        (-4 + w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixSubtractionDoubleExpr) {
+  const MatrixX<Expression> M1{M_double_fixed_ - M_expr_fixed_};
+  const MatrixX<Expression> M2{M_double_fixed_ - M_expr_dyn_};
+  const MatrixX<Expression> M3{M_double_dyn_ - M_expr_fixed_};
+  const MatrixX<Expression> M4{M_double_dyn_ - M_expr_dyn_};
+  const string expected{
+      "      (1 - x)       (2 - y)\n      (3 - z)       (4 - w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixSubtractionDoubleVar) {
+  const MatrixX<Expression> M1{M_double_fixed_ - M_var_fixed_};
+  const MatrixX<Expression> M2{M_double_fixed_ - M_var_dyn_};
+  const MatrixX<Expression> M3{M_double_dyn_ - M_var_fixed_};
+  const MatrixX<Expression> M4{M_double_dyn_ - M_var_dyn_};
+  const string expected{
+      "      (1 - x)       (2 - y)\n      (3 - z)       (4 - w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationExprVar) {
+  const MatrixX<Expression> M1{M_expr_fixed_ * M_var_fixed_};
+  const MatrixX<Expression> M2{M_expr_fixed_ * M_var_dyn_};
+  const MatrixX<Expression> M3{M_expr_dyn_ * M_var_fixed_};
+  const MatrixX<Expression> M4{M_expr_dyn_ * M_var_dyn_};
+  const string expected{
+      "                    ((y * z) + pow(x, 2))"
+      "                     ((x * y) + (y * w))\n"
+      "                    ((x * z) + (z * w))"
+      "                     ((y * z) + pow(w, 2))"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixVectorMultiplicationExprVar) {
+  const MatrixX<Expression> M1{M_expr_fixed_ * V_var_fixed_};
+  const MatrixX<Expression> M2{M_expr_fixed_ * V_var_dyn_};
+  const MatrixX<Expression> M3{M_expr_dyn_ * V_var_fixed_};
+  const MatrixX<Expression> M4{M_expr_dyn_ * V_var_dyn_};
+  const string expected{
+      "                      (pow(x, 2) + pow(y, 2))\n"
+      "                      ((x * z) + (y * w))"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorMatrixMultiplicationExprVar) {
+  const MatrixX<Expression> M1{V_expr_fixed_.transpose() * M_var_fixed_};
+  const MatrixX<Expression> M2{V_expr_fixed_.transpose() * M_var_dyn_};
+  const MatrixX<Expression> M3{V_expr_dyn_.transpose() * M_var_fixed_};
+  const MatrixX<Expression> M4{V_expr_dyn_.transpose() * M_var_dyn_};
+  const string expected{
+      "                    ((y * z) + pow(x, 2))"
+      "                     ((x * y) + (y * w))"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorVectorMultiplicationExprVar) {
+  const MatrixX<Expression> M1{V_expr_fixed_.transpose() * V_var_fixed_};
+  const MatrixX<Expression> M2{V_expr_fixed_.transpose() * V_var_dyn_};
+  const MatrixX<Expression> M3{V_expr_dyn_.transpose() * V_var_fixed_};
+  const MatrixX<Expression> M4{V_expr_dyn_.transpose() * V_var_dyn_};
+  const string expected{"                      (pow(x, 2) + pow(y, 2))"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationVarExpr) {
+  const MatrixX<Expression> M1{M_var_fixed_ * M_expr_fixed_};
+  const MatrixX<Expression> M2{M_var_fixed_ * M_expr_dyn_};
+  const MatrixX<Expression> M3{M_var_dyn_ * M_expr_fixed_};
+  const MatrixX<Expression> M4{M_var_dyn_ * M_expr_dyn_};
+  const string expected{
+      "                    ((y * z) + pow(x, 2))"
+      "                     ((x * y) + (y * w))\n"
+      "                    ((x * z) + (z * w))"
+      "                     ((y * z) + pow(w, 2))"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixVectorMultiplicationVarExpr) {
+  const MatrixX<Expression> M1{M_var_fixed_ * V_expr_fixed_};
+  const MatrixX<Expression> M2{M_var_fixed_ * V_expr_dyn_};
+  const MatrixX<Expression> M3{M_var_dyn_ * V_expr_fixed_};
+  const MatrixX<Expression> M4{M_var_dyn_ * V_expr_dyn_};
+  const string expected{
+      "                      (pow(x, 2) + pow(y, 2))\n"
+      "                      ((x * z) + (y * w))"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorMatrixMultiplicationVarExpr) {
+  const MatrixX<Expression> M1{V_var_fixed_.transpose() * M_expr_fixed_};
+  const MatrixX<Expression> M2{V_var_fixed_.transpose() * M_expr_dyn_};
+  const MatrixX<Expression> M3{V_var_dyn_.transpose() * M_expr_fixed_};
+  const MatrixX<Expression> M4{V_var_dyn_.transpose() * M_expr_dyn_};
+  const string expected{
+      "                    ((y * z) + pow(x, 2))"
+      "                     ((x * y) + (y * w))"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorVectorMultiplicationVarExpr) {
+  const MatrixX<Expression> M1{V_var_fixed_.transpose() * V_expr_fixed_};
+  const MatrixX<Expression> M2{V_var_fixed_.transpose() * V_expr_dyn_};
+  const MatrixX<Expression> M3{V_var_dyn_.transpose() * V_expr_fixed_};
+  const MatrixX<Expression> M4{V_var_dyn_.transpose() * V_expr_dyn_};
+  const string expected{"                      (pow(x, 2) + pow(y, 2))"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationExprDouble) {
+  const MatrixX<Expression> M1{M_expr_fixed_ * M_double_fixed_};
+  const MatrixX<Expression> M2{M_expr_fixed_ * M_double_dyn_};
+  const MatrixX<Expression> M3{M_expr_dyn_ * M_double_fixed_};
+  const MatrixX<Expression> M4{M_expr_dyn_ * M_double_dyn_};
+  const string expected{
+      "              (x + 3 * y)"
+      "               (2 * x + 4 * y)\n"
+      "              (z + 3 * w)"
+      "               (2 * z + 4 * w)"};
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixVectorMultiplicationExprDouble) {
+  const MatrixX<Expression> M1{M_expr_fixed_ * V_double_fixed_};
+  const MatrixX<Expression> M2{M_expr_fixed_ * V_double_dyn_};
+  const MatrixX<Expression> M3{M_expr_dyn_ * V_double_fixed_};
+  const MatrixX<Expression> M4{M_expr_dyn_ * V_double_dyn_};
+  const string expected{"          (x + 2 * y)\n          (z + 2 * w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorMatrixMultiplicationExprDouble) {
+  const MatrixX<Expression> M1{V_expr_fixed_.transpose() * M_double_fixed_};
+  const MatrixX<Expression> M2{V_expr_fixed_.transpose() * M_double_dyn_};
+  const MatrixX<Expression> M3{V_expr_dyn_.transpose() * M_double_fixed_};
+  const MatrixX<Expression> M4{V_expr_dyn_.transpose() * M_double_dyn_};
+  const string expected{
+      "              (x + 3 * y)               (2 * x + 4 * y)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorVectorMultiplicationExprDouble) {
+  const MatrixX<Expression> M1{V_expr_fixed_.transpose() * V_double_fixed_};
+  const MatrixX<Expression> M2{V_expr_fixed_.transpose() * V_double_dyn_};
+  const MatrixX<Expression> M3{V_expr_dyn_.transpose() * V_double_fixed_};
+  const MatrixX<Expression> M4{V_expr_dyn_.transpose() * V_double_dyn_};
+  const string expected{"          (x + 2 * y)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationDoubleExpr) {
+  const MatrixX<Expression> M1{M_double_fixed_ * M_expr_fixed_};
+  const MatrixX<Expression> M2{M_double_fixed_ * M_expr_dyn_};
+  const MatrixX<Expression> M3{M_double_dyn_ * M_expr_fixed_};
+  const MatrixX<Expression> M4{M_double_dyn_ * M_expr_dyn_};
+  const string expected{
+      "              (x + 2 * z)"
+      "               (y + 2 * w)\n"
+      "              (3 * x + 4 * z)"
+      "               (3 * y + 4 * w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixVectorMultiplicationDoubleExpr) {
+  const MatrixX<Expression> M1{M_double_fixed_ * V_expr_fixed_};
+  const MatrixX<Expression> M2{M_double_fixed_ * V_expr_dyn_};
+  const MatrixX<Expression> M3{M_double_dyn_ * V_expr_fixed_};
+  const MatrixX<Expression> M4{M_double_dyn_ * V_expr_dyn_};
+  const string expected{
+      "              (x + 2 * y)\n              (3 * x + 4 * y)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorMatrixMultiplicationDoubleExpr) {
+  const MatrixX<Expression> M1{V_double_fixed_.transpose() * M_expr_fixed_};
+  const MatrixX<Expression> M2{V_double_fixed_.transpose() * M_expr_dyn_};
+  const MatrixX<Expression> M3{V_double_dyn_.transpose() * M_expr_fixed_};
+  const MatrixX<Expression> M4{V_double_dyn_.transpose() * M_expr_dyn_};
+  const string expected{"          (x + 2 * z)           (y + 2 * w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorVectorMultiplicationDoubleExpr) {
+  const MatrixX<Expression> M1{V_double_fixed_.transpose() * V_expr_fixed_};
+  const MatrixX<Expression> M2{V_double_fixed_.transpose() * V_expr_dyn_};
+  const MatrixX<Expression> M3{V_double_dyn_.transpose() * V_expr_fixed_};
+  const MatrixX<Expression> M4{V_double_dyn_.transpose() * V_expr_dyn_};
+  const string expected{"          (x + 2 * y)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationVarDouble) {
+  const MatrixX<Expression> M1{M_var_fixed_ * M_double_fixed_};
+  const MatrixX<Expression> M2{M_var_fixed_ * M_double_dyn_};
+  const MatrixX<Expression> M3{M_var_dyn_ * M_double_fixed_};
+  const MatrixX<Expression> M4{M_var_dyn_ * M_double_dyn_};
+  const string expected{
+      "              (x + 3 * y)"
+      "               (2 * x + 4 * y)\n"
+      "              (z + 3 * w)"
+      "               (2 * z + 4 * w)"};
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixVectorMultiplicationVarDouble) {
+  const MatrixX<Expression> M1{M_var_fixed_ * V_double_fixed_};
+  const MatrixX<Expression> M2{M_var_fixed_ * V_double_dyn_};
+  const MatrixX<Expression> M3{M_var_dyn_ * V_double_fixed_};
+  const MatrixX<Expression> M4{M_var_dyn_ * V_double_dyn_};
+  const string expected{"          (x + 2 * y)\n          (z + 2 * w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorMatrixMultiplicationVarDouble) {
+  const MatrixX<Expression> M1{V_var_fixed_.transpose() * M_double_fixed_};
+  const MatrixX<Expression> M2{V_var_fixed_.transpose() * M_double_dyn_};
+  const MatrixX<Expression> M3{V_var_dyn_.transpose() * M_double_fixed_};
+  const MatrixX<Expression> M4{V_var_dyn_.transpose() * M_double_dyn_};
+  const string expected{
+      "              (x + 3 * y)               (2 * x + 4 * y)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorVectorMultiplicationVarDouble) {
+  const MatrixX<Expression> M1{V_var_fixed_.transpose() * V_double_fixed_};
+  const MatrixX<Expression> M2{V_var_fixed_.transpose() * V_double_dyn_};
+  const MatrixX<Expression> M3{V_var_dyn_.transpose() * V_double_fixed_};
+  const MatrixX<Expression> M4{V_var_dyn_.transpose() * V_double_dyn_};
+  const string expected{"          (x + 2 * y)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixMatrixMultiplicationDoubleVar) {
+  const MatrixX<Expression> M1{M_double_fixed_ * M_var_fixed_};
+  const MatrixX<Expression> M2{M_double_fixed_ * M_var_dyn_};
+  const MatrixX<Expression> M3{M_double_dyn_ * M_var_fixed_};
+  const MatrixX<Expression> M4{M_double_dyn_ * M_var_dyn_};
+  const string expected{
+      "              (x + 2 * z)"
+      "               (y + 2 * w)\n"
+      "              (3 * x + 4 * z)"
+      "               (3 * y + 4 * w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, MatrixVectorMultiplicationDoubleVar) {
+  const MatrixX<Expression> M1{M_double_fixed_ * V_var_fixed_};
+  const MatrixX<Expression> M2{M_double_fixed_ * V_var_dyn_};
+  const MatrixX<Expression> M3{M_double_dyn_ * V_var_fixed_};
+  const MatrixX<Expression> M4{M_double_dyn_ * V_var_dyn_};
+  const string expected{
+      "              (x + 2 * y)\n              (3 * x + 4 * y)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorMatrixMultiplicationDoubleVar) {
+  const MatrixX<Expression> M1{V_double_fixed_.transpose() * M_var_fixed_};
+  const MatrixX<Expression> M2{V_double_fixed_.transpose() * M_var_dyn_};
+  const MatrixX<Expression> M3{V_double_dyn_.transpose() * M_var_fixed_};
+  const MatrixX<Expression> M4{V_double_dyn_.transpose() * M_var_dyn_};
+  const string expected{"          (x + 2 * z)           (y + 2 * w)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
+}
+
+TEST_F(SymbolicMixingScalarTypesTest, VectorVectorMultiplicationDoubleVar) {
+  const MatrixX<Expression> M1{V_double_fixed_.transpose() * V_var_fixed_};
+  const MatrixX<Expression> M2{V_double_fixed_.transpose() * V_var_dyn_};
+  const MatrixX<Expression> M3{V_double_dyn_.transpose() * V_var_fixed_};
+  const MatrixX<Expression> M4{V_double_dyn_.transpose() * V_var_dyn_};
+  const string expected{"          (x + 2 * y)"};
+  EXPECT_EQ(to_string(M1), expected);
+  EXPECT_EQ(to_string(M2), expected);
+  EXPECT_EQ(to_string(M3), expected);
+  EXPECT_EQ(to_string(M4), expected);
 }
 
 }  // namespace


### PR DESCRIPTION
Multiplications among Eigen matrices of `{symbolic::Expression, symbolic::Variable, double}` were not properly handled previously. If operands have dynamic sizes, it causes compile-time errors.

According to [1], this is an issue on Eigen side. This patch is a workaround explicitly providing operator overloading among them.

[1]: http://stackoverflow.com/questions/41494288/mixing-scalar-types-in-eigen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4702)
<!-- Reviewable:end -->
