### PR TITLE
Add drake_visualizer local repository to workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -127,3 +127,8 @@ gurobi_repository(
     build_file = "tools/gurobi.BUILD",
 )
 
+load("//tools:soft_failure.bzl", "soft_failure_binary_repository")
+soft_failure_binary_repository(
+    name = "drake_visualizer",
+    local_path = __workspace_dir__ + "/build/install/bin/drake-visualizer",
+)

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -93,7 +93,7 @@ cc_googletest(
     deps = [
         ":collision",
         "//drake/common:drake_path",
-        "//drake/common:eigen_matrix_compare"
+        "//drake/common:eigen_matrix_compare",
     ],
 )
 

--- a/tools/soft_failure.bzl
+++ b/tools/soft_failure.bzl
@@ -1,0 +1,112 @@
+# -*- python -*-
+
+# This file provides a repository rule:
+#
+#   soft_failure_binary_repository(name, local_path)
+#
+# The rule brings an external program into the workspace in a soft-failure way.
+# For example, an invocation like this ...
+#
+#  soft_failure_binary_repository(
+#    name = "foo",
+#    local_path = "/usr/local/bin/bar"
+#  )
+#
+# ... will create a binary target @foo//:bar that can be used via "bazel run",
+# or as in the data=[...] attribute of some other rule, test, etc.  At build
+# time the path will be symlinked in the repository; the build will succeed
+# even if the referenced path is missing.  Only if the @foo//:bar target is
+# actually run and the referenced path does not exist will we die with a
+# diagnostic.  The pass / failure condition is hermetic; if the program later
+# (dis)appears, any targets that depended on *running* it will be rebuilt.
+#
+# === Implementation notes follow ==
+#
+# This rule is tricky due to https://github.com/bazelbuild/bazel/issues/1595.
+# In the repository rule, we can't do any sensing that will vary over time
+# (such as $PATH lookup or "$(which ...)"), so instead we must ask our caller
+# to hard-code where the program comes from.  What we can do is have a rule in
+# our generated BUILD file that yields different results.  For that, we use a
+# glob() call, detailed below.
+#
+# When building the repository, we add a symlink for where the program should
+# be.  By using glob() against that symlink in our BUILD, Bazel will notice at
+# build time whether or not the symlink resolves, and bring it into the sandbox
+# only if so.  Bazel notices when glob() outcomes change, so rebuilds anytime
+# the actual program (dis)appears.
+
+def _soft_failure_binary_repository_impl(repository_ctx):
+    repo_name = repository_ctx.name
+    local_path = getattr(repository_ctx.attr, "local_path")
+    basename = local_path[(local_path.rfind("/") + 1):]
+
+    # Symlink the requested binary's path into the repository.  The symlink
+    # might be broken, but we are careful to handle that below.
+    symlink_basename = "__symlink_" + basename
+    repository_ctx.symlink(local_path, symlink_basename)
+    symlink_path = "external/" + repo_name + "/" + symlink_basename
+
+    # Set up an error message to be used by generated code.
+    label = "@{repo_name}//:{basename}".format(
+        repo_name=repo_name, basename=basename)
+    warning = "soft_failure.bzl: " + (
+        "{label} does not work because {local_path} was missing".format(
+            label=label, local_path=local_path))
+
+    # Emit the wrapper that unconditionally fails at runtime; this is selected
+    # at build-time when the glob() fails.
+    wrapper_failure_basename = "__failure_" + basename
+    wrapper_sh = """#!/bin/sh
+    echo "{warning}"
+    exit 1
+    """.format(warning=warning)
+    repository_ctx.file(wrapper_failure_basename, content=wrapper_sh)
+
+    # Emit the wrapper that delegates to the target program; this is selected
+    # at build-time when the glob() succeeds.
+    wrapper_success_basename = "__success_" + basename
+    wrapper_sh = """#!/bin/sh
+    if [ ! -L "{symlink_path}" ]; then
+      # We are running outside of the sandbox.
+      exec "{local_path}" "$@"
+    fi
+    if [ ! -x "{symlink_path}" ]; then
+      # We are running inside of the sandbox; the symlink exists but is broken.
+      echo "{warning}; this is unexpected, because it was present at build-time"
+      exit 1
+    fi
+    exec "{symlink_path}" "$@"
+    """.format(
+        symlink_path=symlink_path,
+        local_path=local_path,
+        warning=warning)
+    repository_ctx.file(wrapper_success_basename, content=wrapper_sh)
+
+    # Emit the BUILD file into the repository.  Define a sh_binary named as the
+    # target binary's basename (so "/path/to/tool" turns into label ":tool").
+    # The sh_binary source code will be one of the two wrapper scripts above.
+    BUILD = """
+    data = glob(["{symlink_basename}"]) or print("{warning}")
+    src = "{wrapper_success_basename}" if data else "{wrapper_failure_basename}"
+    sh_binary(
+        name = "{basename}",
+        srcs = [src],
+        data = data,
+        visibility = ["//visibility:public"],
+    )
+    """.format(
+        symlink_basename=symlink_basename,
+        warning=warning,
+        basename=basename,
+        wrapper_success_basename=wrapper_success_basename,
+        wrapper_failure_basename=wrapper_failure_basename)
+    BUILD = BUILD.replace("\n    ", "\n")  # Strip leading indent from lines.
+    repository_ctx.file("BUILD", content=BUILD)
+
+soft_failure_binary_repository = repository_rule(
+    attrs = {
+        "local_path": attr.string(mandatory = True),
+    },
+    local = True,
+    implementation = _soft_failure_binary_repository_impl,
+)


### PR DESCRIPTION
Enables launching the GUI via Bazel if the program is available in a well-known-location at build time.  If not, it only fails at runtime.

```
jwnimmer@call-cc:~/jwnimmer-tri/drake-distro$ bazel run @drake_visualizer//:drake-visualizer
...
INFO: Build completed successfully, 3 total actions
INFO: Running command line: bazel-bin/external/drake_visualizer/drake-visualizer
... (gui appears) ...

jwnimmer@call-cc:~/jwnimmer-tri/drake-distro$ mv build/debug/install/bin/drake-visualizer{,.bak}
jwnimmer@call-cc:~/jwnimmer-tri/drake-distro$ bazel run @drake_visualizer//:drake-visualizer
WARNING: .../external/drake_visualizer/BUILD:1:46: The target @drake_visualizer//:drake-visualizer will not run correctly because /home/jwnimmer/jwnimmer-tri/drake-distro/build/install/bin/drake-visualizer is missing
...
INFO: Build completed successfully, 3 total actions
INFO: Running command line: bazel-bin/external/drake_visualizer/drake-visualizer
tools/soft_failure.bzl: as of last build, no such file /home/jwnimmer/jwnimmer-tri/drake-distro/build/install/bin/drake-visualizer
ERROR: Non-zero return code '1' from command: Process exited with status 1

jwnimmer@call-cc:~/jwnimmer-tri/drake-distro$ mv build/debug/install/bin/drake-visualizer{.bak,}
jwnimmer@call-cc:~/jwnimmer-tri/drake-distro$ bazel run @drake_visualizer//:drake-visualizer
...
INFO: Build completed successfully, 3 total actions
INFO: Running command line: bazel-bin/external/drake_visualizer/drake-visualizer
... (gui appears) ...
```

This will be used in a future PR where the `automotive` demo can optionally launch the visualizer, eventually including in CI.

This is also (hopefully) just a stop-gap until we get `drake-visualizer` actually compiling under Bazel, but it's unclear how long that will take, and we need this now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4705)
<!-- Reviewable:end -->
