### PR TITLE
Updates ROS Indigo Installation Instructions to Remove Octomap and FCL

### DIFF
--- a/drake/doc/from_source_ros_indigo.rst
+++ b/drake/doc/from_source_ros_indigo.rst
@@ -10,8 +10,12 @@ Step 1: Install Prerequisites
 =============================
 
 Install `Ubuntu 14.04.4 LTS (Trusty Tahr) <http://releases.ubuntu.com/14.04/>`_
-and `ROS Indigo <http://wiki.ros.org/indigo>`_. We recommend installing the
-"desktop-full" version of ROS to get its full feature set.
+and `ROS Indigo <http://wiki.ros.org/indigo>`_. We recommend initially
+installing the "desktop-full" version of ROS, but then uninstalling the
+following two packages due to incompatibility with Drake (see
+`issue #3814 <https://github.com/RobotLocomotion/drake/issues/3814>`_)::
+
+    sudo apt-get remove ros-indigo-octomap ros-indigo-fcl
 
 Add your public SSH key to your github.com account by following
 `these instructions <https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/>`_. This is necessary because the


### PR DESCRIPTION
This PR resolves #3814 the brute-force way: by removing ROS' versions of Octomap and FCL. This was done as a last resort. See notes in #3814 on various ways we tried to get Drake to prioritize its own versions of Octomap and FCL libraries over ROS' versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4709)
<!-- Reviewable:end -->
