### PR TITLE
For xcode and gtest, literals must be marked as unsigned

### DIFF
--- a/drake/multibody/collision/test/model_test.cc
+++ b/drake/multibody/collision/test/model_test.cc
@@ -918,7 +918,7 @@ GTEST_TEST(ModelTest, PointDistanceToNonConvex) {
   std::vector<PointPair> results;
   model->collisionDetectFromPoints(points, false, results);
 
-  ASSERT_EQ(results.size(), 4);
+  ASSERT_EQ(results.size(), 4u);
   const double inf = std::numeric_limits<double>::infinity();
   for (auto& pair : results) {
     EXPECT_EQ(pair.distance, inf);
@@ -949,7 +949,7 @@ GTEST_TEST(ModelTest, PointDistanceToEmptyWorld) {
   std::vector<PointPair> results;
   model->collisionDetectFromPoints(points, false, results);
 
-  ASSERT_EQ(results.size(), 4);
+  ASSERT_EQ(results.size(), 4u);
   const double inf = std::numeric_limits<double>::infinity();
   for (auto& pair : results) {
     EXPECT_EQ(pair.distance, inf);
@@ -996,7 +996,7 @@ GTEST_TEST(ModelTest, DistanceToNonConvex) {
   std::vector<ElementIdPair> pairs;
   pairs.emplace_back(sphere->getId(), cap->getId());
   model->closestPointsPairwise(pairs, true, results);
-  EXPECT_EQ(results.size(), 0);
+  EXPECT_EQ(results.size(), 0u);
 }
 
 }  // namespace


### PR DESCRIPTION
There were three test comparing a size_t with a literal; the literals were
*not* marked as being unsigned.  This led to compilation errors in
xcode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4712)
<!-- Reviewable:end -->
