### PR TITLE
Adds a version of RigidBodyPlant that publishes xdot over LCM.

### DIFF
--- a/drake/multibody/rigid_body_plant/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/CMakeLists.txt
@@ -15,6 +15,7 @@ set(lcm_dependent_header_files)
 if (lcm_FOUND)
   set(lcm_dependent_header_files
     drake_visualizer.h
+    rigid_body_plant_that_publishes_xdot.h
     viewer_draw_translator.h)
 endif ()
 
@@ -22,6 +23,7 @@ set(lcm_dependent_source_files)
 if (lcm_FOUND)
   set(lcm_dependent_source_files
     drake_visualizer.cc
+    rigid_body_plant_that_publishes_xdot.cc
     viewer_draw_translator.cc)
 endif ()
 

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.cc
@@ -1,0 +1,65 @@
+#include "drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h"
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+RigidBodyPlantThatPublishesXdot<T>::RigidBodyPlantThatPublishesXdot(
+    std::unique_ptr<const RigidBodyTree<T>> tree,
+    const std::string& channel, drake::lcm::DrakeLcmInterface* lcm)
+    : RigidBodyPlant<T>::RigidBodyPlant(move(tree)), lcm_(lcm),
+      channel_(channel) {
+  derivatives_ = LeafSystem<T>::AllocateTimeDerivatives();
+  const RigidBodyTree<T>& rigid_body_tree =
+      RigidBodyPlant<T>::get_rigid_body_tree();
+  const int num_states = rigid_body_tree.get_num_positions() +
+                         rigid_body_tree.get_num_velocities();
+  message_.dim = num_states;
+  message_.val.resize(num_states, 0);  // Initializes vector to contain zeros.
+  for (int i = 0; i < rigid_body_tree.get_num_positions(); ++i) {
+    message_.coord.push_back(rigid_body_tree.get_position_name(i));
+  }
+  for (int i = 0; i < rigid_body_tree.get_num_velocities(); ++i) {
+    message_.coord.push_back(rigid_body_tree.get_velocity_name(i));
+  }
+  DRAKE_DEMAND(message_.coord.size() == message_.val.size());
+}
+
+template <typename T>
+RigidBodyPlantThatPublishesXdot<T>::~RigidBodyPlantThatPublishesXdot() {}
+
+// TODO(liang.fok) Eliminate the re-computation of `xdot` once it is cached.
+// Ideally, switch to outputting the derivatives in an output port. This can
+// only be done once #2890 is resolved.
+template <typename T>
+void RigidBodyPlantThatPublishesXdot<T>::DoPublish(const Context<T>& context)
+    const {
+  RigidBodyPlant<T>::DoCalcTimeDerivatives(context, derivatives_.get());
+  const auto xdot = derivatives_->CopyToVector();
+
+  const RigidBodyTree<T>& rigid_body_tree =
+      RigidBodyPlant<T>::get_rigid_body_tree();
+  const int num_states = rigid_body_tree.get_num_positions() +
+                         rigid_body_tree.get_num_velocities();
+
+  DRAKE_DEMAND(xdot.size() == num_states);
+  for (int i = 0; i < num_states; ++i) {
+    message_.val[i] = xdot(i);
+  }
+  message_.timestamp = static_cast<int64_t>(context.get_time() * 1000);
+
+  const int num_bytes = message_.getEncodedSize();
+  std::vector<uint8_t> message_bytes(num_bytes);
+  const int num_bytes_encoded =
+      message_.encode(message_bytes.data(), 0 /* offset */, num_bytes);
+  DRAKE_DEMAND(num_bytes == num_bytes_encoded);
+  lcm_->Publish(channel_, message_bytes.data(), num_bytes);
+}
+
+// Explicitly instantiates on the most common scalar types.
+template class RigidBodyPlantThatPublishesXdot<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.cc
@@ -36,7 +36,7 @@ RigidBodyPlantThatPublishesXdot<T>::~RigidBodyPlantThatPublishesXdot() {}
 template <typename T>
 void RigidBodyPlantThatPublishesXdot<T>::DoPublish(const Context<T>& context)
     const {
-  RigidBodyPlant<T>::DoCalcTimeDerivatives(context, derivatives_.get());
+  RigidBodyPlant<T>::CalcTimeDerivatives(context, derivatives_.get());
   const auto xdot = derivatives_->CopyToVector();
 
   const RigidBodyTree<T>& rigid_body_tree =
@@ -48,6 +48,9 @@ void RigidBodyPlantThatPublishesXdot<T>::DoPublish(const Context<T>& context)
   for (int i = 0; i < num_states; ++i) {
     message_.val[i] = xdot(i);
   }
+
+  // Saves the timestamp in milliseconds. This matches the behavior in
+  // LcmtDrakeSignalTranslator::Serialize().
   message_.timestamp = static_cast<int64_t>(context.get_time() * 1000);
 
   const int num_bytes = message_.getEncodedSize();

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+
+#include "drake/lcm/drake_lcm_interface.h"
+#include "drake/lcmt_drake_signal.hpp"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/framework/continuous_state.h"
+
+namespace drake {
+namespace systems {
+
+/// This is a child class of RigidBodyPlant that publishes `xdot`, the
+/// derivative of x, which is the RigidBodyPlant's output state vector.
+///
+/// @tparam T The scalar type. Must be a valid Eigen scalar.
+/// @ingroup rigid_body_systems
+template <typename T>
+class RigidBodyPlantThatPublishesXdot : public RigidBodyPlant<T> {
+ public:
+  /// Instantiates a %RigidBodyPlantThatPublishesXdot.
+  ///
+  /// @param[in] tree The RigidBodyTree. This defines the multi-body dynamics of
+  /// the world. This parameter must not be `nullptr`.
+  ///
+  /// @param[in] channel The name of the channel on which to publish `xdot`.
+  ///
+  /// @param[in] lcm  A non-null pointer to the LCM subsystem to publish on.
+  /// The pointer must remain valid for the lifetime of this object.
+  explicit RigidBodyPlantThatPublishesXdot(
+      std::unique_ptr<const RigidBodyTree<T>> tree, const std::string& channel,
+      drake::lcm::DrakeLcmInterface* lcm);
+
+  ~RigidBodyPlantThatPublishesXdot() override;
+
+ protected:
+  /// Publishes `xdot`, the derivative of `x`, which is this system's
+  /// generalized state vector. This vector contains the derivatives of the
+  /// RigidBodyTree's joint's positions and velocities. Thus, the units are
+  /// velocities and accelerations.
+  void DoPublish(const Context<T>& context) const override;
+
+ private:
+  // A const pointer to an LCM subsystem. Note that while the pointer is const,
+  // the LCM subsystem is not const.
+  lcm::DrakeLcmInterface* const lcm_{};
+
+  // The LCM message upon which to publish `xdot`.
+  const std::string channel_;
+
+  // Variables for holding the `xdot` and the LCM message that holds `xdot`.
+  std::unique_ptr<ContinuousState<double>> derivatives_;
+  mutable lcmt_drake_signal message_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
@@ -17,8 +17,9 @@
 namespace drake {
 namespace systems {
 
-/// This is a child class of RigidBodyPlant that publishes `xdot`, the
-/// derivative of x, which is the RigidBodyPlant's output state vector.
+/// This is a child class of RigidBodyPlant that publishes `xdot`, time
+/// derivative of RBPlant's state vector `x`, on an LCM channel encoded as an
+/// `lcmt_drake_signal` message.
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 /// @ingroup rigid_body_systems
@@ -40,14 +41,13 @@ class RigidBodyPlantThatPublishesXdot : public RigidBodyPlant<T> {
 
   ~RigidBodyPlantThatPublishesXdot() override;
 
- protected:
+ private:
   /// Publishes `xdot`, the derivative of `x`, which is this system's
   /// generalized state vector. This vector contains the derivatives of the
   /// RigidBodyTree's joint's positions and velocities. Thus, the units are
   /// velocities and accelerations.
   void DoPublish(const Context<T>& context) const override;
 
- private:
   // A const pointer to an LCM subsystem. Note that while the pointer is const,
   // the LCM subsystem is not const.
   lcm::DrakeLcmInterface* const lcm_{};

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
@@ -21,7 +21,7 @@ namespace systems {
 /// derivative of RBPlant's state vector `x`, on an LCM channel encoded as an
 /// `lcmt_drake_signal` message.
 ///
-/// @tparam T The scalar type. Must be a valid Eigen scalar.
+/// @tparam T The scalar type. Currently, the only supported type is `double`.
 /// @ingroup rigid_body_systems
 template <typename T>
 class RigidBodyPlantThatPublishesXdot : public RigidBodyPlant<T> {
@@ -42,10 +42,10 @@ class RigidBodyPlantThatPublishesXdot : public RigidBodyPlant<T> {
   ~RigidBodyPlantThatPublishesXdot() override;
 
  private:
-  /// Publishes `xdot`, the derivative of `x`, which is this system's
-  /// generalized state vector. This vector contains the derivatives of the
-  /// RigidBodyTree's joint's positions and velocities. Thus, the units are
-  /// velocities and accelerations.
+  // Publishes `xdot`, the derivative of `x`, which is this system's generalized
+  // state vector. This vector contains the derivatives of the RigidBodyTree's
+  // joint's positions and velocities. Thus, the units are velocities and
+  // accelerations.
   void DoPublish(const Context<T>& context) const override;
 
   // A const pointer to an LCM subsystem. Note that while the pointer is const,
@@ -55,7 +55,8 @@ class RigidBodyPlantThatPublishesXdot : public RigidBodyPlant<T> {
   // The LCM message upon which to publish `xdot`.
   const std::string channel_;
 
-  // Variables for holding the `xdot` and the LCM message that holds `xdot`.
+  // A variable and LCM message for holding the `xdot`. These class member
+  // variables exist to avoid repeated memory reallocation and deallocation.
   std::unique_ptr<ContinuousState<double>> derivatives_;
   mutable lcmt_drake_signal message_;
 };

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
@@ -7,7 +7,6 @@
 
 #include <Eigen/Geometry>
 
-
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcmt_drake_signal.hpp"
 #include "drake/multibody/rigid_body_tree.h"

--- a/drake/multibody/rigid_body_plant/test/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/test/CMakeLists.txt
@@ -14,8 +14,8 @@ if(Bullet_FOUND)
   target_link_libraries(compute_contact_result_test drakeRigidBodyPlant drakeRBSystem)
 
   if (lcm_FOUND)
-    drake_add_cc_test(rigid_body_plant_that_outputs_xdot_test)
-    target_link_libraries(rigid_body_plant_that_outputs_xdot_test
+    drake_add_cc_test(rigid_body_plant_that_publishes_xdot_test)
+    target_link_libraries(rigid_body_plant_that_publishes_xdot_test
         drakeLcm
         drakeMultibodyParsers
         drakeRigidBodyPlant)

--- a/drake/multibody/rigid_body_plant/test/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/test/CMakeLists.txt
@@ -14,6 +14,12 @@ if(Bullet_FOUND)
   target_link_libraries(compute_contact_result_test drakeRigidBodyPlant drakeRBSystem)
 
   if (lcm_FOUND)
+    drake_add_cc_test(rigid_body_plant_that_outputs_xdot_test)
+    target_link_libraries(rigid_body_plant_that_outputs_xdot_test
+        drakeLcm
+        drakeMultibodyParsers
+        drakeRigidBodyPlant)
+
     drake_add_cc_test(viewer_draw_translator_test)
     target_link_libraries(viewer_draw_translator_test drakeRigidBodyPlant)
 

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_outputs_xdot_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_outputs_xdot_test.cc
@@ -1,0 +1,80 @@
+#include "drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_path.h"
+#include "drake/lcm/drake_mock_lcm.h"
+#include "drake/lcmt_drake_signal.hpp"
+#include "drake/lcm/lcmt_drake_signal_utils.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+
+using std::make_unique;
+using std::move;
+using std::string;
+using std::unique_ptr;
+
+namespace drake {
+
+using lcm::CompareLcmtDrakeSignalMessages;
+using lcm::DrakeMockLcm;
+using multibody::joints::kQuaternion;
+using parsers::urdf::AddModelInstanceFromUrdfFile;
+
+namespace systems {
+namespace plants {
+namespace rigid_body_plant {
+namespace test {
+namespace {
+
+// Tests that RigidBodyPlantThatOutputsXdot actually publishes LCM messages when
+// DoPublish() is called.
+GTEST_TEST(RigidBodyPlantThatOutputsXdotTest, TestPublishLcmMessage) {
+  auto tree_ptr = make_unique<RigidBodyTree<double>>();
+  AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() + "/multibody/models/box.urdf",
+      kQuaternion, nullptr /* weld to frame */, tree_ptr.get());
+  string kChannelName = "XDOT_CHANNEL_NAME";
+  DrakeMockLcm lcm;
+  RigidBodyPlantThatPublishesXdot<double> dut(move(tree_ptr), kChannelName,
+      &lcm);
+  // A quaternion floating joint has 7 position values and 6 velocity values.
+  const int kNumStates = 13;
+
+  // Verifies that the number of states, inputs, and outputs are correct.
+  EXPECT_EQ(dut.get_num_states(), kNumStates);
+  EXPECT_EQ(dut.get_input_size(), 0);
+  EXPECT_EQ(dut.get_output_size(), kNumStates);
+
+  // Forces the DUT to publish an LCM message.
+  unique_ptr<Context<double>> context = dut.CreateDefaultContext();
+  EXPECT_NO_THROW(dut.Publish(*context));
+
+  // Verifies that the transmitted message is correct.
+  const std::vector<uint8_t>& transmitted_message_bytes =
+      lcm.get_last_published_message(kChannelName);
+
+  lcmt_drake_signal transmitted_message;
+  EXPECT_EQ(transmitted_message.decode(transmitted_message_bytes.data(), 0,
+                           transmitted_message_bytes.size()),
+            transmitted_message_bytes.size());
+
+  lcmt_drake_signal expected_message;
+  expected_message.dim = kNumStates;
+  expected_message.val = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -9.81};
+  expected_message.coord = {"base_x", "base_y", "base_z", "base_qw", "base_qx",
+                            "base_qy", "base_qz", "base_wx", "base_wy",
+                            "base_wz", "base_vx", "base_vy", "base_vz"};
+  expected_message.timestamp = 0;
+
+  EXPECT_TRUE(CompareLcmtDrakeSignalMessages(
+    transmitted_message, expected_message));
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace rigid_body_plant
+}  // namespace plants
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_publishes_xdot_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_publishes_xdot_test.cc
@@ -21,15 +21,16 @@ using lcm::CompareLcmtDrakeSignalMessages;
 using lcm::DrakeMockLcm;
 using multibody::joints::kQuaternion;
 using parsers::urdf::AddModelInstanceFromUrdfFile;
+using systems::Context;
+using systems::RigidBodyPlantThatPublishesXdot;
 
-namespace systems {
-namespace plants {
+namespace multibody {
 namespace rigid_body_plant {
 namespace test {
 namespace {
 
-// Tests that RigidBodyPlantThatOutputsXdot actually publishes LCM messages when
-// DoPublish() is called.
+// Tests that RigidBodyPlantThatPublishesXdot actually publishes LCM messages
+// when DoPublish() is called.
 GTEST_TEST(RigidBodyPlantThatOutputsXdotTest, TestPublishLcmMessage) {
   auto tree_ptr = make_unique<RigidBodyTree<double>>();
   AddModelInstanceFromUrdfFile(
@@ -56,6 +57,7 @@ GTEST_TEST(RigidBodyPlantThatOutputsXdotTest, TestPublishLcmMessage) {
       lcm.get_last_published_message(kChannelName);
 
   lcmt_drake_signal transmitted_message;
+  // Decodes message and checks that the correct number of bytes was processed.
   EXPECT_EQ(transmitted_message.decode(transmitted_message_bytes.data(), 0,
                            transmitted_message_bytes.size()),
             transmitted_message_bytes.size());
@@ -68,6 +70,7 @@ GTEST_TEST(RigidBodyPlantThatOutputsXdotTest, TestPublishLcmMessage) {
                             "base_wz", "base_vx", "base_vy", "base_vz"};
   expected_message.timestamp = 0;
 
+  // Compares the previously decoded message entry by entry.
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(
     transmitted_message, expected_message));
 }
@@ -75,6 +78,5 @@ GTEST_TEST(RigidBodyPlantThatOutputsXdotTest, TestPublishLcmMessage) {
 }  // namespace
 }  // namespace test
 }  // namespace rigid_body_plant
-}  // namespace plants
-}  // namespace systems
+}  // namespace multibody
 }  // namespace drake

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_publishes_xdot_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_publishes_xdot_test.cc
@@ -31,7 +31,7 @@ namespace {
 
 // Tests that RigidBodyPlantThatPublishesXdot actually publishes LCM messages
 // when DoPublish() is called.
-GTEST_TEST(RigidBodyPlantThatOutputsXdotTest, TestPublishLcmMessage) {
+GTEST_TEST(RigidBodyPlantThatPublishesXdotTest, TestPublishLcmMessage) {
   auto tree_ptr = make_unique<RigidBodyTree<double>>();
   AddModelInstanceFromUrdfFile(
       drake::GetDrakePath() + "/multibody/models/box.urdf",


### PR DESCRIPTION
This was extracted from #4682. It is intended to be a workaround until #2890 is resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4721)
<!-- Reviewable:end -->
