### PR TITLE
Adds a warning saying RigidBodyTree::computePositionNameToIndexMap() is buggy.

### DIFF
--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -116,6 +116,12 @@ class RigidBodyTree {
 
   void addFrame(std::shared_ptr<RigidBodyFrame<T>> frame);
 
+  /**
+   * Returns a map from DOF position name to DOF index within the output vector
+   * of this RigidBodyTree.
+   *
+   * WARNING: There is a known bug in this method, see: #4697.
+   */
   std::map<std::string, int> computePositionNameToIndexMap() const;
 
   void surfaceTangents(

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -120,7 +120,7 @@ class RigidBodyTree {
    * Returns a map from DOF position name to DOF index within the output vector
    * of this RigidBodyTree.
    *
-   * WARNING: There is a known bug in this method, see: #4697.
+   * <b>WARNING:</b> There is a known bug in this method, see: #4697.
    */
   std::map<std::string, int> computePositionNameToIndexMap() const;
 


### PR DESCRIPTION
Resolves #4697.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4722)
<!-- Reviewable:end -->
