### PR TITLE
Added missing documentation of some preconditions in System

### DIFF
--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -752,11 +752,11 @@ class System {
   /// You must override this method to calculate values for output ports into
   /// the supplied argument, based on the contents of the given Context.
   ///
-  /// This method is called from the public non-virtual CalcOutput()
+  /// This method is called only from the public non-virtual CalcOutput()
   /// which will already have error-checked the parameters so you don't have to.
   /// In particular, implementations may assume that the given Context is valid
   /// for this %System; that the `output` pointer is non-null, and that
-  /// the given `output` argument is valid for this %System.
+  /// the referenced object is valid for this %System.
   virtual void DoCalcOutput(const Context<T>& context,
                             SystemOutput<T>* output) const = 0;
 
@@ -767,11 +767,12 @@ class System {
   /// the Context has second-order structure `xc=[q,v,z]`, that same structure
   /// applies to the derivatives.
   ///
-  /// This method is called from the public non-virtual CalcTimeDerivatives()
-  /// which will already have error-checked the parameters so you don't have to.
+  /// This method is called only from the public non-virtual
+  /// CalcTimeDerivatives() which will already have error-checked
+  /// the parameters so you don't have to.
   /// In particular, implementations may assume that the given Context is valid
   /// for this %System; that the `derivatives` pointer is non-null, and that
-  /// the given `derivatives` argument has the same constituent structure as was
+  /// the referenced object has the same constituent structure as was
   /// produced by AllocateTimeDerivatives().
   ///
   /// The default implementation does nothing if the `derivatives` vector is
@@ -787,20 +788,23 @@ class System {
   /// Implement this in your concrete System if you want it to take some action
   /// when the Simulator calls the Publish() method. This can be used for
   /// sending messages, producing console output, debugging, logging, saving the
-  /// trajectory to a file, etc. You may assume that the `context` has already
-  /// been validated before it is passed to you here.
+  /// trajectory to a file, etc.
+  ///
+  /// This method is called only from the public non-virtual Publish() which
+  /// will have already error-checked `context` so you may assume that it is
+  /// valid for this %System.
   virtual void DoPublish(const Context<T>& context) const {}
 
   /// Updates the @p discrete_state on sample events.
   /// Override it, along with DoCalcNextUpdateTime(), if your System has any
   /// discrete variables.
   ///
-  /// This method is called from the public non-virtual
+  /// This method is called only from the public non-virtual
   /// CalcDiscreteVariableUpdates() which will already have error-checked the
   /// parameters so you don't have to. In particular, implementations may assume
   /// that the given Context is valid for this %System; that the
-  /// `discrete_state` pointer is non-null, and that the given `discrete_state`
-  /// argument has the same constituent structure as was produced by
+  /// `discrete_state` pointer is non-null, and that the referenced object
+  /// has the same constituent structure as was produced by
   /// AllocateDiscreteVariables().
   virtual void DoCalcDiscreteVariableUpdates(
       const Context<T>& context, DiscreteState<T>* discrete_state) const {}
@@ -811,11 +815,11 @@ class System {
   /// made using CalcDiscreteVariableUpdates() or via integration of continuous
   /// variables.
   ///
-  /// This method is called from the public non-virtual
+  /// This method is called only from the public non-virtual
   /// CalcUnrestrictedUpdate() which will already have error-checked the
   /// parameters so you don't have to. In particular, implementations may assume
   /// that the given Context is valid for this %System; that the `state` pointer
-  /// is non-null, and that the given `state` argument has the same constituent
+  /// is non-null, and that the referenced object has the same constituent
   /// structure as the state in `context`.
   ///
   /// @param[in]     context The "before" state that is to be used to calculate
@@ -832,13 +836,16 @@ class System {
   /// action.
   ///
   /// Override this method if your System has any discrete actions which must
-  /// interrupt the continuous simulation. You may assume that the context
-  /// has already been validated and the `actions` pointer is not nullptr.
+  /// interrupt the continuous simulation. This method is called only from the
+  /// public non-virtual CalcNextUpdateTime() which will already have
+  /// error-checked the parameters so you don't have to. You may assume that
+  /// `context` has already been validated and the `actions` pointer is
+  /// not `nullptr`.
   ///
   /// The default implementation returns with `actions` having a next sample
   /// time of Infinity and no actions to take.  If you declare actions, you may
   /// specify custom do_publish and do_update handlers.  If you do not,
-  /// DoPublish and DoEvalDifferenceUpdates will be used by default.
+  /// DoPublish and DoCalcDifferenceUpdates will be used by default.
   virtual void DoCalcNextUpdateTime(const Context<T>& context,
                                     UpdateActions<T>* actions) const {
     actions->time = std::numeric_limits<T>::infinity();


### PR DESCRIPTION
The NVI pattern allows the public method to pre-check arguments before invoking the virtual method so can promise the implementer that the arguments are good. We are doing that in System but I forgot to say so for some of the virtuals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4725)
<!-- Reviewable:end -->
