### PR TITLE
Don't require the use of std::default_random_generator for random rotations

### DIFF
--- a/drake/math/BUILD
+++ b/drake/math/BUILD
@@ -34,7 +34,6 @@ cc_library(
     srcs = [
         "axis_angle.cc",
         "quaternion.cc",
-        "random_rotation.cc",
         "roll_pitch_yaw.cc",
         "rotation_matrix.cc",
     ],

--- a/drake/math/CMakeLists.txt
+++ b/drake/math/CMakeLists.txt
@@ -12,7 +12,6 @@ set(sources
   matrix_util.cc
   normalize_vector.cc
   quaternion.cc
-  random_rotation.cc
   roll_pitch_yaw.cc
   rotation_conversion_gradient.cc
   rotation_matrix.cc)

--- a/drake/math/random_rotation.cc
+++ b/drake/math/random_rotation.cc
@@ -1,38 +1,5 @@
+// For now, this is an empty .cc file that only serves to confirm
+// random_rotation.h is a stand-alone header.
+
 #include "drake/math/random_rotation.h"
 
-#include "drake/math/axis_angle.h"
-
-using Eigen::Vector3d;
-using Eigen::Vector4d;
-
-namespace drake {
-namespace math {
-// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-Vector4d UniformlyRandomAxisAngle(std::default_random_engine& generator) {
-  std::normal_distribution<double> normal;
-  std::uniform_real_distribution<double> uniform(-M_PI, M_PI);
-  double angle = uniform(generator);
-  Vector3d axis =
-      Vector3d(normal(generator), normal(generator), normal(generator));
-  axis.normalize();
-  Vector4d a;
-  a << axis, angle;
-  return a;
-}
-
-// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-Vector4d UniformlyRandomQuat(std::default_random_engine& generator) {
-  return axis2quat(UniformlyRandomAxisAngle(generator));
-}
-
-// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-Eigen::Matrix3d UniformlyRandomRotmat(std::default_random_engine& generator) {
-  return axis2rotmat(UniformlyRandomAxisAngle(generator));
-}
-
-// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-Eigen::Vector3d UniformlyRandomRPY(std::default_random_engine& generator) {
-  return axis2rpy(UniformlyRandomAxisAngle(generator));
-}
-}  // namespace math
-}  // namespace drake

--- a/drake/math/random_rotation.h
+++ b/drake/math/random_rotation.h
@@ -6,20 +6,59 @@
 
 #include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
+#include "drake/math/axis_angle.h"
 
 namespace drake {
 namespace math {
-Eigen::Vector4d UniformlyRandomAxisAngle(
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    std::default_random_engine& generator);
-Eigen::Vector4d UniformlyRandomQuat(
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    std::default_random_engine& generator);
-Eigen::Matrix3d UniformlyRandomRotmat(
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    std::default_random_engine& generator);
-Eigen::Vector3d UniformlyRandomRPY(
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    std::default_random_engine& generator);
+
+/// Generates a rotation (in the axis-angle representation) that rotates a
+/// point on the unit sphere to another point on the unit sphere with a uniform
+/// distribution over the sphere.
+///
+/// Justification for the algorithm can be found in, e.g.:
+/// Mervin E. Muller. 1959. A note on a method for generating points
+/// uniformly on n-dimensional spheres. Commun. ACM 2, 4 (April 1959), 19-20.
+/// DOI=http://dx.doi.org/10.1145/377939.377946
+template <class Generator>
+// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+Eigen::Vector4d UniformlyRandomAxisAngle(Generator& generator) {
+  std::normal_distribution<double> normal;
+  std::uniform_real_distribution<double> uniform(-M_PI, M_PI);
+  double angle = uniform(generator);
+  Eigen::Vector3d axis =
+      Eigen::Vector3d(normal(generator), normal(generator), normal(generator));
+  axis.normalize();
+  Eigen::Vector4d a;
+  a << axis, angle;
+  return a;
+}
+
+/// Generates a rotation (in the quaternion representation) that rotates a
+/// point on the unit sphere to another point on the unit sphere with a uniform
+/// distribution over the sphere.
+template <class Generator>
+// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+Eigen::Vector4d UniformlyRandomQuat(Generator& generator) {
+  return axis2quat(UniformlyRandomAxisAngle(generator));
+}
+
+/// Generates a rotation (in the rotation matrix representation) that rotates a
+/// point on the unit sphere to another point on the unit sphere with a uniform
+/// distribution over the sphere.
+template <class Generator>
+// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+Eigen::Matrix3d UniformlyRandomRotmat(Generator& generator) {
+  return axis2rotmat(UniformlyRandomAxisAngle(generator));
+}
+
+/// Generates a rotation (in the roll-pitch-yaw representation) that rotates a
+/// point on the unit sphere to another point on the unit sphere with a uniform
+/// distribution over the sphere.
+template <class Generator>
+// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+Eigen::Vector3d UniformlyRandomRPY(Generator& generator) {
+  return axis2rpy(UniformlyRandomAxisAngle(generator));
+}
+
 }  // namespace math
 }  // namespace drake


### PR DESCRIPTION
The default generator is different on different compilers/operating systems, so should not be the default choice, and certainly shouldn't be imposed on the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4741)
<!-- Reviewable:end -->
