### PR TITLE
Minor tweak to cxx_inl to reduce brittleness in comment

### DIFF
--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -25,7 +25,7 @@ namespace automotive {
 /// Instantiated templates for the following ScalarTypes are provided:
 /// - double
 ///
-/// They are already available to link against in libdrakeAutomotive.
+/// They are already available to link against in the containing library.
 template <typename T>
 class AutomotiveSimulator {
  public:

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -17,7 +17,7 @@ namespace automotive {
 /// - drake::TaylorVarXd
 /// - drake::symbolic::Expression
 ///
-/// They are already available to link against in libdrakeAutomotive.
+/// They are already available to link against in the containing library.
 ///
 /// @ingroup automotive_systems
 ///

--- a/drake/automotive/linear_car.h
+++ b/drake/automotive/linear_car.h
@@ -13,7 +13,7 @@ namespace automotive {
 /// - drake::TaylorVarXd
 /// - drake::symbolic::Expression
 ///
-/// They are already available to link against in libdrakeAutomotive.
+/// They are already available to link against in the containing library.
 ///
 /// @ingroup automotive_systems
 ///

--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -39,7 +39,7 @@ namespace automotive {
 /// - drake::AutoDiffXd
 /// - drake::symbolic::Expression
 ///
-/// They are already available to link against in libdrakeAutomotive.
+/// They are already available to link against in the containing library.
 ///
 /// @ingroup automotive_systems
 template <typename T>

--- a/drake/automotive/single_lane_ego_and_agent.h
+++ b/drake/automotive/single_lane_ego_and_agent.h
@@ -38,7 +38,7 @@ namespace automotive {
 /// - AutoDiffXd
 /// - drake::symbolic::Expression
 ///
-/// They are already available to link against in libdrakeAutomotive.
+/// They are already available to link against in the containing library.
 ///
 /// @ingroup automotive_systems
 template <typename T>

--- a/drake/doc/cxx_inl.rst
+++ b/drake/doc/cxx_inl.rst
@@ -79,7 +79,7 @@ The header file declares and documents the class::
   /// Instantiated templates for the following kinds of T's are provided:
   /// - double
   ///
-  /// They are already available to link against in libmylibrary.
+  /// They are already available to link against in the containing library.
   template <typename T>
   class MyClass {
    public:

--- a/drake/examples/bouncing_ball/ball.h
+++ b/drake/examples/bouncing_ball/ball.h
@@ -20,7 +20,7 @@ namespace bouncing_ball {
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///
-/// They are already available to link against in drakeBouncingBall.
+/// They are already available to link against in the containing library.
 ///
 /// Inputs: no inputs.
 /// States: vertical position (state index 0) and velocity (state index 1) in

--- a/drake/examples/bouncing_ball/bouncing_ball.h
+++ b/drake/examples/bouncing_ball/bouncing_ball.h
@@ -21,7 +21,7 @@ namespace bouncing_ball {
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///
-/// They are already available to link against in drakeBouncingBall.
+/// They are already available to link against in the containing library.
 ///
 /// Inputs: no inputs.
 /// States: vertical position (state index 0) and velocity (state index 1) in

--- a/drake/multibody/rigid_body_frame.h
+++ b/drake/multibody/rigid_body_frame.h
@@ -23,7 +23,7 @@ class XMLElement;
 /// - AutoDiffXd
 /// - AutoDiffUpTo73d
 ///
-/// They are already available to link against in drakeRBM.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 template <typename T>
 class RigidBodyFrame {

--- a/drake/multibody/rigid_body_loop.h
+++ b/drake/multibody/rigid_body_loop.h
@@ -22,7 +22,7 @@
 /// - AutoDiffXd
 /// - AutoDiffUpTo73d
 ///
-/// They are already available to link against in drakeRBM.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 template <typename T>
 class RigidBodyLoop {

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -52,7 +52,7 @@ namespace systems {
  * @tparam T The vector element type, which must be a valid Eigen scalar.
  *
  * Instantiated templates for the following kinds of T's are provided and
- * available to link against in libdrakeSystemAnalysis:
+ * available to link against in the containing library:
  * - double
  * - AutoDiffXd
  *

--- a/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.h
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.h
@@ -23,7 +23,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 /// @ingroup rigid_body_systems
 template <typename T>

--- a/drake/systems/controllers/pid_controller.h
+++ b/drake/systems/controllers/pid_controller.h
@@ -28,7 +28,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 /// @ingroup primitive_systems
 template <typename T>

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.h
@@ -21,7 +21,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 template <typename T>
 class SpringMassStateVector : public BasicVector<T> {
@@ -66,7 +66,7 @@ class SpringMassStateVector : public BasicVector<T> {
 /// Instantiated templates for the following kinds of T's are provided:
 /// - const T&
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 ///
 /// @ingroup rigid_body_systems

--- a/drake/systems/primitives/adder.h
+++ b/drake/systems/primitives/adder.h
@@ -20,7 +20,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 template <typename T>
 class Adder : public LeafSystem<T> {

--- a/drake/systems/primitives/affine_system.h
+++ b/drake/systems/primitives/affine_system.h
@@ -27,7 +27,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 ///
 /// @ingroup primitive_systems

--- a/drake/systems/primitives/constant_value_source.h
+++ b/drake/systems/primitives/constant_value_source.h
@@ -21,7 +21,7 @@ namespace systems {
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 template <typename T>
 class ConstantValueSource : public LeafSystem<T> {
  public:

--- a/drake/systems/primitives/constant_vector_source.h
+++ b/drake/systems/primitives/constant_vector_source.h
@@ -20,7 +20,7 @@ namespace systems {
 /// - AutoDiffXd
 /// - symbolic::Expression
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 template <typename T>
 class ConstantVectorSource : public LeafSystem<T> {

--- a/drake/systems/primitives/demultiplexer.h
+++ b/drake/systems/primitives/demultiplexer.h
@@ -17,7 +17,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 /// @ingroup primitive_systems
 template <typename T>

--- a/drake/systems/primitives/gain.h
+++ b/drake/systems/primitives/gain.h
@@ -19,7 +19,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in drakeSystemFramework.
+/// They are already available to link against in the containing library.
 ///
 /// To use other specific scalar types see gain-inl.h.
 ///

--- a/drake/systems/primitives/integrator.h
+++ b/drake/systems/primitives/integrator.h
@@ -18,7 +18,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 /// @ingroup primitive_systems
 

--- a/drake/systems/primitives/linear_system.h
+++ b/drake/systems/primitives/linear_system.h
@@ -28,7 +28,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 ///
 /// @ingroup primitive_systems

--- a/drake/systems/primitives/matrix_gain.h
+++ b/drake/systems/primitives/matrix_gain.h
@@ -20,7 +20,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 ///
 /// @ingroup primitive_systems

--- a/drake/systems/primitives/multiplexer.h
+++ b/drake/systems/primitives/multiplexer.h
@@ -16,7 +16,7 @@ namespace systems {
 /// Instantiated templates for the following `T` values are provided:
 /// - double
 ///
-/// They are already available to link against in `libdrakeSystemsFramework`.
+/// They are already available to link against in the containing library.
 /// Currently, no other values for `T` are supported.
 ///
 /// @ingroup primitive_systems

--- a/drake/systems/primitives/pass_through.h
+++ b/drake/systems/primitives/pass_through.h
@@ -31,7 +31,7 @@ namespace systems {
 /// - double
 /// - AutoDiffXd
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// @ingroup primitive_systems
 
 template <typename T>

--- a/drake/systems/primitives/trajectory_source.h
+++ b/drake/systems/primitives/trajectory_source.h
@@ -20,7 +20,7 @@ namespace systems {
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
 ///
-/// They are already available to link against in libdrakeSystemFramework.
+/// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 /// @ingroup primitive_systems
 template <typename T>


### PR DESCRIPTION
To avoid boilerplate comment that is likely to be wrong, if not right away then a while later after changes occurring in code far, far away. Prompted by actual error [here](https://reviewable.io/reviews/robotlocomotion/drake/4708#-Ka4CDpdoat8g7kylhEt).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4742)
<!-- Reviewable:end -->
