### PR TITLE
Adds utility rotation matrix operations

### DIFF
--- a/drake/math/rotation_matrix.h
+++ b/drake/math/rotation_matrix.h
@@ -184,5 +184,72 @@ VectorX<typename Derived::Scalar> rotmat2Representation(
   }
 }
 
+/// Computes the rotation matrix for rotating by theta (radians) around the
+/// positive X axis.
+template <typename T>
+Matrix3<T> XRotation(const T& theta) {
+  Matrix3<T> R;
+  using std::sin;
+  using std::cos;
+  const double c = cos(theta), s = sin(theta);
+  // clang-format off
+  R << 1, 0,  0,
+       0, c, -s,
+       0, s,  c;
+  // clang-format on
+  return R;
+}
+
+/// Computes the rotation matrix for rotating by theta (radians) around the
+/// positive Y axis.
+template <typename T>
+Matrix3<T> YRotation(const T& theta) {
+  Matrix3<T> R;
+  using std::sin;
+  using std::cos;
+  const double c = cos(theta), s = sin(theta);
+  // clang-format off
+  R <<  c, 0, s,
+        0, 1, 0,
+       -s, 0, c;
+  // clang-format on
+  return R;
+}
+
+/// Computes the rotation matrix for rotating by theta (radians) around the
+/// positive Z axis.
+template <typename T>
+Matrix3<T> ZRotation(const T& theta) {
+  Matrix3<T> R;
+  using std::sin;
+  using std::cos;
+  const double c = cos(theta), s = sin(theta);
+  // clang-format off
+  R << c, -s, 0,
+       s,  c, 0,
+       0,  0,  1;
+  // clang-format on
+  return R;
+}
+
+/// Projects a full-rank 3x3 matrix @p M onto O(3), defined as
+/// <pre>
+///   min_R  \sum_i,j | R(i,j) - M(i,j) |^2
+///  subject to   R*R^T = I.
+/// </pre>
+///
+/// The algorithm (just SVD) can be derived as a small modification of
+/// section 3.2 in http://haralick.org/conferences/pose_estimation.pdf .
+///
+/// Note that it does not enforce det(R)=1; you could get det(R)=-1 if that
+/// solution is closer to the matrix M using the norm above.
+template <typename Derived>
+Matrix3<typename Derived::Scalar> ProjectMatToRotMat(
+    const Eigen::MatrixBase<Derived>& M) {
+  DRAKE_DEMAND(M.rows() == 3 && M.cols() == 3);
+  const auto svd = M.jacobiSvd(Eigen::ComputeFullU | Eigen::ComputeFullV);
+  return svd.matrixU() * svd.matrixV().transpose();
+}
+
 }  // namespace math
 }  // namespace drake

--- a/drake/math/test/rotation_matrix_test.cc
+++ b/drake/math/test/rotation_matrix_test.cc
@@ -1,0 +1,81 @@
+#include <cmath>
+#include <iostream>
+
+#include <Eigen/Dense>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/math/rotation_matrix.h"
+
+using Eigen::Vector3d;
+using Eigen::Matrix3d;
+
+namespace drake {
+namespace math {
+namespace {
+
+// Test XRotation, YRotation, ZRotation
+GTEST_TEST(RotationMatrixTest, TestXYZ) {
+  Vector3d i(1, 0, 0), j(0, 1, 0), k(0, 0, 1);
+
+  double tol = 1e-12;
+  EXPECT_TRUE(CompareMatrices(XRotation(M_PI_4) * i, i, tol));
+  EXPECT_TRUE(CompareMatrices(XRotation(M_PI_4) * j,
+                              Vector3d(0, M_SQRT1_2, M_SQRT1_2), tol));
+  EXPECT_TRUE(CompareMatrices(XRotation(M_PI_4) * k,
+                              Vector3d(0, -M_SQRT1_2, M_SQRT1_2), tol));
+
+  EXPECT_TRUE(CompareMatrices(YRotation(M_PI_4) * i,
+                              Vector3d(M_SQRT1_2, 0, -M_SQRT1_2), tol));
+  EXPECT_TRUE(CompareMatrices(YRotation(M_PI_4) * j, j, tol));
+  EXPECT_TRUE(CompareMatrices(YRotation(M_PI_4) * k,
+                              Vector3d(M_SQRT1_2, 0, M_SQRT1_2), tol));
+
+  EXPECT_TRUE(CompareMatrices(ZRotation(M_PI_4) * i,
+                              Vector3d(M_SQRT1_2, M_SQRT1_2, 0), tol));
+  EXPECT_TRUE(CompareMatrices(ZRotation(M_PI_4) * j,
+                              Vector3d(-M_SQRT1_2, M_SQRT1_2, 0), tol));
+  EXPECT_TRUE(CompareMatrices(ZRotation(M_PI_4) * k, k, tol));
+
+  // Test that rotations by PI do not change the rotation axis, and flip the
+  // signs on the other two axes.
+  EXPECT_TRUE(CompareMatrices(
+      XRotation(M_PI + 0.3),
+      Eigen::DiagonalMatrix<double, 3>(1, -1, -1) * XRotation(0.3), tol));
+  EXPECT_TRUE(CompareMatrices(
+      YRotation(M_PI + 0.3),
+      Eigen::DiagonalMatrix<double, 3>(-1, 1, -1) * YRotation(0.3), tol));
+  EXPECT_TRUE(CompareMatrices(
+      ZRotation(M_PI + 0.3),
+      Eigen::DiagonalMatrix<double, 3>(-1, -1, 1) * ZRotation(0.3), tol));
+}
+
+GTEST_TEST(RotationMatrixTest, TestProjection) {
+  double tol = 1e-12;
+
+  // Identity => Identity
+  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(Matrix3d::Identity()),
+                              Matrix3d::Identity(), tol));
+
+  // R1 (a valid rotation matrix) => R1
+  Matrix3d R1 = rpy2rotmat(Vector3d(0.1, 0.2, 0.3));
+  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(R1), R1, tol));
+
+  // 2*R1 => R1
+  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(2 * R1), R1, tol));
+
+  // Non-rotation matrix in gets an orthonormal matrix out.
+  Matrix3d M2;
+  M2 << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  Matrix3d R2 = ProjectMatToRotMat(M2);
+  EXPECT_TRUE(CompareMatrices(R2.transpose(), R2.inverse(), tol));
+
+  // Determinant could be -1 or 1.
+  EXPECT_NEAR(std::abs(R2.determinant()), 1.0, tol);
+}
+
+}  // namespace
+}  // namespace math
+}  // namespace drake


### PR DESCRIPTION
 - rotation matrices about the x-, y-, and z- axes
 - projecting a non-rotation matrix to the closest orthonormal matrix (in the frobenious norm).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4751)
<!-- Reviewable:end -->
