### PR TITLE
Format BUILD files; add reviewable syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# These lines tell reviewable.io how to highlight source code.
+**/*.bzl diff=python
+**/BUILD diff=python
+**/BUILD.bazel diff=python
+WORKSPACE diff=python

--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -8,12 +8,12 @@ cc_library(
     srcs = [
         "generate_obj.cc",
         "generate_urdf.cc",
-        "infinite_circuit_road.cc"
+        "infinite_circuit_road.cc",
     ],
     hdrs = [
         "generate_obj.h",
         "generate_urdf.h",
-        "infinite_circuit_road.h"
+        "infinite_circuit_road.h",
     ],
     linkstatic = 1,
     deps = [
@@ -32,7 +32,6 @@ cc_binary(
         "//drake/common:text_logging_gflags",
     ],
 )
-
 
 # === test/ ===
 
@@ -65,7 +64,7 @@ py_test(
     srcs = ["test/yaml_to_obj_test.py"],
     args = ["drake/automotive/maliput/utility/yaml_to_obj"],
     data = [
-        "//drake/automotive/maliput/monolane:yamls",
         ":yaml_to_obj",
+        "//drake/automotive/maliput/monolane:yamls",
     ],
 )

--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -20,8 +20,8 @@ cc_library(
     hdrs = ["param_parsers/rigid_body_tree_alias_groups.h"],
     linkstatic = 1,
     deps = [
-        "@yaml_cpp//:lib",
         "//drake/multibody:rigid_body_tree",
+        "@yaml_cpp//:lib",
     ],
 )
 

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -177,10 +177,11 @@ cc_library(
 cc_googletest(
     name = "binding_test",
     srcs = [
-        "test/binding_test.cc"
+        "test/binding_test.cc",
     ],
-    deps = [":binding",
-            ":constraint"
+    deps = [
+        ":binding",
+        ":constraint",
     ],
 )
 


### PR DESCRIPTION
This runs `tools/buildifier.sh` to format `BUILD` files in the standard way.  (We will eventually enforce this with CI and editor configs, but for now it's just me doing it manually.)

But really, this is a chance to see if Reviewable/Reviewable#449 suggestion for syntax highlighting is going to work, by adding a `.gitattributes` file.  _Edit: Looks great!_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4759)
<!-- Reviewable:end -->
