### PR TITLE
Expand message when non-triangular meshes are loaded as static meshes

### DIFF
--- a/drake/multibody/collision/bullet_model.cc
+++ b/drake/multibody/collision/bullet_model.cc
@@ -300,7 +300,9 @@ void BulletModel::DoAddElement(const Element& element) {
             bt_shape_no_margin = newBulletStaticMeshShape(mesh, false);
             success = true;
           } catch (std::exception &e) {
-            drake::log()->log(spdlog::level::warn, e.what());
+            drake::log()->warn(std::string(e.what()) +
+                ". Unable to construct triangle mesh from obj file; using "
+                "convex hull of mesh instead.");
           }
         }
         if (!success) {  // A convex hull representation of the mesh points.


### PR DESCRIPTION
The log message for when a static triangle mesh cannot be created has been
extended to provide more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4763)
<!-- Reviewable:end -->
