### PR TITLE
Added Named Accessors to RigidBodyPlant's Ports and Made Plant-Centric Actuator Command Input Port Only Available in Mono-Model-instance RigidBodyPlants.

### DIFF
--- a/drake/examples/Quadrotor/test/quadrotor_dynamics_test.cc
+++ b/drake/examples/Quadrotor/test/quadrotor_dynamics_test.cc
@@ -77,14 +77,6 @@ class RigidBodyQuadrotor: public systems::Diagram<T> {
     plant_ =
         builder.template AddSystem<systems::RigidBodyPlant<T>>(std::move(tree));
 
-    VectorX<T> hover_input(plant_->get_input_size());
-    hover_input.setZero();
-    systems::ConstantVectorSource<T> *source =
-        builder.template AddSystem<systems::ConstantVectorSource<T>>(
-            hover_input);
-
-    builder.Connect(source->get_output_port(), plant_->get_input_port(0));
-
     builder.BuildInto(this);
   }
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
@@ -100,7 +100,7 @@ PassiveVisualizedPlant<T>::PassiveVisualizedPlant(
   // Fixes constant sources to all inputs.
   const systems::RigidBodyPlant<T>& plant = visualized_plant_->plant();
 
-  for (int instance_id = RigidBodyTreeConstants::kFirstModelInstanceId;
+  for (int instance_id = RigidBodyTreeConstants::kFirstNonWorldModelInstanceId;
       instance_id < plant.get_num_model_instances(); ++instance_id) {
     if (plant.model_instance_has_actuators(instance_id)) {
       const int input_port_index =

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
@@ -39,6 +39,7 @@ using systems::Demultiplexer;
 using systems::Diagram;
 using systems::DiagramBuilder;
 using systems::DrakeVisualizer;
+using systems::InputPortDescriptor;
 using systems::Multiplexer;
 using systems::PidControlledSystem;
 using systems::RigidBodyPlant;
@@ -73,9 +74,14 @@ VisualizedPlant<T>::VisualizedPlant(
   builder.Connect(rigid_body_plant_->state_output_port(),
                   viz_publisher_->get_input_port(0));
 
-  // Exposes output and input ports of the Diagram.
-  builder.ExportOutput(rigid_body_plant_->get_output_port(0));
-  builder.ExportInput(rigid_body_plant_->get_input_port(0));
+  // Exports all of the RigidBodyPlant's input and output ports.
+  for (int i = 0; i < rigid_body_plant_->get_num_input_ports(); ++i) {
+    builder.ExportInput(rigid_body_plant_->get_input_port(i));
+  }
+
+  for (int i = 0; i < rigid_body_plant_->get_num_output_ports(); ++i) {
+    builder.ExportOutput(rigid_body_plant_->get_output_port(i));
+  }
 
   drake::log()->debug("Plant and visualizer Diagram built...");
 
@@ -88,22 +94,34 @@ PassiveVisualizedPlant<T>::PassiveVisualizedPlant(
     std::unique_ptr<VisualizedPlant<T>> visualized_plant) {
   // Sets up a builder for the demo.
   DiagramBuilder<T> builder;
-
-  const int num_inputs = visualized_plant->get_input_port(0).size();
   visualized_plant_ = builder.template AddSystem<VisualizedPlant<T>>(
       std::move(visualized_plant));
 
-  // Instantiates a constant source that outputs a vector of zeros.
-  VectorX<double> constant_value(num_inputs);
-  constant_value.setZero();
+  // Fixes constant sources to all inputs.
+  const systems::RigidBodyPlant<T>& plant = visualized_plant_->plant();
 
-  constant_vector_source_ =
-      builder.template AddSystem<systems::ConstantVectorSource<T>>(
-          constant_value);
+  for (int instance_id = RigidBodyTreeConstants::kFirstModelInstanceId;
+      instance_id < plant.get_num_model_instances(); ++instance_id) {
+    if (plant.model_instance_has_actuators(instance_id)) {
+      const int input_port_index =
+          plant.model_instance_actuator_command_input_port(instance_id)
+              .get_index();
+      const InputPortDescriptor<T>& input_port =
+          visualized_plant_->get_input_port(input_port_index);
+      const int num_inputs = input_port.size();
+      // Instantiates a constant source that outputs a vector of zeros.
+      VectorX<double> constant_value(num_inputs);
+      constant_value.setZero();
 
-  // Cascades the constant source to the plant and visualizer diagram. This
-  // effectively results in the robot being uncontrolled.
-  builder.Cascade(*constant_vector_source_, *visualized_plant_);
+      // Cascades the constant source to the model instance within the plant and
+      // visualizer diagram. This effectively results in the model instance
+      // being uncontrolled, i.e., passive.
+      systems::ConstantVectorSource<T>* constant_vector_source =
+          builder.template AddSystem<systems::ConstantVectorSource<T>>(
+              constant_value);
+      builder.Connect(constant_vector_source->get_output_port(), input_port);
+    }
+  }
 
   builder.BuildInto(this);
 }
@@ -123,9 +141,10 @@ PositionControlledPlantWithRobot<T>::PositionControlledPlantWithRobot(
       builder.template AddSystem<RigidBodyPlant>(std::move(world_tree));
 
   const auto& robot_input_port =
-      rigid_body_plant_->model_input_port(robot_instance_id);
+      rigid_body_plant_->model_instance_actuator_command_input_port(
+          robot_instance_id);
   const auto& robot_output_port =
-      rigid_body_plant_->model_state_output_port(robot_instance_id);
+      rigid_body_plant_->model_instance_state_output_port(robot_instance_id);
   const auto& plant_output_port = rigid_body_plant_->state_output_port();
 
   rigid_body_plant_->set_contact_parameters(

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
@@ -70,7 +70,7 @@ VisualizedPlant<T>::VisualizedPlant(
       rigid_body_plant_->get_rigid_body_tree(), lcm);
 
   // Connects the plant to the publisher for visualization.
-  builder.Connect(rigid_body_plant_->get_output_port(0),
+  builder.Connect(rigid_body_plant_->state_output_port(),
                   viz_publisher_->get_input_port(0));
 
   // Exposes output and input ports of the Diagram.
@@ -126,7 +126,7 @@ PositionControlledPlantWithRobot<T>::PositionControlledPlantWithRobot(
       rigid_body_plant_->model_input_port(robot_instance_id);
   const auto& robot_output_port =
       rigid_body_plant_->model_state_output_port(robot_instance_id);
-  const auto& plant_output_port = rigid_body_plant_->get_output_port(0);
+  const auto& plant_output_port = rigid_body_plant_->state_output_port();
 
   rigid_body_plant_->set_contact_parameters(
       penetration_stiffness, penetration_damping, friction_coefficient);

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.h
@@ -40,6 +40,9 @@ class VisualizedPlant : public systems::Diagram<T> {
                   double penetration_stiffness, double penetration_damping,
                   double friction_coefficient, lcm::DrakeLcmInterface* lcm);
 
+  const systems::RigidBodyPlant<T>& plant() const {
+    return *rigid_body_plant_;
+  }
  private:
   systems::RigidBodyPlant<T>* rigid_body_plant_{nullptr};
   systems::DrakeVisualizer* drake_visualizer{nullptr};
@@ -58,7 +61,6 @@ class PassiveVisualizedPlant : public systems::Diagram<T> {
 
  private:
   VisualizedPlant<T>* visualized_plant_{nullptr};
-  systems::ConstantVectorSource<T>* constant_vector_source_{nullptr};
 };
 
 /// A custom `systems::Diagram` consisting of a `systems::PidControlledSystem`

--- a/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -136,13 +136,15 @@ class SimulatedIiwaWithWsg : public systems::Diagram<T> {
     int wsg_instance_id{};
     plant_ = builder.AddSystem(BuildCombinedPlant<T>(&iiwa_instance_id,
                                                      &wsg_instance_id));
-    const auto& iiwa_input_port = plant_->model_input_port(iiwa_instance_id);
+    const auto& iiwa_input_port =
+        plant_->model_instance_actuator_command_input_port(iiwa_instance_id);
     const auto& iiwa_output_port =
-        plant_->model_state_output_port(iiwa_instance_id);
+        plant_->model_instance_state_output_port(iiwa_instance_id);
 
-    const auto& wsg_input_port = plant_->model_input_port(wsg_instance_id);
+    const auto& wsg_input_port =
+        plant_->model_instance_actuator_command_input_port(wsg_instance_id);
     const auto& wsg_output_port =
-            plant_->model_state_output_port(wsg_instance_id);
+            plant_->model_instance_state_output_port(wsg_instance_id);
 
     // Connect the pid controllers for each device.
 

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -86,7 +86,7 @@ class SimulatedKuka : public systems::Diagram<T> {
           std::move(rigid_body_tree));
       plant_ = plant.get();
 
-      DRAKE_ASSERT(plant_->get_input_port(0).size() ==
+      DRAKE_ASSERT(plant_->command_input_port().size() ==
                    plant_->get_num_positions());
 
       // Constants are chosen by trial and error to qualitatively match

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -86,7 +86,7 @@ class SimulatedKuka : public systems::Diagram<T> {
           std::move(rigid_body_tree));
       plant_ = plant.get();
 
-      DRAKE_ASSERT(plant_->command_input_port().size() ==
+      DRAKE_ASSERT(plant_->actuator_command_input_port().size() ==
                    plant_->get_num_positions());
 
       // Constants are chosen by trial and error to qualitatively match

--- a/drake/examples/toyota_hsrb/hsrb_diagram_factories.cc
+++ b/drake/examples/toyota_hsrb/hsrb_diagram_factories.cc
@@ -71,7 +71,8 @@ unique_ptr<systems::Diagram<double>> BuildPlantAndVisualizerDiagram(
 
   // Instantiates a system for visualizing the model.
   const auto visualizer = builder.AddSystem<DrakeVisualizer>(tree, lcm);
-  builder.Connect(plant_ptr->get_output_port(0), visualizer->get_input_port(0));
+  builder.Connect(plant_ptr->state_output_port(),
+                  visualizer->get_input_port(0));
 
   // Exports all of the RigidBodyPlant's input and output ports.
   for (int i = 0; i < plant_ptr->get_num_input_ports(); ++i) {

--- a/drake/multibody/benchmarks/cylinder_torque_free_analytical_solution/test/cylinder_torque_free_analytical_solution.cc
+++ b/drake/multibody/benchmarks/cylinder_torque_free_analytical_solution/test/cylinder_torque_free_analytical_solution.cc
@@ -269,7 +269,7 @@ GTEST_TEST(uniformSolidCylinderTorqueFree, testA) {
   const drake::multibody::joints::FloatingBaseType joint_type =
       drake::multibody::joints::kQuaternion;
   std::shared_ptr<RigidBodyFrame<double>> weld_to_frame = nullptr;
-  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+  parsers::urdf::AddModelInstanceFromUrdfFile(
       urdf_dir_file_name, joint_type, weld_to_frame, tree.get());
 
   // Create 4x1 matrix for quaternion e0, e1, e2, e3 (defined below).
@@ -333,11 +333,6 @@ GTEST_TEST(uniformSolidCylinderTorqueFree, testA) {
   // Allocate space to hold time-derivative of state_drake.
   std::unique_ptr<systems::ContinuousState<double>> stateDt_drake =
       rigid_body_plant.AllocateTimeDerivatives();
-
-  // Even though there are no actuators here we have to create a zero-length
-  // actuator input port.
-  const int num_actuators = rigid_body_plant.get_num_actuators();
-  context->FixInputPort(0, VectorXd::Zero(num_actuators));
 
   // Evaluate the time-derivatives of the state.
   rigid_body_plant.CalcTimeDerivatives(*context, stateDt_drake.get());

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -15,6 +15,7 @@
 
 using std::make_unique;
 using std::move;
+using std::runtime_error;
 using std::string;
 using std::unique_ptr;
 using std::vector;
@@ -33,21 +34,18 @@ template <typename T>
 RigidBodyPlant<T>::RigidBodyPlant(std::unique_ptr<const RigidBodyTree<T>> tree)
     : tree_(move(tree)) {
   DRAKE_DEMAND(tree_ != nullptr);
-
-  // Declares an input port for the command vector. The commands in this vector
-  // are sent to the actuators within the RigidBodyTree.
-  command_input_port_index_ = System<T>::DeclareInputPort(kVectorValued,
-      get_num_actuators()).get_index();
-  // Declares a vector-valued output port for `x`, the plant's generalized state
-  // vector.
   state_output_port_index_ =
       this->DeclareOutputPort(kVectorValued, get_num_states()).get_index();
+  ExportModelInstanceCentricPorts();
   // Declares an abstract valued output port for kinematics results.
   kinematics_output_port_index_ = this->DeclareAbstractOutputPort().get_index();
   // Declares an abstract valued output port for contact information.
   contact_output_port_index_ = this->DeclareAbstractOutputPort().get_index();
+}
 
-  const int num_instances = tree_->get_num_model_instances();
+template <typename T>
+void RigidBodyPlant<T>::ExportModelInstanceCentricPorts() {
+const int num_instances = tree_->get_num_model_instances();
   const std::pair<int, int> default_entry =
       std::pair<int, int>(kInvalidPortIdentifier, 0);
   input_map_.resize(num_instances, kInvalidPortIdentifier);
@@ -250,9 +248,23 @@ template <typename T>
 std::unique_ptr<SystemOutput<T>> RigidBodyPlant<T>::AllocateOutput(
     const Context<T>& context) const {
   auto output = make_unique<LeafSystemOutput<T>>();
-  // Allocates an output port for the state vector.
+
+  // Note that the ordering here must match the order in which the output ports
+  // were declared during construction.
+
+  // Allocates an output port for the plant-centric state vector.
   {
     auto data = make_unique<BasicVector<T>>(get_num_states());
+    auto port = make_unique<OutputPort>(move(data));
+    output->get_mutable_ports()->push_back(move(port));
+  }
+
+  // Allocates an output port for each model instance's state vector in the
+  // RigidBodyTree.
+  for (int instance_id = 0;
+       instance_id < get_num_model_instances(); ++instance_id) {
+    if (output_map_[instance_id] == kInvalidPortIdentifier) { continue; }
+    auto data = make_unique<BasicVector<T>>(get_num_states(instance_id));
     auto port = make_unique<OutputPort>(move(data));
     output->get_mutable_ports()->push_back(move(port));
   }
@@ -271,29 +283,65 @@ std::unique_ptr<SystemOutput<T>> RigidBodyPlant<T>::AllocateOutput(
     output->add_port(move(contact_results));
   }
 
-  // Allocates an output port for each model instance's state vector in the
-  // RigidBodyTree.
-  for (int instance_id = 0;
-       instance_id < get_num_model_instances(); ++instance_id) {
-    if (output_map_[instance_id] == kInvalidPortIdentifier) { continue; }
-    auto data = make_unique<BasicVector<T>>(get_num_states(instance_id));
-    auto port = make_unique<OutputPort>(move(data));
-    output->get_mutable_ports()->push_back(move(port));
-  }
-
   return std::unique_ptr<SystemOutput<T>>(output.release());
+}
+
+template <typename T>
+const OutputPortDescriptor<T>&
+RigidBodyPlant<T>::model_instance_state_output_port(
+    int model_instance_id) const {
+  if (model_instance_id >= static_cast<int>(output_map_.size())) {
+    throw std::runtime_error("RigidBodyPlant::model_state_output_port(): "
+        "ERROR: Model instance with ID " + std::to_string(model_instance_id) +
+        " does not exist! Maximum ID is " +
+        std::to_string(output_map_.size() - 1) + ".");
+  }
+  if (output_map_.at(model_instance_id) == kInvalidPortIdentifier) {
+    throw std::runtime_error("RigidBodyPlant::model_state_output_port(): "
+        "ERROR: Model instance with ID " + std::to_string(model_instance_id) +
+        " does not have any state output port!");
+  }
+  return System<T>::get_output_port(output_map_.at(model_instance_id));
 }
 
 template <typename T>
 std::unique_ptr<ContinuousState<T>> RigidBodyPlant<T>::AllocateContinuousState()
     const {
-  // The state is second-order.
-  DRAKE_ASSERT(command_input_port().size() == get_num_actuators());
   // TODO(amcastro-tri): add z state to track energy conservation.
-  return std::make_unique<ContinuousState<T>>(
-      std::make_unique<BasicVector<T>>(get_num_states()),
-      get_num_positions() /* num_q */, get_num_velocities() /* num_v */,
-      0 /* num_z */);
+  return make_unique<ContinuousState<T>>(
+      make_unique<BasicVector<T>>(get_num_states()),
+      get_num_positions()    /* num_q */,
+      get_num_velocities()   /* num_v */,
+      0                      /* num_z */);
+}
+
+template <typename T>
+bool RigidBodyPlant<T>::model_instance_has_actuators(int model_instance_id)
+    const {
+  DRAKE_ASSERT(static_cast<int>(input_map_.size()) ==
+                   get_num_model_instances());
+  if (model_instance_id >= get_num_model_instances()) {
+    throw std::runtime_error(
+        "RigidBodyPlant::model_instance_has_actuators(): ERROR: provided "
+        "model_instance_id of " + std::to_string(model_instance_id) +
+        " does not exist. Maximum model_instance_id is " +
+        std::to_string(get_num_model_instances()));
+  }
+  return input_map_.at(model_instance_id) != kInvalidPortIdentifier;
+}
+
+template <typename T>
+const InputPortDescriptor<T>&
+    RigidBodyPlant<T>::model_instance_actuator_command_input_port(
+        int model_instance_id) const {
+  if (input_map_.at(model_instance_id) == kInvalidPortIdentifier) {
+    throw std::runtime_error("RigidBodyPlant::"
+        "model_instance_actuator_command_input_port(): ERROR model instance "
+        "with ID " + std::to_string(model_instance_id) + " does not have "
+        "an actuator command input ports because it does not have any "
+        "actuators.");
+  }
+  return System<T>::get_input_port(input_map_.at(model_instance_id));
 }
 
 template <typename T>
@@ -302,15 +350,17 @@ void RigidBodyPlant<T>::DoCalcOutput(const Context<T>& context,
   DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
+  // TODO(amcastro-tri): Remove this copy by allowing output ports to be
+  // mere pointers to state variables (or cache lines).
+  const VectorX<T> state_vector =
+      context.get_continuous_state()->CopyToVector();
+
   // Evaluates the state output port.
   BasicVector<T>* state_output_vector =
       output->GetMutableVectorData(state_output_port_index_);
-  // TODO(amcastro-tri): Remove this copy by allowing output ports to be
-  // mere pointers to state variables (or cache lines).
-  state_output_vector->get_mutable_value() =
-      context.get_continuous_state()->CopyToVector();
-  const auto state_vector = state_output_vector->get_value();
+  state_output_vector->get_mutable_value() = state_vector;
 
+  // Updates the model-instance-centric state output ports.
   for (int instance_id = 0;
        instance_id < get_num_model_instances(); ++instance_id) {
     if (output_map_[instance_id] == kInvalidPortIdentifier) { continue; }
@@ -328,13 +378,13 @@ void RigidBodyPlant<T>::DoCalcOutput(const Context<T>& context,
                              instance_velocities.second);
   }
 
-  // Evaluates the kinematics results output port.
+  // Updates the kinematics results output port.
   auto& kinematics_results =
       output->GetMutableData(kinematics_output_port_index_)
           ->template GetMutableValue<KinematicsResults<T>>();
   kinematics_results.UpdateFromContext(context);
 
-  // Evaluates the contact results output port.
+  // Updates the contact results output port.
   auto& contact_results = output->GetMutableData(contact_output_port_index_)
                               ->template GetMutableValue<ContactResults<T>>();
   ComputeContactResults(context, &contact_results);
@@ -354,20 +404,28 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
   DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
   DRAKE_DEMAND(derivatives != nullptr);
 
-  // The input vector of actuation values.
-  VectorX<T> u;
-  const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-  if (input != nullptr) {
+
+
+  VectorX<T> u;   // The plant-centric input vector of actuation values.
+  u.resize(get_num_actuators());
+  u.fill(0.);
+
+  if (get_num_actuators() > 0) {
+    // The following code checks that all plant-centric actuator command input
+    // ports for are connected. It throws a runtime_error exception if this is
+    // not the case.
     for (int instance_id = 0;
-         instance_id < get_num_model_instances(); ++instance_id) {
+        instance_id < get_num_model_instances(); ++instance_id) {
       if (input_map_[instance_id] == kInvalidPortIdentifier) { continue; }
-      DRAKE_ASSERT(
-          this->EvalVectorInput(context, input_map_[instance_id]) == nullptr);
+      if (this->EvalVectorInput(context, input_map_[instance_id]) == nullptr) {
+        throw runtime_error("RigidBodyPlant::DoCalcTimeDerivatives(): ERROR: "
+           "Actuator command input port for model instance " +
+           std::to_string(instance_id) + " is not connected. All " +
+           std::to_string(get_num_model_instances()) + " actuator command "
+           "input ports must be connected.");
+      }
     }
-    u = input->get_value();
-  } else {
-    u.resize(get_num_actuators());
-    u.fill(0.);
+
     for (int instance_id = 0;
          instance_id < get_num_model_instances(); ++instance_id) {
       if (input_map_[instance_id] == kInvalidPortIdentifier) { continue; }
@@ -489,7 +547,7 @@ int RigidBodyPlant<T>::FindInstancePositionIndexFromWorldIndex(
   const auto& instance_positions = position_map_[model_instance_id];
   if (world_position_index >=
       (instance_positions.first + instance_positions.second)) {
-    throw std::runtime_error(
+    throw runtime_error(
         "Unable to find position index in model instance.");
   }
   return world_position_index - instance_positions.first;

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -34,9 +34,8 @@ RigidBodyPlant<T>::RigidBodyPlant(std::unique_ptr<const RigidBodyTree<T>> tree)
     : tree_(move(tree)) {
   DRAKE_DEMAND(tree_ != nullptr);
 
-  // Declares an input port for the generalized force vector. The generalized
-  // forces in this vector are sent as commands to the actuators within the
-  // RigidBodyTree.
+  // Declares an input port for the command vector. The commands in this vector
+  // are sent to the actuators within the RigidBodyTree.
   command_input_port_index_ = System<T>::DeclareInputPort(kVectorValued,
       get_num_actuators()).get_index();
   // Declares a vector-valued output port for `x`, the plant's generalized state

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -411,9 +411,8 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
   u.fill(0.);
 
   if (get_num_actuators() > 0) {
-    // The following code checks that all plant-centric actuator command input
-    // ports for are connected. It throws a runtime_error exception if this is
-    // not the case.
+    // The following code evaluates the actuator command input ports and throws
+    // a runtime_error exception if at least one of the ports is not connected.
     for (int instance_id = 0;
         instance_id < get_num_model_instances(); ++instance_id) {
       if (input_map_[instance_id] == kInvalidPortIdentifier) { continue; }

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -71,9 +71,7 @@ namespace systems {
 ///   actuators, use model_instance_has_actuators().
 ///
 /// - model_instance_state_output_port(): A vector-valued port containing the
-///   state vector for a particular model instance in the RigidBodyTree. This
-///   method can only be called when this class is instantiated with constructor
-///   parameter `export_model_instance_centric_ports` equal to `true`.
+///   state vector for a particular model instance in the RigidBodyTree.
 ///
 /// The %RigidBodyPlant's state consists of a vector containing the generalized
 /// positions followed by the generalized velocities of the system. This state
@@ -115,7 +113,7 @@ template <typename T>
 class RigidBodyPlant : public LeafSystem<T> {
  public:
   /// Instantiates a %RigidBodyPlant from a Multi-Body Dynamics (MBD) model of
-  /// the world in @p tree.  @p tree must not be `nullptr`.
+  /// the world in `tree`.  `tree` must not be `nullptr`.
   ///
   /// @param[in] tree the dynamic model to use with this plant.
   // TODO(SeanCurtis-TRI): It appears that the tree has to be "compiled"
@@ -178,25 +176,25 @@ class RigidBodyPlant : public LeafSystem<T> {
   /// of the continuous state vector.
   int get_output_size() const;
 
-  /// Sets the generalized coordinate @p position_index to the value
-  /// @p position.
+  /// Sets the generalized coordinate `position_index` to the value
+  /// `position`.
   void set_position(Context<T>* context,
                     int position_index, T position) const;
 
-  /// Sets the generalized velocity @p velocity_index to the value
-  /// @p velocity.
+  /// Sets the generalized velocity `velocity_index` to the value
+  /// `velocity`.
   void set_velocity(Context<T>* context,
                     int velocity_index, T velocity) const;
 
-  /// Sets the continuous state vector of the system to be @p x.
+  /// Sets the continuous state vector of the system to be `x`.
   void set_state_vector(Context<T>* context,
                         const Eigen::Ref<const VectorX<T>> x) const;
 
-  /// Sets the continuous state vector of the system to be @p x.
+  /// Sets the continuous state vector of the system to be `x`.
   void set_state_vector(State<T>* state,
                         const Eigen::Ref<const VectorX<T>> x) const;
 
-  /// Sets the state in @p context so that generalized positions and velocities
+  /// Sets the state in `context` so that generalized positions and velocities
   /// are zero. For quaternion based joints the quaternion is set to be the
   /// identity (or equivalently a zero rotation).
   void SetDefaultState(const Context<T>& context,
@@ -229,9 +227,9 @@ class RigidBodyPlant : public LeafSystem<T> {
   static T JointLimitForce(const DrakeJoint& joint,
                            const T& position, const T& velocity);
 
-  /// Returns the index into the output port for @p model_instance_id
-  /// which corresponds to the world position index of @p
-  /// world_position_index, or throws if the position index does not
+  /// Returns the index into the output port for `model_instance_id`
+  /// which corresponds to the world position index of
+  /// `world_position_index`, or throws if the position index does not
   /// correspond to the model id.
   int FindInstancePositionIndexFromWorldIndex(
       int model_instance_id, int world_position_index);
@@ -256,7 +254,7 @@ class RigidBodyPlant : public LeafSystem<T> {
   /// only be called when there is only one model instance in the RigidBodyTree.
   /// Otherwise, a std::runtime_error will be thrown. It returns the same port
   /// as model_instance_actuator_command_input_port() using input
-  /// parameter RigidBodyTreeConstants::kFirstModelInstanceId.
+  /// parameter RigidBodyTreeConstants::kFirstNonWorldModelInstanceId.
   const InputPortDescriptor<T>& actuator_command_input_port() const {
     if (get_num_model_instances() != 1) {
       throw std::runtime_error("RigidBodyPlant::actuator_command_input_port(): "
@@ -266,12 +264,12 @@ class RigidBodyPlant : public LeafSystem<T> {
           "RigidBodyTree.");
     }
     return model_instance_actuator_command_input_port(
-                         RigidBodyTreeConstants::kFirstModelInstanceId);
+                         RigidBodyTreeConstants::kFirstNonWorldModelInstanceId);
   }
 
-  // Returns true if and only if the model instance with the provided
-  // `model_instance_id` has actuators. This is useful when trying to determine
-  // whether it's safe to call model_instance_actuator_command_input_port().
+  /// Returns true if and only if the model instance with the provided
+  /// `model_instance_id` has actuators. This is useful when trying to determine
+  /// whether it's safe to call model_instance_actuator_command_input_port().
   bool model_instance_has_actuators(int model_instance_id) const;
 
   /// Returns a descriptor of the input port for a specific model instance. This
@@ -295,8 +293,8 @@ class RigidBodyPlant : public LeafSystem<T> {
   }
 
   /// Returns a descriptor of the output port containing the state of a
-  /// particular model with instance ID equal to @p model_instance_id. Throws a
-  /// std::runtime_error if @p model_instance_id does not exist. This method can
+  /// particular model with instance ID equal to `model_instance_id`. Throws a
+  /// std::runtime_error if `model_instance_id` does not exist. This method can
   /// only be called when this class is instantiated with constructor parameter
   /// `export_model_instance_centric_ports` equal to `true`.
   const OutputPortDescriptor<T>& model_instance_state_output_port(

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -18,40 +18,35 @@ namespace systems {
 /// This class provides a System interface around a multibody dynamics model
 /// of the world represented by a RigidBodyTree.
 ///
-/// The %RigidBodyPlant provides a number of input and output ports. The precise
-/// number depends on the number of model instances within the RigidBodyTree
-/// and the number of them that have actuators. The following lists the
-/// accessors for obtaining the input and output ports of the %RigidBodyPlant.
-/// These accessors are typically used when "wiring up" a RigidBodyPlant within
-/// a Diagram using DiagramBuilder. See, for example, DiagramBuilder::Connect(),
+/// The %RigidBodyPlant provides a number of input and output ports. The number
+/// and types of port accessors depends on the number of model instances within
+/// the RigidBodyTree with actuators. The following lists the accessors for
+/// obtaining the input and output ports of the %RigidBodyPlant. These accessors
+/// are typically used when "wiring up" a RigidBodyPlant within a Diagram using
+/// DiagramBuilder. See, for example, DiagramBuilder::Connect(),
 /// DiagramBuilder::ExportInput(), and DiagramBuilder::ExportOutput().
 ///
-/// <B>Input Port Accessors:</B>
+/// <B>Plant-Centric Port Accessors:</B>
 ///
-/// - command_input_port(): Contains the command vector for the RigidBodyTree's
-///   actuators. Note that if this port is connected, none of the ports returned
-///   by model_input_port() can be connected. The size of this vector is equal
-///   to the number of RigidBodyActuator's in the RigidBodyTree. Each
-///   RigidBodyActuator maps to a single-DOF joint (currently actuation cannot
-///   be applied to multiple-DOF joints). The units of the actuation are the
-///   same as the units of the generalized force on the joint. In addition,
-///   actuators allow for a gear box reduction factor and for actuation
-///   limits which are only used by controllers; the RigidBodyPlant does
-///   not apply these limits. The gear box factor effectively is a
-///   multiplier on the input actuation to the RigidBodyPlant.
-///
-/// - model_input_port(): Contains the command vector for the actuators
-///   belonging to a particular model instance within the RigidBodyTree.
-///   If any port returned by model_input_port() is connected, the input port
-///   for the full tree, which is obtained using command_input_port(), must not
-///   be used.
-///
-/// <B>Output Port Accessors:</B>
+/// - actuator_command_input_port(): Contains the command vector for the
+///   RigidBodyTree's actuators. This method can only be called when there is
+///   only one model instance in the RigidBodyTree, as
+///   determined by get_num_model_instances(), and this model instance has at
+///   least one actuator. The size of this vector equals the number of
+///   RigidBodyActuator's in the RigidBodyTree. Each RigidBodyActuator maps to a
+///   single-DOF joint (currently actuation cannot be applied to multiple-DOF
+///   joints). The units of the actuation are the same as the units of the
+///   generalized force on the joint. In addition, actuators allow for a gear
+///   box reduction factor and for actuation limits which are only used by
+///   controllers; the RigidBodyPlant does not apply these limits. The gear box
+///   factor effectively is a multiplier on the input actuation to the
+///   RigidBodyPlant.
 ///
 /// - state_output_port(): A vector-valued port containing the state vector,
-///   `x`, of the system. The state vector, `x`, consists of generalized
-///   positions followed by generalized velocities. Semantics of `x` can be
-///   obtained using the following methods:
+///   `x`, of the system. This is useful for downstream systems that require
+///   `x`, which includes DrakeVisualizer. The state vector, `x`, consists of
+///   generalized positions followed by generalized velocities. Semantics of `x`
+///   can be obtained using the following methods:
 ///
 ///   - RigidBodyPlant<T>::get_num_states()
 ///   - RigidBodyTree<T>::get_num_positions()
@@ -67,8 +62,18 @@ namespace systems {
 ///   ContactsResults object allowing access to the results from contact
 ///   computations.
 ///
-/// - model_state_output_port(): A vector-valued port containing the state
-///   vector for a particular model instance in the RigidBodyTree.
+/// <B>Model-Instance-Centric Port Accessors:</B>
+///
+/// - model_instance_actuator_command_input_port(): Contains the command vector
+///   for the actuators belonging to a particular model instance within the
+///   RigidBodyTree. This method can only be called using the model instance ID
+///   of a model with actuators. To determine if a model instance possesses
+///   actuators, use model_instance_has_actuators().
+///
+/// - model_instance_state_output_port(): A vector-valued port containing the
+///   state vector for a particular model instance in the RigidBodyTree. This
+///   method can only be called when this class is instantiated with constructor
+///   parameter `export_model_instance_centric_ports` equal to `true`.
 ///
 /// The %RigidBodyPlant's state consists of a vector containing the generalized
 /// positions followed by the generalized velocities of the system. This state
@@ -111,6 +116,8 @@ class RigidBodyPlant : public LeafSystem<T> {
  public:
   /// Instantiates a %RigidBodyPlant from a Multi-Body Dynamics (MBD) model of
   /// the world in @p tree.  @p tree must not be `nullptr`.
+  ///
+  /// @param[in] tree the dynamic model to use with this plant.
   // TODO(SeanCurtis-TRI): It appears that the tree has to be "compiled"
   // already.  Confirm/deny and document that result.
   explicit RigidBodyPlant(std::unique_ptr<const RigidBodyTree<T>> tree);
@@ -159,7 +166,8 @@ class RigidBodyPlant : public LeafSystem<T> {
   /// Returns the number of actuators for a specific model instance.
   int get_num_actuators(int model_instance_id) const;
 
-  /// Returns the number of model instances in the world.
+  /// Returns the number of model instances in the world, not including the
+  /// world.
   int get_num_model_instances() const;
 
   /// Returns the size of the input vector to the system. This equals the
@@ -244,17 +252,33 @@ class RigidBodyPlant : public LeafSystem<T> {
   /// and how these accessors are typically used.
   ///@{
 
-  /// Returns a descriptor of the actuator command input port.
-  const InputPortDescriptor<T>& command_input_port() const {
-    return System<T>::get_input_port(command_input_port_index_);
+  /// Returns a descriptor of the actuator command input port. This method can
+  /// only be called when there is only one model instance in the RigidBodyTree.
+  /// Otherwise, a std::runtime_error will be thrown. It returns the same port
+  /// as model_instance_actuator_command_input_port() using input
+  /// parameter RigidBodyTreeConstants::kFirstModelInstanceId.
+  const InputPortDescriptor<T>& actuator_command_input_port() const {
+    if (get_num_model_instances() != 1) {
+      throw std::runtime_error("RigidBodyPlant::actuator_command_input_port(): "
+          "ERROR: This method can only called when there is only one model "
+          "instance in the RigidBodyTree. There are currently " +
+          std::to_string(get_num_model_instances()) + " model instances in the "
+          "RigidBodyTree.");
+    }
+    return model_instance_actuator_command_input_port(
+                         RigidBodyTreeConstants::kFirstModelInstanceId);
   }
 
-  /// Returns a descriptor of the input port for a specific model
-  /// instance.
-  const InputPortDescriptor<T>& model_input_port(
-      int model_instance_id) const {
-    return System<T>::get_input_port(input_map_.at(model_instance_id));
-  }
+  // Returns true if and only if the model instance with the provided
+  // `model_instance_id` has actuators. This is useful when trying to determine
+  // whether it's safe to call model_instance_actuator_command_input_port().
+  bool model_instance_has_actuators(int model_instance_id) const;
+
+  /// Returns a descriptor of the input port for a specific model instance. This
+  /// method can only be called when this class is instantiated with constructor
+  /// parameter `export_model_instance_centric_ports` equal to `true`.
+  const InputPortDescriptor<T>& model_instance_actuator_command_input_port(
+      int model_instance_id) const;
 
   ///@}
 
@@ -264,10 +288,19 @@ class RigidBodyPlant : public LeafSystem<T> {
   /// and how these accessors are typically used.
   ///@{
 
-  /// Returns a descriptor of the state output port.
+  /// Returns a descriptor of the plant-centric state output port. The size of
+  /// this port is equal to get_num_states().
   const OutputPortDescriptor<T>& state_output_port() const {
     return System<T>::get_output_port(state_output_port_index_);
   }
+
+  /// Returns a descriptor of the output port containing the state of a
+  /// particular model with instance ID equal to @p model_instance_id. Throws a
+  /// std::runtime_error if @p model_instance_id does not exist. This method can
+  /// only be called when this class is instantiated with constructor parameter
+  /// `export_model_instance_centric_ports` equal to `true`.
+  const OutputPortDescriptor<T>& model_instance_state_output_port(
+      int model_instance_id) const;
 
   /// Returns a descriptor of the KinematicsResults output port.
   const OutputPortDescriptor<T>& kinematics_results_output_port() const {
@@ -277,20 +310,6 @@ class RigidBodyPlant : public LeafSystem<T> {
   /// Returns a descriptor of the ContactResults output port.
   const OutputPortDescriptor<T>& contact_results_output_port() const {
     return System<T>::get_output_port(contact_output_port_index_);
-  }
-
-  /// Returns a descriptor of the output port containing the state of a
-  /// particular model with instance ID equal to @p model_instance_id. Throws a
-  /// std::runtime_error if @p model_instance_id does not exist.
-  const OutputPortDescriptor<T>& model_state_output_port(
-      int model_instance_id) const {
-    if (model_instance_id >= static_cast<int>(output_map_.size())) {
-      throw std::runtime_error("RigidBodyPlant: model_state_output_port: "
-          "ERROR: Model instance ID " + std::to_string(model_instance_id) +
-          " does not exist! Maximum ID is " +
-          std::to_string(output_map_.size() - 1) + ".");
-    }
-    return System<T>::get_output_port(output_map_.at(model_instance_id));
   }
   ///@}
 
@@ -335,6 +354,8 @@ class RigidBodyPlant : public LeafSystem<T> {
       VectorBase<T> *generalized_velocity) const override;
 
  private:
+  void ExportModelInstanceCentricPorts();
+
   // Computes the contact results for feeding the corresponding output port.
   void ComputeContactResults(const Context<T>& context,
                              ContactResults<T>* contacts) const;
@@ -351,30 +372,30 @@ class RigidBodyPlant : public LeafSystem<T> {
   VectorX<T> ComputeContactForce(const KinematicsCache<T>& kinsol,
                                  ContactResults<T>* contacts = nullptr) const;
 
+  std::unique_ptr<const RigidBodyTree<T>> tree_;
+
   // Some parameters defining the contact.
   // TODO(amcastro-tri): Implement contact materials for the RBT engine.
   T penetration_stiffness_{150.0};  // An arbitrarily large number.
   T penetration_damping_{penetration_stiffness_ / 10.0};
   T friction_coefficient_{1.0};
 
-  std::unique_ptr<const RigidBodyTree<T>> tree_;
-  int command_input_port_index_{};
   int state_output_port_index_{};
   int kinematics_output_port_index_{};
   int contact_output_port_index_{};
 
-  // Maps model instance ids to input port indices.  A value of -1
-  // indicates that a model instance has no actuators, and thus no
-  // corresponding input port.
+  // Maps model instance ids to input port indices.  A value of
+  // kInvalidPortIdentifier indicates that a model instance has no actuators,
+  // and thus no corresponding input port.
   std::vector<int> input_map_;
   // Maps model instance ids to actuator indices and number of
   // actuators in the RigidBodyTree.  Values are stored as a pair of
   // (index, count).
   std::vector<std::pair<int, int>> actuator_map_;
 
-  // Maps model instance ids to output port indices.  A value of -1
-  // indicates that a model instance has no state and thus no
-  // corresponding output port.
+  // Maps model instance ids to output port indices.  A value of
+  // kInvalidPortIdentifier indicates that a model instance has no state and
+  // thus no corresponding output port.
   std::vector<int> output_map_;
   // Maps model instance ids to position indices and number of
   // position states in the RigidBodyTree.  Values are stored as a

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -32,8 +32,8 @@ namespace systems {
 ///   actuators. Note that if this port is connected, none of the ports returned
 ///   by model_input_port() can be connected. The size of this vector is equal
 ///   to the number of RigidBodyActuator's in the RigidBodyTree. Each
-///   RigidBodyActuator maps to a single DOF joint (currently actuation cannot
-///   be applied to multiple DOF's joints). The units of the actuation are the
+///   RigidBodyActuator maps to a single-DOF joint (currently actuation cannot
+///   be applied to multiple-DOF joints). The units of the actuation are the
 ///   same as the units of the generalized force on the joint. In addition,
 ///   actuators allow for a gear box reduction factor and for actuation
 ///   limits which are only used by controllers; the RigidBodyPlant does
@@ -74,10 +74,11 @@ namespace systems {
 /// positions followed by the generalized velocities of the system. This state
 /// is applied to a RigidBodyTree, which is a multibody model that consists of a
 /// set of rigid bodies connected through joints in a tree structure. Bodies may
-/// have a collision model in which case collisions are considered. In addition,
-/// the model may contain loop constraints described by RigidBodyLoop's in the
-/// multibody model. Even though loop constraints are a particular case of
-/// holonomic constraints, general holonomic constraints are not yet supported.
+/// have a collision model, in which case, collisions are considered. In
+/// addition, the model may contain loop constraints described by
+/// RigidBodyLoop instances in the multibody model. Even though loop constraints
+/// are a particular case of holonomic constraints, general holonomic
+/// constraints are not yet supported.
 ///
 /// The system dynamics is given by the set of multibody equations written in
 /// generalized coordinates including loop joints as a set of holonomic

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -294,27 +294,6 @@ class RigidBodyPlant : public LeafSystem<T> {
   }
   ///@}
 
-  /// @name System output port index accessors.
-  /// These are accessors for obtaining indices of this RigidBodyPlant's output
-  /// ports. See this class's description for details about these ports.
-  ///@{
-  int state_output_port_index() const {
-    return state_output_port().get_index();
-  }
-
-  int kinematics_results_output_port_index() const {
-    return kinematics_results_output_port().get_index();
-  }
-
-  int contact_results_output_port_index() const {
-    return contact_results_output_port().get_index();
-  }
-
-  int model_state_output_port_index(int model_instance_id) const {
-    return model_state_output_port(model_instance_id).get_index();
-  }
-  ///@}
-
  protected:
   // LeafSystem<T> override.
   std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -18,24 +18,6 @@ namespace systems {
 /// This class provides a System interface around a multibody dynamics model
 /// of the world represented by a RigidBodyTree.
 ///
-/// <B>%System input</B>: A %RigidBodyPlant has a vector valued input
-/// port for external actuation with size equal to the number of
-/// RigidBodyActuator's in the RigidBodyTree. Each RigidBodyActuator
-/// maps to a single DOF joint (currently actuation cannot be applied
-/// to multiple DOF's joints). The units of the actuation are the same
-/// as the units of the generalized force on the joint. In addition,
-/// actuators allow for a gear box reduction factor and for actuation
-/// limits which are only used by controllers; the RigidBodyPlant does
-/// not apply these limits. The gear box factor effectively is a
-/// multiplier on the input actuation to the RigidBodyPlant.
-/// Alternately, individual input ports for each model instance which
-/// has actuators are provided by model_input_port().  If any port
-/// returned by model_input_port() is connected, the input port for
-/// the full tree must not be used.
-///
-/// The %RigidBodyPlant's state consists of a vector containing the generalized
-/// positions followed by the generalized velocities of the system.
-///
 /// The %RigidBodyPlant provides a number of input and output ports. The precise
 /// number depends on the number of model instances within the RigidBodyTree
 /// and the number of them that have actuators. The following lists the
@@ -47,10 +29,22 @@ namespace systems {
 /// <B>Input Port Accessors:</B>
 ///
 /// - command_input_port(): Contains the command vector for the RigidBodyTree's
-///   actuators.
+///   actuators. Note that if this port is connected, none of the ports returned
+///   by model_input_port() can be connected. The size of this vector is equal
+///   to the number of RigidBodyActuator's in the RigidBodyTree. Each
+///   RigidBodyActuator maps to a single DOF joint (currently actuation cannot
+///   be applied to multiple DOF's joints). The units of the actuation are the
+///   same as the units of the generalized force on the joint. In addition,
+///   actuators allow for a gear box reduction factor and for actuation
+///   limits which are only used by controllers; the RigidBodyPlant does
+///   not apply these limits. The gear box factor effectively is a
+///   multiplier on the input actuation to the RigidBodyPlant.
 ///
 /// - model_input_port(): Contains the command vector for the actuators
 ///   belonging to a particular model instance within the RigidBodyTree.
+///   If any port returned by model_input_port() is connected, the input port
+///   for the full tree, which is obtained using command_input_port(), must not
+///   be used.
 ///
 /// <B>Output Port Accessors:</B>
 ///
@@ -76,12 +70,14 @@ namespace systems {
 /// - model_state_output_port(): A vector-valued port containing the state
 ///   vector for a particular model instance in the RigidBodyTree.
 ///
-/// The multibody model consists of a set of rigid bodies connected through
-/// joints in a tree structure. Bodies may have a collision model in which case
-/// collisions are considered. In addition, the model may contain loop
-/// constraints described by RigidBodyLoop's in the multibody model. Even though
-/// loop constraints are a particular case of holonomic constrants, general
-/// holonomic constrants are not yet supported.
+/// The %RigidBodyPlant's state consists of a vector containing the generalized
+/// positions followed by the generalized velocities of the system. This state
+/// is applied to a RigidBodyTree, which is a multibody model that consists of a
+/// set of rigid bodies connected through joints in a tree structure. Bodies may
+/// have a collision model in which case collisions are considered. In addition,
+/// the model may contain loop constraints described by RigidBodyLoop's in the
+/// multibody model. Even though loop constraints are a particular case of
+/// holonomic constraints, general holonomic constraints are not yet supported.
 ///
 /// The system dynamics is given by the set of multibody equations written in
 /// generalized coordinates including loop joints as a set of holonomic

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -238,9 +238,9 @@ class RigidBodyPlant : public LeafSystem<T> {
   static Matrix3<T> ComputeBasisFromZ(const Vector3<T>& z_axis_W);
 
   /// @name System input port descriptor accessors.
-  /// These are accessors for obtaining descriptors of this
-  /// RigidBodyPlant's input ports. See this class's description for details
-  /// about these ports.
+  /// These are accessors for obtaining descriptors of this RigidBodyPlant's
+  /// input ports. See this class's description for details about these ports
+  /// and how these accessors are typically used.
   ///@{
 
   /// Returns a descriptor of the actuator command input port.
@@ -258,9 +258,9 @@ class RigidBodyPlant : public LeafSystem<T> {
   ///@}
 
   /// @name System output port descriptor accessors.
-  /// These are accessors for obtaining descriptors of this
-  /// RigidBodyPlant's output ports. See this class's description for details
-  /// about these ports.
+  /// These are accessors for obtaining descriptors of this RigidBodyPlant's
+  /// output ports. See this class's description for details about these ports
+  /// and how these accessors are typically used.
   ///@{
 
   /// Returns a descriptor of the state output port.

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -36,18 +36,23 @@ namespace systems {
 /// The %RigidBodyPlant's state consists of a vector containing the generalized
 /// positions followed by the generalized velocities of the system.
 ///
-/// <B>Input Port:</B>
+/// The %RigidBodyPlant provides a number of input and output ports. The precise
+/// number depends on the number of model instances within the RigidBodyTree
+/// and the number of them that have actuators. The following lists the
+/// accessors for obtaining the input and output ports of the %RigidBodyPlant.
+/// These accessors are typically used when "wiring up" a RigidBodyPlant within
+/// a Diagram using DiagramBuilder. See, for example, DiagramBuilder::Connect(),
+/// DiagramBuilder::ExportInput(), and DiagramBuilder::ExportOutput().
 ///
-/// There is one input port. It is accessible via the following accessor:
+/// <B>Input Port Accessors:</B>
 ///
-/// - command_input_port(): Contains the command vector for the
-///   RigidBodyTree's actuators.
+/// - command_input_port(): Contains the command vector for the RigidBodyTree's
+///   actuators.
 ///
-/// <B>Output Ports:</B>
+/// - model_input_port(): Contains the command vector for the actuators
+///   belonging to a particular model instance within the RigidBodyTree.
 ///
-/// There are numerous output ports. The number depends on how many model
-/// instances exist in the RigidBodyTree. The output ports are available via
-/// the following accessors.
+/// <B>Output Port Accessors:</B>
 ///
 /// - state_output_port(): A vector-valued port containing the state vector,
 ///   `x`, of the system. The state vector, `x`, consists of generalized
@@ -69,8 +74,7 @@ namespace systems {
 ///   computations.
 ///
 /// - model_state_output_port(): A vector-valued port containing the state
-///   vector for a particular model instance within the RigidBodyTree that is
-///   within this RigidBodyPlant.
+///   vector for a particular model instance in the RigidBodyTree.
 ///
 /// The multibody model consists of a set of rigid bodies connected through
 /// joints in a tree structure. Bodies may have a collision model in which case
@@ -220,15 +224,6 @@ class RigidBodyPlant : public LeafSystem<T> {
   static T JointLimitForce(const DrakeJoint& joint,
                            const T& position, const T& velocity);
 
-  /// Returns a descriptor of the input port for a specific model
-  /// instance.
-  const InputPortDescriptor<T>& model_input_port(
-      int model_instance_id) const {
-    return System<T>::get_input_port(input_map_.at(model_instance_id));
-  }
-
-
-
   /// Returns the index into the output port for @p model_instance_id
   /// which corresponds to the world position index of @p
   /// world_position_index, or throws if the position index does not
@@ -248,14 +243,22 @@ class RigidBodyPlant : public LeafSystem<T> {
 
   /// @name System input port descriptor accessors.
   /// These are accessors for obtaining descriptors of this
-  /// RigidBodyPlant's input port. See this class's description for details
-  /// about this port.
+  /// RigidBodyPlant's input ports. See this class's description for details
+  /// about these ports.
   ///@{
 
   /// Returns a descriptor of the actuator command input port.
   const InputPortDescriptor<T>& command_input_port() const {
     return System<T>::get_input_port(command_input_port_index_);
   }
+
+  /// Returns a descriptor of the input port for a specific model
+  /// instance.
+  const InputPortDescriptor<T>& model_input_port(
+      int model_instance_id) const {
+    return System<T>::get_input_port(input_map_.at(model_instance_id));
+  }
+
   ///@}
 
   /// @name System output port descriptor accessors.

--- a/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -86,7 +86,6 @@ class ContactResultTest : public ::testing::Test {
     plant_ = make_unique<RigidBodyPlant<double>>(move(unique_tree));
     context_ = plant_->CreateDefaultContext();
     output_ = plant_->AllocateOutput(*context_);
-    context_->FixInputPort(0, make_unique<BasicVector<double>>(0));
     plant_->CalcOutput(*context_.get(), output_.get());
 
     const int port_index = plant_->contact_results_output_port().get_index();

--- a/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -89,8 +89,8 @@ class ContactResultTest : public ::testing::Test {
     context_->FixInputPort(0, make_unique<BasicVector<double>>(0));
     plant_->CalcOutput(*context_.get(), output_.get());
 
-    return output_->get_data(plant_->contact_results_output_port_index())->
-        GetValue<ContactResults<double>>();
+    const int port_index = plant_->contact_results_output_port().get_index();
+    return output_->get_data(port_index)->GetValue<ContactResults<double>>();
   }
 
   // Add a sphere with default radius, placed at the given position.

--- a/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -89,10 +89,8 @@ class ContactResultTest : public ::testing::Test {
     context_->FixInputPort(0, make_unique<BasicVector<double>>(0));
     plant_->CalcOutput(*context_.get(), output_.get());
 
-    // TODO(SeanCurtis-TRI): This hard-coded value is unfortunate. However,
-    //  there is no mechanism for finding out the port id for a known port
-    //  (e.g., contact results). Update when such a mechanism exists.
-    return output_->get_data(2)->GetValue<ContactResults<double>>();
+    return output_->get_data(plant_->contact_results_output_port_index())->
+        GetValue<ContactResults<double>>();
   }
 
   // Add a sphere with default radius, placed at the given position.

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -252,8 +252,8 @@ TEST_F(KukaArmTest, EvalOutput) {
   ASSERT_EQ(1, context_->get_num_input_ports());
   ASSERT_EQ(1, kuka_plant_->get_num_model_instances());
 
-  // TODO(liang.fok) Update this to be 1 once #3088 is resolved.
-  const int kModelInstanceId = 0;
+  const int kModelInstanceId =
+      RigidBodyTreeConstants::kFirstNonWorldModelInstanceId;
 
   // Checks the size of the input ports to match the number of generalized
   // forces that can be applied.
@@ -292,7 +292,7 @@ TEST_F(KukaArmTest, EvalOutput) {
   // Four output ports:
   //
   //    (1) plant state
-  //    (2) model instance state
+  //    (2) model instance state for tree containing a single model instance
   //    (3) kinematic results
   //    (4) contact results
   //

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -305,7 +305,8 @@ TEST_F(KukaArmTest, EvalOutput) {
 
   // Evaluates the correctness of the kinematics results port.
   auto& kinematics_results =
-      output_->get_data(1)->GetValue<KinematicsResults<double>>();
+      output_->get_data(kuka_plant_->kinematics_results_output_port_index())->
+         GetValue<KinematicsResults<double>>();
   ASSERT_EQ(kinematics_results.get_num_positions(), kNumPositions_);
   ASSERT_EQ(kinematics_results.get_num_velocities(), kNumVelocities_);
 

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -231,7 +231,7 @@ TEST_F(KukaArmTest, SetDefaultState) {
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
   // derivatives per #3218.
-  context_->FixInputPort(kuka_plant_->command_input_port().get_index(),
+  context_->FixInputPort(kuka_plant_->actuator_command_input_port().get_index(),
                          make_unique<BasicVector<double>>(
                              kuka_plant_->get_num_actuators()));
 
@@ -243,18 +243,17 @@ TEST_F(KukaArmTest, SetDefaultState) {
 }
 
 // Tests RigidBodyPlant<T>::CalcOutput() for a KUKA iiwa arm model.
-// For a RigidBodyPlant<T> the first output of the system should equal the
-// state vector. The second output from this system should correspond to a
-// RigidBodyPlant<T>::VectorOfPoses containing the poses of all bodies in the
-// system.
 TEST_F(KukaArmTest, EvalOutput) {
   auto& tree = kuka_plant_->get_rigid_body_tree();
 
   // Checks that the number of input and output ports in the system and context
   // are consistent.
-  ASSERT_EQ(2, kuka_plant_->get_num_input_ports());
-  ASSERT_EQ(2, context_->get_num_input_ports());
+  ASSERT_EQ(1, kuka_plant_->get_num_input_ports());
+  ASSERT_EQ(1, context_->get_num_input_ports());
   ASSERT_EQ(1, kuka_plant_->get_num_model_instances());
+
+  // TODO(liang.fok) Update this to be 1 once #3088 is resolved.
+  const int kModelInstanceId = 0;
 
   // Checks the size of the input ports to match the number of generalized
   // forces that can be applied.
@@ -266,15 +265,18 @@ TEST_F(KukaArmTest, EvalOutput) {
   ASSERT_EQ(kNumStates_, kuka_plant_->get_num_states(0));
   ASSERT_EQ(kNumActuators_, kuka_plant_->get_num_actuators());
   ASSERT_EQ(kNumActuators_, kuka_plant_->get_num_actuators(0));
-  ASSERT_EQ(kNumActuators_, kuka_plant_->get_input_port(0).size());
-  ASSERT_EQ(kNumActuators_, kuka_plant_->model_input_port(0).size());
+  ASSERT_EQ(kNumActuators_,
+      kuka_plant_->model_instance_actuator_command_input_port(
+          kModelInstanceId).size());
 
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
   // derivatives per #3218.
-  context_->FixInputPort(kuka_plant_->command_input_port().get_index(),
-                         make_unique<BasicVector<double>>(
-                             kuka_plant_->get_num_actuators()));
+  context_->FixInputPort(
+      kuka_plant_->model_instance_actuator_command_input_port(
+                       kModelInstanceId).get_index(),
+                       make_unique<BasicVector<double>>(
+                           kuka_plant_->get_num_actuators()));
 
   // Sets the state to a non-zero value.
   VectorXd desired_angles(kNumPositions_);
@@ -287,25 +289,27 @@ TEST_F(KukaArmTest, EvalOutput) {
   VectorXd xc = context_->get_continuous_state()->CopyToVector();
   ASSERT_EQ(xc, desired_state);
 
-  // 4 outputs: state, kinematic results, contact results, model instance state.
+  // Four output ports:
+  //
+  //    (1) plant state
+  //    (2) model instance state
+  //    (3) kinematic results
+  //    (4) contact results
+  //
   // (In this context, there is only one model instance and thus only one model
   // instance state port.)
   ASSERT_EQ(4, output_->get_num_ports());
-  const BasicVector<double>* output_state = output_->get_vector_data(0);
-  ASSERT_NE(nullptr, output_state);
 
   kuka_plant_->CalcOutput(*context_, output_.get());
 
-  // Asserts the output equals the state.
-  EXPECT_EQ(desired_state, output_state->get_value());
-
   // Check that the per-instance port (we should only have one) equals
   // the expected state.
+  const int output_index = kuka_plant_->
+      model_instance_state_output_port(kModelInstanceId).get_index();
   const BasicVector<double>* instance_output =
-      output_->get_vector_data(
-          kuka_plant_->model_state_output_port(0).get_index());
+      output_->get_vector_data(output_index);
   ASSERT_NE(nullptr, instance_output);
-  EXPECT_EQ(desired_state, instance_output->get_value());
+  EXPECT_EQ(desired_state, instance_output->get_value().eval());
 
   // Evaluates the correctness of the kinematics results port.
   const int index = kuka_plant_->kinematics_results_output_port().get_index();
@@ -401,7 +405,7 @@ double GetPrismaticJointLimitAccel(double position, double applied_force) {
   input << applied_force;
   auto input_vector = std::make_unique<BasicVector<double>>(1);
   input_vector->set_value(input);
-  context->FixInputPort(plant.command_input_port().get_index(),
+  context->FixInputPort(plant.actuator_command_input_port().get_index(),
                         move(input_vector));
 
   // Obtain the time derivatives; test that speed is zero, return acceleration.
@@ -521,26 +525,6 @@ GTEST_TEST(RigidBodyPlantTest, InstancePortTest) {
   EXPECT_EQ(joint4_instance, 3);
   EXPECT_ANY_THROW(
       plant.FindInstancePositionIndexFromWorldIndex(0, joint4_world));
-}
-
-// Tests what happens with both types of input ports are connected
-// (entire plant vs. individual model instance).
-GTEST_TEST(rigid_body_plant_test, TestConnectBothTypesOfInputPorts) {
-  auto tree = std::make_unique<RigidBodyTree<double>>();
-  const ModelInstanceIdTable table =
-      AddModelInstancesFromSdfFile(drake::GetDrakePath() +
-          "/multibody/rigid_body_plant/test/limited_prismatic.sdf",
-          kQuaternion, nullptr /* weld to frame */, tree.get());
-  const int model_instance_id = table.at("limited_prismatic_test_model");
-  RigidBodyPlant<double> plant(move(tree));
-  const int num_inputs = plant.get_num_actuators(model_instance_id) * 2;
-  auto context = plant.CreateDefaultContext();
-  context->FixInputPort(
-      plant.command_input_port().get_index(),
-      make_unique<BasicVector<double>>(Eigen::VectorXd::Zero(num_inputs)));
-  context->FixInputPort(
-      plant.model_input_port(model_instance_id).get_index(),
-      make_unique<BasicVector<double>>(Eigen::VectorXd::Zero(num_inputs)));
 }
 
 }  // namespace

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -229,8 +229,9 @@ TEST_F(KukaArmTest, SetDefaultState) {
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
   // derivatives per #3218.
-  context_->FixInputPort(0, make_unique<BasicVector<double>>(
-                                kuka_plant_->get_num_actuators()));
+  context_->FixInputPort(kuka_plant_->command_input_port().get_index(),
+                         make_unique<BasicVector<double>>(
+                             kuka_plant_->get_num_actuators()));
 
   // Asserts that for this case the zero configuration corresponds to a state
   // vector with all entries equal to zero.
@@ -269,8 +270,9 @@ TEST_F(KukaArmTest, EvalOutput) {
   // Connect to a "fake" free standing input.
   // TODO(amcastro-tri): Connect to a ConstantVectorSource once Diagrams have
   // derivatives per #3218.
-  context_->FixInputPort(0, make_unique<BasicVector<double>>(
-                                kuka_plant_->get_num_actuators()));
+  context_->FixInputPort(kuka_plant_->command_input_port().get_index(),
+                         make_unique<BasicVector<double>>(
+                             kuka_plant_->get_num_actuators()));
 
   // Sets the state to a non-zero value.
   VectorXd desired_angles(kNumPositions_);
@@ -397,7 +399,8 @@ double GetPrismaticJointLimitAccel(double position, double applied_force) {
   input << applied_force;
   auto input_vector = std::make_unique<BasicVector<double>>(1);
   input_vector->set_value(input);
-  context->FixInputPort(0, move(input_vector));
+  context->FixInputPort(plant.command_input_port().get_index(),
+                        move(input_vector));
 
   // Obtain the time derivatives; test that speed is zero, return acceleration.
   auto derivatives = plant.AllocateTimeDerivatives();

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -308,9 +308,9 @@ TEST_F(KukaArmTest, EvalOutput) {
   EXPECT_EQ(desired_state, instance_output->get_value());
 
   // Evaluates the correctness of the kinematics results port.
+  const int index = kuka_plant_->kinematics_results_output_port().get_index();
   auto& kinematics_results =
-      output_->get_data(kuka_plant_->kinematics_results_output_port_index())->
-         GetValue<KinematicsResults<double>>();
+      output_->get_data(index)->GetValue<KinematicsResults<double>>();
   ASSERT_EQ(kinematics_results.get_num_positions(), kNumPositions_);
   ASSERT_EQ(kinematics_results.get_num_velocities(), kNumVelocities_);
 

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_publishes_xdot_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_publishes_xdot_test.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include <Eigen/Dense>
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_path.h"
@@ -10,8 +9,6 @@
 #include "drake/lcmt_drake_signal.hpp"
 #include "drake/lcm/lcmt_drake_signal_utils.h"
 #include "drake/multibody/parsers/urdf_parser.h"
-
-using Eigen::VectorXd;
 
 using std::make_unique;
 using std::move;
@@ -51,9 +48,8 @@ GTEST_TEST(RigidBodyPlantThatPublishesXdotTest, TestPublishLcmMessage) {
   EXPECT_EQ(dut.get_input_size(), 0);
   EXPECT_EQ(dut.get_output_size(), kNumStates);
 
-  unique_ptr<Context<double>> context = dut.CreateDefaultContext();
-
   // Forces the DUT to publish an LCM message.
+  unique_ptr<Context<double>> context = dut.CreateDefaultContext();
   EXPECT_NO_THROW(dut.Publish(*context));
 
   // Verifies that the transmitted message is correct.

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_publishes_xdot_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_that_publishes_xdot_test.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <Eigen/Dense>
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_path.h"
@@ -9,6 +10,8 @@
 #include "drake/lcmt_drake_signal.hpp"
 #include "drake/lcm/lcmt_drake_signal_utils.h"
 #include "drake/multibody/parsers/urdf_parser.h"
+
+using Eigen::VectorXd;
 
 using std::make_unique;
 using std::move;
@@ -48,8 +51,9 @@ GTEST_TEST(RigidBodyPlantThatPublishesXdotTest, TestPublishLcmMessage) {
   EXPECT_EQ(dut.get_input_size(), 0);
   EXPECT_EQ(dut.get_output_size(), kNumStates);
 
-  // Forces the DUT to publish an LCM message.
   unique_ptr<Context<double>> context = dut.CreateDefaultContext();
+
+  // Forces the DUT to publish an LCM message.
   EXPECT_NO_THROW(dut.Publish(*context));
 
   // Verifies that the transmitted message is correct.

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -80,7 +80,9 @@ using std::endl;
 
 const char* const RigidBodyTreeConstants::kWorldName = "world";
 const int RigidBodyTreeConstants::kWorldBodyIndex = 0;
-// TODO(liang.fok) Update this along with the resolution of #3088.
+// TODO(liang.fok) Update the following two variables along with the resolution
+// of #3088. Once #3088 is resolved, ID of the first model instance should be 1.
+const int RigidBodyTreeConstants::kFirstModelInstanceId = 0;
 const set<int> RigidBodyTreeConstants::default_model_instance_id_set = {0};
 
 template <typename T>
@@ -2873,6 +2875,8 @@ int RigidBodyTree<T>::add_model_instance() {
   return num_model_instances_++;
 }
 
+// TODO(liang.fok) Update this method implementation once the world is assigned
+// its own model instance ID (#3088). It should return num_model_instances_ - 1.
 template <typename T>
 int RigidBodyTree<T>::get_num_model_instances() const {
   return num_model_instances_;

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -82,7 +82,7 @@ const char* const RigidBodyTreeConstants::kWorldName = "world";
 const int RigidBodyTreeConstants::kWorldBodyIndex = 0;
 // TODO(liang.fok) Update the following two variables along with the resolution
 // of #3088. Once #3088 is resolved, ID of the first model instance should be 1.
-const int RigidBodyTreeConstants::kFirstModelInstanceId = 0;
+const int RigidBodyTreeConstants::kFirstNonWorldModelInstanceId = 0;
 const set<int> RigidBodyTreeConstants::default_model_instance_id_set = {0};
 
 template <typename T>

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -53,6 +53,11 @@ struct RigidBodyTreeConstants {
   static const int kWorldBodyIndex;
 
   /**
+   * The ID of the first model instance in the tree.
+   */
+  static const int kFirstModelInstanceId;
+
+  /**
    * Defines the default model instance ID set. This is a set containing the
    * model instance ID of the first model instance that is added to the tree.
    */
@@ -118,7 +123,7 @@ class RigidBodyTree {
   int get_next_clique_id() { return next_available_clique_++; }
 
   /**
-   * Returns the number of model instances in the tree.
+   * Returns the number of model instances in the tree, not including the world.
    */
   int get_num_model_instances() const;
 

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -53,9 +53,9 @@ struct RigidBodyTreeConstants {
   static const int kWorldBodyIndex;
 
   /**
-   * The ID of the first model instance in the tree.
+   * The ID of the first non-world model instance in the tree.
    */
-  static const int kFirstModelInstanceId;
+  static const int kFirstNonWorldModelInstanceId;
 
   /**
    * Defines the default model instance ID set. This is a set containing the

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -344,10 +344,6 @@ GTEST_TEST(RK3RK2IntegratorTest, RigidBody) {
   RigidBodyPlant<double> plant(move(tree));
   auto context = plant.CreateDefaultContext();
 
-  // Setup an empty input port.
-  context->SetInputPort(0, std::make_unique<FreestandingInputPort>(
-      std::make_unique<BasicVector<double>>(plant.get_num_actuators())));
-
   Eigen::Vector3d v0(1, 2, 3);    // Linear velocity in body's frame.
   Eigen::Vector3d w0(-4, 5, -6);  // Angular velocity in body's frame.
   BasicVector<double> generalized_velocities(plant.get_num_velocities());


### PR DESCRIPTION
This will be more robust against future `RigidBodyPlant` port number changes due to the addition of ports.

The actuator command input ports are modified as follows:

1. There is only one model instance-centric actuator command port per model instance with an actuator. (It is now possible for the plant to not have any input ports when there are no actuators.)

2. The plant-centric actuator command port is only available when there is only one model instance in the RigidBodyTree, and it returns the same port as the model-instance-centric port using the first model instance ID.

Resolves #4025.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4766)
<!-- Reviewable:end -->