### PR TITLE
Make PortDescriptors copyable.

### DIFF
--- a/drake/automotive/idm_planner.cc
+++ b/drake/automotive/idm_planner.cc
@@ -34,12 +34,12 @@ template <typename T>
 IdmPlanner<T>::~IdmPlanner() {}
 
 template <typename T>
-const systems::InputPortDescriptor<T>& IdmPlanner<T>::get_ego_port() const {
+systems::InputPortDescriptor<T> IdmPlanner<T>::get_ego_port() const {
   return systems::System<T>::get_input_port(0);
 }
 
 template <typename T>
-const systems::InputPortDescriptor<T>& IdmPlanner<T>::get_agent_port() const {
+systems::InputPortDescriptor<T> IdmPlanner<T>::get_agent_port() const {
   return systems::System<T>::get_input_port(1);
 }
 

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -36,10 +36,10 @@ class IdmPlanner : public systems::LeafSystem<T> {
   ~IdmPlanner() override;
 
   /// Returns the port to the ego car input subvector.
-  const systems::InputPortDescriptor<T>& get_ego_port() const;
+  systems::InputPortDescriptor<T> get_ego_port() const;
 
   /// Returns the port to the agent car input subvector.
-  const systems::InputPortDescriptor<T>& get_agent_port() const;
+  systems::InputPortDescriptor<T> get_agent_port() const;
 
   // System<T> overrides.
   // The output of this system is an algebraic relation of its inputs.

--- a/drake/automotive/linear_car.cc
+++ b/drake/automotive/linear_car.cc
@@ -28,12 +28,12 @@ template <typename T>
 LinearCar<T>::~LinearCar() {}
 
 template <typename T>
-const systems::InputPortDescriptor<T>& LinearCar<T>::get_input_port() const {
+systems::InputPortDescriptor<T> LinearCar<T>::get_input_port() const {
   return systems::System<T>::get_input_port(0);
 }
 
 template <typename T>
-const systems::OutputPortDescriptor<T>& LinearCar<T>::get_output_port() const {
+systems::OutputPortDescriptor<T> LinearCar<T>::get_output_port() const {
   return systems::System<T>::get_output_port(0);
 }
 

--- a/drake/automotive/linear_car.h
+++ b/drake/automotive/linear_car.h
@@ -31,10 +31,10 @@ class LinearCar : public systems::LeafSystem<T> {
   ~LinearCar() override;
 
   /// Returns the input port.
-  const systems::InputPortDescriptor<T>& get_input_port() const;
+  systems::InputPortDescriptor<T> get_input_port() const;
 
   /// Returns the output port.
-  const systems::OutputPortDescriptor<T>& get_output_port() const;
+  systems::OutputPortDescriptor<T> get_output_port() const;
 
   /// Sets the continuous states in @p context to default values.
   void SetDefaultState(const systems::Context<T>& context,

--- a/drake/examples/Pendulum/pendulum_plant.cc
+++ b/drake/examples/Pendulum/pendulum_plant.cc
@@ -21,13 +21,13 @@ template <typename T>
 PendulumPlant<T>::~PendulumPlant() {}
 
 template <typename T>
-const systems::InputPortDescriptor<T>&
+systems::InputPortDescriptor<T>
 PendulumPlant<T>::get_tau_port() const {
   return this->get_input_port(0);
 }
 
 template <typename T>
-const systems::OutputPortDescriptor<T>&
+systems::OutputPortDescriptor<T>
 PendulumPlant<T>::get_output_port() const {
   return systems::System<T>::get_output_port(0);
 }

--- a/drake/examples/Pendulum/pendulum_plant.h
+++ b/drake/examples/Pendulum/pendulum_plant.h
@@ -32,10 +32,10 @@ class PendulumPlant : public systems::LeafSystem<T> {
   bool has_any_direct_feedthrough() const override { return false; }
 
   /// Returns the input port to the externally applied force.
-  const systems::InputPortDescriptor<T>& get_tau_port() const;
+  systems::InputPortDescriptor<T> get_tau_port() const;
 
   /// Returns the port to output state.
-  const systems::OutputPortDescriptor<T>& get_output_port() const;
+  systems::OutputPortDescriptor<T> get_output_port() const;
 
   void set_theta(MyContext* context, const T& theta) const {
     get_mutable_state(context)->set_theta(theta);

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h
@@ -131,7 +131,7 @@ class JointLevelControllerSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: HumanoidStatus.
    */
-  inline const InputPortDescriptor<double>& get_input_port_humanoid_status()
+  InputPortDescriptor<double> get_input_port_humanoid_status()
       const {
     return get_input_port(in_port_idx_humanoid_status_);
   }
@@ -139,14 +139,14 @@ class JointLevelControllerSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: QPOutput.
    */
-  inline const InputPortDescriptor<double>& get_input_port_qp_output() const {
+  InputPortDescriptor<double> get_input_port_qp_output() const {
     return get_input_port(in_port_idx_qp_output_);
   }
 
   /**
    * @return Port for the output: bot_core::atlas_command_t message
    */
-  inline const OutputPortDescriptor<double>& get_output_port_atlas_command()
+  OutputPortDescriptor<double> get_output_port_atlas_command()
       const {
     return get_output_port(out_port_index_atlas_cmd_);
   }

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_system.h
@@ -114,7 +114,7 @@ class PlanEvalSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: HumanoidStatus.
    */
-  inline const InputPortDescriptor<double>& get_input_port_humanoid_status()
+  InputPortDescriptor<double> get_input_port_humanoid_status()
       const {
     return get_input_port(input_port_index_humanoid_status_);
   }
@@ -122,7 +122,7 @@ class PlanEvalSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the output: QPInput.
    */
-  inline const OutputPortDescriptor<double>& get_output_port_qp_input() const {
+  OutputPortDescriptor<double> get_output_port_qp_input() const {
     return get_output_port(output_port_index_qp_input_);
   }
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h
@@ -69,7 +69,7 @@ class QPControllerSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: HumanoidStatus.
    */
-  inline const InputPortDescriptor<double>& get_input_port_humanoid_status()
+  InputPortDescriptor<double> get_input_port_humanoid_status()
       const {
     return get_input_port(input_port_index_humanoid_status_);
   }
@@ -77,14 +77,14 @@ class QPControllerSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: QPInput.
    */
-  inline const InputPortDescriptor<double>& get_input_port_qp_input() const {
+  InputPortDescriptor<double> get_input_port_qp_input() const {
     return get_input_port(input_port_index_qp_input_);
   }
 
   /**
    * @return Port for the output: QPOutput.
    */
-  inline const OutputPortDescriptor<double>& get_output_port_qp_output() const {
+  OutputPortDescriptor<double> get_output_port_qp_output() const {
     return get_output_port(output_port_index_qp_input_);
   }
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/robot_state_decoder_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/robot_state_decoder_system.h
@@ -73,7 +73,7 @@ class RobotStateDecoderSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the input: lcm message bot_core::robot_state_t
    */
-  inline const InputPortDescriptor<double>& get_input_port_robot_state_msg()
+  InputPortDescriptor<double> get_input_port_robot_state_msg()
       const {
     return get_input_port(input_port_index_lcm_msg_);
   }
@@ -81,7 +81,7 @@ class RobotStateDecoderSystem : public systems::LeafSystem<double> {
   /**
    * @return Port for the output: HumanoidStatus.
    */
-  inline const OutputPortDescriptor<double>& get_output_port_humanoid_status()
+  OutputPortDescriptor<double> get_output_port_humanoid_status()
       const {
     return get_output_port(output_port_index_humanoid_status_);
   }

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.cc
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.cc
@@ -43,7 +43,7 @@ ActuatorEffortToRigidBodyPlantInputConverter<T>::DeclareEffortInputPorts(
 }
 
 template <typename T>
-const InputPortDescriptor<T>& ActuatorEffortToRigidBodyPlantInputConverter<
+InputPortDescriptor<T> ActuatorEffortToRigidBodyPlantInputConverter<
     T>::effort_input_port(const RigidBodyActuator& actuator) {
   return get_input_port(effort_ports_indices_.at(&actuator));
 }

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
@@ -33,7 +33,7 @@ class ActuatorEffortToRigidBodyPlantInputConverter : public LeafSystem<T> {
 
   /// Returns the descriptor of the effort input port corresponding for
   /// @param actuator
-  const InputPortDescriptor<T>& effort_input_port(
+  InputPortDescriptor<T> effort_input_port(
       const RigidBodyActuator& actuator);
 
  private:

--- a/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.cc
+++ b/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.cc
@@ -49,7 +49,7 @@ void RobotCommandToDesiredEffortConverter::DoCalcOutput(
   }
 }
 
-const OutputPortDescriptor<double>&
+OutputPortDescriptor<double>
 RobotCommandToDesiredEffortConverter::desired_effort_output_port(
     const RigidBodyActuator& actuator) const {
   return get_output_port(desired_effort_port_indices_.at(&actuator));

--- a/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h
+++ b/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h
@@ -42,7 +42,7 @@ class RobotCommandToDesiredEffortConverter
 
   /// Descriptor of output port that presents desired effort for @param
   /// actuator.
-  const OutputPortDescriptor<double>& desired_effort_output_port(
+  OutputPortDescriptor<double> desired_effort_output_port(
       const RigidBodyActuator& actuator) const;
 
  private:

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -88,22 +88,22 @@ std::unique_ptr<SystemOutput<double>> RobotStateEncoder::AllocateOutput(
   return std::unique_ptr<SystemOutput<double>>(output.release());
 }
 
-const OutputPortDescriptor<double>& RobotStateEncoder::lcm_message_port()
+OutputPortDescriptor<double> RobotStateEncoder::lcm_message_port()
     const {
   return get_output_port(lcm_message_port_index_);
 }
 
-const InputPortDescriptor<double>& RobotStateEncoder::kinematics_results_port()
+InputPortDescriptor<double> RobotStateEncoder::kinematics_results_port()
     const {
   return get_input_port(kinematics_results_port_index_);
 }
 
-const InputPortDescriptor<double>& RobotStateEncoder::contact_results_port()
+InputPortDescriptor<double> RobotStateEncoder::contact_results_port()
     const {
   return get_input_port(contact_results_port_index_);
 }
 
-const InputPortDescriptor<double>& RobotStateEncoder::effort_port(
+InputPortDescriptor<double> RobotStateEncoder::effort_port(
     const RigidBodyActuator& actuator) const {
   return get_input_port(effort_port_indices_.at(&actuator));
 }

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -45,16 +45,16 @@ class RobotStateEncoder final : public LeafSystem<double> {
       const Context<double>& context) const override;
 
   /// Returns descriptor of output port on which the LCM message is presented.
-  const OutputPortDescriptor<double>& lcm_message_port() const;
+  OutputPortDescriptor<double> lcm_message_port() const;
 
   /// Returns descriptor of kinematics result input port.
-  const InputPortDescriptor<double>& kinematics_results_port() const;
+  InputPortDescriptor<double> kinematics_results_port() const;
 
   /// Returns descriptor of contact results input port.
-  const InputPortDescriptor<double>& contact_results_port() const;
+  InputPortDescriptor<double> contact_results_port() const;
 
   /// Returns descriptor of effort input port corresponding to @param actuator.
-  const InputPortDescriptor<double>& effort_port(
+  InputPortDescriptor<double> effort_port(
       const RigidBodyActuator& actuator) const;
 
  private:

--- a/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
+++ b/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
@@ -27,12 +27,12 @@ class ValkyriePDAndFeedForwardController : public systems::LeafSystem<double> {
     return std::move(output);
   }
 
-  inline const InputPortDescriptor<double>& get_input_port_kinematics_result()
+  InputPortDescriptor<double> get_input_port_kinematics_result()
       const {
     return get_input_port(input_port_index_kinematics_result_);
   }
 
-  inline const OutputPortDescriptor<double>& get_output_port_atlas_command()
+  OutputPortDescriptor<double> get_output_port_atlas_command()
       const {
     return get_output_port(output_port_index_atlas_command_);
   }

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
@@ -42,11 +42,11 @@ class IiwaStatusSender : public systems::LeafSystem<double> {
  public:
   IiwaStatusSender();
 
-  const systems::InputPortDescriptor<double>& get_command_input_port() const {
+  systems::InputPortDescriptor<double> get_command_input_port() const {
     return this->get_input_port(0);
   }
 
-  const systems::InputPortDescriptor<double>& get_state_input_port() const {
+  systems::InputPortDescriptor<double> get_state_input_port() const {
     return this->get_input_port(1);
   }
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -268,23 +268,23 @@ class SimulatedIiwaWithWsg : public systems::Diagram<T> {
 
   const RigidBodyPlant<T>& get_plant() const { return *plant_; }
 
-  const InputPortDescriptor<T>& get_iiwa_input_port() const {
+  InputPortDescriptor<T> get_iiwa_input_port() const {
     return this->get_input_port(0);
   }
 
-  const OutputPortDescriptor<T>& get_iiwa_state_port() const {
+  OutputPortDescriptor<T> get_iiwa_state_port() const {
     return this->get_output_port(0);
   }
 
-  const InputPortDescriptor<T>& get_wsg_input_port() const {
+  InputPortDescriptor<T> get_wsg_input_port() const {
     return this->get_input_port(1);
   }
 
-  const OutputPortDescriptor<T>& get_wsg_state_port() const {
+  OutputPortDescriptor<T> get_wsg_state_port() const {
     return this->get_output_port(1);
   }
 
-  const OutputPortDescriptor<T>& get_plant_output_port() const {
+  OutputPortDescriptor<T> get_plant_output_port() const {
     return this->get_output_port(2);
   }
 

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.h
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.h
@@ -31,11 +31,11 @@ class SchunkWsgTrajectoryGenerator : public systems::LeafSystem<double> {
   /// which contains the position of the actuated finger.
   SchunkWsgTrajectoryGenerator(int input_size, int position_index);
 
-  const systems::InputPortDescriptor<double>& get_command_input_port() const {
+  systems::InputPortDescriptor<double> get_command_input_port() const {
     return this->get_input_port(0);
   }
 
-  const systems::InputPortDescriptor<double>& get_state_input_port() const {
+  systems::InputPortDescriptor<double> get_state_input_port() const {
     return this->get_input_port(1);
   }
 

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -196,7 +196,7 @@ class RigidBodyPlant : public LeafSystem<T> {
 
   /// Returns a descriptor of the input port for a specific model
   /// instance.
-  const InputPortDescriptor<T>& model_input_port(
+  InputPortDescriptor<T> model_input_port(
       int model_instance_id) const {
     return System<T>::get_input_port(input_map_.at(model_instance_id));
   }
@@ -227,24 +227,24 @@ class RigidBodyPlant : public LeafSystem<T> {
   ///@{
 
   /// Returns a descriptor of the state output port.
-  const OutputPortDescriptor<T>& state_output_port() const {
+  OutputPortDescriptor<T> state_output_port() const {
     return System<T>::get_output_port(state_output_port_id_);
   }
 
   /// Returns a descriptor of the KinematicsResults output port.
-  const OutputPortDescriptor<T>& kinematics_results_output_port() const {
+  OutputPortDescriptor<T> kinematics_results_output_port() const {
     return System<T>::get_output_port(kinematics_output_port_id_);
   }
 
   /// Returns a descriptor of the ContactResults output port.
-  const OutputPortDescriptor<T>& contact_results_output_port() const {
+  OutputPortDescriptor<T> contact_results_output_port() const {
     return System<T>::get_output_port(contact_output_port_id_);
   }
 
   /// Returns a descriptor of the output port containing the state of a
   /// particular model with instance ID equal to @p model_instance_id. Throws a
   /// std::runtime_error if @p model_instance_id does not exist.
-  const OutputPortDescriptor<T>& model_state_output_port(
+  OutputPortDescriptor<T> model_state_output_port(
       int model_instance_id) const {
     if (model_instance_id >= static_cast<int>(output_map_.size())) {
       throw std::runtime_error("RigidBodyPlant: model_state_output_port: "

--- a/drake/systems/controllers/pid_controlled_system.h
+++ b/drake/systems/controllers/pid_controlled_system.h
@@ -131,12 +131,12 @@ class PidControlledSystem : public Diagram<T> {
   System<T>* plant() { return plant_; }
 
   /// @return the input port for the feed forward control input.
-  const InputPortDescriptor<T>& get_control_input_port() const {
+  InputPortDescriptor<T> get_control_input_port() const {
     return this->get_input_port(0);
   }
 
   /// @return the input port for the desired position/velocity state.
-  const InputPortDescriptor<T>& get_state_input_port() const {
+  InputPortDescriptor<T> get_state_input_port() const {
     return this->get_input_port(1);
   }
 

--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -90,19 +90,19 @@ bool PidController<T>::has_any_direct_feedthrough() const {
 }
 
 template <typename T>
-const InputPortDescriptor<T>& PidController<T>::get_error_port() const {
+InputPortDescriptor<T> PidController<T>::get_error_port() const {
   return Diagram<T>::get_input_port(0);
 }
 
 template <typename T>
-const InputPortDescriptor<T>&
+InputPortDescriptor<T>
 PidController<T>::get_error_derivative_port() const {
   return Diagram<T>::get_input_port(1);
 }
 
 
 template <typename T>
-const OutputPortDescriptor<T>&
+OutputPortDescriptor<T>
 PidController<T>::get_control_output_port() const {
   return System<T>::get_output_port(0);
 }

--- a/drake/systems/controllers/pid_controller.h
+++ b/drake/systems/controllers/pid_controller.h
@@ -96,13 +96,13 @@ class PidController : public Diagram<T> {
                           const Eigen::Ref<const VectorX<T>>& value) const;
 
   /// Returns the input port to the error signal.
-  const InputPortDescriptor<T>& get_error_port() const;
+  InputPortDescriptor<T> get_error_port() const;
 
   /// Returns the input port to the time derivative or rate of the error signal.
-  const InputPortDescriptor<T>& get_error_derivative_port() const;
+  InputPortDescriptor<T> get_error_derivative_port() const;
 
   /// Returns the output port to the control output.
-  const OutputPortDescriptor<T>& get_control_output_port() const;
+  OutputPortDescriptor<T> get_control_output_port() const;
 
  private:
   Adder<T>* adder_ = nullptr;

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -452,6 +452,15 @@ cc_googletest(
 )
 
 cc_googletest(
+    name = "system_port_descriptor_test",
+    deps = [
+        ":leaf_system",
+        ":system_port_descriptor",
+        "//drake/common",
+    ],
+)
+
+cc_googletest(
     name = "value_test",
     deps = [
         ":value",

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -552,7 +552,7 @@ class System {
   }
 
   /// Returns the descriptor of the input port at index @p port_index.
-  const InputPortDescriptor<T>& get_input_port(int port_index) const {
+  InputPortDescriptor<T> get_input_port(int port_index) const {
     if (port_index >= get_num_input_ports()) {
       throw std::out_of_range("System " + get_name() + ": Port index " +
           std::to_string(port_index) + " is out of range. There are only " +
@@ -562,7 +562,7 @@ class System {
   }
 
   /// Returns the descriptor of the output port at index @p port_index.
-  const OutputPortDescriptor<T>& get_output_port(int port_index) const {
+  OutputPortDescriptor<T> get_output_port(int port_index) const {
     if (port_index >= get_num_output_ports()) {
       throw std::out_of_range("System " + get_name() + ": Port index " +
           std::to_string(port_index) + " is out of range. There are only " +
@@ -709,7 +709,7 @@ class System {
 
   /// Adds a port with the specified @p type and @p size to the input topology.
   /// @return descriptor of declared port.
-  const InputPortDescriptor<T>& DeclareInputPort(PortDataType type, int size) {
+  InputPortDescriptor<T> DeclareInputPort(PortDataType type, int size) {
     int port_index = get_num_input_ports();
     input_ports_.emplace_back(this, port_index, type, size);
     return input_ports_.back();
@@ -717,13 +717,13 @@ class System {
 
   /// Adds an abstract-valued port to the input topology.
   /// @return descriptor of declared port.
-  const InputPortDescriptor<T>& DeclareAbstractInputPort() {
+  InputPortDescriptor<T> DeclareAbstractInputPort() {
     return DeclareInputPort(kAbstractValued, 0 /* size */);
   }
 
   /// Adds a port with the specified @p type and @p size to the output topology.
   /// @return descriptor of declared port.
-  const OutputPortDescriptor<T>& DeclareOutputPort(PortDataType type,
+  OutputPortDescriptor<T> DeclareOutputPort(PortDataType type,
                                                    int size) {
     int port_index = get_num_output_ports();
     output_ports_.emplace_back(this, port_index, type, size);
@@ -732,7 +732,7 @@ class System {
 
   /// Adds an abstract-valued port with to the output topology.
   /// @return descriptor of declared port.
-  const OutputPortDescriptor<T>& DeclareAbstractOutputPort() {
+  OutputPortDescriptor<T> DeclareAbstractOutputPort() {
     return DeclareOutputPort(kAbstractValued, 0 /* size */);
   }
   //@}

--- a/drake/systems/framework/system_port_descriptor.h
+++ b/drake/systems/framework/system_port_descriptor.h
@@ -44,23 +44,13 @@ class InputPortDescriptor {
   }
 
   /// @name Basic Concepts
-  /// MoveConstructible only; not CopyConstructible; not Copy/Move-Assignable.
+  /// MoveConstructible, CopyConstructible, Copy-Assignable, Move-Assignable
   /// @{
-  //
-  // Implementation note: This class aliases a pointer to the system that
-  // contains it and captures its own index within that system's port vector,
-  // so we must be careful not to allow C++ copying to extend the lifetime of
-  // the system alias or duplicate our claim to the index.  Thus, this class is
-  // `MoveConstructible` but neither copyable nor assignable: it supports move
-  // to populate a vector, but is non-copyable in order remain the "one true
-  // descriptor" after construction and non-assignable in order to remain
-  // const.  Code that wishes to refer to this descriptor after insertion into
-  // the vector should use a reference (not copy) of this descriptor.
   InputPortDescriptor() = delete;
   InputPortDescriptor(InputPortDescriptor&& other) = default;
-  InputPortDescriptor(const InputPortDescriptor&) = delete;
-  InputPortDescriptor& operator=(InputPortDescriptor&&) = delete;
-  InputPortDescriptor& operator=(const InputPortDescriptor&) = delete;
+  InputPortDescriptor(const InputPortDescriptor&) = default;
+  InputPortDescriptor& operator=(InputPortDescriptor&&) = default;
+  InputPortDescriptor& operator=(const InputPortDescriptor&) = default;
   ~InputPortDescriptor() = default;
   /// @}
 
@@ -70,10 +60,10 @@ class InputPortDescriptor {
   int size() const { return size_; }
 
  private:
-  const System<T>* const system_;
-  const int index_;
-  const PortDataType data_type_;
-  const int size_;
+  const System<T>* system_{nullptr};
+  int index_{0};
+  PortDataType data_type_{kVectorValued};
+  int size_{0};
 };
 
 /// OutputPortDescriptor is a notation for specifying the kind of output a
@@ -99,14 +89,13 @@ class OutputPortDescriptor {
     }
   }
   /// @name Basic Concepts
-  /// MoveConstructible only; not CopyConstructible; not Copy/Move-Assignable.
+  /// MoveConstructible, CopyConstructible, Copy-Assignable, Move-Assignable
   /// @{
-  // See InputPortDescriptor doc for implementation note and justification.
   OutputPortDescriptor() = delete;
   OutputPortDescriptor(OutputPortDescriptor&&) = default;
-  OutputPortDescriptor(const OutputPortDescriptor&) = delete;
+  OutputPortDescriptor(const OutputPortDescriptor&) = default;
   OutputPortDescriptor& operator=(OutputPortDescriptor&&) = default;
-  OutputPortDescriptor& operator=(const OutputPortDescriptor&) = delete;
+  OutputPortDescriptor& operator=(const OutputPortDescriptor&) = default;
   ~OutputPortDescriptor() = default;
   /// @}
 
@@ -116,10 +105,10 @@ class OutputPortDescriptor {
   int size() const { return size_; }
 
  private:
-  const System<T>* const system_;
-  const int index_;
-  const PortDataType data_type_;
-  const int size_;
+  const System<T>* system_{nullptr};
+  int index_{0};
+  PortDataType data_type_{kVectorValued};
+  int size_{0};
 };
 
 }  // namespace systems

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -48,3 +48,6 @@ target_link_libraries(leaf_system_test drakeSystemFramework drakeSystemPrimitive
 
 drake_add_cc_test(parameters_test)
 target_link_libraries(parameters_test drakeSystemFramework drakeSystemPrimitives)
+
+drake_add_cc_test(system_port_descriptor_test)
+target_link_libraries(system_port_descriptor_test drakeSystemFramework drakeSystemPrimitives)

--- a/drake/systems/framework/test/system_port_descriptor_test.cc
+++ b/drake/systems/framework/test/system_port_descriptor_test.cc
@@ -1,0 +1,65 @@
+#include "drake/systems/framework/system_port_descriptor.h"
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+class TestSystem : public LeafSystem<double> {
+ public:
+  TestSystem() {}
+  ~TestSystem() override {}
+
+  void DoCalcOutput(const Context<double>& context,
+                    SystemOutput<double>* output) const override {}
+};
+
+GTEST_TEST(InputPortDescriptor, CopyConstructable) {
+  TestSystem system;
+  InputPortDescriptor<double> descriptor(&system, 42, kVectorValued, 28);
+  InputPortDescriptor<double> copy(descriptor);
+  EXPECT_EQ(&system, copy.get_system());
+  EXPECT_EQ(42, copy.get_index());
+  EXPECT_EQ(kVectorValued, copy.get_data_type());
+  EXPECT_EQ(28, copy.size());
+}
+
+GTEST_TEST(InputPortDescriptor, Assignable) {
+  TestSystem system;
+  InputPortDescriptor<double> descriptor(&system, 42, kVectorValued, 28);
+  InputPortDescriptor<double> copy(&system, 1, kAbstractValued, 2);
+  copy = descriptor;
+  EXPECT_EQ(&system, copy.get_system());
+  EXPECT_EQ(42, copy.get_index());
+  EXPECT_EQ(kVectorValued, copy.get_data_type());
+  EXPECT_EQ(28, copy.size());
+}
+
+GTEST_TEST(OutputPortDescriptor, CopyConstructable) {
+  TestSystem system;
+  OutputPortDescriptor<double> descriptor(&system, 42, kVectorValued, 28);
+  OutputPortDescriptor<double> copy(descriptor);
+  EXPECT_EQ(&system, copy.get_system());
+  EXPECT_EQ(42, copy.get_index());
+  EXPECT_EQ(kVectorValued, copy.get_data_type());
+  EXPECT_EQ(28, copy.size());
+}
+
+GTEST_TEST(OutputPortDescriptor, Assignable) {
+  TestSystem system;
+  OutputPortDescriptor<double> descriptor(&system, 42, kVectorValued, 28);
+  OutputPortDescriptor<double> copy(&system, 1, kAbstractValued, 2);
+  copy = descriptor;
+  EXPECT_EQ(&system, copy.get_system());
+  EXPECT_EQ(42, copy.get_index());
+  EXPECT_EQ(kVectorValued, copy.get_data_type());
+  EXPECT_EQ(28, copy.size());
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -77,7 +77,7 @@ SpringMassSystem<T>::SpringMassSystem(const T& spring_constant_N_per_m,
 }
 
 template <typename T>
-const InputPortDescriptor<T>& SpringMassSystem<T>::get_force_port() const {
+InputPortDescriptor<T> SpringMassSystem<T>::get_force_port() const {
   if (system_is_forced_) {
     return this->get_input_port(0);
   } else {
@@ -88,7 +88,7 @@ const InputPortDescriptor<T>& SpringMassSystem<T>::get_force_port() const {
 }
 
 template <typename T>
-const OutputPortDescriptor<T>& SpringMassSystem<T>::get_output_port() const {
+OutputPortDescriptor<T> SpringMassSystem<T>::get_output_port() const {
   return System<T>::get_output_port(0);
 }
 

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.h
@@ -94,10 +94,10 @@ class SpringMassSystem : public LeafSystem<T> {
   // Provide methods specific to this System.
 
   /// Returns the input port to the externally applied force.
-  const InputPortDescriptor<T>& get_force_port() const;
+  InputPortDescriptor<T> get_force_port() const;
 
   /// Returns the port to output state.
-  const OutputPortDescriptor<T>& get_output_port() const;
+  OutputPortDescriptor<T> get_output_port() const;
 
   /// Returns the spring constant k that was provided at construction, in N/m.
   const T& get_spring_constant() const { return spring_constant_N_per_m_; }

--- a/drake/systems/primitives/adder.cc
+++ b/drake/systems/primitives/adder.cc
@@ -21,7 +21,7 @@ Adder<T>::Adder(int num_inputs, int size) {
 }
 
 template <typename T>
-const OutputPortDescriptor<T>& Adder<T>::get_output_port() const {
+OutputPortDescriptor<T> Adder<T>::get_output_port() const {
   return System<T>::get_output_port(0);
 }
 

--- a/drake/systems/primitives/adder.h
+++ b/drake/systems/primitives/adder.h
@@ -34,7 +34,7 @@ class Adder : public LeafSystem<T> {
   bool has_any_direct_feedthrough() const override { return true; }
 
   /// Returns the output port.
-  const OutputPortDescriptor<T>& get_output_port() const;
+  OutputPortDescriptor<T> get_output_port() const;
 
   /// Returns an Adder<AutoDiffXd> with the same dimensions as this Adder.
   std::unique_ptr<Adder<AutoDiffXd>> ToAutoDiffXd() const {

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -63,13 +63,13 @@ AffineSystem<AutoDiffXd>* AffineSystem<T>::DoToAutoDiffXd() const {
 }
 
 template <typename T>
-const InputPortDescriptor<T>& AffineSystem<T>::get_input_port() const {
+InputPortDescriptor<T> AffineSystem<T>::get_input_port() const {
   DRAKE_DEMAND(num_inputs_ > 0);
   return System<T>::get_input_port(0);
 }
 
 template <typename T>
-const OutputPortDescriptor<T>& AffineSystem<T>::get_output_port() const {
+OutputPortDescriptor<T> AffineSystem<T>::get_output_port() const {
   DRAKE_DEMAND(num_outputs_ > 0);
   return System<T>::get_output_port(0);
 }

--- a/drake/systems/primitives/affine_system.h
+++ b/drake/systems/primitives/affine_system.h
@@ -63,10 +63,10 @@ class AffineSystem : public LeafSystem<T> {
   bool has_any_direct_feedthrough() const override { return !D_.isZero(0.0); }
 
   /// Returns the input port containing the externally applied input.
-  const InputPortDescriptor<T>& get_input_port() const;
+  InputPortDescriptor<T> get_input_port() const;
 
   /// Returns the port containing the output state.
-  const OutputPortDescriptor<T>& get_output_port() const;
+  OutputPortDescriptor<T> get_output_port() const;
 
   // Helper getter methods.
   const Eigen::MatrixXd& A() const { return A_; }

--- a/drake/systems/primitives/constant_vector_source.cc
+++ b/drake/systems/primitives/constant_vector_source.cc
@@ -26,7 +26,7 @@ ConstantVectorSource<T>::ConstantVectorSource(const T& source_value)
 }
 
 template <typename T>
-const OutputPortDescriptor<T>& ConstantVectorSource<T>::get_output_port()
+OutputPortDescriptor<T> ConstantVectorSource<T>::get_output_port()
     const {
   return System<T>::get_output_port(0);
 }

--- a/drake/systems/primitives/constant_vector_source.h
+++ b/drake/systems/primitives/constant_vector_source.h
@@ -40,7 +40,7 @@ class ConstantVectorSource : public LeafSystem<T> {
 
 
   /// Returns the output port to the constant source.
-  const OutputPortDescriptor<T>& get_output_port() const;
+  OutputPortDescriptor<T> get_output_port() const;
 
  private:
   // Outputs a signal with a fixed value as specified by the user.

--- a/drake/systems/primitives/gain-inl.h
+++ b/drake/systems/primitives/gain-inl.h
@@ -47,12 +47,12 @@ const VectorX<T>& Gain<T>::get_gain_vector() const {
 }
 
 template <typename T>
-const InputPortDescriptor<T>& Gain<T>::get_input_port() const {
+InputPortDescriptor<T> Gain<T>::get_input_port() const {
   return System<T>::get_input_port(0);
 }
 
 template <typename T>
-const OutputPortDescriptor<T>& Gain<T>::get_output_port() const {
+OutputPortDescriptor<T> Gain<T>::get_output_port() const {
   return System<T>::get_output_port(0);
 }
 

--- a/drake/systems/primitives/gain.h
+++ b/drake/systems/primitives/gain.h
@@ -53,10 +53,10 @@ class Gain : public LeafSystem<T> {
 
 
   /// Returns the input port.
-  const InputPortDescriptor<T>& get_input_port() const;
+  InputPortDescriptor<T> get_input_port() const;
 
   /// Returns the output port.
-  const OutputPortDescriptor<T>& get_output_port() const;
+  OutputPortDescriptor<T> get_output_port() const;
 
  private:
   // Sets the output port value to the product of the gain and the input port

--- a/drake/systems/primitives/saturation.cc
+++ b/drake/systems/primitives/saturation.cc
@@ -52,12 +52,12 @@ void Saturation<T>::DoCalcOutput(const Context<T>& context,
 }
 
 template <typename T>
-const InputPortDescriptor<T>& Saturation<T>::get_input_port() const {
+InputPortDescriptor<T> Saturation<T>::get_input_port() const {
   return System<T>::get_input_port(input_port_index_);
 }
 
 template <typename T>
-const OutputPortDescriptor<T>& Saturation<T>::get_output_port() const {
+OutputPortDescriptor<T> Saturation<T>::get_output_port() const {
   return System<T>::get_output_port(output_port_index_);
 }
 

--- a/drake/systems/primitives/saturation.h
+++ b/drake/systems/primitives/saturation.h
@@ -57,10 +57,10 @@ class Saturation : public LeafSystem<T> {
                       const Eigen::Ref<const VectorX<T>>& u_max);
 
   /// Returns the input port.
-  const InputPortDescriptor<T>& get_input_port() const;
+  InputPortDescriptor<T> get_input_port() const;
 
   /// Returns the output port.
-  const OutputPortDescriptor<T>& get_output_port() const;
+  OutputPortDescriptor<T> get_output_port() const;
 
   /// Returns the lower limit `u_{min}` as a scalar value. Aborts if the lower
   /// limit cannot be represented by a single scalar value. This can occur if

--- a/drake/systems/sensors/depth_sensor.cc
+++ b/drake/systems/sensors/depth_sensor.cc
@@ -113,12 +113,12 @@ void DepthSensor::PrecomputeRaycastEndpoints() {
   }
 }
 
-const InputPortDescriptor<double>&
+InputPortDescriptor<double>
 DepthSensor::get_rigid_body_tree_state_input_port() const {
   return this->get_input_port(input_port_index_);
 }
 
-const OutputPortDescriptor<double>& DepthSensor::get_sensor_state_output_port()
+OutputPortDescriptor<double> DepthSensor::get_sensor_state_output_port()
     const {
   return System<double>::get_output_port(output_port_index_);
 }

--- a/drake/systems/sensors/depth_sensor.h
+++ b/drake/systems/sensors/depth_sensor.h
@@ -164,12 +164,12 @@ class DepthSensor : public systems::LeafSystem<double> {
 
   /// Returns a descriptor of the input port containing the generalized state of
   /// the RigidBodyTree.
-  const InputPortDescriptor<double>& get_rigid_body_tree_state_input_port()
+  InputPortDescriptor<double> get_rigid_body_tree_state_input_port()
       const;
 
   /// Returns a descriptor of the state output port, which contains the sensor's
   /// sensed values.
-  const OutputPortDescriptor<double>& get_sensor_state_output_port() const;
+  OutputPortDescriptor<double> get_sensor_state_output_port() const;
 
   /// Allocates the output vector. See this class' description for details of
   /// this output vector.


### PR DESCRIPTION
Update System<T> to stop returning PortDescriptor references of hazardous lifetime.

@jwnimmer-tri for both levels(?) of review.  Most of the diff is perl -pie.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4768)
<!-- Reviewable:end -->
