### PR TITLE
Collision filter groups

### DIFF
--- a/drake/matlab/systems/plants/constructModelmex.cpp
+++ b/drake/matlab/systems/plants/constructModelmex.cpp
@@ -290,12 +290,12 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
       size_t numel_belongs_to(mxGetNumberOfElements(belongs_to));
       size_t numel_ignores(mxGetNumberOfElements(ignores));
       size_t num_collision_filter_groups = max(numel_belongs_to, numel_ignores);
-      if (num_collision_filter_groups > MAX_NUM_COLLISION_FILTER_GROUPS) {
+      if (num_collision_filter_groups > kMaxNumCollisionFilterGroups) {
         mexErrMsgIdAndTxt(
             "Drake:constructModelmex:TooManyCollisionFilterGroups",
             "The total number of collision filter groups (%d) "
             "exceeds the maximum allowed number (%d)",
-            num_collision_filter_groups, MAX_NUM_COLLISION_FILTER_GROUPS);
+            num_collision_filter_groups, kMaxNumCollisionFilterGroups);
       }
 
       mxLogical* logical_belongs_to = mxGetLogicals(belongs_to);

--- a/drake/matlab/systems/plants/constructModelmex.cpp
+++ b/drake/matlab/systems/plants/constructModelmex.cpp
@@ -311,7 +311,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
           mask.set(j);
         }
       }
-      b->setCollisionFilter(group, mask);
+      b->set_collision_filter(group, mask);
     }
 
     model->bodies.push_back(std::move(b));

--- a/drake/matlab/systems/plants/constructModelmex.cpp
+++ b/drake/matlab/systems/plants/constructModelmex.cpp
@@ -311,7 +311,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
           mask.set(j);
         }
       }
-      b->set_collision_filter(group, mask);
+      model->SetBodyCollisionFilters(*b, group, mask);
     }
 
     model->bodies.push_back(std::move(b));

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -9,10 +9,12 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "model",
     srcs = [
+        "collision_filter.cc",
         "element.cc",
         "model.cc",
     ],
     hdrs = [
+        "collision_filter.h",
         "element.h",
         "model.h",
         "point_pair.h",
@@ -20,6 +22,7 @@ cc_library(
     linkstatic = 1,
     deps = [
         "//drake/common",
+        "//drake/common:autodiff",
         "//drake/common:sorted_vectors_have_intersection",
         "//drake/multibody/shapes",
     ],
@@ -101,6 +104,17 @@ cc_googletest(
     name = "fcl_model_test",
     deps = [
         ":fcl_collision",
+    ],
+)
+
+cc_googletest(
+    name = "collision_filter_group_test",
+    data = [":test_models"],
+    deps = [
+        ":collision",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
     ],
 )
 

--- a/drake/multibody/collision/CMakeLists.txt
+++ b/drake/multibody/collision/CMakeLists.txt
@@ -1,4 +1,9 @@
-set(drakeCollision_SRC_FILES drake_collision.cc element.cc model.cc)
+set(drakeCollision_SRC_FILES
+    drake_collision.cc
+    element.cc
+    model.cc
+    collision_filter.cc
+    )
 
 if(Bullet_FOUND)
   set(drakeCollision_SRC_FILES ${drakeCollision_SRC_FILES} bullet_model.cc)
@@ -33,7 +38,12 @@ target_link_libraries(drakeCollision
   Eigen3::Eigen)
 
 drake_install_libraries(drakeCollision)
-drake_install_headers(drake_collision.h point_pair.h element.h model.h)
+drake_install_headers(drake_collision.h
+    point_pair.h
+    element.h
+    model.h
+    collision_filter.h
+    )
 drake_install_pkg_config_file(drake-collision
   TARGET drakeCollision
   LIBS -ldrakeCollision

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -1,0 +1,21 @@
+#include "drake/multibody/collision/collision_filter.h"
+
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace DrakeCollision {
+
+using drake::AutoDiffXd ;
+
+template <typename T>
+CollisionFilterGroup<T>::CollisionFilterGroup() : name_(""), model_id_(-1) {}
+
+template <typename T>
+CollisionFilterGroup<T>::CollisionFilterGroup(const std::string& name,
+                                           int model_id)
+    : name_(name), model_id_(model_id) {}
+
+// Explicitly instantiates on the most common scalar types.
+template class CollisionFilterGroup<double>;
+template class CollisionFilterGroup<AutoDiffXd>;
+
+}  // namespace DrakeCollision

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -9,6 +9,9 @@
 
 namespace DrakeCollision {
 
+const bitmask NONE_MASK(0);
+const bitmask DEFAULT_GROUP(1);
+
 using drake::AutoDiffXd;
 
 template <typename T>
@@ -37,7 +40,7 @@ template <typename T>
 void CollisionFilterGroupManager<T>::CompileGroups() {
   for (auto& pair : collision_filter_groups_) {
     CollisionFilterGroup<T>& group = pair.second;
-    bitmask group_mask, ignore_mask;
+    bitmask group_mask = DEFAULT_GROUP, ignore_mask = NONE_MASK;
     group_mask.set(group.get_mask_id());
     for (const auto& ignore_name : group.get_ignore_groups()) {
       const auto& itr = collision_filter_groups_.find(ignore_name);

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -21,6 +21,9 @@ CollisionFilterGroup<T>::CollisionFilterGroup(const std::string& name, int id)
 }
 
 template <typename T>
+const int CollisionFilterGroupManager<T>::kInvalidGroupId = -1;
+
+template <typename T>
 void CollisionFilterGroupManager<T>::DefineCollisionFilterGroup(
     const std::string& name) {
   auto itr = collision_filter_groups_.find(name);
@@ -91,7 +94,7 @@ template <typename T>
 int CollisionFilterGroupManager<T>::GetGroupId(const std::string& group_name) {
   auto itr = collision_filter_groups_.find(group_name);
   if (itr == collision_filter_groups_.end()) {
-    return -1;
+    return kInvalidGroupId;
   }
   return itr->second.get_mask_id();
 }

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/collision/collision_filter.h"
 
+#include <drake/common/drake_assert.h>
+#include <drake/common/text_logging.h>
 #include "drake/common/eigen_autodiff_types.h"
 
 namespace DrakeCollision {
@@ -11,18 +13,51 @@ CollisionFilterGroup<T>::CollisionFilterGroup() : name_(""), model_id_(-1) {}
 
 template <typename T>
 CollisionFilterGroup<T>::CollisionFilterGroup(const std::string& name,
-                                              int model_id)
-    : name_(name), model_id_(model_id) {}
+                                              int model_id, int id)
+    : name_(name), model_id_(model_id), mask_id_(id) {
+  DRAKE_ASSERT(mask_id_ >= 0 && mask_id_ < MAX_NUM_COLLISION_FILTER_GROUPS);
+}
 
 template <typename T>
 void CollisionFilterGroupManager<T>::DefineCollisionFilterGroup(
     const std::string& name, int model_id) {
   auto itr = collision_filter_groups_.find(name);
   if (itr == collision_filter_groups_.end()) {
-    collision_filter_groups_[name] = CollisionFilterGroup<T>(name, model_id);
+    int id = acquire_next_group_id();
+    collision_filter_groups_[name] =
+        CollisionFilterGroup<T>(name, model_id, id);
   }
   throw std::runtime_error(
       "Attempting to create duplicate collision filter group: " + name);
+}
+
+template <typename T>
+void CollisionFilterGroupManager<T>::CompileGroups() {
+  for (auto& pair : collision_filter_groups_) {
+    CollisionFilterGroup<T>& group = pair.second;
+    bitmask group_mask, ignore_mask;
+    group_mask.set(group.get_mask_id());
+    for (const auto& ignore_name : group.get_ignore_groups()) {
+      const auto& itr = collision_filter_groups_.find(ignore_name);
+      if (itr != collision_filter_groups_.end()) {
+        ignore_mask.set(itr->second.get_mask_id());
+      } else {
+        drake::log()->warn(
+            "Collision filter group '{}' was specified to ignore"
+            " group '{}', but '{}' was not defined.",
+            pair.first, ignore_name, ignore_name);
+      }
+    }
+    for (const RigidBody<T>* body : group.get_bodies()) {
+      auto itr = body_groups_.find(body);
+      if (itr == body_groups_.end()) {
+        body_groups_[body] = std::make_pair(group_mask, ignore_mask);
+      } else {
+        body_groups_[body].first |= group_mask;
+        body_groups_[body].second |= group_mask;
+      }
+    }
+  }
 }
 
 template <typename T>
@@ -58,6 +93,44 @@ int CollisionFilterGroupManager<T>::GetGroupModelInstanceId(
     return -1;
   }
   return itr->second.get_model_id();
+}
+
+template <typename T>
+bitmask CollisionFilterGroupManager<T>::get_group_mask(
+    const RigidBody<T>& body) {
+  auto itr = body_groups_.find(&body);
+  if (itr != body_groups_.end()) {
+    return itr->second.first;
+  }
+  return NONE_MASK;
+}
+
+template <typename T>
+bitmask CollisionFilterGroupManager<T>::get_ignore_mask(
+    const RigidBody<T>& body) {
+  auto itr = body_groups_.find(&body);
+  if (itr != body_groups_.end()) {
+    return itr->second.second;
+  }
+  return NONE_MASK;
+}
+
+template <typename T>
+void CollisionFilterGroupManager<T>::Clear() {
+  collision_filter_groups_.clear();
+  body_groups_.clear();
+}
+
+template <typename T>
+int CollisionFilterGroupManager<T>::acquire_next_group_id() {
+  if (next_id_ >= MAX_NUM_COLLISION_FILTER_GROUPS) {
+    throw std::runtime_error(
+        "Requesting a collision filter group id when"
+        " there are no more available. Drake only supports " +
+        std::to_string(MAX_NUM_COLLISION_FILTER_GROUPS) +
+        " collision filter groups per RigidBodyTree instance.");
+  }
+  return next_id_++;
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -15,14 +15,14 @@ CollisionFilterGroup<T>::CollisionFilterGroup(const std::string& name,
     : name_(name), model_id_(model_id) {}
 
 template <typename T>
-bool CollisionFilterGroupManager<T>::DefineCollisionFilterGroup(
+void CollisionFilterGroupManager<T>::DefineCollisionFilterGroup(
     const std::string& name, int model_id) {
   auto itr = collision_filter_groups_.find(name);
   if (itr == collision_filter_groups_.end()) {
     collision_filter_groups_[name] = CollisionFilterGroup<T>(name, model_id);
-    return true;
   }
-  return false;
+  throw std::runtime_error(
+      "Attempting to create duplicate collision filter group: " + name);
 }
 
 template <typename T>

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -4,18 +4,66 @@
 
 namespace DrakeCollision {
 
-using drake::AutoDiffXd ;
+using drake::AutoDiffXd;
 
 template <typename T>
 CollisionFilterGroup<T>::CollisionFilterGroup() : name_(""), model_id_(-1) {}
 
 template <typename T>
 CollisionFilterGroup<T>::CollisionFilterGroup(const std::string& name,
-                                           int model_id)
+                                              int model_id)
     : name_(name), model_id_(model_id) {}
+
+template <typename T>
+bool CollisionFilterGroupManager<T>::DefineCollisionFilterGroup(
+    const std::string& name, int model_id) {
+  auto itr = collision_filter_groups_.find(name);
+  if (itr == collision_filter_groups_.end()) {
+    collision_filter_groups_[name] = CollisionFilterGroup<T>(name, model_id);
+    return true;
+  }
+  return false;
+}
+
+template <typename T>
+bool CollisionFilterGroupManager<T>::AddCollisionFilterGroupMember(
+    const std::string& group_name, RigidBody<T>* body) {
+  auto itr = collision_filter_groups_.find(group_name);
+  if (itr == collision_filter_groups_.end()) {
+    return false;
+  }
+  CollisionFilterGroup<T>& group = itr->second;
+  group.add_body(body);
+  return true;
+}
+
+template <typename T>
+void CollisionFilterGroupManager<T>::AddCollisionFilterIgnoreTarget(
+    const std::string& group_name, const std::string& target_group_name) {
+  auto itr = collision_filter_groups_.find(group_name);
+  if (itr == collision_filter_groups_.end()) {
+    throw std::runtime_error(
+        "Attempting to add an ignored collision filter group to an undefined "
+        "collision filter group: Ignoring " +
+        target_group_name + " by " + group_name + ".");
+  }
+  itr->second.add_ignore_group(target_group_name);
+}
+
+template <typename T>
+int CollisionFilterGroupManager<T>::GetGroupModelInstanceId(
+    const std::string& group_name) {
+  auto itr = collision_filter_groups_.find(group_name);
+  if (itr == collision_filter_groups_.end()) {
+    return -1;
+  }
+  return itr->second.get_model_id();
+}
 
 // Explicitly instantiates on the most common scalar types.
 template class CollisionFilterGroup<double>;
 template class CollisionFilterGroup<AutoDiffXd>;
+template class CollisionFilterGroupManager<double>;
+template class CollisionFilterGroupManager<AutoDiffXd>;
 
 }  // namespace DrakeCollision

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -1,8 +1,8 @@
 #include "drake/multibody/collision/collision_filter.h"
 
-#include <drake/common/drake_assert.h>
-#include <drake/common/text_logging.h>
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/text_logging.h"
 
 #include <string>
 #include <utility>
@@ -32,7 +32,7 @@ void CollisionFilterGroupManager<T>::DefineCollisionFilterGroup(
     collision_filter_groups_[name] = CollisionFilterGroup<T>(name, id);
   } else {
     throw std::runtime_error(
-        "Attempting to create duplicate collision filter group: " + name);
+        "Attempting to create duplicate collision filter group: " + name + ".");
   }
 }
 
@@ -100,7 +100,7 @@ int CollisionFilterGroupManager<T>::GetGroupId(const std::string& group_name) {
 }
 
 template <typename T>
-bitmask CollisionFilterGroupManager<T>::get_group_mask(
+const bitmask& CollisionFilterGroupManager<T>::get_group_mask(
     const RigidBody<T>& body) {
   auto itr = body_groups_.find(&body);
   if (itr != body_groups_.end()) {
@@ -110,7 +110,7 @@ bitmask CollisionFilterGroupManager<T>::get_group_mask(
 }
 
 template <typename T>
-bitmask CollisionFilterGroupManager<T>::get_ignore_mask(
+const bitmask& CollisionFilterGroupManager<T>::get_ignore_mask(
     const RigidBody<T>& body) {
   auto itr = body_groups_.find(&body);
   if (itr != body_groups_.end()) {

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -9,9 +9,6 @@
 
 namespace DrakeCollision {
 
-const bitmask NONE_MASK(0);
-const bitmask DEFAULT_GROUP(1);
-
 using drake::AutoDiffXd;
 
 template <typename T>
@@ -20,7 +17,7 @@ CollisionFilterGroup<T>::CollisionFilterGroup() : name_(""), mask_id_(-1) {}
 template <typename T>
 CollisionFilterGroup<T>::CollisionFilterGroup(const std::string& name, int id)
     : name_(name), mask_id_(id) {
-  DRAKE_ASSERT(mask_id_ >= 0 && mask_id_ < MAX_NUM_COLLISION_FILTER_GROUPS);
+  DRAKE_ASSERT(mask_id_ >= 0 && mask_id_ < kMaxNumCollisionFilterGroups);
 }
 
 template <typename T>
@@ -40,7 +37,7 @@ template <typename T>
 void CollisionFilterGroupManager<T>::CompileGroups() {
   for (auto& pair : collision_filter_groups_) {
     CollisionFilterGroup<T>& group = pair.second;
-    bitmask group_mask = DEFAULT_GROUP, ignore_mask = NONE_MASK;
+    bitmask group_mask = kDefaultGroup, ignore_mask = kNoneMask;
     group_mask.set(group.get_mask_id());
     for (const auto& ignore_name : group.get_ignore_groups()) {
       const auto& itr = collision_filter_groups_.find(ignore_name);
@@ -106,7 +103,7 @@ const bitmask& CollisionFilterGroupManager<T>::get_group_mask(
   if (itr != body_groups_.end()) {
     return itr->second.first;
   }
-  return NONE_MASK;
+  return kNoneMask;
 }
 
 template <typename T>
@@ -116,7 +113,7 @@ const bitmask& CollisionFilterGroupManager<T>::get_ignore_mask(
   if (itr != body_groups_.end()) {
     return itr->second.second;
   }
-  return NONE_MASK;
+  return kNoneMask;
 }
 
 template <typename T>
@@ -133,11 +130,11 @@ void CollisionFilterGroupManager<T>::Clear() {
 
 template <typename T>
 int CollisionFilterGroupManager<T>::acquire_next_group_id() {
-  if (next_id_ >= MAX_NUM_COLLISION_FILTER_GROUPS) {
+  if (next_id_ >= kMaxNumCollisionFilterGroups) {
     throw std::runtime_error(
         "Requesting a collision filter group id when"
         " there are no more available. Drake only supports " +
-        std::to_string(MAX_NUM_COLLISION_FILTER_GROUPS) +
+        std::to_string(kMaxNumCollisionFilterGroups) +
         " collision filter groups per RigidBodyTree instance.");
   }
   return next_id_++;

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -117,6 +117,12 @@ bitmask CollisionFilterGroupManager<T>::get_ignore_mask(
 }
 
 template <typename T>
+void CollisionFilterGroupManager<T>::SetBodyCollisionFilters(
+    const RigidBody<T>& body, const bitmask& group, const bitmask& ignores) {
+  body_groups_[&body] = std::make_pair(group, ignores);
+}
+
+template <typename T>
 void CollisionFilterGroupManager<T>::Clear() {
   collision_filter_groups_.clear();
   body_groups_.clear();

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -62,7 +62,7 @@ void CollisionFilterGroupManager<T>::CompileGroups() {
 
 template <typename T>
 bool CollisionFilterGroupManager<T>::AddCollisionFilterGroupMember(
-    const std::string& group_name, RigidBody<T>* body) {
+    const std::string& group_name, const RigidBody<T>& body) {
   auto itr = collision_filter_groups_.find(group_name);
   if (itr == collision_filter_groups_.end()) {
     return false;

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -17,8 +17,12 @@ namespace DrakeCollision {
 typedef std::bitset<MAX_NUM_COLLISION_FILTER_GROUPS> bitmask;
 
 // Constants
-extern const bitmask ALL_MASK;
+// The empty bit mask.  Used in the membership group mask represents no
+// membership.  As the ignore mask, the body ignores nothing.
 extern const bitmask NONE_MASK;
+// The membership bit mask indicating the CFG to which *all* bodies belong. A
+// body can be made invisible (from a collision perspective) by having setting
+// its ignore mask to DEFAULT_GROUP.
 extern const bitmask DEFAULT_GROUP;
 
 /**
@@ -200,8 +204,9 @@ class CollisionFilterGroupManager {
   // if this manager is out of ids.
   int acquire_next_group_id();
 
-  // The next available collision filter group identifier.
-  int next_id_{0};
+  // The next available collision filter group identifier.  Assumes that 0
+  // is the default group (which is implicitly consumed.)
+  int next_id_{1};
 
   // Map between group names and specification of its collision filter group.
   std::unordered_map<std::string, DrakeCollision::CollisionFilterGroup<T>>

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -104,8 +104,8 @@ class CollisionFilterGroup {
  instance.
 
  The manager is used in parsing *sessions*.  By design, one session maps to
- parsing a single file.  The session ends with a call to Clear (called in
- RigidBodyTree::compile).  Multiple sessions can be run on a single manager
+ parsing a single file.  The session ends with a call to Clear() (called in
+ RigidBodyTree::compile()).  Multiple sessions can be run on a single manager
  (this naturally arises from parsing multiple files).  Collision filter groups
  defined during a single session must all have unique group *names*. Names
  repeated in different sessions are treated as being *different* collision
@@ -113,7 +113,7 @@ class CollisionFilterGroup {
  During compilation, the names are replaced with integer identifiers.
 
  The group manager can handle a finite number of groups
- (MAX_NUM_COLLISION_FILTER_GROUPS).  Each session contributes towards reaching
+ (kMaxNumCollisionFilterGroups).  Each session contributes towards reaching
  that total.  If the maximum number of groups has been defined, subsequent
  efforts to define a new collision filter group will cause exceptions to be
  thrown.
@@ -187,7 +187,7 @@ class CollisionFilterGroupManager {
   /**
    Reports the collision filter group assigned to the given group name.
    @param group_name    The group name to query.
-   @returns the assigned group name (-1 if in valid group name).
+   @returns the assigned group id (kInvalidGroupId if an valid group name).
    */
   int GetGroupId(const std::string& group_name);
 
@@ -209,7 +209,7 @@ class CollisionFilterGroupManager {
   // removed.  There is a corresponding method on the RigidBodyTree.
   /**
    Directly set the masks for a body.  The values will remain in the current
-   session (i.e., until Clear is called). This is a convenience function for
+   session (i.e., until Clear() is called). This is a convenience function for
    Matlab integration.  The Matlab parser handles the mapping of collision
    filter group names to ids and passes the mapped ids directly the manager for
    when the tree gets compiled. The input bitmasks are in no way validated.
@@ -222,9 +222,20 @@ class CollisionFilterGroupManager {
   /**
    Clears the cached collision filter group specification data from the current
    session.  It does *not* reset the counter for available collision filter
-   groups.
+   groups. This is what makes it possible for a file to be read multiple times
+   in sequence, but to have each parsing produce a unique set of collision
+   filter groups.  Or if two files are parsed, and both use a common name for a
+   collision filter group. They are treated as unique collision filter groups
+   and all of those groups count against the *total* number of groups supported
+   by a single instance of the manager.
    */
   void Clear();
+
+  /**
+   Reported value for group names that do not map to known collision filter
+   groups.
+   */
+  static const int kInvalidGroupId;
 
  private:
   // Attempts to provision a group id for the next group.  Throws an exception

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <bitset>
+
+static const int MAX_NUM_COLLISION_FILTER_GROUPS = 128;
+
+namespace DrakeCollision {
+
+typedef std::bitset<MAX_NUM_COLLISION_FILTER_GROUPS> bitmask;
+
+// Constants
+extern const bitmask ALL_MASK;
+extern const bitmask NONE_MASK;
+extern const bitmask DEFAULT_GROUP;
+}  // namespace DrakeCollision

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -38,11 +38,11 @@ constexpr bitmask kDefaultGroup(1);
 
  Given the following definitions:
 
-   - @f$G(A) \triangleq \{g^A_0, g^A_1, ..., g^A_n\}@f$ is the set of all groups
+   - @f$G(A) ≜ \{g^A_0, g^A_1, ..., g^A_n\}@f$ is the set of all groups
      to which @f$A@f$ belongs,
-   - @f$I(f) \triangleq \{g^f_0, g^f_1, ..., g^f_m\}@f$ is the set set of all
+   - @f$I(f) ≜ \{g^f_0, g^f_1, ..., g^f_m\}@f$ is the set set of all
      groups that group @f$f@f$ ignores,
-   - @f$I(A) \triangleq \{I(g^A_0) \cap I(g^A_1) \cap ... \cap I(g^A_n)\}@f$
+   - @f$I(A) ≜ \{I(g^A_0) \cap I(g^A_1) \cap ... \cap I(g^A_n)\}@f$
      such that @f$g^A_i \in G(A)@f$ is the set of all groups that @f$A@f$
      ignores.
 

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -50,9 +50,9 @@ class CollisionFilterGroup {
 
   int get_mask_id() const { return mask_id_; }
 
-  void add_body(RigidBody<T>* body) { bodies_.push_back(body); }
+  void add_body(const RigidBody<T>& body) { bodies_.push_back(&body); }
 
-  std::vector<RigidBody<T>*> get_bodies() { return bodies_; }
+  std::vector<const RigidBody<T>*> get_bodies() { return bodies_; }
 
   const std::vector<std::string>& get_ignore_groups() const {
     return ignore_groups_;
@@ -66,7 +66,7 @@ class CollisionFilterGroup {
   std::string name_{};
   int model_id_{};
   int mask_id_{};
-  std::vector<RigidBody<T>*> bodies_{};
+  std::vector<const RigidBody<T>*> bodies_{};
   std::vector<std::string> ignore_groups_{};
 };
 
@@ -106,7 +106,7 @@ class CollisionFilterGroupManager {
    @returns False if the group could not be found.
    */
   bool AddCollisionFilterGroupMember(const std::string& group_name,
-                                     RigidBody<T>* body);
+                                     const RigidBody<T>& body);
 
   /**
    Adds a collision group to the set of groups ignored by the specified

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -1,8 +1,13 @@
 #pragma once
 
 #include <bitset>
+#include <vector>
 
 static const int MAX_NUM_COLLISION_FILTER_GROUPS = 128;
+
+
+// forward declaration
+template <typename U> class RigidBody;
 
 namespace DrakeCollision {
 
@@ -12,4 +17,43 @@ typedef std::bitset<MAX_NUM_COLLISION_FILTER_GROUPS> bitmask;
 extern const bitmask ALL_MASK;
 extern const bitmask NONE_MASK;
 extern const bitmask DEFAULT_GROUP;
+
+/**
+ The specification of a collision filter group: its name, bodies that belong
+ to it, and the names of collision filter groups that it ignores.  This
+ class is used for initialization and not run-time calculations.
+
+ By definition, a collision filter group can only apply to bodies within a
+ single model instance.  This class tracks the identifier of the model it
+ works with.
+ */
+template <typename T>
+class CollisionFilterGroup {
+ public:
+  /**
+   Default constructor for use with unordered_map.
+   */
+  CollisionFilterGroup();
+
+  /**
+   @param name          The name for the collision filter group.
+   @param model_id      The identifier of the model with which this group is
+                        associated.
+   */
+  CollisionFilterGroup(const std::string& name, int model_id);
+
+  int get_model_id() const { return model_id_; }
+
+  void add_body(RigidBody<T>* body) { bodies_.push_back(body); }
+
+  void add_ignore_group(const std::string& group_name) {
+    ignore_groups_.push_back(group_name);
+  }
+
+ private:
+  std::string name_{};
+  int model_id_{};
+  std::vector<RigidBody<T>*> bodies_{};
+  std::vector<std::string> ignore_groups_{};
+};
 }  // namespace DrakeCollision

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -74,12 +74,13 @@ class CollisionFilterGroupManager {
 
   /**
    Attempts to define a new collision filter group.  The given name *must*
-   be unique.  Duplicate names will lead to failure.
+   be unique.  Duplicate names or attempting to add more
+   collision filter groups than the system can handle will lead to failure. In
+   the event of failure, an exception is thrown.
    @param name        The unique name of the new group.
    @param model_id    The model instance id to associate with this group.
-   @returns           True to indicate successful addition.
    */
-  bool DefineCollisionFilterGroup(const std::string& name, int model_id);
+  void DefineCollisionFilterGroup(const std::string& name, int model_id);
 
   /**
    Adds a RigidBody to a collision filter group.  The process will fail if the

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -174,6 +174,19 @@ class CollisionFilterGroupManager {
    */
   bitmask get_ignore_mask(const RigidBody<T>& body);
 
+  // TODO(SeanCurtis-TRI): Kill this method when matlab dependencies are
+  // removed.  There is a corresponding method on the RigidBodyTree.
+  /**
+   Directly set the masks for a body.  The values will remain in the current
+   session (i.e., until Clear is called).
+   This is a convenience function for Matlab integration.  The Matlab parser
+   handles the mapping of collision filter group names to ids and passes the
+   mapped ids directly the manager for when the tree gets compiled.  It relies
+   on correct encoding of groups into bitmasks.
+   */
+  void SetBodyCollisionFilters(const RigidBody<T>& body, const bitmask& group,
+                               const bitmask& ignores);
+
   /**
    Clears the cached collision filter group specification data.  It does *not*
    reset the counter for available collision filter groups.  This allows the

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-static const int MAX_NUM_COLLISION_FILTER_GROUPS = 128;
+constexpr int kMaxNumCollisionFilterGroups = 128;
 
 // forward declaration
 template <typename U>
@@ -14,21 +14,44 @@ class RigidBody;
 
 namespace DrakeCollision {
 
-typedef std::bitset<MAX_NUM_COLLISION_FILTER_GROUPS> bitmask;
+typedef std::bitset<kMaxNumCollisionFilterGroups> bitmask;
 
 // Constants
 // The empty bit mask.  Used in the membership group mask represents no
 // membership.  As the ignore mask, the body ignores nothing.
-extern const bitmask NONE_MASK;
+constexpr bitmask kNoneMask(0);
 // The membership bit mask indicating the CFG to which *all* bodies belong. A
 // body can be made invisible (from a collision perspective) by having setting
-// its ignore mask to DEFAULT_GROUP.
-extern const bitmask DEFAULT_GROUP;
+// its ignore mask to kDefaultGroup.
+constexpr bitmask kDefaultGroup(1);
 
 /**
  The specification of a collision filter group: its name, bodies that belong
  to it, and the names of collision filter groups that it ignores.  This
  class is used for initialization and not run-time calculations.
+
+ A collision filter group is a mechanism for cheaply culling pairs of collision
+ elements from consideration during collision detection. One collision filter
+ group associates a set of bodies with a set of *ignored* collision filter
+ groups.  At runtime, when a pair of bodies @f$(A, B)@f$ are determined to be a
+ collision candidate, their collision filter group membership is examined.
+
+ Given the following definitions:
+
+   - @f$G(A) \triangleq \{g^A_0, g^A_1, ..., g^A_n\}@f$ is the set of all groups
+     to which @f$A@f$ belongs,
+   - @f$I(f) \triangleq \{g^f_0, g^f_1, ..., g^f_m\}@f$ is the set set of all
+     groups that group @f$f@f$ ignores,
+   - @f$I(A) \triangleq \{I(g^A_0) \cap I(g^A_1) \cap ... \cap I(g^A_n)\}@f$
+     such that @f$g^A_i \in G(A)@f$ is the set of all groups that @f$A@f$
+     ignores.
+
+ Then, the pair @f$(A, B)@f$ will be filtered if:
+
+    @f$I(A) \cap G(B) \ne \emptyset \lor I(B) \cap G(A) \ne \emptyset@f$.
+
+ In other words, if either body belongs to a group which is ignored by *any*
+ group the other body belongs to.
 
  @tparam  T  A valid Eigen scalar type.
  */

--- a/drake/multibody/collision/drake_collision.cc
+++ b/drake/multibody/collision/drake_collision.cc
@@ -1,4 +1,5 @@
 #include "drake/multibody/collision/drake_collision.h"
+#include "drake/multibody/collision/collision_filter.h"
 
 #ifdef BULLET_COLLISION
 #include "drake/multibody/collision/bullet_model.h"

--- a/drake/multibody/collision/drake_collision.cc
+++ b/drake/multibody/collision/drake_collision.cc
@@ -13,7 +13,7 @@ namespace DrakeCollision {
 
 const bitmask ALL_MASK(bitmask(0).set());
 const bitmask NONE_MASK(0);
-const bitmask DEFAULT_GROUP(1);
+const bitmask DEFAULT_GROUP(0);
 
 unique_ptr<Model> newModel() {
 #ifdef BULLET_COLLISION

--- a/drake/multibody/collision/drake_collision.cc
+++ b/drake/multibody/collision/drake_collision.cc
@@ -11,10 +11,6 @@ using std::unique_ptr;
 
 namespace DrakeCollision {
 
-const bitmask ALL_MASK(bitmask(0).set());
-const bitmask NONE_MASK(0);
-const bitmask DEFAULT_GROUP(0);
-
 unique_ptr<Model> newModel() {
 #ifdef BULLET_COLLISION
   return unique_ptr<Model>(new BulletModel());

--- a/drake/multibody/collision/drake_collision.h
+++ b/drake/multibody/collision/drake_collision.h
@@ -1,21 +1,9 @@
 #pragma once
 
-#include <bitset>
 #include <memory>
 
 #include "drake/multibody/collision/model.h"
 
-static const int MAX_NUM_COLLISION_FILTER_GROUPS = 128;
-
 namespace DrakeCollision {
-
 std::unique_ptr<Model> newModel();
-
-typedef std::bitset<MAX_NUM_COLLISION_FILTER_GROUPS> bitmask;
-
-// Constants
-extern const bitmask ALL_MASK;
-extern const bitmask NONE_MASK;
-extern const bitmask DEFAULT_GROUP;
-
 }  // namespace DrakeCollision

--- a/drake/multibody/collision/element.cc
+++ b/drake/multibody/collision/element.cc
@@ -100,18 +100,9 @@ const std::vector<int>& Element::collision_cliques() const {
   return collision_cliques_;
 }
 
-void Element::setCollisionFilter(const DrakeCollision::bitmask& group,
-                                 const DrakeCollision::bitmask& ignores) {
-  setCollisionFilterGroup(group);
-  setCollisionFilterIgnores(ignores);
-}
-
-void Element::setCollisionFilterGroup(const DrakeCollision::bitmask& group) {
+void Element::set_collision_filter(const DrakeCollision::bitmask &group,
+                                   const DrakeCollision::bitmask &ignores) {
   collision_filter_group_ = group;
-}
-
-void Element::setCollisionFilterIgnores(
-    const DrakeCollision::bitmask& ignores) {
   collision_filter_ignores_ = ignores;
 }
 

--- a/drake/multibody/collision/element.cc
+++ b/drake/multibody/collision/element.cc
@@ -11,34 +11,26 @@ using std::ostream;
 namespace DrakeCollision {
 
 Element::Element()
-    : DrakeShapes::Element(Eigen::Isometry3d::Identity()), body_(nullptr),
-      collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
-      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
+    : DrakeShapes::Element(Eigen::Isometry3d::Identity()), body_(nullptr) {
   id = (ElementId) this;
 }
 
 Element::Element(const DrakeShapes::Geometry& geometry,
                  const Isometry3d& T_element_to_local)
-    : DrakeShapes::Element(geometry, T_element_to_local), body_(nullptr),
-      collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
-      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
+    : DrakeShapes::Element(geometry, T_element_to_local), body_(nullptr) {
   id = (ElementId) this;
 }
 
 Element::Element(const Isometry3d& T_element_to_link,
                  const RigidBody<double>* body)
-    : DrakeShapes::Element(T_element_to_link), body_(body),
-      collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
-      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
+    : DrakeShapes::Element(T_element_to_link), body_(body) {
   id = (ElementId) this;
 }
 
 Element::Element(const DrakeShapes::Geometry& geometry,
                  const Isometry3d& T_element_to_link,
                  const RigidBody<double>* body)
-    : DrakeShapes::Element(geometry, T_element_to_link), body_(body),
-      collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
-      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
+    : DrakeShapes::Element(geometry, T_element_to_link), body_(body) {
   id = (ElementId) this;
 }
 

--- a/drake/multibody/collision/element.cc
+++ b/drake/multibody/collision/element.cc
@@ -11,26 +11,34 @@ using std::ostream;
 namespace DrakeCollision {
 
 Element::Element()
-    : DrakeShapes::Element(Eigen::Isometry3d::Identity()), body_(nullptr) {
+    : DrakeShapes::Element(Eigen::Isometry3d::Identity()), body_(nullptr),
+      collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
+      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
   id = (ElementId) this;
 }
 
 Element::Element(const DrakeShapes::Geometry& geometry,
                  const Isometry3d& T_element_to_local)
-    : DrakeShapes::Element(geometry, T_element_to_local), body_(nullptr) {
+    : DrakeShapes::Element(geometry, T_element_to_local), body_(nullptr),
+      collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
+      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
   id = (ElementId) this;
 }
 
 Element::Element(const Isometry3d& T_element_to_link,
                  const RigidBody<double>* body)
-    : DrakeShapes::Element(T_element_to_link), body_(body) {
+    : DrakeShapes::Element(T_element_to_link), body_(body),
+      collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
+      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
   id = (ElementId) this;
 }
 
 Element::Element(const DrakeShapes::Geometry& geometry,
                  const Isometry3d& T_element_to_link,
                  const RigidBody<double>* body)
-    : DrakeShapes::Element(geometry, T_element_to_link), body_(body) {
+    : DrakeShapes::Element(geometry, T_element_to_link), body_(body),
+      collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
+      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
   id = (ElementId) this;
 }
 
@@ -42,7 +50,9 @@ Element::Element(const Element& other)
       id(reinterpret_cast<ElementId>(this)),
       is_anchored_(other.is_anchored_),
       body_(other.body_),
-      collision_cliques_(other.collision_cliques_) {}
+      collision_cliques_(other.collision_cliques_),
+      collision_filter_group_(other.collision_filter_group_),
+      collision_filter_ignores_(other.collision_filter_ignores_) {}
 
 Element* Element::clone() const { return new Element(*this); }
 
@@ -52,11 +62,21 @@ const RigidBody<double>* Element::get_body() const { return body_; }
 
 void Element::set_body(const RigidBody<double> *body) { body_ = body; }
 
-bool Element::CanCollideWith(const Element *other) const {
-  // If collision_cliques_.size() = N and other->collision_cliques_.size() = M
-  // The worst case (overlapping elements without intersection) is O(N+M).
-  return !SortedVectorsHaveIntersection(collision_cliques_,
-                                        other->collision_cliques_);
+bool Element::CanCollideWith(const Element* other) const {
+  // Determines if the elements filter each other via filter *groups*. The
+  // pair is *excluded* from consideration if this element's group is ignored
+  // by the other, or the other's group is ignored by this element.
+  bool excluded =
+      (collision_filter_group_ & other->collision_filter_ignores_).any() ||
+      (other->collision_filter_group_ & collision_filter_ignores_).any();
+  if (!excluded) {
+    // Group filtering didn't exclude the pair, try cliques.
+    // If collision_cliques_.size() = N and other->collision_cliques_.size() = M
+    // The worst case (overlapping elements without intersection) is O(N+M).
+    return !SortedVectorsHaveIntersection(collision_cliques_,
+                                          other->collision_cliques_);
+  }
+  return false;
 }
 
 void Element::AddToCollisionClique(int clique_id) {
@@ -78,6 +98,21 @@ int Element::get_num_cliques() const {
 
 const std::vector<int>& Element::collision_cliques() const {
   return collision_cliques_;
+}
+
+void Element::setCollisionFilter(const DrakeCollision::bitmask& group,
+                                 const DrakeCollision::bitmask& ignores) {
+  setCollisionFilterGroup(group);
+  setCollisionFilterIgnores(ignores);
+}
+
+void Element::setCollisionFilterGroup(const DrakeCollision::bitmask& group) {
+  collision_filter_group_ = group;
+}
+
+void Element::setCollisionFilterIgnores(
+    const DrakeCollision::bitmask& ignores) {
+  collision_filter_ignores_ = ignores;
 }
 
 ostream& operator<<(ostream& out, const Element& ee) {

--- a/drake/multibody/collision/element.h
+++ b/drake/multibody/collision/element.h
@@ -7,6 +7,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/multibody/collision/collision_filter.h"
 #include "drake/multibody/shapes/drake_shapes.h"
 
 // Forward declaration.
@@ -129,6 +130,16 @@ class Element : public DrakeShapes::Element {
   /** Sets the `RigidBody` this collision element is attached to. **/
   void set_body(const RigidBody<double> *body);
 
+  /** Sets the collision filter state of the element. */
+  void setCollisionFilter(const DrakeCollision::bitmask& group,
+                          const DrakeCollision::bitmask& ignores);
+
+  /** Sets the groups that this element belongs to. */
+  void setCollisionFilterGroup(const DrakeCollision::bitmask& group);
+
+  /** Sets the groups that this element ignores. */
+  void setCollisionFilterIgnores(const DrakeCollision::bitmask& ignores);
+
   /**
    * A toString method for this class.
    */
@@ -160,6 +171,16 @@ class Element : public DrakeShapes::Element {
   // requires the entries in CollisionElement::collision_cliques_ to be sorted.
   // By arbitrary convention, the ordering is monotonically increasing.
   std::vector<int> collision_cliques_;
+
+  // A bitmask that determines the collision groups that this rigid body is part
+  // of. If the i-th bit is set this rigid body belongs to the i-th collision
+  // group. A rigid body can belong to several collision groups.
+  DrakeCollision::bitmask collision_filter_group_;
+
+  // A bitmask that determines which collision groups this rigid body does not
+  // collide with. Thus, if the i-th bit is set this rigid body is not checked
+  // for collisions with bodies in the i-th group.
+  DrakeCollision::bitmask collision_filter_ignores_;
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/multibody/collision/element.h
+++ b/drake/multibody/collision/element.h
@@ -132,8 +132,16 @@ class Element : public DrakeShapes::Element {
 
   /** Sets the collision filter state of the element: the groups to which this
    * element belongs and the groups that it should ignore. */
-  void set_collision_filter(const DrakeCollision::bitmask &group,
-                            const DrakeCollision::bitmask &ignores);
+  void set_collision_filter(const bitmask &group,
+                            const bitmask &ignores);
+
+  const bitmask& get_collision_filter_group() const {
+    return collision_filter_group_;
+  }
+
+  const bitmask& get_collision_filter_ignores() const {
+    return collision_filter_ignores_;
+  }
 
   /**
    * A toString method for this class.

--- a/drake/multibody/collision/element.h
+++ b/drake/multibody/collision/element.h
@@ -180,12 +180,12 @@ class Element : public DrakeShapes::Element {
   // A bitmask that determines the collision groups that this element is part
   // of. If the i-th bit is set this rigid body belongs to the i-th collision
   // group. An element can belong to multiple collision groups.
-  DrakeCollision::bitmask collision_filter_group_{DEFAULT_GROUP};
+  DrakeCollision::bitmask collision_filter_group_{kDefaultGroup};
 
   // A bitmask that determines which collision groups this element can *not*
   // collide with. Thus, if the i-th bit is set this element is not checked
   // for collisions with elements in the i-th group.
-  DrakeCollision::bitmask collision_filter_ignores_{NONE_MASK};
+  DrakeCollision::bitmask collision_filter_ignores_{kNoneMask};
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/multibody/collision/element.h
+++ b/drake/multibody/collision/element.h
@@ -130,15 +130,10 @@ class Element : public DrakeShapes::Element {
   /** Sets the `RigidBody` this collision element is attached to. **/
   void set_body(const RigidBody<double> *body);
 
-  /** Sets the collision filter state of the element. */
-  void setCollisionFilter(const DrakeCollision::bitmask& group,
-                          const DrakeCollision::bitmask& ignores);
-
-  /** Sets the groups that this element belongs to. */
-  void setCollisionFilterGroup(const DrakeCollision::bitmask& group);
-
-  /** Sets the groups that this element ignores. */
-  void setCollisionFilterIgnores(const DrakeCollision::bitmask& ignores);
+  /** Sets the collision filter state of the element: the groups to which this
+   * element belongs and the groups that it should ignore. */
+  void set_collision_filter(const DrakeCollision::bitmask &group,
+                            const DrakeCollision::bitmask &ignores);
 
   /**
    * A toString method for this class.

--- a/drake/multibody/collision/element.h
+++ b/drake/multibody/collision/element.h
@@ -124,14 +124,16 @@ class Element : public DrakeShapes::Element {
   const std::vector<int>& collision_cliques() const;
 
   /** Returns a pointer to the `RigidBody` to which this `Element`
-  is attached. **/
+   *  is attached.
+   */
   const RigidBody<double>* get_body() const;
 
-  /** Sets the `RigidBody` this collision element is attached to. **/
+  /** Sets the `RigidBody` this collision element is attached to. */
   void set_body(const RigidBody<double> *body);
 
   /** Sets the collision filter state of the element: the groups to which this
-   * element belongs and the groups that it should ignore. */
+   * element belongs and the groups that it should ignore.
+   */
   void set_collision_filter(const bitmask &group,
                             const bitmask &ignores);
 
@@ -175,15 +177,15 @@ class Element : public DrakeShapes::Element {
   // By arbitrary convention, the ordering is monotonically increasing.
   std::vector<int> collision_cliques_;
 
-  // A bitmask that determines the collision groups that this rigid body is part
+  // A bitmask that determines the collision groups that this element is part
   // of. If the i-th bit is set this rigid body belongs to the i-th collision
-  // group. A rigid body can belong to several collision groups.
-  DrakeCollision::bitmask collision_filter_group_;
+  // group. An element can belong to multiple collision groups.
+  DrakeCollision::bitmask collision_filter_group_{DEFAULT_GROUP};
 
-  // A bitmask that determines which collision groups this rigid body does not
-  // collide with. Thus, if the i-th bit is set this rigid body is not checked
-  // for collisions with bodies in the i-th group.
-  DrakeCollision::bitmask collision_filter_ignores_;
+  // A bitmask that determines which collision groups this element can *not*
+  // collide with. Thus, if the i-th bit is set this element is not checked
+  // for collisions with elements in the i-th group.
+  DrakeCollision::bitmask collision_filter_ignores_{NONE_MASK};
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/drake/multibody/collision/test/CMakeLists.txt
+++ b/drake/multibody/collision/test/CMakeLists.txt
@@ -1,6 +1,13 @@
 if(Bullet_FOUND)
   drake_add_cc_test(model_test)
   target_link_libraries(model_test drakeCollision)
+
+  drake_add_cc_test(collision_filter_group_test)
+  target_link_libraries(collision_filter_group_test
+      drakeCollision
+      drakeMultibodyParsers
+      drakeRBM
+      )
 endif()
 
 if(ccd_FOUND AND fcl_FOUND AND octomap_FOUND)

--- a/drake/multibody/collision/test/collision_filter_group_test.cc
+++ b/drake/multibody/collision/test/collision_filter_group_test.cc
@@ -1,0 +1,297 @@
+#include "drake/multibody/collision/collision_filter.h"
+
+#include "drake/multibody/rigid_body.h"
+
+#include "gtest/gtest.h"
+
+// This tests the implementation of the `collision_filter_group` information
+// contained in a URDF file.  The full implementation spans multiple drake
+// libraries.  These tests seek to validate all aspects of the collision
+// filter group functionality: from the underlying data structures, its
+// interaction with the RigidBodyTree and with parsing.
+namespace DrakeCollision {
+namespace test {
+namespace  {
+
+// Confirms that adding two groups with the same name causes a *meaningful*
+// message to be thrown.
+GTEST_TEST(CollisionFilterGroupDefinition, DuplicateGroupNames) {
+  CollisionFilterGroupManager<double> manager;
+  const std::string group_name = "group1";
+  manager.DefineCollisionFilterGroup(group_name);
+  try {
+    manager.DefineCollisionFilterGroup(group_name);
+    GTEST_FAIL();
+  } catch (std::runtime_error& e) {
+    std::string expected_msg = "Attempting to create duplicate collision "
+        "filter group: " + group_name;
+    EXPECT_EQ(e.what(), expected_msg);
+  }
+}
+
+// Confirms that the group ids assigned to the group start at 0 and increase
+// by 1 and are assigned in the order the groups are "defined".
+GTEST_TEST(CollisionFilterGroupDefinition, CollisionGroupAssignment) {
+  CollisionFilterGroupManager<double> manager;
+  const int group_count = 10;
+  for (int i = 0; i < group_count; ++i) {
+    std::string group_name = "group" + std::to_string(i);
+    manager.DefineCollisionFilterGroup(group_name);
+  }
+
+  for (int i = 0; i < group_count; ++i) {
+    std::string group_name = "group" + std::to_string(i);
+    EXPECT_EQ(manager.GetGroupId(group_name), i);
+  }
+}
+
+// Confirms that the attempt to create more than the maximum allowable
+// number of collision filter groups throws an exception with a meaningful
+// message.
+GTEST_TEST(CollisionFilterGroupDefinition, CollisionGroupOverflow) {
+  CollisionFilterGroupManager<double> manager;
+  for (int i = 0; i < MAX_NUM_COLLISION_FILTER_GROUPS; ++i) {
+    std::string group_name = "group" + std::to_string(i);
+    manager.DefineCollisionFilterGroup(group_name);
+  }
+  try {
+    manager.DefineCollisionFilterGroup("bad_group");
+    GTEST_FAIL();
+  } catch (std::runtime_error& e) {
+    std::string expected_msg = "Requesting a collision filter group id when"
+        " there are no more available. Drake only supports " +
+        std::to_string(MAX_NUM_COLLISION_FILTER_GROUPS) +
+        " collision filter groups per RigidBodyTree instance.";
+    EXPECT_EQ(e.what(), expected_msg);
+  }
+}
+
+// The same group can be added to a collision group's ignore list multiple
+// times.  Although this is undesirable behavior, it is not *bad*.  It has
+// the same result as only adding a single.  This test confirms that there
+// is no error during the definition process.
+GTEST_TEST(CollisionFilterGroupDefinition, RepeatIgnoreName) {
+  CollisionFilterGroupManager<double> manager;
+  std::string group_name = "group1";
+  manager.DefineCollisionFilterGroup(group_name);
+  manager.AddCollisionFilterIgnoreTarget(group_name, group_name);
+  manager.AddCollisionFilterIgnoreTarget(group_name, group_name);
+  // Note: no exception thrown implies success.
+}
+
+// The same body can be added to a collision group multiple times.  Although
+// this is undesirable behavior, it is not *bad*.  It has
+// the same result as only adding a single.  This test confirms that there
+// is no error during the definition process.
+GTEST_TEST(CollisionFilterGroupDefinition, RepeatAddBody) {
+  CollisionFilterGroupManager<double> manager;
+  std::string group_name = "group1";
+  manager.DefineCollisionFilterGroup(group_name);
+  RigidBody<double> body;
+  manager.AddCollisionFilterGroupMember(group_name, body);
+  manager.AddCollisionFilterGroupMember(group_name, body);
+  // Note: no exception thrown implies success.
+}
+
+// Confirms that adding an ignore group to a non-existant group throws a
+// meaningful exception.
+GTEST_TEST(CollisionFilterGroupDefinition, AddIgnoreGroupToUndefinedGroup) {
+  CollisionFilterGroupManager<double> manager;
+  std::string group_name = "group1";
+  try {
+    manager.AddCollisionFilterIgnoreTarget(group_name, group_name);
+  } catch (std::runtime_error& e) {
+    std::string expected_msg =
+        "Attempting to add an ignored collision filter group to an undefined "
+            "collision filter group: Ignoring " +
+            group_name + " by " + group_name + ".";
+    EXPECT_EQ(e.what(), expected_msg);
+  }
+}
+
+// Confirms that adding a RigidBody to a non-existant group reports failure.
+GTEST_TEST(CollisionFilterGroupDefinition, AddBodyToUndefinedGroup) {
+  CollisionFilterGroupManager<double> manager;
+  std::string group_name = "group1";
+  RigidBody<double> body;
+  bool result = manager.AddCollisionFilterGroupMember(group_name, body);
+  EXPECT_FALSE(result);
+}
+
+//---------------------------------------------------------------------------
+
+// Tests correct bit mask for a body belonging to a single group.
+GTEST_TEST(CollisionFilterGroupCompile, SingleGroupMembership) {
+  CollisionFilterGroupManager<double> manager;
+  const std::string group_name = "group1";
+  manager.DefineCollisionFilterGroup(group_name);
+  RigidBody<double> body;
+  manager.AddCollisionFilterGroupMember(group_name, body);
+  manager.CompileGroups();
+  bitmask expected_group;
+  // First group added should be group: 0.  See CollisionGroupAssignment test.
+  int expected_id = 0;
+  expected_group.set(expected_id);
+  EXPECT_EQ(manager.get_group_mask(body), expected_group);
+}
+
+// Tests correct bit mask for a body belonging to multiple groups.
+GTEST_TEST(CollisionFilterGroupCompile, MultiGroupMembership) {
+  CollisionFilterGroupManager<double> manager;
+  manager.DefineCollisionFilterGroup("group0");
+  manager.DefineCollisionFilterGroup("group1");
+  manager.DefineCollisionFilterGroup("group2");
+  RigidBody<double> body;
+  manager.AddCollisionFilterGroupMember("group0", body);
+  manager.AddCollisionFilterGroupMember("group2", body);
+  manager.CompileGroups();
+  bitmask expected_group;
+  expected_group.set(0);
+  expected_group.set(2);
+  EXPECT_EQ(manager.get_group_mask(body), expected_group);
+}
+
+// Tests correct ignore bit mask for a body belonging to a single group.
+GTEST_TEST(CollisionFilterGroupCompile, SingleGroupIgnoreSet) {
+  CollisionFilterGroupManager<double> manager;
+  for (int i = 0; i < 4; ++i) {
+    manager.DefineCollisionFilterGroup("group" + std::to_string(i));
+  }
+  // group 0 ignores itself, 2, & 3
+  std::vector<int> ignores = {0, 2, 3};
+  for (auto i : ignores) {
+    manager.AddCollisionFilterIgnoreTarget("group0",
+                                           "group" + std::to_string(i));
+  }
+  RigidBody<double> body;
+  manager.AddCollisionFilterGroupMember("group0", body);
+  manager.CompileGroups();
+  bitmask expected_ignores;
+  for (auto i : ignores) {
+    expected_ignores.set(i);
+  }
+  EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
+}
+
+// Tests correct ignore bit mask for a body belonging to a multiple groups: it
+// should be the union of its groups ignores.
+GTEST_TEST(CollisionFilterGroupCompile, MultiGroupIgnoreSet) {
+  CollisionFilterGroupManager<double> manager;
+  for (int i = 0; i < 6; ++i) {
+    manager.DefineCollisionFilterGroup("group" + std::to_string(i));
+  }
+  // group 0 ignores itself, 2, & 3
+  std::set<int> ignores0 = {0, 2, 3};
+  for (auto i : ignores0) {
+    manager.AddCollisionFilterIgnoreTarget("group0",
+                                           "group" + std::to_string(i));
+  }
+  // group 1 ignores 3 & 4
+  std::set<int> ignores1 = {3, 4};
+  for (auto i : ignores1) {
+    manager.AddCollisionFilterIgnoreTarget("group1",
+                                           "group" + std::to_string(i));
+  }
+  RigidBody<double> body;
+  manager.AddCollisionFilterGroupMember("group0", body);
+  manager.AddCollisionFilterGroupMember("group1", body);
+  manager.CompileGroups();
+  std::vector<int> ignore_union;
+  std::set_union(ignores0.begin(), ignores0.end(),
+                 ignores1.begin(), ignores1.end(),
+                 std::inserter(ignore_union, ignore_union.begin()));
+  bitmask expected_ignores;
+  for (auto i : ignore_union) {
+    expected_ignores.set(i);
+  }
+  EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
+}
+
+// Tests that references to undefined groups are simply ignored.
+GTEST_TEST(CollisionFilterGroupCompile, IgnoreNonExistentGroup) {
+  CollisionFilterGroupManager<double> manager;
+  manager.DefineCollisionFilterGroup("group0");
+  // group1 does not exist.
+  manager.AddCollisionFilterIgnoreTarget("group0", "group1");
+
+  RigidBody<double> body;
+  manager.AddCollisionFilterGroupMember("group0", body);
+  manager.CompileGroups();
+
+  bitmask expected_ignores = NONE_MASK;
+  EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
+}
+
+// Tests that references to redundant groups behaves the same as a single
+// reference.
+GTEST_TEST(CollisionFilterGroupCompile, IgnoreRedundantGroup) {
+  CollisionFilterGroupManager<double> manager;
+  manager.DefineCollisionFilterGroup("group0");
+  manager.DefineCollisionFilterGroup("group1");
+  // Redundantly adds group 1.
+  manager.AddCollisionFilterIgnoreTarget("group0", "group1");
+  manager.AddCollisionFilterIgnoreTarget("group0", "group1");
+
+  RigidBody<double> body;
+  manager.AddCollisionFilterGroupMember("group0", body);
+  manager.CompileGroups();
+
+  bitmask expected_ignores = NONE_MASK;
+  expected_ignores.set(1);
+  EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
+}
+
+// Tests that adding a body redundantly to a group has the same effect as adding
+// it once.
+GTEST_TEST(CollisionFilterGroupCompile, AddBodyRedundantly) {
+  CollisionFilterGroupManager<double> manager;
+  manager.DefineCollisionFilterGroup("group0");
+  manager.DefineCollisionFilterGroup("group1");
+  // Redundantly adds group 1.
+  manager.AddCollisionFilterIgnoreTarget("group0", "group1");
+
+  RigidBody<double> body;
+  manager.AddCollisionFilterGroupMember("group0", body);
+  manager.AddCollisionFilterGroupMember("group0", body);
+  manager.CompileGroups();
+
+  bitmask expected_ignores = NONE_MASK;
+  expected_ignores.set(1);
+  EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
+}
+
+// Tests that clearing the manager removes all data except the next group.
+GTEST_TEST(CollisionFilterGroupCompile, ClearFlushesData) {
+  CollisionFilterGroupManager<double> manager;
+  manager.DefineCollisionFilterGroup("group0");
+  manager.DefineCollisionFilterGroup("group1");
+  // Redundantly adds group 1.
+  manager.AddCollisionFilterIgnoreTarget("group0", "group1");
+
+  RigidBody<double> body1, body2;
+  manager.AddCollisionFilterGroupMember("group0", body1);
+  manager.AddCollisionFilterGroupMember("group0", body2);
+  manager.CompileGroups();
+
+  manager.Clear();
+  // Confirms zero membership and ignore bitmasks for both bodies.
+  EXPECT_EQ(manager.get_group_mask(body1), NONE_MASK);
+  EXPECT_EQ(manager.get_ignore_mask(body1), NONE_MASK);
+  EXPECT_EQ(manager.get_group_mask(body2), NONE_MASK);
+  EXPECT_EQ(manager.get_ignore_mask(body2), NONE_MASK);
+  // Confirms that the groups have been deleted.
+  EXPECT_EQ(manager.GetGroupId("group0"), -1);
+  EXPECT_EQ(manager.GetGroupId("group1"), -1);
+
+  // Confirms that the available group counter has continued counting.
+  manager.DefineCollisionFilterGroup("group2");
+  EXPECT_EQ(manager.GetGroupId("group2"), 2);
+}
+
+//---------------------------------------------------------------------------
+
+GTEST_TEST(CollisionFilterGroupRBT, test) {
+}
+}  // namespace
+}  // namespace test
+}  // namespace DrakeCollision

--- a/drake/multibody/collision/test/collision_filter_group_test.cc
+++ b/drake/multibody/collision/test/collision_filter_group_test.cc
@@ -415,8 +415,11 @@ GTEST_TEST(CollisionFilterGroupRBT, CollisionElementSetFilters) {
 
   // Adds collision elements.
   Element element(DrakeShapes::Sphere(1.0));
-  tree.addCollisionElement(element, *body1, "");
-  tree.addCollisionElement(element, *body2, "");
+  // This is not a *filter* group.  This is a designation used to select
+  // so-called "terrain points".  See RigidBodyTree::getTerrainContactPoints().
+  std::string collision_group = "";
+  tree.addCollisionElement(element, *body1, collision_group);
+  tree.addCollisionElement(element, *body2, collision_group);
 
   // Sets up collision filter groups.
   std::string group_name1 = "test-group1";

--- a/drake/multibody/collision/test/collision_filter_group_test.cc
+++ b/drake/multibody/collision/test/collision_filter_group_test.cc
@@ -24,7 +24,6 @@ namespace {
 using drake::parsers::urdf::AddModelInstanceFromUrdfFileToWorld;
 using Eigen::Isometry3d;
 using Eigen::VectorXd;
-using std::make_unique;
 using std::unique_ptr;
 using std::move;
 
@@ -67,7 +66,7 @@ GTEST_TEST(CollisionFilterGroupDefinition, CollisionGroupAssignment) {
 // message.
 GTEST_TEST(CollisionFilterGroupDefinition, CollisionGroupOverflow) {
   CollisionFilterGroupManager<double> manager;
-  for (int i = 1; i < MAX_NUM_COLLISION_FILTER_GROUPS; ++i) {
+  for (int i = 1; i < kMaxNumCollisionFilterGroups; ++i) {
     std::string group_name = "group" + std::to_string(i);
     manager.DefineCollisionFilterGroup(group_name);
   }
@@ -78,7 +77,7 @@ GTEST_TEST(CollisionFilterGroupDefinition, CollisionGroupOverflow) {
     std::string expected_msg =
         "Requesting a collision filter group id when"
         " there are no more available. Drake only supports " +
-        std::to_string(MAX_NUM_COLLISION_FILTER_GROUPS) +
+        std::to_string(kMaxNumCollisionFilterGroups) +
         " collision filter groups per RigidBodyTree instance.";
     EXPECT_EQ(e.what(), expected_msg);
   }
@@ -233,7 +232,7 @@ GTEST_TEST(CollisionFilterGroupCompile, IgnoreNonExistentGroup) {
   manager.AddCollisionFilterGroupMember("group1", body);
   manager.CompileGroups();
 
-  bitmask expected_ignores = NONE_MASK;
+  bitmask expected_ignores = kNoneMask;
   EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
 }
 
@@ -288,10 +287,10 @@ GTEST_TEST(CollisionFilterGroupCompile, ClearFlushesData) {
 
   manager.Clear();
   // Confirms zero membership and ignore bitmasks for both bodies.
-  EXPECT_EQ(manager.get_group_mask(body1), NONE_MASK);
-  EXPECT_EQ(manager.get_ignore_mask(body1), NONE_MASK);
-  EXPECT_EQ(manager.get_group_mask(body2), NONE_MASK);
-  EXPECT_EQ(manager.get_ignore_mask(body2), NONE_MASK);
+  EXPECT_EQ(manager.get_group_mask(body1), kNoneMask);
+  EXPECT_EQ(manager.get_ignore_mask(body1), kNoneMask);
+  EXPECT_EQ(manager.get_group_mask(body2), kNoneMask);
+  EXPECT_EQ(manager.get_ignore_mask(body2), kNoneMask);
   // Confirms that the groups have been deleted.
   EXPECT_EQ(manager.GetGroupId("group1"), -1);
   EXPECT_EQ(manager.GetGroupId("group2"), -1);
@@ -311,8 +310,8 @@ GTEST_TEST(CollisionFilterGroupElement, ElementCanCollideWithTest) {
   DrakeCollision::Element e2;
 
   // Case 1: By default, elements belong to no group and ignore nothing.
-  EXPECT_EQ(e1.get_collision_filter_group(), DEFAULT_GROUP);
-  EXPECT_EQ(e1.get_collision_filter_ignores(), NONE_MASK);
+  EXPECT_EQ(e1.get_collision_filter_group(), kDefaultGroup);
+  EXPECT_EQ(e1.get_collision_filter_ignores(), kNoneMask);
 
   // Case 2: Two elements, belonging to the same group (which does *not*
   // ignore itself) are considered a viable collision pair.
@@ -429,7 +428,7 @@ GTEST_TEST(CollisionFilterGroupRBT, CollisionElementSetFilters) {
   for (auto itr = body2->collision_elements_begin();
        itr != body2->collision_elements_end(); ++itr) {
     EXPECT_EQ((*itr)->get_collision_filter_group(), expected_group2);
-    EXPECT_EQ((*itr)->get_collision_filter_ignores(), NONE_MASK);
+    EXPECT_EQ((*itr)->get_collision_filter_ignores(), kNoneMask);
   }
 }
 

--- a/drake/multibody/collision/test/collision_filter_group_test.cc
+++ b/drake/multibody/collision/test/collision_filter_group_test.cc
@@ -17,6 +17,14 @@
 // filter group functionality: from the underlying data structures, their
 // interactions with the RigidBodyTree, parsing, and in the collision detection
 // model.
+//
+// Because collision filter groups are ultimately represented with bitmasks,
+// expected mask values are initialized using binary representations of numbers.
+// For example, a bit mask that has groups 0, 1, and 4 set would equate to
+// the binary value:
+//    Value: 0b10011
+//    Group:   43210,
+// where groups are enumerated from *right* to *left*.
 namespace DrakeCollision {
 namespace test {
 namespace {
@@ -110,7 +118,7 @@ GTEST_TEST(CollisionFilterGroupDefinition, RepeatAddBody) {
   // Note: no exception thrown implies success.
 }
 
-// Confirms that adding an ignore group to a non-existant group throws a
+// Confirms that adding an ignore group to a non-existent group throws a
 // meaningful exception.
 GTEST_TEST(CollisionFilterGroupDefinition, AddIgnoreGroupToUndefinedGroup) {
   CollisionFilterGroupManager<double> manager;
@@ -126,7 +134,7 @@ GTEST_TEST(CollisionFilterGroupDefinition, AddIgnoreGroupToUndefinedGroup) {
   }
 }
 
-// Confirms that adding a RigidBody to a non-existant group reports failure.
+// Confirms that adding a RigidBody to a non-existent group reports failure.
 GTEST_TEST(CollisionFilterGroupDefinition, AddBodyToUndefinedGroup) {
   CollisionFilterGroupManager<double> manager;
   std::string group_name = "group1";
@@ -201,7 +209,7 @@ GTEST_TEST(CollisionFilterGroupCompile, MultiGroupIgnoreSet) {
                                            "group" + std::to_string(i));
   }
   // group 2 ignores 4 & 5
-  std::set<int> ignores1 = {3, 4};
+  std::set<int> ignores1 = {4, 5};
   for (auto i : ignores1) {
     manager.AddCollisionFilterIgnoreTarget("group2",
                                            "group" + std::to_string(i));
@@ -225,7 +233,7 @@ GTEST_TEST(CollisionFilterGroupCompile, MultiGroupIgnoreSet) {
 GTEST_TEST(CollisionFilterGroupCompile, IgnoreNonExistentGroup) {
   CollisionFilterGroupManager<double> manager;
   manager.DefineCollisionFilterGroup("group1");
-  // group1 does not exist.
+  // group2 does not exist.
   manager.AddCollisionFilterIgnoreTarget("group1", "group2");
 
   RigidBody<double> body;
@@ -236,7 +244,7 @@ GTEST_TEST(CollisionFilterGroupCompile, IgnoreNonExistentGroup) {
   EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
 }
 
-// Tests that references to redundant groups behaves the same as a single
+// Tests that references to redundant groups behave the same as a single
 // reference.
 GTEST_TEST(CollisionFilterGroupCompile, IgnoreRedundantGroup) {
   CollisionFilterGroupManager<double> manager;
@@ -292,8 +300,10 @@ GTEST_TEST(CollisionFilterGroupCompile, ClearFlushesData) {
   EXPECT_EQ(manager.get_group_mask(body2), kNoneMask);
   EXPECT_EQ(manager.get_ignore_mask(body2), kNoneMask);
   // Confirms that the groups have been deleted.
-  EXPECT_EQ(manager.GetGroupId("group1"), -1);
-  EXPECT_EQ(manager.GetGroupId("group2"), -1);
+  EXPECT_EQ(manager.GetGroupId("group1"),
+            CollisionFilterGroupManager<double>::kInvalidGroupId);
+  EXPECT_EQ(manager.GetGroupId("group2"),
+            CollisionFilterGroupManager<double>::kInvalidGroupId);
 
   // Confirms that the available group counter has continued counting.
   manager.DefineCollisionFilterGroup("group3");
@@ -350,7 +360,7 @@ GTEST_TEST(CollisionFilterGroupElement, ElementCanCollideWithTest) {
 // order to do so, I need to support modifications of the underlying model
 // (a la RBT::updateCollisionTransform.)
 
-// This test confirms that when a body is being added to an non-existant
+// This test confirms that when a body is being added to an non-existent
 // group through the RigidBodyTree interface, that a meaningful exception is
 // thrown.
 GTEST_TEST(CollisionFilterGroupRBT, AddBodyToUndefinedGroup) {

--- a/drake/multibody/collision/test/collision_filter_group_test.cc
+++ b/drake/multibody/collision/test/collision_filter_group_test.cc
@@ -41,7 +41,7 @@ GTEST_TEST(CollisionFilterGroupDefinition, DuplicateGroupNames) {
     std::string expected_msg =
         "Attempting to create duplicate collision "
         "filter group: " +
-        group_name;
+        group_name + ".";
     EXPECT_EQ(e.what(), expected_msg);
   }
 }
@@ -162,7 +162,7 @@ GTEST_TEST(CollisionFilterGroupCompile, MultiGroupMembership) {
   manager.AddCollisionFilterGroupMember("group1", body);
   manager.AddCollisionFilterGroupMember("group3", body);
   manager.CompileGroups();
-  bitmask expected_group( 0b1011);
+  bitmask expected_group(0b1011);
   EXPECT_EQ(manager.get_group_mask(body), expected_group);
 }
 

--- a/drake/multibody/collision/test/collision_filter_group_test.cc
+++ b/drake/multibody/collision/test/collision_filter_group_test.cc
@@ -154,7 +154,8 @@ GTEST_TEST(CollisionFilterGroupCompile, SingleGroupMembership) {
   manager.AddCollisionFilterGroupMember(group_name, body);
   manager.CompileGroups();
   // First group added should be group: 1 and 0 (default).
-  // See CollisionGroupAssignment test.
+  // See CollisionGroupAssignment test. See file documentation for explanation
+  // of binary value.
   bitmask expected_group(0b11);
   EXPECT_EQ(manager.get_group_mask(body), expected_group);
 }
@@ -169,6 +170,7 @@ GTEST_TEST(CollisionFilterGroupCompile, MultiGroupMembership) {
   manager.AddCollisionFilterGroupMember("group1", body);
   manager.AddCollisionFilterGroupMember("group3", body);
   manager.CompileGroups();
+  // See file documentation for explanation of binary value.
   bitmask expected_group(0b1011);
   EXPECT_EQ(manager.get_group_mask(body), expected_group);
 }
@@ -258,6 +260,7 @@ GTEST_TEST(CollisionFilterGroupCompile, IgnoreRedundantGroup) {
   manager.AddCollisionFilterGroupMember("group1", body);
   manager.CompileGroups();
 
+  // See file documentation for explanation of binary value.
   bitmask expected_ignores(0b100);
   EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
 }
@@ -276,6 +279,7 @@ GTEST_TEST(CollisionFilterGroupCompile, AddBodyRedundantly) {
   manager.AddCollisionFilterGroupMember("group1", body);
   manager.CompileGroups();
 
+  // See file documentation for explanation of binary value.
   bitmask expected_ignores(0b100);
   EXPECT_EQ(manager.get_ignore_mask(body), expected_ignores);
 }
@@ -427,6 +431,7 @@ GTEST_TEST(CollisionFilterGroupRBT, CollisionElementSetFilters) {
 
   tree.compile();
   // Tests the state of the collision filters.
+  // See file documentation for explanation of binary value.
   bitmask expected_group1(0b11), expected_ignore1(0b100);
   for (auto itr = body1->collision_elements_begin();
        itr != body1->collision_elements_end(); ++itr) {

--- a/drake/multibody/collision/test/collision_filter_group_test_multi_ignore.urdf
+++ b/drake/multibody/collision/test/collision_filter_group_test_multi_ignore.urdf
@@ -19,8 +19,18 @@
         centers both lie on the x-axis at a distance of 2R - d, where id is 0.1
         units (the penetration depth).
 
-        This tests the parser's ability to correctly create a group with an
-        ignore set with multiple members.
+        This tests the parser's ability to correctly create a group with a
+        member set with multiple members.
+
+        The robot *may* appear overly complex for the test.  But collision
+        cliques already exclude possible collisions between pairs (A, B) and
+        (B, C) due to their adjacency.  The collision between pair (A, C) will
+        *not* be dismissed due to cliques.  Only the collision filter groups
+        will prevent a reported collision.
+
+        There are two variants of this file to test two aspects of collision
+        filter groups.  This variant tests that a body that ignores multiple
+         *collision filter groups* will lead to the correct filtering behavior.
     -->
  <link name="body1">
    <collision>

--- a/drake/multibody/collision/test/collision_filter_group_test_multi_ignore.urdf
+++ b/drake/multibody/collision/test/collision_filter_group_test_multi_ignore.urdf
@@ -1,0 +1,88 @@
+<robot name="simple_anchored">
+    <!--
+        A chain of spheres. Each sphere's center is displaced exactly 2R
+        from its parent.  They are connected by a revolute joint centered on
+        the center of the parent sphere.
+
+        At q = 0, this has been pre-posed as:
+                     ____
+                    /    \            z  y
+                   |   B  |           | /
+                  __\____/__          |/____x
+                 /    \/    \
+                |  A  ||  C  |
+                 \____/\____/
+
+        Where the chain is A -> B -> C.  A is centered on the world origin
+
+        A and C are overlapping with a penetration depth of 0.1 units.  Their
+        centers both lie on the x-axis at a distance of 2R - d, where id is 0.1
+        units (the penetration depth).
+
+        This tests the parser's ability to correctly create a group with an
+        ignore set with multiple members.
+    -->
+ <link name="body1">
+   <collision>
+     <origin xyz="0 0 0" rpy="0 0 0"/>
+     <geometry>
+       <sphere radius="1" />
+     </geometry>
+   </collision>
+  </link>
+
+  <link name="body2">
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1" />
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="body3">
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1" />
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="fixed21" type="revolute">
+    <origin rpy="0 0 0" xyz="0.95 0 1.7599715906798041"/>
+    <axis xyz="0 1 0"/>
+    <parent link="body1"/>
+    <child link="body2"/>
+  </joint>
+
+  <joint name="fixed32" type="revolute">
+    <origin rpy="0 0 0" xyz="0.95 0 -1.7599715906798041"/>
+    <axis xyz="0 1 0"/>
+    <parent link="body2"/>
+    <child link="body3"/>
+  </joint>
+
+  <!-- The net effect of these groups is that body 1 and 3 will *not* be
+  considered colliding.  -->
+  <collision_filter_group name="group1">
+    <member link="body1"/>
+    <ignored_collision_filter_group collision_filter_group="group2"/>
+    <ignored_collision_filter_group collision_filter_group="group3"/>
+  </collision_filter_group>
+  <collision_filter_group name="group2">
+    <member link="body2"/>
+  </collision_filter_group>
+  <collision_filter_group name="group3">
+    <member link="body3"/>
+  </collision_filter_group>
+
+</robot>

--- a/drake/multibody/collision/test/collision_filter_group_test_multi_ignore.urdf
+++ b/drake/multibody/collision/test/collision_filter_group_test_multi_ignore.urdf
@@ -19,9 +19,6 @@
         centers both lie on the x-axis at a distance of 2R - d, where id is 0.1
         units (the penetration depth).
 
-        This tests the parser's ability to correctly create a group with a
-        member set with multiple members.
-
         The robot *may* appear overly complex for the test.  But collision
         cliques already exclude possible collisions between pairs (A, B) and
         (B, C) due to their adjacency.  The collision between pair (A, C) will
@@ -30,7 +27,7 @@
 
         There are two variants of this file to test two aspects of collision
         filter groups.  This variant tests that a body that ignores multiple
-         *collision filter groups* will lead to the correct filtering behavior.
+        *collision filter groups* will lead to the correct filtering behavior.
     -->
  <link name="body1">
    <collision>

--- a/drake/multibody/collision/test/collision_filter_group_test_multi_member.urdf
+++ b/drake/multibody/collision/test/collision_filter_group_test_multi_member.urdf
@@ -21,6 +21,16 @@
 
         This tests the parser's ability to correctly create a group with a
         member set with multiple members.
+
+        The robot *may* appear overly complex for the test.  But collision
+        cliques already exclude possible collisions between pairs (A, B) and
+        (B, C) due to their adjacency.  The collision between pair (A, C) will
+        *not* be dismissed due to cliques.  Only the collision filter groups
+        will prevent a reported collision.
+
+        There are two variants of this file to test two aspects of collision
+        filter groups.  This variant tests that multiple *bodies* in a single
+        group will lead to the correct filtering behavior.
     -->
  <link name="body1">
    <collision>

--- a/drake/multibody/collision/test/collision_filter_group_test_multi_member.urdf
+++ b/drake/multibody/collision/test/collision_filter_group_test_multi_member.urdf
@@ -1,0 +1,82 @@
+<robot name="simple_anchored">
+    <!--
+        A chain of spheres. Each sphere's center is displaced exactly 2R
+        from its parent.  They are connected by a revolute joint centered on
+        the center of the parent sphere.
+
+        At q = 0, this has been pre-posed as:
+                     ____
+                    /    \            z  y
+                   |   B  |           | /
+                  __\____/__          |/____x
+                 /    \/    \
+                |  A  ||  C  |
+                 \____/\____/
+
+        Where the chain is A -> B -> C.  A is centered on the world origin
+
+        A and C are overlapping with a penetration depth of 0.1 units.  Their
+        centers both lie on the x-axis at a distance of 2R - d, where id is 0.1
+        units (the penetration depth).
+
+        This tests the parser's ability to correctly create a group with a
+        member set with multiple members.
+    -->
+ <link name="body1">
+   <collision>
+     <origin xyz="0 0 0" rpy="0 0 0"/>
+     <geometry>
+       <sphere radius="1" />
+     </geometry>
+   </collision>
+  </link>
+
+  <link name="body2">
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1" />
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="body3">
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1" />
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="fixed21" type="revolute">
+    <origin rpy="0 0 0" xyz="0.95 0 1.7599715906798041"/>
+    <axis xyz="0 1 0"/>
+    <parent link="body1"/>
+    <child link="body2"/>
+  </joint>
+
+  <joint name="fixed32" type="revolute">
+    <origin rpy="0 0 0" xyz="0.95 0 -1.7599715906798041"/>
+    <axis xyz="0 1 0"/>
+    <parent link="body2"/>
+    <child link="body3"/>
+  </joint>
+
+  <!-- This prevents self-collision between bodies 1 and 3.  -->
+  <collision_filter_group name="self_group">
+    <member link="body1"/>
+    <member link="body2"/>
+    <member link="body3"/>
+    <ignored_collision_filter_group collision_filter_group="self_group"/>
+  </collision_filter_group>
+
+</robot>

--- a/drake/multibody/collision/test/collision_filter_group_test_multi_member.urdf
+++ b/drake/multibody/collision/test/collision_filter_group_test_multi_member.urdf
@@ -19,9 +19,6 @@
         centers both lie on the x-axis at a distance of 2R - d, where id is 0.1
         units (the penetration depth).
 
-        This tests the parser's ability to correctly create a group with a
-        member set with multiple members.
-
         The robot *may* appear overly complex for the test.  But collision
         cliques already exclude possible collisions between pairs (A, B) and
         (B, C) due to their adjacency.  The collision between pair (A, C) will

--- a/drake/multibody/parsers/urdf_parser.cc
+++ b/drake/multibody/parsers/urdf_parser.cc
@@ -554,7 +554,7 @@ void ParseCollisionFilterGroup(RigidBodyTree<double>* tree, XMLElement* node,
   const char* attr = node->Attribute("drake_ignore");
   if (attr && (std::strcmp(attr, "true") == 0)) return;
 
-  // TODO(SeanCurtis-TRI): After upgarding to newest tinyxml, add line numbers
+  // TODO(SeanCurtis-TRI): After upgrading to newest tinyxml, add line numbers
   // to error messages.
   attr = node->Attribute("name");
   if (!attr)

--- a/drake/multibody/parsers/urdf_parser.cc
+++ b/drake/multibody/parsers/urdf_parser.cc
@@ -565,12 +565,12 @@ void ParseCollisionFilterGroup(RigidBodyTree<double>* tree, XMLElement* node,
 
   for (XMLElement* member_node = node->FirstChildElement("member"); member_node;
        member_node =
-           member_node->NextSiblingElement("collision_filter_group")) {
-    const char* link_name = node->Attribute("link");
+           member_node->NextSiblingElement("member")) {
+    const char* link_name = member_node->Attribute("link");
     if (!link_name)
       throw runtime_error(
-          "Collision filter group provides a member tag without specifying the "
-          "\"link\".");
+          "Collision filter group " + group_name + " provides a member tag "
+          "without specifying the \"link\" attribute.");
     tree->AddCollisionFilterGroupMember(group_name, link_name,
                                         model_instance_id);
   }
@@ -578,8 +578,8 @@ void ParseCollisionFilterGroup(RigidBodyTree<double>* tree, XMLElement* node,
   for (XMLElement* ignore_node =
            node->FirstChildElement("ignored_collision_filter_group");
        ignore_node; ignore_node = ignore_node->NextSiblingElement(
-                        "collision_filter_group")) {
-    const char* target_name = node->Attribute("collision_filter_group");
+                        "ignored_collision_filter_group")) {
+    const char* target_name = ignore_node->Attribute("collision_filter_group");
     if (!target_name)
       throw runtime_error(
           "Collision filter group provides a tag specifying a group to ignore "

--- a/drake/multibody/parsers/urdf_parser.cc
+++ b/drake/multibody/parsers/urdf_parser.cc
@@ -561,7 +561,7 @@ void ParseCollisionFilterGroup(RigidBodyTree<double>* tree, XMLElement* node,
         "Collision filter group specification missing name attribute.");
   string group_name(attr);
 
-  tree->DefineCollisionFilterGroup(group_name, model_instance_id);
+  tree->DefineCollisionFilterGroup(group_name);
 
   for (XMLElement* member_node = node->FirstChildElement("member"); member_node;
        member_node =
@@ -571,7 +571,8 @@ void ParseCollisionFilterGroup(RigidBodyTree<double>* tree, XMLElement* node,
       throw runtime_error(
           "Collision filter group provides a member tag without specifying the "
           "\"link\".");
-    tree->AddCollisionFilterGroupMember(group_name, link_name);
+    tree->AddCollisionFilterGroupMember(group_name, link_name,
+                                        model_instance_id);
   }
 
   for (XMLElement* ignore_node =

--- a/drake/multibody/parsers/urdf_parser.cc
+++ b/drake/multibody/parsers/urdf_parser.cc
@@ -561,11 +561,7 @@ void ParseCollisionFilterGroup(RigidBodyTree<double>* tree, XMLElement* node,
         "Collision filter group specification missing name attribute.");
   string group_name(attr);
 
-  if (!tree->DefineCollisionFilterGroup(group_name, model_instance_id)) {
-    throw runtime_error(
-        "Attempting to add a collision filter group that already exists: " +
-        group_name + ".");
-  }
+  tree->DefineCollisionFilterGroup(group_name, model_instance_id);
 
   for (XMLElement* member_node = node->FirstChildElement("member"); member_node;
        member_node =
@@ -587,6 +583,7 @@ void ParseCollisionFilterGroup(RigidBodyTree<double>* tree, XMLElement* node,
       throw runtime_error(
           "Collision filter group provides a tag specifying a group to ignore "
           "without specifying the \"collision_filter_group\".");
+
     tree->AddCollisionFilterIgnoreTarget(group_name, target_name);
   }
 }

--- a/drake/multibody/rigid_body.cc
+++ b/drake/multibody/rigid_body.cc
@@ -244,10 +244,7 @@ bool RigidBody<T>::adjacentTo(const RigidBody& other) const {
 
 template <typename T>
 bool RigidBody<T>::CanCollideWith(const RigidBody& other) const {
-  bool ignored =
-      this == &other || adjacentTo(other) ||
-      (collision_filter_group_ & other.get_collision_filter_ignores()).any() ||
-      (other.get_collision_filter_group() & collision_filter_ignores_).any();
+  bool ignored = this == &other || adjacentTo(other);
   return !ignored;
 }
 

--- a/drake/multibody/rigid_body.cc
+++ b/drake/multibody/rigid_body.cc
@@ -186,50 +186,52 @@ Isometry3d RigidBody<T>::ComputeWorldFixedPose() const {
 }
 
 template <typename T>
-void RigidBody<T>::setCollisionFilter(const DrakeCollision::bitmask& group,
-                                   const DrakeCollision::bitmask& ignores) {
-  setCollisionFilterGroup(group);
-  setCollisionFilterIgnores(ignores);
+void RigidBody<T>::set_collision_filter(
+    const DrakeCollision::bitmask& group,
+    const DrakeCollision::bitmask& ignores) {
+  set_collision_filter_group(group);
+  set_collision_filter_ignores(ignores);
 }
 
 template <typename T>
-const DrakeCollision::bitmask& RigidBody<T>::getCollisionFilterGroup() const {
+const DrakeCollision::bitmask& RigidBody<T>::get_collision_filter_group()
+    const {
   return collision_filter_group_;
 }
 
 template <typename T>
-void RigidBody<T>::setCollisionFilterGroup(
-  const DrakeCollision::bitmask& group) {
+void RigidBody<T>::set_collision_filter_group(
+    const DrakeCollision::bitmask& group) {
   collision_filter_group_ = group;
 }
 
 template <typename T>
-const DrakeCollision::bitmask& RigidBody<T>::getCollisionFilterIgnores() const {
+const DrakeCollision::bitmask& RigidBody<T>::get_collision_filter_ignores()
+    const {
   return collision_filter_ignores_;
 }
 
 template <typename T>
-void RigidBody<T>::setCollisionFilterIgnores(const DrakeCollision::bitmask&
-    ignores) {
+void RigidBody<T>::set_collision_filter_ignores(
+    const DrakeCollision::bitmask& ignores) {
   collision_filter_ignores_ = ignores;
 }
 
 template <typename T>
-void RigidBody<T>::addToCollisionFilterGroup(const DrakeCollision::bitmask&
-    group) {
+void RigidBody<T>::add_to_collision_filter_group(
+    const DrakeCollision::bitmask& group) {
   collision_filter_group_ |= group;
 }
 
 template <typename T>
-void RigidBody<T>::ignoreCollisionFilterGroup(const DrakeCollision::bitmask&
-    group) {
+void RigidBody<T>::ignore_collision_filter_group(
+    const DrakeCollision::bitmask& group) {
   collision_filter_ignores_ |= group;
 }
 
 template <typename T>
-void RigidBody<T>::collideWithCollisionFilterGroup(
-  const DrakeCollision::bitmask&
-    group) {
+void RigidBody<T>::collides_with_collision_filter_groups(
+    const DrakeCollision::bitmask& group) {
   collision_filter_ignores_ &= ~group;
 }
 
@@ -244,8 +246,8 @@ template <typename T>
 bool RigidBody<T>::CanCollideWith(const RigidBody& other) const {
   bool ignored =
       this == &other || adjacentTo(other) ||
-      (collision_filter_group_ & other.getCollisionFilterIgnores()).any() ||
-      (other.getCollisionFilterGroup() & collision_filter_ignores_).any();
+      (collision_filter_group_ & other.get_collision_filter_ignores()).any() ||
+      (other.get_collision_filter_group() & collision_filter_ignores_).any();
   return !ignored;
 }
 

--- a/drake/multibody/rigid_body.cc
+++ b/drake/multibody/rigid_body.cc
@@ -16,9 +16,7 @@ using std::stringstream;
 using std::vector;
 
 template <typename T>
-RigidBody<T>::RigidBody()
-    : collision_filter_group_(DrakeCollision::DEFAULT_GROUP),
-      collision_filter_ignores_(DrakeCollision::NONE_MASK) {
+RigidBody<T>::RigidBody() {
   center_of_mass_ = Vector3d::Zero();
   spatial_inertia_ << drake::SquareTwistMatrix<double>::Zero();
 }
@@ -183,56 +181,6 @@ Isometry3d RigidBody<T>::ComputeWorldFixedPose() const {
   }
   return parent_->ComputeWorldFixedPose() *
          joint_->get_transform_to_parent_body();
-}
-
-template <typename T>
-void RigidBody<T>::set_collision_filter(
-    const DrakeCollision::bitmask& group,
-    const DrakeCollision::bitmask& ignores) {
-  set_collision_filter_group(group);
-  set_collision_filter_ignores(ignores);
-}
-
-template <typename T>
-const DrakeCollision::bitmask& RigidBody<T>::get_collision_filter_group()
-    const {
-  return collision_filter_group_;
-}
-
-template <typename T>
-void RigidBody<T>::set_collision_filter_group(
-    const DrakeCollision::bitmask& group) {
-  collision_filter_group_ = group;
-}
-
-template <typename T>
-const DrakeCollision::bitmask& RigidBody<T>::get_collision_filter_ignores()
-    const {
-  return collision_filter_ignores_;
-}
-
-template <typename T>
-void RigidBody<T>::set_collision_filter_ignores(
-    const DrakeCollision::bitmask& ignores) {
-  collision_filter_ignores_ = ignores;
-}
-
-template <typename T>
-void RigidBody<T>::add_to_collision_filter_group(
-    const DrakeCollision::bitmask& group) {
-  collision_filter_group_ |= group;
-}
-
-template <typename T>
-void RigidBody<T>::ignore_collision_filter_group(
-    const DrakeCollision::bitmask& group) {
-  collision_filter_ignores_ |= group;
-}
-
-template <typename T>
-void RigidBody<T>::collides_with_collision_filter_groups(
-    const DrakeCollision::bitmask& group) {
-  collision_filter_ignores_ &= ~group;
 }
 
 template <typename T>

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -423,6 +423,13 @@ class RigidBody {
   // A bitmask that determines the collision groups that this rigid body is part
   // of. If the i-th bit is set this rigid body belongs to the i-th collision
   // group. A rigid body can belong to several collision groups.
+  //
+  // This data structure does not *directly* contribute to collision filter.
+  // The body stores this data because collision filter groups are defined
+  // with respect to bodies.  However, the collision filtering functionality
+  // belongs to the DrakeCollision::Element.  If a new Element gets added to
+  // a body, it learns its collision filter groups from this cached data.
+  // Same for RigidBody::collision_filter_ignores_.
   DrakeCollision::bitmask collision_filter_group_;
 
   // A bitmask that determines which collision groups this rigid body does not

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -396,7 +396,7 @@ class RigidBody {
 
   /**
    * Reports the total number of *registered* collision elements attached to
-   * this body.
+   * this body. See Model::AddElement for definition of "registered".
    */
   int get_num_collision_element() const {
     return static_cast<int>(collision_elements_.size());

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -396,7 +396,7 @@ class RigidBody {
 
   /**
    * Reports the total number of *registered* collision elements attached to
-   * this body. See Model::AddElement for definition of "registered".
+   * this body. See Model::AddElement() for definition of "registered".
    */
   int get_num_collision_element() const {
     return static_cast<int>(collision_elements_.size());

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -413,6 +413,14 @@ class RigidBody {
     return collision_elements_.end();
   }
 
+  /**
+   * Reports the total number of *registered* collision elements attached to
+   * this body.
+   */
+  int get_num_collision_element() const {
+    return static_cast<int>(collision_elements_.size());
+  }
+
  private:
   // TODO(tkoolen): It's very ugly, but parent, dofnum, and pitch also exist
   // currently (independently) at the RigidBodyTree level to represent the

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -274,22 +274,24 @@ class RigidBody {
    */
   Eigen::Isometry3d ComputeWorldFixedPose() const;
 
-  void setCollisionFilter(const DrakeCollision::bitmask& group,
-                          const DrakeCollision::bitmask& ignores);
+  void set_collision_filter(const DrakeCollision::bitmask &group,
+                            const DrakeCollision::bitmask &ignores);
 
-  const DrakeCollision::bitmask& getCollisionFilterGroup() const;
+  const DrakeCollision::bitmask& get_collision_filter_group() const;
 
-  void setCollisionFilterGroup(const DrakeCollision::bitmask& group);
+  void set_collision_filter_group(const DrakeCollision::bitmask &group);
 
-  const DrakeCollision::bitmask& getCollisionFilterIgnores() const;
+  const DrakeCollision::bitmask& get_collision_filter_ignores() const;
 
-  void setCollisionFilterIgnores(const DrakeCollision::bitmask& ignores);
+  void set_collision_filter_ignores(const DrakeCollision::bitmask &ignores);
 
-  void addToCollisionFilterGroup(const DrakeCollision::bitmask& group);
+  // TODO(SeanCurtis-TRI): Consider deleting these three methods.
+  void add_to_collision_filter_group(const DrakeCollision::bitmask& group);
 
-  void ignoreCollisionFilterGroup(const DrakeCollision::bitmask& group);
+  void ignore_collision_filter_group(const DrakeCollision::bitmask& group);
 
-  void collideWithCollisionFilterGroup(const DrakeCollision::bitmask& group);
+  void collides_with_collision_filter_groups(
+      const DrakeCollision::bitmask& group);
 
   // TODO(amcastro-tri): Change to is_adjacent_to().
   // TODO(SeanCurtis-TRI): This method is only used by the collision clique

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -398,7 +398,7 @@ class RigidBody {
    * Reports the total number of *registered* collision elements attached to
    * this body. See Model::AddElement() for definition of "registered".
    */
-  int get_num_collision_element() const {
+  int get_num_collision_elements() const {
     return static_cast<int>(collision_elements_.size());
   }
 

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -274,25 +274,6 @@ class RigidBody {
    */
   Eigen::Isometry3d ComputeWorldFixedPose() const;
 
-  void set_collision_filter(const DrakeCollision::bitmask &group,
-                            const DrakeCollision::bitmask &ignores);
-
-  const DrakeCollision::bitmask& get_collision_filter_group() const;
-
-  void set_collision_filter_group(const DrakeCollision::bitmask &group);
-
-  const DrakeCollision::bitmask& get_collision_filter_ignores() const;
-
-  void set_collision_filter_ignores(const DrakeCollision::bitmask &ignores);
-
-  // TODO(SeanCurtis-TRI): Consider deleting these three methods.
-  void add_to_collision_filter_group(const DrakeCollision::bitmask& group);
-
-  void ignore_collision_filter_group(const DrakeCollision::bitmask& group);
-
-  void collides_with_collision_filter_groups(
-      const DrakeCollision::bitmask& group);
-
   // TODO(amcastro-tri): Change to is_adjacent_to().
   // TODO(SeanCurtis-TRI): This method is only used by the collision clique
   // calculation.  Maybe it would be better if the name reflected this: e.g.,
@@ -429,23 +410,6 @@ class RigidBody {
   // The "parent" joint of this rigid body. This is the joint through which this
   // rigid body connects to the rest of the rigid body tree.
   std::unique_ptr<DrakeJoint> joint_;
-
-  // A bitmask that determines the collision groups that this rigid body is part
-  // of. If the i-th bit is set this rigid body belongs to the i-th collision
-  // group. A rigid body can belong to several collision groups.
-  //
-  // This data structure does not *directly* contribute to collision filter.
-  // The body stores this data because collision filter groups are defined
-  // with respect to bodies.  However, the collision filtering functionality
-  // belongs to the DrakeCollision::Element.  If a new Element gets added to
-  // a body, it learns its collision filter groups from this cached data.
-  // Same for RigidBody::collision_filter_ignores_.
-  DrakeCollision::bitmask collision_filter_group_;
-
-  // A bitmask that determines which collision groups this rigid body does not
-  // collide with. Thus, if the i-th bit is set this rigid body is not checked
-  // for collisions with bodies in the i-th group.
-  DrakeCollision::bitmask collision_filter_ignores_;
 
   // The name of this rigid body.
   std::string name_;

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -215,8 +215,7 @@ void RigidBodyTree<T>::AddCollisionFilterGroupMember(
   RigidBody<T>* body = bodies[body_index].get();
   if (body->get_num_collision_element() > 0) {
     throw std::runtime_error("Attempting to add a body, '" + body->get_name() +
-                             "', to a collision "
-                             "group, '" +
+                             "', to a collision group, '" +
                              group_name +
                              "' that has already been compiled with "
                              "collision elements.");
@@ -363,22 +362,21 @@ void RigidBodyTree<T>::CompileCollisionState() {
   // Process collision filter groups
   collision_group_manager_.CompileGroups();
 
-  // Set the collision filter data on the body's elements.  Note: this does
+  // Set the collision filter data on the body's elements. Note: this does
   // *not* update the collision elements that may have already been registered
-  // with the collision model.
+  // with the collision model. But attempts to add bodies with registered
+  // collision elements to a collision filter group, should have already thrown
+  // an exception.
   for (auto& pair : body_collision_map_) {
     RigidBody<T>* body = pair.first;
     DrakeCollision::bitmask group =
         collision_group_manager_.get_group_mask(*body);
-    if (group.any()) {
-      // No body can ignore collision filter groups without belonging to one.
-      DrakeCollision::bitmask ignore =
-          collision_group_manager_.get_ignore_mask(*body);
-      BodyCollisions &elements = pair.second;
-      for (const auto &collision_item : elements) {
-        element_order_[collision_item.element]->set_collision_filter(group,
-                                                                     ignore);
-      }
+    DrakeCollision::bitmask ignore =
+        collision_group_manager_.get_ignore_mask(*body);
+    BodyCollisions& elements = pair.second;
+    for (const auto& collision_item : elements) {
+      element_order_[collision_item.element]->set_collision_filter(group,
+                                                                   ignore);
     }
   }
   collision_group_manager_.Clear();

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -355,17 +355,6 @@ void RigidBodyTree<T>::CompileCollisionState() {
 
   // Process collision filter groups
   collision_group_manager_.CompileGroups();
-  // Set the collision filter data on the body.
-  for (auto& body : bodies) {
-    DrakeCollision::bitmask group =
-        collision_group_manager_.get_group_mask(*body);
-    if (group.any()) {
-      // No body can ignore collision filter groups without belonging to one.
-      DrakeCollision::bitmask ignore =
-          collision_group_manager_.get_ignore_mask(*body);
-      body->set_collision_filter(group, ignore);
-    }
-  }
 
   // Set the collision filter data on the body's elements.  Note: this does
   // *not* update the collision elements that may have already been registered
@@ -373,11 +362,18 @@ void RigidBodyTree<T>::CompileCollisionState() {
   collision_group_manager_.Clear();
   for (auto& pair : body_collision_map_) {
     RigidBody<T>* body = pair.first;
-    BodyCollisions& elements = pair.second;
-    for (const auto& collision_item : elements) {
-      element_order_[collision_item.element]->set_collision_filter(
-          body->get_collision_filter_group(),
-          body->get_collision_filter_ignores());
+    DrakeCollision::bitmask group =
+        collision_group_manager_.get_group_mask(*body);
+    if (group.any()) {
+      // No body can ignore collision filter groups without belonging to one.
+      DrakeCollision::bitmask ignore =
+          collision_group_manager_.get_ignore_mask(*body);
+
+      BodyCollisions &elements = pair.second;
+      for (const auto &collision_item : elements) {
+        element_order_[collision_item.element]->set_collision_filter(group,
+                                                                     ignore);
+      }
     }
   }
 

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -222,7 +222,7 @@ void RigidBodyTree<T>::AddCollisionFilterGroupMember(
   int body_index = FindBodyIndex(body_name, model_id);
   RigidBody<T>* body = bodies[body_index].get();
   if (!collision_group_manager_.AddCollisionFilterGroupMember(group_name,
-                                                              body)) {
+                                                              *body)) {
     throw std::runtime_error(
         "Attempting to add a link to an undefined collision filter group: "
         "Adding " +
@@ -355,6 +355,7 @@ void RigidBodyTree<T>::CompileCollisionState() {
 
   // Process collision filter groups
   collision_group_manager_.CompileGroups();
+  // Set the collision filter data on the body.
   for (auto& body : bodies) {
     DrakeCollision::bitmask group =
         collision_group_manager_.get_group_mask(*body);
@@ -365,6 +366,8 @@ void RigidBodyTree<T>::CompileCollisionState() {
       body->set_collision_filter(group, ignore);
     }
   }
+
+  // Set the collision filter data on the body's elements.
   collision_group_manager_.Clear();
   for (auto& pair : body_collision_map_) {
     RigidBody<T>* body = pair.first;

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -359,7 +359,6 @@ void RigidBodyTree<T>::CompileCollisionState() {
   // Set the collision filter data on the body's elements.  Note: this does
   // *not* update the collision elements that may have already been registered
   // with the collision model.
-  collision_group_manager_.Clear();
   for (auto& pair : body_collision_map_) {
     RigidBody<T>* body = pair.first;
     DrakeCollision::bitmask group =
@@ -368,7 +367,6 @@ void RigidBodyTree<T>::CompileCollisionState() {
       // No body can ignore collision filter groups without belonging to one.
       DrakeCollision::bitmask ignore =
           collision_group_manager_.get_ignore_mask(*body);
-
       BodyCollisions &elements = pair.second;
       for (const auto &collision_item : elements) {
         element_order_[collision_item.element]->set_collision_filter(group,
@@ -376,6 +374,7 @@ void RigidBodyTree<T>::CompileCollisionState() {
       }
     }
   }
+  collision_group_manager_.Clear();
 
   // Builds cliques for collision filtering.
   CreateCollisionCliques();

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -204,9 +204,9 @@ const RigidBodyActuator& RigidBodyTree<T>::GetActuator(
 }
 
 template <typename T>
-bool RigidBodyTree<T>::DefineCollisionFilterGroup(const std::string& name,
+void RigidBodyTree<T>::DefineCollisionFilterGroup(const std::string& name,
                                                   int model_id) {
-  return collision_group_manager_.DefineCollisionFilterGroup(name, model_id);
+  collision_group_manager_.DefineCollisionFilterGroup(name, model_id);
 }
 
 template <typename T>

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -213,7 +213,7 @@ void RigidBodyTree<T>::AddCollisionFilterGroupMember(
     const std::string& group_name, const std::string& body_name, int model_id) {
   int body_index = FindBodyIndex(body_name, model_id);
   RigidBody<T>* body = bodies[body_index].get();
-  if (body->get_num_collision_element() > 0) {
+  if (body->get_num_collision_elements() > 0) {
     throw std::runtime_error("Attempting to add a body, '" + body->get_name() +
                              "', to a collision group, '" +
                              group_name +

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -238,6 +238,13 @@ void RigidBodyTree<T>::AddCollisionFilterIgnoreTarget(
 }
 
 template <typename T>
+void RigidBodyTree<T>::SetBodyCollisionFilters(
+    const RigidBody<T>& body, const DrakeCollision::bitmask& group,
+    const DrakeCollision::bitmask& ignores) {
+  collision_group_manager_.SetBodyCollisionFilters(body, group, ignores);
+}
+
+template <typename T>
 void RigidBodyTree<T>::compile(void) {
   SortTree();
 

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -362,7 +362,7 @@ void RigidBodyTree<T>::CompileCollisionState() {
       // No body can ignore collision filter groups without belonging to one.
       DrakeCollision::bitmask ignore =
           collision_group_manager_.get_ignore_mask(*body);
-      body->setCollisionFilter(group, ignore);
+      body->set_collision_filter(group, ignore);
     }
   }
   collision_group_manager_.Clear();
@@ -370,8 +370,9 @@ void RigidBodyTree<T>::CompileCollisionState() {
     RigidBody<T>* body = pair.first;
     BodyCollisions& elements = pair.second;
     for (const auto& collision_item : elements) {
-      element_order_[collision_item.element]->setCollisionFilter(
-          body->getCollisionFilterGroup(), body->getCollisionFilterIgnores());
+      element_order_[collision_item.element]->set_collision_filter(
+          body->get_collision_filter_group(),
+          body->get_collision_filter_ignores());
     }
   }
 

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1182,12 +1182,13 @@ class RigidBodyTree {
 
   /**
    * Attempts to define a new collision filter group.  The given name *must*
-   * be unique.  Duplicate names will lead to failure.
+   * be unique.  Duplicate names or attempting to add more
+   * collision filter groups than the system can handle will lead to failure. In
+   * the event of failure, an exception is thrown.
    * @param name        The unique name of the new group.
    * @param model_id    The model instance id to associate with this group.
-   * @return            True to indicate successful addition.
    */
-  bool DefineCollisionFilterGroup(const std::string& name, int model_id);
+  void DefineCollisionFilterGroup(const std::string& name, int model_id);
 
   /**
    * Adds a RigidBody to a collision filter group.  The RigidBody is referenced

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1182,9 +1182,10 @@ class RigidBodyTree {
 
   /**
    * Attempts to define a new collision filter group.  The given name *must*
-   * be unique.  Duplicate names or attempting to add more collision filter
-   * groups than the system can handle will lead to failure. In the event of
-   * failure, an exception is thrown.
+   * be unique in the current session (see CollisionFilterGroupManager for more
+   * detail).  Duplicate names or attempting to add more collision filter groups
+   * than the system can handle will lead to failure. In the event of failure,
+   * an exception is thrown.
    * @param name        The unique name of the new group.
    */
   void DefineCollisionFilterGroup(const std::string& name);
@@ -1192,14 +1193,11 @@ class RigidBodyTree {
   /**
    * Adds a RigidBody to a collision filter group.  The RigidBody is referenced
    * by name and model instance id. The process will fail if the body cannot be
-   * found (with the previously provided model instance id), or if the group
-   * cannot be found, or if the indicated boy already has *registered*
-   * collision elements (i.e., it has previously been compiled with collision
-   * elements).
+   * found, if the group cannot be found, or if the indicated boy already has
+   * *registered* collision elements (see Model::AddElement for more details).
    * An exception is thrown in the event of failure.
    * @param group_name      The collision filter group name to add the body to.
-   * @param body_name       The name of the body to add (as a member of the
-   *                        group's model instance id.
+   * @param body_name       The name of the body to add.
    * @param model_id        The id of the model instance to which this body
    *                        belongs.
    */
@@ -1209,8 +1207,8 @@ class RigidBodyTree {
 
   /**
    * Adds a collision group to the set of groups ignored by the specified
-   * collision filter group.  Will fail if the specified specified group name
-   * does not refer to an existing collision filter group.  (Although, the
+   * collision filter group.  Will fail if the specified group name
+   * does not refer to an existing collision filter group.  (The
    * target group name need not exist at this time.)  An exception is thrown
    * upon failure.
    * @param group_name
@@ -1220,8 +1218,7 @@ class RigidBodyTree {
                                       const std::string& target_group_name);
 
   // TODO(SeanCurtis-TRI): Kill this method when matlab dependencies are
-  // removed.  There is a corresponding method on the
-  // CollisionFilterGroupManager.
+  // removed.  There is a corresponding method on CollisionFilterGroupManager.
   /**
    Directly set the masks for a body.  The values will remain in the current
    session (i.e., until Clear is called).

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1193,8 +1193,8 @@ class RigidBodyTree {
   /**
    * Adds a RigidBody to a collision filter group.  The RigidBody is referenced
    * by name and model instance id. The process will fail if the body cannot be
-   * found, if the group cannot be found, or if the indicated boy already has
-   * *registered* collision elements (see Model::AddElement for more details).
+   * found, if the group cannot be found, or if the indicated body already has
+   * *registered* collision elements (see Model::AddElement() for more details).
    * An exception is thrown in the event of failure.
    * @param group_name      The collision filter group name to add the body to.
    * @param body_name       The name of the body to add.

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1191,8 +1191,11 @@ class RigidBodyTree {
 
   /**
    * Adds a RigidBody to a collision filter group.  The RigidBody is referenced
-   * by name.  The process will fail if the body cannot be found (with the
-   * previously provided model instance id) or if the group cannot be found.
+   * by name and model instance id. The process will fail if the body cannot be
+   * found (with the previously provided model instance id), or if the group
+   * cannot be found, or if the indicated boy already has *registered*
+   * collision elements (i.e., it has previously been compiled with collision
+   * elements).
    * An exception is thrown in the event of failure.
    * @param group_name      The collision filter group name to add the body to.
    * @param body_name       The name of the body to add (as a member of the

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1219,6 +1219,21 @@ class RigidBodyTree {
   void AddCollisionFilterIgnoreTarget(const std::string& group_name,
                                       const std::string& target_group_name);
 
+  // TODO(SeanCurtis-TRI): Kill this method when matlab dependencies are
+  // removed.  There is a corresponding method on the
+  // CollisionFilterGroupManager.
+  /**
+   Directly set the masks for a body.  The values will remain in the current
+   session (i.e., until Clear is called).
+   This is a convenience function for Matlab integration.  The Matlab parser
+   handles the mapping of collision filter group names to ids and passes the
+   mapped ids directly the manager for when the tree gets compiled.  It relies
+   on correct encoding of groups into bitmasks.
+   */
+  void SetBodyCollisionFilters(const RigidBody<T>& body,
+                               const DrakeCollision::bitmask& group,
+                               const DrakeCollision::bitmask& ignores);
+
   /**
    * @brief Returns a mutable reference to the RigidBody associated with the
    * world in the model. This is the root of the RigidBodyTree.

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1185,7 +1185,7 @@ class RigidBodyTree {
    * be unique in the current session (see CollisionFilterGroupManager for more
    * detail).  Duplicate names or attempting to add more collision filter groups
    * than the system can handle will lead to failure. In the event of failure,
-   * an exception is thrown.
+   * an exception is thrown.  kMaxNumCollisionFilterGroups defines the limit.
    * @param name        The unique name of the new group.
    */
   void DefineCollisionFilterGroup(const std::string& name);
@@ -1221,7 +1221,7 @@ class RigidBodyTree {
   // removed.  There is a corresponding method on CollisionFilterGroupManager.
   /**
    Directly set the masks for a body.  The values will remain in the current
-   session (i.e., until Clear is called).
+   session (i.e., until CollisionFilterGroupManager::Clear() is called).
    This is a convenience function for Matlab integration.  The Matlab parser
    handles the mapping of collision filter group names to ids and passes the
    mapped ids directly the manager for when the tree gets compiled.  It relies

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1369,9 +1369,6 @@ class RigidBodyTree {
   int next_available_clique_ = 0;
 
  private:
-  // Map between group names and specification of its collision filter group.
-  std::unordered_map<std::string, DrakeCollision::CollisionFilterGroup<T>>
-      collision_filter_groups_;
 
   // Utility class for storing body collision data during RBT instantiation.
   struct BodyCollisionItem {
@@ -1392,12 +1389,16 @@ class RigidBodyTree {
   // proper, intermediate representation.
   std::unordered_map<RigidBody<T>*, BodyCollisions>
       body_collision_map_;
+
   // Bullet's collision results are affected by the order in which the collision
   // elements are added. This queues the collision elements in the added order
   // so that when actually registered with the collision engine, they'll be
   // submitted in the invocation order.
   // See https://github.com/bulletphysics/bullet3/issues/888
   std::vector< std::unique_ptr<DrakeCollision::Element>> element_order_;
+
+  // Manager for instantiating and managing collision filter groups.
+  DrakeCollision::CollisionFilterGroupManager<T> collision_group_manager_{};
 };
 
 typedef RigidBodyTree<double> RigidBodyTreed;

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1182,13 +1182,12 @@ class RigidBodyTree {
 
   /**
    * Attempts to define a new collision filter group.  The given name *must*
-   * be unique.  Duplicate names or attempting to add more
-   * collision filter groups than the system can handle will lead to failure. In
-   * the event of failure, an exception is thrown.
+   * be unique.  Duplicate names or attempting to add more collision filter
+   * groups than the system can handle will lead to failure. In the event of
+   * failure, an exception is thrown.
    * @param name        The unique name of the new group.
-   * @param model_id    The model instance id to associate with this group.
    */
-  void DefineCollisionFilterGroup(const std::string& name, int model_id);
+  void DefineCollisionFilterGroup(const std::string& name);
 
   /**
    * Adds a RigidBody to a collision filter group.  The RigidBody is referenced
@@ -1198,9 +1197,12 @@ class RigidBodyTree {
    * @param group_name      The collision filter group name to add the body to.
    * @param body_name       The name of the body to add (as a member of the
    *                        group's model instance id.
+   * @param model_id        The id of the model instance to which this body
+   *                        belongs.
    */
   void AddCollisionFilterGroupMember(const std::string& group_name,
-                                     const std::string& body_name);
+                                     const std::string& body_name,
+                                     int model_id);
 
   /**
    * Adds a collision group to the set of groups ignored by the specified
@@ -1370,7 +1372,6 @@ class RigidBodyTree {
   int next_available_clique_ = 0;
 
  private:
-
   // Utility class for storing body collision data during RBT instantiation.
   struct BodyCollisionItem {
     BodyCollisionItem(const std::string& grp_name,


### PR DESCRIPTION
This implements collision filter groups in C++ (see issue #4204).

 The behavior in C++ resembles that of Matlab but does not reproduce it exactly.  

1) In C++, a single urdf file can be loaded multiple times (in matlab, this would lead to an error.)
2) In matlab, links (aka bodies) can be added/removed to collision filter groups programmatically, outside of parsing.  In *this* C++ implementation, only parsed collision filter groups are supported.  There is a TODO indicating that this needs to change as per this issue: #4729.
3) Similarly, matlab provides runtime querying (e.g., given the *name* of the a collision filter group, can look up the bit id.) C++, not so much.  It is also worth noting, that this matlab functionality must be run *before* it is converted into a C++ object via the mex functionality.

Of the 1311 reported additions, 221 are comments, 190 are in new urdf files for unit testing, and 900 are new lines of code (and white space, includes, namespace declarations, using, etc).  It is *possible* to decompose this into two PRs, but it is unlikely that the split would be remotely even and that the second PR would be appreciably near 500.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4773)
<!-- Reviewable:end -->
