### PR TITLE
update llvm installation on xenial

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -22,13 +22,13 @@ while true; do
   echo "The Ubuntu 16.04 distribution includes Clang 3.8 by default."
   echo "To install Clang 3.9 it is necessary to add a Personal Package Archive (PPA)."
   echo "This script will add the repository
-    'deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main'"
+    'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'"
   read -p "Do you want to continue? [Y/n] " yn
   case $yn in
     [Yy]*)
       apt-get install --no-install-recommends lsb-core software-properties-common wget
       wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-      add-apt-repository -y "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main"
+      apt-add-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main"
       apt-get update
       apt install --no-install-recommends clang-3.9
       break


### PR DESCRIPTION
This should fix https://github.com/RobotLocomotion/drake/issues/4748. I found this post on ask Ubuntu:

http://askubuntu.com/questions/787383/how-to-install-llvm-3-9

It recommended to use a slightly different form of the llvm apt url and a version agnostic repository. You should make sure it installs the correct version, but it seems to work for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4776)
<!-- Reviewable:end -->
