### PR TITLE
adds a test method for checking matrix equality up to a permutation

### DIFF
--- a/drake/common/is_approx_equal_abstol.h
+++ b/drake/common/is_approx_equal_abstol.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <Eigen/Dense>
 
 #include "drake/common/drake_compat.h"
@@ -18,5 +20,45 @@ bool is_approx_equal_abstol(const Eigen::MatrixBase<DerivedA>& m1,
       (m1.cols() == m2.cols()) &&
       ((m1 - m2).template lpNorm<Eigen::Infinity>() <= tolerance));
 }
+
+/// Returns true if and only if a simple greedy search reveals a permutation
+/// of the columns of m2 to make the matrix equal to m1 to within a certain
+/// absolute elementwise @p tolerance. E.g., there exists a P such that
+/// <pre>
+///    forall i,j,  |m1 - m2*P|_{i,j} <= tolerance
+///    where P is a permutation matrix:
+///       P(i,j)={0,1}, sum_i P(i,j)=1, sum_j P(i,j)=1.
+/// </pre>
+/// Note: Returns false for matrices of different sizes.
+/// Note: The current implementation is O(n^2) in the number of columns.
+/// Note: In marginal cases (with similar but not identical columns) this
+/// algorithm can fail to find a permutation P even if it exists because it
+/// accepts the first column match (m1(i),m2(j)) and removes m2(j) from the
+/// pool. It is possible that other columns of m2 would also match m1(i) but
+/// that m2(j) is the only match possible for a later column of m1.
+template <typename DerivedA, typename DerivedB>
+bool IsApproxEqualAbsTolWithPermutedColumns(
+    const Eigen::MatrixBase<DerivedA>& m1,
+    const Eigen::MatrixBase<DerivedB>& m2, double tolerance) {
+  if ((m1.cols() != m2.cols()) || (m1.rows() != m2.rows())) return false;
+
+  std::vector<bool> available(m2.cols());
+  for (int i = 0; i < m2.cols(); i++) available[i] = true;
+
+  for (int i = 0; i < m1.cols(); i++) {
+    bool found_match = false;
+    for (int j = 0; j < m2.cols(); j++) {
+      if (available[j] &&
+          is_approx_equal_abstol(m1.col(i), m2.col(j), tolerance)) {
+        found_match = true;
+        available[j] = false;
+        break;
+      }
+    }
+    if (!found_match) return false;
+  }
+  return true;
+}
+
 
 }  // namespace drake

--- a/drake/common/test/is_approx_equal_abstol_test.cc
+++ b/drake/common/test/is_approx_equal_abstol_test.cc
@@ -57,8 +57,46 @@ GTEST_TEST(IsApproxEqualMatrixTest, BasicTest) {
   EXPECT_FALSE(is_approx_equal_abstol(nan2, ones2, tolerance));
 }
 
+GTEST_TEST(IsApproxEqualAbstolPermutationTest, PermutationTest) {
+  MatrixXd test(2, 3);
+  // clang-format off
+  test << 1, 2, 3,
+          4, 5, 6;
+  // clang-format on
+
+  const double tol = 1e-8;
+  EXPECT_TRUE(IsApproxEqualAbsTolWithPermutedColumns(test, test, tol));
+  EXPECT_FALSE(
+      IsApproxEqualAbsTolWithPermutedColumns(test, test.leftCols<2>(), tol));
+  EXPECT_FALSE(
+      IsApproxEqualAbsTolWithPermutedColumns(test.leftCols<2>(), test, tol));
+
+  MatrixXd test2(2, 3);
+
+  // Switch cols 2 and 3.
+  // clang-format off
+  test2 << 1, 3, 2,
+           4, 6, 5;
+  // clang-format on
+  EXPECT_TRUE(IsApproxEqualAbsTolWithPermutedColumns(test, test2, tol));
+
+  // All columns in test2 are in test1, but one is repeated.
+  // clang-format off
+  test2 << 1, 1, 2,
+           4, 4, 5;
+  // clang-format on
+  EXPECT_FALSE(IsApproxEqualAbsTolWithPermutedColumns(test, test2, tol));
+  EXPECT_FALSE(IsApproxEqualAbsTolWithPermutedColumns(test2, test, tol));
+
+  // Matching but with one duplicated columns.
+  test2.resize(2, 4);
+  // clang-format off
+  test2 << 1, 1, 2, 3,
+           4, 4, 5, 6;
+  // clang-format on
+  EXPECT_FALSE(IsApproxEqualAbsTolWithPermutedColumns(test, test2, tol));
+  EXPECT_FALSE(IsApproxEqualAbsTolWithPermutedColumns(test2, test, tol));
+}
 
 }  // namespace
 }  // namespace drake
-
-


### PR DESCRIPTION
 (which I've found myself needing when checking symmetry of a mesh, and in a number of test files).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4788)
<!-- Reviewable:end -->
