### PR TITLE
Fixed warning in primitives/CMakeLists.txt.

### DIFF
--- a/drake/systems/primitives/CMakeLists.txt
+++ b/drake/systems/primitives/CMakeLists.txt
@@ -43,10 +43,8 @@ drake_install_headers(
 set(private_headers)
 
 add_library_with_exports(LIB_NAME drakeSystemPrimitives
-    SOURCE_FILES ${sources} ${installed_headers} ${private_headers})
+    SOURCE_FILES ${sources} ${private_headers})
 target_link_libraries(drakeSystemPrimitives drakeSystemFramework drakeCommon)
-
-drake_install_headers(${installed_headers})
 
 drake_install_libraries(drakeSystemPrimitives)
 drake_install_pkg_config_file(drake-system-primitives


### PR DESCRIPTION
This PR resolves the following warning:

```
CMake Warning (dev) at systems/primitives/CMakeLists.txt:45 (add_library_with_exports):
  uninitialized variable 'installed_headers'
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at systems/primitives/CMakeLists.txt:49 (drake_install_headers):
  uninitialized variable 'installed_headers'
This warning is for project developers.  Use -Wno-dev to suppress it.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4791)
<!-- Reviewable:end -->
