### PR TITLE
CompareMatrices method embraces gtest.

### DIFF
--- a/drake/common/eigen_matrix_compare.h
+++ b/drake/common/eigen_matrix_compare.h
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <string>
 
+#include <gtest/gtest.h>
 #include <Eigen/Dense>
 
 #include "drake/common/drake_compat.h"
@@ -29,24 +29,18 @@ enum class MatrixCompareType { absolute, relative };
  * @return true if the two matrices are equal based on the specified tolerance.
  */
 template <typename DerivedA, typename DerivedB>
-bool CompareMatrices(
+::testing::AssertionResult CompareMatrices(
     const Eigen::MatrixBase<DerivedA>& m1,
     const Eigen::MatrixBase<DerivedB>& m2, double tolerance = 0.0,
-    MatrixCompareType compare_type = MatrixCompareType::absolute,
-    std::string* explanation = nullptr) {
-  bool result = true;
-  std::string error_message;
-
+    MatrixCompareType compare_type = MatrixCompareType::absolute) {
   if (m1.rows() != m2.rows() || m1.cols() != m2.cols()) {
-    std::stringstream msg;
-    msg << "Matrix size mismatch: (" << m1.rows() << " x " << m1.cols()
-        << " vs. " << m2.rows() << " x " << m2.cols() << ")";
-    error_message = msg.str();
-    result = false;
+    return ::testing::AssertionFailure()
+           << "Matrix size mismatch: (" << m1.rows() << " x " << m1.cols()
+           << " vs. " << m2.rows() << " x " << m2.cols() << ")";
   }
 
-  for (int ii = 0; result && ii < m1.rows(); ii++) {
-    for (int jj = 0; result && jj < m1.cols(); jj++) {
+  for (int ii = 0; ii < m1.rows(); ii++) {
+    for (int jj = 0; jj < m1.cols(); jj++) {
       // First handle the corner cases of positive infinity, negative infinity,
       // and NaN
       bool both_positive_infinity =
@@ -65,13 +59,10 @@ bool CompareMatrices(
       // Check for case where one value is NaN and the other is not
       if ((std::isnan(m1(ii, jj)) && !std::isnan(m2(ii, jj))) ||
           (!std::isnan(m1(ii, jj)) && std::isnan(m2(ii, jj)))) {
-        std::stringstream msg;
-        msg << "NaN missmatch at (" << ii << ", " << jj << "):\nm1 =\n"
-            << m1 << "\nm2 =\n"
-            << m2;
-        error_message = msg.str();
-        result = false;
-        continue;
+        return ::testing::AssertionFailure() << "NaN missmatch at (" << ii
+                                             << ", " << jj << "):\nm1 =\n"
+                                             << m1 << "\nm2 =\n"
+                                             << m2;
       }
 
       // Determine whether the difference between the two matrices is less than
@@ -82,17 +73,14 @@ bool CompareMatrices(
         // Perform comparison using absolute tolerance.
 
         if (delta > tolerance) {
-          std::stringstream msg;
-          msg << "Values at (" << ii << ", " << jj
-              << ") exceed tolerance: " << m1(ii, jj) << " vs. " << m2(ii, jj)
-              << ", diff = " << delta << ", tolerance = " << tolerance
-              << "\nm1 =\n"
-              << m1 << "\nm2 =\n"
-              << m2 << "\ndelta=\n"
-              << (m1 - m2);
-
-          error_message = msg.str();
-          result = false;
+          return ::testing::AssertionFailure()
+                 << "Values at (" << ii << ", " << jj
+                 << ") exceed tolerance: " << m1(ii, jj) << " vs. "
+                 << m2(ii, jj) << ", diff = " << delta
+                 << ", tolerance = " << tolerance << "\nm1 =\n"
+                 << m1 << "\nm2 =\n"
+                 << m2 << "\ndelta=\n"
+                 << (m1 - m2);
         }
       } else {
         // Perform comparison using relative tolerance, see:
@@ -101,29 +89,25 @@ bool CompareMatrices(
         double relative_tolerance = tolerance * std::max(1.0, max_value);
 
         if (delta > relative_tolerance) {
-          std::stringstream msg;
-          msg << "Values at (" << ii << ", " << jj
-              << ") exceed tolerance: " << m1(ii, jj) << " vs. " << m2(ii, jj)
-              << ", diff = " << delta << ", tolerance = " << tolerance
-              << ", relative tolerance = " << relative_tolerance << "\nm1 =\n"
-              << m1 << "\nm2 =\n"
-              << m2 << "\ndelta=\n"
-              << (m1 - m2);
-          error_message = msg.str();
-          result = false;
+          return ::testing::AssertionFailure()
+                 << "Values at (" << ii << ", " << jj
+                 << ") exceed tolerance: " << m1(ii, jj) << " vs. "
+                 << m2(ii, jj) << ", diff = " << delta
+                 << ", tolerance = " << tolerance
+                 << ", relative tolerance = " << relative_tolerance
+                 << "\nm1 =\n"
+                 << m1 << "\nm2 =\n"
+                 << m2 << "\ndelta=\n"
+                 << (m1 - m2);
         }
       }
     }
   }
 
-  if (!result) {
-    if (explanation != nullptr)
-      *explanation = error_message;
-    else
-      drake::log()->error(error_message);
-  }
-
-  return result;
+  return ::testing::AssertionSuccess() << "m1 =\n"
+                                       << m1
+                                       << "\nis approximately equal to m2 =\n"
+                                       << m2;
 }
 
 }  // namespace drake

--- a/drake/common/test/eigen_matrix_compare_test.cc
+++ b/drake/common/test/eigen_matrix_compare_test.cc
@@ -16,19 +16,14 @@ GTEST_TEST(MatrixCompareTest, CompareIdentical) {
   m3 << 100, 200, 300, 400;
 
   const double tolerance = 1e-8;
-  std::string explanation;
 
-  EXPECT_TRUE(CompareMatrices(m1, m2, tolerance, MatrixCompareType::absolute,
-                              &explanation));
+  EXPECT_TRUE(CompareMatrices(m1, m2, tolerance, MatrixCompareType::absolute));
 
-  EXPECT_TRUE(CompareMatrices(m1, m2, tolerance, MatrixCompareType::relative,
-                              &explanation));
+  EXPECT_TRUE(CompareMatrices(m1, m2, tolerance, MatrixCompareType::relative));
 
-  EXPECT_FALSE(CompareMatrices(m1, m3, tolerance, MatrixCompareType::absolute,
-                               &explanation));
+  EXPECT_FALSE(CompareMatrices(m1, m3, tolerance, MatrixCompareType::absolute));
 
-  EXPECT_FALSE(CompareMatrices(m1, m3, tolerance, MatrixCompareType::relative,
-                               &explanation));
+  EXPECT_FALSE(CompareMatrices(m1, m3, tolerance, MatrixCompareType::relative));
 }
 
 // Tests absolute tolerance with real numbers.
@@ -46,22 +41,18 @@ GTEST_TEST(MatrixCompareTest, AbsoluteCompare) {
   m4 << 0, 1, 2, 3 - 1e-6;
 
   const double tolerance = 1e-8;
-  std::string error_msg;
 
   // The difference between m1 and m2 is less than the tolerance.
   // They should be considered equal.
-  EXPECT_TRUE(CompareMatrices(m1, m2, tolerance, MatrixCompareType::absolute,
-                              &error_msg));
+  EXPECT_TRUE(CompareMatrices(m1, m2, tolerance, MatrixCompareType::absolute));
 
   // The difference between m1 and m3 is exactly equal to the tolerance.
   // They should be considered equal.
-  EXPECT_TRUE(CompareMatrices(m1, m3, tolerance, MatrixCompareType::absolute,
-                              &error_msg));
+  EXPECT_TRUE(CompareMatrices(m1, m3, tolerance, MatrixCompareType::absolute));
 
   // The difference between m1 and m4 is greater than the tolerance.
   // They should be considered different.
-  EXPECT_FALSE(CompareMatrices(m1, m4, tolerance, MatrixCompareType::absolute,
-                               &error_msg));
+  EXPECT_FALSE(CompareMatrices(m1, m4, tolerance, MatrixCompareType::absolute));
 }
 
 // Tests absolute tolerance with NaN values
@@ -79,22 +70,18 @@ GTEST_TEST(MatrixCompareTest, AbsoluteNaNCompare) {
   m4 << 0, 1, 2, 3;
 
   const double tolerance = 1e-8;
-  std::string error_msg;
 
   // The difference between m1 and m2 is less than the tolerance.
   // They should be considered equal.
-  EXPECT_TRUE(CompareMatrices(m1, m2, tolerance, MatrixCompareType::absolute,
-                              &error_msg));
+  EXPECT_TRUE(CompareMatrices(m1, m2, tolerance, MatrixCompareType::absolute));
 
   // The difference between m1 and m3 is exactly equal to the tolerance.
   // They should be considered equal.
-  EXPECT_TRUE(CompareMatrices(m1, m3, tolerance, MatrixCompareType::absolute,
-                              &error_msg));
+  EXPECT_TRUE(CompareMatrices(m1, m3, tolerance, MatrixCompareType::absolute));
 
   // The difference between m1 and m4 is greater than the tolerance.
   // They should be considered different.
-  EXPECT_FALSE(CompareMatrices(m1, m4, tolerance, MatrixCompareType::absolute,
-                               &error_msg));
+  EXPECT_FALSE(CompareMatrices(m1, m4, tolerance, MatrixCompareType::absolute));
 }
 
 // Tests absolute tolerance with real numbers.
@@ -105,38 +92,17 @@ GTEST_TEST(MatrixCompareTest, RelativeCompare) {
   Eigen::MatrixXd m2(2, 2);
   m2 << 100, 100 * 0.9, 100, 100;
 
-  std::string error_msg;
-
   // The difference between m1 and m2 is more than 1%.
   // They should be considered not equal.
-  EXPECT_FALSE(
-      CompareMatrices(m1, m2, 0.01, MatrixCompareType::relative, &error_msg));
+  EXPECT_FALSE(CompareMatrices(m1, m2, 0.01, MatrixCompareType::relative));
 
   // The difference between m1 and m2 is equal to 10%.
   // They should be considered equal.
-  EXPECT_TRUE(
-      CompareMatrices(m1, m2, 0.1, MatrixCompareType::relative, &error_msg));
+  EXPECT_TRUE(CompareMatrices(m1, m2, 0.1, MatrixCompareType::relative));
 
   // The difference between m1 and m4 is less than 20%.
   // They should be considered equal.
-  EXPECT_TRUE(
-      CompareMatrices(m1, m2, 0.2, MatrixCompareType::relative, &error_msg));
-}
-
-// Tests ability to not specify an error message parameter
-GTEST_TEST(MatrixCompareTest, NoMessageParam) {
-  Eigen::MatrixXd m1(2, 2);
-  m1 << 1, 2, 3, 4;
-
-  Eigen::MatrixXd m2(2, 2);
-  m2 << 1, 2, 3, 4;
-
-  const double one_pct = 0.01;
-
-  // The difference between m1 and m2 is less than 1%.
-  // They should be considered equal.
-  // Note that we do not specify an error message parameter.
-  EXPECT_TRUE(CompareMatrices(m1, m2, one_pct, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(m1, m2, 0.2, MatrixCompareType::relative));
 }
 
 }  // namespace

--- a/drake/examples/Pendulum/CMakeLists.txt
+++ b/drake/examples/Pendulum/CMakeLists.txt
@@ -49,7 +49,8 @@ if(lcm_FOUND)
     drakePendulumPlant
     drakeRigidBodyPlant
     drakeSystemControllers
-    drakeSystemAnalysis)
+    drakeSystemAnalysis
+    GTest::GTest)
 
   if(ipopt_FOUND OR NLopt_FOUND OR snopt_FOUND)
     drake_add_test(NAME pendulum_run_swing_up

--- a/drake/matlab/systems/plants/test/CMakeLists.txt
+++ b/drake/matlab/systems/plants/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(Matlab_FOUND)
   add_rbm_mex(compareParsersmex)
+  target_link_libraries(compareParsersmex GTest::GTest)
 
   macro(add_ikoptions_mex)
     drake_add_mex(${ARGV} ${ARGV}.cpp)

--- a/drake/multibody/rigid_body_system1/test/compareRigidBodySystems.cpp
+++ b/drake/multibody/rigid_body_system1/test/compareRigidBodySystems.cpp
@@ -56,9 +56,8 @@ GTEST_TEST(CompareRigidBodySystemsTest, TestAll) {
     auto xdot1 = r1->dynamics(t, x, u);
     auto xdot2 = r2->dynamics(t, x, u);
 
-    std::string explanation;
     EXPECT_TRUE(CompareMatrices(
-        xdot1, xdot2, 1e-8, MatrixCompareType::relative, &explanation))
+        xdot1, xdot2, 1e-8, MatrixCompareType::relative))
         << "Model mismatch!" << std::endl
         << "  - initial state:" << std::endl
         << x << std::endl
@@ -67,9 +66,7 @@ GTEST_TEST(CompareRigidBodySystemsTest, TestAll) {
         << "  - xdot1:" << std::endl
         << xdot1.transpose() << std::endl
         << "  - xdot2:" << std::endl
-        << xdot2.transpose() << std::endl
-        << "  - error message:" << std::endl
-        << explanation;
+        << xdot2.transpose() << std::endl;
   }
 }
 

--- a/drake/systems/sensors/test/depth_sensor_test.cc
+++ b/drake/systems/sensors/test/depth_sensor_test.cc
@@ -192,10 +192,7 @@ GTEST_TEST(TestDepthSensor, XyBoxInWorldTest) {
   expected_depths(26) = box_distance / cos(specification.min_yaw() +
                                            26 * specification.yaw_increment());
 
-  std::string message;
-  EXPECT_TRUE(CompareMatrices(depth_measurements, expected_depths, 1e-8,
-                              MatrixCompareType::absolute, &message))
-      << message;
+  EXPECT_TRUE(CompareMatrices(depth_measurements, expected_depths, 1e-8));
 
   const Matrix3Xd point_cloud = std::get<1>(result);
 
@@ -248,10 +245,8 @@ GTEST_TEST(TestDepthSensor, XzBoxInWorldTest) {
       box_distance /
       sin(specification.min_pitch() + 49 * specification.pitch_increment());
 
-  std::string message;
   EXPECT_TRUE(CompareMatrices(depth_measurements, expected_output, 1e-8,
-                              MatrixCompareType::absolute, &message))
-      << message;
+                              MatrixCompareType::absolute));
 }
 
 // Tests that the sensor will return negative infinity when the object is less
@@ -272,10 +267,8 @@ GTEST_TEST(TestDepthSensor, TestTooClose) {
   Eigen::VectorXd expected_output =
       VectorXd::Constant(depth_measurements.size(), DepthSensor::kTooClose);
 
-  std::string message;
   EXPECT_TRUE(CompareMatrices(depth_measurements, expected_output, 1e-8,
-                              MatrixCompareType::absolute, &message))
-      << message;
+                              MatrixCompareType::absolute));
 
   const Matrix3Xd point_cloud = std::get<1>(result);
   EXPECT_EQ(point_cloud.cols(), 0);


### PR DESCRIPTION
Instead of providing an optional string output that can capture a message, use the gtest assertion results type:
https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#using-a-function-that-returns-an-assertionresult
In addition to being cleaner (the values are printed on failure with no extra work by the test author), this also has the advantage of adding support for giving a more informative message when using EXPECT_FALSE(CompareMatrices(...)).

Sample output:
```
eigen_matrix_compare_test.cc:84: Failure
Value of: CompareMatrices(m1, m3, tolerance, MatrixCompareType::absolute)
  Actual: true (m1 =
  0   1
nan   3
 is approximately equal to m2 =
                  0 0.99999999989999999
                nan                   3)
Expected: false
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4797)
<!-- Reviewable:end -->
