### PR TITLE
Mark Value<T> as non-copyable

### DIFF
--- a/drake/systems/framework/test/value_test.cc
+++ b/drake/systems/framework/test/value_test.cc
@@ -20,12 +20,6 @@ GTEST_TEST(ValueTest, Access) {
   EXPECT_EQ(3, erased.GetValueOrThrow<int>());
 }
 
-GTEST_TEST(ValueTest, Copy) {
-  Value<int> value(42);
-  Value<int> copied_value = value;
-  EXPECT_EQ(42, copied_value.get_value());
-}
-
 GTEST_TEST(ValueTest, Clone) {
   Value<int> value(43);
   const AbstractValue& erased = value;
@@ -117,9 +111,9 @@ class PrintableValue : public Value<T>, public PrintInterface {
  public:
   explicit PrintableValue(const T& v) : Value<T>(v) {}
 
-  // PrintableValues are copyable but not moveable.
-  PrintableValue(const PrintableValue<T>& other) = default;
-  PrintableValue& operator=(const PrintableValue<T>& other) = default;
+  // PrintableValues neither copyable nor moveable.
+  PrintableValue(const PrintableValue<T>& other) = delete;
+  PrintableValue& operator=(const PrintableValue<T>& other) = delete;
   PrintableValue(PrintableValue<T>&& other) = delete;
   PrintableValue& operator=(PrintableValue<T>&& other) = delete;
 

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -145,14 +145,14 @@ class Value : public AbstractValue {
   explicit Value(const T& v) : value_(v) {}
   ~Value() override {}
 
-  // Values are copyable but not moveable.
-  Value(const Value<T>& other) = default;
-  Value& operator=(const Value<T>& other) = default;
+  // Values are neither copyable nor moveable.
+  Value(const Value<T>& other) = delete;
+  Value& operator=(const Value<T>& other) = delete;
   Value(Value<T>&& other) = delete;
   Value& operator=(Value<T>&& other) = delete;
 
   std::unique_ptr<AbstractValue> Clone() const override {
-    return std::make_unique<Value<T>>(*this);
+    return std::make_unique<Value<T>>(get_value());
   }
 
   void SetFrom(const AbstractValue& other) override {


### PR DESCRIPTION
In the presence of subclassing, only Clone() can be correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4810)
<!-- Reviewable:end -->
