### PR TITLE
Use drake_copyable in automotive

### DIFF
--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -9,6 +9,7 @@
 #include "drake/automotive/simple_car.h"
 #include "drake/automotive/simple_car_to_euler_floating_joint.h"
 #include "drake/automotive/trajectory_car.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/analysis/simulator.h"
@@ -29,6 +30,8 @@ namespace automotive {
 template <typename T>
 class AutomotiveSimulator {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AutomotiveSimulator)
+
   /// A constructor that configures this object to use DrakeLcm, which
   /// encapsulates a _real_ LCM instance.
   AutomotiveSimulator();
@@ -133,10 +136,6 @@ class AutomotiveSimulator {
 
   /// Advance simulated time by the given @p time_step increment in seconds.
   void StepBy(const T& time_step);
-
-  // We are neither copyable nor moveable.
-  AutomotiveSimulator(const AutomotiveSimulator<T>& other) = delete;
-  AutomotiveSimulator& operator=(const AutomotiveSimulator<T>& other) = delete;
 
  private:
   int allocate_vehicle_number();

--- a/drake/automotive/curve2.h
+++ b/drake/automotive/curve2.h
@@ -7,6 +7,8 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_copyable.h"
+
 namespace drake {
 namespace automotive {
 
@@ -22,6 +24,8 @@ namespace automotive {
 template <typename T>
 class Curve2 {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Curve2)
+
   /// A two-dimensional Cartesian point that is alignment-safe.
   typedef Eigen::Matrix<T, 2, 1, Eigen::DontAlign> Point2;
 
@@ -33,10 +37,6 @@ class Curve2 {
     // waypoints (derivative problems); this will probably come for
     // free as part of the spline refactoring.
   }
-
-  // Copyable.
-  Curve2(const Curve2&) = default;
-  Curve2& operator=(const Curve2&) = default;
 
   /// @return the length of this curve (the total distance traced).
   T path_length() const { return path_length_; }
@@ -125,8 +125,8 @@ class Curve2 {
     return result;
   }
 
-  const std::vector<Point2> waypoints_;
-  const T path_length_;
+  std::vector<Point2> waypoints_;
+  T path_length_;
 };
 
 }  // namespace automotive

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -31,6 +32,8 @@ namespace automotive {
 template <typename T>
 class IdmPlanner : public systems::LeafSystem<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IdmPlanner)
+
   /// @p v_ref desired velocity of the ego car in units of m/s.
   explicit IdmPlanner(const T& v_ref);
   ~IdmPlanner() override;
@@ -50,12 +53,6 @@ class IdmPlanner : public systems::LeafSystem<T> {
 
   void SetDefaultParameters(const systems::LeafContext<T>& context,
                             systems::Parameters<T>* params) const override;
-
-  // Disable copy and assignment.
-  IdmPlanner(const IdmPlanner<T>&) = delete;
-  IdmPlanner& operator=(const IdmPlanner<T>&) = delete;
-  IdmPlanner(IdmPlanner<T>&&) = delete;
-  IdmPlanner& operator=(IdmPlanner<T>&&) = delete;
 
  private:
   void DoCalcOutput(const systems::Context<T>& context,

--- a/drake/automotive/linear_car.h
+++ b/drake/automotive/linear_car.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -25,6 +26,8 @@ namespace automotive {
 template <typename T>
 class LinearCar : public systems::LeafSystem<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearCar)
+
   /// @p x_init initial position.
   /// @p v_init initial velocity.
   explicit LinearCar(const T& x_init, const T& v_init);
@@ -43,12 +46,6 @@ class LinearCar : public systems::LeafSystem<T> {
   // System<T> overrides.
   // Declare that the outputs are all algebraically isolated from the input.
   bool has_any_direct_feedthrough() const override { return false; }
-
-  // Disable copy and assignment.
-  LinearCar(const LinearCar<T>&) = delete;
-  LinearCar& operator=(const LinearCar<T>&) = delete;
-  LinearCar(LinearCar<T>&&) = delete;
-  LinearCar& operator=(LinearCar<T>&&) = delete;
 
  private:
   void DoCalcOutput(const systems::Context<T>& context,

--- a/drake/automotive/maliput/api/branch_point.h
+++ b/drake/automotive/maliput/api/branch_point.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "drake/automotive/maliput/api/lane_data.h"
-
 #include <memory>
 #include <string>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -24,7 +25,9 @@ class LaneEndSet {
   // E.g., it could very well be a view into a database or tiled storage or
   // something.
  public:
-  virtual ~LaneEndSet() {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LaneEndSet)
+
+  virtual ~LaneEndSet() = default;
 
   /// Returns the number of LaneEnds in this set.
   ///
@@ -36,15 +39,8 @@ class LaneEndSet {
   /// @pre @p index must be >= 0 and < size().
   const LaneEnd& get(int index) const { return do_get(index); }
 
-  /// @name Deleted Copy/Move Operations
-  /// LaneEndSet is neither copyable nor moveable.
-  ///@{
-  explicit LaneEndSet(const LaneEndSet&) = delete;
-  LaneEndSet& operator=(const LaneEndSet&) = delete;
-  ///@}
-
  protected:
-  LaneEndSet() {}
+  LaneEndSet() = default;
 
  private:
   /// @name NVI implementations of the public methods.
@@ -69,7 +65,9 @@ class LaneEndSet {
 /// to those of LaneEnds on the other side.
 class BranchPoint {
  public:
-  virtual ~BranchPoint() {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BranchPoint)
+
+  virtual ~BranchPoint() = default;
 
   /// Returns the persistent identifier.
   const BranchPointId id() const { return do_id(); }
@@ -116,15 +114,8 @@ class BranchPoint {
   /// Returns the set of LaneEnds grouped together on the "B-side".
   const LaneEndSet* GetBSide() const { return DoGetBSide(); }
 
-  /// @name Deleted Copy/Move Operations
-  /// BranchPoint is neither copyable nor moveable.
-  ///@{
-  explicit BranchPoint(const BranchPoint&) = delete;
-  BranchPoint& operator=(const BranchPoint&) = delete;
-  ///@}
-
  protected:
-  BranchPoint() {}
+  BranchPoint() = default;
 
  private:
   /// @name NVI implementations of the public methods.

--- a/drake/automotive/maliput/api/junction.h
+++ b/drake/automotive/maliput/api/junction.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "drake/common/drake_copyable.h"
+
 namespace drake {
 namespace maliput {
 namespace api {
@@ -25,7 +27,9 @@ struct JunctionId {
 /// Junctions are grouped by RoadGeometry.
 class Junction {
  public:
-  virtual ~Junction() {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Junction)
+
+  virtual ~Junction() = default;
 
   /// Returns the persistent identifier.
   const JunctionId id() const { return do_id(); }
@@ -43,15 +47,8 @@ class Junction {
   /// @pre @p index must be >= 0 and < num_segments().
   const Segment* segment(int index) const { return do_segment(index); }
 
-  /// @name Deleted Copy/Move Operations
-  /// Junction is neither copyable nor moveable.
-  ///@{
-  explicit Junction(const Junction&) = delete;
-  Junction& operator=(const Junction&) = delete;
-  ///@}
-
  protected:
-  Junction() {}
+  Junction() = default;
 
  private:
   /// @name NVI implementations of the public methods.

--- a/drake/automotive/maliput/api/lane.h
+++ b/drake/automotive/maliput/api/lane.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "drake/automotive/maliput/api/lane_data.h"
-
 #include <memory>
 #include <string>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -31,7 +32,9 @@ struct LaneId {
 /// parameterizations (e.g., each Lane has its own reference curve).
 class Lane {
  public:
-  virtual ~Lane() {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Lane)
+
+  virtual ~Lane() = default;
 
   /// Returns the persistent identifier.
   const LaneId id() const { return do_id(); }
@@ -155,15 +158,8 @@ class Lane {
     return DoGetDefaultBranch(which_end);
   }
 
-  /// @name Deleted Copy/Move Operations
-  /// Lane is neither copyable nor moveable.
-  ///@{
-  explicit Lane(const Lane&) = delete;
-  Lane& operator=(const Lane&) = delete;
-  ///@}
-
  protected:
-  Lane() {}
+  Lane() = default;
 
  private:
   /// @name NVI implementations of the public methods.

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -30,7 +30,7 @@ struct LaneEnd {
   };
 
   /// Default constructor.
-  LaneEnd() {}
+  LaneEnd() = default;
 
   /// Construct a LaneEnd specifying the @p end of @p lane.
   LaneEnd(const Lane* _lane, Which _end) : lane(_lane), end(_end) {}
@@ -44,7 +44,7 @@ struct LaneEnd {
 /// by pitch around Y, followed by yaw around Z.
 struct Rotation {
   /// Default constructor.
-  Rotation() {}
+  Rotation() = default;
 
   /// Fully parameterized constructor.
   Rotation(double _roll, double _pitch, double _yaw)
@@ -59,7 +59,7 @@ struct Rotation {
 /// A position in 3-dimensional geographical Cartesian space.
 struct GeoPosition {
   /// Default constructor.
-  GeoPosition() {}
+  GeoPosition() = default;
 
   /// Fully parameterized constructor.
   GeoPosition(double _x, double _y, double _z) : x(_x), y(_y), z(_z) {}
@@ -76,7 +76,7 @@ struct GeoPosition {
 ///  * h is height above the road surface.
 struct LanePosition {
   /// Default constructor.
-  LanePosition() {}
+  LanePosition() = default;
 
   /// Fully parameterized constructor.
   LanePosition(double _s, double _r, double _h) : s(_s), r(_r), h(_h) {}
@@ -97,7 +97,7 @@ struct LanePosition {
 /// with an orientation relative to the road surface).
 struct IsoLaneVelocity {
   /// Default constructor.
-  IsoLaneVelocity() {}
+  IsoLaneVelocity() = default;
 
   /// Fully parameterized constructor.
   IsoLaneVelocity(double _sigma_v, double _rho_v, double _eta_v)
@@ -113,7 +113,7 @@ struct IsoLaneVelocity {
 /// Lane and a LANE-space position on that Lane.
 struct RoadPosition {
   /// Default constructor.
-  RoadPosition() {}
+  RoadPosition() = default;
 
   /// Fully parameterized constructor.
   RoadPosition(const Lane* _lane, const LanePosition& _pos)
@@ -129,7 +129,7 @@ struct RoadPosition {
 /// i.e., the minimum must be <= 0 and the maximum must be >= 0.
 struct RBounds {
   /// Default constructor.
-  RBounds() {}
+  RBounds() = default;
 
   /// Fully parameterized constructor.
   RBounds(double rmin, double rmax) : r_min(rmin), r_max(rmax) {

--- a/drake/automotive/maliput/api/road_geometry.h
+++ b/drake/automotive/maliput/api/road_geometry.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "drake/automotive/maliput/api/lane_data.h"
-
 #include <string>
 #include <vector>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -25,7 +26,9 @@ struct RoadGeometryId {
 //                          scalar type T like everything else in drake.
 class RoadGeometry {
  public:
-  virtual ~RoadGeometry() {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadGeometry)
+
+  virtual ~RoadGeometry() = default;
 
   /// Returns the persistent identifier.
   ///
@@ -88,15 +91,8 @@ class RoadGeometry {
   /// Return value with size() == 0 indicates success.
   std::vector<std::string> CheckInvariants() const;
 
-  /// @name Deleted Copy/Move Operations
-  /// RoadGeometry is neither copyable nor moveable.
-  ///@{
-  explicit RoadGeometry(const RoadGeometry&) = delete;
-  RoadGeometry& operator=(const RoadGeometry&) = delete;
-  ///@}
-
  protected:
-  RoadGeometry() {}
+  RoadGeometry() = default;
 
  private:
   /// @name NVI implementations of the public methods.

--- a/drake/automotive/maliput/api/segment.h
+++ b/drake/automotive/maliput/api/segment.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "drake/common/drake_copyable.h"
+
 namespace drake {
 namespace maliput {
 namespace api {
@@ -25,7 +27,9 @@ struct SegmentId {
 /// Segments are grouped by Junction.
 class Segment {
  public:
-  virtual ~Segment() {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Segment)
+
+  virtual ~Segment() = default;
 
   /// Returns the persistent identifier.
   const SegmentId id() const { return do_id(); }
@@ -48,15 +52,8 @@ class Segment {
   //                         implementation.
   const Lane* lane(int index) const { return do_lane(index); }
 
-  /// @name Deleted Copy/Move Operations
-  /// Segment is neither copyable nor moveable.
-  ///@{
-  explicit Segment(const Segment&) = delete;
-  Segment& operator=(const Segment&) = delete;
-  ///@}
-
  protected:
-  Segment() {}
+  Segment() = default;
 
  private:
   /// @name NVI implementations of the public methods.

--- a/drake/automotive/maliput/monolane/arc_lane.h
+++ b/drake/automotive/maliput/monolane/arc_lane.h
@@ -4,6 +4,7 @@
 
 #include "drake/automotive/maliput/monolane/lane.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -13,6 +14,8 @@ namespace monolane {
 /// in the xy-plane (the ground plane) of the world frame.
 class ArcLane : public Lane {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ArcLane)
+
   /// Constructs an ArcLane, specified by a circular arc defined in the
   /// xy-plane (the ground plane) of the world frame.
   ///
@@ -33,7 +36,7 @@ class ArcLane : public Lane {
           const CubicPolynomial& elevation,
           const CubicPolynomial& superelevation);
 
-  virtual ~ArcLane() {}
+  ~ArcLane() override = default;
 
  private:
   api::LanePosition DoToLanePosition(

--- a/drake/automotive/maliput/monolane/branch_point.h
+++ b/drake/automotive/maliput/monolane/branch_point.h
@@ -7,6 +7,7 @@
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -20,10 +21,13 @@ class RoadGeometry;
 /// An implementation of LaneEndSet.
 class LaneEndSet : public api::LaneEndSet {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LaneEndSet)
+
+  LaneEndSet() = default;
+  ~LaneEndSet() override = default;
+
   /// Adds a LaneEnd.
   void add(const api::LaneEnd& end) { ends_.push_back(end); }
-
-  virtual ~LaneEndSet() {}
 
  private:
   int do_size() const override { return ends_.size(); }
@@ -37,6 +41,8 @@ class LaneEndSet : public api::LaneEndSet {
 /// An implementation of api::BranchPoint.
 class BranchPoint : public api::BranchPoint {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BranchPoint)
+
   /// Constructs an empty BranchPoint.
   ///
   /// @p road_geometry must remain valid for the lifetime of this class.
@@ -54,7 +60,7 @@ class BranchPoint : public api::BranchPoint {
   void SetDefault(const api::LaneEnd& lane_end,
                   const api::LaneEnd& default_branch);
 
-  virtual ~BranchPoint() {}
+  ~BranchPoint() override = default;
 
  private:
   const api::BranchPointId do_id() const override { return id_; }

--- a/drake/automotive/maliput/monolane/builder.h
+++ b/drake/automotive/maliput/monolane/builder.h
@@ -10,8 +10,8 @@
 
 #include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/monolane/junction.h"
-
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -57,8 +57,10 @@ namespace monolane {
 ///  - heading: heading of reference path (radians, zero == x-direction)
 class EndpointXy {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(EndpointXy)
+
   // Constructs an EndpointXy with all zero parameters.
-  EndpointXy() {}
+  EndpointXy() = default;
 
   EndpointXy(double x, double y, double heading)
       :x_(x), y_(y), heading_(heading) {}
@@ -95,8 +97,10 @@ class EndpointXy {
 ///               of the reference path
 class EndpointZ {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(EndpointZ)
+
   // Constructs an EndpointZ with all zero parameters.
-  EndpointZ() {}
+  EndpointZ() = default;
 
   EndpointZ(double z, double z_dot, double theta, double theta_dot)
       : z_(z), z_dot_(z_dot), theta_(theta), theta_dot_(theta_dot) {}
@@ -129,8 +133,10 @@ class EndpointZ {
 /// out-of-plane aspects of an endpoint.
 class Endpoint {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Endpoint)
+
   // Constructs an Endpoint with all zero parameters.
-  Endpoint() {}
+  Endpoint() = default;
 
   Endpoint(const EndpointXy& xy, const EndpointZ& z) : xy_(xy), z_(z) {}
 
@@ -159,8 +165,10 @@ class Endpoint {
 ///    * d_theta < 0 is clockwise ('veer to right')
 class ArcOffset {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ArcOffset)
+
   /// Constructs an ArcOffset with all zero parameters.
-  ArcOffset() {}
+  ArcOffset() = default;
 
   ArcOffset(double radius, double d_theta)
       : radius_(radius), d_theta_(d_theta) {
@@ -191,6 +199,8 @@ class ArcOffset {
 /// of the endpoints.
 class Connection {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Connection)
+
   /// Possible connection geometries:  line- or arc-segment.
   enum Type { kLine, kArc };
 
@@ -248,13 +258,6 @@ class Connection {
     return d_theta_;
   }
 
-  /// @name Deleted Copy/Move Operations
-  /// Connection is neither copyable nor moveable.
-  ///@{
-  explicit Connection(const Connection&) = delete;
-  Connection& operator=(const Connection&) = delete;
-  ///@}
-
  private:
   Type type_{};
   std::string id_;
@@ -275,6 +278,8 @@ class Connection {
 /// corresponding Segments specified by all the Connections in the Group.
 class Group {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Group)
+
   /// Constructs an empty Group with the specified @p id.
   explicit Group(const std::string& id) : id_(id) {}
 
@@ -297,13 +302,6 @@ class Group {
     return connections_;
   }
 
-  /// @name Deleted Copy/Move Operations
-  /// Group is neither copyable nor moveable.
-  ///@{
-  explicit Group(const Group&) = delete;
-  Group& operator=(const Group&) = delete;
-  ///@}
-
  private:
   std::string id_;
   std::set<const Connection*> connections_;
@@ -313,6 +311,8 @@ class Group {
 // N.B. The Builder class overview documentation lives at the top of this file.
 class Builder {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Builder)
+
   /// Constructs a Builder which can be used to specify and assemble a
   /// monolane implementation of an api::RoadGeometry.
   ///
@@ -367,13 +367,6 @@ class Builder {
   std::unique_ptr<const api::RoadGeometry> Build(
       const api::RoadGeometryId& id) const;
 
-  /// @name Deleted Copy/Move Operations
-  /// Builder is neither copyable nor moveable.
-  ///@{
-  explicit Builder(const Builder&) = delete;
-  Builder& operator=(const Builder&) = delete;
-  ///@}
-
  private:
   // EndpointFuzzyOrder is an arbitrary strict complete ordering of Endpoints
   // useful for, e.g., std::map.  It provides a comparison operation that
@@ -385,6 +378,8 @@ class Builder {
   // would not be robust given the use of floating-point values in Endpoints.
   class EndpointFuzzyOrder {
    public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(EndpointFuzzyOrder)
+
     explicit EndpointFuzzyOrder(const double linear_tolerance)
         : lin_tol_(linear_tolerance) {}
 
@@ -422,11 +417,11 @@ class Builder {
       }
     }
 
-    const double lin_tol_{};
+    double lin_tol_{};
   };
 
   struct DefaultBranch {
-    DefaultBranch() {}
+    DefaultBranch() = default;
 
     DefaultBranch(
         const Connection* ain, const api::LaneEnd::Which ain_end,

--- a/drake/automotive/maliput/monolane/junction.h
+++ b/drake/automotive/maliput/monolane/junction.h
@@ -7,6 +7,7 @@
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/automotive/maliput/monolane/segment.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -17,6 +18,8 @@ class RoadGeometry;
 /// An api::Junction implementation.
 class Junction : public api::Junction {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Junction)
+
   /// Constructs an empty Junction.
   ///
   /// @p road_geometry must remain valid for the lifetime of this class,
@@ -28,7 +31,7 @@ class Junction : public api::Junction {
   /// Creates and adds a new Segment with the specified @p id.
   Segment* NewSegment(api::SegmentId id);
 
-  virtual ~Junction() {}
+  ~Junction() override = default;
 
  private:
   const api::JunctionId do_id() const override { return id_; }

--- a/drake/automotive/maliput/monolane/lane.h
+++ b/drake/automotive/maliput/monolane/lane.h
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/segment.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
 
@@ -28,6 +29,8 @@ typedef Vector3<double> V3;
 ///   Rot3(yaw,pitch,roll) * V = RotZ(yaw) * RotY(pitch) * RotX(roll) * V
 class Rot3 {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Rot3)
+
   Rot3(double roll, double pitch, double yaw) : rpy_(roll, pitch, yaw) {}
 
   /// Applies the rotation to a 3-vector.
@@ -45,6 +48,8 @@ class Rot3 {
 /// A cubic polynomial, f(p) = a + b*p + c*p^2 + d*p^3.
 class CubicPolynomial {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CubicPolynomial)
+
   /// Default constructor, all zero coefficients.
   CubicPolynomial() : CubicPolynomial(0., 0., 0., 0.) {}
 
@@ -119,6 +124,8 @@ class CubicPolynomial {
 /// Base class for the monolane implementation of api::Lane.
 class Lane : public api::Lane {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Lane)
+
   /// Constructs a Lane.
   ///
   /// @param id the ID
@@ -194,7 +201,7 @@ class Lane : public api::Lane {
 
   BranchPoint* end_bp() { return end_bp_; }
 
-  virtual ~Lane() {}
+  ~Lane() override = default;
 
  private:
   const api::LaneId do_id() const override { return id_; }

--- a/drake/automotive/maliput/monolane/line_lane.h
+++ b/drake/automotive/maliput/monolane/line_lane.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/automotive/maliput/monolane/lane.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -10,6 +11,8 @@ namespace monolane {
 /// in the xy-plane (the ground plane) of the world frame.
 class LineLane : public Lane {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LineLane)
+
   /// Constructs a LineLane, a lane specified by a line segment defined in the
   /// xy-plane (the ground plane) of the world frame.
   ///
@@ -34,7 +37,7 @@ class LineLane : public Lane {
         dy_(dxy.y()),
         heading_(std::atan2(dy_, dx_)) {}
 
-  virtual ~LineLane() {}
+  ~LineLane() override = default;
 
  private:
   api::LanePosition DoToLanePosition(

--- a/drake/automotive/maliput/monolane/road_geometry.h
+++ b/drake/automotive/maliput/monolane/road_geometry.h
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/monolane/branch_point.h"
 #include "drake/automotive/maliput/monolane/junction.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -18,6 +19,8 @@ namespace monolane {
 /// a sensible road network.
 class RoadGeometry : public api::RoadGeometry {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadGeometry)
+
   /// Constructs an empty RoadGeometry with the specified tolerances.
   RoadGeometry(const api::RoadGeometryId& id,
                const double linear_tolerance,
@@ -32,7 +35,7 @@ class RoadGeometry : public api::RoadGeometry {
   /// Creates and adds a new BranchPoint with the specified @p id.
   BranchPoint* NewBranchPoint(api::BranchPointId id);
 
-  virtual ~RoadGeometry() {}
+  ~RoadGeometry() override = default;
 
  private:
   const api::RoadGeometryId do_id() const override { return id_; }

--- a/drake/automotive/maliput/monolane/segment.h
+++ b/drake/automotive/maliput/monolane/segment.h
@@ -6,6 +6,7 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/automotive/maliput/monolane/lane.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace maliput {
@@ -18,6 +19,8 @@ class LineLane;
 /// An api::Segment implementation.
 class Segment : public api::Segment {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Segment)
+
   /// Constructs a new Segment.
   ///
   /// The Segment is not fully initialized until one of NewLineLane()
@@ -43,7 +46,7 @@ class Segment : public api::Segment {
                       const CubicPolynomial& elevation,
                       const CubicPolynomial& superelevation);
 
-  virtual ~Segment() {}
+  ~Segment() override = default;
 
  private:
   const api::SegmentId do_id() const override { return id_; }

--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -5,6 +5,7 @@
 #include "drake/automotive/gen/driving_command.h"
 #include "drake/automotive/gen/simple_car_config.h"
 #include "drake/automotive/gen/simple_car_state.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -45,6 +46,8 @@ namespace automotive {
 template <typename T>
 class SimpleCar : public systems::LeafSystem<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimpleCar)
+
   explicit SimpleCar(const SimpleCarConfig<T>& config = get_default_config());
 
   static SimpleCarConfig<T> get_default_config();

--- a/drake/automotive/simple_car_to_euler_floating_joint.h
+++ b/drake/automotive/simple_car_to_euler_floating_joint.h
@@ -4,6 +4,7 @@
 
 #include "drake/automotive/gen/euler_floating_joint_state.h"
 #include "drake/automotive/gen/simple_car_state.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -13,6 +14,8 @@ namespace automotive {
 template <typename T>
 class SimpleCarToEulerFloatingJoint : public systems::LeafSystem<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimpleCarToEulerFloatingJoint)
+
   SimpleCarToEulerFloatingJoint() {
     this->set_name("SimpleCarToEulerFloatingJoint");
     this->DeclareInputPort(systems::kVectorValued,

--- a/drake/automotive/single_lane_ego_and_agent.h
+++ b/drake/automotive/single_lane_ego_and_agent.h
@@ -4,6 +4,7 @@
 
 #include "drake/automotive/idm_planner.h"
 #include "drake/automotive/linear_car.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/primitives/constant_vector_source.h"
@@ -44,6 +45,8 @@ namespace automotive {
 template <typename T>
 class SingleLaneEgoAndAgent : public systems::Diagram<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SingleLaneEgoAndAgent)
+
   /// Constructs a two-car system.
   ///
   /// @p v_ref desired velocity of the ego (controlled) car.
@@ -52,18 +55,12 @@ class SingleLaneEgoAndAgent : public systems::Diagram<T> {
                         const T& x_agent_init, const T& v_agent_init,
                         const T& v_ref, const T& a_agent);
 
-  ~SingleLaneEgoAndAgent() override {}
+  ~SingleLaneEgoAndAgent() override = default;
 
   /// Getters for the ego and agent car systems.
   const LinearCar<T>* get_ego_car_system() const { return ego_car_; }
   const LinearCar<T>* get_agent_car_system() const { return agent_car_; }
   const IdmPlanner<T>* get_planner_system() const { return planner_; }
-
-  // Disable copy and assignment.
-  SingleLaneEgoAndAgent(const SingleLaneEgoAndAgent<T>&) = delete;
-  SingleLaneEgoAndAgent& operator=(const SingleLaneEgoAndAgent<T>&) = delete;
-  SingleLaneEgoAndAgent(SingleLaneEgoAndAgent<T>&&) = delete;
-  SingleLaneEgoAndAgent& operator=(SingleLaneEgoAndAgent<T>&&) = delete;
 
  private:
   const LinearCar<T>* ego_car_ = nullptr;

--- a/drake/automotive/trajectory_car.h
+++ b/drake/automotive/trajectory_car.h
@@ -6,6 +6,7 @@
 #include "drake/automotive/curve2.h"
 #include "drake/automotive/gen/driving_command.h"
 #include "drake/automotive/gen/simple_car_state.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -29,6 +30,8 @@ namespace automotive {
 template <typename T>
 class TrajectoryCar : public systems::LeafSystem<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectoryCar)
+
   /// Constructs a TrajectoryCar system that traces the given @p curve,
   /// at the given constant @p speed, starting at the given @p start_time.
   /// Throws an error if the curve is empty (a zero @p path_length).


### PR DESCRIPTION
Big picture:
 1. All `class`es declare copy or no-copy, as first thing after `public:`.
 2. For `structs`, we implicitly presume default copy.
 3. All subclasses declare dtor `override`s, not just `virtual`.
 4. Trivial ctors / dtors are marked `= default` instead of `{}` to keep them trivially-{con,de}destructible, which is sometimes helpful to the compiler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4826)
<!-- Reviewable:end -->
