### PR TITLE
Run clang-format on drake/common

### DIFF
--- a/drake/common/autodiff_overloads.h
+++ b/drake/common/autodiff_overloads.h
@@ -26,8 +26,8 @@
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/cond.h"
-#include "drake/common/dummy_value.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/dummy_value.h"
 
 namespace Eigen {
 

--- a/drake/common/cond.h
+++ b/drake/common/cond.h
@@ -32,7 +32,7 @@ ScalarType cond(const ScalarType& e) {
   return e;
 }
 template <typename ScalarType, typename... Rest>
-ScalarType cond(const decltype(ScalarType() < ScalarType()) & f_cond,
+ScalarType cond(const decltype(ScalarType() < ScalarType())& f_cond,
                 const ScalarType& e_then, Rest... rest) {
   return if_then_else(f_cond, e_then, cond(rest...));
 }

--- a/drake/common/drake_assert.cc
+++ b/drake/common/drake_assert.cc
@@ -8,7 +8,7 @@ namespace detail {
 
 void Abort(const char* condition, const char* func, const char* file,
            int line) {
-  std::cerr << "abort: failure at " << file << ":" << line
+  std::cerr << "abort: failure at " << file << ":" << line  // BR
             << " in " << func << "()";
   if (condition) {
     std::cerr << ": assertion '" << condition << "' failed.";

--- a/drake/common/drake_assert.h
+++ b/drake/common/drake_assert.h
@@ -50,21 +50,21 @@
 
 // Users should NOT set these; only this header should set them.
 #ifdef DRAKE_ASSERT_IS_ARMED
-# error Unexpected DRAKE_ASSERT_IS_ARMED defined.
+#error Unexpected DRAKE_ASSERT_IS_ARMED defined.
 #endif
 #ifdef DRAKE_ASSERT_IS_DISARMED
-# error Unexpected DRAKE_ASSERT_IS_DISARMED defined.
+#error Unexpected DRAKE_ASSERT_IS_DISARMED defined.
 #endif
 
 // Decide whether Drake assertions are enabled.
 #if defined(DRAKE_ENABLE_ASSERTS) && defined(DRAKE_DISABLE_ASSERTS)
-# error Conflicting assertion toggles.
+#error Conflicting assertion toggles.
 #elif defined(DRAKE_ENABLE_ASSERTS)
-# define DRAKE_ASSERT_IS_ARMED
+#define DRAKE_ASSERT_IS_ARMED
 #elif defined(DRAKE_DISABLE_ASSERTS) || defined(NDEBUG)
-# define DRAKE_ASSERT_IS_DISARMED
+#define DRAKE_ASSERT_IS_DISARMED
 #else
-# define DRAKE_ASSERT_IS_ARMED
+#define DRAKE_ASSERT_IS_ARMED
 #endif
 
 namespace drake {
@@ -82,47 +82,52 @@ namespace assert {
 template <typename Condition>
 struct ConditionTraits {
   static constexpr bool is_valid = std::is_convertible<Condition, bool>::value;
-  static bool Evaluate(const Condition& value) {
+  static bool Evaluate(const Condition& value) {  // BR
     return value;
   }
 };
 }  // namespace assert
 }  // namespace drake
 
-#define DRAKE_ABORT()                                           \
+#define DRAKE_ABORT() \
   ::drake::detail::Abort(nullptr, __func__, __FILE__, __LINE__)
 
 #define DRAKE_DEMAND(condition)                                              \
   do {                                                                       \
     typedef ::drake::assert::ConditionTraits<                                \
-        typename std::remove_cv<decltype(condition)>::type> Trait;           \
+        typename std::remove_cv<decltype(condition)>::type>                  \
+        Trait;                                                               \
     static_assert(Trait::is_valid, "Condition should be bool-convertible."); \
     if (!Trait::Evaluate(condition)) {                                       \
       ::drake::detail::Abort(#condition, __func__, __FILE__, __LINE__);      \
     }                                                                        \
   } while (0)
 
-#define DRAKE_ABORT_MSG(msg)                                    \
+#define DRAKE_ABORT_MSG(msg) \
   ::drake::detail::Abort(msg, __func__, __FILE__, __LINE__)
 
 #ifdef DRAKE_ASSERT_IS_ARMED
-// Assertions are enabled.
-# define DRAKE_ASSERT(condition) DRAKE_DEMAND(condition)
-# define DRAKE_ASSERT_VOID(expression) do {                     \
-    static_assert(                                              \
-        std::is_convertible<decltype(expression), void>::value, \
-        "Expression should be void.");                          \
-    expression;                                                 \
-  } while (0)
-#else
-// Assertions are disabled, so just typecheck the expression.
-# define DRAKE_ASSERT(condition) static_assert(                        \
-    ::drake::assert::ConditionTraits<                                  \
-        typename std::remove_cv<decltype(condition)>::type>::is_valid, \
-    "Condition should be bool-convertible.");
-# define DRAKE_ASSERT_VOID(expression) static_assert(           \
-    std::is_convertible<decltype(expression), void>::value,     \
-    "Expression should be void.")
-#endif
 
+// Assertions are enabled.
+#define DRAKE_ASSERT(condition) DRAKE_DEMAND(condition)
+#define DRAKE_ASSERT_VOID(expression)                                     \
+  do {                                                                    \
+    static_assert(std::is_convertible<decltype(expression), void>::value, \
+                  "Expression should be void.");                          \
+    expression;                                                           \
+  } while (0)
+
+#else
+
+// Assertions are disabled, so just typecheck the expression.
+#define DRAKE_ASSERT(condition)                                          \
+  static_assert(                                                         \
+      ::drake::assert::ConditionTraits<                                  \
+          typename std::remove_cv<decltype(condition)>::type>::is_valid, \
+      "Condition should be bool-convertible.");
+#define DRAKE_ASSERT_VOID(expression)                                   \
+  static_assert(std::is_convertible<decltype(expression), void>::value, \
+                "Expression should be void.")
+
+#endif  // DRAKE_ASSERT_IS_ARMED
 #endif  // DRAKE_DOXYGEN_CXX

--- a/drake/common/drake_compat.h
+++ b/drake/common/drake_compat.h
@@ -16,12 +16,12 @@
 
 namespace std {
 
-template<typename T, typename... Args>
+template <typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-template<bool B, class T = void>
+template <bool B, class T = void>
 using enable_if_t = typename enable_if<B, T>::type;
 
 }  // namespace std

--- a/drake/common/drake_copyable.h
+++ b/drake/common/drake_copyable.h
@@ -32,10 +32,10 @@ class Foo {
 };
 </pre>
 */
-#define DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Classname)      \
-  Classname(const Classname&) = delete;                 \
-  void operator=(const Classname&) = delete;            \
-  Classname(Classname&&) = delete;                      \
+#define DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Classname) \
+  Classname(const Classname&) = delete;            \
+  void operator=(const Classname&) = delete;       \
+  Classname(Classname&&) = delete;                 \
   void operator=(Classname&&) = delete;
 
 /** DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN defaults the special member
@@ -56,13 +56,13 @@ class Foo {
 };
 </pre>
 */
-#define DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Classname)       \
-  Classname(const Classname&) = default;                        \
-  Classname& operator=(const Classname&) = default;             \
-  Classname(Classname&&) = default;                             \
-  Classname& operator=(Classname&&) = default;                  \
-  /* Fails at compile-time if default-copy doesn't work. */     \
-  static void DRAKE_COPYABLE_DEMAND_COPY_CAN_COMPILE() {        \
-    (void) static_cast<Classname& (Classname::*)(               \
-        const Classname&)>(&Classname::operator=);              \
+#define DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Classname)           \
+  Classname(const Classname&) = default;                            \
+  Classname& operator=(const Classname&) = default;                 \
+  Classname(Classname&&) = default;                                 \
+  Classname& operator=(Classname&&) = default;                      \
+  /* Fails at compile-time if default-copy doesn't work. */         \
+  static void DRAKE_COPYABLE_DEMAND_COPY_CAN_COMPILE() {            \
+    (void)static_cast<Classname& (Classname::*)(const Classname&)>( \
+        &Classname::operator=);                                     \
   }

--- a/drake/common/drake_deprecated.h
+++ b/drake/common/drake_deprecated.h
@@ -37,16 +37,16 @@ C++14-compliant compiler. **/
 /* C++14 introduces a standard way to mark deprecated declarations. Before
 that we can use non-standard compiler hacks. */
 #ifndef SWIG
-  /* Figure out the best form of deprecation for this compiler. */
-  #if __cplusplus >= 201402L
-    /* C++14 */
-    #define DRAKE_DEPRECATED(MSG) [[deprecated("\nDRAKE DEPRECATED: " MSG)]]
-  #else /* gcc or clang */
-    #define DRAKE_DEPRECATED(MSG) \
-      __attribute__((deprecated("\nDRAKE DEPRECATED: " MSG)))
-  #endif
+/* Figure out the best form of deprecation for this compiler. */
+#if __cplusplus >= 201402L
+/* C++14 */
+#define DRAKE_DEPRECATED(MSG) [[deprecated("\nDRAKE DEPRECATED: " MSG)]]
+#else /* gcc or clang */
+#define DRAKE_DEPRECATED(MSG) \
+  __attribute__((deprecated("\nDRAKE DEPRECATED: " MSG)))
+#endif
 #else /* Swigging */
-  #define DRAKE_DEPRECATED(MSG)
+#define DRAKE_DEPRECATED(MSG)
 #endif
 
 #endif  // DRAKE_DOXYGEN_CXX

--- a/drake/common/drake_path.cc.in
+++ b/drake/common/drake_path.cc.in
@@ -4,12 +4,8 @@
 
 namespace drake {
 
-std::string GetDrakePath() {
-  return std::string("@PROJECT_SOURCE_DIR@");
-}
+std::string GetDrakePath() { return std::string("@PROJECT_SOURCE_DIR@"); }
 
-std::string getDrakePath() {
-  return GetDrakePath();
-}
+std::string getDrakePath() { return GetDrakePath(); }
 
 }  // namespace drake

--- a/drake/common/drake_throw.cc
+++ b/drake/common/drake_throw.cc
@@ -1,7 +1,7 @@
 #include "drake/common/drake_throw.h"
 
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 
 namespace drake {
 namespace detail {
@@ -9,9 +9,8 @@ namespace detail {
 void Throw(const char* condition, const char* func, const char* file,
            int line) {
   std::stringstream message;
-  message
-      << "Failure at " << file << ":" << line << " in " << func << "(): "
-      << "condition '" << condition << "' failed.";
+  message << "Failure at " << file << ":" << line << " in " << func << "(): "
+          << "condition '" << condition << "' failed.";
   throw std::runtime_error(message.str());
 }
 

--- a/drake/common/drake_throw.h
+++ b/drake/common/drake_throw.h
@@ -22,7 +22,8 @@ void Throw(const char* condition, const char* func, const char* file, int line);
 #define DRAKE_THROW_UNLESS(condition)                                        \
   do {                                                                       \
     typedef ::drake::assert::ConditionTraits<                                \
-        typename std::remove_cv<decltype(condition)>::type> Trait;           \
+        typename std::remove_cv<decltype(condition)>::type>                  \
+        Trait;                                                               \
     static_assert(Trait::is_valid, "Condition should be bool-convertible."); \
     if (!Trait::Evaluate(condition)) {                                       \
       ::drake::detail::Throw(#condition, __func__, __FILE__, __LINE__);      \

--- a/drake/common/eigen_autodiff_types.h
+++ b/drake/common/eigen_autodiff_types.h
@@ -25,7 +25,7 @@ using AutoDiffXd = Eigen::AutoDiffScalar<Eigen::VectorXd>;
 // note: tried using template default values (e.g. Eigen::Dynamic), but they
 // didn't seem to work on my mac clang
 template <int num_vars>
-using TaylorVard = Eigen::AutoDiffScalar<Eigen::Matrix<double, num_vars, 1> >;
+using TaylorVard = Eigen::AutoDiffScalar<Eigen::Matrix<double, num_vars, 1>>;
 template <int num_vars, int rows>
 using TaylorVecd = Eigen::Matrix<TaylorVard<num_vars>, rows, 1>;
 template <int num_vars, int rows, int cols>

--- a/drake/common/functional_form.h
+++ b/drake/common/functional_form.h
@@ -619,7 +619,7 @@ typename std::enable_if<
         std::is_same<typename MatrixL::Scalar, FunctionalForm>::value &&
         std::is_same<typename MatrixR::Scalar, double>::value,
     Eigen::Matrix<FunctionalForm, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
+                  MatrixR::ColsAtCompileTime>>::type
 operator*(MatrixL const& lhs, MatrixR const& rhs) {
   return lhs * rhs.template cast<FunctionalForm>();
 }
@@ -635,7 +635,7 @@ typename std::enable_if<
         std::is_same<typename MatrixL::Scalar, double>::value &&
         std::is_same<typename MatrixR::Scalar, FunctionalForm>::value,
     Eigen::Matrix<FunctionalForm, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
+                  MatrixR::ColsAtCompileTime>>::type
 operator*(MatrixL const& lhs, MatrixR const& rhs) {
   return lhs.template cast<FunctionalForm>() * rhs;
 }
@@ -734,11 +734,9 @@ struct NumTraits<drake::FunctionalForm> {
     MulCost = 1
   };
 
-  template<bool Vectorized>
+  template <bool Vectorized>
   struct Div {
-    enum {
-      Cost = 1
-    };
+    enum { Cost = 1 };
   };
 
   typedef drake::FunctionalForm Real;

--- a/drake/common/is_approx_equal_abstol.h
+++ b/drake/common/is_approx_equal_abstol.h
@@ -15,10 +15,9 @@ template <typename DerivedA, typename DerivedB>
 bool is_approx_equal_abstol(const Eigen::MatrixBase<DerivedA>& m1,
                             const Eigen::MatrixBase<DerivedB>& m2,
                             double tolerance) {
-  return (
-      (m1.rows() == m2.rows()) &&
-      (m1.cols() == m2.cols()) &&
-      ((m1 - m2).template lpNorm<Eigen::Infinity>() <= tolerance));
+  return ((m1.rows() == m2.rows()) &&  // BR
+          (m1.cols() == m2.cols()) &&  // BR
+          ((m1 - m2).template lpNorm<Eigen::Infinity>() <= tolerance));
 }
 
 /// Returns true if and only if a simple greedy search reveals a permutation
@@ -59,6 +58,5 @@ bool IsApproxEqualAbsTolWithPermutedColumns(
   }
   return true;
 }
-
 
 }  // namespace drake

--- a/drake/common/nice_type_name.cc
+++ b/drake/common/nice_type_name.cc
@@ -47,24 +47,24 @@ string drake::NiceTypeName::Canonicalize(const string& demangled) {
   using SPair = std::pair<std::regex, string>;
   // These are applied in this order.
   const std::array<SPair, 8> subs{{
-    // Remove unwanted keywords and following space. (\b is word boundary.)
-    SPair(std::regex("\\b(class|struct|enum|union) "), ""),
-    // Tidy up anonymous namespace.
-    SPair(std::regex("[`(]anonymous namespace[')]"), "(anonymous)"),
-    // Replace Microsoft __int64 with long long.
-    SPair(std::regex("\\b__int64\\b"), "long long"),
-    // Temporarily replace spaces we want to keep with "!". (\w is
-    // alphanumeric or underscore.)
-    SPair(std::regex("(\\w) (\\w)"), "$1!$2"),
-    SPair(std::regex(" "), ""),  // Delete unwanted spaces.
-    // Some compilers throw in extra namespaces like "__1" or "__cxx11".
-    // Delete them.
-    SPair(std::regex("\\b__[[:alnum:]_]+::"), ""),
-    SPair(std::regex("!"), " "),  // Restore wanted spaces.
-    // Recognize std::string's full name and abbreviate.
-    SPair(std::regex("\\bstd::basic_string<char,std::char_traits<char>,"
-                     "std::allocator<char>>"),
-          "std::string")
+      // Remove unwanted keywords and following space. (\b is word boundary.)
+      SPair(std::regex("\\b(class|struct|enum|union) "), ""),
+      // Tidy up anonymous namespace.
+      SPair(std::regex("[`(]anonymous namespace[')]"), "(anonymous)"),
+      // Replace Microsoft __int64 with long long.
+      SPair(std::regex("\\b__int64\\b"), "long long"),
+      // Temporarily replace spaces we want to keep with "!". (\w is
+      // alphanumeric or underscore.)
+      SPair(std::regex("(\\w) (\\w)"), "$1!$2"),
+      SPair(std::regex(" "), ""),  // Delete unwanted spaces.
+      // Some compilers throw in extra namespaces like "__1" or "__cxx11".
+      // Delete them.
+      SPair(std::regex("\\b__[[:alnum:]_]+::"), ""),
+      SPair(std::regex("!"), " "),  // Restore wanted spaces.
+      // Recognize std::string's full name and abbreviate.
+      SPair(std::regex("\\bstd::basic_string<char,std::char_traits<char>,"
+                       "std::allocator<char>>"),
+            "std::string"),
   }};
 
   string canonical(demangled);
@@ -75,4 +75,3 @@ string drake::NiceTypeName::Canonicalize(const string& demangled) {
 }
 
 }  // namespace drake
-

--- a/drake/common/polynomial.cc
+++ b/drake/common/polynomial.cc
@@ -68,12 +68,9 @@ Polynomial<CoefficientType>::Polynomial(
     typename vector<typename Polynomial<CoefficientType>::Monomial>::
         const_iterator finish) {
   is_univariate_ = true;
-  for (
-      typename vector<
-          typename Polynomial<CoefficientType>::Monomial>::const_iterator iter =
-          start;
-      iter != finish; iter++)
+  for (auto iter = start; iter != finish; iter++) {
     monomials_.push_back(*iter);
+  }
   MakeMonomialsUnique();
 }
 
@@ -134,7 +131,9 @@ Polynomial<CoefficientType>::Monomial::Factor(const Monomial& divisor) const {
   result.coefficient = coefficient / divisor.coefficient;
   for (const Term& term : terms) {
     const PowerType divisor_power = divisor.GetDegreeOf(term.var);
-    if (term.power < divisor_power) { return error; }
+    if (term.power < divisor_power) {
+      return error;
+    }
     Term new_term;
     new_term.var = term.var;
     new_term.power = term.power - divisor_power;
@@ -143,7 +142,9 @@ Polynomial<CoefficientType>::Monomial::Factor(const Monomial& divisor) const {
     }
   }
   for (const Term& divisor_term : divisor.terms) {
-    if (!GetDegreeOf(divisor_term.var)) { return error; }
+    if (!GetDegreeOf(divisor_term.var)) {
+      return error;
+    }
   }
   return result;
 }
@@ -261,8 +262,8 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
 
   for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
-    if (!iter->terms.empty() && (
-            iter->terms[0].power >= static_cast<PowerType>(derivative_order))) {
+    if (!iter->terms.empty() &&
+        (iter->terms[0].power >= static_cast<PowerType>(derivative_order))) {
       Monomial m = *iter;
       for (unsigned int k = 0; k < derivative_order;
            k++) {  // take the remaining derivatives
@@ -544,8 +545,7 @@ Polynomial<CoefficientType>::VariableNameToId(const string name,
     multiplier *= kNumNameChars + 1;
   }
   if (name_part > kMaxNamePart) {
-    throw runtime_error("name " + name +
-                        " (" + std::to_string(name_part) +
+    throw runtime_error("name " + name + " (" + std::to_string(name_part) +
                         ") exceeds max allowed");
   }
   const VarType maxId = std::numeric_limits<VarType>::max() / 2 / kMaxNamePart;
@@ -561,7 +561,7 @@ string Polynomial<CoefficientType>::IdToVariableName(const VarType id) {
                                                 // doing the trig support here
 
   unsigned int m = id / 2 / kMaxNamePart;
-  unsigned int multiplier = static_cast<unsigned int>(
+  unsigned int multiplier = static_cast<unsigned int>(  // BR
       std::pow(static_cast<double>(kNumNameChars + 1),
                static_cast<int>(kNameLength) - 1));
   char name[kNameLength + 1];

--- a/drake/common/polynomial.h
+++ b/drake/common/polynomial.h
@@ -87,7 +87,7 @@ class Polynomial {
     /// A comparison to allow std::lexicographical_compare on this class; does
     /// not reflect any sort of mathematical total order.
     bool operator<(const Monomial& other) const {
-      return ((coefficient < other.coefficient)  ||
+      return ((coefficient < other.coefficient) ||
               ((coefficient == other.coefficient) && (terms < other.terms)));
     }
 
@@ -193,12 +193,13 @@ class Polynomial {
     for (typename std::vector<Monomial>::const_iterator iter =
              monomials_.begin();
          iter != monomials_.end(); iter++) {
-      if (iter->terms.empty())
+      if (iter->terms.empty()) {
         value += iter->coefficient;
-      else
+      } else {
         value += iter->coefficient *
-                  Pow((ProductType) x,
-                      (PowerType) iter->terms[0].power);
+                 Pow(static_cast<ProductType>(x),
+                     static_cast<PowerType>(iter->terms[0].power));
+      }
     }
     return value;
   }
@@ -217,14 +218,14 @@ class Polynomial {
   typename Product<CoefficientType, T>::type EvaluateMultivariate(
       const std::map<VarType, T>& var_values) const {
     typedef typename std::remove_const<
-      typename Product<CoefficientType, T>::type>::type ProductType;
+        typename Product<CoefficientType, T>::type>::type ProductType;
     ProductType value = 0;
     for (const Monomial& monomial : monomials_) {
       ProductType monomial_value = monomial.coefficient;
       for (const Term& term : monomial.terms) {
-        monomial_value *= std::pow(
-            static_cast<ProductType>(var_values.at(term.var)),
-            term.power);
+        monomial_value *=
+            std::pow(static_cast<ProductType>(var_values.at(term.var)),  // BR
+                     term.power);
       }
       value += monomial_value;
     }

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -494,7 +494,7 @@ typename std::enable_if<
         std::is_same<typename MatrixL::Scalar, Expression>::value &&
         std::is_same<typename MatrixR::Scalar, Variable>::value,
     Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
+                  MatrixR::ColsAtCompileTime>>::type
 operator*(const MatrixL& lhs, const MatrixR& rhs) {
   return lhs * rhs.template cast<Expression>();
 }
@@ -507,7 +507,7 @@ typename std::enable_if<
         std::is_same<typename MatrixL::Scalar, Variable>::value &&
         std::is_same<typename MatrixR::Scalar, Expression>::value,
     Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
+                  MatrixR::ColsAtCompileTime>>::type
 operator*(const MatrixL& lhs, const MatrixR& rhs) {
   return lhs.template cast<Expression>() * rhs;
 }
@@ -520,7 +520,7 @@ typename std::enable_if<
         std::is_same<typename MatrixL::Scalar, Expression>::value &&
         std::is_same<typename MatrixR::Scalar, double>::value,
     Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
+                  MatrixR::ColsAtCompileTime>>::type
 operator*(const MatrixL& lhs, const MatrixR& rhs) {
   return lhs.template cast<Expression>() * rhs.template cast<Expression>();
 }
@@ -533,7 +533,7 @@ typename std::enable_if<
         std::is_same<typename MatrixL::Scalar, double>::value &&
         std::is_same<typename MatrixR::Scalar, Expression>::value,
     Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
+                  MatrixR::ColsAtCompileTime>>::type
 operator*(const MatrixL& lhs, const MatrixR& rhs) {
   return lhs.template cast<Expression>() * rhs.template cast<Expression>();
 }
@@ -546,7 +546,7 @@ typename std::enable_if<
         std::is_same<typename MatrixL::Scalar, Variable>::value &&
         std::is_same<typename MatrixR::Scalar, double>::value,
     Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
+                  MatrixR::ColsAtCompileTime>>::type
 operator*(const MatrixL& lhs, const MatrixR& rhs) {
   return lhs.template cast<Expression>() * rhs.template cast<Expression>();
 }
@@ -559,7 +559,7 @@ typename std::enable_if<
         std::is_same<typename MatrixL::Scalar, double>::value &&
         std::is_same<typename MatrixR::Scalar, Variable>::value,
     Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
+                  MatrixR::ColsAtCompileTime>>::type
 operator*(const MatrixL& lhs, const MatrixR& rhs) {
   return lhs.template cast<Expression>() * rhs.template cast<Expression>();
 }

--- a/drake/common/text_logging.h
+++ b/drake/common/text_logging.h
@@ -37,8 +37,8 @@ printed without any special handling.
 #define SPDLOG_DEBUG_ON 1
 #define SPDLOG_TRACE_ON 1
 #endif
-#include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
+#include <spdlog/spdlog.h>
 #endif
 
 #include "drake/common/drake_copyable.h"
@@ -77,12 +77,14 @@ class logger {
   template <typename... Args>
   void critical(const char* fmt, const Args&... args) {}
 
+  // clang-format off
   template <typename T> void trace(const T&) {}
   template <typename T> void debug(const T&) {}
   template <typename T> void info(const T&) {}
   template <typename T> void warn(const T&) {}
   template <typename T> void error(const T&) {}
   template <typename T> void critical(const T&) {}
+  // clang-format on
 };
 
 }  // namespace logging

--- a/drake/common/trig_poly.h
+++ b/drake/common/trig_poly.h
@@ -399,7 +399,7 @@ class TrigPoly {
         std::string var = PolyType::IdToVariableName(k_v_pair.first);
         std::string sin = PolyType::IdToVariableName(k_v_pair.second.s);
         std::string cos = PolyType::IdToVariableName(k_v_pair.second.c);
-        os << sin << "=sin(" << var << "), "
+        os << sin << "=sin(" << var << "), "  // BR
            << cos << "=cos(" << var << "), ";
       }
     }


### PR DESCRIPTION
The additional manual edits were:
- Add BR in several place to control line-wrapping
- drake_assert.h: Add whitespace; add endif comment
- polynomial.cc: Use auto
- polynomial.h: Add required braces; fix cast style

This continues the slow burn towards making clang-format our One True God.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4827)
<!-- Reviewable:end -->
