### PR TITLE
Add syntactic sugar for abstract-valued I/O.

### DIFF
--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -187,9 +187,16 @@ class Context {
   /// Returns the number of input ports.
   virtual int get_num_input_ports() const = 0;
 
-  /// Connects a FreestandingInputPort with the given @p value at the given
-  /// @p index. Asserts if @p index is out of range.
+  /// Connects a FreestandingInputPort with the given vector @p value at the
+  /// given @p index. Asserts if @p index is out of range.
   void FixInputPort(int index, std::unique_ptr<BasicVector<T>> value) {
+    SetInputPort(index,
+                 std::make_unique<FreestandingInputPort>(std::move(value)));
+  }
+
+  /// Connects a FreestandingInputPort with the given abstract @p value at the
+  /// given @p index. Asserts if @p index is out of range.
+  void FixInputPort(int index, std::unique_ptr<AbstractValue> value) {
     SetInputPort(index,
                  std::make_unique<FreestandingInputPort>(std::move(value)));
   }

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -35,9 +35,8 @@ class LeafContextTest : public ::testing::Test {
     // Input
     context_.SetNumInputPorts(kNumInputPorts);
     for (int i = 0; i < kNumInputPorts; ++i) {
-      auto port_data = std::make_unique<BasicVector<double>>(kInputSize[i]);
-      auto port = std::make_unique<FreestandingInputPort>(std::move(port_data));
-      context_.SetInputPort(i, std::move(port));
+      context_.FixInputPort(
+          i, std::make_unique<BasicVector<double>>(kInputSize[i]));
     }
 
     // Reserve a continuous state with five elements.
@@ -191,11 +190,7 @@ TEST_F(LeafContextTest, GetVectorInput) {
   context.SetNumInputPorts(2);
 
   // Add input port 0 to the context, but leave input port 1 uninitialized.
-  std::unique_ptr<BasicVector<double>> vec(new BasicVector<double>(2));
-  vec->get_mutable_value() << 5, 6;
-  std::unique_ptr<FreestandingInputPort> port(
-      new FreestandingInputPort(std::move(vec)));
-  context.SetInputPort(0, std::move(port));
+  context.FixInputPort(0, BasicVector<double>::Make({5, 6}));
 
   // Test that port 0 is retrievable.
   VectorX<double> expected(2);
@@ -211,10 +206,7 @@ TEST_F(LeafContextTest, GetAbstractInput) {
   context.SetNumInputPorts(2);
 
   // Add input port 0 to the context, but leave input port 1 uninitialized.
-  std::unique_ptr<AbstractValue> value(new Value<std::string>("foo"));
-  std::unique_ptr<FreestandingInputPort> port(
-      new FreestandingInputPort(std::move(value)));
-  context.SetInputPort(0, std::move(port));
+  context.FixInputPort(0, AbstractValue::Make<std::string>("foo"));
 
   // Test that port 0 is retrievable.
   EXPECT_EQ("foo", *ReadStringInputPort(context, 0));

--- a/drake/systems/framework/test/value_test.cc
+++ b/drake/systems/framework/test/value_test.cc
@@ -13,6 +13,11 @@ namespace drake {
 namespace systems {
 namespace {
 
+GTEST_TEST(ValueTest, Make) {
+  auto abstract_value = AbstractValue::Make<int>(42);
+  EXPECT_EQ(42, abstract_value->GetValue<int>());
+}
+
 GTEST_TEST(ValueTest, Access) {
   Value<int> value(3);
   const AbstractValue& erased = value;

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -94,6 +94,12 @@ class AbstractValue {
     DownCastMutableOrThrow<T>()->set_value(value_to_set);
   }
 
+  /// Returns an AbstractValue containing the given @p value.
+  template <typename T>
+  static std::unique_ptr<AbstractValue> Make(const T& value) {
+    return std::unique_ptr<AbstractValue>(new Value<T>(value));
+  }
+
  private:
   // Casts this to a Value<T>*.  Throws std::bad_cast if the cast fails.
   template <typename T>


### PR DESCRIPTION
Fixes #3217.  Factored out from #4823.

@siyuanfeng-tri for feature review, @jwnimmer-tri for platform review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4829)
<!-- Reviewable:end -->
