### PR TITLE
Symbolic lorentz cone

### DIFF
--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -299,6 +299,12 @@ class SymbolicError : public runtime_error {
    *  \pre{1. @c coeffs is a row vector of double, whose length matches with the
    *          size of @c map_var_to_index.
    *       2. @c e is an addition symbolic-expression.}
+   * @tparam Derived An Eigen row vector of doubles.
+   * @param[in] e The symbolic linear expression
+   * @param[in] map_var_to_index A mapping from variable ID to variable index,
+   * such that map_var_to_index[vi.get_ID()] = i.
+   * @param[out] coeffs A row vector. coeffs(i) = ci.
+   * @param[out] constant_term c0 in the equation above.
    */
 template <typename Derived>
 void DecomposeLinearExpression(
@@ -367,7 +373,7 @@ void DecomposeLinearExpression(
       DecomposeLinearExpression(e_i, map_var_to_index, A->row(i),
                                 b->data() + i);
     } else if (is_multiplication(e_i)) {
-      double c = get_constant_in_multiplication(e_i);
+      const double c = get_constant_in_multiplication(e_i);
       const std::map<symbolic::Expression, symbolic::Expression>&
           map_base_to_exponent = get_base_to_exp_map_in_multiplication(e_i);
       if (map_base_to_exponent.size() == 1) {
@@ -447,7 +453,7 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
       new_ub(i) = ub(i) - constant_term;
     } else if (is_multiplication(e_i)) {
       // i-th constraint should be lb <= c * var_i <= ub, where c is a constant.
-      double c = get_constant_factor_in_multiplication(e_i);
+      const double c = get_constant_factor_in_multiplication(e_i);
       const std::map<symbolic::Expression, symbolic::Expression>&
           map_base_to_exponent = get_products_in_multiplication(e_i);
       if (map_base_to_exponent.size() == 1) {

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -25,11 +25,15 @@ namespace solvers {
 
 using std::map;
 using std::ostringstream;
+using std::pair;
 using std::runtime_error;
 using std::shared_ptr;
 using std::string;
 using std::unordered_map;
 using std::vector;
+
+using symbolic::Variable;
+using symbolic::Expression;
 
 namespace {
 
@@ -264,19 +268,19 @@ namespace {
 
 class SymbolicError : public runtime_error {
  public:
-  SymbolicError(const symbolic::Expression& e, const string& msg)
+  SymbolicError(const Expression& e, const string& msg)
       : runtime_error{make_string(e, msg)} {}
-  SymbolicError(const symbolic::Expression& e, const double lb, const double ub,
+  SymbolicError(const Expression& e, const double lb, const double ub,
                 const string& msg)
       : runtime_error{make_string(e, lb, ub, msg)} {}
 
  private:
-  static string make_string(const symbolic::Expression& e, const string& msg) {
+  static string make_string(const Expression& e, const string& msg) {
     ostringstream oss;
     oss << "Constraint " << e << " is " << msg << ".";
     return oss.str();
   }
-  static string make_string(const symbolic::Expression& e, const double lb,
+  static string make_string(const Expression& e, const double lb,
                             const double ub, const string& msg) {
     ostringstream oss;
     oss << "Constraint " << lb << " <= " << e << " <= " << ub << " is " << msg
@@ -308,7 +312,7 @@ class SymbolicError : public runtime_error {
    */
 template <typename Derived>
 void DecomposeLinearExpression(
-    const symbolic::Expression& e,
+    const Expression& e,
     const std::unordered_map<size_t, int>& map_var_to_index,
     const Eigen::MatrixBase<Derived>& coeffs, double* constant_term) {
   static_assert(std::is_same<typename Derived::Scalar, double>::value,
@@ -317,9 +321,9 @@ void DecomposeLinearExpression(
   DRAKE_DEMAND(static_cast<size_t>(coeffs.cols()) == map_var_to_index.size());
   DRAKE_ASSERT(is_addition(e));
   *constant_term = get_constant_in_addition(e);
-  const std::map<symbolic::Expression, double>& exp_to_coeff_map{
+  const std::map<Expression, double>& exp_to_coeff_map{
       get_exp_to_coeff_map_in_addition(e)};
-  for (const std::pair<symbolic::Expression, double>& p : exp_to_coeff_map) {
+  for (const pair<Expression, double>& p : exp_to_coeff_map) {
     if (is_variable(p.first)) {
       const symbolic::Variable& var{get_variable(p.first)};
       const double coeff{p.second};
@@ -342,7 +346,7 @@ void DecomposeLinearExpression(
  * @param[out] vars All variables.
  */
 void DecomposeLinearExpression(
-    const Eigen::Ref<const VectorX<symbolic::Expression>>& v,
+    const Eigen::Ref<const VectorX<Expression>>& v,
     Eigen::MatrixXd* A, Eigen::VectorXd* b, VectorXDecisionVariable* vars) {
   // 0. Setup map_var_to_index and var_vec.
   unordered_map<size_t, int> map_var_to_index;
@@ -368,16 +372,16 @@ void DecomposeLinearExpression(
   *A = Eigen::MatrixXd::Zero(v.rows(), vars->rows());
   *b = Eigen::VectorXd::Zero(v.rows());
   for (int i{0}; i < v.size(); ++i) {
-    const symbolic::Expression& e_i{v(i)};
+    const Expression& e_i{v(i)};
     if (is_addition(e_i)) {
       DecomposeLinearExpression(e_i, map_var_to_index, A->row(i),
                                 b->data() + i);
     } else if (is_multiplication(e_i)) {
       const double c = get_constant_in_multiplication(e_i);
-      const std::map<symbolic::Expression, symbolic::Expression>&
+      const std::map<Expression, Expression>&
           map_base_to_exponent = get_base_to_exp_map_in_multiplication(e_i);
       if (map_base_to_exponent.size() == 1) {
-        for (const std::pair<symbolic::Expression, symbolic::Expression>& p :
+        for (const pair<Expression, Expression>& p :
             map_base_to_exponent) {
           if (!is_variable(p.first) || !is_one(p.second)) {
             throw SymbolicError(e_i, "is non-linear");
@@ -397,7 +401,6 @@ void DecomposeLinearExpression(
       (*b)(i) = 0;
     } else if (is_constant(e_i)) {
       (*b)(i) = get_constant_value(e_i);
-
     } else {
       throw SymbolicError(e_i, "is non-linear");
     }
@@ -406,14 +409,14 @@ void DecomposeLinearExpression(
 }  // anonymous namespace
 
 Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
-    const symbolic::Expression& e, const double lb, const double ub) {
-  return AddLinearConstraint(drake::Vector1<symbolic::Expression>(e),
+    const Expression& e, const double lb, const double ub) {
+  return AddLinearConstraint(drake::Vector1<Expression>(e),
                              drake::Vector1<double>(lb),
                              drake::Vector1<double>(ub));
 }
 
 Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
-    const Eigen::Ref<const drake::VectorX<symbolic::Expression>>& v,
+    const Eigen::Ref<const drake::VectorX<Expression>>& v,
     const Eigen::Ref<const Eigen::VectorXd>& lb,
     const Eigen::Ref<const Eigen::VectorXd>& ub) {
   DRAKE_ASSERT(v.rows() == lb.rows() && v.rows() == ub.rows());
@@ -442,7 +445,7 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
   Eigen::VectorXd new_lb{v.size()};
   Eigen::VectorXd new_ub{v.size()};
   for (int i{0}; i < v.size(); ++i) {
-    const symbolic::Expression& e_i{v(i)};
+    const Expression& e_i{v(i)};
     const double lb_i{lb(i)};
     const double ub_i{ub(i)};
     if (is_addition(e_i)) {
@@ -454,16 +457,16 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
     } else if (is_multiplication(e_i)) {
       // i-th constraint should be lb <= c * var_i <= ub, where c is a constant.
       const double c = get_constant_in_multiplication(e_i);
-      const std::map<symbolic::Expression, symbolic::Expression>&
+      const std::map<Expression, Expression>&
           map_base_to_exponent = get_base_to_exp_map_in_multiplication(e_i);
       if (map_base_to_exponent.size() == 1) {
-        for (const std::pair<symbolic::Expression, symbolic::Expression>& p :
+        for (const pair<Expression, Expression>& p :
              map_base_to_exponent) {
           if (!is_variable(p.first) || !is_one(p.second)) {
             throw SymbolicError(
                 e_i, "non-linear but called with AddLinearConstraint");
           } else {
-            const symbolic::Variable& var_i = get_variable(p.first);
+            const Variable& var_i = get_variable(p.first);
             if (v.size() == 1) {
               // Add a bounding box constraint lb/c <= v <= ub/c
               if (c > 0) {
@@ -489,7 +492,7 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
       }
     } else if (is_variable(e_i)) {
       // i-th constraint is lb <= var_i <= ub
-      const symbolic::Variable& var_i{get_variable(e_i)};
+      const Variable& var_i{get_variable(e_i)};
       if (v.size() == 1) {
         // If this is the only constraint, we call AddBoundingBoxConstraint.
         return Binding<BoundingBoxConstraint>{
@@ -595,7 +598,7 @@ void MathematicalProgram::AddConstraint(
 }
 
 Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
-    const Eigen::Ref<const VectorX<drake::symbolic::Expression>>& v) {
+    const Eigen::Ref<const VectorX<Expression>>& v) {
   DRAKE_DEMAND(v.rows() >= 2);
   Eigen::MatrixXd A{};
   Eigen::VectorXd b(v.size());
@@ -637,7 +640,7 @@ void MathematicalProgram::AddConstraint(
 
 Binding<RotatedLorentzConeConstraint>
 MathematicalProgram::AddRotatedLorentzConeConstraint(
-    const Eigen::Ref<const VectorX<drake::symbolic::Expression>>& v) {
+    const Eigen::Ref<const VectorX<Expression>>& v) {
   DRAKE_DEMAND(v.rows() >= 3);
   Eigen::MatrixXd A{};
   Eigen::VectorXd b(v.size());
@@ -824,18 +827,18 @@ MathematicalProgram::AddLinearMatrixInequalityConstraint(
 }
 
 size_t MathematicalProgram::FindDecisionVariableIndex(
-    const symbolic::Variable& var) const {
+    const Variable& var) const {
   auto it = decision_variable_index_.find(var.get_id());
   DRAKE_ASSERT(it != decision_variable_index_.end());
   return it->second;
 }
 
 MathematicalProgram::VarType MathematicalProgram::DecisionVariableType(
-    const symbolic::Variable& var) const {
+    const Variable& var) const {
   return decision_variable_type_[FindDecisionVariableIndex(var)];
 }
 
-double MathematicalProgram::GetSolution(const symbolic::Variable& var) const {
+double MathematicalProgram::GetSolution(const Variable& var) const {
   return x_values_[FindDecisionVariableIndex(var)];
 }
 
@@ -854,7 +857,7 @@ void MathematicalProgram::SetDecisionVariableValues(
 }
 
 void MathematicalProgram::SetDecisionVariableValue(
-    const symbolic::Variable& var, double value) {
+    const Variable& var, double value) {
   x_values_[FindDecisionVariableIndex(var)] = value;
 }
 

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -435,7 +435,6 @@ void MathematicalProgram::AddConstraint(
 void MathematicalProgram::AddConstraint(
     const Binding<LorentzConeConstraint>& binding) {
   required_capabilities_ |= kLorentzConeConstraint;
-  DRAKE_ASSERT(binding.GetNumElements() >= 2);
   lorentz_cone_constraint_.push_back(binding);
 }
 
@@ -492,6 +491,7 @@ Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
   Eigen::VectorXd b(v.size());
   VectorXDecisionVariable vars{};
   DecomposeLinearExpression(v, &A, &b, &vars);
+  DRAKE_DEMAND(vars.rows() >= 1);
   return Binding<LorentzConeConstraint>(AddLorentzConeConstraint(A, b, vars), vars);
 }
 
@@ -515,7 +515,6 @@ MathematicalProgram::AddLorentzConeConstraint(
 void MathematicalProgram::AddConstraint(
     const Binding<RotatedLorentzConeConstraint>& binding) {
   required_capabilities_ |= kRotatedLorentzConeConstraint;
-  DRAKE_ASSERT(binding.GetNumElements() >= 3);
   rotated_lorentz_cone_constraint_.push_back(binding);
 }
 
@@ -532,6 +531,7 @@ Binding<RotatedLorentzConeConstraint> MathematicalProgram::AddRotatedLorentzCone
   Eigen::VectorXd b(v.size());
   VectorXDecisionVariable vars{};
   DecomposeLinearExpression(v, &A, &b, &vars);
+  DRAKE_DEMAND(vars.rows() >= 1);
   return Binding<RotatedLorentzConeConstraint>(AddRotatedLorentzConeConstraint(A, b, vars), vars);
 }
 

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -332,44 +332,44 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
       new_lb(i) = lb(i) - constant_term;
       new_ub(i) = ub(i) - constant_term;
     } else if (is_multiplication(e_i)) {
-        // i-th constraint should be lb <= c * var_i <= ub, where c is a constant.
+      // i-th constraint should be lb <= c * var_i <= ub, where c is a constant.
       double c = get_constant_factor_in_multiplication(e_i);
-      const std::map<symbolic::Expression, symbolic::Expression>& map_base_to_exponent = get_products_in_multiplication(e_i);
+      const std::map<symbolic::Expression, symbolic::Expression>&
+          map_base_to_exponent = get_products_in_multiplication(e_i);
       if (map_base_to_exponent.size() == 1) {
-        for (const std::pair<symbolic::Expression, symbolic::Expression>& p : map_base_to_exponent) {
+        for (const std::pair<symbolic::Expression, symbolic::Expression>& p :
+             map_base_to_exponent) {
           if (!is_variable(p.first) || !is_one(p.second)) {
-            throw SymbolicError(e_i, "non-linear but called with AddLinearConstraint");
-          }
-          else {
+            throw SymbolicError(
+                e_i, "non-linear but called with AddLinearConstraint");
+          } else {
             const symbolic::Variable& var_i = get_variable(p.first);
             if (v.size() == 1) {
               // Add a bounding box constraint lb/c <= v <= ub/c
               if (c > 0) {
                 new_lb(i) = lb(i) / c;
                 new_ub(i) = ub(i) / c;
-              }
-              else {
+              } else {
                 new_lb(i) = ub(i) / c;
                 new_ub(i) = lb(i) / c;
               }
-              return Binding<BoundingBoxConstraint>(AddBoundingBoxConstraint(new_lb(i), new_ub(i), var_i), vars);
-            }
-            else {
+              return Binding<BoundingBoxConstraint>(
+                  AddBoundingBoxConstraint(new_lb(i), new_ub(i), var_i), vars);
+            } else {
               A(i, map_var_to_index[var_i.get_id()]) = c;
               new_lb(i) = lb(i);
               new_ub(i) = ub(i);
             }
           }
         }
-      }
-      else {
+      } else {
         // There is more than one base, like x^2*y^3
-        throw SymbolicError(e_i, "non-linear but called with AddLinearConstraint");
+        throw SymbolicError(e_i,
+                            "non-linear but called with AddLinearConstraint");
       }
-    }
-    else if (is_variable(e_i)) {
+    } else if (is_variable(e_i)) {
       // i-th constraint is lb <= var_i <= ub
-      const symbolic::Variable &var_i{get_variable(e_i)};
+      const symbolic::Variable& var_i{get_variable(e_i)};
       if (v.size() == 1) {
         // If this is the only constraint, we call AddBoundingBoxConstraint.
         return Binding<BoundingBoxConstraint>{
@@ -393,7 +393,6 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
       throw SymbolicError(e_i, lb_i, ub_i,
                           "non-linear but called with AddLinearConstraint");
     }
-
   }
   return Binding<LinearConstraint>{AddLinearConstraint(A, new_lb, new_ub, vars),
                                    vars};
@@ -475,10 +474,9 @@ void MathematicalProgram::AddConstraint(
   lorentz_cone_constraint_.push_back(binding);
 }
 
-void MathematicalProgram::DecomposeLinearExpression(const Eigen::Ref<const VectorX<drake::symbolic::Expression>> &v,
-                                                    Eigen::MatrixXd* A,
-                                                    Eigen::VectorXd* b,
-                                                    VectorXDecisionVariable* vars) {
+void MathematicalProgram::DecomposeLinearExpression(
+    const Eigen::Ref<const VectorX<drake::symbolic::Expression>>& v,
+    Eigen::MatrixXd* A, Eigen::VectorXd* b, VectorXDecisionVariable* vars) {
   // 0. Setup map_var_to_index and var_vec.
   unordered_map<size_t, int> map_var_to_index;
   vector<symbolic::Variable> var_vec;
@@ -505,27 +503,29 @@ void MathematicalProgram::DecomposeLinearExpression(const Eigen::Ref<const Vecto
   for (int i{0}; i < v.size(); ++i) {
     const symbolic::Expression& e_i{v(i)};
     if (is_addition(e_i)) {
-      DecomposeLinearExpression(e_i, map_var_to_index, A->row(i), b->data() + i);
-    } else if (is_multiplication(e_i)){
+      DecomposeLinearExpression(e_i, map_var_to_index, A->row(i),
+                                b->data() + i);
+    } else if (is_multiplication(e_i)) {
       double c = get_constant_factor_in_multiplication(e_i);
-      const std::map<symbolic::Expression, symbolic::Expression>& map_base_to_exponent = get_products_in_multiplication(e_i);
+      const std::map<symbolic::Expression, symbolic::Expression>&
+          map_base_to_exponent = get_products_in_multiplication(e_i);
       if (map_base_to_exponent.size() == 1) {
-        for (const std::pair<symbolic::Expression, symbolic::Expression>& p : map_base_to_exponent) {
+        for (const std::pair<symbolic::Expression, symbolic::Expression>& p :
+             map_base_to_exponent) {
           if (!is_variable(p.first) || !is_one(p.second)) {
             throw SymbolicError(e_i, "is non-linear");
           } else {
-            const symbolic::Variable &var_i = get_variable(p.first);
+            const symbolic::Variable& var_i = get_variable(p.first);
             (*A)(i, map_var_to_index[var_i.get_id()]) = c;
           }
         }
-      }
-      else {
+      } else {
         // There is more than one base, like x^2*y^3
         throw SymbolicError(e_i, "is non-linear");
       }
     } else if (is_variable(e_i)) {
       // i-th row is var_i
-      const symbolic::Variable &var_i{get_variable(e_i)};
+      const symbolic::Variable& var_i{get_variable(e_i)};
       (*A)(i, map_var_to_index[var_i.get_id()]) = 1;
       (*b)(i) = 0;
     } else if (is_constant(e_i)) {
@@ -534,10 +534,8 @@ void MathematicalProgram::DecomposeLinearExpression(const Eigen::Ref<const Vecto
     } else {
       throw SymbolicError(e_i, "is non-linear");
     }
-
   }
 }
-
 
 Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
     const Eigen::Ref<const VectorX<drake::symbolic::Expression>>& v) {
@@ -547,7 +545,8 @@ Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
   VectorXDecisionVariable vars{};
   DecomposeLinearExpression(v, &A, &b, &vars);
   DRAKE_DEMAND(vars.rows() >= 1);
-  return Binding<LorentzConeConstraint>(AddLorentzConeConstraint(A, b, vars), vars);
+  return Binding<LorentzConeConstraint>(AddLorentzConeConstraint(A, b, vars),
+                                        vars);
 }
 
 void MathematicalProgram::AddConstraint(
@@ -579,7 +578,8 @@ void MathematicalProgram::AddConstraint(
   AddConstraint(Binding<RotatedLorentzConeConstraint>(con, vars));
 }
 
-Binding<RotatedLorentzConeConstraint> MathematicalProgram::AddRotatedLorentzConeConstraint(
+Binding<RotatedLorentzConeConstraint>
+MathematicalProgram::AddRotatedLorentzConeConstraint(
     const Eigen::Ref<const VectorX<drake::symbolic::Expression>>& v) {
   DRAKE_DEMAND(v.rows() >= 3);
   Eigen::MatrixXd A{};
@@ -587,7 +587,8 @@ Binding<RotatedLorentzConeConstraint> MathematicalProgram::AddRotatedLorentzCone
   VectorXDecisionVariable vars{};
   DecomposeLinearExpression(v, &A, &b, &vars);
   DRAKE_DEMAND(vars.rows() >= 1);
-  return Binding<RotatedLorentzConeConstraint>(AddRotatedLorentzConeConstraint(A, b, vars), vars);
+  return Binding<RotatedLorentzConeConstraint>(
+      AddRotatedLorentzConeConstraint(A, b, vars), vars);
 }
 
 std::shared_ptr<RotatedLorentzConeConstraint>

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -453,9 +453,9 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
       new_ub(i) = ub(i) - constant_term;
     } else if (is_multiplication(e_i)) {
       // i-th constraint should be lb <= c * var_i <= ub, where c is a constant.
-      const double c = get_constant_factor_in_multiplication(e_i);
+      const double c = get_constant_in_multiplication(e_i);
       const std::map<symbolic::Expression, symbolic::Expression>&
-          map_base_to_exponent = get_products_in_multiplication(e_i);
+          map_base_to_exponent = get_base_to_exp_map_in_multiplication(e_i);
       if (map_base_to_exponent.size() == 1) {
         for (const std::pair<symbolic::Expression, symbolic::Expression>& p :
              map_base_to_exponent) {

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -331,31 +331,69 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
                                 &constant_term);
       new_lb(i) = lb(i) - constant_term;
       new_ub(i) = ub(i) - constant_term;
-    } else if (is_variable(e_i)) {
-      // i-th constraint is lb <= var_i <= ub
-      const symbolic::Variable& var_i{get_variable(e_i)};
-      if (v.size() == 1) {
-        // If this is the only constraint, we call AddBoundingBoxConstraint.
-        return Binding<BoundingBoxConstraint>{
-            AddBoundingBoxConstraint(lb(i), ub(i), var_i), vars};
-      } else {
-        A(i, map_var_to_index[var_i.get_id()]) = 1;
-        new_lb(i) = lb(i);
-        new_ub(i) = ub(i);
-      }
-    } else if (is_constant(e_i)) {
-      const double c_i{get_constant_value(e_i)};
-      if (lb_i <= c_i && c_i <= ub_i) {
-        throw SymbolicError(e_i, lb_i, ub_i,
-                            "trivial but called with AddLinearConstraint");
-      } else {
-        throw SymbolicError(
-            e_i, lb_i, ub_i,
-            "unsatisfiable but called with AddLinearConstraint");
-      }
     } else {
-      throw SymbolicError(e_i, lb_i, ub_i,
-                          "non-linear but called with AddLinearConstraint");
+      if (is_multiplication(e_i)) {
+        // i-th constraint should be lb <= c * var_i <= ub, where c is a constant.
+        double c = get_constant_factor_in_multiplication(e_i);
+        const std::map<symbolic::Expression, symbolic::Expression>& map_base_to_exponent = get_products_in_multiplication(e_i);
+        if (map_base_to_exponent.size() == 1) {
+          for (const std::pair<symbolic::Expression, symbolic::Expression>& p : map_base_to_exponent) {
+            if (!is_variable(p.first) || !is_one(p.second)) {
+              throw SymbolicError(e_i, "non-linear but called with AddLinearConstraint");
+            }
+            else {
+              const symbolic::Variable& var_i = get_variable(p.first);
+              if (v.size() == 1) {
+                // Add a bounding box constraint lb/c <= v <= ub/c
+                if (c > 0) {
+                  new_lb(i) = lb(i) / c;
+                  new_ub(i) = ub(i) / c;
+                }
+                else {
+                  new_lb(i) = ub(i) / c;
+                  new_ub(i) = lb(i) / c;
+                }
+                return Binding<BoundingBoxConstraint>(AddBoundingBoxConstraint(new_lb(i), new_ub(i), var_i), vars);
+              }
+              else {
+                A(i, map_var_to_index[get_variable(p.first).get_id()]) = c;
+                new_lb(i) = lb(i);
+                new_ub(i) = ub(i);
+              }
+            }
+          }
+        }
+        else {
+          // There is more than one base, like x^2*y^3
+          throw SymbolicError(e_i, "non-linear but called with AddLinearConstraint");
+        }
+      }
+      else if (is_variable(e_i)) {
+        // i-th constraint is lb <= var_i <= ub
+        const symbolic::Variable &var_i{get_variable(e_i)};
+        if (v.size() == 1) {
+          // If this is the only constraint, we call AddBoundingBoxConstraint.
+          return Binding<BoundingBoxConstraint>{
+              AddBoundingBoxConstraint(lb(i), ub(i), var_i), vars};
+        } else {
+          A(i, map_var_to_index[var_i.get_id()]) = 1;
+          new_lb(i) = lb(i);
+          new_ub(i) = ub(i);
+        }
+      } else if (is_constant(e_i)) {
+        const double c_i{get_constant_value(e_i)};
+        if (lb_i <= c_i && c_i <= ub_i) {
+          throw SymbolicError(e_i, lb_i, ub_i,
+                              "trivial but called with AddLinearConstraint");
+        } else {
+          throw SymbolicError(
+              e_i, lb_i, ub_i,
+              "unsatisfiable but called with AddLinearConstraint");
+        }
+      } else {
+        throw SymbolicError(e_i, lb_i, ub_i,
+                            "non-linear but called with AddLinearConstraint");
+      }
     }
   }
   return Binding<LinearConstraint>{AddLinearConstraint(A, new_lb, new_ub, vars),

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1448,14 +1448,17 @@ class MathematicalProgram {
   }
 
   /**
-   * Adds Lorentz cone constraint referencing potentially a subset of the decision variables.
+   * Adds Lorentz cone constraint referencing potentially a subset of the
+   * decision variables.
    * @param v An Eigen::Vector of symbolic::Expression. Constraining that
    * \f[
    * v_0 \ge \sqrt{v_1^2 + ... + v_{n-1}^2}
    * \f]
-   * @return The newly constructed Lorentz cone constraint with the bounded variables.
+   * @return The newly constructed Lorentz cone constraint with the bounded
+   * variables.
    */
-  Binding<LorentzConeConstraint> AddLorentzConeConstraint(const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(
+      const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
 
   /**
    * Adds Lorentz cone constraint referencing potentially a subset
@@ -1607,10 +1610,14 @@ class MathematicalProgram {
    * v_0v_1 \ge v_2^2 + ... + v_{n-1}^2\\
    * v_0 \ge 0, v_1 \ge 0
    * \f]
-   * @param v A linear expression of variables, \f$ v = A x + b\f$, where \f$ A, b \f$ are given matrices of the correct size, \f$ x \f$ is the vector of decision variables.
-   * @retval binding The newly added rotated Lorentz cone constraint, together with the bound variables.
+   * @param v A linear expression of variables, \f$ v = A x + b\f$, where \f$ A,
+   * b \f$ are given matrices of the correct size, \f$ x \f$ is the vector of
+   * decision variables.
+   * @retval binding The newly added rotated Lorentz cone constraint, together
+   * with the bound variables.
    */
-  Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
+  Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
+      const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
@@ -2417,8 +2424,7 @@ class MathematicalProgram {
    */
   void DecomposeLinearExpression(
       const Eigen::Ref<const VectorX<symbolic::Expression>>& v,
-      Eigen::MatrixXd* A, Eigen::VectorXd* b,
-      VectorXDecisionVariable* vars);
+      Eigen::MatrixXd* A, Eigen::VectorXd* b, VectorXDecisionVariable* vars);
 };
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1605,7 +1605,8 @@ class MathematicalProgram {
                      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
-   * Add a symbolic expression @param v is in the rotated Lorentz cone, i.e.,
+   * Adds a constraint that a symbolic expression @param v is in the rotated
+   * Lorentz cone, i.e.,
    * \f[
    * v_0v_1 \ge v_2^2 + ... + v_{n-1}^2\\
    * v_0 \ge 0, v_1 \ge 0

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1448,6 +1448,16 @@ class MathematicalProgram {
   }
 
   /**
+   * Adds Lorentz cone constraint referencing potentially a subset of the decision variables.
+   * @param v An Eigen::Vector of symbolic::Expression. Constraining that
+   * \f[
+   * v_0 \ge \sqrt{v_1^2 + ... + v_{n-1}^2}
+   * \f]
+   * @return The newly constructed Lorentz cone constraint with the bounded variables.
+   */
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
+
+  /**
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables.
    */

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1602,6 +1602,17 @@ class MathematicalProgram {
                      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
+   * Add a symbolic expression @param v is in the rotated Lorentz cone, i.e.,
+   * \f[
+   * v_0v_1 \ge v_2^2 + ... + v_{n-1}^2\\
+   * v_0 \ge 0, v_1 \ge 0
+   * \f]
+   * @param v A linear expression of variables, \f$ v = A x + b\f$, where \f$ A, b \f$ are given matrices of the correct size, \f$ x \f$ is the vector of decision variables.
+   * @retval binding The newly added rotated Lorentz cone constraint, together with the bound variables.
+   */
+  Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
+
+  /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
    * of decision variables, The linear expression @f$ z=Ax+b @f$ is in rotated
    * Lorentz cone.
@@ -2395,6 +2406,19 @@ class MathematicalProgram {
       }
     }
   }
+
+  /**
+   * Given a vector of linear expressions v, decompose it to
+   * \f$ v = A vars + b \f$
+   * @param[in] v A vector of linear expressions
+   * @param[out] A
+   * @param[out] b
+   * @param[out] vars
+   */
+  void DecomposeLinearExpression(
+      const Eigen::Ref<const VectorX<symbolic::Expression>>& v,
+      Eigen::MatrixXd* A, Eigen::VectorXd* b,
+      VectorXDecisionVariable* vars);
 };
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2371,60 +2371,6 @@ class MathematicalProgram {
 
   VectorXDecisionVariable NewVariables(VarType type, int rows,
                                        const std::vector<std::string>& names);
-
-  /** Decomposes a linear combination @p e = c0 + c1 * v1 + ... cn * vn into
-   *  the followings:
-   *
-   *     constant term      : c0
-   *     coefficient vector : [c1, ..., cn]
-   *     variable vector    : [v1, ..., vn]
-   *
-   *  Then, it returns a pair (c0, [c1, ..., cn]). A map from variable ID to
-   *  int, @p map_var_to_index, is used to decide a variable's index in a linear
-   *  combination.
-   *
-   *  \pre{1. @c coeffs is a row vector of double, whose length matches with the
-   *          size of @c map_var_to_index.
-   *       2. @c e is an addition symbolic-expression.}
-   */
-  template <typename Derived>
-  void DecomposeLinearExpression(
-      const symbolic::Expression& e,
-      const std::unordered_map<size_t, int>& map_var_to_index,
-      const Eigen::MatrixBase<Derived>& coeffs, double* constant_term) {
-    static_assert(std::is_same<typename Derived::Scalar, double>::value,
-                  "coeffs must be a matrix of double.");
-    DRAKE_DEMAND(coeffs.rows() == 1);
-    DRAKE_DEMAND(static_cast<size_t>(coeffs.cols()) == map_var_to_index.size());
-    DRAKE_ASSERT(is_addition(e));
-    *constant_term = get_constant_in_addition(e);
-    const std::map<symbolic::Expression, double>& exp_to_coeff_map{
-        get_exp_to_coeff_map_in_addition(e)};
-    for (const std::pair<symbolic::Expression, double>& p : exp_to_coeff_map) {
-      if (is_variable(p.first)) {
-        const symbolic::Variable& var{get_variable(p.first)};
-        const double coeff{p.second};
-        const_cast<Eigen::MatrixBase<Derived>&>(coeffs)(
-            0, map_var_to_index.at(var.get_id())) = coeff;
-      } else {
-        std::ostringstream oss;
-        oss << "Expression " << e << " is non-linear.";
-        throw std::runtime_error(oss.str());
-      }
-    }
-  }
-
-  /**
-   * Given a vector of linear expressions v, decompose it to
-   * \f$ v = A vars + b \f$
-   * @param[in] v A vector of linear expressions
-   * @param[out] A
-   * @param[out] b
-   * @param[out] vars
-   */
-  void DecomposeLinearExpression(
-      const Eigen::Ref<const VectorX<symbolic::Expression>>& v,
-      Eigen::MatrixXd* A, Eigen::VectorXd* b, VectorXDecisionVariable* vars);
 };
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -604,24 +604,19 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
     auto y = prog_intersect.NewContinuousVariables(kXdim, "y");
 
     // Add the constraint that both
-    // A_lorentz3 * u1 + b_lorentz3
-    // and
-    // A_lorentz4 * u2 + b_lorentz4
-    // are in the Lorentz cone.
-    // A_lorentz3 = [0; I], b_lorentz3 = [1; 0]
-    // A_lorentz4 = [0; I], b_lorentz4 = [1; 0]
-    Eigen::MatrixXd A_lorentz3(R1.cols() + 1, R1.cols());
-    Eigen::MatrixXd A_lorentz4(R2.cols() + 1, R2.cols());
-    Eigen::VectorXd b_lorentz3(R1.cols() + 1);
-    Eigen::VectorXd b_lorentz4(R2.cols() + 1);
-    A_lorentz3 << Eigen::RowVectorXd::Zero(R1.cols()),
-        Eigen::MatrixXd::Identity(R1.cols(), R1.cols());
-    A_lorentz4 << Eigen::RowVectorXd::Zero(R2.cols()),
-        Eigen::MatrixXd::Identity(R2.cols(), R1.cols());
-    b_lorentz3 << 1, Eigen::VectorXd::Zero(R1.cols());
-    b_lorentz4 << 1, Eigen::VectorXd::Zero(R2.cols());
-    prog_intersect.AddLorentzConeConstraint(A_lorentz3, b_lorentz3, u1);
-    prog_intersect.AddLorentzConeConstraint(A_lorentz4, b_lorentz4, u2);
+    // [1; u1] and [1; u2] are in the Lorentz cone
+    VectorX<symbolic::Expression> e1(1 + u1.rows());
+    VectorX<symbolic::Expression> e2(1 + u2.rows());
+    e1(0) = 1;
+    e2(0) = 1;
+    for (int i = 0; i < u1.rows(); ++i) {
+      e1(i + 1) = +u1(i);
+    }
+    for (int i = 0; i < u2.rows(); ++i) {
+      e2(i + 1) = +u2(i);
+    }
+    prog_intersect.AddLorentzConeConstraint(e1);
+    prog_intersect.AddLorentzConeConstraint(e2);
 
     // Add constraint y = x1 + R1*u1
     //                y = x2 + R2*u2

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -705,7 +705,8 @@ void SolveQPasSOCP(const Eigen::MatrixBase<DerivedQ>& Q,
       c.transpose() * x_socp_value + prog_socp.GetSolution(y(0));
 
   // Check the solution
-  EXPECT_NEAR(2 * prog_socp.GetSolution(y(0)), (Q_sqrt * x_socp_value).squaredNorm(), 1E-6);
+  EXPECT_NEAR(2 * prog_socp.GetSolution(y(0)),
+              (Q_sqrt * x_socp_value).squaredNorm(), 1E-6);
   EXPECT_GE(prog_socp.GetSolution(y(0)), 0);
 
   // Now solve the problem as a QP.

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -604,7 +604,7 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
     auto y = prog_intersect.NewContinuousVariables(kXdim, "y");
 
     // Add the constraint that both
-    // [1; u1] and [1; u2] are in the Lorentz cone
+    // [1; u1] and [1; u2] are in the Lorentz cone.
     VectorX<symbolic::Expression> e1(1 + u1.rows());
     VectorX<symbolic::Expression> e2(1 + u2.rows());
     e1(0) = 1;

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -402,6 +402,150 @@ GTEST_TEST(testMathematicalProgram, trivialLinearEquality) {
     EXPECT_DOUBLE_EQ(vars_value(1), 1);
   });
 }
+GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic2) {
+  // Add Linear Constraint: -10 <= x0 <= 10
+  // Note that this constraint is a bounding-box constraint which is a sub-class
+  // of linear-constraint.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables(3, "x");
+  const symbolic::Expression e{x(0)};
+  const auto binding = prog.AddLinearConstraint(e, -10, 10);
+
+  // Check that the constraint in the binding is of BoundingBoxConstraint by
+  // using dynamic_pointer_cast.
+  const std::shared_ptr<BoundingBoxConstraint> constraint_ptr{
+      std::dynamic_pointer_cast<BoundingBoxConstraint>(binding.constraint())};
+  EXPECT_TRUE(constraint_ptr != nullptr);
+  EXPECT_EQ(constraint_ptr->num_constraints(), 1);
+
+  // Check if the binding includes the correct linear constraint.
+  const VectorXDecisionVariable& var_vec{binding.variables()};
+  const symbolic::Expression Ax{(constraint_ptr->A() * var_vec)(0, 0)};
+  const symbolic::Expression lb_in_ctr{constraint_ptr->lower_bound()[0]};
+  const symbolic::Expression ub_in_ctr{constraint_ptr->upper_bound()[0]};
+  EXPECT_TRUE((e - -10).EqualTo(Ax - lb_in_ctr));
+  EXPECT_TRUE((e - 10).EqualTo(Ax - ub_in_ctr));
+}
+
+GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic3) {
+  // Add Linear Constraints
+  //     3 <=  3 - 5*x0 +      + 10*x2        - 7*y1        <= 9
+  //   -10 <=                       x2                      <= 10
+  //    -7 <= -5 + 2*x0 + 3*x2         + 3*y0 - 2*y1 + 6*y2 <= 12
+  //
+  // Note: the second constraint, -10 <= x2 <= 10 is actually a bounding-box
+  // constraint but We still process the three symbolic-constraints into a
+  // single linear-constraint whose coefficient matrix is the following.
+  //
+  //         [-5 0 10 0 -7 0]
+  //         [ 0 0  1 0  0 0]
+  //         [ 2 3  0 3 -2 6]
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables(3, "x");
+  auto y = prog.NewContinuousVariables(3, "y");
+  Matrix<symbolic::Expression, 3, 1> M_e;
+  Vector3d M_lb;
+  Vector3d M_ub;
+
+  // clang-format off
+  M_e  <<  3 - 5 * x(0) + 10 * x(2) - 7 * y(1),
+      +x(2),
+      -5 + 2 * x(0) + 3 * x(2) + 3 * y(0) - 2 * y(1) + 6 * y(2);
+  M_lb <<  3,
+      -10,
+      7;
+  M_ub << -7,
+      10,
+      12;
+  // clang-format on
+
+  // Check if the binding includes the correct linear constraint.
+  const auto binding = prog.AddLinearConstraint(M_e, M_lb, M_ub);
+  const VectorXDecisionVariable& var_vec{binding.variables()};
+  const auto constraint_ptr = binding.constraint();
+  EXPECT_EQ(constraint_ptr->num_constraints(), 3);
+  const auto Ax = constraint_ptr->A() * var_vec;
+  const auto lb_in_ctr = constraint_ptr->lower_bound();
+  const auto ub_in_ctr = constraint_ptr->upper_bound();
+
+  EXPECT_EQ(M_e - M_lb, Ax - lb_in_ctr);
+  EXPECT_EQ(M_e - M_ub, Ax - ub_in_ctr);
+}
+
+namespace {
+bool CheckParsedSymbolicLorentzConeConstraint(const Binding<LorentzConeConstraint>& binding, const Eigen::Ref<const Eigen::Matrix<symbolic::Expression, Eigen::Dynamic, 1>>& e) {
+  return binding.constraint()->A() * binding.variables() + binding.constraint()->b() == e;
+}
+}  // namespace anonymous
+
+GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint1) {
+  // Add Lorentz cone constraint:
+  // x is in Lorentz cone
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>("x");
+  Matrix<symbolic::Expression, 3, 1> e;
+  e << 1 * x(0), 1.0 * x(1), 1.0 * x(2);
+  prog.AddLorentzConeConstraint(e);
+
+  // Check if the added Lorentz cone constraint is parsed correctly.
+  const auto& binding = prog.lorentz_cone_constraints().back();
+  EXPECT_TRUE(CheckParsedSymbolicLorentzConeConstraint(binding, e));
+  EXPECT_TRUE(CompareMatrices(binding.constraint()->b(), Eigen::Vector3d::Zero()));
+}
+
+GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint2) {
+  // Add Lorentz cone constraint:
+  // x + [1, 2, 0] is in Lorentz cone.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>("x");
+  Matrix<symbolic::Expression, 3, 1> e;
+  e << x(0) + 1, x(1) + 2, + x(2);
+  prog.AddLorentzConeConstraint(e);
+
+  // Check is the added Lorentz cone constraint is parsed correctly.
+  EXPECT_TRUE(CheckParsedSymbolicLorentzConeConstraint(prog.lorentz_cone_constraints().back(), e));
+}
+
+GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint3) {
+  // Add Lorentz cone constraint:
+  // [2 * x(0) + 3 * x(1)          ]
+  // [  - x(0)           + 2 * x(2)]    is in Lorentz cone
+  // [               x(1)          ]
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>("x");
+  Matrix<symbolic::Expression, 3, 1> e;
+  // clang-format on
+  e << 2*x(0) + 3*x(1),
+        -x(0) +         2*x(2),
+                 +x(1);
+  // clang-format off;
+  prog.AddLorentzConeConstraint(e);
+
+  // Check if the added Lorentz cone constraint is parsed correctly.
+  const auto& binding = prog.lorentz_cone_constraints().back();
+  EXPECT_TRUE(CheckParsedSymbolicLorentzConeConstraint(binding, e));
+  EXPECT_TRUE(CompareMatrices(binding.constraint()->b(), Eigen::Vector3d::Zero()));
+}
+
+GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzCOneConstraint4) {
+  // Add Lorentz cone constraint:
+  // [ 2 * x(0) + 3 * x(1) +            5]
+  // [ 4 * x(0)            + 4 * x(2) - 7]
+  // [                                 10]
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>("x");
+  Matrix<symbolic::Expression, 3, 1> e;
+  // clang-format off
+  e << 2 * x(0) + 3 * x(1) + 5,
+       4 * x(0) + 4 * x(2) - 7,
+       10;
+  // clang-format on
+  prog.AddLorentzConeConstraint(e);
+
+  // Check if the added Lorentz cone constraint is parsed correctly.
+  const auto& binding = prog.lorentz_cone_constraints().back();
+  EXPECT_TRUE(CheckParsedSymbolicLorentzConeConstraint(binding, e));
+}
 
 // Tests a quadratic optimization problem, with only quadratic cost
 // 0.5 *x'*Q*x + b'*x
@@ -1541,76 +1685,6 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic1) {
   const symbolic::Expression ub_in_ctr{constraint_ptr->upper_bound()[0]};
   EXPECT_TRUE((e - lb).EqualTo(Ax - lb_in_ctr));
   EXPECT_TRUE((e - ub).EqualTo(Ax - ub_in_ctr));
-}
-
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic2) {
-  // Add Linear Constraint: -10 <= x0 <= 10
-  // Note that this constraint is a bounding-box constraint which is a sub-class
-  // of linear-constraint.
-  MathematicalProgram prog;
-  auto x = prog.NewContinuousVariables(3, "x");
-  const symbolic::Expression e{x(0)};
-  const auto binding = prog.AddLinearConstraint(e, -10, 10);
-
-  // Check that the constraint in the binding is of BoundingBoxConstraint by
-  // using dynamic_pointer_cast.
-  const std::shared_ptr<BoundingBoxConstraint> constraint_ptr{
-      std::dynamic_pointer_cast<BoundingBoxConstraint>(binding.constraint())};
-  EXPECT_TRUE(constraint_ptr != nullptr);
-  EXPECT_EQ(constraint_ptr->num_constraints(), 1);
-
-  // Check if the binding includes the correct linear constraint.
-  const VectorXDecisionVariable& var_vec{binding.variables()};
-  const symbolic::Expression Ax{(constraint_ptr->A() * var_vec)(0, 0)};
-  const symbolic::Expression lb_in_ctr{constraint_ptr->lower_bound()[0]};
-  const symbolic::Expression ub_in_ctr{constraint_ptr->upper_bound()[0]};
-  EXPECT_TRUE((e - -10).EqualTo(Ax - lb_in_ctr));
-  EXPECT_TRUE((e - 10).EqualTo(Ax - ub_in_ctr));
-}
-
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic3) {
-  // Add Linear Constraints
-  //     3 <=  3 - 5*x0 +      + 10*x2        - 7*y1        <= 9
-  //   -10 <=                       x2                      <= 10
-  //    -7 <= -5 + 2*x0 + 3*x2         + 3*y0 - 2*y1 + 6*y2 <= 12
-  //
-  // Note: the second constraint, -10 <= x2 <= 10 is actually a bounding-box
-  // constraint but We still process the three symbolic-constraints into a
-  // single linear-constraint whose coefficient matrix is the following.
-  //
-  //         [-5 0 10 0 -7 0]
-  //         [ 0 0  1 0  0 0]
-  //         [ 2 3  0 3 -2 6]
-  MathematicalProgram prog;
-  auto x = prog.NewContinuousVariables(3, "x");
-  auto y = prog.NewContinuousVariables(3, "y");
-  Matrix<symbolic::Expression, 3, 1> M_e;
-  Vector3d M_lb;
-  Vector3d M_ub;
-
-  // clang-format off
-  M_e  <<  3 - 5 * x(0) + 10 * x(2) - 7 * y(1),
-          +x(2),
-          -5 + 2 * x(0) + 3 * x(2) + 3 * y(0) - 2 * y(1) + 6 * y(2);
-  M_lb <<  3,
-         -10,
-           7;
-  M_ub << -7,
-          10,
-          12;
-  // clang-format on
-
-  // Check if the binding includes the correct linear constraint.
-  const auto binding = prog.AddLinearConstraint(M_e, M_lb, M_ub);
-  const VectorXDecisionVariable& var_vec{binding.variables()};
-  const auto constraint_ptr = binding.constraint();
-  EXPECT_EQ(constraint_ptr->num_constraints(), 3);
-  const auto Ax = constraint_ptr->A() * var_vec;
-  const auto lb_in_ctr = constraint_ptr->lower_bound();
-  const auto ub_in_ctr = constraint_ptr->upper_bound();
-
-  EXPECT_EQ(M_e - M_lb, Ax - lb_in_ctr);
-  EXPECT_EQ(M_e - M_ub, Ax - ub_in_ctr);
 }
 
 }  // namespace

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -477,6 +477,40 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic3) {
   EXPECT_EQ(M_e - M_ub, Ax - ub_in_ctr);
 }
 
+GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic4) {
+  // Check the linear constraint 2  <= 2 * x <= 4.
+  // Note: this is a bounding box constraint
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>("x");
+  const symbolic::Expression e(2 * x(1));
+  const auto& binding = prog.AddLinearConstraint(e, 2, 4);
+
+  EXPECT_TRUE(prog.linear_constraints().empty());
+  EXPECT_EQ(prog.bounding_box_constraints().size(), 1);
+  EXPECT_EQ(prog.bounding_box_constraints().back().constraint(), binding.constraint());
+  EXPECT_EQ(prog.bounding_box_constraints().back().variables(), binding.variables());
+  EXPECT_EQ(binding.variables(), VectorDecisionVariable<1>(x(1)));
+  EXPECT_TRUE(CompareMatrices(binding.constraint()->lower_bound(), Vector1d(1)));
+  EXPECT_TRUE(CompareMatrices(binding.constraint()->upper_bound(), Vector1d(2)));
+}
+
+GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic5) {
+  // Check the linear constraint 2  <= -2 * x <= 4.
+  // Note: this is a bounding box constraint
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>("x");
+  const symbolic::Expression e(-2 * x(1));
+  const auto& binding = prog.AddLinearConstraint(e, 2, 4);
+
+  EXPECT_TRUE(prog.linear_constraints().empty());
+  EXPECT_EQ(prog.bounding_box_constraints().size(), 1);
+  EXPECT_EQ(prog.bounding_box_constraints().back().constraint(), binding.constraint());
+  EXPECT_EQ(prog.bounding_box_constraints().back().variables(), binding.variables());
+  EXPECT_EQ(binding.variables(), VectorDecisionVariable<1>(x(1)));
+  EXPECT_TRUE(CompareMatrices(binding.constraint()->lower_bound(), Vector1d(-2)));
+  EXPECT_TRUE(CompareMatrices(binding.constraint()->upper_bound(), Vector1d(-1)));
+}
+
 namespace {
 void CheckParsedSymbolicLorentzConeConstraint(MathematicalProgram* prog, const Eigen::Ref<const Eigen::Matrix<symbolic::Expression, Eigen::Dynamic, 1>>& e) {
   const auto& binding1 = prog->AddLorentzConeConstraint(e);

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -198,14 +198,12 @@ class GenericTrivialCost1 : public Constraint {
         private_val_(2) {}
 
  protected:
-  void DoEval(const Ref<const Eigen::VectorXd> &x,
-              VectorXd &y) const override {
+  void DoEval(const Ref<const Eigen::VectorXd>& x, VectorXd& y) const override {
     y.resize(1);
     y(0) = x(0) * x(1) + x(2) / x(0) * private_val_;
   }
 
-  void DoEval(const Ref<const TaylorVecXd> &x,
-              TaylorVecXd &y) const override {
+  void DoEval(const Ref<const TaylorVecXd>& x, TaylorVecXd& y) const override {
     y.resize(1);
     y(0) = x(0) * x(1) + x(2) / x(0) * private_val_;
   }
@@ -487,11 +485,15 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic4) {
 
   EXPECT_TRUE(prog.linear_constraints().empty());
   EXPECT_EQ(prog.bounding_box_constraints().size(), 1);
-  EXPECT_EQ(prog.bounding_box_constraints().back().constraint(), binding.constraint());
-  EXPECT_EQ(prog.bounding_box_constraints().back().variables(), binding.variables());
+  EXPECT_EQ(prog.bounding_box_constraints().back().constraint(),
+            binding.constraint());
+  EXPECT_EQ(prog.bounding_box_constraints().back().variables(),
+            binding.variables());
   EXPECT_EQ(binding.variables(), VectorDecisionVariable<1>(x(1)));
-  EXPECT_TRUE(CompareMatrices(binding.constraint()->lower_bound(), Vector1d(1)));
-  EXPECT_TRUE(CompareMatrices(binding.constraint()->upper_bound(), Vector1d(2)));
+  EXPECT_TRUE(
+      CompareMatrices(binding.constraint()->lower_bound(), Vector1d(1)));
+  EXPECT_TRUE(
+      CompareMatrices(binding.constraint()->upper_bound(), Vector1d(2)));
 }
 
 GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic5) {
@@ -504,32 +506,49 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic5) {
 
   EXPECT_TRUE(prog.linear_constraints().empty());
   EXPECT_EQ(prog.bounding_box_constraints().size(), 1);
-  EXPECT_EQ(prog.bounding_box_constraints().back().constraint(), binding.constraint());
-  EXPECT_EQ(prog.bounding_box_constraints().back().variables(), binding.variables());
+  EXPECT_EQ(prog.bounding_box_constraints().back().constraint(),
+            binding.constraint());
+  EXPECT_EQ(prog.bounding_box_constraints().back().variables(),
+            binding.variables());
   EXPECT_EQ(binding.variables(), VectorDecisionVariable<1>(x(1)));
-  EXPECT_TRUE(CompareMatrices(binding.constraint()->lower_bound(), Vector1d(-2)));
-  EXPECT_TRUE(CompareMatrices(binding.constraint()->upper_bound(), Vector1d(-1)));
+  EXPECT_TRUE(
+      CompareMatrices(binding.constraint()->lower_bound(), Vector1d(-2)));
+  EXPECT_TRUE(
+      CompareMatrices(binding.constraint()->upper_bound(), Vector1d(-1)));
 }
 
 namespace {
-void CheckParsedSymbolicLorentzConeConstraint(MathematicalProgram* prog, const Eigen::Ref<const Eigen::Matrix<symbolic::Expression, Eigen::Dynamic, 1>>& e) {
+void CheckParsedSymbolicLorentzConeConstraint(
+    MathematicalProgram* prog,
+    const Eigen::Ref<
+        const Eigen::Matrix<symbolic::Expression, Eigen::Dynamic, 1>>& e) {
   const auto& binding1 = prog->AddLorentzConeConstraint(e);
   const auto& binding2 = prog->lorentz_cone_constraints().back();
 
   EXPECT_EQ(binding1.constraint(), binding2.constraint());
-  EXPECT_EQ(binding1.constraint()->A() * binding1.variables() + binding1.constraint()->b(), e);
-  EXPECT_EQ(binding2.constraint()->A() * binding2.variables() + binding2.constraint()->b(), e);
+  EXPECT_EQ(binding1.constraint()->A() * binding1.variables() +
+                binding1.constraint()->b(),
+            e);
+  EXPECT_EQ(binding2.constraint()->A() * binding2.variables() +
+                binding2.constraint()->b(),
+            e);
 }
 
-void CheckParsedSymbolicRotatedLorentzConeConstraint(MathematicalProgram* prog, const Eigen::Ref<const Eigen::Matrix<symbolic::Expression, Eigen::Dynamic, 1>>& e) {
+void CheckParsedSymbolicRotatedLorentzConeConstraint(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const VectorX<symbolic::Expression>>& e) {
   const auto& binding1 = prog->AddRotatedLorentzConeConstraint(e);
   const auto& binding2 = prog->rotated_lorentz_cone_constraints().back();
 
   EXPECT_EQ(binding1.constraint(), binding2.constraint());
-  EXPECT_EQ(binding1.constraint()->A() * binding1.variables() + binding1.constraint()->b(), e);
-  EXPECT_EQ(binding2.constraint()->A() * binding2.variables() + binding2.constraint()->b(), e);
+  EXPECT_EQ(binding1.constraint()->A() * binding1.variables() +
+                binding1.constraint()->b(),
+            e);
+  EXPECT_EQ(binding2.constraint()->A() * binding2.variables() +
+                binding2.constraint()->b(),
+            e);
 }
-}  // namespace anonymous
+}  // namespace
 
 GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint1) {
   // Add Lorentz cone constraint:
@@ -547,7 +566,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint2) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>("x");
   Matrix<symbolic::Expression, 3, 1> e;
-  e << x(0) + 1, x(1) + 2, + x(2);
+  e << x(0) + 1, x(1) + 2, +x(2);
   CheckParsedSymbolicLorentzConeConstraint(&prog, e);
 }
 
@@ -560,9 +579,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint3) {
   auto x = prog.NewContinuousVariables<3>("x");
   Matrix<symbolic::Expression, 3, 1> e;
   // clang-format on
-  e << 2*x(0) + 3*x(2),
-        -x(0) + 2*x(2),
-                 +x(2);
+  e << 2 * x(0) + 3 * x(2), -x(0) + 2 * x(2), +x(2);
   // clang-format off;
   CheckParsedSymbolicLorentzConeConstraint(&prog, e);
 }
@@ -631,7 +648,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint4) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<4>("x");
   Matrix<symbolic::Expression, 5, 1> e;
-  e << 2 * x(0) + 3*x(2) + 3, x(0) - 4 * x(2), 2 * x(2), 3 * x(0) + 1, 4;
+  e << 2 * x(0) + 3 * x(2) + 3, x(0) - 4 * x(2), 2 * x(2), 3 * x(0) + 1, 4;
   CheckParsedSymbolicRotatedLorentzConeConstraint(&prog, e);
 }
 
@@ -1000,12 +1017,12 @@ class LowerBoundTestConstraint : public Constraint {
 
  protected:
   // for just these two types, implementing this locally is almost cleaner...
-  void DoEval(const Eigen::Ref<const Eigen::VectorXd> &x,
-              Eigen::VectorXd &y) const override {
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd& y) const override {
     EvalImpl(x, y);
   }
-  void DoEval(const Eigen::Ref<const TaylorVecXd> &x,
-              TaylorVecXd &y) const override {
+  void DoEval(const Eigen::Ref<const TaylorVecXd>& x,
+              TaylorVecXd& y) const override {
     EvalImpl(x, y);
   }
 
@@ -1179,18 +1196,17 @@ class GloptipolyConstrainedExampleConstraint
                            // constraint without going through drake::Function
  public:
   GloptipolyConstrainedExampleConstraint()
-      : Constraint(
-            1, 3, Vector1d::Constant(0),
-            Vector1d::Constant(numeric_limits<double>::infinity())) {}
+      : Constraint(1, 3, Vector1d::Constant(0),
+                   Vector1d::Constant(numeric_limits<double>::infinity())) {}
 
  protected:
   // for just these two types, implementing this locally is almost cleaner...
-  void DoEval(const Eigen::Ref<const Eigen::VectorXd> &x,
-              Eigen::VectorXd &y) const override {
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd& y) const override {
     EvalImpl(x, y);
   }
-  void DoEval(const Eigen::Ref<const TaylorVecXd> &x,
-              TaylorVecXd &y) const override {
+  void DoEval(const Eigen::Ref<const TaylorVecXd>& x,
+              TaylorVecXd& y) const override {
     EvalImpl(x, y);
   }
 


### PR DESCRIPTION
1. Add Lorentz cone and rotated Lorentz cone in the symbolic form.
2. Fix a bug when adding linear constraint in the symbolic form, that the following form is not parsed: `lb <= c*x <= ub`, where `x` is a single decision variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4836)
<!-- Reviewable:end -->
