### PR TITLE
Adds a unit test demonstrating odd return value of RigidBodyTree::CalcFramePoseInWorldFrame().

### DIFF
--- a/drake/multibody/test/rigid_body_tree/CMakeLists.txt
+++ b/drake/multibody/test/rigid_body_tree/CMakeLists.txt
@@ -25,6 +25,11 @@ if(Bullet_FOUND)
       drakeRBM)
 endif()
 
+drake_add_cc_test(rigid_body_tree_calc_frame_pose_in_world_frame_test)
+target_link_libraries(rigid_body_tree_calc_frame_pose_in_world_frame_test
+    drakeMultibodyParsers
+    drakeRBM)
+
 drake_add_cc_test(NAME rigid_body_tree_creation_test SIZE medium)
 target_link_libraries(rigid_body_tree_creation_test
     drakeMultibodyParsers

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_calc_frame_pose_in_world_frame_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_calc_frame_pose_in_world_frame_test.cc
@@ -34,7 +34,7 @@ GTEST_TEST(RigidBodyTreeCalcFramePoseInWorldFrameTests, BoxAtOriginTest) {
       tree->FindBody("box"), Eigen::Isometry3d::Identity());
   tree->addFrame(frame);
 
-  const VectorXd q = VectorXd::Zero(tree->get_num_positions());
+  VectorXd q = tree->getZeroConfiguration();
   const VectorXd v = VectorXd::Zero(tree->get_num_velocities());
   const KinematicsCache<double> cache = tree->doKinematics(q, v);
   drake::Isometry3<double> X_WF =

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_calc_frame_pose_in_world_frame_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_calc_frame_pose_in_world_frame_test.cc
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_tree.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+using std::make_unique;
+
+namespace drake {
+
+using parsers::urdf::AddModelInstanceFromUrdfFileToWorld;
+
+namespace multibody {
+
+// Tests that RigidBodyTree::doKinematics() will not throw an exception if
+// provided a valid KinematicsCache.
+GTEST_TEST(RigidBodyTreeCalcFramePoseInWorldFrameTests, BoxAtOriginTest) {
+  auto tree = make_unique<RigidBodyTree<double>>();
+
+  // Adds a box to the RigidBodyTree.
+  AddModelInstanceFromUrdfFileToWorld(
+      GetDrakePath() + "/multibody/models/box.urdf",
+      drake::multibody::joints::kQuaternion, tree.get());
+
+  // Adds a frame to the RigidBodyTree called "box frame" that is coincident
+  // with the "box" body within the RigidBodyTree.
+  auto frame = std::allocate_shared<RigidBodyFrame<double>>(
+      Eigen::aligned_allocator<RigidBodyFrame<double>>(), "box frame",
+      tree->FindBody("box"), Eigen::Isometry3d::Identity());
+  tree->addFrame(frame);
+
+  const VectorXd q = VectorXd::Zero(tree->get_num_positions());
+  const VectorXd v = VectorXd::Zero(tree->get_num_velocities());
+  const KinematicsCache<double> cache = tree->doKinematics(q, v);
+  drake::Isometry3<double> X_WF =
+      tree->CalcFramePoseInWorldFrame(cache, *frame);
+
+  // The following is a debug print statement.
+  std::cout << "Accelerometer::DoCalcOutput:\n"
+            << "  - frame transform =\n"
+            << frame->get_transform_to_body().matrix() << "\n"
+            << "  - X_WF =\n"
+            << X_WF.matrix() << std::endl;
+
+  EXPECT_TRUE(CompareMatrices(X_WF.linear(), MatrixXd::Identity(3, 3),
+                              1e-10 /* tolerance */,
+                              drake::MatrixCompareType::absolute));
+}
+
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
I created this PR so @siyuanfeng-tri can help me debug why the linear portion of the returned `Isometry3d` is all zeros as opposed to identity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4837)
<!-- Reviewable:end -->
