### PR TITLE
Add VTK as an optional external

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -111,3 +111,6 @@
 [submodule "externals/qt_property_browser"]
 	path = externals/qt_property_browser
 	url = https://github.com/patmarion/QtPropertyBrowser
+[submodule "externals/vtk"]
+	path = externals/vtk
+	url = git://vtk.org/VTK.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,18 @@ drake_add_external(octomap PUBLIC CMAKE
     -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON
   SOURCE_SUBDIR octomap)
 
+# vtk
+drake_add_external(vtk PUBLIC CMAKE PYTHON QT
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=ON
+    -DBUILD_TESTING=OFF
+    -DBUILD_EXAMPLES=OFF
+    -DVTK_USE_GUISUPPORT=ON
+    -DVTK_USE_QT=ON
+    -DVTK_WRAP_PYTHON=ON
+    -DVTK_WRAP_TCL=OFF
+    -DVTK_USE_TK=OFF)
+
 # fcl
 drake_add_external(fcl PUBLIC CMAKE
   CMAKE_ARGS -DFCL_BUILD_TESTS=OFF
@@ -324,6 +336,7 @@ drake_add_external(director PUBLIC CMAKE ${TEST_DIRECTOR} PYTHON QT VTK
     libbot
     pythonqt
     qt_property_browser
+    vtk
 )
 
 # END external projects

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -204,11 +204,7 @@ macro(drake_add_cmake_external PROJECT)
     list(APPEND _ext_PROPAGATE_CACHE_VARS QT_QMAKE_EXECUTABLE)
   endif()
 
-  if(_ext_VTK)
-    find_package(VTK 5.10)
-    if(NOT VTK_FOUND)
-      find_package(VTK 5.8 REQUIRED)
-    endif()
+  if(_ext_VTK AND USE_SYSTEM_VTK)
     list(APPEND _ext_PROPAGATE_CACHE_VARS VTK_DIR)
   endif()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -167,6 +167,25 @@ function(drake_optional_external NAME DEFAULT_STATE)
 endfunction()
 
 #------------------------------------------------------------------------------
+# Set internal flag indicating whether or not to build an optional component.
+#
+# This sets the variables WITH_<NAME> and HAVE_<NAME>, indicating if the
+# specified external is available and will be built. These will be true iff
+# <WHEN> is also true.
+#------------------------------------------------------------------------------
+function(drake_dependent_external NAME WHEN)
+  string(REPLACE " " ";" WHEN "${WHEN}") # Force splitting
+  if(${WHEN})
+    set(_value ON)
+  else()
+    set(_value OFF)
+  endif()
+
+  set(WITH_${NAME} "${_value}" PARENT_SCOPE)
+  set(HAVE_${NAME} "${_value}" PARENT_SCOPE)
+endfunction()
+
+#------------------------------------------------------------------------------
 # Set up options
 #------------------------------------------------------------------------------
 macro(drake_setup_options)
@@ -304,7 +323,7 @@ macro(drake_setup_options)
   drake_optional_external(MOSEK OFF
     "Convex optimization solver\; free for academics")
 
-  drake_optional_external(SIGNALSCOPE OFF DEPENDS "WITH_DIRECTOR"
+  drake_optional_external(SIGNALSCOPE OFF
     "Live plotting tool for LCM messages")
 
   drake_optional_external(SNOPT OFF
@@ -323,9 +342,12 @@ macro(drake_setup_options)
   # BEGIN indirectly optional external projects
 
   # The following projects are enabled iff their related externals are enabled.
-  set(WITH_CTK_PYTHON_CONSOLE ${WITH_DIRECTOR})
-  set(WITH_PYTHONQT ${WITH_DIRECTOR})
-  set(WITH_QT_PROPERTY_BROWSER ${WITH_DIRECTOR})
+  drake_dependent_external(CTK_PYTHON_CONSOLE
+    "WITH_DIRECTOR OR WITH_SIGNALSCOPE")
+  drake_dependent_external(PYTHONQT
+    "WITH_DIRECTOR OR WITH_SIGNALSCOPE")
+  drake_dependent_external(QT_PROPERTY_BROWSER
+    "WITH_DIRECTOR")
 
   # END indirectly optional external projects
 endmacro()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -54,12 +54,20 @@ endfunction()
 # Arguments:
 #   OPTIONAL - Dependency is not required.
 #
+#   PREFER_SYSTEM_VERSION
+#     Default to using the system version of the dependency rather than the
+#     internal version.
+#
 #   REQUIRES <package>
 #     Name of package (as passed to `find_package`) that must be found if the
 #     system version is selected.
 #
 #   VERSION <version>
 #     Required version of the system package (passed to `find_package`).
+#
+#   ADDITIONAL_VERSIONS <version>
+#     Versions of the system package to be accepted in addition to the named
+#     VERSION.
 #
 #   DEPENDS <expression>
 #     A list of expressions which must evaluate to true for the component to

--- a/drake/doc/faq.rst
+++ b/drake/doc/faq.rst
@@ -43,11 +43,11 @@ appropriate subsection below.
 Non-ROS Users
 -------------
 
-To workaround the problem, configure Director's build system to build VTK5 from
+To workaround the problem, configure Drake's build system to build VTK5 from
 source (``drake-visualizer`` is built on Director, which is built on VTK5)::
 
-    cd drake-distro/build/externals/director
-    cmake . -DUSE_SYSTEM_VTK=OFF
+    cd drake-distro/build
+    cmake . -DUSE_SYSTEM_VTK=OFF -DWITH_VTK=ON
     cd drake-distro/build
     make (or ninja)
 
@@ -57,7 +57,7 @@ the present working directory)::
 
     cd drake-distro
     export LD_LIBRARY_PATH=`pwd`/build/install/lib/vtk-5.10:$LD_LIBRARY_PATH
-    export PYTHONPATH=`pwd`/build/externals/director/src/vtk-build/Wrapping/Python:`pwd`/build/externals/director/src/vtk-build/bin:$PYTHONPATH
+    export PYTHONPATH=`pwd`/build/externals/vtk/Wrapping/Python:`pwd`/build/externals/vtk/bin:$PYTHONPATH
 
 You should now be able to start ``drake-visualizer``.
 
@@ -70,8 +70,8 @@ ROS Indigo Users
 To workaround the problem, configure Director's build system to build VTK5 from
 source (``drake-visualizer`` is built on Director, which is built on VTK5)::
 
-    cd ~/dev/drake_catkin_workspace/build/drake/externals/director
-    cmake . -DUSE_SYSTEM_VTK=OFF
+    cd ~/dev/drake_catkin_workspace/build/drake
+    cmake . -DUSE_SYSTEM_VTK=OFF -DWITH_VTK=ON
     cd ~/dev/drake_catkin_workspace
     catkin build
 
@@ -79,7 +79,7 @@ Next, modify two environment variables before starting
 ``drake-visualizer``::
 
     export LD_LIBRARY_PATH=$HOME/dev/drake_catkin_workspace/install/lib/vtk-5.10:$LD_LIBRARY_PATH
-    export PYTHONPATH=$HOME/dev/drake_catkin_workspace/build/drake/externals/director/src/vtk-build/Wrapping/Python:$HOME/dev/drake_catkin_workspace/build/drake/externals/director/src/vtk-build/bin:$PYTHONPATH
+    export PYTHONPATH=$HOME/dev/drake_catkin_workspace/build/drake/externals/vtk/Wrapping/Python:$HOME/dev/drake_catkin_workspace/build/drake/externals/vtk/bin:$PYTHONPATH
 
 You should now be able to start ``drake-visualizer``.
 

--- a/drake/doc/from_source_ros_kinetic.rst
+++ b/drake/doc/from_source_ros_kinetic.rst
@@ -105,11 +105,11 @@ Execute the following commands to build the workspace::
     catkin build
 
 The build will fail because ``libvtk5-dev`` is not installed. To get around
-this, execute the following commands, which configure Director to obtain VTK5
+this, execute the following commands, which configure Drake to obtain VTK5
 by building it from source::
 
-    cd ~/dev/drake_catkin_workspace/build/drake/externals/director
-    cmake . -DUSE_SYSTEM_VTK=OFF
+    cd ~/dev/drake_catkin_workspace/build/drake
+    cmake . -DUSE_SYSTEM_VTK=OFF -DWITH_VTK=ON
     cd ~/dev/drake_catkin_workspace
     catkin build
 
@@ -132,7 +132,7 @@ environment variables as follows::
 
 
     export LD_LIBRARY_PATH=$HOME/dev/drake_catkin_workspace/install/lib/vtk-5.10:$LD_LIBRARY_PATH
-    export PYTHONPATH=$HOME/dev/drake_catkin_workspace/build/drake/externals/director/src/vtk-build/Wrapping/Python:$HOME/dev/drake_catkin_workspace/build/drake/externals/director/src/vtk-build/bin:$PYTHONPATH
+    export PYTHONPATH=$HOME/dev/drake_catkin_workspace/build/drake/externals/vtk/Wrapping/Python:$HOME/dev/drake_catkin_workspace/build/drake/externals/vtk/bin:$PYTHONPATH
 
 You should now be able to run ``drake-visualizer``. For more background
 information, see


### PR DESCRIPTION
Teach the superbuild that VTK is an optional system dependency, which defaults to using the system version, and how to build it if enabled but not using the system version.

This enables us to provide our own VTK if the system version is not available (fixes #4807). This is also much easier to use than the old method of relying on the director superbuild (which we no longer use) to build VTK, and unlike that approach will also allow drake itself (#4834) to use VTK.

Also, false coupling between director and signalscope is now fully broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4844)
<!-- Reviewable:end -->
