### PR TITLE
Selectively apply desirable clang-format fixes

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -97,7 +97,9 @@ int AutomotiveSimulator<T>::AddSimpleCarFromSdf(const std::string& sdf_filename,
 
 template <typename T>
 int AutomotiveSimulator<T>::AddTrajectoryCarFromSdf(
-    const std::string& sdf_filename, const Curve2<double>& curve, double speed,
+    const std::string& sdf_filename,
+    const Curve2<double>& curve,
+    double speed,
     double start_time) {
   DRAKE_DEMAND(!started_);
   const int vehicle_number = allocate_vehicle_number();

--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -86,7 +86,8 @@ class AutomotiveSimulator {
   /// @return The model instance ID of the TrajectoryCar that was just added to
   /// the simulation.
   int AddTrajectoryCarFromSdf(const std::string& sdf_filename,
-                              const Curve2<double>& curve, double speed,
+                              const Curve2<double>& curve,
+                              double speed,
                               double start_time);
 
   /// Adds an LCM publisher for the given @p system.

--- a/drake/automotive/car_sim_lcm.cc
+++ b/drake/automotive/car_sim_lcm.cc
@@ -88,9 +88,9 @@ int main(int argc, char* argv[]) {
   multibody::AddFlatTerrainToWorld(rigid_body_tree.get());
   if (FLAGS_with_speed_bump) {
     AddModelInstancesFromSdfFile(
-      drake::GetDrakePath() + "/automotive/models/speed_bump/speed_bump.sdf",
-      multibody::joints::kFixed, nullptr /* weld to frame */,
-      rigid_body_tree.get());
+        drake::GetDrakePath() + "/automotive/models/speed_bump/speed_bump.sdf",
+        multibody::joints::kFixed, nullptr /* weld to frame */,
+        rigid_body_tree.get());
     VerifyCarSimLcmTree(*rigid_body_tree, 19);
   } else {
     VerifyCarSimLcmTree(*rigid_body_tree, 18);

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -48,7 +48,6 @@ class IdmPlanner : public systems::LeafSystem<T> {
   // The output of this system is an algebraic relation of its inputs.
   bool has_any_direct_feedthrough() const override { return true; }
 
-
   std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
 
   void SetDefaultParameters(const systems::LeafContext<T>& context,

--- a/drake/automotive/maliput/monolane/branch_point.cc
+++ b/drake/automotive/maliput/monolane/branch_point.cc
@@ -35,8 +35,7 @@ std::unique_ptr<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
 }
 
 const api::LaneEnd& BranchPoint::AddABranch(const api::LaneEnd& lane_end) {
-  DRAKE_DEMAND(
-      confluent_branches_.find(lane_end) == confluent_branches_.end());
+  DRAKE_DEMAND(confluent_branches_.find(lane_end) == confluent_branches_.end());
   DRAKE_DEMAND(ongoing_branches_.find(lane_end) == ongoing_branches_.end());
   a_side_.add(lane_end);
   confluent_branches_[lane_end] = &a_side_;
@@ -45,8 +44,7 @@ const api::LaneEnd& BranchPoint::AddABranch(const api::LaneEnd& lane_end) {
 }
 
 const api::LaneEnd& BranchPoint::AddBBranch(const api::LaneEnd& lane_end) {
-  DRAKE_DEMAND(
-      confluent_branches_.find(lane_end) == confluent_branches_.end());
+  DRAKE_DEMAND(confluent_branches_.find(lane_end) == confluent_branches_.end());
   DRAKE_DEMAND(ongoing_branches_.find(lane_end) == ongoing_branches_.end());
   b_side_.add(lane_end);
   confluent_branches_[lane_end] = &b_side_;

--- a/drake/automotive/maliput/monolane/builder.h
+++ b/drake/automotive/maliput/monolane/builder.h
@@ -63,7 +63,7 @@ class EndpointXy {
   EndpointXy() = default;
 
   EndpointXy(double x, double y, double heading)
-      :x_(x), y_(y), heading_(heading) {}
+      : x_(x), y_(y), heading_(heading) {}
 
   /// Returns an EndpointXy with reversed direction.
   EndpointXy reverse() const {

--- a/drake/automotive/maliput/monolane/loader.cc
+++ b/drake/automotive/maliput/monolane/loader.cc
@@ -63,7 +63,7 @@ std::unique_ptr<Endpoint> ResolvePointReference(
     const std::string& ref,
     const std::map<std::string, Endpoint>& xyz_catalog) {
   const auto parsed = [&]() {
-    static const std::string kReverse {"reverse "};
+    static const std::string kReverse{"reverse "};
     int where = ref.find(kReverse);
     if (where == 0) {
       // Strip "reverse " from head, and tag as reversed.

--- a/drake/automotive/maliput/monolane/road_geometry.h
+++ b/drake/automotive/maliput/monolane/road_geometry.h
@@ -52,13 +52,9 @@ class RoadGeometry : public api::RoadGeometry {
       const api::GeoPosition& geo_pos,
       const api::RoadPosition& hint) const override;
 
-  double do_linear_tolerance() const override {
-    return linear_tolerance_;
-  }
+  double do_linear_tolerance() const override { return linear_tolerance_; }
 
-  double do_angular_tolerance() const override {
-    return angular_tolerance_;
-  }
+  double do_angular_tolerance() const override { return angular_tolerance_; }
 
   api::RoadGeometryId id_;
   double linear_tolerance_{};

--- a/drake/automotive/maliput/utility/test/generate_urdf_test.cc
+++ b/drake/automotive/maliput/utility/test/generate_urdf_test.cc
@@ -1,6 +1,5 @@
 #include "drake/automotive/maliput/utility/generate_urdf.h"
 
-
 #include "drake/automotive/maliput/monolane/arc_lane.h"
 #include "drake/automotive/maliput/monolane/builder.h"
 #include "drake/automotive/maliput/monolane/junction.h"
@@ -23,7 +22,7 @@ namespace mono = maliput::monolane;
 
 class GenerateUrdfTest : public ::testing::Test {
  protected:
-  const std::string kJunkBasename {"junk"};
+  const std::string kJunkBasename{"junk"};
 
   void SetUp() override {
     directory_.setAsTemp();
@@ -44,13 +43,13 @@ class GenerateUrdfTest : public ::testing::Test {
 TEST_F(GenerateUrdfTest, AtLeastRunIt) {
   const double kLinearTolerance = 0.01;
   const double kAngularTolerance = 0.01 * M_PI;
-  const api::RBounds kLaneBounds {-1., 1.};
-  const api::RBounds kDriveableBounds {-2., 2.};
+  const api::RBounds kLaneBounds{-1., 1.};
+  const api::RBounds kDriveableBounds{-2., 2.};
   mono::Builder b(kLaneBounds, kDriveableBounds,
                   kLinearTolerance, kAngularTolerance);
 
-  const mono::EndpointZ kZeroZ {0., 0., 0., 0.};
-  const mono::Endpoint start {{0., 0., 0.}, kZeroZ};
+  const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
+  const mono::Endpoint start{{0., 0., 0.}, kZeroZ};
   b.Connect("0", start, 10., kZeroZ);
   const std::unique_ptr<const api::RoadGeometry> dut = b.Build({"dut"});
 

--- a/drake/automotive/maliput/utility/test/infinite_circuit_road_test.cc
+++ b/drake/automotive/maliput/utility/test/infinite_circuit_road_test.cc
@@ -15,8 +15,8 @@ namespace mono = monolane;
 
 class InfiniteCircuitRoadTestBase : public ::testing::Test {
  protected:
-  const double kLinearTolerance {1e-6};
-  const double kAngularTolerance {1e-6 * M_PI};
+  const double kLinearTolerance{1e-6};
+  const double kAngularTolerance{1e-6 * M_PI};
 
   const api::Lane* FindLane(const api::RoadGeometry* road,
                             const std::string& id_string) {
@@ -79,7 +79,7 @@ class InfiniteCircuitRoadTest : public InfiniteCircuitRoadTestBase {
       const mono::EndpointZ kTiltedSlopedLowerZ(0., -10. / kShorterLength,
                                                 kTilt, 0.);
 
-      const mono::Endpoint start {{0., 0., M_PI / 2.}, kFlatLowZ};
+      const mono::Endpoint start{{0., 0., M_PI / 2.}, kFlatLowZ};
       auto c0 = b.Connect("0", start, kStraightLength, kFlatHighZ);
 
       auto c1 = b.Connect("1", c0->end(), kSmallClockwiseArc, kFlatHighZ);
@@ -402,8 +402,8 @@ TEST_F(InfiniteCircuitRoadTestBase, Bounds) {
   mono::Builder b(kLaneBounds, kDriveableBounds,
                   kLinearTolerance, kAngularTolerance);
 
-  const mono::EndpointZ kZeroZ {0., 0., 0., 0.};
-  const mono::Endpoint start {{0., 0., 0.}, kZeroZ};
+  const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
+  const mono::Endpoint start{{0., 0., 0.}, kZeroZ};
   b.Connect("0", start, mono::ArcOffset(100., 2. * M_PI), kZeroZ);
   auto source = b.Build({"source"});
 
@@ -451,8 +451,8 @@ TEST_F(InfiniteCircuitRoadTestBase, CircuitFinding) {
 
   const double kSpurLength = 100.;
   const double kRingRadius = 50.;
-  const mono::EndpointZ kZeroZ {0., 0., 0., 0.};
-  const mono::Endpoint start {{0., 0., 0.}, kZeroZ};
+  const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
+  const mono::Endpoint start{{0., 0., 0.}, kZeroZ};
   auto c0 = b.Connect("spur", start, kSpurLength, kZeroZ);
   b.Connect("ring", c0->end(), mono::ArcOffset(kRingRadius, 2. * M_PI), kZeroZ);
   auto source = b.Build({"source"});

--- a/drake/automotive/simple_car.cc
+++ b/drake/automotive/simple_car.cc
@@ -35,10 +35,10 @@ SimpleCarConfig<T> SimpleCar<T>::get_default_config() {
   result.set_wheelbase(static_cast<T>(106.3 * kInchToMeter));
   result.set_track(static_cast<T>(59.9 * kInchToMeter));
   result.set_max_abs_steering_angle(static_cast<T>(27 * kDegToRadian));
-  result.set_max_velocity(static_cast<T>(45.0));  // meters/second
-  result.set_max_acceleration(static_cast<T>(4.0));  // meters/second**2
+  result.set_max_velocity(static_cast<T>(45.0));            // meters/second
+  result.set_max_acceleration(static_cast<T>(4.0));         // meters/second**2
   result.set_velocity_lookahead_time(static_cast<T>(1.0));  // second
-  result.set_velocity_kp(static_cast<T>(1.0));  // Hz
+  result.set_velocity_kp(static_cast<T>(1.0));              // Hz
   return result;
 }
 

--- a/drake/automotive/test/idm_planner_test.cc
+++ b/drake/automotive/test/idm_planner_test.cc
@@ -20,9 +20,8 @@ class IdmPlannerTest : public ::testing::Test {
   double get_v_0() const { return v_0_; }
 
   void SetInputValue(const std::vector<double>& state) {
-    int state_size =
-        dut_->get_ego_port().size() + dut_->get_ego_port().size();
-    DRAKE_DEMAND(state_size == (int) state.size());
+    int state_size = dut_->get_ego_port().size() + dut_->get_ego_port().size();
+    DRAKE_DEMAND(state_size == static_cast<int>(state.size()));
     // Get the state values.
     const double x_ego = state[0];
     const double v_ego = state[1];

--- a/drake/automotive/test/simple_car_test.cc
+++ b/drake/automotive/test/simple_car_test.cc
@@ -45,14 +45,12 @@ TEST_F(SimpleCarTest, Topology) {
   ASSERT_EQ(1, dut_->get_num_input_ports());
   const auto& input_descriptor = dut_->get_input_port(0);
   EXPECT_EQ(systems::kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(DrivingCommandIndices::kNumCoordinates,
-            input_descriptor.size());
+  EXPECT_EQ(DrivingCommandIndices::kNumCoordinates, input_descriptor.size());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_descriptor = dut_->get_output_port(0);
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
-  EXPECT_EQ(SimpleCarStateIndices::kNumCoordinates,
-            output_descriptor.size());
+  EXPECT_EQ(SimpleCarStateIndices::kNumCoordinates, output_descriptor.size());
 }
 
 TEST_F(SimpleCarTest, Output) {


### PR DESCRIPTION
Some edits are fixing defects; some are style on files I own; some are style on others' files that should be uncontroversial.

The one hand-rolled edit was from C-style cast to static_cast, noted when clang-format applied special formatting to the C-style cast to call my attention to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4847)
<!-- Reviewable:end -->
