### PR TITLE
Changed PiecewisePolynomial multiplication operator to be coefficient-wise

### DIFF
--- a/drake/common/trajectories/piecewise_polynomial.cc
+++ b/drake/common/trajectories/piecewise_polynomial.cc
@@ -166,8 +166,9 @@ operator*=(const PiecewisePolynomial<CoefficientType>& other) {
   if (!segmentTimesEqual(other, kEpsilonTime))
     throw runtime_error(
         "Multiplication not yet implemented when segment times are not equal");
-  for (size_t i = 0; i < polynomials_.size(); i++)
-    polynomials_[i] *= other.polynomials_[i];
+  for (size_t i = 0; i < polynomials_.size(); i++) {
+    polynomials_[i].array() *= other.polynomials_[i].array();
+  }
   return *this;
 }
 

--- a/drake/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_test.cc
@@ -95,6 +95,7 @@ void testBasicFunctionality() {
     PiecewisePolynomialType piecewise1_minus_offset = piecewise1 - offset;
     PiecewisePolynomialType piecewise1_shifted = piecewise1;
     piecewise1_shifted.shiftRight(shift);
+    PiecewisePolynomialType product = piecewise1 * piecewise2;
 
     uniform_real_distribution<double> uniform(piecewise1.getStartTime(),
                                               piecewise1.getEndTime());
@@ -119,6 +120,11 @@ void testBasicFunctionality() {
     EXPECT_TRUE(CompareMatrices(piecewise1_shifted.value(t),
                                 piecewise1.value(t - shift), 1e-8,
                                 MatrixCompareType::absolute));
+
+    EXPECT_TRUE(CompareMatrices(
+        product.value(t),
+        (piecewise1.value(t).array() * piecewise2.value(t).array()).matrix(),
+        1e-8, MatrixCompareType::absolute));
   }
 }
 


### PR DESCRIPTION
Previous behavior when multiplying two PiecewisePolys of the same (non-square) shape was to segfault during an attempted matrix multiplication.

Is that intended? I ran into this trying to square a trajectory element-wise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4854)
<!-- Reviewable:end -->
