### PR TITLE
Adds loopback support to DrakeMockLcm.

### DIFF
--- a/drake/lcm/drake_mock_lcm.cc
+++ b/drake/lcm/drake_mock_lcm.cc
@@ -8,10 +8,7 @@
 namespace drake {
 namespace lcm {
 
-DrakeMockLcm::DrakeMockLcm() : DrakeMockLcm(LoopbackSwitch::kWithoutLoopback) {}
-
-DrakeMockLcm::DrakeMockLcm(LoopbackSwitch loop_back_switch)
-    : loop_back_switch_(loop_back_switch) {}
+DrakeMockLcm::DrakeMockLcm() {}
 
 void DrakeMockLcm::StartReceiveThread() {
   DRAKE_DEMAND(!receive_thread_started_);
@@ -37,7 +34,7 @@ void DrakeMockLcm::Publish(const std::string& channel, const void* data,
   const uint8_t* bytes = reinterpret_cast<const uint8_t*>(data);
   saved_message->data = std::vector<uint8_t>(&bytes[0], &bytes[data_size]);
 
-  if (loop_back_switch_ == LoopbackSwitch::kWithLoopback) {
+  if (enable_loop_back_) {
     InduceSubscriberCallback(channel, data, data_size);
   }
 }

--- a/drake/lcm/drake_mock_lcm.h
+++ b/drake/lcm/drake_mock_lcm.h
@@ -11,6 +11,8 @@
 namespace drake {
 namespace lcm {
 
+enum LoopbackSwitch { kWithoutLoopback = 0, kWithLoopback = 1 };
+
 /**
  * A *mock* LCM instance. This does not actually publish or subscribe to LCM
  * messages. It contains additional methods for accessing the most recent
@@ -18,7 +20,18 @@ namespace lcm {
  */
 class DrakeMockLcm : public DrakeLcmInterface {
  public:
+  /**
+   * A constructor that does not loop-back, i.e., a call to Publish() will not
+   * result in subscriber callback function being called.
+   */
   DrakeMockLcm();
+
+  /**
+   * A constructor that optionally enables loop-back behavior. When loop-back
+   * behavior is enabled, a call to Publish() will result in subscriber callback
+   * functions being called.
+   */
+  explicit DrakeMockLcm(LoopbackSwitch loop_back_switch);
 
   // Disable copy and assign.
   DrakeMockLcm(const DrakeMockLcm&) = delete;
@@ -104,6 +117,7 @@ class DrakeMockLcm : public DrakeLcmInterface {
                                int data_size);
 
  private:
+  LoopbackSwitch loop_back_switch_{LoopbackSwitch::kWithoutLoopback};
   bool receive_thread_started_{false};
 
   struct LastPublishedMessage {

--- a/drake/lcm/drake_mock_lcm.h
+++ b/drake/lcm/drake_mock_lcm.h
@@ -11,8 +11,6 @@
 namespace drake {
 namespace lcm {
 
-enum LoopbackSwitch { kWithoutLoopback = 0, kWithLoopback = 1 };
-
 /**
  * A *mock* LCM instance. This does not actually publish or subscribe to LCM
  * messages. It contains additional methods for accessing the most recent
@@ -21,21 +19,17 @@ enum LoopbackSwitch { kWithoutLoopback = 0, kWithLoopback = 1 };
 class DrakeMockLcm : public DrakeLcmInterface {
  public:
   /**
-   * A constructor that does not loop-back, i.e., a call to Publish() will not
-   * result in subscriber callback function being called.
+   * A constructor that creates a DrakeMockLcm where loopback is diabled, i.e.,
+   * a call to Publish() will not result in subscriber callback function being
+   * called. To enable loop-back behavior, call EnableLoopBack().
    */
   DrakeMockLcm();
-
-  /**
-   * A constructor that optionally enables loop-back behavior. When loop-back
-   * behavior is enabled, a call to Publish() will result in subscriber callback
-   * functions being called.
-   */
-  explicit DrakeMockLcm(LoopbackSwitch loop_back_switch);
 
   // Disable copy and assign.
   DrakeMockLcm(const DrakeMockLcm&) = delete;
   DrakeMockLcm& operator=(const DrakeMockLcm&) = delete;
+
+  void EnableLoopBack() { enable_loop_back_ = true; }
 
   void StartReceiveThread() override;
 
@@ -117,7 +111,7 @@ class DrakeMockLcm : public DrakeLcmInterface {
                                int data_size);
 
  private:
-  LoopbackSwitch loop_back_switch_{LoopbackSwitch::kWithoutLoopback};
+  bool enable_loop_back_{false};
   bool receive_thread_started_{false};
 
   struct LastPublishedMessage {

--- a/drake/lcm/test/drake_mock_lcm_test.cc
+++ b/drake/lcm/test/drake_mock_lcm_test.cc
@@ -170,7 +170,8 @@ GTEST_TEST(DrakeMockLcmTest, WithLoopbackTest) {
   // Instantiates the Device Under Test (DUT). Note that loopback is enabled,
   // which results in subscribers being notified when a message is published on
   // the subscribed channel.
-  DrakeMockLcm dut(LoopbackSwitch::kWithLoopback);
+  DrakeMockLcm dut;
+  dut.EnableLoopBack();
 
   // Instantiates a message handler.
   MockMessageHandler handler;
@@ -202,10 +203,10 @@ GTEST_TEST(DrakeMockLcmTest, WithoutLoopbackTest) {
   const string kChannelName =
       "drake_mock_lcm_test_without_loopback_channel";
 
-  // Instantiates the Device Under Test (DUT). Note that loopback is disabled,
-  // which results in subscribers not being notified when a message is published
-  // on the subscribed channel.
-  DrakeMockLcm dut(LoopbackSwitch::kWithoutLoopback);
+  // Instantiates the Device Under Test (DUT). Note that loopback is by default
+  // disabled, which results in subscribers not being notified when a message is
+  // published on the subscribed channel.
+  DrakeMockLcm dut;
 
   // Instantiates a message handler.
   MockMessageHandler handler;


### PR DESCRIPTION
This was extracted from #4682, where it was found that the ability to fake a LCM message loopback is useful to allow a unit test to avoid touching the real network stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4855)
<!-- Reviewable:end -->
