### PR TITLE
Disallow dummy symbolic variables

### DIFF
--- a/drake/common/symbolic_environment.cc
+++ b/drake/common/symbolic_environment.cc
@@ -17,24 +17,42 @@ using std::runtime_error;
 using std::string;
 using std::initializer_list;
 
+namespace {
+void throw_if_dummy(const Variable& var) {
+  if (var.is_dummy()) {
+    ostringstream oss;
+    oss << "Dummy symbolic variable (ID = 0) is detected"
+        << "in the initialization of a symbolic environment.";
+    throw runtime_error(oss.str());
+  }
+}
+
+void throw_if_nan(const double v) {
+  if (std::isnan(v)) {
+    ostringstream oss;
+    oss << "NaN is detected in the initialization of a symbolic environment.";
+    throw runtime_error(oss.str());
+  }
+}
+}  // anonymous namespace
+
 Environment::Environment(const initializer_list<value_type> init) : map_(init) {
   for (const auto& p : init) {
-    if (std::isnan(p.second)) {
-      ostringstream oss;
-      oss << "(" << p.first << ", " << p.second << ")"
-          << " is detected in the initialization of a symbolic environment.";
-      throw runtime_error(oss.str());
-    }
+    throw_if_dummy(p.first);
+    throw_if_nan(p.second);
   }
 }
 
 Environment::Environment(const initializer_list<key_type> vars) {
   for (const auto& var : vars) {
+    throw_if_dummy(var);
     map_.emplace(var, 0.0);
   }
 }
 
 void Environment::insert(const key_type& key, const mapped_type& elem) {
+  throw_if_dummy(key);
+  throw_if_nan(elem);
   map_.emplace(key, elem);
 }
 
@@ -45,6 +63,11 @@ string Environment::to_string() const {
 }
 
 Environment::mapped_type& Environment::operator[](const key_type& key) {
+  if (key.is_dummy()) {
+    ostringstream oss;
+    oss << "Environment::operator[] is called with a dummy variable.";
+    throw runtime_error(oss.str());
+  }
   return map_[key];
 }
 

--- a/drake/common/symbolic_environment.h
+++ b/drake/common/symbolic_environment.h
@@ -32,6 +32,22 @@ namespace symbolic {
  *   const double res2 = e2.Evaluate(env);  // x - y => 2.0 - 3.0 => -1.0
  *   const bool res = f.Evaluate(env);  // x + y > x - y => 5.0 >= -1.0 => True
  * \endcode
+ *
+ * Note that it is not allowed to have a dummy variable in a symbolic
+ * environment. It throws std::runtime_error for the attempts to create an
+ * environment with a dummy variable, to insert a dummy variable to an existing
+ * environment, or to take a reference to a value mapped to a dummy
+ * variable. See the following examples.
+ *
+ * \code{.cpp}
+ *   Variable    var_dummy{};           // OK to have a dummy variable
+ *   Environment e1{var_dummy};         // throws std::runtime_error exception
+ *   Environment e2{{var_dummy, 1.0}};  // throws std::runtime_error exception
+ *   Environment e{};
+ *   e.insert(var_dummy, 1.0);          // throws std::runtime_error exception
+ *   e[var_dummy] = 3.0;                // throws std::runtime_error exception
+ * \endcode
+ *
  */
 class Environment {
  public:
@@ -87,7 +103,8 @@ class Environment {
   std::string to_string() const;
 
   /** Returns a reference to the value that is mapped to a key equivalent to
-   * @p key, performing an insertion if such key does not already exist. */
+   *  @p key, performing an insertion if such key does not already exist.
+   */
   mapped_type& operator[](const key_type& key);
 
   friend std::ostream& operator<<(std::ostream& os, const Environment& env);

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -169,8 +169,8 @@ class Expression {
   Polynomial<double> ToPolynomial() const;
 
   /** Evaluates under a given environment (by default, an empty environment).
-      It throws a std::runtime exception if NaN is detected during evaluation.
-  */
+   *  @throws std::runtime_error if NaN is detected during evaluation.
+   */
   double Evaluate(const Environment& env = Environment{}) const;
 
   /** Returns string representation of Expression. */

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -186,8 +186,9 @@ double BinaryExpressionCell::Evaluate(const Environment& env) const {
 ExpressionVar::ExpressionVar(const Variable& v)
     : ExpressionCell{ExpressionKind::Var, hash_value<Variable>{}(v), true},
       var_{v} {
-  // Variable shouldn't be constructed by the default constructor.
-  DRAKE_DEMAND(var_.get_id() > 0);
+  // Dummy symbolic variable (ID = 0) should not be used in constructing
+  // symbolic expressions.
+  DRAKE_DEMAND(!var_.is_dummy());
 }
 
 Variables ExpressionVar::GetVariables() const { return {get_variable()}; }

--- a/drake/common/symbolic_expression_cell.h
+++ b/drake/common/symbolic_expression_cell.h
@@ -38,11 +38,16 @@ class ExpressionCell {
   virtual bool EqualTo(const ExpressionCell& c) const = 0;
   /** Provides lexicographical ordering between expressions. */
   virtual bool Less(const ExpressionCell& c) const = 0;
-  /** Checks if it is a polynomial. */
+  /** Checks if this symbolic expression is convertible to Polynomial. */
   bool is_polynomial() const { return is_polynomial_; }
-  /** Returns Polynomial. */
+  /** Returns a Polynomial representing this expression.
+   *  Note that the ID of a variable is preserved in this translation.
+   *  \pre{is_polynomial() is true.}
+   */
   virtual Polynomial<double> ToPolynomial() const = 0;
-  /** Evaluates under a given environment. */
+  /** Evaluates under a given environment (by default, an empty environment).
+   *  @throws std::runtime_error if NaN is detected during evaluation.
+   */
   virtual double Evaluate(const Environment& env) const = 0;
   /** Outputs string representation of expression into output stream @p os. */
   virtual std::ostream& Display(std::ostream& os) const = 0;

--- a/drake/common/symbolic_variable.h
+++ b/drake/common/symbolic_variable.h
@@ -18,16 +18,23 @@ class Variable {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Variable)
 
-  /** Default constructor. This is needed to have Eigen::Matrix<Variable>. The
-      objects created by the default constructor share the same ID, zero. As a
-      result, they all are identified as a single variable by equality operator
-      (==). They all have the same hash value as well.
+  /** Default constructor. Constructs a dummy variable. This is needed to have
+   *  Eigen::Matrix<Variable>. The objects created by the default constructor
+   *  share the same ID, zero. As a result, they all are identified as a single
+   *  variable by equality operator (==). They all have the same hash value as
+   *  well.
+   *
+   *  It is allowed to construct a dummy variable but it should not be used to
+   *  construct a symbolic expression.
    */
   Variable() : id_{0}, name_{std::string()} {}
 
   /** Constructs a variable with a string . */
   explicit Variable(const std::string& name);
 
+  /** Checks if this is a dummy variable (ID = 0) which is created by
+   *  the default constructor. */
+  bool is_dummy() const { return get_id() == 0; }
   size_t get_id() const;
   size_t get_hash() const { return std::hash<size_t>{}(id_); }
   std::string get_name() const;

--- a/drake/common/test/symbolic_environment_test.cc
+++ b/drake/common/test/symbolic_environment_test.cc
@@ -18,6 +18,7 @@ using std::runtime_error;
 // Provides common variables that are used by the following tests.
 class SymbolicEnvironmentTest : public ::testing::Test {
  protected:
+  const Variable var_dummy_{};
   const Variable var_x_{"x"};
   const Variable var_y_{"y"};
   const Variable var_z_{"z"};
@@ -71,6 +72,16 @@ TEST_F(SymbolicEnvironmentTest, ToString) {
   EXPECT_TRUE(out.find("x -> 2") != string::npos);
   EXPECT_TRUE(out.find("y -> 3") != string::npos);
   EXPECT_TRUE(out.find("z -> 3") != string::npos);
+}
+
+TEST_F(SymbolicEnvironmentTest, DummyVariable1) {
+  EXPECT_THROW(Environment({var_dummy_, var_x_}), runtime_error);
+  EXPECT_THROW(Environment({{var_dummy_, 1.0}, {var_x_, 2}}), runtime_error);
+}
+
+TEST_F(SymbolicEnvironmentTest, DummyVariable2) {
+  Environment env{{var_x_, 2}, {var_y_, 3}, {var_z_, 3}};
+  EXPECT_THROW(env.insert(var_dummy_, 0.0), runtime_error);
 }
 
 }  // namespace

--- a/drake/common/test/symbolic_variable_test.cc
+++ b/drake/common/test/symbolic_variable_test.cc
@@ -38,7 +38,11 @@ class SymbolicVariableTest : public ::testing::Test {
 };
 
 TEST_F(SymbolicVariableTest, GetId) {
+  const Variable dummy{};
   const Variable x_prime{"x"};
+  EXPECT_TRUE(dummy.is_dummy());
+  EXPECT_FALSE(x_.is_dummy());
+  EXPECT_FALSE(x_prime.is_dummy());
   EXPECT_NE(x_.get_id(), x_prime.get_id());
 }
 


### PR DESCRIPTION
It is valid to construct a dummy variable but the following operations
are not allowed (throw a runtime_error exception):

 - Evaluating a symbolic expression including a dummy variable.
 - Constructing a symbolic environment with a dummy variable.
 - Converting a symbolic expression including a dummy variable into a
   Polynomial via Expression::ToPolynomial method. Note that
   Expression::is_polynomial returns false if an expression includes a

Close https://github.com/RobotLocomotion/drake/issues/4850

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4860)
<!-- Reviewable:end -->
