### PR TITLE
Rebuilt PR to replace #4805.

### DIFF
--- a/drake/examples/painleve/CMakeLists.txt
+++ b/drake/examples/painleve/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_with_exports(LIB_NAME drakePainleve SOURCE_FILES
 target_link_libraries(drakePainleve
   drakeCommon
   drakeSystemFramework
+  drakeOptimization
   )
 drake_install_libraries(drakePainleve)
 drake_install_headers(

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -6,29 +6,65 @@
 // For background, see http://drake.mit.edu/cxx_inl.html.
 
 #include <limits>
+#include <memory>
+#include <vector>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/examples/painleve/painleve.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace painleve {
 
 template <typename T>
 Painleve<T>::Painleve() {
+  // Piecewise DAE approach needs six continuous variables.
   this->DeclareContinuousState(3, 3, 0);
   this->DeclareOutputPort(systems::kVectorValued, 6);
 }
 
-// Utility method for determining the lower rod endpoint.
+template <typename T>
+Painleve<T>::Painleve(double dt) : dt_(dt) {
+  // Verify that step size parameter is valid.
+  if (dt_ <= 0.0)
+    throw std::logic_error("Time stepping system must be constructed using "
+                               "positive integration step.");
+
+  // Time stepping approach requires three position variables and
+  // three velocity variables.
+  this->DeclareDiscreteState(6);
+  this->DeclareDiscreteUpdatePeriodSec(dt);
+  this->DeclareOutputPort(systems::kVectorValued, 6);
+}
+
+/// Gets the integer variable 'k' used to determine the point of contact
+/// indicated by the current mode.
+/// @throws std::logic_error if this is a time-stepping system (implying that
+///         modes are unused).
+/// @returns the value -1 to indicate the bottom of the rod (when theta = pi/2),
+///          +1 to indicate the top of the rod (when theta = pi/2), or 0 to
+///          indicate the mode where both endpoints of the rod are contacting
+///          the halfspace.
 template <class T>
-std::pair<T, T> Painleve<T>::CalcRodLowerEndpoint(const T& x,
-                                                  const T& y,
-                                                  const int k,
-                                                  const T& ctheta,
-                                                  const T& stheta,
-                                                  const double half_rod_len) {
+int Painleve<T>::get_k(const systems::Context<T>& context) const {
+  if (is_time_stepping_system())
+    throw std::logic_error("'k' is not valid for time stepping systems.");
+  const int k = context.template get_abstract_state<int>(1);
+  DRAKE_DEMAND(std::abs(k) <= 1);
+  return k;
+}
+
+// Utility method for determining the rod endpoint, given the endpoint 
+// k = { -1, 0, 1 }.
+template <class T>
+std::pair<T, T> Painleve<T>::CalcRodEndpoint(const T& x,
+                                             const T& y,
+                                             const int k,
+                                             const T& ctheta,
+                                             const T& stheta,
+                                             const double half_rod_len) {
   const T cx = x + k * ctheta * half_rod_len;
   const T cy = y + k * stheta * half_rod_len;
   return std::make_pair(cx, cy);
@@ -47,10 +83,180 @@ void Painleve<T>::DoCalcOutput(const systems::Context<T>& context,
       context.get_continuous_state()->CopyToVector();
 }
 
+/// Integrates the Painleve Paradox example forward in time using a
+/// half-explicit time stepping scheme.
+template <class T>
+void Painleve<T>::DoCalcDiscreteVariableUpdates(
+                           const systems::Context<T>& context,
+                           systems::DiscreteState<T>* discrete_state) const {
+  // Set ERP (error reduction parameter) and CFM (constraint force mixing) 
+  // to make this problem "mostly rigid" and with rapid stabilization. These
+  // parameters are described in the Open Dynamics Engine user manual (see
+  // http://ode.org/ode-latest-userguide.html#sec_3_8 titled "Soft constraint
+  // and constraint force mixing (CFM)") as well as in a presentation by
+  // Erin Catto at the 2011 Game Developers Conference (Soft Constraints:
+  // Reinventing the Spring, 
+  // http://box2d.org/files/GDC2011/GDC2011_Catto_Erin_Soft_Constraints.pdf).
+  const double erp = 0.8;
+  const double cfm = 1e-8;
+
+  // Get the necessary state variables.
+  const systems::BasicVector<T>& state = *context.get_discrete_state(0);
+  const auto& q = state.get_value().template segment<3>(0);
+  Vector3<T> v = state.get_value().template segment<3>(3);
+  const T& x = q(0);
+  const T& y = q(1);
+  const T& theta = q(2);
+
+  // Compute the two rod vertical endpoint locations.
+  const T stheta = sin(theta);
+  const T ctheta = cos(theta);
+  const int k1 = -1.0;
+  const int k2 = 1.0;
+  const T half_rod_length = rod_length_ / 2;
+
+  // Three generalized coordinates / velocities.
+  const int ngc = 3;
+
+  // Two contact points, corresponding to the two rod endpoints, are always
+  // used, regardless of whether any part of the rod is in contact with the
+  // halfspace. This practice is standard in time stepping approaches with
+  // constraint stabilization. See:
+  // M. Anitescu and G. Hart. A Constraint-Stabilized Time-Stepping Approach
+  // for Rigid Multibody Dynamics with Joints, Contact, and Friction. Intl.
+  // J. for Numerical Methods in Engr., 60(14), 2004.
+  const int nc = 2;
+
+  // The two contact points are (xep1, yep1) and (xep2, yep2).
+  const T xep1 = x + k1 * ctheta * half_rod_length;
+  const T yep1 = y + k1 * stheta * half_rod_length;
+  const T xep2 = x + k2 * ctheta * half_rod_length;
+  const T yep2 = y + k2 * stheta * half_rod_length;
+
+  // Total number of friction directions = number of friction directions
+  // per contact * number of contacts. Because this problem is two dimensional,
+  // no polygonalization of a friction cone is necessary. However, the LCP
+  // variables can only assume positive values, so the negation of the tangent
+  // direction permits obtaining the same effect.
+  const int nk = 2 * nc;
+
+  // Problem matrices and vectors are mildly adapted from:
+  // M. Anitescu and F. Potra. Formulating Dynamic Multi-Rigid Body Contact
+  // Problems as Solvable Linear Complementarity Problems. Nonlinear Dynamics,
+  // 14, 1997.
+
+  // Set up the inverse generalized inertia matrix, expressed in Frame A:
+  // aligned with the "world" and located at the center of mass of the rod.
+  Matrix3<T> iM;
+  iM << 1.0/mass_, 0,         0,
+        0,         1.0/mass_, 0,
+        0,         0,         1.0/J_;
+
+  // Update the generalized velocity vector with discretized external forces
+  // (expressed in Frame A).
+  v(1) += dt_ * get_gravitational_acceleration();
+
+  // Set up the contact normal and tangent (friction) direction Jacobian
+  // matrices. These take the form:
+  //     | 0 1 n1 |        | 1 0 f1 |
+  // N = | 0 1 n2 |    F = | 1 0 f2 |
+  // where n1, n2/f1, f2 are the moment arm induced by applying the
+  // force at the given contact point along the normal/tangent direction.
+  MatrixX<T> N(nc, ngc), F(nc, ngc);
+  N(0, 0) = N(1, 0) = 0;
+  N(0, 1) = N(1, 1) = 1;
+  N(0, 2) = (xep1 - x);
+  N(1, 2) = (xep2 - x);
+  F(0, 0) = F(1, 0) = 1;
+  F(0, 1) = F(1, 1) = 0;
+  F(0, 2) = -(yep1 - y);
+  F(1, 2) = -(yep2 - y);
+
+  // Construct a matrix similar to E in Anitscu and Potra 1997. This matrix
+  // will yield mu*fN - E*fF = 0, or, equivalently:
+  // mu*fN₁ - fF₁⁺ - fF₁⁻ ≥ 0
+  // mu*fN₂ - fF₂⁺ - fF₂⁻ ≥ 0
+  MatrixX<T> E(nk, nc);
+  E.col(0) << 1, 0, 1, 0;
+  E.col(1) << 0, 1, 0, 1;
+
+  // Construct the LCP matrix. First do the "normal contact direction" rows.
+  MatrixX<T> MM(8, 8);
+  MM.template block<2, 2>(0, 0) = N * iM * N.transpose();
+  MM.template block<2, 2>(0, 2) = N * iM * F.transpose();
+  MM.template block<2, 2>(0, 4) = -MM.template block<2, 2>(0, 2);
+  MM.template block<2, 2>(0, 6).setZero();
+
+  // Now construct the un-negated tangent contact direction rows (everything
+  // but last block column).
+  MM.template block<2, 2>(2, 0) = F * iM * N.transpose();
+  MM.template block<2, 2>(2, 2) = F * iM * F.transpose();
+  MM.template block<2, 2>(2, 4) = -MM.template block<2, 2>(2, 2);
+
+  // Now construct the negated tangent contact direction rows (everything but
+  // last block column). These negated tangent contact directions allow the
+  // LCP to compute forces applied along the negative x-axis.
+  MM.template block<2, 6>(4, 0) = -MM.template block<2, 6>(2, 0);
+
+  // Construct the last block column for the last set of rows (see Anitescu and
+  // Potra, 1997).
+  MM.template block<4, 2>(2, 6) = E;
+
+  // Construct the last two rows, which provide the friction "cone" constraint.
+  MM.template block<2, 2>(6, 0) = Matrix2<T>::Identity() * get_mu_coulomb();
+  MM.template block<2, 4>(6, 2) = -E.transpose();
+  MM.template block<2, 2>(6, 6).setZero();
+
+  // Construct the LCP vector.
+  VectorX<T> qq(8);
+  qq.segment(0, 2) = N * v;
+  qq(0) += erp * yep1/dt_;
+  qq(1) += erp * yep2/dt_;
+  qq.segment(2, 2) = F * v;
+  qq.segment(4, 2) = -qq.segment(2, 2);
+  qq.template segment(6, 2).setZero();
+
+  // Regularize the LCP matrix: this is essentially Tikhonov Regularization.
+  // Cottle et al. show that any linear complementarity problem is solvable
+  // for sufficiently large cfm.
+  // R. Cottle, J.-S. Pang, and R. Stone. The Linear Complementarity Problem.
+  // Academic Press, 1992.
+  MM += MatrixX<T>::Identity(8, 8) * cfm;
+
+  // Solve the LCP.
+  VectorX<T> zz;
+  bool success = lcp_.SolveLcpLemke(MM, qq, &zz);
+  DRAKE_DEMAND(success);
+
+  // Obtain the normal and frictional contact forces.
+  VectorX<T> fN = zz.segment(0, 2);
+  VectorX<T> fF_pos = zz.segment(2, 2);
+  VectorX<T> fF_neg = zz.segment(4, 2);
+
+  // Compute the new velocity. Note that external forces have already been
+  // incorporated into v.
+  VectorX<T> vplus = v + iM * (N.transpose()*fN + F.transpose()*fF_pos -
+                               F.transpose()*fF_neg);
+
+  // Compute the new position using explicit Euler integration.
+  VectorX<T> qplus = q + vplus*dt_;
+
+  // Set the new discrete state.
+  systems::BasicVector<T>* new_state = discrete_state->
+      get_mutable_discrete_state(0);
+  new_state->get_mutable_value().segment(0, 3) = qplus;
+  new_state->get_mutable_value().segment(3, 3) = vplus;
+}
+
+/// Models impact using an inelastic impact model with friction.
 template <typename T>
 void Painleve<T>::HandleImpact(const systems::Context<T>& context,
-                               systems::ContinuousState<T>* new_state) const {
+                               systems::State<T>* new_state) const {
   using std::abs;
+
+  // This method is only used for piecewise DAE integration. The time
+  // stepping method implicitly incorporates impact into its model.
+  DRAKE_DEMAND(!is_time_stepping_system());
 
   // Get the necessary parts of the state.
   const systems::VectorBase<T>& state = context.get_continuous_state_vector();
@@ -61,13 +267,19 @@ void Painleve<T>::HandleImpact(const systems::Context<T>& context,
   const T& ydot = state.GetAtIndex(4);
   const T& thetadot = state.GetAtIndex(5);
 
-  // Get the state vector.
-  systems::VectorBase<T>* new_statev = new_state->get_mutable_vector();
+  // Get the continuous state vector.
+  systems::VectorBase<T>* new_statev = new_state->
+      get_mutable_continuous_state()->get_mutable_vector();
 
   // Positional aspects of state do not change.
   new_statev->SetAtIndex(0, x);
   new_statev->SetAtIndex(1, y);
   new_statev->SetAtIndex(2, theta);
+
+  // Copy abstract variables (mode and contact point) by default. Mode
+  // may change depending on impact outcome.
+  new_state->get_mutable_abstract_state()->CopyFrom(
+      *context.get_abstract_state());
 
   // If there is no impact, quit now.
   if (!IsImpacting(context)) {
@@ -76,6 +288,9 @@ void Painleve<T>::HandleImpact(const systems::Context<T>& context,
     new_statev->SetAtIndex(5, thetadot);
     return;
   }
+
+  // TODO(edrumwri): Handle two-point impact.
+  DRAKE_DEMAND(abs(sin(theta)) >= std::numeric_limits<T>::epsilon());
 
   // The two points of the rod are located at (x,y) + R(theta)*[0,r/2] and
   // (x,y) + R(theta)*[0,-r/2], where
@@ -90,7 +305,7 @@ void Painleve<T>::HandleImpact(const systems::Context<T>& context,
   const T stheta = sin(theta);
   const int k = (stheta > 0) ? -1 : 1;
   const double half_rod_length = rod_length_ / 2;
-  const std::pair<T, T> c = CalcRodLowerEndpoint(x, y, k, ctheta, stheta,
+  const std::pair<T, T> c = CalcRodEndpoint(x, y, k, ctheta, stheta,
                                                  half_rod_length);
   const T cx = c.first;
   const T cy = c.second;
@@ -108,6 +323,14 @@ void Painleve<T>::HandleImpact(const systems::Context<T>& context,
     const Vector2<T> f_sliding = CalcFConeImpactImpulse(context);
     fN = f_sliding(0);
     fF = f_sliding(1);
+
+    // Set the mode to sliding.
+    new_state->template get_mutable_abstract_state<Mode>(0) =
+      Painleve<T>::kSlidingSingleContact;
+  } else {
+    // Set the mode to sticking.
+    new_state->template get_mutable_abstract_state<Mode>(0) =
+      Painleve<T>::kStickingSingleContact;
   }
 
   // Compute the change in linear velocity.
@@ -301,9 +524,9 @@ Vector2<T> Painleve<T>::CalcStickingImpactImpulse(
 
 // Sets the velocity derivatives for the rod, given contact forces.
 template <class T>
-void Painleve<T>::SetVelocityDerivatives(const systems::Context<T>& context,
-                                         systems::VectorBase<T>* const f,
-                                         T fN, T fF, T cx, T cy) const {
+void Painleve<T>::SetAccelerations(const systems::Context<T>& context,
+                                   systems::VectorBase<T>* const f,
+                                   T fN, T fF, T cx, T cy) const {
   using std::abs;
 
   // Get necessary state variables.
@@ -327,7 +550,7 @@ void Painleve<T>::SetVelocityDerivatives(const systems::Context<T>& context,
   const double r = rod_length_;
   const T ctheta = cos(theta);
   const T stheta = sin(theta);
-  const int k = (stheta > 0) ? -1 : 1;
+  const int k = get_k(context);
 
   // Verify that the vertical acceleration at the point of contact is zero
   // (i.e., cyddot = 0).
@@ -387,7 +610,7 @@ Vector2<T> Painleve<T>::CalcStickingContactForces(
   // Precompute quantities that will be used repeatedly.
   const T ctheta = cos(theta);
   const T stheta = sin(theta);
-  const int k = (stheta > 0) ? -1 : 1;
+  const int k = get_k(context);
 
   // Set named Mathematica constants.
   const double mass = mass_;
@@ -417,10 +640,10 @@ Vector2<T> Painleve<T>::CalcStickingContactForces(
   return Vector2<T>(fN, fF);
 }
 
-// Computes the time derivatives for the case of the rod contacting the
-// surface at exactly one point and with sliding velocity.
+// Computes the accelerations of the rod center of mass for the case of the rod
+// contacting the surface at exactly one point and with sliding velocity.
 template <class T>
-void Painleve<T>::CalcTimeDerivativesOneContactSliding(
+void Painleve<T>::CalcAccelerationsOneContactSliding(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
   using std::abs;
@@ -446,10 +669,10 @@ void Painleve<T>::CalcTimeDerivativesOneContactSliding(
   const double half_rod_length = rod_length_ / 2;
   const T ctheta = cos(theta);
   const T stheta = sin(theta);
-  const int k = (stheta > 0) ? -1 : 1;
+  const int k = get_k(context);
 
   // Determine the point of contact (cx, cy).
-  const std::pair<T, T> c = CalcRodLowerEndpoint(x, y, k, ctheta, stheta,
+  const std::pair<T, T> c = CalcRodEndpoint(x, y, k, ctheta, stheta,
                                                  half_rod_length);
   const T cx = c.first;
   const T cy = c.second;
@@ -522,10 +745,10 @@ void Painleve<T>::CalcTimeDerivativesOneContactSliding(
   DRAKE_DEMAND(abs(cyddot) < std::numeric_limits<double>::epsilon() * 10);
 }
 
-// Computes the time derivatives for the case of the rod contacting the
-// surface at exactly one point and without any sliding velocity.
+// Computes the accelerations of the rod center of mass for the case of the rod
+// contacting the surface at exactly one point and without any sliding velocity.
 template <class T>
-void Painleve<T>::CalcTimeDerivativesOneContactNoSliding(
+void Painleve<T>::CalcAccelerationsOneContactNoSliding(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
   using std::abs;
@@ -540,12 +763,12 @@ void Painleve<T>::CalcTimeDerivativesOneContactNoSliding(
   const T& theta = context.get_continuous_state_vector().GetAtIndex(2);
   const T& thetadot = context.get_continuous_state_vector().GetAtIndex(5);
 
-  // Compute contact point.
+  // Get the contact point.
+  const int k = get_k(context);
   const double half_rod_length = rod_length_ / 2;
   const T ctheta = cos(theta);
   const T stheta = sin(theta);
-  const int k = (stheta > 0) ? -1 : 1;
-  const std::pair<T, T> c = CalcRodLowerEndpoint(x, y, k, ctheta, stheta,
+  const std::pair<T, T> c = CalcRodEndpoint(x, y, k, ctheta, stheta,
                                                  half_rod_length);
   const T cx = c.first;
   const T cy = c.second;
@@ -606,20 +829,20 @@ void Painleve<T>::CalcTimeDerivativesOneContactNoSliding(
 
     // Pick the one that is smaller in magnitude.
     if (abs(cxddot1) < abs(cxddot2)) {
-      SetVelocityDerivatives(context, f, fN1, fF1, cx, cy);
+      SetAccelerations(context, f, fN1, fF1, cx, cy);
     } else {
-      SetVelocityDerivatives(context, f, fN2, fF2, cx, cy);
+      SetAccelerations(context, f, fN2, fF2, cx, cy);
     }
   } else {
     // Friction force is within the friction cone.
-    SetVelocityDerivatives(context, f, fN, fF, cx, cy);
+    SetAccelerations(context, f, fN, fF, cx, cy);
   }
 }
 
-// Computes the time derivatives for the case of the rod contacting the
-// surface at more than one point.
+// Computes the accelerations of the rod center of mass for the case of the rod
+// contacting the surface at more than one point.
 template <class T>
-void Painleve<T>::CalcTimeDerivativesTwoContact(
+void Painleve<T>::CalcAccelerationsTwoContact(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
   using std::abs;
@@ -651,6 +874,8 @@ bool Painleve<T>::IsImpacting(const systems::Context<T>& context) const {
   using std::sin;
   using std::cos;
 
+  // Note: we do not consider modes here.
+
   // Get state data necessary to compute the point of contact.
   const systems::VectorBase<T>& state = context.get_continuous_state_vector();
   const T& y = state.GetAtIndex(1);
@@ -662,7 +887,7 @@ bool Painleve<T>::IsImpacting(const systems::Context<T>& context) const {
   const double half_rod_length = rod_length_ / 2;
   const T ctheta = cos(theta);
   const T stheta = sin(theta);
-  const int k = (stheta > 0) ? -1 : 1;
+  const int k = (stheta > 0) ? -1 : (stheta < 0) ? 1 : 0;
   const T cy = y + k * stheta * half_rod_length;
 
   // If rod endpoint is not touching, there is no impact.
@@ -676,6 +901,22 @@ bool Painleve<T>::IsImpacting(const systems::Context<T>& context) const {
   return (cydot < -std::numeric_limits<double>::epsilon());
 }
 
+// Computes the accelerations of the rod center of mass for the case of
+// ballistic motion.
+template <typename T>
+void Painleve<T>::CalcAccelerationsBallistic(
+    const systems::Context<T>& context,
+    systems::ContinuousState<T>* derivatives) const {
+  // Obtain the structure we need to write into.
+  systems::VectorBase<T>* const f = derivatives->get_mutable_vector();
+
+  // Second three derivative components are simple: just add in gravitational
+  // acceleration.
+  f->SetAtIndex(3, T(0));
+  f->SetAtIndex(4, get_gravitational_acceleration());
+  f->SetAtIndex(5, T(0));
+}
+
 template <typename T>
 void Painleve<T>::DoCalcTimeDerivatives(
     const systems::Context<T>& context,
@@ -685,20 +926,14 @@ void Painleve<T>::DoCalcTimeDerivatives(
   using std::cos;
   using std::abs;
 
-  // TODO(edrumwri): This method currently determines the (hybrid) dynamics
-  //                 mode based on the current values of the state variables.
-  //                 Different dynamics equations are evaluated depending on
-  //                 which mode is selected (e.g., sliding at a single contact,
-  //                 ballistic motion, etc.) A future update to this example
-  //                 will store the dynamics mode as an abstract variable, and
-  //                 this mode variable will be updated through event handling
-  //                 functions.
+  // Don't compute any derivatives if this is the time stepping system.
+  if (is_time_stepping_system()) {
+    DRAKE_ASSERT(derivatives->size() == 0);
+    return;
+  }
 
   // Get the necessary parts of the state.
   const systems::VectorBase<T>& state = context.get_continuous_state_vector();
-  const T& x = state.GetAtIndex(0);
-  const T& y = state.GetAtIndex(1);
-  const T& theta = state.GetAtIndex(2);
   const T& xdot = state.GetAtIndex(3);
   const T& ydot = state.GetAtIndex(4);
   const T& thetadot = state.GetAtIndex(5);
@@ -706,67 +941,51 @@ void Painleve<T>::DoCalcTimeDerivatives(
   // Obtain the structure we need to write into.
   systems::VectorBase<T>* const f = derivatives->get_mutable_vector();
 
-  // The two endpoints of the rod are located at (x,y) + R(theta)*[0,r/2] and
-  // (x,y) + R(theta)*[0,-r/2], where
-  // R(theta) = | cos(theta) -sin(theta) |
-  //            | sin(theta)  cos(theta) |
-  // and r is designated as the rod length. Thus, the heights of
-  // the rod endpoints are y + sin(theta)*r/2 and y - sin(theta)*r/2.
-  const double half_rod_length = rod_length_ / 2;
-  const T ctheta = cos(theta);
-  const T stheta = sin(theta);
-  const int k = (stheta > 0) ? -1 : 1;
-
-  // Determine the height of the point of contact (cx, cy).
-  const T cy =  CalcRodLowerEndpoint(x, y, k, ctheta, stheta,
-                                     half_rod_length).second;
-
-  // Compute the horizontal velocity at the point of contact.
-  const T cxdot = xdot - k * stheta * half_rod_length * thetadot;
+  // Get the abstract variables that determine the current system mode and
+  // the endpoint in contact.
+  const Mode mode = context.template get_abstract_state<Mode>(0);
 
   // First three derivative components are xdot, ydot, thetadot.
   f->SetAtIndex(0, xdot);
   f->SetAtIndex(1, ydot);
   f->SetAtIndex(2, thetadot);
 
-  // Case 1 (ballistic mode): the rod is not touching the ground
-  // (located at y=0).
-  if (cy > std::numeric_limits<double>::epsilon()) {
-    // Second three derivative components are simple: just add in gravitational
-    // acceleration.
-    f->SetAtIndex(3, T(0));
-    f->SetAtIndex(4, get_gravitational_acceleration());
-    f->SetAtIndex(5, T(0));
+  // Call the proper derivative function (depending on mode type).
+  switch (mode) {
+    case kBallisticMotion:
+      return CalcAccelerationsBallistic(context, derivatives);
+    case kSlidingSingleContact:
+      return CalcAccelerationsOneContactSliding(context, derivatives);
+    case kStickingSingleContact:
+      return CalcAccelerationsOneContactNoSliding(context, derivatives);
+    case kSlidingTwoContacts:
+      return CalcAccelerationsTwoContact(context, derivatives);
+    case kStickingTwoContacts:
+      return CalcAccelerationsTwoContact(context, derivatives);
+
+    default:
+      DRAKE_ABORT();
+  }
+}
+
+/// Allocates the abstract state (for piecewise DAE systems).
+template <typename T>
+std::unique_ptr<systems::AbstractState> Painleve<T>::
+  AllocateAbstractState() const {
+  if (!is_time_stepping_system()) {
+    // Piecewise DAE approach needs two abstract variables (one mode and one
+    // contact point indicator).
+    std::vector<std::unique_ptr<systems::AbstractValue>> abstract_data;
+    abstract_data.push_back(
+        std::make_unique<systems::Value<Painleve<T>::Mode>>(
+            Painleve<T>::kInvalid));
+
+    // Indicates that the rod is in contact at both points.
+    abstract_data.push_back(std::make_unique<systems::Value<int>>(0));
+    return std::make_unique<systems::AbstractState>(std::move(abstract_data));
   } else {
-    // Case 2: the rod is touching the ground (or even embedded in the ground).
-    // Constraint stabilization should be used to eliminate embedding, but we
-    // perform no such check in the derivative evaluation.
-
-    // Handle the case where the rod is both parallel to the halfspace and
-    // contacting the halfspace (at the entire length of the rod).
-    // TODO(edrumwri): Modify this two-contact point routine to account for
-    //                 contacts along the entire length of the rod, assumingly
-    //                 only a single coefficient of friction).
-    if (abs(sin(theta)) < std::numeric_limits<double>::epsilon()) {
-      CalcTimeDerivativesTwoContact(context, derivatives);
-      return;
-    }
-
-    // At this point, it is known that exactly one endpoint of the rod is
-    // touching the halfspace. Compute the normal acceleration at that point of
-    // contact (cy_ddot), *assuming zero contact force*.
-    T cyddot = get_gravitational_acceleration() -
-               k * half_rod_length * stheta * thetadot * thetadot;
-
-    // If this derivative is negative, we must compute the normal force
-    // necessary to set it to zero.
-    if (cyddot < 0) {
-      // Look for the case where the tangential velocity is zero.
-      if (abs(cxdot) < std::numeric_limits<double>::epsilon())
-        CalcTimeDerivativesOneContactNoSliding(context, derivatives);
-      else
-        CalcTimeDerivativesOneContactSliding(context, derivatives);
-    }
+    // Time stepping approach needs no abstract variables.
+    return std::make_unique<systems::AbstractState>();
   }
 }
 
@@ -782,7 +1001,24 @@ void Painleve<T>::SetDefaultState(const systems::Context<T>& context,
   VectorX<T> x0(6);
   const double r22 = sqrt(2) / 2;
   x0 << half_len * r22, half_len * r22, M_PI / 4.0, -1, 0, 0;  // Initial state.
-  state->get_mutable_continuous_state()->SetFromVector(x0);
+  if (!is_time_stepping_system()) {
+    // DAE mode.
+    state->get_mutable_continuous_state()->SetFromVector(x0);
+
+    // Indicate that the rod is in the single contact sliding mode.
+    state->get_mutable_abstract_state()->get_mutable_abstract_state(0).
+        template GetMutableValue<Painleve<T>::Mode>() =
+            Painleve<T>::kSlidingSingleContact;
+
+    // Determine and set the point of contact.
+    const double theta = x0(2);
+    const int k = (std::sin(theta) > 0) ? -1 : 1;
+    state->get_mutable_abstract_state()->get_mutable_abstract_state(1).
+        template GetMutableValue<int>() = k;
+  } else {
+    state->get_mutable_discrete_state()->get_mutable_discrete_state(0)->
+        SetFromVector(x0);
+  }
 }
 
 }  // namespace painleve

--- a/drake/examples/painleve/painleve.cc
+++ b/drake/examples/painleve/painleve.cc
@@ -5,7 +5,6 @@ namespace drake {
 namespace painleve {
 
 template class Painleve<double>;
-template class Painleve<Eigen::AutoDiffScalar<drake::Vector1d>>;
 
 }  // namespace painleve
 }  // namespace drake

--- a/drake/examples/painleve/painleve.h
+++ b/drake/examples/painleve/painleve.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <memory>
 #include <utility>
 
+#include "drake/solvers/moby_lcp_solver.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -30,22 +32,63 @@ namespace painleve {
 ///         index 2), and planar linear velocity (state indices 3 and 4) and
 ///         scalar angular velocity (state index 5) in units of m, radians,
 ///         m/s, and rad/s, respectively. Orientation is measured counter-
-///         clockwise with respect to the x-axis.
+///         clockwise with respect to the x-axis. One abstract state variable
+///         (of type Painleve::Mode) is used to identify which dynamic mode
+///         the system is in (e.g., ballistic, contacting at one point and
+///         sliding, etc.) and one abstract state variable (of type int) is used
+///         to determine which endpoint(s) of the rod contact the halfspace
+///         (k=-1 indicates the bottom of the rod when theta = pi/2, k=+1
+///         indicates the top of the rod when theta = pi/2, and k=0 indicates
+///         both endpoints of the rod are contacting the halfspace).
 ///
-/// Outputs: same as state.
+/// Outputs: planar position (state indices 0 and 1) and orientation (state
+///          index 2), and planar linear velocity (state indices 3 and 4) and
+///          scalar angular velocity (state index 5) in units of m, radians,
+///          m/s, and rad/s, respectively.
 ///
 /// * [Stewart, 2000]  D. Stewart, "Rigid-Body Dynamics with Friction and
-///                    Impact. SIAM Rev., 42(1), 3-39, 2000.
+///                    Impact". SIAM Rev., 42(1), 3-39, 2000.
 template <typename T>
 class Painleve : public systems::LeafSystem<T> {
  public:
+  /// Possible dynamic modes for the Painleve Paradox rod.
+  enum Mode {
+    /// Mode is invalid.
+    kInvalid,
+
+    /// Rod is currently undergoing ballistic motion.
+    kBallisticMotion,
+
+    /// Rod is sliding while undergoing non-impacting contact at one contact
+    /// point (a rod endpoint); the other rod endpoint is not in contact.
+    kSlidingSingleContact,
+
+    /// Rod is sticking while undergoing non-impacting contact at one contact
+    /// point (a rod endpoint); the other rod endpoint is not in contact.
+    kStickingSingleContact,
+
+    /// Rod is sliding at two contact points without impact.
+    kSlidingTwoContacts,
+
+    /// Rod is sticking at two contact points without impact.
+    kStickingTwoContacts
+  };
+
+  /// Constructor for the Painleve' Paradox system using a piecewise DAE
+  /// (differential algebraic equation) based approach.
   Painleve();
+
+  /// Constructor for the Painleve' Paradox system using a time stepping
+  /// approach.
+  /// @param dt The integration step size. This step size cannot be reset
+  ///           after construction.
+  /// @throws std::logic_error if @p dt is not positive.
+  explicit Painleve(double dt);
 
   /// Models impact using an inelastic impact model with friction.
   /// @p new_state is set to the output of the impact model on return.
-  void HandleImpact(
-      const systems::Context<T>& context,
-      systems::ContinuousState<T>* new_state) const;
+  void HandleImpact(const systems::Context<T>& context,
+                    systems::State<T>* new_state) const;
 
   /// Gets the acceleration (with respect to the positive y-axis) due to
   /// gravity (i.e., this number should generally be negative).
@@ -87,41 +130,57 @@ class Painleve : public systems::LeafSystem<T> {
   /// this method returns `false`.
   bool IsImpacting(const systems::Context<T>& context) const;
 
+  /// Gets the integration step size for the time stepping system.
+  /// @returns 0 if this is a DAE-based system.
+  double get_integration_step_size() const { return dt_; }
+
+  /// Determines whether this is a time stepping system.
+  bool is_time_stepping_system() const { return dt_ > 0.0; }
+
  protected:
-  void SetDefaultState(const systems::Context<T>& context,
-                       systems::State<T>* state) const override;
+  int get_k(const systems::Context<T>& context) const;
+  std::unique_ptr<systems::AbstractState> AllocateAbstractState()
+                                            const override;
   void DoCalcOutput(const systems::Context<T>& context,
                     systems::SystemOutput<T>* output) const override;
-
-  void DoCalcTimeDerivatives(
-      const systems::Context<T>& context,
-      systems::ContinuousState<T>* derivatives) const override;
+  void DoCalcTimeDerivatives(const systems::Context<T>& context,
+                             systems::ContinuousState<T>* derivatives)
+                               const override;
+  void DoCalcDiscreteVariableUpdates(const systems::Context<T>& context,
+                                     systems::DiscreteState<T>* discrete_state)
+      const override;
+  void SetDefaultState(const systems::Context<T>& context,
+                       systems::State<T>* state) const override;
 
  private:
   Vector2<T> CalcStickingImpactImpulse(const systems::Context<T>& context)
     const;
   Vector2<T> CalcFConeImpactImpulse(const systems::Context<T>& context) const;
-  void CalcTimeDerivativesTwoContact(const systems::Context<T>& context,
-                                       systems::ContinuousState<T>* derivatives)
-                                         const;
-  void CalcTimeDerivativesOneContactNoSliding(
+  void CalcAccelerationsBallistic(const systems::Context<T>& context,
+                                  systems::ContinuousState<T>* derivatives)
+                                    const;
+  void CalcAccelerationsTwoContact(const systems::Context<T>& context,
+                                   systems::ContinuousState<T>* derivatives)
+                                     const;
+  void CalcAccelerationsOneContactNoSliding(
       const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const;
-  void CalcTimeDerivativesOneContactSliding(
+  void CalcAccelerationsOneContactSliding(
       const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const;
-  void SetVelocityDerivatives(const systems::Context<T>& context,
-                              systems::VectorBase<T>* const f,
-                              T fN, T fF, T xc, T yc) const;
+  void SetAccelerations(const systems::Context<T>& context,
+                        systems::VectorBase<T>* const f,
+                        T fN, T fF, T xc, T yc) const;
   Vector2<T> CalcStickingContactForces(
       const systems::Context<T>& context) const;
-  static std::pair<T, T> CalcRodLowerEndpoint(const T& x,
-                                              const T& y,
-                                              const int k,
-                                              const T& ctheta,
-                                              const T& stheta,
-                                              const double half_rod_len);
+  static std::pair<T, T> CalcRodEndpoint(const T& x, const T& y, const int k,
+                                         const T& ctheta, const T& stheta,
+                                         const double half_rod_len);
 
+  // Solves linear complementarity problems for time stepping.
+  solvers::MobyLCPSolver lcp_;
+
+  double dt_{0.0};          // Integration step-size for time stepping approach.
   double mass_{1.0};        // The mass of the rod.
   double rod_length_{1.0};  // The length of the rod.
   double mu_{1000.0};       // The coefficient of friction.

--- a/drake/examples/painleve/test/CMakeLists.txt
+++ b/drake/examples/painleve/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 drake_add_cc_test(painleve_test)
-target_link_libraries(painleve_test drakePainleve)
+target_link_libraries(painleve_test drakePainleve drakeSystemAnalysis)
 

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -1,4 +1,5 @@
 #include "drake/examples/painleve/painleve.h"
+#include "drake/systems/analysis/simulator.h"
 
 #include <memory>
 
@@ -12,7 +13,9 @@ namespace drake {
 namespace painleve {
 namespace {
 
-class PainleveTest : public ::testing::Test {
+/// Class for testing the Painleve Paradox example using a piecewise DAE
+/// approach.
+class PainleveDAETest : public ::testing::Test {
  protected:
   void SetUp() override {
     dut_ = std::make_unique<Painleve<double>>();
@@ -21,15 +24,11 @@ class PainleveTest : public ::testing::Test {
     derivatives_ = dut_->AllocateTimeDerivatives();
   }
 
-  std::unique_ptr<ContinuousState<double>> CreateNewContinuousState()
-                                                                         const {
-    const int state_dim = 6;
-    auto cstate_vec = std::make_unique<BasicVector<double>>(state_dim);
-    return std::make_unique<ContinuousState<double>>(
-        std::move(cstate_vec), state_dim / 2, state_dim / 2, 0);
+  std::unique_ptr<State<double>> CloneState() const {
+    return context_->CloneState();
   }
 
-  VectorBase<double>* continuous_state() {
+  systems::VectorBase<double>* continuous_state() {
     return context_->get_mutable_continuous_state_vector();
   }
 
@@ -43,7 +42,7 @@ class PainleveTest : public ::testing::Test {
     //                    Impact. SIAM Rev., 42(1), 3-39, 2000.
     using std::sqrt;
     const double half_len = dut_->get_rod_length() / 2;
-    const double r22 = sqrt(2) / 2;
+    const double r22 = std::sqrt(2) / 2;
     ContinuousState<double>& xc =
         *context_->get_mutable_continuous_state();
     xc[0] = -half_len * r22;
@@ -52,6 +51,41 @@ class PainleveTest : public ::testing::Test {
     xc[3] = 1.0;
     xc[4] = 0.0;
     xc[5] = 0.0;
+
+    // Indicate that the rod is in the single contact sliding mode.
+    AbstractState* abs_state = context_->get_mutable_state()->
+                                 get_mutable_abstract_state();
+    abs_state->get_mutable_abstract_state(0).
+      template GetMutableValue<Painleve<double>::Mode>() =
+        Painleve<double>::kSlidingSingleContact;
+
+    // Determine the point of contact.
+    const double theta = xc[2];
+    const int k = (std::sin(theta) > 0) ? -1 : 1;
+    abs_state->get_mutable_abstract_state(1).
+      template GetMutableValue<int>() = k;
+  }
+
+  // Sets the rod to a state that corresponds to ballistic motion.
+  void SetBallisticState() {
+    const double half_len = dut_->get_rod_length() / 2;
+    ContinuousState<double>& xc =
+        *context_->get_mutable_continuous_state();
+    xc[0] = 0.0;
+    xc[1] = 10*half_len;
+    xc[2] = M_PI_2;
+    xc[3] = 1.0;
+    xc[4] = 2.0;
+    xc[5] = 3.0;
+
+    // Set the mode to ballistic.
+    AbstractState* abs_state = context_->get_mutable_state()->
+                                 get_mutable_abstract_state();
+    abs_state->get_mutable_abstract_state(0).
+      template GetMutableValue<Painleve<double>::Mode>() =
+        Painleve<double>::kBallisticMotion;
+
+    // Note: contact point mode is now arbitrary.
   }
 
   // Sets the rod to an arbitrary impacting state.
@@ -63,16 +97,29 @@ class PainleveTest : public ::testing::Test {
     ContinuousState<double>& xc =
         *context_->get_mutable_continuous_state();
     xc[4] = -1.0;
+
+    // Indicate that the rod is in the single contact sliding mode.
+    AbstractState* abs_state = context_->get_mutable_state()->
+                                 get_mutable_abstract_state();
+    abs_state->get_mutable_abstract_state(0).
+      template GetMutableValue<Painleve<double>::Mode>() =
+        Painleve<double>::kSlidingSingleContact;
+
+    // Determine the point of contact.
+    const double theta = xc[2];
+    const int k = (std::sin(theta) > 0) ? -1 : 1;
+    abs_state->get_mutable_abstract_state(1).
+      template GetMutableValue<int>() = k;
   }
 
   std::unique_ptr<Painleve<double>> dut_;  //< The device under test.
-  std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<SystemOutput<double>> output_;
-  std::unique_ptr<ContinuousState<double>> derivatives_;
+  std::unique_ptr<systems::Context<double>> context_;
+  std::unique_ptr<systems::SystemOutput<double>> output_;
+  std::unique_ptr<systems::ContinuousState<double>> derivatives_;
 };
 
 // Checks that the output port represents the state.
-TEST_F(PainleveTest, Output) {
+TEST_F(PainleveDAETest, Output) {
   const ContinuousState<double>& xc = *context_->get_continuous_state();
   std::unique_ptr<SystemOutput<double>> output =
       dut_->AllocateOutput(*context_);
@@ -83,13 +130,13 @@ TEST_F(PainleveTest, Output) {
 
 // Verifies that setting dut to an impacting state actually results in an
 // impacting state.
-TEST_F(PainleveTest, ImpactingState) {
+TEST_F(PainleveDAETest, ImpactingState) {
   SetImpactingState();
   EXPECT_TRUE(dut_->IsImpacting(*context_));
 }
 
 // Tests parameter getting and setting.
-TEST_F(PainleveTest, Parameters) {
+TEST_F(PainleveDAETest, Parameters) {
   // Set parameters to non-default values.
   const double g = -1.0;
   const double mass = 0.125;
@@ -109,10 +156,9 @@ TEST_F(PainleveTest, Parameters) {
 }
 
 // Verify that impact handling works as expected.
-TEST_F(PainleveTest, ImpactWorks) {
+TEST_F(PainleveDAETest, ImpactWorks) {
   // Set writable state.
-  std::unique_ptr<ContinuousState<double>> new_cstate =
-      CreateNewContinuousState();
+  std::unique_ptr<State<double>> new_state = CloneState();
 
   // Cause the initial state to be impacting, with center of mass directly
   // over the point of contact.
@@ -125,11 +171,20 @@ TEST_F(PainleveTest, ImpactWorks) {
   xc[3] = 0.0;
   xc[4] = -1.0;
   xc[5] = 0.0;
+
+  // Set the mode variables.
+  context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
+      Painleve<double>::kStickingSingleContact;
+  const double theta = xc[3];
+  const int k = (std::sin(theta) > 0) ? -1 : 1;
+  context_->template get_mutable_abstract_state<int>(1) = k;
+
+  // Rod should not be impacting.
   EXPECT_TRUE(dut_->IsImpacting(*context_));
 
   // Handle the impact.
-  dut_->HandleImpact(*context_, new_cstate.get());
-  context_->get_mutable_continuous_state()->SetFrom(*new_cstate);
+  dut_->HandleImpact(*context_, new_state.get());
+  context_->get_mutable_state()->SetFrom(*new_state);
 
   // Verify that the state has been modified such that the body is no longer
   // in an impacting state and the configuration has not been modified.
@@ -144,17 +199,9 @@ TEST_F(PainleveTest, ImpactWorks) {
 
 // Verify that derivatives match what we expect from a non-inconsistent,
 // ballistic configuration.
-TEST_F(PainleveTest, ConsistentDerivativesBallistic) {
+TEST_F(PainleveDAETest, ConsistentDerivativesBallistic) {
   // Set the initial state to ballistic motion.
-  const double half_len = dut_->get_rod_length() / 2;
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
-  xc[0] = 0.0;
-  xc[1] = 10*half_len;
-  xc[2] = M_PI_2;
-  xc[3] = 1.0;
-  xc[4] = 2.0;
-  xc[5] = 3.0;
+  SetBallisticState();
 
   // Calculate the derivatives.
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
@@ -163,17 +210,22 @@ TEST_F(PainleveTest, ConsistentDerivativesBallistic) {
   // ballistic system.
   const double tol = std::numeric_limits<double>::epsilon();
   const double g = dut_->get_gravitational_acceleration();
+  const ContinuousState<double>& xc = *context_->get_continuous_state();
   EXPECT_NEAR((*derivatives_)[0], xc[3], tol);  // qdot = v ...
   EXPECT_NEAR((*derivatives_)[1], xc[4], tol);  // ... for this ...
   EXPECT_NEAR((*derivatives_)[2], xc[5], tol);  // ... system.
   EXPECT_NEAR((*derivatives_)[3], 0.0, tol);   // Zero horizontal acceleration.
   EXPECT_NEAR((*derivatives_)[4], g, tol);     // Gravitational acceleration.
   EXPECT_NEAR((*derivatives_)[5], 0.0, tol);   // Zero rotational acceleration.
+
+  // Verify the mode is still ballistic.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kBallisticMotion);
 }
 
 // Verify that derivatives match what we expect from a non-inconsistent
 // contacting configuration.
-TEST_F(PainleveTest, ConsistentDerivativesContacting) {
+TEST_F(PainleveDAETest, ConsistentDerivativesContacting) {
   // Set the initial state to sustained contact with zero tangential velocity
   // at the point of contact.
   const double half_len = dut_->get_rod_length() / 2;
@@ -185,6 +237,8 @@ TEST_F(PainleveTest, ConsistentDerivativesContacting) {
   xc[3] = 0.0;
   xc[4] = 0.0;
   xc[5] = 0.0;
+  context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
+      Painleve<double>::kStickingSingleContact;
 
   // Calculate the derivatives.
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
@@ -205,6 +259,8 @@ TEST_F(PainleveTest, ConsistentDerivativesContacting) {
   // and try again. Derivatives should be exactly the same because no frictional
   // force can be applied.
   xc[3] = -1.0;
+  context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
+      Painleve<double>::kSlidingSingleContact;
   dut_->set_mu_coulomb(0.0);
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
   EXPECT_NEAR((*derivatives_)[0], xc[3], tol);
@@ -216,13 +272,13 @@ TEST_F(PainleveTest, ConsistentDerivativesContacting) {
 }
 
 // Verify the inconsistent (Painlevé Paradox) configuration occurs.
-TEST_F(PainleveTest, Inconsistent) {
+TEST_F(PainleveDAETest, Inconsistent) {
   EXPECT_THROW(dut_->CalcTimeDerivatives(*context_, derivatives_.get()),
                std::runtime_error);
 }
 
 // Verify the second inconsistent (Painlevé Paradox) configuration occurs.
-TEST_F(PainleveTest, Inconsistent2) {
+TEST_F(PainleveDAETest, Inconsistent2) {
   SetSecondInitialConfig();
   EXPECT_THROW(dut_->CalcTimeDerivatives(*context_, derivatives_.get()),
                std::runtime_error);
@@ -230,42 +286,54 @@ TEST_F(PainleveTest, Inconsistent2) {
 
 // Verify that the (non-impacting) Painlevé configuration does not result in a
 // state change.
-TEST_F(PainleveTest, ImpactNoChange) {
+TEST_F(PainleveDAETest, ImpactNoChange) {
   // Set state.
-  std::unique_ptr<ContinuousState<double>> new_cstate =
-      CreateNewContinuousState();
+  std::unique_ptr<State<double>> new_state = CloneState();
   EXPECT_FALSE(dut_->IsImpacting(*context_));
-  dut_->HandleImpact(*context_, new_cstate.get());
-  EXPECT_TRUE(CompareMatrices(new_cstate->get_vector().CopyToVector(),
+  dut_->HandleImpact(*context_, new_state.get());
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+                                  CopyToVector(),
                               context_->get_continuous_state()->get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::absolute));
+
+  // Verify that the mode is still sliding.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kSlidingSingleContact);
 }
 
 // Verify that applying the impact model to an impacting configuration results
 // in a non-impacting configuration. This test exercises the model for the case
 // where impulses that yield tangential sticking lie within the friction cone.
-TEST_F(PainleveTest, InfFrictionImpactThenNoImpact) {
+TEST_F(PainleveDAETest, InfFrictionImpactThenNoImpact) {
   // Set writable state.
-  std::unique_ptr<ContinuousState<double>> new_cstate =
-      CreateNewContinuousState();
+  std::unique_ptr<State<double>> new_state = CloneState();
 
   // Cause the initial state to be impacting.
   SetImpactingState();
+
+  // Verify that the state is in a sliding mode.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kSlidingSingleContact);
 
   // Set the coefficient of friction to infinite. This forces the Painlevé code
   // to go through the first impact path (impulse within the friction cone).
   dut_->set_mu_coulomb(std::numeric_limits<double>::infinity());
 
   // Handle the impact and copy the result to the context.
-  dut_->HandleImpact(*context_, new_cstate.get());
-  context_->get_mutable_continuous_state()->SetFrom(*new_cstate);
+  dut_->HandleImpact(*context_, new_state.get());
+  context_->get_mutable_state()->SetFrom(*new_state);
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 
+  // Verify that the state is now in a sticking mode.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kStickingSingleContact);
+
   // Do one more impact- there should now be no change.
-  dut_->HandleImpact(*context_, new_cstate.get());
-  EXPECT_TRUE(CompareMatrices(new_cstate->get_vector().CopyToVector(),
+  dut_->HandleImpact(*context_, new_state.get());
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+                                  CopyToVector(),
                               context_->get_continuous_state()->get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
@@ -275,9 +343,13 @@ TEST_F(PainleveTest, InfFrictionImpactThenNoImpact) {
 // Verify that applying an impact model to an impacting state results in a
 // non-impacting state. This test exercises the model for the case
 // where impulses that yield tangential sticking lie outside the friction cone.
-TEST_F(PainleveTest, NoFrictionImpactThenNoImpact) {
+TEST_F(PainleveDAETest, NoFrictionImpactThenNoImpact) {
   // Set the initial state to be impacting.
   SetImpactingState();
+
+  // Verify that the state is in a sliding mode.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kSlidingSingleContact);
 
   // Set the coefficient of friction to zero. This forces the Painlevé code
   // to go through the second impact path (impulse corresponding to sticking
@@ -285,24 +357,32 @@ TEST_F(PainleveTest, NoFrictionImpactThenNoImpact) {
   dut_->set_mu_coulomb(0.0);
 
   // Handle the impact and copy the result to the context.
-  std::unique_ptr<ContinuousState<double>> new_cstate =
-      CreateNewContinuousState();
-  dut_->HandleImpact(*context_, new_cstate.get());
-  context_->get_mutable_continuous_state()->SetFrom(*new_cstate);
+  std::unique_ptr<State<double>> new_state = CloneState();
+  dut_->HandleImpact(*context_, new_state.get());
+  context_->get_mutable_state()->SetFrom(*new_state);
   EXPECT_FALSE(dut_->IsImpacting(*context_));
+
+  // Verify that the state is still in a sliding mode.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kSlidingSingleContact);
 
   // Do one more impact- there should now be no change.
   // Verify that there is no further change from this second impact.
-  dut_->HandleImpact(*context_, new_cstate.get());
-  EXPECT_TRUE(CompareMatrices(new_cstate->get_vector().CopyToVector(),
+  dut_->HandleImpact(*context_, new_state.get());
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+                                  CopyToVector(),
                               context_->get_continuous_state()->get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::absolute));
+
+  // Verify that the state is still in a sliding mode.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kSlidingSingleContact);
 }
 
 // Verify that no exceptions thrown for a non-sliding configuration.
-TEST_F(PainleveTest, NoSliding) {
+TEST_F(PainleveDAETest, NoSliding) {
   const double half_len = dut_->get_rod_length() / 2;
   const double r22 = std::sqrt(2) / 2;
   ContinuousState<double>& xc =
@@ -319,6 +399,8 @@ TEST_F(PainleveTest, NoSliding) {
   xc[3] = 0.0;
   xc[4] = 0.0;
   xc[5] = 0.0;
+  context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
+      Painleve<double>::kStickingSingleContact;
 
   // Verify no impact.
   EXPECT_FALSE(dut_->IsImpacting(*context_));
@@ -335,7 +417,7 @@ TEST_F(PainleveTest, NoSliding) {
 }
 
 // Test multiple (two-point) contact configurations.
-TEST_F(PainleveTest, MultiPoint) {
+TEST_F(PainleveDAETest, MultiPoint) {
   ContinuousState<double>& xc =
       *context_->get_mutable_continuous_state();
 
@@ -347,6 +429,8 @@ TEST_F(PainleveTest, MultiPoint) {
   xc[3] = 0.0;
   xc[4] = 0.0;
   xc[5] = 0.0;
+  context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
+      Painleve<double>::kStickingTwoContacts;
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
   for (int i=0; i< derivatives_->size(); ++i)
     EXPECT_NEAR((*derivatives_)[i], 0.0, tol);
@@ -361,6 +445,8 @@ TEST_F(PainleveTest, MultiPoint) {
   xc[3] = 1.0;
   xc[4] = 0.0;
   xc[5] = 0.0;
+  context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
+      Painleve<double>::kSlidingTwoContacts;
   EXPECT_THROW(dut_->CalcTimeDerivatives(*context_, derivatives_.get()),
                std::logic_error);
 
@@ -370,17 +456,17 @@ TEST_F(PainleveTest, MultiPoint) {
 
 // Verify that the Painlevé configuration does not correspond to an impacting
 // state.
-TEST_F(PainleveTest, ImpactNoChange2) {
+TEST_F(PainleveDAETest, ImpactNoChange2) {
   SetSecondInitialConfig();
 
   // Verify no impact.
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 
   // Set writable state.
-  std::unique_ptr<ContinuousState<double>> new_cstate =
-      CreateNewContinuousState();
-  dut_->HandleImpact(*context_, new_cstate.get());
-  EXPECT_TRUE(CompareMatrices(new_cstate->get_vector().CopyToVector(),
+  std::unique_ptr<State<double>> new_state = CloneState();
+  dut_->HandleImpact(*context_, new_state.get());
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+                                  CopyToVector(),
                               context_->get_continuous_state()->get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
@@ -389,10 +475,9 @@ TEST_F(PainleveTest, ImpactNoChange2) {
 
 // Verify that applying the impact model to an impacting state results
 // in a non-impacting state.
-TEST_F(PainleveTest, InfFrictionImpactThenNoImpact2) {
+TEST_F(PainleveDAETest, InfFrictionImpactThenNoImpact2) {
   // Set writable state.
-  std::unique_ptr<ContinuousState<double>> new_cstate =
-      CreateNewContinuousState();
+  std::unique_ptr<State<double>> new_state = CloneState();
 
   // Cause the initial state to be impacting.
   SetImpactingState();
@@ -402,65 +487,154 @@ TEST_F(PainleveTest, InfFrictionImpactThenNoImpact2) {
   dut_->set_mu_coulomb(std::numeric_limits<double>::infinity());
 
   // Handle the impact and copy the result to the context.
-  dut_->HandleImpact(*context_, new_cstate.get());
-  context_->get_mutable_continuous_state()->SetFrom(*new_cstate);
+  dut_->HandleImpact(*context_, new_state.get());
+  context_->get_mutable_state()->SetFrom(*new_state);
 
   // Verify the state no longer corresponds to an impact.
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 
+  // Verify that the state is now in a sticking mode.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kStickingSingleContact);
+
   // Do one more impact- there should now be no change.
-  dut_->HandleImpact(*context_, new_cstate.get());
-  EXPECT_TRUE(CompareMatrices(new_cstate->get_vector().CopyToVector(),
+  dut_->HandleImpact(*context_, new_state.get());
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+                                  CopyToVector(),
                               context_->get_continuous_state()->get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::absolute));
 }
 
+
 // Verify that applying the impact model to an impacting state results in a
 // non-impacting state.
-TEST_F(PainleveTest, NoFrictionImpactThenNoImpact2) {
+TEST_F(PainleveDAETest, NoFrictionImpactThenNoImpact2) {
   // Set writable state.
-  std::unique_ptr<ContinuousState<double>> new_cstate =
-      CreateNewContinuousState();
+  std::unique_ptr<State<double>> new_state = CloneState();
 
   // Cause the initial state to be impacting.
   SetImpactingState();
+
+  // Verify that the state is still in a sliding configuration.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kSlidingSingleContact);
 
   // Set the coefficient of friction to zero. This forces the Painlevé code
   // to go through the second impact path.
   dut_->set_mu_coulomb(0.0);
 
+  // Verify that the state is still in a sliding configuration.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kSlidingSingleContact);
+
   // Handle the impact and copy the result to the context.
-  dut_->HandleImpact(*context_, new_cstate.get());
-  context_->get_mutable_continuous_state()->SetFrom(*new_cstate);
+  dut_->HandleImpact(*context_, new_state.get());
+  context_->get_mutable_state()->SetFrom(*new_state);
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 
   // Do one more impact- there should now be no change.
-  dut_->HandleImpact(*context_, new_cstate.get());
-  EXPECT_TRUE(CompareMatrices(new_cstate->get_vector().CopyToVector(),
+  dut_->HandleImpact(*context_, new_state.get());
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+                                  CopyToVector(),
                               context_->get_continuous_state()->get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::absolute));
+
+  // Verify that the state is still in a sliding configuration.
+  EXPECT_EQ(context_->template get_abstract_state<Painleve<double>::Mode>(0),
+            Painleve<double>::kSlidingSingleContact);
 }
 
 // Verifies that rod in a ballistic state does not correspond to an impact.
-TEST_F(PainleveTest, BallisticNoImpact) {
+TEST_F(PainleveDAETest, BallisticNoImpact) {
   // Set writable state.
-  std::unique_ptr<ContinuousState<double>> new_cstate =
-  CreateNewContinuousState();
+  std::unique_ptr<State<double>> new_state = CloneState();
 
   // Cause the initial state to be impacting.
   SetImpactingState();
 
-  // Move the rod upward vertically so that it is no longer impacting.
+  // Move the rod upward vertically so that it is no longer impacting and
+  // set the mode to ballistic motion.
   ContinuousState<double>& xc =
       *context_->get_mutable_continuous_state();
   xc[1] += 10.0;
+  context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
+      Painleve<double>::kBallisticMotion;
 
   // Verify that no impact occurs.
   EXPECT_FALSE(dut_->IsImpacting(*context_));
+}
+
+/// Class for testing the Painleve Paradox example using a first order time
+/// stepping approach.
+class PainleveTimeSteppingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const double dt = 1e-2;
+    dut_ = std::make_unique<Painleve<double>>(dt);
+    context_ = dut_->CreateDefaultContext();
+    output_ = dut_->AllocateOutput(*context_);
+  }
+
+  systems::BasicVector<double>* discrete_state() {
+    return context_->get_mutable_discrete_state(0);
+  }
+
+  // Sets a secondary initial Painleve configuration.
+  void SetSecondInitialConfig() {
+    // Set the configuration to an inconsistent (Painlevé) type state with
+    // the rod at a 135 degree counter-clockwise angle with respect to the
+    // x-axis. The rod in [Stewart, 2000] is at a 45 degree counter-clockwise
+    // angle with respect to the x-axis.
+    // * [Stewart, 2000]  D. Stewart, "Rigid-Body Dynamics with Friction and
+    //                    Impact. SIAM Rev., 42(1), 3-39, 2000.
+    using std::sqrt;
+    const double half_len = dut_->get_rod_length() / 2;
+    const double r22 = std::sqrt(2) / 2;
+    auto xd = discrete_state()->get_mutable_value();
+
+    xd[0] = -half_len * r22;
+    xd[1] = half_len * r22;
+    xd[2] = 3 * M_PI / 4.0;
+    xd[3] = 1.0;
+    xd[4] = 0.0;
+    xd[5] = 0.0;
+  }
+
+  std::unique_ptr<Painleve<double>> dut_;  //< The device under test.
+  std::unique_ptr<systems::Context<double>> context_;
+  std::unique_ptr<systems::SystemOutput<double>> output_;
+  std::unique_ptr<systems::ContinuousState<double>> derivatives_;
+};
+
+/// Verify that Painleve Paradox system can be effectively simulated using
+/// the first-order time stepping approach.
+TEST_F(PainleveTimeSteppingTest, TimeStepping) {
+  // Set the initial state to an inconsistent configuration.
+  SetSecondInitialConfig();
+
+  // Init the simulator.
+  systems::Simulator<double> simulator(*dut_, std::move(context_));
+
+  // Integrate forward to a point where the rod should be at rest.
+  const double t_final = 10;
+  simulator.StepTo(t_final);
+
+  // Get angular orientation and velocity.
+  const auto xd = simulator.get_context().get_discrete_state(0)->get_value();
+  const double theta = xd(2);
+  const double theta_dot = xd(5);
+
+  // After sufficiently long, theta should be 0 or M_PI and the velocity
+  // should be nearly zero.
+  EXPECT_TRUE(std::fabs(theta) < 1e-6 || std::fabs(theta - M_PI) < 1e-6);
+  EXPECT_NEAR(theta_dot, 0.0, 1e-6);
+
+  // TODO(edrumwri): Introduce more extensive tests that cross-validate the
+  // time-stepping based approach against the piecewise DAE-based approach.
 }
 
 }  // namespace

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -147,6 +147,12 @@ class Context {
     return get_state().get_abstract_state()->size();
   }
 
+  /// Returns a pointer to the abstract component of the state, which
+  /// may be of size zero.
+  const AbstractState* get_abstract_state() const {
+    return get_state().get_abstract_state();
+  }
+
   /// Returns a mutable pointer to the abstract component of the state,
   /// which may be of size zero.
   AbstractState* get_mutable_abstract_state() {

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -65,6 +65,22 @@ class State {
     return abstract_state_.get();
   }
 
+  /// Returns a const pointer to the abstract component of the
+  /// state at @p index.  Asserts if @p index doesn't exist.
+  template <typename U>
+  const U& get_abstract_state(int index) const {
+    const AbstractState* xm = get_abstract_state();
+    return xm->get_abstract_state(index).GetValue<U>();
+  }
+
+  /// Returns a mutable pointer to element @p index of the abstract state.
+  /// Asserts if @p index doesn't exist.
+  template <typename U>
+  U& get_mutable_abstract_state(int index) {
+    AbstractState* xm = get_mutable_abstract_state();
+    return xm->get_mutable_abstract_state(index).GetMutableValue<U>();
+  }
+
   /// Copies the values from another State of the same scalar type into this
   /// State.
   void CopyFrom(const State<T>& other) {


### PR DESCRIPTION
This PR adds time stepping integration to the Painleve Paradox example so that we have a second algorithmic mechanism to check the solution to the 2D rod system. This PR also introduces abstract (hybrid system mode) variables toward more robust piecewise DAE integration.

Piecewise DAE integration is not yet supported. To effect this functionality, it remains to: (1) Incorporate unrestricted updates into this example (to permit both impact modeling and transitions from, e.g., sliding to non-sliding contact); (2) Add witness functions to this class; and (3) Support both witness functions and corresponding event handling in Simulator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4868)
<!-- Reviewable:end -->
