### PR TITLE
Saturating version of ConnectController

### DIFF
--- a/drake/systems/controllers/BUILD
+++ b/drake/systems/controllers/BUILD
@@ -42,6 +42,7 @@ cc_library(
         "//drake/systems/primitives:gain",
         "//drake/systems/primitives:integrator",
         "//drake/systems/primitives:pass_through",
+        "//drake/systems/primitives:saturation",
     ],
 )
 

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -135,7 +135,7 @@ PidControlledSystem<T>::ConnectController(
 
 template <typename T>
 typename PidControlledSystem<T>::ConnectResult
-PidControlledSystem<T>::ConnectController(
+PidControlledSystem<T>::ConnectControllerWithInputSaturation(
     const InputPortDescriptor<T>& plant_input,
     const OutputPortDescriptor<T>& plant_output,
     std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -3,29 +3,31 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/systems/primitives/saturation.h"
 
 namespace drake {
 namespace systems {
 
 template <typename T>
-PidControlledSystem<T>::PidControlledSystem(
-    std::unique_ptr<System<T>> plant,
-    const T& Kp, const T& Ki, const T& Kd)
-    : PidControlledSystem(std::move(plant), nullptr /* feedback selector */,
-        Kp, Ki, Kd) {}
+PidControlledSystem<T>::PidControlledSystem(std::unique_ptr<System<T>> plant,
+                                            const T& Kp, const T& Ki,
+                                            const T& Kd)
+    : PidControlledSystem(std::move(plant), nullptr /* feedback selector */, Kp,
+                          Ki, Kd) {}
+
+template <typename T>
+PidControlledSystem<T>::PidControlledSystem(std::unique_ptr<System<T>> plant,
+                                            const VectorX<T>& Kp,
+                                            const VectorX<T>& Ki,
+                                            const VectorX<T>& Kd)
+    : PidControlledSystem(std::move(plant), nullptr /* feedback selector */, Kp,
+                          Ki, Kd) {}
 
 template <typename T>
 PidControlledSystem<T>::PidControlledSystem(
     std::unique_ptr<System<T>> plant,
-    const VectorX<T>& Kp, const VectorX<T>& Ki, const VectorX<T>& Kd)
-    : PidControlledSystem(std::move(plant), nullptr /* feedback selector */,
-        Kp, Ki, Kd) {}
-
-template <typename T>
-PidControlledSystem<T>::PidControlledSystem(
-    std::unique_ptr<System<T>> plant,
-    std::unique_ptr<MatrixGain<T>> feedback_selector,
-    const T& Kp, const T& Ki, const T& Kd) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const T& Kp, const T& Ki,
+    const T& Kd) {
   const int input_size = plant->get_input_port(0).size();
   const VectorX<T> Kp_v = VectorX<T>::Ones(input_size) * Kp;
   const VectorX<T> Ki_v = VectorX<T>::Ones(input_size) * Ki;
@@ -36,25 +38,25 @@ PidControlledSystem<T>::PidControlledSystem(
 template <typename T>
 PidControlledSystem<T>::PidControlledSystem(
     std::unique_ptr<System<T>> plant,
-    std::unique_ptr<MatrixGain<T>> feedback_selector,
-    const VectorX<T>& Kp, const VectorX<T>& Ki, const VectorX<T>& Kd) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
+    const VectorX<T>& Ki, const VectorX<T>& Kd) {
   Initialize(std::move(plant), std::move(feedback_selector), Kp, Ki, Kd);
 }
 
 template <typename T>
 void PidControlledSystem<T>::Initialize(
     std::unique_ptr<System<T>> plant,
-    std::unique_ptr<MatrixGain<T>> feedback_selector,
-    const VectorX<T>& Kp, const VectorX<T>& Ki, const VectorX<T>& Kd) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
+    const VectorX<T>& Ki, const VectorX<T>& Kd) {
   DRAKE_DEMAND(plant != nullptr);
   DiagramBuilder<T> builder;
   plant_ = builder.template AddSystem(std::move(plant));
   DRAKE_ASSERT(plant_->get_num_input_ports() >= 1);
   DRAKE_ASSERT(plant_->get_num_output_ports() >= 1);
 
-  auto input_ports = ConnectController(
-      plant_->get_input_port(0), plant_->get_output_port(0),
-      std::move(feedback_selector), Kp, Ki, Kd, &builder);
+  auto input_ports =
+      ConnectController(plant_->get_input_port(0), plant_->get_output_port(0),
+                        std::move(feedback_selector), Kp, Ki, Kd, &builder);
 
   builder.ExportInput(input_ports.control_input_port);
   builder.ExportInput(input_ports.state_input_port);
@@ -67,16 +69,13 @@ typename PidControlledSystem<T>::ConnectResult
 PidControlledSystem<T>::ConnectController(
     const InputPortDescriptor<T>& plant_input,
     const OutputPortDescriptor<T>& plant_output,
-    std::unique_ptr<MatrixGain<T>> feedback_selector,
-    const VectorX<T>& Kp, const VectorX<T>& Ki,
-    const VectorX<T>& Kd,
-    DiagramBuilder<T>* builder) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
+    const VectorX<T>& Ki, const VectorX<T>& Kd, DiagramBuilder<T>* builder) {
   if (feedback_selector == nullptr) {
     // No feedback selector was provided. Create a GainMatrix containing an
     // identity matrix, which results in every element of the plant's output
     // port zero being used as the feedback signal to the PID controller.
-    feedback_selector =
-        std::make_unique<MatrixGain<T>>(plant_output.size());
+    feedback_selector = std::make_unique<MatrixGain<T>>(plant_output.size());
   }
   auto feedback_selector_p =
       builder->template AddSystem(std::move(feedback_selector));
@@ -88,20 +87,18 @@ PidControlledSystem<T>::ConnectController(
 
   DRAKE_ASSERT(feedback_selector_p->get_output_port().size() == num_states);
 
-  auto state_minus_target = builder->template AddSystem<Adder<T>>(
-      2, num_states);
-  auto controller = builder->template AddSystem<PidController<T>>(
-      Kp, Ki, Kd);
+  auto state_minus_target =
+      builder->template AddSystem<Adder<T>>(2, num_states);
+  auto controller = builder->template AddSystem<PidController<T>>(Kp, Ki, Kd);
 
   // Split the input into two signals one with the positions and one
   // with the velocities.
   auto error_demux = builder->template AddSystem<Demultiplexer<T>>(
       num_states, num_effort_commands);
 
-  auto controller_inverter = builder->template AddSystem<Gain<T>>(
-      -1.0, num_effort_commands);
-  auto error_inverter = builder->template AddSystem<Gain<T>>(
-      -1.0, num_states);
+  auto controller_inverter =
+      builder->template AddSystem<Gain<T>>(-1.0, num_effort_commands);
+  auto error_inverter = builder->template AddSystem<Gain<T>>(-1.0, num_states);
 
   // Create an adder to sum the provided input with the output of the
   // controller.
@@ -110,8 +107,7 @@ PidControlledSystem<T>::ConnectController(
 
   builder->Connect(error_inverter->get_output_port(),
                    state_minus_target->get_input_port(0));
-  builder->Connect(plant_output,
-                   feedback_selector_p->get_input_port());
+  builder->Connect(plant_output, feedback_selector_p->get_input_port());
   builder->Connect(feedback_selector_p->get_output_port(),
                    state_minus_target->get_input_port(1));
 
@@ -130,12 +126,88 @@ PidControlledSystem<T>::ConnectController(
   builder->Connect(controller_inverter->get_output_port(),
                    plant_input_adder->get_input_port(0));
 
-  builder->Connect(plant_input_adder->get_output_port(),
-                   plant_input);
+  builder->Connect(plant_input_adder->get_output_port(), plant_input);
 
   return ConnectResult{
-    plant_input_adder->get_input_port(1),
-    error_inverter->get_input_port(),
+      plant_input_adder->get_input_port(1), error_inverter->get_input_port(),
+  };
+}
+
+template <typename T>
+typename PidControlledSystem<T>::ConnectResult
+PidControlledSystem<T>::ConnectController(
+    const InputPortDescriptor<T>& plant_input,
+    const OutputPortDescriptor<T>& plant_output,
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
+    const VectorX<T>& Ki, const VectorX<T>& Kd,
+    const VectorX<T>& min_plant_input, const VectorX<T>& max_plant_input,
+    DiagramBuilder<T>* builder) {
+  if (feedback_selector == nullptr) {
+    // No feedback selector was provided. Create a GainMatrix containing an
+    // identity matrix, which results in every element of the plant's output
+    // port zero being used as the feedback signal to the PID controller.
+    feedback_selector = std::make_unique<MatrixGain<T>>(plant_output.size());
+  }
+  auto feedback_selector_p =
+      builder->template AddSystem(std::move(feedback_selector));
+
+  DRAKE_ASSERT(plant_output.size() ==
+               feedback_selector_p->get_input_port().size());
+  const int num_effort_commands = plant_input.size();
+  const int num_states = num_effort_commands * 2;
+
+  DRAKE_ASSERT(feedback_selector_p->get_output_port().size() == num_states);
+
+  auto state_minus_target =
+      builder->template AddSystem<Adder<T>>(2, num_states);
+  auto controller = builder->template AddSystem<PidController<T>>(Kp, Ki, Kd);
+
+  // Split the input into two signals one with the positions and one
+  // with the velocities.
+  auto error_demux = builder->template AddSystem<Demultiplexer<T>>(
+      num_states, num_effort_commands);
+
+  auto controller_inverter =
+      builder->template AddSystem<Gain<T>>(-1.0, num_effort_commands);
+  auto error_inverter = builder->template AddSystem<Gain<T>>(-1.0, num_states);
+
+  // Create an adder to sum the provided input with the output of the
+  // controller.
+  auto plant_input_adder =
+      builder->template AddSystem<Adder<T>>(2, num_effort_commands);
+
+  auto force_saturator = builder->template AddSystem<Saturation<T>>(
+      min_plant_input, max_plant_input);
+
+  builder->Connect(error_inverter->get_output_port(),
+                   state_minus_target->get_input_port(0));
+  builder->Connect(plant_output, feedback_selector_p->get_input_port());
+  builder->Connect(feedback_selector_p->get_output_port(),
+                   state_minus_target->get_input_port(1));
+
+  // Splits the error signal into positions and velocities components.
+  builder->Connect(state_minus_target->get_output_port(),
+                   error_demux->get_input_port(0));
+
+  // Connects PID controller.
+  builder->Connect(error_demux->get_output_port(0),
+                   controller->get_error_port());
+  builder->Connect(error_demux->get_output_port(1),
+                   controller->get_error_derivative_port());
+  // Adds feedback.
+  builder->Connect(controller->get_output_port(0),
+                   controller_inverter->get_input_port());
+  builder->Connect(controller_inverter->get_output_port(),
+                   plant_input_adder->get_input_port(0));
+
+  // Passes the control input through the force saturator.
+  builder->Connect(plant_input_adder->get_output_port(),
+                   force_saturator->get_input_port());
+
+  builder->Connect(force_saturator->get_output_port(), plant_input);
+
+  return ConnectResult{
+      plant_input_adder->get_input_port(1), error_inverter->get_input_port(),
   };
 }
 

--- a/drake/systems/controllers/pid_controlled_system.h
+++ b/drake/systems/controllers/pid_controlled_system.h
@@ -161,7 +161,7 @@ class PidControlledSystem : public Diagram<T> {
   /// additional systems (adders, multiplexers, gains, saturation etc.) as
   /// needed. Note that using input limits along with integral gain constant
   /// may result in integral windup effects.
-  static ConnectResult ConnectController(
+  static ConnectResult ConnectControllerWithInputSaturation(
       const InputPortDescriptor<T>& plant_input,
       const OutputPortDescriptor<T>& plant_output,
       std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,

--- a/drake/systems/controllers/pid_controlled_system.h
+++ b/drake/systems/controllers/pid_controlled_system.h
@@ -67,8 +67,8 @@ class PidControlledSystem : public Diagram<T> {
   /// @param[in] Kp the proportional constant.
   /// @param[in] Ki the integral constant.
   /// @param[in] Kd the derivative constant.
-  PidControlledSystem(std::unique_ptr<System<T>> plant,
-                      const T& Kp, const T& Ki, const T& Kd);
+  PidControlledSystem(std::unique_ptr<System<T>> plant, const T& Kp,
+                      const T& Ki, const T& Kd);
 
   /// A constructor where the gains are vector values and all of the plant's
   /// output port zero is part of the feedback signal. The length of the gain
@@ -82,9 +82,8 @@ class PidControlledSystem : public Diagram<T> {
   /// @param[in] Ki the integral vector constant.
   ///
   /// @param[in] Kd the derivative vector constant.
-  PidControlledSystem(std::unique_ptr<System<T>> plant,
-                      const VectorX<T>& Kp, const VectorX<T>& Ki,
-                      const VectorX<T>& Kd);
+  PidControlledSystem(std::unique_ptr<System<T>> plant, const VectorX<T>& Kp,
+                      const VectorX<T>& Ki, const VectorX<T>& Kd);
 
   /// A constructor where the gains are scalar values and some of the plant's
   /// output is part of the feedback signal as specified by
@@ -154,20 +153,30 @@ class PidControlledSystem : public Diagram<T> {
   static ConnectResult ConnectController(
       const InputPortDescriptor<T>& plant_input,
       const OutputPortDescriptor<T>& plant_output,
-      std::unique_ptr<MatrixGain<T>> feedback_selector,
-      const VectorX<T>& Kp,
-      const VectorX<T>& Ki,
-      const VectorX<T>& Kd,
+      std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
+      const VectorX<T>& Ki, const VectorX<T>& Kd, DiagramBuilder<T>* builder);
+
+  /// Creates a PidController with input saturation and uses @p builder to
+  /// connect @p plant_input and @p plant_output from an existing plant, adding
+  /// additional systems (adders, multiplexers, gains, saturation etc.) as
+  /// needed. Note that using input limits along with integral gain constant
+  /// may result in integral windup effects.
+  static ConnectResult ConnectController(
+      const InputPortDescriptor<T>& plant_input,
+      const OutputPortDescriptor<T>& plant_output,
+      std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
+      const VectorX<T>& Ki, const VectorX<T>& Kd,
+      const VectorX<T>& min_plant_input, const VectorX<T>& max_plant_input,
       DiagramBuilder<T>* builder);
 
  private:
   // A helper function for the constructors. This is necessary to avoid seg
-  // faults caused by simultaneously moving the plant and calling methods on the
-  // plant when one constructor delegates to another constructor.
-  void Initialize(
-    std::unique_ptr<System<T>> plant,
-    std::unique_ptr<MatrixGain<T>> feedback_selector,
-    const VectorX<T>& Kp, const VectorX<T>& Ki, const VectorX<T>& Kd);
+  // faults caused by simultaneously moving the plant and calling methods on
+  // the plant when one constructor delegates to another constructor.
+  void Initialize(std::unique_ptr<System<T>> plant,
+                  std::unique_ptr<MatrixGain<T>> feedback_selector,
+                  const VectorX<T>& Kp, const VectorX<T>& Ki,
+                  const VectorX<T>& Kd);
 
   System<T>* plant_{nullptr};
 };

--- a/drake/systems/controllers/test/pid_controlled_system_test.cc
+++ b/drake/systems/controllers/test/pid_controlled_system_test.cc
@@ -196,6 +196,10 @@ void DoConnectControllerTest(bool saturation_test = false) {
   const Vector1d Ki(0);
   const Vector1d Kd(0.5);
 
+  // Sets the max input in the case of saturation_test.
+  const double saturation_max = 0.5;
+
+
   if (!saturation_test) {
     auto plant_pid_ports = PidControlledSystem<double>::ConnectController(
         plant_input_port, plant_output_port, std::move(feedback_selector), Kp,
@@ -210,7 +214,7 @@ void DoConnectControllerTest(bool saturation_test = false) {
     auto plant_pid_ports = PidControlledSystem<double>::ConnectController(
         plant_input_port, plant_output_port, std::move(feedback_selector), Kp,
         Ki, Kd, VectorX<double>::Constant(1, 0.0) /* u_min */,
-        VectorX<double>::Constant(1, 0.5) /* u_max */, &standardBuilder);
+        VectorX<double>::Constant(1, saturation_max) /* u_max */, &standardBuilder);
 
     standardBuilder.Connect(input_source->get_output_port(),
                             plant_pid_ports.control_input_port);
@@ -238,9 +242,7 @@ void DoConnectControllerTest(bool saturation_test = false) {
   if (!saturation_test) {
     EXPECT_EQ(pid_input, calculated_input);
   } else {
-    if (calculated_input > 0.5 /* u_max */) {
-      calculated_input = 0.5;
-    }
+   calculated_input = saturation_max;
     EXPECT_EQ(pid_input, calculated_input);
   }
 }

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -141,6 +141,16 @@ cc_library(
 )
 
 cc_library(
+    name = "saturation",
+    srcs = ["saturation.cc"],
+    hdrs = ["saturation.h"],
+    linkstatic = 1,
+    deps = [
+        "//drake/systems/framework",
+    ],
+)
+
+cc_library(
     name = "signal_logger",
     srcs = ["signal_logger.cc"],
     hdrs = ["signal_logger.h"],
@@ -301,6 +311,13 @@ cc_googletest(
         ":signal_logger",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/analysis",
+    ],
+)
+
+cc_googletest(
+    name = "saturation_test",
+    deps = [
+        ":saturation",
     ],
 )
 


### PR DESCRIPTION
Constant Saturation added to an alternative ConnectController Method. Needed to utilise input-saturating PID controller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4872)
<!-- Reviewable:end -->
