### PR TITLE
remove references to the matlab bindings from {add|rm}path_drake.m

### DIFF
--- a/drake/addpath_drake.m
+++ b/drake/addpath_drake.m
@@ -59,11 +59,6 @@ addpath(fullfile(root,'matlab','solvers','qpSpline'));
 addpath(fullfile(root,'matlab','util'));
 addpath(fullfile(root,'matlab','util','geometry'));
 addpath(fullfile(root,'matlab','util','visualization'));
-addpath(fullfile(root,'bindings','matlab'));
-bindings_dir = fullfile(get_drake_binary_dir(),'bindings','matlab');
-if exist(bindings_dir, 'dir')
-  addpath(bindings_dir);
-end
 
 
 % OSX platform-specific

--- a/drake/rmpath_drake.m
+++ b/drake/rmpath_drake.m
@@ -42,7 +42,6 @@ rmpath(fullfile(root,'matlab','solvers','qpSpline'));
 rmpath(fullfile(root,'matlab','util'));
 rmpath(fullfile(root,'matlab','util','geometry'));
 rmpath(fullfile(root,'matlab','util','visualization'));
-rmpath(fullfile(root,'bindings','matlab'));
 
 javarmpath(fullfile(drake_get_base_path,'share','java','drake.jar'));
 javarmpath(fullfile(drake_get_base_path,'share','java','lcmtypes_drake.jar'));


### PR DESCRIPTION
Fixes the warnings mentioned in https://github.com/RobotLocomotion/drake/pull/4869#issuecomment-274895349

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4891)
<!-- Reviewable:end -->
