### PR TITLE
Resolved a couple AutoDiffX-induced issues in RBP.

### DIFF
--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -637,12 +637,18 @@ T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint, const T& position,
     const T violation = position - qmax;
     const T limit_force =
         (-joint_stiffness * violation * (1 + joint_dissipation * velocity));
-    return std::min(limit_force, 0.);
+    // The following two lines are necessary to support templating on AutoDiffX.
+    // See: https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275099824.
+    using std::min;
+    return min(limit_force, 0.);
   } else if (position < qmin) {
     const T violation = position - qmin;
     const T limit_force =
         (-joint_stiffness * violation * (1 - joint_dissipation * velocity));
-    return std::max(limit_force, 0.);
+    // The following two lines are necessary to support templating on AutoDiffX.
+    // See: https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275099824.
+    using std::max;
+    return max(limit_force, 0.);
   }
   return 0;
 }

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -638,7 +638,8 @@ T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint, const T& position,
     const T limit_force =
         (-joint_stiffness * violation * (1 + joint_dissipation * velocity));
     // The following two lines are necessary to support templating on AutoDiffX.
-    // See: https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275099824.
+    // See https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275099824
+    // and the file description of drake/common/autodiff_overloads.h.
     using std::min;
     return min(limit_force, 0.);
   } else if (position < qmin) {
@@ -646,7 +647,8 @@ T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint, const T& position,
     const T limit_force =
         (-joint_stiffness * violation * (1 - joint_dissipation * velocity));
     // The following two lines are necessary to support templating on AutoDiffX.
-    // See: https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275099824.
+    // See https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275099824
+    // and the file description of drake/common/autodiff_overloads.h.
     using std::max;
     return max(limit_force, 0.);
   }

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -637,19 +637,13 @@ T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint, const T& position,
     const T violation = position - qmax;
     const T limit_force =
         (-joint_stiffness * violation * (1 + joint_dissipation * velocity));
-    // The following two lines are necessary to support templating on AutoDiffX.
-    // See https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275099824
-    // and the file description of drake/common/autodiff_overloads.h.
-    using std::min;
+    using std::min;  // Needed for ADL.
     return min(limit_force, 0.);
   } else if (position < qmin) {
     const T violation = position - qmin;
     const T limit_force =
         (-joint_stiffness * violation * (1 - joint_dissipation * velocity));
-    // The following two lines are necessary to support templating on AutoDiffX.
-    // See https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275099824
-    // and the file description of drake/common/autodiff_overloads.h.
-    using std::max;
+    using std::max;  // Needed for ADL.
     return max(limit_force, 0.);
   }
   return 0;


### PR DESCRIPTION
Note that even with these changes RBP still doesn't support being templated on `AutoDiffX`. See https://github.com/RobotLocomotion/drake/issues/4897#issuecomment-275114870.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4903)
<!-- Reviewable:end -->
