### PR TITLE
Add and use SingleOutputVectorSource

### DIFF
--- a/drake/examples/Pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_run_swing_up.cc
@@ -90,9 +90,9 @@ int do_main(int argc, char* argv[]) {
 
   auto publisher = builder.AddSystem<systems::DrakeVisualizer>(*tree, &lcm);
 
-  builder.Connect(input_source->get_output_port(0),
+  builder.Connect(input_source->get_output_port(),
                   controller->get_input_port(0));
-  builder.Connect(state_source->get_output_port(0),
+  builder.Connect(state_source->get_output_port(),
                   controller->get_input_port(1));
   builder.Connect(controller->get_output_port(0), publisher->get_input_port(0));
 

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo_plant_builder.h
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/kuka_demo_plant_builder.h
@@ -123,7 +123,7 @@ class KukaDemo : public systems::Diagram<T> {
     viz_publisher_ = builder.template AddSystem<systems::DrakeVisualizer>(
         plant_->get_rigid_body_tree(), &lcm_);
 
-    builder.Connect(desired_plan_->get_output_port(0),
+    builder.Connect(desired_plan_->get_output_port(),
                     input_mux->get_input_port(0));
 
     // Splits the RBP output into positions (q) and velocities (v).

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
@@ -201,7 +201,7 @@ PositionControlledPlantWithRobot<T>::PositionControlledPlantWithRobot(
   // Creates a plan and wraps it into a source system.
   desired_plan_ =
       builder.template AddSystem<TrajectorySource<double>>(*poly_trajectory_);
-  builder.Connect(desired_plan_->get_output_port(0),
+  builder.Connect(desired_plan_->get_output_port(),
                   input_mux_->get_input_port(0));
 
   auto rbp_state_demux = builder.template AddSystem<Demultiplexer<T>>(

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -20,6 +20,7 @@ cc_library(
         ":leaf_context",
         ":leaf_system",
         ":parameters",
+        ":single_output_vector_source",
         ":state",
         ":system",
         ":value",
@@ -294,6 +295,16 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "single_output_vector_source",
+    srcs = ["single_output_vector_source.cc"],
+    hdrs = ["single_output_vector_source.h"],
+    linkstatic = 1,
+    deps = [
+        ":leaf_system",
+    ],
+)
+
 # === test/ ===
 
 cc_googletest(
@@ -457,6 +468,13 @@ cc_googletest(
     deps = [
         ":value",
         "//drake/common",
+    ],
+)
+
+cc_googletest(
+    name = "single_output_vector_source_test",
+    deps = [
+        ":single_output_vector_source",
     ],
 )
 

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -15,6 +15,7 @@ set(sources
   leaf_system.cc
   output_port_listener_interface.cc
   parameters.cc
+  single_output_vector_source.cc
   state.cc
   subvector.cc
   supervector.cc
@@ -23,7 +24,8 @@ set(sources
   system_output.cc
   system_port_descriptor.cc
   value.cc
-  vector_base.cc)
+  vector_base.cc
+  )
 
 # Headers that should be installed with Drake so that they
 # are available elsewhere via #include.
@@ -50,16 +52,18 @@ set(installed_headers
   leaf_system.h
   output_port_listener_interface.h
   parameters.h
+  single_output_vector_source.h
   state.h
   subvector.h
   supervector.h
   system.h
-  systems.h
   system_input.h
   system_output.h
   system_port_descriptor.h
+  systems.h
   value.h
-  vector_base.h)
+  vector_base.h
+  )
 
 # Headers that are needed by code here but should not
 # be exposed anywhere else.

--- a/drake/systems/framework/single_output_vector_source.cc
+++ b/drake/systems/framework/single_output_vector_source.cc
@@ -1,0 +1,9 @@
+#include "drake/systems/framework/single_output_vector_source.h"
+
+namespace drake {
+namespace systems {
+
+template class SingleOutputVectorSource<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/single_output_vector_source.h
+++ b/drake/systems/framework/single_output_vector_source.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+
+namespace drake {
+namespace systems {
+
+/// A base class that specializes LeafSystem for use with no input ports, and
+/// only a single output port.  Subclasses should override the protected method
+///   DoCalcOutput(const Context<T>&, Eigen::VectorBlock<VectorX<T>>*) const
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+template <typename T>
+class SingleOutputVectorSource : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SingleOutputVectorSource)
+
+  /// Deleted default constructor.  The output vector size must be supplied to
+  /// the single-argument constructor SingleOutputVectorSource(int).
+  SingleOutputVectorSource() = delete;
+
+  ~SingleOutputVectorSource() override = default;
+
+  /// Returns the sole output port.
+  const OutputPortDescriptor<T>& get_output_port() const {
+    return LeafSystem<T>::get_output_port(0);
+  }
+
+  // Don't use the indexed get_output_port when calling this system directly.
+  void get_output_port(int) = delete;
+
+  // Confirms the single-output invariant when allocating the context.
+  std::unique_ptr<Context<T>> AllocateContext() const override {
+    DRAKE_DEMAND(this->get_num_input_ports() == 0);
+    DRAKE_DEMAND(this->get_num_output_ports() == 1);
+    return LeafSystem<T>::AllocateContext();
+  }
+
+  /// Sanity checks the context and output, then delegates to
+  /// DoCalcOutput(const Context<T>&, Eigen::VectorBlock<VectorX<T>>*) const
+  void DoCalcOutput(const Context<T>& context,
+                    SystemOutput<T>* output) const final {
+    Eigen::VectorBlock<VectorX<T>> block =
+        System<T>::GetMutableOutputVector(output, 0);
+    DoCalcVectorOutput(context, &block);
+  }
+
+ protected:
+  /// Creates a source with the given sole output port configuration.
+  explicit SingleOutputVectorSource(int size) {
+    this->DeclareOutputPort(kVectorValued, size);
+  }
+
+  /// Convenience overload supplied for subclasses.  This method performs the
+  /// same logical operation as
+  ///   System::DoCalcOutput(const Context<T>&, SystemOutput<T>*) const
+  /// but this overload provides the single output's VectorBlock instead.
+  /// Subclasses should override this method, and not the base class method
+  /// (which is `final`).
+  virtual void DoCalcVectorOutput(
+      const Context<T>& context,
+      Eigen::VectorBlock<VectorX<T>>* output) const = 0;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -48,3 +48,7 @@ target_link_libraries(leaf_system_test drakeSystemFramework drakeSystemPrimitive
 
 drake_add_cc_test(parameters_test)
 target_link_libraries(parameters_test drakeSystemFramework drakeSystemPrimitives)
+
+drake_add_cc_test(single_output_vector_source_test)
+target_link_libraries(single_output_vector_source_test
+  drakeSystemFramework drakeSystemPrimitives)

--- a/drake/systems/framework/test/single_output_vector_source_test.cc
+++ b/drake/systems/framework/test/single_output_vector_source_test.cc
@@ -1,0 +1,62 @@
+#include "drake/systems/framework/single_output_vector_source.h"
+
+#include <memory>
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_copyable.h"
+
+#include "gtest/gtest.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+const int kSize = 3;
+
+class TestSource : public SingleOutputVectorSource<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestSource)
+
+  TestSource() : SingleOutputVectorSource<double>(kSize) {}
+
+  // N.B. This method signature might be used by many downstream projects.
+  // Change it only with good reason and with a deprecation period first.
+  void DoCalcVectorOutput(
+      const Context<double>& context,
+      Eigen::VectorBlock<Eigen::VectorXd>* output) const final {
+    *output = Eigen::Vector3d::Ones();
+  }
+};
+
+class SingleOutputVectorSourceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    source_ = std::make_unique<TestSource>();
+    context_ = source_->CreateDefaultContext();
+    output_ = source_->AllocateOutput(*context_);
+  }
+
+  std::unique_ptr<System<double>> source_;
+  std::unique_ptr<Context<double>> context_;
+  std::unique_ptr<SystemOutput<double>> output_;
+};
+
+// Tests that the output is correct.
+TEST_F(SingleOutputVectorSourceTest, OutputTest) {
+  ASSERT_EQ(context_->get_num_input_ports(), 0);
+  ASSERT_EQ(output_->get_num_ports(), 1);
+
+  source_->CalcOutput(*context_, output_.get());
+
+  EXPECT_EQ(output_->get_vector_data(0)->get_value(), Eigen::Vector3d::Ones());
+}
+
+// Tests that the state is empty.
+TEST_F(SingleOutputVectorSourceTest, IsStateless) {
+  EXPECT_EQ(context_->get_continuous_state()->size(), 0);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/primitives/CMakeLists.txt
+++ b/drake/systems/primitives/CMakeLists.txt
@@ -36,7 +36,8 @@ drake_install_headers(
   signal_logger.h
   trajectory_source.h
   zero_order_hold.h
-  zero_order_hold-inl.h)
+  zero_order_hold-inl.h
+  )
 
 # Headers that are needed by code here but should not
 # be exposed anywhere else.

--- a/drake/systems/primitives/constant_vector_source.cc
+++ b/drake/systems/primitives/constant_vector_source.cc
@@ -1,12 +1,9 @@
 #include "drake/systems/primitives/constant_vector_source.h"
 
 #include "drake/common/autodiff_overloads.h"
-#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic_formula.h"
-#include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/leaf_context.h"
 
 namespace drake {
 namespace systems {
@@ -14,29 +11,20 @@ namespace systems {
 template <typename T>
 ConstantVectorSource<T>::ConstantVectorSource(
     const Eigen::Ref<const VectorX<T>>& source_value)
-    : source_value_(source_value) {
-  const int n = static_cast<int>(source_value.rows());
-  this->DeclareOutputPort(kVectorValued, n);
-}
+    : SingleOutputVectorSource<T>(source_value.rows()),
+      source_value_(source_value) {}
 
 template <typename T>
 ConstantVectorSource<T>::ConstantVectorSource(const T& source_value)
-    : source_value_(Vector1<T>::Constant(source_value)) {
-  this->DeclareOutputPort(kVectorValued, 1);
-}
+    : ConstantVectorSource(Vector1<T>::Constant(source_value)) {}
 
 template <typename T>
-const OutputPortDescriptor<T>& ConstantVectorSource<T>::get_output_port()
-    const {
-  return System<T>::get_output_port(0);
-}
+ConstantVectorSource<T>::~ConstantVectorSource() = default;
 
 template <typename T>
-void ConstantVectorSource<T>::DoCalcOutput(const Context<T>& context,
-                                           SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-  System<T>::GetMutableOutputVector(output, 0) = source_value_;
+void ConstantVectorSource<T>::DoCalcVectorOutput(
+    const Context<T>& context, Eigen::VectorBlock<VectorX<T>>* output) const {
+  *output = source_value_;
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/systems/primitives/constant_vector_source.h
+++ b/drake/systems/primitives/constant_vector_source.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <cstdint>
-#include <memory>
-
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/context.h"
-#include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/single_output_vector_source.h"
 
 namespace drake {
 namespace systems {
@@ -23,8 +20,10 @@ namespace systems {
 /// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 template <typename T>
-class ConstantVectorSource : public LeafSystem<T> {
+class ConstantVectorSource : public SingleOutputVectorSource<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ConstantVectorSource)
+
   /// Constructs a system with a vector output that is constant and equals the
   /// supplied @p source_value at all times.
   /// @param source_value the constant value of the output so that
@@ -38,15 +37,15 @@ class ConstantVectorSource : public LeafSystem<T> {
   /// `y = source_value` at all times.
   explicit ConstantVectorSource(const T& source_value);
 
+  ~ConstantVectorSource() override;
 
-  /// Returns the output port to the constant source.
-  const OutputPortDescriptor<T>& get_output_port() const;
+ protected:
+  /// Outputs a signal with a fixed value as specified by the user.
+  void DoCalcVectorOutput(
+      const Context<T>& context,
+      Eigen::VectorBlock<VectorX<T>>* output) const override;
 
  private:
-  // Outputs a signal with a fixed value as specified by the user.
-  void DoCalcOutput(const Context<T>& context,
-                    SystemOutput<T>* output) const override;
-
   // TODO(amcastro-tri): move source_value_ to the system's parameters.
   const VectorX<T> source_value_;
 };

--- a/drake/systems/primitives/test/trajectory_source_test.cc
+++ b/drake/systems/primitives/test/trajectory_source_test.cc
@@ -2,13 +2,13 @@
 
 #include <memory>
 
+#include "gtest/gtest.h"
+
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system_input.h"
-
-#include "gtest/gtest.h"
 
 using Eigen::Matrix;
 using Eigen::MatrixXd;

--- a/drake/systems/primitives/trajectory_source.cc
+++ b/drake/systems/primitives/trajectory_source.cc
@@ -1,26 +1,23 @@
 #include "drake/systems/primitives/trajectory_source.h"
 
 #include "drake/common/drake_assert.h"
-#include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace systems {
 
 template <typename T>
 TrajectorySource<T>::TrajectorySource(const Trajectory& trajectory)
-    : trajectory_(trajectory) {
-  this->DeclareOutputPort(kVectorValued, trajectory_.rows());
+    : SingleOutputVectorSource<T>(trajectory.rows()),
+      trajectory_(trajectory) {
   // This class does not currently support trajectories which output
   // more complicated matrices.
   DRAKE_DEMAND(trajectory.cols() == 1);
 }
 
 template <typename T>
-void TrajectorySource<T>::DoCalcOutput(const Context<T>& context,
-                                       SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
-  T time = context.get_time();
-  System<T>::GetMutableOutputVector(output, 0) = trajectory_.value(time);
+void TrajectorySource<T>::DoCalcVectorOutput(
+    const Context<T>& context, Eigen::VectorBlock<VectorX<T>>* output) const {
+  *output = trajectory_.value(context.get_time());
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/systems/primitives/trajectory_source.h
+++ b/drake/systems/primitives/trajectory_source.h
@@ -1,19 +1,17 @@
 #pragma once
 
-#include <cstdint>
-
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
 #include "drake/common/trajectories/trajectory.h"
 #include "drake/systems/framework/context.h"
-#include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/single_output_vector_source.h"
 
 namespace drake {
 namespace systems {
 
-/// A source block which generates the value of a Trajectory for a
-/// given time.  The output is vector values, and may vary with the
-/// time (as reflected in the context) at which the output is
-/// evaluated.
+/// A source block that generates the value of a Trajectory for a given time.
+/// The output is vector values, and may vary with the time (as reflected in
+/// the context) at which the output is evaluated.
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///
@@ -24,19 +22,24 @@ namespace systems {
 /// No other values for T are currently supported.
 /// @ingroup primitive_systems
 template <typename T>
-class TrajectorySource : public LeafSystem<T> {
+class TrajectorySource : public SingleOutputVectorSource<T> {
  public:
-  /// @param trajectory Trajectory used by the system.  This reference
-  /// is aliased, and must remain valid for the lifetime of the
-  /// system.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectorySource)
+
+  /// @param trajectory Trajectory used by the system.  This reference is
+  /// aliased, and must remain valid for the lifetime of the system.
   explicit TrajectorySource(const Trajectory& trajectory);
 
- private:
-  // Outputs a signal using the time-varying trajectory specified in the
-  // constructor.
-  void DoCalcOutput(const Context<T>& context,
-                    SystemOutput<T>* output) const override;
+  ~TrajectorySource() override = default;
 
+ protected:
+  /// Outputs a signal using the time-varying trajectory specified in the
+  /// constructor.
+  void DoCalcVectorOutput(
+      const Context<T>& context,
+      Eigen::VectorBlock<VectorX<T>>* output) const override;
+
+ private:
   const Trajectory& trajectory_;
 };
 


### PR DESCRIPTION
This is a small first portion of #4448.

The base class isn't super-valuable (as discussed in 4448), but might consolidate a few more use cases in the future, and offers at least a little benefit for now.

Mostly, this PR serves as an early example of the other base class(es) I'm working on for 4448, and a way to iterate on the design pattern before scaling up to things like SisoVectorSystem that is much more wide-reaching.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4928)
<!-- Reviewable:end -->
