### PR TITLE
Use drake_copyable in systems/framework

### DIFF
--- a/drake/systems/framework/abstract_state.h
+++ b/drake/systems/framework/abstract_state.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
@@ -17,6 +18,9 @@ namespace systems {
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
 class AbstractState {
  public:
+  // AbstractState is not copyable or moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AbstractState)
+
   // Constructs an empty abstract state.
   AbstractState();
 
@@ -48,12 +52,6 @@ class AbstractState {
   /// will own its own data. This is true regardless of whether the state being
   /// cloned had ownership of its data or not.
   std::unique_ptr<AbstractState> Clone() const;
-
-  // AbstractState is not copyable or moveable.
-  AbstractState(const AbstractState& other) = delete;
-  AbstractState& operator=(const AbstractState& other) = delete;
-  AbstractState(AbstractState&& other) = delete;
-  AbstractState& operator=(AbstractState&& other) = delete;
 
  private:
   // Pointers to the data comprising the state. If the data is owned, these

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -24,6 +24,9 @@ namespace systems {
 template <typename T>
 class BasicVector : public VectorBase<T> {
  public:
+  // TODO(jwnimmer-tri) Should we use a drake_copyable macro here?  Right now,
+  // we are copy-only.
+
   /// Initializes with the given @p size using the drake::dummy_value<T>, which
   /// is NaN when T = double.
   explicit BasicVector(int size)

--- a/drake/systems/framework/cache.h
+++ b/drake/systems/framework/cache.h
@@ -22,6 +22,9 @@ namespace internal {
 /// entries that depend on it.
 class CacheEntry {
  public:
+  // TODO(jwnimmer-tri) Should we use a drake_copyable macro here?  Right now,
+  // we are moveable via our copy ctor, rather than a move-specific overload.
+
   CacheEntry();
   ~CacheEntry();
 

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/state.h"
@@ -34,11 +35,10 @@ struct StepInfo {
 template <typename T>
 class Context {
  public:
-  virtual ~Context() {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Context)
 
   Context() = default;
-  Context(const Context&) = delete;
-  Context& operator=(const Context&) = delete;
+  virtual ~Context() = default;
 
   // =========================================================================
   // Accessors and Mutators for Time.

--- a/drake/systems/framework/continuous_state.h
+++ b/drake/systems/framework/continuous_state.h
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/subvector.h"
@@ -22,6 +23,9 @@ namespace systems {
 template <typename T>
 class ContinuousState {
  public:
+  // ContinuousState is not copyable or moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContinuousState)
+
   /// Constructs a ContinuousState for a system that does not have second-order
   /// structure: All of the state is misc_continuous_state_.
   explicit ContinuousState(std::unique_ptr<VectorBase<T>> state) {
@@ -167,12 +171,6 @@ class ContinuousState {
 
   /// Returns a copy of the entire continuous state vector into an Eigen vector.
   VectorX<T> CopyToVector() const { return this->get_vector().CopyToVector(); }
-
-  // ContinuousState is not copyable or moveable.
-  ContinuousState(const ContinuousState& other) = delete;
-  ContinuousState& operator=(const ContinuousState& other) = delete;
-  ContinuousState(ContinuousState&& other) = delete;
-  ContinuousState& operator=(ContinuousState&& other) = delete;
 
  private:
   template <typename U>

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/common/number_traits.h"
 #include "drake/common/text_logging.h"
 #include "drake/systems/framework/cache.h"
@@ -57,6 +58,10 @@ bool HasEvent(const UpdateActions<T> actions,
 template <typename T>
 class DiagramOutput : public SystemOutput<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramOutput)
+
+  DiagramOutput() = default;
+
   int get_num_ports() const override { return static_cast<int>(ports_.size()); }
 
   OutputPort* get_mutable_port(int index) override {
@@ -89,6 +94,8 @@ class DiagramOutput : public SystemOutput<T> {
 template <typename T>
 class DiagramTimeDerivatives : public DiagramContinuousState<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramTimeDerivatives)
+
   explicit DiagramTimeDerivatives(
       std::vector<std::unique_ptr<ContinuousState<T>>>&& substates)
       : DiagramContinuousState<T>(Unpack(substates)),
@@ -106,6 +113,8 @@ class DiagramTimeDerivatives : public DiagramContinuousState<T> {
 template <typename T>
 class DiagramDiscreteVariables : public DiscreteState<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramDiscreteVariables)
+
   explicit DiagramDiscreteVariables(
       std::vector<std::unique_ptr<DiscreteState<T>>>&& subdiscretes)
       : DiscreteState<T>(Flatten(Unpack(subdiscretes))),
@@ -146,6 +155,9 @@ template <typename T>
 class Diagram : public System<T>,
                 public detail::InputPortEvaluatorInterface<T> {
  public:
+  // Diagram objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Diagram)
+
   typedef typename std::pair<const System<T>*, int> PortIdentifier;
 
   ~Diagram() override {}
@@ -1094,12 +1106,6 @@ class Diagram : public System<T>,
   int num_subsystems() const {
     return static_cast<int>(sorted_systems_.size());
   }
-
-  // Diagram objects are neither copyable nor moveable.
-  Diagram(const Diagram<T>& other) = delete;
-  Diagram& operator=(const Diagram<T>& other) = delete;
-  Diagram(Diagram<T>&& other) = delete;
-  Diagram& operator=(Diagram<T>&& other) = delete;
 
   // A map from the input ports of constituent systems, to the output ports of
   // the systems on which they depend.

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/system.h"
@@ -26,6 +27,9 @@ namespace systems {
 template <typename T>
 class DiagramBuilder {
  public:
+  // DiagramBuilder objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramBuilder)
+
   DiagramBuilder() {}
   virtual ~DiagramBuilder() {}
 
@@ -272,12 +276,6 @@ class DiagramBuilder {
     blueprint.sorted_systems = SortSystems();
     return blueprint;
   }
-
-  // DiagramBuilder objects are neither copyable nor moveable.
-  DiagramBuilder(const DiagramBuilder<T>& other) = delete;
-  DiagramBuilder& operator=(const DiagramBuilder<T>& other) = delete;
-  DiagramBuilder(DiagramBuilder<T>&& other) = delete;
-  DiagramBuilder& operator=(DiagramBuilder<T>&& other) = delete;
 
   // The ordered inputs and outputs of the Diagram to be built.
   std::vector<PortIdentifier> input_port_ids_;

--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_continuous_state.h"
@@ -24,6 +25,8 @@ namespace systems {
 template <typename T>
 class DiagramState : public State<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramState)
+
   /// Constructs a DiagramState consisting of @p size substates.
   explicit DiagramState<T>(int size) :
       State<T>(),
@@ -107,6 +110,8 @@ class DiagramState : public State<T> {
 template <typename T>
 class DiagramContext : public Context<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramContext)
+
   typedef int SystemIndex;
   typedef int PortIndex;
   typedef std::pair<SystemIndex, PortIndex> PortIdentifier;

--- a/drake/systems/framework/diagram_continuous_state.h
+++ b/drake/systems/framework/diagram_continuous_state.h
@@ -2,6 +2,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/continuous_state.h"
 #include "drake/systems/framework/supervector.h"
 
@@ -15,6 +16,8 @@ namespace systems {
 template <typename T>
 class DiagramContinuousState : public ContinuousState<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramContinuousState)
+
   /// Constructs a ContinuousState that is composed of other ContinuousStates,
   /// which are not owned by this object and must outlive it.
   ///

--- a/drake/systems/framework/discrete_state.h
+++ b/drake/systems/framework/discrete_state.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/value.h"
 
@@ -26,6 +27,9 @@ namespace systems {
 template <typename T>
 class DiscreteState {
  public:
+  // DiscreteState is not copyable or moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteState)
+
   /// Constructs an empty discrete state.
   DiscreteState() {}
 
@@ -93,12 +97,6 @@ class DiscreteState {
     }
     return std::make_unique<DiscreteState>(std::move(cloned_data));
   }
-
-  // DiscreteState is not copyable or moveable.
-  DiscreteState(const DiscreteState& other) = delete;
-  DiscreteState& operator=(const DiscreteState& other) = delete;
-  DiscreteState(DiscreteState&& other) = delete;
-  DiscreteState& operator=(DiscreteState&& other) = delete;
 
  private:
   // Pointers to the data comprising the state. If the data is owned, these

--- a/drake/systems/framework/input_port_evaluator_interface.h
+++ b/drake/systems/framework/input_port_evaluator_interface.h
@@ -2,6 +2,7 @@
 
 #include <sstream>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/system_port_descriptor.h"
 
@@ -25,6 +26,9 @@ namespace detail {
 template <typename T>
 class InputPortEvaluatorInterface {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InputPortEvaluatorInterface)
+
+  InputPortEvaluatorInterface() {}
   virtual ~InputPortEvaluatorInterface() {}
 
   /// Evaluates the input port with the given @p id in the given @p context.

--- a/drake/systems/framework/leaf_context.h
+++ b/drake/systems/framework/leaf_context.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/cache.h"
@@ -29,8 +30,11 @@ namespace systems {
 template <typename T>
 class LeafContext : public Context<T> {
  public:
+  // LeafContext objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LeafContext)
+
   LeafContext() : state_(std::make_unique<State<T>>()) {}
-  virtual ~LeafContext() {}
+  ~LeafContext() override {}
 
   void SetInputPort(int index, std::unique_ptr<InputPort> port) override {
     DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
@@ -190,12 +194,6 @@ class LeafContext : public Context<T> {
   }
 
  private:
-  // LeafContext objects are neither copyable nor moveable.
-  LeafContext(const LeafContext& other) = delete;
-  LeafContext& operator=(const LeafContext& other) = delete;
-  LeafContext(LeafContext&& other) = delete;
-  LeafContext& operator=(LeafContext&& other) = delete;
-
   // The external inputs to the System.
   std::vector<std::unique_ptr<InputPort>> inputs_;
 

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -11,6 +11,7 @@
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/number_traits.h"
 #include "drake/systems/framework/abstract_state.h"
@@ -45,6 +46,9 @@ struct PeriodicEvent {
 template <typename T>
 class LeafSystem : public System<T> {
  public:
+  // LeafSystem objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LeafSystem)
+
   ~LeafSystem() override {}
 
   // =========================================================================
@@ -147,12 +151,6 @@ class LeafSystem : public System<T> {
       const override {
     return AllocateDiscreteState();
   }
-
-  // LeafSystem objects are neither copyable nor moveable.
-  explicit LeafSystem(const System<T>& other) = delete;
-  LeafSystem& operator=(const System<T>& other) = delete;
-  explicit LeafSystem(System<T>&& other) = delete;
-  LeafSystem& operator=(System<T>&& other) = delete;
 
  protected:
   LeafSystem() {}

--- a/drake/systems/framework/output_port_listener_interface.cc
+++ b/drake/systems/framework/output_port_listener_interface.cc
@@ -4,6 +4,8 @@ namespace drake {
 namespace systems {
 namespace detail {
 
+OutputPortListenerInterface::OutputPortListenerInterface() {}
+
 OutputPortListenerInterface::~OutputPortListenerInterface() {}
 
 }  // namespace detail

--- a/drake/systems/framework/output_port_listener_interface.h
+++ b/drake/systems/framework/output_port_listener_interface.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "drake/common/drake_copyable.h"
+
 namespace drake {
 namespace systems {
 namespace detail {
@@ -9,6 +11,9 @@ namespace detail {
 /// port's version number is incremented.
 class OutputPortListenerInterface {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OutputPortListenerInterface)
+
+  OutputPortListenerInterface();
   virtual ~OutputPortListenerInterface();
 
   /// Invalidates any data that depends on the OutputPort. Called whenever

--- a/drake/systems/framework/parameters.h
+++ b/drake/systems/framework/parameters.h
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/abstract_state.h"
 #include "drake/systems/framework/discrete_state.h"
 
@@ -24,6 +25,9 @@ namespace systems {
 template <typename T>
 class Parameters {
  public:
+  // Parameters are not copyable or moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Parameters)
+
   /// Constructs an empty Parameters.
   Parameters() : Parameters({}, {}) {}
 
@@ -101,12 +105,6 @@ class Parameters {
     clone->abstract_parameters_ = abstract_parameters_->Clone();
     return clone;
   }
-
-  // Parameters are not copyable or moveable.
-  Parameters(const Parameters& other) = delete;
-  Parameters& operator=(const Parameters& other) = delete;
-  Parameters(Parameters&& other) = delete;
-  Parameters& operator=(Parameters&& other) = delete;
 
  private:
   // TODO(david-german-tri): Consider renaming AbstractState and DiscreteState

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/abstract_state.h"
 #include "drake/systems/framework/continuous_state.h"
 #include "drake/systems/framework/discrete_state.h"
@@ -20,6 +21,9 @@ namespace systems {
 template <typename T>
 class State {
  public:
+  // State is not copyable or moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(State)
+
   State()
       : abstract_state_(std::make_unique<AbstractState>()),
         continuous_state_(std::make_unique<ContinuousState<T>>()),
@@ -96,12 +100,6 @@ class State {
     discrete_state_->SetFrom(*other.get_discrete_state());
     abstract_state_->CopyFrom(*other.get_abstract_state());
   }
-
-  // State is not copyable or moveable.
-  State(const State& other) = delete;
-  State& operator=(const State& other) = delete;
-  State(State&& other) = delete;
-  State& operator=(State&& other) = delete;
 
  private:
   std::unique_ptr<AbstractState> abstract_state_;

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <stdexcept>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/systems/framework/vector_base.h"
 
@@ -18,6 +19,9 @@ namespace systems {
 template <typename T>
 class Subvector : public VectorBase<T> {
  public:
+  // Subvector objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Subvector)
+
   /// Constructs a subvector of vector that consists of num_elements starting
   /// at first_element.
   /// @param vector The vector to slice.  Must not be nullptr. Must remain
@@ -52,12 +56,6 @@ class Subvector : public VectorBase<T> {
   }
 
  private:
-  // Subvector objects are neither copyable nor moveable.
-  Subvector(const Subvector& other) = delete;
-  Subvector& operator=(const Subvector& other) = delete;
-  Subvector(Subvector&& other) = delete;
-  Subvector& operator=(Subvector&& other) = delete;
-
   VectorBase<T>* vector_{nullptr};
   int first_element_{0};
   int num_elements_{0};

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/vector_base.h"
 
 namespace drake {
@@ -21,6 +22,9 @@ namespace systems {
 template <typename T>
 class Supervector : public VectorBase<T> {
  public:
+  // Supervector objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Supervector)
+
   /// Constructs a supervector consisting of all the vectors in
   /// subvectors, which must live at least as long as this supervector.
   explicit Supervector(const std::vector<VectorBase<T>*>& subvectors)
@@ -80,12 +84,6 @@ class Supervector : public VectorBase<T> {
     const int start_of_subvector = (subvector_id == 0) ? 0 : *(it - 1);
     return std::make_pair(subvector, index - start_of_subvector);
   }
-
-  // Supervector objects are neither copyable nor moveable.
-  Supervector(const Supervector& other) = delete;
-  Supervector& operator=(const Supervector& other) = delete;
-  Supervector(Supervector&& other) = delete;
-  Supervector& operator=(Supervector&& other) = delete;
 
   // An ordered list of all the constituent vectors in this supervector.
   std::vector<VectorBase<T>*> vectors_;

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -8,6 +8,7 @@
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/systems/framework/cache.h"
@@ -90,6 +91,9 @@ struct UpdateActions {
 template <typename T>
 class System {
  public:
+  // System objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(System)
+
   virtual ~System() {}
 
   //----------------------------------------------------------------------------
@@ -1003,12 +1007,6 @@ class System {
   //@}
 
  private:
-  // System objects are neither copyable nor moveable.
-  System(const System<T>& other) = delete;
-  System& operator=(const System<T>& other) = delete;
-  System(System<T>&& other) = delete;
-  System& operator=(System<T>&& other) = delete;
-
   std::string name_;
   // input_ports_ and output_ports_ are vectors of unique_ptr so that references
   // to the descriptors will remain valid even if the vector is resized.

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/output_port_listener_interface.h"
@@ -20,6 +21,8 @@ namespace systems {
 /// FreestandingInputPorts.
 class InputPort : public detail::OutputPortListenerInterface {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InputPort)
+
   ~InputPort() override;
 
   /// Returns a positive number that increases monotonically, and changes
@@ -71,6 +74,9 @@ class InputPort : public detail::OutputPortListenerInterface {
 /// OutputPort.
 class DependentInputPort : public InputPort {
  public:
+  // DependentInputPort objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DependentInputPort)
+
   /// Creates an input port connected to the given @p output_port, which
   /// must not be nullptr. The output port must outlive this input port.
   explicit DependentInputPort(OutputPort* output_port);
@@ -92,19 +98,16 @@ class DependentInputPort : public InputPort {
   const OutputPort* get_output_port() const override { return output_port_; }
 
  private:
-  // DependentInputPort objects are neither copyable nor moveable.
-  DependentInputPort(const DependentInputPort& other) = delete;
-  DependentInputPort& operator=(const DependentInputPort& other) = delete;
-  DependentInputPort(DependentInputPort&& other) = delete;
-  DependentInputPort& operator=(DependentInputPort&& other) = delete;
-
-  OutputPort* output_port_;
+  OutputPort* output_port_{};
 };
 
 /// The FreestandingInputPort encapsulates a vector of data for use as an input
 /// to a System.
 class FreestandingInputPort : public InputPort {
  public:
+  // FreestandingInputPort objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FreestandingInputPort)
+
   /// Constructs a vector-valued FreestandingInputPort.
   /// Takes ownership of @p vec.
   ///
@@ -173,12 +176,6 @@ class FreestandingInputPort : public InputPort {
   const OutputPort* get_output_port() const override { return &output_port_; }
 
  private:
-  // FreestandingInputPort objects are neither copyable nor moveable.
-  FreestandingInputPort(const FreestandingInputPort& other) = delete;
-  FreestandingInputPort& operator=(const FreestandingInputPort& other) = delete;
-  FreestandingInputPort(FreestandingInputPort&& other) = delete;
-  FreestandingInputPort& operator=(FreestandingInputPort&& other) = delete;
-
   OutputPort output_port_;
 };
 

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/output_port_listener_interface.h"
 #include "drake/systems/framework/value.h"
@@ -20,6 +21,9 @@ namespace systems {
 /// meaning those ports will resolve to nullptr.
 class OutputPort {
  public:
+  // OutputPort objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OutputPort)
+
   /// Constructs a vector-valued OutputPort.
   /// Takes ownership of @p vec.
   ///
@@ -99,12 +103,6 @@ class OutputPort {
  private:
   void InvalidateAndIncrement();
 
-  // OutputPort objects are neither copyable nor moveable.
-  OutputPort(const OutputPort& other) = delete;
-  OutputPort& operator=(const OutputPort& other) = delete;
-  OutputPort(OutputPort&& other) = delete;
-  OutputPort& operator=(OutputPort&& other) = delete;
-
   // The port data.
   std::unique_ptr<AbstractValue> data_;
 
@@ -121,6 +119,9 @@ class OutputPort {
 template <typename T>
 class SystemOutput {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemOutput)
+
+  SystemOutput() {}
   virtual ~SystemOutput() {}
 
   virtual int get_num_ports() const = 0;
@@ -177,10 +178,10 @@ class SystemOutput {
 /// @tparam T The type of the output data. Must be a valid Eigen scalar.
 template <typename T>
 struct LeafSystemOutput : public SystemOutput<T> {
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LeafSystemOutput)
+
   LeafSystemOutput() = default;
-  LeafSystemOutput(const LeafSystemOutput&) = delete;
-  LeafSystemOutput& operator=(const LeafSystemOutput&) = delete;
-  ~LeafSystemOutput() override {}
+  ~LeafSystemOutput() override = default;
 
   int get_num_ports() const override { return static_cast<int>(ports_.size()); }
 

--- a/drake/systems/framework/test/value_test.cc
+++ b/drake/systems/framework/test/value_test.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 
 #include "gtest/gtest.h"
@@ -114,13 +115,9 @@ GTEST_TEST(ValueTest, CannotUneraseToParentClass) {
 template <typename T>
 class PrintableValue : public Value<T>, public PrintInterface {
  public:
-  explicit PrintableValue(const T& v) : Value<T>(v) {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PrintableValue)
 
-  // PrintableValues neither copyable nor moveable.
-  PrintableValue(const PrintableValue<T>& other) = delete;
-  PrintableValue& operator=(const PrintableValue<T>& other) = delete;
-  PrintableValue(PrintableValue<T>&& other) = delete;
-  PrintableValue& operator=(PrintableValue<T>&& other) = delete;
+  explicit PrintableValue(const T& v) : Value<T>(v) {}
 
   std::unique_ptr<AbstractValue> Clone() const override {
     return std::unique_ptr<PrintableValue<T>>(

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -6,6 +6,7 @@
 #include <typeinfo>
 #include <utility>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -28,6 +29,10 @@ class Value;
 /// sensitive code (e.g., inner loops), and the safer version otherwise.
 class AbstractValue {
  public:
+  // TODO(jwnimmer-tri) This should use DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN but
+  // in-tree code is currently using the move operations!  I will fix in a
+  // subsequent PR.
+
   AbstractValue() {}
   virtual ~AbstractValue();
 
@@ -148,14 +153,11 @@ class AbstractValue {
 template <typename T>
 class Value : public AbstractValue {
  public:
+  // Values are copyable but not moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Value)
+
   explicit Value(const T& v) : value_(v) {}
   ~Value() override {}
-
-  // Values are neither copyable nor moveable.
-  Value(const Value<T>& other) = delete;
-  Value& operator=(const Value<T>& other) = delete;
-  Value(Value<T>&& other) = delete;
-  Value& operator=(Value<T>&& other) = delete;
 
   std::unique_ptr<AbstractValue> Clone() const override {
     return std::make_unique<Value<T>>(get_value());
@@ -203,9 +205,6 @@ class VectorValue : public Value<BasicVector<T>*> {
     owned_value_->set_value(other.get_value()->get_value());
     return *this;
   }
-
-  explicit VectorValue(Value<T>&& other) = delete;
-  VectorValue& operator=(Value<T>&& other) = delete;
 
   std::unique_ptr<AbstractValue> Clone() const override {
     return std::make_unique<VectorValue<T>>(*this);

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -6,6 +6,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 
@@ -25,6 +26,9 @@ namespace systems {
 template <typename T>
 class VectorBase {
  public:
+  // VectorBase objects are neither copyable nor moveable.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(VectorBase)
+
   virtual ~VectorBase() {}
 
   /// Returns the number of elements in the vector.
@@ -165,12 +169,6 @@ class VectorBase {
 
     return norm;
   }
-
-  // VectorBase objects are neither copyable nor moveable.
-  VectorBase(const VectorBase<T>& other) = delete;
-  VectorBase& operator=(const VectorBase<T>& other) = delete;
-  VectorBase(VectorBase<T>&& other) = delete;
-  VectorBase& operator=(VectorBase<T>&& other) = delete;
 
  protected:
   VectorBase() {}


### PR DESCRIPTION
A portion of #4861.

I have tried to change as little as possible in this PR -- keeping styles the same, and in places where the copy-move use is wrong I've TODO'd it rather than adding this macro (those will be another PR).

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4932)
<!-- Reviewable:end -->
