### PR TITLE
Refine direct feedthrough to be port-count-aware

### DIFF
--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -156,9 +156,11 @@ class System {
   /// (implicit computations) in system diagrams. Any System for which none of
   /// the input ports ever feeds through to any of the output ports should
   /// override this method to return false.
-  // TODO(amcastro-tri): Provide a more descriptive mechanism to specify
-  // pairwise (input_port, output_port) feedthrough.
-  virtual bool has_any_direct_feedthrough() const { return true; }
+  // TODO(4105): Provide a more descriptive mechanism to specify pairwise
+  // (input_port, output_port) feedthrough.
+  virtual bool has_any_direct_feedthrough() const {
+    return (get_num_input_ports() > 0) && (get_num_output_ports() > 0);
+  }
 
   //@}
 

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -141,6 +141,26 @@ class SystemTest : public ::testing::Test {
   LeafContext<double> context_;
 };
 
+TEST_F(SystemTest, Feedthrough) {
+  // No inputs or outputs.
+  EXPECT_FALSE(system_.has_any_direct_feedthrough());
+
+  // Both inputs and outputs.
+  system_.AddAbstractInputPort();
+  system_.AddAbstractOutputPort();
+  EXPECT_TRUE(system_.has_any_direct_feedthrough());
+
+  // Only inputs.
+  TestSystem input_only;
+  input_only.AddAbstractInputPort();
+  EXPECT_FALSE(input_only.has_any_direct_feedthrough());
+
+  // Only outputs.
+  TestSystem output_only;
+  output_only.AddAbstractOutputPort();
+  EXPECT_FALSE(output_only.has_any_direct_feedthrough());
+}
+
 TEST_F(SystemTest, MapVelocityToConfigurationDerivatives) {
   auto state_vec1 = BasicVector<double>::Make({1.0, 2.0, 3.0});
   BasicVector<double> state_vec2(kSize);


### PR DESCRIPTION
Relates slightly to #4105 and #4928.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4933)
<!-- Reviewable:end -->
