### PR TITLE
Add bazel build files for pybind11

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -100,6 +100,13 @@ new_git_repository(
     build_file = "tools/ipopt.BUILD",
 )
 
+new_git_repository(
+    name = "pybind11",
+    remote = "https://github.com/pybind/pybind11.git",
+    commit = "7830e8509f2adc97ce9ee32bf99cd4b82089cc4c",
+    build_file = "tools/pybind11.BUILD",
+)
+
 # Necessary for buildifier.
 http_archive(
     name = "io_bazel_rules_go",

--- a/tools/pybind11.BUILD
+++ b/tools/pybind11.BUILD
@@ -1,0 +1,26 @@
+# -*- python -*-
+
+cc_library(
+    name = "pybind11",
+    hdrs = [
+        "include/pybind11/attr.h",
+        "include/pybind11/cast.h",
+        "include/pybind11/chrono.h",
+        "include/pybind11/common.h",
+        "include/pybind11/complex.h",
+        "include/pybind11/descr.h",
+        "include/pybind11/eigen.h",
+        "include/pybind11/eval.h",
+        "include/pybind11/functional.h",
+        "include/pybind11/numpy.h",
+        "include/pybind11/operators.h",
+        "include/pybind11/options.h",
+        "include/pybind11/pybind11.h",
+        "include/pybind11/pytypes.h",
+        "include/pybind11/stl_bind.h",
+        "include/pybind11/stl.h",
+        "include/pybind11/typeid.h",
+    ],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This may need some tweaking when we actually use `pybind11`. At the very least, I assume bindings will need to link to the Python libraries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4937)
<!-- Reviewable:end -->
