### PR TITLE
Correct the types for which BasicVector is supported.

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -45,7 +45,9 @@ cc_library(
     linkstatic = 1,
     deps = [
         "//drake/common",
+        "//drake/common:autodiff",
         "//drake/common:dummy_value",
+        "//drake/common:symbolic",
     ],
 )
 
@@ -314,7 +316,7 @@ cc_googletest(
         "//drake/common",
         "//drake/common:autodiff",
         "//drake/common:eigen_matrix_compare",
-        "//drake/common:functional_form",
+        "//drake/common:symbolic",
     ],
 )
 

--- a/drake/systems/framework/basic_vector.cc
+++ b/drake/systems/framework/basic_vector.cc
@@ -1,4 +1,15 @@
-// For now, this is an empty .cc file that only serves to confirm
-// basic_vector.h is a stand-alone header.
-
 #include "drake/systems/framework/basic_vector.h"
+
+#include "drake/common/autodiff_overloads.h"
+#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/symbolic_expression.h"
+
+namespace drake {
+namespace systems {
+
+template class BasicVector<double>;
+template class BasicVector<AutoDiffXd>;
+template class BasicVector<symbolic::Expression>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -10,7 +10,7 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/functional_form.h"
+#include "drake/common/symbolic_expression.h"
 
 namespace drake {
 namespace systems {
@@ -18,12 +18,10 @@ namespace {
 
 // Tests SetZero functionality.
 GTEST_TEST(BasicVectorTest, SetZero) {
-  BasicVector<int> vec(3);
-  vec.get_mutable_value() << 1, 2, 3;
-  vec.SetZero();
-  Eigen::Vector3i expected;
-  expected << 0, 0, 0;
-  EXPECT_EQ(expected, vec.get_value());
+  auto vec = BasicVector<double>::Make(1.0, 2.0, 3.0);
+  EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), vec->get_value());
+  vec->SetZero();
+  EXPECT_EQ(Eigen::Vector3d(0, 0, 0), vec->get_value());
 }
 
 // Tests that the BasicVector<double> is initialized to NaN.
@@ -43,47 +41,43 @@ GTEST_TEST(BasicVectorTest, AutodiffInitiallyNaN) {
   EXPECT_TRUE(std::isnan(vec.GetAtIndex(2).value()));
 }
 
-// Tests that the BasicVector<int> is initialized to non-zero dummy that is the
-// same for all elements.
-GTEST_TEST(BasicVectorTest, IntInitiallyDummy) {
-  BasicVector<int> vec(3);
-
-  EXPECT_NE(vec.GetAtIndex(0), 0);
-  EXPECT_NE(vec.GetAtIndex(1), 0);
-  EXPECT_NE(vec.GetAtIndex(2), 0);
-
-  EXPECT_EQ(vec.GetAtIndex(0), vec.GetAtIndex(1));
-  EXPECT_EQ(vec.GetAtIndex(0), vec.GetAtIndex(2));
+// Tests that the BasicVector<symbolic::Expression> is initialized to NaN.
+GTEST_TEST(BasicVectorTest, SymbolicInitiallyNaN) {
+  BasicVector<symbolic::Expression> vec(1);
+  EXPECT_TRUE(symbolic::is_nan(vec.get_value()[0]));
 }
 
-// Tests that the BasicVector<FunctionalForm> is initialized to undefined.
-GTEST_TEST(BasicVectorTest, FunctionalFormInitiallyUndefined) {
-  BasicVector<FunctionalForm> vec(1);
-  EXPECT_TRUE(vec.get_value()[0].IsUndefined());
+// Tests that BasicVector<symbolic::Expression>::Make does what it says on
+// the tin.
+GTEST_TEST(BasicVectorTest, MakeSymbolic) {
+  auto vec = BasicVector<symbolic::Expression>::Make("x", "y", "z");
+  EXPECT_EQ("x", vec->GetAtIndex(0).to_string());
+  EXPECT_EQ("y", vec->GetAtIndex(1).to_string());
+  EXPECT_EQ("z", vec->GetAtIndex(2).to_string());
 }
 
 // Tests that the BasicVector has a size as soon as it is constructed.
 GTEST_TEST(BasicVectorTest, Size) {
-  BasicVector<int> vec(5);
+  BasicVector<double> vec(5);
   EXPECT_EQ(5, vec.size());
 }
 
 // Tests that the BasicVector can be mutated in-place.
 GTEST_TEST(BasicVectorTest, Mutate) {
-  BasicVector<int> vec(2);
+  BasicVector<double> vec(2);
   vec.get_mutable_value() << 1, 2;
-  Eigen::Vector2i expected;
+  Eigen::Vector2d expected;
   expected << 1, 2;
   EXPECT_EQ(expected, vec.get_value());
 }
 
 // Tests that the BasicVector can be addressed as an array.
 GTEST_TEST(BasicVectorTest, ArrayOperator) {
-  BasicVector<int> vec(2);
+  BasicVector<double> vec(2);
   vec[0] = 76;
   vec[1] = 42;
 
-  Eigen::Vector2i expected;
+  Eigen::Vector2d expected;
   expected << 76, 42;
   EXPECT_EQ(expected, vec.get_value());
   EXPECT_EQ(76, vec[0]);
@@ -92,9 +86,9 @@ GTEST_TEST(BasicVectorTest, ArrayOperator) {
 
 // Tests that the BasicVector can be set from another vector.
 GTEST_TEST(BasicVectorTest, SetWholeVector) {
-  BasicVector<int> vec(2);
+  BasicVector<double> vec(2);
   vec.get_mutable_value() << 1, 2;
-  Eigen::Vector2i next_value;
+  Eigen::Vector2d next_value;
   next_value << 3, 4;
   vec.set_value(next_value);
   EXPECT_EQ(next_value, vec.get_value());
@@ -102,12 +96,12 @@ GTEST_TEST(BasicVectorTest, SetWholeVector) {
 
 // Tests that when BasicVector is cloned, its data is preserved.
 GTEST_TEST(BasicVectorTest, Clone) {
-  BasicVector<int> vec(2);
+  BasicVector<double> vec(2);
   vec.get_mutable_value() << 1, 2;
 
-  std::unique_ptr<BasicVector<int>> clone = vec.Clone();
+  std::unique_ptr<BasicVector<double>> clone = vec.Clone();
 
-  Eigen::Vector2i expected;
+  Eigen::Vector2d expected;
   expected << 1, 2;
   EXPECT_EQ(expected, clone->get_value());
 }
@@ -115,34 +109,34 @@ GTEST_TEST(BasicVectorTest, Clone) {
 // Tests that an error is thrown when the BasicVector is set from a vector
 // of a different size.
 GTEST_TEST(BasicVectorTest, ReinitializeInvalid) {
-  BasicVector<int> vec(2);
-  Eigen::Vector3i next_value;
+  BasicVector<double> vec(2);
+  Eigen::Vector3d next_value;
   next_value << 3, 4, 5;
   EXPECT_THROW(vec.set_value(next_value), std::out_of_range);
 }
 
 // Tests the infinity norm computation
 GTEST_TEST(BasicVectorTest, InfNorm) {
-  BasicVector<int> vec(2);
+  BasicVector<double> vec(2);
   vec.get_mutable_value() << 3, -4;
   EXPECT_EQ(vec.NormInf(), 4);
 }
 
 // Tests all += * operations for BasicVector.
 GTEST_TEST(BasicVectorTest, PlusEqScaled) {
-  BasicVector<int> ogvec(2), vec1(2), vec2(2), vec3(2), vec4(2), vec5(2);
-  Eigen::Vector2i ans1, ans2, ans3, ans4, ans5;
+  BasicVector<double> ogvec(2), vec1(2), vec2(2), vec3(2), vec4(2), vec5(2);
+  Eigen::Vector2d ans1, ans2, ans3, ans4, ans5;
   ogvec.SetZero();
   vec1.get_mutable_value() << 1, 2;
   vec2.get_mutable_value() << 3, 5;
   vec3.get_mutable_value() << 7, 11;
   vec4.get_mutable_value() << 13, 17;
   vec5.get_mutable_value() << 19, 23;
-  VectorBase<int>& v1 = vec1;
-  VectorBase<int>& v2 = vec2;
-  VectorBase<int>& v3 = vec3;
-  VectorBase<int>& v4 = vec4;
-  VectorBase<int>& v5 = vec5;
+  VectorBase<double>& v1 = vec1;
+  VectorBase<double>& v2 = vec2;
+  VectorBase<double>& v3 = vec3;
+  VectorBase<double>& v4 = vec4;
+  VectorBase<double>& v5 = vec5;
   ogvec.PlusEqScaled(2, v1);
   ans1 << 2, 4;
   EXPECT_EQ(ans1, ogvec.get_value());


### PR DESCRIPTION
In particular, remove the appearance of support for `int`, and add support for `symbolic::Expression.`  Add a form of `BasicVector<T>::Make` that reduces boilerplate for types `T` that have single-argument constructors.

Contributes to #4658.

@soonho-tri for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4938)
<!-- Reviewable:end -->
