### PR TITLE
Remove add cost for all variables

### DIFF
--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -504,7 +504,8 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
     // 1/time constant of position constraint satisfaction.
     const T alpha = 5.0;
 
-    position_force = prog.NewContinuousVariables(nc, "position constraint force");
+    position_force = prog.NewContinuousVariables(nc,
+                                                 "position constraint force");
 
     auto phi = tree_->positionConstraints(kinsol);
     auto J = tree_->positionConstraintsJacobian(kinsol, false);
@@ -520,7 +521,8 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
   }
 
   // Adds [H,-J^T] * [vdot;f] = -C.
-  prog.AddLinearEqualityConstraint(H_and_neg_JT, -right_hand_side, {vdot, position_force});
+  prog.AddLinearEqualityConstraint(H_and_neg_JT, -right_hand_side,
+                                   {vdot, position_force});
 
   prog.Solve();
 

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -497,12 +497,14 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
 
   right_hand_side -= ComputeContactForce(kinsol);
 
+  solvers::VectorXDecisionVariable position_force{};
+
   if (tree_->getNumPositionConstraints()) {
     size_t nc = tree_->getNumPositionConstraints();
     // 1/time constant of position constraint satisfaction.
     const T alpha = 5.0;
 
-    prog.NewContinuousVariables(nc, "position constraint force");
+    position_force = prog.NewContinuousVariables(nc, "position constraint force");
 
     auto phi = tree_->positionConstraints(kinsol);
     auto J = tree_->positionConstraintsJacobian(kinsol, false);
@@ -518,7 +520,7 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
   }
 
   // Adds [H,-J^T] * [vdot;f] = -C.
-  prog.AddLinearEqualityConstraint(H_and_neg_JT, -right_hand_side);
+  prog.AddLinearEqualityConstraint(H_and_neg_JT, -right_hand_side, {vdot, position_force});
 
   prog.Solve();
 

--- a/drake/multibody/rigid_body_system1/RigidBodySystem.cpp
+++ b/drake/multibody/rigid_body_system1/RigidBodySystem.cpp
@@ -237,15 +237,14 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
     }
   }
 
+  solvers::VectorXDecisionVariable position_force{};
   if (tree->getNumPositionConstraints()) {
     size_t nc = tree->getNumPositionConstraints();
     const double alpha = 5.0;  // 1/time constant of position constraint
                                // satisfaction (see my latex rigid body notes)
 
-    prog.NewContinuousVariables(
-        nc, "position constraint force");  // don't actually need to use the
-                                           // decision variable reference that
-                                           // would be returned...
+    position_force = prog.NewContinuousVariables(
+        nc, "position constraint force");
 
     // then compute the constraint force
     auto phi = tree->positionConstraints(kinsol);
@@ -261,7 +260,7 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
   }
 
   // add [H,-J^T]*[vdot;f] = -C
-  prog.AddLinearEqualityConstraint(H_and_neg_JT, -C);
+  prog.AddLinearEqualityConstraint(H_and_neg_JT, -C, {vdot, position_force});
 
   prog.Solve();
   //      prog.PrintSolution();
@@ -354,7 +353,7 @@ RigidBodySystem::StateVector<double> getInitialState(
     }
 
     VectorXd q_guess = x0.topRows(nq);
-    prog.AddQuadraticCost(MatrixXd::Identity(nq, nq), q_guess);
+    prog.AddQuadraticCost(MatrixXd::Identity(nq, nq), q_guess, qvar);
     prog.Solve();
 
     const VectorXd& qvar_value = prog.GetSolution(qvar);

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -469,8 +469,8 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
       if (map_base_to_exponent.size() == 1) {
         const pair<Expression, Expression>& p = *map_base_to_exponent.begin();
         if (!is_variable(p.first) || !is_one(p.second)) {
-          throw SymbolicError(
-              e_i, "non-linear but called with AddLinearConstraint");
+          throw SymbolicError(e_i,
+                              "non-linear but called with AddLinearConstraint");
         } else {
           const Variable& var_i = get_variable(p.first);
           if (v.size() == 1) {
@@ -574,7 +574,7 @@ void MathematicalProgram::AddConstraint(
 Binding<LinearEqualityConstraint>
 MathematicalProgram::AddLinearEqualityConstraint(const Expression& e,
                                                  double b) {
-  return AddLinearEqualityConstraint(drake::Vector1<Expression>(e),
+  return AddLinearEqualityConstraint(drake::Vector1<symbolic::Expression>(e),
                                      drake::Vector1d(b));
 }
 

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -662,14 +662,6 @@ class MathematicalProgram {
   }
 
   /**
-   * Adds a cost to the problem which covers all decision
-   * variables created at the time the cost was added.
-   */
-  void AddCost(std::shared_ptr<Constraint> obj) {
-    AddCost(obj, decision_variables_);
-  }
-
-  /**
    * Convert an input of type @tparam F to a ConstraintImpl object.
    * @tparam F This class should have functions numInputs(), numOutputs and
    * eval(x, y). Check drake::solvrs::detail::FunctionTraits for more details.
@@ -712,20 +704,6 @@ class MathematicalProgram {
     return c;
   }
 
-  /**
-   * Adds a cost to the optimization program on all decision variables.
-   * @tparam F it should define functions numInputs, numOutputs and eval. Check
-   * drake::solvers::detail::FunctionTraits for more detail.
-   */
-  template <typename F>
-  typename std::enable_if<
-      !std::is_convertible<F, std::shared_ptr<Constraint>>::value &&
-          !std::is_convertible<F, Binding<Constraint>>::value,
-      std::shared_ptr<Constraint>>::type
-  AddCost(F&& f) {
-    return AddCost(std::forward<F>(f), decision_variables_);
-  }
-
   // libstdc++ 4.9 evaluates
   // `std::is_convertible<std::unique_ptr<Unrelated>,
   // std::shared_ptr<Constraint>>::value`
@@ -754,20 +732,6 @@ class MathematicalProgram {
         std::forward<std::unique_ptr<F>>(f));
     AddCost(c, vars);
     return c;
-  }
-
-  /**
-   * Adds a cost to the optimization program on all decision variables.
-   * @tparam F it should define functions numInputs, numOutputs and eval. Check
-   * drake::solvers::detail::FunctionTraits for more detail.
-   */
-  template <typename F>
-  typename std::enable_if<
-      (!std::is_convertible<F, std::shared_ptr<Constraint>>::value) &&
-          (!std::is_convertible<F, Binding<Constraint>>::value),
-      std::shared_ptr<Constraint>>::type
-  AddCost(std::unique_ptr<F>&& f) {
-    return AddCost(std::forward<std::unique_ptr<F>>(f), decision_variables_);
   }
 
   /**
@@ -825,17 +789,6 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
-   * Adds a linear cost term of the form c'*x.
-   * Applied to all decision variables existing at the time when
-   * the cost is added, and pushes onto
-   * the linear cost data structure.
-   */
-  std::shared_ptr<LinearConstraint> AddLinearCost(
-      const Eigen::Ref<const Eigen::VectorXd>& c) {
-    return AddLinearCost(c, decision_variables_);
-  }
-
-  /**
    * Adds a cost term of the form 0.5*x'*Q*x + b'x.
    * Applied to subset of the variables and pushes onto
    * the quadratic cost data structure.
@@ -880,16 +833,6 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
-   * Adds a cost term of the form (x-x_desired)'*Q*(x-x_desired).
-   * Applied to all (currently existing) variables.
-   */
-  std::shared_ptr<QuadraticConstraint> AddQuadraticErrorCost(
-      const Eigen::Ref<const Eigen::MatrixXd>& Q,
-      const Eigen::Ref<const Eigen::VectorXd>& x_desired) {
-    return AddQuadraticErrorCost(Q, x_desired, decision_variables_);
-  }
-
-  /**
    * Adds a cost term of the form | Ax - b |^2.
    */
   std::shared_ptr<QuadraticConstraint> AddL2NormCost(
@@ -927,25 +870,6 @@ class MathematicalProgram {
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& b,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
-
-  /**
-   * Adds a cost term of the form 0.5*x'*Q*x + b'x.
-   * Applies to all (currently existing) variables.
-   */
-  std::shared_ptr<QuadraticConstraint> AddQuadraticCost(
-      const Eigen::Ref<const Eigen::MatrixXd>& Q,
-      const Eigen::Ref<const Eigen::VectorXd>& b) {
-    return AddQuadraticCost(Q, b, decision_variables_);
-  }
-
-  /**
-   * Adds a constraint to the problem which covers all decision.
-   * variables created at the time the constraint was added.
-   */
-  template <typename ConstraintT>
-  void AddConstraint(std::shared_ptr<ConstraintT> constraint) {
-    AddConstraint(constraint, decision_variables_);
-  }
 
   /**
    * Adds a generic constraint to the program.  This should
@@ -1020,17 +944,6 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
-   * Adds linear constraints to the program for all (currently existing)
-   * variables.
-   */
-  std::shared_ptr<LinearConstraint> AddLinearConstraint(
-      const Eigen::Ref<const Eigen::MatrixXd>& A,
-      const Eigen::Ref<const Eigen::VectorXd>& lb,
-      const Eigen::Ref<const Eigen::VectorXd>& ub) {
-    return AddLinearConstraint(A, lb, ub, decision_variables_);
-  }
-
-  /**
    * Adds one row of linear constraint referencing potentially a
    * subset of the decision variables (defined in the vars parameter).
    * lb <= a*vars <= ub
@@ -1061,21 +974,6 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars) {
     return AddLinearConstraint(a, drake::Vector1d(lb), drake::Vector1d(ub),
                                vars);
-  }
-
-  /**
-   * Adds one row of linear constraint on all variables.
-   * lb <= a*vars <= ub
-   * @param a A row vector.
-   * @param lb A scalar, the lower bound.
-   * @param ub A scalar, the upper bound
-   */
-  template <typename DerivedA>
-  std::shared_ptr<LinearConstraint> AddLinearConstraint(
-      const Eigen::MatrixBase<DerivedA>& a, double lb, double ub) {
-    DRAKE_ASSERT(a.rows() == 1);
-    return AddLinearConstraint(a, drake::Vector1d(lb), drake::Vector1d(ub),
-                               decision_variables_);
   }
 
   /**
@@ -1207,21 +1105,6 @@ class MathematicalProgram {
       const Eigen::Ref<const Eigen::VectorXd>& beq,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
-  /** AddLinearEqualityConstraint
-   *
-   * Adds linear equality constraints to the program for all
-   * (currently existing) variables.
-   */
-  template <typename DerivedA, typename DerivedB>
-  typename std::enable_if<
-      std::is_same<typename DerivedA::Scalar, double>::value &&
-          std::is_same<typename DerivedB::Scalar, double>::value,
-      std::shared_ptr<LinearEqualityConstraint>>::type
-  AddLinearEqualityConstraint(const Eigen::MatrixBase<DerivedA>& Aeq,
-                              const Eigen::MatrixBase<DerivedB>& beq) {
-    return AddLinearEqualityConstraint(Aeq, beq, decision_variables_);
-  }
-
   /**
    * Adds one row of linear equality constraint referencing potentially a subset
    * of decision variables.
@@ -1253,21 +1136,6 @@ class MathematicalProgram {
       const Eigen::Ref<const Eigen::RowVectorXd>& a, double beq,
       const Eigen::Ref<const VectorXDecisionVariable>& vars) {
     return AddLinearEqualityConstraint(a, drake::Vector1d(beq), vars);
-  }
-
-  /**
-   * Adds one row of linear equality constraint referencing all
-   * decision variables.
-   * @f[
-   * ax = beq
-   * @f]
-   * @param a A row vector.
-   * @param beq A scalar.
-   */
-  std::shared_ptr<LinearEqualityConstraint> AddLinearEqualityConstraint(
-      const Eigen::Ref<const Eigen::RowVectorXd>& a, double beq) {
-    return AddLinearEqualityConstraint(a, drake::Vector1d(beq),
-                                       decision_variables_);
   }
 
   /**
@@ -1333,17 +1201,6 @@ class MathematicalProgram {
       const Eigen::Ref<const Eigen::VectorXd>& lb,
       const Eigen::Ref<const Eigen::VectorXd>& ub,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
-
-  /** AddBoundingBoxConstraint
-   *
-   * Adds bounding box constraints to the program for all
-   * (currently existing) variables.
-   */
-  std::shared_ptr<BoundingBoxConstraint> AddBoundingBoxConstraint(
-      const Eigen::Ref<const Eigen::VectorXd>& lb,
-      const Eigen::Ref<const Eigen::VectorXd>& ub) {
-    return AddBoundingBoxConstraint(lb, ub, decision_variables_);
-  }
 
   /**
    * Adds bounds for a single variable.
@@ -1513,27 +1370,6 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
-   * Adds Lorentz cone constraint to the program for all
-   * (currently existing) variables.
-   * The linear expression @f$ z=Ax+b @f$ is in the Lorentz cone.
-   * A vector \f$ z \in\mathbb{R}^n \f$ is in the Lorentz cone, if
-   * <!--
-   * z(0) >= sqrt{z(1)² + ... + z(n-1)²}
-   * -->
-   * @f[
-   * z_0 \ge \sqrt{z_1^2 + ... + z_{n-1}^2}
-   * @f]
-   * @param A A @f$\mathbb{R}^{n \times m}@f$ matrix.
-   * @param b A @f$ \mathbb{R}^{n} @f$ vector.
-   * @return The newly added Lorentz cone constraint.
-   */
-  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
-      const Eigen::Ref<const Eigen::MatrixXd>& A,
-      const Eigen::Ref<const Eigen::VectorXd>& b) {
-    return AddLorentzConeConstraint(A, b, decision_variables_);
-  }
-
-  /**
    * Imposes that a vector @f$ x\in\mathbb{R}^m @f$ lies in Lorentz cone. Namely
    * @f[
    * x_0 \ge \sqrt{x_1^2 + .. + x_{m-1}^2}
@@ -1669,30 +1505,6 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
-   * Adds a rotated Lorentz constraint to the program for all
-   * (currently existing) variables, the linear expression @f$ z=Ax+b @f$ is in
-   * rotated Lorentz cone.
-   * A vector \f$ z \in\mathbb{R}^n \f$ is in the rotated Lorentz cone, if
-   * <!--
-   * z(0)*z(1) >= z(2)^2 + ... + z(n-1)^2
-   * -->
-   * @f[
-   * z_0z_1 \ge z_2^2 + ... + z_{n-1}^2
-   * @f]
-   * where @f$ A\in\mathbb{R}^{n\times m}, b\in\mathbb{R}^n@f$ are given
-   * matrices.
-   * @param A A matrix whose number of columns equals to the size of the
-   * decision variables.
-   * @param b A vector whose number of rows equals to the size fo the decision
-   * variables.
-   */
-  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
-      const Eigen::Ref<const Eigen::MatrixXd>& A,
-      const Eigen::Ref<const Eigen::VectorXd>& b) {
-    return AddRotatedLorentzConeConstraint(A, b, decision_variables_);
-  }
-
-  /**
    * Impose that a vector @f$ x\in\mathbb{R}^m @f$ is in rotated Lorentz cone.
    * Namely
    * @f[
@@ -1780,17 +1592,6 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
-   * Adds a linear complementarity constraint to the program for all
-   * (currently existing) variables.
-   */
-  std::shared_ptr<LinearComplementarityConstraint>
-  AddLinearComplementarityConstraint(
-      const Eigen::Ref<const Eigen::MatrixXd>& M,
-      const Eigen::Ref<const Eigen::VectorXd>& q) {
-    return AddLinearComplementarityConstraint(M, q, decision_variables_);
-  }
-
-  /**
    * Adds a polynomial constraint to the program referencing a subset
    * of the decision variables (defined in the vars parameter).
    */
@@ -1812,17 +1613,6 @@ class MathematicalProgram {
       const std::vector<Polynomiald::VarType>& poly_vars,
       const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
-  /**
-   * Adds a polynomial constraint to the program referencing all of the
-   * decision variables.
-   */
-  std::shared_ptr<Constraint> AddPolynomialConstraint(
-      const VectorXPoly& polynomials,
-      const std::vector<Polynomiald::VarType>& poly_vars,
-      const Eigen::VectorXd& lb, const Eigen::VectorXd& ub) {
-    return AddPolynomialConstraint(polynomials, poly_vars, lb, ub,
-                                   decision_variables_);
-  }
 
   /**
    * Adds a positive semidefinite constraint on a symmetric matrix.

--- a/drake/solvers/system_identification.cc
+++ b/drake/solvers/system_identification.cc
@@ -299,7 +299,7 @@ SystemIdentification<T>::EstimateParameters(
     }
     problem.AddPolynomialConstraint(constraint_polys, problem_vartypes,
                                     Eigen::VectorXd::Zero(polys.rows()),
-                                    Eigen::VectorXd::Zero(polys.rows()));
+                                    Eigen::VectorXd::Zero(polys.rows()), {parameter_variables, error_variables});
   }
 
   // Create a cost function that is least-squares on the error terms.

--- a/drake/solvers/system_identification.cc
+++ b/drake/solvers/system_identification.cc
@@ -299,7 +299,8 @@ SystemIdentification<T>::EstimateParameters(
     }
     problem.AddPolynomialConstraint(constraint_polys, problem_vartypes,
                                     Eigen::VectorXd::Zero(polys.rows()),
-                                    Eigen::VectorXd::Zero(polys.rows()), {parameter_variables, error_variables});
+                                    Eigen::VectorXd::Zero(polys.rows()),
+                                    {parameter_variables, error_variables});
   }
 
   // Create a cost function that is least-squares on the error terms.

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -55,7 +55,7 @@ void TestLinearProgramFeasibility(
   A << 1, 2, 3, 0, 1, -2, 0, 0, 0;
   Eigen::Vector3d b_lb(0, -std::numeric_limits<double>::infinity(), -1);
   Eigen::Vector3d b_ub(10, 3, 0);
-  prog.AddLinearConstraint(A, b_lb, b_ub);
+  prog.AddLinearConstraint(A, b_lb, b_ub, x);
   prog.AddBoundingBoxConstraint(1.0, std::numeric_limits<double>::infinity(),
                                 x(1));
 
@@ -88,13 +88,13 @@ void TestLinearProgram0(const MathematicalProgramSolverInterface& solver) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
 
-  prog.AddLinearCost(Eigen::Vector2d(2.0, 1.0));
+  prog.AddLinearCost(Eigen::Vector2d(2.0, 1.0), x);
   Eigen::Matrix<double, 3, 2> A;
   A << -1, 1, 1, 1, 1, -2;
   Eigen::Vector3d b_lb(-std::numeric_limits<double>::infinity(), 2.0,
                        -std::numeric_limits<double>::infinity());
   Eigen::Vector3d b_ub(1.0, std::numeric_limits<double>::infinity(), 4.0);
-  prog.AddLinearConstraint(A, b_lb, b_ub);
+  prog.AddLinearConstraint(A, b_lb, b_ub, x);
   prog.AddBoundingBoxConstraint(
       Eigen::Vector2d(0.0, 2.0),
       Eigen::Vector2d(std::numeric_limits<double>::infinity(),
@@ -121,8 +121,8 @@ void TestLinearProgram0(const MathematicalProgramSolverInterface& solver) {
 void TestLinearProgram1(const MathematicalProgramSolverInterface& solver) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
-  prog.AddLinearCost(Eigen::Vector2d(1.0, -2.0));
-  prog.AddBoundingBoxConstraint(Eigen::Vector2d(0, -1), Eigen::Vector2d(2, 4));
+  prog.AddLinearCost(Eigen::Vector2d(1.0, -2.0), x);
+  prog.AddBoundingBoxConstraint(Eigen::Vector2d(0, -1), Eigen::Vector2d(2, 4), x);
 
   if (solver.SolverName() == "SNOPT") {
     prog.SetInitialGuessForAllVariables(Eigen::Vector2d::Zero());
@@ -227,7 +227,7 @@ void TestQuadraticProgram0(const MathematicalProgramSolverInterface& solver) {
   prog.AddBoundingBoxConstraint(-1, std::numeric_limits<double>::infinity(),
                                 x(1));
 
-  prog.AddLinearEqualityConstraint(Eigen::RowVector2d(1, 1), 1);
+  prog.AddLinearEqualityConstraint(Eigen::RowVector2d(1, 1), 1, x);
 
   if (solver.SolverName() == "SNOPT") {
     prog.SetInitialGuessForAllVariables(Eigen::Vector2d::Zero());
@@ -260,11 +260,11 @@ void TestQuadraticProgram1(const MathematicalProgramSolverInterface& solver) {
   Q(2, 1) = 1;
   Eigen::VectorXd b(3);
   b << 2.0, 0.0, 0.0;
-  prog.AddQuadraticCost(Q, b);
+  prog.AddQuadraticCost(Q, b, x);
 
   prog.AddBoundingBoxConstraint(
       Eigen::MatrixXd::Zero(3, 1),
-      Eigen::MatrixXd::Constant(3, 1, std::numeric_limits<double>::infinity()));
+      Eigen::MatrixXd::Constant(3, 1, std::numeric_limits<double>::infinity()), x);
 
   // This test handles the case that in one LinearConstraint,
   // some rows have active upper bounds;
@@ -277,9 +277,9 @@ void TestQuadraticProgram1(const MathematicalProgramSolverInterface& solver) {
                        -std::numeric_limits<double>::infinity());
   Eigen::Vector4d b_ub(std::numeric_limits<double>::infinity(), -1, 100,
                        std::numeric_limits<double>::infinity());
-  prog.AddLinearConstraint(A1, b_lb, b_ub);
+  prog.AddLinearConstraint(A1, b_lb, b_ub, x);
   // This test also handles linear equality constraint
-  prog.AddLinearEqualityConstraint(Eigen::RowVector3d(3, 1, 3), 3);
+  prog.AddLinearEqualityConstraint(Eigen::RowVector3d(3, 1, 3), 3, x);
 
   if (solver.SolverName() == "SNOPT") {
     prog.SetInitialGuessForAllVariables(Eigen::Vector3d::Zero());
@@ -314,7 +314,7 @@ void TestQuadraticProgram2(const MathematicalProgramSolverInterface& solver) {
 
   b << 3.2, 1.3, 5.6, 9.0, 1.2;
 
-  prog.AddQuadraticCost(Q, b);
+  prog.AddQuadraticCost(Q, b, x);
 
   if (solver.SolverName() == "SNOPT") {
     prog.SetInitialGuessForAllVariables(Eigen::Matrix<double, 5, 1>::Zero());
@@ -400,7 +400,7 @@ void TestQuadraticProgram4(const MathematicalProgramSolverInterface& solver) {
   Eigen::Matrix3d Q = Eigen::Matrix3d::Identity();
   Q(2, 2) = 2.0;
   Eigen::Vector3d b = Eigen::Vector3d::Zero();
-  prog.AddQuadraticCost(Q, b);
+  prog.AddQuadraticCost(Q, b, x);
   prog.AddLinearEqualityConstraint(Eigen::RowVector2d(1, 1),
                                    Vector1d::Constant(1), x.head<2>());
   prog.AddLinearEqualityConstraint(Eigen::RowVector2d(1, 2),
@@ -427,13 +427,13 @@ void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
   Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
   Eigen::Vector2d x_desired;
   x_desired << 1.0, 0.0;
-  auto objective = prog.AddQuadraticErrorCost(Q, x_desired);
+  auto objective = prog.AddQuadraticErrorCost(Q, x_desired, x);
 
   Eigen::Matrix2d A;
   A << 1.0, 1.0, -1.0, 1.0;
   Eigen::Vector2d ub = Eigen::Vector2d::Constant(1.0);
   Eigen::Vector2d lb = Eigen::Vector2d::Constant(-1.0);
-  auto constraint = prog.AddLinearConstraint(A, lb, ub);
+  auto constraint = prog.AddLinearConstraint(A, lb, ub, x);
   Eigen::Vector2d x_expected;
 
   const int N = 40;  // number of points to test around the circle
@@ -1229,7 +1229,14 @@ MatrixDecisionVariable<x_dim, x_dim> AddLyapunovCondition(
                                   lin_eq_triplets.end());
 
   Eigen::MatrixXd lin_eq_A(lin_eq_A_sparse);
-  prog->AddLinearEqualityConstraint(lin_eq_A, lin_eq_bnd);
+  VectorDecisionVariable<x_dim * (x_dim + 1) / 2> lower_triangular_P{};
+  int P_count = 0;
+  for (int j = 0; j < x_dim; ++j) {
+    for (int i = j; i < x_dim; ++i) {
+      lower_triangular_P(P_count++) = P(i, j);
+    }
+  }
+  prog->AddLinearEqualityConstraint(lin_eq_A, lin_eq_bnd, lower_triangular_P);
   return Q;
 }
 }  // namespace

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -122,7 +122,8 @@ void TestLinearProgram1(const MathematicalProgramSolverInterface& solver) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
   prog.AddLinearCost(Eigen::Vector2d(1.0, -2.0), x);
-  prog.AddBoundingBoxConstraint(Eigen::Vector2d(0, -1), Eigen::Vector2d(2, 4), x);
+  prog.AddBoundingBoxConstraint(Eigen::Vector2d(0, -1), Eigen::Vector2d(2, 4),
+                                x);
 
   if (solver.SolverName() == "SNOPT") {
     prog.SetInitialGuessForAllVariables(Eigen::Vector2d::Zero());
@@ -264,7 +265,8 @@ void TestQuadraticProgram1(const MathematicalProgramSolverInterface& solver) {
 
   prog.AddBoundingBoxConstraint(
       Eigen::MatrixXd::Zero(3, 1),
-      Eigen::MatrixXd::Constant(3, 1, std::numeric_limits<double>::infinity()), x);
+      Eigen::MatrixXd::Constant(3, 1, std::numeric_limits<double>::infinity()),
+      x);
 
   // This test handles the case that in one LinearConstraint,
   // some rows have active upper bounds;
@@ -1208,14 +1210,17 @@ MatrixDecisionVariable<x_dim, x_dim> AddLyapunovCondition(
   // M = A' * P + P * A + Q.
   Eigen::Matrix<symbolic::Expression, x_dim, x_dim> M;
   M = A.transpose() * P + P * A + Q;
-  Eigen::Matrix<symbolic::Expression, x_dim * (x_dim + 1) / 2, 1> M_lower_triangular{};
+  Eigen::Matrix<symbolic::Expression, x_dim*(x_dim + 1) / 2, 1>
+      M_lower_triangular{};
   int M_count = 0;
   for (int j = 0; j < x_dim; ++j) {
     for (int i = j; i < x_dim; ++i) {
       M_lower_triangular(M_count++) = M(i, j);
     }
   }
-  prog->AddLinearEqualityConstraint(M_lower_triangular, Eigen::Matrix<double, x_dim * (x_dim + 1)/2, 1>::Zero());
+  prog->AddLinearEqualityConstraint(
+      M_lower_triangular,
+      Eigen::Matrix<double, x_dim*(x_dim + 1) / 2, 1>::Zero());
   return Q;
 }
 }  // namespace

--- a/drake/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/drake/solvers/test/equality_constrained_qp_solver_test.cc
@@ -30,7 +30,7 @@ GTEST_TEST(testMathematicalProgram, testUnconstrainedQPDispatch) {
   Matrix2d Q = Matrix2d::Identity();
   Vector2d c(-1, -1);
 
-  prog.AddQuadraticCost(Q, c);
+  prog.AddQuadraticCost(Q, c, x);
 
   prog.SetInitialGuessForAllVariables(Eigen::Vector2d::Zero());
   prog.Solve();
@@ -85,12 +85,12 @@ GTEST_TEST(testMathematicalProgram, testLinearlyConstrainedQPDispatch) {
   VectorXd c(2);
   c << -1.0, -1.0;
 
-  prog.AddQuadraticCost(Q, c);
+  prog.AddQuadraticCost(Q, c, x);
 
   VectorXd constraint1(2);
   // x1 + x2 = 1
   constraint1 << 1, 1;
-  prog.AddLinearEqualityConstraint(constraint1.transpose(), 1.0);
+  prog.AddLinearEqualityConstraint(constraint1.transpose(), 1.0, x);
 
   prog.SetInitialGuessForAllVariables(Eigen::Vector2d::Zero());
   prog.Solve();

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -66,19 +66,19 @@ struct Unique {
 
 GTEST_TEST(testMathematicalProgram, testAddFunction) {
   MathematicalProgram prog;
-  prog.NewContinuousVariables<1>();
+  auto x = prog.NewContinuousVariables<1>();
 
   Movable movable;
-  prog.AddCost(std::move(movable));
-  prog.AddCost(Movable());
+  prog.AddCost(std::move(movable), x);
+  prog.AddCost(Movable(), x);
 
   Copyable copyable;
-  prog.AddCost(copyable);
+  prog.AddCost(copyable, x);
 
   Unique unique;
-  prog.AddCost(std::cref(unique));
-  prog.AddCost(std::make_shared<Unique>());
-  prog.AddCost(std::unique_ptr<Unique>(new Unique));
+  prog.AddCost(std::cref(unique), x);
+  prog.AddCost(std::make_shared<Unique>(), x);
+  prog.AddCost(std::unique_ptr<Unique>(new Unique), x);
 }
 
 GTEST_TEST(testMathematicalProgram, BoundingBoxTest2) {
@@ -107,7 +107,7 @@ GTEST_TEST(testMathematicalProgram, BoundingBoxTest2) {
   auto constraint4 = prog.AddBoundingBoxConstraint(0, 1, x3);
   auto constraint5 = prog.AddBoundingBoxConstraint(0, 1, x4);
   auto constraint6 = prog.AddBoundingBoxConstraint(Eigen::Vector4d::Zero(),
-                                                   Eigen::Vector4d::Ones());
+                                                   Eigen::Vector4d::Ones(), x3);
 
   // Checks that the bound variables are correct.
   for (const auto& binding : prog.bounding_box_constraints()) {

--- a/drake/solvers/test/mixed_integer_optimization_test.cc
+++ b/drake/solvers/test/mixed_integer_optimization_test.cc
@@ -31,9 +31,9 @@ GTEST_TEST(TestMixedIntegerOptimization, TestMixedIntegerLinearProgram1) {
     MathematicalProgram prog;
     auto x = prog.NewBinaryVariables(3, "x");
     Eigen::Vector3d c(-1, -1, -2);
-    prog.AddLinearCost(c);
+    prog.AddLinearCost(c, x);
     Eigen::RowVector3d a1(1, 2, 3);
-    prog.AddLinearConstraint(a1, -std::numeric_limits<double>::infinity(), 4);
+    prog.AddLinearConstraint(a1, -std::numeric_limits<double>::infinity(), 4, x);
     Eigen::RowVector2d a2(1, 1);
     prog.AddLinearConstraint(a2, 1, std::numeric_limits<double>::infinity(),
                              x.head<2>());
@@ -60,9 +60,9 @@ GTEST_TEST(TestMixedIntegerOptimization, TestMixedIntegerLinearProgram2) {
     MathematicalProgram prog;
     auto x = prog.NewBinaryVariables<3>("x");
     Eigen::Vector3d c(2, 1, -2);
-    prog.AddLinearCost(c);
+    prog.AddLinearCost(c, x);
     Eigen::RowVector3d a1(0.7, 0.5, 1);
-    prog.AddLinearConstraint(a1, 1.8, std::numeric_limits<double>::infinity());
+    prog.AddLinearConstraint(a1, 1.8, std::numeric_limits<double>::infinity(), x);
 
     RunSolver(&prog, *solver);
 

--- a/drake/solvers/test/mixed_integer_optimization_test.cc
+++ b/drake/solvers/test/mixed_integer_optimization_test.cc
@@ -33,7 +33,8 @@ GTEST_TEST(TestMixedIntegerOptimization, TestMixedIntegerLinearProgram1) {
     Eigen::Vector3d c(-1, -1, -2);
     prog.AddLinearCost(c, x);
     Eigen::RowVector3d a1(1, 2, 3);
-    prog.AddLinearConstraint(a1, -std::numeric_limits<double>::infinity(), 4, x);
+    prog.AddLinearConstraint(a1, -std::numeric_limits<double>::infinity(), 4,
+                             x);
     Eigen::RowVector2d a2(1, 1);
     prog.AddLinearConstraint(a2, 1, std::numeric_limits<double>::infinity(),
                              x.head<2>());
@@ -62,7 +63,8 @@ GTEST_TEST(TestMixedIntegerOptimization, TestMixedIntegerLinearProgram2) {
     Eigen::Vector3d c(2, 1, -2);
     prog.AddLinearCost(c, x);
     Eigen::RowVector3d a1(0.7, 0.5, 1);
-    prog.AddLinearConstraint(a1, 1.8, std::numeric_limits<double>::infinity(), x);
+    prog.AddLinearConstraint(a1, 1.8, std::numeric_limits<double>::infinity(),
+                             x);
 
     RunSolver(&prog, *solver);
 

--- a/drake/solvers/test/nonlinear_program_test.cc
+++ b/drake/solvers/test/nonlinear_program_test.cc
@@ -111,7 +111,7 @@ GTEST_TEST(testNonlinearProgram, trivialLinearEquality) {
 
   // Use a non-square matrix to catch row/column mistakes in the solvers.
   prog.AddLinearEqualityConstraint(Eigen::RowVector2d(0, 1),
-                                   Vector1d::Constant(1));
+                                   Vector1d::Constant(1), vars);
   prog.SetInitialGuess(vars, Vector2d(2, 2));
   RunNonlinearProgram(&prog, [&]() {
     const auto& vars_value = prog.GetSolution(vars);
@@ -133,7 +133,7 @@ GTEST_TEST(testNonlinearProgram, QuadraticCost) {
   Q(2, 3) = -0.02;
 
   Vector4d b(1.0, -0.5, 1.3, 2.5);
-  prog.AddQuadraticCost(Q, b);
+  prog.AddQuadraticCost(Q, b, x);
 
   Matrix4d Q_transpose = Q;
   Q_transpose.transposeInPlace();
@@ -220,7 +220,7 @@ class SixHumpCamelCost {
 GTEST_TEST(testNonlinearProgram, sixHumpCamel) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables(2);
-  auto cost = prog.AddCost(SixHumpCamelCost());
+  auto cost = prog.AddCost(SixHumpCamelCost(), x);
 
   prog.SetInitialGuess(x, Vector2d::Random());
   RunNonlinearProgram(&prog, [&]() {
@@ -270,7 +270,7 @@ GTEST_TEST(testNonlinearProgram, linearPolynomialConstraint) {
   std::shared_ptr<Constraint> resulting_constraint =
       problem.AddPolynomialConstraint(VectorXPoly::Constant(1, x), var_mapping,
                                       Vector1d::Constant(2),
-                                      Vector1d::Constant(2));
+                                      Vector1d::Constant(2), x_var);
   // Check that the resulting constraint is a LinearConstraint.
   EXPECT_NE(dynamic_cast<LinearConstraint*>(resulting_constraint.get()),
             nullptr);
@@ -298,7 +298,7 @@ GTEST_TEST(testNonlinearProgram, polynomialConstraint) {
         x.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, x), var_mapping,
                                     Vector1d::Constant(2),
-                                    Vector1d::Constant(2));
+                                    Vector1d::Constant(2), x_var);
     problem.SetInitialGuessForAllVariables(drake::Vector1d::Zero());
     RunNonlinearProgram(&problem, [&]() {
       EXPECT_NEAR(problem.GetSolution(x_var(0)), 2, kEpsilon);
@@ -317,7 +317,7 @@ GTEST_TEST(testNonlinearProgram, polynomialConstraint) {
         x.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, poly), var_mapping,
                                     Eigen::VectorXd::Zero(1),
-                                    Eigen::VectorXd::Zero(1));
+                                    Eigen::VectorXd::Zero(1), x_var);
     problem.SetInitialGuessForAllVariables(drake::Vector1d::Zero());
     RunNonlinearProgram(&problem, [&]() {
       EXPECT_NEAR(problem.GetSolution(x_var(0)), 1, 0.2);
@@ -337,7 +337,7 @@ GTEST_TEST(testNonlinearProgram, polynomialConstraint) {
         x.GetSimpleVariable(), y.GetSimpleVariable()};
     problem.AddPolynomialConstraint(VectorXPoly::Constant(1, poly), var_mapping,
                                     Eigen::VectorXd::Zero(1),
-                                    Eigen::VectorXd::Zero(1));
+                                    Eigen::VectorXd::Zero(1), xy_var);
     problem.SetInitialGuessForAllVariables(Eigen::Vector2d::Zero());
     RunNonlinearProgram(&problem, [&]() {
       EXPECT_NEAR(problem.GetSolution(xy_var(0)), 1, 0.2);
@@ -364,7 +364,7 @@ GTEST_TEST(testNonlinearProgram, polynomialConstraint) {
     polynomials_vec << poly, x;
     problem.AddPolynomialConstraint(polynomials_vec, var_mapping,
                                     Eigen::VectorXd::Constant(2, -kInf),
-                                    Eigen::VectorXd::Zero(2));
+                                    Eigen::VectorXd::Zero(2), x_var);
     RunNonlinearProgram(&problem, [&]() {
       EXPECT_NEAR(problem.GetSolution(x_var(0)), -0.7, 0.2);
       EXPECT_LE(poly.EvaluateUnivariate(problem.GetSolution(x_var(0))),

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -415,12 +415,12 @@ MinDistanceFromPlaneToOrigin::MinDistanceFromPlaneToOrigin(
       prog_rotated_lorentz_->NewContinuousVariables(kXdim, "x");
 
   switch (cost_form) {
-    case kNonSymbolicCost : {
+    case kNonSymbolicCost: {
       prog_lorentz_->AddLinearCost(Vector1d(1), t_lorentz_);
       prog_rotated_lorentz_->AddLinearCost(Vector1d(1), t_rotated_lorentz_);
       break;
     }
-    case kSymbolicCost : {
+    case kSymbolicCost: {
       prog_lorentz_->AddLinearCost(+t_lorentz_(0));
       prog_rotated_lorentz_->AddLinearCost(+t_rotated_lorentz_(0));
       break;

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -83,7 +83,7 @@ NonConvexQPproblem1::NonConvexQPproblem1(CostForm cost_form,
   prog_->AddBoundingBoxConstraint(0, 1, x_);
   switch (cost_form) {
     case kGenericCost: {
-      prog_->AddCost(TestProblem1Cost());
+      prog_->AddCost(TestProblem1Cost(), x_);
       break;
     }
     case kQuadraticCost: {
@@ -120,7 +120,7 @@ bool NonConvexQPproblem1::CheckSolution() const {
 void NonConvexQPproblem1::AddConstraint() {
   Eigen::Matrix<double, 1, 5> a;
   a << 20, 12, 11, 7, 4;
-  prog_->AddLinearConstraint(a, -numeric_limits<double>::infinity(), 40);
+  prog_->AddLinearConstraint(a, -numeric_limits<double>::infinity(), 40, x_);
 }
 
 void NonConvexQPproblem1::AddSymbolicConstraint() {
@@ -135,7 +135,7 @@ void NonConvexQPproblem1::AddQuadraticCost() {
       -100 * Eigen::Matrix<double, 5, 5>::Identity();
   Eigen::Matrix<double, 5, 1> c;
   c << 42, 44, 45, 47, 47.5;
-  prog_->AddQuadraticCost(Q, c);
+  prog_->AddQuadraticCost(Q, c, x_);
 }
 
 NonConvexQPproblem2::NonConvexQPproblem2(CostForm cost_form,
@@ -148,7 +148,7 @@ NonConvexQPproblem2::NonConvexQPproblem2(CostForm cost_form,
 
   switch (cost_form) {
     case kGenericCost: {
-      prog_->AddCost(TestProblem2Cost());
+      prog_->AddCost(TestProblem2Cost(), x_);
       break;
     }
     case kQuadraticCost: {
@@ -190,7 +190,7 @@ void NonConvexQPproblem2::AddQuadraticCost() {
   Eigen::Matrix<double, 6, 1> c{};
   c << -10.5, -7.5, -3.5, -2.5, -1.5, -10.0;
 
-  prog_->AddQuadraticCost(Q, c);
+  prog_->AddQuadraticCost(Q, c, x_);
 }
 
 void NonConvexQPproblem2::AddNonSymbolicConstraint() {
@@ -198,8 +198,8 @@ void NonConvexQPproblem2::AddNonSymbolicConstraint() {
   Eigen::Matrix<double, 1, 6> a2{};
   a1 << 6, 3, 3, 2, 1, 0;
   a2 << 10, 0, 10, 0, 0, 1;
-  prog_->AddLinearConstraint(a1, -numeric_limits<double>::infinity(), 6.5);
-  prog_->AddLinearConstraint(a2, -numeric_limits<double>::infinity(), 20);
+  prog_->AddLinearConstraint(a1, -numeric_limits<double>::infinity(), 6.5, x_);
+  prog_->AddLinearConstraint(a2, -numeric_limits<double>::infinity(), 20, x_);
 }
 
 void NonConvexQPproblem2::AddSymbolicConstraint() {
@@ -221,13 +221,13 @@ LowerBoundedProblem::LowerBoundedProblem(ConstraintForm cnstr_form)
   lb << 0, 0, 1, 0, 1, 0;
   ub << numeric_limits<double>::infinity(), numeric_limits<double>::infinity(),
       5, 6, 5, 10;
-  prog_->AddBoundingBoxConstraint(lb, ub);
+  prog_->AddBoundingBoxConstraint(lb, ub, x_);
 
-  prog_->AddCost(LowerBoundTestCost());
+  prog_->AddCost(LowerBoundTestCost(), x_);
   std::shared_ptr<Constraint> con1(new LowerBoundTestConstraint(2, 3));
-  prog_->AddConstraint(con1);
+  prog_->AddConstraint(con1, x_);
   std::shared_ptr<Constraint> con2(new LowerBoundTestConstraint(4, 5));
-  prog_->AddConstraint(con2);
+  prog_->AddConstraint(con2, x_);
 
   switch (cnstr_form) {
     case kNonSymbolic: {


### PR DESCRIPTION
Resolves #4910 

@RussTedrake you might like the changes in `convex_optimization_test.cc`, when writing linear equality constraint for matrices. Thanks to @soonho-tri 's work on symbolic expression, this part is a lot cleaner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4943)
<!-- Reviewable:end -->
