### PR TITLE
Updated Ubuntu Trusty instructions to install libvtk5.

### DIFF
--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -70,8 +70,8 @@ Other prerequisites may be installed as follows::
     sudo apt-get install --no-install-recommends \
       autoconf automake bison doxygen freeglut3-dev git graphviz \
       libgtk2.0-dev libhtml-form-perl libjpeg-dev libmpfr-dev libpng-dev \
-      libterm-readkey-perl libtool libwww-perl make ninja-build perl \
-      pkg-config python-bs4 python-dev python-gtk2 python-html5lib \
+      libterm-readkey-perl libtool libvtk5-dev libwww-perl make ninja-build \
+      perl pkg-config python-bs4 python-dev python-gtk2 python-html5lib \
       python-numpy python-pip python-sphinx python-yaml unzip valgrind
 
 If you will be building/using Director, some additional prerequisites may be
@@ -80,7 +80,12 @@ installed as follows::
     sudo apt-get update
     sudo apt-get install --no-install-recommends \
       libgl1-mesa-dri libqt4-dev libqt4-opengl-dev libqwt-dev \
-      libvtk-java libvtk5-dev libvtk5-qt4-dev python-lxml python-vtk xvfb
+      libvtk-java libvtk5-qt4-dev python-lxml python-vtk xvfb
+
+Note that the above installs an old version of VTK that is required by Drake. If
+a different version needs to be installed, Drake's build system can be
+configured to use its own version as described
+:ref:`here <faq_cmake_vtk_version_crash>`.
 
 Environment
 -----------


### PR DESCRIPTION
This is necessary now that Drake contains systems that rely on VTK5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4948)
<!-- Reviewable:end -->
