### PR TITLE
Fix "dyld: Symbol not found" errors in OSX+bazel build

### DIFF
--- a/drake/examples/Pendulum/BUILD
+++ b/drake/examples/Pendulum/BUILD
@@ -18,6 +18,7 @@ cc_library(
     name = "pendulum_plant",
     srcs = ["pendulum_plant.cc"],
     hdrs = ["pendulum_plant.h"],
+    linkstatic = 1,
     deps = [
         ":pendulum_state_vector",
         "//drake/systems/framework",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4952)
<!-- Reviewable:end -->
