### PR TITLE
Move Variable/Variables/Environment classes under 'drake' namespace

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -76,6 +76,19 @@ cc_library(
 )
 
 cc_library(
+    name = "environment",
+    srcs = ["environment.cc"],
+    hdrs = [
+        "environment.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":common",
+        ":variable",
+    ],
+)
+
+cc_library(
     name = "extract_double",
     hdrs = ["extract_double.h"],
     linkstatic = 1,
@@ -114,31 +127,54 @@ cc_library(
 cc_library(
     name = "symbolic",
     srcs = [
-        "symbolic_environment.cc",
         "symbolic_expression.cc",
         "symbolic_expression_cell.cc",
         "symbolic_expression_cell.h",
         "symbolic_formula.cc",
         "symbolic_formula_cell.cc",
         "symbolic_formula_cell.h",
-        "symbolic_variable.cc",
-        "symbolic_variables.cc",
     ],
     hdrs = [
         "hash.h",
-        "symbolic_environment.h",
         "symbolic_expression.h",
         "symbolic_formula.h",
-        "symbolic_variable.h",
-        "symbolic_variables.h",
     ],
     linkstatic = 1,
     deps = [
         ":common",
         ":cond",
         ":dummy_value",
+        ":environment",
         ":number_traits",
         ":polynomial",
+        ":variable",
+        ":variables",
+    ],
+)
+
+cc_library(
+    name = "variable",
+    srcs = ["variable.cc"],
+    hdrs = [
+        "hash.h",
+        "variable.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":common",
+    ],
+)
+
+cc_library(
+    name = "variables",
+    srcs = ["variables.cc"],
+    hdrs = [
+        "variables.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":common",
+        ":variable",
     ],
 )
 
@@ -391,7 +427,7 @@ cc_googletest(
 )
 
 cc_googletest(
-    name = "symbolic_environment_test",
+    name = "environment_test",
     deps = [
         ":common",
         ":symbolic",
@@ -423,7 +459,7 @@ cc_googletest(
 )
 
 cc_googletest(
-    name = "symbolic_variable_overloading_test",
+    name = "variable_overloading_test",
     deps = [
         ":common",
         ":symbolic",
@@ -440,7 +476,7 @@ cc_googletest(
 )
 
 cc_googletest(
-    name = "symbolic_variable_test",
+    name = "variable_test",
     deps = [
         ":common",
         ":symbolic",
@@ -448,7 +484,7 @@ cc_googletest(
 )
 
 cc_googletest(
-    name = "symbolic_variables_test",
+    name = "variables_test",
     deps = [
         ":common",
         ":symbolic",

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -14,20 +14,20 @@ set(sources
   drake_assert.cc
   ${drake_path_cc}
   drake_throw.cc
+  environment.cc
   functional_form.cc
   monomial.cc
   nice_type_name.cc
   polynomial.cc
-  symbolic_environment.cc
   symbolic_expression.cc
   symbolic_expression_cell.cc
   symbolic_expression_cell.h
   symbolic_formula.cc
   symbolic_formula_cell.cc
   symbolic_formula_cell.h
-  symbolic_variable.cc
-  symbolic_variables.cc
   text_logging.cc
+  variable.cc
+  variables.cc
   )
 
 # List headers that should be installed with Drake so that they
@@ -48,6 +48,7 @@ set(installed_headers
   eigen_matrix_compare.h
   eigen_stl_types.h
   eigen_types.h
+  environment.h
   extract_double.h
   functional_form.h
   hash.h
@@ -58,14 +59,13 @@ set(installed_headers
   number_traits.h
   polynomial.h
   sorted_vectors_have_intersection.h
-  symbolic_environment.h
   symbolic_expression.h
   symbolic_formula.h
-  symbolic_variable.h
-  symbolic_variables.h
   text_logging.h
   text_logging_gflags.h
   trig_poly.h
+  variable.h
+  variables.h
   )
 
 # List headers that are needed by code here but should not

--- a/drake/common/environment.cc
+++ b/drake/common/environment.cc
@@ -1,4 +1,4 @@
-#include "drake/common/symbolic_environment.h"
+#include "drake/common/environment.h"
 
 #include <cmath>
 #include <initializer_list>
@@ -8,7 +8,6 @@
 #include <string>
 
 namespace drake {
-namespace symbolic {
 
 using std::endl;
 using std::ostream;
@@ -21,8 +20,8 @@ namespace {
 void throw_if_dummy(const Variable& var) {
   if (var.is_dummy()) {
     ostringstream oss;
-    oss << "Dummy symbolic variable (ID = 0) is detected"
-        << "in the initialization of a symbolic environment.";
+    oss << "Dummy variable (ID = 0) is detected"
+        << "in the initialization of an environment.";
     throw runtime_error(oss.str());
   }
 }
@@ -30,7 +29,7 @@ void throw_if_dummy(const Variable& var) {
 void throw_if_nan(const double v) {
   if (std::isnan(v)) {
     ostringstream oss;
-    oss << "NaN is detected in the initialization of a symbolic environment.";
+    oss << "NaN is detected in the initialization of an environment.";
     throw runtime_error(oss.str());
   }
 }
@@ -77,5 +76,4 @@ ostream& operator<<(ostream& os, const Environment& env) {
   }
   return os;
 }
-}  // namespace symbolic
 }  // namespace drake

--- a/drake/common/environment.h
+++ b/drake/common/environment.h
@@ -6,12 +6,10 @@
 #include <unordered_map>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 namespace drake {
-namespace symbolic {
-/** Represents a symbolic form of an environment (mapping from a variable to a
- * value).
+/** Represents an environment (mapping from a variable to a value).
  *
  * This class is used when we evaluate symbolic expressions or formulas which
  * include unquantified (free) variables. Here are examples:
@@ -33,11 +31,11 @@ namespace symbolic {
  *   const bool res = f.Evaluate(env);  // x + y > x - y => 5.0 >= -1.0 => True
  * \endcode
  *
- * Note that it is not allowed to have a dummy variable in a symbolic
- * environment. It throws std::runtime_error for the attempts to create an
- * environment with a dummy variable, to insert a dummy variable to an existing
- * environment, or to take a reference to a value mapped to a dummy
- * variable. See the following examples.
+ * Note that it is not allowed to have a dummy variable in an environment. It
+ * throws std::runtime_error for the attempts to create an environment with a
+ * dummy variable, to insert a dummy variable to an existing environment, or to
+ * take a reference to a value mapped to a dummy variable. See the following
+ * examples.
  *
  * \code{.cpp}
  *   Variable    var_dummy{};           // OK to have a dummy variable
@@ -53,7 +51,7 @@ class Environment {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Environment)
 
-  typedef typename drake::symbolic::Variable key_type;
+  typedef typename drake::Variable key_type;
   typedef double mapped_type;
   typedef
       typename std::unordered_map<key_type, mapped_type, hash_value<key_type>>
@@ -112,5 +110,4 @@ class Environment {
  private:
   map map_;
 };
-}  // namespace symbolic
 }  // namespace drake

--- a/drake/common/monomial.cc
+++ b/drake/common/monomial.cc
@@ -9,8 +9,8 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_expression_cell.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/monomial.h
+++ b/drake/common/monomial.h
@@ -13,8 +13,8 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 
@@ -208,10 +208,10 @@ Expression Monomial(
 
 /** Returns all monomials up to a given degree under the graded reverse
  * lexicographic order. Note that graded reverse lexicographic order uses the
- * total order among symbolic::Variable which is based on a variable's unique
- * ID. For example, for a given variable ordering x > y > z,
- * <tt>MonomialBasis({x, y, z}, 2)</tt> returns a column vector <tt>[x^2, xy,
- * y^2, xz, yz, z^2, x, y, z, 1]</tt>.
+ * total order among Variable which is based on a variable's unique ID. For
+ * example, for a given variable ordering x > y > z, <tt>MonomialBasis({x, y,
+ * z}, 2)</tt> returns a column vector <tt>[x^2, xy, y^2, xz, yz, z^2, x, y, z,
+ * 1]</tt>.
  *
  * \pre{@p vars is a non-empty set.}
  * \pre{@p degree is a non-negative integer.}

--- a/drake/common/symbolic_expression.cc
+++ b/drake/common/symbolic_expression.cc
@@ -9,12 +9,12 @@
 #include <string>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/environment.h"
 #include "drake/common/never_destroyed.h"
-#include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_expression_cell.h"
 #include "drake/common/symbolic_formula.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {
@@ -421,53 +421,6 @@ ostream& operator<<(ostream& os, const Expression& e) {
   return e.ptr_->Display(os);
 }
 
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator+=(Expression& lhs, const Variable& rhs) {
-  return lhs += Expression{rhs};
-}
-Expression operator+(const Variable& lhs, const Variable& rhs) {
-  return Expression{lhs} + Expression{rhs};
-}
-Expression operator+(Expression lhs, const Variable& rhs) { return lhs += rhs; }
-Expression operator+(const Variable& lhs, Expression rhs) { return rhs += lhs; }
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator-=(Expression& lhs, const Variable& rhs) {
-  return lhs -= Expression{rhs};
-}
-Expression operator-(const Variable& lhs, const Variable& rhs) {
-  return Expression{lhs} - Expression{rhs};
-}
-Expression operator-(Expression lhs, const Variable& rhs) { return lhs -= rhs; }
-Expression operator-(const Variable& lhs, const Expression& rhs) {
-  return Expression(lhs) - rhs;
-}
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator*=(Expression& lhs, const Variable& rhs) {
-  return lhs *= Expression{rhs};
-}
-Expression operator*(const Variable& lhs, const Variable& rhs) {
-  return Expression{lhs} * Expression{rhs};
-}
-Expression operator*(Expression lhs, const Variable& rhs) { return lhs *= rhs; }
-Expression operator*(const Variable& lhs, Expression rhs) { return rhs *= lhs; }
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator/=(Expression& lhs, const Variable& rhs) {
-  return lhs /= Expression{rhs};
-}
-Expression operator/(const Variable& lhs, const Variable& rhs) {
-  return Expression{lhs} / Expression{rhs};
-}
-Expression operator/(Expression lhs, const Variable& rhs) { return lhs /= rhs; }
-Expression operator/(const Variable& lhs, const Expression& rhs) {
-  return Expression(lhs) / rhs;
-}
-
-Expression operator+(const Variable& var) { return Expression{var}; }
-Expression operator-(const Variable& var) { return -Expression{var}; }
-
 Expression log(const Expression& e) {
   // Simplification: constant folding.
   if (is_constant(e)) {
@@ -729,4 +682,74 @@ const map<Expression, Expression>& get_base_to_exp_map_in_multiplication(
 }
 
 }  // namespace symbolic
+
+// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+symbolic::Expression& operator+=(symbolic::Expression& lhs,
+                                 const Variable& rhs) {
+  return lhs += symbolic::Expression{rhs};
+}
+symbolic::Expression operator+(const Variable& lhs, const Variable& rhs) {
+  return symbolic::Expression{lhs} + symbolic::Expression{rhs};
+}
+symbolic::Expression operator+(symbolic::Expression lhs, const Variable& rhs) {
+  return lhs += rhs;
+}
+symbolic::Expression operator+(const Variable& lhs, symbolic::Expression rhs) {
+  return rhs += lhs;
+}
+
+// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+symbolic::Expression& operator-=(symbolic::Expression& lhs,
+                                 const Variable& rhs) {
+  return lhs -= symbolic::Expression{rhs};
+}
+symbolic::Expression operator-(const Variable& lhs, const Variable& rhs) {
+  return symbolic::Expression{lhs} - symbolic::Expression{rhs};
+}
+symbolic::Expression operator-(symbolic::Expression lhs, const Variable& rhs) {
+  return lhs -= rhs;
+}
+symbolic::Expression operator-(const Variable& lhs,
+                               const symbolic::Expression& rhs) {
+  return symbolic::Expression(lhs) - rhs;
+}
+
+// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+symbolic::Expression& operator*=(symbolic::Expression& lhs,
+                                 const Variable& rhs) {
+  return lhs *= symbolic::Expression{rhs};
+}
+symbolic::Expression operator*(const Variable& lhs, const Variable& rhs) {
+  return symbolic::Expression{lhs} * symbolic::Expression{rhs};
+}
+symbolic::Expression operator*(symbolic::Expression lhs, const Variable& rhs) {
+  return lhs *= rhs;
+}
+symbolic::Expression operator*(const Variable& lhs, symbolic::Expression rhs) {
+  return rhs *= lhs;
+}
+
+// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+symbolic::Expression& operator/=(symbolic::Expression& lhs,
+                                 const Variable& rhs) {
+  return lhs /= symbolic::Expression{rhs};
+}
+symbolic::Expression operator/(const Variable& lhs, const Variable& rhs) {
+  return symbolic::Expression{lhs} / symbolic::Expression{rhs};
+}
+symbolic::Expression operator/(symbolic::Expression lhs, const Variable& rhs) {
+  return lhs /= rhs;
+}
+symbolic::Expression operator/(const Variable& lhs,
+                               const symbolic::Expression& rhs) {
+  return symbolic::Expression(lhs) / rhs;
+}
+
+symbolic::Expression operator+(const Variable& var) {
+  return symbolic::Expression{var};
+}
+symbolic::Expression operator-(const Variable& var) {
+  return -symbolic::Expression{var};
+}
+
 }  // namespace drake

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -15,12 +15,12 @@
 #include "drake/common/cond.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/dummy_value.h"
+#include "drake/common/environment.h"
 #include "drake/common/hash.h"
 #include "drake/common/number_traits.h"
 #include "drake/common/polynomial.h"
-#include "drake/common/symbolic_environment.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 
@@ -143,7 +143,7 @@ class Expression {
   /** Constructs a constant. */
   // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
   Expression(double d);
-  /** Constructs a variable expression from symbolic::Variable. */
+  /** Constructs a variable expression from Variable. */
   explicit Expression(const Variable& var);
   /** Constructs a variable expression from string @p name. */
   explicit Expression(const std::string& name);
@@ -340,33 +340,6 @@ Expression operator/(Expression lhs, const Expression& rhs);
 // NOLINTNEXTLINE(runtime/references) per C++ standard signature.
 Expression& operator/=(Expression& lhs, const Expression& rhs);
 
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator+=(Expression& lhs, const Variable& rhs);
-Expression operator+(const Variable& lhs, const Variable& rhs);
-Expression operator+(Expression lhs, const Variable& rhs);
-Expression operator+(const Variable& lhs, Expression rhs);
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator-=(Expression& lhs, const Variable& rhs);
-Expression operator-(const Variable& lhs, const Variable& rhs);
-Expression operator-(Expression lhs, const Variable& rhs);
-Expression operator-(const Variable& lhs, const Expression& rhs);
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator*=(Expression& lhs, const Variable& rhs);
-Expression operator*(const Variable& lhs, const Variable& rhs);
-Expression operator*(Expression lhs, const Variable& rhs);
-Expression operator*(const Variable& lhs, Expression rhs);
-
-// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
-Expression& operator/=(Expression& lhs, const Variable& rhs);
-Expression operator/(const Variable& lhs, const Variable& rhs);
-Expression operator/(Expression lhs, const Variable& rhs);
-Expression operator/(const Variable& lhs, const Expression& rhs);
-
-Expression operator+(const Variable& var);
-Expression operator-(const Variable& var);
-
 Expression log(const Expression& e);
 Expression abs(const Expression& e);
 Expression exp(const Expression& e);
@@ -455,7 +428,7 @@ bool is_if_then_else(const Expression& e);
  *  \pre{@p e is a constant expression.}
  */
 double get_constant_value(const Expression& e);
-/** Returns the embedded symbolic variable in the variable expression @p e.
+/** Returns the embedded variable in the variable expression @p e.
  *  \pre{@p e is a variable expression.}
  */
 const Variable& get_variable(const Expression& e);
@@ -496,32 +469,6 @@ double get_constant_in_multiplication(const Expression& e);
 const std::map<Expression, Expression>& get_base_to_exp_map_in_multiplication(
     const Expression& e);
 
-// Matrix<Expression> * Matrix<Variable> => Matrix<Expression>
-template <typename MatrixL, typename MatrixR>
-typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
-        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
-        std::is_same<typename MatrixL::Scalar, Expression>::value &&
-        std::is_same<typename MatrixR::Scalar, Variable>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
-operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs * rhs.template cast<Expression>();
-}
-
-// Matrix<Variable> * Matrix<Expression> => Matrix<Expression>
-template <typename MatrixL, typename MatrixR>
-typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
-        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
-        std::is_same<typename MatrixL::Scalar, Variable>::value &&
-        std::is_same<typename MatrixR::Scalar, Expression>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime> >::type
-operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs.template cast<Expression>() * rhs;
-}
-
 // Matrix<Expression> * Matrix<double> => Matrix<Expression>
 template <typename MatrixL, typename MatrixR>
 typename std::enable_if<
@@ -548,6 +495,67 @@ operator*(const MatrixL& lhs, const MatrixR& rhs) {
   return lhs.template cast<Expression>() * rhs.template cast<Expression>();
 }
 
+}  // namespace symbolic
+
+// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+symbolic::Expression& operator+=(symbolic::Expression& lhs,
+                                 const Variable& rhs);
+symbolic::Expression operator+(const Variable& lhs, const Variable& rhs);
+symbolic::Expression operator+(symbolic::Expression lhs, const Variable& rhs);
+symbolic::Expression operator+(const Variable& lhs, symbolic::Expression rhs);
+
+// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+symbolic::Expression& operator-=(symbolic::Expression& lhs,
+                                 const Variable& rhs);
+symbolic::Expression operator-(const Variable& lhs, const Variable& rhs);
+symbolic::Expression operator-(symbolic::Expression lhs, const Variable& rhs);
+symbolic::Expression operator-(const Variable& lhs,
+                               const symbolic::Expression& rhs);
+
+// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+symbolic::Expression& operator*=(symbolic::Expression& lhs,
+                                 const Variable& rhs);
+symbolic::Expression operator*(const Variable& lhs, const Variable& rhs);
+symbolic::Expression operator*(symbolic::Expression lhs, const Variable& rhs);
+symbolic::Expression operator*(const Variable& lhs, symbolic::Expression rhs);
+
+// NOLINTNEXTLINE(runtime/references) per C++ standard signature.
+symbolic::Expression& operator/=(symbolic::Expression& lhs,
+                                 const Variable& rhs);
+symbolic::Expression operator/(const Variable& lhs, const Variable& rhs);
+symbolic::Expression operator/(symbolic::Expression lhs, const Variable& rhs);
+symbolic::Expression operator/(const Variable& lhs,
+                               const symbolic::Expression& rhs);
+
+symbolic::Expression operator+(const Variable& var);
+symbolic::Expression operator-(const Variable& var);
+
+// Matrix<Expression> * Matrix<Variable> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, symbolic::Expression>::value &&
+        std::is_same<typename MatrixR::Scalar, Variable>::value,
+    Eigen::Matrix<symbolic::Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs * rhs.template cast<symbolic::Expression>();
+}
+
+// Matrix<Variable> * Matrix<Expression> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Variable>::value &&
+        std::is_same<typename MatrixR::Scalar, symbolic::Expression>::value,
+    Eigen::Matrix<symbolic::Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime> >::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<symbolic::Expression>() * rhs;
+}
+
 // Matrix<Variable> * Matrix<double> => Matrix<Expression>
 template <typename MatrixL, typename MatrixR>
 typename std::enable_if<
@@ -555,10 +563,11 @@ typename std::enable_if<
         std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
         std::is_same<typename MatrixL::Scalar, Variable>::value &&
         std::is_same<typename MatrixR::Scalar, double>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+    Eigen::Matrix<symbolic::Expression, MatrixL::RowsAtCompileTime,
                   MatrixR::ColsAtCompileTime> >::type
 operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+  return lhs.template cast<symbolic::Expression>() *
+         rhs.template cast<symbolic::Expression>();
 }
 
 // Matrix<double> * Matrix<Variable> => Matrix<Expression>
@@ -568,13 +577,12 @@ typename std::enable_if<
         std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
         std::is_same<typename MatrixL::Scalar, double>::value &&
         std::is_same<typename MatrixR::Scalar, Variable>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+    Eigen::Matrix<symbolic::Expression, MatrixL::RowsAtCompileTime,
                   MatrixR::ColsAtCompileTime> >::type
 operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+  return lhs.template cast<symbolic::Expression>() *
+         rhs.template cast<symbolic::Expression>();
 }
-
-}  // namespace symbolic
 
 /** Provides specialization of @c cond function defined in drake/common/cond.h
  * file. This specialization is required to handle @c double to @c
@@ -640,38 +648,37 @@ struct NumTraits<drake::symbolic::Expression>
 
 // Informs Eigen that Variable op Variable gets Expression.
 template <typename BinaryOp>
-struct ScalarBinaryOpTraits<drake::symbolic::Variable,
-                            drake::symbolic::Variable, BinaryOp> {
+struct ScalarBinaryOpTraits<drake::Variable, drake::Variable, BinaryOp> {
   enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
 
 // Informs Eigen that Variable op Expression gets Expression.
 template <typename BinaryOp>
-struct ScalarBinaryOpTraits<drake::symbolic::Variable,
-                            drake::symbolic::Expression, BinaryOp> {
+struct ScalarBinaryOpTraits<drake::Variable, drake::symbolic::Expression,
+                            BinaryOp> {
   enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
 
 // Informs Eigen that Expression op Variable gets Expression.
 template <typename BinaryOp>
-struct ScalarBinaryOpTraits<drake::symbolic::Expression,
-                            drake::symbolic::Variable, BinaryOp> {
+struct ScalarBinaryOpTraits<drake::symbolic::Expression, drake::Variable,
+                            BinaryOp> {
   enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
 
 // Informs Eigen that Variable op double gets Expression.
 template <typename BinaryOp>
-struct ScalarBinaryOpTraits<drake::symbolic::Variable, double, BinaryOp> {
+struct ScalarBinaryOpTraits<drake::Variable, double, BinaryOp> {
   enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
 
 // Informs Eigen that double op Variable gets Expression.
 template <typename BinaryOp>
-struct ScalarBinaryOpTraits<double, drake::symbolic::Variable, BinaryOp> {
+struct ScalarBinaryOpTraits<double, drake::Variable, BinaryOp> {
   enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -14,11 +14,11 @@
 #include <utility>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/environment.h"
 #include "drake/common/hash.h"
-#include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/symbolic_expression_cell.h
+++ b/drake/common/symbolic_expression_cell.h
@@ -10,12 +10,12 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/environment.h"
 #include "drake/common/polynomial.h"
-#include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_formula.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/symbolic_formula.cc
+++ b/drake/common/symbolic_formula.cc
@@ -6,11 +6,11 @@
 #include <set>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/symbolic_environment.h"
+#include "drake/common/environment.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_formula_cell.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {
@@ -39,7 +39,7 @@ size_t Formula::get_hash() const {
   return ptr_->get_hash();
 }
 
-symbolic::Variables Formula::GetFreeVariables() const {
+Variables Formula::GetFreeVariables() const {
   DRAKE_ASSERT(ptr_ != nullptr);
   return ptr_->GetFreeVariables();
 }

--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -8,11 +8,11 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/environment.h"
 #include "drake/common/hash.h"
-#include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {
@@ -69,11 +69,11 @@ The following simple simplifications are implemented:
 
 \note Formula class has an explicit conversion operator to bool. It evaluates a
 symbolic formula under an empty environment. If a symbolic formula includes
-symbolic variables, the conversion operator throws an exception. This operator
-is only intended for third-party code doing things like
-<tt>(imag(SymbolicExpression(0)) == SymbolicExpression(0)) { ... };<tt> that we
-found in Eigen3 codebase. In general, a user of this class should explicitly
-call \c Evaluate from within Drake for readability.
+variables, the conversion operator throws an exception. This operator is only
+intended for third-party code doing things like <tt>(imag(SymbolicExpression(0))
+== SymbolicExpression(0)) { ... };<tt> that we found in Eigen3 codebase. In
+general, a user of this class should explicitly call \c Evaluate from within
+Drake for readability.
 
 */
 class Formula {

--- a/drake/common/symbolic_formula_cell.cc
+++ b/drake/common/symbolic_formula_cell.cc
@@ -7,12 +7,12 @@
 #include <stdexcept>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/environment.h"
 #include "drake/common/hash.h"
-#include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_formula.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {
@@ -113,9 +113,7 @@ ostream& NaryFormulaCell::DisplayWithOp(ostream& os, const string& op) const {
 FormulaTrue::FormulaTrue()
     : FormulaCell{FormulaKind::True, hash<string>{}("True")} {}
 
-symbolic::Variables FormulaTrue::GetFreeVariables() const {
-  return Variables{};
-}
+Variables FormulaTrue::GetFreeVariables() const { return Variables{}; }
 
 bool FormulaTrue::EqualTo(const FormulaCell& f) const {
   // Formula::EqualTo guarantees the following assertion.
@@ -137,9 +135,7 @@ ostream& FormulaTrue::Display(ostream& os) const { return os << "True"; }
 FormulaFalse::FormulaFalse()
     : FormulaCell{FormulaKind::False, hash<string>{}("False")} {}
 
-symbolic::Variables FormulaFalse::GetFreeVariables() const {
-  return Variables{};
-}
+Variables FormulaFalse::GetFreeVariables() const { return Variables{}; }
 
 bool FormulaFalse::EqualTo(const FormulaCell& f) const {
   // Formula::EqualTo guarantees the following assertion.
@@ -281,9 +277,7 @@ ostream& FormulaOr::Display(ostream& os) const {
 FormulaNot::FormulaNot(const Formula& f)
     : FormulaCell{FormulaKind::Not, f.get_hash()}, f_{f} {}
 
-symbolic::Variables FormulaNot::GetFreeVariables() const {
-  return f_.GetFreeVariables();
-}
+Variables FormulaNot::GetFreeVariables() const { return f_.GetFreeVariables(); }
 
 bool FormulaNot::EqualTo(const FormulaCell& f) const {
   // Formula::EqualTo guarantees the following assertion.
@@ -312,7 +306,7 @@ FormulaForall::FormulaForall(const Variables& vars, const Formula& f)
       vars_{vars},
       f_{f} {}
 
-symbolic::Variables FormulaForall::GetFreeVariables() const {
+Variables FormulaForall::GetFreeVariables() const {
   return f_.GetFreeVariables() - vars_;
 }
 

--- a/drake/common/symbolic_formula_cell.h
+++ b/drake/common/symbolic_formula_cell.h
@@ -8,11 +8,11 @@
 #include <utility>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/symbolic_environment.h"
+#include "drake/common/environment.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_formula.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -6,8 +6,20 @@ target_link_libraries(autodiff_overloads_test drakeCommon)
 drake_add_cc_test(double_overloads_test)
 target_link_libraries(double_overloads_test drakeCommon)
 
+drake_add_cc_test(drake_throw_test)
+target_link_libraries(drake_throw_test drakeCommon)
+
 drake_add_cc_test(dummy_value_test)
 target_link_libraries(dummy_value_test drakeCommon)
+
+drake_add_cc_test(eigen_matrix_compare_test)
+target_link_libraries(eigen_matrix_compare_test drakeCommon)
+
+drake_add_cc_test(eigen_stl_types_test)
+target_link_libraries(eigen_stl_types_test Eigen3::Eigen)
+
+drake_add_cc_test(environment_test)
+target_link_libraries(environment_test drakeCommon)
 
 drake_add_cc_test(extract_double_test)
 target_link_libraries(extract_double_test drakeCommon)
@@ -26,18 +38,6 @@ target_link_libraries(monomial_test drakeCommon)
 
 drake_add_cc_test(nice_type_name_test)
 target_link_libraries(nice_type_name_test drakeCommon)
-
-drake_add_cc_test(symbolic_variable_test)
-target_link_libraries(symbolic_variable_test drakeCommon)
-
-drake_add_cc_test(symbolic_variable_overloading_test)
-target_link_libraries(symbolic_variable_overloading_test drakeCommon)
-
-drake_add_cc_test(symbolic_variables_test)
-target_link_libraries(symbolic_variables_test drakeCommon)
-
-drake_add_cc_test(symbolic_environment_test)
-target_link_libraries(symbolic_environment_test drakeCommon)
 
 drake_add_cc_test(symbolic_expression_test)
 target_link_libraries(symbolic_expression_test drakeCommon)
@@ -60,14 +60,14 @@ target_link_libraries(trig_poly_test drakeCommon)
 drake_add_cc_test(polynomial_test)
 target_link_libraries(polynomial_test drakeCommon)
 
-drake_add_cc_test(eigen_matrix_compare_test)
-target_link_libraries(eigen_matrix_compare_test drakeCommon)
+drake_add_cc_test(variable_test)
+target_link_libraries(variable_test drakeCommon)
 
-drake_add_cc_test(eigen_stl_types_test)
-target_link_libraries(eigen_stl_types_test Eigen3::Eigen)
+drake_add_cc_test(variable_overloading_test)
+target_link_libraries(variable_overloading_test drakeCommon)
 
-drake_add_cc_test(drake_throw_test)
-target_link_libraries(drake_throw_test drakeCommon)
+drake_add_cc_test(variables_test)
+target_link_libraries(variables_test drakeCommon)
 
 # Adds "drake_assert.h" unit testing.
 add_executable(drake_assert_test_default drake_assert_test.cc)

--- a/drake/common/test/environment_test.cc
+++ b/drake/common/test/environment_test.cc
@@ -1,4 +1,4 @@
-#include "drake/common/symbolic_environment.h"
+#include "drake/common/environment.h"
 
 #include <cmath>
 #include <stdexcept>
@@ -6,17 +6,16 @@
 
 #include "gtest/gtest.h"
 
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 namespace drake {
-namespace symbolic {
 namespace {
 
 using std::string;
 using std::runtime_error;
 
 // Provides common variables that are used by the following tests.
-class SymbolicEnvironmentTest : public ::testing::Test {
+class EnvironmentTest : public ::testing::Test {
  protected:
   const Variable var_dummy_{};
   const Variable var_x_{"x"};
@@ -26,7 +25,7 @@ class SymbolicEnvironmentTest : public ::testing::Test {
   const Variable var_v_{"v"};
 };
 
-TEST_F(SymbolicEnvironmentTest, EmptySize) {
+TEST_F(EnvironmentTest, EmptySize) {
   const Environment env1{};
   EXPECT_TRUE(env1.empty());
   EXPECT_EQ(env1.size(), 0u);
@@ -36,18 +35,18 @@ TEST_F(SymbolicEnvironmentTest, EmptySize) {
   EXPECT_EQ(env2.size(), 3u);
 }
 
-TEST_F(SymbolicEnvironmentTest, InitWithNan) {
+TEST_F(EnvironmentTest, InitWithNan) {
   EXPECT_THROW((Environment{{var_x_, 10}, {var_y_, NAN}}), runtime_error);
 }
 
-TEST_F(SymbolicEnvironmentTest, InitializerListWithoutValues) {
+TEST_F(EnvironmentTest, InitializerListWithoutValues) {
   const Environment env{var_x_, var_y_, var_z_};
   for (const auto& p : env) {
     EXPECT_EQ(p.second, 0.0);
   }
 }
 
-TEST_F(SymbolicEnvironmentTest, insert_find) {
+TEST_F(EnvironmentTest, insert_find) {
   Environment env1{{var_x_, 2}, {var_y_, 3}, {var_z_, 4}};
   const Environment env2{env1};
 
@@ -66,7 +65,7 @@ TEST_F(SymbolicEnvironmentTest, insert_find) {
   EXPECT_EQ(env1.size(), 5u);
 }
 
-TEST_F(SymbolicEnvironmentTest, ToString) {
+TEST_F(EnvironmentTest, ToString) {
   const Environment env{{var_x_, 2}, {var_y_, 3}, {var_z_, 3}};
   const string out{env.to_string()};
   EXPECT_TRUE(out.find("x -> 2") != string::npos);
@@ -74,16 +73,15 @@ TEST_F(SymbolicEnvironmentTest, ToString) {
   EXPECT_TRUE(out.find("z -> 3") != string::npos);
 }
 
-TEST_F(SymbolicEnvironmentTest, DummyVariable1) {
+TEST_F(EnvironmentTest, DummyVariable1) {
   EXPECT_THROW(Environment({var_dummy_, var_x_}), runtime_error);
   EXPECT_THROW(Environment({{var_dummy_, 1.0}, {var_x_, 2}}), runtime_error);
 }
 
-TEST_F(SymbolicEnvironmentTest, DummyVariable2) {
+TEST_F(EnvironmentTest, DummyVariable2) {
   Environment env{{var_x_, 2}, {var_y_, 3}, {var_z_, 3}};
   EXPECT_THROW(env.insert(var_dummy_, 0.0), runtime_error);
 }
 
 }  // namespace
-}  // namespace symbolic
 }  // namespace drake

--- a/drake/common/test/monomial_test.cc
+++ b/drake/common/test/monomial_test.cc
@@ -7,7 +7,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 using std::unordered_map;
 

--- a/drake/common/test/symbolic_expression_matrix_test.cc
+++ b/drake/common/test/symbolic_expression_matrix_test.cc
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -16,11 +16,11 @@
 
 #include "gtest/gtest.h"
 
+#include "drake/common/environment.h"
 #include "drake/common/hash.h"
-#include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_formula.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 using std::count_if;
 using std::domain_error;

--- a/drake/common/test/symbolic_formula_test.cc
+++ b/drake/common/test/symbolic_formula_test.cc
@@ -10,10 +10,10 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
-#include "drake/common/symbolic_environment.h"
+#include "drake/common/environment.h"
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_variable.h"
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variable.h"
+#include "drake/common/variables.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/test/symbolic_mixing_scalar_types_test.cc
+++ b/drake/common/test/symbolic_mixing_scalar_types_test.cc
@@ -6,7 +6,7 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/symbolic_formula.h"
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/test/variable_overloading_test.cc
+++ b/drake/common/test/variable_overloading_test.cc
@@ -1,16 +1,15 @@
-#include "drake/common/symbolic_expression.h"
-
 #include <sstream>
 
 #include "gtest/gtest.h"
 
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/symbolic_expression.h"
+#include "drake/common/variable.h"
 
 namespace drake {
-namespace symbolic {
 namespace {
 
 using std::ostringstream;
+using symbolic::Expression;
 
 bool ExprEqual(const Expression& e1, const Expression& e2) {
   return e1.EqualTo(e2);
@@ -18,7 +17,7 @@ bool ExprEqual(const Expression& e1, const Expression& e2) {
 
 // Provides common variables and matrices that are used by the
 // following tests.
-class SymbolicVariableOverloadingTest : public ::testing::Test {
+class VariableOverloadingTest : public ::testing::Test {
  protected:
   const Variable x_{"x"};
   const Variable y_{"y"};
@@ -26,8 +25,8 @@ class SymbolicVariableOverloadingTest : public ::testing::Test {
   const Variable w_{"w"};
 
   Eigen::Matrix<double, 2, 2, Eigen::DontAlign> double_mat_;
-  Eigen::Matrix<symbolic::Variable, 2, 2, Eigen::DontAlign> var_mat_;
-  Eigen::Matrix<symbolic::Expression, 2, 2, Eigen::DontAlign> expr_mat_;
+  Eigen::Matrix<Variable, 2, 2, Eigen::DontAlign> var_mat_;
+  Eigen::Matrix<Expression, 2, 2, Eigen::DontAlign> expr_mat_;
 
   void SetUp() override {
     // clang-format off
@@ -41,7 +40,7 @@ class SymbolicVariableOverloadingTest : public ::testing::Test {
   }
 };
 
-TEST_F(SymbolicVariableOverloadingTest, OperatorOverloadingArithmetic) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingArithmetic) {
   // Variable op Variable.
   const Expression e1{x_ + y_};
   const Expression e2{x_ - y_};
@@ -93,8 +92,7 @@ TEST_F(SymbolicVariableOverloadingTest, OperatorOverloadingArithmetic) {
   EXPECT_EQ(e20.to_string(), "(5 / y)");
 }
 
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingArithmeticAssignment) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingArithmeticAssignment) {
   Expression e{x_ + y_};
   e += z_;  // x + y + z
   EXPECT_EQ(e.to_string(), "(x + y + z)");
@@ -106,8 +104,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_EQ(e.to_string(), "((w * (y + z)) / y)");
 }
 
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingEigenTestSanityCheck) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingEigenTestSanityCheck) {
   // [1.0  2.0]
   // [3.0  4.0]
   EXPECT_EQ(double_mat_(0, 0), 1.0);
@@ -130,8 +127,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_PRED2(ExprEqual, expr_mat_(1, 1), y_ + w_);
 }
 
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingEigenVariableOpVariable) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingEigenVariableOpVariable) {
   const Eigen::Matrix<Expression, 2, 2> m1{var_mat_ + var_mat_};
   const Eigen::Matrix<Expression, 2, 2> m2{var_mat_ - var_mat_};
   const Eigen::Matrix<Expression, 2, 2> m3{var_mat_ * var_mat_};
@@ -158,8 +154,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_PRED2(ExprEqual, m3(1, 1), z_ * y_ + w_ * w_);
 }
 
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingEigenVariableOpExpression) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingEigenVariableOpExpression) {
   const Eigen::Matrix<Expression, 2, 2> m1{var_mat_ + expr_mat_};
   const Eigen::Matrix<Expression, 2, 2> m2{var_mat_ - expr_mat_};
   const Eigen::Matrix<Expression, 2, 2> m3{var_mat_ * expr_mat_};
@@ -188,8 +183,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_PRED2(ExprEqual, m3(1, 1), z_ * (x_ + w_) + w_ * (y_ + w_));
 }
 
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingEigenExpressionOpVariable) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingEigenExpressionOpVariable) {
   const Eigen::Matrix<Expression, 2, 2> m1{expr_mat_ + var_mat_};
   const Eigen::Matrix<Expression, 2, 2> m2{expr_mat_ - var_mat_};
   const Eigen::Matrix<Expression, 2, 2> m3{expr_mat_ * var_mat_};
@@ -219,8 +213,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_PRED2(ExprEqual, m3(1, 1), (y_ + z_) * y_ + (y_ + w_) * w_);
 }
 
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingEigenVariableOpDouble) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingEigenVariableOpDouble) {
   const Eigen::Matrix<Expression, 2, 2> m1{var_mat_ + double_mat_};
   const Eigen::Matrix<Expression, 2, 2> m2{var_mat_ - double_mat_};
   const Eigen::Matrix<Expression, 2, 2> m3{var_mat_ * double_mat_};
@@ -247,8 +240,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_PRED2(ExprEqual, m3(1, 1), z_ * 2.0 + w_ * 4.0);
 }
 
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingEigenDoubleOpVariable) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingEigenDoubleOpVariable) {
   const Eigen::Matrix<Expression, 2, 2> m1{double_mat_ + var_mat_};
   const Eigen::Matrix<Expression, 2, 2> m2{double_mat_ - var_mat_};
   const Eigen::Matrix<Expression, 2, 2> m3{double_mat_ * var_mat_};
@@ -275,8 +267,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_PRED2(ExprEqual, m3(1, 1), 3.0 * y_ + 4.0 * w_);
 }
 
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingEigenDivideByVariable) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingEigenDivideByVariable) {
   const Eigen::Matrix<Expression, 2, 2> m1{double_mat_ / x_};
   const Eigen::Matrix<Expression, 2, 2> m2{var_mat_ / x_};
   const Eigen::Matrix<Expression, 2, 2> m3{expr_mat_ / x_};
@@ -302,8 +293,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_PRED2(ExprEqual, m3(1, 0), (y_ + z_) / x_);
   EXPECT_PRED2(ExprEqual, m3(1, 1), (y_ + w_) / x_);
 }
-TEST_F(SymbolicVariableOverloadingTest,
-       OperatorOverloadingEigenDivideVariable) {
+TEST_F(VariableOverloadingTest, OperatorOverloadingEigenDivideVariable) {
   const Eigen::Matrix<Expression, 2, 2> m1{var_mat_ / 3.0};
   const Eigen::Matrix<Expression, 2, 2> m2{var_mat_ / (x_ + y_)};
 
@@ -322,7 +312,7 @@ TEST_F(SymbolicVariableOverloadingTest,
   EXPECT_PRED2(ExprEqual, m2(1, 1), w_ / (x_ + y_));
 }
 
-TEST_F(SymbolicVariableOverloadingTest, EigenExpressionMatrixOutput) {
+TEST_F(VariableOverloadingTest, EigenExpressionMatrixOutput) {
   ostringstream oss1;
   oss1 << expr_mat_;
 
@@ -333,5 +323,4 @@ TEST_F(SymbolicVariableOverloadingTest, EigenExpressionMatrixOutput) {
   EXPECT_EQ(oss1.str(), oss2.str());
 }
 }  // namespace
-}  // namespace symbolic
 }  // namespace drake

--- a/drake/common/test/variable_test.cc
+++ b/drake/common/test/variable_test.cc
@@ -1,4 +1,4 @@
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 #include <sstream>
 #include <unordered_map>
@@ -21,13 +21,13 @@ using std::unordered_set;
 using std::vector;
 
 // Provides common variables that are used by the following tests.
-class SymbolicVariableTest : public ::testing::Test {
+class VariableTest : public ::testing::Test {
  protected:
   const Variable x_{"x"};
   const Variable y_{"y"};
   const Variable z_{"z"};
   const Variable w_{"w"};
-  Eigen::Matrix<symbolic::Variable, 2, 2> M_;
+  Eigen::Matrix<Variable, 2, 2> M_;
 
   void SetUp() override {
     // clang-format off
@@ -37,7 +37,7 @@ class SymbolicVariableTest : public ::testing::Test {
   }
 };
 
-TEST_F(SymbolicVariableTest, GetId) {
+TEST_F(VariableTest, GetId) {
   const Variable dummy{};
   const Variable x_prime{"x"};
   EXPECT_TRUE(dummy.is_dummy());
@@ -46,12 +46,12 @@ TEST_F(SymbolicVariableTest, GetId) {
   EXPECT_NE(x_.get_id(), x_prime.get_id());
 }
 
-TEST_F(SymbolicVariableTest, GetName) {
+TEST_F(VariableTest, GetName) {
   const Variable x_prime{"x"};
   EXPECT_EQ(x_.get_name(), x_prime.get_name());
 }
 
-TEST_F(SymbolicVariableTest, MoveCopyPreserveId) {
+TEST_F(VariableTest, MoveCopyPreserveId) {
   Variable x{"x"};
   const size_t x_id{x.get_id()};
   const size_t x_hash{x.get_hash()};
@@ -63,7 +63,7 @@ TEST_F(SymbolicVariableTest, MoveCopyPreserveId) {
   EXPECT_EQ(x_hash, x_moved.get_hash());
 }
 
-TEST_F(SymbolicVariableTest, Lt) {
+TEST_F(VariableTest, Lt) {
   EXPECT_FALSE(x_ < x_);
   EXPECT_TRUE(x_ < y_);
   EXPECT_TRUE(x_ < z_);
@@ -85,7 +85,7 @@ TEST_F(SymbolicVariableTest, Lt) {
   EXPECT_FALSE(w_ < w_);
 }
 
-TEST_F(SymbolicVariableTest, Eq) {
+TEST_F(VariableTest, Eq) {
   EXPECT_TRUE(x_ == x_);
   EXPECT_FALSE(x_ == y_);
   EXPECT_FALSE(x_ == z_);
@@ -107,42 +107,39 @@ TEST_F(SymbolicVariableTest, Eq) {
   EXPECT_TRUE(w_ == w_);
 }
 
-TEST_F(SymbolicVariableTest, ToString) {
+TEST_F(VariableTest, ToString) {
   EXPECT_EQ(x_.to_string(), "x");
   EXPECT_EQ(y_.to_string(), "y");
   EXPECT_EQ(z_.to_string(), "z");
   EXPECT_EQ(w_.to_string(), "w");
 }
 
-// This test checks whether symbolic::Variable is compatible with
-// std::unordered_set.
-TEST_F(SymbolicVariableTest, CompatibleWithUnorderedSet) {
+// This test checks whether Variable is compatible with std::unordered_set.
+TEST_F(VariableTest, CompatibleWithUnorderedSet) {
   unordered_set<Variable, hash_value<Variable>> uset;
   uset.emplace(x_);
   uset.emplace(y_);
 }
 
-// This test checks whether symbolic::Variable is compatible with
-// std::unordered_map.
-TEST_F(SymbolicVariableTest, CompatibleWithUnorderedMap) {
+// This test checks whether Variable is compatible with std::unordered_map.
+TEST_F(VariableTest, CompatibleWithUnorderedMap) {
   unordered_map<Variable, Variable, hash_value<Variable>> umap;
   umap.emplace(x_, y_);
 }
 
-// This test checks whether symbolic::Variable is compatible with
-// std::vector.
-TEST_F(SymbolicVariableTest, CompatibleWithVector) {
+// This test checks whether Variable is compatible with std::vector.
+TEST_F(VariableTest, CompatibleWithVector) {
   vector<Variable> vec;
   vec.push_back(x_);
 }
 
-TEST_F(SymbolicVariableTest, EigenVariableMatrix) {
+TEST_F(VariableTest, EigenVariableMatrix) {
   EXPECT_EQ(M_(0, 0), x_);
   EXPECT_EQ(M_(0, 1), y_);
   EXPECT_EQ(M_(1, 0), z_);
   EXPECT_EQ(M_(1, 1), w_);
 }
-TEST_F(SymbolicVariableTest, EigenVariableMatrixOutput) {
+TEST_F(VariableTest, EigenVariableMatrixOutput) {
   ostringstream oss1;
   oss1 << M_;
 

--- a/drake/common/test/variables_test.cc
+++ b/drake/common/test/variables_test.cc
@@ -1,8 +1,8 @@
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variables.h"
 
 #include "gtest/gtest.h"
 
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/variable.cc
+++ b/drake/common/variable.cc
@@ -1,4 +1,4 @@
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 #include <atomic>
 #include <iostream>
@@ -13,7 +13,6 @@ using std::ostringstream;
 using std::string;
 
 namespace drake {
-namespace symbolic {
 
 Variable::Id Variable::get_next_id() {
   // Note that id 0 is reserved for anonymous variable which is created by the
@@ -45,5 +44,4 @@ ostream& operator<<(ostream& os, const Variable& var) {
   return os;
 }
 
-}  // namespace symbolic
 }  // namespace drake

--- a/drake/common/variable.h
+++ b/drake/common/variable.h
@@ -11,9 +11,8 @@
 #include "drake/common/hash.h"
 
 namespace drake {
-namespace symbolic {
 
-/** Represents a symbolic variable. */
+/** Represents a variable. */
 class Variable {
  public:
   typedef size_t Id;
@@ -57,21 +56,18 @@ bool operator<(const Variable& lhs, const Variable& rhs);
 /// Check equality
 bool operator==(const Variable& lhs, const Variable& rhs);
 
-}  // namespace symbolic
-
-/** Computes the hash value of a symbolic variable. */
+/** Computes the hash value of a variable. */
 template <>
-struct hash_value<symbolic::Variable> {
-  size_t operator()(const symbolic::Variable& v) const { return v.get_hash(); }
+struct hash_value<Variable> {
+  size_t operator()(const Variable& v) const { return v.get_hash(); }
 };
 }  // namespace drake
 
 #if !defined(DRAKE_DOXYGEN_CXX)
 namespace Eigen {
-// Eigen scalar type traits for Matrix<drake::symbolic::Variable>.
+// Eigen scalar type traits for Matrix<drake::Variable>.
 template <>
-struct NumTraits<drake::symbolic::Variable>
-    : GenericNumTraits<drake::symbolic::Variable> {
+struct NumTraits<drake::Variable> : GenericNumTraits<drake::Variable> {
   static inline int digits10() { return 0; }
 };
 }  // namespace Eigen

--- a/drake/common/variables.cc
+++ b/drake/common/variables.cc
@@ -1,4 +1,4 @@
-#include "drake/common/symbolic_variables.h"
+#include "drake/common/variables.h"
 
 #include <algorithm>
 #include <iterator>
@@ -17,7 +17,6 @@ using std::ostringstream;
 using std::string;
 
 namespace drake {
-namespace symbolic {
 
 Variables::Variables(std::initializer_list<value_type> init) : vars_(init) {}
 
@@ -114,7 +113,7 @@ Variables operator-(Variables vars, const Variable& var) {
   return vars;
 }
 
-ostream& operator<<(ostream& os, const symbolic::Variables& vars) {
+ostream& operator<<(ostream& os, const Variables& vars) {
   os << "{";
   if (!vars.vars_.empty()) {
     // output 1st ... N-1th elements by adding ", " at the end
@@ -126,5 +125,4 @@ ostream& operator<<(ostream& os, const symbolic::Variables& vars) {
   return os;
 }
 
-}  // namespace symbolic
 }  // namespace drake

--- a/drake/common/variables.h
+++ b/drake/common/variables.h
@@ -7,13 +7,11 @@
 #include <set>
 #include <string>
 
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 namespace drake {
 
-namespace symbolic {
-
-/** Represents a set of symbolic variables.
+/** Represents a set of variables.
  *
  * This class is based on std::set<Variable>. The intent is to add things that
  * we need including set-union (Variables::insert, operator+, operator+=),
@@ -26,8 +24,8 @@ class Variables {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Variables)
 
-  typedef typename drake::symbolic::Variable key_type;
-  typedef typename drake::symbolic::Variable value_type;
+  typedef typename drake::Variable key_type;
+  typedef typename drake::Variable value_type;
   typedef typename std::set<key_type> set;
   typedef typename set::size_type size_type;
   typedef typename set::iterator iterator;
@@ -142,13 +140,9 @@ Variables operator-(Variables vars1, const Variables& vars2);
 /** Returns set-minus(@p vars, { @p var }). */
 Variables operator-(Variables vars, const Variable& var);
 
-}  // namespace symbolic
-
 /** Computes the hash value of a symbolic variables. */
 template <>
-struct hash_value<symbolic::Variables> {
-  size_t operator()(const symbolic::Variables& vars) const {
-    return vars.get_hash();
-  }
+struct hash_value<Variables> {
+  size_t operator()(const Variables& vars) const { return vars.get_hash(); }
 };
 }  // namespace drake

--- a/drake/math/test/matrix_util_test.cc
+++ b/drake/math/test/matrix_util_test.cc
@@ -30,9 +30,9 @@ GTEST_TEST(TestMatrixUtil, TestIsSymmetric) {
 
   // Tests a symbolic expression.
   Eigen::Matrix<symbolic::Expression, 2, 2> S;
-  symbolic::Variable s1{"s1"};
-  symbolic::Variable s2{"s2"};
-  symbolic::Variable s3{"s3"};
+  Variable s1{"s1"};
+  Variable s2{"s2"};
+  Variable s3{"s3"};
   symbolic::Expression S00{s1};
   symbolic::Expression S01{s2};
   symbolic::Expression S11{s3};
@@ -61,8 +61,8 @@ GTEST_TEST(TestMatrixUtil, TestToSymmetricMatrixFromLowerTriangularColumns) {
         2, 4, 5,
         3, 5, 6;
   // clang-format on
-  EXPECT_TRUE(CompareMatrices(ToSymmetricMatrixFromLowerTriangularColumns(x2),
-                              X2));
+  EXPECT_TRUE(
+      CompareMatrices(ToSymmetricMatrixFromLowerTriangularColumns(x2), X2));
 }
 }  // namespace test
 }  // namespace math

--- a/drake/solvers/binding.h
+++ b/drake/solvers/binding.h
@@ -47,7 +47,7 @@ class Binding {
 
   /**
    * Returns true iff the given @p var is included in this Binding.*/
-  bool ContainsVariable(const symbolic::Variable& var) const {
+  bool ContainsVariable(const Variable& var) const {
     for (int i = 0; i < vars_.rows(); ++i) {
       if (vars_(i) == var) {
         return true;

--- a/drake/solvers/decision_variable.h
+++ b/drake/solvers/decision_variable.h
@@ -10,13 +10,12 @@
 
 #include <Eigen/Core>
 
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 
 namespace drake {
 namespace solvers {
 template <int rows, int cols>
-using MatrixDecisionVariable =
-    Eigen::Matrix<drake::symbolic::Variable, rows, cols>;
+using MatrixDecisionVariable = Eigen::Matrix<Variable, rows, cols>;
 template <int rows>
 using VectorDecisionVariable = MatrixDecisionVariable<rows, 1>;
 using MatrixXDecisionVariable =
@@ -30,6 +29,6 @@ using VariableRefList = std::list<Eigen::Ref<const VectorXDecisionVariable>>;
  * decision variables, returns this concatenated vector.
  */
 VectorXDecisionVariable ConcatenateVariableRefList(
-    const VariableRefList &var_list);
+    const VariableRefList& var_list);
 }  // end namespace solvers
 }  // end namespace drake

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -32,7 +32,6 @@ using std::string;
 using std::unordered_map;
 using std::vector;
 
-using symbolic::Variable;
 using symbolic::Expression;
 
 namespace {
@@ -221,7 +220,7 @@ void ExtractVariablesFromExpression(
     const Expression& e, VectorXDecisionVariable* vars,
     unordered_map<Variable::Id, int>* map_var_to_index) {
   DRAKE_DEMAND(static_cast<int>(map_var_to_index->size()) == vars->size());
-  for (const symbolic::Variable& var : e.GetVariables()) {
+  for (const Variable& var : e.GetVariables()) {
     if (map_var_to_index->find(var.get_id()) == map_var_to_index->end()) {
       map_var_to_index->emplace(var.get_id(), vars->size());
       vars->conservativeResize(vars->size() + 1, Eigen::NoChange);
@@ -265,7 +264,7 @@ void DecomposeLinearExpression(
         get_exp_to_coeff_map_in_addition(e)};
     for (const pair<Expression, double>& p : exp_to_coeff_map) {
       if (is_variable(p.first)) {
-        const symbolic::Variable& var{get_variable(p.first)};
+        const Variable& var{get_variable(p.first)};
         const double coeff{p.second};
         const_cast<Eigen::MatrixBase<Derived>&>(coeffs)(
             0, map_var_to_index.at(var.get_id())) = coeff;
@@ -284,7 +283,7 @@ void DecomposeLinearExpression(
       if (!is_variable(p.first) || !is_one(p.second)) {
         throw SymbolicError(e, "is not linear");
       } else {
-        const symbolic::Variable& var = get_variable(p.first);
+        const Variable& var = get_variable(p.first);
         const_cast<Eigen::MatrixBase<Derived>&>(coeffs)(
             map_var_to_index.at(var.get_id())) = c;
         *constant_term = 0;
@@ -295,7 +294,7 @@ void DecomposeLinearExpression(
     }
   } else if (is_variable(e)) {
     // Just a single variable.
-    const symbolic::Variable& var{get_variable(e)};
+    const Variable& var{get_variable(e)};
     const_cast<Eigen::MatrixBase<Derived>&>(coeffs)(
         map_var_to_index.at(var.get_id())) = 1;
     *constant_term = 0;
@@ -471,8 +470,8 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
       if (map_base_to_exponent.size() == 1) {
         const pair<Expression, Expression>& p = *map_base_to_exponent.begin();
         if (!is_variable(p.first) || !is_one(p.second)) {
-          throw SymbolicError(
-              e_i, "non-linear but called with AddLinearConstraint");
+          throw SymbolicError(e_i,
+                              "non-linear but called with AddLinearConstraint");
         } else {
           const Variable& var_i = get_variable(p.first);
           if (v.size() == 1) {

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -20,7 +20,7 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 #include "drake/solvers/binding.h"
 #include "drake/solvers/constraint.h"
 #include "drake/solvers/decision_variable.h"
@@ -334,8 +334,7 @@ class MathematicalProgram {
    * The name of the variable is only used for the user for understand.
    */
   MatrixXDecisionVariable NewContinuousVariables(
-      size_t rows, size_t cols,
-      const std::vector<std::string>& names);
+      size_t rows, size_t cols, const std::vector<std::string>& names);
 
   /**
    * Adds continuous variables to this MathematicalProgram, with default name
@@ -344,8 +343,7 @@ class MathematicalProgram {
    * @see NewContinuousVariables(size_t rows, size_t cols, const
    * std::vector<std::string>& names);
    */
-  MatrixXDecisionVariable NewContinuousVariables(size_t rows,
-                                                 size_t cols,
+  MatrixXDecisionVariable NewContinuousVariables(size_t rows, size_t cols,
                                                  const std::string& name = "X");
 
   /// Adds continuous variables to this MathematicalProgram.
@@ -1352,7 +1350,7 @@ class MathematicalProgram {
    * @param var The decision variable.
    */
   std::shared_ptr<BoundingBoxConstraint> AddBoundingBoxConstraint(
-      double lb, double ub, const symbolic::Variable& var) {
+      double lb, double ub, const Variable& var) {
     MatrixDecisionVariable<1, 1> var_matrix(var);
     return AddBoundingBoxConstraint(drake::Vector1d(lb), drake::Vector1d(ub),
                                     var_matrix);
@@ -1371,7 +1369,7 @@ class MathematicalProgram {
 
   /**
    * Adds the same scalar lower and upper bound to every variable in @p vars.
-   * @tparam Derived An Eigen Vector type with symbolic::Variable as the scalar
+   * @tparam Derived An Eigen Vector type with Variable as the scalar
    * type.
    * @param lb Lower bound.
    * @param ub Upper bound.
@@ -1379,7 +1377,7 @@ class MathematicalProgram {
    */
   template <typename Derived>
   typename std::enable_if<
-      std::is_same<typename Derived::Scalar, symbolic::Variable>::value &&
+      std::is_same<typename Derived::Scalar, Variable>::value &&
           Derived::ColsAtCompileTime == 1,
       std::shared_ptr<BoundingBoxConstraint>>::type
   AddBoundingBoxConstraint(double lb, double ub,
@@ -1392,7 +1390,7 @@ class MathematicalProgram {
 
   /**
    * Adds the same scalar lower and upper bound to every variable in @p vars.
-   * @tparam Derived An Eigen::Matrix with symbolic::Variable as the scalar
+   * @tparam Derived An Eigen::Matrix with Variable as the scalar
    * type. The matrix has unknown number of columns at compile time, or has
    * more than one column.
    * @param lb Lower bound.
@@ -1401,7 +1399,7 @@ class MathematicalProgram {
    */
   template <typename Derived>
   typename std::enable_if<
-      std::is_same<typename Derived::Scalar, symbolic::Variable>::value &&
+      std::is_same<typename Derived::Scalar, Variable>::value &&
           Derived::ColsAtCompileTime != 1,
       std::shared_ptr<BoundingBoxConstraint>>::type
   AddBoundingBoxConstraint(double lb, double ub,
@@ -1411,7 +1409,7 @@ class MathematicalProgram {
                 Derived::ColsAtCompileTime != Eigen::Dynamic
             ? Derived::RowsAtCompileTime * Derived::ColsAtCompileTime
             : Eigen::Dynamic;
-    Eigen::Matrix<symbolic::Variable, kSize, 1> flat_vars(vars.size());
+    Eigen::Matrix<Variable, kSize, 1> flat_vars(vars.size());
     for (int j = 0; j < vars.cols(); ++j) {
       for (int i = 0; i < vars.rows(); ++i) {
         flat_vars(j * vars.rows() + i) = vars(i, j);
@@ -1962,7 +1960,7 @@ class MathematicalProgram {
    * @param var A decision variable in the program.
    * @param value The value of that decision variable.
    */
-  void SetDecisionVariableValue(const symbolic::Variable& var, double value);
+  void SetDecisionVariableValue(const Variable& var, double value);
 
   /**
    * Set an option for a particular solver.  This interface does not
@@ -2169,7 +2167,7 @@ class MathematicalProgram {
   }
 
   /** Returns the type of the decision variable. */
-  VarType DecisionVariableType(const symbolic::Variable& var) const;
+  VarType DecisionVariableType(const Variable& var) const;
 
   /** Getter for the initial guess */
   const Eigen::VectorXd& initial_guess() const { return x_initial_guess_; }
@@ -2190,20 +2188,19 @@ class MathematicalProgram {
    * @pre{@p var is a decision variable in the mathematical program, otherwise
    * this function asserts an error.}
    */
-  size_t FindDecisionVariableIndex(const symbolic::Variable& var) const;
+  size_t FindDecisionVariableIndex(const Variable& var) const;
 
   /**
    * Gets the solution of an Eigen matrix of decision variables.
-   * @tparam Derived An Eigen matrix containing symbolic::Variable.
+   * @tparam Derived An Eigen matrix containing Variable.
    * @param var The decision variables.
    * @return The value of the decision variable after solving the problem.
    */
   template <typename Derived>
   Eigen::Matrix<double, Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>
   GetSolution(const Eigen::MatrixBase<Derived>& var) const {
-    static_assert(
-        std::is_same<typename Derived::Scalar, symbolic::Variable>::value,
-        "The input should be an Eigen matrix of symbolic::Variable object.");
+    static_assert(std::is_same<typename Derived::Scalar, Variable>::value,
+                  "The input should be an Eigen matrix of Variable object.");
     Eigen::Matrix<double, Derived::RowsAtCompileTime,
                   Derived::ColsAtCompileTime>
         value(var.rows(), var.cols());
@@ -2220,7 +2217,7 @@ class MathematicalProgram {
   /**
    * Gets the value of a single decision variable.
    */
-  double GetSolution(const symbolic::Variable& var) const;
+  double GetSolution(const Variable& var) const;
 
   /**
    * Evaluate the constraint in the Binding at the solution value.
@@ -2242,14 +2239,14 @@ class MathematicalProgram {
   }
 
   /** Getter for the decision variable with index @p i in the program. */
-  const symbolic::Variable& decision_variable(int i) const {
+  const Variable& decision_variable(int i) const {
     return decision_variables_(i);
   }
 
  private:
   // maps the ID of a symbolic variable to the index of the variable stored in
   // the optimization program.
-  std::unordered_map<symbolic::Variable::Id, size_t> decision_variable_index_{};
+  std::unordered_map<Variable::Id, size_t> decision_variable_index_{};
 
   std::vector<VarType> decision_variable_type_;  // decision_variable_type_[i]
                                                  // stores the type of the
@@ -2331,7 +2328,7 @@ class MathematicalProgram {
     int row_index = 0;
     int col_index = 0;
     for (int i = 0; i < num_new_vars; ++i) {
-      decision_variables_(num_vars_ + i) = symbolic::Variable(names[i]);
+      decision_variables_(num_vars_ + i) = Variable(names[i]);
       const size_t new_var_index = num_vars_ + i;
       decision_variable_index_.insert(std::pair<size_t, size_t>(
           decision_variables_(new_var_index).get_id(), new_var_index));
@@ -2378,13 +2375,12 @@ class MathematicalProgram {
   /*
    * Given a matrix of decision variables, return true if every entry in the
    * matrix is a decision variable in the program; otherwise return false.
-   * @tparam  A Eigen::Matrix type of symbolic::Variable.
+   * @tparam  A Eigen::Matrix type of Variable.
    * @param vars A matrix of variable.
    */
   template <typename Derived>
   typename std::enable_if<
-      std::is_same<typename Derived::Scalar, symbolic::Variable>::value,
-      bool>::type
+      std::is_same<typename Derived::Scalar, Variable>::value, bool>::type
   IsDecisionVariable(const Eigen::MatrixBase<Derived>& vars) {
     for (int i = 0; i < vars.rows(); ++i) {
       for (int j = 0; j < vars.cols(); ++j) {

--- a/drake/solvers/test/binding_test.cc
+++ b/drake/solvers/test/binding_test.cc
@@ -8,9 +8,9 @@ namespace drake {
 namespace solvers {
 namespace test {
 GTEST_TEST(TestBinding, constructBinding) {
-  symbolic::Variable x1("x1");
-  symbolic::Variable x2("x2");
-  symbolic::Variable x3("x3");
+  Variable x1("x1");
+  Variable x2("x2");
+  Variable x3("x3");
   auto bb_con = std::make_shared<BoundingBoxConstraint>(
       Eigen::Vector3d::Zero(), Eigen::Vector3d::Ones());
 

--- a/drake/solvers/test/decision_variable_test.cc
+++ b/drake/solvers/test/decision_variable_test.cc
@@ -6,10 +6,10 @@ namespace drake {
 namespace solvers {
 namespace test {
 GTEST_TEST(TestDecisionVariable, TestVariableListRef) {
-  symbolic::Variable x1("x1");
-  symbolic::Variable x2("x2");
-  symbolic::Variable x3("x3");
-  symbolic::Variable x4("x4");
+  Variable x1("x1");
+  Variable x2("x2");
+  Variable x3("x3");
+  Variable x4("x4");
 
   VectorDecisionVariable<2> x_vec1(x3, x1);
   VectorDecisionVariable<2> x_vec2(x2, x4);

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -7,7 +7,7 @@
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_variable.h"
+#include "drake/common/variable.h"
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/constraint.h"
 #include "drake/solvers/mathematical_program.h"
@@ -216,7 +216,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable4) {
 
 template <typename Derived1, typename Derived2>
 typename std::enable_if<
-    std::is_same<typename Derived1::Scalar, symbolic::Variable>::value &&
+    std::is_same<typename Derived1::Scalar, Variable>::value &&
     std::is_same<typename Derived2::Scalar, double>::value>::type
 CheckGetSolution(const MathematicalProgram& prog,
                  const Eigen::MatrixBase<Derived1>& vars,

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -13,7 +13,6 @@ using Eigen::VectorXd;
 using Eigen::RowVectorXd;
 
 using std::numeric_limits;
-using drake::symbolic::Variable;
 using drake::symbolic::Expression;
 namespace drake {
 namespace solvers {
@@ -415,12 +414,12 @@ MinDistanceFromPlaneToOrigin::MinDistanceFromPlaneToOrigin(
       prog_rotated_lorentz_->NewContinuousVariables(kXdim, "x");
 
   switch (cost_form) {
-    case kNonSymbolicCost : {
+    case kNonSymbolicCost: {
       prog_lorentz_->AddLinearCost(Vector1d(1), t_lorentz_);
       prog_rotated_lorentz_->AddLinearCost(Vector1d(1), t_rotated_lorentz_);
       break;
     }
-    case kSymbolicCost : {
+    case kSymbolicCost: {
       prog_lorentz_->AddLinearCost(+t_lorentz_(0));
       prog_rotated_lorentz_->AddLinearCost(+t_rotated_lorentz_(0));
       break;

--- a/drake/solvers/test/optimization_examples.h
+++ b/drake/solvers/test/optimization_examples.h
@@ -29,7 +29,7 @@ class LinearSystemExample1 {
   virtual bool CheckSolution() const;
 
  protected:
-  double tol() const {return 1E-10;}
+  double tol() const { return 1E-10; }
 
  private:
   std::unique_ptr<MathematicalProgram> prog_;
@@ -118,7 +118,7 @@ class NonConvexQPproblem1 {
 
     template <typename ScalarType>
     void eval(detail::VecIn<ScalarType> const& x,
-        // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+              // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
               detail::VecOut<ScalarType>& y) const {
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
       DRAKE_ASSERT(static_cast<size_t>(y.rows()) == numOutputs());
@@ -181,7 +181,7 @@ class NonConvexQPproblem2 {
 
     template <typename ScalarType>
     void eval(detail::VecIn<ScalarType> const& x,
-        // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+              // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
               detail::VecOut<ScalarType>& y) const {
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
       DRAKE_ASSERT(static_cast<size_t>(y.rows()) == numOutputs());
@@ -199,7 +199,7 @@ class NonConvexQPproblem2 {
   void AddSymbolicConstraint();
 
   std::unique_ptr<MathematicalProgram> prog_;
-  Eigen::Matrix<symbolic::Variable, 6, 1> x_;
+  Eigen::Matrix<Variable, 6, 1> x_;
   Eigen::Matrix<double, 6, 1> x_expected_;
 };
 
@@ -240,7 +240,7 @@ class LowerBoundedProblem {
 
     template <typename ScalarType>
     void eval(detail::VecIn<ScalarType> const& x,
-        // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+              // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
               detail::VecOut<ScalarType>& y) const {
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
       DRAKE_ASSERT(static_cast<size_t>(y.rows()) == numOutputs());
@@ -291,7 +291,7 @@ class LowerBoundedProblem {
   void AddNonSymbolicConstraint();
 
   std::unique_ptr<MathematicalProgram> prog_;
-  Eigen::Matrix<symbolic::Variable, 6, 1> x_;
+  Eigen::Matrix<Variable, 6, 1> x_;
   Eigen::Matrix<double, 6, 1> x_expected_;
 };
 
@@ -344,7 +344,7 @@ class GloptiPolyConstrainedMinimizationProblem {
 
     template <typename ScalarType>
     void eval(detail::VecIn<ScalarType> const& x,
-        // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+              // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
               detail::VecOut<ScalarType>& y) const {
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
       DRAKE_ASSERT(static_cast<size_t>(y.rows()) == numOutputs());
@@ -381,8 +381,8 @@ class GloptiPolyConstrainedMinimizationProblem {
         Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>* y) const {
       y->resize(1);
       (*y)(0) = 24 - 20 * x(0) + 9 * x(1) - 13 * x(2) + 4 * x(0) * x(0) -
-             4 * x(0) * x(1) + 4 * x(0) * x(2) + 2 * x(1) * x(1) -
-             2 * x(1) * x(2) + 2 * x(2) * x(2);
+                4 * x(0) * x(1) + 4 * x(0) * x(2) + 2 * x(1) * x(1) -
+                2 * x(1) * x(2) + 2 * x(2) * x(2);
     }
   };
 
@@ -442,9 +442,7 @@ class MinDistanceFromPlaneToOrigin {
                                const Eigen::VectorXd& b, CostForm cost_form,
                                ConstraintForm cnstr_form);
 
-  MathematicalProgram* prog_lorentz() const {
-    return prog_lorentz_.get();
-  }
+  MathematicalProgram* prog_lorentz() const { return prog_lorentz_.get(); }
 
   MathematicalProgram* prog_rotated_lorentz() const {
     return prog_rotated_lorentz_.get();


### PR DESCRIPTION
 - Move `Variable`/`Variables`/`Environment` classes from `drake::symbolic` namespace to 'drake' namespace.
 - Rename `symbolic_variable.{h,cc}` => `variable.{h,cc}`, `symbolic_variables.{h,cc}` => `variables.{h,cc}`, `symbolic_environment.{h,cc}` => `environment.{h,cc}`
 - Fix Bazel `BUILD` file
 - Fix `CMakeLists.txt` files

Close https://github.com/RobotLocomotion/drake/issues/4884

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4953)
<!-- Reviewable:end -->
