### PR TITLE
Removes unused member variable "already_printed_warnings" from RigidBodyTree.

### DIFF
--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1539,7 +1539,6 @@ class RigidBodyTree {
   RigidBodyTree(const RigidBodyTree&);
   RigidBodyTree& operator=(const RigidBodyTree&) { return *this; }
 
-  std::set<std::string> already_printed_warnings;
   // TODO(SeanCurtis-TRI): This isn't properly used.
   // No query operations should work if it hasn't been initialized.  Calling
   // compile() is the only thing that should set this. Furthermore, any


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4954)
<!-- Reviewable:end -->
