### PR TITLE
Add a missing `using` to get the floating abs on OSX

### DIFF
--- a/drake/multibody/benchmarks/cylinder_torque_free_analytical_solution/test/cylinder_torque_free_analytical_solution.cc
+++ b/drake/multibody/benchmarks/cylinder_torque_free_analytical_solution/test/cylinder_torque_free_analytical_solution.cc
@@ -112,7 +112,8 @@ T CalculateQuaternionDtConstraintFromQuaternionDt(
 template <typename T>
 bool TestQuaternionDtConstraintFromQuaternionDt(
     const Eigen::Quaternion<T>& quat, const Vector4<T>& quatDt) {
-
+  using std::abs;
+  
   // For an accurate test, the quaternion should be reasonably accurate.
   const double double_epsilon = std::numeric_limits<double>::epsilon();
   const double tolerance = 800 * double_epsilon;

--- a/drake/multibody/benchmarks/cylinder_torque_free_analytical_solution/test/cylinder_torque_free_analytical_solution.cc
+++ b/drake/multibody/benchmarks/cylinder_torque_free_analytical_solution/test/cylinder_torque_free_analytical_solution.cc
@@ -113,7 +113,7 @@ template <typename T>
 bool TestQuaternionDtConstraintFromQuaternionDt(
     const Eigen::Quaternion<T>& quat, const Vector4<T>& quatDt) {
   using std::abs;
-  
+
   // For an accurate test, the quaternion should be reasonably accurate.
   const double double_epsilon = std::numeric_limits<double>::epsilon();
   const double tolerance = 800 * double_epsilon;


### PR DESCRIPTION
A missing `using std::abs` caused OSX to choose the integer absolute value rather than floating.

Fixes #4955.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4956)
<!-- Reviewable:end -->
