### PR TITLE
Add test for infinity norm for an autodiff type

### DIFF
--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -116,10 +116,43 @@ GTEST_TEST(BasicVectorTest, ReinitializeInvalid) {
 }
 
 // Tests the infinity norm computation
-GTEST_TEST(BasicVectorTest, InfNorm) {
+GTEST_TEST(BasicVectorTest, NormInf) {
   BasicVector<double> vec(2);
   vec.get_mutable_value() << 3, -4;
   EXPECT_EQ(vec.NormInf(), 4);
+}
+
+// Tests the infinity norm for an autodiff type.
+GTEST_TEST(BasicVectorTest, NormInfAutodiff) {
+  // Set up the device under test ("dut").
+  // The DUT is a vector with two values [-11.5, 22.5].
+  // The ∂/∂t of DUT is [1.5, 3.5] (where t is some arbitrary variable).
+  AutoDiffXd element0;
+  element0.value() = -11.5;
+  element0.derivatives() = Vector1d(1.5);
+  AutoDiffXd element1;
+  element1.value() = 22.5;
+  element1.derivatives() = Vector1d(3.5);
+  auto dut = BasicVector<AutoDiffXd>::Make({element0, element1});
+
+  // The norminf(DUT) is 22.5 and the ∂/∂t of norminf(DUT) is 3.5.
+  // The element1 has the max absolute value of the AutoDiffScalar's scalar.
+  // It is positive, so the sign of its derivatives remains unchanged.
+  AutoDiffXd expected_norminf;
+  expected_norminf.value() = 22.5;
+  expected_norminf.derivatives() = Vector1d(3.5);
+  EXPECT_EQ(dut->NormInf().value(), expected_norminf.value());
+  EXPECT_EQ(dut->NormInf().derivatives(), expected_norminf.derivatives());
+
+  // We change the DUT to two values [-11.5, -33.5] with ∂/∂t of [1.5, 3.5].
+  // The norminf(DUT) is now 33.5 and the ∂/∂t of norminf(DUT) is -3.5.
+  // The element0 has the max absolute value of the AutoDiffScalar's scalar.
+  // It is negative, so the sign of its derivatives gets flipped.
+  dut->GetAtIndex(0).value() = -33.5;
+  expected_norminf.value() = 33.5;
+  expected_norminf.derivatives() = Vector1d(-1.5);
+  EXPECT_EQ(dut->NormInf().value(), expected_norminf.value());
+  EXPECT_EQ(dut->NormInf().derivatives(), expected_norminf.derivatives());
 }
 
 // Tests all += * operations for BasicVector.


### PR DESCRIPTION
The purpose of #4006 was to get `NormInf` working with non-double types, but it did not have unit tests for non-double types.  This PR adds them retroactively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4959)
<!-- Reviewable:end -->
