### PR TITLE
Add missing lcm_FOUND guard around pose_estimation_test

### DIFF
--- a/drake/systems/estimators/dev/CMakeLists.txt
+++ b/drake/systems/estimators/dev/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-if (mosek_FOUND)
+if(lcm_FOUND AND mosek_FOUND)
   drake_add_cc_test(pose_estimation_test)
   target_link_libraries(pose_estimation_test drakeRBM drakeMultibodyParsers drakeOptimization lcm)
-endif(mosek_FOUND)
+endif()


### PR DESCRIPTION
I just happened to using a very strange combination of options.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4961)
<!-- Reviewable:end -->
