### PR TITLE
Python style -- assorted cleanups.

### DIFF
--- a/drake/bindings/python/pydrake/insource_path.py
+++ b/drake/bindings/python/pydrake/insource_path.py
@@ -1,4 +1,6 @@
 import os.path
 
+
 def getDrakePath():
-    return os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+    return os.path.realpath(
+        os.path.join(os.path.dirname(__file__), '..', '..', '..'))

--- a/drake/bindings/python/pydrake/test/testPR2IK.py
+++ b/drake/bindings/python/pydrake/test/testPR2IK.py
@@ -3,6 +3,7 @@ import numpy as np
 import pydrake
 from pydrake.solvers import ik
 
+
 def load_robot_from_urdf(urdf_file):
     """
     This function demonstrates how to pass a complete

--- a/drake/bindings/python/pydrake/test/testRBTCoM.py
+++ b/drake/bindings/python/pydrake/test/testRBTCoM.py
@@ -29,9 +29,10 @@ class TestRBTCoM(unittest.TestCase):
         kinsol = r.doKinematics(q, np.zeros((7, 1)))
         J = r.centerOfMassJacobian(kinsol)
 
-        self.assertTrue(np.allclose(J.flat, [1., 0., 0., 0., -0.2425, 0., -0.25,
-        0., 1., 0., 0.2425, 0., 0., 0.,
-        0., 0., 1., 0., 0., 0., 0.], atol=1e-4))
+        self.assertTrue(
+            np.allclose(J.flat, [1., 0., 0., 0., -0.2425, 0., -0.25,
+                                 0., 1., 0., 0.2425, 0., 0., 0.,
+                                 0., 0., 1., 0., 0., 0., 0.], atol=1e-4))
 
 
 if __name__ == '__main__':

--- a/drake/bindings/python/pydrake/test/testRBTIK.py
+++ b/drake/bindings/python/pydrake/test/testRBTIK.py
@@ -4,6 +4,7 @@ import pydrake
 from pydrake.solvers import ik
 import os.path
 
+
 class TestRBTIK(unittest.TestCase):
     def testPostureConstraint(self):
         r = pydrake.rbtree.RigidBodyTree(
@@ -14,14 +15,16 @@ class TestRBTIK(unittest.TestCase):
         posture_constraint.setJointLimits(np.array([[6]], dtype=np.int32),
                                           np.array([[q]]),
                                           np.array([[q]]))
-        # Choose a seed configuration (randomly) and a nominal configuration (at 0)
-        q_seed = np.vstack((np.zeros((6,1)),
+        # Choose a seed configuration (randomly) and a nominal configuration
+        # (at 0)
+        q_seed = np.vstack((np.zeros((6, 1)),
                             0.8147))
-        q_nom = np.vstack((np.zeros((6,1)),
-                       0.))
+        q_nom = np.vstack((np.zeros((6, 1)),
+                           0.))
 
         options = ik.IKoptions(r)
-        results = ik.InverseKin(r, q_seed, q_nom, [posture_constraint], options)
+        results = ik.InverseKin(
+            r, q_seed, q_nom, [posture_constraint], options)
         self.assertEqual(results.info[0], 1)
         self.assertAlmostEqual(results.q_sol[0][6], q, 1e-9)
 

--- a/drake/bindings/python/pydrake/test/testRBTTransformPoints.py
+++ b/drake/bindings/python/pydrake/test/testRBTTransformPoints.py
@@ -5,43 +5,50 @@ import pydrake
 from pydrake.autodiffutils import toAutoDiff
 import os.path
 
+
 class TestRBMForwardKin(unittest.TestCase):
     def test_value(self):
-        r = pydrake.rbtree.RigidBodyTree(os.path.join(pydrake.getDrakePath(), "examples/Pendulum/Pendulum.urdf"))
+        r = pydrake.rbtree.RigidBodyTree(
+            os.path.join(pydrake.getDrakePath(),
+                         "examples/Pendulum/Pendulum.urdf"))
         self.assertEqual(r.number_of_positions(), 7)
         self.assertEqual(r.number_of_velocities(), 7)
 
-        kinsol = r.doKinematics(np.zeros((7,1)), np.zeros((7,1)))
+        kinsol = r.doKinematics(np.zeros((7, 1)), np.zeros((7, 1)))
 
-        p = r.transformPoints(kinsol, np.zeros((3,1)), 0, 1)
-        self.assertTrue(np.allclose(p, np.zeros((3,1))))
+        p = r.transformPoints(kinsol, np.zeros((3, 1)), 0, 1)
+        self.assertTrue(np.allclose(p, np.zeros((3, 1))))
 
     def test_gradient(self):
-        r = pydrake.rbtree.RigidBodyTree(os.path.join(pydrake.getDrakePath(), "examples/Pendulum/Pendulum.urdf"))
+        r = pydrake.rbtree.RigidBodyTree(
+            os.path.join(pydrake.getDrakePath(),
+                         "examples/Pendulum/Pendulum.urdf"))
 
-        q = toAutoDiff(np.zeros((7,1)), np.eye(7, 7))
-        v = toAutoDiff(np.zeros((7,1)), np.zeros((7, 7)))
+        q = toAutoDiff(np.zeros((7, 1)), np.eye(7, 7))
+        v = toAutoDiff(np.zeros((7, 1)), np.zeros((7, 7)))
         kinsol = r.doKinematics(q, v)
 
-        point = np.ones((3,1))
+        point = np.ones((3, 1))
         p = r.transformPoints(kinsol, point, 2, 0)
-        self.assertTrue(np.allclose(p.value(), np.ones((3,1))))
+        self.assertTrue(np.allclose(p.value(), np.ones((3, 1))))
         self.assertTrue(np.allclose(p.derivatives(),
                                     np.array([[1, 0, 0, 0, 1, -1, 1],
                                               [0, 1, 0, -1, 0, 1, 0],
                                               [0, 0, 1, 1, -1, 0, -1]])))
 
     def test_big_gradient(self):
-        r = pydrake.rbtree.RigidBodyTree(os.path.join(pydrake.getDrakePath(), "examples/Pendulum/Pendulum.urdf"))
+        r = pydrake.rbtree.RigidBodyTree(
+            os.path.join(pydrake.getDrakePath(),
+                         "examples/Pendulum/Pendulum.urdf"))
 
-        q = toAutoDiff(np.zeros((7,1)), np.eye(7, 100))
-        v = toAutoDiff(np.zeros((7,1)), np.zeros((7, 100)))
+        q = toAutoDiff(np.zeros((7, 1)), np.eye(7, 100))
+        v = toAutoDiff(np.zeros((7, 1)), np.zeros((7, 100)))
         kinsol = r.doKinematics(q, v)
 
-        point = np.ones((3,1))
+        point = np.ones((3, 1))
         p = r.transformPoints(kinsol, point, 2, 0)
-        self.assertTrue(np.allclose(p.value(), np.ones((3,1))))
-        self.assertTrue(np.allclose(p.derivatives()[:3,:7],
+        self.assertTrue(np.allclose(p.value(), np.ones((3, 1))))
+        self.assertTrue(np.allclose(p.derivatives()[:3, :7],
                                     np.array([[1, 0, 0, 0, 1, -1, 1],
                                               [0, 1, 0, -1, 0, 1, 0],
                                               [0, 0, 1, 1, -1, 0, -1]])))
@@ -49,5 +56,3 @@ class TestRBMForwardKin(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-

--- a/drake/bindings/python/pydrake/test/test_urdf_parser.py
+++ b/drake/bindings/python/pydrake/test/test_urdf_parser.py
@@ -2,9 +2,12 @@ import unittest
 import pydrake
 import os.path
 
-# Tests that an instance of a URDF model can be loaded into a RigidBodyTree by
-# passing a complete set of arguments to Drake's URDF parser.
+
 class TestUrdfParser(unittest.TestCase):
+    """Test that an instance of a URDF model can be loaded into a
+    RigidBodyTree by passing a complete set of arguments to Drake's URDF
+    parser.
+    """
     def testAddModelInstanceFromUrdfStringSearchingInRosPackages(self):
         urdf_file = os.path.join(pydrake.getDrakePath(),
                                  "examples/PR2/pr2.urdf")
@@ -25,8 +28,8 @@ class TestUrdfParser(unittest.TestCase):
 
         expected_num_bodies = 83
         self.assertEqual(robot.get_num_bodies(), expected_num_bodies,
-            msg='Incorrect number of bodies: {0} vs. {1}'.format(
-                robot.get_num_bodies(), expected_num_bodies))
+                         msg='Incorrect number of bodies: {0} vs. {1}'.format(
+                             robot.get_num_bodies(), expected_num_bodies))
 
 if __name__ == '__main__':
     unittest.main()

--- a/drake/common/test/cpplint_wrapper.py
+++ b/drake/common/test/cpplint_wrapper.py
@@ -70,7 +70,7 @@ def multiprocess_cpplint(cmdline, files, args):
 
     # Lint the files N at a time, to amortize interpreter start-up.
     N = 10
-    files_groups = [files[i:i+N] for i in xrange(0, len(files), N)]
+    files_groups = [files[i:i + N] for i in xrange(0, len(files), N)]
     cmdlines = [cmdline + some_files for some_files in files_groups]
 
     # Farm out each chunk to a process in a Pool.

--- a/drake/examples/kuka_iiwa_arm/director_ik_app.py
+++ b/drake/examples/kuka_iiwa_arm/director_ik_app.py
@@ -21,14 +21,14 @@ class KukaSimInfoLabel(object):
         self.label = QtGui.QLabel('')
         statusBar.addPermanentWidget(self.label)
 
-        self.sub = lcmUtils.addSubscriber('IIWA_STATUS',
-                                  lcmdrake.lcmt_iiwa_status, self.onIiwaStatus)
+        self.sub = lcmUtils.addSubscriber(
+            'IIWA_STATUS', lcmdrake.lcmt_iiwa_status, self.onIiwaStatus)
         self.sub.setSpeedLimit(30)
 
         self.label.text = '[waiting for sim status]'
 
     def onIiwaStatus(self, msg):
-        simTime = msg.utime*1e-6
+        simTime = msg.utime * 1e-6
         simFreq = self.sub.getMessageRate()
         self.label.text = 'Sim freq: %d hz  |  Sim time: %.2f' % (simFreq,
                                                                   simTime)
@@ -38,7 +38,7 @@ def makeRobotSystem(view):
     factory = robotsystem.RobotSystemFactory()
     options = factory.getDisabledOptions()
     factory.setDependentOptions(options, usePlannerPublisher=True,
-                                         useTeleop=True)
+                                useTeleop=True)
     return factory.construct(view=view, options=options)
 
 
@@ -70,7 +70,7 @@ robotSystem.playbackPanel.animateOnExecute = True
 robotSystem.ikPlanner.getIkOptions().setProperty('Use pointwise', False)
 
 # set the default camera view
-applogic.resetCamera(viewDirection=[-1,0,0], view=app.view)
+applogic.resetCamera(viewDirection=[-1, 0, 0], view=app.view)
 
 # start!
 app.app.start()

--- a/drake/examples/kuka_iiwa_arm/kuka_iiwa_signal_scope.py
+++ b/drake/examples/kuka_iiwa_arm/kuka_iiwa_signal_scope.py
@@ -2,7 +2,6 @@ import numpy
 import colorsys
 
 
-
 addPlot(timeWindow=15, yLimits=[-3.14, 3.14])
 addSignals('IIWA_STATUS', msg.utime, msg.joint_position_measured, range(7))
 addSignals('IIWA_STATUS', msg.utime, msg.joint_position_commanded, range(7))
@@ -10,4 +9,3 @@ addSignals('IIWA_STATUS', msg.utime, msg.joint_position_commanded, range(7))
 
 addPlot(timeWindow=15, yLimits=[-3.14, 3.14])
 addSignals('IIWA_COMMAND', msg.utime, msg.joint_position, range(7))
-

--- a/drake/examples/kuka_iiwa_arm/kuka_iiwa_state_translator.py
+++ b/drake/examples/kuka_iiwa_arm/kuka_iiwa_state_translator.py
@@ -12,5 +12,6 @@ def onIiwaStatus(msg):
     lcmUtils.publish('EST_ROBOT_STATE', stateMsg)
 
 
-subscriber = lcmUtils.addSubscriber('IIWA_STATUS', lcmdrake.lcmt_iiwa_status, onIiwaStatus)
+subscriber = lcmUtils.addSubscriber(
+    'IIWA_STATUS', lcmdrake.lcmt_iiwa_status, onIiwaStatus)
 consoleapp.ConsoleApp.start()


### PR DESCRIPTION
This PR cleans up the remaining PEP8 (and in a few cases, PEP257) issues in checked-in drake python files, neglecting **/dev/ and thirdParty/.  These changes clear the way to (limited) automated checking of python style.

I have done my best to limit the changes to mechanical white-space and comment changes only.

These are mostly files with which I am unfamiliar -- if any are obsolete and/or better deleted than maintained, let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4962)
<!-- Reviewable:end -->
