### PR TITLE
Add support for IPOPT on Mac by pinning to a specific GCC version.

### DIFF
--- a/drake/doc/mac.rst
+++ b/drake/doc/mac.rst
@@ -19,8 +19,9 @@ Install the prerequisites::
     brew tap-pin robotlocomotion/director
     brew update
     brew upgrade
-    brew install autoconf automake cmake doxygen gcc glib graphviz gtk+ jpeg \
+    brew install autoconf automake cmake doxygen gcc5 glib graphviz gtk+ jpeg \
       libpng libtool libyaml mpfr ninja numpy python qt qwt valgrind vtk5 wget
+    brew pin gcc5
     pip install -U beautifulsoup4 html5lib lxml PyYAML Sphinx
 
 Add the line::

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -55,7 +55,7 @@ cc_library(
 # - equality_constrained_qp_solver
 # - linear_system_solver
 # - moby_lcp_solver
-# - IPOPT (on Ubuntu only)
+# - IPOPT
 # - Gurobi (on Ubuntu only)
 
 # Unsupported solvers:
@@ -174,23 +174,15 @@ cc_library(
 
 cc_library(
     name = "ipopt_solver",
-    srcs = select({
-        "//tools:apple": ["no_ipopt.cc"],
-        "//tools:linux": ["ipopt_solver.cc"],
-    }),
+    srcs = ["ipopt_solver.cc"],
     hdrs = ["ipopt_solver.h"],
     linkstatic = 1,
     visibility = ["//visibility:private"],
-    deps = select({
-        "//tools:linux": [
-            "@ipopt//:lib",
-            ":mathematical_program_api",
-            "//drake/math:autodiff",
-        ],
-        "//tools:apple": [
-            ":mathematical_program_api",
-        ],
-    }),
+    deps = [
+         "@ipopt//:lib",
+         ":mathematical_program_api",
+         "//drake/math:autodiff",
+    ],
 )
 
 # === test/ ===


### PR DESCRIPTION
This makes it possible to locate `libgfortran.a` on Mac, since Homebrew doesn't install or symlink it to a canonical location.  It would be much better to use `pkg-config`, but Homebrew doesn't install a .pc file.  It would also be much better to interrogate `gfortran` directly, as IPOPT itself does, but Bazel apparently provides no mechanism to use the results of a shell command as linker arguments to a `cc_library` rule.

@soonho-tri for feature review; could you test locally please?

@jamiesnape @BetsyMcPhail The OS X images in CI should be updated to pin gcc 5.4, instead of tracking the head of gcc.  Aside and apart from the Bazel issue, I think it's saner to use a version of gfortran on Mac that's consistent with the project's other uses of gcc.

Also, if anyone knows of a way to make `brew pin` more precise, that would be great.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4970)
<!-- Reviewable:end -->
