### PR TITLE
Add python_headers to WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -190,3 +190,12 @@ github_archive(
 load("@org_pubref_rules_protobuf//python:rules.bzl",
      "py_proto_repositories")
 py_proto_repositories()
+
+# The "@python_headers//:python_headers" target is required by protobuf_python
+# during "bazel query" but not "bazel build", so a stub is fine.
+new_local_repository(
+    name = "python_headers",
+    path = "not/real/stub",
+    build_file_content = ("cc_library(name = 'python_headers', " +
+                          "visibility = ['//visibility:public'])")
+)


### PR DESCRIPTION
This allows `bazel query` to work again -- without this we get:
```
ERROR: .../external/protobuf_python/BUILD:574:1:
no such target '//external:python_headers':
target 'python_headers' not declared in package 'external'
defined by /home/jwnimmer/jwnimmer-tri/drake-distro/WORKSPACE
and referenced by '@protobuf_python//:internal/_api_implementation.so'.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4973)
<!-- Reviewable:end -->
