### PR TITLE
Revert "Fixes bug in rigid body velocity<->quaternion time derivative mapping"

### DIFF
--- a/drake/matlab/systems/plants/joints/test/CMakeLists.txt
+++ b/drake/matlab/systems/plants/joints/test/CMakeLists.txt
@@ -1,4 +1,7 @@
-# Disabling this test because no indications of failure are given (only an
-# exception is thrown), and it appears to conflict with the accepted
-# solution for the qdot to angular velocity conversions (which have been
-# validated using an analytical solution). 
+if(Matlab_FOUND)
+  drake_add_mex(testDrakeJointsmex testDrakeJointsmex.cpp)
+  target_link_libraries(testDrakeJointsmex drakeJoints drakeMexUtil)
+endif()
+
+drake_add_matlab_test(NAME systems/plants/joints/test/testDrakeJointsComparison COMMAND testDrakeJointsComparison)
+

--- a/drake/matlab/systems/plants/test/CMakeLists.txt
+++ b/drake/matlab/systems/plants/test/CMakeLists.txt
@@ -47,6 +47,7 @@ drake_add_matlab_test(NAME systems/plants/test/testFloatingBaseDynamics OPTIONAL
 drake_add_matlab_test(NAME systems/plants/test/testFloatingMassSpringDamperForceGradients OPTIONAL bullet COMMAND testFloatingMassSpringDamperForceGradients)
 drake_add_matlab_test(NAME systems/plants/test/testForwardJacDotTimesV OPTIONAL bullet COMMAND testForwardJacDotTimesV)
 drake_add_matlab_test(NAME systems/plants/test/testForwardKinRot OPTIONAL bullet COMMAND testForwardKinRot)
+drake_add_matlab_test(NAME systems/plants/test/testGeometricJacobian OPTIONAL bullet COMMAND testGeometricJacobian)
 drake_add_matlab_test(NAME systems/plants/test/testGeometricJacobianDotTimesV OPTIONAL bullet COMMAND testGeometricJacobianDotTimesV)
 drake_add_matlab_test(NAME systems/plants/test/testGeometricJacobianDotV OPTIONAL bullet COMMAND testGeometricJacobianDotV)
 drake_add_matlab_test(NAME systems/plants/test/testGradients OPTIONAL bullet COMMAND testGradients)

--- a/drake/multibody/benchmarks/cylinder_torque_free_analytical_solution/test/cylinder_torque_free_analytical_solution.cc
+++ b/drake/multibody/benchmarks/cylinder_torque_free_analytical_solution/test/cylinder_torque_free_analytical_solution.cc
@@ -422,7 +422,7 @@ void  TestMapVelocityToQDot(
   // TODO(Mitiguy and Drumwright) change tolerance to 50*epsilon with PR #4604.
   //--------------------------------------------------------------
   const double epsilon = std::numeric_limits<double>::epsilon();
-  const double tolerance = 50 * epsilon;
+  const double tolerance = 1.0E17 * epsilon;
   EXPECT_TRUE(CompareMatrices(xyzDt_map,      xyzDt_exact, tolerance));
   EXPECT_TRUE(CompareMatrices(quatDt_map, quatDt_NB_exact, tolerance));
 }
@@ -462,7 +462,7 @@ void  TestMapQDotToVelocity(
   // TODO(Mitiguy and Drumwright) change tolerance to 50*epsilon with PR #4604.
   //--------------------------------------------------------------
   const double epsilon = std::numeric_limits<double>::epsilon();
-  const double tolerance = 50 * epsilon;
+  const double tolerance = 1.0E17 * epsilon;
   EXPECT_TRUE(CompareMatrices(w_map,  w_NB_B_exact, tolerance));
   EXPECT_TRUE(CompareMatrices(v_map, v_NBo_B_exact, tolerance));
 }

--- a/drake/multibody/joints/drake_joint.h
+++ b/drake/multibody/joints/drake_joint.h
@@ -102,17 +102,17 @@ class DrakeJoint {
   virtual ~DrakeJoint();
 
   /**
-   * Returns the transform `X_PF` giving the pose of the joint's "fixed" frame
+   * Returns the transform `T_PF` giving the pose of the joint's "fixed" frame
    * `F` in its parent body frame `P`. Frame `F` is the joint frame that is
-   * fixed to the parent body; thus `X_PF` is not configuration dependent.
+   * fixed to the parent body; thus `T_PF` is not configuration dependent.
    *
-   * To clarify the sense of the returned transform `X_PF`, consider the
+   * To clarify the sense of the returned transform `T_PF`, consider the
    * location of a point `Q` somewhere in space. Let `p_PQ` be point `Q`
    * measured and expressed in frame `P` and `p_FQ` be point `Q` measured and
    * expressed in frame `F`. Then `p_PQ` is given by:
    *
    * <pre>
-   * p_PQ = X_PF * p_FQ
+   * p_PQ = T_PF * p_FQ
    * </pre>
    */
   const Eigen::Isometry3d& get_transform_to_parent_body() const;

--- a/drake/multibody/joints/quaternion_floating_joint.h
+++ b/drake/multibody/joints/quaternion_floating_joint.h
@@ -12,66 +12,6 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
-// TODO(sherm1,mitiguy) Verify that this is correct.
-/**
- * Defines a 6 dof tree joint (mobilizer) that uses a unit quaternion as the
- * generalized orientation coordinates.
- *
- * <h3>Generalized coordinates (configuration variables)</h3>
- * There are 7 generalized coordinates q,
- * organized as a position vector and quaternion. A tree joint connects an
- * inboard (parent) body P to an outboard (child) body B. In those terms this
- * joint's generalized coordinates are: <pre>
- *          --------- ------------- T
- *     q = | p_PB_P  |    q_PB     |
- *          --------- -------------  7×1
- *          px py pz   qw qx qy qz
- * </pre>
- * where `p_PB_P` is the position vector from P's origin Po to B's origin Bo,
- * expressed in the P basis, and `q_PB` is the quaternion that is equivalent
- * to the rotation matrix `R_PB`. The second line shows the 7 generalized
- * coordinate scalars in order. Note that `qw` is the scalar part of the
- * quaternion while `[qx qy qz]` is the vector part. See
- * @ref multibody_spatial_pose for more  information about this notation.
- *
- * The time derivatives qdot of the generalized coordinates, _not_ to be
- * confused with the generalized velocity variables v, are: <pre>
- *          --------- ------------- T
- *  qdot = | v_PB_P  |   qdot_PB   |
- *          --------- -------------  7×1
- * </pre>
- * where `v_PB_P = d_P/dt p_PB_P` is the velocity of point Bo measured and
- * expressed in the P frame, where we have emphasized that the derivative is
- * taken in P, and `qdot_PB = d/dt q_PB` is the time derivative of the
- * quaternion.
- *
- * <h3>Generalized velocity</h3>
- * There are 6 generalized velocity variables v, organized as follows: <pre>
- *          --------- -------- T
- *     v = | ω_PB_B  | v_PB_B |
- *          --------- --------  6×1
- * </pre>
- * where `ω_PB_B` is B's angular velocity in P, expressed in B, and
- * `v_PB_B` is point Bo's translational velocity in P, expressed in B.
- *
- * Note that
- * the rotational and translational quantities are in the reverse order from
- * those in the generalized coordinates, and that the velocities are expressed
- * in the _child_ frame B rather than in the parent. Clearly these are _not_
- * the derivatives of the generalized coordinates!
- *
- * The time derivatives of the generalized velocities are: <pre>
- *          --------- ----------- T
- *  vdot = | α_PB_B  | vdot_PB_B |
- *          --------- -----------  6×1
- * </pre>
- * where `α_PB_B` is B's angular acceleration in P, expressed in B, and
- * `vdot_PB_B = d_B/dt v_PB_B` where we have emphasized that the derivative is
- * taken in the B frame, so this is *not* the acceleration of Bo in P. That
- * acceleration is given by `a_PB_B = vdot_PB_B + ω_PB_B × v_PB_B` (still in B).
- * Re-expressing `a_PB_B` in P provides the configuration second derivative
- * `a_PB_P = d²_P/dt² p_PB_P = R_PB*a_PB_B`.
- */
 class QuaternionFloatingJoint : public DrakeJointImpl<QuaternionFloatingJoint> {
  public:
   QuaternionFloatingJoint(const std::string& name,
@@ -80,9 +20,6 @@ class QuaternionFloatingJoint : public DrakeJointImpl<QuaternionFloatingJoint> {
 
   virtual ~QuaternionFloatingJoint() {}
 
-  /** Returns the transform `X_PB(q)` where P is the parent body and B the
-   * child body connected by this joint.
-   */
   template <typename DerivedQ>
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
   jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
@@ -129,41 +66,6 @@ class QuaternionFloatingJoint : public DrakeJointImpl<QuaternionFloatingJoint> {
     }
   }
 
-  /**
-   * For the %QuaternionFloatingJoint, computes the matrix `N⁺(q)`∊ℝ⁶ˣ⁷ that
-   * maps generalized coordinate time derivatives qdot to generalized
-   * velocities v, with `v=N⁺ qdot`. The name signifies that `N⁺=pinv(N)` where
-   * `N(q)` is the matrix that maps v to qdot with `qdot=N v` and `pinv()`
-   * is the pseudoinverse (in this case the left pseudoinverse).
-   *
-   * See the class description for precise definitions of the generalized
-   * coordinates and velocities. Because the velocities are not the time
-   * derivatives of the coordinates, rotations and translations are
-   * reversed, and different expressed-in frames are employed, `N⁺` has the
-   * following elaborate structure: <pre>
-   *        -------- -----------
-   *       |  0₃ₓ₃  | Nq⁺_PB_B  |
-   *  N⁺ = |--------|-----------|
-   *       |  R_BP  |   0₃ₓ₄    |
-   *        -------- ----------- 6×7
-   * </pre>
-   * where `Nq_PB_B` is the matrix that maps angular velocity `ω_PB_B` to
-   * quaternion time derivative `qdot_PB` such that `qdot_PB=Nq_PB_B*ω_PB_B`,
-   * and `Nq⁺_PB_B` is the left pseudoinverse of `Nq_PB_B`.
-   *
-   * @param[in]  q The 7-element generalized configuration variable. See the
-   *   class documentation for details. See warning below regarding the effect
-   *   if the contained quaternion is not normalized.
-   * @param[out] qdot_to_v The matrix `N⁺`.
-   * @param      dqdot_to_v Unused, must be `nullptr` on entry.
-   *
-   * @warning Let `s` be the norm of the quaternion in `q`. If `s ≠ 1`, then
-   * we will calculate `s*Nq⁺_PB_B` in the upper right block of `N⁺` so the
-   * resulting angular velocity vector will be scaled by `s` as well. This
-   * method neither performs a normalization check nor normalizes the quaternion
-   * orientation parameters. Implications for integration techniques must be
-   * carefully considered.
-   */
   template <typename DerivedQ>
   void qdot2v(const Eigen::MatrixBase<DerivedQ>& q,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
@@ -177,76 +79,24 @@ class QuaternionFloatingJoint : public DrakeJointImpl<QuaternionFloatingJoint> {
     }
 
     qdot_to_v.resize(get_num_velocities(), get_num_positions());
-
-    // Get the quaternion values.
+    typedef typename DerivedQ::Scalar Scalar;
     auto quat =
         q.template middleRows<drake::kQuaternionSize>(drake::kSpaceDimension);
-    const auto& ew = quat[0];
-    const auto& ex = quat[1];
-    const auto& ey = quat[2];
-    const auto& ez = quat[3];
-
-    // Assume that the quaternion orientation (e) gives a transformation matrix
-    // that re-expresses vectors from some frame B to some frame N. The upper
-    // right hand block of the transformation matrix represents
-    // the 2 L part of the relationship ω = 2 L de/dt, where
-    // e = [ ew ex ey ez ] are the quaternion values and ω is an angular
-    // velocity given in frame B. The relationship ω = 2 L de/dt and the
-    // matrix L was taken from:
-    // - P. Nikravesh, Computer-Aided Analysis of Mechanical Systems. Prentice
-    //     Hall, New Jersey, 1988. Equation 6.108.
-    // NOTE: the torque-free, cylindrical solid unit test successfully detects
-    //       when this matrix (incorrectly) is set to that which transforms
-    //       unit quaternion time derivatives to angular velocities in the
-    //       global frame.
-    qdot_to_v.template block<3, 3>(0, 0).setZero();
-    qdot_to_v.template block<3, 4>(0, 3) <<  -ex,  ew,  ez, -ey,
-                                             -ey, -ez,  ew,  ex,
-                                             -ez,  ey, -ex,  ew;
-    qdot_to_v.template block<3, 4>(0, 3) *= 2.;
-
-    // Given the arbitrary frames B and N described above, the next three
-    // columns re-express linear velocities from frame N to frame B.
     auto R = drake::math::quat2rotmat(quat);
+
+    Eigen::Matrix<Scalar, 4, 1> quattilde;
+    typename drake::math::Gradient<Eigen::Matrix<Scalar, 4, 1>,
+                                   drake::kQuaternionSize,
+                                   1>::type dquattildedquat;
+    drake::math::NormalizeVector(quat, quattilde, &dquattildedquat);
+    auto RTransposeM = (R.transpose() * quatdot2angularvelMatrix(quat)).eval();
+    qdot_to_v.template block<3, 3>(0, 0).setZero();
+    qdot_to_v.template block<3, 4>(0, 3).noalias() =
+        RTransposeM * dquattildedquat;
     qdot_to_v.template block<3, 3>(3, 0) = R.transpose();
     qdot_to_v.template block<3, 4>(3, 3).setZero();
   }
 
-
-  /**
-   * For the %QuaternionFloatingJoint, computes the matrix `N(q)`∊ℝ⁷ˣ⁶ that
-   * maps generalized velocities v to generalized coordinate time derivatives
-   * qdot, with `qdot=N v`.
-   *
-   * See the class description for precise definitions of the generalized
-   * coordinates and velocities. Because the velocities are not the time
-   * derivatives of the coordinates, rotations and translations are
-   * reversed, and different expressed-in frames are employed, `N` has the
-   * following elaborate structure: <pre>
-   *        ------- ------
-   *       |  0₃ₓ₃ | R_PB |
-   *       |-------|------|
-   *   N = |       |      |
-   *       |Nq_PB_B| 0₄ₓ₃ |
-   *       |       |      |
-   *        -------------- 7×6
-   * </pre>
-   * where `Nq_PB_B` is the matrix that maps angular velocity `ω_PB_B` to
-   * quaternion time derivative `qdot_PB` such that `qdot_PB=Nq_PB_B*ω_PB_B`.
-   *
-   * @param[in]  q The 7-element generalized configuration variable. See the
-   *   class documentation for details. See warning below regarding the effect
-   *   if the contained quaternion is not normalized.
-   * @param[out] v_to_qdot The matrix `N`.
-   * @param      dv_to_qdot Unused, must be `nullptr` on entry.
-   *
-   * @warning Let `s` be the norm of the quaternion in `q`. If `s ≠ 1`, then
-   * we will calculate `s*Nq_PB_B` in the lower left block of `N` so the
-   * resulting quaternion derivative will be scaled by `s` as well. This
-   * method neither performs a normalization check nor normalizes the quaternion
-   * orientation parameters. Implications for integration techniques must be
-   * carefully considered.
-   */
   template <typename DerivedQ>
   void v2qdot(const Eigen::MatrixBase<DerivedQ>& q,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
@@ -255,40 +105,39 @@ class QuaternionFloatingJoint : public DrakeJointImpl<QuaternionFloatingJoint> {
                             DrakeJoint::MAX_NUM_VELOCITIES>& v_to_qdot,
               Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic,
                             Eigen::Dynamic>* dv_to_qdot) const {
+    typedef typename DerivedQ::Scalar Scalar;
     v_to_qdot.resize(get_num_positions(), get_num_velocities());
 
-    if (dv_to_qdot) {
-      throw std::runtime_error("no longer supported");
-    }
-
-    // Get the quaternion values.
     auto quat =
         q.template middleRows<drake::kQuaternionSize>(drake::kSpaceDimension);
-    const auto& ew = quat[0];
-    const auto& ex = quat[1];
-    const auto& ey = quat[2];
-    const auto& ez = quat[3];
+    auto R = drake::math::quat2rotmat(quat);
 
-    // Assume that the quaternion orientation (e) gives a transformation matrix
-    // that re-expresses vectors from some frame B to some frame N. The upper
-    // right hand block of the tranfsormation matrix corresponds to the
-    // transpose of the "L" matrix used in qdot2v(). Specifically, this matrix
-    // represents the 1/2 Lᵀ part of the relationship de/dt = 1/2 Lᵀω, where
-    // e = [ ew ex ey ez ] are the quaternion values and ω is an angular
-    // velocity given in frame B. The relationship de/dt = 1/2 Lᵀω and the
-    // matrix L was taken from:
-    // - P. Nikravesh, Computer-Aided Analysis of Mechanical Systems. Prentice
-    //     Hall, New Jersey, 1988. Equation 6.109.
-    v_to_qdot.template block<4, 3>(0, 0).setZero();
-    v_to_qdot.template block<4, 3>(3, 0) <<  -ex, -ey, -ez,
-                                              ew, -ez,  ey,
-                                              ez,  ew, -ex,
-                                             -ey,  ex,  ew;
-    v_to_qdot.template block<4, 3>(3, 0) *= 0.5;
+    Eigen::Matrix<Scalar, drake::kQuaternionSize, drake::kSpaceDimension> M;
+    if (dv_to_qdot) {
+      auto dR = drake::math::dquat2rotmat(quat);
+      typename drake::math::Gradient<decltype(M), drake::kQuaternionSize,
+                                     1>::type dM;
+      angularvel2quatdotMatrix(quat, M, &dM);
 
-    // Given the arbitrary frames B and N described above, the next three
-    // columns re-express linear velocities from frame B to frame N.
-    v_to_qdot.template block<3, 3>(0, 3) = drake::math::quat2rotmat(quat);
+      dv_to_qdot->setZero(v_to_qdot.size(), get_num_positions());
+
+      using drake::math::setSubMatrixGradient;
+      using drake::math::intRange;
+      setSubMatrixGradient<4>(*dv_to_qdot, dR, intRange<3>(0), intRange<3>(3),
+                              v_to_qdot.rows(), 3);
+      auto dMR = drake::math::matGradMultMat(M, R, dM, dR);
+      setSubMatrixGradient<4>(*dv_to_qdot, dMR, intRange<4>(3), intRange<3>(0),
+                              v_to_qdot.rows(), 3);
+    } else {
+      angularvel2quatdotMatrix(
+          quat, M,
+          (typename drake::math::Gradient<decltype(M), drake::kQuaternionSize,
+                                          1>::type*)nullptr);
+    }
+
+    v_to_qdot.template block<3, 3>(0, 0).setZero();
+    v_to_qdot.template block<3, 3>(0, 3) = R;
+    v_to_qdot.template block<4, 3>(3, 0).noalias() = M * R;
     v_to_qdot.template block<4, 3>(3, 3).setZero();
   }
 

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -523,8 +523,19 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
   prog.Solve();
 
   VectorX<T> xdot(get_num_states());
+
+  /*
+   * TODO(hongkai.dai): This only works for templates on double, it does not
+   * work for autodiff yet, I will add the code to compute the gradient of vdot
+   * w.r.t. q and v. See issue
+   * https://github.com/RobotLocomotion/drake/issues/4267.
+   */
+  // TODO(amcastro-tri): Remove .eval() below once RigidBodyTree is fully
+  // templatized.
   const auto& vdot_value = prog.GetSolution(vdot);
-  xdot << tree_->transformVelocityToQDot(kinsol, v), vdot_value;
+  xdot << tree_->transformQDotMappingToVelocityMapping(
+      kinsol, MatrixX<T>::Identity(nq, nq).eval()) * v, vdot_value;
+
   derivatives->SetFromVector(xdot);
 }
 
@@ -544,7 +555,7 @@ int RigidBodyPlant<T>::FindInstancePositionIndexFromWorldIndex(
 template <typename T>
 void RigidBodyPlant<T>::DoMapQDotToVelocity(
     const Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& qdot,
+    const Eigen::Ref<const VectorX<T>>& configuration_dot,
     VectorBase<T>* generalized_velocity) const {
   // TODO(amcastro-tri): provide nicer accessor to an Eigen representation for
   // LeafSystems.
@@ -556,7 +567,7 @@ void RigidBodyPlant<T>::DoMapQDotToVelocity(
   const int nv = get_num_velocities();
   const int nstates = get_num_states();
 
-  DRAKE_ASSERT(qdot.size() == nq);
+  DRAKE_ASSERT(configuration_dot.size() == nq);
   DRAKE_ASSERT(generalized_velocity->size() == nv);
   DRAKE_ASSERT(x.size() == nstates);
 
@@ -572,7 +583,8 @@ void RigidBodyPlant<T>::DoMapQDotToVelocity(
   // TODO(amcastro-tri): Remove .eval() below once RigidBodyTree is fully
   // templatized.
   generalized_velocity->SetFromVector(
-      tree_->transformQDotToVelocity(kinsol, qdot));
+      tree_->transformQDotMappingToVelocityMapping(
+          kinsol, configuration_dot.transpose().eval()).transpose());
 }
 
 template <typename T>
@@ -604,7 +616,11 @@ void RigidBodyPlant<T>::DoMapVelocityToQDot(
   // reused.
   auto kinsol = tree_->doKinematics(q, v);
 
-  configuration_dot->SetFromVector(tree_->transformVelocityToQDot(kinsol, v));
+  // TODO(amcastro-tri): Remove .eval() below once RigidBodyTree is fully
+  // templatized.
+  configuration_dot->SetFromVector(
+      tree_->transformVelocityMappingToQDotMapping(
+          kinsol, v.transpose().eval()).transpose());
 }
 
 template <typename T>

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -69,8 +69,9 @@ GTEST_TEST(RigidBodyPlantTest, TestLoadUrdf) {
 // Tests the generalized velocities to generalized coordinates time
 // derivatives for a free body with a quaternion base.
 GTEST_TEST(RigidBodyPlantTest, MapVelocityToConfigurationDerivativesAndBack) {
-  const double kTol = 5e-12;     // Loosest tolerance that all tests succeed.
-  const int kNumPositions = 7;   // One quaternion + 3d position.
+  const double kTol = 1e-10;     // Test succeeds at one order of magnitude
+                                 // greater tolerance on my machine.
+  const int kNumPositions = 7;   // One quaternion + 3D position.
   const int kNumVelocities = 6;  // Angular velocity + linear velocity.
   const int kNumStates = kNumPositions + kNumVelocities;
 
@@ -129,7 +130,7 @@ GTEST_TEST(RigidBodyPlantTest, MapVelocityToConfigurationDerivativesAndBack) {
   EXPECT_EQ(v0[1], positions_derivatives.GetAtIndex(1));
   EXPECT_EQ(v0[2], positions_derivatives.GetAtIndex(2));
 
-  // Loop over roll-pitch-yaw values: this will run approximately 1,000 tests.
+  // Loop over roll-pitch-yaw values. This will run approximately 1,000 tests.
   const double kAngleInc = 10.0 * M_PI / 180.0;  // 10 degree increments
   for (double roll = 0; roll <= M_PI_2; roll += kAngleInc) {
     for (double pitch = 0; pitch <= M_PI_2; pitch += kAngleInc) {
@@ -160,18 +161,15 @@ GTEST_TEST(RigidBodyPlantTest, MapVelocityToConfigurationDerivativesAndBack) {
         // derivative code is correct. See #4121.
 
         // Test q * qdot near zero.
-         Quaterniond qdot(positions_derivatives.GetAtIndex(3),
-                          positions_derivatives.GetAtIndex(4),
-                          positions_derivatives.GetAtIndex(5),
-                          positions_derivatives.GetAtIndex(6));
-        DRAKE_ASSERT(std::abs(q.dot(qdot)) < 1e-15);
+        // Quaterniond qdot(xc->GetAtIndex(3), xc->GetAtIndex(4),
+        //                  xc->GetAtIndex(5), xc->GetAtIndex(6));
+        // DRAKE_ASSERT(std::abs(q.dot(qdot)) < 1e-14);
 
         // Map time derivative of generalized configuration back to generalized
         // velocity.
         plant.MapQDotToVelocity(*context, positions_derivatives,
                                 &generalized_velocities);
 
-        // Ordering is angular velocities first, linear velocities second.
         EXPECT_NEAR(w0[0], generalized_velocities.GetAtIndex(0), kTol);
         EXPECT_NEAR(w0[1], generalized_velocities.GetAtIndex(1), kTol);
         EXPECT_NEAR(w0[2], generalized_velocities.GetAtIndex(2), kTol);

--- a/drake/multibody/rigid_body_system1/RigidBodySystem.cpp
+++ b/drake/multibody/rigid_body_system1/RigidBodySystem.cpp
@@ -268,8 +268,14 @@ RigidBodySystem::StateVector<double> RigidBodySystem::dynamics(
 
   StateVector<double> dot(nq + nv);
 
+  // TODO(amcastro-tri): Remove .eval() below once RigidBodyTree is fully
+  // templatized.
   Eigen::VectorXd vdot_value = prog.GetSolution(vdot);
-  dot << tree->transformVelocityToQDot(kinsol, v), vdot_value;
+  dot << tree->transformQDotMappingToVelocityMapping(kinsol,
+             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>::Identity(
+                 nq, nq).eval()) *
+             v,
+      vdot_value;
   return dot;
 }
 

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -1482,41 +1482,6 @@ Eigen::Matrix<Scalar, kSpaceDimension, 1> RigidBodyTree<T>::centerOfMass(
 }
 
 template <typename T>
-VectorX<T> RigidBodyTree<T>::transformVelocityToQDot(
-    const KinematicsCache<T>& cache,
-    const VectorX<T>& v) {
-  VectorX<T> qdot(cache.get_num_positions());
-  int qdot_start = 0;
-  int v_start = 0;
-  for (int body_id = 0; body_id < cache.get_num_cache_elements(); ++body_id) {
-    const auto& element = cache.get_element(body_id);
-    qdot.segment(qdot_start, element.get_num_positions()).noalias() =
-        element.v_to_qdot * v.segment(v_start, element.get_num_velocities());
-    qdot_start += element.get_num_positions();
-    v_start += element.get_num_velocities();
-  }
-  return qdot;
-}
-
-template <typename T>
-VectorX<T> RigidBodyTree<T>::transformQDotToVelocity(
-    const KinematicsCache<T>& cache,
-    const VectorX<T>& qdot) {
-  VectorX<T> v(cache.get_num_velocities());
-  int qdot_start = 0;
-  int v_start = 0;
-  for (int body_id = 0; body_id < cache.get_num_cache_elements(); ++body_id) {
-    const auto& element = cache.get_element(body_id);
-    v.segment(v_start, element.get_num_velocities()).noalias() =
-        element.qdot_to_v *
-            qdot.segment(qdot_start, element.get_num_positions());
-    qdot_start += element.get_num_positions();
-    v_start += element.get_num_velocities();
-  }
-  return v;
-}
-
-template <typename T>
 template <typename Derived>
 MatrixX<typename Derived::Scalar>
 RigidBodyTree<T>::transformVelocityMappingToQDotMapping(
@@ -1531,8 +1496,8 @@ RigidBodyTree<T>::transformVelocityMappingToQDotMapping(
   for (int body_id = 0; body_id < cache.get_num_cache_elements(); ++body_id) {
     const auto& element = cache.get_element(body_id);
     Ap.middleCols(Ap_col_start, element.get_num_positions()).noalias() =
-            Av.middleCols(Av_col_start, element.get_num_velocities()) *
-                element.qdot_to_v;
+        Av.middleCols(Av_col_start, element.get_num_velocities()) *
+            element.qdot_to_v;
     Ap_col_start += element.get_num_positions();
     Av_col_start += element.get_num_velocities();
   }

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -476,32 +476,6 @@ class RigidBodyTree {
         cache, body, drake::Isometry3<T>::Identity());
   }
 
-  /// Converts a vector of the time derivative of generalized coordinates (qdot)
-  /// to generalized velocity (v).
-  /// @param cache the kinematics cache, which is assumed to be up-to-date with
-  ///        respect to the state
-  /// @param qdot a `nq` dimensional vector, where `nq` is the dimension of the
-  ///      generalized coordinates.
-  /// @returns a `nv` dimensional vector, where `nv` is the dimension of the
-  ///      generalized velocities.
-  /// @sa transformVelocityToQDot()
-  static drake::VectorX<T> transformQDotToVelocity(
-      const KinematicsCache<T>& cache,
-      const drake::VectorX<T>& qdot);
-
-  /// Converts a vector of generalized velocities (v) to the time
-  /// derivative of generalized coordinates (qdot).
-  /// @param cache the kinematics cache, which is assumed to be up-to-date with
-  ///        respect to the state
-  /// @param v a `nv` dimensional vector, where `nv` is the dimension of the
-  ///      generalized velocities.
-  /// @retval qdot a `nq` dimensional vector, where `nq` is the dimension of the
-  ///      generalized coordinates.
-  /// @sa transformQDotToVelocity()
-  static drake::VectorX<T> transformVelocityToQDot(
-      const KinematicsCache<T>& cache,
-      const drake::VectorX<T>& v);
-
   /**
    * Converts a matrix B, which transforms generalized velocities (v) to an
    * output space X, to a matrix A, which transforms the time

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_kinematics_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_kinematics_test.cc
@@ -254,21 +254,6 @@ class RBTDifferentialKinematicsHelperTest : public ::testing::Test {
     for (int i = 0; i < q_.size(); ++i) q_[i] = 0.2 * i;
     for (int i = 0; i < v_.size(); ++i) v_[i] = -0.2 * i;
 
-    // Normalize quaternion so that spatial transformations to world frame
-    // using spatial isometries operate correctly- this is necessary for the
-    // method TestSpatialVelocityJacobian() to provide a matching result.
-    // TODO(amcastro-tri): Remove this block of code once Issue #4942 has been
-    // resolved.
-    std::vector<int> base_body_indices = robot_->FindBaseBodies();
-    EXPECT_EQ(base_body_indices.size(), 1);
-    const int base_index = base_body_indices.front();
-    const RigidBody<double>& base_body = robot_->get_body(base_index);
-    const int quat_offset = 3;
-    const int quat_size = 4;
-    auto q_quat = q_.middleRows(base_body.get_position_start_index()+
-                                quat_offset, quat_size);
-    q_quat /= q_quat.norm();
-
     cache_->initialize(q_, v_);
     robot_->doKinematics(*cache_, true);
 

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -353,16 +353,7 @@ GTEST_TEST(RK3RK2IntegratorTest, RigidBody) {
   for (int i=0; i< plant.get_num_velocities(); ++i)
     plant.set_velocity(context.get(), i, generalized_velocities[i]);
 
-  // Set a non-identity position and orientation.
-  plant.set_position(context.get(), 0, 1.0);  // Set position to (1,2,3).
-  plant.set_position(context.get(), 1, 2.0);
-  plant.set_position(context.get(), 2, 3.0);
-  plant.set_position(context.get(), 3, std::sqrt(2)/2);  // Set orientation to
-  plant.set_position(context.get(), 4, 0.0);             // 90 degree rotation
-  plant.set_position(context.get(), 5, std::sqrt(2)/2);  // about y-axis.
-  plant.set_position(context.get(), 6, 0.0);
-
-  // Integrate for ten thousand steps using a RK2 integrator with
+  // Integrate for one second of virtual time using a RK2 integrator with
   // small step size.
   const double dt = 5e-5;
   const double inf = std::numeric_limits<double>::infinity();
@@ -381,14 +372,6 @@ GTEST_TEST(RK3RK2IntegratorTest, RigidBody) {
   plant.SetDefaultState(*context, context->get_mutable_state());
   for (int i=0; i< plant.get_num_velocities(); ++i)
     plant.set_velocity(context.get(), i, generalized_velocities[i]);
-  // Reset the non-identity position and orientation.
-  plant.set_position(context.get(), 0, 1.0);  // Set position to (1,2,3).
-  plant.set_position(context.get(), 1, 2.0);
-  plant.set_position(context.get(), 2, 3.0);
-  plant.set_position(context.get(), 3, std::sqrt(2)/2);  // Set orientation to
-  plant.set_position(context.get(), 4, 0.0);             // 90 degree rotation
-  plant.set_position(context.get(), 5, std::sqrt(2)/2);  // about y-axis.
-  plant.set_position(context.get(), 6, 0.0);
   RungeKutta3Integrator<double> rk3(plant, context.get());
   rk3.set_maximum_step_size(0.1);
   rk3.set_target_accuracy(1e-6);
@@ -404,7 +387,7 @@ GTEST_TEST(RK3RK2IntegratorTest, RigidBody) {
   // Verify that the final states are "close".
   VectorX<double> x_final_rk3 = context->get_continuous_state_vector().
       CopyToVector();
-  const double close_tol = 2e-6;
+  const double close_tol = 1e-6;
   for (int i=0; i< x_final_rk2.size(); ++i)
     EXPECT_NEAR(x_final_rk2[i], x_final_rk3[i], close_tol);
 }


### PR DESCRIPTION
Dear @edrumwri ,

The on-call build cop, @betsymcphail, believes that your PR #4965 may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration pre-merge, because additional
platforms and tests are built post-merge.

The specific build failures under investigation include:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-gcc-continuous-matlab-documentation/813/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-gcc-continuous-matlab-debug/887/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4981)
<!-- Reviewable:end -->
