### PR TITLE
Replace cc_library and cc_binary with Drake-specific wrappers.

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -4,7 +4,7 @@
 load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
-    "cc_googletest",
+    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_binary",
 )
@@ -236,7 +236,7 @@ filegroup(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "automotive_simulator_test",
     data = ["//drake/automotive:models"],
     local = 1,
@@ -246,56 +246,56 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "curve2_test",
     deps = [
         "//drake/automotive:curve2",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "simple_car_test",
     deps = [
         "//drake/automotive:simple_car",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "idm_planner_test",
     deps = [
         "//drake/automotive:idm_planner",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "linear_car_test",
     deps = [
         "//drake/automotive:linear_car",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "simple_car_to_euler_floating_joint_test",
     deps = [
         "//drake/automotive:simple_car",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "single_lane_ego_and_agent_test",
     deps = [
         "//drake/automotive:single_lane_ego_and_agent",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "trajectory_car_test",
     deps = [
         "//drake/automotive:trajectory_car",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "simple_car_state_translator_test",
     deps = [
         "//drake/automotive:generated_translators",

--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -2,11 +2,16 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load(
+    "//tools:drake.bzl",
+    "cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "generated_vectors",
     srcs = [
         "gen/driving_command.cc",
@@ -28,7 +33,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "generated_translators",
     srcs = [
         "gen/driving_command_translator.cc",
@@ -51,7 +56,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "curve2",
     srcs = ["curve2.cc"],
     hdrs = ["curve2.h"],
@@ -61,7 +66,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "linear_car",
     srcs = ["linear_car.cc"],
     hdrs = ["linear_car.h"],
@@ -72,7 +77,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "idm_planner",
     srcs = ["idm_planner.cc"],
     hdrs = ["idm_planner.h"],
@@ -83,7 +88,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "simple_car",
     srcs = ["simple_car.cc"],
     hdrs = [
@@ -97,7 +102,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "single_lane_ego_and_agent",
     srcs = ["single_lane_ego_and_agent.cc"],
     hdrs = ["single_lane_ego_and_agent.h"],
@@ -109,7 +114,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "trajectory_car",
     srcs = ["trajectory_car.cc"],
     hdrs = ["trajectory_car.h"],
@@ -120,7 +125,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "automotive_simulator",
     srcs = ["automotive_simulator.cc"],
     hdrs = ["automotive_simulator.h"],
@@ -140,7 +145,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+drake_cc_binary(
     name = "automotive_demo",
     srcs = [
         "automotive_demo.cc",
@@ -156,7 +161,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+drake_cc_binary(
     name = "car_sim_lcm",
     srcs = [
         "car_sim_lcm.cc",
@@ -179,8 +184,8 @@ py_binary(
     name = "steering_command_driver",
     srcs = ["steering_command_driver.py"],
     deps = [
-        "//drake/lcmtypes:automotive-py",
         "@lcm//:lcm-python",
+        "//drake/lcmtypes:automotive-py",
     ],
 )
 
@@ -197,11 +202,11 @@ py_binary(
     name = "demo",
     srcs = ["automotive_demo.py"],
     data = [
+        "@drake_visualizer//:drake-visualizer",
+        "@lcm//:lcm-logger",
         ":automotive_demo",
         ":lcm-spy",
         ":steering_command_driver",
-        "@drake_visualizer//:drake-visualizer",
-        "@lcm//:lcm-logger",
     ],
     main = "automotive_demo.py",
     deps = [

--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -2,10 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "api",
     srcs = [
         "road_geometry.cc",

--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/automotive/maliput/monolane/BUILD
+++ b/drake/automotive/maliput/monolane/BUILD
@@ -2,10 +2,16 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
+load(
+    "//tools:drake.bzl",
+    "cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "monolane",
     srcs = [],
     hdrs = [],
@@ -17,7 +23,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "lanes",
     srcs = [
         "arc_lane.cc",
@@ -45,7 +51,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "builder",
     srcs = [
         "builder.cc",
@@ -59,7 +65,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "loader",
     srcs = [
         "loader.cc",
@@ -69,8 +75,8 @@ cc_library(
     ],
     linkstatic = 1,
     deps = [
-        ":builder",
         "@yaml_cpp//:lib",
+        ":builder",
     ],
 )
 
@@ -86,8 +92,8 @@ cc_test(
     size = "small",
     srcs = ["test/monolane_builder_test.cc"],
     deps = [
-        ":builder",
         "@gtest//:main",
+        ":builder",
     ],
 )
 
@@ -96,13 +102,13 @@ cc_test(
     size = "small",
     srcs = ["test/monolane_lanes_test.cc"],
     deps = [
+        "@gtest//:main",
         ":lanes",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
-cc_binary(
+drake_cc_binary(
     name = "yaml_load",
     testonly = 1,
     srcs = ["test/yaml_load.cc"],

--- a/drake/automotive/maliput/monolane/BUILD
+++ b/drake/automotive/maliput/monolane/BUILD
@@ -4,7 +4,7 @@
 load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
-    "cc_googletest",
+    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_binary",
 )

--- a/drake/automotive/maliput/monolane/BUILD
+++ b/drake/automotive/maliput/monolane/BUILD
@@ -2,12 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load(
-    "//tools:drake.bzl",
-    "drake_cc_googletest",
-    "drake_cc_library",
-    "drake_cc_binary",
-)
+load("//tools:drake.bzl", "drake_cc_library", "drake_cc_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -2,10 +2,16 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
+load(
+    "//tools:drake.bzl",
+    "cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "utility",
     srcs = [
         "generate_obj.cc",
@@ -25,7 +31,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+drake_cc_binary(
     name = "yaml_to_obj",
     srcs = ["yaml_to_obj.cc"],
     deps = [
@@ -42,10 +48,10 @@ cc_test(
     size = "small",
     srcs = ["test/generate_urdf_test.cc"],
     deps = [
+        "@gtest//:main",
         ":utility",
         "//drake/automotive/maliput/monolane",
         "//drake/thirdParty:spruce",
-        "@gtest//:main",
     ],
 )
 
@@ -54,9 +60,9 @@ cc_test(
     size = "small",
     srcs = ["test/infinite_circuit_road_test.cc"],
     deps = [
+        "@gtest//:main",
         ":utility",
         "//drake/automotive/maliput/monolane",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -4,7 +4,7 @@
 load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
-    "cc_googletest",
+    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_binary",
 )

--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -43,24 +43,18 @@ drake_cc_binary(
 
 # === test/ ===
 
-cc_test(
+drake_cc_googletest(
     name = "generate_urdf_test",
-    size = "small",
-    srcs = ["test/generate_urdf_test.cc"],
     deps = [
-        "@gtest//:main",
         ":utility",
         "//drake/automotive/maliput/monolane",
         "//drake/thirdParty:spruce",
     ],
 )
 
-cc_test(
+drake_cc_googletest(
     name = "infinite_circuit_road_test",
-    size = "small",
-    srcs = ["test/infinite_circuit_road_test.cc"],
     deps = [
-        "@gtest//:main",
         ":utility",
         "//drake/automotive/maliput/monolane",
     ],

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -2,13 +2,13 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
 # A library of things that EVERYONE should want and MUST EAT.
 # Be appropriately hesitant when adding new things here.
-cc_library(
+drake_cc_library(
     name = "common",
     srcs = [
         "drake_assert.cc",
@@ -35,33 +35,33 @@ cc_library(
 )
 
 # Specific traits and operators that are relevant to all ScalarTypes.
-cc_library(
+drake_cc_library(
     name = "cond",
     hdrs = ["cond.h"],
     linkstatic = 1,
 )
 
-cc_library(
+drake_cc_library(
     name = "dummy_value",
     hdrs = ["dummy_value.h"],
     linkstatic = 1,
 )
 
-cc_library(
+drake_cc_library(
     name = "number_traits",
     hdrs = ["number_traits.h"],
     linkstatic = 1,
 )
 
 # Drake's specific ScalarType-providing libraries.
-cc_library(
+drake_cc_library(
     name = "double",
     srcs = ["double_overloads.cc"],
     hdrs = ["double_overloads.h"],
     linkstatic = 1,
 )
 
-cc_library(
+drake_cc_library(
     name = "autodiff",
     hdrs = [
         "autodiff_overloads.h",
@@ -75,7 +75,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "environment",
     srcs = ["environment.cc"],
     hdrs = [
@@ -88,7 +88,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "extract_double",
     hdrs = ["extract_double.h"],
     linkstatic = 1,
@@ -99,7 +99,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "functional_form",
     srcs = ["functional_form.cc"],
     hdrs = ["functional_form.h"],
@@ -110,7 +110,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "polynomial",
     srcs = ["polynomial.cc"],
     hdrs = [
@@ -124,7 +124,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "symbolic",
     srcs = [
         "symbolic_expression.cc",
@@ -179,7 +179,7 @@ cc_library(
 )
 
 # Miscellaneous utilities.
-cc_library(
+drake_cc_library(
     name = "drake_path",
     # TODO(david-german-tri): Set testonly = 1 once the non-test uses of
     # drake_path are removed.
@@ -208,7 +208,7 @@ genrule(
 
 # TODO(jwnimmer-tri) Move this header file into test/ subdirectory (and this
 # stanza below the "test/" comment marker).
-cc_library(
+drake_cc_library(
     name = "eigen_matrix_compare",
     testonly = 1,
     hdrs = ["eigen_matrix_compare.h"],
@@ -218,7 +218,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "is_approx_equal_abstol",
     hdrs = ["is_approx_equal_abstol.h"],
     linkstatic = 1,
@@ -227,7 +227,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "monomial",
     srcs = ["monomial.cc"],
     hdrs = ["monomial.h"],
@@ -238,7 +238,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "nice_type_name",
     srcs = ["nice_type_name.cc"],
     hdrs = ["nice_type_name.h"],
@@ -248,7 +248,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "sorted_vectors_have_intersection",
     hdrs = ["sorted_vectors_have_intersection.h"],
     linkstatic = 1,
@@ -257,7 +257,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "text_logging_gflags",
     hdrs = ["text_logging_gflags.h"],
     # TODO(jwnimmer-tri) Ideally, gflags BUILD would do this for us.  Figure
@@ -273,7 +273,7 @@ cc_library(
 
 # === test/ ===
 
-cc_library(
+drake_cc_library(
     name = "random_polynomial_matrix",
     testonly = 1,
     hdrs = ["test/random_polynomial_matrix.h"],
@@ -283,7 +283,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "measure_execution",
     testonly = 1,
     hdrs = ["test/measure_execution.h"],

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -290,7 +290,7 @@ drake_cc_library(
     linkstatic = 1,
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "autodiff_overloads_test",
     deps = [
         ":autodiff",
@@ -300,7 +300,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "double_overloads_test",
     deps = [
         ":common",
@@ -309,21 +309,21 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "drake_assert_test",
     deps = [
         ":common",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "drake_assert_test_compile",
     deps = [
         ":common",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "drake_deprecated_test",
     # Remove spurious warnings from the default build output.
     copts = ["-Wno-deprecated-declarations"],
@@ -332,21 +332,21 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "drake_throw_test",
     deps = [
         ":common",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "dummy_value_test",
     deps = [
         ":dummy_value",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "eigen_matrix_compare_test",
     deps = [
         ":common",
@@ -354,14 +354,14 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "eigen_stl_types_test",
     deps = [
         ":common",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "extract_double_test",
     deps = [
         ":common",
@@ -369,7 +369,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "functional_form_test",
     deps = [
         ":common",
@@ -377,7 +377,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "is_approx_equal_abstol_test",
     deps = [
         ":common",
@@ -385,7 +385,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "monomial_test",
     deps = [
         ":common",
@@ -394,14 +394,14 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "never_destroyed_test",
     deps = [
         ":common",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "nice_type_name_test",
     deps = [
         ":common",
@@ -409,7 +409,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "polynomial_test",
     deps = [
         ":common",
@@ -418,7 +418,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "sorted_vectors_have_intersection_test",
     deps = [
         ":common",
@@ -426,7 +426,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "environment_test",
     deps = [
         ":common",
@@ -434,7 +434,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "symbolic_expression_test",
     deps = [
         ":common",
@@ -442,7 +442,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "symbolic_mixing_scalar_types_test",
     deps = [
         ":common",
@@ -450,7 +450,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "symbolic_expression_matrix_test",
     deps = [
         ":common",
@@ -458,7 +458,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "variable_overloading_test",
     deps = [
         ":common",
@@ -466,7 +466,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "symbolic_formula_test",
     deps = [
         ":common",
@@ -474,7 +474,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "variable_test",
     deps = [
         ":common",
@@ -482,7 +482,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "variables_test",
     deps = [
         ":common",
@@ -490,14 +490,14 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "text_logging_test",
     deps = [
         ":common",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "trig_poly_test",
     deps = [
         ":common",

--- a/drake/common/trajectories/BUILD
+++ b/drake/common/trajectories/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -82,14 +82,14 @@ drake_cc_library(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "piecewise_function_test",
     deps = [
         ":piecewise_function",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "piecewise_generation_test",
     srcs = ["test/piecewise_polynomial_generation_test.cc"],
     deps = [
@@ -98,7 +98,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "piecewise_polynomial_test",
     deps = [
         ":piecewise_polynomial",
@@ -107,7 +107,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "exponential_plus_piecewise_polynomial_test",
     deps = [
         ":piecewise_polynomial",
@@ -116,7 +116,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "piecewise_polynomial_trajectory_test",
     deps = [
         ":piecewise_polynomial_trajectory",
@@ -125,7 +125,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "piecewise_quaternion_test",
     deps = [
         ":piecewise_quaternion",

--- a/drake/common/trajectories/BUILD
+++ b/drake/common/trajectories/BUILD
@@ -2,12 +2,12 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
 # TODO(jwnimmer-tri) Move code to a trajectory.cc file
-cc_library(
+drake_cc_library(
     name = "trajectory",
     hdrs = ["trajectory.h"],
     linkstatic = 1,
@@ -16,7 +16,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "piecewise_function",
     srcs = ["piecewise_function.cc"],
     hdrs = ["piecewise_function.h"],
@@ -26,7 +26,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "piecewise_polynomial",
     srcs = [
         "exponential_plus_piecewise_polynomial.cc",
@@ -46,7 +46,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "piecewise_polynomial_trajectory",
     srcs = ["piecewise_polynomial_trajectory.cc"],
     hdrs = ["piecewise_polynomial_trajectory.h"],
@@ -58,7 +58,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "piecewise_quaternion",
     srcs = ["piecewise_quaternion.cc"],
     hdrs = ["piecewise_quaternion.h"],
@@ -72,7 +72,7 @@ cc_library(
 
 # === test/ ===
 
-cc_library(
+drake_cc_library(
     name = "random_piecewise_polynomial",
     testonly = 1,
     hdrs = ["test/random_piecewise_polynomial.h"],

--- a/drake/common/trajectories/qp_spline/BUILD
+++ b/drake/common/trajectories/qp_spline/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "continuity_constraint",
     srcs = ["continuity_constraint.cc"],
     hdrs = ["continuity_constraint.h"],
@@ -16,7 +16,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "spline_generation",
     srcs = ["spline_generation.cc"],
     hdrs = ["spline_generation.h"],
@@ -27,7 +27,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "spline_information",
     srcs = ["spline_information.cc"],
     hdrs = ["spline_information.h"],
@@ -39,7 +39,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "value_constraint",
     srcs = ["value_constraint.cc"],
     hdrs = ["value_constraint.h"],

--- a/drake/common/trajectories/qp_spline/BUILD
+++ b/drake/common/trajectories/qp_spline/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -51,7 +51,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "spline_generation_test",
     deps = [
         ":spline_generation",

--- a/drake/examples/Pendulum/BUILD
+++ b/drake/examples/Pendulum/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 drake_cc_library(
     name = "pendulum_state_vector",
@@ -37,7 +37,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "pendulum_urdf_dynamics_test",
     data = ["Pendulum.urdf"],
     deps = [
@@ -49,7 +49,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "pendulum_dynamic_constraint_test",
     deps = [
         ":pendulum_plant",
@@ -58,7 +58,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "pendulum_trajectory_optimization_test",
     deps = [
         ":pendulum_swing_up",

--- a/drake/examples/Pendulum/BUILD
+++ b/drake/examples/Pendulum/BUILD
@@ -2,9 +2,9 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
-cc_library(
+drake_cc_library(
     name = "pendulum_state_vector",
     srcs = ["gen/pendulum_state_vector.cc"],
     hdrs = ["gen/pendulum_state_vector.h"],
@@ -14,7 +14,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "pendulum_plant",
     srcs = ["pendulum_plant.cc"],
     hdrs = ["pendulum_plant.h"],
@@ -25,7 +25,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "pendulum_swing_up",
     srcs = ["pendulum_swing_up.cc"],
     hdrs = ["pendulum_swing_up.h"],

--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -2,8 +2,9 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
-cc_library(
+drake_cc_library(
     name = "control_utils",
     srcs = [],
     hdrs = ["control_utils.h"],
@@ -14,7 +15,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "rigid_body_tree_alias_groups",
     srcs = [
         "param_parsers/rigid_body_tree_alias_groups.cc",
@@ -24,12 +25,12 @@ cc_library(
     ],
     linkstatic = 1,
     deps = [
-        "//drake/multibody:rigid_body_tree",
         "@yaml_cpp//:lib",
+        "//drake/multibody:rigid_body_tree",
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "param_parser",
     srcs = [
         "param_parsers/param_parser.cc",
@@ -44,7 +45,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "humanoid_status",
     srcs = ["humanoid_status.cc"],
     hdrs = ["humanoid_status.h"],
@@ -57,7 +58,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "qp_controller_common",
     srcs = ["qp_controller_common.cc"],
     hdrs = ["qp_controller_common.h"],
@@ -67,7 +68,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "qp_controller",
     srcs = ["qp_controller.cc"],
     hdrs = ["qp_controller.h"],
@@ -97,13 +98,13 @@ cc_test(
         "local",
     ],
     deps = [
+        "@gtest//:main",
         ":control_utils",
         ":param_parser",
         ":qp_controller",
         "//drake/common:eigen_matrix_compare",
         "//drake/examples/Valkyrie:valkyrie_constants",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
@@ -118,10 +119,10 @@ cc_test(
         "//drake/multibody:test_models",
     ],
     deps = [
+        "@gtest//:main",
         ":rigid_body_tree_alias_groups",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
@@ -134,11 +135,11 @@ cc_test(
         "//drake/examples/Valkyrie:models",
     ],
     deps = [
+        "@gtest//:main",
         ":param_parser",
         ":rigid_body_tree_alias_groups",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 drake_cc_library(
     name = "control_utils",

--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -84,7 +84,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_test(
+drake_cc_googletest(
     name = "valkyrie_balancing_test",
     srcs = ["test/valkyrie_balancing_test.cc"],
     data = [
@@ -98,7 +98,6 @@ cc_test(
         "local",
     ],
     deps = [
-        "@gtest//:main",
         ":control_utils",
         ":param_parser",
         ":qp_controller",
@@ -108,7 +107,7 @@ cc_test(
     ],
 )
 
-cc_test(
+drake_cc_googletest(
     name = "rigid_body_tree_alias_groups_test",
     srcs = ["param_parsers/test/rigid_body_tree_alias_groups_test.cc"],
     data = [
@@ -119,14 +118,13 @@ cc_test(
         "//drake/multibody:test_models",
     ],
     deps = [
-        "@gtest//:main",
         ":rigid_body_tree_alias_groups",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody/parsers",
     ],
 )
 
-cc_test(
+drake_cc_googletest(
     name = "param_parser_test",
     srcs = ["param_parsers/test/param_parser_test.cc"],
     data = [
@@ -135,7 +133,6 @@ cc_test(
         "//drake/examples/Valkyrie:models",
     ],
     deps = [
-        "@gtest//:main",
         ":param_parser",
         ":rigid_body_tree_alias_groups",
         "//drake/common:eigen_matrix_compare",

--- a/drake/examples/Valkyrie/BUILD
+++ b/drake/examples/Valkyrie/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/examples/Valkyrie/BUILD
+++ b/drake/examples/Valkyrie/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/examples/Valkyrie/BUILD
+++ b/drake/examples/Valkyrie/BUILD
@@ -2,10 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "valkyrie_constants",
     srcs = ["valkyrie_constants.cc"],
     hdrs = ["valkyrie_constants.h"],

--- a/drake/examples/bouncing_ball/BUILD
+++ b/drake/examples/bouncing_ball/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -36,14 +36,14 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "ball_test",
     deps = [
         ":ball",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "bouncing_ball_test",
     deps = [
         ":bouncing_ball",

--- a/drake/examples/bouncing_ball/BUILD
+++ b/drake/examples/bouncing_ball/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "ball",
     srcs = ["ball.cc"],
     hdrs = [
@@ -20,7 +20,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "bouncing_ball",
     srcs = ["bouncing_ball.cc"],
     hdrs = [

--- a/drake/lcm/BUILD
+++ b/drake/lcm/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -73,7 +73,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "drake_lcm_test",
     local = 1,
     deps = [
@@ -82,7 +82,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "drake_mock_lcm_test",
     deps = [
         ":lcmt_drake_signal_utils",
@@ -90,14 +90,14 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "lcmt_drake_signal_utils_test",
     deps = [
         ":lcmt_drake_signal_utils",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "lcm_call_matlab_test",
     local = 1,
     deps = [

--- a/drake/lcm/BUILD
+++ b/drake/lcm/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "interface",
     hdrs = [
         "drake_lcm_interface.h",
@@ -18,7 +18,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "mock",
     testonly = 1,
     srcs = ["drake_mock_lcm.cc"],
@@ -29,7 +29,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "lcm",
     srcs = [
         "drake_lcm.cc",
@@ -47,7 +47,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "lcmt_drake_signal_utils",
     testonly = 1,
     srcs = ["lcmt_drake_signal_utils.cc"],
@@ -59,7 +59,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "lcm_call_matlab",
     testonly = 1,
     srcs = ["lcm_call_matlab.cc"],

--- a/drake/math/BUILD
+++ b/drake/math/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -123,7 +123,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "autodiff_test",
     deps = [
         ":autodiff",
@@ -132,7 +132,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "cross_product_test",
     deps = [
         ":gradient",
@@ -140,7 +140,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "expmap_test",
     deps = [
         ":expmap",
@@ -148,7 +148,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "eigen_sparse_triplet_test",
     deps = [
         ":eigen_sparse_triplet",
@@ -156,7 +156,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "jacobian_test",
     deps = [
         ":gradient",
@@ -165,7 +165,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "gradient_util_test",
     deps = [
         ":gradient",
@@ -173,7 +173,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "matrix_util_test",
     deps = [
         ":matrix_util",
@@ -182,7 +182,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "normalize_vector_test",
     deps = [
         ":gradient",
@@ -190,7 +190,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rotation_matrix_test",
     deps = [
         ":geometric_transform",
@@ -198,7 +198,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rotation_conversion_test",
     deps = [
         ":geometric_transform",

--- a/drake/math/BUILD
+++ b/drake/math/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "autodiff",
     srcs = ["autodiff.cc"],
     hdrs = ["autodiff.h"],
@@ -17,7 +17,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "continuous_algebraic_ricatti_equation",
     srcs = ["continuous_algebraic_ricatti_equation.cc"],
     hdrs = ["continuous_algebraic_ricatti_equation.h"],
@@ -29,7 +29,7 @@ cc_library(
 )
 
 # TODO(jwnimmer-tri) Improved name for this library, "pose_representations"?
-cc_library(
+drake_cc_library(
     name = "geometric_transform",
     srcs = [
         "axis_angle.cc",
@@ -53,7 +53,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "gradient",
     srcs = [
         "autodiff_gradient.cc",
@@ -77,7 +77,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "matrix_util",
     srcs = ["matrix_util.cc"],
     hdrs = ["matrix_util.h"],
@@ -90,7 +90,7 @@ cc_library(
 
 # These all require bleeding-edge Eigen, so please don't fold them into any
 # other important labels until we get all workspaces on newer-Eigen.
-cc_library(
+drake_cc_library(
     name = "eigen_sparse_triplet",
     srcs = ["eigen_sparse_triplet.cc"],
     hdrs = ["eigen_sparse_triplet.h"],
@@ -100,7 +100,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "expmap",
     srcs = ["expmap.cc"],
     hdrs = ["expmap.h"],
@@ -111,7 +111,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "jacobian",
     srcs = ["jacobian.cc"],
     hdrs = ["jacobian.h"],

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -4,7 +4,7 @@
 load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
-    "cc_googletest",
+    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_binary",
 )
@@ -124,7 +124,7 @@ drake_cc_binary(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rbt_collisions_test",
     srcs = ["test/rigid_body_tree/rbt_collisions_test.cc"],
     data = [":test_models"],
@@ -134,7 +134,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rigid_body_collision_clique_test",
     srcs = ["test/rigid_body_tree/rigid_body_collision_clique_test.cc"],
     deps = [
@@ -143,7 +143,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rigid_body_constraint_test",
     srcs = ["constraint/test/rigid_body_constraint_test.cc"],
     data = ["//drake/examples/Atlas:models"],
@@ -153,7 +153,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rigid_body_tree_kinematics_test",
     srcs = ["test/rigid_body_tree/rigid_body_tree_kinematics_test.cc"],
     data = [
@@ -169,7 +169,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rigid_body_tree_dynamics_test",
     srcs = ["test/rigid_body_tree/rigid_body_tree_dynamics_test.cc"],
     data = ["//drake/examples/Atlas:models"],
@@ -181,7 +181,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rigid_body_tree_creation_test",
     srcs = ["test/rigid_body_tree/rigid_body_tree_creation_test.cc"],
     data = glob(["test/rigid_body_tree/*.urdf"]),
@@ -191,7 +191,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "test_kinematics_cache_checks",
     data = ["//drake/examples/Atlas:models"],
     deps = [
@@ -200,7 +200,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rigid_body_test",
     deps = [
         ":rigid_body_tree",

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -2,11 +2,16 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load(
+    "//tools:drake.bzl",
+    "cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "inverse_kinematics",
     srcs = [
         "constraint_wrappers.cc",
@@ -34,7 +39,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "rigid_body_constraint",
     srcs = ["constraint/rigid_body_constraint.cc"],
     hdrs = ["constraint/rigid_body_constraint.h"],
@@ -44,7 +49,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "rigid_body_tree",
     srcs = [
         "kinematics_cache.cc",
@@ -83,7 +88,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "rigid_body_tree_construction",
     srcs = ["rigid_body_tree_construction.cc"],
     hdrs = ["rigid_body_tree_construction.h"],
@@ -94,21 +99,21 @@ cc_library(
 )
 
 # TODO(jwnimmer-tri) This is just some random program.  Do we want to keep it?
-cc_binary(
+drake_cc_binary(
     name = "benchmark_rigid_body_tree",
     testonly = 1,
     srcs = ["test/benchmark_rigid_body_tree.cc"],
     linkstatic = 1,
     deps = [
+        "@gtest//:main",
         ":rigid_body_tree",
         "//drake/common:measure_execution",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
 # TODO(jwnimmer-tri) This is just some random program.  Do we want to keep it?
-cc_binary(
+drake_cc_binary(
     name = "debug_manipulator_dynamics",
     testonly = 1,
     srcs = ["test/debug_manipulator_dynamics.cc"],

--- a/drake/multibody/benchmarks/BUILD
+++ b/drake/multibody/benchmarks/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "acrobot",
     srcs = ["acrobot/acrobot.cc"],
     hdrs = ["acrobot/acrobot.h"],

--- a/drake/multibody/benchmarks/BUILD
+++ b/drake/multibody/benchmarks/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/multibody/benchmarks/BUILD
+++ b/drake/multibody/benchmarks/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "model",
     srcs = [
         "collision_filter.cc",
@@ -28,7 +28,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "collision_api",
     hdrs = ["drake_collision.h"],
     deps = [
@@ -36,7 +36,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "bullet_collision",
     srcs = [
         "bullet_model.cc",
@@ -54,7 +54,7 @@ cc_library(
 # TODO(jwnimmer-tri) Remove this once CMake is no longer using it (and thus we
 # can delete unusable_model.*).  This cc_library only exists a sanity check to
 # ensure the file still compiles.
-cc_library(
+drake_cc_library(
     name = "unusable_collision",
     srcs = [
         "drake_collision.cc",
@@ -70,7 +70,7 @@ cc_library(
 
 # N.B. This is just the FCL model, not the drake_collision dispatcher.  (The
 # other foo_collision libraries *do* contain the dispatcher.)
-cc_library(
+drake_cc_library(
     name = "fcl_collision",
     srcs = [
         "fcl_model.cc",

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -90,7 +90,7 @@ alias(
     actual = ":bullet_collision",
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "model_test",
     data = [":test_models"],
     deps = [
@@ -100,14 +100,14 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "fcl_model_test",
     deps = [
         ":fcl_collision",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "collision_filter_group_test",
     data = [":test_models"],
     deps = [

--- a/drake/multibody/joints/BUILD
+++ b/drake/multibody/joints/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "joints",
     srcs = [
         "drake_joint.cc",

--- a/drake/multibody/joints/BUILD
+++ b/drake/multibody/joints/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -39,7 +39,7 @@ drake_cc_library(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "joint_test",
     deps = [
         ":joints",

--- a/drake/multibody/parsers/BUILD
+++ b/drake/multibody/parsers/BUILD
@@ -4,7 +4,7 @@
 load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
-    "cc_googletest",
+    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_binary",
 )
@@ -73,7 +73,7 @@ drake_cc_binary(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "package_map_test",
     srcs = ["test/package_map_test/package_map_test.cc"],
     data = [
@@ -84,7 +84,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "parser_common_test",
     srcs = ["test/parser_common_test/parser_common_test.cc"],
     data = ["test/parser_common_test/test_file.txt"],
@@ -93,7 +93,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "urdf_parser_test",
     srcs = ["test/urdf_parser_test/urdf_parser_test.cc"],
     data = [
@@ -105,7 +105,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "xml_util_test",
     deps = [
         ":parsers",

--- a/drake/multibody/parsers/BUILD
+++ b/drake/multibody/parsers/BUILD
@@ -2,11 +2,16 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load(
+    "//tools:drake.bzl",
+    "cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "parsers",
     srcs = [
         "model_instance_id_table.cc",
@@ -31,40 +36,40 @@ cc_library(
 )
 
 # TODO(jwnimmer-tri) This is just some random program.  Do we want to keep it?
-cc_binary(
+drake_cc_binary(
     name = "urdf_kinematics_test",
     testonly = 1,
     srcs = ["test/urdf_kinematics_test.cc"],
     linkstatic = 1,
     deps = [
+        "@gtest//:main",
         ":parsers",
         "//drake/multibody:rigid_body_tree",
-        "@gtest//:main",
     ],
 )
 
 # TODO(jwnimmer-tri) This is just some random program.  Do we want to keep it?
-cc_binary(
+drake_cc_binary(
     name = "urdf_collision_test",
     testonly = 1,
     srcs = ["test/urdf_collision_test.cc"],
     linkstatic = 1,
     deps = [
+        "@gtest//:main",
         ":parsers",
         "//drake/multibody:rigid_body_tree",
-        "@gtest//:main",
     ],
 )
 
 # TODO(jwnimmer-tri) This is just some random program.  Do we want to keep it?
-cc_binary(
+drake_cc_binary(
     name = "urdf_manipulator_dynamics_test",
     srcs = ["test/urdf_manipulator_dynamics_test.cc"],
     linkstatic = 1,
     deps = [
+        "@gtest//:main",
         ":parsers",
         "//drake/multibody:rigid_body_tree",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "rigid_body_plant",
     srcs = [
         "contact_detail.cc",
@@ -36,7 +36,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "rigid_body_plant_that_publishes_xdot",
     srcs = [
         "rigid_body_plant_that_publishes_xdot.cc",
@@ -52,7 +52,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "drake_visualizer",
     srcs = [
         "drake_visualizer.cc",

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -70,7 +70,7 @@ drake_cc_library(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "compute_contact_result_test",
     deps = [
         ":rigid_body_plant",
@@ -78,14 +78,14 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "contact_detail_test",
     deps = [
         ":rigid_body_plant",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "contact_force_test",
     deps = [
         ":rigid_body_plant",
@@ -93,14 +93,14 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "contact_info_test",
     deps = [
         ":rigid_body_plant",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "contact_resultant_force_test",
     deps = [
         ":rigid_body_plant",
@@ -108,7 +108,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "drake_visualizer_test",
     data = ["//drake/multibody/collision:test_models"],
     deps = [
@@ -118,7 +118,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "kinematics_results_test",
     data = ["//drake/multibody:test_models"],
     deps = [
@@ -128,7 +128,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rigid_body_plant_test",
     data = [
         ":test_models",
@@ -143,7 +143,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "rigid_body_plant_that_publishes_xdot_test",
     data = [
         "//drake/multibody:models",
@@ -157,7 +157,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "viewer_draw_translator_test",
     deps = [
         ":drake_visualizer",

--- a/drake/multibody/shapes/BUILD
+++ b/drake/multibody/shapes/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,7 +26,7 @@ drake_cc_library(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "mesh_triangulate_test",
     srcs = ["test/mesh_triangulate_test.cc"],
     data = [

--- a/drake/multibody/shapes/BUILD
+++ b/drake/multibody/shapes/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "shapes",
     srcs = [
         "element.cc",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "binding",
     srcs = [],
     hdrs = ["binding.h"],
@@ -16,7 +16,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "constraint",
     srcs = ["constraint.cc"],
     hdrs = ["constraint.h"],
@@ -29,7 +29,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "decision_variable",
     srcs = ["decision_variable.cc"],
     hdrs = ["decision_variable.h"],
@@ -41,7 +41,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "function",
     srcs = [],
     hdrs = ["function.h"],
@@ -65,7 +65,7 @@ cc_library(
 # - MOSEK
 
 # TODO(jwnimmer-tri, david-german-tri): Support more solvers.
-cc_library(
+drake_cc_library(
     name = "mathematical_program",
     srcs = [
         "dreal_solver.h",
@@ -105,7 +105,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "system_identification",
     srcs = ["system_identification.cc"],
     hdrs = ["system_identification.h"],
@@ -125,7 +125,7 @@ cc_library(
 # TODO(hongkai-dai): MathematicalProgram should be refactored so that
 # implementations of MathematicalProgramSolverInterface are not co-dependent
 # with MathematicalProgram itself, and then this target should be deleted.
-cc_library(
+drake_cc_library(
     name = "mathematical_program_api",
     srcs = [],
     hdrs = [
@@ -151,7 +151,7 @@ cc_library(
 # If --config gurobi is used, this target builds object code that satisfies
 # MathematicalProgramSolverInterface by calling Gurobi. Otherwise, this target
 # builds dummy object code that fails at runtime.
-cc_library(
+drake_cc_library(
     name = "gurobi_solver",
     srcs = select({
         "//tools:with_gurobi": ["gurobi_solver.cc"],
@@ -172,7 +172,7 @@ cc_library(
     }),
 )
 
-cc_library(
+drake_cc_library(
     name = "ipopt_solver",
     srcs = select({
         "//tools:apple": ["no_ipopt.cc"],

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -194,7 +194,7 @@ drake_cc_library(
 )
 
 # === test/ ===
-cc_googletest(
+drake_cc_googletest(
     name = "binding_test",
     srcs = [
         "test/binding_test.cc",
@@ -205,7 +205,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "constraint_test",
     deps = [
         ":mathematical_program",
@@ -216,7 +216,7 @@ cc_googletest(
 
 # TODO(hongkai-dai): Separate this test into a test that uses Gurobi, and a
 # test that doesn't.
-cc_googletest(
+drake_cc_googletest(
     name = "convex_optimization_test",
     srcs = [
         "test/convex_optimization_test.cc",
@@ -233,7 +233,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "decision_variable_test",
     deps = [
         ":mathematical_program",
@@ -241,7 +241,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "equality_constrained_qp_solver_test",
     srcs = [
         "test/equality_constrained_qp_solver_test.cc",
@@ -253,7 +253,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "linear_complementary_problem_test",
     srcs = [
         "test/linear_complementary_problem_test.cc",
@@ -264,7 +264,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "linear_system_solver_test",
     srcs = [
         "test/linear_system_solver_test.cc",
@@ -278,7 +278,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "mathematical_program_test",
     srcs = [
         "test/mathematical_program_test.cc",
@@ -292,7 +292,7 @@ cc_googletest(
 
 # TODO(hongkai-dai): Separate this test into a test that uses Gurobi, and a
 # test that doesn't.
-cc_googletest(
+drake_cc_googletest(
     name = "mixed_integer_optimization_test",
     srcs = [
         "test/mathematical_program_test_util.h",
@@ -309,7 +309,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "moby_lcp_solver_test",
     deps = [
         ":mathematical_program",
@@ -317,7 +317,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "nonlinear_program_test",
     srcs = [
         "test/mathematical_program_test_util.h",
@@ -331,7 +331,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "system_identification_test",
     # The test takes ~20 sec in opt mode but ~140 sec in dbg mode.
     # To avoid timeouts in dbg or valgrind, we need "moderate" here.

--- a/drake/systems/analysis/BUILD
+++ b/drake/systems/analysis/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "analysis",
     srcs = [],
     hdrs = [],
@@ -19,7 +19,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "integrator_base",
     hdrs = ["integrator_base.h"],
     linkstatic = 1,
@@ -29,7 +29,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "explicit_euler_integrator",
     srcs = [],
     hdrs = ["explicit_euler_integrator.h"],
@@ -39,7 +39,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "runge_kutta2_integrator",
     srcs = [],
     hdrs = ["runge_kutta2_integrator.h"],
@@ -49,7 +49,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "runge_kutta3_integrator",
     srcs = ["runge_kutta3_integrator.cc"],
     hdrs = [
@@ -63,7 +63,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "simulator",
     srcs = ["simulator.cc"],
     hdrs = ["simulator.h"],
@@ -78,7 +78,7 @@ cc_library(
 
 # === test/ ===
 
-cc_library(
+drake_cc_library(
     name = "my_spring_mass_system",
     testonly = 1,
     hdrs = ["test/my_spring_mass_system.h"],

--- a/drake/systems/analysis/BUILD
+++ b/drake/systems/analysis/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -88,7 +88,7 @@ drake_cc_library(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "simulator_test",
     deps = [
         ":explicit_euler_integrator",
@@ -98,7 +98,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "explicit_euler_integrator_test",
     deps = [
         ":explicit_euler_integrator",
@@ -106,7 +106,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "runge_kutta2_integrator_test",
     deps = [
         ":my_spring_mass_system",
@@ -114,7 +114,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "runge_kutta3_integrator_test",
     deps = [
         ":my_spring_mass_system",

--- a/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "controlled_spring_mass_system",
     testonly = 1,
     srcs = ["controlled_spring_mass_system.cc"],

--- a/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -23,7 +23,7 @@ drake_cc_library(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "controlled_spring_mass_system_test",
     srcs = ["controlled_spring_mass_system_test.cc"],
     deps = [

--- a/drake/systems/controllers/BUILD
+++ b/drake/systems/controllers/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -61,7 +61,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "gravity_compensator_test",
     data = [
         "//drake/examples/SimpleFourBar:models",
@@ -73,7 +73,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "linear_quadratic_regulator_test",
     deps = [
         ":linear_quadratic_regulator",
@@ -81,7 +81,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "pid_controlled_system_test",
     deps = [
         ":pid_controlled_system",
@@ -89,7 +89,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "pid_controller_test",
     deps = [
         ":pid_controller",

--- a/drake/systems/controllers/BUILD
+++ b/drake/systems/controllers/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "gravity_compensator",
     srcs = ["gravity_compensator.cc"],
     hdrs = ["gravity_compensator.h"],
@@ -18,7 +18,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "linear_quadratic_regulator",
     srcs = ["linear_quadratic_regulator.cc"],
     hdrs = ["linear_quadratic_regulator.h"],
@@ -31,7 +31,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "pid_controller",
     srcs = ["pid_controller.cc"],
     hdrs = ["pid_controller.h"],
@@ -46,7 +46,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "pid_controlled_system",
     srcs = ["pid_controlled_system.cc"],
     hdrs = ["pid_controlled_system.h"],

--- a/drake/systems/estimators/BUILD
+++ b/drake/systems/estimators/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "kalman_filter",
     srcs = ["kalman_filter.cc"],
     hdrs = ["kalman_filter.h"],
@@ -19,7 +19,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "luenberger_observer",
     srcs = ["luenberger_observer.cc"],
     hdrs = ["luenberger_observer.h"],

--- a/drake/systems/estimators/BUILD
+++ b/drake/systems/estimators/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,7 +31,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "kalman_filter_test",
     deps = [
         ":kalman_filter",
@@ -39,7 +39,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "luenberger_observer_test",
     deps = [
         ":luenberger_observer",

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -310,7 +310,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "basic_vector_test",
     deps = [
         ":vector",
@@ -321,7 +321,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "cache_test",
     deps = [
         ":cache",
@@ -330,7 +330,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "continuous_state_test",
     deps = [
         ":continuous_state",
@@ -338,7 +338,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "diagram_builder_test",
     deps = [
         ":diagram_builder",
@@ -351,7 +351,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "diagram_context_test",
     deps = [
         ":diagram_context",
@@ -365,7 +365,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "diagram_test",
     deps = [
         ":diagram",
@@ -379,7 +379,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "discrete_state_test",
     deps = [
         ":discrete_state",
@@ -387,7 +387,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "leaf_context_test",
     deps = [
         ":leaf_context",
@@ -397,7 +397,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "leaf_system_test",
     deps = [
         ":leaf_system",
@@ -406,7 +406,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "abstract_state_test",
     deps = [
         ":abstract_state",
@@ -415,7 +415,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "parameters_test",
     deps = [
         ":parameters",
@@ -424,7 +424,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "subvector_test",
     deps = [
         ":vector",
@@ -433,7 +433,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "supervector_test",
     deps = [
         ":vector",
@@ -441,7 +441,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "system_input_test",
     deps = [
         ":system_input",
@@ -449,7 +449,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "system_output_test",
     deps = [
         ":system_output",
@@ -457,7 +457,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "system_test",
     deps = [
         ":leaf_context",
@@ -466,7 +466,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "value_test",
     deps = [
         ":value",
@@ -474,7 +474,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "single_output_vector_source_test",
     deps = [
         ":single_output_vector_source",

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "framework",
     srcs = [],
     hdrs = [],
@@ -28,7 +28,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "vector",
     srcs = [
         "basic_vector.cc",
@@ -51,7 +51,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "value",
     srcs = ["value.cc"],
     hdrs = ["value.h"],
@@ -62,7 +62,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "cache",
     srcs = ["cache.cc"],
     hdrs = ["cache.h"],
@@ -73,7 +73,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "abstract_state",
     srcs = ["abstract_state.cc"],
     hdrs = ["abstract_state.h"],
@@ -85,7 +85,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "continuous_state",
     srcs = ["continuous_state.cc"],
     hdrs = ["continuous_state.h"],
@@ -97,7 +97,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "discrete_state",
     srcs = ["discrete_state.cc"],
     hdrs = ["discrete_state.h"],
@@ -110,7 +110,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "state",
     srcs = ["state.cc"],
     hdrs = ["state.h"],
@@ -126,7 +126,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "parameters",
     srcs = ["parameters.cc"],
     hdrs = ["parameters.h"],
@@ -138,7 +138,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "system_port_descriptor",
     srcs = ["system_port_descriptor.cc"],
     hdrs = ["system_port_descriptor.h"],
@@ -148,7 +148,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "output_port_listener_interface",
     srcs = ["output_port_listener_interface.cc"],
     hdrs = ["output_port_listener_interface.h"],
@@ -158,7 +158,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "system_output",
     srcs = ["system_output.cc"],
     hdrs = ["system_output.h"],
@@ -171,7 +171,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "input_port_evaluator_interface",
     srcs = ["input_port_evaluator_interface.cc"],
     hdrs = ["input_port_evaluator_interface.h"],
@@ -183,7 +183,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "system_input",
     srcs = ["system_input.cc"],
     hdrs = ["system_input.h"],
@@ -195,7 +195,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "context",
     srcs = ["context.cc"],
     hdrs = ["context.h"],
@@ -208,7 +208,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "leaf_context",
     srcs = ["leaf_context.cc"],
     hdrs = ["leaf_context.h"],
@@ -222,7 +222,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "system",
     srcs = ["system.cc"],
     hdrs = ["system.h"],
@@ -236,7 +236,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "leaf_system",
     srcs = ["leaf_system.cc"],
     hdrs = ["leaf_system.h"],
@@ -249,7 +249,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "diagram_continuous_state",
     srcs = ["diagram_continuous_state.cc"],
     hdrs = ["diagram_continuous_state.h"],
@@ -260,7 +260,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "diagram_context",
     srcs = ["diagram_context.cc"],
     hdrs = ["diagram_context.h"],
@@ -273,7 +273,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "diagram",
     srcs = ["diagram.cc"],
     hdrs = ["diagram.h"],
@@ -287,7 +287,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "diagram_builder",
     srcs = ["diagram_builder.cc"],
     hdrs = ["diagram_builder.h"],
@@ -298,7 +298,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "single_output_vector_source",
     srcs = ["single_output_vector_source.cc"],
     hdrs = ["single_output_vector_source.h"],

--- a/drake/systems/framework/test_utilities/BUILD
+++ b/drake/systems/framework/test_utilities/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/systems/framework/test_utilities/BUILD
+++ b/drake/systems/framework/test_utilities/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/systems/framework/test_utilities/BUILD
+++ b/drake/systems/framework/test_utilities/BUILD
@@ -2,10 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "test_utilities",
     testonly = 1,
     srcs = [],
@@ -16,7 +17,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "pack_value",
     testonly = 1,
     srcs = [],

--- a/drake/systems/lcm/BUILD
+++ b/drake/systems/lcm/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "translator",
     srcs = [
         "lcm_and_vector_base_translator.cc",
@@ -22,7 +22,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "lcm",
     srcs = [
         "lcm_publisher_system.cc",
@@ -42,7 +42,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "lcmt_drake_signal_translator",
     srcs = ["lcmt_drake_signal_translator.cc"],
     hdrs = ["lcmt_drake_signal_translator.h"],

--- a/drake/systems/lcm/BUILD
+++ b/drake/systems/lcm/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -56,7 +56,7 @@ drake_cc_library(
 
 # === test ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "lcm_publisher_system_test",
     deps = [
         ":lcm",
@@ -67,7 +67,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "lcm_subscriber_system_test",
     deps = [
         ":lcm",
@@ -77,7 +77,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "lcm_translator_dictionary_test",
     deps = [
         ":lcmt_drake_signal_translator",
@@ -87,7 +87,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "serializer_test",
     deps = [
         ":lcm",

--- a/drake/systems/plants/spring_mass_system/BUILD
+++ b/drake/systems/plants/spring_mass_system/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "spring_mass_system",
     srcs = ["spring_mass_system.cc"],
     hdrs = ["spring_mass_system.h"],

--- a/drake/systems/plants/spring_mass_system/BUILD
+++ b/drake/systems/plants/spring_mass_system/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -18,7 +18,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "spring_mass_system_test",
     deps = [
         ":spring_mass_system",

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -193,7 +193,7 @@ drake_cc_library(
     linkstatic = 1,
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "adder_test",
     deps = [
         ":adder",
@@ -202,7 +202,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "affine_system_test",
     deps = [
         ":affine_linear_test",
@@ -212,7 +212,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "constant_value_source_test",
     deps = [
         ":constant_value_source",
@@ -221,7 +221,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "constant_vector_source_test",
     deps = [
         ":constant_vector_source",
@@ -230,7 +230,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "demultiplexer_test",
     deps = [
         ":demultiplexer",
@@ -239,7 +239,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "gain_test",
     srcs = [
         "test/gain_scalartype_test.cc",
@@ -253,7 +253,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "integrator_test",
     deps = [
         ":integrator",
@@ -262,7 +262,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "linear_system_test",
     deps = [
         ":affine_linear_test",
@@ -272,7 +272,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "matrix_gain_test",
     deps = [
         ":affine_linear_test",
@@ -282,7 +282,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "multiplexer_test",
     deps = [
         ":multiplexer",
@@ -291,7 +291,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "pass_through_test",
     srcs = [
         "test/pass_through_scalartype_test.cc",
@@ -304,7 +304,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "random_source_test",
     deps = [
         ":random_source",
@@ -314,14 +314,14 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "saturation_test",
     deps = [
         ":saturation",
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "signal_logger_test",
     deps = [
         ":affine_system",
@@ -333,7 +333,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "trajectory_source_test",
     deps = [
         ":trajectory_source",
@@ -343,7 +343,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "zero_order_hold_test",
     deps = [
         ":zero_order_hold",

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "adder",
     srcs = ["adder.cc"],
     hdrs = ["adder.h"],
@@ -16,7 +16,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "affine_system",
     srcs = ["affine_system.cc"],
     hdrs = ["affine_system.h"],
@@ -26,7 +26,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "constant_value_source",
     srcs = ["constant_value_source.cc"],
     hdrs = [
@@ -39,7 +39,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "constant_vector_source",
     srcs = ["constant_vector_source.cc"],
     hdrs = ["constant_vector_source.h"],
@@ -50,7 +50,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "demultiplexer",
     srcs = ["demultiplexer.cc"],
     hdrs = ["demultiplexer.h"],
@@ -60,7 +60,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "gain",
     srcs = ["gain.cc"],
     hdrs = [
@@ -73,7 +73,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "integrator",
     srcs = ["integrator.cc"],
     hdrs = ["integrator.h"],
@@ -83,7 +83,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "linear_system",
     srcs = ["linear_system.cc"],
     hdrs = ["linear_system.h"],
@@ -96,7 +96,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "matrix_gain",
     srcs = ["matrix_gain.cc"],
     hdrs = ["matrix_gain.h"],
@@ -107,7 +107,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "multiplexer",
     srcs = ["multiplexer.cc"],
     hdrs = ["multiplexer.h"],
@@ -117,7 +117,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "pass_through",
     srcs = ["pass_through.cc"],
     hdrs = [
@@ -130,7 +130,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "random_source",
     srcs = ["random_source.cc"],
     hdrs = ["random_source.h"],
@@ -140,7 +140,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "saturation",
     srcs = ["saturation.cc"],
     hdrs = ["saturation.h"],
@@ -150,7 +150,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "signal_logger",
     srcs = ["signal_logger.cc"],
     hdrs = ["signal_logger.h"],
@@ -160,7 +160,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "trajectory_source",
     srcs = ["trajectory_source.cc"],
     hdrs = ["trajectory_source.h"],
@@ -171,7 +171,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "zero_order_hold",
     srcs = ["zero_order_hold.cc"],
     hdrs = [
@@ -186,7 +186,7 @@ cc_library(
 
 # === test/ ===
 
-cc_library(
+drake_cc_library(
     name = "affine_linear_test",
     testonly = 1,
     hdrs = ["test/affine_linear_test.h"],

--- a/drake/systems/rendering/BUILD
+++ b/drake/systems/rendering/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "pose_aggregator",
     srcs = ["pose_aggregator.cc"],
     hdrs = ["pose_aggregator.h"],
@@ -20,7 +20,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "pose_bundle",
     srcs = ["pose_bundle.cc"],
     hdrs = ["pose_bundle.h"],

--- a/drake/systems/rendering/BUILD
+++ b/drake/systems/rendering/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,7 +31,7 @@ drake_cc_library(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "pose_aggregator_test",
     linkstatic = 1,
     deps = [

--- a/drake/systems/robotInterfaces/BUILD
+++ b/drake/systems/robotInterfaces/BUILD
@@ -2,10 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "side",
     srcs = ["Side.cpp"],
     hdrs = ["Side.h"],

--- a/drake/systems/robotInterfaces/BUILD
+++ b/drake/systems/robotInterfaces/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/systems/robotInterfaces/BUILD
+++ b/drake/systems/robotInterfaces/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "sensors",
     srcs = [],
     hdrs = [],
@@ -17,7 +17,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "rotary_encoders",
     srcs = ["rotary_encoders.cc"],
     hdrs = ["rotary_encoders.h"],
@@ -27,7 +27,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "depth_sensor",
     srcs = [
         "depth_sensor.cc",

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -48,7 +48,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "rotary_encoders_test",
     deps = [
         ":rotary_encoders",
@@ -56,7 +56,7 @@ cc_googletest(
     ],
 )
 
-cc_googletest(
+drake_cc_googletest(
     name = "depth_sensor_test",
     srcs = ["test/depth_sensor_test.cc"],
     deps = [

--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -38,7 +38,7 @@ drake_cc_library(
 
 # === test/ ===
 
-cc_googletest(
+drake_cc_googletest(
     name = "direct_collocation_constraint_test",
     deps = [
         ":direct_collocation",

--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -2,11 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "direct_collocation",
     srcs = [
         "direct_collocation.cc",
@@ -23,7 +23,7 @@ cc_library(
     ],
 )
 
-cc_library(
+drake_cc_library(
     name = "direct_trajectory_optimization",
     srcs = ["direct_trajectory_optimization.cc"],
     hdrs = ["direct_trajectory_optimization.h"],

--- a/drake/thirdParty/BUILD
+++ b/drake/thirdParty/BUILD
@@ -3,9 +3,11 @@
 # This file contains rules for the Bazel build system.
 # See http://bazel.io/ .
 
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "spruce",
     srcs = ["bsd/spruce/spruce.cc"],
     hdrs = ["bsd/spruce/spruce.hh"],
@@ -13,13 +15,13 @@ cc_library(
     linkstatic = 1,
 )
 
-cc_library(
+drake_cc_library(
     name = "tinydir",
     hdrs = ["bsd/tinydir/tinydir.h"],
     linkstatic = 1,
 )
 
-cc_library(
+drake_cc_library(
     name = "tinyxml2",
     srcs = ["zlib/tinyxml2/tinyxml2.cpp"],
     hdrs = ["zlib/tinyxml2/tinyxml2.h"],

--- a/drake/thirdParty/BUILD
+++ b/drake/thirdParty/BUILD
@@ -3,7 +3,7 @@
 # This file contains rules for the Bazel build system.
 # See http://bazel.io/ .
 
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/thirdParty/BUILD
+++ b/drake/thirdParty/BUILD
@@ -3,7 +3,7 @@
 # This file contains rules for the Bazel build system.
 # See http://bazel.io/ .
 
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/util/BUILD
+++ b/drake/util/BUILD
@@ -2,10 +2,11 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
+load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+drake_cc_library(
     name = "util",
     srcs = [
         "drakeGeometryUtil.cpp",

--- a/drake/util/BUILD
+++ b/drake/util/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/util/BUILD
+++ b/drake/util/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "cc_googletest", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -28,7 +28,7 @@ def drake_cc_binary(
         deps=deps,
         **kwargs)
 
-def cc_googletest(
+def drake_cc_googletest(
         name,
         size=None,
         srcs=None,

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -1,5 +1,33 @@
 # -*- python -*-
 
+def drake_cc_library(
+        name,
+        hdrs=None,
+        srcs=None,
+        deps=None,
+        **kwargs):
+    """Creates a rule to declare a C++ library."""
+    native.cc_library(
+        name=name,
+        hdrs=hdrs,
+        srcs=srcs,
+        deps=deps,
+        **kwargs)
+
+def drake_cc_binary(
+        name,
+        hdrs=None,
+        srcs=None,
+        deps=None,
+        **kwargs):
+    """Creates a rule to declare a C++ binary."""
+    native.cc_binary(
+        name=name,
+        hdrs=hdrs,
+        srcs=srcs,
+        deps=deps,
+        **kwargs)
+
 def cc_googletest(
         name,
         size=None,


### PR DESCRIPTION
This is a no-op.  It is a first step towards specifying Drake-specific compiler flags in the BUILD files instead of the CROSSTOOL, as recommended by the Bazel team at https://github.com/bazelbuild/bazel/issues/2444.

@jwnimmer-tri for both levels of review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/4991)
<!-- Reviewable:end -->
