### PR TITLE
Set platform-specific C++ compiler flags in the macro rules.

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -110,3 +110,27 @@ config_setting(
     name = "apple",
     values = {"cpu": "darwin"},
 )
+
+config_setting(
+    name = "gcc5-linux",
+    values = {
+        "compiler": "gcc-5",
+        "cpu": "k8",
+    },
+)
+
+config_setting(
+    name = "gcc4.9-linux",
+    values = {
+        "compiler": "gcc-4.9",
+        "cpu": "k8",
+    },
+)
+
+config_setting(
+    name = "clang3.9-linux",
+    values = {
+        "compiler": "clang-3.9",
+        "cpu": "k8",
+    },
+)

--- a/tools/CROSSTOOL
+++ b/tools/CROSSTOOL
@@ -103,12 +103,6 @@ toolchain {
     linker_flag: "-Wl,--gc-sections"
   }
   linking_mode_flags { mode: DYNAMIC }
-
-  # Extra warning flags specific to Drake.
-  cxx_flag: "-Werror=extra"
-  cxx_flag: "-Werror=return-local-addr"
-  cxx_flag: "-Wno-unused-parameter"
-  cxx_flag: "-Wno-missing-field-initializers"
 }
 
 # GCC 4.9 on Linux
@@ -189,12 +183,6 @@ toolchain {
     linker_flag: "-Wl,--gc-sections"
   }
   linking_mode_flags { mode: DYNAMIC }
-
-  # Extra warning flags specific to Drake.
-  cxx_flag: "-Werror=extra"
-  cxx_flag: "-Werror=return-local-addr"
-  cxx_flag: "-Wno-unused-parameter"
-  cxx_flag: "-Wno-missing-field-initializers"
 }
 
 # Clang 3.9 on Linux
@@ -268,11 +256,6 @@ toolchain {
     linker_flag: "-Wl,--gc-sections"
   }
   linking_mode_flags { mode: DYNAMIC }
-
-  # Extra warning flags specific to Drake.
-  cxx_flag: "-Werror=inconsistent-missing-override"
-  cxx_flag: "-Werror=sign-compare"
-  cxx_flag: "-Werror=return-stack-address"
 }
 
 # Clang on OS X
@@ -369,9 +352,4 @@ toolchain {
     compiler_flag: "-fdata-sections"
   }
   linking_mode_flags { mode: DYNAMIC }
-
-  # Extra warning flags specific to Drake.
-  cxx_flag: "-Werror=inconsistent-missing-override"
-  cxx_flag: "-Werror=sign-compare"
-  cxx_flag: "-Werror=return-stack-address"
 }

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -4,7 +4,6 @@ build -c opt
 
 # Default build options.
 build --strip=never
-build --copt -Werror=all
 build --crosstool_top=//tools:default-toolchain
 # Only show warnings from Drake, not from externals.
 build --output_filter="^//"

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -1,10 +1,40 @@
 # -*- python -*-
 
+# The CLANG_FLAGS will be enabled for all C++ rules in the project when
+# building with clang.
+CLANG_FLAGS = [
+    "-Werror=all",
+    "-Werror=inconsistent-missing-override",
+    "-Werror=sign-compare",
+    "-Werror=return-stack-address",
+]
+
+# The GCC_FLAGS will be enabled for all C++ rules in the project when
+# building with gcc.
+GCC_FLAGS = [
+    "-Werror=all",
+    "-Werror=extra",
+    "-Werror=return-local-addr",
+    "-Wno-unused-parameter",
+    "-Wno-missing-field-initializers",
+]
+
+def _platform_copts(rule_copts):
+  """Returns both the rule_copts, and platform-specific copts."""
+  return select({
+      "//tools:gcc4.9-linux": GCC_FLAGS + rule_copts,
+      "//tools:gcc5-linux": GCC_FLAGS + rule_copts,
+      "//tools:clang3.9-linux": CLANG_FLAGS + rule_copts,
+      "//tools:apple": CLANG_FLAGS + rule_copts,
+      "//conditions:default": rule_copts,
+  })
+
 def drake_cc_library(
         name,
         hdrs=None,
         srcs=None,
         deps=None,
+        copts=[],
         **kwargs):
     """Creates a rule to declare a C++ library."""
     native.cc_library(
@@ -12,6 +42,7 @@ def drake_cc_library(
         hdrs=hdrs,
         srcs=srcs,
         deps=deps,
+        copts=_platform_copts(copts),
         **kwargs)
 
 def drake_cc_binary(
@@ -19,6 +50,7 @@ def drake_cc_binary(
         hdrs=None,
         srcs=None,
         deps=None,
+        copts=[],
         **kwargs):
     """Creates a rule to declare a C++ binary."""
     native.cc_binary(
@@ -26,6 +58,7 @@ def drake_cc_binary(
         hdrs=hdrs,
         srcs=srcs,
         deps=deps,
+        copts=_platform_copts(copts),
         **kwargs)
 
 def drake_cc_googletest(


### PR DESCRIPTION
Remove them from the CROSSTOOL.

Follows guidance from the Bazel team in https://github.com/bazelbuild/bazel/issues/2444.

@rpoyner-tri for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5004)
<!-- Reviewable:end -->
