### PR TITLE
Convert simple_car_gen.sh inline vectors to proto descriptions

### DIFF
--- a/drake/automotive/euler_floating_joint_state.named_vector
+++ b/drake/automotive/euler_floating_joint_state.named_vector
@@ -1,0 +1,24 @@
+element {
+    name: "x"
+    doc: "x"
+}
+element {
+    name: "y"
+    doc: "y"
+}
+element {
+    name: "z"
+    doc: "z"
+}
+element {
+    name: "roll"
+    doc: "roll"
+}
+element {
+    name: "pitch"
+    doc: "pitch"
+}
+element {
+    name: "yaw"
+    doc: "yaw"
+}

--- a/drake/automotive/simple_car_config.named_vector
+++ b/drake/automotive/simple_car_config.named_vector
@@ -1,0 +1,28 @@
+element {
+    name: "wheelbase"
+    doc: "wheelbase"
+}
+element {
+    name: "track"
+    doc: "track"
+}
+element {
+    name: "max_abs_steering_angle"
+    doc: "max_abs_steering_angle"
+}
+element {
+    name: "max_velocity"
+    doc: "max_velocity"
+}
+element {
+    name: "max_acceleration"
+    doc: "max_acceleration"
+}
+element {
+    name: "velocity_lookahead_time"
+    doc: "velocity_lookahead_time"
+}
+element {
+    name: "velocity_kp"
+    doc: "velocity_kp"
+}

--- a/drake/automotive/simple_car_gen.sh
+++ b/drake/automotive/simple_car_gen.sh
@@ -12,7 +12,7 @@ namespace="drake::automotive"
 source $drake/tools/lcm_vector_gen.sh
 
 gen_lcm_and_vector_from_proto "driving command" $drake/automotive/driving_command_fields.named_vector
-gen_lcm_and_vector "euler floating joint state" x y z roll pitch yaw
+gen_lcm_and_vector_from_proto "euler floating joint state" $drake/automotive/euler_floating_joint_state.named_vector
 gen_vector_proto "idm planner parameters" $drake/automotive/idm_planner_parameters.named_vector
-gen_lcm_and_vector "simple car state" x y heading velocity
-gen_lcm_and_vector "simple car config" wheelbase track max_abs_steering_angle max_velocity max_acceleration velocity_lookahead_time velocity_kp
+gen_lcm_and_vector_from_proto "simple car state" $drake/automotive/simple_car_state.named_vector
+gen_lcm_and_vector_from_proto "simple car config" $drake/automotive/simple_car_config.named_vector

--- a/drake/automotive/simple_car_state.named_vector
+++ b/drake/automotive/simple_car_state.named_vector
@@ -1,0 +1,16 @@
+element {
+    name: "x"
+    doc: "x"
+}
+element {
+    name: "y"
+    doc: "y"
+}
+element {
+    name: "heading"
+    doc: "heading"
+}
+element {
+    name: "velocity"
+    doc: "velocity"
+}


### PR DESCRIPTION
Extracted from #4939 and then widened to include all automotive vector descriptions (instead of just one).  Note that this is functionality-neutral -- the generated code is unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5005)
<!-- Reviewable:end -->
