### PR TITLE
Continue the drake_copyable porting of framework

### DIFF
--- a/drake/systems/framework/cache.h
+++ b/drake/systems/framework/cache.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
@@ -22,13 +23,11 @@ namespace internal {
 /// entries that depend on it.
 class CacheEntry {
  public:
-  // TODO(jwnimmer-tri) Should we use a drake_copyable macro here?  Right now,
-  // we are moveable via our copy ctor, rather than a move-specific overload.
-
   CacheEntry();
   ~CacheEntry();
 
-  // CacheEntry is copyable.
+  // Implements CopyConstructible and CopyAssignable directly, and
+  // MoveConstructible and MoveAssignable indirectly via copying.
   CacheEntry(const CacheEntry& other);
   CacheEntry& operator=(const CacheEntry& other);
 
@@ -81,6 +80,8 @@ class CacheEntry {
 /// Cache is not thread-safe. It is copyable, assignable, and movable.
 class Cache {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Cache)
+
   Cache();
   ~Cache();
 

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -29,9 +29,7 @@ class Value;
 /// sensitive code (e.g., inner loops), and the safer version otherwise.
 class AbstractValue {
  public:
-  // TODO(jwnimmer-tri) This should use DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN but
-  // in-tree code is currently using the move operations!  I will fix in a
-  // subsequent PR.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AbstractValue)
 
   AbstractValue() {}
   virtual ~AbstractValue();

--- a/drake/systems/primitives/constant_value_source-inl.h
+++ b/drake/systems/primitives/constant_value_source-inl.h
@@ -37,10 +37,7 @@ std::unique_ptr<SystemOutput<T>> ConstantValueSource<T>::AllocateOutput(
 template <typename T>
 void ConstantValueSource<T>::DoCalcOutput(const Context<T>& context,
                                         SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-  AbstractValue* output_data = output->GetMutableData(0);
-  *output_data = *source_value_;
+  output->GetMutableData(0)->SetFrom(*source_value_);
 }
 
 }  // namespace systems


### PR DESCRIPTION
Continue the drake_copyable porting of framework
- Convert Cache to the new idiom
- Convert ConstantValueSource to not use copy-assign(!)
- Delete Value's copy and move operations

These changes have been broken out of #4939, where they have already been reviewed.

This is a portion of #4861.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5006)
<!-- Reviewable:end -->
