### PR TITLE
Renames libdrakeLCMSystem to be libdrakeOldLcmSystem.

### DIFF
--- a/drake/multibody/rigid_body_system1/CMakeLists.txt
+++ b/drake/multibody/rigid_body_system1/CMakeLists.txt
@@ -6,19 +6,19 @@ drake_install_pkg_config_file(drake-system1
   REQUIRES eigen3)
 
 if(lcm_FOUND)
-  add_library_with_exports(LIB_NAME drakeLCMSystem SOURCE_FILES
+  add_library_with_exports(LIB_NAME drakeOldLcmSystem SOURCE_FILES
     LCMSystem.h
     LCMSystem.cpp
     )
-  target_link_libraries(drakeLCMSystem
+  target_link_libraries(drakeOldLcmSystem
     drakeLCMTypes
     Eigen3::Eigen
     lcm)
 
-  drake_install_libraries(drakeLCMSystem)
+  drake_install_libraries(drakeOldLcmSystem)
   drake_install_pkg_config_file(drake-lcm-system
-    TARGET drakeLCMSystem
-    LIBS -ldrakeLCMSystem
+    TARGET drakeOldLcmSystem
+    LIBS -ldrakeOldLcmSystem
     REQUIRES
       eigen3
       drake-lcmtypes-cpp
@@ -61,7 +61,7 @@ if (lcm_FOUND)
   add_executable(rigidBodyLCMNode rigidBodyLCMNode.cpp)
   target_link_libraries(rigidBodyLCMNode
       Threads::Threads
-      drakeLCMSystem
+      drakeOldLcmSystem
       drakeRBSystem
       gflags)
   drake_install_executables(TARGETS rigidBodyLCMNode)


### PR DESCRIPTION
Fix-forwards a breakage caused by #4988. Apparently, the dynamic loader on OSX is case-insensitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5010)
<!-- Reviewable:end -->
