### PR TITLE
Refactor symbolic tests

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -152,6 +152,17 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "symbolic_test_util",
+    hdrs = [
+        "test/symbolic_test_util.h",
+    ],
+    deps = [
+        ":symbolic",
+    ],
+    testonly = 1,
+)
+
 cc_library(
     name = "variable",
     srcs = ["variable.cc"],
@@ -391,6 +402,7 @@ drake_cc_googletest(
         ":common",
         ":monomial",
         ":symbolic",
+        ":symbolic_test_util",
     ],
 )
 
@@ -439,6 +451,7 @@ drake_cc_googletest(
     deps = [
         ":common",
         ":symbolic",
+        ":symbolic_test_util",
     ],
 )
 
@@ -463,6 +476,7 @@ drake_cc_googletest(
     deps = [
         ":common",
         ":symbolic",
+        ":symbolic_test_util",
     ],
 )
 
@@ -471,6 +485,7 @@ drake_cc_googletest(
     deps = [
         ":common",
         ":symbolic",
+        ":symbolic_test_util",
     ],
 )
 

--- a/drake/common/test/monomial_test.cc
+++ b/drake/common/test/monomial_test.cc
@@ -7,6 +7,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic_expression.h"
+#include "drake/common/test/symbolic_test_util.h"
 #include "drake/common/variable.h"
 
 using std::unordered_map;
@@ -15,30 +16,7 @@ namespace drake {
 namespace symbolic {
 namespace {
 
-bool ExprEqual(const Expression& e1, const Expression& e2) {
-  return e1.EqualTo(e2);
-}
-
-// Compare two Eigen::Matrix<Expression> m1 and m2.
-//
-// TODO(soonho): Make CompareMatrices in eigen_matrix_compare.h compatible
-// with Eigen::Matrix<symbolic::Expression> and use that instead of this.
-bool MatrixEqual(const drake::MatrixX<Expression>& m1,
-                 const drake::MatrixX<Expression>& m2) {
-  if (m1.rows() != m2.rows() || m1.cols() != m2.cols()) {
-    return false;
-  }
-  for (int i{0}; i < m1.rows(); ++i) {
-    for (int j{0}; j < m1.cols(); ++j) {
-      const Expression& e1{m1(i, j)};
-      const Expression& e2{m2(i, j)};
-      if (!e1.EqualTo(e2)) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
+using test::ExprEqual;
 
 class MonomialTest : public ::testing::Test {
  protected:
@@ -91,8 +69,8 @@ TEST_F(MonomialTest, MonomialBasis_x_0) {
   // MonomialBasis({x}, 0)
   expected << Expression{1.0};
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_2) {
@@ -108,8 +86,8 @@ TEST_F(MonomialTest, MonomialBasis_x_2) {
               1.0;
   // clang-format on
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_0) {
@@ -121,8 +99,8 @@ TEST_F(MonomialTest, MonomialBasis_x_y_0) {
   // MonomialBasis({x, y}, 0)
   expected << Expression{1.0};
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_1) {
@@ -138,8 +116,8 @@ TEST_F(MonomialTest, MonomialBasis_x_y_1) {
               1.0;
   // clang-format on
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_2) {
@@ -158,8 +136,8 @@ TEST_F(MonomialTest, MonomialBasis_x_y_2) {
               1.0;
   // clang-format on
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_3) {
@@ -182,8 +160,8 @@ TEST_F(MonomialTest, MonomialBasis_x_y_3) {
               1;
   // clang-format on
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_z_2) {
@@ -208,8 +186,8 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_2) {
               1;
   // clang-format on
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_z_3) {
@@ -243,8 +221,8 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_3) {
               1;
   // clang-format on
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_z_w_3) {
@@ -293,8 +271,8 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_w_3) {
               1;
   // clang-format on
 
-  EXPECT_PRED2(MatrixEqual, basis1, expected);
-  EXPECT_PRED2(MatrixEqual, basis2, expected);
+  EXPECT_EQ(basis1, expected);
+  EXPECT_EQ(basis2, expected);
 }
 
 }  // namespace

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -19,6 +19,7 @@
 #include "drake/common/environment.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic_formula.h"
+#include "drake/common/test/symbolic_test_util.h"
 #include "drake/common/variable.h"
 #include "drake/common/variables.h"
 
@@ -39,21 +40,10 @@ namespace drake {
 namespace symbolic {
 namespace {
 
-bool ExprEqual(const Expression& e1, const Expression& e2) {
-  return e1.EqualTo(e2);
-}
-
-bool ExprNotEqual(const Expression& e1, const Expression& e2) {
-  return !ExprEqual(e1, e2);
-}
-
-bool ExprLess(const Expression& e1, const Expression& e2) {
-  return e1.Less(e2);
-}
-
-bool ExprNotLess(const Expression& e1, const Expression& e2) {
-  return !ExprLess(e1, e2);
-}
+using test::ExprEqual;
+using test::ExprLess;
+using test::ExprNotEqual;
+using test::ExprNotLess;
 
 // Checks if a given 'expressions' is ordered by Expression::Less.
 static void CheckOrdering(const vector<Expression>& expressions) {

--- a/drake/common/test/symbolic_formula_test.cc
+++ b/drake/common/test/symbolic_formula_test.cc
@@ -13,6 +13,7 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/environment.h"
 #include "drake/common/symbolic_expression.h"
+#include "drake/common/test/symbolic_test_util.h"
 #include "drake/common/variable.h"
 #include "drake/common/variables.h"
 
@@ -20,43 +21,19 @@ namespace drake {
 namespace symbolic {
 namespace {
 
-using std::all_of;
-using std::any_of;
 using std::map;
 using std::set;
 using std::unordered_map;
 using std::unordered_set;
 using std::vector;
 
-template <typename F>
-bool all_of(const vector<Formula>& formulas, const F& f) {
-  return all_of(formulas.begin(), formulas.end(), f);
-}
-
-template <typename F>
-bool any_of(const vector<Formula>& formulas, const F& f) {
-  return any_of(formulas.begin(), formulas.end(), f);
-}
-
-static bool ExprEqual(const Expression& e1, const Expression& e2) {
-  return e1.EqualTo(e2);
-}
-
-static bool FormulaEqual(const Formula& f1, const Formula& f2) {
-  return f1.EqualTo(f2);
-}
-
-static bool FormulaNotEqual(const Formula& f1, const Formula& f2) {
-  return !FormulaEqual(f1, f2);
-}
-
-static bool FormulaLess(const Formula& f1, const Formula& f2) {
-  return f1.Less(f2);
-}
-
-static bool FormulaNotLess(const Formula& f1, const Formula& f2) {
-  return !FormulaLess(f1, f2);
-}
+using test::all_of;
+using test::any_of;
+using test::ExprEqual;
+using test::FormulaEqual;
+using test::FormulaLess;
+using test::FormulaNotEqual;
+using test::FormulaNotLess;
 
 // Checks if a given 'formulas' is ordered by Formula::Less.
 static void CheckOrdering(const vector<Formula>& formulas) {

--- a/drake/common/test/symbolic_test_util.h
+++ b/drake/common/test/symbolic_test_util.h
@@ -1,0 +1,58 @@
+#include <algorithm>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/symbolic_expression.h"
+#include "drake/common/symbolic_formula.h"
+#include "drake/common/variable.h"
+
+namespace drake {
+namespace symbolic {
+namespace test {
+
+inline bool ExprEqual(const Expression& e1, const Expression& e2) {
+  return e1.EqualTo(e2);
+}
+
+inline bool ExprNotEqual(const Expression& e1, const Expression& e2) {
+  return !ExprEqual(e1, e2);
+}
+
+inline bool ExprLess(const Expression& e1, const Expression& e2) {
+  return e1.Less(e2);
+}
+
+inline bool ExprNotLess(const Expression& e1, const Expression& e2) {
+  return !ExprLess(e1, e2);
+}
+
+template <typename F>
+bool all_of(const std::vector<Formula>& formulas, const F& f) {
+  return std::all_of(formulas.begin(), formulas.end(), f);
+}
+
+template <typename F>
+bool any_of(const std::vector<Formula>& formulas, const F& f) {
+  return std::any_of(formulas.begin(), formulas.end(), f);
+}
+
+inline bool FormulaEqual(const Formula& f1, const Formula& f2) {
+  return f1.EqualTo(f2);
+}
+
+inline bool FormulaNotEqual(const Formula& f1, const Formula& f2) {
+  return !FormulaEqual(f1, f2);
+}
+
+inline bool FormulaLess(const Formula& f1, const Formula& f2) {
+  return f1.Less(f2);
+}
+
+inline bool FormulaNotLess(const Formula& f1, const Formula& f2) {
+  return !FormulaLess(f1, f2);
+}
+
+}  // namespace test
+}  // namespace symbolic
+}  // namespace drake

--- a/drake/common/test/variable_overloading_test.cc
+++ b/drake/common/test/variable_overloading_test.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "drake/common/symbolic_expression.h"
+#include "drake/common/test/symbolic_test_util.h"
 #include "drake/common/variable.h"
 
 namespace drake {
@@ -10,10 +11,7 @@ namespace {
 
 using std::ostringstream;
 using symbolic::Expression;
-
-bool ExprEqual(const Expression& e1, const Expression& e2) {
-  return e1.EqualTo(e2);
-}
+using symbolic::test::ExprEqual;
 
 // Provides common variables and matrices that are used by the
 // following tests.

--- a/drake/common/test/variable_test.cc
+++ b/drake/common/test/variable_test.cc
@@ -11,7 +11,6 @@
 #include "gtest/gtest.h"
 
 namespace drake {
-namespace symbolic {
 namespace {
 
 using std::move;
@@ -152,5 +151,4 @@ TEST_F(VariableTest, EigenVariableMatrixOutput) {
 }
 
 }  // namespace
-}  // namespace symbolic
 }  // namespace drake

--- a/drake/common/test/variables_test.cc
+++ b/drake/common/test/variables_test.cc
@@ -5,11 +5,10 @@
 #include "drake/common/variable.h"
 
 namespace drake {
-namespace symbolic {
 namespace {
 
 // Provides common variables that are used by the following tests.
-class SymbolicVariablesTest : public ::testing::Test {
+class VariablesTest : public ::testing::Test {
  protected:
   const Variable x_{"x"};
   const Variable y_{"y"};
@@ -18,14 +17,14 @@ class SymbolicVariablesTest : public ::testing::Test {
   const Variable v_{"v"};
 };
 
-TEST_F(SymbolicVariablesTest, HashEq) {
+TEST_F(VariablesTest, HashEq) {
   const Variables vars1{x_, y_, z_};
   const Variables vars2{z_, y_, x_};
   EXPECT_EQ(vars1.get_hash(), vars2.get_hash());
   EXPECT_EQ(vars1, vars2);
 }
 
-TEST_F(SymbolicVariablesTest, InsertSize) {
+TEST_F(VariablesTest, InsertSize) {
   Variables vars1{x_, y_, z_};
   EXPECT_EQ(vars1.size(), 3u);
 
@@ -35,7 +34,7 @@ TEST_F(SymbolicVariablesTest, InsertSize) {
   EXPECT_EQ(vars1.size(), 3u);
 }
 
-TEST_F(SymbolicVariablesTest, Plus) {
+TEST_F(VariablesTest, Plus) {
   Variables vars1{x_, y_, z_};
   EXPECT_EQ(vars1.size(), 3u);
   EXPECT_TRUE(vars1.include(x_));
@@ -56,7 +55,7 @@ TEST_F(SymbolicVariablesTest, Plus) {
   EXPECT_TRUE(vars1.include(z_));
 }
 
-TEST_F(SymbolicVariablesTest, Erase) {
+TEST_F(VariablesTest, Erase) {
   Variables vars1{x_, y_, z_};
   Variables vars2{y_, z_, w_};
   EXPECT_EQ(vars1.size(), 3u);
@@ -72,7 +71,7 @@ TEST_F(SymbolicVariablesTest, Erase) {
   EXPECT_FALSE(vars1.include(z_));
 }
 
-TEST_F(SymbolicVariablesTest, Minus) {
+TEST_F(VariablesTest, Minus) {
   Variables vars1{x_, y_, z_};
   EXPECT_EQ(vars1.size(), 3u);
   EXPECT_TRUE(vars1.include(x_));
@@ -98,7 +97,7 @@ TEST_F(SymbolicVariablesTest, Minus) {
   EXPECT_TRUE(vars2.include(x_));
 }
 
-TEST_F(SymbolicVariablesTest, IsSubsetOf) {
+TEST_F(VariablesTest, IsSubsetOf) {
   const Variables vars1{x_, y_, z_, w_, v_};
   const Variables vars2{x_, y_};
   const Variables vars3{x_, y_, z_};
@@ -141,7 +140,7 @@ TEST_F(SymbolicVariablesTest, IsSubsetOf) {
   EXPECT_TRUE(vars5.IsSubsetOf(vars5));
 }
 
-TEST_F(SymbolicVariablesTest, IsStrictSubsetOf) {
+TEST_F(VariablesTest, IsStrictSubsetOf) {
   const Variables vars1{x_, y_, z_, w_, v_};
   const Variables vars2{x_, y_};
   const Variables vars3{x_, y_, z_};
@@ -184,7 +183,7 @@ TEST_F(SymbolicVariablesTest, IsStrictSubsetOf) {
   EXPECT_FALSE(vars5.IsStrictSubsetOf(vars5));
 }
 
-TEST_F(SymbolicVariablesTest, IsSuperSetOf) {
+TEST_F(VariablesTest, IsSuperSetOf) {
   const Variables vars1{x_, y_, z_, w_, v_};
   const Variables vars2{x_, y_};
   const Variables vars3{x_, y_, z_};
@@ -227,7 +226,7 @@ TEST_F(SymbolicVariablesTest, IsSuperSetOf) {
   EXPECT_TRUE(vars5.IsSupersetOf(vars5));
 }
 
-TEST_F(SymbolicVariablesTest, IsStrictSuperSetOf) {
+TEST_F(VariablesTest, IsStrictSuperSetOf) {
   const Variables vars1{x_, y_, z_, w_, v_};
   const Variables vars2{x_, y_};
   const Variables vars3{x_, y_, z_};
@@ -270,7 +269,7 @@ TEST_F(SymbolicVariablesTest, IsStrictSuperSetOf) {
   EXPECT_FALSE(vars5.IsStrictSupersetOf(vars5));
 }
 
-TEST_F(SymbolicVariablesTest, ToString) {
+TEST_F(VariablesTest, ToString) {
   const Variables vars0{};
   const Variables vars1{x_, y_, z_, w_, v_};
   const Variables vars2{x_, y_};
@@ -286,5 +285,4 @@ TEST_F(SymbolicVariablesTest, ToString) {
   EXPECT_EQ(vars5.to_string(), "{w, v}");
 }
 }  // namespace
-}  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
 - Use "test" namespace instead of anonymous namespace.
 - Factor out common test methods such as `ExprEqual` into
   `common/test/symbolic_test_util.h`.
 - Remove `MatrixEqual` in `monomial_test.cc`. We find that `operator==`
   just works to compare two `Eigen::Matrix<symbolic::Expression>`s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5011)
<!-- Reviewable:end -->
