### PR TITLE
sensors::CameraInfo: Add CameraInfo class and the unit test

### DIFF
--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -16,8 +16,23 @@ drake_cc_library(
     linkstatic = 1,
     deps = [
         ":accelerometer",
+        ":camera_info",
         ":depth_sensor",
         ":rotary_encoders",
+    ],
+)
+
+drake_cc_library(
+    name = "camera_info",
+    srcs = [
+        "camera_info.cc",
+    ],
+    hdrs = [
+        "camera_info.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//drake/systems/framework",
     ],
 )
 
@@ -112,6 +127,14 @@ drake_cc_binary(
 )
 
 # === test/ ===
+
+drake_cc_googletest(
+    name = "camera_info_test",
+    deps = [
+        ":camera_info",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
 
 drake_cc_googletest(
     name = "rotary_encoders_test",

--- a/drake/systems/sensors/CMakeLists.txt
+++ b/drake/systems/sensors/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(drakeSensors_SRC_FILES
     accelerometer.cc
     accelerometer_output.cc
+    camera_info.cc
     depth_sensor.cc
     depth_sensor_output.cc
     depth_sensor_specification.cc
@@ -9,6 +10,7 @@ set(drakeSensors_SRC_FILES
 set(drakeSensors_HEADERS
     accelerometer.h
     accelerometer_output.h
+    camera_info.h
     depth_sensor.h
     depth_sensor_output.h
     depth_sensor_specification.h

--- a/drake/systems/sensors/camera_info.cc
+++ b/drake/systems/sensors/camera_info.cc
@@ -1,0 +1,15 @@
+#include "drake/systems/sensors/camera_info.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+CameraInfo::CameraInfo(uint32_t width, uint32_t height, double vertical_fov_rad)
+    : CameraInfo(width, height, width * 0.5 / std::tan(
+          0.5 * width / height * vertical_fov_rad),
+                 height * 0.5 / std::tan(0.5 * vertical_fov_rad),
+                 width * 0.5, height * 0.5) {}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/camera_info.cc
+++ b/drake/systems/sensors/camera_info.cc
@@ -4,6 +4,20 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
+CameraInfo::CameraInfo(int width, int height, double focal_x, double focal_y,
+             double center_x, double center_y)
+    : width_(width), height_(height), intrinsic_matrix_((
+          Eigen::Matrix3d() << focal_x, 0., center_x,
+                               0., focal_y, center_y,
+                               0., 0., 1.).finished()) {
+  DRAKE_ASSERT(width > 0);
+  DRAKE_ASSERT(height > 0);
+  DRAKE_ASSERT(focal_x > 0);
+  DRAKE_ASSERT(focal_y > 0);
+  DRAKE_ASSERT(center_x > 0 && center_x < static_cast<double>(width));
+  DRAKE_ASSERT(center_y > 0 && center_y < static_cast<double>(height));
+}
+
 CameraInfo::CameraInfo(int width, int height, double vertical_fov_rad)
     : CameraInfo(width, height, width * 0.5 / std::tan(
           0.5 * width / height * vertical_fov_rad),

--- a/drake/systems/sensors/camera_info.cc
+++ b/drake/systems/sensors/camera_info.cc
@@ -4,7 +4,7 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
-CameraInfo::CameraInfo(uint32_t width, uint32_t height, double vertical_fov_rad)
+CameraInfo::CameraInfo(int width, int height, double vertical_fov_rad)
     : CameraInfo(width, height, width * 0.5 / std::tan(
           0.5 * width / height * vertical_fov_rad),
                  height * 0.5 / std::tan(0.5 * vertical_fov_rad),

--- a/drake/systems/sensors/camera_info.cc
+++ b/drake/systems/sensors/camera_info.cc
@@ -19,8 +19,9 @@ CameraInfo::CameraInfo(int width, int height, double focal_x, double focal_y,
 }
 
 CameraInfo::CameraInfo(int width, int height, double vertical_fov_rad)
-    : CameraInfo(width, height, width * 0.5 / std::tan(
-          0.5 * width / height * vertical_fov_rad),
+    : CameraInfo(width, height,
+                 width * 0.5 / std::tan(
+                     0.5 * width / height * vertical_fov_rad),
                  height * 0.5 / std::tan(0.5 * vertical_fov_rad),
                  width * 0.5, height * 0.5) {}
 

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -11,6 +11,43 @@ namespace sensors {
 /// Simple data structure for camera information that includes the image size
 /// and camera intrinsic parameters.
 ///
+/// To clarify the terminology used to describe 2D and/or 3D spaces throughout
+/// the class, we use `coordinate system` rather than `frame`.  Since the term
+/// `frame` in the computer vision field has two major meaning: a synonym of
+/// coordinate system, and a snaphot out of consecutively captured images.  To
+/// ensure the reader will not be confused, we clearly differenciate the use of
+/// the terms `coordinate system` and `frame`.
+///
+/// There are three types of the coordinate systems that you should be aware of:
+/// 1) `camera coordinate system`, 2) `image coordinate system`, 3) `pixel`
+/// `coordinate system`.
+/// The `camera coordinate system` expresses camera's 6D pose with regard to the
+/// world coordinate system.  We have chosen the axes in the `camera coordinate`
+/// `system` to be `X-right`, `Y-down` and `Z-forward`.  The `Z` axis is also
+/// called `optical axis`.  Note that the each axis is expressed by the upper
+/// case like `(X, Y, Z)` to distinguish from those of the `image coordinate`
+/// `system` which we explain next.
+/// The `image coordinate system` is the 2D coordinate system made by projecting
+/// the `camera coordinate system` onto the 2D image plane which is
+/// perpendicular to the `optical axis`.  Therefore, the direction of the each
+/// axis is `x-right` and `y-down`, and the origin of the `image coordinate`
+/// `system` is located at the crossing point between the 2D image plane and the
+/// `optical axis`.  This origin is called `image center` or `principal point`.
+/// Note that the each axis is expressed by the lower case like `(x, y)`.
+/// The `pixel coordinate system` is also the 2D coordinate system.  The main
+/// differences between the `pixel coordinate system` and the `image coordinate`
+/// `system` are the location of the origin and the direction of the axes.  We
+/// have chosen the origin of the `pixel coordinate system` to be the left-upper
+/// corner in the image and the direction of the each axis to be the same as
+/// those of the `image coordinate system`.  The axes of the `pixel coordinate`
+/// `system` are expressed by using the `u` and `v`, therefore the directions of
+/// the axes are `u-right` and `v-down`.
+///
+/// For more detail including the explanation for the focal lengths, refer to:
+/// http://docs.opencv.org/2.4/modules/calib3d/doc/
+/// camera_calibration_and_3d_reconstruction.html and https://en.wikipedia.org/
+/// wiki/Pinhole_camera_model
+///
 /// @ingroup sensor_systems
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
 // needed.
@@ -20,12 +57,12 @@ class CameraInfo {
   ///
   /// @param width The image width in pixels, must be greater than zero.
   /// @param height The image height in pixels, must be greater than zero.
-  /// @param focal_x The focal length for the x direction in pixels.
-  /// @param focal_y The focal length for the y direction in pixels.
-  /// @param center_x X value at the image center in the image coordinate system
-  /// in pixels.
-  /// @param center_y Y value at the image center in the image coordinate system
-  /// in pixels.
+  /// @param focal_x The focal length x in pixels.
+  /// @param focal_y The focal length y in pixels.
+  /// @param center_x The image center x with regard to the pixel coordinate
+  /// system in pixels.
+  /// @param center_y The image center y with regard to the pixel coordinate
+  /// system in pixels.
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y)
       : width_(width), height_(height), intrinsic_matrix_((
@@ -40,22 +77,22 @@ class CameraInfo {
     DRAKE_ASSERT(center_y > 0 && center_y < static_cast<double>(height));
   }
 
-  /// Constructor that sets the image size and vertical field of view (fov).  We
-  /// assume there is no image offset, so the center of the image `(center_x,`
+  /// Constructor that sets the image size and vertical field of view `fov_y`.
+  /// We assume there is no image offset, so the image center `(center_x,`
   /// `center_y)` is equal to `(width / 2, height / 2)`.  The horizontal field
-  /// of view is calculated by the aspect ratio of the image width and height
-  /// together with the vertical field of view. The focal lengths `focal_x` and
-  /// `focal_y` are calculated by both of the field of views:
+  /// of view `fov_x`is calculated by the aspect ratio of the image width and
+  /// height together with the vertical field of view. The focal lengths
+  /// `focal_x` and `focal_y` are calculated by both of the field of views:
   /// <pre>
-  ///   focal_x = width / 2 / tan(horizontal_fov / 2)
-  ///   focal_y = height / 2 / tan(vertical_fov / 2)
+  ///   focal_x = width / 2 / tan(fov_x / 2)
+  ///   focal_y = height / 2 / tan(fov_y / 2)
   /// </pre>
-  /// where `horizontal_fov = width / height * vertical_fov`.
+  /// where `fov_x = width / height * fov_x`.
   ///
   /// @param width The image width in pixels, must be greater than zero.
   /// @param height The image height in pixels, must be greater than zero.
-  /// @param vertical_fov The vertical field of view.
-  CameraInfo(int width, int height, double vertical_fov);
+  /// @param fov_y The vertical field of view.
+  CameraInfo(int width, int height, double fov_y);
 
   /// Default copy constructor.
   CameraInfo(const CameraInfo&) = default;
@@ -73,16 +110,16 @@ class CameraInfo {
   /// Returns the height of the image in pixels.
   int height() const { return height_; }
 
-  /// Returns the focal length for the x direction in pixels.
+  /// Returns the focal length x in pixels.
   double focal_x() const { return intrinsic_matrix_(0, 0); }
 
-  /// Returns the focal length for the y direction in pixels.
+  /// Returns the focal length y in pixels.
   double focal_y() const { return intrinsic_matrix_(1, 1); }
 
-  /// Returns the center of image for the x direction in pixels.
+  /// Returns the image center x value in pixels.
   double center_x() const { return intrinsic_matrix_(0, 2); }
 
-  /// Returns the center of image for the y direction in pixels.
+  /// Returns the image center y value in pixels.
   double center_y() const { return intrinsic_matrix_(1, 2); }
 
   /// Returns the camera intrinsic matrix.

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -12,20 +12,20 @@ namespace sensors {
 /// and camera intrinsic parameters.
 ///
 /// @ingroup sensor_systems
-// TODO(kunimatsu-tri) Add camera distortion parameters and other things when
+// TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
 // needed.
 class CameraInfo {
  public:
-  /// Constructor with image size, focal lengths and center of image.
+  /// Constructor that directly sets the image size, center, and focal lengths.
   ///
-  /// @param width Size of width for image in pixels which should be greater
-  /// than zero
-  /// @param height Size of height for image in pixels which should be greater
-  /// than zero
-  /// @param fx Focal length for x direction in pixels
-  /// @param fy Focal length for y direction in pixels
-  /// @param cx X value for center of image at image coordinate system in pixels
-  /// @param cy Y value for center of image at image coordinate system in pixels
+  /// @param width The image width in pixels, must be greater than zero.
+  /// @param height The image height in pixels, must be greater than zero.
+  /// @param fx The focal length for the x direction in pixels.
+  /// @param fy The focal length for the y direction in pixels.
+  /// @param cx X value for the image center at image coordinate system in
+  /// pixels.
+  /// @param cy Y value for the image center at image coordinate system in
+  /// pixels.
   CameraInfo(int width, int height, double fx, double fy, double cx, double cy)
       : width_(width), height_(height), intrinsic_matrix_(
             (Eigen::Matrix3d() <<
@@ -38,21 +38,21 @@ class CameraInfo {
     DRAKE_ASSERT(cy > 0 && cy < static_cast<double>(height));
   }
 
-  /// Constructor with image size and vertical field of view (fov).  We assume
-  /// there is no image offset, so the center of the image `(cx, cy)` is equal
-  /// to `(width / 2, height / 2)`.  The horizontal field of view is calculated
-  /// by the aspect ratio of the image width and height together with the
-  /// vertical field of view. The focal lengths "fx" and "fy" are calculated by
-  /// both of the field of views:
+  /// Constructor that sets the image size, vertical field of view (fov).  We
+  /// assume there is no image offset, so the center of the image `(cx, cy)` is
+  /// equal to `(width / 2, height / 2)`.  The horizontal field of view is
+  /// calculated by the aspect ratio of the image width and height together with
+  /// the vertical field of view. The focal lengths `fx` and `fy` are calculated
+  /// by both of the field of views:
   /// <pre>
   ///   fx = width / 2 / tan(horizontal_fov / 2)
   ///   fy = height / 2 / tan(vertical_fov / 2)
   /// </pre>
-  /// where horizontal_fov = width / height * vertical_fov.
+  /// where `horizontal_fov = width / height * vertical_fov`.
   ///
-  /// @param width Size of width for image which should be greater than zero
-  /// @param height Size of height for image which should be greater than zero
-  /// @param vertical_fov Vertical field of view angle
+  /// @param width The image width in pixels, must be greater than zero.
+  /// @param height The image height in pixels, must be greater than zero.
+  /// @param vertical_fov The vertical field of view.
   CameraInfo(int width, int height, double vertical_fov);
 
   /// Default copy constructor.
@@ -71,16 +71,16 @@ class CameraInfo {
   /// Returns the height of the image in pixels.
   int height() const { return height_; }
 
-  /// Returns the focal length for x direction in pixels.
+  /// Returns the focal length for the x direction in pixels.
   double focal_x() const { return intrinsic_matrix_(0, 0); }
 
-  /// Returns the focal length for y direction in pixels.
+  /// Returns the focal length for the y direction in pixels.
   double focal_y() const { return intrinsic_matrix_(1, 1); }
 
-  /// Returns the center of image for x direction in pixels.
+  /// Returns the center of image for the x direction in pixels.
   double center_x() const { return intrinsic_matrix_(0, 2); }
 
-  /// Returns the center of image for y direction in pixels.
+  /// Returns the center of image for the y direction in pixels.
   double center_y() const { return intrinsic_matrix_(1, 2); }
 
   /// Returns the camera intrinsic matrix.

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -20,33 +20,35 @@ class CameraInfo {
   ///
   /// @param width The image width in pixels, must be greater than zero.
   /// @param height The image height in pixels, must be greater than zero.
-  /// @param fx The focal length for the x direction in pixels.
-  /// @param fy The focal length for the y direction in pixels.
-  /// @param cx X value for the image center at image coordinate system in
+  /// @param focal_x The focal length for the x direction in pixels.
+  /// @param focal_y The focal length for the y direction in pixels.
+  /// @param center_x X value for the image center at image coordinate system in
   /// pixels.
-  /// @param cy Y value for the image center at image coordinate system in
+  /// @param center_y Y value for the image center at image coordinate system in
   /// pixels.
-  CameraInfo(int width, int height, double fx, double fy, double cx, double cy)
-      : width_(width), height_(height), intrinsic_matrix_(
-            (Eigen::Matrix3d() <<
-             fx, 0., cx, 0., fy, cy, 0., 0., 1.).finished()) {
+  CameraInfo(int width, int height, double focal_x, double focal_y,
+             double center_x, double center_y)
+      : width_(width), height_(height), intrinsic_matrix_((
+            Eigen::Matrix3d() << focal_x, 0., center_x,
+                                 0., focal_y, center_y,
+                                 0., 0., 1.).finished()) {
     DRAKE_ASSERT(width > 0);
     DRAKE_ASSERT(height > 0);
-    DRAKE_ASSERT(fx > 0);
-    DRAKE_ASSERT(fy > 0);
-    DRAKE_ASSERT(cx > 0 && cx < static_cast<double>(width));
-    DRAKE_ASSERT(cy > 0 && cy < static_cast<double>(height));
+    DRAKE_ASSERT(focal_x > 0);
+    DRAKE_ASSERT(focal_y > 0);
+    DRAKE_ASSERT(center_x > 0 && center_x < static_cast<double>(width));
+    DRAKE_ASSERT(center_y > 0 && center_y < static_cast<double>(height));
   }
 
-  /// Constructor that sets the image size, vertical field of view (fov).  We
-  /// assume there is no image offset, so the center of the image `(cx, cy)` is
-  /// equal to `(width / 2, height / 2)`.  The horizontal field of view is
-  /// calculated by the aspect ratio of the image width and height together with
-  /// the vertical field of view. The focal lengths `fx` and `fy` are calculated
-  /// by both of the field of views:
+  /// Constructor that sets the image size and vertical field of view (fov).  We
+  /// assume there is no image offset, so the center of the image `(center_x,`
+  /// `center_y)` is equal to `(width / 2, height / 2)`.  The horizontal field
+  /// of view is calculated by the aspect ratio of the image width and height
+  /// together with the vertical field of view. The focal lengths `focal_x` and
+  /// `focal_y` are calculated by both of the field of views:
   /// <pre>
-  ///   fx = width / 2 / tan(horizontal_fov / 2)
-  ///   fy = height / 2 / tan(vertical_fov / 2)
+  ///   focal_x = width / 2 / tan(horizontal_fov / 2)
+  ///   focal_y = height / 2 / tan(vertical_fov / 2)
   /// </pre>
   /// where `horizontal_fov = width / height * vertical_fov`.
   ///

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -69,18 +69,7 @@ class CameraInfo {
   /// @param center_y The y coordinate of the image center in the pixel
   /// coordinate system in pixels.
   CameraInfo(int width, int height, double focal_x, double focal_y,
-             double center_x, double center_y)
-      : width_(width), height_(height), intrinsic_matrix_((
-            Eigen::Matrix3d() << focal_x, 0., center_x,
-                                 0., focal_y, center_y,
-                                 0., 0., 1.).finished()) {
-    DRAKE_ASSERT(width > 0);
-    DRAKE_ASSERT(height > 0);
-    DRAKE_ASSERT(focal_x > 0);
-    DRAKE_ASSERT(focal_y > 0);
-    DRAKE_ASSERT(center_x > 0 && center_x < static_cast<double>(width));
-    DRAKE_ASSERT(center_y > 0 && center_y < static_cast<double>(height));
-  }
+             double center_x, double center_y);
 
   /// Constructor that sets the image size and vertical field of view `fov_y`.
   /// We assume there is no image offset, so the image center `(center_x,`
@@ -133,8 +122,8 @@ class CameraInfo {
   }
 
  private:
-  const int width_;
-  const int height_;
+  const int width_{};
+  const int height_{};
   // Camera intrinsic parameter matrix. For the detail, see
   // http://docs.opencv.org/2.4/modules/calib3d/doc/
   // camera_calibration_and_3d_reconstruction.html

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -8,7 +8,7 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
-/// Simple data format for camera information that includes the size of image
+/// Simple data structure for camera information that includes the image size
 /// and camera intrinsic parameters.
 ///
 /// @ingroup sensor_systems
@@ -19,75 +19,73 @@ class CameraInfo {
   /// Constructor with image size, focal lengths and center of image.
   /// @param width Size of width for image which should be greater than zero
   /// @param height Size of height for image which should be greater than zero
-  /// @param fx Focal length for x direction in pixel
-  /// @param fy Focal length for y direction in pixel
-  /// @param cx X value for center of image at image coordinate system
-  /// @param cy Y value for center of image at image coordinate system
-  CameraInfo(uint32_t width, uint32_t height, double fx, double fy,
-             double cx, double cy) : width_(width), height_(height) {
+  /// @param fx Focal length for x direction in pixel.
+  /// @param fy Focal length for y direction in pixel.
+  /// @param cx X value for center of image at image coordinate system.
+  /// @param cy Y value for center of image at image coordinate system.
+  CameraInfo(int width, int height, double fx, double fy, double cx, double cy)
+      : width_(width), height_(height), intrinsic_matrix_(
+            (Eigen::Matrix3d() <<
+             fx, 0., cx, 0., fy, cy, 0., 0., 1.).finished()) {
     DRAKE_ASSERT(width > 0);
     DRAKE_ASSERT(height > 0);
     DRAKE_ASSERT(fx > 0);
     DRAKE_ASSERT(fy > 0);
     DRAKE_ASSERT(cx > 0 && cx < static_cast<double>(width));
     DRAKE_ASSERT(cy > 0 && cy < static_cast<double>(height));
-    intrinsic_matrix_ << fx, 0., cx,
-                         0., fy, cy,
-                         0., 0., 1.;
   }
 
   /// Constructor with image size and vertical field of view (fov).  We assume
-  /// there is no image offset, and so the center of the image (cx, cy) is equal
-  /// to (width / 2, height / 2).  The horizontal field of view is calculated by
-  /// the aspect ratio of the image width and height together with the vertical
-  /// field of view, then the focal lengths fx and fy are calculated by both of
-  /// the field of views.
-  /// @param width Size of width for image which should be greater than zero
-  /// @param height Size of height for image which should be greater than zero
-  /// @param vertical_fov_rad Vertical field of view in radians
-  CameraInfo(uint32_t width, uint32_t height, double vertical_fov_rad);
+  /// there is no image offset, so the center of the image "(cx, cy)" is equal
+  /// to "(width / 2, height / 2)".  The horizontal field of view is calculated
+  /// by the aspect ratio of the image width and height together with the
+  /// vertical field of view. The focal lengths "fx" and "fy" are calculated by
+  /// both of the field of views:
+  ///   fx = width / 2. / tan(horizontal_fov_rad / 2.)
+  ///   fy = height / 2. / tan(vertical_fov_rad / 2.)
+  ///   where horizontal_fov_rad = width / height * vertical_fov_rad.
+  /// @param width Size of width for image which should be greater than zero.
+  /// @param height Size of height for image which should be greater than zero.
+  /// @param vertical_fov_rad Vertical field of view in radians.
+  CameraInfo(int width, int height, double vertical_fov_rad);
 
-  /// Default copy constructor
+  /// Default copy constructor.
   CameraInfo(const CameraInfo&) = default;
 
-  /// Default copy assignment operator
-  CameraInfo& operator=(const CameraInfo&) = default;
-
-  /// Default move constructor
+  /// Default move constructor.
   CameraInfo(CameraInfo&&) = default;
 
-  /// Default move assignment operator
-  CameraInfo& operator=(CameraInfo&&) = default;
-
   CameraInfo() = delete;
+  CameraInfo& operator=(const CameraInfo&) = delete;
+  CameraInfo& operator=(CameraInfo&&) = delete;
 
-  /// Return the size of width for image
-  uint32_t width() const { return width_; }
+  /// Returns the size of width for image.
+  int width() const { return width_; }
 
-  /// Return the size of height for image
-  uint32_t height() const { return height_; }
+  /// Returns the size of height for image.
+  int height() const { return height_; }
 
-  /// Return the focal length for x direction
+  /// Returns the focal length for x direction.
   double fx() const { return intrinsic_matrix_(0, 0); }
 
-  /// Return the focal length for y direction
+  /// Returns the focal length for y direction.
   double fy() const { return intrinsic_matrix_(1, 1); }
 
-  /// Return the center of image for x direction
+  /// Returns the center of image for x direction.
   double cx() const { return intrinsic_matrix_(0, 2); }
 
-  /// Return the center of image for y direction
+  /// Returns the center of image for y direction.
   double cy() const { return intrinsic_matrix_(1, 2); }
 
-  /// Return the camera intrinsic matrix
+  /// Returns the camera intrinsic matrix.
   const Eigen::Matrix3d& intrinsic_matrix() const {
     return intrinsic_matrix_;
   }
 
  private:
-  uint32_t width_;
-  uint32_t height_;
-  Eigen::Matrix3d intrinsic_matrix_;
+  const int width_;
+  const int height_;
+  const Eigen::Matrix3d intrinsic_matrix_;
 };
 
 }  // namespace sensors

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -20,37 +20,39 @@ namespace sensors {
 /// system" to denote 2D/3D spaces and "frame" to denote a captured image.
 ///
 /// There are three types of the coordinate systems that are relevant to this
-/// class: 1) "camera coordinate system", 2) "image coordinate system", 3)
-/// "pixel coordinate system".
-/// The "camera coordinate system" expresses a camera's 6D pose with regard to
-/// the world coordinate system.  We have chosen the axes in the "camera
-/// coordinate system" to be `X-right`, `Y-down` and `Z-forward`.  The `Z` axis
-/// is also called the "optical axis".  Note that each axis in the "camera
-/// coordinate system" is expressed in the upper case, like `(X, Y, Z)` to
-/// distinguish from those of the "image coordinate system" which we explain
-/// next.
+/// class:
+///   - the camera coordinate system
+///   - the image coordinate system
+///   - the pixel coordinate system.
 ///
-/// The "image coordinate system" is the 2D coordinate system made by projecting
-/// the "camera coordinate system" onto the 2D image plane which is
-/// perpendicular to the "optical axis".  Therefore, the direction of the each
-/// axis is `x-right` and `y-down`, and the origin of the "image coordinate
-/// system" is located at the crossing point between the 2D image plane and the
-/// "optical axis".  This origin is called the "image center" or "principal
-/// point".  Note that each axis in the "image coordinate system" is expressed
-/// in the lower case, like `(x, y)`.
+/// The camera coordinate system expresses a camera's 6D pose with regard to the
+/// world coordinate system.  We have chosen the axes in the camera coordinate
+/// system to be `X-right`, `Y-down` and `Z-forward`.  The `Z` axis is also
+/// called the "optical axis".  Note that each axis in the camera coordinate
+/// system is expressed in the upper case, like `(X, Y, Z)` to distinguish from
+/// those of the image coordinate system which we explain next.
 ///
-/// The "pixel coordinate system" is also the 2D coordinate system.  The main
-/// differences between the "pixel coordinate system" and the "image coordinate
-/// system" are the location of the origin and the direction of the axes.  We
-/// have chosen the origin of the "pixel coordinate system" to be the left-upper
-/// corner of the image and the direction of the each axis to be the same as
-/// those of the "image coordinate system".  The axes of the "pixel coordinate
-/// system" are expressed by using `u` and `v`, therefore the directions of
-/// the axes are `u-right` and `v-down`.
+/// The image coordinate system is the 2D coordinate system made by projecting
+/// the camera coordinate system onto the 2D image plane which is perpendicular
+/// to the "optical axis".  Therefore, the direction of the each axis is
+/// `x-right` and `y-down`, and the origin of the image coordinate system is
+/// located at the crossing point between the 2D image plane and the "optical
+/// axis".  This origin is called the "image center" or "principal point".  Note
+/// that each axis in the image coordinate system is expressed in the lower case
+/// , like `(x, y)`.
+///
+/// The pixel coordinate system is also a 2D coordinate system.  The main
+/// differences between the pixel coordinate system and the image coordinate
+/// system are the location of the origin the direction of the axes. We have
+/// chosen the origin of the pixel coordinate system to be the left-upper corner
+/// of the image and the direction of the each axis to be the same as those of
+/// the image coordinate system.  The axes of the pixel coordinate system are
+/// expressed by using `u` and `v`, therefore the directions of the axes are
+/// `u-right` and `v-down`.
 ///
 /// For more detail including an explanation of the focal lengths, refer to:
-/// http://docs.opencv.org/2.4/modules/calib3d/doc/calib3d.html and
-/// https://en.wikipedia.org/wiki/Pinhole_camera_model.
+/// http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
+/// and https://en.wikipedia.org/wiki/Pinhole_camera_model.
 ///
 /// @ingroup sensor_systems
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -22,10 +22,10 @@ class CameraInfo {
   /// @param height The image height in pixels, must be greater than zero.
   /// @param focal_x The focal length for the x direction in pixels.
   /// @param focal_y The focal length for the y direction in pixels.
-  /// @param center_x X value for the image center at image coordinate system in
-  /// pixels.
-  /// @param center_y Y value for the image center at image coordinate system in
-  /// pixels.
+  /// @param center_x X value at the image center in the image coordinate system
+  /// in pixels.
+  /// @param center_y Y value at the image center in the image coordinate system
+  /// in pixels.
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y)
       : width_(width), height_(height), intrinsic_matrix_((

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -12,41 +12,46 @@ namespace sensors {
 /// and camera intrinsic parameters.
 ///
 /// To clarify the terminology used to describe 2D and/or 3D spaces throughout
-/// the class, we use `coordinate system` rather than `frame`.  Since the term
-/// `frame` in the computer vision field has two major meaning: a synonym of
-/// coordinate system, and a snaphot out of consecutively captured images.  To
-/// ensure the reader will not be confused, we clearly differenciate the use of
-/// the terms `coordinate system` and `frame`.
+/// the class, we use "coordinate system" rather than "frame".  This is because
+/// the term "frame" in the computer vision field has two major meaning: a
+/// synonym of coordinate system, and a snapshot out of consecutively captured
+/// images.  To ensure the reader will not be confused, we clearly differentiate
+/// the use of the terms "coordinate system" and "frame" by using "coordinate
+/// system" to denote 2D/3D spaces and "frame" to denote a captured image.
 ///
-/// There are three types of the coordinate systems that you should be aware of:
-/// 1) `camera coordinate system`, 2) `image coordinate system`, 3) `pixel`
-/// `coordinate system`.
-/// The `camera coordinate system` expresses camera's 6D pose with regard to the
-/// world coordinate system.  We have chosen the axes in the `camera coordinate`
-/// `system` to be `X-right`, `Y-down` and `Z-forward`.  The `Z` axis is also
-/// called `optical axis`.  Note that the each axis is expressed by the upper
-/// case like `(X, Y, Z)` to distinguish from those of the `image coordinate`
-/// `system` which we explain next.
-/// The `image coordinate system` is the 2D coordinate system made by projecting
-/// the `camera coordinate system` onto the 2D image plane which is
-/// perpendicular to the `optical axis`.  Therefore, the direction of the each
-/// axis is `x-right` and `y-down`, and the origin of the `image coordinate`
-/// `system` is located at the crossing point between the 2D image plane and the
-/// `optical axis`.  This origin is called `image center` or `principal point`.
-/// Note that the each axis is expressed by the lower case like `(x, y)`.
-/// The `pixel coordinate system` is also the 2D coordinate system.  The main
-/// differences between the `pixel coordinate system` and the `image coordinate`
-/// `system` are the location of the origin and the direction of the axes.  We
-/// have chosen the origin of the `pixel coordinate system` to be the left-upper
-/// corner in the image and the direction of the each axis to be the same as
-/// those of the `image coordinate system`.  The axes of the `pixel coordinate`
-/// `system` are expressed by using the `u` and `v`, therefore the directions of
+/// There are three types of the coordinate systems that are relevant to this
+/// class: 1) "camera coordinate system", 2) "image coordinate system", 3)
+/// "pixel coordinate system".
+/// The "camera coordinate system" expresses a camera's 6D pose with regard to
+/// the world coordinate system.  We have chosen the axes in the "camera
+/// coordinate system" to be `X-right`, `Y-down` and `Z-forward`.  The `Z` axis
+/// is also called the "optical axis".  Note that each axis in the "camera
+/// coordinate system" is expressed in the upper case, like `(X, Y, Z)` to
+/// distinguish from those of the "image coordinate system" which we explain
+/// next.
+///
+/// The "image coordinate system" is the 2D coordinate system made by projecting
+/// the "camera coordinate system" onto the 2D image plane which is
+/// perpendicular to the "optical axis".  Therefore, the direction of the each
+/// axis is `x-right` and `y-down`, and the origin of the "image coordinate
+/// system" is located at the crossing point between the 2D image plane and the
+/// "optical axis".  This origin is called the "image center" or "principal
+/// point".  Note that each axis in the "image coordinate system" is expressed
+/// in the lower case, like `(x, y)`.
+///
+/// The "pixel coordinate system" is also the 2D coordinate system.  The main
+/// differences between the "pixel coordinate system" and the "image coordinate
+/// system" are the location of the origin and the direction of the axes.  We
+/// have chosen the origin of the "pixel coordinate system" to be the left-upper
+/// corner of the image and the direction of the each axis to be the same as
+/// those of the "image coordinate system".  The axes of the "pixel coordinate
+/// system" are expressed by using `u` and `v`, therefore the directions of
 /// the axes are `u-right` and `v-down`.
 ///
-/// For more detail including the explanation for the focal lengths, refer to:
+/// For more detail including an explanation of the focal lengths, refer to:
 /// http://docs.opencv.org/2.4/modules/calib3d/doc/
 /// camera_calibration_and_3d_reconstruction.html and https://en.wikipedia.org/
-/// wiki/Pinhole_camera_model
+/// wiki/Pinhole_camera_model.
 ///
 /// @ingroup sensor_systems
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
@@ -59,9 +64,9 @@ class CameraInfo {
   /// @param height The image height in pixels, must be greater than zero.
   /// @param focal_x The focal length x in pixels.
   /// @param focal_y The focal length y in pixels.
-  /// @param center_x The image center x with regard to the pixel coordinate
+  /// @param center_x The x coordinate of the image center in the pixel coordinate
   /// system in pixels.
-  /// @param center_y The image center y with regard to the pixel coordinate
+  /// @param center_y The y coordinate of the image center in the pixel coordinate
   /// system in pixels.
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y)
@@ -80,9 +85,9 @@ class CameraInfo {
   /// Constructor that sets the image size and vertical field of view `fov_y`.
   /// We assume there is no image offset, so the image center `(center_x,`
   /// `center_y)` is equal to `(width / 2, height / 2)`.  The horizontal field
-  /// of view `fov_x`is calculated by the aspect ratio of the image width and
+  /// of view `fov_x` is calculated using the aspect ratio of the image width and
   /// height together with the vertical field of view. The focal lengths
-  /// `focal_x` and `focal_y` are calculated by both of the field of views:
+  /// `focal_x` and `focal_y` are calculated as follows:
   /// <pre>
   ///   focal_x = width / 2 / tan(fov_x / 2)
   ///   focal_y = height / 2 / tan(fov_y / 2)

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -25,12 +25,12 @@ namespace sensors {
 ///   - the image coordinate system
 ///   - the pixel coordinate system.
 ///
-/// The camera coordinate system expresses a camera's 6D pose with regard to the
-/// world coordinate system.  We have chosen the axes in the camera coordinate
-/// system to be `X-right`, `Y-down` and `Z-forward`.  The `Z` axis is also
-/// called the "optical axis".  Note that each axis in the camera coordinate
-/// system is expressed in the upper case, like `(X, Y, Z)` to distinguish from
-/// those of the image coordinate system which we explain next.
+/// The camera coordinate system expresses a camera's 6D pose relative to the
+/// world coordinate system.  The camera coordinate system is defined to be
+/// `X-right`, `Y-down` and `Z-forward`.  The `Z` axis is also called the
+/// "optical axis".  Note that each axis in the camera coordinate system is
+/// expressed in the upper case, like `(X, Y, Z)` to distinguish from those of
+/// the image coordinate system which we explain next.
 ///
 /// The image coordinate system is the 2D coordinate system made by projecting
 /// the camera coordinate system onto the 2D image plane which is perpendicular
@@ -43,12 +43,11 @@ namespace sensors {
 ///
 /// The pixel coordinate system is also a 2D coordinate system.  The main
 /// differences between the pixel coordinate system and the image coordinate
-/// system are the location of the origin the direction of the axes. We have
-/// chosen the origin of the pixel coordinate system to be the left-upper corner
-/// of the image and the direction of the each axis to be the same as those of
-/// the image coordinate system.  The axes of the pixel coordinate system are
-/// expressed by using `u` and `v`, therefore the directions of the axes are
-/// `u-right` and `v-down`.
+/// system are the location of the origin and the direction of the axes.  The
+/// origin of the pixel coordinate system is at the left-upper corner of the
+/// image and the direction of the each axis is the same as those of the image
+/// coordinate system.  The axes of the pixel coordinate system are expressed
+/// using `u` and `v`, therefore the axes directions are `u-right` and `v-down`.
 ///
 /// For more detail including an explanation of the focal lengths, refer to:
 /// http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -13,7 +13,7 @@ namespace sensors {
 ///
 /// To clarify the terminology used to describe 2D and/or 3D spaces throughout
 /// the class, we use "coordinate system" rather than "frame".  This is because
-/// the term "frame" in the computer vision field has two major meaning: a
+/// the term "frame" has two different meanings in the computer vision field: a
 /// synonym of coordinate system, and a snapshot out of consecutively captured
 /// images.  To ensure the reader will not be confused, we clearly differentiate
 /// the use of the terms "coordinate system" and "frame" by using "coordinate
@@ -49,9 +49,8 @@ namespace sensors {
 /// the axes are `u-right` and `v-down`.
 ///
 /// For more detail including an explanation of the focal lengths, refer to:
-/// http://docs.opencv.org/2.4/modules/calib3d/doc/
-/// camera_calibration_and_3d_reconstruction.html and https://en.wikipedia.org/
-/// wiki/Pinhole_camera_model.
+/// http://docs.opencv.org/2.4/modules/calib3d/doc/calib3d.html and
+/// https://en.wikipedia.org/wiki/Pinhole_camera_model.
 ///
 /// @ingroup sensor_systems
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
@@ -64,10 +63,10 @@ class CameraInfo {
   /// @param height The image height in pixels, must be greater than zero.
   /// @param focal_x The focal length x in pixels.
   /// @param focal_y The focal length y in pixels.
-  /// @param center_x The x coordinate of the image center in the pixel coordinate
-  /// system in pixels.
-  /// @param center_y The y coordinate of the image center in the pixel coordinate
-  /// system in pixels.
+  /// @param center_x The x coordinate of the image center in the pixel
+  /// coordinate system in pixels.
+  /// @param center_y The y coordinate of the image center in the pixel
+  /// coordinate system in pixels.
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y)
       : width_(width), height_(height), intrinsic_matrix_((
@@ -85,8 +84,8 @@ class CameraInfo {
   /// Constructor that sets the image size and vertical field of view `fov_y`.
   /// We assume there is no image offset, so the image center `(center_x,`
   /// `center_y)` is equal to `(width / 2, height / 2)`.  The horizontal field
-  /// of view `fov_x` is calculated using the aspect ratio of the image width and
-  /// height together with the vertical field of view. The focal lengths
+  /// of view `fov_x` is calculated using the aspect ratio of the image width
+  /// and height together with the vertical field of view. The focal lengths
   /// `focal_x` and `focal_y` are calculated as follows:
   /// <pre>
   ///   focal_x = width / 2 / tan(fov_x / 2)

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -17,12 +17,15 @@ namespace sensors {
 class CameraInfo {
  public:
   /// Constructor with image size, focal lengths and center of image.
-  /// @param width Size of width for image which should be greater than zero
-  /// @param height Size of height for image which should be greater than zero
-  /// @param fx Focal length for x direction in pixel.
-  /// @param fy Focal length for y direction in pixel.
-  /// @param cx X value for center of image at image coordinate system.
-  /// @param cy Y value for center of image at image coordinate system.
+  ///
+  /// @param width Size of width for image in pixels which should be greater
+  /// than zero
+  /// @param height Size of height for image in pixels which should be greater
+  /// than zero
+  /// @param fx Focal length for x direction in pixels
+  /// @param fy Focal length for y direction in pixels
+  /// @param cx X value for center of image at image coordinate system in pixels
+  /// @param cy Y value for center of image at image coordinate system in pixels
   CameraInfo(int width, int height, double fx, double fy, double cx, double cy)
       : width_(width), height_(height), intrinsic_matrix_(
             (Eigen::Matrix3d() <<
@@ -36,18 +39,21 @@ class CameraInfo {
   }
 
   /// Constructor with image size and vertical field of view (fov).  We assume
-  /// there is no image offset, so the center of the image "(cx, cy)" is equal
-  /// to "(width / 2, height / 2)".  The horizontal field of view is calculated
+  /// there is no image offset, so the center of the image `(cx, cy)` is equal
+  /// to `(width / 2, height / 2)`.  The horizontal field of view is calculated
   /// by the aspect ratio of the image width and height together with the
   /// vertical field of view. The focal lengths "fx" and "fy" are calculated by
   /// both of the field of views:
-  ///   fx = width / 2. / tan(horizontal_fov_rad / 2.)
-  ///   fy = height / 2. / tan(vertical_fov_rad / 2.)
-  ///   where horizontal_fov_rad = width / height * vertical_fov_rad.
-  /// @param width Size of width for image which should be greater than zero.
-  /// @param height Size of height for image which should be greater than zero.
-  /// @param vertical_fov_rad Vertical field of view in radians.
-  CameraInfo(int width, int height, double vertical_fov_rad);
+  /// <pre>
+  ///   fx = width / 2 / tan(horizontal_fov / 2)
+  ///   fy = height / 2 / tan(vertical_fov / 2)
+  /// </pre>
+  /// where horizontal_fov = width / height * vertical_fov.
+  ///
+  /// @param width Size of width for image which should be greater than zero
+  /// @param height Size of height for image which should be greater than zero
+  /// @param vertical_fov Vertical field of view angle
+  CameraInfo(int width, int height, double vertical_fov);
 
   /// Default copy constructor.
   CameraInfo(const CameraInfo&) = default;
@@ -59,23 +65,23 @@ class CameraInfo {
   CameraInfo& operator=(const CameraInfo&) = delete;
   CameraInfo& operator=(CameraInfo&&) = delete;
 
-  /// Returns the size of width for image.
+  /// Returns the width of the image in pixels.
   int width() const { return width_; }
 
-  /// Returns the size of height for image.
+  /// Returns the height of the image in pixels.
   int height() const { return height_; }
 
-  /// Returns the focal length for x direction.
-  double fx() const { return intrinsic_matrix_(0, 0); }
+  /// Returns the focal length for x direction in pixels.
+  double focal_x() const { return intrinsic_matrix_(0, 0); }
 
-  /// Returns the focal length for y direction.
-  double fy() const { return intrinsic_matrix_(1, 1); }
+  /// Returns the focal length for y direction in pixels.
+  double focal_y() const { return intrinsic_matrix_(1, 1); }
 
-  /// Returns the center of image for x direction.
-  double cx() const { return intrinsic_matrix_(0, 2); }
+  /// Returns the center of image for x direction in pixels.
+  double center_x() const { return intrinsic_matrix_(0, 2); }
 
-  /// Returns the center of image for y direction.
-  double cy() const { return intrinsic_matrix_(1, 2); }
+  /// Returns the center of image for y direction in pixels.
+  double center_y() const { return intrinsic_matrix_(1, 2); }
 
   /// Returns the camera intrinsic matrix.
   const Eigen::Matrix3d& intrinsic_matrix() const {
@@ -85,6 +91,9 @@ class CameraInfo {
  private:
   const int width_;
   const int height_;
+  // Camera intrinsic parameter matrix. For the detail, see
+  // http://docs.opencv.org/2.4/modules/calib3d/doc/
+  // camera_calibration_and_3d_reconstruction.html
   const Eigen::Matrix3d intrinsic_matrix_;
 };
 

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/// Simple data format for camera information that includes the size of image
+/// and camera intrinsic parameters.
+///
+/// @ingroup sensor_systems
+// TODO(kunimatsu-tri) Add camera distortion parameters and other things when
+// needed.
+class CameraInfo {
+ public:
+  /// Constructor with image size, focal lengths and center of image.
+  /// @param width Size of width for image which should be greater than zero
+  /// @param height Size of height for image which should be greater than zero
+  /// @param fx Focal length for x direction in pixel
+  /// @param fy Focal length for y direction in pixel
+  /// @param cx X value for center of image at image coordinate system
+  /// @param cy Y value for center of image at image coordinate system
+  CameraInfo(uint32_t width, uint32_t height, double fx, double fy,
+             double cx, double cy) : width_(width), height_(height) {
+    DRAKE_ASSERT(width > 0);
+    DRAKE_ASSERT(height > 0);
+    DRAKE_ASSERT(fx > 0);
+    DRAKE_ASSERT(fy > 0);
+    DRAKE_ASSERT(cx > 0 && cx < static_cast<double>(width));
+    DRAKE_ASSERT(cy > 0 && cy < static_cast<double>(height));
+    intrinsic_matrix_ << fx, 0., cx,
+                         0., fy, cy,
+                         0., 0., 1.;
+  }
+
+  /// Constructor with image size and vertical field of view (fov).  We assume
+  /// there is no image offset, and so the center of the image (cx, cy) is equal
+  /// to (width / 2, height / 2).  The horizontal field of view is calculated by
+  /// the aspect ratio of the image width and height together with the vertical
+  /// field of view, then the focal lengths fx and fy are calculated by both of
+  /// the field of views.
+  /// @param width Size of width for image which should be greater than zero
+  /// @param height Size of height for image which should be greater than zero
+  /// @param vertical_fov_rad Vertical field of view in radians
+  CameraInfo(uint32_t width, uint32_t height, double vertical_fov_rad);
+
+  /// Default copy constructor
+  CameraInfo(const CameraInfo&) = default;
+
+  /// Default copy assignment operator
+  CameraInfo& operator=(const CameraInfo&) = default;
+
+  /// Default move constructor
+  CameraInfo(CameraInfo&&) = default;
+
+  /// Default move assignment operator
+  CameraInfo& operator=(CameraInfo&&) = default;
+
+  CameraInfo() = delete;
+
+  /// Return the size of width for image
+  uint32_t width() const { return width_; }
+
+  /// Return the size of height for image
+  uint32_t height() const { return height_; }
+
+  /// Return the focal length for x direction
+  double fx() const { return intrinsic_matrix_(0, 0); }
+
+  /// Return the focal length for y direction
+  double fy() const { return intrinsic_matrix_(1, 1); }
+
+  /// Return the center of image for x direction
+  double cx() const { return intrinsic_matrix_(0, 2); }
+
+  /// Return the center of image for y direction
+  double cy() const { return intrinsic_matrix_(1, 2); }
+
+  /// Return the camera intrinsic matrix
+  const Eigen::Matrix3d& intrinsic_matrix() const {
+    return intrinsic_matrix_;
+  }
+
+ private:
+  uint32_t width_;
+  uint32_t height_;
+  Eigen::Matrix3d intrinsic_matrix_;
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/test/CMakeLists.txt
+++ b/drake/systems/sensors/test/CMakeLists.txt
@@ -4,6 +4,9 @@ target_link_libraries(rotary_encoders_test drakeSensors)
 drake_add_cc_test(image_test)
 target_link_libraries(image_test drakeSensors)
 
+drake_add_cc_test(camera_info_test)
+target_link_libraries(camera_info_test drakeSensors)
+
 if(Bullet_FOUND)
   drake_add_cc_test(depth_sensor_test)
   target_link_libraries(depth_sensor_test

--- a/drake/systems/sensors/test/camera_info_test.cc
+++ b/drake/systems/sensors/test/camera_info_test.cc
@@ -11,8 +11,8 @@ namespace {
 
 const double kTolerance = 1e-10;
 
-const uint32_t kWidth = 640;
-const uint32_t kHeight = 480;
+const int kWidth = 640;
+const int kHeight = 480;
 const double kFx = 554.25625842204079;  // in pixels
 const double kFy = 579.41125496954282;  // in pixels
 const double kCx = kWidth * 0.5;
@@ -68,45 +68,9 @@ GTEST_TEST(TestCameraInfo, CopyConstructorTest) {
                               kTolerance));
 }
 
-GTEST_TEST(TestCameraInfo, CopyAssignmentOperatorTest) {
-  CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
-  CameraInfo dut(0, 0, 0., 0., 0., 0.);
-  dut = camera_info;
-
-  Eigen::Matrix3d expected_intrinsic;
-  expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;
-
-  EXPECT_EQ(kWidth, dut.width());
-  EXPECT_EQ(kHeight, dut.height());
-  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
-  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
-  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
-  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
-  EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
-                              kTolerance));
-}
-
 GTEST_TEST(TestCameraInfo, MoveConstructorTest) {
   CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
   CameraInfo dut(std::move(camera_info));
-
-  Eigen::Matrix3d expected_intrinsic;
-  expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;
-
-  EXPECT_EQ(kWidth, dut.width());
-  EXPECT_EQ(kHeight, dut.height());
-  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
-  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
-  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
-  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
-  EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
-                              kTolerance));
-}
-
-GTEST_TEST(TestCameraInfo, MoveAssignmentOperatorTest) {
-  CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
-  CameraInfo dut(0, 0, 0., 0., 0., 0.);
-  dut = std::move(camera_info);
 
   Eigen::Matrix3d expected_intrinsic;
   expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;

--- a/drake/systems/sensors/test/camera_info_test.cc
+++ b/drake/systems/sensors/test/camera_info_test.cc
@@ -1,0 +1,127 @@
+#include "drake/systems/sensors/camera_info.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace {
+
+const double kTolerance = 1e-10;
+
+const uint32_t kWidth = 640;
+const uint32_t kHeight = 480;
+const double kFx = 554.25625842204079;  // in pixels
+const double kFy = 579.41125496954282;  // in pixels
+const double kCx = kWidth * 0.5;
+const double kCy = kHeight * 0.5;
+const double kVerticalFovRad = 0.78539816339744828;  // = 45.0 in degrees
+
+GTEST_TEST(TestCameraInfo, ConstructionTest) {
+  CameraInfo dut(kWidth, kHeight, kFx, kFy, kCx, kCy);
+
+  Eigen::Matrix3d expected_intrinsic;
+  expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;
+
+  EXPECT_EQ(kWidth, dut.width());
+  EXPECT_EQ(kHeight, dut.height());
+  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
+  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
+  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
+  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
+                              kTolerance));
+}
+
+GTEST_TEST(TestCameraInfo, ConstructionWithFovTest) {
+  CameraInfo dut(kWidth, kHeight, kVerticalFovRad);
+
+  Eigen::Matrix3d expected_intrinsic;
+  expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;
+
+  EXPECT_EQ(kWidth, dut.width());
+  EXPECT_EQ(kHeight, dut.height());
+  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
+  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
+  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
+  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
+                              kTolerance));
+}
+
+GTEST_TEST(TestCameraInfo, CopyConstructorTest) {
+  CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
+  CameraInfo dut(camera_info);
+
+  Eigen::Matrix3d expected_intrinsic;
+  expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;
+
+  EXPECT_EQ(kWidth, dut.width());
+  EXPECT_EQ(kHeight, dut.height());
+  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
+  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
+  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
+  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
+                              kTolerance));
+}
+
+GTEST_TEST(TestCameraInfo, CopyAssignmentOperatorTest) {
+  CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
+  CameraInfo dut(0, 0, 0., 0., 0., 0.);
+  dut = camera_info;
+
+  Eigen::Matrix3d expected_intrinsic;
+  expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;
+
+  EXPECT_EQ(kWidth, dut.width());
+  EXPECT_EQ(kHeight, dut.height());
+  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
+  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
+  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
+  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
+                              kTolerance));
+}
+
+GTEST_TEST(TestCameraInfo, MoveConstructorTest) {
+  CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
+  CameraInfo dut(std::move(camera_info));
+
+  Eigen::Matrix3d expected_intrinsic;
+  expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;
+
+  EXPECT_EQ(kWidth, dut.width());
+  EXPECT_EQ(kHeight, dut.height());
+  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
+  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
+  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
+  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
+                              kTolerance));
+}
+
+GTEST_TEST(TestCameraInfo, MoveAssignmentOperatorTest) {
+  CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
+  CameraInfo dut(0, 0, 0., 0., 0., 0.);
+  dut = std::move(camera_info);
+
+  Eigen::Matrix3d expected_intrinsic;
+  expected_intrinsic << kFx, 0., kCx, 0., kFy, kCy, 0., 0., 1.;
+
+  EXPECT_EQ(kWidth, dut.width());
+  EXPECT_EQ(kHeight, dut.height());
+  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
+  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
+  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
+  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
+                              kTolerance));
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/test/camera_info_test.cc
+++ b/drake/systems/sensors/test/camera_info_test.cc
@@ -27,10 +27,10 @@ GTEST_TEST(TestCameraInfo, ConstructionTest) {
 
   EXPECT_EQ(kWidth, dut.width());
   EXPECT_EQ(kHeight, dut.height());
-  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
-  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
-  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
-  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_NEAR(kFx, dut.focal_x(), kTolerance);
+  EXPECT_NEAR(kFy, dut.focal_y(), kTolerance);
+  EXPECT_NEAR(kCx, dut.center_x(), kTolerance);
+  EXPECT_NEAR(kCy, dut.center_y(), kTolerance);
   EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
                               kTolerance));
 }
@@ -43,10 +43,10 @@ GTEST_TEST(TestCameraInfo, ConstructionWithFovTest) {
 
   EXPECT_EQ(kWidth, dut.width());
   EXPECT_EQ(kHeight, dut.height());
-  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
-  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
-  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
-  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_NEAR(kFx, dut.focal_x(), kTolerance);
+  EXPECT_NEAR(kFy, dut.focal_y(), kTolerance);
+  EXPECT_NEAR(kCx, dut.center_x(), kTolerance);
+  EXPECT_NEAR(kCy, dut.center_y(), kTolerance);
   EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
                               kTolerance));
 }
@@ -60,10 +60,10 @@ GTEST_TEST(TestCameraInfo, CopyConstructorTest) {
 
   EXPECT_EQ(kWidth, dut.width());
   EXPECT_EQ(kHeight, dut.height());
-  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
-  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
-  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
-  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_NEAR(kFx, dut.focal_x(), kTolerance);
+  EXPECT_NEAR(kFy, dut.focal_y(), kTolerance);
+  EXPECT_NEAR(kCx, dut.center_x(), kTolerance);
+  EXPECT_NEAR(kCy, dut.center_y(), kTolerance);
   EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
                               kTolerance));
 }
@@ -77,10 +77,10 @@ GTEST_TEST(TestCameraInfo, MoveConstructorTest) {
 
   EXPECT_EQ(kWidth, dut.width());
   EXPECT_EQ(kHeight, dut.height());
-  EXPECT_NEAR(kFx, dut.fx(), kTolerance);
-  EXPECT_NEAR(kFy, dut.fy(), kTolerance);
-  EXPECT_NEAR(kCx, dut.cx(), kTolerance);
-  EXPECT_NEAR(kCy, dut.cy(), kTolerance);
+  EXPECT_NEAR(kFx, dut.focal_x(), kTolerance);
+  EXPECT_NEAR(kFy, dut.focal_y(), kTolerance);
+  EXPECT_NEAR(kCx, dut.center_x(), kTolerance);
+  EXPECT_NEAR(kCy, dut.center_y(), kTolerance);
   EXPECT_TRUE(CompareMatrices(expected_intrinsic, dut.intrinsic_matrix(),
                               kTolerance));
 }


### PR DESCRIPTION
Introduce CameraInfo class which holds the size of image and camera intrinsic parameters for now.  In future, distortion parameters and other stuff might be included in this class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5015)
<!-- Reviewable:end -->
