### PR TITLE
Added semi-explicit Euler integrator.

### DIFF
--- a/drake/systems/analysis/CMakeLists.txt
+++ b/drake/systems/analysis/CMakeLists.txt
@@ -12,6 +12,7 @@ set(installed_headers
     runge_kutta2_integrator.h
     runge_kutta3_integrator.h
     runge_kutta3_integrator-inl.h
+    semi_explicit_euler_integrator.h
     simulator.h
 )
 

--- a/drake/systems/analysis/semi_explicit_euler_integrator.h
+++ b/drake/systems/analysis/semi_explicit_euler_integrator.h
@@ -89,7 +89,7 @@ class SemiExplicitEulerIntegrator : public IntegratorBase<T> {
    * Gets the error estimate order (returns zero, since error estimation is
    * not provided).
    */
-  int get_error_estimate_order() const { return 0; }
+  int get_error_estimate_order() const override { return 0; }
 
   /**
    * Integrator does not support accuracy estimation.

--- a/drake/systems/analysis/semi_explicit_euler_integrator.h
+++ b/drake/systems/analysis/semi_explicit_euler_integrator.h
@@ -11,15 +11,15 @@ namespace systems {
  * following manner:
  * <pre>
  * v(t₀+h) = v(t₀) + dv/dt(t₀) * h
- * dq/dt  = N(q(t₀)) * v(t₀+h)
+ * dq/dt  = N * v(t₀+h)
  * q(t₀+h) = q(t₀) + dq/dt * h
  * </pre>
  * where `v` are the generalized velocity variables and `q` are generalized
  * coordinates. `h` is the integration step size, and `N` is a matrix 
- * (dependent upon `q`) that maps velocities to time derivatives of generalized
- * coordinates. For rigid body systems in 2D, for example, `N` will generally 
- * be an identity matrix. For a single rigid body in 3D, `N` and its 
- * pseudo-inverse (`N` is generally non-square but always left invertible)
+ * (dependent upon `q(t₀)`) that maps velocities to time derivatives of 
+ * generalized coordinates. For rigid body systems in 2D, for example, `N`
+ * will generally be an identity matrix. For a single rigid body in 3D, `N` and
+ * its pseudo-inverse (`N` is generally non-square but always left invertible)
  * are frequently used to transform between time derivatives of Euler 
  * parameters (unit quaternions) and angular velocities (and vice versa), 
  * [Nikravesh 1988].
@@ -31,12 +31,13 @@ namespace systems {
  *
  * When a mechanical system is Hamiltonian (informally meaning that the
  * system is not subject to velocity-dependent forces), the semi-explicit
- * Euler integrator is a symplectic (momentum conserving) integrator.
+ * Euler integrator is a symplectic (energy conserving) integrator.
  * Symplectic integrators advertise energetically consistent behavior with large
  * step sizes compared to non-symplectic integrators. Multi-body systems
  * are not Hamiltonian, even in the absence of externally applied
  * velocity-dependent forces, due to the presence of both Coriolis and
- * gyroscopic forces. 
+ * gyroscopic forces. This integrator thus does not generally conserve energy
+ * for such systems.
  *
  * <h4>Association between time stepping and the semi-explicit Euler
  * integrator:</h4>
@@ -78,7 +79,7 @@ class SemiExplicitEulerIntegrator : public IntegratorBase<T> {
    * @sa Initialize()
    */
   SemiExplicitEulerIntegrator(const System<T>& system, const T& max_step_size,
-                          Context<T>* context = nullptr)
+                              Context<T>* context = nullptr)
       : IntegratorBase<T>(system, context) {
     IntegratorBase<T>::set_maximum_step_size(max_step_size);
     derivs_ = system.AllocateTimeDerivatives();

--- a/drake/systems/analysis/semi_explicit_euler_integrator.h
+++ b/drake/systems/analysis/semi_explicit_euler_integrator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "drake/systems/analysis/integrator_base.h"
 
 namespace drake {
@@ -115,7 +116,7 @@ void SemiExplicitEulerIntegrator<T>::DoStepOnceFixedSize(const T& dt) {
   const auto& xc = context->get_mutable_continuous_state();
   const auto& system = this->get_system();
 
-  // Retrieve the generalized coordinates and velocities and auxiliary 
+  // Retrieve the generalized coordinates and velocities and auxiliary
   // variables.
   VectorBase<T>* q = xc->get_mutable_generalized_position();
   VectorBase<T>* v = xc->get_mutable_generalized_velocity();
@@ -129,10 +130,10 @@ void SemiExplicitEulerIntegrator<T>::DoStepOnceFixedSize(const T& dt) {
   // Retrieve the accelerations and auxiliary variable derivatives.
   const auto& vdot = derivs_->get_generalized_velocity();
   const auto& zdot = derivs_->get_misc_continuous_state();
-  
+ 
   // Update the generalized velocity and auxiliary variables.
   v->PlusEqScaled({ {dt, vdot} });
-  z->PlusEqScaled({ {dt, zdot} }); 
+  z->PlusEqScaled({ {dt, zdot} });
 
   // Convert the generalized velocity to the time derivative of generalized
   // coordinates and update the generalized coordinates.

--- a/drake/systems/analysis/semi_explicit_euler_integrator.h
+++ b/drake/systems/analysis/semi_explicit_euler_integrator.h
@@ -130,7 +130,7 @@ void SemiExplicitEulerIntegrator<T>::DoStepOnceFixedSize(const T& dt) {
   // Retrieve the accelerations and auxiliary variable derivatives.
   const auto& vdot = derivs_->get_generalized_velocity();
   const auto& zdot = derivs_->get_misc_continuous_state();
- 
+
   // Update the generalized velocity and auxiliary variables.
   v->PlusEqScaled({ {dt, vdot} });
   z->PlusEqScaled({ {dt, zdot} });

--- a/drake/systems/analysis/semi_explicit_euler_integrator.h
+++ b/drake/systems/analysis/semi_explicit_euler_integrator.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include "drake/systems/analysis/integrator_base.h"
+
+namespace drake {
+namespace systems {
+
+/**
+ * A first-order, semi-explicit Euler integrator. State is updated in the
+ * following manner:
+ * <pre>
+ * v(t₀+h) = v(t₀) + dv/dt(t₀) * h
+ * dq/dt  = N(q(t₀)) * v(t₀+h)
+ * q(t₀+h) = q(t₀) + dq/dt * h
+ * </pre>
+ * where `v` are the generalized velocity variables and `q` are generalized
+ * coordinates. `h` is the integration step size, and `N` is a matrix 
+ * (dependent upon `q`) that maps velocities to time derivatives of generalized
+ * coordinates. For rigid body systems in 2D, for example, `N` will generally 
+ * be an identity matrix. For a single rigid body in 3D, `N` and its 
+ * pseudo-inverse (`N` is generally non-square but always left invertible)
+ * are frequently used to transform between time derivatives of Euler 
+ * parameters (unit quaternions) and angular velocities (and vice versa), 
+ * [Nikravesh 1988].
+ * 
+ * Note that these equations imply that the velocity variables are updated
+ * first and that these new velocities are then used to update the generalized
+ * coordinates (compare to ExplicitEulerIntegrator, where the generalized
+ * coordinates are updated using the previous velocity variables).
+ *
+ * When a mechanical system is Hamiltonian (informally meaning that the
+ * system is not subject to velocity-dependent forces), the semi-explicit
+ * Euler integrator is a symplectic (momentum conserving) integrator.
+ * Symplectic integrators advertise energetically consistent behavior with large
+ * step sizes compared to non-symplectic integrators. Multi-body systems
+ * are not Hamiltonian, even in the absence of externally applied
+ * velocity-dependent forces, due to the presence of both Coriolis and
+ * gyroscopic forces. 
+ *
+ * <h4>Association between time stepping and the semi-explicit Euler
+ * integrator:</h4>
+ * Though many time stepping approaches use the formulations above, these
+ * equations do not represent a "time stepping scheme". The semi-explicit
+ * Euler integration equations can be applied from one point in state space to 
+ * another, assuming smoothness in between, just like any other integrator using
+ * the following process: 
+ * (1) a simulator integrates to discontinuities, (2) the state of the ODE/DAE 
+ * is re-initialized, and (3) integration continues.
+ *
+ * In contrast, time stepping schemes enforce all constraints at a single
+ * time in the integration process: though a billiard break may consist of tens
+ * of collisions occurring sequentially over a millisecond of time, a time
+ * stepping method will treat all of these collisions as occurring
+ * simultaneously. 
+ *
+ * - [Nikravesh 1988]  P. Nikravesh. Computer-Aided Analysis of Mechanical 
+ *                       Systems. Prentice Hall. New Jersey, 1988.
+ * - [Stewart 2000]    D. Stewart. Rigid-body Dynamics with Friction and 
+ *                       Impact. SIAM Review, 42:1, 2000.
+ */
+template <class T>
+class SemiExplicitEulerIntegrator : public IntegratorBase<T> {
+ public:
+  virtual ~SemiExplicitEulerIntegrator() {}
+
+  // TODO(edrumwri): update documentation to account for stretching (after
+  //                 stretching has become a user settable).
+  /**
+   * Constructs a fixed-step integrator for a given system using the given
+   * context for initial conditions.
+   * @param system A reference to the system to be simulated.
+   * @param max_step_size The maximum (fixed) step size; the integrator will
+   *                      not take larger step sizes than this.
+   * @param context Pointer to the context (nullptr is ok, but the caller
+   *                must set a non-null context before Initialize()-ing the
+   *                integrator).
+   * @sa Initialize()
+   */
+  SemiExplicitEulerIntegrator(const System<T>& system, const T& max_step_size,
+                          Context<T>* context = nullptr)
+      : IntegratorBase<T>(system, context) {
+    IntegratorBase<T>::set_maximum_step_size(max_step_size);
+    derivs_ = system.AllocateTimeDerivatives();
+    qdot_ = std::make_unique<BasicVector<T>>(
+            context->get_continuous_state()->get_generalized_position().size());
+  }
+
+  /**
+   * Gets the error estimate order (returns zero, since error estimation is
+   * not provided).
+   */
+  int get_error_estimate_order() const { return 0; }
+
+  /**
+   * Integrator does not support accuracy estimation.
+   */
+  bool supports_error_estimation() const override { return false; }
+
+ private:
+  void DoStepOnceFixedSize(const T& dt) override;
+
+  // These are pre-allocated temporaries for use by integration
+  std::unique_ptr<ContinuousState<T>> derivs_;
+  std::unique_ptr<BasicVector<T>> qdot_;
+};
+
+/**
+ * Integrates the system forward in time by dt. This value is determined
+ * by IntegratorBase::StepOnce().
+ */
+template <class T>
+void SemiExplicitEulerIntegrator<T>::DoStepOnceFixedSize(const T& dt) {
+  // Find the continuous state xc within the Context, just once.
+  auto context = this->get_mutable_context();
+  const auto& xc = context->get_mutable_continuous_state();
+  const auto& system = this->get_system();
+
+  // Retrieve the generalized coordinates and velocities and auxiliary 
+  // variables.
+  VectorBase<T>* q = xc->get_mutable_generalized_position();
+  VectorBase<T>* v = xc->get_mutable_generalized_velocity();
+  VectorBase<T>* z = xc->get_mutable_misc_continuous_state();
+
+  // Calcuate the derivatives.
+  // TODO(sherm1) This should be calculating into the cache so that
+  // Publish() doesn't have to recalculate if it wants to output derivatives.
+  system.CalcTimeDerivatives(this->get_context(), derivs_.get());
+
+  // Retrieve the accelerations and auxiliary variable derivatives.
+  const auto& vdot = derivs_->get_generalized_velocity();
+  const auto& zdot = derivs_->get_misc_continuous_state();
+  
+  // Update the generalized velocity and auxiliary variables.
+  v->PlusEqScaled({ {dt, vdot} });
+  z->PlusEqScaled({ {dt, zdot} }); 
+
+  // Convert the generalized velocity to the time derivative of generalized
+  // coordinates and update the generalized coordinates.
+  system.MapVelocityToQDot(*context, *v, qdot_.get());
+  q->PlusEqScaled({ {dt, *qdot_} });
+
+  // Update the time.
+  context->set_time(context->get_time() + dt);
+}
+}  // namespace systems
+}  // namespace drake
+

--- a/drake/systems/analysis/test/CMakeLists.txt
+++ b/drake/systems/analysis/test/CMakeLists.txt
@@ -19,6 +19,11 @@ target_link_libraries(runge_kutta2_integrator_test
 # RigidBodyPlant does not fail when no geometry is present (specifically for
 # the minimal build case). See issue #4294.
 if(Bullet_FOUND)
+  drake_add_cc_test(NAME semi_explicit_euler_integrator_test SIZE medium)
+  target_link_libraries(semi_explicit_euler_integrator_test
+          drakeSystemAnalysis drakeSystemFramework drakeCommon
+          drakeSpringMassSystemPlant drakeRigidBodyPlant drakeRBSystem)
+
   drake_add_cc_test(NAME runge_kutta3_integrator_test SIZE medium)
   target_link_libraries(runge_kutta3_integrator_test
           drakeSystemAnalysis drakeSystemFramework drakeCommon

--- a/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -94,8 +94,7 @@ GTEST_TEST(IntegratorTest, RigidBody) {
   for (int i=0; i< plant.get_num_velocities(); ++i)
     plant.set_velocity(context.get(), i, generalized_velocities[i]);
 
-  // Integrate for one second of virtual time using explicit Euler integrator
-  // with large step size.
+  // Integrate for one second of virtual time using explicit Euler integrator.
   const double small_dt = 1e-4;
   ExplicitEulerIntegrator<double> ee(plant, small_dt, context.get());
   ee.Initialize();

--- a/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -14,29 +14,6 @@ namespace drake {
 namespace systems {
 namespace {
 
-GTEST_TEST(IntegratorTest, MiscAPI) {
-  typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
-  SpringMassSystem<double> spring_mass_dbl(1., 1., 0.);
-  SpringMassSystem<AScalar> spring_mass_ad(1., 1., 0.);
-
-  // Setup the integration step size.
-  const double dt = 1e-3;
-
-  // Create a context.
-  auto context_dbl = spring_mass_dbl.CreateDefaultContext();
-  auto context_ad = spring_mass_ad.CreateDefaultContext();
-
-  // Create the integrator as a double and as an autodiff type
-  SemiExplicitEulerIntegrator<double> int_dbl(spring_mass_dbl, dt,
-                                          context_dbl.get());
-  SemiExplicitEulerIntegrator<AScalar> int_ad(spring_mass_ad, dt,
-                                          context_ad.get());
-
-  // Test that setting the target accuracy or initial step size target fails.
-  EXPECT_THROW(int_dbl.set_target_accuracy(1.0), std::logic_error);
-  EXPECT_THROW(int_dbl.request_initial_step_size_target(1.0), std::logic_error);
-}
-
 GTEST_TEST(IntegratorTest, ContextAccess) {
   // Create the mass spring system.
   SpringMassSystem<double> spring_mass(1., 1., 0.);
@@ -207,9 +184,9 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
               5e-3);
 
   // Verify that integrator statistics are valid
-  EXPECT_GE(integrator.get_previous_integration_step_size(), 0.0);
-  EXPECT_GE(integrator.get_largest_step_size_taken(), 0.0);
-  EXPECT_GE(integrator.get_num_steps_taken(), 0);
+  EXPECT_GT(integrator.get_previous_integration_step_size(), 0.0);
+  EXPECT_GT(integrator.get_largest_step_size_taken(), 0.0);
+  EXPECT_GT(integrator.get_num_steps_taken(), 0);
   EXPECT_EQ(integrator.get_error_estimate(), nullptr);
 }
 

--- a/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -1,0 +1,217 @@
+#include "drake/multibody/joints/prismatic_joint.h"
+#include "drake/multibody/joints/quaternion_floating_joint.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/analysis/explicit_euler_integrator.h"
+#include "drake/systems/analysis/semi_explicit_euler_integrator.h"
+
+#include <cmath>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/analysis/test/my_spring_mass_system.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(IntegratorTest, MiscAPI) {
+  typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
+  SpringMassSystem<double> spring_mass_dbl(1., 1., 0.);
+  SpringMassSystem<AScalar> spring_mass_ad(1., 1., 0.);
+
+  // Setup the integration step size.
+  const double dt = 1e-3;
+
+  // Create a context.
+  auto context_dbl = spring_mass_dbl.CreateDefaultContext();
+  auto context_ad = spring_mass_ad.CreateDefaultContext();
+
+  // Create the integrator as a double and as an autodiff type
+  SemiExplicitEulerIntegrator<double> int_dbl(spring_mass_dbl, dt,
+                                          context_dbl.get());
+  SemiExplicitEulerIntegrator<AScalar> int_ad(spring_mass_ad, dt, context_ad.get());
+
+  // Test that setting the target accuracy or initial step size target fails.
+  EXPECT_THROW(int_dbl.set_target_accuracy(1.0), std::logic_error);
+  EXPECT_THROW(int_dbl.request_initial_step_size_target(1.0), std::logic_error);
+}
+
+GTEST_TEST(IntegratorTest, ContextAccess) {
+  // Create the mass spring system.
+  SpringMassSystem<double> spring_mass(1., 1., 0.);
+
+  // Setup the integration step size.
+  const double dt = 1e-3;
+
+  // Create a context.
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Create the integrator.
+  SemiExplicitEulerIntegrator<double> integrator(
+      spring_mass, dt, context.get());  // Use default Context.
+
+  integrator.get_mutable_context()->set_time(3.);
+  EXPECT_EQ(integrator.get_context().get_time(), 3.);
+  EXPECT_EQ(context->get_time(), 3.);\
+  integrator.reset_context(nullptr);
+  EXPECT_THROW(integrator.Initialize(), std::logic_error);
+  EXPECT_THROW(integrator.StepOnceAtMost(dt, dt, dt), std::logic_error);
+}
+
+/// Verifies error estimation is unsupported.
+GTEST_TEST(IntegratorTest, AccuracyEstAndErrorControl) {
+  // Spring-mass system is necessary only to setup the problem.
+  SpringMassSystem<double> spring_mass(1., 1., 0.);
+  const double dt = 1e-3;
+  auto context = spring_mass.CreateDefaultContext();
+  SemiExplicitEulerIntegrator<double> integrator(
+      spring_mass, dt, context.get());
+
+  EXPECT_EQ(integrator.get_error_estimate_order(), 0);
+  EXPECT_EQ(integrator.supports_error_estimation(), false);
+  EXPECT_THROW(integrator.set_target_accuracy(1e-1), std::logic_error);
+  EXPECT_THROW(integrator.request_initial_step_size_target(dt),
+               std::logic_error);
+}
+
+// Tests accuracy when generalized velocity is not the time derivative of
+// generalized configuration (using a rigid body).
+GTEST_TEST(IntegratorTest, RigidBody) {
+  // Instantiates a Multibody Dynamics (MBD) model of the world.
+  auto tree = std::make_unique<RigidBodyTree<double>>();
+
+  // Add a single free body with a quaternion base.
+  RigidBody<double>* body;
+  tree->add_rigid_body(
+      std::unique_ptr<RigidBody<double>>(body = new RigidBody<double>()));
+  body->set_name("free_body");
+
+  // Sets body to have a non-zero spatial inertia. Otherwise the body gets
+  // welded by a fixed joint to the world by RigidBodyTree::compile().
+  body->set_mass(1.0);
+  body->set_spatial_inertia(Matrix6<double>::Identity());
+  body->add_joint(&tree->world(), std::make_unique<QuaternionFloatingJoint>(
+      "base", Eigen::Isometry3d::Identity()));
+
+  tree->compile();
+
+  // Instantiates a RigidBodyPlant from the  MBD model.
+  RigidBodyPlant<double> plant(move(tree));
+  auto context = plant.CreateDefaultContext();
+
+  // Set free_body to have zero translation, zero rotation, and zero velocity.
+  plant.SetDefaultState(*context, context->get_mutable_state());
+
+  Eigen::Vector3d v0(1, 2, 3);    // Linear velocity in body's frame.
+  Eigen::Vector3d w0(-4, 5, 6);  // Angular velocity in body's frame.
+  BasicVector<double> generalized_velocities(plant.get_num_velocities());
+  generalized_velocities.get_mutable_value() << w0, v0;
+
+  // Set the linear and angular velocity.
+  for (int i=0; i< plant.get_num_velocities(); ++i)
+    plant.set_velocity(context.get(), i, generalized_velocities[i]);
+
+  // Integrate for one second of virtual time using a RK2 integrator with
+  // large step size.
+  const double small_dt = 1e-4;
+  ExplicitEulerIntegrator<double> ee(plant, small_dt, context.get());
+  ee.Initialize();
+  const double t_final = 1.0;
+  double t_remaining = t_final - context->get_time();
+  do {
+    ee.StepOnceAtMost(t_remaining, t_remaining, t_remaining);
+    t_remaining = t_final - context->get_time();
+  } while (t_remaining > 0.0);
+
+  // Get the final state.
+  VectorX<double> x_final_ee = context->get_continuous_state_vector().
+      CopyToVector();
+
+  // Re-integrate with semi-explicit Euler.
+  context->set_time(0.);
+  plant.SetDefaultState(*context, context->get_mutable_state());
+  for (int i=0; i< plant.get_num_velocities(); ++i)
+    plant.set_velocity(context.get(), i, generalized_velocities[i]);
+  SemiExplicitEulerIntegrator<double> see(plant, small_dt, context.get());
+  see.Initialize();
+
+  // Integrate for one second.
+  t_remaining = t_final - context->get_time();
+  do {
+    see.StepOnceAtMost(t_remaining, t_remaining, t_remaining);
+    t_remaining = t_final - context->get_time();
+  } while (t_remaining > 0.0);
+
+  // Verify that the final states are "close".
+  VectorX<double> x_final_see = context->get_continuous_state_vector().
+      CopyToVector();
+  const double tol = 5e-3;
+  for (int i=0; i< x_final_see.size(); ++i)
+    EXPECT_NEAR(x_final_ee[i], x_final_see[i], tol);
+}
+
+// Try a purely continuous system with no sampling.
+// d^2x/dt^2 = -kx/m
+// solution to this ODE: x(t) = c1*cos(omega*t) + c2*sin(omega*t)
+// where omega = sqrt(k/m)
+// x'(t) = -c1*sin(omega*t)*omega + c2*cos(omega*t)*omega
+// for t = 0, x(0) = c1, x'(0) = c2*omega
+GTEST_TEST(IntegratorTest, SpringMassStep) {
+  const double kSpring = 300.0;  // N/m
+  const double kMass = 2.0;      // kg
+
+  // Create the spring-mass system.
+  SpringMassSystem<double> spring_mass(kSpring, kMass, 0.);
+
+  // Create a context.
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Setup the integration size and infinity.
+  const double dt = 1e-6;
+  const double inf = std::numeric_limits<double>::infinity();
+
+  // Create the integrator.
+  SemiExplicitEulerIntegrator<double> integrator(
+      spring_mass, dt, context.get());  // Use default Context.
+
+  // Setup the initial position and initial velocity.
+  const double kInitialPosition = 0.1;
+  const double kInitialVelocity = 0.01;
+  const double kOmega = std::sqrt(kSpring / kMass);
+
+  // Set initial condition.
+  spring_mass.set_position(context.get(), kInitialPosition);
+
+  // Take all the defaults.
+  integrator.Initialize();
+
+  // Setup c1 and c2 for ODE constants.
+  const double c1 = kInitialPosition;
+  const double c2 = kInitialVelocity / kOmega;
+
+  // Integrate for 1 second.
+  const double kTFinal = 1.0;
+  double t;
+  for (t = 0.0; std::abs(t - kTFinal) > dt; t += dt)
+    integrator.StepOnceAtMost(inf, inf, dt);
+
+  EXPECT_NEAR(context->get_time(), t, dt);  // Should be exact.
+
+  // Get the final position.
+  const double x_final =
+      context->get_continuous_state()->get_vector().GetAtIndex(0);
+
+  // Check the solution.
+  EXPECT_NEAR(c1 * std::cos(kOmega * t) + c2 * std::sin(kOmega * t), x_final,
+              5e-3);
+
+  // Verify that integrator statistics are valid
+  EXPECT_GE(integrator.get_previous_integration_step_size(), 0.0);
+  EXPECT_GE(integrator.get_largest_step_size_taken(), 0.0);
+  EXPECT_GE(integrator.get_num_steps_taken(), 0);
+  EXPECT_EQ(integrator.get_error_estimate(), nullptr);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -14,6 +14,8 @@ namespace drake {
 namespace systems {
 namespace {
 
+// Tests context-related operations, including determining whether or not
+// system can be integrated without a context (it can't).
 GTEST_TEST(IntegratorTest, ContextAccess) {
   // Create the mass spring system.
   SpringMassSystem<double> spring_mass(1., 1., 0.);
@@ -36,7 +38,7 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
   EXPECT_THROW(integrator.StepOnceAtMost(dt, dt, dt), std::logic_error);
 }
 
-/// Verifies error estimation is unsupported.
+// Verifies error estimation is unsupported.
 GTEST_TEST(IntegratorTest, AccuracyEstAndErrorControl) {
   // Spring-mass system is necessary only to setup the problem.
   SpringMassSystem<double> spring_mass(1., 1., 0.);
@@ -83,14 +85,17 @@ GTEST_TEST(IntegratorTest, RigidBody) {
   Eigen::Vector3d v0(1, 2, 3);    // Linear velocity in body's frame.
   Eigen::Vector3d w0(-4, 5, 6);  // Angular velocity in body's frame.
   BasicVector<double> generalized_velocities(plant.get_num_velocities());
+
+  // NOTE: the functionality of this code is dependent upon the rigid body
+  // velocity variables being ordering as [ angular, linear ].
   generalized_velocities.get_mutable_value() << w0, v0;
 
   // Set the linear and angular velocity.
   for (int i=0; i< plant.get_num_velocities(); ++i)
     plant.set_velocity(context.get(), i, generalized_velocities[i]);
 
-  // Integrate for one second of virtual time using a RK2 integrator with
-  // large step size.
+  // Integrate for one second of virtual time using explicit Euler integrator
+  // with large step size.
   const double small_dt = 1e-4;
   ExplicitEulerIntegrator<double> ee(plant, small_dt, context.get());
   ee.Initialize();

--- a/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -29,7 +29,7 @@ GTEST_TEST(IntegratorTest, MiscAPI) {
   // Create the integrator as a double and as an autodiff type
   SemiExplicitEulerIntegrator<double> int_dbl(spring_mass_dbl, dt,
                                           context_dbl.get());
-  SemiExplicitEulerIntegrator<AScalar> int_ad(spring_mass_ad, dt, 
+  SemiExplicitEulerIntegrator<AScalar> int_ad(spring_mass_ad, dt,
                                           context_ad.get());
 
   // Test that setting the target accuracy or initial step size target fails.

--- a/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -29,7 +29,8 @@ GTEST_TEST(IntegratorTest, MiscAPI) {
   // Create the integrator as a double and as an autodiff type
   SemiExplicitEulerIntegrator<double> int_dbl(spring_mass_dbl, dt,
                                           context_dbl.get());
-  SemiExplicitEulerIntegrator<AScalar> int_ad(spring_mass_ad, dt, context_ad.get());
+  SemiExplicitEulerIntegrator<AScalar> int_ad(spring_mass_ad, dt, 
+                                          context_ad.get());
 
   // Test that setting the target accuracy or initial step size target fails.
   EXPECT_THROW(int_dbl.set_target_accuracy(1.0), std::logic_error);


### PR DESCRIPTION
Adds semi-explicit Euler integration (thereby adding symplectic integration for Hamiltonian systems) and also stresses the conversions between generalized coordinates and generalized velocities (when the two are distinct). 

_This PR relies upon the bugfix provided by PR #4965 to obtain the same result (to numerical tolerances) from integrating a rigid body using semi-explicit Euler integration and "standard" explicit Euler integration. Prior to #4965, the two answers would be distinct._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5017)
<!-- Reviewable:end -->
