### PR TITLE
Remove unary minus (-E) in symbolic::Expression

### DIFF
--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -31,7 +31,6 @@ namespace symbolic {
 enum class ExpressionKind {
   Constant,    ///< constant (double)
   Var,         ///< variable
-  Neg,         ///< unary minus
   Add,         ///< addition (+)
   Mul,         ///< multiplication (*)
   Div,         ///< division (/)
@@ -82,7 +81,7 @@ using Substitution =
 Its syntax tree is as follows:
 
 @verbatim
-    E := Var | Constant | - E | E + ... + E | E * ... * E | E / E | log(E)
+    E := Var | Constant | E + ... + E | E * ... * E | E / E | log(E)
        | abs(E) | exp(E) | sqrt(E) | pow(E, E) | sin(E) | cos(E) | tan(E)
        | asin(E) | acos(E) | atan(E) | atan2(E, E) | sinh(E) | cosh(E) | tanh(E)
        | min(E, E) | max(E, E) | if_then_else(F, E, E) | NaN
@@ -96,8 +95,9 @@ allow sharing sub-expressions.
 
 @note The sharing of sub-expressions is not yet implemented.
 
-@note A subtraction E1 - E2 is represented with an addition and unary minus,
-that is, E1 + (-E2).
+@note -E is represented as -1 * E internally.
+
+@note A subtraction E1 - E2 is represented as E1 + (-1 * E2) internally.
 
 The following simple simplifications are implemented:
 @verbatim
@@ -107,8 +107,6 @@ The following simple simplifications are implemented:
     E - E             ->  0
     E * 1             ->  E
     1 * E             ->  E
-    E * -1            -> -E
-   -1 * E             -> -E
     E * 0             ->  0
     0 * E             ->  0
     E / 1             ->  E
@@ -303,7 +301,6 @@ class Expression {
 
   friend bool is_constant(const Expression& e);
   friend bool is_variable(const Expression& e);
-  friend bool is_unary_minus(const Expression& e);
   friend bool is_addition(const Expression& e);
   friend bool is_multiplication(const Expression& e);
   friend bool is_division(const Expression& e);
@@ -401,8 +398,6 @@ bool is_two(const Expression& e);
 bool is_nan(const Expression& e);
 /** Checks if @p e is a variable expression. */
 bool is_variable(const Expression& e);
-/** Checks if @p e is a unary-minus expression. */
-bool is_unary_minus(const Expression& e);
 /** Checks if @p e is an addition expression. */
 bool is_addition(const Expression& e);
 /** Checks if @p e is a multiplication expression. */

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -311,24 +311,6 @@ Expression ExpressionNaN::Substitute(const Substitution& s) const {
 
 ostream& ExpressionNaN::Display(ostream& os) const { return os << "NaN"; }
 
-ExpressionNeg::ExpressionNeg(const Expression& e)
-    : UnaryExpressionCell{ExpressionKind::Neg, e, e.is_polynomial()} {}
-
-ostream& ExpressionNeg::Display(ostream& os) const {
-  return os << "-(" << get_argument() << ")";
-}
-
-Polynomial<double> ExpressionNeg::ToPolynomial() const {
-  DRAKE_ASSERT(is_polynomial());
-  return -get_argument().ToPolynomial();
-}
-
-Expression ExpressionNeg::Substitute(const Substitution& s) const {
-  return -get_argument().Substitute(s);
-}
-
-double ExpressionNeg::DoEvaluate(const double v) const { return -v; }
-
 ExpressionAdd::ExpressionAdd(const double constant,
                              const map<Expression, double>& exp_to_coeff_map)
     : ExpressionCell{ExpressionKind::Add,
@@ -528,11 +510,6 @@ void ExpressionAddFactory::AddConstant(const double constant) {
 
 void ExpressionAddFactory::AddTerm(const double coeff, const Expression& term) {
   DRAKE_ASSERT(!is_constant(term));
-
-  // If (term, coeff) = (-E, coeff), add (E, -coeff) by recursive call.
-  if (is_unary_minus(term)) {
-    return AddTerm(-coeff, get_argument(term));
-  }
 
   const auto it(exp_to_coeff_map_.find(term));
   if (it != exp_to_coeff_map_.end()) {
@@ -1263,9 +1240,6 @@ bool is_constant(const ExpressionCell& c) {
 bool is_variable(const ExpressionCell& c) {
   return c.get_kind() == ExpressionKind::Var;
 }
-bool is_unary_minus(const ExpressionCell& c) {
-  return c.get_kind() == ExpressionKind::Neg;
-}
 bool is_addition(const ExpressionCell& c) {
   return c.get_kind() == ExpressionKind::Add;
 }
@@ -1350,11 +1324,11 @@ shared_ptr<ExpressionVar> to_variable(const Expression& e) {
 
 shared_ptr<UnaryExpressionCell> to_unary(
     const shared_ptr<ExpressionCell> exp_ptr) {
-  DRAKE_ASSERT(is_unary_minus(*exp_ptr) || is_log(*exp_ptr) ||
-               is_abs(*exp_ptr) || is_exp(*exp_ptr) || is_sqrt(*exp_ptr) ||
-               is_sin(*exp_ptr) || is_cos(*exp_ptr) || is_tan(*exp_ptr) ||
-               is_asin(*exp_ptr) || is_acos(*exp_ptr) || is_atan(*exp_ptr) ||
-               is_sinh(*exp_ptr) || is_cosh(*exp_ptr) || is_tanh(*exp_ptr));
+  DRAKE_ASSERT(is_log(*exp_ptr) || is_abs(*exp_ptr) || is_exp(*exp_ptr) ||
+               is_sqrt(*exp_ptr) || is_sin(*exp_ptr) || is_cos(*exp_ptr) ||
+               is_tan(*exp_ptr) || is_asin(*exp_ptr) || is_acos(*exp_ptr) ||
+               is_atan(*exp_ptr) || is_sinh(*exp_ptr) || is_cosh(*exp_ptr) ||
+               is_tanh(*exp_ptr));
   return static_pointer_cast<UnaryExpressionCell>(exp_ptr);
 }
 shared_ptr<UnaryExpressionCell> to_unary(const Expression& e) {

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -629,7 +629,7 @@ double ExpressionMul::Evaluate(const Environment& env) const {
 
 Expression ExpressionMul::Substitute(const Substitution& s) const {
   return accumulate(
-      base_to_exp_map_.begin(), base_to_exp_map_.end(), Expression::One(),
+      base_to_exp_map_.begin(), base_to_exp_map_.end(), Expression{constant_},
       [&s](const Expression& init, const pair<Expression, Expression>& p) {
         return init * pow(p.first.Substitute(s), p.second.Substitute(s));
       });

--- a/drake/common/symbolic_expression_cell.h
+++ b/drake/common/symbolic_expression_cell.h
@@ -193,18 +193,6 @@ class ExpressionNaN : public ExpressionCell {
   std::ostream& Display(std::ostream& os) const override;
 };
 
-/** Symbolic expression representing unary minus. */
-class ExpressionNeg : public UnaryExpressionCell {
- public:
-  explicit ExpressionNeg(const Expression& e);
-  Polynomial<double> ToPolynomial() const override;
-  std::ostream& Display(std::ostream& os) const override;
-  Expression Substitute(const Substitution& s) const override;
-
- private:
-  double DoEvaluate(double v) const override;
-};
-
 /** Symbolic expression representing an addition which is a sum of products.
  *
  * @f[
@@ -674,8 +662,6 @@ class ExpressionIfThenElse : public ExpressionCell {
 bool is_constant(const ExpressionCell& c);
 /** Checks if @p exp_ptr is a variable expression. */
 bool is_variable(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a unary-minus expression. */
-bool is_unary_minus(const ExpressionCell& c);
 /** Checks if @p exp_ptr is an addition expression. */
 bool is_addition(const ExpressionCell& c);
 /** Checks if @p exp_ptr is an multiplication expression. */

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -108,8 +108,8 @@ class SymbolicExpressionTest : public ::testing::Test {
 
   const Expression e_constant_{1.0};
   const Expression e_var_{var_x_};
-  const Expression e_neg_{-x_};
   const Expression e_add_{x_ + y_};
+  const Expression e_neg_{-x_};  // -1 * x_
   const Expression e_mul_{x_ * y_};
   const Expression e_div_{x_ / y_};
   const Expression e_log_{log(x_)};
@@ -132,7 +132,7 @@ class SymbolicExpressionTest : public ::testing::Test {
   const Expression e_ite_{if_then_else(x_ < y_, x_, y_)};
 
   const vector<Expression> collection_{
-      e_constant_, e_var_,  e_neg_,   e_add_,  e_mul_,
+      e_constant_, e_var_,  e_add_,   e_neg_,  e_mul_,
       e_div_,      e_log_,  e_abs_,   e_exp_,  e_sqrt_,
       e_pow_,      e_sin_,  e_cos_,   e_tan_,  e_asin_,
       e_acos_,     e_atan_, e_atan2_, e_sinh_, e_cosh_,
@@ -190,14 +190,6 @@ TEST_F(SymbolicExpressionTest, IsVariable) {
   EXPECT_EQ(cnt, 1);
 }
 
-TEST_F(SymbolicExpressionTest, IsUnaryMinus) {
-  EXPECT_TRUE(is_unary_minus(e_neg_));
-  const vector<Expression>::difference_type cnt{
-      count_if(collection_.begin(), collection_.end(),
-               [](const Expression& e) { return is_unary_minus(e); })};
-  EXPECT_EQ(cnt, 1);
-}
-
 TEST_F(SymbolicExpressionTest, IsAddition) {
   EXPECT_TRUE(is_addition(e_add_));
   const vector<Expression>::difference_type cnt{
@@ -211,7 +203,7 @@ TEST_F(SymbolicExpressionTest, IsMultiplication) {
   const vector<Expression>::difference_type cnt{
       count_if(collection_.begin(), collection_.end(),
                [](const Expression& e) { return is_multiplication(e); })};
-  EXPECT_EQ(cnt, 1);
+  EXPECT_EQ(cnt, 2);
 }
 
 TEST_F(SymbolicExpressionTest, IsDivision) {
@@ -377,7 +369,6 @@ TEST_F(SymbolicExpressionTest, GetVariable) {
 }
 
 TEST_F(SymbolicExpressionTest, GetArgument) {
-  EXPECT_PRED2(ExprEqual, get_argument(e_neg_), x_);
   EXPECT_PRED2(ExprEqual, get_argument(e_log_), x_);
   EXPECT_PRED2(ExprEqual, get_argument(e_abs_), x_);
   EXPECT_PRED2(ExprEqual, get_argument(e_exp_), x_);
@@ -423,6 +414,7 @@ TEST_F(SymbolicExpressionTest, GetTermsInAddition) {
 }
 
 TEST_F(SymbolicExpressionTest, GetConstantFactorInMultiplication) {
+  EXPECT_PRED2(ExprEqual, get_constant_in_multiplication(e_neg_), -1.0);
   EXPECT_PRED2(ExprEqual, get_constant_in_multiplication(x_ * y_ * y_), 1.0);
   EXPECT_PRED2(ExprEqual, get_constant_in_multiplication(2 * x_ * y_ * y_),
                2.0);
@@ -557,7 +549,7 @@ TEST_F(SymbolicExpressionTest, ToPolynomial2) {
 }
 
 TEST_F(SymbolicExpressionTest, LessKind) {
-  CheckOrdering({e_constant_, e_var_,  e_neg_,   e_add_,  e_mul_,
+  CheckOrdering({e_constant_, e_var_,  e_add_,   e_neg_,  e_mul_,
                  e_div_,      e_log_,  e_abs_,   e_exp_,  e_sqrt_,
                  e_pow_,      e_sin_,  e_cos_,   e_tan_,  e_asin_,
                  e_acos_,     e_atan_, e_atan2_, e_sinh_, e_cosh_,
@@ -859,7 +851,7 @@ TEST_F(SymbolicExpressionTest, UnaryMinus) {
 
   EXPECT_PRED2(ExprEqual, -(x_plus_y_ + x_plus_z_ + pi_),
                -x_plus_y_ + (-x_plus_z_) + (-pi_));
-  EXPECT_EQ((-(x_)).to_string(), "-(x)");
+  EXPECT_EQ((-(x_)).to_string(), "(-1 * x)");
 }
 
 TEST_F(SymbolicExpressionTest, Add1) {

--- a/drake/common/test/symbolic_substitution_test.cc
+++ b/drake/common/test/symbolic_substitution_test.cc
@@ -86,7 +86,9 @@ TEST_F(SymbolicSubstitutionTest, CheckHomomorphismExpressionVarExpr) {
   vector<F> fns;
   fns.push_back([](const Expression& x) { return 3.0; });
   fns.push_back([](const Expression& x) { return x; });
+  fns.push_back([](const Expression& x) { return 2 * x; });
   fns.push_back([](const Expression& x) { return -x; });
+  fns.push_back([](const Expression& x) { return -3 * x; });
   fns.push_back([&](const Expression& x) { return x + y_; });
   fns.push_back([&](const Expression& x) { return y_ + x; });
   fns.push_back([&](const Expression& x) { return x - y_; });
@@ -158,7 +160,9 @@ TEST_F(SymbolicSubstitutionTest, CheckHomomorphismExpressionSubstitution) {
   vector<F> fns;
   fns.push_back([](const vector<Expression>& v) { return 3.0; });
   fns.push_back([](const vector<Expression>& v) { return v[0]; });
+  fns.push_back([](const vector<Expression>& v) { return 2 * v[0]; });
   fns.push_back([](const vector<Expression>& v) { return -v[0]; });
+  fns.push_back([](const vector<Expression>& v) { return -3 * v[0]; });
   fns.push_back([](const vector<Expression>& v) { return v[0] + v[1]; });
   fns.push_back([](const vector<Expression>& v) { return v[1] - v[2]; });
   fns.push_back([](const vector<Expression>& v) { return v[0] * v[2]; });

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -293,13 +293,6 @@ void DecomposeLinearExpression(
       // There are more than one base, like x^2 * y^3
       throw SymbolicError(e, "is not linear");
     }
-  } else if (is_unary_minus(e) && is_variable(get_argument(e))) {
-    // TODO(hongkai.dai or soonho): rewrite this condition without using
-    // is_unary_minus.
-    const Variable& var{get_variable(get_argument(e))};
-    const_cast<Eigen::MatrixBase<Derived>&>(coeffs)(
-        map_var_to_index.at(var.get_id())) = -1;
-    *constant_term = 0;
   } else if (is_variable(e)) {
     // Just a single variable.
     const Variable& var{get_variable(e)};
@@ -503,20 +496,6 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
         // There is more than one base, like x^2*y^3
         throw SymbolicError(e_i,
                             "non-linear but called with AddLinearConstraint");
-      }
-    } else if (is_unary_minus(e_i) && is_variable(get_argument(e_i))) {
-      // TODO(hongkai.dai or soonho): rewrite this condition without using
-      // is_unary_minus.
-      // i-th constraint is lb <= -var_i <= ub
-      const Variable& var_i{get_variable(get_argument(e_i))};
-      if (v.size() == 1) {
-        // If this is the only constraint, we call AddBoundingBoxConstraint.
-        return Binding<BoundingBoxConstraint>(
-            AddBoundingBoxConstraint(-ub(i), -lb(i), var_i), vars);
-      } else {
-        A(i, map_var_to_index[var_i.get_id()]) = -1;
-        new_lb(i) = lb(i);
-        new_ub(i) = ub(i);
       }
     } else if (is_variable(e_i)) {
       // i-th constraint is lb <= var_i <= ub


### PR DESCRIPTION
 * `-E` is represented as a multiplication expression `-1 * E`. For example, `-x` becomes `-1 * x ^ 1` (as a multiplication expression).
 * Motivation: fewer syntactic kinds -> fewer pattern-matching in application code. (see `mathematical_program.cc`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5024)
<!-- Reviewable:end -->
