### PR TITLE
Upgrade to protobuf 3.1.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,25 @@
 # This file is named BUILD.bazel instead of the more typical BUILD, so that on
 # OSX it won't conflict with a build artifacts directory named "build".
 
+package(
+    default_visibility = ["//visibility:public"],
+)
+
 exports_files([
     "CPPLINT.cfg",
 ])
+
+alias(
+    name="protoc",
+    actual="@protobuf//:protoc",
+)
+
+alias(
+    name="protobuf",
+    actual="@protobuf//:protobuf",
+)
+
+alias(
+    name="protobuf_python",
+    actual="@protobuf//:protobuf_python",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -184,26 +184,14 @@ bind(
     actual = "@six_archive//:six",
 )
 
-# Protocol Buffers
-http_archive(
-    name = 'protobuf_python',
-    url = 'https://github.com/google/protobuf/releases/download/v3.0.0/protobuf-python-3.0.0.tar.gz',
-    sha256 = '6a093cbdb6b40e593c508a03bc9a884239c7bfb377b79d0c0bf43eafe007fb0e',
-    strip_prefix = "protobuf-3.0.0",
-)
-
 github_archive(
-    name = "org_pubref_rules_protobuf",
-    repository = "pubref/rules_protobuf",
-    commit = "v0.7.1",
-    sha256 = "646b39438d8eeba02d9af890dee444c7e4e9d08ae8611bc0e0621257010162db",
+    name = "protobuf",
+    repository = "google/protobuf",
+    commit = "v3.1.0",
+    sha256 = "0a0ae63cbffc274efb573bdde9a253e3f32e458c41261df51c5dbc5ad541e8f7",
 )
 
-load("@org_pubref_rules_protobuf//python:rules.bzl",
-     "py_proto_repositories")
-py_proto_repositories()
-
-# The "@python_headers//:python_headers" target is required by protobuf_python
+# The "@python_headers//:python_headers" target is required by protobuf
 # during "bazel query" but not "bazel build", so a stub is fine.
 new_local_repository(
     name = "python_headers",

--- a/drake/tools/BUILD
+++ b/drake/tools/BUILD
@@ -1,20 +1,14 @@
-load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_compile")
+load("@protobuf//:protobuf.bzl", "py_proto_library")
 
-py_proto_compile(
+py_proto_library(
     name = "named_vector",
-    protos = [
-        "named_vector.proto",
-    ],
-    with_grpc = False,
+    srcs = ["named_vector.proto"],
 )
 
 py_binary(
     name = "lcm_vector_gen",
-    srcs = [
-        "lcm_vector_gen.py",
-        ":named_vector",
-    ],
+    srcs = ["lcm_vector_gen.py"],
     deps = [
-        "@protobuf_python//:protobuf_python",
+        ":named_vector",
     ],
 )


### PR DESCRIPTION
Drop org_pubref_rules_protobuf, which is superseded for our purposes by upstream rules, since we need no gRPC magic.

@soonho-tri for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5025)
<!-- Reviewable:end -->
