### PR TITLE
Refactor symbolic classes

### DIFF
--- a/drake/common/cond.h
+++ b/drake/common/cond.h
@@ -8,16 +8,17 @@ namespace drake {
   Constructs conditional expression (similar to Lisp's cond).
 
   @verbatim
-    cond(cond_1, exp_1,
-         cond_2, exp_2,
+    cond(cond_1, expr_1,
+         cond_2, expr_2,
             ...,   ...,
-         cond_n, exp_n,
-         exp_{n+1})
+         cond_n, expr_n,
+         expr_{n+1})
   @endverbatim
 
-  The value returned by the above cond expression is @c exp_1 if @c cond_1 is
-  true; else if @c cond_2 is true then @c exp_2; ... ; else if @c cond_n is true
-  then @c exp_n. If none of the conditions are true, it returns @c exp_{n+1}.
+  The value returned by the above cond expression is @c expr_1 if @c cond_1 is
+  true; else if @c cond_2 is true then @c expr_2; ... ; else if @c cond_n is
+  true then @c expr_n. If none of the conditions are true, it returns @c
+  expr_{n+1}.
 
   @note This functions assumes that @p ScalarType provides @c operator< and the
   type of @c f_cond is the type of the return type of <tt>operator<(ScalarType,

--- a/drake/common/monomial.cc
+++ b/drake/common/monomial.cc
@@ -24,11 +24,11 @@ using std::runtime_error;
 using std::unordered_map;
 
 namespace internal {
-Monomial::Monomial(const Variable& var, const int exponent)
-    : total_degree_{exponent} {
-  DRAKE_DEMAND(exponent >= 0);
-  if (exponent > 0) {
-    powers_.emplace(var.get_id(), exponent);
+Monomial::Monomial(const Variable& var, const int expnt)
+    : total_degree_{expnt} {
+  DRAKE_DEMAND(expnt >= 0);
+  if (expnt > 0) {
+    powers_.emplace(var.get_id(), expnt);
   }
 }
 
@@ -37,16 +37,16 @@ Monomial::Monomial(const map<Variable::Id, int>& powers)
 
 Expression Monomial::ToExpression(
     const unordered_map<Variable::Id, Variable>& id_to_var_map) const {
-  // It builds this base_to_exp_map and uses ExpressionMulFactory to build a
+  // It builds this base_to_expnt_map and uses ExpressionMulFactory to build a
   // multiplication expression.
-  map<Expression, Expression> base_to_exp_map;
+  map<Expression, Expression> base_to_expnt_map;
   for (const auto& p : powers_) {
     const Variable::Id id{p.first};
-    const int exponent{p.second};
+    const int expnt{p.second};
     const auto it = id_to_var_map.find(id);
     if (it != id_to_var_map.end()) {
       const Variable& var{it->second};
-      base_to_exp_map.emplace(Expression{var}, exponent);
+      base_to_expnt_map.emplace(Expression{var}, expnt);
     } else {
       ostringstream oss;
       oss << "Variable whose ID is " << id << " appeared in a monomial "
@@ -56,7 +56,7 @@ Expression Monomial::ToExpression(
       throw runtime_error(oss.str());
     }
   }
-  return ExpressionMulFactory{1.0, base_to_exp_map}.GetExpression();
+  return ExpressionMulFactory{1.0, base_to_expnt_map}.GetExpression();
 }
 
 int Monomial::TotalDegree(const map<Variable::Id, int>& powers) {
@@ -78,12 +78,12 @@ Monomial operator*(const Monomial& m1, const Monomial& m2) {
   map<Variable::Id, int> powers{m1.get_powers()};
   for (const pair<Variable::Id, int>& p : m2.get_powers()) {
     const Variable::Id var{p.first};
-    const int exponent{p.second};
+    const int expnt{p.second};
     auto it = powers.find(var);
     if (it == powers.end()) {
       powers.insert(p);
     } else {
-      it->second += exponent;
+      it->second += expnt;
     }
   }
   return Monomial{powers};
@@ -91,13 +91,13 @@ Monomial operator*(const Monomial& m1, const Monomial& m2) {
 }  // namespace internal
 
 Expression Monomial(const unordered_map<Variable, int, hash_value<Variable>>&
-                        map_var_to_exponent) {
-  map<Expression, Expression> base_to_exp_map;
-  for (const auto& p : map_var_to_exponent) {
+                        map_var_to_expnt) {
+  map<Expression, Expression> base_to_expnt_map;
+  for (const auto& p : map_var_to_expnt) {
     DRAKE_DEMAND(p.second > 0);
-    base_to_exp_map.emplace(Expression{p.first}, p.second);
+    base_to_expnt_map.emplace(Expression{p.first}, p.second);
   }
-  return ExpressionMulFactory{1.0, base_to_exp_map}.GetExpression();
+  return ExpressionMulFactory{1.0, base_to_expnt_map}.GetExpression();
 }
 
 Eigen::Matrix<Expression, Eigen::Dynamic, 1> MonomialBasis(

--- a/drake/common/monomial.h
+++ b/drake/common/monomial.h
@@ -35,8 +35,8 @@ class Monomial {
   Monomial() = default;
   /** Constructs a Monomial from @p powers. */
   explicit Monomial(const std::map<Variable::Id, int>& powers);
-  /** Constructs a Monomial from @p var and @exponent. */
-  Monomial(const Variable& var, int exponent);
+  /** Constructs a Monomial from @p var and @expnt. */
+  Monomial(const Variable& var, int expnt);
   /** Returns the total degree of this Monomial. */
   int total_degree() const { return total_degree_; }
   const std::map<Variable::Id, int>& get_powers() const { return powers_; }
@@ -114,19 +114,19 @@ struct GradedReverseLexOrder {
     while (it1 != powers1.cend() && it2 != powers2.cend()) {
       const Variable::Id var1{it1->first};
       const Variable::Id var2{it2->first};
-      const int exponent1{it1->second};
-      const int exponent2{it2->second};
+      const int expnt1{it1->second};
+      const int expnt2{it2->second};
       if (variable_order_(var2, var1)) {
         return true;
       } else if (variable_order_(var1, var2)) {
         return false;
       } else {
         // var1 == var2
-        if (exponent1 == exponent2) {
+        if (expnt1 == expnt2) {
           ++it1;
           ++it2;
         } else {
-          return exponent2 > exponent1;
+          return expnt2 > expnt1;
         }
       }
     }
@@ -197,14 +197,14 @@ Eigen::Matrix<Expression, rows, 1> ComputeMonomialBasis(const Variables& vars,
 }  // namespace internal
 
 /** Returns a monomial of the form x^2*y^3, it does not have the constant
- * factor. To generate a monomial x^2*y^3, @p map_var_to_exponent contains the
+ * factor. To generate a monomial x^2*y^3, @p map_var_to_expnt contains the
  * pair (x, 2) and (y, 3).
  *
- * \pre{All exponents in @p map_var_to_exponent are positive integers.}
+ * \pre{All exponents in @p map_var_to_expnt are positive integers.}
  */
 Expression Monomial(
     const std::unordered_map<Variable, int, hash_value<Variable>>&
-        map_var_to_exponent);
+        map_var_to_expnt);
 
 /** Returns all monomials up to a given degree under the graded reverse
  * lexicographic order. Note that graded reverse lexicographic order uses the

--- a/drake/common/symbolic_expression.cc
+++ b/drake/common/symbolic_expression.cc
@@ -528,8 +528,8 @@ Expression pow(const Expression& e1, const Expression& e2) {
   if (is_pow(e1)) {
     // pow(base, exponent) ^ e2 => pow(base, exponent * e2)
     const Expression& base{get_first_argument(e1)};
-    const Expression& exponent{get_second_argument(e1)};
-    return Expression{make_shared<ExpressionPow>(base, exponent * e2)};
+    const Expression& expnt{get_second_argument(e1)};
+    return Expression{make_shared<ExpressionPow>(base, expnt * e2)};
   }
   return Expression{make_shared<ExpressionPow>(e1, e2)};
 }
@@ -709,16 +709,16 @@ const Expression& get_second_argument(const Expression& e) {
 double get_constant_in_addition(const Expression& e) {
   return to_addition(e)->get_constant();
 }
-const map<Expression, double>& get_exp_to_coeff_map_in_addition(
+const map<Expression, double>& get_expr_to_coeff_map_in_addition(
     const Expression& e) {
-  return to_addition(e)->get_exp_to_coeff_map();
+  return to_addition(e)->get_expr_to_coeff_map();
 }
 double get_constant_in_multiplication(const Expression& e) {
   return to_multiplication(e)->get_constant();
 }
-const map<Expression, Expression>& get_base_to_exp_map_in_multiplication(
+const map<Expression, Expression>& get_base_to_expnt_map_in_multiplication(
     const Expression& e) {
-  return to_multiplication(e)->get_base_to_exp_map();
+  return to_multiplication(e)->get_base_to_expnt_map();
 }
 
 }  // namespace symbolic

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -258,25 +258,25 @@ class Expression {
   /** Constructs if-then-else expression.
 
     @verbatim
-      if_then_else(cond, exp_then, exp_else)
+      if_then_else(cond, expr_then, expr_else)
     @endverbatim
 
-    The value returned by the above if-then-else expression is @p exp_then if @p
-    cond is evaluated to true. Otherwise, it returns @p exp_else.
+    The value returned by the above if-then-else expression is @p expr_then if
+    @p cond is evaluated to true. Otherwise, it returns @p expr_else.
 
     The semantics is similar to the C++'s conditional expression constructed by
     its ternary operator, @c ?:. However, there is a key difference between the
     C++'s conditional expression and our @c if_then_else expression in a way the
     arguments are evaluated during the construction.
 
-     - In case of the C++'s conditional expression, <tt> cond ? exp_then :
-       exp_else</tt>, the then expression @c exp_then (respectively, the else
-       expression @c exp_else) is \b only evaluated when the conditional
+     - In case of the C++'s conditional expression, <tt> cond ? expr_then :
+       expr_else</tt>, the then expression @c expr_then (respectively, the else
+       expression @c expr_else) is \b only evaluated when the conditional
        expression @c cond is evaluated to \b true (respectively, when @c cond is
        evaluated to \b false).
 
-     - In case of the symbolic expression, <tt>if_then_else(cond, exp_then,
-       exp_else)</tt>, however, \b both arguments @c exp_then and @c exp_else
+     - In case of the symbolic expression, <tt>if_then_else(cond, expr_then,
+       expr_else)</tt>, however, \b both arguments @c expr_then and @c expr_else
        are evaluated first and then passed to the @c if_then_else function.
 
      @note This function returns an \b expression and it is different from the
@@ -471,7 +471,7 @@ double get_constant_in_addition(const Expression& e);
  *  maps 'x' to 2 and 'y' to 3.
  *  \pre{@p e is an addition expression.}
 */
-const std::map<Expression, double>& get_exp_to_coeff_map_in_addition(
+const std::map<Expression, double>& get_expr_to_coeff_map_in_addition(
     const Expression& e);
 /** Returns the constant part of the multiplication expression @p e. For
  *  instance, given 7 * x^2 * y^3, it returns 7.
@@ -483,7 +483,7 @@ double get_constant_in_multiplication(const Expression& e);
  * return value maps 'x' to 2, 'y' to 3, and 'z' to 'x'.
  *  \pre{@p e is a multiplication expression.}
 */
-const std::map<Expression, Expression>& get_base_to_exp_map_in_multiplication(
+const std::map<Expression, Expression>& get_base_to_expnt_map_in_multiplication(
     const Expression& e);
 
 // Matrix<Expression> * Matrix<double> => Matrix<Expression>

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -72,33 +72,33 @@ bool determine_polynomial(
 // polynomial-convertible or not. This function is used in the
 // constructor of ExpressionMul.
 static bool determine_polynomial(
-    const std::map<Expression, Expression>& term_to_exp_map) {
-  return all_of(term_to_exp_map.begin(), term_to_exp_map.end(),
+    const std::map<Expression, Expression>& base_to_expnt_map) {
+  return all_of(base_to_expnt_map.begin(), base_to_expnt_map.end(),
                 [](const pair<Expression, Expression>& p) {
                   // For each base^exponent, it has to satisfy the following
                   // conditions:
                   //     - base is polynomial-convertible.
                   //     - exponent is a non-negative integer.
                   const Expression& base{p.first};
-                  const Expression& exponent{p.second};
-                  if (!base.is_polynomial() || !is_constant(exponent)) {
+                  const Expression& expnt{p.second};
+                  if (!base.is_polynomial() || !is_constant(expnt)) {
                     return false;
                   }
-                  const double e{get_constant_value(exponent)};
+                  const double e{get_constant_value(expnt)};
                   return is_non_negative_integer(e);
                 });
 }
 
 // Determines if pow(base, exponent) is polynomial-convertible or not. This
 // function is used in constructor of ExpressionPow.
-bool determine_polynomial(const Expression& base, const Expression& exponent) {
+bool determine_polynomial(const Expression& base, const Expression& expnt) {
   // base ^ exponent is polynomial-convertible if the followings hold:
   //    - base is polynomial-convertible.
   //    - exponent is a non-negative integer.
-  if (!(base.is_polynomial() && is_constant(exponent))) {
+  if (!(base.is_polynomial() && is_constant(expnt))) {
     return false;
   }
-  const double e{get_constant_value(exponent)};
+  const double e{get_constant_value(expnt)};
   return is_non_negative_integer(e);
 }
 
@@ -312,18 +312,18 @@ Expression ExpressionNaN::Substitute(const Substitution& s) const {
 ostream& ExpressionNaN::Display(ostream& os) const { return os << "NaN"; }
 
 ExpressionAdd::ExpressionAdd(const double constant,
-                             const map<Expression, double>& exp_to_coeff_map)
+                             const map<Expression, double>& expr_to_coeff_map)
     : ExpressionCell{ExpressionKind::Add,
-                     hash_combine(hash<double>{}(constant), exp_to_coeff_map),
-                     determine_polynomial(exp_to_coeff_map)},
+                     hash_combine(hash<double>{}(constant), expr_to_coeff_map),
+                     determine_polynomial(expr_to_coeff_map)},
       constant_(constant),
-      exp_to_coeff_map_(exp_to_coeff_map) {
-  DRAKE_ASSERT(!exp_to_coeff_map_.empty());
+      expr_to_coeff_map_(expr_to_coeff_map) {
+  DRAKE_ASSERT(!expr_to_coeff_map_.empty());
 }
 
 Variables ExpressionAdd::GetVariables() const {
   Variables ret{};
-  for (const auto& p : exp_to_coeff_map_) {
+  for (const auto& p : expr_to_coeff_map_) {
     ret.insert(p.first.GetVariables());
   }
   return ret;
@@ -337,8 +337,9 @@ bool ExpressionAdd::EqualTo(const ExpressionCell& e) const {
   if (constant_ != add_e.constant_) {
     return false;
   }
-  return equal(exp_to_coeff_map_.cbegin(), exp_to_coeff_map_.cend(),
-               add_e.exp_to_coeff_map_.cbegin(), add_e.exp_to_coeff_map_.cend(),
+  return equal(expr_to_coeff_map_.cbegin(), expr_to_coeff_map_.cend(),
+               add_e.expr_to_coeff_map_.cbegin(),
+               add_e.expr_to_coeff_map_.cend(),
                [](const pair<Expression, double>& p1,
                   const pair<Expression, double>& p2) {
                  return p1.first.EqualTo(p2.first) && p1.second == p2.second;
@@ -358,8 +359,8 @@ bool ExpressionAdd::Less(const ExpressionCell& e) const {
   }
   // Compare the two maps.
   return lexicographical_compare(
-      exp_to_coeff_map_.cbegin(), exp_to_coeff_map_.cend(),
-      add_e.exp_to_coeff_map_.cbegin(), add_e.exp_to_coeff_map_.cend(),
+      expr_to_coeff_map_.cbegin(), expr_to_coeff_map_.cend(),
+      add_e.expr_to_coeff_map_.cbegin(), add_e.expr_to_coeff_map_.cend(),
       [](const pair<Expression, double>& p1,
          const pair<Expression, double>& p2) {
         const Expression& term1{p1.first};
@@ -378,7 +379,7 @@ bool ExpressionAdd::Less(const ExpressionCell& e) const {
 
 Polynomial<double> ExpressionAdd::ToPolynomial() const {
   DRAKE_ASSERT(is_polynomial());
-  return accumulate(exp_to_coeff_map_.begin(), exp_to_coeff_map_.end(),
+  return accumulate(expr_to_coeff_map_.begin(), expr_to_coeff_map_.end(),
                     Polynomial<double>(constant_),
                     [](const Polynomial<double>& polynomial,
                        const pair<Expression, double>& p) {
@@ -388,7 +389,7 @@ Polynomial<double> ExpressionAdd::ToPolynomial() const {
 
 double ExpressionAdd::Evaluate(const Environment& env) const {
   return accumulate(
-      exp_to_coeff_map_.begin(), exp_to_coeff_map_.end(), constant_,
+      expr_to_coeff_map_.begin(), expr_to_coeff_map_.end(), constant_,
       [&env](const double init, const pair<Expression, double>& p) {
         return init + p.first.Evaluate(env) * p.second;
       });
@@ -396,21 +397,22 @@ double ExpressionAdd::Evaluate(const Environment& env) const {
 
 Expression ExpressionAdd::Substitute(const Substitution& s) const {
   return accumulate(
-      exp_to_coeff_map_.begin(), exp_to_coeff_map_.end(), Expression{constant_},
+      expr_to_coeff_map_.begin(), expr_to_coeff_map_.end(),
+      Expression{constant_},
       [&s](const Expression& init, const pair<Expression, double>& p) {
         return init + p.first.Substitute(s) * p.second;
       });
 }
 
 ostream& ExpressionAdd::Display(ostream& os) const {
-  DRAKE_ASSERT(!exp_to_coeff_map_.empty());
+  DRAKE_ASSERT(!expr_to_coeff_map_.empty());
   bool print_plus{false};
   os << "(";
   if (constant_ != 0.0) {
     os << constant_;
     print_plus = true;
   }
-  for (auto& p : exp_to_coeff_map_) {
+  for (auto& p : expr_to_coeff_map_) {
     DisplayTerm(os, print_plus, p.second, p.first);
     print_plus = true;
   }
@@ -442,12 +444,12 @@ ostream& ExpressionAdd::DisplayTerm(ostream& os, const bool print_plus,
 }
 
 ExpressionAddFactory::ExpressionAddFactory(
-    const double constant, const map<Expression, double>& exp_to_coeff_map)
-    : constant_{constant}, exp_to_coeff_map_{exp_to_coeff_map} {}
+    const double constant, const map<Expression, double>& expr_to_coeff_map)
+    : constant_{constant}, expr_to_coeff_map_{expr_to_coeff_map} {}
 
 ExpressionAddFactory::ExpressionAddFactory(
     const shared_ptr<const ExpressionAdd> ptr)
-    : ExpressionAddFactory{ptr->get_constant(), ptr->get_exp_to_coeff_map()} {}
+    : ExpressionAddFactory{ptr->get_constant(), ptr->get_expr_to_coeff_map()} {}
 
 void ExpressionAddFactory::AddExpression(const Expression& e) {
   if (is_constant(e)) {
@@ -465,7 +467,7 @@ void ExpressionAddFactory::AddExpression(const Expression& e) {
       // add (constant, 1.0 * b1^t1 ... bn^tn).
       return AddTerm(
           constant,
-          ExpressionMulFactory(1.0, get_base_to_exp_map_in_multiplication(e))
+          ExpressionMulFactory(1.0, get_base_to_expnt_map_in_multiplication(e))
               .GetExpression());
     }
   }
@@ -474,34 +476,34 @@ void ExpressionAddFactory::AddExpression(const Expression& e) {
 
 void ExpressionAddFactory::Add(const shared_ptr<const ExpressionAdd> ptr) {
   AddConstant(ptr->get_constant());
-  AddMap(ptr->get_exp_to_coeff_map());
+  AddMap(ptr->get_expr_to_coeff_map());
 }
 
 ExpressionAddFactory& ExpressionAddFactory::operator=(
     const shared_ptr<ExpressionAdd> ptr) {
   constant_ = ptr->get_constant();
-  exp_to_coeff_map_ = ptr->get_exp_to_coeff_map();
+  expr_to_coeff_map_ = ptr->get_expr_to_coeff_map();
   return *this;
 }
 
 ExpressionAddFactory& ExpressionAddFactory::Negate() {
   constant_ = -constant_;
-  for (auto& p : exp_to_coeff_map_) {
+  for (auto& p : expr_to_coeff_map_) {
     p.second = -p.second;
   }
   return *this;
 }
 
 Expression ExpressionAddFactory::GetExpression() const {
-  if (exp_to_coeff_map_.empty()) {
+  if (expr_to_coeff_map_.empty()) {
     return Expression{constant_};
   }
-  if (constant_ == 0.0 && exp_to_coeff_map_.size() == 1u) {
+  if (constant_ == 0.0 && expr_to_coeff_map_.size() == 1u) {
     // 0.0 + c1 * t1 -> c1 * t1
-    const auto it(exp_to_coeff_map_.cbegin());
+    const auto it(expr_to_coeff_map_.cbegin());
     return it->first * it->second;
   }
-  return Expression{make_shared<ExpressionAdd>(constant_, exp_to_coeff_map_)};
+  return Expression{make_shared<ExpressionAdd>(constant_, expr_to_coeff_map_)};
 }
 
 void ExpressionAddFactory::AddConstant(const double constant) {
@@ -511,8 +513,8 @@ void ExpressionAddFactory::AddConstant(const double constant) {
 void ExpressionAddFactory::AddTerm(const double coeff, const Expression& term) {
   DRAKE_ASSERT(!is_constant(term));
 
-  const auto it(exp_to_coeff_map_.find(term));
-  if (it != exp_to_coeff_map_.end()) {
+  const auto it(expr_to_coeff_map_.find(term));
+  if (it != expr_to_coeff_map_.end()) {
     // Case1: term is already in the map
     double& this_coeff{it->second};
     this_coeff += coeff;
@@ -520,35 +522,35 @@ void ExpressionAddFactory::AddTerm(const double coeff, const Expression& term) {
       // If the coefficient becomes zero, remove the entry.
       // TODO(soonho-tri): The following operation is not sound since it cancels
       // `term` which might contain 0/0 problems.
-      exp_to_coeff_map_.erase(it);
+      expr_to_coeff_map_.erase(it);
     }
   } else {
-    // Case2: term is not found in exp_to_coeff_map_.
+    // Case2: term is not found in expr_to_coeff_map_.
     // Add the entry (term, coeff).
-    exp_to_coeff_map_.emplace(term, coeff);
+    expr_to_coeff_map_.emplace(term, coeff);
   }
 }
 
 void ExpressionAddFactory::AddMap(
-    const map<Expression, double> exp_to_coeff_map) {
-  for (const auto& p : exp_to_coeff_map) {
+    const map<Expression, double> expr_to_coeff_map) {
+  for (const auto& p : expr_to_coeff_map) {
     AddTerm(p.second, p.first);
   }
 }
 
-ExpressionMul::ExpressionMul(const double constant,
-                             const map<Expression, Expression>& base_to_exp_map)
+ExpressionMul::ExpressionMul(
+    const double constant, const map<Expression, Expression>& base_to_expnt_map)
     : ExpressionCell{ExpressionKind::Mul,
-                     hash_combine(hash<double>{}(constant), base_to_exp_map),
-                     determine_polynomial(base_to_exp_map)},
+                     hash_combine(hash<double>{}(constant), base_to_expnt_map),
+                     determine_polynomial(base_to_expnt_map)},
       constant_(constant),
-      base_to_exp_map_(base_to_exp_map) {
-  DRAKE_ASSERT(!base_to_exp_map_.empty());
+      base_to_expnt_map_(base_to_expnt_map) {
+  DRAKE_ASSERT(!base_to_expnt_map_.empty());
 }
 
 Variables ExpressionMul::GetVariables() const {
   Variables ret{};
-  for (const auto& p : base_to_exp_map_) {
+  for (const auto& p : base_to_expnt_map_) {
     ret.insert(p.first.GetVariables());
     ret.insert(p.second.GetVariables());
   }
@@ -564,13 +566,13 @@ bool ExpressionMul::EqualTo(const ExpressionCell& e) const {
     return false;
   }
   // Check each (term, coeff) pairs in two maps.
-  return equal(base_to_exp_map_.cbegin(), base_to_exp_map_.cend(),
-               mul_e.base_to_exp_map_.cbegin(), mul_e.base_to_exp_map_.cend(),
-               [](const pair<Expression, Expression>& p1,
-                  const pair<Expression, Expression>& p2) {
-                 return p1.first.EqualTo(p2.first) &&
-                        p1.second.EqualTo(p2.second);
-               });
+  return equal(
+      base_to_expnt_map_.cbegin(), base_to_expnt_map_.cend(),
+      mul_e.base_to_expnt_map_.cbegin(), mul_e.base_to_expnt_map_.cend(),
+      [](const pair<Expression, Expression>& p1,
+         const pair<Expression, Expression>& p2) {
+        return p1.first.EqualTo(p2.first) && p1.second.EqualTo(p2.second);
+      });
 }
 
 bool ExpressionMul::Less(const ExpressionCell& e) const {
@@ -586,8 +588,8 @@ bool ExpressionMul::Less(const ExpressionCell& e) const {
   }
   // Compare the two maps.
   return lexicographical_compare(
-      base_to_exp_map_.cbegin(), base_to_exp_map_.cend(),
-      mul_e.base_to_exp_map_.cbegin(), mul_e.base_to_exp_map_.cend(),
+      base_to_expnt_map_.cbegin(), base_to_expnt_map_.cend(),
+      mul_e.base_to_expnt_map_.cbegin(), mul_e.base_to_expnt_map_.cend(),
       [](const pair<Expression, Expression>& p1,
          const pair<Expression, Expression>& p2) {
         const Expression& base1{p1.first};
@@ -607,21 +609,21 @@ bool ExpressionMul::Less(const ExpressionCell& e) const {
 Polynomial<double> ExpressionMul::ToPolynomial() const {
   DRAKE_ASSERT(is_polynomial());
   return accumulate(
-      base_to_exp_map_.begin(), base_to_exp_map_.end(),
+      base_to_expnt_map_.begin(), base_to_expnt_map_.end(),
       Polynomial<double>{constant_}, [](const Polynomial<double>& polynomial,
                                         const pair<Expression, Expression>& p) {
         const Expression& base{p.first};
-        const Expression& exponent{p.second};
+        const Expression& expnt{p.second};
         DRAKE_ASSERT(base.is_polynomial());
-        DRAKE_ASSERT(is_constant(exponent));
+        DRAKE_ASSERT(is_constant(expnt));
         return polynomial * pow(base.ToPolynomial(),
-                                static_cast<int>(get_constant_value(exponent)));
+                                static_cast<int>(get_constant_value(expnt)));
       });
 }
 
 double ExpressionMul::Evaluate(const Environment& env) const {
   return accumulate(
-      base_to_exp_map_.begin(), base_to_exp_map_.end(), constant_,
+      base_to_expnt_map_.begin(), base_to_expnt_map_.end(), constant_,
       [&env](const double init, const pair<Expression, Expression>& p) {
         return init * std::pow(p.first.Evaluate(env), p.second.Evaluate(env));
       });
@@ -629,21 +631,22 @@ double ExpressionMul::Evaluate(const Environment& env) const {
 
 Expression ExpressionMul::Substitute(const Substitution& s) const {
   return accumulate(
-      base_to_exp_map_.begin(), base_to_exp_map_.end(), Expression{constant_},
+      base_to_expnt_map_.begin(), base_to_expnt_map_.end(),
+      Expression{constant_},
       [&s](const Expression& init, const pair<Expression, Expression>& p) {
         return init * pow(p.first.Substitute(s), p.second.Substitute(s));
       });
 }
 
 ostream& ExpressionMul::Display(ostream& os) const {
-  DRAKE_ASSERT(!base_to_exp_map_.empty());
+  DRAKE_ASSERT(!base_to_expnt_map_.empty());
   bool print_mul{false};
   os << "(";
   if (constant_ != 1.0) {
     os << constant_;
     print_mul = true;
   }
-  for (auto& p : base_to_exp_map_) {
+  for (auto& p : base_to_expnt_map_) {
     DisplayTerm(os, print_mul, p.first, p.second);
     print_mul = true;
   }
@@ -653,28 +656,28 @@ ostream& ExpressionMul::Display(ostream& os) const {
 
 ostream& ExpressionMul::DisplayTerm(ostream& os, const bool print_mul,
                                     const Expression& base,
-                                    const Expression& exponent) const {
+                                    const Expression& expnt) const {
   // Print " * pow(base, exponent)" if print_mul is true
   // Print "pow(base, exponent)" if print_mul is false
   // Print "base" instead of "pow(base, exponent)" if exponent == 1.0
   if (print_mul) {
     os << " * ";
   }
-  if (is_one(exponent)) {
+  if (is_one(expnt)) {
     os << base;
   } else {
-    os << "pow(" << base << ", " << exponent << ")";
+    os << "pow(" << base << ", " << expnt << ")";
   }
   return os;
 }
 
 ExpressionMulFactory::ExpressionMulFactory(
-    const double constant, const map<Expression, Expression>& base_to_exp_map)
-    : constant_{constant}, base_to_exp_map_{base_to_exp_map} {}
+    const double constant, const map<Expression, Expression>& base_to_expnt_map)
+    : constant_{constant}, base_to_expnt_map_{base_to_expnt_map} {}
 
 ExpressionMulFactory::ExpressionMulFactory(
     const shared_ptr<const ExpressionMul> ptr)
-    : ExpressionMulFactory{ptr->get_constant(), ptr->get_base_to_exp_map()} {}
+    : ExpressionMulFactory{ptr->get_constant(), ptr->get_base_to_expnt_map()} {}
 
 void ExpressionMulFactory::AddExpression(const Expression& e) {
   if (is_constant(e)) {
@@ -690,13 +693,13 @@ void ExpressionMulFactory::AddExpression(const Expression& e) {
 
 void ExpressionMulFactory::Add(const shared_ptr<const ExpressionMul> ptr) {
   AddConstant(ptr->get_constant());
-  AddMap(ptr->get_base_to_exp_map());
+  AddMap(ptr->get_base_to_expnt_map());
 }
 
 ExpressionMulFactory& ExpressionMulFactory::operator=(
     const shared_ptr<ExpressionMul> ptr) {
   constant_ = ptr->get_constant();
-  base_to_exp_map_ = ptr->get_base_to_exp_map();
+  base_to_expnt_map_ = ptr->get_base_to_expnt_map();
   return *this;
 }
 
@@ -706,15 +709,15 @@ ExpressionMulFactory& ExpressionMulFactory::Negate() {
 }
 
 Expression ExpressionMulFactory::GetExpression() const {
-  if (base_to_exp_map_.empty()) {
+  if (base_to_expnt_map_.empty()) {
     return Expression{constant_};
   }
-  if (constant_ == 1.0 && base_to_exp_map_.size() == 1u) {
+  if (constant_ == 1.0 && base_to_expnt_map_.size() == 1u) {
     // 1.0 * c1^t1 -> c1^t1
-    const auto it(base_to_exp_map_.cbegin());
+    const auto it(base_to_expnt_map_.cbegin());
     return pow(it->first, it->second);
   }
-  return Expression{make_shared<ExpressionMul>(constant_, base_to_exp_map_)};
+  return Expression{make_shared<ExpressionMul>(constant_, base_to_expnt_map_)};
 }
 
 void ExpressionMulFactory::AddConstant(const double constant) {
@@ -722,41 +725,41 @@ void ExpressionMulFactory::AddConstant(const double constant) {
 }
 
 void ExpressionMulFactory::AddTerm(const Expression& base,
-                                   const Expression& exponent) {
+                                   const Expression& expnt) {
   // The following assertion holds because of
   // ExpressionMulFactory::AddExpression.
-  DRAKE_ASSERT(!(is_constant(base) && is_constant(exponent)));
+  DRAKE_ASSERT(!(is_constant(base) && is_constant(expnt)));
   if (is_pow(base)) {
     // If (base, exponent) = (pow(e1, e2), exponent)), then add (e1, e2 *
     // exponent)
     // Example: (x^2)^3 => x^(2 * 3)
-    return AddTerm(get_first_argument(base),
-                   get_second_argument(base) * exponent);
+    return AddTerm(get_first_argument(base), get_second_argument(base) * expnt);
   }
 
-  const auto it(base_to_exp_map_.find(base));
-  if (it != base_to_exp_map_.end()) {
+  const auto it(base_to_expnt_map_.find(base));
+  if (it != base_to_expnt_map_.end()) {
     // base is already in map.
     // (= b1^e1 * ... * (base^this_exponent) * ... * en^bn).
     // Update it to be (... * (base^(this_exponent + exponent)) * ...)
     // Example: x^3 * x^2 => x^5
-    Expression& this_exponent{it->second};
-    this_exponent += exponent;
-    if (is_zero(this_exponent)) {
+    Expression& this_expnt{it->second};
+    this_expnt += expnt;
+    if (is_zero(this_expnt)) {
       // If it ends up with base^0 (= 1.0) then remove this entry from the map.
       // TODO(soonho-tri): The following operation is not sound since it can
       // cancels `base` which might include 0/0 problems.
-      base_to_exp_map_.erase(it);
+      base_to_expnt_map_.erase(it);
     }
   } else {
-    // Product is not found in term_to_exp_map_. Add the entry (base, exponent).
-    base_to_exp_map_.emplace(base, exponent);
+    // Product is not found in base_to_expnt_map_. Add the entry (base,
+    // exponent).
+    base_to_expnt_map_.emplace(base, expnt);
   }
 }
 
 void ExpressionMulFactory::AddMap(
-    const map<Expression, Expression> base_to_exp_map) {
-  for (const auto& p : base_to_exp_map) {
+    const map<Expression, Expression> base_to_expnt_map) {
+  for (const auto& p : base_to_expnt_map) {
     AddTerm(p.first, p.second);
   }
 }
@@ -901,9 +904,8 @@ void ExpressionPow::check_domain(const double v1, const double v2) {
 
 Polynomial<double> ExpressionPow::ToPolynomial() const {
   DRAKE_ASSERT(is_polynomial());
-  const int exponent{
-      static_cast<int>(get_constant_value(get_second_argument()))};
-  return pow(get_first_argument().ToPolynomial(), exponent);
+  const int expnt{static_cast<int>(get_constant_value(get_second_argument()))};
+  return pow(get_first_argument().ToPolynomial(), expnt);
 }
 
 Expression ExpressionPow::Substitute(const Substitution& s) const {
@@ -1305,68 +1307,68 @@ bool is_if_then_else(const ExpressionCell& c) {
 }
 
 shared_ptr<ExpressionConstant> to_constant(
-    const shared_ptr<ExpressionCell> exp_ptr) {
-  DRAKE_ASSERT(is_constant(*exp_ptr));
-  return static_pointer_cast<ExpressionConstant>(exp_ptr);
+    const shared_ptr<ExpressionCell> expr_ptr) {
+  DRAKE_ASSERT(is_constant(*expr_ptr));
+  return static_pointer_cast<ExpressionConstant>(expr_ptr);
 }
 shared_ptr<ExpressionConstant> to_constant(const Expression& e) {
   return to_constant(e.ptr_);
 }
 
 shared_ptr<ExpressionVar> to_variable(
-    const shared_ptr<ExpressionCell> exp_ptr) {
-  DRAKE_ASSERT(is_variable(*exp_ptr));
-  return static_pointer_cast<ExpressionVar>(exp_ptr);
+    const shared_ptr<ExpressionCell> expr_ptr) {
+  DRAKE_ASSERT(is_variable(*expr_ptr));
+  return static_pointer_cast<ExpressionVar>(expr_ptr);
 }
 shared_ptr<ExpressionVar> to_variable(const Expression& e) {
   return to_variable(e.ptr_);
 }
 
 shared_ptr<UnaryExpressionCell> to_unary(
-    const shared_ptr<ExpressionCell> exp_ptr) {
-  DRAKE_ASSERT(is_log(*exp_ptr) || is_abs(*exp_ptr) || is_exp(*exp_ptr) ||
-               is_sqrt(*exp_ptr) || is_sin(*exp_ptr) || is_cos(*exp_ptr) ||
-               is_tan(*exp_ptr) || is_asin(*exp_ptr) || is_acos(*exp_ptr) ||
-               is_atan(*exp_ptr) || is_sinh(*exp_ptr) || is_cosh(*exp_ptr) ||
-               is_tanh(*exp_ptr));
-  return static_pointer_cast<UnaryExpressionCell>(exp_ptr);
+    const shared_ptr<ExpressionCell> expr_ptr) {
+  DRAKE_ASSERT(is_log(*expr_ptr) || is_abs(*expr_ptr) || is_exp(*expr_ptr) ||
+               is_sqrt(*expr_ptr) || is_sin(*expr_ptr) || is_cos(*expr_ptr) ||
+               is_tan(*expr_ptr) || is_asin(*expr_ptr) || is_acos(*expr_ptr) ||
+               is_atan(*expr_ptr) || is_sinh(*expr_ptr) || is_cosh(*expr_ptr) ||
+               is_tanh(*expr_ptr));
+  return static_pointer_cast<UnaryExpressionCell>(expr_ptr);
 }
 shared_ptr<UnaryExpressionCell> to_unary(const Expression& e) {
   return to_unary(e.ptr_);
 }
 
 shared_ptr<BinaryExpressionCell> to_binary(
-    const shared_ptr<ExpressionCell> exp_ptr) {
-  DRAKE_ASSERT(is_division(*exp_ptr) || is_pow(*exp_ptr) ||
-               is_atan2(*exp_ptr) || is_min(*exp_ptr) || is_max(*exp_ptr));
-  return static_pointer_cast<BinaryExpressionCell>(exp_ptr);
+    const shared_ptr<ExpressionCell> expr_ptr) {
+  DRAKE_ASSERT(is_division(*expr_ptr) || is_pow(*expr_ptr) ||
+               is_atan2(*expr_ptr) || is_min(*expr_ptr) || is_max(*expr_ptr));
+  return static_pointer_cast<BinaryExpressionCell>(expr_ptr);
 }
 shared_ptr<BinaryExpressionCell> to_binary(const Expression& e) {
   return to_binary(e.ptr_);
 }
 
 shared_ptr<ExpressionAdd> to_addition(
-    const shared_ptr<ExpressionCell> exp_ptr) {
-  DRAKE_ASSERT(is_addition(*exp_ptr));
-  return static_pointer_cast<ExpressionAdd>(exp_ptr);
+    const shared_ptr<ExpressionCell> expr_ptr) {
+  DRAKE_ASSERT(is_addition(*expr_ptr));
+  return static_pointer_cast<ExpressionAdd>(expr_ptr);
 }
 shared_ptr<ExpressionAdd> to_addition(const Expression& e) {
   return to_addition(e.ptr_);
 }
 
 shared_ptr<ExpressionMul> to_multiplication(
-    const shared_ptr<ExpressionCell> exp_ptr) {
-  DRAKE_ASSERT(is_multiplication(*exp_ptr));
-  return static_pointer_cast<ExpressionMul>(exp_ptr);
+    const shared_ptr<ExpressionCell> expr_ptr) {
+  DRAKE_ASSERT(is_multiplication(*expr_ptr));
+  return static_pointer_cast<ExpressionMul>(expr_ptr);
 }
 shared_ptr<ExpressionMul> to_multiplication(const Expression& e) {
   return to_multiplication(e.ptr_);
 }
 
 shared_ptr<ExpressionIfThenElse> to_if_then_else(
-    const shared_ptr<ExpressionCell> exp_ptr) {
-  DRAKE_ASSERT(is_if_then_else(*exp_ptr));
-  return static_pointer_cast<ExpressionIfThenElse>(exp_ptr);
+    const shared_ptr<ExpressionCell> expr_ptr) {
+  DRAKE_ASSERT(is_if_then_else(*expr_ptr));
+  return static_pointer_cast<ExpressionIfThenElse>(expr_ptr);
 }
 shared_ptr<ExpressionIfThenElse> to_if_then_else(const Expression& e) {
   return to_if_then_else(e.ptr_);

--- a/drake/common/symbolic_expression_cell.h
+++ b/drake/common/symbolic_expression_cell.h
@@ -202,7 +202,7 @@ class ExpressionNaN : public ExpressionCell {
  *  where @f$ c_i @f$ is a constant and @f$ e_i @f$ is a symbolic expression.
  *
  * Internally this class maintains a member variable @c constant_ to represent
- * @f$ c_0 @f$ and another member variable @c exp_to_coeff_map_ to represent a
+ * @f$ c_0 @f$ and another member variable @c expr_to_coeff_map_ to represent a
  * mapping from an expression @f$ e_i @f$ to its coefficient @f$ c_i @f$ of
  * double.
  */
@@ -211,7 +211,7 @@ class ExpressionAdd : public ExpressionCell {
   /** Constructs ExpressionAdd from @p constant_term and @term_to_coeff_map.
    */
   ExpressionAdd(double constant,
-                const std::map<Expression, double>& exp_to_coeff_map);
+                const std::map<Expression, double>& expr_to_coeff_map);
   Variables GetVariables() const override;
   bool EqualTo(const ExpressionCell& e) const override;
   bool Less(const ExpressionCell& e) const override;
@@ -222,8 +222,8 @@ class ExpressionAdd : public ExpressionCell {
   /** Returns the constant. */
   double get_constant() const { return constant_; }
   /** Returns map from an expression to its coefficient. */
-  const std::map<Expression, double>& get_exp_to_coeff_map() const {
-    return exp_to_coeff_map_;
+  const std::map<Expression, double>& get_expr_to_coeff_map() const {
+    return expr_to_coeff_map_;
   }
 
  private:
@@ -231,7 +231,7 @@ class ExpressionAdd : public ExpressionCell {
                             const Expression& term) const;
 
   const double constant_{};
-  const std::map<Expression, double> exp_to_coeff_map_;
+  const std::map<Expression, double> expr_to_coeff_map_;
 };
 
 /** Factory class to help build ExpressionAdd expressions. */
@@ -243,9 +243,9 @@ class ExpressionAddFactory {
   ExpressionAddFactory() = default;
 
   /** Constructs ExpressionAddFactory with @p constant and @p
-   * exp_to_coeff_map. */
+   * expr_to_coeff_map. */
   ExpressionAddFactory(double constant,
-                       const std::map<Expression, double>& exp_to_coeff_map);
+                       const std::map<Expression, double>& expr_to_coeff_map);
 
   /** Constructs ExpressionAddFactory from @p ptr. */
   explicit ExpressionAddFactory(std::shared_ptr<const ExpressionAdd> ptr);
@@ -284,12 +284,12 @@ class ExpressionAddFactory {
    * it also performs simplifications to merge the coefficients of common terms.
    */
   void AddTerm(double coeff, const Expression& term);
-  /* Adds exp_to_coeff_map to this factory. It calls AddConstant and AddTerm
+  /* Adds expr_to_coeff_map to this factory. It calls AddConstant and AddTerm
    * methods. */
-  void AddMap(const std::map<Expression, double> exp_to_coeff_map);
+  void AddMap(const std::map<Expression, double> expr_to_coeff_map);
 
   double constant_{0.0};
-  std::map<Expression, double> exp_to_coeff_map_;
+  std::map<Expression, double> expr_to_coeff_map_;
 };
 
 /** Symbolic expression representing a multiplication of powers.
@@ -302,14 +302,14 @@ class ExpressionAddFactory {
  * expressions.
  *
  * Internally this class maintains a member variable @c constant_ representing
- * @f$ c_0 @f$ and another member variable @c base_to_exp_map_ representing
+ * @f$ c_0 @f$ and another member variable @c base_to_expnt_map_ representing
  * a mapping from a base, @f$ b_i @f$ to its exponentiation @f$ e_i @f$.
  */
 class ExpressionMul : public ExpressionCell {
  public:
-  /** Constructs ExpressionMul from @p constant and @p base_to_exp_map. */
+  /** Constructs ExpressionMul from @p constant and @p base_to_expnt_map. */
   ExpressionMul(double constant,
-                const std::map<Expression, Expression>& base_to_exp_map);
+                const std::map<Expression, Expression>& base_to_expnt_map);
   Variables GetVariables() const override;
   bool EqualTo(const ExpressionCell& e) const override;
   bool Less(const ExpressionCell& e) const override;
@@ -320,8 +320,8 @@ class ExpressionMul : public ExpressionCell {
   /** Returns constant term. */
   double get_constant() const { return constant_; }
   /** Returns map from a term to its coefficient. */
-  const std::map<Expression, Expression>& get_base_to_exp_map() const {
-    return base_to_exp_map_;
+  const std::map<Expression, Expression>& get_base_to_expnt_map() const {
+    return base_to_expnt_map_;
   }
 
  private:
@@ -330,7 +330,7 @@ class ExpressionMul : public ExpressionCell {
                             const Expression& pow) const;
 
   double constant_{};
-  std::map<Expression, Expression> base_to_exp_map_;
+  std::map<Expression, Expression> base_to_expnt_map_;
 };
 
 /** Factory class to help build ExpressionMul expressions. */
@@ -342,9 +342,10 @@ class ExpressionMulFactory {
   ExpressionMulFactory() = default;
 
   /** Constructs ExpressionMulFactory with @p constant and @p
-   * base_to_exp_map. */
-  ExpressionMulFactory(double constant,
-                       const std::map<Expression, Expression>& base_to_exp_map);
+   * base_to_expnt_map. */
+  ExpressionMulFactory(
+      double constant,
+      const std::map<Expression, Expression>& base_to_expnt_map);
 
   /** Constructs ExpressionMulFactory from @p ptr. */
   explicit ExpressionMulFactory(std::shared_ptr<const ExpressionMul> ptr);
@@ -381,12 +382,12 @@ class ExpressionMulFactory {
      it also performs simplifications to merge the exponents of common bases.
   */
   void AddTerm(const Expression& base, const Expression& exponent);
-  /* Adds base_to_exp_map to this factory. It calls AddConstant and AddTerm
+  /* Adds base_to_expnt_map to this factory. It calls AddConstant and AddTerm
    * methods. */
-  void AddMap(const std::map<Expression, Expression> base_to_exp_map);
+  void AddMap(const std::map<Expression, Expression> base_to_expnt_map);
 
   double constant_{1.0};
-  std::map<Expression, Expression> base_to_exp_map_;
+  std::map<Expression, Expression> base_to_expnt_map_;
 };
 
 /** Symbolic expression representing division. */
@@ -658,125 +659,125 @@ class ExpressionIfThenElse : public ExpressionCell {
   const Expression e_else_;
 };
 
-/** Checks if @p exp_ptr is a constant expression. */
+/** Checks if @p c is a constant expression. */
 bool is_constant(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a variable expression. */
+/** Checks if @p c is a variable expression. */
 bool is_variable(const ExpressionCell& c);
-/** Checks if @p exp_ptr is an addition expression. */
+/** Checks if @p c is an addition expression. */
 bool is_addition(const ExpressionCell& c);
-/** Checks if @p exp_ptr is an multiplication expression. */
+/** Checks if @p c is an multiplication expression. */
 bool is_multiplication(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a division expression. */
+/** Checks if @p c is a division expression. */
 bool is_division(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a log expression. */
+/** Checks if @p c is a log expression. */
 bool is_log(const ExpressionCell& c);
-/** Checks if @p exp_ptr is an absolute-value-function expression. */
+/** Checks if @p c is an absolute-value-function expression. */
 bool is_abs(const ExpressionCell& c);
-/** Checks if @p exp_ptr is an exp expression. */
+/** Checks if @p c is an exp expression. */
 bool is_exp(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a square-root expression. */
+/** Checks if @p c is a square-root expression. */
 bool is_sqrt(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a power-function expression. */
+/** Checks if @p c is a power-function expression. */
 bool is_pow(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a sine expression. */
+/** Checks if @p c is a sine expression. */
 bool is_sin(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a cosine expression. */
+/** Checks if @p c is a cosine expression. */
 bool is_cos(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a tangent expression. */
+/** Checks if @p c is a tangent expression. */
 bool is_tan(const ExpressionCell& c);
-/** Checks if @p exp_ptr is an arcsine expression. */
+/** Checks if @p c is an arcsine expression. */
 bool is_asin(const ExpressionCell& c);
-/** Checks if @p exp_ptr is an arccosine expression. */
+/** Checks if @p c is an arccosine expression. */
 bool is_acos(const ExpressionCell& c);
-/** Checks if @p exp_ptr is an arctangent expression. */
+/** Checks if @p c is an arctangent expression. */
 bool is_atan(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a arctangent2  expression. */
+/** Checks if @p c is a arctangent2  expression. */
 bool is_atan2(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a hyperbolic-sine expression. */
+/** Checks if @p c is a hyperbolic-sine expression. */
 bool is_sinh(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a hyperbolic-cosine expression. */
+/** Checks if @p c is a hyperbolic-cosine expression. */
 bool is_cosh(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a hyperbolic-tangent expression. */
+/** Checks if @p c is a hyperbolic-tangent expression. */
 bool is_tanh(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a min expression. */
+/** Checks if @p c is a min expression. */
 bool is_min(const ExpressionCell& c);
-/** Checks if @p exp_ptr is a max expression. */
+/** Checks if @p c is a max expression. */
 bool is_max(const ExpressionCell& c);
-/** Checks if @p exp_ptr is an if-then-else expression. */
+/** Checks if @p c is an if-then-else expression. */
 bool is_if_then_else(const ExpressionCell& c);
 
-/** Casts @p exp_ptr of shared_ptr<ExpressionCell> to
+/** Casts @p expr_ptr of shared_ptr<ExpressionCell> to
  *  @c shared_ptr<ExpressionConstant>.
- *  \pre{@p *exp_ptr is of @c ExpressionConstant.}
+ *  \pre{@p *expr_ptr is of @c ExpressionConstant.}
  */
 std::shared_ptr<ExpressionConstant> to_constant(
-    const std::shared_ptr<ExpressionCell> exp_ptr);
+    const std::shared_ptr<ExpressionCell> expr_ptr);
 /** Casts @p e of Expression to @c shared_ptr<ExpressionConstant>.
  *  \pre{@p *(e.ptr_) is of @c ExpressionConstant.}
  */
 std::shared_ptr<ExpressionConstant> to_constant(const Expression& e);
 
-/** Casts @p exp_ptr of shared_ptr<ExpressionCell> to
+/** Casts @p expr_ptr of shared_ptr<ExpressionCell> to
  *  @c shared_ptr<ExpressionVar>.
- *  \pre{@p *exp_ptr is of @c ExpressionVar.}
+ *  \pre{@p *expr_ptr is of @c ExpressionVar.}
  */
 std::shared_ptr<ExpressionVar> to_variable(
-    const std::shared_ptr<ExpressionCell> exp_ptr);
+    const std::shared_ptr<ExpressionCell> expr_ptr);
 /** Casts @p e of Expression to @c shared_ptr<ExpressionVar>.
  *  \pre{@p *(e.ptr_) is of @c ExpressionVar.}
  */
 std::shared_ptr<ExpressionVar> to_variable(const Expression& e);
 
-/** Casts @p exp_ptr of shared_ptr<ExpressionCell> to
+/** Casts @p expr_ptr of shared_ptr<ExpressionCell> to
  *  @c shared_ptr<UnaryExpressionCell>.
- *  \pre{@c *exp_ptr is of @c UnaryExpressionCell.}
+ *  \pre{@c *expr_ptr is of @c UnaryExpressionCell.}
  */
 std::shared_ptr<UnaryExpressionCell> to_unary(
-    const std::shared_ptr<ExpressionCell> exp_ptr);
+    const std::shared_ptr<ExpressionCell> expr_ptr);
 /** Casts @p e of Expression to @c shared_ptr<UnaryExpressionCell>.
  *  \pre{@c *(e.ptr_) is of @c UnaryExpressionCell.}
  */
 std::shared_ptr<UnaryExpressionCell> to_unary(const Expression& e);
 
-/** Casts @p exp_ptr of shared_ptr<ExpressionCell> to
+/** Casts @p expr_ptr of shared_ptr<ExpressionCell> to
  *  @c shared_ptr<BinaryExpressionCell>.
- *  \pre{@c *exp_ptr is of @c BinaryExpressionCell.}
+ *  \pre{@c *expr_ptr is of @c BinaryExpressionCell.}
  */
 std::shared_ptr<BinaryExpressionCell> to_binary(
-    const std::shared_ptr<ExpressionCell> exp_ptr);
+    const std::shared_ptr<ExpressionCell> expr_ptr);
 /** Casts @p e of Expression to @c shared_ptr<BinaryExpressionCell>.
  *  \pre{@c *(e.ptr_) is of @c BinaryExpressionCell.}
  */
 std::shared_ptr<BinaryExpressionCell> to_binary(const Expression& e);
 
-/** Casts @p exp_ptr of shared_ptr<ExpressionCell> to
+/** Casts @p expr_ptr of shared_ptr<ExpressionCell> to
  *  @c shared_ptr<ExpressionAdd>.
- *  \pre{@c *exp_ptr is of @c ExpressionAdd.}
+ *  \pre{@c *expr_ptr is of @c ExpressionAdd.}
  */
 std::shared_ptr<ExpressionAdd> to_addition(
-    const std::shared_ptr<ExpressionCell> exp_ptr);
+    const std::shared_ptr<ExpressionCell> expr_ptr);
 /** Casts @p e of Expression to @c shared_ptr<ExpressionAdd>.
  *  \pre{@c *(e.ptr_) is of @c ExpressionAdd.}
  */
 std::shared_ptr<ExpressionAdd> to_addition(const Expression& e);
 
-/** Casts @p exp_ptr of shared_ptr<ExpressionCell> to
+/** Casts @p expr_ptr of shared_ptr<ExpressionCell> to
  *  @c shared_ptr<ExpressionMul>.
- *  \pre{@c *exp_ptr is of @c ExpressionConstant.}
+ *  \pre{@c *expr_ptr is of @c ExpressionConstant.}
  */
 std::shared_ptr<ExpressionMul> to_multiplication(
-    const std::shared_ptr<ExpressionCell> exp_ptr);
+    const std::shared_ptr<ExpressionCell> expr_ptr);
 /** Casts @p e of Expression to @c shared_ptr<ExpressionMul>.
  *  \pre{@c *(e.ptr_) is of @c ExpressionConstant.}
  */
 std::shared_ptr<ExpressionMul> to_multiplication(const Expression& e);
 
-/** Casts @p exp_ptr of shared_ptr<ExpressionCell> to
+/** Casts @p expr_ptr of shared_ptr<ExpressionCell> to
  *  @c shared_ptr<ExpressionIfThenElse>.
- *  \pre{@c *exp_ptr is of @c ExpressionIfThenElse.}
+ *  \pre{@c *expr_ptr is of @c ExpressionIfThenElse.}
  */
 std::shared_ptr<ExpressionIfThenElse> to_if_then_else(
-    const std::shared_ptr<ExpressionCell> exp_ptr);
+    const std::shared_ptr<ExpressionCell> expr_ptr);
 /** Casts @p e of Expression to @c shared_ptr<ExpressionIfThenElse>.
  *  \pre{@c *(e.ptr_) is of @c ExpressionIfThenElse.}
  */

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -408,7 +408,7 @@ TEST_F(SymbolicExpressionTest, GetConstantTermInAddition) {
 
 TEST_F(SymbolicExpressionTest, GetTermsInAddition) {
   const Expression e{3 + 2 * x_ + 3 * y_};
-  const map<Expression, double> terms{get_exp_to_coeff_map_in_addition(e)};
+  const map<Expression, double> terms{get_expr_to_coeff_map_in_addition(e)};
   EXPECT_EQ(terms.at(x_), 2.0);
   EXPECT_EQ(terms.at(y_), 3.0);
 }
@@ -425,7 +425,7 @@ TEST_F(SymbolicExpressionTest, GetConstantFactorInMultiplication) {
 TEST_F(SymbolicExpressionTest, GetProductsInMultiplication) {
   const Expression e{2 * x_ * y_ * y_ * pow(z_, y_)};
   const map<Expression, Expression> products{
-      get_base_to_exp_map_in_multiplication(e)};
+      get_base_to_expnt_map_in_multiplication(e)};
   EXPECT_PRED2(ExprEqual, products.at(x_), 1.0);
   EXPECT_PRED2(ExprEqual, products.at(y_), 2.0);
   EXPECT_PRED2(ExprEqual, products.at(z_), y_);

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -261,9 +261,9 @@ void DecomposeLinearExpression(
   DRAKE_DEMAND(coeffs.cols() == static_cast<int>(map_var_to_index.size()));
   if (is_addition(e)) {
     *constant_term = get_constant_in_addition(e);
-    const std::map<Expression, double>& exp_to_coeff_map{
-        get_exp_to_coeff_map_in_addition(e)};
-    for (const pair<Expression, double>& p : exp_to_coeff_map) {
+    const std::map<Expression, double>& expr_to_coeff_map{
+        get_expr_to_coeff_map_in_addition(e)};
+    for (const pair<Expression, double>& p : expr_to_coeff_map) {
       if (is_variable(p.first)) {
         const Variable& var{get_variable(p.first)};
         const double coeff{p.second};
@@ -278,7 +278,7 @@ void DecomposeLinearExpression(
   } else if (is_multiplication(e)) {
     const double c = get_constant_in_multiplication(e);
     const std::map<Expression, Expression>& map_base_to_exponent =
-        get_base_to_exp_map_in_multiplication(e);
+        get_base_to_expnt_map_in_multiplication(e);
     if (map_base_to_exponent.size() == 1) {
       const pair<Expression, Expression>& p = *map_base_to_exponent.begin();
       if (!is_variable(p.first) || !is_one(p.second)) {
@@ -467,7 +467,7 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
       // i-th constraint should be lb <= c * var_i <= ub, where c is a constant.
       const double c = get_constant_in_multiplication(e_i);
       const std::map<Expression, Expression>& map_base_to_exponent =
-          get_base_to_exp_map_in_multiplication(e_i);
+          get_base_to_expnt_map_in_multiplication(e_i);
       if (map_base_to_exponent.size() == 1) {
         const pair<Expression, Expression>& p = *map_base_to_exponent.begin();
         if (!is_variable(p.first) || !is_one(p.second)) {


### PR DESCRIPTION
 - Use `expr` instead of `exp` for `Expression`s.
 - Use `expnt` instead of `exp` for exponents.

Close https://github.com/RobotLocomotion/drake/issues/5034

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5040)
<!-- Reviewable:end -->
