### PR TITLE
Removes extraneous blank line from RigidBody::Clone().

### DIFF
--- a/drake/multibody/rigid_body.cc
+++ b/drake/multibody/rigid_body.cc
@@ -37,7 +37,6 @@ std::unique_ptr<RigidBody<T>> RigidBody<T>::Clone() const {
   body->set_body_index(body_index_);
   body->set_position_start_index(position_start_index_);
   body->set_velocity_start_index(velocity_start_index_);
-
   body->set_contact_points(contact_points_);
   body->set_mass(mass_);
   body->set_center_of_mass(center_of_mass_);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5042)
<!-- Reviewable:end -->
