### PR TITLE
sensors::CameraInfo: Fix test failure

### DIFF
--- a/drake/systems/sensors/test/camera_info_test.cc
+++ b/drake/systems/sensors/test/camera_info_test.cc
@@ -8,8 +8,8 @@ namespace drake {
 namespace systems {
 namespace sensors {
 namespace {
-
-const double kTolerance = std::numeric_limits<double>::epsilon();
+// This is bacause there is a precision difference between Ubuntu and Mac.
+const double kTolerance = 1e-12;
 
 const int kWidth = 640;
 const int kHeight = 480;


### PR DESCRIPTION
The unit test failed due to the precision difference between Ubuntu and Mac.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5051)
<!-- Reviewable:end -->
