### PR TITLE
maliput: levelize the monolane implementation.

### DIFF
--- a/drake/automotive/maliput/monolane/arc_lane.cc
+++ b/drake/automotive/maliput/monolane/arc_lane.cc
@@ -10,7 +10,7 @@ namespace drake {
 namespace maliput {
 namespace monolane {
 
-ArcLane::ArcLane(const api::LaneId& id, const Segment* segment,
+ArcLane::ArcLane(const api::LaneId& id, const api::Segment* segment,
                  const V2& center, double radius,
                  const double theta0, const double d_theta,
                  const api::RBounds& lane_bounds,

--- a/drake/automotive/maliput/monolane/arc_lane.h
+++ b/drake/automotive/maliput/monolane/arc_lane.h
@@ -28,7 +28,7 @@ class ArcLane : public Lane {
   ///
   /// @param id,segment,lane_bounds,driveable_bounds,elevation,superelevation
   ///        See documentation for the Lane base class.
-  ArcLane(const api::LaneId& id, const Segment* segment,
+  ArcLane(const api::LaneId& id, const api::Segment* segment,
           const V2& center, double radius,
           double theta0, double d_theta,
           const api::RBounds& lane_bounds,

--- a/drake/automotive/maliput/monolane/branch_point.cc
+++ b/drake/automotive/maliput/monolane/branch_point.cc
@@ -1,8 +1,5 @@
 #include "drake/automotive/maliput/monolane/branch_point.h"
 
-#include "drake/automotive/maliput/monolane/lane.h"
-#include "drake/automotive/maliput/monolane/road_geometry.h"
-
 #include "drake/common/drake_assert.h"
 
 namespace drake {
@@ -10,7 +7,7 @@ namespace maliput {
 namespace monolane {
 
 BranchPoint::BranchPoint(const api::BranchPointId& id,
-                         RoadGeometry* road_geometry)
+                         api::RoadGeometry* road_geometry)
     : id_(id), road_geometry_(road_geometry) {}
 
 const api::RoadGeometry* BranchPoint::do_road_geometry() const {

--- a/drake/automotive/maliput/monolane/branch_point.h
+++ b/drake/automotive/maliput/monolane/branch_point.h
@@ -15,7 +15,6 @@ namespace monolane {
 
 class BranchPoint;
 class Lane;
-class RoadGeometry;
 
 
 /// An implementation of LaneEndSet.
@@ -46,7 +45,7 @@ class BranchPoint : public api::BranchPoint {
   /// Constructs an empty BranchPoint.
   ///
   /// @p road_geometry must remain valid for the lifetime of this class.
-  BranchPoint(const api::BranchPointId& id, RoadGeometry* road_geometry);
+  BranchPoint(const api::BranchPointId& id, api::RoadGeometry* road_geometry);
 
   /// Adds a LaneEnd to the "A side" of the BranchPoint.
   const api::LaneEnd& AddABranch(const api::LaneEnd& lane_end);
@@ -81,7 +80,7 @@ class BranchPoint : public api::BranchPoint {
   const api::LaneEndSet* DoGetBSide() const override { return &b_side_; }
 
   api::BranchPointId id_;
-  RoadGeometry* road_geometry_{};
+  api::RoadGeometry* road_geometry_{};
   LaneEndSet a_side_;
   LaneEndSet b_side_;
 

--- a/drake/automotive/maliput/monolane/builder.h
+++ b/drake/automotive/maliput/monolane/builder.h
@@ -16,11 +16,8 @@
 namespace drake {
 namespace maliput {
 
-namespace api {
-class RoadGeometry;
-}
-
 namespace monolane {
+class RoadGeometry;
 
 /// @class Builder
 /// Convenient builder class which makes it easy to construct a monolane road

--- a/drake/automotive/maliput/monolane/junction.cc
+++ b/drake/automotive/maliput/monolane/junction.cc
@@ -1,8 +1,5 @@
 #include "drake/automotive/maliput/monolane/junction.h"
 
-#include "drake/automotive/maliput/monolane/road_geometry.h"
-#include "drake/automotive/maliput/monolane/segment.h"
-
 namespace drake {
 namespace maliput {
 namespace monolane {

--- a/drake/automotive/maliput/monolane/junction.h
+++ b/drake/automotive/maliput/monolane/junction.h
@@ -13,8 +13,6 @@ namespace drake {
 namespace maliput {
 namespace monolane {
 
-class RoadGeometry;
-
 /// An api::Junction implementation.
 class Junction : public api::Junction {
  public:
@@ -25,7 +23,7 @@ class Junction : public api::Junction {
   /// @p road_geometry must remain valid for the lifetime of this class,
   /// and must refer to the RoadGeometry which will contain the newly
   /// constructed Junction instance.
-  Junction(const api::JunctionId& id, RoadGeometry* road_geometry)
+  Junction(const api::JunctionId& id, api::RoadGeometry* road_geometry)
       : id_(id), road_geometry_(road_geometry) {}
 
   /// Creates and adds a new Segment with the specified @p id.
@@ -45,7 +43,7 @@ class Junction : public api::Junction {
   }
 
   api::JunctionId id_;
-  RoadGeometry* road_geometry_{};
+  api::RoadGeometry* road_geometry_{};
   std::vector<std::unique_ptr<Segment>> segments_;
 };
 

--- a/drake/automotive/maliput/monolane/lane.cc
+++ b/drake/automotive/maliput/monolane/lane.cc
@@ -1,7 +1,6 @@
 #include "drake/automotive/maliput/monolane/lane.h"
 
 #include "drake/automotive/maliput/monolane/branch_point.h"
-#include "drake/automotive/maliput/monolane/segment.h"
 
 #include "drake/common/drake_assert.h"
 

--- a/drake/automotive/maliput/monolane/lane.h
+++ b/drake/automotive/maliput/monolane/lane.h
@@ -17,7 +17,6 @@ namespace maliput {
 namespace monolane {
 
 class BranchPoint;
-class Segment;
 
 typedef Vector2<double> V2;
 typedef Vector3<double> V3;
@@ -171,7 +170,7 @@ class Lane : public api::Lane {
   ///  * @p p_scale is q_max (and p = q / p_scale);
   ///  * @p elevation is  E_scaled = (1 / p_scale) * E_true(p_scale * p);
   ///  * @p superelevation is  S_scaled = (1 / p_scale) * S_true(p_scale * p).
-  Lane(const api::LaneId& id, const Segment* segment,
+  Lane(const api::LaneId& id, const api::Segment* segment,
        const api::RBounds& lane_bounds,
        const api::RBounds& driveable_bounds,
        double p_scale,
@@ -330,7 +329,7 @@ class Lane : public api::Lane {
   V3 r_hat_of_Rabg(const Rot3& Rabg) const;
 
   const api::LaneId id_;
-  const Segment* segment_{};
+  const api::Segment* segment_{};
   BranchPoint* start_bp_{};
   BranchPoint* end_bp_{};
 

--- a/drake/automotive/maliput/monolane/line_lane.h
+++ b/drake/automotive/maliput/monolane/line_lane.h
@@ -21,7 +21,7 @@ class LineLane : public Lane {
   ///
   /// @param id,segment,lane_bounds,driveable_bounds,elevation,superelevation
   ///        See documentation for the Lane base class.
-  LineLane(const api::LaneId& id, const Segment* segment,
+  LineLane(const api::LaneId& id, const api::Segment* segment,
            const V2& xy0, const V2& dxy,
            const api::RBounds& lane_bounds,
            const api::RBounds& driveable_bounds,

--- a/drake/automotive/maliput/monolane/road_geometry.cc
+++ b/drake/automotive/maliput/monolane/road_geometry.cc
@@ -1,8 +1,5 @@
 #include "drake/automotive/maliput/monolane/road_geometry.h"
 
-#include "drake/automotive/maliput/monolane/branch_point.h"
-#include "drake/automotive/maliput/monolane/junction.h"
-
 #include "drake/common/drake_assert.h"
 
 namespace drake {

--- a/drake/automotive/maliput/monolane/segment.cc
+++ b/drake/automotive/maliput/monolane/segment.cc
@@ -3,8 +3,6 @@
 #include <utility>
 
 #include "drake/automotive/maliput/monolane/arc_lane.h"
-#include "drake/automotive/maliput/monolane/junction.h"
-#include "drake/automotive/maliput/monolane/lane.h"
 #include "drake/automotive/maliput/monolane/line_lane.h"
 
 #include "drake/common/drake_assert.h"

--- a/drake/automotive/maliput/monolane/segment.h
+++ b/drake/automotive/maliput/monolane/segment.h
@@ -12,7 +12,6 @@ namespace drake {
 namespace maliput {
 namespace monolane {
 
-class Junction;
 class ArcLane;
 class LineLane;
 
@@ -26,7 +25,7 @@ class Segment : public api::Segment {
   /// The Segment is not fully initialized until one of NewLineLane()
   /// or NewArcLane() is called exactly once.  @p junction must remain
   /// valid for the lifetime of this class.
-  Segment(const api::SegmentId& id, Junction* junction)
+  Segment(const api::SegmentId& id, api::Junction* junction)
       : id_(id), junction_(junction) {}
 
   /// Gives the segment a newly constructed LineLane.
@@ -58,7 +57,7 @@ class Segment : public api::Segment {
   const api::Lane* do_lane(int index) const override;
 
   api::SegmentId id_;
-  Junction* junction_{};
+  api::Junction* junction_{};
   std::unique_ptr<Lane> lane_;
 };
 


### PR DESCRIPTION
 * Stop wasting type information:
   * Most of the parent-ish pointers can be api:: type with no harm.
 * Remove various unused and/or redundant includes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5067)
<!-- Reviewable:end -->
