### PR TITLE
Add external forcing and more comprehensive testing for sticking friction to planar rod simulation.

### DIFF
--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -161,7 +161,7 @@ void Painleve<T>::DoCalcDiscreteVariableUpdates(
   // Update the generalized velocity vector with discretized external forces
   // (expressed in Frame A).
   const Vector3<T> fgrav(0, mass_*get_gravitational_acceleration(), 0);
-  const Vector3<T> fapplied = input.segment(0,3);
+  const Vector3<T> fapplied = input.segment(0, 3);
   v += dt_ * (fgrav + fapplied);
 
   // Set up the contact normal and tangent (friction) direction Jacobian
@@ -437,7 +437,7 @@ Vector2<T> Painleve<T>::CalcFConeImpactImpulse(
   // Compute the impulses.
   const T cxdot = xdot - k * stheta * half_rod_length * thetadot;
   const int sgn_cxdot = (cxdot > 0) ? 1 : -1;
-  const T fN = -(( 2 * (2 * fY * J + k * mass * r * tau * ctheta +
+  const T fN = -((2 * (2 * fY * J + k * mass * r * tau * ctheta +
        J * k * mass * r * ctheta * thetadot +
        2 * J * mass * ydot)) /
       (4 * J - 2 * k * mass * r * x * ctheta +
@@ -557,7 +557,7 @@ void Painleve<T>::SetAccelerations(const systems::Context<T>& context,
   const T& thetadot = context.get_continuous_state_vector().GetAtIndex(5);
 
   // Compute the external forces.
-  const Vector3<T> fapplied = input.segment(0,3);
+  const Vector3<T> fapplied = input.segment(0, 3);
 
   // Compute the derivatives
   const T xddot = (fapplied(0) + fF) / mass_;
@@ -661,8 +661,8 @@ Vector2<T> Painleve<T>::CalcStickingContactForces(
       k * mass * r * (4 * J + k * k * mass * r * r)*
           stheta * thetadot * thetadot));
 
-  const T fF = (-(1/(8 * J + 2 * k * k * mass * r * r))*
-      (8 * fX * J + fX * k * k * mass * r * r +
+  const T fF = (-(1/(8 * J + 2 * k * k * mass * r * r)) *
+         (8 * fX * J + fX * k * k * mass * r * r +
           fX * k * k * mass* r * r * cos(2 * theta)-
           4 * k * mass * r * tau * stheta +
           fY * k * k * mass * r * r * sin(2 * theta)+

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -602,8 +602,8 @@ void Painleve<T>::SetAccelerations(const systems::Context<T>& context,
 //          D[D[theta[t], t], t] } ]
 // where theta is the counter-clockwise angle the rod makes with the
 // x-axis; fN and fF are contact normal and frictional forces; [fX fY] are
-// arbitrary "external" forces (expressed in the world frame) applied at the
-// center-of-mass of the rod; tau is an arbitrary "external" torque (expressed
+// arbitrary external forces (expressed in the world frame) applied at the
+// center-of-mass of the rod; tau is an arbitrary external torque (expressed
 // in the world frame) that should contain any moments due to any forces applied
 // away from the center-of-mass plus any pure torques; g is the
 // acceleration due to gravity, and (hopefully) all other variables are
@@ -731,8 +731,8 @@ void Painleve<T>::CalcAccelerationsOneContactSliding(
   // where theta is the counter-clockwise angle the rod makes with the
   // x-axis; 'r' is the length of the rod; fN and fF are normal and
   // frictional forces, respectively; [fX fY] are arbitrary
-  // "external" forces (expressed in the world frame) applied at the
-  // center-of-mass of the rod; tau is an arbitrary "external" torque (expressed
+  // external forces (expressed in the world frame) applied at the
+  // center-of-mass of the rod; tau is an arbitrary external torque (expressed
   // in the world frame) that should contain any moments due to any forces
   // applied away from the center-of-mass plus any pure torques; sgn_cxdot is
   // the sign function applied to the horizontal contact velocity; g is the
@@ -836,10 +836,13 @@ void Painleve<T>::CalcAccelerationsOneContactNoSliding(
     const double J = get_rod_moment_of_inertia();
     const double g = get_gravitational_acceleration();
 
-    // Pick the solution that minimizes the tangential acceleration.
-    // This solution was obtained by solving for zero normal acceleration
-    // with the frictional force pointing either possible direction (indicated
-    // by d, meaning positive x-axis and negative x-axis).
+    // Pick the solution that minimizes the tangential acceleration toward
+    // obeying the principle of maximum dissipation, which states that the
+    // friction forces should be those that maximize the dot product
+    // between slip velocity and frictional force. This particular solution was
+    // obtained by solving for zero normal acceleration with the frictional
+    // force pointing either possible direction (indicated by d, meaning
+    // positive x-axis and negative x-axis).
     // cx[t_] := x[t] + k*Cos[theta[t]]*(r/2)
     // cy[t_] := y[t] + k*Sin[theta[t]]*(r/2)
     // Solve[{0 == D[D[cy[t], t], t],
@@ -853,7 +856,7 @@ void Painleve<T>::CalcAccelerationsOneContactNoSliding(
                    J * k * mass * r * stheta * thetadot * thetadot)/
                    (4 * J + k * k * mass * r * r * ctheta * ctheta +
                     d* k * k * mass * mu * r * r * ctheta * stheta));
-      const T F = -d * mu * (N + fY);
+      const T F = -d * mu * N;
       return Vector2<T>(N, F);
     };
     Vector2<T> s1 = calc_force(+1);

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -840,12 +840,19 @@ void Painleve<T>::CalcAccelerationsOneContactNoSliding(
     // This solution was obtained by solving for zero normal acceleration
     // with the frictional force pointing either possible direction (indicated
     // by d, meaning positive x-axis and negative x-axis).
+    // cx[t_] := x[t] + k*Cos[theta[t]]*(r/2)
+    // cy[t_] := y[t] + k*Sin[theta[t]]*(r/2)
+    // Solve[{0 == D[D[cy[t], t], t],
+    //       D[D[y[t], t], t] == (N + fY)/mass + g,
+    //       D[D[x[t], t], t] == (F + fX)/mass,
+    // J*D[D[theta[t], t], t] == (cx[t] - x[t])*N - (cy[t] - y[t])*F + tau,
+    //       F == -d*mu*N},
+   // {N, F, D[D[y[t], t], t], D[D[x[t], t], t], D[D[theta[t], t], t]}]
     auto calc_force = [=](int d) {
-      const T N =
-          (2 * mass *
-              (-2 * g * J + r * J * k * stheta * thetadot * thetadot)) /
-              (4 * J + r * r * k * k * mass * ctheta * ctheta +
-                  r * r * k * k * mass * mu * ctheta * d * stheta) - fY;
+      const T N = (-2 * (2 * J * (fY + g * mass) + k * mass * r * tau * ctheta -
+                   J * k * mass * r * stheta * thetadot * thetadot)/
+                   (4 * J + k * k * mass * r * r * ctheta * ctheta +
+                    d* k * k * mass * mu * r * r * ctheta * stheta));
       const T F = -d * mu * (N + fY);
       return Vector2<T>(N, F);
     };

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -160,9 +160,9 @@ void Painleve<T>::DoCalcDiscreteVariableUpdates(
 
   // Update the generalized velocity vector with discretized external forces
   // (expressed in the world frame).
-  const Vector3<T> fgrav(0, mass_*get_gravitational_acceleration(), 0);
+  const Vector3<T> fgrav(0, mass_ * get_gravitational_acceleration(), 0);
   const Vector3<T> fapplied = input.segment(0, 3);
-  v += dt_ * iM*(fgrav + fapplied);
+  v += dt_ * iM * (fgrav + fapplied);
 
   // Set up the contact normal and tangent (friction) direction Jacobian
   // matrices. These take the form:
@@ -534,7 +534,8 @@ Vector2<T> Painleve<T>::CalcStickingImpactImpulse(
 template <class T>
 void Painleve<T>::SetAccelerations(const systems::Context<T>& context,
                                    systems::VectorBase<T>* const f,
-                                   T fN, T fF, T cx, T cy) const {
+                                   const T& fN, const T& fF,
+                                   const T& cx, const T& cy) const {
   using std::abs;
 
   // Get the inputs.
@@ -576,7 +577,7 @@ void Painleve<T>::SetAccelerations(const systems::Context<T>& context,
 
   // If the force is within the friction cone, verify that the horizontal
   // acceleration at the point of contact is zero (i.e., cxddot = 0).
-  if (fN*mu > abs(fF)) {
+  if (fN * mu > abs(fF)) {
     const T cxddot =
         xddot +
             r * k * (-stheta * thetaddot - ctheta * thetadot * thetadot) / 2;
@@ -734,7 +735,7 @@ void Painleve<T>::CalcAccelerationsOneContactSliding(
   // center-of-mass of the rod; tau is an arbitrary "external" torque (expressed
   // in the world frame) that should contain any moments due to any forces
   // applied away from the center-of-mass plus any pure torques; sgn_cxdot is
-  // the signum function applied to the horizontal contact velocity; g is the
+  // the sign function applied to the horizontal contact velocity; g is the
   // acceleration due to gravity, and (hopefully) all other variables are
   // self-explanatory. The first two equations above are the formula
   // for the point of contact. The next equation requires that the
@@ -822,7 +823,6 @@ void Painleve<T>::CalcAccelerationsOneContactNoSliding(
   const int port_index = 0;
   const auto input = this->EvalEigenVectorInput(context, port_index);
   const double fX = input(0);
-//  const double fY = input(1);
   const double tau = input(2);
 
   // Recompute fF if it does not lie within the friction cone.
@@ -956,7 +956,7 @@ void Painleve<T>::CalcAccelerationsBallistic(
   const auto input = this->EvalEigenVectorInput(context, port_index);
 
   // Second three derivative components are acceleration due to gravity and
-  // other "external" forces.
+  // external forces.
   f->SetAtIndex(3, input(0)/mass_);
   f->SetAtIndex(4, input(1)/mass_ + get_gravitational_acceleration());
   f->SetAtIndex(5, input(2)/J_);

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -823,6 +823,7 @@ void Painleve<T>::CalcAccelerationsOneContactNoSliding(
   const int port_index = 0;
   const auto input = this->EvalEigenVectorInput(context, port_index);
   const double fX = input(0);
+  const double fY = input(1);
   const double tau = input(2);
 
   // Recompute fF if it does not lie within the friction cone.
@@ -844,8 +845,8 @@ void Painleve<T>::CalcAccelerationsOneContactNoSliding(
           (2 * mass *
               (-2 * g * J + r * J * k * stheta * thetadot * thetadot)) /
               (4 * J + r * r * k * k * mass * ctheta * ctheta +
-                  r * r * k * k * mass * mu * ctheta * d * stheta);
-      const T F = -d * mu * N;
+                  r * r * k * k * mass * mu * ctheta * d * stheta) - fY;
+      const T F = -d * mu * (N + fY);
       return Vector2<T>(N, F);
     };
     Vector2<T> s1 = calc_force(+1);

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -652,7 +652,7 @@ Vector2<T> Painleve<T>::CalcStickingContactForces(
   const double fY = input(1);
   const double tau = input(2);
   const T fN = (-(1/(8*J +
-   2 * k * k * mass * r * r)) * (8 * fY * J + 8 * g * J * mass +
+      2 * k * k * mass * r * r)) * (8 * fY * J + 8 * g * J * mass +
       fY * k * k * mass * r * r +  g * k * k * mass * mass * r * r +
       4 * k * mass * r * tau * ctheta -
       fY * k * k * mass * r * r * cos(2 * theta) -

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -603,7 +603,8 @@ void Painleve<T>::SetAccelerations(const systems::Context<T>& context,
 // x-axis; fN and fF are contact normal and frictional forces; [fX fY] are
 // arbitrary "external" forces (expressed in the world frame) applied at the
 // center-of-mass of the rod; tau is an arbitrary "external" torque (expressed
-// in the world frame) applied at the center-of-mass; g is the
+// in the world frame) that should contain any moments due to any forces applied
+// away from the center-of-mass plus any pure torques; g is the
 // acceleration due to gravity, and (hopefully) all other variables are
 // self-explanatory.
 //
@@ -731,8 +732,9 @@ void Painleve<T>::CalcAccelerationsOneContactSliding(
   // frictional forces, respectively; [fX fY] are arbitrary
   // "external" forces (expressed in the world frame) applied at the
   // center-of-mass of the rod; tau is an arbitrary "external" torque (expressed
-  // in the world frame) applied at the center-of-mass; sgn_cxdot is the signum
-  // function applied to the horizontal contact velocity; g is the
+  // in the world frame) that should contain any moments due to any forces
+  // applied away from the center-of-mass plus any pure torques; sgn_cxdot is
+  // the signum function applied to the horizontal contact velocity; g is the
   // acceleration due to gravity, and (hopefully) all other variables are
   // self-explanatory. The first two equations above are the formula
   // for the point of contact. The next equation requires that the

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -857,6 +857,8 @@ void Painleve<T>::CalcAccelerationsOneContactNoSliding(
     const T fN2 = s2(0);
     const T fF1 = s1(1);
     const T fF2 = s2(1);
+    DRAKE_ASSERT(fN1 > -10*std::numeric_limits<double>::epsilon());
+    DRAKE_ASSERT(fN2 > -10*std::numeric_limits<double>::epsilon());
 
     // Calculate candidate tangential accelerations.
     auto calc_tan_accel = [=](int d, const T N, const T F) {

--- a/drake/examples/painleve/painleve.h
+++ b/drake/examples/painleve/painleve.h
@@ -26,7 +26,9 @@ namespace painleve {
 ///
 /// They are already available to link against in the containing library.
 ///
-/// Inputs: no inputs.
+/// Inputs: force and torque (i.e., three-dimensional), which are arbitrary
+//          "external" forces (expressed in the world frame) applied at the
+//          center-of-mass of the rod.
 ///
 /// States: planar position (state indices 0 and 1) and orientation (state
 ///         index 2), and planar linear velocity (state indices 3 and 4) and

--- a/drake/examples/painleve/painleve.h
+++ b/drake/examples/painleve/painleve.h
@@ -26,9 +26,9 @@ namespace painleve {
 ///
 /// They are already available to link against in the containing library.
 ///
-/// Inputs: force and torque (i.e., three-dimensional), which are arbitrary
-//          "external" forces (expressed in the world frame) applied at the
-//          center-of-mass of the rod.
+/// Inputs: planar force (two-dimensional) and torque (scalar), which are
+///         arbitrary "external" forces (expressed in the world frame) applied
+///         at the center-of-mass of the rod.
 ///
 /// States: planar position (state indices 0 and 1) and orientation (state
 ///         index 2), and planar linear velocity (state indices 3 and 4) and

--- a/drake/examples/painleve/painleve.h
+++ b/drake/examples/painleve/painleve.h
@@ -208,7 +208,8 @@ class Painleve : public systems::LeafSystem<T> {
       systems::ContinuousState<T>* derivatives) const;
   void SetAccelerations(const systems::Context<T>& context,
                         systems::VectorBase<T>* const f,
-                        T fN, T fF, T xc, T yc) const;
+                        const T& fN, const T& fF,
+                        const T& xc, const T& yc) const;
   Vector2<T> CalcStickingContactForces(
       const systems::Context<T>& context) const;
   static std::pair<T, T> CalcRodEndpoint(const T& x, const T& y, const int k,

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -311,7 +311,7 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
   std::unique_ptr<BasicVector<double>> ext_input =
       std::make_unique<BasicVector<double>>(3);
   const double f_x = 1.0;
-  const double f_y = 0.0;
+  const double f_y = -1.0;
   ext_input->SetAtIndex(0, f_x);
   ext_input->SetAtIndex(1, f_y);
   ext_input->SetAtIndex(2, f_x * dut_->get_rod_length()/2);

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -344,7 +344,7 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
   EXPECT_NEAR((*derivatives_)[4], 0.0, tol);
   // The moment caused by applying the force should result in a
   // counter-clockwise acceleration.
-  EXPECT_NEAR((*derivatives_)[5], 
+  EXPECT_NEAR((*derivatives_)[5],
               fext(2)/dut_->get_rod_moment_of_inertia(), tol);
 }
 

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -320,7 +320,7 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
 
   // Set the coefficient of friction such that the contact forces are right
   // on the edge of the friction cone. Determine the predicted normal force
-  // (this simple formula is dependent upon the upright rod configuration). 
+  // (this simple formula is dependent upon the upright rod configuration).
   const double mu_stick = f_x / (dut_->get_rod_mass() *
                                  -dut_->get_gravitational_acceleration() -
                                  f_y);
@@ -340,11 +340,11 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
 
   // Set the coefficient of friction to 99.9% of the sticking value and then
   // verify that the contact state transitions from a sticking one to a
-  // non-sticking one. 
+  // non-sticking one.
   const double mu_slide = 0.999 * mu_stick;
   dut_->set_mu_coulomb(mu_slide);
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
-  EXPECT_GT((*derivatives_)[3], tol);
+  EXPECT_GT((*derivatives_)[3], tol);  // horizontal accel. should be nonzero.
 
   // Set the coefficient of friction to zero and try again.
   context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
@@ -360,7 +360,7 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
   EXPECT_NEAR((*derivatives_)[4], 0.0, tol);
   // The moment caused by applying the force should result in a
   // counter-clockwise acceleration.
-  EXPECT_NEAR((*derivatives_)[5], 
+  EXPECT_NEAR((*derivatives_)[5],
               fext(2)/dut_->get_rod_moment_of_inertia(), tol);
 }
 

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -289,19 +289,6 @@ TEST_F(PainleveDAETest, ConsistentDerivativesContacting) {
   EXPECT_NEAR((*derivatives_)[5], 0.0, tol);
 }
 
-// Returns the sign of the floating point argument with a two-epsilon band
-// around zero.
-int intsign(double x) {
-  if (x > std::numeric_limits<double>::epsilon()) {
-    return 1;
-  } else {
-    if (x < -std::numeric_limits<double>::epsilon())
-      return -1;
-    else
-      return 0;
-  }
-}
-
 // Verify that derivatives match what we expect from a sticking contact
 // configuration.
 TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
@@ -352,12 +339,13 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
   EXPECT_NEAR((*derivatives_)[1], xc[4], tol);
   EXPECT_NEAR((*derivatives_)[2], xc[5], tol);
   // Rod should now accelerate in the direction of any external forces.
-  EXPECT_EQ(intsign((*derivatives_)[3]), intsign(fext(0)));
+  EXPECT_NEAR((*derivatives_)[3], fext(0)/dut_->get_rod_mass(), tol);
   // There should still be no vertical acceleration.
   EXPECT_NEAR((*derivatives_)[4], 0.0, tol);
   // The moment caused by applying the force should result in a
   // counter-clockwise acceleration.
-  EXPECT_EQ(intsign((*derivatives_)[5]), intsign(fext(2)));
+  EXPECT_NEAR((*derivatives_)[5], 
+              fext(2)/dut_->get_rod_moment_of_inertia(), tol);
 }
 
 // Verify the inconsistent (Painlevé Paradox) configuration occurs.

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -20,8 +20,8 @@ namespace drake {
 namespace painleve {
 namespace {
 
-/// Class for testing the Painleve Paradox example using a piecewise DAE
-/// approach.
+// Class for testing the Painleve Paradox example using a piecewise DAE
+// approach.
 class PainleveDAETest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -646,8 +646,8 @@ TEST_F(PainleveDAETest, BallisticNoImpact) {
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 }
 
-/// Class for testing the Painleve Paradox example using a first order time
-/// stepping approach.
+// Class for testing the Painleve Paradox example using a first order time
+// stepping approach.
 class PainleveTimeSteppingTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -830,8 +830,8 @@ GTEST_TEST(PainleveCrossValidationTest, OneStepSolutionSticking) {
       Painleve<double>::kStickingSingleContact;
 
   // Set constant input forces for both.
-  const double x = 1.0;
-  Vector3<double> fext(x, -1.0, x * ts.get_rod_length()/2);
+  const double fext_x = 1.0;
+  Vector3<double> fext(fext_x, -1.0, fext_x * ts.get_rod_length()/2);
   std::unique_ptr<BasicVector<double>> ext_input =
     std::make_unique<BasicVector<double>>(fext);
   context_ts->FixInputPort(0, std::move(ext_input));

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -304,7 +304,7 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
   xc[4] = 0.0;
   xc[5] = 0.0;
   context_->template get_mutable_abstract_state<Painleve<double>::Mode>(0) =
-  Painleve<double>::kStickingSingleContact;
+      Painleve<double>::kStickingSingleContact;
 
   // Set a constant horizontal input force, as if applied at the bottom of
   // the rod.

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -312,7 +312,7 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
       std::make_unique<BasicVector<double>>(3);
   const double f = 1.0;
   ext_input->SetAtIndex(0, f);
-  ext_input->SetAtIndex(1, 0.0);
+  ext_input->SetAtIndex(1, -1.0);
   ext_input->SetAtIndex(2, f * dut_->get_rod_length()/2);
   const Vector3<double> fext = ext_input->CopyToVector();
   context_->FixInputPort(0, std::move(ext_input));
@@ -831,7 +831,7 @@ GTEST_TEST(PainleveCrossValidationTest, OneStepSolutionSticking) {
 
   // Set constant input forces for both.
   const double x = 1.0;
-  Vector3<double> fext(x, 0, x * ts.get_rod_length()/2);
+  Vector3<double> fext(x, -1.0, x * ts.get_rod_length()/2);
   std::unique_ptr<BasicVector<double>> ext_input =
     std::make_unique<BasicVector<double>>(fext);
   context_ts->FixInputPort(0, std::move(ext_input));

--- a/drake/examples/painleve/test/painleve_test.cc
+++ b/drake/examples/painleve/test/painleve_test.cc
@@ -286,7 +286,8 @@ TEST_F(PainleveDAETest, ConsistentDerivativesContacting) {
   EXPECT_NEAR((*derivatives_)[5], 0.0, tol);
 }
 
-// Returns the sign of the floating point argument.
+// Returns the sign of the floating point argument with a two-epsilon band
+// around zero.
 int intsign(double x) {
   if (x > std::numeric_limits<double>::epsilon()) {
     return 1;
@@ -333,7 +334,7 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
 
   // Verify that derivatives match what we expect: sticking should continue.
-  const double tol = std::numeric_limits<double>::epsilon() * 10;
+  const double tol = 10 * std::numeric_limits<double>::epsilon();
   EXPECT_NEAR((*derivatives_)[0], xc[3], tol);
   EXPECT_NEAR((*derivatives_)[1], xc[4], tol);
   EXPECT_NEAR((*derivatives_)[2], xc[5], tol);
@@ -341,15 +342,18 @@ TEST_F(PainleveDAETest, DerivativesContactingAndSticking) {
   EXPECT_NEAR((*derivatives_)[4], 0.0, tol);
   EXPECT_NEAR((*derivatives_)[5], 0.0, tol);
 
-  // Set the coefficient of friction to zero and try again. Rod should now
-  // accelerate in the direction of any external forces.
+  // Set the coefficient of friction to zero and try again.
   dut_->set_mu_coulomb(0.0);
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
   EXPECT_NEAR((*derivatives_)[0], xc[3], tol);
   EXPECT_NEAR((*derivatives_)[1], xc[4], tol);
   EXPECT_NEAR((*derivatives_)[2], xc[5], tol);
+  // Rod should now accelerate in the direction of any external forces.
   EXPECT_EQ(intsign((*derivatives_)[3]), intsign(fext(0)));
+  // There should still be no vertical acceleration.
   EXPECT_NEAR((*derivatives_)[4], 0.0, tol);
+  // The moment caused by applying the force should result in a
+  // counter-clockwise acceleration.
   EXPECT_EQ(intsign((*derivatives_)[5]), intsign(fext(2)));
 }
 


### PR DESCRIPTION
The Painlevé Paradox (really, a general planar rod simulation) has not supported applying external forces, which has precluded testing and using the rigid, sticking contact code. By extension, this omission has precluded implementation of witness functions for transitioning between sticking and sliding contact.

This PR adds the ability to apply external forces to the system and adds testing for (1) verifying that sticking contact really does stick and (2) that sticking contact does transition to sliding contact when sufficient external force is added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5068)
<!-- Reviewable:end -->
