### PR TITLE
Change CameraInfo to be noncopyable

### DIFF
--- a/drake/systems/sensors/camera_info.cc
+++ b/drake/systems/sensors/camera_info.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/sensors/camera_info.h"
 
+#include "drake/common/drake_assert.h"
+
 namespace drake {
 namespace systems {
 namespace sensors {

--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -2,7 +2,7 @@
 
 #include <Eigen/Dense>
 
-#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace systems {
@@ -58,6 +58,8 @@ namespace sensors {
 // needed.
 class CameraInfo {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CameraInfo)
+
   /// Constructor that directly sets the image size, center, and focal lengths.
   ///
   /// @param width The image width in pixels, must be greater than zero.
@@ -87,16 +89,6 @@ class CameraInfo {
   /// @param height The image height in pixels, must be greater than zero.
   /// @param fov_y The vertical field of view.
   CameraInfo(int width, int height, double fov_y);
-
-  /// Default copy constructor.
-  CameraInfo(const CameraInfo&) = default;
-
-  /// Default move constructor.
-  CameraInfo(CameraInfo&&) = default;
-
-  CameraInfo() = delete;
-  CameraInfo& operator=(const CameraInfo&) = delete;
-  CameraInfo& operator=(CameraInfo&&) = delete;
 
   /// Returns the width of the image in pixels.
   int width() const { return width_; }

--- a/drake/systems/sensors/test/camera_info_test.cc
+++ b/drake/systems/sensors/test/camera_info_test.cc
@@ -53,18 +53,6 @@ TEST_F(CameraInfoTest, ConstructionWithFovTest) {
   Verify(dut);
 }
 
-TEST_F(CameraInfoTest, CopyConstructorTest) {
-  CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
-  CameraInfo dut(camera_info);
-  Verify(dut);
-}
-
-TEST_F(CameraInfoTest, MoveConstructorTest) {
-  CameraInfo camera_info(kWidth, kHeight, kFx, kFy, kCx, kCy);
-  CameraInfo dut(std::move(camera_info));
-  Verify(dut);
-}
-
 }  // namespace
 }  // namespace sensors
 }  // namespace systems


### PR DESCRIPTION
The copying is not needed in any current development branch.

A portion of #4861.  Relates to #5076.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5080)
<!-- Reviewable:end -->
