### PR TITLE
common: more back-porting to C++11 and Eigen 3.2.

### DIFF
--- a/drake/common/drake_compat.h
+++ b/drake/common/drake_compat.h
@@ -4,18 +4,20 @@
 /// This header provides a std::make_unique implementation to be used when the
 /// compiler does not support C++14, or is not in C++14 mode.  This file is
 /// included from a few basic headers within the drake/common subdirectory,
-/// such that almost every file in Drake is exposed to it.  This allows us to
-/// write code using the std::make_unique phrasing, but still support GCC 4.8.
+/// such that almost every file in Drake is exposed to it.
 
 #ifndef DRAKE_DOXYGEN_CXX
 #if __cplusplus <= 201103L  // If C++11 or earlier, we need our own helpers.
 
+#include <iterator>
 #include <memory>
 #include <type_traits>
 #include <utility>
 
 namespace std {
 
+/// This allows us to write code using the std::make_unique phrasing, but still
+/// support GCC 4.8.
 template<typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
@@ -24,7 +26,22 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 template<bool B, class T = void>
 using enable_if_t = typename enable_if<B, T>::type;
 
+
+/// This implements the 4-iterator `equal` overload available in c++14, in a
+/// way compatible with GCC 4.8.
+template<class InputIt1, class InputIt2, class BinaryPredicate>
+bool equal(InputIt1 first1, InputIt1 last1,
+           InputIt2 first2, InputIt2 last2,
+           BinaryPredicate p) {
+  if (std::distance(first1, last1) != std::distance(last2, first2)) {
+    return false;  // Lengths differ.
+  }
+  return std::equal(first1, last1, first2, p);
+}
+
+
 }  // namespace std
 
 #endif  // version check
 #endif  // doxygen check
+

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -643,6 +643,23 @@ struct equal_to<drake::symbolic::Expression> {
     return lhs.EqualTo(rhs);
   }
 };
+
+#if !EIGEN_VERSION_AT_LEAST(3, 2, 93)
+/// Provides std::max<drake::symbolic::Expression>. There is nothing about this
+/// hack that is not horrible.
+template <>
+inline const drake::symbolic::Expression& max(
+    const drake::symbolic::Expression& lhs,
+    const drake::symbolic::Expression& rhs) {
+  static constexpr char doom[] = R"doom(
+Eigen algebra over drake::symbolic::Expressions cannot be safely implemented
+using Eigen 3.2. If you need this, use a platform that supports Eigen 3.3 or
+later.
+)doom";
+  DRAKE_ABORT_MSG(doom);
+}
+#endif  // EIGEN_VERSION_AT_LEAST(3, 2, 93)
+
 }  // namespace std
 
 #if !defined(DRAKE_DOXYGEN_CXX)
@@ -655,6 +672,7 @@ struct NumTraits<drake::symbolic::Expression>
   static inline int digits10() { return 0; }
 };
 
+#if EIGEN_VERSION_AT_LEAST(3, 2, 93)
 // Informs Eigen that Variable op Variable gets Expression.
 template <typename BinaryOp>
 struct ScalarBinaryOpTraits<drake::symbolic::Variable,
@@ -706,6 +724,7 @@ struct ScalarBinaryOpTraits<double, drake::symbolic::Expression, BinaryOp> {
   enum { Defined = 1 };
   typedef drake::symbolic::Expression ReturnType;
 };
+#endif  // EIGEN_VERSION_AT_LEAST(3, 2, 93)
 
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -14,6 +14,7 @@
 #include <utility>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_compat.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_expression.h"
@@ -122,16 +123,16 @@ Variables UnaryExpressionCell::GetVariables() const {
 bool UnaryExpressionCell::EqualTo(const ExpressionCell& e) const {
   // Expression::EqualTo guarantees the following assertion.
   DRAKE_ASSERT(get_kind() == e.get_kind());
-  const UnaryExpressionCell& unary_e{
-      static_cast<const UnaryExpressionCell&>(e)};
+  const UnaryExpressionCell& unary_e =
+      static_cast<const UnaryExpressionCell&>(e);
   return e_.EqualTo(unary_e.e_);
 }
 
 bool UnaryExpressionCell::Less(const ExpressionCell& e) const {
   // Expression::Less guarantees the following assertion.
   DRAKE_ASSERT(get_kind() == e.get_kind());
-  const UnaryExpressionCell& unary_e{
-      static_cast<const UnaryExpressionCell&>(e)};
+  const UnaryExpressionCell& unary_e =
+      static_cast<const UnaryExpressionCell&>(e);
   return e_.Less(unary_e.e_);
 }
 
@@ -157,16 +158,16 @@ Variables BinaryExpressionCell::GetVariables() const {
 bool BinaryExpressionCell::EqualTo(const ExpressionCell& e) const {
   // Expression::EqualTo guarantees the following assertion.
   DRAKE_ASSERT(get_kind() == e.get_kind());
-  const BinaryExpressionCell& binary_e{
-      static_cast<const BinaryExpressionCell&>(e)};
+  const BinaryExpressionCell& binary_e =
+      static_cast<const BinaryExpressionCell&>(e);
   return e1_.EqualTo(binary_e.e1_) && e2_.EqualTo(binary_e.e2_);
 }
 
 bool BinaryExpressionCell::Less(const ExpressionCell& e) const {
   // Expression::Less guarantees the following assertion.
   DRAKE_ASSERT(get_kind() == e.get_kind());
-  const BinaryExpressionCell& binary_e{
-      static_cast<const BinaryExpressionCell&>(e)};
+  const BinaryExpressionCell& binary_e =
+      static_cast<const BinaryExpressionCell&>(e);
   if (e1_.Less(binary_e.e1_)) {
     return true;
   }
@@ -747,7 +748,7 @@ void ExpressionMulFactory::AddTerm(const Expression& base,
     // (= b1^e1 * ... * (base^this_exponent) * ... * en^bn).
     // Update it to be (... * (base^(this_exponent + exponent)) * ...)
     // Example: x^3 * x^2 => x^5
-    Expression& this_exponent{it->second};
+    Expression& this_exponent = it->second;
     this_exponent += exponent;
     if (is_zero(this_exponent)) {
       // If it ends up with base^0 (= 1.0) then remove this entry from the map.

--- a/drake/common/symbolic_formula_cell.cc
+++ b/drake/common/symbolic_formula_cell.cc
@@ -7,6 +7,7 @@
 #include <stdexcept>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_compat.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_expression.h"
@@ -45,16 +46,16 @@ Variables RelationalFormulaCell::GetFreeVariables() const {
 bool RelationalFormulaCell::EqualTo(const FormulaCell& f) const {
   // Formula::EqualTo guarantees the following assertion.
   DRAKE_ASSERT(get_kind() == f.get_kind());
-  const RelationalFormulaCell& rel_f{
-      static_cast<const RelationalFormulaCell&>(f)};
+  const RelationalFormulaCell& rel_f =
+      static_cast<const RelationalFormulaCell&>(f);
   return e_lhs_.EqualTo(rel_f.e_lhs_) && e_rhs_.EqualTo(rel_f.e_rhs_);
 }
 
 bool RelationalFormulaCell::Less(const FormulaCell& f) const {
   // Formula::Less guarantees the following assertion.
   DRAKE_ASSERT(get_kind() == f.get_kind());
-  const RelationalFormulaCell& rel_f{
-      static_cast<const RelationalFormulaCell&>(f)};
+  const RelationalFormulaCell& rel_f =
+      static_cast<const RelationalFormulaCell&>(f);
   if (e_lhs_.Less(rel_f.e_lhs_)) {
     return true;
   }
@@ -80,7 +81,7 @@ Variables NaryFormulaCell::GetFreeVariables() const {
 bool NaryFormulaCell::EqualTo(const FormulaCell& f) const {
   // Formula::EqualTo guarantees the following assertion.
   DRAKE_ASSERT(get_kind() == f.get_kind());
-  const NaryFormulaCell& nary_f{static_cast<const NaryFormulaCell&>(f)};
+  const NaryFormulaCell& nary_f = static_cast<const NaryFormulaCell&>(f);
   return equal(
       formulas_.cbegin(), formulas_.cend(), nary_f.formulas_.cbegin(),
       nary_f.formulas_.cend(),
@@ -90,7 +91,7 @@ bool NaryFormulaCell::EqualTo(const FormulaCell& f) const {
 bool NaryFormulaCell::Less(const FormulaCell& f) const {
   // Formula::Less guarantees the following assertion.
   DRAKE_ASSERT(get_kind() == f.get_kind());
-  const NaryFormulaCell& nary_f{static_cast<const NaryFormulaCell&>(f)};
+  const NaryFormulaCell& nary_f = static_cast<const NaryFormulaCell&>(f);
   return lexicographical_compare(
       formulas_.cbegin(), formulas_.cend(), nary_f.formulas_.cbegin(),
       nary_f.formulas_.cend(),


### PR DESCRIPTION
There exists a *cough* proprietary consumer of Drake that will require GCC 4.8
and Eigen 3.2 for some months yet. Once it has upgraded, the version-sensitive
shim code can be removed.

 * Convert some uses of {} initialization on references to =, to avoid
   constructor calls.
 * Provide a shim for 4-iterator std::equal().
 * Provide a doom-laden specialization for std::max<Expression>().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5084)
<!-- Reviewable:end -->
