### PR TITLE
Revert the bazel test rules from #5090.

### DIFF
--- a/drake/examples/schunk_wsg/BUILD
+++ b/drake/examples/schunk_wsg/BUILD
@@ -4,7 +4,6 @@
 load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
-    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_binary",
 )
@@ -30,43 +29,6 @@ drake_cc_library(
         "//drake/lcmtypes:schunk",
         "//drake/systems/framework:leaf_system",
     ],
-)
-
-# === test/ ===
-
-drake_cc_googletest(
-    name = "schunk_wsg_lift_test",
-    data = [
-        ":models",
-        "//drake/multibody:models",
-    ],
-    deps = [
-        "//drake/common",
-        "//drake/common:drake_path",
-        "//drake/common/trajectories:piecewise_polynomial_trajectory",
-        "//drake/common/trajectories:trajectory",
-        "//drake/lcm:lcm",
-        "//drake/multibody/parsers:parsers",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/multibody/rigid_body_plant:drake_visualizer",
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody:rigid_body_tree_construction",
-        "//drake/systems/analysis",
-        "//drake/systems/controllers:pid_controlled_system",
-        "//drake/systems/framework:diagram_builder",
-        "//drake/systems/primitives:constant_vector_source",
-        "//drake/systems/primitives:trajectory_source",
-    ]
-)
-
-filegroup(
-    name = "models",
-    srcs = glob([
-        "**/*.obj",
-        "**/*.sdf",
-        "**/*.urdf",
-        "**/*.xml",
-    ]),
 )
 
 cpplint()


### PR DESCRIPTION
It times out the debug build in CI, and I'm not clear on how to keep
CI from running it during bazel debug builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5102)
<!-- Reviewable:end -->
