### PR TITLE
Introduce SparsityMatrix.

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -21,6 +21,7 @@ drake_cc_library(
         ":leaf_system",
         ":parameters",
         ":single_output_vector_source",
+        ":sparsity_matrix",
         ":state",
         ":system",
         ":value",
@@ -299,6 +300,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "sparsity_matrix",
+    srcs = ["sparsity_matrix.cc"],
+    hdrs = ["sparsity_matrix.h"],
+    deps = [
+        ":context",
+        ":system",
+        "//drake/common:symbolic",
+    ],
+)
+
+drake_cc_library(
     name = "single_output_vector_source",
     srcs = ["single_output_vector_source.cc"],
     hdrs = ["single_output_vector_source.h"],
@@ -471,6 +483,14 @@ drake_cc_googletest(
     deps = [
         ":value",
         "//drake/common",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sparsity_matrix_test",
+    deps = [
+        ":leaf_system",
+        ":sparsity_matrix",
     ],
 )
 

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -16,6 +16,7 @@ set(sources
   output_port_listener_interface.cc
   parameters.cc
   single_output_vector_source.cc
+  sparsity_matrix.cc
   state.cc
   subvector.cc
   supervector.cc
@@ -53,6 +54,7 @@ set(installed_headers
   output_port_listener_interface.h
   parameters.h
   single_output_vector_source.h
+  sparsity_matrix.h
   state.h
   subvector.h
   supervector.h

--- a/drake/systems/framework/sparsity_matrix.cc
+++ b/drake/systems/framework/sparsity_matrix.cc
@@ -1,0 +1,156 @@
+#include "drake/systems/framework/sparsity_matrix.h"
+
+#include <sstream>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace systems {
+
+SparsityMatrix::SparsityMatrix(const System<symbolic::Expression>& system)
+    : context_(system.CreateDefaultContext()),
+      output_(system.AllocateOutput(*context_)),
+      input_expressions_(system.get_num_input_ports()),
+      output_port_types_(system.get_num_output_ports()),
+      context_is_abstract_(IsAbstract(system, *context_)) {
+  // Stop analysis if the Context is in any way abstract, because we have no way
+  // to initialize the abstract elements.
+  if (context_is_abstract_) return;
+
+  // Time
+  context_->set_time(symbolic::Expression("t"));
+
+  // Input
+  InitializeVectorInputs(system);
+
+  // State
+  InitializeContinuousState();
+  InitializeDiscreteState();
+
+  // Parameters
+  // TODO(david-german-tri): Initialize parameters, once #5072 is resolved.
+
+  // Outputs
+  // -- Record the output port descriptors.
+  for (int i = 0; i < system.get_num_output_ports(); ++i) {
+    output_port_types_[i] = system.get_output_port(i).get_data_type();
+  }
+
+  // -- Compute the Outputs.
+  system.CalcOutput(*context_, output_.get());
+  // TODO(david-german-tri): Other System computations, such as derivatives.
+}
+
+void SparsityMatrix::InitializeVectorInputs(
+    const System<symbolic::Expression>& system) {
+  // For each input vector i, set each element j to a symbolic expression whose
+  // value is the variable "ui_j".
+  for (int i = 0; i < system.get_num_input_ports(); ++i) {
+    DRAKE_ASSERT(system.get_input_port(i).get_data_type() == kVectorValued);
+    const int n = system.get_input_port(i).size();
+    auto value = std::make_unique<BasicVector<symbolic::Expression>>(n);
+    for (int j = 0; j < n; ++j) {
+      std::ostringstream name;
+      name << "u" << i << "_" << j;
+      value->SetAtIndex(j, symbolic::Expression(name.str()));
+      // Save a copy of the input expression.
+      input_expressions_[i].push_back(value->GetAtIndex(j));
+    }
+    context_->FixInputPort(i, std::move(value));
+  }
+}
+
+void SparsityMatrix::InitializeContinuousState() {
+  // Set each element i in the continuous state to a symbolic expression whose
+  // value is the variable "xci".
+  VectorBase<symbolic::Expression>& xc =
+      *context_->get_mutable_continuous_state_vector();
+  for (int i = 0; i < xc.size(); ++i) {
+    std::ostringstream name;
+    name << "xc" << i;
+    xc[i] = symbolic::Expression(name.str());
+  }
+}
+
+void SparsityMatrix::InitializeDiscreteState() {
+  // For each discrete state vector i, set each element j to a symbolic
+  // expression whose value is the variable "xdi_j".
+  auto& xd = *context_->get_mutable_discrete_state();
+  for (int i = 0; i < context_->get_num_discrete_state_groups(); ++i) {
+    auto& xdi = *xd.get_mutable_discrete_state(i);
+    for (int j = 0; j < xdi.size(); ++j) {
+      std::ostringstream name;
+      name << "xd" << i << "_" << j;
+      xdi[j] = symbolic::Expression(name.str());
+    }
+  }
+}
+
+bool SparsityMatrix::IsAbstract(const System<symbolic::Expression>& system,
+                                const Context<symbolic::Expression>& context) {
+  // If any of the input ports are abstract, we cannot do sparsity analysis of
+  // this Context.
+  for (int i = 0; i < system.get_num_input_ports(); ++i) {
+    if (system.get_input_port(i).get_data_type() == kAbstractValued) {
+      return true;
+    }
+  }
+
+  // If there is any abstract state, we cannot do sparsity analysis of this
+  // Context.
+  if (context.get_num_abstract_state_groups() > 0) {
+    return true;
+  }
+
+  // TODO(david-german-tri): Check parameters once #5072 is resolved.
+
+  return false;
+}
+
+bool SparsityMatrix::IsConnectedInputToOutput(int input_port_index,
+                                              int output_port_index) const {
+  DRAKE_ASSERT(
+      input_port_index >= 0 &&
+      input_port_index < static_cast<int>(input_expressions_.size()));
+  DRAKE_ASSERT(
+      output_port_index >= 0 &&
+      output_port_index < static_cast<int>(output_port_types_.size()));
+
+  // If the Context contains any abstract values, any input might be connected
+  // to any output.
+  if (context_is_abstract_) {
+    return true;
+  }
+
+  // If the given output port is abstract, we can't determine which inputs
+  // influenced it.
+  if (output_port_types_[output_port_index] == kAbstractValued) {
+    return true;
+  }
+
+  // Extract all the variables that appear in any element of the given
+  // output_port_index.
+  symbolic::Variables output_variables;
+  const BasicVector<symbolic::Expression>* output_exprs =
+      output_->get_vector_data(output_port_index);
+  for (int j = 0; j < output_exprs->size(); ++j) {
+    output_variables.insert(output_exprs->GetAtIndex(j).GetVariables());
+  }
+
+  // Check whether any of the variables in any of the input_expressions_ are
+  // among the output_variables.
+  for (const auto& expr : input_expressions_[input_port_index]) {
+    symbolic::Variables input_variables = expr.GetVariables();
+    DRAKE_DEMAND(input_variables.size() == 1);
+    for (const auto& var : input_variables) {
+      if (output_variables.include(var)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/sparsity_matrix.h
+++ b/drake/systems/framework/sparsity_matrix.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/system.h"
+
+namespace drake {
+namespace systems {
+
+/// The SparsityMatrix reports the connectivity between fields in a System's
+/// Context, and outputs computed by that System.
+///
+/// TODO(david-german-tri): Extend SparsityMatrix to report input-to-state,
+/// state-to-derivatives, state-to-discrete-updates, and state-to-output
+/// sparsity.
+///
+/// A SparsityMatrix is only interesting if the Context contains purely
+/// vector-valued elements. If any abstract-valued elements are present, the
+/// SparsityMatrix will report no sparsity. Why? In the presence of opaque
+/// variables, proving sparsity is equivalent to solving the halting problem.
+///
+/// It would be possible to report sparsity for a specific configuration of
+/// the abstract inputs, state, or parameters. We intentionally do not provide
+/// such an analysis, because it would invite developers to shoot themselves
+/// in the foot by accidentally overstating sparsity, for instance if a given
+/// input affects a given output in some modes, but not the mode tested.
+///
+/// Even with that limitation on scope, SparsityMatrix has risks. If the System
+/// contains C++ native conditionals like "if" or "switch", accurate analysis
+/// is once again equivalent to the halting problem. symbolic::Expression does
+/// not provide an implicit conversion to `bool`, so it is unlikely that anyone
+/// will accidentally write a System that both uses native conditionals and
+/// compiles with a symbolic::Expression scalar type. However, it is possible,
+/// for instance using an explicit cast, or `std::equal_to`.
+class SparsityMatrix {
+ public:
+  /// Constructs a sparsity matrix for the given @p system by initializing
+  /// every vector-valued element in the Context with symbolic variables.
+  explicit SparsityMatrix(const System<symbolic::Expression>& system);
+
+  ~SparsityMatrix() = default;
+
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SparsityMatrix)
+
+  /// Returns true if the input port at the given @p input_port_index is or
+  /// might possibly be a term in the output at the given @p output_port_index.
+  bool IsConnectedInputToOutput(int input_port_index,
+                                int output_port_index) const;
+
+ private:
+  // Populates the @p system inputs in the context_ with symbolic variables.
+  void InitializeVectorInputs(const System<symbolic::Expression>& system);
+  // Populates the continuous state in the context_ with symbolic variables.
+  void InitializeContinuousState();
+  // Populates the discrete state in the context_ with symbolic variables.
+  void InitializeDiscreteState();
+
+  // Returns true if any field in the @p context is abstract-valued.
+  static bool IsAbstract(const System<symbolic::Expression>& system,
+                         const Context<symbolic::Expression>& context);
+
+  const std::unique_ptr<Context<symbolic::Expression>> context_;
+  const std::unique_ptr<SystemOutput<symbolic::Expression>> output_;
+
+  // The symbolic expression attached to each input port in the `context_`.
+  std::vector<std::vector<symbolic::Expression>> input_expressions_;
+
+  // The types of the output ports.
+  std::vector<PortDataType> output_port_types_;
+
+  // True if the `context_` contains any abstract elements.
+  const bool context_is_abstract_{false};
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/CMakeLists.txt
+++ b/drake/systems/framework/test/CMakeLists.txt
@@ -49,6 +49,9 @@ target_link_libraries(leaf_system_test drakeSystemFramework drakeSystemPrimitive
 drake_add_cc_test(parameters_test)
 target_link_libraries(parameters_test drakeSystemFramework drakeSystemPrimitives)
 
+drake_add_cc_test(sparsity_matrix_test)
+target_link_libraries(sparsity_matrix_test drakeSystemFramework)
+
 drake_add_cc_test(single_output_vector_source_test)
 target_link_libraries(single_output_vector_source_test
   drakeSystemFramework drakeSystemPrimitives)

--- a/drake/systems/framework/test/sparsity_matrix_test.cc
+++ b/drake/systems/framework/test/sparsity_matrix_test.cc
@@ -1,0 +1,105 @@
+#include "drake/systems/framework/sparsity_matrix.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+const int kSize = 2;
+
+class SparseSystem : public LeafSystem<symbolic::Expression> {
+ public:
+  SparseSystem() {
+    this->DeclareInputPort(kVectorValued, kSize);
+    this->DeclareInputPort(kVectorValued, kSize);
+    this->DeclareOutputPort(kVectorValued, kSize);
+    this->DeclareOutputPort(kVectorValued, kSize);
+    this->DeclareAbstractOutputPort();
+
+    this->DeclareContinuousState(kSize);
+    this->DeclareDiscreteState(kSize);
+  }
+
+  void AddAbstractInputPort() {
+    this->DeclareAbstractInputPort();
+  }
+
+  ~SparseSystem() override {}
+
+ protected:
+  void DoCalcOutput(const Context<symbolic::Expression>& context,
+                    SystemOutput<symbolic::Expression>* output) const override {
+    const auto& u0 = *(this->EvalVectorInput(context, 0));
+    const auto& u1 = *(this->EvalVectorInput(context, 1));
+    auto& y0 = *(output->GetMutableVectorData(0));
+    auto& y1 = *(output->GetMutableVectorData(1));
+
+    const auto& xc = context.get_continuous_state_vector();
+    const auto& xd = *(context.get_discrete_state(0));
+
+    // Output 0 depends on input 0 and the continuous state.  Input 1 appears in
+    // an intermediate computation, but is ultimately cancelled out.
+    y0.set_value(u1.get_value());
+    y0.PlusEqScaled(1, u0);
+    y0.PlusEqScaled(-1, u1);
+    y0.PlusEqScaled(12, xc);
+
+    // Output 1 depends on both inputs and the discrete state.
+    y1.set_value(u0.get_value() + u1.get_value() + xd.get_value());
+  }
+
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<symbolic::Expression>& descriptor)
+  const override {
+    return AbstractValue::Make<int>(42);
+  }
+};
+
+class SparsityMatrixTest : public ::testing::Test {
+ public:
+  SparsityMatrixTest()
+      : system_() {}
+
+ protected:
+  void SetUp() override {
+    matrix_ = std::make_unique<SparsityMatrix>(system_);
+  }
+
+  SparseSystem system_;
+  std::unique_ptr<SparsityMatrix> matrix_;
+};
+
+// Tests that the SparsityMatrix infers, from the symbolic equations of the
+// System, that input 1 does not affect output 0.
+TEST_F(SparsityMatrixTest, InputToOutput) {
+  // Only input 0 affects output 0.
+  EXPECT_TRUE(matrix_->IsConnectedInputToOutput(0, 0));
+  EXPECT_FALSE(matrix_->IsConnectedInputToOutput(1, 0));
+  // Both inputs affect output 1.
+  EXPECT_TRUE(matrix_->IsConnectedInputToOutput(0, 1));
+  EXPECT_TRUE(matrix_->IsConnectedInputToOutput(1, 1));
+  // All inputs are presumed to affect output 2, since it is abstract.
+  EXPECT_TRUE(matrix_->IsConnectedInputToOutput(0, 2));
+  EXPECT_TRUE(matrix_->IsConnectedInputToOutput(1, 2));
+}
+
+// Tests that, if the System has an abstract input, the SparsityMatrix
+// conservatively reports that every output might depend on every input.
+TEST_F(SparsityMatrixTest, AbstractContextThrwartsSparsity) {
+  system_.AddAbstractInputPort();
+  matrix_ = std::make_unique<SparsityMatrix>(system_);
+  for (int i = 0; i < system_.get_num_input_ports(); ++i) {
+    for (int j = 0; j < system_.get_num_output_ports(); ++j) {
+      EXPECT_TRUE(matrix_->IsConnectedInputToOutput(i, j));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
SparsityMatrix uses `symbolic::Expression` to report the input-to-output sparsity of a System.

@soonho-tri for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5106)
<!-- Reviewable:end -->
