### PR TITLE
Reintroduce the schunk_wsg_lift_test.

### DIFF
--- a/drake/examples/schunk_wsg/BUILD
+++ b/drake/examples/schunk_wsg/BUILD
@@ -40,23 +40,25 @@ drake_cc_googletest(
         ":models",
         "//drake/multibody:models",
     ],
+    # This test is prohibitively slow with --compilation_mode=dbg.
+    disable_in_compilation_mode_dbg = True,
     deps = [
         "//drake/common",
         "//drake/common:drake_path",
         "//drake/common/trajectories:piecewise_polynomial_trajectory",
         "//drake/common/trajectories:trajectory",
-        "//drake/lcm:lcm",
-        "//drake/multibody/parsers:parsers",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/lcm",
         "//drake/multibody:rigid_body_tree",
         "//drake/multibody:rigid_body_tree_construction",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
         "//drake/systems/controllers:pid_controlled_system",
         "//drake/systems/framework:diagram_builder",
         "//drake/systems/primitives:constant_vector_source",
         "//drake/systems/primitives:trajectory_source",
-    ]
+    ],
 )
 
 filegroup(

--- a/drake/examples/schunk_wsg/BUILD
+++ b/drake/examples/schunk_wsg/BUILD
@@ -4,6 +4,7 @@
 load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
+    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_binary",
 )
@@ -29,6 +30,43 @@ drake_cc_library(
         "//drake/lcmtypes:schunk",
         "//drake/systems/framework:leaf_system",
     ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "schunk_wsg_lift_test",
+    data = [
+        ":models",
+        "//drake/multibody:models",
+    ],
+    deps = [
+        "//drake/common",
+        "//drake/common:drake_path",
+        "//drake/common/trajectories:piecewise_polynomial_trajectory",
+        "//drake/common/trajectories:trajectory",
+        "//drake/lcm:lcm",
+        "//drake/multibody/parsers:parsers",
+        "//drake/multibody/rigid_body_plant",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody:rigid_body_tree_construction",
+        "//drake/systems/analysis",
+        "//drake/systems/controllers:pid_controlled_system",
+        "//drake/systems/framework:diagram_builder",
+        "//drake/systems/primitives:constant_vector_source",
+        "//drake/systems/primitives:trajectory_source",
+    ]
+)
+
+filegroup(
+    name = "models",
+    srcs = glob([
+        "**/*.obj",
+        "**/*.sdf",
+        "**/*.urdf",
+        "**/*.xml",
+    ]),
 )
 
 cpplint()

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -97,6 +97,11 @@ cc_toolchain(
 # === config_setting rules ===
 
 config_setting(
+    name = "debug",
+    values = {"compilation_mode": "dbg"}
+)
+
+config_setting(
     name = "with_gurobi",
     values = {"define": "WITH_GUROBI=ON"},
 )

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -66,6 +66,7 @@ def drake_cc_googletest(
         size=None,
         srcs=None,
         deps=None,
+        disable_in_compilation_mode_dbg=False,
         **kwargs):
     """Creates a rule to declare a C++ unit test using googletest.  Always adds a
     deps= entry for googletest main (@gtest//:main).
@@ -73,11 +74,18 @@ def drake_cc_googletest(
     By default, sets size="small" because that indicates a unit test.
     By default, sets name="test/${name}.cc" per Drake's filename convention.
 
+    If disable_in_compilation_mode_dbg is True, the srcs will be suppressed
+    in debug-mode builds, so the test will trivially pass. This option should
+    be used only rarely, and the reason should always be documented.
     """
     if size == None:
         size = "small"
     if srcs == None:
         srcs = ["test/%s.cc" % name]
+    if disable_in_compilation_mode_dbg:
+        # Remove the test declarations from the test in debug mode.
+        # TODO(david-german-tri): Actually suppress the test rule.
+        srcs = select({"//tools:debug" : [], "//conditions:default" : srcs})
     if deps == None:
         deps = []
     deps.append("@gtest//:main")


### PR DESCRIPTION
This change should not merge until CI specifies `--test_flag_filters=-nodebug` for the debug-mode builds.  @jamiesnape @BetsyMcPhail 

@sammy-tri for feature and platform review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5108)
<!-- Reviewable:end -->
