### PR TITLE
Dev/viz contacts

### DIFF
--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -34,6 +34,20 @@ lcm_cc_library(
 )
 
 lcm_cc_library(
+    name = "contact_info_for_viz",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_contact_info_for_viz.lcm"],
+    linkstatic = 1,
+)
+
+lcm_cc_library(
+    name = "contact_results_for_viz",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_contact_results_for_viz.lcm"],
+    linkstatic = 1,
+)
+
+lcm_cc_library(
     name = "contact_information",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_contact_information.lcm"],

--- a/drake/lcmtypes/CMakeLists.txt
+++ b/drake/lcmtypes/CMakeLists.txt
@@ -28,6 +28,8 @@ lcm_wrap_types(
   lcmt_body_wrench_data.lcm
   lcmt_constrained_values.lcm
   lcmt_contact_information.lcm
+  lcmt_contact_info_for_viz.lcm
+  lcmt_contact_results_for_viz.lcm
   lcmt_desired_body_motion.lcm
   lcmt_desired_centroidal_momentum_dot.lcm
   lcmt_desired_dof_motions.lcm

--- a/drake/lcmtypes/lcmt_contact_info_for_viz.lcm
+++ b/drake/lcmtypes/lcmt_contact_info_for_viz.lcm
@@ -1,0 +1,15 @@
+package drake;
+
+struct lcmt_contact_info_for_viz {
+  // In microseconds
+  int64_t timestamp;
+
+  // Names of the colliding bodies
+  string body1_name;
+  string body2_name;
+
+  // These are all expressed in the world frame.
+  double contact_point[3];
+  double contact_force[3];
+  double normal[3];
+}

--- a/drake/lcmtypes/lcmt_contact_results_for_viz.lcm
+++ b/drake/lcmtypes/lcmt_contact_results_for_viz.lcm
@@ -1,0 +1,9 @@
+package drake;
+
+struct lcmt_contact_results_for_viz {
+  // in microseconds
+  int64_t timestamp;
+
+  int32_t num_contacts;
+  lcmt_contact_info_for_viz contact_info[num_contacts];
+}

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -37,6 +37,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "contact_results_to_lcm",
+    srcs = [
+        "contact_results_to_lcm.cc",
+    ],
+    hdrs = [
+        "contact_results_to_lcm.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":rigid_body_plant",
+        "//drake/lcmtypes:contact_info_for_viz",
+        "//drake/lcmtypes:contact_results_for_viz",
+    ],
+)
+
+drake_cc_library(
     name = "rigid_body_plant_that_publishes_xdot",
     srcs = [
         "rigid_body_plant_that_publishes_xdot.cc",

--- a/drake/multibody/rigid_body_plant/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/CMakeLists.txt
@@ -14,6 +14,7 @@ set(source_files
 set(lcm_dependent_header_files)
 if (lcm_FOUND)
   set(lcm_dependent_header_files
+    contact_results_to_lcm.h
     drake_visualizer.h
     rigid_body_plant_that_publishes_xdot.h
     viewer_draw_translator.h)
@@ -22,6 +23,7 @@ endif ()
 set(lcm_dependent_source_files)
 if (lcm_FOUND)
   set(lcm_dependent_source_files
+    contact_results_to_lcm.cc
     drake_visualizer.cc
     rigid_body_plant_that_publishes_xdot.cc
     viewer_draw_translator.cc)

--- a/drake/multibody/rigid_body_plant/contact_results_to_lcm.cc
+++ b/drake/multibody/rigid_body_plant/contact_results_to_lcm.cc
@@ -1,0 +1,64 @@
+#include "drake/multibody/rigid_body_plant/contact_results_to_lcm.h"
+
+#include <memory>
+
+#include "drake/lcmt_contact_results_for_viz.hpp"
+#include "drake/util/drakeUtil.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
+    const RigidBodyTree<T>& tree)
+    : tree_(tree) {
+  set_name("ContactResultsToLcmSystem");
+  DeclareAbstractInputPort();
+  DeclareAbstractOutputPort();
+}
+
+template <typename T>
+std::unique_ptr<AbstractValue>
+ContactResultsToLcmSystem<T>::AllocateOutputAbstract(
+    const OutputPortDescriptor<T>& descriptor) const {
+  return systems::AbstractValue::Make<lcmt_contact_results_for_viz>(
+      lcmt_contact_results_for_viz());
+}
+
+template <typename T>
+void ContactResultsToLcmSystem<T>::DoCalcOutput(const Context<T>& context,
+                                                SystemOutput<T>* output) const {
+  // Get input / output.
+  const auto& contact_results =
+      EvalAbstractInput(context, 0)->template GetValue<ContactResults<T>>();
+  auto& msg = output->GetMutableData(0)
+                  ->template GetMutableValue<lcmt_contact_results_for_viz>();
+
+  msg.timestamp = static_cast<int64_t>(context.get_time() * 1e6);
+  msg.num_contacts = contact_results.get_num_contacts();
+  msg.contact_info.resize(msg.num_contacts);
+
+  for (int i = 0; i < contact_results.get_num_contacts(); ++i) {
+    lcmt_contact_info_for_viz& info_msg = msg.contact_info[i];
+    info_msg.timestamp = static_cast<int64_t>(context.get_time() * 1e6);
+
+    const ContactInfo<T>& contact_info = contact_results.get_contact_info(i);
+    const RigidBody<T>* b1 = tree_.FindBody(contact_info.get_element_id_1());
+    const RigidBody<T>* b2 = tree_.FindBody(contact_info.get_element_id_2());
+
+    const ContactForce<T>& contact_force = contact_info.get_resultant_force();
+
+    info_msg.body1_name = b1->get_name();
+    info_msg.body2_name = b2->get_name();
+
+    eigenVectorToCArray(contact_force.get_application_point(),
+                        info_msg.contact_point);
+    eigenVectorToCArray(contact_force.get_force(), info_msg.contact_force);
+    eigenVectorToCArray(contact_force.get_normal(), info_msg.normal);
+  }
+}
+
+template class ContactResultsToLcmSystem<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/contact_results_to_lcm.h
+++ b/drake/multibody/rigid_body_plant/contact_results_to_lcm.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/rigid_body_plant/contact_results.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/**
+ * A System that encodes ContactResults into a lcmt_contact_results_for_viz
+ * message. It has a single input port with type ContactResults<T> and a
+ * single output port with lcmt_contact_results_for_viz.
+ */
+template <typename T>
+class ContactResultsToLcmSystem : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactResultsToLcmSystem)
+
+  /**
+   * Constructs a ContactResultsToLcmSystem.
+   * @param tree, The RigidBodyTree that the ContactResults are generated with,
+   * which should be returned by RigidBodyPlant's get_rigid_body_tree(). The
+   * life span of @p tree needs to be longer than this instance.
+   */
+  explicit ContactResultsToLcmSystem(const RigidBodyTree<T>& tree);
+
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<T>& descriptor) const override;
+
+  void DoCalcOutput(const Context<T>& context,
+                    SystemOutput<T>* output) const override;
+
+ private:
+  const RigidBodyTree<T>& tree_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/visualization/README
+++ b/drake/multibody/rigid_body_plant/visualization/README
@@ -1,0 +1,4 @@
+To run drake-visualizer with the contact force visualization:
+
+$ cd drake-distro
+$ ./build/install/bin/drake-visualizer --script ./drake/multibody/rigid_body_plant/visualization/contact_viz.py

--- a/drake/multibody/rigid_body_plant/visualization/contact_viz.py
+++ b/drake/multibody/rigid_body_plant/visualization/contact_viz.py
@@ -1,0 +1,108 @@
+# Note that this script runs in the main context of drake-visulizer,
+# where many modules and variables already exist in the global scope.
+from director import lcmUtils
+from director import applogic
+from director import objectmodel as om
+from director import visualization as vis
+from director.debugVis import DebugData
+import numpy as np
+import drake as lcmdrakemsg
+
+
+class ContactVisualizer(object):
+    def __init__(self):
+        self._folder_name = 'Contact Results'
+        self._name = "Contact Visualizer"
+        self._enabled = False
+        self._sub = None
+
+        self.set_enabled(True)
+
+    def add_subscriber(self):
+        if self._sub is not None:
+            return
+
+        self._sub = lcmUtils.addSubscriber(
+            'CONTACT_RESULTS',
+            messageClass=lcmdrakemsg.lcmt_contact_results_for_viz,
+            callback=self.handle_message)
+        # Limits the rate of message handling, since redrawing is done in the
+        # message handler.
+        self._sub.setSpeedLimit(30)
+        print self._name + " subscriber added."
+
+    def remove_subscriber(self):
+        if self._sub is None:
+            return
+
+        lcmUtils.removeSubscriber(self._sub)
+        self._sub = None
+        om.removeFromObjectModel(om.findObjectByName(self._folder_name))
+        print self._name + " subscriber removed."
+
+    def is_enabled(self):
+        return self._enabled
+
+    def set_enabled(self, enable):
+        self._enabled = enable
+        if enable:
+            self.add_subscriber()
+        else:
+            self.remove_subscriber()
+
+    def handle_message(self, msg):
+        # Removes the folder completely.
+        om.removeFromObjectModel(om.findObjectByName(self._folder_name))
+
+        # Recreates folder.
+        folder = om.getOrCreateContainer(self._folder_name)
+
+        # A map from pair of body names to a list of contact forces
+        collision_pair_to_forces = {}
+        for contact in msg.contact_info:
+            point = np.array([contact.contact_point[0],
+                              contact.contact_point[1],
+                              contact.contact_point[2]])
+            force = np.array([contact.contact_force[0],
+                              contact.contact_force[1],
+                              contact.contact_force[2]])
+            mag = np.linalg.norm(force)
+            if mag > 1e-4:
+                mag = 0.3 / mag
+
+            key1 = (str(contact.body1_name), str(contact.body2_name))
+            key2 = (str(contact.body2_name), str(contact.body1_name))
+
+            if key1 in collision_pair_to_forces:
+                collision_pair_to_forces[key1].append(
+                    (point, point + mag * force))
+            elif key2 in collision_pair_to_forces:
+                collision_pair_to_forces[key2].append(
+                    (point, point + mag * force))
+            else:
+                collision_pair_to_forces[key1] = [(point, point + mag * force)]
+
+        for key, list_of_forces in collision_pair_to_forces.iteritems():
+            d = DebugData()
+            for force_pair in list_of_forces:
+                d.addArrow(start=force_pair[0],
+                           end=force_pair[1],
+                           tubeRadius=0.005,
+                           headRadius=0.01)
+
+            vis.showPolyData(
+                d.getPolyData(), str(key), parent=folder, color=[0, 1, 0])
+
+
+def init_visualizer():
+    # Create a visualizer instance.
+    my_visualizer = ContactVisualizer()
+
+    # Adds to the "Tools" menu.
+    applogic.MenuActionToggleHelper(
+        'Tools', my_visualizer._name,
+        my_visualizer.is_enabled, my_visualizer.set_enabled)
+    return my_visualizer
+
+# Creates the visualizer when this script is executed.
+contact_viz = init_visualizer()


### PR DESCRIPTION
Added visualization for contact forces. 
This PR address #5091. This solution has two components: contact related information (ContactResults) are packaged into a lcm message in a System block. The message is handled and force visualization is rendered by a python script loaded by director. 

See examples/Valkyrie/valkyrie_simulation.cc for an example of wiring up the Diagram. To run drake-visualization, execute the following command in drake's home directory. 
./build/install/bin/drake-visualizer --script ./drake/multibody/rigid_body_plant/visualization/contact_viz.py

cc @SeanCurtis-TRI @sherm1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5109)
<!-- Reviewable:end -->
