### PR TITLE
Fixes deep copy of DrakeJoint and its descendant classes.

### DIFF
--- a/drake/multibody/joints/BUILD
+++ b/drake/multibody/joints/BUILD
@@ -39,10 +39,25 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "joint_compare_to_clone",
+    testonly = 1,
+    srcs = [
+        "test/joint_compare_to_clone.cc",
+    ],
+    hdrs = [
+        "test/joint_compare_to_clone.h",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":joints",
+    ],
+)
+
 drake_cc_googletest(
     name = "joint_test",
     deps = [
-        ":joints",
+        ":joint_compare_to_clone",
     ],
 )
 

--- a/drake/multibody/joints/drake_joint.cc
+++ b/drake/multibody/joints/drake_joint.cc
@@ -31,6 +31,12 @@ DrakeJoint::~DrakeJoint() {
   // empty
 }
 
+std::unique_ptr<DrakeJoint> DrakeJoint::Clone() const {
+  std::unique_ptr<DrakeJoint> clone = DoClone();
+  InitializeClone(clone.get());
+  return clone;
+}
+
 const Isometry3d& DrakeJoint::get_transform_to_parent_body() const {
   return transform_to_parent_body;
 }
@@ -86,82 +92,10 @@ const Eigen::VectorXd& DrakeJoint::get_joint_limit_dissipation() const {
   return joint_limit_dissipation_;
 }
 
-bool DrakeJoint::CompareToClone(const DrakeJoint &other) const {
-  if (get_transform_to_parent_body().matrix() !=
-      other.get_transform_to_parent_body().matrix()) {
-    drake::log()->debug(
-        "DrakeJoint::CompareToClone(): "
-        "transform_to_parent_body mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        get_transform_to_parent_body().matrix(),
-        other.get_transform_to_parent_body().matrix());
-    return false;
-  }
-  if (get_num_positions() != other.get_num_positions()) {
-    drake::log()->debug(
-        "DrakeJoint::CompareToClone(): get_num_positions mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        get_num_positions(),
-        other.get_num_positions());
-    return false;
-  }
-  if (get_num_velocities() != other.get_num_velocities()) {
-    drake::log()->debug(
-        "DrakeJoint::CompareToClone(): get_num_velocities mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        get_num_velocities(),
-        other.get_num_velocities());
-    return false;
-  }
-  if (get_name() != other.get_name()) {
-    drake::log()->debug(
-        "DrakeJoint::CompareToClone(): get_name mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        get_name(),
-        other.get_name());
-    return false;
-  }
-  if (getJointLimitMin() != other.getJointLimitMin()) {
-    drake::log()->debug(
-        "DrakeJoint::CompareToClone(): getJointLimitMin mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        getJointLimitMin(),
-        other.getJointLimitMin());
-    return false;
-  }
-  if (getJointLimitMax() != other.getJointLimitMax()) {
-    drake::log()->debug(
-        "DrakeJoint::CompareToClone(): getJointLimitMax mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        getJointLimitMax(),
-        other.getJointLimitMax());
-    return false;
-  }
-  if (get_joint_limit_stiffness() != other.get_joint_limit_stiffness()) {
-    drake::log()->debug(
-        "DrakeJoint::CompareToClone(): "
-        "get_joint_limit_stiffness mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        get_joint_limit_stiffness(),
-        other.get_joint_limit_stiffness());
-    return false;
-  }
-  if (get_joint_limit_dissipation() != other.get_joint_limit_dissipation()) {
-    drake::log()->debug(
-        "DrakeJoint::CompareToClone(): "
-        "get_joint_limit_dissipation mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        get_joint_limit_dissipation(),
-        other.get_joint_limit_dissipation());
-    return false;
-  }
-  return true;
+void DrakeJoint::InitializeClone(DrakeJoint* clone) const {
+  DoInitializeClone(clone);
+  clone->joint_limit_min = joint_limit_min;
+  clone->joint_limit_max = joint_limit_max;
+  clone->joint_limit_stiffness_ = joint_limit_stiffness_;
+  clone->joint_limit_dissipation_ = joint_limit_dissipation_;
 }

--- a/drake/multibody/joints/drake_joint.h
+++ b/drake/multibody/joints/drake_joint.h
@@ -106,7 +106,7 @@ class DrakeJoint {
   /**
    * Returns a clone of this DrakeJoint.
    */
-  virtual std::unique_ptr<DrakeJoint> Clone() const = 0;
+  std::unique_ptr<DrakeJoint> Clone() const;
 
   /**
    * Returns the transform `X_PF` giving the pose of the joint's "fixed" frame
@@ -227,35 +227,26 @@ class DrakeJoint {
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  /// Compares this joint with a cloned joint. Since this method is intended to
-  /// compare a clone, an *exact* match is performed. This method will only
-  /// return `true` if the provided `other` joint is exactly the same as this
-  /// joint.
-  virtual bool CompareToClone(const DrakeJoint& other) const;
-
  protected:
-  /// Attempts to downcast the provided `other` to the template class type. If
-  /// the downcast is successful, it returns a pointer to the downcasted type.
-  /// Otherwise, it will log a debug message using `drake::log()->debug()` and
-  /// return `nullptr`.
-  template <class DowncastType>
-  const DowncastType* DowncastOrLog(const DrakeJoint* other) const {
-    const DowncastType* result = dynamic_cast<const DowncastType*>(other);
-    if (result == nullptr) {
-      drake::log()->debug(
-          "DrakeJoint::DowncastOrLog(): Downcast failed.");
-    }
-    return result;
-  }
-
   const std::string name;
   Eigen::VectorXd joint_limit_min;
   Eigen::VectorXd joint_limit_max;
   Eigen::VectorXd joint_limit_stiffness_;
   Eigen::VectorXd joint_limit_dissipation_;
 
+ protected:
+  /// Allows descendent classes to perform the actual clone operation.
+  virtual std::unique_ptr<DrakeJoint> DoClone() const = 0;
+
+  /// Initializes the private member variables within the provided `clone`.
+  void InitializeClone(DrakeJoint* clone) const;
+
+  /// Initializes any additional members within @p clone that could not be set
+  /// during construction.
+  virtual void DoInitializeClone(DrakeJoint* clone) const = 0;
+
  private:
   const Eigen::Isometry3d transform_to_parent_body;
-  const int num_positions;
-  const int num_velocities;
+  const int num_positions{};
+  const int num_velocities{};
 };

--- a/drake/multibody/joints/fixed_axis_one_dof_joint.h
+++ b/drake/multibody/joints/fixed_axis_one_dof_joint.h
@@ -9,6 +9,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/text_logging.h"
 #include "drake/math/autodiff.h"
@@ -25,10 +26,10 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
                        const Eigen::Isometry3d& transform_to_parent_body,
                        const drake::TwistVector<double>& _joint_axis)
       : DrakeJointImpl<Derived>(derived, name, transform_to_parent_body, 1, 1),
-        joint_axis(_joint_axis),
-        damping(0.0),
-        coulomb_friction(0.0),
-        coulomb_window(0.0) {}
+        joint_axis_(_joint_axis),
+        damping_(0.0),
+        coulomb_friction_(0.0),
+        coulomb_window_(0.0) {}
 
  public:
   virtual ~FixedAxisOneDoFJoint() {}
@@ -43,7 +44,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
       Eigen::MatrixBase<DerivedMS>& motion_subspace,
       typename drake::math::Gradient<DerivedMS, Eigen::Dynamic>::type*
           dmotion_subspace = nullptr) const {
-    motion_subspace = joint_axis.cast<typename DerivedQ::Scalar>();
+    motion_subspace = joint_axis_.cast<typename DerivedQ::Scalar>();
     if (dmotion_subspace) {
       dmotion_subspace->setZero(motion_subspace.size(), get_num_positions());
     }
@@ -108,11 +109,11 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
     typedef typename DerivedV::Scalar Scalar;
     Eigen::Matrix<Scalar, Eigen::Dynamic, 1> ret(get_num_velocities(), 1);
     using std::abs;
-    ret[0] = damping * v[0];
-    Scalar coulomb_window_fraction = v[0] / coulomb_window;
+    ret[0] = damping_ * v[0];
+    Scalar coulomb_window_fraction = v[0] / coulomb_window_;
     Scalar coulomb =
         std::min(Scalar(1), std::max(Scalar(-1), coulomb_window_fraction)) *
-        coulomb_friction;
+        coulomb_friction_;
     ret[0] += coulomb;
     return ret;
   }
@@ -171,11 +172,11 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
     return q;
   }
 
-  void setDynamics(double damping_in, double coulomb_friction_in,
-                   double coulomb_window_in) {
-    damping = damping_in;
-    coulomb_friction = coulomb_friction_in;
-    coulomb_window = coulomb_window_in;
+  void setDynamics(double damping, double coulomb_friction,
+      double coulomb_window) {
+    damping_ = damping;
+    coulomb_friction_ = coulomb_friction;
+    coulomb_window_ = coulomb_window;
   }
 
   std::string get_position_name(int index) const override {
@@ -191,63 +192,30 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
     return get_position_name(index);
   }
 
-  bool CompareToClone(const DrakeJoint& other) const override {
-    if (!DrakeJoint::CompareToClone(other)) return false;
-    const FixedAxisOneDoFJoint* downcasted_joint =
-        dynamic_cast<const FixedAxisOneDoFJoint*>(&other);
-    if (downcasted_joint == nullptr) {
-      drake::log()->debug(
-        "FixedAxisOneDoFJoint::CompareToClone: "
-        "other is not of type FixedAxisOneDoFJoint.");
-      return false;
-    }
-    if (joint_axis != downcasted_joint->joint_axis) {
-      drake::log()->debug(
-          "FixedAxisOneDoFJoint::CompareToClone: joint_axis mismatch:\n"
-          "  - this: {}\n"
-          "  - other: {}",
-          joint_axis,
-          downcasted_joint->joint_axis);
-      return false;
-    }
-    if (damping != downcasted_joint->damping) {
-        drake::log()->debug(
-          "FixedAxisOneDoFJoint::CompareToClone: damping mismatch:\n"
-          "  - this: {}\n"
-          "  - other: {}",
-          damping,
-          downcasted_joint->damping);
-      return false;
-    }
-    if (coulomb_friction != downcasted_joint->coulomb_friction) {
-        drake::log()->debug(
-          "FixedAxisOneDoFJoint::CompareToClone: "
-          "coulomb_friction mismatch:\n"
-          "  - this: {}\n"
-          "  - other: {}",
-          coulomb_friction,
-          downcasted_joint->coulomb_friction);
-      return false;
-    }
-    if (coulomb_window != downcasted_joint->coulomb_window) {
-        drake::log()->debug(
-          "FixedAxisOneDoFJoint::CompareToClone: "
-          "coulomb_window mismatch:\n"
-          "  - this: {}\n"
-          "  - other: {}",
-          coulomb_window,
-          downcasted_joint->coulomb_window);
-      return false;
-    }
-    return true;
-  }
+  const drake::TwistVector<double>& joint_axis() const { return joint_axis_; }
+
+  double damping() const { return damping_; }
+  double coulomb_friction() const { return coulomb_friction_; }
+  double coulomb_window() const { return coulomb_window_; }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+ protected:
+  /// Initializes the private member variables within the provided `clone`.
+  void DoInitializeClone(DrakeJoint* clone) const override {
+    FixedAxisOneDoFJoint* fixed_axis_one_dof_joint =
+        dynamic_cast<FixedAxisOneDoFJoint*>(clone);
+    DRAKE_DEMAND(fixed_axis_one_dof_joint != nullptr);
+    fixed_axis_one_dof_joint->joint_axis_ = this->joint_axis_;
+    fixed_axis_one_dof_joint->damping_ = this->damping_;
+    fixed_axis_one_dof_joint->coulomb_friction_ = this->coulomb_friction_;
+    fixed_axis_one_dof_joint->coulomb_window_ = this->coulomb_window_;
+  }
+
  private:
-  drake::TwistVector<double> joint_axis;
-  double damping;
-  double coulomb_friction;
-  double coulomb_window;
+  drake::TwistVector<double> joint_axis_;
+  double damping_{};
+  double coulomb_friction_{};
+  double coulomb_window_{};
 };
 #pragma GCC diagnostic pop  // pop -Wno-overloaded-virtual

--- a/drake/multibody/joints/fixed_joint.cc
+++ b/drake/multibody/joints/fixed_joint.cc
@@ -3,12 +3,6 @@
 #include <memory>
 #include <utility>
 
-std::unique_ptr<DrakeJoint> FixedJoint::Clone() const {
-  auto joint = std::make_unique<FixedJoint>(get_name(),
-                                            get_transform_to_parent_body());
-  return std::move(joint);
-}
-
 std::string FixedJoint::get_position_name(int index) const {
   throw std::runtime_error("bad index");
 }
@@ -25,4 +19,10 @@ Eigen::VectorXd FixedJoint::randomConfiguration(
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.
 std::string FixedJoint::getPositionName(int index) const {
   return get_position_name(index);
+}
+
+std::unique_ptr<DrakeJoint> FixedJoint::DoClone() const {
+  auto joint = std::make_unique<FixedJoint>(get_name(),
+                                            get_transform_to_parent_body());
+  return std::move(joint);
 }

--- a/drake/multibody/joints/fixed_joint.h
+++ b/drake/multibody/joints/fixed_joint.h
@@ -16,8 +16,6 @@ class FixedJoint : public DrakeJointImpl<FixedJoint> {
 
   virtual ~FixedJoint() {}
 
-  std::unique_ptr<DrakeJoint> Clone() const final;
-
   template <typename DerivedQ>
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
   jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
@@ -109,5 +107,9 @@ class FixedJoint : public DrakeJointImpl<FixedJoint> {
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ protected:
+  std::unique_ptr<DrakeJoint> DoClone() const final;
+  void DoInitializeClone(DrakeJoint* clone) const final {}
 };
 #pragma GCC diagnostic pop  // pop -Wno-overloaded-virtual

--- a/drake/multibody/joints/helical_joint.cc
+++ b/drake/multibody/joints/helical_joint.cc
@@ -7,13 +7,6 @@
 
 using Eigen::Vector3d;
 
-std::unique_ptr<DrakeJoint> HelicalJoint::Clone() const {
-  auto joint = std::make_unique<HelicalJoint>(get_name(),
-                                              get_transform_to_parent_body(),
-                                              axis_, pitch_);
-  return std::move(joint);
-}
-
 drake::TwistVector<double> HelicalJoint::spatialJointAxis(const Vector3d& axis,
                                                           double pitch) {
   drake::TwistVector<double> ret;
@@ -22,28 +15,9 @@ drake::TwistVector<double> HelicalJoint::spatialJointAxis(const Vector3d& axis,
   return ret;
 }
 
-bool HelicalJoint::CompareToClone(const DrakeJoint& other) const {
-  if (!FixedAxisOneDoFJoint::CompareToClone(other)) return false;
-  const HelicalJoint* downcasted_joint =
-      DrakeJoint::DowncastOrLog<HelicalJoint>(&other);
-  if (downcasted_joint == nullptr) return false;
-  if (axis_ != downcasted_joint->axis_) {
-    drake::log()->debug(
-        "HelicalJoint::CompareToClone(): axis mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        axis_,
-        downcasted_joint->axis_);
-    return false;
-  }
-  if (pitch_ != downcasted_joint->pitch_) {
-      drake::log()->debug(
-        "HelicalJoint::CompareToClone(): pitch mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        pitch_,
-        downcasted_joint->pitch_);
-    return false;
-  }
-  return true;
+std::unique_ptr<DrakeJoint> HelicalJoint::DoClone() const {
+  auto joint = std::make_unique<HelicalJoint>(get_name(),
+                                              get_transform_to_parent_body(),
+                                              axis_, pitch_);
+  return std::move(joint);
 }

--- a/drake/multibody/joints/helical_joint.h
+++ b/drake/multibody/joints/helical_joint.h
@@ -21,8 +21,6 @@ class HelicalJoint : public FixedAxisOneDoFJoint<HelicalJoint> {
 
   virtual ~HelicalJoint() {}
 
-  std::unique_ptr<DrakeJoint> Clone() const final;
-
   template <typename DerivedQ>
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
   jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
@@ -34,15 +32,20 @@ class HelicalJoint : public FixedAxisOneDoFJoint<HelicalJoint> {
     return ret;
   }
 
-  bool CompareToClone(const DrakeJoint& other) const final;
+  const Eigen::Vector3d& axis() const { return axis_; }
+  double pitch() const { return pitch_; }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ protected:
+  std::unique_ptr<DrakeJoint> DoClone() const final;
+  void DoInitializeClone(DrakeJoint* clone) const final {}
 
  private:
   static drake::TwistVector<double> spatialJointAxis(
       const Eigen::Vector3d& axis, double pitch);
 
   const Eigen::Vector3d axis_;
-  const double pitch_;
+  const double pitch_{};
 };
 #pragma GCC diagnostic pop  // pop -Wno-overloaded-virtual

--- a/drake/multibody/joints/prismatic_joint.cc
+++ b/drake/multibody/joints/prismatic_joint.cc
@@ -5,13 +5,6 @@
 
 using Eigen::Vector3d;
 
-std::unique_ptr<DrakeJoint> PrismaticJoint::Clone() const {
-  auto joint = std::make_unique<PrismaticJoint>(get_name(),
-                                                get_transform_to_parent_body(),
-                                                translation_axis_);
-  return std::move(joint);
-}
-
 drake::TwistVector<double> PrismaticJoint::spatialJointAxis(
     const Vector3d& translation_axis) {
   drake::TwistVector<double> ret;
@@ -20,20 +13,9 @@ drake::TwistVector<double> PrismaticJoint::spatialJointAxis(
   return ret;
 }
 
-bool PrismaticJoint::CompareToClone(const DrakeJoint& other) const {
-  if (!FixedAxisOneDoFJoint::CompareToClone(other)) return false;
-  const PrismaticJoint* downcasted_joint =
-      DrakeJoint::DowncastOrLog<PrismaticJoint>(&other);
-  if (downcasted_joint == nullptr) return false;
-  if (translation_axis_ != downcasted_joint->translation_axis_) {
-    drake::log()->debug(
-        "PrismaticJoint::CompareToClone(): translation_axis mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        translation_axis_.transpose(),
-        downcasted_joint->translation_axis_.transpose());
-    return false;
-  }
-  return true;
+std::unique_ptr<DrakeJoint> PrismaticJoint::DoClone() const {
+  auto joint = std::make_unique<PrismaticJoint>(get_name(),
+                                                get_transform_to_parent_body(),
+                                                translation_axis_);
+  return std::move(joint);
 }
-

--- a/drake/multibody/joints/prismatic_joint.h
+++ b/drake/multibody/joints/prismatic_joint.h
@@ -48,11 +48,12 @@ class PrismaticJoint : public FixedAxisOneDoFJoint<PrismaticJoint> {
 
   virtual ~PrismaticJoint() {}
 
-  std::unique_ptr<DrakeJoint> Clone() const final;
-
-  bool CompareToClone(const DrakeJoint& other) const final;
+  const Eigen::Vector3d& translation_axis() const { return translation_axis_; }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ protected:
+  std::unique_ptr<DrakeJoint> DoClone() const final;
 
  private:
   static drake::TwistVector<double> spatialJointAxis(

--- a/drake/multibody/joints/quaternion_floating_joint.cc
+++ b/drake/multibody/joints/quaternion_floating_joint.cc
@@ -10,12 +10,6 @@ using Eigen::Vector4d;
 using Eigen::VectorXd;
 using std::normal_distribution;
 
-std::unique_ptr<DrakeJoint> QuaternionFloatingJoint::Clone() const {
-  auto joint = std::make_unique<QuaternionFloatingJoint>(get_name(),
-      get_transform_to_parent_body());
-  return std::move(joint);
-}
-
 std::string QuaternionFloatingJoint::get_position_name(int index) const {
   switch (index) {
     case 0:
@@ -90,3 +84,10 @@ std::string QuaternionFloatingJoint::getPositionName(int index) const {
 std::string QuaternionFloatingJoint::getVelocityName(int index) const {
   return get_velocity_name(index);
 }
+
+std::unique_ptr<DrakeJoint> QuaternionFloatingJoint::DoClone() const {
+  auto joint = std::make_unique<QuaternionFloatingJoint>(get_name(),
+      get_transform_to_parent_body());
+  return std::move(joint);
+}
+

--- a/drake/multibody/joints/quaternion_floating_joint.h
+++ b/drake/multibody/joints/quaternion_floating_joint.h
@@ -81,8 +81,6 @@ class QuaternionFloatingJoint : public DrakeJointImpl<QuaternionFloatingJoint> {
 
   virtual ~QuaternionFloatingJoint() {}
 
-  std::unique_ptr<DrakeJoint> Clone() const final;
-
   /** Returns the transform `X_PB(q)` where P is the parent body and B the
    * child body connected by this joint.
    */
@@ -330,5 +328,9 @@ class QuaternionFloatingJoint : public DrakeJointImpl<QuaternionFloatingJoint> {
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ protected:
+  std::unique_ptr<DrakeJoint> DoClone() const final;
+  void DoInitializeClone(DrakeJoint* clone) const final {}
 };
 #pragma GCC diagnostic pop  // pop -Wno-overloaded-virtual

--- a/drake/multibody/joints/revolute_joint.cc
+++ b/drake/multibody/joints/revolute_joint.cc
@@ -5,13 +5,6 @@
 
 using Eigen::Vector3d;
 
-std::unique_ptr<DrakeJoint> RevoluteJoint::Clone() const {
-  auto joint = std::make_unique<RevoluteJoint>(get_name(),
-                                               get_transform_to_parent_body(),
-                                               rotation_axis);
-  return std::move(joint);
-}
-
 drake::TwistVector<double> RevoluteJoint::spatialJointAxis(
     const Vector3d& rotation_axis) {
   drake::TwistVector<double> ret;
@@ -20,21 +13,9 @@ drake::TwistVector<double> RevoluteJoint::spatialJointAxis(
   return ret;
 }
 
-bool RevoluteJoint::CompareToClone(const DrakeJoint& other) const {
-  if (!FixedAxisOneDoFJoint::CompareToClone(other)) return false;
-  const RevoluteJoint* downcasted_joint =
-      DrakeJoint::DowncastOrLog<RevoluteJoint>(&other);
-  if (downcasted_joint == nullptr) {
-    return false;
-  }
-  if (rotation_axis != downcasted_joint->rotation_axis) {
-    drake::log()->debug(
-        "RevoluteJoint::CompareToClone(): rotation_axis mismatch:\n"
-        "  - this: {}\n"
-        "  - other: {}",
-        rotation_axis.transpose(),
-        downcasted_joint->rotation_axis.transpose());
-    return false;
-  }
-  return true;
+std::unique_ptr<DrakeJoint> RevoluteJoint::DoClone() const {
+  auto joint = std::make_unique<RevoluteJoint>(get_name(),
+                                               get_transform_to_parent_body(),
+                                               rotation_axis_);
+  return std::move(joint);
 }

--- a/drake/multibody/joints/revolute_joint.h
+++ b/drake/multibody/joints/revolute_joint.h
@@ -15,36 +15,37 @@ class RevoluteJoint : public FixedAxisOneDoFJoint<RevoluteJoint> {
  public:
   RevoluteJoint(const std::string& name,
                 const Eigen::Isometry3d& transform_to_parent_body,
-                const Eigen::Vector3d& _rotation_axis)
+                const Eigen::Vector3d& rotation_axis)
       : FixedAxisOneDoFJoint<RevoluteJoint>(*this, name,
                                             transform_to_parent_body,
-                                            spatialJointAxis(_rotation_axis)),
-        rotation_axis(_rotation_axis) {
-    DRAKE_ASSERT(std::abs(rotation_axis.norm() - 1.0) < 1e-10);
+                                            spatialJointAxis(rotation_axis)),
+        rotation_axis_(rotation_axis) {
+    DRAKE_ASSERT(std::abs(rotation_axis_.norm() - 1.0) < 1e-10);
   }
 
   virtual ~RevoluteJoint() {}
-
-  std::unique_ptr<DrakeJoint> Clone() const final;
 
   template <typename DerivedQ>
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
   jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
     typedef typename DerivedQ::Scalar Scalar;
     Eigen::Transform<Scalar, 3, Eigen::Isometry> ret(
-        Eigen::AngleAxis<Scalar>(q[0], rotation_axis.cast<Scalar>()));
+        Eigen::AngleAxis<Scalar>(q[0], rotation_axis_.cast<Scalar>()));
     ret.makeAffine();
     return ret;
   }
 
-  bool CompareToClone(const DrakeJoint& other) const final;
+  const Eigen::Vector3d& rotation_axis() const { return rotation_axis_; }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ protected:
+  std::unique_ptr<DrakeJoint> DoClone() const final;
 
  private:
   static drake::TwistVector<double> spatialJointAxis(
       const Eigen::Vector3d& rotation_axis);
 
-  Eigen::Vector3d rotation_axis;
+  Eigen::Vector3d rotation_axis_;
 };
 #pragma GCC diagnostic pop  // pop -Wno-overloaded-virtual

--- a/drake/multibody/joints/roll_pitch_yaw_floating_joint.cc
+++ b/drake/multibody/joints/roll_pitch_yaw_floating_joint.cc
@@ -12,13 +12,6 @@ using Eigen::Map;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 
-std::unique_ptr<DrakeJoint> RollPitchYawFloatingJoint::Clone() const {
-  auto joint = std::make_unique<RollPitchYawFloatingJoint>(
-      get_name(),
-      get_transform_to_parent_body());
-  return std::move(joint);
-}
-
 std::string RollPitchYawFloatingJoint::get_position_name(int index) const {
   switch (index) {
     case 0:
@@ -61,4 +54,11 @@ VectorXd RollPitchYawFloatingJoint::randomConfiguration(
 std::string RollPitchYawFloatingJoint::getPositionName(int index)
     const {
   return get_position_name(index);
+}
+
+std::unique_ptr<DrakeJoint> RollPitchYawFloatingJoint::DoClone() const {
+  auto joint = std::make_unique<RollPitchYawFloatingJoint>(
+      get_name(),
+      get_transform_to_parent_body());
+  return std::move(joint);
 }

--- a/drake/multibody/joints/roll_pitch_yaw_floating_joint.h
+++ b/drake/multibody/joints/roll_pitch_yaw_floating_joint.h
@@ -27,8 +27,6 @@ class RollPitchYawFloatingJoint
 
   virtual ~RollPitchYawFloatingJoint() {}
 
-  std::unique_ptr<DrakeJoint> Clone() const final;
-
   template <typename DerivedQ>
   Eigen::Transform<typename DerivedQ::Scalar, 3, Eigen::Isometry>
   jointTransform(const Eigen::MatrixBase<DerivedQ>& q) const {
@@ -292,5 +290,9 @@ class RollPitchYawFloatingJoint
   std::string getPositionName(int index) const override;
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ protected:
+  std::unique_ptr<DrakeJoint> DoClone() const final;
+  void DoInitializeClone(DrakeJoint* clone) const final {}
 };
 #pragma GCC diagnostic pop  // pop -Wno-overloaded-virtual

--- a/drake/multibody/joints/test/CMakeLists.txt
+++ b/drake/multibody/joints/test/CMakeLists.txt
@@ -1,2 +1,8 @@
+add_library_with_exports(LIB_NAME drakeJointCompareToClone SOURCE_FILES
+    joint_compare_to_clone.cc)
+
+target_link_libraries(drakeJointCompareToClone
+  drakeJoints)
+
 drake_add_cc_test(joint_test)
-target_link_libraries(joint_test drakeJoints)
+target_link_libraries(joint_test drakeJointCompareToClone)

--- a/drake/multibody/joints/test/joint_compare_to_clone.cc
+++ b/drake/multibody/joints/test/joint_compare_to_clone.cc
@@ -1,0 +1,182 @@
+#include "drake/multibody/joints/test/joint_compare_to_clone.h"
+
+#include <typeinfo>
+
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace multibody {
+
+bool CompareDrakeJointToClone(const DrakeJoint& original,
+    const DrakeJoint& clone) {
+  if (typeid(original) != typeid(clone)) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): "
+        "types mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        typeid(original).name(),
+        typeid(clone).name());
+    return false;
+  }
+  if (original.get_transform_to_parent_body().matrix() !=
+      clone.get_transform_to_parent_body().matrix()) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): "
+        "transform_to_parent_body mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.get_transform_to_parent_body().matrix(),
+        clone.get_transform_to_parent_body().matrix());
+    return false;
+  }
+  if (original.get_num_positions() != clone.get_num_positions()) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): get_num_positions mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.get_num_positions(),
+        clone.get_num_positions());
+    return false;
+  }
+  if (original.get_num_velocities() != clone.get_num_velocities()) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): get_num_velocities mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.get_num_velocities(),
+        clone.get_num_velocities());
+    return false;
+  }
+  if (original.get_name() != clone.get_name()) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): get_name mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.get_name(),
+        clone.get_name());
+    return false;
+  }
+  if (original.getJointLimitMin() != clone.getJointLimitMin()) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): getJointLimitMin mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.getJointLimitMin(),
+        clone.getJointLimitMin());
+    return false;
+  }
+  if (original.getJointLimitMax() != clone.getJointLimitMax()) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): getJointLimitMax mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.getJointLimitMax(),
+        clone.getJointLimitMax());
+    return false;
+  }
+  if (original.get_joint_limit_stiffness() !=
+      clone.get_joint_limit_stiffness()) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): "
+        "get_joint_limit_stiffness mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.get_joint_limit_stiffness(),
+        clone.get_joint_limit_stiffness());
+    return false;
+  }
+  if (original.get_joint_limit_dissipation() !=
+      clone.get_joint_limit_dissipation()) {
+    drake::log()->debug(
+        "CompareDrakeJointToClone(): "
+        "get_joint_limit_dissipation mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.get_joint_limit_dissipation(),
+        clone.get_joint_limit_dissipation());
+    return false;
+  }
+  return true;
+}
+
+bool CompareFixedJointToClone(const FixedJoint& original,
+    const FixedJoint& other) {
+  return CompareDrakeJointToClone(original, other);
+}
+
+
+bool CompareHelicalJointToClone(const HelicalJoint& original,
+    const HelicalJoint& clone) {
+  if (!CompareFixedAxisOneDofJointToClone<HelicalJoint>(original, clone)) {
+    return false;
+  }
+  if (original.axis() != clone.axis()) {
+    drake::log()->debug(
+        "CompareHelicalJointToClone(): axis mismatch:\n"
+        "  - original: {}\n"
+        "  - other: {}",
+        original.axis(),
+        clone.axis());
+    return false;
+  }
+  if (original.pitch()  != clone.pitch()) {
+      drake::log()->debug(
+        "CompareHelicalJointToClone(): pitch mismatch:\n"
+        "  - original: {}\n"
+        "  - other: {}",
+        original.pitch(),
+        clone.pitch());
+    return false;
+  }
+  return true;
+}
+
+bool ComparePrismaticJointToClone(const PrismaticJoint& original,
+    const PrismaticJoint& clone) {
+  if (!CompareFixedAxisOneDofJointToClone<PrismaticJoint>(original, clone)) {
+    return false;
+  }
+  if (original.translation_axis() != clone.translation_axis()) {
+    drake::log()->debug(
+        "ComparePrismaticJointToClone(): translation_axis mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.translation_axis().transpose(),
+        clone.translation_axis().transpose());
+    return false;
+  }
+  return true;
+}
+
+bool CompareQuaternionFloatingJointToClone(
+    const QuaternionFloatingJoint& original,
+    const QuaternionFloatingJoint& clone) {
+  return CompareDrakeJointToClone(original, clone);
+}
+
+bool CompareRevoluteJointToClone(const RevoluteJoint& original,
+    const RevoluteJoint& clone) {
+  if (!CompareFixedAxisOneDofJointToClone<RevoluteJoint>(original, clone)) {
+    return false;
+  }
+  if (original.rotation_axis() != clone.rotation_axis()) {
+    drake::log()->debug(
+        "CompareRevoluteJointToClone(): rotation_axis mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.rotation_axis().transpose(),
+        clone.rotation_axis().transpose());
+    return false;
+  }
+  return true;
+}
+
+bool CompareRollPitchYawFloatingJointToClone(
+    const RollPitchYawFloatingJoint& original,
+    const RollPitchYawFloatingJoint& clone) {
+  return CompareDrakeJointToClone(original, clone);
+}
+
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/joints/test/joint_compare_to_clone.h
+++ b/drake/multibody/joints/test/joint_compare_to_clone.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "drake/multibody/joints/drake_joint.h"
+#include "drake/multibody/joints/fixed_axis_one_dof_joint.h"
+#include "drake/multibody/joints/fixed_joint.h"
+#include "drake/multibody/joints/helical_joint.h"
+#include "drake/multibody/joints/prismatic_joint.h"
+#include "drake/multibody/joints/quaternion_floating_joint.h"
+#include "drake/multibody/joints/revolute_joint.h"
+#include "drake/multibody/joints/roll_pitch_yaw_floating_joint.h"
+
+namespace drake {
+namespace multibody {
+
+/// @name Drake joint comparison methods.
+///
+/// These methods compare joint `original` with joint `clone`. Since these
+/// methods are intended to compare a clone, an *exact* match is performed. This
+/// method will only return `true` if the provided `clone` joint is exactly the
+/// same as the provided `original` joint.
+/// @{
+
+bool CompareDrakeJointToClone(
+    const DrakeJoint& original,
+    const DrakeJoint& clone);
+
+template <typename Derived>
+bool CompareFixedAxisOneDofJointToClone(
+    const FixedAxisOneDoFJoint<Derived>& original,
+    const FixedAxisOneDoFJoint<Derived>& clone) {
+  if (!CompareDrakeJointToClone(original, clone)) {
+    return false;
+  }
+  if (original.joint_axis() != clone.joint_axis()) {
+    drake::log()->debug(
+        "CompareFixedAxisOneDofJointToClone(): "
+        "joint_axis mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.joint_axis(),
+        clone.joint_axis());
+    return false;
+  }
+  if (original.damping() != clone.damping()) {
+      drake::log()->debug(
+        "CompareFixedAxisOneDofJointToClone(): "
+        "damping mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.damping(),
+        clone.damping());
+    return false;
+  }
+  if (original.coulomb_friction() != clone.coulomb_friction()) {
+      drake::log()->debug(
+        "CompareFixedAxisOneDofJointToClone(): "
+        "coulomb_friction mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.coulomb_friction(),
+        clone.coulomb_friction());
+    return false;
+  }
+  if (original.coulomb_window() != clone.coulomb_window()) {
+      drake::log()->debug(
+        "CompareFixedAxisOneDofJointToClone(): "
+        "coulomb_window mismatch:\n"
+        "  - original: {}\n"
+        "  - clone: {}",
+        original.coulomb_window(),
+        clone.coulomb_window());
+    return false;
+  }
+  return true;
+}
+
+bool CompareFixedJointToClone(
+    const FixedJoint& original,
+    const FixedJoint& clone);
+
+bool CompareHelicalJointToClone(
+    const HelicalJoint& original,
+    const HelicalJoint& clone);
+
+bool ComparePrismaticJointToClone(
+    const PrismaticJoint& original,
+    const PrismaticJoint& clone);
+
+bool CompareQuaternionFloatingJointToClone(
+    const QuaternionFloatingJoint& original,
+    const QuaternionFloatingJoint& clone);
+
+bool CompareRevoluteJointToClone(
+    const RevoluteJoint& original,
+    const RevoluteJoint& clone);
+
+bool CompareRollPitchYawFloatingJointToClone(
+    const RollPitchYawFloatingJoint& original,
+    const RollPitchYawFloatingJoint& clone);
+/// @}
+
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Fixes a bug identified in #4958. Goes toward spiral 1 of #4897.

Also removes `CompareToClone()` from Drake's joint classes, which is part of #5096.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5110)
<!-- Reviewable:end -->
