### PR TITLE
Adds a simple LeafSystem that provides easy playback ability

### DIFF
--- a/drake/systems/primitives/CMakeLists.txt
+++ b/drake/systems/primitives/CMakeLists.txt
@@ -13,6 +13,7 @@ set(sources
     pass_through.cc
     saturation.cc
     signal_logger.cc
+    signal_logger_playback.cc
     trajectory_source.cc
     zero_order_hold.cc)
 
@@ -34,6 +35,7 @@ drake_install_headers(
   random_source.h
   saturation.h
   signal_logger.h
+  signal_logger_playback.h
   trajectory_source.h
   zero_order_hold.h
   zero_order_hold-inl.h
@@ -45,7 +47,11 @@ set(private_headers)
 
 add_library_with_exports(LIB_NAME drakeSystemPrimitives
     SOURCE_FILES ${sources} ${private_headers})
-target_link_libraries(drakeSystemPrimitives drakeSystemFramework drakeCommon)
+target_link_libraries(drakeSystemPrimitives
+    drakeSystemFramework
+    drakeCommon
+    drakeSystemAnalysis
+    )
 
 drake_install_libraries(drakeSystemPrimitives)
 drake_install_pkg_config_file(drake-system-primitives

--- a/drake/systems/primitives/signal_logger.h
+++ b/drake/systems/primitives/signal_logger.h
@@ -43,14 +43,15 @@ class SignalLogger : public LeafSystem<T> {
     return const_cast<const MatrixX<T>&>(data_).leftCols(num_samples_);
   }
 
- private:
-  // No output.
+ protected:
+  /// Calculates the output - by default, there are no outputs.
   void DoCalcOutput(const Context<T>& context,
                     SystemOutput<T>* output) const override {}
 
-  // Logging is done in this method.
+  /// Logs the context state.
   void DoPublish(const Context<T>& context) const override;
 
+ private:
   const int batch_allocation_size_{1000};
 
   // Use mutable variables to hold the logged data.

--- a/drake/systems/primitives/signal_logger_playback.cc
+++ b/drake/systems/primitives/signal_logger_playback.cc
@@ -1,0 +1,90 @@
+#include "drake/systems/primitives/signal_logger_playback.h"
+
+#include <iomanip>
+#include <vector>
+
+#include "drake/common/extract_double.h"
+#include "drake/systems/analysis/simulator.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+SignalLoggerPlayback<T>::SignalLoggerPlayback(int input_size,
+                                              int batch_allocation_size)
+    : SignalLogger<T>(input_size, batch_allocation_size) {
+  this->DeclareOutputPort(kVectorValued, input_size);
+}
+
+template <typename T>
+void SignalLoggerPlayback<T>::InitializePlayback() {
+  if (!playback_active_) {
+    auto times = this->sample_times();
+    // NOTE: The SignalLogger parent class will record signal for multiple
+    // identical time stamps.  This culls the duplicates as required by the
+    // PiecewisePolynomial.
+    std::vector<int> included_times;
+    included_times.reserve(times.rows());
+    std::vector<double> breaks;
+    included_times.push_back(0);
+    breaks.push_back(ExtractDoubleOrThrow<T>(times(0)));
+    int last = 0;
+    for (int i = 1; i < times.rows(); ++i) {
+      double val = times(i);
+      if (val != breaks[last]) {
+        breaks.push_back(ExtractDoubleOrThrow<T>(val));
+        included_times.push_back(i);
+        ++last;
+      }
+    }
+
+    auto sample_data = this->data();
+    std::vector<MatrixX<T>> knots;
+    knots.reserve(sample_data.cols());
+    for (int c : included_times) {
+      knots.push_back(sample_data.col(c));
+    }
+    playback_data_ = PiecewisePolynomial<T>::ZeroOrderHold(breaks, knots);
+    playback_active_ = true;
+  }
+}
+
+template <typename T>
+void SignalLoggerPlayback<T>::ResetPlayback(Simulator<T> *simulator) {
+  auto context = simulator->get_mutable_context();
+  simulator->set_target_realtime_rate(1.0);
+  simulator->get_mutable_integrator()->set_maximum_step_size(1/60.0);
+  context->set_time(0.0);
+  simulator->ResetStatistics();
+}
+
+template <typename T>
+void SignalLoggerPlayback<T>::DoCalcOutput(const Context<T>& context,
+                                           SystemOutput<T>* output) const {
+  // Evaluates the state output port.
+  BasicVector<T>* output_vector = output->GetMutableVectorData(0);
+  auto output_data = output_vector->get_mutable_value();
+
+  if (playback_active_) {
+    // NOTE: this is safe for *any* time value because the time value gets
+    // clamped to the domain of the playback data.
+    T time = context.get_time();
+    output_data = playback_data_.value(time);
+  } else {
+    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
+    output_data = input->get_value();
+  }
+}
+
+template <typename T>
+void SignalLoggerPlayback<T>::DoPublish(
+    const Context<T>& context) const {
+  if (!playback_active_) SignalLogger<T>::DoPublish(context);
+}
+
+template class SignalLoggerPlayback<double>;
+// TODO(SeanCurtis-TRI): Specialize on AutoDiffXd if the need is shown; as is,
+// attempting to compile with AutoDiff is a real pain.
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/primitives/signal_logger_playback.h
+++ b/drake/systems/primitives/signal_logger_playback.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include <memory>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/system_output.h"
+#include "drake/systems/primitives/signal_logger.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+class Simulator;
+
+/**
+ This system extends the SignalLogger class providing simple playback abilities.
+ It is intended to work in conjunction with the DrakeVisualizer. In
+ addition to the logging of input to memory, it also provides an output which,
+ depending on the state of the system, provides either the passed through
+ input value or the cached value.
+
+ This system does not persist the simulation results beyond the scope of the
+ Diagram (i.e., nothing written to disk or output in LCM messages).  It is
+ simply intended to cache simulation results and then to interactively replay
+ them at real time.
+
+ The cached values can be evaluated in a time-continuous manner.  The cached
+ samples are interpolated using a zero-order hold (i.e., piecewise constant
+ function of time).
+
+ Once this system is set to playback, it cannot be set back to record; the state
+ of the simulator's context cannot be guaranteed.
+
+ Typical usage would look like the following:
+
+    - Initialize simulator
+       - Place the SignalLoggerPlayback leaf system between the DrakeVisualizer
+         system and its upstream dependencies.  What would formerly have been
+         the inputs of the DrakeVisualizer system become the inputs of this
+         system.  This system's output are connected into the DrakeVisualizer's
+         input.
+       - Store a pointer to the SignalLoggerPlayback (signal_playback).
+    - Define simulation duration: `T`
+    - Run simulator to duration time `T` (e.g, `simulator.StepTo(T)`).
+    - Initialize playback: `signal_playback->InitializePlayback()`
+    - For each playback (e.g., as in a looped playback):
+       - Reset playback: `signal_playback->ResetPlayback(&simulator)`
+       - Advance the simulator the duration again: `simulator.StepTo(T)`.
+
+ @param T  The vector element type, which must be a valid Eigen scalar.
+
+ Instantiated templates for the following kind of T's are provided:
+    - double
+
+ @ingroup primitive_systems
+ */
+template <typename T>
+class SignalLoggerPlayback : public SignalLogger<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SignalLoggerPlayback)
+
+  /** Construct the signal logger system.
+   @param input_size Dimension of the (single) input port.
+   @param batch_allocation_size Storage is (re)allocated in blocks of
+   input_size-by-batch_allocation_size.
+   */
+  explicit SignalLoggerPlayback(int input_size,
+                                int batch_allocation_size = 1000);
+
+  /** Reports true if the output data is set by cached data. */
+  bool is_playing_back() const { return playback_active_; }
+
+  /** Stops logging and sets the logger to playback; this cannot be undone. */
+  void InitializePlayback();
+
+  /** Resets the playback for looping. This must be called prior to each
+   simulation loop. This can safely be called redundantly. */
+  void ResetPlayback(Simulator<T>* simulator);
+
+ protected:
+  /** Sets the output value based on the playback state. */
+  void DoCalcOutput(const Context<T>& context,
+                    SystemOutput<T>* output) const override;
+
+  /** Caches the data, unless in playback. */
+  void DoPublish(const Context<T>& context) const override;
+
+ private:
+  // If true, output is set from cached data.
+  bool playback_active_{false};
+
+  // A trajectory pointer that is null when not in playback, non-null when it
+  // is.
+  PiecewisePolynomial<T> playback_data_{};
+};
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
The `SimpleLoggerPlayback` allows a simulation to be run over a fixed
time domain at arbitrary time step, and then immediately enter a repeating
loop of real-time playback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5125)
<!-- Reviewable:end -->
