### PR TITLE
maliput/api: Resolve TODO regarding order of Lane indices in a Segment

### DIFF
--- a/drake/automotive/maliput/api/segment.h
+++ b/drake/automotive/maliput/api/segment.h
@@ -43,13 +43,12 @@ class Segment {
   int num_lanes() const { return do_num_lanes(); }
 
   /// Returns the Lane indexed by @p index.
+  ///
   /// The indexing order is meaningful; numerically adjacent indices correspond
-  /// to geometrically adjacent Lanes.
+  /// to geometrically adjacent Lanes.  Indices increase "to the left", i.e.,
+  /// in the direction of increasing `r` coordinate.
   ///
   /// @pre @p index must be >= 0 and < num_lanes().
-  // TODO(maddog@tri.global) Does increasing index value mean "to left" or
-  //                         "to right"?  Resolve this by the first multilane
-  //                         implementation.
   const Lane* lane(int index) const { return do_lane(index); }
 
  protected:


### PR DESCRIPTION
This is a documentation-only change.

Resolve the TODO regarding order of Lane indices in a Segment:
increasing index should correspond to increasing `r` (lateral) position.
In other words:  Lane 0 is the 'rightmost' lane with minimal 'r' values.

Aside from being the least-surprising and most-natural mapping, it also
matches the lane ordering in OpenDrive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5127)
<!-- Reviewable:end -->
