### PR TITLE
Foist test_tag_filters management on the developer.

### DIFF
--- a/drake/doc/bazel.rst
+++ b/drake/doc/bazel.rst
@@ -120,6 +120,7 @@ Proprietary Solvers
 The Drake Bazel build currently supports the following proprietary solvers:
 
  * Gurobi (on Ubuntu only)
+ * SNOPT
 
 Gurobi
 ------
@@ -130,10 +131,30 @@ Gurobi
 4. Unzip it in a local directory, e.g. ``/home/myuser/bin/gurobi``
 5. ``export GUROBI_PATH=/home/myuser/bin/gurobi/gurobi605/linux64``
 
-To confirm that your setup was successful, run the tests that require Gurobi.
-Note that this config includes *only* the tests that require Gurobi::
 
-  ``bazel test --config gurobi ...``
+To confirm that your setup was successful, run the tests that require Gurobi.
+
+  ``bazel test --config gurobi --test_tag_filters=gurobi ...``
+
+The default value of ``--test_tag_filters`` in Drake's ``bazel.rc`` excludes
+these tests. If you will be developing with Gurobi regularly, you may wish
+to specify a more convenient ``--test_tag_filters`` in a local ``.bazelrc``.
+See https://bazel.build/versions/master/docs/bazel-user-manual.html#bazelrc.
+
+SNOPT
+-----
+
+1. Obtain access to the private RobotLocomotion/snopt GitHub repository.
+2. `Set up SSH access to github.com <https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/>`_.
+
+To confirm that your setup was successful, run the tests that require SNOPT.
+
+  ``bazel test --config snopt --test_tag_filters=snopt ...``
+
+The default value of ``--test_tag_filters`` in Drake's ``bazel.rc`` excludes
+these tests. If you will be developing with SNOPT regularly, you may wish
+to specify a more convenient ``--test_tag_filters`` in a local ``.bazelrc``.
+See https://bazel.build/versions/master/docs/bazel-user-manual.html#bazelrc.
 
 Optional Tools
 ==============

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -11,8 +11,10 @@ build --output_filter="^//"
 # Default test options.
 test --test_output=errors
 
-# By default, disable targets that require proprietary software.
-build --build_tag_filters=-gurobi,-snopt
+# By default, disable execution of tests that require proprietary software.
+# Individual targets that use proprietary software are responsible for ensuring
+# they can also build without it, typically by using a select statement.
+# config_setting rules for proprietary software are provided in //tools.
 test --test_tag_filters=-gurobi,-snopt
 
 ### A configuration that enables Gurobi. ###
@@ -25,25 +27,26 @@ test --test_tag_filters=-gurobi,-snopt
 # -- the tag "exclusive", to rate-limit license servers with a small number of
 # -- licenses.
 # -- TODO(david-german-tri): Find a better fix for the license server problem.
+#
+# -- To run tests that require Gurobi, also specify a custom set of
+# -- test_tag_filters that does not exclude the "gurobi" tag.
 build:gurobi --define=WITH_GUROBI=ON
 # -- By default, Gurobi looks for the license file in the homedir.
 test:gurobi --test_env=HOME
 # -- If set, the GRB_LICENSE_FILE path takes precedence.
 test:gurobi --test_env=GRB_LICENSE_FILE
-# -- This configuration runs only tests that require Gurobi.
-test:gurobi --test_tag_filters=gurobi
 
 
 ### A configuration that enables SNOPT. ###
 # -- To use this config, you must have access to the private repository
 # -- RobotLocomotion/snopt on GitHub, and your local git must be configured
 # -- with SSH keys as documented at http://drake.mit.edu/from_source.html.
+#
+# -- To run tests that require SNOPT, also specify a set of test_tag_filters
+# -- that does not exclude the "snopt" tag.
 build:snopt --define=WITH_SNOPT=ON
-# -- This configuration runs only tests that require SNOPT.
-test:snopt --test_tag_filters=snopt
 
 ### A configuration that enables all optional dependencies. ###
-# This is probably only useful for CI.
 test:everything --test_tag_filters=
 
 # -- Options for Gurobi.


### PR DESCRIPTION
This is the best we can do, given that tags are not configurable and `--test_tag_filters` has last-one-wins semantics.

See https://github.com/bazelbuild/bazel/issues/2451.

@siyuanfeng-tri for feature review: is this helpful?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5134)
<!-- Reviewable:end -->
