### PR TITLE
Bump the snopt SHA for Bazel fixes.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -184,7 +184,7 @@ gfortran_repository(
 git_repository(
   name = "snopt",
   remote = "git@github.com:RobotLocomotion/snopt.git",
-  commit = "9f8c7972fa257d2341ecefcf58617e11b9ebb504",
+  commit = "d08d0ea5454349d252b2bc355c6d7c7237090a46",
 )
 
 # Python Libraries


### PR DESCRIPTION
In particular, this removes a snopt-provided `main()` that was defeating the `main()` in some Drake targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5135)
<!-- Reviewable:end -->
