### PR TITLE
Port most of rigid_body_plant to drake_copyable

### DIFF
--- a/drake/multibody/rigid_body_plant/contact_detail.cc
+++ b/drake/multibody/rigid_body_plant/contact_detail.cc
@@ -4,6 +4,9 @@ namespace drake {
 namespace systems {
 
 template <typename T>
+ContactDetail<T>::ContactDetail() {}
+
+template <typename T>
 ContactDetail<T>::~ContactDetail() {}
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/multibody/rigid_body_plant/contact_detail.h
+++ b/drake/multibody/rigid_body_plant/contact_detail.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/rigid_body_plant/contact_force.h"
 
 namespace drake {
@@ -26,6 +27,9 @@ namespace systems {
 template <typename T>
 class ContactDetail {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactDetail)
+
+  ContactDetail();
   virtual ~ContactDetail();
 
   virtual std::unique_ptr<ContactDetail<T>> Clone() const = 0;

--- a/drake/multibody/rigid_body_plant/contact_force.h
+++ b/drake/multibody/rigid_body_plant/contact_force.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -34,6 +35,8 @@ namespace systems {
 template <typename T>
 class ContactForce {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactForce)
+
   /** Default constructor.  All values are initialized to NaN. */
   ContactForce();
 
@@ -67,12 +70,6 @@ class ContactForce {
   ContactForce get_reaction_force() const {
     return ContactForce(application_point_, -normal_, -force_, -torque_);
   }
-
-  // Contact force is copyable and movable
-  ContactForce(const ContactForce& other) = default;
-  ContactForce& operator=(const ContactForce& other) = default;
-  ContactForce(ContactForce&& other) = default;
-  ContactForce& operator=(ContactForce&& other) = default;
 
   const Vector3<T>& get_application_point() const { return application_point_; }
 

--- a/drake/multibody/rigid_body_plant/contact_resultant_force_calculator.h
+++ b/drake/multibody/rigid_body_plant/contact_resultant_force_calculator.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/rigid_body_plant/contact_force.h"
 #include "drake/multibody/rigid_body_plant/contact_detail.h"
 
@@ -138,6 +139,8 @@ namespace systems {
 template <typename T>
 class ContactResultantForceCalculator {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactResultantForceCalculator)
+
   /** Default constructor -- no accumulation.  As contact forces are added to
    the calculator, the force will be added to the set of forces for calculation,
    but they will be destroyed when the calculator is destroyed.
@@ -240,16 +243,6 @@ class ContactResultantForceCalculator {
    @param reference_point is in the same frame as all the individual forces.
    */
   ContactForce<T> ComputeResultant(const Vector3<T>& reference_point) const;
-
-  // Neither movable or copyable.
-  ContactResultantForceCalculator(
-      const ContactResultantForceCalculator& other) = delete;
-  ContactResultantForceCalculator& operator=(
-      const ContactResultantForceCalculator& other) = delete;
-  ContactResultantForceCalculator(ContactResultantForceCalculator&& other) =
-      delete;
-  ContactResultantForceCalculator& operator=(
-      ContactResultantForceCalculator&& other) = delete;
 
  private:
   // Aggregator for the force data that has been added.

--- a/drake/multibody/rigid_body_plant/contact_results.h
+++ b/drake/multibody/rigid_body_plant/contact_results.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/rigid_body_plant/contact_info.h"
 
@@ -24,12 +25,9 @@ class RigidBodyPlant;
 template <typename T>
 class ContactResults {
  public:
-  ContactResults();
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactResults)
 
-  ContactResults(const ContactResults<T>& other) = default;
-  ContactResults<T>& operator=(const ContactResults<T>& other) = default;
-  ContactResults(ContactResults<T>&& other) = delete;
-  ContactResults<T>& operator=(ContactResults<T>&& other) = delete;
+  ContactResults();
 
   /** Returns the number of unique collision element pairs in contact. */
   int get_num_contacts() const;

--- a/drake/multibody/rigid_body_plant/drake_visualizer.h
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/lcmt_viewer_load_robot.hpp"
 #include "drake/lcmt_viewer_draw.hpp"
 #include "drake/lcm/drake_lcm_interface.h"
@@ -40,6 +41,8 @@ namespace systems {
  */
 class DrakeVisualizer : public LeafSystem<double> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeVisualizer)
+
   /**
    * A constructor that prepares for the transmission of `lcmt_viewer_draw` and
    * `lcmt_viewer_load_robot` messages, but does not actually publish anything.

--- a/drake/multibody/rigid_body_plant/kinematics_results.h
+++ b/drake/multibody/rigid_body_plant/kinematics_results.h
@@ -2,6 +2,7 @@
 
 #include <Eigen/Geometry>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/context.h"
 
@@ -17,6 +18,8 @@ class RigidBodyPlant;
 template <typename T>
 class KinematicsResults {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(KinematicsResults)
+
   /// Constructs a KinematicsResults object associated with @param tree.
   /// An alias to @param tree is maintained so that the tree's lifetime must
   /// exceed this object's lifetime.

--- a/drake/multibody/rigid_body_plant/point_contact_detail.h
+++ b/drake/multibody/rigid_body_plant/point_contact_detail.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/rigid_body_plant/contact_detail.h"
 
 namespace drake {
@@ -19,15 +20,12 @@ namespace systems {
 template <typename T>
 class PointContactDetail : public ContactDetail<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PointContactDetail)
+
   explicit PointContactDetail(const ContactForce<T>& force);
   std::unique_ptr<ContactDetail<T>> Clone() const override;
   ContactForce<T> ComputeContactForce() const override { return force_; }
 
-  // not copyable or movable
-  PointContactDetail(const PointContactDetail& other) = delete;
-  PointContactDetail& operator=(const PointContactDetail& other) = delete;
-  PointContactDetail(PointContactDetail&& other) = delete;
-  PointContactDetail& operator=(PointContactDetail&& other) = delete;
  private:
   ContactForce<T> force_;
 };

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -7,6 +7,7 @@
 
 #include <Eigen/Geometry>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/multibody/rigid_body_plant/contact_results.h"
 #include "drake/multibody/rigid_body_plant/kinematics_results.h"
@@ -112,6 +113,8 @@ namespace systems {
 template <typename T>
 class RigidBodyPlant : public LeafSystem<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RigidBodyPlant)
+
   /// Instantiates a %RigidBodyPlant from a Multi-Body Dynamics (MBD) model of
   /// the world in `tree`.  `tree` must not be `nullptr`.
   ///

--- a/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant_that_publishes_xdot.h
@@ -7,6 +7,7 @@
 
 #include <Eigen/Geometry>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcmt_drake_signal.hpp"
 #include "drake/multibody/rigid_body_tree.h"
@@ -25,6 +26,8 @@ namespace systems {
 template <typename T>
 class RigidBodyPlantThatPublishesXdot : public RigidBodyPlant<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RigidBodyPlantThatPublishesXdot)
+
   /// Instantiates a %RigidBodyPlantThatPublishesXdot.
   ///
   /// @param[in] tree The RigidBodyTree. This defines the multi-body dynamics of

--- a/drake/multibody/rigid_body_plant/viewer_draw_translator.h
+++ b/drake/multibody/rigid_body_plant/viewer_draw_translator.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/vector_base.h"
@@ -19,6 +20,8 @@ namespace systems {
  */
 class ViewerDrawTranslator : public lcm::LcmAndVectorBaseTranslator {
  public:
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ViewerDrawTranslator)
+
   /**
    * A constructor that sets the expected sizes of both the LCM message and
    * VectorBase vector to be the size of the state vector of @p tree,


### PR DESCRIPTION
A portion of #4861.

(Does not touch `ContactInfo`, because that class does not use the default implementations.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5144)
<!-- Reviewable:end -->
