### PR TITLE
Compare two monomials with total degree 0

### DIFF
--- a/drake/common/monomial.cc
+++ b/drake/common/monomial.cc
@@ -54,10 +54,6 @@ size_t Monomial::GetHash() const {
 }
 
 bool Monomial::operator==(const Monomial& m) const {
-  // Both monomials are 1, does not matter if the variables are the same.
-  if (total_degree_ == 0 && m.total_degree() == 0) {
-    return true;
-  }
   return powers_ == m.powers_;
 }
 

--- a/drake/common/monomial.cc
+++ b/drake/common/monomial.cc
@@ -35,7 +35,15 @@ Monomial::Monomial(const Variable& var, const int exponent)
 }
 
 Monomial::Monomial(const map<Variable::Id, int>& powers)
-    : total_degree_{TotalDegree(powers)}, powers_(powers) {}
+    : total_degree_{TotalDegree(powers)}, powers_{} {
+  for (const auto& p : powers) {
+    if (p.second > 0) {
+      powers_.insert(p);
+    } else if (p.second < 0) {
+      throw std::runtime_error("The exponent is negative.");
+    }
+  }
+}
 
 size_t Monomial::GetHash() const {
   // To get a hash value for a Monomial, we re-use the hash value for

--- a/drake/common/monomial.cc
+++ b/drake/common/monomial.cc
@@ -24,6 +24,8 @@ using std::runtime_error;
 using std::unordered_map;
 
 namespace internal {
+Monomial::Monomial() : total_degree_{0}, powers_{} {}
+
 Monomial::Monomial(const Variable& var, const int exponent)
     : total_degree_{exponent} {
   DRAKE_DEMAND(exponent >= 0);
@@ -44,6 +46,10 @@ size_t Monomial::GetHash() const {
 }
 
 bool Monomial::operator==(const Monomial& m) const {
+  // Both monomials are 1, does not matter if the variables are the same.
+  if (total_degree_ == 0 && m.total_degree() == 0) {
+    return true;
+  }
   return powers_ == m.powers_;
 }
 

--- a/drake/common/monomial.h
+++ b/drake/common/monomial.h
@@ -34,8 +34,8 @@ constexpr int NChooseK(int n, int k) {
 class Monomial {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Monomial)
-  /** Default constructor. */
-  Monomial() = default;
+  /** Constructs a monomial equal to 1. Namely the total degree is zero. */
+  Monomial();
   /** Constructs a Monomial from @p powers. */
   explicit Monomial(const std::map<Variable::Id, int>& powers);
   /** Constructs a Monomial from @p var and @exponent. */

--- a/drake/common/monomial.h
+++ b/drake/common/monomial.h
@@ -27,8 +27,8 @@ constexpr int NChooseK(int n, int k) {
   return (k == 0) ? 1 : (n * NChooseK(n - 1, k - 1)) / k;
 }
 
-/** Represents a monomial, a product of powers of variables with integer
- * exponents. Note that it does not include the coefficient part of a
+/** Represents a monomial, a product of powers of variables with non-negative
+ * integer exponents. Note that it does not include the coefficient part of a
  * monomial. Internally, it is represented by a map from a variable ID to its
  * integer exponent. */
 class Monomial {

--- a/drake/common/test/monomial_test.cc
+++ b/drake/common/test/monomial_test.cc
@@ -37,6 +37,16 @@ class MonomialTest : public ::testing::Test {
   }
 };
 
+TEST_F(MonomialTest, MonomialOne) {
+  // Compares monomials all equal to 1, but with different variables.
+  internal::Monomial m1{};
+  internal::Monomial m2({{var_x_.get_id(), 0}});
+  internal::Monomial m3({{var_x_.get_id(), 0}, {var_y_.get_id(), 0}});
+  EXPECT_EQ(m1, m2);
+  EXPECT_EQ(m1, m3);
+  EXPECT_EQ(m2, m3);
+}
+
 TEST_F(MonomialTest, Monomial) {
   // clang-format off
   EXPECT_PRED2(

--- a/drake/common/test/monomial_test.cc
+++ b/drake/common/test/monomial_test.cc
@@ -47,6 +47,17 @@ TEST_F(MonomialTest, MonomialOne) {
   EXPECT_EQ(m2, m3);
 }
 
+TEST_F(MonomialTest, MonomialWithZeroExponent) {
+  // Compares monomials containing zero exponent, such as x^0 * y^2
+  internal::Monomial m1({{var_y_.get_id(), 2}});
+  internal::Monomial m2({{var_x_.get_id(), 0}, {var_y_.get_id(), 2}});
+  EXPECT_EQ(m1, m2);
+  EXPECT_EQ(m2.get_powers().size(), 1);
+  std::map<Variable::Id, int> power_expected;
+  power_expected.emplace(var_y_.get_id(), 2);
+  EXPECT_EQ(m2.get_powers(), power_expected);
+}
+
 TEST_F(MonomialTest, Monomial) {
   // clang-format off
   EXPECT_PRED2(


### PR DESCRIPTION
Fix a corner case, monomial `x^0` should equal to `x^0*y^`, although they contain different variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5146)
<!-- Reviewable:end -->
