### PR TITLE
Remove now-redundant parameter checks in System NVI overrides

### DIFF
--- a/drake/automotive/linear_car.cc
+++ b/drake/automotive/linear_car.cc
@@ -48,8 +48,6 @@ template <typename T>
 void LinearCar<T>::DoCalcTimeDerivatives(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
-  DRAKE_ASSERT(derivatives != nullptr);
 
   // Obtain the state.
   const systems::VectorBase<T>& context_state =

--- a/drake/automotive/simple_car.cc
+++ b/drake/automotive/simple_car.cc
@@ -34,9 +34,6 @@ bool SimpleCar<T>::has_any_direct_feedthrough() const {
 template <typename T>
 void SimpleCar<T>::DoCalcOutput(const systems::Context<T>& context,
                                 systems::SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidOutput(output));
-
   // Obtain the state.
   const systems::VectorBase<T>& context_state =
       context.get_continuous_state_vector();
@@ -62,8 +59,6 @@ template <typename T>
 void SimpleCar<T>::DoCalcTimeDerivatives(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
-
   // Obtain the parameters.
   const SimpleCarConfig<T>& config =
       this->template GetNumericParameter<SimpleCarConfig>(context, 0);

--- a/drake/examples/Acrobot/acrobot_plant.cc
+++ b/drake/examples/Acrobot/acrobot_plant.cc
@@ -75,8 +75,6 @@ template <typename T>
 void AcrobotPlant<T>::DoCalcTimeDerivatives(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
-
   const AcrobotStateVector<T>& x = dynamic_cast<const AcrobotStateVector<T>&>(
       context.get_continuous_state_vector());
   const T& tau = this->EvalVectorInput(context, 0)->GetAtIndex(0);
@@ -93,7 +91,6 @@ void AcrobotPlant<T>::DoCalcTimeDerivatives(
 template <typename T>
 T AcrobotPlant<T>::DoCalcKineticEnergy(
     const systems::Context<T>& context) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
   const AcrobotStateVector<T>& x = dynamic_cast<const AcrobotStateVector<T>&>(
       context.get_continuous_state_vector());
 
@@ -106,7 +103,6 @@ T AcrobotPlant<T>::DoCalcKineticEnergy(
 template <typename T>
 T AcrobotPlant<T>::DoCalcPotentialEnergy(
     const systems::Context<T>& context) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
   const AcrobotStateVector<T>& x = dynamic_cast<const AcrobotStateVector<T>&>(
       context.get_continuous_state_vector());
 

--- a/drake/examples/Pendulum/pendulum_plant.cc
+++ b/drake/examples/Pendulum/pendulum_plant.cc
@@ -60,8 +60,6 @@ template <typename T>
 void PendulumPlant<T>::DoCalcTimeDerivatives(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
-
   const PendulumStateVector<T>& state = get_state(context);
   PendulumStateVector<T>* derivative_vector = get_mutable_state(derivatives);
 

--- a/drake/examples/Quadrotor/quadrotor_plant.cc
+++ b/drake/examples/Quadrotor/quadrotor_plant.cc
@@ -47,8 +47,6 @@ template <typename T>
 void QuadrotorPlant<T>::DoCalcTimeDerivatives(
     const systems::Context<T> &context,
     systems::ContinuousState<T> *derivatives) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
-
   VectorX<T> state = context.get_continuous_state_vector().CopyToVector();
 
   VectorX<T> u = this->EvalVectorInput(context, 0)->get_value();

--- a/drake/examples/painleve/painleve-inl.h
+++ b/drake/examples/painleve/painleve-inl.h
@@ -979,7 +979,6 @@ template <typename T>
 void Painleve<T>::DoCalcTimeDerivatives(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
-  DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(context));
   using std::sin;
   using std::cos;
   using std::abs;

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -347,9 +347,6 @@ const InputPortDescriptor<T>&
 template <typename T>
 void RigidBodyPlant<T>::DoCalcOutput(const Context<T>& context,
                                      SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   // TODO(amcastro-tri): Remove this copy by allowing output ports to be
   // mere pointers to state variables (or cache lines).
   const VectorX<T> state_vector =
@@ -401,10 +398,6 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
     const Context<T>& context, ContinuousState<T>* derivatives) const {
   static_assert(std::is_same<double, T>::value,
                 "Only support templating on double for now");
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-  DRAKE_DEMAND(derivatives != nullptr);
-
-
 
   VectorX<T> u;   // The plant-centric input vector of actuation values.
   u.resize(get_num_actuators());

--- a/drake/systems/controllers/gravity_compensator.cc
+++ b/drake/systems/controllers/gravity_compensator.cc
@@ -23,9 +23,6 @@ GravityCompensator<T>::GravityCompensator(const RigidBodyTree<T>& tree)
 template <typename T>
 void GravityCompensator<T>::DoCalcOutput(const Context<T>& context,
                                          SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   Eigen::VectorXd q = this->EvalEigenVectorInput(context, 0);
 
   KinematicsCache<T> cache = tree_.doKinematics(q);

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -508,7 +508,6 @@ class PublishingSystem : public LeafSystem<double> {
                     SystemOutput<double>* output) const override {}
 
   void DoPublish(const Context<double>& context) const override {
-    CheckValidContext(context);
     callback_(this->EvalVectorInput(context, 0)->get_value()[0]);
   }
 

--- a/drake/systems/primitives/adder.cc
+++ b/drake/systems/primitives/adder.cc
@@ -28,9 +28,6 @@ const OutputPortDescriptor<T>& Adder<T>::get_output_port() const {
 template <typename T>
 void Adder<T>::DoCalcOutput(const Context<T>& context,
                             SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   BasicVector<T>* output_vector = output->GetMutableVectorData(0);
 
   // Zeroes the output.

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -79,9 +79,6 @@ void AffineSystem<T>::DoCalcOutput(const Context<T>& context,
                                    SystemOutput<T>* output) const {
   if (num_outputs_ == 0) return;
 
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   // Evaluates the state output port.
   BasicVector<T>* output_vector = output->GetMutableVectorData(0);
 
@@ -104,7 +101,6 @@ template <typename T>
 void AffineSystem<T>::DoCalcTimeDerivatives(
     const Context<T>& context, ContinuousState<T>* derivatives) const {
   if (num_states_ == 0 || time_period_ > 0.0) return;
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   const auto& x =
       dynamic_cast<const BasicVector<T>&>(context.get_continuous_state_vector())
@@ -127,7 +123,6 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
     const drake::systems::Context<T>& context,
     drake::systems::DiscreteState<T>* updates) const {
   if (num_states_ == 0 || time_period_ == 0.0) return;
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
 
   const auto& x = context.get_discrete_state(0)->get_value();
 

--- a/drake/systems/primitives/demultiplexer.cc
+++ b/drake/systems/primitives/demultiplexer.cc
@@ -25,9 +25,6 @@ Demultiplexer<T>::Demultiplexer(int size, int output_ports_sizes) {
 template <typename T>
 void Demultiplexer<T>::DoCalcOutput(const Context<T>& context,
                                     SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   // All output ports have the same size as defined in the constructor.
   const int out_size = this->get_output_port(0).size();
 

--- a/drake/systems/primitives/gain-inl.h
+++ b/drake/systems/primitives/gain-inl.h
@@ -59,9 +59,6 @@ const OutputPortDescriptor<T>& Gain<T>::get_output_port() const {
 template <typename T>
 void Gain<T>::DoCalcOutput(const Context<T>& context,
                            SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   auto input_vector = this->EvalEigenVectorInput(context, 0);
   System<T>::GetMutableOutputVector(output, 0) =
       k_.array() * input_vector.array();

--- a/drake/systems/primitives/integrator.cc
+++ b/drake/systems/primitives/integrator.cc
@@ -54,7 +54,6 @@ std::unique_ptr<ContinuousState<T>> Integrator<T>::AllocateContinuousState()
 template <typename T>
 void Integrator<T>::DoCalcTimeDerivatives(
     const Context<T>& context, ContinuousState<T>* derivatives) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
   const BasicVector<T>* input = this->EvalVectorInput(context, 0);
   derivatives->SetFromVector(input->get_value());
 }
@@ -62,9 +61,6 @@ void Integrator<T>::DoCalcTimeDerivatives(
 template <typename T>
 void Integrator<T>::DoCalcOutput(const Context<T>& context,
                                  SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   // TODO(david-german-tri): Remove this copy by allowing output ports to be
   // mere pointers to state variables (or cache lines).
   System<T>::GetMutableOutputVector(output, 0) =

--- a/drake/systems/primitives/multiplexer.cc
+++ b/drake/systems/primitives/multiplexer.cc
@@ -24,8 +24,6 @@ Multiplexer<T>::Multiplexer(std::vector<int> input_sizes)
 template <typename T>
 void Multiplexer<T>::DoCalcOutput(const Context<T>& context,
                                   SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
   auto output_vector = System<T>::GetMutableOutputVector(output, 0);
   int output_vector_index{0};
   for (int i = 0; i < this->get_num_input_ports(); ++i) {

--- a/drake/systems/primitives/pass_through-inl.h
+++ b/drake/systems/primitives/pass_through-inl.h
@@ -29,9 +29,6 @@ PassThrough<T>::PassThrough(int size) {
 template <typename T>
 void PassThrough<T>::DoCalcOutput(const Context<T>& context,
                                   SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   // TODO(amcastro-tri): the output should simply reference the input port's
   // value to avoid copy.
   System<T>::GetMutableOutputVector(output, 0) =

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -34,9 +34,6 @@ ZeroOrderHold<T>::ZeroOrderHold(const T& period_sec, int size) {
 template <typename T>
 void ZeroOrderHold<T>::DoCalcOutput(const Context<T>& context,
                                     SystemOutput<T>* output) const {
-  DRAKE_ASSERT_VOID(System<T>::CheckValidOutput(output));
-  DRAKE_ASSERT_VOID(System<T>::CheckValidContext(context));
-
   System<T>::GetMutableOutputVector(output, 0) =
       context.get_discrete_state(0)->CopyToVector();
 }

--- a/drake/systems/sensors/depth_sensor.cc
+++ b/drake/systems/sensors/depth_sensor.cc
@@ -131,9 +131,6 @@ std::unique_ptr<BasicVector<double>> DepthSensor::AllocateOutputVector(
 
 void DepthSensor::DoCalcOutput(const systems::Context<double>& context,
                                systems::SystemOutput<double>* output) const {
-  DRAKE_ASSERT_VOID(System<double>::CheckValidContext(context));
-  DRAKE_ASSERT_VOID(System<double>::CheckValidOutput(output));
-
   VectorXd u = this->EvalEigenVectorInput(context, 0);
   auto q = u.head(tree_.get_num_positions());
   KinematicsCache<double> kinematics_cache = tree_.doKinematics(q);


### PR DESCRIPTION
The `System` API uses the NVI pattern where there is a public interface method (like `CalcTimeDerivatives()`) that performs common code (like error-checking the arguments) before dispatching to a corresponding protected virtual (like `DoCalcTimeDerivatives()`) whose API documentation promises that the arguments are safe and do not need to be checked in the overriding implementation.

This PR removes all the leftover redundant checks in the overrides to prevent further copy-paste propagation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5147)
<!-- Reviewable:end -->
