### PR TITLE
Add scipy dependency to the developer documentation.

### DIFF
--- a/drake/doc/mac.rst
+++ b/drake/doc/mac.rst
@@ -20,7 +20,8 @@ Install the prerequisites::
     brew update
     brew upgrade
     brew install autoconf automake cmake doxygen gcc glib graphviz gtk+ jpeg \
-      libpng libtool libyaml mpfr ninja numpy python qt qwt valgrind vtk5 wget
+      libpng libtool libyaml mpfr ninja numpy python qt qwt scipy valgrind \
+      vtk5 wget
     pip install -U beautifulsoup4 html5lib lxml PyYAML Sphinx
 
 Add the line::

--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -80,7 +80,7 @@ installed as follows::
     sudo apt-get update
     sudo apt-get install --no-install-recommends \
       libgl1-mesa-dri libqt4-dev libqt4-opengl-dev libqwt-dev \
-      libvtk-java libvtk5-qt4-dev python-lxml python-vtk xvfb
+      libvtk-java libvtk5-qt4-dev python-lxml python-scipy python-vtk xvfb
 
 Note that the above installs an old version of VTK that is required by Drake. If
 a different version needs to be installed, Drake's build system can be

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -100,6 +100,7 @@ python-gtk2
 python-html5lib
 python-lxml
 python-numpy
+python-scipy
 python-sphinx
 python-vtk
 python-yaml


### PR DESCRIPTION
scipy is a dependency of some director modules related to ik planning
which are imported when running director's robot tests.

Note, scipy is not a build dependency or a runtime dependency of
drake-visualizer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5150)
<!-- Reviewable:end -->
