### PR TITLE
Add playback to Drake visualizer

### DIFF
--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -76,9 +76,11 @@ drake_cc_library(
         "viewer_draw_translator.h",
     ],
     deps = [
+        "//drake/common/trajectories:piecewise_polynomial",
         "//drake/lcmtypes:viewer",
         "//drake/multibody:rigid_body_tree",
         "//drake/systems/lcm",
+        "//drake/systems/primitives:signal_log"
     ],
 )
 

--- a/drake/multibody/rigid_body_plant/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/CMakeLists.txt
@@ -32,7 +32,7 @@ endif ()
 set(lcm_dependent_link_libraries)
 set(lcm_dependent_requires)
 if (lcm_FOUND)
-  set(lcm_dependent_link_libraries drakeLcmSystem)
+  set(lcm_dependent_link_libraries drakeLcmSystem drakeSystemPrimitives)
   set(lcm_dependent_requires drake-lcm-system2)
 endif ()
 

--- a/drake/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 
+#include <chrono>
+#include <thread>
+
+
 namespace drake {
 namespace systems {
 
@@ -8,19 +12,89 @@ namespace {
 const int kPortIndex = 0;
 }  // namespace
 
-DrakeVisualizer::DrakeVisualizer(
-    const RigidBodyTree<double>& tree, drake::lcm::DrakeLcmInterface* lcm)
+DrakeVisualizer::DrakeVisualizer(const RigidBodyTree<double>& tree,
+                                 drake::lcm::DrakeLcmInterface* lcm,
+                                 bool record_for_playback)
     : lcm_(lcm),
       load_message_(CreateLoadMessage(tree)),
-      draw_message_translator_(tree) {
+      draw_message_translator_(tree),
+      has_playback_(record_for_playback) {
   set_name("drake_visualizer");
   const int vector_size =
       tree.get_num_positions() + tree.get_num_velocities();
   DeclareInputPort(kVectorValued, vector_size);
+  if (has_playback_) log_.reset(new SignalLog<double>(vector_size));
 }
 
 void DrakeVisualizer::set_publish_period(double period) {
   LeafSystem<double>::DeclarePublishPeriodSec(period);
+}
+
+void DrakeVisualizer::ReplayCachedSimulation() {
+  if (has_playback_) {
+    // Build piecewise polynomial
+    auto times = log_->sample_times();
+    // NOTE: The SignalLog can record signal for multiple identical time stamps.
+    //  This culls the duplicates as required by the PiecewisePolynomial.
+    std::vector<int> included_times;
+    included_times.reserve(times.rows());
+    std::vector<double> breaks;
+    included_times.push_back(0);
+    breaks.push_back(times(0));
+    int last = 0;
+    for (int i = 1; i < times.rows(); ++i) {
+      double val = times(i);
+      if (val != breaks[last]) {
+        breaks.push_back(val);
+        included_times.push_back(i);
+        ++last;
+      }
+    }
+
+    auto sample_data = log_->data();
+    std::vector<MatrixX<double>> knots;
+    knots.reserve(sample_data.cols());
+    for (int c : included_times) {
+      knots.push_back(sample_data.col(c));
+    }
+    auto func = PiecewisePolynomial<double>::ZeroOrderHold(breaks, knots);
+
+    RunPlaybackLoop(func, breaks[breaks.size() - 1]);
+  }
+}
+
+void DrakeVisualizer::RunPlaybackLoop(
+    const PiecewisePolynomial<double>& trajectory,
+    const double kMaxTime) const {
+  using Clock = std::chrono::steady_clock;
+  using Duration = std::chrono::duration<double>;
+  using TimePoint = std::chrono::time_point<Clock, Duration>;
+
+  // Target frame length at 60 Hz playback rate.
+  const double kFrameLength = 1 / 60.0;
+  double sim_time = 0;
+  TimePoint prev_time = Clock::now();
+  BasicVector<double> data(log_->get_input_size());
+  while (sim_time <= kMaxTime) {
+    data.set_value(trajectory.value(sim_time));
+
+    // Evaluate at time
+    // Translates the input vector into an array of bytes representing an LCM
+    // message.
+    std::vector<uint8_t> message_bytes;
+    draw_message_translator_.Serialize(sim_time, data,
+                                       &message_bytes);
+
+    // Publishes onto the specified LCM channel.
+    lcm_->Publish("DRAKE_VIEWER_DRAW", message_bytes.data(),
+                  message_bytes.size());
+
+    const TimePoint earliest_next_frame = prev_time + Duration(kFrameLength);
+    std::this_thread::sleep_until(earliest_next_frame);
+    TimePoint curr_time = Clock::now();
+    sim_time += (curr_time - prev_time).count();
+    prev_time = curr_time;
+  }
 }
 
 void DrakeVisualizer::DoPublish(const Context<double>& context) const {
@@ -38,6 +112,9 @@ void DrakeVisualizer::DoPublish(const Context<double>& context) const {
   // RigidBodyTree.
   const BasicVector<double>* input_vector = EvalVectorInput(context,
                                                             kPortIndex);
+  if (has_playback_) {
+    log_->AddData(context.get_time(), input_vector->get_value());
+  }
 
   // Translates the input vector into an array of bytes representing an LCM
   // message.

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -142,6 +142,17 @@ drake_cc_library(
     srcs = ["signal_logger.cc"],
     hdrs = ["signal_logger.h"],
     deps = [
+        ":signal_log",
+        "//drake/systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "signal_log",
+    srcs = ["signal_log.cc"],
+    hdrs = ["signal_log.h"],
+    linkstatic = 1,
+    deps = [
         "//drake/systems/framework",
     ],
 )

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -151,7 +151,6 @@ drake_cc_library(
     name = "signal_log",
     srcs = ["signal_log.cc"],
     hdrs = ["signal_log.h"],
-    linkstatic = 1,
     deps = [
         "//drake/systems/framework",
     ],

--- a/drake/systems/primitives/CMakeLists.txt
+++ b/drake/systems/primitives/CMakeLists.txt
@@ -12,6 +12,7 @@ set(sources
     multiplexer.cc
     pass_through.cc
     saturation.cc
+    signal_log.cc
     signal_logger.cc
     trajectory_source.cc
     zero_order_hold.cc)
@@ -33,6 +34,7 @@ drake_install_headers(
   pass_through-inl.h
   random_source.h
   saturation.h
+  signal_log.h
   signal_logger.h
   trajectory_source.h
   zero_order_hold.h

--- a/drake/systems/primitives/signal_log.cc
+++ b/drake/systems/primitives/signal_log.cc
@@ -1,0 +1,44 @@
+#include "drake/systems/primitives/signal_log.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+SignalLog<T>::SignalLog(int input_size, int batch_allocation_size)
+    : batch_allocation_size_(batch_allocation_size),
+      sample_times_(batch_allocation_size_),
+      data_(input_size, batch_allocation_size_) {
+  DRAKE_DEMAND(input_size > 0);
+  DRAKE_DEMAND(batch_allocation_size_ > 0);
+}
+
+template <typename T>
+void SignalLog<T>::AddData(T time, VectorX<T> sample) {
+  if (num_samples_ == 0 || time >= sample_times_(num_samples_ - 1))
+    ++num_samples_;
+
+  // If num_samples exceeds the current allocation, then do a conservative
+  // resize (ouch!).
+  // TODO(russt): change to allocating on a std::vector here and moving into a
+  // single block of contiguous memory on the (first) data access, to avoid the
+  // O(n^2) complexity.
+  if (num_samples_ > sample_times_.size()) {
+    sample_times_.conservativeResize(sample_times_.size() +
+        batch_allocation_size_);
+    data_.conservativeResize(data_.rows(),
+                             data_.cols() + batch_allocation_size_);
+  }
+
+  // Record time and input to the num_samples position.
+  sample_times_(num_samples_ - 1) = time;
+  data_.col(num_samples_ - 1) = sample;
+}
+
+template class SignalLog<double>;
+template class SignalLog<AutoDiffXd>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/primitives/signal_log.h
+++ b/drake/systems/primitives/signal_log.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace systems {
+
+/**
+ This class serves as an in-memory cache of the time-dependent vector values.
+
+ @tparam T The vector element type, which must be a valid Eigen scalar.
+ */
+template <typename T>
+class SignalLog {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SignalLog)
+
+  /** Construct the signal log.
+   @param input_size Dimension of the per-time step data set..
+   @param batch_allocation_size Storage is (re)allocated in
+   (input_size X batch_allocation_size)-sized blocks.
+  */
+  explicit SignalLog(int input_size, int batch_allocation_size = 1000);
+
+  /** Access the (simulation) time of the logged data. */
+  Eigen::VectorBlock<const VectorX<T>> sample_times() const {
+    return const_cast<const VectorX<T>&>(sample_times_).head(num_samples_);
+  }
+
+  /** Access the logged data. */
+  Eigen::Block<const MatrixX<T>, Eigen::Dynamic, Eigen::Dynamic, true> data()
+  const {
+    return const_cast<const MatrixX<T>&>(data_).leftCols(num_samples_);
+  }
+
+  /** Add a `sample` to the data set with the associated `time` value.
+
+   @param time      The time value for this sample.
+   @param sample    A vector of data of the declared size for this log.
+   */
+  void AddData(T time, VectorX<T> sample);
+
+  /** Reports the size of the log's input vector. */
+  int64_t get_input_size() const { return data_.rows(); }
+
+ private:
+  const int batch_allocation_size_{1000};
+
+  // Use mutable variables to hold the logged data.
+  mutable int num_samples_{0};
+  mutable VectorX<T> sample_times_;
+  mutable MatrixX<T> data_;
+};
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/primitives/signal_log.h
+++ b/drake/systems/primitives/signal_log.h
@@ -7,7 +7,7 @@ namespace drake {
 namespace systems {
 
 /**
- This class serves as an in-memory cache of the time-dependent vector values.
+ This class serves as an in-memory cache of time-dependent vector values.
 
  @tparam T The vector element type, which must be a valid Eigen scalar.
  */
@@ -16,25 +16,25 @@ class SignalLog {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SignalLog)
 
-  /** Construct the signal log.
-   @param input_size Dimension of the per-time step data set..
-   @param batch_allocation_size Storage is (re)allocated in
-   (input_size X batch_allocation_size)-sized blocks.
+  /** Constructs the signal log.
+   @param input_size                Dimension of the per-time step data set.
+   @param batch_allocation_size     Storage is (re)allocated in blocks of size
+                                    (input_size X batch_allocation_size).
   */
   explicit SignalLog(int input_size, int batch_allocation_size = 1000);
 
-  /** Access the (simulation) time of the logged data. */
+  /** Accesses the logged time stamps. */
   Eigen::VectorBlock<const VectorX<T>> sample_times() const {
     return const_cast<const VectorX<T>&>(sample_times_).head(num_samples_);
   }
 
-  /** Access the logged data. */
+  /** Accesses the logged data. */
   Eigen::Block<const MatrixX<T>, Eigen::Dynamic, Eigen::Dynamic, true> data()
   const {
     return const_cast<const MatrixX<T>&>(data_).leftCols(num_samples_);
   }
 
-  /** Add a `sample` to the data set with the associated `time` value.
+  /** Adds a `sample` to the data set with the associated `time` value.
 
    @param time      The time value for this sample.
    @param sample    A vector of data of the declared size for this log.
@@ -48,7 +48,7 @@ class SignalLog {
   const int batch_allocation_size_{1000};
 
   // Use mutable variables to hold the logged data.
-  mutable int num_samples_{0};
+  mutable int64_t num_samples_{0};
   mutable VectorX<T> sample_times_;
   mutable MatrixX<T> data_;
 };

--- a/drake/systems/primitives/signal_logger.cc
+++ b/drake/systems/primitives/signal_logger.cc
@@ -1,42 +1,18 @@
 #include "drake/systems/primitives/signal_logger.h"
 
-#include "drake/common/drake_assert.h"
-
 namespace drake {
 namespace systems {
 
 template <typename T>
 SignalLogger<T>::SignalLogger(int input_size, int batch_allocation_size)
-    : batch_allocation_size_(batch_allocation_size),
-      sample_times_(batch_allocation_size_),
-      data_(input_size, batch_allocation_size_) {
-  DRAKE_DEMAND(input_size > 0);
+    : log_(input_size, batch_allocation_size) {
   this->DeclareInputPort(kVectorValued, input_size);
-  DRAKE_DEMAND(batch_allocation_size_ > 0);
 }
 
 template <typename T>
 void SignalLogger<T>::DoPublish(const Context<T>& context) const {
-  T current_time = context.get_time();
-
-  if (num_samples_ == 0 || current_time >= sample_times_(num_samples_ - 1))
-    ++num_samples_;
-
-  // If num_samples exceeds the current allocation, then do a conservative
-  // resize (ouch!).
-  // TODO(russt): change to allocating on a std::vector here and moving into a
-  // single block of contiguous memory on the (first) data access, to avoid the
-  // O(n^2) complexity.
-  if (num_samples_ > sample_times_.size()) {
-    sample_times_.conservativeResize(sample_times_.size() +
-                                     batch_allocation_size_);
-    data_.conservativeResize(data_.rows(),
-                             data_.cols() + batch_allocation_size_);
-  }
-
-  // Record time and input to the num_samples position.
-  sample_times_(num_samples_ - 1) = current_time;
-  data_.col(num_samples_ - 1) = this->EvalVectorInput(context, 0)->get_value();
+  log_.AddData(context.get_time(),
+               this->EvalVectorInput(context, 0)->get_value());
 }
 
 template class SignalLogger<double>;

--- a/drake/systems/primitives/signal_logger.h
+++ b/drake/systems/primitives/signal_logger.h
@@ -7,6 +7,7 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/system_output.h"
+#include "drake/systems/primitives/signal_log.h"
 
 namespace drake {
 namespace systems {
@@ -34,13 +35,13 @@ class SignalLogger : public LeafSystem<T> {
 
   /// Access the (simulation) time of the logged data.
   Eigen::VectorBlock<const VectorX<T>> sample_times() const {
-    return const_cast<const VectorX<T>&>(sample_times_).head(num_samples_);
+    return log_.sample_times();
   }
 
   /// Access the logged data.
   Eigen::Block<const MatrixX<T>, Eigen::Dynamic, Eigen::Dynamic, true> data()
       const {
-    return const_cast<const MatrixX<T>&>(data_).leftCols(num_samples_);
+    return log_.data();
   }
 
  private:
@@ -51,12 +52,7 @@ class SignalLogger : public LeafSystem<T> {
   // Logging is done in this method.
   void DoPublish(const Context<T>& context) const override;
 
-  const int batch_allocation_size_{1000};
-
-  // Use mutable variables to hold the logged data.
-  mutable int num_samples_{0};
-  mutable VectorX<T> sample_times_;
-  mutable MatrixX<T> data_;
+  mutable SignalLog<T> log_;
 };
 
 }  // namespace systems


### PR DESCRIPTION
1) The `SignalLog` class handles the basic logic for caching the time-dependent
data.
2) `SignalLogger` and `DrakeVisualizer` both own an instance of SignalLog
3) `DrakeVisualizer` conditionally populates and replays the signal log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5152)
<!-- Reviewable:end -->
