### PR TITLE
Factor out MakeGeometryData.

### DIFF
--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -80,7 +80,8 @@ drake_cc_library(
         "//drake/lcmtypes:viewer",
         "//drake/multibody:rigid_body_tree",
         "//drake/systems/lcm",
-        "//drake/systems/primitives:signal_log"
+        "//drake/systems/primitives:signal_log",
+        "//drake/systems/rendering:drake_visualizer_client",
     ],
 )
 

--- a/drake/multibody/rigid_body_plant/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/CMakeLists.txt
@@ -32,8 +32,11 @@ endif ()
 set(lcm_dependent_link_libraries)
 set(lcm_dependent_requires)
 if (lcm_FOUND)
-  set(lcm_dependent_link_libraries drakeLcmSystem drakeSystemPrimitives)
-  set(lcm_dependent_requires drake-lcm-system2)
+  set(lcm_dependent_link_libraries
+    drakeLcmSystem
+    drakeSystemPrimitives
+    drakeRenderingLcm)
+  set(lcm_dependent_requires drake-lcm-system2 drake-rendering-lcm)
 endif ()
 
 add_library_with_exports(LIB_NAME drakeRigidBodyPlant SOURCE_FILES

--- a/drake/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.cc
@@ -4,6 +4,7 @@
 #include <thread>
 
 #include "drake/common/text_logging.h"
+#include "drake/systems/rendering/drake_visualizer_client.h"
 
 namespace drake {
 namespace systems {
@@ -161,85 +162,7 @@ lcmt_viewer_load_robot DrakeVisualizer::CreateLoadMessage(
     link.robot_num = body->get_model_instance_id();
     link.num_geom = body->get_visual_elements().size();
     for (const auto& visual_element : body->get_visual_elements()) {
-      lcmt_viewer_geometry_data geometry_data;
-      const DrakeShapes::Geometry& geometry = visual_element.getGeometry();
-
-      // TODO(liang.fok) Do this through virtual methods without introducing any
-      // LCM dependency on the Geometry classes.
-      //
-      // TODO(liang.fok) Add support for the DrakeShapes::MESH_POINTS type.
-      switch (visual_element.getShape()) {
-        case DrakeShapes::BOX: {
-          geometry_data.type = geometry_data.BOX;
-          geometry_data.num_float_data = 3;
-          auto box = dynamic_cast<const DrakeShapes::Box&>(geometry);
-          for (int i = 0; i < 3; ++i)
-            geometry_data.float_data.push_back(static_cast<float>(box.size(i)));
-          break;
-        }
-        case DrakeShapes::SPHERE: {
-          geometry_data.type = geometry_data.SPHERE;
-          geometry_data.num_float_data = 1;
-          auto sphere = dynamic_cast<const DrakeShapes::Sphere&>(geometry);
-          geometry_data.float_data.push_back(static_cast<float>(sphere.radius));
-          break;
-        }
-        case DrakeShapes::CYLINDER: {
-          geometry_data.type = geometry_data.CYLINDER;
-          geometry_data.num_float_data = 2;
-          auto cylinder = dynamic_cast<const DrakeShapes::Cylinder&>(geometry);
-          geometry_data.float_data.push_back(static_cast<float>(
-              cylinder.radius));
-          geometry_data.float_data.push_back(static_cast<float>(
-              cylinder.length));
-          break;
-        }
-        case DrakeShapes::MESH: {
-          geometry_data.type = geometry_data.MESH;
-          geometry_data.num_float_data = 3;
-          auto mesh = dynamic_cast<const DrakeShapes::Mesh&>(geometry);
-          geometry_data.float_data.push_back(static_cast<float>(
-              mesh.scale_[0]));
-          geometry_data.float_data.push_back(static_cast<float>(
-              mesh.scale_[1]));
-          geometry_data.float_data.push_back(static_cast<float>(
-              mesh.scale_[2]));
-
-          if (mesh.uri_.find("package://") == 0) {
-            geometry_data.string_data = mesh.uri_;
-          } else {
-            geometry_data.string_data = mesh.resolved_filename_;
-          }
-
-          break;
-        }
-        case DrakeShapes::CAPSULE: {
-          geometry_data.type = geometry_data.CAPSULE;
-          geometry_data.num_float_data = 2;
-          auto c = dynamic_cast<const DrakeShapes::Capsule&>(geometry);
-          geometry_data.float_data.push_back(static_cast<float>(c.radius));
-          geometry_data.float_data.push_back(static_cast<float>(c.length));
-          break;
-        }
-        default: {
-          // Intentionally do nothing.
-          break;
-        }
-      }
-
-      // Saves the location and orientation of the visualization geometry in the
-      // `lcmt_viewer_geometry_data` object. The location and orientation are
-      // specified in the body's frame.
-      Eigen::Isometry3d transform = visual_element.getLocalTransform();
-      Eigen::Map<Eigen::Vector3f> position(geometry_data.position);
-      position = transform.translation().cast<float>();
-      Eigen::Map<Eigen::Vector4f> quaternion(geometry_data.quaternion);
-      quaternion = math::rotmat2quat(transform.rotation()).cast<float>();
-
-      Eigen::Map<Eigen::Vector4f> color(geometry_data.color);
-      color = visual_element.getMaterial().template cast<float>();
-
-      link.geom.push_back(geometry_data);
+      link.geom.push_back(rendering::MakeGeometryData(visual_element));
     }
     load_message.link.push_back(link);
   }

--- a/drake/multibody/shapes/BUILD
+++ b/drake/multibody/shapes/BUILD
@@ -25,10 +25,10 @@ drake_cc_library(
     ],
 )
 
-drake_cc_googletest(
-    name = "mesh_triangulate_test",
-    srcs = ["test/mesh_triangulate_test.cc"],
-    data = [
+filegroup(
+    name = "test_models",
+    testonly = 1,
+    srcs = [
         "test/colinear_vertex.obj",
         "test/concave_face_bad.obj",
         "test/concave_face_good.obj",
@@ -37,6 +37,14 @@ drake_cc_googletest(
         "test/quad_cube.obj",
         "test/tiny_triangle.obj",
         "test/tri_cube.obj",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_triangulate_test",
+    srcs = ["test/mesh_triangulate_test.cc"],
+    data = [
+        ":test_models",
     ],
     deps = [
         ":shapes",

--- a/drake/systems/rendering/BUILD
+++ b/drake/systems/rendering/BUILD
@@ -29,11 +29,35 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "drake_visualizer_client",
+    srcs = ["drake_visualizer_client.cc"],
+    hdrs = ["drake_visualizer_client.h"],
+    deps = [
+        "@eigen//:eigen",
+        "//drake/lcmtypes:viewer",
+        "//drake/math:geometric_transform",
+        "//drake/multibody/shapes",
+    ],
+)
+
 drake_cc_googletest(
     name = "pose_aggregator_test",
     deps = [
         ":pose_aggregator",
         "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "drake_visualizer_client_test",
+    data = [
+        "//drake/multibody/shapes:test_models",
+    ],
+    deps = [
+        ":drake_visualizer_client",
+        "//drake/common:drake_path",
+        "//drake/lcmtypes:viewer",
     ],
 )
 

--- a/drake/systems/rendering/CMakeLists.txt
+++ b/drake/systems/rendering/CMakeLists.txt
@@ -11,7 +11,29 @@ drake_install_headers(
     pose_bundle.h)
 drake_install_pkg_config_file(drake-rendering
     TARGET drakeRendering
-    LIBS -ldrakeRendering)
+    LIBS -ldrakeRendering
+    REQUIRES
+        drake-rbm
+        drake-system-framework
+)
+
+if(lcm_FOUND)
+  add_library_with_exports(LIB_NAME drakeRenderingLcm SOURCE_FILES
+      drake_visualizer_client.cc)
+
+  drake_install_libraries(drakeRenderingLcm)
+  target_link_libraries(drakeRenderingLcm
+      drakeLCMTypes drakeShapes)
+  drake_install_headers(
+      drake_visualizer_client.h)
+  drake_install_pkg_config_file(drake-rendering-lcm
+      TARGET drakeRenderingLcm
+      LIBS -ldrakeRenderingLcm
+      REQUIRES
+          drake_lcmtypes
+          drake-shapes
+  )
+endif()
 
 if(BUILD_TESTING)
     add_subdirectory(test)

--- a/drake/systems/rendering/drake_visualizer_client.cc
+++ b/drake/systems/rendering/drake_visualizer_client.cc
@@ -1,0 +1,89 @@
+#include "drake/systems/rendering/drake_visualizer_client.h"
+
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace systems {
+namespace rendering {
+
+lcmt_viewer_geometry_data MakeGeometryData(
+    const DrakeShapes::VisualElement& visual_element) {
+  lcmt_viewer_geometry_data geometry_data;
+  const DrakeShapes::Geometry& geometry = visual_element.getGeometry();
+
+  // TODO(liang.fok) Do this through virtual methods without introducing any
+  // LCM dependency on the Geometry classes.
+  //
+  // TODO(liang.fok) Add support for the DrakeShapes::MESH_POINTS type.
+  switch (visual_element.getShape()) {
+    case DrakeShapes::BOX: {
+      geometry_data.type = geometry_data.BOX;
+      geometry_data.num_float_data = 3;
+      auto box = dynamic_cast<const DrakeShapes::Box&>(geometry);
+      for (int i = 0; i < 3; ++i)
+        geometry_data.float_data.push_back(static_cast<float>(box.size(i)));
+      break;
+    }
+    case DrakeShapes::SPHERE: {
+      geometry_data.type = geometry_data.SPHERE;
+      geometry_data.num_float_data = 1;
+      auto sphere = dynamic_cast<const DrakeShapes::Sphere&>(geometry);
+      geometry_data.float_data.push_back(static_cast<float>(sphere.radius));
+      break;
+    }
+    case DrakeShapes::CYLINDER: {
+      geometry_data.type = geometry_data.CYLINDER;
+      geometry_data.num_float_data = 2;
+      auto cylinder = dynamic_cast<const DrakeShapes::Cylinder&>(geometry);
+      geometry_data.float_data.push_back(static_cast<float>(cylinder.radius));
+      geometry_data.float_data.push_back(static_cast<float>(cylinder.length));
+      break;
+    }
+    case DrakeShapes::MESH: {
+      geometry_data.type = geometry_data.MESH;
+      geometry_data.num_float_data = 3;
+      auto mesh = dynamic_cast<const DrakeShapes::Mesh&>(geometry);
+      geometry_data.float_data.push_back(static_cast<float>(mesh.scale_[0]));
+      geometry_data.float_data.push_back(static_cast<float>(mesh.scale_[1]));
+      geometry_data.float_data.push_back(static_cast<float>(mesh.scale_[2]));
+
+      if (mesh.uri_.find("package://") == 0) {
+        geometry_data.string_data = mesh.uri_;
+      } else {
+        geometry_data.string_data = mesh.resolved_filename_;
+      }
+
+      break;
+    }
+    case DrakeShapes::CAPSULE: {
+      geometry_data.type = geometry_data.CAPSULE;
+      geometry_data.num_float_data = 2;
+      auto c = dynamic_cast<const DrakeShapes::Capsule&>(geometry);
+      geometry_data.float_data.push_back(static_cast<float>(c.radius));
+      geometry_data.float_data.push_back(static_cast<float>(c.length));
+      break;
+    }
+    default: {
+      // Intentionally do nothing.
+      break;
+    }
+  }
+
+  // Saves the location and orientation of the visualization geometry in the
+  // `lcmt_viewer_geometry_data` object. The location and orientation are
+  // specified in the body's frame.
+  Eigen::Isometry3d transform = visual_element.getLocalTransform();
+  Eigen::Map<Eigen::Vector3f> position(geometry_data.position);
+  position = transform.translation().cast<float>();
+  Eigen::Map<Eigen::Vector4f> quaternion(geometry_data.quaternion);
+  quaternion = math::rotmat2quat(transform.rotation()).cast<float>();
+
+  Eigen::Map<Eigen::Vector4f> color(geometry_data.color);
+  color = visual_element.getMaterial().template cast<float>();
+
+  return geometry_data;
+}
+
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/rendering/drake_visualizer_client.h
+++ b/drake/systems/rendering/drake_visualizer_client.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "drake/lcmt_viewer_geometry_data.hpp"
+#include "drake/multibody/shapes/visual_element.h"
+
+/// @file Utilities for implementing the Drake Visualizer Interface. This is
+/// the oldest supported interface in the RobotLocomotion/director GUI called
+/// drake-visualizer. It uses LCM messages, and conventionally communicates on
+/// LCM channels named DRAKE_VIEWER_DRAW and DRAKE_VIEWER_LOAD_ROBOT.
+///
+/// The Drake Visualizer Interface is distinct from, and should not be confused
+/// with, the newer Remote Tree Viewer Interface, which was introduced in
+/// https://github.com/RobotLocomotion/director/pull/420.
+
+namespace drake {
+namespace systems {
+namespace rendering {
+
+/// Returns an lcmt_viewer_geometry_message with contents that mirror the
+/// @p visual_element.
+lcmt_viewer_geometry_data MakeGeometryData(
+    const DrakeShapes::VisualElement& visual_element);
+
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/rendering/test/CMakeLists.txt
+++ b/drake/systems/rendering/test/CMakeLists.txt
@@ -1,2 +1,7 @@
 drake_add_cc_test(pose_aggregator_test)
 target_link_libraries(pose_aggregator_test drakeRendering)
+
+if(lcm_FOUND)
+  drake_add_cc_test(drake_visualizer_client_test)
+  target_link_libraries(drake_visualizer_client_test drakeRenderingLcm drakeLCMTypes)
+endif()

--- a/drake/systems/rendering/test/drake_visualizer_client_test.cc
+++ b/drake/systems/rendering/test/drake_visualizer_client_test.cc
@@ -1,0 +1,125 @@
+#include "drake/systems/rendering/drake_visualizer_client.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/common/drake_path.h"
+#include "drake/lcmt_viewer_geometry_data.hpp"
+#include "drake/multibody/shapes/visual_element.h"
+
+namespace drake {
+namespace systems {
+namespace rendering {
+namespace {
+
+class MakeGeometryDataTest : public ::testing::Test {
+ protected:
+  /// Expects that the position and quaternion in the given @p geometry_data
+  /// are an identity transform, and the color is a vector of ones.
+  static void VerifyPositionQuaternionAndColor(
+      const lcmt_viewer_geometry_data &geometry_data) {
+    for (int i = 0; i < 3; ++i) {
+      EXPECT_EQ(0.0, geometry_data.position[i]);  // x, y, z
+    }
+    EXPECT_EQ(1.0, geometry_data.quaternion[0]);  // w
+    for (int i = 1; i < 4; ++i) {
+      EXPECT_EQ(0.0, geometry_data.quaternion[i]);  // x, y, z
+    }
+    for (int i = 0; i < 4; ++i) {
+      EXPECT_EQ(1.0, geometry_data.color[i]);
+    }
+  }
+
+  // This circumlocution is necessary because EXPECT_EQ takes the address of
+  // its arguments, and LCM enums are static variables with no linkage.
+  static void VerifyGeometryType(int8_t expected_type, int8_t actual_type) {
+    EXPECT_EQ(expected_type, actual_type);
+  }
+
+  Eigen::Isometry3d transform_ = Eigen::Isometry3d::Identity();
+  Eigen::Vector4d color_ = Eigen::Vector4d::Ones();
+};
+
+TEST_F(MakeGeometryDataTest, Box) {
+  const DrakeShapes::VisualElement box(
+      DrakeShapes::Box(Eigen::Vector3d({1.0, 2.0, 3.0})), transform_, color_);
+
+  lcmt_viewer_geometry_data geometry_data(MakeGeometryData(box));
+
+
+  VerifyGeometryType(lcmt_viewer_geometry_data::BOX, geometry_data.type);
+  ASSERT_EQ(3, geometry_data.num_float_data);
+  EXPECT_EQ(1.0, geometry_data.float_data[0]);
+  EXPECT_EQ(2.0, geometry_data.float_data[1]);
+  EXPECT_EQ(3.0, geometry_data.float_data[2]);
+  VerifyPositionQuaternionAndColor(geometry_data);
+}
+
+TEST_F(MakeGeometryDataTest, Sphere) {
+  const double radius = 5.0;
+  const DrakeShapes::VisualElement sphere(DrakeShapes::Sphere(radius),
+                                          transform_, color_);
+
+  lcmt_viewer_geometry_data geometry_data(MakeGeometryData(sphere));
+
+  // This circumlocution is necessary because EXPECT_EQ takes the address of
+  // its arguments, and LCM enums are static variables with no linkage.
+  VerifyGeometryType(lcmt_viewer_geometry_data::SPHERE, geometry_data.type);
+  ASSERT_EQ(1, geometry_data.num_float_data);
+  EXPECT_EQ(radius, geometry_data.float_data[0]);
+  VerifyPositionQuaternionAndColor(geometry_data);
+}
+
+TEST_F(MakeGeometryDataTest, Cylinder) {
+  const double radius = 1.0;
+  const double length = 2.0;
+  const DrakeShapes::VisualElement cylinder(
+      DrakeShapes::Cylinder(radius, length), transform_, color_);
+
+  lcmt_viewer_geometry_data geometry_data(MakeGeometryData(cylinder));
+
+  VerifyGeometryType(lcmt_viewer_geometry_data::CYLINDER, geometry_data.type);
+  ASSERT_EQ(2, geometry_data.num_float_data);
+  EXPECT_EQ(radius, geometry_data.float_data[0]);
+  EXPECT_EQ(length, geometry_data.float_data[1]);
+  VerifyPositionQuaternionAndColor(geometry_data);
+}
+
+TEST_F(MakeGeometryDataTest, Capsule) {
+  const double radius = 1.0;
+  const double length = 2.0;
+  const DrakeShapes::VisualElement capsule(DrakeShapes::Capsule(radius, length),
+                                           transform_, color_);
+
+  lcmt_viewer_geometry_data geometry_data(MakeGeometryData(capsule));
+
+  VerifyGeometryType(lcmt_viewer_geometry_data::CAPSULE, geometry_data.type);
+  ASSERT_EQ(2, geometry_data.num_float_data);
+  EXPECT_EQ(radius, geometry_data.float_data[0]);
+  EXPECT_EQ(length, geometry_data.float_data[1]);
+  VerifyPositionQuaternionAndColor(geometry_data);
+}
+
+TEST_F(MakeGeometryDataTest, Mesh) {
+  const std::string kFileName =
+      drake::GetDrakePath() + "/multibody/shapes/test/quad_cube.obj";
+  const DrakeShapes::VisualElement mesh(
+      DrakeShapes::Mesh("arbitrary_identifier", kFileName), transform_, color_);
+
+  lcmt_viewer_geometry_data geometry_data(MakeGeometryData(mesh));
+
+  VerifyGeometryType(lcmt_viewer_geometry_data::MESH, geometry_data.type);
+  const std::string string_data(geometry_data.string_data);
+  // Expect that the message string contains the filename.
+  EXPECT_LT(string_data.rfind("quad_cube.obj"), string_data.length());
+  ASSERT_EQ(3, geometry_data.num_float_data);
+  // Expect unit scale.
+  EXPECT_EQ(1.0, geometry_data.float_data[0]);
+  EXPECT_EQ(1.0, geometry_data.float_data[1]);
+  EXPECT_EQ(1.0, geometry_data.float_data[2]);
+  VerifyPositionQuaternionAndColor(geometry_data);
+}
+
+}  // namespace
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
We're going to reuse it in code that sends aggregated poses to DrakeVisualizer without reference to RigidBodyTree.

@liangfok for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5170)
<!-- Reviewable:end -->
