### PR TITLE
Remove string constructor of Expression

### DIFF
--- a/drake/common/symbolic_expression.cc
+++ b/drake/common/symbolic_expression.cc
@@ -63,8 +63,6 @@ Expression NegateMultiplication(const Expression& e) {
 
 Expression::Expression(const Variable& var)
     : ptr_{make_shared<ExpressionVar>(var)} {}
-Expression::Expression(const string& name)
-    : ptr_{make_shared<ExpressionVar>(Variable{name})} {}
 Expression::Expression(const double d) : ptr_{make_cell(d)} {}
 Expression::Expression(const shared_ptr<ExpressionCell> ptr) : ptr_{ptr} {}
 

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -150,9 +150,8 @@ class Expression {
   // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
   Expression(double d);
   /** Constructs a variable expression from Variable. */
-  explicit Expression(const Variable& var);
-  /** Constructs a variable expression from string @p name. */
-  explicit Expression(const std::string& name);
+  // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
+  Expression(const Variable& var);
   /** Returns expression kind. */
   ExpressionKind get_kind() const;
   /** Returns hash value. */

--- a/drake/systems/framework/sparsity_matrix.cc
+++ b/drake/systems/framework/sparsity_matrix.cc
@@ -18,7 +18,7 @@ SparsityMatrix::SparsityMatrix(const System<symbolic::Expression>& system)
   if (context_is_abstract_) return;
 
   // Time
-  context_->set_time(symbolic::Expression("t"));
+  context_->set_time(symbolic::Variable("t"));
 
   // Input
   InitializeVectorInputs(system);
@@ -52,7 +52,7 @@ void SparsityMatrix::InitializeVectorInputs(
     for (int j = 0; j < n; ++j) {
       std::ostringstream name;
       name << "u" << i << "_" << j;
-      value->SetAtIndex(j, symbolic::Expression(name.str()));
+      value->SetAtIndex(j, symbolic::Variable(name.str()));
       // Save a copy of the input expression.
       input_expressions_[i].push_back(value->GetAtIndex(j));
     }
@@ -68,7 +68,7 @@ void SparsityMatrix::InitializeContinuousState() {
   for (int i = 0; i < xc.size(); ++i) {
     std::ostringstream name;
     name << "xc" << i;
-    xc[i] = symbolic::Expression(name.str());
+    xc[i] = symbolic::Variable(name.str());
   }
 }
 
@@ -81,7 +81,7 @@ void SparsityMatrix::InitializeDiscreteState() {
     for (int j = 0; j < xdi.size(); ++j) {
       std::ostringstream name;
       name << "xd" << i << "_" << j;
-      xdi[j] = symbolic::Expression(name.str());
+      xdi[j] = symbolic::Variable(name.str());
     }
   }
 }

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -50,10 +50,13 @@ GTEST_TEST(BasicVectorTest, SymbolicInitiallyNaN) {
 // Tests that BasicVector<symbolic::Expression>::Make does what it says on
 // the tin.
 GTEST_TEST(BasicVectorTest, MakeSymbolic) {
-  auto vec = BasicVector<symbolic::Expression>::Make("x", "y", "z");
+  auto vec = BasicVector<symbolic::Expression>::Make(
+      symbolic::Variable("x"),
+      2.0,
+      symbolic::Variable("y") + 2.0);
   EXPECT_EQ("x", vec->GetAtIndex(0).to_string());
-  EXPECT_EQ("y", vec->GetAtIndex(1).to_string());
-  EXPECT_EQ("z", vec->GetAtIndex(2).to_string());
+  EXPECT_EQ("2", vec->GetAtIndex(1).to_string());
+  EXPECT_EQ("(2 + y)", vec->GetAtIndex(2).to_string());
 }
 
 // Tests that the BasicVector has a size as soon as it is constructed.

--- a/drake/systems/primitives/test/integrator_test.cc
+++ b/drake/systems/primitives/test/integrator_test.cc
@@ -102,12 +102,15 @@ class SymbolicIntegratorTest : public IntegratorTest {
 
     ASSERT_EQ(1, symbolic_context_->get_num_input_ports());
     symbolic_context_->FixInputPort(
-        0, BasicVector<symbolic::Expression>::Make("u0", "u1", "u2"));
+        0, BasicVector<symbolic::Expression>::Make(
+            symbolic::Variable("u0"),
+            symbolic::Variable("u1"),
+            symbolic::Variable("u2")));
 
     auto& xc = *symbolic_context_->get_mutable_continuous_state_vector();
-    xc[0] = symbolic::Expression("x0");
-    xc[1] = symbolic::Expression("x1");
-    xc[2] = symbolic::Expression("x2");
+    xc[0] = symbolic::Variable("x0");
+    xc[1] = symbolic::Variable("x1");
+    xc[2] = symbolic::Variable("x2");
   }
 
   std::unique_ptr<System<symbolic::Expression>> symbolic_integrator_;


### PR DESCRIPTION
The overload is too easy to abuse or accidentally misuse, especially because so many things can match the implicit string constructors.  Variables are special (have ~identity~ _nonce_ equality, not value equality) so must always be created with care.

Replaces #4935.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5174)
<!-- Reviewable:end -->
