### PR TITLE
Add missing include to cond.h

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -37,6 +37,10 @@ drake_cc_library(
 drake_cc_library(
     name = "cond",
     hdrs = ["cond.h"],
+    srcs = ["cond.cc"],
+    deps = [
+        ":double",
+    ],
 )
 
 drake_cc_library(
@@ -265,6 +269,13 @@ drake_cc_googletest(
     name = "reinit_after_move_test",
     deps = [
         ":reinit_after_move",
+    ],
+)
+
+drake_cc_googletest(
+    name = "cond_test",
+    deps = [
+        ":cond",
     ],
 )
 

--- a/drake/common/cond.cc
+++ b/drake/common/cond.cc
@@ -1,0 +1,4 @@
+#include "drake/common/cond.h"
+
+// For now, this is an empty .cc file that only serves to confirm that cond.h
+// is a stand-alone header.

--- a/drake/common/cond.h
+++ b/drake/common/cond.h
@@ -3,6 +3,8 @@
 #include <functional>
 #include <type_traits>
 
+#include "drake/common/double_overloads.h"
+
 namespace drake {
 /** @name cond
   Constructs conditional expression (similar to Lisp's cond).

--- a/drake/common/test/cond_test.cc
+++ b/drake/common/test/cond_test.cc
@@ -1,0 +1,19 @@
+#include "drake/common/cond.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/common/double_overloads.h"
+
+namespace drake {
+namespace {
+
+// Mostly, this just checks for compilation failures.
+GTEST_TEST(CondTest, BasicTest) {
+  const double x = cond(true, 1, 2);
+  const double y = cond(false, 3, 4);
+  EXPECT_EQ(x, 1);
+  EXPECT_EQ(y, 4);
+}
+
+}  // namespace
+}  // namespace drake


### PR DESCRIPTION
The unit test does not compile when the include is absent.

I noticed this when using `cond` in `SimpleCar` in a feature branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5176)
<!-- Reviewable:end -->
