### PR TITLE
Specify lint tools as absolute labels.

### DIFF
--- a/tools/cpplint.bzl
+++ b/tools/cpplint.bzl
@@ -57,7 +57,7 @@ def _add_linter_rules(source_labels, source_filenames, name, data=None):
     srcs = ["@google_styleguide//:cpplint"],
     data = data + cpplint_cfg + source_labels,
     args = _EXTENSIONS_ARGS + source_filenames,
-    main = "cpplint.py",
+    main = "@google_styleguide//:cpplint/cpplint.py",
     size = size,
     tags = tags,
   )
@@ -68,7 +68,7 @@ def _add_linter_rules(source_labels, source_filenames, name, data=None):
     srcs = ["//tools:drakelint"],
     data = data + source_labels,
     args = source_filenames,
-    main = "drakelint.py",
+    main = "//tools:drakelint.py",
     size = size,
     tags = tags,
   )


### PR DESCRIPTION
This better conforms with the py_test documentation, and prevents `//drake/foo:all-targets` from treating `cpplint.py` as a package-local file, which it isn't.

https://bazel.build/versions/master/docs/be/python.html#py_test

Fixes #5180.

@soonho-tri feature, @jwnimmer-tri platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5181)
<!-- Reviewable:end -->
