### PR TITLE
Polishes Doxygen comment in enless_road_oracle.

### DIFF
--- a/drake/automotive/dev/endless_road_oracle.h
+++ b/drake/automotive/dev/endless_road_oracle.h
@@ -36,9 +36,12 @@ namespace automotive {
 ///    vehicle will be treated as blocked until clear.
 ///
 /// The underlying algorithm is independent for each vehicle, in the sense
-/// that:
+/// that for each Sensing-Car:
+///
+/// <pre>
 ///   Sensor-Output = F(State-of-Sensing-Car, State-of-All-Other-Cars)
-///                   for each Sensing-Car
+/// </pre>
+///
 /// Even though there are no dependencies between sensor outputs (e.g.,
 /// explicitly mediated turntaking), this class computes the sensor-output for
 /// all cars at once for the sake of efficiency.


### PR DESCRIPTION
# Before
Without this, the Doxygen-generated website looks odd, as shown below.

![screenshot from 2017-02-16 13 27 59](https://cloud.githubusercontent.com/assets/1388098/23035004/c01c5604-f44b-11e6-9b74-b2bc846a3d22.png)

# After
Here's how it looks with the changes in this PR:

![screenshot from 2017-02-16 13 49 38](https://cloud.githubusercontent.com/assets/1388098/23035908/cea392c0-f44e-11e6-865c-1a9f823c5d85.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5194)
<!-- Reviewable:end -->
