### PR TITLE
Use symbolic sparsity for direct-feedthrough analysis

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -226,6 +226,7 @@ drake_cc_library(
     hdrs = ["leaf_system.h"],
     deps = [
         ":leaf_context",
+        ":sparsity_matrix",
         ":system",
         "//drake/common",
         "//drake/common:number_traits",

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -173,20 +173,68 @@ class Diagram : public System<T>,
     return result;
   }
 
-  /// Returns true if any output of the Diagram might have direct-feedthrough
-  /// from any input of the Diagram.
+  /// This method is DEPRECATED. Legacy overrides will be respected for now,
+  /// but will be deleted as soon as automatic analysis can replicate them.
+  /// There will thereafter be no manual override for the direct feedthrough
+  /// properties of a Diagram: developers will be required to express the
+  /// direct feedthrough properties of each constituent System correctly, which
+  /// will enable the Diagram to deduce its own direct-feedthrough properties
+  /// without manual intervention.
+  ///
+  /// Returns `true` as a conservative default.
   bool has_any_direct_feedthrough() const override {
-    // TODO(david-german-tri, bradking): Make this less conservative once the
-    // sparsity matrix is available.
+    return true;
+  }
 
-    // For each output, see whether it has direct feedthrough all the way back
-    // to any input.
-    for (const auto& output_port_id : output_port_ids_) {
-      if (HasDirectFeedthroughFromAnyInput(output_port_id)) {
+  /// Returns true if any output of the Diagram might have direct-feedthrough
+  /// from any input of the Diagram. The implementation is quite conservative:
+  /// it will return true if there is any path on the directed acyclic graph
+  /// of subsystems that begins at any input port to the Diagram, and ends at
+  /// any System producing an output port of the Diagram, such that every System
+  /// in that path HasAnyDirectFeedthrough.
+  ///
+  /// TODO(david-german-tri): Improve the implementation by inspecting the
+  /// fine-grained HasDirectFeedthrough(input_port, output_port) relationships
+  /// of the subsystems.
+  bool HasAnyDirectFeedthrough() const final {
+    // Respect legacy overrides.
+    if (!has_any_direct_feedthrough()) return false;
+
+    for (int i = 0; i < this->get_num_output_ports(); i++) {
+      if (HasDirectFeedthrough(i)) {
         return true;
       }
     }
     return false;
+  }
+
+  /// Returns true if the given @p output_port of the Diagram might have
+  /// direct-feedthrough from any input of the Diagram. The implementation is
+  /// quite conservative: it will return true if there is any path on the
+  /// directed acyclic graph of subsystems that begins at any input port to
+  /// the Diagram, and ends at the system producing the given @p output_port,
+  /// such that every System in that path HasAnyDirectFeedthrough.
+  ///
+  /// TODO(david-german-tri): Improve the implementation by inspecting the
+  /// fine-grained HasDirectFeedthrough(input_port, output_port) relationships
+  /// of the subsystems.
+  bool HasDirectFeedthrough(int output_port) const final {
+    // Respect legacy overrides.
+    if (!has_any_direct_feedthrough()) return false;
+
+    DRAKE_ASSERT(output_port >= 0);
+    DRAKE_ASSERT(output_port < this->get_num_output_ports());
+    return HasDirectFeedthroughFromAnyInput(output_port_ids_[output_port]);
+  }
+
+  /// Aborts.
+  /// Once this is implemented, the following comment will apply:
+  ///
+  /// Returns true if there might be direct feedthrough from the given
+  /// @p input_port of the Diagram to the given @p output_port of the Diagram.
+  bool HasDirectFeedthrough(int input_port, int output_port) const final {
+    DRAKE_ABORT_MSG("The two-argument version of HasDirectFeedthrough is "
+                    "not yet implemented for Diagrams.");
   }
 
   std::unique_ptr<Context<T>> AllocateContext() const override {
@@ -957,7 +1005,7 @@ class Diagram : public System<T>,
       // If the destination system has no direct feedthrough, it does not
       // matter whether it is sorted before or after the systems on which
       // it depends.
-      if (!dest->has_any_direct_feedthrough()) {
+      if (!dest->HasAnyDirectFeedthrough()) {
         continue;
       }
       if (GetSystemIndexOrAbort(dest) <= GetSystemIndexOrAbort(src)) {
@@ -967,17 +1015,19 @@ class Diagram : public System<T>,
     return true;
   }
 
-  // Checks whether any input port of the Diagram feeds directly through to the
-  // given @p output_port_id.
+  // Returns true if any input port of the Diagram might feed directly through
+  // to the given @p output_port_id, which is an output port of some subsystem
+  // of the Diagram.
   bool HasDirectFeedthroughFromAnyInput(
       const PortIdentifier& output_port_id) const {
-    // TODO(david-german-tri, bradking): This can be made less conservative
-    // once the sparsity matrix is available.
+    // TODO(david-german-tri): Make this less conservative by checking only
+    // HasAnyDirectFeedthrough(input, output), i.e. inspecting the graph of
+    // ports, not the graph of systems.
 
     // If the system producing output_port_id has no direct-feedthrough, then
     // there is definitely no direct-feedthrough to output_port_id.
     const System<T>* system = output_port_id.first;
-    if (!system->has_any_direct_feedthrough()) {
+    if (!system->HasAnyDirectFeedthrough()) {
       return false;
     }
 

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -220,13 +220,39 @@ class DiagramBuilder {
     for (const auto& connection : dependency_graph_) {
       const System<T>* src = connection.second.first;
       const System<T>* dest = connection.first.first;
-      // If a system is not direct-feedthrough, the connections to its inputs
-      // are not relevant for detecting algebraic loops or determining
-      // execution order.
-      //
       // TODO(david-german-tri): Make direct-feedthrough resolution more
-      // fine-grained once #3170 is resolved.
-      if (dest->has_any_direct_feedthrough()) {
+      // fine-grained once #2890 is resolved. Until then, avoiding false
+      // positives in algebraic loop detection here would simply lead to
+      // spurious infinite loops at diagram execution time.
+      //
+      // To understand this, consider the following diagram:
+      //
+      //  input A0--[A]-----output A0--input B0-X---[B]--output B0-|
+      //     ^          |-X-output A1--input B1---|                |
+      //     |-----------------------------------------------------|
+      //
+      // Suppose there is direct feedthrough from input A0 to output A0, but not
+      // output A1.  Similarly, suppose there is direct feedthrough from input
+      // B1 to output B0, but not from input B0 to output B0. (The X character
+      // above indicates absence of direct-feedthrough.) There is no algebraic
+      // loop in this diagram, and we could detect that there is no algebraic
+      // loop at diagram build time. To detect it, we would construct a graph
+      // where the vertices are input and output ports, and the edges are
+      // direct-feedthrough connections (input to output) and Diagram edges
+      // (output to input). Observing that this graph contains no cycles is
+      // equivalent to observing that there is no algebraic loop.
+      //
+      // However, this observation does us no good without per-port evaluation
+      // from #2890, because #3455 made the execution order implicit instead of
+      // explicit. When we need to compute input A0, we will pull on output B0,
+      // which will pull on both outputs of A. Pulling on output A0 in
+      // particular will spuriously pull on input A0, yielding an infinite loop.
+      //
+      // Consequently, this function remains for now a topological sort of
+      // Systems, not of ports, and we must restrict ourselves to considering
+      // an entire System direct-feedthrough if it has direct feedthrough from
+      // any input to any output.
+      if (dest->HasAnyDirectFeedthrough()) {
         dependents[src].insert(dest);
         dependencies[dest].insert(src);
       }

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -186,7 +186,11 @@ TEST_F(DiagramTest, Topology) {
   }
 
   // The diagram has direct feedthrough.
-  EXPECT_TRUE(diagram_->has_any_direct_feedthrough());
+  EXPECT_TRUE(diagram_->HasAnyDirectFeedthrough());
+  // Specifically, outputs 0 and 1 have direct feedthrough, but not output 2.
+  EXPECT_TRUE(diagram_->HasDirectFeedthrough(0));
+  EXPECT_TRUE(diagram_->HasDirectFeedthrough(1));
+  EXPECT_FALSE(diagram_->HasDirectFeedthrough(2));
 }
 
 TEST_F(DiagramTest, Path) {
@@ -584,7 +588,7 @@ class FeedbackDiagram : public Diagram<double> {
 // Tests that since there are no outputs, there is no direct feedthrough.
 GTEST_TEST(FeedbackDiagramTest, HasDirectFeedthrough) {
   FeedbackDiagram diagram;
-  EXPECT_FALSE(diagram.has_any_direct_feedthrough());
+  EXPECT_FALSE(diagram.HasAnyDirectFeedthrough());
 }
 
 // Tests that a FeedbackDiagram's context can be deleted without accessing

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -55,6 +55,17 @@ class TestSystem : public System<double> {
     return this->DeclareAbstractOutputPort();
   }
 
+  bool HasAnyDirectFeedthrough() const override {
+    return true;
+  }
+
+  bool HasDirectFeedthrough(int output_port) const override {
+    return true;
+  }
+
+  bool HasDirectFeedthrough(int input_port, int output_port) const override {
+    return true;
+  }
 
   int get_publish_count() const { return publish_count_; }
   int get_update_count() const { return update_count_; }
@@ -140,26 +151,6 @@ class SystemTest : public ::testing::Test {
   TestSystem system_;
   LeafContext<double> context_;
 };
-
-TEST_F(SystemTest, Feedthrough) {
-  // No inputs or outputs.
-  EXPECT_FALSE(system_.has_any_direct_feedthrough());
-
-  // Both inputs and outputs.
-  system_.AddAbstractInputPort();
-  system_.AddAbstractOutputPort();
-  EXPECT_TRUE(system_.has_any_direct_feedthrough());
-
-  // Only inputs.
-  TestSystem input_only;
-  input_only.AddAbstractInputPort();
-  EXPECT_FALSE(input_only.has_any_direct_feedthrough());
-
-  // Only outputs.
-  TestSystem output_only;
-  output_only.AddAbstractOutputPort();
-  EXPECT_FALSE(output_only.has_any_direct_feedthrough());
-}
 
 TEST_F(SystemTest, MapVelocityToConfigurationDerivatives) {
   auto state_vec1 = BasicVector<double>::Make({1.0, 2.0, 3.0});
@@ -325,6 +316,18 @@ class ValueIOTestSystem : public System<double> {
                        State<double>* state) const override {}
 
   void SetDefaults(Context<double>* context) const override {}
+
+  bool HasAnyDirectFeedthrough() const override {
+    return true;
+  }
+
+  bool HasDirectFeedthrough(int output_port) const override {
+    return true;
+  }
+
+  bool HasDirectFeedthrough(int input_port, int output_port) const override {
+    return true;
+  }
 
   // Append "output" to input(0), and sets output(1) = 2 * input(1).
   void DoCalcOutput(const Context<double>& context,

--- a/drake/systems/primitives/integrator.cc
+++ b/drake/systems/primitives/integrator.cc
@@ -32,14 +32,6 @@ void Integrator<T>::set_integral_value(
   state_vector->SetFromVector(value);
 }
 
-// TODO(amcastro-tri): we should be able to express that initial conditions
-// feed through an integrator but the dynamic signal during simulation does
-// not.
-template <typename T>
-bool Integrator<T>::has_any_direct_feedthrough() const {
-  return false;
-}
-
 template <typename T>
 std::unique_ptr<ContinuousState<T>> Integrator<T>::AllocateContinuousState()
     const {

--- a/drake/systems/primitives/integrator.h
+++ b/drake/systems/primitives/integrator.h
@@ -40,9 +40,6 @@ class Integrator : public LeafSystem<T> {
   void set_integral_value(Context<T>* context,
                           const Eigen::Ref<const VectorX<T>>& value) const;
 
-  // System<T> override.
-  bool has_any_direct_feedthrough() const override;
-
   // Returns an Integrator<AutoDiffXd> with the same dimensions as this
   // Integrator.
   std::unique_ptr<Integrator<AutoDiffXd>> ToAutoDiffXd() const {

--- a/drake/systems/primitives/test/integrator_test.cc
+++ b/drake/systems/primitives/test/integrator_test.cc
@@ -88,7 +88,7 @@ TEST_F(IntegratorTest, Derivatives) {
 
 // Asserts that integrators do not have any direct feedthrough inputs.
 TEST_F(IntegratorTest, IntegratorIsNotDirectFeedthrough) {
-  EXPECT_FALSE(integrator_->has_any_direct_feedthrough());
+  EXPECT_FALSE(integrator_->HasAnyDirectFeedthrough());
 }
 
 class SymbolicIntegratorTest : public IntegratorTest {


### PR DESCRIPTION
Define the System::HasDirectFeedthrough API, which is pure virtual.  Implement it in LeafSystem using conservative values by default, symbolic analysis if available, and manual overrides if provided.  Implement it in Diagram using the same crude subsystem-level analysis we've always used.  

All the building blocks are now in place to do port-level Diagram sparsity analysis in a follow-up PR, although we will not be able to make use of it for DiagramBuilder-time algebraic loop detection until #2890 is resolved.

Migrate Integrator to the new API, which it satisfies using symbolic analysis with zero extra code.

@jadecastro for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5199)
<!-- Reviewable:end -->
