### PR TITLE
Remove  libgl1-mesa-dri and xvfb

### DIFF
--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -79,8 +79,8 @@ installed as follows::
 
     sudo apt-get update
     sudo apt-get install --no-install-recommends \
-      libgl1-mesa-dri libqt4-dev libqt4-opengl-dev libqwt-dev \
-      libvtk-java libvtk5-qt4-dev python-lxml python-scipy python-vtk xvfb
+      libqt4-dev libqt4-opengl-dev libqwt-dev \
+      libvtk-java libvtk5-qt4-dev python-lxml python-scipy python-vtk
 
 Note that the above installs an old version of VTK that is required by Drake. If
 a different version needs to be installed, Drake's build system can be

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -77,7 +77,6 @@ gfortran-5
 gfortran-5-multilib
 git
 graphviz
-libgl1-mesa-dri
 libgtk2.0-dev
 libhtml-form-perl
 libmpfr-dev
@@ -106,7 +105,6 @@ python-vtk
 python-yaml
 unzip
 valgrind
-xvfb
 zip
 zlib1g-dev
 


### PR DESCRIPTION
From the Xenial installation script and the Trusty install instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5207)
<!-- Reviewable:end -->
