### PR TITLE
enable equalto check in decompose_polynomial_test

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -288,6 +288,7 @@ drake_cc_googletest(
         ":common",
         ":monomial",
         ":symbolic",
+        ":symbolic_test_util",
     ],
 )
 

--- a/drake/common/test/decompose_polynomial_test.cc
+++ b/drake/common/test/decompose_polynomial_test.cc
@@ -4,10 +4,13 @@
 
 #include "drake/common/hash.h"
 #include "drake/common/monomial.h"
+#include "drake/common/test/symbolic_test_util.h"
 
 namespace drake {
 namespace symbolic {
 namespace {
+
+using test::ExprEqual;
 
 // Provides common variables that are used by the following tests.
 class DecomposePolynomialTest : public ::testing::Test {
@@ -24,36 +27,29 @@ class DecomposePolynomialTest : public ::testing::Test {
  public:
   void CheckDecomposePolynomial4(const Expression& e);
   void CheckDecomposePolynomial5(const Expression& e);
-  void CheckDecomposePolynomial6(const Expression& e,
-                                 bool check_expression_equal = true);
+  void CheckDecomposePolynomial6(const Expression& e);
   void CheckDecomposePolynomial7(const Expression& e);
-  void CheckDecomposePolynomial8(const Expression& e,
-                                 bool check_expression_equal = true);
+  void CheckDecomposePolynomial8(const Expression& e);
 };
 
 // Decomposes the expression `e` w.r.t `vars`, compares the decomposed map
 // which maps the monomial to the coefficient, to `map_expected`.
 // If `check_expression_equal` is true, checks if the summation of
 // map[monomial] * monomial is equal to `e`.
-// TODO(hongkai.dai) : Expression::EqualTo only checks structural equality. When
-// we can compare two expressions reliably beyond structural equality, then
-// always set `check_expression_equal` to true.
 void CheckMonomialToCoeffMap(const symbolic::Expression& e,
                              const Variables& vars,
-                             const MonomialToCoefficientMap& map_expected,
-                             bool check_expression_equal = true) {
+                             const MonomialToCoefficientMap& map_expected) {
   const auto& map = DecomposePolynomial(e, vars);
   EXPECT_EQ(map.size(), map_expected.size());
   symbolic::Expression e_expected(0);
   for (const auto& p : map) {
     const auto it = map_expected.find(p.first);
     ASSERT_NE(it, map_expected.end());
-    EXPECT_TRUE(p.second.EqualTo(it->second));
+    EXPECT_PRED2(ExprEqual, p.second.Expand(), it->second.Expand());
     e_expected += p.first * p.second;
   }
-  if (check_expression_equal) {
-    EXPECT_TRUE(e.EqualTo(e_expected));
-  }
+
+  EXPECT_PRED2(ExprEqual, e.Expand(), e_expected.Expand());
 }
 
 TEST_F(DecomposePolynomialTest, DecomposePolynomial0) {
@@ -108,7 +104,7 @@ TEST_F(DecomposePolynomialTest, DecomposePolynomial3) {
 
 void DecomposePolynomialTest::CheckDecomposePolynomial4(const Expression& e) {
   // Decomposes 2 * x * x.
-  EXPECT_TRUE(e.EqualTo(2 * x_ * x_));
+  EXPECT_PRED2(ExprEqual, e, 2 * x_ * x_);
 
   MonomialToCoefficientMap map_expected1({{x_ * x_, 2}});
   CheckMonomialToCoeffMap(e, {var_x_}, map_expected1);
@@ -132,7 +128,7 @@ TEST_F(DecomposePolynomialTest, DecomposePolynomial4) {
 
 void DecomposePolynomialTest::CheckDecomposePolynomial5(const Expression& e) {
   // Decomposes 6 * x * y.
-  EXPECT_TRUE(e.EqualTo(6 * x_ * y_));
+  EXPECT_PRED2(ExprEqual, e, 6 * x_ * y_);
 
   MonomialToCoefficientMap map_expected1({{x_ * y_, 6}});
   CheckMonomialToCoeffMap(e, var_xy_, map_expected1);
@@ -154,68 +150,59 @@ TEST_F(DecomposePolynomialTest, DecomposePolynomial5) {
   CheckDecomposePolynomial5(6 * x_ * y_ * pow(z_, 0));
 }
 
-void DecomposePolynomialTest::CheckDecomposePolynomial6(
-    const Expression& e, bool check_expression_equal) {
+void DecomposePolynomialTest::CheckDecomposePolynomial6(const Expression& e) {
   // Decomposes 3*x*x*y + 4*y^3*z + 2.
 
-  if (check_expression_equal) {
-    Expression e_expected{3 * x_ * x_ * y_ + 4 * pow(y_, 3) * z_ + 2};
-    EXPECT_TRUE(e.EqualTo(e_expected));
-  }
+  Expression e_expected{3 * x_ * x_ * y_ + 4 * pow(y_, 3) * z_ + 2};
+  EXPECT_PRED2(ExprEqual, e.Expand(), e_expected);
 
   MonomialToCoefficientMap map_expected1(
       {{x_ * x_, 3 * y_}, {1, 4 * pow(y_, 3) * z_ + 2}});
-  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1, check_expression_equal);
+  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1);
 
   MonomialToCoefficientMap map_expected2;
   map_expected2.emplace(y_, 3 * x_ * x_);
   map_expected2.emplace(pow(y_, 3), 4 * z_);
   map_expected2.emplace(1, 2);
-  CheckMonomialToCoeffMap(e, {var_y_}, map_expected2, check_expression_equal);
+  CheckMonomialToCoeffMap(e, {var_y_}, map_expected2);
 
   MonomialToCoefficientMap map_expected3(
       {{z_, 4 * pow(y_, 3)}, {1, 3 * x_ * x_ * y_ + 2}});
-  CheckMonomialToCoeffMap(e, {var_z_}, map_expected3, check_expression_equal);
+  CheckMonomialToCoeffMap(e, {var_z_}, map_expected3);
 
   MonomialToCoefficientMap map_expected4;
   map_expected4.emplace(x_ * x_ * y_, 3);
   map_expected4.emplace(pow(y_, 3), 4 * z_);
   map_expected4.emplace(1, 2);
-  CheckMonomialToCoeffMap(e, var_xy_, map_expected4,
-                          check_expression_equal);
+  CheckMonomialToCoeffMap(e, var_xy_, map_expected4);
 
   MonomialToCoefficientMap map_expected5;
   map_expected5.emplace(x_ * x_, 3 * y_);
   map_expected5.emplace(z_, 4 * pow(y_, 3));
   map_expected5.emplace(1, 2);
-  CheckMonomialToCoeffMap(e, {var_x_, var_z_}, map_expected5,
-                          check_expression_equal);
+  CheckMonomialToCoeffMap(e, {var_x_, var_z_}, map_expected5);
 
   MonomialToCoefficientMap map_expected6;
   map_expected6.emplace(y_, 3 * x_ * x_);
   map_expected6.emplace(pow(y_, 3) * z_, 4);
   map_expected6.emplace(1, 2);
-  CheckMonomialToCoeffMap(e, {var_y_, var_z_}, map_expected6,
-                          check_expression_equal);
+  CheckMonomialToCoeffMap(e, {var_y_, var_z_}, map_expected6);
 
   MonomialToCoefficientMap map_expected7;
   map_expected7.emplace(x_ * x_ * y_, 3);
   map_expected7.emplace(pow(y_, 3) * z_, 4);
   map_expected7.emplace(1, 2);
-  CheckMonomialToCoeffMap(e, var_xyz_, map_expected7,
-                          check_expression_equal);
+  CheckMonomialToCoeffMap(e, var_xyz_, map_expected7);
 }
 
 TEST_F(DecomposePolynomialTest, DecomposePolynomial6) {
   CheckDecomposePolynomial6(3 * x_ * x_ * y_ + 4 * pow(y_, 3) * z_ + 2);
 
-  // (x * (y + z)).EqualTo(x*y + x*z) returns false because structurally they
-  // are different, so ignore the expression equality check.
-  CheckDecomposePolynomial6(y_ * (3 * x_ * x_ + 4 * y_ * y_ * z_) + 2, false);
+  CheckDecomposePolynomial6(y_ * (3 * x_ * x_ + 4 * y_ * y_ * z_) + 2);
 }
 
 void DecomposePolynomialTest::CheckDecomposePolynomial7(const Expression& e) {
-  EXPECT_TRUE(e.EqualTo(6 * pow(x_, 3) * y_ * y_));
+  EXPECT_PRED2(ExprEqual, e.Expand(), 6 * pow(x_, 3) * y_ * y_);
 
   MonomialToCoefficientMap map_expected1({{pow(x_, 3), 6 * y_ * y_}});
   CheckMonomialToCoeffMap(e, {var_x_}, map_expected1);
@@ -240,47 +227,45 @@ TEST_F(DecomposePolynomialTest, DecomposePolynomial7) {
   CheckDecomposePolynomial7(6 * pow(x_, 3) * pow(y_, 2) * pow(z_, 0));
 }
 
-void DecomposePolynomialTest::CheckDecomposePolynomial8(
-    const Expression& e, bool check_expression_equal) {
+void DecomposePolynomialTest::CheckDecomposePolynomial8(const Expression& e) {
   // Decomposes x^3 - 4*x*y^2 + 2*x^2*y - 8*y^3.
-  if (check_expression_equal) {
-    EXPECT_TRUE(e.EqualTo(pow(x_, 3) - 4 * x_ * y_ * y_ + 2 * x_ * x_ * y_ -
-                          8 * pow(y_, 3)));
-  }
+
+  EXPECT_PRED2(
+      ExprEqual, e.Expand(),
+      pow(x_, 3) - 4 * x_ * y_ * y_ + 2 * x_ * x_ * y_ - 8 * pow(y_, 3));
 
   MonomialToCoefficientMap map_expected1;
   map_expected1.emplace(pow(x_, 3), 1);
   map_expected1.emplace(pow(x_, 2), 2 * y_);
   map_expected1.emplace(x_, -4 * y_ * y_);
   map_expected1.emplace(1, -8 * pow(y_, 3));
-  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1, check_expression_equal);
+  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1);
 
   MonomialToCoefficientMap map_expected2;
   map_expected2.emplace(pow(y_, 3), -8);
   map_expected2.emplace(y_ * y_, -4 * x_);
   map_expected2.emplace(y_, 2 * x_ * x_);
   map_expected2.emplace(1, pow(x_, 3));
-  CheckMonomialToCoeffMap(e, {var_y_}, map_expected2, check_expression_equal);
+  CheckMonomialToCoeffMap(e, {var_y_}, map_expected2);
 
   MonomialToCoefficientMap map_expected3;
   map_expected3.emplace(pow(x_, 3), 1);
   map_expected3.emplace(x_ * y_ * y_, -4);
   map_expected3.emplace(x_ * x_ * y_, 2);
   map_expected3.emplace(pow(y_, 3), -8);
-  CheckMonomialToCoeffMap(e, var_xy_, map_expected3,
-                          check_expression_equal);
+  CheckMonomialToCoeffMap(e, var_xy_, map_expected3);
 }
 
 TEST_F(DecomposePolynomialTest, DecomposePolynomial8) {
   CheckDecomposePolynomial8(pow(x_, 3) - 4 * x_ * y_ * y_ + 2 * x_ * x_ * y_ -
                             8 * pow(y_, 3));
 
-  CheckDecomposePolynomial8(pow(x_ + 2 * y_, 2) * (x_ - 2 * y_), false);
+  CheckDecomposePolynomial8(pow(x_ + 2 * y_, 2) * (x_ - 2 * y_));
 
-  CheckDecomposePolynomial8((x_ + 2 * y_) * (x_ * x_ - 4 * y_ * y_), false);
+  CheckDecomposePolynomial8((x_ + 2 * y_) * (x_ * x_ - 4 * y_ * y_));
 
   CheckDecomposePolynomial8(
-      (x_ * x_ + 4 * x_ * y_ + 4 * y_ * y_) * (x_ - 2 * y_), false);
+      (x_ * x_ + 4 * x_ * y_ + 4 * y_ * y_) * (x_ - 2 * y_));
 }
 
 TEST_F(DecomposePolynomialTest, DecomposePolynomial9) {
@@ -302,7 +287,7 @@ TEST_F(DecomposePolynomialTest, DecomposePolynomial10) {
   map_expected1.emplace(pow(x_, 2), 6 * pow(y_ + 1, 2));
   map_expected1.emplace(x_, 4 * pow(y_ + 1, 3));
   map_expected1.emplace(1, pow(y_ + 1, 4));
-  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1, false);
+  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1);
 
   MonomialToCoefficientMap map_expected2;
   map_expected2.emplace(pow(x_, 4), 1);
@@ -320,7 +305,7 @@ TEST_F(DecomposePolynomialTest, DecomposePolynomial10) {
   map_expected2.emplace(x_, 4);
   map_expected2.emplace(y_, 4);
   map_expected2.emplace(1, 1);
-  CheckMonomialToCoeffMap(e, var_xy_, map_expected2, false);
+  CheckMonomialToCoeffMap(e, var_xy_, map_expected2);
 }
 
 TEST_F(DecomposePolynomialTest, DecomposePolynomial11) {
@@ -328,12 +313,10 @@ TEST_F(DecomposePolynomialTest, DecomposePolynomial11) {
   Expression e = pow(x_ + y_ + 1, 3);
   MonomialToCoefficientMap map_expected1;
   map_expected1.emplace(pow(x_, 3), 1);
-  // TODO(hongkai.dai): change this to 3 * (y_ + 1) when Expand() method
-  // is available.
-  map_expected1.emplace(pow(x_, 2), 1 + y_ + 2 * (y_ + 1));
+  map_expected1.emplace(pow(x_, 2), 3 * (y_ + 1));
   map_expected1.emplace(x_, 3 * pow(y_ + 1, 2));
   map_expected1.emplace(1, pow(y_ + 1, 3));
-  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1, false);
+  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1);
 
   MonomialToCoefficientMap map_expected2;
   map_expected2.emplace(pow(x_, 3), 1);
@@ -346,7 +329,7 @@ TEST_F(DecomposePolynomialTest, DecomposePolynomial11) {
   map_expected2.emplace(x_, 3);
   map_expected2.emplace(y_, 3);
   map_expected2.emplace(1, 1);
-  CheckMonomialToCoeffMap(e, var_xy_, map_expected2, false);
+  CheckMonomialToCoeffMap(e, var_xy_, map_expected2);
 }
 // TODO(hongkai.dai): enable the following tests, when ((x^2 * y +
 // x^3)/(x^2)).is_polynomial() returns true.
@@ -356,18 +339,16 @@ TEST_F(DecomposePolynomialTest, DISABLED_DecomposePolynomial12) {
   // Decomposes x^2 * y / (x * y)
   MonomialToCoefficientMap map_expected1;
   map_expected1.emplace(x_, 1);
-  CheckMonomialToCoeffMap((x_ * x_ * y_) / (x_ * y_), {var_x_}, map_expected1,
-false);
+  CheckMonomialToCoeffMap((x_ * x_ * y_) / (x_ * y_), {var_x_}, map_expected1);
 
   MonomialToCoefficientMap map_expected2;
   // TODO(hongkai.dai) : Currently (pow(x_, 2) / x_).EqualTo(x_) returns false,
   // revisit this code when we can simplify the division result.
   map_expected2.emplace(1, pow(x_, 2) / x_);
-  CheckMonomialToCoeffMap((x_ * x_ * y_) / (x_ * y_), {var_y_}, map_expected2,
-false);
+  CheckMonomialToCoeffMap((x_ * x_ * y_) / (x_ * y_), {var_y_}, map_expected2);
 
   CheckMonomialToCoeffMap((x_ * x_ * y_) / (x_ * y_), var_xy_,
-map_expected1, false);
+map_expected1);
 }
 
 TEST_F(DecomposePolynomialTest, DISABLED_DecomposePolynomial13) {
@@ -378,17 +359,17 @@ TEST_F(DecomposePolynomialTest, DISABLED_DecomposePolynomial13) {
   MonomialToCoefficientMap map_expected1;
   map_expected1.emplace(x_, 3 * pow(y_, 3) / (3 * y_));
   map_expected1.emplace(x_ * x_, (2 * y_ * y_) / (3 * y_));
-  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1, false);
+  CheckMonomialToCoeffMap(e, {var_x_}, map_expected1);
 
   MonomialToCoefficientMap map_expected2;
   map_expected2.emplace(y_ * y_, (3 * x_ * x_) / (3 * x_));
   map_expected2.emplace(y_, (2 * pow(x_, 3))/(3 * x_));
-  CheckMonomialToCoeffMap(e, {var_y_}, map_expected2, false);
+  CheckMonomialToCoeffMap(e, {var_y_}, map_expected2);
 
   MonomialToCoefficientMap map_expected3;
   map_expected3.emplace(x_ * y_ * y_, 1);
   map_expected3.emplace(x_ * x_ * y_, 2.0 / 3);
-  CheckMonomialToCoeffMap(e, var_xy_, map_expected3, false);
+  CheckMonomialToCoeffMap(e, var_xy_, map_expected3);
 }
 
 }  // namespace


### PR DESCRIPTION
Since `Expand()` is enabled, we can compare if two expressions are equal, beyond structural equality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5229)
<!-- Reviewable:end -->
