### PR TITLE
Removes initialization of xc from gyroscope_test and accelerometer_test.

### DIFF
--- a/drake/systems/sensors/test/accelerometer_test/accelerometer_test.cc
+++ b/drake/systems/sensors/test/accelerometer_test/accelerometer_test.cc
@@ -86,14 +86,6 @@ void TestAccelerometerFreeFall(const Eigen::Vector3d& xyz,
       dut.get_plant_state_derivative_input_port().get_index(),
       make_unique<BasicVector<double>>(VectorX<double>::Zero(num_states)));
 
-  auto xc_vector = make_unique<BasicVector<double>>(
-      VectorX<double>::Zero(num_states).eval());
-  auto xc = make_unique<ContinuousState<double>>(move(xc_vector), num_positions,
-                                                 num_velocities,
-                                                 0 /* num other variables */);
-
-  dut_context->set_continuous_state(move(xc));
-
   unique_ptr<SystemOutput<double>> output = dut.AllocateOutput(*dut_context);
   ASSERT_EQ(output->get_num_ports(), 1);
   dut.CalcOutput(*dut_context, output.get());

--- a/drake/systems/sensors/test/gyroscope_test.cc
+++ b/drake/systems/sensors/test/gyroscope_test.cc
@@ -85,14 +85,6 @@ TEST_F(TestGyroscope, TestFreeFall) {
       dut_->get_input_port().get_index(),
       make_unique<BasicVector<double>>(state_vector));
 
-  auto xc_vector = make_unique<BasicVector<double>>(
-      VectorX<double>::Zero(num_states_).eval());
-  auto xc = make_unique<ContinuousState<double>>(
-      move(xc_vector), num_positions_, num_velocities_,
-      0 /* num other variables */);
-
-  context_->set_continuous_state(move(xc));
-
   unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput(*context_);
   ASSERT_EQ(output->get_num_ports(), 1);
   dut_->CalcOutput(*context_, output.get());
@@ -128,14 +120,6 @@ TEST_F(TestGyroscope, TestNonZeroRotationalVelocity) {
   context_->FixInputPort(
       dut_->get_input_port().get_index(),
       make_unique<BasicVector<double>>(state_vector));
-
-  auto xc_vector = make_unique<BasicVector<double>>(
-      VectorX<double>::Zero(num_states_).eval());
-  auto xc = make_unique<ContinuousState<double>>(
-      move(xc_vector), num_positions_, num_velocities_,
-      0 /* num other variables */);
-
-  context_->set_continuous_state(move(xc));
 
   unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput(*context_);
   ASSERT_EQ(output->get_num_ports(), 1);


### PR DESCRIPTION
This is possible since the gyroscope and accelerometer do not have any continuous state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5232)
<!-- Reviewable:end -->
