### PR TITLE
change to consistently use "breaks" instead of "segment_times".

### DIFF
--- a/drake/common/trajectories/exponential_plus_piecewise_polynomial.cc
+++ b/drake/common/trajectories/exponential_plus_piecewise_polynomial.cc
@@ -71,7 +71,7 @@ Eigen::Index ExponentialPlusPiecewisePolynomial<CoefficientType>::cols() const {
 template <typename CoefficientType>
 void ExponentialPlusPiecewisePolynomial<CoefficientType>::shiftRight(
     double offset) {
-  for (auto it = segment_times.begin(); it != segment_times.end(); ++it) {
+  for (auto it = breaks.begin(); it != breaks.end(); ++it) {
     *it += offset;
   }
   piecewise_polynomial_part_.shiftRight(offset);

--- a/drake/common/trajectories/piecewise_function.h
+++ b/drake/common/trajectories/piecewise_function.h
@@ -6,15 +6,15 @@
 
 class PiecewiseFunction {
  protected:
-  std::vector<double> segment_times;
+  std::vector<double> breaks;
 
  public:
   /// Minimum delta quantity used for comparing time.
   static constexpr double kEpsilonTime = 1e-10;
 
-  /// @throws std::runtime_exception if `segment_times`'s increments are
+  /// @throws std::runtime_exception if `breaks` increments are
   /// smaller than kEpsilonTime.
-  explicit PiecewiseFunction(std::vector<double> const& segment_times);
+  explicit PiecewiseFunction(std::vector<double> const& breaks);
 
   virtual ~PiecewiseFunction();
 

--- a/drake/common/trajectories/piecewise_polynomial.cc
+++ b/drake/common/trajectories/piecewise_polynomial.cc
@@ -1,5 +1,5 @@
-#include "drake/common/trajectories/piecewise_polynomial.h"
 #include <algorithm>
+#include "drake/common/trajectories/piecewise_polynomial.h"
 
 #include "drake/common/drake_assert.h"
 
@@ -9,9 +9,9 @@ using std::vector;
 template <typename CoefficientType>
 PiecewisePolynomial<CoefficientType>::PiecewisePolynomial(
     std::vector<PolynomialMatrix> const& polynomials,
-    std::vector<double> const& segment_times)
-    : PiecewisePolynomialBase(segment_times), polynomials_(polynomials) {
-  DRAKE_ASSERT(segment_times.size() == (polynomials.size() + 1));
+    std::vector<double> const& breaks)
+    : PiecewisePolynomialBase(breaks), polynomials_(polynomials) {
+  DRAKE_ASSERT(breaks.size() == (polynomials.size() + 1));
   for (int i = 1; i < getNumberOfSegments(); i++) {
     if (polynomials[i].rows() != polynomials[0].rows())
       throw std::runtime_error(
@@ -27,9 +27,9 @@ PiecewisePolynomial<CoefficientType>::PiecewisePolynomial(
 template <typename CoefficientType>
 PiecewisePolynomial<CoefficientType>::PiecewisePolynomial(
     std::vector<PolynomialType> const& polynomials,
-    std::vector<double> const& segment_times)
-    : PiecewisePolynomialBase(segment_times) {
-  DRAKE_ASSERT(segment_times.size() == (polynomials.size() + 1));
+    std::vector<double> const& breaks)
+    : PiecewisePolynomialBase(breaks) {
+  DRAKE_ASSERT(breaks.size() == (polynomials.size() + 1));
 
   for (size_t i = 0; i < polynomials.size(); i++) {
     PolynomialMatrix matrix(1, 1);
@@ -260,7 +260,7 @@ bool PiecewisePolynomial<CoefficientType>::isApprox(
 
 template <typename CoefficientType>
 void PiecewisePolynomial<CoefficientType>::shiftRight(double offset) {
-  for (auto it = segment_times.begin(); it != segment_times.end(); ++it) {
+  for (auto it = breaks.begin(); it != breaks.end(); ++it) {
     *it += offset;
   }
 }
@@ -282,10 +282,10 @@ PiecewisePolynomial<CoefficientType>::slice(int start_segment_index,
   segmentNumberRangeCheck(start_segment_index);
   segmentNumberRangeCheck(start_segment_index + num_segments - 1);
 
-  auto segment_times_start_it = segment_times.begin() + start_segment_index;
-  auto segment_times_slice = vector<double>(
-      segment_times_start_it,
-      segment_times_start_it + num_segments +
+  auto breaks_start_it = breaks.begin() + start_segment_index;
+  auto breaks_slice = vector<double>(
+      breaks_start_it,
+      breaks_start_it + num_segments +
           1);  // + 1 because there's one more segment times than segments.
 
   auto polynomials_start_it = polynomials_.begin() + start_segment_index;
@@ -293,7 +293,7 @@ PiecewisePolynomial<CoefficientType>::slice(int start_segment_index,
       polynomials_start_it, polynomials_start_it + num_segments);
 
   return PiecewisePolynomial<CoefficientType>(polynomials_slice,
-                                              segment_times_slice);
+                                              breaks_slice);
 }
 
 template <typename CoefficientType>

--- a/drake/common/trajectories/piecewise_polynomial.cc
+++ b/drake/common/trajectories/piecewise_polynomial.cc
@@ -1,5 +1,6 @@
-#include <algorithm>
 #include "drake/common/trajectories/piecewise_polynomial.h"
+
+#include <algorithm>
 
 #include "drake/common/drake_assert.h"
 

--- a/drake/common/trajectories/piecewise_polynomial.h
+++ b/drake/common/trajectories/piecewise_polynomial.h
@@ -59,11 +59,11 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
 
   // Matrix constructor
   PiecewisePolynomial(std::vector<PolynomialMatrix> const& polynomials,
-                      std::vector<double> const& segment_times);
+                      std::vector<double> const& breaks);
 
   // Scalar constructor
   PiecewisePolynomial(std::vector<PolynomialType> const& polynomials,
-                      std::vector<double> const& segment_times);
+                      std::vector<double> const& breaks);
 
   /**
    * Constructs a piecewise constant PiecewisePolynomial.
@@ -143,7 +143,8 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
       const CoefficientMatrix& knot_dot_end);
 
   /**
-   * Constructs a third order PiecewisePolynomial from `breaks`, `knots` and `knots`dot.
+   * Constructs a third order PiecewisePolynomial from `breaks`, `knots` and
+   * `knots`dot.
    * Each segment is fully specified by @knots and @knot_dot at both ends.
    * Second derivatives are not continuous.
    *
@@ -219,9 +220,7 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
   PiecewisePolynomial integral(
       const CoefficientMatrixRef& value_at_start_time) const;
 
-  bool empty() const {
-    return polynomials_.empty();
-  }
+  bool empty() const { return polynomials_.empty(); }
 
   double scalarValue(double t, Eigen::Index row = 0, Eigen::Index col = 0);
 
@@ -232,8 +231,7 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
   const PolynomialType& getPolynomial(int segment_index, Eigen::Index row = 0,
                                       Eigen::Index col = 0) const;
 
-  int getSegmentPolynomialDegree(int segment_index,
-                                 Eigen::Index row = 0,
+  int getSegmentPolynomialDegree(int segment_index, Eigen::Index row = 0,
                                  Eigen::Index col = 0) const override;
 
   Eigen::Index rows() const override;
@@ -311,8 +309,8 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
   // Throws std::runtime_error
   // if `dt` < Eigen::NumTraits<CoefficientType>::epsilon()
   static Eigen::Matrix<CoefficientType, 4, 1> ComputeCubicSplineCoeffs(
-      double dt, CoefficientType y0, CoefficientType y1,
-      CoefficientType yd0, CoefficientType yd1);
+      double dt, CoefficientType y0, CoefficientType y1, CoefficientType yd0,
+      CoefficientType yd1);
 
   // For a cubic spline, there are 4 unknowns for each segment Pi, namely
   // the coefficients for Pi = a0 + a1 * t + a2 * t^2 + a3 * t^3.
@@ -342,16 +340,13 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
   // "not-a-knot" / etc). These will be specified by the callers.
   static int SetupCubicSplineInteriorCoeffsLinearSystem(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots,
-      int row, int col,
-      drake::MatrixX<CoefficientType>* A,
-      drake::VectorX<CoefficientType>* b);
+      const std::vector<CoefficientMatrix>& knots, int row, int col,
+      drake::MatrixX<CoefficientType>* A, drake::VectorX<CoefficientType>* b);
 
   // Computes the first derivative at the end point using a non-centered,
   // shape-preserving three-point formulae.
   static CoefficientMatrix ComputePchipEndSlope(
-      double dt0, double dt1,
-      const CoefficientMatrix& slope0,
+      double dt0, double dt1, const CoefficientMatrix& slope0,
       const CoefficientMatrix& slope1);
 
   // Throws std::runtime_error if
@@ -361,6 +356,5 @@ class PiecewisePolynomial : public PiecewisePolynomialBase {
   // `breaks` has length smaller than min_length.
   static void CheckSplineGenerationInputValidityOrThrow(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots,
-      int min_length);
+      const std::vector<CoefficientMatrix>& knots, int min_length);
 };

--- a/drake/common/trajectories/piecewise_polynomial_base.cc
+++ b/drake/common/trajectories/piecewise_polynomial_base.cc
@@ -5,8 +5,8 @@
 #include <stdexcept>
 
 PiecewisePolynomialBase::PiecewisePolynomialBase(
-    std::vector<double> const& segment_times)
-    : PiecewiseFunction(segment_times) {
+    std::vector<double> const& breaks)
+    : PiecewiseFunction(breaks) {
   // empty
 }
 

--- a/drake/common/trajectories/piecewise_polynomial_base.h
+++ b/drake/common/trajectories/piecewise_polynomial_base.h
@@ -8,7 +8,7 @@
 
 class PiecewisePolynomialBase : public PiecewiseFunction {
  public:
-  explicit PiecewisePolynomialBase(std::vector<double> const& segment_times);
+  explicit PiecewisePolynomialBase(std::vector<double> const& breaks);
 
   virtual ~PiecewisePolynomialBase();
 

--- a/drake/common/trajectories/piecewise_polynomial_trajectory.h
+++ b/drake/common/trajectories/piecewise_polynomial_trajectory.h
@@ -18,8 +18,7 @@ class PiecewisePolynomialTrajectory : public Trajectory {
   /**
    * Construct a PiecewisePolynomialTrajectory from a PiecewisePolynomial.
    */
-  explicit PiecewisePolynomialTrajectory(
-      const PiecewisePolynomial<double>& pp)
+  explicit PiecewisePolynomialTrajectory(const PiecewisePolynomial<double>& pp)
       : pp_(pp) {}
 
   /**
@@ -28,8 +27,8 @@ class PiecewisePolynomialTrajectory : public Trajectory {
    * @return a CoefficientMatrix that is the value of the wrapped
    * PiecewisePolynomial.
    */
-  PiecewisePolynomial<double>::CoefficientMatrix
-  value(double t) const override {
+  PiecewisePolynomial<double>::CoefficientMatrix value(
+      double t) const override {
     return pp_.value(t);
   }
 

--- a/drake/common/trajectories/qp_spline/spline_information.cc
+++ b/drake/common/trajectories/qp_spline/spline_information.cc
@@ -6,10 +6,10 @@
 
 SplineInformation::SplineInformation(
     std::vector<int> const& segment_polynomial_orders,
-    std::vector<double> const& segment_times)
-    : PiecewisePolynomialBase(segment_times),
+    std::vector<double> const& breaks)
+    : PiecewisePolynomialBase(breaks),
       segment_polynomial_degrees(segment_polynomial_orders) {
-  DRAKE_ASSERT(segment_times.size() == segment_polynomial_orders.size() + 1);
+  DRAKE_ASSERT(breaks.size() == segment_polynomial_orders.size() + 1);
   value_constraints.resize(getNumberOfSegments());
 }
 
@@ -44,7 +44,7 @@ void SplineInformation::addContinuityConstraint(
 }
 
 std::vector<double> const& SplineInformation::getSegmentTimes() const {
-  return segment_times;
+  return breaks;
 }
 
 int SplineInformation::getSegmentPolynomialDegree(int segment_number,

--- a/drake/common/trajectories/qp_spline/spline_information.h
+++ b/drake/common/trajectories/qp_spline/spline_information.h
@@ -16,7 +16,7 @@ class SplineInformation : public PiecewisePolynomialBase {
   virtual ~SplineInformation() {}
 
   SplineInformation(std::vector<int> const& segment_polynomial_orders,
-                    std::vector<double> const& segment_times);
+                    std::vector<double> const& breaks);
 
   virtual int getSegmentPolynomialDegree(int segment_number, Eigen::Index row,
                                          Eigen::Index cols) const;


### PR DESCRIPTION
the pp / pp trajectory classes use a mix of notation.  this is especially sensitive, since piecewise_function should not have any notion of time (while it would be ok for a trajectory).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5242)
<!-- Reviewable:end -->
