### PR TITLE
Adds Configuration File Support for Specifying MaliputRailcars and IDM-controlled MaliputRailcars.

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -9,6 +9,7 @@ load(
     "drake_cc_binary",
 )
 load("//tools:python_lint.bzl", "python_lint")
+load("@protobuf//:protobuf.bzl", "cc_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -360,6 +361,28 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "load_maliput_railcar_scenario_config_from_file",
+    srcs = [
+        "load_maliput_railcar_scenario_config_from_file.cc",
+    ],
+    hdrs = [
+        "load_maliput_railcar_scenario_config_from_file.h",
+    ],
+    deps = [
+        ":generated_vectors",
+        ":maliput_railcar_scenario_config",
+        "//drake/common",
+    ],
+)
+
+cc_proto_library(
+    name = "maliput_railcar_scenario_config",
+    srcs = [
+        "maliput_railcar_scenario_config.proto",
+    ],
+)
+
 drake_cc_binary(
     name = "automotive_demo",
     srcs = [
@@ -613,6 +636,18 @@ drake_cc_googletest(
     deps = [
         "//drake/automotive:calc_smooth_acceleration",
         "//drake/common",
+    ],
+)
+
+drake_cc_googletest(
+    name = "load_maliput_railcar_scenario_config_from_file_test",
+    srcs = ["test/load_maliput_railcar_scenario_config_from_file_test.cc"],
+    data = [
+        "test/typical.maliput_railcar_scenario_config",
+    ],
+    deps = [
+        ":load_maliput_railcar_scenario_config_from_file",
+        "//drake/common:drake_path",
     ],
 )
 

--- a/drake/automotive/load_maliput_railcar_scenario_config_from_file.cc
+++ b/drake/automotive/load_maliput_railcar_scenario_config_from_file.cc
@@ -1,0 +1,28 @@
+#include "drake/automotive/load_maliput_railcar_scenario_config_from_file.h"
+
+#include <fcntl.h>
+
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/text_format.h"
+
+namespace drake {
+namespace automotive {
+
+void LoadMaliputRailcarScenarioConfigFromFile(
+    const std::string& path, MaliputRailcarScenarioConfig* scenario_config) {
+  int fid = open(path.data(), O_RDONLY);
+  if (fid < 0) {
+    throw std::runtime_error("LoadMaliputRailcarScenarioConfigFromFile:"
+        " Cannot open file " + path + ".");
+  }
+  google::protobuf::io::FileInputStream istream(fid);
+  if (!google::protobuf::TextFormat::Parse(&istream, scenario_config)) {
+    throw std::runtime_error("LoadMaliputRailcarScenarioConfigFromFile:"
+        " Error parsing " + path + ".");
+  }
+  istream.Close();
+}
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/load_maliput_railcar_scenario_config_from_file.h
+++ b/drake/automotive/load_maliput_railcar_scenario_config_from_file.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+#include "drake/automotive/maliput_railcar_scenario_config.pb.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace automotive {
+
+/**
+ * Loads MaliputRailcarScenarioConfig parameters from a file. The format of
+ * the config file is defined in `maliput_railcar_scenario_config.proto`.
+ *
+ * @param path The path to the config file.
+ *
+ * @param scenario_config The destination where the parameters should be saved.
+ *
+ * @throws std::runtime_error if the provided file cannot be parsed.
+ */
+void LoadMaliputRailcarScenarioConfigFromFile(
+    const std::string& path, MaliputRailcarScenarioConfig* scenario_config);
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/maliput_railcar_scenario_config.proto
+++ b/drake/automotive/maliput_railcar_scenario_config.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package drake.automotive;
+
+// Defines parameters for instantiating and initializing a MaliputRailcar.
+message MaliputRailcarConfig {
+  string car_name = 1;
+  string initial_lane_name = 2;
+  bool initial_with_s = 3;
+
+  // Initial state.
+  double initial_s = 4;
+  double initial_speed = 5;
+
+  // Parameters.
+  double r = 6;
+  double h = 7;
+  double max_speed = 8;
+  double velocity_limit_kp = 9;
+}
+
+// Defines parameters for instantiating and initializing an IdmController.
+message IdmControllerConfig {
+  double v_ref = 1;         // Desired velocity in free traffic.
+  double a = 2;             // Max acceleration.
+  double b = 3;             // Comfortable braking deceleration.
+  double s_0 = 4;           // Minimum desired net distance.
+  double time_headway = 5;  // Desired time headway to vehicle in front.
+  double delta = 6;         // Free-road exponent.
+
+  // Diameter of circle about the vehicle's pose that encloses its physical
+  // footprint.
+  double bloat_diameter = 7;
+
+  // Lower saturation bound on net distance to prevent near-singular IDM
+  // solutions.
+  double distance_lower_limit = 8;
+}
+
+// Defines parameters for instantiating and initializing an IDM-controlled
+// MaliputRailcar.
+message IdmControlledMaliputRailcarConfig {
+    MaliputRailcarConfig maliput_railcar_config = 1;
+    IdmControllerConfig idm_controller_config = 2;
+}
+
+// Contains parameters for initializing both uncontrolled and IDM-controlled
+// MaliputRailcars.
+message MaliputRailcarScenarioConfig {
+    repeated MaliputRailcarConfig maliput_railcar_config = 1;
+    repeated IdmControlledMaliputRailcarConfig
+        idm_controlled_maliput_railcar_config = 2;
+}

--- a/drake/automotive/test/load_maliput_railcar_scenario_config_from_file_test.cc
+++ b/drake/automotive/test/load_maliput_railcar_scenario_config_from_file_test.cc
@@ -1,0 +1,85 @@
+#include "drake/automotive/load_maliput_railcar_scenario_config_from_file.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/drake_path.h"
+
+namespace drake {
+namespace automotive {
+namespace {
+
+// Tests that a scenario config file instantiating a Protocol Buffer message
+// defined by maliput_railcar_scenario_config.proto can be parsed.
+GTEST_TEST(LoadMaliputRailcarScenarioConfigFromFileTest, BasicTest) {
+  const std::string config_file_name = drake::GetDrakePath() +
+      "/automotive/test/typical.maliput_railcar_scenario_config";
+  MaliputRailcarScenarioConfig scenario_config;
+  EXPECT_NO_THROW(LoadMaliputRailcarScenarioConfigFromFile(config_file_name,
+    &scenario_config));
+  ASSERT_EQ(scenario_config.maliput_railcar_config_size(), 2);
+
+  {
+    const MaliputRailcarConfig& config =
+        scenario_config.maliput_railcar_config(0);
+    EXPECT_EQ(config.car_name(), "prius_prime");
+    EXPECT_EQ(config.initial_lane_name(), "fast_lane");
+    EXPECT_EQ(config.initial_with_s(), true);
+    EXPECT_EQ(config.initial_s(), 1.2843);
+    EXPECT_EQ(config.initial_speed(), 4.927);
+    EXPECT_EQ(config.r(), 0.2);
+    EXPECT_EQ(config.h(), 0.15);
+    EXPECT_EQ(config.max_speed(), 13.5);
+    EXPECT_EQ(config.velocity_limit_kp(), 20.2);
+  }
+
+  {
+    const MaliputRailcarConfig& config =
+        scenario_config.maliput_railcar_config(1);
+    EXPECT_EQ(config.car_name(), "ls460h");
+    EXPECT_EQ(config.initial_lane_name(), "luxury_lane");
+    EXPECT_EQ(config.initial_with_s(), false);
+    EXPECT_EQ(config.initial_s(), 2.5);
+    EXPECT_EQ(config.initial_speed(), 7.8);
+    EXPECT_EQ(config.r(), -0.6);
+    EXPECT_EQ(config.h(), 0.2);
+    EXPECT_EQ(config.max_speed(), 71.5);
+    EXPECT_EQ(config.velocity_limit_kp(), 45.3);
+  }
+
+  {
+    ASSERT_EQ(scenario_config.idm_controlled_maliput_railcar_config_size(), 1);
+    const IdmControlledMaliputRailcarConfig& idm_railcar_config =
+        scenario_config.idm_controlled_maliput_railcar_config(0);
+    EXPECT_TRUE(idm_railcar_config.has_maliput_railcar_config());
+    EXPECT_TRUE(idm_railcar_config.has_idm_controller_config());
+
+    const MaliputRailcarConfig& railcar_config =
+        idm_railcar_config.maliput_railcar_config();
+    EXPECT_EQ(railcar_config.car_name(), "controlled_camry");
+    EXPECT_EQ(railcar_config.initial_lane_name(), "comfort_lane");
+    EXPECT_EQ(railcar_config.initial_with_s(), true);
+    EXPECT_EQ(railcar_config.initial_s(), 6.7);
+    EXPECT_EQ(railcar_config.initial_speed(), 8.3);
+    EXPECT_EQ(railcar_config.r(), 0);
+    EXPECT_EQ(railcar_config.h(), 0);
+    EXPECT_EQ(railcar_config.max_speed(), 22.5);
+    EXPECT_EQ(railcar_config.velocity_limit_kp(), 30.5);
+
+    const IdmControllerConfig& idm_config =
+        idm_railcar_config.idm_controller_config();
+    EXPECT_EQ(idm_config.v_ref(), 10.1);
+    EXPECT_EQ(idm_config.a(), 25.5);
+    EXPECT_EQ(idm_config.b(), 30.2);
+    EXPECT_EQ(idm_config.s_0(), 5.5);
+    EXPECT_EQ(idm_config.time_headway(), 5.2);
+    EXPECT_EQ(idm_config.delta(), 6.1);
+    EXPECT_EQ(idm_config.bloat_diameter(), 7.5);
+    EXPECT_EQ(idm_config.distance_lower_limit(), 8.1);
+  }
+}
+
+}  // namespace
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/test/typical.maliput_railcar_scenario_config
+++ b/drake/automotive/test/typical.maliput_railcar_scenario_config
@@ -1,0 +1,47 @@
+maliput_railcar_config {
+  car_name: "prius_prime"
+  initial_lane_name: "fast_lane"
+  initial_with_s: true
+  initial_s: 1.2843
+  initial_speed: 4.927
+  r: 0.2
+  h: 0.15
+  max_speed: 13.5
+  velocity_limit_kp: 20.2
+}
+
+maliput_railcar_config {
+  car_name: "ls460h"
+  initial_lane_name: "luxury_lane"
+  initial_with_s: false
+  initial_s: 2.5
+  initial_speed: 7.8
+  r: -0.6
+  h: 0.2
+  max_speed: 71.5
+  velocity_limit_kp: 45.3
+}
+
+idm_controlled_maliput_railcar_config {
+  maliput_railcar_config {
+    car_name: "controlled_camry"
+    initial_lane_name: "comfort_lane"
+    initial_with_s: true
+    initial_s: 6.7
+    initial_speed: 8.3
+    r: 0
+    h: 0
+    max_speed: 22.5
+    velocity_limit_kp: 30.5
+  }
+  idm_controller_config {
+    v_ref: 10.1
+    a: 25.5
+    b: 30.2
+    s_0: 5.5
+    time_headway: 5.2
+    delta: 6.1
+    bloat_diameter: 7.5
+    distance_lower_limit: 8.1
+  }
+}


### PR DESCRIPTION
This PR only defines the configuration file and its parser. It does not integrate them with AutomotiveDemo. The integration will be done in a followup PR.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5250)
<!-- Reviewable:end -->
