### PR TITLE
Port multibody/collison to drake_copyable

### DIFF
--- a/drake/multibody/collision/bullet_model.h
+++ b/drake/multibody/collision/bullet_model.h
@@ -10,6 +10,7 @@
 #include "BulletCollision/NarrowPhaseCollision/btGjkPairDetector.h"
 #include "BulletCollision/NarrowPhaseCollision/btPointCollector.h"
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/collision/model.h"
 
@@ -52,6 +53,8 @@ class UnknownShapeException : public std::runtime_error {
 
 class BulletModel : public Model {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BulletModel)
+
   BulletModel() {}
 
   virtual ~BulletModel() {}
@@ -168,10 +171,6 @@ class BulletModel : public Model {
 
   static constexpr double kSmallMargin = 1e-9;
   static constexpr double kLargeMargin = 0.05;
-
-  // BulletModel objects are not copyable
-  BulletModel(const BulletModel&) = delete;
-  BulletModel& operator=(const BulletModel&) = delete;
 
   /**
    * \brief Finds the points where elements A and B are closest.

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
+
 constexpr int kMaxNumCollisionFilterGroups = 128;
 
 // forward declaration
@@ -58,6 +60,8 @@ constexpr bitmask kDefaultGroup(1);
 template <typename T>
 class CollisionFilterGroup {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterGroup)
+
   /**
    Default constructor required by use in std::unordered_map.
    */
@@ -135,6 +139,8 @@ class CollisionFilterGroup {
 template <typename T>
 class CollisionFilterGroupManager {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CollisionFilterGroupManager)
+
   /** Default constructor. */
   CollisionFilterGroupManager() {}
 

--- a/drake/multibody/collision/fcl_model.h
+++ b/drake/multibody/collision/fcl_model.h
@@ -4,14 +4,18 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/collision/model.h"
 #include "drake/multibody/collision/point_pair.h"
 
 namespace DrakeCollision {
 
+// TODO(jwnimmer-tri) This should be named FclModel per cppguide.
 class FCLModel : public Model {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FCLModel)
+
   FCLModel() {}
   virtual ~FCLModel() {}
 
@@ -40,9 +44,6 @@ class FCLModel : public Model {
       const Eigen::Matrix3Xd& points, bool use_margins,
       std::vector<PointPair>& closest_points) override;
   void updateModel() override;
-
-  FCLModel(const FCLModel&) = delete;
-  FCLModel& operator=(const FCLModel&) = delete;
 };
 
 }  // namespace DrakeCollision

--- a/drake/multibody/collision/model.h
+++ b/drake/multibody/collision/model.h
@@ -7,6 +7,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/collision/point_pair.h"
 
@@ -17,6 +18,8 @@ typedef std::pair<ElementId, ElementId> ElementIdPair;
  implement the actual collision detection logic. **/
 class Model {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Model)
+
   Model() {}
 
   virtual ~Model() {}
@@ -285,10 +288,6 @@ class Model {
   // Please do not add new references to this member.  Instead, use
   // the accessors.
   std::unordered_map<ElementId, std::unique_ptr<Element>> elements;
-
- private:
-  Model(const Model&) {}
-  Model& operator=(const Model&) { return *this; }
 };
 
 }  // namespace DrakeCollision

--- a/drake/multibody/collision/unusable_model.h
+++ b/drake/multibody/collision/unusable_model.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/collision/model.h"
 
@@ -11,6 +12,8 @@ namespace DrakeCollision {
 /// An unusable model, used when no collision detection backend is available.
 class UnusableModel : public Model {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UnusableModel)
+
   UnusableModel() {}
 
   virtual ~UnusableModel() {}
@@ -51,11 +54,6 @@ class UnusableModel : public Model {
   std::vector<size_t> collidingPoints(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
-
- private:
-  // UnusableModel objects are not copyable
-  UnusableModel(const UnusableModel&) = delete;
-  UnusableModel& operator=(const UnusableModel&) = delete;
 };
 
 }  // namespace DrakeCollision


### PR DESCRIPTION
Port multibody/collison to drake_copyable, except for Element, which is a separate PR.

A portion of #4861.  Relates #5253.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5252)
<!-- Reviewable:end -->
