### PR TITLE
wrap symbolic AddQuadraticCost; support pow() and unary minus from python

### DIFF
--- a/drake/bindings/pybind11/pydrake_autodiffutils.cc
+++ b/drake/bindings/pybind11/pydrake_autodiffutils.cc
@@ -42,40 +42,40 @@ PYBIND11_PLUGIN(_pydrake_autodiffutils) {
     .def("cos", [](const AutoDiffXd& self) { return eval(cos(self)); })
     .def("__add__", [](const AutoDiffXd& self, const AutoDiffXd& other) {
       return eval(self + other);
-    })
+    }, py::is_operator())
     .def("__add__", [](const AutoDiffXd& self, double other) {
       return eval(self + other);
-    })
+    }, py::is_operator())
     .def("__radd__", [](const AutoDiffXd& self, double other) {
       return eval(other + self);
-    })
+    }, py::is_operator())
     .def("__sub__", [](const AutoDiffXd& self, const AutoDiffXd& other) {
       return eval(self - other);
-    })
+    }, py::is_operator())
     .def("__sub__", [](const AutoDiffXd& self, double other) {
       return eval(self - other);
-    })
+    }, py::is_operator())
     .def("__rsub__", [](const AutoDiffXd& self, double other) {
       return eval(other - self);
-    })
+    }, py::is_operator())
     .def("__mul__", [](const AutoDiffXd& self, const AutoDiffXd& other) {
       return eval(self * other);
-    })
+    }, py::is_operator())
     .def("__mul__", [](const AutoDiffXd& self, double other) {
       return eval(self * other);
-    })
+    }, py::is_operator())
     .def("__rmul__", [](const AutoDiffXd& self, double other) {
       return eval(other * self);
-    })
+    }, py::is_operator())
     .def("__truediv__", [](const AutoDiffXd& self, const AutoDiffXd& other) {
       return eval(self / other);
-    })
+    }, py::is_operator())
     .def("__truediv__", [](const AutoDiffXd& self, double other) {
       return eval(self / other);
-    })
+    }, py::is_operator())
     .def("__rtruediv__", [](const AutoDiffXd& self, double other) {
       return eval(other / self);
-    });
+    }, py::is_operator());
 
   return m.ptr();
 }

--- a/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
+++ b/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
@@ -111,7 +111,7 @@ PYBIND11_PLUGIN(_pydrake_mathematicalprogram) {
           const Eigen::Ref<const VectorXDecisionVariable>&))
          &MathematicalProgram::AddQuadraticCost)
     .def("AddQuadraticCost", (Binding<QuadraticConstraint>
-         (MathematicalProgram::*)(const Expression&)) 
+         (MathematicalProgram::*)(const Expression&))
          &MathematicalProgram::AddQuadraticCost)
     .def("Solve", &MathematicalProgram::Solve)
     .def("linear_constraints", &MathematicalProgram::linear_constraints)

--- a/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
+++ b/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
@@ -110,6 +110,9 @@ PYBIND11_PLUGIN(_pydrake_mathematicalprogram) {
           const Eigen::Ref<const Eigen::VectorXd>&,
           const Eigen::Ref<const VectorXDecisionVariable>&))
          &MathematicalProgram::AddQuadraticCost)
+    .def("AddQuadraticCost", (Binding<QuadraticConstraint>
+         (MathematicalProgram::*)(const Expression&)) 
+         &MathematicalProgram::AddQuadraticCost)
     .def("Solve", &MathematicalProgram::Solve)
     .def("linear_constraints", &MathematicalProgram::linear_constraints)
     .def("linear_equality_constraints",

--- a/drake/bindings/pybind11/pydrake_symbolic.cc
+++ b/drake/bindings/pybind11/pydrake_symbolic.cc
@@ -11,121 +11,121 @@ PYBIND11_PLUGIN(symbolic) {
   using drake::symbolic::Variable;
   using drake::symbolic::Expression;
   using drake::symbolic::Formula;
+  using drake::symbolic::pow;
 
   py::module m("symbolic", "Symbolic variables, expressions, and formulae");
 
   py::class_<Variable>(m, "Variable")
     .def(py::init<const std::string&>())
     .def("__repr__", &Variable::to_string)
-    .def("__add__", [](const Variable& self,
-                       const Variable& other) {
+    .def("__add__", [](const Variable& self, const Variable& other) {
       return Expression{self + other};
-    })
+    }, py::is_operator())
     .def("__add__", [](const Variable& self, double other) {
       return Expression{self + other};
-    })
+    }, py::is_operator())
     .def("__add__", [](const Variable& self, const Expression& other) {
       return Expression{self + other};
-    })
+    }, py::is_operator())
     .def("__radd__", [](const Variable& self, double other) {
       return Expression{other + self};
-    })
-    .def("__sub__", [](const Variable& self,
-                       const Variable& other) {
+    }, py::is_operator())
+    .def("__sub__", [](const Variable& self, const Variable& other) {
       return Expression{self - other};
-    })
+    }, py::is_operator())
     .def("__sub__", [](const Variable& self, double other) {
       return Expression{self - other};
-    })
+    }, py::is_operator())
     .def("__sub__", [](const Variable& self, const Expression& other) {
       return Expression{self - other};
-    })
+    }, py::is_operator())
     .def("__rsub__", [](const Variable& self, double other) {
       return Expression{other - self};
-    })
-    .def("__mul__", [](const Variable& self,
-                       const Variable& other) {
+    }, py::is_operator())
+    .def("__mul__", [](const Variable& self, const Variable& other) {
       return Expression{self * other};
-    })
+    }, py::is_operator())
     .def("__mul__", [](const Variable& self, double other) {
       return Expression{self * other};
-    })
+    }, py::is_operator())
     .def("__mul__", [](const Variable& self, const Expression& other) {
       return Expression{self * other};
-    })
+    }, py::is_operator())
     .def("__rmul__", [](const Variable& self, double other) {
       return Expression{other * self};
-    })
-    .def("__truediv__", [](const Variable& self,
-                           const Variable& other) {
+    }, py::is_operator())
+    .def("__truediv__", [](const Variable& self, const Variable& other) {
       return Expression{self / other};
-    })
-    .def("__truediv__", [](const Variable& self,
-                           double other) {
+    }, py::is_operator())
+    .def("__truediv__", [](const Variable& self, double other) {
       return Expression{self / other};
-    })
+    }, py::is_operator())
     .def("__truediv__", [](const Variable& self, const Expression& other) {
       return Expression{self / other};
-    })
-    .def("__rtruediv__", [](const Variable& self,
-                            double other) {
+    }, py::is_operator())
+    .def("__rtruediv__", [](const Variable& self, double other) {
       return Expression{other / self};
-    })
-    .def("__lt__", [](const Variable& self,
-                      const Variable& other) {
+    }, py::is_operator())
+    .def("__pow__", [](const Variable& self, int other) {
+      return Expression{pow(self, other)};
+    }, py::is_operator())
+    .def("__pow__", [](const Variable& self, double other) {
+      return Expression{pow(self, other)};
+    }, py::is_operator())
+    .def("__pow__", [](const Variable& self, const Variable& other) {
+      return Expression{pow(self, other)};
+    }, py::is_operator())
+    .def("__pow__", [](const Variable& self, const Expression& other) {
+      return Expression{pow(self, other)};
+    }, py::is_operator())
+    .def("__neg__", [](const Variable& self) {
+      return Expression{-self};
+    }, py::is_operator())
+    .def("__lt__", [](const Variable& self, const Variable& other) {
       return Formula{Expression(self) < Expression(other)};
-    })
-    .def("__lt__", [](const Variable& self,
-                      double other) {
+    }, py::is_operator())
+    .def("__lt__", [](const Variable& self, double other) {
       return Formula{Expression(self) < Expression(other)};
-    })
+    }, py::is_operator())
     .def("__lt__", [](const Variable& self, const Expression& other) {
       return Formula{Expression(self) < other};
-    })
-    .def("__le__", [](const Variable& self,
-                      const Variable& other) {
+    }, py::is_operator())
+    .def("__le__", [](const Variable& self, const Variable& other) {
       return Formula{Expression(self) <= Expression(other)};
-    })
-    .def("__le__", [](const Variable& self,
-                      double other) {
+    }, py::is_operator())
+    .def("__le__", [](const Variable& self, double other) {
       return Formula{Expression(self) <= Expression(other)};
-    })
+    }, py::is_operator())
     .def("__le__", [](const Variable& self, const Expression& other) {
       return Formula{Expression(self) <= other};
-    })
-    .def("__gt__", [](const Variable& self,
-                      const Variable& other) {
+    }, py::is_operator())
+    .def("__gt__", [](const Variable& self, const Variable& other) {
       return Formula{Expression(self) > Expression(other)};
-    })
-    .def("__gt__", [](const Variable& self,
-                      double other) {
+    }, py::is_operator())
+    .def("__gt__", [](const Variable& self, double other) {
       return Formula{Expression(self) > Expression(other)};
-    })
+    }, py::is_operator())
     .def("__gt__", [](const Variable& self, const Expression& other) {
       return Formula{Expression(self) > other};
-    })
-    .def("__ge__", [](const Variable& self,
-                      const Variable& other) {
+    }, py::is_operator())
+    .def("__ge__", [](const Variable& self, const Variable& other) {
       return Formula{Expression(self) >= Expression(other)};
-    })
-    .def("__ge__", [](const Variable& self,
-                      double other) {
+    }, py::is_operator())
+    .def("__ge__", [](const Variable& self, double other) {
       return Formula{Expression(self) >= Expression(other)};
-    })
+    }, py::is_operator())
     .def("__ge__", [](const Variable& self, const Expression& other) {
       return Formula{Expression(self) >= other};
-    })
-    .def("__eq__", [](const Variable& self,
-                      const Variable& other) {
+    }, py::is_operator())
+    .def("__eq__", [](const Variable& self, const Variable& other) {
       return Formula{Expression(self) == Expression(other)};
-    })
-    .def("__eq__", [](const Variable& self,
-                      double other) {
+    }, py::is_operator())
+    .def("__eq__", [](const Variable& self, double other) {
       return Formula{Expression(self) == Expression(other)};
-    })
+    }, py::is_operator())
     .def("__eq__", [](const Variable& self, const Expression& other) {
       return Formula{Expression(self) == other};
-    });
+    }, py::is_operator());
 
 
   py::class_<Expression>(m, "Expression")
@@ -149,66 +149,81 @@ PYBIND11_PLUGIN(symbolic) {
     .def(py::self   / Variable())
     .def(py::self   / double())
     .def(double()   / py::self)
+    .def("__pow__", [](const Expression& self, int other) {
+      return pow(self, other);
+    }, py::is_operator())
+    .def("__pow__", [](const Expression& self, double other) {
+      return pow(self, other);
+    }, py::is_operator())
+    .def("__pow__", [](const Expression& self, const Variable& other) {
+      return pow(self, other);
+    }, py::is_operator())
+    .def("__pow__", [](const Expression& self, const Expression& other) {
+      return pow(self, other);
+    }, py::is_operator())
+    .def("__neg__", [](const Expression& self) {
+      return -self;
+    }, py::is_operator())
     .def("__lt__", [](const Expression& self,
                       const Variable& other) {
       return Formula{Expression(self) < Expression(other)};
-    })
+    }, py::is_operator())
     .def("__lt__", [](const Expression& self,
                       const Expression& other) {
       return Formula{Expression(self) < Expression(other)};
-    })
+    }, py::is_operator())
     .def("__lt__", [](const Expression& self,
                       double other) {
       return Formula{Expression(self) < Expression(other)};
-    })
+    }, py::is_operator())
     .def("__le__", [](const Expression& self,
                       const Variable& other) {
       return Formula{Expression(self) <= Expression(other)};
-    })
+    }, py::is_operator())
     .def("__le__", [](const Expression& self,
                       const Expression& other) {
       return Formula{Expression(self) <= Expression(other)};
-    })
+    }, py::is_operator())
     .def("__le__", [](const Expression& self,
                       double other) {
       return Formula{Expression(self) <= Expression(other)};
-    })
+    }, py::is_operator())
     .def("__gt__", [](const Expression& self,
                       const Variable& other) {
       return Formula{Expression(self) > Expression(other)};
-    })
+    }, py::is_operator())
     .def("__gt__", [](const Expression& self,
                       const Expression& other) {
       return Formula{Expression(self) > Expression(other)};
-    })
+    }, py::is_operator())
     .def("__gt__", [](const Expression& self,
                       double other) {
       return Formula{Expression(self) > Expression(other)};
-    })
+    }, py::is_operator())
     .def("__ge__", [](const Expression& self,
                       const Variable& other) {
       return Formula{Expression(self) >= Expression(other)};
-    })
+    }, py::is_operator())
     .def("__ge__", [](const Expression& self,
                       const Expression& other) {
       return Formula{Expression(self) >= Expression(other)};
-    })
+    }, py::is_operator())
     .def("__ge__", [](const Expression& self,
                       double other) {
       return Formula{Expression(self) >= Expression(other)};
-    })
+    }, py::is_operator())
     .def("__eq__", [](const Expression& self,
                       const Variable& other) {
       return Formula{Expression(self) == Expression(other)};
-    })
+    }, py::is_operator())
     .def("__eq__", [](const Expression& self,
                       const Expression& other) {
       return Formula{Expression(self) == Expression(other)};
-    })
+    }, py::is_operator())
     .def("__eq__", [](const Expression& self,
                       double other) {
       return Formula{Expression(self) == Expression(other)};
-    });
+    }, py::is_operator());
 
   py::class_<Formula>(m, "Formula")
     .def("__repr__", &Formula::to_string);

--- a/drake/bindings/python/pydrake/test/testMathematicalProgram.py
+++ b/drake/bindings/python/pydrake/test/testMathematicalProgram.py
@@ -44,6 +44,18 @@ class TestMathematicalProgram(unittest.TestCase):
         x_expected = np.array([1, 1])
         self.assertTrue(np.allclose(prog.GetSolution(x), x_expected))
 
+    def test_symbolic_qp(self):
+        prog = mp.MathematicalProgram()
+        x = prog.NewContinuousVariables(2, "x")
+        prog.AddLinearConstraint(x[0] >= 1)
+        prog.AddLinearConstraint(x[1] >= 1)
+        prog.AddQuadraticCost(x[0]**2 + x[1]**2)
+        result = prog.Solve()
+        self.assertEqual(result, mp.SolutionResult.kSolutionFound)
+
+        x_expected = np.array([1, 1])
+        self.assertTrue(np.allclose(prog.GetSolution(x), x_expected))
+
     def test_bindings(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, "x")

--- a/drake/bindings/python/pydrake/test/testSymbolic.py
+++ b/drake/bindings/python/pydrake/test/testSymbolic.py
@@ -44,6 +44,17 @@ class TestSymbolicVariables(unittest.TestCase):
         self.assertEqual(str(ex), "(2 * (x + y))")
         self.assertEqual(str(ex.Expand()), "(2 * x + 2 * y)")
 
+    def testPow(self):
+        x = sym.Variable("x")
+        self.assertEqual(str(x**2), "pow(x, 2)")
+        y = sym.Variable("y")
+        self.assertEqual(str(x**y), "pow(x, y)")
+        self.assertEqual(str((x + 1)**(y - 1)), "pow((1 + x), (-1 + y))")
+
+    def testNeg(self):
+        x = sym.Variable("x")
+        self.assertEqual(str(-x), "(-1 * x)")
+        self.assertEqual(str(-(x + 1)), "(-1 - x)")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This also adds the [missing `py::is_operator()`](http://pybind11.readthedocs.io/en/master/advanced/classes.html#operator-overloading) to our symbolic and autodiff wrapped types. ~~I still need to do that for the autodiff types (it's not a big problem: it just affects the type of error that is thrown when you try to do something that isn't implemented)~~.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5275)
<!-- Reviewable:end -->
