### PR TITLE
Make ContinuousState(state,q,v,z) protected

### DIFF
--- a/drake/systems/framework/continuous_state.h
+++ b/drake/systems/framework/continuous_state.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
@@ -34,6 +35,7 @@ class ContinuousState {
     generalized_velocity_.reset(new Subvector<T>(state_.get()));
     misc_continuous_state_.reset(
         new Subvector<T>(state_.get(), 0, state_->size()));
+    DRAKE_ASSERT_VOID(DemandInvariants());
   }
 
   /// Constructs a ContinuousState that exposes second-order structure.
@@ -71,6 +73,7 @@ class ContinuousState {
     generalized_velocity_.reset(new Subvector<T>(state_.get(), num_q, num_v));
     misc_continuous_state_.reset(
         new Subvector<T>(state_.get(), num_q + num_v, num_z));
+    DRAKE_ASSERT_VOID(DemandInvariants());
   }
 
   /// Constructs a zero-length ContinuousState.
@@ -168,11 +171,7 @@ class ContinuousState {
         generalized_position_(std::move(q)),
         generalized_velocity_(std::move(v)),
         misc_continuous_state_(std::move(z)) {
-    const int num_q = generalized_position_->size();
-    const int num_v = generalized_velocity_->size();
-    const int n = num_q + num_v + misc_continuous_state_->size();
-    DRAKE_ASSERT(state_->size() == n);
-    DRAKE_ASSERT(num_v <= num_q);
+    DRAKE_ASSERT_VOID(DemandInvariants());
   }
 
  private:
@@ -186,6 +185,55 @@ class ContinuousState {
     DRAKE_DEMAND(get_misc_continuous_state().size() ==
         other.get_misc_continuous_state().size());
     SetFromVector(other.CopyToVector().template cast<T>());
+  }
+
+  // Demand that the representation invariants hold.
+  void DemandInvariants() const {
+    // Nothing is nullptr.
+    DRAKE_DEMAND(!!generalized_position_);
+    DRAKE_DEMAND(!!generalized_velocity_);
+    DRAKE_DEMAND(!!misc_continuous_state_);
+
+    // The sizes are consistent.
+    const int num_q = generalized_position_->size();
+    const int num_v = generalized_velocity_->size();
+    const int num_z = misc_continuous_state_->size();
+    const int num_total = (num_q + num_v + num_z);
+    DRAKE_DEMAND(num_q >= 0);
+    DRAKE_DEMAND(num_v >= 0);
+    DRAKE_DEMAND(num_z >= 0);
+    DRAKE_DEMAND(num_v <= num_q);
+    DRAKE_DEMAND(state_->size() == num_total);
+
+    // The storage addresses of `state_` elements contain no duplicates.
+    std::unordered_set<const T*> state_element_pointers;
+    for (int i = 0; i < num_total; ++i) {
+      const T* element = &(state_->GetAtIndex(i));
+      state_element_pointers.emplace(element);
+    }
+    DRAKE_DEMAND(static_cast<int>(state_element_pointers.size()) == num_total);
+
+    // The storage addresses of (q, v, z) elements contain no duplicates, and
+    // are drawn from the set of storage addresses of `state_` elements.
+    // Therefore, the `state_` vector and (q, v, z) vectors form views into the
+    // same unique underlying data, just with different indexing.
+    std::unordered_set<const T*> qvz_element_pointers;
+    for (int i = 0; i < num_q; ++i) {
+      const T* element = &(generalized_position_->GetAtIndex(i));
+      qvz_element_pointers.emplace(element);
+      DRAKE_DEMAND(state_element_pointers.count(element) == 1);
+    }
+    for (int i = 0; i < num_v; ++i) {
+      const T* element = &(generalized_velocity_->GetAtIndex(i));
+      qvz_element_pointers.emplace(element);
+      DRAKE_DEMAND(state_element_pointers.count(element) == 1);
+    }
+    for (int i = 0; i < num_z; ++i) {
+      const T* element = &(misc_continuous_state_->GetAtIndex(i));
+      qvz_element_pointers.emplace(element);
+      DRAKE_DEMAND(state_element_pointers.count(element) == 1);
+    }
+    DRAKE_DEMAND(static_cast<int>(qvz_element_pointers.size()) == num_total);
   }
 
   // The entire continuous state vector.  May or may not own the underlying

--- a/drake/systems/framework/continuous_state.h
+++ b/drake/systems/framework/continuous_state.h
@@ -73,28 +73,6 @@ class ContinuousState {
         new Subvector<T>(state_.get(), num_q + num_v, num_z));
   }
 
-  /// Constructs a continuous state that exposes second-order structure, with
-  /// no particular constraints on the layout.
-  ///
-  /// @param state The entire continuous state.
-  /// @param q The subset of state that is generalized position.
-  /// @param v The subset of state that is generalized velocity.
-  /// @param z The subset of state that is neither position nor velocity.
-  ContinuousState(std::unique_ptr<VectorBase<T>> state,
-                  std::unique_ptr<VectorBase<T>> q,
-                  std::unique_ptr<VectorBase<T>> v,
-                  std::unique_ptr<VectorBase<T>> z)
-      : state_(std::move(state)),
-        generalized_position_(std::move(q)),
-        generalized_velocity_(std::move(v)),
-        misc_continuous_state_(std::move(z)) {
-    const int num_q = generalized_position_->size();
-    const int num_v = generalized_velocity_->size();
-    const int n = num_q + num_v + misc_continuous_state_->size();
-    DRAKE_ASSERT(state_->size() == n);
-    DRAKE_ASSERT(num_v <= num_q);
-  }
-
   /// Constructs a zero-length ContinuousState.
   ContinuousState()
       : ContinuousState(std::make_unique<BasicVector<T>>(0)) {}
@@ -171,6 +149,31 @@ class ContinuousState {
 
   /// Returns a copy of the entire continuous state vector into an Eigen vector.
   VectorX<T> CopyToVector() const { return this->get_vector().CopyToVector(); }
+
+ protected:
+  /// Constructs a continuous state that exposes second-order structure, with
+  /// no particular constraints on the layout.
+  ///
+  /// @pre The q, v, z are all views into the same storage as @p state.
+  ///
+  /// @param state The entire continuous state.
+  /// @param q The subset of state that is generalized position.
+  /// @param v The subset of state that is generalized velocity.
+  /// @param z The subset of state that is neither position nor velocity.
+  ContinuousState(std::unique_ptr<VectorBase<T>> state,
+                  std::unique_ptr<VectorBase<T>> q,
+                  std::unique_ptr<VectorBase<T>> v,
+                  std::unique_ptr<VectorBase<T>> z)
+      : state_(std::move(state)),
+        generalized_position_(std::move(q)),
+        generalized_velocity_(std::move(v)),
+        misc_continuous_state_(std::move(z)) {
+    const int num_q = generalized_position_->size();
+    const int num_v = generalized_velocity_->size();
+    const int n = num_q + num_v + misc_continuous_state_->size();
+    DRAKE_ASSERT(state_->size() == n);
+    DRAKE_ASSERT(num_v <= num_q);
+  }
 
  private:
   template <typename U>

--- a/drake/systems/framework/diagram_continuous_state.h
+++ b/drake/systems/framework/diagram_continuous_state.h
@@ -55,34 +55,30 @@ class DiagramContinuousState : public ContinuousState<T> {
   // substate in @p substates, as indicated by @p selector.
   static std::unique_ptr<VectorBase<T>> Span(
       const std::vector<ContinuousState<T>*>& substates,
-      std::function<VectorBase<T>*(ContinuousState<T>&)> selector) {
+      std::function<VectorBase<T>*(ContinuousState<T>*)> selector) {
     std::vector<VectorBase<T>*> sub_xs;
     for (const auto& substate : substates) {
       DRAKE_DEMAND(substate != nullptr);
-      sub_xs.push_back(selector(*substate));
+      sub_xs.push_back(selector(substate));
     }
     return std::make_unique<Supervector<T>>(sub_xs);
   }
 
   // Returns the entire state vector in @p xc.
-  // TODO(#2274) Fix this NOLINTNEXTLINE(runtime/references).
-  static VectorBase<T>* x_selector(ContinuousState<T>& xc) {
-    return xc.get_mutable_vector();
+  static VectorBase<T>* x_selector(ContinuousState<T>* xc) {
+    return xc->get_mutable_vector();
   }
   // Returns the generalized position vector in @p xc.
-  // TODO(#2274) Fix this NOLINTNEXTLINE(runtime/references).
-  static VectorBase<T>* q_selector(ContinuousState<T>& xc) {
-    return xc.get_mutable_generalized_position();
+  static VectorBase<T>* q_selector(ContinuousState<T>* xc) {
+    return xc->get_mutable_generalized_position();
   }
   // Returns the generalized velocity vector in @p xc.
-  // TODO(#2274) Fix this NOLINTNEXTLINE(runtime/references).
-  static VectorBase<T>* v_selector(ContinuousState<T>& xc) {
-    return xc.get_mutable_generalized_velocity();
+  static VectorBase<T>* v_selector(ContinuousState<T>* xc) {
+    return xc->get_mutable_generalized_velocity();
   }
   // Returns the misc continuous state vector in @p xc.
-  // TODO(#2274) Fix this NOLINTNEXTLINE(runtime/references).
-  static VectorBase<T>* z_selector(ContinuousState<T>& xc) {
-    return xc.get_mutable_misc_continuous_state();
+  static VectorBase<T>* z_selector(ContinuousState<T>* xc) {
+    return xc->get_mutable_misc_continuous_state();
   }
 
   std::vector<ContinuousState<T>*> substates_;


### PR DESCRIPTION
The fact that q,v,z were a view into state was a bit subtle in the API comment, so we clarify that slightly; we also make the constructor protected because it is only needed by Diagram and will do very bad things if a naive user tries to call it with BasicVectors.  We also fix up some NOLINT suppressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5276)
<!-- Reviewable:end -->
