### PR TITLE
split atlas / valkyrie specific content from joint level controller.

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
@@ -29,6 +29,15 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "atlas_joint_level_controller_system",
+    srcs = ["atlas_joint_level_controller_system.cc"],
+    hdrs = ["atlas_joint_level_controller_system.h"],
+    deps = [
+        ":joint_level_controller_system",
+    ],
+)
+
+drake_cc_library(
     name = "plan_eval_system",
     srcs = ["plan_eval_system.cc"],
     hdrs = ["plan_eval_system.h"],
@@ -68,7 +77,7 @@ drake_cc_binary(
         "local",
     ],
     deps = [
-        ":joint_level_controller_system",
+        ":atlas_joint_level_controller_system",
         ":plan_eval_system",
         ":qp_controller_system",
         ":humanoid_status_translator_system",
@@ -107,5 +116,18 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "joint_level_controller_system_test",
+    srcs = ["test/joint_level_controller_system_test.cc"],
+    data = [
+        "//drake/examples/Valkyrie:models",
+    ],
+    deps = [
+        ":atlas_joint_level_controller_system",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/systems/framework",
+        "//drake/multibody/parsers",
+    ],
+)
 
 cpplint()

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.cc
@@ -1,0 +1,92 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h"
+
+#include <memory>
+
+#include "bot_core/atlas_command_t.hpp"
+#include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller_common.h"
+#include "drake/util/drakeUtil.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+AtlasJointLevelControllerSystem::AtlasJointLevelControllerSystem(
+    const RigidBodyTree<double>& robot)
+    : JointLevelControllerBaseSystem(robot) {
+  output_port_index_atlas_cmd_ = DeclareAbstractOutputPort().get_index();
+
+  // TODO(siyuan.feng): Load gains from some config.
+  const int act_size = get_robot().get_num_actuators();
+  k_q_p_ = VectorX<double>::Zero(act_size);
+  k_q_i_ = VectorX<double>::Zero(act_size);
+  k_qd_p_ = VectorX<double>::Zero(act_size);
+  k_f_p_ = VectorX<double>::Zero(act_size);
+  ff_qd_ = VectorX<double>::Zero(act_size);
+  ff_qd_d_ = VectorX<double>::Zero(act_size);
+  // Directly feed torque through without any other feedbacks.
+  ff_f_d_ = VectorX<double>::Constant(act_size, 1.);
+  ff_const_ = VectorX<double>::Zero(act_size);
+}
+
+void AtlasJointLevelControllerSystem::DoCalcExtendedOutput(
+    const systems::Context<double>& context,
+    systems::SystemOutput<double>* output) const {
+  // Gets a mutable reference to bot_core::atlas_command_t from output.
+  bot_core::atlas_command_t& msg =
+      output->GetMutableData(output_port_index_atlas_cmd_)
+          ->GetMutableValue<bot_core::atlas_command_t>();
+
+  // Makes bot_core::atlas_command_t message.
+  msg.utime = static_cast<uint64_t>(context.get_time() * 1e6);
+
+  msg.num_joints = get_robot().get_num_actuators();
+  msg.joint_names.resize(msg.num_joints);
+  msg.position.resize(msg.num_joints);
+  msg.velocity.resize(msg.num_joints);
+  msg.effort.resize(msg.num_joints);
+
+  // The torques have already been computed and set in
+  // JointLevelControllerBaseSystem::DoCalcOutput()
+  VectorX<double> act_torques =
+      output->get_vector_data(get_output_port_torque().get_index())
+          ->get_value();
+
+  // Set desired position, velocity and torque for all actuators.
+  for (int i = 0; i < msg.num_joints; ++i) {
+    msg.joint_names[i] = get_robot().actuators[i].name_;
+    msg.position[i] = 0;
+    msg.velocity[i] = 0;
+    msg.effort[i] = act_torques[i];
+  }
+
+  eigenVectorToStdVector(k_q_p_, msg.k_q_p);
+  eigenVectorToStdVector(k_q_i_, msg.k_q_i);
+  eigenVectorToStdVector(k_qd_p_, msg.k_qd_p);
+  eigenVectorToStdVector(k_f_p_, msg.k_f_p);
+  eigenVectorToStdVector(ff_qd_, msg.ff_qd);
+  eigenVectorToStdVector(ff_qd_d_, msg.ff_qd_d);
+  eigenVectorToStdVector(ff_f_d_, msg.ff_f_d);
+  eigenVectorToStdVector(ff_const_, msg.ff_const);
+
+  // This is only used for the Virtual Robotics Challenge's gazebo simulator.
+  // Should be deprecated by now.
+  msg.k_effort.resize(msg.num_joints, 0);
+  // TODO(siyuan.feng): I am not sure what this does exactly, most likely for
+  // deprecated simulation as well.
+  // Consider removing this from atlas_command_t.
+  msg.desired_controller_period_ms = 0;
+}
+
+std::unique_ptr<systems::AbstractValue>
+AtlasJointLevelControllerSystem::AllocateOutputAbstract(
+    const systems::OutputPortDescriptor<double>& descriptor) const {
+  DRAKE_DEMAND(output_port_index_atlas_cmd_ == descriptor.get_index());
+
+  return systems::AbstractValue::Make<bot_core::atlas_command_t>(
+      bot_core::atlas_command_t());
+}
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+/**
+ * A class that extends JointLevelControllerBaseSystem to output an additional
+ * bot_core::atlas_command_t.
+ */
+class AtlasJointLevelControllerSystem : public JointLevelControllerBaseSystem {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AtlasJointLevelControllerSystem)
+
+  /**
+   * @param robot A reference to the RigidBodyTree within the plant that is
+   * being controlled. The lifespan of this reference must exceed that of this
+   * class's instance. @p robot should only contain a single model instance.
+   */
+  explicit AtlasJointLevelControllerSystem(const RigidBodyTree<double>& robot);
+
+  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
+      const systems::OutputPortDescriptor<double>& descriptor) const override;
+
+  /**
+   * Returns the output port for bot_core::atlas_command_t.
+   */
+  inline const systems::OutputPortDescriptor<double>&
+  get_output_port_atlas_command() const {
+    return get_output_port(output_port_index_atlas_cmd_);
+  }
+
+ private:
+  // Generates an additional bot_core::atlas_command_t output.
+  void DoCalcExtendedOutput(
+      const systems::Context<double>& context,
+      systems::SystemOutput<double>* output) const override;
+
+  int output_port_index_atlas_cmd_{0};
+
+  // Joint level gains. These are in the actuator order within the
+  // RigidBodyTree. These names are chosen to exactly match the API provided
+  // by Boston Dynamics for the Atlas robot. ff stands for feedforward, f
+  // stands for force.
+  VectorX<double> k_q_p_;
+  VectorX<double> k_q_i_;
+  VectorX<double> k_qd_p_;
+  VectorX<double> k_f_p_;
+  VectorX<double> ff_qd_;
+  VectorX<double> ff_qd_d_;
+  VectorX<double> ff_f_d_;
+  VectorX<double> ff_const_;
+};
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.cc
@@ -1,104 +1,37 @@
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h"
 
-#include <memory>
-#include <utility>
-
-#include "bot_core/atlas_command_t.hpp"
-#include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller.h"
-#include "drake/util/drakeUtil.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller_common.h"
 
 namespace drake {
 namespace examples {
 namespace qp_inverse_dynamics {
 
-JointLevelControllerSystem::JointLevelControllerSystem(
+JointLevelControllerBaseSystem::JointLevelControllerBaseSystem(
     const RigidBodyTree<double>& robot)
     : robot_(robot) {
-  in_port_idx_qp_output_ = DeclareAbstractInputPort().get_index();
-
-  in_port_idx_humanoid_status_ = DeclareAbstractInputPort().get_index();
-
-  out_port_index_atlas_cmd_ = DeclareAbstractOutputPort().get_index();
-
-  // TODO(siyuan.feng): Load gains from some config file.
-  const int act_size = robot_.get_num_actuators();
-  k_q_p_ = VectorX<double>::Zero(act_size);
-  k_q_i_ = VectorX<double>::Zero(act_size);
-  k_qd_p_ = VectorX<double>::Zero(act_size);
-  k_f_p_ = VectorX<double>::Zero(act_size);
-  ff_qd_ = VectorX<double>::Zero(act_size);
-  ff_qd_d_ = VectorX<double>::Zero(act_size);
-  // Directly feed torque through without any other feedback.
-  ff_f_d_ = VectorX<double>::Constant(act_size, 1.);
-  ff_const_ = VectorX<double>::Zero(act_size);
+  input_port_index_qp_output_ = DeclareAbstractInputPort().get_index();
+  output_port_index_torque_ =
+      DeclareOutputPort(systems::kVectorValued, robot_.get_num_actuators())
+          .get_index();
 }
 
-void JointLevelControllerSystem::DoCalcOutput(
+void JointLevelControllerBaseSystem::DoCalcOutput(
     const systems::Context<double>& context,
     systems::SystemOutput<double>* output) const {
-  // Inputs
+  // Input:
   const QpOutput* qp_output =
-      EvalInputValue<QpOutput>(context, in_port_idx_qp_output_);
-  const HumanoidStatus* rs =
-      EvalInputValue<HumanoidStatus>(context, in_port_idx_humanoid_status_);
+      EvalInputValue<QpOutput>(context, input_port_index_qp_output_);
 
-  // Output
-  bot_core::atlas_command_t& msg =
-      output->GetMutableData(out_port_index_atlas_cmd_)
-          ->GetMutableValue<bot_core::atlas_command_t>();
+  // Output:
+  auto out_vector = GetMutableOutputVector(output, output_port_index_torque_);
 
-  // Make bot_core::atlas_command_t message.
-  msg.utime = static_cast<uint64_t>(rs->time() * 1e6);
+  out_vector = robot_.B.transpose() * qp_output->dof_torques();
 
-  int act_size = robot_.get_num_actuators();
-  msg.num_joints = act_size;
-  msg.joint_names.resize(msg.num_joints);
-  msg.position.resize(msg.num_joints);
-  msg.velocity.resize(msg.num_joints);
-  msg.effort.resize(msg.num_joints);
+  DRAKE_ASSERT(out_vector.size() == robot_.get_num_actuators());
 
-  // bot_core::atlas_command_t assumes the joints are in actuator ordering.
-  // dof torque = RigidBodyTree.B * actuator torque.
-  // Assuming no coupling among joints,
-  // actuator torque = RigidBodyTree.B.transpose() * dof torque
-  VectorX<double> act_torques = robot_.B.transpose() * qp_output->dof_torques();
-  if (act_torques.size() != act_size) {
-    throw std::runtime_error("torque dimension mismatch.");
-  }
-
-  // Set desired position, velocity and torque for all actuators.
-  for (int i = 0; i < act_size; ++i) {
-    msg.joint_names[i] = robot_.actuators[i].name_;
-    msg.position[i] = 0;
-    msg.velocity[i] = 0;
-    msg.effort[i] = act_torques[i];
-  }
-
-  eigenVectorToStdVector(k_q_p_, msg.k_q_p);
-  eigenVectorToStdVector(k_q_i_, msg.k_q_i);
-  eigenVectorToStdVector(k_qd_p_, msg.k_qd_p);
-  eigenVectorToStdVector(k_f_p_, msg.k_f_p);
-  eigenVectorToStdVector(ff_qd_, msg.ff_qd);
-  eigenVectorToStdVector(ff_qd_d_, msg.ff_qd_d);
-  eigenVectorToStdVector(ff_f_d_, msg.ff_f_d);
-  eigenVectorToStdVector(ff_const_, msg.ff_const);
-
-  // This is only used for the Virtual Robotics Challenge's Gazebo simulator.
-  // Should be deprecated by now.
-  msg.k_effort.resize(msg.num_joints, 0);
-  // TODO(siyuan.feng): I am not sure what this does exactly, most likely for
-  // deprecated simulation as well.
-  // Consider removing this from atlas_command_t.
-  msg.desired_controller_period_ms = 0;
-}
-
-std::unique_ptr<systems::AbstractValue>
-JointLevelControllerSystem::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  DRAKE_DEMAND(out_port_index_atlas_cmd_ == descriptor.get_index());
-
-  return systems::AbstractValue::Make<bot_core::atlas_command_t>(
-      bot_core::atlas_command_t());
+  // Call Derived class's extended methods.
+  DoCalcExtendedOutput(context, output);
 }
 
 }  // namespace qp_inverse_dynamics

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -10,69 +11,83 @@ namespace examples {
 namespace qp_inverse_dynamics {
 
 /**
- * A stub for a more complex interface for joint level controllers.
- * The idea is to separate all joint level control from the higher level
- * full state feedback controller, e.g. qp inverse dynamics controller.
- * This can also run at a higher rate than the full state feedback controller.
- *
- * Possible things to be implemented here:
- *  joint level set points, gains, integrators, filters,
- *  disturbance observers, etc.
- *
- * Input: HumanoidStatus
- * Input: QpOutput
- * Output: lcm message bot_core::atlas_command_t in channel "ROBOT_COMMAND"
+ * An abstract base class that translates a QpOutput to a vector of torque
+ * commands in the actuator order within the RigidBodyTree. Derived classes
+ * need to implement DoCalcExtendedOutput() to generate additional custom
+ * outputs.
  */
-class JointLevelControllerSystem : public systems::LeafSystem<double> {
+class JointLevelControllerBaseSystem : public systems::LeafSystem<double> {
  public:
-  explicit JointLevelControllerSystem(const RigidBodyTree<double>& robot);
-
-  void DoCalcOutput(const systems::Context<double>& context,
-                    systems::SystemOutput<double>* output) const override;
-
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JointLevelControllerBaseSystem)
 
   /**
-   * @return Port for the input: HumanoidStatus.
+   * @param robot A reference to the RigidBodyTree within the plant that is
+   * being controlled. The lifespan of this reference must exceed that of this
+   * class's instance. @p robot should only contain a single model instance.
    */
-  inline const systems::InputPortDescriptor<double>&
-  get_input_port_humanoid_status() const {
-    return get_input_port(in_port_idx_humanoid_status_);
-  }
+  explicit JointLevelControllerBaseSystem(const RigidBodyTree<double>& robot);
 
   /**
-   * @return Port for the input: QpOutput.
+   * Returns the input port for QpOutput.
    */
   inline const systems::InputPortDescriptor<double>& get_input_port_qp_output()
       const {
-    return get_input_port(in_port_idx_qp_output_);
+    return get_input_port(input_port_index_qp_output_);
   }
 
   /**
-   * @return Port for the output: bot_core::atlas_command_t message
+   * Returns the output port for the torques.
    */
-  inline const systems::OutputPortDescriptor<double>&
-  get_output_port_atlas_command() const {
-    return get_output_port(out_port_index_atlas_cmd_);
+  inline const systems::OutputPortDescriptor<double>& get_output_port_torque()
+      const {
+    return get_output_port(output_port_index_torque_);
   }
 
+  inline const RigidBodyTree<double>& get_robot() const { return robot_; }
+
+ protected:
+  /**
+   * Derived classes can implement custom outputs in this function. It is called
+   * by DoCalcOutput(), and it is safe to assume that output port returned by
+   * get_output_port_torque() is already filled.
+   */
+  virtual void DoCalcExtendedOutput(
+      const systems::Context<double>& context,
+      systems::SystemOutput<double>* output) const = 0;
+
  private:
+  // Extracts the torques from a QpOutput and output them in the actuator order
+  // within the RigidBodyTree passed to the constructor. More specifically, the
+  // output is `tau_act = B^T * qp_output.dof_torques`, where `B` is the
+  // selection matrix that maps the actuator indices to the generalized
+  // coordinate indices. Then calls DoCalcExtendedOutput(). Derived classes need
+  // to implement DoCalcExtendedOutput(), and can assume that output port
+  // returned by get_output_port_torque() is already filled.
+  void DoCalcOutput(const systems::Context<double>& context,
+                    systems::SystemOutput<double>* output) const final;
+
   const RigidBodyTree<double>& robot_;
 
-  int in_port_idx_qp_output_;
-  int in_port_idx_humanoid_status_;
-  int out_port_index_atlas_cmd_;
+  int input_port_index_qp_output_{0};
+  int output_port_index_torque_{0};
+};
 
-  // Joint level gains, these are in actuator order.
-  VectorX<double> k_q_p_;
-  VectorX<double> k_q_i_;
-  VectorX<double> k_qd_p_;
-  VectorX<double> k_f_p_;
-  VectorX<double> ff_qd_;
-  VectorX<double> ff_qd_d_;
-  VectorX<double> ff_f_d_;
-  VectorX<double> ff_const_;
+/**
+ * Translates a QpOutput to a vector of torque commands in the actuator order
+ * within the RigidBodyTree.
+ */
+class TrivialJointLevelControllerSystem
+    : public JointLevelControllerBaseSystem {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrivialJointLevelControllerSystem);
+
+  explicit TrivialJointLevelControllerSystem(const RigidBodyTree<double>& robot)
+      : JointLevelControllerBaseSystem(robot) {}
+
+ private:
+  void DoCalcExtendedOutput(const systems::Context<double>& context,
+                            systems::SystemOutput<double>* output) const final {
+  }
 };
 
 }  // namespace qp_inverse_dynamics

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/joint_level_controller_system_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/joint_level_controller_system_test.cc
@@ -1,0 +1,120 @@
+#include <memory>
+
+#include "bot_core/atlas_command_t.hpp"
+
+#include "gtest/gtest.h"
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller_common.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+class JointLevelControllerTest : public ::testing::Test {
+ protected:
+  template <typename ControllerType>
+  void Init() {
+    robot_ = std::make_unique<RigidBodyTree<double>>();
+    // Use this model because the dof order and actuator order are different.
+    parsers::urdf::AddModelInstanceFromUrdfFile(
+        GetDrakePath() +
+            "/examples/Valkyrie/urdf/urdf/"
+            "valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf",
+        drake::multibody::joints::kQuaternion, nullptr /* weld to frame */,
+        robot_.get());
+
+    dut_ = std::make_unique<ControllerType>(*robot_);
+    context_ = dut_->CreateDefaultContext();
+    output_ = dut_->AllocateOutput(*context_);
+
+    context_->set_time(3.);
+
+    qp_output_ = std::make_unique<QpOutput>(GetDofNames(*robot_));
+    for (int i = 0; i < qp_output_->dof_torques().size(); i++) {
+      qp_output_->mutable_dof_torques()[i] = i * 0.3;
+    }
+
+    auto input = systems::AbstractValue::Make<QpOutput>(*qp_output_);
+    context_->FixInputPort(dut_->get_input_port_qp_output().get_index(),
+                           std::move(input));
+
+    dut_->CalcOutput(*context_, output_.get());
+  }
+
+  std::unique_ptr<RigidBodyTree<double>> robot_;
+  std::unique_ptr<JointLevelControllerBaseSystem> dut_;
+  std::unique_ptr<systems::Context<double>> context_;
+  std::unique_ptr<systems::SystemOutput<double>> output_;
+  std::unique_ptr<QpOutput> qp_output_;
+};
+
+// Checks that TrivialJointLevelControllerSystem's torque output port's value
+// equals RBT.B^T * qp_output.dof_torques().
+TEST_F(JointLevelControllerTest, TrivialJointLevelControllerSystemTest) {
+  Init<TrivialJointLevelControllerSystem>();
+
+  VectorX<double> expected_torque =
+      robot_->B.transpose() * qp_output_->dof_torques();
+  VectorX<double> dut_output =
+      output_->get_vector_data(dut_->get_output_port_torque().get_index())
+          ->get_value();
+
+  EXPECT_TRUE(drake::CompareMatrices(expected_torque, dut_output, 1e-12,
+                                     drake::MatrixCompareType::absolute));
+}
+
+// Checks that AtlasJointLevelControllerSystem's torque output port's value
+// equals RBT.B^T * qp_output.dof_torques().
+// Also checks that AtlasJointLevelControllerSystem's bot_core::atlas_command_t
+// output matches expected.
+TEST_F(JointLevelControllerTest, AtlasJointLevelControllerTest) {
+  Init<AtlasJointLevelControllerSystem>();
+
+  VectorX<double> expected_torque =
+      robot_->B.transpose() * qp_output_->dof_torques();
+  VectorX<double> dut_output =
+      output_->get_vector_data(dut_->get_output_port_torque().get_index())
+          ->get_value();
+
+  // Checks raw vector output.
+  EXPECT_TRUE(drake::CompareMatrices(expected_torque, dut_output, 1e-12,
+                                     drake::MatrixCompareType::absolute));
+
+  // Checks bot_core::atlas_command_t output.
+  const bot_core::atlas_command_t& dut_output_msg =
+      output_
+          ->get_data(dynamic_cast<AtlasJointLevelControllerSystem*>(dut_.get())
+                         ->get_output_port_atlas_command()
+                         .get_index())
+          ->GetValue<bot_core::atlas_command_t>();
+
+  EXPECT_EQ(dut_output_msg.utime,
+            static_cast<uint64_t>(context_->get_time() * 1e6));
+  EXPECT_EQ(dut_output_msg.num_joints, robot_->get_num_actuators());
+  for (int i = 0; i < dut_output_msg.num_joints; i++) {
+    EXPECT_EQ(dut_output_msg.joint_names[i], robot_->actuators[i].name_);
+    EXPECT_EQ(dut_output_msg.position[i], 0);
+    EXPECT_EQ(dut_output_msg.velocity[i], 0);
+    EXPECT_EQ(dut_output_msg.effort[i], expected_torque[i]);
+
+    EXPECT_EQ(dut_output_msg.k_q_p[i], 0);
+    EXPECT_EQ(dut_output_msg.k_q_i[i], 0);
+    EXPECT_EQ(dut_output_msg.k_qd_p[i], 0);
+    EXPECT_EQ(dut_output_msg.k_f_p[i], 0);
+    EXPECT_EQ(dut_output_msg.ff_qd[i], 0);
+    EXPECT_EQ(dut_output_msg.ff_qd_d[i], 0);
+    EXPECT_EQ(dut_output_msg.ff_f_d[i], 1);
+    EXPECT_EQ(dut_output_msg.ff_const[i], 0);
+  }
+}
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_balancing_controller_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_balancing_controller_system.cc
@@ -7,7 +7,7 @@
 #include "drake/common/drake_path.h"
 #include "drake/common/text_logging.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.h"
-#include "drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_system.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h"
 #include "drake/examples/Valkyrie/valkyrie_constants.h"
@@ -53,8 +53,8 @@ void controller_loop() {
       builder.AddSystem(std::make_unique<PlanEvalSystem>(*robot));
   QpControllerSystem* qp_con =
       builder.AddSystem(std::make_unique<QpControllerSystem>(*robot, 0.003));
-  JointLevelControllerSystem* joint_con =
-      builder.AddSystem<JointLevelControllerSystem>(*robot);
+  AtlasJointLevelControllerSystem* joint_con =
+      builder.AddSystem<AtlasJointLevelControllerSystem>(*robot);
 
   auto& robot_state_subscriber = *builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<bot_core::robot_state_t>(
@@ -74,9 +74,7 @@ void controller_loop() {
                   qp_con->get_input_port_humanoid_status());
   builder.Connect(plan_eval->get_output_port_qp_input(),
                   qp_con->get_input_port_qp_input());
-  // rs + qp_output -> atlas_command_t
-  builder.Connect(rs_msg_to_rs->get_output_port_humanoid_status(),
-                  joint_con->get_input_port_humanoid_status());
+  // qp_output -> atlas_command_t
   builder.Connect(qp_con->get_output_port_qp_output(),
                   joint_con->get_input_port_qp_output());
   // atlas_command_t -> lcm


### PR DESCRIPTION
part 1 of refactoring the system blocks to generalize the inverse dynamics controller to manipulators. 

split atlas / valkyrie specific lcm output from the joint level controller. so that the joint level controller is only responsible for generating a basic vector of torque in actuator order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5284)
<!-- Reviewable:end -->
