### PR TITLE
Change not to execute car_sim_lcm test on Debug mode

### DIFF
--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -115,9 +115,10 @@ if(lcm_FOUND)
       drakeRigidBodyPlant
       drakeSystemAnalysis
       drakeSystemControllers)
-  if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    drake_add_test(NAME car_sim_lcm COMMAND car_sim_lcm --simulation_sec 0.1)
-  endif()
+
+  drake_add_test(NAME car_sim_lcm COMMAND car_sim_lcm --simulation_sec 0.1
+      CONFIGURATIONS "MinSizeRel;Release")
+
 
   # TODO(liang.fok) Enable the following unit test once the build system is able
   # to automatically generate the speed_bump.obj file from the speed_bump.yaml

--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -115,7 +115,9 @@ if(lcm_FOUND)
       drakeRigidBodyPlant
       drakeSystemAnalysis
       drakeSystemControllers)
-  drake_add_test(NAME car_sim_lcm COMMAND car_sim_lcm --simulation_sec 0.1)
+  if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    drake_add_test(NAME car_sim_lcm COMMAND car_sim_lcm --simulation_sec 0.1)
+  endif()
 
   # TODO(liang.fok) Enable the following unit test once the build system is able
   # to automatically generate the speed_bump.obj file from the speed_bump.yaml


### PR DESCRIPTION
A temporal solution for #5263 to avoid test failure in CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5294)
<!-- Reviewable:end -->
