### PR TITLE
Change SystemOutput get_mutable_ports to add_port

### DIFF
--- a/drake/examples/Acrobot/acrobot_lcm.cc
+++ b/drake/examples/Acrobot/acrobot_lcm.cc
@@ -54,7 +54,7 @@ AcrobotCommandSender::AllocateOutput(
   lcmt_acrobot_u msg{};
   msg.tau = 0;
 
-  output->get_mutable_ports()->emplace_back(
+  output->add_port(
       std::make_unique<systems::OutputPort>(
           std::make_unique<systems::Value<lcmt_acrobot_u>>(msg)));
   return std::unique_ptr<SystemOutput<double>>(output.release());
@@ -106,7 +106,7 @@ AcrobotStateSender::AllocateOutput(
   msg.theta1Dot = 0;
   msg.theta2Dot = 0;
 
-  output->get_mutable_ports()->emplace_back(
+  output->add_port(
       std::make_unique<systems::OutputPort>(
           std::make_unique<systems::Value<lcmt_acrobot_x>>(msg)));
   return std::unique_ptr<SystemOutput<double>>(output.release());

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -89,7 +89,7 @@ IiwaStatusSender::AllocateOutput(
   msg.joint_torque_commanded.resize(msg.num_joints, 0);
   msg.joint_torque_external.resize(msg.num_joints, 0);
 
-  output->get_mutable_ports()->emplace_back(
+  output->add_port(
       std::make_unique<systems::OutputPort>(
           std::make_unique<systems::Value<lcmt_iiwa_status>>(msg)));
   return std::unique_ptr<SystemOutput<double>>(output.release());

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -292,7 +292,7 @@ std::unique_ptr<SystemOutput<T>> RigidBodyPlant<T>::AllocateOutput(
   {
     auto data = make_unique<BasicVector<T>>(get_num_states());
     auto port = make_unique<OutputPort>(move(data));
-    output->get_mutable_ports()->push_back(move(port));
+    output->add_port(move(port));
   }
 
   // Allocates an output port for each model instance's state vector in the
@@ -304,7 +304,7 @@ std::unique_ptr<SystemOutput<T>> RigidBodyPlant<T>::AllocateOutput(
     }
     auto data = make_unique<BasicVector<T>>(get_num_states(instance_id));
     auto port = make_unique<OutputPort>(move(data));
-    output->get_mutable_ports()->push_back(move(port));
+    output->add_port(move(port));
   }
 
   // Allocates an output port for the kinematics results.

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -132,11 +132,11 @@ class LeafSystem : public System<T> {
     for (int i = 0; i < this->get_num_output_ports(); ++i) {
       const OutputPortDescriptor<T>& descriptor = this->get_output_port(i);
       if (descriptor.get_data_type() == kVectorValued) {
-        output->get_mutable_ports()->emplace_back(
-            new OutputPort(AllocateOutputVector(descriptor)));
+        output->add_port(
+            std::make_unique<OutputPort>(AllocateOutputVector(descriptor)));
       } else {
-        output->get_mutable_ports()->emplace_back(
-            new OutputPort(AllocateOutputAbstract(descriptor)));
+        output->add_port(
+            std::make_unique<OutputPort>(AllocateOutputAbstract(descriptor)));
       }
     }
     return std::unique_ptr<SystemOutput<T>>(output.release());

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -195,12 +195,12 @@ struct LeafSystemOutput : public SystemOutput<T> {
     return *ports_[index];
   }
 
-  std::vector<std::unique_ptr<OutputPort>>* get_mutable_ports() {
-    return &ports_;
+  void add_port(std::unique_ptr<AbstractValue> value) {
+    add_port(std::make_unique<OutputPort>(std::move(value)));
   }
 
-  void add_port(std::unique_ptr<AbstractValue> value) {
-    ports_.emplace_back(new OutputPort(std::move(value)));
+  void add_port(std::unique_ptr<OutputPort> port) {
+    ports_.emplace_back(std::move(port));
   }
 
  protected:

--- a/drake/systems/framework/test/system_output_test.cc
+++ b/drake/systems/framework/test/system_output_test.cc
@@ -135,12 +135,12 @@ class LeafSystemOutputTest : public ::testing::Test {
     {
       std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
       vec->get_mutable_value() << 5, 25;
-      output_.get_mutable_ports()->emplace_back(new OutputPort(std::move(vec)));
+      output_.add_port(std::make_unique<OutputPort>(std::move(vec)));
     }
     {
       std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(3));
       vec->get_mutable_value() << 125, 625, 3125;
-      output_.get_mutable_ports()->emplace_back(new OutputPort(std::move(vec)));
+      output_.add_port(std::make_unique<OutputPort>(std::move(vec)));
     }
   }
 

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -351,9 +351,8 @@ class ValueIOTestSystem : public System<double> {
     output->add_port(
         std::unique_ptr<AbstractValue>(new Value<std::string>("output")));
 
-    std::unique_ptr<OutputPort> vec_out_port(
-        new OutputPort(std::make_unique<BasicVector<double>>(1)));
-    output->get_mutable_ports()->push_back(std::move(vec_out_port));
+    output->add_port(std::make_unique<OutputPort>(
+        std::make_unique<BasicVector<double>>(1)));
 
     return std::unique_ptr<SystemOutput<double>>(output.release());
   }

--- a/drake/systems/framework/test/value_test.cc
+++ b/drake/systems/framework/test/value_test.cc
@@ -5,10 +5,10 @@
 #include <string>
 #include <vector>
 
+#include "gtest/gtest.h"
+
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
-
-#include "gtest/gtest.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -109,7 +109,7 @@ LcmSubscriberSystem::AllocateOutput(const Context<double>& context) const {
   } else {
     // For abstract-valued output, we need to roll our own.
     auto output = std::make_unique<LeafSystemOutput<double>>();
-    output->get_mutable_ports()->emplace_back(
+    output->add_port(
         std::make_unique<OutputPort>(serializer_->CreateDefaultValue()));
     return std::unique_ptr<SystemOutput<double>>(output.release());
   }


### PR DESCRIPTION
By using an API to receive ports instead of exposing our representation, we can (in the future) assert invariants about the ports contained in a SystemOutput.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5301)
<!-- Reviewable:end -->
