### PR TITLE
maliput::api: Fix contracts for RoadGeometry::ToRoadPosition() and Lane::ToLanePosition()

### DIFF
--- a/drake/automotive/dev/infinite_circuit_road.cc
+++ b/drake/automotive/dev/infinite_circuit_road.cc
@@ -44,7 +44,9 @@ InfiniteCircuitRoad::do_branch_point(int index) const { DRAKE_ABORT(); }
 api::RoadPosition
 InfiniteCircuitRoad::DoToRoadPosition(
     const api::GeoPosition& geo_pos,
-    const api::RoadPosition& hint) const { DRAKE_ABORT(); }
+    const api::RoadPosition& hint,
+    api::GeoPosition* nearest_point,
+    double* distance) const { DRAKE_ABORT(); }
 
 double
 InfiniteCircuitRoad::do_linear_tolerance() const {

--- a/drake/automotive/dev/infinite_circuit_road.cc
+++ b/drake/automotive/dev/infinite_circuit_road.cc
@@ -44,7 +44,7 @@ InfiniteCircuitRoad::do_branch_point(int index) const { DRAKE_ABORT(); }
 api::RoadPosition
 InfiniteCircuitRoad::DoToRoadPosition(
     const api::GeoPosition& geo_pos,
-    const api::RoadPosition& hint,
+    const api::RoadPosition* hint,
     api::GeoPosition* nearest_point,
     double* distance) const { DRAKE_ABORT(); }
 

--- a/drake/automotive/dev/infinite_circuit_road.h
+++ b/drake/automotive/dev/infinite_circuit_road.h
@@ -210,7 +210,7 @@ class InfiniteCircuitRoad : public api::RoadGeometry {
   const api::BranchPoint* do_branch_point(int index) const override;
   api::RoadPosition DoToRoadPosition(
       const api::GeoPosition& geo_pos,
-      const api::RoadPosition& hint,
+      const api::RoadPosition* hint,
       api::GeoPosition* nearest_point,
       double* distance) const override;
   double do_linear_tolerance() const override;

--- a/drake/automotive/dev/infinite_circuit_road.h
+++ b/drake/automotive/dev/infinite_circuit_road.h
@@ -152,7 +152,9 @@ class InfiniteCircuitRoad : public api::RoadGeometry {
         const api::LanePosition& position,
         const api::IsoLaneVelocity& velocity) const override;
     api::LanePosition DoToLanePosition(
-        const api::GeoPosition&) const override {
+        const api::GeoPosition&,
+        api::GeoPosition* nearest_point,
+        double* distance) const override {
       // TODO(maddog@tri.global) Implement when someone needs this.
       DRAKE_ABORT();
     }
@@ -208,7 +210,9 @@ class InfiniteCircuitRoad : public api::RoadGeometry {
   const api::BranchPoint* do_branch_point(int index) const override;
   api::RoadPosition DoToRoadPosition(
       const api::GeoPosition& geo_pos,
-      const api::RoadPosition& hint) const override;
+      const api::RoadPosition& hint,
+      api::GeoPosition* nearest_point,
+      double* distance) const override;
   double do_linear_tolerance() const override;
   double do_angular_tolerance() const override;
 

--- a/drake/automotive/maliput/api/lane.h
+++ b/drake/automotive/maliput/api/lane.h
@@ -89,14 +89,22 @@ class Lane {
     return DoToGeoPosition(lane_pos);
   }
 
-  /// Calculates position in the LANE-space domain of the Lane which maps to
-  /// the GEO-space point closest (per Cartesian metric) to the specified
-  /// @p geo_pos.
-  // TODO(maddog@tri.global)  UNDER CONSTRUCTION
-  // TODO(maddog@tri.global)  Return the minimal-distance, too?
-  // TODO(maddog@tri.global)  Select between lane_bounds and driveable_bounds?
-  LanePosition ToLanePosition(const GeoPosition& geo_pos) const {
-    return DoToLanePosition(geo_pos);
+  /// Determines the LanePosition corresponding to GeoPosition @p geo_position.
+  ///
+  /// The return value is the LanePosition of the point within the Lane's
+  /// driveable-bounds which is closest to @p geo_position (as measured by
+  /// the Cartesian metric in the world frame).  If @p nearest_point is
+  /// non-null, then it will be populated with the GeoPosition of that
+  /// nearest point.  If @p distance is non-null, then it will be populated
+  /// with the Cartesian distance from @p geo_position to that nearest point.
+  ///
+  /// This method guarantees that its result satisfies the condition that
+  /// `ToGeoPosition(result)` is within `linear_tolerance()` of
+  /// `*nearest_position`.
+  LanePosition ToLanePosition(const GeoPosition& geo_position,
+                              GeoPosition* nearest_point,
+                              double* distance) const {
+    return DoToLanePosition(geo_position, nearest_point, distance);
   }
 
   // TODO(maddog@tri.global) Method to convert LanePosition to that of
@@ -184,7 +192,9 @@ class Lane {
 
   virtual GeoPosition DoToGeoPosition(const LanePosition& lane_pos) const = 0;
 
-  virtual LanePosition DoToLanePosition(const GeoPosition& geo_pos) const = 0;
+  virtual LanePosition DoToLanePosition(const GeoPosition& geo_position,
+                                        GeoPosition* nearest_point,
+                                        double* distance) const = 0;
 
   virtual Rotation DoGetOrientation(const LanePosition& lane_pos) const = 0;
 

--- a/drake/automotive/maliput/api/road_geometry.h
+++ b/drake/automotive/maliput/api/road_geometry.h
@@ -59,8 +59,10 @@ class RoadGeometry {
     return do_branch_point(index);
   }
 
-  /// Determines the RoadPosition corresponding to GeoPosition @p geo_position,
-  /// potentially using @p hint to guide the search.
+  /// Determines the RoadPosition corresponding to GeoPosition @p geo_position.
+  ///
+  /// If @p hint in non-null, its value is used to help guide the search and
+  /// select the result.
   ///
   /// The return value is the RoadPosition of the point in the RoadGeometry's
   /// manifold which is, in the world frame, closest to @p geo_position.  If
@@ -73,11 +75,11 @@ class RoadGeometry {
   /// `result.lane->ToGeoPosition(result.pos)` is within `linear_tolerance()`
   /// of `*nearest_position`.
   ///
-  /// The map from RoadGeometry to world frame is not onto (as a RoadGeometry
-  /// is bounded, and the Cartesian universe is not).  If @p geo_position
-  /// does represent a point contained within the volume of the RoadGeometry,
-  /// then result @p distance is guaranteed to be less than or equal to
-  /// `linear_tolerance()`.
+  /// The map from RoadGeometry to the world frame is not onto (as a bounded
+  /// RoadGeometry cannot completely cover the unbounded Cartesian universe).
+  /// If @p geo_position does represent a point contained within the volume
+  /// of the RoadGeometry, then result @p distance is guaranteed to be less
+  /// than or equal to `linear_tolerance()`.
   ///
   /// The map from RoadGeometry to world frame is not necessarily one-to-one.
   /// Different `(s,r,h)` coordinates from different Lanes, potentially from
@@ -88,8 +90,8 @@ class RoadGeometry {
   /// height `h` value in the result.  If the chosen Segment has multiple
   /// Lanes, then ToRoadPosition() will choose a Lane which contains
   /// @p geo_position within its `lane_bounds()` if possible, and if that is
-  /// still ambiguous, will further select a Lane which minimizes the absolute
-  /// value of the lateral `r` coordinate in the result.
+  /// still ambiguous, it will further select a Lane which minimizes the
+  /// absolute value of the lateral `r` coordinate in the result.
   // TODO(maddog@tri.global)  Establish what effect `hint` has on the outcome.
   //                          Two notions:
   //                          1)  the hint helps to bootstrap a search;
@@ -100,7 +102,7 @@ class RoadGeometry {
   //                          might expect an updated RoadPosition which is
   //                          nearby (e.g., on the same Lane).
   RoadPosition ToRoadPosition(const GeoPosition& geo_position,
-                              const RoadPosition& hint,
+                              const RoadPosition* hint,
                               GeoPosition* nearest_position,
                               double* distance) const {
     return DoToRoadPosition(geo_position, hint, nearest_position, distance);
@@ -141,7 +143,7 @@ class RoadGeometry {
   virtual const BranchPoint* do_branch_point(int index) const = 0;
 
   virtual RoadPosition DoToRoadPosition(const GeoPosition& geo_pos,
-                                        const RoadPosition& hint,
+                                        const RoadPosition* hint,
                                         GeoPosition* nearest_position,
                                         double* distance) const = 0;
 

--- a/drake/automotive/maliput/api/road_geometry.h
+++ b/drake/automotive/maliput/api/road_geometry.h
@@ -61,7 +61,7 @@ class RoadGeometry {
 
   /// Determines the RoadPosition corresponding to GeoPosition @p geo_position.
   ///
-  /// If @p hint is non-null, its value is used to help determine result.
+  /// If @p hint is non-null, its value is used to help determine the result.
   ///
   /// The return value is the RoadPosition of the point in the RoadGeometry's
   /// manifold which is, in the world frame, closest to @p geo_position.  If

--- a/drake/automotive/maliput/api/road_geometry.h
+++ b/drake/automotive/maliput/api/road_geometry.h
@@ -61,8 +61,7 @@ class RoadGeometry {
 
   /// Determines the RoadPosition corresponding to GeoPosition @p geo_position.
   ///
-  /// If @p hint in non-null, its value is used to help guide the search and
-  /// select the result.
+  /// If @p hint is non-null, its value is used to help determine result.
   ///
   /// The return value is the RoadPosition of the point in the RoadGeometry's
   /// manifold which is, in the world frame, closest to @p geo_position.  If

--- a/drake/automotive/maliput/api/road_geometry.h
+++ b/drake/automotive/maliput/api/road_geometry.h
@@ -59,20 +59,51 @@ class RoadGeometry {
     return do_branch_point(index);
   }
 
-  /// Determines the RoadPosition corresponding to GeoPosition @p geo_pos,
+  /// Determines the RoadPosition corresponding to GeoPosition @p geo_position,
   /// potentially using @p hint to guide the search.
   ///
-  /// For an input value g, this method guarantees that the return
-  /// value will satisfy the condition that
-  ///   ToRoadPosition(g).lane->ToGeoPosition(ToRoadPosition(g).pos)
-  /// is within linear_tolerance() of g.
-  // TODO(maddog@tri.global)  How should the "geo_pos is nowhere near the
-  //                          road surface" case be handled?  Ability to
-  //                          return 'no result'?
-  RoadPosition ToRoadPosition(const GeoPosition& geo_pos,
-                              const RoadPosition& hint) const {
-    // TODO(maddog@tri.global)  Assert the linear-tolerance constraint.
-    return DoToRoadPosition(geo_pos, hint);
+  /// The return value is the RoadPosition of the point in the RoadGeometry's
+  /// manifold which is, in the world frame, closest to @p geo_position.  If
+  /// @p nearest_position is non-null, then it will be populated with the
+  /// GeoPosition of that nearest point.  If @p distance is non-null, then it
+  /// will be populated with the Cartesian distance from @p geo_position to
+  /// that nearest point.
+  ///
+  /// This method guarantees that its result satisfies the condition that
+  /// `result.lane->ToGeoPosition(result.pos)` is within `linear_tolerance()`
+  /// of `*nearest_position`.
+  ///
+  /// The map from RoadGeometry to world frame is not onto (as a RoadGeometry
+  /// is bounded, and the Cartesian universe is not).  If @p geo_position
+  /// does represent a point contained within the volume of the RoadGeometry,
+  /// then result @p distance is guaranteed to be less than or equal to
+  /// `linear_tolerance()`.
+  ///
+  /// The map from RoadGeometry to world frame is not necessarily one-to-one.
+  /// Different `(s,r,h)` coordinates from different Lanes, potentially from
+  /// different Segments, may map to the same `(x,y,z)` world frame location.
+  ///
+  /// If @p geo_position is contained within the volumes of multiple Segments,
+  /// then ToRoadPosition() will choose a Segment which yields the minimum
+  /// height `h` value in the result.  If the chosen Segment has multiple
+  /// Lanes, then ToRoadPosition() will choose a Lane which contains
+  /// @p geo_position within its `lane_bounds()` if possible, and if that is
+  /// still ambiguous, will further select a Lane which minimizes the absolute
+  /// value of the lateral `r` coordinate in the result.
+  // TODO(maddog@tri.global)  Establish what effect `hint` has on the outcome.
+  //                          Two notions:
+  //                          1)  the hint helps to bootstrap a search;
+  //                          2)  the hint helps to choose between multiple
+  //                              equally valid solutions.
+  //                          The general idea:  if one knows the RoadPosition
+  //                          of an entity some small dT in the past, then one
+  //                          might expect an updated RoadPosition which is
+  //                          nearby (e.g., on the same Lane).
+  RoadPosition ToRoadPosition(const GeoPosition& geo_position,
+                              const RoadPosition& hint,
+                              GeoPosition* nearest_position,
+                              double* distance) const {
+    return DoToRoadPosition(geo_position, hint, nearest_position, distance);
   }
 
   /// Returns the tolerance guaranteed for linear measurements (positions).
@@ -110,7 +141,9 @@ class RoadGeometry {
   virtual const BranchPoint* do_branch_point(int index) const = 0;
 
   virtual RoadPosition DoToRoadPosition(const GeoPosition& geo_pos,
-                                        const RoadPosition& hint) const = 0;
+                                        const RoadPosition& hint,
+                                        GeoPosition* nearest_position,
+                                        double* distance) const = 0;
 
   virtual double do_linear_tolerance() const = 0;
 

--- a/drake/automotive/maliput/dragway/lane.cc
+++ b/drake/automotive/maliput/dragway/lane.cc
@@ -90,7 +90,9 @@ api::Rotation Lane::DoGetOrientation(
 }
 
 api::LanePosition Lane::DoToLanePosition(
-    const api::GeoPosition& geo_pos) const {
+    const api::GeoPosition& geo_pos,
+    api::GeoPosition* nearest_point,
+    double* distance) const {
   DRAKE_ABORT();  // TODO(liangfok) Implement me.
 }
 

--- a/drake/automotive/maliput/dragway/lane.h
+++ b/drake/automotive/maliput/dragway/lane.h
@@ -149,8 +149,9 @@ class Lane final : public api::Lane {
   api::Rotation DoGetOrientation(const api::LanePosition& lane_pos) const
       final;
 
-  api::LanePosition DoToLanePosition(const api::GeoPosition& geo_pos) const
-      final;
+  api::LanePosition DoToLanePosition(const api::GeoPosition& geo_pos,
+                                     api::GeoPosition* nearest_point,
+                                     double* distance) const final;
 
   const Segment* segment_{};  // The segment to which this lane belongs.
   const api::LaneId id_;

--- a/drake/automotive/maliput/dragway/road_geometry.cc
+++ b/drake/automotive/maliput/dragway/road_geometry.cc
@@ -49,7 +49,10 @@ const api::BranchPoint* RoadGeometry::do_branch_point(int index) const {
 }
 
 api::RoadPosition RoadGeometry::DoToRoadPosition(
-    const api::GeoPosition&, const api::RoadPosition&) const {
+    const api::GeoPosition&,
+    const api::RoadPosition&,
+    api::GeoPosition*,
+    double*) const {
   DRAKE_ABORT();  // TODO(liang.fok) Implement me.
 }
 

--- a/drake/automotive/maliput/dragway/road_geometry.cc
+++ b/drake/automotive/maliput/dragway/road_geometry.cc
@@ -50,7 +50,7 @@ const api::BranchPoint* RoadGeometry::do_branch_point(int index) const {
 
 api::RoadPosition RoadGeometry::DoToRoadPosition(
     const api::GeoPosition&,
-    const api::RoadPosition&,
+    const api::RoadPosition*,
     api::GeoPosition*,
     double*) const {
   DRAKE_ABORT();  // TODO(liang.fok) Implement me.

--- a/drake/automotive/maliput/dragway/road_geometry.h
+++ b/drake/automotive/maliput/dragway/road_geometry.h
@@ -69,7 +69,7 @@ class RoadGeometry final : public api::RoadGeometry {
 
   api::RoadPosition DoToRoadPosition(
       const api::GeoPosition& geo_position,
-      const api::RoadPosition& hint,
+      const api::RoadPosition* hint,
       api::GeoPosition* nearest_point,
       double* distance) const final;
 

--- a/drake/automotive/maliput/dragway/road_geometry.h
+++ b/drake/automotive/maliput/dragway/road_geometry.h
@@ -68,8 +68,10 @@ class RoadGeometry final : public api::RoadGeometry {
   const api::BranchPoint* do_branch_point(int index) const final;
 
   api::RoadPosition DoToRoadPosition(
-      const api::GeoPosition& geo_pos,
-      const api::RoadPosition& hint) const final;
+      const api::GeoPosition& geo_position,
+      const api::RoadPosition& hint,
+      api::GeoPosition* nearest_point,
+      double* distance) const final;
 
   double do_linear_tolerance() const final { return linear_tolerance_; }
 

--- a/drake/automotive/maliput/monolane/arc_lane.cc
+++ b/drake/automotive/maliput/monolane/arc_lane.cc
@@ -135,7 +135,9 @@ double ArcLane::heading_dot_of_p(const double p) const {
 }
 
 
-api::LanePosition ArcLane::DoToLanePosition(const api::GeoPosition&) const {
+api::LanePosition ArcLane::DoToLanePosition(const api::GeoPosition&,
+                                            api::GeoPosition*,
+                                            double*) const {
   DRAKE_ABORT();  // TODO(maddog@tri.global) Implement me.
 }
 

--- a/drake/automotive/maliput/monolane/arc_lane.h
+++ b/drake/automotive/maliput/monolane/arc_lane.h
@@ -40,7 +40,9 @@ class ArcLane : public Lane {
 
  private:
   api::LanePosition DoToLanePosition(
-      const api::GeoPosition& geo_pos) const override;
+      const api::GeoPosition& geo_pos,
+      api::GeoPosition* nearest_point,
+      double* distance) const override;
 
   V2 xy_of_p(const double p) const override;
   V2 xy_dot_of_p(const double p) const override;

--- a/drake/automotive/maliput/monolane/line_lane.cc
+++ b/drake/automotive/maliput/monolane/line_lane.cc
@@ -26,7 +26,9 @@ double LineLane::heading_of_p(const double) const { return heading_; }
 double LineLane::heading_dot_of_p(const double) const { return 0.; }
 
 
-api::LanePosition LineLane::DoToLanePosition(const api::GeoPosition&) const {
+api::LanePosition LineLane::DoToLanePosition(const api::GeoPosition&,
+                                             api::GeoPosition*,
+                                             double*) const {
   DRAKE_ABORT();  // TODO(maddog@tri.global) Implement me.
 }
 

--- a/drake/automotive/maliput/monolane/line_lane.h
+++ b/drake/automotive/maliput/monolane/line_lane.h
@@ -41,7 +41,9 @@ class LineLane : public Lane {
 
  private:
   api::LanePosition DoToLanePosition(
-      const api::GeoPosition& geo_pos) const override;
+      const api::GeoPosition& geo_pos,
+      api::GeoPosition* nearest_point,
+      double* distance) const override;
 
   V2 xy_of_p(const double p) const override;
   V2 xy_dot_of_p(const double p) const override;

--- a/drake/automotive/maliput/monolane/road_geometry.cc
+++ b/drake/automotive/maliput/monolane/road_geometry.cc
@@ -29,7 +29,10 @@ const api::BranchPoint* RoadGeometry::do_branch_point(int index) const {
 
 
 api::RoadPosition RoadGeometry::DoToRoadPosition(
-    const api::GeoPosition&, const api::RoadPosition&) const {
+    const api::GeoPosition&,
+    const api::RoadPosition&,
+    api::GeoPosition*,
+    double*) const {
   DRAKE_ABORT();  // TODO(maddog@tri.global) Implement me.
 }
 

--- a/drake/automotive/maliput/monolane/road_geometry.cc
+++ b/drake/automotive/maliput/monolane/road_geometry.cc
@@ -30,7 +30,7 @@ const api::BranchPoint* RoadGeometry::do_branch_point(int index) const {
 
 api::RoadPosition RoadGeometry::DoToRoadPosition(
     const api::GeoPosition&,
-    const api::RoadPosition&,
+    const api::RoadPosition*,
     api::GeoPosition*,
     double*) const {
   DRAKE_ABORT();  // TODO(maddog@tri.global) Implement me.

--- a/drake/automotive/maliput/monolane/road_geometry.h
+++ b/drake/automotive/maliput/monolane/road_geometry.h
@@ -50,7 +50,7 @@ class RoadGeometry : public api::RoadGeometry {
 
   api::RoadPosition DoToRoadPosition(
       const api::GeoPosition& geo_pos,
-      const api::RoadPosition& hint,
+      const api::RoadPosition* hint,
       api::GeoPosition* nearest_point,
       double* distance) const override;
 

--- a/drake/automotive/maliput/monolane/road_geometry.h
+++ b/drake/automotive/maliput/monolane/road_geometry.h
@@ -50,7 +50,9 @@ class RoadGeometry : public api::RoadGeometry {
 
   api::RoadPosition DoToRoadPosition(
       const api::GeoPosition& geo_pos,
-      const api::RoadPosition& hint) const override;
+      const api::RoadPosition& hint,
+      api::GeoPosition* nearest_point,
+      double* distance) const override;
 
   double do_linear_tolerance() const override { return linear_tolerance_; }
 


### PR DESCRIPTION
Clarify/enhance the contracts for api::RoadGeometry::ToRoadPosition() and
api::Lane::ToLanePosition() --- yielding a net reduction of 4 TODO's.

Neither of these methods has a functional implementation yet in the codebase.
The key aspects of these changes:
 1) These methods always return a result.
 2) If the input `geo_position` is not actually within the volume of
    the RoadGeometry or Lane, then the methods do the sensible thing
    of returning the closest point,  which is on the boundary of the volume.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5302)
<!-- Reviewable:end -->
