### PR TITLE
Add ZeroOrderHold::DoToSymbolic.

### DIFF
--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -34,9 +34,9 @@ namespace systems {
 template <typename T>
 struct PeriodicEvent {
   /// The period with which this event should recur.
-  T period_sec{0.0};
+  double period_sec{0.0};
   /// The time after zero when this event should first occur.
-  T offset_sec{0.0};
+  double offset_sec{0.0};
   /// The action that should be taken when this event occurs.
   DiscreteEvent<T> event;
 };
@@ -350,7 +350,7 @@ class LeafSystem : public System<T> {
   /// The first tick will be at t = period_sec, and it will recur at every
   /// period_sec thereafter. On the discrete tick, the system may perform
   /// the given type of action.
-  void DeclarePeriodicAction(const T& period_sec, const T& offset_sec,
+  void DeclarePeriodicAction(double period_sec, double offset_sec,
       const typename DiscreteEvent<T>::ActionType& action) {
     PeriodicEvent<T> event;
     event.period_sec = period_sec;
@@ -363,7 +363,7 @@ class LeafSystem : public System<T> {
   /// The first tick will be at t = period_sec, and it will recur at every
   /// period_sec thereafter. On the discrete tick, the system may update
   /// the discrete state.
-  void DeclareDiscreteUpdatePeriodSec(const T& period_sec) {
+  void DeclareDiscreteUpdatePeriodSec(double period_sec) {
     DeclarePeriodicAction(period_sec, 0.0,
         DiscreteEvent<T>::kDiscreteUpdateAction);
   }
@@ -372,7 +372,7 @@ class LeafSystem : public System<T> {
   /// The first tick will be at t = offset_sec, and it will recur at every
   /// period_sec thereafter. On the discrete tick, the system may update the
   /// discrete state.
-  void DeclarePeriodicDiscreteUpdate(const T& period_sec, const T& offset_sec) {
+  void DeclarePeriodicDiscreteUpdate(double period_sec, double offset_sec) {
     DeclarePeriodicAction(period_sec, offset_sec,
         DiscreteEvent<T>::kDiscreteUpdateAction);
   }
@@ -381,8 +381,7 @@ class LeafSystem : public System<T> {
   /// update. The first tick will be at t = offset_sec, and it will recur at
   /// every period_sec thereafter. On the discrete tick, the system may perform
   /// unrestricted updates.
-  void DeclarePeriodicUnrestrictedUpdate(const T& period_sec,
-      const T& offset_sec) {
+  void DeclarePeriodicUnrestrictedUpdate(double period_sec, double offset_sec) {
     DeclarePeriodicAction(period_sec, offset_sec,
         DiscreteEvent<T>::kUnrestrictedUpdateAction);
   }
@@ -391,7 +390,7 @@ class LeafSystem : public System<T> {
   /// The first tick will be at t = period_sec, and it will recur at every
   /// period_sec thereafter. On the discrete tick, the system may update
   /// the discrete state.
-  void DeclarePublishPeriodSec(const T& period_sec) {
+  void DeclarePublishPeriodSec(double period_sec) {
     DeclarePeriodicAction(period_sec, 0, DiscreteEvent<T>::kPublishAction);
   }
 
@@ -487,9 +486,9 @@ class LeafSystem : public System<T> {
   // Returns the next sample time for the given @p event.
   static T GetNextSampleTime(const PeriodicEvent<T>& event,
                              const T& current_time_sec) {
-    const T& period = event.period_sec;
+    const double period = event.period_sec;
     DRAKE_ASSERT(period > 0);
-    const T& offset = event.offset_sec;
+    const double offset = event.offset_sec;
     DRAKE_ASSERT(offset >= 0);
 
     // If the first sample time hasn't arrived yet, then that is the next

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -11,8 +11,8 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-ZeroOrderHold<T>::ZeroOrderHold(const T& period_sec, int size)
-    : SisoVectorSystem<T>(size, size) {
+ZeroOrderHold<T>::ZeroOrderHold(double period_sec, int size)
+    : SisoVectorSystem<T>(size, size), period_sec_(period_sec) {
   // TODO(david-german-tri): remove the size parameter from the constructor
   // once #3109 supporting automatic sizes is resolved.
   this->DeclareDiscreteState(size);
@@ -35,6 +35,12 @@ void ZeroOrderHold<T>::DoCalcVectorDiscreteVariableUpdates(
     const Eigen::VectorBlock<const VectorX<T>>& state,
     Eigen::VectorBlock<VectorX<T>>* discrete_updates) const {
   *discrete_updates = input;
+}
+
+template <typename T>
+ZeroOrderHold<symbolic::Expression>* ZeroOrderHold<T>::DoToSymbolic() const {
+  return new ZeroOrderHold<symbolic::Expression>(period_sec_,
+                                                 this->get_input_port().size());
 }
 
 }  // namespace systems

--- a/drake/systems/primitives/zero_order_hold.cc
+++ b/drake/systems/primitives/zero_order_hold.cc
@@ -9,6 +9,7 @@ namespace systems {
 
 template class ZeroOrderHold<double>;
 template class ZeroOrderHold<AutoDiffXd>;
+template class ZeroOrderHold<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/primitives/zero_order_hold.h
+++ b/drake/systems/primitives/zero_order_hold.h
@@ -4,6 +4,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/symbolic_expression.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/siso_vector_system.h"
 
@@ -20,13 +21,13 @@ class ZeroOrderHold : public SisoVectorSystem<T> {
 
   /// Constructs a ZeroOrderHold system with the given @p period_sec, over a
   /// vector-valued input of size @p size.
-  ZeroOrderHold(const T& period_sec, int size);
-
-  /// In a zero-order hold, the output depends only on the state, so there is
-  /// no direct-feedthrough.
-  bool has_any_direct_feedthrough() const override { return false; }
+  ZeroOrderHold(double period_sec, int size);
 
  protected:
+  // System<T> override.  Returns a ZeroOrderHold<symbolic::Expression> with
+  // the same dimensions as this ZeroOrderHold.
+  ZeroOrderHold<symbolic::Expression>* DoToSymbolic() const override;
+
   /// Sets the output port value to the value that is currently latched in the
   /// zero-order hold.
   void DoCalcVectorOutput(
@@ -41,6 +42,9 @@ class ZeroOrderHold : public SisoVectorSystem<T> {
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* discrete_updates) const override;
+
+ private:
+  const double period_sec_{};
 };
 
 }  // namespace systems


### PR DESCRIPTION
Remove spurious and unused support for scalar-type discrete periods.

@jadecastro for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5312)
<!-- Reviewable:end -->
