### PR TITLE
Zap has_any_direct_feedthrough in drake/automotive.

### DIFF
--- a/drake/automotive/dev/endless_road_car.cc
+++ b/drake/automotive/dev/endless_road_car.cc
@@ -47,12 +47,12 @@ EndlessRoadCar<T>::EndlessRoadCar(
                           EndlessRoadCarStateIndices::kNumCoordinates);
 }
 
-
 template <typename T>
-bool EndlessRoadCar<T>::has_any_direct_feedthrough() const {
+bool EndlessRoadCar<T>::DoHasDirectFeedthrough(
+    const systems::SparsityMatrix* sparsity,
+    int input_port, int output_port) const {
   return false;
 }
-
 
 template <typename T>
 void EndlessRoadCar<T>::DoCalcOutput(const systems::Context<T>& context,

--- a/drake/automotive/dev/endless_road_car.h
+++ b/drake/automotive/dev/endless_road_car.h
@@ -79,7 +79,6 @@ class EndlessRoadCar : public systems::LeafSystem<T> {
 
  public:
   // System<T> overrides
-  bool has_any_direct_feedthrough() const override;
   void DoCalcOutput(const systems::Context<T>& context,
                     systems::SystemOutput<T>* output) const override;
   void DoCalcTimeDerivatives(
@@ -100,6 +99,8 @@ class EndlessRoadCar : public systems::LeafSystem<T> {
   std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
       const systems::OutputPortDescriptor<T>& descriptor) const override;
   std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
+  bool DoHasDirectFeedthrough(const systems::SparsityMatrix* sparsity,
+                              int input_port, int output_port) const override;
 
  private:
   struct Accelerations {

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -45,13 +45,17 @@ class IdmPlanner : public systems::LeafSystem<T> {
   const systems::InputPortDescriptor<T>& get_agent_port() const;
 
   // System<T> overrides.
-  // The output of this system is an algebraic relation of its inputs.
-  bool has_any_direct_feedthrough() const override { return true; }
-
   std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
 
   void SetDefaultParameters(const systems::LeafContext<T>& context,
                             systems::Parameters<T>* params) const override;
+
+ protected:
+  // The output of this system is an algebraic relation of its inputs.
+  bool DoHasDirectFeedthrough(const systems::SparsityMatrix* sparsity,
+                              int input_port, int output_port) const override {
+    return true;
+  }
 
  private:
   void DoCalcOutput(const systems::Context<T>& context,

--- a/drake/automotive/linear_car.h
+++ b/drake/automotive/linear_car.h
@@ -43,11 +43,15 @@ class LinearCar : public systems::LeafSystem<T> {
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override;
 
-  // System<T> overrides.
-  // Declare that the outputs are all algebraically isolated from the input.
-  bool has_any_direct_feedthrough() const override { return false; }
+ protected:
+  // Declares that the outputs are all algebraically isolated from the input.
+  bool DoHasDirectFeedthrough(const systems::SparsityMatrix* sparsity,
+                              int input_port, int output_port) const override {
+    return false;
+  }
 
  private:
+  // System<T> overrides.
   void DoCalcOutput(const systems::Context<T>& context,
                     systems::SystemOutput<T>* output) const override;
 


### PR DESCRIPTION
We use manual overrides instead of symbolic sparsity because all of these Systems have nontrivial construction semantics.  I'll leave it to original authors to decide whether or how to convert to symbolic.

@jwnimmer-tri for all review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5315)
<!-- Reviewable:end -->
