### PR TITLE
Implements the second half of dragway::RoadGeometry::DoToRoadPosition().

### DIFF
--- a/drake/automotive/maliput/dragway/road_geometry.cc
+++ b/drake/automotive/maliput/dragway/road_geometry.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 
+#include <cmath>
 #include <memory>
 
 #include "drake/automotive/maliput/dragway/branch_point.h"
@@ -12,6 +13,26 @@ using std::make_unique;
 namespace drake {
 namespace maliput {
 namespace dragway {
+
+namespace {
+
+// Clamps the provided `value` by the provided `min` and `max` values. Returns
+// the clamped result.
+//
+// TODO(liang.fok) Once c++17 or later is used, switch to std::clamp().
+//
+double clamp(double value, double min, double max) {
+  double result = value;
+  if (value < min) {
+    result = min;
+  }
+  if (value > max) {
+    result = max;
+  }
+  return result;
+}
+
+}  // namespace
 
 RoadGeometry::RoadGeometry(const api::RoadGeometryId& id,
                int num_lanes,
@@ -115,32 +136,73 @@ api::RoadPosition RoadGeometry::DoToRoadPosition(
     const api::RoadPosition* hint,
     api::GeoPosition* nearest_position,
     double* distance) const {
-  api::LanePosition result_lane_position;
-  result_lane_position.s = geo_pos.x;
-  result_lane_position.h = geo_pos.z;
-  if (IsGeoPositionOnDragway(geo_pos)) {
-    const int lane_index = GetLaneIndex(geo_pos);
-    const Lane* lane =
-        dynamic_cast<const Lane*>(junction_.segment(0)->lane(lane_index));
-    DRAKE_ASSERT(lane != nullptr);
-    const double y_offset = lane->y_offset();
-    result_lane_position.r = geo_pos.y - y_offset;
-    if (nearest_position != nullptr) {
-      nearest_position->x = geo_pos.x;
-      nearest_position->y = geo_pos.y;
-      nearest_position->z = geo_pos.z;
-    }
-    if (distance != nullptr) {
-      *distance = 0;
-    }
-    return api::RoadPosition(lane, result_lane_position);
-  } else {
-    // TODO(liang.fok): Implement this!
-    throw std::runtime_error(
-        "dragway::RoadGeometry::DoToRoadPosition: The ability to determine the "
-        "road position of a GeoPosition that's not on top of the dragway has "
-        "yet to be implemented.");
+  // Computes the dragway's (x,y) driveable region coordinates.
+  DRAKE_ASSERT(junction_.num_segments() > 0);
+  const api::Segment* segment = junction_.segment(0);
+  DRAKE_ASSERT(segment != nullptr);
+  DRAKE_ASSERT(segment->num_lanes() > 0);
+  const Lane* lane = dynamic_cast<const Lane*>(segment->lane(0));
+  DRAKE_ASSERT(lane != nullptr);
+  const double length = lane->length();
+  const api::RBounds lane_driveable_bounds = lane->driveable_bounds(0 /* s */);
+  const double min_y = lane->y_offset() + lane_driveable_bounds.r_min;
+  const double max_y = lane->y_offset() + lane_driveable_bounds.r_max;
+  const double min_x = 0;
+  const double max_x = length;
+
+  /*
+      A figure of a typical dragway is shown below. The minimum and maximum
+      values of the dragway's driveable region are demarcated.
+
+                            X
+              Y = max_y     ^      Y = min_y
+                            :
+                  |         :         |
+                  |         :         |
+          --------+---------+---------+---------  X = max_x
+                  | .   .   :   .   . |
+                  | .   .   :   .   . |
+                  | .   .   :   .   . |
+                  | .   .  The  .   . |
+                  | .   . Dragway   . |
+                  | .   .   :   .   . |
+                  | .   .   :   .   . |
+                  | .   .   :   .   . |
+     Y <----------+---------o---------+---------  X = min_x
+                  |         :         |
+                  |         :         |
+                            :
+                            V
+
+      The (x, y) coordinate of the closest point is basically the (x, y)
+      coordinates of the provide `geo_pos` clamped by the minimum and maximum
+      values of of the dragway's driveable region. This can be encoded as
+      follows.
+  */
+  api::GeoPosition closest_position;
+  closest_position.x = clamp(geo_pos.x, min_x, max_x);
+  closest_position.y = clamp(geo_pos.y, min_y, max_y);
+  closest_position.z = geo_pos.z;
+
+  if (distance != nullptr) {
+    *distance = std::sqrt(std::pow(geo_pos.x - closest_position.x, 2) +
+                          std::pow(geo_pos.y - closest_position.y, 2) +
+                          std::pow(geo_pos.z - closest_position.z, 2));
   }
+
+  if (nearest_position != nullptr) {
+    *nearest_position = closest_position;
+  }
+
+  const int closest_lane_index = GetLaneIndex(closest_position);
+  const Lane* closest_lane =
+      dynamic_cast<const Lane*>(junction_.segment(0)->lane(closest_lane_index));
+  DRAKE_ASSERT(closest_lane != nullptr);
+  const api::LanePosition closest_lane_position(
+      closest_position.x                             /* s */,
+      closest_position.y - closest_lane->y_offset()  /* r */,
+      geo_pos.z                                      /* h */);
+  return api::RoadPosition(closest_lane, closest_lane_position);
 }
 
 }  // namespace dragway


### PR DESCRIPTION
This PR builds upon #5313 by handling cases where the geographic position is not on top of the dragway's driveable region.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5320)
<!-- Reviewable:end -->
