### PR TITLE
iiwa pick and place demo

### DIFF
--- a/drake/examples/kuka_iiwa_arm/BUILD
+++ b/drake/examples/kuka_iiwa_arm/BUILD
@@ -77,7 +77,7 @@ drake_cc_binary(
         "//drake/examples/schunk_wsg:schunk_wsg_lcm",
         "//drake/lcm",
         "//drake/multibody/rigid_body_plant",
-        "//drake/systems/analysis:simulator",
+        "//drake/systems/analysis",
         "//drake/systems/controllers:pid_controller",
         "//drake/systems/controllers:pid_with_gravity_compensator",
         "//drake/systems/primitives:matrix_gain",

--- a/drake/examples/kuka_iiwa_arm/dev/CMakeLists.txt
+++ b/drake/examples/kuka_iiwa_arm/dev/CMakeLists.txt
@@ -14,6 +14,8 @@ drake_install_pkg_config_file(drake-kuka-iiwa-arm-ik
     LIBS -ldrakeKukaIiwaArmIK
     REQUIRES drake-lcm-system drake-lcmtypes-cpp drake-rbm)
 
+add_subdirectory(pick_and_place)
+
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/drake/examples/kuka_iiwa_arm/dev/iiwa_ik_planner.h
+++ b/drake/examples/kuka_iiwa_arm/dev/iiwa_ik_planner.h
@@ -123,8 +123,7 @@ class IiwaIkPlanner {
   bool SolveIk(const IkCartesianWaypoint& waypoint, const VectorX<double>& q0,
                const VectorX<double>& q_nom,
                const Vector3<double>& position_tol, double rot_tolerance,
-               VectorX<double>* ik_res,
-               std::vector<int>* info,
+               VectorX<double>* ik_res, std::vector<int>* info,
                std::vector<std::string>* infeasible_constraints);
 
   std::default_random_engine rand_generator_;

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD
@@ -1,0 +1,51 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:cpplint.bzl", "cpplint")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_binary",
+    "drake_cc_library",
+)
+
+package(
+    default_visibility = [":__subpackages__"],
+)
+
+drake_cc_library(
+    name = "kuka_pick_and_place",
+    srcs = [
+        "action.cc",
+        "world_state.cc",
+    ],
+    hdrs = [
+        "action.h",
+        "world_state.h",
+    ],
+    deps = [
+        "//drake/examples/kuka_iiwa_arm:iiwa_common",
+        "//drake/lcmtypes:schunk",
+        "//drake/util:lcm_util",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/parsers",
+    ],
+)
+
+drake_cc_binary(
+    name = "pick_and_place_state_machine",
+    srcs = [
+        "pick_and_place_state_machine.cc",
+    ],
+    deps = [
+        ":kuka_pick_and_place",
+        "//drake/examples/kuka_iiwa_arm/dev:iiwa_ik_planner",
+        "//drake/examples/kuka_iiwa_arm:iiwa_common",
+        "//drake/examples/kuka_iiwa_arm:iiwa_lcm",
+        "//drake/common/trajectories:piecewise_quaternion",
+        "//drake/common/trajectories:piecewise_polynomial",
+        "//drake/examples/schunk_wsg:schunk_wsg_lcm",
+        "//drake/util:lcm_util",
+    ],
+)
+
+# === test/ ===

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/CMakeLists.txt
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/CMakeLists.txt
@@ -1,0 +1,14 @@
+if(lcm_FOUND)
+  add_executable(pick_and_place_demo
+    action.cc
+    pick_and_place_state_machine.cc
+    world_state.cc)
+  target_link_libraries(pick_and_place_demo
+    drakeKukaIiwaArmCommon
+    drakeKukaIiwaArmIK
+    drakeLCMTypes
+    drakeLCMUtil
+    drakeRigidBodyPlant
+    robotlocomotion-lcmtypes-cpp)
+endif()
+

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/README
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/README
@@ -1,0 +1,8 @@
+To run the demo, start three terminals from drake's home directory. (bazel build)
+
+tty1:
+$ ./bazel-bin/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation
+tty2:
+$ ./bazel-bin/drake/examples/kuka_iiwa_arm/kuka_plan_runner
+tty3:
+$ ./bazel-bin/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_state_machine

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/action.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/action.cc
@@ -1,0 +1,71 @@
+#include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/action.h"
+
+#include <limits>
+
+#include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
+#include "drake/lcmt_schunk_wsg_command.hpp"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace pick_and_place_demo {
+
+void IiwaMove::MoveJoints(const WorldState& est_state,
+                          const std::vector<double>& time,
+                          const std::vector<VectorX<double>>& q) {
+  DRAKE_DEMAND(time.size() == q.size());
+
+  std::vector<int> info(time.size(), 1);
+  MatrixX<double> q_mat(q.front().size(), q.size());
+  for (size_t i = 0; i < q.size(); ++i) q_mat.col(i) = q[i];
+  robotlocomotion::robot_plan_t plan =
+      EncodeKeyFrames(iiwa_, time, info, q_mat);
+  lcm_->publish(pub_channel_, &plan);
+  StartAction(est_state.get_iiwa_time());
+  finish_time_ = time.back();
+}
+
+void IiwaMove::Reset() {
+  Action::Reset();
+  finish_time_ = std::numeric_limits<double>::infinity();
+}
+
+bool IiwaMove::ActionFinished(const WorldState& est_state) const {
+  if (!ActionStarted()) return false;
+
+  if (get_time_since_action_start(est_state.get_iiwa_time()) > finish_time_ &&
+      est_state.get_iiwa_v().norm() < 1e-1) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void WsgAction::OpenGripper(const WorldState& est_state) {
+  StartAction(est_state.get_wsg_time());
+  lcmt_schunk_wsg_command msg;
+  // Max aperture.
+  msg.target_position_mm = 110;
+  lcm_->publish(pub_channel_, &msg);
+}
+
+void WsgAction::CloseGripper(const WorldState& est_state) {
+  StartAction(est_state.get_wsg_time());
+  lcmt_schunk_wsg_command msg;
+  msg.target_position_mm = 0;
+  lcm_->publish(pub_channel_, &msg);
+}
+
+bool WsgAction::ActionFinished(const WorldState& est_state) const {
+  if (!ActionStarted()) return false;
+
+  if (std::abs(est_state.get_wsg_v()) < 1e-2 &&
+      (get_time_since_action_start(est_state.get_wsg_time()) > 0.5))
+    return true;
+  return false;
+}
+
+}  // namespace pick_and_place_demo
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/action.h
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/action.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <lcm/lcm-cpp.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace pick_and_place_demo {
+
+/**
+ * Base class that represents actions for the pick and place demo. E.g. moving
+ * iiwa arm, open / close gripper. The commands are packaged and sent through
+ * LCM.
+ */
+class Action {
+ public:
+  explicit Action(lcm::LCM* lcm) : lcm_(lcm) { Reset(); }
+
+  /**
+   * Returns true if the action has finished given estimated state.
+   */
+  virtual bool ActionFinished(const WorldState& est_state) const = 0;
+
+  /**
+   * Returns true if the action has failed given estimated state.
+   */
+  virtual bool ActionFailed(const WorldState& est_state) const = 0;
+
+  /**
+   * Returns true if the action has started.
+   */
+  virtual bool ActionStarted() const {
+    if (act_start_time_ < 0) return false;
+    return true;
+  }
+
+  /**
+   * Returns the time when the action has started.
+   */
+  double get_action_start_time() const { return act_start_time_; }
+
+  /**
+   * Returns elapsed time since beginning of the action.
+   */
+  double get_time_since_action_start(double time) const {
+    if (ActionStarted())
+      return time - act_start_time_;
+    else
+      return 0;
+  }
+
+  /**
+   * Resets the action's internal states.
+   */
+  virtual void Reset() { act_start_time_ = -1; }
+
+ protected:
+  // Sets the action initial time.
+  virtual void StartAction(double start_time) {
+    DRAKE_DEMAND(start_time >= 0);
+    act_start_time_ = start_time;
+  }
+
+  lcm::LCM* lcm_;
+
+ private:
+  double act_start_time_;
+};
+
+/**
+ * A class that represents action that sends a sequence of desired joint
+ * positions through LCM to move the iiwa arm.
+ */
+class IiwaMove : public Action {
+ public:
+  /**
+   * Constructs an Action class to move the iiwa arm.
+   * @param iiwa Reference to a RigidBodyTree that represents the iiwa robot.
+   * Its life span must be longer than this instance.
+   * @param channel Lcm message channel name of the output
+   * robotlocomotion::robot_plan_t.
+   */
+  IiwaMove(const RigidBodyTree<double>& iiwa, const std::string& channel,
+           lcm::LCM* lcm)
+      : Action(lcm), iiwa_(iiwa), pub_channel_(channel) {}
+
+  /**
+   * Returns a constant reference to the iiwa model.
+   */
+  const RigidBodyTree<double>& get_iiwa() const { return iiwa_; }
+
+  /**
+   * Sends a LCM message that moves the iiwa arm through the joint positions
+   * in @p q at time @p time.
+   */
+  void MoveJoints(const WorldState& est_state, const std::vector<double>& time,
+                  const std::vector<VectorX<double>>& q);
+
+  /**
+   * Resets all internal states including IK waypoints solutions.
+   */
+  void Reset() override;
+
+  // TODO(siyuanfeng): have something meaningful here, like the object slipped
+  // out.
+  bool ActionFailed(const WorldState& est_state) const override {
+    return false;
+  }
+
+  /**
+   * Returns ture if time since beginning of action is longer than then the
+   * duration of the desired motion, and the arm stopped moving.
+   */
+  bool ActionFinished(const WorldState& est_state) const override;
+
+ private:
+  const RigidBodyTree<double>& iiwa_;
+  const std::string pub_channel_;
+  double finish_time_;
+};
+
+/**
+ * An Action that closes / open the gripper.
+ */
+class WsgAction : public Action {
+ public:
+  WsgAction(const std::string& channel, lcm::LCM* lcm)
+      : Action(lcm), pub_channel_(channel) {}
+
+  /*
+   * Sends a lcm message that tells the WSG gripper driver to open all the way.
+   */
+  void OpenGripper(const WorldState& est_state);
+
+  /*
+   * Sends a lcm message that tells the WSG gripper driver to close all the way.
+   */
+  void CloseGripper(const WorldState& est_state);
+
+  // TODO(siyuanfeng): have something meaningful here, like check for force
+  // threshold.
+  bool ActionFailed(const WorldState& est_state) const { return false; }
+
+  /**
+   * Returns true if the gripper stopped moving, and it is at least 0.5 second
+   * after
+   * a Open / Close command was last issued.
+   */
+  bool ActionFinished(const WorldState& est_state) const;
+
+ private:
+  const std::string pub_channel_;
+};
+
+}  // namespace pick_and_place_demo
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_state_machine.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_state_machine.cc
@@ -1,0 +1,435 @@
+/**
+ * @file This file implements a state machine that drives the kuka iiwa arm to
+ * pick up a block from one table to place it on another repeatedly.
+ */
+
+#include <iostream>
+#include <list>
+#include <memory>
+
+#include <lcm/lcm-cpp.hpp>
+
+#include "bot_core/robot_state_t.hpp"
+#include "drake/common/drake_path.h"
+#include "drake/common/trajectories/piecewise_quaternion.h"
+#include "drake/examples/kuka_iiwa_arm/dev/iiwa_ik_planner.h"
+#include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/action.h"
+#include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h"
+#include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
+#include "drake/lcmt_iiwa_status.hpp"
+
+#include "drake/lcmt_schunk_wsg_command.hpp"
+#include "drake/lcmt_schunk_wsg_status.hpp"
+#include "drake/util/lcmUtil.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace pick_and_place_demo {
+namespace {
+
+// Desired location to place the object for table0 and table1. Positions are
+// specified in the iiwa arm base frame. Table0 is right in front of the arm
+// base.
+const Vector3<double> kPlacePosition0(0.8, 0, 0);
+const Vector3<double> kPlacePosition1(0, 0.8, 0);
+
+// Determines which table the object is on based on its xy distance to the
+// center of each table.
+// TODO(siyuan): have a better way to determine.
+int get_table(const Isometry3<double>& X_WObj,
+              const Isometry3<double>& X_WIiiwa) {
+  // These need to match iiwa_wsg_simulation.cc's table configuration.
+  const Vector3<double> p_IiwaMidTable0 = Vector3<double>(0.8, 0, 0);
+  const Vector3<double> p_IiwaMidTable1 = Vector3<double>(0, 0.85, 0);
+
+  Isometry3<double> X_IiwaObj = X_WIiiwa.inverse() * X_WObj;
+  double dist_to_table_0 = (X_IiwaObj.translation() - p_IiwaMidTable0).norm();
+  double dist_to_table_1 = (X_IiwaObj.translation() - p_IiwaMidTable1).norm();
+
+  int table = 1;
+  if (dist_to_table_0 < dist_to_table_1) table = 0;
+  return table;
+}
+
+// Computes the desired end effector pose in the world frame given the object
+// pose in the world frame.
+Isometry3<double> ComputeGraspPose(const Isometry3<double>& X_WObj) {
+  // Sets desired end effector location to be 12cm behind the object,
+  // with the same orientation relative to the object frame. This number
+  // dependents on the length of the finger and how the gripper is attached.
+  const double kEndEffectorToMidFingerDepth = 0.12;
+  Isometry3<double> X_ObjEndEffector_desired;
+  X_ObjEndEffector_desired.translation() =
+      Vector3<double>(-kEndEffectorToMidFingerDepth, 0, 0);
+  X_ObjEndEffector_desired.linear().setIdentity();
+  return X_WObj * X_ObjEndEffector_desired;
+}
+
+// Generates a sequence (@p num_via_points + 1) of key frames s.t. the end
+// effector moves in a straight line between @pX_WEndEffector0 and
+// @p X_WEndEffector1. Orientation is interpolated with slerp. Intermediate
+// waypoints' tolerance can be adjusted separately.
+bool PlanStraightLineMotion(const VectorX<double>& q_current,
+                            const int num_via_points, double duration,
+                            const Isometry3<double>& X_WEndEffector0,
+                            const Isometry3<double>& X_WEndEffector1,
+                            const Vector3<double>& via_points_pos_tolerance,
+                            const double via_points_rot_tolerance,
+                            IiwaIkPlanner* planner, IKResults* ik_res,
+                            std::vector<double>* times) {
+  DRAKE_DEMAND(duration > 0 && num_via_points >= 0);
+  // Makes a slerp trajectory from start to end.
+  const eigen_aligned_std_vector<Quaternion<double>> quats = {
+      Quaternion<double>(X_WEndEffector0.linear()),
+      Quaternion<double>(X_WEndEffector1.linear())};
+
+  const std::vector<MatrixX<double>> pos = {X_WEndEffector0.translation(),
+                                            X_WEndEffector1.translation()};
+  PiecewiseQuaternionSlerp<double> rot_traj({0, duration}, quats);
+  PiecewisePolynomial<double> pos_traj =
+      PiecewisePolynomial<double>::FirstOrderHold({0, duration}, pos);
+
+  std::vector<IiwaIkPlanner::IkCartesianWaypoint> waypoints(num_via_points + 1);
+  const double dt = duration / (num_via_points + 1);
+  double time = 0;
+  times->clear();
+  times->push_back(time);
+  for (int i = 0; i <= num_via_points; ++i) {
+    time += dt;
+    times->push_back(time);
+    waypoints[i].pose.translation() = pos_traj.value(time);
+    waypoints[i].pose.linear() = Matrix3<double>(rot_traj.orientation(time));
+    if (i != num_via_points) {
+      waypoints[i].pos_tol = via_points_pos_tolerance;
+      waypoints[i].rot_tol = via_points_rot_tolerance;
+    }
+    waypoints[i].constrain_orientation = true;
+  }
+  DRAKE_DEMAND(times->size() == waypoints.size() + 1);
+  return planner->PlanSequentialTrajectory(waypoints, q_current, ik_res);
+}
+
+// Different states for the pick and place task.
+enum PickAndPlaceState {
+  OPEN_GRIPPER,
+  APPROACH_PICK_PREGRASP,
+  APPROACH_PICK,
+  GRASP,
+  LIFT_FROM_PICK,
+  APPROACH_PLACE_PREGRASP,
+  APPROACH_PLACE,
+  PLACE,
+  LIFT_FROM_PLACE,
+  DONE,
+};
+
+// Makes a state machine that drives the iiwa to pick up a block from one table
+// and place it on on the other.
+void RunPickAndPlaceDemo() {
+  lcm::LCM lcm;
+
+  const std::string iiwa_path =
+      GetDrakePath() + "/examples/kuka_iiwa_arm/urdf/iiwa14.urdf";
+  const std::string iiwa_end_effector_name = "iiwa_link_ee";
+
+  // Makes a WorldState, and sets up LCM subscriptions.
+  WorldState env_state(iiwa_path, iiwa_end_effector_name, &lcm);
+  env_state.SubscribeToWsgStatus("SCHUNK_WSG_STATUS");
+  env_state.SubscribeToIiwaStatus("IIWA_STATE_EST");
+  env_state.SubscribeToObjectStatus("OBJECT_STATE_EST");
+
+  // Spins until we get at least 1 message from all channels.
+  while (lcm.handleTimeout(10) == 0 || env_state.get_iiwa_time() == -1 ||
+         env_state.get_obj_time() == -1 || env_state.get_wsg_time() == -1) {
+  }
+
+  // Makes a planner.
+  const Isometry3<double> iiwa_base = env_state.get_iiwa_base();
+  std::shared_ptr<RigidBodyFrame<double>> iiwa_base_frame =
+      std::make_shared<RigidBodyFrame<double>>("world", nullptr, iiwa_base);
+  IiwaIkPlanner planner(iiwa_path, iiwa_end_effector_name, iiwa_base);
+  IKResults ik_res;
+  std::vector<double> times;
+
+  // Makes action handles.
+  WsgAction wsg_act("SCHUNK_WSG_COMMAND", &lcm);
+  IiwaMove iiwa_move(env_state.get_iiwa(), "COMMITTED_ROBOT_PLAN", &lcm);
+
+  // Desired end effector pose in the world frame for pick and place.
+  Isometry3<double> X_WEndEffector0, X_WEndEffector1;
+
+  // Desired object end pose relative to the base of the iiwa arm.
+  Isometry3<double> X_IiwaObj_desired;
+
+  // Desired object end pose in the world frame.
+  Isometry3<double> X_WObj_desired;
+
+  // Set initial state
+  PickAndPlaceState state = OPEN_GRIPPER;
+
+  // Position the gripper 30cm above the object before grasp.
+  const double kPreGraspHeightOffset = 0.3;
+
+  // Position and rotation tolerances.
+  // These should be adjusted to a tight bound until IK stops reliably giving
+  // results.
+  const Vector3<double> kTightPosTol(0.005, 0.005, 0.005);
+  const double kTightRotTol = 0.05;
+
+  const Vector3<double> kLoosePosTol(0.05, 0.05, 0.05);
+  const double kLooseRotTol = 0.5;
+
+  // lcm handle loop
+  while (true) {
+    // Handles all messages.
+    while (lcm.handleTimeout(10) == 0) {
+    }
+
+    switch (state) {
+      // Opens the gripper.
+      case OPEN_GRIPPER:
+        if (!wsg_act.ActionStarted()) {
+          wsg_act.OpenGripper(env_state);
+          std::cout << "OPEN_GRIPPER: " << env_state.get_iiwa_time()
+                    << std::endl;
+        }
+
+        if (wsg_act.ActionFinished(env_state)) {
+          state = APPROACH_PICK_PREGRASP;
+          wsg_act.Reset();
+        }
+        break;
+
+      // Approaches kPreGraspHeightOffset above the center of the object.
+      case APPROACH_PICK_PREGRASP:
+        if (!iiwa_move.ActionStarted()) {
+          // Computes the desired end effector pose in the world frame to be
+          // kPreGraspHeightOffset above the object.
+          X_WEndEffector0 = env_state.get_iiwa_end_effector_pose();
+          X_WEndEffector1 = ComputeGraspPose(env_state.get_object_pose());
+          X_WEndEffector1.translation()[2] += kPreGraspHeightOffset;
+
+          // 2 seconds, no via points.
+          bool res = PlanStraightLineMotion(
+              env_state.get_iiwa_q(), 0, 2, X_WEndEffector0, X_WEndEffector1,
+              kLoosePosTol, kLooseRotTol, &planner, &ik_res, &times);
+          DRAKE_DEMAND(res);
+          iiwa_move.MoveJoints(env_state, times, ik_res.q_sol);
+
+          std::cout << "APPROACH_PICK_PREGRASP: " << env_state.get_iiwa_time()
+                    << std::endl;
+        }
+
+        if (iiwa_move.ActionFinished(env_state)) {
+          state = APPROACH_PICK;
+          iiwa_move.Reset();
+        }
+        break;
+
+      // Moves gripper straight down.
+      case APPROACH_PICK:
+        if (!iiwa_move.ActionStarted()) {
+          X_WEndEffector0 = X_WEndEffector1;
+          X_WEndEffector1 = ComputeGraspPose(env_state.get_object_pose());
+
+          // 1 second, 3 via points. More via points to ensure the end effector
+          // moves in more or less a straight line.
+          bool res = PlanStraightLineMotion(
+              env_state.get_iiwa_q(), 3, 1, X_WEndEffector0, X_WEndEffector1,
+              kTightPosTol, kTightRotTol, &planner, &ik_res, &times);
+          DRAKE_DEMAND(res);
+
+          iiwa_move.MoveJoints(env_state, times, ik_res.q_sol);
+          std::cout << "APPROACH_PICK: " << env_state.get_iiwa_time()
+                    << std::endl;
+        }
+
+        if (iiwa_move.ActionFinished(env_state)) {
+          state = GRASP;
+          iiwa_move.Reset();
+        }
+        break;
+
+      // Grasps the object.
+      case GRASP:
+        if (!wsg_act.ActionStarted()) {
+          wsg_act.CloseGripper(env_state);
+          std::cout << "GRASP: " << env_state.get_iiwa_time() << std::endl;
+        }
+
+        if (wsg_act.ActionFinished(env_state)) {
+          state = LIFT_FROM_PICK;
+          wsg_act.Reset();
+        }
+        break;
+
+      // Lifts the object straight up.
+      case LIFT_FROM_PICK:
+        if (!iiwa_move.ActionStarted()) {
+          X_WEndEffector0 = X_WEndEffector1;
+          X_WEndEffector1.translation()[2] += kPreGraspHeightOffset;
+
+          // 1 seconds, 3 via points.
+          bool res = PlanStraightLineMotion(
+              env_state.get_iiwa_q(), 3, 1, X_WEndEffector0, X_WEndEffector1,
+              kTightPosTol, kTightRotTol, &planner, &ik_res, &times);
+          DRAKE_DEMAND(res);
+
+          iiwa_move.MoveJoints(env_state, times, ik_res.q_sol);
+          std::cout << "LIFT_FROM_PICK: " << env_state.get_iiwa_time()
+                    << std::endl;
+        }
+
+        if (iiwa_move.ActionFinished(env_state)) {
+          state = APPROACH_PLACE_PREGRASP;
+          iiwa_move.Reset();
+        }
+        break;
+
+      // Uses 2 seconds to move to right about the target place location.
+      case APPROACH_PLACE_PREGRASP:
+        if (!iiwa_move.ActionStarted()) {
+          int table = get_table(env_state.get_object_pose(), iiwa_base);
+
+          // Sets desired place location based on where we picked up the object.
+          // Table 0 is in front of iiwa base, and table 1 is to the left.
+          if (table == 0) {
+            // Table 0 -> table 1.
+            X_IiwaObj_desired.translation() = kPlacePosition1;
+            X_IiwaObj_desired.linear() = Matrix3<double>(
+                AngleAxis<double>(M_PI / 2., Vector3<double>::UnitZ()));
+          } else {
+            // Table 1 -> table 0.
+            X_IiwaObj_desired.translation() = kPlacePosition0;
+            X_IiwaObj_desired.linear().setIdentity();
+          }
+          X_WObj_desired = iiwa_base * X_IiwaObj_desired;
+
+          // Recomputes gripper's pose relative the object since the object
+          // probably moved during transfer.
+          const Isometry3<double> X_ObjEndEffector =
+              env_state.get_object_pose().inverse() *
+              env_state.get_iiwa_end_effector_pose();
+
+          X_WEndEffector0 = X_WEndEffector1;
+          X_WEndEffector1 = X_WObj_desired * X_ObjEndEffector;
+          X_WEndEffector1.translation()[2] += kPreGraspHeightOffset;
+
+          // 2 seconds, 2 via points. This doesn't have to be a move straight
+          // primitive. I did it this way because I have seen the IK gives a
+          // wild motion that causes the gripper to lose the object.
+          bool res = PlanStraightLineMotion(
+              env_state.get_iiwa_q(), 2, 2, X_WEndEffector0, X_WEndEffector1,
+              kLoosePosTol, kLooseRotTol, &planner, &ik_res, &times);
+          DRAKE_DEMAND(res);
+
+          iiwa_move.MoveJoints(env_state, times, ik_res.q_sol);
+          std::cout << "APPROACH_PLACE_PREGRASP: " << env_state.get_iiwa_time()
+                    << std::endl;
+        }
+
+        if (iiwa_move.ActionFinished(env_state)) {
+          state = APPROACH_PLACE;
+          iiwa_move.Reset();
+        }
+        break;
+
+      // Moves straight down.
+      case APPROACH_PLACE:
+        if (!iiwa_move.ActionStarted()) {
+          // Recomputes gripper's pose relative the object since the object
+          // probably moved during transfer.
+          const Isometry3<double> X_ObjEndEffector =
+              env_state.get_object_pose().inverse() *
+              env_state.get_iiwa_end_effector_pose();
+
+          // Computes the desired end effector pose in the world frame.
+          X_WEndEffector0 = X_WEndEffector1;
+          X_WEndEffector1 = X_WObj_desired * X_ObjEndEffector;
+          // TODO(siyuan): This hack is to prevent the robot from forcefully
+          // pushing the object into the table. Shouldn't be necessary once
+          // we have guarded moves supported by the controller side.
+          X_WEndEffector1.translation()[2] += 0.02;
+
+          // 1 seconds, 3 via points.
+          bool res = PlanStraightLineMotion(
+              env_state.get_iiwa_q(), 3, 1, X_WEndEffector0, X_WEndEffector1,
+              kTightPosTol, kTightRotTol, &planner, &ik_res, &times);
+          DRAKE_DEMAND(res);
+
+          iiwa_move.MoveJoints(env_state, times, ik_res.q_sol);
+          std::cout << "APPROACH_PLACE: " << env_state.get_iiwa_time()
+                    << std::endl;
+        }
+
+        if (iiwa_move.ActionFinished(env_state)) {
+          state = PLACE;
+          iiwa_move.Reset();
+        }
+        break;
+
+      // Releases the object.
+      case PLACE:
+        if (!wsg_act.ActionStarted()) {
+          wsg_act.OpenGripper(env_state);
+          std::cout << "PLACE: " << env_state.get_iiwa_time() << std::endl;
+        }
+
+        if (wsg_act.ActionFinished(env_state)) {
+          state = LIFT_FROM_PLACE;
+          wsg_act.Reset();
+        }
+        break;
+
+      // Moves straight up.
+      case LIFT_FROM_PLACE:
+        if (!iiwa_move.ActionStarted()) {
+          X_WEndEffector0 = X_WEndEffector1;
+          X_WEndEffector1.translation()[2] += kPreGraspHeightOffset;
+
+          // 1 seconds, 3 via points.
+          bool res = PlanStraightLineMotion(
+              env_state.get_iiwa_q(), 3, 1, X_WEndEffector0, X_WEndEffector1,
+              kTightPosTol, kTightRotTol, &planner, &ik_res, &times);
+          DRAKE_DEMAND(res);
+
+          iiwa_move.MoveJoints(env_state, times, ik_res.q_sol);
+          std::cout << "LIFT_FROM_PLACE: " << env_state.get_iiwa_time()
+                    << std::endl;
+        }
+
+        if (iiwa_move.ActionFinished(env_state)) {
+          state = OPEN_GRIPPER;
+          iiwa_move.Reset();
+        }
+        break;
+
+      case DONE:
+        if (!iiwa_move.ActionStarted()) {
+          const std::vector<double> time = {0, 2};
+          std::vector<VectorX<double>> q(2, env_state.get_iiwa_q());
+          q[1].setZero();
+          iiwa_move.MoveJoints(env_state, time, q);
+          std::cout << "DONE: " << env_state.get_iiwa_time() << std::endl;
+        }
+
+        if (iiwa_move.ActionFinished(env_state)) {
+          state = OPEN_GRIPPER;
+          iiwa_move.Reset();
+        }
+        break;
+    }
+  }
+}
+
+}  // namespace
+}  // namespace pick_and_place_demo
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake
+
+int main(int argc, const char* argv[]) {
+  drake::examples::kuka_iiwa_arm::pick_and_place_demo::RunPickAndPlaceDemo();
+  return 0;
+}

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.cc
@@ -1,0 +1,120 @@
+#include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h"
+
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/util/lcmUtil.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace pick_and_place_demo {
+
+WorldState::WorldState(const std::string& iiwa_model_path,
+                   const std::string end_effector_name, lcm::LCM* lcm)
+    : iiwa_model_path_(iiwa_model_path),
+      ee_name_(end_effector_name),
+      lcm_(lcm) {
+  iiwa_time_ = -1;
+  iiwa_base_ = iiwa_ee_pose_ = Isometry3<double>::Identity();
+  iiwa_q_ = VectorX<double>::Zero(7);
+  iiwa_v_ = VectorX<double>::Zero(7);
+  iiwa_ee_vel_.setZero();
+
+  wsg_time_ = -1;
+  wsg_q_ = 0;
+  wsg_v_ = 0;
+  wsg_force_ = 0;
+
+  obj_time_ = -1;
+  obj_pose_ = Isometry3<double>::Identity();
+  obj_vel_.setZero();
+}
+
+WorldState::~WorldState() {
+  for (lcm::Subscription* sub : lcm_subscriptions_) {
+    int status = lcm_->unsubscribe(sub);
+    DRAKE_DEMAND(status == 0);
+  }
+  lcm_subscriptions_.clear();
+}
+
+void WorldState::SubscribeToIiwaStatus(const std::string& channel) {
+  lcm_subscriptions_.push_back(
+      lcm_->subscribe(channel, &WorldState::HandleIiwaStatus, this));
+}
+
+void WorldState::SubscribeToWsgStatus(const std::string& channel) {
+  lcm_subscriptions_.push_back(
+      lcm_->subscribe(channel, &WorldState::HandleWsgStatus, this));
+}
+
+void WorldState::SubscribeToObjectStatus(const std::string& channel) {
+  lcm_subscriptions_.push_back(
+      lcm_->subscribe(channel, &WorldState::HandleObjectStatus, this));
+}
+
+void WorldState::HandleIiwaStatus(const lcm::ReceiveBuffer* rbuf,
+                                const std::string& chan,
+                                const bot_core::robot_state_t* iiwa_msg) {
+  iiwa_base_ = DecodePose(iiwa_msg->pose);
+
+  if (iiwa_time_ == -1) {
+    auto base_frame = std::allocate_shared<RigidBodyFrame<double>>(
+        Eigen::aligned_allocator<RigidBodyFrame<double>>(), "world", nullptr,
+        iiwa_base_);
+
+    iiwa_ = std::make_unique<RigidBodyTree<double>>();
+    parsers::urdf::AddModelInstanceFromUrdfFile(
+        iiwa_model_path_, multibody::joints::kFixed, base_frame, iiwa_.get());
+    end_effector_ = iiwa_->FindBody("iiwa_link_ee");
+  }
+
+  iiwa_time_ = iiwa_msg->utime / 1e6;
+
+  for (int i = 0; i < iiwa_msg->num_joints; i++) {
+    iiwa_v_[i] = iiwa_msg->joint_velocity[i];
+    iiwa_q_[i] = iiwa_msg->joint_position[i];
+  }
+
+  KinematicsCache<double> cache = iiwa_->doKinematics(iiwa_q_, iiwa_v_, true);
+
+  iiwa_ee_pose_ = iiwa_->CalcBodyPoseInWorldFrame(cache, *end_effector_);
+  iiwa_ee_vel_ =
+      iiwa_->CalcBodySpatialVelocityInWorldFrame(cache, *end_effector_);
+}
+
+void WorldState::HandleWsgStatus(const lcm::ReceiveBuffer* rbuf,
+                               const std::string& chan,
+                               const lcmt_schunk_wsg_status* wsg_msg) {
+  bool is_first_msg = wsg_time_ == -1;
+  double cur_time = wsg_msg->utime / 1e6;
+  double dt = cur_time - wsg_time_;
+
+  wsg_time_ = cur_time;
+
+  if (is_first_msg) {
+    wsg_q_ = wsg_msg->actual_position_mm / 1000.;
+    wsg_v_ = 0;
+    wsg_force_ = wsg_msg->actual_force;
+    return;
+  }
+
+  if (!is_first_msg && dt == 0) return;
+
+  // TODO(siyuanfeng): Need to filter
+  wsg_v_ = (wsg_msg->actual_position_mm / 1000. - wsg_q_) / dt;
+  wsg_q_ = wsg_msg->actual_position_mm / 1000.;
+  wsg_force_ = wsg_msg->actual_force;
+}
+
+void WorldState::HandleObjectStatus(const lcm::ReceiveBuffer* rbuf,
+                                  const std::string& chan,
+                                  const bot_core::robot_state_t* obj_msg) {
+  obj_time_ = obj_msg->utime / 1e6;
+  obj_pose_ = DecodePose(obj_msg->pose);
+  obj_vel_ = DecodeTwist(obj_msg->twist);
+}
+
+}  // namespace pick_and_place_demo
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <lcm/lcm-cpp.hpp>
+#include <list>
+#include <memory>
+#include <string>
+
+#include "bot_core/robot_state_t.hpp"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/lcmt_schunk_wsg_status.hpp"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace pick_and_place_demo {
+
+/**
+ * A class that represents the iiwa pick and place world, which contains a
+ * kuka iiwa arm, a schunk wsg gripper and an object that is being
+ * manipulated. These states are updated through LCM messages.
+ */
+class WorldState {
+ public:
+  /**
+   * Constructs an WorldState object that holds the states represent a pick and
+   * place scenario.
+   */
+  WorldState(const std::string& iiwa_model_path,
+           const std::string end_effector_name, lcm::LCM* lcm);
+
+  virtual ~WorldState();
+
+  /**
+   * Adds a lcm callback listening to @p channel to process iiwa status.
+   */
+  void SubscribeToIiwaStatus(const std::string& channel);
+
+  /**
+   * Adds a lcm callback listening to @p channel to process wsg gripper status.
+   */
+  void SubscribeToWsgStatus(const std::string& channel);
+
+  /**
+   * Adds a lcm callback listening to @p channel to process object status.
+   */
+  void SubscribeToObjectStatus(const std::string& channel);
+
+  double get_iiwa_time() const { return iiwa_time_; }
+  double get_wsg_time() const { return wsg_time_; }
+  double get_obj_time() const { return obj_time_; }
+  const Isometry3<double>& get_object_pose() const { return obj_pose_; }
+  const Vector6<double>& get_object_velocity() const { return obj_vel_; }
+  const Isometry3<double>& get_iiwa_base() const { return iiwa_base_; }
+  const Isometry3<double>& get_iiwa_end_effector_pose() const {
+    return iiwa_ee_pose_;
+  }
+  const Vector6<double>& get_iiwa_end_effector_velocity() const {
+    return iiwa_ee_vel_;
+  }
+  const VectorX<double>& get_iiwa_q() const { return iiwa_q_; }
+  const VectorX<double>& get_iiwa_v() const { return iiwa_v_; }
+  double get_wsg_q() const { return wsg_q_; }
+  double get_wsg_v() const { return wsg_v_; }
+
+  const RigidBodyTree<double>& get_iiwa() const { return *iiwa_; }
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ private:
+  // Handles iiwa states from the lcm message.
+  void HandleIiwaStatus(const lcm::ReceiveBuffer* rbuf, const std::string& chan,
+                        const bot_core::robot_state_t* iiwa_msg);
+
+  // Handles wsg states from the lcm message.
+  void HandleWsgStatus(const lcm::ReceiveBuffer* rbuf, const std::string& chan,
+                       const lcmt_schunk_wsg_status* wsg_msg);
+
+  // Handles object states from the lcm message.
+  void HandleObjectStatus(const lcm::ReceiveBuffer* rbuf,
+                          const std::string& chan,
+                          const bot_core::robot_state_t* obj_msg);
+
+  // Since we can't initialize the RBT unless we know where its base is,
+  // which is coming from lcm. So it's easier for us to own a model internally.
+  std::unique_ptr<RigidBodyTree<double>> iiwa_;
+  const std::string iiwa_model_path_;
+  const std::string ee_name_;
+  const RigidBody<double>* end_effector_{nullptr};
+
+  // Iiwa status
+  double iiwa_time_;
+  Isometry3<double> iiwa_base_;
+  VectorX<double> iiwa_q_;
+  VectorX<double> iiwa_v_;
+  Isometry3<double> iiwa_ee_pose_;
+  Vector6<double> iiwa_ee_vel_;
+
+  // Gripper status
+  double wsg_time_;
+  double wsg_q_;  // units [m]
+  double wsg_v_;  // units [m/s]
+  double wsg_force_;
+
+  // Object status
+  double obj_time_;
+  Isometry3<double> obj_pose_;
+  Vector6<double> obj_vel_;
+
+  // Lcm subscription management
+  lcm::LCM* lcm_;
+  std::list<lcm::Subscription*> lcm_subscriptions_;
+};
+
+}  // namespace pick_and_place_demo
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -119,15 +119,7 @@ std::unique_ptr<RigidBodyPlant<T>> BuildCombinedPlant(
   *wsg_instance = tree_builder->get_model_info_for_instance(id);
 
   auto plant = std::make_unique<RigidBodyPlant<T>>(tree_builder->Build());
-  // Contact parameters
-  const double kStiffness = 10000;
-  const double kDissipation = 5.0;
-  const double kStaticFriction = 0.9;
-  const double kDynamicFriction = 0.5;
-  const double kStictionSlipTolerance = 0.01;
-  plant->set_normal_contact_parameters(kStiffness, kDissipation);
-  plant->set_friction_contact_parameters(kStaticFriction, kDynamicFriction,
-                                         kStictionSlipTolerance);
+
   return plant;
 }
 

--- a/drake/examples/schunk_wsg/BUILD
+++ b/drake/examples/schunk_wsg/BUILD
@@ -22,7 +22,7 @@ drake_cc_library(
     name = "schunk_wsg_lcm",
     srcs = ["schunk_wsg_lcm.cc"],
     hdrs = ["schunk_wsg_lcm.h"],
-    visibility = ["//drake/examples/kuka_iiwa_arm:__pkg__"],
+    visibility = ["//drake/examples/kuka_iiwa_arm:__subpackages__"],
     deps = [
         ":schunk_wsg_trajectory_generator_state_vector",
         "//drake/common/trajectories:piecewise_polynomial_trajectory",


### PR DESCRIPTION
added very crude primitives to represent the full state of simulation environment.
added very crude guarded actions. 
added a state machine that does the pick and place demo, in which an object is moved between two tables repeatedly. 

some known issues:
0. PID controller needs tunning.
1. kuka_plan_runner should emit trajectories that start and end with zero velocity at least. 
2. the object slowly rotates on the table. tuning contact params seems to help very little, and i don't want to slow down the simulation massively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5321)
<!-- Reviewable:end -->
