### PR TITLE
DirectTrajectoryOptimization is-a MathematicalProgram, instead of has-a.

### DIFF
--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -44,4 +44,14 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "trajectory_optimization_test",
+    deps = [
+        ":direct_collocation",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/common/trajectories:piecewise_polynomial",
+    ],
+)
+
+
 cpplint()

--- a/drake/systems/trajectory_optimization/direct_trajectory_optimization.h
+++ b/drake/systems/trajectory_optimization/direct_trajectory_optimization.h
@@ -33,9 +33,39 @@ namespace systems {
  * implementation assumes that all constraints and costs are
  * time-invariant.
  */
-class DirectTrajectoryOptimization {
+class DirectTrajectoryOptimization : public solvers::MathematicalProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DirectTrajectoryOptimization)
+
+  /// Returns the decision variable associated with the timestep, h, at time
+  /// index @p index.
+  Eigen::VectorBlock<const solvers::VectorXDecisionVariable> h(
+      int index) const {
+    DRAKE_DEMAND(index >= 0 && index < N_);
+    return h_vars_.segment(index,
+                           1);  // TODO(russt): Replace with segment<1>(index).
+  }
+  /// Returns the decision variables associated with the state, x, at time
+  /// index @p index.
+  Eigen::VectorBlock<const solvers::VectorXDecisionVariable> x(
+      int index) const {
+    DRAKE_DEMAND(index >= 0 && index < N_);
+    return x_vars_.segment(index * num_states_, num_states_);
+  }
+  /// Returns the decision variables associated with the input, u, at time
+  /// index @p index.
+  Eigen::VectorBlock<const solvers::VectorXDecisionVariable> u(
+      int index) const {
+    DRAKE_DEMAND(index >= 0 && index < N_);
+    return u_vars_.segment(index * num_inputs_, num_inputs_);
+  }
+
+  // TODO(russt): Remove the methods below that add constraints without
+  // requesting the variable list to be passed in.  We should force the user
+  // to specify the variables to provide clarity and robustness.
+  // The "add to a list of times" utilities are still useful... we can replace
+  // them with methods of the form AddCost(..., MatrixXDecisionVariable), which
+  // adds the same constraint to each column of the variable matrix.
 
   /**
    * Adds an integrated cost to all time steps.
@@ -83,8 +113,7 @@ class DirectTrajectoryOptimization {
                           const std::vector<int>& time_indices) {
     for (const int i : time_indices) {
       DRAKE_ASSERT(i < N_);
-      opt_problem_.AddConstraint(
-          constraint, u_vars_.segment(i * num_inputs_, num_inputs_));
+      AddConstraint(constraint, u_vars_.segment(i * num_inputs_, num_inputs_));
     }
   }
 
@@ -101,8 +130,7 @@ class DirectTrajectoryOptimization {
                           const std::vector<int>& time_indices) {
     for (const int i : time_indices) {
       DRAKE_ASSERT(i < N_);
-      opt_problem_.AddConstraint(
-          constraint, x_vars_.segment(i * num_states_, num_states_));
+      AddConstraint(constraint, x_vars_.segment(i * num_states_, num_states_));
     }
   }
 
@@ -131,30 +159,6 @@ class DirectTrajectoryOptimization {
    */
   void AddTimeIntervalBounds(const Eigen::VectorXd& lower_bound,
                              const Eigen::VectorXd& upper_bound);
-
-  /**
-   * Add a cost to the initial state.
-   */
-  template <typename ConstraintT>
-  void AddInitialCost(std::shared_ptr<ConstraintT> constraint) {
-    opt_problem_.AddCost(constraint, x_vars_.head(num_states_));
-  }
-
-  /**
-   * Add a cost to the initial state.
-   *
-   * @param f A callable which meets the requirments of
-   * MathematicalProgram::AddCost().
-  */
-  template <typename F>
-  typename std::enable_if<
-      !std::is_convertible<F, std::shared_ptr<solvers::Constraint>>::value,
-      std::shared_ptr<solvers::Constraint>>::type
-  AddInitialCostFunc(F&& f) {
-    auto c = solvers::MathematicalProgram::MakeCost(std::forward<F>(f));
-    AddInitialCost(c);
-    return c;
-  }
 
   /**
    * Add a cost to the final state and total time.
@@ -267,7 +271,6 @@ class DirectTrajectoryOptimization {
   int num_inputs() const { return num_inputs_; }
   int num_states() const { return num_states_; }
   int N() const { return N_; }
-  solvers::MathematicalProgram* opt_problem() { return &opt_problem_; }
   const solvers::VectorXDecisionVariable& h_vars() const { return h_vars_; }
   const solvers::VectorXDecisionVariable& u_vars() const { return u_vars_; }
   const solvers::VectorXDecisionVariable& x_vars() const { return x_vars_; }
@@ -291,15 +294,14 @@ class DirectTrajectoryOptimization {
                       const PiecewisePolynomial<double>& traj_init_u,
                       const PiecewisePolynomial<double>& traj_init_x);
 
-  const int num_inputs_;
-  const int num_states_;
-  const int N_;  // Number of time samples
+  const int num_inputs_{};
+  const int num_states_{};
+  const int N_{};  // Number of time samples
 
-  solvers::MathematicalProgram opt_problem_;
   solvers::VectorXDecisionVariable h_vars_;  // Time deltas between each
                                              // input/state sample.
-  solvers::VectorXDecisionVariable u_vars_;
   solvers::VectorXDecisionVariable x_vars_;
+  solvers::VectorXDecisionVariable u_vars_;
 };
 
 }  // namespace systems

--- a/drake/systems/trajectory_optimization/test/direct_collocation_constraint_test.cc
+++ b/drake/systems/trajectory_optimization/test/direct_collocation_constraint_test.cc
@@ -11,15 +11,16 @@ namespace drake {
 namespace systems {
 namespace {
 
-class PendulumTestDirectCollocationConstraint :
-      public DirectCollocationConstraint {
+class PendulumTestDirectCollocationConstraint
+    : public DirectCollocationConstraint {
  public:
-  PendulumTestDirectCollocationConstraint(int num_states, int num_inputs)
-      : DirectCollocationConstraint(num_states, num_inputs) {}
+  PendulumTestDirectCollocationConstraint()
+      : DirectCollocationConstraint(2,  // num_states
+                                    1)  // num_inputs
+  {}
 
  protected:
-  void dynamics(const TaylorVecXd& state,
-                const TaylorVecXd& input,
+  void dynamics(const TaylorVecXd& state, const TaylorVecXd& input,
                 TaylorVecXd* xdot) const override {
     // From the Pendulum example:
     const double m = 1.0;
@@ -53,7 +54,7 @@ GTEST_TEST(DirectCollocationConstraintPendulumDynamicsTest,
   x(5) = 0.00537668;   // u0
   x(6) = 0.018339;     // u1
 
-  PendulumTestDirectCollocationConstraint dut(kNumStates, kNumInputs);
+  PendulumTestDirectCollocationConstraint dut;
 
   TaylorVecXd result;
   dut.Eval(math::initializeAutoDiff(x), result);
@@ -64,8 +65,8 @@ GTEST_TEST(DirectCollocationConstraintPendulumDynamicsTest,
   Eigen::VectorXd d_0_expected(x.size());
   d_0_expected << -6.26766, -7.0095, -0.74, 7.015539, -0.76, -0.1, 0.1;
   Eigen::VectorXd d_1_expected(x.size());
-  d_1_expected << 0.1508698, 14.488559, -6.715012, 14.818155,
-      7.315012, -2.96, -3.04;
+  d_1_expected << 0.1508698, 14.488559, -6.715012, 14.818155, 7.315012, -2.96,
+      -3.04;
   EXPECT_TRUE(CompareMatrices(result(0).derivatives(), d_0_expected, 1e-4,
                               MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(result(1).derivatives(), d_1_expected, 1e-4,

--- a/drake/systems/trajectory_optimization/test/trajectory_optimization_test.cc
+++ b/drake/systems/trajectory_optimization/test/trajectory_optimization_test.cc
@@ -19,18 +19,6 @@ namespace {
 
 typedef PiecewisePolynomial<double> PiecewisePolynomialType;
 
-class InitialCost {
- public:
-  static size_t numInputs() { return 2; }
-  static size_t numOutputs() { return 1; }
-
-  template <typename ScalarType>
-  // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-  void eval(VecIn<ScalarType> const& x, VecOut<ScalarType>& y) const {
-    y(0) = x(1) * x(1);
-  }
-};
-
 class FinalCost {
  public:
   static size_t numInputs() { return 3; }
@@ -173,7 +161,12 @@ GTEST_TEST(TrajectoryOptimizationTest, DirectTrajectoryOptimizationTest) {
   // we're going to try to minimize next time.
   direct_traj.GetResultSamples(&inputs, &states, &times_out);
 
-  direct_traj.AddInitialCostFunc(InitialCost());
+  // Tests adding constrainst to the original mathematical program, via
+  // the state variable accessor and symbolic formula.
+  direct_traj.AddLinearConstraint(direct_traj.x(0)(0) == 0.0);
+  direct_traj.AddLinearConstraint(direct_traj.x(0)(1) == 0.0);
+
+  // Adds a final cost
   direct_traj.AddFinalCostFunc(FinalCost());
   result = direct_traj.SolveTraj(t_init_in, inputs_u, states_x);
   EXPECT_EQ(result, solvers::SolutionResult::kSolutionFound)


### PR DESCRIPTION
This allows us to reuse the symbolic constraint adding tools (without passing through massive numbers of method interfaces).  The abstraction of state variables in time is still encapsulated by the DirectTrajectoryOptimization class -- t,x,u decision variables are only accessed via their times, and the ability to add Costs/Constraints without specifying the decision variables explicitly has been removed from MathematicalProgram.

Also:
- Added trajectory_optimization_test to bazel.
- AddInitialCost is not a thing people do, and was only used in a test, so I've removed it.
- modified the test case to provide a minimal coverage of adding of constraints using symbolic formula.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5322)
<!-- Reviewable:end -->
