### PR TITLE
Adds model.config files for desk and table.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/models/desk/model.config
+++ b/drake/examples/kuka_iiwa_arm/models/desk/model.config
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Transcendesk Sit/Stand 55"</name>
+  <version>1.0</version>
+  <sdf>transcendesk55inch.sdf</sdf>
+
+  <author>
+    <name>Drake Developers</name>
+    <email>user@host.com</email>
+  </author>
+
+  <description>
+    A model of a sit-stand desk that's 55" wide. It is modeled after this one:
+    https://www.amazon.com/Transcendesk-Standing-Desk-Easily-Sitting/dp/B01C66L75C
+  </description>
+</model>

--- a/drake/examples/kuka_iiwa_arm/models/table/model.config
+++ b/drake/examples/kuka_iiwa_arm/models/table/model.config
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Extra Heavy Duty Table</name>
+  <version>1.0</version>
+  <sdf>extra_heavy_duty_table.sdf</sdf>
+
+  <author>
+    <name>Drake Developers</name>
+    <email>user@host.com</email>
+  </author>
+
+  <description>
+    A model of a metal industrial table with a square work surface area. It is
+    modeled after this one: http://littlegiant-usa.com/products/mth1-1630-24.
+  </description>
+</model>


### PR DESCRIPTION
This is necessary for other SDF models to reference these models. Towards #5317.

I tested these by verifying that the models can be loaded into `gazebo`:

```
$ cd ~/dev/drake-distro-1/drake/examples/kuka_iiwa_arm/models
$ export GAZEBO_MODEL_PATH=`pwd`:$GAZEBO_MODEL_PATH
$ gazebo
```

Once `gazebo` starts, I was able to add the desk and table to the simulation using the "Insert" tab:

![screenshot from 2017-02-26 09-26-33](https://cloud.githubusercontent.com/assets/1388098/23340559/727e3eea-fc06-11e6-9127-e1e695643a1e.png)

For more information about `model.config` files, see: http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot.%3C/p%3E#ModelDatabaseStructure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5324)
<!-- Reviewable:end -->
