### PR TITLE
Changes constructors of NotSoGoodVector and NoteQuiteGoodVector to be `{}` instead of `= default`.

### DIFF
--- a/drake/systems/framework/test/value_checker_test.cc
+++ b/drake/systems/framework/test/value_checker_test.cc
@@ -39,14 +39,14 @@ class MissingCloneVector : public BasicVector<double> {
 class NotSoGoodVector : public GoodVector {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NotSoGoodVector)
-  NotSoGoodVector() = default;
+  NotSoGoodVector() {}
 };
 
 // This one remembers to DoClone in the subclass, but does it wrong.
 class NotQuiteGoodVector : public GoodVector {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NotQuiteGoodVector)
-  NotQuiteGoodVector() = default;
+  NotQuiteGoodVector() {}
   GoodVector* DoClone() const override {
     auto result = new GoodVector;
     result->set_value(this->get_value());


### PR DESCRIPTION
Resolves #5327.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5328)
<!-- Reviewable:end -->
