### PR TITLE
Add symbolic cost

### DIFF
--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -537,15 +537,14 @@ Binding<Constraint> MathematicalProgram::AddCost(const Expression& e) {
                                  "expression.\n";
     throw std::runtime_error(oss.str());
   } else if (total_degree == 2) {
-    auto binding = AddQuadraticCostWithMonomialToCoeffMap(
+    return  AddQuadraticCostWithMonomialToCoeffMap(
         monomial_to_coeff_map, vars_vec, map_var_to_index, this);
-    return Binding<Constraint>(binding.constraint(), binding.variables());
   } else {
     Eigen::VectorXd c(vars_vec.size());
     c.setZero();
     for (const auto& p : monomial_to_coeff_map) {
       if (p.first.total_degree() == 1) {
-        Variable::Id var_id = p.first.get_powers().begin()->first;
+        const Variable::Id var_id = p.first.get_powers().begin()->first;
         DRAKE_DEMAND(is_constant(p.second));
         c(map_var_to_index.at(var_id)) += get_constant_value(p.second);
       }

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -215,7 +215,7 @@ class SymbolicError : public runtime_error {
 
 // Given an expression `e`, extracts all variables inside `e`.
 // @param[in] e A symbolic expression.
-// @return pair. pair.first is the variables in `e`. pair.second is the mapping
+// @retval pair pair.first is the variables in `e`. pair.second is the mapping
 // from the variable ID to the index in pair.first, such that
 // pair.second[pair.first(i).get_id()] = i
 std::pair<VectorXDecisionVariable, unordered_map<Variable::Id, int>>
@@ -235,10 +235,10 @@ ExtractVariablesFromExpression(const Expression& e) {
 
 // Given an expression `e`, extract all variables inside `e`, append these
 // variables to `vars` if they are not included in `vars` yet.
-// @param[in] e.  A symbolic expression.
-// @param[in,out] vars.  As an input, `vars` contain the variables before
+// @param[in] e  A symbolic expression.
+// @param[in,out] vars  As an input, `vars` contain the variables before
 // extracting expression `e`. As an output, the variables in `e` that were not
-// included in `vars`, will be appended to the end of `vars.
+// included in `vars`, will be appended to the end of `vars`.
 // @param[in,out] map_var_to_index. map_var_to_index is of the same size as
 // `vars`, and map_var_to_index[vars(i).get_id()] = i. This invariance holds
 // for map_var_to_index both as the input and as the output.

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -530,9 +530,9 @@ Binding<Constraint> MathematicalProgram::AddCost(const Expression& e) {
   }
 
 
-  auto p = ExtractVariablesFromExpression(e);
-  const VectorXDecisionVariable& vars_vec = p.first;
-  const auto& map_var_to_index = p.second;
+  auto e_extracted = ExtractVariablesFromExpression(e);
+  const VectorXDecisionVariable& vars_vec = e_extracted.first;
+  const auto& map_var_to_index = e_extracted.second;
 
   if (total_degree > 2) {
     std::ostringstream oss;

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -906,10 +906,10 @@ class MathematicalProgram {
   /**
    * Adds a cost in the symbolic form.
    * Note that the constant part of the cost is ignored. So if you set
-   * `e` = x + 2, then only the cost on `x` is added, the constant term 2 is
+   * `e = x + 2`, then only the cost on `x` is added, the constant term 2 is
    * ignored.
    * @param e The linear or quadratic expression of the cost.
-   * @pre{e is linear or e is quadratic. Otherwise throws a runtime error.}
+   * @pre `e` is linear or `e` is quadratic. Otherwise throws a runtime error.
    * @return The newly created cost, together with the bound variables.
    */
   Binding<Constraint> AddCost(const symbolic::Expression& e);
@@ -2367,8 +2367,8 @@ class MathematicalProgram {
    * Given a matrix of decision variables, checks if every entry in the
    * matrix is a decision variable in the program; throws a runtime
    * error if any variable is not a decision variable in the program.
-   * @tparam Derived A Eigen::Matrix type of symbolic Variable.
-   * @param vars A matrix of variable.
+   * @tparam Derived An Eigen::Matrix type of symbolic Variable.
+   * @param vars A matrix of variables.
    */
   template <typename Derived>
   typename std::enable_if<

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -904,6 +904,17 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
+   * Adds a cost in the symbolic form.
+   * Note that the constant part of the cost is ignored. So if you set
+   * `e` = x + 2, then only the cost on `x` is added, the constant term 2 is
+   * ignored.
+   * @param e The linear expression of the cost
+   * @pre{e is linear or e is quadratic. Otherwise throws a runtime error.}
+   * @return The newly created cost, together with the bound variables.
+   */
+  Binding<Constraint> AddCost(const symbolic::Expression& e);
+
+  /**
    * Adds a generic constraint to the program.  This should
    * only be used if a more specific type of constraint is not
    * available, as it may require the use of a significantly more

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -908,7 +908,7 @@ class MathematicalProgram {
    * Note that the constant part of the cost is ignored. So if you set
    * `e` = x + 2, then only the cost on `x` is added, the constant term 2 is
    * ignored.
-   * @param e The linear expression of the cost
+   * @param e The linear or quadratic expression of the cost.
    * @pre{e is linear or e is quadratic. Otherwise throws a runtime error.}
    * @return The newly created cost, together with the bound variables.
    */
@@ -2366,8 +2366,8 @@ class MathematicalProgram {
   /*
    * Given a matrix of decision variables, checks if every entry in the
    * matrix is a decision variable in the program; throws a runtime
-   * error if any variable is not a decsion variable in the program.
-   * @tparam  A Eigen::Matrix type of symbolic Variable.
+   * error if any variable is not a decision variable in the program.
+   * @tparam Derived A Eigen::Matrix type of symbolic Variable.
    * @param vars A matrix of variable.
    */
   template <typename Derived>

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2364,25 +2364,27 @@ class MathematicalProgram {
                                        const std::vector<std::string>& names);
 
   /*
-   * Given a matrix of decision variables, return true if every entry in the
-   * matrix is a decision variable in the program; otherwise return false.
+   * Given a matrix of decision variables, checks if every entry in the
+   * matrix is a decision variable in the program; throws a runtime
+   * error if any variable is not a decsion variable in the program.
    * @tparam  A Eigen::Matrix type of symbolic Variable.
    * @param vars A matrix of variable.
    */
   template <typename Derived>
   typename std::enable_if<
-      std::is_same<typename Derived::Scalar, symbolic::Variable>::value,
-      bool>::type
-  IsDecisionVariable(const Eigen::MatrixBase<Derived>& vars) {
+      std::is_same<typename Derived::Scalar, symbolic::Variable>::value>::type
+  CheckIsDecisionVariable(const Eigen::MatrixBase<Derived> &vars) {
     for (int i = 0; i < vars.rows(); ++i) {
       for (int j = 0; j < vars.cols(); ++j) {
         if (decision_variable_index_.find(vars(i, j).get_id()) ==
             decision_variable_index_.end()) {
-          return false;
+          std::ostringstream oss;
+          oss << vars(i, j)
+              << " is not a decision variable of the mathematical program.\n";
+          throw std::runtime_error(oss.str());
         }
       }
     }
-    return true;
   }
 
   Binding<LinearEqualityConstraint> DoAddLinearEqualityConstraint(

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -546,18 +546,18 @@ GTEST_TEST(testMathematicalProgram, AddLinearCostSymbolic) {
   CheckAddedSymbolicLinearCost(&prog, 2 * x(0) + 3 * x(1) + 2);
   // Add linear cost 2 * x(1)
   CheckAddedSymbolicLinearCost(&prog, 2 * x(1));
-  // Add Linear (constant) cost 3
+  // Add linear (constant) cost 3
   CheckAddedSymbolicLinearCost(&prog, 3);
-  // Add Linear cost -x(0)
+  // Add linear cost -x(0)
   CheckAddedSymbolicLinearCost(&prog, -x(0));
-  // Add Linear cost -(x(1) + 3 * x(0))
+  // Add linear cost -(x(1) + 3 * x(0))
   CheckAddedSymbolicLinearCost(&prog, -(x(1) + 3 * x(0)));
   // Add linear cost x(1)*x(1) + x(0) - x(1)*x(1)
   CheckAddedSymbolicLinearCost(&prog, x(1) * x(1) + x(0) - x(1) * x(1));
 }
 
 GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic1) {
-  // Add Linear Constraint: -10 <= 3 - 5*x0 + 10*x2 - 7*y1 <= 10
+  // Add linear constraint: -10 <= 3 - 5*x0 + 10*x2 - 7*y1 <= 10
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables(3, "x");
   auto y = prog.NewContinuousVariables(3, "y");
@@ -578,7 +578,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic1) {
 }
 
 GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic2) {
-  // Add Linear Constraint: -10 <= x0 <= 10
+  // Add linear constraint: -10 <= x0 <= 10
   // Note that this constraint is a bounding-box constraint which is a sub-class
   // of linear-constraint.
   MathematicalProgram prog;
@@ -603,7 +603,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic2) {
 }
 
 GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic3) {
-  // Add Linear Constraints
+  // Add linear constraints
   //     3 <=  3 - 5*x0 +      + 10*x2        - 7*y1        <= 9
   //   -10 <=                       x2                      <= 10
   //    -7 <= -5 + 2*x0 + 3*x2         + 3*y0 - 2*y1 + 6*y2 <= 12

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -552,6 +552,8 @@ GTEST_TEST(testMathematicalProgram, AddLinearCostSymbolic) {
   CheckAddedSymbolicLinearCost(&prog, -x(0));
   // Add Linear cost -(x(1) + 3 * x(0))
   CheckAddedSymbolicLinearCost(&prog, -(x(1) + 3 * x(0)));
+  // AddLinear cost x(1)*x(1) + x(0) - x(1)*x(1)
+  CheckAddedSymbolicLinearCost(&prog, x(1) * x(1) + x(0) - x(1) * x(1));
 }
 
 GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic1) {

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -552,7 +552,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearCostSymbolic) {
   CheckAddedSymbolicLinearCost(&prog, -x(0));
   // Add Linear cost -(x(1) + 3 * x(0))
   CheckAddedSymbolicLinearCost(&prog, -(x(1) + 3 * x(0)));
-  // AddLinear cost x(1)*x(1) + x(0) - x(1)*x(1)
+  // Add linear cost x(1)*x(1) + x(0) - x(1)*x(1)
   CheckAddedSymbolicLinearCost(&prog, x(1) * x(1) + x(0) - x(1) * x(1));
 }
 
@@ -1458,11 +1458,12 @@ GTEST_TEST(testMathematicalProgram, testAddCostThrowError) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
 
-  // Add a non-polynomial cost
+  // Add a non-polynomial cost.
   EXPECT_THROW(prog.AddCost(sin(x(0))), std::runtime_error);
 
-  // Add a cubic cost
+  // Add a third order polynomial cost.
   EXPECT_THROW(prog.AddCost(x(0) * x(0) * x(1)), std::runtime_error);
+  EXPECT_THROW(prog.AddCost(pow(x(0), 3)), std::runtime_error);
 
   // Add a cost containing variable not included in the mathematical program.
   symbolic::Variable y("y");

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -504,7 +504,10 @@ GTEST_TEST(testMathematicalProgram, AddCostTest) {
                    Eigen::Vector2d(1, 2), num_generic_costs);
 }
 
-void CheckAddedSymbolicLinearCostUserFun(const MathematicalProgram& prog, const Expression& e, const Binding<Constraint>& binding, int num_linear_costs) {
+void CheckAddedSymbolicLinearCostUserFun(const MathematicalProgram& prog,
+                                         const Expression& e,
+                                         const Binding<Constraint>& binding,
+                                         int num_linear_costs) {
   EXPECT_EQ(prog.linear_costs().size(), num_linear_costs);
   EXPECT_EQ(prog.linear_costs().back().constraint(), binding.constraint());
   EXPECT_EQ(prog.linear_costs().back().variables(), binding.variables());
@@ -1347,7 +1350,11 @@ GTEST_TEST(testMathematicalProgram, AddQuadraticCost) {
   CheckAddedQuadraticCost(&prog, Matrix3d::Identity(), Vector3d(1, 2, 3), x);
 }
 
-void CheckAddedSymbolicQuadraticCostUserFun(const MathematicalProgram& prog, const Expression& e, double constant, const Binding<Constraint>& binding, int num_quadratic_cost) {
+void CheckAddedSymbolicQuadraticCostUserFun(const MathematicalProgram& prog,
+                                            const Expression& e,
+                                            double constant,
+                                            const Binding<Constraint>& binding,
+                                            int num_quadratic_cost) {
   EXPECT_EQ(num_quadratic_cost, prog.quadratic_costs().size());
   EXPECT_EQ(binding.constraint(), prog.quadratic_costs().back().constraint());
   EXPECT_EQ(binding.variables(), prog.quadratic_costs().back().variables());
@@ -1364,9 +1371,11 @@ void CheckAddedSymbolicQuadraticCost(MathematicalProgram* prog,
                                      const Expression& e, double constant) {
   int num_quadratic_cost = prog->quadratic_costs().size();
   auto binding1 = prog->AddQuadraticCost(e);
-  CheckAddedSymbolicQuadraticCostUserFun(*prog, e, constant, binding1, ++num_quadratic_cost);
+  CheckAddedSymbolicQuadraticCostUserFun(*prog, e, constant, binding1,
+                                         ++num_quadratic_cost);
   auto binding2 = prog->AddCost(e);
-  CheckAddedSymbolicQuadraticCostUserFun(*prog, e, constant, binding2, ++num_quadratic_cost);
+  CheckAddedSymbolicQuadraticCostUserFun(*prog, e, constant, binding2,
+                                         ++num_quadratic_cost);
 }
 
 GTEST_TEST(testMathematicalProgram, AddSymbolicQuadraticCost) {


### PR DESCRIPTION
now `AddCost(const symbolic::Expression& e)` accepts both linear and quadratic cost. Partially resolves #5325

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5340)
<!-- Reviewable:end -->
