### PR TITLE
Make LeafSystem::AllocateOutput final.

### DIFF
--- a/drake/examples/Acrobot/acrobot_lcm.cc
+++ b/drake/examples/Acrobot/acrobot_lcm.cc
@@ -47,17 +47,12 @@ AcrobotCommandSender::AcrobotCommandSender() {
   this->DeclareAbstractOutputPort();
 }
 
-std::unique_ptr<systems::SystemOutput<double>>
-AcrobotCommandSender::AllocateOutput(
-    const systems::Context<double>& context) const {
-  auto output = std::make_unique<systems::LeafSystemOutput<double>>();
+std::unique_ptr<systems::AbstractValue>
+AcrobotCommandSender::AllocateOutputAbstract(
+    const systems::OutputPortDescriptor<double>& descriptor) const {
   lcmt_acrobot_u msg{};
   msg.tau = 0;
-
-  output->add_port(
-      std::make_unique<systems::OutputPort>(
-          std::make_unique<systems::Value<lcmt_acrobot_u>>(msg)));
-  return std::unique_ptr<SystemOutput<double>>(output.release());
+  return std::make_unique<systems::Value<lcmt_acrobot_u>>(msg);
 }
 
 void AcrobotCommandSender::DoCalcOutput(const Context<double>& context,
@@ -96,20 +91,16 @@ AcrobotStateSender::AcrobotStateSender() {
   this->DeclareAbstractOutputPort();
 }
 
-std::unique_ptr<systems::SystemOutput<double>>
-AcrobotStateSender::AllocateOutput(
-    const systems::Context<double>& context) const {
+std::unique_ptr<systems::AbstractValue>
+AcrobotStateSender::AllocateOutputAbstract(
+    const systems::OutputPortDescriptor<double>& descriptor) const {
   auto output = std::make_unique<systems::LeafSystemOutput<double>>();
   lcmt_acrobot_x msg{};
   msg.theta1 = 0;
   msg.theta2 = 0;
   msg.theta1Dot = 0;
   msg.theta2Dot = 0;
-
-  output->add_port(
-      std::make_unique<systems::OutputPort>(
-          std::make_unique<systems::Value<lcmt_acrobot_x>>(msg)));
-  return std::unique_ptr<SystemOutput<double>>(output.release());
+  return std::make_unique<systems::Value<lcmt_acrobot_x>>(msg);
 }
 
 void AcrobotStateSender::DoCalcOutput(const Context<double>& context,

--- a/drake/examples/Acrobot/acrobot_lcm.h
+++ b/drake/examples/Acrobot/acrobot_lcm.h
@@ -19,6 +19,7 @@ class AcrobotStateReceiver : public systems::LeafSystem<double> {
  public:
   AcrobotStateReceiver();
 
+ protected:
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
 
@@ -33,8 +34,9 @@ class AcrobotCommandSender : public systems::LeafSystem<double> {
  public:
   AcrobotCommandSender();
 
-  std::unique_ptr<systems::SystemOutput<double>> AllocateOutput(
-      const systems::Context<double>& context) const override;
+ protected:
+  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
+      const systems::OutputPortDescriptor<double>& descriptor) const override;
 
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
@@ -47,6 +49,7 @@ class AcrobotCommandReceiver : public systems::LeafSystem<double> {
  public:
   AcrobotCommandReceiver();
 
+ protected:
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
 };
@@ -58,8 +61,9 @@ class AcrobotStateSender : public systems::LeafSystem<double> {
  public:
   AcrobotStateSender();
 
-  std::unique_ptr<systems::SystemOutput<double>> AllocateOutput(
-      const systems::Context<double>& context) const override;
+ protected:
+  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
+      const systems::OutputPortDescriptor<double>& descriptor) const override;
 
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;

--- a/drake/examples/Valkyrie/robot_state_decoder.cc
+++ b/drake/examples/Valkyrie/robot_state_decoder.cc
@@ -162,14 +162,10 @@ void RobotStateDecoder::DoCalcOutput(const Context<double>& context,
   tree_.doKinematics(kinematics_cache, true);
 }
 
-std::unique_ptr<SystemOutput<double>> RobotStateDecoder::AllocateOutput(
-    const Context<double>& context) const {
-  auto output = make_unique<LeafSystemOutput<double>>();
-  auto kinematics_cache =
-      std::make_unique<Value<KinematicsCache<double>>>(
-          tree_.CreateKinematicsCache());
-  output->add_port(move(kinematics_cache));
-  return unique_ptr<SystemOutput<double>>(output.release());
+std::unique_ptr<AbstractValue> RobotStateDecoder::AllocateOutputAbstract(
+    const OutputPortDescriptor<double>& output) const {
+  return std::make_unique<Value<KinematicsCache<double>>>(
+      tree_.CreateKinematicsCache());
 }
 
 std::map<std::string, const RigidBody<double>*>

--- a/drake/examples/Valkyrie/robot_state_decoder.h
+++ b/drake/examples/Valkyrie/robot_state_decoder.h
@@ -30,13 +30,14 @@ class RobotStateDecoder : public LeafSystem<double> {
 
   RobotStateDecoder& operator=(const RobotStateDecoder&) = delete;
 
-  std::unique_ptr<SystemOutput<double>> AllocateOutput(
-      const Context<double>& context) const override;
+ protected:
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<double>& descriptor) const override;
 
- private:
   void DoCalcOutput(const Context<double>& context,
                     SystemOutput<double>* output) const override;
 
+ private:
   std::map<std::string, const RigidBody<double>*> CreateJointNameToBodyMap(
       const RigidBodyTree<double>& tree);
 

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -78,14 +78,9 @@ void RobotStateEncoder::DoCalcOutput(const Context<double>& context,
   SetForceTorque(kinematics_results, contact_results, &message);
 }
 
-std::unique_ptr<SystemOutput<double>> RobotStateEncoder::AllocateOutput(
-    const Context<double>& context) const {
-  auto output = make_unique<LeafSystemOutput<double>>();
-
-  auto data = make_unique<Value<robot_state_t>>(robot_state_t());
-  output->add_port(move(data));
-
-  return std::unique_ptr<SystemOutput<double>>(output.release());
+std::unique_ptr<AbstractValue> RobotStateEncoder::AllocateOutputAbstract(
+    const OutputPortDescriptor<double>& descriptor) const {
+  return make_unique<Value<robot_state_t>>(robot_state_t());
 }
 
 const OutputPortDescriptor<double>& RobotStateEncoder::lcm_message_port()

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -41,9 +41,6 @@ class RobotStateEncoder final : public LeafSystem<double> {
 
   RobotStateEncoder& operator=(const RobotStateEncoder&) = delete;
 
-  std::unique_ptr<SystemOutput<double>> AllocateOutput(
-      const Context<double>& context) const override;
-
   /// Returns descriptor of output port on which the LCM message is presented.
   const OutputPortDescriptor<double>& lcm_message_port() const;
 
@@ -56,6 +53,10 @@ class RobotStateEncoder final : public LeafSystem<double> {
   /// Returns descriptor of effort input port corresponding to @param actuator.
   const InputPortDescriptor<double>& effort_port(
       const RigidBodyActuator& actuator) const;
+
+ protected:
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<double>& descriptor) const override;
 
  private:
   void DoCalcOutput(const Context<double>& context,

--- a/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
+++ b/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
@@ -17,16 +17,6 @@ class ValkyriePDAndFeedForwardController : public systems::LeafSystem<double> {
                          const VectorX<double>& nominal_torque,
                          const VectorX<double>& Kp, const VectorX<double>& Kd);
 
-  std::unique_ptr<SystemOutput<double>> AllocateOutput(
-      const Context<double>& context) const override {
-    std::unique_ptr<LeafSystemOutput<double>> output(
-        new LeafSystemOutput<double>);
-
-    output->add_port(std::unique_ptr<AbstractValue>(
-        new Value<bot_core::atlas_command_t>(bot_core::atlas_command_t())));
-    return std::move(output);
-  }
-
   inline const InputPortDescriptor<double>& get_input_port_kinematics_result()
       const {
     return get_input_port(input_port_index_kinematics_result_);
@@ -35,6 +25,13 @@ class ValkyriePDAndFeedForwardController : public systems::LeafSystem<double> {
   inline const OutputPortDescriptor<double>& get_output_port_atlas_command()
       const {
     return get_output_port(output_port_index_atlas_command_);
+  }
+
+ protected:
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<double>& descriptor) const override {
+    return std::make_unique<Value<bot_core::atlas_command_t>>(
+        bot_core::atlas_command_t());
   }
 
  private:

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -82,15 +82,11 @@ IiwaCommandSender::IiwaCommandSender()
   this->DeclareAbstractOutputPort();
 }
 
-std::unique_ptr<systems::SystemOutput<double>>
-IiwaCommandSender::AllocateOutput(
-    const systems::Context<double>& context) const {
-  auto output = std::make_unique<systems::LeafSystemOutput<double>>();
+std::unique_ptr<systems::AbstractValue>
+IiwaCommandSender::AllocateOutputAbstract(
+    const systems::OutputPortDescriptor<double>& descriptor) const {
   lcmt_iiwa_command msg{};
-  output->add_port(
-      std::make_unique<systems::OutputPort>(
-          std::make_unique<systems::Value<lcmt_iiwa_command>>(msg)));
-  return std::unique_ptr<SystemOutput<double>>(output.release());
+  return std::make_unique<systems::Value<lcmt_iiwa_command>>(msg);
 }
 
 void IiwaCommandSender::DoCalcOutput(
@@ -187,10 +183,9 @@ IiwaStatusSender::IiwaStatusSender() {
   this->DeclareAbstractOutputPort();
 }
 
-std::unique_ptr<systems::SystemOutput<double>>
-IiwaStatusSender::AllocateOutput(
-    const systems::Context<double>& context) const {
-  auto output = std::make_unique<systems::LeafSystemOutput<double>>();
+std::unique_ptr<systems::AbstractValue>
+IiwaStatusSender::AllocateOutputAbstract(
+    const systems::OutputPortDescriptor<double>& descriptor) const {
   lcmt_iiwa_status msg{};
   msg.num_joints = kNumJoints;
   msg.joint_position_measured.resize(msg.num_joints, 0);
@@ -199,11 +194,7 @@ IiwaStatusSender::AllocateOutput(
   msg.joint_torque_measured.resize(msg.num_joints, 0);
   msg.joint_torque_commanded.resize(msg.num_joints, 0);
   msg.joint_torque_external.resize(msg.num_joints, 0);
-
-  output->add_port(
-      std::make_unique<systems::OutputPort>(
-          std::make_unique<systems::Value<lcmt_iiwa_status>>(msg)));
-  return std::unique_ptr<SystemOutput<double>>(output.release());
+  return std::make_unique<systems::Value<lcmt_iiwa_status>>(msg);
 }
 
 void IiwaStatusSender::DoCalcOutput(

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
@@ -72,11 +72,10 @@ class IiwaCommandSender : public systems::LeafSystem<double> {
     return this->get_input_port(torque_input_port_);
   }
 
-  std::unique_ptr<systems::SystemOutput<double>> AllocateOutput(
-      const systems::Context<double>& context) const override;
-
-
  protected:
+  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
+      const systems::OutputPortDescriptor<double>& descriptor) const override;
+
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
 
@@ -154,8 +153,9 @@ class IiwaStatusSender : public systems::LeafSystem<double> {
     return this->get_input_port(1);
   }
 
-  std::unique_ptr<systems::SystemOutput<double>> AllocateOutput(
-      const systems::Context<double>& context) const override;
+ protected:
+  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
+      const systems::OutputPortDescriptor<double>& descriptor) const override;
 
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
@@ -165,13 +165,11 @@ SchunkWsgStatusSender(int input_size,
   this->DeclareAbstractOutputPort();
 }
 
-std::unique_ptr<SystemOutput<double>> SchunkWsgStatusSender::AllocateOutput(
-    const Context<double>& context) const {
-  auto output = std::make_unique<systems::LeafSystemOutput<double>>();
+std::unique_ptr<systems::AbstractValue>
+SchunkWsgStatusSender::AllocateOutputAbstract(
+    const systems::OutputPortDescriptor<double>& descriptor) const {
   lcmt_schunk_wsg_status msg{};
-  output->add_port(
-      std::make_unique<systems::Value<lcmt_schunk_wsg_status>>(msg));
-  return std::unique_ptr<SystemOutput<double>>(output.release());
+  return std::make_unique<systems::Value<lcmt_schunk_wsg_status>>(msg);
 }
 
 void SchunkWsgStatusSender::DoCalcOutput(const Context<double>& context,

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.h
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.h
@@ -76,8 +76,9 @@ class SchunkWsgStatusSender : public systems::LeafSystem<double> {
   SchunkWsgStatusSender(int input_size,
                         int position_index, int velocity_index);
 
-  std::unique_ptr<systems::SystemOutput<double>> AllocateOutput(
-      const systems::Context<double>& context) const override;
+ protected:
+  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
+      const systems::OutputPortDescriptor<double>& descriptor) const override;
 
  private:
   void DoCalcOutput(const systems::Context<double>& context,

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -236,11 +236,6 @@ class RigidBodyPlant : public LeafSystem<T> {
   }
 
   // System<T> overrides.
-  /// Allocates the output ports. See this class' description for details of
-  /// these ports.
-  std::unique_ptr<SystemOutput<T>> AllocateOutput(
-      const Context<T>& context) const override;
-
   bool has_any_direct_feedthrough() const override;
 
   /// Computes the force exerted by the stop when a joint hits its limit,
@@ -352,8 +347,18 @@ class RigidBodyPlant : public LeafSystem<T> {
 
  protected:
   // LeafSystem<T> overrides.
+
   std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;
   std::unique_ptr<DiscreteState<T>> AllocateDiscreteState() const override;
+
+  /// Allocates the data for the abstract-valued output port specified by
+  /// @p descriptor.
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<T>& descriptor) const override;
+  /// Allocates the data for the vector-valued output port specified by
+  /// @p descriptor.
+  std::unique_ptr<BasicVector<T>> AllocateOutputVector(
+      const OutputPortDescriptor<T>& descriptor) const override;
 
   // System<T> overrides.
 

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -147,7 +147,7 @@ class LeafSystem : public System<T> {
   }
 
   std::unique_ptr<SystemOutput<T>> AllocateOutput(
-      const Context<T>& context) const override {
+      const Context<T>& context) const final {
     std::unique_ptr<LeafSystemOutput<T>> output(new LeafSystemOutput<T>);
     for (int i = 0; i < this->get_num_output_ports(); ++i) {
       const OutputPortDescriptor<T>& descriptor = this->get_output_port(i);

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -105,9 +105,6 @@ class LcmSubscriberSystem : public LeafSystem<double>,
 
   const std::string& get_channel_name() const;
 
-  std::unique_ptr<SystemOutput<double>> AllocateOutput(
-      const Context<double>& context) const override;
-
   /**
    * Returns the translator used by this subscriber. This translator can be used
    * to translate a BasicVector into a serialized LCM message, which is then
@@ -120,6 +117,9 @@ class LcmSubscriberSystem : public LeafSystem<double>,
  protected:
   void DoCalcOutput(const Context<double>& context,
                     SystemOutput<double>* output) const override;
+
+  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<double>& descriptor) const override;
 
   std::unique_ptr<BasicVector<double>> AllocateOutputVector(
       const OutputPortDescriptor<double>& descriptor) const override;

--- a/drake/systems/primitives/constant_value_source-inl.h
+++ b/drake/systems/primitives/constant_value_source-inl.h
@@ -27,11 +27,9 @@ ConstantValueSource<T>::ConstantValueSource(
 }
 
 template <typename T>
-std::unique_ptr<SystemOutput<T>> ConstantValueSource<T>::AllocateOutput(
-    const Context<T>& context) const {
-  std::unique_ptr<LeafSystemOutput<T>> output(new LeafSystemOutput<T>);
-  output->add_port(source_value_->Clone());
-  return std::unique_ptr<SystemOutput<T>>(output.release());
+std::unique_ptr<AbstractValue> ConstantValueSource<T>::AllocateOutputAbstract(
+    const OutputPortDescriptor<T>& descriptor) const {
+  return source_value_->Clone();
 }
 
 template <typename T>

--- a/drake/systems/primitives/constant_value_source.h
+++ b/drake/systems/primitives/constant_value_source.h
@@ -31,8 +31,9 @@ class ConstantValueSource : public LeafSystem<T> {
   /// @p value The constant value to emit.
   explicit ConstantValueSource(std::unique_ptr<AbstractValue> value);
 
-  std::unique_ptr<SystemOutput<T>> AllocateOutput(
-      const Context<T>& context) const override;
+ protected:
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<T>& descriptor) const override;
 
   void DoCalcOutput(const Context<T>& context,
                     SystemOutput<T>* output) const override;

--- a/drake/systems/sensors/rgbd_camera.cc
+++ b/drake/systems/sensors/rgbd_camera.cc
@@ -521,21 +521,19 @@ RgbdCamera::depth_image_output_port() const {
 }
 
 
-std::unique_ptr<SystemOutput<double>> RgbdCamera::AllocateOutput(
-    const Context<double>& context) const {
-  auto output = std::make_unique<systems::LeafSystemOutput<double>>();
-
-  sensors::Image<uint8_t> color_image(kImageWidth, kImageHeight,
-                                      kColorImageChannel);
-  output->add_port(
-      std::make_unique<systems::Value<sensors::Image<uint8_t>>>(color_image));
-
-  sensors::Image<float> depth_image(kImageWidth, kImageHeight,
-                                    kDepthImageChannel);
-  output->add_port(
-      std::make_unique<systems::Value<sensors::Image<float>>>(depth_image));
-
-  return std::unique_ptr<SystemOutput<double>>(output.release());
+std::unique_ptr<AbstractValue> RgbdCamera::AllocateOutputAbstract(
+    const OutputPortDescriptor<double>& descriptor) const {
+  if (descriptor.get_index() == color_image_output_port().get_index()) {
+    sensors::Image<uint8_t> color_image(kImageWidth, kImageHeight,
+                                        kColorImageChannel);
+    return std::make_unique<systems::Value<sensors::Image<uint8_t>>>(
+        color_image);
+  } else if (descriptor.get_index() == depth_image_output_port().get_index()) {
+    Image<float> depth_image(kImageWidth, kImageHeight, kDepthImageChannel);
+    return std::make_unique<systems::Value<sensors::Image<float>>>(depth_image);
+  }
+  DRAKE_ABORT_MSG("Unknown output port.");
+  return nullptr;
 }
 
 void RgbdCamera::DoCalcOutput(const systems::Context<double>& context,

--- a/drake/systems/sensors/rgbd_camera.h
+++ b/drake/systems/sensors/rgbd_camera.h
@@ -155,13 +155,11 @@ class RgbdCamera : public LeafSystem<double> {
   /// Image<float>.
   const OutputPortDescriptor<double>& depth_image_output_port() const;
 
-  /// Allocates the output vector. See this class's description for details of
-  /// this output vector.
-  std::unique_ptr<SystemOutput<double>> AllocateOutput(
-    const Context<double>& context) const override;
-
-
  protected:
+  /// Allocates the outputs.  See class description.
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<double>& descriptor) const override;
+
   /// Updates all the model frames for the renderer and outputs the rendered
   /// images.
   void DoCalcOutput(const systems::Context<double>& context,


### PR DESCRIPTION
Remove some legacy, boilerplate AllocateOutput overrides.

@amcastro-tri and @liangfok for feature review, since the only nontrivial change diffs are in RigidBodyPlant and LcmSubscriberSystem.  They are intended to be no-ops.

Fixes #5344.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5348)
<!-- Reviewable:end -->
