### PR TITLE
Make IdmPlanner a function rather than a System

### DIFF
--- a/drake/automotive/gen/idm_planner_parameters.cc
+++ b/drake/automotive/gen/idm_planner_parameters.cc
@@ -13,7 +13,6 @@ const int IdmPlannerParametersIndices::kB;
 const int IdmPlannerParametersIndices::kS0;
 const int IdmPlannerParametersIndices::kTimeHeadway;
 const int IdmPlannerParametersIndices::kDelta;
-const int IdmPlannerParametersIndices::kLA;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/idm_planner_parameters.h
+++ b/drake/automotive/gen/idm_planner_parameters.h
@@ -16,7 +16,7 @@ namespace automotive {
 /// Describes the row indices of a IdmPlannerParameters.
 struct IdmPlannerParametersIndices {
   /// The total number of rows (coordinates).
-  static const int kNumCoordinates = 7;
+  static const int kNumCoordinates = 6;
 
   // The index of each individual coordinate.
   static const int kVRef = 0;
@@ -25,7 +25,6 @@ struct IdmPlannerParametersIndices {
   static const int kS0 = 3;
   static const int kTimeHeadway = 4;
   static const int kDelta = 5;
-  static const int kLA = 6;
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -68,9 +67,6 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
   /// free-road exponent
   const T& delta() const { return this->GetAtIndex(K::kDelta); }
   void set_delta(const T& delta) { this->SetAtIndex(K::kDelta, delta); }
-  /// length of leading car
-  const T& l_a() const { return this->GetAtIndex(K::kLA); }
-  void set_l_a(const T& l_a) { this->SetAtIndex(K::kLA, l_a); }
   //@}
 };
 

--- a/drake/automotive/idm_planner.cc
+++ b/drake/automotive/idm_planner.cc
@@ -1,65 +1,23 @@
 #include "drake/automotive/idm_planner.h"
 
-#include <algorithm>
 #include <cmath>
-#include <utility>
 
-#include <Eigen/Geometry>
-
-#include "drake/automotive/gen/idm_planner_parameters.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/autodiff_overloads.h"
+#include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_formula.h"
 
 namespace drake {
 namespace automotive {
 
 template <typename T>
-IdmPlanner<T>::IdmPlanner(const T& v_ref) : v_ref_(v_ref) {
-  // TODO(jadecastro): Remove v_ref from the constructor.
-  // The reference velocity must be strictly positive.
-  DRAKE_ASSERT(v_ref > 0);
-
-  const int kEgoCarOutputVectorSize = 2;
-  const int kAgentCarOutputVectorSize = 2;
-  const int kLinearAccelerationSize = 1;
-  // Declare the ego car input port.
-  this->DeclareInputPort(systems::kVectorValued, kEgoCarOutputVectorSize);
-  // Declare the agent car input port.
-  this->DeclareInputPort(systems::kVectorValued, kAgentCarOutputVectorSize);
-  // Declare the output port.
-  this->DeclareOutputPort(systems::kVectorValued, kLinearAccelerationSize);
-}
-
-template <typename T>
-IdmPlanner<T>::~IdmPlanner() {}
-
-template <typename T>
-const systems::InputPortDescriptor<T>& IdmPlanner<T>::get_ego_port() const {
-  return systems::System<T>::get_input_port(0);
-}
-
-template <typename T>
-const systems::InputPortDescriptor<T>& IdmPlanner<T>::get_agent_port() const {
-  return systems::System<T>::get_input_port(1);
-}
-
-template <typename T>
-void IdmPlanner<T>::DoCalcOutput(const systems::Context<T>& context,
-                                 systems::SystemOutput<T>* output) const {
-  // Obtain the input/output structures we need to read from and write into.
-  const systems::BasicVector<T>* input_ego =
-      this->EvalVectorInput(context, this->get_ego_port().get_index());
-  const systems::BasicVector<T>* input_agent =
-      this->EvalVectorInput(context, this->get_agent_port().get_index());
-  systems::BasicVector<T>* const output_vector =
-      output->GetMutableVectorData(0);
-  DRAKE_ASSERT(output_vector != nullptr);
-
-  // Obtain the parameters.
-  const int kParamsIndex = 0;
-  const IdmPlannerParameters<T>& params =
-      this->template GetNumericParameter<IdmPlannerParameters>(context,
-                                                               kParamsIndex);
+T IdmPlanner<T>::Evaluate(
+    const IdmPlannerParameters<T>& params,
+    const T& ego_velocity,
+    const T& target_distance,
+    const T& target_distance_dot) {
+  using std::pow;
+  using std::sqrt;
 
   const T& v_ref = params.v_ref();
   const T& a = params.a();
@@ -67,48 +25,28 @@ void IdmPlanner<T>::DoCalcOutput(const systems::Context<T>& context,
   const T& s_0 = params.s_0();
   const T& time_headway = params.time_headway();
   const T& delta = params.delta();
-  const T& l_a = params.l_a();
-
-  const T& x_ego = input_ego->GetAtIndex(0);
-  const T& v_ego = input_ego->GetAtIndex(1);
-  const T& x_agent = input_agent->GetAtIndex(0);
-  const T& v_agent = input_agent->GetAtIndex(1);
-
-  // Ensure that we are supplying the planner with sane parameters and
-  // input values.
   DRAKE_DEMAND(a > 0.0);
   DRAKE_DEMAND(b > 0.0);
-  DRAKE_DEMAND(x_agent > (l_a + x_ego));
+  DRAKE_DEMAND(target_distance > 0.0);
+  const T& v_ego = ego_velocity;
 
-  output_vector->SetAtIndex(
-      0, a * (1.0 - pow(v_ego / v_ref, delta) -
+  return a * (1.0 - pow(v_ego / v_ref, delta) -
               pow((s_0 + v_ego * time_headway +
-                   v_ego * (v_ego - v_agent) / (2 * sqrt(a * b))) /
-                      (x_agent - x_ego - l_a),
-                  2.0)));
+                   v_ego * target_distance_dot / (2 * sqrt(a * b))) /
+                      target_distance,
+                  2.0));
 }
 
 template <typename T>
-std::unique_ptr<systems::Parameters<T>> IdmPlanner<T>::AllocateParameters()
-    const {
-  auto params = std::make_unique<IdmPlannerParameters<T>>();
-  return std::make_unique<systems::Parameters<T>>(std::move(params));
-}
-
-template <typename T>
-void IdmPlanner<T>::SetDefaultParameters(const systems::LeafContext<T>& context,
-                                         systems::Parameters<T>* params) const {
+void IdmPlanner<T>::SetDefaultParameters(IdmPlannerParameters<T>* idm_params) {
   // Default values from https://en.wikipedia.org/wiki/Intelligent_driver_model.
-  auto idm_params = dynamic_cast<IdmPlannerParameters<T>*>(
-      params->get_mutable_numeric_parameter(0));
   DRAKE_DEMAND(idm_params != nullptr);
-  idm_params->set_v_ref(v_ref_);         // desired velocity in free traffic.
+  idm_params->set_v_ref(1.0);            // desired velocity in free traffic.
   idm_params->set_a(T(1.0));             // max acceleration.
   idm_params->set_b(T(3.0));             // comfortable braking deceleration.
   idm_params->set_s_0(T(1.0));           // minimum desired net distance.
   idm_params->set_time_headway(T(0.1));  // desired headway to lead vehicle.
   idm_params->set_delta(T(4.0));  // recommended choice of free-road exponent.
-  idm_params->set_l_a(T(4.5));    // length of leading car.
 }
 
 // These instantiations must match the API documentation in

--- a/drake/automotive/idm_planner.cc
+++ b/drake/automotive/idm_planner.cc
@@ -2,20 +2,17 @@
 
 #include <cmath>
 
-#include "drake/common/drake_assert.h"
 #include "drake/common/autodiff_overloads.h"
-#include "drake/common/symbolic_expression.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/symbolic_formula.h"
 
 namespace drake {
 namespace automotive {
 
 template <typename T>
-T IdmPlanner<T>::Evaluate(
-    const IdmPlannerParameters<T>& params,
-    const T& ego_velocity,
-    const T& target_distance,
-    const T& target_distance_dot) {
+const T IdmPlanner<T>::Evaluate(const IdmPlannerParameters<T>& params,
+                                const T& ego_velocity, const T& target_distance,
+                                const T& target_distance_dot) {
   using std::pow;
   using std::sqrt;
 
@@ -25,35 +22,42 @@ T IdmPlanner<T>::Evaluate(
   const T& s_0 = params.s_0();
   const T& time_headway = params.time_headway();
   const T& delta = params.delta();
-  DRAKE_DEMAND(a > 0.0);
-  DRAKE_DEMAND(b > 0.0);
-  DRAKE_DEMAND(target_distance > 0.0);
+
+  DRAKE_DEMAND(a > 0.);
+  DRAKE_DEMAND(b > 0.);
+  DRAKE_DEMAND(target_distance > 0.);
+
   const T& v_ego = ego_velocity;
 
-  return a * (1.0 - pow(v_ego / v_ref, delta) -
-              pow((s_0 + v_ego * time_headway +
-                   v_ego * target_distance_dot / (2 * sqrt(a * b))) /
-                      target_distance,
-                  2.0));
+  // Compute the interaction acceleration terms.
+  const T& closing_term = v_ego * target_distance_dot / (2 * sqrt(a * b));
+  const T& small_distance_term = s_0 + v_ego * time_headway;
+
+  const T& accel_interaction =
+      pow((closing_term + small_distance_term) / target_distance, 2.);
+  // Compute the free-road accleration term.
+  const T& accel_free_road = pow(v_ego / v_ref, delta);
+
+  // Compute the IDM acceleration.
+  return a * (1. - accel_free_road - accel_interaction);
 }
 
 template <typename T>
 void IdmPlanner<T>::SetDefaultParameters(IdmPlannerParameters<T>* idm_params) {
   // Default values from https://en.wikipedia.org/wiki/Intelligent_driver_model.
   DRAKE_DEMAND(idm_params != nullptr);
-  idm_params->set_v_ref(1.0);            // desired velocity in free traffic.
-  idm_params->set_a(T(1.0));             // max acceleration.
-  idm_params->set_b(T(3.0));             // comfortable braking deceleration.
-  idm_params->set_s_0(T(1.0));           // minimum desired net distance.
+  idm_params->set_v_ref(10.);            // desired velocity in free traffic.
+  idm_params->set_a(T(1.));              // max acceleration.
+  idm_params->set_b(T(3.));              // comfortable braking deceleration.
+  idm_params->set_s_0(T(1.));            // minimum desired net distance.
   idm_params->set_time_headway(T(0.1));  // desired headway to lead vehicle.
-  idm_params->set_delta(T(4.0));  // recommended choice of free-road exponent.
+  idm_params->set_delta(T(4.));  // recommended choice of free-road exponent.
 }
 
-// These instantiations must match the API documentation in
-// idm_planner.h.
+// These instantiations must match the API documentation in idm_planner.h.
 template class IdmPlanner<double>;
-template class IdmPlanner<drake::TaylorVarXd>;
-template class IdmPlanner<drake::symbolic::Expression>;
+// template class IdmPlanner<drake::TaylorVarXd>;
+// template class IdmPlanner<drake::symbolic::Expression>;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/idm_planner.cc
+++ b/drake/automotive/idm_planner.cc
@@ -27,16 +27,15 @@ const T IdmPlanner<T>::Evaluate(const IdmPlannerParameters<T>& params,
   DRAKE_DEMAND(b > 0.);
   DRAKE_DEMAND(target_distance > 0.);
 
-  const T& v_ego = ego_velocity;
-
   // Compute the interaction acceleration terms.
-  const T& closing_term = v_ego * target_distance_dot / (2 * sqrt(a * b));
-  const T& small_distance_term = s_0 + v_ego * time_headway;
-
+  const T& closing_term =
+      ego_velocity * target_distance_dot / (2 * sqrt(a * b));
+  const T& too_close_term = s_0 + ego_velocity * time_headway;
   const T& accel_interaction =
-      pow((closing_term + small_distance_term) / target_distance, 2.);
+      pow((closing_term + too_close_term) / target_distance, 2.);
+
   // Compute the free-road accleration term.
-  const T& accel_free_road = pow(v_ego / v_ref, delta);
+  const T& accel_free_road = pow(ego_velocity / v_ref, delta);
 
   // Compute the IDM acceleration.
   return a * (1. - accel_free_road - accel_interaction);
@@ -56,8 +55,8 @@ void IdmPlanner<T>::SetDefaultParameters(IdmPlannerParameters<T>* idm_params) {
 
 // These instantiations must match the API documentation in idm_planner.h.
 template class IdmPlanner<double>;
-// template class IdmPlanner<drake::TaylorVarXd>;
-// template class IdmPlanner<drake::symbolic::Expression>;
+template class IdmPlanner<drake::TaylorVarXd>;
+template class IdmPlanner<drake::symbolic::Expression>;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/idm_planner.cc
+++ b/drake/automotive/idm_planner.cc
@@ -34,7 +34,7 @@ const T IdmPlanner<T>::Evaluate(const IdmPlannerParameters<T>& params,
   const T& accel_interaction =
       pow((closing_term + too_close_term) / target_distance, 2.);
 
-  // Compute the free-road accleration term.
+  // Compute the free-road acceleration term.
   const T& accel_free_road = pow(ego_velocity / v_ref, delta);
 
   // Compute the resultant acceleration (IDM equation).
@@ -45,12 +45,12 @@ template <typename T>
 void IdmPlanner<T>::SetDefaultParameters(IdmPlannerParameters<T>* idm_params) {
   // Default values from https://en.wikipedia.org/wiki/Intelligent_driver_model.
   DRAKE_DEMAND(idm_params != nullptr);
-  idm_params->set_v_ref(10.);            // desired velocity in free traffic.
-  idm_params->set_a(T(1.));              // max acceleration.
-  idm_params->set_b(T(3.));              // comfortable braking deceleration.
-  idm_params->set_s_0(T(1.));            // minimum desired net distance.
-  idm_params->set_time_headway(T(0.1));  // desired headway to lead vehicle.
-  idm_params->set_delta(T(4.));  // recommended choice of free-road exponent.
+  idm_params->set_v_ref(10.);  // desired velocity in free traffic [m/s].
+  idm_params->set_a(T(1.));    // max acceleration [m/s^2].
+  idm_params->set_b(T(3.));    // comfortable braking deceleration [m/s^2].
+  idm_params->set_s_0(T(1.));  // minimum desired net distance [m].
+  idm_params->set_time_headway(T(0.1));  // desired headway to lead vehicle [s].
+  idm_params->set_delta(T(4.));  // recommended choice of acceleration exponent.
 }
 
 // These instantiations must match the API documentation in idm_planner.h.

--- a/drake/automotive/idm_planner.cc
+++ b/drake/automotive/idm_planner.cc
@@ -37,7 +37,7 @@ const T IdmPlanner<T>::Evaluate(const IdmPlannerParameters<T>& params,
   // Compute the free-road accleration term.
   const T& accel_free_road = pow(ego_velocity / v_ref, delta);
 
-  // Compute the IDM acceleration.
+  // Compute the resultant acceleration (IDM equation).
   return a * (1. - accel_free_road - accel_interaction);
 }
 

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -1,15 +1,28 @@
 #pragma once
 
-#include "drake/common/drake_copyable.h"
 #include "drake/automotive/gen/idm_planner_parameters.h"
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace automotive {
 
-/// IdmPlanner -- an IDM (Intelligent Driver Model) planner.
+/// IdmPlanner -- an IDM (Intelligent Driver Model) planner.  The IDM is a
+/// simple model governing longitudinal accelerations of a vehicle in
+/// single-lane traffic [1, 2].  It is derived based on qualitative obvervations
+/// of actual driving behavior such as keeping a safe distance away from a lead
+/// vehicle, maintaining a desired speed, and accelerating and decelerating
+/// within comfortable limits.
 ///
-/// IDM: Intelligent Driver Model:
-///    https://en.wikipedia.org/wiki/Intelligent_driver_model
+/// The model captures three basic driving modes:
+///  - Free-road behavior: when the target distance to the leading car is large,
+///    the IDM regulates acceleration to match the desired speed @p v_0.
+///  - Behavior at fast closing speeds: when the target distance decreases, an
+///    interaction term compensates for the velocity difference, while keeping
+///    deceleration comfortable according to parameter @p b.
+///  - Behavior at small target distances: within small distances, comfort is
+///    ignored in favor of increasing the target distance to @p s_0.
+///
+/// IDM creates a smooth transitioning between these modes.
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
@@ -18,6 +31,10 @@ namespace automotive {
 ///
 /// They are already available to link against in the containing library.
 ///
+/// [1] Martin Treiber and Arne Kesting. Traffic Flow Dynamics, Data, Models,
+///     and Simulation. Springer, 2013.
+/// [2] https://en.wikipedia.org/wiki/Intelligent_driver_model.
+///
 /// @ingroup automotive_systems
 template <typename T>
 class IdmPlanner {
@@ -25,16 +42,16 @@ class IdmPlanner {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IdmPlanner)
   IdmPlanner() = delete;
 
-  static T Evaluate(
-      const IdmPlannerParameters<T>& params,
-      const T& ego_velocity,
-      const T& target_distance,
-      const T& target_distance_dot);
+  /// Evaluates the IDM equation for the chosen planner parameters @param
+  /// params, given the current velocity @param ego_velocity, distance to the
+  /// lead car @param target_distance, and the closing velocity @param
+  /// target_distance_dot.
+  static const T Evaluate(const IdmPlannerParameters<T>& params,
+                          const T& ego_velocity, const T& target_distance,
+                          const T& target_distance_dot);
 
-  /// Sets defaults for all parameters.  Most callers will want to replace
-  /// v_ref with a new value, because the default is 1.0 m/s.
+  /// Sets defaults for all parameters.
   static void SetDefaultParameters(IdmPlannerParameters<T>* params);
-
 };
 
 }  // namespace automotive

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <memory>
-
 #include "drake/common/drake_copyable.h"
-#include "drake/systems/framework/leaf_system.h"
+#include "drake/automotive/gen/idm_planner_parameters.h"
 
 namespace drake {
 namespace automotive {
@@ -21,47 +19,22 @@ namespace automotive {
 /// They are already available to link against in the containing library.
 ///
 /// @ingroup automotive_systems
-///
-/// Inputs:
-///   0: @p x_ego ego car position (scalar) [m]
-///   1: @p v_ego ego car velocity (scalar) [m/s]
-///   2: @p x_agent agent car position (scalar) [m]
-///   3: @p v_agent agent car velocity (scalar) [m/s]
-/// Outputs:
-///   0: @p vdot_ego linear acceleration of the ego car (scalar) [m/s^2].
 template <typename T>
-class IdmPlanner : public systems::LeafSystem<T> {
+class IdmPlanner {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IdmPlanner)
+  IdmPlanner() = delete;
 
-  /// @p v_ref desired velocity of the ego car in units of m/s.
-  explicit IdmPlanner(const T& v_ref);
-  ~IdmPlanner() override;
+  static T Evaluate(
+      const IdmPlannerParameters<T>& params,
+      const T& ego_velocity,
+      const T& target_distance,
+      const T& target_distance_dot);
 
-  /// Returns the port to the ego car input subvector.
-  const systems::InputPortDescriptor<T>& get_ego_port() const;
+  /// Sets defaults for all parameters.  Most callers will want to replace
+  /// v_ref with a new value, because the default is 1.0 m/s.
+  static void SetDefaultParameters(IdmPlannerParameters<T>* params);
 
-  /// Returns the port to the agent car input subvector.
-  const systems::InputPortDescriptor<T>& get_agent_port() const;
-
-  // System<T> overrides.
-  std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
-
-  void SetDefaultParameters(const systems::LeafContext<T>& context,
-                            systems::Parameters<T>* params) const override;
-
- protected:
-  // The output of this system is an algebraic relation of its inputs.
-  bool DoHasDirectFeedthrough(const systems::SparsityMatrix* sparsity,
-                              int input_port, int output_port) const override {
-    return true;
-  }
-
- private:
-  void DoCalcOutput(const systems::Context<T>& context,
-                    systems::SystemOutput<T>* output) const override;
-
-  const T v_ref_;  // Desired vehicle velocity.
 };
 
 }  // namespace automotive

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -8,21 +8,20 @@ namespace automotive {
 
 /// IdmPlanner -- an IDM (Intelligent Driver Model) planner.  The IDM is a
 /// simple model governing longitudinal accelerations of a vehicle in
-/// single-lane traffic [1, 2].  It is derived based on qualitative obvervations
-/// of actual driving behavior such as keeping a safe distance away from a lead
-/// vehicle, maintaining a desired speed, and accelerating and decelerating
-/// within comfortable limits.
+/// single-lane traffic [1, 2].  It is derived based on qualitative observations
+/// of actual driving behavior and captures objectives such as keeping a safe
+/// distance away from a lead vehicle, maintaining a desired speed, and
+/// accelerating and decelerating within comfortable limits.
 ///
-/// The model captures three basic driving modes:
-///  - Free-road behavior: when the target distance to the leading car is large,
-///    the IDM regulates acceleration to match the desired speed @p v_0.
-///  - Behavior at fast closing speeds: when the target distance decreases, an
+/// The IDM equation produces accelerations that realize smooth transitions
+/// between the following three modes:
+///  - Free-road behavior: when the distance to the leading car is large, the
+///    IDM regulates acceleration to match the desired speed `v_0`.
+///  - Fast-closing-speed behavior: when the target distance decreases, an
 ///    interaction term compensates for the velocity difference, while keeping
-///    deceleration comfortable according to parameter @p b.
-///  - Behavior at small target distances: within small distances, comfort is
-///    ignored in favor of increasing the target distance to @p s_0.
-///
-/// IDM creates a smooth transitioning between these modes.
+///    deceleration comfortable according to parameter `b`.
+///  - Small-distance behavior: within small net distances to the lead vehicle,
+///    comfort is ignored in favor of increasing this distance to `s_0`.
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
@@ -33,6 +32,7 @@ namespace automotive {
 ///
 /// [1] Martin Treiber and Arne Kesting. Traffic Flow Dynamics, Data, Models,
 ///     and Simulation. Springer, 2013.
+///
 /// [2] https://en.wikipedia.org/wiki/Intelligent_driver_model.
 ///
 /// @ingroup automotive_systems
@@ -42,10 +42,9 @@ class IdmPlanner {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IdmPlanner)
   IdmPlanner() = delete;
 
-  /// Evaluates the IDM equation for the chosen planner parameters @param
-  /// params, given the current velocity @param ego_velocity, distance to the
-  /// lead car @param target_distance, and the closing velocity @param
-  /// target_distance_dot.
+  /// Evaluates the IDM equation for the chosen planner parameters @p params,
+  /// given the current velocity @p ego_velocity, distance to the lead car @p
+  /// target_distance, and the closing velocity @p target_distance_dot.
   static const T Evaluate(const IdmPlannerParameters<T>& params,
                           const T& ego_velocity, const T& target_distance,
                           const T& target_distance_dot);

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -10,7 +10,7 @@ namespace automotive {
 /// simple model governing longitudinal accelerations of a vehicle in
 /// single-lane traffic [1, 2].  It is derived based on qualitative observations
 /// of actual driving behavior and captures objectives such as keeping a safe
-/// distance away from a lead vehicle, maintaining a desired speed, and
+/// distance behind a lead vehicle, maintaining a desired speed, and
 /// accelerating and decelerating within comfortable limits.
 ///
 /// The IDM equation produces accelerations that realize smooth transitions
@@ -22,6 +22,8 @@ namespace automotive {
 ///    deceleration comfortable according to parameter `b`.
 ///  - Small-distance behavior: within small net distances to the lead vehicle,
 ///    comfort is ignored in favor of increasing this distance to `s_0`.
+///
+/// See the corresponding .cc file for details about the IDM equation.
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
@@ -44,7 +46,8 @@ class IdmPlanner {
 
   /// Evaluates the IDM equation for the chosen planner parameters @p params,
   /// given the current velocity @p ego_velocity, distance to the lead car @p
-  /// target_distance, and the closing velocity @p target_distance_dot.
+  /// target_distance, and the closing velocity @p target_distance_dot.  The
+  /// returned value is a longitudinal acceleration.
   static const T Evaluate(const IdmPlannerParameters<T>& params,
                           const T& ego_velocity, const T& target_distance,
                           const T& target_distance_dot);

--- a/drake/automotive/idm_planner_parameters.named_vector
+++ b/drake/automotive/idm_planner_parameters.named_vector
@@ -22,7 +22,3 @@ element {
      name: "delta"
      doc: "free-road exponent"
 }
-element {
-     name: "l_a"
-     doc: "length of leading car"
-}

--- a/drake/automotive/single_lane_ego_and_agent.cc
+++ b/drake/automotive/single_lane_ego_and_agent.cc
@@ -39,7 +39,7 @@ void Idm<T>::DoCalcOutput(const systems::Context<T>& context,
                           systems::SystemOutput<T>* output) const {
   const T l_car = 4.5;  // Length of the lead car [m].
 
-  // Obtain the input/output structures we need to read from and write into.
+  // Obtain the input/output data structures.
   const systems::BasicVector<T>* input_ego =
       this->EvalVectorInput(context, this->get_ego_port().get_index());
   const systems::BasicVector<T>* input_agent =

--- a/drake/automotive/single_lane_ego_and_agent.cc
+++ b/drake/automotive/single_lane_ego_and_agent.cc
@@ -1,10 +1,83 @@
 #include "drake/automotive/single_lane_ego_and_agent.h"
 
+#include <utility>
+
 #include "drake/common/symbolic_formula.h"
 #include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
 namespace automotive {
+
+template <typename T>
+Idm<T>::Idm() {
+  const int kEgoCarOutputVectorSize = 2;
+  const int kAgentCarOutputVectorSize = 2;
+  const int kLinearAccelerationSize = 1;
+  // Declare the ego car input port.
+  this->DeclareInputPort(systems::kVectorValued, kEgoCarOutputVectorSize);
+  // Declare the agent car input port.
+  this->DeclareInputPort(systems::kVectorValued, kAgentCarOutputVectorSize);
+  // Declare the output port.
+  this->DeclareOutputPort(systems::kVectorValued, kLinearAccelerationSize);
+}
+
+template <typename T>
+Idm<T>::~Idm() {}
+
+template <typename T>
+const systems::InputPortDescriptor<T>& Idm<T>::get_ego_port() const {
+  return systems::System<T>::get_input_port(0);
+}
+
+template <typename T>
+const systems::InputPortDescriptor<T>& Idm<T>::get_agent_port() const {
+  return systems::System<T>::get_input_port(1);
+}
+
+template <typename T>
+void Idm<T>::DoCalcOutput(const systems::Context<T>& context,
+                          systems::SystemOutput<T>* output) const {
+  const T l_car = 4.5;  // Length of the lead car [m].
+
+  // Obtain the input/output structures we need to read from and write into.
+  const systems::BasicVector<T>* input_ego =
+      this->EvalVectorInput(context, this->get_ego_port().get_index());
+  const systems::BasicVector<T>* input_agent =
+      this->EvalVectorInput(context, this->get_agent_port().get_index());
+  systems::BasicVector<T>* const output_vector =
+      output->GetMutableVectorData(0);
+  DRAKE_ASSERT(output_vector != nullptr);
+
+  // Parse the inputs.
+  const T& x_ego = input_ego->GetAtIndex(0);
+  const T& v_ego = input_ego->GetAtIndex(1);
+  const T& x_agent = input_agent->GetAtIndex(0);
+  const T& v_agent = input_agent->GetAtIndex(1);
+
+  // Obtain the parameters.
+  const int kParamsIndex = 0;
+  const IdmPlannerParameters<T>& params =
+      this->template GetNumericParameter<IdmPlannerParameters>(context,
+                                                               kParamsIndex);
+  // Evaluate the IDM equation.
+  output_vector->SetAtIndex(
+      0, IdmPlanner<T>::Evaluate(params, v_ego, x_agent - x_ego - l_car,
+                                 v_agent - v_ego));
+}
+
+template <typename T>
+std::unique_ptr<systems::Parameters<T>> Idm<T>::AllocateParameters() const {
+  auto params = std::make_unique<IdmPlannerParameters<T>>();
+  return std::make_unique<systems::Parameters<T>>(std::move(params));
+}
+
+template <typename T>
+void Idm<T>::SetDefaultParameters(const systems::LeafContext<T>& context,
+                                  systems::Parameters<T>* params) const {
+  auto idm_params = dynamic_cast<IdmPlannerParameters<T>*>(
+      params->get_mutable_numeric_parameter(0));
+  IdmPlanner<T>::SetDefaultParameters(idm_params);
+}
 
 template <typename T>
 SingleLaneEgoAndAgent<T>::SingleLaneEgoAndAgent(
@@ -26,8 +99,7 @@ SingleLaneEgoAndAgent<T>::SingleLaneEgoAndAgent(
   const systems::ConstantVectorSource<T>* value =
       builder.AddSystem(std::make_unique<systems::ConstantVectorSource<T>>(
           a_agent /* acceleration of the agent */));
-  planner_ = builder.AddSystem(std::make_unique<IdmPlanner<T>>(
-      v_ref /* desired velocity of the ego car */));
+  planner_ = builder.AddSystem(std::make_unique<Idm<T>>());
 
   builder.Connect(*planner_, *ego_car_);
   builder.Connect(*value, *agent_car_);

--- a/drake/automotive/single_lane_ego_and_agent.h
+++ b/drake/automotive/single_lane_ego_and_agent.h
@@ -12,6 +12,29 @@
 namespace drake {
 namespace automotive {
 
+/// A system enclosing the IdmPlanner as an output equation.
+template <typename T>
+class Idm : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Idm)
+
+  Idm();
+  ~Idm() override;
+
+  /// Getters for the ego and agent car ports.
+  const systems::InputPortDescriptor<T>& get_ego_port() const;
+  const systems::InputPortDescriptor<T>& get_agent_port() const;
+
+  /// System<T> overrides.
+  void DoCalcOutput(const systems::Context<T>& context,
+                    systems::SystemOutput<T>* output) const override;
+
+  std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
+
+  void SetDefaultParameters(const systems::LeafContext<T>& context,
+                            systems::Parameters<T>* params) const override;
+};
+
 /// System consisting of two cars: an ego and an agent, where the ego
 /// is governed by an IDM (intelligent driver model) planner, and
 /// where the agent is fed a constant acceleration input.
@@ -60,12 +83,12 @@ class SingleLaneEgoAndAgent : public systems::Diagram<T> {
   /// Getters for the ego and agent car systems.
   const LinearCar<T>* get_ego_car_system() const { return ego_car_; }
   const LinearCar<T>* get_agent_car_system() const { return agent_car_; }
-  const IdmPlanner<T>* get_planner_system() const { return planner_; }
+  const Idm<T>* get_planner_system() const { return planner_; }
 
  private:
   const LinearCar<T>* ego_car_ = nullptr;
   const LinearCar<T>* agent_car_ = nullptr;
-  const IdmPlanner<T>* planner_ = nullptr;
+  const Idm<T>* planner_ = nullptr;
 };
 
 }  // namespace automotive

--- a/drake/automotive/single_lane_ego_and_agent.h
+++ b/drake/automotive/single_lane_ego_and_agent.h
@@ -12,7 +12,20 @@
 namespace drake {
 namespace automotive {
 
-/// A system enclosing the IdmPlanner as an output equation.
+/// Idm -- A System that takes in the positions and velocities of an ego car and
+/// agent car, and produces an output with the computed IDM acceleration (see
+/// IdmPlanner).
+///
+/// Inputs:
+///   0: A BasicVector consisting of
+///       - @p x_ego ego car position (scalar) [m]
+///       - @p v_ego ego car velocity (scalar) [m/s]
+///      (InputPortDescriptor getter: get_ego_port())
+///   1: A BasicVector consisting of
+///       - @p x_agent agent car position (scalar) [m]
+///       - @p v_agent agent car velocity (scalar) [m/s]
+/// Output:
+///   0: @p vdot_ego linear acceleration of the ego car (scalar) [m/s^2].
 template <typename T>
 class Idm : public systems::LeafSystem<T> {
  public:
@@ -35,9 +48,9 @@ class Idm : public systems::LeafSystem<T> {
                             systems::Parameters<T>* params) const override;
 };
 
-/// System consisting of two cars: an ego and an agent, where the ego
-/// is governed by an IDM (intelligent driver model) planner, and
-/// where the agent is fed a constant acceleration input.
+/// SingleLaneEgoAndAgent -- A System consisting of two cars: an ego and an
+/// agent, where the ego is governed by an IDM (intelligent driver model)
+/// planner, and where the agent is fed a constant acceleration input.
 ///
 ///   +--------------+         +-------------+
 ///   | Acceleration | v_dot_a |  Agent Car  |  x_a, v_a
@@ -47,13 +60,13 @@ class Idm : public systems::LeafSystem<T> {
 ///                                               |
 ///       +---------------------------------------+
 ///       | port
-///       |  1   +--------------+         +-------------+
-///       +----->|   Planner    | v_dot_e |   Ego Car   |  x_e, v_e
-///              |              |-------->|             |----+
-///       +----->| (IdmPlanner) |         | (LinearCar) |    |
-///       | port +--------------+         +-------------+    |
-///       |  0                                               |
-///       +--------------------------------------------------+
+///       |  1   +-------------+         +-------------+
+///       +----->|   Planner   | v_dot_e |   Ego Car   |  x_e, v_e
+///              |             |-------->|             |----+
+///       +----->|    (Idm)    |         | (LinearCar) |    |
+///       | port +-------------+         +-------------+    |
+///       |  0                                              |
+///       +-------------------------------------------------+
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///

--- a/drake/automotive/single_lane_ego_and_agent.h
+++ b/drake/automotive/single_lane_ego_and_agent.h
@@ -25,7 +25,8 @@ namespace automotive {
 ///       - @p x_agent agent car position (scalar) [m]
 ///       - @p v_agent agent car velocity (scalar) [m/s]
 /// Output:
-///   0: @p vdot_ego linear acceleration of the ego car (scalar) [m/s^2].
+///   0: @p vdot_ego longitudinal acceleration request to the ego car (scalar)
+///      [m/s^2].
 template <typename T>
 class Idm : public systems::LeafSystem<T> {
  public:
@@ -52,6 +53,7 @@ class Idm : public systems::LeafSystem<T> {
 /// agent, where the ego is governed by an IDM (intelligent driver model)
 /// planner, and where the agent is fed a constant acceleration input.
 ///
+/// <pre>
 ///   +--------------+         +-------------+
 ///   | Acceleration | v_dot_a |  Agent Car  |  x_a, v_a
 ///   |    Input     |-------->|             |----+
@@ -67,6 +69,7 @@ class Idm : public systems::LeafSystem<T> {
 ///       | port +-------------+         +-------------+    |
 ///       |  0                                              |
 ///       +-------------------------------------------------+
+/// </pre>
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///

--- a/drake/automotive/test/idm_planner_test.cc
+++ b/drake/automotive/test/idm_planner_test.cc
@@ -22,7 +22,7 @@ class IdmPlannerTest : public ::testing::Test {
 };
 
 // Set the initial states such that the agent and ego start at the
-// headway distance, with the ego closing in on the lead car.
+// headway distance, with the ego car closing in on the lead car.
 TEST_F(IdmPlannerTest, SameSpeedAtHeadwayDistance) {
   const double ego_velocity = params_->v_ref();
   const double target_distance = params_->v_ref() * params_->time_headway();
@@ -32,7 +32,7 @@ TEST_F(IdmPlannerTest, SameSpeedAtHeadwayDistance) {
   const double result = IdmPlanner<double>::Evaluate(
       *params_, ego_velocity, target_distance, target_distance_dot);
 
-  // We expect zero acceleration.
+  // We expect acceleration to be close to zero.
   EXPECT_NEAR(0., result, 1e-2);
 }
 
@@ -74,12 +74,12 @@ TEST_F(IdmPlannerTest, EgoAtDesiredSpeed) {
   const double result = IdmPlanner<double>::Evaluate(
       *params_, ego_velocity, target_distance, target_distance_dot);
 
-  // We expect acceleration to be close-to-zero.
+  // We expect acceleration to be close to zero.
   EXPECT_NEAR(0., result, 1e-2);
 }
 
 // Set the agent and ego sufficiently far apart from one another, with
-// the ego car speed initially zero.  set-point.
+// the ego car speed initially zero.
 TEST_F(IdmPlannerTest, EgoStartFromRest) {
   const double ego_velocity = 0.;
   const double target_distance = 1e6;

--- a/drake/automotive/test/single_lane_ego_and_agent_test.cc
+++ b/drake/automotive/test/single_lane_ego_and_agent_test.cc
@@ -153,7 +153,7 @@ TEST_F(SingleLaneEgoAndAgentTest, EvalTimeDerivatives) {
   // Expected state derivatives. Velocity v maps should map to x_dot.
   // The car should rapidly decelerate, as evidenced by a negative v_dot.
   EXPECT_EQ(25.0, derivatives_ego->GetAtIndex(0));
-  EXPECT_NEAR(-411.914474, derivatives_ego->GetAtIndex(1), 1e-6);
+  EXPECT_NEAR(-400.8138313, derivatives_ego->GetAtIndex(1), 1e-6);
   EXPECT_EQ(10.0, derivatives_agent->GetAtIndex(0));
   EXPECT_EQ(2.7, derivatives_agent->GetAtIndex(1));
 }


### PR DESCRIPTION
This allows the IDM equation to be accessible to consumers that require it.

SingleLaneEgoAndAgent has been refactored to subsume the IDM system, however, this is temporary as the intent is to eventually deprecate SingleLaneEgoAndAgent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5349)
<!-- Reviewable:end -->
