### PR TITLE
Fixed bug in dragway's ToRoadPosition().

### DIFF
--- a/drake/automotive/maliput/dragway/road_geometry.cc
+++ b/drake/automotive/maliput/dragway/road_geometry.cc
@@ -131,7 +131,7 @@ api::RoadPosition RoadGeometry::DoToRoadPosition(
       nearest_position->z = geo_pos.z;
     }
     if (distance != nullptr) {
-      *distance = geo_pos.z;
+      *distance = 0;
     }
     return api::RoadPosition(lane, result_lane_position);
   } else {

--- a/drake/automotive/maliput/dragway/test/dragway_test.cc
+++ b/drake/automotive/maliput/dragway/test/dragway_test.cc
@@ -311,7 +311,7 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
         EXPECT_DOUBLE_EQ(nearest_position.x, x);
         EXPECT_DOUBLE_EQ(nearest_position.y, y);
         EXPECT_DOUBLE_EQ(nearest_position.z, z);
-        EXPECT_DOUBLE_EQ(distance, z);
+        EXPECT_DOUBLE_EQ(distance, 0);
         EXPECT_EQ(road_position.lane, expected_lane);
         EXPECT_EQ(road_position.pos.s, x);
         EXPECT_EQ(road_position.pos.r, y + lane_width_ / 2);
@@ -337,7 +337,7 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
         EXPECT_DOUBLE_EQ(nearest_position.x, x);
         EXPECT_DOUBLE_EQ(nearest_position.y, y);
         EXPECT_DOUBLE_EQ(nearest_position.z, z);
-        EXPECT_DOUBLE_EQ(distance, z);
+        EXPECT_DOUBLE_EQ(distance, 0);
         EXPECT_EQ(road_position.lane, expected_lane);
         EXPECT_EQ(road_position.pos.s, x);
         if (y == 0) {


### PR DESCRIPTION
The distance is always zero since the provided `geo_pos` is on the driveable region.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5355)
<!-- Reviewable:end -->
