### PR TITLE
Revert "Suppress some Mac-specific linker warnings."

### DIFF
--- a/tools/CROSSTOOL
+++ b/tools/CROSSTOOL
@@ -356,20 +356,6 @@ toolchain {
   tool_path { name: "cpp" path: "/usr/bin/cpp" }
   tool_path { name: "dwp" path: "/usr/bin/dwp" }
   tool_path { name: "gcc" path: "third_party/bazel/tools/cpp/osx_cc_wrapper.sh" }
-
-  ### Additional flags for Drake.
-  ### These must go above the Bazel-derived flags, because some of those flags
-  ### are designed to be concatenated with a predicate, for instance the
-  ### ar_flag "-o".
-  # This warning is common in Drake, and we don't really care about compact
-  # exception unwinding, since catching exceptions is forbidden, so we suppress
-  # it. See https://github.com/RobotLocomotion/drake/issues/5183
-  linker_flag: "-Wl,-no_compact_unwind"
-  # The no-symbols warning is common and harmless for header-only libraries,
-  # so we suppress it. See https://github.com/RobotLocomotion/drake/issues/5183
-  ar_flag: "-no_warning_for_no_symbols"
-  ### End of additional flags for Drake.
-
   cxx_flag: "-std=c++1y"
   ar_flag: "-static"
   ar_flag: "-s"


### PR DESCRIPTION
Reverts RobotLocomotion/drake#5338

It was discovered that this PR resulted in `gtest` failing to catch exceptions. Specifically, unit tests containing `EXPECT_THROW()` or `EXPECT_ANY_THROW()` would fail because the exceptions were not being caught by `gTest`. Here is an example error:

```
$ bazel run //drake/systems/primitives:saturation_test
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: Failure at drake/systems/primitives/saturation.cc:23 in Saturation(): condition 'input_size_ > 0' failed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5362)
<!-- Reviewable:end -->