### PR TITLE
disable explicit instantiation of inverse dynamics on autodiffxd.

### DIFF
--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -3502,16 +3502,6 @@ RigidBodyTree<double>::inverseDynamics<double>(
                   Eigen::aligned_allocator<pair<RigidBody<double> const* const,
                                                 WrenchVector<double>>>> const&,
     VectorX<double> const&, bool) const;
-template VectorX<AutoDiffXd>
-RigidBodyTree<AutoDiffXd>::inverseDynamics<AutoDiffXd>(
-    KinematicsCache<AutoDiffXd>&,
-    unordered_map<RigidBody<AutoDiffXd> const*, TwistVector<AutoDiffXd>,
-                  hash<RigidBody<AutoDiffXd> const*>,
-                  equal_to<RigidBody<AutoDiffXd> const*>,
-                  Eigen::aligned_allocator<pair<
-                  RigidBody<AutoDiffXd> const* const,
-                  TwistVector<AutoDiffXd>>>> const&,
-    VectorX<AutoDiffXd> const&, bool) const;
 
 // Explicit template instantiations for jointLimitConstraints.
 template void RigidBodyTree<double>::jointLimitConstraints<
@@ -3739,10 +3729,6 @@ template KinematicsCache<double>
 RigidBodyTree<double>::doKinematics(
     Eigen::MatrixBase<Eigen::Map<VectorXd const>> const&,
     Eigen::MatrixBase<Eigen::Map<VectorXd const>> const&, bool) const;
-template KinematicsCache<AutoDiffXd>
-RigidBodyTree<AutoDiffXd>::doKinematics(
-    Eigen::MatrixBase<VectorX<AutoDiffXd>> const&,
-    Eigen::MatrixBase<VectorX<AutoDiffXd>> const&, bool) const;
 
 // Explicit template instantiations for parseBodyOrFrameID.
 template int RigidBodyTree<double>::parseBodyOrFrameID(
@@ -3759,4 +3745,3 @@ RigidBodyTree<double>::CreateKinematicsCacheWithType<AutoDiffUpTo73d>() const;
 
 // Explicitly instantiates on the most common scalar types.
 template class RigidBodyTree<double>;
-template class RigidBodyTree<AutoDiffXd>;

--- a/drake/systems/controllers/inverse_dynamics.cc
+++ b/drake/systems/controllers/inverse_dynamics.cc
@@ -70,7 +70,8 @@ void InverseDynamics<T>::DoCalcOutput(const Context<T>& context,
 }
 
 template class InverseDynamics<double>;
-template class InverseDynamics<AutoDiffXd>;
+// TODO(siyuan): some linking issue on mac.
+// template class InverseDynamics<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
e.g. https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=428934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5366)
<!-- Reviewable:end -->
