### PR TITLE
Updates simple_car doc to refer to drake::symbolic::Expression.

### DIFF
--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -36,7 +36,7 @@ namespace automotive {
 /// output port 1: A PoseVector containing X_WC, where C is the car frame.
 ///
 /// @tparam T must support certain arithmetic operations;
-/// for details, see ./test/simple_car_scalartype_test.cc.
+/// for details, see drake::symbolic::Expression.
 ///
 /// Instantiated templates for the following ScalarTypes are provided:
 /// - double


### PR DESCRIPTION
The originally-referenced file no longer exists on `master`. I made this changed based on #3912.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5368)
<!-- Reviewable:end -->
