### PR TITLE
Integrates Maliput Railcar Model With Automotive  Demo.

### DIFF
--- a/drake/automotive/README.md
+++ b/drake/automotive/README.md
@@ -66,12 +66,13 @@ The following demos are available:
    cars which includes a merge.
 
  * A 3-lane dragway with four `TrajectoryCar` vehicles traveling down each lane
-   at different speeds plus one `SimpleCar`:
+   at different speeds plus one `SimpleCar` and one `MaliputRailcar`:
 
    ```
    bazel run //drake/automotive:demo -- \
        --num_dragway_lanes=3 \
-       --num_trajectory_car=12
+       --num_trajectory_car=12 \
+       --num_maliput_railcar=1
    ```
 
 Driving the Prius

--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -6,6 +6,7 @@
 #include "drake/automotive/gen/driving_command_translator.h"
 #include "drake/automotive/gen/endless_road_car_state_translator.h"
 #include "drake/automotive/gen/euler_floating_joint_state_translator.h"
+#include "drake/automotive/gen/maliput_railcar_state_translator.h"
 #include "drake/automotive/gen/simple_car_state_translator.h"
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/utility/generate_urdf.h"
@@ -272,6 +273,18 @@ void AutomotiveSimulator<T>::GenerateAndLoadRoadNetworkUrdf() {
       urdf_filepath,
       drake::multibody::joints::kFixed,
       tree_.get());
+}
+
+template <typename T>
+void AutomotiveSimulator<T>::AddPublisher(const MaliputRailcar<T>& system,
+                                          int vehicle_number) {
+  DRAKE_DEMAND(!has_started());
+  static const MaliputRailcarStateTranslator translator;
+  auto publisher =
+      builder_->template AddSystem<systems::lcm::LcmPublisherSystem>(
+          std::to_string(vehicle_number) + "_MALIPUT_RAILCAR_STATE", translator,
+          lcm_.get());
+  builder_->Connect(system.state_output(), publisher->get_input_port(0));
 }
 
 template <typename T>

--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -223,6 +223,10 @@ class AutomotiveSimulator {
 
   // Adds an LCM publisher for the given @p system.
   // @pre Start() has NOT been called.
+  void AddPublisher(const MaliputRailcar<T>& system, int vehicle_number);
+
+  // Adds an LCM publisher for the given @p system.
+  // @pre Start() has NOT been called.
   void AddPublisher(const SimpleCar<T>& system, int vehicle_number);
 
   // Adds an LCM publisher for the given @p system.


### PR DESCRIPTION
To run a demo, start `drake-visualizer`, then execute:

```
$ bazel run //drake/automotive:automotive_demo -- --num_dragway_lanes=1 --num_trajectory_car=0 --num_maliput_railcar=1 --dragway_base_speed=20
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5377)
<!-- Reviewable:end -->