### PR TITLE
Adds a rigid gripper

### DIFF
--- a/drake/examples/contact_model/BUILD
+++ b/drake/examples/contact_model/BUILD
@@ -40,8 +40,6 @@ drake_cc_binary(
     ],
     deps = [
         "//drake/common:drake_path",
-        "//drake/common/trajectories:piecewise_polynomial",
-        "//drake/common/trajectories:piecewise_polynomial_trajectory",
         "//drake/lcm:lcm",
         "//drake/multibody/parsers:parsers",
         "//drake/multibody/rigid_body_plant:contact_results_to_lcm",
@@ -49,9 +47,6 @@ drake_cc_binary(
         "//drake/multibody/rigid_body_plant:rigid_body_plant",
         "//drake/multibody:rigid_body_tree_construction",
         "//drake/systems/analysis",
-        "//drake/systems/controllers:pid_controlled_system",
-        "//drake/systems/primitives:constant_vector_source",
-        "//drake/systems/primitives:trajectory_source",
         "@gflags//:gflags",
     ],
 )

--- a/drake/examples/contact_model/BUILD
+++ b/drake/examples/contact_model/BUILD
@@ -31,4 +31,29 @@ drake_cc_binary(
     ],
 )
 
+drake_cc_binary(
+    name = "rigid_gripper",
+    srcs = ["rigid_gripper.cc"],
+    data = [
+        "rigid_gripper.urdf",
+        "//drake/multibody:models",
+    ],
+    deps = [
+        "//drake/common:drake_path",
+        "//drake/common/trajectories:piecewise_polynomial",
+        "//drake/common/trajectories:piecewise_polynomial_trajectory",
+        "//drake/lcm:lcm",
+        "//drake/multibody/parsers:parsers",
+        "//drake/multibody/rigid_body_plant:contact_results_to_lcm",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/multibody/rigid_body_plant:rigid_body_plant",
+        "//drake/multibody:rigid_body_tree_construction",
+        "//drake/systems/analysis",
+        "//drake/systems/controllers:pid_controlled_system",
+        "//drake/systems/primitives:constant_vector_source",
+        "//drake/systems/primitives:trajectory_source",
+        "@gflags//:gflags",
+    ],
+)
+
 cpplint()

--- a/drake/examples/contact_model/BUILD
+++ b/drake/examples/contact_model/BUILD
@@ -34,9 +34,14 @@ drake_cc_binary(
 drake_cc_binary(
     name = "rigid_gripper",
     srcs = ["rigid_gripper.cc"],
+    add_test_rule = 1,
     data = [
         "rigid_gripper.urdf",
         "//drake/multibody:models",
+    ],
+    test_rule_args = [
+        " --sim_duration=0.01",
+        " --playback=false",
     ],
     deps = [
         "//drake/common:drake_path",

--- a/drake/examples/contact_model/CMakeLists.txt
+++ b/drake/examples/contact_model/CMakeLists.txt
@@ -6,6 +6,17 @@ if (lcm_FOUND AND Bullet_FOUND)
       drakeRigidBodyPlant
       drakeSystemAnalysis
       drakeSystemFramework
+      )
+
+  add_executable(rigid_gripper rigid_gripper.cc)
+  target_link_libraries(rigid_gripper
+      drakeCommon
+      drakeLcmSystem
+      drakeMultibodyParsers
+      drakeRBM
+      drakeRigidBodyPlant
+      drakeSystemAnalysis
+      drakeSystemControllers
       drakeSystemPrimitives
       )
   # A test to guarantee the example doesn't fall out of sync with Drake.

--- a/drake/examples/contact_model/CMakeLists.txt
+++ b/drake/examples/contact_model/CMakeLists.txt
@@ -16,8 +16,6 @@ if (lcm_FOUND AND Bullet_FOUND)
       drakeRBM
       drakeRigidBodyPlant
       drakeSystemAnalysis
-      drakeSystemControllers
-      drakeSystemPrimitives
       )
   # A test to guarantee the example doesn't fall out of sync with Drake.
   drake_add_test(NAME sliding_bricks COMMAND sliding_bricks --sim_duration 0.01 --playback=false)

--- a/drake/examples/contact_model/CMakeLists.txt
+++ b/drake/examples/contact_model/CMakeLists.txt
@@ -7,6 +7,8 @@ if (lcm_FOUND AND Bullet_FOUND)
       drakeSystemAnalysis
       drakeSystemFramework
       )
+  # A test to guarantee the example doesn't fall out of sync with Drake.
+  drake_add_test(NAME sliding_bricks COMMAND sliding_bricks --sim_duration 0.01 --playback=false)
 
   add_executable(rigid_gripper rigid_gripper.cc)
   target_link_libraries(rigid_gripper
@@ -17,6 +19,5 @@ if (lcm_FOUND AND Bullet_FOUND)
       drakeRigidBodyPlant
       drakeSystemAnalysis
       )
-  # A test to guarantee the example doesn't fall out of sync with Drake.
-  drake_add_test(NAME sliding_bricks COMMAND sliding_bricks --sim_duration 0.01 --playback=false)
+  drake_add_test(NAME rigid_gripper COMMAND rigid_gripper --simulation_sec 0.01 --playback=false)
 endif()

--- a/drake/examples/contact_model/CMakeLists.txt
+++ b/drake/examples/contact_model/CMakeLists.txt
@@ -19,5 +19,5 @@ if (lcm_FOUND AND Bullet_FOUND)
       drakeRigidBodyPlant
       drakeSystemAnalysis
       )
-  drake_add_test(NAME rigid_gripper COMMAND rigid_gripper --simulation_sec 0.01 --playback=false)
+  drake_add_test(NAME rigid_gripper COMMAND rigid_gripper --sim_duration 0.01 --playback=false)
 endif()

--- a/drake/examples/contact_model/rigid_gripper.cc
+++ b/drake/examples/contact_model/rigid_gripper.cc
@@ -39,10 +39,11 @@ DEFINE_double(us, 0.9, "The coefficient of static friction");
 DEFINE_double(ud, 0.5, "The coefficient of dynamic friction");
 DEFINE_double(stiffness, 10000, "The contact material stiffness");
 DEFINE_double(dissipation, 2.0, "The contact material dissipation");
-DEFINE_double(slip, 0.01,
+DEFINE_double(v_stiction_tolerance, 0.01,
               "The maximum slipping speed allowed during stiction");
+DEFINE_double(sim_duration, 5, "Amount of time to simulate");
 DEFINE_bool(playback, true,
-            "If true, simulation beings looping playback when complete");
+            "If true, simulation begins looping playback when complete");
 
 namespace drake {
 namespace examples {
@@ -88,10 +89,12 @@ int main() {
   std::cout << "\tStiffness:                " << FLAGS_stiffness << "\n";
   std::cout << "\tstatic friction:          " << FLAGS_us << "\n";
   std::cout << "\tdynamic friction:         " << FLAGS_ud << "\n";
-  std::cout << "\tAllowed stiction speed:   " << FLAGS_slip  << "\n";
+  std::cout << "\tAllowed stiction speed:   " << FLAGS_v_stiction_tolerance
+            << "\n";
   std::cout << "\tDissipation:              " << FLAGS_dissipation << "\n";
   plant->set_normal_contact_parameters(FLAGS_stiffness, FLAGS_dissipation);
-  plant->set_friction_contact_parameters(FLAGS_us, FLAGS_ud, FLAGS_slip);
+  plant->set_friction_contact_parameters(FLAGS_us, FLAGS_ud,
+                                         FLAGS_v_stiction_tolerance);
 
   // Creates and adds LCM publisher for visualization.  The test doesn't
   // require `drake_visualizer` but it is convenient to have when debugging.
@@ -128,10 +131,11 @@ int main() {
 
   simulator.Initialize();
 
-  const double kDuration = 5;  // Comparable with schunk_wsg_lift_test.
-  // Print a time stamp update every tenth of a second.
+  // Print a time stamp update every tenth of a second.  This helps communicate
+  // progress in the event that the integrator crawls to a very small timestep.
   const double kPrintPeriod = 0.1;
-  int step_count = static_cast<int>(std::ceil(kDuration / kPrintPeriod));
+  int step_count =
+      static_cast<int>(std::ceil(FLAGS_sim_duration / kPrintPeriod));
   for (int i = 1; i <= step_count; ++i) {
     double t = context->get_time();
     std::cout << "time: " << t << "\n";

--- a/drake/examples/contact_model/rigid_gripper.cc
+++ b/drake/examples/contact_model/rigid_gripper.cc
@@ -1,0 +1,157 @@
+// A simple example of a rigid gripper attempting to hold a block. The gripper
+// has rigid geometry: two fingers a fixed distance from each other. They
+// are positioned in a configuration *slightly* narrower than the box placed
+// between them.
+//
+// This is a test to evaluate/debug the contact model.  This configuration
+// simplifies the test by defining a known penetration and eliminating all
+// controller-dependent variation.
+//
+// This is an even simpler example of what is shown in schung_wsg_lift_test.
+// This eliminates the PID controller and ground contact.  At the end of the
+// simulation time, the box should have slipped an amount less than the duration
+// length times v_stiction_tolerance (i.e., the highest allowable slip speed
+// during stiction).
+
+#include <memory>
+
+#include <gflags/gflags.h>
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_contact_results_for_viz.hpp"
+#include "drake/multibody/parsers/sdf_parser.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_frame.h"
+#include "drake/multibody/rigid_body_plant/contact_results_to_lcm.h"
+#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/multibody/rigid_body_tree_construction.h"
+#include "drake/systems/analysis/runge_kutta3_integrator.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/controllers/pid_controlled_system.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/primitives/constant_vector_source.h"
+#include "drake/systems/primitives/trajectory_source.h"
+
+DEFINE_double(accuracy, 5e-5, "Sets the simulation accuracy");
+DEFINE_double(us, 0.9, "The coefficient of static friction");
+DEFINE_double(ud, 0.5, "The coefficient of dynamic friction");
+DEFINE_double(stiffness, 10000, "The contact material stiffness");
+DEFINE_double(dissipation, 2.0, "The contact material dissipation");
+DEFINE_double(slip, 0.01,
+              "The maximum slipping speed allowed during stiction");
+DEFINE_bool(playback, true,
+            "If true, simulation beings looping playback when complete");
+
+namespace drake {
+namespace examples {
+
+using drake::systems::RungeKutta3Integrator;
+using drake::systems::ContactResultsToLcmSystem;
+using drake::systems::lcm::LcmPublisherSystem;
+
+std::unique_ptr<RigidBodyTreed> BuildTestTree() {
+  std::unique_ptr<RigidBodyTreed> tree = std::make_unique<RigidBodyTreed>();
+
+  /// Add the gripper.  Offset it slightly back and up so that we can
+  // locate the bos at the origin.
+  auto gripper_frame = std::allocate_shared<RigidBodyFrame<double>>(
+      Eigen::aligned_allocator<RigidBodyFrame<double>>(), "gripper_pose_frame",
+      &tree->world(), Eigen::Vector3d(0, -0.065, 0.05),
+      Eigen::Vector3d::Zero());
+  parsers::urdf::AddModelInstanceFromUrdfFile(
+      GetDrakePath() + "/examples/contact_model/rigid_gripper.urdf",
+      multibody::joints::kFixed, gripper_frame, tree.get());
+
+  // Add a box to grip.  Position it such that if there *were* a plane at z = 0,
+  // the box would be sitting on it (this maintains parity with the
+  // schunk_wsg_lift_test scenario).
+  auto box_frame = std::allocate_shared<RigidBodyFrame<double>>(
+      Eigen::aligned_allocator<RigidBodyFrame<double>>(), "box_offset",
+      &tree->world(), Eigen::Vector3d(0, 0, 0.075), Eigen::Vector3d::Zero());
+  parsers::urdf::AddModelInstanceFromUrdfFile(
+      GetDrakePath() + "/multibody/models/box_small.urdf",
+      multibody::joints::kQuaternion, box_frame, tree.get());
+
+  tree->compile();
+  return tree;
+}
+
+// Simple scenario of gripper lifting box.
+int main() {
+  systems::DiagramBuilder<double> builder;
+
+  systems::RigidBodyPlant<double>* plant =
+      builder.AddSystem<systems::RigidBodyPlant<double>>(BuildTestTree());
+
+  // Command-line specified contact parameters.
+  std::cout << "Contact properties:\n";
+  std::cout << "\tStiffness:                " << FLAGS_stiffness << "\n";
+  std::cout << "\tstatic friction:          " << FLAGS_us << "\n";
+  std::cout << "\tdynamic friction:         " << FLAGS_ud << "\n";
+  std::cout << "\tAllowed stiction speed:   " << FLAGS_slip  << "\n";
+  std::cout << "\tDissipation:              " << FLAGS_dissipation << "\n";
+  plant->set_normal_contact_parameters(FLAGS_stiffness, FLAGS_dissipation);
+  plant->set_friction_contact_parameters(FLAGS_us, FLAGS_ud, FLAGS_slip);
+
+  // Creates and adds LCM publisher for visualization.  The test doesn't
+  // require `drake_visualizer` but it is convenient to have when debugging.
+  drake::lcm::DrakeLcm lcm;
+  const auto viz_publisher =
+      builder.template AddSystem<systems::DrakeVisualizer>(
+          plant->get_rigid_body_tree(), &lcm, true);
+  builder.Connect(plant->state_output_port(),
+                  viz_publisher->get_input_port(0));
+
+  // contact force visualization
+  const ContactResultsToLcmSystem<double>& contact_viz =
+  *builder.template AddSystem<ContactResultsToLcmSystem<double>>(
+      plant->get_rigid_body_tree());
+  auto& contact_results_publisher = *builder.AddSystem(
+      LcmPublisherSystem::Make<lcmt_contact_results_for_viz>(
+          "CONTACT_RESULTS", &lcm));
+  // Contact results to lcm msg.
+  builder.Connect(plant->contact_results_output_port(),
+                  contact_viz.get_input_port(0));
+  builder.Connect(contact_viz.get_output_port(0),
+                  contact_results_publisher.get_input_port(0));
+
+  // Set up the model and simulator and set their starting state.
+  const std::unique_ptr<systems::Diagram<double>> model = builder.Build();
+  systems::Simulator<double> simulator(*model);
+
+  auto context = simulator.get_mutable_context();
+
+  simulator.reset_integrator<RungeKutta3Integrator<double>>(*model, context);
+  simulator.get_mutable_integrator()->request_initial_step_size_target(1e-4);
+  simulator.get_mutable_integrator()->set_target_accuracy(FLAGS_accuracy);
+  std::cout << "Variable-step integrator accuracy: " << FLAGS_accuracy << "\n";
+
+  simulator.Initialize();
+
+  const double kDuration = 5;  // Comparable with schunk_wsg_lift_test.
+  // Print a time stamp update every tenth of a second.
+  const double kPrintPeriod = 0.1;
+  int step_count = static_cast<int>(std::ceil(kDuration / kPrintPeriod));
+  for (int i = 1; i <= step_count; ++i) {
+    double t = context->get_time();
+    std::cout << "time: " << t << "\n";
+    simulator.StepTo(i * kPrintPeriod);
+  }
+
+  while (FLAGS_playback) viz_publisher->ReplayCachedSimulation();
+  return 0;
+}
+
+}  // namespace examples
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::main();
+}

--- a/drake/examples/contact_model/rigid_gripper.cc
+++ b/drake/examples/contact_model/rigid_gripper.cc
@@ -1,28 +1,27 @@
-// A simple example of a rigid gripper attempting to hold a block. The gripper
-// has rigid geometry: two fingers a fixed distance from each other. They
-// are positioned in a configuration *slightly* narrower than the box placed
-// between them.
-//
-// This is a test to evaluate/debug the contact model.  This configuration
-// simplifies the test by defining a known penetration and eliminating all
-// controller-dependent variation.
-//
-// This is an even simpler example of what is shown in schung_wsg_lift_test.
-// This eliminates the PID controller and ground contact.  At the end of the
-// simulation time, the box should have slipped an amount less than the duration
-// length times v_stiction_tolerance (i.e., the highest allowable slip speed
-// during stiction).
+/*! @file
+A simple example of a rigid gripper attempting to hold a block. The gripper
+has rigid geometry: two fingers at a fixed distance from each other. They
+are positioned in a configuration *slightly* narrower than the box placed
+between them.
+
+This is a test to evaluate/debug the contact model.  This configuration
+simplifies the test by defining a known penetration and eliminating all
+controller-dependent variation.
+
+This is an even simpler example of what is shown in schung_wsg_lift_test.
+This eliminates the PID controller and ground contact.  At the end of the
+simulation, the box should have slipped an amount less than the duration
+length times v_stiction_tolerance (i.e., the highest allowable slip speed
+during stiction).
+*/
 
 #include <memory>
 
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_path.h"
-#include "drake/common/eigen_types.h"
-#include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_contact_results_for_viz.hpp"
-#include "drake/multibody/parsers/sdf_parser.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_frame.h"
 #include "drake/multibody/rigid_body_plant/contact_results_to_lcm.h"
@@ -32,11 +31,8 @@
 #include "drake/multibody/rigid_body_tree_construction.h"
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
 #include "drake/systems/analysis/simulator.h"
-#include "drake/systems/controllers/pid_controlled_system.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/primitives/constant_vector_source.h"
-#include "drake/systems/primitives/trajectory_source.h"
 
 DEFINE_double(accuracy, 5e-5, "Sets the simulation accuracy");
 DEFINE_double(us, 0.9, "The coefficient of static friction");
@@ -58,8 +54,8 @@ using drake::systems::lcm::LcmPublisherSystem;
 std::unique_ptr<RigidBodyTreed> BuildTestTree() {
   std::unique_ptr<RigidBodyTreed> tree = std::make_unique<RigidBodyTreed>();
 
-  /// Add the gripper.  Offset it slightly back and up so that we can
-  // locate the bos at the origin.
+  // Add the gripper.  Offset it slightly back and up so that we can
+  // locate the box at the origin.
   auto gripper_frame = std::allocate_shared<RigidBodyFrame<double>>(
       Eigen::aligned_allocator<RigidBodyFrame<double>>(), "gripper_pose_frame",
       &tree->world(), Eigen::Vector3d(0, -0.065, 0.05),
@@ -78,11 +74,9 @@ std::unique_ptr<RigidBodyTreed> BuildTestTree() {
       GetDrakePath() + "/multibody/models/box_small.urdf",
       multibody::joints::kQuaternion, box_frame, tree.get());
 
-  tree->compile();
   return tree;
 }
 
-// Simple scenario of gripper lifting box.
 int main() {
   systems::DiagramBuilder<double> builder;
 
@@ -108,7 +102,7 @@ int main() {
   builder.Connect(plant->state_output_port(),
                   viz_publisher->get_input_port(0));
 
-  // contact force visualization
+  // Enable contact force visualization.
   const ContactResultsToLcmSystem<double>& contact_viz =
   *builder.template AddSystem<ContactResultsToLcmSystem<double>>(
       plant->get_rigid_body_tree());

--- a/drake/examples/contact_model/rigid_gripper.urdf
+++ b/drake/examples/contact_model/rigid_gripper.urdf
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<robot xmlns="http://drake.mit.edu"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://drake.mit.edu ../../../../doc/drakeURDF.xsd" name="rigid_gripper">
+
+ <!-- A simple, rigid, two-fingered gripper.  The placement of the fingers is
+ just enough to fit the the box in `box_small.urdf`.
+ -->
+
+  <link name="gripper">
+    <inertial>
+      <origin xyz="0 -0.03525 0" rpy="0 0 0" />
+      <!-- The mass of the schunk gripper -->
+      <mass value="1.088882"/>
+      <!-- The inertia of the schunk gripper *body* (ignoring fingers). -->
+        <inertia>
+          <ixx>0.162992</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.162992</iyy>
+          <iyz>0</iyz>
+          <izz>0.164814</izz>
+        </inertia>
+    </inertial>
+
+    <!-- palm -->
+    <visual>
+      <origin xyz="0 -0.03525 0" rpy="0 0 0" />
+      <geometry>
+        <box size="0.146 0.0725 0.049521" />
+      </geometry>
+      <material name="">
+        <color rgba="0.5 0 0 1" />
+      </material>
+    </visual>
+    <collision group="gripper">
+      <origin xyz="0 -0.03525 0" rpy="0 0 0" />
+      <geometry>
+        <box size="0.146 0.0725 0.049521" />
+      </geometry>
+    </collision>
+
+    <!-- NOTE:
+        This assumes that box_small.urdf has a size of 0.05 along the x-axis.
+        As such, any contact sphere's x-position of magnitude greater than
+        0.25 + radius will be collision free (finger 1 having a negative value,
+        finger 2 having the corresponding positive value).
+
+        Below, we are assuming a contact radius of 0.01, which means the contact
+        threshold is 0.025 + 0.01 = 0.035.  So, the following values will
+        provide the corresponding penetration depths:
+
+        | displacement  |  Penetration depth  |
+        |---------------+---------------------|
+        |     0.035     |       0             |
+        |     0.0349    |       0.0001        |
+        |     0.0345    |       0.0005        |
+        |     0.034     |       0.001         | <-- Value used below
+    -->
+    <!-- finger 1 -->
+    <visual>
+      <origin xyz="-0.032 0.0375 0" rpy="0 0 0" />
+      <geometry>
+        <box size="0.016 0.075 0.02" />
+      </geometry>
+      <material name="">
+        <color rgba="0.5 0 0 1" />
+      </material>
+    </visual>
+
+    <collision group="gripper">
+      <origin xyz="-0.034 0.015 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+    <collision group="gripper">
+      <origin xyz="-0.034 0.03 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+    <collision group="gripper">
+      <origin xyz="-0.034 0.045 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+    <collision group="gripper">
+      <origin xyz="-0.034 0.06 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+    <collision group="gripper">
+      <origin xyz="-0.034 0.075 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+
+    <!-- finger 2 -->
+    <visual>
+      <origin xyz="0.032 0.0375 0" rpy="0 0 0" />
+      <geometry>
+        <box size="0.016 0.075 0.02" />
+      </geometry>
+      <material name="">
+        <color rgba="0.5 0 0 1" />
+      </material>
+    </visual>
+
+    <collision group="gripper">
+      <origin xyz="0.034 0.015 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+    <collision group="gripper">
+      <origin xyz="0.034 0.03 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+    <collision group="gripper">
+      <origin xyz="0.034 0.045 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+    <collision group="gripper">
+      <origin xyz="0.034 0.06 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+    <collision group="gripper">
+      <origin xyz="0.034 0.075 0" rpy="0 0 0" />
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/drake/examples/contact_model/rigid_gripper.urdf
+++ b/drake/examples/contact_model/rigid_gripper.urdf
@@ -11,7 +11,7 @@
   <link name="gripper">
     <inertial>
       <origin xyz="0 -0.03525 0" rpy="0 0 0" />
-      <!-- The mass of the schunk gripper -->
+      <!-- The mass of the schunk gripper; mass of body plus two fingers. -->
       <mass value="1.088882"/>
       <!-- The inertia of the schunk gripper *body* (ignoring fingers). -->
         <inertia>

--- a/drake/examples/contact_model/rigid_gripper.urdf
+++ b/drake/examples/contact_model/rigid_gripper.urdf
@@ -3,8 +3,9 @@
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://drake.mit.edu ../../../../doc/drakeURDF.xsd" name="rigid_gripper">
 
- <!-- A simple, rigid, two-fingered gripper.  The placement of the fingers is
- just enough to fit the the box in `box_small.urdf`.
+ <!-- A simple, rigid, two-fingered gripper.  The space between the fingers is
+ just enough to fit the box in `box_small.urdf` (placed on opposite sides
+ along the x-axis).
  -->
 
   <link name="gripper">
@@ -41,10 +42,11 @@
     </collision>
 
     <!-- NOTE:
-        This assumes that box_small.urdf has a size of 0.05 along the x-axis.
-        As such, any contact sphere's x-position of magnitude greater than
-        0.25 + radius will be collision free (finger 1 having a negative value,
-        finger 2 having the corresponding positive value).
+        This assumes that box_small.urdf has a size of 0.05 along the x-axis,
+        centered on the y-z plane. As such, for a sphere with radius `r`, any
+        x-position of magnitude greater than 0.025 + `r` will be collision free
+        (finger 1 having a negative value, finger 2 having the corresponding
+        positive value).
 
         Below, we are assuming a contact radius of 0.01, which means the contact
         threshold is 0.025 + 0.01 = 0.035.  So, the following values will


### PR DESCRIPTION
This is the simplest approximation of testing gripping with the schunk
gripper.  Introduces a rigid gripper in a permanent pose of squeezing.
Simply runs the simulation to see if the box slides out of the perma-grip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5388)
<!-- Reviewable:end -->
