### PR TITLE
Add FooVector::IsValid to generated BasicVectors

### DIFF
--- a/drake/automotive/gen/bicycle_car_parameters.h
+++ b/drake/automotive/gen/bicycle_car_parameters.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -31,7 +32,7 @@ struct BicycleCarParametersIndices {
 template <typename T>
 class BicycleCarParameters : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef BicycleCarParametersIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -66,6 +67,19 @@ class BicycleCarParameters : public systems::BasicVector<T> {
   const T& Cr() const { return this->GetAtIndex(K::kCr); }
   void set_Cr(const T& Cr) { this->SetAtIndex(K::kCr, Cr); }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(mass());
+    result = result && !isnan(lf());
+    result = result && !isnan(lr());
+    result = result && !isnan(Iz());
+    result = result && !isnan(Cf());
+    result = result && !isnan(Cr());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/bicycle_car_state.h
+++ b/drake/automotive/gen/bicycle_car_state.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -31,7 +32,7 @@ struct BicycleCarStateIndices {
 template <typename T>
 class BicycleCarState : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef BicycleCarStateIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -66,6 +67,19 @@ class BicycleCarState : public systems::BasicVector<T> {
   const T& sy() const { return this->GetAtIndex(K::kSy); }
   void set_sy(const T& sy) { this->SetAtIndex(K::kSy, sy); }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(Psi());
+    result = result && !isnan(Psi_dot());
+    result = result && !isnan(beta());
+    result = result && !isnan(vel());
+    result = result && !isnan(sx());
+    result = result && !isnan(sy());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/driving_command.h
+++ b/drake/automotive/gen/driving_command.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -28,7 +29,7 @@ struct DrivingCommandIndices {
 template <typename T>
 class DrivingCommand : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef DrivingCommandIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -61,6 +62,16 @@ class DrivingCommand : public systems::BasicVector<T> {
   const T& brake() const { return this->GetAtIndex(K::kBrake); }
   void set_brake(const T& brake) { this->SetAtIndex(K::kBrake, brake); }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(steering_angle());
+    result = result && !isnan(throttle());
+    result = result && !isnan(brake());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/endless_road_car_config.h
+++ b/drake/automotive/gen/endless_road_car_config.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -30,7 +31,7 @@ struct EndlessRoadCarConfigIndices {
 template <typename T>
 class EndlessRoadCarConfig : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef EndlessRoadCarConfigIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -79,6 +80,18 @@ class EndlessRoadCarConfig : public systems::BasicVector<T> {
     this->SetAtIndex(K::kMaxDeceleration, max_deceleration);
   }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(wheelbase());
+    result = result && !isnan(max_abs_steering_angle());
+    result = result && !isnan(max_velocity());
+    result = result && !isnan(max_acceleration());
+    result = result && !isnan(max_deceleration());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/endless_road_car_state.h
+++ b/drake/automotive/gen/endless_road_car_state.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -29,7 +30,7 @@ struct EndlessRoadCarStateIndices {
 template <typename T>
 class EndlessRoadCarState : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef EndlessRoadCarStateIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -58,6 +59,17 @@ class EndlessRoadCarState : public systems::BasicVector<T> {
   const T& speed() const { return this->GetAtIndex(K::kSpeed); }
   void set_speed(const T& speed) { this->SetAtIndex(K::kSpeed, speed); }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(s());
+    result = result && !isnan(r());
+    result = result && !isnan(heading());
+    result = result && !isnan(speed());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/endless_road_oracle_output.h
+++ b/drake/automotive/gen/endless_road_oracle_output.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -27,7 +28,7 @@ struct EndlessRoadOracleOutputIndices {
 template <typename T>
 class EndlessRoadOracleOutput : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef EndlessRoadOracleOutputIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -60,6 +61,15 @@ class EndlessRoadOracleOutput : public systems::BasicVector<T> {
     this->SetAtIndex(K::kDeltaSigmaDot, delta_sigma_dot);
   }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(net_delta_sigma());
+    result = result && !isnan(delta_sigma_dot());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/euler_floating_joint_state.h
+++ b/drake/automotive/gen/euler_floating_joint_state.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -31,7 +32,7 @@ struct EulerFloatingJointStateIndices {
 template <typename T>
 class EulerFloatingJointState : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef EulerFloatingJointStateIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -66,6 +67,19 @@ class EulerFloatingJointState : public systems::BasicVector<T> {
   const T& yaw() const { return this->GetAtIndex(K::kYaw); }
   void set_yaw(const T& yaw) { this->SetAtIndex(K::kYaw, yaw); }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(x());
+    result = result && !isnan(y());
+    result = result && !isnan(z());
+    result = result && !isnan(roll());
+    result = result && !isnan(pitch());
+    result = result && !isnan(yaw());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/idm_planner_parameters.h
+++ b/drake/automotive/gen/idm_planner_parameters.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -31,7 +32,7 @@ struct IdmPlannerParametersIndices {
 template <typename T>
 class IdmPlannerParameters : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef IdmPlannerParametersIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -68,6 +69,19 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
   const T& delta() const { return this->GetAtIndex(K::kDelta); }
   void set_delta(const T& delta) { this->SetAtIndex(K::kDelta, delta); }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(v_ref());
+    result = result && !isnan(a());
+    result = result && !isnan(b());
+    result = result && !isnan(s_0());
+    result = result && !isnan(time_headway());
+    result = result && !isnan(delta());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/simple_car_config.h
+++ b/drake/automotive/gen/simple_car_config.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -31,7 +32,7 @@ struct SimpleCarConfigIndices {
 template <typename T>
 class SimpleCarConfig : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef SimpleCarConfigIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -90,6 +91,19 @@ class SimpleCarConfig : public systems::BasicVector<T> {
     this->SetAtIndex(K::kVelocityLimitKp, velocity_limit_kp);
   }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(wheelbase());
+    result = result && !isnan(track());
+    result = result && !isnan(max_abs_steering_angle());
+    result = result && !isnan(max_velocity());
+    result = result && !isnan(max_acceleration());
+    result = result && !isnan(velocity_limit_kp());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/gen/simple_car_state.h
+++ b/drake/automotive/gen/simple_car_state.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -29,7 +30,7 @@ struct SimpleCarStateIndices {
 template <typename T>
 class SimpleCarState : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef SimpleCarStateIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -60,6 +61,17 @@ class SimpleCarState : public systems::BasicVector<T> {
     this->SetAtIndex(K::kVelocity, velocity);
   }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(x());
+    result = result && !isnan(y());
+    result = result && !isnan(heading());
+    result = result && !isnan(velocity());
+    return result;
+  }
 };
 
 }  // namespace automotive

--- a/drake/automotive/test/simple_car_test.cc
+++ b/drake/automotive/test/simple_car_test.cc
@@ -3,8 +3,10 @@
 #include <cmath>
 #include <memory>
 
-#include "drake/common/eigen_matrix_compare.h"
 #include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/symbolic_formula.h"
 
 namespace drake {
 

--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -199,6 +199,12 @@ Formula operator>=(const Expression& e1, const Expression& e2);
 
 std::ostream& operator<<(std::ostream& os, const Formula& f);
 
+/** Returns a NaN check predicate on @p e. */
+// TODO(soonho-tri) This implementation is broken.
+inline Formula isnan(const Expression& e) {
+  return (e == Expression::NaN());
+}
+
 /** Checks if @p f is structurally equal to False formula. */
 bool is_false(const Formula& f);
 /** Checks if @p f is structurally equal to True formula. */

--- a/drake/examples/Acrobot/gen/acrobot_input_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_input_vector.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -27,7 +28,7 @@ struct AcrobotInputVectorIndices {
 template <typename T>
 class AcrobotInputVector : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef AcrobotInputVectorIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -47,6 +48,14 @@ class AcrobotInputVector : public systems::BasicVector<T> {
   const T& tau() const { return this->GetAtIndex(K::kTau); }
   void set_tau(const T& tau) { this->SetAtIndex(K::kTau, tau); }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(tau());
+    return result;
+  }
 };
 
 }  // namespace acrobot

--- a/drake/examples/Acrobot/gen/acrobot_output_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_output_vector.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -28,7 +29,7 @@ struct AcrobotOutputVectorIndices {
 template <typename T>
 class AcrobotOutputVector : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef AcrobotOutputVectorIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -51,6 +52,15 @@ class AcrobotOutputVector : public systems::BasicVector<T> {
   const T& theta2() const { return this->GetAtIndex(K::kTheta2); }
   void set_theta2(const T& theta2) { this->SetAtIndex(K::kTheta2, theta2); }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(theta1());
+    result = result && !isnan(theta2());
+    return result;
+  }
 };
 
 }  // namespace acrobot

--- a/drake/examples/Acrobot/gen/acrobot_state_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_state_vector.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -30,7 +31,7 @@ struct AcrobotStateVectorIndices {
 template <typename T>
 class AcrobotStateVector : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef AcrobotStateVectorIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -63,6 +64,17 @@ class AcrobotStateVector : public systems::BasicVector<T> {
     this->SetAtIndex(K::kTheta2dot, theta2dot);
   }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(theta1());
+    result = result && !isnan(theta2());
+    result = result && !isnan(theta1dot());
+    result = result && !isnan(theta2dot());
+    return result;
+  }
 };
 
 }  // namespace acrobot

--- a/drake/examples/Pendulum/gen/pendulum_state_vector.h
+++ b/drake/examples/Pendulum/gen/pendulum_state_vector.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -28,7 +29,7 @@ struct PendulumStateVectorIndices {
 template <typename T>
 class PendulumStateVector : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef PendulumStateVectorIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -53,6 +54,15 @@ class PendulumStateVector : public systems::BasicVector<T> {
     this->SetAtIndex(K::kThetadot, thetadot);
   }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(theta());
+    result = result && !isnan(thetadot());
+    return result;
+  }
 };
 
 }  // namespace pendulum

--- a/drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h
+++ b/drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -28,7 +29,7 @@ struct SchunkWsgTrajectoryGeneratorStateVectorIndices {
 template <typename T>
 class SchunkWsgTrajectoryGeneratorStateVector : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef SchunkWsgTrajectoryGeneratorStateVectorIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -60,6 +61,15 @@ class SchunkWsgTrajectoryGeneratorStateVector : public systems::BasicVector<T> {
     this->SetAtIndex(K::kTrajectoryStartTime, trajectory_start_time);
   }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(last_target_position());
+    result = result && !isnan(trajectory_start_time());
+    return result;
+  }
 };
 
 }  // namespace schunk_wsg

--- a/drake/tools/BUILD
+++ b/drake/tools/BUILD
@@ -56,6 +56,8 @@ drake_cc_googletest(
     name = "sample_test",
     deps = [
         ":sample",
+        "//drake/common:autodiff",
+        "//drake/common:symbolic",
     ],
 )
 

--- a/drake/tools/lcm_vector_gen.py
+++ b/drake/tools/lcm_vector_gen.py
@@ -48,6 +48,8 @@ def generate_indices(hh, caller_context, fields):
         # field is the LCM message field name
         # kname is the C++ kConstant name
         # kvalue is the C++ vector row index integer value
+        # TODO(jwnimmer-tri) The per-field context.update for name, kname, doc,
+        # etc. is copy-pasta'd throughout this file.  We should abbreviate it.
         context.update(kname=to_kname(field['name']))
         context.update(kvalue=kvalue)
         put(hh, INDICES_FIELD % context, 1)
@@ -125,11 +127,37 @@ def generate_accessors(hh, caller_context, fields):
     put(hh, ACCESSOR_END % context, 2)
 
 
+IS_VALID_BEGIN = """
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+"""
+IS_VALID = """
+    result = result && !isnan(%(field)s());
+"""
+IS_VALID_END = """
+    return result;
+  }
+"""
+
+
+def generate_is_valid(hh, caller_context, fields):
+    context = dict(caller_context)
+    put(hh, IS_VALID_BEGIN % context, 1)
+    for field in fields:
+        context.update(field=field['name'])
+        context.update(kname=to_kname(field['name']))
+        put(hh, IS_VALID % context, 1)
+    put(hh, IS_VALID_END % context, 2)
+
+
 VECTOR_HH_PREAMBLE = """
 #pragma once
 
 %(generated_code_warning)s
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -140,15 +168,13 @@ VECTOR_HH_PREAMBLE = """
 %(opening_namespace)s
 """
 
-# TODO(jwnimmer-tri) Turn this into doxygen style in the template below, for
-# better doxygen output: "// An abbreviation for our row index constants."
 VECTOR_CLASS_BEGIN = """
 
 /// Specializes BasicVector with specific getters and setters.
 template <typename T>
 class %(camel)s : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef %(indices)s K;
 """
 
@@ -362,6 +388,7 @@ def generate_code(args):
         generate_default_ctor(hh, context, fields)
         generate_do_clone(hh, context, fields)
         generate_accessors(hh, context, fields)
+        generate_is_valid(hh, context, fields)
         put(hh, VECTOR_CLASS_END % context, 2)
         put(hh, VECTOR_HH_POSTAMBLE % context, 1)
 

--- a/drake/tools/test/gen/sample.h
+++ b/drake/tools/test/gen/sample.h
@@ -3,6 +3,7 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -28,7 +29,7 @@ struct SampleIndices {
 template <typename T>
 class Sample : public systems::BasicVector<T> {
  public:
-  // An abbreviation for our row index constants.
+  /// An abbreviation for our row index constants.
   typedef SampleIndices K;
 
   /// Default constructor.  Sets all rows to zero.
@@ -54,6 +55,15 @@ class Sample : public systems::BasicVector<T> {
     this->SetAtIndex(K::kTwoWord, two_word);
   }
   //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(x());
+    result = result && !isnan(two_word());
+    return result;
+  }
 };
 
 }  // namespace test

--- a/drake/tools/test/sample_test.cc
+++ b/drake/tools/test/sample_test.cc
@@ -1,6 +1,13 @@
 #include "drake/tools/test/gen/sample.h"
 
+#include <cmath>
+
 #include "gtest/gtest.h"
+
+#include "drake/common/autodiff_overloads.h"
+#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/symbolic_expression.h"
+#include "drake/common/symbolic_formula.h"
 
 namespace drake {
 namespace tools {
@@ -33,6 +40,46 @@ GTEST_TEST(SampleTest, SimpleCoverage) {
   EXPECT_NE(dynamic_cast<Sample<double>*>(cloned.get()), nullptr);
   EXPECT_EQ(cloned->GetAtIndex(0), 11.0);
   EXPECT_EQ(cloned->GetAtIndex(1), 22.0);
+}
+
+// Cover Simple<double>::IsValid.
+GTEST_TEST(SampleTest, IsValid) {
+  Sample<double> dummy1;
+  EXPECT_TRUE(dummy1.IsValid());
+  dummy1.set_x(std::numeric_limits<double>::quiet_NaN());
+  EXPECT_FALSE(dummy1.IsValid());
+
+  Sample<double> dummy2;
+  EXPECT_TRUE(dummy2.IsValid());
+  dummy2.set_two_word(std::numeric_limits<double>::quiet_NaN());
+  EXPECT_FALSE(dummy2.IsValid());
+}
+
+// Cover Simple<AutoDiffXd>::IsValid.
+GTEST_TEST(SampleTest, AutoDiffXdIsValid) {
+  // A NaN in the AutoDiffScalar::value() makes us invalid.
+  Sample<AutoDiffXd> dut;
+  EXPECT_TRUE(dut.IsValid());
+  dut.set_x(std::numeric_limits<double>::quiet_NaN());
+  EXPECT_FALSE(dut.IsValid());
+
+  // A NaN in the AutoDiffScalar::derivatives() is still valid.
+  AutoDiffXd zero_with_nan_derivatives{0};
+  zero_with_nan_derivatives.derivatives() =
+      Vector1d(std::numeric_limits<double>::quiet_NaN());
+  ASSERT_EQ(zero_with_nan_derivatives.derivatives().size(), 1);
+  EXPECT_TRUE(std::isnan(zero_with_nan_derivatives.derivatives()(0)));
+  dut.set_x(zero_with_nan_derivatives);
+  EXPECT_TRUE(dut.IsValid());
+}
+
+// Cover Simple<Expression>::IsValid.
+GTEST_TEST(SampleTest, SymbolicIsValid) {
+  Sample<symbolic::Expression> dut;
+  dut.set_x(symbolic::Variable("x"));
+  dut.set_two_word(symbolic::Variable("two_word"));
+  EXPECT_EQ(dut.IsValid().to_string(),
+            "(!((x = NaN)) and !((two_word = NaN)))");
 }
 
 }  // namespace


### PR DESCRIPTION
For now, this only covers NaN-ness, which is the default.  But, it gets the big-diff changes out of the way, which will make the next step of schema-defined limits more clear.

Also tidies a doxygen TODO from previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5391)
<!-- Reviewable:end -->
