### PR TITLE
Put all lcmtypes-py into a single library

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -289,7 +289,7 @@ py_binary(
     name = "steering_command_driver",
     srcs = ["steering_command_driver.py"],
     deps = [
-        "//drake/lcmtypes:automotive-py",
+        "//drake/lcmtypes:lcmtypes-py",
         "@lcm//:lcm-python",
     ],
 )

--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -158,12 +158,6 @@ lcm_cc_library(
     lcm_srcs = ["lcmt_drake_signal.lcm"],
 )
 
-lcm_py_library(
-    name = "drake_signal-py",
-    lcm_package = "drake",
-    lcm_srcs = ["lcmt_drake_signal.lcm"],
-)
-
 _VIEWER_LCM_SRCS = [
     "lcmt_viewer_command.lcm",
     "lcmt_viewer_draw.lcm",
@@ -208,12 +202,6 @@ lcm_java_library(
     lcm_srcs = _AUTOMOTIVE_LCM_SRCS,
 )
 
-lcm_py_library(
-    name = "automotive-py",
-    lcm_package = "drake",
-    lcm_srcs = _AUTOMOTIVE_LCM_SRCS,
-)
-
 lcm_cc_library(
     name = "iiwa",
     lcm_package = "drake",
@@ -241,4 +229,20 @@ lcm_cc_library(
     ],
 )
 
-# TODO(jwnimmer-tri) Many more messages are missing ...
+# TODO(jwnimmer-tri) Many more C++ messages are missing ...
+
+lcm_py_library(
+    name = "lcmtypes-py",
+    lcm_package = "drake",
+    lcm_srcs = glob(["*.lcm"]),
+)
+
+# === test/ ===
+
+py_test(
+    name = "polynomial_matrix_test",
+    srcs = ["test/polynomial_matrix_test.py"],
+    deps = [
+        ":lcmtypes-py",
+    ],
+)

--- a/drake/lcmtypes/test/polynomial_matrix_test.py
+++ b/drake/lcmtypes/test/polynomial_matrix_test.py
@@ -1,0 +1,11 @@
+
+# This test is simply to confirm that nested LCM-generated python messages are
+# code-gen'd correctly, and can be imported at will.  If something isn't
+# working, it will raise an exception during instantiation or construction.
+
+import drake.lcmt_polynomial
+import drake.lcmt_polynomial_matrix
+
+mat = drake.lcmt_polynomial_matrix()
+mat.polynomials.append(drake.lcmt_polynomial())
+mat.encode()

--- a/tools/lcm.bzl
+++ b/tools/lcm.bzl
@@ -22,9 +22,17 @@ def _lcm_outs(lcm_srcs, lcm_package, lcm_structs, extension):
 
     # Assemble the expected output paths, inferring struct names from what we
     # got in lcm_srcs, if necessary.
-    return [
+    struct_outs = [
         dirname + lcm_package + "/" + lcm_struct + extension
         for lcm_struct in (lcm_structs or lcm_basenames)]
+
+    # Some languages have extra metadata.
+    extra_outs = []
+    (extension in [".hpp", ".py", ".java"]) or fail(extension)
+    if extension == ".py":
+        extra_outs.append(dirname + lcm_package + "/__init__.py")
+
+    return struct_outs + extra_outs
 
 def _lcmgen_impl(ctx):
     """The implementation actions to invoke lcm-gen.
@@ -40,22 +48,22 @@ def _lcmgen_impl(ctx):
     # package-name-derived directory name (which we do via slicing off striplen
     # characters), including the '/' right before it (thus the "+ 1" below).
     striplen = len(ctx.attr.lcm_package) + 1
-    for lcm_src, output in zip(ctx.files.lcm_srcs, ctx.outputs.outs):
-        outpath = output.dirname[:-striplen]
-        if ctx.attr.language == "cc":
-            arguments = ["--cpp", "--cpp-std=c++11", "--cpp-hpath=" + outpath]
-        elif ctx.attr.language == "py":
-            arguments = ["--python", "--ppath=" + outpath]
-        elif ctx.attr.language == "java":
-            arguments = ["--java", "--jpath=" + outpath]
-        else:
-            fail("Unknown language")
-        ctx.action(
-            inputs = [lcm_src],
-            outputs = [output],
-            arguments = arguments + [lcm_src.path],
-            executable = ctx.executable.lcmgen,
-            )
+    outpath = ctx.outputs.outs[0].dirname[:-striplen]
+    if ctx.attr.language == "cc":
+        arguments = ["--cpp", "--cpp-std=c++11", "--cpp-hpath=" + outpath]
+    elif ctx.attr.language == "py":
+        arguments = ["--python", "--ppath=" + outpath]
+    elif ctx.attr.language == "java":
+        arguments = ["--java", "--jpath=" + outpath]
+    else:
+        fail("Unknown language")
+    ctx.action(
+        inputs = ctx.files.lcm_srcs,
+        outputs = ctx.outputs.outs,
+        arguments = arguments + [
+            lcm_src.path for lcm_src in ctx.files.lcm_srcs],
+        executable = ctx.executable.lcmgen,
+    )
     return struct()
 
 # Create rule to invoke lcm-gen on some lcm_srcs.
@@ -135,6 +143,9 @@ def lcm_py_library(
     The standard parameters (lcm_srcs, lcm_package, lcm_structs) are documented
     in lcm_cc_library.
 
+    This library has an ${lcm_package}/__init__.py, which means that this macro
+    should only be used once for a given lcm_package in a given subdirectory.
+    (Bazel will fail-fast with a "duplicate file" error if this is violated.)
     """
     if not lcm_srcs:
         fail("lcm_srcs is required")


### PR DESCRIPTION
This is because the `drake/__init__.py` is generated with a shim for each struct, so we need to do the whole lcm_package all at once.

Fixes #5359.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5403)
<!-- Reviewable:end -->
