### PR TITLE
Add more detail to rigid_body_tree BUILD rules

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
@@ -42,6 +42,7 @@ drake_cc_library(
     srcs = ["plan_eval_system.cc"],
     hdrs = ["plan_eval_system.h"],
     deps = [
+        "//drake/common:drake_path",
         "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
         "//drake/examples/QPInverseDynamicsForHumanoids:humanoid_status",
         "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -49,40 +49,134 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "rigid_body_tree",
-    srcs = [
-        "kinematics_cache.cc",
-        "rigid_body.cc",
-        "rigid_body_actuator.cc",
-        "rigid_body_frame.cc",
-        "rigid_body_loop.cc",
-        "rigid_body_tree.cc",
-        "rigid_body_tree_contact.cc",
+    name = "kinematics_cache",
+    srcs = ["kinematics_cache.cc"],
+    hdrs = [
+        "kinematics_cache.h",
+        "kinematics_cache-inl.h",
     ],
+    deps = [
+        "//drake/common",
+        "//drake/common:autodiff",
+        "//drake/multibody/joints",
+    ],
+)
+
+drake_cc_library(
+    name = "rigid_body",
+    srcs = ["rigid_body.cc"],
+    hdrs = ["rigid_body.h"],
+    deps = [
+        "//drake/common",
+        "//drake/common:autodiff",
+        "//drake/multibody/collision",
+        "//drake/multibody/joints",
+        "//drake/util",
+    ],
+)
+
+drake_cc_library(
+    name = "rigid_body_actuator",
+    srcs = ["rigid_body_actuator.cc"],
+    hdrs = ["rigid_body_actuator.h"],
+    deps = [
+        ":rigid_body",
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
+    name = "rigid_body_frame",
+    srcs = ["rigid_body_frame.cc"],
+    hdrs = ["rigid_body_frame.h"],
+    deps = [
+        ":rigid_body",
+        "//drake/common",
+        "//drake/common:autodiff",
+        "//drake/math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
+    name = "rigid_body_loop",
+    srcs = ["rigid_body_loop.cc"],
+    hdrs = ["rigid_body_loop.h"],
+    deps = [
+        ":rigid_body_frame",
+        "//drake/common",
+        "//drake/common:autodiff",
+    ],
+)
+
+drake_cc_library(
+    name = "rigid_body_tree_datatypes",
+    srcs = [],
     hdrs = [
         "force_torque_measurement.h",
         "kinematic_path.h",
-        "kinematics_cache.h",
-        "kinematics_cache-inl.h",
         "material_map.h",
         "pose_map.h",
-        "rigid_body.h",
-        "rigid_body_actuator.h",
-        "rigid_body_frame.h",
-        "rigid_body_loop.h",
-        "rigid_body_tree.h",
     ],
+    visibility = [],
     deps = [
-        "//drake/common:drake_path",
+        "//drake/common",
+    ],
+)
+
+# The rigid_body_tree.h implementation is in two files: rigid_body_tree.cc and
+# rigid_body_tree_contact.cc.  This is the rule for the first file.
+drake_cc_library(
+    name = "rigid_body_tree_cc",
+    srcs = ["rigid_body_tree.cc"],
+    hdrs = ["rigid_body_tree.h"],
+    visibility = [],
+    deps = [
+        ":kinematics_cache",
+        ":rigid_body",
+        ":rigid_body_actuator",
+        ":rigid_body_frame",
+        ":rigid_body_loop",
+        ":rigid_body_tree_datatypes",
+        "//drake/common",
+        "//drake/common:autodiff",
         "//drake/math:geometric_transform",
         "//drake/math:gradient",
         "//drake/multibody/collision",
         "//drake/multibody/joints",
         "//drake/multibody/shapes",
-        "//drake/thirdParty:spruce",
-        "//drake/thirdParty:tinydir",
-        "//drake/thirdParty:tinyxml2",
         "//drake/util",
+    ],
+)
+
+# The rigid_body_tree.h implementation is in two files: rigid_body_tree.cc and
+# rigid_body_tree_contact.cc.  This is the rule for the second file.
+drake_cc_library(
+    name = "rigid_body_tree_contact",
+    srcs = ["rigid_body_tree_contact.cc"],
+    hdrs = ["rigid_body_tree.h"],
+    visibility = [],
+    deps = [
+        ":kinematics_cache",
+        ":rigid_body",
+        ":rigid_body_actuator",
+        ":rigid_body_frame",
+        ":rigid_body_loop",
+        ":rigid_body_tree_datatypes",
+        "//drake/common",
+        "//drake/common:autodiff",
+        "//drake/math:geometric_transform",
+        "//drake/multibody/collision",
+        "//drake/multibody/joints",
+        "//drake/multibody/shapes",
+    ],
+)
+
+# This provides a public label for the whole RigidBodyTree.
+drake_cc_library(
+    name = "rigid_body_tree",
+    deps = [
+        ":rigid_body_tree_cc",
+        ":rigid_body_tree_contact",
     ],
 )
 

--- a/drake/multibody/parsers/BUILD
+++ b/drake/multibody/parsers/BUILD
@@ -30,7 +30,11 @@ drake_cc_library(
         "xml_util.h",
     ],
     deps = [
+        "//drake/common:drake_path",
         "//drake/multibody:rigid_body_tree",
+        "//drake/thirdParty:spruce",
+        "//drake/thirdParty:tinydir",
+        "//drake/thirdParty:tinyxml2",
     ],
 )
 

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -136,6 +136,7 @@ drake_cc_googletest(
     data = ["//drake/multibody/collision:test_models"],
     deps = [
         ":drake_visualizer",
+        "//drake/common:drake_path",
         "//drake/lcm:mock",
         "//drake/systems/analysis",
     ],

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -193,6 +193,7 @@ drake_cc_googletest(
     srcs = ["test/depth_sensor_test.cc"],
     deps = [
         ":depth_sensor",
+        "//drake/common:drake_path",
         "//drake/common:eigen_matrix_compare",
     ],
 )

--- a/drake/util/BUILD
+++ b/drake/util/BUILD
@@ -16,7 +16,6 @@ drake_cc_library(
         "drakeGeometryUtil.h",
         "drakeUtil.h",
     ],
-    deprecation = "Consider pitching in by porting the dependencies you need to //drake/math.",
     deps = [
         "//drake/common",
         "//drake/math:geometric_transform",


### PR DESCRIPTION
Add more detail to rigid_body_tree BUILD rules.  This is the first step in shaving minutes off of the latency of the automotive build.

Also:
- Remove noisy warning.
- Add missing dependencies to downstream targets now that RBT is shaved a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5413)
<!-- Reviewable:end -->
