### PR TITLE
added some constants to schunk wsg gripper.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/BUILD
+++ b/drake/examples/kuka_iiwa_arm/BUILD
@@ -93,6 +93,7 @@ drake_cc_binary(
         ":iiwa_lcm",
         ":oracular_state_estimator",
         "//drake/examples/kuka_iiwa_arm/iiwa_world:world_sim_tree_builder",
+        "//drake/examples/schunk_wsg:schunk_wsg_constants",
         "//drake/examples/schunk_wsg:schunk_wsg_lcm",
         "//drake/lcm",
         "//drake/multibody/rigid_body_plant",

--- a/drake/examples/schunk_wsg/BUILD
+++ b/drake/examples/schunk_wsg/BUILD
@@ -10,6 +10,15 @@ load(
 )
 
 drake_cc_library(
+    name = "schunk_wsg_constants",
+    hdrs = ["schunk_wsg_constants.h"],
+    visibility = ["//drake/examples/kuka_iiwa_arm:__subpackages__"],
+    deps = [
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
     name = "schunk_wsg_trajectory_generator_state_vector",
     srcs = ["gen/schunk_wsg_trajectory_generator_state_vector.cc"],
     hdrs = ["gen/schunk_wsg_trajectory_generator_state_vector.h"],
@@ -50,6 +59,7 @@ drake_cc_binary(
     data = [":models"],
     test_rule_args = ["--simulation_sec=0.1"],
     deps = [
+        ":schunk_wsg_constants",
         ":schunk_wsg_lcm",
         ":simulated_schunk_wsg_system",
         "//drake/lcm",
@@ -68,6 +78,20 @@ drake_cc_binary(
 )
 
 # === test/ ===
+
+drake_cc_googletest(
+    name = "schunk_wsg_constants_test",
+    data = [
+        ":models",
+    ],
+    deps = [
+        ":schunk_wsg_constants",
+        "//drake/common:drake_path",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/parsers",
+    ],
+)
 
 drake_cc_googletest(
     name = "schunk_wsg_lift_test",

--- a/drake/examples/schunk_wsg/schunk_wsg_constants.h
+++ b/drake/examples/schunk_wsg/schunk_wsg_constants.h
@@ -1,0 +1,45 @@
+/**
+ * @file
+ *
+ * Constants defined in this file are for the Schunk WSG gripper modeled in
+ * models/schunk_wsg_50.sdf. Although the gripper only has one actuator, the
+ * model has a number of constrained linkages to mimic two fingers moving
+ * in a coordinated manner. This results in more states than actuators, and
+ * a need for a selection matrix for state feedback control.
+ */
+
+#pragma once
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace examples {
+namespace schunk_wsg {
+
+constexpr int kSchunkWsgNumActuators = 1;
+constexpr int kSchunkWsgNumPositions = 5;
+constexpr int kSchunkWsgNumVelocities = 5;
+
+constexpr int kSchunkWsgPositionIndex = 0;
+constexpr int kSchunkWsgVelocityIndex =
+    kSchunkWsgNumPositions + kSchunkWsgPositionIndex;
+
+/**
+ * Returns the selection matrix that selects the position and velocity indices
+ * that correspond to the `left_finger_sliding_joint` in the model. The
+ * returned matrix projects the full state to two dimensions (position and
+ * velocity).
+ */
+template <typename T>
+MatrixX<T> GetSchunkWsgFeedbackSelector() {
+  MatrixX<T> selector =
+      MatrixX<T>::Zero(2 * kSchunkWsgNumActuators,
+                       kSchunkWsgNumPositions + kSchunkWsgNumVelocities);
+  selector(0, kSchunkWsgPositionIndex) = 1;
+  selector(1, kSchunkWsgVelocityIndex) = 1;
+  return selector;
+}
+
+}  // namespace schunk_wsg
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/schunk_wsg/schunk_wsg_simulation.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_simulation.cc
@@ -12,6 +12,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/examples/schunk_wsg/schunk_wsg_constants.h"
 #include "drake/examples/schunk_wsg/schunk_wsg_lcm.h"
 #include "drake/examples/schunk_wsg/simulated_schunk_wsg_system.h"
 #include "drake/lcm/drake_lcm.h"
@@ -67,20 +68,7 @@ class PidControlledSchunkWsg : public systems::Diagram<T> {
     auto zero_source = builder.template AddSystem<ConstantVectorSource<T>>(
         Eigen::VectorXd::Zero(1));
 
-    const RigidBodyTree<T>& tree = plant->get_rigid_body_tree();
-    const std::map<std::string, int> index_map =
-        tree.computePositionNameToIndexMap();
-    const int left_finger_position_index =
-        index_map.at("left_finger_sliding_joint");
-    position_index_ = left_finger_position_index;
-    velocity_index_ = left_finger_position_index +
-        plant->get_num_positions();
-
-    Eigen::MatrixXd feedback_matrix = Eigen::MatrixXd::Zero(
-        2 * plant->get_num_actuators(),
-        2 * plant->get_num_positions());
-    feedback_matrix(0, position_index_) = 1.;
-    feedback_matrix(1, velocity_index_) = 1.;
+    const Eigen::MatrixXd feedback_matrix = GetSchunkWsgFeedbackSelector<T>();
     std::unique_ptr<MatrixGain<T>> feedback_selector =
         std::make_unique<MatrixGain<T>>(feedback_matrix);
 

--- a/drake/examples/schunk_wsg/test/CMakeLists.txt
+++ b/drake/examples/schunk_wsg/test/CMakeLists.txt
@@ -22,3 +22,8 @@ if(lcm_FOUND)
     drakeSystemControllers
     drakeSystemPrimitives)
 endif()
+
+drake_add_cc_test(schunk_wsg_constants_test)
+target_link_libraries(schunk_wsg_constants_test
+    drakeMultibodyParsers
+    drakeRBM)

--- a/drake/examples/schunk_wsg/test/schunk_wsg_constants_test.cc
+++ b/drake/examples/schunk_wsg/test/schunk_wsg_constants_test.cc
@@ -1,0 +1,50 @@
+#include "drake/examples/schunk_wsg/schunk_wsg_constants.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/multibody/parsers/sdf_parser.h"
+#include "drake/multibody/rigid_body_tree.h"
+
+namespace drake {
+namespace examples {
+namespace schunk_wsg {
+namespace {
+
+// Test that the constants defined in schunk_wsg_constants.h are
+// correct wrt `models/schunk_wsg_50.sdf`.
+GTEST_TEST(SchunkWsgConstantTest, ConstantTest) {
+  RigidBodyTree<double> wsg;
+  parsers::sdf::AddModelInstancesFromSdfFile(
+      GetDrakePath() + "/examples/schunk_wsg/models/schunk_wsg_50.sdf",
+      multibody::joints::kFixed, nullptr, &wsg);
+
+  const std::map<std::string, int> index_map =
+      wsg.computePositionNameToIndexMap();
+
+  const int position_index = index_map.at("left_finger_sliding_joint");
+
+  const int velocity_index = position_index + wsg.get_num_positions();
+
+  EXPECT_EQ(wsg.get_num_positions(), kSchunkWsgNumPositions);
+  EXPECT_EQ(wsg.get_num_velocities(), kSchunkWsgNumVelocities);
+  EXPECT_EQ(wsg.get_num_actuators(), kSchunkWsgNumActuators);
+
+  EXPECT_EQ(position_index, kSchunkWsgPositionIndex);
+  EXPECT_EQ(velocity_index, kSchunkWsgVelocityIndex);
+
+  MatrixX<double> feedback_matrix = MatrixX<double>::Zero(
+      2 * wsg.get_num_actuators(), 2 * wsg.get_num_positions());
+  feedback_matrix(0, position_index) = 1.;
+  feedback_matrix(1, velocity_index) = 1.;
+
+  EXPECT_TRUE(drake::CompareMatrices(
+      feedback_matrix, GetSchunkWsgFeedbackSelector<double>(), 1e-15,
+      drake::MatrixCompareType::absolute));
+}
+
+}  // namespace
+}  // namespace schunk_wsg
+}  // namespace examples
+}  // namespace drake


### PR DESCRIPTION
added position / velocity index constants and a helper function to return the selection matrix for the schunk wsg gripper.

useful for creating a wsg gripper controller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5418)
<!-- Reviewable:end -->
