### PR TITLE
Adds a Maliput Railcar Model.

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -22,6 +22,8 @@ drake_cc_library(
         "gen/endless_road_oracle_output.cc",
         "gen/euler_floating_joint_state.cc",
         "gen/idm_planner_parameters.cc",
+        "gen/maliput_railcar_config.cc",
+        "gen/maliput_railcar_state.cc",
         "gen/simple_car_config.cc",
         "gen/simple_car_state.cc",
     ],
@@ -34,6 +36,8 @@ drake_cc_library(
         "gen/endless_road_oracle_output.h",
         "gen/euler_floating_joint_state.h",
         "gen/idm_planner_parameters.h",
+        "gen/maliput_railcar_config.h",
+        "gen/maliput_railcar_state.h",
         "gen/simple_car_config.h",
         "gen/simple_car_state.h",
     ],
@@ -52,6 +56,8 @@ drake_cc_library(
         "gen/endless_road_car_state_translator.cc",
         "gen/endless_road_oracle_output_translator.cc",
         "gen/euler_floating_joint_state_translator.cc",
+        "gen/maliput_railcar_config_translator.cc",
+        "gen/maliput_railcar_state_translator.cc",
         "gen/simple_car_config_translator.cc",
         "gen/simple_car_state_translator.cc",
     ],
@@ -63,6 +69,8 @@ drake_cc_library(
         "gen/endless_road_car_state_translator.h",
         "gen/endless_road_oracle_output_translator.h",
         "gen/euler_floating_joint_state_translator.h",
+        "gen/maliput_railcar_config_translator.h",
+        "gen/maliput_railcar_state_translator.h",
         "gen/simple_car_config_translator.h",
         "gen/simple_car_state_translator.h",
     ],
@@ -136,6 +144,17 @@ drake_cc_library(
     deps = [
         ":generated_vectors",
         "//drake/common:symbolic",
+    ],
+)
+
+drake_cc_library(
+    name = "maliput_railcar",
+    srcs = ["maliput_railcar.cc"],
+    hdrs = ["maliput_railcar.h",],
+    deps = [
+        ":generated_vectors",
+        "//drake/automotive/maliput/api",
+        "//drake/systems/rendering:pose_vector",
     ],
 )
 
@@ -507,6 +526,22 @@ drake_cc_googletest(
     deps = [
         "//drake/automotive:endless_road_car",
         "//drake/automotive/maliput/monolane:builder",
+    ],
+)
+
+drake_cc_googletest(
+    name = "maliput_railcar_test",
+    data = [
+        ":test/flat_curved_lane.yaml",
+    ],
+    deps = [
+        "//drake/automotive:maliput_railcar",
+        "//drake/automotive/maliput/api",
+        "//drake/automotive/maliput/dragway",
+        "//drake/automotive/maliput/monolane",
+        "//drake/common:drake_path",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/math:geometric_transform",
     ],
 )
 

--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
   gen/endless_road_oracle_output.cc
   gen/euler_floating_joint_state.cc
   gen/idm_planner_parameters.cc
+  gen/maliput_railcar_config.cc
+  gen/maliput_railcar_state.cc
   gen/simple_car_config.cc
   gen/simple_car_state.cc
   idm_planner.cc
@@ -37,6 +39,7 @@ add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
   maliput/monolane/segment.cc
   maliput/utility/generate_obj.cc
   maliput/utility/generate_urdf.cc
+  maliput_railcar.cc
   monolane_onramp_merge.cc
   simple_car.cc
   simple_powertrain.cc
@@ -59,6 +62,7 @@ drake_install_headers(
   curve2.h
   idm_planner.h
   linear_car.h
+  maliput_railcar.h
   monolane_onramp_merge.h
   simple_car.h
   simple_car_to_euler_floating_joint.h
@@ -91,6 +95,8 @@ if(lcm_FOUND)
     gen/endless_road_car_state_translator.cc
     gen/endless_road_oracle_output_translator.cc
     gen/euler_floating_joint_state_translator.cc
+    gen/maliput_railcar_config_translator.cc
+    gen/maliput_railcar_state_translator.cc
     gen/simple_car_config_translator.cc
     gen/simple_car_state_translator.cc
     )

--- a/drake/automotive/gen/CMakeLists.txt
+++ b/drake/automotive/gen/CMakeLists.txt
@@ -13,6 +13,10 @@ if(lcm_FOUND)
     euler_floating_joint_state.h
     euler_floating_joint_state_translator.h
     idm_planner_parameters.h
+    maliput_railcar_config.h
+    maliput_railcar_config_translator.h
+    maliput_railcar_state.h
+    maliput_railcar_state_translator.h
     simple_car_config.h
     simple_car_config_translator.h
     simple_car_state.h

--- a/drake/automotive/gen/maliput_railcar_config.cc
+++ b/drake/automotive/gen/maliput_railcar_config.cc
@@ -1,0 +1,15 @@
+#include "drake/automotive/gen/maliput_railcar_config.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace drake {
+namespace automotive {
+
+const int MaliputRailcarConfigIndices::kNumCoordinates;
+const int MaliputRailcarConfigIndices::kR;
+const int MaliputRailcarConfigIndices::kH;
+const int MaliputRailcarConfigIndices::kInitialSpeed;
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_config.h
+++ b/drake/automotive/gen/maliput_railcar_config.h
@@ -1,0 +1,73 @@
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+#include <Eigen/Core>
+
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace automotive {
+
+/// Describes the row indices of a MaliputRailcarConfig.
+struct MaliputRailcarConfigIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 3;
+
+  // The index of each individual coordinate.
+  static const int kR = 0;
+  static const int kH = 1;
+  static const int kInitialSpeed = 2;
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class MaliputRailcarConfig : public systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef MaliputRailcarConfigIndices K;
+
+  /// Default constructor.  Sets all rows to zero.
+  MaliputRailcarConfig() : systems::BasicVector<T>(K::kNumCoordinates) {
+    this->SetFromVector(VectorX<T>::Zero(K::kNumCoordinates));
+  }
+
+  MaliputRailcarConfig<T>* DoClone() const override {
+    auto result = new MaliputRailcarConfig;
+    result->set_value(this->get_value());
+    return result;
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// The vehicle's position on the lane's r-axis.
+  const T& r() const { return this->GetAtIndex(K::kR); }
+  void set_r(const T& r) { this->SetAtIndex(K::kR, r); }
+  /// The vehicle's height above the lane's surface.
+  const T& h() const { return this->GetAtIndex(K::kH); }
+  void set_h(const T& h) { this->SetAtIndex(K::kH, h); }
+  /// The vehicle's initial speed along the lane's s-axis.
+  const T& initial_speed() const { return this->GetAtIndex(K::kInitialSpeed); }
+  void set_initial_speed(const T& initial_speed) {
+    this->SetAtIndex(K::kInitialSpeed, initial_speed);
+  }
+  //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(r());
+    result = result && !isnan(h());
+    result = result && !isnan(initial_speed());
+    return result;
+  }
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_config_translator.cc
+++ b/drake/automotive/gen/maliput_railcar_config_translator.cc
@@ -1,0 +1,54 @@
+#include "drake/automotive/gen/maliput_railcar_config_translator.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <stdexcept>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace automotive {
+
+std::unique_ptr<systems::BasicVector<double>>
+MaliputRailcarConfigTranslator::AllocateOutputVector() const {
+  return std::make_unique<MaliputRailcarConfig<double>>();
+}
+
+void MaliputRailcarConfigTranslator::Serialize(
+    double time, const systems::VectorBase<double>& vector_base,
+    std::vector<uint8_t>* lcm_message_bytes) const {
+  const auto* const vector =
+      dynamic_cast<const MaliputRailcarConfig<double>*>(&vector_base);
+  DRAKE_DEMAND(vector != nullptr);
+  drake::lcmt_maliput_railcar_config_t message;
+  message.timestamp = static_cast<int64_t>(time * 1000);
+  message.r = vector->r();
+  message.h = vector->h();
+  message.initial_speed = vector->initial_speed();
+  const int lcm_message_length = message.getEncodedSize();
+  lcm_message_bytes->resize(lcm_message_length);
+  message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
+}
+
+void MaliputRailcarConfigTranslator::Deserialize(
+    const void* lcm_message_bytes, int lcm_message_length,
+    systems::VectorBase<double>* vector_base) const {
+  DRAKE_DEMAND(vector_base != nullptr);
+  auto* const my_vector =
+      dynamic_cast<MaliputRailcarConfig<double>*>(vector_base);
+  DRAKE_DEMAND(my_vector != nullptr);
+
+  drake::lcmt_maliput_railcar_config_t message;
+  int status = message.decode(lcm_message_bytes, 0, lcm_message_length);
+  if (status < 0) {
+    throw std::runtime_error(
+        "Failed to decode LCM message maliput_railcar_config.");
+  }
+  my_vector->set_r(message.r);
+  my_vector->set_h(message.h);
+  my_vector->set_initial_speed(message.initial_speed);
+}
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_config_translator.h
+++ b/drake/automotive/gen/maliput_railcar_config_translator.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <memory>
+#include <vector>
+
+#include "drake/automotive/gen/maliput_railcar_config.h"
+#include "drake/lcmt_maliput_railcar_config_t.hpp"
+#include "drake/systems/lcm/lcm_and_vector_base_translator.h"
+
+namespace drake {
+namespace automotive {
+
+/**
+ * Translates between LCM message objects and VectorBase objects for the
+ * MaliputRailcarConfig type.
+ */
+class MaliputRailcarConfigTranslator
+    : public systems::lcm::LcmAndVectorBaseTranslator {
+ public:
+  MaliputRailcarConfigTranslator()
+      : LcmAndVectorBaseTranslator(
+            MaliputRailcarConfigIndices::kNumCoordinates) {}
+  std::unique_ptr<systems::BasicVector<double>> AllocateOutputVector()
+      const override;
+  void Deserialize(const void* lcm_message_bytes, int lcm_message_length,
+                   systems::VectorBase<double>* vector_base) const override;
+  void Serialize(double time, const systems::VectorBase<double>& vector_base,
+                 std::vector<uint8_t>* lcm_message_bytes) const override;
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_state.cc
+++ b/drake/automotive/gen/maliput_railcar_state.cc
@@ -1,0 +1,14 @@
+#include "drake/automotive/gen/maliput_railcar_state.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace drake {
+namespace automotive {
+
+const int MaliputRailcarStateIndices::kNumCoordinates;
+const int MaliputRailcarStateIndices::kS;
+const int MaliputRailcarStateIndices::kSDot;
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_state.h
+++ b/drake/automotive/gen/maliput_railcar_state.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+#include <Eigen/Core>
+
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace automotive {
+
+/// Describes the row indices of a MaliputRailcarState.
+struct MaliputRailcarStateIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 2;
+
+  // The index of each individual coordinate.
+  static const int kS = 0;
+  static const int kSDot = 1;
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class MaliputRailcarState : public systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef MaliputRailcarStateIndices K;
+
+  /// Default constructor.  Sets all rows to zero.
+  MaliputRailcarState() : systems::BasicVector<T>(K::kNumCoordinates) {
+    this->SetFromVector(VectorX<T>::Zero(K::kNumCoordinates));
+  }
+
+  MaliputRailcarState<T>* DoClone() const override {
+    auto result = new MaliputRailcarState;
+    result->set_value(this->get_value());
+    return result;
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// The position along the lane's s-axis.
+  const T& s() const { return this->GetAtIndex(K::kS); }
+  void set_s(const T& s) { this->SetAtIndex(K::kS, s); }
+  /// The speed along the lane's s-axis.
+  const T& s_dot() const { return this->GetAtIndex(K::kSDot); }
+  void set_s_dot(const T& s_dot) { this->SetAtIndex(K::kSDot, s_dot); }
+  //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(s());
+    result = result && !isnan(s_dot());
+    return result;
+  }
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_state_translator.cc
+++ b/drake/automotive/gen/maliput_railcar_state_translator.cc
@@ -1,0 +1,52 @@
+#include "drake/automotive/gen/maliput_railcar_state_translator.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <stdexcept>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace automotive {
+
+std::unique_ptr<systems::BasicVector<double>>
+MaliputRailcarStateTranslator::AllocateOutputVector() const {
+  return std::make_unique<MaliputRailcarState<double>>();
+}
+
+void MaliputRailcarStateTranslator::Serialize(
+    double time, const systems::VectorBase<double>& vector_base,
+    std::vector<uint8_t>* lcm_message_bytes) const {
+  const auto* const vector =
+      dynamic_cast<const MaliputRailcarState<double>*>(&vector_base);
+  DRAKE_DEMAND(vector != nullptr);
+  drake::lcmt_maliput_railcar_state_t message;
+  message.timestamp = static_cast<int64_t>(time * 1000);
+  message.s = vector->s();
+  message.s_dot = vector->s_dot();
+  const int lcm_message_length = message.getEncodedSize();
+  lcm_message_bytes->resize(lcm_message_length);
+  message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
+}
+
+void MaliputRailcarStateTranslator::Deserialize(
+    const void* lcm_message_bytes, int lcm_message_length,
+    systems::VectorBase<double>* vector_base) const {
+  DRAKE_DEMAND(vector_base != nullptr);
+  auto* const my_vector =
+      dynamic_cast<MaliputRailcarState<double>*>(vector_base);
+  DRAKE_DEMAND(my_vector != nullptr);
+
+  drake::lcmt_maliput_railcar_state_t message;
+  int status = message.decode(lcm_message_bytes, 0, lcm_message_length);
+  if (status < 0) {
+    throw std::runtime_error(
+        "Failed to decode LCM message maliput_railcar_state.");
+  }
+  my_vector->set_s(message.s);
+  my_vector->set_s_dot(message.s_dot);
+}
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_state_translator.h
+++ b/drake/automotive/gen/maliput_railcar_state_translator.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <memory>
+#include <vector>
+
+#include "drake/automotive/gen/maliput_railcar_state.h"
+#include "drake/lcmt_maliput_railcar_state_t.hpp"
+#include "drake/systems/lcm/lcm_and_vector_base_translator.h"
+
+namespace drake {
+namespace automotive {
+
+/**
+ * Translates between LCM message objects and VectorBase objects for the
+ * MaliputRailcarState type.
+ */
+class MaliputRailcarStateTranslator
+    : public systems::lcm::LcmAndVectorBaseTranslator {
+ public:
+  MaliputRailcarStateTranslator()
+      : LcmAndVectorBaseTranslator(
+            MaliputRailcarStateIndices::kNumCoordinates) {}
+  std::unique_ptr<systems::BasicVector<double>> AllocateOutputVector()
+      const override;
+  void Deserialize(const void* lcm_message_bytes, int lcm_message_length,
+                   systems::VectorBase<double>* vector_base) const override;
+  void Serialize(double time, const systems::VectorBase<double>& vector_base,
+                 std::vector<uint8_t>* lcm_message_bytes) const override;
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -1,0 +1,197 @@
+#include "drake/automotive/maliput_railcar.h"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+#include <Eigen/Geometry>
+
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/common/drake_assert.h"
+#include "drake/math/roll_pitch_yaw_not_using_quaternion.h"
+#include "drake/systems/framework/vector_base.h"
+
+namespace drake {
+
+using maliput::api::GeoPosition;
+using maliput::api::IsoLaneVelocity;
+using maliput::api::Lane;
+using maliput::api::LanePosition;
+using maliput::api::Rotation;
+using systems::rendering::PoseVector;
+
+namespace automotive {
+
+// Linkage for MaliputRailcar constants.
+template <typename T> constexpr double MaliputRailcar<T>::kDefaultR;
+template <typename T> constexpr double MaliputRailcar<T>::kDefaultH;
+template <typename T> constexpr double MaliputRailcar<T>::kDefaultSpeed;
+
+template <typename T>
+MaliputRailcar<T>::MaliputRailcar(const Lane& lane, double start_time)
+    : lane_(lane), start_time_(start_time) {
+  state_output_port_index_ =
+      this->DeclareOutputPort(systems::kVectorValued,
+          MaliputRailcarStateIndices::kNumCoordinates).get_index();
+  pose_output_port_index_ =
+      this->DeclareOutputPort(systems::kVectorValued,
+          PoseVector<T>::kSize).get_index();
+}
+
+template <typename T>
+const systems::OutputPortDescriptor<T>& MaliputRailcar<T>::state_output()
+    const {
+  return this->get_output_port(state_output_port_index_);
+}
+
+template <typename T>
+const systems::OutputPortDescriptor<T>& MaliputRailcar<T>::pose_output()
+    const {
+  return this->get_output_port(pose_output_port_index_);
+}
+
+template <typename T>
+void MaliputRailcar<T>::DoCalcOutput(const systems::Context<T>& context,
+    systems::SystemOutput<T>* output) const {
+  // Obtains the parameters.
+  const MaliputRailcarConfig<T>& config =
+      this->template GetNumericParameter<MaliputRailcarConfig>(context, 0);
+
+  // Obtains the state.
+  const MaliputRailcarState<T>* const state =
+      dynamic_cast<const MaliputRailcarState<T>*>(
+          &context.get_continuous_state_vector());
+  DRAKE_ASSERT(state != nullptr);
+
+  // Obtains the output vectors.
+  MaliputRailcarState<T>* const state_vector =
+      dynamic_cast<MaliputRailcarState<T>*>(
+          output->GetMutableVectorData(state_output_port_index_));
+  DRAKE_ASSERT(state_vector != nullptr);
+
+  ImplCalcOutput(*state, state_vector);
+
+  PoseVector<T>* const pose_vector =
+      dynamic_cast<PoseVector<T>*>(
+          output->GetMutableVectorData(pose_output_port_index_));
+  DRAKE_ASSERT(pose_vector != nullptr);
+
+  ImplCalcPose(config, *state, pose_vector);
+}
+
+template <typename T>
+void MaliputRailcar<T>::ImplCalcOutput(const MaliputRailcarState<T>& state,
+    MaliputRailcarState<T>* output) const {
+  output->set_value(state.get_value());
+}
+
+template <typename T>
+void MaliputRailcar<T>::ImplCalcPose(const MaliputRailcarConfig<T>& config,
+    const MaliputRailcarState<T>& state, PoseVector<T>* pose) const {
+  const LanePosition lane_position(state.s(), config.r(), config.h());
+  const GeoPosition geo_position = lane_.ToGeoPosition(lane_position);
+  const Rotation rotation = lane_.GetOrientation(lane_position);
+
+  pose->set_translation(
+      Eigen::Translation<T, 3>(geo_position.x, geo_position.y, geo_position.z));
+
+  const Vector4<T> quaternion =
+      math::rpy2quat(Vector3<T>(rotation.roll, rotation.pitch, rotation.yaw));
+  pose->set_rotation(Eigen::Quaternion<T>(
+      quaternion(0), quaternion(1), quaternion(2), quaternion(3)));
+}
+
+template <typename T>
+void MaliputRailcar<T>::DoCalcTimeDerivatives(
+    const systems::Context<T>& context,
+    systems::ContinuousState<T>* derivatives) const {
+  DRAKE_ASSERT(derivatives != nullptr);
+
+  // Obtains the parameters.
+  const MaliputRailcarConfig<T>& config =
+      this->template GetNumericParameter<MaliputRailcarConfig>(context, 0);
+
+  // Obtains the state.
+  const systems::VectorBase<T>& context_state =
+      context.get_continuous_state_vector();
+  const MaliputRailcarState<T>* const state =
+      dynamic_cast<const MaliputRailcarState<T>*>(&context_state);
+  DRAKE_ASSERT(state != nullptr);
+
+  // Obtains the result structure.
+  systems::VectorBase<T>* const vector_derivatives =
+      derivatives->get_mutable_vector();
+  DRAKE_ASSERT(vector_derivatives);
+  MaliputRailcarState<T>* const rates =
+      dynamic_cast<MaliputRailcarState<T>*>(vector_derivatives);
+  DRAKE_ASSERT(rates != nullptr);
+
+  ImplCalcTimeDerivatives(config, *state, rates);
+}
+
+template<typename T>
+void MaliputRailcar<T>::ImplCalcTimeDerivatives(
+    const MaliputRailcarConfig<T>& config,
+    const MaliputRailcarState<T>& state,
+    MaliputRailcarState<T>* rates) const {
+  const T speed = config.initial_speed();
+  if (state.s() < 0 || state.s() >= lane_.length()) {
+    rates->set_s(0);
+  } else {
+    rates->set_s(speed);
+  }
+  // TODO(liang.fok): Set this to the desired acceleration once it is an input
+  // into this system.
+  rates->set_s_dot(0);
+}
+
+template <typename T>
+std::unique_ptr<systems::ContinuousState<T>>
+MaliputRailcar<T>::AllocateContinuousState() const {
+  return std::make_unique<systems::ContinuousState<T>>(
+      std::make_unique<MaliputRailcarState<T>>());
+}
+
+template <typename T>
+std::unique_ptr<systems::BasicVector<T>>
+MaliputRailcar<T>::AllocateOutputVector(
+    const systems::OutputPortDescriptor<T>& descriptor) const {
+  DRAKE_DEMAND(descriptor.get_index() <= 1);
+  if (descriptor.get_index() == state_output_port_index_) {
+    return std::make_unique<MaliputRailcarState<T>>();
+  } else if (descriptor.get_index() == pose_output_port_index_) {
+    return std::make_unique<PoseVector<T>>();
+  }
+  return nullptr;
+}
+
+template <typename T>
+std::unique_ptr<systems::Parameters<T>>
+MaliputRailcar<T>::AllocateParameters() const {
+  auto params = std::make_unique<MaliputRailcarConfig<T>>();
+  return std::make_unique<systems::Parameters<T>>(std::move(params));
+}
+
+template <typename T>
+void MaliputRailcar<T>::SetDefaultParameters(
+    const systems::LeafContext<T>& context,
+    systems::Parameters<T>* params) const {
+  MaliputRailcarConfig<T>* config = dynamic_cast<MaliputRailcarConfig<T>*>(
+      params->get_mutable_numeric_parameter(0));
+  DRAKE_DEMAND(config != nullptr);
+  SetDefaultParameters(config);
+}
+
+template <typename T>
+void MaliputRailcar<T>::SetDefaultParameters(MaliputRailcarConfig<T>* config) {
+  DRAKE_DEMAND(config != nullptr);
+  config->set_r(kDefaultR);
+  config->set_h(kDefaultH);
+  config->set_initial_speed(kDefaultSpeed);
+}
+
+// This section must match the API documentation in maliput_railcar.h.
+template class MaliputRailcar<double>;
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/automotive/gen/maliput_railcar_config.h"
+#include "drake/automotive/gen/maliput_railcar_state.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/rendering/pose_vector.h"
+
+namespace drake {
+namespace automotive {
+
+/// MaliputRailcar -- models a vehicle that follows a maliput::api::Lane as if
+/// it were on rails and neglecting all physics. It can only move forward at a
+/// predetermined speed.
+///
+/// Configuration (for more details, see MaliputRailcarConfig):
+///   * A `const` reference to a maliput::api::Lane that it should follow.
+///   * An `h` height above the lane's surface.
+///   * An `r` offset from the lane's `s` axis.
+///   * An `initial_speed` at which the vehicle should initially move.
+///
+/// State vector (for more details, see MaliputRailcarState):
+///   * position: `s`
+///   * speed: `s_dot`
+///
+/// <B>Input Port Accessors:</B>
+///
+///   - None.
+///
+/// <B>Output Port Accessors:</B>
+///
+///   - state_output(): Contains this system's state vector. See
+///     MaliputRailcarState.
+///
+///   - pose_output(): Contains PoseVector `X_WC`, where `C` is the car frame
+///     and `W` is the world frame.
+///
+/// @tparam T must support certain arithmetic operations;
+/// for details, see drake::symbolic::Expression.
+///
+/// Instantiated templates for the following ScalarTypes are provided:
+/// - double
+///
+/// They are already available to link against in the containing library.
+///
+/// @ingroup automotive_systems
+template <typename T>
+class MaliputRailcar : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MaliputRailcar)
+
+  /// The constructor.
+  ///
+  /// @param lane The lane on which this MaliputRailcar travels. The lifetime
+  /// of this parameter must exceed that of this class's instance.
+  ///
+  /// @param start_time The time at which this vehicle starts moving.
+  ///
+  explicit MaliputRailcar(const maliput::api::Lane& lane,
+                          double start_time = 0);
+
+  // System<T> overrides.
+  void DoCalcOutput(const systems::Context<T>& context,
+                    systems::SystemOutput<T>* output) const override;
+  void DoCalcTimeDerivatives(
+      const systems::Context<T>& context,
+      systems::ContinuousState<T>* derivatives) const override;
+
+  // LeafSystem<T> overrides.
+  void SetDefaultParameters(const systems::LeafContext<T>& context,
+                            systems::Parameters<T>* params) const override;
+
+  /// Sets `config` to contain the default parameters for MaliputRailcar.
+  static void SetDefaultParameters(MaliputRailcarConfig<T>* config);
+
+  /// Getter methods for output port descriptors.
+  /// @{
+  const systems::OutputPortDescriptor<T>& state_output() const;
+  const systems::OutputPortDescriptor<T>& pose_output() const;
+  /// @}
+
+  static constexpr double kDefaultR = 0;      // meters
+  static constexpr double kDefaultH = 0;      // meters
+  static constexpr double kDefaultSpeed = 1;  // meters / second
+
+ protected:
+  // LeafSystem<T> overrides.
+  std::unique_ptr<systems::ContinuousState<T>> AllocateContinuousState()
+      const override;
+  std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
+      const systems::OutputPortDescriptor<T>& descriptor) const override;
+  std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
+
+ private:
+  void ImplCalcOutput(
+      const MaliputRailcarState<T>& state,
+      MaliputRailcarState<T>* output) const;
+
+  void ImplCalcPose(
+      const MaliputRailcarConfig<T>& config,
+      const MaliputRailcarState<T>& state,
+      systems::rendering::PoseVector<T>* pose) const;
+
+  void ImplCalcTimeDerivatives(
+      const MaliputRailcarConfig<T>& config,
+      const MaliputRailcarState<T>& state,
+      MaliputRailcarState<T>* rates) const;
+
+  void ImplCalcTimeDerivativesDouble(
+    const MaliputRailcarConfig<double>& config,
+    const MaliputRailcarState<double>& state,
+    MaliputRailcarState<double>* rates) const;
+
+  const maliput::api::Lane& lane_;
+  const double start_time_{};
+  int state_output_port_index_{};
+  int pose_output_port_index_{};
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/maliput_railcar_config.named_vector
+++ b/drake/automotive/maliput_railcar_config.named_vector
@@ -1,0 +1,12 @@
+element {
+    name: "r"
+    doc: "The vehicle's position on the lane's r-axis."
+}
+element {
+    name: "h"
+    doc: "The vehicle's height above the lane's surface."
+}
+element {
+    name: "initial_speed"
+    doc: "The vehicle's initial speed along the lane's s-axis."
+}

--- a/drake/automotive/maliput_railcar_state.named_vector
+++ b/drake/automotive/maliput_railcar_state.named_vector
@@ -1,0 +1,8 @@
+element {
+    name: "s"
+    doc: "The position along the lane's s-axis."
+}
+element {
+    name: "s_dot"
+    doc: "The speed along the lane's s-axis."
+}

--- a/drake/automotive/simple_car_gen.sh
+++ b/drake/automotive/simple_car_gen.sh
@@ -19,5 +19,7 @@ gen_lcm_and_vector_from_proto "endless road car state" $drake/automotive/dev/end
 gen_lcm_and_vector_from_proto "endless road oracle output" $drake/automotive/dev/endless_road_oracle_output.named_vector
 gen_lcm_and_vector_from_proto "euler floating joint state" $drake/automotive/euler_floating_joint_state.named_vector
 gen_vector_proto "idm planner parameters" $drake/automotive/idm_planner_parameters.named_vector
+gen_lcm_and_vector_from_proto "maliput railcar state" $drake/automotive/maliput_railcar_state.named_vector
+gen_lcm_and_vector_from_proto "maliput railcar config" $drake/automotive/maliput_railcar_config.named_vector
 gen_lcm_and_vector_from_proto "simple car state" $drake/automotive/simple_car_state.named_vector
 gen_lcm_and_vector_from_proto "simple car config" $drake/automotive/simple_car_config.named_vector

--- a/drake/automotive/test/flat_curved_lane.yaml
+++ b/drake/automotive/test/flat_curved_lane.yaml
@@ -1,0 +1,30 @@
+# -*- yaml -*-
+---
+# Implements a flat but curved lane. The lane is 4 m wide with 2 m shoulders. It
+# starts at the world origin with its +s axis coincident with the world's +X
+# axis. It immediately curves to the left (+Y direction) by 90 degrees with a
+# turning radius of 10 m.
+#
+# Distances are meters; angles are degrees.
+#
+# The lane parameters must not change due to hard-coded assumptions about their
+# values in `maliput_railcar_test.cc`. The unit test, for example, has a hard
+# coded constant named `kCurvedRoadRadius` that must match the arc length. In
+# addition, there are assumptions that the lane turns 90 degrees and has a
+# certain width and shoulder width.
+#
+maliput_monolane_builder:
+  id: flat_curved_lane
+  lane_bounds: [-2, 2]
+  driveable_bounds: [-4, 4]
+  position_precision: .01
+  orientation_precision: 0.5
+  points:
+    start:
+      xypoint: [0, 0, 0]    # x, y, heading
+      zpoint: [0, 0, 0, 0]  # z, zdot, theta (superelevation), thetadot
+  connections:
+    0:
+      start: "points.start"
+      arc: [10, 90]        # ArcOffset: radius, theta
+      z_end: [0, 0, 0, 0]  # EndpointZ: z, z_dot, theta, theta_dot

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -1,0 +1,254 @@
+#include "drake/automotive/maliput_railcar.h"
+
+#include <cmath>
+#include <memory>
+
+#include <Eigen/Dense>
+#include "gtest/gtest.h"
+
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/dragway/road_geometry.h"
+#include "drake/automotive/maliput/monolane/loader.h"
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/math/roll_pitch_yaw_not_using_quaternion.h"
+#include "drake/systems/framework/leaf_context.h"
+
+namespace drake {
+
+using systems::BasicVector;
+using systems::LeafContext;
+using systems::Parameters;
+using systems::rendering::PoseVector;
+
+namespace automotive {
+namespace {
+
+class MaliputRailcarTest : public ::testing::Test {
+ protected:
+  void InitializeDragwayLane() {
+    // Defines the dragway's parameters.
+    const int kNumLanes{1};
+    const double kDragwayLength{50};
+    const double kDragwayLaneWidth{0.5};
+    const double kDragwayShoulderWidth{0.25};
+    Initialize(std::make_unique<const maliput::dragway::RoadGeometry>(
+        maliput::api::RoadGeometryId({"RailcarTestDragway"}), kNumLanes,
+        kDragwayLength, kDragwayLaneWidth, kDragwayShoulderWidth));
+  }
+
+  void InitializeCurvedMonoLane() {
+    const std::string filename = GetDrakePath() +
+                               "/automotive/test/flat_curved_lane.yaml";
+    Initialize(maliput::monolane::LoadFile(filename));
+  }
+
+  void Initialize(std::unique_ptr<const maliput::api::RoadGeometry> road) {
+    road_ = std::move(road);
+    const maliput::api::Lane* lane = road_->junction(0)->segment(0)->lane(0);
+    dut_.reset(new MaliputRailcar<double>(*lane));
+    context_ = dut_->CreateDefaultContext();
+    output_ = dut_->AllocateOutput(*context_);
+    derivatives_ = dut_->AllocateTimeDerivatives();
+  }
+
+  MaliputRailcarState<double>* continuous_state() {
+    auto result = dynamic_cast<MaliputRailcarState<double>*>(
+        context_->get_mutable_continuous_state_vector());
+    if (result == nullptr) { throw std::bad_cast(); }
+    return result;
+  }
+
+  const MaliputRailcarState<double>* state_output() const {
+    auto state = dynamic_cast<const MaliputRailcarState<double>*>(
+        output_->get_vector_data(dut_->state_output().get_index()));
+    DRAKE_DEMAND(state != nullptr);
+    return state;
+  }
+
+  const PoseVector<double>* pose_output() const {
+    auto pose = dynamic_cast<const PoseVector<double>*>(
+        output_->get_vector_data(dut_->pose_output().get_index()));
+    DRAKE_DEMAND(pose != nullptr);
+    return pose;
+  }
+
+  // Sets the configuration parameters of the vehicle.
+  void SetConfig(double r, double h, double initial_speed) {
+    LeafContext<double>* leaf_context =
+        dynamic_cast<LeafContext<double>*>(context_.get());
+    ASSERT_NE(leaf_context, nullptr);
+    Parameters<double>* parameters = leaf_context->get_mutable_parameters();
+    ASSERT_NE(parameters, nullptr);
+    BasicVector<double>* vector_param =
+        parameters->get_mutable_numeric_parameter(0);
+    ASSERT_NE(vector_param, nullptr);
+    MaliputRailcarConfig<double>* config =
+        dynamic_cast<MaliputRailcarConfig<double>*>(vector_param);
+    ASSERT_NE(config, nullptr);
+    config->set_r(1.5);
+    config->set_h(8.2);
+    config->set_initial_speed(initial_speed);
+  }
+
+  // The arc radius of the road's s-axis when the road is created using
+  // InitializeCurvedMonoLane(). This value must match the value specified in
+  // `flat_curved_lane.yaml`.
+  const double kCurvedRoadRadius{10};
+
+  std::unique_ptr<const maliput::api::RoadGeometry> road_;
+  std::unique_ptr<MaliputRailcar<double>> dut_;  //< The device under test.
+  std::unique_ptr<systems::Context<double>> context_;
+  std::unique_ptr<systems::SystemOutput<double>> output_;
+  std::unique_ptr<systems::ContinuousState<double>> derivatives_;
+};
+
+TEST_F(MaliputRailcarTest, Topology) {
+  EXPECT_NO_FATAL_FAILURE(InitializeDragwayLane());
+  ASSERT_EQ(dut_->get_num_input_ports(), 0);
+
+  ASSERT_EQ(dut_->get_num_output_ports(), 2);
+  const auto& state_output = dut_->state_output();
+  EXPECT_EQ(systems::kVectorValued, state_output.get_data_type());
+  EXPECT_EQ(MaliputRailcarStateIndices::kNumCoordinates, state_output.size());
+
+  const auto& pose_output = dut_->pose_output();
+  EXPECT_EQ(systems::kVectorValued, pose_output.get_data_type());
+  EXPECT_EQ(PoseVector<double>::kSize, pose_output.size());
+
+  EXPECT_FALSE(dut_->HasAnyDirectFeedthrough());
+}
+
+TEST_F(MaliputRailcarTest, ZeroInitialOutput) {
+  EXPECT_NO_FATAL_FAILURE(InitializeDragwayLane());
+  dut_->CalcOutput(*context_, output_.get());
+  auto state = state_output();
+  EXPECT_EQ(state->s(), 0);
+  EXPECT_EQ(state->s_dot(), 0);
+  auto pose = pose_output();
+  EXPECT_TRUE(CompareMatrices(pose->get_isometry().matrix(),
+                              Eigen::Isometry3d::Identity().matrix()));
+  Eigen::Translation<double, 3> translation = pose->get_translation();
+  EXPECT_EQ(translation.x(), 0);
+  EXPECT_EQ(translation.y(), 0);
+  EXPECT_EQ(translation.z(), 0);
+}
+
+TEST_F(MaliputRailcarTest, StateAppearsInOutputDragway) {
+  EXPECT_NO_FATAL_FAILURE(InitializeDragwayLane());
+
+  continuous_state()->set_s(1.0);
+  continuous_state()->set_s_dot(2.0);
+  dut_->CalcOutput(*context_, output_.get());
+
+  auto state = state_output();
+  EXPECT_EQ(state->s(), 1);
+  EXPECT_EQ(state->s_dot(), 2);
+
+  auto pose = pose_output();
+  Eigen::Isometry3d expected_pose = Eigen::Isometry3d::Identity();
+  // For the dragway, the `(s, r, h)` axes in lane-space coorespond to the
+  // `(x, y, z)` axes in geo-space. In this case, `s = 1` while `r` and `h` are
+  // by default zero.
+  expected_pose.translation() = Eigen::Vector3d(1, 0, 0);
+  EXPECT_TRUE(CompareMatrices(pose->get_isometry().matrix(),
+                              expected_pose.matrix()));
+}
+
+TEST_F(MaliputRailcarTest, StateAppearsInOutputMonolane) {
+  EXPECT_NO_FATAL_FAILURE(InitializeCurvedMonoLane());
+  const maliput::api::Lane* lane = road_->junction(0)->segment(0)->lane(0);
+
+  continuous_state()->set_s(lane->length());
+  continuous_state()->set_s_dot(3.5);
+  dut_->CalcOutput(*context_, output_.get());
+
+  ASSERT_NE(lane, nullptr);
+  auto state = state_output();
+  EXPECT_EQ(state->s(), lane->length());
+  EXPECT_EQ(state->s_dot(), 3.5);
+
+  auto pose = pose_output();
+  Eigen::Isometry3d expected_pose = Eigen::Isometry3d::Identity();
+  {
+    const Eigen::Vector3d rpy(0, 0, M_PI_2);
+    const Eigen::Vector3d xyz(kCurvedRoadRadius, kCurvedRoadRadius, 0);
+    expected_pose.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
+  }
+  // The following tolerance was determined emperically.
+  EXPECT_TRUE(CompareMatrices(pose->get_isometry().matrix(),
+                              expected_pose.matrix(), 1e-15 /* tolerance */));
+}
+
+TEST_F(MaliputRailcarTest, NonZeroParametersAppearInOutputDragway) {
+  EXPECT_NO_FATAL_FAILURE(InitializeDragwayLane());
+  // Sets the parameters to be non-zero values.
+  SetConfig(1.5 /* r */, 8.2 /* h */, 1 /* initial speed */);
+  dut_->CalcOutput(*context_, output_.get());
+  auto pose = pose_output();
+  Eigen::Isometry3d expected_pose = Eigen::Isometry3d::Identity();
+  expected_pose.translation() = Eigen::Vector3d(0, 1.5, 8.2);
+  EXPECT_TRUE(CompareMatrices(pose->get_isometry().matrix(),
+                              expected_pose.matrix()));
+}
+
+TEST_F(MaliputRailcarTest, NonZeroParametersAppearInOutputMonolane) {
+  EXPECT_NO_FATAL_FAILURE(InitializeCurvedMonoLane());
+
+  // Sets the parameters to be non-zero values.
+  SetConfig(1.5 /* r */, 8.2 /* h */, 1 /* initial speed */);
+  dut_->CalcOutput(*context_, output_.get());
+  auto start_pose = pose_output();
+  Eigen::Isometry3d expected_start_pose = Eigen::Isometry3d::Identity();
+  {
+    const Eigen::Vector3d rpy(0, 0, 0);
+    const Eigen::Vector3d xyz(0, 1.5, 8.2);
+    expected_start_pose.matrix()
+        << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
+  }
+  // The following tolerance was determined emperically.
+  EXPECT_TRUE(CompareMatrices(start_pose->get_isometry().matrix(),
+                              expected_start_pose.matrix(),
+                              1e-15 /* tolerance */));
+
+  // Moves the vehicle to be at the end of the curved lane.
+  const maliput::api::Lane* lane = road_->junction(0)->segment(0)->lane(0);
+  continuous_state()->set_s(lane->length());
+
+  dut_->CalcOutput(*context_, output_.get());
+  auto end_pose = pose_output();
+  Eigen::Isometry3d expected_end_pose = Eigen::Isometry3d::Identity();
+  {
+    const Eigen::Vector3d rpy(0, 0, M_PI_2);
+    const Eigen::Vector3d xyz(kCurvedRoadRadius - 1.5, kCurvedRoadRadius, 8.2);
+    expected_end_pose.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
+  }
+  // The following tolerance was determined emperically.
+  EXPECT_TRUE(CompareMatrices(end_pose->get_isometry().matrix(),
+                              expected_end_pose.matrix(),
+                              1e-15 /* tolerance */));
+}
+
+TEST_F(MaliputRailcarTest, Derivatives) {
+  EXPECT_NO_FATAL_FAILURE(InitializeDragwayLane());
+  // Grabs a pointer to where the EvalTimeDerivatives results end up.
+  const MaliputRailcarState<double>* const result =
+      dynamic_cast<const MaliputRailcarState<double>*>(
+          derivatives_->get_mutable_vector());
+  ASSERT_NE(nullptr, result);
+
+  // Checks the derivatives given the default continous state.
+  dut_->CalcTimeDerivatives(*context_, derivatives_.get());
+  EXPECT_EQ(result->s(), MaliputRailcar<double>::kDefaultSpeed);
+  EXPECT_EQ(result->s_dot(), 0.0);  // Expect zero acceleration.
+
+  // Checks the derivatives given a non-default continuous state.
+  continuous_state()->set_s(3.5);
+  dut_->CalcTimeDerivatives(*context_, derivatives_.get());
+  EXPECT_EQ(result->s(), MaliputRailcar<double>::kDefaultSpeed);
+  EXPECT_EQ(result->s_dot(), 0.0);
+}
+
+}  // namespace
+}  // namespace automotive
+}  // namespace drake

--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -186,6 +186,8 @@ _AUTOMOTIVE_LCM_SRCS = [
     "lcmt_endless_road_car_state_t.lcm",
     "lcmt_endless_road_oracle_output_t.lcm",
     "lcmt_euler_floating_joint_state_t.lcm",
+    "lcmt_maliput_railcar_config_t.lcm",
+    "lcmt_maliput_railcar_state_t.lcm",
     "lcmt_simple_car_config_t.lcm",
     "lcmt_simple_car_state_t.lcm",
 ]

--- a/drake/lcmtypes/CMakeLists.txt
+++ b/drake/lcmtypes/CMakeLists.txt
@@ -46,6 +46,8 @@ lcm_wrap_types(
   lcmt_iiwa_command.lcm
   lcmt_iiwa_status.lcm
   lcmt_joint_pd_override.lcm
+  lcmt_maliput_railcar_config_t.lcm
+  lcmt_maliput_railcar_state_t.lcm
   lcmt_matlab_array.lcm
   lcmt_call_matlab.lcm
   lcmt_piecewise_polynomial.lcm

--- a/drake/lcmtypes/lcmt_maliput_railcar_config_t.lcm
+++ b/drake/lcmtypes/lcmt_maliput_railcar_config_t.lcm
@@ -1,0 +1,13 @@
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+package drake;
+
+struct lcmt_maliput_railcar_config_t {
+  // The timestamp in milliseconds.
+  int64_t timestamp;
+
+  double r;  // The vehicle's position on the lane's r-axis.
+  double h;  // The vehicle's height above the lane's surface.
+  double initial_speed;  // The vehicle's initial speed along the lane's s-axis.
+}

--- a/drake/lcmtypes/lcmt_maliput_railcar_state_t.lcm
+++ b/drake/lcmtypes/lcmt_maliput_railcar_state_t.lcm
@@ -1,0 +1,12 @@
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+package drake;
+
+struct lcmt_maliput_railcar_state_t {
+  // The timestamp in milliseconds.
+  int64_t timestamp;
+
+  double s;  // The position along the lane's s-axis.
+  double s_dot;  // The speed along the lane's s-axis.
+}


### PR DESCRIPTION
The content of this PR was extracted from #5377, which had grown too large.

# Visualization of the Flat Curved Lane

This PR includes a file called `flat_curved_lane.yaml` that is used to test the railcar. Here is a visualization of the `monolane::RoadGeometry` it specifies:

<img width="682" alt="screen shot 2017-03-05 at 8 43 47 pm" src="https://cloud.githubusercontent.com/assets/1388098/23625030/bb901b4c-0275-11e7-9138-c16661779762.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5419)
<!-- Reviewable:end -->
