### PR TITLE
Allow derivative(0), which just returns the original object.

### DIFF
--- a/drake/common/polynomial.cc
+++ b/drake/common/polynomial.cc
@@ -252,7 +252,7 @@ void Polynomial<CoefficientType>::Subs(const VarType& orig,
 
 template <typename CoefficientType>
 Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
-    unsigned int derivative_order) const {
+    int derivative_order) const {
   DRAKE_DEMAND(derivative_order >= 0);
   if (!is_univariate_)
     throw runtime_error(
@@ -267,7 +267,7 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
     if (!iter->terms.empty() && (
             iter->terms[0].power >= static_cast<PowerType>(derivative_order))) {
       Monomial m = *iter;
-      for (unsigned int k = 0; k < derivative_order;
+      for (int k = 0; k < derivative_order;
            k++) {  // take the remaining derivatives
         m.coefficient = m.coefficient * m.terms[0].power;
         m.terms[0].power -= 1;

--- a/drake/common/polynomial.cc
+++ b/drake/common/polynomial.cc
@@ -253,10 +253,13 @@ void Polynomial<CoefficientType>::Subs(const VarType& orig,
 template <typename CoefficientType>
 Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
     unsigned int derivative_order) const {
+  DRAKE_DEMAND(derivative_order >= 0);
   if (!is_univariate_)
     throw runtime_error(
         "Derivative is only defined for univariate polynomials");
-
+  if (derivative_order == 0) {
+    return *this;
+  }
   Polynomial<CoefficientType> ret;
 
   for (typename vector<Monomial>::const_iterator iter = monomials_.begin();

--- a/drake/common/polynomial.h
+++ b/drake/common/polynomial.h
@@ -279,7 +279,7 @@ class Polynomial {
    * If derivative_order is given, takes the nth derivative of this
    * Polynomial.
    */
-  Polynomial Derivative(unsigned int derivative_order = 1) const;
+  Polynomial Derivative(int derivative_order = 1) const;
 
   /** Takes the integral of this (univariate, non-constant) Polynomial.
    *

--- a/drake/common/test/polynomial_test.cc
+++ b/drake/common/test/polynomial_test.cc
@@ -27,10 +27,6 @@ void testIntegralAndDerivative() {
                               poly.Derivative(0).GetCoefficients(), 1e-14,
                               MatrixCompareType::absolute));
 
-  EXPECT_FALSE(CompareMatrices(poly.GetCoefficients(),
-                              poly.Derivative(-1).GetCoefficients(), 1e-14,
-                              MatrixCompareType::absolute));
-
   Polynomial<CoefficientType> third_derivative = poly.Derivative(3);
 
   Polynomial<CoefficientType> third_derivative_check =

--- a/drake/common/test/polynomial_test.cc
+++ b/drake/common/test/polynomial_test.cc
@@ -23,6 +23,14 @@ void testIntegralAndDerivative() {
   VectorXd coefficients = VectorXd::Random(5);
   Polynomial<CoefficientType> poly(coefficients);
 
+  EXPECT_TRUE(CompareMatrices(poly.GetCoefficients(),
+                              poly.Derivative(0).GetCoefficients(), 1e-14,
+                              MatrixCompareType::absolute));
+
+  EXPECT_FALSE(CompareMatrices(poly.GetCoefficients(),
+                              poly.Derivative(-1).GetCoefficients(), 1e-14,
+                              MatrixCompareType::absolute));
+
   Polynomial<CoefficientType> third_derivative = poly.Derivative(3);
 
   Polynomial<CoefficientType> third_derivative_check =

--- a/drake/common/trajectories/piecewise_polynomial.cc
+++ b/drake/common/trajectories/piecewise_polynomial.cc
@@ -50,7 +50,7 @@ PiecewisePolynomial<CoefficientType>::derivative(int derivative_order) const {
   DRAKE_DEMAND(derivative_order >= 0);
   PiecewisePolynomial ret = *this;
   if (derivative_order == 0) {
-    return *this;
+    return ret;
   }
   for (auto it = ret.polynomials_.begin(); it != ret.polynomials_.end(); ++it) {
     PolynomialMatrix& matrix = *it;

--- a/drake/common/trajectories/piecewise_polynomial.cc
+++ b/drake/common/trajectories/piecewise_polynomial.cc
@@ -47,7 +47,11 @@ PiecewisePolynomial<CoefficientType>::PiecewisePolynomial() {
 template <typename CoefficientType>
 PiecewisePolynomial<CoefficientType>
 PiecewisePolynomial<CoefficientType>::derivative(int derivative_order) const {
+  DRAKE_DEMAND(derivative_order >= 0);
   PiecewisePolynomial ret = *this;
+  if (derivative_order == 0) {
+    return *this;
+  }
   for (auto it = ret.polynomials_.begin(); it != ret.polynomials_.end(); ++it) {
     PolynomialMatrix& matrix = *it;
     for (Eigen::Index row = 0; row < rows(); row++) {

--- a/drake/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_test.cc
@@ -38,6 +38,12 @@ void testIntegralAndDerivative() {
       test::MakeRandomPiecewisePolynomial<CoefficientType>(
           rows, cols, num_coefficients, segment_times);
 
+  // derivative(0) should be same as original piecewise.
+  EXPECT_TRUE(
+      CompareMatrices(piecewise.value(piecewise.getStartTime()),
+                      piecewise.derivative(0).value(piecewise.getStartTime()),
+                      1e-10, MatrixCompareType::absolute));
+
   // differentiate integral, get original back
   PiecewisePolynomialType piecewise_back = piecewise.integral().derivative();
   if (!piecewise.isApprox(piecewise_back, 1e-10)) throw runtime_error("wrong");

--- a/drake/common/trajectories/test/piecewise_polynomial_trajectory_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_trajectory_test.cc
@@ -92,6 +92,9 @@ GTEST_TEST(piecewisePolynomialTrajectoryTest, testBasicFunctionality) {
   EXPECT_EQ(kPpTrajFromPpMatrix.value(3)(2), 6);
 
   // Test derivative()
+  EXPECT_TRUE(CompareMatrices(kPpFromMatrix.derivative(0).value(1.5),
+                              kPpTrajFromPpMatrix.derivative(0)->value(1.5),
+                              1e-10, MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(kPpFromMatrix.derivative(1).value(1.5),
                               kPpTrajFromPpMatrix.derivative(1)->value(1.5),
                               1e-10, MatrixCompareType::absolute));


### PR DESCRIPTION
The master branch gives incorrect results with derivative(0). It would be handy to be able to do derivative(0), to be more general, and for an easy copy of the object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5425)
<!-- Reviewable:end -->
