### PR TITLE
Added syntactic sugar for variable step integration without simulation.

### DIFF
--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -385,8 +385,7 @@ class IntegratorBase {
     do {
       StepOnceAtMost(inf, inf, t_remaining);
       t_remaining = t_final - context.get_time();
-    }
-    while (t_remaining > 0);
+    } while (t_remaining > 0);
   }
 
   /// Stepping function for integrators operating outside of simulation

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -354,11 +354,40 @@ class IntegratorBase {
    * @warning Users should generally not call this function directly; within
    *          simulation circumstances, users will typically call
    *          `Simulator::StepTo()`. In other circumstances, users will
-   *          typically call `IntegratorBase::StepOnceExactly()`.
+   *          typically call `IntegratorBase::StepExactlyFixed()`.
    */
   // TODO(edrumwri): Make the stretch size configurable.
   StepResult StepOnceAtMost(const T& publish_dt, const T& update_dt,
                             const T& boundary_dt);
+
+  /// Stepping function for integrators operating outside of simulation
+  /// circumstances. This method is designed for integrator
+  /// users that do not wish to consider publishing or discontinuous,
+  /// mid-interval updates _and_ are using integrators with error control.
+  /// @warning Users should simulate systems using `Simulator::StepTo()` in
+  ///          place of this function (which was created for off-simulation
+  ///          purposes), generally.
+  /// @note Users desiring this functionality for integrators operating in
+  ///       fixed step mode should use StepExactlyFixed().
+  /// @throws std::logic_error If the integrator has not been initialized or
+  ///                          boundary_dt is negative **or** if the integrator
+  ///                          is operating in fixed step mode.
+  /// @sa StepExactlyFixed()
+  void StepExactlyVariable(const T& boundary_dt) {
+    if (this->get_fixed_step_mode()) {
+      throw std::logic_error("StepExactlyVariable() requires variable "
+                             "stepping.");
+    }
+    const Context<T>& context = get_context();
+    const T inf = std::numeric_limits<double>::infinity();
+    T t_remaining = boundary_dt;
+    const T t_final = context.get_time() + t_remaining;
+    do {
+      StepOnceAtMost(inf, inf, t_remaining);
+      t_remaining = t_final - context.get_time();
+    }
+    while (t_remaining > 0);
+  }
 
   /// Stepping function for integrators operating outside of simulation
   /// circumstances. This method is designed for integrator
@@ -371,12 +400,17 @@ class IntegratorBase {
   /// @warning Users should simulate systems using `Simulator::StepTo()` in
   ///          place of this function (which was created for off-simulation
   ///          purposes), generally.
+  /// @note Users desiring this functionality for integrators not operating in
+  ///       fixed step mode should use StepExactlyVariable()- these functions
+  ///       are kept distinct to make clear to the caller which of these
+  ///       functions uses fixed integration steps.
   /// @throws std::logic_error If the integrator has not been initialized or
   ///                          boundary_dt is negative **or** if the integrator
   ///                          is not operating in fixed step mode.
-  void StepOnceExactly(const T& boundary_dt) {
+  /// @sa StepExactlyVariable()
+  void StepExactlyFixed(const T& boundary_dt) {
     if (!this->get_fixed_step_mode())
-      throw std::logic_error("StepOnceExactly() requires fixed stepping.");
+      throw std::logic_error("StepExactlyFixed() requires fixed stepping.");
     const T inf = std::numeric_limits<double>::infinity();
     StepOnceAtMost(inf, inf, boundary_dt);
   }

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -1268,12 +1268,15 @@ typename IntegratorBase<T>::StepResult IntegratorBase<T>::StepOnceAtMost(
   if (!IntegratorBase<T>::is_initialized())
     throw std::logic_error("Integrator not initialized.");
 
-  // Verify that update dt is positive
-  DRAKE_DEMAND(update_dt > 0.0);
+  // Verify that update dt is positive.
+  if (update_dt <= 0.0)
+    throw std::logic_error("Update dt must be non-negative.");
 
-  // Verify that other dt's are non-negative
-  DRAKE_DEMAND(publish_dt >= 0.0);
-  DRAKE_DEMAND(boundary_dt >= 0.0);
+  // Verify that other dt's are non-negative.
+  if (publish_dt < 0.0)
+    throw std::logic_error("Publish dt is negative.");
+  if (boundary_dt < 0.0)
+    throw std::logic_error("Boundary dt is negative.");
 
   // The size of the integration step is the minimum of the time until the next
   // update event, the time until the next publish event, the boundary time

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -373,19 +373,22 @@ class IntegratorBase {
   ///                          boundary_dt is negative **or** if the integrator
   ///                          is operating in fixed step mode.
   /// @sa StepExactlyFixed()
-  void StepExactlyVariable(const T& boundary_dt) {
+  void StepExactlyVariable(const T& dt) {
+    using std::max;
+
     if (this->get_fixed_step_mode()) {
       throw std::logic_error("StepExactlyVariable() requires variable "
                              "stepping.");
     }
     const Context<T>& context = get_context();
     const T inf = std::numeric_limits<double>::infinity();
-    T t_remaining = boundary_dt;
+    T t_remaining = dt;
     const T t_final = context.get_time() + t_remaining;
     do {
       StepOnceAtMost(inf, inf, t_remaining);
       t_remaining = t_final - context.get_time();
-    } while (t_remaining > 0);
+    } while (t_remaining > std::numeric_limits<double>::epsilon()*
+                           max(1.0, context.get_time()));
   }
 
   /// Stepping function for integrators operating outside of simulation
@@ -407,11 +410,11 @@ class IntegratorBase {
   ///                          boundary_dt is negative **or** if the integrator
   ///                          is not operating in fixed step mode.
   /// @sa StepExactlyVariable()
-  void StepExactlyFixed(const T& boundary_dt) {
+  void StepExactlyFixed(const T& dt) {
     if (!this->get_fixed_step_mode())
       throw std::logic_error("StepExactlyFixed() requires fixed stepping.");
     const T inf = std::numeric_limits<double>::infinity();
-    StepOnceAtMost(inf, inf, boundary_dt);
+    StepOnceAtMost(inf, inf, dt);
   }
 
   /**

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -384,12 +384,18 @@ class IntegratorBase {
     const Context<T>& context = get_context();
     const T inf = std::numeric_limits<double>::infinity();
     T t_remaining = dt;
+
+    // Note: A concern below is that the while loop while run forever because
+    // t_remaining could be small, but not quite zero, if dt is relatively
+    // small compared to the context time. In such a case, t_final will be
+    // equal to context.get_time() in the expression immediately below,
+    // context.get_time() will not change during the call to StepOnceAtMost(),
+    // and t_remaining will be equal to zero.
     const T t_final = context.get_time() + t_remaining;
     do {
       StepOnceAtMost(inf, inf, t_remaining);
       t_remaining = t_final - context.get_time();
-    } while (t_remaining > std::numeric_limits<double>::epsilon()*
-                           max(1.0, context.get_time()));
+    } while (t_remaining > 0);
   }
 
   /// Stepping function for integrators operating outside of simulation

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -342,7 +342,7 @@ class IntegratorBase {
    *
    * @param publish_dt The step size, >= 0.0 (exception will be thrown
    *        if this is not the case) at which the next publish will occur.
-   * @param update_dt The step size, >= 0.0 (exception will be thrown
+   * @param update_dt The step size, > 0.0 (exception will be thrown
    *        if this is not the case) at which the next update will occur.
    * @param boundary_dt The step size, >= 0.0 (exception will be thrown
    *        if this is not the case) marking the end of the user-designated
@@ -369,8 +369,9 @@ class IntegratorBase {
   ///          purposes), generally.
   /// @note Users desiring this functionality for integrators operating in
   ///       fixed step mode should use StepExactlyFixed().
+  /// @param dt The non-negative integration step to take. 
   /// @throws std::logic_error If the integrator has not been initialized or
-  ///                          boundary_dt is negative **or** if the integrator
+  ///                          dt is negative **or** if the integrator
   ///                          is operating in fixed step mode.
   /// @sa StepExactlyFixed()
   void StepExactlyVariable(const T& dt) {
@@ -406,8 +407,9 @@ class IntegratorBase {
   ///       fixed step mode should use StepExactlyVariable()- these functions
   ///       are kept distinct to make clear to the caller which of these
   ///       functions uses fixed integration steps.
+  /// @param dt The non-negative integration step to take. 
   /// @throws std::logic_error If the integrator has not been initialized or
-  ///                          boundary_dt is negative **or** if the integrator
+  ///                          dt is negative **or** if the integrator
   ///                          is not operating in fixed step mode.
   /// @sa StepExactlyVariable()
   void StepExactlyFixed(const T& dt) {
@@ -1273,7 +1275,7 @@ typename IntegratorBase<T>::StepResult IntegratorBase<T>::StepOnceAtMost(
 
   // Verify that update dt is positive.
   if (update_dt <= 0.0)
-    throw std::logic_error("Update dt must be non-negative.");
+    throw std::logic_error("Update dt must be strictly positive.");
 
   // Verify that other dt's are non-negative.
   if (publish_dt < 0.0)

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -369,7 +369,7 @@ class IntegratorBase {
   ///          purposes), generally.
   /// @note Users desiring this functionality for integrators operating in
   ///       fixed step mode should use StepExactlyFixed().
-  /// @param dt The non-negative integration step to take. 
+  /// @param dt The non-negative integration step to take.
   /// @throws std::logic_error If the integrator has not been initialized or
   ///                          dt is negative **or** if the integrator
   ///                          is operating in fixed step mode.
@@ -407,7 +407,7 @@ class IntegratorBase {
   ///       fixed step mode should use StepExactlyVariable()- these functions
   ///       are kept distinct to make clear to the caller which of these
   ///       functions uses fixed integration steps.
-  /// @param dt The non-negative integration step to take. 
+  /// @param dt The non-negative integration step to take.
   /// @throws std::logic_error If the integrator has not been initialized or
   ///                          dt is negative **or** if the integrator
   ///                          is not operating in fixed step mode.

--- a/drake/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -89,6 +89,35 @@ GTEST_TEST(IntegratorTest, AccuracyEstAndErrorControl) {
                std::logic_error);
 }
 
+// Verifies that the stepping works with large magnitude times and small
+// magnitude step sizes.
+GTEST_TEST(IntegratorTest, MagDisparity) {
+  const double spring_k = 300.0;  // N/m
+  const double mass = 2.0;      // kg
+
+  // Create the spring-mass system.
+  SpringMassSystem<double> spring_mass(spring_k, mass, 0.);
+
+  // Create a context.
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Set a large magnitude time.
+  context->set_time(1e10);
+
+  // Setup the integration size and infinity.
+  const double dt = 1e-6;
+
+  // Create the integrator.
+  ExplicitEulerIntegrator<double> integrator(
+      spring_mass, dt, context.get());  // Use default Context.
+
+  // Take all the defaults.
+  integrator.Initialize();
+
+  // Take a fixed integration step.
+  integrator.StepExactlyFixed(dt);
+}
+
 // Try a purely continuous system with no sampling.
 // d^2x/dt^2 = -kx/m
 // solution to this ODE: x(t) = c1*cos(omega*t) + c2*sin(omega*t)

--- a/drake/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -57,6 +57,22 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
   EXPECT_THROW(integrator.StepOnceAtMost(dt, dt, dt), std::logic_error);
 }
 
+/// Checks that the integrator can catch invalid dt's.
+GTEST_TEST(IntegratorTest, InvalidDts) {
+  // Spring-mass system is necessary only to setup the problem.
+  SpringMassSystem<double> spring_mass(1., 1., 0.);
+  const double dt = 1e-3;
+  auto context = spring_mass.CreateDefaultContext();
+  ExplicitEulerIntegrator<double> integrator(
+      spring_mass, dt, context.get());
+  integrator.Initialize();
+
+  EXPECT_NO_THROW(integrator.StepOnceAtMost(dt, dt, dt));
+  EXPECT_THROW(integrator.StepOnceAtMost(dt, 0.0, dt), std::logic_error);
+  EXPECT_THROW(integrator.StepOnceAtMost(-1, dt, dt), std::logic_error);
+  EXPECT_THROW(integrator.StepOnceAtMost(dt, dt, -1), std::logic_error);
+}
+
 /// Verifies error estimation is unsupported.
 GTEST_TEST(IntegratorTest, AccuracyEstAndErrorControl) {
   // Spring-mass system is necessary only to setup the problem.

--- a/drake/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -30,6 +30,9 @@ GTEST_TEST(IntegratorTest, MiscAPI) {
   // Test that setting the target accuracy or initial step size target fails.
   EXPECT_THROW(int_dbl.set_target_accuracy(1.0), std::logic_error);
   EXPECT_THROW(int_dbl.request_initial_step_size_target(1.0), std::logic_error);
+
+  // Verify that attempting to integrate in variable step mode fails.
+  EXPECT_THROW(int_dbl.StepExactlyVariable(1.0), std::logic_error);
 }
 
 GTEST_TEST(IntegratorTest, ContextAccess) {
@@ -200,7 +203,7 @@ GTEST_TEST(IntegratorTest, StepSize) {
   // The step ends on the simulation end time.
   {
     const double boundary_dt = 0.0009;
-    integrator.StepOnceExactly(boundary_dt);
+    integrator.StepExactlyFixed(boundary_dt);
     EXPECT_EQ(t + boundary_dt, context->get_time());
     t = context->get_time();
   }

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -79,7 +79,7 @@ TEST_F(RK3IntegratorTest, MagDisparity) {
   integrator_->set_target_accuracy(1e-3);
 
   // Take a variable step.
-  integrator.StepExactlyVariable(dt);
+  integrator_->StepExactlyVariable(dt);
 }
 
 // Test scaling vectors

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -72,14 +72,14 @@ TEST_F(RK3IntegratorTest, MagDisparity) {
 
   // Set integrator parameters.
   integrator_->set_maximum_step_size(0.1);
-  integrator_->set_minimum_step_size(1e-6);
+  integrator_->set_minimum_step_size(1e-10);
   integrator_->set_target_accuracy(1e-3);
 
   // Take all the defaults.
   integrator_->Initialize();
 
   // Take a variable step.
-  integrator_->StepExactlyVariable(dt);
+  integrator_->StepExactlyVariable(1e-10);
 }
 
 // Test scaling vectors

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -300,7 +300,7 @@ TEST_F(RK3IntegratorTest, IllegalFixedStep) {
   // Initialize the integrator.
   integrator_->Initialize();
 
-  EXPECT_THROW(integrator_->StepOnceExactly(1e-8), std::logic_error);
+  EXPECT_THROW(integrator_->StepExactlyFixed(1e-8), std::logic_error);
 }
 
 // Verifies statistics validity for error controlled integrator.
@@ -381,12 +381,12 @@ GTEST_TEST(RK3RK2IntegratorTest, RigidBody) {
   // Integrate for ten thousand steps using a RK2 integrator with
   // small step size.
   const double dt = 5e-5;
-  const double inf = std::numeric_limits<double>::infinity();
   RungeKutta2Integrator<double> rk2(plant, dt, context.get());
   rk2.Initialize();
   const double t_final = 1.0;
-  for (double t = 0.0; std::abs(t - t_final) >= dt; t += dt)
-    rk2.StepOnceAtMost(inf, inf, dt);  // Steps forward by dt.
+  const int n_steps = t_final / dt;
+  for (int i = 0; i< n_steps; ++i)
+    rk2.StepExactlyFixed(dt);
 
   // Get the final state.
   VectorX<double> x_final_rk2 = context->get_continuous_state_vector().
@@ -410,12 +410,10 @@ GTEST_TEST(RK3RK2IntegratorTest, RigidBody) {
   rk3.set_target_accuracy(1e-6);
   rk3.Initialize();
 
-  // StepOnceAtFixedSize for one second.
-  double t_remaining = t_final - context->get_time();
-  do {
-    rk3.StepOnceAtMost(t_remaining, t_remaining, t_remaining);
-    t_remaining = t_final - context->get_time();
-  } while (t_remaining > 0.0);
+  // Verify that StepExactlyVariable works.
+  const double tol = std::numeric_limits<double>::epsilon();
+  rk3.StepExactlyVariable(t_final - context->get_time());
+  EXPECT_NEAR(context->get_time(), t_final, tol);
 
   // Verify that the final states are "close".
   VectorX<double> x_final_rk3 = context->get_continuous_state_vector().

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -64,6 +64,24 @@ TEST_F(RK3IntegratorTest, ErrorEstSupport) {
   EXPECT_NO_THROW(integrator_->request_initial_step_size_target(dt));
 }
 
+// Verifies that the stepping works with large magnitude times and small
+// magnitude step sizes.
+TEST_F(RK3IntegratorTest, MagDisparity) {
+  // Set a large magnitude time.
+  context_->set_time(1e10);
+
+  // Take all the defaults.
+  integrator_->Initialize();
+
+  // Set integrator parameters.
+  integrator_->set_maximum_step_size(0.1);
+  integrator_->set_minimum_step_size(1e-6);
+  integrator_->set_target_accuracy(1e-3);
+
+  // Take a variable step.
+  integrator.StepExactlyVariable(dt);
+}
+
 // Test scaling vectors
 TEST_F(RK3IntegratorTest, Scaling) {
   // Setting maximum integrator step size is necessary to prevent integrator

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -68,18 +68,18 @@ TEST_F(RK3IntegratorTest, ErrorEstSupport) {
 // magnitude step sizes.
 TEST_F(RK3IntegratorTest, MagDisparity) {
   // Set a large magnitude time.
-  context_->set_time(1e10);
+  context_->set_time(1.0);
 
   // Set integrator parameters.
   integrator_->set_maximum_step_size(0.1);
-  integrator_->set_minimum_step_size(1e-10);
+  integrator_->set_minimum_step_size(1e-40);
   integrator_->set_target_accuracy(1e-3);
 
   // Take all the defaults.
   integrator_->Initialize();
 
   // Take a variable step.
-  integrator_->StepExactlyVariable(1e-10);
+  integrator_->StepExactlyVariable(1e-40);
 }
 
 // Test scaling vectors

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -70,13 +70,13 @@ TEST_F(RK3IntegratorTest, MagDisparity) {
   // Set a large magnitude time.
   context_->set_time(1e10);
 
-  // Take all the defaults.
-  integrator_->Initialize();
-
   // Set integrator parameters.
   integrator_->set_maximum_step_size(0.1);
   integrator_->set_minimum_step_size(1e-6);
   integrator_->set_target_accuracy(1e-3);
+
+  // Take all the defaults.
+  integrator_->Initialize();
 
   // Take a variable step.
   integrator_->StepExactlyVariable(dt);


### PR DESCRIPTION
Per request from Paul Mitiguy, this PR adds some syntactic sugar for facilitating variable step integration _without a simulator_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5429)
<!-- Reviewable:end -->
