### PR TITLE
Quadratic expression in lorentz cone

### DIFF
--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -887,8 +887,8 @@ Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
               << " is negative, cannot call AddLorentzConeConstraint.\n";
           throw std::runtime_error(oss.str());
         }
-        Vector2<Expression> expr(linear_expr, std::sqrt(a));
-        return AddLorentzConeConstraint(expr);
+        Vector2<Expression> expr_constant_quadratic(linear_expr, std::sqrt(a));
+        return AddLorentzConeConstraint(expr_constant_quadratic);
       }
     }
     // Q is not strictly positive, nor is it zero. Use LDLT to decompose Q

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1477,6 +1477,24 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
 
   /**
+   * Adds Lorentz cone constraint on the linear expression v1 and quadratic
+   * expression v2, such that v1 >= sqrt(v2)
+   * @param linear_expr     The linear expression v1.
+   * @param quadratic_expr  The quadratic expression v2.
+   * @retval binding The newly added Lorentz cone constraint, together with the
+   * bound variables.
+   * @pre{1. `linear_expr` is a linear expression, in the form of c'*x + d.
+   *      2. `quadratic_expr` is a quadratic expression, in the form of
+   *          0.5 * x'*Q*x + b'x + a
+   *          Also the quadratic expression has to be convex, namely Q is a
+   *          positive semidefinite matrix.}
+   * Throws a runtime error if the preconditions are not satisfied.
+   * Notice we will add additional variables z into the program, with the linear
+   * constraint z = R * x + b, where R is the matrix satisfying R'*R = Q.
+   */
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(const symbolic::Expression& linear_expr, const symbolic::Expression& quadratic_expr);
+
+  /**
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables.
    */

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1487,10 +1487,14 @@ class MathematicalProgram {
    *      2. `quadratic_expr` is a quadratic expression, in the form of
    *          0.5 * x'*Q*x + b'x + a
    *          Also the quadratic expression has to be convex, namely Q is a
-   *          positive semidefinite matrix.}
+   *          positive semidefinite matrix, and the quadratic expression needs
+   *          to be non-negative for any x.}
    * Throws a runtime error if the preconditions are not satisfied.
-   * Notice we will add additional variables z into the program, with the linear
-   * constraint z = R * x + b, where R is the matrix satisfying R'*R = Q.
+   * Notice this constraint is equivalent to the vector [z;y] is within a
+   * Lorentz cone, where
+   * z = v1
+   * y = [1 / sqrt(2) * R * x + R⁻ᵀb; sqrt(a - 0.5 * bᵀ * Q⁻¹ * a)]
+   * where R satisfies Rᵀ * R = Q
    */
   Binding<LorentzConeConstraint> AddLorentzConeConstraint(const symbolic::Expression& linear_expr, const symbolic::Expression& quadratic_expr);
 

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1479,26 +1479,32 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint on the linear expression v1 and quadratic
    * expression v2, such that v1 >= sqrt(v2)
-   * @param linear_expr     The linear expression v1.
-   * @param quadratic_expr  The quadratic expression v2.
+   * @param v1     The linear expression.
+   * @param v2  The quadratic expression.
    * @retval binding The newly added Lorentz cone constraint, together with the
    * bound variables.
-   * @pre{1. `linear_expr` is a linear expression, in the form of c'*x + d.
-   *      2. `quadratic_expr` is a quadratic expression, in the form of
+   * @pre
+   * 1. `linear_expr` is a linear expression, in the form of c'*x + d.
+   * 2. `quadratic_expr` is a quadratic expression, in the form of
+   *    <pre>
    *          0.5 * x'*Q*x + b'x + a
-   *          Also the quadratic expression has to be convex, namely Q is a
-   *          positive semidefinite matrix, and the quadratic expression needs
-   *          to be non-negative for any x.}
-   * Throws a runtime error if the preconditions are not satisfied.
+   *    </pre>
+   *    Also the quadratic expression has to be convex, namely Q is a
+   *    positive semidefinite matrix, and the quadratic expression needs
+   *    to be non-negative for any x.
+   * Throws a runtime_error if the preconditions are not satisfied.
+   *
    * Notice this constraint is equivalent to the vector [z;y] is within a
    * Lorentz cone, where
-   * z = v1
-   * y = [1 / sqrt(2) * R * x + R⁻ᵀb; sqrt(a - 0.5 * bᵀ * Q⁻¹ * a)]
-   * where R satisfies Rᵀ * R = Q
+   * <pre>
+   *  z = v1
+   *  y = [1 / sqrt(2) * R * x + R⁻ᵀb; sqrt(a - 0.5 * bᵀ * Q⁻¹ * a)]
+   * </pre>
+   * while R satisfies Rᵀ * R = Q
    */
   Binding<LorentzConeConstraint> AddLorentzConeConstraint(
-      const symbolic::Expression& linear_expr,
-      const symbolic::Expression& quadratic_expr);
+      const symbolic::Expression& v1,
+      const symbolic::Expression& v2);
 
   /**
    * Adds Lorentz cone constraint referencing potentially a subset

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1496,7 +1496,9 @@ class MathematicalProgram {
    * y = [1 / sqrt(2) * R * x + R⁻ᵀb; sqrt(a - 0.5 * bᵀ * Q⁻¹ * a)]
    * where R satisfies Rᵀ * R = Q
    */
-  Binding<LorentzConeConstraint> AddLorentzConeConstraint(const symbolic::Expression& linear_expr, const symbolic::Expression& quadratic_expr);
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(
+      const symbolic::Expression& linear_expr,
+      const symbolic::Expression& quadratic_expr);
 
   /**
    * Adds Lorentz cone constraint referencing potentially a subset

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -1281,14 +1281,24 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint7) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>("x");
 
-  // The Hessian matrix is not positive definite.
-  EXPECT_THROW(prog.AddLorentzConeConstraint(2 * x(0) + 3, x(1) * x(1) - x(2) * x(2)), std::runtime_error);
-  EXPECT_THROW(prog.AddLorentzConeConstraint(2 * x(0) + 3, x(1) * x(1) + x(2) * x(2) + 3 * x(1) * x(2)), std::runtime_error);
-  EXPECT_THROW(prog.AddLorentzConeConstraint(2 * x(0) + 3, x(1) * x(1) + x(2) * x(2) + 3 * x(0) * x(2)), std::runtime_error);
+  // The Hessian matrix is not positive semidefinite.
+  EXPECT_THROW(
+      prog.AddLorentzConeConstraint(2 * x(0) + 3, x(1) * x(1) - x(2) * x(2)),
+      std::runtime_error);
+  EXPECT_THROW(prog.AddLorentzConeConstraint(
+                   2 * x(0) + 3, x(1) * x(1) + x(2) * x(2) + 3 * x(1) * x(2)),
+               std::runtime_error);
+  EXPECT_THROW(prog.AddLorentzConeConstraint(
+                   2 * x(0) + 3, x(1) * x(1) + x(2) * x(2) + 3 * x(0) * x(2)),
+               std::runtime_error);
 
   // The quadratic expression is not always non-negative.
-  EXPECT_THROW(prog.AddLorentzConeConstraint(2 * x(0) + 3, x(1) * x(1) + x(2) * x(2) - 1), std::runtime_error);
-  EXPECT_THROW(prog.AddLorentzConeConstraint(2 * x(0) + 3, pow(2 * x(0) + 3 * x(1) + 2, 2) - 1), std::runtime_error);
+  EXPECT_THROW(prog.AddLorentzConeConstraint(2 * x(0) + 3,
+                                             x(1) * x(1) + x(2) * x(2) - 1),
+               std::runtime_error);
+  EXPECT_THROW(prog.AddLorentzConeConstraint(
+                   2 * x(0) + 3, pow(2 * x(0) + 3 * x(1) + 2, 2) - 1),
+               std::runtime_error);
 }
 
 GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint1) {

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -1256,6 +1256,16 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint4) {
 
 GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint5) {
   // Add Lorentz cone constraint:
+  // [x(0); x(1); x(2); 0] is in the Lorentz cone.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>("x");
+  Vector4<Expression> e;
+  e << x(0), x(1), x(2), 0;
+  CheckParsedSymbolicLorentzConeConstraint(&prog, e);
+}
+
+GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint6) {
+  // Add Lorentz cone constraint:
   // [x(0); x(1) + x(2)] is in the Lorentz cone.
 
   MathematicalProgram prog;
@@ -1265,7 +1275,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint5) {
   CheckParsedSymbolicLorentzConeConstraint(&prog, e);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint6) {
+GTEST_TEST(testMathematicalProgram, AddSymbolicLorentzConeConstraint7) {
   // Check the cases to add with invalid quadratic expression.
 
   MathematicalProgram prog;


### PR DESCRIPTION
Now we can accept 
```C++
AddLorentzConeConstraint(const Expression& v1, const Expression& v2)
```
To impose the Lorentz cone constraint `v1 >= sqrt(v2)`, where `v1` is a linear expression, `v2` is a quadratic expression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5433)
<!-- Reviewable:end -->
