### PR TITLE
Adds a global collision sensor.

### DIFF
--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -19,6 +19,7 @@ drake_cc_library(
         ":accelerometer",
         ":camera_info",
         ":depth_sensor",
+        ":global_collision_sensor",
         ":rotary_encoders",
     ],
 )
@@ -33,6 +34,20 @@ drake_cc_library(
     ],
     deps = [
         "//drake/systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "global_collision_sensor",
+    srcs = [
+        "global_collision_sensor.cc",
+    ],
+    hdrs = [
+        "global_collision_sensor.h",
+    ],
+    deps = [
+        "//drake/systems/framework",
+        "//drake/multibody/rigid_body_plant",
     ],
 )
 
@@ -154,6 +169,17 @@ drake_cc_googletest(
     deps = [
         ":camera_info",
         "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "global_collision_sensor_test",
+    data = [
+        "//drake/multibody:models",
+    ],
+    deps = [
+        ":global_collision_sensor",
+        "//drake/multibody/parsers",
     ],
 )
 

--- a/drake/systems/sensors/global_collision_sensor.cc
+++ b/drake/systems/sensors/global_collision_sensor.cc
@@ -1,0 +1,77 @@
+#include "drake/systems/sensors/global_collision_sensor.h"
+
+#include <utility>
+#include <vector>
+
+#include <Eigen/Dense>
+
+using Eigen::VectorXd;
+
+using std::make_unique;
+using std::string;
+using std::unique_ptr;
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+GlobalCollisionSensor::GlobalCollisionSensor(const string& name,
+    unique_ptr<RigidBodyTree<double>> tree)
+    : name_(name), plant_(std::move(tree)) {
+  const RigidBodyTree<double>& t = plant_.get_rigid_body_tree();
+  input_port_index_ = DeclareInputPort(kVectorValued,
+      t.get_num_positions() + t.get_num_velocities()).get_index();
+  output_port_index_ = DeclareAbstractOutputPort().get_index();
+}
+
+GlobalCollisionSensor* GlobalCollisionSensor::AttachGlobalCollisionSensor(
+    const string& name,
+    unique_ptr<RigidBodyTree<double>> tree,
+    const OutputPortDescriptor<double>& plant_state_port,
+    DiagramBuilder<double>* builder) {
+  auto global_collision_sensor =
+      builder->template AddSystem<GlobalCollisionSensor>(name, std::move(tree));
+  builder->Connect(plant_state_port, global_collision_sensor->get_input_port());
+  return global_collision_sensor;
+}
+
+std::unique_ptr<AbstractValue> GlobalCollisionSensor::AllocateOutputAbstract(
+    const OutputPortDescriptor<double>& descriptor) const {
+  DRAKE_DEMAND(descriptor.get_data_type() == kAbstractValued);
+  if (descriptor.get_index() == output_port_index_) {
+    return make_unique<Value<ContactResults<double>>>(ContactResults<double>());
+  }
+  DRAKE_ABORT_MSG("Unknown abstract output port.");
+  return nullptr;
+}
+
+void GlobalCollisionSensor::DoCalcOutput(
+    const systems::Context<double>& context,
+    systems::SystemOutput<double>* output) const {
+  const VectorXd x = this->EvalEigenVectorInput(context, input_port_index_);
+  const RigidBodyTree<double>& tree = plant_.get_rigid_body_tree();
+
+  // Computes:
+  //
+  //  - q:    The RigidBodyPlant's position state vector.
+  //  - v:    The RigidBodyPlant's velocity state vector.
+  //
+  // Note that x = [q, v].
+  //
+  const auto q = x.head(tree.get_num_positions());
+  const auto v = x.tail(tree.get_num_velocities());
+
+  // TODO(liang.fok): Obtain the KinematicsCache directly from the context
+  // instead of recomputing it here.
+  const KinematicsCache<double> cache = tree.doKinematics(q, v);
+
+  // Updates the contact results output port.
+  auto& contact_results =
+      output->GetMutableData(output_port_index_)->
+          template GetMutableValue<ContactResults<double>>();
+  VectorX<double> result = plant_.ComputeContactForce(cache, &contact_results);
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/global_collision_sensor.h
+++ b/drake/systems/sensors/global_collision_sensor.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/system.h"
+#include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/// An ideal sensor that measures collisions between any two bodies in the
+/// world.
+///
+/// <B>%System Input Port:</B>
+///
+/// This system has one input port that is accessible via the following
+/// accessor:
+///
+///  - get_input_port(): Contains `x`, the generalized joint position and
+///    velocity state vector of the world.
+///
+/// <B>%System Output Port:</B>
+///
+/// This system has one output port that is accessible via the following
+/// accessor:
+///
+///  - get_output_port(): Contains the sensed collision data in this sensor's
+///    frame. It's an abstract port containing a `ContactResults<double>`.
+///
+/// @ingroup sensor_systems
+///
+class GlobalCollisionSensor : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GlobalCollisionSensor);
+
+  /// A constructor that initializes an GlobalCollisionSensor.
+  ///
+  /// @param[in] name The name of the GlobalCollisionSensor. This can be any
+  /// value.
+  ///
+  /// @param[in] tree The RigidBodyTree that models the world being sensed.
+  ///
+  GlobalCollisionSensor(const std::string& name,
+      std::unique_ptr<RigidBodyTree<double>> tree);
+
+  /// Instantiates and attaches a GlobalCollisionSensor to a RigidBodyPlant. It
+  /// connects the GlobalCollisionSensor's plant state input port.
+  ///
+  /// @param[in] name The name of the sensor. This can be any value.
+  ///
+  /// @param[in] tree The RigidBodyTree that describes the world.
+  ///
+  /// @param[in] plant_state_port A descriptor of the port containing the
+  /// plant's generalized joint state vector.
+  ///
+  /// @param[out] builder A pointer to the DiagramBuilder to which the newly
+  /// instantiated GlobalCollisionSensor is added. This must not be `nullptr`.
+  ///
+  /// @return A pointer to the newly instantiated and added
+  /// GlobalCollisionSensor. The GlobalCollisionSensor is initially owned by the
+  /// builder. Ownership will subsequently be transferred to the Diagram that is
+  /// built by the builder.
+  static GlobalCollisionSensor* AttachGlobalCollisionSensor(
+      const std::string& name,
+      std::unique_ptr<RigidBodyTree<double>> tree,
+      const OutputPortDescriptor<double>& plant_state_port,
+      DiagramBuilder<double>* builder);
+
+  /// Returns the name of this sensor.
+  const std::string& get_name() const { return name_; }
+
+  const RigidBodyTree<double>& get_tree() {
+    return plant_.get_rigid_body_tree();
+  }
+
+  /// Returns a descriptor of the input port that contains `x`, the generalized
+  /// position and velocity vector of the world.
+  const InputPortDescriptor<double>& get_input_port() const {
+    return System<double>::get_input_port(input_port_index_);
+  }
+
+  /// Returns a descriptor of the output port that contains the sensed
+  /// ContactResults<double> value.
+  const OutputPortDescriptor<double>& get_output_port() const {
+    return System<double>::get_output_port(output_port_index_);
+  }
+
+ protected:
+  /// Allocates the data for the abstract-valued output port specified by
+  /// @p descriptor.
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<double>& descriptor) const override;
+
+  /// Computes the "sensed" collisions.
+  void DoCalcOutput(const systems::Context<double>& context,
+                    systems::SystemOutput<double>* output) const override;
+
+ private:
+  const std::string name_;
+  const RigidBodyPlant<double> plant_;
+
+  int input_port_index_{};
+  int output_port_index_{};
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/test/global_collision_sensor_test.cc
+++ b/drake/systems/sensors/test/global_collision_sensor_test.cc
@@ -1,0 +1,155 @@
+#include "drake/systems/sensors/global_collision_sensor.h"
+
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/drake_path.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/system_output.h"
+
+using std::make_unique;
+using std::string;
+using std::stringstream;
+using std::unique_ptr;
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace {
+
+GTEST_TEST(TestGlobalCollisionSensor, TopologyTest) {
+  const char* const kSensorName = "my collision sensor";
+
+  auto tree_ptr = make_unique<RigidBodyTree<double>>();
+
+  // Defines the Device Under Test (DUT).
+  GlobalCollisionSensor dut(kSensorName, std::move(tree_ptr));
+  const RigidBodyTree<double>& tree = dut.get_tree();
+
+  ASSERT_EQ(dut.get_num_input_ports(), 1);
+  const auto& input_descriptor = dut.get_input_port();
+  EXPECT_EQ(input_descriptor.get_data_type(), systems::kVectorValued);
+  EXPECT_EQ(input_descriptor.size(),
+            tree.get_num_positions() + tree.get_num_velocities());
+
+  ASSERT_EQ(dut.get_num_output_ports(), 1);
+  const auto& collision_output = dut.get_output_port();
+  EXPECT_EQ(collision_output.get_data_type(), systems::kAbstractValued);
+}
+
+GTEST_TEST(TestGlobalCollisionSensor, BasicCollisionTest) {
+  const char* const kSensorName = "my collision sensor";
+
+  auto tree_ptr = make_unique<RigidBodyTree<double>>();
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() + "/multibody/models/box.urdf",
+      drake::multibody::joints::kQuaternion, nullptr /* weld to frame */,
+      tree_ptr.get());
+  drake::parsers::urdf::AddModelInstanceFromUrdfFile(
+      drake::GetDrakePath() + "/multibody/models/box.urdf",
+      drake::multibody::joints::kQuaternion, nullptr /* weld to frame */,
+      tree_ptr.get());
+
+  ASSERT_EQ(tree_ptr->get_num_model_instances(), 2);
+  ASSERT_EQ(tree_ptr->get_num_positions(), 14);
+  ASSERT_EQ(tree_ptr->get_num_velocities(), 12);
+
+  // Defines the Device Under Test (DUT).
+  GlobalCollisionSensor dut(kSensorName, std::move(tree_ptr));
+  const RigidBodyTree<double>& tree = dut.get_tree();
+  std::unique_ptr<systems::Context<double>> context =
+      dut.CreateDefaultContext();
+
+  const int num_positions = tree.get_num_positions();
+  const int num_velocities = tree.get_num_velocities();
+  const int num_states = num_positions + num_velocities;;
+  Eigen::VectorXd x = Eigen::VectorXd::Zero(num_states);
+  x.head(num_positions) = tree.getZeroConfiguration();
+
+  /* The indices of the position states within `x` are as follows:
+
+        Index   Name
+        ------ --------
+          0     base_x
+          1     base_y
+          2     base_z
+          3     base_qw
+          4     base_qx
+          5     base_qy
+          6     base_qz
+          7     base_x
+          8     base_y
+          9     base_z
+          10    base_qw
+          11    base_qx
+          12    base_qy
+          13    base_qz
+
+    The boxes are 0.1 m wide along their x-axes (they protrude by 0.05 m on each
+    side of the axis). Thus, placing one box at x = 0 and the other at x = 0.11
+    will result in a separation of 0.11 m, which should be sufficient to avoid
+    collision between the two boxes.
+  */
+  x(0) = 0;
+  x(7) = 0.11;
+
+  // Places the boxes far enough away from each other so as to avoid contact.
+  // Then verifies there are no sensed collisions.
+  BasicVector<double>* input_vector =
+      context->FixInputPort(dut.get_input_port().get_index(), x);
+  EXPECT_EQ(input_vector->size(), num_states);
+
+  std::unique_ptr<systems::SystemOutput<double>> output =
+      dut.AllocateOutput(*context);;
+  dut.CalcOutput(*context, output.get());
+
+  const AbstractValue* output_value =
+      output->get_data(dut.get_output_port().get_index());
+  ASSERT_NE(output_value, nullptr);
+  const ContactResults<double>& contact_results =
+      output_value->GetValueOrThrow<ContactResults<double>>();
+
+  EXPECT_EQ(contact_results.get_num_contacts(), 0);
+
+  // Places the boxes in contact with each other and verifies that the
+  // GlobalCollisionSensor senses the collision. In this case, one box is placed
+  // at x = -0.04 and the other box is placed at x = 0.04, resulting in a
+  // separation distance of 0.08, which results in an overlap of
+  // 0.08 - 0.1 = -0.02 m.
+  x(0) = -0.04;
+  x(7) = 0.04;
+  input_vector->set_value(x);
+  dut.CalcOutput(*context, output.get());
+  EXPECT_EQ(contact_results.get_num_contacts(), 1);
+}
+
+GTEST_TEST(TestGlobalCollisionSensor, AttachGlobalCollisionSensorTest) {
+  auto world_tree_ptr = make_unique<RigidBodyTree<double>>();
+  auto collision_tree_ptr = make_unique<RigidBodyTree<double>>();
+  DiagramBuilder<double> builder;
+  auto plant = builder.AddSystem<RigidBodyPlant>(std::move(world_tree_ptr));
+  GlobalCollisionSensor* collision_sensor =
+      GlobalCollisionSensor::AttachGlobalCollisionSensor(
+          "Foo Collision Sensor",
+          std::move(collision_tree_ptr),
+          plant->state_output_port(),
+          &builder);
+  EXPECT_NE(collision_sensor, nullptr);
+  std::unique_ptr<Diagram<double>> diagram = builder.Build();
+  ASSERT_NE(diagram.get(), nullptr);
+  std::vector<const systems::System<double>*> subsystems =
+      diagram->GetSystems();
+  ASSERT_EQ(subsystems.size(), 2u);
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This global collision sensor is useful for simulations that involve non-physics-based agents. Once `GeometyWorld` exists, this sensor will be updated to internally use it rather than a `RigidBodyPlant`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5435)
<!-- Reviewable:end -->
