### PR TITLE
Add FixInputPortsFrom to System<T>.

### DIFF
--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -334,8 +334,13 @@ class Context {
     parent_ = parent;
   }
 
-  // Throws an exception unless the given @p descriptor matches this context.
-  void VerifyInputPort(const InputPortDescriptor<T>& descriptor) const {
+  /// Throws an exception unless the given @p descriptor matches the inputs
+  /// actually connected to this context in shape.
+  /// Supports any scalar type of `descriptor`, but expects T by default.
+  ///
+  /// @tparam T1 the scalar type of the InputPortDescriptor to check.
+  template<typename T1 = T>
+  void VerifyInputPort(const InputPortDescriptor<T1>& descriptor) const {
     const int i = descriptor.get_index();
     const InputPort* port = GetInputPort(i);
     // If the port isn't connected, we don't have anything else to check.
@@ -344,7 +349,8 @@ class Context {
 
     // In the vector-valued case, check the size.
     if (descriptor.get_data_type() == kVectorValued) {
-      const BasicVector<T>* input_vector = port->template get_vector_data<T>();
+      const BasicVector<T>* input_vector =
+          port->template get_vector_data<T>();
       DRAKE_THROW_UNLESS(input_vector != nullptr);
       DRAKE_THROW_UNLESS(input_vector->size() == descriptor.size());
     }

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "drake/common/autodiff_overloads.h"
@@ -761,9 +762,13 @@ class System {
     }
   }
 
-  /// Checks that @p context is consistent for this system.
+  /// Checks that @p context is consistent for this System template. Supports
+  /// any scalar type, but expects T by default.
+  ///
   /// @throw exception unless `context` is valid for this system.
-  void CheckValidContext(const Context<T>& context) const {
+  /// @tparam T1 the scalar type of the Context to check.
+  template <typename T1 = T>
+  void CheckValidContext(const Context<T1>& context) const {
     // Checks that the number of input ports in the context is consistent with
     // the number of ports declared by the System.
     DRAKE_THROW_UNLESS(context.get_num_input_ports() ==
@@ -890,6 +895,51 @@ class System {
     return std::unique_ptr<S<symbolic::Expression>>(
         dynamic_cast<S<symbolic::Expression>*>(clone.release()));
   }
+  //@}
+
+
+  //----------------------------------------------------------------------------
+  /// @name                Transmogrification utilities
+
+  /// Fixes all of the input ports in @p target_context to their current values
+  /// in @p other_context, as evaluated by @p other_system. Throws an exception
+  /// unless `other_context` and `target_context` both have the same shape as
+  /// this System, and the `other_system`. Ignores disconnected inputs.
+  void FixInputPortsFrom(const System<double>& other_system,
+                         const Context<double>& other_context,
+                         Context<T>* target_context) const {
+    DRAKE_ASSERT_VOID(CheckValidContext(other_context));
+    DRAKE_ASSERT_VOID(CheckValidContext(*target_context));
+    DRAKE_ASSERT_VOID(other_system.CheckValidContext(other_context));
+    DRAKE_ASSERT_VOID(other_system.CheckValidContext(*target_context));
+
+    for (int i = 0; i < get_num_input_ports(); ++i) {
+      const auto& descriptor = get_input_port(i);
+
+      if (descriptor.get_data_type() == kVectorValued) {
+        // For vector-valued input ports, we placewise initialize a fixed input
+        // vector using the explicit conversion from double to T.
+        const BasicVector<double>* other_vec =
+            other_system.EvalVectorInput(other_context, i);
+        if (other_vec == nullptr) continue;
+        auto our_vec = this->AllocateInputVector(descriptor);
+        for (int j = 0; j < our_vec->size(); ++j) {
+          our_vec->SetAtIndex(j, T(other_vec->GetAtIndex(j)));
+        }
+        target_context->FixInputPort(i, std::move(our_vec));
+      } else if (descriptor.get_data_type() == kAbstractValued) {
+        // For abstract-valued input ports, we just clone the value and fix
+        // it to the port.
+        const AbstractValue* other_value = other_system.EvalAbstractInput(
+            other_context, i);
+        if (other_value == nullptr) continue;
+        target_context->FixInputPort(i, other_value->Clone());
+      } else {
+        DRAKE_ABORT_MSG("Unknown descriptor type.");
+      }
+    }
+  }
+
   //@}
 
  protected:

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -292,65 +292,67 @@ TEST_F(SystemTest, PortDescriptorsAreStable) {
   EXPECT_EQ(kAbstractValued, first_output.get_data_type());
 }
 
-class TestTypedVector : public BasicVector<double> {
+template <typename T>
+class TestTypedVector : public BasicVector<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestTypedVector)
-  explicit TestTypedVector(int size) : BasicVector(size) {}
+  explicit TestTypedVector(int size) : BasicVector<T>(size) {}
 
  protected:
   TestTypedVector* DoClone() const {
-    return new TestTypedVector(size());
+    return new TestTypedVector(this->size());
   }
 };
 
-// A shell System for AbstractValue IO test
-class ValueIOTestSystem : public System<double> {
+// A shell System for AbstractValue IO test.
+template <typename T>
+class ValueIOTestSystem : public System<T> {
  public:
   // Has 2 input and 2 output ports.
   // The first input / output pair are abstract type, but assumed to be
   // std::string.
   // The second input / output pair are vector type with length 1.
   ValueIOTestSystem() {
-    DeclareAbstractInputPort();
-    DeclareAbstractOutputPort();
+    this->DeclareAbstractInputPort();
+    this->DeclareAbstractOutputPort();
 
-    DeclareInputPort(kVectorValued, 1);
-    DeclareOutputPort(kVectorValued, 1);
+    this->DeclareInputPort(kVectorValued, 1);
+    this->DeclareOutputPort(kVectorValued, 1);
 
-    set_name("ValueIOTestSystem");
+    this->set_name("ValueIOTestSystem");
   }
 
   ~ValueIOTestSystem() override {}
 
   AbstractValue* DoAllocateInputAbstract(
-      const InputPortDescriptor<double>& descriptor) const override {
+      const InputPortDescriptor<T>& descriptor) const override {
     // Should only get called for the first input.
     EXPECT_EQ(descriptor.get_index(), 0);
     return AbstractValue::Make<std::string>("").release();
   }
 
-  BasicVector<double>* DoAllocateInputVector(
-      const InputPortDescriptor<double>& descriptor) const override {
+  BasicVector<T>* DoAllocateInputVector(
+      const InputPortDescriptor<T>& descriptor) const override {
     // Should only get called for the second input.
     EXPECT_EQ(descriptor.get_index(), 1);
-    return new TestTypedVector(1);
+    return new TestTypedVector<T>(1);
   }
 
-  std::unique_ptr<ContinuousState<double>> AllocateTimeDerivatives()
+  std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives()
       const override {
     return nullptr;
   }
 
-  std::unique_ptr<Context<double>> AllocateContext() const override {
-    std::unique_ptr<LeafContext<double>> context(new LeafContext<double>);
+  std::unique_ptr<Context<T>> AllocateContext() const override {
+    std::unique_ptr<LeafContext<T>> context(new LeafContext<T>);
     context->SetNumInputPorts(this->get_num_input_ports());
-    return std::unique_ptr<Context<double>>(context.release());
+    return std::unique_ptr<Context<T>>(context.release());
   }
 
-  void SetDefaultState(const Context<double>& context,
-                       State<double>* state) const override {}
+  void SetDefaultState(const Context<T>& context,
+                       State<T>* state) const override {}
 
-  void SetDefaults(Context<double>* context) const override {}
+  void SetDefaults(Context<T>* context) const override {}
 
   bool HasAnyDirectFeedthrough() const override {
     return true;
@@ -365,78 +367,104 @@ class ValueIOTestSystem : public System<double> {
   }
 
   // Append "output" to input(0), and sets output(1) = 2 * input(1).
-  void DoCalcOutput(const Context<double>& context,
-                    SystemOutput<double>* output) const override {
-    const std::string* str_in = EvalInputValue<std::string>(context, 0);
+  void DoCalcOutput(const Context<T>& context,
+                    SystemOutput<T>* output) const override {
+    const std::string* str_in =
+        this->template EvalInputValue<std::string>(context, 0);
 
     std::string& str_out =
-        output->GetMutableData(0)->GetMutableValue<std::string>();
+        output->GetMutableData(0)->template GetMutableValue<std::string>();
     str_out = *str_in + "output";
 
-    const BasicVector<double>* vec_in = EvalVectorInput(context, 1);
-    BasicVector<double>* vec_out = output->GetMutableVectorData(1);
+    const BasicVector<T>* vec_in = this->EvalVectorInput(context, 1);
+    BasicVector<T>* vec_out = output->GetMutableVectorData(1);
 
     vec_out->get_mutable_value() = 2 * vec_in->get_value();
   }
 
-  std::unique_ptr<SystemOutput<double>> AllocateOutput(
-      const Context<double>& context) const override {
-    std::unique_ptr<LeafSystemOutput<double>> output(
-        new LeafSystemOutput<double>);
+  std::unique_ptr<SystemOutput<T>> AllocateOutput(
+      const Context<T>& context) const override {
+    std::unique_ptr<LeafSystemOutput<T>> output(
+        new LeafSystemOutput<T>);
     output->add_port(
         std::unique_ptr<AbstractValue>(new Value<std::string>("output")));
 
     output->add_port(std::make_unique<OutputPort>(
-        std::make_unique<BasicVector<double>>(1)));
+        std::make_unique<BasicVector<T>>(1)));
 
-    return std::unique_ptr<SystemOutput<double>>(output.release());
+    return std::unique_ptr<SystemOutput<T>>(output.release());
   }
 };
 
-GTEST_TEST(SystemIOTest, SystemValueIOTest) {
-  ValueIOTestSystem test_sys;
+class SystemIOTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    context_ = test_sys_.CreateDefaultContext();
+    output_ = test_sys_.AllocateOutput(*context_);
 
-  std::unique_ptr<Context<double>> context = test_sys.CreateDefaultContext();
-  std::unique_ptr<SystemOutput<double>> output =
-      test_sys.AllocateOutput(*context);
+    // make string input
+    std::unique_ptr<Value<std::string>> str_input =
+        std::make_unique<Value<std::string>>("input");
+    context_->SetInputPort(
+        0, std::make_unique<FreestandingInputPort>(std::move(str_input)));
 
-  // make string input
-  std::unique_ptr<Value<std::string>> str_input =
-      std::make_unique<Value<std::string>>("input");
-  context->SetInputPort(
-      0, std::make_unique<FreestandingInputPort>(std::move(str_input)));
+    // make vector input
+    std::unique_ptr<BasicVector<double>> vec_input =
+        std::make_unique<BasicVector<double>>(1);
+    vec_input->SetAtIndex(0, 2);
+    context_->SetInputPort(
+        1, std::make_unique<FreestandingInputPort>(std::move(vec_input)));
+  }
 
-  // make vector input
-  std::unique_ptr<BasicVector<double>> vec_input =
-      std::make_unique<BasicVector<double>>(1);
-  vec_input->SetAtIndex(0, 2);
-  context->SetInputPort(
-      1, std::make_unique<FreestandingInputPort>(std::move(vec_input)));
+  ValueIOTestSystem<double> test_sys_;
+  std::unique_ptr<Context<double>> context_;
+  std::unique_ptr<SystemOutput<double>> output_;
+};
 
-  test_sys.CalcOutput(*context, output.get());
+TEST_F(SystemIOTest, SystemValueIOTest) {
+  test_sys_.CalcOutput(*context_, output_.get());
 
-  EXPECT_EQ(context->get_num_input_ports(), 2);
-  EXPECT_EQ(output->get_num_ports(), 2);
+  EXPECT_EQ(context_->get_num_input_ports(), 2);
+  EXPECT_EQ(output_->get_num_ports(), 2);
 
-  EXPECT_EQ(output->get_data(0)->GetValue<std::string>(),
+  EXPECT_EQ(output_->get_data(0)->GetValue<std::string>(),
             std::string("inputoutput"));
-  EXPECT_EQ(output->get_vector_data(1)->get_value()(0), 4);
+  EXPECT_EQ(output_->get_vector_data(1)->get_value()(0), 4);
 
   // Test AllocateInput*
   // Second input is not (yet) a TestTypedVector, since I haven't called the
   // Allocate methods directly yet.
-  EXPECT_EQ(dynamic_cast<const TestTypedVector*>(
-                test_sys.EvalVectorInput(*context, 1)),
+  EXPECT_EQ(dynamic_cast<const TestTypedVector<double>*>(
+                test_sys_.EvalVectorInput(*context_, 1)),
             nullptr);
   // Now allocate.
-  test_sys.AllocateFreestandingInputs(context.get());
+  test_sys_.AllocateFreestandingInputs(context_.get());
   // First input should have been re-allocated to the empty string.
-  EXPECT_EQ(test_sys.EvalAbstractInput(*context, 0)->GetValue<std::string>(),
-            std::string(""));
+  EXPECT_EQ(test_sys_.EvalAbstractInput(*context_, 0)->GetValue<std::string>(),
+            "");
   // Second input should now be of type TestTypedVector.
-  EXPECT_NE(dynamic_cast<const TestTypedVector*>(
-                test_sys.EvalVectorInput(*context, 1)),
+  EXPECT_NE(dynamic_cast<const TestTypedVector<double>*>(
+                test_sys_.EvalVectorInput(*context_, 1)),
             nullptr);
+}
+
+// Tests that FixInputPortsFrom allocates ports of the same dimension as the
+// source context, with the values computed by the source system, and that
+// double values in vector-valued ports are explicitly converted to AutoDiffXd.
+TEST_F(SystemIOTest, TransmogrifyAndFix) {
+  ValueIOTestSystem<AutoDiffXd> dest_system;
+  auto dest_context = dest_system.AllocateContext();
+  dest_system.FixInputPortsFrom(test_sys_, *context_, dest_context.get());
+
+  EXPECT_EQ(
+      dest_system.EvalAbstractInput(*dest_context, 0)->GetValue<std::string>(),
+      "input");
+
+  const TestTypedVector<AutoDiffXd>* fixed_vec =
+      dest_system.EvalVectorInput<TestTypedVector>(*dest_context, 1);
+  EXPECT_NE(fixed_vec, nullptr);
+  EXPECT_EQ(2, fixed_vec->GetAtIndex(0).value());
+  EXPECT_EQ(0, fixed_vec->GetAtIndex(0).derivatives().size());
 }
 
 }  // namespace


### PR DESCRIPTION
Coupled with `Context<T>::SetTimeStateAndParametersFrom`, this enables clients to upconvert a `Context<double>` to `Context<AutoDiffXd>`, at any given moment in the evolution of the `Context<double>`.

@edrumwri for feature review.  The payoff is at `system_test.cc:457`, let me know if it meets your needs!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5436)
<!-- Reviewable:end -->
