### PR TITLE
Implements RollPitchYawToQuaternion()

### DIFF
--- a/drake/math/roll_pitch_yaw_using_quaternion.h
+++ b/drake/math/roll_pitch_yaw_using_quaternion.h
@@ -36,8 +36,10 @@ Vector4<typename Derived::Scalar> rpy2axis(
 /**
  * Computes the Quaternion representation of a rotation given the set of Euler
  * angles describing this rotation. These angles follow the Tait–Bryan formalism
- * about body-fixed z-y'-x'' axes.
- * @param rpy A vector in ℝ³ with the Euler angles `rpy = [roll, pitch, yaw]`.
+ * about body-fixed z-y'-x'' axes. This convention is equivalent to a
+ * space-fixed x-y-z sequence.
+ * @param rpy A vector conveniently packing the Euler angles as
+ *            `rpy = [roll, pitch, yaw]`.
  *            These are defined such that they represent the rotations about the
  *            body-fixed z-y'-x'' axes.
  * @return A Quaternion representing the same rotation given by the input Euler
@@ -47,12 +49,7 @@ template <typename Derived>
 Quaternion<typename Derived::Scalar> RollPitchYawToQuaternion(
     const Eigen::MatrixBase<Derived>& rpy) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 3);
-  auto quaternion_as_vector4 = rpy2quat(rpy);
-  return Quaternion<typename Derived::Scalar>(
-      quaternion_as_vector4[0],
-      quaternion_as_vector4[1],
-      quaternion_as_vector4[2],
-      quaternion_as_vector4[3]);
+  return quat2eigenQuaternion(rpy2quat(rpy));
 }
 
 }  // namespace math

--- a/drake/math/roll_pitch_yaw_using_quaternion.h
+++ b/drake/math/roll_pitch_yaw_using_quaternion.h
@@ -32,5 +32,28 @@ Vector4<typename Derived::Scalar> rpy2axis(
   // the range problem in Eigen
   return quat2axis(rpy2quat(rpy));
 }
+
+/**
+ * Computes the Quaternion representation of a rotation given the set of Euler
+ * angles describing this rotation. These angles follow the Tait–Bryan formalism
+ * about body-fixed z-y'-x'' axes.
+ * @param rpy A vector in ℝ³ with the Euler angles `rpy = [roll, pitch, yaw]`.
+ *            These are defined such that they represent the rotations about the
+ *            body-fixed z-y'-x'' axes.
+ * @return A Quaternion representing the same rotation given by the input Euler
+ *         angles `rpy`.
+ */
+template <typename Derived>
+Quaternion<typename Derived::Scalar> RollPitchYawToQuaternion(
+    const Eigen::MatrixBase<Derived>& rpy) {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 3);
+  auto quaternion_as_vector4 = rpy2quat(rpy);
+  return Quaternion<typename Derived::Scalar>(
+      quaternion_as_vector4[0],
+      quaternion_as_vector4[1],
+      quaternion_as_vector4[2],
+      quaternion_as_vector4[3]);
+}
+
 }  // namespace math
 }  // namespace drake

--- a/drake/math/test/rotation_conversion_test.cc
+++ b/drake/math/test/rotation_conversion_test.cc
@@ -587,6 +587,10 @@ TEST_F(RotationConversionTest, RPYAxis) {
   }
 }
 
+// Verifies the correctness of the method drake::math::rpy2quat() by comparing
+// its output to a quaternion obtained using the composition of
+// Eigen::AngleAxisd transformations in the method
+// BodyZYXAnglesToEigenQuaternion() local in this file.
 TEST_F(RotationConversionTest, RPYQuat) {
   // Compute the quaternion representation using Eigen's geometry model,
   // compare the result with rpy2quat
@@ -601,6 +605,23 @@ TEST_F(RotationConversionTest, RPYQuat) {
     EXPECT_TRUE(AreRollPitchYawForSameOrientation(rpyi, rpy_expected));
     EXPECT_TRUE(
         AreRollPitchYawForSameOrientation(rpyi, rotmat2rpy(rpy2rotmat(rpyi))));
+  }
+}
+
+// Verifies the correctness of the method
+// drake::math::RollPitchYawToQuaternion() by comparing
+// its output to a quaternion obtained using the composition of
+// Eigen::AngleAxisd transformations in the method
+// BodyZYXAnglesToEigenQuaternion() local in this file.
+TEST_F(RotationConversionTest, RollPitchYawToQuaternion) {
+  // Compute the quaternion representation using Eigen's geometry model,
+  // compare the result with rpy2quat
+  for (const auto& rpyi : rpy_test_cases_) {
+    Vector3d bodyZYX_angles(rpyi(2), rpyi(1), rpyi(0));
+    auto quat_expected = BodyZYXAnglesToEigenQuaternion(bodyZYX_angles);
+    auto quat = RollPitchYawToQuaternion(rpyi);
+    EXPECT_TRUE(
+        quat.isApprox(quat_expected, Eigen::NumTraits<double>::epsilon()));
   }
 }
 


### PR DESCRIPTION
Implements a method to obtain an `Eigen::Quaternion` given the a set of Euler angles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5438)
<!-- Reviewable:end -->
