### PR TITLE
Correct the drift of the box that slowly rotates

### DIFF
--- a/drake/examples/kuka_iiwa_arm/models/objects/block_for_pick_and_place.urdf
+++ b/drake/examples/kuka_iiwa_arm/models/objects/block_for_pick_and_place.urdf
@@ -17,10 +17,73 @@
       </material>
     </visual>
 
+    <!--
+      This places contact spheres on the corners of the visual box and a
+      *slightly* smaller inset contact box (centered on the visual origin). This
+      accounts for issues in the contact computation providing stable table
+      contact *and* supports grasping.
+
+      When the box is in stable contact with the ground plane, the corner
+      spheres will provide fixed contact points (simulating distributed contact
+      points around the face).  However, for arbitrary grip configuration, the
+      slightly inset box will provide contact with a *slight* offset (in this
+      case a deviation of 0.0005 m from the visual surface).
+     -->
     <collision>
       <geometry>
-        <box size="0.06 0.06 0.2" />
+        <box size="0.059 0.059 0.199" />
       </geometry>
     </collision>
+
+    <collision>
+      <origin xyz="-0.03 -0.03 -0.1" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1e-7"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="-0.03 0.03 -0.1" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1e-7"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.03 0.03 -0.1" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1e-7"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.03 -0.03 -0.1" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1e-7"/>
+      </geometry>
+    </collision>
+
+    <collision>
+      <origin xyz="-0.03 -0.03 0.1" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1e-7"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="-0.03 0.03 0.1" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1e-7"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.03 0.03 0.1" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1e-7"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.03 -0.03 0.1" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="1e-7"/>
+      </geometry>
+    </collision>
+
    </link>
 </robot>


### PR DESCRIPTION
With the advent of the new contact model, it has been reported that the box in the `iiwa_wsg_simulation` demo gradually rotates in place.

The primary cause for this is how we handle surface-to-surface contact.  Contact across the entire surface is reduced to contact at a single point, but we have no guarantees about the continuity of that point.  (In fact, we have guarantees that it will jump.)  This behavior can be mitigated by using a better integrator (RK3) and/or reducing the time step.  

However, we can also account for it by modifying the collision representation of the box to accommodate the weaknesses in the contact.  With the following change, we can virtually eliminate the rotational drift *and* maintain the same simulation parameters: modify how the box handles contact with dedicated contacts for surface  contact and another for gripper contact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5441)
<!-- Reviewable:end -->
