### PR TITLE
Updates documentation of Maliput Railcar's s_dot to be "time derivative of s" as opposed to "speed".

### DIFF
--- a/drake/automotive/gen/maliput_railcar_config.cc
+++ b/drake/automotive/gen/maliput_railcar_config.cc
@@ -9,7 +9,7 @@ namespace automotive {
 const int MaliputRailcarConfigIndices::kNumCoordinates;
 const int MaliputRailcarConfigIndices::kR;
 const int MaliputRailcarConfigIndices::kH;
-const int MaliputRailcarConfigIndices::kInitialSpeed;
+const int MaliputRailcarConfigIndices::kInitialSDot;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_config.h
+++ b/drake/automotive/gen/maliput_railcar_config.h
@@ -22,7 +22,7 @@ struct MaliputRailcarConfigIndices {
   // The index of each individual coordinate.
   static const int kR = 0;
   static const int kH = 1;
-  static const int kInitialSpeed = 2;
+  static const int kInitialSDot = 2;
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -51,10 +51,11 @@ class MaliputRailcarConfig : public systems::BasicVector<T> {
   /// The vehicle's height above the lane's surface.
   const T& h() const { return this->GetAtIndex(K::kH); }
   void set_h(const T& h) { this->SetAtIndex(K::kH, h); }
-  /// The vehicle's initial speed along the lane's s-axis.
-  const T& initial_speed() const { return this->GetAtIndex(K::kInitialSpeed); }
-  void set_initial_speed(const T& initial_speed) {
-    this->SetAtIndex(K::kInitialSpeed, initial_speed);
+  /// The initial time derivative of the vehicle's `s` coordinate. See
+  /// MaliputRailcar's class description for more details.
+  const T& initial_s_dot() const { return this->GetAtIndex(K::kInitialSDot); }
+  void set_initial_s_dot(const T& initial_s_dot) {
+    this->SetAtIndex(K::kInitialSDot, initial_s_dot);
   }
   //@}
 
@@ -64,7 +65,7 @@ class MaliputRailcarConfig : public systems::BasicVector<T> {
     auto result = (T(0) == T(0));
     result = result && !isnan(r());
     result = result && !isnan(h());
-    result = result && !isnan(initial_speed());
+    result = result && !isnan(initial_s_dot());
     return result;
   }
 };

--- a/drake/automotive/gen/maliput_railcar_config_translator.cc
+++ b/drake/automotive/gen/maliput_railcar_config_translator.cc
@@ -25,7 +25,7 @@ void MaliputRailcarConfigTranslator::Serialize(
   message.timestamp = static_cast<int64_t>(time * 1000);
   message.r = vector->r();
   message.h = vector->h();
-  message.initial_speed = vector->initial_speed();
+  message.initial_s_dot = vector->initial_s_dot();
   const int lcm_message_length = message.getEncodedSize();
   lcm_message_bytes->resize(lcm_message_length);
   message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
@@ -47,7 +47,7 @@ void MaliputRailcarConfigTranslator::Deserialize(
   }
   my_vector->set_r(message.r);
   my_vector->set_h(message.h);
-  my_vector->set_initial_speed(message.initial_speed);
+  my_vector->set_initial_s_dot(message.initial_s_dot);
 }
 
 }  // namespace automotive

--- a/drake/automotive/gen/maliput_railcar_state.h
+++ b/drake/automotive/gen/maliput_railcar_state.h
@@ -44,10 +44,11 @@ class MaliputRailcarState : public systems::BasicVector<T> {
 
   /// @name Getters and Setters
   //@{
-  /// The position along the lane's s-axis.
+  /// The s-coordinate of the vehicle in lane-space.
   const T& s() const { return this->GetAtIndex(K::kS); }
   void set_s(const T& s) { this->SetAtIndex(K::kS, s); }
-  /// The speed along the lane's s-axis.
+  /// The time derivative of the vehicle's `s` coordinate. See MaliputRailcar's
+  /// class description for more details.
   const T& s_dot() const { return this->GetAtIndex(K::kSDot); }
   void set_s_dot(const T& s_dot) { this->SetAtIndex(K::kSDot, s_dot); }
   //@}

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -25,7 +25,7 @@ namespace automotive {
 // Linkage for MaliputRailcar constants.
 template <typename T> constexpr double MaliputRailcar<T>::kDefaultR;
 template <typename T> constexpr double MaliputRailcar<T>::kDefaultH;
-template <typename T> constexpr double MaliputRailcar<T>::kDefaultSpeed;
+template <typename T> constexpr double MaliputRailcar<T>::kDefaultSDot;
 
 template <typename T>
 MaliputRailcar<T>::MaliputRailcar(const Lane& lane, double start_time)
@@ -134,14 +134,13 @@ void MaliputRailcar<T>::ImplCalcTimeDerivatives(
     const MaliputRailcarConfig<T>& config,
     const MaliputRailcarState<T>& state,
     MaliputRailcarState<T>* rates) const {
-  const T speed = config.initial_speed();
+  const T s_dot = config.initial_s_dot();
   if (state.s() < 0 || state.s() >= lane_.length()) {
     rates->set_s(0);
   } else {
-    rates->set_s(speed);
+    rates->set_s(s_dot);
   }
-  // TODO(liang.fok): Set this to the desired acceleration once it is an input
-  // into this system.
+  // TODO(liang.fok): Set this to s_dot_dot once it is a system input.
   rates->set_s_dot(0);
 }
 
@@ -187,7 +186,7 @@ void MaliputRailcar<T>::SetDefaultParameters(MaliputRailcarConfig<T>* config) {
   DRAKE_DEMAND(config != nullptr);
   config->set_r(kDefaultR);
   config->set_h(kDefaultH);
-  config->set_initial_speed(kDefaultSpeed);
+  config->set_initial_s_dot(kDefaultSDot);
 }
 
 // This section must match the API documentation in maliput_railcar.h.

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -16,15 +16,11 @@ namespace automotive {
 /// it were on rails and neglecting all physics. It can only move forward at a
 /// predetermined speed.
 ///
-/// Configuration (for more details, see MaliputRailcarConfig):
-///   * A `const` reference to a maliput::api::Lane that it should follow.
-///   * An `h` height above the lane's surface.
-///   * An `r` offset from the lane's `s` axis.
-///   * An `initial_speed` at which the vehicle should initially move.
+/// Configuration:
+///   * See MaliputRailcarConfig.
 ///
-/// State vector (for more details, see MaliputRailcarState):
-///   * position: `s`
-///   * speed: `s_dot`
+/// State vector:
+///   * See MaliputRailcarState.
 ///
 /// <B>Input Port Accessors:</B>
 ///
@@ -84,7 +80,7 @@ class MaliputRailcar : public systems::LeafSystem<T> {
 
   static constexpr double kDefaultR = 0;      // meters
   static constexpr double kDefaultH = 0;      // meters
-  static constexpr double kDefaultSpeed = 1;  // meters / second
+  static constexpr double kDefaultSDot = 1;   // time derivative of `s`
 
  protected:
   // LeafSystem<T> overrides.

--- a/drake/automotive/maliput_railcar_config.named_vector
+++ b/drake/automotive/maliput_railcar_config.named_vector
@@ -7,6 +7,6 @@ element {
     doc: "The vehicle's height above the lane's surface."
 }
 element {
-    name: "initial_speed"
-    doc: "The vehicle's initial speed along the lane's s-axis."
+    name: "initial_s_dot"
+    doc: "The initial time derivative of the vehicle's `s` coordinate. See MaliputRailcar's class description for more details."
 }

--- a/drake/automotive/maliput_railcar_state.named_vector
+++ b/drake/automotive/maliput_railcar_state.named_vector
@@ -1,8 +1,8 @@
 element {
     name: "s"
-    doc: "The position along the lane's s-axis."
+    doc: "The s-coordinate of the vehicle in lane-space."
 }
 element {
     name: "s_dot"
-    doc: "The speed along the lane's s-axis."
+    doc: "The time derivative of the vehicle's `s` coordinate. See MaliputRailcar's class description for more details."
 }

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -74,7 +74,7 @@ class MaliputRailcarTest : public ::testing::Test {
   }
 
   // Sets the configuration parameters of the vehicle.
-  void SetConfig(double r, double h, double initial_speed) {
+  void SetConfig(double r, double h, double initial_s_dot) {
     LeafContext<double>* leaf_context =
         dynamic_cast<LeafContext<double>*>(context_.get());
     ASSERT_NE(leaf_context, nullptr);
@@ -88,7 +88,7 @@ class MaliputRailcarTest : public ::testing::Test {
     ASSERT_NE(config, nullptr);
     config->set_r(1.5);
     config->set_h(8.2);
-    config->set_initial_speed(initial_speed);
+    config->set_initial_s_dot(initial_s_dot);
   }
 
   // The arc radius of the road's s-axis when the road is created using
@@ -183,7 +183,7 @@ TEST_F(MaliputRailcarTest, StateAppearsInOutputMonolane) {
 TEST_F(MaliputRailcarTest, NonZeroParametersAppearInOutputDragway) {
   EXPECT_NO_FATAL_FAILURE(InitializeDragwayLane());
   // Sets the parameters to be non-zero values.
-  SetConfig(1.5 /* r */, 8.2 /* h */, 1 /* initial speed */);
+  SetConfig(1.5 /* r */, 8.2 /* h */, 1 /* initial s_dot */);
   dut_->CalcOutput(*context_, output_.get());
   auto pose = pose_output();
   Eigen::Isometry3d expected_pose = Eigen::Isometry3d::Identity();
@@ -196,7 +196,7 @@ TEST_F(MaliputRailcarTest, NonZeroParametersAppearInOutputMonolane) {
   EXPECT_NO_FATAL_FAILURE(InitializeCurvedMonoLane());
 
   // Sets the parameters to be non-zero values.
-  SetConfig(1.5 /* r */, 8.2 /* h */, 1 /* initial speed */);
+  SetConfig(1.5 /* r */, 8.2 /* h */, 1 /* initial s_dot */);
   dut_->CalcOutput(*context_, output_.get());
   auto start_pose = pose_output();
   Eigen::Isometry3d expected_start_pose = Eigen::Isometry3d::Identity();
@@ -239,13 +239,13 @@ TEST_F(MaliputRailcarTest, Derivatives) {
 
   // Checks the derivatives given the default continous state.
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
-  EXPECT_EQ(result->s(), MaliputRailcar<double>::kDefaultSpeed);
+  EXPECT_EQ(result->s(), MaliputRailcar<double>::kDefaultSDot);
   EXPECT_EQ(result->s_dot(), 0.0);  // Expect zero acceleration.
 
   // Checks the derivatives given a non-default continuous state.
   continuous_state()->set_s(3.5);
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
-  EXPECT_EQ(result->s(), MaliputRailcar<double>::kDefaultSpeed);
+  EXPECT_EQ(result->s(), MaliputRailcar<double>::kDefaultSDot);
   EXPECT_EQ(result->s_dot(), 0.0);
 }
 

--- a/drake/lcmtypes/lcmt_maliput_railcar_config_t.lcm
+++ b/drake/lcmtypes/lcmt_maliput_railcar_config_t.lcm
@@ -9,5 +9,5 @@ struct lcmt_maliput_railcar_config_t {
 
   double r;  // The vehicle's position on the lane's r-axis.
   double h;  // The vehicle's height above the lane's surface.
-  double initial_speed;  // The vehicle's initial speed along the lane's s-axis.
+  double initial_s_dot;  // The initial time derivative of the vehicle's `s` coordinate. See MaliputRailcar's class description for more details.
 }

--- a/drake/lcmtypes/lcmt_maliput_railcar_state_t.lcm
+++ b/drake/lcmtypes/lcmt_maliput_railcar_state_t.lcm
@@ -7,6 +7,6 @@ struct lcmt_maliput_railcar_state_t {
   // The timestamp in milliseconds.
   int64_t timestamp;
 
-  double s;  // The position along the lane's s-axis.
-  double s_dot;  // The speed along the lane's s-axis.
+  double s;  // The s-coordinate of the vehicle in lane-space.
+  double s_dot;  // The time derivative of the vehicle's `s` coordinate. See MaliputRailcar's class description for more details.
 }


### PR DESCRIPTION
This PR was created based on a conversation with @maddog-tri. We want to emphasize that `s_dot` may not be the vehicle's physical speed, and prevent future users from trying to control `s_dot`.

It builds upon #5419.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5443)
<!-- Reviewable:end -->
