### PR TITLE
Add equality operators to Eigen matrix/array of symbolic expressions

### DIFF
--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -87,8 +87,8 @@ class Formula {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Formula)
 
-  /** Default constructor (deleted). */
-  Formula() = delete;
+  /** Default constructor. */
+  Formula() { *this = True(); }
 
   explicit Formula(const std::shared_ptr<FormulaCell> ptr);
 
@@ -313,3 +313,15 @@ struct equal_to<drake::symbolic::Formula> {
   }
 };
 }  // namespace std
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+// Define Eigen traits needed for Matrix<drake::symbolic::Formula>.
+namespace Eigen {
+// Eigen scalar type traits for Matrix<drake::symbolic::Formula>.
+template <>
+struct NumTraits<drake::symbolic::Formula>
+    : GenericNumTraits<drake::symbolic::Formula> {
+  static inline int digits10() { return 0; }
+};
+}  // namespace Eigen
+#endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <utility>
 
+#include <Eigen/Core>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/hash.h"
@@ -271,6 +273,46 @@ const Variables& get_quantified_variables(const Formula& f);
  */
 const Formula& get_quantified_formula(const Formula& f);
 
+/** Returns an Eigen array of symbolic formula where each element
+    includes element-wise symbolic-equality of two symbolic
+    arrays @p m1 and @p m2. */
+template <typename DerivedA, typename DerivedB>
+typename std::enable_if<
+    std::is_base_of<Eigen::ArrayBase<DerivedA>, DerivedA>::value &&
+        std::is_base_of<Eigen::ArrayBase<DerivedB>, DerivedB>::value &&
+        std::is_same<typename DerivedA::Scalar, Expression>::value &&
+        std::is_same<typename DerivedB::Scalar, Expression>::value,
+    Eigen::Array<Formula, DerivedA::RowsAtCompileTime,
+                 DerivedB::ColsAtCompileTime>>::type
+operator==(const DerivedA& m1, const DerivedB& m2) {
+  EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
+  DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());
+  const auto expr_equal = [](const Expression& e1, const Expression& e2) {
+    return e1 == e2;
+  };
+  return m1.binaryExpr(m2, expr_equal);
+}
+
+// Returns a symbolic formula checking if two matrices of symbolic expression @p
+// m1 and @p m2 are equal.
+template <typename DerivedA, typename DerivedB>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<DerivedA>, DerivedA>::value &&
+        std::is_base_of<Eigen::MatrixBase<DerivedB>, DerivedB>::value &&
+        std::is_same<typename DerivedA::Scalar, Expression>::value &&
+        std::is_same<typename DerivedB::Scalar, Expression>::value,
+    Formula>::type
+operator==(const DerivedA& m1, const DerivedB& m2) {
+  EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
+  DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());
+  const auto expr_equal = [](const Expression& e1, const Expression& e2) {
+    return e1 == e2;
+  };
+  const auto logic_and = [](const Formula& f1, const Formula& f2) {
+    return f1 && f2;
+  };
+  return m1.binaryExpr(m2, expr_equal).redux(logic_and);
+}
 }  // namespace symbolic
 
 /** Computes the hash value of a symbolic formula. */

--- a/drake/common/test/symbolic_expression_matrix_test.cc
+++ b/drake/common/test/symbolic_expression_matrix_test.cc
@@ -1,12 +1,17 @@
 #include "drake/common/symbolic_expression.h"
 
+#include <functional>
+
 #include "gtest/gtest.h"
 
+#include "drake/common/symbolic_formula.h"
 #include "drake/common/symbolic_variable.h"
 
 namespace drake {
 namespace symbolic {
 namespace {
+
+using std::ptr_fun;
 
 class SymbolicExpressionMatrixTest : public ::testing::Test {
  protected:
@@ -127,6 +132,81 @@ TEST_F(SymbolicExpressionMatrixTest, EigenDiv) {
                 (z_ / 2), (pi_ / 2);
   // clang-format on
   EXPECT_EQ(M, M_expected);
+}
+
+TEST_F(SymbolicExpressionMatrixTest, CheckStructuralEquality) {
+  EXPECT_TRUE(CheckStructuralEquality(A_, A_));
+  EXPECT_TRUE(CheckStructuralEquality(B_, B_));
+  EXPECT_TRUE(CheckStructuralEquality(C_, C_));
+
+  EXPECT_FALSE(CheckStructuralEquality(A_, C_));
+  EXPECT_FALSE(CheckStructuralEquality(B_ * A_, B_ * C_));
+}
+
+// Checks if m1.array() == m2.array() returns an array whose (i, j) element is a
+// formula m1(i, j) == m2(i, j).
+bool CheckArrayOperatorEq(const MatrixX<Expression>& m1,
+                          const MatrixX<Expression>& m2) {
+  const auto arr = (m1.array() == m2.array());
+  for (int i = 0; i < arr.rows(); ++i) {
+    for (int j = 0; j < arr.cols(); ++j) {
+      if (!arr(i, j).EqualTo(m1(i, j) == m2(i, j))) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+TEST_F(SymbolicExpressionMatrixTest, ArrayOperatorEq) {
+  const Eigen::Array<Formula, 3, 2> a1{A_.array() == A_.array()};
+  const Eigen::Array<Formula, 2, 3> a2{B_.array() == B_.array()};
+  const Eigen::Array<Formula, 3, 2> a3{C_.array() == C_.array()};
+  EXPECT_TRUE(a1.unaryExpr(ptr_fun(is_true)).all());
+  EXPECT_TRUE(a2.unaryExpr(ptr_fun(is_true)).all());
+  EXPECT_TRUE(a3.unaryExpr(ptr_fun(is_true)).all());
+
+  EXPECT_TRUE(CheckArrayOperatorEq(A_, C_));
+  EXPECT_TRUE(CheckArrayOperatorEq(B_ * A_, B_ * C_));
+}
+
+// Checks if m1 == m2 returns a formula which is a conjunction of
+// m1(i, j) == m2(i, j) for all i and j.
+bool CheckMatrixOperatorEq(const MatrixX<Expression>& m1,
+                           const MatrixX<Expression>& m2) {
+  const Formula f{m1 == m2};
+  Formula f_expected{};  // True
+  for (int i = 0; i < m1.rows(); ++i) {
+    for (int j = 0; j < m1.cols(); ++j) {
+      f_expected = f_expected && (m1(i, j) == m2(i, j));
+    }
+  }
+  return f.EqualTo(f_expected);
+}
+
+TEST_F(SymbolicExpressionMatrixTest, MatrixOperatorEq1) {
+  Eigen::Matrix<Expression, 2, 2> m1;
+  Eigen::Matrix<Expression, 2, 2> m2;
+  m1 << x_, y_, z_, x_;
+  m2 << z_, x_, y_, z_;
+  const Formula f{m1 == m2};
+  EXPECT_EQ(f.to_string(), "((x = z) and (y = x) and (z = y))");
+  ASSERT_TRUE(is_conjunction(f));
+  EXPECT_EQ(get_operands(f).size(), 3);
+  EXPECT_TRUE(CheckMatrixOperatorEq(m1, m2));
+}
+
+TEST_F(SymbolicExpressionMatrixTest, MatrixOperatorEq2) {
+  Eigen::Matrix<Expression, 2, 2> m1;
+  Eigen::Matrix<Expression, 2, 2> m2;
+  m1 << x_, 1.0, z_, x_;
+  m2 << z_, 2.0, y_, z_;
+  const Formula f1{m1 == m2};
+  // Because (1.0 == 2.0) is false, the whole conjunction is reduced
+  // to false.
+  EXPECT_TRUE(is_false(f1));
+  const Formula f2{m1 == m1};
+  EXPECT_TRUE(is_true(f2));
 }
 
 }  // namespace


### PR DESCRIPTION
Related issue : https://github.com/RobotLocomotion/drake/issues/5345.

In this PR, we add the following three operations:

```c++
operator== : Eigen::Matrix<Expression> x Eigen::Matrix<Expression> -> Formula
operator== : Eigen::Array<Expression> x Eigen::Array<Expression> -> Eigen::Array<Formula>
CheckStructuralEquality : Eigen::Matrix<Expression> x Eigen::Matrix<Expression> -> bool
```

Note that the types of the first two operations correspond to the `double` case:
```c++
operator== : Eigen::Matrix<double> x Eigen::Matrix<double> -> bool
operator== : Eigen::Array<double> x Eigen::Array<double> -> Eigen::Array<bool>
```
See the following code:
```c++
  Eigen::Matrix<double, 2, 2> m1;
  Eigen::Matrix<double, 2, 2> m2;
  m1 << 1, 2, 3, 4;
  m2 << 1, 3, 2, 4;

  const bool b = (m1 == m2);  // b = false
  Eigen::Array<bool, 2, 2> a{m1.array() == m2.array()};
  // a = |1 0|
  //     |0 1|
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5445)
<!-- Reviewable:end -->
