### PR TITLE
Package a subset of Drake in the Bazel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,8 @@ bin
 drake.jar
 *.out
 pod-build
-build
+/BUILD
+/build
 cmake-build-*
 mlint_output.html
 .#*

--- a/drake/BUILD
+++ b/drake/BUILD
@@ -1,0 +1,47 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:drake.bzl", "drake_header_tar")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+# This list is obviously incomplete.
+# TODO(david-german-tri, jamiesnape): Add everything Director needs, and
+# eventually everything any consumer of Drake would need.
+# When adding new components to the package, please also add the licenses for
+# any new external dependencies to :external_licenses.
+_LIBDRAKE_COMPONENTS = [
+    "//drake/multibody/parsers",
+    "//drake/systems/framework",
+    "//drake/systems/primitives",
+]
+
+# The Drake binary package. libdrake.so contains all the symbols from all the
+# _LIBDRAKE_COMPONENTS and all the Drake externals. We use linkstatic=1 so
+# that the binary package will not contain any references to shared libraries
+# inside the build tree.
+cc_binary(
+    name = "libdrake.so",
+    linkshared = 1,
+    linkstatic = 1,
+    deps = _LIBDRAKE_COMPONENTS,
+)
+
+# All the headers mentioned in "hdrs" attributes of the transitive closure of
+# dependencies of the _LIBDRAKE_COMPONENTS. This is a superset of the headers
+# actually required to operate Drake.
+drake_header_tar(
+    name = "libdrake_headers",
+    deps = _LIBDRAKE_COMPONENTS,
+)
+
+pkg_tar(
+    name = "external_licenses",
+    extension = "tar.gz",
+    deps = [
+        "@bullet//:license",
+        "@eigen//:license",
+        "@spdlog//:license",
+    ],
+)

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -7,6 +7,32 @@ load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 package(default_visibility = ["//visibility:public"])
 
 drake_cc_library(
+    name = "primitives",
+    srcs = [],
+    hdrs = [],
+    deps = [
+        ":adder",
+        ":affine_system",
+        ":constant_value_source",
+        ":constant_vector_source",
+        ":demultiplexer",
+        ":first_order_low_pass_filter",
+        ":gain",
+        ":integrator",
+        ":linear_system",
+        ":matrix_gain",
+        ":multiplexer",
+        ":pass_through",
+        ":random_source",
+        ":saturation",
+        ":signal_log",
+        ":signal_logger",
+        ":trajectory_source",
+        ":zero_order_hold",
+    ],
+)
+
+drake_cc_library(
     name = "adder",
     srcs = ["adder.cc"],
     hdrs = ["adder.h"],

--- a/tools/bullet.BUILD
+++ b/tools/bullet.BUILD
@@ -1,5 +1,11 @@
 # -*- python -*-
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
 # Note that this is only a portion of Bullet.
 cc_library(
     name = "lib",
@@ -14,5 +20,11 @@ cc_library(
     copts = ["-Wno-all"],
     defines = ["BT_USE_DOUBLE_PRECISION"],
     includes = ["src"],
-    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "license",
+    extension = "tar.gz",
+    files = ["LICENSE.txt"],
+    package_dir = "bullet",
 )

--- a/tools/eigen.BUILD
+++ b/tools/eigen.BUILD
@@ -1,5 +1,11 @@
 # -*- python -*-
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "eigen",
     hdrs = glob([
@@ -10,5 +16,11 @@ cc_library(
     ]),
     defines = ["EIGEN_MPL2_ONLY"],
     includes = ["."],
-    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "license",
+    extension = "tar.gz",
+    files = glob(["COPYING.*"]),
+    package_dir = "eigen",
 )

--- a/tools/package_drake.sh
+++ b/tools/package_drake.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+### Builds libdrake.so, and packages it with the required headers.
+### @param1 the name of the output file, which should end in .tar.gz.
+### After installing the package, OS X users may want to adjust the .so file's
+### id to match its installed location, using install_name_tool -id.
+
+# If any command in the script exits non-zero, stop.
+set -e
+
+[ -n "$1" ] || (echo "error: Please specify an output file." && false)
+
+mydir=$(dirname "$0")
+outfile="$(cd $(dirname "$1") && pwd)/$(basename "$1")"
+touch "$outfile"
+cd "$mydir"
+
+# Build Drake.
+workspace=$(bazel info workspace)
+cd "$workspace"
+bazel build //drake:libdrake.so //drake:libdrake_headers //drake:external_licenses
+
+# Copy off all the package artifacts into a temporary directory.
+# TODO(jamiesnape): Add drake-config.cmake and drake-targets.cmake.
+tmpdir=$(mktemp -d)
+mkdir -p "$tmpdir/lib"
+mkdir -p "$tmpdir/include/external/scratch"
+cp bazel-bin/drake/libdrake.so "$tmpdir/lib"
+cp bazel-bin/drake/libdrake_headers.tar.gz "$tmpdir/include/external/scratch"
+cp bazel-bin/drake/external_licenses.tar.gz "$tmpdir/include/external"
+chmod -R 755 "$tmpdir"
+
+# Un-tar the headers. The -P flag and scratch directory are necessary because
+# Bazel bakes a .. into the paths of external headers.
+cd "$tmpdir/include/external/scratch"
+tar -xPzf libdrake_headers.tar.gz
+
+# Headers from Drake proper are now inside include/external/scratch, while
+# headers from externals are in external/scratch.  Move the Drake headers up
+# to include/drake.
+mv drake "$tmpdir/include"
+
+# Clean up the header tarball, and the scratch directory.
+rm libdrake_headers.tar.gz
+cd .. # include/external
+rmdir scratch
+
+# Un-tar the license notices.
+tar -xzf external_licenses.tar.gz
+rm external_licenses.tar.gz
+
+# Copy the license for Drake itself.
+cp "$workspace/LICENSE.TXT" $tmpdir
+
+# Make the package tarball.
+cd "$tmpdir"
+tar -czf "$outfile" ./*

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -1,5 +1,11 @@
 # -*- python -*-
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "spdlog",
     hdrs = glob(["include/spdlog/**"]),
@@ -9,5 +15,11 @@ cc_library(
         "@//tools:linux": ["-pthread"],
         "@//conditions:default": [],
     }),
-    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "license",
+    extension = "tar.gz",
+    files = ["LICENSE"],
+    package_dir = "spdlog",
 )


### PR DESCRIPTION
Contributes to #3129, #1766.

To demo this, do the following from the workspace root on OS X. (Yes, this is awkward!  It's designed to be friendly to downstream build systems, and isn't especially considerate of humans.)

```
mkdir ~/test
bash tools/package_drake.sh ~/test/drake.tar.gz
cd ~/test
tar -xzf drake.tar.gz 
wget https://tinyurl.com/zge7gcs -O main.cc
install_name_tool -id lib/libdrake.so lib/libdrake.so
clang++ main.cc --std=c++14 -I ./include/external/eigen/ -I ./include -L ./lib -l drake
./a.out
```

On Linux, skip the `install_name_tool` step, and pass `-Wl,-rpath ./lib` to the compiler instead.

 `a.out` should print `18.000000`. 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5448)
<!-- Reviewable:end -->
