### PR TITLE
Modifies maliput_railcar to use speed instead of s_dot as its state variable.

### DIFF
--- a/drake/automotive/gen/maliput_railcar_config.cc
+++ b/drake/automotive/gen/maliput_railcar_config.cc
@@ -9,7 +9,7 @@ namespace automotive {
 const int MaliputRailcarConfigIndices::kNumCoordinates;
 const int MaliputRailcarConfigIndices::kR;
 const int MaliputRailcarConfigIndices::kH;
-const int MaliputRailcarConfigIndices::kInitialSDot;
+const int MaliputRailcarConfigIndices::kInitialSpeed;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_config.h
+++ b/drake/automotive/gen/maliput_railcar_config.h
@@ -22,7 +22,7 @@ struct MaliputRailcarConfigIndices {
   // The index of each individual coordinate.
   static const int kR = 0;
   static const int kH = 1;
-  static const int kInitialSDot = 2;
+  static const int kInitialSpeed = 2;
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -51,11 +51,10 @@ class MaliputRailcarConfig : public systems::BasicVector<T> {
   /// The vehicle's height above the lane's surface.
   const T& h() const { return this->GetAtIndex(K::kH); }
   void set_h(const T& h) { this->SetAtIndex(K::kH, h); }
-  /// The initial time derivative of the vehicle's `s` coordinate. See
-  /// MaliputRailcar's class description for more details.
-  const T& initial_s_dot() const { return this->GetAtIndex(K::kInitialSDot); }
-  void set_initial_s_dot(const T& initial_s_dot) {
-    this->SetAtIndex(K::kInitialSDot, initial_s_dot);
+  /// The initial speed of the vehicle.
+  const T& initial_speed() const { return this->GetAtIndex(K::kInitialSpeed); }
+  void set_initial_speed(const T& initial_speed) {
+    this->SetAtIndex(K::kInitialSpeed, initial_speed);
   }
   //@}
 
@@ -65,7 +64,7 @@ class MaliputRailcarConfig : public systems::BasicVector<T> {
     auto result = (T(0) == T(0));
     result = result && !isnan(r());
     result = result && !isnan(h());
-    result = result && !isnan(initial_s_dot());
+    result = result && !isnan(initial_speed());
     return result;
   }
 };

--- a/drake/automotive/gen/maliput_railcar_config_translator.cc
+++ b/drake/automotive/gen/maliput_railcar_config_translator.cc
@@ -25,7 +25,7 @@ void MaliputRailcarConfigTranslator::Serialize(
   message.timestamp = static_cast<int64_t>(time * 1000);
   message.r = vector->r();
   message.h = vector->h();
-  message.initial_s_dot = vector->initial_s_dot();
+  message.initial_speed = vector->initial_speed();
   const int lcm_message_length = message.getEncodedSize();
   lcm_message_bytes->resize(lcm_message_length);
   message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
@@ -47,7 +47,7 @@ void MaliputRailcarConfigTranslator::Deserialize(
   }
   my_vector->set_r(message.r);
   my_vector->set_h(message.h);
-  my_vector->set_initial_s_dot(message.initial_s_dot);
+  my_vector->set_initial_speed(message.initial_speed);
 }
 
 }  // namespace automotive

--- a/drake/automotive/gen/maliput_railcar_state.cc
+++ b/drake/automotive/gen/maliput_railcar_state.cc
@@ -8,7 +8,7 @@ namespace automotive {
 
 const int MaliputRailcarStateIndices::kNumCoordinates;
 const int MaliputRailcarStateIndices::kS;
-const int MaliputRailcarStateIndices::kSDot;
+const int MaliputRailcarStateIndices::kSpeed;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_state.h
+++ b/drake/automotive/gen/maliput_railcar_state.h
@@ -21,7 +21,7 @@ struct MaliputRailcarStateIndices {
 
   // The index of each individual coordinate.
   static const int kS = 0;
-  static const int kSDot = 1;
+  static const int kSpeed = 1;
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -47,10 +47,9 @@ class MaliputRailcarState : public systems::BasicVector<T> {
   /// The s-coordinate of the vehicle in lane-space.
   const T& s() const { return this->GetAtIndex(K::kS); }
   void set_s(const T& s) { this->SetAtIndex(K::kS, s); }
-  /// The time derivative of the vehicle's `s` coordinate. See MaliputRailcar's
-  /// class description for more details.
-  const T& s_dot() const { return this->GetAtIndex(K::kSDot); }
-  void set_s_dot(const T& s_dot) { this->SetAtIndex(K::kSDot, s_dot); }
+  /// The speed of the vehicle in physical space.
+  const T& speed() const { return this->GetAtIndex(K::kSpeed); }
+  void set_speed(const T& speed) { this->SetAtIndex(K::kSpeed, speed); }
   //@}
 
   /// Returns whether the current values of this vector are well-formed.
@@ -58,7 +57,7 @@ class MaliputRailcarState : public systems::BasicVector<T> {
     using std::isnan;
     auto result = (T(0) == T(0));
     result = result && !isnan(s());
-    result = result && !isnan(s_dot());
+    result = result && !isnan(speed());
     return result;
   }
 };

--- a/drake/automotive/gen/maliput_railcar_state_translator.cc
+++ b/drake/automotive/gen/maliput_railcar_state_translator.cc
@@ -24,7 +24,7 @@ void MaliputRailcarStateTranslator::Serialize(
   drake::lcmt_maliput_railcar_state_t message;
   message.timestamp = static_cast<int64_t>(time * 1000);
   message.s = vector->s();
-  message.s_dot = vector->s_dot();
+  message.speed = vector->speed();
   const int lcm_message_length = message.getEncodedSize();
   lcm_message_bytes->resize(lcm_message_length);
   message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
@@ -45,7 +45,7 @@ void MaliputRailcarStateTranslator::Deserialize(
         "Failed to decode LCM message maliput_railcar_state.");
   }
   my_vector->set_s(message.s);
-  my_vector->set_s_dot(message.s_dot);
+  my_vector->set_speed(message.speed);
 }
 
 }  // namespace automotive

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -80,7 +80,7 @@ class MaliputRailcar : public systems::LeafSystem<T> {
 
   static constexpr double kDefaultR = 0;      // meters
   static constexpr double kDefaultH = 0;      // meters
-  static constexpr double kDefaultSDot = 1;   // time derivative of `s`
+  static constexpr double kDefaultSpeed = 1;  // meters per second
 
  protected:
   // LeafSystem<T> overrides.

--- a/drake/automotive/maliput_railcar_config.named_vector
+++ b/drake/automotive/maliput_railcar_config.named_vector
@@ -7,6 +7,6 @@ element {
     doc: "The vehicle's height above the lane's surface."
 }
 element {
-    name: "initial_s_dot"
-    doc: "The initial time derivative of the vehicle's `s` coordinate. See MaliputRailcar's class description for more details."
+    name: "initial_speed"
+    doc: "The initial speed of the vehicle."
 }

--- a/drake/automotive/maliput_railcar_state.named_vector
+++ b/drake/automotive/maliput_railcar_state.named_vector
@@ -3,6 +3,6 @@ element {
     doc: "The s-coordinate of the vehicle in lane-space."
 }
 element {
-    name: "s_dot"
-    doc: "The time derivative of the vehicle's `s` coordinate. See MaliputRailcar's class description for more details."
+    name: "speed"
+    doc: "The speed of the vehicle in physical space."
 }

--- a/drake/lcmtypes/lcmt_maliput_railcar_config_t.lcm
+++ b/drake/lcmtypes/lcmt_maliput_railcar_config_t.lcm
@@ -9,5 +9,5 @@ struct lcmt_maliput_railcar_config_t {
 
   double r;  // The vehicle's position on the lane's r-axis.
   double h;  // The vehicle's height above the lane's surface.
-  double initial_s_dot;  // The initial time derivative of the vehicle's `s` coordinate. See MaliputRailcar's class description for more details.
+  double initial_speed;  // The initial speed of the vehicle.
 }

--- a/drake/lcmtypes/lcmt_maliput_railcar_state_t.lcm
+++ b/drake/lcmtypes/lcmt_maliput_railcar_state_t.lcm
@@ -8,5 +8,5 @@ struct lcmt_maliput_railcar_state_t {
   int64_t timestamp;
 
   double s;  // The s-coordinate of the vehicle in lane-space.
-  double s_dot;  // The time derivative of the vehicle's `s` coordinate. See MaliputRailcar's class description for more details.
+  double speed;  // The speed of the vehicle in physical space.
 }


### PR DESCRIPTION
Per discussion with @jwnimmer-tri and @maddog-tri, `speed` is a more appropriate state variable for `MaliputRailcar` since it has physical meaning, as opposed to `s_dot`, which does not.

See: https://github.com/RobotLocomotion/drake/pull/5443#issuecomment-284919461

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5451)
<!-- Reviewable:end -->
