### PR TITLE
Add explicit instantiation on double for all framework classes

### DIFF
--- a/drake/systems/framework/context.cc
+++ b/drake/systems/framework/context.cc
@@ -1,4 +1,11 @@
-// For now, this is an empty .cc file that only serves to confirm
-// context.h is a stand-alone header.
-
 #include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace systems {
+
+template struct StepInfo<double>;
+
+template class Context<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/diagram.cc
+++ b/drake/systems/framework/diagram.cc
@@ -2,6 +2,15 @@
 
 namespace drake {
 namespace systems {
+namespace internal {
+
+template class DiagramOutput<double>;
+
+template class DiagramTimeDerivatives<double>;
+
+template class DiagramDiscreteVariables<double>;
+
+}  // namespace internal
 
 template class Diagram<double>;
 

--- a/drake/systems/framework/diagram_context.cc
+++ b/drake/systems/framework/diagram_context.cc
@@ -3,6 +3,8 @@
 namespace drake {
 namespace systems {
 
+template class DiagramState<double>;
+
 template class DiagramContext<double>;
 
 }  // namespace systems

--- a/drake/systems/framework/input_port_evaluator_interface.cc
+++ b/drake/systems/framework/input_port_evaluator_interface.cc
@@ -1,1 +1,11 @@
 #include "drake/systems/framework/input_port_evaluator_interface.h"
+
+namespace drake {
+namespace systems {
+namespace detail {
+
+template class InputPortEvaluatorInterface<double>;
+
+}  // namespace detail
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/leaf_system.cc
+++ b/drake/systems/framework/leaf_system.cc
@@ -1,4 +1,11 @@
-// For now, this is an empty .cc file that only serves to confirm
-// leaf_system.h is a stand-alone header.
-
 #include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+template struct PeriodicEvent<double>;
+
+template class LeafSystem<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/system.cc
+++ b/drake/systems/framework/system.cc
@@ -1,4 +1,13 @@
-// For now, this is an empty .cc file that only serves to confirm
-// system.h is a stand-alone header.
-
 #include "drake/systems/framework/system.h"
+
+namespace drake {
+namespace systems {
+
+template struct DiscreteEvent<double>;
+
+template struct UpdateActions<double>;
+
+template class System<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/system_output.cc
+++ b/drake/systems/framework/system_output.cc
@@ -27,5 +27,9 @@ void OutputPort::InvalidateAndIncrement() {
   }
 }
 
+template class SystemOutput<double>;
+
+template class LeafSystemOutput<double>;
+
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/system_output.h
+++ b/drake/systems/framework/system_output.h
@@ -178,7 +178,8 @@ class SystemOutput {
 ///
 /// @tparam T The type of the output data. Must be a valid Eigen scalar.
 template <typename T>
-struct LeafSystemOutput : public SystemOutput<T> {
+class LeafSystemOutput : public SystemOutput<T> {
+ public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LeafSystemOutput)
 
   LeafSystemOutput() = default;

--- a/drake/systems/framework/system_port_descriptor.cc
+++ b/drake/systems/framework/system_port_descriptor.cc
@@ -1,4 +1,11 @@
-// For now, this is an empty .cc file that only serves to confirm
-// system_port_descriptor.h is a stand-alone header.
-
 #include "drake/systems/framework/system_port_descriptor.h"
+
+namespace drake {
+namespace systems {
+
+template class InputPortDescriptor<double>;
+
+template class OutputPortDescriptor<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/vector_base.cc
+++ b/drake/systems/framework/vector_base.cc
@@ -1,4 +1,9 @@
-// For now, this is an empty .cc file that only serves to confirm
-// vector_base.h is a stand-alone header.
-
 #include "drake/systems/framework/vector_base.h"
+
+namespace drake {
+namespace systems {
+
+template class VectorBase<double>;
+
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This helps us fail-fast on compiler errors within method bodies.

Noticed while implementing #5431.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5453)
<!-- Reviewable:end -->
