### PR TITLE
Rotation constraint tighten1

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -454,6 +454,25 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "rotation_constraint_limit_test",
+    srcs = [
+        "test/rotation_constraint_limit_test.cc"
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    size = "large",
+    deps = [
+        ":mathematical_program",
+        ":rotation_constraint",
+        ":gurobi_solver",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "snopt_solver_test",
     srcs = [
         "test/snopt_solver_test.cc",

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -582,7 +582,6 @@ void AddMcCormickVectorConstraints(
     }
   }
 }
-
 }  // namespace
 
 void AddRotationMatrixMcCormickEnvelopeMilpConstraints(
@@ -645,40 +644,26 @@ void AddRotationMatrixMcCormickEnvelopeMilpConstraints(
         // -Bneg[k](i,j) <= R(i,j)+phi(k) <= 2-2*Bneg[k](i,j)
 
         // Tight on the lower bound:
-        prog->AddLinearConstraint(
-            Eigen::RowVector2d(1, 1), -phi(k), 2 - phi(k),
-            VectorDecisionVariable<2>{R(i, j), Bneg[k](i, j)});
+        prog->AddLinearConstraint(R(i, j) + Bneg[k](i, j), -phi(k), 2- phi(k));
+
         // Tight on the lower bound:
-        prog->AddLinearConstraint(
-            Eigen::RowVector2d(1, 2), -phi(k), 2 - phi(k),
-            VectorDecisionVariable<2>{R(i, j), Bneg[k](i, j)});
+        prog->AddLinearConstraint(R(i, j) + 2 * Bneg[k](i, j), -phi(k), 2 - phi(k));
 
         if (k == num_binary_vars_per_half_axis - 1) {
           //   Cpos[k](i,j) = Bpos[k](i,j)
-          prog->AddLinearEqualityConstraint(
-              Eigen::RowVector2d(1, -1), 0,
-              {Cpos[k].block<1, 1>(i, j), Bpos[k].block<1, 1>(i, j)});
+          prog->AddLinearEqualityConstraint(Cpos[k](i, j) - Bpos[k](i, j), 0);
+
           //   Cneg[k](i,j) = Bneg[k](i,j)
-          prog->AddLinearEqualityConstraint(
-              Eigen::RowVector2d(1, -1), 0,
-              {Cneg[k].block<1, 1>(i, j), Bneg[k].block<1, 1>(i, j)});
+          prog->AddLinearEqualityConstraint(Cneg[k](i, j) - Bneg[k](i, j), 0);
         } else {
           //   Cpos[k](i,j) = Bpos[k](i,j) - Bpos[k+1](i,j)
-          prog->AddLinearEqualityConstraint(
-              Eigen::RowVector3d(1, -1, 1), 0,
-              {Cpos[k].block<1, 1>(i, j), Bpos[k].block<1, 1>(i, j),
-               Bpos[k + 1].block<1, 1>(i, j)});
+          prog->AddLinearConstraint(Cpos[k](i, j) == Bpos[k](i, j) - Bpos[k + 1](i, j));
           //   Cneg[k](i,j) = Bneg[k](i,j) - Bneg[k+1](i,j)
-          prog->AddLinearEqualityConstraint(
-              Eigen::RowVector3d(1, -1, 1), 0,
-              {Cneg[k].block<1, 1>(i, j), Bneg[k].block<1, 1>(i, j),
-               Bneg[k + 1].block<1, 1>(i, j)});
+          prog->AddLinearConstraint(Cneg[k](i, j) == Bneg[k](i, j) - Bneg[k + 1](i, j));
         }
       }
       // Bpos[0](i,j) + Bneg[0](i,j) = 1.  (have to pick a side).
-      prog->AddLinearEqualityConstraint(
-          Eigen::RowVector2d(1, 1), 1,
-          {Bpos[0].block<1, 1>(i, j), Bneg[0].block<1, 1>(i, j)});
+      prog->AddLinearConstraint(Bpos[0](i, j) + Bneg[0](i, j) == 1);
 
       // for debugging: constrain to positive orthant.
       //      prog->AddBoundingBoxConstraint(1,1,{Bpos[0].block<1,1>(i,j)});

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -626,21 +626,27 @@ void AddRotationMatrixMcCormickEnvelopeMilpConstraints(
         // R(i,j) > phi(k) => Bpos[k](i,j) = 1
         // R(i,j) < phi(k) => Bpos[k](i,j) = 0
         // R(i,j) = phi(k) => Bpos[k](i,j) = 0 or 1
-        // -2 + 2*Bpos[k](i,j) <= R(i,j)-phi(k) <= Bpos[k](i,j)
+        // Since -s <= R(i, j) - phi(k) <= 1,
+        // where s = 2 - 1 / num_binary_vars_per_half_axis, the point
+        // [R(i,j) - phi(k), Bpos[k](i,j)] has to lie within the convex hull,
+        // whose vertices are (-s, 0), (0, 0), (1, 1), (0, 1). By computing the
+        // edges of this convex hull, we get
+        // -s + s*Bpos[k](i,j) <= R(i,j)-phi(k) <= Bpos[k](i,j)
+        double s = 2 - 1.0 / num_binary_vars_per_half_axis;
+        prog->AddLinearConstraint(R(i, j) - phi(k) >= -s + s * Bpos[k](i, j));
+        prog->AddLinearConstraint(R(i, j) - phi(k) <= Bpos[k](i, j));
 
-        // Tight on the lower bound:
-        prog->AddLinearConstraint(
-            Eigen::RowVector2d(1, -2), -2 + phi(k), phi(k),
-            VectorDecisionVariable<2>{R(i, j), Bpos[k](i, j)});
-        // Tight on the upper bound:
-        prog->AddLinearConstraint(
-            Eigen::RowVector2d(1, -1), -2 + phi(k), phi(k),
-            VectorDecisionVariable<2>{R(i, j), Bpos[k](i, j)});
-
-        // -R(i,j) >= phi(k) => Bneg[k](i,j) = 1
-        // -R(i,j) <= phi(k) => Bneg[k](i,j) = 0
+        // -R(i,j) > phi(k) => Bneg[k](i,j) = 1
+        // -R(i,j) < phi(k) => Bneg[k](i,j) = 0
         // -R(i,j) = phi(k) => Bneg[k](i,j) = 0 or 1
-        // -Bneg[k](i,j) <= R(i,j)+phi(k) <= 2-2*Bneg[k](i,j)
+        // Since -1 <= R(i, j) + phi(k) <= s,
+        // where s = 2 - 1 / num_binary_vars_per_half_axis, the point
+        // [R(i,j) + phi(k), Bneg[k](i,j)] has to lie within the convex hull
+        // whose vertices are (-1, 1), (0, 0), (s, 0), (0, 1). By computing the
+        // edges of the convex hull, we get
+        // -Bneg[k](i,j) <= R(i,j)+phi(k) <= s-s*Bneg[k](i,j)
+        prog->AddLinearConstraint(R(i, j) + phi(k) <= 2 - 2 * Bneg[k](i, j));
+        prog->AddLinearConstraint(R(i, j) + phi(k) >= -Bneg[k](i, j));
 
         // Tight on the lower bound:
         prog->AddLinearConstraint(R(i, j) + Bneg[k](i, j), -phi(k), 2- phi(k));

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -176,13 +176,13 @@ void AddOrthogonalConstraint(
   Eigen::Matrix<double, 5, 1> b;
 
   // |v1+v2|^2 <= 2
-  // Implemented as a Lorenz cone using z = Ax+b = [ sqrt(2); v1+v2 ].
+  // Implemented as a Lorenz cone using z = [ sqrt(2); v1+v2 ].
   Vector4<symbolic::Expression> z;
   z << std::sqrt(2), v1 + v2;
   prog->AddLorentzConeConstraint(z);
 
   // |v1-v2|^2 <= 2
-  // Implemented as a Lorenz cone using z = Ax+b = [ sqrt(2); v1-v2 ].
+  // Implemented as a Lorenz cone using z = [ sqrt(2); v1-v2 ].
   z.tail<3>() = v1 - v2;
   prog->AddLorentzConeConstraint(z);
 }

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -76,6 +76,12 @@ if (mosek_FOUND)
   target_link_libraries(rotation_constraint_test drakeOptimization)
 endif(mosek_FOUND)
 
+if (gurobi_FOUND)
+  drake_add_cc_test(rotation_constraint_limit_test)
+  set_tests_properties(rotation_constraint_limit_test PROPERTIES TIMEOUT 600)
+  target_link_libraries(rotation_constraint_limit_test drakeOptimization)
+endif(gurobi_FOUND)
+
 if (lcm_FOUND)
   add_executable(plot_feasible_rotation_matrices plot_feasible_rotation_matrices.cc)
   target_link_libraries(plot_feasible_rotation_matrices

--- a/drake/solvers/test/rotation_constraint_limit_test.cc
+++ b/drake/solvers/test/rotation_constraint_limit_test.cc
@@ -1,0 +1,145 @@
+#include "drake/solvers/rotation_constraint.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/solvers/gurobi_solver.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+// Compute the minimum distance of R.col(0) and R.col(1), if R satisfies
+// the McCormick envelope constraint. This test records how well we can
+// approximate the rotation matrix on SO(3). If in the future we improved
+// our relaxation and get a larger minimal distance, please update this test.
+class TestMinimumDistance : public testing::TestWithParam<int> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestMinimumDistance)
+
+  TestMinimumDistance()
+      : prog_(),
+        R_(NewRotationMatrixVars(&prog_)),
+        d_(prog_.NewContinuousVariables<1>("d")),
+        num_binary_vars_per_half_axis_(GetParam()),
+        minimal_distance_expected_(0) {
+    AddRotationMatrixMcCormickEnvelopeMilpConstraints(
+        &prog_,
+        R_,
+        num_binary_vars_per_half_axis_);
+
+    // Add the constraint that d_ >= |R_.col(0) - R_.col(1)|
+    Vector4<symbolic::Expression> s;
+    s << d_(0), R_.col(0) - R_.col(1);
+    prog_.AddLorentzConeConstraint(s);
+
+    // Miminize the distance.
+    prog_.AddCost(d_(0));
+  }
+
+  ~TestMinimumDistance() override {}
+
+  void SetMinimumDistanceExpected() { DoSetMinimumDistanceExpected(); }
+
+  void SolveAndCheckSolution() {
+    GurobiSolver gurobi_solver;
+    if (gurobi_solver.available()) {
+      prog_.SetSolverOption(SolverType::kGurobi, "OutputFlag", true);
+      SolutionResult sol_result = gurobi_solver.Solve(prog_);
+
+      EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
+      double d_val = prog_.GetSolution(d_(0));
+      EXPECT_NEAR(d_val, minimal_distance_expected_, 1E-2);
+    }
+  }
+
+ protected:
+  MathematicalProgram prog_;
+  MatrixDecisionVariable<3, 3> R_;
+  VectorDecisionVariable<1> d_;
+  int num_binary_vars_per_half_axis_;
+  double minimal_distance_expected_;
+
+ private:
+  virtual void DoSetMinimumDistanceExpected() {
+    // Update the expected minimal distance, when we improve the relaxation on
+    // SO(3).
+    switch (num_binary_vars_per_half_axis_) {
+      case 1 : {
+        // TODO(hongkai.dai): The minimum distance should not be zero. Add some
+        // constraint to prevent this, such as no two columns/rows can be in the
+        // same bin.
+        minimal_distance_expected_ = 0;
+        break;
+      }
+      case 2 : {
+        minimal_distance_expected_ = 0.974;
+        break;
+      }
+      case 3 : {
+        // TODO(hongkai.dai): Figure out why 3 binary variables give closest
+        // distance smaller than 2 binary variables case.
+        minimal_distance_expected_ = 0.38;
+        break;
+      }
+      default : {
+        throw std::runtime_error(
+            "Have not attempted this number of binary variables yet.");
+      }
+    }
+  }
+};
+
+class TestMinimumDistanceWOrthonormalSocp : public TestMinimumDistance {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestMinimumDistanceWOrthonormalSocp)
+
+  TestMinimumDistanceWOrthonormalSocp() : TestMinimumDistance() {
+    AddRotationMatrixOrthonormalSocpConstraint(&prog_, R_);
+  }
+
+  ~TestMinimumDistanceWOrthonormalSocp() override {}
+
+ private:
+  void DoSetMinimumDistanceExpected() override {
+    // Update the expected minimal distance, when we improve the relaxation on
+    // SO(3).
+    switch (num_binary_vars_per_half_axis_) {
+      case 1 : {
+        minimal_distance_expected_ = 0;
+        break;
+      }
+      case 2 : {
+        minimal_distance_expected_ = 1.1928;
+        break;
+      }
+      case 3 : {
+        minimal_distance_expected_ = 1.3056;
+        break;
+      }
+      default : {
+        throw std::runtime_error(
+            "Have not attempted this number of binary variables yet.");
+      }
+    }
+  }
+};
+
+TEST_P(TestMinimumDistance, Test) {
+  SetMinimumDistanceExpected();
+  SolveAndCheckSolution();
+}
+
+TEST_P(TestMinimumDistanceWOrthonormalSocp, Test) {
+  SetMinimumDistanceExpected();
+  SolveAndCheckSolution();
+}
+
+INSTANTIATE_TEST_CASE_P(RotationTest, TestMinimumDistance,
+    ::testing::ValuesIn({1, 2, 3})
+);
+
+INSTANTIATE_TEST_CASE_P(RotationTest, TestMinimumDistanceWOrthonormalSocp,
+    ::testing::ValuesIn({1, 2, 3})
+);
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -450,5 +450,6 @@ GTEST_TEST(RotationTest, TestMcCormick) {
       EXPECT_FALSE(IsFeasible(R_test));
   }
 }
+
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -9,7 +9,6 @@
 #include "drake/math/random_rotation.h"
 #include "drake/math/roll_pitch_yaw_not_using_quaternion.h"
 #include "drake/math/rotation_matrix.h"
-#include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mathematical_program.h"
 
 using Eigen::Vector3d;
@@ -450,25 +449,6 @@ GTEST_TEST(RotationTest, TestMcCormick) {
     else
       EXPECT_FALSE(IsFeasible(R_test));
   }
-}
-
-GTEST_TEST(RotationTest, TestMinimumDistance) {
-  // Compute the minimum distance of R.col(0) and R.col(1), if R satisfies
-  // the McCormick envelope constraint. This minimum distance cannot be 0.
-  MathematicalProgram prog;
-  auto R = NewRotationMatrixVars(&prog);
-  AddRotationMatrixMcCormickEnvelopeMilpConstraints(&prog, R, 2);
-
-  // Add the cost to minimize R.col(0) - R.col(1)
-  prog.AddCost((R.col(0) - R.col(1)).squaredNorm());
-
-  GurobiSolver gurobi_solver;
-  prog.SetSolverOption(SolverType::kGurobi, "OutputFlag", true);
-  SolutionResult sol_result = gurobi_solver.Solve(prog);
-  EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
-
-  const Matrix3d R_val = prog.GetSolution(R);
-  EXPECT_GE((R_val.col(0) - R_val.col(1)).norm(), 0.94);
 }
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -9,6 +9,7 @@
 #include "drake/math/random_rotation.h"
 #include "drake/math/roll_pitch_yaw_not_using_quaternion.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mathematical_program.h"
 
 using Eigen::Vector3d;
@@ -451,5 +452,23 @@ GTEST_TEST(RotationTest, TestMcCormick) {
   }
 }
 
+GTEST_TEST(RotationTest, TestMinimumDistance) {
+  // Compute the minimum distance of R.col(0) and R.col(1), if R satisfies
+  // the McCormick envelope constraint. This minimum distance cannot be 0.
+  MathematicalProgram prog;
+  auto R = NewRotationMatrixVars(&prog);
+  AddRotationMatrixMcCormickEnvelopeMilpConstraints(&prog, R, 2);
+
+  // Add the cost to minimize R.col(0) - R.col(1)
+  prog.AddCost((R.col(0) - R.col(1)).squaredNorm());
+
+  GurobiSolver gurobi_solver;
+  prog.SetSolverOption(SolverType::kGurobi, "OutputFlag", true);
+  SolutionResult sol_result = gurobi_solver.Solve(prog);
+  EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
+
+  const Matrix3d R_val = prog.GetSolution(R);
+  EXPECT_GE((R_val.col(0) - R_val.col(1)).norm(), 0.1);
+}
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -142,7 +142,7 @@ GTEST_TEST(RotationTest, TestSpectralPsd) {
 // <pre>
 //    min_R  sum_{i,j} |R(i,j) - R_desired(i,j)|^2
 // </pre>
-// where the columans (and rows) of R_desired are outside the unit ball.
+// where the columns (and rows) of R_desired are outside the unit ball.
 // Confirms that the Orthonormal SOCP constraints result in a solution matrix
 // with columns and rows of unit length or less, and that the specific
 // orthogonality relaxation implemented by the routine is satisfied.
@@ -468,7 +468,7 @@ GTEST_TEST(RotationTest, TestMinimumDistance) {
   EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
 
   const Matrix3d R_val = prog.GetSolution(R);
-  EXPECT_GE((R_val.col(0) - R_val.col(1)).norm(), 0.1);
+  EXPECT_GE((R_val.col(0) - R_val.col(1)).norm(), 0.94);
 }
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Tighten the constraint in the McCormick envelope relaxation on the binary variables. In one of the test I observe that the computation time drops from 34 seconds to 12 seconds.

~~I will add the bazel build for the test once #5401 is merged.~~

@RussTedrake there are two interesting things I find out through the test, that first if we use only 1 binary variable per half axis, then `R.col(0)` can be equal to `R.col(1)`. This should be fixed once we add some constraint, that no two column / row vectors call fall into the same bin. Second is that with 3 binary variables per half axis, the closest distance between `R.col(0)` and `R.col(1)` is actually smaller than the 2 binary variable case. I will solve these two issues, or find out an explanation, in the future PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5459)
<!-- Reviewable:end -->
