### PR TITLE
Global ik cost

### DIFF
--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -9,8 +9,8 @@ load(
 
 drake_cc_googletest(
     name = "global_inverse_kinematics_test",
-    size = "medium",
     srcs = ["test/global_inverse_kinematics_test.cc"],
+    size = "large",
     data = [
         "//drake/examples/kuka_iiwa_arm:models",
     ],

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -37,8 +37,8 @@ class KukaTest : public ::testing::Test {
  public:
   KukaTest()
       : rigid_body_tree_(ConstructKuka()),
-        global_ik_(*rigid_body_tree_, 2), // Test with 2 binary variables per
-                                          // half axis.
+        global_ik_(*rigid_body_tree_, 2),  // Test with 2 binary variables per
+                                           // half axis.
         ee_idx_(rigid_body_tree_->FindBodyIndex("iiwa_link_ee")) {}
 
   ~KukaTest() override {};

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -215,9 +215,11 @@ TEST_F(KukaTest, ReachableWithCost) {
     // There is extra error introduced from gurobi optimality condition and SVD,
     // so the tolerance is loose.
     EXPECT_TRUE(
-        CompareMatrices(q_w_cost, q, 1E-2, MatrixCompareType::absolute));
+        CompareMatrices(q_w_cost, q, 3E-3, MatrixCompareType::absolute));
+    EXPECT_LE((q_w_cost - q).norm(), 4E-3);
     // The posture from IK with cost should be different from that without cost.
-    EXPECT_GE((q_w_cost - q_no_cost).norm(), 1E-3);
+    EXPECT_GE((q_w_cost - q_no_cost).norm(), 2E-2);
+    EXPECT_LE((q_w_cost - q).norm(), (q_no_cost - q).norm());
   }
 }
 }  // namespace

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -171,14 +171,14 @@ TEST_F(KukaTest, ReachableWithCost) {
   // Constrain the global IK to reach the exact end effector pose as the
   // posture q.
   global_ik_.AddWorldPositionConstraint(
-      ee_idx_, // body index
-      Vector3d::Zero(), // p_BQ
-      ee_desired_pose.translation(), // lower bound
-      ee_desired_pose.translation()); // upper bound
+      ee_idx_,  // body index
+      Vector3d::Zero(),  // p_BQ
+      ee_desired_pose.translation(),  // lower bound
+      ee_desired_pose.translation());  // upper bound
   global_ik_.AddWorldOrientationConstraint(
-      ee_idx_, // body index
-      Eigen::Quaterniond(ee_desired_pose.linear()), // desired orientation
-      0); // tolerance.
+      ee_idx_,  // body index
+      Eigen::Quaterniond(ee_desired_pose.linear()),  // desired orientation
+      0);  // tolerance.
 
   solvers::GurobiSolver gurobi_solver;
 
@@ -212,7 +212,8 @@ TEST_F(KukaTest, ReachableWithCost) {
     const Eigen::VectorXd q_w_cost = global_ik_.ReconstructPostureSolution();
     // There is extra error introduced from gurobi optimality condition and SVD,
     // so the tolerance is loose.
-    EXPECT_TRUE(CompareMatrices(q_w_cost, q, 1E-2, MatrixCompareType::absolute));
+    EXPECT_TRUE(
+        CompareMatrices(q_w_cost, q, 1E-2, MatrixCompareType::absolute));
     // The posture from IK with cost should be different from that without cost.
     EXPECT_GE((q_w_cost - q_no_cost).norm(), 1E-3);
   }

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -164,8 +164,8 @@ TEST_F(KukaTest, ReachableWithCost) {
   cache.initialize(q);
   rigid_body_tree_->doKinematics(cache);
 
-  Isometry3d ee_desired_pose = rigid_body_tree_->CalcFramePoseInWorldFrame(
-      cache, rigid_body_tree_->get_body(ee_idx_), Isometry3d::Identity());
+  Isometry3d ee_desired_pose = rigid_body_tree_->CalcBodyPoseInWorldFrame(
+      cache, rigid_body_tree_->get_body(ee_idx_));
   // Constrain the global IK to reach the exact end effector pose as the
   // posture q.
   global_ik_.AddWorldPositionConstraint(ee_idx_, Vector3d::Zero(),

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -50,7 +50,8 @@ class KukaTest : public ::testing::Test {
    * in the global IK.
    */
   void CheckGlobalIKSolution(double pos_tol, double orient_tol) const {
-    Eigen::VectorXd q_global_ik = global_ik_.ReconstructPostureSolution();
+    Eigen::VectorXd q_global_ik =
+        global_ik_.ReconstructGeneralizedPositionSolution();
 
     std::cout << "Reconstructed robot posture:\n" << q_global_ik << std::endl;
     KinematicsCache<double> cache = rigid_body_tree_->doKinematics(q_global_ik);
@@ -189,15 +190,15 @@ TEST_F(KukaTest, ReachableWithCost) {
 
     EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
 
-    const Eigen::VectorXd q_no_cost = global_ik_.ReconstructPostureSolution();
+    const Eigen::VectorXd q_no_cost =
+        global_ik_.ReconstructGeneralizedPositionSolution();
 
     DRAKE_DEMAND(rigid_body_tree_->get_num_bodies() == 12);
     // Now add the cost on the posture error.
     // Any positive cost should be able to achieve the optimal solution
     // being equal to q.
     global_ik_.AddPostureCost(q, Eigen::VectorXd::Constant(12, 1),
-                            Eigen::VectorXd::Constant(12, 1));
-
+                              Eigen::VectorXd::Constant(12, 1));
 
     sol_result = gurobi_solver.Solve(global_ik_);
 
@@ -209,7 +210,8 @@ TEST_F(KukaTest, ReachableWithCost) {
     double orientation_error = 2E-5;
     CheckGlobalIKSolution(position_error, orientation_error);
 
-    const Eigen::VectorXd q_w_cost = global_ik_.ReconstructPostureSolution();
+    const Eigen::VectorXd q_w_cost =
+        global_ik_.ReconstructGeneralizedPositionSolution();
     // There is extra error introduced from gurobi optimality condition and SVD,
     // so the tolerance is loose.
     EXPECT_TRUE(

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -176,8 +176,9 @@ TEST_F(KukaTest, ReachableWithCost) {
 
   Eigen::Matrix<double, 7, 1> q_err =
       Eigen::Matrix<double, 7, 1>::Constant(0.2);
-  global_ik_.AddPostureCost(q + q_err, Eigen::VectorXd::Constant(11, 1),
-                            Eigen::VectorXd::Constant(11, 1));
+  DRAKE_DEMAND(rigid_body_tree_->get_num_bodies() == 12);
+  global_ik_.AddPostureCost(q + q_err, Eigen::VectorXd::Constant(12, 1),
+                            Eigen::VectorXd::Constant(12, 1));
 
   solvers::GurobiSolver gurobi_solver;
   if (gurobi_solver.available()) {

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -357,6 +357,8 @@ void GlobalInverseKinematics::AddPostureCost(
   solvers::VectorXDecisionVariable p_WBo_err =
       NewContinuousVariables(num_bodies - 1, "p_WBo_error");
   for (int i = 1; i < num_bodies; ++i) {
+    // body 0 is the world. There is no position or orientation error on the
+    // world, so we just skip i = 0 and start from i = 1.
     const auto& X_WB_desired = robot_->CalcFramePoseInWorldFrame(
         cache, robot_->get_body(i), Isometry3d::Identity());
     // Add the constraint p_WBo_err(i-1) >= body_position_cost(i) *

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -224,7 +224,8 @@ GlobalInverseKinematics::body_position(int body_index) const {
   return p_WBo_[body_index];
 }
 
-Eigen::VectorXd GlobalInverseKinematics::ReconstructPostureSolution() const {
+Eigen::VectorXd
+GlobalInverseKinematics::ReconstructGeneralizedPositionSolution() const {
   Eigen::VectorXd q(robot_->get_num_positions());
   for (int body_idx = 1; body_idx < robot_->get_num_bodies(); ++body_idx) {
     const RigidBody<double>& body = robot_->get_body(body_idx);

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -167,9 +167,12 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * body_orientation_error(i) is computed as (1 - cos(θ)), where θ is the
    * angle between the orientation of body i'th frame and body i'th frame using
    * the desired posture.
-   * Notice that since body 0 is the world, the cost on that is omitted.
+   * Notice that since body 0 is the world, the cost on that body is always 0,
+   * no matter what value `body_position_cost(0)` and `body_orientation_cost(0)`
+   * take.
    * @param q_desired  The desired posture.
-   * @param body_position_cost  The cost for each body's position error.
+   * @param body_position_cost  The cost for each body's position error. Unit is
+   * [1/m] (one over meters).
    * @pre
    * 1. body_position_cost.rows() == robot->get_num_bodies(), where `robot`
    *    is the input argument in the constructor of the class.

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -59,12 +59,12 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
 
   /**
    * After solving the inverse kinematics problem and finding out the pose of
-   * each body, reconstruct the robot posture (joint angles, etc) that matches
-   * with the body poses. Notice that since the rotation matrix is approximated,
-   * that the solution of body_rotmat() might not be on SO(3) exactly, the
-   * reconstructed body posture might not match with the body poses exactly, and
-   * the kinematics constraint might not be satisfied exactly with this
-   * reconstructed posture.
+   * each body, reconstruct the robot generalized position (joint angles, etc)
+   * that matches with the body poses. Notice that since the rotation matrix is
+   * approximated, that the solution of body_rotmat() might not be on SO(3)
+   * exactly, the reconstructed body posture might not match with the body poses
+   * exactly, and the kinematics constraint might not be satisfied exactly with
+   * this reconstructed posture.
    * @warning Do not call this method if the problem is not solved successfully!
    * The returned value can be NaN or meaningless number if the problem is
    * not solved.
@@ -72,7 +72,7 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * coordinates, corresponding to the RigidBodyTree on which the inverse
    * kinematics problem is solved.
    */
-  Eigen::VectorXd ReconstructPostureSolution() const;
+  Eigen::VectorXd ReconstructGeneralizedPositionSolution() const;
 
   /**
    * Adds the constraint that the position of a point `Q` on a body `B`
@@ -83,13 +83,13 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * </pre>
    * where
    *   - p_WQ is the position of the body point Q measured and expressed in the
-   * world frame `W`.
+   *     world frame `W`.
    *   - p_WBo is the position of the body origin Bo measured and expressed in
-   * the world frame `W`.
+   *     the world frame `W`.
    *   - R_WB is the rotation matrix of the body measured and expressed in the
-   * world frame `W`.
+   *     world frame `W`.
    *   - p_BQ is the position of the body point Q measured and expressed in the
-   * body frame `B`.
+   *     body frame `B`.
    * p_WQ should lie within a bounding box in the frame `F`. Namely
    * <pre>
    *   box_lb_F <= p_FQ <= box_ub_F
@@ -166,7 +166,8 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    *
    * body_orientation_error(i) is computed as (1 - cos(θ)), where θ is the
    * angle between the orientation of body i'th frame and body i'th frame using
-   * the desired posture.
+   * the desired posture. Notice that 1 - cos(θ) = θ²/2 + O(θ⁴), so this cost
+   * is on the square of θ, when θ is small.
    * Notice that since body 0 is the world, the cost on that body is always 0,
    * no matter what value `body_position_cost(0)` and `body_orientation_cost(0)`
    * take.

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -140,6 +140,31 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
       int body_idx, const Eigen::Quaterniond& desired_orientation,
       double angle_tol);
 
+  /** Penalizes the deviation to the desired posture.
+   * For each body in the kinematic tree, we impose the constraint
+   * body_position_cost(i) * body_position_error(i) + body_orientation_cost(i) * body_orientation_error(i)
+   * where body_position_error(i) is computed as the Euclidean distance error
+   * (p_WBo(i) - p_WBo_desired(i))^T * (p_WBo(i) - p_WBo_desired(i))
+   * p_WBo(i)         : position of body i'th frame in the world frame.
+   * p_WB_desired(i) : position of body i'th frame in the world frame, computed
+   * from the desired posture `q_desired`.
+   * body_orientation_error(i) is computed as (1 - cos(θ)), where θ is the
+   * angle between the orientation of body i'th frame in the world frame, and
+   * body i'th frame in the world frame using the desired posture.
+   * @param q_desired  The desired posture.
+   * @param body_position_cost  The cost for each body's position error.
+   * @pre{1. body_position_cost.rows() == robot_->get_num_bodies() - 1.
+   *         since the body 0 is the world frame, and we should not impose a cost
+   *         on the world frame position.
+   *      2. body_position_cost(i) is non-negative.}
+   *      Throw a runtime error if the precondition is not satisfied.
+   * @param body_orientation_cost The cost for each body's orientation error.
+   * @pre{1. body_orientation_cost.rows() == robot_->get_num_bodies() - 1.
+   *      2. body_position_cost(i) is non-negative.}
+   *      Throws a runtime error if the precondition is not satisfied.
+   */
+  void AddPostureCost(const Eigen::VectorXd& q_desired, const Eigen::VectorXd& body_position_cost, const Eigen::VectorXd& body_orientation_cost);
+
  private:
   const RigidBodyTree<double> *robot_;
 

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -144,13 +144,13 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * For each body in the kinematic tree, we impose the constraint
    * body_position_cost(i) * body_position_error(i) + body_orientation_cost(i) * body_orientation_error(i)
    * where body_position_error(i) is computed as the Euclidean distance error
-   * (p_WBo(i) - p_WBo_desired(i))^T * (p_WBo(i) - p_WBo_desired(i))
+   * |p_WBo(i) - p_WBo_desired(i)|
    * p_WBo(i)         : position of body i'th frame in the world frame.
-   * p_WB_desired(i) : position of body i'th frame in the world frame, computed
+   * p_WBo_desired(i) : position of body i'th frame in the world frame, computed
    * from the desired posture `q_desired`.
    * body_orientation_error(i) is computed as (1 - cos(θ)), where θ is the
-   * angle between the orientation of body i'th frame in the world frame, and
-   * body i'th frame in the world frame using the desired posture.
+   * angle between the orientation of body i'th frame and body i'th frame using
+   * the desired posture.
    * @param q_desired  The desired posture.
    * @param body_position_cost  The cost for each body's position error.
    * @pre{1. body_position_cost.rows() == robot_->get_num_bodies() - 1.
@@ -161,9 +161,12 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * @param body_orientation_cost The cost for each body's orientation error.
    * @pre{1. body_orientation_cost.rows() == robot_->get_num_bodies() - 1.
    *      2. body_position_cost(i) is non-negative.}
-   *      Throws a runtime error if the precondition is not satisfied.
+   *      Throws a runtime_error if the precondition is not satisfied.
    */
-  void AddPostureCost(const Eigen::VectorXd& q_desired, const Eigen::VectorXd& body_position_cost, const Eigen::VectorXd& body_orientation_cost);
+  void AddPostureCost(
+      const Eigen::Ref<const Eigen::VectorXd>& q_desired,
+      const Eigen::Ref<const Eigen::VectorXd>& body_position_cost,
+      const Eigen::Ref<const Eigen::VectorXd>& body_orientation_cost);
 
  private:
   const RigidBodyTree<double> *robot_;

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -153,7 +153,7 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
       double angle_tol);
 
   /** Penalizes the deviation to the desired posture.
-   * For each body in the kinematic tree, we add the cost
+   * For each body (except the world) in the kinematic tree, we add the cost
    *  `body_position_cost(i - 1) * body_position_error(i) +
    *  body_orientation_cost(i - 1) * body_orientation_error(i)`
    * where `body_position_error(i)` is computed as the Euclidean distance error
@@ -167,6 +167,7 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * body_orientation_error(i) is computed as (1 - cos(θ)), where θ is the
    * angle between the orientation of body i'th frame and body i'th frame using
    * the desired posture.
+   * Since the body 0 is the world frame, we should not impose a cost on it.
    * @param q_desired  The desired posture.
    * @param body_position_cost  The cost for each body's position error.
    * @pre

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -154,8 +154,8 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
 
   /** Penalizes the deviation to the desired posture.
    * For each body (except the world) in the kinematic tree, we add the cost
-   *  `body_position_cost(i - 1) * body_position_error(i) +
-   *  body_orientation_cost(i - 1) * body_orientation_error(i)`
+   *  `∑ᵢ body_position_cost(i) * body_position_error(i) +
+   *  body_orientation_cost(i) * body_orientation_error(i)`
    * where `body_position_error(i)` is computed as the Euclidean distance error
    * |p_WBo(i) - p_WBo_desired(i)|
    * where
@@ -167,19 +167,17 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * body_orientation_error(i) is computed as (1 - cos(θ)), where θ is the
    * angle between the orientation of body i'th frame and body i'th frame using
    * the desired posture.
-   * Since the body 0 is the world frame, we should not impose a cost on it.
+   * Notice that since body 0 is the world, the cost on that is omitted.
    * @param q_desired  The desired posture.
    * @param body_position_cost  The cost for each body's position error.
    * @pre
-   * 1. body_position_cost.rows() == robot->get_num_bodies() - 1, where `robot`
+   * 1. body_position_cost.rows() == robot->get_num_bodies(), where `robot`
    *    is the input argument in the constructor of the class.
-   *    Since the body 0 is the world frame, we should not impose a cost
-   *    on the world frame position.
    * 2. body_position_cost(i) is non-negative.
    * @throw a runtime error if the precondition is not satisfied.
    * @param body_orientation_cost The cost for each body's orientation error.
    * @pre
-   * 1. body_orientation_cost.rows() == robot->get_num_bodies() - 1, where
+   * 1. body_orientation_cost.rows() == robot->get_num_bodies() , where
    *    `robot` is the input argument in the constructor of the class.
    * 2. body_position_cost(i) is non-negative.
    * @throw a runtime_error if the precondition is not satisfied.


### PR DESCRIPTION
Emulate the cost in the `inverseKin`, in global IK, add a cost to penalize the deviation of each body pose to the desired body pose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5460)
<!-- Reviewable:end -->
