### PR TITLE
Add model values for input and output ports

### DIFF
--- a/drake/automotive/simple_car.cc
+++ b/drake/automotive/simple_car.cc
@@ -13,11 +13,9 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/symbolic_expression.h"
+#include "drake/common/symbolic_formula.h"
 #include "drake/math/saturate.h"
 #include "drake/systems/framework/vector_base.h"
-
-// This is used indirectly to allow DRAKE_ASSERT on symbolic::Expression.
-#include "drake/common/symbolic_formula.h"
 
 namespace drake {
 
@@ -28,12 +26,10 @@ namespace automotive {
 
 template <typename T>
 SimpleCar<T>::SimpleCar() {
-  this->DeclareInputPort(systems::kVectorValued,
-                         DrivingCommandIndices::kNumCoordinates);
-  this->DeclareOutputPort(systems::kVectorValued,
-                          SimpleCarStateIndices::kNumCoordinates);
-  this->DeclareOutputPort(systems::kVectorValued, PoseVector<T>::kSize);
-  this->DeclareOutputPort(systems::kVectorValued, FrameVelocity<T>::kSize);
+  this->DeclareVectorInputPort(DrivingCommand<T>());
+  this->DeclareVectorOutputPort(SimpleCarState<T>());
+  this->DeclareVectorOutputPort(PoseVector<T>());
+  this->DeclareVectorOutputPort(FrameVelocity<T>());
 }
 
 template <typename T>
@@ -210,33 +206,10 @@ systems::System<symbolic::Expression>* SimpleCar<T>::DoToSymbolic() const {
 }
 
 template <typename T>
-systems::BasicVector<T>* SimpleCar<T>::DoAllocateInputVector(
-    const systems::InputPortDescriptor<T>& descriptor) const {
-  DRAKE_DEMAND(descriptor.get_index() == 0);
-  return new DrivingCommand<T>();
-}
-
-template <typename T>
 std::unique_ptr<systems::ContinuousState<T>>
 SimpleCar<T>::AllocateContinuousState() const {
   return std::make_unique<systems::ContinuousState<T>>(
       std::make_unique<SimpleCarState<T>>());
-}
-
-template <typename T>
-std::unique_ptr<systems::BasicVector<T>> SimpleCar<T>::AllocateOutputVector(
-    const systems::OutputPortDescriptor<T>& descriptor) const {
-  DRAKE_DEMAND(descriptor.get_index() <= 2);
-  switch (descriptor.get_index()) {
-    case 0:
-      return std::make_unique<SimpleCarState<T>>();
-    case 1:
-      return std::make_unique<PoseVector<T>>();
-    case 2:
-      return std::make_unique<FrameVelocity<T>>();
-    default:
-      return nullptr;
-  }
 }
 
 template <typename T>

--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -77,14 +77,10 @@ class SimpleCar : public systems::LeafSystem<T> {
   // System<T> overrides
   systems::System<AutoDiffXd>* DoToAutoDiffXd() const override;
   systems::System<symbolic::Expression>* DoToSymbolic() const override;
-  systems::BasicVector<T>* DoAllocateInputVector(
-      const systems::InputPortDescriptor<T>& descriptor) const override;
 
   // LeafSystem<T> overrides
   std::unique_ptr<systems::ContinuousState<T>> AllocateContinuousState()
       const override;
-  std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::OutputPortDescriptor<T>& descriptor) const override;
   std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
 
  private:

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -252,6 +252,7 @@ drake_cc_library(
     hdrs = ["leaf_system.h"],
     deps = [
         ":leaf_context",
+        ":model_values",
         ":sparsity_matrix",
         ":system",
         ":value_checker",

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -294,6 +294,106 @@ TEST_F(LeafSystemTest, DeclareAbstractOutput) {
   EXPECT_EQ(42, UnpackIntValue(output->get_data(1)));
 }
 
+// A system that exercises the model_value-based input and output ports.
+class DeclaredModelPortsSystem : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DeclaredModelPortsSystem);
+
+  DeclaredModelPortsSystem() {
+    this->DeclareInputPort(kVectorValued, 1);
+    this->DeclareVectorInputPort(MyVector2d());
+    this->DeclareAbstractInputPort(Value<int>(22));
+
+    this->DeclareOutputPort(kVectorValued, 3);
+    this->DeclareVectorOutputPort(MyVector4d());
+    this->DeclareAbstractOutputPort(Value<std::string>("44"));
+  }
+
+  void DoCalcOutput(const Context<double>& context,
+                    SystemOutput<double>* output) const override {}
+};
+
+// Tests that Declare{Vector,Abstract}{Input,Output}Port end up with the
+// correct topology.
+GTEST_TEST(ModelLeafSystemTest, ModelPortsTopology) {
+  DeclaredModelPortsSystem dut;
+
+  ASSERT_EQ(dut.get_num_input_ports(), 3);
+  ASSERT_EQ(dut.get_num_output_ports(), 3);
+
+  const InputPortDescriptor<double>& in0 = dut.get_input_port(0);
+  const InputPortDescriptor<double>& in1 = dut.get_input_port(1);
+  const InputPortDescriptor<double>& in2 = dut.get_input_port(2);
+
+  const OutputPortDescriptor<double>& out0 = dut.get_output_port(0);
+  const OutputPortDescriptor<double>& out1 = dut.get_output_port(1);
+  const OutputPortDescriptor<double>& out2 = dut.get_output_port(2);
+
+  EXPECT_EQ(in0.get_data_type(), kVectorValued);
+  EXPECT_EQ(in1.get_data_type(), kVectorValued);
+  EXPECT_EQ(in2.get_data_type(), kAbstractValued);
+
+  EXPECT_EQ(out0.get_data_type(), kVectorValued);
+  EXPECT_EQ(out1.get_data_type(), kVectorValued);
+  EXPECT_EQ(out2.get_data_type(), kAbstractValued);
+
+  EXPECT_EQ(in0.size(), 1);
+  EXPECT_EQ(in1.size(), 2);
+
+  EXPECT_EQ(out0.size(), 3);
+  EXPECT_EQ(out1.size(), 4);
+}
+
+// Tests that the model values specified in Declare{...} are actually used by
+// the corresponding Allocate{...} methods to yield correct types and values.
+GTEST_TEST(ModelLeafSystemTest, ModelPortsInput) {
+  DeclaredModelPortsSystem dut;
+
+  // Check that BasicVector<double>(1) came out.
+  auto input0 = dut.AllocateInputVector(dut.get_input_port(0));
+  ASSERT_NE(input0, nullptr);
+  EXPECT_EQ(input0->size(), 1);
+
+  // Check that MyVector2d came out.
+  auto input1 = dut.AllocateInputVector(dut.get_input_port(1));
+  ASSERT_NE(input1, nullptr);
+  MyVector2d* downcast_input1 = dynamic_cast<MyVector2d*>(input1.get());
+  ASSERT_NE(downcast_input1, nullptr);
+
+  // Check that Value<int>(22) came out.
+  auto input2 = dut.AllocateInputAbstract(dut.get_input_port(2));
+  ASSERT_NE(input2, nullptr);
+  int downcast_input2{};
+  EXPECT_NO_THROW(downcast_input2 = input2->GetValueOrThrow<int>());
+  EXPECT_EQ(downcast_input2, 22);
+}
+
+// Tests that Declare{Vector,Abstract}OutputPort flow through to allocating the
+// correct values.
+GTEST_TEST(ModelLeafSystemTest, ModelPortsOutput) {
+  DeclaredModelPortsSystem dut;
+  auto context = dut.CreateDefaultContext();
+  auto system_output = dut.AllocateOutput(*context);
+
+  // Check that BasicVector<double>(3) came out.
+  auto output0 = system_output->get_vector_data(0);
+  ASSERT_NE(output0, nullptr);
+  EXPECT_EQ(output0->size(), 3);
+
+  // Check that MyVector4d came out.
+  auto output1 = system_output->GetMutableVectorData(1);
+  ASSERT_NE(output1, nullptr);
+  MyVector4d* downcast_output1 = dynamic_cast<MyVector4d*>(output1);
+  ASSERT_NE(downcast_output1, nullptr);
+
+  // Check that Value<string>("44") came out.
+  auto output2 = system_output->get_data(2);
+  ASSERT_NE(output2, nullptr);
+  std::string downcast_output2{};
+  EXPECT_NO_THROW(downcast_output2 = output2->GetValueOrThrow<std::string>());
+  EXPECT_EQ(downcast_output2, "44");
+}
+
 // Tests both that an unrestricted update callback is called and that
 // modifications to state dimension are caught.
 TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {


### PR DESCRIPTION
Fixes #5431.

Add model values for input and output ports.
Update simple_car to use model ports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5462)
<!-- Reviewable:end -->
