### PR TITLE
Remove duplicated code from generated DoClone

### DIFF
--- a/drake/automotive/gen/bicycle_car_parameters.h
+++ b/drake/automotive/gen/bicycle_car_parameters.h
@@ -41,9 +41,7 @@ class BicycleCarParameters : public systems::BasicVector<T> {
   }
 
   BicycleCarParameters<T>* DoClone() const override {
-    auto result = new BicycleCarParameters;
-    result->set_value(this->get_value());
-    return result;
+    return new BicycleCarParameters;
   }
 
   /// @name Getters and Setters

--- a/drake/automotive/gen/bicycle_car_state.h
+++ b/drake/automotive/gen/bicycle_car_state.h
@@ -40,11 +40,7 @@ class BicycleCarState : public systems::BasicVector<T> {
     this->SetFromVector(VectorX<T>::Zero(K::kNumCoordinates));
   }
 
-  BicycleCarState<T>* DoClone() const override {
-    auto result = new BicycleCarState;
-    result->set_value(this->get_value());
-    return result;
-  }
+  BicycleCarState<T>* DoClone() const override { return new BicycleCarState; }
 
   /// @name Getters and Setters
   //@{

--- a/drake/automotive/gen/driving_command.h
+++ b/drake/automotive/gen/driving_command.h
@@ -37,11 +37,7 @@ class DrivingCommand : public systems::BasicVector<T> {
     this->SetFromVector(VectorX<T>::Zero(K::kNumCoordinates));
   }
 
-  DrivingCommand<T>* DoClone() const override {
-    auto result = new DrivingCommand;
-    result->set_value(this->get_value());
-    return result;
-  }
+  DrivingCommand<T>* DoClone() const override { return new DrivingCommand; }
 
   /// @name Getters and Setters
   //@{

--- a/drake/automotive/gen/endless_road_car_config.h
+++ b/drake/automotive/gen/endless_road_car_config.h
@@ -40,9 +40,7 @@ class EndlessRoadCarConfig : public systems::BasicVector<T> {
   }
 
   EndlessRoadCarConfig<T>* DoClone() const override {
-    auto result = new EndlessRoadCarConfig;
-    result->set_value(this->get_value());
-    return result;
+    return new EndlessRoadCarConfig;
   }
 
   /// @name Getters and Setters

--- a/drake/automotive/gen/endless_road_car_state.h
+++ b/drake/automotive/gen/endless_road_car_state.h
@@ -39,9 +39,7 @@ class EndlessRoadCarState : public systems::BasicVector<T> {
   }
 
   EndlessRoadCarState<T>* DoClone() const override {
-    auto result = new EndlessRoadCarState;
-    result->set_value(this->get_value());
-    return result;
+    return new EndlessRoadCarState;
   }
 
   /// @name Getters and Setters

--- a/drake/automotive/gen/endless_road_oracle_output.h
+++ b/drake/automotive/gen/endless_road_oracle_output.h
@@ -37,9 +37,7 @@ class EndlessRoadOracleOutput : public systems::BasicVector<T> {
   }
 
   EndlessRoadOracleOutput<T>* DoClone() const override {
-    auto result = new EndlessRoadOracleOutput;
-    result->set_value(this->get_value());
-    return result;
+    return new EndlessRoadOracleOutput;
   }
 
   /// @name Getters and Setters

--- a/drake/automotive/gen/euler_floating_joint_state.h
+++ b/drake/automotive/gen/euler_floating_joint_state.h
@@ -41,9 +41,7 @@ class EulerFloatingJointState : public systems::BasicVector<T> {
   }
 
   EulerFloatingJointState<T>* DoClone() const override {
-    auto result = new EulerFloatingJointState;
-    result->set_value(this->get_value());
-    return result;
+    return new EulerFloatingJointState;
   }
 
   /// @name Getters and Setters

--- a/drake/automotive/gen/idm_planner_parameters.h
+++ b/drake/automotive/gen/idm_planner_parameters.h
@@ -41,9 +41,7 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
   }
 
   IdmPlannerParameters<T>* DoClone() const override {
-    auto result = new IdmPlannerParameters;
-    result->set_value(this->get_value());
-    return result;
+    return new IdmPlannerParameters;
   }
 
   /// @name Getters and Setters

--- a/drake/automotive/gen/maliput_railcar_config.h
+++ b/drake/automotive/gen/maliput_railcar_config.h
@@ -38,9 +38,7 @@ class MaliputRailcarConfig : public systems::BasicVector<T> {
   }
 
   MaliputRailcarConfig<T>* DoClone() const override {
-    auto result = new MaliputRailcarConfig;
-    result->set_value(this->get_value());
-    return result;
+    return new MaliputRailcarConfig;
   }
 
   /// @name Getters and Setters

--- a/drake/automotive/gen/maliput_railcar_state.h
+++ b/drake/automotive/gen/maliput_railcar_state.h
@@ -37,9 +37,7 @@ class MaliputRailcarState : public systems::BasicVector<T> {
   }
 
   MaliputRailcarState<T>* DoClone() const override {
-    auto result = new MaliputRailcarState;
-    result->set_value(this->get_value());
-    return result;
+    return new MaliputRailcarState;
   }
 
   /// @name Getters and Setters

--- a/drake/automotive/gen/simple_car_config.h
+++ b/drake/automotive/gen/simple_car_config.h
@@ -40,11 +40,7 @@ class SimpleCarConfig : public systems::BasicVector<T> {
     this->SetFromVector(VectorX<T>::Zero(K::kNumCoordinates));
   }
 
-  SimpleCarConfig<T>* DoClone() const override {
-    auto result = new SimpleCarConfig;
-    result->set_value(this->get_value());
-    return result;
-  }
+  SimpleCarConfig<T>* DoClone() const override { return new SimpleCarConfig; }
 
   /// @name Getters and Setters
   //@{

--- a/drake/automotive/gen/simple_car_state.h
+++ b/drake/automotive/gen/simple_car_state.h
@@ -38,11 +38,7 @@ class SimpleCarState : public systems::BasicVector<T> {
     this->SetFromVector(VectorX<T>::Zero(K::kNumCoordinates));
   }
 
-  SimpleCarState<T>* DoClone() const override {
-    auto result = new SimpleCarState;
-    result->set_value(this->get_value());
-    return result;
-  }
+  SimpleCarState<T>* DoClone() const override { return new SimpleCarState; }
 
   /// @name Getters and Setters
   //@{

--- a/drake/examples/Acrobot/gen/acrobot_input_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_input_vector.h
@@ -37,9 +37,7 @@ class AcrobotInputVector : public systems::BasicVector<T> {
   }
 
   AcrobotInputVector<T>* DoClone() const override {
-    auto result = new AcrobotInputVector;
-    result->set_value(this->get_value());
-    return result;
+    return new AcrobotInputVector;
   }
 
   /// @name Getters and Setters

--- a/drake/examples/Acrobot/gen/acrobot_output_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_output_vector.h
@@ -38,9 +38,7 @@ class AcrobotOutputVector : public systems::BasicVector<T> {
   }
 
   AcrobotOutputVector<T>* DoClone() const override {
-    auto result = new AcrobotOutputVector;
-    result->set_value(this->get_value());
-    return result;
+    return new AcrobotOutputVector;
   }
 
   /// @name Getters and Setters

--- a/drake/examples/Acrobot/gen/acrobot_state_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_state_vector.h
@@ -40,9 +40,7 @@ class AcrobotStateVector : public systems::BasicVector<T> {
   }
 
   AcrobotStateVector<T>* DoClone() const override {
-    auto result = new AcrobotStateVector;
-    result->set_value(this->get_value());
-    return result;
+    return new AcrobotStateVector;
   }
 
   /// @name Getters and Setters

--- a/drake/examples/Pendulum/gen/pendulum_state_vector.h
+++ b/drake/examples/Pendulum/gen/pendulum_state_vector.h
@@ -38,9 +38,7 @@ class PendulumStateVector : public systems::BasicVector<T> {
   }
 
   PendulumStateVector<T>* DoClone() const override {
-    auto result = new PendulumStateVector;
-    result->set_value(this->get_value());
-    return result;
+    return new PendulumStateVector;
   }
 
   /// @name Getters and Setters

--- a/drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h
+++ b/drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h
@@ -39,9 +39,7 @@ class SchunkWsgTrajectoryGeneratorStateVector : public systems::BasicVector<T> {
   }
 
   SchunkWsgTrajectoryGeneratorStateVector<T>* DoClone() const override {
-    auto result = new SchunkWsgTrajectoryGeneratorStateVector;
-    result->set_value(this->get_value());
-    return result;
+    return new SchunkWsgTrajectoryGeneratorStateVector;
   }
 
   /// @name Getters and Setters

--- a/drake/tools/lcm_vector_gen.py
+++ b/drake/tools/lcm_vector_gen.py
@@ -89,9 +89,7 @@ def generate_default_ctor(hh, context, _):
 
 DO_CLONE = """
   %(camel)s<T>* DoClone() const override {
-    auto result = new %(camel)s;
-    result->set_value(this->get_value());
-    return result;
+    return new %(camel)s;
   }
 """
 

--- a/drake/tools/test/gen/sample.h
+++ b/drake/tools/test/gen/sample.h
@@ -37,11 +37,7 @@ class Sample : public systems::BasicVector<T> {
     this->SetFromVector(VectorX<T>::Zero(K::kNumCoordinates));
   }
 
-  Sample<T>* DoClone() const override {
-    auto result = new Sample;
-    result->set_value(this->get_value());
-    return result;
-  }
+  Sample<T>* DoClone() const override { return new Sample; }
 
   /// @name Getters and Setters
   //@{


### PR DESCRIPTION
The BasicVector::Clone NVI promises to set the values, so that subclasses don't have to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5464)
<!-- Reviewable:end -->
