### PR TITLE
Adds ability to specify x-offset of vehicle visualization to ensure it matches the model's origin.

### DIFF
--- a/drake/automotive/automotive_demo.cc
+++ b/drake/automotive/automotive_demo.cc
@@ -104,14 +104,16 @@ void AddVehicles(RoadNetworkType road_network_type,
            FLAGS_dragway_vehicle_delay;
       const auto& params = CreateTrajectoryParamsForDragway(
           *dragway_road_geometry, lane_index, speed, start_time);
-      simulator->AddTrajectoryCarFromSdf(kSdfFile, std::get<0>(params),
+      simulator->AddTrajectoryCarFromSdf(kSdfFile,
+                                         std::get<0>(params),
                                          std::get<1>(params),
                                          std::get<2>(params));
     }
   } else {
     for (int i = 0; i < FLAGS_num_trajectory_car; ++i) {
       const auto& params = CreateTrajectoryParams(i);
-      simulator->AddTrajectoryCarFromSdf(kSdfFile, std::get<0>(params),
+      simulator->AddTrajectoryCarFromSdf(kSdfFile,
+                                         std::get<0>(params),
                                          std::get<1>(params),
                                          std::get<2>(params));
     }

--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -115,7 +115,7 @@ int AutomotiveSimulator<T>::AddTrajectoryCarFromSdf(
   builder_->Connect(*trajectory_car, *coord_transform);
   AddPublisher(*trajectory_car, vehicle_number);
   AddPublisher(*coord_transform, vehicle_number);
-  return AddSdfModel(sdf_filename, coord_transform, ""/* model_name */);
+  return AddSdfModel(sdf_filename, coord_transform, "" /* model_name */);
 }
 
 template <typename T>

--- a/drake/automotive/simple_car_to_euler_floating_joint.h
+++ b/drake/automotive/simple_car_to_euler_floating_joint.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <memory>
 
 #include "drake/automotive/gen/euler_floating_joint_state.h"
@@ -39,12 +40,20 @@ class SimpleCarToEulerFloatingJoint : public systems::LeafSystem<T> {
         dynamic_cast<EulerFloatingJointState<T>*>(output_vector);
     DRAKE_ASSERT(output_data != nullptr);
 
-    output_data->set_x(input_data->x());
-    output_data->set_y(input_data->y());
+    using std::cos;
+    using std::sin;
+
+    const double heading = input_data->heading();
+    // TODO(liang.fok) The following number is hard-coded to equal the distance
+    // between the origin and the middle of the rear axle in prius.sdf and
+    // prius_with_lidar.sdf. Generalize this to support arbitrary models.
+    const double p_MoVo{1.40948};
+    output_data->set_x(p_MoVo * cos(heading) + input_data->x());
+    output_data->set_y(p_MoVo * sin(heading) + input_data->y());
     output_data->set_z(0.0);
     output_data->set_roll(0.0);
     output_data->set_pitch(0.0);
-    output_data->set_yaw(input_data->heading());
+    output_data->set_yaw(heading);
   }
 
  protected:

--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -102,8 +102,10 @@ void TestSimpleCarWithSdf(const std::string& sdf_filename,
   EulerFloatingJointState<double> joint_value;
   GetLastPublishedJointValue(kJointStateChannelName, state_pub.get_translator(),
                              mock_lcm, &joint_value);
-  EXPECT_GT(joint_value.x(), 0.0);
-  EXPECT_LT(joint_value.x(), 0.001);
+  // The following is hard-coded to match prius.sdf and prius_with_lidar.sdf.
+  const double kp_MoVo{1.40948};
+  EXPECT_GT(joint_value.x() - kp_MoVo, 0.0);
+  EXPECT_LT(joint_value.x() - kp_MoVo, 0.001);
 
   // Move a lot.  Confirm that we're moving in +x.
   for (int i = 0; i < 100; ++i) {
@@ -133,12 +135,12 @@ void TestSimpleCarWithSdf(const std::string& sdf_filename,
 }
 
 // Cover AddSimpleCar (and thus AddPublisher), Start, StepBy, GetSystemByName.
-GTEST_TEST(AutomotiveSimulatorTest, SimpleCarTestPrius) {
+GTEST_TEST(AutomotiveSimulatorTest, SimpleCarTestPriusWithLidar) {
   TestSimpleCarWithSdf(GetDrakePath() +
                        "/automotive/models/prius/prius_with_lidar.sdf", 17);
 }
 
-GTEST_TEST(AutomotiveSimulatorTest, SimpleCarTestTwoDofBot) {
+GTEST_TEST(AutomotiveSimulatorTest, SimpleCarTestPrius) {
   TestSimpleCarWithSdf(GetDrakePath() +
                        "/automotive/models/prius/prius.sdf", 13);
 }

--- a/drake/automotive/test/simple_car_to_euler_floating_joint_test.cc
+++ b/drake/automotive/test/simple_car_to_euler_floating_joint_test.cc
@@ -8,6 +8,9 @@ namespace drake {
 namespace automotive {
 namespace {
 
+// Tests the conversion from the vehicle's state to the visualization's state
+// when the origin of the vehicle's model's frame, Mo, is equal to the origin of
+// the vehicle's visualization's frame, Vo.
 GTEST_TEST(SimpleCarToEulerFloatingJointTest, BasicTest) {
   // The device under test.
   auto dut = std::make_unique<SimpleCarToEulerFloatingJoint<double>>();
@@ -30,12 +33,75 @@ GTEST_TEST(SimpleCarToEulerFloatingJointTest, BasicTest) {
 
   // Output matches the input.
   dut->CalcOutput(*context, output.get());
-  EXPECT_EQ(11.0, result->x());
-  EXPECT_EQ(22.0, result->y());
+  // The following is hard-coded to match prius.sdf and prius_with_lidar.sdf.
+  const double kp_MoVo{1.40948};
+  EXPECT_EQ(11.0 + kp_MoVo * std::cos(33), result->x());
+  EXPECT_EQ(22.0 + kp_MoVo * std::sin(33), result->y());
   EXPECT_EQ(0.0, result->z());
   EXPECT_EQ(33.0, result->yaw());
   EXPECT_EQ(0.0, result->pitch());
   EXPECT_EQ(0.0, result->roll());
+}
+
+// Tests the conversion from the vehicle's state to the visualization's state.
+// This is necessary because prius_with_lidar.sdf has a non-zero distance
+// between its origin (which is in the middle of the chassis_floor) and
+// SimpleCar's origin (which is in the middle of the rear axle).
+GTEST_TEST(SimpleCarToEulerFloatingJointTest, XOriginOffsetTest) {
+  const double kX{5};
+  const double kY{0};
+  const double kZeroHeading{0};
+  // The following is hard-coded to match prius.sdf and prius_with_lidar.sdf.
+  const double kp_MoVo{1.40948};
+  // The device under test.
+  auto dut = std::make_unique<SimpleCarToEulerFloatingJoint<double>>();
+  auto context = dut->CreateDefaultContext();
+  auto output = dut->AllocateOutput(*context);
+
+  // Grabs a pointer to where the CalcOutput results end up.
+  const EulerFloatingJointState<double>* const result =
+      dynamic_cast<const EulerFloatingJointState<double>*>(
+          output->get_vector_data(0));
+  ASSERT_NE(nullptr, result);
+
+  // Configures M's +X axis to be coincident with the world frame's (W's)
+  // +X axis. This should result in Vo's X-coordinate to be offset by kP_MoVo.
+  {
+    auto value = std::make_unique<SimpleCarState<double>>();
+    value->set_x(kX);
+    value->set_y(kY);
+    value->set_heading(kZeroHeading);
+    context->SetInputPort(
+        0, std::make_unique<systems::FreestandingInputPort>(std::move(value)));
+  }
+
+  dut->CalcOutput(*context, output.get());
+  EXPECT_EQ(result->x(), kX + kp_MoVo);
+  EXPECT_EQ(result->y(), kY);
+  EXPECT_EQ(result->z(), 0);
+  EXPECT_EQ(result->yaw(), kZeroHeading);
+  EXPECT_EQ(result->pitch(), 0);
+  EXPECT_EQ(result->roll(), 0);
+
+  // Configures M's +X axis to be coincident with the world frame's (W's)
+  // +Y axis. This should result in Vo's Y-coordinate to be offset by kP_MoVo.
+  const double kLeftHeading{M_PI_2};
+  {
+    auto value = std::make_unique<SimpleCarState<double>>();
+    value->set_x(kX);
+    value->set_y(kY);
+    value->set_heading(kLeftHeading);
+    context->SetInputPort(
+        0, std::make_unique<systems::FreestandingInputPort>(std::move(value)));
+  }
+
+  dut->CalcOutput(*context, output.get());
+  EXPECT_EQ(result->x(), kX);
+  EXPECT_EQ(result->y(), kY + kp_MoVo);
+  EXPECT_EQ(result->z(), 0);
+  EXPECT_EQ(result->yaw(), kLeftHeading);
+  EXPECT_EQ(result->pitch(), 0);
+  EXPECT_EQ(result->roll(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
Resolves #5341. This is an alternative to #5457.

Here's what `SimpleCar` looks like with the correct x-offset applied:

https://youtu.be/iDpAANTiuPU

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5470)
<!-- Reviewable:end -->
