### PR TITLE
Rotation constraint tighten2

### DIFF
--- a/drake/matlab/solvers/test/CMakeLists.txt
+++ b/drake/matlab/solvers/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 drake_add_matlab_test(NAME matlab/solvers/test/rrt_basic COMMAND rrt_basic)
 drake_add_matlab_test(NAME matlab/solvers/test/rrt_bugtrap COMMAND rrt_bugtrap)
 drake_add_matlab_test(NAME matlab/solvers/test/rrt_piano_mover REQUIRES lcm libbot OPTIONAL bullet COMMAND rrt_piano_mover)
-drake_add_matlab_test(NAME matlab/solvers/test/rrt_piano_mover_rotation REQUIRES lcm libbot OPTIONAL bullet COMMAND rrt_piano_mover_rotation)
+drake_add_matlab_test(NAME matlab/solvers/test/rrt_piano_mover_rotation REQUIRES lcm libbot OPTIONAL bullet COMMAND rrt_piano_mover_rotation SIZE large)
 drake_add_matlab_test(NAME matlab/solvers/test/rrt_piano_mover_translation REQUIRES lcm libbot OPTIONAL bullet COMMAND rrt_piano_mover_translation)
 # drake_add_matlab_test(NAME matlab/solvers/test/sixHumpCamel REQUIRES spotless OPTIONAL  snopt COMMAND sixHumpCamel)  # FIXME: see #3313
 drake_add_matlab_test(NAME matlab/solvers/test/testConstraint COMMAND testConstraint)

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -83,7 +83,6 @@ class KukaTest : public ::testing::Test {
       std::cout << "forward kinematics\n"
                 << body_pose_fk.translation() << std::endl;
       std::cout << std::endl;
-
       EXPECT_TRUE(CompareMatrices(body_pose_fk.translation(),
                                   body_pos_global_ik,
                                   pos_tol,

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -83,7 +83,6 @@ class KukaTest : public ::testing::Test {
       std::cout << "forward kinematics\n"
                 << body_pose_fk.translation() << std::endl;
       std::cout << std::endl;
-      // This error bound is chosen as tight as possible.
 
       EXPECT_TRUE(CompareMatrices(body_pose_fk.translation(),
                                   body_pos_global_ik,

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -119,8 +119,8 @@ TEST_F(KukaTest, ReachableTest) {
 
     EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
 
-    double pos_tol = 0.03;
-    double orient_tol = 0.1;
+    double pos_tol = 0.06;
+    double orient_tol = 0.2;
     CheckGlobalIKSolution(pos_tol, orient_tol);
   }
 }

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -513,10 +513,12 @@ drake_cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
 drake_cc_googletest(
     name = "rotation_constraint_test",
+    size = "medium",
     srcs = [
-        "test/rotation_constraint_test.cc"
+        "test/rotation_constraint_test.cc",
     ],
     tags = [
         "exclusive",
@@ -527,9 +529,8 @@ drake_cc_googletest(
     deps = [
         ":mathematical_program",
         ":rotation_constraint",
-        "//drake/math:geometric_transform",
-        ":gurobi_solver",
         "//drake/common:eigen_matrix_compare",
+        "//drake/math:geometric_transform",
     ],
 )
 
@@ -545,35 +546,20 @@ drake_cc_binary(
 )
 
 drake_cc_googletest(
-    name = "rotation_constraint_test",
-    size = "medium",
-    srcs = [
-        "test/rotation_constraint_test.cc",
-    ],
-    tags = ["mosek"],
-    deps = [
-        ":mathematical_program",
-        ":rotation_constraint",
-        "//drake/common:eigen_matrix_compare",
-        "//drake/math:geometric_transform",
-    ],
-)
-
-drake_cc_googletest(
     name = "rotation_constraint_limit_test",
+    size = "large",
     srcs = [
-        "test/rotation_constraint_limit_test.cc"
+        "test/rotation_constraint_limit_test.cc",
     ],
     tags = [
         "exclusive",
         "gurobi",
         "local",
     ],
-    size = "large",
     deps = [
+        ":gurobi_solver",
         ":mathematical_program",
         ":rotation_constraint",
-        ":gurobi_solver",
         "//drake/common:eigen_matrix_compare",
     ],
 )

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -163,8 +163,8 @@ drake_cc_library(
     srcs = ["test/mathematical_program_test_util.cc"],
     hdrs = ["test/mathematical_program_test_util.h"],
     deps = [
-        ":mathematical_program",
         "@gtest//:main",
+        ":mathematical_program",
     ],
 )
 
@@ -174,10 +174,10 @@ drake_cc_library(
     srcs = ["test/optimization_examples.cc"],
     hdrs = ["test/optimization_examples.h"],
     deps = [
+        "@gtest//:main",
         ":mathematical_program",
         ":mathematical_program_test_util",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:main",
     ],
 )
 
@@ -318,9 +318,9 @@ drake_cc_library(
     srcs = ["nlopt_solver.cc"],
     hdrs = ["nlopt_solver.h"],
     deps = [
+        "@nlopt//:lib",
         ":mathematical_program_api",
         "//drake/math:autodiff",
-        "@nlopt//:lib",
     ],
 )
 
@@ -517,9 +517,6 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "rotation_constraint_test",
     size = "medium",
-    srcs = [
-        "test/rotation_constraint_test.cc",
-    ],
     tags = [
         "exclusive",
         "gurobi",
@@ -549,9 +546,6 @@ drake_cc_binary(
 drake_cc_googletest(
     name = "rotation_constraint_limit_test",
     size = "large",
-    srcs = [
-        "test/rotation_constraint_limit_test.cc",
-    ],
     tags = [
         "exclusive",
         "gurobi",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -527,6 +527,7 @@ drake_cc_googletest(
         "mosek",
     ],
     deps = [
+        ":gurobi_solver",
         ":mathematical_program",
         ":rotation_constraint",
         "//drake/common:eigen_matrix_compare",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -513,6 +513,25 @@ drake_cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+drake_cc_googletest(
+    name = "rotation_constraint_test",
+    srcs = [
+        "test/rotation_constraint_test.cc"
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+        "mosek",
+    ],
+    deps = [
+        ":mathematical_program",
+        ":rotation_constraint",
+        "//drake/math:geometric_transform",
+        ":gurobi_solver",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
 
 drake_cc_binary(
     name = "plot_feasible_rotation_matrices",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -541,6 +541,25 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "rotation_constraint_limit_test",
+    srcs = [
+        "test/rotation_constraint_limit_test.cc"
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    size = "large",
+    deps = [
+        ":mathematical_program",
+        ":rotation_constraint",
+        ":gurobi_solver",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "snopt_solver_test",
     srcs = [
         "test/snopt_solver_test.cc",

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -669,8 +669,10 @@ void AddMcCormickVectorConstraints(
  * Bpos0.col(0).sum() + Bpos0.col(1).sum() <= 5.
  * Similarly we can impose the constraint on the other orthant.
  * @param prog Add the constraint to this mathematical program.
- * @param Bpos0 Bpos0(i,j) = 1 => R(i, j) >= 0.
- * @param Bneg0 Bneg0(i,j) = 1 => R(i, j) <= 0.
+ * @param Bpos0 Defined in AddRotationMatrixMcCormickEnvelopeMilpConstraints(),
+ * Bpos0(i,j) = 1 => R(i, j) >= 0.
+ * @param Bneg0 Defined in AddRotationMatrixMcCormickEnvelopeMilpConstraints(),
+ * Bneg0(i,j) = 1 => R(i, j) <= 0.
  */
 void AddNotInSameOrOppositeOrthantConstraint(
     MathematicalProgram* prog,
@@ -805,10 +807,10 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
 
         if (k == num_binary_vars_per_half_axis - 1) {
           //   Cpos[k](i,j) = Bpos[k](i,j)
-          prog->AddLinearEqualityConstraint(Cpos[k](i, j) - Bpos[k](i, j), 0);
+          prog->AddLinearConstraint(Cpos[k](i, j) == Bpos[k](i, j));
 
           //   Cneg[k](i,j) = Bneg[k](i,j)
-          prog->AddLinearEqualityConstraint(Cneg[k](i, j) - Bneg[k](i, j), 0);
+          prog->AddLinearConstraint(Cneg[k](i, j) == Bneg[k](i, j));
         } else {
           //   Cpos[k](i,j) = Bpos[k](i,j) - Bpos[k+1](i,j)
           prog->AddLinearConstraint(Cpos[k](i, j) ==
@@ -818,7 +820,7 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
                                     Bneg[k](i, j) - Bneg[k + 1](i, j));
         }
       }
-      // Bpos[0](i,j) + Bneg[0](i,j) = 1.  (have to pick a side).
+      // R(i,j) has to pick a side, either non-positive or non-negative.
       prog->AddLinearConstraint(Bpos[0](i, j) + Bneg[0](i, j) == 1);
 
       // for debugging: constrain to positive orthant.

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -180,13 +180,13 @@ void AddOrthogonalConstraint(
   Eigen::Matrix<double, 5, 1> b;
 
   // |v1+v2|^2 <= 2
-  // Implemented as a Lorenz cone using z = Ax+b = [ sqrt(2); v1+v2 ].
+  // Implemented as a Lorenz cone using z = [ sqrt(2); v1+v2 ].
   Vector4<symbolic::Expression> z;
   z << std::sqrt(2), v1 + v2;
   prog->AddLorentzConeConstraint(z);
 
   // |v1-v2|^2 <= 2
-  // Implemented as a Lorenz cone using z = Ax+b = [ sqrt(2); v1-v2 ].
+  // Implemented as a Lorenz cone using z = [ sqrt(2); v1-v2 ].
   z.tail<3>() = v1 - v2;
   prog->AddLorentzConeConstraint(z);
 }

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -180,16 +180,15 @@ void AddOrthogonalConstraint(
   Eigen::Matrix<double, 5, 1> b;
 
   // |v1+v2|^2 <= 2
-  // Implemented as a rotated Lorenz cone using z = Ax+b = [ 1; 2; v1+v2 ].
-  A.topRows<2>() = Eigen::Matrix<double, 2, 6>::Zero();
-  A.bottomRows<3>() << Eigen::Matrix3d::Identity(), Eigen::Matrix3d::Identity();
-  b << 1, 2, 0, 0, 0;
-  prog->AddRotatedLorentzConeConstraint(A, b, {v1, v2});
+  // Implemented as a Lorenz cone using z = Ax+b = [ sqrt(2); v1+v2 ].
+  Vector4<symbolic::Expression> z;
+  z << std::sqrt(2), v1 + v2;
+  prog->AddLorentzConeConstraint(z);
 
   // |v1-v2|^2 <= 2
-  // Implemented as a rotated Lorenz cone using z = Ax+b = [ 1; 2; v1-v2 ].
-  A.block<3, 3>(2, 3) = -Eigen::Matrix3d::Identity();
-  prog->AddRotatedLorentzConeConstraint(A, b, {v1, v2});
+  // Implemented as a Lorenz cone using z = Ax+b = [ sqrt(2); v1-v2 ].
+  z.tail<3>() = v1 - v2;
+  prog->AddLorentzConeConstraint(z);
 }
 
 }  // namespace
@@ -742,6 +741,28 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
 
       // for debugging: constrain to positive orthant.
       //      prog->AddBoundingBoxConstraint(1,1,{Bpos[0].block<1,1>(i,j)});
+    }
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 1; k < num_binary_vars_per_half_axis; ++k) {
+        // Bpos[k-1](i,j) = 0 => R(i,j) <= phi(k-1) < phi(k) => Bpos[k](i,j) = 0
+        // Bpos[k](i,j) = 1 => R(i,j) >= phi(k) > phi(k-1) => Bpos[k-1](i,j) = 1
+        // Thus Bpos[k](i, j) <= Bpos[k-1](i, j)
+        prog->AddLinearConstraint(Bpos[k](i, j) <= Bpos[k-1](i, j));
+
+        // Bneg[k](i,j) = 1 => -R(i,j) >= phi(k) > phi(k-1) => Bneg[k-1](i,j) = 1
+        // Bneg[k-1](i,j) = 0 => -R(i,j) <= phi(k-1) < phi(k) => Bneg[k](i,j) = 0
+        // Thus Bneg[k](i,j) <= Bneg[k-1](i,j)
+        prog->AddLinearConstraint(Bneg[k](i, j) <= Bneg[k-1](i, j));
+
+        for (int l = 1; l < num_binary_vars_per_half_axis; ++l) {
+          // Either R(i, j) >= phi(k) or R(i, j) <= -phi(l).
+          // So Bpos[k](i,j) + Bneg[l](i,j) <= 1
+          prog->AddLinearConstraint(Bpos[k](i, j) + Bneg[l](i, j) <= 1);
+        }
+      }
     }
   }
 

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -701,33 +701,28 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
         // R(i,j) > phi(k) => Bpos[k](i,j) = 1
         // R(i,j) < phi(k) => Bpos[k](i,j) = 0
         // R(i,j) = phi(k) => Bpos[k](i,j) = 0 or 1
-        // Since -s <= R(i, j) - phi(k) <= 1,
-        // where s = 2 - 1 / num_binary_vars_per_half_axis, the point
+        // Since -s1 <= R(i, j) - phi(k) <= s2,
+        // where s1 = 1 + phi(k), s2 = 1 - phi(k). The point
         // [R(i,j) - phi(k), Bpos[k](i,j)] has to lie within the convex hull,
-        // whose vertices are (-s, 0), (0, 0), (1, 1), (0, 1). By computing the
-        // edges of this convex hull, we get
-        // -s + s*Bpos[k](i,j) <= R(i,j)-phi(k) <= Bpos[k](i,j)
-        double s = 2 - 1.0 / num_binary_vars_per_half_axis;
-        prog->AddLinearConstraint(R(i, j) - phi(k) >= -s + s * Bpos[k](i, j));
-        prog->AddLinearConstraint(R(i, j) - phi(k) <= Bpos[k](i, j));
+        // whose vertices are (-s1, 0), (0, 0), (s2, 1), (0, 1). By computing
+        // the edges of this convex hull, we get
+        // -s1 + s1*Bpos[k](i,j) <= R(i,j)-phi(k) <= s2 * Bpos[k](i,j)
+        double s1 = 1 + phi(k);
+        double s2 = 1 - phi(k);
+        prog->AddLinearConstraint(R(i, j) - phi(k) >= -s1 + s1 * Bpos[k](i, j));
+        prog->AddLinearConstraint(R(i, j) - phi(k) <= s2 * Bpos[k](i, j));
 
         // -R(i,j) > phi(k) => Bneg[k](i,j) = 1
         // -R(i,j) < phi(k) => Bneg[k](i,j) = 0
         // -R(i,j) = phi(k) => Bneg[k](i,j) = 0 or 1
-        // Since -1 <= R(i, j) + phi(k) <= s,
-        // where s = 2 - 1 / num_binary_vars_per_half_axis, the point
+        // Since -s2 <= R(i, j) + phi(k) <= s1,
+        // where s1 = 1 + phi(k), s2 = 1 - phi(k). The point
         // [R(i,j) + phi(k), Bneg[k](i,j)] has to lie within the convex hull
-        // whose vertices are (-1, 1), (0, 0), (s, 0), (0, 1). By computing the
-        // edges of the convex hull, we get
-        // -Bneg[k](i,j) <= R(i,j)+phi(k) <= s-s*Bneg[k](i,j)
-        prog->AddLinearConstraint(R(i, j) + phi(k) <= 2 - 2 * Bneg[k](i, j));
-        prog->AddLinearConstraint(R(i, j) + phi(k) >= -Bneg[k](i, j));
-
-        // Tight on the lower bound:
-        prog->AddLinearConstraint(R(i, j) + Bneg[k](i, j), -phi(k), 2- phi(k));
-
-        // Tight on the lower bound:
-        prog->AddLinearConstraint(R(i, j) + 2 * Bneg[k](i, j), -phi(k), 2 - phi(k));
+        // whose vertices are (-s2, 1), (0, 0), (s1, 0), (0, 1). By computing
+        // the edges of the convex hull, we get
+        // -s2 * Bneg[k](i,j) <= R(i,j)+phi(k) <= s1-s1*Bneg[k](i,j)
+        prog->AddLinearConstraint(R(i, j) + phi(k) <= s1 - s1 * Bneg[k](i, j));
+        prog->AddLinearConstraint(R(i, j) + phi(k) >= -s2 * Bneg[k](i, j));
 
         if (k == num_binary_vars_per_half_axis - 1) {
           //   Cpos[k](i,j) = Bpos[k](i,j)
@@ -737,9 +732,11 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
           prog->AddLinearEqualityConstraint(Cneg[k](i, j) - Bneg[k](i, j), 0);
         } else {
           //   Cpos[k](i,j) = Bpos[k](i,j) - Bpos[k+1](i,j)
-          prog->AddLinearConstraint(Cpos[k](i, j) == Bpos[k](i, j) - Bpos[k + 1](i, j));
+          prog->AddLinearConstraint(Cpos[k](i, j) ==
+                                    Bpos[k](i, j) - Bpos[k + 1](i, j));
           //   Cneg[k](i,j) = Bneg[k](i,j) - Bneg[k+1](i,j)
-          prog->AddLinearConstraint(Cneg[k](i, j) == Bneg[k](i, j) - Bneg[k + 1](i, j));
+          prog->AddLinearConstraint(Cneg[k](i, j) ==
+                                    Bneg[k](i, j) - Bneg[k + 1](i, j));
         }
       }
       // Bpos[0](i,j) + Bneg[0](i,j) = 1.  (have to pick a side).
@@ -753,21 +750,15 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
       for (int k = 1; k < num_binary_vars_per_half_axis; ++k) {
-        // Bpos[k-1](i,j) = 0 => R(i,j) <= phi(k-1) < phi(k) => Bpos[k](i,j) = 0
-        // Bpos[k](i,j) = 1 => R(i,j) >= phi(k) > phi(k-1) => Bpos[k-1](i,j) = 1
+        // Bpos[k-1](i,j) = 0 => R(i,j) ≤ phi(k-1) < phi(k) => Bpos[k](i,j) = 0
+        // Bpos[k](i,j) = 1 => R(i,j) ≥ phi(k) > phi(k-1) => Bpos[k-1](i,j) = 1
         // Thus Bpos[k](i, j) <= Bpos[k-1](i, j)
-        prog->AddLinearConstraint(Bpos[k](i, j) <= Bpos[k-1](i, j));
+        prog->AddLinearConstraint(Bpos[k](i, j) <= Bpos[k - 1](i, j));
 
-        // Bneg[k](i,j) = 1 => -R(i,j) >= phi(k) > phi(k-1) => Bneg[k-1](i,j) = 1
-        // Bneg[k-1](i,j) = 0 => -R(i,j) <= phi(k-1) < phi(k) => Bneg[k](i,j) = 0
+        // Bneg[k](i,j) = 1 => -R(i,j) ≥ phi(k) > phi(k-1) => Bneg[k-1](i,j) = 1
+        // Bneg[k-1](i,j) = 0 => -R(i,j) ≤ phi(k-1) < phi(k) => Bneg[k](i,j) = 0
         // Thus Bneg[k](i,j) <= Bneg[k-1](i,j)
         prog->AddLinearConstraint(Bneg[k](i, j) <= Bneg[k-1](i, j));
-
-        for (int l = 1; l < num_binary_vars_per_half_axis; ++l) {
-          // Either R(i, j) >= phi(k) or R(i, j) <= -phi(l).
-          // So Bpos[k](i,j) + Bneg[l](i,j) <= 1
-          prog->AddLinearConstraint(Bpos[k](i, j) + Bneg[l](i, j) <= 1);
-        }
       }
     }
   }

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -662,18 +662,16 @@ void AddMcCormickVectorConstraints(
  * R.col(i) and R.col(j) are in the first orthant (+++), their inner product
  * has to be non-negative. If the inner product of two first orthant vectors
  * is exactly zero, then both vectors has to be on the boundaries of the first
- * orthant (more specifically, as one of the axis). But we can then assign the
- * vector to a different orthant. The same proof applies to the opposite orthant
- * case.
+ * orthant. But we can then assign the vector to a different orthant. The same
+ * proof applies to the opposite orthant case.
  * To impose the constraint that R.col(0) and R.col(1) are not both in the first
  * orthant, we consider the constraint
  * Bpos0.col(0).sum() + Bpos0.col(1).sum() <= 5.
- * Similarly we can impose the constrant on the other orthant.
+ * Similarly we can impose the constraint on the other orthant.
  * @param prog Add the constraint to this mathematical program.
- * @param Bpos0 Bpos0(i,j) = 0 => R(i, j) >= 0.
- * @param Bneg0 Bneg0(i,j) = 0 => R(i, j) <= 0.
+ * @param Bpos0 Bpos0(i,j) = 1 => R(i, j) >= 0.
+ * @param Bneg0 Bneg0(i,j) = 1 => R(i, j) <= 0.
  */
-
 void AddNotInSameOrOppositeOrthantConstraint(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& Bpos0,

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -85,6 +85,12 @@ if (mosek_FOUND)
   target_link_libraries(rotation_constraint_test drakeRotationConstraint)
 endif(mosek_FOUND)
 
+if (gurobi_FOUND)
+  drake_add_cc_test(rotation_constraint_limit_test)
+  set_tests_properties(rotation_constraint_limit_test PROPERTIES TIMEOUT 600)
+  target_link_libraries(rotation_constraint_limit_test drakeOptimization)
+endif(gurobi_FOUND)
+
 if (lcm_FOUND)
   add_executable(plot_feasible_rotation_matrices plot_feasible_rotation_matrices.cc)
   target_link_libraries(plot_feasible_rotation_matrices

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -88,7 +88,7 @@ endif(mosek_FOUND)
 if (gurobi_FOUND)
   drake_add_cc_test(rotation_constraint_limit_test)
   set_tests_properties(rotation_constraint_limit_test PROPERTIES TIMEOUT 600)
-  target_link_libraries(rotation_constraint_limit_test drakeOptimization)
+  target_link_libraries(rotation_constraint_limit_test drakeRotationConstraint)
 endif(gurobi_FOUND)
 
 if (lcm_FOUND)

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 
 if (mosek_FOUND)
   drake_add_cc_test(rotation_constraint_test rotation_constraint_test.cc)
-  set_tests_properties(rotation_constraint_test PROPERTIES TIMEOUT 400)
+  set_tests_properties(rotation_constraint_test PROPERTIES TIMEOUT 500)
   target_link_libraries(rotation_constraint_test drakeRotationConstraint)
 endif(mosek_FOUND)
 

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -81,13 +81,13 @@ endif()
 
 if (mosek_FOUND)
   drake_add_cc_test(rotation_constraint_test rotation_constraint_test.cc)
-  set_tests_properties(rotation_constraint_test PROPERTIES TIMEOUT 500)
+  set_tests_properties(rotation_constraint_test PROPERTIES TIMEOUT 900)
   target_link_libraries(rotation_constraint_test drakeRotationConstraint)
 endif(mosek_FOUND)
 
 if (gurobi_FOUND)
   drake_add_cc_test(rotation_constraint_limit_test)
-  set_tests_properties(rotation_constraint_limit_test PROPERTIES TIMEOUT 600)
+  set_tests_properties(rotation_constraint_limit_test PROPERTIES TIMEOUT 900)
   target_link_libraries(rotation_constraint_limit_test drakeRotationConstraint)
 endif(gurobi_FOUND)
 

--- a/drake/solvers/test/linear_program_examples.h
+++ b/drake/solvers/test/linear_program_examples.h
@@ -159,7 +159,11 @@ std::vector<LinearProblems> linear_problems();
  */
 class InfeasibleLinearProgramTest0 : public ::testing::Test {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InfeasibleLinearProgramTest0)
+
   InfeasibleLinearProgramTest0();
+
+  ~InfeasibleLinearProgramTest0() override {}
 
  protected:
   std::unique_ptr<MathematicalProgram> prog_;
@@ -173,7 +177,11 @@ class InfeasibleLinearProgramTest0 : public ::testing::Test {
  */
 class UnboundedLinearProgramTest0 : public ::testing::Test {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UnboundedLinearProgramTest0)
+
   UnboundedLinearProgramTest0();
+
+  ~UnboundedLinearProgramTest0() override {}
 
  protected:
   std::unique_ptr<MathematicalProgram> prog_;

--- a/drake/solvers/test/rotation_constraint_limit_test.cc
+++ b/drake/solvers/test/rotation_constraint_limit_test.cc
@@ -8,11 +8,12 @@
 
 namespace drake {
 namespace solvers {
-// The goal of this class is to meaure how well we can approximate the
+// The goal of this class is to measure how well we can approximate the
 // constraint on SO(3). To do so, we choose to compute the closest distance
-// between R.col(0) and R.col(1), that satisfies our relaxation.
-// If `R` satisfies the SO(3) constraint exactly, thn the closest distance
-// is sqrt(2).
+// between R.col(0) and R.col(1), where `R` satisfies our relaxation.
+// If `R` satisfies the SO(3) constraint exactly, then the closest distance
+// is sqrt(2). Due to the relaxation, we should see the closest distance
+// being smaller than sqrt(2).
 // This test records how well we can approximate the rotation matrix on SO(3).
 // If in the future we improved our relaxation and get a larger minimal
 // distance, please update this test.

--- a/drake/solvers/test/rotation_constraint_limit_test.cc
+++ b/drake/solvers/test/rotation_constraint_limit_test.cc
@@ -1,0 +1,145 @@
+#include "drake/solvers/rotation_constraint.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/solvers/gurobi_solver.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+// Compute the minimum distance of R.col(0) and R.col(1), if R satisfies
+// the McCormick envelope constraint. This test records how well we can
+// approximate the rotation matrix on SO(3). If in the future we improved
+// our relaxation and get a larger minimal distance, please update this test.
+class TestMinimumDistance : public testing::TestWithParam<int> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestMinimumDistance)
+
+  TestMinimumDistance()
+      : prog_(),
+        R_(NewRotationMatrixVars(&prog_)),
+        d_(prog_.NewContinuousVariables<1>("d")),
+        num_binary_vars_per_half_axis_(GetParam()),
+        minimal_distance_expected_(0) {
+    AddRotationMatrixMcCormickEnvelopeMilpConstraints(
+        &prog_,
+        R_,
+        num_binary_vars_per_half_axis_);
+
+    // Add the constraint that d_ >= |R_.col(0) - R_.col(1)|
+    Vector4<symbolic::Expression> s;
+    s << d_(0), R_.col(0) - R_.col(1);
+    prog_.AddLorentzConeConstraint(s);
+
+    // Miminize the distance.
+    prog_.AddCost(d_(0));
+  }
+
+  ~TestMinimumDistance() override {}
+
+  void SetMinimumDistanceExpected() { DoSetMinimumDistanceExpected(); }
+
+  void SolveAndCheckSolution() {
+    GurobiSolver gurobi_solver;
+    if (gurobi_solver.available()) {
+      prog_.SetSolverOption(SolverType::kGurobi, "OutputFlag", true);
+      SolutionResult sol_result = gurobi_solver.Solve(prog_);
+
+      EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
+      double d_val = prog_.GetSolution(d_(0));
+      EXPECT_NEAR(d_val, minimal_distance_expected_, 1E-2);
+    }
+  }
+
+ protected:
+  MathematicalProgram prog_;
+  MatrixDecisionVariable<3, 3> R_;
+  VectorDecisionVariable<1> d_;
+  int num_binary_vars_per_half_axis_;
+  double minimal_distance_expected_;
+
+ private:
+  virtual void DoSetMinimumDistanceExpected() {
+    // Update the expected minimal distance, when we improve the relaxation on
+    // SO(3).
+    switch (num_binary_vars_per_half_axis_) {
+      case 1 : {
+        // TODO(hongkai.dai): The minimum distance should not be zero. Add some
+        // constraint to prevent this, such as no two columns/rows can be in the
+        // same bin.
+        minimal_distance_expected_ = 0;
+        break;
+      }
+      case 2 : {
+        minimal_distance_expected_ = 0.974;
+        break;
+      }
+      case 3 : {
+        // TODO(hongkai.dai): Figure out why 3 binary variables give closest
+        // distance smaller than 2 binary variables case.
+        minimal_distance_expected_ = 0.38;
+        break;
+      }
+      default : {
+        throw std::runtime_error(
+            "Have not attempted this number of binary variables yet.");
+      }
+    }
+  }
+};
+
+class TestMinimumDistanceWOrthonormalSocp : public TestMinimumDistance {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestMinimumDistanceWOrthonormalSocp)
+
+  TestMinimumDistanceWOrthonormalSocp() : TestMinimumDistance() {
+    AddRotationMatrixOrthonormalSocpConstraint(&prog_, R_);
+  }
+
+  ~TestMinimumDistanceWOrthonormalSocp() override {}
+
+ private:
+  void DoSetMinimumDistanceExpected() override {
+    // Update the expected minimal distance, when we improve the relaxation on
+    // SO(3).
+    switch (num_binary_vars_per_half_axis_) {
+      case 1 : {
+        minimal_distance_expected_ = 0;
+        break;
+      }
+      case 2 : {
+        minimal_distance_expected_ = 1.1928;
+        break;
+      }
+      case 3 : {
+        minimal_distance_expected_ = 1.3056;
+        break;
+      }
+      default : {
+        throw std::runtime_error(
+            "Have not attempted this number of binary variables yet.");
+      }
+    }
+  }
+};
+
+TEST_P(TestMinimumDistance, Test) {
+  SetMinimumDistanceExpected();
+  SolveAndCheckSolution();
+}
+
+TEST_P(TestMinimumDistanceWOrthonormalSocp, Test) {
+  SetMinimumDistanceExpected();
+  SolveAndCheckSolution();
+}
+
+INSTANTIATE_TEST_CASE_P(RotationTest, TestMinimumDistance,
+    ::testing::ValuesIn({1, 2, 3})
+);
+
+INSTANTIATE_TEST_CASE_P(RotationTest, TestMinimumDistanceWOrthonormalSocp,
+    ::testing::ValuesIn({1, 2, 3})
+);
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/test/rotation_constraint_limit_test.cc
+++ b/drake/solvers/test/rotation_constraint_limit_test.cc
@@ -8,10 +8,14 @@
 
 namespace drake {
 namespace solvers {
-// Compute the minimum distance of R.col(0) and R.col(1), if R satisfies
-// the McCormick envelope constraint. This test records how well we can
-// approximate the rotation matrix on SO(3). If in the future we improved
-// our relaxation and get a larger minimal distance, please update this test.
+// The goal of this class is to meaure how well we can approximate the
+// constraint on SO(3). To do so, we choose to compute the closest distance
+// between R.col(0) and R.col(1), that satisfies our relaxation.
+// If `R` satisfies the SO(3) constraint exactly, thn the closest distance
+// is sqrt(2).
+// This test records how well we can approximate the rotation matrix on SO(3).
+// If in the future we improved our relaxation and get a larger minimal
+// distance, please update this test.
 class TestMinimumDistance : public testing::TestWithParam<int> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestMinimumDistance)
@@ -65,10 +69,7 @@ class TestMinimumDistance : public testing::TestWithParam<int> {
     // SO(3).
     switch (num_binary_vars_per_half_axis_) {
       case 1 : {
-        // TODO(hongkai.dai): The minimum distance should not be zero. Add some
-        // constraint to prevent this, such as no two columns/rows can be in the
-        // same bin.
-        minimal_distance_expected_ = 0;
+        minimal_distance_expected_ = 0.069166;
         break;
       }
       case 2 : {
@@ -76,9 +77,7 @@ class TestMinimumDistance : public testing::TestWithParam<int> {
         break;
       }
       case 3 : {
-        // TODO(hongkai.dai): Figure out why 3 binary variables give closest
-        // distance smaller than 2 binary variables case.
-        minimal_distance_expected_ = 0.38;
+        minimal_distance_expected_ = 1.0354;
         break;
       }
       default : {
@@ -105,7 +104,7 @@ class TestMinimumDistanceWOrthonormalSocp : public TestMinimumDistance {
     // SO(3).
     switch (num_binary_vars_per_half_axis_) {
       case 1 : {
-        minimal_distance_expected_ = 0;
+        minimal_distance_expected_ = 0.06916;
         break;
       }
       case 2 : {

--- a/drake/solvers/test/rotation_constraint_limit_test.cc
+++ b/drake/solvers/test/rotation_constraint_limit_test.cc
@@ -78,7 +78,7 @@ class TestMinimumDistance : public testing::TestWithParam<int> {
         break;
       }
       case 3 : {
-        minimal_distance_expected_ = 1.0354;
+        minimal_distance_expected_ = 1.0823199;
         break;
       }
       default : {

--- a/drake/solvers/test/rotation_constraint_limit_test.cc
+++ b/drake/solvers/test/rotation_constraint_limit_test.cc
@@ -135,11 +135,13 @@ TEST_P(TestMinimumDistanceWOrthonormalSocp, Test) {
 }
 
 INSTANTIATE_TEST_CASE_P(RotationTest, TestMinimumDistance,
-    ::testing::ValuesIn({1, 2, 3})
-);
+                        ::testing::ValuesIn<std::vector<int>>(
+                            {1, 2,
+                             3}));  // number of binary variables per half axis
 
 INSTANTIATE_TEST_CASE_P(RotationTest, TestMinimumDistanceWOrthonormalSocp,
-    ::testing::ValuesIn({1, 2, 3})
-);
+                        ::testing::ValuesIn<std::vector<int>>(
+                            {1, 2,
+                             3}));  // number of binary variables per half axis
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -666,7 +666,7 @@ std::array<std::pair<int, int>, 3> vector_indices = {{{0, 1}, {0, 2}, {1, 2}}};
 INSTANTIATE_TEST_CASE_P(
     RotationTest, TestMcCormickOrthant,
     ::testing::Combine(
-        ::testing::ValuesIn({1, 2}),  // # of binary variables per half axis
+        ::testing::ValuesIn({1}),  // # of binary variables per half axis
         ::testing::ValuesIn({0, 1, 2, 3, 4, 5, 6, 7}),  // orthant index
         ::testing::ValuesIn({false, true}),    // row vector or column vector
         ::testing::ValuesIn(vector_indices),   // vector indices

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -9,7 +9,6 @@
 #include "drake/math/random_rotation.h"
 #include "drake/math/roll_pitch_yaw_not_using_quaternion.h"
 #include "drake/math/rotation_matrix.h"
-#include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mathematical_program.h"
 
 using Eigen::Vector3d;

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -662,14 +662,18 @@ TEST_P(TestMcCormickOrthant, test) {
   }
 }
 
-std::array<std::pair<int, int>, 3> vector_indices = {{{0, 1}, {0, 2}, {1, 2}}};
+std::array<std::pair<int, int>, 3> vector_indices() {
+  std::array<std::pair<int, int>, 3> idx = {{{0, 1}, {0, 2}, {1, 2}}};
+  return idx;
+}
+
 INSTANTIATE_TEST_CASE_P(
     RotationTest, TestMcCormickOrthant,
     ::testing::Combine(
         ::testing::ValuesIn({1}),  // # of binary variables per half axis
         ::testing::ValuesIn({0, 1, 2, 3, 4, 5, 6, 7}),  // orthant index
         ::testing::ValuesIn({false, true}),    // row vector or column vector
-        ::testing::ValuesIn(vector_indices),   // vector indices
+        ::testing::ValuesIn(vector_indices()),   // vector indices
         ::testing::ValuesIn({false, true})));  // same of opposite orthant
 }  // namespace
 }  // namespace solvers

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -572,7 +572,7 @@ GTEST_TEST(RotationTest, TestMinimumDistance) {
   EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
 
   const Matrix3d R_val = prog.GetSolution(R);
-  EXPECT_GE((R_val.col(0) - R_val.col(1)).norm(), 0.1);
+  EXPECT_GE((R_val.col(0) - R_val.col(1)).norm(), 0.94);
 }
 }  // namespace
 }  // namespace solvers

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -572,21 +572,6 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn({true, false}),  // bmin or bmax
                        ::testing::ValuesIn({0, 1, 2})));    // column index
 
-GTEST_TEST(RotationTest, TestMinimumDistance) {
-  // Compute the minimum distance of R.col(0) and R.col(1), if R satisfies
-  // the McCormick envelope constraint. This minimum distance cannot be 0.
-  MathematicalProgram prog;
-  MatrixDecisionVariable<3, 3> R = NewRotationMatrixVars(&prog);
-
-  AddRotationMatrixMcCormickEnvelopeMilpConstraints(&prog, R, 1);
-
-  // Same orthant
-  Eigen::Vector3d v1(1.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0);
-  Eigen::Vector3d v2(2.0 / 3.0, 1.0 / 3.0, 2.0 / 3.0);
-  Eigen::Vector3d v3(2.0 / 3.0, 2.0 / 3.0, 1.0 / 3.0);
-  Eigen::Matrix3d R_test;
-  R_test << v1, v2, v3;
-}
 
 // Make sure that no two row or column vectors in R, which satisfies the
 // McCormick relaxation, can lie in the same or the opposite orthant.


### PR DESCRIPTION
Add the constraint that no two rows (or columns) of the rotation matrix can lie in the same orthant.

@RussTedrake  this solves the problem that the closest distance between R.col(0) and R.col(1) with three binary variables, is smaller than that with 2 binary variables. The problem there is basically we do not have an orthonormal constraint between `R.col(0)` and `R.col(1)`, when we use McCormick envelope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5472)
<!-- Reviewable:end -->
