### PR TITLE
Adds to AutomotiveSimulator the ability to specify the initial state of a SimpleCar.

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -74,7 +74,9 @@ const RigidBodyTree<T>& AutomotiveSimulator<T>::get_rigid_body_tree() {
 template <typename T>
 int AutomotiveSimulator<T>::AddSimpleCarFromSdf(
     const std::string& sdf_filename,
-    const std::string& model_name, const std::string& channel_name) {
+    const std::string& model_name,
+    const std::string& channel_name,
+    const SimpleCarState<T>& initial_state) {
   DRAKE_DEMAND(!started_);
   const int vehicle_number = allocate_vehicle_number();
 
@@ -84,6 +86,7 @@ int AutomotiveSimulator<T>::AddSimpleCarFromSdf(
       builder_->template AddSystem<systems::lcm::LcmSubscriberSystem>(
           channel_name, driving_command_translator, lcm_.get());
   auto simple_car = builder_->template AddSystem<SimpleCar<T>>();
+  simple_car_initial_states_[simple_car].set_value(initial_state.get_value());
   auto coord_transform =
       builder_->template AddSystem<SimpleCarToEulerFloatingJoint<T>>();
 
@@ -512,6 +515,21 @@ void AutomotiveSimulator<T>::Start(double target_realtime_rate) {
 
   diagram_ = builder_->Build();
   simulator_ = std::make_unique<systems::Simulator<T>>(*diagram_);
+
+  // Initialize the state of the SimpleCars.
+  for (const auto& pair : simple_car_initial_states_) {
+    const SimpleCar<T>* const car = pair.first;
+    const SimpleCarState<T>& initial_state = pair.second;
+
+    systems::VectorBase<T>* context_state =
+        diagram_->GetMutableSubsystemContext(simulator_->get_mutable_context(),
+                                             car)
+        ->get_mutable_continuous_state()->get_mutable_vector();
+    SimpleCarState<T>* const state =
+        dynamic_cast<SimpleCarState<T>*>(context_state);
+    DRAKE_ASSERT(state);
+    state->set_value(initial_state.get_value());
+  }
 
   // Initialize the state of the EndlessRoadCars.
   for (auto& pair : endless_road_cars_) {

--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -66,17 +66,23 @@ class AutomotiveSimulator {
   /// model of a vehicle (i.e., a model that's not connected to the world). A
   /// floating joint of type multibody::joints::kRollPitchYaw is added to
   /// connect the vehicle model to the world.
+  ///
   /// @param model_name  If this is non-empty, the car's model will be labeled
   ///                    with this name.
+  ///
   /// @param channel_name  The simple car will subscribe to a channel
   ///                      with this name to receive commands.  Must be
   ///                      non-empty.
+  ///
+  /// @param initial_state The initial state of the SimpleCar.
   ///
   /// @return The model instance ID of the SimpleCar that was just added to
   /// the simulation.
   int AddSimpleCarFromSdf(const std::string& sdf_filename,
                           const std::string& model_name,
-                          const std::string& channel_name);
+                          const std::string& channel_name,
+                          const SimpleCarState<T>& initial_state =
+                              SimpleCarState<T>());
 
   /// Adds a TrajectoryCar system to this simulation, including its
   /// EulerFloatingJoint output.
@@ -254,6 +260,10 @@ class AutomotiveSimulator {
   // via non-RPY floating joints. See #3919.
   std::vector<std::pair<int, const systems::System<T>*>>
       rigid_body_tree_publisher_inputs_;
+
+  // Holds the desired initial states of each SimpleCar. It is used to
+  // initialize the simulation's diagram's state.
+  std::map<const SimpleCar<T>*, SimpleCarState<T>> simple_car_initial_states_;
   // === End for building. ===
 
   int next_vehicle_number_{0};


### PR DESCRIPTION
This allows us to start a simulation where each `SimpleCar` starts at a different location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5473)
<!-- Reviewable:end -->
