### PR TITLE
Introduce PoseBundleToDrawMessage.

### DIFF
--- a/drake/systems/rendering/BUILD
+++ b/drake/systems/rendering/BUILD
@@ -20,6 +20,18 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "pose_bundle_to_draw_message",
+    srcs = ["pose_bundle_to_draw_message.cc"],
+    hdrs = ["pose_bundle_to_draw_message.h"],
+    deps = [
+        ":pose_bundle",
+        "//drake/common",
+        "//drake/lcmtypes:viewer",
+        "//drake/systems/framework:leaf_system",
+    ],
+)
+
 # TODO(david-german-tri): Rename PoseVector to FramePose.
 drake_cc_library(
     name = "pose_vector",
@@ -85,6 +97,13 @@ drake_cc_googletest(
     deps = [
         ":frame_velocity",
         "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "pose_bundle_to_draw_message_test",
+    deps = [
+        ":pose_bundle_to_draw_message",
     ],
 )
 

--- a/drake/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/drake/systems/rendering/pose_bundle_to_draw_message.cc
@@ -1,0 +1,64 @@
+#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
+
+#include "drake/lcmtypes/drake/lcmt_viewer_draw.hpp"
+#include "drake/systems/rendering/pose_bundle.h"
+
+namespace drake {
+namespace systems {
+namespace rendering {
+
+PoseBundleToDrawMessage::PoseBundleToDrawMessage() {
+  this->DeclareAbstractInputPort();
+  this->DeclareAbstractOutputPort();
+}
+
+PoseBundleToDrawMessage::~PoseBundleToDrawMessage() {}
+
+void PoseBundleToDrawMessage::DoCalcOutput(const Context<double>& context,
+                                           SystemOutput<double>* output) const {
+  const PoseBundle<double>& poses =
+      this->EvalAbstractInput(context, 0)
+          ->template GetValue<PoseBundle<double>>();
+  lcmt_viewer_draw& message =
+      output->GetMutableData(0)->template GetMutableValue<lcmt_viewer_draw>();
+
+  const int n = poses.get_num_poses();
+
+  message.timestamp = static_cast<int64_t>(context.get_time() * 1000.0);
+  message.num_links = n;
+  message.link_name.resize(n);
+  message.robot_num.resize(n);
+  message.position.resize(n);
+  message.quaternion.resize(n);
+
+  for (int i = 0; i < n; ++i) {
+    // TODO(david-german-tri): Support non-unique link names by populating
+    // robot_num. Will require changes in PoseAggregator and PoseBundle.
+    message.robot_num[i] = 0;
+
+    message.link_name[i] = poses.get_name(i);
+
+    Eigen::Translation<double, 3> t(poses.get_pose(i).translation());
+    message.position[i].resize(3);
+    message.position[i][0] = t.x();
+    message.position[i][1] = t.y();
+    message.position[i][2] = t.z();
+
+    Eigen::Quaternion<double> q(poses.get_pose(i).rotation());
+    message.quaternion[i].resize(4);
+    message.quaternion[i][0] = q.w();
+    message.quaternion[i][1] = q.x();
+    message.quaternion[i][2] = q.y();
+    message.quaternion[i][3] = q.z();
+  }
+}
+
+std::unique_ptr<AbstractValue>
+PoseBundleToDrawMessage::AllocateOutputAbstract(
+    const OutputPortDescriptor<double>& descriptor) const {
+  return AbstractValue::Make<lcmt_viewer_draw>(lcmt_viewer_draw());
+}
+
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/rendering/pose_bundle_to_draw_message.h
+++ b/drake/systems/rendering/pose_bundle_to_draw_message.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+
+#include <Eigen/Dense>
+
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+namespace rendering {
+
+/// PoseBundleToDrawMessage converts a PoseBundle on its single abstract-valued
+/// input port to a Drake Visualizer Interface LCM draw message,
+/// lcmt_viewer_draw, on its single abstract-valued output port.
+///
+/// The draw message will contain one link for each pose in the PoseBundle. The
+/// name of the link will be the name of the corresponding pose. The robot_num
+/// will always be 0. Because of this restriction, only one instance of a
+/// model can be visualized, and no two models can have overlapping link names.
+/// TODO(david-german-tri): Lift this restriction.
+class PoseBundleToDrawMessage : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseBundleToDrawMessage)
+
+  PoseBundleToDrawMessage();
+  ~PoseBundleToDrawMessage() override;
+
+ protected:
+  /// Copies the input poses into the draw message.
+  void DoCalcOutput(const Context<double>& context,
+                    SystemOutput<double>* output) const override;
+
+  /// Allocates a draw message.
+  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
+      const OutputPortDescriptor<double>& descriptor) const override;
+};
+
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/rendering/test/pose_bundle_to_draw_message_test.cc
+++ b/drake/systems/rendering/test/pose_bundle_to_draw_message_test.cc
@@ -1,0 +1,70 @@
+#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/rendering/pose_bundle.h"
+#include "drake/lcmtypes/drake/lcmt_viewer_draw.hpp"
+
+namespace drake {
+namespace systems {
+namespace rendering {
+namespace {
+
+GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
+  PoseBundle<double> bundle(2);
+  Eigen::Isometry3d foo_pose = Eigen::Isometry3d::Identity();
+  foo_pose.translation()[0] = 123;
+  bundle.set_name(0, "foo");
+  bundle.set_pose(0, foo_pose);
+
+  Eigen::Isometry3d bar_pose = Eigen::Isometry3d::Identity();
+  const double roll = -M_PI_2;
+  bar_pose *= Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX());
+  bundle.set_name(1, "bar");
+  bundle.set_pose(1, bar_pose);
+
+  PoseBundleToDrawMessage converter;
+  auto context = converter.AllocateContext();
+  context->FixInputPort(0, AbstractValue::Make(bundle));
+  auto output = converter.AllocateOutput(*context);
+  converter.CalcOutput(*context, output.get());
+
+  const auto& message = output->get_data(0)->GetValue<lcmt_viewer_draw>();
+  EXPECT_EQ(2, message.num_links);
+
+  EXPECT_EQ("foo", message.link_name[0]);
+  EXPECT_EQ(0, message.robot_num[0]);
+  // foo is translated in x.
+  EXPECT_EQ(123, message.position[0][0]);  // x
+  EXPECT_EQ(0, message.position[0][1]);    // y
+  EXPECT_EQ(0, message.position[0][2]);    // z
+  // foo has no rotation.
+  EXPECT_EQ(1, message.quaternion[0][0]);  // w
+  EXPECT_EQ(0, message.quaternion[0][1]);  // x
+  EXPECT_EQ(0, message.quaternion[0][2]);  // y
+  EXPECT_EQ(0, message.quaternion[0][3]);  // z
+
+  EXPECT_EQ("bar", message.link_name[1]);
+  EXPECT_EQ(0, message.robot_num[1]);
+  // bar has no translation.
+  EXPECT_EQ(0, message.position[1][0]);  // x
+  EXPECT_EQ(0, message.position[1][1]);  // y
+  EXPECT_EQ(0, message.position[1][2]);  // z
+  // bar has a rotation around x.
+  EXPECT_NEAR(std::cos(roll / 2), message.quaternion[1][0], 1.0e-6);  // w
+  EXPECT_NEAR(std::sin(roll / 2), message.quaternion[1][1], 1.0e-6);  // x
+  EXPECT_EQ(0, message.quaternion[0][2]);  // y
+  EXPECT_EQ(0, message.quaternion[0][3]);  // z
+}
+
+// Tests that PoseBundleToDrawMessageTest allocates no state variables.
+GTEST_TEST(PoseBundleToDrawMessageTest, Stateless) {
+  PoseBundleToDrawMessage converter;
+  auto context = converter.AllocateContext();
+  EXPECT_TRUE(context->is_stateless());
+}
+
+}  // namespace
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This converter can be used to send Drake Visualizer draw messages without reference to a RigidBodyTree.

For example usage, see https://gist.github.com/david-german-tri/c26a3cc834a3fae3e79f6d125f4f8a91.  We can integrate with AutomotiveSimulator once #5474 lands. 

@liangfok for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5476)
<!-- Reviewable:end -->
