### PR TITLE
Move type safe index into common

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -149,6 +149,21 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "type_safe_index",
+    srcs = [],
+    hdrs = ["type_safe_index.h"],
+    deps = [
+        ":common",
+        ":nice_type_name",
+    ],
+)
+
+drake_cc_googletest(
+    name = "type_safe_index_test",
+    deps = [":type_safe_index"],
+)
+
 # Miscellaneous utilities.
 drake_cc_library(
     name = "drake_path",

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -159,11 +159,6 @@ drake_cc_library(
     ],
 )
 
-drake_cc_googletest(
-    name = "type_safe_index_test",
-    deps = [":type_safe_index"],
-)
-
 # Miscellaneous utilities.
 drake_cc_library(
     name = "drake_path",
@@ -552,6 +547,11 @@ drake_cc_googletest(
         ":common",
         ":polynomial",
     ],
+)
+
+drake_cc_googletest(
+    name = "type_safe_index_test",
+    deps = [":type_safe_index"],
 )
 
 # TODO(jwnimmer-tri) These tests are currently missing...

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -84,6 +84,9 @@ target_link_libraries(symbolic_variable_overloading_test drakeCommon)
 drake_add_cc_test(symbolic_variables_test)
 target_link_libraries(symbolic_variables_test drakeCommon)
 
+drake_add_cc_test(type_safe_index_test type_safe_index_test.cc)
+target_link_libraries(type_safe_index_test drakeCommon)
+
 # Adds "drake_assert.h" unit testing.
 add_executable(drake_assert_test_default drake_assert_test.cc)
 target_link_libraries(drake_assert_test_default drakeCommon GTest::GTest GTest::Main)

--- a/drake/common/test/type_safe_index_test.cc
+++ b/drake/common/test/type_safe_index_test.cc
@@ -19,144 +19,136 @@ namespace {
 using AIndex = TypeSafeIndex<class A>;
 using BIndex = TypeSafeIndex<class B>;
 
-template <class IndexType>
-void RunMultibodyIndexTests() {
-  // Construction from an int.
-  {
-    IndexType index(1);
-    EXPECT_EQ(index, 1);  // This also tests operator==(int).
-    // In Debug builds construction from a negative int throws.
+// Verifies the constructor behavior -- in debug and release modes.
+GTEST_TEST(TypeSafeIndex, Constructor) {
+  AIndex index(1);
+  EXPECT_EQ(index, 1);  // This also tests operator==(int).
+// In Debug builds construction from a negative int throws.
 #ifndef DRAKE_ASSERT_IS_DISARMED
-    try {
-      IndexType negative_index(-1);
-      GTEST_FAIL();
-    } catch (std::runtime_error& e) {
-      std::string expected_msg =
-          "This index, of type \"" + drake::NiceTypeName::Get<IndexType>() +
-          "\", has the negative value = -1. Negative indexes are not allowed";
-      EXPECT_EQ(e.what(), expected_msg);
-    }
+  try {
+    AIndex negative_index(-1);
+    GTEST_FAIL();
+  } catch (std::runtime_error& e) {
+    std::string expected_msg =
+        "This index, of type \"" + drake::NiceTypeName::Get<AIndex>() +
+        "\", has the negative value = -1. Negative indexes are not allowed.";
+    EXPECT_EQ(e.what(), expected_msg);
+  }
 #endif
-  }
+}
 
-  // Conversion operator.
-  {
-    IndexType index(4);
-    int four = index;
-    EXPECT_EQ(four, index);
-  }
+// Verifies implicit conversion from index to int.
+GTEST_TEST(TypeSafeIndex, ConversionToInt) {
+  AIndex index(4);
+  int four = index;
+  EXPECT_EQ(four, index);
+}
 
-  // Comparison operators.
-  {
-    IndexType index1(5);
-    IndexType index2(5);
-    IndexType index3(7);
-    // true-returning coverage.
-    EXPECT_TRUE(index1 == index2);  // operator==
-    EXPECT_TRUE(index1 != index3);  // operator!=
-    EXPECT_TRUE(index1 <  index3);  // operator<
-    EXPECT_TRUE(index1 <= index2);  // operator<=
-    EXPECT_TRUE(index3 >  index1);  // operator>
-    EXPECT_TRUE(index2 >= index1);  // operator>=
-    // false-returning coverage.
-    EXPECT_FALSE(index1 == index3);  // operator==
-    EXPECT_FALSE(index1 != index2);  // operator!=
-    EXPECT_FALSE(index3 <  index1);  // operator<
-    EXPECT_FALSE(index3 <= index1);  // operator<=
-    EXPECT_FALSE(index1 >  index3);  // operator>
-    EXPECT_FALSE(index1 >= index3);  // operator>=
-  }
+// Tests valid comparisons of like-typed index instances.
+GTEST_TEST(TypeSafeIndex, IndexComparisonOperators) {
+  AIndex index1(5);
+  AIndex index2(5);
+  AIndex index3(7);
+  // true-returning coverage.
+  EXPECT_TRUE(index1 == index2);  // operator==
+  EXPECT_TRUE(index1 != index3);  // operator!=
+  EXPECT_TRUE(index1 <  index3);  // operator<
+  EXPECT_TRUE(index1 <= index2);  // operator<=
+  EXPECT_TRUE(index3 >  index1);  // operator>
+  EXPECT_TRUE(index2 >= index1);  // operator>=
+  // false-returning coverage.
+  EXPECT_FALSE(index1 == index3);  // operator==
+  EXPECT_FALSE(index1 != index2);  // operator!=
+  EXPECT_FALSE(index3 <  index1);  // operator<
+  EXPECT_FALSE(index3 <= index1);  // operator<=
+  EXPECT_FALSE(index1 >  index3);  // operator>
+  EXPECT_FALSE(index1 >= index3);  // operator>=
+}
 
-  // Prefix increment.
-  {
-    IndexType index(8);
-    EXPECT_EQ(index, IndexType(8));
-    IndexType index_plus = ++index;
-    EXPECT_EQ(index, IndexType(9));
-    EXPECT_EQ(index_plus, IndexType(9));
-  }
+// Tests the prefix increment behavior.
+GTEST_TEST(TypeSafeIndex, PrefixIncrement) {
+  AIndex index(8);
+  EXPECT_EQ(index, AIndex(8));
+  AIndex index_plus = ++index;
+  EXPECT_EQ(index, AIndex(9));
+  EXPECT_EQ(index_plus, AIndex(9));
+}
 
-  // Postfix increment.
-  {
-    IndexType index(8);
-    EXPECT_EQ(index, IndexType(8));
-    IndexType index_plus = index++;
-    EXPECT_EQ(index, IndexType(9));
-    EXPECT_EQ(index_plus, IndexType(8));
-  }
+// Tests the postfix increment behavior.
+GTEST_TEST(TypeSafeIndex, PostfixIncrement) {
+  AIndex index(8);
+  EXPECT_EQ(index, AIndex(8));
+  AIndex index_plus = index++;
+  EXPECT_EQ(index, AIndex(9));
+  EXPECT_EQ(index_plus, AIndex(8));
+}
 
-  // Prefix decrement.
-  {
-    IndexType index(8);
-    EXPECT_EQ(index, IndexType(8));
-    IndexType index_minus = --index;
-    EXPECT_EQ(index, IndexType(7));
-    EXPECT_EQ(index_minus, IndexType(7));
-    // In Debug builds decrements leading to a negative result will throw.
-    IndexType about_to_be_negative_index(0);
-    EXPECT_THROW_IF_ARMED(--about_to_be_negative_index);
-  }
+// Tests the prefix decrement behavior.
+GTEST_TEST(TypeSafeIndex, PrefixDecrement) {
+  AIndex index(8);
+  EXPECT_EQ(index, AIndex(8));
+  AIndex index_minus = --index;
+  EXPECT_EQ(index, AIndex(7));
+  EXPECT_EQ(index_minus, AIndex(7));
+  // In Debug builds decrements leading to a negative result will throw.
+  AIndex about_to_be_negative_index(0);
+  EXPECT_THROW_IF_ARMED(--about_to_be_negative_index);
+}
 
-  // Postfix decrement.
-  {
-    IndexType index(8);
-    EXPECT_EQ(index, IndexType(8));
-    IndexType index_minus = index--;
-    EXPECT_EQ(index, IndexType(7));
-    EXPECT_EQ(index_minus, IndexType(8));
-    // In Debug builds decrements leading to a negative result will throw.
-    IndexType about_to_be_negative_index(0);
-    EXPECT_THROW_IF_ARMED(about_to_be_negative_index--);
-  }
+// Tests the postfix decrement behavior.
+GTEST_TEST(TypeSafeIndex, PostfixDecrement) {
+  AIndex index(8);
+  EXPECT_EQ(index, AIndex(8));
+  AIndex index_minus = index--;
+  EXPECT_EQ(index, AIndex(7));
+  EXPECT_EQ(index_minus, AIndex(8));
+  // In Debug builds decrements leading to a negative result will throw.
+  AIndex about_to_be_negative_index(0);
+  EXPECT_THROW_IF_ARMED(about_to_be_negative_index--);
+}
 
-  // Addition and Subtraction.
-  {
-    IndexType index1(8);
-    IndexType index2(5);
-    EXPECT_EQ(index1 + index2, IndexType(13));
-    EXPECT_EQ(index1 - index2, IndexType(3));
-    // Negative results are an int, not an index, and therefore are allowed.
-    EXPECT_EQ(index2 - index1, -3);
-    // However construction from a negative result is not allowed.
-    EXPECT_THROW_IF_ARMED(IndexType bad_index(index2 - index1));
-  }
+// Tests integer addition and subtraction.
+GTEST_TEST(TypeSafeIndex, AdditionAndSubtraction) {
+  AIndex index1(8);
+  AIndex index2(5);
+  EXPECT_EQ(index1 + index2, AIndex(13));
+  EXPECT_EQ(index1 - index2, AIndex(3));
+  // Negative results are an int, not an index, and therefore are allowed.
+  EXPECT_EQ(index2 - index1, -3);
+  // However construction from a negative result is not allowed.
+  EXPECT_THROW_IF_ARMED(AIndex bad_index(index2 - index1));
+}
 
-  // Addition assignment.
-  {
-    IndexType index(8);
-    IndexType index_plus_seven = index += 7;
-    EXPECT_EQ(index, IndexType(15));
-    EXPECT_EQ(index_plus_seven, IndexType(15));
-    EXPECT_EQ(index, index_plus_seven);
-    // In Debug builds additions leading to a negative result will throw.
-    IndexType about_to_be_negative_index(7);
-    EXPECT_THROW_IF_ARMED(about_to_be_negative_index += (-9));
-  }
+// Tests in-place addition.
+GTEST_TEST(TypeSafeIndex, InPlaceAddition) {
+  AIndex index(8);
+  AIndex index_plus_seven = index += 7;
+  EXPECT_EQ(index, AIndex(15));
+  EXPECT_EQ(index_plus_seven, AIndex(15));
+  EXPECT_EQ(index, index_plus_seven);
+  // In Debug builds additions leading to a negative result will throw.
+  AIndex about_to_be_negative_index(7);
+  EXPECT_THROW_IF_ARMED(about_to_be_negative_index += (-9));
+}
 
-  // Subtraction assignment.
-  {
-    IndexType index(8);
-    IndexType index_minus_seven = index -= 7;
-    EXPECT_EQ(index, IndexType(1));
-    EXPECT_EQ(index_minus_seven, IndexType(1));
-    EXPECT_EQ(index, index_minus_seven);
-    // In Debug builds decrements leading to a negative result will throw.
-    IndexType about_to_be_negative_index(0);
-    EXPECT_THROW_IF_ARMED(about_to_be_negative_index -= 7);
-  }
+// Tests in-place subtraction.
+GTEST_TEST(TypeSafeIndex, InPlaceSubtract) {
+  AIndex index(8);
+  AIndex index_minus_seven = index -= 7;
+  EXPECT_EQ(index, AIndex(1));
+  EXPECT_EQ(index_minus_seven, AIndex(1));
+  EXPECT_EQ(index, index_minus_seven);
+  // In Debug builds decrements leading to a negative result will throw.
+  AIndex about_to_be_negative_index(0);
+  EXPECT_THROW_IF_ARMED(about_to_be_negative_index -= 7);
+}
 
-  // Stream insertion operator.
-  {
-    IndexType index(8);
+// Tests stream insertion.
+GTEST_TEST(TypeSafeIndex, StreamInsertion) {
+    AIndex index(8);
     std::stringstream stream;
     stream << index;
     EXPECT_EQ(stream.str(), "8");
-  }
-}
-
-// Verifies the correct behavior of class.
-GTEST_TEST(TypeSafeIndex, BasicFunctionality) {
-  RunMultibodyIndexTests<AIndex>();
 }
 
 // Verifies that it is not possible to convert between two different

--- a/drake/common/test/type_safe_index_test.cc
+++ b/drake/common/test/type_safe_index_test.cc
@@ -1,0 +1,176 @@
+#include "drake/common/type_safe_index.h"
+
+#include <sstream>
+#include <type_traits>
+
+#include "gtest/gtest.h"
+
+namespace drake {
+namespace common {
+namespace {
+
+#ifndef DRAKE_ASSERT_IS_DISARMED
+#define EXPECT_THROW_IF_ARMED(expr) EXPECT_THROW(expr, std::runtime_error);
+#else
+#define EXPECT_THROW_IF_ARMED(expr)
+#endif
+
+// Create dummy index types to exercise the functionality
+using AIndex = TypeSafeIndex<class A>;
+using BIndex = TypeSafeIndex<class B>;
+
+template <class IndexType>
+void RunMultibodyIndexTests() {
+  // Construction from an int.
+  {
+    IndexType index(1);
+    EXPECT_EQ(index, 1);  // This also tests operator==(int).
+    // In Debug builds construction from a negative int throws.
+#ifndef DRAKE_ASSERT_IS_DISARMED
+    try {
+      IndexType negative_index(-1);
+      GTEST_FAIL();
+    } catch (std::runtime_error& e) {
+      std::string expected_msg =
+          "This index, of type \"" + drake::NiceTypeName::Get<IndexType>() +
+          "\", has the negative value = -1. Negative indexes are not allowed";
+      EXPECT_EQ(e.what(), expected_msg);
+    }
+#endif
+  }
+
+  // Conversion operator.
+  {
+    IndexType index(4);
+    int four = index;
+    EXPECT_EQ(four, index);
+  }
+
+  // Comparison operators.
+  {
+    IndexType index1(5);
+    IndexType index2(5);
+    IndexType index3(7);
+    // true-returning coverage.
+    EXPECT_TRUE(index1 == index2);  // operator==
+    EXPECT_TRUE(index1 != index3);  // operator!=
+    EXPECT_TRUE(index1 <  index3);  // operator<
+    EXPECT_TRUE(index1 <= index2);  // operator<=
+    EXPECT_TRUE(index3 >  index1);  // operator>
+    EXPECT_TRUE(index2 >= index1);  // operator>=
+    // false-returning coverage.
+    EXPECT_FALSE(index1 == index3);  // operator==
+    EXPECT_FALSE(index1 != index2);  // operator!=
+    EXPECT_FALSE(index3 <  index1);  // operator<
+    EXPECT_FALSE(index3 <= index1);  // operator<=
+    EXPECT_FALSE(index1 >  index3);  // operator>
+    EXPECT_FALSE(index1 >= index3);  // operator>=
+  }
+
+  // Prefix increment.
+  {
+    IndexType index(8);
+    EXPECT_EQ(index, IndexType(8));
+    IndexType index_plus = ++index;
+    EXPECT_EQ(index, IndexType(9));
+    EXPECT_EQ(index_plus, IndexType(9));
+  }
+
+  // Postfix increment.
+  {
+    IndexType index(8);
+    EXPECT_EQ(index, IndexType(8));
+    IndexType index_plus = index++;
+    EXPECT_EQ(index, IndexType(9));
+    EXPECT_EQ(index_plus, IndexType(8));
+  }
+
+  // Prefix decrement.
+  {
+    IndexType index(8);
+    EXPECT_EQ(index, IndexType(8));
+    IndexType index_minus = --index;
+    EXPECT_EQ(index, IndexType(7));
+    EXPECT_EQ(index_minus, IndexType(7));
+    // In Debug builds decrements leading to a negative result will throw.
+    IndexType about_to_be_negative_index(0);
+    EXPECT_THROW_IF_ARMED(--about_to_be_negative_index);
+  }
+
+  // Postfix decrement.
+  {
+    IndexType index(8);
+    EXPECT_EQ(index, IndexType(8));
+    IndexType index_minus = index--;
+    EXPECT_EQ(index, IndexType(7));
+    EXPECT_EQ(index_minus, IndexType(8));
+    // In Debug builds decrements leading to a negative result will throw.
+    IndexType about_to_be_negative_index(0);
+    EXPECT_THROW_IF_ARMED(about_to_be_negative_index--);
+  }
+
+  // Addition and Subtraction.
+  {
+    IndexType index1(8);
+    IndexType index2(5);
+    EXPECT_EQ(index1 + index2, IndexType(13));
+    EXPECT_EQ(index1 - index2, IndexType(3));
+    // Negative results are an int, not an index, and therefore are allowed.
+    EXPECT_EQ(index2 - index1, -3);
+    // However construction from a negative result is not allowed.
+    EXPECT_THROW_IF_ARMED(IndexType bad_index(index2 - index1));
+  }
+
+  // Addition assignment.
+  {
+    IndexType index(8);
+    IndexType index_plus_seven = index += 7;
+    EXPECT_EQ(index, IndexType(15));
+    EXPECT_EQ(index_plus_seven, IndexType(15));
+    EXPECT_EQ(index, index_plus_seven);
+    // In Debug builds additions leading to a negative result will throw.
+    IndexType about_to_be_negative_index(7);
+    EXPECT_THROW_IF_ARMED(about_to_be_negative_index += (-9));
+  }
+
+  // Subtraction assignment.
+  {
+    IndexType index(8);
+    IndexType index_minus_seven = index -= 7;
+    EXPECT_EQ(index, IndexType(1));
+    EXPECT_EQ(index_minus_seven, IndexType(1));
+    EXPECT_EQ(index, index_minus_seven);
+    // In Debug builds decrements leading to a negative result will throw.
+    IndexType about_to_be_negative_index(0);
+    EXPECT_THROW_IF_ARMED(about_to_be_negative_index -= 7);
+  }
+
+  // Stream insertion operator.
+  {
+    IndexType index(8);
+    std::stringstream stream;
+    stream << index;
+    EXPECT_EQ(stream.str(), "8");
+  }
+}
+
+// Verifies the correct behavior of class.
+GTEST_TEST(TypeSafeIndex, BasicFunctionality) {
+  RunMultibodyIndexTests<AIndex>();
+}
+
+// Verifies that it is not possible to convert between two different
+// index types.
+GTEST_TEST(TypeSafeIndex, ConversionNotAllowedBetweenDifferentTypes) {
+  // Conversion is not allowed between two different index types.
+  // Note: the extra set of parentheses are needed to avoid the test macro
+  // getting confused with the comma inside the template brackets.
+  EXPECT_FALSE((std::is_convertible<AIndex, BIndex>::value));
+  // The trivial case of course is true.
+  EXPECT_TRUE((std::is_convertible<AIndex, AIndex>::value));
+  EXPECT_TRUE((std::is_convertible<BIndex, BIndex>::value));
+}
+
+}  // namespace
+}  // namespace common
+}  // namespace drake

--- a/drake/common/type_safe_index.h
+++ b/drake/common/type_safe_index.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/nice_type_name.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace drake {
+namespace common {
+
+/// A type-safe non-negative index that can be associated to a tag name.
+/// Different instantiations of TypeSafeIndex are not interconvertible.
+/// TypeSafeIndex allows for instantiations from an `int` as well as it allows
+/// to convert back to an `int` via its conversion operator. Negative index
+/// values are not allowed.
+/// TypeSafeIndex can be used in places where an index is needed and therefore
+/// basic operations such as prefix and postfix increment/decrement are
+/// implemented. As an example, consider the creation of an index associated
+/// with class `Foo`. This can be done in code as: <pre>
+///   using FooIndex = TypeSafeIndex<class FooTag>;
+/// </pre>
+/// where the class `FooTag` above should simply be a dummy argument, a
+/// never-defined type.
+///
+/// @tparam Tag The name of the tag associated with a class type.
+template <class Tag>
+class TypeSafeIndex {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TypeSafeIndex)
+
+  /// Default constructor is disabled to force users to intialize their indexes
+  /// at creation.
+  TypeSafeIndex() = delete;
+
+  /// Construction from an `int` value.
+  /// For Debug builds this constructor throws if the provided input `int`
+  /// `index` is negative. There is no check for Release builds.
+  explicit TypeSafeIndex(int index) : index_(index) {
+    DRAKE_ASSERT_VOID(CheckInvariants());
+  }
+
+  /// Implicit conversion to int operator.
+  operator int() const { return index_; }
+
+  /// @name Arithmetic operators.
+  ///@{
+
+  /// Prefix increment operator.
+  const TypeSafeIndex& operator++() {
+    ++index_;
+    return *this;
+  }
+
+  /// Postfix increment operator.
+  TypeSafeIndex operator++(int) {
+    ++index_;
+    return TypeSafeIndex(index_ - 1);
+  }
+
+  /// Prefix decrement operator.
+  /// In Debug builds this method asserts that the resulting index is
+  /// non-negative.
+  const TypeSafeIndex& operator--() {
+    --index_;
+    DRAKE_ASSERT_VOID(CheckInvariants());
+    return *this;
+  }
+
+  /// Postfix decrement operator.
+  /// In Debug builds this method asserts that the resulting index is
+  /// non-negative.
+  TypeSafeIndex operator--(int) {
+    --index_;
+    DRAKE_ASSERT_VOID(CheckInvariants());
+    return TypeSafeIndex(index_ + 1);
+  }
+  ///@}
+
+  /// @name Compound assignment operators.
+  ///@{
+
+  /// Addition assignment operator.
+  TypeSafeIndex& operator+=(int i) {
+    index_ += i;
+    DRAKE_ASSERT_VOID(CheckInvariants());
+    return *this;
+  }
+
+  /// Subtraction assignment operator.
+  /// In Debug builds this method asserts that the resulting index is
+  /// non-negative.
+  TypeSafeIndex& operator-=(int i) {
+    index_ -= i;
+    DRAKE_ASSERT_VOID(CheckInvariants());
+    return *this;
+  }
+  ///@}
+
+ private:
+  // Checks if this index is negative and if so it throws an exception.
+  void CheckInvariants() const {
+    if (index_ < 0) {
+      throw std::runtime_error(
+          "This index, of type \"" +
+              drake::NiceTypeName::Get<TypeSafeIndex<Tag>>() +
+              "\", has the negative value = " + std::to_string(index_) +
+              ". Negative indexes are not allowed");
+    }
+  }
+
+  int index_{0};
+};
+
+}  // namespace common
+}  // namespace drake

--- a/drake/common/type_safe_index.h
+++ b/drake/common/type_safe_index.h
@@ -4,12 +4,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/nice_type_name.h"
 
-#include <iostream>
-#include <stdexcept>
-#include <string>
-
 namespace drake {
-namespace common {
 
 /// A type-safe non-negative index that can be associated to a tag name.
 /// Different instantiations of TypeSafeIndex are not interconvertible.
@@ -31,13 +26,12 @@ class TypeSafeIndex {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TypeSafeIndex)
 
-  /// Default constructor is disabled to force users to intialize their indexes
+  /// Default constructor is disabled to force users to initialize their indexes
   /// at creation.
   TypeSafeIndex() = delete;
 
-  /// Construction from an `int` value.
-  /// For Debug builds this constructor throws if the provided input `int`
-  /// `index` is negative. There is no check for Release builds.
+  /// Construction from a non-negative `int` value.
+  /// Constructor only promises to enforce non-negativity in Debug build.
   explicit TypeSafeIndex(int index) : index_(index) {
     DRAKE_ASSERT_VOID(CheckInvariants());
   }
@@ -61,7 +55,7 @@ class TypeSafeIndex {
   }
 
   /// Prefix decrement operator.
-  /// In Debug builds this method asserts that the resulting index is
+  /// In Debug builds, this method asserts that the resulting index is
   /// non-negative.
   const TypeSafeIndex& operator--() {
     --index_;
@@ -70,7 +64,7 @@ class TypeSafeIndex {
   }
 
   /// Postfix decrement operator.
-  /// In Debug builds this method asserts that the resulting index is
+  /// In Debug builds, this method asserts that the resulting index is
   /// non-negative.
   TypeSafeIndex operator--(int) {
     --index_;
@@ -83,6 +77,8 @@ class TypeSafeIndex {
   ///@{
 
   /// Addition assignment operator.
+  /// In Debug builds, this method asserts that the resulting index is
+  /// non-negative.
   TypeSafeIndex& operator+=(int i) {
     index_ += i;
     DRAKE_ASSERT_VOID(CheckInvariants());
@@ -90,7 +86,7 @@ class TypeSafeIndex {
   }
 
   /// Subtraction assignment operator.
-  /// In Debug builds this method asserts that the resulting index is
+  /// In Debug builds, this method asserts that the resulting index is
   /// non-negative.
   TypeSafeIndex& operator-=(int i) {
     index_ -= i;
@@ -107,12 +103,11 @@ class TypeSafeIndex {
           "This index, of type \"" +
               drake::NiceTypeName::Get<TypeSafeIndex<Tag>>() +
               "\", has the negative value = " + std::to_string(index_) +
-              ". Negative indexes are not allowed");
+              ". Negative indexes are not allowed.");
     }
   }
 
   int index_{0};
 };
 
-}  // namespace common
 }  // namespace drake

--- a/drake/multibody/multibody_tree/BUILD
+++ b/drake/multibody/multibody_tree/BUILD
@@ -17,8 +17,7 @@ drake_cc_library(
     srcs = [],
     hdrs = ["multibody_tree_indexes.h"],
     deps = [
-        "//drake/common",
-        "//drake/common:nice_type_name",
+        "//drake/common:type_safe_index",
     ],
 )
 

--- a/drake/multibody/multibody_tree/multibody_tree_indexes.h
+++ b/drake/multibody/multibody_tree/multibody_tree_indexes.h
@@ -2,21 +2,17 @@
 
 #include "drake/common/type_safe_index.h"
 
-#include <iostream>
-#include <stdexcept>
-#include <string>
-
 namespace drake {
 namespace multibody {
 
 /// Type used to identify frames by index in a multibody tree system.
-using FrameIndex = common::TypeSafeIndex<class FrameTag>;
+using FrameIndex = TypeSafeIndex<class FrameTag>;
 
 /// Type used to identify bodies by index in a multibody tree system.
-using BodyIndex = common::TypeSafeIndex<class BodyTag>;
+using BodyIndex = TypeSafeIndex<class BodyTag>;
 
 /// Type used to identify mobilizers by index in a multibody tree system.
-using MobilizerIndex = common::TypeSafeIndex<class MobilizerTag>;
+using MobilizerIndex = TypeSafeIndex<class MobilizerTag>;
 
 /// For every MultibodyTree the **world** body _always_ has this unique index
 /// and it is always zero.

--- a/drake/multibody/multibody_tree/multibody_tree_indexes.h
+++ b/drake/multibody/multibody_tree/multibody_tree_indexes.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "drake/common/drake_assert.h"
-#include "drake/common/drake_copyable.h"
-#include "drake/common/nice_type_name.h"
+#include "drake/common/type_safe_index.h"
 
 #include <iostream>
 #include <stdexcept>
@@ -11,117 +9,14 @@
 namespace drake {
 namespace multibody {
 
-/// A type-safe non-negative index that can be associated to a tag name.
-/// Different instantiations of TypeSafeIndex are not interconvertible.
-/// TypeSafeIndex allows for instantiations from an `int` as well as it allows
-/// to convert back to an `int` via its conversion operator. Negative index
-/// values are not allowed.
-/// TypeSafeIndex can be used in places where an index is needed and therefore
-/// basic operations such as prefix and postfix increment/decrement are
-/// implemented. As an example, consider the creation of an index associated
-/// with class `Foo`. This can be done in code as: <pre>
-///   using FooIndex = TypeSafeIndex<class FooTag>;
-/// </pre>
-/// where the class `FooTag` above should simply be a dummy argument, a
-/// never-defined type.
-///
-/// @tparam Tag The name of the tag associated with a class type.
-template <class Tag>
-class TypeSafeIndex {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TypeSafeIndex)
-
-  /// Default constructor is disabled to force users to intialize their indexes
-  /// at creation.
-  TypeSafeIndex() = delete;
-
-  /// Construction from an `int` value.
-  /// For Debug builds this constructor throws if the provided input `int`
-  /// `index` is negative. There is no check for Release builds.
-  explicit TypeSafeIndex(int index) : index_(index) {
-    DRAKE_ASSERT_VOID(CheckInvariants());
-  }
-
-  /// Implicit conversion to int operator.
-  operator int() const { return index_; }
-
-  /// @name Arithmetic operators.
-  ///@{
-
-  /// Prefix increment operator.
-  const TypeSafeIndex& operator++() {
-    ++index_;
-    return *this;
-  }
-
-  /// Postfix increment operator.
-  TypeSafeIndex operator++(int) {
-    ++index_;
-    return TypeSafeIndex(index_ - 1);
-  }
-
-  /// Prefix decrement operator.
-  /// In Debug builds this method asserts that the resulting index is
-  /// non-negative.
-  const TypeSafeIndex& operator--() {
-    --index_;
-    DRAKE_ASSERT_VOID(CheckInvariants());
-    return *this;
-  }
-
-  /// Postfix decrement operator.
-  /// In Debug builds this method asserts that the resulting index is
-  /// non-negative.
-  TypeSafeIndex operator--(int) {
-    --index_;
-    DRAKE_ASSERT_VOID(CheckInvariants());
-    return TypeSafeIndex(index_ + 1);
-  }
-  ///@}
-
-  /// @name Compound assignment operators.
-  ///@{
-
-  /// Addition assignment operator.
-  TypeSafeIndex& operator+=(int i) {
-    index_ += i;
-    DRAKE_ASSERT_VOID(CheckInvariants());
-    return *this;
-  }
-
-  /// Subtraction assignment operator.
-  /// In Debug builds this method asserts that the resulting index is
-  /// non-negative.
-  TypeSafeIndex& operator-=(int i) {
-    index_ -= i;
-    DRAKE_ASSERT_VOID(CheckInvariants());
-    return *this;
-  }
-  ///@}
-
- private:
-  // Checks if this index is negative and if so it throws an exception.
-  void CheckInvariants() const {
-    if (index_ < 0) {
-      throw std::runtime_error(
-          "This index, of type \"" +
-              drake::NiceTypeName::Get<TypeSafeIndex<Tag>>() +
-              "\", has the negative value = " + std::to_string(index_) +
-              ". Negative indexes are not allowed");
-    }
-  }
-
-  int index_{0};
-};
-
 /// Type used to identify frames by index in a multibody tree system.
-using FrameIndex = TypeSafeIndex<class FrameTag>;
+using FrameIndex = common::TypeSafeIndex<class FrameTag>;
 
 /// Type used to identify bodies by index in a multibody tree system.
-using BodyIndex = TypeSafeIndex<class BodyTag>;
+using BodyIndex = common::TypeSafeIndex<class BodyTag>;
 
 /// Type used to identify mobilizers by index in a multibody tree system.
-using MobilizerIndex = TypeSafeIndex<class MobilizerTag>;
+using MobilizerIndex = common::TypeSafeIndex<class MobilizerTag>;
 
 /// For every MultibodyTree the **world** body _always_ has this unique index
 /// and it is always zero.

--- a/drake/multibody/multibody_tree/test/multibody_tree_indexes_tests.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_indexes_tests.cc
@@ -1,172 +1,15 @@
 #include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
 
-#include <sstream>
-#include <type_traits>
-
 #include "gtest/gtest.h"
-
-#include "drake/common/nice_type_name.h"
 
 namespace drake {
 namespace multibody {
 namespace {
 
-#ifndef DRAKE_ASSERT_IS_DISARMED
-#define EXPECT_THROW_IF_ARMED(expr) EXPECT_THROW(expr, std::runtime_error);
-#else
-#define EXPECT_THROW_IF_ARMED(expr)
-#endif
-
-template <class IndexType>
-void RunMultibodyIndexTests() {
-  // Construction from an int.
-  {
-    IndexType index(1);
-    EXPECT_EQ(index, 1);  // This also tests operator==(int).
-    // In Debug builds construction from a negative int throws.
-#ifndef DRAKE_ASSERT_IS_DISARMED
-    try {
-      IndexType negative_index(-1);
-      GTEST_FAIL();
-    } catch (std::runtime_error& e) {
-      std::string expected_msg =
-          "This index, of type \"" + drake::NiceTypeName::Get<IndexType>() +
-          "\", has the negative value = -1. Negative indexes are not allowed";
-      EXPECT_EQ(e.what(), expected_msg);
-    }
-#endif
-  }
-
-  // Conversion operator.
-  {
-    IndexType index(4);
-    int four = index;
-    EXPECT_EQ(four, index);
-  }
-
-  // Comparison operators.
-  {
-    IndexType index1(5);
-    IndexType index2(5);
-    IndexType index3(7);
-    // true-returning coverage.
-    EXPECT_TRUE(index1 == index2);  // operator==
-    EXPECT_TRUE(index1 != index3);  // operator!=
-    EXPECT_TRUE(index1 <  index3);  // operator<
-    EXPECT_TRUE(index1 <= index2);  // operator<=
-    EXPECT_TRUE(index3 >  index1);  // operator>
-    EXPECT_TRUE(index2 >= index1);  // operator>=
-    // false-returning coverage.
-    EXPECT_FALSE(index1 == index3);  // operator==
-    EXPECT_FALSE(index1 != index2);  // operator!=
-    EXPECT_FALSE(index3 <  index1);  // operator<
-    EXPECT_FALSE(index3 <= index1);  // operator<=
-    EXPECT_FALSE(index1 >  index3);  // operator>
-    EXPECT_FALSE(index1 >= index3);  // operator>=
-  }
-
-  // Prefix increment.
-  {
-    IndexType index(8);
-    EXPECT_EQ(index, IndexType(8));
-    IndexType index_plus = ++index;
-    EXPECT_EQ(index, IndexType(9));
-    EXPECT_EQ(index_plus, IndexType(9));
-  }
-
-  // Postfix increment.
-  {
-    IndexType index(8);
-    EXPECT_EQ(index, IndexType(8));
-    IndexType index_plus = index++;
-    EXPECT_EQ(index, IndexType(9));
-    EXPECT_EQ(index_plus, IndexType(8));
-  }
-
-  // Prefix decrement.
-  {
-    IndexType index(8);
-    EXPECT_EQ(index, IndexType(8));
-    IndexType index_minus = --index;
-    EXPECT_EQ(index, IndexType(7));
-    EXPECT_EQ(index_minus, IndexType(7));
-    // In Debug builds decrements leading to a negative result will throw.
-    IndexType about_to_be_negative_index(0);
-    EXPECT_THROW_IF_ARMED(--about_to_be_negative_index);
-  }
-
-  // Postfix decrement.
-  {
-    IndexType index(8);
-    EXPECT_EQ(index, IndexType(8));
-    IndexType index_minus = index--;
-    EXPECT_EQ(index, IndexType(7));
-    EXPECT_EQ(index_minus, IndexType(8));
-    // In Debug builds decrements leading to a negative result will throw.
-    IndexType about_to_be_negative_index(0);
-    EXPECT_THROW_IF_ARMED(about_to_be_negative_index--);
-  }
-
-  // Addition and Subtraction.
-  {
-    IndexType index1(8);
-    IndexType index2(5);
-    EXPECT_EQ(index1 + index2, IndexType(13));
-    EXPECT_EQ(index1 - index2, IndexType(3));
-    // Negative results are an int, not an index, and therefore are allowed.
-    EXPECT_EQ(index2 - index1, -3);
-    // However construction from a negative result is not allowed.
-    EXPECT_THROW_IF_ARMED(IndexType bad_index(index2 - index1));
-  }
-
-  // Addition assignment.
-  {
-    IndexType index(8);
-    IndexType index_plus_seven = index += 7;
-    EXPECT_EQ(index, IndexType(15));
-    EXPECT_EQ(index_plus_seven, IndexType(15));
-    EXPECT_EQ(index, index_plus_seven);
-    // In Debug builds additions leading to a negative result will throw.
-    IndexType about_to_be_negative_index(7);
-    EXPECT_THROW_IF_ARMED(about_to_be_negative_index += (-9));
-  }
-
-  // Subtraction assignment.
-  {
-    IndexType index(8);
-    IndexType index_minus_seven = index -= 7;
-    EXPECT_EQ(index, IndexType(1));
-    EXPECT_EQ(index_minus_seven, IndexType(1));
-    EXPECT_EQ(index, index_minus_seven);
-    // In Debug builds decrements leading to a negative result will throw.
-    IndexType about_to_be_negative_index(0);
-    EXPECT_THROW_IF_ARMED(about_to_be_negative_index -= 7);
-  }
-
-  // Stream insertion operator.
-  {
-    IndexType index(8);
-    std::stringstream stream;
-    stream << index;
-    EXPECT_EQ(stream.str(), "8");
-  }
-}
-
-// Verifies the correct behavior of FrameIndex.
-GTEST_TEST(MultibodyTreeIndexes, FrameIndex) {
-  RunMultibodyIndexTests<FrameIndex>();
-}
-
 // Verifies the correct behavior of BodyIndex.
 GTEST_TEST(MultibodyTreeIndexes, BodyIndex) {
-  RunMultibodyIndexTests<BodyIndex>();
   // Verify the we can retrieve the "world" id.
   EXPECT_EQ(world_index(), BodyIndex(0));
-}
-
-// Verifies the correct behavior of MobilizerIndex.
-GTEST_TEST(MultibodyTreeIndexes, MobilizerIndex) {
-  RunMultibodyIndexTests<MobilizerIndex>();
 }
 
 // Verifies that it is not possible to convert between two different
@@ -180,7 +23,6 @@ GTEST_TEST(MultibodyTreeIndexes, ConversionNotAllowedBetweenDifferentTypes) {
   EXPECT_TRUE((std::is_convertible<BodyIndex, BodyIndex>::value));
   EXPECT_TRUE((std::is_convertible<FrameIndex, FrameIndex>::value));
 }
-
 
 }  // namespace
 }  // namespace multibody


### PR DESCRIPTION
This moves the type safe index template class into common, leaving the multibody instantiations in place.

This is necessary for `GeometryWorld` to exploit this functionality.
It also changes the unit test *slightly*.  The previous incarnation of the unit test tested the functionality for
each instantiation type (e.g., `FrameIndex`, `BodyIndex`, etc.)  In retrospect, this seems to be redundant testing.

Otherwise, this is *predominantly* simply file moves.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5479)
<!-- Reviewable:end -->
