### PR TITLE
Removes name of system from start of Doxygen comment blocks in drake/automotive/

### DIFF
--- a/drake/automotive/bicycle_car.h
+++ b/drake/automotive/bicycle_car.h
@@ -12,7 +12,7 @@
 namespace drake {
 namespace automotive {
 
-/// BicycleCar -- Implements a nonlinear rigid body bicycle model from Althoff &
+/// BicycleCar implements a nonlinear rigid body bicycle model from Althoff &
 /// Dolan (2014) [1].  The three-DOF model captures the rigid-body dynamics in
 /// the lateral, longitudinal, and yaw directions but not in the roll and pitch
 /// directions.  The model assumes a vehicle that has two wheels: one at the

--- a/drake/automotive/curve2.h
+++ b/drake/automotive/curve2.h
@@ -12,9 +12,8 @@
 namespace drake {
 namespace automotive {
 
-/// Curve2 -- a path through two-dimensional Cartesian space.
-///
-/// Given a list of waypoints, traces a path between them.
+/// Curve2 represents a path through two-dimensional Cartesian space. Given a
+/// list of waypoints, it traces a path between them.
 ///
 /// TODO(jwnimmer-tri) We will soon trace the path using a spline, but
 /// for now it's easiest to just interpolate straight segments, as a

--- a/drake/automotive/idm_planner.h
+++ b/drake/automotive/idm_planner.h
@@ -6,12 +6,12 @@
 namespace drake {
 namespace automotive {
 
-/// IdmPlanner -- an IDM (Intelligent Driver Model) planner.  The IDM is a
-/// simple model governing longitudinal accelerations of a vehicle in
-/// single-lane traffic [1, 2].  It is derived based on qualitative observations
-/// of actual driving behavior and captures objectives such as keeping a safe
-/// distance behind a lead vehicle, maintaining a desired speed, and
-/// accelerating and decelerating within comfortable limits.
+/// IdmPlanner (Intelligent Driver Model Planner) is a simple model governing
+/// longitudinal accelerations of a vehicle in single-lane traffic [1, 2].  It
+/// is derived based on qualitative observations of actual driving behavior and
+/// captures objectives such as keeping a safe distance behind a lead vehicle,
+/// maintaining a desired speed, and accelerating and decelerating within
+/// comfortable limits.
 ///
 /// The IDM equation produces accelerations that realize smooth transitions
 /// between the following three modes:

--- a/drake/automotive/linear_car.h
+++ b/drake/automotive/linear_car.h
@@ -6,8 +6,8 @@
 namespace drake {
 namespace automotive {
 
-/// LinearCar -- model a car operating in a single lane using a double
-/// integrator with an acceleration input.
+/// LinearCar models a car operating in a single lane using a double integrator
+/// with an acceleration input.
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -13,8 +13,8 @@
 namespace drake {
 namespace automotive {
 
-/// Models a vehicle that follows a maliput::api::Lane as if it were on rails
-/// and neglecting all physics.
+/// MaliputRailcar models a vehicle that follows a maliput::api::Lane as if it
+/// were on rails and neglecting all physics.
 ///
 /// Configuration:
 ///   * See MaliputRailcarConfig.

--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -13,9 +13,9 @@
 namespace drake {
 namespace automotive {
 
-/// SimpleCar -- model an idealized response to driving commands, neglecting
-/// all physics. Note that the SimpleCar can move forward, stop, turn left, and
-/// turn right but *cannot* travel in reverse.
+/// SimpleCar models an idealized response to driving commands, neglecting all
+/// physics. Note that SimpleCar can move forward, stop, turn left, and turn
+/// right but *cannot* travel in reverse.
 ///
 /// configuration:
 /// * uses systems::Parameters wrapping a SimpleCarConfig

--- a/drake/automotive/simple_powertrain.h
+++ b/drake/automotive/simple_powertrain.h
@@ -5,9 +5,9 @@
 namespace drake {
 namespace automotive {
 
-/// SimplePowertrain -- A simple powertrain system modeled as a first-order lag,
-/// with input taken as the throttle setting and the output taken as the applied
-/// lumped force from the vehicle to the road.
+/// SimplePowertrain models a powertrain with first-order lag. It accepts
+/// throttle as the input and outputs the applied lumped force from the vehicle
+/// to the road.
 ///
 /// Input:
 ///  - A unitless scalar value representing the throttle input to the power

--- a/drake/automotive/single_lane_ego_and_agent.h
+++ b/drake/automotive/single_lane_ego_and_agent.h
@@ -12,9 +12,9 @@
 namespace drake {
 namespace automotive {
 
-/// Idm -- A System that takes in the positions and velocities of an ego car and
-/// agent car, and produces an output with the computed IDM acceleration (see
-/// IdmPlanner).
+/// Idm (Intelligent Driver Model) is a System that takes in the positions and
+/// velocities of an ego car and agent car, and produces an output with the
+/// computed IDM acceleration (see IdmPlanner).
 ///
 /// Inputs:
 ///   0: A BasicVector consisting of
@@ -49,7 +49,7 @@ class Idm : public systems::LeafSystem<T> {
                             systems::Parameters<T>* params) const override;
 };
 
-/// SingleLaneEgoAndAgent -- A System consisting of two cars: an ego and an
+/// SingleLaneEgoAndAgent is a System consisting of two cars: an ego and an
 /// agent, where the ego is governed by an IDM (intelligent driver model)
 /// planner, and where the agent is fed a constant acceleration input.
 ///

--- a/drake/automotive/trajectory_car.h
+++ b/drake/automotive/trajectory_car.h
@@ -12,7 +12,8 @@
 namespace drake {
 namespace automotive {
 
-/// A car that follows a pre-established trajectory, neglecting all physics.
+/// TrajectoryCar models a car that follows a pre-established trajectory,
+/// neglecting all physics.
 ///
 /// state vector
 /// * none


### PR DESCRIPTION
The motivation for this is this comment: https://reviewable.io/reviews/robotlocomotion/drake/5463#-Kf4ng3kYHfYTieWm6a2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5482)
<!-- Reviewable:end -->
