### PR TITLE
Port automotive to model-based declarations

### DIFF
--- a/drake/automotive/bicycle_car.cc
+++ b/drake/automotive/bicycle_car.cc
@@ -14,33 +14,22 @@
 namespace drake {
 namespace automotive {
 
-namespace {
-
-// Specify the dimension of the state vector and of each input port.
-static constexpr int kStateDimension{BicycleCarStateIndices::kNumCoordinates};
-static constexpr int kSteeringInputDimension{1};
-static constexpr int kForceInputDimension{1};
-
-}  // namespace
-
 template <typename T>
 BicycleCar<T>::BicycleCar() {
-  auto& steering_input =
-      this->DeclareInputPort(systems::kVectorValued, kSteeringInputDimension);
-  auto& force_input =
-      this->DeclareInputPort(systems::kVectorValued, kForceInputDimension);
-  auto& state_output =
-      this->DeclareOutputPort(systems::kVectorValued, kStateDimension);
+  auto& steering_input = this->DeclareInputPort(systems::kVectorValued, 1);
+  auto& force_input = this->DeclareInputPort(systems::kVectorValued, 1);
+  auto& state_output = this->DeclareVectorOutputPort(BicycleCarState<T>());
   static_assert(BicycleCarStateIndices::kPsi == 0,
                 "BicycleCar requires BicycleCarStateIndices::kPsi to be the "
                 "0th element.");
   static_assert(BicycleCarStateIndices::kPsiDot == 1,
                 "BicycleCar requires BicycleCarStateIndices::kPsiDot to be the "
                 "1st element.");
-  this->DeclareContinuousState(1,                     // num_q (Ψ)
-                               1,                     // num_v (Ψ_dot)
-                               kStateDimension - 2);  // num_z (all but Ψ,
-                                                      // Ψ_dot)
+  this->DeclareContinuousState(
+      std::make_unique<BicycleCarState<T>>(),
+      1,                                             // num_q (Ψ)
+      1,                                             // num_v (Ψ_dot)
+      BicycleCarStateIndices::kNumCoordinates - 2);  // num_z (all but Ψ, Ψ_dot)
   // TODO(jadecastro): Expose translational second-order structure of `sx`, `sy`
   // using `vel` as the generalized velocity (#5323).
 
@@ -177,19 +166,6 @@ void BicycleCar<T>::ImplCalcTimeDerivatives(
   derivatives->set_vel(vel_dot);
   derivatives->set_sx(sx_dot);
   derivatives->set_sy(sy_dot);
-}
-
-template <typename T>
-std::unique_ptr<systems::ContinuousState<T>>
-BicycleCar<T>::AllocateContinuousState() const {
-  return std::make_unique<systems::ContinuousState<T>>(
-      std::make_unique<BicycleCarState<T>>());
-}
-
-template <typename T>
-std::unique_ptr<systems::BasicVector<T>> BicycleCar<T>::AllocateOutputVector(
-    const systems::OutputPortDescriptor<T>& descriptor) const {
-  return std::make_unique<BicycleCarState<T>>();
 }
 
 template <typename T>

--- a/drake/automotive/bicycle_car.h
+++ b/drake/automotive/bicycle_car.h
@@ -84,10 +84,6 @@ class BicycleCar : public systems::LeafSystem<T> {
                             systems::Parameters<T>* params) const override;
 
   // LeafSystem<T> overrides
-  std::unique_ptr<systems::ContinuousState<T>> AllocateContinuousState()
-      const override;
-  std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::OutputPortDescriptor<T>& descriptor) const override;
   std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
 
   // System<T> overrides.

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -97,10 +97,6 @@ class MaliputRailcar : public systems::LeafSystem<T> {
 
  protected:
   // LeafSystem<T> overrides.
-  std::unique_ptr<systems::ContinuousState<T>> AllocateContinuousState()
-      const override;
-  std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::OutputPortDescriptor<T>& descriptor) const override;
   std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
   bool DoHasDirectFeedthrough(const systems::SparsityMatrix* sparsity,
                               int input_port, int output_port) const override;

--- a/drake/automotive/simple_car.cc
+++ b/drake/automotive/simple_car.cc
@@ -30,6 +30,10 @@ SimpleCar<T>::SimpleCar() {
   this->DeclareVectorOutputPort(SimpleCarState<T>());
   this->DeclareVectorOutputPort(PoseVector<T>());
   this->DeclareVectorOutputPort(FrameVelocity<T>());
+  // TODO(jwnimmer-tri) Offer one-argument model sugar for this next line.
+  this->DeclareContinuousState(
+      std::make_unique<SimpleCarState<T>>(),
+      0, 0, SimpleCarStateIndices::kNumCoordinates);
 }
 
 template <typename T>
@@ -203,13 +207,6 @@ systems::System<AutoDiffXd>* SimpleCar<T>::DoToAutoDiffXd() const {
 template <typename T>
 systems::System<symbolic::Expression>* SimpleCar<T>::DoToSymbolic() const {
   return new SimpleCar<symbolic::Expression>;
-}
-
-template <typename T>
-std::unique_ptr<systems::ContinuousState<T>>
-SimpleCar<T>::AllocateContinuousState() const {
-  return std::make_unique<systems::ContinuousState<T>>(
-      std::make_unique<SimpleCarState<T>>());
 }
 
 template <typename T>

--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -79,8 +79,6 @@ class SimpleCar : public systems::LeafSystem<T> {
   systems::System<symbolic::Expression>* DoToSymbolic() const override;
 
   // LeafSystem<T> overrides
-  std::unique_ptr<systems::ContinuousState<T>> AllocateContinuousState()
-      const override;
   std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
 
  private:

--- a/drake/automotive/simple_car_to_euler_floating_joint.h
+++ b/drake/automotive/simple_car_to_euler_floating_joint.h
@@ -19,10 +19,8 @@ class SimpleCarToEulerFloatingJoint : public systems::LeafSystem<T> {
 
   SimpleCarToEulerFloatingJoint() {
     this->set_name("SimpleCarToEulerFloatingJoint");
-    this->DeclareInputPort(systems::kVectorValued,
-                           SimpleCarStateIndices::kNumCoordinates);
-    this->DeclareOutputPort(systems::kVectorValued,
-                            EulerFloatingJointStateIndices::kNumCoordinates);
+    this->DeclareVectorInputPort(SimpleCarState<T>());
+    this->DeclareVectorOutputPort(EulerFloatingJointState<T>());
   }
 
   void DoCalcOutput(const systems::Context<T>& context,
@@ -54,12 +52,6 @@ class SimpleCarToEulerFloatingJoint : public systems::LeafSystem<T> {
     output_data->set_roll(0.0);
     output_data->set_pitch(0.0);
     output_data->set_yaw(heading);
-  }
-
- protected:
-  std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::OutputPortDescriptor<T>& descriptor) const override {
-    return std::make_unique<EulerFloatingJointState<T>>();
   }
 };
 

--- a/drake/automotive/trajectory_car.h
+++ b/drake/automotive/trajectory_car.h
@@ -40,8 +40,7 @@ class TrajectoryCar : public systems::LeafSystem<T> {
     if (curve_.path_length() == 0.0) {
       throw std::invalid_argument{"empty curve"};
     }
-    this->DeclareOutputPort(systems::kVectorValued,
-                            SimpleCarStateIndices::kNumCoordinates);
+    this->DeclareVectorOutputPort(SimpleCarState<T>());
   }
 
  protected:
@@ -52,11 +51,6 @@ class TrajectoryCar : public systems::LeafSystem<T> {
     DRAKE_ASSERT(output_vector);
 
     ImplCalcOutput(context.get_time(), output_vector);
-  }
-
-  std::unique_ptr<systems::BasicVector<T>> AllocateOutputVector(
-      const systems::OutputPortDescriptor<T>& descriptor) const override {
-    return std::make_unique<SimpleCarState<T>>();
   }
 
  private:


### PR DESCRIPTION
This uses #5431's sugar for the benefit of `automotive`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5484)
<!-- Reviewable:end -->
