### PR TITLE
added a stub for the smart inverse dynamics controller

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
@@ -61,6 +61,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "manipulator_plan_eval_system",
+    srcs = ["manipulator_plan_eval_system.cc"],
+    hdrs = ["manipulator_plan_eval_system.h"],
+    deps = [
+        ":plan_eval_base_system",
+        "//drake/lcmtypes:plan_eval_debug_info",
+    ],
+)
+
+drake_cc_library(
     name = "qp_controller_system",
     srcs = ["qp_controller_system.cc"],
     hdrs = ["qp_controller_system.h"],
@@ -69,6 +79,20 @@ drake_cc_library(
         "//drake/lcmtypes:inverse_dynamics_debug_info",
         "//drake/multibody:rigid_body_tree",
         "//drake/systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_library(
+    name = "manipulator_inverse_dynamics_controller",
+    srcs = ["manipulator_inverse_dynamics_controller.cc"],
+    hdrs = ["manipulator_inverse_dynamics_controller.h"],
+    deps = [
+        ":humanoid_status_translator_system",
+        ":joint_level_controller_system",
+        ":manipulator_plan_eval_system",
+        ":qp_controller_system",
+        "//drake/systems/controllers:model_based_controller_base",
+        "//drake/systems/framework",
     ],
 )
 
@@ -127,6 +151,30 @@ drake_cc_googletest(
         "//drake/systems/analysis:simulator",
         "//drake/systems/framework",
         "//drake/systems/primitives:constant_value_source",
+    ],
+)
+
+drake_cc_googletest(
+    name = "manipulator_inverse_dynamics_controller_test",
+    srcs = ["test/manipulator_inverse_dynamics_controller_test.cc"],
+    data = [
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
+        "//drake/examples/kuka_iiwa_arm:models",
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [
+        ":manipulator_inverse_dynamics_controller",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/multibody/parsers",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/controllers:inverse_dynamics_controller",
+        "//drake/systems/framework",
+        "//drake/systems/primitives:constant_vector_source",
     ],
 )
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_inverse_dynamics_controller.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_inverse_dynamics_controller.cc
@@ -1,0 +1,105 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_inverse_dynamics_controller.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+ManipulatorInverseDynamicsController::ManipulatorInverseDynamicsController(
+    const std::string& model_path, const std::string& alias_group_path,
+    const std::string& controller_config_path, double dt,
+    std::shared_ptr<RigidBodyFrame<double>> world_offset)
+    : systems::ModelBasedController<double>(model_path, world_offset,
+                                            multibody::joints::kFixed) {
+  const RigidBodyTree<double>& robot = get_robot_for_control();
+
+  this->set_name("ManipulatorInverseDynamicsController");
+
+  systems::DiagramBuilder<double> builder;
+
+  // Converts raw state to humanoid status.
+  StateToHumanoidStatusSystem* rs_wrapper =
+      builder.AddSystem<StateToHumanoidStatusSystem>(robot, alias_group_path);
+  // Converts qp output to raw torque.
+  TrivialJointLevelControllerSystem* joint_level_controller =
+      builder.AddSystem<TrivialJointLevelControllerSystem>(robot);
+  // Generates qp_input from desired q and v vd.
+  plan_eval_ = builder.AddSystem<ManipulatorPlanEvalSystem>(
+      robot, alias_group_path, controller_config_path, dt);
+  // Inverse dynamics controller
+  QpControllerSystem* id_controller =
+      builder.AddSystem<QpControllerSystem>(robot, dt);
+
+  // Connects state translator to plan eval.
+  builder.Connect(rs_wrapper->get_output_port_humanoid_status(),
+                  plan_eval_->get_input_port_humanoid_status());
+
+  // Connects state translator to inverse dynamics.
+  builder.Connect(rs_wrapper->get_output_port_humanoid_status(),
+                  id_controller->get_input_port_humanoid_status());
+
+  // Connects plan eval to inverse dynamics.
+  builder.Connect(plan_eval_->get_output_port_qp_input(),
+                  id_controller->get_input_port_qp_input());
+
+  // Connects inverse dynamics to torque translator.
+  builder.Connect(id_controller->get_output_port_qp_output(),
+                  joint_level_controller->get_input_port_qp_output());
+
+  // Exposes raw estimated state input.
+  int index = builder.ExportInput(rs_wrapper->get_input_port_state());
+  this->set_input_port_index_estimated_state(index);
+
+  // Exposes desired q + vd input.
+  index = builder.ExportInput(plan_eval_->get_input_port_desired_state());
+  this->set_input_port_index_desired_state(index);
+
+  // Exposes desired vd input.
+  input_port_index_desired_acceleration_ =
+      builder.ExportInput(plan_eval_->get_input_port_desired_acceleration());
+
+  // Exposes raw torque output.
+  index =
+      builder.ExportOutput(joint_level_controller->get_output_port_torque());
+  this->set_output_port_index_control(index);
+
+  // Exposes plan eval's debug output.
+  output_port_index_plan_eval_debug_ =
+      builder.ExportOutput(plan_eval_->get_output_port_debug_info());
+
+  // Exposes plan eval's QpInput output.
+  output_port_index_qp_input_ =
+      builder.ExportOutput(plan_eval_->get_output_port_qp_input());
+
+  // Exposes inverse dynamics' debug output.
+  output_port_index_inverse_dynamics_debug_ =
+      builder.ExportOutput(plan_eval_->get_output_port_debug_info());
+
+  // Exposes inverse dynamics' QpOutput output.
+  output_port_index_qp_output_ =
+      builder.ExportOutput(id_controller->get_output_port_qp_output());
+
+  builder.BuildInto(this);
+}
+
+void ManipulatorInverseDynamicsController::Initialize(
+    systems::Context<double>* context) {
+  systems::Context<double>* plan_eval_context =
+      GetMutableSubsystemContext(context, plan_eval_);
+  systems::State<double>* plan_eval_state =
+      plan_eval_context->get_mutable_state();
+  plan_eval_->Initialize(plan_eval_state);
+}
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_inverse_dynamics_controller.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_inverse_dynamics_controller.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.h"
+#include "drake/systems/controllers/model_based_controller_base.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+/**
+ * This class implements an example of a general purpose controller for a
+ * fixed based manipulator based on qp inverse dynamics. It contains two main
+ * components, plan eval and qp inverse dynamics. Plan eval is responsible for
+ * implementing various desired behaviors. It outputs a QpInput struct which is
+ * handed to qp inverse dynamics. The latter is responsible for generating
+ * torque outputs that best tracks the desired inputs while satisfying all the
+ * physical constraints (torque limit, contact maintenance, etc).
+ * The biggest advantage for this formulation is that the details of the
+ * physical robot is hidden from the behavior level.
+ *
+ * This particular example implements a controller that tracks desired
+ * generalized position, velocity and acceleration. It is functionally
+ * identical to systems::InverseDynamicsController for the unconstrained
+ * situations (no torque limits). More advanced behaviors such as end effector
+ * tracking in Cartesian space, freeze if unexpected is sensed can be
+ * implemented by different plan eval modules.
+ */
+class ManipulatorInverseDynamicsController
+    : public systems::ModelBasedController<double> {
+ public:
+  /**
+   * Constructs a inverse dynamics controller for a fixed base manipulator that
+   * tracks desired generalized position, velocity and acceleration.
+   * @param model_path Path to the manipulator model, from which the internal
+   * model is instantiated.
+   * @param alias_group_path Path to the alias groups file. Used by the
+   * controller to understand to topology of the robot.
+   * @param controller_config_path Path the config file for the controller.
+   * @param dt Time step
+   * @param world_offset RigidBodyFrame X_WB, where B is the base of the robot.
+   */
+  ManipulatorInverseDynamicsController(
+      const std::string& model_path, const std::string& alias_group_path,
+      const std::string& controller_config_path, double dt,
+      std::shared_ptr<RigidBodyFrame<double>> world_offset = nullptr);
+
+  /**
+   * Initializes the controller's internal state. Must be called before
+   * execution.
+   */
+  void Initialize(systems::Context<double>* context);
+
+  /**
+   * Returns plan eval's alias groups.
+   */
+  const param_parsers::RigidBodyTreeAliasGroups<double>& get_alias_groups()
+      const {
+    return plan_eval_->get_alias_groups();
+  }
+
+  /**
+   * Returns plan eval's parameters.
+   */
+  const param_parsers::ParamSet& get_paramset() const {
+    return plan_eval_->get_paramset();
+  }
+
+  /**
+   * Returns the input port for desired acceleration.
+   */
+  const systems::InputPortDescriptor<double>&
+  get_input_port_desired_acceleration() const {
+    return systems::Diagram<double>::get_input_port(
+        input_port_index_desired_acceleration_);
+  }
+
+  /**
+   * Returns the output port for a lcm message that contains plan eval's
+   * debug data.
+   */
+  const systems::OutputPortDescriptor<double>&
+  get_output_port_plan_eval_debug_info() const {
+    return systems::Diagram<double>::get_output_port(
+        output_port_index_plan_eval_debug_);
+  }
+
+  /**
+   * Returns the output port for a lcm message that contains qp inverse
+   * dynamics' debug data.
+   */
+  const systems::OutputPortDescriptor<double>&
+  get_output_port_inverse_dynamics_debug_info() const {
+    return systems::Diagram<double>::get_output_port(
+        output_port_index_inverse_dynamics_debug_);
+  }
+
+  /**
+   * Returns the output port for QpInput from plan eval.
+   */
+  const systems::OutputPortDescriptor<double>&
+  get_output_port_qp_input() const {
+    return systems::Diagram<double>::get_output_port(
+        output_port_index_qp_input_);
+  }
+
+  /**
+   * Returns the output port for QpOutput from inverse dynamics.
+   */
+  const systems::OutputPortDescriptor<double>&
+  get_output_port_qp_output() const {
+    return systems::Diagram<double>::get_output_port(
+        output_port_index_qp_output_);
+  }
+
+ private:
+  ManipulatorPlanEvalSystem* plan_eval_{nullptr};
+  int input_port_index_desired_acceleration_{};
+  int output_port_index_plan_eval_debug_{};
+  int output_port_index_qp_input_{};
+  int output_port_index_inverse_dynamics_debug_{};
+  int output_port_index_qp_output_{};
+};
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.cc
@@ -1,0 +1,146 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.h"
+
+#include <vector>
+
+#include "drake/examples/QPInverseDynamicsForHumanoids/control_utils.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller_common.h"
+#include "drake/lcmt_plan_eval_debug_info.hpp"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+ManipulatorPlanEvalSystem::ManipulatorPlanEvalSystem(
+    const RigidBodyTree<double>& robot,
+    const std::string& alias_groups_file_name,
+    const std::string& param_file_name, double dt)
+    : PlanEvalBaseSystem(robot, alias_groups_file_name, param_file_name, dt),
+      abs_state_index_plan_(0),
+      abs_state_index_debug_(1) {
+  DRAKE_DEMAND(get_robot().get_num_velocities() ==
+               get_robot().get_num_positions());
+  const int kStateDim =
+      get_robot().get_num_positions() + get_robot().get_num_velocities();
+  const int kAccDim = get_robot().get_num_velocities();
+
+  input_port_index_desired_state_ =
+      DeclareInputPort(systems::kVectorValued, kStateDim).get_index();
+  input_port_index_desired_acceleration_ =
+      DeclareInputPort(systems::kVectorValued, kAccDim).get_index();
+
+  output_port_index_debug_info_ = DeclareAbstractOutputPort().get_index();
+  set_name("ManipulatorPlanEvalSystem");
+}
+
+void ManipulatorPlanEvalSystem::Initialize(systems::State<double>* state) {
+  VectorSetpoint<double>& plan =
+      get_mutable_abstract_value<VectorSetpoint<double>>(state,
+                                                         abs_state_index_plan_);
+  plan = VectorSetpoint<double>(get_robot().get_num_velocities());
+  get_paramset().LookupDesiredDofMotionGains(&(plan.mutable_Kp()),
+                                             &(plan.mutable_Kd()));
+
+  QpInput& qp_input = get_mutable_qp_input(state);
+  qp_input = get_paramset().MakeQpInput({}, /* contacts */
+                                        {}, /* tracked bodies */
+                                        get_alias_groups());
+}
+
+void ManipulatorPlanEvalSystem::DoExtendedCalcOutput(
+    const systems::Context<double>& context,
+    systems::SystemOutput<double>* output) const {
+  // Copies additional debugging info from abstract state to output.
+  lcmt_plan_eval_debug_info& debug =
+      output->GetMutableData(output_port_index_debug_info_)
+          ->GetMutableValue<lcmt_plan_eval_debug_info>();
+  debug = context.get_abstract_state<lcmt_plan_eval_debug_info>(
+      abs_state_index_debug_);
+}
+
+void ManipulatorPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
+    const systems::Context<double>& context,
+    systems::State<double>* state) const {
+  // Gets the plan from abstract state.
+  VectorSetpoint<double>& plan =
+      get_mutable_abstract_value<VectorSetpoint<double>>(state,
+                                                         abs_state_index_plan_);
+
+  // Gets the robot state from input.
+  const HumanoidStatus* robot_status = EvalInputValue<HumanoidStatus>(
+      context, get_input_port_humanoid_status().get_index());
+
+  // Gets the desired position and velocity.
+  const systems::BasicVector<double>* state_d =
+      EvalVectorInput(context, input_port_index_desired_state_);
+
+  // Gets the desired acceleration.
+  const systems::BasicVector<double>* acc_d =
+      EvalVectorInput(context, input_port_index_desired_acceleration_);
+
+  // Updates the plan.
+  const int dim = get_robot().get_num_positions();
+  for (int i = 0; i < dim; i++) {
+    plan.mutable_desired_position()[i] = state_d->GetAtIndex(i);
+    plan.mutable_desired_velocity()[i] = state_d->GetAtIndex(i + dim);
+    plan.mutable_desired_acceleration()[i] = acc_d->GetAtIndex(i);
+  }
+
+  // Updates the desired accelerations.
+  QpInput& qp_input = get_mutable_qp_input(state);
+  qp_input.mutable_desired_dof_motions().mutable_values() =
+      plan.ComputeTargetAcceleration(robot_status->position(),
+                                     robot_status->velocity());
+
+  // Generates debugging info.
+  lcmt_plan_eval_debug_info& debug =
+      get_mutable_abstract_value<lcmt_plan_eval_debug_info>(
+          state, abs_state_index_debug_);
+
+  debug.timestamp = static_cast<int64_t>(context.get_time() * 1e6);
+  debug.num_dof = dim;
+  debug.dof_names.resize(dim);
+  debug.nominal_q.resize(dim);
+  debug.nominal_v.resize(dim);
+  debug.nominal_vd.resize(dim);
+
+  for (int i = 0; i < dim; i++) {
+    debug.dof_names[i] = get_robot().get_position_name(i);
+    debug.nominal_q[i] = plan.desired_position()[i];
+    debug.nominal_v[i] = plan.desired_velocity()[i];
+    debug.nominal_vd[i] = plan.desired_acceleration()[i];
+  }
+}
+
+std::vector<std::unique_ptr<systems::AbstractValue>>
+ManipulatorPlanEvalSystem::ExtendedAllocateAbstractState() const {
+  std::vector<std::unique_ptr<systems::AbstractValue>> abstract_vals(
+      get_num_extended_abstract_states());
+
+  const int dim = get_robot().get_num_velocities();
+  abstract_vals[abs_state_index_plan_] =
+      systems::AbstractValue::Make<VectorSetpoint<double>>(
+          VectorSetpoint<double>(dim));
+
+  abstract_vals[abs_state_index_debug_] =
+      systems::AbstractValue::Make<lcmt_plan_eval_debug_info>(
+          lcmt_plan_eval_debug_info());
+
+  return abstract_vals;
+}
+
+std::unique_ptr<systems::AbstractValue>
+ManipulatorPlanEvalSystem::ExtendedAllocateOutputAbstract(
+    const systems::OutputPortDescriptor<double>& descriptor) const {
+  if (descriptor.get_index() == output_port_index_debug_info_) {
+    return systems::AbstractValue::Make<lcmt_plan_eval_debug_info>(
+        lcmt_plan_eval_debug_info());
+  }
+  std::string msg = "ManipulatorPlanEvalSystem does not have outputport " +
+                    std::to_string(descriptor.get_index());
+  DRAKE_ABORT_MSG(msg.c_str());
+}
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_base_system.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+/**
+ * This class extends PlanEvalBaseSystem. It generates QpInput to track
+ * desired instantaneous position, velocity and acceleration in joint space.
+ */
+class ManipulatorPlanEvalSystem : public PlanEvalBaseSystem {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ManipulatorPlanEvalSystem)
+
+  /**
+   * Constructor.
+   * @param robot Reference to a RigidBodyTree, whose life span must be longer
+   * than this instance.
+   * @param alias_groups_file_name Path to the alias groups file that describes
+   * the robot's topology for the controller.
+   * @param param_file_name Path to the config file for the controller.
+   * @param dt Time step
+   */
+  ManipulatorPlanEvalSystem(const RigidBodyTree<double>& robot,
+                            const std::string& alias_groups_file_name,
+                            const std::string& param_file_name, double dt);
+
+  /**
+   * Initializes the plan and gains. Must be called before execution.
+   */
+  void Initialize(systems::State<double>* state);
+
+  /**
+   * Initializes the plan and gains. Must be called before execution.
+   */
+  void Initialize(systems::Context<double>* context) {
+    systems::State<double>* servo_state = context->get_mutable_state();
+    Initialize(servo_state);
+  }
+
+  /**
+   * Returns the input port for desired position and velocity.
+   */
+  inline const systems::InputPortDescriptor<double>&
+  get_input_port_desired_state() const {
+    return get_input_port(input_port_index_desired_state_);
+  }
+
+  /**
+   * Returns the input port for desired acceleration.
+   */
+  inline const systems::InputPortDescriptor<double>&
+  get_input_port_desired_acceleration() const {
+    return get_input_port(input_port_index_desired_acceleration_);
+  }
+
+  /**
+   * Returns the output port for debugging information.
+   */
+  inline const systems::OutputPortDescriptor<double>&
+  get_output_port_debug_info() const {
+    return get_output_port(output_port_index_debug_info_);
+  }
+
+ private:
+  int get_num_extended_abstract_states() const override { return 2; }
+
+  void DoExtendedCalcUnrestrictedUpdate(
+      const systems::Context<double>& context,
+      systems::State<double>* state) const override;
+
+  void DoExtendedCalcOutput(
+      const systems::Context<double>& context,
+      systems::SystemOutput<double>* output) const override;
+
+  std::vector<std::unique_ptr<systems::AbstractValue>>
+  ExtendedAllocateAbstractState() const override;
+
+  std::unique_ptr<systems::AbstractValue> ExtendedAllocateOutputAbstract(
+      const systems::OutputPortDescriptor<double>& descriptor) const override;
+
+  int input_port_index_desired_state_{};
+  int input_port_index_desired_acceleration_{};
+  int output_port_index_debug_info_{};
+
+  const int abs_state_index_plan_{};
+  const int abs_state_index_debug_{};
+};
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/manipulator_inverse_dynamics_controller_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/manipulator_inverse_dynamics_controller_test.cc
@@ -1,0 +1,225 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_inverse_dynamics_controller.h"
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/control_utils.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/systems/controllers/inverse_dynamics_controller.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/constant_vector_source.h"
+
+#include "gtest/gtest.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+namespace {
+
+// Builds a test diagram that gives a ManipulatorInverseDynamicsController and
+// a systems::InverseDynamicsController the exact same inputs (estimated state,
+// desired state and desired acceleration), and expects their outputs (torque)
+// to be the same assuming the computed torques are within the torque limits.
+class ManipulatorInverseDynamicsControllerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::string kModelPath = drake::GetDrakePath() +
+                                   "/examples/kuka_iiwa_arm/models/iiwa14/"
+                                   "iiwa14_simplified_collision.urdf";
+
+    const std::string kAliasGroupsPath =
+        drake::GetDrakePath() +
+        "/examples/QPInverseDynamicsForHumanoids/"
+        "config/iiwa.alias_groups";
+
+    const std::string kControlConfigPath =
+        drake::GetDrakePath() +
+        "/examples/QPInverseDynamicsForHumanoids/"
+        "config/iiwa.id_controller_config";
+
+    auto robot = std::make_unique<RigidBodyTree<double>>();
+    parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
+        kModelPath, multibody::joints::kFixed, robot.get());
+
+    // Esimated state.
+    VectorX<double> q(7);
+    VectorX<double> v(7);
+    VectorX<double> x(14);
+    q << -1, 1, -0.4, 0.7, 0.99, -0.4, 0.33;
+    v << -0.3, 0.8, 2, 1, -0.55, 0.06, 0;
+    x << q, v;
+
+    // Desired state.
+    VectorX<double> q_r(7);
+    VectorX<double> v_r(7);
+    VectorX<double> vd_r(7);
+    VectorX<double> x_r(14);
+    q_r << -1.3, 1.2, -0.45, 0.3, 0.6, -0.1, 0;
+    v_r << -1, 1, 2.3, 1.2, -0.8, 0, 0.1;
+    vd_r << 1, 2, 0, 3, 4, -3, -3;
+    x_r << q_r, v_r;
+
+    // Makes a diagram for testing.
+    systems::DiagramBuilder<double> builder;
+    auto qp_id_controller =
+        builder.AddSystem<ManipulatorInverseDynamicsController>(
+            kModelPath, kAliasGroupsPath, kControlConfigPath, 0.02);
+    params_ = &qp_id_controller->get_paramset();
+
+    // Use the same kp kd gains from qp_id_controller.
+    VectorX<double> kp, kd;
+    params_->LookupDesiredDofMotionGains(&kp, &kd);
+    auto vanilla_id_controller =
+        builder.AddSystem<systems::InverseDynamicsController>(
+            kModelPath, nullptr, kp, VectorX<double>::Zero(7), kd, true);
+
+    // Estimated state source.
+    auto estimated_state_source =
+        builder.AddSystem<systems::ConstantVectorSource<double>>(x);
+
+    // Desired state source.
+    auto desired_state_source =
+        builder.AddSystem<systems::ConstantVectorSource<double>>(x_r);
+    auto desired_acceleration_source =
+        builder.AddSystem<systems::ConstantVectorSource<double>>(vd_r);
+
+    // Estimated state -> controllers.
+    builder.Connect(estimated_state_source->get_output_port(),
+                    qp_id_controller->get_input_port_estimated_state());
+
+    builder.Connect(estimated_state_source->get_output_port(),
+                    vanilla_id_controller->get_input_port_estimated_state());
+
+    // Desired -> controllers
+    builder.Connect(desired_state_source->get_output_port(),
+                    qp_id_controller->get_input_port_desired_state());
+    builder.Connect(desired_acceleration_source->get_output_port(),
+                    qp_id_controller->get_input_port_desired_acceleration());
+
+    builder.Connect(desired_state_source->get_output_port(),
+                    vanilla_id_controller->get_input_port_desired_state());
+    builder.Connect(
+        desired_acceleration_source->get_output_port(),
+        vanilla_id_controller->get_input_port_desired_acceleration());
+
+    // Expose the output ports for QpInput and QpOutput.
+    plan_eval_output_index_ =
+        builder.ExportOutput(qp_id_controller->get_output_port_qp_input());
+    qp_controller_output_index_ =
+        builder.ExportOutput(qp_id_controller->get_output_port_control());
+    vanilla_controller_output_index_ =
+        builder.ExportOutput(vanilla_id_controller->get_output_port_control());
+
+    diagram_ = builder.Build();
+
+    context_ = diagram_->CreateDefaultContext();
+    context_->set_time(0);
+    output_ = diagram_->AllocateOutput(*context_);
+
+    // Initializes.
+    qp_id_controller->Initialize(
+        diagram_->GetMutableSubsystemContext(context_.get(), qp_id_controller));
+
+    // Computes results.
+    systems::UpdateActions<double> actions;
+    diagram_->CalcNextUpdateTime(*context_, &actions);
+    EXPECT_EQ(actions.events.size(), 1);
+
+    std::unique_ptr<systems::State<double>> state = context_->CloneState();
+
+    // Generates QpInput from the plan eval block within
+    // ManipulatorInverseDynamicsController.
+    diagram_->CalcUnrestrictedUpdate(*context_, actions.events.front(),
+                                     state.get());
+    context_->get_mutable_state()->CopyFrom(*state);
+
+    // Generates QpOuput from the inverse dynamics block within
+    // ManipulatorInverseDynamicsController.
+    diagram_->CalcUnrestrictedUpdate(*context_, actions.events.front(),
+                                     state.get());
+    context_->get_mutable_state()->CopyFrom(*state);
+
+    // Gets output.
+    diagram_->CalcOutput(*context_, output_.get());
+
+    // Computes expected acceleration input:
+    // vd_d = kp * (q_r - q) + kd * (v_r - v) + vd_r
+    VectorSetpoint<double> tracker(q_r, v_r, vd_r, kp, kd);
+    expected_vd_d_ = tracker.ComputeTargetAcceleration(q, v);
+  }
+
+  std::unique_ptr<systems::Diagram<double>> diagram_{nullptr};
+  std::unique_ptr<systems::Context<double>> context_{nullptr};
+  std::unique_ptr<systems::SystemOutput<double>> output_{nullptr};
+
+  const param_parsers::ParamSet* params_;
+
+  VectorX<double> expected_vd_d_;
+
+  int plan_eval_output_index_{};
+  int qp_controller_output_index_{};
+  int vanilla_controller_output_index_{};
+};
+
+// Tests QpInput from the plan eval component. The desired generalized
+// acceleration should equal to expected_vd_d_, and various modes and weights
+// should be specified by params_ loaded from kControlConfigPath.
+TEST_F(ManipulatorInverseDynamicsControllerTest, PlanEvalTest) {
+  const QpInput& qp_input =
+      output_->get_data(plan_eval_output_index_)->GetValue<QpInput>();
+
+  // Desired generalized acceleration should match expected.
+  EXPECT_TRUE(drake::CompareMatrices(
+      expected_vd_d_, qp_input.desired_dof_motions().values(), 1e-12,
+      drake::MatrixCompareType::absolute));
+  VectorX<double> expected_weights = params_->MakeDesiredDofMotions().weights();
+  EXPECT_TRUE(drake::CompareMatrices(
+      expected_weights, qp_input.desired_dof_motions().weights(), 1e-12,
+      drake::MatrixCompareType::absolute));
+  std::vector<ConstraintType> expected_constraint_type =
+      params_->MakeDesiredDofMotions().constraint_types();
+  for (size_t i = 0; i < expected_constraint_type.size(); ++i) {
+    EXPECT_EQ(qp_input.desired_dof_motions().constraint_type(i),
+              expected_constraint_type[i]);
+  }
+
+  // Contact force basis regularization weight is irrelevant here since there
+  // is not contacts, but its value should match params'.
+  EXPECT_EQ(qp_input.w_basis_reg(), params_->get_basis_regularization_weight());
+
+  // Not tracking Cartesian motions.
+  EXPECT_TRUE(qp_input.desired_body_motions().empty());
+
+  // No contacts.
+  EXPECT_TRUE(qp_input.contact_information().empty());
+
+  // Doesn't care about overall center of mass or angular momentum.
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_EQ(qp_input.desired_centroidal_momentum_dot().value(i), 0);
+    EXPECT_EQ(qp_input.desired_centroidal_momentum_dot().weight(i), 0);
+    EXPECT_EQ(qp_input.desired_centroidal_momentum_dot().constraint_type(i),
+              ConstraintType::Skip);
+  }
+}
+
+// The torque outputs from ManipulatorInverseDynamicsController and
+// systems::InverseDynamicsController should be the same for this simple case.
+TEST_F(ManipulatorInverseDynamicsControllerTest,
+       CompareWithBasicInverseDyanmics) {
+  EXPECT_EQ(context_->get_time(), 0);
+  VectorX<double> qp_output =
+      output_->get_vector_data(qp_controller_output_index_)->CopyToVector();
+  VectorX<double> vanilla_output =
+      output_->get_vector_data(vanilla_controller_output_index_)
+          ->CopyToVector();
+
+  EXPECT_TRUE(drake::CompareMatrices(qp_output, vanilla_output, 1e-8,
+                                     drake::MatrixCompareType::absolute));
+}
+
+}  // namespace
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -103,6 +103,12 @@ lcm_cc_library(
 )
 
 lcm_cc_library(
+    name = "plan_eval_debug_info",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_plan_eval_debug_info.lcm"],
+)
+
+lcm_cc_library(
     name = "polynomial_matrix",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_polynomial_matrix.lcm"],

--- a/drake/lcmtypes/lcmt_plan_eval_debug_info.lcm
+++ b/drake/lcmtypes/lcmt_plan_eval_debug_info.lcm
@@ -1,0 +1,15 @@
+package drake;
+
+// Stub message for outputting debug information from plan eval.
+struct lcmt_plan_eval_debug_info {
+  int64_t timestamp;
+
+  int32_t num_dof;
+
+  string dof_names[num_dof];
+
+  // Planned position, velocity and acceleration.
+  double nominal_q[num_dof];
+  double nominal_v[num_dof];
+  double nominal_vd[num_dof];
+}

--- a/drake/systems/controllers/inverse_dynamics_controller.cc
+++ b/drake/systems/controllers/inverse_dynamics_controller.cc
@@ -69,10 +69,12 @@ void InverseDynamicsController<T>::SetUp(const VectorX<T>& kp,
                   inverse_dynamics->get_input_port_desired_acceleration());
 
   // Exposes estimated state input port.
-  builder.ExportInput(pass_through->get_input_port());
+  int index = builder.ExportInput(pass_through->get_input_port());
+  this->set_input_port_index_estimated_state(index);
 
   // Exposes reference state input port.
-  builder.ExportInput(pid_->get_input_port_desired_state());
+  index = builder.ExportInput(pid_->get_input_port_desired_state());
+  this->set_input_port_index_desired_state(index);
 
   if (!has_reference_acceleration_) {
     // Uses a zero constant source for reference acceleration.
@@ -83,11 +85,13 @@ void InverseDynamicsController<T>::SetUp(const VectorX<T>& kp,
                     adder->get_input_port(1));
   } else {
     // Exposes reference acceleration input port.
-    builder.ExportInput(adder->get_input_port(1));
+    input_port_index_desired_acceleration_ =
+        builder.ExportInput(adder->get_input_port(1));
   }
 
   // Exposes inverse dynamics' output torque port.
-  builder.ExportOutput(inverse_dynamics->get_output_port_torque());
+  index = builder.ExportOutput(inverse_dynamics->get_output_port_torque());
+  this->set_output_port_index_control(index);
 
   builder.BuildInto(this);
 }

--- a/drake/systems/controllers/inverse_dynamics_controller.h
+++ b/drake/systems/controllers/inverse_dynamics_controller.h
@@ -98,7 +98,8 @@ class InverseDynamicsController : public ModelBasedController<T> {
    */
   const InputPortDescriptor<T>& get_input_port_desired_acceleration() const {
     DRAKE_DEMAND(has_reference_acceleration_);
-    return Diagram<T>::get_input_port(2);
+    DRAKE_DEMAND(input_port_index_desired_acceleration_ >= 0);
+    return Diagram<T>::get_input_port(input_port_index_desired_acceleration_);
   }
 
  private:
@@ -106,6 +107,7 @@ class InverseDynamicsController : public ModelBasedController<T> {
 
   PidController<T>* pid_{nullptr};
   const bool has_reference_acceleration_{false};
+  int input_port_index_desired_acceleration_{-1};
 };
 
 }  // namespace systems

--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -300,13 +300,16 @@ void PidController<T>::ConnectPorts(
       controller_inverter->get_input_port());
 
   // Expose state input
-  builder.ExportInput(feedback_selector_p->get_input_port());
+  int index = builder.ExportInput(feedback_selector_p->get_input_port());
+  this->set_input_port_index_estimated_state(index);
 
   // Exposes desired state input
-  builder.ExportInput(error_inverter->get_input_port());
+  index = builder.ExportInput(error_inverter->get_input_port());
+  this->set_input_port_index_desired_state(index);
 
   // Exposes torque output
-  builder.ExportOutput(controller_inverter->get_output_port());
+  index = builder.ExportOutput(controller_inverter->get_output_port());
+  this->set_output_port_index_control(index);
 
   builder.BuildInto(this);
 }

--- a/drake/systems/controllers/state_feedback_controller_base.h
+++ b/drake/systems/controllers/state_feedback_controller_base.h
@@ -20,25 +20,43 @@ class StateFeedbackController : public Diagram<T> {
    * Returns the input port for the estimated state.
    */
   const InputPortDescriptor<T>& get_input_port_estimated_state() const {
-    return Diagram<T>::get_input_port(0);
+    DRAKE_DEMAND(input_port_index_estimated_state_ >= 0);
+    return Diagram<T>::get_input_port(input_port_index_estimated_state_);
   }
 
   /**
    * Returns the input port for the desired state.
    */
   const InputPortDescriptor<T>& get_input_port_desired_state() const {
-    return Diagram<T>::get_input_port(1);
+    DRAKE_DEMAND(input_port_index_desired_state_ >= 0);
+    return Diagram<T>::get_input_port(input_port_index_desired_state_);
   }
 
   /**
    * Returns the output port for computed control.
    */
   const OutputPortDescriptor<T>& get_output_port_control() const {
-    return Diagram<T>::get_output_port(0);
+    DRAKE_DEMAND(output_port_index_control_ >= 0);
+    return Diagram<T>::get_output_port(output_port_index_control_);
   }
 
  protected:
+  void set_input_port_index_estimated_state(int index) {
+    input_port_index_estimated_state_ = index;
+  }
+
+  void set_input_port_index_desired_state(int index) {
+    input_port_index_desired_state_ = index;
+  }
+
+  void set_output_port_index_control(int index) {
+    output_port_index_control_ = index;
+  }
+
   StateFeedbackController() {}
+  int input_port_index_estimated_state_{-1};
+  int input_port_index_desired_state_{-1};
+  int output_port_index_control_{-1};
 };
 
 }  // namespace systems


### PR DESCRIPTION
0. added a stub plan eval block for manipulators.
1. added a inverse dynamics controller diagram built on top of this plan eval and qp inverse dynamics. 
2. updated the all the state feedback controller family to use proper indexing for io ports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5492)
<!-- Reviewable:end -->
