### PR TITLE
Adds start time support to MaliputRailcar.

### DIFF
--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -164,7 +164,12 @@ void MaliputRailcar<T>::DoCalcTimeDerivatives(
       dynamic_cast<MaliputRailcarState<T>*>(vector_derivatives);
   DRAKE_ASSERT(rates != nullptr);
 
-  ImplCalcTimeDerivatives(config, *state, *input, rates);
+  if (context.get_time() < T(start_time_)) {
+    rates->set_s(T(0));
+    rates->set_speed(T(0));
+  } else {
+    ImplCalcTimeDerivatives(config, *state, *input, rates);
+  }
 }
 
 template<typename T>


### PR DESCRIPTION
The `start_time` input parameter existed but was not being used. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5493)
<!-- Reviewable:end -->
