### PR TITLE
Rename OutputPort to OutputPortValue

### DIFF
--- a/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.cc
+++ b/drake/examples/Valkyrie/robot_command_to_desired_effort_converter.cc
@@ -32,7 +32,7 @@ void RobotCommandToDesiredEffortConverter::DoCalcOutput(
   // (with empty std::vectors for the efforts and such).
   for (const auto& actuator_and_port_index : desired_effort_port_indices_) {
     int port_index = actuator_and_port_index.second;
-    output->get_mutable_port(port_index)
+    output->get_mutable_port_value(port_index)
         ->GetMutableVectorData<double>()
         ->SetAtIndex(0, 0.0);
   }
@@ -43,7 +43,7 @@ void RobotCommandToDesiredEffortConverter::DoCalcOutput(
     const double& effort = message.effort[i];
     const RigidBodyActuator* actuator = name_to_actuator_.at(joint_name);
     int port_index = desired_effort_port_indices_.at(actuator);
-    output->get_mutable_port(port_index)
+    output->get_mutable_port_value(port_index)
         ->GetMutableVectorData<double>()
         ->SetAtIndex(0, effort);
   }

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -52,7 +52,7 @@ bool HasEvent(const UpdateActions<T> actions,
 }
 
 /// DiagramOutput is an implementation of SystemOutput that holds unowned
-/// OutputPort pointers. It is used to expose the outputs of constituent
+/// OutputPortValue pointers. It is used to expose the outputs of constituent
 /// systems as outputs of a Diagram.
 ///
 /// @tparam T The type of the output data. Must be a valid Eigen scalar.
@@ -78,7 +78,8 @@ class DiagramOutput : public SystemOutput<T> {
   std::vector<OutputPortValue*>* get_mutable_port_values() { return &ports_; }
 
  protected:
-  // Returns a clone that has the same number of output ports, set to nullptr.
+  // Returns a clone that has the same number of output ports, with values
+  // set to nullptr.
   DiagramOutput<T>* DoClone() const override {
     DiagramOutput<T>* clone = new DiagramOutput<T>();
     clone->ports_.resize(get_num_ports());
@@ -978,8 +979,8 @@ class Diagram : public System<T>,
     return output;
   }
 
-  // Sets up the OutputPort pointers in @p output to point to the subsystem
-  // outputs, found in @p context, that are the outputs of this Diagram.
+  // Sets up the OutputPortValue pointers in @p output to point to the subsystem
+  // output values, found in @p context, that are the outputs of this Diagram.
   void ExposeSubsystemOutputs(const DiagramContext<T>& context,
                               internal::DiagramOutput<T>* output) const {
     // The number of output ports of this diagram must equal the number of
@@ -990,15 +991,15 @@ class Diagram : public System<T>,
     for (int i = 0; i < num_ports; ++i) {
       const PortIdentifier& id = output_port_ids_[i];
       // For each configured output port ID, obtain from the DiagramContext the
-      // actual OutputPort that produces it.
+      // actual OutputPortValue that supplies its value.
       const int sys_index = GetSystemIndexOrAbort(id.first);
       const int port_index = id.second;
       SystemOutput<T>* subsystem_output = context.GetSubsystemOutput(sys_index);
-      OutputPortValue* output_port =
+      OutputPortValue* output_port_value =
           subsystem_output->get_mutable_port_value(port_index);
 
-      // Then, put a pointer to that OutputPort in the DiagramOutput.
-      (*output->get_mutable_port_values())[i] = output_port;
+      // Then, put a pointer to that OutputPortValue in the DiagramOutput.
+      (*output->get_mutable_port_values())[i] = output_port_value;
     }
   }
 

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -65,17 +65,17 @@ class DiagramOutput : public SystemOutput<T> {
 
   int get_num_ports() const override { return static_cast<int>(ports_.size()); }
 
-  OutputPort* get_mutable_port(int index) override {
+  OutputPortValue* get_mutable_port_value(int index) override {
     DRAKE_DEMAND(index >= 0 && index < get_num_ports());
     return ports_[index];
   }
 
-  const OutputPort& get_port(int index) const override {
+  const OutputPortValue& get_port_value(int index) const override {
     DRAKE_DEMAND(index >= 0 && index < get_num_ports());
     return *ports_[index];
   }
 
-  std::vector<OutputPort*>* get_mutable_ports() { return &ports_; }
+  std::vector<OutputPortValue*>* get_mutable_port_values() { return &ports_; }
 
  protected:
   // Returns a clone that has the same number of output ports, set to nullptr.
@@ -86,7 +86,7 @@ class DiagramOutput : public SystemOutput<T> {
   }
 
  private:
-  std::vector<OutputPort*> ports_;
+  std::vector<OutputPortValue*> ports_;
 };
 
 /// DiagramTimeDerivatives is a version of DiagramContinuousState that owns
@@ -304,7 +304,7 @@ class Diagram : public System<T>,
     // The output ports of this Diagram are output ports of its constituent
     // systems. Create a DiagramOutput with that many ports.
     auto output = std::make_unique<internal::DiagramOutput<T>>();
-    output->get_mutable_ports()->resize(output_port_ids_.size());
+    output->get_mutable_port_values()->resize(output_port_ids_.size());
     ExposeSubsystemOutputs(*diagram_context, output.get());
     return std::unique_ptr<SystemOutput<T>>(output.release());
   }
@@ -994,10 +994,11 @@ class Diagram : public System<T>,
       const int sys_index = GetSystemIndexOrAbort(id.first);
       const int port_index = id.second;
       SystemOutput<T>* subsystem_output = context.GetSubsystemOutput(sys_index);
-      OutputPort* output_port = subsystem_output->get_mutable_port(port_index);
+      OutputPortValue* output_port =
+          subsystem_output->get_mutable_port_value(port_index);
 
       // Then, put a pointer to that OutputPort in the DiagramOutput.
-      (*output->get_mutable_ports())[i] = output_port;
+      (*output->get_mutable_port_values())[i] = output_port;
     }
   }
 

--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -161,7 +161,8 @@ class DiagramContext : public Context<T> {
     SystemOutput<T>* src_ports = GetSubsystemOutput(src_system_index);
     DRAKE_DEMAND(src_port_index >= 0);
     DRAKE_DEMAND(src_port_index < src_ports->get_num_ports());
-    OutputPort* output_port = src_ports->get_mutable_port(src_port_index);
+    OutputPortValue* output_port_value =
+        src_ports->get_mutable_port_value(src_port_index);
 
     // Identify and validate the destination port.
     SystemIndex dest_system_index = dest.first;
@@ -171,7 +172,7 @@ class DiagramContext : public Context<T> {
     DRAKE_DEMAND(dest_port_index < dest_context->get_num_input_ports());
 
     // Construct and install the destination port.
-    auto input_port = std::make_unique<DependentInputPort>(output_port);
+    auto input_port = std::make_unique<DependentInputPort>(output_port_value);
     dest_context->SetInputPort(dest_port_index, std::move(input_port));
 
     // Remember the graph structure. We need it in DoClone().

--- a/drake/systems/framework/input_port_evaluator_interface.h
+++ b/drake/systems/framework/input_port_evaluator_interface.h
@@ -14,7 +14,7 @@ template <typename T> class Context;
 namespace detail {
 
 /// InputPortEvaluatorInterface is implemented by classes that are able to
-/// evaluate the OutputPort connected to a particular InputPort.
+/// evaluate the OutputPortValue connected to a particular InputPort.
 ///
 /// This interface is a Drake-internal detail. Users should never implement
 /// it. In fact, only Diagram should implement it. It exists primarily to

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -153,11 +153,11 @@ class LeafSystem : public System<T> {
     for (int i = 0; i < this->get_num_output_ports(); ++i) {
       const OutputPortDescriptor<T>& descriptor = this->get_output_port(i);
       if (descriptor.get_data_type() == kVectorValued) {
-        output->add_port(
-            std::make_unique<OutputPort>(AllocateOutputVector(descriptor)));
+        output->add_port(std::make_unique<OutputPortValue>(
+            AllocateOutputVector(descriptor)));
       } else {
-        output->add_port(
-            std::make_unique<OutputPort>(AllocateOutputAbstract(descriptor)));
+        output->add_port(std::make_unique<OutputPortValue>(
+            AllocateOutputAbstract(descriptor)));
       }
     }
     return std::unique_ptr<SystemOutput<T>>(output.release());

--- a/drake/systems/framework/output_port_listener_interface.h
+++ b/drake/systems/framework/output_port_listener_interface.h
@@ -7,8 +7,8 @@ namespace systems {
 namespace detail {
 
 /// OutputPortListenerInterface is an interface that consumers of an output
-/// port must satisfy to receive notifications when the value on that output
-/// port's version number is incremented.
+/// port must satisfy to receive notifications when the value of that output
+/// port may have changed.
 class OutputPortListenerInterface {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OutputPortListenerInterface)
@@ -16,11 +16,11 @@ class OutputPortListenerInterface {
   OutputPortListenerInterface();
   virtual ~OutputPortListenerInterface();
 
-  /// Invalidates any data that depends on the OutputPort. Called whenever
-  /// the OutputPort's version number is incremented.
+  /// Invalidates any data that depends on the OutputPortValue. Called whenever
+  /// the output port's value may have changed.
   virtual void Invalidate() = 0;
 
-  /// Notifies the consumer that the OutputPort is no longer valid and should
+  /// Notifies the consumer that the output port is no longer valid and should
   /// not be read.
   virtual void Disconnect() = 0;
 };

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -1338,8 +1338,8 @@ class System {
   //@{
 
   /// Returns a mutable Eigen expression for a vector valued output port with
-  /// index @p port_index in this system. All InputPorts that directly depend
-  /// on this OutputPort will be notified that upstream data has changed, and
+  /// index @p port_index in this system. All input ports that directly depend
+  /// on this output port will be notified that upstream data has changed, and
   /// may invalidate cache entries as a result.
   Eigen::VectorBlock<VectorX<T>> GetMutableOutputVector(SystemOutput<T>* output,
                                                         int port_index) const {

--- a/drake/systems/framework/system_input.cc
+++ b/drake/systems/framework/system_input.cc
@@ -11,8 +11,8 @@ void InputPort::Invalidate() {
   }
 }
 
-DependentInputPort::DependentInputPort(OutputPortValue* output_port)
-    : output_port_value_(output_port) {
+DependentInputPort::DependentInputPort(OutputPortValue* output_port_value)
+    : output_port_value_(output_port_value) {
   DRAKE_DEMAND(output_port_value_ != nullptr);
   output_port_value_->add_dependent(this);
 }

--- a/drake/systems/framework/system_input.cc
+++ b/drake/systems/framework/system_input.cc
@@ -11,29 +11,29 @@ void InputPort::Invalidate() {
   }
 }
 
-DependentInputPort::DependentInputPort(OutputPort* output_port)
-    : output_port_(output_port) {
-  DRAKE_DEMAND(output_port_ != nullptr);
-  output_port_->add_dependent(this);
+DependentInputPort::DependentInputPort(OutputPortValue* output_port)
+    : output_port_value_(output_port) {
+  DRAKE_DEMAND(output_port_value_ != nullptr);
+  output_port_value_->add_dependent(this);
 }
 
 DependentInputPort::~DependentInputPort() {
-  if (output_port_ != nullptr) {
-    output_port_->remove_dependent(this);
+  if (output_port_value_ != nullptr) {
+    output_port_value_->remove_dependent(this);
   }
 }
 
 void DependentInputPort::Disconnect() {
-  output_port_ = nullptr;
+  output_port_value_ = nullptr;
 }
 FreestandingInputPort::FreestandingInputPort(
     std::unique_ptr<AbstractValue> data)
-    : output_port_(std::move(data)) {
-  output_port_.add_dependent(this);
+    : output_port_value_(std::move(data)) {
+  output_port_value_.add_dependent(this);
 }
 
 FreestandingInputPort::~FreestandingInputPort() {
-  output_port_.remove_dependent(this);
+  output_port_value_.remove_dependent(this);
 }
 
 }  // namespace systems

--- a/drake/systems/framework/system_input.h
+++ b/drake/systems/framework/system_input.h
@@ -69,22 +69,23 @@ class InputPort : public detail::OutputPortListenerInterface {
   std::function<void()> invalidation_callback_ = nullptr;
 };
 
-/// The DependentInputPort wraps a pointer to the OutputPort of a System for use
-/// as an input to another System. Many DependentInputPorts may wrap a single
-/// OutputPort.
+/// A %DependentInputPort wraps a pointer to an OutputPortValue associated
+/// with one System for use as an input to another System. Many
+/// %DependentInputPort objects may wrap a single OutputPortValue.
 class DependentInputPort : public InputPort {
  public:
   // DependentInputPort objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DependentInputPort)
 
-  /// Creates an input port connected to the given @p output_port, which
-  /// must not be nullptr. The output port must outlive this input port.
-  explicit DependentInputPort(OutputPortValue* output_port);
+  /// Creates an input port value source connected to the given
+  /// @p output_port_value, which must not be nullptr. The OutputPortValue must
+  /// outlive this %DependentInputPort object.
+  explicit DependentInputPort(OutputPortValue* output_port_value);
 
   /// Disconnects from the output port.
   ~DependentInputPort() override;
 
-  /// Sets the output port to nullptr.
+  /// Sets the associated OutputPortValue to nullptr.
   void Disconnect() override;
 
   /// Returns the value version of the connected output port.
@@ -92,7 +93,7 @@ class DependentInputPort : public InputPort {
     return output_port_value_->get_version();
   }
 
-  /// A DependentInputPort must be evaluated in a Context, because it does not
+  /// A %DependentInputPort must be evaluated in a Context, because it does not
   /// control its own data.
   bool requires_evaluation() const override { return true; }
 
@@ -105,14 +106,14 @@ class DependentInputPort : public InputPort {
   OutputPortValue* output_port_value_{};
 };
 
-/// The FreestandingInputPort encapsulates a vector of data for use as an input
-/// to a System.
+/// The FreestandingInputPort encapsulates a vector of data for use as the
+/// value of a System's input port.
 class FreestandingInputPort : public InputPort {
  public:
   // FreestandingInputPort objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FreestandingInputPort)
 
-  /// Constructs a vector-valued FreestandingInputPort.
+  /// Constructs a vector-valued %FreestandingInputPort.
   /// Takes ownership of @p vec.
   ///
   /// @tparam T The type of the vector data. Must be a valid Eigen scalar.
@@ -123,11 +124,11 @@ class FreestandingInputPort : public InputPort {
     output_port_value_.add_dependent(this);
   }
 
-  /// Constructs an abstract-valued FreestandingInputPort.
+  /// Constructs an abstract-valued %FreestandingInputPort.
   /// Takes ownership of @p data.
   explicit FreestandingInputPort(std::unique_ptr<AbstractValue> data);
 
-  /// Constructs an abstract-valued FreestandingInputPort.
+  /// Constructs an abstract-valued %FreestandingInputPort.
   /// Takes ownership of @p data.
   ///
   /// @tparam T The type of the data.
@@ -143,31 +144,31 @@ class FreestandingInputPort : public InputPort {
     return output_port_value_.get_version();
   }
 
-  /// A FreestandingInputPort does not require evaluation, because it controls
+  /// A %FreestandingInputPort does not require evaluation, because it controls
   /// its own data.
   bool requires_evaluation() const override { return false; }
 
-  /// Returns a pointer to the data inside this InputPort, and updates the
-  /// version so that Contexts depending on this InputPort know to invalidate
+  /// Returns a pointer to the data inside this %FreestandingInputPort, and
+  /// updates the version so that Contexts depending on this know to invalidate
   /// their caches.
   ///
   /// To ensure invalidation notifications are delivered, callers should
   /// call this method every time they wish to update the stored value.  In
   /// particular, callers MUST NOT write on the returned pointer if there is any
-  /// possibility this FreestandingInputPort has been accessed since the last
+  /// possibility this %FreestandingInputPort has been accessed since the last
   /// time this method was called.
   AbstractValue* GetMutableData() {
     return output_port_value_.GetMutableData();
   }
 
-  /// Returns a pointer to the data inside this InputPort, and updates the
-  /// version so that Contexts depending on this InputPort know to invalidate
+  /// Returns a pointer to the data inside this %FreestandingInputPort, and
+  /// updates the version so that Contexts depending on this know to invalidate
   /// their caches. Throws std::bad_cast if the data is not vector data.
   ///
   /// To ensure invalidation notifications are delivered, callers should
   /// call this method every time they wish to update the stored value.  In
   /// particular, callers MUST NOT write on the returned pointer if there is any
-  /// possibility this FreestandingInputPort has been accessed since the last
+  /// possibility this %FreestandingInputPort has been accessed since the last
   /// time this method was called.
   ///
   /// @tparam T The type of the input port. Must be a valid Eigen scalar.
@@ -176,8 +177,8 @@ class FreestandingInputPort : public InputPort {
     return output_port_value_.GetMutableVectorData<T>();
   }
 
-  /// Does nothing. A FreestandingInputPort wraps its own OutputPort, so there
-  /// is no need to handle unexpected destruction of the OutputPort.
+  /// Does nothing. A %FreestandingInputPort wraps its own OutputPortValue, so
+  /// there is no need to handle unexpected destruction of an output port.
   void Disconnect() override {}
 
  protected:

--- a/drake/systems/framework/system_output.cc
+++ b/drake/systems/framework/system_output.cc
@@ -3,7 +3,7 @@
 namespace drake {
 namespace systems {
 
-OutputPort::~OutputPort() {
+OutputPortValue::~OutputPortValue() {
   // Notify any input ports that are still connected to this output port that
   // this output port no longer exists.
   for (detail::OutputPortListenerInterface* dependent : dependents_) {
@@ -12,15 +12,15 @@ OutputPort::~OutputPort() {
 }
 
 
-std::unique_ptr<OutputPort> OutputPort::Clone() const {
+std::unique_ptr<OutputPortValue> OutputPortValue::Clone() const {
   if (data_ != nullptr) {
-    return std::make_unique<OutputPort>(data_->Clone());
+    return std::make_unique<OutputPortValue>(data_->Clone());
   }
   return nullptr;
 }
 
 
-void OutputPort::InvalidateAndIncrement() {
+void OutputPortValue::InvalidateAndIncrement() {
   ++version_;
   for (detail::OutputPortListenerInterface* dependent : dependents_) {
     dependent->Invalidate();

--- a/drake/systems/framework/test/system_input_test.cc
+++ b/drake/systems/framework/test/system_input_test.cc
@@ -86,13 +86,13 @@ class DependentInputPortTest : public ::testing::Test {
   void SetUp() override {
     std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
     vec->get_mutable_value() << 5, 6;
-    output_port_.reset(new OutputPort(std::move(vec)));
-    port_.reset(new DependentInputPort(output_port_.get()));
+    output_port_value_.reset(new OutputPortValue(std::move(vec)));
+    port_.reset(new DependentInputPort(output_port_value_.get()));
     port_->set_invalidation_callback(
         std::bind(&DependentInputPortTest::Invalidate, this));
   }
 
-  std::unique_ptr<OutputPort> output_port_;
+  std::unique_ptr<OutputPortValue> output_port_value_;
   std::unique_ptr<DependentInputPort> port_;
   int64_t latest_version_ = -1;
 
@@ -110,8 +110,8 @@ TEST_F(DependentInputPortTest, Access) {
 // is connected to it.
 TEST_F(DependentInputPortTest, Mutation) {
   EXPECT_EQ(0, port_->get_version());
-  output_port_->template GetMutableVectorData<int>()->get_mutable_value() << 7,
-      8;
+  output_port_value_->template GetMutableVectorData<int>()->get_mutable_value()
+      << 7, 8;
 
   // Check that the version number was incremented.
   EXPECT_EQ(1, port_->get_version());

--- a/drake/systems/framework/test/system_output_test.cc
+++ b/drake/systems/framework/test/system_output_test.cc
@@ -59,7 +59,7 @@ TEST_F(OutputPortVectorTest, Mutation) {
             output_port_value_->template get_vector_data<int>()->get_value());
 }
 
-// Tests that a clone of an OutputPort has a deep copy of the data.
+// Tests that a clone of an OutputPortValue has a deep copy of the data.
 TEST_F(OutputPortVectorTest, Clone) {
   auto clone = output_port_value_->Clone();
   // Changes to the original port should not affect the clone.
@@ -76,7 +76,7 @@ TEST_F(OutputPortVectorTest, Clone) {
 }
 
 // Tests that listeners are notified when GetMutableVectorData is called, and
-// when the OutputPort is deleted.
+// when the OutputPortValue is deleted.
 TEST_F(OutputPortVectorTest, Listeners) {
   TestOutputPortListener a, b, c;
   output_port_value_->add_dependent(&a);
@@ -93,7 +93,7 @@ TEST_F(OutputPortVectorTest, Listeners) {
   EXPECT_EQ(2, b.get_invalidations());
   EXPECT_EQ(1, c.get_invalidations());
 
-  // Only the listeners that are connected at the time the OutputPort is
+  // Only the listeners that are connected at the time the OutputPortValue is
   // destroyed get a disconnect notification.
   output_port_value_.reset();
   EXPECT_EQ(0, a.get_disconnections());
@@ -128,7 +128,7 @@ TEST_F(OutputPortAbstractValueTest, Mutation) {
             output_port_value_->get_abstract_data()->GetValue<std::string>());
 }
 
-// Tests that a clone of an OutputPort has a deep copy of the data.
+// Tests that a clone of an OutputPortValue has a deep copy of the data.
 TEST_F(OutputPortAbstractValueTest, Clone) {
   auto clone = output_port_value_->Clone();
   // Changes to the original port should not affect the clone.
@@ -162,19 +162,21 @@ TEST_F(LeafSystemOutputTest, Clone) {
   std::unique_ptr<SystemOutput<int>> clone = output_.Clone();
 
   {
-    const OutputPortValue& port = clone->get_port_value(0);
+    const OutputPortValue& port_value = clone->get_port_value(0);
     VectorX<int> expected(2);
     expected << 5, 25;
-    EXPECT_EQ(expected, port.template get_vector_data<int>()->get_value());
-    EXPECT_NE(nullptr, port.template get_vector_data<int>());
+    EXPECT_EQ(expected,
+              port_value.template get_vector_data<int>()->get_value());
+    EXPECT_NE(nullptr, port_value.template get_vector_data<int>());
   }
 
   {
-    const OutputPortValue& port = clone->get_port_value(1);
+    const OutputPortValue& port_value = clone->get_port_value(1);
     VectorX<int> expected(3);
     expected << 125, 625, 3125;
-    EXPECT_EQ(expected, port.template get_vector_data<int>()->get_value());
-    EXPECT_NE(nullptr, port.template get_vector_data<int>());
+    EXPECT_EQ(expected,
+              port_value.template get_vector_data<int>()->get_value());
+    EXPECT_NE(nullptr, port_value.template get_vector_data<int>());
   }
 }
 

--- a/drake/systems/framework/test/system_output_test.cc
+++ b/drake/systems/framework/test/system_output_test.cc
@@ -30,36 +30,42 @@ class OutputPortVectorTest : public ::testing::Test {
   void SetUp() override {
     std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
     vec->get_mutable_value() << 5, 6;
-    port_.reset(new OutputPort(std::move(vec)));
+    output_port_value_.reset(new OutputPortValue(std::move(vec)));
   }
 
-  std::unique_ptr<OutputPort> port_;
+  std::unique_ptr<OutputPortValue> output_port_value_;
 };
 
 TEST_F(OutputPortVectorTest, Access) {
   VectorX<int> expected(2);
   expected << 5, 6;
-  EXPECT_EQ(expected, port_->template get_vector_data<int>()->get_value());
+  EXPECT_EQ(expected,
+            output_port_value_->template get_vector_data<int>()->get_value());
 }
 
 TEST_F(OutputPortVectorTest, Mutation) {
-  EXPECT_EQ(0, port_->get_version());
-  port_->template GetMutableVectorData<int>()->get_mutable_value() << 7, 8;
+  EXPECT_EQ(0, output_port_value_->get_version());
+  output_port_value_->template GetMutableVectorData<int>()->get_mutable_value()
+      << 7,
+      8;
 
   // Check that the version number was incremented.
-  EXPECT_EQ(1, port_->get_version());
+  EXPECT_EQ(1, output_port_value_->get_version());
 
   // Check that the vector contents changed.
   VectorX<int> expected(2);
   expected << 7, 8;
-  EXPECT_EQ(expected, port_->template get_vector_data<int>()->get_value());
+  EXPECT_EQ(expected,
+            output_port_value_->template get_vector_data<int>()->get_value());
 }
 
 // Tests that a clone of an OutputPort has a deep copy of the data.
 TEST_F(OutputPortVectorTest, Clone) {
-  auto clone = port_->Clone();
+  auto clone = output_port_value_->Clone();
   // Changes to the original port should not affect the clone.
-  port_->template GetMutableVectorData<int>()->get_mutable_value() << 7, 8;
+  output_port_value_->template GetMutableVectorData<int>()->get_mutable_value()
+      << 7,
+      8;
 
   VectorX<int> expected(2);
   expected << 5, 6;
@@ -73,23 +79,23 @@ TEST_F(OutputPortVectorTest, Clone) {
 // when the OutputPort is deleted.
 TEST_F(OutputPortVectorTest, Listeners) {
   TestOutputPortListener a, b, c;
-  port_->add_dependent(&a);
-  port_->add_dependent(&b);
-  port_->template GetMutableVectorData<int>();
+  output_port_value_->add_dependent(&a);
+  output_port_value_->add_dependent(&b);
+  output_port_value_->template GetMutableVectorData<int>();
   EXPECT_EQ(1, a.get_invalidations());
   EXPECT_EQ(1, b.get_invalidations());
   EXPECT_EQ(0, c.get_invalidations());
 
-  port_->remove_dependent(&a);
-  port_->add_dependent(&c);
-  port_->template GetMutableVectorData<int>();
+  output_port_value_->remove_dependent(&a);
+  output_port_value_->add_dependent(&c);
+  output_port_value_->template GetMutableVectorData<int>();
   EXPECT_EQ(1, a.get_invalidations());
   EXPECT_EQ(2, b.get_invalidations());
   EXPECT_EQ(1, c.get_invalidations());
 
   // Only the listeners that are connected at the time the OutputPort is
   // destroyed get a disconnect notification.
-  port_.reset();
+  output_port_value_.reset();
   EXPECT_EQ(0, a.get_disconnections());
   EXPECT_EQ(1, b.get_disconnections());
   EXPECT_EQ(1, c.get_disconnections());
@@ -99,34 +105,37 @@ class OutputPortAbstractValueTest : public ::testing::Test {
  protected:
   void SetUp() override {
     auto value = std::make_unique<Value<std::string>>("foo");
-    port_.reset(new OutputPort(std::move(value)));
+    output_port_value_.reset(new OutputPortValue(std::move(value)));
   }
 
-  std::unique_ptr<OutputPort> port_;
+  std::unique_ptr<OutputPortValue> output_port_value_;
 };
 
 TEST_F(OutputPortAbstractValueTest, Access) {
-  EXPECT_EQ("foo", port_->get_abstract_data()->GetValue<std::string>());
+  EXPECT_EQ("foo",
+            output_port_value_->get_abstract_data()->GetValue<std::string>());
 }
 
 TEST_F(OutputPortAbstractValueTest, Mutation) {
-  EXPECT_EQ(0, port_->get_version());
-  port_->GetMutableData()->GetMutableValue<std::string>() = "bar";
+  EXPECT_EQ(0, output_port_value_->get_version());
+  output_port_value_->GetMutableData()->GetMutableValue<std::string>() = "bar";
 
   // Check that the version number was incremented.
-  EXPECT_EQ(1, port_->get_version());
+  EXPECT_EQ(1, output_port_value_->get_version());
 
   // Check that the contents changed.
-  EXPECT_EQ("bar", port_->get_abstract_data()->GetValue<std::string>());
+  EXPECT_EQ("bar",
+            output_port_value_->get_abstract_data()->GetValue<std::string>());
 }
 
 // Tests that a clone of an OutputPort has a deep copy of the data.
 TEST_F(OutputPortAbstractValueTest, Clone) {
-  auto clone = port_->Clone();
+  auto clone = output_port_value_->Clone();
   // Changes to the original port should not affect the clone.
   clone->GetMutableData()->GetMutableValue<std::string>() = "bar";
   EXPECT_EQ("bar", clone->get_abstract_data()->GetValue<std::string>());
-  EXPECT_EQ("foo", port_->get_abstract_data()->GetValue<std::string>());
+  EXPECT_EQ("foo",
+            output_port_value_->get_abstract_data()->GetValue<std::string>());
 }
 
 class LeafSystemOutputTest : public ::testing::Test {
@@ -135,12 +144,12 @@ class LeafSystemOutputTest : public ::testing::Test {
     {
       std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(2));
       vec->get_mutable_value() << 5, 25;
-      output_.add_port(std::make_unique<OutputPort>(std::move(vec)));
+      output_.add_port(std::make_unique<OutputPortValue>(std::move(vec)));
     }
     {
       std::unique_ptr<BasicVector<int>> vec(new BasicVector<int>(3));
       vec->get_mutable_value() << 125, 625, 3125;
-      output_.add_port(std::make_unique<OutputPort>(std::move(vec)));
+      output_.add_port(std::make_unique<OutputPortValue>(std::move(vec)));
     }
   }
 
@@ -153,7 +162,7 @@ TEST_F(LeafSystemOutputTest, Clone) {
   std::unique_ptr<SystemOutput<int>> clone = output_.Clone();
 
   {
-    const OutputPort& port = clone->get_port(0);
+    const OutputPortValue& port = clone->get_port_value(0);
     VectorX<int> expected(2);
     expected << 5, 25;
     EXPECT_EQ(expected, port.template get_vector_data<int>()->get_value());
@@ -161,7 +170,7 @@ TEST_F(LeafSystemOutputTest, Clone) {
   }
 
   {
-    const OutputPort& port = clone->get_port(1);
+    const OutputPortValue& port = clone->get_port_value(1);
     VectorX<int> expected(3);
     expected << 125, 625, 3125;
     EXPECT_EQ(expected, port.template get_vector_data<int>()->get_value());

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -381,7 +381,7 @@ class ValueIOTestSystem : public System<T> {
     output->add_port(
         std::unique_ptr<AbstractValue>(new Value<std::string>("output")));
 
-    output->add_port(std::make_unique<OutputPort>(
+    output->add_port(std::make_unique<OutputPortValue>(
         std::make_unique<BasicVector<T>>(1)));
 
     return std::unique_ptr<SystemOutput<T>>(output.release());

--- a/drake/systems/primitives/test/constant_value_source_test.cc
+++ b/drake/systems/primitives/test/constant_value_source_test.cc
@@ -38,8 +38,9 @@ TEST_F(ConstantValueSourceTest, Output) {
 
   source_->CalcOutput(*context_, output_.get());
 
-  EXPECT_EQ("foo",
-            output_->get_port(0).get_abstract_data()->GetValue<std::string>());
+  EXPECT_EQ(
+      "foo",
+      output_->get_port_value(0).get_abstract_data()->GetValue<std::string>());
   EXPECT_EQ("foo", output_->get_data(0)->GetValue<std::string>());
 }
 


### PR DESCRIPTION
Renames OutputPort to OutputPortValue to more accurately reflect what it does and to free up the OutputPort name for later use. Will follow with a similar change to InputPort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5496)
<!-- Reviewable:end -->
