### PR TITLE
Modify CMake build to install solver-specific optimization headers

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -195,7 +195,6 @@ drake_cc_library(
         "mathematical_program.h",
         "mathematical_program_solver_interface.h",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         ":binding",
         ":constraint",
@@ -220,7 +219,6 @@ drake_cc_library(
         "//conditions:default": ["no_gurobi.cc"],
     }),
     hdrs = ["gurobi_solver.h"],
-    visibility = ["//visibility:private"],
     deps = select({
         "//tools:with_gurobi": [
             ":mathematical_program_api",
@@ -243,7 +241,6 @@ drake_cc_library(
         "//conditions:default": ["no_mosek.cc"],
     }),
     hdrs = ["mosek_solver.h"],
-    visibility = ["//visibility:private"],
     deps = select({
         "//tools:with_mosek": [
             ":mathematical_program_api",
@@ -265,7 +262,6 @@ drake_cc_library(
         "//conditions:default": ["no_snopt.cc"],
     }),
     hdrs = ["snopt_solver.h"],
-    visibility = ["//visibility:private"],
     deps = select({
         "//tools:with_snopt": [
             ":mathematical_program_api",
@@ -285,7 +281,6 @@ drake_cc_library(
         "//conditions:default": ["ipopt_solver.cc"],
     }),
     hdrs = ["ipopt_solver.h"],
-    visibility = ["//visibility:private"],
     deps = select({
         "//conditions:default": [
             "@ipopt//:lib",
@@ -302,7 +297,6 @@ drake_cc_library(
     name = "nlopt_solver",
     srcs = ["nlopt_solver.cc"],
     hdrs = ["nlopt_solver.h"],
-    visibility = ["//visibility:private"],
     deps = [
         ":mathematical_program_api",
         "//drake/math:autodiff",

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -14,7 +14,7 @@ if(gurobi_FOUND)
       gurobi)
 endif()
 
-set(private_headers
+set(solver_headers
   dreal_solver.h
   gurobi_solver.h
   ipopt_solver.h
@@ -27,7 +27,7 @@ set(private_headers
 set(optimization_files)
 set(optimization_requires)
 list(APPEND optimization_files
-  ${private_headers}
+  ${solver_headers}
   constraint.cc
   decision_variable.cc
   equality_constrained_qp_solver.cc
@@ -80,6 +80,7 @@ target_link_libraries(drakeOptimization
   drakeCommon
   Eigen3::Eigen)
 drake_install_headers(
+  ${solver_headers}
   binding.h
   constraint.h
   function.h


### PR DESCRIPTION
These headers are necessary to invoke and work with specific solvers (e.g. the gurobi solver). They're installed by the BAZEL build but not by the CMake build. While I know the CMake build has a short lifespan left, this tweak is useful to those of us still using CMake right now and needing these headers exposed!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5506)
<!-- Reviewable:end -->
