### PR TITLE
Add model instance ID to PoseBundle.

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -92,7 +92,7 @@ int AutomotiveSimulator<T>::AddSimpleCarFromSdf(
   auto coord_transform =
       builder_->template AddSystem<SimpleCarToEulerFloatingJoint<T>>();
   const auto& descriptor = aggregator_->AddSingleInput(
-      "simple_car" + std::to_string(vehicle_number));
+      "simple_car", vehicle_number);
   builder_->Connect(simple_car->pose_output(),
                     aggregator_->get_input_port(descriptor.get_index()));
 
@@ -119,7 +119,7 @@ int AutomotiveSimulator<T>::AddTrajectoryCarFromSdf(
   auto coord_transform =
       builder_->template AddSystem<SimpleCarToEulerFloatingJoint<T>>();
   const auto& descriptor = aggregator_->AddSingleInput(
-      "trajectory_car" + std::to_string(vehicle_number));
+      "trajectory_car", vehicle_number);
   builder_->Connect(trajectory_car->pose_output(),
                     aggregator_->get_input_port(descriptor.get_index()));
 

--- a/drake/systems/rendering/pose_aggregator.cc
+++ b/drake/systems/rendering/pose_aggregator.cc
@@ -24,7 +24,7 @@ PoseAggregator<T>::~PoseAggregator() {}
 template <typename T>
 const InputPortDescriptor<T>& PoseAggregator<T>::AddRigidBodyPlantInput(
     const RigidBodyTree<double>& tree) {
-  input_records_.emplace_back(&tree);
+  input_records_.push_back(MakeRigidBodyTreeInputRecord(&tree));
   const int num_states = tree.get_num_positions() + tree.get_num_velocities();
   const InputPortDescriptor<T>& descriptor =
       this->DeclareInputPort(kVectorValued, num_states);
@@ -33,8 +33,8 @@ const InputPortDescriptor<T>& PoseAggregator<T>::AddRigidBodyPlantInput(
 
 template <typename T>
 const InputPortDescriptor<T>& PoseAggregator<T>::AddSingleInput(
-    const std::string& name) {
-  input_records_.emplace_back(name);
+    const std::string& name, int model_instance_id) {
+  input_records_.push_back(MakeSinglePoseInputRecord(name, model_instance_id));
   const InputPortDescriptor<T>& descriptor =
       this->DeclareInputPort(kVectorValued, PoseVector<T>::kSize);
   return descriptor;
@@ -43,7 +43,7 @@ const InputPortDescriptor<T>& PoseAggregator<T>::AddSingleInput(
 template <typename T>
 const InputPortDescriptor<T>& PoseAggregator<T>::AddBundleInput(
     const std::string& bundle_name, int num_poses) {
-  input_records_.emplace_back(bundle_name, num_poses);
+  input_records_.push_back(MakePoseBundleInputRecord(bundle_name, num_poses));
   const InputPortDescriptor<T>& descriptor = this->DeclareAbstractInputPort();
   return descriptor;
 }
@@ -79,7 +79,10 @@ void PoseAggregator<T>::DoCalcOutput(const Context<T>& context,
           DRAKE_ASSERT(pose_index < bundle.get_num_poses());
           bundle.set_pose(pose_index,
                           cache.get_element(body_index).transform_to_world);
-          bundle.set_name(pose_index, MakeBodyName(tree, body_index));
+          const RigidBody<double>& body = tree.get_body(body_index);
+          bundle.set_name(pose_index, MakeBodyName(body));
+          bundle.set_model_instance_id(pose_index,
+                                       body.get_model_instance_id());
           pose_index++;
         }
         break;
@@ -90,6 +93,7 @@ void PoseAggregator<T>::DoCalcOutput(const Context<T>& context,
         DRAKE_ASSERT(pose_index < bundle.get_num_poses());
         bundle.set_name(pose_index, record.name);
         bundle.set_pose(pose_index, value->get_isometry());
+        bundle.set_model_instance_id(pose_index, record.model_instance_id);
         pose_index++;
         break;
       }
@@ -105,6 +109,8 @@ void PoseAggregator<T>::DoCalcOutput(const Context<T>& context,
           DRAKE_ASSERT(pose_index < bundle.get_num_poses());
           bundle.set_pose(pose_index, value->get_pose(j));
           bundle.set_name(pose_index, bundle_name + "::" + value->get_name(j));
+          bundle.set_model_instance_id(pose_index,
+                                       value->get_model_instance_id(j));
           pose_index++;
         }
         break;
@@ -134,10 +140,43 @@ int PoseAggregator<T>::CountNumPoses() const {
 
 template <typename T>
 const std::string PoseAggregator<T>::MakeBodyName(
-    const RigidBodyTree<double>& tree, int body_index) const {
-  const RigidBody<double>& body = tree.get_body(body_index);
-  const std::string model_instance = to_string(body.get_model_instance_id());
-  return body.get_model_name() + "_" + model_instance + "::" + body.get_name();
+    const RigidBody<double>& body) const {
+  return body.get_model_name() + "::" + body.get_name();
+}
+
+template <typename T>
+typename PoseAggregator<T>::InputRecord
+PoseAggregator<T>::MakeRigidBodyTreeInputRecord(
+    const RigidBodyTree<double>* tree) {
+  InputRecord rec;
+  rec.type = kRigidBodyTree;
+  // Subtract one to omit the world body.
+  rec.num_poses = tree->get_num_bodies() - 1;
+  rec.tree = tree;
+  return rec;
+}
+
+template <typename T>
+typename PoseAggregator<T>::InputRecord
+PoseAggregator<T>::MakeSinglePoseInputRecord(
+    const std::string& name, int model_instance_id) {
+  InputRecord rec;
+  rec.type = kSingle;
+  rec.num_poses = 1;
+  rec.name = name;
+  rec.model_instance_id = model_instance_id;
+  return rec;
+}
+
+template <typename T>
+typename PoseAggregator<T>::InputRecord
+PoseAggregator<T>::MakePoseBundleInputRecord(
+    const std::string& bundle_name, int num_poses) {
+  InputRecord rec;
+  rec.type = kBundle;
+  rec.num_poses = num_poses;
+  rec.name = bundle_name;
+  return rec;
 }
 
 template class PoseAggregator<double>;

--- a/drake/systems/rendering/pose_bundle.cc
+++ b/drake/systems/rendering/pose_bundle.cc
@@ -12,7 +12,7 @@ namespace rendering {
 
 template <typename T>
 PoseBundle<T>::PoseBundle(int num_poses)
-    : poses_(num_poses), names_(num_poses) {
+    : poses_(num_poses), names_(num_poses), ids_(num_poses) {
 }
 
 template <typename T>
@@ -46,6 +46,19 @@ void PoseBundle<T>::set_name(int index, const std::string& name) {
   DRAKE_DEMAND(index >= 0 && index < get_num_poses());
   names_[index] = name;
 }
+template <typename T>
+int PoseBundle<T>::get_model_instance_id(int index) const {
+  DRAKE_DEMAND(index >= 0 && index < get_num_poses());
+  return ids_[index];
+}
+
+template <typename T>
+void PoseBundle<T>::set_model_instance_id(int index, int id) {
+  DRAKE_DEMAND(index >= 0 && index < get_num_poses());
+  DRAKE_DEMAND(id >= 0);
+  ids_[index] = id;
+}
+
 
 template class PoseBundle<double>;
 template class PoseBundle<AutoDiffXd>;

--- a/drake/systems/rendering/pose_bundle.h
+++ b/drake/systems/rendering/pose_bundle.h
@@ -21,8 +21,10 @@ namespace rendering {
 // here.  "Names" as currently construed are unlikely to be useful to
 // consumers of aggregated poses.
 
-/// PoseBundle is a container for a set of named poses, represented by an
-/// Isometry3. The poses are expressed in the world frame: X_WFi.
+/// PoseBundle is a container for a set of poses, represented by an Isometry3.
+/// The poses are expressed in the world frame: X_WFi. Each pose has a name,
+/// and a model instance ID.  If two poses in the bundle have the same model
+/// instance ID, they must not have the same name.
 ///
 /// This class is explicitly instantiated for the following scalar types. No
 /// other scalar types are supported.
@@ -44,11 +46,15 @@ class PoseBundle {
   const std::string& get_name(int index) const;
   void set_name(int index, const std::string& name);
 
+  int get_model_instance_id(int index) const;
+  void set_model_instance_id(int index, int id);
+
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PoseBundle)
 
  private:
   std::vector<Isometry3<T>> poses_;
   std::vector<std::string> names_;
+  std::vector<int> ids_;
 };
 
 }  // namespace rendering

--- a/drake/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/drake/systems/rendering/pose_bundle_to_draw_message.cc
@@ -32,9 +32,7 @@ void PoseBundleToDrawMessage::DoCalcOutput(const Context<double>& context,
   message.quaternion.resize(n);
 
   for (int i = 0; i < n; ++i) {
-    // TODO(david-german-tri): Support non-unique link names by populating
-    // robot_num. Will require changes in PoseAggregator and PoseBundle.
-    message.robot_num[i] = 0;
+    message.robot_num[i] = poses.get_model_instance_id(i);
 
     message.link_name[i] = poses.get_name(i);
 

--- a/drake/systems/rendering/pose_bundle_to_draw_message.h
+++ b/drake/systems/rendering/pose_bundle_to_draw_message.h
@@ -17,9 +17,7 @@ namespace rendering {
 ///
 /// The draw message will contain one link for each pose in the PoseBundle. The
 /// name of the link will be the name of the corresponding pose. The robot_num
-/// will always be 0. Because of this restriction, only one instance of a
-/// model can be visualized, and no two models can have overlapping link names.
-/// TODO(david-german-tri): Lift this restriction.
+/// will be the corresponding model instance ID.
 class PoseBundleToDrawMessage : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseBundleToDrawMessage)

--- a/drake/systems/rendering/test/pose_aggregator_test.cc
+++ b/drake/systems/rendering/test/pose_aggregator_test.cc
@@ -54,7 +54,8 @@ class PoseAggregatorTest : public ::testing::Test {
     // Allocate another input for a PoseBundle.
     aggregator_.AddBundleInput("bundle", kNumGenericPoses);
     // Allocate a third input for a PoseVector.
-    aggregator_.AddSingleInput("vector");
+    const int kRandomModelInstanceId = 42;
+    aggregator_.AddSingleInput("vector", kRandomModelInstanceId);
 
     context_ = aggregator_.CreateDefaultContext();
     output_ = aggregator_.AllocateOutput(*context_);
@@ -81,10 +82,15 @@ TEST_F(PoseAggregatorTest, HeterogeneousAggregation) {
   PoseBundle<double> generic_input(2);
   Eigen::Translation3d translation_0(0, 1, 0);
   Eigen::Translation3d translation_1(0, 1, 1);
+  const int kSherlockModelInstanceId = 17;
   generic_input.set_name(0, "Sherlock");
   generic_input.set_pose(0, Isometry3d(translation_0));
+  generic_input.set_model_instance_id(0, kSherlockModelInstanceId);
+
+  const int kMycroftModelInstanceId = 13;
   generic_input.set_name(1, "Mycroft");
   generic_input.set_pose(1, Isometry3d(translation_1));
+  generic_input.set_model_instance_id(1, kMycroftModelInstanceId);
   context_->FixInputPort(1, AbstractValue::Make(generic_input));
 
   // Set an arbitrary rotation in the PoseVector input.
@@ -101,15 +107,18 @@ TEST_F(PoseAggregatorTest, HeterogeneousAggregation) {
 
   // Check that the rigid body poses, as determined by the kinematics,
   // appear in the output.
-  EXPECT_EQ("robot_0::link1", bundle.get_name(0));
+  EXPECT_EQ("robot::link1", bundle.get_name(0));
+  EXPECT_EQ(0, bundle.get_model_instance_id(0));
   const Isometry3d& link1_pose = bundle.get_pose(0);
   EXPECT_TRUE(CompareMatrices(Isometry3d(AngleAxisd(M_PI, axis_)).matrix(),
                               link1_pose.matrix()));
 
   // Check that the generic poses are passed through to the output.
   EXPECT_EQ("bundle::Sherlock", bundle.get_name(1));
+  EXPECT_EQ(kSherlockModelInstanceId, bundle.get_model_instance_id(1));
   const Isometry3d& generic_pose_0 = bundle.get_pose(1);
   EXPECT_EQ("bundle::Mycroft", bundle.get_name(2));
+  EXPECT_EQ(kMycroftModelInstanceId, bundle.get_model_instance_id(2));
   const Isometry3d& generic_pose_1 = bundle.get_pose(2);
 
   EXPECT_TRUE(CompareMatrices(Isometry3d(translation_0).matrix(),
@@ -119,6 +128,7 @@ TEST_F(PoseAggregatorTest, HeterogeneousAggregation) {
 
   EXPECT_EQ("vector", bundle.get_name(3));
   const Isometry3d& vector_pose = bundle.get_pose(3);
+  EXPECT_EQ(42, bundle.get_model_instance_id(3));
   EXPECT_TRUE(CompareMatrices(
       Isometry3d(Eigen::Quaternion<double>(0.5, 0.5, 0.5, 0.5)).matrix(),
       vector_pose.matrix()));

--- a/drake/systems/rendering/test/pose_bundle_to_draw_message_test.cc
+++ b/drake/systems/rendering/test/pose_bundle_to_draw_message_test.cc
@@ -16,12 +16,14 @@ GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
   foo_pose.translation()[0] = 123;
   bundle.set_name(0, "foo");
   bundle.set_pose(0, foo_pose);
+  bundle.set_model_instance_id(0, 42);
 
   Eigen::Isometry3d bar_pose = Eigen::Isometry3d::Identity();
   const double roll = -M_PI_2;
   bar_pose *= Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX());
   bundle.set_name(1, "bar");
   bundle.set_pose(1, bar_pose);
+  bundle.set_model_instance_id(1, 43);
 
   PoseBundleToDrawMessage converter;
   auto context = converter.AllocateContext();
@@ -33,7 +35,7 @@ GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
   EXPECT_EQ(2, message.num_links);
 
   EXPECT_EQ("foo", message.link_name[0]);
-  EXPECT_EQ(0, message.robot_num[0]);
+  EXPECT_EQ(42, message.robot_num[0]);
   // foo is translated in x.
   EXPECT_EQ(123, message.position[0][0]);  // x
   EXPECT_EQ(0, message.position[0][1]);    // y
@@ -45,7 +47,7 @@ GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
   EXPECT_EQ(0, message.quaternion[0][3]);  // z
 
   EXPECT_EQ("bar", message.link_name[1]);
-  EXPECT_EQ(0, message.robot_num[1]);
+  EXPECT_EQ(43, message.robot_num[1]);
   // bar has no translation.
   EXPECT_EQ(0, message.position[1][0]);  // x
   EXPECT_EQ(0, message.position[1][1]);  // y


### PR DESCRIPTION
Use it to populate `robot_num` in the draw message, following the example of https://github.com/RobotLocomotion/drake/blob/master/drake/multibody/rigid_body_plant/drake_visualizer.cc#L161

Example usage: https://gist.github.com/david-german-tri/0021ef9ff01602e12bf0776b95a7413e

@liangfok for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5508)
<!-- Reviewable:end -->
