### PR TITLE
Compile a separate rotation constraint library

### DIFF
--- a/drake/multibody/CMakeLists.txt
+++ b/drake/multibody/CMakeLists.txt
@@ -86,6 +86,7 @@ drake_install_pkg_config_file(drake-ik
 add_library_with_exports(LIB_NAME drakeGlobalIK SOURCE_FILES global_inverse_kinematics.cc)
 target_link_libraries(drakeGlobalIK
         drakeOptimization
+        drakeRotationConstraint
         drakeRBM
         Eigen3::Eigen)
 drake_install_libraries(drakeGlobalIK)

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -35,7 +35,6 @@ list(APPEND optimization_files
   mathematical_program.cc
   mathematical_program_solver_interface.cc
   moby_lcp_solver.cc
-  rotation_constraint.cc
   system_identification.cc
   )
 if(ipopt_FOUND)
@@ -86,7 +85,6 @@ drake_install_headers(
   mathematical_program.h
   mathematical_program_solver_interface.h
   decision_variable.h
-  rotation_constraint.h
   system_identification.h
   )
 drake_install_libraries(drakeOptimization)
@@ -134,6 +132,21 @@ endif()
 if(mosek_FOUND)
   target_link_libraries(drakeOptimization mosek)
 endif()
+
+add_library_with_exports(LIB_NAME drakeRotationConstraint SOURCE_FILES rotation_constraint.cc)
+target_link_libraries(drakeRotationConstraint
+        drakeOptimization)
+drake_install_headers(
+        rotation_constraint.h
+)
+drake_install_pkg_config_file(drake-rotation-constraint
+        TARGET drakeRotationConstraint
+        LIBS -ldrakeRotationConstraint
+        REQUIRES
+        drake-common
+        drake-optimization)
+
+drake_install_libraries(drakeRotationConstraint)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 
 if (mosek_FOUND)
   drake_add_cc_test(rotation_constraint_test rotation_constraint_test.cc)
-  target_link_libraries(rotation_constraint_test drakeOptimization)
+  target_link_libraries(rotation_constraint_test drakeRotationConstraint)
 endif(mosek_FOUND)
 
 if (lcm_FOUND)

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -80,6 +80,7 @@ if (lcm_FOUND)
   add_executable(plot_feasible_rotation_matrices plot_feasible_rotation_matrices.cc)
   target_link_libraries(plot_feasible_rotation_matrices
     drakeOptimization
+    drakeRotationConstraint
     drakeLCMTypes
     drakeLcm)
 endif(lcm_FOUND)


### PR DESCRIPTION
In Bazel, there is a separate `rotation_constraint` library, but in CMake, it is wrapped into `drakeOptimization` library. Just take it out from CMake as a separate library also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5510)
<!-- Reviewable:end -->
