### PR TITLE
Port sensors to model-based port declarations

### DIFF
--- a/drake/systems/sensors/accelerometer.cc
+++ b/drake/systems/sensors/accelerometer.cc
@@ -32,8 +32,8 @@ Accelerometer::Accelerometer(const string& name,
   plant_state_derivative_input_port_index_ =
       DeclareInputPort(kVectorValued, tree_.get_num_positions() +
                                       tree_.get_num_velocities()).get_index();
-  output_port_index_ =
-      DeclareOutputPort(kVectorValued, 3).get_index();
+  output_port_index_ = DeclareVectorOutputPort(
+      AccelerometerOutput<double>()).get_index();
 }
 
 Accelerometer* Accelerometer::AttachAccelerometer(
@@ -70,11 +70,6 @@ Accelerometer* Accelerometer::AttachAccelerometer(
   // port once RigidBodyPlant has an output port containing xdot. This can only
   // be done once #2890 is resolved.
   return accelerometer;
-}
-
-std::unique_ptr<BasicVector<double>> Accelerometer::AllocateOutputVector(
-    const OutputPortDescriptor<double>& descriptor) const {
-  return std::make_unique<AccelerometerOutput<double>>();
 }
 
 void Accelerometer::DoCalcOutput(const systems::Context<double>& context,

--- a/drake/systems/sensors/accelerometer.h
+++ b/drake/systems/sensors/accelerometer.h
@@ -189,11 +189,6 @@ class Accelerometer : public systems::LeafSystem<double> {
     return System<double>::get_output_port(output_port_index_);
   }
 
-  /// Allocates the output vector. See this class's description for details of
-  /// this output vector.
-  std::unique_ptr<BasicVector<double>> AllocateOutputVector(
-      const OutputPortDescriptor<double>& descriptor) const override;
-
  protected:
   /// Computes the "sensed" linear acceleration.
   void DoCalcOutput(const systems::Context<double>& context,

--- a/drake/systems/sensors/depth_sensor.cc
+++ b/drake/systems/sensors/depth_sensor.cc
@@ -58,8 +58,8 @@ DepthSensor::DepthSensor(const std::string& name,
       DeclareInputPort(kVectorValued,
                        tree.get_num_positions() + tree.get_num_velocities())
           .get_index();
-  output_port_index_ =
-      DeclareOutputPort(kVectorValued, get_num_depth_readings()).get_index();
+  output_port_index_ = DeclareVectorOutputPort(
+      DepthSensorOutput<double>(specification_)).get_index();
   PrecomputeRaycastEndpoints();
 }
 
@@ -117,12 +117,6 @@ DepthSensor::get_rigid_body_tree_state_input_port() const {
 const OutputPortDescriptor<double>& DepthSensor::get_sensor_state_output_port()
     const {
   return System<double>::get_output_port(output_port_index_);
-}
-
-std::unique_ptr<BasicVector<double>> DepthSensor::AllocateOutputVector(
-    const OutputPortDescriptor<double>& descriptor) const {
-  DRAKE_DEMAND(descriptor.size() == specification_.num_depth_readings());
-  return std::make_unique<DepthSensorOutput<double>>(specification_);
 }
 
 void DepthSensor::DoCalcOutput(const systems::Context<double>& context,

--- a/drake/systems/sensors/depth_sensor.h
+++ b/drake/systems/sensors/depth_sensor.h
@@ -150,11 +150,6 @@ class DepthSensor : public systems::LeafSystem<double> {
   /// sensed values.
   const OutputPortDescriptor<double>& get_sensor_state_output_port() const;
 
-  /// Allocates the output vector. See this class' description for details of
-  /// this output vector.
-  std::unique_ptr<BasicVector<double>> AllocateOutputVector(
-      const OutputPortDescriptor<double>& descriptor) const override;
-
   friend std::ostream& operator<<(std::ostream& out,
                                   const DepthSensor& depth_sensor);
 

--- a/drake/systems/sensors/gyroscope.cc
+++ b/drake/systems/sensors/gyroscope.cc
@@ -22,13 +22,8 @@ Gyroscope::Gyroscope(const std::string& name,
   input_port_index_ =
       DeclareInputPort(kVectorValued, tree_.get_num_positions() +
                                       tree_.get_num_velocities()).get_index();
-  output_port_index_ =
-      DeclareOutputPort(kVectorValued, 3).get_index();
-}
-
-std::unique_ptr<BasicVector<double>> Gyroscope::AllocateOutputVector(
-    const OutputPortDescriptor<double>& descriptor) const {
-  return make_unique<GyroscopeOutput<double>>();
+  output_port_index_ = DeclareVectorOutputPort(
+      GyroscopeOutput<double>()).get_index();
 }
 
 void Gyroscope::DoCalcOutput(const systems::Context<double>& context,

--- a/drake/systems/sensors/gyroscope.h
+++ b/drake/systems/sensors/gyroscope.h
@@ -102,11 +102,6 @@ class Gyroscope : public systems::LeafSystem<double> {
     return System<double>::get_output_port(output_port_index_);
   }
 
-  /// Allocates the output vector. See this class' description for details of
-  /// this output vector.
-  std::unique_ptr<BasicVector<double>> AllocateOutputVector(
-      const OutputPortDescriptor<double>& descriptor) const override;
-
  protected:
   /// Computes the angular velocity as sensed by this sensor.
   void DoCalcOutput(const systems::Context<double>& context,


### PR DESCRIPTION
Relates #5431.

Note that I did not port the RGBD camera, because it only builds under CMake.

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5513)
<!-- Reviewable:end -->
