### PR TITLE
Adds MaliputRailcar::DoCalcNextUpdateTime().

### DIFF
--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -130,6 +130,11 @@ class MaliputRailcar : public systems::LeafSystem<T> {
   std::unique_ptr<systems::Parameters<T>> AllocateParameters() const override;
   bool DoHasDirectFeedthrough(const systems::SparsityMatrix* sparsity,
                               int input_port, int output_port) const override;
+  void DoCalcNextUpdateTime(const systems::Context<T>& context,
+                            systems::UpdateActions<T>* actions) const override;
+
+  void DoCalcUnrestrictedUpdate(const systems::Context<T>& context,
+                                systems::State<T>* state) const override;
 
  private:
   void ImplCalcOutput(


### PR DESCRIPTION
This is another incremental step towards allowing `MaliputRailcar` to cross lane boundaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5532)
<!-- Reviewable:end -->
