### PR TITLE
clang-format-includes on automotive

### DIFF
--- a/drake/automotive/dev/infinite_circuit_road.h
+++ b/drake/automotive/dev/infinite_circuit_road.h
@@ -7,12 +7,11 @@
 #include <vector>
 
 #include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/lane_data.h"
-#include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/api/segment.h"
-
 #include "drake/common/drake_assert.h"
 
 namespace drake {

--- a/drake/automotive/dev/test/infinite_circuit_road_test.cc
+++ b/drake/automotive/dev/test/infinite_circuit_road_test.cc
@@ -2,9 +2,9 @@
 
 #include <cmath>
 
-#include "drake/automotive/maliput/monolane/builder.h"
-
 #include "gtest/gtest.h"
+
+#include "drake/automotive/maliput/monolane/builder.h"
 
 namespace drake {
 namespace maliput {

--- a/drake/automotive/maliput/api/road_geometry.cc
+++ b/drake/automotive/maliput/api/road_geometry.cc
@@ -10,7 +10,6 @@
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/segment.h"
-
 #include "drake/common/drake_assert.h"
 
 namespace drake {

--- a/drake/automotive/maliput/dragway/dragway_to_urdf.cc
+++ b/drake/automotive/maliput/dragway/dragway_to_urdf.cc
@@ -2,13 +2,14 @@
  @file Instantiates a dragway with a user-specified number of lanes and outputs
  a URDF model of it.
  **/
+
 #include <gflags/gflags.h>
+#include "spruce.hh"
 
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/maliput/utility/generate_urdf.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/text_logging_gflags.h"
-#include "spruce.hh"
 
 DEFINE_int32(num_lanes, 2, "The number of lanes.");
 DEFINE_double(length, 10, "The length of the dragway in meters.");

--- a/drake/automotive/maliput/monolane/builder.cc
+++ b/drake/automotive/maliput/monolane/builder.cc
@@ -7,7 +7,6 @@
 #include "drake/automotive/maliput/monolane/branch_point.h"
 #include "drake/automotive/maliput/monolane/line_lane.h"
 #include "drake/automotive/maliput/monolane/road_geometry.h"
-
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 

--- a/drake/automotive/maliput/monolane/lane.cc
+++ b/drake/automotive/maliput/monolane/lane.cc
@@ -1,7 +1,6 @@
 #include "drake/automotive/maliput/monolane/lane.h"
 
 #include "drake/automotive/maliput/monolane/branch_point.h"
-
 #include "drake/common/drake_assert.h"
 
 namespace drake {

--- a/drake/automotive/maliput/monolane/segment.cc
+++ b/drake/automotive/maliput/monolane/segment.cc
@@ -4,7 +4,6 @@
 
 #include "drake/automotive/maliput/monolane/arc_lane.h"
 #include "drake/automotive/maliput/monolane/line_lane.h"
-
 #include "drake/common/drake_assert.h"
 
 namespace drake {

--- a/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
@@ -1,16 +1,15 @@
+#include <cmath>
+#include <iostream>
+
+#include "gtest/gtest.h"
+
 #include "drake/automotive/maliput/monolane/arc_lane.h"
 #include "drake/automotive/maliput/monolane/junction.h"
 #include "drake/automotive/maliput/monolane/lane.h"
 #include "drake/automotive/maliput/monolane/line_lane.h"
 #include "drake/automotive/maliput/monolane/road_geometry.h"
 #include "drake/automotive/maliput/monolane/segment.h"
-
 #include "drake/common/eigen_matrix_compare.h"
-
-#include <cmath>
-#include <iostream>
-
-#include "gtest/gtest.h"
 
 namespace drake {
 namespace maliput {

--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -16,7 +16,6 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/api/segment.h"
-
 #include "drake/common/drake_assert.h"
 
 namespace drake {

--- a/drake/automotive/maliput/utility/test/generate_urdf_test.cc
+++ b/drake/automotive/maliput/utility/test/generate_urdf_test.cc
@@ -1,5 +1,11 @@
 #include "drake/automotive/maliput/utility/generate_urdf.h"
 
+#include <cmath>
+#include <fstream>
+
+#include "gtest/gtest.h"
+#include "spruce.hh"
+
 #include "drake/automotive/maliput/monolane/arc_lane.h"
 #include "drake/automotive/maliput/monolane/builder.h"
 #include "drake/automotive/maliput/monolane/junction.h"
@@ -7,12 +13,6 @@
 #include "drake/automotive/maliput/monolane/line_lane.h"
 #include "drake/automotive/maliput/monolane/road_geometry.h"
 #include "drake/automotive/maliput/monolane/segment.h"
-
-#include <cmath>
-#include <fstream>
-
-#include "gtest/gtest.h"
-#include "spruce.hh"
 
 namespace drake {
 namespace maliput {

--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -4,8 +4,8 @@
 
 #include "drake/common/drake_path.h"
 #include "drake/lcm/drake_mock_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/lcmt_simple_car_state_t.hpp"
+#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/automotive` to obey `cppguide` and `code_style_guide`.

Relates #2269.

I have a tool that generates these changes, but it's not good enough for master yet (it requires fixing-by-hand of a few nits).  However, pushing its true-positive fixes to master in the meantime (1) helps us have cleaner code, and (2) allows me to more easily iterate on the remaining diffs that the tool wants to make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5539)
<!-- Reviewable:end -->
