### PR TITLE
clang-format-includes on common

### DIFF
--- a/drake/common/autodiff_overloads.h
+++ b/drake/common/autodiff_overloads.h
@@ -26,8 +26,8 @@
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/cond.h"
-#include "drake/common/dummy_value.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/dummy_value.h"
 
 namespace Eigen {
 

--- a/drake/common/drake_throw.cc
+++ b/drake/common/drake_throw.cc
@@ -1,7 +1,7 @@
 #include "drake/common/drake_throw.h"
 
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 
 namespace drake {
 namespace detail {

--- a/drake/common/eigen_matrix_compare.h
+++ b/drake/common/eigen_matrix_compare.h
@@ -4,8 +4,8 @@
 #include <cmath>
 #include <limits>
 
-#include <gtest/gtest.h>
 #include <Eigen/Dense>
+#include <gtest/gtest.h>
 
 #include "drake/common/drake_compat.h"
 #include "drake/common/text_logging.h"

--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -4,7 +4,6 @@
 
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>
-
 #include "gtest/gtest.h"
 
 #include "drake/common/cond.h"

--- a/drake/common/test/eigen_matrix_compare_test.cc
+++ b/drake/common/test/eigen_matrix_compare_test.cc
@@ -1,4 +1,5 @@
 #include "drake/common/eigen_matrix_compare.h"
+
 #include "gtest/gtest.h"
 
 namespace drake {

--- a/drake/common/test/functional_form_test.cc
+++ b/drake/common/test/functional_form_test.cc
@@ -4,7 +4,6 @@
 #include <sstream>
 
 #include <Eigen/Core>
-
 #include "gtest/gtest.h"
 
 namespace drake {

--- a/drake/common/test/sorted_vectors_have_intersection_test.cc
+++ b/drake/common/test/sorted_vectors_have_intersection_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/sorted_vectors_have_intersection.h"
 
 #include <vector>
+
 #include "gtest/gtest.h"
 
 using std::vector;

--- a/drake/common/test/symbolic_expression_differentiation_test.cc
+++ b/drake/common/test/symbolic_expression_differentiation_test.cc
@@ -5,10 +5,11 @@
 #include <tuple>
 #include <vector>
 
+#include "gtest/gtest.h"
+
 #include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_formula.h"
 #include "drake/common/test/symbolic_test_util.h"
-#include "gtest/gtest.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/test/symbolic_expression_jacobian_test.cc
+++ b/drake/common/test/symbolic_expression_jacobian_test.cc
@@ -1,8 +1,8 @@
 #include "drake/common/symbolic_expression.h"
 
-#include "drake/common/eigen_types.h"
-
 #include "gtest/gtest.h"
+
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace symbolic {

--- a/drake/common/test/symbolic_mixing_scalar_types_test.cc
+++ b/drake/common/test/symbolic_mixing_scalar_types_test.cc
@@ -1,10 +1,9 @@
-#include "drake/common/symbolic_expression.h"
-
 #include <sstream>
 #include <string>
 
 #include "gtest/gtest.h"
 
+#include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_formula.h"
 #include "drake/common/symbolic_variable.h"
 

--- a/drake/common/test/symbolic_variable_overloading_test.cc
+++ b/drake/common/test/symbolic_variable_overloading_test.cc
@@ -1,9 +1,10 @@
+#include "drake/common/symbolic_variable.h"
+
 #include <sstream>
 
 #include "gtest/gtest.h"
 
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_variable.h"
 #include "drake/common/test/symbolic_test_util.h"
 
 namespace drake {

--- a/drake/common/test/symbolic_variable_test.cc
+++ b/drake/common/test/symbolic_variable_test.cc
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include <Eigen/Core>
-
 #include "gtest/gtest.h"
 
 #include "drake/common/test/symbolic_test_util.h"

--- a/drake/common/test/trig_poly_test.cc
+++ b/drake/common/test/trig_poly_test.cc
@@ -1,7 +1,7 @@
 #include "drake/common/trig_poly.h"
 
-#include <sstream>
 #include <map>
+#include <sstream>
 
 #include "gtest/gtest.h"
 

--- a/drake/common/trajectories/piecewise_function.h
+++ b/drake/common/trajectories/piecewise_function.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <Eigen/Core>
-#include <vector>
 #include <random>
+#include <vector>
+
+#include <Eigen/Core>
 
 class PiecewiseFunction {
  protected:

--- a/drake/common/trajectories/test/piecewise_function_test.cc
+++ b/drake/common/trajectories/test/piecewise_function_test.cc
@@ -2,8 +2,9 @@
 
 #include <random>
 
-#include "drake/common/drake_assert.h"
 #include "gtest/gtest.h"
+
+#include "drake/common/drake_assert.h"
 
 // Dummy implementation of PiecewiseFunction to test the basic indexing
 // functions.

--- a/drake/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -1,3 +1,5 @@
+#include "drake/common/trajectories/piecewise_polynomial.h"
+
 #include <iostream>
 #include <random>
 #include <vector>
@@ -6,7 +8,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/common/trajectories/piecewise_polynomial.h"
 
 using std::default_random_engine;
 

--- a/drake/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_test.cc
@@ -1,3 +1,5 @@
+#include "drake/common/trajectories/piecewise_polynomial.h"
+
 #include <iostream>
 #include <random>
 #include <vector>
@@ -7,7 +9,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/common/trajectories/test/random_piecewise_polynomial.h"
 
 using Eigen::Matrix;

--- a/drake/common/trajectories/test/piecewise_polynomial_trajectory_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_trajectory_test.cc
@@ -1,7 +1,6 @@
 #include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
 
 #include <Eigen/Core>
-
 #include "gtest/gtest.h"
 
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/common/trajectories/test/piecewise_quaternion_test.cc
+++ b/drake/common/trajectories/test/piecewise_quaternion_test.cc
@@ -2,10 +2,11 @@
 
 #include <random>
 
+#include "gtest/gtest.h"
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/util/drakeGeometryUtil.h"
-#include "gtest/gtest.h"
 
 namespace drake {
 namespace {

--- a/drake/common/trajectories/trajectory.h
+++ b/drake/common/trajectories/trajectory.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <memory>
+
 #include <Eigen/Core>
+
 #include "drake/common/eigen_types.h"
 
 namespace drake {


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/common` to obey `cppguide` and `code_style_guide`.

Relates #2269.

I have a tool that generates these changes, but it's not good enough for master yet (it requires fixing-by-hand of a few nits).  However, pushing its true-positive fixes to master in the meantime (1) helps us have cleaner code, and (2) allows me to more easily iterate on the remaining diffs that the tool wants to make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5540)
<!-- Reviewable:end -->
