### PR TITLE
Fix CLion instructions for cpplint tool when using Bazel

### DIFF
--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -249,7 +249,7 @@ Run ``Cpplint`` on Single File
    :Description: ``Apply cpplint to the current file.``
    :Program: ``$Projectpath$/drake/common/test/cpplint_wrapper.py``
    :Parameters: ``$FilePath$``
-   :Working directory: ``$ProjectFileDir$``
+   :Working directory: <empty> (CLion may set this; if so leave it.)
 5. Make sure that *only* the following Options are checked (the
    ``Synchronize files after execution`` is unnecessary because cpplint is
    a read-only operation):
@@ -279,7 +279,7 @@ differences:
     :Description: ``Apply cpplint to the entire project.``
     :Program: ``$Projectpath$/drake/common/test/cpplint_wrapper.py``
     :Parameters: <empty>
-    :Working directory: ``$ProjectFileDir$``
+    :Working directory: <empty> (CLion may set this; if so leave it.)
 
 Continue on with steps 5 to the end.
 

--- a/drake/doc/clion.rst
+++ b/drake/doc/clion.rst
@@ -229,6 +229,9 @@ This will give you the ability to execute ``cpplint`` on a single file or the fu
 project and have the result presented in the CLion console with each warning
 a clickable hyperlink.
 
+(These instructions assume you are using CLion with Bazel, as you should be.
+They are slightly different for CMake project organization.)
+
 Creating the External Tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -244,7 +247,7 @@ Run ``Cpplint`` on Single File
 
    :Name: ``Cpplint File``
    :Description: ``Apply cpplint to the current file.``
-   :Program: ``$ProjectFileDir$/common/test/cpplint_wrapper.py``
+   :Program: ``$Projectpath$/drake/common/test/cpplint_wrapper.py``
    :Parameters: ``$FilePath$``
    :Working directory: ``$ProjectFileDir$``
 5. Make sure that *only* the following Options are checked (the
@@ -274,7 +277,7 @@ differences:
 
     :Name: ``Cpplint Project``
     :Description: ``Apply cpplint to the entire project.``
-    :Program: ``$ProjectFileDir$/common/test/cpplint_wrapper.py``
+    :Program: ``$Projectpath$/drake/common/test/cpplint_wrapper.py``
     :Parameters: <empty>
     :Working directory: ``$ProjectFileDir$``
 


### PR DESCRIPTION
The project root in CLion is `drake-distro` with Bazel, but was `drake-distro/drake` with CMake. Also the generated files are outside the source tree. That requires some adjustments to the instructions for making the cpplint external tool work.

I don't see any reason to preserve the old instructions since CLion is now fully functional with Bazel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5543)
<!-- Reviewable:end -->
