### PR TITLE
Fix missing solution enum types in python

### DIFF
--- a/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
+++ b/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
@@ -161,7 +161,10 @@ PYBIND11_PLUGIN(_pydrake_mathematicalprogram) {
     .value("kInvalidInput", SolutionResult::kInvalidInput)
     .value("kInfeasibleConstraints",
            SolutionResult::kInfeasibleConstraints)
-    .value("kUnknownError", SolutionResult::kUnknownError);
+    .value("kUnbounded", SolutionResult::kUnbounded)
+    .value("kUnknownError", SolutionResult::kUnknownError)
+    .value("kInfeasible_Or_Unbounded",
+           SolutionResult::kInfeasible_Or_Unbounded);
 
   // Assign the wrapped Constraint class to the name 'constraint'
   // so we can use it in this file to indicate that the other constraint


### PR DESCRIPTION
These were added relatively recently to MathematicalProgram, but weren't accessible from Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5544)
<!-- Reviewable:end -->
