### PR TITLE
clang-format-includes on primitives

### DIFF
--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -3,7 +3,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
-
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_context.h"
 

--- a/drake/systems/primitives/linear_system.cc
+++ b/drake/systems/primitives/linear_system.cc
@@ -8,7 +8,6 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
-
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 

--- a/drake/systems/primitives/multiplexer.cc
+++ b/drake/systems/primitives/multiplexer.cc
@@ -1,10 +1,10 @@
 #include "drake/systems/primitives/multiplexer.h"
 
-#include "drake/common/autodiff_overloads.h"
-#include "drake/common/eigen_autodiff_types.h"
-
 #include <functional>
 #include <numeric>
+
+#include "drake/common/autodiff_overloads.h"
+#include "drake/common/eigen_autodiff_types.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/saturation.cc
+++ b/drake/systems/primitives/saturation.cc
@@ -1,5 +1,3 @@
-
-
 #include "drake/systems/primitives/saturation.h"
 
 #include <algorithm>

--- a/drake/systems/primitives/test/adder_test.cc
+++ b/drake/systems/primitives/test/adder_test.cc
@@ -4,11 +4,11 @@
 #include <stdexcept>
 #include <string>
 
+#include <gtest/gtest.h>
+
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/system_port_descriptor.h"
-
-#include <gtest/gtest.h>
 
 using std::make_unique;
 

--- a/drake/systems/primitives/test/affine_system_test.cc
+++ b/drake/systems/primitives/test/affine_system_test.cc
@@ -1,5 +1,6 @@
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/primitives/affine_system.h"
+
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/primitives/test/affine_linear_test.h"
 
 using std::make_unique;

--- a/drake/systems/primitives/test/constant_value_source_test.cc
+++ b/drake/systems/primitives/test/constant_value_source_test.cc
@@ -4,10 +4,10 @@
 #include <stdexcept>
 #include <string>
 
+#include <gtest/gtest.h>
+
 #include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/value.h"
-
-#include <gtest/gtest.h>
 
 using Eigen::Matrix;
 using std::make_unique;

--- a/drake/systems/primitives/test/constant_vector_source_test.cc
+++ b/drake/systems/primitives/test/constant_vector_source_test.cc
@@ -4,10 +4,10 @@
 #include <stdexcept>
 #include <string>
 
+#include <gtest/gtest.h>
+
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-
-#include <gtest/gtest.h>
 
 using Eigen::Matrix;
 using std::make_unique;

--- a/drake/systems/primitives/test/demultiplexer_test.cc
+++ b/drake/systems/primitives/test/demultiplexer_test.cc
@@ -2,12 +2,11 @@
 
 #include <memory>
 
+#include <gtest/gtest.h>
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-
-#include <gtest/gtest.h>
 
 using Eigen::AutoDiffScalar;
 using Eigen::Vector2d;

--- a/drake/systems/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/primitives/test/gain_scalartype_test.cc
@@ -4,14 +4,14 @@
 #include <stdexcept>
 #include <string>
 
+#include <gtest/gtest.h>
+
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-
-#include <gtest/gtest.h>
 
 using Eigen::AutoDiffScalar;
 using Eigen::Vector2d;

--- a/drake/systems/primitives/test/gain_test.cc
+++ b/drake/systems/primitives/test/gain_test.cc
@@ -2,11 +2,11 @@
 
 #include <memory>
 
+#include <gtest/gtest.h>
+
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-
-#include <gtest/gtest.h>
 
 using Eigen::Vector3d;
 using std::make_unique;

--- a/drake/systems/primitives/test/integrator_test.cc
+++ b/drake/systems/primitives/test/integrator_test.cc
@@ -5,12 +5,11 @@
 #include <string>
 
 #include <Eigen/Dense>
+#include <gtest/gtest.h>
 
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/system_port_descriptor.h"
-
-#include <gtest/gtest.h>
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/test/linear_system_test.cc
+++ b/drake/systems/primitives/test/linear_system_test.cc
@@ -1,9 +1,10 @@
+#include "drake/systems/primitives/linear_system.h"
+
 #include <stdexcept>
 
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/systems/primitives/linear_system.h"
 #include "drake/systems/primitives/test/affine_linear_test.h"
 
 using std::make_unique;

--- a/drake/systems/primitives/test/multiplexer_test.cc
+++ b/drake/systems/primitives/test/multiplexer_test.cc
@@ -2,10 +2,10 @@
 
 #include <memory>
 
+#include <gtest/gtest.h>
+
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-
-#include <gtest/gtest.h>
 
 using std::make_unique;
 

--- a/drake/systems/primitives/test/pass_through_scalartype_test.cc
+++ b/drake/systems/primitives/test/pass_through_scalartype_test.cc
@@ -5,12 +5,11 @@
 
 #include <memory>
 
+#include <gtest/gtest.h>
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-
-#include <gtest/gtest.h>
 
 using Eigen::AutoDiffScalar;
 using Eigen::Vector3d;

--- a/drake/systems/primitives/test/pass_through_test.cc
+++ b/drake/systems/primitives/test/pass_through_test.cc
@@ -2,12 +2,11 @@
 
 #include <memory>
 
+#include <gtest/gtest.h>
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-
-#include <gtest/gtest.h>
 
 using Eigen::AutoDiffScalar;
 using Eigen::Vector2d;

--- a/drake/systems/primitives/test/random_source_test.cc
+++ b/drake/systems/primitives/test/random_source_test.cc
@@ -1,3 +1,5 @@
+#include "drake/systems/primitives/random_source.h"
+
 #include <stdexcept>
 
 #include <gtest/gtest.h>
@@ -7,7 +9,6 @@
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/primitives/random_source.h"
 #include "drake/systems/primitives/signal_logger.h"
 
 namespace drake {

--- a/drake/systems/primitives/test/trajectory_source_test.cc
+++ b/drake/systems/primitives/test/trajectory_source_test.cc
@@ -4,12 +4,12 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system_input.h"
-#include "drake/common/eigen_matrix_compare.h"
 
 using Eigen::Matrix;
 using Eigen::MatrixXd;

--- a/drake/systems/primitives/test/zero_order_hold_test.cc
+++ b/drake/systems/primitives/test/zero_order_hold_test.cc
@@ -5,13 +5,12 @@
 #include <string>
 
 #include <Eigen/Dense>
+#include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
 #include "drake/systems/framework/system_output.h"
-
-#include <gtest/gtest.h>
 
 namespace drake {
 namespace systems {


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/systems/primitives` to obey `cppguide` and `code_style_guide`.

Relates #2269.

I have a tool that generates these changes, but it's not good enough for master yet (it requires fixing-by-hand of a few nits).  However, pushing its true-positive fixes to master in the meantime (1) helps us have cleaner code, and (2) allows me to more easily iterate on the remaining diffs that the tool wants to make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5547)
<!-- Reviewable:end -->
