### PR TITLE
Fix warnings in model-based xc declarations

### DIFF
--- a/drake/examples/Acrobot/acrobot_plant.cc
+++ b/drake/examples/Acrobot/acrobot_plant.cc
@@ -40,7 +40,7 @@ AcrobotPlant<T>::AcrobotPlant(double m1, double m2, double l1, double l2,
   this->DeclareVectorOutputPort(AcrobotStateVector<T>());
   static_assert(AcrobotStateVectorIndices::kNumCoordinates == kNumDOF * 2, "");
   this->DeclareContinuousState(
-      std::make_unique<AcrobotStateVector<T>>(),
+      AcrobotStateVector<T>(),
       kNumDOF /* num_q */,
       kNumDOF /* num_v */,
       0 /* num_z */);

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -76,7 +76,7 @@ SpringMassSystem<T>::SpringMassSystem(const T& spring_constant_N_per_m,
   this->DeclareVectorOutputPort(SpringMassStateVector<T>());
 
   this->DeclareContinuousState(
-      std::make_unique<SpringMassStateVector<T>>(),
+      SpringMassStateVector<T>(),
       1 /* num_q */, 1 /* num_v */, 1 /* num_z */);
 }
 


### PR DESCRIPTION
Fixes a few lines missed in #5514 that are causing deprecation warnings now.  Relates #5431.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5548)
<!-- Reviewable:end -->
