### PR TITLE
clang-format-includes on analysis and framework 

### DIFF
--- a/drake/systems/analysis/semi_explicit_euler_integrator.h
+++ b/drake/systems/analysis/semi_explicit_euler_integrator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+
 #include "drake/systems/analysis/integrator_base.h"
 
 namespace drake {

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -11,8 +11,8 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/text_logging.h"
-#include "drake/systems/analysis/runge_kutta2_integrator.h"
 #include "drake/systems/analysis/integrator_base.h"
+#include "drake/systems/analysis/runge_kutta2_integrator.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"
 

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -8,11 +8,11 @@
 #include <stdexcept>
 #include <utility>
 
+#include <Eigen/Dense>
+
 #include "drake/common/drake_throw.h"
 #include "drake/common/dummy_value.h"
 #include "drake/systems/framework/vector_base.h"
-
-#include <Eigen/Dense>
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/leaf_context.h
+++ b/drake/systems/framework/leaf_context.h
@@ -7,8 +7,8 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/context.h"
 #include "drake/systems/framework/cache.h"
+#include "drake/systems/framework/context.h"
 #include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/parameters.h"
 #include "drake/systems/framework/state.h"

--- a/drake/systems/framework/model_values.h
+++ b/drake/systems/framework/model_values.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Eigen/Dense>
-
 #include <cstdint>
 #include <stdexcept>
+
+#include <Eigen/Dense>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <Eigen/Dense>
-
 #include <algorithm>
 #include <cstdint>
 #include <stdexcept>
 #include <utility>
 #include <vector>
+
+#include <Eigen/Dense>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/vector_base.h"

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -12,8 +12,8 @@
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-#include "drake/systems/framework/value.h"
 #include "drake/systems/framework/test_utilities/pack_value.h"
+#include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/test/model_values_test.cc
+++ b/drake/systems/framework/test/model_values_test.cc
@@ -8,8 +8,8 @@
 #include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_formula.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/value.h"
 #include "drake/systems/framework/test_utilities/my_vector.h"
+#include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/test/single_output_vector_source_test.cc
+++ b/drake/systems/framework/test/single_output_vector_source_test.cc
@@ -3,10 +3,9 @@
 #include <memory>
 
 #include <Eigen/Dense>
+#include <gtest/gtest.h>
 
 #include "drake/common/drake_copyable.h"
-
-#include <gtest/gtest.h>
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/test/subvector_test.cc
+++ b/drake/systems/framework/test/subvector_test.cc
@@ -1,14 +1,14 @@
+#include "drake/systems/framework/subvector.h"
+
 #include <memory>
 
 #include <Eigen/Dense>
-
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff_overloads.h"
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/subvector.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/test/supervector_test.cc
+++ b/drake/systems/framework/test/supervector_test.cc
@@ -1,11 +1,11 @@
+#include "drake/systems/framework/supervector.h"
+
 #include <memory>
 
 #include <Eigen/Dense>
-
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/supervector.h"
 #include "drake/systems/framework/vector_base.h"
 
 namespace drake {

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -3,8 +3,8 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <typeinfo>
 #include <type_traits>
+#include <typeinfo>
 #include <utility>
 
 #include "drake/common/drake_assert.h"


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/systems/{analysis,framework}` to obey `cppguide` and `code_style_guide`.

Relates #2269.

I have a tool that generates these changes, but it's not good enough for master yet (it requires fixing-by-hand of a few nits).  However, pushing its true-positive fixes to master in the meantime (1) helps us have cleaner code, and (2) allows me to more easily iterate on the remaining diffs that the tool wants to make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5549)
<!-- Reviewable:end -->
