### PR TITLE
Adds Lane Change Capability to MaliputRailcar.

### DIFF
--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -155,9 +155,14 @@ class MaliputRailcar : public systems::LeafSystem<T> {
       MaliputRailcarState<T>* rates) const;
 
   void ImplCalcTimeDerivativesDouble(
-    const MaliputRailcarConfig<double>& config,
-    const MaliputRailcarState<double>& state,
-    MaliputRailcarState<double>* rates) const;
+      const MaliputRailcarConfig<double>& config,
+      const MaliputRailcarState<double>& state,
+      MaliputRailcarState<double>* rates) const;
+
+  // Calculates the vehicle's `r` coordinate based on whether it's traveling
+  // with or against `s` in the current lane relative to the initial lane.
+  T CalcR(const MaliputRailcarConfig<T>& config,
+          const LaneDirection& lane_direction) const;
 
   const LaneDirection initial_lane_direction_{};
   int command_input_port_index_{};


### PR DESCRIPTION
This enables `MaliputRailcar` to proceed onto an ongoing branch when it reaches the end of its current lane.

Two new `RoadGeometry` objects are introduced in `maliput_railcar_test.cc` that are created by the newly added method `InitializeTwoLaneSegment()`, as shown below. They differ in the direction of the curved lane's s-axis, and are used to show that `MaliputRailcar::DoCalcUnrestrictedUpdate()` can handle traversals in both directions. In both scenarios, the `MaliputRailcar` starts at the beginning of the straight lane, which is at the origin of the world frame. The vehicle is then moved to the end of the straight lane at which point `MaliputRailcar::DoCalcUnrestrictedUpdate()` is called to force the vehicle to switch onto the curved lane.

# Consistent s-direction

![s_same](https://cloud.githubusercontent.com/assets/1388098/24077459/5554851c-0c24-11e7-8bc7-6eaadb83e2b9.png)

# Inconsistent s-direction

![s_flips](https://cloud.githubusercontent.com/assets/1388098/24077460/57bf334c-0c24-11e7-91b7-eafe59bfddd4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5552)
<!-- Reviewable:end -->