### PR TITLE
Fixes Bug in Orientation of MaliputRailcar When it is Traveling Against s.

### DIFF
--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -145,10 +145,22 @@ void MaliputRailcar<T>::ImplCalcPose(const MaliputRailcarConfig<T>& config,
   const Rotation rotation =
       lane_direction.lane->GetOrientation(lane_position);
 
+  using std::atan2;
+  using std::sin;
+  using std::cos;
+
+  // Adjust the rotation based on whether the vehicle is traveling with s or
+  // against s.
+  const Rotation adjusted_rotation =
+      (lane_direction.with_s ? rotation :
+          Rotation(-rotation.roll,
+                   -rotation.pitch,
+                   atan2(-sin(rotation.yaw), -cos(rotation.yaw))));
   pose->set_translation(
       Eigen::Translation<T, 3>(geo_position.x, geo_position.y, geo_position.z));
   pose->set_rotation(math::RollPitchYawToQuaternion(
-      Vector3<T>(rotation.roll, rotation.pitch, rotation.yaw)));
+      Vector3<T>(adjusted_rotation.roll, adjusted_rotation.pitch,
+                 adjusted_rotation.yaw)));
 }
 
 template <typename T>


### PR DESCRIPTION
This change set was extracted from #5552. I believe it fixes a bug in `MaliputRailcar`'s orientation when it is traveling against `s`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5553)
<!-- Reviewable:end -->
