### PR TITLE
clang-format-includes on solvers

### DIFF
--- a/drake/solvers/dreal_solver.cc
+++ b/drake/solvers/dreal_solver.cc
@@ -1,6 +1,7 @@
 #include "drake/solvers/dreal_solver.h"
 
 #include <stdexcept>
+
 #include "dreal/dreal.h"
 
 #include "drake/solvers/mathematical_program.h"

--- a/drake/solvers/fast_qp.h
+++ b/drake/solvers/fast_qp.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <vector>
 #include <set>
+#include <vector>
 
 #include <Eigen/Dense>
 

--- a/drake/solvers/gurobi_qp.h
+++ b/drake/solvers/gurobi_qp.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <vector>
 #include <set>
+#include <vector>
 
 #include <Eigen/Dense>
-
 #include <gurobi_c++.h>
 
 #define CGE(call, env)                                                  \

--- a/drake/solvers/mathematical_program_solver_interface.cc
+++ b/drake/solvers/mathematical_program_solver_interface.cc
@@ -1,7 +1,7 @@
 #include "drake/solvers/mathematical_program_solver_interface.h"
 
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -1,8 +1,5 @@
 #include "drake/solvers/moby_lcp_solver.h"
 
-#include <Eigen/SparseCore>
-#include <Eigen/SparseLU>
-
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -12,9 +9,12 @@
 #include <sstream>
 #include <vector>
 
-#include "drake/common/drake_assert.h"
-
+#include <Eigen/LU>
+#include <Eigen/SparseCore>
+#include <Eigen/SparseLU>
 #include <unsupported/Eigen/AutoDiff>
+
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/moby_lcp_solver.h
+++ b/drake/solvers/moby_lcp_solver.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <fstream>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <Eigen/SparseCore>
 

--- a/drake/solvers/mosek_solver.cc
+++ b/drake/solvers/mosek_solver.cc
@@ -6,10 +6,9 @@
 #include <list>
 #include <vector>
 
-#include <mosek.h>
-
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
+#include <mosek.h>
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/no_ipopt.cc
+++ b/drake/solvers/no_ipopt.cc
@@ -1,4 +1,3 @@
-
 #include "drake/solvers/ipopt_solver.h"
 
 #include <stdexcept>

--- a/drake/solvers/no_mosek.cc
+++ b/drake/solvers/no_mosek.cc
@@ -1,4 +1,3 @@
-
 #include "drake/solvers/mosek_solver.h"
 
 #include <stdexcept>

--- a/drake/solvers/no_nlopt.cc
+++ b/drake/solvers/no_nlopt.cc
@@ -1,4 +1,3 @@
-
 #include "drake/solvers/nlopt_solver.h"
 
 #include <stdexcept>

--- a/drake/solvers/no_snopt.cc
+++ b/drake/solvers/no_snopt.cc
@@ -1,4 +1,3 @@
-
 #include "drake/solvers/snopt_solver.h"
 
 #include <stdexcept>

--- a/drake/solvers/qp.cc
+++ b/drake/solvers/qp.cc
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <iostream>
+
 #include <Eigen/Cholesky>
 #include <Eigen/LU>
 #include <Eigen/SVD>

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -1,5 +1,4 @@
 #include <iostream>
-
 #include <list>
 
 #include <gtest/gtest.h>

--- a/drake/solvers/test/dreal_solver_test.cc
+++ b/drake/solvers/test/dreal_solver_test.cc
@@ -1,6 +1,7 @@
 #include "drake/solvers/dreal_solver.h"
 
 #include <typeinfo>
+
 #include "dreal/dreal.h"
 #include <gtest/gtest.h>
 

--- a/drake/solvers/test/plot_feasible_rotation_matrices.cc
+++ b/drake/solvers/test/plot_feasible_rotation_matrices.cc
@@ -1,4 +1,3 @@
-
 #include <limits>
 
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/solvers/test/system_identification_test.cc
+++ b/drake/solvers/test/system_identification_test.cc
@@ -3,7 +3,6 @@
 #include <random>  // Used only with deterministic seeds!
 
 #include <Eigen/Core>
-
 #include <gtest/gtest.h>
 
 #include "drake/common/polynomial.h"


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/solvers` to obey `cppguide` and `code_style_guide`.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5554)
<!-- Reviewable:end -->
