### PR TITLE
clang-format-includes on kuka_iiwa_arm,schunk_wsg

### DIFF
--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/action.h
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/action.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <lcm/lcm-cpp.hpp>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <lcm/lcm-cpp.hpp>
 
 #include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h"
 

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_state_machine.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_state_machine.cc
@@ -8,8 +8,8 @@
 #include <memory>
 
 #include <lcm/lcm-cpp.hpp>
-
 #include "bot_core/robot_state_t.hpp"
+
 #include "drake/common/drake_path.h"
 #include "drake/common/trajectories/piecewise_quaternion.h"
 #include "drake/examples/kuka_iiwa_arm/dev/iiwa_ik_planner.h"
@@ -18,7 +18,6 @@
 #include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 #include "drake/lcmt_iiwa_status.hpp"
-
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
 #include "drake/util/lcmUtil.h"

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/world_state.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <lcm/lcm-cpp.hpp>
 #include <list>
 #include <memory>
 #include <string>
 
+#include <lcm/lcm-cpp.hpp>
 #include "bot_core/robot_state_t.hpp"
-#include "drake/multibody/rigid_body_tree.h"
+
 #include "drake/lcmt_schunk_wsg_status.hpp"
+#include "drake/multibody/rigid_body_tree.h"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/kuka_iiwa_arm/iiwa_common.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_common.cc
@@ -1,6 +1,5 @@
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 
-#include <memory.h>
 #include <map>
 #include <set>
 #include <string>
@@ -17,7 +16,6 @@
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_ik.h"
 #include "drake/multibody/rigid_body_tree.h"
-
 #include "drake/util/drakeGeometryUtil.h"
 
 using Eigen::Vector3d;

--- a/drake/examples/kuka_iiwa_arm/iiwa_common.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_common.h
@@ -4,12 +4,12 @@
 #include <string>
 #include <vector>
 
+#include "robotlocomotion/robot_plan_t.hpp"
+
 #include "drake/common/eigen_types.h"
 #include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
 #include "drake/multibody/rigid_body_ik.h"
 #include "drake/multibody/rigid_body_tree.h"
-
-#include "robotlocomotion/robot_plan_t.hpp"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -5,7 +5,6 @@
 #include <memory>
 
 #include <gflags/gflags.h>
-
 #include "robotlocomotion/robot_plan_t.hpp"
 
 #include "drake/common/drake_path.h"
@@ -14,6 +13,8 @@
 #include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_plan_source.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_iiwa_command.hpp"
+#include "drake/lcmt_iiwa_status.hpp"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/controllers/pid_controlled_system.h"
 #include "drake/systems/framework/context.h"
@@ -22,9 +23,6 @@
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/primitives/demultiplexer.h"
-
-#include "drake/lcmt_iiwa_command.hpp"
-#include "drake/lcmt_iiwa_status.hpp"
 
 using robotlocomotion::robot_plan_t;
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_plan_source.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_plan_source.h
@@ -3,10 +3,10 @@
 #include <memory>
 #include <string>
 
+#include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/value.h"
-#include "drake/multibody/rigid_body_tree.h"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.cc
@@ -4,12 +4,11 @@
 #include <set>
 #include <string>
 #include <utility>
-#include "drake/util/drakeGeometryUtil.h"
 
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
+#include "drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_tree_builder.h"
 #include "drake/examples/kuka_iiwa_arm/oracular_state_estimator.h"
 #include "drake/examples/kuka_iiwa_arm/sim_diagram_builder.h"
-#include "drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_tree_builder.h"
 #include "drake/examples/schunk_wsg/schunk_wsg_constants.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 #include "drake/systems/controllers/inverse_dynamics_controller.h"
@@ -18,6 +17,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/constant_vector_source.h"
 #include "drake/systems/primitives/matrix_gain.h"
+#include "drake/util/drakeGeometryUtil.h"
 
 namespace drake {
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.cc
@@ -1,7 +1,6 @@
-#include <memory>
-
 #include "drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_diagram_factory.h"
 
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_tree_builder.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_tree_builder.cc
@@ -4,6 +4,8 @@
 #include <map>
 #include <utility>
 
+#include "spruce.hh"
+
 #include "drake/common/drake_path.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/multibody/parsers/model_instance_id_table.h"
@@ -13,8 +15,6 @@
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/multibody/rigid_body_tree_construction.h"
-
-#include "spruce.hh"
 
 using Eigen::aligned_allocator;
 using Eigen::Vector3d;

--- a/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -20,6 +20,10 @@
 #include "drake/examples/kuka_iiwa_arm/oracular_state_estimator.h"
 #include "drake/examples/schunk_wsg/schunk_wsg_lcm.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_iiwa_command.hpp"
+#include "drake/lcmt_iiwa_status.hpp"
+#include "drake/lcmt_schunk_wsg_command.hpp"
+#include "drake/lcmt_schunk_wsg_status.hpp"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
@@ -31,12 +35,6 @@
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/primitives/constant_vector_source.h"
 #include "drake/systems/primitives/matrix_gain.h"
-
-#include "drake/lcmt_iiwa_command.hpp"
-#include "drake/lcmt_iiwa_status.hpp"
-#include "drake/lcmt_schunk_wsg_command.hpp"
-#include "drake/lcmt_schunk_wsg_status.hpp"
-
 #include "drake/util/drakeGeometryUtil.h"
 
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),

--- a/drake/examples/kuka_iiwa_arm/kuka_ik_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_ik_demo.cc
@@ -8,7 +8,6 @@
 #include <memory>
 
 #include <lcm/lcm-cpp.hpp>
-
 #include "robotlocomotion/robot_plan_t.hpp"
 
 #include "drake/common/drake_path.h"

--- a/drake/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -12,7 +12,6 @@
 #include <memory>
 
 #include <lcm/lcm-cpp.hpp>
-
 #include "robotlocomotion/robot_plan_t.hpp"
 
 #include "drake/common/drake_assert.h"
@@ -20,12 +19,11 @@
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
+#include "drake/lcmt_iiwa_command.hpp"
+#include "drake/lcmt_iiwa_status.hpp"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_tree.h"
-
-#include "drake/lcmt_iiwa_command.hpp"
-#include "drake/lcmt_iiwa_status.hpp"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -15,6 +15,8 @@
 #include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 #include "drake/examples/kuka_iiwa_arm/sim_diagram_builder.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_iiwa_command.hpp"
+#include "drake/lcmt_iiwa_status.hpp"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
@@ -27,9 +29,6 @@
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/primitives/constant_vector_source.h"
-
-#include "drake/lcmt_iiwa_command.hpp"
-#include "drake/lcmt_iiwa_status.hpp"
 
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "Number of seconds to simulate.");

--- a/drake/examples/kuka_iiwa_arm/oracular_state_estimator.h
+++ b/drake/examples/kuka_iiwa_arm/oracular_state_estimator.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "bot_core/robot_state_t.hpp"
+
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/util/lcmUtil.h"

--- a/drake/examples/kuka_iiwa_arm/test/sim_diagram_builder_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/sim_diagram_builder_test.cc
@@ -1,12 +1,12 @@
-#include "drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_tree_builder.h"
+#include "drake/examples/kuka_iiwa_arm/sim_diagram_builder.h"
 
 #include <gtest/gtest.h>
-#include "drake/lcm/drake_lcm.h"
 
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
-#include "drake/examples/kuka_iiwa_arm/sim_diagram_builder.h"
+#include "drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_tree_builder.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/controllers/inverse_dynamics_controller.h"
 #include "drake/systems/controllers/pid_controller.h"

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
@@ -6,7 +6,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
-
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
 

--- a/drake/examples/schunk_wsg/schunk_wsg_simulation.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_simulation.cc
@@ -16,6 +16,8 @@
 #include "drake/examples/schunk_wsg/schunk_wsg_lcm.h"
 #include "drake/examples/schunk_wsg/simulated_schunk_wsg_system.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_schunk_wsg_command.hpp"
+#include "drake/lcmt_schunk_wsg_status.hpp"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 #include "drake/systems/analysis/simulator.h"
@@ -28,9 +30,6 @@
 #include "drake/systems/primitives/constant_vector_source.h"
 #include "drake/systems/primitives/matrix_gain.h"
 #include "drake/systems/primitives/multiplexer.h"
-
-#include "drake/lcmt_schunk_wsg_command.hpp"
-#include "drake/lcmt_schunk_wsg_status.hpp"
 
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "Number of seconds to simulate.");


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/examples/{kuka_iiwa_arm,schunk_wsg}` to obey `cppguide` and `code_style_guide`.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5555)
<!-- Reviewable:end -->
