### PR TITLE
clang-format-includes on Valkyrie and etc.

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/control_utils.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/control_utils.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <Eigen/Dense>
 #include <iostream>
+
+#include <Eigen/Dense>
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/rotation_matrix.h"

--- a/drake/examples/QPInverseDynamicsForHumanoids/lcm_utils.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/lcm_utils.h
@@ -6,9 +6,9 @@
 
 #include "bot_core/atlas_command_t.hpp"
 #include "bot_core/robot_state_t.hpp"
+
 #include "drake/common/eigen_types.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller_common.h"
-
 #include "drake/lcmt_body_acceleration.hpp"
 #include "drake/lcmt_constrained_values.hpp"
 #include "drake/lcmt_contact_information.hpp"

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.cc
@@ -2,11 +2,11 @@
 
 #include <fcntl.h>
 
+#include <set>
+
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/text_format.h"
-
-#include <set>
 
 namespace drake {
 namespace examples {

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "drake/examples/QPInverseDynamicsForHumanoids/param_parsers/alias_groups.pb.h"
-
 #include "drake/multibody/rigid_body_tree.h"
 
 namespace drake {

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/rigid_body_tree_alias_groups_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/test/rigid_body_tree_alias_groups_test.cc
@@ -1,7 +1,8 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.h"
+
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_path.h"
-#include "drake/examples/QPInverseDynamicsForHumanoids/param_parsers/rigid_body_tree_alias_groups.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 
 namespace drake {

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.cc
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "bot_core/atlas_command_t.hpp"
+
 #include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller_common.h"
 #include "drake/util/drakeUtil.h"

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.cc
@@ -1,6 +1,7 @@
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.h"
 
 #include "bot_core/robot_state_t.hpp"
+
 #include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/lcm_utils.h"
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/humanoid_plan_eval_system_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/humanoid_plan_eval_system_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.h"
 
+#include <gtest/gtest.h>
+
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/control_utils.h"
@@ -10,8 +12,6 @@
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/constant_value_source.h"
-
-#include <gtest/gtest.h>
 
 namespace drake {
 namespace examples {

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/joint_level_controller_system_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/joint_level_controller_system_test.cc
@@ -1,14 +1,14 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h"
+
 #include <memory>
 
 #include "bot_core/atlas_command_t.hpp"
-
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/qp_controller_common.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h"
-#include "drake/examples/QPInverseDynamicsForHumanoids/system/joint_level_controller_system.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/systems/framework/value.h"

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/qp_controller_system_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/qp_controller_system_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h"
 
+#include <gtest/gtest.h>
+
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/control_utils.h"
@@ -7,12 +9,9 @@
 #include "drake/examples/QPInverseDynamicsForHumanoids/param_parsers/param_parser.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
-
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/constant_value_source.h"
-
-#include <gtest/gtest.h>
 
 namespace drake {
 namespace examples {

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_balancing_controller_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_balancing_controller_system.cc
@@ -4,6 +4,7 @@
 
 #include "bot_core/atlas_command_t.hpp"
 #include "bot_core/robot_state_t.hpp"
+
 #include "drake/common/drake_path.h"
 #include "drake/common/text_logging.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h"

--- a/drake/examples/QPInverseDynamicsForHumanoids/test/lcm_utils_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/test/lcm_utils_test.cc
@@ -1,3 +1,5 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/lcm_utils.h"
+
 #include <cstdlib>
 #include <memory>
 
@@ -5,7 +7,6 @@
 
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/examples/QPInverseDynamicsForHumanoids/lcm_utils.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_tree.h"

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <vector>
 #include <map>
+#include <vector>
 
-#include "drake/systems/framework/leaf_system.h"
 #include "drake/multibody/rigid_body_actuator.h"
+#include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace systems {

--- a/drake/examples/Valkyrie/robot_state_decoder.cc
+++ b/drake/examples/Valkyrie/robot_state_decoder.cc
@@ -2,11 +2,11 @@
 
 #include <utility>
 
+#include "lcmtypes/bot_core/robot_state_t.hpp"
+
 #include "drake/examples/Valkyrie/robot_state_lcmtype_util.h"
 #include "drake/util/drakeGeometryUtil.h"
 #include "drake/util/lcmUtil.h"
-
-#include "lcmtypes/bot_core/robot_state_t.hpp"
 
 namespace drake {
 namespace systems {

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -1,7 +1,8 @@
+#include "drake/examples/Valkyrie/robot_state_encoder.h"
+
 #include <list>
 
 #include "drake/common/constants.h"
-#include "drake/examples/Valkyrie/robot_state_encoder.h"
 #include "drake/examples/Valkyrie/robot_state_lcmtype_util.h"
 #include "drake/multibody/rigid_body_plant/contact_force.h"
 #include "drake/multibody/rigid_body_plant/contact_resultant_force_calculator.h"

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -3,14 +3,14 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "lcmtypes/bot_core/robot_state_t.hpp"
 
+#include "drake/multibody/rigid_body_frame.h"
 #include "drake/multibody/rigid_body_plant/contact_results.h"
 #include "drake/multibody/rigid_body_plant/kinematics_results.h"
-#include "drake/multibody/rigid_body_frame.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"

--- a/drake/examples/Valkyrie/test/robot_command_to_desired_effort_converter_test.cc
+++ b/drake/examples/Valkyrie/test/robot_command_to_desired_effort_converter_test.cc
@@ -1,8 +1,7 @@
 #include "drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h"
 
-#include <gtest/gtest.h>
-
 #include "lcmtypes/bot_core/atlas_command_t.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -13,7 +13,6 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/constant_value_source.h"
 #include "drake/systems/primitives/constant_vector_source.h"
-
 #include "drake/util/drakeGeometryUtil.h"
 
 namespace drake {

--- a/drake/examples/Valkyrie/test/valkyrie_ik_test.cc
+++ b/drake/examples/Valkyrie/test/valkyrie_ik_test.cc
@@ -7,15 +7,13 @@
 
 #include <gtest/gtest.h>
 
-// Includes for IK solver.
-#include "drake/multibody/ik_options.h"
-#include "drake/multibody/rigid_body_ik.h"
-#include "drake/multibody/constraint/rigid_body_constraint.h"
-
 #include "drake/common/drake_path.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/multibody/constraint/rigid_body_constraint.h"
+#include "drake/multibody/ik_options.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_ik.h"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/analysis/simulator.h"

--- a/drake/examples/Valkyrie/valkyrie_pd_ff_controller.cc
+++ b/drake/examples/Valkyrie/valkyrie_pd_ff_controller.cc
@@ -1,23 +1,24 @@
+#include "drake/examples/Valkyrie/valkyrie_pd_ff_controller.h"
+
 #include <cmath>
 #include <iostream>
 #include <memory>
 #include <string>
 
+#include "lcmtypes/bot_core/atlas_command_t.hpp"
+#include "lcmtypes/bot_core/robot_state_t.hpp"
+
 #include "drake/common/drake_path.h"
 #include "drake/examples/Valkyrie/robot_state_decoder.h"
 #include "drake/examples/Valkyrie/valkyrie_constants.h"
-#include "drake/examples/Valkyrie/valkyrie_pd_ff_controller.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/kinematics_cache.h"
 #include "drake/multibody/parsers/urdf_parser.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/util/drakeUtil.h"
-
-#include "lcmtypes/bot_core/atlas_command_t.hpp"
-#include "lcmtypes/bot_core/robot_state_t.hpp"
 
 namespace drake {
 using lcm::DrakeLcm;

--- a/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
+++ b/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
@@ -5,6 +5,8 @@
 
 #include "lcmtypes/bot_core/atlas_command_t.hpp"
 
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {

--- a/drake/examples/Valkyrie/valkyrie_simulation.cc
+++ b/drake/examples/Valkyrie/valkyrie_simulation.cc
@@ -1,5 +1,8 @@
 #include <memory>
 
+#include "lcmtypes/bot_core/atlas_command_t.hpp"
+#include "lcmtypes/bot_core/robot_state_t.hpp"
+
 #include "drake/common/drake_path.h"
 #include "drake/common/text_logging.h"
 #include "drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h"
@@ -21,9 +24,6 @@
 #include "drake/systems/lcm/lcmt_drake_signal_translator.h"
 #include "drake/systems/primitives/constant_vector_source.h"
 #include "drake/systems/primitives/pass_through.h"
-
-#include "lcmtypes/bot_core/atlas_command_t.hpp"
-#include "lcmtypes/bot_core/robot_state_t.hpp"
 
 namespace drake {
 namespace systems {

--- a/drake/examples/ZMP/test/zmp_planner_test.cc
+++ b/drake/examples/ZMP/test/zmp_planner_test.cc
@@ -1,9 +1,9 @@
-#include "drake/common/eigen_matrix_compare.h"
-#include "drake/examples/ZMP/zmp_test_util.h"
-
 #include "drake/systems/controllers/zmp_planner.h"
 
 #include <gtest/gtest.h>
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/examples/ZMP/zmp_test_util.h"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/ZMP/zmp_example.cc
+++ b/drake/examples/ZMP/zmp_example.cc
@@ -2,7 +2,6 @@
 #include <thread>
 
 #include "drake/examples/ZMP/zmp_test_util.h"
-
 #include "drake/lcm/lcm_call_matlab.h"
 
 void PlotResults(const drake::examples::zmp::ZMPTestTraj& traj) {

--- a/drake/examples/ZMP/zmp_test_util.h
+++ b/drake/examples/ZMP/zmp_test_util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+
 #include "drake/systems/controllers/zmp_planner.h"
 
 namespace drake {

--- a/drake/systems/controllers/InstantaneousQPController.h
+++ b/drake/systems/controllers/InstantaneousQPController.h
@@ -5,13 +5,13 @@
 #include <unordered_map>
 #include <utility>
 
-#include "QPCommon.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_stl_types.h"
-#include "drake/solvers/gurobi_qp.h"
 #include "drake/lcmt_qp_controller_input.hpp"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/solvers/gurobi_qp.h"
+#include "drake/systems/controllers/QPCommon.h"
 
 #define INSTQP_USE_FASTQP 1
 #define INSTQP_GUROBI_OUTPUTFLAG 0

--- a/drake/systems/controllers/QPCommon.h
+++ b/drake/systems/controllers/QPCommon.h
@@ -10,10 +10,10 @@
 #include <Eigen/Core>
 
 #include "drake/common/eigen_stl_types.h"
-#include "drake/systems/controllers/controlUtil.h"
 #include "drake/multibody/force_torque_measurement.h"
-#include "drake/multibody/rigid_body_tree.h"
 #include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/controllers/controlUtil.h"
 #include "drake/systems/robotInterfaces/Side.h"
 #include "drake/util/drakeUtil.h"
 

--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -4,10 +4,10 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/adder.h"
+#include "drake/systems/primitives/demultiplexer.h"
 #include "drake/systems/primitives/gain.h"
 #include "drake/systems/primitives/integrator.h"
 #include "drake/systems/primitives/pass_through.h"
-#include "drake/systems/primitives/demultiplexer.h"
 
 using std::make_unique;
 

--- a/drake/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/drake/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -3,9 +3,9 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <unsupported/Eigen/AutoDiff>
 
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"

--- a/drake/systems/controllers/test/inverse_dynamics_test.cc
+++ b/drake/systems/controllers/test/inverse_dynamics_test.cc
@@ -3,9 +3,9 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <unsupported/Eigen/AutoDiff>
 
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"

--- a/drake/systems/controllers/test/pid_controller_test.cc
+++ b/drake/systems/controllers/test/pid_controller_test.cc
@@ -2,11 +2,11 @@
 
 #include <memory>
 
+#include <gtest/gtest.h>
+
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/system_input.h"
-
-#include <gtest/gtest.h>
 
 using std::make_unique;
 

--- a/drake/systems/controllers/zmp_planner.cc
+++ b/drake/systems/controllers/zmp_planner.cc
@@ -1,7 +1,8 @@
 #include "drake/systems/controllers/zmp_planner.h"
 
-#include <unsupported/Eigen/MatrixFunctions>
 #include <vector>
+
+#include <unsupported/Eigen/MatrixFunctions>
 
 #include "drake/common/text_logging.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"

--- a/drake/systems/robotInterfaces/QPLocomotionPlan.h
+++ b/drake/systems/robotInterfaces/QPLocomotionPlan.h
@@ -6,7 +6,6 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-
 #include <lcm/lcm-cpp.hpp>
 
 #include "drake/common/trajectories/exponential_plus_piecewise_polynomial.h"


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/systems/{controllers,robotInterfaces}` and `drake/examples/{QPInverseDynamicsForHumanoids,Valkyrie,ZMP}` to obey `cppguide` and `code_style_guide`.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5556)
<!-- Reviewable:end -->
