### PR TITLE
clang-format-includes on Acrobot,Pendulum,Quadrotor

### DIFF
--- a/drake/examples/Acrobot/acrobot_lcm_msg_handler.h
+++ b/drake/examples/Acrobot/acrobot_lcm_msg_handler.h
@@ -6,11 +6,10 @@
 #include <string>
 #include <thread>
 
-#include "drake/lcmt_acrobot_u.hpp"
-#include "drake/lcmt_acrobot_x.hpp"
-
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
+#include "drake/lcmt_acrobot_u.hpp"
+#include "drake/lcmt_acrobot_x.hpp"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/Acrobot/acrobot_plant_w_lcm.cc
+++ b/drake/examples/Acrobot/acrobot_plant_w_lcm.cc
@@ -9,17 +9,17 @@
  * LcmPublisherSystem
  *
  */
+#include "drake/examples/Acrobot/acrobot_plant.h"
+
 #include <memory>
 
 #include <gflags/gflags.h>
 
+#include "drake/common/drake_path.h"
 #include "drake/examples/Acrobot/acrobot_lcm.h"
-#include "drake/examples/Acrobot/acrobot_plant.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_acrobot_u.hpp"
 #include "drake/lcmt_acrobot_x.hpp"
-
-#include "drake/common/drake_path.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"

--- a/drake/examples/Acrobot/acrobot_run_swing_up.cc
+++ b/drake/examples/Acrobot/acrobot_run_swing_up.cc
@@ -12,10 +12,9 @@
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/controllers/linear_quadratic_regulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-
-#include "drake/systems/controllers/linear_quadratic_regulator.h"
 #include "drake/systems/primitives/linear_system.h"
 
 namespace drake {

--- a/drake/examples/Acrobot/acrobot_spong_controller_w_lcm.cc
+++ b/drake/examples/Acrobot/acrobot_spong_controller_w_lcm.cc
@@ -9,16 +9,15 @@
  * LcmPublisherSystem
  *
  */
+#include "drake/examples/Acrobot/acrobot_spong_controller.h"
 
 #include <memory>
 
+#include "drake/common/drake_path.h"
 #include "drake/examples/Acrobot/acrobot_lcm.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_acrobot_u.hpp"
 #include "drake/lcmt_acrobot_x.hpp"
-
-#include "drake/common/drake_path.h"
-#include "drake/examples/Acrobot/acrobot_spong_controller.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"

--- a/drake/examples/Acrobot/acrobot_swing_up.cc
+++ b/drake/examples/Acrobot/acrobot_swing_up.cc
@@ -4,6 +4,7 @@
 #include "drake/examples/Acrobot/acrobot_swing_up.h"
 
 #include <cmath>
+
 #include <Eigen/Core>
 
 #include "drake/common/drake_assert.h"

--- a/drake/examples/Pendulum/pendulum_plant.cc
+++ b/drake/examples/Pendulum/pendulum_plant.cc
@@ -1,7 +1,7 @@
 #include "drake/examples/Pendulum/pendulum_plant.h"
 
-#include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/eigen_autodiff_types.h"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/Pendulum/pendulum_run_energy_shaping.cc
+++ b/drake/examples/Pendulum/pendulum_run_energy_shaping.cc
@@ -5,13 +5,13 @@
 #include "drake/common/drake_path.h"
 #include "drake/examples/Pendulum/pendulum_plant.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/multibody/joints/floating_base_types.h"
-#include "drake/multibody/parsers/urdf_parser.h"
-#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/Pendulum/pendulum_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_swing_up.cc
@@ -1,3 +1,5 @@
+#include "drake/examples/Pendulum/pendulum_swing_up.h"
+
 #include <cmath>
 
 #include <Eigen/Core>
@@ -6,7 +8,6 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/examples/Pendulum/gen/pendulum_state_vector.h"
-#include "drake/examples/Pendulum/pendulum_swing_up.h"
 #include "drake/examples/Pendulum/pendulum_plant.h"
 #include "drake/solvers/function.h"
 #include "drake/systems/trajectory_optimization/direct_collocation.h"

--- a/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_dynamic_constraint_test.cc
@@ -1,6 +1,4 @@
-
 #include <cmath>
-
 #include <memory>
 
 #include <gtest/gtest.h>

--- a/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
@@ -5,8 +5,8 @@
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
-#include "drake/examples/Pendulum/pendulum_swing_up.h"
 #include "drake/examples/Pendulum/pendulum_plant.h"
+#include "drake/examples/Pendulum/pendulum_swing_up.h"
 
 using drake::solvers::SolutionResult;
 

--- a/drake/examples/Quadrotor/quadrotor_plant.h
+++ b/drake/examples/Quadrotor/quadrotor_plant.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <Eigen/Core>
 #include <memory>
+
+#include <Eigen/Core>
 
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_system.h"

--- a/drake/examples/Quadrotor/run_quadrotor_lqr.cc
+++ b/drake/examples/Quadrotor/run_quadrotor_lqr.cc
@@ -8,9 +8,9 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_path.h"
+#include "drake/common/is_approx_equal_abstol.h"
 #include "drake/examples/Quadrotor/quadrotor_plant.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/common/is_approx_equal_abstol.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/examples/{Acrobot,Pendulum,Quadrotor}` to obey `cppguide` and `code_style_guide`.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5557)
<!-- Reviewable:end -->
