### PR TITLE
clang-format-includes on sensors

### DIFF
--- a/drake/systems/sensors/rgbd_camera.cc
+++ b/drake/systems/sensors/rgbd_camera.cc
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <string>
 
+#include <Eigen/Dense>
 #include <vtkActor.h>
 #include <vtkCamera.h>
 #include <vtkCubeSource.h>
@@ -13,19 +14,18 @@
 #include <vtkImageShiftScale.h>
 #include <vtkNew.h>
 #include <vtkOBJReader.h>
+#include <vtkPNGReader.h>
 #include <vtkPlaneSource.h>
 #include <vtkPolyData.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkProperty.h>
-#include <vtkPNGReader.h>
-#include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
 #include <vtkSphereSource.h>
 #include <vtkTransform.h>
 #include <vtkTransformPolyDataFilter.h>
 #include <vtkWindowToImageFilter.h>
-#include <Eigen/Dense>
 
 #include "drake/math/roll_pitch_yaw_using_quaternion.h"
 #include "drake/systems/rendering/pose_vector.h"

--- a/drake/systems/sensors/test/accelerometer_test/accelerometer_example_diagram.h
+++ b/drake/systems/sensors/test/accelerometer_test/accelerometer_example_diagram.h
@@ -12,7 +12,6 @@
 #include "drake/systems/sensors/test/accelerometer_test/accelerometer_test_logger.h"
 #include "drake/systems/sensors/test/accelerometer_test/accelerometer_xdot_hack.h"
 
-
 namespace drake {
 namespace systems {
 namespace sensors {

--- a/drake/systems/sensors/test/rgbd_camera_test.cc
+++ b/drake/systems/sensors/test/rgbd_camera_test.cc
@@ -4,8 +4,8 @@
 #include <functional>
 #include <stdexcept>
 
-#include <gtest/gtest.h>
 #include <Eigen/Dense>
+#include <gtest/gtest.h>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_path.h"
@@ -17,8 +17,8 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/sensors/image.h"
 #include "drake/systems/rendering/pose_vector.h"
+#include "drake/systems/sensors/image.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/sensors/test/vtk_util_test.cc
+++ b/drake/systems/sensors/test/vtk_util_test.cc
@@ -3,11 +3,11 @@
 #include <cmath>
 #include <limits>
 
+#include <Eigen/Dense>
 #include <gtest/gtest.h>
 #include <vtkCellData.h>
 #include <vtkPlaneSource.h>
 #include <vtkSmartPointer.h>
-#include <Eigen/Dense>
 
 namespace drake {
 namespace systems {

--- a/drake/systems/sensors/vtk_util.cc
+++ b/drake/systems/sensors/vtk_util.cc
@@ -1,10 +1,10 @@
 #include "drake/systems/sensors/vtk_util.h"
 
+#include <Eigen/Dense>
 #include <vtkNew.h>
 #include <vtkPlaneSource.h>
 #include <vtkSmartPointer.h>
 #include <vtkTransform.h>
-#include <Eigen/Dense>
 
 namespace drake {
 namespace systems {

--- a/drake/systems/sensors/vtk_util.h
+++ b/drake/systems/sensors/vtk_util.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <Eigen/Dense>
 #include <vtkPlaneSource.h>
 #include <vtkSmartPointer.h>
 #include <vtkTransform.h>
-#include <Eigen/Dense>
 
 #include "drake/common/drake_copyable.h"
 


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `drake/systems/sensors` to obey `cppguide` and `code_style_guide`.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5558)
<!-- Reviewable:end -->
