### PR TITLE
clang-format-includes on ros

### DIFF
--- a/ros/drake_ros_common_test/test/parameter_server_test.cc
+++ b/ros/drake_ros_common_test/test/parameter_server_test.cc
@@ -1,8 +1,7 @@
-#include <gtest/gtest.h>
-
-#include "ros/ros.h"
-
 #include "drake/ros/parameter_server.h"
+
+#include <gtest/gtest.h>
+#include "ros/ros.h"
 
 namespace drake {
 namespace ros {

--- a/ros/drake_ros_systems/include/drake/systems/ros_tf_publisher.h
+++ b/ros/drake_ros_systems/include/drake/systems/ros_tf_publisher.h
@@ -8,12 +8,12 @@
 #include "ros/ros.h"
 #include "tf/transform_broadcaster.h"
 
-#include "drake/systems/framework/context.h"
-#include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/system_output.h"
 #include "drake/multibody/rigid_body.h"
 #include "drake/multibody/rigid_body_frame.h"
 #include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/system_output.h"
 
 namespace drake {
 namespace systems {

--- a/ros/drake_ros_systems/test/ros_clock_publisher_test.cc
+++ b/ros/drake_ros_systems/test/ros_clock_publisher_test.cc
@@ -1,8 +1,8 @@
 #include "drake/systems/ros_clock_publisher.h"
 
 #include <mutex>
-#include <gtest/gtest.h>
 
+#include <gtest/gtest.h>
 #include "ros/ros.h"
 #include "rosgraph_msgs/Clock.h"
 

--- a/ros/drake_ros_systems/test/ros_test.cc
+++ b/ros/drake_ros_systems/test/ros_test.cc
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "ros/ros.h"
+
+#include <gtest/gtest.h>
 
 namespace drake {
 namespace systems {

--- a/ros/drake_ros_systems/test/ros_tf_publisher_test.cc
+++ b/ros/drake_ros_systems/test/ros_tf_publisher_test.cc
@@ -1,8 +1,8 @@
 #include "drake/systems/ros_tf_publisher.h"
 
-#include <gtest/gtest.h>
 #include <memory>
 
+#include <gtest/gtest.h>
 #include "ros/ros.h"
 
 #include "drake/multibody/parsers/urdf_parser.h"


### PR DESCRIPTION
Changes (almost?) all `#include` statements in `ros` to obey `cppguide` and `code_style_guide`.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5559)
<!-- Reviewable:end -->
