### PR TITLE
clang-format-includes on math and etc.

### DIFF
--- a/drake/bindings/pybind11/pydrake_symbolic_types.h
+++ b/drake/bindings/pybind11/pydrake_symbolic_types.h
@@ -1,9 +1,9 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>
 
-#include "drake/common/symbolic_variable.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_formula.h"
+#include "drake/common/symbolic_variable.h"
 
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Variable);
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Expression);

--- a/drake/examples/bead_on_a_wire/bead_on_a_wire.h
+++ b/drake/examples/bead_on_a_wire/bead_on_a_wire.h
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 #include <unsupported/Eigen/AutoDiff>
+
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {

--- a/drake/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/drake/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -1,10 +1,11 @@
 #include "drake/examples/bouncing_ball/bouncing_ball.h"
-#include "drake/systems/analysis/simulator.h"
-#include "drake/systems/analysis/runge_kutta3_integrator.h"
 
 #include <memory>
 
 #include <gtest/gtest.h>
+
+#include "drake/systems/analysis/runge_kutta3_integrator.h"
+#include "drake/systems/analysis/simulator.h"
 
 namespace drake {
 namespace bouncing_ball {

--- a/drake/examples/rod2d/rod2d-inl.h
+++ b/drake/examples/rod2d/rod2d-inl.h
@@ -10,8 +10,8 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/systems/framework/basic_vector.h"

--- a/drake/lcm/lcm_receive_thread.cc
+++ b/drake/lcm/lcm_receive_thread.cc
@@ -1,8 +1,8 @@
 #include "drake/lcm/lcm_receive_thread.h"
 
-#include <iostream>
-
 #include <sys/select.h>
+
+#include <iostream>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"

--- a/drake/lcm/test/lcm_call_matlab_test.cc
+++ b/drake/lcm/test/lcm_call_matlab_test.cc
@@ -1,8 +1,8 @@
+#include "drake/lcm/lcm_call_matlab.h"
+
 #include <cmath>
 
 #include <gtest/gtest.h>
-
-#include "drake/lcm/lcm_call_matlab.h"
 
 // Note: Unfortunately these really only test whether the code compiles and
 // runs... the actual output must currently be verified by human inspection in

--- a/drake/math/discrete_algebraic_riccati_equation.h
+++ b/drake/math/discrete_algebraic_riccati_equation.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <Eigen/Dense>
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
+
+#include <Eigen/Dense>
 
 namespace drake {
 namespace math {

--- a/drake/math/matrix_util.h
+++ b/drake/math/matrix_util.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <Eigen/Dense>
-
 #include <cmath>
 #include <functional>
+
+#include <Eigen/Dense>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"

--- a/drake/math/roll_pitch_yaw.h
+++ b/drake/math/roll_pitch_yaw.h
@@ -1,3 +1,4 @@
 #pragma once
-#include "drake/math/roll_pitch_yaw_using_quaternion.h"
+
 #include "drake/math/roll_pitch_yaw_not_using_quaternion.h"
+#include "drake/math/roll_pitch_yaw_using_quaternion.h"

--- a/drake/math/test/autodiff_test.cc
+++ b/drake/math/test/autodiff_test.cc
@@ -1,9 +1,8 @@
 #include "drake/math/autodiff.h"
 
 #include <Eigen/Dense>
-#include <unsupported/Eigen/AutoDiff>
-
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"

--- a/drake/math/test/discrete_algebraic_riccati_equation_test.cc
+++ b/drake/math/test/discrete_algebraic_riccati_equation_test.cc
@@ -1,7 +1,10 @@
 #include "drake/math/discrete_algebraic_riccati_equation.h"
+
+#include <gtest/gtest.h>
+
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
-#include <gtest/gtest.h>
+
 using Eigen::MatrixXd;
 
 namespace drake {

--- a/drake/math/test/gradient_util_test.cc
+++ b/drake/math/test/gradient_util_test.cc
@@ -6,7 +6,6 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/math/test/jacobian_test.cc
+++ b/drake/math/test/jacobian_test.cc
@@ -1,9 +1,8 @@
 #include "drake/math/jacobian.h"
 
 #include <Eigen/Dense>
-#include <unsupported/Eigen/AutoDiff>
-
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"

--- a/drake/math/test/rotation_conversion_test.cc
+++ b/drake/math/test/rotation_conversion_test.cc
@@ -5,7 +5,6 @@
 #include <iostream>
 
 #include <Eigen/Dense>
-
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/math/test/rotation_matrix_test.cc
+++ b/drake/math/test/rotation_matrix_test.cc
@@ -1,13 +1,13 @@
+#include "drake/math/rotation_matrix.h"
+
 #include <cmath>
 #include <iostream>
 
 #include <Eigen/Dense>
-
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/roll_pitch_yaw.h"
-#include "drake/math/rotation_matrix.h"
 
 using Eigen::Vector3d;
 using Eigen::Matrix3d;

--- a/drake/math/test/saturate_test.cc
+++ b/drake/math/test/saturate_test.cc
@@ -1,9 +1,8 @@
 #include "drake/math/saturate.h"
 
 #include <Eigen/Dense>
-#include <unsupported/Eigen/AutoDiff>
-
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_creation_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_creation_test.cc
@@ -1,3 +1,5 @@
+#include "drake/multibody/rigid_body_tree.h"
+
 #include <iostream>
 
 #include <gtest/gtest.h>
@@ -10,7 +12,6 @@
 #include "drake/multibody/joints/revolute_joint.h"
 #include "drake/multibody/parsers/model_instance_id_table.h"
 #include "drake/multibody/parsers/urdf_parser.h"
-#include "drake/multibody/rigid_body_tree.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/rendering/test/frame_velocity_test.cc
+++ b/drake/systems/rendering/test/frame_velocity_test.cc
@@ -2,8 +2,8 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/eigen_types.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/rendering/test/pose_bundle_to_draw_message_test.cc
+++ b/drake/systems/rendering/test/pose_bundle_to_draw_message_test.cc
@@ -2,8 +2,8 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/systems/rendering/pose_bundle.h"
 #include "drake/lcmtypes/drake/lcmt_viewer_draw.hpp"
+#include "drake/systems/rendering/pose_bundle.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/trajectory_optimization/test/direct_collocation_constraint_test.cc
+++ b/drake/systems/trajectory_optimization/test/direct_collocation_constraint_test.cc
@@ -1,3 +1,4 @@
+#include "drake/systems/trajectory_optimization/direct_collocation_constraint.h"
 
 #include <cmath>
 
@@ -5,7 +6,6 @@
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
-#include "drake/systems/trajectory_optimization/direct_collocation_constraint.h"
 
 namespace drake {
 namespace systems {

--- a/drake/util/convexHull.h
+++ b/drake/util/convexHull.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+
 #include <Eigen/Dense>
 
 typedef double coord_t;   // coordinate type

--- a/drake/util/drakeAppUtil.h
+++ b/drake/util/drakeAppUtil.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <algorithm>
+#include <string>
 
 /*** getCommandLineOption
  * @brief Provides a platform-independent way to parse command line options

--- a/drake/util/drakeGeometryUtil.h
+++ b/drake/util/drakeGeometryUtil.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include <Eigen/Dense>
 #include <cmath>
 #include <cstring>
 #include <random>
+
+#include <Eigen/Dense>
 
 #include "drake/common/constants.h"
 #include "drake/common/drake_assert.h"

--- a/drake/util/lcmUtil.h
+++ b/drake/util/lcmUtil.h
@@ -3,7 +3,6 @@
 #include <iostream>
 
 #include <Eigen/Core>
-
 #include "bot_core/position_3d_t.hpp"
 #include "bot_core/quaternion_t.hpp"
 #include "bot_core/twist_t.hpp"

--- a/drake/util/yaml/yamlUtil.h
+++ b/drake/util/yaml/yamlUtil.h
@@ -6,8 +6,8 @@
 #include "yaml-cpp/yaml.h"
 
 #include "drake/common/eigen_stl_types.h"
-#include "drake/systems/controllers/QPCommon.h"
 #include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/controllers/QPCommon.h"
 
 YAML::Node applyDefaults(const YAML::Node& node,
                          const YAML::Node& default_node);


### PR DESCRIPTION
Changes (almost?) all `#include` statements in ...

- bead_on_a_wire
- bouncing_ball
- lcm
- math
- multibody
- pybind11
- rendering
- rod2d
- trajectory_optimization

... to obey `cppguide` and `code_style_guide`.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5560)
<!-- Reviewable:end -->
