### PR TITLE
Add more BUILD rules for Acrobot,Pendulum,Quadrotor

### DIFF
--- a/drake/examples/Acrobot/BUILD
+++ b/drake/examples/Acrobot/BUILD
@@ -4,6 +4,7 @@
 load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
+    "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_binary",
 )
@@ -11,7 +12,10 @@ load(
 filegroup(
     name = "models",
     srcs = glob([
-        "Acrobot.urdf",
+        "**/*.obj",
+        "**/*.sdf",
+        "**/*.urdf",
+        "**/*.xml",
     ]),
     visibility = ["//visibility:public"],
 )
@@ -38,6 +42,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "acrobot_lcm_msg_handler",
+    srcs = [],
+    hdrs = ["acrobot_lcm_msg_handler.h"],
+    deps = [
+        "//drake/lcm",
+        "//drake/lcmtypes:acrobot",
+    ],
+)
+
+drake_cc_library(
     name = "acrobot_swing_up",
     srcs = ["acrobot_swing_up.cc"],
     hdrs = ["acrobot_swing_up.h"],
@@ -53,10 +67,84 @@ drake_cc_library(
     hdrs = ["acrobot_plant.h"],
     deps = [
         ":acrobot_state_vector",
-        "//drake/multibody/parsers",
         "//drake/systems/controllers:linear_quadratic_regulator",
         "//drake/systems/framework",
         "//drake/systems/sensors:rotary_encoders",
+    ],
+)
+
+drake_cc_binary(
+    name = "acrobot_lcm_msg_generator",
+    srcs = ["acrobot_lcm_msg_generator.cpp"],
+    deps = [
+        ":acrobot_lcm_msg_handler",
+        "//drake/lcm",
+        "//drake/lcmtypes:acrobot",
+        "//drake/systems/analysis:simulator",
+    ],
+)
+
+drake_cc_binary(
+    name = "acrobot_run_lqr",
+    srcs = ["acrobot_run_lqr.cc"],
+    add_test_rule = 1,
+    data = [":models"],
+    test_rule_args = ["-realtime_factor=0.0"],
+    deps = [
+        ":acrobot_plant",
+        "//drake/common:drake_path",
+        "//drake/lcm",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:simulator",
+        "@gflags//:gflags",
+    ],
+)
+
+drake_cc_binary(
+    name = "acrobot_run_lqr_w_estimator",
+    testonly = 1,
+    srcs = ["acrobot_run_lqr_w_estimator.cc"],
+    add_test_rule = 1,
+    data = [":models"],
+    test_rule_args = ["-realtime_factor=0.0"],
+    deps = [
+        ":acrobot_plant",
+        "//drake/common:drake_path",
+        "//drake/lcm",
+        "//drake/lcm:lcm_call_matlab",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/estimators:kalman_filter",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/primitives:linear_system",
+        "//drake/systems/primitives:signal_logger",
+        "//drake/systems/sensors:rotary_encoders",
+        "@gflags//:gflags",
+    ],
+)
+
+drake_cc_binary(
+    name = "acrobot_run_passive",
+    srcs = ["acrobot_run_passive.cc"],
+    add_test_rule = 1,
+    data = [":models"],
+    test_rule_args = ["-realtime_factor=0.0"],
+    deps = [
+        ":acrobot_plant",
+        "//drake/common:drake_path",
+        "//drake/lcm",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "@gflags//:gflags",
     ],
 )
 
@@ -66,10 +154,13 @@ drake_cc_binary(
         "acrobot_run_swing_up.cc",
         "acrobot_spong_controller.h",
     ],
+    data = [":models"],
     deps = [
         ":acrobot_plant",
         "//drake/lcm",
-        "//drake/multibody/rigid_body_plant",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
         "//drake/systems/controllers:linear_quadratic_regulator",
@@ -80,11 +171,14 @@ drake_cc_binary(
 drake_cc_binary(
     name = "acrobot_run_swing_up_traj_optimization",
     srcs = ["acrobot_run_swing_up_traj_optimization.cc"],
+    data = [":models"],
     deps = [
         ":acrobot_plant",
         ":acrobot_swing_up",
         "//drake/lcm",
-        "//drake/multibody/rigid_body_plant",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
         "//drake/systems/controllers:linear_quadratic_regulator",
@@ -103,7 +197,7 @@ drake_cc_binary(
         ":acrobot_lcm",
         ":acrobot_plant",
         "//drake/lcm",
-        "//drake/multibody/rigid_body_plant",
+        "//drake/multibody:rigid_body_tree",
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
         "//drake/systems/controllers:linear_quadratic_regulator",
@@ -113,6 +207,7 @@ drake_cc_binary(
 drake_cc_binary(
     name = "acrobot_plant_w_lcm",
     srcs = ["acrobot_plant_w_lcm.cc"],
+    data = [":models"],
     deps = [
         ":acrobot_lcm",
         ":acrobot_plant",
@@ -123,6 +218,19 @@ drake_cc_binary(
         "//drake/systems/analysis",
         "//drake/systems/controllers:linear_quadratic_regulator",
         "@gflags//:gflags",
+    ],
+)
+
+drake_cc_googletest(
+    name = "acrobot_urdf_dynamics_test",
+    data = [":models"],
+    deps = [
+        ":acrobot_plant",
+        "//drake/common:drake_path",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant",
     ],
 )
 

--- a/drake/examples/Acrobot/acrobot_spong_controller_w_lcm.cc
+++ b/drake/examples/Acrobot/acrobot_spong_controller_w_lcm.cc
@@ -13,7 +13,6 @@
 
 #include <memory>
 
-#include "drake/common/drake_path.h"
 #include "drake/examples/Acrobot/acrobot_lcm.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_acrobot_u.hpp"

--- a/drake/examples/Pendulum/BUILD
+++ b/drake/examples/Pendulum/BUILD
@@ -34,6 +34,62 @@ drake_cc_library(
 )
 
 drake_cc_binary(
+    name = "pendulum_run_dynamics",
+    srcs = ["pendulum_run_dynamics.cc"],
+    add_test_rule = 1,
+    data = [":models"],
+    deps = [
+        ":pendulum_plant",
+        "//drake/common:drake_path",
+        "//drake/lcm",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/primitives:constant_vector_source",
+    ],
+)
+
+drake_cc_binary(
+    name = "pendulum_run_energy_shaping",
+    srcs = ["pendulum_run_energy_shaping.cc"],
+    add_test_rule = 1,
+    data = [":models"],
+    deps = [
+        ":pendulum_plant",
+        "//drake/common:drake_path",
+        "//drake/lcm",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_binary(
+    name = "pendulum_run_lqr",
+    srcs = ["pendulum_run_lqr.cc"],
+    add_test_rule = 1,
+    data = [":models"],
+    deps = [
+        ":pendulum_plant",
+        "//drake/common:drake_path",
+        "//drake/lcm",
+        "//drake/multibody/joints",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/controllers:linear_quadratic_regulator",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_binary(
     name = "pendulum_run_swing_up",
     srcs = ["pendulum_run_swing_up.cc"],
     add_test_rule = 1,
@@ -80,6 +136,14 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "pendulum_plant_test",
+    deps = [
+        ":pendulum_plant",
+        "//drake/common:autodiff",
+    ],
+)
+
+drake_cc_googletest(
     name = "pendulum_trajectory_optimization_test",
     deps = [
         ":pendulum_swing_up",
@@ -90,7 +154,10 @@ drake_cc_googletest(
 filegroup(
     name = "models",
     srcs = glob([
-        "Pendulum.urdf",
+        "**/*.obj",
+        "**/*.sdf",
+        "**/*.urdf",
+        "**/*.xml",
     ]),
     visibility = ["//visibility:public"],
 )

--- a/drake/examples/Quadrotor/BUILD
+++ b/drake/examples/Quadrotor/BUILD
@@ -1,0 +1,101 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:cpplint.bzl", "cpplint")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
+
+filegroup(
+    name = "models",
+    srcs = glob([
+        "**/*.obj",
+        "**/*.sdf",
+        "**/*.urdf",
+        "**/*.xml",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+drake_cc_library(
+    name = "quadrotor_plant",
+    srcs = ["quadrotor_plant.cc"],
+    hdrs = ["quadrotor_plant.h"],
+    deps = [
+        "//drake/math:geometric_transform",
+        "//drake/math:gradient",
+        "//drake/systems/controllers:linear_quadratic_regulator",
+        "//drake/systems/framework:leaf_system",
+        "//drake/systems/primitives:affine_system",
+        "//drake/util",
+    ],
+)
+
+drake_cc_binary(
+    name = "run_quadrotor_dynamics",
+    srcs = ["run_quadrotor_dynamics.cc"],
+    add_test_rule = 1,
+    data = [":models"],
+    test_rule_args = ["--duration=1.0"],
+    test_rule_size = "medium",
+    deps = [
+        ":quadrotor_plant",
+        "//drake/common:drake_path",
+        "//drake/lcm",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody:rigid_body_tree_construction",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/primitives:constant_vector_source",
+        "@gflags//:gflags",
+    ],
+)
+
+drake_cc_binary(
+    name = "run_quadrotor_lqr",
+    srcs = ["run_quadrotor_lqr.cc"],
+    add_test_rule = 1,
+    data = [":models"],
+    test_rule_args = [
+        "-simulation_trials=2",
+        "-simulation_real_time_rate=0.0",
+    ],
+    deps = [
+        ":quadrotor_plant",
+        "//drake/common:drake_path",
+        "//drake/common:is_approx_equal_abstol",
+        "//drake/lcm",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody:rigid_body_tree_construction",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "@gflags//:gflags",
+    ],
+)
+
+drake_cc_googletest(
+    name = "quadrotor_dynamics_test",
+    data = [":models"],
+    deps = [
+        ":quadrotor_plant",
+        "//drake/common:drake_path",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/multibody:rigid_body_tree_construction",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/primitives:constant_vector_source",
+    ],
+)
+
+cpplint()

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -72,6 +72,7 @@ def drake_cc_binary(
         testonly=0,
         add_test_rule=0,
         test_rule_args=[],
+        test_rule_size=None,
         **kwargs):
     """Creates a rule to declare a C++ binary.
 
@@ -79,10 +80,10 @@ def drake_cc_binary(
     This default could be revisited if binary size becomes a concern.
 
     If you wish to create a smoke-test demonstrating that your binary runs
-    without crashing, supply add_test_rule=1, and any necessary arguments
-    with test_rule_args=["-f", "--bar=42"]. Note that if you wish to do this,
-    you should consider suppressing that urge, and instead writing real tests.
-    The smoke-test will be named <name>_test.
+    without crashing, supply add_test_rule=1. Note that if you wish to do
+    this, you should consider suppressing that urge, and instead writing real
+    tests. The smoke-test will be named <name>_test. You may override cc_test
+    defaults using test_rule_args=["-f", "--bar=42"] or test_rule_size="baz".
     """
     native.cc_binary(
         name=name,
@@ -113,6 +114,7 @@ def drake_cc_binary(
             srcs=srcs,
             deps=deps,
             copts=copts,
+            size=test_rule_size,
             testonly=testonly,
             linkstatic=linkstatic,
             args=test_rule_args,


### PR DESCRIPTION
As of this PR, `tools/dev/compare_cmake_to_bazel.py | grep 'Only CMake' ` has no entries from these examples, and I _think_ I've gotten all of the tests added now also.  (There will be a separate comparison tool that checks those.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5563)
<!-- Reviewable:end -->
