### PR TITLE
Bazel build uses gtest-1.8.0 instead of gtest-1.7.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,8 +22,8 @@ pkg_config_package(
 github_archive(
     name = "gtest",
     repository = "google/googletest",
-    commit = "release-1.7.0",
-    sha256 = "f73a6546fdf9fce9ff93a5015e0333a8af3062a152a9ad6bcb772c96687016cc",
+    commit = "release-1.8.0",
+    sha256 = "58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8",
     build_file = "tools/gtest.BUILD",
 )
 

--- a/tools/gtest.BUILD
+++ b/tools/gtest.BUILD
@@ -3,12 +3,12 @@
 cc_library(
     name = "main",
     srcs = glob(
-        ["src/*.cc"],
-        exclude = ["src/gtest-all.cc"],
+        ["googletest/src/*.cc"],
+        exclude = ["googletest/src/gtest-all.cc"],
     ),
     hdrs = glob([
-        "include/**/*.h",
-        "src/*.h",
+        "googletest/include/**/*.h",
+        "googletest/src/*.h",
     ]),
     copts = ["-Wno-unused-const-variable"],
     defines = [
@@ -16,7 +16,10 @@ cc_library(
         "GTEST_DONT_DEFINE_SUCCEED=1",
         "GTEST_DONT_DEFINE_TEST=1",
     ],
-    includes = ["include"],
+    includes = [
+        "googletest",
+        "googletest/include",
+    ],
     linkopts = select({
         "@//tools:linux": ["-pthread"],
         "@//conditions:default": [],


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5569)
<!-- Reviewable:end -->
