### PR TITLE
Valgrind Memcheck Warnings

### DIFF
--- a/tools/valgrind-cmake.supp
+++ b/tools/valgrind-cmake.supp
@@ -135,3 +135,20 @@
     obj:/usr/local/bin/python
     ...
 }
+
+# This causes "possibly lost" warnings for valgrind memchecks.
+# The cause of the error seems to be in the btAlignedAllocDefault function
+# in btAlignedAllocator.cpp file of the bullet3 library.  We believe that the function
+# may return a pointer not pointing at the head of the allocated memory, which
+# causes the "possibly lost" warnings. [ *((void **)(ret)-1) = (void *)(real); ]
+{
+    <bullet3-1>
+    Memcheck:Leak
+    match-leak-kinds: possible
+    fun:malloc
+    fun:_ZL14btAllocDefaultm
+    fun:_ZL21btAlignedAllocDefaultmi
+    fun:_Z22btAlignedAllocInternalmi
+    ...
+    fun:_ZN14DrakeCollision27BulletCollisionWorldWrapperC1Ev
+}

--- a/tools/valgrind-cmake.supp
+++ b/tools/valgrind-cmake.supp
@@ -136,7 +136,7 @@
     ...
 }
 
-# This causes "possibly lost" warnings for valgrind memchecks.
+# This suppresses "possibly lost" warnings for valgrind memchecks.
 # The cause of the error seems to be in the btAlignedAllocDefault function
 # in btAlignedAllocator.cpp file of the bullet3 library.  We believe that the function
 # may return a pointer not pointing at the head of the allocated memory, which
@@ -149,6 +149,4 @@
     fun:_ZL14btAllocDefaultm
     fun:_ZL21btAlignedAllocDefaultmi
     fun:_Z22btAlignedAllocInternalmi
-    ...
-    fun:_ZN14DrakeCollision27BulletCollisionWorldWrapperC1Ev
 }


### PR DESCRIPTION
This suppresses all the "possibly lost" valgrind warnings in the Xenial built  [ linux-xenial-gcc-nightly-memcheck-valgrind-open-source-drake]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5573)
<!-- Reviewable:end -->
