### PR TITLE
clang-format-includes on misc files

### DIFF
--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -3,8 +3,8 @@
 #include <type_traits>
 
 #include <Eigen/Dense>
-#include <unsupported/Eigen/AutoDiff>
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/cond.h"
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/common/test/extract_double_test.cc
+++ b/drake/common/test/extract_double_test.cc
@@ -3,8 +3,8 @@
 #include <stdexcept>
 
 #include <Eigen/Dense>
-#include <unsupported/Eigen/AutoDiff>
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 // A non-numeric ScalarType for testing.
 namespace { struct NonNumericScalar { }; }

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/joint_level_controller_system_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/joint_level_controller_system_test.cc
@@ -2,8 +2,8 @@
 
 #include <memory>
 
-#include "bot_core/atlas_command_t.hpp"
 #include <gtest/gtest.h>
+#include "bot_core/atlas_command_t.hpp"
 
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/examples/Valkyrie/test/robot_command_to_desired_effort_converter_test.cc
+++ b/drake/examples/Valkyrie/test/robot_command_to_desired_effort_converter_test.cc
@@ -1,7 +1,7 @@
 #include "drake/examples/Valkyrie/robot_command_to_desired_effort_converter.h"
 
-#include "lcmtypes/bot_core/atlas_command_t.hpp"
 #include <gtest/gtest.h>
+#include "lcmtypes/bot_core/atlas_command_t.hpp"
 
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"

--- a/drake/math/test/expmap_test.cc
+++ b/drake/math/test/expmap_test.cc
@@ -1,7 +1,7 @@
 #include "drake/math/expmap.h"
 
-#include <unsupported/Eigen/AutoDiff>
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"

--- a/drake/multibody/joints/test/joint_test.cc
+++ b/drake/multibody/joints/test/joint_test.cc
@@ -1,5 +1,6 @@
+#include <memory>
+
 #include <gtest/gtest.h>
-#include  <memory>
 
 #include <Eigen/Geometry>
 

--- a/drake/solvers/test/dreal_solver_test.cc
+++ b/drake/solvers/test/dreal_solver_test.cc
@@ -2,8 +2,8 @@
 
 #include <typeinfo>
 
-#include "dreal/dreal.h"
 #include <gtest/gtest.h>
+#include "dreal/dreal.h"
 
 #include "drake/solvers/mathematical_program.h"
 

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -5,8 +5,8 @@
 #include <functional>
 #include <map>
 
-#include <unsupported/Eigen/AutoDiff>
 #include <gtest/gtest.h>
+#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"


### PR DESCRIPTION
This concludes the last batch of `#include` statement fixes to obey `cppguide` and `code_style_guide`.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5577)
<!-- Reviewable:end -->
