### PR TITLE
Add clang-format-include suppressions

### DIFF
--- a/drake/automotive/dev/endless_road_oracle.cc
+++ b/drake/automotive/dev/endless_road_oracle.cc
@@ -1,5 +1,7 @@
+/* clang-format off */
 #include "drake/automotive/dev/endless_road_oracle.h"
 #include "drake/automotive/dev/endless_road_oracle-internal.h"
+/* clang-format on */
 
 #include <algorithm>
 #include <cmath>

--- a/drake/automotive/dev/test/endless_road_oracle_test.cc
+++ b/drake/automotive/dev/test/endless_road_oracle_test.cc
@@ -1,5 +1,7 @@
+/* clang-format off */
 #include "drake/automotive/dev/endless_road_oracle.h"
 #include "drake/automotive/dev/endless_road_oracle-internal.h"
+/* clang-format on */
 
 #include <memory>
 

--- a/drake/automotive/maliput/monolane/test/monolane_builder_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_builder_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/automotive/maliput/monolane/builder.h"
+/* clang-format on */
 
 #include <cmath>
 #include <iostream>

--- a/drake/common/nice_type_name.cc
+++ b/drake/common/nice_type_name.cc
@@ -17,8 +17,10 @@ using std::string;
 // __GNUG__ is defined both for gcc and clang. See:
 // https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html
 #if defined(__GNUG__)
+/* clang-format off */
 #include <cxxabi.h>
 #include <cstdlib>
+/* clang-format on */
 #endif
 
 namespace drake {

--- a/drake/common/test/decompose_polynomial_test.cc
+++ b/drake/common/test/decompose_polynomial_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/common/symbolic_expression.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/common/text_logging.h
+++ b/drake/common/text_logging.h
@@ -37,8 +37,10 @@ printed without any special handling.
 #define SPDLOG_DEBUG_ON 1
 #define SPDLOG_TRACE_ON 1
 #endif
+/* clang-format off */
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
+/* clang-format on */
 #endif
 
 #include "drake/common/drake_copyable.h"

--- a/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/drake/examples/Valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -1,5 +1,7 @@
+/* clang-format off */
 #include "drake/examples/Valkyrie/robot_state_encoder.h"
 #include "drake/examples/Valkyrie/robot_state_decoder.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/examples/bouncing_ball/bouncing_ball.cc
+++ b/drake/examples/bouncing_ball/bouncing_ball.cc
@@ -1,5 +1,7 @@
+/* clang-format off */
 // NOLINTNEXTLINE(build/include) False positive on inl file.
 #include "drake/examples/bouncing_ball/bouncing_ball-inl.h"
+/* clang-format on */
 
 #include "drake/common/eigen_autodiff_types.h"
 

--- a/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+/* clang-format on */
 
 #include <memory>
 

--- a/drake/multibody/rigid_body_plant/test/contact_force_formula_test.cc
+++ b/drake/multibody/rigid_body_plant/test/contact_force_formula_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+/* clang-format on */
 
 #include <memory>
 

--- a/drake/multibody/rigid_body_plant/test/contact_resultant_force_test.cc
+++ b/drake/multibody/rigid_body_plant/test/contact_resultant_force_test.cc
@@ -1,5 +1,7 @@
+/* clang-format off */
 #include "drake/multibody/rigid_body_plant/contact_force.h"
 #include "drake/multibody/rigid_body_plant/contact_resultant_force_calculator.h"
+/* clang-format on */
 
 #include <memory>
 

--- a/drake/multibody/shapes/test/face_query_test.cc
+++ b/drake/multibody/shapes/test/face_query_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/shapes/geometry.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/multibody/shapes/test/mesh_scaling_test.cc
+++ b/drake/multibody/shapes/test/mesh_scaling_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/shapes/geometry.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/multibody/shapes/test/mesh_triangulate_test.cc
+++ b/drake/multibody/shapes/test/mesh_triangulate_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/shapes/geometry.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/multibody/test/rigid_body_tree/anchored_geometry_test.cc
+++ b/drake/multibody/test/rigid_body_tree/anchored_geometry_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/multibody/test/rigid_body_tree/contact_points_generation_test.cc
+++ b/drake/multibody/test/rigid_body_tree/contact_points_generation_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <string>
 

--- a/drake/multibody/test/rigid_body_tree/point_collision_detection_test.cc
+++ b/drake/multibody/test/rigid_body_tree/point_collision_detection_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <vector>
 

--- a/drake/multibody/test/test_kinematics_cache_checks.cc
+++ b/drake/multibody/test/test_kinematics_cache_checks.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <cstdlib>
 #include <iostream>

--- a/drake/solvers/no_dreal.cc
+++ b/drake/solvers/no_dreal.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/solvers/dreal_solver.h"
+/* clang-format on */
 
 #include <stdexcept>
 

--- a/drake/solvers/no_gurobi.cc
+++ b/drake/solvers/no_gurobi.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/solvers/gurobi_solver.h"
+/* clang-format on */
 
 #include <stdexcept>
 

--- a/drake/solvers/no_ipopt.cc
+++ b/drake/solvers/no_ipopt.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/solvers/ipopt_solver.h"
+/* clang-format on */
 
 #include <stdexcept>
 

--- a/drake/solvers/no_mosek.cc
+++ b/drake/solvers/no_mosek.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/solvers/mosek_solver.h"
+/* clang-format on */
 
 #include <stdexcept>
 

--- a/drake/solvers/no_nlopt.cc
+++ b/drake/solvers/no_nlopt.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/solvers/nlopt_solver.h"
+/* clang-format on */
 
 #include <stdexcept>
 

--- a/drake/solvers/no_snopt.cc
+++ b/drake/solvers/no_snopt.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/solvers/snopt_solver.h"
+/* clang-format on */
 
 #include <stdexcept>
 

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -1,5 +1,7 @@
+/* clang-format off */
 #include "drake/solvers/rotation_constraint.h"
 #include "drake/solvers/rotation_constraint_internal.h"
+/* clang-format on */
 
 #include <algorithm>
 #include <cmath>

--- a/drake/solvers/snopt_solver.cc
+++ b/drake/solvers/snopt_solver.cc
@@ -14,10 +14,10 @@ namespace snopt {
 // not work.
 // clang-format wants to switch the order of this inclusion, which causes
 // compiler failure.
-// clang-format off
+/* clang-format off */
 #include "snopt.hh"
 #include "snfilewrapper.hh"
-// clang-format on
+/* clang-format on */
 }
 
 // todo(sammy-tri) :  implement sparsity inside each cost/constraint

--- a/drake/solvers/test/linear_complementary_problem_test.cc
+++ b/drake/solvers/test/linear_complementary_problem_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off */
 #include "drake/solvers/mathematical_program.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -1,5 +1,7 @@
+/* clang-format off */
 #include "drake/solvers/rotation_constraint.h"
 #include "drake/solvers/rotation_constraint_internal.h"
+/* clang-format on */
 
 #include <random>
 


### PR DESCRIPTION
These are places where the author has artisinally crafted include statements that do not follow the style guide (most of the suppressions are needed because the component and its unit test have unrelated names).

Some of these suppressions can probably be removed with a bit of care and attention; rather than try to pay that down all up front, my proposal is to suppress them all now and then let authors roll back the comments on an item-by-item basis if they come up with fixes they like.

We use C style comment instead of C++ style because clang-format does not treat them identically(!) -- sometimes, the C++-style toggle comments are ignored when sorting includes.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5578)
<!-- Reviewable:end -->
