### PR TITLE
Change order of includes for generated translators

### DIFF
--- a/drake/automotive/gen/bicycle_car_parameters_translator.h
+++ b/drake/automotive/gen/bicycle_car_parameters_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/bicycle_car_parameters.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/bicycle_car_parameters.h"
 #include "drake/lcmt_bicycle_car_parameters_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/bicycle_car_state_translator.h
+++ b/drake/automotive/gen/bicycle_car_state_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/bicycle_car_state.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/bicycle_car_state.h"
 #include "drake/lcmt_bicycle_car_state_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/driving_command_translator.h
+++ b/drake/automotive/gen/driving_command_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/driving_command.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/driving_command.h"
 #include "drake/lcmt_driving_command_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/endless_road_car_config_translator.h
+++ b/drake/automotive/gen/endless_road_car_config_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/endless_road_car_config.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/endless_road_car_config.h"
 #include "drake/lcmt_endless_road_car_config_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/endless_road_car_state_translator.h
+++ b/drake/automotive/gen/endless_road_car_state_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/endless_road_car_state.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/endless_road_car_state.h"
 #include "drake/lcmt_endless_road_car_state_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/endless_road_oracle_output_translator.h
+++ b/drake/automotive/gen/endless_road_oracle_output_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/endless_road_oracle_output.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/endless_road_oracle_output.h"
 #include "drake/lcmt_endless_road_oracle_output_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/euler_floating_joint_state_translator.h
+++ b/drake/automotive/gen/euler_floating_joint_state_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/euler_floating_joint_state.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/euler_floating_joint_state.h"
 #include "drake/lcmt_euler_floating_joint_state_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/maliput_railcar_config_translator.h
+++ b/drake/automotive/gen/maliput_railcar_config_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/maliput_railcar_config.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/maliput_railcar_config.h"
 #include "drake/lcmt_maliput_railcar_config_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/maliput_railcar_state_translator.h
+++ b/drake/automotive/gen/maliput_railcar_state_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/maliput_railcar_state.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/maliput_railcar_state.h"
 #include "drake/lcmt_maliput_railcar_state_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/simple_car_config_translator.h
+++ b/drake/automotive/gen/simple_car_config_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/simple_car_config.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/simple_car_config.h"
 #include "drake/lcmt_simple_car_config_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/automotive/gen/simple_car_state_translator.h
+++ b/drake/automotive/gen/simple_car_state_translator.h
@@ -3,10 +3,11 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/automotive/gen/simple_car_state.h"
+
 #include <memory>
 #include <vector>
 
-#include "drake/automotive/gen/simple_car_state.h"
 #include "drake/lcmt_simple_car_state_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 

--- a/drake/tools/lcm_vector_gen.py
+++ b/drake/tools/lcm_vector_gen.py
@@ -201,12 +201,13 @@ TRANSLATOR_HH_PREAMBLE = """
 
 %(generated_code_warning)s
 
+#include "%(relative_cxx_dir)s/%(snake)s.h"
+
 #include <memory>
 #include <vector>
 
-#include "%(relative_cxx_dir)s/%(snake)s.h"
-#include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "drake/lcmt_%(snake)s_t.hpp"
+#include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
 %(opening_namespace)s
 """

--- a/drake/tools/test/gen/sample_translator.h
+++ b/drake/tools/test/gen/sample_translator.h
@@ -3,12 +3,13 @@
 // GENERATED FILE DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
+#include "drake/tools/test/gen/sample.h"
+
 #include <memory>
 #include <vector>
 
 #include "drake/lcmt_sample_t.hpp"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
-#include "drake/tools/test/gen/sample.h"
 
 namespace drake {
 namespace tools {


### PR DESCRIPTION
This is borderline `cppguide` on what a "related header" is, but the `clang-format` default regexp for identifying related headers chooses this as such, and I think its a fair choice.  Once we use `clang-format-4.0` we can configure the regexp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5590)
<!-- Reviewable:end -->
