### PR TITLE
Convert ccache_is_bad from a genrule to a Skylark rule.

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -84,13 +84,11 @@ sh_binary(
     visibility = ["//visibility:private"],
 )
 
-# This genrule will fail loudly if ccache is on the path.
-genrule(
+load("//tools:ccache.bzl", "ccache_is_bad")
+
+# This rule will fail loudly if ccache is on the path.
+ccache_is_bad(
     name = "ccache_is_bad",
-    srcs = [],
-    outs = ["ccache.txt"],
-    cmd = "$(location :complain_about_ccache) | tee $(@)",
-    tools = [":complain_about_ccache"],
     visibility = ["//visibility:private"],
 )
 
@@ -102,10 +100,10 @@ filegroup(
 
 # This filegroup contains the files on which every toolchain component should
 # always depend, regardless of platform. It is a useful place for the outputs
-# of genrules that check preconditions for the entire build.
+# of rules that check preconditions for the entire build.
 filegroup(
     name = "universal_toolchain_deps",
-    srcs = ["ccache.txt"],
+    srcs = ["ccache.txt"],  # ccache.txt is an output of :ccache_is_bad
     visibility = ["//visibility:private"],
 )
 

--- a/tools/ccache.bzl
+++ b/tools/ccache.bzl
@@ -1,0 +1,26 @@
+# -*- python -*-
+
+def impl(ctx):
+  ctx.action(
+      outputs=[ctx.outputs.out],
+      executable=ctx.executable._script,
+      arguments=[
+        ctx.outputs.out.path
+      ],
+      use_default_shell_env=True,
+  )
+
+ccache_is_bad = rule(
+    implementation=impl,
+    outputs={
+      "out": "ccache.txt",
+    },
+    attrs={
+        "_script": attr.label(
+            default=Label("//tools:complain_about_ccache.sh"),
+            allow_single_file=True,
+            executable=True,
+            cfg="host",
+        ),
+    }
+)

--- a/tools/complain_about_ccache.sh
+++ b/tools/complain_about_ccache.sh
@@ -10,21 +10,26 @@
 # present on the path in an unconventional directory.
 #
 # TODO(david-german-tri, soonho-tri): Can we detect ccache more robustly?
+touch "$1"
 echo $PATH | egrep "/ccache([:/]|$)" > /dev/null
 if [ $? -eq 0 ]
 then
-  echo ""
-  echo "ccache appears on your PATH, but Bazel cannot interoperate with ccache."
-  echo "Please remove ccache from your PATH, then do the following to reassure "
-  echo "Bazel that ccache is really gone: "
-  echo ""
-  # TODO(david-german-tri): Remove the kill step once we have updated to a Bazel
-  # release that includes the fix for bazelbuild/bazel#1143.
-  echo "  kill \`bazel info server_pid\` && bazel clean"
-  echo ""
-  echo "Observed PATH: "$PATH
-  echo ""
+  echo "" > "$1"
+  echo "ccache is on your PATH, but Bazel cannot operate with ccache." >> "$1"
+  echo "Please remove ccache from your PATH, then do the following to " >> "$1"
+  echo "reassure Bazel that ccache is really gone: " >> "$1"
+  echo "" >> "$1"
+  # TODO(david-german-tri): Remove the kill step once we have updated to Bazel
+  # 0.4.5 and added --action_env=PATH to our bazelrc. See bazelbuild/bazel#1143.
+  echo "  kill \`bazel info server_pid\` && bazel clean" >> "$1"
+  echo "" >> "$1"
+  echo "Observed PATH: "$PATH >> "$1"
+  echo "" >> "$1"
+  cat "$1"
   exit 1
 else
+  echo "ccache is not on your path. Great!" > "$1"
+  echo "Observed PATH: "$PATH >> "$1"
+  echo "" >> "$1"
   exit 0
 fi


### PR DESCRIPTION
Works around https://github.com/bazelbuild/bazel/issues/2691.  On Ubuntu 14.04, I've tested that it (a) still detects `ccache` in the path with Bazel 0.4.4 and (b) builds successfully with Bazel 0.4.5 when `ccache` is not in the path.

@soonho-tri for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5595)
<!-- Reviewable:end -->
