### PR TITLE
Removes start time from MaliputRailcar.

### DIFF
--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -47,10 +47,8 @@ template <typename T> constexpr T MaliputRailcar<T>::kDefaultMaxSpeed;
 template <typename T> constexpr T MaliputRailcar<T>::kDefaultVelocityLimitKp;
 
 template <typename T>
-MaliputRailcar<T>::MaliputRailcar(const LaneDirection& initial_lane_direction,
-    double start_time)
-    : start_time_(start_time),
-      initial_lane_direction_(initial_lane_direction) {
+MaliputRailcar<T>::MaliputRailcar(const LaneDirection& initial_lane_direction)
+    : initial_lane_direction_(initial_lane_direction) {
   command_input_port_index_ =
       this->DeclareInputPort(systems::kVectorValued, 1).get_index();
   state_output_port_index_ =
@@ -201,12 +199,7 @@ void MaliputRailcar<T>::DoCalcTimeDerivatives(
       dynamic_cast<MaliputRailcarState<T>*>(vector_derivatives);
   DRAKE_ASSERT(rates != nullptr);
 
-  if (context.get_time() < T(start_time_)) {
-    rates->set_s(T(0));
-    rates->set_speed(T(0));
-  } else {
-    ImplCalcTimeDerivatives(config, *state, lane_direction, *input, rates);
-  }
+  ImplCalcTimeDerivatives(config, *state, lane_direction, *input, rates);
 }
 
 template<typename T>

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -83,10 +83,7 @@ class MaliputRailcar : public systems::LeafSystem<T> {
   ///
   /// @param initial_lane_direction The initial lane and direction of travel.
   ///
-  /// @param start_time The time at which this vehicle starts moving.
-  ///
-  explicit MaliputRailcar(const LaneDirection& initial_lane_direction,
-                          double start_time = 0);
+  explicit MaliputRailcar(const LaneDirection& initial_lane_direction);
 
   // System<T> overrides.
   void DoCalcOutput(const systems::Context<T>& context,
@@ -162,7 +159,6 @@ class MaliputRailcar : public systems::LeafSystem<T> {
     const MaliputRailcarState<double>& state,
     MaliputRailcarState<double>* rates) const;
 
-  const double start_time_{};
   const LaneDirection initial_lane_direction_{};
   int command_input_port_index_{};
   int state_output_port_index_{};


### PR DESCRIPTION
Per https://github.com/RobotLocomotion/drake/pull/5552#issuecomment-288531943, the "start time" can better be modeled using the input acceleration command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5596)
<!-- Reviewable:end -->
