### PR TITLE
Adds end-of-road stop conditions to MaliputRailcar.

### DIFF
--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -2,11 +2,14 @@
 
 #include <cmath>
 #include <limits>
+#include <list>
 #include <memory>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/maliput/monolane/builder.h"
@@ -17,7 +20,9 @@
 
 namespace drake {
 
+using maliput::api::LaneEnd;
 using maliput::monolane::ArcOffset;
+using maliput::monolane::Connection;
 using maliput::monolane::Endpoint;
 using maliput::monolane::EndpointXy;
 using maliput::monolane::EndpointZ;
@@ -76,6 +81,87 @@ class MaliputRailcarTest : public ::testing::Test {
         with_s);
   }
 
+  // Creates a RoadGeometry based on monolane that consists of a straight lane
+  // that's then connected to a left turning lane. See #5552 for screenshots of
+  // the lane visualizations.
+  //
+  // @param with_s Whether the MaliputRailcar is traveling with or against the
+  // lane's s-curve.
+  //
+  // @param flip_curve_lane Whether to flip the curved lane's s-axis. This is
+  // useful for testing whether MaliputRailcar can traverse lanes that have
+  // opposing s-directions.
+  void InitializeTwoLaneStretchOfRoad(bool with_s = true,
+                                bool flip_curve_lane = false) {
+    maliput::monolane::Builder builder(
+        maliput::api::RBounds(-2, 2),   /* lane_bounds       */
+        maliput::api::RBounds(-4, 4),   /* driveable_bounds  */
+        0.01,                           /* linear tolerance  */
+        0.5 * M_PI / 180.0);            /* angular_tolerance */
+    const Connection* straight_lane_connection = builder.Connect(
+        "point.0",                                                /* id     */
+        Endpoint(EndpointXy(0, 0, 0), EndpointZ(0, 0, 0, 0)),     /* start  */
+        kStraightRoadLength,                                      /* length */
+        EndpointZ(0, 0, 0, 0));                                   /* z_end  */
+
+    if (flip_curve_lane) {
+      /*
+      When flip_curve_lane == true, the two lanes are configured as follows:
+
+                  -----
+                  | V |
+        ----------  | |
+        |>------>|<-- |
+        --------------
+
+      An OBJ rendering of this configuration is given in #5552.
+      */
+      const Connection* curved_lane_connection = builder.Connect(
+          "point.1",                                              /* id     */
+          Endpoint(                                               /* start  */
+              EndpointXy(kStraightRoadLength + kCurvedRoadRadius,
+                         kCurvedRoadRadius, 1.5 * M_PI),
+              EndpointZ(0, 0, 0, 0)),
+          ArcOffset(kCurvedRoadRadius, -kCurvedRoadTheta),        /* arc    */
+          EndpointZ(0, 0, 0, 0));                                 /* z_end  */
+      builder.SetDefaultBranch(
+          straight_lane_connection, LaneEnd::kFinish,             /* in_end */
+          curved_lane_connection, LaneEnd::kFinish);              /* out_end */
+      builder.SetDefaultBranch(
+          curved_lane_connection, LaneEnd::kFinish,               /* in_end */
+          straight_lane_connection, LaneEnd::kFinish);            /* out_end */
+    } else {
+      /*
+      When flip_curve_lane == false, the two lanes are configured as follows:
+
+                  -----
+                  | ^ |
+        ----------  | |
+        |>------>|>-- |
+        --------------
+
+      An OBJ rendering of this configuration is given in #5552.
+      */
+      const Connection* curved_lane_connection = builder.Connect(
+          "point.1",                                              /* id     */
+          Endpoint(EndpointXy(kStraightRoadLength, 0, 0),
+                   EndpointZ(0, 0, 0, 0)),  /* start  */
+          ArcOffset(kCurvedRoadRadius, kCurvedRoadTheta),         /* arc    */
+          EndpointZ(0, 0, 0, 0));                                 /* z_end  */
+      builder.SetDefaultBranch(
+          straight_lane_connection, LaneEnd::kFinish,             /* in_end */
+          curved_lane_connection, LaneEnd::kStart);               /* out_end */
+      builder.SetDefaultBranch(
+          curved_lane_connection, LaneEnd::kStart,                /* in_end */
+          straight_lane_connection, LaneEnd::kFinish);            /* out_end */
+    }
+
+    std::unique_ptr<const maliput::api::RoadGeometry> road =
+        builder.Build(maliput::api::RoadGeometryId(
+            {"RailcarTestTwoLaneStretchOfRoad"}));
+    Initialize(std::move(road), with_s);
+  }
+
   void Initialize(std::unique_ptr<const maliput::api::RoadGeometry> road,
       bool with_s) {
     road_ = std::move(road);
@@ -98,6 +184,10 @@ class MaliputRailcarTest : public ::testing::Test {
         context_->get_mutable_continuous_state_vector());
     if (result == nullptr) { throw std::bad_cast(); }
     return result;
+  }
+
+  LaneDirection& lane_direction() {
+    return context_->template get_mutable_abstract_state<LaneDirection>(0);
   }
 
   const MaliputRailcarState<double>* state_output() const {
@@ -128,6 +218,32 @@ class MaliputRailcarTest : public ::testing::Test {
     ASSERT_NE(railcar_config, nullptr);
     railcar_config->SetFrom(config);
   }
+
+  // Obtains the lanes created by the call to InitializeTwoLaneStretchOfRoad().
+  // Since a monolane::Builder was used to create the RoadGeometry, we don't
+  // know which Junction contains which lane and thus need to figure it out.
+  // This is done by checking the lengths of the two lanes. The straight lane
+  // has a length of kStraightRoadLength = 10 while the curved lane has a length
+  // of approximately 2 * PI * kCurvedRoadRadius /4 = 2 * PI * 10 / 4= 15.078.
+  std::pair<const maliput::api::Lane*, const maliput::api::Lane*>
+  GetStraightAndCurvedLanes() {
+    DRAKE_DEMAND(road_->num_junctions() == 2);
+    const maliput::api::Lane* lane_0 =
+        road_->junction(0)->segment(0)->lane(0);
+    const maliput::api::Lane* lane_1 =
+        road_->junction(1)->segment(0)->lane(0);
+
+    const maliput::api::Lane* straight_lane =
+        (lane_0->length() == kStraightRoadLength) ? lane_0 : lane_1;
+    const maliput::api::Lane* curved_lane =
+        (lane_0->length() == kStraightRoadLength) ? lane_1 : lane_0;
+
+    return std::make_pair(straight_lane, curved_lane);
+  }
+
+  // The length of the straight lane segment of the road when it is created
+  // using InitializeTwoLaneStretchOfRoad().
+  const double kStraightRoadLength{10};
 
   // The arc radius and theta of the road when it is created using
   // InitializeCurvedMonoLane().
@@ -655,6 +771,155 @@ TEST_F(MaliputRailcarTest, DoCalcNextUpdateTimeMonolaneAgainstS) {
   SetConfig(config);
   dut_->CalcNextUpdateTime(*context_, &actions);
   EXPECT_GT(actions.time, kZeroAccelerationTime);
+}
+
+// Tests the two-lane stretch of road.
+TEST_F(MaliputRailcarTest, TestTwoLaneStretchOfRoad) {
+    EXPECT_NO_FATAL_FAILURE(InitializeTwoLaneStretchOfRoad(
+        true /* with_s */, false /* flip_curve_lane */));
+    const maliput::api::Lane* straight_lane{};
+    const maliput::api::Lane* curved_lane{};
+    std::tie(straight_lane, curved_lane) = GetStraightAndCurvedLanes();
+
+    // Verifies that the end of the straight lane is connected to the start of
+    // the curved lane if it is not flipped.
+    std::unique_ptr<LaneEnd> straight_lane_start =
+        straight_lane->GetDefaultBranch(LaneEnd::kStart);
+    std::unique_ptr<LaneEnd> straight_lane_finish =
+        straight_lane->GetDefaultBranch(LaneEnd::kFinish);
+    std::unique_ptr<LaneEnd> curved_lane_start =
+        curved_lane->GetDefaultBranch(LaneEnd::kStart);
+    std::unique_ptr<LaneEnd> curved_lane_finish =
+        curved_lane->GetDefaultBranch(LaneEnd::kFinish);
+    EXPECT_EQ(straight_lane_start, nullptr);
+    ASSERT_NE(straight_lane_finish, nullptr);
+    EXPECT_EQ(straight_lane_finish->lane, curved_lane);
+    EXPECT_EQ(straight_lane_finish->end, LaneEnd::kStart);
+    ASSERT_NE(curved_lane_start, nullptr);
+    EXPECT_EQ(curved_lane_finish, nullptr);
+    EXPECT_EQ(curved_lane_start->lane, straight_lane);
+    EXPECT_EQ(curved_lane_start->end, LaneEnd::kFinish);
+
+    // Verifies that the end of the straight lane is connected to the end of the
+    // curved lane if it is flipped.
+    EXPECT_NO_FATAL_FAILURE(InitializeTwoLaneStretchOfRoad(
+        true /* with_s */, true /* flip_curve_lane */));
+    std::tie(straight_lane, curved_lane) = GetStraightAndCurvedLanes();
+    straight_lane_start = straight_lane->GetDefaultBranch(LaneEnd::kStart);
+    straight_lane_finish = straight_lane->GetDefaultBranch(LaneEnd::kFinish);
+    curved_lane_start = curved_lane->GetDefaultBranch(LaneEnd::kStart);
+    curved_lane_finish = curved_lane->GetDefaultBranch(LaneEnd::kFinish);
+    EXPECT_EQ(straight_lane_start, nullptr);
+    ASSERT_NE(straight_lane_finish, nullptr);
+    EXPECT_EQ(straight_lane_finish->lane, curved_lane);
+    EXPECT_EQ(straight_lane_finish->end, LaneEnd::kFinish);
+    ASSERT_NE(curved_lane_finish, nullptr);
+    EXPECT_EQ(curved_lane_start, nullptr);
+    EXPECT_EQ(curved_lane_finish->lane, straight_lane);
+    EXPECT_EQ(curved_lane_finish->end, LaneEnd::kFinish);
+}
+
+// Tests that MaliputRailcar will stop when it has reached the end of the road,
+// and will not stop otherwise.
+TEST_F(MaliputRailcarTest, TestStopConditions) {
+  EXPECT_NO_FATAL_FAILURE(InitializeTwoLaneStretchOfRoad(
+        true /* with_s */, false /* flip_curve_lane */));
+  const maliput::api::Lane* straight_lane{};
+  const maliput::api::Lane* curved_lane{};
+  std::tie(straight_lane, curved_lane) = GetStraightAndCurvedLanes();
+
+  const double kSpeed(10);
+
+  MaliputRailcarConfig<double> config;
+  config.set_r(1);
+  config.set_h(0);
+  config.set_initial_speed(kSpeed);
+  config.set_max_speed(30);
+  config.set_velocity_limit_kp(8);
+  SetConfig(config);
+
+  systems::DiscreteEvent<double> event;
+  event.action = systems::DiscreteEvent<double>::kUnrestrictedUpdateAction;
+
+  // Verifies that when the car is on the straight lane and is just before the
+  // lane, it does not stop if it is with s, but does stop if it is against s
+  // since there are no ongoing branches.
+  continuous_state()->set_s(-1e-10);
+  continuous_state()->set_speed(kSpeed);
+  lane_direction().lane = straight_lane;
+  lane_direction().with_s = true;
+  dut_->CalcUnrestrictedUpdate(
+      *context_, event, context_->get_mutable_state());
+  EXPECT_EQ(continuous_state()->speed(), kSpeed);
+  lane_direction().with_s = false;
+  dut_->CalcUnrestrictedUpdate(
+      *context_, event, context_->get_mutable_state());
+  EXPECT_EQ(continuous_state()->speed(), 0);
+
+  // Verifies that the car does not stop when it is on the straight lane and is
+  // (1) just past the lane's start, (2) in the middle of the lane, (3) just
+  // before the lane's end, or (4) just after the lane's end.
+  //
+  // The above should be true regardless of whether it is (1) traveling with or
+  // against s or (2) traveling left or right of the s axis.
+  for (const auto s : std::list<double>{1e-10,
+                                        straight_lane->length() / 2.0,
+                                        straight_lane->length() - 1e-10,
+                                        straight_lane->length() + 1e-10}) {
+    continuous_state()->set_s(s);
+    continuous_state()->set_speed(kSpeed);
+    lane_direction().lane = straight_lane;
+    for (const auto with_s : std::list<bool>{true, false}) {
+      lane_direction().with_s = with_s;
+      for (const auto r : std::list<double>{-1, 0, 1}) {
+        config.set_r(r);
+        SetConfig(config);
+        dut_->CalcUnrestrictedUpdate(
+            *context_, event, context_->get_mutable_state());
+        EXPECT_EQ(continuous_state()->speed(), kSpeed);
+      }
+    }
+  }
+
+  // Verifies that the car does not stop when it is on the curved lane and is
+  // (1) just before the lane's start, (2) just after the lane's start, (3) in
+  // the middle of the lane, or (4) just before the lane's end.
+  //
+  // The above should be true regardless of whether it is (1) traveling with or
+  // against s or (2) traveling left or right of the s axis.
+  for (const auto s : std::list<double>{-1e-10,
+                                        1e-10,
+                                        curved_lane->length() / 2.0,
+                                        curved_lane->length() - 1e-10}) {
+    continuous_state()->set_s(s);
+    continuous_state()->set_speed(kSpeed);
+    lane_direction().lane = curved_lane;
+    for (const auto with_s : std::list<bool>{true, false}) {
+      lane_direction().with_s = with_s;
+      for (const auto r : std::list<double>{-1, 0, 1}) {
+        config.set_r(r);
+        SetConfig(config);
+        dut_->CalcUnrestrictedUpdate(
+            *context_, event, context_->get_mutable_state());
+        EXPECT_EQ(continuous_state()->speed(), kSpeed);
+      }
+    }
+  }
+
+  // Verifies that when the car is on the curved lane and is just after the
+  // lane's end, it does not stop when it is traveling against s but stops
+  // when it is traveling with s since there are no ongoing branches.
+  continuous_state()->set_s(curved_lane->length() + 1e-10);
+  continuous_state()->set_speed(kSpeed);
+  lane_direction().lane = curved_lane;
+  lane_direction().with_s = false;
+  dut_->CalcUnrestrictedUpdate(
+      *context_, event, context_->get_mutable_state());
+  EXPECT_EQ(continuous_state()->speed(), kSpeed);
+  lane_direction().with_s = true;
+  dut_->CalcUnrestrictedUpdate(
+      *context_, event, context_->get_mutable_state());
+  EXPECT_EQ(continuous_state()->speed(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
This PR is based on https://github.com/RobotLocomotion/drake/pull/5552#issuecomment-288531943. `MaliputRailcar`'s speed is only zero'ed by `CalcUnrestrictedUpdate()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5600)
<!-- Reviewable:end -->
