### PR TITLE
Initial guess variables initialized to NaN and utilized in Gurobi Solver

### DIFF
--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -573,13 +573,14 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
     DRAKE_DEMAND(!error);
   }
 
-  for (int i=0; i<prog.initial_guess().rows(); i++){
-    if (!isnan(prog.initial_guess()(i))){
-      error = GRBsetdblattrelement(model, "Start", i, prog.initial_guess()(i));
+  for (int i = 0; i < prog.initial_guess().rows(); i++) {
+    if (!isnan(prog.initial_guess()(i))) {
+      error = GRBsetdblattrelement(model, "Start",
+                                   i, prog.initial_guess()(i));
       DRAKE_DEMAND(!error);
     }
   }
-  
+
   error = GRBoptimize(model);
 
   SolutionResult result = SolutionResult::kUnknownError;

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -568,12 +568,18 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
     DRAKE_DEMAND(!error);
   }
 
-
   for (const auto it : prog.GetSolverOptionsInt(SolverType::kGurobi)) {
     error = GRBsetintparam(model_env, it.first.c_str(), it.second);
     DRAKE_DEMAND(!error);
   }
 
+  for (int i=0; i<prog.initial_guess().rows(); i++){
+    if (!isnan(prog.initial_guess()(i))){
+      error = GRBsetdblattrelement(model, "Start", i, prog.initial_guess()(i));
+      DRAKE_DEMAND(!error);
+    }
+  }
+  
   error = GRBoptimize(model);
 
   SolutionResult result = SolutionResult::kUnknownError;

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -573,7 +573,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
     DRAKE_DEMAND(!error);
   }
 
-  for (size_t i = 0; i < prog.num_vars(); i++) {
+  for (int i = 0; i < static_cast<int>(prog.num_vars()); ++i) {
     if (!std::isnan(prog.initial_guess()(i))) {
       error = GRBsetdblattrelement(model, "Start",
                                    i, prog.initial_guess()(i));

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -573,7 +573,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
     DRAKE_DEMAND(!error);
   }
 
-  for (int i = 0; i < prog.initial_guess().rows(); i++) {
+  for (size_t i = 0; i < prog.num_vars(); i++) {
     if (!std::isnan(prog.initial_guess()(i))) {
       error = GRBsetdblattrelement(model, "Start",
                                    i, prog.initial_guess()(i));

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -574,7 +574,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   }
 
   for (int i = 0; i < prog.initial_guess().rows(); i++) {
-    if (!isnan(prog.initial_guess()(i))) {
+    if (!std::isnan(prog.initial_guess()(i))) {
       error = GRBsetdblattrelement(model, "Start",
                                    i, prog.initial_guess()(i));
       DRAKE_DEMAND(!error);

--- a/drake/solvers/ipopt_solver.cc
+++ b/drake/solvers/ipopt_solver.cc
@@ -266,7 +266,11 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
       const Eigen::VectorXd& initial_guess = problem_->initial_guess();
       DRAKE_ASSERT(initial_guess.size() == n);
       for (Index i = 0; i < n; i++) {
-        x[i] = initial_guess[i];
+        if (!std::isnan(initial_guess[i])) {
+          x[i] = initial_guess[i];
+        } else {
+          x[i] = 0.0;
+        }
       }
     }
 

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2384,7 +2384,8 @@ class MathematicalProgram {
 
     num_vars_ += num_new_vars;
     x_initial_guess_.conservativeResize(num_vars_);
-    x_initial_guess_.tail(num_new_vars).fill(std::numeric_limits<double>::quiet_NaN());
+    x_initial_guess_.tail(num_new_vars).fill(
+      std::numeric_limits<double>::quiet_NaN());
   }
 
   MatrixXDecisionVariable NewVariables(VarType type, int rows, int cols,

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2384,7 +2384,7 @@ class MathematicalProgram {
 
     num_vars_ += num_new_vars;
     x_initial_guess_.conservativeResize(num_vars_);
-    x_initial_guess_.tail(num_new_vars) = Eigen::VectorXd::Zero(num_new_vars);
+    x_initial_guess_.tail(num_new_vars).fill(std::numeric_limits<double>::quiet_NaN());
   }
 
   MatrixXDecisionVariable NewVariables(VarType type, int rows, int cols,

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -238,7 +238,8 @@ class MathematicalProgram {
   /**
    * Adds new variables to MathematicalProgram.
    * Appending new variables to an internal vector of any existing vars.
-   * The new variables are initialized to zero.
+   * The initial guess values for the new variables are set to NaN, to
+   * indicate that an initial guess has not been assigned.
    * Callers are expected to add costs
    * and/or constraints to have any effect during optimization.
    * Callers can also set the initial guess of the decision variables through
@@ -314,7 +315,8 @@ class MathematicalProgram {
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
-   * The new variables are initialized to zero.
+   * The initial guess values for the new variables are set to NaN, to
+   * indicate that an initial guess has not been assigned.
    * Callers are expected to add costs
    * and/or constraints to have any effect during optimization.
    * Callers can also set the initial guess of the decision variables through
@@ -352,7 +354,8 @@ class MathematicalProgram {
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
-   * The new variables are initialized to zero.
+   * The initial guess values for the new variables are set to NaN, to
+   * indicate that an initial guess has not been assigned.
    * Callers are expected to add costs
    * and/or constraints to have any effect during optimization.
    * Callers can also set the initial guess of the decision variables through
@@ -383,7 +386,8 @@ class MathematicalProgram {
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
-   * The new variables are initialized to zero.
+   * The initial guess values for the new variables are set to NaN, to
+   * indicate that an initial guess has not been assigned.
    * Callers are expected to add costs
    * and/or constraints to have any effect during optimization.
    * Callers can also set the initial guess of the decision variables through
@@ -420,7 +424,8 @@ class MathematicalProgram {
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
-   * The new variables are initialized to zero.
+   * The initial guess values for the new variables are set to NaN, to
+   * indicate that an initial guess has not been assigned.
    * Callers are expected to add costs
    * and/or constraints to have any effect during optimization.
    * Callers can also set the initial guess of the decision variables through
@@ -467,7 +472,8 @@ class MathematicalProgram {
   /**
    * Adds binary variables, appending them to an internal vector of any
    * existing vars.
-   * The new variables are initialized to zero.
+   * The initial guess values for the new variables are set to NaN, to
+   * indicate that an initial guess has not been assigned.
    * Callers are expected to add costs
    * and/or constraints to have any effect during optimization.
    * Callers can also set the initial guess of the decision variables through
@@ -551,7 +557,8 @@ class MathematicalProgram {
   /**
    * Adds binary variables, appending them to an internal vector of any
    * existing vars.
-   * The new variables are initialized to zero.
+   * The initial guess values for the new variables are set to NaN, to
+   * indicate that an initial guess has not been assigned.
    * Callers are expected to add costs
    * and/or constraints to have any effect during optimization.
    * Callers can also set the initial guess of the decision variables through
@@ -1912,6 +1919,8 @@ class MathematicalProgram {
 
   /**
    * Set the initial guess for the decision variables stored in @p var to be x0.
+   * Variables begin with a default initial guess of NaN to indicate that no
+   * guess is available.
    */
   template <typename DerivedA, typename DerivedB>
   void SetInitialGuess(const Eigen::MatrixBase<DerivedA>& decision_variable_mat,
@@ -1928,6 +1937,8 @@ class MathematicalProgram {
 
   /**
    * Set the intial guess for ALL decision variables.
+   * Note that variables begin with a default initial guess of NaN to indicate
+   * that no guess is available.
    * @param x0 A vector of appropriate size (num_vars() x 1).
    */
   template <typename Derived>

--- a/drake/solvers/nlopt_solver.cc
+++ b/drake/solvers/nlopt_solver.cc
@@ -304,7 +304,11 @@ SolutionResult NloptSolver::Solve(MathematicalProgram& prog) const {
   const Eigen::VectorXd& initial_guess = prog.initial_guess();
   std::vector<double> x(initial_guess.size());
   for (size_t i = 0; i < x.size(); i++) {
-    x[i] = initial_guess[i];
+    if (!std::isnan(initial_guess[i])) {
+      x[i] = initial_guess[i];
+    } else {
+      x[i] = 0.0;
+    }
   }
 
   std::vector<double> xlow(nx, -std::numeric_limits<double>::infinity());

--- a/drake/solvers/snopt_solver.cc
+++ b/drake/solvers/snopt_solver.cc
@@ -364,7 +364,11 @@ SolutionResult SnoptSolver::Solve(MathematicalProgram& prog) const {
   snopt::doublereal* xupp = d->xupp.data();
   const Eigen::VectorXd x_initial_guess = prog.initial_guess();
   for (int i = 0; i < nx; i++) {
-    x[i] = static_cast<snopt::doublereal>(x_initial_guess(i));
+    if (!std::isnan(x_initial_guess(i))) {
+      x[i] = static_cast<snopt::doublereal>(x_initial_guess(i));
+    } else {
+      x[i] = 0.0;
+    }
     xlow[i] = static_cast<snopt::doublereal>(
         -std::numeric_limits<double>::infinity());
     xupp[i] = static_cast<snopt::doublereal>(  // BR

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -86,10 +86,10 @@ GTEST_TEST(GurobiTest, TestInitialGuess) {
     prog.SetSolverOption(SolverType::kGurobi, "Presolve", 0);
     prog.SetSolverOption(SolverType::kGurobi, "Heuristics", 0.0);
 
-    double x_expected_to_test[] = {0.0, 1.0};
+    double x_expected0_to_test[] = {0.0, 1.0};
     for (int i = 0; i < 2; i++) {
       Eigen::VectorXd x_expected(1);
-      x_expected[0] = x_expected_to_test[i];
+      x_expected[0] = x_expected0_to_test[i];
       prog.SetInitialGuess(x, x_expected);
       SolutionResult result = solver.Solve(prog);
       EXPECT_EQ(result, SolutionResult::kSolutionFound);

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -72,18 +72,31 @@ GTEST_TEST(QPtest, TestUnitBallExample) {
 GTEST_TEST(GurobiTest, TestInitialGuess) {
   GurobiSolver solver;
   if (solver.available()) {
-    // Formulate a simple problem, supply an exactly-correct
-    // initial guess, and solve.
+    // Formulate a simple problem with multiple optimal
+    // solutions, and solve it twice with two different
+    // initial conditions. The resulting solutions should
+    // match the initial conditions supplied. Doing two
+    // solves from different initial positions ensures the
+    // test doesn't pass by chance.
     MathematicalProgram prog;
     auto x = prog.NewBinaryVariables<1>("x");
-    prog.AddLinearCost(-1.0 * Eigen::VectorXd::Ones(1), x);
-    Eigen::VectorXd x_expected = Eigen::VectorXd::Ones(1);
-    prog.SetInitialGuess(x, x_expected);
-    SolutionResult result = solver.Solve(prog);
-    EXPECT_EQ(result, SolutionResult::kSolutionFound);
-    const auto& x_value = prog.GetSolution(x);
-    EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1E-6,
-                                MatrixCompareType::absolute));
+    // Presolve and Heuristics would each independently solve
+    // this problem inside of the Gurobi solver, but without
+    // consulting the initial guess.
+    prog.SetSolverOption(SolverType::kGurobi, "Presolve", 0);
+    prog.SetSolverOption(SolverType::kGurobi, "Heuristics", 0.0);
+
+    double x_expected_to_test[] = {0.0, 1.0};
+    for (int i = 0; i < 2; i++) {
+      Eigen::VectorXd x_expected(1);
+      x_expected[0] = x_expected_to_test[i];
+      prog.SetInitialGuess(x, x_expected);
+      SolutionResult result = solver.Solve(prog);
+      EXPECT_EQ(result, SolutionResult::kSolutionFound);
+      const auto& x_value = prog.GetSolution(x);
+      EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1E-6,
+                                  MatrixCompareType::absolute));
+    }
   }
 }
 }  // namespace test


### PR DESCRIPTION
I switched the initialization of `x_initial_guess_` to `NaN` so it was clear which entries contained real guesses, and which entries contained no valid guess. I've also included the code to hand these variables off to Gurobi to chew on, and a small test checking that does a [relatively shallow] check of this functionality.

I've been using this in some of my mixed integer perception work, and it's been pretty useful! 

@hongkai-dai, probably of interest to you.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5605)
<!-- Reviewable:end -->
