### PR TITLE
Pull in the `fmt` string formatting library as a proper external dependency....

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -104,3 +104,6 @@
 [submodule "externals/pybind11"]
 	path = externals/pybind11
 	url = https://github.com/RobotLocomotion/pybind11
+[submodule "externals/fmt"]
+	path = externals/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,17 @@ drake_setup_options()
 # External projects in order of dependencies; 'trivial' ones first
 drake_add_external(avl PUBLIC CMAKE FORTRAN)
 drake_add_external(eigen PUBLIC CMAKE)
+drake_add_external(fmt PUBLIC CMAKE ALWAYS)
 drake_add_external(meshconverters PUBLIC CMAKE)
 drake_add_external(qt_property_browser CMAKE QT)
 drake_add_external(sedumi PUBLIC CMAKE MATLAB)
-drake_add_external(spdlog PUBLIC CMAKE)
 drake_add_external(spotless PUBLIC CMAKE MATLAB)
 drake_add_external(xfoil PUBLIC CMAKE FORTRAN)
 drake_add_external(yalmip PUBLIC CMAKE MATLAB)
+
+# spdlog
+drake_add_external(spdlog PUBLIC CMAKE
+  DEPENDS fmt)
 
 # bullet
 drake_add_external(bullet PUBLIC CMAKE
@@ -283,6 +287,7 @@ drake_add_external(drake LOCAL PUBLIC CMAKE ALWAYS MATLAB PYTHON VTK
     ccd
     eigen
     fcl
+    fmt
     gflags
     google_styleguide
     googletest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,6 +58,14 @@ github_archive(
     sha256 = "5166c036eacd625b86f725bfba356547e0bc497232649662c61cde7b1b423292",
 )
 
+github_archive(
+    name = "fmt",
+    repository = "fmtlib/fmt",
+    commit = "3.0.1",
+    build_file = "tools/fmt.BUILD",
+    sha256 = "dce62ab75a161dd4353a98364feb166d35e7eea382169d59d9ce842c49c55bad",
+)
+
 maven_jar(
     name = "net_sf_jchart2d_jchart2d",
     artifact = "net.sf.jchart2d:jchart2d:3.3.2",

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -135,6 +135,7 @@ macro(drake_find_packages)
   set_property(TARGET Eigen3::Eigen APPEND PROPERTY
     INTERFACE_COMPILE_DEFINITIONS EIGEN_MPL2_ONLY)  # Per #4065.
 
+  drake_find_package(fmt CONFIG REQUIRED)
   drake_find_package(gflags CONFIG REQUIRED)
 
   set(GTEST_DEFINITIONS

--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(drakeAutomotive
   drakeSystemFramework
   drakeSystemPrimitives
   drakeRendering
+  fmt
   Eigen3::Eigen
   yaml-cpp
   )

--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -23,8 +23,8 @@ drake_cc_library(
     ],
     deps = [
         "//drake/automotive/maliput/api",
-        "//drake/common",
         "//drake/math:geometric_transform",
+        "@fmt//:fmt",
     ],
 )
 

--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "spdlog/fmt/ostr.h"
+#include "fmt/ostream.h"
 
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/lane.h"
@@ -209,26 +209,29 @@ class GeoMesh {
   std::tuple<int, int>
   EmitObj(std::ostream& os, const std::string& material,
           int vertex_index_offset, int normal_index_offset) {
-    os << "# Vertices\n";
+    fmt::print(os, "# Vertices\n");
     for (const GeoVertex* gv : vertices_.vector()) {
-      os << "v " << gv->v().x << " " << gv->v().y << " " << gv->v().z << "\n";
+      fmt::print(os, "v {} {} {}\n",
+                 gv->v().x, gv->v().y, gv->v().z);
     }
-    os << "# Normals\n";
+    fmt::print(os, "# Normals\n");
     for (const GeoNormal* gn : normals_.vector()) {
-      os << "vn " << gn->n().x << " " << gn->n().y << " " << gn->n().z << "\n";
+      fmt::print(os, "vn {} {} {}\n",
+                 gn->n().x, gn->n().y, gn->n().z);
     }
-    os << "\n"
-       << "# Faces\n";
+    fmt::print(os, "\n");
+    fmt::print(os, "# Faces\n");
     if (!material.empty()) {
-      os << "usemtl " << material << "\n";
+      fmt::print(os, "usemtl {}\n", material);
     }
     for (const IndexFace& f : faces_) {
-      os << "f";
+      fmt::print(os, "f");
       for (const IndexFace::Vertex& ifv : f.vertices()) {
-        os << " " << (ifv.vertex_index + 1 + vertex_index_offset)
-           << "//" << (ifv.normal_index + 1 + normal_index_offset);
+        fmt::print(os, " {}//{}",
+                   (ifv.vertex_index + 1 + vertex_index_offset),
+                   (ifv.normal_index + 1 + normal_index_offset));
       }
-      os << "\n";
+      fmt::print(os, "\n");
     }
     return std::make_tuple(vertex_index_offset + vertices_.vector().size(),
                            normal_index_offset + normals_.vector().size());

--- a/drake/automotive/maliput/utility/generate_urdf.cc
+++ b/drake/automotive/maliput/utility/generate_urdf.cc
@@ -2,7 +2,7 @@
 
 #include <fstream>
 
-#include "spdlog/fmt/ostr.h"
+#include "fmt/ostream.h"
 
 #include "drake/automotive/maliput/utility/generate_obj.h"
 #include "drake/common/drake_assert.h"

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -89,7 +89,7 @@ set(drakeCommon_REQUIRES)
 if(spdlog_FOUND)
   target_compile_definitions(drakeCommon PUBLIC HAVE_SPDLOG)
   target_link_libraries(drakeCommon spdlog::spdlog)
-  set(drakeCommon_CFLAGS -DHAVE_SPDLOG)
+  set(drakeCommon_CFLAGS -DHAVE_SPDLOG -DSPDLOG_FMT_EXTERNAL)
   set(drakeCommon_REQUIRES spdlog)
 endif()
 

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library_with_exports(LIB_NAME drakeCommon
   SOURCE_FILES ${sources} ${installed_headers} ${private_headers})
 target_link_libraries(drakeCommon
   Eigen3::Eigen
+  fmt
   gflags
   Threads::Threads)
 
@@ -87,7 +88,9 @@ set(drakeCommon_CFLAGS)
 set(drakeCommon_REQUIRES)
 
 if(spdlog_FOUND)
-  target_compile_definitions(drakeCommon PUBLIC HAVE_SPDLOG)
+  target_compile_definitions(drakeCommon
+    PUBLIC HAVE_SPDLOG
+    SPDLOG_FMT_EXTERNAL)
   target_link_libraries(drakeCommon spdlog::spdlog)
   set(drakeCommon_CFLAGS -DHAVE_SPDLOG -DSPDLOG_FMT_EXTERNAL)
   set(drakeCommon_REQUIRES spdlog)

--- a/tools/fmt.BUILD
+++ b/tools/fmt.BUILD
@@ -13,6 +13,7 @@ cc_library(
         "fmt/*.h",
     ]),
     hdrs = glob(["fmt/*.h"]),
+    includes = ["."],
 )
 
 pkg_tar(

--- a/tools/fmt.BUILD
+++ b/tools/fmt.BUILD
@@ -1,0 +1,23 @@
+# -*- python -*-
+
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "fmt",
+    srcs = glob([
+        "fmt/*.cc",
+        "fmt/*.h",
+    ]),
+    hdrs = glob(["fmt/*.h"]),
+)
+
+pkg_tar(
+    name = "license",
+    extension = "tar.gz",
+    files = ["LICENSE.rst"],
+    package_dir = "fmt",
+)

--- a/tools/fmt.BUILD
+++ b/tools/fmt.BUILD
@@ -8,10 +8,7 @@ package(
 
 cc_library(
     name = "fmt",
-    srcs = glob([
-        "fmt/*.cc",
-        "fmt/*.h",
-    ]),
+    srcs = glob(["fmt/*.cc"]),
     hdrs = glob(["fmt/*.h"]),
     includes = ["."],
 )

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -9,12 +9,16 @@ package(
 cc_library(
     name = "spdlog",
     hdrs = glob(["include/spdlog/**"]),
-    defines = ["HAVE_SPDLOG"],
+    defines = [
+        "HAVE_SPDLOG",
+        "SPDLOG_FMT_EXTERNAL",
+    ],
     includes = ["include"],
     linkopts = select({
         "@//tools:linux": ["-pthread"],
         "@//conditions:default": [],
     }),
+    deps = ["@fmt//:fmt"],
 )
 
 pkg_tar(


### PR DESCRIPTION
Pull in the `fmt` string formatting library as a proper external dependency,
and have `maliput/utility` use it (for `GenerateObj()`, `GenerateUrdf()`).
Prior to this, this code was using the copy of the `fmt` library embedded in
`spdlog`.  However, `spdlog` is actually considered an optional dependency
(kind of), and stubs are provided if the real `spdlog` is not present (and
if bazel is lied-to in the right way).  This causes `maliput/utility` to
mysteriously fail to build if a user has asked for "spdlog stubs".  So...
now we will pull in `fmt` properly on its own.

Also, use `fmt::print()` uniformly throughout `GenerateObj()` --- `operator<<`
style output was still being used in some places --- places where `fmt` syntax
is more readable/terse.

Since `fmt` is the underlying formatting library used by our logging library,
it is generally useful to have that syntax consistently available for all of
our string formatting needs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5607)
<!-- Reviewable:end -->
