### PR TITLE
Add drake/tools/clang-format-includes program

### DIFF
--- a/drake/tools/BUILD
+++ b/drake/tools/BUILD
@@ -28,6 +28,14 @@ py_library(
     data = ["//tools:clang-format"],
 )
 
+py_binary(
+    name = "clang-format-includes",
+    main = "clang_format_includes.py",
+    srcs = ["clang_format_includes.py"],
+    deps = [":formatter"],
+    data = ["//tools:clang-format"],
+)
+
 # === test/ ===
 
 lcm_cc_library(
@@ -95,6 +103,14 @@ py_test(
     name = "formatter_test",
     srcs = ["test/formatter_test.py"],
     deps = [":formatter"],
+)
+
+sh_test(
+    name = "clang_format_includes_test",
+    srcs = ["test/clang_format_includes_test.sh"],
+    data = [
+        ":clang-format-includes",
+    ],
 )
 
 cpplint(data = ["test/gen/drake/CPPLINT.cfg"])

--- a/drake/tools/clang_format_includes.py
+++ b/drake/tools/clang_format_includes.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python2
+
+"""Rewrite the filenames given on the command line to obey formatting rules for
+#include statements.  The only changes this script will make are to relocate
+#include statements, and possibly some associated additions or removals of blank
+lines near the #include blocks.
+
+"""
+
+import argparse
+import os
+import sys
+
+from drake.tools.formatter import IncludeFormatter
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog='clang-format-includes',
+        description=__doc__)
+    parser.add_argument(
+        'filenames', metavar='filename', type=str, nargs='*',
+        help='full path to filename to reformat in place')
+    parser.add_argument(
+        '--all', action='store_true', default=False,
+        help='reformat all first-party sources within the project')
+    parser.add_argument(
+        '--check-only', action='store_true', default=False,
+        help='check if the file(s) are formatted correctly; do not edit')
+    args = parser.parse_args()
+
+    if args.all:
+        # TODO(jwnimmer-tri) Consolidate this logic with the cpplint_wrapper
+        # tree searching logic, including some way to unit test "all" search.
+        extensions = ["cc", "h"]
+        pathnames = ["drake", "ros"]
+        filenames = [
+            os.path.join(dirpath, filename)
+            for pathname in pathnames
+            for dirpath, _, filenames in os.walk(pathname)
+            for filename in filenames
+            if os.path.splitext(filename)[1][1:] in extensions and
+            # TODO(jwnimmer-tri) Eventually do pybind11.
+            "bindings/pybind11" not in dirpath and
+            "/thirdParty/" not in dirpath and
+            "/third_party/" not in dirpath and
+            "/matlab/" not in dirpath
+        ]
+    else:
+        filenames = args.filenames
+
+    num_errors = 0
+    for filename in filenames:
+        tool = IncludeFormatter(filename)
+        tool.format_includes()
+        if tool.is_same_as_original():
+            continue
+        if args.check_only:
+            num_errors += 1
+        else:
+            tool.rewrite_file()
+
+    if num_errors > 0:
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/drake/tools/test/clang_format_includes_test.sh
+++ b/drake/tools/test/clang_format_includes_test.sh
@@ -1,0 +1,58 @@
+# A basic _acceptance_ test for clang-format-includes.
+# More specific _unit_ testing is in formatter_test.py.
+# This test should only be run via Bazel, never directly on the command line.
+
+set -ex
+
+# Dump some debugging output.
+find .
+
+# Prep.
+dut=./drake/tools/clang-format-includes
+[ -x "$dut" ]
+mkdir -p drake/dummy
+
+# Set up a test input that is mis-formatted and the correct formatting.
+cat > drake/dummy/foo.cc <<EOF
+#include "drake/common/drake_assert.h"
+#include "drake/dummy/bar.h"
+#include "drake/dummy/foo.h"
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+#include <algorithm>
+#include <poll.h>
+#include <sys/wait.h>
+#include <vector>
+EOF
+cp -a drake/dummy/foo.cc{,.orig}
+cat > drake/dummy/foo.cc-expected <<EOF
+#include "drake/dummy/foo.h"
+
+#include <poll.h>
+#include <sys/wait.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/dummy/bar.h"
+EOF
+
+# The foo.cc needs reformatting, but check-only leaves it unchanged.
+(set +e; "$dut" --check-only drake/dummy/foo.cc; [ $? == 1 ])
+diff -U 999 drake/dummy/foo.cc{,.orig}
+
+# Reformat and ensure the expected result appeared.
+"$dut" drake/dummy/foo.cc
+diff -U 999 drake/dummy/foo.cc{,-expected}
+
+# The foo.cc no longer needs reformatting, and check-only leaves it unchanged.
+"$dut" --check-only drake/dummy/foo.cc
+diff -U 999 drake/dummy/foo.cc{,-expected}
+
+# Done.
+echo "PASS"
+exit 0


### PR DESCRIPTION
```
$ bazel-bin/drake/tools/clang-format-includes --help
usage: clang-format-includes [-h] [--all] [--check-only]
                             [filename [filename ...]]

Rewrite the filenames given on the command line to obey formatting rules for
#include statements. The only changes this script will make are to relocate
#include statements, and possibly some assocated additions or removals of
blank lines near the #include blocks.

positional arguments:
  filename      full path to filename to reformat in place

optional arguments:
  -h, --help    show this help message and exit
  --all         reformat all first-party sources within the project
  --check-only  check if the file(s) are formatted correctly; do not edit
```

This PR does not add instructions to sphinx, nor automatically apply this tool in CI, nor add any Bazel lint checks.  This PR just puts the program into master with unit tests, so we can beta-test it with early adopters.

Relates #2269.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5614)
<!-- Reviewable:end -->
