### PR TITLE
Clean up doxygen sensor system list

### DIFF
--- a/drake/systems/sensors/camera_info.h
+++ b/drake/systems/sensors/camera_info.h
@@ -53,7 +53,6 @@ namespace sensors {
 /// http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
 /// and https://en.wikipedia.org/wiki/Pinhole_camera_model.
 ///
-/// @ingroup sensor_systems
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
 // needed.
 class CameraInfo {

--- a/drake/systems/sensors/image.h
+++ b/drake/systems/sensors/image.h
@@ -18,8 +18,6 @@ namespace sensors {
 /// Eigen, Mat in OpenCV, and so on.
 ///
 /// The origin of image coordinate system is on the left-upper corner.
-///
-/// @ingroup sensor_systems
 template <typename T>
 class Image {
  public:

--- a/drake/systems/sensors/rgbd_camera.h
+++ b/drake/systems/sensors/rgbd_camera.h
@@ -53,6 +53,8 @@ namespace sensors {
 ///     in the scene. For the pixels corresponding to no body, namely the sky
 ///     and the flat terrain, we assign Label::kNoBody and Label::kFlatTerrain,
 ///     respectively.
+///
+/// @ingroup sensor_systems
 // TODO(kunimatsu-tri) Add support for the image publish capability.
 class RgbdCamera : public LeafSystem<double> {
  public:


### PR DESCRIPTION
visible at http://drake.mit.edu/doxygen_cxx/group__sensor__systems.html

The `RgbdSensor` is a sensor system, but `CameraInfo` and `Image<T>` are not.  Plus, the RgbdSensor doc is very good, but was hard to find!


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5620)
<!-- Reviewable:end -->
