### PR TITLE
First pass of trajectory optimization classes cleanup (with symbolic support)

### DIFF
--- a/drake/examples/Pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_run_swing_up.cc
@@ -20,8 +20,6 @@
 
 using drake::solvers::SolutionResult;
 
-typedef PiecewisePolynomial<double> PiecewisePolynomialType;
-
 namespace drake {
 namespace examples {
 namespace pendulum {
@@ -63,26 +61,25 @@ int do_main(int argc, char* argv[]) {
 
   auto context = pendulum->CreateDefaultContext();
 
-  systems::DircolTrajectoryOptimization dircol_traj(
+  systems::DircolTrajectoryOptimization dircol(
       pendulum, *context, kNumTimeSamples, kTrajectoryTimeLowerBound,
       kTrajectoryTimeUpperBound);
-  drake::examples::pendulum::AddSwingUpTrajectoryParams(kNumTimeSamples, x0, xG,
-                                                        &dircol_traj);
+  drake::examples::pendulum::AddSwingUpTrajectoryParams(x0, xG, &dircol);
 
   const double timespan_init = 4;
   auto traj_init_x =
-      PiecewisePolynomialType::FirstOrderHold({0, timespan_init}, {x0, xG});
-  SolutionResult result = dircol_traj.SolveTraj(
-      timespan_init, PiecewisePolynomialType(), traj_init_x);
+      PiecewisePolynomial<double>::FirstOrderHold({0, timespan_init}, {x0, xG});
+  SolutionResult result = dircol.SolveTraj(
+      timespan_init, PiecewisePolynomial<double>(), traj_init_x);
   if (result != SolutionResult::kSolutionFound) {
     std::cerr << "Result is an Error" << std::endl;
     return 1;
   }
 
   const PiecewisePolynomialTrajectory pp_traj =
-      dircol_traj.ReconstructInputTrajectory();
+      dircol.ReconstructInputTrajectory();
   const PiecewisePolynomialTrajectory pp_xtraj =
-      dircol_traj.ReconstructStateTrajectory();
+      dircol.ReconstructStateTrajectory();
   auto input_source = builder.AddSystem<systems::TrajectorySource>(pp_traj);
   auto state_source = builder.AddSystem<systems::TrajectorySource>(pp_xtraj);
 

--- a/drake/examples/Pendulum/pendulum_swing_up.cc
+++ b/drake/examples/Pendulum/pendulum_swing_up.cc
@@ -20,22 +20,22 @@ namespace drake {
 namespace examples {
 namespace pendulum {
 
-void AddSwingUpTrajectoryParams(
-    const Eigen::Vector2d& x0, const Eigen::Vector2d& xG,
-    systems::DircolTrajectoryOptimization* dircol) {
-
+void AddSwingUpTrajectoryParams(const Eigen::Vector2d& x0,
+                                const Eigen::Vector2d& xG,
+                                systems::DircolTrajectoryOptimization* dircol) {
   const int kTorqueLimit = 3;  // Arbitrary, taken from PendulumPlant.m.
   const drake::Vector1d umin(-kTorqueLimit);
   const drake::Vector1d umax(kTorqueLimit);
   dircol->AddInputBounds(umin, umax);
 
-  // TODO: Simplify to e.g. state(0) == x0 once the required overloads arrive.
-  dircol->AddLinearConstraint( dircol->initial_state().array() == x0.array() );
-  dircol->AddLinearConstraint( dircol->final_state().array() == xG.array() );
+  // TODO(soonho): Simplify to e.g. state(0) == x0 once the required
+  // overloads arrive.
+  dircol->AddLinearConstraint(dircol->initial_state().array() == x0.array());
+  dircol->AddLinearConstraint(dircol->final_state().array() == xG.array());
 
   const double R = 10;  // Cost on input "effort".
   auto u = dircol->input();
-  dircol->AddRunningCost( (R * u) * u );
+  dircol->AddRunningCost((R * u) * u);
 }
 
 }  // namespace pendulum

--- a/drake/examples/Pendulum/pendulum_swing_up.h
+++ b/drake/examples/Pendulum/pendulum_swing_up.h
@@ -17,7 +17,6 @@ namespace pendulum {
  * between @p x0 and @p xG).
  */
 void AddSwingUpTrajectoryParams(
-    int num_time_samples,
     const Eigen::Vector2d& x0, const Eigen::Vector2d& xG,
     systems::DircolTrajectoryOptimization*);
 

--- a/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
@@ -29,17 +29,17 @@ GTEST_TEST(PendulumTrajectoryOptimization,
   const PendulumPlant<double> pendulum;
   auto context = pendulum.CreateDefaultContext();
 
-  systems::DircolTrajectoryOptimization dircol_traj(
+  systems::DircolTrajectoryOptimization dircol(
       &pendulum, *context,
       kNumTimeSamples, kTrajectoryTimeLowerBound,
       kTrajectoryTimeUpperBound);
-  AddSwingUpTrajectoryParams(kNumTimeSamples, x0, xG, &dircol_traj);
+  AddSwingUpTrajectoryParams(x0, xG, &dircol);
 
   const double timespan_init = 4;
   auto traj_init_x = PiecewisePolynomialType::FirstOrderHold(
       {0, timespan_init}, {x0, xG});
   const SolutionResult result =
-      dircol_traj.SolveTraj(timespan_init, PiecewisePolynomialType(),
+      dircol.SolveTraj(timespan_init, PiecewisePolynomialType(),
                             traj_init_x);
   ASSERT_EQ(result, SolutionResult::kSolutionFound) << "Result is an Error";
 
@@ -47,13 +47,13 @@ GTEST_TEST(PendulumTrajectoryOptimization,
   Eigen::MatrixXd states;
   std::vector<double> times_out;
 
-  dircol_traj.GetResultSamples(&inputs, &states, &times_out);
+  dircol.GetResultSamples(&inputs, &states, &times_out);
   EXPECT_TRUE(CompareMatrices(x0, states.col(0),
                               1e-10, MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(xG, states.col(kNumTimeSamples - 1),
                               1e-10, MatrixCompareType::absolute));
   const PiecewisePolynomialTrajectory state_traj =
-      dircol_traj.ReconstructStateTrajectory();
+      dircol.ReconstructStateTrajectory();
   for (int i = 0; i < kNumTimeSamples; ++i) {
     EXPECT_TRUE(CompareMatrices(states.col(i), state_traj.value(times_out[i]),
                                 1e-10, MatrixCompareType::absolute));

--- a/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
+++ b/drake/examples/Pendulum/test/pendulum_trajectory_optimization_test.cc
@@ -74,8 +74,8 @@ GTEST_TEST(PendulumTrajectoryOptimization,
   // regression test.
   double abs_diff =
       std::fabs(linear_avr_of_2_points(0, 0) - spline_interpolation(0, 0));
-  EXPECT_LT(abs_diff, 0.1);
-  EXPECT_GT(abs_diff, 0.09);
+  EXPECT_LT(abs_diff, 0.11);
+  EXPECT_GT(abs_diff, 0.1);
 }
 
 }  // namespace

--- a/drake/systems/trajectory_optimization/direct_collocation.cc
+++ b/drake/systems/trajectory_optimization/direct_collocation.cc
@@ -109,6 +109,22 @@ class RunningCostMidWrapper : public solvers::Constraint {
 
 }  // anon namespace
 
+void DircolTrajectoryOptimization::AddRunningCost(
+    const symbolic::Expression& g) {
+  // Trapezoidal integration:
+  //    sum_{i=0...N-2} h_i/2.0 * (g_i + g_{i+1}), or
+  // g_0*h_0/2.0 + [sum_{i=1...N-1} g_i (h_{i-1} + h_i)/2.0] + g_N*h_{N-1}/2.0.
+
+  // TODO(russt): Insert h(i) terms.  Currently not supported because it's
+  // no longer a quadratic constraint.
+
+  AddCost(0.5*SubstitutePlaceholderVariables(g,0));
+  for (int i = 1; i < N() - 2; i++) {
+    AddCost(SubstitutePlaceholderVariables(g, i));
+  }
+  AddCost(0.5*SubstitutePlaceholderVariables(g,N()-1));
+}
+
 // We just use a generic constraint here since we need to mangle the
 // input and output anyway.
 void DircolTrajectoryOptimization::AddRunningCost(

--- a/drake/systems/trajectory_optimization/direct_collocation.cc
+++ b/drake/systems/trajectory_optimization/direct_collocation.cc
@@ -113,16 +113,16 @@ void DircolTrajectoryOptimization::AddRunningCost(
     const symbolic::Expression& g) {
   // Trapezoidal integration:
   //    sum_{i=0...N-2} h_i/2.0 * (g_i + g_{i+1}), or
-  // g_0*h_0/2.0 + [sum_{i=1...N-1} g_i (h_{i-1} + h_i)/2.0] + g_N*h_{N-1}/2.0.
+  // g_0*h_0/2.0 + [sum_{i=1...N-1} g_i*(h_{i-1} + h_i)/2.0] + g_N*h_{N-1}/2.0.
 
   // TODO(russt): Insert h(i) terms.  Currently not supported because it's
   // no longer a quadratic constraint.
 
-  AddCost(0.5*SubstitutePlaceholderVariables(g,0));
+  AddCost(0.5 * SubstitutePlaceholderVariables(g, 0));
   for (int i = 1; i < N() - 2; i++) {
     AddCost(SubstitutePlaceholderVariables(g, i));
   }
-  AddCost(0.5*SubstitutePlaceholderVariables(g,N()-1));
+  AddCost(0.5 * SubstitutePlaceholderVariables(g, N() - 1));
 }
 
 // We just use a generic constraint here since we need to mangle the

--- a/drake/systems/trajectory_optimization/direct_collocation.h
+++ b/drake/systems/trajectory_optimization/direct_collocation.h
@@ -53,6 +53,7 @@ class DircolTrajectoryOptimization : public DirectTrajectoryOptimization {
 
   void AddRunningCost(std::shared_ptr<solvers::Constraint> constraint) override;
   using DirectTrajectoryOptimization::AddRunningCost;
+  using DirectTrajectoryOptimization::AddFinalCost;
 
   PiecewisePolynomialTrajectory ReconstructStateTrajectory() const override;
   // TODO(Lucy-tri) According to @siyuanfeng-tri, the current calculation of

--- a/drake/systems/trajectory_optimization/direct_collocation.h
+++ b/drake/systems/trajectory_optimization/direct_collocation.h
@@ -49,7 +49,10 @@ class DircolTrajectoryOptimization : public DirectTrajectoryOptimization {
 
   ~DircolTrajectoryOptimization() override {}
 
+  void AddRunningCost(const symbolic::Expression& e) override;
+
   void AddRunningCost(std::shared_ptr<solvers::Constraint> constraint) override;
+  using DirectTrajectoryOptimization::AddRunningCost;
 
   PiecewisePolynomialTrajectory ReconstructStateTrajectory() const override;
   // TODO(Lucy-tri) According to @siyuanfeng-tri, the current calculation of

--- a/drake/systems/trajectory_optimization/test/trajectory_optimization_test.cc
+++ b/drake/systems/trajectory_optimization/test/trajectory_optimization_test.cc
@@ -4,6 +4,9 @@
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/solvers/mathematical_program.h"
+#include "drake/systems/framework/siso_vector_system.h"
+#include "drake/systems/trajectory_optimization/direct_collocation.h"
 #include "drake/systems/trajectory_optimization/direct_trajectory_optimization.h"
 
 using std::vector;
@@ -40,7 +43,11 @@ class MyDirectTrajOpt : public DirectTrajectoryOptimization {
       : DirectTrajectoryOptimization(num_inputs, num_states, num_time_samples,
                                      traj_time_lower_bound,
                                      traj_time_upper_bound) {}
-  void AddRunningCost(std::shared_ptr<solvers::Constraint> constraint) {}
+  void AddRunningCost(const symbolic::Expression& g) override {}
+  void AddRunningCost(
+      std::shared_ptr<solvers::Constraint> constraint) override {}
+  using DirectTrajectoryOptimization::AddRunningCost;
+  using DirectTrajectoryOptimization::AddFinalCost;
 };
 
 GTEST_TEST(TrajectoryOptimizationTest, DirectTrajectoryOptimizationTest) {
@@ -163,8 +170,8 @@ GTEST_TEST(TrajectoryOptimizationTest, DirectTrajectoryOptimizationTest) {
 
   // Tests adding constrainst to the original mathematical program, via
   // the state variable accessor and symbolic formula.
-  direct_traj.AddLinearConstraint(direct_traj.x(0)(0) == 0.0);
-  direct_traj.AddLinearConstraint(direct_traj.x(0)(1) == 0.0);
+  direct_traj.AddLinearConstraint(direct_traj.initial_state().array() ==
+                                  Eigen::Vector2d::Zero().array());
 
   // Adds a final cost
   direct_traj.AddFinalCostFunc(FinalCost());
@@ -175,6 +182,113 @@ GTEST_TEST(TrajectoryOptimizationTest, DirectTrajectoryOptimizationTest) {
   direct_traj.GetResultSamples(&inputs, &states, &times_out);
   EXPECT_NEAR(states(1, 0), 0, 1e-10);
   EXPECT_NEAR(states(1, kNumTimeSamples - 1), 0, 1e-10);
+}
+
+GTEST_TEST(TrajectoryOptimizationTest, PlaceholderVariableTest) {
+  const int kNumInputs(1);
+  const int kNumStates(2);
+  const int kNumTimeSamples(21);  // aka N.
+  MyDirectTrajOpt prog(kNumInputs, kNumStates, kNumTimeSamples, 0, 25);
+
+  // Adding a placeholder variable directly to the program should fail.
+  // (but currently does NOT; see #5623)
+  auto u = prog.input();
+  prog.AddCost(u(0));  // TODO(russt): EXPECT_THROW
+}
+
+// qddot = u.
+template <typename T>
+class DoubleIntegrator : public SisoVectorSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DoubleIntegrator);
+
+  DoubleIntegrator() : SisoVectorSystem<T>(1, 1) {
+    this->DeclareContinuousState(1, 1, 0);
+  }
+  ~DoubleIntegrator() override{};
+
+ protected:
+  DoubleIntegrator<AutoDiffXd>* DoToAutoDiffXd() const override {
+    return new DoubleIntegrator<AutoDiffXd>();
+  }
+
+  void DoCalcVectorOutput(
+      const Context<T>& context,
+      const Eigen::VectorBlock<const VectorX<T>>& input,
+      const Eigen::VectorBlock<const VectorX<T>>& state,
+      Eigen::VectorBlock<VectorX<T>>* output) const override {
+    *output << state(0);
+  }
+
+  void DoCalcVectorTimeDerivatives(
+      const Context<T>& context,
+      const Eigen::VectorBlock<const VectorX<T>>& input,
+      const Eigen::VectorBlock<const VectorX<T>>& state,
+      Eigen::VectorBlock<VectorX<T>>* derivatives) const override {
+    *derivatives << state(1), input(0);
+  }
+};
+
+// Tests the double integrator minimum-time problem known solution.
+GTEST_TEST(TrajectoryOptimizationTest, DoubleIntegratorTest) {
+  DoubleIntegrator<double> double_integrator;
+  auto context = double_integrator.CreateDefaultContext();
+  const int timesteps{10};
+  DircolTrajectoryOptimization prog(&double_integrator, *context, timesteps,
+                                    0.5, 20.0);
+
+  // u \in [-1,1].
+  prog.AddInputBounds(Vector1d(-1.0), Vector1d(1.0));
+  // xf = [0,0].
+  prog.AddLinearConstraint(prog.final_state().array() ==
+                           Eigen::Vector2d::Zero().array());
+
+  // x0 = [-1,0].
+  prog.AddLinearConstraint(prog.initial_state().array() ==
+                           Eigen::Vector2d(-1.0, 0.0).array());
+
+  // Cost is just total time.
+  prog.AddFinalCost(prog.time().cast<symbolic::Expression>());
+
+  EXPECT_EQ(prog.Solve(), solvers::SolutionResult::kSolutionFound);
+
+  // Solution should be bang-band (u = +1 then -1).
+  int i = 0;
+  while (i < timesteps / 2.0)
+    EXPECT_NEAR(prog.GetSolution(prog.input(i++))(0), 1.0, 1e-5);
+  while (i < timesteps)
+    EXPECT_NEAR(prog.GetSolution(prog.input(i++))(0), -1.0, 1e-5);
+}
+
+// Tests the double integrator without input limits results in minimal time.
+GTEST_TEST(TrajectoryOptimizationTest, MinimumTimeTest) {
+  DoubleIntegrator<double> double_integrator;
+  auto context = double_integrator.CreateDefaultContext();
+  const int timesteps{10};
+  const double min_time{0.5};
+  DircolTrajectoryOptimization prog(&double_integrator, *context, timesteps,
+                                    min_time, 20.0);
+
+  // Note: No input limits this time.
+
+  // xf = [0,0].
+  prog.AddLinearConstraint(prog.final_state().array() ==
+                           Eigen::Vector2d::Zero().array());
+
+  // x0 = [-1,0].
+  prog.AddLinearConstraint(prog.initial_state().array() ==
+                           Eigen::Vector2d(-1.0, 0.0).array());
+
+  // Cost is just total time.
+  prog.AddFinalCost(prog.time().cast<symbolic::Expression>());
+
+  EXPECT_EQ(prog.Solve(), solvers::SolutionResult::kSolutionFound);
+
+  // Solution should have total time equal to 0.5.
+  double total_time = 0;
+  for (int i = 0; i < timesteps - 1; i++)
+    total_time += prog.GetSolution(prog.timestep(i))(0);
+  EXPECT_NEAR(total_time, min_time, 1e-5);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Adds a new interface for accessing the time indexed decision variables, and dramatically simplifies the pendulum swing-up example.  Note especially the new AddRunningCost change.

Adds a few new simple trajectory optimization tests to provide (admittedly modest) coverage of the interface. 

Fixes the RunningCost to use trapezoidal integration -- the existing version was not doing proper integration -- with a big TODO due to the missing support for AddCost of > quadratic expressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5624)
<!-- Reviewable:end -->
