### PR TITLE
Correct demo to not overrun specified simulation duration

### DIFF
--- a/drake/examples/contact_model/rigid_gripper.cc
+++ b/drake/examples/contact_model/rigid_gripper.cc
@@ -133,7 +133,7 @@ int main() {
 
   // Print a time stamp update every tenth of a second.  This helps communicate
   // progress in the event that the integrator crawls to a very small timestep.
-  const double kPrintPeriod = 0.1;
+  const double kPrintPeriod = std::min(0.1, FLAGS_sim_duration);
   int step_count =
       static_cast<int>(std::ceil(FLAGS_sim_duration / kPrintPeriod));
   for (int i = 1; i <= step_count; ++i) {

--- a/drake/examples/contact_model/rigid_gripper.cc
+++ b/drake/examples/contact_model/rigid_gripper.cc
@@ -15,6 +15,7 @@ length times v_stiction_tolerance (i.e., the highest allowable slip speed
 during stiction).
 */
 
+#include <algorithm>
 #include <memory>
 
 #include <gflags/gflags.h>


### PR DESCRIPTION
To provide feedback on progress for very slow simulations, the demo would
take steps bounded by a "print time" interval so it could print progress
to the console.  However, if the simulation duration was *smaller* than
this print interval, the simulation would be extended to at least one
print duration.  The print duration is now constrained by the simulation
time.

Resolves #5617

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5627)
<!-- Reviewable:end -->
