### PR TITLE
Add local_repository_override to github_archive

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,17 @@
 # This file marks a workspace root for the Bazel build system. see
 # http://bazel.io/ .
 
+# To temporarily use a local copy of a github_archive, within this file add a
+# local_repository_archive argument to its github_archive macro call, e.g.:
+#
+# github_archive(
+#     name = "foobar",
+#     local_repository_override = "/path/to/local/foo/bar",
+#     repository = "foo/bar",
+#     commit = "0123456789abcdef0123456789abcdef01234567",
+#     sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+# )
+
 workspace(name = "drake")
 
 load("//tools/third_party/kythe/tools/build_rules/config:pkg_config.bzl", "pkg_config_package")

--- a/tools/github.bzl
+++ b/tools/github.bzl
@@ -6,6 +6,7 @@ def github_archive(
         commit = None,
         sha256 = None,
         build_file = None,
+        local_repository_override=None,
         **kwargs):
     """A macro to be called in the WORKSPACE that adds an external from github
     using a workspace rule.
@@ -24,6 +25,9 @@ def github_archive(
     The optional build_file= is the BUILD file label to use for building this
     external.  When omitted, the BUILD file(s) within the archive will be used.
 
+    The optional local_repository_override= can be used for temporary local
+    testing; instead of retrieving the code from github, the code is retrieved
+    from the local filesystem path given in the argument.
     """
     if repository == None:
         fail("Missing repository=")
@@ -47,6 +51,18 @@ def github_archive(
         # Github archives omit the "v" in version tags, for some reason.
         strip_commit = commit[1:]
     strip_prefix = project + "-" + strip_commit
+
+    if local_repository_override != None:
+        if build_file == None:
+            native.local_repository(
+                name=name,
+                path=local_repository_override)
+        else:
+            native.new_local_repository(
+                name=name,
+                build_file=build_file,
+                path=local_repository_override)
+        return
 
     if build_file == None:
         native.http_archive(


### PR DESCRIPTION
This allows users to easily test-build different revisions of WORKSPACE externals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5628)
<!-- Reviewable:end -->
