### PR TITLE
Fix bug in PriusVis's use of KinematicsCache.

### DIFF
--- a/drake/automotive/prius_vis.cc
+++ b/drake/automotive/prius_vis.cc
@@ -44,11 +44,10 @@ const vector<lcmt_viewer_link_data>& PriusVis<T>::GetVisElements() const {
 template <typename T>
 systems::rendering::PoseBundle<T> PriusVis<T>::CalcPoses(
     const Isometry3<T>& X_WM) const {
-  const int kNumPositionDofs{14};
   const auto rotation = X_WM.linear();
   const auto transform = X_WM.translation();
   Vector3<T> rpy = rotation.eulerAngles(2, 1, 0);
-  VectorX<T> q = VectorX<T>::Zero(kNumPositionDofs);
+  VectorX<T> q = VectorX<T>::Zero(tree_->get_num_positions());
   q(0) = transform.x();
   q(1) = transform.y();
   q(2) = transform.z();


### PR DESCRIPTION
This fix-forwards a bug that's resulting in numerous CI-continuous failures.

The bug was originally introduced in #5602.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5635)
<!-- Reviewable:end -->
