### PR TITLE
Rotation constraint tighten3

### DIFF
--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -68,8 +68,8 @@ class KukaTest : public ::testing::Test {
           global_ik_.GetSolution(global_ik_.body_rotation_matrix(i));
       // Use 1E-10 for the error tolerance.
       EXPECT_TRUE((body_Ri.array().abs() <= 1 + 1E-10).all());
-      EXPECT_LE(body_Ri.trace(), 3);
-      EXPECT_GE(body_Ri.trace(), -1);
+      EXPECT_LE(body_Ri.trace(), 3 + 1E-10);
+      EXPECT_GE(body_Ri.trace(), -1 - 1E-10);
       // TODO(hongkai.dai): We will have a more meaningful bound on the
       // relaxation of rotation matrix. Then clean up this print out with
       // the check on the error bound, and move this file out of dev folder.

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -206,7 +206,7 @@ TEST_F(KukaTest, ReachableWithCost) {
     // The position tolerance and the orientation tolerance is chosen
     // according to the Gurobi solver tolerance.
     double position_error = 1E-5;
-    double orientation_error = 2E-5;
+    double orientation_error = 3E-5;
     CheckGlobalIKSolution(position_error, orientation_error);
 
     const Eigen::VectorXd q_w_cost =

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -206,7 +206,7 @@ TEST_F(KukaTest, ReachableWithCost) {
     // The position tolerance and the orientation tolerance is chosen
     // according to the Gurobi solver tolerance.
     double position_error = 1E-5;
-    double orientation_error = 3E-5;
+    double orientation_error = 2E-5;
     CheckGlobalIKSolution(position_error, orientation_error);
 
     const Eigen::VectorXd q_w_cost =

--- a/drake/solvers/rotation_constraint_internal.h
+++ b/drake/solvers/rotation_constraint_internal.h
@@ -14,6 +14,10 @@ std::vector<Eigen::Vector3d> ComputeBoxEdgesAndSphereIntersection(
 
 void ComputeHalfSpaceRelaxationForBoxSphereIntersection(
     const std::vector<Eigen::Vector3d>& pts, Eigen::Vector3d* n, double* d);
+
+void ComputeInnerFacetsForBoxSphereIntersection(
+    const std::vector<Eigen::Vector3d>& pts,
+    Eigen::Matrix<double, Eigen::Dynamic, 3>* A, Eigen::VectorXd* b);
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/rotation_constraint_internal.h
+++ b/drake/solvers/rotation_constraint_internal.h
@@ -4,7 +4,8 @@
 
 // This file only exists to expose some internal methods for unit testing.  It
 // should NOT be included in user code.
-
+// The API documentation for these functions lives in rotation_constraint.cc,
+// where they are implemented.
 namespace drake {
 namespace solvers {
 namespace internal {
@@ -14,6 +15,9 @@ std::vector<Eigen::Vector3d> ComputeBoxEdgesAndSphereIntersection(
 
 void ComputeHalfSpaceRelaxationForBoxSphereIntersection(
     const std::vector<Eigen::Vector3d>& pts, Eigen::Vector3d* n, double* d);
+
+bool AreAllVerticesCoPlanar(const std::vector<Eigen::Vector3d>& pts,
+                            Eigen::Vector3d* n, double* d);
 
 void ComputeInnerFacetsForBoxSphereIntersection(
     const std::vector<Eigen::Vector3d>& pts,

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -197,9 +197,48 @@ void CompareIntersectionResults(std::vector<Vector3d> desired,
   }
 }
 
+// For 2 binary variable per half axis, we know it cuts the first orthant into
+// 7 regions. 3 of these regions have 4 co-planar vertices; 3 of these regions
+// have 4 non-coplanar vertices, and one region has 3 vertices.
+GTEST_TEST(RotationTest, TestAreAllVerticesCoPlanar) {
+  Eigen::Vector3d n;
+  double d;
+
+  // 4 co-planar vertices. Due to symmetry, we only test one out of the three
+  // regions.
+  Eigen::Vector3d bmin(0.5, 0.5, 0);
+  Eigen::Vector3d bmax(1, 1, 0.5);
+  std::vector<Eigen::Vector3d> pts =
+      internal::ComputeBoxEdgesAndSphereIntersection(bmin, bmax);
+  EXPECT_TRUE(internal::AreAllVerticesCoPlanar(pts, &n, &d));
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_NEAR(n.norm(), 1, 1E-10);
+    EXPECT_NEAR(n.dot(pts[i]), d, 1E-10);
+    EXPECT_TRUE((n.array() > 0).all());
+  }
+
+  // 4 non co-planar vertices. Due to symmetry, we only test one out of the
+  // three regions.
+  bmin << 0.5, 0, 0;
+  bmax << 1, 0.5, 0.5;
+  pts = internal::ComputeBoxEdgesAndSphereIntersection(bmin, bmax);
+  EXPECT_FALSE(internal::AreAllVerticesCoPlanar(pts, &n, &d));
+  EXPECT_TRUE(CompareMatrices(n, Eigen::Vector3d::Zero()));
+  EXPECT_EQ(d, 0);
+
+  // 3 vertices
+  bmin << 0.5, 0.5, 0.5;
+  bmax << 1, 1, 1;
+  pts = internal::ComputeBoxEdgesAndSphereIntersection(bmin, bmax);
+  EXPECT_TRUE(internal::AreAllVerticesCoPlanar(pts, &n, &d));
+  EXPECT_TRUE(CompareMatrices(n, Eigen::Vector3d::Constant(1.0 / std::sqrt(3)),
+                              1E-10, MatrixCompareType::absolute));
+  EXPECT_NEAR(pts[0].dot(n), d, 1E-10);
+}
+
 void CheckInnerFacets(const std::vector<Vector3d>& pts) {
   // Compute the inner facets of the convex hull of pts. Make sure for each
-  // facet, there are  three points on the facet, and the facet points
+  // facet, there are three points on the facet, and the facet points
   // outward from the origin.
   Eigen::Matrix<double, Eigen::Dynamic, 3> A;
   Eigen::VectorXd b;

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -234,6 +234,9 @@ void CompareHalfspaceRelaxation(const std::vector<Vector3d> &pts) {
   double d_expected;
   internal::ComputeHalfSpaceRelaxationForBoxSphereIntersection(pts, &n_expected,
                                                                &d_expected);
+  if (pts.size() == 3) {
+    EXPECT_NEAR(d_expected, d, 1E-6);
+  }
   EXPECT_GE(d_expected, d - 1E-8);
   for (const auto &pt : pts) {
     EXPECT_GE(pt.transpose() * n_expected - d_expected, -1E-6);
@@ -415,7 +418,7 @@ GTEST_TEST(RotationTest, TestMcCormick) {
         -0.54132589862048197, 0.68892119955432829, 0.48203096610835455;
     EXPECT_TRUE(IsFeasible(R_test));
 
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < 40; i++) {
       R_test = math::UniformlyRandomRotmat(generator);
       EXPECT_TRUE(IsFeasible(R_test));
     }

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -306,8 +306,8 @@ GTEST_TEST(RotationTest, TestHalfSpaceRelaxation) {
 GTEST_TEST(RotationTest, TestInnerFacetsAndHalfSpace) {
   // We show that the inner facet is tighter than the half space for some case.
   // To this end, we show that for a box [0 0.5 0] <= x <= [0.5 1 0.5], there is
-  // some point lying in between the inner facets A*x<=b, and the half space
-  // nᵀ*x>=d.
+  // some point that does not satisfy the inner facets constraint A*x<=b, but
+  // satisfies the half space constraint nᵀ*x>=d.
   const Eigen::Vector3d bmin(0, 0.5, 0);
   const Eigen::Vector3d bmax(0.5, 1, 0.5);
   const auto intersection_pts =

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -306,7 +306,8 @@ GTEST_TEST(RotationTest, TestHalfSpaceRelaxation) {
 GTEST_TEST(RotationTest, TestInnerFacetsAndHalfSpace) {
   // We show that the inner facet is tighter than the half space for some case.
   // To this end, we show that for a box [0 0.5 0] <= x <= [0.5 1 0.5], there is
-  // some point lying in between the inner facets,, and the half space.
+  // some point lying in between the inner facets A*x<=b, and the half space
+  // nᵀ*x>=d.
   const Eigen::Vector3d bmin(0, 0.5, 0);
   const Eigen::Vector3d bmax(0.5, 1, 0.5);
   const auto intersection_pts =


### PR DESCRIPTION
We want to compute the convex hull of the region, as the intersection between the box and the surface of the sphere. Previously we only used on halfspace to push the point out. But if the intersection region has more than 3 vertices, we can get the convex hull by using more than one halfspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5639)
<!-- Reviewable:end -->
