### PR TITLE
Refactor trajectory optimization by using NVI pattern

### DIFF
--- a/drake/systems/trajectory_optimization/direct_collocation.cc
+++ b/drake/systems/trajectory_optimization/direct_collocation.cc
@@ -109,7 +109,7 @@ class RunningCostMidWrapper : public solvers::Constraint {
 
 }  // anon namespace
 
-void DircolTrajectoryOptimization::AddRunningCost(
+void DircolTrajectoryOptimization::DoAddRunningCost(
     const symbolic::Expression& g) {
   // Trapezoidal integration:
   //    sum_{i=0...N-2} h_i/2.0 * (g_i + g_{i+1}), or
@@ -127,7 +127,7 @@ void DircolTrajectoryOptimization::AddRunningCost(
 
 // We just use a generic constraint here since we need to mangle the
 // input and output anyway.
-void DircolTrajectoryOptimization::AddRunningCost(
+void DircolTrajectoryOptimization::DoAddRunningCost(
     std::shared_ptr<solvers::Constraint> constraint) {
   AddCost(std::make_shared<RunningCostEndWrapper>(constraint),
           {h_vars().head(1), x_vars().head(num_states()),

--- a/drake/systems/trajectory_optimization/direct_collocation.h
+++ b/drake/systems/trajectory_optimization/direct_collocation.h
@@ -49,18 +49,17 @@ class DircolTrajectoryOptimization : public DirectTrajectoryOptimization {
 
   ~DircolTrajectoryOptimization() override {}
 
-  void AddRunningCost(const symbolic::Expression& e) override;
-
-  void AddRunningCost(std::shared_ptr<solvers::Constraint> constraint) override;
-  using DirectTrajectoryOptimization::AddRunningCost;
-  using DirectTrajectoryOptimization::AddFinalCost;
-
   PiecewisePolynomialTrajectory ReconstructStateTrajectory() const override;
   // TODO(Lucy-tri) According to @siyuanfeng-tri, the current calculation of
   // derivatives is not correct for floating base joints. More strongly, we
   // can't use independent splines for joints with coupled degrees of freedom.
 
  private:
+  void DoAddRunningCost(const symbolic::Expression& e) override;
+
+  void DoAddRunningCost(
+      std::shared_ptr<solvers::Constraint> constraint) override;
+
   const System<double>* system_{nullptr};
   const std::unique_ptr<Context<double>> context_{nullptr};
   const std::unique_ptr<ContinuousState<double>> continuous_state_{nullptr};

--- a/drake/systems/trajectory_optimization/test/trajectory_optimization_test.cc
+++ b/drake/systems/trajectory_optimization/test/trajectory_optimization_test.cc
@@ -43,11 +43,11 @@ class MyDirectTrajOpt : public DirectTrajectoryOptimization {
       : DirectTrajectoryOptimization(num_inputs, num_states, num_time_samples,
                                      traj_time_lower_bound,
                                      traj_time_upper_bound) {}
-  void AddRunningCost(const symbolic::Expression& g) override {}
-  void AddRunningCost(
+
+ private:
+  void DoAddRunningCost(const symbolic::Expression& g) override {}
+  void DoAddRunningCost(
       std::shared_ptr<solvers::Constraint> constraint) override {}
-  using DirectTrajectoryOptimization::AddRunningCost;
-  using DirectTrajectoryOptimization::AddFinalCost;
 };
 
 GTEST_TEST(TrajectoryOptimizationTest, DirectTrajectoryOptimizationTest) {


### PR DESCRIPTION
 - `AddRunningCost` methods are public/non-virtual in `DirectTrajectoryOptimization` class.
 - `DoAddRunningCost` methods are private/abstract which should be implemented by a derived class of `DirectTrajectoryOptimization` (such as `DircolTrajectoryOptimization`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5643)
<!-- Reviewable:end -->
