### PR TITLE
Adds offset between the vehicle model's frame and the Prius visualization's frame.

### DIFF
--- a/drake/automotive/car_vis.h
+++ b/drake/automotive/car_vis.h
@@ -39,11 +39,11 @@ class CarVis {
   /// Returns the visualization elements.
   virtual const std::vector<lcmt_viewer_link_data>& GetVisElements() const = 0;
 
-  /// Computes and returns the poses of the bodies that are part of the
+  /// Computes and returns the poses of the bodies that constitute the vehicle's
   /// visualization. The provided `X_WM` is the pose of the vehicle model in the
-  /// world frame. It typically serves as the "root" or "base frame" of a
-  /// visualization model. The poses in the returned PoseBundle are for the
-  /// visualization geometry's elements, and are also in the world frame. The
+  /// world frame. The origin of the model's frame is assumed to be in the
+  /// middle of the vehicle's rear axle. The poses in the returned PoseBundle
+  /// are for the visualization's elements, and are also in the world frame. The
   /// size of this bundle is the value returned by num_poses().
   virtual systems::rendering::PoseBundle<T> CalcPoses(
       const Isometry3<T>& X_WM) const = 0;

--- a/drake/automotive/prius_vis.h
+++ b/drake/automotive/prius_vis.h
@@ -27,6 +27,10 @@ class PriusVis : public CarVis<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PriusVis)
 
+  /// Defines the distance between the visual model's origin and the middle of
+  /// the rear axle.
+  static constexpr double kVisOffset{1.40948};
+
   PriusVis(int id, const std::string& name);
 
   const std::vector<lcmt_viewer_link_data>& GetVisElements() const override;


### PR DESCRIPTION
Resolves #5341. Hopefully for real this time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5658)
<!-- Reviewable:end -->
