### PR TITLE
Revert "Adds offset between the vehicle model's frame and the Prius visualization's frame."

### DIFF
--- a/drake/automotive/car_vis.h
+++ b/drake/automotive/car_vis.h
@@ -39,11 +39,11 @@ class CarVis {
   /// Returns the visualization elements.
   virtual const std::vector<lcmt_viewer_link_data>& GetVisElements() const = 0;
 
-  /// Computes and returns the poses of the bodies that constitute the vehicle's
+  /// Computes and returns the poses of the bodies that are part of the
   /// visualization. The provided `X_WM` is the pose of the vehicle model in the
-  /// world frame. The origin of the model's frame is assumed to be in the
-  /// middle of the vehicle's rear axle. The poses in the returned PoseBundle
-  /// are for the visualization's elements, and are also in the world frame. The
+  /// world frame. It typically serves as the "root" or "base frame" of a
+  /// visualization model. The poses in the returned PoseBundle are for the
+  /// visualization geometry's elements, and are also in the world frame. The
   /// size of this bundle is the value returned by num_poses().
   virtual systems::rendering::PoseBundle<T> CalcPoses(
       const Isometry3<T>& X_WM) const = 0;

--- a/drake/automotive/prius_vis.cc
+++ b/drake/automotive/prius_vis.cc
@@ -1,7 +1,5 @@
 #include "drake/automotive/prius_vis.h"
 
-#include <Eigen/Geometry>
-
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"
 #include "drake/lcmt_viewer_load_robot.hpp"
@@ -21,7 +19,6 @@ using multibody::joints::kRollPitchYaw;
 using systems::rendering::PoseBundle;
 
 namespace automotive {
-template <typename T> constexpr double PriusVis<T>::kVisOffset;
 
 template <typename T>
 PriusVis<T>::PriusVis(int id, const std::string& name)
@@ -60,19 +57,8 @@ const vector<lcmt_viewer_link_data>& PriusVis<T>::GetVisElements() const {
 template <typename T>
 systems::rendering::PoseBundle<T> PriusVis<T>::CalcPoses(
     const Isometry3<T>& X_WM) const {
-  // Computes X_MV, the transform from the visualization's frame to the model's
-  // frame. The 'V' in the variable name stands for "visualization". This is
-  // necessary because the model frame's origin is centered at the midpoint of
-  // the vehicle's rear axle whereas the visualization frame's origin is
-  // centered in the middle of a body called "chassis_floor". The axes of the
-  // two frames are parallel with each other. However, the distance between the
-  // origins of the two frames is 1.40948 m along the model's x-axis.
-  const Isometry3<T> X_MV(Eigen::Translation<T, 3>(T(1.40948) /* x offset */,
-                                                   T(0)       /* y offset */,
-                                                   T(0)       /* z offset */));
-  const Isometry3<T> X_WV = X_WM * X_MV;
-  const auto rotation = X_WV.linear();
-  const auto transform = X_WV.translation();
+  const auto rotation = X_WM.linear();
+  const auto transform = X_WM.translation();
   Vector3<T> rpy = rotation.eulerAngles(2, 1, 0);
   VectorX<T> q = VectorX<T>::Zero(tree_->get_num_positions());
   q(0) = transform.x();

--- a/drake/automotive/prius_vis.h
+++ b/drake/automotive/prius_vis.h
@@ -31,10 +31,6 @@ class PriusVis : public CarVis<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PriusVis)
 
-  /// Defines the distance between the visual model's origin and the middle of
-  /// the rear axle.
-  static constexpr double kVisOffset{1.40948};
-
   PriusVis(int id, const std::string& name);
 
   const std::vector<lcmt_viewer_link_data>& GetVisElements() const override;

--- a/drake/automotive/test/prius_vis_test.cc
+++ b/drake/automotive/test/prius_vis_test.cc
@@ -1,6 +1,5 @@
 #include "drake/automotive/prius_vis.h"
 
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -19,18 +18,6 @@ using systems::rendering::PoseBundle;
 
 namespace automotive {
 namespace {
-
-// Searches the provided PoseBundle for the pose of "chassis_floor" and returns
-// a reference to it if found. It throws a std::runtime_error exception if it
-// fails to find the pose.
-const Isometry3<double>& GetChassisFloorPose(const PoseBundle<double>& poses) {
-  for (int i = 0; i < poses.get_num_poses(); ++i) {
-    if (poses.get_name(i) == "chassis_floor") {
-      return poses.get_pose(i);
-    }
-  }
-  throw std::runtime_error("Failed to find pose of chassis_floor.");
-}
 
 GTEST_TEST(PriusVisTest, BasicTest) {
   const int kModelInstanceId = 1600;
@@ -144,51 +131,7 @@ GTEST_TEST(PriusVisTest, BasicTest) {
                 frame_velocity_higher.get_value());
     }
   }
-
-  // The following tests verify that the visualization's pose is correctly
-  // offset from the model's pose. See prius_vis.cc, method CalcPoses(), for
-  // more details.
-
-  // Tests the visualization's pose when the model is rotated 90 degrees about
-  // its +Z axis.
-  const Isometry3<double>& floor_pose_identity =
-      GetChassisFloorPose(origin_vis_poses);
-  EXPECT_DOUBLE_EQ(floor_pose_identity.translation().x(),
-                   PriusVis<double>::kVisOffset);
-
-  // Tests the visualization's pose when the model is rotated 90 degrees about
-  // its +Z axis. In other words, the vehicle is facing left.
-  const Eigen::Isometry3d X_WM_W_90_about_z = math::RollPitchYawToQuaternion(
-      Eigen::Vector3d(0, 0, M_PI_2)) * Eigen::Isometry3d::Identity();
-  EXPECT_DOUBLE_EQ(
-      GetChassisFloorPose(dut.CalcPoses(X_WM_W_90_about_z)).translation().y(),
-      PriusVis<double>::kVisOffset);
-
-  // Tests the visualization's pose when the model is rotated 45 degrees about
-  // its +Y axis. In other words, the vehicle is going down a steep hill.
-  const Eigen::Isometry3d X_WM_W_45_about_y = math::RollPitchYawToQuaternion(
-      Eigen::Vector3d(0, M_PI_4, 0)) * Eigen::Isometry3d::Identity();
-  const Isometry3<double>& floor_pose_down_hill =
-      GetChassisFloorPose(dut.CalcPoses(X_WM_W_45_about_y));
-  EXPECT_DOUBLE_EQ(
-      floor_pose_down_hill.translation().x(),
-      PriusVis<double>::kVisOffset * std::cos(M_PI_4));
-  EXPECT_DOUBLE_EQ(
-      floor_pose_down_hill.translation().z(),
-      -PriusVis<double>::kVisOffset * std::cos(M_PI_4) +
-          floor_pose_identity.translation().z());
-
-  // Tests the visualization's pose when the model is rotated 45 degrees about
-  // its +X axis. In other words, the vehicle is leaning to its right side due
-  // to the lane being severely cambered.
-  const Eigen::Isometry3d X_WM_W_45_about_x = math::RollPitchYawToQuaternion(
-      Eigen::Vector3d(M_PI_4, 0, 0)) * Eigen::Isometry3d::Identity();
-  const Isometry3<double>& floor_pose_severe_camber =
-      GetChassisFloorPose(dut.CalcPoses(X_WM_W_45_about_x));
-  EXPECT_DOUBLE_EQ(floor_pose_severe_camber.translation().x(),
-      PriusVis<double>::kVisOffset);
 }
-
 
 }  // namespace
 }  // namespace automotive


### PR DESCRIPTION
Dear @liangfok ,

The on-call build cop, @mwoehlke-kitware, believes that your PR #5658 may have broken
Drake's continuous integration build [1]. It is possible to break the build even if your PR passed continuous integration pre-merge, because additional platforms and tests are built post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-clang-bazel-continuous-release/426/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-gcc-ninja-continuous-release/1710/
...and every other contemporaneous build

Therefore, the build cop has created this revert PR and started a complete post-merge build to determine whether your PR was in fact the cause of the problem. If that build passes, this revert PR will be merged 60 minutes from now. You can then fix the problem at your leisure, and send a new PR to reinstate your change.

If you believe your original PR did not actually break the build, please explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be reverted, please review and LGTM this PR. This allows the build cop to merge without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5670)
<!-- Reviewable:end -->
