### PR TITLE
Ensure that TestQPonUnitBallExample uses the specified solver interface

### DIFF
--- a/drake/solvers/test/quadratic_program_examples.cc
+++ b/drake/solvers/test/quadratic_program_examples.cc
@@ -410,11 +410,8 @@ void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
 
     x_expected << 2.0 / 3.0, 1.0 / 3.0;
 
-    SolutionResult result = SolutionResult::kUnknownError;
-
     prog.SetSolverOption(SolverType::kGurobi, "BarConvTol", 1E-9);
-    ASSERT_NO_THROW(result = prog.Solve());
-    EXPECT_EQ(result, SolutionResult::kSolutionFound);
+    ASSERT_NO_THROW(RunSolver(&prog, solver));
 
     const auto& x_value = prog.GetSolution(x);
     EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1e-5,


### PR DESCRIPTION
To address #5673, this ensures that the correct solver is used via `RunSolver` is called rather than using `MathematicalProgram::Solve`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5674)
<!-- Reviewable:end -->
