### PR TITLE
Revert Revert Adds offset between the vehicle model's frame and the Prius visualization's frame. (#5658)

### DIFF
--- a/drake/automotive/car_vis.h
+++ b/drake/automotive/car_vis.h
@@ -39,11 +39,11 @@ class CarVis {
   /// Returns the visualization elements.
   virtual const std::vector<lcmt_viewer_link_data>& GetVisElements() const = 0;
 
-  /// Computes and returns the poses of the bodies that are part of the
+  /// Computes and returns the poses of the bodies that constitute the vehicle's
   /// visualization. The provided `X_WM` is the pose of the vehicle model in the
-  /// world frame. It typically serves as the "root" or "base frame" of a
-  /// visualization model. The poses in the returned PoseBundle are for the
-  /// visualization geometry's elements, and are also in the world frame. The
+  /// world frame. The origin of the model's frame is assumed to be in the
+  /// middle of the vehicle's rear axle. The poses in the returned PoseBundle
+  /// are for the visualization's elements, and are also in the world frame. The
   /// size of this bundle is the value returned by num_poses().
   virtual systems::rendering::PoseBundle<T> CalcPoses(
       const Isometry3<T>& X_WM) const = 0;

--- a/drake/automotive/prius_vis.cc
+++ b/drake/automotive/prius_vis.cc
@@ -1,5 +1,7 @@
 #include "drake/automotive/prius_vis.h"
 
+#include <Eigen/Geometry>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"
 #include "drake/lcmt_viewer_load_robot.hpp"
@@ -19,6 +21,7 @@ using multibody::joints::kRollPitchYaw;
 using systems::rendering::PoseBundle;
 
 namespace automotive {
+template <typename T> constexpr double PriusVis<T>::kVisOffset;
 
 template <typename T>
 PriusVis<T>::PriusVis(int id, const std::string& name)
@@ -57,8 +60,19 @@ const vector<lcmt_viewer_link_data>& PriusVis<T>::GetVisElements() const {
 template <typename T>
 systems::rendering::PoseBundle<T> PriusVis<T>::CalcPoses(
     const Isometry3<T>& X_WM) const {
-  const auto rotation = X_WM.linear();
-  const auto transform = X_WM.translation();
+  // Computes X_MV, the transform from the visualization's frame to the model's
+  // frame. The 'V' in the variable name stands for "visualization". This is
+  // necessary because the model frame's origin is centered at the midpoint of
+  // the vehicle's rear axle whereas the visualization frame's origin is
+  // centered in the middle of a body called "chassis_floor". The axes of the
+  // two frames are parallel with each other. However, the distance between the
+  // origins of the two frames is 1.40948 m along the model's x-axis.
+  const Isometry3<T> X_MV(Eigen::Translation<T, 3>(T(1.40948) /* x offset */,
+                                                   T(0)       /* y offset */,
+                                                   T(0)       /* z offset */));
+  const Isometry3<T> X_WV = X_WM * X_MV;
+  const auto rotation = X_WV.linear();
+  const auto transform = X_WV.translation();
   Vector3<T> rpy = rotation.eulerAngles(2, 1, 0);
   VectorX<T> q = VectorX<T>::Zero(tree_->get_num_positions());
   q(0) = transform.x();

--- a/drake/automotive/prius_vis.h
+++ b/drake/automotive/prius_vis.h
@@ -31,6 +31,10 @@ class PriusVis : public CarVis<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PriusVis)
 
+  /// Defines the distance between the visual model's origin and the middle of
+  /// the rear axle.
+  static constexpr double kVisOffset{1.40948};
+
   PriusVis(int id, const std::string& name);
 
   const std::vector<lcmt_viewer_link_data>& GetVisElements() const override;

--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -257,7 +257,8 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
   // Checks the chassis_floor body of the first car.
   EXPECT_EQ(draw_message.link_name.at(0), "chassis_floor");
   EXPECT_EQ(draw_message.robot_num.at(0), 0);
-  EXPECT_NEAR(draw_message.position.at(0).at(0), 0.99, 1e-8);
+  EXPECT_NEAR(draw_message.position.at(0).at(0),
+      PriusVis<double>::kVisOffset + 0.99, 1e-6);
   EXPECT_NEAR(draw_message.position.at(0).at(1), 0, 1e-8);
   EXPECT_NEAR(draw_message.position.at(0).at(2), 0.378326, 1e-8);
   EXPECT_NEAR(draw_message.quaternion.at(0).at(0), 1, 1e-8);


### PR DESCRIPTION
This reverts #5670 which was a revert of #5658 and includes a fix for the bug that resulted in #5658 being reverted. Relative to the original #5658 , the only difference is in `drake-distro/drake/automotive/test/automotive_simulator_test.cc`, line 260. 

# Previous Code

```
EXPECT_NEAR(draw_message.position.at(0).at(0), 0.99, 1e-8);
```

# Corrected Code

```
  EXPECT_NEAR(draw_message.position.at(0).at(0),
      PriusVis<double>::kVisOffset + 0.99, 1e-6);
```

The above change is necessary due to this PR shifting the visualization's origin. 

# Post Mortem
The #5670 revert was due to #5664 being merged followed by #5677 being merged without first rebasing with `master`. #5664 added a unit test that's sensitive to the pose of the `PriusVis` visual elements while #5677 shifted the poses of these elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5677)
<!-- Reviewable:end -->
