### PR TITLE
Add Get/SetOptimalCost in MathematicalProgram

### DIFF
--- a/drake/solvers/equality_constrained_qp_solver.cc
+++ b/drake/solvers/equality_constrained_qp_solver.cc
@@ -110,7 +110,10 @@ SolutionResult EqualityConstrainedQPSolver::Solve(
     Eigen::VectorXd lambda = qr.solve(AiG_T.transpose() * c + b);
 
     // Solve G*x = A'y - c
-    prog.SetDecisionVariableValues(llt.solve(A.transpose() * lambda - c));
+    const Eigen::VectorXd x = llt.solve(A.transpose() * lambda - c);
+    prog.SetDecisionVariableValues(x);
+    const double optimal_cost = 0.5 * x.dot(G * x + c);
+    prog.SetOptimalCost(optimal_cost);
     prog.SetSolverResult(solver_type(), 0);
     return SolutionResult::kSolutionFound;
   }
@@ -139,7 +142,11 @@ SolutionResult EqualityConstrainedQPSolver::Solve(
   // Compute the least-squares solution.
   Eigen::VectorXd sol =
       A_full.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(b_full);
-  prog.SetDecisionVariableValues(sol.segment(0, prog.num_vars()));
+  const Eigen::VectorXd x = sol.segment(0, prog.num_vars());
+  prog.SetDecisionVariableValues(x);
+
+  const double optimal_cost = 0.5 * x.dot(G * x + c);
+  prog.SetOptimalCost(optimal_cost);
 
   prog.SetSolverResult(solver_type(), 0);
   return SolutionResult::kSolutionFound;

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -636,6 +636,11 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
         }
       }
       prog.SetDecisionVariableValues(prog_sol_vector);
+
+      // Obtain optimal cost
+      double optimal_cost = std::numeric_limits<double>::quiet_NaN();
+      GRBgetdblattr(model, GRB_DBL_ATTR_OBJVAL, &optimal_cost);
+      prog.SetOptimalCost(optimal_cost);
     }
   }
 

--- a/drake/solvers/ipopt_solver.cc
+++ b/drake/solvers/ipopt_solver.cc
@@ -405,6 +405,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
       solution(i) = x[i];
     }
     problem_->SetDecisionVariableValues(solution);
+    problem_->SetOptimalCost(obj_value);
   }
 
   SolutionResult result() const { return result_; }

--- a/drake/solvers/linear_system_solver.cc
+++ b/drake/solvers/linear_system_solver.cc
@@ -46,6 +46,7 @@ SolutionResult LinearSystemSolver::Solve(MathematicalProgram& prog) const {
   // least-squares solution
   prog.SetDecisionVariableValues(
       Aeq.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(beq));
+  prog.SetOptimalCost(0.);
 
   prog.SetSolverResult(solver_type(), 0);
   return SolutionResult::kSolutionFound;

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -86,6 +86,7 @@ MathematicalProgram::MathematicalProgram()
       x_initial_guess_(
           static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)),
       solver_result_(0),
+      optimal_cost_(std::numeric_limits<double>::quiet_NaN()),
       required_capabilities_(kNoCapabilities),
       ipopt_solver_(new IpoptSolver()),
       nlopt_solver_(new NloptSolver()),

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2153,6 +2153,18 @@ class MathematicalProgram {
   }
 
   /**
+   * Getter for optimal cost at the solution. Will return NaN if there has
+   * been no successful solution.
+   */
+  double GetOptimalCost() const {
+    return optimal_cost_;
+  }
+
+  void SetOptimalCost(double optimal_cost) {
+    optimal_cost_ = optimal_cost;
+  }
+
+  /**
    * Getter for all generic costs.
    */
   const std::vector<Binding<Constraint>>& generic_costs() const {
@@ -2401,6 +2413,7 @@ class MathematicalProgram {
   std::shared_ptr<SolverData> solver_data_;
   SolverType solver_type_;
   int solver_result_;
+  double optimal_cost_;
   std::map<SolverType, std::map<std::string, double>> solver_options_double_;
   std::map<SolverType, std::map<std::string, int>> solver_options_int_;
   std::map<SolverType, std::map<std::string, std::string>> solver_options_str_;

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -196,6 +196,7 @@ SolutionResult MobyLCPSolver<T>::Solve(MathematicalProgram& prog) const {
       return SolutionResult::kUnknownError;
     }
     prog.SetDecisionVariableValues(binding.variables(), constraint_solution);
+    prog.SetOptimalCost(0.0);
   }
   return SolutionResult::kSolutionFound;
 }

--- a/drake/solvers/mosek_solver.cc
+++ b/drake/solvers/mosek_solver.cc
@@ -683,6 +683,12 @@ SolutionResult MosekSolver::Solve(MathematicalProgram& prog) const {
           if (rescode == MSK_RES_OK) {
             prog.SetDecisionVariableValues(sol_vector);
           }
+          MSKrealt optimal_cost;
+          rescode = MSK_getprimalobj(task, solution_type, &optimal_cost);
+          DRAKE_ASSERT(rescode == MSK_RES_OK);
+          if (rescode == MSK_RES_OK) {
+            prog.SetOptimalCost(optimal_cost);
+          }
           break;
         }
         case MSK_SOL_STA_DUAL_INFEAS_CER:

--- a/drake/solvers/nlopt_solver.cc
+++ b/drake/solvers/nlopt_solver.cc
@@ -374,8 +374,9 @@ SolutionResult NloptSolver::Solve(MathematicalProgram& prog) const {
 
   SolutionResult result = SolutionResult::kSolutionFound;
   nlopt::result nlopt_result = nlopt::FAILURE;
+
+  double minf = 0;
   try {
-    double minf = 0;
     nlopt_result = opt.optimize(x, minf);
   } catch (std::invalid_argument&) {
     result = SolutionResult::kInvalidInput;
@@ -395,6 +396,7 @@ SolutionResult NloptSolver::Solve(MathematicalProgram& prog) const {
   }
 
   prog.SetDecisionVariableValues(sol);
+  prog.SetOptimalCost(minf);
   prog.SetSolverResult(solver_type(), nlopt_result);
   return result;
 }

--- a/drake/solvers/snopt_solver.cc
+++ b/drake/solvers/snopt_solver.cc
@@ -545,6 +545,7 @@ SolutionResult SnoptSolver::Solve(MathematicalProgram& prog) const {
     sol(i) = static_cast<double>(x[i]);
   }
   prog.SetDecisionVariableValues(sol);
+  prog.SetOptimalCost(*F);
   prog.SetSolverResult(solver_type(), info);
 
   // todo: extract the other useful quantities, too.

--- a/drake/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/drake/solvers/test/equality_constrained_qp_solver_test.cc
@@ -41,6 +41,8 @@ GTEST_TEST(testMathematicalProgram, testUnconstrainedQPDispatch) {
   auto x_value = prog.GetSolution(x);
   EXPECT_TRUE(CompareMatrices(expected_answer, x_value, 1e-10,
                               MatrixCompareType::absolute));
+  EXPECT_NEAR(0.0, prog.GetOptimalCost(), 1e-10);
+
 // There are no inequality constraints, and only quadratic costs,
 // so this should hold:
   CheckSolver(prog, SolverType::kEqualityConstrainedQP);
@@ -66,6 +68,7 @@ GTEST_TEST(testMathematicalProgram, testUnconstrainedQPDispatch) {
                               MatrixCompareType::absolute))
             << "\tExpected: " << expected_answer.transpose()
             << "\tActual: " << actual_answer.transpose();
+  EXPECT_NEAR(0.0, prog.GetOptimalCost(), 1e-10);
 
   // Problem still has only quadratic costs, so solver should be the same.
   CheckSolver(prog, SolverType::kEqualityConstrainedQP);
@@ -102,6 +105,8 @@ GTEST_TEST(testMathematicalProgram, testLinearlyConstrainedQPDispatch) {
   EXPECT_TRUE(CompareMatrices(expected_answer, x_value, 1e-10,
                               MatrixCompareType::absolute));
 
+  EXPECT_NEAR(-0.25, prog.GetOptimalCost(), 1e-10);
+
   // This problem is now an Equality Constrained QP and should
   // use this solver:
   CheckSolver(
@@ -129,6 +134,7 @@ GTEST_TEST(testMathematicalProgram, testLinearlyConstrainedQPDispatch) {
                               MatrixCompareType::absolute))
             << "\tExpected: " << expected_answer.transpose()
             << "\tActual: " << actual_answer.transpose();
+  EXPECT_NEAR(-0.25, prog.GetOptimalCost(), 1e-10);
 }
 }  // namespace test
 }  // namespace solvers

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -31,9 +31,11 @@ TEST_F(InfeasibleLinearProgramTest0, TestGurobiInfeasible) {
     prog_->SetSolverOption(SolverType::kGurobi, "DualReductions", 1);
     SolutionResult result = solver.Solve(*prog_);
     EXPECT_EQ(result, SolutionResult::kInfeasible_Or_Unbounded);
+    EXPECT_TRUE(std::isnan(prog_->GetOptimalCost()));
     prog_->SetSolverOption(SolverType::kGurobi, "DualReductions", 0);
     result = solver.Solve(*prog_);
     EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
+    EXPECT_TRUE(std::isnan(prog_->GetOptimalCost()));
   }
 }
 
@@ -96,6 +98,7 @@ GTEST_TEST(GurobiTest, TestInitialGuess) {
       const auto& x_value = prog.GetSolution(x);
       EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1E-6,
                                   MatrixCompareType::absolute));
+      ExpectSolutionCostAccurate(prog, 1E-6);
     }
   }
 }

--- a/drake/solvers/test/linear_program_examples.cc
+++ b/drake/solvers/test/linear_program_examples.cc
@@ -132,6 +132,7 @@ void LinearProgram0::CheckSolution(SolverType solver_type) const {
   double tol = GetSolverSolutionDefaultCompareTolerance(solver_type);
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), tol);
 }
 
 LinearProgram1::LinearProgram1(CostForm cost_form, ConstraintForm cnstr_form)
@@ -171,6 +172,7 @@ void LinearProgram1::CheckSolution(SolverType solver_type) const {
   double tol = GetSolverSolutionDefaultCompareTolerance(solver_type);
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), tol);
 }
 
 LinearProgram2::LinearProgram2(CostForm cost_form, ConstraintForm cnstr_form)
@@ -257,6 +259,7 @@ void LinearProgram2::CheckSolution(SolverType solver_type) const {
   double tol = GetSolverSolutionDefaultCompareTolerance(solver_type);
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), tol);
 }
 
 LinearProgram3::LinearProgram3(CostForm cost_form, ConstraintForm cnstr_form)
@@ -327,8 +330,14 @@ void LinearProgram3::CheckSolution(SolverType solver_type) const {
   if (solver_type == SolverType::kMosek) {
     tol = 1E-6;
   }
+  // Ipopt has a looser objective tolerance
+  double cost_tol = tol;
+  if (solver_type == SolverType::kIpopt) {
+    cost_tol = 1E-5;
+  }
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), cost_tol);
 }
 
 

--- a/drake/solvers/test/linear_system_solver_test.cc
+++ b/drake/solvers/test/linear_system_solver_test.cc
@@ -14,7 +14,7 @@ namespace {
 void TestLinearSystemExample(LinearSystemExample1* example) {
   example->prog()->Solve();
   CheckSolver(*(example->prog()), SolverType::kLinearSystem);
-  EXPECT_TRUE(example->CheckSolution());
+  example->CheckSolution();
 }
 }  // namespace
 
@@ -33,7 +33,7 @@ GTEST_TEST(testLinearSystemSolver, linearMatrixEqualityExample) {
   LinearMatrixEqualityExample example{};
   example.prog()->Solve();
   CheckSolver(*(example.prog()), SolverType::kLinearSystem);
-  EXPECT_TRUE(example.CheckSolution());
+  example.CheckSolution();
 }
 }  // namespace test
 }  // namespace solvers

--- a/drake/solvers/test/nonlinear_program_test.cc
+++ b/drake/solvers/test/nonlinear_program_test.cc
@@ -93,15 +93,15 @@ GTEST_TEST(testNonlinearProgram, BoundingBoxTest) {
 GTEST_TEST(testNonlinearProgram, trivialLinearSystem) {
   LinearSystemExample1 example1{};
   auto prog = example1.prog();
-  RunNonlinearProgram(prog, [&]() { EXPECT_TRUE(example1.CheckSolution()); });
+  RunNonlinearProgram(prog, [&]() { example1.CheckSolution(); });
 
   LinearSystemExample2 example2{};
   prog = example2.prog();
-  RunNonlinearProgram(prog, [&]() { EXPECT_TRUE(example2.CheckSolution()); });
+  RunNonlinearProgram(prog, [&]() { example2.CheckSolution(); });
 
   LinearSystemExample3 example3{};
   prog = example3.prog();
-  RunNonlinearProgram(prog, [&]() { EXPECT_TRUE(example3.CheckSolution()); });
+  RunNonlinearProgram(prog, [&]() { example3.CheckSolution(); });
 }
 
 GTEST_TEST(testNonlinearProgram, trivialLinearEquality) {
@@ -157,7 +157,7 @@ GTEST_TEST(testNonlinearProgram, testNonConvexQPproblem1) {
     for (const auto& cnstr_form : NonConvexQPproblem1::constraint_forms()) {
       NonConvexQPproblem1 prob(cost_form, cnstr_form);
       RunNonlinearProgram(prob.prog(),
-                          [&]() { EXPECT_TRUE(prob.CheckSolution()); });
+                          [&]() { prob.CheckSolution(); });
     }
   }
 }
@@ -167,7 +167,7 @@ GTEST_TEST(testNonlinearProgram, testNonConvexQPproblem2) {
     for (const auto& cnstr_form : NonConvexQPproblem2::constraint_forms()) {
       NonConvexQPproblem2 prob(cost_form, cnstr_form);
       RunNonlinearProgram(prob.prog(),
-                          [&]() { EXPECT_TRUE(prob.CheckSolution()); });
+                          [&]() { prob.CheckSolution(); });
     }
   }
 }
@@ -177,10 +177,10 @@ GTEST_TEST(testNonlinearProgram, testLowerBoundedProblem) {
     LowerBoundedProblem prob(cnstr_form);
     prob.SetInitialGuess1();
     RunNonlinearProgram(prob.prog(),
-                        [&]() { EXPECT_TRUE(prob.CheckSolution()); });
+                        [&]() { prob.CheckSolution(); });
     prob.SetInitialGuess2();
     RunNonlinearProgram(prob.prog(),
-                        [&]() { EXPECT_TRUE(prob.CheckSolution()); });
+                        [&]() { prob.CheckSolution(); });
   }
 }
 
@@ -229,7 +229,7 @@ GTEST_TEST(testNonlinearProgram, testGloptiPolyConstrainedMinimization) {
          GloptiPolyConstrainedMinimizationProblem::constraint_forms()) {
       GloptiPolyConstrainedMinimizationProblem prob(cost_form, cnstr_form);
       RunNonlinearProgram(prob.prog(),
-                          [&]() { EXPECT_TRUE(prob.CheckSolution()); });
+                          [&]() { prob.CheckSolution(); });
     }
   }
 }

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -35,6 +35,22 @@ std::set<CostForm> quadratic_cost_form() {
   return std::set<CostForm>{CostForm::kNonSymbolic, CostForm::kSymbolic};
 }
 
+double EvaluateSolutionCost(const MathematicalProgram &prog) {
+  double cost{0};
+  for (auto const& binding : prog.GetAllCosts()) {
+    cost += prog.EvalBindingAtSolution(binding)(0);
+  }
+  return cost;
+}
+
+/*
+ * Expect that the optimal cost stored by the solver in the MathematicalProgram
+ * be nearly the same as the cost reevaluated at the solution
+ */
+void ExpectSolutionCostAccurate(const MathematicalProgram &prog, double tol) {
+  EXPECT_NEAR(EvaluateSolutionCost(prog), prog.GetOptimalCost(), tol);
+}
+
 OptimizationProgram::OptimizationProgram(CostForm cost_form,
                                          ConstraintForm cnstr_form)
     : prog_(std::make_unique<MathematicalProgram>()) {}
@@ -79,21 +95,15 @@ LinearSystemExample1::LinearSystemExample1()
   prog_->SetInitialGuessForAllVariables(Vector4d::Zero());
 }
 
-bool LinearSystemExample1::CheckSolution() const {
+void LinearSystemExample1::CheckSolution() const {
   auto x_sol = prog_->GetSolution(x_);
-  if (!CompareMatrices(x_sol, b_, tol(), MatrixCompareType::absolute)) {
-    return false;
-  }
+  EXPECT_TRUE(CompareMatrices(x_sol, b_, tol(), MatrixCompareType::absolute));
   for (int i = 0; i < 4; ++i) {
-    if (std::abs(x_sol(i) - b_(i)) > tol()) {
-      return false;
-    }
-    if (!CompareMatrices(x_sol.head(i), b_.head(i), tol(),
-                         MatrixCompareType::absolute)) {
-      return false;
-    }
+    EXPECT_NEAR(b_(i), x_sol(i), tol());
+    EXPECT_TRUE(CompareMatrices(x_sol.head(i), b_.head(i), tol(),
+                                MatrixCompareType::absolute));
   }
-  return true;
+  EXPECT_NEAR(0.0, prog_->GetOptimalCost(), tol());
 }
 
 LinearSystemExample2::LinearSystemExample2() : LinearSystemExample1(), y_{} {
@@ -102,31 +112,23 @@ LinearSystemExample2::LinearSystemExample2() : LinearSystemExample1(), y_{} {
                                       b().topRows<2>(), y_);
 }
 
-bool LinearSystemExample2::CheckSolution() const {
-  if (!LinearSystemExample1::CheckSolution()) {
-    return false;
-  }
-  if (!CompareMatrices(prog()->GetSolution(y_), b().topRows<2>() / 2, tol(),
-                       MatrixCompareType::absolute)) {
-    return false;
-  }
-  return true;
+void LinearSystemExample2::CheckSolution() const {
+  LinearSystemExample1::CheckSolution();
+  EXPECT_TRUE(CompareMatrices(prog()->GetSolution(y_), b().topRows<2>() / 2,
+                              tol(), MatrixCompareType::absolute));
+  EXPECT_NEAR(0.0, prog()->GetOptimalCost(), tol());
 }
 
 LinearSystemExample3::LinearSystemExample3() : LinearSystemExample2() {
   con()->UpdateConstraint(3 * Matrix4d::Identity(), b());
 }
 
-bool LinearSystemExample3::CheckSolution() const {
-  if (!CompareMatrices(prog()->GetSolution(x()), b() / 3, tol(),
-                       MatrixCompareType::absolute)) {
-    return false;
-  }
-  if (!CompareMatrices(prog()->GetSolution(y()), b().topRows<2>() / 2, tol(),
-                       MatrixCompareType::absolute)) {
-    return false;
-  }
-  return true;
+void LinearSystemExample3::CheckSolution() const {
+  EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x()), b() / 3, tol(),
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(prog()->GetSolution(y()), b().topRows<2>() / 2,
+                              tol(), MatrixCompareType::absolute));
+  EXPECT_NEAR(0.0, prog()->GetOptimalCost(), tol());
 }
 
 LinearMatrixEqualityExample::LinearMatrixEqualityExample()
@@ -141,19 +143,15 @@ LinearMatrixEqualityExample::LinearMatrixEqualityExample()
                                      -Eigen::Matrix3d::Identity(), true);
 }
 
-bool LinearMatrixEqualityExample::CheckSolution() const {
+void LinearMatrixEqualityExample::CheckSolution() const {
   auto X_value = prog_->GetSolution(X_);
-  if (!CompareMatrices(A_.transpose() * X_value + X_value * A_,
-                       -Eigen::Matrix3d::Identity(), 1E-8,
-                       MatrixCompareType::absolute)) {
-    return false;
-  }
+  EXPECT_TRUE(CompareMatrices(A_.transpose() * X_value + X_value * A_,
+                              -Eigen::Matrix3d::Identity(), 1E-8,
+                              MatrixCompareType::absolute));
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es;
   es.compute(X_value);
-  if (!(es.eigenvalues().array() >= 0).all()) {
-    return false;
-  }
-  return true;
+  EXPECT_TRUE((es.eigenvalues().array() >= 0).all());
+  EXPECT_NEAR(0.0, prog_->GetOptimalCost(), 1E-8);
 }
 
 NonConvexQPproblem1::NonConvexQPproblem1(CostForm cost_form,
@@ -191,10 +189,11 @@ NonConvexQPproblem1::NonConvexQPproblem1(CostForm cost_form,
       x_, x_expected_ + 0.01 * Eigen::Matrix<double, 5, 1>::Random());
 }
 
-bool NonConvexQPproblem1::CheckSolution() const {
+void NonConvexQPproblem1::CheckSolution() const {
   const auto& x_value = prog_->GetSolution(x_);
-  return CompareMatrices(x_value, x_expected_, 1E-9,
-                         MatrixCompareType::absolute);
+  EXPECT_TRUE(CompareMatrices(x_value, x_expected_, 1E-9,
+                              MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog_, 1E-5);
 }
 
 void NonConvexQPproblem1::AddConstraint() {
@@ -257,10 +256,11 @@ NonConvexQPproblem2::NonConvexQPproblem2(CostForm cost_form,
       x_, x_expected_ + 0.01 * Eigen::Matrix<double, 6, 1>::Random());
 }
 
-bool NonConvexQPproblem2::CheckSolution() const {
+void NonConvexQPproblem2::CheckSolution() const {
   const auto& x_value = prog_->GetSolution(x_);
-  return CompareMatrices(x_value, x_expected_, 1E-3,
-                         MatrixCompareType::absolute);
+  EXPECT_TRUE(CompareMatrices(x_value, x_expected_, 1E-3,
+                              MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog_, 1E-4);
 }
 
 void NonConvexQPproblem2::AddQuadraticCost() {
@@ -325,10 +325,11 @@ LowerBoundedProblem::LowerBoundedProblem(ConstraintForm cnstr_form)
   x_expected_ << 5, 1, 5, 0, 5, 10;
 }
 
-bool LowerBoundedProblem::CheckSolution() const {
+void LowerBoundedProblem::CheckSolution() const {
   const auto& x_value = prog_->GetSolution(x_);
-  return CompareMatrices(x_value, x_expected_, 1E-3,
-                         MatrixCompareType::absolute);
+  EXPECT_TRUE(CompareMatrices(x_value, x_expected_, 1E-3,
+                              MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog_, 1E-2);
 }
 
 void LowerBoundedProblem::SetInitialGuess1() {
@@ -421,13 +422,14 @@ GloptiPolyConstrainedMinimizationProblem::
   prog_->SetInitialGuess(y_, initial_guess);
 }
 
-bool GloptiPolyConstrainedMinimizationProblem::CheckSolution() const {
+void GloptiPolyConstrainedMinimizationProblem::CheckSolution() const {
   const auto& x_value = prog_->GetSolution(x_);
   const auto& y_value = prog_->GetSolution(y_);
-  return (CompareMatrices(x_value, expected_, 1E-4,
-                          MatrixCompareType::absolute)) &&
-         (CompareMatrices(y_value, expected_, 1E-4,
-                          MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(x_value, expected_, 1E-4,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(y_value, expected_, 1E-4,
+                              MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog_, 1E-4);
 }
 
 void GloptiPolyConstrainedMinimizationProblem::AddGenericCost() {
@@ -583,24 +585,27 @@ void MinDistanceFromPlaneToOrigin::SetInitialGuess() {
       x_rotated_lorentz_, x_expected_ + 0.1 * VectorXd::Ones(A_.cols()));
 }
 
-bool MinDistanceFromPlaneToOrigin::CheckSolution(bool rotated_cone) const {
+void MinDistanceFromPlaneToOrigin::CheckSolution(bool rotated_cone) const {
   if (rotated_cone) {
     auto x_rotated_lorentz_value =
         prog_rotated_lorentz_->GetSolution(x_rotated_lorentz_);
     auto t_rotated_lorentz_value =
         prog_rotated_lorentz_->GetSolution(t_rotated_lorentz_);
-    return CompareMatrices(x_rotated_lorentz_value, x_expected_, 1E-3,
-                           MatrixCompareType::absolute) &&
-           CompareMatrices(t_rotated_lorentz_value,
-                           Vector1d(x_expected_.squaredNorm()), 1E-3,
-                           MatrixCompareType::absolute);
+    EXPECT_TRUE(CompareMatrices(x_rotated_lorentz_value, x_expected_, 1E-3,
+                                MatrixCompareType::absolute));
+    EXPECT_TRUE(CompareMatrices(t_rotated_lorentz_value,
+                                Vector1d(x_expected_.squaredNorm()), 1E-3,
+                                MatrixCompareType::absolute));
+    ExpectSolutionCostAccurate(*prog_rotated_lorentz_, 1E-3);
   } else {
     auto x_lorentz_value = prog_lorentz_->GetSolution(x_lorentz_);
     auto t_lorentz_value = prog_lorentz_->GetSolution(t_lorentz_);
-    return CompareMatrices(x_lorentz_value, x_expected_, 1E-3,
-                           MatrixCompareType::absolute) &&
-           CompareMatrices(t_lorentz_value, Vector1d(x_expected_.norm()), 1E-3,
-                           MatrixCompareType::absolute);
+    EXPECT_TRUE(CompareMatrices(x_lorentz_value, x_expected_, 1E-3,
+                                MatrixCompareType::absolute));
+    EXPECT_TRUE(CompareMatrices(t_lorentz_value,
+                                Vector1d(x_expected_.norm()), 1E-3,
+                                MatrixCompareType::absolute));
+    ExpectSolutionCostAccurate(*prog_lorentz_, 1E-3);
   }
 }
 }  // namespace test

--- a/drake/solvers/test/optimization_examples.h
+++ b/drake/solvers/test/optimization_examples.h
@@ -27,6 +27,8 @@ enum class ConstraintForm {
   kFormula = 3,
 };
 
+void ExpectSolutionCostAccurate(const MathematicalProgram &prog, double tol);
+
 class OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptimizationProgram)
@@ -65,7 +67,7 @@ class LinearSystemExample1 {
 
   std::shared_ptr<LinearEqualityConstraint> con() const { return con_; }
 
-  virtual bool CheckSolution() const;
+  virtual void CheckSolution() const;
 
  protected:
   double tol() const { return 1E-10; }
@@ -92,7 +94,7 @@ class LinearSystemExample2 : public LinearSystemExample1 {
 
   VectorDecisionVariable<2> y() const { return y_; }
 
-  bool CheckSolution() const override;
+  void CheckSolution() const override;
 
  private:
   VectorDecisionVariable<2> y_;
@@ -111,7 +113,7 @@ class LinearSystemExample3 : public LinearSystemExample2 {
   LinearSystemExample3();
   ~LinearSystemExample3() override {}
 
-  bool CheckSolution() const override;
+  void CheckSolution() const override;
 };
 
 /**
@@ -127,7 +129,7 @@ class LinearMatrixEqualityExample {
 
   MathematicalProgram* prog() const { return prog_.get(); }
 
-  bool CheckSolution() const;
+  void CheckSolution() const;
 
  private:
   std::unique_ptr<MathematicalProgram> prog_;
@@ -162,7 +164,7 @@ class NonConvexQPproblem1 {
 
   MathematicalProgram* prog() const { return prog_.get(); }
 
-  bool CheckSolution() const;
+  void CheckSolution() const;
 
  private:
   class TestProblem1Cost {
@@ -219,7 +221,7 @@ class NonConvexQPproblem2 {
 
   NonConvexQPproblem2(CostForm cost_form, ConstraintForm cnstr_form);
 
-  bool CheckSolution() const;
+  void CheckSolution() const;
 
   MathematicalProgram* prog() const { return prog_.get(); }
 
@@ -273,7 +275,7 @@ class LowerBoundedProblem {
 
   explicit LowerBoundedProblem(ConstraintForm cnstr_form);
 
-  bool CheckSolution() const;
+  void CheckSolution() const;
 
   MathematicalProgram* prog() { return prog_.get(); }
 
@@ -379,7 +381,7 @@ class GloptiPolyConstrainedMinimizationProblem {
 
   MathematicalProgram* prog() const { return prog_.get(); }
 
-  bool CheckSolution() const;
+  void CheckSolution() const;
 
  private:
   class GloptipolyConstrainedExampleCost {
@@ -496,7 +498,7 @@ class MinDistanceFromPlaneToOrigin {
 
   void SetInitialGuess();
 
-  bool CheckSolution(bool is_rotated_cone) const;
+  void CheckSolution(bool is_rotated_cone) const;
 
  private:
   void AddNonSymbolicConstraint();

--- a/drake/solvers/test/quadratic_program_examples.cc
+++ b/drake/solvers/test/quadratic_program_examples.cc
@@ -120,6 +120,7 @@ void QuadraticProgram0::CheckSolution(SolverType solver_type) const {
   }
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), tol);
 }
 
 QuadraticProgram1::QuadraticProgram1(CostForm cost_form,
@@ -204,6 +205,7 @@ void QuadraticProgram1::CheckSolution(SolverType solver_type) const {
   }
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), tol);
 }
 
 QuadraticProgram2::QuadraticProgram2(CostForm cost_form,
@@ -243,6 +245,7 @@ void QuadraticProgram2::CheckSolution(SolverType solver_type) const {
   }
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), tol);
 }
 
 QuadraticProgram3::QuadraticProgram3(CostForm cost_form,
@@ -298,6 +301,7 @@ void QuadraticProgram3::CheckSolution(SolverType solver_type) const {
   }
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), tol);
 }
 
 QuadraticProgram4::QuadraticProgram4(CostForm cost_form,
@@ -347,6 +351,7 @@ void QuadraticProgram4::CheckSolution(SolverType solver_type) const {
   }
   EXPECT_TRUE(CompareMatrices(prog()->GetSolution(x_), x_expected_, tol,
                               MatrixCompareType::absolute));
+  ExpectSolutionCostAccurate(*prog(), tol);
 }
 
 void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
@@ -416,6 +421,7 @@ void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
     const auto& x_value = prog.GetSolution(x);
     EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1e-5,
                                 MatrixCompareType::absolute));
+    ExpectSolutionCostAccurate(prog, 1E-5);
   }
 }
 }  // namespace test


### PR DESCRIPTION
To address #5647, this updates the `MathematicalProgram` interface to expose the aggregate cost at the optimal solution, updates each solver implementation to use this interface, and updates existing solver tests to check this behavior.

Further actions regarding how the decision variables and cost will synchronize with failures will be addressed in #5681.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5685)
<!-- Reviewable:end -->
