### PR TITLE
Adds onramp road network option to automotive_demo.

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -319,6 +319,7 @@ drake_cc_binary(
     ],
     deps = [
         ":automotive_simulator",
+        ":monolane_onramp_merge",
         "//drake/automotive/maliput/dragway",
         "//drake/common:text_logging_gflags",
     ],

--- a/drake/automotive/automotive_demo.cc
+++ b/drake/automotive/automotive_demo.cc
@@ -8,18 +8,20 @@
 #include "drake/automotive/create_trajectory_params.h"
 #include "drake/automotive/gen/maliput_railcar_params.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
+#include "drake/automotive/monolane_onramp_merge.h"
 #include "drake/common/drake_path.h"
 #include "drake/common/text_logging_gflags.h"
-
 
 DEFINE_string(simple_car_names, "",
               "A comma-separated list (e.g. 'Russ,Jeremy,Liang' would spawn 3 "
               "cars subscribed to DRIVING_COMMAND_Russ, "
               "DRIVING_COMMAND_Jeremy, and DRIVING_COMMAND_Liang)");
-DEFINE_int32(num_trajectory_car, 1, "Number of TrajectoryCar vehicles");
+DEFINE_int32(num_trajectory_car, 1, "Number of TrajectoryCar vehicles. This "
+             "option is currently only applied when the road network is a flat "
+             " plane or a dragway.");
 DEFINE_int32(num_maliput_railcar, 0, "Number of MaliputRailcar vehicles. This "
              "option is currently only applied when the road network is a "
-             "dragway.");
+             "dragway or merge.");
 DEFINE_double(target_realtime_rate, 1.0,
               "Playback speed.  See documentation for "
               "Simulator::set_target_realtime_rate() for details.");
@@ -30,7 +32,8 @@ DEFINE_int32(num_dragway_lanes, 0,
              "The number of lanes on the dragway. The number of lanes is by "
              "default zero to disable the dragway. A dragway road network is "
              "only enabled when the user specifies a number of lanes greater "
-             "than zero.");
+             "than zero. Only one road network can be enabled. Thus if this "
+             "option is enabled, no other road network can be enabled.");
 DEFINE_double(dragway_length, 100, "The length of the dragway.");
 DEFINE_double(dragway_lane_width, 3.7, "The dragway lane width.");
 DEFINE_double(dragway_shoulder_width, 3.0, "The dragway's shoulder width.");
@@ -49,13 +52,25 @@ DEFINE_double(dragway_vehicle_delay, 3,
               "The starting time delay between consecutive vehicles on a "
               "lane.");
 
+DEFINE_bool(with_onramp, false, "Loads the onramp road network. Only one road "
+            "network can be enabled. Thus, if this option is enabled, no other "
+            "road network can be enabled.");
+DEFINE_double(onramp_base_speed, 25, "The speed of the vehicles added to the "
+              "onramp.");
+DEFINE_bool(onramp_swap_start, false, "Whether to swap the starting lanes of "
+    "the vehicles on the onramp.");
+
 namespace drake {
+
+using maliput::api::Lane;
+
 namespace automotive {
 namespace {
 
 enum class RoadNetworkType {
   flat = 0,
-  dragway = 1
+  dragway = 1,
+  onramp = 2
 };
 
 std::string MakeChannelName(const std::string& name) {
@@ -112,12 +127,33 @@ void AddVehicles(RoadNetworkType road_network_type,
       MaliputRailcarParams<double> params;
       params.set_r(0);
       params.set_h(0);
-      MaliputRailcarState<double> state;
-      state.set_speed(speed);
-      const maliput::api::Lane* lane =
+
+      const Lane* lane =
           dragway_road_geometry->junction(0)->segment(0)->lane(lane_index);
+      MaliputRailcarState<double> state;
+
+      state.set_speed(speed);
       simulator->AddPriusMaliputRailcar("MaliputRailcar" + std::to_string(i),
                                         LaneDirection(lane), params, state);
+    }
+  } else if (road_network_type == RoadNetworkType::onramp) {
+    DRAKE_DEMAND(road_geometry != nullptr);
+    for (int i = 0; i < FLAGS_num_maliput_railcar; ++i) {
+      // Alternate starting the MaliputRailcar vehicles between the two possible
+      // starting locations.
+      const int n = FLAGS_onramp_swap_start ? (i + 1) : i;
+      const std::string lane_name = (n % 2 == 0) ? "l:onramp0" : "l:post0";
+      const bool with_s = false;
+
+      LaneDirection lane_direction(simulator->FindLane(lane_name), with_s);
+      MaliputRailcarParams<double> params;
+      params.set_r(0);
+      params.set_h(0);
+      MaliputRailcarState<double> state;
+      state.set_s(with_s ? 0 : lane_direction.lane->length());
+      state.set_speed(FLAGS_onramp_base_speed);
+      simulator->AddPriusMaliputRailcar("MaliputRailcar" + std::to_string(i),
+          lane_direction, params, state);
     }
   } else {
     for (int i = 0; i < FLAGS_num_trajectory_car; ++i) {
@@ -157,6 +193,13 @@ const maliput::api::RoadGeometry* AddDragway(
   return simulator->SetRoadGeometry(std::move(road_geometry));
 }
 
+// Adds a monolane-based onramp road network to the provided `simulator`.
+const maliput::api::RoadGeometry* AddOnramp(
+    AutomotiveSimulator<double>* simulator) {
+  auto onramp_generator = std::make_unique<MonolaneOnrampMerge>();
+  return simulator->SetRoadGeometry(onramp_generator->BuildOnramp());
+}
+
 // Adds a terrain to the simulated world. The type of terrain added depends on
 // the provided `road_network_type` parameter. A pointer to the road network is
 // returned. A return value of `nullptr` is possible if no road network is
@@ -173,6 +216,10 @@ const maliput::api::RoadGeometry* AddTerrain(RoadNetworkType road_network_type,
       road_geometry = AddDragway(simulator);
       break;
     }
+    case RoadNetworkType::onramp: {
+      road_geometry = AddOnramp(simulator);
+      break;
+    }
   }
   return road_geometry;
 }
@@ -180,8 +227,18 @@ const maliput::api::RoadGeometry* AddTerrain(RoadNetworkType road_network_type,
 // Determines and returns the road network type based on the command line
 // arguments.
 RoadNetworkType DetermineRoadNetworkType() {
+  int num_environments_selected{0};
+  if (FLAGS_with_onramp) ++num_environments_selected;
+  if (FLAGS_num_dragway_lanes) ++num_environments_selected;
+  if (num_environments_selected > 1) {
+    throw std::runtime_error("ERROR: More than one road network selected. Only "
+        "one road network can be selected at a time.");
+  }
+
   if (FLAGS_num_dragway_lanes > 0) {
     return RoadNetworkType::dragway;
+  } else if (FLAGS_with_onramp) {
+    return RoadNetworkType::onramp;
   } else {
     return RoadNetworkType::flat;
   }

--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -199,6 +199,30 @@ const RoadGeometry* AutomotiveSimulator<T>::SetRoadGeometry(
 }
 
 template <typename T>
+const maliput::api::Lane* AutomotiveSimulator<T>::FindLane(
+    const std::string& name) const {
+  if (road_ == nullptr) {
+    throw std::runtime_error("AutomotiveSimulator::FindLane(): RoadGeometry "
+        "not set. Please call SetRoadGeometry() first before calling this "
+        "method.");
+  }
+  for (int i = 0; i < road_->num_junctions(); ++i) {
+    const maliput::api::Junction* junction = road_->junction(i);
+    for (int j = 0; j < junction->num_segments(); ++j) {
+      const maliput::api::Segment* segment = junction->segment(j);
+      for (int k = 0; k < segment->num_lanes(); ++k) {
+        const maliput::api::Lane* lane = segment->lane(k);
+        if (lane->id().id == name) {
+          return lane;
+        }
+      }
+    }
+  }
+  throw std::runtime_error("AutomotiveSimulator::FindLane(): Failed to find "
+      "lane named \"" + name + "\".");
+}
+
+template <typename T>
 void AutomotiveSimulator<T>::GenerateAndLoadRoadNetworkUrdf() {
   maliput::utility::GenerateUrdfFile(road_.get(),
                                      "/tmp", road_->id().id,

--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -134,6 +134,13 @@ class AutomotiveSimulator {
   const maliput::api::RoadGeometry* SetRoadGeometry(
       std::unique_ptr<const maliput::api::RoadGeometry> road);
 
+  /// Finds and returns a pointer to a lane with the specified name. This method
+  /// throws a std::runtime_error if no such lane exists.
+  ///
+  /// @pre SetRoadGeometry() was called.
+  ///
+  const maliput::api::Lane* FindLane(const std::string& name) const;
+
   /// Returns the System whose name matches @p name.  Throws an exception if no
   /// such system has been added, or multiple such systems have been added.
   //

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -43,6 +44,8 @@ namespace automotive {
 
 template <typename T> constexpr T MaliputRailcar<T>::kDefaultInitialS;
 template <typename T> constexpr T MaliputRailcar<T>::kDefaultInitialSpeed;
+template <typename T> constexpr double MaliputRailcar<T>::kLaneEndEpsilon;
+template <typename T> constexpr double MaliputRailcar<T>::kTimeEpsilon;
 
 template <typename T>
 MaliputRailcar<T>::MaliputRailcar(const LaneDirection& initial_lane_direction)
@@ -290,36 +293,44 @@ void MaliputRailcar<T>::SetDefaultState(
 template <typename T>
 void MaliputRailcar<T>::DoCalcNextUpdateTime(const systems::Context<T>& context,
     systems::UpdateActions<T>* actions) const {
-  // Obtains the relevant parameters.
-  const MaliputRailcarParams<T>& params =
-      this->template GetNumericParameter<MaliputRailcarParams>(context, 0);
-
   const VectorBase<T>& context_state = context.get_continuous_state_vector();
   const MaliputRailcarState<T>* const state =
       dynamic_cast<const MaliputRailcarState<T>*>(&context_state);
   DRAKE_ASSERT(state != nullptr);
+  if (state->speed() == 0) {
+    actions->time = T(std::numeric_limits<double>::infinity());
+  } else {
+    const MaliputRailcarParams<T>& params =
+        this->template GetNumericParameter<MaliputRailcarParams>(context, 0);
+    const LaneDirection& lane_direction =
+        context.template get_abstract_state<LaneDirection>(0);
 
-  const LaneDirection& lane_direction =
-      context.template get_abstract_state<LaneDirection>(0);
+    const T& s = state->s();
+    const T& speed = state->speed();
+    const maliput::api::Lane* lane = lane_direction.lane;
+    const bool with_s = lane_direction.with_s;
 
-  const T& s = state->s();
-  const T& speed = state->speed();
-  const maliput::api::Lane* lane = lane_direction.lane;
-  const bool with_s = lane_direction.with_s;
+    DRAKE_ASSERT(lane != nullptr);
 
-  DRAKE_ASSERT(lane != nullptr);
+    // Computes `s_dot`, the time derivative of `s`.
+    const T sigma_v = cond(with_s, speed, -speed);
+    const LanePosition motion_derivatives =
+        lane_direction.lane->EvalMotionDerivatives(
+            LanePosition(s, CalcR(params, lane_direction), params.h()),
+            IsoLaneVelocity(sigma_v, 0 /* rho_v */, 0 /* eta_v */));
+    const T s_dot = motion_derivatives.s;
 
-  // Computes `s_dot`, the time derivative of `s`.
-  const T sigma_v = cond(with_s, speed, -speed);
-  const LanePosition motion_derivatives =
-      lane_direction.lane->EvalMotionDerivatives(
-          LanePosition(s, CalcR(params, lane_direction), params.h()),
-          IsoLaneVelocity(sigma_v, 0 /* rho_v */, 0 /* eta_v */));
-  const T s_dot = motion_derivatives.s;
+    const T distance = cond(with_s, T(lane->length()) - s, -s);
 
-  const T distance = cond(with_s, T(lane->length()) - s, -s);
+    actions->time = context.get_time() + distance / s_dot;
+  }
 
-  actions->time = context.get_time() + distance / s_dot;
+  // Gracefully handle the situation when the next update time is equal to the
+  // current time. Since the integrator requires that the next update time be
+  // strictly greater than the current time, a small time epsilon is used.
+  if (actions->time == context.get_time()) {
+    actions->time = context.get_time() + kTimeEpsilon;
+  }
   actions->events.push_back(systems::DiscreteEvent<T>());
   actions->events.back().action =
       systems::DiscreteEvent<T>::kUnrestrictedUpdateAction;
@@ -351,9 +362,11 @@ void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
       dynamic_cast<MaliputRailcarState<T>*>(cv);
   DRAKE_ASSERT(next_railcar_state != nullptr);
 
-  // Handles the case where no lane change or speed adjustment is necessary.
-  if ((current_with_s && current_s < current_length) ||
-      (!current_with_s && current_s > 0)) {
+  // Handles the case where no lane change or speed adjustment is necessary. No
+  // lane change is necessary when the vehicle is more than epilon away from the
+  // next lane boundary.
+  if ((current_with_s && current_s < current_length - kLaneEndEpsilon) ||
+      (!current_with_s && current_s > kLaneEndEpsilon)) {
     return;
   }
 
@@ -361,13 +374,13 @@ void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
   if (current_with_s) {
     const int num_branches = current_lane_direction.lane->
         GetOngoingBranches(LaneEnd::kFinish)->size();
-    if (num_branches == 0 && current_s >= current_length) {
+    if (num_branches == 0 && current_s >= current_length - kLaneEndEpsilon) {
       next_railcar_state->set_speed(0);
     }
   } else {
     const int num_branches = current_lane_direction.lane->
         GetOngoingBranches(LaneEnd::kStart)->size();
-    if (num_branches == 0 && current_s <= 0) {
+    if (num_branches == 0 && current_s <= kLaneEndEpsilon) {
       next_railcar_state->set_speed(0);
     }
   }
@@ -376,22 +389,41 @@ void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
     LaneDirection& next_lane_direction =
         next_state->template get_mutable_abstract_state<LaneDirection>(0);
     // TODO(liang.fok) Generalize the following to support the selection of
-    // non-default branches.
-    std::unique_ptr<LaneEnd> default_branch;
+    // non-default branches or non-zero ongoing branches. See #5702.
+    std::unique_ptr<LaneEnd> next_branch;
     if (current_with_s) {
-      default_branch = current_lane_direction.lane->GetDefaultBranch(
+      next_branch = current_lane_direction.lane->GetDefaultBranch(
           LaneEnd::kFinish);
+      if (next_branch == nullptr) {
+        const maliput::api::LaneEndSet* ongoing_lanes =
+            current_lane_direction.lane->GetOngoingBranches(LaneEnd::kFinish);
+        if (ongoing_lanes != nullptr) {
+          if (ongoing_lanes->size() > 0) {
+            next_branch = std::make_unique<LaneEnd>(ongoing_lanes->get(0));
+          }
+        }
+      }
     } else {
-      default_branch = current_lane_direction.lane->GetDefaultBranch(
+      next_branch = current_lane_direction.lane->GetDefaultBranch(
           LaneEnd::kStart);
+      if (next_branch == nullptr) {
+        const maliput::api::LaneEndSet* ongoing_lanes =
+            current_lane_direction.lane->GetOngoingBranches(LaneEnd::kStart);
+        if (ongoing_lanes != nullptr) {
+          if (ongoing_lanes->size() > 0) {
+            next_branch = std::make_unique<LaneEnd>(ongoing_lanes->get(0));
+          }
+        }
+      }
     }
 
-    if (default_branch == nullptr) {
+    if (next_branch == nullptr) {
       DRAKE_ABORT_MSG("MaliputRailcar::DoCalcUnrestrictedUpdate: ERROR: "
-          "Vehicle should switch lanes but is at the end of the road.");
+          "Vehicle should switch lanes but no default or ongoing branch "
+          "exists.");
     } else {
-      next_lane_direction.lane = default_branch->lane;
-      if (default_branch->end == LaneEnd::kStart) {
+      next_lane_direction.lane = next_branch->lane;
+      if (next_branch->end == LaneEnd::kStart) {
         next_lane_direction.with_s = true;
         next_railcar_state->set_s(0);
       } else {

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -57,6 +57,30 @@ template <typename T>
 class MaliputRailcar : public systems::LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MaliputRailcar)
+  /// Defines a distance that is "close enough" to the end of a lane for the
+  /// vehicle to transition to an ongoing branch. The primary constraint on the
+  /// selection of this variable is the application's degree of sensitivity to
+  /// position state discontinuity when the MaliputRailcar "jumps" from its
+  /// current lane to a lane in an ongoing branch. A smaller value results in a
+  /// smaller spatial discontinuity. If this value is zero, the spatial
+  /// discontinuity will be zero. However, it will trigger the use of
+  /// kTimeEpsilon, which results in a temporal discontinuity.
+  static constexpr double kLaneEndEpsilon{1e-12};
+
+  /// Defines a time interval that is used to ensure a desired update time is
+  /// always greater than (i.e., after) the current time. Despite the spatial
+  /// window provided by kLaneEndEpsilon, it is still possible for the vehicle
+  /// to end up precisely at the end of its current lane (e.g., it could be
+  /// initialized in this state). In this scenario, the next update time will be
+  /// equal to the current time. The integrator, however, requires that the next
+  /// update time be strictly after the current time, which is when this
+  /// constant is used. The primary constraint on the selection of this constant
+  /// is the application's sensitivity to a MaliputRailcar being "late" in its
+  /// transition to an ongoing branch once it is at the end of its current lane.
+  /// The smaller this value, the less "late" the transition will occur. This
+  /// value cannot be zero since that will violate the integrator's need for the
+  /// next update time to be strictly after the current time.
+  static constexpr double kTimeEpsilon{1e-12};
 
   /// The constructor.
   ///


### PR DESCRIPTION
# Screenshot of On-ramp Road Network
Here's a screenshot of a `MaliputRailcar` traversing an onramp road network:

<img width="1126" alt="screen shot 2017-04-02 at 11 28 21 am" src="https://cloud.githubusercontent.com/assets/1388098/24588507/a9ffd048-1797-11e7-92eb-e62a31064714.png">

The onramp was originally introduced in #5169.

# Video

https://youtu.be/VmUCRWHor5c

# Commands
The commands to run the demo are:

```
./build/install/bin/drake-visualizer
bazel run //drake/automotive:automotive_demo -- --num_trajectory_car=0 --num_maliput_railcar=2 --with_onramp 

```

# Annotated Onramp

![onramp_annotated](https://cloud.githubusercontent.com/assets/1388098/24590281/64632154-17b8-11e7-88ad-b4a1ebee3161.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5699)
<!-- Reviewable:end -->
