### PR TITLE
Add MobilPlanner as a benchmark for lane switching

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -24,6 +24,7 @@ drake_cc_library(
         "gen/idm_planner_parameters.cc",
         "gen/maliput_railcar_params.cc",
         "gen/maliput_railcar_state.cc",
+        "gen/mobil_planner_parameters.cc",
         "gen/simple_car_params.cc",
         "gen/simple_car_state.cc",
     ],
@@ -38,6 +39,7 @@ drake_cc_library(
         "gen/idm_planner_parameters.h",
         "gen/maliput_railcar_params.h",
         "gen/maliput_railcar_state.h",
+        "gen/mobil_planner_parameters.h",
         "gen/simple_car_params.h",
         "gen/simple_car_state.h",
     ],
@@ -171,7 +173,6 @@ drake_cc_library(
         ":generated_vectors",
         ":idm_planner",
         ":pose_selector",
-        ":simple_car",
         "//drake/automotive/maliput/api",
         "//drake/math:saturate",
         "//drake/systems/rendering:pose_bundle",
@@ -208,6 +209,25 @@ drake_cc_library(
         ":lane_direction",
         "//drake/automotive/maliput/api",
         "//drake/math:geometric_transform",
+        "//drake/systems/rendering:pose_vector",
+    ],
+)
+
+drake_cc_library(
+    name = "mobil_planner",
+    srcs = ["mobil_planner.cc"],
+    hdrs = ["mobil_planner.h"],
+    deps = [
+        ":generated_vectors",
+        ":idm_controller",
+        ":idm_planner",
+        ":lane_direction",
+        ":pose_selector",
+        "//drake/automotive/maliput/api",
+        "//drake/common:cond",
+        "//drake/common:symbolic",
+        "//drake/math:saturate",
+        "//drake/systems/rendering:pose_bundle",
         "//drake/systems/rendering:pose_vector",
     ],
 )
@@ -676,9 +696,16 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_library(
+    name = "idm_test",
+    testonly = 1,
+    hdrs = ["test/idm_test.h"],
+)
+
 drake_cc_googletest(
     name = "idm_controller_test",
     deps = [
+        ":idm_test",
         "//drake/automotive:idm_controller",
         "//drake/automotive/maliput/dragway",
     ],
@@ -688,6 +715,15 @@ drake_cc_googletest(
     name = "idm_planner_test",
     deps = [
         "//drake/automotive:idm_planner",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mobil_planner_test",
+    deps = [
+        ":idm_test",
+        "//drake/automotive:mobil_planner",
+        "//drake/automotive/maliput/dragway",
     ],
 )
 

--- a/drake/automotive/gen/mobil_planner_parameters.cc
+++ b/drake/automotive/gen/mobil_planner_parameters.cc
@@ -1,0 +1,15 @@
+#include "drake/automotive/gen/mobil_planner_parameters.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace drake {
+namespace automotive {
+
+const int MobilPlannerParametersIndices::kNumCoordinates;
+const int MobilPlannerParametersIndices::kP;
+const int MobilPlannerParametersIndices::kThreshold;
+const int MobilPlannerParametersIndices::kMaxDeceleration;
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/gen/mobil_planner_parameters.h
+++ b/drake/automotive/gen/mobil_planner_parameters.h
@@ -1,0 +1,91 @@
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+#include <Eigen/Core>
+
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace automotive {
+
+/// Describes the row indices of a MobilPlannerParameters.
+struct MobilPlannerParametersIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 3;
+
+  // The index of each individual coordinate.
+  static const int kP = 0;
+  static const int kThreshold = 1;
+  static const int kMaxDeceleration = 2;
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class MobilPlannerParameters : public systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef MobilPlannerParametersIndices K;
+
+  /// Default constructor.  Sets all rows to their default value:
+  /// @arg @c p defaults to 0.5 in units of dimensionless.
+  /// @arg @c threshold defaults to 0.1 in units of m/s^2.
+  /// @arg @c max_deceleration defaults to 4.0 in units of m/s^2.
+  MobilPlannerParameters() : systems::BasicVector<T>(K::kNumCoordinates) {
+    this->set_p(0.5);
+    this->set_threshold(0.1);
+    this->set_max_deceleration(4.0);
+  }
+
+  MobilPlannerParameters<T>* DoClone() const override {
+    return new MobilPlannerParameters;
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// politeness factor (0.0 is purely egoistic, higher values increase
+  /// politeness)
+  /// @note @c p is expressed in units of dimensionless.
+  /// @note @c p has a limited domain of [0.0, 1.0].
+  const T& p() const { return this->GetAtIndex(K::kP); }
+  void set_p(const T& p) { this->SetAtIndex(K::kP, p); }
+  /// acceleration threshold for changing lanes (Delta_a_th)
+  /// @note @c threshold is expressed in units of m/s^2.
+  /// @note @c threshold has a limited domain of [0.0, +Inf].
+  const T& threshold() const { return this->GetAtIndex(K::kThreshold); }
+  void set_threshold(const T& threshold) {
+    this->SetAtIndex(K::kThreshold, threshold);
+  }
+  /// maximum safe deceleration (b_safe)
+  /// @note @c max_deceleration is expressed in units of m/s^2.
+  /// @note @c max_deceleration has a limited domain of [0.0, +Inf].
+  const T& max_deceleration() const {
+    return this->GetAtIndex(K::kMaxDeceleration);
+  }
+  void set_max_deceleration(const T& max_deceleration) {
+    this->SetAtIndex(K::kMaxDeceleration, max_deceleration);
+  }
+  //@}
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(p());
+    result = result && (p() >= T(0.0));
+    result = result && (p() <= T(1.0));
+    result = result && !isnan(threshold());
+    result = result && (threshold() >= T(0.0));
+    result = result && !isnan(max_deceleration());
+    result = result && (max_deceleration() >= T(0.0));
+    return result;
+  }
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/mobil_planner.cc
+++ b/drake/automotive/mobil_planner.cc
@@ -1,0 +1,254 @@
+#include "drake/automotive/mobil_planner.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/common/cond.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/symbolic_formula.h"
+#include "drake/math/saturate.h"
+
+namespace drake {
+
+using maliput::api::GeoPosition;
+using maliput::api::Lane;
+using maliput::api::LanePosition;
+using maliput::api::RoadGeometry;
+using maliput::api::RoadPosition;
+using math::saturate;
+using automotive::pose_selector::RoadOdometry;
+using systems::rendering::FrameVelocity;
+using systems::rendering::PoseBundle;
+using systems::rendering::PoseVector;
+
+namespace automotive {
+
+namespace {
+
+static constexpr double kDefaultLargeAccel{1e6};  // m/s^2
+
+}  // namespace
+
+template <typename T>
+MobilPlanner<T>::MobilPlanner(const RoadGeometry& road, bool initial_with_s)
+    : IdmController<T>(road),
+      with_s_(initial_with_s),
+      lane_index_(this->DeclareAbstractOutputPort(
+                          systems::Value<LaneDirection>(LaneDirection()))
+                      .get_index()) {
+  // Validate the provided RoadGeometry.
+  DRAKE_DEMAND(this->road().num_junctions() > 0);
+  DRAKE_DEMAND(this->road().junction(0)->num_segments() > 0);
+  DRAKE_DEMAND(this->road().junction(0)->segment(0)->num_lanes() > 0);
+  this->DeclareNumericParameter(MobilPlannerParameters<T>());
+}
+
+template <typename T>
+const systems::OutputPortDescriptor<T>& MobilPlanner<T>::lane_output() const {
+  return systems::System<T>::get_output_port(lane_index_);
+}
+
+template <typename T>
+void MobilPlanner<T>::DoCalcOutput(const systems::Context<T>& context,
+                                   systems::SystemOutput<T>* output) const {
+  // Obtain the parameters.
+  DRAKE_DEMAND(context.get_parameters().num_numeric_parameters() == 2);
+  const IdmPlannerParameters<T>& idm_params =
+      this->template GetNumericParameter<IdmPlannerParameters>(context, 0);
+  const MobilPlannerParameters<T>& mobil_params =
+      this->template GetNumericParameter<MobilPlannerParameters>(context, 1);
+
+  // Obtain the input/output data structures.
+  const PoseVector<T>* const ego_pose =
+      this->template EvalVectorInput<PoseVector>(context,
+                                                 this->ego_pose_index());
+  DRAKE_ASSERT(ego_pose != nullptr);
+
+  const FrameVelocity<T>* const ego_velocity =
+      this->template EvalVectorInput<FrameVelocity>(context,
+                                                    this->ego_velocity_index());
+  DRAKE_ASSERT(ego_velocity != nullptr);
+
+  const PoseBundle<T>* const traffic_poses =
+      this->template EvalInputValue<PoseBundle<T>>(context,
+                                                   this->traffic_index());
+  DRAKE_ASSERT(traffic_poses != nullptr);
+
+  systems::BasicVector<T>* const command_output_vector =
+      output->GetMutableVectorData(this->driving_command_index());
+  DRAKE_ASSERT(command_output_vector != nullptr);
+  DrivingCommand<T>* const driving_command =
+      dynamic_cast<DrivingCommand<T>*>(command_output_vector);
+  DRAKE_ASSERT(driving_command != nullptr);
+
+  this->ImplDoCalcOutput(*ego_pose, *ego_velocity, *traffic_poses, idm_params,
+                         driving_command);
+
+  LaneDirection* lane_direction =
+      &output->GetMutableData(lane_index_)
+           ->template GetMutableValue<LaneDirection>();
+  DRAKE_ASSERT(lane_direction != nullptr);
+
+  ImplDoCalcLane(*ego_pose, *ego_velocity, *traffic_poses, *driving_command,
+                 idm_params, mobil_params, lane_direction);
+}
+
+template <typename T>
+void MobilPlanner<T>::ImplDoCalcLane(
+    const PoseVector<T>& ego_pose, const FrameVelocity<T>& ego_velocity,
+    const PoseBundle<T>& traffic_poses,
+    const DrivingCommand<T>& driving_command,
+    const IdmPlannerParameters<T>& idm_params,
+    const MobilPlannerParameters<T>& mobil_params,
+    LaneDirection* lane_direction) const {
+  DRAKE_DEMAND(idm_params.IsValid());
+  DRAKE_DEMAND(mobil_params.IsValid());
+
+  const RoadPosition& ego_position =
+      pose_selector::CalcRoadPosition(this->road(), ego_pose.get_isometry());
+  // Prepare a list of (possibly nullptr) Lanes to evaluate.
+  std::pair<const Lane*, const Lane*> lanes = std::make_pair(
+      ego_position.lane->to_left(), ego_position.lane->to_right());
+
+  const Lane* lane = ego_position.lane;
+  if (lanes.first != nullptr || lanes.second != nullptr) {
+    const std::pair<T, T> incentives = ComputeIncentives(
+        lanes, idm_params, mobil_params, ego_pose, ego_velocity, traffic_poses,
+        driving_command.acceleration());
+    // Switch to the lane with the highest incentive score greater than zero,
+    // staying in the same lane if under the threshold.
+    const T threshold = mobil_params.threshold();
+    if (incentives.first >= incentives.second)
+      lane = (incentives.first > threshold) ? lanes.first : ego_position.lane;
+    else
+      lane = (incentives.second > threshold) ? lanes.second : ego_position.lane;
+  }
+  *lane_direction = LaneDirection(lane, with_s_);
+  // N.B. Assumes neighboring lanes are all confluent (i.e. with_s points in the
+  // same direction).
+}
+
+template <typename T>
+const std::pair<T, T> MobilPlanner<T>::ComputeIncentives(
+    const std::pair<const Lane*, const Lane*> lanes,
+    const IdmPlannerParameters<T>& idm_params,
+    const MobilPlannerParameters<T>& mobil_params,
+    const PoseVector<T>& ego_pose, const FrameVelocity<T>& ego_velocity,
+    const PoseBundle<T>& traffic_poses, const T& ego_acceleration) const {
+  // Initially disincentivize both neighboring lane options.  N.B. The first and
+  // second elements correspond to the left and right lanes, respectively.
+  std::pair<T, T> incentives(-kDefaultLargeAccel, -kDefaultLargeAccel);
+
+  const RoadPosition& ego_position =
+      pose_selector::CalcRoadPosition(this->road(), ego_pose.get_isometry());
+  DRAKE_DEMAND(ego_position.lane != nullptr);
+  RoadOdometry<T> leading_odometry{};
+  RoadOdometry<T> trailing_odometry{};
+  std::tie(leading_odometry, trailing_odometry) =
+      pose_selector::FindClosestPair(this->road(), ego_pose, traffic_poses);
+
+  // Current acceleration of the ego car.
+  const RoadOdometry<T>& ego_odometry =
+      RoadOdometry<T>(ego_position, ego_velocity);
+  // Current acceleration of the trailing car.
+  const T trailing_this_old_accel =
+      EvaluateIdm(idm_params, trailing_odometry, ego_odometry);
+  // New acceleration of the trailing car if the ego were to change lanes.
+  const T trailing_this_new_accel =
+      EvaluateIdm(idm_params, trailing_odometry, leading_odometry);
+  // Acceleration delta of the trailing car in the ego car's current lane.
+  const T trailing_delta_accel_this =
+      trailing_this_new_accel - trailing_this_old_accel;
+  // Compute the incentive for the left lane.
+  if (lanes.first != nullptr) {
+    const OdometryPair& odometries = pose_selector::FindClosestPair(
+        this->road(), ego_pose, traffic_poses, lanes.first);
+    ComputeIncentiveOutOfLane(idm_params, mobil_params, odometries,
+                              ego_odometry, ego_acceleration,
+                              trailing_delta_accel_this, &incentives.first);
+  }
+  // Compute the incentive for the right lane.
+  if (lanes.second != nullptr) {
+    const OdometryPair& odometries = pose_selector::FindClosestPair(
+        this->road(), ego_pose, traffic_poses, lanes.second);
+    ComputeIncentiveOutOfLane(idm_params, mobil_params, odometries,
+                              ego_odometry, ego_acceleration,
+                              trailing_delta_accel_this, &incentives.second);
+  }
+  return incentives;
+}
+
+template <typename T>
+void MobilPlanner<T>::ComputeIncentiveOutOfLane(
+    const IdmPlannerParameters<T>& idm_params,
+    const MobilPlannerParameters<T>& mobil_params,
+    const OdometryPair& odometries, const RoadOdometry<T>& ego_odometry,
+    const T& ego_old_accel, const T& trailing_delta_accel_this,
+    T* incentive) const {
+  RoadOdometry<T> leading_odometry{};
+  RoadOdometry<T> trailing_odometry{};
+  std::tie(leading_odometry, trailing_odometry) = odometries;
+  // Acceleration of the ego car if it were to move to the neighboring lane.
+  const T ego_new_accel =
+      EvaluateIdm(idm_params, ego_odometry, leading_odometry);
+  // Original acceleration of the trailing car in the neighboring lane.
+  const T trailing_old_accel =
+      EvaluateIdm(idm_params, trailing_odometry, leading_odometry);
+  // Acceleration of the trailing car in the neighboring lane if the ego moves
+  // here.
+  const T trailing_new_accel =
+      EvaluateIdm(idm_params, trailing_odometry, ego_odometry);
+  // Acceleration delta of the trailing car in the neighboring (other) lane.
+  const T trailing_delta_accel_other = trailing_new_accel - trailing_old_accel;
+  const T ego_delta_accel = ego_new_accel - ego_old_accel;
+
+  // Do not switch to this lane if it discomforts the trailing car too much.
+  if (trailing_new_accel < -mobil_params.max_deceleration()) return;
+
+  // Compute the incentive as a weighted sum of the net accelerations for
+  // the ego and each immediate neighbor.
+  *incentive = ego_delta_accel +
+               mobil_params.p() *
+                   (trailing_delta_accel_other + trailing_delta_accel_this);
+}
+
+template <typename T>
+const T MobilPlanner<T>::EvaluateIdm(
+    const IdmPlannerParameters<T>& idm_params,
+    const RoadOdometry<T>& ego_odometry,
+    const RoadOdometry<T>& lead_car_odometry) const {
+  const T& s_ego = ego_odometry.pos.s;
+  const T& s_dot_ego = pose_selector::GetSVelocity(ego_odometry);
+  const T& s_lead = lead_car_odometry.pos.s;
+  const T& s_dot_lead = pose_selector::GetSVelocity(lead_car_odometry);
+
+  const T delta = s_lead - s_ego;
+  // Saturate the net_distance at distance_lower_bound away from the ego car to
+  // prevent the IDM equation from producing near-singular solutions.
+  // clang-format off
+  // TODO(jadecastro): Move this to IdmPlanner::Evaluate().
+  const T net_distance =
+      cond(delta > T(0.), saturate(delta - idm_params.bloat_diameter(),
+                                   idm_params.distance_lower_limit(),
+                                   std::numeric_limits<T>::infinity()),
+                          saturate(delta + idm_params.bloat_diameter(),
+                                   -std::numeric_limits<T>::infinity(),
+                                   -idm_params.distance_lower_limit()));
+  // clang-format on
+  DRAKE_DEMAND(std::abs(net_distance) >= idm_params.distance_lower_limit());
+  const T closing_velocity = s_dot_ego - s_dot_lead;
+
+  return IdmPlanner<T>::Evaluate(idm_params, s_dot_ego, net_distance,
+                                 closing_velocity);
+}
+
+// These instantiations must match the API documentation in mobil_planner.h.
+template class MobilPlanner<double>;
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/mobil_planner.h
+++ b/drake/automotive/mobil_planner.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <Eigen/Geometry>
+
+#include "drake/automotive/gen/driving_command.h"
+#include "drake/automotive/gen/idm_planner_parameters.h"
+#include "drake/automotive/gen/mobil_planner_parameters.h"
+#include "drake/automotive/idm_controller.h"
+#include "drake/automotive/idm_planner.h"
+#include "drake/automotive/lane_direction.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/pose_selector.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/rendering/pose_bundle.h"
+#include "drake/systems/rendering/pose_vector.h"
+
+namespace drake {
+namespace automotive {
+
+/// MOBIL (Minimizing Overall Braking Induced by Lane Changes) [1] is a planner
+/// that minimizes braking requirement for the ego car while also minimizing
+/// (per a weighting factor) the braking requirements of any trailing cars
+/// within the ego car's immediate neighborhood.  The weighting factor
+/// encapsulates the politeness of the ego car to the surrounding traffic.
+/// Neighboring cars are defined as those cars immediately ahead and behind the
+/// ego, in the current lane and any adjacent lanes; these are determined from
+/// the PoseSelector logic applied to a multi-lane Maliput road.
+///
+/// The induced braking by the ego car and the car following immediately behind
+/// it is compared with the induced braking by the ego and its new follower if
+/// the ego were to move to any of the neighboring lanes.  The choice that
+/// minimizes the induced braking - alternatively maximizes the ego car's
+/// "incentive" (the weighted sum of accelerations that the ego car and its
+/// neighbors gain by changing lanes) - is chosen as the new lane request.  The
+/// request is expressed as a LaneDirection, that references a valid lane in the
+/// provided RoadGeometry and the direction of travel.  MobilPlanner also
+/// creates a longitudinal DrivingCommand for the ego car based on the IDM
+/// equation (see IdmPlanner).
+///
+/// Assumptions:
+///   1) The planner supports only symmetric lane change rules, without giving
+///      preference to lanes to the left or right.
+///   2) The planner assumes all traffic behaves according to the Intelligent
+///      Driver Model (IDM).
+///   3) All neighboring lanes are confluent (i.e. with_s points in the same
+///      direction).
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+///
+/// They are already available to link against in the containing library.
+///
+/// Input Port 0: A PoseVector for the ego car.
+///   (InputPortDescriptor getter: ego_pose_input())
+///
+/// Input Port 1: A FrameVelocity for the ego car.
+///   (InputPortDescriptor getter: ego_velocity_input())
+///
+/// Input Port 2: A PoseBundle for the traffic cars, possibly including the ego
+///   car's pose.
+///   (InputPortDescriptor getter: traffic_input())
+///
+/// Output Port 0: A DrivingCommand with the following elements:
+///   * steering angle (unused - outputs 0).
+///   * acceleration.
+///   (OutputPortDescriptor getter: driving_command_output())
+///
+/// Output Port 1: A LaneDirection containing a lane that the ego vehicle must
+///   move into and the direction of travel with respect to the lane's canonical
+///   direction of travel.  LaneDirection must be consistent with the provided
+///   road.
+///   (OutputPortDescriptor getter: lane_output())
+///
+/// @ingroup automotive_systems
+///
+/// [1] Arne Kesting, Martin Treiber and Dirk Helbing, MOBIL: General
+///     Lane-Changing Model for Car-Following Models, Journal of the
+///     Transportation Research Board, v1999, 2007, pp 86-94.
+///     http://trrjournalonline.trb.org/doi/abs/10.3141/1999-10.
+template <typename T>
+class MobilPlanner : public IdmController<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MobilPlanner)
+
+  /// A constructor that initializes the MOBIL planner.
+  /// @param road is the pre-defined RoadGeometry.
+  /// @param initial_with_s is the initial direction of travel in the lane
+  /// corresponding to the ego vehicle's initial state.
+  explicit MobilPlanner(const maliput::api::RoadGeometry& road,
+                        bool initial_with_s);
+
+  /// See the class description for details on the following input ports.
+  const systems::OutputPortDescriptor<T>& lane_output() const;
+
+ private:
+  typedef typename std::pair<const pose_selector::RoadOdometry<T>,
+                             const pose_selector::RoadOdometry<T>>
+      OdometryPair;
+
+  void DoCalcOutput(const systems::Context<T>& context,
+                    systems::SystemOutput<T>* output) const override;
+
+  // Performs the calculations for the lane_output() port.
+  void ImplDoCalcLane(const systems::rendering::PoseVector<T>& ego_pose,
+                      const systems::rendering::FrameVelocity<T>& ego_velocity,
+                      const systems::rendering::PoseBundle<T>& traffic_poses,
+                      const DrivingCommand<T>& driving_command,
+                      const IdmPlannerParameters<T>& idm_params,
+                      const MobilPlannerParameters<T>& mobil_params,
+                      LaneDirection* lane_direction) const;
+
+  // Computes a pair of incentive measures for the provided neighboring lanes.
+  // The first and second elements in `lanes` correspond to, respectively, a
+  // pair of lanes included in the incentive query.  The respective incentives
+  // for these lanes are returned as the first and second elements in the return
+  // value.
+  const std::pair<T, T> ComputeIncentives(
+      const std::pair<const maliput::api::Lane*, const maliput::api::Lane*>
+          lanes,
+      const IdmPlannerParameters<T>& idm_params,
+      const MobilPlannerParameters<T>& mobil_params,
+      const systems::rendering::PoseVector<T>& ego_pose,
+      const systems::rendering::FrameVelocity<T>& ego_velocity,
+      const systems::rendering::PoseBundle<T>& traffic_poses,
+      const T& ego_acceleration) const;
+
+  // Computes a pair of incentive measures that consider the leading and
+  // trailing vehicles that are closest to the pre-computed result in the
+  // current lane.  The first and second elements of `odometries`
+  // correspond to, respectively, odometries of the leading and trailing cars.
+  void ComputeIncentiveOutOfLane(
+      const IdmPlannerParameters<T>& idm_params,
+      const MobilPlannerParameters<T>& mobil_params,
+      const OdometryPair& odometries,
+      const pose_selector::RoadOdometry<T>& ego_odometry,
+      const T& ego_old_accel, const T& trailing_delta_accel_this,
+      T* incentive) const;
+
+  // Computes an acceleration based on the IDM equation (via a call to
+  // IdmPlanner::Eval()).
+  const T EvaluateIdm(
+      const IdmPlannerParameters<T>& idm_params,
+      const pose_selector::RoadOdometry<T>& ego_odometry,
+      const pose_selector::RoadOdometry<T>& lead_car_odometry) const;
+
+  const bool with_s_{true};
+
+  // Index for the lane output port.
+  const int lane_index_;
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/mobil_planner_parameters.named_vector
+++ b/drake/automotive/mobil_planner_parameters.named_vector
@@ -1,0 +1,24 @@
+# The default values contained below are from Kesting, Treiber and Helbing,
+# 2007 (cited in mobil_planner.h).
+element {
+     name: "p"
+     doc: "politeness factor (0.0 is purely egoistic, higher values increase politeness)"
+     doc_units: "dimensionless"
+     default_value: "0.5"
+     min_value: "0.0"
+     max_value: "1.0"
+}
+element {
+     name: "threshold"
+     doc: "acceleration threshold for changing lanes (Delta_a_th)"
+     doc_units: "m/s^2"
+     default_value: "0.1"
+     min_value: "0.0"
+}
+element {
+     name: "max_deceleration"
+     doc: "maximum safe deceleration (b_safe)"
+     doc_units: "m/s^2"
+     default_value: "4.0"
+     min_value: "0.0"
+}

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -79,6 +79,15 @@ const RoadPosition CalcRoadPosition(const RoadGeometry& road,
       nullptr, nullptr, nullptr);
 }
 
+double GetSVelocity(const RoadOdometry<double>& road_odom) {
+  const maliput::api::Rotation rot =
+      road_odom.lane->GetOrientation(road_odom.pos);
+  const double vx = road_odom.vel.get_velocity().translational().x();
+  const double vy = road_odom.vel.get_velocity().translational().y();
+
+  return vx * std::cos(rot.yaw) + vy * std::sin(rot.yaw);
+}
+
 }  // namespace pose_selector
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/pose_selector.h
+++ b/drake/automotive/pose_selector.h
@@ -13,6 +13,7 @@
 
 namespace drake {
 namespace automotive {
+namespace pose_selector {
 
 /// Contains the position of the vehicle with respect to a lane in a road, along
 /// with its velocity vector in the world frame.
@@ -29,8 +30,6 @@ struct RoadOdometry {
   maliput::api::LanePosition pos{};
   systems::rendering::FrameVelocity<T> vel{};
 };
-
-namespace pose_selector {
 
 /// Returns the leading and trailing cars that have closest `s`-coordinates in a
 /// given @p traffic_lane to an ego car as if the ego car were traveling in @p
@@ -79,6 +78,12 @@ const RoadOdometry<double> FindClosestLeading(
 /// road.
 const maliput::api::RoadPosition CalcRoadPosition(
     const maliput::api::RoadGeometry& road, const Isometry3<double>& pose);
+
+// Extracts the vehicle's `s`-direction velocity based on its RoadOdometry @p
+// road_odom.  Assumes the road has zero elevation and superelevation.
+//
+// TODO(jadecastro): Generalize to three-dimensional rotations.
+double GetSVelocity(const pose_selector::RoadOdometry<double>& road_odom);
 
 }  // namespace pose_selector
 }  // namespace automotive

--- a/drake/automotive/simple_car_gen.sh
+++ b/drake/automotive/simple_car_gen.sh
@@ -21,5 +21,6 @@ gen_lcm_and_vector_from_proto "euler floating joint state" $drake/automotive/eul
 gen_vector_proto "idm planner parameters" $drake/automotive/idm_planner_parameters.named_vector
 gen_lcm_and_vector_from_proto "maliput railcar state" $drake/automotive/maliput_railcar_state.named_vector
 gen_lcm_and_vector_from_proto "maliput railcar params" $drake/automotive/maliput_railcar_params.named_vector
+gen_vector_proto "mobil planner parameters" $drake/automotive/mobil_planner_parameters.named_vector
 gen_lcm_and_vector_from_proto "simple car state" $drake/automotive/simple_car_state.named_vector
 gen_lcm_and_vector_from_proto "simple car params" $drake/automotive/simple_car_params.named_vector

--- a/drake/automotive/test/idm_controller_test.cc
+++ b/drake/automotive/test/idm_controller_test.cc
@@ -1,11 +1,9 @@
 #include "drake/automotive/idm_controller.h"
 
-#include <cmath>
-#include <memory>
-
 #include "gtest/gtest.h"
 
 #include "drake/automotive/maliput/dragway/road_geometry.h"
+#include "drake/automotive/test/idm_test.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/multibody_tree/math/spatial_velocity.h"
 
@@ -14,18 +12,10 @@ namespace automotive {
 namespace {
 
 using maliput::dragway::RoadGeometry;
-using systems::rendering::FrameVelocity;
-using systems::rendering::PoseBundle;
-using systems::rendering::PoseVector;
 
-constexpr double kEgoSPosition{10.};
-
-constexpr int kLeadIndex{0};
-constexpr int kEgoIndex{1};
-
-class IdmControllerTest : public ::testing::Test {
+class IdmControllerTest : public IdmTest {
  protected:
-  void SetUp() override {
+  void Initialize() override {
     // Create a straight road with one lane.
     road_.reset(new maliput::dragway::RoadGeometry(
         maliput::api::RoadGeometryId({"Single-Lane Dragway"}),
@@ -36,130 +26,57 @@ class IdmControllerTest : public ::testing::Test {
     dut_.reset(new IdmController<double>(*road_));
     context_ = dut_->CreateDefaultContext();
     output_ = dut_->AllocateOutput(*context_);
+
+    idm_ = dynamic_cast<const IdmController<double>*>(dut_.get());
+    DRAKE_DEMAND(idm_ != nullptr);
   }
 
-  systems::ContinuousState<double>* continuous_state() {
-    return context_->get_mutable_continuous_state();
+  int ego_pose_input_index() override {
+    return idm_->ego_pose_input().get_index();
+  }
+  int ego_velocity_input_index() override {
+    return idm_->ego_velocity_input().get_index();
+  }
+  int traffic_input_index() override {
+    return idm_->traffic_input().get_index();
+  }
+  int command_output_index() override {
+    return idm_->driving_command_output().get_index();
   }
 
-  std::unique_ptr<IdmController<double>> dut_;  //< The device under test.
-  std::unique_ptr<systems::Context<double>> context_;
-  std::unique_ptr<systems::SystemOutput<double>> output_;
+  const IdmController<double>* idm_{nullptr};
   std::unique_ptr<maliput::dragway::RoadGeometry> road_;
-
-  // Set the default poses according to the desired offset position and speeds
-  // for the lead car.  `s_offset = s_lead - s_ego`, `relative_sdot =
-  // sdot_lead - sdot_ego`, and `relative_rdot = rdot_lead - rdot_ego`.
-  void SetDefaultPoses(const double ego_speed, const double s_offset = 0.,
-                       const double relative_sdot = 0.,
-                       const double relative_rdot = 0.) {
-    DRAKE_DEMAND(s_offset >= 0.);
-    EXPECT_LE(0., ego_speed);
-
-    // Configure the ego car pose and velocity.
-    auto ego_pose = std::make_unique<PoseVector<double>>();
-    const Eigen::Translation3d translation_ego(kEgoSPosition /* x */,
-                                               0. /* y */, 0. /* z */);
-    ego_pose->set_translation(translation_ego);
-    context_->FixInputPort(dut_->ego_pose_input().get_index(),
-                           std::move(ego_pose));
-
-    auto ego_velocity = std::make_unique<FrameVelocity<double>>();
-    Vector6<double> velocity{};
-    velocity << 0. /* ωx */, 0. /* ωy */, 0. /* ωz */, ego_speed /* vx */,
-        0. /* vy */, 0. /* vz */;
-    ego_velocity->set_velocity(multibody::SpatialVelocity<double>(velocity));
-    context_->FixInputPort(dut_->ego_velocity_input().get_index(),
-                           std::move(ego_velocity));
-
-    // Configure the traffic poses, inclusive of the ego car.
-    PoseBundle<double> traffic_poses(2);
-    FrameVelocity<double> lead_velocity;
-    const Eigen::Translation3d translation_lead(
-        kEgoSPosition + s_offset /* x */, 0. /* y */, 0. /* z */);
-    traffic_poses.set_pose(kLeadIndex, Eigen::Isometry3d(translation_lead));
-    velocity[3] += relative_sdot;
-    velocity[4] += relative_rdot;
-    lead_velocity.set_velocity(multibody::SpatialVelocity<double>(velocity));
-    traffic_poses.set_velocity(kLeadIndex, lead_velocity);
-    traffic_poses.set_pose(kEgoIndex, Eigen::Isometry3d(translation_ego));
-    context_->FixInputPort(dut_->traffic_input().get_index(),
-                           systems::AbstractValue::Make(traffic_poses));
-  }
 };
 
 TEST_F(IdmControllerTest, Topology) {
   ASSERT_EQ(3, dut_->get_num_input_ports());
-  const auto& ego_pose_input_descriptor = dut_->get_input_port(0);
+  const auto& ego_pose_input_descriptor =
+      dut_->get_input_port(ego_pose_input_index());
   EXPECT_EQ(systems::kVectorValued, ego_pose_input_descriptor.get_data_type());
   EXPECT_EQ(7 /* PoseVector input */, ego_pose_input_descriptor.size());
-  const auto& ego_velocity_input_descriptor = dut_->get_input_port(1);
+  const auto& ego_velocity_input_descriptor =
+      dut_->get_input_port(ego_velocity_input_index());
   EXPECT_EQ(systems::kVectorValued,
             ego_velocity_input_descriptor.get_data_type());
   EXPECT_EQ(6 /* FrameVelocity input */, ego_velocity_input_descriptor.size());
-  const auto& traffic_input_descriptor = dut_->get_input_port(2);
+  const auto& traffic_input_descriptor =
+      dut_->get_input_port(traffic_input_index());
   EXPECT_EQ(systems::kAbstractValued, traffic_input_descriptor.get_data_type());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
-  const auto& output_descriptor = dut_->get_output_port(0);
+  const auto& output_descriptor = dut_->get_output_port(command_output_index());
   EXPECT_EQ(systems::kVectorValued, output_descriptor.get_data_type());
   EXPECT_EQ(2 /* DrivingCommand output */, output_descriptor.size());
 }
 
 TEST_F(IdmControllerTest, Output) {
   // Define a pointer to where the DrivingCommand results end up.
-  const auto result =
-      output_->get_vector_data(dut_->get_output_port(0).get_index());
+  const auto result = output_->get_vector_data(command_output_index());
   const auto command = dynamic_cast<const DrivingCommand<double>*>(result);
+  ASSERT_NE(nullptr, command);
 
-  // Set the lead car to be immediately ahead of the ego car and moving slower.
-  SetDefaultPoses(10. /* ego_speed */, 6. /* s_offset */, -5. /* rel_sdot */);
-  dut_->CalcOutput(*context_, output_.get());
-  const double closing_accel = command->acceleration();  // A negative number.
-
-  // Expect the car to decelerate in this configuration.
-  EXPECT_GT(0., closing_accel);
-  EXPECT_EQ(0., command->steering_angle());  // Always zero.
-
-  // Set the same conditions as above, but with the lead car having a nonzero
-  // r-component in its velocity.
-  SetDefaultPoses(10. /* ego_speed */, 6. /* s_offset */, -5. /* rel_sdot */,
-                  5. /* rel_rdot */);
-  dut_->CalcOutput(*context_, output_.get());
-
-  // Expect no change to the previous results.
-  EXPECT_EQ(closing_accel, command->acceleration());
-
-  // Set the lead car to be immediately ahead of the ego car and moving faster.
-  SetDefaultPoses(10. /* ego_speed */, 6. /* s_offset */, 5. /* rel_sdot */);
-  dut_->CalcOutput(*context_, output_.get());
-
-  // Expect the magnitude of the deceleration to be smaller when the ego is not
-  // closing in on the lead car.
-  EXPECT_GT(command->acceleration(), closing_accel);
-
-  // Set the ego car to be alone on the road.  We effectively enable this by
-  // setting the poses of all traffic cars to be that of the ego car.
-  SetDefaultPoses(10. /* ego_speed */);
-  dut_->CalcOutput(*context_, output_.get());
-
-  // Expect zero acceleration (input velocity is at the desired velocity).
-  EXPECT_NEAR(0., command->acceleration(), 1e-4);
-
-  // Set the lead car well ahead of the ego, with the ego moving slower than the
-  // desired velocity.
-  SetDefaultPoses(4. /* ego_speed */, 30. /* s_offset */, 0. /* rel_sdot */);
-  dut_->CalcOutput(*context_, output_.get());
-
-  // Expect a positive acceleration in this configuration.
-  EXPECT_LT(0., command->acceleration());
-
-  // Set the lead car to be well within `distance_lower_limit`.
-  SetDefaultPoses(10. /* ego_speed */, 1e-3 /* s_offset */, -5. /* rel_sdot */);
-  dut_->CalcOutput(*context_, output_.get());
-
-  // Expect an enormous deceleration.
-  EXPECT_GT(closing_accel, command->acceleration());
+  // Perform the IDM test.
+  this->TestIdmPlanner(*command);
 }
 
 }  // namespace

--- a/drake/automotive/test/idm_test.h
+++ b/drake/automotive/test/idm_test.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/system.h"
+
+namespace drake {
+namespace automotive {
+
+using systems::rendering::FrameVelocity;
+using systems::rendering::PoseBundle;
+using systems::rendering::PoseVector;
+
+constexpr double kEgoSPosition{10.};
+constexpr int kLeadIndex{0};
+constexpr int kEgoIndex{1};
+
+// Base class for IdmControllerTest and MobilPlannerTest.
+class IdmTest : public ::testing::Test {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IdmTest)
+
+  IdmTest() = default;
+
+  void SetUp() override { Initialize(); }
+
+  virtual void Initialize() {}
+
+  // Indices for the input ports required for invoking this unit test.
+  virtual int ego_pose_input_index() = 0;
+  virtual int ego_velocity_input_index() = 0;
+  virtual int traffic_input_index() = 0;
+  virtual int command_output_index() = 0;
+
+  // Set the default poses according to the desired offset position and speeds
+  // for the lead car.  `s_offset = s_lead - s_ego`, `relative_sdot =
+  // sdot_lead - sdot_ego`, and `relative_rdot = rdot_lead - rdot_ego`.
+  void SetDefaultPoses(double ego_speed, double s_offset = 0.,
+                       double relative_sdot = 0., double relative_rdot = 0.) {
+    DRAKE_DEMAND(ego_pose_input_index() >= 0 &&
+                 ego_pose_input_index() < dut_->get_num_input_ports());
+    DRAKE_DEMAND(ego_velocity_input_index() >= 0 &&
+                 ego_velocity_input_index() < dut_->get_num_input_ports());
+    DRAKE_DEMAND(traffic_input_index() >= 0 &&
+                 traffic_input_index() < dut_->get_num_input_ports());
+
+    auto ego_pose = std::make_unique<PoseVector<double>>();
+    auto ego_velocity = std::make_unique<FrameVelocity<double>>();
+    PoseBundle<double> traffic_poses(2);
+
+    DRAKE_DEMAND(s_offset >= 0.);
+    EXPECT_LE(0., ego_speed);
+
+    // Configure the ego car pose and velocity.
+    const Eigen::Translation3d translation_ego(kEgoSPosition /* x */,
+                                               0. /* y */, 0. /* z */);
+    ego_pose->set_translation(translation_ego);
+    context_->FixInputPort(ego_pose_input_index(), std::move(ego_pose));
+
+    Vector6<double> velocity{};
+    velocity << 0. /* ωx */, 0. /* ωy */, 0. /* ωz */, ego_speed /* vx */,
+        0. /* vy */, 0. /* vz */;
+    ego_velocity->set_velocity(multibody::SpatialVelocity<double>(velocity));
+    context_->FixInputPort(ego_velocity_input_index(), std::move(ego_velocity));
+
+    // Configure the traffic poses, inclusive of the ego car.
+    FrameVelocity<double> lead_velocity;
+    const Eigen::Translation3d translation_lead(
+        kEgoSPosition + s_offset /* x */, 0. /* y */, 0. /* z */);
+    traffic_poses.set_pose(kLeadIndex, Eigen::Isometry3d(translation_lead));
+    velocity[3] += relative_sdot;
+    velocity[4] += relative_rdot;
+    lead_velocity.set_velocity(multibody::SpatialVelocity<double>(velocity));
+    traffic_poses.set_velocity(kLeadIndex, lead_velocity);
+    traffic_poses.set_pose(kEgoIndex, Eigen::Isometry3d(translation_ego));
+    context_->FixInputPort(traffic_input_index(),
+                           systems::AbstractValue::Make(traffic_poses));
+  }
+
+  void TestIdmPlanner(const DrivingCommand<double>& command) {
+    // Set the lead car to be immediately ahead of the ego car and moving
+    // slower.
+    SetDefaultPoses(10. /* ego_speed */, 6. /* s_offset */, -5. /* rel_sdot */);
+    dut_->CalcOutput(*context_, output_.get());
+    const double closing_accel = command.acceleration();  // A negative number.
+
+    // Expect the car to decelerate in this configuration.
+    EXPECT_GT(0., closing_accel);
+    EXPECT_EQ(0., command.steering_angle());  // Always zero.
+
+    // Set the same conditions as above, but with the lead car having a nonzero
+    // r-component in its velocity.
+    SetDefaultPoses(10. /* ego_speed */, 6. /* s_offset */, -5. /* rel_sdot */,
+                    5. /* rel_rdot */);
+    dut_->CalcOutput(*context_, output_.get());
+
+    // Expect no change to the previous results.
+    EXPECT_EQ(closing_accel, command.acceleration());
+
+    // Set the lead car to be immediately ahead of the ego car and moving
+    // faster.
+    SetDefaultPoses(10. /* ego_speed */, 6. /* s_offset */, 5. /* rel_sdot */);
+    dut_->CalcOutput(*context_, output_.get());
+
+    // Expect the magnitude of the deceleration to be smaller when the ego is
+    // not closing in on the lead car.
+    EXPECT_GT(command.acceleration(), closing_accel);
+
+    // Set the ego car to be alone on the road.  We effectively enable this by
+    // setting the poses of all traffic cars to be that of the ego car.
+    SetDefaultPoses(10. /* ego_speed */);
+    dut_->CalcOutput(*context_, output_.get());
+
+    // Expect zero acceleration (input velocity is at the desired velocity).
+    EXPECT_NEAR(0., command.acceleration(), 1e-4);
+
+    // Set the lead car well ahead of the ego, with the ego moving slower than
+    // the desired velocity.
+    SetDefaultPoses(4. /* ego_speed */, 30. /* s_offset */, 0. /* rel_sdot */);
+    dut_->CalcOutput(*context_, output_.get());
+
+    // Expect a positive acceleration in this configuration.
+    EXPECT_LT(0., command.acceleration());
+
+    // Set the lead car to be well within `distance_lower_limit`.
+    SetDefaultPoses(10. /* ego_speed */, 1e-3 /* s_offset */,
+                    -5. /* rel_sdot */);
+    dut_->CalcOutput(*context_, output_.get());
+
+    // Expect an enormous deceleration.
+    EXPECT_GT(closing_accel, command.acceleration());
+  }
+
+ protected:
+  std::unique_ptr<systems::System<double>> dut_;  //< The device under test.
+  std::unique_ptr<systems::Context<double>> context_;
+  std::unique_ptr<systems::SystemOutput<double>> output_;
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/test/mobil_planner_test.cc
+++ b/drake/automotive/test/mobil_planner_test.cc
@@ -1,0 +1,333 @@
+#include "drake/automotive/mobil_planner.h"
+
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/dragway/road_geometry.h"
+#include "drake/automotive/test/idm_test.h"
+
+namespace drake {
+namespace automotive {
+namespace {
+
+using maliput::api::Lane;
+using maliput::dragway::RoadGeometry;
+using systems::rendering::FrameVelocity;
+using systems::rendering::PoseBundle;
+using systems::rendering::PoseVector;
+
+constexpr double kEgoXPosition{10.};
+constexpr double kLaneWidth{4.};
+constexpr double kEgoSpeed{10.};
+
+class MobilPlannerTest : public IdmTest {
+ protected:
+  void InitializeDragway(int num_lanes) {
+    DRAKE_ASSERT(num_lanes >= 0);
+    // Create a dragway with the specified number of lanes starting at `x = 0`
+    // and centered at `y = 0`.
+    road_.reset(new maliput::dragway::RoadGeometry(
+        maliput::api::RoadGeometryId({"Two-Lane Dragway"}), num_lanes,
+        100 /* length */, kLaneWidth /* lane_width */,
+        0. /* shoulder_width */));
+    segment_ = road_->junction(0)->segment(0);
+    ExtractLaneDirectionsFromDragway();
+    right_lane_index_ = 0;
+    left_lane_index_ = num_lanes - 1;
+  }
+
+  int ego_pose_input_index() override {
+    return mp_->ego_pose_input().get_index();
+  }
+  int ego_velocity_input_index() override {
+    return mp_->ego_velocity_input().get_index();
+  }
+  int traffic_input_index() override {
+    return mp_->traffic_input().get_index();
+  }
+  int command_output_index() override {
+    return mp_->driving_command_output().get_index();
+  }
+
+  // Initializes MobilPlanner with the dragway at a given LaneDirection.
+  void InitializeMobilPlanner(bool initial_with_s) {
+    DRAKE_DEMAND(road_ != nullptr);
+    DRAKE_DEMAND(mp_ == nullptr);
+    dut_.reset(new MobilPlanner<double>(*road_, initial_with_s));
+    context_ = dut_->CreateDefaultContext();
+    output_ = dut_->AllocateOutput(*context_);
+
+    mp_ = dynamic_cast<const MobilPlanner<double>*>(dut_.get());
+    DRAKE_DEMAND(mp_ != nullptr);
+  }
+
+  void ExtractLaneDirectionsFromDragway() {
+    lane_directions_.clear();
+    for (int i = 0; i < segment_->num_lanes(); ++i) {
+      lane_directions_.push_back({segment_->lane(i), true});
+    }
+  }
+
+  int get_lane_index(const Lane* lane) {
+    if (segment_->lane(0)->id().id == lane->id().id) {
+      return 0;
+    } else if (segment_->lane(1)->id().id == lane->id().id) {
+      return 1;
+    } else if (segment_->lane(2)->id().id == lane->id().id) {
+      return 2;
+    } else {
+      throw std::runtime_error("The specified Lane does not belong to road_.");
+    }
+  }
+
+  // Creates poses for one ego car and two traffic cars.  One traffic car is
+  // positioned within each parallel lane in the road.
+  void SetDefaultMultiLanePoses(const LaneDirection& initial_lane_direction,
+                                const std::vector<double> delta_positions) {
+    const int num_lanes = delta_positions.size();
+    const int lane_index = get_lane_index(initial_lane_direction.lane);
+    auto ego_pose = std::make_unique<PoseVector<double>>();
+    auto ego_velocity = std::make_unique<FrameVelocity<double>>();
+    PoseBundle<double> traffic_poses(num_lanes + 1);  // Bundles the ego and
+                                                      // traffic cars.
+
+    // Configure the ego car pose and velocity.
+    const Eigen::Translation3d translation_ego(
+        kEgoXPosition,                                     /* x */
+        (lane_index - 0.5 * (num_lanes - 1)) * kLaneWidth, /* y */
+        0.);                                               /* z */
+    ego_pose->set_translation(translation_ego);
+    context_->FixInputPort(ego_pose_input_index(), std::move(ego_pose));
+
+    Vector6<double> velocity{};
+    velocity << 0., /* ωx */ 0., /* ωy */ 0., /* ωz */
+        kEgoSpeed, /* vx */ 0., /* vy */ 0.;  /* vz */
+    ego_velocity->set_velocity(multibody::SpatialVelocity<double>(velocity));
+    context_->FixInputPort(ego_velocity_input_index(), std::move(ego_velocity));
+
+    // Configure the traffic poses and velocities, inclusive of the ego car,
+    // where all cars are traveling at the same x-velocity.
+    FrameVelocity<double> all_velocity;
+    all_velocity.set_velocity(multibody::SpatialVelocity<double>(velocity));
+    for (int i = 0; i < num_lanes; ++i) {
+      const Eigen::Translation3d translation(
+          kEgoXPosition + delta_positions[i],       /* x */
+          (i - 0.5 * (num_lanes - 1)) * kLaneWidth, /* y */
+          0.);                                      /* z */
+      traffic_poses.set_pose(i, Eigen::Isometry3d(translation));
+      traffic_poses.set_velocity(i, all_velocity);
+    }
+    traffic_poses.set_pose(num_lanes, Eigen::Isometry3d(translation_ego));
+    traffic_poses.set_velocity(num_lanes, all_velocity);
+    context_->FixInputPort(traffic_input_index(),
+                           systems::AbstractValue::Make(traffic_poses));
+  }
+
+  const MobilPlanner<double>* mp_{nullptr};
+  std::unique_ptr<maliput::api::RoadGeometry> road_;
+  const maliput::api::Segment* segment_;
+  std::vector<LaneDirection> lane_directions_{};
+
+  int right_lane_index_{};
+  int left_lane_index_{};
+};
+
+TEST_F(MobilPlannerTest, Topology) {
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  ASSERT_EQ(3, mp_->get_num_input_ports());
+  const auto& ego_pose_input_descriptor =
+      mp_->get_input_port(ego_pose_input_index());
+  EXPECT_EQ(systems::kVectorValued, ego_pose_input_descriptor.get_data_type());
+  EXPECT_EQ(7 /* PoseVector input */, ego_pose_input_descriptor.size());
+  const auto& ego_velocity_input_descriptor =
+      mp_->get_input_port(ego_velocity_input_index());
+  EXPECT_EQ(systems::kVectorValued,
+            ego_velocity_input_descriptor.get_data_type());
+  EXPECT_EQ(6 /* FrameVelocity input */, ego_velocity_input_descriptor.size());
+  const auto& traffic_input_descriptor =
+      mp_->get_input_port(traffic_input_index());
+  EXPECT_EQ(systems::kAbstractValued, traffic_input_descriptor.get_data_type());
+
+  ASSERT_EQ(2, mp_->get_num_output_ports());
+  const auto& command_output_descriptor =
+      mp_->get_output_port(command_output_index());
+  EXPECT_EQ(systems::kVectorValued, command_output_descriptor.get_data_type());
+  EXPECT_EQ(2 /* DrivingCommand output */, command_output_descriptor.size());
+  const auto& lane_output_descriptor =
+      mp_->get_output_port(mp_->lane_output().get_index());
+  EXPECT_EQ(systems::kAbstractValued, lane_output_descriptor.get_data_type());
+}
+
+// Tests that the IDM equations are performing as expected.
+TEST_F(MobilPlannerTest, IdmOutput) {
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Define a pointer to where the DrivingCommand results end up.
+  const auto result = output_->get_vector_data(command_output_index());
+  const auto command = dynamic_cast<const DrivingCommand<double>*>(result);
+  ASSERT_NE(nullptr, command);
+
+  this->TestIdmPlanner(*command);
+}
+
+// Tests the incentive of the ego car to change lanes when tailgating a car
+// close ahead.
+TEST_F(MobilPlannerTest, IncentiveWhileTailgating) {
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Arrange the ego car in the right lane with two traffic cars ahead, the
+  // right car being closer ahead.
+  SetDefaultMultiLanePoses(lane_directions_[right_lane_index_], /* ego lane */
+                           {5.,    /* right car position */
+                            40.}); /* left car position */
+
+  // Compute the output.
+  const auto result = output_->GetMutableData(mp_->lane_output().get_index());
+  mp_->CalcOutput(*context_, output_.get());
+  auto lane_direction = result->template GetMutableValue<LaneDirection>();
+
+  // Expect the left lane to be more desirable.
+  EXPECT_EQ(lane_directions_[left_lane_index_].lane->id().id,
+            lane_direction.lane->id().id);
+}
+
+// Verifies that the same results as above are obtained when `with_s = false`.
+TEST_F(MobilPlannerTest, IncentiveWhileTailgatingInBackwardLane) {
+  // Arrange the ego car facing in the direction opposite to the canonical lane
+  // direction.
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Arrange two traffic cars ahead of the ego, with the right car closer ahead.
+  SetDefaultMultiLanePoses(lane_directions_[right_lane_index_], /* ego lane */
+                           {-5.,    /* right car position */
+                            -40.}); /* left car position */
+
+  // Compute the output.
+  const auto result = output_->GetMutableData(mp_->lane_output().get_index());
+  mp_->CalcOutput(*context_, output_.get());
+  auto lane_direction = result->template GetMutableValue<LaneDirection>();
+
+  // Expect the left lane to be more desirable.
+  EXPECT_EQ(lane_directions_[left_lane_index_].lane->id().id,
+            lane_direction.lane->id().id);
+}
+
+// Tests the incentive of the ego car to keep its current lane when a car is far
+// ahead.
+TEST_F(MobilPlannerTest, IncentiveWhileNotTailgating) {
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Arrange the ego car in the left lane with two traffic cars ahead, the right
+  // car being closer ahead.
+  SetDefaultMultiLanePoses(lane_directions_[left_lane_index_], /* ego lane */
+                           {5.,    /* right car position */
+                            40.}); /* left car position */
+
+  // Compute the output.
+  const auto result = output_->GetMutableData(mp_->lane_output().get_index());
+  mp_->CalcOutput(*context_, output_.get());
+  auto lane_direction = result->template GetMutableValue<LaneDirection>();
+
+  // Expect the left lane to be more desirable.
+  EXPECT_EQ(lane_directions_[left_lane_index_].lane->id().id,
+            lane_direction.lane->id().id);
+}
+
+// Tests the politeness of the ego car to keep its current lane when a car is
+// far behind.
+TEST_F(MobilPlannerTest, PolitenessNoTailgator) {
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Arrange the ego car in the right lane with two traffic cars behind, the
+  // left car being closer behind.
+  SetDefaultMultiLanePoses(lane_directions_[right_lane_index_], /* ego lane */
+                           {-40.,  /* right car position */
+                            -5.}); /* left car position */
+
+  // Compute the output.
+  const auto result = output_->GetMutableData(mp_->lane_output().get_index());
+  mp_->CalcOutput(*context_, output_.get());
+  auto lane_direction = result->template GetMutableValue<LaneDirection>();
+
+  // Expect the right lane to be more desirable.
+  EXPECT_EQ(lane_directions_[right_lane_index_].lane->id().id,
+            lane_direction.lane->id().id);
+}
+
+// Tests the politeness of the ego car to change lanes in response to being
+// tailgated by a car close behind.
+TEST_F(MobilPlannerTest, PolitenessWithTailgator) {
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Arrange the ego car in the right lane with two traffic cars behind, the
+  // right car being closer behind.
+  SetDefaultMultiLanePoses(lane_directions_[right_lane_index_], /* ego lane */
+                           {-5.,    /* right car position */
+                            -40.}); /* left car position */
+
+  // Compute the output.
+  const auto result = output_->GetMutableData(mp_->lane_output().get_index());
+  mp_->CalcOutput(*context_, output_.get());
+  auto lane_direction = result->template GetMutableValue<LaneDirection>();
+
+  // Expect the left lane to be more desirable.
+  EXPECT_EQ(lane_directions_[left_lane_index_].lane->id().id,
+            lane_direction.lane->id().id);
+}
+
+TEST_F(MobilPlannerTest, ThreeLanePolitenessTestPreferLeft) {
+  InitializeDragway(3 /* num_lanes */);
+  const int center_lane_index = 1;
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Arrange the ego in the middle lane with three trailing traffic cars; the
+  // one behind being the closest and the leftmost car furthest behind.
+  SetDefaultMultiLanePoses(lane_directions_[center_lane_index], /* ego lane */
+                           {-6.,    /* rightmost car position */
+                            -5,     /* car directly behind */
+                            -40.}); /* leftmost car position */
+
+  // Compute the output.
+  const auto result = output_->GetMutableData(mp_->lane_output().get_index());
+  mp_->CalcOutput(*context_, output_.get());
+  auto lane_direction = result->template GetMutableValue<LaneDirection>();
+
+  // Expect the leftmost lane to be more desirable.
+  EXPECT_EQ(lane_directions_[left_lane_index_].lane->id().id,
+            lane_direction.lane->id().id);
+}
+
+TEST_F(MobilPlannerTest, ThreeLaneIncentiveTestPreferRight) {
+  InitializeDragway(3 /* num_lanes */);
+  const int center_lane_index = 1;
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Arrange the ego in the middle lane with three trailing traffic cars; the
+  // one behind being the closest and the leftmost car furthest behind.
+  SetDefaultMultiLanePoses(lane_directions_[center_lane_index], /* ego lane */
+                           {40.,  /* rightmost car position */
+                            5,    /* car directly behind */
+                            6.}); /* leftmost car position */
+
+  // Compute the output.
+  const auto result = output_->GetMutableData(mp_->lane_output().get_index());
+  mp_->CalcOutput(*context_, output_.get());
+  auto lane_direction = result->template GetMutableValue<LaneDirection>();
+
+  // Expect the rightmost lane to be more desirable.
+  EXPECT_EQ(lane_directions_[right_lane_index_].lane->id().id,
+            lane_direction.lane->id().id);
+}
+}  // namespace
+}  // namespace automotive
+}  // namespace drake


### PR DESCRIPTION
Also reconfigures `IdmControllerTest` to share some of the test functionality with `MobilPlannerTest`.

Note:
- About 100 LoC are auto-generated code (`gen/mobil_planner_parameters.{cc, h}`)
- About 130 LoC are attributed to porting the unit tests in `IdmControllerTest` to `IdmTest`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5701)
<!-- Reviewable:end -->
