### PR TITLE
Remove a misleading use of BasicVector subclass

### DIFF
--- a/drake/systems/lcm/BUILD
+++ b/drake/systems/lcm/BUILD
@@ -71,6 +71,7 @@ drake_cc_googletest(
         ":lcmt_drake_signal_translator",
         "//drake/lcm:lcmt_drake_signal_utils",
         "//drake/lcm:mock",
+        "//drake/systems/framework/test_utilities:my_vector",
     ],
 )
 


### PR DESCRIPTION
VectorBase subclasses should not add non-mutable state, because only the vector elements will be cloned / copied / assigned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5709)
<!-- Reviewable:end -->
