### PR TITLE
[Draft] Consistently return `Binding<T>` from `Add...Cost` and `Add...Constraint` methods

### DIFF
--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -714,7 +714,7 @@ class MathematicalProgram {
   typename std::enable_if<
       (!std::is_convertible<F, std::shared_ptr<Constraint>>::value) &&
           (!std::is_convertible<F, Binding<Constraint>>::value),
-      std::shared_ptr<Constraint>>::type
+      Binding<Constraint>>::type
   AddCost(F&& f, const VariableRefList& vars) {
     return AddCost(f, ConcatenateVariableRefList(vars));
   }
@@ -729,11 +729,10 @@ class MathematicalProgram {
   typename std::enable_if<
       (!std::is_convertible<F, std::shared_ptr<Constraint>>::value) &&
           (!std::is_convertible<F, Binding<Constraint>>::value),
-      std::shared_ptr<Constraint>>::type
+      Binding<Constraint>>::type
   AddCost(F&& f, const Eigen::Ref<const VectorXDecisionVariable>& vars) {
     auto c = MakeCost(std::forward<F>(f));
-    AddCost(c, vars);
-    return c;
+    return AddCost(c, vars);
   }
 
   // libstdc++ 4.9 evaluates
@@ -742,7 +741,7 @@ class MathematicalProgram {
   // incorrectly as `true` so our enable_if overload is not used.
   // Provide an explicit alternative for this case.
   template <typename F>
-  std::shared_ptr<Constraint> AddCost(std::unique_ptr<F>&& f,
+  Binding<Constraint> AddCost(std::unique_ptr<F>&& f,
                                       const VariableRefList& vars) {
     return AddCost(f, ConcatenateVariableRefList(vars));
   }
@@ -757,13 +756,12 @@ class MathematicalProgram {
   typename std::enable_if<
       (!std::is_convertible<F, std::shared_ptr<Constraint>>::value) &&
           (!std::is_convertible<F, Binding<Constraint>>::value),
-      std::shared_ptr<Constraint>>::type
+      Binding<Constraint>>::type
   AddCost(std::unique_ptr<F>&& f,
           const Eigen::Ref<const VectorXDecisionVariable>& vars) {
     auto c = std::make_shared<ConstraintImpl<std::unique_ptr<F>>>(
         std::forward<std::unique_ptr<F>>(f));
-    AddCost(c, vars);
-    return c;
+    return AddCost(c, vars);
   }
 
   /**

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -673,15 +673,15 @@ class MathematicalProgram {
   /**
    * Adds a generic cost to the optimization program.
    */
-  void AddCost(const Binding<Constraint>& binding);
+  Binding<Constraint> AddCost(const Binding<Constraint>& binding);
 
   /**
    * Adds a generic cost to the optimization program.
    * @param obj The added objective.
    * @param vars The decision variables on which the cost depend.
    */
-  void AddCost(const std::shared_ptr<Constraint>& obj,
-               const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<Constraint> AddCost(const std::shared_ptr<Constraint>& obj,
+                              const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds a generic cost to the optimization program.
@@ -771,16 +771,16 @@ class MathematicalProgram {
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
    */
-  void AddCost(const Binding<LinearConstraint>& binding);
+  Binding<LinearConstraint> AddCost(const Binding<LinearConstraint>& binding);
 
   /**
    * Adds a cost term of the form c'*x.
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
    */
-  void AddCost(const std::shared_ptr<LinearConstraint>& obj,
-               const VariableRefList& vars) {
-    AddCost(obj, ConcatenateVariableRefList(vars));
+  Binding<LinearConstraint> AddCost(const std::shared_ptr<LinearConstraint>&
+                                    obj, const VariableRefList& vars) {
+    return AddCost(obj, ConcatenateVariableRefList(vars));
   }
 
   /**
@@ -788,8 +788,8 @@ class MathematicalProgram {
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
    */
-  void AddCost(const std::shared_ptr<LinearConstraint>& obj,
-               const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<LinearConstraint> AddCost(const std::shared_ptr<LinearConstraint>& obj,
+                                    const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds a linear cost term of the form c'*x.
@@ -806,7 +806,7 @@ class MathematicalProgram {
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
    */
-  std::shared_ptr<LinearConstraint> AddLinearCost(
+  Binding<LinearConstraint> AddLinearCost(
       const Eigen::Ref<const Eigen::VectorXd>& c, const VariableRefList& vars) {
     return AddLinearCost(c, ConcatenateVariableRefList((vars)));
   }
@@ -816,7 +816,7 @@ class MathematicalProgram {
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
    */
-  std::shared_ptr<LinearConstraint> AddLinearCost(
+  Binding<LinearConstraint> AddLinearCost(
       const Eigen::Ref<const Eigen::VectorXd>& c,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
@@ -825,16 +825,18 @@ class MathematicalProgram {
    * Applied to subset of the variables and pushes onto
    * the quadratic cost data structure.
    */
-  void AddCost(const Binding<QuadraticConstraint>& binding);
+  Binding<QuadraticConstraint> AddCost(const Binding<QuadraticConstraint>&
+                                       binding);
 
   /**
    * Adds a cost term of the form 0.5*x'*Q*x + b'x.
    * Applied to subset of the variables and pushes onto
    * the quadratic cost data structure.
    */
-  void AddCost(const std::shared_ptr<QuadraticConstraint>& obj,
-               const VariableRefList& vars) {
-    AddCost(obj, ConcatenateVariableRefList(vars));
+  Binding<QuadraticConstraint> AddCost(
+      const std::shared_ptr<QuadraticConstraint>& obj,
+      const VariableRefList& vars) {
+    return AddCost(obj, ConcatenateVariableRefList(vars));
   }
 
   /**
@@ -842,8 +844,9 @@ class MathematicalProgram {
    * Applied to subset of the variables and pushes onto
    * the quadratic cost data structure.
    */
-  void AddCost(const std::shared_ptr<QuadraticConstraint>& obj,
-               const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<QuadraticConstraint> AddCost(
+      const std::shared_ptr<QuadraticConstraint>& obj,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Add a quadratic cost term of the form 0.5*x'*Q*x + b'*x + c.
@@ -858,7 +861,7 @@ class MathematicalProgram {
   /**
    * Adds a cost term of the form (x-x_desired)'*Q*(x-x_desired).
    */
-  std::shared_ptr<QuadraticConstraint> AddQuadraticErrorCost(
+  Binding<QuadraticConstraint> AddQuadraticErrorCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& x_desired,
       const VariableRefList& vars) {
@@ -869,7 +872,7 @@ class MathematicalProgram {
   /**
    * Adds a cost term of the form (x-x_desired)'*Q*(x-x_desired).
    */
-  std::shared_ptr<QuadraticConstraint> AddQuadraticErrorCost(
+  Binding<QuadraticConstraint> AddQuadraticErrorCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& x_desired,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
@@ -877,7 +880,7 @@ class MathematicalProgram {
   /**
    * Adds a cost term of the form | Ax - b |^2.
    */
-  std::shared_ptr<QuadraticConstraint> AddL2NormCost(
+  Binding<QuadraticConstraint> AddL2NormCost(
       const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::VectorXd>& b, const VariableRefList& vars) {
     return AddL2NormCost(A, b, ConcatenateVariableRefList(vars));
@@ -886,7 +889,7 @@ class MathematicalProgram {
   /**
    * Adds a cost term of the form | Ax - b |^2.
    */
-  std::shared_ptr<QuadraticConstraint> AddL2NormCost(
+  Binding<QuadraticConstraint> AddL2NormCost(
       const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::VectorXd>& b,
       const Eigen::Ref<const VectorXDecisionVariable>& vars) {
@@ -898,7 +901,7 @@ class MathematicalProgram {
    * Adds a cost term of the form 0.5*x'*Q*x + b'x
    * Applied to subset of the variables.
    */
-  std::shared_ptr<QuadraticConstraint> AddQuadraticCost(
+  Binding<QuadraticConstraint> AddQuadraticCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& b, const VariableRefList& vars) {
     return AddQuadraticCost(Q, b, ConcatenateVariableRefList(vars));
@@ -908,7 +911,7 @@ class MathematicalProgram {
    * Adds a cost term of the form 0.5*x'*Q*x + b'x
    * Applied to subset of the variables.
    */
-  std::shared_ptr<QuadraticConstraint> AddQuadraticCost(
+  Binding<QuadraticConstraint> AddQuadraticCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& b,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
@@ -938,7 +941,7 @@ class MathematicalProgram {
    * available, as it may require the use of a significantly more
    * expensive solver.
    */
-  void AddConstraint(const Binding<Constraint>& binding);
+  Binding<Constraint> AddConstraint(const Binding<Constraint>& binding);
 
   /**
    * Adds a generic constraint to the program.  This should
@@ -946,9 +949,9 @@ class MathematicalProgram {
    * available, as it may require the use of a significantly more
    * expensive solver.
    */
-  void AddConstraint(std::shared_ptr<Constraint> con,
+  Binding<Constraint> AddConstraint(std::shared_ptr<Constraint> con,
                      const VariableRefList& vars) {
-    AddConstraint(con, ConcatenateVariableRefList(vars));
+    return AddConstraint(con, ConcatenateVariableRefList(vars));
   }
 
   /**
@@ -957,36 +960,37 @@ class MathematicalProgram {
    * available, as it may require the use of a significantly more
    * expensive solver.
    */
-  void AddConstraint(std::shared_ptr<Constraint> con,
+  Binding<Constraint> AddConstraint(std::shared_ptr<Constraint> con,
                      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds linear constraints referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    */
-  void AddConstraint(const Binding<LinearConstraint>& binding);
+  Binding<LinearConstraint> AddConstraint(
+      const Binding<LinearConstraint>& binding);
 
   /**
    * Adds linear constraints referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    */
-  void AddConstraint(std::shared_ptr<LinearConstraint> con,
+  Binding<LinearConstraint> AddConstraint(std::shared_ptr<LinearConstraint> con,
                      const VariableRefList& vars) {
-    AddConstraint(con, ConcatenateVariableRefList(vars));
+    return AddConstraint(con, ConcatenateVariableRefList(vars));
   }
 
   /**
    * Adds linear constraints referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    */
-  void AddConstraint(std::shared_ptr<LinearConstraint> con,
+  Binding<LinearConstraint> AddConstraint(std::shared_ptr<LinearConstraint> con,
                      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds linear constraints referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    */
-  std::shared_ptr<LinearConstraint> AddLinearConstraint(
+  Binding<LinearConstraint> AddLinearConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::VectorXd>& lb,
       const Eigen::Ref<const Eigen::VectorXd>& ub,
@@ -998,7 +1002,7 @@ class MathematicalProgram {
    * Adds linear constraints referencing potentially a subset
    * of the decision variables (defined in the vars parameter).
    */
-  std::shared_ptr<LinearConstraint> AddLinearConstraint(
+  Binding<LinearConstraint> AddLinearConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::VectorXd>& lb,
       const Eigen::Ref<const Eigen::VectorXd>& ub,
@@ -1014,7 +1018,7 @@ class MathematicalProgram {
    * @param vars The decision variables on which to impose the linear
    * constraint.
    */
-  std::shared_ptr<LinearConstraint> AddLinearConstraint(
+  Binding<LinearConstraint> AddLinearConstraint(
       const Eigen::Ref<const Eigen::RowVectorXd>& a, double lb, double ub,
       const VariableRefList& vars) {
     return AddLinearConstraint(a, lb, ub, ConcatenateVariableRefList(vars));
@@ -1030,7 +1034,7 @@ class MathematicalProgram {
    * @param vars The decision variables on which to impose the linear
    * constraint.
    */
-  std::shared_ptr<LinearConstraint> AddLinearConstraint(
+  Binding<LinearConstraint> AddLinearConstraint(
       const Eigen::Ref<const Eigen::RowVectorXd>& a, double lb, double ub,
       const Eigen::Ref<const VectorXDecisionVariable>& vars) {
     return AddLinearConstraint(a, drake::Vector1d(lb), drake::Vector1d(ub),
@@ -1171,7 +1175,7 @@ class MathematicalProgram {
    * Adds linear equality constraints referencing potentially a
    * subset of the decision variables.
    */
-  void AddConstraint(const Binding<LinearEqualityConstraint>& binding);
+  Binding <LinearEqualityConstraint> AddConstraint(const Binding<LinearEqualityConstraint>& binding);
 
   /**
    * Adds linear equality constraints referencing potentially a
@@ -1186,8 +1190,9 @@ class MathematicalProgram {
    * Adds linear equality constraints referencing potentially a
    * subset of the decision variables.
    */
-  void AddConstraint(std::shared_ptr<LinearEqualityConstraint> con,
-                     const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<LinearEqualityConstraint> AddConstraint(
+      std::shared_ptr<LinearEqualityConstraint> con,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds one row of linear constraint e = b where @p e is a symbolic
@@ -1335,7 +1340,7 @@ class MathematicalProgram {
    * @f[-x(2) + 2x(5) = 1 @f]
    * @f[ x(2) +  x(5) = 3 @f]
    */
-  std::shared_ptr<LinearEqualityConstraint> AddLinearEqualityConstraint(
+  Binding<LinearEqualityConstraint> AddLinearEqualityConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& Aeq,
       const Eigen::Ref<const Eigen::VectorXd>& beq,
       const VariableRefList& vars) {
@@ -1362,7 +1367,7 @@ class MathematicalProgram {
    *   prog.AddLinearEqualityConstraint(Aeq, beq, x.head<2>());
    * @endcode
    */
-  std::shared_ptr<LinearEqualityConstraint> AddLinearEqualityConstraint(
+  Binding<LinearEqualityConstraint> AddLinearEqualityConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& Aeq,
       const Eigen::Ref<const Eigen::VectorXd>& beq,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
@@ -1377,7 +1382,7 @@ class MathematicalProgram {
    * @param beq A scalar.
    * @param vars The decision variables on which the constraint is imposed.
    */
-  std::shared_ptr<LinearEqualityConstraint> AddLinearEqualityConstraint(
+  Binding<LinearEqualityConstraint> AddLinearEqualityConstraint(
       const Eigen::Ref<const Eigen::RowVectorXd>& a, double beq,
       const VariableRefList& vars) {
     return AddLinearEqualityConstraint(a, beq,
@@ -1394,7 +1399,7 @@ class MathematicalProgram {
    * @param beq A scalar.
    * @param vars The decision variables on which the constraint is imposed.
    */
-  std::shared_ptr<LinearEqualityConstraint> AddLinearEqualityConstraint(
+  Binding<LinearEqualityConstraint> AddLinearEqualityConstraint(
       const Eigen::Ref<const Eigen::RowVectorXd>& a, double beq,
       const Eigen::Ref<const VectorXDecisionVariable>& vars) {
     return AddLinearEqualityConstraint(a, drake::Vector1d(beq), vars);
@@ -1408,23 +1413,24 @@ class MathematicalProgram {
    * binding.constraint()->lower_bound()(i) <= binding.variables()(i)
    *                   <= binding.constraint().upper_bound()(i)
    */
-  void AddConstraint(const Binding<BoundingBoxConstraint>& binding);
+  Binding<BoundingBoxConstraint> AddConstraint(const Binding<BoundingBoxConstraint>& binding);
 
   /**
    * Adds bounding box constraints referencing potentially a subest of the
    * decision variables.
    */
-  void AddConstraint(std::shared_ptr<BoundingBoxConstraint> con,
-                     const VariableRefList& vars) {
-    AddConstraint(con, ConcatenateVariableRefList(vars));
+  Binding<BoundingBoxConstraint> AddConstraint(
+      std::shared_ptr<BoundingBoxConstraint> con,
+      const VariableRefList& vars) {
+    return AddConstraint(con, ConcatenateVariableRefList(vars));
   }
 
   /**
    * Adds bounding box constraints referencing potentially a subest of the
    * decision variables.
    */
-  void AddConstraint(std::shared_ptr<BoundingBoxConstraint> con,
-                     const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<BoundingBoxConstraint> AddConstraint(std::shared_ptr<BoundingBoxConstraint> con,
+                                               const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /** AddBoundingBoxConstraint
    *
@@ -1444,7 +1450,7 @@ class MathematicalProgram {
    * prog.AddBoundingBoxConstraint(lb, ub, {x, y});
    * \endcode
    */
-  std::shared_ptr<BoundingBoxConstraint> AddBoundingBoxConstraint(
+  Binding<BoundingBoxConstraint> AddBoundingBoxConstraint(
       const Eigen::Ref<const Eigen::VectorXd>& lb,
       const Eigen::Ref<const Eigen::VectorXd>& ub,
       const VariableRefList& vars) {
@@ -1459,7 +1465,7 @@ class MathematicalProgram {
    * @param vars Will imposes constraint lb(i) <= vars(i) <= ub(i).
    * @return The newly constructed BoundingBoxConstraint.
    */
-  std::shared_ptr<BoundingBoxConstraint> AddBoundingBoxConstraint(
+  Binding<BoundingBoxConstraint> AddBoundingBoxConstraint(
       const Eigen::Ref<const Eigen::VectorXd>& lb,
       const Eigen::Ref<const Eigen::VectorXd>& ub,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
@@ -1470,7 +1476,7 @@ class MathematicalProgram {
    * @param ub Upper bound.
    * @param var The decision variable.
    */
-  std::shared_ptr<BoundingBoxConstraint> AddBoundingBoxConstraint(
+  Binding<BoundingBoxConstraint> AddBoundingBoxConstraint(
       double lb, double ub, const symbolic::Variable& var) {
     MatrixDecisionVariable<1, 1> var_matrix(var);
     return AddBoundingBoxConstraint(drake::Vector1d(lb), drake::Vector1d(ub),
@@ -1483,7 +1489,7 @@ class MathematicalProgram {
    * @param ub Upper bound.
    * @param vars The decision variables.
    */
-  std::shared_ptr<BoundingBoxConstraint> AddBoundingBoxConstraint(
+  Binding<BoundingBoxConstraint> AddBoundingBoxConstraint(
       double lb, double ub, const VariableRefList& vars) {
     return AddBoundingBoxConstraint(lb, ub, ConcatenateVariableRefList(vars));
   }
@@ -1500,7 +1506,7 @@ class MathematicalProgram {
   typename std::enable_if<
       std::is_same<typename Derived::Scalar, symbolic::Variable>::value &&
           Derived::ColsAtCompileTime == 1,
-      std::shared_ptr<BoundingBoxConstraint>>::type
+      Binding<BoundingBoxConstraint>>::type
   AddBoundingBoxConstraint(double lb, double ub,
                            const Eigen::MatrixBase<Derived>& vars) {
     const int kSize = Derived::RowsAtCompileTime;
@@ -1522,7 +1528,7 @@ class MathematicalProgram {
   typename std::enable_if<
       std::is_same<typename Derived::Scalar, symbolic::Variable>::value &&
           Derived::ColsAtCompileTime != 1,
-      std::shared_ptr<BoundingBoxConstraint>>::type
+      Binding<BoundingBoxConstraint>>::type
   AddBoundingBoxConstraint(double lb, double ub,
                            const Eigen::MatrixBase<Derived>& vars) {
     const int kSize =
@@ -1553,14 +1559,16 @@ class MathematicalProgram {
    * z_0 \ge \sqrt{z_1^2 + ... + z_{n-1}^2}
    * @f]
    */
-  void AddConstraint(const Binding<LorentzConeConstraint>& binding);
+  Binding<LorentzConeConstraint> AddConstraint(
+      const Binding<LorentzConeConstraint>& binding);
 
   /**
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables.
    */
-  void AddConstraint(std::shared_ptr<LorentzConeConstraint> con,
-                     const VariableRefList& vars) {
+  Binding<LorentzConeConstraint> AddConstraint(
+      std::shared_ptr<LorentzConeConstraint> con,
+      const VariableRefList& vars) {
     return AddConstraint(con, ConcatenateVariableRefList(vars));
   }
 
@@ -1611,8 +1619,9 @@ class MathematicalProgram {
    * Adds Lorentz cone constraint referencing potentially a subset
    * of the decision variables.
    */
-  void AddConstraint(std::shared_ptr<LorentzConeConstraint> con,
-                     const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<LorentzConeConstraint> AddConstraint(
+      std::shared_ptr<LorentzConeConstraint> con,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds Lorentz cone constraint referencing potentially a subset of the
@@ -1632,7 +1641,7 @@ class MathematicalProgram {
    * @param vars The list of @f$ m @f$ decision variables.
    * @return The newly added Lorentz cone constraint.
    */
-  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::VectorXd>& b, const VariableRefList& vars) {
     return AddLorentzConeConstraint(A, b, ConcatenateVariableRefList(vars));
@@ -1656,7 +1665,7 @@ class MathematicalProgram {
    * @param vars The Eigen vector of @f$ m @f$ decision variables.
    * @return The newly added Lorentz cone constraint.
    */
-  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::VectorXd>& b,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
@@ -1672,7 +1681,7 @@ class MathematicalProgram {
    * @param vars The stacked column of vars should lie within the Lorentz cone.
    * @return The newly added Lorentz cone constraint.
    */
-  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(
       const VariableRefList& vars) {
     return AddLorentzConeConstraint(ConcatenateVariableRefList(vars));
   }
@@ -1689,7 +1698,7 @@ class MathematicalProgram {
    * @return The newly added Lorentz cone constraint.
    */
   template <int rows>
-  std::shared_ptr<LorentzConeConstraint> AddLorentzConeConstraint(
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(
       const Eigen::MatrixBase<VectorDecisionVariable<rows>>& vars) {
     Eigen::Matrix<double, rows, rows> A(vars.rows(), vars.rows());
     A.setIdentity();
@@ -1710,16 +1719,18 @@ class MathematicalProgram {
    * z_0z_1 \ge z_2^2 + ... + z_{n-1}^2
    * @f]
    */
-  void AddConstraint(const Binding<RotatedLorentzConeConstraint>& binding);
+  Binding<RotatedLorentzConeConstraint> AddConstraint(
+      const Binding<RotatedLorentzConeConstraint>& binding);
 
   /**
    * Adds a rotated Lorentz cone constraint referencing potentially a subset
    * of decision variables. The linear expression @f$ z=Ax+b @f$ is in rotated
    * Lorentz cone.
    */
-  void AddConstraint(std::shared_ptr<RotatedLorentzConeConstraint> con,
-                     const VariableRefList& vars) {
-    AddConstraint(con, ConcatenateVariableRefList(vars));
+  Binding<RotatedLorentzConeConstraint> AddConstraint(
+      std::shared_ptr<RotatedLorentzConeConstraint> con,
+      const VariableRefList& vars) {
+    return AddConstraint(con, ConcatenateVariableRefList(vars));
   }
 
   /**
@@ -1727,8 +1738,9 @@ class MathematicalProgram {
    * of decision variables. The linear expression @f$ z=Ax+b @f$ is in rotated
    * Lorentz cone.
    */
-  void AddConstraint(std::shared_ptr<RotatedLorentzConeConstraint> con,
-                     const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<RotatedLorentzConeConstraint> AddConstraint(
+      std::shared_ptr<RotatedLorentzConeConstraint> con,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds a constraint that a symbolic expression @param v is in the rotated
@@ -1765,7 +1777,7 @@ class MathematicalProgram {
    * variables.
    * @param vars The decision variables on which the constraint is imposed.
    */
-  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
+  Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::VectorXd>& b, const VariableRefList& vars) {
     return AddRotatedLorentzConeConstraint(A, b,
@@ -1791,7 +1803,7 @@ class MathematicalProgram {
    * variables.
    * @param vars The decision variables on which the constraint is imposed.
    */
-  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
+  Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::VectorXd>& b,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
@@ -1810,7 +1822,7 @@ class MathematicalProgram {
    * @param vars The stacked column of vars lies in the rotated Lorentz cone.
    * @return The newly added rotated Lorentz cone constraint.
    */
-  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
+  Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
       const VariableRefList& vars) {
     return AddRotatedLorentzConeConstraint(ConcatenateVariableRefList(vars));
   }
@@ -1830,7 +1842,7 @@ class MathematicalProgram {
    * @return The newly added rotated Lorentz cone constraint.
    */
   template <int rows>
-  std::shared_ptr<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
+  Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
       const Eigen::MatrixBase<VectorDecisionVariable<rows>>& vars) {
     Eigen::Matrix<double, rows, rows> A(vars.rows(), vars.rows());
     A.setIdentity();
@@ -1843,29 +1855,32 @@ class MathematicalProgram {
    * Adds a linear complementarity constraints referencing a subset of
    * the decision variables.
    */
-  void AddConstraint(const Binding<LinearComplementarityConstraint>& binding);
+  Binding<LinearComplementarityConstraint> AddConstraint(
+      const Binding<LinearComplementarityConstraint>& binding);
 
   /**
    * Adds a linear complementarity constraints referencing a subset of
    * the decision variables.
    */
-  void AddConstraint(std::shared_ptr<LinearComplementarityConstraint> con,
-                     const VariableRefList& vars) {
-    AddConstraint(con, ConcatenateVariableRefList(vars));
+  Binding<LinearComplementarityConstraint> AddConstraint(
+      std::shared_ptr<LinearComplementarityConstraint> con,
+      const VariableRefList& vars) {
+    return AddConstraint(con, ConcatenateVariableRefList(vars));
   }
 
   /**
    * Adds a linear complementarity constraints referencing a subset of
    * the decision variables.
    */
-  void AddConstraint(std::shared_ptr<LinearComplementarityConstraint> con,
-                     const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<LinearComplementarityConstraint> AddConstraint(
+      std::shared_ptr<LinearComplementarityConstraint> con,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds a linear complementarity constraints referencing a subset of
    * the decision variables.
    */
-  std::shared_ptr<LinearComplementarityConstraint>
+  Binding<LinearComplementarityConstraint>
   AddLinearComplementarityConstraint(const Eigen::Ref<const Eigen::MatrixXd>& M,
                                      const Eigen::Ref<const Eigen::VectorXd>& q,
                                      const VariableRefList& vars) {
@@ -1877,7 +1892,7 @@ class MathematicalProgram {
    * Adds a linear complementarity constraints referencing a subset of
    * the decision variables.
    */
-  std::shared_ptr<LinearComplementarityConstraint>
+  Binding<LinearComplementarityConstraint>
   AddLinearComplementarityConstraint(
       const Eigen::Ref<const Eigen::MatrixXd>& M,
       const Eigen::Ref<const Eigen::VectorXd>& q,
@@ -1887,7 +1902,7 @@ class MathematicalProgram {
    * Adds a polynomial constraint to the program referencing a subset
    * of the decision variables (defined in the vars parameter).
    */
-  std::shared_ptr<Constraint> AddPolynomialConstraint(
+  Binding<Constraint> AddPolynomialConstraint(
       const VectorXPoly& polynomials,
       const std::vector<Polynomiald::VarType>& poly_vars,
       const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
@@ -1900,7 +1915,7 @@ class MathematicalProgram {
    * Adds a polynomial constraint to the program referencing a subset
    * of the decision variables (defined in the vars parameter).
    */
-  std::shared_ptr<Constraint> AddPolynomialConstraint(
+  Binding<Constraint> AddPolynomialConstraint(
       const VectorXPoly& polynomials,
       const std::vector<Polynomiald::VarType>& poly_vars,
       const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
@@ -1909,13 +1924,14 @@ class MathematicalProgram {
   /**
    * Adds a positive semidefinite constraint on a symmetric matrix.
    */
-  void AddConstraint(const Binding<PositiveSemidefiniteConstraint>& binding);
+  Binding<PositiveSemidefiniteConstraint> AddConstraint(
+      const Binding<PositiveSemidefiniteConstraint>& binding);
 
   /**
    * Adds a positive semidefinite constraint on a symmetric matrix.
    * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
    */
-  void AddConstraint(
+  Binding<PositiveSemidefiniteConstraint> AddConstraint(
       std::shared_ptr<PositiveSemidefiniteConstraint> con,
       const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var);
 
@@ -1925,7 +1941,7 @@ class MathematicalProgram {
    * @p symmetric_matrix_var is not symmetric.
    * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
    */
-  std::shared_ptr<PositiveSemidefiniteConstraint>
+  Binding<PositiveSemidefiniteConstraint>
   AddPositiveSemidefiniteConstraint(
       const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var);
 
@@ -1963,33 +1979,35 @@ class MathematicalProgram {
         e_rows == Eigen::Dynamic ? Eigen::Dynamic : e_rows * e_rows;
     const Eigen::Map<Eigen::Matrix<symbolic::Variable, M_flat_size, 1>> M_flat(
         &M(0, 0), e.size());
-    return Binding<PositiveSemidefiniteConstraint>(
-        AddPositiveSemidefiniteConstraint(M), M_flat);
+    return AddPositiveSemidefiniteConstraint(M);
   }
 
   /**
    * Adds a linear matrix inequality constraint to the program.
    */
-  void AddConstraint(const Binding<LinearMatrixInequalityConstraint>& binding);
+  Binding<LinearMatrixInequalityConstraint> AddConstraint(
+      const Binding<LinearMatrixInequalityConstraint>& binding);
 
   /**
    * Adds a linear matrix inequality constraint to the program.
    */
-  void AddConstraint(std::shared_ptr<LinearMatrixInequalityConstraint> con,
-                     const VariableRefList& vars) {
-    AddConstraint(con, ConcatenateVariableRefList(vars));
+  Binding<LinearMatrixInequalityConstraint> AddConstraint(
+      std::shared_ptr<LinearMatrixInequalityConstraint> con,
+      const VariableRefList& vars) {
+    return AddConstraint(con, ConcatenateVariableRefList(vars));
   }
 
   /**
    * Adds a linear matrix inequality constraint to the program.
    */
-  void AddConstraint(std::shared_ptr<LinearMatrixInequalityConstraint> con,
-                     const Eigen::Ref<const VectorXDecisionVariable>& vars);
+  Binding<LinearMatrixInequalityConstraint> AddConstraint(
+      std::shared_ptr<LinearMatrixInequalityConstraint> con,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds a linear matrix inequality constraint to the program.
    */
-  std::shared_ptr<LinearMatrixInequalityConstraint>
+  Binding<LinearMatrixInequalityConstraint>
   AddLinearMatrixInequalityConstraint(
       const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
       const VariableRefList& vars) {
@@ -2000,7 +2018,7 @@ class MathematicalProgram {
   /**
    * Adds a linear matrix inequality constraint to the program.
    */
-  std::shared_ptr<LinearMatrixInequalityConstraint>
+  Binding<LinearMatrixInequalityConstraint>
   AddLinearMatrixInequalityConstraint(
       const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);

--- a/drake/solvers/system_identification.cc
+++ b/drake/solvers/system_identification.cc
@@ -306,7 +306,7 @@ SystemIdentification<T>::EstimateParameters(
   // Create a cost function that is least-squares on the error terms.
   auto cost = problem.AddQuadraticCost(
       Eigen::MatrixXd::Identity(num_err_terms, num_err_terms),
-      Eigen::VectorXd::Zero(num_err_terms), error_variables);
+      Eigen::VectorXd::Zero(num_err_terms), error_variables).constraint();
 
   // Solve the problem and copy out the result.
   SolutionResult solution_result = problem.Solve();

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -95,14 +95,16 @@ void RunEllipsoidsSeparation(const Eigen::MatrixBase<DerivedX1>& x1,
   Eigen::VectorXd b_lorentz1 = Eigen::VectorXd::Zero(1 + R1.cols());
   Eigen::VectorXd b_lorentz2 = Eigen::VectorXd::Zero(1 + R2.cols());
   auto lorentz_cone1 = prog.AddLorentzConeConstraint(A_lorentz1, b_lorentz1,
-                                                     {t.segment<1>(0), a});
+                                                     {t.segment<1>(0), a})
+                                                     .constraint();
   auto lorentz_cone2 = prog.AddLorentzConeConstraint(A_lorentz2, b_lorentz2,
                                                      {t.segment<1>(1), a});
+                                                     .constraint();
   // a'*(x2 - x1) = 1
   prog.AddLinearEqualityConstraint((x2 - x1).transpose(), 1.0, a);
 
   // Add cost
-  auto cost = prog.AddLinearCost(Eigen::Vector2d(1.0, 1.0), t);
+  auto cost = prog.AddLinearCost(Eigen::Vector2d(1.0, 1.0), t).constraint();
 
   RunSolver(&prog, solver);
 
@@ -578,7 +580,8 @@ GTEST_TEST(TestSemidefiniteProgram, TestCommonLyapunov) {
            0, 0, -1;
     // clang-format on
     auto binding1 = prog.AddPositiveSemidefiniteConstraint(
-        -A1.transpose() * P - P * A1 - 1E-3 * Matrix3d::Identity());
+        -A1.transpose() * P - P * A1 - 1E-3 * Matrix3d::Identity())
+        .constraint();
 
     Eigen::Matrix3d A2;
     // clang-format off
@@ -587,7 +590,8 @@ GTEST_TEST(TestSemidefiniteProgram, TestCommonLyapunov) {
            0, 0, -0.4;
     // clang-format on
     auto binding2 = prog.AddPositiveSemidefiniteConstraint(
-        -A2.transpose() * P - P * A2 - 1E-3 * Matrix3d::Identity());
+        -A2.transpose() * P - P * A2 - 1E-3 * Matrix3d::Identity())
+        .constraint();
 
     RunSolver(&prog, *solver);
 

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -324,14 +324,15 @@ GTEST_TEST(testMathematicalProgram, BoundingBoxTest2) {
   // 5. Imposes constraint on a dynamic-sized vector of decision variables.
   // 6. Imposes constraint using a vector of lower/upper bound, as compared
   //    to the previous three cases which use a scalar lower/upper bound.
-  auto constraint1 = prog.AddBoundingBoxConstraint(0, 1, x1);
+  auto constraint1 = prog.AddBoundingBoxConstraint(0, 1, x1).constraint();
   auto constraint2 =
-      prog.AddBoundingBoxConstraint(0, 1, {x1.col(0), x1.col(1)});
-  auto constraint3 = prog.AddBoundingBoxConstraint(0, 1, x2);
-  auto constraint4 = prog.AddBoundingBoxConstraint(0, 1, x3);
-  auto constraint5 = prog.AddBoundingBoxConstraint(0, 1, x4);
+      prog.AddBoundingBoxConstraint(0, 1, {x1.col(0), x1.col(1)}).constraint();
+  auto constraint3 = prog.AddBoundingBoxConstraint(0, 1, x2).constraint();
+  auto constraint4 = prog.AddBoundingBoxConstraint(0, 1, x3).constraint();
+  auto constraint5 = prog.AddBoundingBoxConstraint(0, 1, x4).constraint();
   auto constraint6 = prog.AddBoundingBoxConstraint(Eigen::Vector4d::Zero(),
-                                                   Eigen::Vector4d::Ones(), x3);
+                                                   Eigen::Vector4d::Ones(), x3)
+                                                   .constraint();
 
   // Checks that the bound variables are correct.
   for (const auto& binding : prog.bounding_box_constraints()) {
@@ -494,7 +495,8 @@ GTEST_TEST(testMathematicalProgram, AddCostTest) {
   // Add an object that can be converted to a ConstraintImpl object on a
   // VectorDecisionVariable object.
   auto returned_cost3 = prog.AddCost(generic_trivial_cost2,
-                                     VectorDecisionVariable<2>(x(0), y(1)));
+                                     VectorDecisionVariable<2>(x(0), y(1)))
+                                     .constraint();
   ++num_generic_costs;
   VerifyAddedCost2(prog, generic_trivial_cost2, returned_cost3,
                    Eigen::Vector2d(1, 2), num_generic_costs);
@@ -502,7 +504,8 @@ GTEST_TEST(testMathematicalProgram, AddCostTest) {
   // Add an object that can be converted to a ConstraintImpl object on a
   // VariableRefList object.
   auto returned_cost4 =
-      prog.AddCost(generic_trivial_cost2, {x.head<1>(), y.tail<1>()});
+      prog.AddCost(generic_trivial_cost2, {x.head<1>(), y.tail<1>()})
+                   .constraint();
   ++num_generic_costs;
   VerifyAddedCost2(prog, generic_trivial_cost2, returned_cost4,
                    Eigen::Vector2d(1, 2), num_generic_costs);
@@ -1697,7 +1700,7 @@ GTEST_TEST(testMathematicalProgram, AddPositiveSemidefiniteConstraint) {
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
 
-  auto psd_cnstr = prog.AddPositiveSemidefiniteConstraint(X);
+  auto psd_cnstr = prog.AddPositiveSemidefiniteConstraint(X).constraint();
   EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1);
   const auto& new_psd_cnstr = prog.positive_semidefinite_constraints().back();
   EXPECT_EQ(psd_cnstr.get(), new_psd_cnstr.constraint().get());
@@ -1737,7 +1740,7 @@ void CheckAddedQuadraticCost(MathematicalProgram* prog,
                              const Eigen::MatrixXd& Q, const Eigen::VectorXd& b,
                              const VectorXDecisionVariable& x) {
   int num_quadratic_cost = prog->quadratic_costs().size();
-  auto cnstr = prog->AddQuadraticCost(Q, b, x);
+  auto cnstr = prog->AddQuadraticCost(Q, b, x).constraint();
 
   EXPECT_EQ(++num_quadratic_cost, prog->quadratic_costs().size());
   // Check if the newly added quadratic constraint, and the returned
@@ -1834,9 +1837,8 @@ GTEST_TEST(testMathematicalProgram, TestL2NormCost) {
   x_desired << 5, 6;
   Eigen::Vector2d b = A * x_desired;
 
-  std::shared_ptr<QuadraticConstraint> obj1 =
-      prog.AddQuadraticErrorCost(Q, x_desired, x);
-  std::shared_ptr<QuadraticConstraint> obj2 = prog.AddL2NormCost(A, b, x);
+  auto obj1 = prog.AddQuadraticErrorCost(Q, x_desired, x).constraint();
+  auto obj2 = prog.AddL2NormCost(A, b, x).constraint();
 
   // Test the objective at a 6 arbitrary values (to guarantee correctness
   // of the six-parameter quadratic form.

--- a/drake/solvers/test/nonlinear_program_test.cc
+++ b/drake/solvers/test/nonlinear_program_test.cc
@@ -207,7 +207,7 @@ class SixHumpCamelCost {
 GTEST_TEST(testNonlinearProgram, sixHumpCamel) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables(2);
-  auto cost = prog.AddCost(SixHumpCamelCost(), x);
+  auto cost = prog.AddCost(SixHumpCamelCost(), x).constraint();
 
   prog.SetInitialGuess(x, Vector2d::Random());
   RunNonlinearProgram(&prog, [&]() {
@@ -247,7 +247,7 @@ GTEST_TEST(testNonlinearProgram, linearPolynomialConstraint) {
   std::shared_ptr<Constraint> resulting_constraint =
       problem.AddPolynomialConstraint(VectorXPoly::Constant(1, x), var_mapping,
                                       Vector1d::Constant(2),
-                                      Vector1d::Constant(2), x_var);
+                                      Vector1d::Constant(2), x_var).constraint();
   // Check that the resulting constraint is a LinearConstraint.
   EXPECT_NE(dynamic_cast<LinearConstraint*>(resulting_constraint.get()),
             nullptr);

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -75,7 +75,8 @@ LinearSystemExample1::LinearSystemExample1()
     : prog_(std::make_unique<MathematicalProgram>()), x_{}, b_{}, con_{} {
   x_ = prog_->NewContinuousVariables<4>();
   b_ = Vector4d::Random();
-  con_ = prog_->AddLinearEqualityConstraint(Matrix4d::Identity(), b_, x_);
+  con_ = prog_->AddLinearEqualityConstraint(Matrix4d::Identity(), b_, x_)
+                                            .constraint();
   prog_->SetInitialGuessForAllVariables(Vector4d::Zero());
 }
 

--- a/drake/solvers/test/quadratic_program_examples.cc
+++ b/drake/solvers/test/quadratic_program_examples.cc
@@ -356,13 +356,13 @@ void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
   Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
   Eigen::Vector2d x_desired;
   x_desired << 1.0, 0.0;
-  auto objective = prog.AddQuadraticErrorCost(Q, x_desired, x);
+  auto objective = prog.AddQuadraticErrorCost(Q, x_desired, x).constraint();
 
   Eigen::Matrix2d A;
   A << 1.0, 1.0, -1.0, 1.0;
   Eigen::Vector2d ub = Eigen::Vector2d::Constant(1.0);
   Eigen::Vector2d lb = Eigen::Vector2d::Constant(-1.0);
-  auto constraint = prog.AddLinearConstraint(A, lb, ub, x);
+  auto constraint = prog.AddLinearConstraint(A, lb, ub, x).constraint();
   Eigen::Vector2d x_expected;
 
   const int N = 40;  // number of points to test around the circle


### PR DESCRIPTION
This is a draft implementation to address #5646, such that the `Add...Cost` and `Add...Constraint` methods in `MathematicalProgram` consistently return `Binding<T>` (where `T` is as specific as possible to the added item).

I am doing this as a draft because I would like to make sure that y'all are okay with how the interface change affects downstream usages.
A good example is how [`mathematical_program_test` changes](https://github.com/RobotLocomotion/drake/compare/master...EricCousineau-TRI:issue/5646_return_binding?expand=1#diff-861ece1bb7e5186e9e44628e43a654ca).

Additional, as discussed in the issue, it appears that we may be inducing extra copies of the decision variable vectors (`VectorXDecisionVariable`) when copying the `Binding`'s. There does not seem to be a clean way to sidestep this, but if you have an idea, please do let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5711)
<!-- Reviewable:end -->
