### PR TITLE
removed publish in simulator.Initialize()

### DIFF
--- a/drake/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.cc
@@ -26,6 +26,9 @@ DrakeVisualizer::DrakeVisualizer(const RigidBodyTree<double>& tree,
       tree.get_num_positions() + tree.get_num_velocities();
   DeclareInputPort(kVectorValued, vector_size);
   if (enable_playback) log_.reset(new SignalLog<double>(vector_size));
+
+  // Sends a load model command to visualizer.
+  PublishLoadRobot();
 }
 
 void DrakeVisualizer::set_publish_period(double period) {
@@ -112,14 +115,6 @@ void DrakeVisualizer::PlaybackTrajectory(
 }
 
 void DrakeVisualizer::DoPublish(const Context<double>& context) const {
-  // TODO(liang.fok): Replace the following code once System 2.0's API allows
-  // systems to declare that they need a certain action to be performed at
-  // simulation time t_0.
-  //
-  // Before any draw commands, we need to send the load_robot message.
-  if (context.get_time() == 0.0) {
-    PublishLoadRobot();
-  }
   DRAKE_DEMAND(sent_load_robot_);
 
   // Obtains the input vector, which contains the generalized q,v state of the

--- a/drake/multibody/rigid_body_plant/drake_visualizer.h
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.h
@@ -24,9 +24,8 @@ namespace systems {
 /**
  * This is a Drake System 2.0 block that takes a RigidBodyTree and publishes LCM
  * messages that are intended for the DrakeVisualizer. It does this in two
- * phases: initialization, which runs when DoPublish() is called with
- * Context::get_time() equal to zero, and run-time, which runs every time
- * DoPublish() is called.
+ * phases: initialization, which is done in the constructor, and run-time, which
+ * runs every time DoPublish() is called.
  *
  * During initialization, this system block analyzes the RigidBodyTree and tells
  * Drake Visualizer what it will be visualizing. For example, these include the

--- a/drake/multibody/rigid_body_plant/test/drake_visualizer_test.cc
+++ b/drake/multibody/rigid_body_plant/test/drake_visualizer_test.cc
@@ -511,6 +511,7 @@ GTEST_TEST(DrakeVisualizerTests, TestPublishPeriod) {
   drake::systems::Simulator<double> simulator(dut, std::move(context));
   simulator.set_publish_every_time_step(false);
   simulator.Initialize();
+  dut.Publish(simulator.get_context());
 
   for (double time = 0; time < 4; time += 0.01) {
     simulator.StepTo(time);

--- a/drake/systems/analysis/simulator.h
+++ b/drake/systems/analysis/simulator.h
@@ -371,9 +371,8 @@ void Simulator<T>::Initialize() {
   // Restore default values.
   ResetStatistics();
 
-  // Do a publish before the simulation starts.
-  system_.Publish(*context_);
-  ++num_publishes_;
+  // TODO(siyuan / sherm1): Removed the Publish() call here. But should add an
+  // initialization event instead.
 
   // Initialize runtime variables.
   initialization_done_ = true;

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -130,7 +130,7 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   EXPECT_EQ(simulator.get_num_steps_taken(), 1000);
   EXPECT_EQ(simulator.get_num_discrete_updates(), 0);
 
-  EXPECT_EQ(spring_mass.get_publish_count(), 1001);
+  EXPECT_EQ(spring_mass.get_publish_count(), 1000);
   EXPECT_EQ(spring_mass.get_update_count(), 0);
 
   // Current time is 1. An earlier final time should fail.
@@ -207,11 +207,11 @@ GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
   simulator.get_mutable_context()->set_time(0.);
   simulator.Initialize();
   // Publish should happen on initialization.
-  EXPECT_EQ(1, simulator.get_num_publishes());
+  EXPECT_EQ(0, simulator.get_num_publishes());
 
   // Simulate for 1 simulated second.  Publish should not happen.
   simulator.StepTo(1.);
-  EXPECT_EQ(1, simulator.get_num_publishes());
+  EXPECT_EQ(0, simulator.get_num_publishes());
 }
 
 // Repeat the previous test but now the continuous steps are interrupted
@@ -531,7 +531,7 @@ GTEST_TEST(SimulatorTest, DiscreteUpdateAndPublish) {
   simulator.StepTo(0.5);
   EXPECT_EQ(500, num_disc_updates);
   // Publication occurs at 400Hz, and also at initialization.
-  EXPECT_EQ(200 + 1, num_publishes);
+  EXPECT_EQ(200, num_publishes);
 }
 
 // Tests that the order of events in a simulator time step is first update

--- a/drake/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/drake/systems/lcm/test/lcm_publisher_system_test.cc
@@ -170,6 +170,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriod) {
   drake::systems::Simulator<double> simulator(*dut, std::move(context));
   simulator.set_publish_every_time_step(false);
   simulator.Initialize();
+  dut->Publish(simulator.get_context());
 
   for (double time = 0; time < 4; time += 0.01) {
     simulator.StepTo(time);


### PR DESCRIPTION
Talked with @sherm1, decided we should remove the Publish() call in Simulator::Initialize(). I added a todo there saying that we should eventually provide an event for Initialization. For now, if system (I don't there are many) relies on Publish for initialization, they should do it explicitly. 

Also moved the load robot message publish call from Publish() to the constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5716)
<!-- Reviewable:end -->
