### PR TITLE
Mosek Valgrind Suppressions

### DIFF
--- a/tools/valgrind-cmake.supp
+++ b/tools/valgrind-cmake.supp
@@ -36,27 +36,71 @@
 }
 
 {
-   <mosek-1>
-   Memcheck:Addr4
-   ...
-   fun:checkout_from_flexlm
-   ...
+    <mosek-1>
+    Memcheck:Addr4
+    ...
+    fun:checkout_from_flexlm
+    ...
 }
 
 {
-   <mosek-2>
-   Memcheck:Addr16
-   ...
-   fun:checkout_from_flexlm
-   ...
+    <mosek-2>
+    Memcheck:Addr16
+    ...
+    fun:checkout_from_flexlm
+    ...
 }
 
 {
-   <mosek-3>
-   Memcheck:Cond
-   ...
-   fun:MSK_sysenv_getsysinfo
-   ...
+    <mosek-3>
+    Memcheck:Cond
+    ...
+    fun:MSK_sysenv_getsysinfo
+    ...
+}
+
+# One of the other places MOSEK's issues with Valgrind have been suppressed quite sweepingly:
+# https://github.com/casadi/casadi/blob/master/test/internal/valgrind-casadi.supp#L242
+{
+    <mosek-4>
+    Memcheck:Cond
+    fun:__intel_sse2_strcpy
+    fun:MSKP_strdupenv
+    ...
+    fun:MSK_ehajakopr
+    fun:MSK_optimize
+    fun:MSK_optimizetrm
+    fun:_ZNK5drake7solvers11MosekSolver5SolveERNS0_19MathematicalProgramE
+}
+
+{
+    <mosek-5>
+    Memcheck:Cond
+    fun:MSK_hom_optlp
+    fun:MSK_hs_optlp
+    fun:MSK_opt_ipmslv
+    fun:MSK_contoptimizer
+    fun:MSK_optimizeunlicensed
+    fun:MSK_optimize
+    fun:MSK_optimizetrm
+    fun:_ZNK5drake7solvers11MosekSolver5SolveERNS0_19MathematicalProgramE
+}
+
+{
+    <mosek-6>
+    Memcheck:Cond
+    fun:mkl_lapack_ps_avx2_xdlansy
+    fun:mkl_lapack_ps_xdlansy
+    fun:mkl_lapack_dlansy
+    fun:mkl_lapack_dsyevd
+    fun:DSYEVD
+    fun:MSK_INTEL_P4_mathenv_symeig
+    fun:intpnt_sdp_ntscaling
+    fun:intpnt_inititer
+    fun:intpnt_conicoptimizer
+    fun:MSK_intpnt_optcone
+    fun:MSK_conic_optimizer
+    fun:MSKP_optimizeconic
 }
 
 {

--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -10,5 +10,69 @@
    ...
    fun:g_static_rec_mutex_lock
    fun:lcm_handle
-   ...
+}
+
+{
+    <mosek-1>
+    Memcheck:Addr4
+    ...
+    fun:checkout_from_flexlm
+}
+
+{
+    <mosek-2>
+    Memcheck:Addr16
+    ...
+    fun:checkout_from_flexlm
+}
+
+{
+    <mosek-3>
+    Memcheck:Cond
+    ...
+    fun:MSK_sysenv_getsysinfo
+}
+
+# One of the other places MOSEK's issues with Valgrind have been suppressed quite sweepingly:
+# https://github.com/casadi/casadi/blob/master/test/internal/valgrind-casadi.supp#L242
+{
+    <mosek-4>
+    Memcheck:Cond
+    fun:__intel_sse2_strcpy
+    fun:MSKP_strdupenv
+    ...
+    fun:MSK_ehajakopr
+    fun:MSK_optimize
+    fun:MSK_optimizetrm
+    fun:_ZNK5drake7solvers11MosekSolver5SolveERNS0_19MathematicalProgramE
+}
+
+{
+    <mosek-5>
+    Memcheck:Cond
+    fun:MSK_hom_optlp
+    fun:MSK_hs_optlp
+    fun:MSK_opt_ipmslv
+    fun:MSK_contoptimizer
+    fun:MSK_optimizeunlicensed
+    fun:MSK_optimize
+    fun:MSK_optimizetrm
+    fun:_ZNK5drake7solvers11MosekSolver5SolveERNS0_19MathematicalProgramE
+}
+
+{
+    <mosek-6>
+    Memcheck:Cond
+    fun:mkl_lapack_ps_avx2_xdlansy
+    fun:mkl_lapack_ps_xdlansy
+    fun:mkl_lapack_dlansy
+    fun:mkl_lapack_dsyevd
+    fun:DSYEVD
+    fun:MSK_INTEL_P4_mathenv_symeig
+    fun:intpnt_sdp_ntscaling
+    fun:intpnt_inititer
+    fun:intpnt_conicoptimizer
+    fun:MSK_intpnt_optcone
+    fun:MSK_conic_optimizer
+    fun:MSKP_optimizeconic
 }


### PR DESCRIPTION
Adding Mosek Suppressions and indenting.
One of the other places where they have been suppressed:
https://github.com/casadi/casadi/blob/master/test/internal/valgrind-casadi.supp#L242

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5722)
<!-- Reviewable:end -->
