### PR TITLE
redo drakve viz load robot msg

### DIFF
--- a/drake/examples/Valkyrie/BUILD
+++ b/drake/examples/Valkyrie/BUILD
@@ -184,9 +184,6 @@ drake_cc_googletest(
         "//drake/multibody/joints",
         "//drake/multibody/parsers",
         "//drake/multibody/rigid_body_plant:drake_visualizer",
-        "//drake/systems/analysis:simulator",
-        "//drake/systems/framework:diagram",
-        "//drake/systems/primitives:constant_vector_source",
     ],
 )
 

--- a/drake/examples/Valkyrie/test/CMakeLists.txt
+++ b/drake/examples/Valkyrie/test/CMakeLists.txt
@@ -27,9 +27,5 @@ if(lcm_FOUND)
     drakeLcm
     drakeMultibodyParsers
     drakeRBM
-    drakeRigidBodyPlant
-    drakeSystemFramework
-    drakeSystemAnalysis
-    drakeSystemFramework
-    drakeSystemPrimitives)
+    drakeRigidBodyPlant)
 endif()

--- a/drake/examples/Valkyrie/test/valkyrie_ik_test.cc
+++ b/drake/examples/Valkyrie/test/valkyrie_ik_test.cc
@@ -14,12 +14,9 @@
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_ik.h"
-#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
+#include "drake/multibody/rigid_body_plant/create_load_robot_message.h"
+#include "drake/multibody/rigid_body_plant/viewer_draw_translator.h"
 #include "drake/multibody/rigid_body_tree.h"
-#include "drake/systems/analysis/simulator.h"
-#include "drake/systems/framework/diagram.h"
-#include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/primitives/constant_vector_source.h"
 
 using Eigen::Vector2d;
 using Eigen::Vector3d;
@@ -261,20 +258,26 @@ GTEST_TEST(ValkyrieIK_Test, ValkyrieIK_Test_StandingPose_Test) {
   EXPECT_GT(com(2), 0);
 
   // show it in drake visualizer
-  VectorXd x(tree->get_num_positions() + tree->get_num_velocities());
-  x.setZero();
+  VectorX<double> x = VectorX<double>::Zero(tree->get_num_positions() +
+                                            tree->get_num_velocities());
   x.head(q_sol.size()) = q_sol;
+  systems::BasicVector<double> q_draw(x);
 
   lcm::DrakeLcm lcm;
-  systems::DiagramBuilder<double> builder;
-  auto source = builder.AddSystem<systems::ConstantVectorSource>(x);
-  auto publisher = builder.AddSystem<systems::DrakeVisualizer>(*tree, &lcm);
-  builder.Connect(source->get_output_port(), publisher->get_input_port(0));
-  auto diagram = builder.Build();
+  std::vector<uint8_t> message_bytes;
 
-  auto context = diagram->CreateDefaultContext();
-  auto output = diagram->AllocateOutput(*context);
-  diagram->Publish(*context);
+  lcmt_viewer_load_robot load_msg =
+      multibody::CreateLoadRobotMessage<double>(*tree);
+  const int length = load_msg.getEncodedSize();
+  message_bytes.resize(length);
+  load_msg.encode(message_bytes.data(), 0, length);
+  lcm.Publish("DRAKE_VIEWER_LOAD_ROBOT", message_bytes.data(),
+              message_bytes.size());
+
+  systems::ViewerDrawTranslator posture_drawer(*tree);
+  posture_drawer.Serialize(0, q_draw, &message_bytes);
+  lcm.Publish("DRAKE_VIEWER_DRAW", message_bytes.data(),
+              message_bytes.size());
 }
 
 }  // namespace


### PR DESCRIPTION
i grepped the drake dir for DrakeVisualizer, and manually checked every instance to make sure that it is used with a simulator except valkyrie_ik_test. I converted to explicitly publish the load and draw message without the system stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5724)
<!-- Reviewable:end -->
