### PR TITLE
Add linter for Python files and fix code style

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,6 +55,14 @@ github_archive(
 )
 
 github_archive(
+    name = "pycodestyle",
+    repository = "PyCQA/pycodestyle",
+    commit = "2.3.1",
+    sha256 = "e9fc1ca3fd85648f45c0d2e33591b608a17d8b9b78e22c5f898e831351bacb03",
+    build_file = "tools/pycodestyle.BUILD",
+)
+
+github_archive(
     name = "eigen",
     repository = "RobotLocomotion/eigen-mirror",
     commit = "d3ee2bc648be3d8be8c596a9a0aefef656ff8637",

--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -8,6 +8,7 @@ load(
     "drake_cc_library",
     "drake_cc_binary",
 )
+load("//tools:python_lint.bzl", "python_lint")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -557,3 +558,5 @@ drake_cc_googletest(
 )
 
 cpplint()
+
+python_lint()

--- a/drake/automotive/automotive_demo.py
+++ b/drake/automotive/automotive_demo.py
@@ -154,6 +154,7 @@ class Launcher(object):
             if child.process.poll() is None:
                 child.process.kill()
 
+
 the_launcher = Launcher()
 
 
@@ -246,6 +247,7 @@ def main():
         the_launcher.kill()
 
     sys.exit(the_launcher.returncode)
+
 
 if __name__ == '__main__':
     main()

--- a/drake/automotive/maliput/monolane/BUILD
+++ b/drake/automotive/maliput/monolane/BUILD
@@ -3,6 +3,7 @@
 
 load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "drake_cc_binary", "drake_cc_googletest", "drake_cc_library")
+load("//tools:python_lint.bzl", "python_lint")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -119,3 +120,5 @@ py_test(
 )
 
 cpplint()
+
+python_lint()

--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -8,6 +8,7 @@ load(
     "drake_cc_library",
     "drake_cc_binary",
 )
+load("//tools:python_lint.bzl", "python_lint")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -61,3 +62,5 @@ py_test(
 )
 
 cpplint()
+
+python_lint()

--- a/drake/automotive/steering_command_driver.py
+++ b/drake/automotive/steering_command_driver.py
@@ -103,18 +103,18 @@ class KeyboardEventProcessor:
             elif (event.key == pygame.K_DOWN):
                 self.brake_gradient = 1
             elif (event.key == pygame.K_LEFT):
-                new_msg = new_msg._replace(steering_angle = _limit_steering(
+                new_msg = new_msg._replace(steering_angle=_limit_steering(
                     last_msg.steering_angle + (
                         STEERING_BUTTON_STEP_ANGLE * TURN_LEFT_SIGN)))
             elif (event.key == pygame.K_RIGHT):
-                new_msg = new_msg._replace(steering_angle = _limit_steering(
+                new_msg = new_msg._replace(steering_angle=_limit_steering(
                     last_msg.steering_angle + (
                         STEERING_BUTTON_STEP_ANGLE * TURN_RIGHT_SIGN)))
 
         new_msg = last_msg._replace(
-            throttle = _limit_throttle(
+            throttle=_limit_throttle(
                 last_msg.throttle + self.throttle_gradient * THROTTLE_SCALE),
-            brake = _limit_brake(
+            brake=_limit_brake(
                 last_msg.brake + self.brake_gradient * BRAKE_SCALE))
 
         return new_msg
@@ -210,7 +210,8 @@ class SteeringCommandPublisher:
                     event, self.last_value)
                 msg = lcm_msg()
                 msg.steering_angle = self.last_value.steering_angle
-                msg.acceleration = self.last_value.throttle - self.last_value.brake
+                msg.acceleration = (self.last_value.throttle -
+                                    self.last_value.brake)
                 self.lc.publish(self.lcm_tag, msg.encode())
                 self.printLCMValues()
 

--- a/drake/bindings/python/pydrake/forwarddiff.py
+++ b/drake/bindings/python/pydrake/forwarddiff.py
@@ -43,7 +43,8 @@ def jacobian(function, x):
         der[i] = 1
         x_ad.flat[i] = AutoDiffXd(x.flat[i], der)
     y_ad = function(x_ad)
-    return np.vstack([y.derivatives() for y in y_ad.flat]).reshape(y_ad.shape + (-1,))
+    return np.vstack(
+        [y.derivatives() for y in y_ad.flat]).reshape(y_ad.shape + (-1,))
 
 
 # Method overloads:

--- a/drake/bindings/python/pydrake/solvers/ik.py
+++ b/drake/bindings/python/pydrake/solvers/ik.py
@@ -22,10 +22,10 @@ class WorldPositionConstraint(_WorldPositionConstraint):
     def __init__(self, model, body, pts, lb, ub, tspan=None):
         pts = np.asarray(pts)
         if pts.ndim == 1:
-            # TODO: deprecate this method. We should require that pts be a 2-d array
-            # even when the second dimension is of length 1. When that requirement is
-            # made, we can delete this entire class and the renamed _WorldPositionConstraint
-            # import.
+            # TODO: deprecate this method. We should require that pts be a 2-d
+            # array even when the second dimension is of length 1. When that
+            # requirement is made, we can delete this entire class and the
+            # renamed _WorldPositionConstraint import.
             # Ref: https://github.com/RobotLocomotion/drake/issues/4950
             pts = pts.reshape((pts.size, 1))
         if tspan is None:

--- a/drake/bindings/python/pydrake/test/testAtlasConstructor.py
+++ b/drake/bindings/python/pydrake/test/testAtlasConstructor.py
@@ -10,8 +10,8 @@ from pydrake import getDrakePath
 class TestAtlasConstructor(unittest.TestCase):
     def test_constructor(self):
         pm = PackageMap()
-        model = os.path.join(getDrakePath(),
-            "examples", "Atlas", "urdf", "atlas_minimal_contact.urdf")
+        model = os.path.join(getDrakePath(), "examples", "Atlas", "urdf",
+                             "atlas_minimal_contact.urdf")
         pm.PopulateUpstreamToDrake(model)
         robot = rbtree.RigidBodyTree(
             model, package_map=pm,

--- a/drake/bindings/python/pydrake/test/testPR2IK.py
+++ b/drake/bindings/python/pydrake/test/testPR2IK.py
@@ -35,6 +35,7 @@ def load_robot_from_urdf(urdf_file):
 
     return robot
 
+
 urdf_file = os.path.join(pydrake.getDrakePath(), "examples/PR2/pr2.urdf")
 
 # Load our model from URDF

--- a/drake/bindings/python/pydrake/test/testPackageMap.py
+++ b/drake/bindings/python/pydrake/test/testPackageMap.py
@@ -18,7 +18,8 @@ class TestPackageMap(unittest.TestCase):
     def test_populate_from_folder(self):
         pm = PackageMap()
         self.assertEqual(pm.size(), 0)
-        pm.PopulateFromFolder(os.path.join(getDrakePath(), "examples", "Atlas"))
+        pm.PopulateFromFolder(
+            os.path.join(getDrakePath(), "examples", "Atlas"))
         self.assertTrue(pm.Contains("Atlas"))
         self.assertEqual(pm.GetPath("Atlas"), os.path.join(
             getDrakePath(), "examples", "Atlas", ""))
@@ -29,8 +30,8 @@ class TestPackageMap(unittest.TestCase):
             getDrakePath(), "examples")
         pm.PopulateFromEnvironment("PYDRAKE_TEST_ROS_PACKAGE_PATH")
         self.assertTrue(pm.Contains("Atlas"))
-        self.assertEqual(pm.GetPath("Atlas"),
-            os.path.join(getDrakePath(), "examples", "Atlas", ""))
+        self.assertEqual(pm.GetPath("Atlas"), os.path.join(
+            getDrakePath(), "examples", "Atlas", ""))
         del os.environ["PYDRAKE_TEST_ROS_PACKAGE_PATH"]
 
     def test_populate_upstream(self):
@@ -39,8 +40,8 @@ class TestPackageMap(unittest.TestCase):
             os.path.join(getDrakePath(), "examples", "Atlas", "urdf",
                          "atlas_minimal_contact.urdf"))
         self.assertTrue(pm.Contains("Atlas"))
-        self.assertEqual(pm.GetPath("Atlas"),
-            os.path.join(getDrakePath(), "examples", "Atlas"))
+        self.assertEqual(pm.GetPath("Atlas"), os.path.join(
+            getDrakePath(), "examples", "Atlas"))
 
 
 if __name__ == '__main__':

--- a/drake/bindings/python/pydrake/test/testRBTTransformPoints.py
+++ b/drake/bindings/python/pydrake/test/testRBTTransformPoints.py
@@ -21,7 +21,8 @@ class TestRBMForwardKin(unittest.TestCase):
 
     def test_gradient(self):
         r = pydrake.rbtree.RigidBodyTree(
-            os.path.join(pydrake.getDrakePath(), "examples/Pendulum/Pendulum.urdf"),
+            os.path.join(pydrake.getDrakePath(),
+                         "examples/Pendulum/Pendulum.urdf"),
             pydrake.rbtree.FloatingBaseType.kRollPitchYaw)
 
         def do_transform(q):
@@ -44,7 +45,6 @@ class TestRBMForwardKin(unittest.TestCase):
         r = pydrake.rbtree.RigidBodyTree(os.path.join(pydrake.getDrakePath(),
                                          "examples/Pendulum/Pendulum.urdf"))
 
-
         q = np.zeros(7)
         q[6] = np.pi / 2
         kinsol = r.doKinematics(q)
@@ -54,9 +54,6 @@ class TestRBMForwardKin(unittest.TestCase):
                                               [0, 1, 0, 0],
                                               [-1, 0, 0, 0],
                                               [0, 0, 0, 1]])))
-
-
-
 
 
 if __name__ == '__main__':

--- a/drake/bindings/python/pydrake/test/testSymbolic.py
+++ b/drake/bindings/python/pydrake/test/testSymbolic.py
@@ -56,5 +56,6 @@ class TestSymbolicVariables(unittest.TestCase):
         self.assertEqual(str(-x), "(-1 * x)")
         self.assertEqual(str(-(x + 1)), "(-1 - x)")
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/drake/bindings/python/pydrake/test/test_urdf_parser.py
+++ b/drake/bindings/python/pydrake/test/test_urdf_parser.py
@@ -33,5 +33,6 @@ class TestUrdfParser(unittest.TestCase):
                          msg='Incorrect number of bodies: {0} vs. {1}'.format(
                              robot.get_num_bodies(), expected_num_bodies))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/drake/doc/serve_sphinx.py
+++ b/drake/doc/serve_sphinx.py
@@ -19,10 +19,12 @@ with zipfile.ZipFile("drake/doc/sphinx.zip", "r") as archive:
 os.chdir("sphinx-tmp")
 file_url = "file://%s/index.html " % os.path.abspath(os.getcwd())
 
+
 # An HTTP handler without logging.
 class Handler(SimpleHTTPRequestHandler):
     def log_request(*_):
         pass
+
 
 # Serve the current directory for local browsing.
 sockaddr = ("127.0.0.1", 8000)

--- a/tools/pycodestyle.BUILD
+++ b/tools/pycodestyle.BUILD
@@ -1,0 +1,10 @@
+# -*- python -*-
+
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "pycodestyle",
+    srcs = ["pycodestyle.py"],
+    main = "pycodestyle.py",
+    srcs_version = "PY2AND3",
+)

--- a/tools/python_lint.bzl
+++ b/tools/python_lint.bzl
@@ -1,0 +1,46 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+"""
+Runs the pycodestyle PEP 8 code style checker on all Python source files
+declared in rules in a BUILD file.
+
+Example:
+    BUILD:
+        load("//tools:python_lint.bzl", "python_lint")
+
+        py_library(
+            name = "foo",
+            srcs = ["foo.py"],
+        )
+
+        python_lint()
+"""
+
+def python_lint():
+    for rule in native.existing_rules().values():
+        srcs = rule.get("srcs", ())
+
+        if type(srcs) == type(()):
+            src_labels = list(srcs)
+
+            py_labels = [
+                src_label for src_label in src_labels
+                if src_label.endswith(".py")
+            ]
+
+            py_locations = [
+                "$(location {})".format(py_label) for py_label in py_labels
+            ]
+
+            if len(py_locations) > 0:
+                native.py_test(
+                    name = rule["name"] + "_pycodestyle",
+                    size = "small",
+                    srcs = ["@pycodestyle//:pycodestyle"],
+                    data = py_labels,
+                    args = py_locations,
+                    main = "@pycodestyle//:pycodestyle.py",
+                    srcs_version = "PY2AND3",
+                    tags = ["pycodestyle"],
+                )


### PR DESCRIPTION
Runs the `pycodestyle` PEP 8 code style checker on all Python source files declared in rules in a BUILD file. I almost have `pydocstyle` working too, but that would be a new PR (which would also add support for `setup.cfg` files).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5728)
<!-- Reviewable:end -->
