### PR TITLE
Implement fine-grained sparsity on Diagrams.

### DIFF
--- a/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.cc
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.cc
@@ -14,9 +14,9 @@ namespace systems {
 
 template <typename T>
 PidControlledSpringMassSystem<T>::PidControlledSpringMassSystem(
-    const T& spring_stiffness, const T& mass,
-    const T& Kp, const T& Ki, const T& Kd,
-    const T& target_position) : Diagram<T>() {
+    const T& spring_stiffness, const T& mass, double Kp, double Ki, double Kd,
+    const T& target_position)
+    : Diagram<T>() {
   DRAKE_ASSERT(spring_stiffness >= 0);
   DRAKE_ASSERT(mass >= 0);
   DRAKE_ASSERT(Kp >= 0);
@@ -28,9 +28,8 @@ PidControlledSpringMassSystem<T>::PidControlledSpringMassSystem(
   plant_ = builder.template
       AddSystem<SpringMassSystem>(spring_stiffness, mass, true /* is forced */);
   controller_ = builder.template AddSystem<PidController>(
-      VectorX<T>::Constant(1, Kp),
-      VectorX<T>::Constant(1, Ki),
-      VectorX<T>::Constant(1, Kd));
+      VectorX<double>::Constant(1, Kp), VectorX<double>::Constant(1, Ki),
+      VectorX<double>::Constant(1, Kd));
   VectorX<T> desired(2);
   desired << target_position, 0;
   target_ = builder.template AddSystem<ConstantVectorSource>(desired);
@@ -67,11 +66,6 @@ PidControlledSpringMassSystem<T>::PidControlledSpringMassSystem(
   // consists of a vector with position, velocity and energy.
   builder.ExportOutput(plant_->get_output_port());
   builder.BuildInto(this);
-}
-
-template <typename T>
-bool PidControlledSpringMassSystem<T>::has_any_direct_feedthrough() const {
-  return false;
 }
 
 template <typename T>

--- a/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.h
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system.h
@@ -39,7 +39,7 @@ class PidControlledSpringMassSystem : public Diagram<T> {
   /// @param[in] Kd the derivative constant.
   /// @param[in] target_position the desired target position.
   PidControlledSpringMassSystem(const T& spring_stiffness, const T& mass,
-                                const T& Kp, const T& Ki, const T& Kd,
+                                double Kp, double Ki, double Kd,
                                 const T& target_position);
 
   ~PidControlledSpringMassSystem() override {}
@@ -58,9 +58,6 @@ class PidControlledSpringMassSystem : public Diagram<T> {
 
   /// Returns the SpringMassSystem plant of the model.
   const SpringMassSystem<T>& get_plant() const;
-
-  // System<T> overrides
-  bool has_any_direct_feedthrough() const override;
 
  private:
   // These are references into the Diagram; no ownership implied.

--- a/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system_test.cc
+++ b/drake/systems/analysis/test/controlled_spring_mass_system/controlled_spring_mass_system_test.cc
@@ -105,6 +105,10 @@ TEST_F(SpringMassSystemTest, EvalTimeDerivatives) {
             plant_xcdot->get_vector().GetAtIndex(2));
 }
 
+TEST_F(SpringMassSystemTest, DirectFeedthrough) {
+  EXPECT_FALSE(model_->HasAnyDirectFeedthrough());
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -10,44 +10,43 @@ namespace systems {
 
 template <typename T>
 PidControlledSystem<T>::PidControlledSystem(std::unique_ptr<System<T>> plant,
-                                            const T& Kp, const T& Ki,
-                                            const T& Kd)
+                                            double Kp, double Ki, double Kd)
     : PidControlledSystem(std::move(plant), nullptr /* feedback selector */, Kp,
                           Ki, Kd) {}
 
 template <typename T>
 PidControlledSystem<T>::PidControlledSystem(std::unique_ptr<System<T>> plant,
-                                            const VectorX<T>& Kp,
-                                            const VectorX<T>& Ki,
-                                            const VectorX<T>& Kd)
+                                            const Eigen::VectorXd& Kp,
+                                            const Eigen::VectorXd& Ki,
+                                            const Eigen::VectorXd& Kd)
     : PidControlledSystem(std::move(plant), nullptr /* feedback selector */, Kp,
                           Ki, Kd) {}
 
 template <typename T>
 PidControlledSystem<T>::PidControlledSystem(
     std::unique_ptr<System<T>> plant,
-    std::unique_ptr<MatrixGain<T>> feedback_selector, const T& Kp, const T& Ki,
-    const T& Kd) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, double Kp, double Ki,
+    double Kd) {
   const int input_size = plant->get_input_port(0).size();
-  const VectorX<T> Kp_v = VectorX<T>::Ones(input_size) * Kp;
-  const VectorX<T> Ki_v = VectorX<T>::Ones(input_size) * Ki;
-  const VectorX<T> Kd_v = VectorX<T>::Ones(input_size) * Kd;
+  const Eigen::VectorXd Kp_v = Eigen::VectorXd::Ones(input_size) * Kp;
+  const Eigen::VectorXd Ki_v = Eigen::VectorXd::Ones(input_size) * Ki;
+  const Eigen::VectorXd Kd_v = Eigen::VectorXd::Ones(input_size) * Kd;
   Initialize(std::move(plant), std::move(feedback_selector), Kp_v, Ki_v, Kd_v);
 }
 
 template <typename T>
 PidControlledSystem<T>::PidControlledSystem(
     std::unique_ptr<System<T>> plant,
-    std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
-    const VectorX<T>& Ki, const VectorX<T>& Kd) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const Eigen::VectorXd& Kp,
+    const Eigen::VectorXd& Ki, const Eigen::VectorXd& Kd) {
   Initialize(std::move(plant), std::move(feedback_selector), Kp, Ki, Kd);
 }
 
 template <typename T>
 void PidControlledSystem<T>::Initialize(
     std::unique_ptr<System<T>> plant,
-    std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
-    const VectorX<T>& Ki, const VectorX<T>& Kd) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const Eigen::VectorXd& Kp,
+    const Eigen::VectorXd& Ki, const Eigen::VectorXd& Kd) {
   DRAKE_DEMAND(plant != nullptr);
   DiagramBuilder<T> builder;
   plant_ = builder.template AddSystem(std::move(plant));
@@ -69,9 +68,9 @@ typename PidControlledSystem<T>::ConnectResult
 PidControlledSystem<T>::ConnectController(
     const InputPortDescriptor<T>& plant_input,
     const OutputPortDescriptor<T>& plant_output,
-    std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
-    const VectorX<T>& Ki, const VectorX<T>& Kd, DiagramBuilder<T>* builder) {
-
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const Eigen::VectorXd& Kp,
+    const Eigen::VectorXd& Ki, const Eigen::VectorXd& Kd,
+    DiagramBuilder<T>* builder) {
   auto controller = builder->template AddSystem<PidController<T>>(
       std::move(feedback_selector),
       Kp, Ki, Kd);
@@ -96,11 +95,10 @@ typename PidControlledSystem<T>::ConnectResult
 PidControlledSystem<T>::ConnectControllerWithInputSaturation(
     const InputPortDescriptor<T>& plant_input,
     const OutputPortDescriptor<T>& plant_output,
-    std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
-    const VectorX<T>& Ki, const VectorX<T>& Kd,
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const Eigen::VectorXd& Kp,
+    const Eigen::VectorXd& Ki, const Eigen::VectorXd& Kd,
     const VectorX<T>& min_plant_input, const VectorX<T>& max_plant_input,
     DiagramBuilder<T>* builder) {
-
   auto saturation = builder->template AddSystem<Saturation<T>>(
       min_plant_input, max_plant_input);
 

--- a/drake/systems/controllers/pid_controlled_system.h
+++ b/drake/systems/controllers/pid_controlled_system.h
@@ -70,8 +70,8 @@ class PidControlledSystem : public Diagram<T> {
   /// @param[in] Kp the proportional constant.
   /// @param[in] Ki the integral constant.
   /// @param[in] Kd the derivative constant.
-  PidControlledSystem(std::unique_ptr<System<T>> plant, const T& Kp,
-                      const T& Ki, const T& Kd);
+  PidControlledSystem(std::unique_ptr<System<T>> plant, double Kp, double Ki,
+                      double Kd);
 
   /// A constructor where the gains are vector values and all of the plant's
   /// output port zero is part of the feedback signal. The length of the gain
@@ -85,8 +85,9 @@ class PidControlledSystem : public Diagram<T> {
   /// @param[in] Ki the integral vector constant.
   ///
   /// @param[in] Kd the derivative vector constant.
-  PidControlledSystem(std::unique_ptr<System<T>> plant, const VectorX<T>& Kp,
-                      const VectorX<T>& Ki, const VectorX<T>& Kd);
+  PidControlledSystem(std::unique_ptr<System<T>> plant,
+                      const Eigen::VectorXd& Kp, const Eigen::VectorXd& Ki,
+                      const Eigen::VectorXd& Kd);
 
   /// A constructor where the gains are scalar values and some of the plant's
   /// output is part of the feedback signal as specified by
@@ -102,7 +103,7 @@ class PidControlledSystem : public Diagram<T> {
   /// @param[in] Kd the derivative constant.
   PidControlledSystem(std::unique_ptr<System<T>> plant,
                       std::unique_ptr<MatrixGain<T>> feedback_selector,
-                      const T& Kp, const T& Ki, const T& Kd);
+                      double Kp, double Ki, double Kd);
 
   /// A constructor where the gains are vector values and some of the plant's
   /// output is part of the feedback signal as specified by
@@ -125,8 +126,8 @@ class PidControlledSystem : public Diagram<T> {
   /// @param[in] Kd the derivative vector constant.
   PidControlledSystem(std::unique_ptr<System<T>> plant,
                       std::unique_ptr<MatrixGain<T>> feedback_selector,
-                      const VectorX<T>& Kp, const VectorX<T>& Ki,
-                      const VectorX<T>& Kd);
+                      const Eigen::VectorXd& Kp, const Eigen::VectorXd& Ki,
+                      const Eigen::VectorXd& Kd);
 
   ~PidControlledSystem() override;
 
@@ -156,8 +157,9 @@ class PidControlledSystem : public Diagram<T> {
   static ConnectResult ConnectController(
       const InputPortDescriptor<T>& plant_input,
       const OutputPortDescriptor<T>& plant_output,
-      std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
-      const VectorX<T>& Ki, const VectorX<T>& Kd, DiagramBuilder<T>* builder);
+      std::unique_ptr<MatrixGain<T>> feedback_selector,
+      const Eigen::VectorXd& Kp, const Eigen::VectorXd& Ki,
+      const Eigen::VectorXd& Kd, DiagramBuilder<T>* builder);
 
   /// Creates a PidController with input saturation and uses @p builder to
   /// connect @p plant_input and @p plant_output from an existing plant, adding
@@ -167,10 +169,10 @@ class PidControlledSystem : public Diagram<T> {
   static ConnectResult ConnectControllerWithInputSaturation(
       const InputPortDescriptor<T>& plant_input,
       const OutputPortDescriptor<T>& plant_output,
-      std::unique_ptr<MatrixGain<T>> feedback_selector, const VectorX<T>& Kp,
-      const VectorX<T>& Ki, const VectorX<T>& Kd,
-      const VectorX<T>& min_plant_input, const VectorX<T>& max_plant_input,
-      DiagramBuilder<T>* builder);
+      std::unique_ptr<MatrixGain<T>> feedback_selector,
+      const Eigen::VectorXd& Kp, const Eigen::VectorXd& Ki,
+      const Eigen::VectorXd& Kd, const VectorX<T>& min_plant_input,
+      const VectorX<T>& max_plant_input, DiagramBuilder<T>* builder);
 
  private:
   // A helper function for the constructors. This is necessary to avoid seg
@@ -178,8 +180,8 @@ class PidControlledSystem : public Diagram<T> {
   // the plant when one constructor delegates to another constructor.
   void Initialize(std::unique_ptr<System<T>> plant,
                   std::unique_ptr<MatrixGain<T>> feedback_selector,
-                  const VectorX<T>& Kp, const VectorX<T>& Ki,
-                  const VectorX<T>& Kd);
+                  const Eigen::VectorXd& Kp, const Eigen::VectorXd& Ki,
+                  const Eigen::VectorXd& Kd);
 
   System<T>* plant_{nullptr};
 };

--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -47,7 +47,7 @@ class PidControllerInternal : public Diagram<T> {
   /// @param Ki the integral constant.
   /// @param Kd the derivative constant.
   /// @param size number of elements in the error signal to be processed.
-  PidControllerInternal(const T& Kp, const T& Ki, const T& Kd, int size);
+  PidControllerInternal(double Kp, double Ki, double Kd, int size);
 
   /// Constructs a %PidControllerInternal system where each gain can have a
   /// different value.
@@ -55,8 +55,8 @@ class PidControllerInternal : public Diagram<T> {
   /// @param Kp the vector of proportional gain constants.
   /// @param Ki the vector of integral gain constants.
   /// @param Kd the vector of derivative gain constants.
-  PidControllerInternal(const VectorX<T>& Kp, const VectorX<T>& Ki,
-                const VectorX<T>& Kd);
+  PidControllerInternal(const Eigen::VectorXd& Kp, const Eigen::VectorXd& Ki,
+                        const Eigen::VectorXd& Kd);
 
   ~PidControllerInternal() override {}
 
@@ -65,36 +65,30 @@ class PidControllerInternal : public Diagram<T> {
   /// element in the proportional gain vector is the same. It will throw a
   /// `std::runtime_error` if the proportional gain cannot be represented as a
   /// scalar value.
-  const T& get_Kp_singleton() const;
+  double get_Kp_singleton() const;
 
   /// Returns the integral gain constant. This method should only be called if
   /// the integral gain can be represented as a scalar value, i.e., every
   /// element in the integral gain vector is the same. It will throw a
   /// `std::runtime_error` if the integral gain cannot be represented as a
   /// scalar value.
-  const T& get_Ki_singleton() const;
+  double get_Ki_singleton() const;
 
   /// Returns the derivative gain constant. This method should only be called if
   /// the derivative gain can be represented as a scalar value, i.e., every
   /// element in the derivative gain vector is the same. It will throw a
   /// `std::runtime_error` if the derivative gain cannot be represented as a
   /// scalar value.
-  const T& get_Kd_singleton() const;
+  double get_Kd_singleton() const;
 
   /// Returns the proportional vector constant.
-  const VectorX<T>& get_Kp_vector() const;
+  const Eigen::VectorXd& get_Kp_vector() const;
 
   /// Returns the integral vector constant.
-  const VectorX<T>& get_Ki_vector() const;
+  const Eigen::VectorXd& get_Ki_vector() const;
 
   /// Returns the derivative vector constant.
-  const VectorX<T>& get_Kd_vector() const;
-
-  // System<T> overrides
-  /// A PID controller directly feedthroughs the error signal to the output when
-  /// the proportional constant is non-zero. It feeds through the rate of change
-  /// of the error signal when the derivative constant is non-zero.
-  bool has_any_direct_feedthrough() const override;
+  const Eigen::VectorXd& get_Kd_vector() const;
 
   /// Sets the integral of the %PidControllerInternal to @p value.
   /// @p value must be a column vector of the appropriate size.
@@ -120,16 +114,16 @@ class PidControllerInternal : public Diagram<T> {
 };
 
 template <typename T>
-PidControllerInternal<T>::PidControllerInternal(
-    const T& Kp, const T& Ki, const T& Kd, int size)
-    : PidControllerInternal(
-        VectorX<T>::Ones(size) * Kp,
-        VectorX<T>::Ones(size) * Ki,
-        VectorX<T>::Ones(size) * Kd) { }
+PidControllerInternal<T>::PidControllerInternal(double Kp, double Ki, double Kd,
+                                                int size)
+    : PidControllerInternal(Eigen::VectorXd::Ones(size) * Kp,
+                            Eigen::VectorXd::Ones(size) * Ki,
+                            Eigen::VectorXd::Ones(size) * Kd) {}
 
 template <typename T>
-PidControllerInternal<T>::PidControllerInternal(
-    const VectorX<T>& Kp, const VectorX<T>& Ki, const VectorX<T>& Kd)
+PidControllerInternal<T>::PidControllerInternal(const Eigen::VectorXd& Kp,
+                                                const Eigen::VectorXd& Ki,
+                                                const Eigen::VectorXd& Kd)
     : Diagram<T>() {
   const int size = Kp.size();
   DRAKE_ASSERT(size > 0);
@@ -169,38 +163,33 @@ PidControllerInternal<T>::PidControllerInternal(
 }
 
 template <typename T>
-const T& PidControllerInternal<T>::get_Kp_singleton() const {
+double PidControllerInternal<T>::get_Kp_singleton() const {
   return proportional_gain_->get_gain();
 }
 
 template <typename T>
-const T& PidControllerInternal<T>::get_Ki_singleton() const {
+double PidControllerInternal<T>::get_Ki_singleton() const {
   return integral_gain_->get_gain();
 }
 
 template <typename T>
-const T& PidControllerInternal<T>::get_Kd_singleton() const {
+double PidControllerInternal<T>::get_Kd_singleton() const {
   return derivative_gain_->get_gain();
 }
 
 template <typename T>
-const VectorX<T>& PidControllerInternal<T>::get_Kp_vector() const {
+const Eigen::VectorXd& PidControllerInternal<T>::get_Kp_vector() const {
   return proportional_gain_->get_gain_vector();
 }
 
 template <typename T>
-const VectorX<T>& PidControllerInternal<T>::get_Ki_vector() const {
+const Eigen::VectorXd& PidControllerInternal<T>::get_Ki_vector() const {
   return integral_gain_->get_gain_vector();
 }
 
 template <typename T>
-const VectorX<T>& PidControllerInternal<T>::get_Kd_vector() const {
+const Eigen::VectorXd& PidControllerInternal<T>::get_Kd_vector() const {
   return derivative_gain_->get_gain_vector();
-}
-
-template <typename T>
-bool PidControllerInternal<T>::has_any_direct_feedthrough() const {
-  return !get_Kp_vector().isZero() || !get_Kd_vector().isZero();
 }
 
 template <typename T>
@@ -230,23 +219,23 @@ void PidControllerInternal<T>::set_integral_value(
 }
 
 template <typename T>
-PidController<T>::PidController(
-    const VectorX<T>& kp, const VectorX<T>& ki, const VectorX<T>& kd) {
+PidController<T>::PidController(const Eigen::VectorXd& kp,
+                                const Eigen::VectorXd& ki,
+                                const Eigen::VectorXd& kd) {
   ConnectPorts(nullptr, kp, ki, kd);
 }
 
 template <typename T>
 PidController<T>::PidController(
-    std::unique_ptr<MatrixGain<T>> feedback_selector,
-    const VectorX<T>& kp, const VectorX<T>& ki, const VectorX<T>& kd) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const Eigen::VectorXd& kp,
+    const Eigen::VectorXd& ki, const Eigen::VectorXd& kd) {
   ConnectPorts(std::move(feedback_selector), kp, ki, kd);
 }
 
 template <typename T>
 void PidController<T>::ConnectPorts(
-    std::unique_ptr<MatrixGain<T>> feedback_selector,
-    const VectorX<T>& kp, const VectorX<T>& ki,
-    const VectorX<T>& kd) {
+    std::unique_ptr<MatrixGain<T>> feedback_selector, const Eigen::VectorXd& kp,
+    const Eigen::VectorXd& ki, const Eigen::VectorXd& kd) {
   DRAKE_DEMAND(kp.size() == kd.size());
   DRAKE_DEMAND(ki.size() == kd.size());
 
@@ -317,32 +306,32 @@ void PidController<T>::ConnectPorts(
 }
 
 template <typename T>
-const T& PidController<T>::get_Kp_singleton() const {
+double PidController<T>::get_Kp_singleton() const {
   return controller_->get_Kp_singleton();
 }
 
 template <typename T>
-const T& PidController<T>::get_Ki_singleton() const {
+double PidController<T>::get_Ki_singleton() const {
   return controller_->get_Ki_singleton();
 }
 
 template <typename T>
-const T& PidController<T>::get_Kd_singleton() const {
+double PidController<T>::get_Kd_singleton() const {
   return controller_->get_Kd_singleton();
 }
 
 template <typename T>
-const VectorX<T>& PidController<T>::get_Kp_vector() const {
+const Eigen::VectorXd& PidController<T>::get_Kp_vector() const {
   return controller_->get_Kp_vector();
 }
 
 template <typename T>
-const VectorX<T>& PidController<T>::get_Ki_vector() const {
+const Eigen::VectorXd& PidController<T>::get_Ki_vector() const {
   return controller_->get_Ki_vector();
 }
 
 template <typename T>
-const VectorX<T>& PidController<T>::get_Kd_vector() const {
+const Eigen::VectorXd& PidController<T>::get_Kd_vector() const {
   return controller_->get_Kd_vector();
 }
 
@@ -354,11 +343,6 @@ void PidController<T>::set_integral_value(
   // TODO(siyuanfeng): need to get rid of the - once we switch the integrator
   // to be int(q_d - q), right now it's (q - q_d).
   controller_->set_integral_value(integrator_context, -value);
-}
-
-template <typename T>
-bool PidController<T>::has_any_direct_feedthrough() const {
-  return !get_Kp_vector().isZero() || !get_Kd_vector().isZero();
 }
 
 // Adds a simple record-based representation of the PID controller to @p dot.

--- a/drake/systems/controllers/pid_controller.h
+++ b/drake/systems/controllers/pid_controller.h
@@ -43,8 +43,8 @@ class PidController : public StateFeedbackController<T> {
    * @param ki I gain.
    * @param kd D gain.
    */
-  PidController(
-      const VectorX<T>& kp, const VectorX<T>& ki, const VectorX<T>& kd);
+  PidController(const Eigen::VectorXd& kp, const Eigen::VectorXd& ki,
+                const Eigen::VectorXd& kd);
 
   /**
    * Constructs a PID controller where some of the input states may not be
@@ -59,43 +59,38 @@ class PidController : public StateFeedbackController<T> {
    * @param kd D gain.
    */
   PidController(std::unique_ptr<MatrixGain<T>> feedback_selector,
-      const VectorX<T>& kp, const VectorX<T>& ki, const VectorX<T>& kd);
+                const Eigen::VectorXd& kp, const Eigen::VectorXd& ki,
+                const Eigen::VectorXd& kd);
 
   /// Returns the proportional gain constant. This method should only be called
   /// if the proportional gain can be represented as a scalar value, i.e., every
   /// element in the proportional gain vector is the same. It will throw a
   /// `std::runtime_error` if the proportional gain cannot be represented as a
   /// scalar value.
-  const T& get_Kp_singleton() const;
+  double get_Kp_singleton() const;
 
   /// Returns the integral gain constant. This method should only be called if
   /// the integral gain can be represented as a scalar value, i.e., every
   /// element in the integral gain vector is the same. It will throw a
   /// `std::runtime_error` if the integral gain cannot be represented as a
   /// scalar value.
-  const T& get_Ki_singleton() const;
+  double get_Ki_singleton() const;
 
   /// Returns the derivative gain constant. This method should only be called if
   /// the derivative gain can be represented as a scalar value, i.e., every
   /// element in the derivative gain vector is the same. It will throw a
   /// `std::runtime_error` if the derivative gain cannot be represented as a
   /// scalar value.
-  const T& get_Kd_singleton() const;
+  double get_Kd_singleton() const;
 
   /// Returns the proportional vector constant.
-  const VectorX<T>& get_Kp_vector() const;
+  const Eigen::VectorXd& get_Kp_vector() const;
 
   /// Returns the integral vector constant.
-  const VectorX<T>& get_Ki_vector() const;
+  const Eigen::VectorXd& get_Ki_vector() const;
 
   /// Returns the derivative vector constant.
-  const VectorX<T>& get_Kd_vector() const;
-
-  // System<T> overrides
-  /// A PID controller directly feedthroughs the error signal to the output when
-  /// the proportional constant is non-zero. It feeds through the rate of change
-  /// of the error signal when the derivative constant is non-zero.
-  bool has_any_direct_feedthrough() const override;
+  const Eigen::VectorXd& get_Kd_vector() const;
 
   /// Sets the integral part of the PidController to @p value.
   /// @p value must be a column vector of the appropriate size.
@@ -116,8 +111,8 @@ class PidController : public StateFeedbackController<T> {
 
  private:
   void ConnectPorts(std::unique_ptr<MatrixGain<T>> feedback_selector,
-                    const VectorX<T>& kp, const VectorX<T>& ki,
-                    const VectorX<T>& kd);
+                    const Eigen::VectorXd& kp, const Eigen::VectorXd& ki,
+                    const Eigen::VectorXd& kd);
 
   // TODO(siyuanfeng): Need to redo the PID controller, then this would go away.
   PidControllerInternal<T>* controller_;

--- a/drake/systems/controllers/test/pid_controller_test.cc
+++ b/drake/systems/controllers/test/pid_controller_test.cc
@@ -148,6 +148,20 @@ TEST_F(PidControllerTest, CalcTimeDerivatives) {
   EXPECT_EQ(error_signal_, -derivatives_->CopyToVector());
 }
 
+TEST_F(PidControllerTest, DirectFeedthrough) {
+  // When the proportional or derivative gain is nonzero, there is direct
+  // feedthrough from both the state and error inputs to the output.
+  EXPECT_TRUE(controller_.HasAnyDirectFeedthrough());
+  EXPECT_TRUE(controller_.HasDirectFeedthrough(0, 0));
+  EXPECT_TRUE(controller_.HasDirectFeedthrough(1, 0));
+
+  // When the gains are all zero, there is no direct feedthrough from any
+  // input to any output.
+  const VectorX<double> zero{VectorX<double>::Zero(port_size_)};
+  PidController<double> zero_controller(zero, zero, zero);
+  EXPECT_FALSE(zero_controller.HasAnyDirectFeedthrough());
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -191,6 +191,12 @@ TEST_F(DiagramTest, Topology) {
   EXPECT_TRUE(diagram_->HasDirectFeedthrough(0));
   EXPECT_TRUE(diagram_->HasDirectFeedthrough(1));
   EXPECT_FALSE(diagram_->HasDirectFeedthrough(2));
+  // Specifically, outputs 0 and 1 have direct feedthrough from all inputs.
+  for (int i = 0; i < kSize; ++i) {
+    EXPECT_TRUE(diagram_->HasDirectFeedthrough(i, 0));
+    EXPECT_TRUE(diagram_->HasDirectFeedthrough(i, 1));
+    EXPECT_FALSE(diagram_->HasDirectFeedthrough(i, 2));
+  }
 }
 
 TEST_F(DiagramTest, Path) {
@@ -520,6 +526,21 @@ TEST_F(DiagramOfDiagramsTest, EvalOutput) {
   EXPECT_EQ(1249, output_->get_vector_data(0)->get_value().x());
   EXPECT_EQ(2489, output_->get_vector_data(1)->get_value().x());
   EXPECT_EQ(81, output_->get_vector_data(2)->get_value().x());
+}
+
+TEST_F(DiagramOfDiagramsTest, DirectFeedthrough) {
+  // The diagram has direct feedthrough.
+  EXPECT_TRUE(diagram_->HasAnyDirectFeedthrough());
+  // Specifically, outputs 0 and 1 have direct feedthrough, but not output 2.
+  EXPECT_TRUE(diagram_->HasDirectFeedthrough(0));
+  EXPECT_TRUE(diagram_->HasDirectFeedthrough(1));
+  EXPECT_FALSE(diagram_->HasDirectFeedthrough(2));
+  // Specifically, outputs 0 and 1 have direct feedthrough from all inputs.
+  for (int i = 0; i < kSize; ++i) {
+    EXPECT_TRUE(diagram_->HasDirectFeedthrough(i, 0));
+    EXPECT_TRUE(diagram_->HasDirectFeedthrough(i, 1));
+    EXPECT_FALSE(diagram_->HasDirectFeedthrough(i, 2));
+  }
 }
 
 // A Diagram that adds a constant to an input, and outputs the sum.

--- a/drake/systems/primitives/adder.cc
+++ b/drake/systems/primitives/adder.cc
@@ -48,9 +48,16 @@ Adder<AutoDiffXd>* Adder<T>::DoToAutoDiffXd() const {
                                this->get_input_port(0).size());
 }
 
+template <typename T>
+Adder<symbolic::Expression>* Adder<T>::DoToSymbolic() const {
+  return new Adder<symbolic::Expression>(this->get_num_input_ports(),
+                                         this->get_input_port(0).size());
+}
+
 // Explicitly instantiates on the most common scalar types.
 template class Adder<double>;
 template class Adder<AutoDiffXd>;
+template class Adder<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/primitives/adder.h
+++ b/drake/systems/primitives/adder.h
@@ -33,9 +33,6 @@ class Adder : public LeafSystem<T> {
   /// @param size number of elements in each input and output signal.
   Adder(int num_inputs, int size);
 
-  /// All inputs to this system are directly fed through to its output.
-  bool has_any_direct_feedthrough() const override { return true; }
-
   /// Returns the output port.
   const OutputPortDescriptor<T>& get_output_port() const;
 
@@ -52,6 +49,10 @@ class Adder : public LeafSystem<T> {
 
   // Returns an Adder<AutoDiffXd> with the same dimensions as this Adder.
   Adder<AutoDiffXd>* DoToAutoDiffXd() const override;
+
+  // System<T> override.  Returns an Adder<symbolic::Expression> with the
+  // same dimensions as this Adder.
+  Adder<symbolic::Expression>* DoToSymbolic() const override;
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -3,6 +3,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/symbolic_formula.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_context.h"
 
@@ -180,6 +181,12 @@ template <typename T>
 AffineSystem<AutoDiffXd>* AffineSystem<T>::DoToAutoDiffXd() const {
   return new AffineSystem<AutoDiffXd>(A_, B_, f0_, C_, D_, y0_,
                                       this->time_period());
+}
+
+template <typename T>
+AffineSystem<symbolic::Expression>* AffineSystem<T>::DoToSymbolic() const {
+  return new AffineSystem<symbolic::Expression>(A_, B_, f0_, C_, D_, y0_,
+                                                this->time_period());
 }
 
 template <typename T>

--- a/drake/systems/primitives/affine_system.h
+++ b/drake/systems/primitives/affine_system.h
@@ -139,10 +139,6 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
                const Eigen::Ref<const Eigen::VectorXd>& y0,
                double time_period = 0.0);
 
-  /// The input to this system is direct feedthrough only if the coefficient
-  /// matrix `D` is non-zero.
-  bool has_any_direct_feedthrough() const override { return !D_.isZero(0.0); }
-
   /// @name Helper getter methods.
   /// @{
   const Eigen::MatrixXd& A() const { return A_; }
@@ -177,6 +173,7 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
 
   // System<T> override.
   AffineSystem<AutoDiffXd>* DoToAutoDiffXd() const final;
+  AffineSystem<symbolic::Expression>* DoToSymbolic() const final;
 
   const Eigen::MatrixXd A_;
   const Eigen::MatrixXd B_;

--- a/drake/systems/primitives/demultiplexer.cc
+++ b/drake/systems/primitives/demultiplexer.cc
@@ -37,6 +37,13 @@ void Demultiplexer<T>::DoCalcOutput(const Context<T>& context,
   }
 }
 
+template <typename T>
+Demultiplexer<symbolic::Expression>* Demultiplexer<T>::DoToSymbolic() const {
+  const int size = this->get_input_port(0).size();
+  return new Demultiplexer<symbolic::Expression>(
+      size, size / this->get_num_output_ports());
+}
+
 template class Demultiplexer<double>;
 template class Demultiplexer<AutoDiffXd>;
 

--- a/drake/systems/primitives/demultiplexer.h
+++ b/drake/systems/primitives/demultiplexer.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/symbolic_expression.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -44,6 +45,10 @@ class Demultiplexer : public LeafSystem<T> {
   // port.
   void DoCalcOutput(const Context<T>& context,
                     SystemOutput<T>* output) const override;
+
+  // Returns a Demultiplexer<symbolic::Expression> with the same dimensions as
+  // this Demultiplexer.
+  Demultiplexer<symbolic::Expression>* DoToSymbolic() const override;
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/gain-inl.h
+++ b/drake/systems/primitives/gain-inl.h
@@ -17,14 +17,14 @@ namespace systems {
 // TODO(amcastro-tri): remove the size parameter from the constructor once
 // #3109 supporting automatic sizes is resolved.
 template <typename T>
-Gain<T>::Gain(const T& k, int size) : Gain(VectorX<T>::Ones(size) * k) {}
+Gain<T>::Gain(double k, int size) : Gain(Eigen::VectorXd::Ones(size) * k) {}
 
 template <typename T>
-Gain<T>::Gain(const VectorX<T>& k)
-    : SisoVectorSystem<T>(k.size(), k.size()), k_(k) { }
+Gain<T>::Gain(const Eigen::VectorXd& k)
+    : SisoVectorSystem<T>(k.size(), k.size()), k_(k) {}
 
 template <typename T>
-const T& Gain<T>::get_gain() const {
+double Gain<T>::get_gain() const {
   if (!k_.isConstant(k_[0])) {
     std::stringstream s;
     s << "The gain vector, [" << k_ << "], cannot be represented as a scalar "
@@ -35,7 +35,7 @@ const T& Gain<T>::get_gain() const {
 }
 
 template <typename T>
-const VectorX<T>& Gain<T>::get_gain_vector() const {
+const Eigen::VectorXd& Gain<T>::get_gain_vector() const {
   return k_;
 }
 
@@ -46,6 +46,11 @@ void Gain<T>::DoCalcVectorOutput(
     const Eigen::VectorBlock<const VectorX<T>>& state,
     Eigen::VectorBlock<VectorX<T>>* output) const {
   *output = k_.array() * input.array();
+}
+
+template <typename T>
+Gain<symbolic::Expression>* Gain<T>::DoToSymbolic() const {
+  return new Gain<symbolic::Expression>(k_);
 }
 
 }  // namespace systems

--- a/drake/systems/primitives/gain.cc
+++ b/drake/systems/primitives/gain.cc
@@ -9,6 +9,7 @@ namespace systems {
 
 template class Gain<double>;
 template class Gain<AutoDiffXd>;
+template class Gain<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/primitives/gain.h
+++ b/drake/systems/primitives/gain.h
@@ -36,23 +36,23 @@ class Gain : public SisoVectorSystem<T> {
   ///
   /// @param[in] k the gain constant so that `y = k * u`.
   /// @param[in] size number of elements in the signal to be processed.
-  Gain(const T& k, int size);
+  Gain(double k, int size);
 
   /// Constructs a %Gain system where different gains can be applied to each
   /// input value.
   ///
   /// @param[in] k the gain vector constants so that `y_i = k_i * u_i` where
   /// subscript `i` indicates the i-th element of the vector.
-  explicit Gain(const VectorX<T>& k);
+  explicit Gain(const Eigen::VectorXd& k);
 
   /// Returns the gain constant. This method should only be called if the gain
   /// can be represented as a scalar value, i.e., every element in the gain
   /// vector is the same. It will abort if the gain cannot be represented as a
   /// single scalar value.
-  const T& get_gain() const;
+  double get_gain() const;
 
   /// Returns the gain vector constant.
-  const VectorX<T>& get_gain_vector() const;
+  const Eigen::VectorXd& get_gain_vector() const;
 
  protected:
   void DoCalcVectorOutput(
@@ -61,8 +61,11 @@ class Gain : public SisoVectorSystem<T> {
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* output) const override;
 
-  // TODO(amcastro-tri): move gain_ to System<T>::Parameter.
-  const VectorX<T> k_;
+  // System<T> override.  Returns a Gain<symbolic::Expression> with the
+  // same dimensions as this Gain.
+  Gain<symbolic::Expression>* DoToSymbolic() const override;
+
+  const Eigen::VectorXd k_;
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/pass_through-inl.h
+++ b/drake/systems/primitives/pass_through-inl.h
@@ -24,5 +24,10 @@ void PassThrough<T>::DoCalcVectorOutput(
   *output = input;
 }
 
+template <typename T>
+PassThrough<symbolic::Expression>* PassThrough<T>::DoToSymbolic() const {
+  return new PassThrough<symbolic::Expression>(this->get_input_port().size());
+}
+
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/primitives/pass_through.cc
+++ b/drake/systems/primitives/pass_through.cc
@@ -9,6 +9,7 @@ namespace systems {
 
 template class PassThrough<double>;
 template class PassThrough<AutoDiffXd>;
+template class PassThrough<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/primitives/pass_through.h
+++ b/drake/systems/primitives/pass_through.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/symbolic_expression.h"
 #include "drake/systems/framework/siso_vector_system.h"
 
 namespace drake {
@@ -50,6 +51,10 @@ class PassThrough : public SisoVectorSystem<T> {
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* output) const override;
+
+  /// Returns an PassThrough<symbolic::Expression> with the same dimensions as
+  /// this PassThrough.
+  PassThrough<symbolic::Expression>* DoToSymbolic() const override;
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/test/adder_test.cc
+++ b/drake/systems/primitives/test/adder_test.cc
@@ -71,9 +71,12 @@ TEST_F(AdderTest, AdderIsStateless) {
   EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
-// Asserts that adders are systems with direct feedthrough inputs.
+// Asserts that adders have direct-feedthrough from all inputs to the output.
 TEST_F(AdderTest, AdderIsDirectFeedthrough) {
-  EXPECT_TRUE(adder_->has_any_direct_feedthrough());
+  EXPECT_TRUE(adder_->HasAnyDirectFeedthrough());
+  for (int i = 0; i < adder_->get_num_input_ports(); ++i) {
+    EXPECT_TRUE(adder_->HasDirectFeedthrough(i, 0));
+  }
 }
 
 }  // namespace

--- a/drake/systems/primitives/test/affine_system_test.cc
+++ b/drake/systems/primitives/test/affine_system_test.cc
@@ -134,7 +134,7 @@ class FeedthroughAffineSystemTest : public ::testing::Test {
 TEST_F(FeedthroughAffineSystemTest, NoFeedthroughTest) {
   SetDCornerElement(0.0);
   InitialiseSystem();
-  EXPECT_FALSE(dut_->has_any_direct_feedthrough());
+  EXPECT_FALSE(dut_->HasAnyDirectFeedthrough());
 }
 
 // Tests that the system renders as a direct feedthrough
@@ -142,7 +142,7 @@ TEST_F(FeedthroughAffineSystemTest, NoFeedthroughTest) {
 TEST_F(FeedthroughAffineSystemTest, FeedthroughTest) {
   SetDCornerElement(1e-12);
   InitialiseSystem();
-  EXPECT_TRUE(dut_->has_any_direct_feedthrough());
+  EXPECT_TRUE(dut_->HasAnyDirectFeedthrough());
 }
 
 // Tests the discrete-time update.

--- a/drake/systems/primitives/test/demultiplexer_test.cc
+++ b/drake/systems/primitives/test/demultiplexer_test.cc
@@ -110,6 +110,13 @@ TEST_F(DemultiplexerTest, DemultiplexerIsStateless) {
   EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
+TEST_F(DemultiplexerTest, DirectFeedthrough) {
+  EXPECT_TRUE(demux_->HasAnyDirectFeedthrough());
+  for (int i = 0; i < demux_->get_num_output_ports(); ++i) {
+    EXPECT_TRUE(demux_->HasDirectFeedthrough(0, i));
+  }
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/primitives/test/gain_scalartype_test.cc
@@ -92,7 +92,7 @@ class SymbolicGainTest : public ::testing::Test {
     input_ = make_unique<BasicVector<symbolic::Expression>>(3 /* length */);
   }
 
-  const symbolic::Expression kGain_{2.0};
+  double kGain_{2.0};
   unique_ptr<System<symbolic::Expression>> gain_;
   unique_ptr<Context<symbolic::Expression>> context_;
   unique_ptr<SystemOutput<symbolic::Expression>> output_;
@@ -121,9 +121,9 @@ TEST_F(SymbolicGainTest, VectorThroughGainSystem) {
   EXPECT_NE(nullptr, output_vector);
   Eigen::Matrix<symbolic::Expression, 3, 1> expected{kGain_ * input_vector};
   EXPECT_EQ(expected, output_vector->get_value());
-  EXPECT_EQ(expected(0).Evaluate(), kGain_.Evaluate() * 1.0);
-  EXPECT_EQ(expected(1).Evaluate(), kGain_.Evaluate() * 3.14);
-  EXPECT_EQ(expected(2).Evaluate(), kGain_.Evaluate() * 2.18);
+  EXPECT_EQ(expected(0).Evaluate(), kGain_ * 1.0);
+  EXPECT_EQ(expected(1).Evaluate(), kGain_ * 3.14);
+  EXPECT_EQ(expected(2).Evaluate(), kGain_ * 2.18);
 }
 }  // namespace
 }  // namespace systems

--- a/drake/systems/primitives/test/gain_test.cc
+++ b/drake/systems/primitives/test/gain_test.cc
@@ -84,6 +84,14 @@ GTEST_TEST(GainTest, GainVectorTest) {
   TestGainSystem(*gain_system, input_vector, expected_output);
 }
 
+GTEST_TEST(GainTest, DirectFeedthrough) {
+  const int kSize = 3;
+  const auto gain_system = make_unique<Gain<double>>(2.0, kSize);
+  EXPECT_TRUE(gain_system->HasAnyDirectFeedthrough());
+  const auto zero_gain = make_unique<Gain<double>>(0.0, kSize);
+  EXPECT_FALSE(zero_gain->HasAnyDirectFeedthrough());
+}
+
 GTEST_TEST(GainDeathTest, GainAccessorTest) {
   const Vector4<double> gain_values(1.0, 2.0, 3.0, 4.0);
   const auto gain_system = make_unique<Gain<double>>(gain_values);

--- a/drake/systems/primitives/test/pass_through_test.cc
+++ b/drake/systems/primitives/test/pass_through_test.cc
@@ -60,6 +60,10 @@ TEST_F(PassThroughTest, PassThroughIsStateless) {
   EXPECT_EQ(0, context_->get_continuous_state()->size());
 }
 
+TEST_F(PassThroughTest, DirectFeedthrough) {
+  EXPECT_TRUE(pass_through_->HasAnyDirectFeedthrough());
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Convert the class-member coefficient in the Gain block (and thus the PID diagram coefficients) from T to double, enabling symbolic conversion.

Remove all remaining uses of has_any_direct_feedthrough in drake/systems.

@siyuanfeng-tri for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5731)
<!-- Reviewable:end -->
