### PR TITLE
Remove RigidBodyPlant support from PoseAggregator.

### DIFF
--- a/drake/systems/rendering/BUILD
+++ b/drake/systems/rendering/BUILD
@@ -15,7 +15,6 @@ drake_cc_library(
         ":pose_vector",
         "//drake/common",
         "//drake/common:autodiff",
-        "//drake/multibody:rigid_body_tree",
         "//drake/systems/framework:leaf_system",
     ],
 )
@@ -69,10 +68,10 @@ drake_cc_library(
     srcs = ["drake_visualizer_client.cc"],
     hdrs = ["drake_visualizer_client.h"],
     deps = [
+        "@eigen//:eigen",
         "//drake/lcmtypes:viewer",
         "//drake/math:geometric_transform",
         "//drake/multibody/shapes",
-        "@eigen//:eigen",
     ],
 )
 

--- a/drake/systems/rendering/test/pose_aggregator_test.cc
+++ b/drake/systems/rendering/test/pose_aggregator_test.cc
@@ -10,9 +10,6 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/multibody/joints/fixed_joint.h"
-#include "drake/multibody/joints/revolute_joint.h"
-#include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/rendering/pose_bundle.h"
 #include "drake/systems/rendering/pose_vector.h"
 
@@ -25,7 +22,6 @@ namespace systems {
 namespace rendering {
 namespace {
 
-const int kNumRigidBodyPoses = 1;
 const int kNumBundlePoses = 2;
 const int kNumSinglePoses = 2;
 
@@ -36,29 +32,13 @@ class PoseAggregatorTest : public ::testing::Test {
     SquareTwistMatrix<double> I = SquareTwistMatrix<double>::Zero();
     I.block<3, 3>(3, 3, 3, 3) << Eigen::Matrix3d::Identity();
 
-    // Attach the link to the origin with a pin joint.
-    auto rb1 = std::make_unique<RigidBody<double>>();
-    rb1->set_model_name("robot");
-    rb1->set_name("link1");
-    rb1->set_model_instance_id(tree_.add_model_instance());
-    rb1->set_spatial_inertia(I);
-
-    rb1->add_joint(&tree_.world(),
-                   std::make_unique<RevoluteJoint>(
-                       "joint", Isometry3d::Identity(), axis_));
-
-    tree_.add_rigid_body(std::move(rb1));
-    tree_.compile();
-
-    // Allocate an input for the tree we just assembled.
-    aggregator_.AddRigidBodyPlantInput(tree_);
-    // Allocate another input for a PoseBundle.
+    // Allocate an input for a PoseBundle.
     aggregator_.AddBundleInput("bundle", kNumBundlePoses);
-    // Allocate a third and fourth input for a PoseVector and FrameVelocity.
+    // Allocate a second and third input for a PoseVector and FrameVelocity.
     const int kRandomModelInstanceId0 = 42;
     aggregator_.AddSinglePoseAndVelocityInput("single_xv",
                                               kRandomModelInstanceId0);
-    // Allocate a fifth input for a PoseVector, without velocity.
+    // Allocate a fourth input for a PoseVector, without velocity.
     const int kRandomModelInstanceId1 = 43;
     aggregator_.AddSingleInput("single_x", kRandomModelInstanceId1);
 
@@ -67,23 +47,13 @@ class PoseAggregatorTest : public ::testing::Test {
   }
 
   PoseAggregator<double> aggregator_;
-  RigidBodyTree<double> tree_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<SystemOutput<double>> output_;
-
-  // The axis of the single DoF in the RigidBodyTree.
-  const Vector3d axis_{Vector3d::UnitX()};
 };
 
-// Tests that PoseAggregator aggregates poses from a RigidBodyTree input, two
-// PoseVector inputs (one with velocity and one without), and a PoseBundle
-// input.
+// Tests that PoseAggregator aggregates poses fromtwo PoseVector inputs (one
+// with velocity and one without), and a PoseBundle input.
 TEST_F(PoseAggregatorTest, HeterogeneousAggregation) {
-  // Set the rigid body state input so that the revolute joint has position
-  // pi/2, which results in the link "link1" pointing in the +y direction.
-  auto rbt_input = BasicVector<double>::Make({M_PI, 0.0});
-  context_->FixInputPort(0, std::move(rbt_input));
-
   // Set some arbitrary translations in the PoseBundle input, and a velocity
   // for one of the poses.
   PoseBundle<double> generic_input(2);
@@ -101,72 +71,63 @@ TEST_F(PoseAggregatorTest, HeterogeneousAggregation) {
   generic_input.set_name(1, "Mycroft");
   generic_input.set_pose(1, Isometry3d(translation_1));
   generic_input.set_model_instance_id(1, kMycroftModelInstanceId);
-  context_->FixInputPort(1, AbstractValue::Make(generic_input));
+  context_->FixInputPort(0, AbstractValue::Make(generic_input));
 
   // Set an arbitrary translation in the first PoseVector input.
   auto pose_vec1 = std::make_unique<PoseVector<double>>();
   pose_vec1->set_translation(Eigen::Translation<double, 3>(0.5, 1.5, 2.5));
-  context_->FixInputPort(2, std::move(pose_vec1));
+  context_->FixInputPort(1, std::move(pose_vec1));
 
   // Set some numbers in the corresponding FrameVelocity input.
   auto frame_vel1 = std::make_unique<FrameVelocity<double>>();
   frame_vel1->get_mutable_value() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-  context_->FixInputPort(3, std::move(frame_vel1));
+  context_->FixInputPort(2, std::move(frame_vel1));
 
   // Set an arbitrary rotation in the second PoseVector input.
   auto pose_vec2 = std::make_unique<PoseVector<double>>();
   pose_vec2->set_rotation(Eigen::Quaternion<double>(0.5, 0.5, 0.5, 0.5));
-  context_->FixInputPort(4, std::move(pose_vec2));
+  context_->FixInputPort(3, std::move(pose_vec2));
 
   aggregator_.CalcOutput(*context_, output_.get());
 
   // Extract the output PoseBundle.
   const PoseBundle<double>& bundle =
       output_->get_data(0)->GetValueOrThrow<PoseBundle<double>>();
-  ASSERT_EQ(kNumBundlePoses + kNumRigidBodyPoses + kNumSinglePoses,
-            bundle.get_num_poses());
-
-  // Check that the rigid body poses, as determined by the kinematics,
-  // appear in the output.
-  EXPECT_EQ("robot::link1", bundle.get_name(0));
-  EXPECT_EQ(0, bundle.get_model_instance_id(0));
-  const Isometry3d& link1_pose = bundle.get_pose(0);
-  EXPECT_TRUE(CompareMatrices(Isometry3d(AngleAxisd(M_PI, axis_)).matrix(),
-                              link1_pose.matrix()));
+  ASSERT_EQ(kNumBundlePoses + kNumSinglePoses, bundle.get_num_poses());
 
   // Check that the PoseBundle poses and velocities are passed through to the
   // output.
-  EXPECT_EQ("bundle::Sherlock", bundle.get_name(1));
-  EXPECT_EQ(kSherlockModelInstanceId, bundle.get_model_instance_id(1));
-  const Isometry3d& generic_pose_0 = bundle.get_pose(1);
+  EXPECT_EQ("bundle::Sherlock", bundle.get_name(0));
+  EXPECT_EQ(kSherlockModelInstanceId, bundle.get_model_instance_id(0));
+  const Isometry3d& generic_pose_0 = bundle.get_pose(0);
   EXPECT_TRUE(CompareMatrices(Isometry3d(translation_0).matrix(),
                               generic_pose_0.matrix()));
   EXPECT_TRUE(CompareMatrices(sherlock_velocity.get_value(),
-                              bundle.get_velocity(1).get_value()));
+                              bundle.get_velocity(0).get_value()));
 
-  EXPECT_EQ("bundle::Mycroft", bundle.get_name(2));
-  EXPECT_EQ(kMycroftModelInstanceId, bundle.get_model_instance_id(2));
-  const Isometry3d& generic_pose_1 = bundle.get_pose(2);
+  EXPECT_EQ("bundle::Mycroft", bundle.get_name(1));
+  EXPECT_EQ(kMycroftModelInstanceId, bundle.get_model_instance_id(1));
+  const Isometry3d& generic_pose_1 = bundle.get_pose(1);
   EXPECT_TRUE(CompareMatrices(Isometry3d(translation_1).matrix(),
                               generic_pose_1.matrix()));
 
   // Check that the PoseVector pose with velocity is passed through to the
   // output.
-  EXPECT_EQ("single_xv", bundle.get_name(3));
-  EXPECT_EQ(42, bundle.get_model_instance_id(3));
-  const Isometry3d& xv_pose = bundle.get_pose(3);
+  EXPECT_EQ("single_xv", bundle.get_name(2));
+  EXPECT_EQ(42, bundle.get_model_instance_id(2));
+  const Isometry3d& xv_pose = bundle.get_pose(2);
   EXPECT_TRUE(CompareMatrices(
       Isometry3d(Eigen::Translation<double, 3>(0.5, 1.5, 2.5)).matrix(),
       xv_pose.matrix()));
   for (int i = 0; i < 6; ++i) {
-    EXPECT_EQ(1.0 + i, bundle.get_velocity(3)[i]);
+    EXPECT_EQ(1.0 + i, bundle.get_velocity(2)[i]);
   }
 
   // Check that the PoseVector pose without velocity is passed through to
   // the output.
-  EXPECT_EQ("single_x", bundle.get_name(4));
-  EXPECT_EQ(43, bundle.get_model_instance_id(4));
-  const Isometry3d& x_pose = bundle.get_pose(4);
+  EXPECT_EQ("single_x", bundle.get_name(3));
+  EXPECT_EQ(43, bundle.get_model_instance_id(3));
+  const Isometry3d& x_pose = bundle.get_pose(3);
   EXPECT_TRUE(CompareMatrices(
       Isometry3d(Eigen::Quaternion<double>(0.5, 0.5, 0.5, 0.5)).matrix(),
       x_pose.matrix()));


### PR DESCRIPTION
This feature was unused and bloating the build time for drake/automotive. If someone needs in in the future, git remembers, though I would recommend implementing it as a separate System that converts RBT state to PoseBundle.

@jwnimmer-tri for all review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5732)
<!-- Reviewable:end -->
