### PR TITLE
Integrator derivative stats

### DIFF
--- a/drake/systems/analysis/explicit_euler_integrator.h
+++ b/drake/systems/analysis/explicit_euler_integrator.h
@@ -68,8 +68,7 @@ void ExplicitEulerIntegrator<T>::DoStepOnceFixedSize(const T& dt) {
 
   // TODO(sherm1) This should be calculating into the cache so that
   // Publish() doesn't have to recalculate if it wants to output derivatives.
-  IntegratorBase<T>::get_system().CalcTimeDerivatives(
-      IntegratorBase<T>::get_context(), derivs_.get());
+  this->CalcTimeDerivatives(*context, derivs_.get());
 
   // Compute derivative and update configuration and velocity.
   // xc(t+h) = xc(t) + dt * xcdot(t, xc(t), u(t))

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -824,8 +824,7 @@ class IntegratorBase {
   void CalcTimeDerivatives(const Context<T>& context,
                            ContinuousState<T>* dxdt) {
     get_system().CalcTimeDerivatives(context, dxdt);
-    ++num_ode_evals_
-        ;
+    ++num_ode_evals_;
   }
 
   /**

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -449,9 +449,14 @@ class IntegratorBase {
   }
 
   /**
-   * Returns the number of ODE function evaluations since the last call to
-   * ResetStatistics() or Initialize().
-  */
+   * Returns the number of ODE function evaluations (calls to
+   * CalcTimeDerivatives()) since the last call to ResetStatistics() or
+   * Initialize(). This count includes *all* such calls including (1)
+   * those necessary to compute Jacobian matrices; (2) those used in rejected
+   * integrated steps (for, e.g., purposes of error control); (3) those used
+   * strictly for integrator error estimation; and (4) calls that exhibit little
+   * cost (due to results being cached).
+   */
   int64_t get_num_derivative_evaluations() const { return num_ode_evals_; }
 
   /**
@@ -819,7 +824,8 @@ class IntegratorBase {
   void CalcTimeDerivatives(const Context<T>& context,
                            ContinuousState<T>* dxdt) {
     get_system().CalcTimeDerivatives(context, dxdt);
-    num_ode_evals_++;
+    ++num_ode_evals_
+        ;
   }
 
   /**

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -444,8 +444,15 @@ class IntegratorBase {
     smallest_adapted_step_size_taken_ = nan();
     largest_step_size_taken_ = nan();
     num_steps_taken_ = 0;
+    num_ode_evals_ = 0;
     error_check_failures_ = 0;
   }
+
+  /**
+   * Returns the number of ODE function evaluations since the last call to
+   * ResetStatistics() or Initialize().
+  */
+  int64_t get_num_derivative_evaluations() const { return num_ode_evals_; }
 
   /**
    * Returns the number of failures to accept an integration step due to
@@ -806,6 +813,15 @@ class IntegratorBase {
    */
 
  protected:
+  /// Evaluates the derivative function (and updates call statistics).
+  /// Subclasses should call this function rather than calling
+  /// system.CalcTimeDerivatives() directly.
+  void CalcTimeDerivatives(const Context<T>& context,
+                           ContinuousState<T>* dxdt) {
+    get_system().CalcTimeDerivatives(context, dxdt);
+    num_ode_evals_++;
+  }
+
   /**
    * Sets the working ("in use") accuracy for this integrator. The working
    * accuracy may not be equivalent to the target accuracy when the latter is
@@ -1017,6 +1033,7 @@ class IntegratorBase {
   T largest_step_size_taken_{nan()};
   int64_t num_steps_taken_{0};
   int64_t error_check_failures_{0};
+  int64_t num_ode_evals_{0};
 
   // Applied as diagonal matrices to weight error estimates.
   Eigen::VectorXd qbar_weight_, z_weight_;

--- a/drake/systems/analysis/runge_kutta2_integrator.h
+++ b/drake/systems/analysis/runge_kutta2_integrator.h
@@ -64,8 +64,7 @@ void RungeKutta2Integrator<T>::DoStepOnceFixedSize(const T& dt) {
 
   // TODO(sherm1) This should be calculating into the cache so that
   // Publish() doesn't have to recalculate if it wants to output derivatives.
-  IntegratorBase<T>::get_system().CalcTimeDerivatives(
-      IntegratorBase<T>::get_context(), derivs0_.get());
+  this->CalcTimeDerivatives(*context, derivs0_.get());
 
   // First stage is an explicit Euler step:
   // xc(t+h) = xc(t) + dt * xcdot(t, xc(t), u(t))
@@ -75,8 +74,7 @@ void RungeKutta2Integrator<T>::DoStepOnceFixedSize(const T& dt) {
   IntegratorBase<T>::get_mutable_context()->set_time(t);
 
   // use derivative at t+dt
-  IntegratorBase<T>::get_system().CalcTimeDerivatives(
-      *IntegratorBase<T>::get_mutable_context(), derivs1_.get());
+  this->CalcTimeDerivatives(*context, derivs1_.get());
   const auto& xcdot1 = derivs1_->get_vector();
 
   // TODO(sherm1) Use better operators when available.

--- a/drake/systems/analysis/runge_kutta3_integrator-inl.h
+++ b/drake/systems/analysis/runge_kutta3_integrator-inl.h
@@ -58,9 +58,8 @@ std::pair<bool, T> RungeKutta3Integrator<T>::DoStepOnceAtMost(const T& max_dt) {
 
   // TODO(edrumwri): move derivative evaluation at t0 to the simulator where
   // it can be used for efficient guard function zero finding.
-  auto& system = this->get_system();
   auto& context = this->get_context();
-  system.CalcTimeDerivatives(context, derivs0_.get());
+  this->CalcTimeDerivatives(context, derivs0_.get());
 
   // Call the generic error controlled stepper unless error control is
   // disabled.
@@ -91,21 +90,20 @@ void RungeKutta3Integrator<T>::DoStepOnceFixedSize(const T& dt) {
   // Get the derivative at the current state (x0) and time (t0).
   const auto& xcdot0 = derivs0_->get_vector();
 
-  // Get the system and the context.
-  const auto& system = this->get_system();
+  // Get the context.
   auto& context = this->get_context();
 
   // Compute the first intermediate state and derivative (at t=0.5, x(0.5)).
   this->get_mutable_context()->set_time(ta + dt * 0.5);
   xc->PlusEqScaled(dt * 0.5, xcdot0);
-  system.CalcTimeDerivatives(context, derivs1_.get());
+  this->CalcTimeDerivatives(context, derivs1_.get());
   const auto& xcdot1 = derivs1_->get_vector();
 
   // Compute the second intermediate state and derivative (at t=1, x(1)).
   this->get_mutable_context()->set_time(tb);
   xc->SetFromVector(this->get_interval_start_state());
   xc->PlusEqScaled({{-dt, xcdot0}, {dt * 2, xcdot1}});
-  system.CalcTimeDerivatives(context, derivs2_.get());
+  this->CalcTimeDerivatives(context, derivs2_.get());
   const auto& xcdot2 = derivs2_->get_vector();
 
   // calculate the state at dt.

--- a/drake/systems/analysis/semi_explicit_euler_integrator.h
+++ b/drake/systems/analysis/semi_explicit_euler_integrator.h
@@ -127,7 +127,7 @@ void SemiExplicitEulerIntegrator<T>::DoStepOnceFixedSize(const T& dt) {
   // Calcuate the derivatives.
   // TODO(sherm1) This should be calculating into the cache so that
   // Publish() doesn't have to recalculate if it wants to output derivatives.
-  system.CalcTimeDerivatives(this->get_context(), derivs_.get());
+  this->CalcTimeDerivatives(this->get_context(), derivs_.get());
 
   // Retrieve the accelerations and auxiliary variable derivatives.
   const auto& vdot = derivs_->get_generalized_velocity();

--- a/drake/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -178,6 +178,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
   EXPECT_GE(integrator.get_largest_step_size_taken(), 0.0);
   EXPECT_GE(integrator.get_num_steps_taken(), 0);
   EXPECT_EQ(integrator.get_error_estimate(), nullptr);
+  EXPECT_GT(integrator.get_num_derivative_evaluations(), 0);
 }
 
 GTEST_TEST(IntegratorTest, StepSize) {

--- a/drake/systems/analysis/test/runge_kutta2_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta2_integrator_test.cc
@@ -117,6 +117,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
   EXPECT_GE(integrator.get_largest_step_size_taken(), 0.0);
   EXPECT_GE(integrator.get_num_steps_taken(), 0);
   EXPECT_EQ(integrator.get_error_estimate(), nullptr);
+  EXPECT_GT(integrator.get_num_derivative_evaluations(), 0);
 }
 
 }  // namespace

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -301,6 +301,7 @@ TEST_F(RK3IntegratorTest, SpringMassStepEC) {
   EXPECT_GE(integrator_->get_smallest_adapted_step_size_taken(), 0.0);
   EXPECT_GE(integrator_->get_num_steps_taken(), 0);
   EXPECT_NE(integrator_->get_error_estimate(), nullptr);
+  EXPECT_GT(integrator.get_num_derivative_evaluations(), 0);
 
   // Verify that less computation was performed compared to the fixed step
   // integrator.

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -301,7 +301,7 @@ TEST_F(RK3IntegratorTest, SpringMassStepEC) {
   EXPECT_GE(integrator_->get_smallest_adapted_step_size_taken(), 0.0);
   EXPECT_GE(integrator_->get_num_steps_taken(), 0);
   EXPECT_NE(integrator_->get_error_estimate(), nullptr);
-  EXPECT_GT(integrator.get_num_derivative_evaluations(), 0);
+  EXPECT_GT(integrator_->get_num_derivative_evaluations(), 0);
 
   // Verify that less computation was performed compared to the fixed step
   // integrator.

--- a/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -192,6 +192,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
   EXPECT_GT(integrator.get_largest_step_size_taken(), 0.0);
   EXPECT_GT(integrator.get_num_steps_taken(), 0);
   EXPECT_EQ(integrator.get_error_estimate(), nullptr);
+  EXPECT_GT(integrator.get_num_derivative_evaluations(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
This PR adds counting of ODE derivative calls to the integrator suite. This basic statistic allows comparing integrators in an apples-to-apples manner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5738)
<!-- Reviewable:end -->
