### PR TITLE
Ensures filename for visualizing road geometry does not contain spaces.

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/automotive_simulator.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "drake/automotive/gen/driving_command_translator.h"
@@ -230,11 +231,13 @@ const maliput::api::Lane* AutomotiveSimulator<T>::FindLane(
 
 template <typename T>
 void AutomotiveSimulator<T>::GenerateAndLoadRoadNetworkUrdf() {
+  std::string filename = road_->id().id;
+  std::transform(filename.begin(), filename.end(), filename.begin(),
+                 [](char ch) { return ch == ' ' ? '_' : ch; });
   maliput::utility::GenerateUrdfFile(road_.get(),
-                                     "/tmp", road_->id().id,
+                                     "/tmp", filename,
                                      maliput::utility::ObjFeatures());
-  const std::string urdf_filepath =
-      std::string("/tmp/") + road_->id().id + ".urdf";
+  const std::string urdf_filepath = "/tmp/" + filename + ".urdf";
   parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
       urdf_filepath,
       drake::multibody::joints::kFixed,


### PR DESCRIPTION
This was necessary for compatibility with `drake-visualizer`. The name is used to save the .obj/.mtl files, which cannot be opened by `drake-visualizer` when they contain spaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5741)
<!-- Reviewable:end -->
