### PR TITLE
Removed the superfluous l-value generator

### DIFF
--- a/drake/common/test/type_safe_index_test.cc
+++ b/drake/common/test/type_safe_index_test.cc
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/drake/common/test/type_safe_index_test.cc
+++ b/drake/common/test/type_safe_index_test.cc
@@ -203,14 +203,9 @@ GTEST_TEST(TypeSafeIndex, ValueAssignment) {
 //    <     |   less_than
 //    +     |   add
 
-// This class provides the compiler with an l-value to trigger compilation on.
-template <class T>
-struct GenerateLValue { T& get_thing(); };
-
 #define BINARY_TEST(OP, OP_NAME) \
 template <typename T, typename U, \
-    typename = decltype(GenerateLValue<T>().get_thing() OP \
-                        GenerateLValue<U>().get_thing())> \
+    typename = decltype(std::declval<T>() OP std::declval<U>())> \
 bool has_ ## OP_NAME ## _helper(int) { return true; } \
 template <typename T, typename U> \
 bool has_ ## OP_NAME ## _helper(...) { return false; } \
@@ -262,7 +257,7 @@ BINARY_TEST(=, Assignment)
 
 // This tests that one index cannot be *constructed* from another index type,
 // but can be constructed from int types.
-template <typename T, typename U, typename = decltype(T(U(1)))>
+template <typename T, typename U, typename = decltype(T(U()))>
 bool has_construct_helper(int) { return true; }
 template <typename T, typename U>
 bool has_construct_helper(...) { return false; }

--- a/drake/geometry/test/identifier_test.cc
+++ b/drake/geometry/test/identifier_test.cc
@@ -3,8 +3,9 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 namespace drake {
 namespace geometry {

--- a/drake/geometry/test/identifier_test.cc
+++ b/drake/geometry/test/identifier_test.cc
@@ -115,10 +115,6 @@ TEST_F(IdentifierTests, StreamOperator) {
 
 // These tests confirm that behavior that *shouldn't* be compilable isn't.
 
-// This class provides the compiler with an l-value to trigger compilation on.
-template <class T>
-struct GenerateLValue { T& get_thing(); };
-
 // This code allows us to turn compile-time errors into run-time errors that
 // we can incorporate in a unit test.  The macro simplifies the boilerplate.
 // This macro confirms binary operations are *valid* between two ids of
@@ -138,8 +134,7 @@ struct GenerateLValue { T& get_thing(); };
 //    +     |   add
 #define BINARY_TEST(OP, OP_NAME) \
 template <typename T, typename U, \
-    typename = decltype(GenerateLValue<T>().get_thing() OP \
-                        GenerateLValue<U>().get_thing())> \
+    typename = decltype(std::declval<T>() OP std::declval<U>())> \
 bool has_ ## OP_NAME ## _helper(int) { return true; } \
 template <typename T, typename U> \
 bool has_ ## OP_NAME ## _helper(...) { return false; } \

--- a/drake/multibody/multibody_tree/test/unit_inertia_tests.cc
+++ b/drake/multibody/multibody_tree/test/unit_inertia_tests.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/multibody_tree/unit_inertia.h"
 
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_autodiff_types.h"

--- a/drake/multibody/multibody_tree/test/unit_inertia_tests.cc
+++ b/drake/multibody/multibody_tree/test/unit_inertia_tests.cc
@@ -299,14 +299,10 @@ GTEST_TEST(UnitInertia, AutoDiff) {
 // instantiated and invoked. Otherwise, only the passing version will be
 // instantiated. There is a variation of this block of code for each disallowed
 // operator.
-//
-// This template generates an l-value at compile time for the templates below.
-template <class T>
-struct GenerateLValue { T& get_thing(); };
 
 // This overload gets chosen if the *= double would compile.
 template <typename T,
-    typename = decltype(GenerateLValue<T>().get_thing() *= 1.)>
+    typename = decltype(std::declval<T&>() *= 1.)>
 bool has_times_equal_helper(int) { return true; }
 
 // This overload gets chosen if the above can't compile.
@@ -333,7 +329,7 @@ GTEST_TEST(UnitInertia, TimesEqualScalar) {
 // See the explanation for these template helpers in the analogous
 // implementation for has_times_equal() above.
 template <typename T,
-    typename = decltype(GenerateLValue<T>().get_thing() /= 1.)>
+    typename = decltype(std::declval<T&>() /= 1.)>
 bool has_divide_equal_helper(int) { return true; }
 template <typename T>
 bool has_divide_equal_helper(...) { return false; }
@@ -353,7 +349,7 @@ GTEST_TEST(UnitInertia, DivideEqualScalar) {
 // See the explanation for this template helpers in the analogous implementation
 // for has_times_equal() above.
 template <typename T,
-    typename = decltype(GenerateLValue<T>().get_thing() += T())>
+    typename = decltype(std::declval<T&>() += T())>
 bool has_plus_equal_helper(int) { return true; }
 template <typename T>
 bool has_plus_equal_helper(...) { return false; }


### PR DESCRIPTION
In solving another SFINAE problem, I realized that these tests are overly complex in their structure. We've introduced the `GenerateLValue` struct that isn't actually necessary; `std::declval` provides all the functionality we need.

1) In two cases (index and identifier tests) r-values are fine (`declval<T>()` has type `T&&`).
2) In the inertia tests, we do require l-values, becase we're doing in-place operations (e.g., `*=`). However, `declval<T&>()` has type `T& &&` which collapses to `T&`.  In short, the rvalue reference of an lvalue reference *is* an lvalue reference.  

So, we simplify the voodoo using fewer arbitrary constructs and rely more directly on built-in C++ functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5749)
<!-- Reviewable:end -->
