### PR TITLE
Adds FrameVelocity output to MaliputRailcar.

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -174,6 +174,7 @@ drake_cc_library(
         ":lane_direction",
         "//drake/automotive/maliput/api",
         "//drake/math:geometric_transform",
+        "//drake/systems/rendering:frame_velocity",
         "//drake/systems/rendering:pose_vector",
     ],
 )

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -15,6 +15,7 @@
 #include "drake/common/cond.h"
 #include "drake/common/drake_assert.h"
 #include "drake/math/roll_pitch_yaw_using_quaternion.h"
+#include "drake/multibody/multibody_tree/math/spatial_velocity.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/value.h"
 #include "drake/systems/framework/vector_base.h"
@@ -27,6 +28,7 @@ using maliput::api::Lane;
 using maliput::api::LaneEnd;
 using maliput::api::LanePosition;
 using maliput::api::Rotation;
+using math::RollPitchYawToQuaternion;
 using systems::BasicVector;
 using systems::Context;
 using systems::ContinuousState;
@@ -38,6 +40,7 @@ using systems::SparsityMatrix;
 using systems::State;
 using systems::SystemOutput;
 using systems::VectorBase;
+using systems::rendering::FrameVelocity;
 using systems::rendering::PoseVector;
 
 namespace automotive {
@@ -59,6 +62,8 @@ MaliputRailcar<T>::MaliputRailcar(const LaneDirection& initial_lane_direction)
           systems::Value<LaneDirection>(initial_lane_direction)).get_index();
   pose_output_port_index_ =
       this->DeclareVectorOutputPort(PoseVector<T>()).get_index();
+  velocity_output_port_index_ =
+      this->DeclareVectorOutputPort(FrameVelocity<T>()).get_index();
   this->DeclareContinuousState(MaliputRailcarState<T>());
   this->DeclareNumericParameter(MaliputRailcarParams<T>());
 }
@@ -81,6 +86,11 @@ const OutputPortDescriptor<T>& MaliputRailcar<T>::lane_state_output() const {
 template <typename T>
 const OutputPortDescriptor<T>& MaliputRailcar<T>::pose_output() const {
   return this->get_output_port(pose_output_port_index_);
+}
+
+template <typename T>
+const OutputPortDescriptor<T>& MaliputRailcar<T>::velocity_output() const {
+  return this->get_output_port(velocity_output_port_index_);
 }
 
 template <typename T>
@@ -116,6 +126,12 @@ void MaliputRailcar<T>::DoCalcOutput(const Context<T>& context,
           output->GetMutableVectorData(pose_output_port_index_));
   DRAKE_ASSERT(pose_vector != nullptr);
   ImplCalcPose(params, *state, lane_direction, pose_vector);
+
+  FrameVelocity<T>* const frame_velocity =
+      dynamic_cast<FrameVelocity<T>*>(
+          output->GetMutableVectorData(velocity_output_port_index_));
+  DRAKE_ASSERT(frame_velocity != nullptr);
+  ImplCalcVelocity(params, *state, lane_direction, frame_velocity);
 }
 
 template <typename T>
@@ -170,9 +186,37 @@ void MaliputRailcar<T>::ImplCalcPose(const MaliputRailcarParams<T>& params,
                    atan2(-sin(rotation.yaw), -cos(rotation.yaw))));
   pose->set_translation(
       Eigen::Translation<T, 3>(geo_position.x, geo_position.y, geo_position.z));
-  pose->set_rotation(math::RollPitchYawToQuaternion(
+  pose->set_rotation(RollPitchYawToQuaternion(
       Vector3<T>(adjusted_rotation.roll, adjusted_rotation.pitch,
                  adjusted_rotation.yaw)));
+}
+
+template <typename T>
+void MaliputRailcar<T>::ImplCalcVelocity(const MaliputRailcarParams<T>& params,
+    const MaliputRailcarState<T>& state, const LaneDirection& lane_direction,
+    FrameVelocity<T>* frame_velocity) const {
+
+  // In the following code:
+  //  - v is the translational component of the spatial velocity.
+  //  - C is the car's frame.
+  //  - L is the lane frame.
+  //  - W is the world frame.
+  //  - R is a rotation matrix.
+
+  const Vector3<T> v_LC_L(lane_direction.with_s ? state.speed() :
+                                                  -state.speed(),
+                          0 /* r_dot */, 0 /* h_dot */);
+  const Rotation rotation =
+      lane_direction.lane->GetOrientation(
+          LanePosition(state.s(), params.r(), params.h()));
+  const Quaternion<T> q = RollPitchYawToQuaternion(
+      Vector3<T>(rotation.roll, rotation.pitch, rotation.yaw));
+  const Eigen::Matrix<T, 3, 3> R_WL = q.matrix();
+  const Vector3<T> v_WC_W = R_WL * v_LC_L;
+
+  // TODO(liang.fok) Add support for non-zero rotational velocity. See #5751.
+  const Vector3<T> w(T(0), T(0), T(0));
+  frame_velocity->set_velocity(multibody::SpatialVelocity<T>(w, v_WC_W));
 }
 
 template <typename T>

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/sparsity_matrix.h"
+#include "drake/systems/rendering/frame_velocity.h"
 #include "drake/systems/rendering/pose_vector.h"
 
 namespace drake {
@@ -43,6 +44,10 @@ namespace automotive {
 ///
 ///   - pose_output(): Contains PoseVector `X_WC`, where `C` is the car frame
 ///     and `W` is the world frame.
+///
+///   - velocity_output(): Contains FrameVelocity `V_WC_W`, where `C` is the car
+///     frame and `W` is the world frame. Currently the rotational component is
+///     always zero, see #5751.
 ///
 /// @tparam T must support certain arithmetic operations;
 /// for details, see drake::symbolic::Expression.
@@ -107,6 +112,7 @@ class MaliputRailcar : public systems::LeafSystem<T> {
   const systems::OutputPortDescriptor<T>& state_output() const;
   const systems::OutputPortDescriptor<T>& lane_state_output() const;
   const systems::OutputPortDescriptor<T>& pose_output() const;
+  const systems::OutputPortDescriptor<T>& velocity_output() const;
   /// @}
 
   static constexpr T kDefaultInitialS = T(0);
@@ -138,6 +144,12 @@ class MaliputRailcar : public systems::LeafSystem<T> {
       const LaneDirection& lane_direction,
       systems::rendering::PoseVector<T>* pose) const;
 
+  void ImplCalcVelocity(
+      const MaliputRailcarParams<T>& params,
+      const MaliputRailcarState<T>& state,
+      const LaneDirection& lane_direction,
+      systems::rendering::FrameVelocity<T>* pose) const;
+
   void ImplCalcTimeDerivatives(
       const MaliputRailcarParams<T>& params,
       const MaliputRailcarState<T>& state,
@@ -160,6 +172,7 @@ class MaliputRailcar : public systems::LeafSystem<T> {
   int state_output_port_index_{};
   int lane_state_output_port_index_{};
   int pose_output_port_index_{};
+  int velocity_output_port_index_{};
 };
 
 }  // namespace automotive

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -16,6 +16,7 @@
 #include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/math/roll_pitch_yaw_not_using_quaternion.h"
+#include "drake/multibody/multibody_tree/math/spatial_velocity.h"
 #include "drake/systems/framework/leaf_context.h"
 #include "drake/systems/framework/system.h"
 
@@ -28,9 +29,12 @@ using maliput::monolane::Endpoint;
 using maliput::monolane::EndpointXy;
 using maliput::monolane::EndpointZ;
 
+using multibody::SpatialVelocity;
+
 using systems::BasicVector;
 using systems::LeafContext;
 using systems::Parameters;
+using systems::rendering::FrameVelocity;
 using systems::rendering::PoseVector;
 
 namespace automotive {
@@ -205,6 +209,13 @@ class MaliputRailcarTest : public ::testing::Test {
     return pose;
   }
 
+  const FrameVelocity<double>* velocity_output() const {
+    auto frame_velocity = dynamic_cast<const FrameVelocity<double>*>(
+        output_->get_vector_data(dut_->velocity_output().get_index()));
+    DRAKE_DEMAND(frame_velocity != nullptr);
+    return frame_velocity;
+  }
+
   // Sets the configuration parameters of the railcar.
   void SetParams(const MaliputRailcarParams<double>& params) {
     LeafContext<double>* leaf_context =
@@ -283,6 +294,8 @@ class MaliputRailcarTest : public ::testing::Test {
 
     dut_->CalcOutput(*context_, output_.get());
     std::unique_ptr<BasicVector<double>> prior_pose = pose_output()->Clone();
+    std::unique_ptr<BasicVector<double>> prior_velocity =
+        velocity_output()->Clone();
 
     systems::DiscreteEvent<double> event;
     event.action = systems::DiscreteEvent<double>::kUnrestrictedUpdateAction;
@@ -315,12 +328,18 @@ class MaliputRailcarTest : public ::testing::Test {
     }
     EXPECT_DOUBLE_EQ(railcar_derivatives->speed(), 0);
 
-    // Verifies the vehicle's pose did not change even after switching lanes.
+    // Verifies the vehicle's pose and velocity did not change even after
+    // switching lanes.
     dut_->CalcOutput(*context_, output_.get());
     const PoseVector<double>* post_pose = pose_output();
-    // The following tolerance was empirically determined.
+    const FrameVelocity<double>* post_velocity = velocity_output();
+    // The following tolerances were empirically determined.
     EXPECT_TRUE(CompareMatrices(prior_pose->get_value(),
-                                post_pose->get_value(), 1e-14 /* tolerance */));
+                                post_pose->get_value(),
+                                1e-14 /* tolerance */));
+    EXPECT_TRUE(CompareMatrices(prior_velocity->get_value(),
+                                post_velocity->get_value(),
+                                1e-14 /* tolerance */));
   }
 
   // The length of the straight lane segment of the road when it is created
@@ -343,7 +362,7 @@ TEST_F(MaliputRailcarTest, Topology) {
   EXPECT_NO_FATAL_FAILURE(InitializeDragwayLane());
   ASSERT_EQ(dut_->get_num_input_ports(), 1);
 
-  ASSERT_EQ(dut_->get_num_output_ports(), 3);
+  ASSERT_EQ(dut_->get_num_output_ports(), 4);
   const auto& state_output = dut_->state_output();
   EXPECT_EQ(systems::kVectorValued, state_output.get_data_type());
   EXPECT_EQ(MaliputRailcarStateIndices::kNumCoordinates, state_output.size());
@@ -351,6 +370,10 @@ TEST_F(MaliputRailcarTest, Topology) {
   const auto& pose_output = dut_->pose_output();
   EXPECT_EQ(systems::kVectorValued, pose_output.get_data_type());
   EXPECT_EQ(PoseVector<double>::kSize, pose_output.size());
+
+  const auto& velocity_output = dut_->velocity_output();
+  EXPECT_EQ(systems::kVectorValued, velocity_output.get_data_type());
+  EXPECT_EQ(FrameVelocity<double>::kSize, velocity_output.size());
 
   EXPECT_FALSE(dut_->HasAnyDirectFeedthrough());
 }
@@ -368,6 +391,9 @@ TEST_F(MaliputRailcarTest, ZeroInitialOutput) {
   EXPECT_EQ(translation.x(), 0);
   EXPECT_EQ(translation.y(), 0);
   EXPECT_EQ(translation.z(), 0);
+  auto velocity = velocity_output();
+  EXPECT_TRUE(CompareMatrices(velocity->get_value(),
+      (Vector6<double>() << 0, 0, 0, state->speed(), 0, 0).finished()));
 }
 
 TEST_F(MaliputRailcarTest, StateAppearsInOutputDragway) {
@@ -391,6 +417,12 @@ TEST_F(MaliputRailcarTest, StateAppearsInOutputDragway) {
   expected_pose.translation() = Eigen::Vector3d(kS, 0, 0);
   EXPECT_TRUE(CompareMatrices(pose->get_isometry().matrix(),
                               expected_pose.matrix()));
+
+  auto velocity = velocity_output();
+  const Vector6<double> expected_velocity =
+      (Vector6<double>() << 0, 0, 0, kSpeed, 0, 0).finished();
+  EXPECT_TRUE(CompareMatrices(velocity->get_value(),
+                              expected_velocity));
 }
 
 TEST_F(MaliputRailcarTest, StateAppearsInOutputMonolane) {
@@ -417,6 +449,38 @@ TEST_F(MaliputRailcarTest, StateAppearsInOutputMonolane) {
   // The following tolerance was determined emperically.
   EXPECT_TRUE(CompareMatrices(pose->get_isometry().matrix(),
                               expected_pose.matrix(), 1e-15 /* tolerance */));
+
+  auto velocity = velocity_output();
+  Vector6<double> expected_velocity;
+  expected_velocity << 0, 0, 0, 0, kSpeed, 0;
+  // The following tolerance was determined emperically.
+  EXPECT_TRUE(CompareMatrices(velocity->get_value(),
+                              expected_velocity, 1e-15 /* tolerance */));
+
+  // Position the vehicle half way down the s-curve of the lane and verify that
+  // the pose and velocity outputs are as expected. At this position, the
+  // vehicle has a yaw of 45 degrees and is on a circle with radius
+  // kCurvedRoadRadius that is centered at (kCurvedRoadRadius, 0, 0). The
+  // tolerance values were emperically determined.
+  continuous_state()->set_s(lane->length() / 2);
+  dut_->CalcOutput(*context_, output_.get());
+  pose = pose_output();
+  {
+    const double expected_x = kCurvedRoadRadius * std::sin(45. / 180. * M_PI);
+    const double expected_y = kCurvedRoadRadius -
+        kCurvedRoadRadius * std::cos(45. / 180. * M_PI);
+    const Eigen::Vector3d rpy(0, 0, M_PI_4);
+    const Eigen::Vector3d xyz(expected_x, expected_y, 0 /* expected z */);
+    expected_pose.matrix() << drake::math::rpy2rotmat(rpy), xyz, 0, 0, 0, 1;
+  }
+  EXPECT_TRUE(CompareMatrices(pose->get_isometry().matrix(),
+                              expected_pose.matrix(), 1e-15 /* tolerance */));
+
+  velocity = velocity_output();
+  expected_velocity
+      << 0, 0, 0, kSpeed * std::cos(M_PI_4), kSpeed * std::sin(M_PI_4), 0;
+  EXPECT_TRUE(CompareMatrices(velocity->get_value(),
+                              expected_velocity, 1e-15 /* tolerance */));
 }
 
 TEST_F(MaliputRailcarTest, NonZeroParametersAppearInOutputDragway) {
@@ -635,6 +699,13 @@ TEST_F(MaliputRailcarTest, DecreasingSDragway) {
   // The following tolerance was determined empirically.
   EXPECT_TRUE(CompareMatrices(
       pose->get_value(), expected_pose.get_value(), 1e-15 /* tolerance */));
+  const FrameVelocity<double>* frame_velocity = velocity_output();
+  const multibody::SpatialVelocity<double> spatial_velocity =
+      frame_velocity->get_velocity();
+  EXPECT_TRUE(CompareMatrices(spatial_velocity.translational(),
+      Eigen::Vector3d(-MaliputRailcar<double>::kDefaultInitialSpeed, 0, 0)));
+  EXPECT_TRUE(CompareMatrices(spatial_velocity.rotational(),
+                              Eigen::Vector3d(0, 0, 0)));
 }
 
 TEST_F(MaliputRailcarTest, DecreasingSMonolane) {
@@ -651,25 +722,32 @@ TEST_F(MaliputRailcarTest, DecreasingSMonolane) {
   continuous_state()->set_s(kS);
   continuous_state()->set_speed(kInitialSpeed);
 
-  // Obtains the against-s pose.
   dut_->CalcOutput(*context_, output_.get());
+
+  // Obtains the against-s pose and spatial velocity.
   const PoseVector<double>* against_s_pose = pose_output();
   Eigen::Translation<double, 3> against_s_translation =
       against_s_pose->get_translation();
   Eigen::Quaternion<double> against_s_orientation =
       against_s_pose->get_rotation();
 
-  // Obtains the with-s pose.
+  const SpatialVelocity<double> against_s_spatial_velocity =
+      velocity_output()->get_velocity();
+
   EXPECT_NO_FATAL_FAILURE(InitializeSlopedCurvedMonoLane(true /* with_s */));
   SetParams(params);
   continuous_state()->set_s(kS);
   continuous_state()->set_speed(kInitialSpeed);
   dut_->CalcOutput(*context_, output_.get());
-  const PoseVector<double>* with_s_pose = pose_output();
 
+  // Obtains the with-s pose and spatial velocity.
+  const PoseVector<double>* with_s_pose = pose_output();
   Eigen::Translation<double, 3> with_s_translation =
       with_s_pose->get_translation();
   Eigen::Quaternion<double> with_s_orientation = with_s_pose->get_rotation();
+
+  const SpatialVelocity<double> with_s_spatial_velocity =
+      velocity_output()->get_velocity();
 
   // Verifies that the with-s and against-s translations are equal.
   EXPECT_TRUE(with_s_translation.isApprox(against_s_translation));
@@ -679,6 +757,18 @@ TEST_F(MaliputRailcarTest, DecreasingSMonolane) {
   // quaternions is equal to zero. The following tolerance was empirically
   // determined.
   EXPECT_NEAR(with_s_orientation.dot(against_s_orientation), 0, 1e-15);
+
+  // Verifies that the with-s and against-s translational velocities negate
+  // each other.
+  EXPECT_TRUE(CompareMatrices(against_s_spatial_velocity.translational() +
+      with_s_spatial_velocity.translational(), Eigen::Vector3d::Zero()));
+
+  // Verifies that the with-s and against-s rotational velocities are zero.
+  // This will change once #5751 is resolved.
+  EXPECT_TRUE(CompareMatrices(against_s_spatial_velocity.rotational(),
+                              Eigen::Vector3d::Zero()));
+  EXPECT_TRUE(CompareMatrices(with_s_spatial_velocity.rotational(),
+                              Eigen::Vector3d::Zero()));
 }
 
 // Tests the correctness of MaliputRailcar::DoCalcNextUpdateTime() when the


### PR DESCRIPTION
This is an incremental step towards supporting an IDM-controlled `MaliputRailcar`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5755)
<!-- Reviewable:end -->
