### PR TITLE
add test coverage for autodiff deriv sizes

### DIFF
--- a/drake/solvers/test/optimization_examples.h
+++ b/drake/solvers/test/optimization_examples.h
@@ -324,6 +324,10 @@ class LowerBoundedProblem {
     }
     void DoEval(const Eigen::Ref<const TaylorVecXd>& x,
                 TaylorVecXd& y) const override {
+      // Check that the autodiff vector was initialized to the proper (minimal)
+      // size.
+      EXPECT_EQ(x.size(), x(0).derivatives().size());
+
       EvalImpl(x, y);
     }
 


### PR DESCRIPTION
following discussion in #5666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5760)
<!-- Reviewable:end -->
