### PR TITLE
Fixes #5745 ("Request to remove lane length restriction in DrawLaneArrow").

### DIFF
--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -517,6 +517,11 @@ void DrawLaneArrow(GeoMesh* mesh, const api::Lane* lane, double grid_unit,
 // @param h_offset  h value of each vertex (height above road surface)
 void MarkLaneEnds(GeoMesh* mesh, const api::Lane* lane, double grid_unit,
                   double h_offset) {
+  // To avoid crossing boundaries (and tripping assertions) due to
+  // numeric precision issues, we will nudge the arrows inward from
+  // the ends of the lanes by the RoadGeometry's linear_tolerance().
+  const double nudge =
+      lane->segment()->junction()->road_geometry()->linear_tolerance();
   const double max_length = 0.3 * lane->length();
   // Arrows are sized relative to their respective ends.
   const api::RBounds start_rb = lane->lane_bounds(0.);
@@ -527,9 +532,11 @@ void MarkLaneEnds(GeoMesh* mesh, const api::Lane* lane, double grid_unit,
   const double finish_s_size = std::min(max_length,
                                         (finish_rb.r_max - finish_rb.r_min));
 
-  DrawLaneArrow(mesh, lane, grid_unit, 0., start_s_size, h_offset);
   DrawLaneArrow(mesh, lane, grid_unit,
-                lane->length() - finish_s_size, finish_s_size, h_offset);
+                0. + nudge, start_s_size, h_offset);
+  DrawLaneArrow(mesh, lane, grid_unit,
+                lane->length() - finish_s_size - nudge, finish_s_size,
+                h_offset);
 }
 
 

--- a/drake/automotive/maliput/utility/test/generate_urdf_test.cc
+++ b/drake/automotive/maliput/utility/test/generate_urdf_test.cc
@@ -6,13 +6,8 @@
 #include <gtest/gtest.h>
 #include "spruce.hh"
 
-#include "drake/automotive/maliput/monolane/arc_lane.h"
 #include "drake/automotive/maliput/monolane/builder.h"
-#include "drake/automotive/maliput/monolane/junction.h"
-#include "drake/automotive/maliput/monolane/lane.h"
-#include "drake/automotive/maliput/monolane/line_lane.h"
-#include "drake/automotive/maliput/monolane/road_geometry.h"
-#include "drake/automotive/maliput/monolane/segment.h"
+#include "drake/automotive/maliput/monolane/loader.h"
 
 namespace drake {
 namespace maliput {
@@ -106,6 +101,58 @@ TEST_F(GenerateUrdfTest, AtLeastRunIt) {
   </link>
 </robot>
 )R", actual_urdf_contents);
+
+  // spruce is retarded: it has no functionality for reading/walking a
+  // directory, so we have to delete all our files individually here where
+  // we know the names.
+  EXPECT_TRUE(spruce::file::remove(expected_urdf));
+  EXPECT_TRUE(spruce::file::remove(expected_obj));
+  EXPECT_TRUE(spruce::file::remove(expected_mtl));
+}
+
+
+// Oblique regression test for tripping of an assertion in DrawLaneArrow()
+// during GenerateObj().  See #5745.
+TEST_F(GenerateUrdfTest, DontTickleDrawLaneArrowAssert) {
+  std::string dut_yaml = R"R(# -*- yaml -*-
+---
+# distances are meters; angles are degrees.
+maliput_monolane_builder:
+  id: city_1
+  lane_bounds: [-2, 2]
+  driveable_bounds: [-4, 4]
+  position_precision: 0.01
+  orientation_precision: 0.5
+  points:
+    street_9_1_3:
+      xypoint: [92.92893218813452, 307.0710678118655, -45.0]
+      zpoint: [0.0, 0, 0, 0]
+    street_9_1_4:
+      xypoint: [95.05025253169417, 304.9497474683058, -45.0]
+      zpoint: [0.0, 0, 0, 0]
+  connections:
+    street_9_1_3-street_9_1_4: {start: points.street_9_1_3, length: 3.000000000000014,
+      explicit_end: points.street_9_1_4}
+  groups: {}
+)R";
+
+  const std::unique_ptr<const api::RoadGeometry> dut = mono::Load(dut_yaml);
+
+  GenerateUrdfFile(dut.get(), directory_.getStr(), kJunkBasename,
+                   ObjFeatures());
+  // We expect to get three files out of this.
+
+  spruce::path expected_urdf(directory_);
+  expected_urdf.append(kJunkBasename + ".urdf");
+  EXPECT_TRUE(expected_urdf.isFile());
+
+  spruce::path expected_obj(directory_);
+  expected_obj.append(kJunkBasename + ".obj");
+  EXPECT_TRUE(expected_obj.isFile());
+
+  spruce::path expected_mtl(directory_);
+  expected_mtl.append(kJunkBasename + ".mtl");
+  EXPECT_TRUE(expected_mtl.isFile());
 
   // spruce is retarded: it has no functionality for reading/walking a
   // directory, so we have to delete all our files individually here where


### PR DESCRIPTION
Fixes #5745 ("Request to remove lane length restriction in DrawLaneArrow").

The "lane length restriction" is actually an assertion ensuring that
`DrawLaneArrow()` is not being asked to draw an arrow which pokes out beyond
the end of the lane.   The caller (`MarkLaneEnds()`) does in fact try to
calculate parameters which avoid that --- but apparently numeric precision
issues in `double` arithmetic can cause the assertion to be violated.

Solution:  nudge arrows inwards by `linear_tolerance()` of the `RoadGeometry`,
which provides plenty of buffer to avoid precision issues.

Also:  create a unit-test (based on @basicNew's test case) which exercises the failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5768)
<!-- Reviewable:end -->
