### PR TITLE
Remove input pointer from SimpleCar::DoCalcOutput()

### DIFF
--- a/drake/automotive/simple_car.h
+++ b/drake/automotive/simple_car.h
@@ -77,7 +77,6 @@ class SimpleCar : public systems::LeafSystem<T> {
                     systems::rendering::PoseVector<T>* pose) const;
   void ImplCalcVelocity(const SimpleCarParams<T>& params,
                         const SimpleCarState<T>& state,
-                        const DrivingCommand<T>& input,
                         systems::rendering::FrameVelocity<T>* velocity) const;
   void ImplCalcTimeDerivatives(const SimpleCarParams<T>& params,
                                const SimpleCarState<T>& state,


### PR DESCRIPTION
When used in as an element in a feedback loop in series with a direct feedthrough element (for instance, `IdmController`), the presence of the `DrivingCommand` input pointer in the `DoCalcOutput` method causes calls to `EvaluateOutputPort()` to occur indefinitely, since the two subsystems in the feedback loop request each other's input ports be evaluated.  Note that this happens despite the fact that `SimpleCar` has no direct feedthrough.

This problem was initiated once `FrameVelocity` was added as an output, as it depends on non-input-dependent state derivatives (setting input-dependent rotation rates to zero).

This is a work-around for this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5773)
<!-- Reviewable:end -->
