### PR TITLE
Modified initialization of SimpleCar And Default Number of TrajectoryCars in AutomotiveDemo.

### DIFF
--- a/drake/automotive/README.md
+++ b/drake/automotive/README.md
@@ -41,8 +41,13 @@ $ bazel run drake/automotive:DEMO_NAME_HERE
 
 The following demos are available:
 
- * Basic cars driving around on an open plane:
-   `bazel run drake/automotive:demo`
+ * One `SimpleCar` under user control and one `TrajectoryCar` driving around in
+   a figure eight on an open plane:
+
+   ```
+   bazel run drake/automotive:demo -- --num_simple_car=1 \
+       --driving_command_gui_names=0 --num_trajectory_car=1
+   ```
 
    This will show one _ado_ car driving in a fixed trajectory, and one _ego_
    car which can be driven anywhere on the infinite plane.  (See "Driving

--- a/drake/automotive/automotive_demo.py
+++ b/drake/automotive/automotive_demo.py
@@ -195,12 +195,6 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--duration", type=float, default=float('Inf'),
                         help="demo run duration in seconds")
-    parser.add_argument("--steering-command-driver", action='store_true',
-                        dest='launch_steering_command_driver', default=True,
-                        help="launch steering_command_driver (default)")
-    parser.add_argument("--no-steering-command-driver", action='store_false',
-                        dest='launch_steering_command_driver', default=True,
-                        help="don't launch steering_command_driver")
     parser.add_argument("--visualizer", action='store_true',
                         dest='launch_visualizer',
                         default=True, help="launch drake-visualizer (default)")
@@ -210,6 +204,10 @@ def main():
     parser.add_argument("--dry-run", action='store_true',
                         default=False,
                         help="print commands instead of running them")
+    parser.add_argument("--driving_command_gui_names", default="",
+                        help="a comma separated list of vehicle names for " +
+                             "the vehicles for which a driving command GUI " +
+                             "should be launched")
     args, tail = parser.parse_known_args()
 
     if '--help' in tail:
@@ -238,8 +236,11 @@ def main():
 
         the_launcher.launch([demo_path] + tail)
 
-        if args.launch_steering_command_driver:
-            the_launcher.launch([steering_command_driver_path])
+        if args.driving_command_gui_names != "":
+            name_list = args.driving_command_gui_names.split(',')
+            for name in name_list:
+                the_launcher.launch([steering_command_driver_path,
+                                     "--lcm_tag=DRIVING_COMMAND_" + name])
 
         the_launcher.wait(args.duration)
 

--- a/drake/automotive/steering_command_driver.py
+++ b/drake/automotive/steering_command_driver.py
@@ -111,11 +111,11 @@ class KeyboardEventProcessor:
                     last_msg.steering_angle + (
                         STEERING_BUTTON_STEP_ANGLE * TURN_RIGHT_SIGN)))
 
-        new_msg = last_msg._replace(
+        new_msg = new_msg._replace(
             throttle=_limit_throttle(
-                last_msg.throttle + self.throttle_gradient * THROTTLE_SCALE),
+                new_msg.throttle + self.throttle_gradient * THROTTLE_SCALE),
             brake=_limit_brake(
-                last_msg.brake + self.brake_gradient * BRAKE_SCALE))
+                new_msg.brake + self.brake_gradient * BRAKE_SCALE))
 
         return new_msg
 
@@ -162,7 +162,7 @@ class SteeringCommandPublisher:
         print 'Initializing...'
         pygame.init()
         self.screen = pygame.display.set_mode((300, 70))
-        pygame.display.set_caption('Steering Command Driver')
+        pygame.display.set_caption(lcm_tag)
         self.font = pygame.font.SysFont('Courier', 20)
         if input_method == 'keyboard':
             self.event_processor = KeyboardEventProcessor()


### PR DESCRIPTION
Prior to this PR, there would always be at least one `SimpleCar` in the demo, which is at times undesirable when the focus is on other types of vehicles. In addition, when multiple `SimpleCar` instances are added, they would all initially be at exactly the same location.

This PR removes the one-`SimpleCar` minimum and initializes the `SimpleCar` with a y-offset so they're not initially at the same location.

This PR also changes the default number of `TrajectoryCar` instances to be zero instead of one. This is so we don't have to include a `--num_trajectory_car=0` command line flag when we're testing other vehicles.

Here's the initial state of the simulation when two `SimpleCar` instances are added:

```
$ bazel run drake/automotive:demo -- --simple_car_names=alice,bob \
    --driving_command_gui_names=alice,bob --num_trajectory_car=1
```

<img width="893" alt="screen shot 2017-04-08 at 11 57 54 pm" src="https://cloud.githubusercontent.com/assets/1388098/24834601/b9d2dab2-1cb8-11e7-8a82-db676b0bb022.png">


# Video

https://youtu.be/n0MZcgPLvVM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5774)
<!-- Reviewable:end -->