### PR TITLE
Adds DepthSensorToLcmPointCloudMessage.

### DIFF
--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -91,6 +91,35 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "depth_sensor_to_lcm_point_cloud_message",
+    srcs = [
+        "depth_sensor_to_lcm_point_cloud_message.cc",
+    ],
+    hdrs = [
+        "depth_sensor_to_lcm_point_cloud_message.h",
+    ],
+    deps = [
+        ":depth_sensor",
+        "//drake/multibody:rigid_body_tree",
+        "@bot_core_lcmtypes//:lib",
+    ],
+)
+
+drake_cc_binary(
+    name = "depth_sensor_to_lcm_point_cloud_message_demo",
+    srcs = [
+        "depth_sensor_to_lcm_point_cloud_message_demo.cc",
+    ],
+    deps = [
+        ":depth_sensor_to_lcm_point_cloud_message",
+        "//drake/common:text_logging_gflags",
+        "//drake/lcm",
+        "//drake/systems/analysis",
+        "//drake/systems/lcm",
+    ],
+)
+
+drake_cc_library(
     name = "gyroscope",
     srcs = [
         "gyroscope.cc",
@@ -195,6 +224,16 @@ drake_cc_googletest(
         ":depth_sensor",
         "//drake/common:drake_path",
         "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "depth_sensor_to_lcm_point_cloud_message_test",
+    srcs = ["test/depth_sensor_to_lcm_point_cloud_message_test.cc"],
+    deps = [
+        ":depth_sensor_to_lcm_point_cloud_message",
+        "//drake/common:drake_path",
+        "//drake/lcm:mock",
     ],
 )
 

--- a/drake/systems/sensors/CMakeLists.txt
+++ b/drake/systems/sensors/CMakeLists.txt
@@ -26,6 +26,15 @@ if(VTK_FOUND)
   list(APPEND drakeSensors_HEADERS rgbd_camera.h vtk_util.h)
 endif()
 
+if(LCM_FOUND AND Bullet_FOUND)
+  list(APPEND drakeSensors_SRC_FILES depth_sensor_to_lcm_point_cloud_message.cc)
+  list(APPEND drakeSensors_HEADERS depth_sensor_to_lcm_point_cloud_message.h)
+  add_executable(depth_sensor_to_lcm_point_cloud_message_demo
+      depth_sensor_to_lcm_point_cloud_message_demo.cc)
+  target_link_libraries(depth_sensor_to_lcm_point_cloud_message_demo
+      drakeSensors)
+endif()
+
 add_library_with_exports(LIB_NAME drakeSensors SOURCE_FILES
     ${drakeSensors_SRC_FILES})
 
@@ -37,6 +46,10 @@ target_link_libraries(drakeSensors
 if(VTK_FOUND)
   target_link_libraries(drakeSensors drakeRendering vtkIO vtkRendering)
   target_include_directories(drakeSensors PUBLIC ${VTK_INCLUDE_DIRS})
+endif()
+
+if(LCM_FOUND)
+  target_link_libraries(drakeSensors robotlocomotion-lcmtypes-cpp)
 endif()
 
 drake_install_libraries(drakeSensors)

--- a/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.cc
+++ b/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.cc
@@ -1,0 +1,63 @@
+#include "drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h"
+
+#include <string>
+#include <vector>
+
+#include "bot_core/pointcloud_t.hpp"
+
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/sensors/depth_sensor_output.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+DepthSensorToLcmPointCloudMessage::DepthSensorToLcmPointCloudMessage(
+      const DepthSensorSpecification& spec) : spec_(spec) {
+  input_port_index_ =
+      DeclareVectorInputPort(DepthSensorOutput<double>(spec_)).get_index();
+  output_port_index_ =
+      DeclareAbstractOutputPort(systems::Value<bot_core::pointcloud_t>())
+          .get_index();
+}
+
+const InputPortDescriptor<double>&
+DepthSensorToLcmPointCloudMessage::depth_readings_input_port() const {
+  return this->get_input_port(input_port_index_);
+}
+
+const OutputPortDescriptor<double>&
+DepthSensorToLcmPointCloudMessage::pointcloud_message_output_port() const {
+  return System<double>::get_output_port(output_port_index_);
+}
+
+void DepthSensorToLcmPointCloudMessage::DoCalcOutput(
+    const systems::Context<double>& context,
+    systems::SystemOutput<double>* output) const {
+  // Obtains the input.
+  const DepthSensorOutput<double>* depth_data =
+      this->template EvalVectorInput<DepthSensorOutput>(context,
+          input_port_index_);
+  const Eigen::Matrix3Xd point_cloud = depth_data->GetPointCloud();
+
+  // Obtains the output.
+  bot_core::pointcloud_t& message =
+      output->GetMutableData(output_port_index_)->
+        GetMutableValue<bot_core::pointcloud_t>();
+
+  message.frame_id = std::string(RigidBodyTreeConstants::kWorldName);
+  message.n_points = point_cloud.cols();
+  message.points.clear();
+  for (int i = 0; i < point_cloud.cols(); ++i) {
+    const auto& point = point_cloud.col(i);
+    message.points.push_back(std::vector<float>{
+        static_cast<float>(point(0)),
+        static_cast<float>(point(1)),
+        static_cast<float>(point(2))});
+  }
+  message.n_channels = 0;
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h
+++ b/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/systems/sensors/depth_sensor_specification.h"
+
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/// A DepthSensorToLcmPointCloudMessage takes as input a DepthSensorOutput and
+/// outputs an AbstractValue containing a `Value<bot_core::pointcloud_t>` LCM
+/// message. This message can then be sent to `drake-visualizer` using
+/// LcmPublisherSystem for visualizing the depth readings contained within the
+/// DepthSensorOutput.
+class DepthSensorToLcmPointCloudMessage : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DepthSensorToLcmPointCloudMessage)
+
+  /// A %DepthSensorToLcmPointCloudMessage constructor.
+  ///
+  /// @param spec The specification of the depth sensor whose output is being
+  /// visualized.
+  explicit DepthSensorToLcmPointCloudMessage(
+      const DepthSensorSpecification& spec);
+
+  /// Returns a descriptor of the input port containing a DepthSensorOutput.
+  const InputPortDescriptor<double>& depth_readings_input_port() const;
+
+  /// Returns a descriptor of the abstract valued output port that contains a
+  /// `Value<bot_core::pointcloud_t>`.
+  const OutputPortDescriptor<double>& pointcloud_message_output_port() const;
+
+ protected:
+  void DoCalcOutput(const systems::Context<double>& context,
+                    systems::SystemOutput<double>* output) const override;
+
+ private:
+  const DepthSensorSpecification& spec_;
+
+  // See class description for the semantics of the input and output ports.
+  int input_port_index_{};
+  int output_port_index_{};
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message_demo.cc
+++ b/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message_demo.cc
@@ -1,0 +1,82 @@
+#include "drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h"
+
+#include "bot_core/pointcloud_t.hpp"
+#include <gflags/gflags.h>
+
+#include "drake/common/text_logging_gflags.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/sensors/depth_sensor_output.h"
+
+DEFINE_string(spec, "octant_1", "The depth sensor specification to use. Valid "
+    "values include:\n"
+    "  - octant_1\n"
+    "  - xy_planar\n"
+    "  - xz_planar\n"
+    "  - xyz_spherical\n"
+    "  - x_linear");
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+int main(int argc, char* argv[]) {
+  const std::string kSensorName = "Foo";
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  logging::HandleSpdlogGflags();
+  ::drake::lcm::DrakeLcm real_lcm;
+
+  DepthSensorSpecification spec;
+  if (FLAGS_spec == "octant_1") {
+    DepthSensorSpecification::set_octant_1_spec(&spec);
+  } else if (FLAGS_spec == "xy_planar") {
+    DepthSensorSpecification::set_xy_planar_spec(&spec);
+  } else if (FLAGS_spec == "xz_planar") {
+    DepthSensorSpecification::set_xz_planar_spec(&spec);
+  } else if (FLAGS_spec == "xyz_spherical") {
+    DepthSensorSpecification::set_xyz_spherical_spec(&spec);
+  } else if (FLAGS_spec == "x_linear") {
+    DepthSensorSpecification::set_x_linear_spec(&spec);
+  } else {
+    throw std::runtime_error("Unknown spec type \"" + FLAGS_spec + "\".");
+  }
+
+  systems::DiagramBuilder<double> builder;
+  auto vis =
+      builder.template AddSystem<DepthSensorToLcmPointCloudMessage>(spec);
+  builder.ExportInput(vis->depth_readings_input_port());
+
+  auto lcm_publisher = builder.template AddSystem(
+      lcm::LcmPublisherSystem::Make<bot_core::pointcloud_t>(
+          "DRAKE_POINTCLOUD_" + kSensorName, &real_lcm));
+  builder.Connect(
+      vis->pointcloud_message_output_port(),
+      lcm_publisher->get_input_port(0));
+
+
+  auto diagram = builder.Build();
+  auto depth_sensor_output = std::make_unique<DepthSensorOutput<double>>(spec);
+  const double half_range = (spec.max_range() - spec.min_range()) / 2;
+  depth_sensor_output->SetFromVector(Eigen::VectorXd::Ones(
+      spec.num_depth_readings()) * half_range);
+
+  auto context = diagram->CreateDefaultContext();
+  context->FixInputPort(0, std::move(depth_sensor_output));
+
+  auto simulator = std::make_unique<systems::Simulator<double>>(
+      *diagram, std::move(context));
+  simulator->Initialize();
+  simulator->StepTo(0.005);
+  simulator->StepTo(0.01);
+  return 0;
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  return drake::systems::sensors::main(argc, argv);
+}

--- a/drake/systems/sensors/test/CMakeLists.txt
+++ b/drake/systems/sensors/test/CMakeLists.txt
@@ -11,6 +11,11 @@ if(Bullet_FOUND)
   drake_add_cc_test(depth_sensor_test)
   target_link_libraries(depth_sensor_test
       drakeSensors)
+  if(LCM_FOUND)
+    drake_add_cc_test(depth_sensor_to_lcm_point_cloud_message_test)
+    target_link_libraries(depth_sensor_to_lcm_point_cloud_message_test
+        drakeSensors)
+  endif()
 endif()
 
 if(BUILD_TESTING)

--- a/drake/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
+++ b/drake/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
@@ -1,0 +1,151 @@
+#include "drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h"
+
+#include <cmath>
+#include <memory>
+#include <utility>
+
+#include "bot_core/pointcloud_t.hpp"
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_path.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/systems/sensors/depth_sensor_output.h"
+#include "drake/systems/sensors/depth_sensor_specification.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace {
+
+class TestDepthSensorToLcmPointCloudMessage : public ::testing::Test {
+ protected:
+  // Initializes the Device Under Test (DUT) based on spec_ and induces it to
+  // output a bot_core::pointcloud_t message.
+  //
+  // @pre spec_ was initialized.
+  const bot_core::pointcloud_t& InitializeAndOutputMessage() {
+    // The Device Under Test (DUT).
+    DepthSensorToLcmPointCloudMessage dut(spec_);
+    const InputPortDescriptor<double>& input_port =
+        dut.depth_readings_input_port();
+    EXPECT_EQ(input_port.get_system(), &dut);
+    EXPECT_EQ(input_port.size(), spec_.num_depth_readings());
+
+    auto depth_sensor_output =
+        std::make_unique<DepthSensorOutput<double>>(spec_);
+
+    const double half_range = (spec_.max_range() - spec_.min_range()) / 2;
+    depth_sensor_output->SetFromVector(Eigen::VectorXd::Ones(
+        spec_.num_depth_readings()) * half_range);
+
+    std::unique_ptr<Context<double>> context = dut.CreateDefaultContext();
+    context->FixInputPort(input_port.get_index(),
+        std::move(depth_sensor_output));
+
+    output_ = dut.AllocateOutput(*context);
+
+    dut.CalcOutput(*context, output_.get());
+
+    const int output_port_index =
+        dut.pointcloud_message_output_port().get_index();
+    return output_->get_data(output_port_index)->
+        template GetValue<bot_core::pointcloud_t>();
+  }
+
+  DepthSensorSpecification spec_;
+  std::unique_ptr<SystemOutput<double>> output_;
+};
+
+const int kX(0);
+const int kY(1);
+const int kZ(2);
+
+// Tests that the DUT can generate a bot_core::pointcloud_t message that
+// contains a point cloud within the first octant of the world frame. The points
+// within the point cloud are hard-coded to be halfway between the minimum and
+// maximum depth sensing range.
+TEST_F(TestDepthSensorToLcmPointCloudMessage, Octant1Test) {
+  DepthSensorSpecification::set_octant_1_spec(&spec_);
+  const bot_core::pointcloud_t& message = InitializeAndOutputMessage();
+  EXPECT_EQ(message.n_points, spec_.num_depth_readings());
+  for (int i = 0; i < message.n_points; ++i) {
+    EXPECT_GE(message.points.at(i).at(kX), 0);
+    EXPECT_GE(message.points.at(i).at(kY), 0);
+    EXPECT_GE(message.points.at(i).at(kZ), 0);
+  }
+}
+
+// Tests that the DUT can generate a bot_core::pointcloud_t message that
+// contains a point cloud that resides within the x/y plane of the world frame.
+// The points within the point cloud are hard-coded to be halfway between the
+// minimum and maximum depth sensing range.
+TEST_F(TestDepthSensorToLcmPointCloudMessage, XyPlanarTest) {
+  DepthSensorSpecification::set_xy_planar_spec(&spec_);
+  const bot_core::pointcloud_t& message = InitializeAndOutputMessage();
+  EXPECT_EQ(message.n_points, spec_.num_depth_readings());
+  const double half_range = (spec_.max_range() - spec_.min_range()) / 2;
+  for (int i = 0; i < message.n_points; ++i) {
+    // The following tolerance was empirically determined.
+    EXPECT_NEAR(std::sqrt(std::pow(message.points.at(i).at(kX), 2) +
+                          std::pow(message.points.at(i).at(kY), 2)),
+                half_range, 1e-7);
+    EXPECT_EQ(message.points.at(i).at(kZ), 0);
+  }
+}
+
+// Tests that the DUT can generate a bot_core::pointcloud_t message that
+// contains a point cloud that resides within the x/z plane of the world frame.
+// The points within the point cloud are hard-coded to be halfway between the
+// minimum and maximum depth sensing range.
+TEST_F(TestDepthSensorToLcmPointCloudMessage, XzPlanarTest) {
+  DepthSensorSpecification::set_xz_planar_spec(&spec_);
+  const bot_core::pointcloud_t& message = InitializeAndOutputMessage();
+  EXPECT_EQ(message.n_points, spec_.num_depth_readings());
+  const double half_range = (spec_.max_range() - spec_.min_range()) / 2;
+  for (int i = 0; i < message.n_points; ++i) {
+    // The following tolerance was empirically determined.
+    EXPECT_NEAR(std::sqrt(std::pow(message.points.at(i).at(kX), 2) +
+                          std::pow(message.points.at(i).at(kZ), 2)),
+                half_range, 1e-7);
+    EXPECT_EQ(message.points.at(i).at(kY), 0);
+  }
+}
+
+// Tests that the DUT can generate a bot_core::pointcloud_t message that
+// contains a point cloud that forms a sphere centered at the origin plane of
+// the world frame. The points within the point cloud are hard-coded to be
+// halfway between the minimum and maximum depth sensing range.
+TEST_F(TestDepthSensorToLcmPointCloudMessage, XyzSphericalTest) {
+  DepthSensorSpecification::set_xyz_spherical_spec(&spec_);
+  const bot_core::pointcloud_t& message = InitializeAndOutputMessage();
+  EXPECT_EQ(message.n_points, spec_.num_depth_readings());
+  const double half_range = (spec_.max_range() - spec_.min_range()) / 2;
+  for (int i = 0; i < message.n_points; ++i) {
+    // The following tolerance was empirically determined.
+    EXPECT_NEAR(std::sqrt(std::pow(message.points.at(i).at(kX), 2) +
+                          std::pow(message.points.at(i).at(kY), 2) +
+                          std::pow(message.points.at(i).at(kZ), 2)),
+                half_range, 1e-7);
+  }
+}
+
+// Tests that the DUT can generate a bot_core::pointcloud_t message that
+// contains a point cloud consisting of a single point on the x-axis of the
+// world frame that is halfway between the minimum and maximum depth sensing
+// range.
+TEST_F(TestDepthSensorToLcmPointCloudMessage, XLinearTest) {
+  DepthSensorSpecification::set_x_linear_spec(&spec_);
+  const bot_core::pointcloud_t& message = InitializeAndOutputMessage();
+  EXPECT_EQ(message.n_points, spec_.num_depth_readings());
+  const double half_range = (spec_.max_range() - spec_.min_range()) / 2;
+  for (int i = 0; i < message.n_points; ++i) {
+    EXPECT_EQ(message.points.at(i).at(kX), half_range);
+    EXPECT_EQ(message.points.at(i).at(kY), 0);
+    EXPECT_EQ(message.points.at(i).at(kZ), 0);
+  }
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Resolves #1586.

Here's a visualization of the first octant point cloud in `drake-visualizer` when the point size is manually set to 5 and colored black:

# First Octant Spec Visualization

```
$ bazel run //drake/systems/sensors:depth_sensor_to_lcm_point_cloud_message_demo
```

<img width="1549" alt="screen shot 2017-04-09 at 9 53 09 pm" src="https://cloud.githubusercontent.com/assets/1388098/24843252/0bc01bc6-1d6f-11e7-92f7-5c6b1e3416aa.png">

# XY Planar Spec Visualization

```
$ bazel run //drake/systems/sensors:depth_sensor_to_lcm_point_cloud_message_demo -- --spec=xy_planar
```

<img width="1549" alt="screen shot 2017-04-10 at 10 04 32 am" src="https://cloud.githubusercontent.com/assets/1388098/24865426/3611a44c-1dd5-11e7-8155-7a22c8a90206.png">

# XZ Planar Spec Visualization

```
$ bazel run //drake/systems/sensors:depth_sensor_to_lcm_point_cloud_message_demo -- --spec=xz_planar
```

<img width="1549" alt="screen shot 2017-04-10 at 10 07 43 am" src="https://cloud.githubusercontent.com/assets/1388098/24865561/9e1bf2ae-1dd5-11e7-99dd-cf4b958d5a53.png">

# XYZ Spherical Spec Visualization

```
$ bazel run //drake/systems/sensors:depth_sensor_to_lcm_point_cloud_message_demo -- --spec=xyz_spherical
```

<img width="1549" alt="screen shot 2017-04-10 at 10 10 38 am" src="https://cloud.githubusercontent.com/assets/1388098/24865687/feacd278-1dd5-11e7-8db3-fc2137229cac.png">

# X Linear Spec Visualization

```
bazel run //drake/systems/sensors:depth_sensor_to_lcm_point_cloud_message_demo -- --spec=x_linear
```

<img width="1549" alt="screen shot 2017-04-10 at 10 14 06 am" src="https://cloud.githubusercontent.com/assets/1388098/24865848/7ca5a9d4-1dd6-11e7-8b7f-cdb12b1d3711.png">

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5779)
<!-- Reviewable:end -->