### PR TITLE
Qt4 Mac Homebrew package was renamed to qt@4

### DIFF
--- a/drake/doc/mac.rst
+++ b/drake/doc/mac.rst
@@ -21,7 +21,7 @@ Install the prerequisites::
     brew upgrade
     brew install autoconf automake bazel clang-format cmake doxygen gcc glib \
       graphviz gtk+ jpeg libpng libtool libyaml mpfr ninja numpy python \
-      qt qwt scipy valgrind vtk5 wget
+      qt@4 qwt-qt4 scipy valgrind vtk5 wget
     pip install -U beautifulsoup4 html5lib lxml PyYAML Sphinx
 
 Add the line::


### PR DESCRIPTION
At the request of Homebrew maintainers, I renamed my Qt4 package from `qt` to `qt@4`. Unfortunately, means that `brew install qt` now installs Qt5, which is probably not what you were expecting. This PR updates your Mac installation instructions to use the new name.

Apologies for the inconvenience.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5783)
<!-- Reviewable:end -->
