### PR TITLE
add a plan eval instance that moves manipulator end effector in cartesian space.

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/BUILD
@@ -35,6 +35,38 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "manipulator_plans",
+    srcs = [
+        "manipulator_move_end_effector_plan.cc",
+    ],
+    hdrs = [
+        "manipulator_move_end_effector_plan.h",
+    ],
+    deps = [
+        ":generic_plan",
+        "//drake/lcmtypes:manipulator_plan_move_end_effector",
+        "//drake/util:lcm_util",
+    ],
+)
+
+drake_cc_googletest(
+    name = "manipulator_plan_test",
+    data = [
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":manipulator_plans",
+        ":test_common",
+        "//drake/common:drake_path",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/parsers",
+    ],
+)
+
+drake_cc_library(
     name = "plan_eval_utils",
     srcs = [
         "plan_eval_utils.cc",

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.cc
@@ -1,0 +1,88 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.h"
+
+#include <vector>
+
+#include "drake/lcmt_manipulator_plan_move_end_effector.hpp"
+#include "drake/util/lcmUtil.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+template <typename T>
+void ManipulatorMoveEndEffectorPlan<T>::InitializeGenericPlanDerived(
+    const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
+    const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) {
+  // Knots are constant, the second time doesn't matter.
+  const std::vector<T> times = {robot_status.time(), robot_status.time() + 1};
+  const RigidBody<T>* ee_body =
+      alias_groups.get_body(kEndEffectorAliasGroupName);
+  Isometry3<T> ee_pose = robot_status.robot().CalcBodyPoseInWorldFrame(
+      robot_status.cache(), *ee_body);
+
+  PiecewiseCartesianTrajectory<T> ee_traj =
+      PiecewiseCartesianTrajectory<T>::MakeCubicLinearWithEndLinearVelocity(
+          times, {ee_pose, ee_pose}, Vector3<double>::Zero(),
+          Vector3<double>::Zero());
+  this->set_body_trajectory(ee_body, ee_traj);
+}
+
+template <typename T>
+void ManipulatorMoveEndEffectorPlan<T>::HandlePlanMessageGenericPlanDerived(
+    const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
+    const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
+    const void* message_bytes, int message_length) {
+  // Tries to decode as a lcmt_manipulator_plan_move_end_effector message.
+  lcmt_manipulator_plan_move_end_effector msg;
+  int consumed = msg.decode(message_bytes, 0, message_length);
+  DRAKE_DEMAND(consumed == message_length);
+
+  // TODO(siyuan): should do better error handling wrt bad plan message.
+  DRAKE_DEMAND(static_cast<size_t>(msg.num_steps) == msg.utimes.size() &&
+               static_cast<size_t>(msg.num_steps) == msg.poses.size());
+  DRAKE_DEMAND(msg.num_steps >= 0);
+
+  if (msg.num_steps == 0) return;
+
+  std::vector<T> times;
+  std::vector<Isometry3<T>> poses;
+  Vector3<double> vel0 = Vector3<double>::Zero();
+
+  const RigidBody<T>* ee_body =
+      alias_groups.get_body(kEndEffectorAliasGroupName);
+
+  // If the first keyframe does not start immediately (its time > 0), we start
+  // from the current desired pose.
+  if (msg.utimes.front() > 0) {
+    times.push_back(robot_status.time());
+    poses.push_back(
+        this->get_body_trajectory(ee_body).get_pose(robot_status.time()));
+    vel0 = this->get_body_trajectory(ee_body)
+               .get_velocity(robot_status.time())
+               .template tail<3>();
+  }
+
+  for (int i = 0; i < msg.num_steps; i++) {
+    times.push_back(robot_status.time() + static_cast<T>(msg.utimes[i]) / 1e6);
+    poses.push_back(DecodePose(msg.poses[i]));
+  }
+
+  // TODO(siyuan): use msg.order_of_interpolation.
+  PiecewiseCartesianTrajectory<T> ee_traj =
+      PiecewiseCartesianTrajectory<T>::MakeCubicLinearWithEndLinearVelocity(
+          times, poses, vel0, Vector3<double>::Zero());
+
+  this->set_body_trajectory(ee_body, ee_traj);
+}
+
+template <typename T>
+GenericPlan<T>* ManipulatorMoveEndEffectorPlan<T>::CloneGenericPlanDerived()
+    const {
+  return new ManipulatorMoveEndEffectorPlan(*this);
+}
+
+template class ManipulatorMoveEndEffectorPlan<double>;
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <string>
+
+#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/generic_plan.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+/**
+ * A concrete plan that sets up a Cartesian tracking objective for the end
+ * effector assuming no contacts. The joint space tracking objective is set
+ * to track the measured joint position when Initialize() is called.
+ * Note that joint position tracking can be turned off by setting the
+ * position gains to zero in the parameters passed to UpdateQpInput.
+ */
+template <typename T>
+class ManipulatorMoveEndEffectorPlan : public GenericPlan<T> {
+ protected:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ManipulatorMoveEndEffectorPlan)
+
+ public:
+  ManipulatorMoveEndEffectorPlan() {}
+
+  static constexpr const char* kEndEffectorAliasGroupName = "flange";
+
+ protected:
+  /**
+   * A desired stationary Cartesian spline is set up for the body whose alias
+   * in @p alias_groups is kEndEffectorAliasGroupName.
+   */
+  void InitializeGenericPlanDerived(
+      const HumanoidStatus& robot_status,
+      const param_parsers::ParamSet& paramset,
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) override;
+
+  /**
+   * This function assumes that the bytes in @p message_bytes encodes a valid
+   * lcmt_manipulator_plan_move_end_effector message, from which the desired
+   * poses (x_i) for the end effector and timing (t_i) are extracted and used
+   * to construct a Cartesian spline. Let t_now be the time in @p robot_stauts.
+   * If t_0 = 0 (first time stamp in @p message_bytes is zero), the spline is
+   * constructed with
+   * MakeCubicLinearWithEndLinearVelocity(t_i + t_now, x_i, 0, 0), which starts
+   * immediately from x_0 regardless of what's the current planned desired
+   * pose and velocity. This introduces a discontinuity in the interpolated
+   * desired position and velocity when interpolating, which can cause a larger
+   * discontinuity (due to gains) in output and instability on robot.
+   * If t_0 > 0, the spline is constructed with
+   * MakeCubicLinearWithEndLinearVelocity({0, t_i} + t_now,
+   * {x_d_now, x_i}, xd_d_now, 0),
+   * where x_d_now and xd_d_now are the current desired pose and velocity of
+   * the end effector. This results in a smoother transition to the new plan.
+   */
+  void HandlePlanMessageGenericPlanDerived(
+      const HumanoidStatus& robot_stauts,
+      const param_parsers::ParamSet& paramset,
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
+      const void* message_bytes, int message_length) override;
+
+ private:
+  GenericPlan<T>* CloneGenericPlanDerived() const override;
+
+  void ModifyPlanGenericPlanDerived(
+      const HumanoidStatus& robot_stauts,
+      const param_parsers::ParamSet& paramset,
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) override {
+  }
+
+  void UpdateQpInputGenericPlanDerived(
+      const HumanoidStatus& robot_status,
+      const param_parsers::ParamSet& paramset,
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
+      QpInput* qp_input) const override {}
+};
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/test/manipulator_plan_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/test/manipulator_plan_test.cc
@@ -1,0 +1,302 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/test/test_common.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+
+#include "drake/lcmt_manipulator_plan_move_end_effector.hpp"
+#include "drake/util/lcmUtil.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+namespace {
+
+// Makes a lcmt_manipulator_plan_move_end_effector message, where the waypoints
+// are defined by @p times and @p poses.
+lcmt_manipulator_plan_move_end_effector make_move_end_effector_message(
+    const std::vector<double>& times,
+    const std::vector<Isometry3<double>>& poses) {
+  lcmt_manipulator_plan_move_end_effector msg;
+
+  msg.num_steps = static_cast<int>(times.size());
+  msg.utimes.resize(msg.num_steps);
+  msg.poses.resize(msg.num_steps);
+
+  for (int i = 0; i < msg.num_steps; i++) {
+    msg.utimes[i] = static_cast<int64_t>(times[i] * 1e6);
+    EncodePose(poses[i], msg.poses[i]);
+  }
+
+  return msg;
+}
+
+}  // namespace
+
+class ManipPlanTest : public GenericPlanTest {
+ protected:
+  void SetUp() override {
+    const std::string kModelPath = drake::GetDrakePath() +
+                                   "/manipulation/models/iiwa_description/urdf/"
+                                   "iiwa14_polytope_collision.urdf";
+
+    const std::string kAliasGroupsPath =
+        drake::GetDrakePath() +
+        "/examples/QPInverseDynamicsForHumanoids/"
+        "config/iiwa.alias_groups";
+
+    const std::string kControlConfigPath =
+        drake::GetDrakePath() +
+        "/examples/QPInverseDynamicsForHumanoids/"
+        "config/iiwa.id_controller_config";
+
+    std::default_random_engine generator(123);
+    AllocateResources(kModelPath, kAliasGroupsPath, kControlConfigPath);
+    SetRandomConfiguration(&generator);
+
+    ee_body_ = alias_groups_->get_body(
+        ManipulatorMoveEndEffectorPlan<double>::kEndEffectorAliasGroupName);
+  }
+
+  // End effector body pointer.
+  const RigidBody<double>* ee_body_;
+};
+
+// Tests Initialization from ManipulatorMoveEndEffectorPlan. Should generate
+// a plan that holds at the current posture with one body tracking objective
+// for the end effector.
+TEST_F(ManipPlanTest, MoveEndEffectorInitializeTest) {
+  dut_ = std::make_unique<ManipulatorMoveEndEffectorPlan<double>>();
+  dut_->Initialize(*robot_status_, *params_, *alias_groups_);
+
+  // There should be no contacts, 1 tracked body for move end effector plan.
+  EXPECT_TRUE(dut_->get_planned_contact_state().empty());
+  EXPECT_EQ(dut_->get_body_trajectories().size(), 1);
+
+  // The desired position interpolated at any time should be equal to the
+  // current posture.
+  // The desired velocity and acceleration should be zero.
+  std::vector<double> test_times = {robot_status_->time() - 0.5,
+                                    robot_status_->time(),
+                                    robot_status_->time() + 3};
+
+  const PiecewiseCartesianTrajectory<double>& ee_traj =
+      dut_->get_body_trajectory(ee_body_);
+  const Isometry3<double> ee_pose =
+      robot_status_->robot().CalcBodyPoseInWorldFrame(robot_status_->cache(),
+                                                      *ee_body_);
+
+  for (double time : test_times) {
+    // Dof trajectory.
+    EXPECT_TRUE(drake::CompareMatrices(
+        robot_status_->position(),
+        dut_->get_dof_trajectory().get_position(time), kSmallTolerance,
+        drake::MatrixCompareType::absolute));
+
+    EXPECT_TRUE(drake::CompareMatrices(
+        VectorX<double>::Zero(robot_->get_num_velocities()),
+        dut_->get_dof_trajectory().get_velocity(time), kSmallTolerance,
+        drake::MatrixCompareType::absolute));
+
+    EXPECT_TRUE(drake::CompareMatrices(
+        VectorX<double>::Zero(robot_->get_num_velocities()),
+        dut_->get_dof_trajectory().get_acceleration(time), kSmallTolerance,
+        drake::MatrixCompareType::absolute));
+
+    // End effector trajectory.
+    EXPECT_TRUE(drake::CompareMatrices(
+        ee_pose.matrix(), ee_traj.get_pose(time).matrix(), kSmallTolerance,
+        drake::MatrixCompareType::absolute));
+
+    EXPECT_TRUE(drake::CompareMatrices(
+        Vector6<double>::Zero(), ee_traj.get_velocity(time), kSmallTolerance,
+        drake::MatrixCompareType::absolute));
+
+    EXPECT_TRUE(drake::CompareMatrices(
+        Vector6<double>::Zero(), ee_traj.get_acceleration(time),
+        kSmallTolerance, drake::MatrixCompareType::absolute));
+  }
+}
+
+// Only testing the body motion objective part, the rest is covered in the
+// base case.
+TEST_F(ManipPlanTest, TestUpdateQpInput) {
+  dut_ = std::make_unique<ManipulatorMoveEndEffectorPlan<double>>();
+  dut_->Initialize(*robot_status_, *params_, *alias_groups_);
+
+  // After initialization, desired body motion objective is set to hold
+  // the current pose.
+  const Isometry3<double> ee_pose_d =
+      robot_status_->robot().CalcBodyPoseInWorldFrame(robot_status_->cache(),
+                                                      *ee_body_);
+  const Vector6<double> ee_vel_d = Vector6<double>::Zero();
+  const Vector6<double> ee_acc_d = Vector6<double>::Zero();
+
+  // Changes the current state, and compute acceleration target.
+  robot_status_->UpdateKinematics(0.66, robot_status_->position() * 0.3,
+                                  robot_status_->velocity());
+
+  QpInput qp_input;
+  dut_->UpdateQpInput(*robot_status_, *params_, *alias_groups_, &qp_input);
+
+  // There should be only one body motion tracking objective.
+  EXPECT_EQ(qp_input.desired_body_motions().size(), 1);
+  const DesiredBodyMotion& ee_motion =
+      qp_input.desired_body_motions().at(ee_body_->get_name());
+
+  // Computes the desired acceleration for that body.
+  Vector6<double> expected_pose_acc =
+      ComputeExpectedBodyAcceleration(ee_body_, ee_pose_d, ee_vel_d, ee_acc_d);
+
+  // Checks body acceleration.
+  EXPECT_TRUE(drake::CompareMatrices(expected_pose_acc, ee_motion.values(),
+                                     kSmallTolerance,
+                                     drake::MatrixCompareType::absolute));
+  for (int i = 0; i < 6; i++) {
+    // Checks body constraint type.
+    EXPECT_EQ(ee_motion.constraint_type(i), ConstraintType::Soft);
+    // Checks body weight.
+    EXPECT_EQ(ee_motion.weight(i), 1);
+  }
+}
+
+// Tests the message handler for ManipulatorMoveEndEffectorPlan.
+TEST_F(ManipPlanTest, MoveEndEffectorHandleMessageTest) {
+  dut_ = std::make_unique<ManipulatorMoveEndEffectorPlan<double>>();
+  dut_->Initialize(*robot_status_, *params_, *alias_groups_);
+
+  // Makes a copy of the current dof tracking trajectory.
+  const PiecewiseCubicTrajectory<double> expected_dof_traj =
+      dut_->get_dof_trajectory();
+
+  std::vector<double> plan_times = {0, 2};
+  std::vector<Isometry3<double>> plan_poses(plan_times.size(),
+                                            Isometry3<double>::Identity());
+
+  std::vector<uint8_t> bytes;
+  lcmt_manipulator_plan_move_end_effector msg =
+      make_move_end_effector_message(plan_times, plan_poses);
+  bytes.resize(msg.getEncodedSize());
+  msg.encode(bytes.data(), 0, msg.getEncodedSize());
+
+  // Handles the new plan.
+  dut_->HandlePlanMessage(*robot_status_, *params_, *alias_groups_,
+                          bytes.data(), bytes.size());
+  {
+    const PiecewiseCartesianTrajectory<double>& body_traj =
+        dut_->get_body_trajectory(ee_body_);
+    // The new body trajectory should run from cur_time, to cur_time +
+    // plan_times[end]
+    EXPECT_EQ(robot_status_->time(),
+              body_traj.get_position_trajectory().get_start_time());
+    EXPECT_EQ(robot_status_->time() + plan_times.back(),
+              body_traj.get_position_trajectory().get_end_time());
+
+    // There should be no contacts, but 1 tracked body.
+    EXPECT_TRUE(dut_->get_planned_contact_state().empty());
+    EXPECT_EQ(dut_->get_body_trajectories().size(), 1);
+    // The dof trajectory should not change.
+    EXPECT_TRUE(expected_dof_traj.is_approx(dut_->get_dof_trajectory(),
+                                            kSmallTolerance));
+
+    // Constructs the expected body traj.
+    std::vector<double> traj_times = plan_times;
+    std::vector<Isometry3<double>> traj_poses = plan_poses;
+
+    for (size_t i = 0; i < traj_times.size(); ++i) {
+      traj_times[i] += robot_status_->time();
+    }
+
+    const Vector3<double> zero = Vector3<double>::Zero();
+    PiecewiseCartesianTrajectory<double> expected_traj =
+        PiecewiseCartesianTrajectory<
+            double>::MakeCubicLinearWithEndLinearVelocity(traj_times,
+                                                          traj_poses, zero,
+                                                          zero);
+
+    EXPECT_TRUE(expected_traj.is_approx(dut_->get_body_trajectory(ee_body_),
+                                        kSmallTolerance));
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Makes a different plan that starts with a non zero first time stamp. The
+  // resulting trajectory should ramp from the pose and velocity interpolated
+  // from the current desired trajectory at t0 to the first pose in the
+  // message, where t0 is the time when HandlePlanMessage() is called.
+  plan_times[0] = 0.8;
+  msg = make_move_end_effector_message(plan_times, plan_poses);
+  bytes.resize(msg.getEncodedSize());
+  msg.encode(bytes.data(), 0, msg.getEncodedSize());
+
+  // Moves the clock forward in time.
+  robot_status_->UpdateKinematics(robot_status_->time() + 1,
+                                  robot_status_->position(),
+                                  robot_status_->velocity());
+
+  // Gets the pose and velocity interpolated from the current desired
+  // trajectory.
+  Isometry3<double> ee_pose_d_now =
+      dut_->get_body_trajectory(ee_body_).get_pose(robot_status_->time());
+  Vector6<double> ee_vel_d_now =
+      dut_->get_body_trajectory(ee_body_).get_velocity(robot_status_->time());
+
+  // Handles the new plan.
+  dut_->HandlePlanMessage(*robot_status_, *params_, *alias_groups_,
+                          bytes.data(), bytes.size());
+  {
+    const PiecewiseCartesianTrajectory<double>& body_traj =
+        dut_->get_body_trajectory(ee_body_);
+
+    // There should be no contacts, 1 tracked body.
+    EXPECT_TRUE(dut_->get_planned_contact_state().empty());
+    EXPECT_EQ(dut_->get_body_trajectories().size(), 1);
+    // The dof trajectory should not change.
+    EXPECT_TRUE(expected_dof_traj.is_approx(dut_->get_dof_trajectory(),
+                                            kSmallTolerance));
+
+    // The new body trajectory should run from cur_time, to cur_time +
+    // plan_times[end]
+    EXPECT_EQ(robot_status_->time(),
+              body_traj.get_position_trajectory().get_start_time());
+    EXPECT_EQ(robot_status_->time() + plan_times.back(),
+              body_traj.get_position_trajectory().get_end_time());
+
+    // Constructs the expected body traj.
+    std::vector<double> traj_times;
+    std::vector<Isometry3<double>> traj_poses;
+
+    traj_times.push_back(robot_status_->time());
+    traj_poses.push_back(ee_pose_d_now);
+
+    for (size_t i = 0; i < plan_times.size(); ++i) {
+      traj_times.push_back(plan_times[i] + robot_status_->time());
+      traj_poses.push_back(plan_poses[i]);
+    }
+
+    PiecewiseCartesianTrajectory<double> expected_traj =
+        PiecewiseCartesianTrajectory<double>::
+            MakeCubicLinearWithEndLinearVelocity(traj_times, traj_poses,
+                                                 ee_vel_d_now.tail<3>(),
+                                                 Vector3<double>::Zero());
+
+    EXPECT_TRUE(expected_traj.is_approx(dut_->get_body_trajectory(ee_body_),
+                                        kSmallTolerance));
+  }
+}
+
+// Tests if the cloned fields are the same as the original.
+TEST_F(ManipPlanTest, TestClone) {
+  dut_ = std::make_unique<ManipulatorMoveEndEffectorPlan<double>>();
+  dut_->Initialize(*robot_status_, *params_, *alias_groups_);
+
+  TestGenericClone();
+}
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/test/test_common.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/test/test_common.h
@@ -5,22 +5,30 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/examples/QPInverseDynamicsForHumanoids/control_utils.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/generic_plan.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/parsers/urdf_parser.h"
 
 namespace drake {
 namespace examples {
 namespace qp_inverse_dynamics {
+
+constexpr double kSmallTolerance = 1e-12;
 
 // This is a common test fixture for all tests for derived classes of
 // GenericPlan. It wraps around couple common objects typically used for
 // making / evaluating a Plan.
 class GenericPlanTest : public ::testing::Test {
  protected:
-  // Assumes robot_ and dut_ have already allocated.
-  void Initialize(const std::string& alias_groups_path,
-                  const std::string& control_param_path) {
-    DRAKE_DEMAND(robot_ != nullptr);
-    DRAKE_DEMAND(dut_ != nullptr);
+  // Allocates robot_, alias_groups_, params_, and robot_status_. dut_ should
+  // be allocated in individual tests depending on which plan is under test.
+  void AllocateResources(const std::string& robot_path,
+                         const std::string& alias_groups_path,
+                         const std::string& control_param_path) {
+    robot_ = std::make_unique<RigidBodyTree<double>>();
+    parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
+        robot_path, multibody::joints::kFixed, robot_.get());
 
     alias_groups_ =
         std::make_unique<param_parsers::RigidBodyTreeAliasGroups<double>>(
@@ -31,18 +39,79 @@ class GenericPlanTest : public ::testing::Test {
     params_->LoadFromFile(control_param_path, *alias_groups_);
 
     robot_status_ = std::make_unique<HumanoidStatus>(*robot_, *alias_groups_);
-    std::default_random_engine generator(123);
+  }
+
+  // Uses the given random number generator to set q and v in robot_status_.
+  // Also sets time = 0.2s.
+  void SetRandomConfiguration(std::default_random_engine* generator) {
     std::normal_distribution<double> normal;
-    VectorX<double> q = robot_->getRandomConfiguration(generator);
+    VectorX<double> q = robot_->getRandomConfiguration(*generator);
     VectorX<double> v(robot_->get_num_velocities());
     for (int i = 0; i < v.size(); i++) {
-      v[i] = normal(generator);
+      v[i] = normal(*generator);
     }
     double time_now = 0.2;
     robot_status_->UpdateKinematics(time_now, q, v);
+  }
 
-    // Initializes the plan using the current robot status.
-    dut_->Initialize(*robot_status_, *params_, *alias_groups_);
+  // Returns kp * (q_d - q) + kd* (v_d - v) + vd_d, where q v are from
+  // robot_status_ and kp and kd are from params_.
+  VectorX<double> ComputeExpectedDoFAcceleration(
+      const VectorX<double>& q_d, const VectorX<double>& v_d,
+      const VectorX<double>& vd_d) const {
+    VectorX<double> kp, kd;
+    params_->LookupDesiredDofMotionGains(&kp, &kd);
+
+    VectorX<double> expected_vd =
+        (kp.array() * (q_d - robot_status_->position()).array() +
+         kd.array() * (v_d - robot_status_->velocity()).array())
+            .matrix() +
+        vd_d;
+
+    return expected_vd;
+  }
+
+  // Returns a spatial acceleration using CartesianSetpoint, it is conceptually
+  // the same as ComputeExpectedDoFAcceleration(), with the exception of the
+  // rotation difference between pose_d and pose. Details are in control_utils.h
+  Vector6<double> ComputeExpectedBodyAcceleration(
+      const RigidBody<double>* body, const Isometry3<double> pose_d,
+      const Vector6<double> vel_d, const Vector6<double> acc_d) const {
+    // Finds the kp and kd gains from param.
+    Vector6<double> kp, kd;
+    params_->LookupDesiredBodyMotionGains(*body, &kp, &kd);
+    CartesianSetpoint<double> tracker(pose_d, vel_d, acc_d, kp, kd);
+
+    // Computes current body pose and velocity.
+    Isometry3<double> pose = robot_status_->robot().CalcBodyPoseInWorldFrame(
+        robot_status_->cache(), *body);
+    Vector6<double> vel =
+        robot_status_->robot().CalcBodySpatialVelocityInWorldFrame(
+            robot_status_->cache(), *body);
+
+    Vector6<double> expected_pose_acc =
+        tracker.ComputeTargetAcceleration(pose, vel);
+
+    return expected_pose_acc;
+  }
+
+  // Tests clone for the any derived classes that does not introduce new member
+  // fields.
+  void TestGenericClone() const {
+    std::unique_ptr<GenericPlan<double>> clone = dut_->Clone();
+    EXPECT_EQ(dut_->get_planned_contact_state(),
+              clone->get_planned_contact_state());
+    EXPECT_TRUE(dut_->get_dof_trajectory().is_approx(
+        clone->get_dof_trajectory(), kSmallTolerance));
+
+    const auto& trajs = dut_->get_body_trajectories();
+    const auto& cloned_trajs = clone->get_body_trajectories();
+    EXPECT_EQ(trajs.size(), cloned_trajs.size());
+    for (const auto& traj_pair : trajs) {
+      auto it = cloned_trajs.find(traj_pair.first);
+      EXPECT_TRUE(it != cloned_trajs.end());
+      EXPECT_TRUE(it->second.is_approx(traj_pair.second, kSmallTolerance));
+    }
   }
 
   std::unique_ptr<RigidBodyTree<double>> robot_{nullptr};
@@ -51,6 +120,7 @@ class GenericPlanTest : public ::testing::Test {
   std::unique_ptr<param_parsers::ParamSet> params_{nullptr};
   std::unique_ptr<HumanoidStatus> robot_status_{nullptr};
 
+  // Plan under test.
   std::unique_ptr<GenericPlan<double>> dut_{nullptr};
 };
 

--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -91,6 +91,15 @@ lcm_cc_library(
 )
 
 lcm_cc_library(
+    name = "manipulator_plan_move_end_effector",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_manipulator_plan_move_end_effector.lcm"],
+    deps = [
+        "@bot_core_lcmtypes//:lib",
+    ],
+)
+
+lcm_cc_library(
     name = "piecewise_polynomial",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_piecewise_polynomial.lcm"],
@@ -243,6 +252,9 @@ lcm_py_library(
     name = "lcmtypes-py",
     lcm_package = "drake",
     lcm_srcs = glob(["*.lcm"]),
+    deps = [
+        "@bot_core_lcmtypes//:py",
+    ],
 )
 
 # === test/ ===

--- a/drake/lcmtypes/lcmt_manipulator_plan_move_end_effector.lcm
+++ b/drake/lcmtypes/lcmt_manipulator_plan_move_end_effector.lcm
@@ -1,0 +1,17 @@
+package drake;
+
+struct lcmt_manipulator_plan_move_end_effector
+{
+  int64_t timestamp;
+
+  int32_t num_steps;
+
+  // Time steps in microseconds.
+  int64_t utimes[num_steps];
+
+  // Desired end effector poses.
+  bot_core.position_3d_t poses[num_steps];
+
+  // Order of polynomial used for interpolation.
+  int32_t order_of_interpolation;
+}

--- a/tools/bot_core_lcmtypes.BUILD
+++ b/tools/bot_core_lcmtypes.BUILD
@@ -11,3 +11,12 @@ lcm_cc_library(
     lcm_structs = [f[18:-4] for f in glob(["lcmtypes/*.lcm"])],
     linkstatic = 1,
 )
+
+lcm_py_library(
+    name = "py",
+    lcm_package = "bot_core",
+    lcm_srcs = glob(["lcmtypes/*.lcm"]),
+    # Input file "lcmtypes/bot_core_foo_t.lcm" yields struct "foo_t".
+    lcm_structs = [f[18:-4] for f in glob(["lcmtypes/*.lcm"])],
+    imports = ["lcmtypes"],
+)


### PR DESCRIPTION
adds the first concrete example in the plan eval stack. it does end effector cartesian tracking for a manipulator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5789)
<!-- Reviewable:end -->
