### PR TITLE
Add a convenience method to NiceTypeName and use it

### DIFF
--- a/drake/common/nice_type_name.h
+++ b/drake/common/nice_type_name.h
@@ -14,11 +14,18 @@ namespace drake {
 arbitrarily-complicated C++ types.
 
 Usage: @code
+// For types:
 using std::pair; using std::string;
 using MyVectorType = pair<int,string>;
 std::cout << "Type MyVectorType was: "
           << drake::NiceTypeName::Get<MyVectorType>() << std::endl;
 // Output: std::pair<int,std::string>
+
+// For expressions:
+std::unique_ptr<AbstractThing> thing;  // Assume actual type is ConcreteThing.
+std::cout << "Actual type of 'thing' was: "
+          << drake::NiceTypeName::Get(*thing) << std::endl;
+// Output: ConcreteThing
 @endcode
 
 We demangle and attempt to canonicalize the compiler-generated type names as
@@ -47,6 +54,15 @@ class NiceTypeName {
     static const never_destroyed<std::string> canonical(
         Canonicalize(Demangle(typeid(T).name())));
     return canonical.access();
+  }
+
+  /** Returns the type name of the most-derived type of an object of type T,
+  typically but not necessarily polymorphic. This must be calculated on the fly
+  so is expensive whenever called, though very reasonable for use in error
+  messages. **/
+  template <typename T>
+  static std::string Get(const T& thing) {
+    return Canonicalize(Demangle(typeid(thing).name()));
   }
 
   /** Using the algorithm appropriate to the current compiler, demangles a type

--- a/drake/common/nice_type_name.h
+++ b/drake/common/nice_type_name.h
@@ -59,7 +59,9 @@ class NiceTypeName {
   /** Returns the type name of the most-derived type of an object of type T,
   typically but not necessarily polymorphic. This must be calculated on the fly
   so is expensive whenever called, though very reasonable for use in error
-  messages. **/
+  messages. For non-polymorphic types this produces the same result as would
+  `Get<decltype(thing)>()` but for polymorphic types the results will
+  differ. **/
   template <typename T>
   static std::string Get(const T& thing) {
     return Canonicalize(Demangle(typeid(thing).name()));

--- a/drake/common/test/is_dynamic_castable.h
+++ b/drake/common/test/is_dynamic_castable.h
@@ -34,8 +34,7 @@ template <typename ToType, typename FromType>
   if (dynamic_cast<const ToType* const>(ptr) == nullptr) {
     const std::string from_name{NiceTypeName::Get<FromType>()};
     const std::string to_name{NiceTypeName::Get<ToType>()};
-    const std::string dynamic_name{NiceTypeName::Canonicalize(
-        NiceTypeName::Demangle(typeid(*ptr).name()))};
+    const std::string dynamic_name{NiceTypeName::Get(*ptr)};
     return ::testing::AssertionFailure()
            << "is_dynamic_castable<" << to_name << ">(" << from_name << "* ptr)"
            << " failed because ptr is of dynamic type " << dynamic_name << ".";

--- a/drake/common/test/nice_type_name_test.cc
+++ b/drake/common/test/nice_type_name_test.cc
@@ -135,8 +135,7 @@ GTEST_TEST(NiceTypeNameTest, Enum) {
             "drake::nice_type_name_test::ForTesting::MyEnumClass");
 }
 
-// Test the other form of NiceTypeName::Get().
-
+// Test the expression-accepting form of NiceTypeName::Get().
 GTEST_TEST(NiceTypeNameTest, Expressions) {
   using nice_type_name_test::Derived;
   using nice_type_name_test::Base;
@@ -148,13 +147,27 @@ GTEST_TEST(NiceTypeNameTest, Expressions) {
 
   Derived derived;
   Base* base = &derived;
+
+  // These both have the same name despite different declarations because
+  // they resolve to the same concrete type.
   EXPECT_EQ(NiceTypeName::Get(derived), "drake::nice_type_name_test::Derived");
   EXPECT_EQ(NiceTypeName::Get(*base), "drake::nice_type_name_test::Derived");
 
+  // OTOH, these differ because we get only the declared types.
+  EXPECT_NE(NiceTypeName::Get<decltype(*base)>(),
+            NiceTypeName::Get<decltype(derived)>());
+
   auto derived_uptr = std::make_unique<Derived>();
   auto base_uptr = std::unique_ptr<Base>(new Derived());
-  EXPECT_EQ(NiceTypeName::Get(*derived_uptr), "drake::nice_type_name_test::Derived");
-  EXPECT_EQ(NiceTypeName::Get(*base_uptr), "drake::nice_type_name_test::Derived");
+  EXPECT_EQ(NiceTypeName::Get(*derived_uptr),
+            "drake::nice_type_name_test::Derived");
+  EXPECT_EQ(NiceTypeName::Get(*base_uptr),
+            "drake::nice_type_name_test::Derived");
+
+  // unique_ptr is not polymorphic (unlike its contents) so its declared type
+  // and runtime type are the same.
+  EXPECT_EQ(NiceTypeName::Get<decltype(base_uptr)>(),
+            NiceTypeName::Get(base_uptr));
 }
 
 }  // namespace

--- a/drake/common/test/nice_type_name_test.cc
+++ b/drake/common/test/nice_type_name_test.cc
@@ -21,7 +21,13 @@ struct ForTesting {
   enum MyEnum { One, Two, Three };
   enum class MyEnumClass { Four, Five, Six };
 };
-}
+
+class Base {
+ public:
+  virtual ~Base() = default;
+};
+class Derived : public Base {};
+}  // namespace nice_type_name_test
 
 namespace {
 // Can't test much of NiceTypeName::Demangle because its behavior is compiler-
@@ -127,6 +133,28 @@ GTEST_TEST(NiceTypeNameTest, Enum) {
   EXPECT_EQ(NiceTypeName::Get<decltype(
                 nice_type_name_test::ForTesting::MyEnumClass::Four)>(),
             "drake::nice_type_name_test::ForTesting::MyEnumClass");
+}
+
+// Test the other form of NiceTypeName::Get().
+
+GTEST_TEST(NiceTypeNameTest, Expressions) {
+  using nice_type_name_test::Derived;
+  using nice_type_name_test::Base;
+  const int i = 10;
+  const double d = 3.14;
+  EXPECT_EQ(NiceTypeName::Get(i), "int");
+  EXPECT_EQ(NiceTypeName::Get(d), "double");
+  EXPECT_EQ(NiceTypeName::Get(i * d), "double");
+
+  Derived derived;
+  Base* base = &derived;
+  EXPECT_EQ(NiceTypeName::Get(derived), "drake::nice_type_name_test::Derived");
+  EXPECT_EQ(NiceTypeName::Get(*base), "drake::nice_type_name_test::Derived");
+
+  auto derived_uptr = std::make_unique<Derived>();
+  auto base_uptr = std::unique_ptr<Base>(new Derived());
+  EXPECT_EQ(NiceTypeName::Get(*derived_uptr), "drake::nice_type_name_test::Derived");
+  EXPECT_EQ(NiceTypeName::Get(*base_uptr), "drake::nice_type_name_test::Derived");
 }
 
 }  // namespace

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -289,8 +289,7 @@ class LeafSystem : public System<T> {
     const int64_t id = this->GetGraphvizId();
     std::string name = this->get_name();
     if (name.empty()) {
-      const std::string type = NiceTypeName::Canonicalize(
-          NiceTypeName::Demangle(typeid(*this).name()));
+      const std::string type = NiceTypeName::Get(*this);
       // Drop the template parameters.
       name = std::regex_replace(type, std::regex("<.*>$"), std::string());
     }

--- a/drake/systems/framework/value_checker.h
+++ b/drake/systems/framework/value_checker.h
@@ -32,11 +32,8 @@ void CheckBasicVectorInvariants(const BasicVector<T>* basic_vector) {
   const auto& original_type = typeid(*basic_vector);
   const auto& cloned_type = typeid(*cloned_vector);
   if (original_type != cloned_type) {
-    using N = NiceTypeName;
-    const std::string original_name =
-        N::Canonicalize(N::Demangle(original_type.name()));
-    const std::string cloned_name =
-        N::Canonicalize(N::Demangle(cloned_type.name()));
+    const std::string original_name = NiceTypeName::Get(*basic_vector);
+    const std::string cloned_name = NiceTypeName::Get(*cloned_vector);
     throw std::runtime_error(
         "CheckVectorValueInvariants failed: " + original_name + "::Clone "
         "produced a " + cloned_name + " object instead of the same type");


### PR DESCRIPTION
NiceTypeName had `Get<T>()` for a known-type T, but if instead you have a variable or expression of unknown type it required magical incantations to get the type name out. This adds `Get(x)` for any expression x, returning the most-derived type of x if it is polymorphic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5800)
<!-- Reviewable:end -->
