### PR TITLE
Updates license of all drake-distro/ros packages to be BSD-3-Clause.

### DIFF
--- a/ros/drake_ros_common/package.xml
+++ b/ros/drake_ros_common/package.xml
@@ -9,7 +9,7 @@
     Drake with ROS.
   </description>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <author>Chien-Liang Fok</author>
 

--- a/ros/drake_ros_common_test/package.xml
+++ b/ros/drake_ros_common_test/package.xml
@@ -6,7 +6,7 @@
     This package contains unit tests for drake_ros_common.
   </description>
   <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/ros/drake_ros_integration/package.xml
+++ b/ros/drake_ros_integration/package.xml
@@ -8,7 +8,7 @@
     A metapackage for grouping all packages that integrate Drake with ROS.
   </description>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <author>Chien-Liang Fok</author>
 

--- a/ros/drake_ros_systems/package.xml
+++ b/ros/drake_ros_systems/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>This package contains Drake systems that interact with ROS.</description>
   <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>ackermann_msgs</build_depend>


### PR DESCRIPTION
Resolves the drake-distro/ros portion of #4045.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5803)
<!-- Reviewable:end -->
