### PR TITLE
Global ik update constraint

### DIFF
--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -5,21 +5,50 @@ load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
     "drake_cc_googletest",
+    "drake_cc_library",
+)
+
+drake_cc_library(
+    name = "global_inverse_kinematics_test_util",
+    testonly = 1,
+    srcs = [
+        "test/global_inverse_kinematics_test_util.cc",
+    ],
+    hdrs = [
+        "test/global_inverse_kinematics_test_util.h",
+    ],
+    deps = [
+        "//drake/common:eigen_matrix_compare",
+        "//drake/multibody:global_inverse_kinematics",
+        "//drake/multibody:rigid_body_tree_construction",
+        "//drake/multibody/parsers",
+    ],
 )
 
 drake_cc_googletest(
     name = "global_inverse_kinematics_test",
-    size = "large",
+    size = "medium",
     srcs = ["test/global_inverse_kinematics_test.cc"],
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
     tags = ["gurobi"],
     deps = [
-        "//drake/common:eigen_matrix_compare",
-        "//drake/multibody:global_inverse_kinematics",
-        "//drake/multibody:rigid_body_tree_construction",
-        "//drake/multibody/parsers",
+        ":global_inverse_kinematics_test_util",
+        "//drake/multibody:inverse_kinematics",
+    ],
+)
+
+drake_cc_googletest(
+    name = "global_inverse_kinematics_reachable_test",
+    size = "medium",
+    srcs = ["test/global_inverse_kinematics_reachable_test.cc"],
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = ["gurobi"],
+    deps = [
+        ":global_inverse_kinematics_test_util",
     ],
 )
 

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -18,8 +18,10 @@ drake_cc_library(
         "test/global_inverse_kinematics_test_util.h",
     ],
     deps = [
+        "@gtest//:main",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody:global_inverse_kinematics",
+        "//drake/multibody:inverse_kinematics",
         "//drake/multibody:rigid_body_tree_construction",
         "//drake/multibody/parsers",
     ],
@@ -35,7 +37,6 @@ drake_cc_googletest(
     tags = ["gurobi"],
     deps = [
         ":global_inverse_kinematics_test_util",
-        "//drake/multibody:inverse_kinematics",
     ],
 )
 

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -18,12 +18,12 @@ drake_cc_library(
         "test/global_inverse_kinematics_test_util.h",
     ],
     deps = [
-        "@gtest//:main",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody:global_inverse_kinematics",
         "//drake/multibody:inverse_kinematics",
         "//drake/multibody:rigid_body_tree_construction",
         "//drake/multibody/parsers",
+        "@gtest//:main",
     ],
 )
 

--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -15,7 +15,7 @@ if(gurobi_FOUND)
             drakeIK)
 
     drake_add_cc_test(global_inverse_kinematics_reachable_test)
-    set_tests_properties(global_inverse_kinematics_reachable_test PROPERTIES TIMEOUT 200)
+    set_tests_properties(global_inverse_kinematics_reachable_test PROPERTIES TIMEOUT 300)
     target_link_libraries(global_inverse_kinematics_reachable_test
             drakeGlobalInverseKinematicsTest)
 endif()

--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -5,14 +5,14 @@ target_link_libraries(drakeGlobalInverseKinematicsTest
         drakeRigidBodyPlant
         drakeMultibodyParsers
         drakeCommon
+        drakeIK
         GTest::GTest)
 
 if(gurobi_FOUND)
     drake_add_cc_test(global_inverse_kinematics_test)
     set_tests_properties(global_inverse_kinematics_test PROPERTIES TIMEOUT 200)
     target_link_libraries(global_inverse_kinematics_test
-            drakeGlobalInverseKinematicsTest
-            drakeIK)
+            drakeGlobalInverseKinematicsTest)
 
     drake_add_cc_test(global_inverse_kinematics_reachable_test)
     set_tests_properties(global_inverse_kinematics_reachable_test PROPERTIES TIMEOUT 300)

--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -1,9 +1,21 @@
+add_library_with_exports(LIB_NAME drakeGlobalInverseKinematicsTest
+        SOURCE_FILES global_inverse_kinematics_test_util.h global_inverse_kinematics_test_util.cc)
+target_link_libraries(drakeGlobalInverseKinematicsTest
+        drakeGlobalIK
+        drakeRigidBodyPlant
+        drakeMultibodyParsers
+        drakeCommon
+        GTest::GTest)
+
 if(gurobi_FOUND)
     drake_add_cc_test(global_inverse_kinematics_test)
-    set_tests_properties(global_inverse_kinematics_test PROPERTIES TIMEOUT 400)
+    set_tests_properties(global_inverse_kinematics_test PROPERTIES TIMEOUT 200)
     target_link_libraries(global_inverse_kinematics_test
-            drakeGlobalIK
-            drakeRigidBodyPlant
-            drakeMultibodyParsers
-            drakeCommon)
+            drakeGlobalInverseKinematicsTest
+            drakeIK)
+
+    drake_add_cc_test(global_inverse_kinematics_reachable_test)
+    set_tests_properties(global_inverse_kinematics_reachable_test PROPERTIES TIMEOUT 200)
+    target_link_libraries(global_inverse_kinematics_reachable_test
+            drakeGlobalInverseKinematicsTest)
 endif()

--- a/drake/multibody/dev/test/global_inverse_kinematics_reachable_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_reachable_test.cc
@@ -1,0 +1,62 @@
+#include "drake/multibody/dev/test/global_inverse_kinematics_test_util.h"
+
+#include "drake/solvers/gurobi_solver.h"
+
+using Eigen::Vector3d;
+using Eigen::Isometry3d;
+
+using drake::solvers::SolutionResult;
+
+namespace drake {
+namespace multibody {
+namespace {
+TEST_F(KukaTest, ReachableTest) {
+  // Test the case that global IK should find a solution.
+  // "ee" stands for "end effector".
+  Eigen::Vector3d ee_pos_lb_W(0.4, -0.1, 0.4);
+  Eigen::Vector3d ee_pos_ub_W(0.6, 0.1, 0.6);
+  auto ee_pos_cnstr = global_ik_.AddWorldPositionConstraint(
+      ee_idx_, Vector3d::Zero(), ee_pos_lb_W, ee_pos_ub_W);
+
+  Eigen::Quaterniond ee_desired_orient(
+      Eigen::AngleAxisd(-M_PI / 2, Vector3d(0, 1, 0)));
+  auto ee_orient_cnstr = global_ik_.AddWorldOrientationConstraint(
+      ee_idx_, ee_desired_orient, 0.2 * M_PI);
+
+  solvers::GurobiSolver gurobi_solver;
+  if (gurobi_solver.available()) {
+    global_ik_.SetSolverOption(solvers::SolverType::kGurobi, "OutputFlag", 1);
+
+    SolutionResult sol_result = gurobi_solver.Solve(global_ik_);
+
+    EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
+
+    double pos_tol = 0.06;
+    double orient_tol = 0.2;
+    CheckGlobalIKSolution(pos_tol, orient_tol);
+
+    // Now update the constraint, the problem should still be feasible.
+    // TODO(hongkai.dai): do a warm start on the binary variables
+    ee_pos_lb_W << 0.2, -1, 0.6;
+    ee_pos_ub_W << 0.4, 1, 1.0;
+    ee_pos_cnstr.constraint()->UpdateLowerBound(ee_pos_lb_W);
+    ee_pos_cnstr.constraint()->UpdateUpperBound(ee_pos_ub_W);
+    double angle_tol = 0.3 * M_PI;
+    ee_orient_cnstr.constraint()->UpdateLowerBound(
+        Vector1d(2 * cos(angle_tol) + 1));
+    sol_result = gurobi_solver.Solve(global_ik_);
+    EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
+    const auto& ee_pos_sol =
+        global_ik_.GetSolution(global_ik_.body_position(ee_idx_));
+    EXPECT_TRUE((ee_pos_sol.array() >= ee_pos_lb_W.array() - 1E-6).all());
+    EXPECT_TRUE((ee_pos_sol.array() <= ee_pos_ub_W.array() + 1E-6).all());
+    const auto& ee_rotmat_sol =
+        global_ik_.GetSolution(global_ik_.body_rotation_matrix(ee_idx_));
+    Eigen::AngleAxisd ee_orient_err(ee_rotmat_sol.transpose() *
+                                    ee_desired_orient.toRotationMatrix());
+    EXPECT_LE(ee_orient_err.angle(), angle_tol + 1E-4);
+  }
+}
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/dev/test/global_inverse_kinematics_reachable_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_reachable_test.cc
@@ -37,11 +37,12 @@ TEST_F(KukaTest, ReachableTest) {
 
     // Now update the constraint, the problem should still be feasible.
     // TODO(hongkai.dai): do a warm start on the binary variables
-    ee_pos_lb_W << 0.2, -1, 0.6;
-    ee_pos_ub_W << 0.4, 1, 1.0;
+    ee_pos_lb_W << 0.2, -0.1, 0.6;
+    ee_pos_ub_W << 0.4, 0.1, 1.0;
     ee_pos_cnstr.constraint()->UpdateLowerBound(ee_pos_lb_W);
     ee_pos_cnstr.constraint()->UpdateUpperBound(ee_pos_ub_W);
     double angle_tol = 0.3 * M_PI;
+    // The orientation constraint is 2 * cos(angle_tol) + 1 <= trace(Rᵀ * R_des)
     ee_orient_cnstr.constraint()->UpdateLowerBound(
         Vector1d(2 * cos(angle_tol) + 1));
     sol_result = gurobi_solver.Solve(global_ik_);

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -2,8 +2,6 @@
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/solvers/gurobi_solver.h"
-#include "drake/multibody/constraint/rigid_body_constraint.h"
-#include "drake/multibody/rigid_body_ik.h"
 
 using Eigen::Vector3d;
 using Eigen::Isometry3d;
@@ -35,25 +33,12 @@ TEST_F(KukaTest, UnreachableTest) {
     EXPECT_TRUE(sol_result == SolutionResult::kInfeasible_Or_Unbounded ||
                 sol_result == SolutionResult::kInfeasibleConstraints);
   }
-  WorldPositionConstraint pos_cnstr(rigid_body_tree_.get(), ee_idx_,
-                                    Eigen::Vector3d::Zero(), ee_pos_lb,
-                                    ee_pos_ub);
-  WorldQuatConstraint orient_cnstr(
-      rigid_body_tree_.get(), ee_idx_,
-      Eigen::Vector4d(ee_desired_orient.w(), ee_desired_orient.x(),
-                      ee_desired_orient.y(), ee_desired_orient.z()),
-      0);
-  IKoptions ikoptions(rigid_body_tree_.get());
-  std::array<RigidBodyConstraint*, 2> constraint_array = {
-      {&pos_cnstr, &orient_cnstr}};
-  Eigen::VectorXd q_ik(7);
-  Eigen::VectorXd q_nom = Eigen::VectorXd::Zero(7);
-  Eigen::VectorXd q_guess = Eigen::VectorXd::Zero(7);
-  int ik_info;
-  std::vector<std::string> infeasible_cnstr;
-  inverseKin(rigid_body_tree_.get(), q_guess, q_nom, 2, constraint_array.data(),
-             ikoptions, &q_ik, &ik_info, &infeasible_cnstr);
-  EXPECT_EQ(ik_info, 13);
+  Eigen::Matrix<double, 7, 1> q_nom;
+  Eigen::Matrix<double, 7, 1> q_guess;
+  q_nom.setZero();
+  q_guess.setZero();
+  CheckNonlinearIK(ee_pos_lb, ee_pos_ub, ee_desired_orient, 0, q_nom, q_guess,
+                   13);
 }
 
 TEST_F(KukaTest, ReachableWithCost) {

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -1,12 +1,9 @@
-#include "drake/multibody/global_inverse_kinematics.h"
+#include "drake/multibody/dev/test/global_inverse_kinematics_test_util.h"
 
-#include <gtest/gtest.h>
-
-#include "drake/common/drake_path.h"
 #include "drake/common/eigen_matrix_compare.h"
-#include "drake/multibody/parsers/urdf_parser.h"
-#include "drake/multibody/rigid_body_tree_construction.h"
 #include "drake/solvers/gurobi_solver.h"
+#include "drake/multibody/constraint/rigid_body_constraint.h"
+#include "drake/multibody/rigid_body_ik.h"
 
 using Eigen::Vector3d;
 using Eigen::Isometry3d;
@@ -16,139 +13,6 @@ using drake::solvers::SolutionResult;
 namespace drake {
 namespace multibody {
 namespace {
-std::unique_ptr<RigidBodyTree<double>> ConstructKuka() {
-  std::unique_ptr<RigidBodyTree<double>> rigid_body_tree =
-      std::make_unique<RigidBodyTree<double>>();
-  const std::string model_path = drake::GetDrakePath() +
-                                 "/manipulation/models/iiwa_description/urdf/"
-                                 "iiwa14_polytope_collision.urdf";
-
-  parsers::urdf::AddModelInstanceFromUrdfFile(
-      model_path,
-      drake::multibody::joints::kFixed,
-      nullptr,
-      rigid_body_tree.get());
-
-  AddFlatTerrainToWorld(rigid_body_tree.get());
-  return rigid_body_tree;
-}
-
-class KukaTest : public ::testing::Test {
- public:
-  KukaTest()
-      : rigid_body_tree_(ConstructKuka()),
-        global_ik_(*rigid_body_tree_, 2),  // Test with 2 binary variables per
-                                           // half axis.
-        ee_idx_(rigid_body_tree_->FindBodyIndex("iiwa_link_ee")) {}
-
-  ~KukaTest() override {};
-
-  /**
-   * Given the solution computed from global IK, reconstruct the posture, then
-   * compute the body pose using forward kinematics with the reconstructed
-   * posture. Compare that forward kinematics body pose, with the body pose
-   * in the global IK.
-   */
-  void CheckGlobalIKSolution(double pos_tol, double orient_tol) const {
-    Eigen::VectorXd q_global_ik =
-        global_ik_.ReconstructGeneralizedPositionSolution();
-
-    std::cout << "Reconstructed robot posture:\n" << q_global_ik << std::endl;
-    KinematicsCache<double> cache = rigid_body_tree_->doKinematics(q_global_ik);
-
-    // TODO(hongkai.dai): replace this print out with error check. We have not
-    // derived a rigorous bound on the rotation matrix relaxation yet. Should be
-    // able to get a more meaningful bound when we have some theoretical proof.
-    for (int i = 1; i < rigid_body_tree_->get_num_bodies(); ++i) {
-      // Compute forward kinematics.
-      const auto &body_pose_fk = rigid_body_tree_->CalcFramePoseInWorldFrame(
-          cache, rigid_body_tree_->get_body(i), Isometry3d::Identity());
-
-      const Eigen::Matrix3d body_Ri =
-          global_ik_.GetSolution(global_ik_.body_rotation_matrix(i));
-      // Use 1E-10 for the error tolerance.
-      EXPECT_TRUE((body_Ri.array().abs() <= 1 + 1E-10).all());
-      EXPECT_LE(body_Ri.trace(), 3 + 1E-10);
-      EXPECT_GE(body_Ri.trace(), -1 - 1E-10);
-      // TODO(hongkai.dai): We will have a more meaningful bound on the
-      // relaxation of rotation matrix. Then clean up this print out with
-      // the check on the error bound, and move this file out of dev folder.
-      std::cout << rigid_body_tree_->get_body(i).get_name() << std::endl;
-      std::cout << "rotation matrix:\n global_ik\n" << body_Ri << std::endl;
-      std::cout << "forward kinematics\n" << body_pose_fk.linear() << std::endl;
-      std::cout << "R * R':\n" << body_Ri * body_Ri.transpose() << std::endl;
-      std::cout << "det(R) = " << body_Ri.determinant() << std::endl;
-      Vector3d body_pos_global_ik =
-          global_ik_.GetSolution(global_ik_.body_position(i));
-      std::cout << "position:\n global_ik\n" << body_pos_global_ik << std::endl;
-      std::cout << "forward kinematics\n"
-                << body_pose_fk.translation() << std::endl;
-      std::cout << std::endl;
-      EXPECT_TRUE(CompareMatrices(body_pose_fk.translation(),
-                                  body_pos_global_ik,
-                                  pos_tol,
-                                  MatrixCompareType::absolute));
-      EXPECT_TRUE(CompareMatrices(body_pose_fk.linear(), body_Ri, orient_tol,
-                                  MatrixCompareType::absolute));
-    }
-  }
-
- protected:
-  std::unique_ptr<RigidBodyTree<double>> rigid_body_tree_;
-  GlobalInverseKinematics global_ik_;
-  int ee_idx_;  // end effector's body index.
-};
-
-TEST_F(KukaTest, ReachableTest) {
-  // Test the case that global IK should find a solution.
-  // "ee" stands for "end effector".
-  Eigen::Vector3d ee_pos_lb_W(0.4, -0.1, 0.4);
-  Eigen::Vector3d ee_pos_ub_W(0.6, 0.1, 0.6);
-  auto ee_pos_cnstr = global_ik_.AddWorldPositionConstraint(
-      ee_idx_, Vector3d::Zero(), ee_pos_lb_W, ee_pos_ub_W);
-
-  Eigen::Quaterniond ee_desired_orient(
-      Eigen::AngleAxisd(-M_PI / 2, Vector3d(0, 1, 0)));
-  auto ee_orient_cnstr = global_ik_.AddWorldOrientationConstraint(
-      ee_idx_, ee_desired_orient, 0.2 * M_PI);
-
-  solvers::GurobiSolver gurobi_solver;
-  if (gurobi_solver.available()) {
-    global_ik_.SetSolverOption(solvers::SolverType::kGurobi, "OutputFlag", 1);
-
-    SolutionResult sol_result = gurobi_solver.Solve(global_ik_);
-
-    EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
-
-    double pos_tol = 0.06;
-    double orient_tol = 0.2;
-    CheckGlobalIKSolution(pos_tol, orient_tol);
-
-    // Now update the constraint, the problem should still be feasible.
-    // TODO(hongkai.dai): do a warm start on the binary variables
-    const auto& q_ik = global_ik_.ReconstructGeneralizedPositionSolution();
-    Eigen::VectorXd q_update = q_ik;
-    q_update(0) = (q_ik(0) + rigid_body_tree_->joint_limit_max(0)) / 2;
-    q_update(1) = (q_ik(1) + rigid_body_tree_->joint_limit_min(1)) / 2;
-    KinematicsCache<double> cache = rigid_body_tree_->doKinematics(q_update);
-    const Eigen::Isometry3d ee_pose_update = rigid_body_tree_->CalcBodyPoseInWorldFrame(cache, rigid_body_tree_->get_body(ee_idx_));
-    ee_pos_lb_W << ee_pose_update.translation() - Eigen::Vector3d::Constant(0.05);
-    ee_pos_ub_W << ee_pose_update.translation() + Eigen::Vector3d::Constant(0.05);
-    ee_pos_cnstr.constraint()->UpdateLowerBound(ee_pos_lb_W);
-    ee_pos_cnstr.constraint()->UpdateLowerBound(ee_pos_ub_W);
-    double angle_tol =  M_PI;
-    ee_orient_cnstr.constraint()->UpdateLowerBound(Vector1d(2 * cos(angle_tol) + 1));
-    sol_result = gurobi_solver.Solve(global_ik_);
-    EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
-    const auto& ee_pos_sol = global_ik_.GetSolution(global_ik_.body_position(ee_idx_));
-    EXPECT_TRUE((ee_pos_sol.array() >= ee_pos_lb_W.array() - 1E-6).all());
-    EXPECT_TRUE((ee_pos_sol.array() <= ee_pos_ub_W.array() + 1E-6).all());
-    const auto& ee_rotmat_sol = global_ik_.GetSolution(global_ik_.body_rotation_matrix(ee_idx_));
-    Eigen::AngleAxisd ee_orient_err(ee_rotmat_sol.transpose() * ee_desired_orient.toRotationMatrix());
-    EXPECT_LE(ee_orient_err.angle(), angle_tol + 1E-4);
-  }
-}
-
 TEST_F(KukaTest, UnreachableTest) {
   // Test a cartesian pose that we know is not reachable.
   Eigen::Vector3d ee_pos_lb(0.6, -0.1, 0.7);
@@ -168,9 +32,28 @@ TEST_F(KukaTest, UnreachableTest) {
 
     SolutionResult sol_result = gurobi_solver.Solve(global_ik_);
 
-    EXPECT_TRUE(sol_result == SolutionResult::kInfeasible_Or_Unbounded
-                    || sol_result == SolutionResult::kInfeasibleConstraints);
+    EXPECT_TRUE(sol_result == SolutionResult::kInfeasible_Or_Unbounded ||
+                sol_result == SolutionResult::kInfeasibleConstraints);
   }
+  WorldPositionConstraint pos_cnstr(rigid_body_tree_.get(), ee_idx_,
+                                    Eigen::Vector3d::Zero(), ee_pos_lb,
+                                    ee_pos_ub);
+  WorldQuatConstraint orient_cnstr(
+      rigid_body_tree_.get(), ee_idx_,
+      Eigen::Vector4d(ee_desired_orient.w(), ee_desired_orient.x(),
+                      ee_desired_orient.y(), ee_desired_orient.z()),
+      0);
+  IKoptions ikoptions(rigid_body_tree_.get());
+  std::array<RigidBodyConstraint*, 2> constraint_array = {
+      {&pos_cnstr, &orient_cnstr}};
+  Eigen::VectorXd q_ik(7);
+  Eigen::VectorXd q_nom = Eigen::VectorXd::Zero(7, 0);
+  Eigen::VectorXd q_guess = Eigen::VectorXd::Zero(7, 0);
+  int ik_info;
+  std::vector<std::string> infeasible_cnstr;
+  inverseKin(rigid_body_tree_.get(), q_guess, q_nom, 2, constraint_array.data(),
+             ikoptions, &q_ik, &ik_info, &infeasible_cnstr);
+  EXPECT_EQ(ik_info, 13);
 }
 
 TEST_F(KukaTest, ReachableWithCost) {

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -47,8 +47,8 @@ TEST_F(KukaTest, UnreachableTest) {
   std::array<RigidBodyConstraint*, 2> constraint_array = {
       {&pos_cnstr, &orient_cnstr}};
   Eigen::VectorXd q_ik(7);
-  Eigen::VectorXd q_nom = Eigen::VectorXd::Zero(7, 0);
-  Eigen::VectorXd q_guess = Eigen::VectorXd::Zero(7, 0);
+  Eigen::VectorXd q_nom = Eigen::VectorXd::Zero(7);
+  Eigen::VectorXd q_guess = Eigen::VectorXd::Zero(7);
   int ik_info;
   std::vector<std::string> infeasible_cnstr;
   inverseKin(rigid_body_tree_.get(), q_guess, q_nom, 2, constraint_array.data(),

--- a/drake/multibody/dev/test/global_inverse_kinematics_test_util.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test_util.cc
@@ -1,0 +1,84 @@
+#include "drake/multibody/dev/test/global_inverse_kinematics_test_util.h"
+
+#include <string>
+
+#include "drake/common/drake_path.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_tree_construction.h"
+
+using Eigen::Vector3d;
+using Eigen::Isometry3d;
+
+using drake::solvers::SolutionResult;
+
+namespace drake {
+namespace multibody {
+std::unique_ptr<RigidBodyTree<double>> ConstructKuka() {
+  std::unique_ptr<RigidBodyTree<double>> rigid_body_tree =
+      std::make_unique<RigidBodyTree<double>>();
+  const std::string model_path = drake::GetDrakePath() +
+      "/manipulation/models/iiwa_description/urdf/"
+          "iiwa14_polytope_collision.urdf";
+
+  parsers::urdf::AddModelInstanceFromUrdfFile(
+      model_path,
+      drake::multibody::joints::kFixed,
+      nullptr,
+      rigid_body_tree.get());
+
+  AddFlatTerrainToWorld(rigid_body_tree.get());
+  return rigid_body_tree;
+}
+
+KukaTest::KukaTest()
+    : rigid_body_tree_(ConstructKuka()),
+      global_ik_(*rigid_body_tree_, 2),  // Test with 2 binary variables per
+    // half axis.
+      ee_idx_(rigid_body_tree_->FindBodyIndex("iiwa_link_ee")) {}
+
+void KukaTest::CheckGlobalIKSolution(double pos_tol, double orient_tol) const {
+  Eigen::VectorXd q_global_ik =
+      global_ik_.ReconstructGeneralizedPositionSolution();
+
+  std::cout << "Reconstructed robot posture:\n" << q_global_ik << std::endl;
+  KinematicsCache<double> cache = rigid_body_tree_->doKinematics(q_global_ik);
+
+  // TODO(hongkai.dai): replace this print out with error check. We have not
+  // derived a rigorous bound on the rotation matrix relaxation yet. Should be
+  // able to get a more meaningful bound when we have some theoretical proof.
+  for (int i = 1; i < rigid_body_tree_->get_num_bodies(); ++i) {
+    // Compute forward kinematics.
+    const auto &body_pose_fk = rigid_body_tree_->CalcFramePoseInWorldFrame(
+        cache, rigid_body_tree_->get_body(i), Isometry3d::Identity());
+
+    const Eigen::Matrix3d body_Ri =
+        global_ik_.GetSolution(global_ik_.body_rotation_matrix(i));
+    // Use 1E-10 for the error tolerance.
+    EXPECT_TRUE((body_Ri.array().abs() <= 1 + 1E-10).all());
+    EXPECT_LE(body_Ri.trace(), 3 + 1E-10);
+    EXPECT_GE(body_Ri.trace(), -1 - 1E-10);
+    // TODO(hongkai.dai): We will have a more meaningful bound on the
+    // relaxation of rotation matrix. Then clean up this print out with
+    // the check on the error bound, and move this file out of dev folder.
+    std::cout << rigid_body_tree_->get_body(i).get_name() << std::endl;
+    std::cout << "rotation matrix:\n global_ik\n" << body_Ri << std::endl;
+    std::cout << "forward kinematics\n" << body_pose_fk.linear() << std::endl;
+    std::cout << "R * R':\n" << body_Ri * body_Ri.transpose() << std::endl;
+    std::cout << "det(R) = " << body_Ri.determinant() << std::endl;
+    Vector3d body_pos_global_ik =
+        global_ik_.GetSolution(global_ik_.body_position(i));
+    std::cout << "position:\n global_ik\n" << body_pos_global_ik << std::endl;
+    std::cout << "forward kinematics\n"
+              << body_pose_fk.translation() << std::endl;
+    std::cout << std::endl;
+    EXPECT_TRUE(CompareMatrices(body_pose_fk.translation(),
+                                body_pos_global_ik,
+                                pos_tol,
+                                MatrixCompareType::absolute));
+    EXPECT_TRUE(CompareMatrices(body_pose_fk.linear(), body_Ri, orient_tol,
+                                MatrixCompareType::absolute));
+  }
+}
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/dev/test/global_inverse_kinematics_test_util.h
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test_util.h
@@ -24,6 +24,25 @@ class KukaTest : public ::testing::Test {
    */
   void CheckGlobalIKSolution(double pos_tol, double orient_tol) const;
 
+  /**
+   * Solve the inverse kinematics problem from the nonlinear solver.
+   * @param ee_pos_lb_W Lower bound of the end effector position.
+   * @param ee_pos_ub_W Upper bound of the end effector position.
+   * @param ee_orient Desired end effector orientation.
+   * @param angle_tol Tolerance on end effector orientation error.
+   * @param q_guess Initial guess for nonlinear IK solution.
+   * @param q_nom Desired posture.
+   * @param info_expected Expected return status from nonlinear IK
+   * @return The nonlinear IK solution.
+   */
+  Eigen::VectorXd CheckNonlinearIK(const Eigen::Vector3d& ee_pos_lb_W,
+                                   const Eigen::Vector3d& ee_pos_ub_W,
+                                   const Eigen::Quaterniond& ee_orient,
+                                   double angle_tol,
+                                   const Eigen::Matrix<double, 7, 1>& q_guess,
+                                   const Eigen::Matrix<double, 7, 1>& q_nom,
+                                   int info_expected) const;
+
  protected:
   std::unique_ptr<RigidBodyTree<double>> rigid_body_tree_;
   GlobalInverseKinematics global_ik_;

--- a/drake/multibody/dev/test/global_inverse_kinematics_test_util.h
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test_util.h
@@ -10,8 +10,6 @@ std::unique_ptr<RigidBodyTree<double>> ConstructKuka();
 
 class KukaTest : public ::testing::Test {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(KukaTest)
-
   KukaTest();
 
   ~KukaTest() override {};

--- a/drake/multibody/dev/test/global_inverse_kinematics_test_util.h
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test_util.h
@@ -1,0 +1,33 @@
+#include "drake/multibody/global_inverse_kinematics.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+std::unique_ptr<RigidBodyTree<double>> ConstructKuka();
+
+class KukaTest : public ::testing::Test {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(KukaTest)
+
+  KukaTest();
+
+  ~KukaTest() override {};
+
+  /**
+   * Given the solution computed from global IK, reconstruct the posture, then
+   * compute the body pose using forward kinematics with the reconstructed
+   * posture. Compare that forward kinematics body pose, with the body pose
+   * in the global IK.
+   */
+  void CheckGlobalIKSolution(double pos_tol, double orient_tol) const;
+
+ protected:
+  std::unique_ptr<RigidBodyTree<double>> rigid_body_tree_;
+  GlobalInverseKinematics global_ik_;
+  int ee_idx_;  // end effector's body index.
+};
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -294,7 +294,8 @@ GlobalInverseKinematics::ReconstructGeneralizedPositionSolution() const {
   return q;
 }
 
-void GlobalInverseKinematics::AddWorldPositionConstraint(
+solvers::Binding<solvers::LinearConstraint>
+GlobalInverseKinematics::AddWorldPositionConstraint(
     int body_idx, const Eigen::Vector3d& p_BQ, const Eigen::Vector3d& box_lb_F,
     const Eigen::Vector3d& box_ub_F, const Isometry3d& X_WF) {
   Vector3<Expression> body_pt_pos =
@@ -302,12 +303,12 @@ void GlobalInverseKinematics::AddWorldPositionConstraint(
   Vector3<Expression> body_pt_in_measured_frame =
       X_WF.linear().transpose() *
       (body_pt_pos - X_WF.translation());
-  AddLinearConstraint(body_pt_in_measured_frame, box_lb_F, box_ub_F);
+  return AddLinearConstraint(body_pt_in_measured_frame, box_lb_F, box_ub_F);
 }
 
-void GlobalInverseKinematics::AddWorldOrientationConstraint(
-    int body_idx,
-    const Eigen::Quaterniond& desired_orientation,
+solvers::Binding<solvers::LinearConstraint>
+GlobalInverseKinematics::AddWorldOrientationConstraint(
+    int body_idx, const Eigen::Quaterniond& desired_orientation,
     double angle_tol) {
   // The rotation matrix error R_e satisfies
   // trace(R_e) = 2 * cos(θ) + 1, where θ is the rotation angle between
@@ -316,7 +317,7 @@ void GlobalInverseKinematics::AddWorldOrientationConstraint(
   Matrix3<Expression> rotation_matrix_err =
   desired_orientation.toRotationMatrix() * R_WB_[body_idx].transpose();
   double lb = angle_tol < M_PI ? 2 * cos(angle_tol) + 1 : -1;
-  AddLinearConstraint(rotation_matrix_err.trace(), lb, 3);
+  return AddLinearConstraint(rotation_matrix_err.trace(), lb, 3);
 }
 
 void GlobalInverseKinematics::AddPostureCost(

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -121,7 +121,7 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    *   - p_WFo is the position of frame `F`'s origin, expressed and measured in
    *     frame `W`. `p_WFo = X_WF.translation()`.
    * @default is the identity transform.
-   * @retval binding The newly added constraint, together with the bounded
+   * @retval binding The newly added constraint, together with the bound
    * variables.
    */
   solvers::Binding<solvers::LinearConstraint> AddWorldPositionConstraint(
@@ -149,7 +149,7 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * @param desired_orientation The desired orientation of the body.
    * @param angle_tol The tolerance on the angle between the body orientation
    * and the desired orientation. Unit is radians.
-   * @retval binding The newly added constraint, together with the bounded
+   * @retval binding The newly added constraint, together with the bound
    * variables.
    */
   solvers::Binding<solvers::LinearConstraint> AddWorldOrientationConstraint(

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -121,12 +121,13 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    *   - p_WFo is the position of frame `F`'s origin, expressed and measured in
    *     frame `W`. `p_WFo = X_WF.translation()`.
    * @default is the identity transform.
+   * @retval binding The newly added constraint, together with the bounded
+   * variables.
    */
-  void AddWorldPositionConstraint(int body_idx, const Eigen::Vector3d& p_BQ,
-                                  const Eigen::Vector3d& box_lb_F,
-                                  const Eigen::Vector3d& box_ub_F,
-                                  const Eigen::Isometry3d& X_WF =
-                                      Eigen::Isometry3d::Identity());
+  solvers::Binding<solvers::LinearConstraint> AddWorldPositionConstraint(
+      int body_idx, const Eigen::Vector3d& p_BQ,
+      const Eigen::Vector3d& box_lb_F, const Eigen::Vector3d& box_ub_F,
+      const Eigen::Isometry3d& X_WF = Eigen::Isometry3d::Identity());
 
   /**
    * Add a constraint that the angle between the body orientation and the
@@ -148,8 +149,10 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * @param desired_orientation The desired orientation of the body.
    * @param angle_tol The tolerance on the angle between the body orientation
    * and the desired orientation. Unit is radians.
+   * @retval binding The newly added constraint, together with the bounded
+   * variables.
    */
-  void AddWorldOrientationConstraint(
+  solvers::Binding<solvers::LinearConstraint> AddWorldOrientationConstraint(
       int body_idx, const Eigen::Quaterniond& desired_orientation,
       double angle_tol);
 

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -882,8 +882,7 @@ void AddNotInSameOrOppositeOrthantConstraint(
 }
 }  // namespace
 
-std::pair<std::vector<MatrixDecisionVariable<3, 3>>,
-          std::vector<MatrixDecisionVariable<3, 3>>>
+AddRotationMatrixMcCormickEnvelopeReturnType
 AddRotationMatrixMcCormickEnvelopeMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
@@ -899,90 +898,93 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   };
 
   // Creates binary decision variables which discretize each axis.
-  //   Bpos[k](i,j) = 1 <=> R(i,j) >= phi(k)
-  //   Bneg[k](i,j) = 1 <=> R(i,j) <= -phi(k)
+  //   BRpos[k](i,j) = 1 <=> R(i,j) >= phi(k)
+  //   BRneg[k](i,j) = 1 <=> R(i,j) <= -phi(k)
   //
   // For convenience, we introduce additional (continuous) variables to
   // represent the individual sections of the real line
-  //   Cpos[k](i,j) = Bpos[k](i,j) if k=N-1, otherwise
-  //   Cpos[k](i,j) = Bpos[k](i,j) - Bpos[k+1](i,j)
+  //   CRpos[k](i,j) = BRpos[k](i,j) if k=N-1, otherwise
+  //   CRpos[k](i,j) = BRpos[k](i,j) - BRpos[k+1](i,j)
   // This is useful only because the *number of decision variables* that we
   // pass into the constraints changes for the k=N-1 case.  Otherwise we
   // could do a simple substitution everywhere.
   // TODO(russt): Use symbolic constraints and remove these decision variables!
-  std::vector<MatrixDecisionVariable<3, 3>> Bpos, Bneg;
-  std::vector<MatrixDecisionVariable<3, 3>> Cpos, Cneg;
+  std::vector<MatrixDecisionVariable<3, 3>> BRpos, BRneg;
+  std::vector<MatrixDecisionVariable<3, 3>> CRpos, CRneg;
   for (int k = 0; k < num_binary_vars_per_half_axis; k++) {
-    Bpos.push_back(prog->NewBinaryVariables<3, 3>("BRpos" + std::to_string(k)));
-    Bneg.push_back(prog->NewBinaryVariables<3, 3>("BRneg" + std::to_string(k)));
-    Cpos.push_back(
+    BRpos.push_back(
+        prog->NewBinaryVariables<3, 3>("BRpos" + std::to_string(k)));
+    BRneg.push_back(
+        prog->NewBinaryVariables<3, 3>("BRneg" + std::to_string(k)));
+    CRpos.push_back(
         prog->NewContinuousVariables<3, 3>("CRpos" + std::to_string(k)));
-    Cneg.push_back(
+    CRneg.push_back(
         prog->NewContinuousVariables<3, 3>("CRneg" + std::to_string(k)));
   }
 
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       for (int k = 0; k < num_binary_vars_per_half_axis; k++) {
-        // R(i,j) > phi(k) => Bpos[k](i,j) = 1
-        // R(i,j) < phi(k) => Bpos[k](i,j) = 0
-        // R(i,j) = phi(k) => Bpos[k](i,j) = 0 or 1
+        // R(i,j) > phi(k) => BRpos[k](i,j) = 1
+        // R(i,j) < phi(k) => BRpos[k](i,j) = 0
+        // R(i,j) = phi(k) => BRpos[k](i,j) = 0 or 1
         // Since -s1 <= R(i, j) - phi(k) <= s2,
         // where s1 = 1 + phi(k), s2 = 1 - phi(k). The point
-        // [R(i,j) - phi(k), Bpos[k](i,j)] has to lie within the convex hull,
+        // [R(i,j) - phi(k), BRpos[k](i,j)] has to lie within the convex hull,
         // whose vertices are (-s1, 0), (0, 0), (s2, 1), (0, 1). By computing
         // the edges of this convex hull, we get
-        // -s1 + s1*Bpos[k](i,j) <= R(i,j)-phi(k) <= s2 * Bpos[k](i,j)
+        // -s1 + s1*BRpos[k](i,j) <= R(i,j)-phi(k) <= s2 * BRpos[k](i,j)
         double s1 = 1 + phi(k);
         double s2 = 1 - phi(k);
-        prog->AddLinearConstraint(R(i, j) - phi(k) >= -s1 + s1 * Bpos[k](i, j));
-        prog->AddLinearConstraint(R(i, j) - phi(k) <= s2 * Bpos[k](i, j));
+        prog->AddLinearConstraint(R(i, j) - phi(k) >=
+                                  -s1 + s1 * BRpos[k](i, j));
+        prog->AddLinearConstraint(R(i, j) - phi(k) <= s2 * BRpos[k](i, j));
 
-        // -R(i,j) > phi(k) => Bneg[k](i,j) = 1
-        // -R(i,j) < phi(k) => Bneg[k](i,j) = 0
-        // -R(i,j) = phi(k) => Bneg[k](i,j) = 0 or 1
+        // -R(i,j) > phi(k) => BRneg[k](i,j) = 1
+        // -R(i,j) < phi(k) => BRneg[k](i,j) = 0
+        // -R(i,j) = phi(k) => BRneg[k](i,j) = 0 or 1
         // Since -s2 <= R(i, j) + phi(k) <= s1,
         // where s1 = 1 + phi(k), s2 = 1 - phi(k). The point
-        // [R(i,j) + phi(k), Bneg[k](i,j)] has to lie within the convex hull
+        // [R(i,j) + phi(k), BRneg[k](i,j)] has to lie within the convex hull
         // whose vertices are (-s2, 1), (0, 0), (s1, 0), (0, 1). By computing
         // the edges of the convex hull, we get
-        // -s2 * Bneg[k](i,j) <= R(i,j)+phi(k) <= s1-s1*Bneg[k](i,j)
-        prog->AddLinearConstraint(R(i, j) + phi(k) <= s1 - s1 * Bneg[k](i, j));
-        prog->AddLinearConstraint(R(i, j) + phi(k) >= -s2 * Bneg[k](i, j));
+        // -s2 * BRneg[k](i,j) <= R(i,j)+phi(k) <= s1-s1*BRneg[k](i,j)
+        prog->AddLinearConstraint(R(i, j) + phi(k) <= s1 - s1 * BRneg[k](i, j));
+        prog->AddLinearConstraint(R(i, j) + phi(k) >= -s2 * BRneg[k](i, j));
 
         if (k == num_binary_vars_per_half_axis - 1) {
-          //   Cpos[k](i,j) = Bpos[k](i,j)
-          prog->AddLinearConstraint(Cpos[k](i, j) == Bpos[k](i, j));
+          //   CRpos[k](i,j) = BRpos[k](i,j)
+          prog->AddLinearConstraint(CRpos[k](i, j) == BRpos[k](i, j));
 
-          //   Cneg[k](i,j) = Bneg[k](i,j)
-          prog->AddLinearConstraint(Cneg[k](i, j) == Bneg[k](i, j));
+          //   CRneg[k](i,j) = BRneg[k](i,j)
+          prog->AddLinearConstraint(CRneg[k](i, j) == BRneg[k](i, j));
         } else {
-          //   Cpos[k](i,j) = Bpos[k](i,j) - Bpos[k+1](i,j)
-          prog->AddLinearConstraint(Cpos[k](i, j) ==
-                                    Bpos[k](i, j) - Bpos[k + 1](i, j));
-          //   Cneg[k](i,j) = Bneg[k](i,j) - Bneg[k+1](i,j)
-          prog->AddLinearConstraint(Cneg[k](i, j) ==
-                                    Bneg[k](i, j) - Bneg[k + 1](i, j));
+          //   CRpos[k](i,j) = BRpos[k](i,j) - BRpos[k+1](i,j)
+          prog->AddLinearConstraint(CRpos[k](i, j) ==
+                                    BRpos[k](i, j) - BRpos[k + 1](i, j));
+          //   CRneg[k](i,j) = BRneg[k](i,j) - BRneg[k+1](i,j)
+          prog->AddLinearConstraint(CRneg[k](i, j) ==
+                                    BRneg[k](i, j) - BRneg[k + 1](i, j));
         }
       }
       // R(i,j) has to pick a side, either non-positive or non-negative.
-      prog->AddLinearConstraint(Bpos[0](i, j) + Bneg[0](i, j) == 1);
+      prog->AddLinearConstraint(BRpos[0](i, j) + BRneg[0](i, j) == 1);
 
       // for debugging: constrain to positive orthant.
-      //      prog->AddBoundingBoxConstraint(1,1,{Bpos[0].block<1,1>(i,j)});
+      //      prog->AddBoundingBoxConstraint(1,1,{BRpos[0].block<1,1>(i,j)});
     }
   }
 
   // Add constraint that no two rows (or two columns) can lie in the same
   // orthant (or opposite orthant).
-  AddNotInSameOrOppositeOrthantConstraint(prog, Bpos[0], Bneg[0]);
-  AddNotInSameOrOppositeOrthantConstraint(prog, Bpos[0].transpose(),
-                                          Bneg[0].transpose());
+  AddNotInSameOrOppositeOrthantConstraint(prog, BRpos[0], BRneg[0]);
+  AddNotInSameOrOppositeOrthantConstraint(prog, BRpos[0].transpose(),
+                                          BRneg[0].transpose());
 
   // Add angle limit constraints.
   // Bounding box will turn on/off an orthant.  It's sufficient to add the
   // constraints only to the positive orthant.
-  AddBoundingBoxConstraintsImpliedByRollPitchYawLimitsToBinary(prog, Bpos[0],
+  AddBoundingBoxConstraintsImpliedByRollPitchYawLimitsToBinary(prog, BRpos[0],
                                                                limits);
 
   // Add constraints to the column and row vectors.
@@ -991,24 +993,24 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   for (int i = 0; i < 3; i++) {
     // Make lists of the decision variables in terms of column vectors and row
     // vectors to facilitate the calls below.
-    // TODO(russt): Consider reorganizing the original Cpos/Cneg variables to
+    // TODO(russt): Consider reorganizing the original CRpos/CRneg variables to
     // avoid this (albeit minor) cost?
     for (int k = 0; k < num_binary_vars_per_half_axis; k++) {
-      cpos[k] = Cpos[k].col(i);
-      cneg[k] = Cneg[k].col(i);
+      cpos[k] = CRpos[k].col(i);
+      cneg[k] = CRneg[k].col(i);
     }
     AddMcCormickVectorConstraints(prog, R.col(i), cpos, cneg,
                                   R.col((i + 1) % 3), R.col((i + 2) % 3));
 
     for (int k = 0; k < num_binary_vars_per_half_axis; k++) {
-      cpos[k] = Cpos[k].row(i).transpose();
-      cneg[k] = Cneg[k].row(i).transpose();
+      cpos[k] = CRpos[k].row(i).transpose();
+      cneg[k] = CRneg[k].row(i).transpose();
     }
     AddMcCormickVectorConstraints(prog, R.row(i).transpose(), cpos, cneg,
                                   R.row((i + 1) % 3).transpose(),
                                   R.row((i + 2) % 3).transpose());
   }
-  return make_pair(Cpos, Cneg);
+  return make_tuple(CRpos, CRneg, BRpos, BRneg);
 }
 
 }  // namespace solvers

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -898,8 +898,8 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   };
 
   // Creates binary decision variables which discretize each axis.
-  //   BRpos[k](i,j) = 1 <=> R(i,j) >= phi(k)
-  //   BRneg[k](i,j) = 1 <=> R(i,j) <= -phi(k)
+  //   BRpos[k](i,j) = 1 => R(i,j) >= phi(k)
+  //   BRneg[k](i,j) = 1 => R(i,j) <= -phi(k)
   //
   // For convenience, we introduce additional (continuous) variables to
   // represent the individual sections of the real line

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -90,6 +90,11 @@ void AddRotationMatrixOrthonormalSocpConstraint(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R);
 
+using AddRotationMatrixMcCormickEnvelopeReturnType =
+std::tuple<std::vector<MatrixDecisionVariable<3, 3>>,
+           std::vector<MatrixDecisionVariable<3, 3>>,
+           std::vector<MatrixDecisionVariable<3, 3>>,
+           std::vector<MatrixDecisionVariable<3, 3>>>;
 /**
  * Adds binary variables that constrain the value of the column *and* row
  * vectors of R, in order to add the following (in some cases non-convex)
@@ -134,11 +139,6 @@ void AddRotationMatrixOrthonormalSocpConstraint(
  * </pre>
  * where `N` is `num_binary_vars_per_half_axis`.
  */
-using AddRotationMatrixMcCormickEnvelopeReturnType =
-std::tuple<std::vector<MatrixDecisionVariable<3, 3>>,
-           std::vector<MatrixDecisionVariable<3, 3>>,
-           std::vector<MatrixDecisionVariable<3, 3>>,
-           std::vector<MatrixDecisionVariable<3, 3>>>;
 
 AddRotationMatrixMcCormickEnvelopeReturnType
 AddRotationMatrixMcCormickEnvelopeMilpConstraints(

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -130,7 +130,7 @@ void AddRotationMatrixOrthonormalSocpConstraint(
  *   CRpos[k](i, j) = 1 => k / N <= R(i, j) <= (k+1) / N
  *   CRneg[k](i, j) = 1 => -(k+1) / N <= R(i, j) <= -k / N
  *   BRpos[k](i, j) = 1 => R(i, j) >= k / N
- *   BRneg[k](i, j) = 1 => R(i, j) <= -k / n
+ *   BRneg[k](i, j) = 1 => R(i, j) <= -k / N
  * </pre>
  * where `N` is `num_binary_vars_per_half_axis`.
  */

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -120,17 +121,26 @@ void AddRotationMatrixOrthonormalSocpConstraint(
  * axis.
  * @param limits The angle joints for space fixed z-y-x representation of the
  * rotation. @default is no constraint. @see RollPitchYawLimitOptions
- * @retval p  `p.first` is the variables CRpos, `p.second` is the
- * variables CRneg. Both variables can only take values either 0 or 1.
+ * @retval NewVars  Included the newly added variables
+ * <CRpos, CRneg, BRpos, BRneg>. All new variables can only take values either
+ * 0 or 1. `CRpos` and `CRneg` are declared as continuous variables, while
+ * `BRpos` and `BRneg` are declared as binary variables.
  * The definition for these variables are
  * <pre>
  *   CRpos[k](i, j) = 1 => k / N <= R(i, j) <= (k+1) / N
  *   CRneg[k](i, j) = 1 => -(k+1) / N <= R(i, j) <= -k / N
+ *   BRpos[k](i, j) = 1 => R(i, j) >= k / N
+ *   BRneg[k](i, j) = 1 => R(i, j) <= -k / n
  * </pre>
  * where `N` is `num_binary_vars_per_half_axis`.
  */
-std::pair<std::vector<MatrixDecisionVariable<3, 3>>,
-          std::vector<MatrixDecisionVariable<3, 3>>>
+using AddRotationMatrixMcCormickEnvelopeReturnType =
+std::tuple<std::vector<MatrixDecisionVariable<3, 3>>,
+           std::vector<MatrixDecisionVariable<3, 3>>,
+           std::vector<MatrixDecisionVariable<3, 3>>,
+           std::vector<MatrixDecisionVariable<3, 3>>>;
+
+AddRotationMatrixMcCormickEnvelopeReturnType
 AddRotationMatrixMcCormickEnvelopeMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -626,10 +626,8 @@ class TestMcCormickCorner
       col_idx_(std::get<2>(GetParam())) {
     DRAKE_DEMAND(orthant_ >= 0);
     DRAKE_DEMAND(orthant_ <= 7);
-    const auto Cpos_Cneg_Bpos_Bneg =
+    std::tie(Cpos_, Cneg_, std::ignore, std::ignore) =
         AddRotationMatrixMcCormickEnvelopeMilpConstraints(&prog_, R_, 3);
-    Cpos_ = std::get<0>(Cpos_Cneg_Bpos_Bneg);
-    Cneg_ = std::get<1>(Cpos_Cneg_Bpos_Bneg);
   }
 
   ~TestMcCormickCorner() override {}

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -626,10 +626,10 @@ class TestMcCormickCorner
       col_idx_(std::get<2>(GetParam())) {
     DRAKE_DEMAND(orthant_ >= 0);
     DRAKE_DEMAND(orthant_ <= 7);
-    const auto Cpos_Cneg =
+    const auto Cpos_Cneg_Bpos_Bneg =
         AddRotationMatrixMcCormickEnvelopeMilpConstraints(&prog_, R_, 3);
-    Cpos_ = Cpos_Cneg.first;
-    Cneg_ = Cpos_Cneg.second;
+    Cpos_ = std::get<0>(Cpos_Cneg_Bpos_Bneg);
+    Cneg_ = std::get<1>(Cpos_Cneg_Bpos_Bneg);
   }
 
   ~TestMcCormickCorner() override {}


### PR DESCRIPTION
1. Return `Binding<LinearConstraint>` for the added position and orientation constraint in global IK, so that we can update the constraint later.
2. Add a call to nonlinear IK for the infeasibility test in global IK test.
3. Split global_inverse_kinematics_test.cc to avoid the test taking too much time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5811)
<!-- Reviewable:end -->
