### PR TITLE
[WIP] Separate output ports (discussion only)

### DIFF
--- a/drake/automotive/car_vis_applicator.h
+++ b/drake/automotive/car_vis_applicator.h
@@ -54,8 +54,7 @@ class CarVisApplicator : public systems::LeafSystem<T> {
 
   /// Returns a descriptor of the output port that contains the visual geometry
   /// poses of all vehicle visualizations.
-  const systems::OutputPortDescriptor<T>&
-  get_visual_geometry_poses_output_port() const;
+  const systems::OutputPort<T>& get_visual_geometry_poses_output_port() const;
 
   /// Adds a CarVis object for a vehicle. The ID returned by CarVis::id() must
   /// be unique among the CarVis objects added to this method. A
@@ -75,11 +74,9 @@ class CarVisApplicator : public systems::LeafSystem<T> {
   /// Returns the total number of poses of bodies being visualized.
   int num_vis_poses() const;
 
- protected:
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
  private:
+  std::unique_ptr<systems::AbstractValue> AllocatePoseBundleOutput() const;
+
   void DoCalcOutput(const systems::Context<T>& context,
                     systems::SystemOutput<T>* output) const override;
 

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -73,6 +73,7 @@ set(installed_headers
   text_logging.h
   text_logging_gflags.h
   trig_poly.h
+  type_safe_index.h
   unused.h
   )
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.cc
@@ -15,7 +15,9 @@ namespace qp_inverse_dynamics {
 AtlasJointLevelControllerSystem::AtlasJointLevelControllerSystem(
     const RigidBodyTree<double>& robot)
     : JointLevelControllerBaseSystem(robot) {
-  output_port_index_atlas_cmd_ = DeclareAbstractOutputPort().get_index();
+  output_port_index_atlas_cmd_ =
+      DeclareAbstractOutputPort(systems::Value<bot_core::atlas_command_t>())
+          .get_index();
 
   // TODO(siyuan.feng): Load gains from some config.
   const int act_size = get_robot().get_num_actuators();
@@ -77,15 +79,6 @@ void AtlasJointLevelControllerSystem::DoCalcExtendedOutput(
   // deprecated simulation as well.
   // Consider removing this from atlas_command_t.
   msg.desired_controller_period_ms = 0;
-}
-
-std::unique_ptr<systems::AbstractValue>
-AtlasJointLevelControllerSystem::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  DRAKE_DEMAND(output_port_index_atlas_cmd_ == descriptor.get_index());
-
-  return systems::AbstractValue::Make<bot_core::atlas_command_t>(
-      bot_core::atlas_command_t());
 }
 
 }  // namespace qp_inverse_dynamics

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h
@@ -24,9 +24,6 @@ class AtlasJointLevelControllerSystem : public JointLevelControllerBaseSystem {
    */
   explicit AtlasJointLevelControllerSystem(const RigidBodyTree<double>& robot);
 
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
   /**
    * Returns the output port for bot_core::atlas_command_t.
    */

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.cc
@@ -38,13 +38,6 @@ void HumanoidPlanEvalSystem::DoExtendedCalcOutput(
     const systems::Context<double>& context,
     systems::SystemOutput<double>* output) const {}
 
-std::unique_ptr<systems::AbstractValue>
-HumanoidPlanEvalSystem::ExtendedAllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  DRAKE_ABORT_MSG(
-      "HumanoidPlanEvalSystem does not have additional abstract output ports.");
-}
-
 void HumanoidPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     systems::State<double>* state) const {

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.h
@@ -53,9 +53,6 @@ class HumanoidPlanEvalSystem : public PlanEvalBaseSystem {
       const systems::Context<double>& context,
       systems::SystemOutput<double>* output) const override;
 
-  std::unique_ptr<systems::AbstractValue> ExtendedAllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
   int abs_state_index_plan_{};
 };
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.cc
@@ -12,14 +12,14 @@ namespace qp_inverse_dynamics {
 HumanoidStatusTranslatorSystem::HumanoidStatusTranslatorSystem(
     const RigidBodyTree<double>& robot, const std::string& alias_group_path)
     : robot_(robot), alias_group_path_(alias_group_path) {
-  output_port_index_humanoid_status_ = DeclareAbstractOutputPort().get_index();
+  output_port_index_humanoid_status_ = DeclareAbstractOutputPort(
+      [this](const systems::Context<double>*) {
+        return this->AllocateOutputPort();
+      }).get_index();
 }
 
 std::unique_ptr<systems::AbstractValue>
-HumanoidStatusTranslatorSystem::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  DRAKE_DEMAND(descriptor.get_index() == output_port_index_humanoid_status_);
-
+HumanoidStatusTranslatorSystem::AllocateOutputPort() const {
   param_parsers::RigidBodyTreeAliasGroups<double> alias_groups(robot_);
   alias_groups.LoadFromFile(alias_group_path_);
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_status_translator_system.h
@@ -30,9 +30,6 @@ class HumanoidStatusTranslatorSystem : public systems::LeafSystem<double> {
   HumanoidStatusTranslatorSystem(const RigidBodyTree<double>& robot,
                                  const std::string& alias_group_path);
 
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
   /**
    * Returns the output port for HumanoidStatus.
    */
@@ -49,6 +46,8 @@ class HumanoidStatusTranslatorSystem : public systems::LeafSystem<double> {
   inline const RigidBodyTree<double>& get_robot() const { return robot_; }
 
  private:
+  std::unique_ptr<systems::AbstractValue> AllocateOutputPort() const;
+
   const RigidBodyTree<double>& robot_;
   const std::string alias_group_path_;
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.cc
@@ -27,7 +27,8 @@ ManipulatorPlanEvalSystem::ManipulatorPlanEvalSystem(
   input_port_index_desired_acceleration_ =
       DeclareInputPort(systems::kVectorValued, kAccDim).get_index();
 
-  output_port_index_debug_info_ = DeclareAbstractOutputPort().get_index();
+  output_port_index_debug_info_ = DeclareAbstractOutputPort(
+      systems::Value<lcmt_plan_eval_debug_info>()).get_index();
   set_name("ManipulatorPlanEvalSystem");
 
   abs_state_index_plan_ =
@@ -116,18 +117,6 @@ void ManipulatorPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
     debug.nominal_v[i] = plan.desired_velocity()[i];
     debug.nominal_vd[i] = plan.desired_acceleration()[i];
   }
-}
-
-std::unique_ptr<systems::AbstractValue>
-ManipulatorPlanEvalSystem::ExtendedAllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  if (descriptor.get_index() == output_port_index_debug_info_) {
-    return systems::AbstractValue::Make<lcmt_plan_eval_debug_info>(
-        lcmt_plan_eval_debug_info());
-  }
-  std::string msg = "ManipulatorPlanEvalSystem does not have outputport " +
-                    std::to_string(descriptor.get_index());
-  DRAKE_ABORT_MSG(msg.c_str());
 }
 
 }  // namespace qp_inverse_dynamics

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/manipulator_plan_eval_system.h
@@ -81,9 +81,6 @@ class ManipulatorPlanEvalSystem : public PlanEvalBaseSystem {
       const systems::Context<double>& context,
       systems::SystemOutput<double>* output) const override;
 
-  std::unique_ptr<systems::AbstractValue> ExtendedAllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
   int input_port_index_desired_state_{};
   int input_port_index_desired_acceleration_{};
   int output_port_index_debug_info_{};

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_base_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_base_system.cc
@@ -20,7 +20,9 @@ PlanEvalBaseSystem::PlanEvalBaseSystem(
   DRAKE_DEMAND(control_dt_ > 0);
 
   input_port_index_humanoid_status_ = DeclareAbstractInputPort().get_index();
-  output_port_index_qp_input_ = DeclareAbstractOutputPort().get_index();
+  output_port_index_qp_input_ =
+      DeclareAbstractOutputPort(systems::Value<QpInput>(GetDofNames(robot_)))
+          .get_index();
 
   // Declares discrete time update.
   DeclarePeriodicUnrestrictedUpdate(control_dt_, 0);
@@ -46,16 +48,6 @@ void PlanEvalBaseSystem::DoCalcOutput(
 
   // Does extended CalcOutput.
   DoExtendedCalcOutput(context, output);
-}
-
-std::unique_ptr<systems::AbstractValue>
-PlanEvalBaseSystem::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  if (descriptor.get_index() == output_port_index_qp_input_) {
-    return systems::AbstractValue::Make<QpInput>(QpInput(GetDofNames(robot_)));
-  } else {
-    return ExtendedAllocateOutputAbstract(descriptor);
-  }
 }
 
 }  // namespace qp_inverse_dynamics

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_base_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/plan_eval_base_system.h
@@ -39,15 +39,6 @@ class PlanEvalBaseSystem : public systems::LeafSystem<double> {
                      const std::string& param_file_name, double dt);
 
   /**
-   * Allocates abstract value types for output @p descriptor. This function
-   * allocates QpInput when @p matches the port for QpInput, and calls
-   * ExtendedAllocateOutputAbstract() to allocate all the other derived class'
-   * custom output types.
-   */
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const final;
-
-  /**
    * Copies QpInput from abstract state to the corresponding output port. Then
    * calls DoExtendedCalcOutput() to handle all the other derived class' custom
    * outputs.
@@ -112,13 +103,6 @@ class PlanEvalBaseSystem : public systems::LeafSystem<double> {
   virtual void DoExtendedCalcOutput(
       const systems::Context<double>& context,
       systems::SystemOutput<double>* output) const = 0;
-
-  /**
-   * Derived classes need to implement this to allocate custom outputs.
-   */
-  virtual std::unique_ptr<systems::AbstractValue>
-  ExtendedAllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const = 0;
 
   /**
    * Derived classes need to implement this for custom behaviors.

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.cc
@@ -27,8 +27,10 @@ QpControllerSystem::QpControllerSystem(const RigidBodyTree<double>& robot,
     : robot_(robot), control_dt_(dt) {
   input_port_index_humanoid_status_ = DeclareAbstractInputPort().get_index();
   input_port_index_qp_input_ = DeclareAbstractInputPort().get_index();
-  output_port_index_qp_output_ = DeclareAbstractOutputPort().get_index();
-  output_port_index_debug_info_ = DeclareAbstractOutputPort().get_index();
+  output_port_index_qp_output_ = DeclareAbstractOutputPort(
+      systems::Value<QpOutput>(GetDofNames(robot_))).get_index();
+  output_port_index_debug_info_ = DeclareAbstractOutputPort(
+      systems::Value<lcmt_inverse_dynamics_debug_info>()).get_index();
 
   set_name("QpControllerSystem");
   DeclarePeriodicUnrestrictedUpdate(control_dt_, 0);
@@ -93,21 +95,6 @@ void QpControllerSystem::DoCalcUnrestrictedUpdate(
     debug.desired_vd[i] = qp_input->desired_dof_motions().value(i);
     debug.solved_vd[i] = qp_output.vd()[i];
     debug.solved_torque[i] = qp_output.dof_torques()[i];
-  }
-}
-
-std::unique_ptr<systems::AbstractValue>
-QpControllerSystem::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  if (descriptor.get_index() == output_port_index_qp_output_) {
-    return systems::AbstractValue::Make<QpOutput>(
-        QpOutput(GetDofNames(robot_)));
-  } else if (descriptor.get_index() == output_port_index_debug_info_) {
-    return systems::AbstractValue::Make<lcmt_inverse_dynamics_debug_info>(
-        lcmt_inverse_dynamics_debug_info());
-  } else {
-    DRAKE_DEMAND(false);
-    return nullptr;
   }
 }
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/qp_controller_system.h
@@ -29,9 +29,6 @@ class QpControllerSystem : public systems::LeafSystem<double> {
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
 
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
   void DoCalcUnrestrictedUpdate(const systems::Context<double>& context,
                                 systems::State<double>* state) const override;
 

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.cc
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.cc
@@ -10,10 +10,10 @@ ActuatorEffortToRigidBodyPlantInputConverter<T>::
     : ordered_actuators_(ordered_actuators),
       effort_ports_indices_(DeclareEffortInputPorts(ordered_actuators)),
       rigid_body_plant_input_port_index_(
-          DeclareOutputPort(kVectorValued,
-                            static_cast<int>(ordered_actuators.size()))
+          this->DeclareOutputPort(kVectorValued,
+                                  static_cast<int>(ordered_actuators.size()))
               .get_index()) {
-  set_name("ActuatorEffortToRigidBodyPlantInputConverter");
+  this->set_name("ActuatorEffortToRigidBodyPlantInputConverter");
 }
 
 template <typename T>
@@ -22,7 +22,7 @@ void ActuatorEffortToRigidBodyPlantInputConverter<T>::DoCalcOutput(
   int index = 0;
   for (const auto& actuator : ordered_actuators_) {
     int port_index = effort_ports_indices_.at(actuator);
-    T effort = EvalVectorInput(context, port_index)->get_value()[0];
+    T effort = this->EvalVectorInput(context, port_index)->get_value()[0];
     output->GetMutableVectorData(rigid_body_plant_input_port_index_)
         ->SetAtIndex(index++, effort);
   }
@@ -37,7 +37,8 @@ ActuatorEffortToRigidBodyPlantInputConverter<T>::DeclareEffortInputPorts(
   // Currently, all RigidBodyActuators are assumed to be one-dimensional.
   const int effort_length = 1;
   for (const auto& actuator : ordered_actuators) {
-    ret[actuator] = DeclareInputPort(kVectorValued, effort_length).get_index();
+    ret[actuator] =
+        this->DeclareInputPort(kVectorValued, effort_length).get_index();
   }
   return ret;
 }
@@ -45,7 +46,7 @@ ActuatorEffortToRigidBodyPlantInputConverter<T>::DeclareEffortInputPorts(
 template <typename T>
 const InputPortDescriptor<T>& ActuatorEffortToRigidBodyPlantInputConverter<
     T>::effort_input_port(const RigidBodyActuator& actuator) {
-  return get_input_port(effort_ports_indices_.at(&actuator));
+  return this->get_input_port(effort_ports_indices_.at(&actuator));
 }
 
 // Explicit instantiations.

--- a/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
+++ b/drake/examples/Valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
@@ -12,12 +12,6 @@ namespace systems {
 template <typename T>
 class ActuatorEffortToRigidBodyPlantInputConverter : public LeafSystem<T> {
  public:
-  using System<T>::DeclareInputPort;
-  using System<T>::DeclareOutputPort;
-  using System<T>::set_name;
-  using System<T>::EvalVectorInput;
-  using System<T>::get_input_port;
-
   ActuatorEffortToRigidBodyPlantInputConverter(
       const std::vector<const RigidBodyActuator*>& ordered_actuators);
 

--- a/drake/examples/Valkyrie/robot_state_decoder.cc
+++ b/drake/examples/Valkyrie/robot_state_decoder.cc
@@ -34,7 +34,10 @@ RobotStateDecoder::RobotStateDecoder(const RigidBodyTree<double>& tree)
                          ? tree.bodies[1].get()
                          : nullptr),
       robot_state_message_port_index_(DeclareAbstractInputPort().get_index()),
-      kinematics_cache_port_index_(DeclareAbstractOutputPort().get_index()),
+      kinematics_cache_port_index_(
+          DeclareAbstractOutputPort(
+              Value<KinematicsCache<double>>(tree_.CreateKinematicsCache()))
+              .get_index()),
       joint_name_to_body_(CreateJointNameToBodyMap(tree)) {
   set_name("RobotStateDecoder");
 }
@@ -160,12 +163,6 @@ void RobotStateDecoder::DoCalcOutput(const Context<double>& context,
 
   kinematics_cache.initialize(q, v);
   tree_.doKinematics(kinematics_cache, true);
-}
-
-std::unique_ptr<AbstractValue> RobotStateDecoder::AllocateOutputAbstract(
-    const OutputPortDescriptor<double>& output) const {
-  return std::make_unique<Value<KinematicsCache<double>>>(
-      tree_.CreateKinematicsCache());
 }
 
 std::map<std::string, const RigidBody<double>*>

--- a/drake/examples/Valkyrie/robot_state_decoder.h
+++ b/drake/examples/Valkyrie/robot_state_decoder.h
@@ -30,14 +30,10 @@ class RobotStateDecoder : public LeafSystem<double> {
 
   RobotStateDecoder& operator=(const RobotStateDecoder&) = delete;
 
- protected:
-  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
-      const OutputPortDescriptor<double>& descriptor) const override;
-
+ private:
   void DoCalcOutput(const Context<double>& context,
                     SystemOutput<double>* output) const override;
 
- private:
   std::map<std::string, const RigidBody<double>*> CreateJointNameToBodyMap(
       const RigidBodyTree<double>& tree);
 

--- a/drake/examples/Valkyrie/robot_state_encoder.cc
+++ b/drake/examples/Valkyrie/robot_state_encoder.cc
@@ -35,7 +35,8 @@ RobotStateEncoder::RobotStateEncoder(
       floating_body_(tree.bodies[1]->getJoint().is_floating()
                          ? tree.bodies[1].get()
                          : nullptr),
-      lcm_message_port_index_(DeclareAbstractOutputPort().get_index()),
+      lcm_message_port_index_(
+          DeclareAbstractOutputPort(Value<robot_state_t>()).get_index()),
       kinematics_results_port_index_(DeclareAbstractInputPort().get_index()),
       contact_results_port_index_(DeclareAbstractInputPort().get_index()),
       effort_port_indices_(DeclareEffortInputPorts()),
@@ -77,11 +78,6 @@ void RobotStateEncoder::DoCalcOutput(const Context<double>& context,
 
   SetStateAndEfforts(kinematics_results, context, &message);
   SetForceTorque(kinematics_results, contact_results, &message);
-}
-
-std::unique_ptr<AbstractValue> RobotStateEncoder::AllocateOutputAbstract(
-    const OutputPortDescriptor<double>& descriptor) const {
-  return make_unique<Value<robot_state_t>>(robot_state_t());
 }
 
 const OutputPortDescriptor<double>& RobotStateEncoder::lcm_message_port()

--- a/drake/examples/Valkyrie/robot_state_encoder.h
+++ b/drake/examples/Valkyrie/robot_state_encoder.h
@@ -54,10 +54,6 @@ class RobotStateEncoder final : public LeafSystem<double> {
   const InputPortDescriptor<double>& effort_port(
       const RigidBodyActuator& actuator) const;
 
- protected:
-  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
-      const OutputPortDescriptor<double>& descriptor) const override;
-
  private:
   void DoCalcOutput(const Context<double>& context,
                     SystemOutput<double>* output) const override;

--- a/drake/examples/Valkyrie/valkyrie_pd_ff_controller.cc
+++ b/drake/examples/Valkyrie/valkyrie_pd_ff_controller.cc
@@ -40,7 +40,8 @@ ValkyriePDAndFeedForwardController::ValkyriePDAndFeedForwardController(
       Kp_(Kp),
       Kd_(Kd) {
   input_port_index_kinematics_result_ = DeclareAbstractInputPort().get_index();
-  output_port_index_atlas_command_ = DeclareAbstractOutputPort().get_index();
+  output_port_index_atlas_command_ = DeclareAbstractOutputPort(
+      systems::Value<bot_core::atlas_command_t>()).get_index();
 
   if (!Kp_.allFinite())
     throw std::runtime_error("Invalid Kp.");

--- a/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
+++ b/drake/examples/Valkyrie/valkyrie_pd_ff_controller.h
@@ -29,13 +29,6 @@ class ValkyriePDAndFeedForwardController : public systems::LeafSystem<double> {
     return get_output_port(output_port_index_atlas_command_);
   }
 
- protected:
-  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
-      const OutputPortDescriptor<double>& descriptor) const override {
-    return std::make_unique<Value<bot_core::atlas_command_t>>(
-        bot_core::atlas_command_t());
-  }
-
  private:
   void DoCalcOutput(const Context<double>& context,
                     SystemOutput<double>* output) const override;

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/action_primitive_base.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/action_primitive_base.cc
@@ -19,7 +19,9 @@ namespace monolithic_pick_and_place {
 ActionPrimitive::ActionPrimitive(double desired_update_interval,
                                  unsigned int action_primitive_state_index)
     : action_primitive_state_index_(action_primitive_state_index),
-      status_output_port_(this->DeclareAbstractOutputPort().get_index()),
+      status_output_port_(this->DeclareAbstractOutputPort(
+          systems::Value<ActionPrimitiveState>(ActionPrimitiveState::WAITING))
+          .get_index()),
       update_interval_(desired_update_interval) {
   this->DeclarePeriodicUnrestrictedUpdate(update_interval_, 0);
 }
@@ -55,16 +57,6 @@ void ActionPrimitive::DoCalcOutput(
 
   // Call DoExtendedCalcOutput.
   DoExtendedCalcOutput(context, output);
-}
-
-std::unique_ptr<systems::AbstractValue> ActionPrimitive::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  if (descriptor.get_index() == status_output_port_) {
-    return systems::AbstractValue::Make<ActionPrimitiveState>(
-        ActionPrimitiveState::WAITING);
-  } else {
-    return ExtendedAllocateOutputAbstract(descriptor);
-  }
 }
 
 }  // namespace monolithic_pick_and_place

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/action_primitive_base.h
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/action_primitive_base.h
@@ -54,10 +54,6 @@ class ActionPrimitive : public systems::LeafSystem<double> {
   std::unique_ptr<systems::AbstractValues> AllocateAbstractState() const final;
 
   // LeafSystem override.
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const final;
-
-  // LeafSystem override.
   void SetDefaultState(const systems::Context<double>& context,
                        systems::State<double>* state) const final;
 
@@ -82,12 +78,6 @@ class ActionPrimitive : public systems::LeafSystem<double> {
   /// default state unique to the class.
   virtual void SetExtendedDefaultState(const systems::Context<double>& context,
                                        systems::State<double>* state) const = 0;
-
-  /// Derived class need to implement this. This method is used to allocate
-  /// the output unique to the derived class.
-  virtual std::unique_ptr<systems::AbstractValue>
-  ExtendedAllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const = 0;
 
   /// Derived class need to implement this. This method is used to specify the
   /// additional `AbstractState` of the derived class.

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/gripper_action.h
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/gripper_action.h
@@ -40,10 +40,6 @@ class GripperAction : public ActionPrimitive {
   std::vector<std::unique_ptr<systems::AbstractValue>>
   AllocateExtendedAbstractState() const override;
 
-  std::unique_ptr<systems::AbstractValue>
-  ExtendedAllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
   void SetExtendedDefaultState(
       const systems::Context<double>& context,
       systems::State<double>* state) const override;
@@ -57,6 +53,8 @@ class GripperAction : public ActionPrimitive {
       systems::State<double>* state) const override;
 
  private:
+  std::unique_ptr<systems::AbstractValue> AllocatePlanOutputPort() const;
+
   // InternalState relevant only to this primitive.
   struct InternalState;
 

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/iiwa_move.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/iiwa_move.cc
@@ -31,7 +31,9 @@ IiwaMove::IiwaMove(const RigidBodyTree<double>& iiwa,
                       1 /* action_primitive_state_index */),
       internal_state_index_(0),
       input_port_primitive_input_(this->DeclareAbstractInputPort().get_index()),
-      output_port_plan_(this->DeclareAbstractOutputPort().get_index()),
+      output_port_plan_(
+          this->DeclareAbstractOutputPort(systems::Value<robot_plan_t>())
+              .get_index()),
       iiwa_tree_(iiwa) {}
 
 std::vector<std::unique_ptr<systems::AbstractValue>>
@@ -39,16 +41,6 @@ IiwaMove::AllocateExtendedAbstractState() const {
   std::vector<std::unique_ptr<systems::AbstractValue>> return_value;
   return_value.push_back(std::unique_ptr<systems::AbstractValue>(
       new systems::Value<InternalState>(InternalState())));
-  return return_value;
-}
-
-std::unique_ptr<systems::AbstractValue>
-IiwaMove::ExtendedAllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  std::unique_ptr<systems::AbstractValue> return_value;
-  if (descriptor.get_index() == output_port_plan_) {
-    return_value = systems::AbstractValue::Make<robot_plan_t>(robot_plan_t());
-  }
   return return_value;
 }
 

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/iiwa_move.h
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/action_primitives/iiwa_move.h
@@ -39,9 +39,6 @@ class IiwaMove : public ActionPrimitive {
   std::vector<std::unique_ptr<systems::AbstractValue>>
   AllocateExtendedAbstractState() const final;
 
-  std::unique_ptr<systems::AbstractValue> ExtendedAllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
   void SetExtendedDefaultState(const systems::Context<double>& context,
                                systems::State<double>* state) const override;
 

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/state_machine_system.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/state_machine_system.cc
@@ -78,8 +78,13 @@ PickAndPlaceStateMachineSystem::PickAndPlaceStateMachineSystem(
   input_port_wsg_status_ = this->DeclareAbstractInputPort().get_index();
   input_port_wsg_action_status_ = this->DeclareAbstractInputPort().get_index();
   input_port_iiwa_action_status_ = this->DeclareAbstractInputPort().get_index();
-  output_port_iiwa_action_ = this->DeclareAbstractOutputPort().get_index();
-  output_port_wsg_action_ = this->DeclareAbstractOutputPort().get_index();
+  output_port_iiwa_action_ =
+      this->DeclareAbstractOutputPort(systems::Value<IiwaActionInput>())
+          .get_index();
+  output_port_wsg_action_ =
+      this->DeclareAbstractOutputPort(
+              systems::Value<GripperActionInput>(GripperActionInput::CLOSE))
+          .get_index();
   this->DeclarePeriodicUnrestrictedUpdate(update_interval, 0);
 }
 
@@ -89,21 +94,6 @@ PickAndPlaceStateMachineSystem::AllocateAbstractState() const {
   abstract_vals.push_back(std::unique_ptr<systems::AbstractValue>(
       new systems::Value<InternalState>(InternalState())));
   return std::make_unique<systems::AbstractValues>(std::move(abstract_vals));
-}
-
-std::unique_ptr<systems::AbstractValue>
-PickAndPlaceStateMachineSystem::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  std::unique_ptr<systems::AbstractValue> return_val;
-  /* allocate iiwa action and wsg output port */
-  if (descriptor.get_index() == output_port_iiwa_action_) {
-    return_val =
-        systems::AbstractValue::Make<IiwaActionInput>(IiwaActionInput());
-  } else if (descriptor.get_index() == output_port_wsg_action_) {
-    return_val = systems::AbstractValue::Make<GripperActionInput>(
-        GripperActionInput::CLOSE);
-  }
-  return return_val;
 }
 
 void PickAndPlaceStateMachineSystem::SetDefaultState(

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/state_machine_system.h
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/state_machine_system.h
@@ -37,15 +37,6 @@ class PickAndPlaceStateMachineSystem : public systems::LeafSystem<double> {
   std::unique_ptr<systems::AbstractValues> AllocateAbstractState()
       const override;
 
-  /**
-   * Allocates abstract value types for output @p descriptor. This function
-   * allocates `IiwaActionInput` when @p matches the port for
-   * `output_port_iiwa_action_`, and 'GripperActionInput` for
-   * `output_port_wsg_action_`.
-   */
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const final;
-
   // This kind of a system is not a direct feedthrough.
   bool DoHasDirectFeedthrough(const systems::SparsityMatrix* sparsity,
                               int input_port, int output_port) const final {

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/trajectory_generator_test.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/trajectory_generator_test.cc
@@ -50,8 +50,12 @@ class PlanSourceTester : public systems::LeafSystem<double> {
         plan_iiwa_joint_angles_(q),
         plan_wsg_positions_(wsg_positions),
         num_points_(time.size()),
-        output_port_iiwa_plan_(DeclareAbstractOutputPort().get_index()),
-        output_port_wsg_plan_(DeclareAbstractOutputPort().get_index()) {}
+        output_port_iiwa_plan_(
+            DeclareAbstractOutputPort(systems::Value<robot_plan_t>())
+                .get_index()),
+        output_port_wsg_plan_(
+            DeclareAbstractOutputPort(systems::Value<lcmt_schunk_wsg_command>())
+                .get_index()) {}
 
   const systems::OutputPortDescriptor<double>& get_output_port_iiwa_action()
       const {
@@ -63,24 +67,7 @@ class PlanSourceTester : public systems::LeafSystem<double> {
     return this->get_output_port(output_port_wsg_plan_);
   }
 
- protected:
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override {
-    std::unique_ptr<systems::AbstractValue> return_value;
-    std::unique_ptr<systems::AbstractValue> return_val;
-
-    /* allocate outputs for IiwaStateFeedbackPlanSource and
-     * SchunkWsgTrajectoryGenerator */
-    if (descriptor.get_index() == output_port_iiwa_plan_) {
-      return_val = systems::AbstractValue::Make<robot_plan_t>(robot_plan_t());
-    } else if (descriptor.get_index() == output_port_wsg_plan_) {
-      lcmt_schunk_wsg_command default_command;
-      return_val = systems::AbstractValue::Make<lcmt_schunk_wsg_command>(
-          default_command);
-    }
-    return return_val;
-  }
-
+ private:
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override {
     robot_plan_t& iiwa_action_output =
@@ -121,7 +108,6 @@ class PlanSourceTester : public systems::LeafSystem<double> {
     }
   }
 
- private:
   const RigidBodyTreed& iiwa_tree_;
   const std::vector<double> plan_time_;
   const std::vector<Eigen::VectorXd> plan_iiwa_joint_angles_;

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -79,14 +79,7 @@ IiwaCommandSender::IiwaCommandSender()
       torque_input_port_(
           this->DeclareInputPort(
               systems::kVectorValued, kNumJoints).get_index()) {
-  this->DeclareAbstractOutputPort();
-}
-
-std::unique_ptr<systems::AbstractValue>
-IiwaCommandSender::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  lcmt_iiwa_command msg{};
-  return std::make_unique<systems::Value<lcmt_iiwa_command>>(msg);
+  this->DeclareAbstractOutputPort(systems::Value<lcmt_iiwa_command>());
 }
 
 void IiwaCommandSender::DoCalcOutput(
@@ -179,12 +172,12 @@ void IiwaStatusReceiver::DoCalcOutput(const Context<double>& context,
 IiwaStatusSender::IiwaStatusSender() {
   this->DeclareInputPort(systems::kVectorValued, kNumJoints * 2);
   this->DeclareInputPort(systems::kVectorValued, kNumJoints * 2);
-  this->DeclareAbstractOutputPort();
+  this->DeclareAbstractOutputPort(
+      [this](const Context<double>*) { return this->AllocateOutputPort(); });
 }
 
 std::unique_ptr<systems::AbstractValue>
-IiwaStatusSender::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
+IiwaStatusSender::AllocateOutputPort() const {
   lcmt_iiwa_status msg{};
   msg.num_joints = kNumJoints;
   msg.joint_position_measured.resize(msg.num_joints, 0);

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.h
@@ -35,7 +35,7 @@ class IiwaCommandReceiver : public systems::LeafSystem<double> {
       systems::Context<double>* context,
       const Eigen::Ref<const VectorX<double>> x) const;
 
- protected:
+ private:
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
 
@@ -72,14 +72,10 @@ class IiwaCommandSender : public systems::LeafSystem<double> {
     return this->get_input_port(torque_input_port_);
   }
 
- protected:
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
+ private:
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
 
- private:
   const int position_input_port_{};
   const int torque_input_port_{};
 };
@@ -111,7 +107,7 @@ class IiwaStatusReceiver : public systems::LeafSystem<double> {
     return this->get_output_port(commanded_position_output_port_);
   }
 
- protected:
+ private:
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
 
@@ -119,7 +115,6 @@ class IiwaStatusReceiver : public systems::LeafSystem<double> {
       const systems::Context<double>& context,
       systems::DiscreteValues<double>* discrete_state) const override;
 
- private:
   const int measured_position_output_port_{};
   const int commanded_position_output_port_{};
 };
@@ -153,9 +148,8 @@ class IiwaStatusSender : public systems::LeafSystem<double> {
     return this->get_input_port(1);
   }
 
- protected:
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
+ private:
+  std::unique_ptr<systems::AbstractValue> AllocateOutputPort() const;
 
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;

--- a/drake/examples/kuka_iiwa_arm/oracular_state_estimator.h
+++ b/drake/examples/kuka_iiwa_arm/oracular_state_estimator.h
@@ -37,7 +37,9 @@ class OracularStateEstimation : public systems::LeafSystem<T> {
                 systems::kVectorValued,
                 robot.get_num_positions() + robot.get_num_velocities())
             .get_index();
-    output_port_index_msg_ = this->DeclareAbstractOutputPort().get_index();
+    output_port_index_msg_ = this->DeclareAbstractOutputPort(
+                                     systems::Value<bot_core::robot_state_t>())
+                                 .get_index();
   }
 
   void DoCalcOutput(const systems::Context<T>& context,
@@ -89,12 +91,6 @@ class OracularStateEstimation : public systems::LeafSystem<T> {
       msg.joint_effort[i] = 0;
       i++;
     }
-  }
-
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<T>& descriptor) const override {
-    return systems::AbstractValue::Make<bot_core::robot_state_t>(
-        bot_core::robot_state_t());
   }
 
   inline const systems::InputPortDescriptor<T>& get_input_port_state() const {

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
@@ -161,14 +161,7 @@ SchunkWsgStatusSender(int input_size,
     : position_index_(position_index), velocity_index_(velocity_index) {
   this->set_name("SchunkWsgStatusSender");
   this->DeclareInputPort(systems::kVectorValued, input_size);
-  this->DeclareAbstractOutputPort();
-}
-
-std::unique_ptr<systems::AbstractValue>
-SchunkWsgStatusSender::AllocateOutputAbstract(
-    const systems::OutputPortDescriptor<double>& descriptor) const {
-  lcmt_schunk_wsg_status msg{};
-  return std::make_unique<systems::Value<lcmt_schunk_wsg_status>>(msg);
+  this->DeclareAbstractOutputPort(systems::Value<lcmt_schunk_wsg_status>());
 }
 
 void SchunkWsgStatusSender::DoCalcOutput(const Context<double>& context,

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.h
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.h
@@ -76,10 +76,6 @@ class SchunkWsgStatusSender : public systems::LeafSystem<double> {
   SchunkWsgStatusSender(int input_size,
                         int position_index, int velocity_index);
 
- protected:
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const systems::OutputPortDescriptor<double>& descriptor) const override;
-
  private:
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -144,11 +144,38 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "system_port_descriptor",
-    srcs = ["system_port_descriptor.cc"],
-    hdrs = ["system_port_descriptor.h"],
+    name = "output_port",
+    srcs = [
+        "output_port.cc",
+    ],
+    hdrs = [
+        "output_port.h",
+        "system.h",
+        "system_port_descriptor.h",
+    ],
     deps = [
+        ":cache",
+        ":context",
+        ":value",
         "//drake/common",
+        "//drake/common:type_safe_index",
+        "//drake/common:unused",
+    ],
+)
+
+drake_cc_library(
+    name = "input_port_descriptor",
+    srcs = [
+        "input_port_descriptor.cc",
+    ],
+    hdrs = [
+        "input_port_descriptor.h",
+        "system_port_descriptor.h",
+    ],
+    deps = [
+        ":value",
+        "//drake/common",
+        "//drake/common:type_safe_index",
     ],
 )
 
@@ -179,8 +206,8 @@ drake_cc_library(
     srcs = ["input_port_evaluator_interface.cc"],
     hdrs = ["input_port_evaluator_interface.h"],
     deps = [
+        ":input_port_descriptor",
         ":output_port_value",
-        ":system_port_descriptor",
         "//drake/common",
     ],
 )
@@ -229,6 +256,7 @@ drake_cc_library(
     deps = [
         ":cache",
         ":context",
+        ":output_port",
         "//drake/common",
         "//drake/common:autodiff",
         "//drake/common:symbolic",

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -10,11 +10,13 @@ set(sources
   diagram_context.cc
   diagram_continuous_state.cc
   discrete_values.cc
+  input_port_descriptor.cc
   input_port_evaluator_interface.cc
   input_port_value.cc
   leaf_context.cc
   leaf_system.cc
   model_values.cc
+  output_port.cc
   output_port_listener_interface.cc
   output_port_value.cc
   parameters.cc
@@ -25,7 +27,6 @@ set(sources
   subvector.cc
   supervector.cc
   system.cc
-  system_port_descriptor.cc
   value.cc
   vector_base.cc
   )
@@ -50,11 +51,13 @@ set(installed_headers
   diagram_context.h
   diagram_continuous_state.h
   discrete_values.h
+  input_port_descriptor.h
   input_port_evaluator_interface.h
   input_port_value.h
   leaf_context.h
   leaf_system.h
   model_values.h
+  output_port.h
   output_port_listener_interface.h
   output_port_value.h
   parameters.h

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -1151,17 +1151,18 @@ class Diagram : public System<T>,
                            subsystem_descriptor.size());
   }
 
-  // Exposes the given port as an output of the Diagram.
+  // Exposes the given subsystem output port as an output of the Diagram.
   void ExportOutput(const PortIdentifier& port) {
     const System<T>* const sys = port.first;
-    const int port_index = port.second;
     // Fail quickly if this system is not part of the sort order.
     GetSystemIndexOrAbort(sys);
+    const int port_index = port.second;
+    const auto& source_output_port = sys->get_output_port(port_index);
 
     // Add this port to our externally visible topology.
-    const auto& subsystem_descriptor = sys->get_output_port(port_index);
-    this->DeclareOutputPort(subsystem_descriptor.get_data_type(),
-                            subsystem_descriptor.size());
+    auto port_info =
+        std::make_unique<DiagramOutputPort<T>>(&source_output_port);
+    this->AddOutputPort(std::move(port_info));
   }
 
   // Evaluates the value of the output port with the given @p id in the given

--- a/drake/systems/framework/input_port_descriptor.cc
+++ b/drake/systems/framework/input_port_descriptor.cc
@@ -1,11 +1,9 @@
-#include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/systems/framework/input_port_descriptor.h"
 
 namespace drake {
 namespace systems {
 
 template class InputPortDescriptor<double>;
-
-template class OutputPortDescriptor<double>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/input_port_descriptor.h
+++ b/drake/systems/framework/input_port_descriptor.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+class System;
+
+/// InputPortDescriptor is a notation for specifying the kind of input a
+/// System accepts, on a given port. It is not a mechanism for handling any
+/// actual input data.
+///
+/// @tparam T The mathematical type of the context, which must be a valid Eigen
+///           scalar.
+template <typename T>
+class InputPortDescriptor {
+ public:
+  /// @param system The system to which this descriptor belongs.
+  /// @param index The index of the input port described, starting from zero and
+  ///              incrementing by one per port.
+  /// @param data_type Whether the port described is vector or abstract valued.
+  /// @param size If the port described is vector-valued, the number of
+  ///             elements, or kAutoSize if determined by connections.
+  InputPortDescriptor(const System<T>* system, int index,
+                      PortDataType data_type, int size)
+      : system_(system), index_(index), data_type_(data_type), size_(size) {
+    if (size_ == kAutoSize) {
+      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+    }
+  }
+
+  /// @name Basic Concepts
+  /// MoveConstructible only; not CopyConstructible; not Copy/Move-Assignable.
+  /// @{
+  //
+  // Implementation note: This class aliases a pointer to the system that
+  // contains it and captures its own index within that system's port vector,
+  // so we must be careful not to allow C++ copying to extend the lifetime of
+  // the system alias or duplicate our claim to the index.  Thus, this class is
+  // `MoveConstructible` but neither copyable nor assignable: it supports move
+  // to populate a vector, but is non-copyable in order remain the "one true
+  // descriptor" after construction and non-assignable in order to remain
+  // const.  Code that wishes to refer to this descriptor after insertion into
+  // the vector should use a reference (not copy) of this descriptor.
+  InputPortDescriptor() = delete;
+  InputPortDescriptor(InputPortDescriptor&& other) = default;
+  InputPortDescriptor(const InputPortDescriptor&) = delete;
+  InputPortDescriptor& operator=(InputPortDescriptor&&) = delete;
+  InputPortDescriptor& operator=(const InputPortDescriptor&) = delete;
+  ~InputPortDescriptor() = default;
+  /// @}
+
+  const System<T>* get_system() const { return system_; }
+  int get_index() const { return index_; }
+  PortDataType get_data_type() const { return data_type_; }
+  int size() const { return size_; }
+
+ private:
+  const System<T>* const system_;
+  const int index_;
+  const PortDataType data_type_;
+  const int size_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/input_port_evaluator_interface.h
+++ b/drake/systems/framework/input_port_evaluator_interface.h
@@ -4,7 +4,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/output_port_value.h"
-#include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/systems/framework/input_port_descriptor.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/output_port.cc
+++ b/drake/systems/framework/output_port.cc
@@ -1,0 +1,136 @@
+#include "drake/systems/framework/output_port.h"
+
+#include <sstream>
+
+#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/nice_type_name.h"
+#include "drake/common/symbolic_expression.h"
+#include "drake/systems/framework/system.h"
+
+namespace drake {
+namespace systems {
+
+//==============================================================================
+//                                OUTPUT PORT
+//==============================================================================
+template <typename T>
+std::unique_ptr<AbstractValue> OutputPort<T>::Allocate(
+    const Context<T>* context) const {
+  if (context != nullptr) {
+    DRAKE_ASSERT_VOID(get_system()->CheckValidContext(*context));
+  }
+  return DoAllocate(context);
+}
+
+// Note that this is just sugar. It calls the real Allocate() method above,
+// assumes the AbstractValue contains a BasicVector, digs out that vector and
+// returns it to the caller, getting rid of the rest of the AbstractValue
+// infrastructure.
+// TODO(sherm1) Consider whether to nuke this method altogether.
+template <typename T>
+std::unique_ptr<BasicVector<T>> OutputPort<T>::AllocateVector(
+    const Context<T>* context) const {
+  std::unique_ptr<AbstractValue> abstract = Allocate(context);
+  // The abstract value must be a VectorValue<T>.
+  VectorValue<T>* value = dynamic_cast<VectorValue<T>*>(abstract.get());
+  if (value == nullptr) {
+    std::ostringstream oss;
+    oss << "OutputPort::AllocateVector(): Expected a vector type from the "
+           "allocator for output port "
+        << this->get_index() << " of System " << this->get_system()->GetPath()
+        << " but got a " << NiceTypeName::Get(*abstract) << " instead.";
+    throw std::logic_error(oss.str());
+  }
+
+  return value->ExtractBasicVector();
+  // The empty AbstractValue shell is destructed here.
+}
+
+template <typename T>
+void OutputPort<T>::Calc(const Context<T>& context,
+                         AbstractValue* value) const {
+  DRAKE_ASSERT_VOID(get_system()->CheckValidContext(context));
+  DRAKE_DEMAND(value != nullptr);
+  // TODO(sherm1) Validate abstract value object.
+  return DoCalc(context, value);
+}
+
+template <typename T>
+const AbstractValue& OutputPort<T>::Eval(const Context<T>& context) const {
+  DRAKE_ASSERT_VOID(get_system()->CheckValidContext(context));
+  return DoEval(context);
+}
+
+//==============================================================================
+//                            LEAF OUTPUT PORT
+//==============================================================================
+template <typename T>
+std::unique_ptr<AbstractValue> LeafOutputPort<T>::DoAllocate(
+    const Context<T>* context) const {
+  std::unique_ptr<AbstractValue> result;
+
+  // Use the allocation function if available, otherwise clone the model
+  // value.
+  if (alloc_function_) {
+    result = alloc_function_(context);
+  } else if (model_value_ != nullptr) {
+    result = model_value_->Clone();
+  } else {
+    std::ostringstream oss;
+    oss << "LeafOutputPort::DoAllocate(): Output port " << this->get_index()
+        << " of System " << NiceTypeName::Get(*this->get_system())
+        << " has neither an allocation function nor a model value so cannot"
+           " be allocated.";
+    throw std::logic_error(oss.str());
+  }
+  DRAKE_DEMAND(result.get() != nullptr);
+  return result;
+}
+
+// TODO(sherm1) Call CalcOutput for backwards compatibility.
+template <typename T>
+void LeafOutputPort<T>::DoCalc(const Context<T>& context,
+                               AbstractValue* value) const {
+  if (calc_function_) {
+    calc_function_(context, value);
+  } else {
+    std::ostringstream oss;
+    oss << "LeafOutputPort::DoCalc(): Output port " << this->get_index()
+        << " had no calculation function available.";
+    throw std::logic_error(oss.str());
+  }
+}
+
+template <typename T>
+const AbstractValue& LeafOutputPort<T>::DoEval(
+    const Context<T>& context) const {
+  if (eval_function_)
+    return eval_function_(context);
+  // TODO(sherm1) Provide proper default behavior for an output port with
+  // its own cache entry.
+  DRAKE_ABORT_MSG("LeafOutputPort::DoEval: NOT IMPLEMENTED YET");
+  return *reinterpret_cast<const AbstractValue*>(0);
+}
+
+template class OutputPort<double>;
+template class LeafOutputPort<double>;
+template class DiagramOutputPort<double>;
+
+template class OutputPort<Eigen::AutoDiffScalar<Eigen::Vector2d>>;
+template class LeafOutputPort<Eigen::AutoDiffScalar<Eigen::Vector2d>>;
+template class DiagramOutputPort<Eigen::AutoDiffScalar<Eigen::Vector2d>>;
+
+template class OutputPort<Eigen::AutoDiffScalar<Eigen::Vector3d>>;
+template class LeafOutputPort<Eigen::AutoDiffScalar<Eigen::Vector3d>>;
+template class DiagramOutputPort<Eigen::AutoDiffScalar<Eigen::Vector3d>>;
+
+template class OutputPort<AutoDiffXd>;
+template class LeafOutputPort<AutoDiffXd>;
+template class DiagramOutputPort<AutoDiffXd>;
+
+template class OutputPort<symbolic::Expression>;
+template class LeafOutputPort<symbolic::Expression>;
+template class DiagramOutputPort<symbolic::Expression>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/output_port.h
+++ b/drake/systems/framework/output_port.h
@@ -1,0 +1,389 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/type_safe_index.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+class System;
+
+template <typename T>
+class Context;
+
+using OutputPortIndex = TypeSafeIndex<class OutputPortTag>;
+
+//==============================================================================
+//                                OUTPUT PORT
+//==============================================================================
+/** An %OutputPort belongs to a System and represents the properties of one of
+that System's output ports. %OutputPort objects are assigned OutputPortIndex
+values in the order they are declared; these are unique within a single System.
+
+An output port can be considered a "window" into a System that permits
+controlled exposure of one of the values contained in that System's Context at
+run time. Input ports of other subsystems may be connected to an output port to
+construct system diagrams with carefully managed interdependencies.
+
+The exposed value may be the result of a an output computation, or it may
+simply expose some other value contained in the Context, such as the values
+of state variables. The Context handles caching of output port values and tracks
+dependencies to ensure that the values are valid with respect to their
+prerequisites. Leaf systems provide for the production of output port values, by
+computation or forwarding from other values within the associated leaf context.
+A diagram's output ports, on the other hand, are exported from output ports of
+its contained subsystems.
+
+An output port's value may always be treated as an AbstractValue, but we also
+provide special handling for output ports known to have numeric (vector) values.
+Vector-valued ports may specify a particular vector length, or may leave that
+to be determined at runtime.
+
+%OutputPort objects support three important operations:
+- Allocate() returns an object that can hold the port's value.
+- Calc() unconditionally computes the port's value.
+- Eval() updates a cached value if necessary.
+
+Variants of the above are available for vector-valued ports. See the method
+documentation for more information.
+
+@tparam T The mathematical type of the containing System, which must be a valid
+          Eigen scalar.
+**/
+template <typename T>
+class OutputPort {
+ public:
+  /// @name Basic Concepts
+  /// MoveConstructible only; not CopyConstructible; not Copy/Move-Assignable.
+  /// @{
+  // See InputPortDescriptor doc for implementation note and justification.
+  OutputPort() = delete;
+  OutputPort(OutputPort&&) = default;
+  OutputPort(const OutputPort&) = delete;
+  OutputPort& operator=(OutputPort&&) = default;
+  OutputPort& operator=(const OutputPort&) = delete;
+  virtual ~OutputPort() = default;
+  /// @}
+
+  /** Allocate a concrete object suitable for holding the value to be exposed
+  by this output port, and return that as an AbstractValue. This works for any
+  output port, even if it is vector valued. You must supply a Context if the
+  port's allocator may depend on it, otherwise it will be null. **/
+  std::unique_ptr<AbstractValue> Allocate(
+      const Context<T>* context = nullptr) const;
+
+  /** If you know this output port is vector valued, this method will give you
+  a numerical vector object of the right size to hold a value of this port.
+  An exception will be thrown if the port is not vector valued. You must supply
+  a Context if the port's allocator may depend on it, otherwise it will be
+  null. **/
+  std::unique_ptr<BasicVector<T>> AllocateVector(
+      const Context<T>* context = nullptr) const;
+
+  /** Unconditionally computes the value of this output port with respect to the
+  given context, into an already-allocated AbstractValue object whose concrete
+  type must be the correct type for this output port. Commonly the output
+  argument will be an entry in the given Context's output cache, but that is not
+  required. **/
+  void Calc(const Context<T>& context, AbstractValue* value) const;
+
+  /** If you know this output port is vector valued, this method is a variant
+  of Calc() that writes the result into a BasicVector object which must be the
+  correct type for this output port. An exception will be thrown if the port is
+  not vector valued. **/
+  void CalcVector(const Context<T>& context, BasicVector<T>* value) const {
+    Value<BasicVector<T>*> abstract(value);
+    Calc(context, &abstract);  // Writes on the output argument.
+    // Destruction of the abstract value is harmless.
+  }
+
+  /** Returns a reference to the value of this output port contained in the
+  given Context. If that value is not up to date with respect to its
+  prerequisites, the Calc() method above is used first to update the value
+  before the reference is returned. **/
+  const AbstractValue& Eval(const Context<T>& context) const;
+
+  /** If you know this output port is vector valued, this method is a variant
+  of Eval() that returns a reference directly to the BasicVector contained in
+  this port's AbstractValue in the given Context. An exception will be thrown if
+  the port is not vector valued. **/
+  const BasicVector<T>& EvalVector(const Context<T>& context) const {
+    const AbstractValue& abstract = Eval(context);
+    return *abstract.template GetValueOrThrow<BasicVector<T>*>();
+  }
+
+  /** Returns a pointer to the System that owns this output port, or `nullptr`
+  if this output port object has not been added to a System. Note that
+  for a diagram output port this will be the diagram, not the leaf system whose
+  output port was forwarded. **/
+  const System<T>* get_system() const {
+    return system_;
+  }
+
+  /** Returns the index of this output port within the owning System. This is
+  not valid if this output port object has not been added to a System. Use
+  get_system() to check if you aren't sure. **/
+  OutputPortIndex get_index() const {
+    DRAKE_DEMAND(system_ != nullptr);
+    return index_;
+  }
+
+  /** This is the port data type specified at port construction. **/
+  PortDataType get_data_type() const { return data_type_; }
+
+  /** For vector-valued output ports, if this is non-negative it is the
+  required runtime size of the value. Otherwise is may be kAutoSize in which
+  case the size is determined upon allocation. **/
+  int size() const { return size_; }
+
+  /** Internal use only. **/
+  void set_system_and_index(const System<T>* system, OutputPortIndex index) {
+    DRAKE_DEMAND(system_ == nullptr && system != nullptr);
+    system_ = system;
+    index_ = index;
+  }
+
+ protected:
+  /** Constructor is for use by derived classes for setting the base class
+  members.
+  @param data_type Whether the port described is vector or abstract valued.
+  @param size If the port described is vector-valued, the number of
+              elements, or kAutoSize if determined by connections. **/
+  OutputPort(PortDataType data_type, int size)
+      : data_type_(data_type), size_(size) {
+    if (size_ == kAutoSize) {
+      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+    }
+  }
+
+  /** A concrete %OutputPort must provide a way to allocate a suitable object
+  for holding the runtime value of this output port. The particulars may depend
+  on values and types of objects in the given Context, if one is supplied. It
+  is up to the implementation to complain if a Context is required but wasn't
+  supplied by the caller.
+
+  @param context
+     If non-null, a Context that has already been validated as compatible with
+     the System whose output port this is.
+  @returns A unique_ptr to the new value-holding object as an AbstractValue. **/
+  virtual std::unique_ptr<AbstractValue> DoAllocate(
+      const Context<T>* context) const = 0;
+
+  /** A concrete %OutputPort must provide a way to write to `value` the value
+  this output port should have given the contents of the supplied Context. The
+  value may be determined by computation or by copying from a source value in
+  the Context.
+
+  @param context A Context that has already been validated as compatible with
+                 the System whose output port this is.
+  @param value   A pointer that has already be validated as non-null and
+                 pointing to an object of the right type to hold a value of
+                 this output port. **/
+  virtual void DoCalc(const Context<T>& context,
+                      AbstractValue* value) const = 0;
+
+  /** A concrete %OutputPort must provide access to the current value of this
+  output port stored within the given Context. If the value is already up to
+  date with respect to its prerequisites in `context`, no computation should be
+  performed. Otherwise, the implementation should arrange for the value to be
+  computed, typically but not necessarily by invoking DoCalc().
+
+  @param context A Context that has already been validated as compatible with
+                 the System whose output port this is. **/
+  virtual const AbstractValue& DoEval(const Context<T>& context) const = 0;
+
+ private:
+  const System<T>* system_{nullptr};
+  OutputPortIndex index_{0};  // TODO(sherm1) Should be illegal value.
+  const PortDataType data_type_;
+  const int size_;
+};
+
+// TODO(sherm1) Get rid of this alias.
+template <typename T>
+using OutputPortDescriptor = OutputPort<T>;
+
+
+//==============================================================================
+//                            LEAF OUTPUT PORT
+//==============================================================================
+/** Adds methods for allocation, calculation, and caching of an output
+port's value. **/
+template <typename T>
+class LeafOutputPort : public OutputPort<T> {
+ public:
+  /** Signature of a function suitable for allocating an object that can hold
+  a value of a particular output port. The result is returned as an
+  AbstractValue even if this is a vector-valued port. **/
+  using AllocCallback = std::function<std::unique_ptr<AbstractValue>(
+      const Context<T>*)>;
+
+  /** Signature of a function suitable for allocating a BasicVector of the
+  right size and concrete type for a particular vector-valued output port. **/
+  using AllocVectorCallback = std::function<std::unique_ptr<BasicVector<T>>(
+      const Context<T>*)>;
+
+  /** Signature of a function suitable for calculating a value of a particular
+  output port, given a place to put the value. **/
+  using CalcCallback = std::function<void(const Context<T>&, AbstractValue*)>;
+
+  /** Signature of a function suitable for obtaining the cached value of a
+  particular output port. **/
+  using EvalCallback = std::function<const AbstractValue&(const Context<T>&)>;
+
+  /** Construct a fixed-size vector-valued, cached output port using the
+  supplied BasicVector as a model for the port's value type and cache entry.
+  You do not need to supply an allocation function. **/
+  explicit LeafOutputPort(const BasicVector<T>& model_value)
+      : OutputPort<T>(kVectorValued, model_value.size()),
+        model_value_(new VectorValue<T>(model_value.Clone())) {
+  }
+
+  /** Construct an abstract-valued, cached output port using the
+  supplied allocator function to provide an object to hold the value.
+  If a particular size is required, supply it here; otherwise use kAutoSize.
+  (Note: currently a fixed size is required.) **/
+  explicit LeafOutputPort(AllocVectorCallback vector_alloc_function, int size)
+      : OutputPort<T>(kVectorValued, size) {
+    set_allocation_function(vector_alloc_function);
+  }
+
+  /** Construct an abstract-valued, cached output port using the
+  supplied AbstractValue as a model for the port's value type and cache
+  entry. You do not need to supply an allocation function; instead the model
+  will be cloned as needed. **/
+  explicit LeafOutputPort(const AbstractValue& model_value)
+      : OutputPort<T>(kAbstractValued, 0 /* size */),
+        model_value_(model_value.Clone()) {}
+
+
+  /** Construct an abstract-valued, cached output port using the supplied
+  allocator function to provide an object to hold the value. **/
+  explicit LeafOutputPort(AllocCallback alloc_function)
+      : OutputPort<T>(kAbstractValued, 0 /* size */),
+        alloc_function_(alloc_function) {}
+
+  /** Construct a port without specifying a model. If you provide an allocation
+  function it will be used. Otherwise, if this is a vector port of known size
+  an appropriate `BasicVector<T>` will be allocated. No default allocator is
+  provided for an abstract port. **/
+  LeafOutputPort(PortDataType data_type, int size,
+                 AllocCallback alloc_function = nullptr)
+      : OutputPort<T>(data_type, size), alloc_function_(alloc_function) {
+    // If this is vector of known size, make a model to use if we don't get
+    // an allocation function.
+    if (data_type == kVectorValued && size >= 0) {
+      model_value_.reset(
+          new VectorValue<T>(std::make_unique<BasicVector<T>>(size)));
+    }
+  }
+
+  /** Set or replace the allocation function for this output port, using
+  a function that returns an AbstractValue. **/
+  void set_allocation_function(AllocCallback alloc_function) {
+    alloc_function_ = alloc_function;
+  }
+
+  /** Set or replace the allocation function for this vector-valued output port,
+  using a function that returns an object derived from `BasicVector<T>`.**/
+  void set_allocation_function(AllocVectorCallback vector_alloc_function) {
+    if (!vector_alloc_function) {
+      alloc_function_ = nullptr;
+    } else {
+      // Wrap the vector-returning function with an AbstractValue-returning
+      // allocator.
+      alloc_function_ = [vector_alloc_function](const Context<T>* context) {
+        std::unique_ptr<BasicVector<T>> vector = vector_alloc_function(context);
+        return std::unique_ptr<AbstractValue>(
+            new VectorValue<T>(std::move(vector)));
+      };
+    }
+  }
+
+  /** Set or replace the calculation function for this output port, using
+  a function that writes into an AbstractValue. **/
+  void set_calculation_function(CalcCallback calc_function) {
+    calc_function_ = calc_function;
+  }
+
+ private:
+  // Invokes the supplied allocation function if there is one, otherwise clones
+  // the model value if there is one, otherwise complains.
+  std::unique_ptr<AbstractValue> DoAllocate(
+      const Context<T>* context) const override;
+
+  // Invokes the supplied calculation function if present, or attempts to use
+  // obsolete CalcOutput() method for backwards compatibility.
+  // TODO(sherm1) Get rid of CalcOutput() fallback.
+  void DoCalc(const Context<T>& context, AbstractValue* value) const override;
+
+  // If this output port has its own cache entry then this checks the validity
+  // bit, invokes DoCalc() into the cache entry if necessary, and then returns
+  // a reference to the cache entry's value. Otherwise it invokes a custom
+  // evaluation function which must exist.
+  const AbstractValue& DoEval(const Context<T>& context) const override;
+
+  // Data.
+  std::unique_ptr<const AbstractValue> model_value_;  // May be nullptr.
+
+  AllocCallback alloc_function_;
+  CalcCallback  calc_function_;
+  EvalCallback  eval_function_;
+};
+
+
+//==============================================================================
+//                          DIAGRAM OUTPUT PORT
+//==============================================================================
+/** Holds information about the subsystem output port that has been exported to
+become one of this Diagram's output ports. The actual methods for determining
+the port's value are supplied by the LeafSystem that ultimately underlies the
+source port, although that may be any number of levels down. **/
+template <typename T>
+class DiagramOutputPort : public OutputPort<T> {
+ public:
+  explicit DiagramOutputPort(const OutputPort<T>* source_output_port)
+      : OutputPort<T>(source_output_port->get_data_type(),
+                      source_output_port->size()),
+        source_output_port_(source_output_port) {}
+
+  /** Obtain a reference to the subsystem output port that was exported to
+  create this diagram port. Note that the source may itself be a diagram output
+  port. **/
+  const OutputPort<T>& get_source_output_port() const {
+    DRAKE_DEMAND(source_output_port_ != nullptr);
+    return *source_output_port_;
+  }
+
+ private:
+  // These forward to the source system output port.
+  std::unique_ptr<AbstractValue> DoAllocate(
+      const Context<T>* context) const override {
+    DRAKE_DEMAND(source_output_port_ != nullptr);
+    return source_output_port_->Allocate(context);
+  }
+  void DoCalc(const Context<T>& context, AbstractValue* value) const override {
+    DRAKE_DEMAND(source_output_port_ != nullptr);
+    return source_output_port_->Calc(context, value);
+  }
+  const AbstractValue& DoEval(const Context<T>& context) const override {
+    DRAKE_ASSERT(source_output_port_ != nullptr);
+    return source_output_port_->Eval(context);
+  }
+
+  const OutputPort<T>* source_output_port_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/system_port_descriptor.h
+++ b/drake/systems/framework/system_port_descriptor.h
@@ -1,15 +1,9 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace systems {
-
-template <typename T>
-class System;
 
 constexpr int kAutoSize = -1;
 
@@ -19,108 +13,6 @@ typedef enum {
   kVectorValued = 0,
   kAbstractValued = 1,
 } PortDataType;
-
-/// InputPortDescriptor is a notation for specifying the kind of input a
-/// System accepts, on a given port. It is not a mechanism for handling any
-/// actual input data.
-///
-/// @tparam T The mathematical type of the context, which must be a valid Eigen
-///           scalar.
-template <typename T>
-class InputPortDescriptor {
- public:
-  /// @param system The system to which this descriptor belongs.
-  /// @param index The index of the input port described, starting from zero and
-  ///              incrementing by one per port.
-  /// @param data_type Whether the port described is vector or abstract valued.
-  /// @param size If the port described is vector-valued, the number of
-  ///             elements, or kAutoSize if determined by connections.
-  InputPortDescriptor(const System<T>* system, int index,
-                      PortDataType data_type, int size)
-      : system_(system), index_(index), data_type_(data_type), size_(size) {
-    if (size_ == kAutoSize) {
-      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
-    }
-  }
-
-  /// @name Basic Concepts
-  /// MoveConstructible only; not CopyConstructible; not Copy/Move-Assignable.
-  /// @{
-  //
-  // Implementation note: This class aliases a pointer to the system that
-  // contains it and captures its own index within that system's port vector,
-  // so we must be careful not to allow C++ copying to extend the lifetime of
-  // the system alias or duplicate our claim to the index.  Thus, this class is
-  // `MoveConstructible` but neither copyable nor assignable: it supports move
-  // to populate a vector, but is non-copyable in order remain the "one true
-  // descriptor" after construction and non-assignable in order to remain
-  // const.  Code that wishes to refer to this descriptor after insertion into
-  // the vector should use a reference (not copy) of this descriptor.
-  InputPortDescriptor() = delete;
-  InputPortDescriptor(InputPortDescriptor&& other) = default;
-  InputPortDescriptor(const InputPortDescriptor&) = delete;
-  InputPortDescriptor& operator=(InputPortDescriptor&&) = delete;
-  InputPortDescriptor& operator=(const InputPortDescriptor&) = delete;
-  ~InputPortDescriptor() = default;
-  /// @}
-
-  const System<T>* get_system() const { return system_; }
-  int get_index() const { return index_; }
-  PortDataType get_data_type() const { return data_type_; }
-  int size() const { return size_; }
-
- private:
-  const System<T>* const system_;
-  const int index_;
-  const PortDataType data_type_;
-  const int size_;
-};
-
-/// OutputPortDescriptor is a notation for specifying the kind of output a
-/// System produces, on a given port. It is not a mechanism for handling any
-/// actual output data.
-///
-/// @tparam T The mathematical type of the context, which must be a valid Eigen
-///           scalar.
-template <typename T>
-class OutputPortDescriptor {
- public:
-  /// @param system The system to which this descriptor belongs.
-  /// @param index The index of the output port described, starting from zero
-  ///              and incrementing by one per port.
-  /// @param data_type Whether the port described is vector or abstract valued.
-  /// @param size If the port described is vector-valued, the number of
-  ///             elements, or kAutoSize if determined by connections.
-  OutputPortDescriptor(const System<T>* system, int index,
-                       PortDataType data_type, int size)
-      : system_(system), index_(index), data_type_(data_type), size_(size) {
-    if (size_ == kAutoSize) {
-      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
-    }
-  }
-  /// @name Basic Concepts
-  /// MoveConstructible only; not CopyConstructible; not Copy/Move-Assignable.
-  /// @{
-  // See InputPortDescriptor doc for implementation note and justification.
-  OutputPortDescriptor() = delete;
-  OutputPortDescriptor(OutputPortDescriptor&&) = default;
-  OutputPortDescriptor(const OutputPortDescriptor&) = delete;
-  OutputPortDescriptor& operator=(OutputPortDescriptor&&) = default;
-  OutputPortDescriptor& operator=(const OutputPortDescriptor&) = delete;
-  ~OutputPortDescriptor() = default;
-  /// @}
-
-  const System<T>* get_system() const { return system_; }
-  int get_index() const { return index_; }
-  PortDataType get_data_type() const { return data_type_; }
-  int size() const { return size_; }
-
- private:
-  const System<T>* const system_;
-  const int index_;
-  const PortDataType data_type_;
-  const int size_;
-};
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -7,7 +7,7 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/systems/framework/output_port.h"
 #include "drake/systems/framework/test_utilities/pack_value.h"
 #include "drake/systems/primitives/adder.h"
 #include "drake/systems/primitives/constant_vector_source.h"

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -26,7 +26,7 @@ class TestSystem : public LeafSystem<T> {
   TestSystem() {
     this->set_name("TestSystem");
     this->DeclareOutputPort(kVectorValued, 17);
-    this->DeclareAbstractOutputPort();
+    this->DeclareAbstractOutputPort(Value<int>(42));
   }
   ~TestSystem() override {}
 
@@ -61,16 +61,6 @@ class TestSystem : public LeafSystem<T> {
   std::unique_ptr<Parameters<T>> AllocateParameters() const override {
     return std::make_unique<Parameters<T>>(
         std::make_unique<BasicVector<T>>(2));
-  }
-
-  std::unique_ptr<BasicVector<T>> AllocateOutputVector(
-      const OutputPortDescriptor<T>& descriptor) const override {
-    return std::make_unique<BasicVector<T>>(17);
-  }
-
-  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
-      const OutputPortDescriptor<T>& descriptor) const override {
-    return AbstractValue::Make<int>(42);
   }
 
   void SetDefaultParameters(const LeafContext<T>& context,

--- a/drake/systems/framework/test/sparsity_matrix_test.cc
+++ b/drake/systems/framework/test/sparsity_matrix_test.cc
@@ -19,7 +19,7 @@ class SparseSystem : public LeafSystem<symbolic::Expression> {
     this->DeclareInputPort(kVectorValued, kSize);
     this->DeclareOutputPort(kVectorValued, kSize);
     this->DeclareOutputPort(kVectorValued, kSize);
-    this->DeclareAbstractOutputPort();
+    this->DeclareAbstractOutputPort(Value<int>(42));
 
     this->DeclareContinuousState(kSize);
     this->DeclareDiscreteState(kSize);
@@ -51,12 +51,6 @@ class SparseSystem : public LeafSystem<symbolic::Expression> {
 
     // Output 1 depends on both inputs and the discrete state.
     y1.set_value(u0.get_value() + u1.get_value() + xd.get_value());
-  }
-
-  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
-      const OutputPortDescriptor<symbolic::Expression>& descriptor)
-  const override {
-    return AbstractValue::Make<int>(42);
   }
 };
 

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -9,6 +9,7 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_context.h"
+#include "drake/systems/framework/output_port.h"
 #include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/framework/test_utilities/my_vector.h"
 
@@ -51,9 +52,12 @@ class TestSystem : public System<double> {
     return this->DeclareAbstractInputPort();
   }
 
-
-  const OutputPortDescriptor<double>& AddAbstractOutputPort() {
-    return this->DeclareAbstractOutputPort();
+  const OutputPort<double>& AddAbstractOutputPort() {
+    auto port =
+        std::make_unique<LeafOutputPort<double>>(kAbstractValued, 0 /* size */);
+    const OutputPort<double>* port_ptr = port.get();
+    AddOutputPort(std::move(port));
+    return *port_ptr;
   }
 
   bool HasAnyDirectFeedthrough() const override {
@@ -306,10 +310,11 @@ class ValueIOTestSystem : public System<T> {
   // The second input / output pair are vector type with length 1.
   ValueIOTestSystem() {
     this->DeclareAbstractInputPort();
-    this->DeclareAbstractOutputPort();
+    this->AddOutputPort(
+        std::make_unique<LeafOutputPort<T>>(kAbstractValued, 0));
 
     this->DeclareInputPort(kVectorValued, 1);
-    this->DeclareOutputPort(kVectorValued, 1);
+    this->AddOutputPort(std::make_unique<LeafOutputPort<T>>(kVectorValued, 1));
 
     this->set_name("ValueIOTestSystem");
   }

--- a/drake/systems/framework/test/value_test.cc
+++ b/drake/systems/framework/test/value_test.cc
@@ -276,6 +276,14 @@ GTEST_TEST(VectorValueTest, AssignmentOperatorSelf) {
   EXPECT_EQ(6, value.get_value()->get_value().z());
 }
 
+GTEST_TEST(VectorValueTest, ExtractBasicVector) {
+  auto basic_vector = BasicVector<double>::Make({4, 5, 6});
+  const BasicVector<double>* ptr = basic_vector.get();
+  VectorValue<double> value(std::move(basic_vector));
+  auto extracted = value.ExtractBasicVector();
+  EXPECT_EQ(extracted.get(), ptr);
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -247,6 +247,16 @@ class VectorValue : public Value<BasicVector<T>*> {
     return std::make_unique<VectorValue>(*this);
   }
 
+  /// Extract the contained basic vector and transfer ownership to
+  /// the caller. The VectorValue is left empty. This is useful when you have
+  /// been handed an AbstractValue but would like to use only the BasicVector
+  /// you know lurks inside. After extracting the vector you should delete
+  /// the now-empty shell of the AbstractValue.
+  std::unique_ptr<BasicVector<T>> ExtractBasicVector() {
+    this->set_value(nullptr);  // Clear the parent Value.
+    return std::move(owned_value_);
+  }
+
  private:
   void CheckInvariants() {
     DRAKE_DEMAND(owned_value_.get() == this->get_value());

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -135,12 +135,6 @@ class LcmSubscriberSystem : public LeafSystem<double>,
   void DoCalcOutput(const Context<double>& context,
                     SystemOutput<double>* output) const override;
 
-  std::unique_ptr<systems::AbstractValue> AllocateOutputAbstract(
-      const OutputPortDescriptor<double>& descriptor) const override;
-
-  std::unique_ptr<BasicVector<double>> AllocateOutputVector(
-      const OutputPortDescriptor<double>& descriptor) const override;
-
   void DoCalcNextUpdateTime(const Context<double>& context,
                             UpdateActions<double>* events) const override;
 
@@ -180,6 +174,10 @@ class LcmSubscriberSystem : public LeafSystem<double>,
   // block on notification_ if it's not nullptr.
   void HandleMessage(const std::string& channel, const void* message_buffer,
                      int message_size) override;
+
+  std::unique_ptr<systems::AbstractValue> AllocateAbstractOutputValue() const;
+
+  std::unique_ptr<BasicVector<double>> AllocateVectorOutputValue() const;
 
   // The channel on which to receive LCM messages.
   const std::string channel_;

--- a/drake/systems/primitives/test/gain_scalartype_test.cc
+++ b/drake/systems/primitives/test/gain_scalartype_test.cc
@@ -30,11 +30,9 @@ namespace {
 // derivatives with respect to this input are zero.
 GTEST_TEST(GainScalarTypeTest, AutoDiff) {
   // There are only two independent variables in this problem with respect to
-  // which we want to take derivatives. Therefore Vector2d_unaligned is the
+  // which we want to take derivatives. Therefore Vector2d is the
   // template argument of AutoDiffScalar.
-  // TODO(amcastro-tri): change to Vector2d once #3145 is fixed.
-  typedef Eigen::Matrix<double, 2, 1, Eigen::DontAlign> Vector2d_unaligned;
-  typedef AutoDiffScalar<Vector2d_unaligned> T;
+  typedef AutoDiffScalar<Vector2d> T;
 
   // Set a Gain system with input and output of size 3. Notice that this size
   // does not necessarily need to be the same as the size of the derivatives

--- a/drake/systems/rendering/pose_aggregator.cc
+++ b/drake/systems/rendering/pose_aggregator.cc
@@ -15,7 +15,13 @@ namespace rendering {
 
 template <typename T>
 PoseAggregator<T>::PoseAggregator() {
-  this->DeclareAbstractOutputPort();
+  // Declare the output port and provide an allocator for a PoseBundle of length
+  // equal to the concatenation of all inputs. This can't be done with a model
+  // value because we don't know at construction how big the output will be.
+  // The lambda here serves only to bind the `this` pointer to the allocator so
+  // that we can invoke the private method.
+  this->DeclareAbstractOutputPort(
+      [this](const Context<T>*) { return this->AllocateOutputValue(); });
 }
 
 template <typename T>
@@ -125,9 +131,10 @@ void PoseAggregator<T>::DoCalcOutput(const Context<T>& context,
   return;
 }
 
+// (This could reasonably be done in the allocation lambda rather than with a
+// separate method.)
 template <typename T>
-std::unique_ptr<AbstractValue> PoseAggregator<T>::AllocateOutputAbstract(
-    const OutputPortDescriptor<T>& descriptor) const {
+std::unique_ptr<AbstractValue> PoseAggregator<T>::AllocateOutputValue() const {
   return AbstractValue::Make(PoseBundle<T>(this->CountNumPoses()));
 }
 

--- a/drake/systems/rendering/pose_aggregator.h
+++ b/drake/systems/rendering/pose_aggregator.h
@@ -100,11 +100,12 @@ class PoseAggregator : public LeafSystem<T> {
   void DoCalcOutput(const Context<T>& context,
                     SystemOutput<T>* output) const override;
 
-  /// Allocates a PoseBundle of length equal to the concatenation of all inputs.
-  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
-      const OutputPortDescriptor<T>& descriptor) const override;
-
  private:
+  // Allocates a PoseBundle of length equal to the concatenation of all inputs.
+  // After binding to `this`, this method has the appropriate signature for
+  // an output port allocation function.
+  std::unique_ptr<AbstractValue> AllocateOutputValue() const;
+
   enum PoseInputType {
     kUnknown = 0,
     kSinglePose = 1,

--- a/drake/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/drake/systems/rendering/pose_bundle_to_draw_message.cc
@@ -9,7 +9,7 @@ namespace rendering {
 
 PoseBundleToDrawMessage::PoseBundleToDrawMessage() {
   this->DeclareAbstractInputPort();
-  this->DeclareAbstractOutputPort();
+  this->DeclareAbstractOutputPort(Value<lcmt_viewer_draw>());
 }
 
 PoseBundleToDrawMessage::~PoseBundleToDrawMessage() {}
@@ -49,12 +49,6 @@ void PoseBundleToDrawMessage::DoCalcOutput(const Context<double>& context,
     message.quaternion[i][2] = q.y();
     message.quaternion[i][3] = q.z();
   }
-}
-
-std::unique_ptr<AbstractValue>
-PoseBundleToDrawMessage::AllocateOutputAbstract(
-    const OutputPortDescriptor<double>& descriptor) const {
-  return AbstractValue::Make<lcmt_viewer_draw>(lcmt_viewer_draw());
 }
 
 }  // namespace rendering

--- a/drake/systems/rendering/pose_bundle_to_draw_message.h
+++ b/drake/systems/rendering/pose_bundle_to_draw_message.h
@@ -25,14 +25,10 @@ class PoseBundleToDrawMessage : public LeafSystem<double> {
   PoseBundleToDrawMessage();
   ~PoseBundleToDrawMessage() override;
 
- protected:
+ private:
   /// Copies the input poses into the draw message.
   void DoCalcOutput(const Context<double>& context,
                     SystemOutput<double>* output) const override;
-
-  /// Allocates a draw message.
-  std::unique_ptr<AbstractValue> AllocateOutputAbstract(
-      const OutputPortDescriptor<double>& descriptor) const override;
 };
 
 }  // namespace rendering

--- a/drake/systems/sensors/test/accelerometer_test/accelerometer_xdot_hack.cc
+++ b/drake/systems/sensors/test/accelerometer_test/accelerometer_xdot_hack.cc
@@ -10,18 +10,11 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
-AccelerometerXdotHack::AccelerometerXdotHack(int port_size)
-    : port_size_(port_size) {
+AccelerometerXdotHack::AccelerometerXdotHack(int port_size) {
   input_port_index_ =
       DeclareInputPort(kVectorValued, port_size).get_index();
   output_port_index_ =
       DeclareOutputPort(kVectorValued, port_size).get_index();
-}
-
-std::unique_ptr<BasicVector<double>>
-AccelerometerXdotHack::AllocateOutputVector(
-    const OutputPortDescriptor<double>& descriptor) const {
-  return std::make_unique<BasicVector<double>>(port_size_);
 }
 
 void AccelerometerXdotHack::DoCalcOutput(

--- a/drake/systems/sensors/test/accelerometer_test/accelerometer_xdot_hack.h
+++ b/drake/systems/sensors/test/accelerometer_test/accelerometer_xdot_hack.h
@@ -33,11 +33,6 @@ class AccelerometerXdotHack : public systems::LeafSystem<double> {
   ///
   explicit AccelerometerXdotHack(int port_size);
 
-  /// Allocates the output vector. See this class' description for details of
-  /// this output vector.
-  std::unique_ptr<BasicVector<double>> AllocateOutputVector(
-      const OutputPortDescriptor<double>& descriptor) const override;
-
   /// @name System input port descriptor accessors.
   ///@{
 
@@ -58,13 +53,11 @@ class AccelerometerXdotHack : public systems::LeafSystem<double> {
   }
   ///@}
 
- protected:
-  /// Filters the input vector and outputs the reults.
+ private:
+  // Filters the input vector and outputs the reults.
   void DoCalcOutput(const systems::Context<double>& context,
                     systems::SystemOutput<double>* output) const override;
 
- private:
-  int port_size_{};
   int input_port_index_{};
   int output_port_index_{};
 };


### PR DESCRIPTION
(Posted for API discussion in Reviewable -- not ready for a full review.)

This is step 1 of a proposed solution to #2890 (along the lines proposed in [this comment](https://github.com/RobotLocomotion/drake/issues/2890#issuecomment-268889174)).

OutputPortDescriptor gets an upgrade to a full object called OutputPort, which supports three functions:
- allocate
- calculate (unconditional)
- evaluate (cached)

The first place to look is the changes I made to the various Systems so you can see how the API works. Output ports that use model values or fixed-size plain BasicVectors are unchanged in this scheme, and most should do so. Systems that use custom allocators required some changes. In most cases I deleted a lot more lines than I added. Then check out leaf_system.h for sugar modifications, and output_port.h to see the new classes. Reviewable will show a big green section for input ports but I actually didn't change those at all so ignore that -- I just split up a file.

Only the changes to port allocation are done here -- calculation remains unchanged. All test cases should pass. Once we converge on the basic API I'll plug in the calculation changes as step 2. Then step 3 puts the output in the cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5821)
<!-- Reviewable:end -->
