### PR TITLE
Adds pose output to DepthSensor and updates DepthSensorToLcmPointCloudMessage to use it.

### DIFF
--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -87,6 +87,7 @@ drake_cc_library(
     deps = [
         "//drake/multibody:rigid_body_tree",
         "//drake/systems/framework",
+        "//drake/systems/rendering:pose_vector",
     ],
 )
 
@@ -101,6 +102,7 @@ drake_cc_library(
     deps = [
         ":depth_sensor",
         "//drake/multibody:rigid_body_tree",
+        "//drake/systems/rendering:pose_vector",
         "@bot_core_lcmtypes//:lib",
     ],
 )

--- a/drake/systems/sensors/CMakeLists.txt
+++ b/drake/systems/sensors/CMakeLists.txt
@@ -21,27 +21,32 @@ set(drakeSensors_HEADERS
     image.h
     rotary_encoders.h)
 
+set(drakeSensors_TARGET_LINK_LIBRARIES
+    drakeRBM
+    drakeRigidBodyPlant
+    drakeSystemFramework)
+
 if(VTK_FOUND)
   list(APPEND drakeSensors_SRC_FILES rgbd_camera.cc vtk_util.cc)
   list(APPEND drakeSensors_HEADERS rgbd_camera.h vtk_util.h)
 endif()
 
-if(LCM_FOUND AND Bullet_FOUND)
+if(lcm_FOUND AND Bullet_FOUND)
   list(APPEND drakeSensors_SRC_FILES depth_sensor_to_lcm_point_cloud_message.cc)
   list(APPEND drakeSensors_HEADERS depth_sensor_to_lcm_point_cloud_message.h)
+  list(APPEND drakeSensors_TARGET_LINK_LIBRARIES robotlocomotion-lcmtypes-cpp)
   add_executable(depth_sensor_to_lcm_point_cloud_message_demo
       depth_sensor_to_lcm_point_cloud_message_demo.cc)
   target_link_libraries(depth_sensor_to_lcm_point_cloud_message_demo
-      drakeSensors)
+      drakeSensors
+      drakeSystemAnalysis)
 endif()
 
 add_library_with_exports(LIB_NAME drakeSensors SOURCE_FILES
     ${drakeSensors_SRC_FILES})
 
 target_link_libraries(drakeSensors
-    drakeRBM
-    drakeRigidBodyPlant
-    drakeSystemFramework)
+    ${drakeSensors_TARGET_LINK_LIBRARIES})
 
 if(VTK_FOUND)
   target_link_libraries(drakeSensors drakeRendering vtkIO vtkRendering)

--- a/drake/systems/sensors/depth_sensor.h
+++ b/drake/systems/sensors/depth_sensor.h
@@ -57,12 +57,11 @@ namespace sensors {
 /// frame to rotate about the base frame's +Z axis, while the pitch causes it to
 /// rotate about this sensor's -Y axis.
 ///
-/// This system has one output port containing the sensed values. It is a
-/// vector representation of a depth image. For each pitch, there is a fixed
-/// number of yaw values as specified as num_pixel_cols(). Each of these vector
+/// This system has two output ports. The first contains the sensed values
+/// stored in a DepthSensorOutput object. For each pitch, there is a fixed
+/// number of yaw values as specified by num_pixel_cols(). Each of these vector
 /// of yaw values that share the same pitch are contiguous in the output vector.
-/// In other words, here is some pseudocode describing this sensor's output
-/// vector:
+/// In other words, here is pseudocode describing this sensor's output vector:
 ///
 /// <pre>
 ///  for i in 0 to num_pixel_rows():
@@ -72,8 +71,8 @@ namespace sensors {
 ///                            pitch = min_pitch() + i * pitch_increment()]
 /// </pre>
 ///
-/// If nothing is detected in between min_range and max_range, an invalid value
-/// of DepthSensor::kTooFar is provided. Is something is detected but the
+/// If nothing is detected between min_range and max_range, an invalid value of
+/// DepthSensor::kTooFar is provided. Is something is detected but the
 /// distance is less than  the sensor's minimum sensing range, a value of
 /// DepthSensor::kTooClose is provided.
 ///
@@ -81,6 +80,10 @@ namespace sensors {
 /// not expected to occur in this system's output because it models an ideal
 /// sensor in which sensing errors do not occur. It is expected to be used by
 /// non-ideal depth sensors.
+///
+/// The second output port contains a PoseVector, which is `X_WS`, i.e., the
+/// transform from this sensor's frame to the world frame. It is useful for
+/// converting this sensor's point cloud into the world frame.
 ///
 /// @ingroup sensor_systems
 ///
@@ -147,6 +150,10 @@ class DepthSensor : public systems::LeafSystem<double> {
   /// sensed values.
   const OutputPortDescriptor<double>& get_sensor_state_output_port() const;
 
+  /// Returns a descriptor of the `X_WS` output port, which contains the
+  /// transform from this sensor's frame to the world frame.
+  const OutputPortDescriptor<double>& get_pose_output_port() const;
+
   friend std::ostream& operator<<(std::ostream& out,
                                   const DepthSensor& depth_sensor);
 
@@ -169,10 +176,12 @@ class DepthSensor : public systems::LeafSystem<double> {
   const RigidBodyFrame<double> frame_;
   const DepthSensorSpecification specification_;
   int input_port_index_{};
-  int output_port_index_{};
+  int depth_output_port_index_{};
+  int pose_output_port_index_{};
 
   // A cache of where a depth measurement ray endpoint would be if the maximum
-  // range were achieved. This is cached to avoid repeated allocation.
+  // range were achieved. This is cached to avoid repeated allocation and
+  // computation.
   Eigen::Matrix3Xd raycast_endpoints_;
 };
 

--- a/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.cc
+++ b/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.cc
@@ -6,16 +6,22 @@
 #include "bot_core/pointcloud_t.hpp"
 
 #include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/rendering/pose_vector.h"
 #include "drake/systems/sensors/depth_sensor_output.h"
 
 namespace drake {
 namespace systems {
+
+using rendering::PoseVector;
+
 namespace sensors {
 
 DepthSensorToLcmPointCloudMessage::DepthSensorToLcmPointCloudMessage(
       const DepthSensorSpecification& spec) : spec_(spec) {
-  input_port_index_ =
+  depth_readings_input_port_index_ =
       DeclareVectorInputPort(DepthSensorOutput<double>(spec_)).get_index();
+  pose_input_port_index_ =
+      DeclareVectorInputPort(PoseVector<double>()).get_index();
   output_port_index_ =
       DeclareAbstractOutputPort(systems::Value<bot_core::pointcloud_t>())
           .get_index();
@@ -23,7 +29,12 @@ DepthSensorToLcmPointCloudMessage::DepthSensorToLcmPointCloudMessage(
 
 const InputPortDescriptor<double>&
 DepthSensorToLcmPointCloudMessage::depth_readings_input_port() const {
-  return this->get_input_port(input_port_index_);
+  return this->get_input_port(depth_readings_input_port_index_);
+}
+
+const InputPortDescriptor<double>&
+DepthSensorToLcmPointCloudMessage::pose_input_port() const {
+  return this->get_input_port(pose_input_port_index_);
 }
 
 const OutputPortDescriptor<double>&
@@ -37,23 +48,35 @@ void DepthSensorToLcmPointCloudMessage::DoCalcOutput(
   // Obtains the input.
   const DepthSensorOutput<double>* depth_data =
       this->template EvalVectorInput<DepthSensorOutput>(context,
-          input_port_index_);
-  const Eigen::Matrix3Xd point_cloud = depth_data->GetPointCloud();
+          depth_readings_input_port_index_);
+  const PoseVector<double>* X_WS =
+      this->template EvalVectorInput<PoseVector>(context,
+          pose_input_port_index_);
+
+  // Handles the scenario where the pose input port is unconnected.
+  if (X_WS == nullptr) {
+    throw std::runtime_error("DepthSensorToLcmPointCloudMessage: ERROR: Pose "
+        "input port unconnected.");
+  }
+
+  // Obtains the point cloud in the sensor's frame (S).
+  const Eigen::Matrix3Xd point_cloud_S = depth_data->GetPointCloud();
 
   // Obtains the output.
   bot_core::pointcloud_t& message =
       output->GetMutableData(output_port_index_)->
-        GetMutableValue<bot_core::pointcloud_t>();
+          GetMutableValue<bot_core::pointcloud_t>();
 
   message.frame_id = std::string(RigidBodyTreeConstants::kWorldName);
-  message.n_points = point_cloud.cols();
+  message.n_points = point_cloud_S.cols();
   message.points.clear();
-  for (int i = 0; i < point_cloud.cols(); ++i) {
-    const auto& point = point_cloud.col(i);
+  for (int i = 0; i < point_cloud_S.cols(); ++i) {
+    const auto& point_S = point_cloud_S.col(i);
+    Eigen::Vector3d point_W = X_WS->get_isometry() * point_S;
     message.points.push_back(std::vector<float>{
-        static_cast<float>(point(0)),
-        static_cast<float>(point(1)),
-        static_cast<float>(point(2))});
+        static_cast<float>(point_W(0)),
+        static_cast<float>(point_W(1)),
+        static_cast<float>(point_W(2))});
   }
   message.n_channels = 0;
 }

--- a/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h
+++ b/drake/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h
@@ -10,10 +10,13 @@ namespace systems {
 namespace sensors {
 
 /// A DepthSensorToLcmPointCloudMessage takes as input a DepthSensorOutput and
-/// outputs an AbstractValue containing a `Value<bot_core::pointcloud_t>` LCM
-/// message. This message can then be sent to `drake-visualizer` using
-/// LcmPublisherSystem for visualizing the depth readings contained within the
-/// DepthSensorOutput.
+/// the pose of the depth sensor in the world (`X_WS`). If the input port
+/// containing `X_WS` is unconnected, a std::runtime_error will be thrown
+/// while evaluating the output of this system. This system outputs an
+/// AbstractValue containing a `Value<bot_core::pointcloud_t>` LCM message that
+/// defines a point cloud in the world frame. This message can then be sent to
+/// `drake-visualizer` using LcmPublisherSystem for visualizing the depth
+/// readings contained within the inputted DepthSensorOutput.
 class DepthSensorToLcmPointCloudMessage : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DepthSensorToLcmPointCloudMessage)
@@ -28,6 +31,9 @@ class DepthSensorToLcmPointCloudMessage : public systems::LeafSystem<double> {
   /// Returns a descriptor of the input port containing a DepthSensorOutput.
   const InputPortDescriptor<double>& depth_readings_input_port() const;
 
+  /// Returns a descriptor of the input port containing `X_WS`.
+  const InputPortDescriptor<double>& pose_input_port() const;
+
   /// Returns a descriptor of the abstract valued output port that contains a
   /// `Value<bot_core::pointcloud_t>`.
   const OutputPortDescriptor<double>& pointcloud_message_output_port() const;
@@ -40,7 +46,8 @@ class DepthSensorToLcmPointCloudMessage : public systems::LeafSystem<double> {
   const DepthSensorSpecification& spec_;
 
   // See class description for the semantics of the input and output ports.
-  int input_port_index_{};
+  int depth_readings_input_port_index_{};
+  int pose_input_port_index_{};
   int output_port_index_{};
 };
 

--- a/drake/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
+++ b/drake/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
@@ -9,11 +9,15 @@
 
 #include "drake/common/drake_path.h"
 #include "drake/systems/framework/system_port_descriptor.h"
+#include "drake/systems/rendering/pose_vector.h"
 #include "drake/systems/sensors/depth_sensor_output.h"
 #include "drake/systems/sensors/depth_sensor_specification.h"
 
 namespace drake {
 namespace systems {
+
+using rendering::PoseVector;
+
 namespace sensors {
 namespace {
 
@@ -23,24 +27,37 @@ class TestDepthSensorToLcmPointCloudMessage : public ::testing::Test {
   // output a bot_core::pointcloud_t message.
   //
   // @pre spec_ was initialized.
-  const bot_core::pointcloud_t& InitializeAndOutputMessage() {
+  const bot_core::pointcloud_t& InitializeAndOutputMessage(
+      const PoseVector<double>& X_WS = PoseVector<double>(),
+      bool fix_pose_input_port = true) {
     // The Device Under Test (DUT).
     DepthSensorToLcmPointCloudMessage dut(spec_);
-    const InputPortDescriptor<double>& input_port =
+    EXPECT_EQ(dut.get_num_input_ports(), 2);
+    EXPECT_EQ(dut.get_num_output_ports(), 1);
+    const InputPortDescriptor<double>& sensor_data_input_port =
         dut.depth_readings_input_port();
-    EXPECT_EQ(input_port.get_system(), &dut);
-    EXPECT_EQ(input_port.size(), spec_.num_depth_readings());
+    EXPECT_EQ(sensor_data_input_port.get_system(), &dut);
+    EXPECT_EQ(sensor_data_input_port.size(), spec_.num_depth_readings());
+    const InputPortDescriptor<double>& pose_input_port =
+        dut.pose_input_port();
+    EXPECT_EQ(pose_input_port.size(), PoseVector<double>::kSize);
 
     auto depth_sensor_output =
         std::make_unique<DepthSensorOutput<double>>(spec_);
-
     const double half_range = (spec_.max_range() - spec_.min_range()) / 2;
     depth_sensor_output->SetFromVector(Eigen::VectorXd::Ones(
         spec_.num_depth_readings()) * half_range);
 
     std::unique_ptr<Context<double>> context = dut.CreateDefaultContext();
-    context->FixInputPort(input_port.get_index(),
+    context->FixInputPort(sensor_data_input_port.get_index(),
         std::move(depth_sensor_output));
+
+    if (fix_pose_input_port) {
+      auto pose_input =  std::make_unique<PoseVector<double>>();
+      pose_input->set_translation(X_WS.get_translation());
+      pose_input->set_rotation(X_WS.get_rotation());
+      context->FixInputPort(pose_input_port.get_index(), std::move(pose_input));
+    }
 
     output_ = dut.AllocateOutput(*context);
 
@@ -66,12 +83,32 @@ const int kZ(2);
 // maximum depth sensing range.
 TEST_F(TestDepthSensorToLcmPointCloudMessage, Octant1Test) {
   DepthSensorSpecification::set_octant_1_spec(&spec_);
-  const bot_core::pointcloud_t& message = InitializeAndOutputMessage();
+  const bot_core::pointcloud_t message = InitializeAndOutputMessage();
   EXPECT_EQ(message.n_points, spec_.num_depth_readings());
   for (int i = 0; i < message.n_points; ++i) {
     EXPECT_GE(message.points.at(i).at(kX), 0);
     EXPECT_GE(message.points.at(i).at(kY), 0);
     EXPECT_GE(message.points.at(i).at(kZ), 0);
+  }
+
+  // Offsets the sensor's frame relative to the world frame. Then verifies the
+  // resulting depth measurements are offset relative to the original
+  // measurements. The tolerance value was determined empirically.
+  const double kXOffset{1};
+  const double kYOffset{2};
+  const double kZOffset{3};
+  PoseVector<double> X_WS;
+  X_WS.set_translation({kXOffset, kYOffset, kZOffset});
+  const bot_core::pointcloud_t& offset_message =
+      InitializeAndOutputMessage(X_WS);
+  EXPECT_EQ(offset_message.n_points, spec_.num_depth_readings());
+  for (int i = 0; i < message.n_points; ++i) {
+    EXPECT_NEAR(message.points.at(i).at(kX) + kXOffset,
+                offset_message.points.at(i).at(kX), 1e-6);
+    EXPECT_NEAR(message.points.at(i).at(kY) + kYOffset,
+                offset_message.points.at(i).at(kY), 1e-6);
+    EXPECT_NEAR(message.points.at(i).at(kZ) + kZOffset,
+                offset_message.points.at(i).at(kZ), 1e-6);
   }
 }
 
@@ -143,6 +180,15 @@ TEST_F(TestDepthSensorToLcmPointCloudMessage, XLinearTest) {
     EXPECT_EQ(message.points.at(i).at(kY), 0);
     EXPECT_EQ(message.points.at(i).at(kZ), 0);
   }
+}
+
+// Tests that the DUT will throw an exception if its pose input port is not
+// connected.
+TEST_F(TestDepthSensorToLcmPointCloudMessage, UnconnectedPoseInput) {
+  DepthSensorSpecification::set_octant_1_spec(&spec_);
+  EXPECT_THROW(InitializeAndOutputMessage(
+      PoseVector<double>(), false /* fix_pose_input_port */),
+      std::runtime_error);
 }
 
 }  // namespace


### PR DESCRIPTION
This is necessary for downstream consumers of the depth sensor's point cloud to convert the point cloud into the world frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5823)
<!-- Reviewable:end -->
