### PR TITLE
Add names to the controller subsystems.

### DIFF
--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -50,6 +50,9 @@ void PidControlledSystem<T>::Initialize(
   DRAKE_DEMAND(plant != nullptr);
   DiagramBuilder<T> builder;
   plant_ = builder.template AddSystem(std::move(plant));
+  if (plant_->get_name().empty()) {
+    plant_->set_name("plant");
+  }
   DRAKE_ASSERT(plant_->get_num_input_ports() >= 1);
   DRAKE_ASSERT(plant_->get_num_output_ports() >= 1);
 
@@ -74,9 +77,11 @@ PidControlledSystem<T>::ConnectController(
   auto controller = builder->template AddSystem<PidController<T>>(
       std::move(feedback_selector),
       Kp, Ki, Kd);
+  controller->set_name("pid_controller");
 
   auto plant_input_adder =
       builder->template AddSystem<Adder<T>>(2, plant_input.size());
+  plant_input_adder->set_name("input_adder");
 
   builder->Connect(plant_output, controller->get_input_port_estimated_state());
 
@@ -101,6 +106,7 @@ PidControlledSystem<T>::ConnectControllerWithInputSaturation(
     DiagramBuilder<T>* builder) {
   auto saturation = builder->template AddSystem<Saturation<T>>(
       min_plant_input, max_plant_input);
+  saturation->set_name("saturation");
 
   builder->Connect(saturation->get_output_port(), plant_input);
 

--- a/drake/systems/controllers/test/pid_controlled_system_test.cc
+++ b/drake/systems/controllers/test/pid_controlled_system_test.cc
@@ -106,52 +106,92 @@ class TestPlantWithMoreOutputs : public TestPlant {
   }
 };
 
-// Instantiates a PidControlledSystem based on the supplied plant and
-// feedback selector. Verifies that the output of the PID controller is correct
-// relative to the hard-coded input and gain values.
-void DoPidControlledSystemTest(
-    std::unique_ptr<TestPlant> plant,
-    std::unique_ptr<MatrixGain<double>> feedback_selector) {
-  DiagramBuilder<double> builder;
-  const Vector1d input(1.);
-  const Eigen::Vector2d state(1.1, 0.2);
-  auto input_source = builder.AddSystem<ConstantVectorSource>(input);
-  auto state_source = builder.AddSystem<ConstantVectorSource>(state);
+class PidControlledSystemTest : public ::testing::Test {
+ protected:
+  // Instantiates a PidControlledSystem based on the supplied plant and
+  // feedback selector. Verifies that the output of the PID controller is
+  // correct relative to the hard-coded input and gain values.
+  void DoPidControlledSystemTest(
+      std::unique_ptr<TestPlant> plant,
+      std::unique_ptr<MatrixGain<double>> feedback_selector) {
+    DiagramBuilder<double> builder;
+    const Vector1d input(1.);
+    const Eigen::Vector2d state(1.1, 0.2);
+    auto input_source = builder.AddSystem<ConstantVectorSource>(input);
+    input_source->set_name("input");
+    auto state_source = builder.AddSystem<ConstantVectorSource>(state);
+    state_source->set_name("state");
 
-  const Vector1d Kp(2);
-  const Vector1d Ki(0);
-  const Vector1d Kd(0.1);
+    auto controller = builder.AddSystem<PidControlledSystem>(
+        std::move(plant), std::move(feedback_selector), Kp_, Ki_, Kd_);
+    // Check that the controller automatically assigns a name to the plant.
+    controller->set_name("controller");
 
-  auto controller = builder.AddSystem<PidControlledSystem>(
-      std::move(plant), std::move(feedback_selector), Kp, Ki, Kd);
+    builder.Connect(input_source->get_output_port(),
+                    controller->get_input_port(0));
+    builder.Connect(state_source->get_output_port(),
+                    controller->get_input_port(1));
+    builder.ExportOutput(controller->get_output_port(0));
+    diagram_ = builder.Build();
+    auto context = diagram_->CreateDefaultContext();
+    auto output = diagram_->AllocateOutput(*context);
 
-  builder.Connect(input_source->get_output_port(),
-                  controller->get_input_port(0));
-  builder.Connect(state_source->get_output_port(),
-                  controller->get_input_port(1));
-  builder.ExportOutput(controller->get_output_port(0));
-  auto diagram = builder.Build();
-  auto context = diagram->CreateDefaultContext();
-  auto output = diagram->AllocateOutput(*context);
+    systems::Context<double>* controller_context =
+        diagram_->GetMutableSubsystemContext(context.get(), controller);
+    systems::Context<double>* plant_context =
+        controller->GetMutableSubsystemContext(controller_context,
+                                               controller->plant());
 
-  systems::Context<double>* controller_context =
-      diagram->GetMutableSubsystemContext(context.get(), controller);
-  systems::Context<double>* plant_context =
-      controller->GetMutableSubsystemContext(controller_context,
-                                             controller->plant());
+    diagram_->CalcOutput(*context, output.get());
+    const BasicVector<double>* output_vec = output->get_vector_data(0);
+    const double pid_input = dynamic_cast<TestPlant*>(controller->plant())
+                                 ->GetInputValue(*plant_context);
+    EXPECT_EQ(pid_input, input[0] +
+                             (state[0] - output_vec->get_value()[0]) * Kp_(0) +
+                             (state[1] - output_vec->get_value()[1]) * Kd_(0));
+  }
 
-  diagram->CalcOutput(*context, output.get());
-  const BasicVector<double>* output_vec = output->get_vector_data(0);
-  const double pid_input = dynamic_cast<TestPlant*>(controller->plant())
-                               ->GetInputValue(*plant_context);
-  EXPECT_EQ(pid_input, input[0] +
-                           (state[0] - output_vec->get_value()[0]) * Kp(0) +
-                           (state[1] - output_vec->get_value()[1]) * Kd(0));
+  const Vector1d Kp_{2};
+  const Vector1d Ki_{0};
+  const Vector1d Kd_{0.1};
+  std::unique_ptr<Diagram<double>> diagram_;
+};
+
+// Tests that the PidController assigns default names to the plant and the
+// feedback selector, if they have no name.
+TEST_F(PidControlledSystemTest, DefaultNamesAssigned) {
+  auto plant = std::make_unique<TestPlantWithMinOutputs>();
+  auto plant_ptr = plant.get();
+  auto feedback_selector =
+    std::make_unique<MatrixGain<double>>(plant->get_output_port(0).size());
+  auto feedback_selector_ptr = feedback_selector.get();
+
+  PidControlledSystem<double> controller(
+      std::move(plant), std::move(feedback_selector), Kp_, Ki_, Kd_);
+  EXPECT_EQ("plant", plant_ptr->get_name());
+  EXPECT_EQ("custom_feedback_selector", feedback_selector_ptr->get_name());
+}
+
+// Tests that the PidController preserves the names of the plant and the
+// feedback selector.
+TEST_F(PidControlledSystemTest, ExistingNamesRespected) {
+  auto plant = std::make_unique<TestPlantWithMinOutputs>();
+  plant->set_name("my awesome plant!");
+  auto plant_ptr = plant.get();
+  auto feedback_selector =
+      std::make_unique<MatrixGain<double>>(plant->get_output_port(0).size());
+  feedback_selector->set_name("my boring feedback selector");
+  auto feedback_selector_ptr = feedback_selector.get();
+
+  PidControlledSystem<double> controller(
+      std::move(plant), std::move(feedback_selector), Kp_, Ki_, Kd_);
+  EXPECT_EQ("my awesome plant!", plant_ptr->get_name());
+  EXPECT_EQ("my boring feedback selector", feedback_selector_ptr->get_name());
 }
 
 // Tests a plant where the size of output port zero is twice the size of input
 // port zero.
-GTEST_TEST(PidControlledSystemTest, SimplePidControlledSystem) {
+TEST_F(PidControlledSystemTest, SimplePidControlledSystem) {
   // Our test plant is just a multiplexer which takes the input and outputs it
   // twice.
   auto plant = std::make_unique<TestPlantWithMinOutputs>();
@@ -162,7 +202,7 @@ GTEST_TEST(PidControlledSystemTest, SimplePidControlledSystem) {
 
 // Tests a plant where the size of output port zero is more than twice the size
 // of input port zero.
-GTEST_TEST(PidControlledSystemTest, PlantWithMoreOutputs) {
+TEST_F(PidControlledSystemTest, PlantWithMoreOutputs) {
   auto plant = std::make_unique<TestPlantWithMoreOutputs>();
   const int plant_output_size = plant->get_output_port(0).size();
   const int controller_feedback_size = plant->get_input_port(0).size() * 2;
@@ -192,7 +232,9 @@ class ConnectControllerTest : public ::testing::Test {
     plant_ = builder_.AddSystem(std::move(plant_ptr));
 
     input_source_ = builder_.AddSystem<ConstantVectorSource>(plant_input_);
+    input_source_->set_name("input");
     state_source_ = builder_.AddSystem<ConstantVectorSource>(desired_state_);
+    state_source_->set_name("state");
 
     builder_.ExportOutput(plant_->get_output_port(0));
   }

--- a/drake/systems/controllers/test/pid_controller_test.cc
+++ b/drake/systems/controllers/test/pid_controller_test.cc
@@ -49,8 +49,6 @@ class PidControllerTest : public ::testing::Test {
   Vector3d error_rate_signal_{1.3, 0.9, 3.14};
 };
 
-typedef PidControllerTest PidControllerDeathTest;
-
 // Tests getter methods for controller constants.
 TEST_F(PidControllerTest, Getters) {
   ASSERT_EQ(kp_, controller_.get_Kp_vector());
@@ -62,7 +60,7 @@ TEST_F(PidControllerTest, Getters) {
   EXPECT_NO_THROW(controller_.get_Kd_singleton());
 }
 
-TEST_F(PidControllerDeathTest, GetterVectors) {
+TEST_F(PidControllerTest, GetterVectors) {
   const Eigen::Vector2d kp{1.0, 2.0};
   const Eigen::Vector2d ki{1.0, 2.0};
   const Eigen::Vector2d kd{1.0, 2.0};
@@ -79,7 +77,7 @@ TEST_F(PidControllerDeathTest, GetterVectors) {
   EXPECT_THROW(controller.get_Kp_singleton(), std::runtime_error);
 }
 
-TEST_F(PidControllerDeathTest, GetterVectorKi) {
+TEST_F(PidControllerTest, GetterVectorKi) {
   const Eigen::Vector2d kp{1.0, 2.0};
   const Eigen::Vector2d ki{1.0, 2.0};
   const Eigen::Vector2d kd{1.0, 2.0};
@@ -88,7 +86,7 @@ TEST_F(PidControllerDeathTest, GetterVectorKi) {
   EXPECT_THROW(controller.get_Ki_singleton(), std::runtime_error);
 }
 
-TEST_F(PidControllerDeathTest, GetterVectorKd) {
+TEST_F(PidControllerTest, GetterVectorKd) {
   const Eigen::Vector2d kp{1.0, 2.0};
   const Eigen::Vector2d ki{1.0, 2.0};
   const Eigen::Vector2d kd{1.0, 2.0};


### PR DESCRIPTION
Add default names for plants and selectors that are supplied to controller-related factory methods, if they do not already have a name.

@liangfok for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5841)
<!-- Reviewable:end -->
