### PR TITLE
Fix broken url in the documentation

### DIFF
--- a/drake/doc/doxygen.h
+++ b/drake/doc/doxygen.h
@@ -26,7 +26,7 @@
   </ul>
 </ul>
 <p>For more general information, you can also visit the <a
-  href="http:/drake.mit.edu">Drake documentation main page</a>.</p>
+  href="http://drake.mit.edu">Drake documentation main page</a>.</p>
 </p>
 
 <p>Drake's C++ libraries use a small amount of template metaprogramming to


### PR DESCRIPTION
Trivial doc url fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5855)
<!-- Reviewable:end -->
