### PR TITLE
adds per major time step events. 

### DIFF
--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -586,6 +586,101 @@ GTEST_TEST(SimulatorTest, AutodiffBasic) {
   simulator.StepTo(1);
 }
 
+// Tests per step publish, discrete and unrestricted update actions. Each
+// action handler logs the context time when it's called, and the test compares
+// the time stamp against the integrator's dt.
+GTEST_TEST(SimulatorTest, PerStepAction) {
+  class PerStepActionTestSystem : public LeafSystem<double> {
+   public:
+    PerStepActionTestSystem() {}
+
+    void AddPerStepAction(
+        const typename DiscreteEvent<double>::ActionType& action) {
+      this->DeclarePerStepAction(action);
+    }
+
+    const std::vector<double>& get_publish_times() const {
+      return publish_times_;
+    }
+
+    const std::vector<double>& get_discrete_update_times() const {
+      return discrete_update_times_;
+    }
+
+    const std::vector<double>& get_unrestricted_update_times() const {
+      return unrestricted_update_times_;
+    }
+
+   private:
+    void DoCalcOutput(const Context<double>& context,
+        SystemOutput<double>* output) const override {}
+
+    void DoCalcDiscreteVariableUpdates(const Context<double>& context,
+        DiscreteValues<double>* discrete_state) const override {
+      discrete_update_times_.push_back(context.get_time());
+    }
+
+    void DoCalcUnrestrictedUpdate(const Context<double>& context,
+        State<double>* state) const override {
+      unrestricted_update_times_.push_back(context.get_time());
+    }
+
+    void DoPublish(const Context<double>& context) const override {
+      publish_times_.push_back(context.get_time());
+    }
+
+    // A hack to test actions easily.
+    // Note that these should really be part of the Context, and users should
+    // NOT use this as an example code.
+    //
+    // Since Publish only takes a const Context, the only way to log time is
+    // through some side effects. Thus, using a mutable vector can be justified.
+    //
+    // One conceptually correct implementation for discrete_update_times_ is
+    // to pre allocate a big DiscreteState in Context, and store all the time
+    // stamps there.
+    //
+    // unrestricted_update_times_ can be put in the AbstractState in Context
+    // and mutated similarly to this implementation.
+    //
+    // The motivation for keeping them as mutable are for simplicity and
+    // easiness to understand.
+    mutable std::vector<double> publish_times_;
+    mutable std::vector<double> discrete_update_times_;
+    mutable std::vector<double> unrestricted_update_times_;
+  };
+
+  PerStepActionTestSystem sys;
+  sys.AddPerStepAction(DiscreteEvent<double>::kPublishAction);
+  sys.AddPerStepAction(DiscreteEvent<double>::kDiscreteUpdateAction);
+  sys.AddPerStepAction(DiscreteEvent<double>::kUnrestrictedUpdateAction);
+  Simulator<double> sim(sys);
+
+  // Disables all simulator induced publish events, so that all publish calls
+  // are intiated by sys.
+  sim.set_publish_at_initialization(false);
+  sim.set_publish_every_time_step(false);
+  sim.Initialize();
+  sim.StepTo(0.1);
+
+  double dt = sim.get_integrator()->get_maximum_step_size();
+  int N = static_cast<int>(0.1 / dt);
+  // Need to change this if the default integrator step size is not 1ms.
+  EXPECT_EQ(N, 100);
+
+  auto& publish_times = sys.get_publish_times();
+  auto& discrete_update_times = sys.get_discrete_update_times();
+  auto& unrestricted_update_times = sys.get_unrestricted_update_times();
+  EXPECT_EQ(publish_times.size(), N);
+  EXPECT_EQ(sys.get_discrete_update_times().size(), N);
+  EXPECT_EQ(sys.get_unrestricted_update_times().size(), N);
+  for (size_t i = 0; i < publish_times.size(); ++i) {
+    EXPECT_NEAR(publish_times[i], i * dt, 1e-12);
+    EXPECT_NEAR(discrete_update_times[i], i * dt, 1e-12);
+    EXPECT_NEAR(unrestricted_update_times[i], i * dt, 1e-12);
+  }
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -42,14 +42,38 @@ std::vector<U*> Unpack(const std::vector<std::unique_ptr<U>>& in) {
   return out;
 }
 
-/// Returns true if any of the events in @p actions has type @p type.
+/// A vector of pair of subsystem id and its DiscreteEvent.
 template <typename T>
-bool HasEvent(const UpdateActions<T>& actions,
-              typename DiscreteEvent<T>::ActionType type) {
-  for (const DiscreteEvent<T>& event : actions.events) {
-    if (event.action == type) return true;
+using SubsystemIdAndEventPairs = std::vector<std::pair<int, DiscreteEvent<T>>>;
+
+/// For a subsystem identified by @p subsystem_id, sorts all its discrete events
+/// @p subsystem_events based on their event types. The results are appended to
+/// @p all_publish, @p all_discrete_update and @p all_unrestricted_update.
+template <typename T>
+void FilterSubsystemEventsByType(int subsystem_id,
+    const std::vector<DiscreteEvent<T>>& subsystem_events,
+    SubsystemIdAndEventPairs<T>* all_publish,
+    SubsystemIdAndEventPairs<T>* all_discrete_update,
+    SubsystemIdAndEventPairs<T>* all_unrestricted_update) {
+  DRAKE_ASSERT(all_publish != nullptr);
+  DRAKE_ASSERT(all_discrete_update != nullptr);
+  DRAKE_ASSERT(all_unrestricted_update != nullptr);
+  for (const auto& event : subsystem_events) {
+    switch (event.action) {
+      case DiscreteEvent<T>::kPublishAction:
+        all_publish->emplace_back(subsystem_id, event);
+        break;
+      case DiscreteEvent<T>::kDiscreteUpdateAction:
+        all_discrete_update->emplace_back(subsystem_id, event);
+        break;
+      case DiscreteEvent<T>::kUnrestrictedUpdateAction:
+        all_unrestricted_update->emplace_back(subsystem_id, event);
+        break;
+      default:
+        DRAKE_ABORT_MSG("Unknown ActionType.");
+        break;
+    }
   }
-  return false;
 }
 
 /// DiagramOutput is an implementation of SystemOutput that holds unowned
@@ -782,6 +806,50 @@ class Diagram : public System<T>,
     DoCalcNextUpdateTimeImpl(context, actions);
   }
 
+  /// Populates a vector of events that need to be handled before the integrator
+  /// can take a step.
+  void DoGetPerStepEvents(const Context<T>& context,
+      std::vector<DiscreteEvent<T>>* events) const override {
+    auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
+    DRAKE_DEMAND(diagram_context != nullptr);
+
+    // Iterate over the subsystems in sorted order, and harvest all their per
+    // step actions.
+    std::vector<std::vector<DiscreteEvent<T>>> sub_events(num_subsystems());
+
+    bool no_events = true;
+    for (int i = 0; i < num_subsystems(); ++i) {
+      const Context<T>* subcontext = diagram_context->GetSubsystemContext(i);
+      DRAKE_DEMAND(subcontext != nullptr);
+      sorted_systems_[i]->GetPerStepEvents(*subcontext, &sub_events[i]);
+      no_events = no_events && sub_events[i].empty();
+    }
+
+    // If no actions are needed, bail early.
+    if (no_events) return;
+
+    internal::SubsystemIdAndEventPairs<T> publishers;
+    internal::SubsystemIdAndEventPairs<T> updaters;
+    internal::SubsystemIdAndEventPairs<T> unrestricted_updaters;
+
+    for (int i = 0; i < num_subsystems(); i++) {
+      internal::FilterSubsystemEventsByType<T>(i, sub_events[i],
+          &publishers, &updaters, &unrestricted_updaters);
+    }
+
+    DRAKE_ASSERT(!publishers.empty() || !updaters.empty() ||
+                 !unrestricted_updaters.empty());
+
+    // Request a publish event, if our subsystems want it.
+    RequestPublishIfAny<T>(publishers, events);
+
+    // Request an update event, if our subsystems want it.
+    RequestDiscreteUpdateIfAny<T>(updaters, events);
+
+    // Request an unrestricted update event, if our subsystems want it.
+    RequestUnrestrictedUpdateIfAny<T>(unrestricted_updaters, events);
+  }
+
   /// Creates a deep copy of this Diagram<double>, converting the scalar type
   /// to AutoDiffXd, and preserving all internal structure. Subclasses
   /// may wish to override to initialize additional member data, or to return a
@@ -959,6 +1027,64 @@ class Diagram : public System<T>,
         "Scalar type conversion is only supported from Diagram<double>.");
   }
 
+  // Adds a Diagram<T1>::HandlePublish callback to handle diagram level
+  // publish in @p my_events if @p sub_events is not empty.
+  template <typename T1 = T>
+  void RequestPublishIfAny(
+      const internal::SubsystemIdAndEventPairs<T1>& sub_events,
+      std::vector<DiscreteEvent<T1>>* my_events) const {
+    if (!sub_events.empty()) {
+      DiscreteEvent<T1> event;
+      event.action = DiscreteEvent<T1>::kPublishAction;
+      event.do_publish = std::bind(&Diagram<T1>::HandlePublish, this,
+                                   std::placeholders::_1, /* context */
+                                   sub_events);
+      DRAKE_ASSERT(my_events != nullptr);
+      my_events->push_back(event);
+    }
+  }
+
+  // Adds a Diagram<T1>::HandleUnrestrictedUpdate callback to handle
+  // diagram level unrestricted update to @p my_events if @p sub_events is
+  // not empty.
+  template <typename T1 = T>
+  void RequestUnrestrictedUpdateIfAny(
+      const internal::SubsystemIdAndEventPairs<T1>& sub_events,
+      std::vector<DiscreteEvent<T1>>* my_events) const {
+    if (!sub_events.empty()) {
+      DiscreteEvent<T1> event;
+      event.action = DiscreteEvent<T1>::kUnrestrictedUpdateAction;
+      event.do_unrestricted_update = std::bind(
+                                  &Diagram<T1>::HandleUnrestrictedUpdate,
+                                  this,
+                                  std::placeholders::_1, /* context */
+                                  std::placeholders::_2, /* state */
+                                  sub_events);
+      DRAKE_ASSERT(my_events != nullptr);
+      my_events->push_back(event);
+    }
+  }
+
+  // Adds a Diagram<T1>::HandleUpdate callback to handle diagram level
+  // discrete state update to @p my_events if @p sub_events is not empty.
+  template <typename T1 = T>
+  void RequestDiscreteUpdateIfAny(
+      const internal::SubsystemIdAndEventPairs<T1>& sub_events,
+      std::vector<DiscreteEvent<T1>>* my_events) const {
+    if (!sub_events.empty()) {
+      DiscreteEvent<T1> event;
+      event.action = DiscreteEvent<T1>::kDiscreteUpdateAction;
+      event.do_calc_discrete_variable_update = std::bind(
+                                  &Diagram<T1>::HandleUpdate,
+                                  this,
+                                  std::placeholders::_1, /* context */
+                                  std::placeholders::_2, /* difference state */
+                                  sub_events);
+      DRAKE_ASSERT(my_events != nullptr);
+      my_events->push_back(event);
+    }
+  }
+
   // Aborts for scalar types that are not numeric, since there is no reasonable
   // definition of "next update time" outside of the real line.
   //
@@ -1001,63 +1127,29 @@ class Diagram : public System<T>,
       return;
     }
 
-    std::vector<std::pair<int, UpdateActions<T1>>> publishers;
-    std::vector<std::pair<int, UpdateActions<T1>>> updaters;
-    std::vector<std::pair<int, UpdateActions<T1>>> unrestricted_updaters;
+    internal::SubsystemIdAndEventPairs<T1> publishers;
+    internal::SubsystemIdAndEventPairs<T1> updaters;
+    internal::SubsystemIdAndEventPairs<T1> unrestricted_updaters;
+
     for (int i = 0; i < num_subsystems(); i++) {
-      // Ignore the subsystems that aren't among the most imminent updates.
       if (sub_actions[i].time > actions->time) continue;
-      if (internal::HasEvent(sub_actions[i],
-                             DiscreteEvent<T1>::kPublishAction)) {
-        publishers.emplace_back(i, sub_actions[i]);
-      }
-      if (internal::HasEvent(sub_actions[i],
-                             DiscreteEvent<T1>::kDiscreteUpdateAction)) {
-        updaters.emplace_back(i, sub_actions[i]);
-      }
-      if (internal::HasEvent(sub_actions[i],
-                             DiscreteEvent<T1>::kUnrestrictedUpdateAction)) {
-        unrestricted_updaters.emplace_back(i, sub_actions[i]);
-      }
+
+      internal::FilterSubsystemEventsByType(i, sub_actions[i].events,
+          &publishers, &updaters, &unrestricted_updaters);
     }
+
     DRAKE_ASSERT(!publishers.empty() || !updaters.empty() ||
                  !unrestricted_updaters.empty());
 
     // Request a publish event, if our subsystems want it.
-    if (!publishers.empty()) {
-      DiscreteEvent<T1> event;
-      event.action = DiscreteEvent<T1>::kPublishAction;
-      event.do_publish = std::bind(&Diagram<T1>::HandlePublish, this,
-                                   std::placeholders::_1, /* context */
-                                   publishers);
-      actions->events.push_back(event);
-    }
+    RequestPublishIfAny<T1>(publishers, &(actions->events));
 
     // Request an update event, if our subsystems want it.
-    if (!updaters.empty()) {
-      DiscreteEvent<T1> event;
-      event.action = DiscreteEvent<T1>::kDiscreteUpdateAction;
-      event.do_calc_discrete_variable_update = std::bind(
-                                  &Diagram<T1>::HandleUpdate,
-                                  this,
-                                  std::placeholders::_1, /* context */
-                                  std::placeholders::_2, /* difference state */
-                                  updaters);
-      actions->events.push_back(event);
-    }
+    RequestDiscreteUpdateIfAny<T1>(updaters, &(actions->events));
 
     // Request an unrestricted update event, if our subsystems want it.
-    if (!unrestricted_updaters.empty()) {
-      DiscreteEvent<T1> event;
-      event.action = DiscreteEvent<T1>::kUnrestrictedUpdateAction;
-      event.do_unrestricted_update = std::bind(
-                                  &Diagram<T1>::HandleUnrestrictedUpdate,
-                                  this,
-                                  std::placeholders::_1, /* context */
-                                  std::placeholders::_2, /* state */
-                                  unrestricted_updaters);
-      actions->events.push_back(event);
-    }
+    RequestUnrestrictedUpdateIfAny<T1>(
+        unrestricted_updaters, &(actions->events));
   }
 
   // A structural outline of a Diagram, produced by DiagramBuilder.
@@ -1287,23 +1379,21 @@ class Diagram : public System<T>,
   /// Dispatches the Publish events to the subsystems that requested them.
   void HandlePublish(
       const Context<T>& context,
-      const std::vector<std::pair<int, UpdateActions<T>>>& sub_actions) const {
+      const internal::SubsystemIdAndEventPairs<T>& sub_actions) const {
     auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
     DRAKE_DEMAND(diagram_context != nullptr);
 
     for (const auto& action : sub_actions) {
       const int index = action.first;
-      const UpdateActions<T>& action_details = action.second;
+      const DiscreteEvent<T>& event = action.second;
       DRAKE_DEMAND(index >= 0 && index < num_subsystems());
 
       const Context<T>* subcontext =
           diagram_context->GetSubsystemContext(index);
       DRAKE_DEMAND(subcontext != nullptr);
-      for (const DiscreteEvent<T>& event : action_details.events) {
-        if (event.action == DiscreteEvent<T>::kPublishAction) {
-          sorted_systems_[index]->Publish(*subcontext, event);
-        }
-      }
+
+      DRAKE_ASSERT(event.action == DiscreteEvent<T>::kPublishAction);
+      sorted_systems_[index]->Publish(*subcontext, event);
     }
   }
 
@@ -1311,7 +1401,7 @@ class Diagram : public System<T>,
   /// Dispatches the Publish events to the subsystems that requested them.
   void HandleUpdate(
       const Context<T>& context, DiscreteValues<T>* update,
-      const std::vector<std::pair<int, UpdateActions<T>>>& sub_actions) const {
+      const internal::SubsystemIdAndEventPairs<T>& sub_actions) const {
     auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
     DRAKE_DEMAND(diagram_context != nullptr);
     auto diagram_differences =
@@ -1329,7 +1419,7 @@ class Diagram : public System<T>,
     // to do so.
     for (const auto& action : sub_actions) {
       const int index = action.first;
-      const UpdateActions<T>& action_details = action.second;
+      const DiscreteEvent<T>& event = action.second;
       DRAKE_DEMAND(index >= 0 && index < num_subsystems());
 
       // Get the context and the difference state for the specified system.
@@ -1341,13 +1431,10 @@ class Diagram : public System<T>,
       DRAKE_DEMAND(subdifference != nullptr);
 
       // Do that system's update actions.
-      for (const DiscreteEvent<T>& event : action_details.events) {
-        if (event.action == DiscreteEvent<T>::kDiscreteUpdateAction) {
-          sorted_systems_[index]->CalcDiscreteVariableUpdates(*subcontext,
-                                                              event,
-                                                              subdifference);
-        }
-      }
+      DRAKE_ASSERT(event.action == DiscreteEvent<T>::kDiscreteUpdateAction);
+      sorted_systems_[index]->CalcDiscreteVariableUpdates(*subcontext,
+                                                          event,
+                                                          subdifference);
     }
   }
 
@@ -1356,7 +1443,7 @@ class Diagram : public System<T>,
   /// them.
   void HandleUnrestrictedUpdate(
       const Context<T>& context, State<T>* state,
-      const std::vector<std::pair<int, UpdateActions<T>>>& sub_actions) const {
+      const internal::SubsystemIdAndEventPairs<T>& sub_actions) const {
     auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
     DRAKE_DEMAND(diagram_context != nullptr);
     auto diagram_state = dynamic_cast<DiagramState<T>*>(state);
@@ -1367,7 +1454,7 @@ class Diagram : public System<T>,
 
     for (const auto& action : sub_actions) {
       const int index = action.first;
-      const UpdateActions<T>& action_details = action.second;
+      const DiscreteEvent<T>& event = action.second;
       DRAKE_DEMAND(index >= 0 && index < num_subsystems());
 
       // Get the context and the state for the specified system.
@@ -1378,13 +1465,10 @@ class Diagram : public System<T>,
       DRAKE_DEMAND(substate != nullptr);
 
       // Do that system's update actions.
-      for (const DiscreteEvent<T>& event : action_details.events) {
-        if (event.action == DiscreteEvent<T>::kUnrestrictedUpdateAction) {
-          sorted_systems_[index]->CalcUnrestrictedUpdate(*subcontext,
-                                                         event,
-                                                         substate);
-        }
-      }
+      DRAKE_ASSERT(event.action == DiscreteEvent<T>::kUnrestrictedUpdateAction);
+      sorted_systems_[index]->CalcUnrestrictedUpdate(*subcontext,
+                                                     event,
+                                                     substate);
     }
   }
 

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -536,6 +536,19 @@ class System {
     return actions->time;
   }
 
+  /// This method is called by a Simulator in its Initialize() to gather all
+  /// the update and publish events that need to be handled before it computes
+  /// derivatives and performs integration. It is assumed that these events
+  /// remain constant throughout the simulation. The `Step` here refers to the
+  /// major time step taken by the Simulator. @p events cannot be null.
+  void GetPerStepEvents(const Context<T>& context,
+                        std::vector<DiscreteEvent<T>>* events) const {
+    DRAKE_ASSERT_VOID(CheckValidContext(context));
+    DRAKE_ASSERT(events != nullptr);
+    events->clear();
+    DoGetPerStepEvents(context, events);
+  }
+
   /// Computes the output values that should result from the current contents
   /// of the given Context. The result may depend on time and the current values
   /// of input ports, parameters, and state variables.
@@ -1199,6 +1212,24 @@ class System {
                                     UpdateActions<T>* actions) const {
     unused(context);
     actions->time = std::numeric_limits<T>::infinity();
+  }
+
+  /// This method is intended to get all the events that need to be handled
+  /// before the simulator can take a step. @p events is cleared in the
+  /// public non-virtual GetPerStepEvents() before calling this function.
+  /// Overriding implementation should not clear @p events, and only append
+  /// to it.
+  ///
+  /// Override this method if your System needs such events. This method is
+  /// called only from the public non-virtual GetPerStepEvents(), which will
+  /// already have error-checked the parameters so you don't have to. You
+  /// may assume that @p context has already been validated and @p events is
+  /// not null, and it can be changed freely by the overriding implementation.
+  ///
+  /// The default implementation returns without changing @p events.
+  virtual void DoGetPerStepEvents(const Context<T>& context,
+      std::vector<DiscreteEvent<T>>* events) const {
+    unused(context);
   }
 
   /// Override this method for physical systems to calculate the potential

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -1305,6 +1305,148 @@ GTEST_TEST(NonUniqueNamesTest, EmptyName) {
   EXPECT_THROW(builder.Build(), std::runtime_error);
 }
 
+// A system for testing per step actions.
+class PerStepActionTestSystem : public LeafSystem<double> {
+ public:
+  PerStepActionTestSystem() {
+    DeclareDiscreteState(1);
+    DeclareAbstractState(AbstractValue::Make<std::string>(""));
+  }
+
+  void AddPerStepAction(
+      const typename DiscreteEvent<double>::ActionType& action) {
+    this->DeclarePerStepAction(action);
+  }
+
+  int get_publish_ctr() const {
+    return publish_ctr_;
+  }
+
+ private:
+  void SetDefaultState(const Context<double>& context,
+                       State<double>* state) const override {
+    (*state->get_mutable_discrete_state())[0] = 0;
+    state->get_mutable_abstract_state<std::string>(0) = "wow";
+  }
+
+  void DoCalcOutput(const Context<double>& context,
+                    SystemOutput<double>* output) const override {}
+
+  void DoCalcDiscreteVariableUpdates(const Context<double>& context,
+      DiscreteValues<double>* discrete_state) const override {
+    (*discrete_state)[0] =
+        context.get_discrete_state(0)->GetAtIndex(0) + 1;
+  }
+
+  void DoCalcUnrestrictedUpdate(const Context<double>& context,
+                                State<double>* state) const override {
+    int int_num = static_cast<int>(
+        context.get_discrete_state(0)->GetAtIndex(0));
+    state->get_mutable_abstract_state<std::string>(0) =
+        "wow" + std::to_string(int_num);
+  }
+
+  void DoPublish(const Context<double>& context) const override {
+    publish_ctr_++;
+  }
+
+  // A hack to test publish calls easily.
+  mutable int publish_ctr_{0};
+};
+
+// Builds a nested diagram and tests per step publish, discrete and
+// unrestricted updates.
+GTEST_TEST(DiagramPerStepActionTest, TestEverything) {
+  std::unique_ptr<Diagram<double>> sub_diagram;
+  PerStepActionTestSystem* sys0;
+  PerStepActionTestSystem* sys1;
+  PerStepActionTestSystem* sys2;
+
+  // Sub diagram. Has sys0, and sys1.
+  // sys0 does not have any per step actions.
+  // sys1 has discrete and unrestricted updates.
+  {
+    DiagramBuilder<double> builder;
+    sys0 = builder.AddSystem<PerStepActionTestSystem>();
+    sys0->set_name("sys0");
+    sys1 = builder.AddSystem<PerStepActionTestSystem>();
+    sys1->set_name("sys1");
+
+    sys1->AddPerStepAction(DiscreteEvent<double>::kDiscreteUpdateAction);
+    sys1->AddPerStepAction(DiscreteEvent<double>::kUnrestrictedUpdateAction);
+
+    sub_diagram = builder.Build();
+    sub_diagram->set_name("sub_diagram");
+  }
+
+  DiagramBuilder<double> builder;
+  builder.AddSystem(std::move(sub_diagram));
+  sys2 = builder.AddSystem<PerStepActionTestSystem>();
+  sys2->set_name("sys2");
+
+  // sys2 has publish and unrestricted updates.
+  sys2->AddPerStepAction(DiscreteEvent<double>::kPublishAction);
+  sys2->AddPerStepAction(DiscreteEvent<double>::kUnrestrictedUpdateAction);
+
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+  diagram->set_name("diagram");
+
+  std::vector<DiscreteEvent<double>> events;
+  diagram->GetPerStepEvents(*context, &events);
+
+  EXPECT_EQ(events.size(), 3);
+
+  auto tmp_discrete_state = diagram->AllocateDiscreteVariables();
+  std::unique_ptr<State<double>> tmp_state;
+
+  // Does unrestricted update first.
+  for (const auto& event : events) {
+    if (event.action == DiscreteEvent<double>::kUnrestrictedUpdateAction) {
+      tmp_state = context->CloneState();
+      diagram->CalcUnrestrictedUpdate(*context, event,
+          tmp_state.get());
+      context->get_mutable_state()->CopyFrom(*tmp_state);
+    }
+  }
+
+  // Does discrete updates second.
+  for (const auto& event : events) {
+    if (event.action == DiscreteEvent<double>::kDiscreteUpdateAction) {
+      diagram->CalcDiscreteVariableUpdates(*context, event,
+          tmp_discrete_state.get());
+      context->get_mutable_discrete_state()->SetFrom(*tmp_discrete_state);
+    }
+  }
+
+  // Publishes last.
+  for (const auto& event : events) {
+    if (event.action == DiscreteEvent<double>::kPublishAction) {
+      diagram->Publish(*context, event);
+    }
+  }
+
+  // Only sys2 published once.
+  EXPECT_EQ(sys0->get_publish_ctr(), 0);
+  EXPECT_EQ(sys1->get_publish_ctr(), 0);
+  EXPECT_EQ(sys2->get_publish_ctr(), 1);
+
+  // sys0 doesn't have any updates.
+  auto& sys0_context = diagram->GetSubsystemContext(*context, sys0);
+  EXPECT_EQ(sys0_context.get_discrete_state(0)->GetAtIndex(0), 0);
+  EXPECT_EQ(sys0_context.get_abstract_state<std::string>(0), "wow");
+
+  // sys1 should have an unrestricted update then a discrete update.
+  auto& sys1_context = diagram->GetSubsystemContext(*context, sys1);
+  EXPECT_EQ(sys1_context.get_discrete_state(0)->GetAtIndex(0), 1);
+  EXPECT_EQ(sys1_context.get_abstract_state<std::string>(0), "wow0");
+
+  // sys2 should have a unrestricted update then a publish.
+  auto& sys2_context = diagram->GetSubsystemContext(*context, sys2);
+  EXPECT_EQ(sys2_context.get_discrete_state(0)->GetAtIndex(0), 0);
+  EXPECT_EQ(sys2_context.get_abstract_state<std::string>(0), "wow0");
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
adds per step event handling mechanisms that are similar to the existing periodic ones. 
these events needs to be handled before the simulator takes another step. 

after this pr, the global per step publish flag in simulator can be removed. 
i think systems that wants immediate actions can override DoGetPerStepEvents, instead of returning a epsilon dt from DoCalcNextUpdateTime().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5861)
<!-- Reviewable:end -->
