### PR TITLE
Ensure that testIK.iiwaIK uses kFixed and tests infeasible constraints

### DIFF
--- a/drake/multibody/test/test_ik.cc
+++ b/drake/multibody/test/test_ik.cc
@@ -62,7 +62,7 @@ GTEST_TEST(testIK, iiwaIK) {
   parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
       GetDrakePath() + "/manipulation/models/iiwa_description/urdf/"
           "iiwa14_primitive_collision.urdf",
-      drake::multibody::joints::kRollPitchYaw, model.get());
+      drake::multibody::joints::kFixed, model.get());
 
   // Create a timespan for the constraints.  It's not particularly
   // meaningful in this test since inverseKin() only tests a single


### PR DESCRIPTION
Addressed #5867: Ensures that `testIK.iiwaIK` uses `kFixed`, and adds a negative test (testing infeasible constraints).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5868)
<!-- Reviewable:end -->
