### PR TITLE
Store cost cnstr form

### DIFF
--- a/drake/solvers/test/linear_program_examples.cc
+++ b/drake/solvers/test/linear_program_examples.cc
@@ -89,7 +89,7 @@ LinearProgram0::LinearProgram0(CostForm cost_form, ConstraintForm cnstr_form)
   Vector3d b_lb(-numeric_limits<double>::infinity(), 2.0,
                 -numeric_limits<double>::infinity());
   Vector3d b_ub(1.0, numeric_limits<double>::infinity(), 4.0);
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic: {
       Eigen::Matrix<double, 3, 2> A;
       // clang-format off
@@ -150,7 +150,7 @@ LinearProgram1::LinearProgram1(CostForm cost_form, ConstraintForm cnstr_form)
     default:
       throw std::runtime_error("Unsupported cost form.");
   }
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic:
     case ConstraintForm::kSymbolic: {
       prog()->AddBoundingBoxConstraint(Vector2d(0, -1), Vector2d(2, 4), x_);
@@ -175,8 +175,9 @@ void LinearProgram1::CheckSolution(SolverType solver_type) const {
   ExpectSolutionCostAccurate(*prog(), tol);
 }
 
-LinearProgram2::LinearProgram2(CostForm cost_form, ConstraintForm cnstr_form)
-    : OptimizationProgram(cost_form, cnstr_form),
+LinearProgram2::LinearProgram2(CostForm cost_form,
+                               ConstraintForm constraint_form)
+    : OptimizationProgram(cost_form, constraint_form),
       x_(),
       x_expected_(0, 0, 15, 25.0 / 3.0) {
   x_ = prog()->NewContinuousVariables<4>();
@@ -199,7 +200,7 @@ LinearProgram2::LinearProgram2(CostForm cost_form, ConstraintForm cnstr_form)
                 -numeric_limits<double>::infinity(), -100);
   Vector4d b_ub(numeric_limits<double>::infinity(), 25,
                 numeric_limits<double>::infinity(), 40);
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic: {
       prog()->AddLinearEqualityConstraint(Eigen::RowVector3d(3, 1, 2), 30,
                                           x_.head<3>());
@@ -281,7 +282,7 @@ LinearProgram3::LinearProgram3(CostForm cost_form, ConstraintForm cnstr_form)
   Eigen::Vector3d b_lb(11, -numeric_limits<double>::infinity(), 35);
   Eigen::Vector3d b_ub(numeric_limits<double>::infinity(), 5,
                        numeric_limits<double>::infinity());
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic: {
       prog()->AddLinearEqualityConstraint(Eigen::RowVector3d(1, -1, -1), 0,
                                           {x_.segment<1>(2), x_.head<2>()});
@@ -343,26 +344,26 @@ void LinearProgram3::CheckSolution(SolverType solver_type) const {
 
 LinearProgramTest::LinearProgramTest() {
   auto cost_form = std::get<0>(GetParam());
-  auto cnstr_form = std::get<1>(GetParam());
+  auto constraint_form = std::get<1>(GetParam());
   switch (std::get<2>(GetParam())) {
     case LinearProblems::kLinearFeasibilityProgram : {
-      prob_ = std::make_unique<LinearFeasibilityProgram>(cnstr_form);
+      prob_ = std::make_unique<LinearFeasibilityProgram>(constraint_form);
       break;
     }
     case LinearProblems::kLinearProgram0 : {
-      prob_ = std::make_unique<LinearProgram0>(cost_form, cnstr_form);
+      prob_ = std::make_unique<LinearProgram0>(cost_form, constraint_form);
       break;
     }
     case LinearProblems::kLinearProgram1 : {
-      prob_ = std::make_unique<LinearProgram1>(cost_form, cnstr_form);
+      prob_ = std::make_unique<LinearProgram1>(cost_form, constraint_form);
       break;
     }
     case LinearProblems::kLinearProgram2 : {
-      prob_ = std::make_unique<LinearProgram2>(cost_form, cnstr_form);
+      prob_ = std::make_unique<LinearProgram2>(cost_form, constraint_form);
       break;
     }
     case LinearProblems::kLinearProgram3 : {
-      prob_ = std::make_unique<LinearProgram3>(cost_form, cnstr_form);
+      prob_ = std::make_unique<LinearProgram3>(cost_form, constraint_form);
       break;
     }
     default : throw std::runtime_error("Un-recognized linear problem.");

--- a/drake/solvers/test/linear_program_examples.cc
+++ b/drake/solvers/test/linear_program_examples.cc
@@ -19,10 +19,11 @@ using drake::symbolic::Expression;
 namespace drake {
 namespace solvers {
 namespace test {
-LinearFeasibilityProgram::LinearFeasibilityProgram(ConstraintForm cnstr_form)
-    : OptimizationProgram(CostForm::kSymbolic, cnstr_form), x_() {
+LinearFeasibilityProgram::LinearFeasibilityProgram(
+    ConstraintForm constraint_form)
+    : OptimizationProgram(CostForm::kSymbolic, constraint_form), x_() {
   x_ = prog()->NewContinuousVariables<3>();
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic: {
       Matrix3d A;
       // clang-format off
@@ -72,8 +73,9 @@ void LinearFeasibilityProgram::CheckSolution(SolverType solver_type) const {
   EXPECT_GE(prog()->GetSolution(x_(1)), 1 - 1E-10);
 }
 
-LinearProgram0::LinearProgram0(CostForm cost_form, ConstraintForm cnstr_form)
-    : OptimizationProgram(cost_form, cnstr_form), x_(), x_expected_(1, 2) {
+LinearProgram0::LinearProgram0(CostForm cost_form,
+                               ConstraintForm constraint_form)
+    : OptimizationProgram(cost_form, constraint_form), x_(), x_expected_(1, 2) {
   x_ = prog()->NewContinuousVariables<2>();
   switch (cost_form) {
     case CostForm::kNonSymbolic: {
@@ -135,8 +137,9 @@ void LinearProgram0::CheckSolution(SolverType solver_type) const {
   ExpectSolutionCostAccurate(*prog(), tol);
 }
 
-LinearProgram1::LinearProgram1(CostForm cost_form, ConstraintForm cnstr_form)
-    : OptimizationProgram(cost_form, cnstr_form), x_{}, x_expected_(0, 4) {
+LinearProgram1::LinearProgram1(CostForm cost_form,
+                               ConstraintForm constraint_form)
+    : OptimizationProgram(cost_form, constraint_form), x_{}, x_expected_(0, 4) {
   x_ = prog()->NewContinuousVariables<2>();
   switch (cost_form) {
     case CostForm::kNonSymbolic: {
@@ -263,8 +266,11 @@ void LinearProgram2::CheckSolution(SolverType solver_type) const {
   ExpectSolutionCostAccurate(*prog(), tol);
 }
 
-LinearProgram3::LinearProgram3(CostForm cost_form, ConstraintForm cnstr_form)
-    : OptimizationProgram(cost_form, cnstr_form), x_(), x_expected_(8, 3, 11) {
+LinearProgram3::LinearProgram3(CostForm cost_form,
+                               ConstraintForm constraint_form)
+    : OptimizationProgram(cost_form, constraint_form),
+      x_(),
+      x_expected_(8, 3, 11) {
   x_ = prog()->NewContinuousVariables<3>("x");
   switch (cost_form) {
     case CostForm::kNonSymbolic: {

--- a/drake/solvers/test/linear_program_examples.h
+++ b/drake/solvers/test/linear_program_examples.h
@@ -19,7 +19,7 @@ class LinearFeasibilityProgram : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearFeasibilityProgram)
 
-  explicit LinearFeasibilityProgram(ConstraintForm cnstr_form);
+  explicit LinearFeasibilityProgram(ConstraintForm constraint_form);
 
   ~LinearFeasibilityProgram() override {};
 
@@ -43,7 +43,7 @@ class LinearProgram0 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearProgram0)
 
-  LinearProgram0(CostForm cost_form, ConstraintForm cnstr_form);
+  LinearProgram0(CostForm cost_form, ConstraintForm constraint_form);
 
   ~LinearProgram0() override {};
 
@@ -64,7 +64,7 @@ class LinearProgram1 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearProgram1)
 
-  LinearProgram1(CostForm cost_form, ConstraintForm cnstr_form);
+  LinearProgram1(CostForm cost_form, ConstraintForm constraint_form);
 
   ~LinearProgram1() override {};
 
@@ -92,7 +92,7 @@ class LinearProgram2 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearProgram2)
 
-  LinearProgram2(CostForm cost_form, ConstraintForm cnstr_form);
+  LinearProgram2(CostForm cost_form, ConstraintForm constraint_form);
 
   ~LinearProgram2() override {};
 
@@ -117,7 +117,7 @@ class LinearProgram3 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearProgram3)
 
-  LinearProgram3(CostForm cost_form, ConstraintForm cnstr_form);
+  LinearProgram3(CostForm cost_form, ConstraintForm constraint_form);
 
   ~LinearProgram3() override {};
 

--- a/drake/solvers/test/nonlinear_program_test.cc
+++ b/drake/solvers/test/nonlinear_program_test.cc
@@ -155,8 +155,9 @@ GTEST_TEST(testNonlinearProgram, QuadraticCost) {
 
 GTEST_TEST(testNonlinearProgram, testNonConvexQPproblem1) {
   for (const auto& cost_form : NonConvexQPproblem1::cost_forms()) {
-    for (const auto& cnstr_form : NonConvexQPproblem1::constraint_forms()) {
-      NonConvexQPproblem1 prob(cost_form, cnstr_form);
+    for (const auto& constraint_form :
+         NonConvexQPproblem1::constraint_forms()) {
+      NonConvexQPproblem1 prob(cost_form, constraint_form);
       RunNonlinearProgram(prob.prog(),
                           [&]() { prob.CheckSolution(); });
     }
@@ -165,8 +166,9 @@ GTEST_TEST(testNonlinearProgram, testNonConvexQPproblem1) {
 
 GTEST_TEST(testNonlinearProgram, testNonConvexQPproblem2) {
   for (const auto& cost_form : NonConvexQPproblem2::cost_forms()) {
-    for (const auto& cnstr_form : NonConvexQPproblem2::constraint_forms()) {
-      NonConvexQPproblem2 prob(cost_form, cnstr_form);
+    for (const auto& constraint_form :
+         NonConvexQPproblem2::constraint_forms()) {
+      NonConvexQPproblem2 prob(cost_form, constraint_form);
       RunNonlinearProgram(prob.prog(),
                           [&]() { prob.CheckSolution(); });
     }
@@ -174,8 +176,8 @@ GTEST_TEST(testNonlinearProgram, testNonConvexQPproblem2) {
 }
 
 GTEST_TEST(testNonlinearProgram, testLowerBoundedProblem) {
-  for (const auto& cnstr_form : LowerBoundedProblem::constraint_forms()) {
-    LowerBoundedProblem prob(cnstr_form);
+  for (const auto& constraint_form : LowerBoundedProblem::constraint_forms()) {
+    LowerBoundedProblem prob(constraint_form);
     prob.SetInitialGuess1();
     RunNonlinearProgram(prob.prog(),
                         [&]() { prob.CheckSolution(); });
@@ -226,9 +228,9 @@ GTEST_TEST(testNonlinearProgram, sixHumpCamel) {
 GTEST_TEST(testNonlinearProgram, testGloptiPolyConstrainedMinimization) {
   for (const auto& cost_form :
        GloptiPolyConstrainedMinimizationProblem::cost_forms()) {
-    for (const auto& cnstr_form :
+    for (const auto& constraint_form :
          GloptiPolyConstrainedMinimizationProblem::constraint_forms()) {
-      GloptiPolyConstrainedMinimizationProblem prob(cost_form, cnstr_form);
+      GloptiPolyConstrainedMinimizationProblem prob(cost_form, constraint_form);
       RunNonlinearProgram(prob.prog(),
                           [&]() { prob.CheckSolution(); });
     }
@@ -360,11 +362,11 @@ GTEST_TEST(testNonlinearProgram, MinDistanceFromPlaneToOrigin) {
   A[1] << 0, 1, 2, -1, 2, 3;
   b[1] = Vector2d(1.0, 3.0);
   for (const auto& cost_form : MinDistanceFromPlaneToOrigin::cost_forms()) {
-    for (const auto& cnstr_form :
+    for (const auto& constraint_form :
          MinDistanceFromPlaneToOrigin::constraint_forms()) {
       for (int k = 0; k < 2; ++k) {
         MinDistanceFromPlaneToOrigin prob(
-            A[k], b[k], cost_form, cnstr_form);
+            A[k], b[k], cost_form, constraint_form);
         prob.SetInitialGuess();
         RunNonlinearProgram(prob.prog_lorentz(),
                             [&]() { prob.CheckSolution(false); });

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -52,7 +52,7 @@ void ExpectSolutionCostAccurate(const MathematicalProgram &prog, double tol) {
 }
 
 OptimizationProgram::OptimizationProgram(CostForm cost_form,
-                                         ConstraintForm cnstr_form)
+                                         ConstraintForm constraint_form)
     : cost_form_(cost_form),
       cnstr_form_(cnstr_form),
       prog_(std::make_unique<MathematicalProgram>()) {}
@@ -221,7 +221,7 @@ void NonConvexQPproblem1::AddQuadraticCost() {
 }
 
 NonConvexQPproblem2::NonConvexQPproblem2(CostForm cost_form,
-                                         ConstraintForm cnstr_form)
+                                         ConstraintForm constraint_form)
     : prog_(std::make_unique<MathematicalProgram>()), x_{}, x_expected_{} {
   x_ = prog_->NewContinuousVariables<6>("x");
 
@@ -241,7 +241,7 @@ NonConvexQPproblem2::NonConvexQPproblem2(CostForm cost_form,
       throw std::runtime_error("Unsupported cost form");
   }
 
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic: {
       AddNonSymbolicConstraint();
       break;
@@ -295,7 +295,7 @@ void NonConvexQPproblem2::AddSymbolicConstraint() {
                              20);
 }
 
-LowerBoundedProblem::LowerBoundedProblem(ConstraintForm cnstr_form)
+LowerBoundedProblem::LowerBoundedProblem(ConstraintForm constraint_form)
     : prog_(std::make_unique<MathematicalProgram>()), x_{}, x_expected_{} {
   x_ = prog_->NewContinuousVariables<6>("x");
 
@@ -312,7 +312,7 @@ LowerBoundedProblem::LowerBoundedProblem(ConstraintForm cnstr_form)
   std::shared_ptr<Constraint> con2(new LowerBoundTestConstraint(4, 5));
   prog_->AddConstraint(con2, x_);
 
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic: {
       AddNonSymbolicConstraint();
       break;
@@ -369,7 +369,7 @@ void LowerBoundedProblem::AddNonSymbolicConstraint() {
 
 GloptiPolyConstrainedMinimizationProblem::
     GloptiPolyConstrainedMinimizationProblem(CostForm cost_form,
-                                             ConstraintForm cnstr_form)
+                                             ConstraintForm constraint_form)
     : prog_(std::make_unique<MathematicalProgram>()),
       x_{},
       y_{},
@@ -407,7 +407,7 @@ GloptiPolyConstrainedMinimizationProblem::
   prog_->AddConstraint(qp_con, x_);
   prog_->AddConstraint(qp_con, y_);
 
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic: {
       AddNonSymbolicConstraint();
       break;
@@ -483,7 +483,7 @@ void GloptiPolyConstrainedMinimizationProblem::AddSymbolicConstraint() {
 
 MinDistanceFromPlaneToOrigin::MinDistanceFromPlaneToOrigin(
     const Eigen::MatrixXd& A, const Eigen::VectorXd& b, CostForm cost_form,
-    ConstraintForm cnstr_form)
+    ConstraintForm constraint_form)
     : A_(A),
       b_(b),
       prog_lorentz_(std::make_unique<MathematicalProgram>()),
@@ -514,7 +514,7 @@ MinDistanceFromPlaneToOrigin::MinDistanceFromPlaneToOrigin(
       throw std::runtime_error("Not a supported cost form");
   }
 
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic: {
       AddNonSymbolicConstraint();
       break;

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -53,7 +53,9 @@ void ExpectSolutionCostAccurate(const MathematicalProgram &prog, double tol) {
 
 OptimizationProgram::OptimizationProgram(CostForm cost_form,
                                          ConstraintForm cnstr_form)
-    : prog_(std::make_unique<MathematicalProgram>()) {}
+    : cost_form_(cost_form),
+      cnstr_form_(cnstr_form),
+      prog_(std::make_unique<MathematicalProgram>()) {}
 
 void OptimizationProgram::RunProblem(
     MathematicalProgramSolverInterface* solver) {

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -54,7 +54,7 @@ void ExpectSolutionCostAccurate(const MathematicalProgram &prog, double tol) {
 OptimizationProgram::OptimizationProgram(CostForm cost_form,
                                          ConstraintForm constraint_form)
     : cost_form_(cost_form),
-      cnstr_form_(cnstr_form),
+      constraint_form_(constraint_form),
       prog_(std::make_unique<MathematicalProgram>()) {}
 
 void OptimizationProgram::RunProblem(

--- a/drake/solvers/test/optimization_examples.h
+++ b/drake/solvers/test/optimization_examples.h
@@ -35,11 +35,11 @@ class OptimizationProgram {
 
   OptimizationProgram(CostForm cost_form, ConstraintForm cnstr_form);
 
-  virtual ~OptimizationProgram() {}
+  ~OptimizationProgram() override {}
 
   CostForm cost_form() const {return cost_form_;}
 
-  ConstraintForm cnstr_form() const {return cnstr_form_;}
+  ConstraintForm constraint_form() const {return cnstr_form_;}
 
   MathematicalProgram* prog() const { return prog_.get(); }
 

--- a/drake/solvers/test/optimization_examples.h
+++ b/drake/solvers/test/optimization_examples.h
@@ -35,7 +35,7 @@ class OptimizationProgram {
 
   OptimizationProgram(CostForm cost_form, ConstraintForm constraint_form);
 
-  ~OptimizationProgram() override {}
+  virtual ~OptimizationProgram() {}
 
   CostForm cost_form() const {return cost_form_;}
 
@@ -51,7 +51,7 @@ class OptimizationProgram {
 
  private:
   CostForm cost_form_;
-  ConstraintForm cnstr_form_;
+  ConstraintForm constraint_form_;
   std::unique_ptr<MathematicalProgram> prog_;
 };
 

--- a/drake/solvers/test/optimization_examples.h
+++ b/drake/solvers/test/optimization_examples.h
@@ -33,13 +33,13 @@ class OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptimizationProgram)
 
-  OptimizationProgram(CostForm cost_form, ConstraintForm cnstr_form);
+  OptimizationProgram(CostForm cost_form, ConstraintForm constraint_form);
 
   ~OptimizationProgram() override {}
 
   CostForm cost_form() const {return cost_form_;}
 
-  ConstraintForm constraint_form() const {return cnstr_form_;}
+  ConstraintForm constraint_form() const {return constraint_form_;}
 
   MathematicalProgram* prog() const { return prog_.get(); }
 
@@ -225,7 +225,7 @@ class NonConvexQPproblem2 {
     return cnstr;
   }
 
-  NonConvexQPproblem2(CostForm cost_form, ConstraintForm cnstr_form);
+  NonConvexQPproblem2(CostForm cost_form, ConstraintForm constraint_form);
 
   void CheckSolution() const;
 
@@ -279,7 +279,7 @@ class LowerBoundedProblem {
     return cnstr;
   }
 
-  explicit LowerBoundedProblem(ConstraintForm cnstr_form);
+  explicit LowerBoundedProblem(ConstraintForm constraint_form);
 
   void CheckSolution() const;
 
@@ -387,7 +387,7 @@ class GloptiPolyConstrainedMinimizationProblem {
   }
 
   GloptiPolyConstrainedMinimizationProblem(CostForm cost_form,
-                                           ConstraintForm cnstr_form);
+                                           ConstraintForm constraint_form);
 
   MathematicalProgram* prog() const { return prog_.get(); }
 
@@ -498,7 +498,7 @@ class MinDistanceFromPlaneToOrigin {
 
   MinDistanceFromPlaneToOrigin(const Eigen::MatrixXd& A,
                                const Eigen::VectorXd& b, CostForm cost_form,
-                               ConstraintForm cnstr_form);
+                               ConstraintForm constraint_form);
 
   MathematicalProgram* prog_lorentz() const { return prog_lorentz_.get(); }
 

--- a/drake/solvers/test/optimization_examples.h
+++ b/drake/solvers/test/optimization_examples.h
@@ -37,6 +37,10 @@ class OptimizationProgram {
 
   virtual ~OptimizationProgram() {}
 
+  CostForm cost_form() const {return cost_form_;}
+
+  ConstraintForm cnstr_form() const {return cnstr_form_;}
+
   MathematicalProgram* prog() const { return prog_.get(); }
 
   virtual void CheckSolution(SolverType solver_type) const = 0;
@@ -46,6 +50,8 @@ class OptimizationProgram {
   void RunProblem(MathematicalProgramSolverInterface* solver);
 
  private:
+  CostForm cost_form_;
+  ConstraintForm cnstr_form_;
   std::unique_ptr<MathematicalProgram> prog_;
 };
 

--- a/drake/solvers/test/quadratic_program_examples.cc
+++ b/drake/solvers/test/quadratic_program_examples.cc
@@ -209,8 +209,8 @@ void QuadraticProgram1::CheckSolution(SolverType solver_type) const {
 }
 
 QuadraticProgram2::QuadraticProgram2(CostForm cost_form,
-                                     ConstraintForm cnstr_form)
-    : OptimizationProgram(cost_form, cnstr_form), x_{}, x_expected_{} {
+                                     ConstraintForm constraint_form)
+    : OptimizationProgram(cost_form, constraint_form), x_{}, x_expected_{} {
   x_ = prog()->NewContinuousVariables<5>();
 
   Eigen::Matrix<double, 5, 1> Q_diag{};
@@ -249,8 +249,8 @@ void QuadraticProgram2::CheckSolution(SolverType solver_type) const {
 }
 
 QuadraticProgram3::QuadraticProgram3(CostForm cost_form,
-                                     ConstraintForm cnstr_form)
-: OptimizationProgram(cost_form, cnstr_form), x_{}, x_expected_{} {
+                                     ConstraintForm constraint_form)
+: OptimizationProgram(cost_form, constraint_form), x_{}, x_expected_{} {
   x_ = prog()->NewContinuousVariables<6>();
   Vector4d Q1_diag;
   Q1_diag << 5.5, 6.5, 6.0, 7.0;
@@ -305,8 +305,10 @@ void QuadraticProgram3::CheckSolution(SolverType solver_type) const {
 }
 
 QuadraticProgram4::QuadraticProgram4(CostForm cost_form,
-                                     ConstraintForm cnstr_form)
-: OptimizationProgram(cost_form, cnstr_form), x_{}, x_expected_(0.8, 0.2, 0.6) {
+                                     ConstraintForm constraint_form)
+    : OptimizationProgram(cost_form, constraint_form),
+      x_{},
+      x_expected_(0.8, 0.2, 0.6) {
   x_ = prog()->NewContinuousVariables<3>();
   switch (cost_form) {
     case CostForm::kNonSymbolic : {

--- a/drake/solvers/test/quadratic_program_examples.cc
+++ b/drake/solvers/test/quadratic_program_examples.cc
@@ -23,26 +23,26 @@ namespace test {
 
 QuadraticProgramTest::QuadraticProgramTest() {
   auto cost_form = std::get<0>(GetParam());
-  auto cnstr_form = std::get<1>(GetParam());
+  auto constraint_form = std::get<1>(GetParam());
   switch (std::get<2>(GetParam())) {
     case QuadraticProblems::kQuadraticProgram0 : {
-      prob_ = std::make_unique<QuadraticProgram0>(cost_form, cnstr_form);
+      prob_ = std::make_unique<QuadraticProgram0>(cost_form, constraint_form);
       break;
     }
     case QuadraticProblems::kQuadraticProgram1 : {
-      prob_ = std::make_unique<QuadraticProgram1>(cost_form, cnstr_form);
+      prob_ = std::make_unique<QuadraticProgram1>(cost_form, constraint_form);
       break;
     }
     case QuadraticProblems::kQuadraticProgram2 : {
-      prob_ = std::make_unique<QuadraticProgram2>(cost_form, cnstr_form);
+      prob_ = std::make_unique<QuadraticProgram2>(cost_form, constraint_form);
       break;
     }
     case QuadraticProblems::kQuadraticProgram3 : {
-      prob_ = std::make_unique<QuadraticProgram3>(cost_form, cnstr_form);
+      prob_ = std::make_unique<QuadraticProgram3>(cost_form, constraint_form);
       break;
     }
     case QuadraticProblems::kQuadraticProgram4 : {
-      prob_ = std::make_unique<QuadraticProgram4>(cost_form, cnstr_form);
+      prob_ = std::make_unique<QuadraticProgram4>(cost_form, constraint_form);
       break;
     }
     default : throw std::runtime_error("Un-recognized quadratic problem.");
@@ -58,8 +58,8 @@ std::vector<QuadraticProblems> quadratic_problems() {
 }
 
 QuadraticProgram0::QuadraticProgram0(CostForm cost_form,
-                                     ConstraintForm cnstr_form)
-    : OptimizationProgram(cost_form, cnstr_form),
+                                     ConstraintForm constraint_form)
+    : OptimizationProgram(cost_form, constraint_form),
       x_(),
       x_expected_(0.25, 0.75) {
   x_ = prog()->NewContinuousVariables<2>();
@@ -84,7 +84,7 @@ QuadraticProgram0::QuadraticProgram0(CostForm cost_form,
       throw std::runtime_error("Unsupported cost form.");
     }
   }
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic : {
       prog()->AddBoundingBoxConstraint(0, numeric_limits<double>::infinity(),
                                        x_);
@@ -124,8 +124,8 @@ void QuadraticProgram0::CheckSolution(SolverType solver_type) const {
 }
 
 QuadraticProgram1::QuadraticProgram1(CostForm cost_form,
-                                     ConstraintForm cnstr_form)
-    : OptimizationProgram(cost_form, cnstr_form),
+                                     ConstraintForm constraint_form)
+    : OptimizationProgram(cost_form, constraint_form),
       x_{},
       x_expected_(0, 1, 2.0 / 3) {
   x_ = prog()->NewContinuousVariables<3>();
@@ -152,7 +152,7 @@ QuadraticProgram1::QuadraticProgram1(CostForm cost_form,
                 -numeric_limits<double>::infinity());
   Vector4d b_ub(numeric_limits<double>::infinity(), -1, 100,
                 numeric_limits<double>::infinity());
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic : {
       prog()->AddBoundingBoxConstraint(0, numeric_limits<double>::infinity(),
                                        x_);
@@ -323,7 +323,7 @@ QuadraticProgram4::QuadraticProgram4(CostForm cost_form,
     }
     default : throw std::runtime_error("Unsupported cost form.");
   }
-  switch (cnstr_form) {
+  switch (constraint_form) {
     case ConstraintForm::kNonSymbolic : {
       prog()->AddLinearEqualityConstraint(RowVector2d(1, 1), 1, x_.head<2>());
       prog()->AddLinearEqualityConstraint(RowVector2d(1, 2), 2,

--- a/drake/solvers/test/quadratic_program_examples.h
+++ b/drake/solvers/test/quadratic_program_examples.h
@@ -42,7 +42,7 @@ class QuadraticProgram0 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(QuadraticProgram0)
 
-  QuadraticProgram0(CostForm cost_form, ConstraintForm cnstr_form);
+  QuadraticProgram0(CostForm cost_form, ConstraintForm constraint_form);
 
   ~QuadraticProgram0() override {};
 
@@ -66,7 +66,7 @@ class QuadraticProgram1 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(QuadraticProgram1)
 
-  QuadraticProgram1(CostForm cost_form, ConstraintForm cnstr_form);
+  QuadraticProgram1(CostForm cost_form, ConstraintForm constraint_form);
 
   ~QuadraticProgram1() override {};
 
@@ -88,7 +88,7 @@ class QuadraticProgram2 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(QuadraticProgram2)
 
-  QuadraticProgram2(CostForm cost_form, ConstraintForm cnstr_form);
+  QuadraticProgram2(CostForm cost_form, ConstraintForm constraint_form);
 
   ~QuadraticProgram2() override {};
 
@@ -114,7 +114,7 @@ class QuadraticProgram3 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(QuadraticProgram3);
 
-  QuadraticProgram3(CostForm cost_form, ConstraintForm cnstr_form);
+  QuadraticProgram3(CostForm cost_form, ConstraintForm constraint_form);
 
   ~QuadraticProgram3() override {};
 
@@ -135,7 +135,7 @@ class QuadraticProgram4 : public OptimizationProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(QuadraticProgram4)
 
-  QuadraticProgram4(CostForm cost_form, ConstraintForm cnstr_form);
+  QuadraticProgram4(CostForm cost_form, ConstraintForm constraint_form);
 
   ~QuadraticProgram4() override {};
 


### PR DESCRIPTION
As discussed in https://drakedevelopers.slack.com/archives/C3L92BM2Q/p1492002741266876, the `cost_form` and `cnstr_form` in the constructor of `OptimizationProgram` are unused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5870)
<!-- Reviewable:end -->
