### PR TITLE
Add MOBIL controller to AutomotiveSimulator

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -245,7 +245,9 @@ drake_cc_library(
         ":lane_direction",
         ":pose_selector",
         "//drake/automotive/maliput/api",
+        "//drake/common:cond",
         "//drake/common:symbolic",
+        "//drake/math:saturate",
         "//drake/systems/rendering:pose_vector",
     ],
 )
@@ -259,7 +261,6 @@ drake_cc_library(
         ":lane_direction",
         ":pose_selector",
         ":pure_pursuit",
-        "//drake/automotive/maliput/api",
         "//drake/systems/rendering:pose_vector",
     ],
 )
@@ -355,6 +356,7 @@ drake_cc_library(
         "//drake/systems/analysis",
         "//drake/systems/lcm",
         "//drake/systems/lcm:lcmt_drake_signal_translator",
+        "//drake/systems/primitives:multiplexer",
         "//drake/systems/rendering:pose_aggregator",
         "//drake/systems/rendering:pose_bundle_to_draw_message",
     ],

--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -185,7 +185,6 @@ drake_cc_library(
     hdrs = ["mobil_planner.h"],
     deps = [
         ":generated_vectors",
-        ":idm_controller",
         ":idm_planner",
         ":lane_direction",
         ":pose_selector",
@@ -246,9 +245,7 @@ drake_cc_library(
         ":lane_direction",
         ":pose_selector",
         "//drake/automotive/maliput/api",
-        "//drake/common:cond",
         "//drake/common:symbolic",
-        "//drake/math:saturate",
         "//drake/systems/rendering:pose_vector",
     ],
 )
@@ -343,7 +340,10 @@ drake_cc_library(
         ":generated_translators",
         ":generated_vectors",
         ":idm_controller",
+        ":lane_direction",
         ":maliput_railcar",
+        ":mobil_planner",
+        ":pure_pursuit_controller",
         ":prius_vis",
         ":simple_car",
         ":trajectory_car",

--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
   gen/idm_planner_parameters.cc
   gen/maliput_railcar_params.cc
   gen/maliput_railcar_state.cc
+  gen/mobil_planner_parameters.cc
   gen/pure_pursuit_params.cc
   gen/simple_car_params.cc
   gen/simple_car_state.cc
@@ -40,6 +41,7 @@ add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
   maliput/utility/generate_obj.cc
   maliput/utility/generate_urdf.cc
   maliput_railcar.cc
+  mobil_planner.cc
   monolane_onramp_merge.cc
   pose_selector.cc
   pure_pursuit.cc
@@ -68,6 +70,7 @@ drake_install_headers(
   idm_controller.h
   idm_planner.h
   maliput_railcar.h
+  mobil_planner.h
   monolane_onramp_merge.h
   road_path.h
   pose_selector.h

--- a/drake/automotive/automotive_demo.cc
+++ b/drake/automotive/automotive_demo.cc
@@ -24,6 +24,7 @@ DEFINE_string(simple_car_names, "",
               "would spawn 3 cars subscribed to DRIVING_COMMAND_Russ, "
               "DRIVING_COMMAND_Jeremy, and DRIVING_COMMAND_Liang). If this "
               "option is provided, num_simple_car must not be provided.");
+DEFINE_int32(num_mobil_car, 0, "Number of MOBIL-controlled SimpleCar vehicles");
 DEFINE_int32(num_trajectory_car, 0, "Number of TrajectoryCar vehicles. This "
              "option is currently only applied when the road network is a flat "
              "plane or a dragway.");
@@ -236,7 +237,21 @@ void AddVehicles(RoadNetworkType road_network_type,
         simulator->AddPriusSimpleCar("StalledCar" + std::to_string(i),
             "StalledCarChannel" + std::to_string(i), state);
       }
+
+**** FIXME
+
+    for (int i = 0; i < FLAGS_num_mobil_car; ++i) {
+      const int lane_index = 0;
+      const std::string name = "MOBIL";
+      SimpleCarState<double> state;
+      // TODO(jadecastro): Modify the state.
+      const Lane* lane =
+          dragway_road_geometry->junction(0)->segment(0)->lane(lane_index);
+      simulator->AddMobilControlledSimpleCar(name, LaneDirection(lane), state);
     }
+
+*****
+
   } else if (road_network_type == RoadNetworkType::onramp) {
     DRAKE_DEMAND(road_geometry != nullptr);
     for (int i = 0; i < FLAGS_num_maliput_railcar; ++i) {

--- a/drake/automotive/automotive_demo.cc
+++ b/drake/automotive/automotive_demo.cc
@@ -24,7 +24,11 @@ DEFINE_string(simple_car_names, "",
               "would spawn 3 cars subscribed to DRIVING_COMMAND_Russ, "
               "DRIVING_COMMAND_Jeremy, and DRIVING_COMMAND_Liang). If this "
               "option is provided, num_simple_car must not be provided.");
-DEFINE_int32(num_mobil_car, 0, "Number of MOBIL-controlled SimpleCar vehicles");
+DEFINE_int32(num_mobil_car, 0,
+             "Number of MOBIL-controlled SimpleCar vehicles. This option is "
+             "currently only applied when the road network is a dragway. "
+             "MOBIL-controlled vehicles are placed behind any idm-controlled "
+             "railcars and any fixed-speed railcars.");
 DEFINE_int32(num_trajectory_car, 0, "Number of TrajectoryCar vehicles. This "
              "option is currently only applied when the road network is a flat "
              "plane or a dragway.");
@@ -89,10 +93,11 @@ using maliput::api::Lane;
 namespace automotive {
 namespace {
 
-// The distance between the coordinates of consecutive rows of railcars on a
-// dragway. 5 m ensures a gap between consecutive rows of Prius vehicles. It was
-// empirically chosen.
+// The distance between the coordinates of consecutive rows of railcars and
+// other controlled cars (e.g. MOBIL) on a dragway. 5 m ensures a gap between
+// consecutive rows of Prius vehicles. It was empirically chosen.
 constexpr double kRailcarRowSpacing{5};
+constexpr double kControlledCarRowSpacing{5};
 
 enum class RoadNetworkType {
   flat = 0,
@@ -216,12 +221,33 @@ void AddVehicles(RoadNetworkType road_network_type,
                                        std::get<1>(params),
                                        std::get<2>(params));
     }
+
+    for (int i = 0; i < FLAGS_num_mobil_car; ++i) {
+      const int lane_index = i % FLAGS_num_dragway_lanes;
+      const std::string name = "MOBIL" + std::to_string(i);
+      SimpleCarState<double> state;
+      const int row = i / FLAGS_num_dragway_lanes;
+      const double x_offset = kControlledCarRowSpacing * row;
+      const Lane* lane =
+          dragway_road_geometry->junction(0)->segment(0)->lane(lane_index);
+      if (x_offset >= lane->length()) {
+        throw std::runtime_error(
+            "Ran out of lane length to add new MOBIL-controlled SimpleCars.");
+      }
+      const double y_offset = lane->ToGeoPosition({0., 0., 0.}).y;
+      state.set_x(x_offset);
+      state.set_y(y_offset);
+      simulator->AddMobilControlledSimpleCar(name, true /* with_s */, state);
+    }
+
     AddMaliputRailcar(FLAGS_num_idm_controlled_maliput_railcar,
         true /* IDM controlled */, 0 /* initial s offset */,
         dragway_road_geometry, simulator);
     const double initial_s_offset =
-      std::ceil(FLAGS_num_idm_controlled_maliput_railcar /
-          FLAGS_num_dragway_lanes) * kRailcarRowSpacing;
+        std::ceil(FLAGS_num_idm_controlled_maliput_railcar /
+                  FLAGS_num_dragway_lanes) * kRailcarRowSpacing +
+        std::ceil(FLAGS_num_mobil_car /
+                  FLAGS_num_dragway_lanes) * kControlledCarRowSpacing;
     AddMaliputRailcar(FLAGS_num_maliput_railcar, false /* IDM controlled */,
         initial_s_offset, dragway_road_geometry, simulator);
     if (FLAGS_with_stalled_cars) {
@@ -237,20 +263,7 @@ void AddVehicles(RoadNetworkType road_network_type,
         simulator->AddPriusSimpleCar("StalledCar" + std::to_string(i),
             "StalledCarChannel" + std::to_string(i), state);
       }
-
-**** FIXME
-
-    for (int i = 0; i < FLAGS_num_mobil_car; ++i) {
-      const int lane_index = 0;
-      const std::string name = "MOBIL";
-      SimpleCarState<double> state;
-      // TODO(jadecastro): Modify the state.
-      const Lane* lane =
-          dragway_road_geometry->junction(0)->segment(0)->lane(lane_index);
-      simulator->AddMobilControlledSimpleCar(name, LaneDirection(lane), state);
     }
-
-*****
 
   } else if (road_network_type == RoadNetworkType::onramp) {
     DRAKE_DEMAND(road_geometry != nullptr);

--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -75,27 +75,32 @@ class AutomotiveSimulator {
   /// @param initial_state The SimpleCar's initial state.
   ///
   /// @return The ID of the car that was just added to the simulation.
-  int AddPriusSimpleCar(const std::string& name,
-                        const std::string& channel_name,
-                        const SimpleCarState<T>& initial_state =
-                        SimpleCarState<T>());
+  int AddPriusSimpleCar(
+      const std::string& name, const std::string& channel_name,
+      const SimpleCarState<T>& initial_state = SimpleCarState<T>());
 
-  /// Adds an IDM-controlled SimpleCar to this simulation visualized as a Toyota
-  /// Prius.
-  ///
-  /// Refer to AddPriusSimpleCar header for parameter descriptions.
-  int AddIdmControlledSimpleCar(const std::string& model_name,
-                                const SimpleCarState<T>& initial_state =
-                                SimpleCarState<T>());
-
-  /// Adds a MOBIL-controlled SimpleCar to this simulation visualized as a
+  /// Adds a SimpleCar to this simulation controlled by a MOBIL planner coupled
+  /// with a PurePursuitController to perform lateral control of the vehicle,
+  /// along with an IDM longitudinal controller.  The car is visualized as a
   /// Toyota Prius.
   ///
-  /// Refer to AddPriusSimpleCar header for parameter descriptions.
-  int AddMobilControlledSimpleCar(const std::string& model_name,
-                                  const LaneDirection& initial_lane_direction,
-                                  const SimpleCarState<T>& initial_state =
-                                  SimpleCarState<T>());
+  /// @pre Start() has NOT been called.
+  ///
+  /// @pre SetRoadGeometry() was called. Otherwise, a std::runtime_error will be
+  /// thrown.
+  ///
+  /// @param name The car's name, which must be unique among all cars.
+  /// Otherwise a std::runtime_error will be thrown.
+  ///
+  /// @param initial_with_s Initial travel direction in the lane. (See
+  /// MobilPlanner documentation.)
+  ///
+  /// @param initial_state The SimpleCar's initial state.
+  ///
+  /// @return The ID of the car that was just added to the simulation.
+  int AddMobilControlledSimpleCar(
+      const std::string& name, bool initial_with_s,
+      const SimpleCarState<T>& initial_state = SimpleCarState<T>());
 
   /// Adds a TrajectoryCar to this simulation visualized as a Toyota Prius. This
   /// includes its EulerFloatingJoint output.

--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -9,8 +9,12 @@
 #include "drake/automotive/car_vis_applicator.h"
 #include "drake/automotive/curve2.h"
 #include "drake/automotive/gen/maliput_railcar_state.h"
+#include "drake/automotive/idm_controller.h"
+#include "drake/automotive/lane_direction.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput_railcar.h"
+#include "drake/automotive/mobil_planner.h"
+#include "drake/automotive/pure_pursuit_controller.h"
 #include "drake/automotive/simple_car.h"
 #include "drake/automotive/simple_car_to_euler_floating_joint.h"
 #include "drake/automotive/trajectory_car.h"
@@ -71,9 +75,27 @@ class AutomotiveSimulator {
   /// @param initial_state The SimpleCar's initial state.
   ///
   /// @return The ID of the car that was just added to the simulation.
-  int AddPriusSimpleCar(
-      const std::string& name, const std::string& channel_name,
-      const SimpleCarState<T>& initial_state = SimpleCarState<T>());
+  int AddPriusSimpleCar(const std::string& name,
+                        const std::string& channel_name,
+                        const SimpleCarState<T>& initial_state =
+                        SimpleCarState<T>());
+
+  /// Adds an IDM-controlled SimpleCar to this simulation visualized as a Toyota
+  /// Prius.
+  ///
+  /// Refer to AddPriusSimpleCar header for parameter descriptions.
+  int AddIdmControlledSimpleCar(const std::string& model_name,
+                                const SimpleCarState<T>& initial_state =
+                                SimpleCarState<T>());
+
+  /// Adds a MOBIL-controlled SimpleCar to this simulation visualized as a
+  /// Toyota Prius.
+  ///
+  /// Refer to AddPriusSimpleCar header for parameter descriptions.
+  int AddMobilControlledSimpleCar(const std::string& model_name,
+                                  const LaneDirection& initial_lane_direction,
+                                  const SimpleCarState<T>& initial_state =
+                                  SimpleCarState<T>());
 
   /// Adds a TrajectoryCar to this simulation visualized as a Toyota Prius. This
   /// includes its EulerFloatingJoint output.

--- a/drake/automotive/mobil_planner.cc
+++ b/drake/automotive/mobil_planner.cc
@@ -256,16 +256,12 @@ const T MobilPlanner<T>::EvaluateIdm(
   const T delta = s_lead - s_ego;
   // Saturate the net_distance at distance_lower_bound away from the ego car to
   // prevent the IDM equation from producing near-singular solutions.
-  // clang-format off
   // TODO(jadecastro): Move this to IdmPlanner::Evaluate().
   const T net_distance =
-      cond(delta > T(0.), saturate(delta - idm_params.bloat_diameter(),
-                                   idm_params.distance_lower_limit(),
-                                   std::numeric_limits<T>::infinity()),
-                          saturate(delta + idm_params.bloat_diameter(),
-                                   -std::numeric_limits<T>::infinity(),
-                                   -idm_params.distance_lower_limit()));
-  // clang-format on
+      cond(delta >= T(0.), std::max(delta - idm_params.bloat_diameter(),
+                                    idm_params.distance_lower_limit()),
+           std::min(delta + idm_params.bloat_diameter(),
+                    -idm_params.distance_lower_limit()));
   DRAKE_DEMAND(std::abs(net_distance) >= idm_params.distance_lower_limit());
   const T closing_velocity = s_dot_ego - s_dot_lead;
 

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -52,7 +52,7 @@ const std::pair<RoadOdometry<double>, RoadOdometry<double>> FindClosestPair(
       if (result_trailing.pos.s < s_traffic &&
           s_traffic < result_leading.pos.s) {
         // N.B. The ego car and traffic may reside in different lanes.
-        if (s_traffic >= ego_position.pos.s) {
+        if (s_traffic > ego_position.pos.s) {
           result_leading = RoadOdometry<double>(traffic_position,
                                                 traffic_poses.get_velocity(i));
         } else {

--- a/drake/automotive/pure_pursuit.cc
+++ b/drake/automotive/pure_pursuit.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <memory>
 
+#include "drake/automotive/maliput/api/lane.h"
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/cond.h"
 #include "drake/common/drake_assert.h"
@@ -14,17 +15,14 @@ namespace automotive {
 
 using maliput::api::GeoPosition;
 using maliput::api::Lane;
-using maliput::api::LaneEnd;
 using maliput::api::LanePosition;
-using maliput::api::RoadGeometry;
-using maliput::api::RoadPosition;
 using systems::rendering::PoseVector;
 
 template <typename T>
 T PurePursuit<T>::Evaluate(const PurePursuitParams<T>& pp_params,
-                                 const SimpleCarParams<T>& car_params,
-                                 bool with_s, const RoadGeometry& road,
-                                 const PoseVector<T>& pose) {
+                           const SimpleCarParams<T>& car_params,
+                           const LaneDirection& lane_direction,
+                           const PoseVector<T>& pose) {
   DRAKE_DEMAND(pp_params.IsValid());
   DRAKE_DEMAND(car_params.IsValid());
 
@@ -34,7 +32,7 @@ T PurePursuit<T>::Evaluate(const PurePursuitParams<T>& pp_params,
   using std::sin;
 
   const GeoPosition goal_position =
-      ComputeGoalPoint(pp_params.s_lookahead(), with_s, road, pose);
+      ComputeGoalPoint(pp_params.s_lookahead(), lane_direction, pose);
 
   const T x = pose.get_translation().translation().x();
   const T y = pose.get_translation().translation().y();
@@ -49,18 +47,21 @@ T PurePursuit<T>::Evaluate(const PurePursuitParams<T>& pp_params,
 }
 
 template <typename T>
-const GeoPosition PurePursuit<T>::ComputeGoalPoint(const T& s_lookahead,
-                                                   bool with_s,
-                                                   const RoadGeometry& road,
-                                                   const PoseVector<T>& pose) {
-  const RoadPosition position =
-      pose_selector::CalcRoadPosition(road, pose.get_isometry());
+const GeoPosition PurePursuit<T>::ComputeGoalPoint(
+    const T& s_lookahead, const LaneDirection& lane_direction,
+    const PoseVector<T>& pose) {
+  const Lane* const lane = lane_direction.lane;
+  const bool with_s = lane_direction.with_s;
+  const LanePosition position =
+      lane->ToLanePosition({pose.get_isometry().translation().x(),
+                            pose.get_isometry().translation().y(),
+                            pose.get_isometry().translation().z()},
+                           nullptr, nullptr);
   const T s_new =
-      cond(with_s, position.pos.s + s_lookahead, position.pos.s - s_lookahead);
-  const T s_goal = math::saturate(s_new, 0., position.lane->length());
-  // TODO(jadecastro): Add support for locating goal points located in ongoing
-  // lanes.
-  return position.lane->ToGeoPosition(LanePosition(s_goal, 0., 0.));
+      cond(with_s, position.s + s_lookahead, position.s - s_lookahead);
+  const T s_goal = math::saturate(s_new, 0., lane->length());
+  // TODO(jadecastro): Add support for locating goal points in ongoing lanes.
+  return lane->ToGeoPosition({s_goal, 0., position.h});
 }
 
 // These instantiations must match the API documentation in pure_pursuit.h.

--- a/drake/automotive/pure_pursuit.h
+++ b/drake/automotive/pure_pursuit.h
@@ -2,8 +2,8 @@
 
 #include "drake/automotive/gen/pure_pursuit_params.h"
 #include "drake/automotive/gen/simple_car_params.h"
+#include "drake/automotive/lane_direction.h"
 #include "drake/automotive/maliput/api/lane_data.h"
-#include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/pose_selector.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/rendering/pose_vector.h"
@@ -37,23 +37,27 @@ class PurePursuit {
 
   /// Evaluates the required steering angle in radians using the pure-pursuit
   /// method.  Assumes zero elevation and superelevation.
+  ///
   /// @param pp_params contains the `lookahead_distance`, the distance along the
   /// path based on the closest position on the path to the vehicle.
+  ///
   /// @param car_params contains the `wheelbase` of the vehicle.
-  /// @param with_s is the direction of travel along the current lane.
-  /// @param road is the RoadGeometry.
+  ///
+  /// @param lane_direction is a LaneDirection containing a reference lane and
+  /// the direction of travel along the positive-s coordinate.
+  ///
   /// @param pose is the PoseVector for the ego vehicle.
   // TODO(jadecastro): Infer the direction of travel rather than require it.
   static T Evaluate(const PurePursuitParams<T>& pp_params,
-                          const SimpleCarParams<T>& car_params,
-                          bool with_s, const maliput::api::RoadGeometry& road,
-                          const systems::rendering::PoseVector<T>& pose);
+                    const SimpleCarParams<T>& car_params,
+                    const LaneDirection& lane_direction,
+                    const systems::rendering::PoseVector<T>& pose);
 
   /// Computes the goal point at a distance `s_lookahead` from the closest
   /// position on the curve in the intended direction of travel, and `with_s`
   /// and `pose` are the direction of travel and PoseVector for the ego vehicle.
   static const maliput::api::GeoPosition ComputeGoalPoint(
-      const T& s_lookahead, bool with_s, const maliput::api::RoadGeometry& road,
+      const T& s_lookahead, const LaneDirection& lane_direction,
       const systems::rendering::PoseVector<T>& pose);
 };
 

--- a/drake/automotive/pure_pursuit_controller.cc
+++ b/drake/automotive/pure_pursuit_controller.cc
@@ -8,12 +8,7 @@
 
 namespace drake {
 
-using maliput::api::GeoPosition;
-using maliput::api::Lane;
-using maliput::api::LanePosition;
-using maliput::api::Junction;
-using maliput::api::RoadGeometry;
-using maliput::api::RoadPosition;
+using systems::BasicVector;
 using systems::rendering::PoseVector;
 
 namespace automotive {
@@ -22,35 +17,19 @@ static constexpr int kPpParamsIndex{0};
 static constexpr int kCarParamsIndex{1};
 
 template <typename T>
-PurePursuitController<T>::PurePursuitController(const RoadGeometry& road)
-    : road_(road) {
-  // Declare the input port for the DrivingCommand request.
-  command_input_index_ =
-      this->DeclareInputPort(systems::kVectorValued,
-                             DrivingCommandIndices::kNumCoordinates)
-          .get_index();
-  // Declare the input port for the desired LaneDirection.
-  lane_index_ = this->DeclareAbstractInputPort().get_index();
-  // Declare the input port for the ego car PoseVector.
-  ego_pose_index_ =
-      this->DeclareInputPort(systems::kVectorValued, PoseVector<T>::kSize)
-          .get_index();
-  // Declare the DrivingCommand output port.
-  command_output_index_ =
-      this->DeclareVectorOutputPort(DrivingCommand<T>()).get_index();
-
+PurePursuitController<T>::PurePursuitController()
+    : lane_index_{this->DeclareAbstractInputPort().get_index()},
+      ego_pose_index_{
+          this->DeclareInputPort(systems::kVectorValued, PoseVector<T>::kSize)
+              .get_index()},
+      steering_command_index_{
+          this->DeclareVectorOutputPort(BasicVector<T>(1)).get_index()} {
   this->DeclareNumericParameter(PurePursuitParams<T>());
   this->DeclareNumericParameter(SimpleCarParams<T>());
 }
 
 template <typename T>
 PurePursuitController<T>::~PurePursuitController() {}
-
-template <typename T>
-const systems::InputPortDescriptor<T>&
-PurePursuitController<T>::driving_command_input() const {
-  return systems::System<T>::get_input_port(command_input_index_);
-}
 
 template <typename T>
 const systems::InputPortDescriptor<T>& PurePursuitController<T>::lane_input()
@@ -66,8 +45,8 @@ PurePursuitController<T>::ego_pose_input() const {
 
 template <typename T>
 const systems::OutputPortDescriptor<T>&
-PurePursuitController<T>::driving_command_output() const {
-  return systems::System<T>::get_output_port(command_output_index_);
+PurePursuitController<T>::steering_command_output() const {
+  return systems::System<T>::get_output_port(steering_command_index_);
 }
 
 template <typename T>
@@ -83,11 +62,6 @@ void PurePursuitController<T>::DoCalcOutput(
                                                           kCarParamsIndex);
 
   // Obtain the input/output data structures.
-  const DrivingCommand<T>* const input_command =
-      this->template EvalVectorInput<DrivingCommand>(
-          context, this->driving_command_input().get_index());
-  DRAKE_ASSERT(input_command != nullptr);
-
   const LaneDirection* const lane_direction =
       this->template EvalInputValue<LaneDirection>(
           context, this->lane_input().get_index());
@@ -98,34 +72,26 @@ void PurePursuitController<T>::DoCalcOutput(
           context, this->ego_pose_input().get_index());
   DRAKE_ASSERT(ego_pose != nullptr);
 
-  systems::BasicVector<T>* const command_output_vector =
+  systems::BasicVector<T>* const steering_output =
       output->GetMutableVectorData(0);
-  DRAKE_ASSERT(command_output_vector != nullptr);
-  DrivingCommand<T>* const output_command =
-      dynamic_cast<DrivingCommand<T>*>(command_output_vector);
-  DRAKE_ASSERT(output_command != nullptr);
+  DRAKE_ASSERT(steering_output != nullptr);
 
-  ImplDoCalcOutput(pp_params, car_params, *input_command, *lane_direction,
-                   *ego_pose, output_command);
+  ImplDoCalcOutput(pp_params, car_params, *lane_direction, *ego_pose,
+                   steering_output);
 }
 
 template <typename T>
 void PurePursuitController<T>::ImplDoCalcOutput(
     const PurePursuitParams<T>& pp_params, const SimpleCarParams<T>& car_params,
-    const DrivingCommand<T>& input_command, const LaneDirection& lane_direction,
-    const PoseVector<T>& ego_pose, DrivingCommand<T>* output_command) const {
+    const LaneDirection& lane_direction, const PoseVector<T>& ego_pose,
+    BasicVector<T>* command) const {
   DRAKE_DEMAND(car_params.IsValid());
   DRAKE_DEMAND(pp_params.IsValid());
 
   // Compute the steering angle using the pure-pursuit method.  N.B. Assumes
   // zero elevation and superelevation.
-  const T steering_angle = PurePursuit<T>::Evaluate(
-      pp_params, car_params, lane_direction.with_s, road_, ego_pose);
-
-  // Pass the commanded throttle and acceleration through to the output,
-  // applying the required steering angle.
-  output_command->set_acceleration(input_command.acceleration());
-  output_command->set_steering_angle(steering_angle);
+  (*command)[0] =
+      PurePursuit<T>::Evaluate(pp_params, car_params, lane_direction, ego_pose);
 }
 
 // These instantiations must match the API documentation in

--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -138,10 +138,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusSimpleCarInitialState) {
   initial_state.set_heading(kHeading);
   initial_state.set_velocity(kVelocity);
 
-  simulator->AddPriusSimpleCar(
-      "My Test Model",
-      "Channel",
-      initial_state);
+  simulator->AddPriusSimpleCar("My Test Model", "Channel", initial_state);
   simulator->Start();
   simulator->StepBy(1e-3);
 
@@ -158,30 +155,6 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusSimpleCarInitialState) {
   EXPECT_EQ(state_message.velocity, kVelocity);
 }
 
-GTEST_TEST(AutomotiveSimulatorTest, TestIdmControlledSimpleCar) {
-  // TODO(jwnimmer-tri) Do something better than "0_" here.
-  const std::string kJointStateChannelName = "0_FLOATING_JOINT_STATE";
-
-  const std::string joint_state_name =
-      systems::lcm::LcmPublisherSystem::make_name(kJointStateChannelName);
-
-  // Set up a basic simulation with just a Prius SimpleCar.
-  auto simulator = std::make_unique<AutomotiveSimulator<double>>(
-      std::make_unique<lcm::DrakeMockLcm>());
-
-  const maliput::api::RoadGeometry* road{};
-  EXPECT_NO_THROW(road = simulator->SetRoadGeometry(
-      std::make_unique<const maliput::dragway::RoadGeometry>(
-          maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
-          100 /* length */, 4 /* lane width */, 1 /* shoulder width */)));
-
-  const int id = simulator->AddIdmControlledSimpleCar("Foo");
-  EXPECT_EQ(id, 0);
-
-  // Finish all initialization, so that we can test the post-init state.
-  simulator->Start();
-}
-
 GTEST_TEST(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   // TODO(jwnimmer-tri) Do something better than "0_" here.
   const std::string kJointStateChannelName = "0_FLOATING_JOINT_STATE";
@@ -189,25 +162,62 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   const std::string joint_state_name =
       systems::lcm::LcmPublisherSystem::make_name(kJointStateChannelName);
 
-  // Set up a basic simulation with just a Prius SimpleCar.
+  // Set up a basic simulation with a MOBIL- and IDM-controlled SimpleCar.
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  lcm::DrakeMockLcm* lcm =
+      dynamic_cast<lcm::DrakeMockLcm*>(simulator->get_lcm());
+  ASSERT_NE(lcm, nullptr);
 
   const maliput::api::RoadGeometry* road{};
   EXPECT_NO_THROW(road = simulator->SetRoadGeometry(
       std::make_unique<const maliput::dragway::RoadGeometry>(
-          maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
+          maliput::api::RoadGeometryId({"TestDragway"}), 2 /* num lanes */,
           100 /* length */, 4 /* lane width */, 1 /* shoulder width */)));
 
-  const maliput::api::Lane* lane =
-     road->junction(0)->segment(0)->lane(0);
+  // Create one MOBIL car and two stopped cars arranged as follows:
+  //
+  // ---------------------------------------------------------------
+  // ^  +r, +y                                          | Decoy 2 |
+  // |    -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+  // +---->  +s, +x  | MOBIL Car |   | Decoy 1 |
+  // ---------------------------------------------------------------
+  SimpleCarState<double> simple_car_state;
+  simple_car_state.set_x(2);
+  simple_car_state.set_y(-2);
+  simple_car_state.set_velocity(10);
+  const int id_mobil =
+      simulator->AddMobilControlledSimpleCar("mobil", true /* with_s */,
+                                             simple_car_state);
+  EXPECT_EQ(id_mobil, 0);
 
-  const int id = simulator->AddMobilControlledSimpleCar("Foo",
-                                                        LaneDirection(lane));
-  EXPECT_EQ(id, 0);
+  MaliputRailcarState<double> decoy_state;
+  decoy_state.set_s(6);
+  decoy_state.set_speed(0);
+  const int id_decoy1 = simulator->AddPriusMaliputRailcar(
+      "decoy1", LaneDirection(road->junction(0)->segment(0)->lane(0)),
+      MaliputRailcarParams<double>(), decoy_state);
+  EXPECT_EQ(id_decoy1, 1);
+
+  decoy_state.set_s(20);
+  const int id_decoy2 = simulator->AddPriusMaliputRailcar(
+      "decoy2", LaneDirection(road->junction(0)->segment(0)->lane(1)),
+      MaliputRailcarParams<double>(), decoy_state);
+  EXPECT_EQ(id_decoy2, 2);
 
   // Finish all initialization, so that we can test the post-init state.
   simulator->Start();
+
+  // Advances the simulation to allow the MaliputRailcar to begin accelerating.
+  simulator->StepBy(0.5);
+
+  const lcmt_viewer_draw draw_message =
+      lcm->DecodeLastPublishedMessageAs<lcmt_viewer_draw>("DRAKE_VIEWER_DRAW");
+  EXPECT_EQ(draw_message.num_links, 3 * PriusVis<double>(0, "").num_poses());
+
+  // Expect the SimpleCar to start steering to the left; y value increases.
+  const double mobil_y = draw_message.position.at(0).at(1);
+  EXPECT_GE(mobil_y, -2.);
 }
 
 // Cover AddTrajectoryCar (and thus AddPublisher).
@@ -215,8 +225,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
   typedef Curve2<double> Curve2d;
   typedef Curve2d::Point2 Point2d;
   const std::vector<Point2d> waypoints{
-      {0.0, 0.0},
-      {100.0, 0.0},
+      {0.0, 0.0}, {100.0, 0.0},
   };
   const Curve2d curve{waypoints};
 
@@ -256,49 +265,48 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
 
   struct LinkInfo {
     LinkInfo(std::string name_in, int robot_num_in, int num_geom_in)
-      : name(name_in), robot_num(robot_num_in), num_geom(num_geom_in) {}
+        : name(name_in), robot_num(robot_num_in), num_geom(num_geom_in) {}
     std::string name;
     int robot_num{};
     int num_geom{};
   };
 
-  const std::vector<LinkInfo> expected_load {
-    LinkInfo("chassis_floor", 0, 1),
-    LinkInfo("front_axle", 0, 1),
-    LinkInfo("left_tie_rod_arm", 0, 2),
-    LinkInfo("left_hub", 0, 1),
-    LinkInfo("tie_rod", 0, 1),
-    LinkInfo("left_wheel", 0, 3),
-    LinkInfo("right_tie_rod_arm", 0, 2),
-    LinkInfo("right_hub", 0, 1),
-    LinkInfo("right_wheel", 0, 3),
-    LinkInfo("rear_axle", 0, 1),
-    LinkInfo("left_wheel_rear", 0, 3),
-    LinkInfo("right_wheel_rear", 0, 3),
-    LinkInfo("body", 0, 1),
-    LinkInfo("front_lidar_link", 0, 1),
-    LinkInfo("top_lidar_link", 0, 1),
-    LinkInfo("rear_right_lidar_link", 0, 1),
-    LinkInfo("rear_left_lidar_link", 0, 1),
-    LinkInfo("chassis_floor", 1, 1),
-    LinkInfo("front_axle", 1, 1),
-    LinkInfo("left_tie_rod_arm", 1, 2),
-    LinkInfo("left_hub", 1, 1),
-    LinkInfo("tie_rod", 1, 1),
-    LinkInfo("left_wheel", 1, 3),
-    LinkInfo("right_tie_rod_arm", 1, 2),
-    LinkInfo("right_hub", 1, 1),
-    LinkInfo("right_wheel", 1, 3),
-    LinkInfo("rear_axle", 1, 1),
-    LinkInfo("left_wheel_rear", 1, 3),
-    LinkInfo("right_wheel_rear", 1, 3),
-    LinkInfo("body", 1, 1),
-    LinkInfo("front_lidar_link", 1, 1),
-    LinkInfo("top_lidar_link", 1, 1),
-    LinkInfo("rear_right_lidar_link", 1, 1),
-    LinkInfo("rear_left_lidar_link", 1, 1),
-    LinkInfo("world", 0, 0)
-  };
+  const std::vector<LinkInfo> expected_load{
+      LinkInfo("chassis_floor", 0, 1),
+      LinkInfo("front_axle", 0, 1),
+      LinkInfo("left_tie_rod_arm", 0, 2),
+      LinkInfo("left_hub", 0, 1),
+      LinkInfo("tie_rod", 0, 1),
+      LinkInfo("left_wheel", 0, 3),
+      LinkInfo("right_tie_rod_arm", 0, 2),
+      LinkInfo("right_hub", 0, 1),
+      LinkInfo("right_wheel", 0, 3),
+      LinkInfo("rear_axle", 0, 1),
+      LinkInfo("left_wheel_rear", 0, 3),
+      LinkInfo("right_wheel_rear", 0, 3),
+      LinkInfo("body", 0, 1),
+      LinkInfo("front_lidar_link", 0, 1),
+      LinkInfo("top_lidar_link", 0, 1),
+      LinkInfo("rear_right_lidar_link", 0, 1),
+      LinkInfo("rear_left_lidar_link", 0, 1),
+      LinkInfo("chassis_floor", 1, 1),
+      LinkInfo("front_axle", 1, 1),
+      LinkInfo("left_tie_rod_arm", 1, 2),
+      LinkInfo("left_hub", 1, 1),
+      LinkInfo("tie_rod", 1, 1),
+      LinkInfo("left_wheel", 1, 3),
+      LinkInfo("right_tie_rod_arm", 1, 2),
+      LinkInfo("right_hub", 1, 1),
+      LinkInfo("right_wheel", 1, 3),
+      LinkInfo("rear_axle", 1, 1),
+      LinkInfo("left_wheel_rear", 1, 3),
+      LinkInfo("right_wheel_rear", 1, 3),
+      LinkInfo("body", 1, 1),
+      LinkInfo("front_lidar_link", 1, 1),
+      LinkInfo("top_lidar_link", 1, 1),
+      LinkInfo("rear_right_lidar_link", 1, 1),
+      LinkInfo("rear_left_lidar_link", 1, 1),
+      LinkInfo("world", 0, 0)};
 
   for (int i = 0; i < load_message.num_links; ++i) {
     EXPECT_EQ(load_message.link.at(i).name, expected_load.at(i).name);
@@ -318,7 +326,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
   EXPECT_EQ(draw_message.link_name.at(0), "chassis_floor");
   EXPECT_EQ(draw_message.robot_num.at(0), 0);
   EXPECT_NEAR(draw_message.position.at(0).at(0),
-      PriusVis<double>::kVisOffset + 0.99, 1e-6);
+              PriusVis<double>::kVisOffset + 0.99, 1e-6);
   EXPECT_NEAR(draw_message.position.at(0).at(1), 0, 1e-8);
   EXPECT_NEAR(draw_message.position.at(0).at(2), 0.378326, 1e-8);
   EXPECT_NEAR(draw_message.quaternion.at(0).at(0), 1, 1e-8);
@@ -348,7 +356,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
 }
 
 // Returns the x-position of the vehicle based on an lcmt_viewer_draw message.
-// It also checks that the y-position of the vehicle is euqal to the provided y
+// It also checks that the y-position of the vehicle is equal to the provided y
 // value.
 double GetPosition(const lcmt_viewer_draw& message, double y) {
   EXPECT_EQ(message.num_links, PriusVis<double>(0, "").num_poses());
@@ -368,15 +376,15 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMaliputRailcar) {
   MaliputRailcarParams<double> params;
   params.set_r(kR);
 
-  EXPECT_THROW(
-      simulator->AddPriusMaliputRailcar("foo", LaneDirection()),
-      std::runtime_error);
+  EXPECT_THROW(simulator->AddPriusMaliputRailcar("foo", LaneDirection()),
+               std::runtime_error);
 
   const maliput::api::RoadGeometry* road{};
-  EXPECT_NO_THROW(road = simulator->SetRoadGeometry(
-      std::make_unique<const maliput::dragway::RoadGeometry>(
-          maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
-          100 /* length */, 4 /* lane width */, 1 /* shoulder width */)));
+  EXPECT_NO_THROW(
+      road = simulator->SetRoadGeometry(
+          std::make_unique<const maliput::dragway::RoadGeometry>(
+              maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
+              100 /* length */, 4 /* lane width */, 1 /* shoulder width */)));
 
   EXPECT_THROW(
       simulator->AddPriusMaliputRailcar("bar", LaneDirection(), params),
@@ -387,13 +395,15 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMaliputRailcar) {
           maliput::api::RoadGeometryId({"DifferentDragway"}), 2 /* num lanes */,
           50 /* length */, 3 /* lane width */, 2 /* shoulder width */);
 
-  EXPECT_THROW(simulator->AddPriusMaliputRailcar("bar",
-      LaneDirection(different_road->junction(0)->segment(0)->lane(0)), params),
-      std::runtime_error);
+  EXPECT_THROW(simulator->AddPriusMaliputRailcar(
+                   "bar", LaneDirection(
+                              different_road->junction(0)->segment(0)->lane(0)),
+                   params),
+               std::runtime_error);
 
-  const int id = simulator->AddPriusMaliputRailcar("model_name",
-      LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
-      MaliputRailcarState<double>() /* initial state */);
+  const int id = simulator->AddPriusMaliputRailcar(
+      "model_name", LaneDirection(road->junction(0)->segment(0)->lane(0)),
+      params, MaliputRailcarState<double>() /* initial state */);
   EXPECT_EQ(id, 0);
 
   simulator->Start();
@@ -462,10 +472,10 @@ GTEST_TEST(AutomotiveSimulatorTest, TestLcmOutput) {
   typedef Curve2d::Point2 Point2d;
   const std::vector<Point2d> waypoints{Point2d{0, 0}, Point2d{1, 0}};
   const Curve2d curve{waypoints};
-  simulator->AddPriusTrajectoryCar(
-      "alice", curve, 1 /* speed */, 0 /* start time */);
-  simulator->AddPriusTrajectoryCar(
-      "bob", curve, 1 /* speed */, 0 /* start time */);
+  simulator->AddPriusTrajectoryCar("alice", curve, 1 /* speed */,
+                                   0 /* start time */);
+  simulator->AddPriusTrajectoryCar("bob", curve, 1 /* speed */,
+                                   0 /* start time */);
 
   simulator->Start();
   simulator->StepBy(1e-3);
@@ -503,7 +513,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
 
   EXPECT_NO_THROW(simulator->AddPriusSimpleCar("Model1", "Channel1"));
   EXPECT_THROW(simulator->AddPriusSimpleCar("Model1", "foo"),
-      std::runtime_error);
+               std::runtime_error);
 
   typedef Curve2<double> Curve2d;
   typedef Curve2d::Point2 Point2d;
@@ -512,26 +522,33 @@ GTEST_TEST(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
 
   EXPECT_NO_THROW(simulator->AddPriusTrajectoryCar(
       "alice", curve, 1 /* speed */, 0 /* start time */));
-  EXPECT_THROW(simulator->AddPriusTrajectoryCar(
-      "alice", curve, 1 /* speed */, 0 /* start time */), std::runtime_error);
-  EXPECT_THROW(simulator->AddPriusTrajectoryCar(
-      "Model1", curve, 1 /* speed */, 0 /* start time */), std::runtime_error);
+  EXPECT_THROW(simulator->AddPriusTrajectoryCar("alice", curve, 1 /* speed */,
+                                                0 /* start time */),
+               std::runtime_error);
+  EXPECT_THROW(simulator->AddPriusTrajectoryCar("Model1", curve, 1 /* speed */,
+                                                0 /* start time */),
+               std::runtime_error);
 
   const MaliputRailcarParams<double> params;
   const maliput::api::RoadGeometry* road{};
-  EXPECT_NO_THROW(road = simulator->SetRoadGeometry(
-      std::make_unique<const maliput::dragway::RoadGeometry>(
-          maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
-          100 /* length */, 4 /* lane width */, 1 /* shoulder width */)));
-  EXPECT_NO_THROW(simulator->AddPriusMaliputRailcar("Foo",
-      LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
+  EXPECT_NO_THROW(
+      road = simulator->SetRoadGeometry(
+          std::make_unique<const maliput::dragway::RoadGeometry>(
+              maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
+              100 /* length */, 4 /* lane width */, 1 /* shoulder width */)));
+  EXPECT_NO_THROW(simulator->AddPriusMaliputRailcar(
+      "Foo", LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
       MaliputRailcarState<double>() /* initial state */));
-  EXPECT_THROW(simulator->AddPriusMaliputRailcar("alice",
-      LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
-      MaliputRailcarState<double>() /* initial state */), std::runtime_error);
-  EXPECT_THROW(simulator->AddPriusMaliputRailcar("Model1",
-      LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
-      MaliputRailcarState<double>() /* initial state */), std::runtime_error);
+  EXPECT_THROW(
+      simulator->AddPriusMaliputRailcar(
+          "alice", LaneDirection(road->junction(0)->segment(0)->lane(0)),
+          params, MaliputRailcarState<double>() /* initial state */),
+      std::runtime_error);
+  EXPECT_THROW(
+      simulator->AddPriusMaliputRailcar(
+          "Model1", LaneDirection(road->junction(0)->segment(0)->lane(0)),
+          params, MaliputRailcarState<double>() /* initial state */),
+      std::runtime_error);
 }
 
 // Verifies that no exception is thrown when multiple IDM-controlled
@@ -541,16 +558,15 @@ GTEST_TEST(AutomotiveSimulatorTest, TestIdmControllerUniqueName) {
       std::make_unique<lcm::DrakeMockLcm>());
 
   const MaliputRailcarParams<double> params;
-  const maliput::api::RoadGeometry* road =
-      simulator->SetRoadGeometry(
-          std::make_unique<const maliput::dragway::RoadGeometry>(
-              maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
-              100 /* length */, 4 /* lane width */, 1 /* shoulder width */));
-  simulator->AddIdmControlledPriusMaliputRailcar("Alice",
-      LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
+  const maliput::api::RoadGeometry* road = simulator->SetRoadGeometry(
+      std::make_unique<const maliput::dragway::RoadGeometry>(
+          maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
+          100 /* length */, 4 /* lane width */, 1 /* shoulder width */));
+  simulator->AddIdmControlledPriusMaliputRailcar(
+      "Alice", LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
       MaliputRailcarState<double>() /* initial state */);
-  simulator->AddIdmControlledPriusMaliputRailcar("Bob",
-      LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
+  simulator->AddIdmControlledPriusMaliputRailcar(
+      "Bob", LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
       MaliputRailcarState<double>() /* initial state */);
 
   EXPECT_NO_THROW(simulator->Start());

--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/automotive/curve2.h"
 #include "drake/automotive/lane_direction.h"
+#include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/prius_vis.h"
 #include "drake/common/drake_path.h"
@@ -155,6 +156,58 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusSimpleCarInitialState) {
   EXPECT_EQ(state_message.y, kY);
   EXPECT_EQ(state_message.heading, kHeading);
   EXPECT_EQ(state_message.velocity, kVelocity);
+}
+
+GTEST_TEST(AutomotiveSimulatorTest, TestIdmControlledSimpleCar) {
+  // TODO(jwnimmer-tri) Do something better than "0_" here.
+  const std::string kJointStateChannelName = "0_FLOATING_JOINT_STATE";
+
+  const std::string joint_state_name =
+      systems::lcm::LcmPublisherSystem::make_name(kJointStateChannelName);
+
+  // Set up a basic simulation with just a Prius SimpleCar.
+  auto simulator = std::make_unique<AutomotiveSimulator<double>>(
+      std::make_unique<lcm::DrakeMockLcm>());
+
+  const maliput::api::RoadGeometry* road{};
+  EXPECT_NO_THROW(road = simulator->SetRoadGeometry(
+      std::make_unique<const maliput::dragway::RoadGeometry>(
+          maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
+          100 /* length */, 4 /* lane width */, 1 /* shoulder width */)));
+
+  const int id = simulator->AddIdmControlledSimpleCar("Foo");
+  EXPECT_EQ(id, 0);
+
+  // Finish all initialization, so that we can test the post-init state.
+  simulator->Start();
+}
+
+GTEST_TEST(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
+  // TODO(jwnimmer-tri) Do something better than "0_" here.
+  const std::string kJointStateChannelName = "0_FLOATING_JOINT_STATE";
+
+  const std::string joint_state_name =
+      systems::lcm::LcmPublisherSystem::make_name(kJointStateChannelName);
+
+  // Set up a basic simulation with just a Prius SimpleCar.
+  auto simulator = std::make_unique<AutomotiveSimulator<double>>(
+      std::make_unique<lcm::DrakeMockLcm>());
+
+  const maliput::api::RoadGeometry* road{};
+  EXPECT_NO_THROW(road = simulator->SetRoadGeometry(
+      std::make_unique<const maliput::dragway::RoadGeometry>(
+          maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
+          100 /* length */, 4 /* lane width */, 1 /* shoulder width */)));
+
+  const maliput::api::Lane* lane =
+     road->junction(0)->segment(0)->lane(0);
+
+  const int id = simulator->AddMobilControlledSimpleCar("Foo",
+                                                        LaneDirection(lane));
+  EXPECT_EQ(id, 0);
+
+  // Finish all initialization, so that we can test the post-init state.
+  simulator->Start();
 }
 
 // Cover AddTrajectoryCar (and thus AddPublisher).

--- a/drake/automotive/test/mobil_planner_test.cc
+++ b/drake/automotive/test/mobil_planner_test.cc
@@ -321,6 +321,26 @@ TEST_F(MobilPlannerTest, ThreeLaneIncentiveTestPreferRight) {
   EXPECT_EQ(lane_directions_[right_lane_index_].lane->id().id,
             lane_direction.lane->id().id);
 }
+
+// Tests that MobilPlanner is failsafe to two cars side-by-side.
+TEST_F(MobilPlannerTest, SideBySideCars) {
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  // Arrange the ego car and traffic cars to have identical poses.
+  SetDefaultMultiLanePoses(lane_directions_[right_lane_index_], /* ego lane */
+                           {10., 0.}); /* traffic car position */
+
+  // Expect failsafe behavior.
+  const auto result = output_->GetMutableData(lane_output_index_);
+  dut_->CalcOutput(*context_, output_.get());
+  auto lane_direction = result->template GetMutableValue<LaneDirection>();
+
+  // Expect the rightmost lane (ego car's lane) to be more desirable.
+  EXPECT_EQ(lane_directions_[right_lane_index_].lane->id().id,
+            lane_direction.lane->id().id);
+}
+
 }  // namespace
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/test/pose_selector_test.cc
+++ b/drake/automotive/test/pose_selector_test.cc
@@ -66,6 +66,28 @@ static void SetDefaultPoses(PoseVector<double>* ego_pose,
                           Eigen::Isometry3d(translation_far_behind));
 }
 
+static void SetDefaultPosesSideBySide(PoseVector<double>* ego_pose,
+                                      PoseBundle<double>* traffic_poses) {
+  DRAKE_DEMAND(traffic_poses->get_num_poses() == 1);
+  DRAKE_DEMAND(kEgoSPosition > 0. && kLaneLength > kEgoSPosition);
+  DRAKE_DEMAND(kLeadingSPosition > kEgoSPosition &&
+               kLaneLength > kLeadingSPosition);
+  DRAKE_DEMAND(kEgoSPosition > kTrailingSPosition && kTrailingSPosition > 0.);
+
+  // Create poses for one traffic car and one ego positioned side-by-side, with
+  // the ego vehicle in the right lane and the traffic vehicle in the left lane.
+  ego_pose->set_translation(Eigen::Translation3d(
+      kEgoSPosition /* s */, kEgoRPosition /* r */, 0. /* h */));
+  const Eigen::Translation3d translation(
+      kEgoSPosition /* s */, kEgoRPosition + kLaneWidth /* r */, 0. /* h */);
+  FrameVelocity<double> velocity{};
+  velocity.get_mutable_value() << 0. /* ωx */, 0. /* ωy */,
+      0. /* ωz */, kTrafficXVelocity /* vx */, 0. /* vy */, 0. /* vz */;
+  traffic_poses->set_pose(0, Eigen::Isometry3d(translation));
+  traffic_poses->set_velocity(0, velocity);
+}
+
+
 GTEST_TEST(PoseSelectorTest, DragwayTest) {
   // Create a straight road, two lanes wide, in which the two s-r
   // Lane-coordinate frames are aligned with the x-y world coordinates, with s_i
@@ -146,6 +168,33 @@ GTEST_TEST(PoseSelectorTest, DragwayTest) {
   // car to be leading.
   EXPECT_EQ(kLeadingSPosition, leading_odometry.pos.s);
   EXPECT_EQ(-std::numeric_limits<double>::infinity(), trailing_odometry.pos.s);
+}
+
+// Verifies the result when the s-positions of the ego traffic vehicles have the
+// same s-position (side-by-side in adjacent lanes).
+GTEST_TEST(PoseSelectorTest, IdenticalSValues) {
+  // Instantiate a two-lane Dragway, identical to DragwayTest.
+  const int kNumLanes{2};
+  const maliput::dragway::RoadGeometry road(
+      maliput::api::RoadGeometryId({"Test Dragway"}), kNumLanes, kLaneLength,
+      kLaneWidth, 0. /* shoulder width */);
+  PoseVector<double> ego_pose;
+  PoseBundle<double> traffic_poses(1);
+
+  // Define the default poses.
+  SetDefaultPosesSideBySide(&ego_pose, &traffic_poses);
+
+  RoadOdometry<double> leading_odometry{};
+  RoadOdometry<double> trailing_odometry{};
+  // Peer into the adjacent lane to the left.
+  std::tie(leading_odometry, trailing_odometry) = FindClosestPair(
+      road, ego_pose, traffic_poses,
+      CalcRoadPosition(road, ego_pose.get_isometry()).lane->to_left());
+
+  // Verifies that the if the cars are side-by-side, then the traffic car is
+  // classified as a trailing car.
+  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s);
+  EXPECT_EQ(kEgoSPosition, trailing_odometry.pos.s);
 }
 
 GTEST_TEST(PoseSelectorTest, TestGetSVelocity) {

--- a/drake/automotive/test/pure_pursuit_controller_test.cc
+++ b/drake/automotive/test/pure_pursuit_controller_test.cc
@@ -31,7 +31,7 @@ class PurePursuitControllerTest : public ::testing::Test {
         new LaneDirection(road_->junction(0)->segment(0)->lane(0), true));
 
     // Initialize PurePursuitController with the dragway.
-    dut_.reset(new PurePursuitController<double>(*road_));
+    dut_.reset(new PurePursuitController<double>());
     context_ = dut_->CreateDefaultContext();
     output_ = dut_->AllocateOutput(*context_);
   }
@@ -44,19 +44,15 @@ class PurePursuitControllerTest : public ::testing::Test {
 
     // Set the ego car's pose.
     auto ego_pose = std::make_unique<PoseVector<double>>();
-    const Eigen::Translation3d translation(
-        kXPosition /* x */, y_position /* y */, 0. /* z */);
-    const Eigen::Quaternion<double> rotation(
-        std::cos(yaw * 0.5) /* w */, 0. /* x */, 0. /* y */,
-        std::sin(yaw * 0.5) /* z */);
+    const Eigen::Translation3d translation(kXPosition /* x */,
+                                           y_position /* y */, 0. /* z */);
+    const Eigen::Quaternion<double> rotation(std::cos(yaw * 0.5) /* w */,
+                                             0. /* x */, 0. /* y */,
+                                             std::sin(yaw * 0.5) /* z */);
     ego_pose->set_translation(translation);
     ego_pose->set_rotation(rotation);
     context_->FixInputPort(dut_->ego_pose_input().get_index(),
                            std::move(ego_pose));
-
-    // Set the DrivingCommand to zero.
-    context_->FixInputPort(dut_->driving_command_input().get_index(),
-                           std::make_unique<DrivingCommand<double>>());
   }
 
   std::unique_ptr<PurePursuitController<double>> dut_;  //< The device under
@@ -68,11 +64,7 @@ class PurePursuitControllerTest : public ::testing::Test {
 };
 
 TEST_F(PurePursuitControllerTest, Topology) {
-  ASSERT_EQ(3, dut_->get_num_input_ports());
-  const auto& command_input_descriptor =
-      dut_->get_output_port(dut_->driving_command_input().get_index());
-  EXPECT_EQ(systems::kVectorValued, command_input_descriptor.get_data_type());
-  EXPECT_EQ(2 /* DrivingCommand input */, command_input_descriptor.size());
+  ASSERT_EQ(2, dut_->get_num_input_ports());
   const auto& lane_input_descriptor =
       dut_->get_input_port(dut_->lane_input().get_index());
   EXPECT_EQ(systems::kAbstractValued, lane_input_descriptor.get_data_type());
@@ -83,33 +75,30 @@ TEST_F(PurePursuitControllerTest, Topology) {
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& command_output_descriptor =
-      dut_->get_output_port(dut_->driving_command_output().get_index());
+      dut_->get_output_port(dut_->steering_command_output().get_index());
   EXPECT_EQ(systems::kVectorValued, command_output_descriptor.get_data_type());
-  EXPECT_EQ(2 /* DrivingCommand output */, command_output_descriptor.size());
+  EXPECT_EQ(1 /* steering angle output */, command_output_descriptor.size());
 }
 
 TEST_F(PurePursuitControllerTest, Output) {
   // Define a pointer to where the DrivingCommand results end up.
   const auto result =
-      output_->get_vector_data(dut_->driving_command_output().get_index());
-  const auto command = dynamic_cast<const DrivingCommand<double>*>(result);
-  ASSERT_NE(nullptr, command);
+      output_->get_vector_data(dut_->steering_command_output().get_index());
+  ASSERT_NE(nullptr, result);
 
   // Set the offset to be to one the centerline with zero orientation.
   SetDefaultInputs(0., 0.);
   dut_->CalcOutput(*context_, output_.get());
 
   // Expect steering to be zero.
-  EXPECT_EQ(0., command->steering_angle());
-  EXPECT_EQ(0., command->acceleration());  // PurePursuitController does not
-                                           // alter the acceleration
+  EXPECT_EQ(0., (*result)[0]);
 
   // Set the offset to be to the right of the centerline with zero orientation.
   SetDefaultInputs(-1., 0.);
   dut_->CalcOutput(*context_, output_.get());
 
   // Expect the car to steer toward the left (positive steering angle).
-  EXPECT_LT(0., command->steering_angle());
+  EXPECT_LT(0., (*result)[0]);
 
   // Set the offset to be to the left of the centerline, oriented at 90 degrees
   // with respect to the track.
@@ -117,7 +106,7 @@ TEST_F(PurePursuitControllerTest, Output) {
   dut_->CalcOutput(*context_, output_.get());
 
   // Expect the car to steer toward the left (positive steering angle).
-  EXPECT_LT(0., command->steering_angle());
+  EXPECT_LT(0., (*result)[0]);
 }
 
 }  // namespace

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -335,7 +335,9 @@ drake_cc_googletest(
     deps = [
         ":multiplexer",
         "//drake/common:eigen_matrix_compare",
+        "//drake/common:is_dynamic_castable",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities:my_vector",
     ],
 )
 

--- a/drake/systems/primitives/multiplexer.cc
+++ b/drake/systems/primitives/multiplexer.cc
@@ -25,6 +25,15 @@ Multiplexer<T>::Multiplexer(std::vector<int> input_sizes)
 }
 
 template <typename T>
+Multiplexer<T>::Multiplexer(const systems::BasicVector<T>& model_vector)
+    : input_sizes_(std::vector<int>(model_vector.size(), 1)) {
+  for (int i = 0; i < model_vector.size(); ++i) {
+    this->DeclareInputPort(kVectorValued, 1);
+  }
+  this->DeclareVectorOutputPort(model_vector);
+}
+
+template <typename T>
 void Multiplexer<T>::DoCalcOutput(const Context<T>& context,
                                   SystemOutput<T>* output) const {
   auto output_vector = System<T>::GetMutableOutputVector(output, 0);

--- a/drake/systems/primitives/multiplexer.h
+++ b/drake/systems/primitives/multiplexer.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -34,6 +35,12 @@ class Multiplexer : public LeafSystem<T> {
   /// ports where the i-th input has size `input_sizes[i]`, and one vector-
   /// valued output port of size `sum(input_sizes)`.
   explicit Multiplexer(std::vector<int> input_sizes);
+
+  /// Constructs a %Multiplexer with model_vector.size() scalar-valued inputs
+  /// and one vector-valued output port whose size equals the size of
+  /// `model_vector`.  In addition, the output type derives from that of
+  /// `model_vector`.
+  explicit Multiplexer(const systems::BasicVector<T>& model_vector);
 
  private:
   void DoCalcOutput(const Context<T>& context,

--- a/drake/systems/primitives/test/multiplexer_test.cc
+++ b/drake/systems/primitives/test/multiplexer_test.cc
@@ -4,8 +4,10 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test/is_dynamic_castable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_value.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
 
 using std::make_unique;
 
@@ -73,6 +75,27 @@ TEST_F(MultiplexerTest, ScalarConstructor) {
   ASSERT_EQ(4, mux_->get_output_port(0).size());
   ASSERT_EQ(1, output_->get_num_ports());
   ASSERT_EQ(4, output_->get_vector_data(0)->size());
+}
+
+TEST_F(MultiplexerTest, ModelVectorConstructor) {
+  mux_ = make_unique<Multiplexer<double>>(MyVector<2, double>());
+  context_ = mux_->CreateDefaultContext();
+  output_ = mux_->AllocateOutput(*context_);
+
+  // Confirm the shape.
+  ASSERT_EQ(2, mux_->get_num_input_ports());
+  ASSERT_EQ(1, mux_->get_input_port(0).size());
+  ASSERT_EQ(1, mux_->get_input_port(1).size());
+  ASSERT_EQ(2, context_->get_num_input_ports());
+  ASSERT_EQ(1, mux_->get_num_output_ports());
+  ASSERT_EQ(2, mux_->get_output_port(0).size());
+  ASSERT_EQ(1, output_->get_num_ports());
+  ASSERT_EQ(2, output_->get_vector_data(0)->size());
+
+  // Confirm that the vector is truly MyVector<2, double>.
+  typedef MyVector<2, double> MyVectorSizeTwo;
+  ASSERT_TRUE(is_dynamic_castable<const MyVectorSizeTwo>(
+      output_->get_vector_data(0)));
 }
 
 TEST_F(MultiplexerTest, IsStateless) {


### PR DESCRIPTION
The simulator with MOBIL planner can be run using the command (for instance):
```
bazel run //drake/automotive:demo -- -num_dragway_lanes=3 -dragway_length=500 -num_mobil_car=1 -num_trajectory_car=3
```
Currently, the implementation only supports single-segment roads (like Dragway), however it should work with any combination of `num_foo_car` and `num_dragway_lanes`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5871)
<!-- Reviewable:end -->
