### PR TITLE
Clean up the DiscreteValues accessors.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -57,7 +57,7 @@ void IiwaCommandReceiver::DoCalcDiscreteVariableUpdates(
       new_positions(i) = command.joint_position[i];
     }
 
-    BasicVector<double>* state = discrete_state->get_mutable_discrete_state(0);
+    BasicVector<double>* state = discrete_state->get_mutable_vector(0);
     auto state_value = state->get_mutable_value();
     state_value.tail(kNumJoints) =
         (new_positions - state_value.head(kNumJoints)) / kIiwaLcmStatusPeriod;
@@ -151,7 +151,7 @@ void IiwaStatusReceiver::DoCalcDiscreteVariableUpdates(
       commanded_position(i) = status.joint_position_commanded[i];
     }
 
-    BasicVector<double>* state = discrete_state->get_mutable_discrete_state(0);
+    BasicVector<double>* state = discrete_state->get_mutable_vector(0);
     auto state_value = state->get_mutable_value();
     state_value.segment(kNumJoints, kNumJoints) =
         (measured_position - state_value.head(kNumJoints)) /

--- a/drake/examples/rod2d/rod2d-inl.h
+++ b/drake/examples/rod2d/rod2d-inl.h
@@ -472,8 +472,7 @@ void Rod2D<T>::DoCalcDiscreteVariableUpdates(
   VectorX<T> qplus = q + vplus*dt_;
 
   // Set the new discrete state.
-  systems::BasicVector<T>* new_state = discrete_state->
-      get_mutable_discrete_state(0);
+  systems::BasicVector<T>* new_state = discrete_state->get_mutable_vector(0);
   new_state->get_mutable_value().segment(0, 3) = qplus;
   new_state->get_mutable_value().segment(3, 3) = vplus;
 }
@@ -1453,8 +1452,8 @@ void Rod2D<T>::SetDefaultState(const systems::Context<T>& context,
   const double r22 = sqrt(2) / 2;
   x0 << half_len * r22, half_len * r22, M_PI / 4.0, -1, 0, 0;  // Initial state.
   if (simulation_type_ == SimulationType::kTimeStepping) {
-    state->get_mutable_discrete_state()->get_mutable_discrete_state(0)->
-        SetFromVector(x0);
+    state->get_mutable_discrete_state()->get_mutable_vector(0)
+        ->SetFromVector(x0);
   } else {
     // Continuous variables.
     state->get_mutable_continuous_state()->SetFromVector(x0);

--- a/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/examples/schunk_wsg/schunk_wsg_lcm.cc
@@ -74,7 +74,7 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
           context.get_discrete_state(0));
   SchunkWsgTrajectoryGeneratorStateVector<double>* new_traj_state =
       dynamic_cast<SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          discrete_state->get_mutable_discrete_state(0));
+          discrete_state->get_mutable_vector(0));
 
   if (std::abs(last_traj_state->last_target_position() - target_position) >
       kTargetEpsilon) {

--- a/drake/examples/simple_discrete_time_system.cc
+++ b/drake/examples/simple_discrete_time_system.cc
@@ -26,7 +26,7 @@ class SimpleDiscreteTimeSystem : public drake::systems::LeafSystem<double> {
       drake::systems::DiscreteValues<double>* updates) const override {
     double x = context.get_discrete_state(0)->GetAtIndex(0);
     double xn = std::pow(x, 3.0);
-    updates->get_mutable_discrete_state(0)->SetAtIndex(0, xn);
+    (*updates)[0] = xn;
   }
 
   // y = x
@@ -47,13 +47,13 @@ int main(int argc, char* argv[]) {
   // Set the initial conditions x(0).
   drake::systems::DiscreteValues<double>& xd =
       *simulator.get_mutable_context()->get_mutable_discrete_state();
-  xd.get_mutable_discrete_state(0)->SetAtIndex(0, 0.99);
+  xd[0] = 0.99;
 
   // Simulate for 10 seconds.
   simulator.StepTo(10);
 
   // Make sure the simulation converges to the stable fixed point at x=0.
-  DRAKE_DEMAND(xd.get_discrete_state(0)->GetAtIndex(0) < 1.0e-4);
+  DRAKE_DEMAND(xd[0] < 1.0e-4);
 
   // TODO(russt): make a plot of the resulting trajectory.
 

--- a/drake/examples/simple_mixed_continuous_and_discrete_time_system.cc
+++ b/drake/examples/simple_mixed_continuous_and_discrete_time_system.cc
@@ -30,7 +30,7 @@ class SimpleMixedContinuousTimeDiscreteTimeSystem
       drake::systems::DiscreteValues<double>* updates) const override {
     const double x = context.get_discrete_state(0)->GetAtIndex(0);
     const double xn = std::pow(x, 3.0);
-    updates->get_mutable_discrete_state(0)->SetAtIndex(0, xn);
+    (*updates)[0] = xn;
   }
 
   // xdot = -x + x^3
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
   // Set the initial conditions x(0).
   drake::systems::DiscreteValues<double>& xd =
       *simulator.get_mutable_context()->get_mutable_discrete_state();
-  xd.get_mutable_discrete_state(0)->SetAtIndex(0, 0.99);
+  xd[0] = 0.99;
   drake::systems::ContinuousState<double>& xc =
       *simulator.get_mutable_context()->get_mutable_continuous_state();
   xc[0] = 0.9;
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
   simulator.StepTo(10);
 
   // Make sure the simulation converges to the stable fixed point at x=0.
-  DRAKE_DEMAND(xd.get_discrete_state(0)->GetAtIndex(0) < 1.0e-4);
+  DRAKE_DEMAND(xd[0] < 1.0e-4);
   DRAKE_DEMAND(xc[0] < 1.0e-4);
 
   // TODO(russt): make a plot of the resulting trajectory (using vtk?).

--- a/drake/multibody/rigid_body_plant/drake_visualizer.h
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.h
@@ -119,9 +119,9 @@ class DrakeVisualizer : public LeafSystem<double> {
   void set_is_load_message_sent(DiscreteValues<double>* state,
                                 bool flag) const {
     if (flag)
-      state->get_mutable_discrete_state(0)->SetAtIndex(0, 1);
+      state->get_mutable_vector(0)->SetAtIndex(0, 1);
     else
-      state->get_mutable_discrete_state(0)->SetAtIndex(0, 0);
+      state->get_mutable_vector(0)->SetAtIndex(0, 0);
   }
 
   // Set the default to "initialization phase has not been completed."

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -276,9 +276,8 @@ void RigidBodyPlant<T>::set_state_vector(
   DRAKE_ASSERT(state != nullptr);
   DRAKE_ASSERT(x.size() == get_num_states());
   if (timestep_ > 0.0) {
-    state->get_mutable_discrete_state()
-        ->get_mutable_discrete_state(0)
-        ->SetFromVector(x);
+    auto* xd = state->get_mutable_discrete_state();
+    xd->get_mutable_vector(0)->SetFromVector(x);
   } else {
     state->get_mutable_continuous_state()->SetFromVector(x);
   }
@@ -567,7 +566,7 @@ void RigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   // qn = q + h*qdn.
   xn << q + timestep_ * tree_->transformVelocityToQDot(kinsol, vn_sol), vn_sol;
-  updates->get_mutable_discrete_state(0)->SetFromVector(xn);
+  updates->get_mutable_vector(0)->SetFromVector(xn);
 }
 
 template <typename T>

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -227,7 +227,7 @@ class RigidBodyPlant : public LeafSystem<T> {
     } else {
       // Extract a pointer to the discrete state from the context.
       BasicVector<T>* xd =
-          state->get_mutable_discrete_state()->get_mutable_discrete_state(0);
+          state->get_mutable_discrete_state()->get_mutable_vector(0);
       DRAKE_DEMAND(xd != nullptr);
 
       // Write the zero configuration into the discrete state.

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -589,8 +589,7 @@ GTEST_TEST(rigid_body_plant_test, BasicTimeSteppingTest) {
   VectorXd xn(qn.rows() + vn.rows());
   xn << qn, vn;
 
-  EXPECT_TRUE(
-      CompareMatrices(updates->get_discrete_state(0)->CopyToVector(), xn));
+  EXPECT_TRUE(CompareMatrices(updates->get_vector(0)->CopyToVector(), xn));
 }
 
 }  // namespace

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -115,7 +115,7 @@ class Context {
 
   /// Returns the number of elements in the discrete state.
   int get_num_discrete_state_groups() const {
-    return get_state().get_discrete_state()->size();
+    return get_state().get_discrete_state()->num_groups();
   }
 
   /// Returns a mutable pointer to the discrete component of the state,
@@ -128,7 +128,7 @@ class Context {
   /// Asserts if @p index doesn't exist.
   BasicVector<T>* get_mutable_discrete_state(int index) {
     DiscreteValues<T>* xd = get_mutable_discrete_state();
-    return xd->get_mutable_discrete_state(index);
+    return xd->get_mutable_vector(index);
   }
 
   /// Sets the discrete state to @p xd, deleting whatever was there before.
@@ -140,7 +140,7 @@ class Context {
   /// state at @p index.  Asserts if @p index doesn't exist.
   const BasicVector<T>* get_discrete_state(int index) const {
     const DiscreteValues<T>* xd = get_state().get_discrete_state();
-    return xd->get_discrete_state(index);
+    return xd->get_vector(index);
   }
 
   /// Returns the number of elements in the abstract state.

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -1320,8 +1320,8 @@ class Diagram : public System<T>,
 
     // As a baseline, initialize all the difference variables to their
     // current values.
-    for (int i = 0; i < diagram_differences->size(); ++i) {
-      diagram_differences->get_mutable_discrete_state(i)->set_value(
+    for (int i = 0; i < diagram_differences->num_groups(); ++i) {
+      diagram_differences->get_mutable_vector(i)->set_value(
           context.get_discrete_state(i)->get_value());
     }
 

--- a/drake/systems/framework/discrete_values.h
+++ b/drake/systems/framework/discrete_values.h
@@ -18,7 +18,7 @@ namespace systems {
 ///
 /// DiscreteValues is an ordered collection of vectors xd = [xd0, xd1...].
 /// Requesting a specific index from this collection is the most granular way
-/// to retrieve discrete state from the Context, and thus is the unit of
+/// to retrieve discrete values from the Context, and thus is the unit of
 /// cache invalidation. System authors are encouraged to partition their
 /// DiscreteValues such that each cacheable computation within the System may
 /// depend on only the elements of DiscreteValues that it needs.
@@ -30,15 +30,15 @@ class DiscreteValues {
   // DiscreteValues is not copyable or moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteValues)
 
-  /// Constructs an empty discrete state.
+  /// Constructs an empty discrete values.
   DiscreteValues() {}
 
-  /// Constructs a discrete state that does not own the underlying @p data.
+  /// Constructs a DiscreteValues that does not own the underlying @p data.
   /// The data must outlive this DiscreteValues.
   explicit DiscreteValues(const std::vector<BasicVector<T>*>& data)
       : data_(data) {}
 
-  /// Constructs a discrete state that owns the underlying @p data.
+  /// Constructs a DiscreteValues that owns the underlying @p data.
   explicit DiscreteValues(std::vector<std::unique_ptr<BasicVector<T>>>&& data)
       : owned_data_(std::move(data)) {
     // Initialize the unowned pointers.
@@ -47,7 +47,7 @@ class DiscreteValues {
     }
   }
 
-  /// Constructs a discrete state that owns a single @p datum vector.
+  /// Constructs a DiscreteValues that owns a single @p datum vector.
   explicit DiscreteValues(std::unique_ptr<BasicVector<T>> datum) {
     data_.push_back(datum.get());
     owned_data_.push_back(std::move(datum));
@@ -55,17 +55,51 @@ class DiscreteValues {
 
   virtual ~DiscreteValues() {}
 
-  int size() const { return static_cast<int>(data_.size()); }
+  int num_groups() const { return static_cast<int>(data_.size()); }
 
   const std::vector<BasicVector<T>*>& get_data() const { return data_; }
 
-  const BasicVector<T>* get_discrete_state(int index) const {
-    DRAKE_ASSERT(index >= 0 && index < size());
+  //----------------------------------------------------------------------------
+  /// @name Convenience accessors for DiscreteValues with just one group.
+  ///
+  //@{
+
+  /// Returns the number of elements in the only DiscreteValues group.
+  int size() const {
+    DRAKE_ASSERT(num_groups() == 1);
+    return data_[0]->size();
+  }
+
+  T& operator[](std::size_t idx) {
+    DRAKE_ASSERT(num_groups() == 1);
+    return (*data_[0])[idx];
+  }
+
+  const T& operator[](std::size_t idx) const {
+    DRAKE_ASSERT(num_groups() == 1);
+    return (*data_[0])[idx];
+  }
+
+  const BasicVector<T>* get_vector() const {
+    DRAKE_ASSERT(num_groups() == 1);
+    return get_vector(0);
+  }
+
+  BasicVector<T>* get_mutable_vector() {
+    DRAKE_ASSERT(num_groups() == 1);
+    return get_mutable_vector(0);
+  }
+
+  //@}
+
+
+  const BasicVector<T>* get_vector(int index) const {
+    DRAKE_ASSERT(index >= 0 && index < num_groups());
     return data_[index];
   }
 
-  BasicVector<T>* get_mutable_discrete_state(int index) {
-    DRAKE_ASSERT(index >= 0 && index < size());
+  BasicVector<T>* get_mutable_vector(int index) {
+    DRAKE_ASSERT(index >= 0 && index < num_groups());
     return data_[index];
   }
 
@@ -79,7 +113,7 @@ class DiscreteValues {
   void SetFrom(const DiscreteValues<double>& other) { SetFromGeneric(other); }
 
   /// Returns a deep copy of all the data in this DiscreteValues. The clone
-  /// will own its own data. This is true regardless of whether the state being
+  /// will own its own data. This is true regardless of whether the values being
   /// cloned had ownership of its data or not.
   std::unique_ptr<DiscreteValues> Clone() const {
     std::vector<std::unique_ptr<BasicVector<T>>> cloned_data;
@@ -91,22 +125,22 @@ class DiscreteValues {
   }
 
  private:
-  // Pointers to the data comprising the state. If the data is owned, these
+  // Pointers to the data comprising the values. If the data is owned, these
   // pointers are equal to the pointers in owned_data_.
   std::vector<BasicVector<T>*> data_;
-  // Owned pointers to the data comprising the state. The only purpose of these
+  // Owned pointers to the data comprising the values. The only purpose of these
   // pointers is to maintain ownership. They may be populated at construction
   // time, and are never accessed thereafter.
   std::vector<std::unique_ptr<BasicVector<T>>> owned_data_;
 
   template <typename U>
   void SetFromGeneric(const DiscreteValues<U>& other) {
-    DRAKE_ASSERT(size() == other.size());
-    for (int i = 0; i < size(); i++) {
-      DRAKE_ASSERT(other.get_discrete_state(i) != nullptr);
+    DRAKE_ASSERT(num_groups() == other.num_groups());
+    for (int i = 0; i < num_groups(); i++) {
+      DRAKE_ASSERT(other.get_vector(i) != nullptr);
       DRAKE_ASSERT(data_[i] != nullptr);
       data_[i]->set_value(
-          other.get_discrete_state(i)->get_value().template cast<T>());
+          other.get_vector(i)->get_value().template cast<T>());
     }
   }
 };

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -109,8 +109,8 @@ class LeafSystem : public System<T> {
     ContinuousState<T>* xc = state->get_mutable_continuous_state();
     xc->SetFromVector(VectorX<T>::Zero(xc->size()));
     DiscreteValues<T>* xd = state->get_mutable_discrete_state();
-    for (int i = 0; i < xd->size(); i++) {
-      BasicVector<T>* s = xd->get_mutable_discrete_state(i);
+    for (int i = 0; i < xd->num_groups(); i++) {
+      BasicVector<T>* s = xd->get_mutable_vector(i);
       s->SetFromVector(VectorX<T>::Zero(s->size()));
     }
   }

--- a/drake/systems/framework/parameters.h
+++ b/drake/systems/framework/parameters.h
@@ -64,7 +64,7 @@ class Parameters {
   virtual ~Parameters() {}
 
   int num_numeric_parameters() const {
-    return numeric_parameters_->size();
+    return numeric_parameters_->num_groups();
   }
 
   int num_abstract_parameters() const {
@@ -74,13 +74,13 @@ class Parameters {
   /// Returns the vector-valued parameter at @p index. Asserts if the index
   /// is out of bounds.
   const BasicVector<T>* get_numeric_parameter(int index) const {
-    return numeric_parameters_->get_discrete_state(index);
+    return numeric_parameters_->get_vector(index);
   }
 
   /// Returns the vector-valued parameter at @p index. Asserts if the index
   /// is out of bounds.
   BasicVector<T>* get_mutable_numeric_parameter(int index) {
-    return numeric_parameters_->get_mutable_discrete_state(index);
+    return numeric_parameters_->get_mutable_vector(index);
   }
 
   const DiscreteValues<T>& get_numeric_parameters() const {

--- a/drake/systems/framework/siso_vector_system.h
+++ b/drake/systems/framework/siso_vector_system.h
@@ -120,7 +120,7 @@ class SisoVectorSystem : public LeafSystem<T> {
       const Context<T>& context,
       DiscreteValues<T>* discrete_state) const final {
     // Short-circuit when there's no work to do.
-    if (discrete_state->size() == 0) {
+    if (discrete_state->num_groups() == 0) {
       return;
     }
 
@@ -138,7 +138,7 @@ class SisoVectorSystem : public LeafSystem<T> {
     // Obtain the block form of xd after the update (i.e., the next state).
     DRAKE_ASSERT(discrete_state != nullptr);
     BasicVector<T>* const discrete_update_vector =
-        discrete_state->get_mutable_discrete_state(0);
+        discrete_state->get_mutable_vector();
     DRAKE_ASSERT(discrete_update_vector != nullptr);
     Eigen::VectorBlock<VectorX<T>> discrete_update_block =
         discrete_update_vector->get_mutable_value();

--- a/drake/systems/framework/sparsity_matrix.cc
+++ b/drake/systems/framework/sparsity_matrix.cc
@@ -77,7 +77,7 @@ void SparsityMatrix::InitializeDiscreteState() {
   // expression whose value is the variable "xdi_j".
   auto& xd = *context_->get_mutable_discrete_state();
   for (int i = 0; i < context_->get_num_discrete_state_groups(); ++i) {
-    auto& xdi = *xd.get_mutable_discrete_state(i);
+    auto& xdi = *xd.get_mutable_vector(i);
     for (int j = 0; j < xdi.size(); ++j) {
       std::ostringstream name;
       name << "xd" << i << "_" << j;

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -499,7 +499,7 @@ class System {
     DRAKE_ASSERT_VOID(CheckValidContext(context));
     DRAKE_DEMAND(event.action == DiscreteEvent<T>::kUnrestrictedUpdateAction);
     const int continuous_state_dim = state->get_continuous_state()->size();
-    const int discrete_state_dim = state->get_discrete_state()->size();
+    const int discrete_state_dim = state->get_discrete_state()->num_groups();
     const int abstract_state_dim = state->get_abstract_state()->size();
 
     // Copy current state to the passed-in state, as specified in the
@@ -512,7 +512,7 @@ class System {
       event.do_unrestricted_update(context, state);
     }
     if (continuous_state_dim != state->get_continuous_state()->size() ||
-        discrete_state_dim != state->get_discrete_state()->size() ||
+        discrete_state_dim != state->get_discrete_state()->num_groups() ||
         abstract_state_dim != state->get_abstract_state()->size())
       throw std::logic_error(
           "State variable dimensions cannot be changed "

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -107,7 +107,7 @@ class DiagramContextTest : public ::testing::Test {
     xc->get_mutable_vector()->SetAtIndex(1, 43.0);
 
     DiscreteValues<double>* xd = context_->get_mutable_discrete_state();
-    xd->get_mutable_discrete_state(0)->SetAtIndex(0, 44.0);
+    xd->get_mutable_vector(0)->SetAtIndex(0, 44.0);
 
     context_->get_mutable_numeric_parameter(0)->SetAtIndex(0, 76.0);
     context_->get_mutable_numeric_parameter(0)->SetAtIndex(1, 77.0);
@@ -153,7 +153,7 @@ void VerifyClonedState(const State<double>& clone) {
   EXPECT_EQ(43.0, xc->get_vector().GetAtIndex(1));
   // - Discrete
   const DiscreteValues<double>* xd = clone.get_discrete_state();
-  EXPECT_EQ(44.0, xd->get_discrete_state(0)->GetAtIndex(0));
+  EXPECT_EQ(44.0, xd->get_vector(0)->GetAtIndex(0));
   // - Abstract
   const AbstractValues* xa = clone.get_abstract_state();
   EXPECT_EQ(42, xa->get_value(0).GetValue<int>());
@@ -204,8 +204,8 @@ TEST_F(DiagramContextTest, State) {
 
   // The zero-order hold has a difference state vector of length 1.
   DiscreteValues<double>* xd = context_->get_mutable_discrete_state();
-  EXPECT_EQ(1, xd->size());
-  EXPECT_EQ(1, xd->get_discrete_state(0)->size());
+  EXPECT_EQ(1, xd->num_groups());
+  EXPECT_EQ(1, xd->get_vector(0)->size());
 
   // Changes to the diagram state write through to constituent system states.
   // - Continuous
@@ -218,15 +218,15 @@ TEST_F(DiagramContextTest, State) {
   // - Discrete
   DiscreteValues<double>* hold_xd =
       context_->GetMutableSubsystemContext(4)->get_mutable_discrete_state();
-  EXPECT_EQ(44.0, hold_xd->get_discrete_state(0)->GetAtIndex(0));
+  EXPECT_EQ(44.0, hold_xd->get_vector(0)->GetAtIndex(0));
 
   // Changes to constituent system states appear in the diagram state.
   // - Continuous
   integrator1_xc->get_mutable_vector()->SetAtIndex(0, 1000.0);
   EXPECT_EQ(1000.0, xc->get_vector().GetAtIndex(1));
   // - Discrete
-  hold_xd->get_mutable_discrete_state(0)->SetAtIndex(0, 1001.0);
-  EXPECT_EQ(1001.0, xd->get_discrete_state(0)->GetAtIndex(0));
+  hold_xd->get_mutable_vector(0)->SetAtIndex(0, 1001.0);
+  EXPECT_EQ(1001.0, xd->get_vector(0)->GetAtIndex(0));
 }
 
 // Tests that the pointers to substates in the DiagramState are equal to the

--- a/drake/systems/framework/test/discrete_values_test.cc
+++ b/drake/systems/framework/test/discrete_values_test.cc
@@ -12,9 +12,9 @@ namespace drake {
 namespace systems {
 namespace {
 
-class DiscreteStateTest : public ::testing::Test {
+class DiscreteValuesTest : public ::testing::Test {
  public:
-  DiscreteStateTest() {
+  DiscreteValuesTest() {
     data_.push_back(BasicVector<double>::Make({1.0, 1.0}));
     data_.push_back(BasicVector<double>::Make({2.0, 3.0}));
   }
@@ -23,44 +23,57 @@ class DiscreteStateTest : public ::testing::Test {
   std::vector<std::unique_ptr<BasicVector<double>>> data_;
 };
 
-TEST_F(DiscreteStateTest, OwnedState) {
+TEST_F(DiscreteValuesTest, OwnedState) {
   DiscreteValues<double> xd(std::move(data_));
-  EXPECT_EQ(1.0, xd.get_discrete_state(0)->GetAtIndex(0));
-  EXPECT_EQ(1.0, xd.get_discrete_state(0)->GetAtIndex(1));
-  EXPECT_EQ(2.0, xd.get_discrete_state(1)->GetAtIndex(0));
-  EXPECT_EQ(3.0, xd.get_discrete_state(1)->GetAtIndex(1));
+  EXPECT_EQ(1.0, xd.get_vector(0)->GetAtIndex(0));
+  EXPECT_EQ(1.0, xd.get_vector(0)->GetAtIndex(1));
+  EXPECT_EQ(2.0, xd.get_vector(1)->GetAtIndex(0));
+  EXPECT_EQ(3.0, xd.get_vector(1)->GetAtIndex(1));
 }
 
-TEST_F(DiscreteStateTest, UnownedState) {
+TEST_F(DiscreteValuesTest, UnownedState) {
   DiscreteValues<double> xd(
       std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
-  EXPECT_EQ(1.0, xd.get_discrete_state(0)->GetAtIndex(0));
-  EXPECT_EQ(1.0, xd.get_discrete_state(0)->GetAtIndex(1));
-  EXPECT_EQ(2.0, xd.get_discrete_state(1)->GetAtIndex(0));
-  EXPECT_EQ(3.0, xd.get_discrete_state(1)->GetAtIndex(1));
+  EXPECT_EQ(1.0, xd.get_vector(0)->GetAtIndex(0));
+  EXPECT_EQ(1.0, xd.get_vector(0)->GetAtIndex(1));
+  EXPECT_EQ(2.0, xd.get_vector(1)->GetAtIndex(0));
+  EXPECT_EQ(3.0, xd.get_vector(1)->GetAtIndex(1));
 }
 
-TEST_F(DiscreteStateTest, Clone) {
+TEST_F(DiscreteValuesTest, Clone) {
   DiscreteValues<double> xd(
       std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
   std::unique_ptr<DiscreteValues<double>> clone = xd.Clone();
-  EXPECT_EQ(1.0, clone->get_discrete_state(0)->GetAtIndex(0));
-  EXPECT_EQ(1.0, clone->get_discrete_state(0)->GetAtIndex(1));
-  EXPECT_EQ(2.0, clone->get_discrete_state(1)->GetAtIndex(0));
-  EXPECT_EQ(3.0, clone->get_discrete_state(1)->GetAtIndex(1));
+  EXPECT_EQ(1.0, clone->get_vector(0)->GetAtIndex(0));
+  EXPECT_EQ(1.0, clone->get_vector(0)->GetAtIndex(1));
+  EXPECT_EQ(2.0, clone->get_vector(1)->GetAtIndex(0));
+  EXPECT_EQ(3.0, clone->get_vector(1)->GetAtIndex(1));
 }
 
-TEST_F(DiscreteStateTest, SetFrom) {
+TEST_F(DiscreteValuesTest, SetFrom) {
   DiscreteValues<AutoDiffXd> ad_xd(
       BasicVector<AutoDiffXd>::Make({AutoDiffXd(1.0), AutoDiffXd(2.0)}));
   DiscreteValues<double> double_xd(BasicVector<double>::Make({3.0, 4.0}));
   ad_xd.SetFrom(double_xd);
 
-  const BasicVector<AutoDiffXd>& vec = *ad_xd.get_discrete_state(0);
+  const BasicVector<AutoDiffXd>& vec = *ad_xd.get_vector(0);
   EXPECT_EQ(3.0, vec[0].value());
   EXPECT_EQ(0, vec[0].derivatives().size());
   EXPECT_EQ(4.0, vec[1].value());
   EXPECT_EQ(0, vec[1].derivatives().size());
+}
+
+// Tests that the convenience accessors for a DiscreteValues that contains
+// just one group work as documented.
+GTEST_TEST(DiscreteValuesSingleGroupTest, ConvenienceSugar) {
+  DiscreteValues<double> xd(BasicVector<double>::Make({42.0, 43.0}));
+  EXPECT_EQ(2, xd.size());
+  EXPECT_EQ(42.0, xd[0]);
+  EXPECT_EQ(43.0, xd[1]);
+  xd[0] = 100.0;
+  EXPECT_EQ(100.0, xd.get_vector()->GetAtIndex(0));
+  xd.get_mutable_vector()->SetAtIndex(1, 1000.0);
+  EXPECT_EQ(1000.0, xd[1]);
 }
 
 }  // namespace

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -107,11 +107,9 @@ void VerifyClonedState(const State<double>& clone) {
     EXPECT_EQ(expected, contents);
   }
 
-  EXPECT_EQ(2, clone.get_discrete_state()->size());
-  const BasicVector<double>* xd0 =
-      clone.get_discrete_state()->get_discrete_state(0);
-  const BasicVector<double>* xd1 =
-      clone.get_discrete_state()->get_discrete_state(1);
+  EXPECT_EQ(2, clone.get_discrete_state()->num_groups());
+  const BasicVector<double>* xd0 = clone.get_discrete_state()->get_vector(0);
+  const BasicVector<double>* xd1 = clone.get_discrete_state()->get_vector(1);
   {
     VectorX<double> contents = xd0->CopyToVector();
     VectorX<double> expected(1);

--- a/drake/systems/framework/test/parameters_test.cc
+++ b/drake/systems/framework/test/parameters_test.cc
@@ -43,7 +43,7 @@ class ParametersTest : public ::testing::Test {
 
 TEST_F(ParametersTest, Numeric) {
   ASSERT_EQ(2, params_->num_numeric_parameters());
-  ASSERT_EQ(2, params_->get_numeric_parameters().size());
+  ASSERT_EQ(2, params_->get_numeric_parameters().num_groups());
   EXPECT_EQ(3.0, params_->get_numeric_parameter(0)->GetAtIndex(0));
   EXPECT_EQ(6.0, params_->get_numeric_parameter(0)->GetAtIndex(1));
   EXPECT_EQ(9.0, params_->get_numeric_parameter(1)->GetAtIndex(0));

--- a/drake/systems/framework/test/siso_vector_system_test.cc
+++ b/drake/systems/framework/test/siso_vector_system_test.cc
@@ -311,12 +311,8 @@ TEST_F(SisoVectorSystemTest, DiscreteVariableUpdates) {
   dut.CalcDiscreteVariableUpdates(*context, event, discrete_updates.get());
   EXPECT_EQ(dut.get_last_context(), context.get());
   EXPECT_EQ(dut.get_discrete_variable_updates_count(), 1);
-  EXPECT_EQ(
-      discrete_updates->get_mutable_discrete_state(0)->GetAtIndex(0),
-      2.0);
-  EXPECT_EQ(
-      discrete_updates->get_mutable_discrete_state(0)->GetAtIndex(1),
-      3.0);
+  EXPECT_EQ(discrete_updates->get_vector(0)->GetAtIndex(0), 2.0);
+  EXPECT_EQ(discrete_updates->get_vector(0)->GetAtIndex(1), 3.0);
 
   // Nothing else weird happened.
   EXPECT_EQ(dut.get_time_derivatives_count(), 0);

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -94,9 +94,9 @@ void LcmSubscriberSystem::ProcessMessageAndStoreToDiscreteState(
   if (!received_message_.empty()) {
     translator_->Deserialize(
         received_message_.data(), received_message_.size(),
-        discrete_state->get_mutable_discrete_state(kStateIndexMessage));
+        discrete_state->get_mutable_vector(kStateIndexMessage));
   }
-  discrete_state->get_mutable_discrete_state(kStateIndexMessageCount)
+  discrete_state->get_mutable_vector(kStateIndexMessageCount)
       ->SetAtIndex(0, received_message_count_);
 }
 

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -145,7 +145,7 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
     DRAKE_DEMAND(Bt.rows() == num_states_ && Bt.cols() == num_inputs_);
     xn += Bt * u;
   }
-  updates->get_mutable_discrete_state(0)->SetFromVector(xn);
+  updates->get_mutable_vector()->SetFromVector(xn);
 }
 
 template class TimeVaryingAffineSystem<double>;
@@ -250,7 +250,7 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
 
     xnext += B_ * u;
   }
-  updates->get_mutable_discrete_state(0)->SetFromVector(xnext);
+  updates->get_mutable_vector()->SetFromVector(xnext);
 }
 
 template class AffineSystem<double>;

--- a/drake/systems/primitives/random_source.h
+++ b/drake/systems/primitives/random_source.h
@@ -48,10 +48,10 @@ class RandomSource : public LeafSystem<double> {
   void DoCalcDiscreteVariableUpdates(
       const drake::systems::Context<double>& context,
       drake::systems::DiscreteValues<double>* updates) const override {
-    const int N = updates->get_discrete_state(0)->size();
+    const int N = updates->size();
     for (int i = 0; i < N; i++) {
       double random_value = distribution_(generator_);
-      updates->get_mutable_discrete_state(0)->SetAtIndex(0, random_value);
+      (*updates)[0] = random_value;
     }
   }
 

--- a/drake/systems/primitives/test/affine_system_test.cc
+++ b/drake/systems/primitives/test/affine_system_test.cc
@@ -77,7 +77,7 @@ TEST_F(AffineSystemTest, Derivatives) {
 TEST_F(AffineSystemTest, Updates) {
   EXPECT_TRUE(context_->has_only_continuous_state());
   EXPECT_NE(updates_, nullptr);
-  EXPECT_EQ(updates_->size(), 0);
+  EXPECT_EQ(updates_->num_groups(), 0);
 }
 
 // Tests that the outputs are correctly computed.
@@ -175,7 +175,7 @@ GTEST_TEST(DiscreteAffineSystemTest, DiscreteTime) {
 
   system.CalcDiscreteVariableUpdates(*context, update_event, update.get());
 
-  EXPECT_TRUE(CompareMatrices(update->get_discrete_state(0)->CopyToVector(),
+  EXPECT_TRUE(CompareMatrices(update->get_vector(0)->CopyToVector(),
                               A * x0 + B * u0 + f0));
 
   // Test TimeVaryingAffineSystem accessor methods.

--- a/drake/systems/primitives/test/zero_order_hold_test.cc
+++ b/drake/systems/primitives/test/zero_order_hold_test.cc
@@ -113,7 +113,7 @@ TEST_F(ZeroOrderHoldTest, Update) {
   hold_->CalcDiscreteVariableUpdates(*context_, {update_event}, update.get());
 
   // Check that the state has been updated to the input.
-  const VectorBase<double>* xd = update->get_discrete_state(0);
+  const VectorBase<double>* xd = update->get_vector(0);
   EXPECT_EQ(1.0, xd->GetAtIndex(0));
   EXPECT_EQ(1.0, xd->GetAtIndex(1));
   EXPECT_EQ(3.0, xd->GetAtIndex(2));
@@ -157,7 +157,7 @@ TEST_F(SymbolicZeroOrderHoldTest, Update) {
       DiscreteEvent<symbolic::Expression>::kDiscreteUpdateAction;
 
   hold_->CalcDiscreteVariableUpdates(*context_, {update_event}, update_.get());
-  const auto& xd = *update_->get_discrete_state(0);
+  const auto& xd = *update_->get_vector(0);
   EXPECT_EQ("u0", xd[0].to_string());
 }
 


### PR DESCRIPTION
Remove obsolete references to "state", and add sugar for DiscreteValues with just one group.

@sherm1 for feature review.  cc @RussTedrake 

Fixes #4184.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5879)
<!-- Reviewable:end -->
