### PR TITLE
ProjectMatToRotMatWithAxis should handle any joint bounds

### DIFF
--- a/drake/math/rotation_matrix.h
+++ b/drake/math/rotation_matrix.h
@@ -322,7 +322,7 @@ double ProjectMatToRotMatWithAxis(const Eigen::MatrixBase<Derived>& M,
   // clang-format on
   Scalar alpha =
       atan2(-(M.transpose() * A * A).trace(), (A.transpose() * M).trace());
-  Scalar theta;
+  Scalar theta{};
   // The bounds on θ + α is [angle_lb + α, angle_ub + α].
   if (std::isinf(angle_lb) && std::isinf(angle_ub)) {
     theta = M_PI_2 - alpha;

--- a/drake/math/rotation_matrix.h
+++ b/drake/math/rotation_matrix.h
@@ -323,7 +323,7 @@ double ProjectMatToRotMatWithAxis(const Eigen::MatrixBase<Derived>& M,
   Scalar alpha =
       atan2(-(M.transpose() * A * A).trace(), (A.transpose() * M).trace());
   Scalar theta;
-  // The bounds on θ + α is [angle_lb - 2π, angle_ub + 2π].
+  // The bounds on θ + α is [angle_lb + α, angle_ub + α].
   if (std::isinf(angle_lb) && std::isinf(angle_ub)) {
     theta = M_PI_2 - alpha;
   } else if (std::isinf(angle_ub)) {

--- a/drake/math/rotation_matrix.h
+++ b/drake/math/rotation_matrix.h
@@ -296,7 +296,7 @@ Matrix3<typename Derived::Scalar> ProjectMatToRotMat(
  * @param angle_lb The lower bound of the rotation angle.
  * @param angle_ub The upper bound of the rotation angle.
  * @return The rotation angle of the projected matrix.
- * @pre angle_lb >= -2π, angle_ub <= 2π. angle_ub >= angle_lb.
+ * @pre angle_ub >= angle_lb.
  * Throw std::runtime_error if these bounds are violated.
  */
 template <typename Derived>
@@ -306,9 +306,6 @@ double ProjectMatToRotMatWithAxis(const Eigen::MatrixBase<Derived>& M,
   using Scalar = typename Derived::Scalar;
   if (M.rows() != 3 || M.cols() != 3) {
     throw std::runtime_error("The input matrix should be of size 3 x 3.");
-  }
-  if (angle_lb < -2 * M_PI || angle_ub > 2 * M_PI) {
-    throw std::runtime_error("The angle bounds has to ben within [-2π, 2π]");
   }
   if (angle_ub < angle_lb) {
     throw std::runtime_error(
@@ -326,22 +323,34 @@ double ProjectMatToRotMatWithAxis(const Eigen::MatrixBase<Derived>& M,
   Scalar alpha =
       atan2(-(M.transpose() * A * A).trace(), (A.transpose() * M).trace());
   Scalar theta;
-  // The bounds on θ + α is [-4π, 4π].
-  bool is_maximal_at_boundary = true;
-  for (int i = -2; i < 2; ++i) {
-    double max_sin_angle = M_PI * (0.5 + 2 * i);
-    if (angle_lb + alpha <= max_sin_angle &&
-        max_sin_angle <= angle_ub + alpha) {
+  // The bounds on θ + α is [angle_lb - 2π, angle_ub + 2π].
+  if (std::isinf(angle_lb) && std::isinf(angle_ub)) {
+    theta = M_PI_2 - alpha;
+  } else if (std::isinf(angle_ub)) {
+    // First if the angle upper bound is inf, start from the angle_lb, and
+    // find the angle θ, such that θ + α = 0.5π + 2kπ
+    int k = ceil((angle_lb + alpha - M_PI_2) / (2 * M_PI));
+    theta = (2 * k + 0.5) * M_PI - alpha;
+  } else if (std::isinf(angle_lb)) {
+    // If the angle lower bound is inf, start from the angle_ub, and find the
+    // angle θ, such that θ + α = 0.5π + 2kπ
+    int k = floor((angle_ub + alpha - M_PI_2) / (2 * M_PI));
+    theta = (2 * k + 0.5) * M_PI - alpha;
+  } else {
+    // Now neither angle_lb nor angle_ub is inf. Check if there exists an
+    // integer k, such that 0.5π + 2kπ ∈ [angle_lb + α, angle_ub + α]
+    int k = floor((angle_ub + alpha - M_PI_2) / (2 * M_PI));
+    double max_sin_angle = M_PI_2 + 2 * k * M_PI;
+    if (max_sin_angle >= angle_lb + alpha) {
+      // 0.5π + 2kπ ∈ [angle_lb + α, angle_ub + α]
       theta = max_sin_angle - alpha;
-      is_maximal_at_boundary = false;
-      break;
-    }
-  }
-  if (is_maximal_at_boundary) {
-    if (sin(angle_lb + alpha) >= sin(angle_ub + alpha)) {
-      theta = angle_lb;
     } else {
-      theta = angle_ub;
+      // Now the maximal is at the boundary, either θ = angle_lb or angle_ub
+      if (sin(angle_lb + alpha) >= sin(angle_ub + alpha)) {
+        theta = angle_lb;
+      } else {
+        theta = angle_ub;
+      }
     }
   }
   return theta;

--- a/drake/math/test/rotation_matrix_test.cc
+++ b/drake/math/test/rotation_matrix_test.cc
@@ -89,7 +89,8 @@ void CheckProjectionWithAxis(const Eigen::Matrix3d& M,
           .toRotationMatrix();
   const double R_error = (R - M).squaredNorm();
   const int kNumAngles = 100;
-  double theta_lb, theta_ub;
+  double theta_lb{};
+  double theta_ub{};
   // Depending on the value of angle_lb and angle_ub, we choose the range for
   // the sampled theta. If angle_lb and/or angle_ub is inf, then the theta_lb
   // and/or theta_ub will be set to a finite value.

--- a/drake/math/test/rotation_matrix_test.cc
+++ b/drake/math/test/rotation_matrix_test.cc
@@ -89,8 +89,26 @@ void CheckProjectionWithAxis(const Eigen::Matrix3d& M,
           .toRotationMatrix();
   const double R_error = (R - M).squaredNorm();
   const int kNumAngles = 100;
+  double theta_lb, theta_ub;
+  // Depending on the value of angle_lb and angle_ub, we choose the range for
+  // the sampled theta. If angle_lb and/or angle_ub is inf, then the theta_lb
+  // and/or theta_ub will be set to a finite value.
+  if (!std::isinf(angle_lb) && !std::isinf(angle_ub)) {
+    theta_lb = angle_lb;
+    theta_ub = angle_ub;
+  } else if (std::isinf(angle_lb) && std::isinf(angle_ub)) {
+    theta_lb = -2 * M_PI;
+    theta_ub = 2 * M_PI;
+  } else if (std::isinf(angle_lb)) {
+    theta_lb = angle_ub - 2 * M_PI;
+    theta_ub = angle_ub;
+  } else {
+    theta_lb = angle_lb;
+    theta_ub = angle_lb + 2 * M_PI;
+  }
   const Eigen::Matrix<double, kNumAngles, 1> theta =
-      Eigen::Matrix<double, kNumAngles, 1>::LinSpaced(angle_lb, angle_ub);
+      Eigen::Matrix<double, kNumAngles, 1>::LinSpaced(theta_lb, theta_ub);
+
   for (int i = 0; i < kNumAngles; ++i) {
     const Eigen::Matrix3d Ri =
         Eigen::AngleAxisd(theta(i), axis).toRotationMatrix();
@@ -112,6 +130,19 @@ GTEST_TEST(RotationMatrixTest, TestProjectionWithAxis) {
   // projection is to one of the bound.
   EXPECT_NEAR(ProjectMatToRotMatWithAxis(M, axis, 0.3, 1), 0.3, 1e-6);
 
+  // If the angle bounds include infinity, the the maximal angle is to shift 0.2
+  // by 2kπ
+  EXPECT_NEAR(ProjectMatToRotMatWithAxis(
+                  M, axis, 0.3, std::numeric_limits<double>::infinity()),
+              0.2 + 2 * M_PI, 1e-6);
+  EXPECT_NEAR(ProjectMatToRotMatWithAxis(
+                  M, axis, -std::numeric_limits<double>::infinity(), 0.1),
+              0.2 - 2 * M_PI, 1e-6);
+  EXPECT_NEAR(ProjectMatToRotMatWithAxis(
+                  M, axis, -std::numeric_limits<double>::infinity(),
+                  std::numeric_limits<double>::infinity()),
+              0.2, 1e-6);
+
   EXPECT_NEAR(ProjectMatToRotMatWithAxis(M, axis, -4, 0.1), 0.1, 1e-6);
 
   M = 2 * Eigen::AngleAxisd(M_PI_2, axis).toRotationMatrix();
@@ -131,6 +162,11 @@ GTEST_TEST(RotationMatrixTest, TestProjectionWithAxis) {
   CheckProjectionWithAxis(M, axis, M_PI, 2 * M_PI);
   CheckProjectionWithAxis(M, axis, -2 * M_PI, 0);
   CheckProjectionWithAxis(M, axis, 0.1, 0.2);
+  CheckProjectionWithAxis(M, axis, -std::numeric_limits<double>::infinity(),
+                          2 * M_PI);
+  CheckProjectionWithAxis(M, axis, -M_PI,
+                          std::numeric_limits<double>::infinity());
+  CheckProjectionWithAxis(M, axis, -2 * M_PI, 4 * M_PI);
 }
 }  // namespace
 }  // namespace math

--- a/drake/multibody/dev/test/global_inverse_kinematics_test_util.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test_util.cc
@@ -31,6 +31,8 @@ std::unique_ptr<RigidBodyTree<double>> ConstructKuka() {
       rigid_body_tree.get());
 
   AddFlatTerrainToWorld(rigid_body_tree.get());
+  // Manually change the joint limits.
+  rigid_body_tree->joint_limit_min(6) = -2.1 * M_PI;
   return rigid_body_tree;
 }
 


### PR DESCRIPTION
Previously it only handles joint bounds with [-2pi, 2pi]. Unfortunately our IRB140 robot has a joint exceeding these bounds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5882)
<!-- Reviewable:end -->
