### PR TITLE
Modified AutomotiveSimulator to name each IdmController to avoid diagram throwing an exception requiring that all names be unique.

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -200,6 +200,7 @@ int AutomotiveSimulator<T>::AddIdmControlledPriusMaliputRailcar(
   DRAKE_DEMAND(railcar != nullptr);
   auto controller =
       builder_->template AddSystem<IdmController<T>>(*road_);
+  controller->set_name(name + "_IdmController");
 
   builder_->Connect(railcar->pose_output(), controller->ego_pose_input());
   builder_->Connect(railcar->velocity_output(),


### PR DESCRIPTION
Here is the exception otherwise:

```
[automotive_demo] [2017-04-19 10:51:31.967] [console] [error] Subsystem of type drake::automotive::IdmController<double> has no name
[automotive_demo] terminate called after throwing an instance of 'std::runtime_error'
[automotive_demo]   what():  Failure at ./drake/systems/framework/diagram.h:1109 in Initialize(): condition 'NamesAreUniqueAndNonEmpty()' failed.
[automotive_demo.py] automotive_demo exited -6
ERROR: Non-zero return code '250' from command: Process exited with status 250.

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5886)
<!-- Reviewable:end -->
