### PR TITLE
Confirm index and id works with std::to_string

### DIFF
--- a/drake/common/test/type_safe_index_test.cc
+++ b/drake/common/test/type_safe_index_test.cc
@@ -148,10 +148,17 @@ GTEST_TEST(TypeSafeIndex, InPlaceSubtract) {
 
 // Tests stream insertion.
 GTEST_TEST(TypeSafeIndex, StreamInsertion) {
-    AIndex index(8);
-    std::stringstream stream;
-    stream << index;
-    EXPECT_EQ(stream.str(), "8");
+  AIndex index(8);
+  std::stringstream stream;
+  stream << index;
+  EXPECT_EQ(stream.str(), "8");
+}
+
+// Tests conversion to string via std::to_string function.
+GTEST_TEST(TypeSafeIndex, ToString) {
+  const int value = 17;
+  AIndex index(value);
+  EXPECT_EQ(std::to_string(index), std::to_string(value));
 }
 
 // Verifies that it is not possible to convert between two different

--- a/drake/geometry/identifier.h
+++ b/drake/geometry/identifier.h
@@ -208,4 +208,10 @@ struct hash<drake::geometry::Identifier<Tag>> {
   }
 };
 
+/** Enables use of identifiers with std::to_string. */
+template <typename Tag>
+std::string to_string(drake::geometry::Identifier<Tag> id){
+  return to_string(id.get_value());
+}
+
 }  // namespace std

--- a/drake/geometry/identifier.h
+++ b/drake/geometry/identifier.h
@@ -195,7 +195,16 @@ inline std::ostream& operator<<(std::ostream& out,
   return out;
 }
 
+/** Enables use of identifiers with to_string. It requires ADL to work. So,
+ it should be invoked as: `to_string(id);` and should be preceded by
+ `using std::to_string`.*/
+template <typename Tag> inline
+std::string to_string(const drake::geometry::Identifier<Tag>& id) {
+  return std::to_string(id.get_value());
+}
+
 }  // namespace geometry
+
 }  // namespace drake
 
 namespace std {
@@ -208,11 +217,5 @@ struct hash<drake::geometry::Identifier<Tag>> {
     return hash<int64_t>()(id.get_value());
   }
 };
-
-/** Enables use of identifiers with std::to_string. */
-template <typename Tag>
-std::string to_string(drake::geometry::Identifier<Tag> id) {
-  return to_string(id.get_value());
-}
 
 }  // namespace std

--- a/drake/geometry/identifier.h
+++ b/drake/geometry/identifier.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <string>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
@@ -210,7 +211,7 @@ struct hash<drake::geometry::Identifier<Tag>> {
 
 /** Enables use of identifiers with std::to_string. */
 template <typename Tag>
-std::string to_string(drake::geometry::Identifier<Tag> id){
+std::string to_string(drake::geometry::Identifier<Tag> id) {
   return to_string(id.get_value());
 }
 

--- a/drake/geometry/test/identifier_test.cc
+++ b/drake/geometry/test/identifier_test.cc
@@ -114,6 +114,11 @@ TEST_F(IdentifierTests, StreamOperator) {
   EXPECT_EQ(ss.str(), "2");
 }
 
+// Tests the ability to convert the id to string via std::to_string.
+TEST_F(IdentifierTests, ToString) {
+  EXPECT_EQ(std::to_string(a2_), std::to_string(a2_.get_value()));
+}
+
 // These tests confirm that behavior that *shouldn't* be compilable isn't.
 
 // This code allows us to turn compile-time errors into run-time errors that

--- a/drake/geometry/test/identifier_test.cc
+++ b/drake/geometry/test/identifier_test.cc
@@ -116,7 +116,8 @@ TEST_F(IdentifierTests, StreamOperator) {
 
 // Tests the ability to convert the id to string via std::to_string.
 TEST_F(IdentifierTests, ToString) {
-  EXPECT_EQ(std::to_string(a2_), std::to_string(a2_.get_value()));
+  using std::to_string;
+  EXPECT_EQ(to_string(a2_), to_string(a2_.get_value()));
 }
 
 // These tests confirm that behavior that *shouldn't* be compilable isn't.


### PR DESCRIPTION
1) Add the functionality to Identifier.
2) Add the test to identifier_test.cc
3) Add the test to type_safe_index_text.cc (no new code is required because
   the implicit cast to conversion to int allows the TypeSafeIndex to be
   compatible with std::to_string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5888)
<!-- Reviewable:end -->
