### PR TITLE
Removes some endif() parameters that aren't needed and produce extraneous warnings.

### DIFF
--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(drakeRotationConstraintVisualization
         drakeRotationConstraint
         drakeLcm
         drakeLCMTypes)
-endif(lcm_FOUND)
+endif()
 
 # Temporarily disabled because we have no Gurobi license in CI. #5862
 # drake_add_cc_test(convex_optimization_test)
@@ -83,7 +83,7 @@ if (FALSE)
   drake_add_cc_test(rotation_constraint_test rotation_constraint_test.cc)
   set_tests_properties(rotation_constraint_test PROPERTIES TIMEOUT 900)
   target_link_libraries(rotation_constraint_test drakeRotationConstraint)
-endif(mosek_FOUND)
+endif()
 
 # Temporarily disabled because we have no Gurobi license in CI. #5862
 # if (gurobi_FOUND)
@@ -93,7 +93,7 @@ if (FALSE)
 	  set_tests_properties(rotation_constraint_limit_test PROPERTIES TIMEOUT 900)
 	  target_link_libraries(rotation_constraint_limit_test drakeRotationConstraint)
   endif()
-endif(gurobi_FOUND)
+endif()
 
 if (lcm_FOUND)
   add_executable(plot_feasible_rotation_matrices plot_feasible_rotation_matrices.cc)
@@ -108,4 +108,4 @@ if (lcm_FOUND)
           drakeOptimization
           drakeRotationConstraint
           drakeRotationConstraintVisualization)
-endif(lcm_FOUND)
+endif()


### PR DESCRIPTION
The warnings are:

```
CMake Warning (dev) in solvers/test/CMakeLists.txt:
  A logical block opening on the line

    /home/liang/dev/drake-distro-1/drake/solvers/test/CMakeLists.txt:82 (if)

  closes on the line

    /home/liang/dev/drake-distro-1/drake/solvers/test/CMakeLists.txt:86 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in solvers/test/CMakeLists.txt:
  A logical block opening on the line

    /home/liang/dev/drake-distro-1/drake/solvers/test/CMakeLists.txt:90 (if)

  closes on the line

    /home/liang/dev/drake-distro-1/drake/solvers/test/CMakeLists.txt:96 (endif)

  with mis-matching arguments.

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5902)
<!-- Reviewable:end -->
