### PR TITLE
Adds string stream operators to Some Maliput abstractions.

### DIFF
--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -23,7 +23,11 @@ add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
   gen/simple_car_state.cc
   idm_controller.cc
   idm_planner.cc
+  maliput/api/junction.cc
+  maliput/api/lane.cc
+  maliput/api/lane_data.cc
   maliput/api/road_geometry.cc
+  maliput/api/segment.cc
   maliput/dragway/branch_point.cc
   maliput/dragway/junction.cc
   maliput/dragway/lane.cc

--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -2,14 +2,18 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_library", "drake_cc_googletest")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
 drake_cc_library(
     name = "api",
     srcs = [
+        "junction.cc",
+        "lane.cc",
+        "lane_data.cc",
         "road_geometry.cc",
+        "segment.cc",
     ],
     hdrs = [
         "branch_point.h",
@@ -25,13 +29,20 @@ drake_cc_library(
 )
 
 # === test/ ===
-
 drake_cc_googletest(
     name = "lane_data_test",
     srcs = ["test/lane_data_test.cc"],
     deps = [
         ":api",
         "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "maliput_test",
+    srcs = ["test/maliput_test.cc"],
+    deps = [
+        ":api",
     ],
 )
 

--- a/drake/automotive/maliput/api/CMakeLists.txt
+++ b/drake/automotive/maliput/api/CMakeLists.txt
@@ -6,3 +6,7 @@ drake_install_headers(
   road_geometry.h
   segment.h
   )
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/drake/automotive/maliput/api/junction.cc
+++ b/drake/automotive/maliput/api/junction.cc
@@ -1,0 +1,16 @@
+#include "drake/automotive/maliput/api/junction.h"
+
+#include <iostream>
+#include <string>
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+std::ostream& operator<<(std::ostream& out, const JunctionId& junction_id) {
+  return out << std::string("Junction(") << junction_id.id << std::string(")");
+}
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/api/junction.h
+++ b/drake/automotive/maliput/api/junction.h
@@ -17,6 +17,10 @@ struct JunctionId {
   std::string id;
 };
 
+/// Streams a string representation of @p junction_id into @p out. Returns
+/// @p out. This method is provided for the purposes of debugging or
+/// text-logging. It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const JunctionId& junction_id);
 
 /// A Junction is a closed set of Segments which have physically
 /// coplanar road surfaces, in the sense that RoadPositions with the

--- a/drake/automotive/maliput/api/lane.cc
+++ b/drake/automotive/maliput/api/lane.cc
@@ -1,0 +1,16 @@
+#include "drake/automotive/maliput/api/lane.h"
+
+#include <iostream>
+#include <string>
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+std::ostream& operator<<(std::ostream& out, const LaneId& lane_id) {
+  return out << std::string("Lane(") << lane_id.id << std::string(")");
+}
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/api/lane.h
+++ b/drake/automotive/maliput/api/lane.h
@@ -20,6 +20,10 @@ struct LaneId {
   std::string id;
 };
 
+/// Streams a string representation of @p lane_id into @p out. Returns @p out.
+/// This method is provided for the purposes of debugging or text-logging. It is
+/// not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const LaneId& lane_id);
 
 /// A Lane represents a lane of travel in a road network.  A Lane defines
 /// a curvilinear coordinate system covering the road surface, with a

--- a/drake/automotive/maliput/api/lane_data.cc
+++ b/drake/automotive/maliput/api/lane_data.cc
@@ -1,0 +1,31 @@
+#include "drake/automotive/maliput/api/lane_data.h"
+
+#include <iostream>
+// #include <string>
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+std::ostream& operator<<(std::ostream& out, const LaneEnd::Which& which_end) {
+  return out << (which_end == LaneEnd::kStart ? "start" : "finish");
+}
+
+std::ostream& operator<<(std::ostream& out, const Rotation& rotation) {
+  return out << "(roll = " << rotation.roll << ", pitch = " << rotation.pitch
+      << ", yaw = " << rotation.yaw << ")";
+}
+
+std::ostream& operator<<(std::ostream& out, const GeoPosition& geo_position) {
+  return out << "(x = " << geo_position.x() << ", y = " << geo_position.y()
+      << ", z = " << geo_position.z() << ")";
+}
+
+std::ostream& operator<<(std::ostream& out, const LanePosition& lane_position) {
+  return out << "(s = " << lane_position.s() << ", r = " << lane_position.r()
+      << ", h = " << lane_position.h() << ")";
+}
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <ostream>
 #include <string>
 
 #include "drake/common/drake_assert.h"
@@ -41,6 +42,10 @@ struct LaneEnd {
   Which end{};
 };
 
+/// Streams a string representation of @p which_end into @p out. Returns
+/// @p out. This method is provided for the purposes of debugging or
+/// text-logging. It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const LaneEnd::Which& which_end);
 
 /// A 3-dimensional rotation, expressed as a roll around X, followed
 /// by pitch around Y, followed by yaw around Z.
@@ -57,6 +62,10 @@ struct Rotation {
   double yaw{};
 };
 
+/// Streams a string representation of @p rotation into @p out. Returns
+/// @p out. This method is provided for the purposes of debugging or
+/// text-logging. It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const Rotation& rotation);
 
 /// A position in 3-dimensional geographical Cartesian space, i.e.,
 /// in the world frame, consisting of three components x, y, and z.
@@ -102,6 +111,10 @@ class GeoPosition {
   explicit GeoPosition(const Vector3<double>& xyz) : xyz_(xyz) {}
 };
 
+/// Streams a string representation of @p geo_position into @p out. Returns
+/// @p out. This method is provided for the purposes of debugging or
+/// text-logging. It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const GeoPosition& geo_position);
 
 /// A 3-dimensional position in a `Lane`-frame, consisting of three components:
 ///  * s is longitudinal position, as arc-length along a Lane's reference line.
@@ -149,6 +162,10 @@ class LanePosition {
   explicit LanePosition(const Vector3<double>& srh) : srh_(srh) {}
 };
 
+/// Streams a string representation of @p lane_position into @p out. Returns
+/// @p out. This method is provided for the purposes of debugging or
+/// text-logging. It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const LanePosition& lane_position);
 
 /// Isometric velocity vector in a `Lane`-frame.
 ///

--- a/drake/automotive/maliput/api/road_geometry.cc
+++ b/drake/automotive/maliput/api/road_geometry.cc
@@ -111,6 +111,11 @@ double Distance(const Rotation& a, const Rotation& b) {
 
 }  // namespace
 
+std::ostream& operator<<(std::ostream& out,
+    const RoadGeometryId& road_geometry_id) {
+  return out << std::string("RoadGeometry(") << road_geometry_id.id
+      << std::string(")");
+}
 
 std::vector<std::string> RoadGeometry::CheckInvariants() const {
   std::vector<std::string> failures;

--- a/drake/automotive/maliput/api/road_geometry.h
+++ b/drake/automotive/maliput/api/road_geometry.h
@@ -19,6 +19,11 @@ struct RoadGeometryId {
   std::string id;
 };
 
+/// Streams a string representation of @p road_geometry_id into @p out.
+/// Returns @p out. This method is provided for the purposes of debugging or
+/// text-logging. It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out,
+    const RoadGeometryId& road_geometry_id);
 
 /// Abstract API for the geometry of a road network, including both
 /// the network topology and the geometry of its embedding in 3-space.

--- a/drake/automotive/maliput/api/segment.cc
+++ b/drake/automotive/maliput/api/segment.cc
@@ -1,0 +1,15 @@
+#include "drake/automotive/maliput/api/segment.h"
+
+#include <iostream>
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+std::ostream& operator<<(std::ostream& out, const SegmentId& segment_id) {
+  return out << std::string("Segment(") << segment_id.id << std::string(")");
+}
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/api/segment.h
+++ b/drake/automotive/maliput/api/segment.h
@@ -17,6 +17,10 @@ struct SegmentId {
   std::string id;
 };
 
+/// Streams a string representation of @p segment_id into @p out. Returns
+/// @p out. This method is provided for the purposes of debugging or
+/// text-logging. It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const SegmentId& segment_id);
 
 /// A Segment represents a bundle of adjacent Lanes which share a
 /// continuously traversable road surface.  Every LanePosition on a

--- a/drake/automotive/maliput/api/test/CMakeLists.txt
+++ b/drake/automotive/maliput/api/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+drake_add_cc_test(maliput_test)
+target_link_libraries(maliput_test drakeAutomotive)

--- a/drake/automotive/maliput/api/test/maliput_test.cc
+++ b/drake/automotive/maliput/api/test/maliput_test.cc
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/segment.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+namespace {
+
+// Tests the streaming string operators for the following Maliput abstractions:
+//   - JunctionId
+//   - LaneId
+//   - RoadGeometryId
+//   - SegmentId
+GTEST_TEST(MaliputApiTest, TestIdToStringStream) {
+  std::stringstream buffer;
+
+  // Tests JunctionId.
+  const std::string junction_name = "foo junction id";
+  buffer << JunctionId({junction_name});
+  EXPECT_EQ(buffer.str(), "Junction(" + junction_name + ")");
+  buffer.str("");
+  buffer.clear();
+
+  // Tests LaneId.
+  const std::string lane_name = "foo lane id";
+  buffer << LaneId({lane_name});
+  EXPECT_EQ(buffer.str(), "Lane(" + lane_name + ")");
+  buffer.str("");
+  buffer.clear();
+
+  // Tests RoadGeometryId.
+  const std::string road_geometry_name = "foo road id";
+  buffer << RoadGeometryId({road_geometry_name});
+  EXPECT_EQ(buffer.str(), "RoadGeometry(" + road_geometry_name + ")");
+  buffer.str("");
+  buffer.clear();
+
+  // Tests SegmentId.
+  const std::string segment_name = "foo segment id";
+  buffer << SegmentId({segment_name});
+  EXPECT_EQ(buffer.str(), "Segment(" + segment_name + ")");
+}
+
+// Tests the streaming string operators for the following Maliput abstractions:
+//   - GeoPosition
+//   - LaneEnd::Which
+//   - LanePosition
+//   - Rotation
+GTEST_TEST(MaliputApiTest, TestLaneDataToStringStream) {
+  std::stringstream buffer;
+
+  // Tests GeoPosition.
+  buffer << GeoPosition(1.5, 2.2, 3.7);
+  EXPECT_EQ(buffer.str(), "(x = 1.5, y = 2.2, z = 3.7)");
+  buffer.str("");
+  buffer.clear();
+
+  // Tests LaneEnd::Which.
+  LaneEnd::Which start = LaneEnd::kStart;
+  buffer <<  start;
+  EXPECT_EQ(buffer.str(), "start");
+  buffer.str("");
+  buffer.clear();
+  LaneEnd::Which end = LaneEnd::kFinish;
+  buffer << end;
+  EXPECT_EQ(buffer.str(), "finish");
+  buffer.str("");
+  buffer.clear();
+
+  // Tests LanePosition.
+  buffer << LanePosition(0.2, 9.1, 15.2);
+  EXPECT_EQ(buffer.str(), "(s = 0.2, r = 9.1, h = 15.2)");
+  buffer.str("");
+  buffer.clear();
+
+  // Tests Rotation.
+  buffer << Rotation({1, 2, 3});
+  EXPECT_EQ(buffer.str(), "(roll = 1, pitch = 2, yaw = 3)");
+  buffer.str("");
+  buffer.clear();
+}
+
+}  // namespace
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/dragway/CMakeLists.txt
+++ b/drake/automotive/maliput/dragway/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library_with_exports(LIB_NAME drakeMaliputDragway SOURCE_FILES
   segment.cc)
 
 target_link_libraries(drakeMaliputDragway
+  drakeAutomotive
   drakeCommon
 )
 


### PR DESCRIPTION
This is useful when constructing debug print statements. More streaming operators will be added to tother Maliput abstractions in followup PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5903)
<!-- Reviewable:end -->
