### PR TITLE
Add "invalid" index semantics to `TypeSafeIndex`

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -668,7 +668,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "type_safe_index_test",
-    deps = [":type_safe_index"],
+    deps = [
+        ":type_safe_index",
+        ":unused",
+    ],
 )
 
 # TODO(jwnimmer-tri) These tests are currently missing...

--- a/drake/common/test/type_safe_index_test.cc
+++ b/drake/common/test/type_safe_index_test.cc
@@ -245,6 +245,10 @@ try { \
 // Performs operations on an invalid index in Debug mode. All of these should
 // throw exceptions with meaningful error messages.
 GTEST_TEST(TypeSafeIndex, OperationOnInvalidInDebug) {
+  // This is a no-op function so the compiler doesn't think I'm computing
+  // unused values. Used to consume otherwise un-used bool and integer values.
+  auto consume = [](bool) {};
+
   int i;
   AIndex valid(1);
   AIndex invalid;
@@ -255,17 +259,13 @@ GTEST_TEST(TypeSafeIndex, OperationOnInvalidInDebug) {
                        ".+negative value = \\-\\d+.+");
 
   // Implicit conversion to int.
-  EXPECT_ERROR_MESSAGE({ i = invalid; }, std::runtime_error,
+  EXPECT_ERROR_MESSAGE(consume(i = invalid), std::runtime_error,
                        "Converting to an int."
                        ".+negative value = \\-\\d+.+");
   // Assignment.
   EXPECT_ERROR_MESSAGE({ invalid = -1; }, std::runtime_error,
                        "Assigning an invalid int."
                        ".+negative value = \\-\\d+.+");
-
-  // This is a no-op function so the compiler doesn't think I'm computing
-  // unused boolean values in the next set of comparison tests.
-  auto consume = [](bool) {};
 
   // Comparison operators.
   EXPECT_ERROR_MESSAGE(consume(invalid == valid), std::runtime_error,

--- a/drake/common/test/type_safe_index_test.cc
+++ b/drake/common/test/type_safe_index_test.cc
@@ -182,7 +182,7 @@ GTEST_TEST(TypeSafeIndex, ValueAssignment) {
 
 //-------------------------------------------------------------------
 
-// This codes tests the operations on invalid indices. In release mode, the
+// This code tests the operations on invalid indices. In release mode, the
 // operations are "valid", but in debug they throw an exception. This is *not*
 // all inclusive. Some invalid tests are included in the previous operator-
 // specific tests, encapsulated within EXPECT_THROW_IF_ARMED.

--- a/drake/common/test/type_safe_index_test.cc
+++ b/drake/common/test/type_safe_index_test.cc
@@ -259,7 +259,7 @@ GTEST_TEST(TypeSafeIndex, OperationOnInvalidInDebug) {
                        ".+negative value = \\-\\d+.+");
 
   // Implicit conversion to int.
-  EXPECT_ERROR_MESSAGE(consume(i = invalid), std::runtime_error,
+  EXPECT_ERROR_MESSAGE(consume((i = invalid)), std::runtime_error,
                        "Converting to an int."
                        ".+negative value = \\-\\d+.+");
   // Assignment.

--- a/drake/common/type_safe_index.h
+++ b/drake/common/type_safe_index.h
@@ -41,13 +41,13 @@ namespace drake {
 ///     type.
 ///   - In general, indices of different types are _not_ interconvertible.
 ///
-/// While there _is_ the conept of an "invalid" index, this only exists to
+/// While there _is_ the concept of an "invalid" index, this only exists to
 /// facilitate use with STL containers that require default constructors. Using
 /// an invalid index in _any_ operation is considered an error. In Debug build,
 /// attempts to compare, increment, decrement, etc. an invalid index
 /// will throw an exception.
 ///
-/// A function that returns %type_safe_index values which need to communicate
+/// A function that returns %TypeSafeIndex values which need to communicate
 /// failure should _not_ use an invalid index. It should return an
 /// `std::optional<Index>` instead.
 ///

--- a/drake/common/type_safe_index.h
+++ b/drake/common/type_safe_index.h
@@ -156,27 +156,15 @@ class TypeSafeIndex {
   template <typename U>
   TypeSafeIndex( const TypeSafeIndex<U>& idx) = delete;
 
-  TypeSafeIndex(const TypeSafeIndex& other) : index_(other.index_) {
-    DRAKE_ASSERT_VOID(
-        AssertValid("Copy constructing from an invalid index."));
-  }
+  TypeSafeIndex(const TypeSafeIndex&) = default;
 
-  TypeSafeIndex& operator=(const TypeSafeIndex& other) {
-    DRAKE_ASSERT_VOID(
-        other.AssertValid("Copy assigning from an invalid index."));
-    index_ = other.index_;
-    return *this;
-  }
+  TypeSafeIndex& operator=(const TypeSafeIndex&) = default;
 
   TypeSafeIndex(TypeSafeIndex&& other) noexcept : index_(other.index_) {
-    // Note: move semantics on invalid indices is acceptable; no _new_ invalid
-    // indices are being created.
     other.index_ = kDefaultInvalid;
   }
 
   TypeSafeIndex& operator=(TypeSafeIndex&& other) noexcept {
-    // Note: move semantics on invalid indices is acceptable; no _new_ invalid
-    // indices are being created.
     index_ = other.index_;
     other.index_ = kDefaultInvalid;
     return *this;
@@ -203,7 +191,8 @@ class TypeSafeIndex {
     // invariant that the only way to get an invalid index is via the default
     // constructor. This assertion will catch any crack in that effort.
     DRAKE_ASSERT((index_ >= 0) || (index_ == kDefaultInvalid));
-    return index_ >= 0; }
+    return index_ >= 0;
+  }
 
   /// @name Arithmetic operators.
   ///@{
@@ -372,6 +361,9 @@ class TypeSafeIndex {
         "In-place addition with another index invalid LHS."));
     DRAKE_ASSERT_VOID(other.AssertValid(
         "In-place addition with another index invalid RHS."));
+    DRAKE_ASSERT_VOID(AssertNoOverflow(
+        other.index_,
+        "In-place addition with another index produced an invalid index."));
     index_ += other.index_;
     DRAKE_ASSERT_VOID(AssertValid(
         "In-place addition with another index produced an invalid index."));
@@ -388,6 +380,9 @@ class TypeSafeIndex {
         "In-place subtraction with another index invalid LHS."));
     DRAKE_ASSERT_VOID(other.AssertValid(
         "In-place subtraction with another index invalid RHS."));
+    // No test for overflow; it would only be necessary if other had a negative
+    // index value. In that case, it would be invalid and that would be caught
+    // by the previous assertion.
     index_ -= other.index_;
     DRAKE_ASSERT_VOID(AssertValid(
         "In-place subtraction with another index produced an invalid index."));

--- a/drake/common/type_safe_index.h
+++ b/drake/common/type_safe_index.h
@@ -147,7 +147,7 @@ class TypeSafeIndex {
   ///@{
 
   /// Default constructor; the result is an _invalid_ index. This only
-  /// exists to applications which require a default constructor.
+  /// exists to serve applications which require a default constructor.
   TypeSafeIndex() {}
 
   /// Construction from a non-negative `int` value.

--- a/drake/common/type_safe_index.h
+++ b/drake/common/type_safe_index.h
@@ -33,7 +33,7 @@ namespace drake {
 /// The type-safe index is a _stripped down_ `int`. Each uniquely declared
 /// index type has the following properties:
 ///
-///   - Index values are _explicitly_ constructed from `int` values.
+///   - Valid index values are _explicitly_ constructed from `int` values.
 ///   - The index is implicitly convertible to an `int` (to serve as an index).
 ///   - The index supports increment, decrement, and in-place addition and
 ///     subtraction to support standard index-like operations.
@@ -165,10 +165,11 @@ class TypeSafeIndex {
   /// Implicit conversion-to-int operator.
   operator int() const {
     DRAKE_ASSERT_VOID(CheckInvariants("Converting to an int.", index_));
-    return index_; }
+    return index_;
+  }
 
-  /// Reports if the index is valid; the only acceptable operation on an invalid
-  /// index.
+  /// Reports if the index is valid--the only operation on an invalid index
+  /// that doesn't throw an exception in Debug builds.
   bool is_valid() const { return index_ >= 0; }
 
   /// @name Arithmetic operators.

--- a/drake/multibody/multibody_tree/multibody_tree_element.h
+++ b/drake/multibody/multibody_tree/multibody_tree_element.h
@@ -152,8 +152,7 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
   friend class MultibodyTree<T>;
 
   const MultibodyTree<T>* parent_tree_{nullptr};
-
-  // ElementIndexType requires a valid initialization.
+  
   ElementIndexType index_;
 };
 

--- a/drake/multibody/multibody_tree/multibody_tree_element.h
+++ b/drake/multibody/multibody_tree/multibody_tree_element.h
@@ -153,6 +153,8 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
 
   const MultibodyTree<T>* parent_tree_{nullptr};
 
+  // The default index value is *invalid*. This must be set to a valid index
+  // value before the element is released to the wild.
   ElementIndexType index_;
 };
 

--- a/drake/multibody/multibody_tree/multibody_tree_element.h
+++ b/drake/multibody/multibody_tree/multibody_tree_element.h
@@ -152,7 +152,7 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
   friend class MultibodyTree<T>;
 
   const MultibodyTree<T>* parent_tree_{nullptr};
-  
+
   ElementIndexType index_;
 };
 

--- a/drake/multibody/multibody_tree/multibody_tree_element.h
+++ b/drake/multibody/multibody_tree/multibody_tree_element.h
@@ -154,7 +154,7 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
   const MultibodyTree<T>* parent_tree_{nullptr};
 
   // ElementIndexType requires a valid initialization.
-  ElementIndexType index_{0};
+  ElementIndexType index_;
 };
 
 }  // namespace multibody


### PR DESCRIPTION
1) Add default constructor so it can be used in STL containers.
2) Define invalid value (any negative value).
3) In Debug build, cause operations on invalid indexes to throw an
   exception.
4) Extend unit tests to cover this functionality.
5) Correct the single usage out in the wild: multibody_tree_element was
   default initializing them to zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5908)
<!-- Reviewable:end -->
