### PR TITLE
Removing Shell Tests From Memchecks

### DIFF
--- a/drake/tools/BUILD
+++ b/drake/tools/BUILD
@@ -97,6 +97,7 @@ sh_test(
         "test/sample.named_vector",
         ":lcm_vector_gen",
     ],
+    tags = ["sh_script"],
 )
 
 py_test(
@@ -111,6 +112,7 @@ sh_test(
     data = [
         ":clang-format-includes",
     ],
+    tags = ["sh_script"],
 )
 
 cpplint(data = ["test/gen/drake/CPPLINT.cfg"])

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -175,7 +175,7 @@ test:ubsan --test_tag_filters=-cpplint,-pycodestyle
 ### Memcheck build. ###
 build:memcheck --copt -g
 build:memcheck --run_under=//tools:valgrind
-test:memcheck --test_tag_filters=-cpplint,-pycodestyle
+test:memcheck --test_tag_filters=-cpplint,-pycodestyle,-sh_script
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
 test:memcheck --test_timeout=300,1500,5400,18000
@@ -190,7 +190,7 @@ test:memcheck --test_timeout=300,1500,5400,18000
 # memcheck` to recompile with line numbers and lower optimization levels.
 #
 build:fastmemcheck --run_under=//tools:valgrind
-test:fastmemcheck --test_tag_filters=-cpplint,-pycodestyle
+test:fastmemcheck --test_tag_filters=-cpplint,-pycodestyle,-sh_script
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
 test:fastmemcheck --test_timeout=300,1500,5400,18000


### PR DESCRIPTION
We don't want to run memchecks on shell scripts.
https://github.com/RobotLocomotion/drake/issues/5892

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5909)
<!-- Reviewable:end -->
