### PR TITLE
Adds AutomotiveSimulator::GetContextToString().

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -572,6 +572,99 @@ void AutomotiveSimulator<T>::StepBy(const T& time_step) {
 }
 
 template <typename T>
+std::string AutomotiveSimulator<T>::GetContextString(const std::string& prefix)
+    const {
+  if (!has_started()) {
+    throw std::runtime_error("AutomotiveSimulator::GetContextString(): ERROR: "
+        "Start() must be called before this method can be called.");
+  }
+
+  const systems::Context<T>& diagram_context = simulator_->get_context();
+  std::stringstream result;
+  result << prefix << "AutomotiveSimulator Context:\n";
+  result << prefix << "  - Time: " << diagram_context.get_time() << "\n";
+
+  const int num_simple_cars = simple_car_initial_states_.size();
+  result << prefix << "  - Number of SimpleCars: " << num_simple_cars << "\n";
+  for (const auto& entry : simple_car_initial_states_) {
+    const SimpleCar<T>* simple_car = entry.first;
+    DRAKE_DEMAND(simple_car != nullptr);
+    const systems::Context<T>& context =
+        diagram_->GetSubsystemContext(diagram_context, simple_car);
+    result << prefix << "    - SimpleCar:\n";
+    result << prefix << "      - Name: " << simple_car->get_name() << "\n";
+
+    const SimpleCarParams<T>* params =
+        dynamic_cast<const SimpleCarParams<T>*>(
+            context.get_parameters().get_numeric_parameter(0));
+    DRAKE_DEMAND(params != nullptr);
+    result << prefix << "      - Parameters:\n";
+    const std::vector<std::string>& param_coordinate_names =
+        params->GetCoordinateNames();
+    for (int i = 0; i < params->size(); ++i) {
+      result << prefix << "        - " << param_coordinate_names.at(i)
+          << ": " << params->GetAtIndex(i) << "\n";
+    }
+
+    const SimpleCarState<T>* state =
+        dynamic_cast<const SimpleCarState<T>*>(
+            &context.get_state().get_continuous_state()->get_vector());
+    DRAKE_DEMAND(state != nullptr);
+    result << prefix << "      - State:\n";
+    const std::vector<std::string>& coordinate_names =
+        state->GetCoordinateNames();
+    for (int i = 0; i < state->size(); ++i) {
+      result << prefix << "        - " << coordinate_names.at(i)
+          << ": " << state->GetAtIndex(i) << "\n";
+    }
+  }
+
+  const int num_railcars = railcar_configs_.size();
+  result << prefix << "  - Number of Maliput Railcars: " << num_railcars
+      << "\n";
+  for (const auto& entry : railcar_configs_) {
+    const MaliputRailcar<T>* railcar = entry.first;
+    DRAKE_DEMAND(railcar != nullptr);
+    const systems::Context<T>& context =
+        diagram_->GetSubsystemContext(diagram_context, railcar);
+
+    result << prefix << "    - MaliputRailcar:\n";
+    result << prefix << "      - Name: " << railcar->get_name() << "\n";
+
+    const MaliputRailcarParams<T>* params =
+        dynamic_cast<const MaliputRailcarParams<T>*>(
+            context.get_parameters().get_numeric_parameter(0));
+    DRAKE_DEMAND(params != nullptr);
+    result << prefix << "      - Parameters:\n";
+    const std::vector<std::string>& param_coordinate_names =
+        params->GetCoordinateNames();
+    for (int i = 0; i < params->size(); ++i) {
+      result << prefix << "        - " << param_coordinate_names.at(i)
+          << ": " << params->GetAtIndex(i) << "\n";
+    }
+
+    const MaliputRailcarState<T>* state =
+        dynamic_cast<const MaliputRailcarState<T>*>(
+            &context.get_state().get_continuous_state()->get_vector());
+    DRAKE_DEMAND(state != nullptr);
+    result << prefix << "      - State:\n";
+    const std::vector<std::string>& state_coordinate_names =
+        state->GetCoordinateNames();
+    for (int i = 0; i < state->size(); ++i) {
+      result << prefix << "        - " << state_coordinate_names.at(i)
+          << ": " << state->GetAtIndex(i) << "\n";
+    }
+  }
+
+  // TODO(liang.fok) Add all other information contained in the Context to the
+  // result string. This includes all states and parameters, and optionally
+  // includes inputs. Inputs are optional since they should be derivable from
+  // the state and parameters.
+
+  return result.str();
+}
+
+template <typename T>
 int AutomotiveSimulator<T>::allocate_vehicle_number() {
   DRAKE_DEMAND(!has_started());
   return next_vehicle_number_++;

--- a/drake/automotive/automotive_simulator.h
+++ b/drake/automotive/automotive_simulator.h
@@ -257,6 +257,11 @@ class AutomotiveSimulator {
   /// @pre Start() has been called.
   systems::rendering::PoseBundle<T> GetCurrentPoses() const;
 
+  /// Returns a string representation of the current context.
+  ///
+  /// @pre Start() has been called.
+  std::string GetContextString(const std::string& prefix = "") const;
+
  private:
   int allocate_vehicle_number();
 

--- a/drake/automotive/test/automotive_simulator_test.cc
+++ b/drake/automotive/test/automotive_simulator_test.cc
@@ -641,6 +641,33 @@ GTEST_TEST(AutomotiveSimulatorTest, TestBuild2) {
   EXPECT_NO_THROW(simulator->GetDiagram());
 }
 
+GTEST_TEST(AutomotiveSimulatorTest, TestContextToString) {
+  auto simulator = std::make_unique<AutomotiveSimulator<double>>();
+
+  simulator->AddPriusSimpleCar("Model1", "Channel1");
+  simulator->AddPriusSimpleCar("Model2", "Channel2");
+
+  MaliputRailcarParams<double> params;
+  params.set_r(1);
+
+  const maliput::api::RoadGeometry* road{};
+  road = simulator->SetRoadGeometry(
+      std::make_unique<const maliput::dragway::RoadGeometry>(
+          maliput::api::RoadGeometryId({"TestDragway"}), 1 /* num lanes */,
+          100 /* length */, 4 /* lane width */, 1 /* shoulder width */));
+
+  simulator->AddPriusMaliputRailcar("My Railcar",
+      LaneDirection(road->junction(0)->segment(0)->lane(0)), params,
+      MaliputRailcarState<double>() /* initial state */);
+
+  simulator->Start();
+
+  const std::string result = simulator->GetContextString();
+  EXPECT_TRUE(result.find("AutomotiveSimulator Context:") != std::string::npos);
+  EXPECT_TRUE(result.find("Number of SimpleCars:") != std::string::npos);
+  EXPECT_TRUE(result.find("Number of Maliput Railcars:") != std::string::npos);
+}
+
 }  // namespace
 }  // namespace automotive
 }  // namespace drake


### PR DESCRIPTION
This is an incremental step towards #5857. The resulting string currently only includes information about the SimpleCars' and MaliputRailcars' continuous state vectors (i.e., `SimpleCarState` and `MaliputRailcarState`) and numerical parameters (`SimpleCarParams` and `MaliputRailcarParams`). If this is the direction we want to go in, I will submit follow-up PRs that include additional information contained in the `Context`.

Here is an example string produced by the changeset in this PR:

```
AutomotiveSimulator Context:
  - Time: 0
  - Number of SimpleCars: 2
    - SimpleCar:
      - Name: Model1
      - Parameters:
        - wheelbase: 2.7
        - track: 1.521
        - max_abs_steering_angle: 0.471
        - max_velocity: 45
        - max_acceleration: 4
        - velocity_limit_kp: 10
      - State:
        - x: 0
        - y: 0
        - heading: 0
        - velocity: 0
    - SimpleCar:
      - Name: Model2
      - Parameters:
        - wheelbase: 2.7
        - track: 1.521
        - max_abs_steering_angle: 0.471
        - max_velocity: 45
        - max_acceleration: 4
        - velocity_limit_kp: 10
      - State:
        - x: 0
        - y: 0
        - heading: 0
        - velocity: 0
  - Number of Maliput Railcars: 1
    - MaliputRailcar:
      - Name: My Railcar
      - Parameters:
        - r: 1
        - h: 0
        - max_speed: 45
        - velocity_limit_kp: 10
      - State:
        - s: 0
        - speed: 0
```

The above text was obtained by printing the `result` string in the included "TestContextToString" unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5910)
<!-- Reviewable:end -->
