### PR TITLE
Updates lcm_vector_gen.py to include GetCoordinateName() in the generated vector class.

### DIFF
--- a/drake/automotive/gen/bicycle_car_parameters.cc
+++ b/drake/automotive/gen/bicycle_car_parameters.cc
@@ -14,5 +14,14 @@ const int BicycleCarParametersIndices::kIz;
 const int BicycleCarParametersIndices::kCf;
 const int BicycleCarParametersIndices::kCr;
 
+const std::vector<std::string>&
+BicycleCarParametersIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "mass", "lf", "lr", "Iz", "Cf", "Cr",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/bicycle_car_parameters.h
+++ b/drake/automotive/gen/bicycle_car_parameters.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -26,6 +28,12 @@ struct BicycleCarParametersIndices {
   static const int kIz = 3;
   static const int kCf = 4;
   static const int kCr = 5;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `BicycleCarParametersIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -88,6 +96,11 @@ class BicycleCarParameters : public systems::BasicVector<T> {
   const T& Cr() const { return this->GetAtIndex(K::kCr); }
   void set_Cr(const T& Cr) { this->SetAtIndex(K::kCr, Cr); }
   //@}
+
+  /// See BicycleCarParametersIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return BicycleCarParametersIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/bicycle_car_state.cc
+++ b/drake/automotive/gen/bicycle_car_state.cc
@@ -14,5 +14,13 @@ const int BicycleCarStateIndices::kVel;
 const int BicycleCarStateIndices::kSx;
 const int BicycleCarStateIndices::kSy;
 
+const std::vector<std::string>& BicycleCarStateIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "Psi", "Psi_dot", "beta", "vel", "sx", "sy",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/bicycle_car_state.h
+++ b/drake/automotive/gen/bicycle_car_state.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -26,6 +28,12 @@ struct BicycleCarStateIndices {
   static const int kVel = 3;
   static const int kSx = 4;
   static const int kSy = 5;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `BicycleCarStateIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -63,6 +71,11 @@ class BicycleCarState : public systems::BasicVector<T> {
   const T& sy() const { return this->GetAtIndex(K::kSy); }
   void set_sy(const T& sy) { this->SetAtIndex(K::kSy, sy); }
   //@}
+
+  /// See BicycleCarStateIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return BicycleCarStateIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/driving_command.cc
+++ b/drake/automotive/gen/driving_command.cc
@@ -10,5 +10,13 @@ const int DrivingCommandIndices::kNumCoordinates;
 const int DrivingCommandIndices::kSteeringAngle;
 const int DrivingCommandIndices::kAcceleration;
 
+const std::vector<std::string>& DrivingCommandIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "steering_angle", "acceleration",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/driving_command.h
+++ b/drake/automotive/gen/driving_command.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -22,6 +24,12 @@ struct DrivingCommandIndices {
   // The index of each individual coordinate.
   static const int kSteeringAngle = 0;
   static const int kAcceleration = 1;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `DrivingCommandIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -60,6 +68,11 @@ class DrivingCommand : public systems::BasicVector<T> {
     this->SetAtIndex(K::kAcceleration, acceleration);
   }
   //@}
+
+  /// See DrivingCommandIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return DrivingCommandIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/euler_floating_joint_state.cc
+++ b/drake/automotive/gen/euler_floating_joint_state.cc
@@ -14,5 +14,14 @@ const int EulerFloatingJointStateIndices::kRoll;
 const int EulerFloatingJointStateIndices::kPitch;
 const int EulerFloatingJointStateIndices::kYaw;
 
+const std::vector<std::string>&
+EulerFloatingJointStateIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "x", "y", "z", "roll", "pitch", "yaw",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/euler_floating_joint_state.h
+++ b/drake/automotive/gen/euler_floating_joint_state.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -26,6 +28,12 @@ struct EulerFloatingJointStateIndices {
   static const int kRoll = 3;
   static const int kPitch = 4;
   static const int kYaw = 5;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `EulerFloatingJointStateIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -65,6 +73,11 @@ class EulerFloatingJointState : public systems::BasicVector<T> {
   const T& yaw() const { return this->GetAtIndex(K::kYaw); }
   void set_yaw(const T& yaw) { this->SetAtIndex(K::kYaw, yaw); }
   //@}
+
+  /// See EulerFloatingJointStateIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return EulerFloatingJointStateIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/idm_planner_parameters.cc
+++ b/drake/automotive/gen/idm_planner_parameters.cc
@@ -16,5 +16,15 @@ const int IdmPlannerParametersIndices::kDelta;
 const int IdmPlannerParametersIndices::kBloatDiameter;
 const int IdmPlannerParametersIndices::kDistanceLowerLimit;
 
+const std::vector<std::string>&
+IdmPlannerParametersIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "v_ref", "a", "b", "s_0", "time_headway", "delta", "bloat_diameter",
+          "distance_lower_limit",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/idm_planner_parameters.h
+++ b/drake/automotive/gen/idm_planner_parameters.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -28,6 +30,12 @@ struct IdmPlannerParametersIndices {
   static const int kDelta = 5;
   static const int kBloatDiameter = 6;
   static const int kDistanceLowerLimit = 7;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `IdmPlannerParametersIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -116,6 +124,11 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
     this->SetAtIndex(K::kDistanceLowerLimit, distance_lower_limit);
   }
   //@}
+
+  /// See IdmPlannerParametersIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return IdmPlannerParametersIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/maliput_railcar_params.cc
+++ b/drake/automotive/gen/maliput_railcar_params.cc
@@ -12,5 +12,14 @@ const int MaliputRailcarParamsIndices::kH;
 const int MaliputRailcarParamsIndices::kMaxSpeed;
 const int MaliputRailcarParamsIndices::kVelocityLimitKp;
 
+const std::vector<std::string>&
+MaliputRailcarParamsIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "r", "h", "max_speed", "velocity_limit_kp",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_params.h
+++ b/drake/automotive/gen/maliput_railcar_params.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -24,6 +26,12 @@ struct MaliputRailcarParamsIndices {
   static const int kH = 1;
   static const int kMaxSpeed = 2;
   static const int kVelocityLimitKp = 3;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `MaliputRailcarParamsIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -76,6 +84,11 @@ class MaliputRailcarParams : public systems::BasicVector<T> {
     this->SetAtIndex(K::kVelocityLimitKp, velocity_limit_kp);
   }
   //@}
+
+  /// See MaliputRailcarParamsIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return MaliputRailcarParamsIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/maliput_railcar_state.cc
+++ b/drake/automotive/gen/maliput_railcar_state.cc
@@ -10,5 +10,14 @@ const int MaliputRailcarStateIndices::kNumCoordinates;
 const int MaliputRailcarStateIndices::kS;
 const int MaliputRailcarStateIndices::kSpeed;
 
+const std::vector<std::string>&
+MaliputRailcarStateIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "s", "speed",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/maliput_railcar_state.h
+++ b/drake/automotive/gen/maliput_railcar_state.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -22,6 +24,12 @@ struct MaliputRailcarStateIndices {
   // The index of each individual coordinate.
   static const int kS = 0;
   static const int kSpeed = 1;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `MaliputRailcarStateIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -49,6 +57,11 @@ class MaliputRailcarState : public systems::BasicVector<T> {
   const T& speed() const { return this->GetAtIndex(K::kSpeed); }
   void set_speed(const T& speed) { this->SetAtIndex(K::kSpeed, speed); }
   //@}
+
+  /// See MaliputRailcarStateIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return MaliputRailcarStateIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/mobil_planner_parameters.cc
+++ b/drake/automotive/gen/mobil_planner_parameters.cc
@@ -11,5 +11,14 @@ const int MobilPlannerParametersIndices::kP;
 const int MobilPlannerParametersIndices::kThreshold;
 const int MobilPlannerParametersIndices::kMaxDeceleration;
 
+const std::vector<std::string>&
+MobilPlannerParametersIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "p", "threshold", "max_deceleration",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/mobil_planner_parameters.h
+++ b/drake/automotive/gen/mobil_planner_parameters.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -23,6 +25,12 @@ struct MobilPlannerParametersIndices {
   static const int kP = 0;
   static const int kThreshold = 1;
   static const int kMaxDeceleration = 2;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `MobilPlannerParametersIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -71,6 +79,11 @@ class MobilPlannerParameters : public systems::BasicVector<T> {
     this->SetAtIndex(K::kMaxDeceleration, max_deceleration);
   }
   //@}
+
+  /// See MobilPlannerParametersIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return MobilPlannerParametersIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/pure_pursuit_params.cc
+++ b/drake/automotive/gen/pure_pursuit_params.cc
@@ -9,5 +9,13 @@ namespace automotive {
 const int PurePursuitParamsIndices::kNumCoordinates;
 const int PurePursuitParamsIndices::kSLookahead;
 
+const std::vector<std::string>& PurePursuitParamsIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "s_lookahead",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/pure_pursuit_params.h
+++ b/drake/automotive/gen/pure_pursuit_params.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -21,6 +23,12 @@ struct PurePursuitParamsIndices {
 
   // The index of each individual coordinate.
   static const int kSLookahead = 0;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `PurePursuitParamsIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -50,6 +58,11 @@ class PurePursuitParams : public systems::BasicVector<T> {
     this->SetAtIndex(K::kSLookahead, s_lookahead);
   }
   //@}
+
+  /// See PurePursuitParamsIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return PurePursuitParamsIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/simple_car_params.cc
+++ b/drake/automotive/gen/simple_car_params.cc
@@ -14,5 +14,14 @@ const int SimpleCarParamsIndices::kMaxVelocity;
 const int SimpleCarParamsIndices::kMaxAcceleration;
 const int SimpleCarParamsIndices::kVelocityLimitKp;
 
+const std::vector<std::string>& SimpleCarParamsIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "wheelbase", "track", "max_abs_steering_angle", "max_velocity",
+          "max_acceleration", "velocity_limit_kp",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/simple_car_params.h
+++ b/drake/automotive/gen/simple_car_params.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -26,6 +28,12 @@ struct SimpleCarParamsIndices {
   static const int kMaxVelocity = 3;
   static const int kMaxAcceleration = 4;
   static const int kVelocityLimitKp = 5;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `SimpleCarParamsIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -104,6 +112,11 @@ class SimpleCarParams : public systems::BasicVector<T> {
     this->SetAtIndex(K::kVelocityLimitKp, velocity_limit_kp);
   }
   //@}
+
+  /// See SimpleCarParamsIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return SimpleCarParamsIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/automotive/gen/simple_car_state.cc
+++ b/drake/automotive/gen/simple_car_state.cc
@@ -12,5 +12,13 @@ const int SimpleCarStateIndices::kY;
 const int SimpleCarStateIndices::kHeading;
 const int SimpleCarStateIndices::kVelocity;
 
+const std::vector<std::string>& SimpleCarStateIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "x", "y", "heading", "velocity",
+      });
+  return coordinates.access();
+}
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/gen/simple_car_state.h
+++ b/drake/automotive/gen/simple_car_state.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -24,6 +26,12 @@ struct SimpleCarStateIndices {
   static const int kY = 1;
   static const int kHeading = 2;
   static const int kVelocity = 3;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `SimpleCarStateIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -57,6 +65,11 @@ class SimpleCarState : public systems::BasicVector<T> {
     this->SetAtIndex(K::kVelocity, velocity);
   }
   //@}
+
+  /// See SimpleCarStateIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return SimpleCarStateIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/examples/Acrobot/gen/acrobot_input_vector.cc
+++ b/drake/examples/Acrobot/gen/acrobot_input_vector.cc
@@ -10,6 +10,15 @@ namespace acrobot {
 const int AcrobotInputVectorIndices::kNumCoordinates;
 const int AcrobotInputVectorIndices::kTau;
 
+const std::vector<std::string>&
+AcrobotInputVectorIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "tau",
+      });
+  return coordinates.access();
+}
+
 }  // namespace acrobot
 }  // namespace examples
 }  // namespace drake

--- a/drake/examples/Acrobot/gen/acrobot_input_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_input_vector.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -22,6 +24,12 @@ struct AcrobotInputVectorIndices {
 
   // The index of each individual coordinate.
   static const int kTau = 0;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `AcrobotInputVectorIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -46,6 +54,11 @@ class AcrobotInputVector : public systems::BasicVector<T> {
   const T& tau() const { return this->GetAtIndex(K::kTau); }
   void set_tau(const T& tau) { this->SetAtIndex(K::kTau, tau); }
   //@}
+
+  /// See AcrobotInputVectorIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return AcrobotInputVectorIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/examples/Acrobot/gen/acrobot_output_vector.cc
+++ b/drake/examples/Acrobot/gen/acrobot_output_vector.cc
@@ -11,6 +11,15 @@ const int AcrobotOutputVectorIndices::kNumCoordinates;
 const int AcrobotOutputVectorIndices::kTheta1;
 const int AcrobotOutputVectorIndices::kTheta2;
 
+const std::vector<std::string>&
+AcrobotOutputVectorIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "theta1", "theta2",
+      });
+  return coordinates.access();
+}
+
 }  // namespace acrobot
 }  // namespace examples
 }  // namespace drake

--- a/drake/examples/Acrobot/gen/acrobot_output_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_output_vector.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -23,6 +25,12 @@ struct AcrobotOutputVectorIndices {
   // The index of each individual coordinate.
   static const int kTheta1 = 0;
   static const int kTheta2 = 1;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `AcrobotOutputVectorIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -50,6 +58,11 @@ class AcrobotOutputVector : public systems::BasicVector<T> {
   const T& theta2() const { return this->GetAtIndex(K::kTheta2); }
   void set_theta2(const T& theta2) { this->SetAtIndex(K::kTheta2, theta2); }
   //@}
+
+  /// See AcrobotOutputVectorIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return AcrobotOutputVectorIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/examples/Acrobot/gen/acrobot_state_vector.cc
+++ b/drake/examples/Acrobot/gen/acrobot_state_vector.cc
@@ -13,6 +13,15 @@ const int AcrobotStateVectorIndices::kTheta2;
 const int AcrobotStateVectorIndices::kTheta1dot;
 const int AcrobotStateVectorIndices::kTheta2dot;
 
+const std::vector<std::string>&
+AcrobotStateVectorIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "theta1", "theta2", "theta1dot", "theta2dot",
+      });
+  return coordinates.access();
+}
+
 }  // namespace acrobot
 }  // namespace examples
 }  // namespace drake

--- a/drake/examples/Acrobot/gen/acrobot_state_vector.h
+++ b/drake/examples/Acrobot/gen/acrobot_state_vector.h
@@ -6,9 +6,14 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
+// The following include was manually added. It was not added to the code
+// generator because the vast majority of the uses cases of the generated
+// classes do not require it. For more detail, see #5912 and #5737.
 #include "drake/common/symbolic_formula.h"
 #include "drake/systems/framework/basic_vector.h"
 
@@ -26,6 +31,12 @@ struct AcrobotStateVectorIndices {
   static const int kTheta2 = 1;
   static const int kTheta1dot = 2;
   static const int kTheta2dot = 3;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `AcrobotStateVectorIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -63,6 +74,11 @@ class AcrobotStateVector : public systems::BasicVector<T> {
     this->SetAtIndex(K::kTheta2dot, theta2dot);
   }
   //@}
+
+  /// See AcrobotStateVectorIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return AcrobotStateVectorIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/examples/Pendulum/gen/pendulum_state_vector.cc
+++ b/drake/examples/Pendulum/gen/pendulum_state_vector.cc
@@ -11,6 +11,15 @@ const int PendulumStateVectorIndices::kNumCoordinates;
 const int PendulumStateVectorIndices::kTheta;
 const int PendulumStateVectorIndices::kThetadot;
 
+const std::vector<std::string>&
+PendulumStateVectorIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "theta", "thetadot",
+      });
+  return coordinates.access();
+}
+
 }  // namespace pendulum
 }  // namespace examples
 }  // namespace drake

--- a/drake/examples/Pendulum/gen/pendulum_state_vector.h
+++ b/drake/examples/Pendulum/gen/pendulum_state_vector.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -23,6 +25,12 @@ struct PendulumStateVectorIndices {
   // The index of each individual coordinate.
   static const int kTheta = 0;
   static const int kThetadot = 1;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `PendulumStateVectorIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -52,6 +60,11 @@ class PendulumStateVector : public systems::BasicVector<T> {
     this->SetAtIndex(K::kThetadot, thetadot);
   }
   //@}
+
+  /// See PendulumStateVectorIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return PendulumStateVectorIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.cc
+++ b/drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.cc
@@ -11,6 +11,15 @@ const int SchunkWsgTrajectoryGeneratorStateVectorIndices::kNumCoordinates;
 const int SchunkWsgTrajectoryGeneratorStateVectorIndices::kLastTargetPosition;
 const int SchunkWsgTrajectoryGeneratorStateVectorIndices::kTrajectoryStartTime;
 
+const std::vector<std::string>&
+SchunkWsgTrajectoryGeneratorStateVectorIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "last_target_position", "trajectory_start_time",
+      });
+  return coordinates.access();
+}
+
 }  // namespace schunk_wsg
 }  // namespace examples
 }  // namespace drake

--- a/drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h
+++ b/drake/examples/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -23,6 +25,13 @@ struct SchunkWsgTrajectoryGeneratorStateVectorIndices {
   // The index of each individual coordinate.
   static const int kLastTargetPosition = 0;
   static const int kTrajectoryStartTime = 1;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words,
+  /// `SchunkWsgTrajectoryGeneratorStateVectorIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -59,6 +68,11 @@ class SchunkWsgTrajectoryGeneratorStateVector : public systems::BasicVector<T> {
     this->SetAtIndex(K::kTrajectoryStartTime, trajectory_start_time);
   }
   //@}
+
+  /// See SchunkWsgTrajectoryGeneratorStateVectorIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return SchunkWsgTrajectoryGeneratorStateVectorIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/tools/test/gen/sample.cc
+++ b/drake/tools/test/gen/sample.cc
@@ -12,6 +12,14 @@ const int SampleIndices::kX;
 const int SampleIndices::kTwoWord;
 const int SampleIndices::kAbsone;
 
+const std::vector<std::string>& SampleIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "x", "two_word", "absone",
+      });
+  return coordinates.access();
+}
+
 }  // namespace test
 }  // namespace tools
 }  // namespace drake

--- a/drake/tools/test/gen/sample.h
+++ b/drake/tools/test/gen/sample.h
@@ -6,9 +6,11 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -24,6 +26,12 @@ struct SampleIndices {
   static const int kX = 0;
   static const int kTwoWord = 1;
   static const int kAbsone = 2;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `SampleIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
 };
 
 /// Specializes BasicVector with specific getters and setters.
@@ -63,6 +71,11 @@ class Sample : public systems::BasicVector<T> {
   const T& absone() const { return this->GetAtIndex(K::kAbsone); }
   void set_absone(const T& absone) { this->SetAtIndex(K::kAbsone, absone); }
   //@}
+
+  /// See SampleIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return SampleIndices::GetCoordinateNames();
+  }
 
   /// Returns whether the current values of this vector are well-formed.
   decltype(T() < T()) IsValid() const {

--- a/drake/tools/test/sample_test.cc
+++ b/drake/tools/test/sample_test.cc
@@ -45,6 +45,14 @@ GTEST_TEST(SampleTest, SimpleCoverage) {
   EXPECT_NE(dynamic_cast<Sample<double>*>(cloned.get()), nullptr);
   EXPECT_EQ(cloned->GetAtIndex(0), 11.0);
   EXPECT_EQ(cloned->GetAtIndex(1), 22.0);
+
+  // Coordinate names.
+  const std::vector<std::string>& coordinate_names = dut.GetCoordinateNames();
+  const std::vector<std::string> expected_names = {"x", "two_word", "absone"};
+  ASSERT_EQ(coordinate_names.size(), expected_names.size());
+  for (int i = 0; i < dut.size(); ++i) {
+    EXPECT_EQ(coordinate_names.at(i), expected_names.at(i));
+  }
 }
 
 // Cover Simple<double>::IsValid.


### PR DESCRIPTION
It also adds a missing `#include "drake/common/symbolic_formula.h"`, which is needed by `drake/examples/Acrobot/gen/acrobot_state_vector.h`. This PR was extracted from #5910.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5912)
<!-- Reviewable:end -->