### PR TITLE
Global ik collision avoidance

### DIFF
--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -18,12 +18,12 @@ drake_cc_library(
         "test/global_inverse_kinematics_test_util.h",
     ],
     deps = [
+        "@gtest//:main",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody:global_inverse_kinematics",
         "//drake/multibody:inverse_kinematics",
         "//drake/multibody:rigid_body_tree_construction",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 
@@ -54,5 +54,18 @@ drake_cc_library(
 #        ":global_inverse_kinematics_test_util",
 #    ],
 #)
+
+drake_cc_googletest(
+    name = "global_inverse_kinematics_collision_avoidance_test",
+    size = "medium",
+    srcs = ["test/global_inverse_kinematics_collision_avoidance_test.cc"],
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = ["gurobi"],
+    deps = [
+        ":global_inverse_kinematics_test_util",
+    ],
+)
 
 cpplint()

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -18,12 +18,12 @@ drake_cc_library(
         "test/global_inverse_kinematics_test_util.h",
     ],
     deps = [
-        "@gtest//:main",
         "//drake/common:eigen_matrix_compare",
         "//drake/multibody:global_inverse_kinematics",
         "//drake/multibody:inverse_kinematics",
         "//drake/multibody:rigid_body_tree_construction",
         "//drake/multibody/parsers",
+        "@gtest//:main",
     ],
 )
 

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -55,17 +55,18 @@ drake_cc_library(
 #    ],
 #)
 
-drake_cc_googletest(
-    name = "global_inverse_kinematics_collision_avoidance_test",
-    size = "medium",
-    srcs = ["test/global_inverse_kinematics_collision_avoidance_test.cc"],
-    data = [
-        "//drake/manipulation/models/iiwa_description:models",
-    ],
-    tags = ["gurobi"],
-    deps = [
-        ":global_inverse_kinematics_test_util",
-    ],
-)
+# Temporarily disabled because we have no Gurobi license in CI. #5862
+#drake_cc_googletest(
+#    name = "global_inverse_kinematics_collision_avoidance_test",
+#    size = "medium",
+#    srcs = ["test/global_inverse_kinematics_collision_avoidance_test.cc"],
+#    data = [
+#        "//drake/manipulation/models/iiwa_description:models",
+#    ],
+#    tags = ["gurobi"],
+#    deps = [
+#        ":global_inverse_kinematics_test_util",
+#    ],
+#)
 
 cpplint()

--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -20,4 +20,9 @@ if (FALSE)
     set_tests_properties(global_inverse_kinematics_reachable_test PROPERTIES TIMEOUT 300)
     target_link_libraries(global_inverse_kinematics_reachable_test
             drakeGlobalInverseKinematicsTest)
+
+    drake_add_cc_test(global_inverse_kinematics_collision_avoidance_test)
+    set_tests_properties(global_inverse_kinematics_collision_avoidance_test PROPERTIES TIMEOUT 200)
+    target_link_libraries(global_inverse_kinematics_collision_avoidance_test
+            drakeGlobalInverseKinematicsTest)
 endif()

--- a/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
@@ -40,7 +40,7 @@ void CheckPtCollisionFreeBinary(
 }
 
 TEST_F(KukaTest, CollisionAvoidanceTest) {
-  // Suppose there is a box with length 0.1m, located at [0.5, 0, 0.4]
+  // Suppose there is a box with length 0.15m, located at [-0.5, 0, 0.4]
   // The goal is to reach the goal position, without colliding with the box
   Eigen::Vector3d box_size(0.15, 0.15, 0.15);
   Eigen::Vector3d box_pos(-0.5, 0, 0.4);
@@ -128,6 +128,9 @@ TEST_F(KukaTest, CollisionAvoidanceTest) {
   int link5_idx = rigid_body_tree_->FindBodyIndex("iiwa_link_5");
   std::vector<Eigen::Vector3d> link5_pts;
   std::vector<Eigen::Vector3d> link6_pts;
+  // Currently only make sure the origin of the body is collision free. We can
+  // add more points if it is not sufficient to guarantee the whole body is
+  // collision free.
   link5_pts.emplace_back(0, 0, 0);
   link6_pts.emplace_back(0, 0, 0);
   std::vector<solvers::VectorXDecisionVariable>

--- a/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
@@ -1,0 +1,40 @@
+#include "drake/multibody/dev/test/global_inverse_kinematics_test_util.h"
+
+#include "drake/solvers/mosek_solver.h"
+
+using Eigen::Vector3d;
+using Eigen::Isometry3d;
+
+using drake::solvers::SolutionResult;
+
+namespace drake {
+namespace multibody {
+namespace {
+TEST_F(KukaTest, CollisionAvoidanceTest) {
+  // Suppose there is a box with length 0.1m, located at [0.5, 0, 0.4]
+  // The goal is to reach the goal position, without colliding with the box
+  Eigen::Vector3d box_size(0.1, 0.1, 0.1);
+  Eigen::Vector3d box_pos(0.5, 0, 0.4);
+  double margin = 0.05;
+
+  // Now first partition the free space into 6 regions.
+  std::vector<Eigen::Matrix3Xd> region_vertices(6);
+
+  // region_vertices[0] are the vertices of the free space region in the +z
+  // direction above the box.
+  region_vertices[0].resize(3, 8);
+  region_vertices[0].row(0) << -0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, 0.5;
+  region_vertices[0].row(1) << -1, 1, -1, 1, -1, 1, -1, 1;
+  region_vertices[0].row(2) << Eigen::RowVector4d::Constant(box_pos(2) + box_size(2) / 3 + margin), Eigen::RowVector4d::Constant(box_pos(2) + box_size(2) / 3 + margin + 0.6);
+
+  // region_vertices[1] are the vertices of the free space region in the -z
+  // direction below the box
+  region_vertices[1].resize(3, 4);
+  region_vertices[1].row(0) = region_vertices[0].row(0);
+  region_vertices[1].row(1) = region_vertices[0].row(1);
+  region_vertices[1].row(2) << Eigen::RowVector
+
+}
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/dev/test/global_inverse_kinematics_test_util.h"
 
-#include "drake/solvers/mosek_solver.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/solvers/gurobi_solver.h"
 
 using Eigen::Vector3d;
 using Eigen::Isometry3d;
@@ -10,11 +11,39 @@ using drake::solvers::SolutionResult;
 namespace drake {
 namespace multibody {
 namespace {
+// Return true if the point with position `pt_pos` is not colliding with a box.
+// The center of the box is in `box_pos`, the size of the box is `box_size`. The
+// box is axis-aligned.
+bool CheckPtCollisionFree(const Eigen::Ref<const Eigen::Vector3d>& pt_pos,
+                          const Eigen::Ref<const Eigen::Vector3d>& box_pos,
+                          const Eigen::Ref<const Eigen::Vector3d>& box_size) {
+  if ((pt_pos.array() >= (box_pos - box_size / 2.0).array()).all() &&
+      (pt_pos.array() >= (box_pos + box_size / 2.0).array()).all()) {
+    return false;
+  }
+  return true;
+}
+
+// Check if the collision free binary variable is right. Namely one of the
+// binary variable equals to 1. This means that the point is in one of the free
+// space regions. (The point can be in the intersection of the free space
+// regions. In that case we just set one of the region binary variable to 1)
+void CheckPtCollisionFreeBinary(
+    const Eigen::Ref<const Eigen::VectorXd>& collision_avoidance_binary_val) {
+  int in_one_free_region = 0;
+  for (int i = 0; i < collision_avoidance_binary_val.rows(); ++i) {
+    if (std::abs(collision_avoidance_binary_val(i) - 1) < 1E-3) {
+      ++in_one_free_region;
+    }
+  }
+  EXPECT_EQ(in_one_free_region, 1);
+}
+
 TEST_F(KukaTest, CollisionAvoidanceTest) {
   // Suppose there is a box with length 0.1m, located at [0.5, 0, 0.4]
   // The goal is to reach the goal position, without colliding with the box
-  Eigen::Vector3d box_size(0.1, 0.1, 0.1);
-  Eigen::Vector3d box_pos(0.5, 0, 0.4);
+  Eigen::Vector3d box_size(0.15, 0.15, 0.15);
+  Eigen::Vector3d box_pos(-0.5, 0, 0.4);
   double margin = 0.05;
 
   // Now first partition the free space into 6 regions.
@@ -25,15 +54,132 @@ TEST_F(KukaTest, CollisionAvoidanceTest) {
   region_vertices[0].resize(3, 8);
   region_vertices[0].row(0) << -0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, 0.5;
   region_vertices[0].row(1) << -1, 1, -1, 1, -1, 1, -1, 1;
-  region_vertices[0].row(2) << Eigen::RowVector4d::Constant(box_pos(2) + box_size(2) / 3 + margin), Eigen::RowVector4d::Constant(box_pos(2) + box_size(2) / 3 + margin + 0.6);
+  region_vertices[0].row(2)
+      << Eigen::RowVector4d::Constant(box_pos(2) + box_size(2) / 2 + margin),
+      Eigen::RowVector4d::Constant(box_pos(2) + box_size(2) / 2 + margin + 0.6);
 
   // region_vertices[1] are the vertices of the free space region in the -z
   // direction below the box
-  region_vertices[1].resize(3, 4);
+  region_vertices[1].resize(3, 8);
   region_vertices[1].row(0) = region_vertices[0].row(0);
   region_vertices[1].row(1) = region_vertices[0].row(1);
-  region_vertices[1].row(2) << Eigen::RowVector
+  region_vertices[1].row(2)
+      << Eigen::RowVector4d::Constant(box_pos(2) - box_size(2) / 2 - margin),
+      Eigen::RowVector4d::Constant(box_pos(2) - box_size(2) / 2 - margin - 0.4);
 
+  // region_vertices[2] are the vertices of the free space region in the -x
+  // direction, before the box
+  region_vertices[2].resize(3, 8);
+  region_vertices[2].row(0) << Eigen::RowVector4d::Constant(
+      box_pos(0) - box_size(0) / 2 - margin - 0.4),
+      Eigen::RowVector4d::Constant(box_pos(0) - box_size(0) / 2 - margin);
+  region_vertices[2].row(1) << -1, 1, -1, 1, -1, 1, -1, 1;
+  region_vertices[2].row(2) << 0, 0, 1, 1, 0, 0, 1, 1;
+
+  // region_vertices[3] are the vertices of the free space region in the +x
+  // direction, behind the box
+  region_vertices[3].resize(3, 8);
+  region_vertices[3].row(0)
+      << Eigen::RowVector4d::Constant(box_pos(0) + box_size(0) / 2 + margin),
+      Eigen::RowVector4d::Constant(1.2);
+  region_vertices[3].row(1) = region_vertices[2].row(1);
+  region_vertices[3].row(2) = region_vertices[2].row(2);
+
+  // region_vertices[4] are the vertices of the free space region in the +y
+  // direction, to the right of the box.
+  region_vertices[4].resize(3, 8);
+  region_vertices[4].row(0) << 0, 1.2, 0, 1.2, 0, 1.2, 0, 1.2;
+  region_vertices[4].row(1)
+      << Eigen::RowVector4d::Constant(box_pos(1) + box_size(1) / 2 + margin),
+      Eigen::RowVector4d::Constant(1);
+  region_vertices[4].row(2) << 0, 0, 1, 1, 0, 0, 1, 1;
+
+  // region_vertices[5] are the vertices of the free space region in the -y
+  // direction, to the left of the box.
+  region_vertices[5].resize(3, 8);
+  region_vertices[5].row(0) = region_vertices[4].row(0);
+  region_vertices[5].row(1)
+      << Eigen::RowVector4d::Constant(box_pos(1) - box_size(1) / 2 - margin),
+      Eigen::RowVector4d::Constant(-1);
+  region_vertices[5].row(2) = region_vertices[4].row(2);
+
+  Eigen::Vector3d ee_pos(-0.7, 0, 0.45);
+  global_ik_.AddWorldPositionConstraint(ee_idx_, Vector3d::Zero(), ee_pos,
+                                        ee_pos);
+
+  // First run the global IK without collision avoidance.
+  solvers::GurobiSolver gurobi_solver;
+  global_ik_.SetSolverOption(solvers::SolverType::kGurobi, "OutputFlag", 1);
+  SolutionResult sol_result = gurobi_solver.Solve(global_ik_);
+  EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
+  const auto& q_without_collision_avoidance =
+      global_ik_.ReconstructGeneralizedPositionSolution();
+  auto cache = rigid_body_tree_->CreateKinematicsCache();
+  cache.initialize(q_without_collision_avoidance);
+  rigid_body_tree_->doKinematics(cache);
+  const auto ee_pose_ik_without_collision_avoidance =
+      rigid_body_tree_->CalcBodyPoseInWorldFrame(
+          cache, rigid_body_tree_->get_body(ee_idx_));
+  EXPECT_TRUE(
+      CompareMatrices(ee_pose_ik_without_collision_avoidance.translation(),
+                      ee_pos, 0.01, MatrixCompareType::absolute));
+
+  int link6_idx = rigid_body_tree_->FindBodyIndex("iiwa_link_6");
+  int link5_idx = rigid_body_tree_->FindBodyIndex("iiwa_link_5");
+  std::vector<Eigen::Vector3d> link5_pts;
+  std::vector<Eigen::Vector3d> link6_pts;
+  link5_pts.emplace_back(0, 0, 0);
+  link6_pts.emplace_back(0, 0, 0);
+  std::vector<solvers::VectorXDecisionVariable>
+      link5_collision_avoidance_binary(link5_pts.size());
+  std::vector<solvers::VectorXDecisionVariable>
+      link6_collision_avoidance_binary(link6_pts.size());
+  for (int i = 0; i < static_cast<int>(link5_pts.size()); ++i) {
+    link5_collision_avoidance_binary[i] = global_ik_.BodyPointInOneOfRegions(
+        link5_idx, link5_pts[i], region_vertices);
+  }
+  for (int i = 0; i < static_cast<int>(link6_pts.size()); ++i) {
+    link6_collision_avoidance_binary[i] = global_ik_.BodyPointInOneOfRegions(
+        link6_idx, link6_pts[i], region_vertices);
+  }
+
+  sol_result = gurobi_solver.Solve(global_ik_);
+  EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
+  const auto& q_with_collision_avoidance =
+      global_ik_.ReconstructGeneralizedPositionSolution();
+  cache.initialize(q_with_collision_avoidance);
+  rigid_body_tree_->doKinematics(cache);
+  const auto ee_pose_ik_with_collision_avoidance =
+      rigid_body_tree_->CalcBodyPoseInWorldFrame(
+          cache, rigid_body_tree_->get_body(ee_idx_));
+  EXPECT_TRUE(CompareMatrices(ee_pose_ik_with_collision_avoidance.translation(),
+                              ee_pos, 0.05, MatrixCompareType::absolute));
+
+  // Now check to make sure the points are collision free.
+  const auto& link5_pose_ik_with_collision_avoidance =
+      rigid_body_tree_->CalcBodyPoseInWorldFrame(
+          cache, rigid_body_tree_->get_body(link5_idx));
+  const auto& link6_pose_ik_with_collision_avoidance =
+      rigid_body_tree_->CalcBodyPoseInWorldFrame(
+          cache, rigid_body_tree_->get_body(link6_idx));
+  for (int i = 0; i < static_cast<int>(link5_pts.size()); ++i) {
+    CheckPtCollisionFree(
+        link5_pose_ik_with_collision_avoidance.linear() * link5_pts[i] +
+            link5_pose_ik_with_collision_avoidance.translation(),
+        box_pos, box_size);
+    const auto& link5_collision_avoidance_binary_val =
+        global_ik_.GetSolution(link5_collision_avoidance_binary[i]);
+    CheckPtCollisionFreeBinary(link5_collision_avoidance_binary_val);
+  }
+  for (int i = 0; i < static_cast<int>(link6_pts.size()); ++i) {
+    CheckPtCollisionFree(
+        link6_pose_ik_with_collision_avoidance.linear() * link6_pts[i] +
+            link6_pose_ik_with_collision_avoidance.translation(),
+        box_pos, box_size);
+    const auto& link6_collision_avoidance_binary_val =
+        global_ik_.GetSolution(link6_collision_avoidance_binary[i]);
+    CheckPtCollisionFreeBinary(link6_collision_avoidance_binary_val);
+  }
 }
 }  // namespace
 }  // namespace multibody

--- a/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
@@ -120,9 +120,9 @@ TEST_F(KukaTest, CollisionAvoidanceTest) {
   const auto ee_pose_ik_without_collision_avoidance =
       rigid_body_tree_->CalcBodyPoseInWorldFrame(
           cache, rigid_body_tree_->get_body(ee_idx_));
-  EXPECT_TRUE(
-      CompareMatrices(ee_pose_ik_without_collision_avoidance.translation(),
-                      ee_pos, 0.01, MatrixCompareType::absolute));
+  EXPECT_LE(
+      (ee_pose_ik_without_collision_avoidance.translation() - ee_pos).norm(),
+      0.05);
 
   int link6_idx = rigid_body_tree_->FindBodyIndex("iiwa_link_6");
   int link5_idx = rigid_body_tree_->FindBodyIndex("iiwa_link_5");
@@ -152,8 +152,8 @@ TEST_F(KukaTest, CollisionAvoidanceTest) {
   const auto ee_pose_ik_with_collision_avoidance =
       rigid_body_tree_->CalcBodyPoseInWorldFrame(
           cache, rigid_body_tree_->get_body(ee_idx_));
-  EXPECT_TRUE(CompareMatrices(ee_pose_ik_with_collision_avoidance.translation(),
-                              ee_pos, 0.05, MatrixCompareType::absolute));
+  EXPECT_LE((ee_pose_ik_with_collision_avoidance.translation() - ee_pos).norm(),
+            0.06);
 
   // Now check to make sure the points are collision free.
   const auto& link5_pose_ik_with_collision_avoidance =

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -412,7 +412,7 @@ GlobalInverseKinematics::BodyPointInOneOfRegions(
 
   AddLinearConstraint(z.cast<symbolic::Expression>().sum() == 1);
 
-  // p_WQ can also be computed from the body pose, as p_WQ = p_WBo + R_WB * p_BQ
+  // p_WQ must match the body pose, as p_WQ = p_WBo + R_WB * p_BQ
   AddLinearEqualityConstraint(p_WBo + R_WB * p_BQ - p_WQ,
                               Eigen::Vector3d::Zero());
 

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -388,7 +388,8 @@ GlobalInverseKinematics::BodyPointInOneOfRegions(
   const auto& p_WBo = body_position(body_index);
   const int num_regions = region_vertices.size();
   const string& body_name = robot_->get_body(body_index).get_name();
-  solvers::VectorXDecisionVariable z = NewBinaryVariables(num_regions, "z_" + body_name);
+  solvers::VectorXDecisionVariable z =
+      NewBinaryVariables(num_regions, "z_" + body_name);
   std::vector<solvers::VectorXDecisionVariable> w(num_regions);
 
   // We will write p_WQ in two ways, we first write p_WQ as
@@ -401,16 +402,19 @@ GlobalInverseKinematics::BodyPointInOneOfRegions(
     if (num_vertices_i < 3) {
       throw std::runtime_error("Each region should have at least 3 vertices.");
     }
-    w[i] = NewContinuousVariables(num_vertices_i, "w_" + body_name + "_region_" + std::to_string(i));
+    w[i] = NewContinuousVariables(
+        num_vertices_i, "w_" + body_name + "_region_" + std::to_string(i));
     AddLinearConstraint(w[i].cast<symbolic::Expression>().sum() - z(i) == 0);
-    AddBoundingBoxConstraint(Eigen::VectorXd::Zero(num_vertices_i), Eigen::VectorXd::Ones(num_vertices_i), w[i]);
+    AddBoundingBoxConstraint(Eigen::VectorXd::Zero(num_vertices_i),
+                             Eigen::VectorXd::Ones(num_vertices_i), w[i]);
     p_WQ += region_vertices[i] * w[i];
   }
 
   AddLinearConstraint(z.cast<symbolic::Expression>().sum() == 1);
 
   // p_WQ can also be computed from the body pose, as p_WQ = p_WBo + R_WB * p_BQ
-  AddLinearEqualityConstraint(p_WBo + R_WB * p_BQ - p_WQ, Eigen::Vector3d::Zero());
+  AddLinearEqualityConstraint(p_WBo + R_WB * p_BQ - p_WQ,
+                              Eigen::Vector3d::Zero());
 
   return z;
 }

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -214,6 +214,10 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    *   sum_i zᵢ = 1
    *   zᵢ ∈ {0, 1}
    * </pre>
+   * This function can be used for collision avoidance, if each region Pᵢ is a
+   * free space. It can also be used for grasping, each each region Pᵢ is a
+   * surface patch on the grasped object.
+   * Note this approach also works if the region Pᵢ overlaps with each other.
    * @param body_index The index of the body to on which point `Q` is attached.
    * @param p_BQThe position of point `Q` in the body frame `B`.
    * @param region_vertices region_vertices[i] is the vertices for the i'th

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -214,9 +214,11 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    *   sum_i zᵢ = 1
    *   zᵢ ∈ {0, 1}
    * </pre>
-   * This function can be used for collision avoidance, if each region Pᵢ is a
-   * free space. It can also be used for grasping, each each region Pᵢ is a
-   * surface patch on the grasped object.
+   * Notice that if zᵢ = 0, then w_i1 * v_i1 + w_i2 * v_i2 + ... + w_in * v_in
+   * is just 0.
+   * This function can be used for collision avoidance, where each region Pᵢ is
+   * a free space region. It can also be used for grasping, where each region Pᵢ
+   * is a surface patch on the grasped object.
    * Note this approach also works if the region Pᵢ overlaps with each other.
    * @param body_index The index of the body to on which point `Q` is attached.
    * @param p_BQThe position of point `Q` in the body frame `B`.

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -195,6 +195,38 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
       const Eigen::Ref<const Eigen::VectorXd>& body_position_cost,
       const Eigen::Ref<const Eigen::VectorXd>& body_orientation_cost);
 
+  /**
+   * Constrain the point `Q` lying within one of the convex polytopes.
+   * Each convex polytope Pᵢ is represented by its vertices as
+   * Pᵢ = ConvexHull(v_i1, v_i2, ... v_in). Mathematically we want to impose the
+   * constraint that the p_WQ, i.e., the position of point `Q` in world frame
+   * `W`, satisfies
+   * <pre>
+   *   p_WQ ∈ Pᵢ for one i.
+   * </pre>
+   * To impose this constraint, we consider to introduce binary variable zᵢ, and
+   * continuous variables w_i1, w_i2, ..., w_in for each vertex of Pᵢ, with the
+   * following constraints
+   * <pre>
+   *   p_WQ = sum_i (w_i1 * v_i1 + w_i2 * v_i2 + ... + w_in * v_in)
+   *   w_ij >= 0, ∀i,j
+   *   w_i1 + w_i2 + ... + w_in = zᵢ
+   *   sum_i zᵢ = 1
+   *   zᵢ ∈ {0, 1}
+   * </pre>
+   * @param body_index The index of the body to on which point `Q` is attached.
+   * @param p_BQThe position of point `Q` in the body frame `B`.
+   * @param region_vertices region_vertices[i] is the vertices for the i'th
+   * region.
+   * @retval z The newly added binary variables. If point `Q` is in the i'th
+   * region, z(i) = 1.
+   * @pre region_vertices[i] has at least 3 columns. Throw a std::runtime_error
+   * if the precondition is not satisfied.
+   */
+  solvers::VectorXDecisionVariable BodyPointInOneOfRegions(
+      int body_index, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+      const std::vector<Eigen::Matrix3Xd>& region_vertices);
+
  private:
   const RigidBodyTree<double> *robot_;
 

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -221,7 +221,7 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * is a surface patch on the grasped object.
    * Note this approach also works if the region Pᵢ overlaps with each other.
    * @param body_index The index of the body to on which point `Q` is attached.
-   * @param p_BQThe position of point `Q` in the body frame `B`.
+   * @param p_BQ The position of point `Q` in the body frame `B`.
    * @param region_vertices region_vertices[i] is the vertices for the i'th
    * region.
    * @retval z The newly added binary variables. If point `Q` is in the i'th


### PR DESCRIPTION
Without collision avoidance:
![without_collision_avoidance](https://cloud.githubusercontent.com/assets/6314000/25297109/ae6af78a-26a0-11e7-822b-996698a6fa6c.png)

With collision avoidance:
![with_collision_avoidance](https://cloud.githubusercontent.com/assets/6314000/25297107/ab69ba94-26a0-11e7-93c3-0735cb867332.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5919)
<!-- Reviewable:end -->
