### PR TITLE
Adds Context::num_abstract_parameters().

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -424,6 +424,7 @@ drake_cc_googletest(
         ":leaf_context",
         "//drake/common",
         "//drake/common:eigen_matrix_compare",
+        "//drake/common:is_dynamic_castable",
         "//drake/systems/framework/test_utilities",
     ],
 )

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -328,6 +328,11 @@ class Context {
     return get_mutable_parameters().get_mutable_numeric_parameter(index);
   }
 
+  /// Returns the number of abstract-valued parameters.
+  int num_abstract_parameters() const {
+    return get_parameters().num_abstract_parameters();
+  }
+
   /// Returns a const reference to the abstract-valued parameter at @p index.
   /// Asserts if @p index doesn't exist.
   const AbstractValue& get_abstract_parameter(int index) const {

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -3,6 +3,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -10,6 +11,7 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/test/is_dynamic_castable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_value.h"
 #include "drake/systems/framework/test_utilities/pack_value.h"
@@ -26,6 +28,13 @@ constexpr int kGeneralizedVelocitySize = 2;
 constexpr int kMiscContinuousStateSize = 1;
 
 constexpr double kTime = 12.0;
+
+// Defines a simple class for evaluating abstract types.
+class TestAbstractType {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TestAbstractType)
+  TestAbstractType() = default;
+};
 
 class LeafContextTest : public ::testing::Test {
  protected:
@@ -59,12 +68,16 @@ class LeafContextTest : public ::testing::Test {
     context_.set_abstract_state(
         std::make_unique<AbstractValues>(std::move(xa)));
 
-    // Reserve two numeric parameters, of size 3 and size 4.
-    std::vector<std::unique_ptr<BasicVector<double>>> params;
-    params.push_back(BasicVector<double>::Make({1.0, 2.0, 4.0}));
-    params.push_back(BasicVector<double>::Make({8.0, 16.0, 32.0, 64.0}));
-    context_.set_parameters(
-        std::make_unique<Parameters<double>>(std::move(params)));
+    // Reserve two numeric parameters of size 3 and size 4, and one abstract
+    // valued parameter of type TestAbstractType.
+    std::vector<std::unique_ptr<BasicVector<double>>> vector_params;
+    vector_params.push_back(BasicVector<double>::Make({1.0, 2.0, 4.0}));
+    vector_params.push_back(BasicVector<double>::Make({8.0, 16.0, 32.0, 64.0}));
+    std::vector<std::unique_ptr<AbstractValue>> abstract_params;
+    abstract_params.push_back(std::make_unique<Value<TestAbstractType>>());
+    context_.set_parameters(std::make_unique<Parameters<double>>(
+        std::move(vector_params),
+        std::move(abstract_params)));
   }
 
   // Mocks up a descriptor sufficient to read a FreestandingInputPortValue
@@ -279,6 +292,9 @@ TEST_F(LeafContextTest, Clone) {
   EXPECT_EQ(16.0, param1[1]);
   EXPECT_EQ(32.0, param1[2]);
   EXPECT_EQ(64.0, param1[3]);
+  ASSERT_EQ(1, leaf_clone->num_abstract_parameters());
+  EXPECT_TRUE(is_dynamic_castable<const TestAbstractType>(
+      &leaf_clone->get_abstract_parameter(0).GetValue<TestAbstractType>()));
 
   // Verify that changes to the cloned parameters do not affect the originals.
   (*leaf_clone->get_mutable_numeric_parameter(0))[0] = 76.0;
@@ -332,6 +348,11 @@ TEST_F(LeafContextTest, SetTimeStateAndParametersFrom) {
   params.push_back(std::make_unique<BasicVector<AutoDiffXd>>(4));
   target.get_mutable_parameters().set_numeric_parameters(
       std::make_unique<DiscreteValues<AutoDiffXd>>(std::move(params)));
+
+  std::vector<std::unique_ptr<AbstractValue>> abstract_params;
+  abstract_params.push_back(std::make_unique<Value<TestAbstractType>>());
+  target.get_mutable_parameters().set_abstract_parameters(
+      std::make_unique<AbstractValues>(std::move(abstract_params)));
 
   // Set the target from the source.
   target.SetTimeStateAndParametersFrom(context_);


### PR DESCRIPTION
This will make it easier to serialize and to-string abstract parameters within a `systems::Context`. It is the abstract value analog to the existing `Context::num_numeric_parameters()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5926)
<!-- Reviewable:end -->
