### PR TITLE
Fixes bug in URDF parser that results in weld_to_frame being ignored.

### DIFF
--- a/drake/multibody/parsers/urdf_parser.cc
+++ b/drake/multibody/parsers/urdf_parser.cc
@@ -1214,7 +1214,7 @@ ModelInstanceIdTable AddModelInstanceFromUrdfString(
   const PackageMap package_map;
   return AddModelInstanceFromUrdfStringSearchingInRosPackages(
       urdf_string, package_map, root_dir, floating_base_type,
-      nullptr /* weld_to_frame */, tree);
+      weld_to_frame, tree);
 }
 
 ModelInstanceIdTable AddModelInstanceFromUrdfStringSearchingInRosPackages(


### PR DESCRIPTION
Without the URDF parser fix, the included unit test would fail as follows:

```
[ RUN      ] URDFParserTest.TestAddModelInstanceFromUrdfStringWeldToFrame
Welding joint base
Welding joint base
Welding joint base
drake/multibody/parsers/test/urdf_parser_test/urdf_parser_test.cc:225: Failure
      Expected: tree->FindBaseBodies().size()
      Which is: 2
To be equal to: 1u
      Which is: 1
drake/multibody/parsers/test/urdf_parser_test/urdf_parser_test.cc:227: Failure
      Expected: tree->FindBaseBodies(model_instance_id_2).size()
      Which is: 1
To be equal to: 0u
      Which is: 0
[  FAILED  ] URDFParserTest.TestAddModelInstanceFromUrdfStringWeldToFrame (1 ms)
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5928)
<!-- Reviewable:end -->
