### PR TITLE
Mirror source for external dependencies to S3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -157,15 +157,12 @@ github_archive(
     sha256 = "e497c849f0787c8eb3a918d72cf4b4ae48117a183d2b3ae800049cc09e102c8d",
 )
 
-new_http_archive(
+github_archive(
     name = "nlopt",
-    urls = [
-        "https://d2tbce6hkathzp.cloudfront.net/github/stevengj/nlopt/516aca7e96405939726648e00faeb26bd2c9b29f.tar.gz",
-        "https://s3.amazonaws.com/drake-mirror/github/stevengj/nlopt/516aca7e96405939726648e00faeb26bd2c9b29f.tar.gz",
-    ],
-    strip_prefix="nlopt-516aca7e96405939726648e00faeb26bd2c9b29f",
-    sha256 = "6041ca30072b354ed3c235743779bf17dacf6199b2b30746c499f65082665d5f",
+    repository = "stevengj/nlopt",
+    commit = "516aca7e96405939726648e00faeb26bd2c9b29f",
     build_file = "tools/nlopt.BUILD",
+    sha256 = "6041ca30072b354ed3c235743779bf17dacf6199b2b30746c499f65082665d5f",
 )
 
 github_archive(

--- a/tools/bitbucket.bzl
+++ b/tools/bitbucket.bzl
@@ -39,8 +39,11 @@ def bitbucket_archive(
     if strip_prefix == None :
         fail("Missing strip_prefix=")
 
+    # Packages are mirrored from Bitbucket to CloudFront backed by an S3 bucket.
     urls = [
-        "https://bitbucket.org/%s/get/%s.tar.gz" % (repository, commit)
+        "https://bitbucket.org/%s/get/%s.tar.gz" % (repository, commit),
+        "https://d2tbce6hkathzp.cloudfront.net/bitbucket/%s/%s.tar.gz" % (repository, commit),
+        "https://s3.amazonaws.com/drake-mirror/bitbucket/%s/%s.tar.gz" % (repository, commit),
     ]
 
     repository_split = repository.split("/")

--- a/tools/github.bzl
+++ b/tools/github.bzl
@@ -38,8 +38,11 @@ def github_archive(
         # allow the first attempt to fail and print the correct sha256.
         sha256 = "0" * 64
 
+    # Packages are mirrored from GitHub to CloudFront backed by an S3 bucket.
     urls = [
-        "https://github.com/%s/archive/%s.tar.gz" % (repository, commit)
+        "https://github.com/%s/archive/%s.tar.gz" % (repository, commit),
+        "https://d2tbce6hkathzp.cloudfront.net/github/%s/%s.tar.gz" % (repository, commit),
+        "https://s3.amazonaws.com/drake-mirror/github/%s/%s.tar.gz" % (repository, commit),
     ]
 
     repository_split = repository.split("/")


### PR DESCRIPTION
I should be able to automate (using Jenkins) the uploading of a new tarball to S3 when a dependency changes, but for now they are manually uploaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5939)
<!-- Reviewable:end -->
