### PR TITLE
cost_test: Ensure that default constructor is explicitly called for a const-constructed object

### DIFF
--- a/drake/solvers/test/cost_test.cc
+++ b/drake/solvers/test/cost_test.cc
@@ -154,7 +154,9 @@ GTEST_TEST(testCost, testFunctionCost) {
   // Test that we can construct FunctionCosts with different signatures
   Eigen::Vector2d x(1, 2);
   VerifyFunctionCost<false>(GenericTrivialCost2(), x);
-  const GenericTrivialCost2 obj_const;
+  // Ensure that we explictly call the default constructor for a const class
+  // @ref http://stackoverflow.com/a/28338123/7829525
+  const GenericTrivialCost2 obj_const {};
   VerifyFunctionCost<false>(obj_const, x);
   VerifyFunctionCost<true>(make_shared<GenericTrivialCost2>(), x);
   VerifyFunctionCost<true>(make_unique<GenericTrivialCost2>(), x);


### PR DESCRIPTION
This a fix for PR #5931, calling the default constructor explicitly for a const-constructed object.

\cc @BetsyMcPhail @soonho-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5949)
<!-- Reviewable:end -->
