### PR TITLE
Assign default names when adding Systems to a Diagram

### DIFF
--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -48,11 +48,13 @@ void PidControlledSystem<T>::Initialize(
     std::unique_ptr<MatrixGain<T>> feedback_selector, const Eigen::VectorXd& Kp,
     const Eigen::VectorXd& Ki, const Eigen::VectorXd& Kd) {
   DRAKE_DEMAND(plant != nullptr);
+
+  if (plant->get_name().empty()) {
+    plant->set_name("plant");
+  }
+
   DiagramBuilder<T> builder;
   plant_ = builder.template AddSystem(std::move(plant));
-  if (plant_->get_name().empty()) {
-    plant_->set_name("plant");
-  }
   DRAKE_ASSERT(plant_->get_num_input_ports() >= 1);
   DRAKE_ASSERT(plant_->get_num_output_ports() >= 1);
 

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -1362,8 +1362,12 @@ class Diagram : public System<T>,
     for (const auto& system : sorted_systems_) {
       const std::string& name = system->get_name();
       if (name.empty()) {
+        // This can only happen if someone blanks out the name *after* adding
+        // it to DiagramBuilder; if an empty name is given to DiagramBuilder,
+        // a default non-empty name is automatically assigned.
         log()->error("Subsystem of type {} has no name",
                      NiceTypeName::Get(*system));
+        // We skip names.insert here, so that the return value will be false.
         continue;
       }
       if (names.find(name) != names.end()) {

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -37,6 +37,9 @@ class DiagramBuilder {
   /// pointer to the System, which will remain valid for the lifetime of the
   /// Diagram built by this builder.
   ///
+  /// If the system's name is unset, sets it to System::GetMemoryObjectName()
+  /// as a default in order to have unique names within the diagram.
+  ///
   /// @code
   ///   DiagramBuilder<T> builder;
   ///   auto foo = builder.AddSystem(std::make_unique<Foo<T>>());
@@ -45,6 +48,9 @@ class DiagramBuilder {
   /// @tparam S The type of system to add.
   template<class S>
   S* AddSystem(std::unique_ptr<S> system) {
+    if (system->get_name().empty()) {
+      system->set_name(system->GetMemoryObjectName());
+    }
     S* raw_sys_ptr = system.get();
     systems_.insert(raw_sys_ptr);
     registered_systems_.push_back(std::move(system));

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <limits>
 #include <memory>
-#include <regex>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -294,9 +293,7 @@ class LeafSystem : public System<T> {
     const int64_t id = this->GetGraphvizId();
     std::string name = this->get_name();
     if (name.empty()) {
-      const std::string type = NiceTypeName::Get(*this);
-      // Drop the template parameters.
-      name = std::regex_replace(type, std::regex("<.*>$"), std::string());
+      name = this->GetMemoryObjectName();
     }
 
     // Open the attributes and label.

--- a/drake/systems/framework/system.cc
+++ b/drake/systems/framework/system.cc
@@ -1,7 +1,31 @@
 #include "drake/systems/framework/system.h"
 
+#include <iomanip>
+#include <ios>
+#include <regex>
+
 namespace drake {
 namespace systems {
+
+std::string SystemImpl::GetMemoryObjectName(
+    const std::string& nice_type_name, int64_t address) {
+  using std::setfill;
+  using std::setw;
+  using std::hex;
+
+  // Remove the template parameter(s).
+  const std::string type_name_without_templates = std::regex_replace(
+      nice_type_name, std::regex("<.*>$"), std::string());
+
+  // Replace "::" with "/" because ":" is the System::GetPath separator.
+  const std::string default_name = std::regex_replace(
+      type_name_without_templates, std::regex(":+"), "/");
+
+  // Append the address spelled like "@0123456789abcdef".
+  std::ostringstream result;
+  result << default_name << '@' << setfill('0') << setw(16) << hex << address;
+  return result.str();
+}
 
 template struct DiscreteEvent<double>;
 

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -90,6 +90,18 @@ struct UpdateActions {
   std::vector<DiscreteEvent<T>> events;
 };
 
+/** @cond */
+// Private helper class for System.
+class SystemImpl {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemImpl)
+  SystemImpl() = delete;
+
+  // The implementation of System<T>::GetMemoryObjectName.
+  static std::string GetMemoryObjectName(const std::string&, int64_t);
+};
+/** @endcond */
+
 /// A superclass template for systems that receive input, maintain state, and
 /// produce output of a given mathematical type T.
 ///
@@ -713,8 +725,20 @@ class System {
   /// Diagram, names of sibling subsystems should be unique.
   void set_name(const std::string& name) { name_ = name; }
 
-  /// Retrieves the name last supplied to set_name().
+  /// Returns the name last supplied to set_name(), or empty if set_name() was
+  /// never called.  Systems created through transmogrification have by default
+  /// an identical name to the system they were created from.
   std::string get_name() const { return name_; }
+
+  /// Returns a name for this %System based on a stringification of its type
+  /// name and memory address.  This is intended for use in diagnostic output
+  /// and should not be used for behavioral logic, because the stringification
+  /// of the type name may produce differing results across platforms and
+  /// because the address can vary from run to run.
+  std::string GetMemoryObjectName() const {
+    return SystemImpl::GetMemoryObjectName(
+        NiceTypeName::Get(*this), GetGraphvizId());
+  }
 
   /// Writes the full path of this System in the tree of Systems to @p output.
   /// The path has the form (::ancestor_system_name)*::this_system_name.
@@ -724,8 +748,7 @@ class System {
     if (parent_ != nullptr) {
       parent_->GetPath(output);
     }
-    *output << "::";
-    *output << (get_name().empty() ? "<unnamed System>" : get_name());
+    *output << "::" << (get_name().empty() ? "_" : get_name());
   }
 
   // Returns the full path of the System in the tree of Systems.

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -1292,16 +1292,24 @@ GTEST_TEST(NonUniqueNamesTest, NonUniqueNames) {
   EXPECT_THROW(builder.Build(), std::runtime_error);
 }
 
-// Tests that an exception is thrown if any system in the Diagram has an empty
-// name.
-GTEST_TEST(NonUniqueNamesTest, EmptyName) {
+// Tests that systems with unset names can be added to a Diagram.
+GTEST_TEST(NonUniqueNamesTest, DefaultEmptyNames) {
   DiagramBuilder<double> builder;
   const int kInputs = 2;
   const int kSize = 1;
-  auto adder0 = builder.AddSystem<Adder<double>>(kInputs, kSize);
-  adder0->set_name("");
-  auto adder1 = builder.AddSystem<Adder<double>>(kInputs, kSize);
-  adder1->set_name("nonempty");
+  builder.AddSystem<Adder<double>>(kInputs, kSize);
+  builder.AddSystem<Adder<double>>(kInputs, kSize);
+  EXPECT_NO_THROW(builder.Build());
+}
+
+// Tests that an exception is thrown if a system is reset to an empty name
+// *after* being added to the diagram builder.
+GTEST_TEST(NonUniqueNamesTest, ForcedEmptyNames) {
+  DiagramBuilder<double> builder;
+  const int kInputs = 2;
+  const int kSize = 1;
+  builder.AddSystem<Adder<double>>(kInputs, kSize);
+  builder.AddSystem<Adder<double>>(kInputs, kSize)->set_name("");
   EXPECT_THROW(builder.Build(), std::runtime_error);
 }
 

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -4,6 +4,7 @@
 #include <stdexcept>
 
 #include <Eigen/Dense>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
@@ -717,10 +718,10 @@ GTEST_TEST(GraphvizTest, Attributes) {
   ASSERT_EQ(reinterpret_cast<int64_t>(&system), system.GetGraphvizId());
   const std::string dot = system.GetGraphvizString();
   // Check that left-to-right ranking is imposed.
-  EXPECT_NE(std::string::npos, dot.find("rankdir=LR")) << dot;
+  EXPECT_THAT(dot, ::testing::HasSubstr("rankdir=LR"));
   // Check that NiceTypeName is used to compute the label.
-  EXPECT_NE(std::string::npos, dot.find(
-      "label=\"drake::systems::(anonymous)::DefaultFeedthroughSystem|"));
+  EXPECT_THAT(dot, ::testing::HasSubstr(
+      "label=\"drake/systems/(anonymous)/DefaultFeedthroughSystem@"));
 }
 
 GTEST_TEST(GraphvizTest, Ports) {
@@ -729,7 +730,8 @@ GTEST_TEST(GraphvizTest, Ports) {
   system.AddAbstractInputPort();
   system.AddAbstractOutputPort();
   const std::string dot = system.GetGraphvizString();
-  EXPECT_NE(std::string::npos, dot.find("{{<u0>u0|<u1>u1} | {<y0>y0}}")) << dot;
+  EXPECT_THAT(dot, ::testing::HasSubstr(
+      "{{<u0>u0|<u1>u1} | {<y0>y0}}"));
 }
 
 }  // namespace

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -1,9 +1,11 @@
 #include "drake/systems/framework/system.h"
 
+#include <cctype>
 #include <memory>
 #include <stdexcept>
 
 #include <Eigen/Dense>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/basic_vector.h"
@@ -291,6 +293,17 @@ TEST_F(SystemTest, PortDescriptorsAreStable) {
   // Check for valid content.
   EXPECT_EQ(kAbstractValued, first_input.get_data_type());
   EXPECT_EQ(kAbstractValued, first_output.get_data_type());
+}
+
+// Tests GetMemoryObjectName.
+TEST_F(SystemTest, GetMemoryObjectName) {
+  const std::string name = system_.GetMemoryObjectName();
+
+  // The nominal value for 'name' is something like:
+  //   drake/systems/(anonymous namespace)/TestSystem@0123456789abcdef
+  // We check only some platform-agnostic portions of that.
+  EXPECT_THAT(name, ::testing::HasSubstr("drake/systems/"));
+  EXPECT_THAT(name, ::testing::ContainsRegex("/TestSystem@[0-9a-fA-F]{16}$"));
 }
 
 template <typename T>


### PR DESCRIPTION
Add `System::GetMemoryObjectName` to provide a diagnostic name, and use that within `DiagramBuilder` when a system is added without a name.

Closes #5934.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5953)
<!-- Reviewable:end -->
