### PR TITLE
Change references to "LANE-space" to "`Lane`-frame" instead.

### DIFF
--- a/drake/automotive/gen/maliput_railcar_state.h
+++ b/drake/automotive/gen/maliput_railcar_state.h
@@ -50,7 +50,7 @@ class MaliputRailcarState : public systems::BasicVector<T> {
 
   /// @name Getters and Setters
   //@{
-  /// The s-coordinate of the vehicle in lane-space.
+  /// The s-coordinate of the vehicle in a `Lane`-frame.
   const T& s() const { return this->GetAtIndex(K::kS); }
   void set_s(const T& s) { this->SetAtIndex(K::kS, s); }
   /// The speed of the vehicle in physical space.

--- a/drake/automotive/maliput/api/lane.h
+++ b/drake/automotive/maliput/api/lane.h
@@ -115,17 +115,17 @@ class Lane {
   //                                    const Lane* other_lane) const;
 
   /// Returns the rotation which expresses the orientation of the
-  /// LANE-space basis at @p lane_pos with regards to the (single, global)
-  /// GEO-space basis.
+  /// `Lane`-frame basis at @p lane_pos with respect to the
+  /// world frame basis.
   Rotation GetOrientation(const LanePosition& lane_pos) const {
     return DoGetOrientation(lane_pos);
   }
 
   /// Computes derivatives of LanePosition given a velocity vector @p velocity.
-  /// @p velocity is a isometric velocity vector oriented in the LANE-space
-  /// reference frame at @p position.
+  /// @p velocity is a isometric velocity vector oriented in the `Lane`-frame
+  /// at @p position.
   ///
-  /// @returns LANE-space derivatives packed into a LanePosition struct.
+  /// @returns `Lane`-frame derivatives packed into a LanePosition struct.
   LanePosition EvalMotionDerivatives(const LanePosition& position,
                                      const IsoLaneVelocity& velocity) const {
     return DoEvalMotionDerivatives(position, velocity);

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -70,7 +70,7 @@ struct GeoPosition {
 };
 
 
-/// A 3-dimensional position in LANE-space, consisting of three components:
+/// A 3-dimensional position in a `Lane`-frame, consisting of three components:
 ///  * s is longitudinal position, as arc-length along a Lane's reference line.
 ///  * r is lateral position, perpendicular to the reference line at s.
 ///  * h is height above the road surface.
@@ -87,7 +87,7 @@ struct LanePosition {
 };
 
 
-/// Isometric velocity vector in LANE-space.
+/// Isometric velocity vector in a `Lane`-frame.
 ///
 /// sigma_v, rho_v, and eta_v are the components of velocity in a
 /// (sigma, rho, eta) coordinate system.  (sigma, rho, eta) have the same
@@ -110,7 +110,7 @@ struct IsoLaneVelocity {
 
 
 /// A position in the road network, consisting of a pointer to a specific
-/// Lane and a LANE-space position on that Lane.
+/// Lane and a `Lane`-frame position in that Lane.
 struct RoadPosition {
   /// Default constructor.
   RoadPosition() = default;
@@ -124,7 +124,7 @@ struct RoadPosition {
 };
 
 
-/// Bounds in the lateral dimension (r component) of LANE-space, consisting
+/// Bounds in the lateral dimension (r component) of a `Lane`-frame, consisting
 /// of a pair of minimum and maximum r value.  The bounds must straddle r = 0,
 /// i.e., the minimum must be <= 0 and the maximum must be >= 0.
 struct RBounds {

--- a/drake/automotive/maliput/api/road_geometry.cc
+++ b/drake/automotive/maliput/api/road_geometry.cc
@@ -174,7 +174,7 @@ std::vector<std::string> RoadGeometry::CheckInvariants() const {
   for (int bpi = 0; bpi < num_branch_points(); ++bpi) {
     const BranchPoint* bp = branch_point(bpi);
     // For each BranchPoint:
-    //  - all branches should map to same GEO-space (x,y,z);
+    //  - all branches should map to same world frame (x,y,z);
     //  - orientation *into* BranchPoint should be the same for all A-side
     //     branches;
     //  - orientation *into* BranchPoint should be the same for all B-side
@@ -193,7 +193,7 @@ std::vector<std::string> RoadGeometry::CheckInvariants() const {
         (bp->GetASide()->size() > 0)
         ? bp->GetASide()->get(0)
         : bp->GetBSide()->get(0);
-    // ...test GEO-space position similarity.
+    // ...test world frame position similarity.
     const GeoPosition ref_geo = LaneEndGeoPosition(ref_end);
     const auto test_geo_position = [&](const LaneEndSet& ends) {
       for (int bi = 0; bi < ends.size(); ++bi) {

--- a/drake/automotive/maliput/monolane/lane.h
+++ b/drake/automotive/maliput/monolane/lane.h
@@ -271,7 +271,7 @@ class Lane : public api::Lane {
   //
   //    W: (p,r,h) --> (x,y,z)
   //
-  // which maps a LANE-space position to its corresponding representation in
+  // which maps a `Lane`-frame position to its corresponding representation in
   // world coordinates (with the caveat that instead of the lane's native
   // longitudinal coordinate 's', the reference curve parameter 'p' is used).
   //
@@ -291,7 +291,7 @@ class Lane : public api::Lane {
   //   β = -atan(dZ/dp) at p
   //   γ = atan2(dG_y/dp, dG_x/dp) at p
   //
-  // (R_αβγ is essentially the orientation of the (s,r,h) LANE-space frame
+  // (R_αβγ is essentially the orientation of the (s,r,h) `Lane`-frame
   // at a location (s,0,0) on the reference-line of the lane.  However, it
   // is *not* necessarily the correct orientation at r != 0 or h != 0.)
   //
@@ -314,7 +314,7 @@ class Lane : public api::Lane {
                     const Rot3& Rabg) const;
 
   // Returns the s-axis unit-vector, expressed in the world frame,
-  // of the (s,r,h) LANE-space frame (with respect to the world frame).
+  // of the (s,r,h) `Lane`-frame (with respect to the world frame).
   //
   // (@p Rabg must be the result of Rabg_of_p(p) --- passed in here to
   // avoid recomputing it.)
@@ -322,7 +322,7 @@ class Lane : public api::Lane {
                   const Rot3& Rabg) const;
 
   // Returns the r-axis unit-vector, expressed in the world frame,
-  // of the (s,r,h) LANE-space frame (with respect to the world frame).
+  // of the (s,r,h) `Lane`-frame (with respect to the world frame).
   //
   // (@p Rabg must be the result of Rabg_of_p(p) --- passed in here to
   // avoid recomputing it.)

--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -255,7 +255,7 @@ class GeoMesh {
 };
 
 
-// A LANE-space face: a sequence of vertices expressed in the (s,r,h)
+// A `Lane`-frame face: a sequence of vertices expressed in the (s,r,h)
 // coordinates of an api::Lane (which is not referenced here).  Each
 // vertex has an implicit unit-length normal vector in the +h
 // direction normal to the road surface.
@@ -412,7 +412,7 @@ void StripeLaneBounds(GeoMesh* mesh, const api::Lane* lane,
 
 
 // Adds faces to @p mesh which draw a simple triangular arrow in the
-// LANE-space of @p lane.  The width of the arrow is fixed at 80% of
+// `Lane`-frame of @p lane.  The width of the arrow is fixed at 80% of
 // the lane_bounds() of @p lane at the base of the arrow.
 //
 // @param mesh  the GeoMesh which will receive the faces

--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -63,7 +63,7 @@ class UniqueIndexer {
 };
 
 
-// A GEO-space (world-frame) vertex.
+// A world frame vertex.
 class GeoVertex {
  public:
   // A hasher operation suitable for std::unordered_map.
@@ -96,7 +96,7 @@ class GeoVertex {
 };
 
 
-// A GEO-space (world-frame) normal vector.
+// A world frame normal vector.
 class GeoNormal {
  public:
   // A hasher operation suitable for std::unordered_map.
@@ -131,8 +131,7 @@ class GeoNormal {
 };
 
 
-// A GEO-space (world-frame) face:  a sequence of vertices with corresponding
-// normals.
+// A world frame face:  a sequence of vertices with corresponding normals.
 class GeoFace {
  public:
   GeoFace() {}
@@ -182,7 +181,7 @@ class IndexFace {
 };
 
 
-// A GEO-space (world-frame) mesh:  a collection of GeoFaces.
+// A world frame mesh:  a collection of GeoFaces.
 class GeoMesh {
  public:
   GeoMesh() {}

--- a/drake/automotive/maliput_railcar_state.named_vector
+++ b/drake/automotive/maliput_railcar_state.named_vector
@@ -1,6 +1,6 @@
 element {
     name: "s"
-    doc: "The s-coordinate of the vehicle in lane-space."
+    doc: "The s-coordinate of the vehicle in a `Lane`-frame."
 }
 element {
     name: "speed"

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -402,8 +402,8 @@ TEST_F(MaliputRailcarTest, StateAppearsInOutputDragway) {
   auto pose = pose_output();
   Eigen::Isometry3d expected_pose = Eigen::Isometry3d::Identity();
   // For the dragway, the `(s, r, h)` axes in `Lane`-frame correspond to the
-  // `(x, y, z)` axes in geo-space. In this case, `s = kS` while `r` and `h` are
-  // by default zero.
+  // `(x, y, z)` axes in world frame. In this case, `s = kS` while `r` and
+  // `h` are by default zero.
   expected_pose.translation() = Eigen::Vector3d(kS, 0, 0);
   EXPECT_TRUE(CompareMatrices(pose->get_isometry().matrix(),
                               expected_pose.matrix()));

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -401,7 +401,7 @@ TEST_F(MaliputRailcarTest, StateAppearsInOutputDragway) {
 
   auto pose = pose_output();
   Eigen::Isometry3d expected_pose = Eigen::Isometry3d::Identity();
-  // For the dragway, the `(s, r, h)` axes in lane-space coorespond to the
+  // For the dragway, the `(s, r, h)` axes in `Lane`-frame correspond to the
   // `(x, y, z)` axes in geo-space. In this case, `s = kS` while `r` and `h` are
   // by default zero.
   expected_pose.translation() = Eigen::Vector3d(kS, 0, 0);

--- a/drake/lcmtypes/lcmt_maliput_railcar_state_t.lcm
+++ b/drake/lcmtypes/lcmt_maliput_railcar_state_t.lcm
@@ -7,6 +7,6 @@ struct lcmt_maliput_railcar_state_t {
   // The timestamp in milliseconds.
   int64_t timestamp;
 
-  double s;  // The s-coordinate of the vehicle in lane-space.
+  double s;  // The s-coordinate of the vehicle in a `Lane`-frame.
   double speed;  // The speed of the vehicle in physical space.
 }


### PR DESCRIPTION
Change references to "LANE-space" to "`Lane`-frame" instead, following the world-frame/lane-frame language used in the maliput design doc.  Fixes #5165.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5982)
<!-- Reviewable:end -->
