### PR TITLE
Fix Wunused-parameter in framework

### DIFF
--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -697,7 +697,8 @@ class LeafSystem : public System<T> {
   }
 
  private:
-  void DoGetPerStepEvents(const Context<T>& context,
+  void DoGetPerStepEvents(
+      const Context<T>&,
       std::vector<DiscreteEvent<T>>* events) const override {
     *events = per_step_events_;
   }

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -1250,9 +1250,10 @@ class System {
   /// not null, and it can be changed freely by the overriding implementation.
   ///
   /// The default implementation returns without changing @p events.
-  virtual void DoGetPerStepEvents(const Context<T>& context,
+  virtual void DoGetPerStepEvents(
+      const Context<T>& context,
       std::vector<DiscreteEvent<T>>* events) const {
-    unused(context);
+    unused(context, events);
   }
 
   /// Override this method for physical systems to calculate the potential


### PR DESCRIPTION
(Most it it was fixed previously, but had broken with some recent API changes.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5992)
<!-- Reviewable:end -->
