### PR TITLE
Change `maliput::api::LanePosition` into a class (from struct), backed by an Eigen 3-vector.

### DIFF
--- a/drake/automotive/create_trajectory_params.cc
+++ b/drake/automotive/create_trajectory_params.cc
@@ -82,10 +82,10 @@ std::tuple<Curve2<double>, double, double> CreateTrajectoryParamsForDragway(
   const maliput::api::Lane* lane = segment->lane(index);
   const maliput::api::GeoPosition start_geo_position =
       lane->ToGeoPosition(maliput::api::LanePosition(
-          {0 /* s */, 0 /* r */, 0 /* h */}));
+          0 /* s */, 0 /* r */, 0 /* h */));
   const maliput::api::GeoPosition end_geo_position =
       lane->ToGeoPosition(maliput::api::LanePosition(
-          {lane->length() /* s */, 0 /* r */, 0 /* h */}));
+          lane->length() /* s */, 0 /* r */, 0 /* h */));
   std::vector<Curve2<double>::Point2> waypoints;
   waypoints.push_back({start_geo_position.x, start_geo_position.y});
   waypoints.push_back({end_geo_position.x, end_geo_position.y});

--- a/drake/automotive/idm_controller.cc
+++ b/drake/automotive/idm_controller.cc
@@ -107,10 +107,10 @@ void IdmController<T>::ImplDoCalcOutput(
   const RoadPosition ego_position =
       pose_selector::CalcRoadPosition(road_, ego_pose.get_isometry());
 
-  const T& s_ego = ego_position.pos.s;
+  const T& s_ego = ego_position.pos.s();
   const T& s_dot_ego = pose_selector::GetSVelocity(
       RoadOdometry<double>(ego_position, ego_velocity));
-  const T& s_lead = lead_car_odom.pos.s;
+  const T& s_lead = lead_car_odom.pos.s();
   const T& s_dot_lead = pose_selector::GetSVelocity(lead_car_odom);
 
   // Saturate the net_distance at distance_lower_bound away from the ego car to

--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -32,6 +32,7 @@ drake_cc_googletest(
     srcs = ["test/api_lane_data_test.cc"],
     deps = [
         ":api",
+        "//drake/common:eigen_matrix_compare",
     ],
 )
 

--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -2,7 +2,7 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_library")
+load("//tools:drake.bzl", "drake_cc_library", "drake_cc_googletest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,6 +21,17 @@ drake_cc_library(
     ],
     deps = [
         "//drake/common",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "api_lane_data_test",
+    size = "small",
+    srcs = ["test/api_lane_data_test.cc"],
+    deps = [
+        ":api",
     ],
 )
 

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -92,7 +92,7 @@ class LanePosition {
   }
 
   /// Returns all components as 3-vector `[s, r, h]`.
-  Vector3<double> srh() const { return srh_; }
+  const Vector3<double>& srh() const { return srh_; }
   /// Sets all components from 3-vector `[s, r, h]`.
   void set_srh(const Vector3<double>& srh) { srh_ = srh; }
 
@@ -113,7 +113,7 @@ class LanePosition {
   //@}
 
  private:
-  Eigen::Matrix<double, 3, 1, Eigen::DontAlign> srh_;
+  Vector3<double> srh_;
 
   explicit LanePosition(const Vector3<double>& srh) : srh_(srh) {}
 };

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -4,6 +4,8 @@
 #include <string>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace maliput {
@@ -74,16 +76,46 @@ struct GeoPosition {
 ///  * s is longitudinal position, as arc-length along a Lane's reference line.
 ///  * r is lateral position, perpendicular to the reference line at s.
 ///  * h is height above the road surface.
-struct LanePosition {
-  /// Default constructor.
-  LanePosition() = default;
+class LanePosition {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LanePosition)
+
+  /// Default constructor, initializing all components to zero.
+  LanePosition() : srh_(0., 0., 0.) {}
 
   /// Fully parameterized constructor.
-  LanePosition(double _s, double _r, double _h) : s(_s), r(_r), h(_h) {}
+  LanePosition(double s, double r, double h) : srh_(s, r, h) {}
 
-  double s{};
-  double r{};
-  double h{};
+  /// Constructs a LanePosition from a 3-vector @p srh of the form `[s, r, h]`.
+  static LanePosition FromSrh(const Vector3<double>& srh) {
+    return LanePosition(srh);
+  }
+
+  /// Returns all components as 3-vector `[s, r, h]`.
+  Vector3<double> srh() const { return srh_; }
+  /// Sets all components from 3-vector `[s, r, h]`.
+  void set_srh(const Vector3<double>& srh) { srh_ = srh; }
+
+  /// @name Accessors
+  //@{
+  /// Gets `s` value.
+  double s() const { return srh_.x(); }
+  /// Sets `s` value.
+  void set_s(double s) { srh_.x() = s; }
+  /// Gets `r` value.
+  double r() const { return srh_.y(); }
+  /// Sets `r` value.
+  void set_r(double r) { srh_.y() = r; }
+  /// Gets `h` value.
+  double h() const { return srh_.z(); }
+  /// Sets `h` value.
+  void set_h(double h) { srh_.z() = h; }
+  //@}
+
+ private:
+  Eigen::Matrix<double, 3, 1, Eigen::DontAlign> srh_;
+
+  explicit LanePosition(const Vector3<double>& srh) : srh_(srh) {}
 };
 
 

--- a/drake/automotive/maliput/api/test/api_lane_data_test.cc
+++ b/drake/automotive/maliput/api/test/api_lane_data_test.cc
@@ -2,40 +2,39 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_matrix_compare.h"
+
 namespace drake {
 namespace maliput {
 namespace api {
 
+#define CHECK_ALL_LANE_ACCESSORS(dut, _s, _r, _h)                \
+  do {                                                           \
+    EXPECT_EQ(dut.s(), _s);                                      \
+    EXPECT_EQ(dut.r(), _r);                                      \
+    EXPECT_EQ(dut.h(), _h);                                      \
+    EXPECT_TRUE(CompareMatrices(dut.srh(), Vector3<double>(_s, _r, _h))); \
+  } while (0)
+
+
 GTEST_TEST(LanePositionTest, DefaultConstructor) {
   // Check that default constructor obeys its contract.
   LanePosition dut;
-
-  EXPECT_EQ(dut.s(), 0.);
-  EXPECT_EQ(dut.r(), 0.);
-  EXPECT_EQ(dut.h(), 0.);
-  EXPECT_EQ(dut.srh(), Vector3<double>::Zero());
+  CHECK_ALL_LANE_ACCESSORS(dut, 0., 0., 0.);
 }
 
 
 GTEST_TEST(LanePositionTest, ParameterizedConstructor) {
   // Check the fully-parameterized constructor.
   LanePosition dut(23., 75., 0.567);
-
-  EXPECT_EQ(dut.s(), 23.);
-  EXPECT_EQ(dut.r(), 75.);
-  EXPECT_EQ(dut.h(), 0.567);
-  EXPECT_EQ(dut.srh(), Vector3<double>(23., 75., 0.567));
+  CHECK_ALL_LANE_ACCESSORS(dut, 23., 75., 0.567);
 }
 
 
 GTEST_TEST(LanePositionTest, ConstructionFromVector) {
   // Check the conversion-construction from a 3-vector.
   LanePosition dut = LanePosition::FromSrh(Vector3<double>(23., 75., 0.567));
-
-  EXPECT_EQ(dut.s(), 23.);
-  EXPECT_EQ(dut.r(), 75.);
-  EXPECT_EQ(dut.h(), 0.567);
-  EXPECT_EQ(dut.srh(), Vector3<double>(23., 75., 0.567));
+  CHECK_ALL_LANE_ACCESSORS(dut, 23., 75., 0.567);
 }
 
 
@@ -43,11 +42,7 @@ GTEST_TEST(LanePositionTest, VectorSetter) {
   // Check the vector-based setter.
   LanePosition dut(23., 75., 0.567);
   dut.set_srh(Vector3<double>(9., 7., 8.));
-
-  EXPECT_EQ(dut.s(), 9.);
-  EXPECT_EQ(dut.r(), 7.);
-  EXPECT_EQ(dut.h(), 8.);
-  EXPECT_EQ(dut.srh(), Vector3<double>(9., 7., 8.));
+  CHECK_ALL_LANE_ACCESSORS(dut, 9., 7., 8.);
 }
 
 
@@ -56,16 +51,13 @@ GTEST_TEST(LanePositionTest, ComponentSetters) {
   LanePosition dut(0.1, 0.2, 0.3);
 
   dut.set_s(99.);
-  EXPECT_EQ(dut.s(), 99.);
-  EXPECT_EQ(dut.srh(), Vector3<double>(99., 0.2, 0.3));
+  CHECK_ALL_LANE_ACCESSORS(dut, 99., 0.2, 0.3);
 
   dut.set_r(2.3);
-  EXPECT_EQ(dut.r(), 2.3);
-  EXPECT_EQ(dut.srh(), Vector3<double>(99., 2.3, 0.3));
+  CHECK_ALL_LANE_ACCESSORS(dut, 99., 2.3, 0.3);
 
   dut.set_h(42.);
-  EXPECT_EQ(dut.h(), 42.);
-  EXPECT_EQ(dut.srh(), Vector3<double>(99., 2.3, 42.));
+  CHECK_ALL_LANE_ACCESSORS(dut, 99., 2.3, 42.);
 }
 
 

--- a/drake/automotive/maliput/api/test/api_lane_data_test.cc
+++ b/drake/automotive/maliput/api/test/api_lane_data_test.cc
@@ -1,0 +1,74 @@
+#include "drake/automotive/maliput/api/lane_data.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+GTEST_TEST(LanePositionTest, DefaultConstructor) {
+  // Check that default constructor obeys its contract.
+  LanePosition dut;
+
+  EXPECT_EQ(dut.s(), 0.);
+  EXPECT_EQ(dut.r(), 0.);
+  EXPECT_EQ(dut.h(), 0.);
+  EXPECT_EQ(dut.srh(), Vector3<double>::Zero());
+}
+
+
+GTEST_TEST(LanePositionTest, ParameterizedConstructor) {
+  // Check the fully-parameterized constructor.
+  LanePosition dut(23., 75., 0.567);
+
+  EXPECT_EQ(dut.s(), 23.);
+  EXPECT_EQ(dut.r(), 75.);
+  EXPECT_EQ(dut.h(), 0.567);
+  EXPECT_EQ(dut.srh(), Vector3<double>(23., 75., 0.567));
+}
+
+
+GTEST_TEST(LanePositionTest, ConstructionFromVector) {
+  // Check the conversion-construction from a 3-vector.
+  LanePosition dut = LanePosition::FromSrh(Vector3<double>(23., 75., 0.567));
+
+  EXPECT_EQ(dut.s(), 23.);
+  EXPECT_EQ(dut.r(), 75.);
+  EXPECT_EQ(dut.h(), 0.567);
+  EXPECT_EQ(dut.srh(), Vector3<double>(23., 75., 0.567));
+}
+
+
+GTEST_TEST(LanePositionTest, VectorSetter) {
+  // Check the vector-based setter.
+  LanePosition dut(23., 75., 0.567);
+  dut.set_srh(Vector3<double>(9., 7., 8.));
+
+  EXPECT_EQ(dut.s(), 9.);
+  EXPECT_EQ(dut.r(), 7.);
+  EXPECT_EQ(dut.h(), 8.);
+  EXPECT_EQ(dut.srh(), Vector3<double>(9., 7., 8.));
+}
+
+
+GTEST_TEST(LanePositionTest, ComponentSetters) {
+  // Check the individual component setters.
+  LanePosition dut(0.1, 0.2, 0.3);
+
+  dut.set_s(99.);
+  EXPECT_EQ(dut.s(), 99.);
+  EXPECT_EQ(dut.srh(), Vector3<double>(99., 0.2, 0.3));
+
+  dut.set_r(2.3);
+  EXPECT_EQ(dut.r(), 2.3);
+  EXPECT_EQ(dut.srh(), Vector3<double>(99., 2.3, 0.3));
+
+  dut.set_h(42.);
+  EXPECT_EQ(dut.h(), 42.);
+  EXPECT_EQ(dut.srh(), Vector3<double>(99., 2.3, 42.));
+}
+
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/dragway/lane.cc
+++ b/drake/automotive/maliput/dragway/lane.cc
@@ -83,7 +83,7 @@ api::LanePosition Lane::DoEvalMotionDerivatives(
 
 api::GeoPosition Lane::DoToGeoPosition(
     const api::LanePosition& lane_pos) const {
-  return {lane_pos.s, lane_pos.r + Lane::y_offset(), lane_pos.h};
+  return {lane_pos.s(), lane_pos.r() + Lane::y_offset(), lane_pos.h()};
 }
 
 api::Rotation Lane::DoGetOrientation(

--- a/drake/automotive/maliput/dragway/test/dragway_test.cc
+++ b/drake/automotive/maliput/dragway/test/dragway_test.cc
@@ -115,9 +115,9 @@ class MaliputDragwayLaneTest : public ::testing::Test {
           const api::LanePosition motion_derivatives =
               lane->EvalMotionDerivatives(lane_position,
                   api::IsoLaneVelocity(kSigma_v, kRho_v, kEta_v));
-          EXPECT_DOUBLE_EQ(motion_derivatives.s, kSigma_v);
-          EXPECT_DOUBLE_EQ(motion_derivatives.r, kRho_v);
-          EXPECT_DOUBLE_EQ(motion_derivatives.h, kEta_v);
+          EXPECT_DOUBLE_EQ(motion_derivatives.s(), kSigma_v);
+          EXPECT_DOUBLE_EQ(motion_derivatives.r(), kRho_v);
+          EXPECT_DOUBLE_EQ(motion_derivatives.h(), kEta_v);
         }
       }
     }
@@ -317,9 +317,9 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
         EXPECT_DOUBLE_EQ(nearest_position.z, z);
         EXPECT_DOUBLE_EQ(distance, 0);
         EXPECT_EQ(road_position.lane, expected_lane);
-        EXPECT_EQ(road_position.pos.s, x);
-        EXPECT_EQ(road_position.pos.r, y + lane_width_ / 2);
-        EXPECT_EQ(road_position.pos.h, z);
+        EXPECT_EQ(road_position.pos.s(), x);
+        EXPECT_EQ(road_position.pos.r(), y + lane_width_ / 2);
+        EXPECT_EQ(road_position.pos.h(), z);
       }
     }
   }
@@ -343,13 +343,13 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
         EXPECT_DOUBLE_EQ(nearest_position.z, z);
         EXPECT_DOUBLE_EQ(distance, 0);
         EXPECT_EQ(road_position.lane, expected_lane);
-        EXPECT_EQ(road_position.pos.s, x);
+        EXPECT_EQ(road_position.pos.s(), x);
         if (y == 0) {
-          EXPECT_EQ(road_position.pos.r, y + lane_width_ / 2);
+          EXPECT_EQ(road_position.pos.r(), y + lane_width_ / 2);
         } else {
-          EXPECT_EQ(road_position.pos.r, y - lane_width_ / 2);
+          EXPECT_EQ(road_position.pos.r(), y - lane_width_ / 2);
         }
-        EXPECT_EQ(road_position.pos.h, z);
+        EXPECT_EQ(road_position.pos.h(), z);
       }
     }
   }
@@ -428,10 +428,10 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOffRoad) {
       const Lane* expected_lane = dynamic_cast<const Lane*>(
           road_geometry.junction(0)->segment(0)->lane(expected_lane_index));
       EXPECT_EQ(road_position.lane, expected_lane);
-      EXPECT_EQ(road_position.pos.s, expected_nearest_position.x);
-      EXPECT_EQ(road_position.pos.r,
+      EXPECT_EQ(road_position.pos.s(), expected_nearest_position.x);
+      EXPECT_EQ(road_position.pos.r(),
           expected_nearest_position.y - expected_lane->y_offset());
-      EXPECT_EQ(road_position.pos.h, z);
+      EXPECT_EQ(road_position.pos.h(), z);
     }
   }
 }
@@ -542,10 +542,10 @@ TEST_F(MaliputDragwayLaneTest, TestToLanePosition) {
       EXPECT_DOUBLE_EQ(nearest_position.y, expected_nearest_position.y);
       EXPECT_DOUBLE_EQ(nearest_position.z, expected_nearest_position.z);
       EXPECT_GE(distance, 0);
-      EXPECT_EQ(lane_position.s, expected_nearest_position.x);
-      EXPECT_EQ(lane_position.r,
+      EXPECT_EQ(lane_position.s(), expected_nearest_position.x);
+      EXPECT_EQ(lane_position.r(),
           expected_nearest_position.y - lane->y_offset());
-      EXPECT_EQ(lane_position.h, expected_nearest_position.z);
+      EXPECT_EQ(lane_position.h(), expected_nearest_position.z);
     }
   }
 }

--- a/drake/automotive/maliput/monolane/lane.cc
+++ b/drake/automotive/maliput/monolane/lane.cc
@@ -123,7 +123,7 @@ V3 Lane::r_hat_of_Rabg(const Rot3& Rabg) const {
 api::GeoPosition Lane::DoToGeoPosition(
     const api::LanePosition& lane_pos) const {
   // Recover parameter p from arc-length position s.
-  const double p = p_from_s(lane_pos.s);
+  const double p = p_from_s(lane_pos.s());
   // Calculate z (elevation) of (s,0,0);
   const double z = elevation().f_p(p) * p_scale_;
   // Calculate x,y of (s,0,0).
@@ -133,16 +133,16 @@ api::GeoPosition Lane::DoToGeoPosition(
 
   // Rotate (0,r,h) and sum with mapped (s,0,0).
   const V3 xyz =
-      ypr.apply({0., lane_pos.r, lane_pos.h}) + V3(xy.x(), xy.y(), z);
+      ypr.apply({0., lane_pos.r(), lane_pos.h()}) + V3(xy.x(), xy.y(), z);
   return {xyz.x(), xyz.y(), xyz.z()};
 }
 
 
 api::Rotation Lane::DoGetOrientation(const api::LanePosition& lane_pos) const {
   // Recover linear parameter p from arc-length position s.
-  const double p = p_from_s(lane_pos.s);
-  const double r = lane_pos.r;
-  const double h = lane_pos.h;
+  const double p = p_from_s(lane_pos.s());
+  const double r = lane_pos.r();
+  const double h = lane_pos.h();
   // Calculate orientation of (s,r,h) basis at (s,0,0).
   const Rot3 Rabg = Rabg_of_p(p);
 
@@ -178,9 +178,9 @@ api::LanePosition Lane::DoEvalMotionDerivatives(
     const api::LanePosition& position,
     const api::IsoLaneVelocity& velocity) const {
 
-  const double p = p_from_s(position.s);
-  const double r = position.r;
-  const double h = position.h;
+  const double p = p_from_s(position.s());
+  const double r = position.r();
+  const double h = position.h();
 
   // TODO(maddog@tri.global)  When s(p) is integrated properly, do this:
   //                          const double g_prime = elevation().fdot_p(p);

--- a/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
@@ -47,9 +47,9 @@ GTEST_TEST(MonolaneLanesTest, Rot3) {
     const api::LanePosition _actual(actual);                  \
     const api::LanePosition _expected expected;               \
     const double _tolerance = (tolerance);                    \
-    EXPECT_NEAR(_actual.s, _expected.s, _tolerance);          \
-    EXPECT_NEAR(_actual.r, _expected.r, _tolerance);          \
-    EXPECT_NEAR(_actual.h, _expected.h, _tolerance);          \
+    EXPECT_NEAR(_actual.s(), _expected.s(), _tolerance);      \
+    EXPECT_NEAR(_actual.r(), _expected.r(), _tolerance);      \
+    EXPECT_NEAR(_actual.h(), _expected.h(), _tolerance);      \
   } while (0)
 
 #define EXPECT_ROT_NEAR(actual, expected, tolerance)                 \
@@ -506,9 +506,7 @@ api::LanePosition IntegrateTrivially(const api::Lane* lane,
   for (int i = 0; i < step_count; ++i) {
     const api::LanePosition lp_dot =
         lane->EvalMotionDerivatives(lp_current, velocity);
-    lp_current.s += lp_dot.s * time_step;
-    lp_current.r += lp_dot.r * time_step;
-    lp_current.h += lp_dot.h * time_step;
+    lp_current.set_srh(lp_current.srh() + (lp_dot.srh() * time_step));
   }
   return lp_current;
 }

--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -264,7 +264,7 @@ class SrhFace {
     // TODO(maddog@tri.global) Provide for explicit normals if we ever
     // consider faces which are not parallel to the road surface.
     for (const api::LanePosition& vertex : v_) {
-      DRAKE_DEMAND(vertex.h == v_[0].h);
+      DRAKE_DEMAND(vertex.h() == v_[0].h());
     }
   }
 
@@ -279,7 +279,8 @@ class SrhFace {
       //                          really use GetOrientation(), and the format
       //                          of the result should have a fixed-point
       //                          precision based on angular_tolerance().
-      api::GeoPosition v1(lane->ToGeoPosition({srh.s, srh.r, srh.h + 1.}));
+      api::GeoPosition v1(lane->ToGeoPosition({
+            srh.s(), srh.r(), srh.h() + 1.}));
       geo_face.push_vn(GeoVertex(v0), GeoNormal(v0, v1));
     }
     return geo_face;

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -284,9 +284,9 @@ void MaliputRailcar<T>::ImplCalcTimeDerivatives(
   // zero, we expect the resulting motion derivative's r and h values to
   // also be zero. The IsoLaneVelocity's sigma_v, which may be non-zero, maps
   // to the motion derivative's s value.
-  DRAKE_ASSERT(motion_derivatives.r == 0);
-  DRAKE_ASSERT(motion_derivatives.h == 0);
-  rates->set_s(motion_derivatives.s);
+  DRAKE_ASSERT(motion_derivatives.r() == 0);
+  DRAKE_ASSERT(motion_derivatives.h() == 0);
+  rates->set_s(motion_derivatives.s());
 
   const T desired_acceleration = input.GetAtIndex(0);
   const T smooth_acceleration = calc_smooth_acceleration(
@@ -369,7 +369,7 @@ void MaliputRailcar<T>::DoCalcNextUpdateTime(const systems::Context<T>& context,
         lane_direction.lane->EvalMotionDerivatives(
             LanePosition(s, CalcR(params, lane_direction), params.h()),
             IsoLaneVelocity(sigma_v, 0 /* rho_v */, 0 /* eta_v */));
-    const T s_dot = motion_derivatives.s;
+    const T s_dot = motion_derivatives.s();
 
     const T distance = cond(with_s, T(lane->length()) - s, -s);
 

--- a/drake/automotive/mobil_planner.cc
+++ b/drake/automotive/mobil_planner.cc
@@ -248,9 +248,9 @@ const T MobilPlanner<T>::EvaluateIdm(
     const IdmPlannerParameters<T>& idm_params,
     const RoadOdometry<T>& ego_odometry,
     const RoadOdometry<T>& lead_car_odometry) const {
-  const T& s_ego = ego_odometry.pos.s;
+  const T& s_ego = ego_odometry.pos.s();
   const T& s_dot_ego = pose_selector::GetSVelocity(ego_odometry);
-  const T& s_lead = lead_car_odometry.pos.s;
+  const T& s_lead = lead_car_odometry.pos.s();
   const T& s_dot_lead = pose_selector::GetSVelocity(lead_car_odometry);
 
   const T delta = s_lead - s_ego;

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -41,18 +41,18 @@ const std::pair<RoadOdometry<double>, RoadOdometry<double>> FindClosestPair(
   for (int i = 0; i < traffic_poses.get_num_poses(); ++i) {
     const RoadPosition traffic_position =
         CalcRoadPosition(road, traffic_poses.get_pose(i));
-    const double& s_traffic = traffic_position.pos.s;
+    const double& s_traffic = traffic_position.pos.s();
 
     if (traffic_position.lane->id().id != lane->id().id) continue;
 
     // If this pose is not the ego car and it is in the correct lane, then
     // insert it into the correct "leading" or "trailing" bin.
     if (ego_position.lane->id().id != lane->id().id ||
-        s_traffic != ego_position.pos.s) {
-      if (result_trailing.pos.s < s_traffic &&
-          s_traffic < result_leading.pos.s) {
+        s_traffic != ego_position.pos.s()) {
+      if (result_trailing.pos.s() < s_traffic &&
+          s_traffic < result_leading.pos.s()) {
         // N.B. The ego car and traffic may reside in different lanes.
-        if (s_traffic > ego_position.pos.s) {
+        if (s_traffic > ego_position.pos.s()) {
           result_leading = RoadOdometry<double>(traffic_position,
                                                 traffic_poses.get_velocity(i));
         } else {

--- a/drake/automotive/pure_pursuit.cc
+++ b/drake/automotive/pure_pursuit.cc
@@ -58,10 +58,10 @@ const GeoPosition PurePursuit<T>::ComputeGoalPoint(
                             pose.get_isometry().translation().z()},
                            nullptr, nullptr);
   const T s_new =
-      cond(with_s, position.s + s_lookahead, position.s - s_lookahead);
+      cond(with_s, position.s() + s_lookahead, position.s() - s_lookahead);
   const T s_goal = math::saturate(s_new, 0., lane->length());
   // TODO(jadecastro): Add support for locating goal points in ongoing lanes.
-  return lane->ToGeoPosition({s_goal, 0., position.h});
+  return lane->ToGeoPosition({s_goal, 0., position.h()});
 }
 
 // These instantiations must match the API documentation in pure_pursuit.h.

--- a/drake/automotive/test/pose_selector_test.cc
+++ b/drake/automotive/test/pose_selector_test.cc
@@ -119,21 +119,22 @@ GTEST_TEST(PoseSelectorTest, DragwayTest) {
       FindClosestPair(road, ego_pose, traffic_poses);
 
   // Verifies that we are on the road and that the correct car was identified.
-  EXPECT_EQ(kLeadingSPosition, leading_odometry.pos.s);
-  EXPECT_EQ(kTrailingSPosition, trailing_odometry.pos.s);
+  EXPECT_EQ(kLeadingSPosition, leading_odometry.pos.s());
+  EXPECT_EQ(kTrailingSPosition, trailing_odometry.pos.s());
 
   // Test that we get the same result when just the leading car is returned.
   const RoadOdometry<double>& traffic_odometry =
       FindClosestLeading(road, ego_pose, traffic_poses);
-  EXPECT_EQ(kLeadingSPosition, traffic_odometry.pos.s);
+  EXPECT_EQ(kLeadingSPosition, traffic_odometry.pos.s());
 
   // Peer into the adjacent lane to the left.
   std::tie(leading_odometry, trailing_odometry) = FindClosestPair(
       road, ego_pose, traffic_poses, ego_position.lane->to_left());
 
   // Expect to see no cars in the left lane.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s);
-  EXPECT_EQ(-std::numeric_limits<double>::infinity(), trailing_odometry.pos.s);
+  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s());
+  EXPECT_EQ(-std::numeric_limits<double>::infinity(),
+            trailing_odometry.pos.s());
 
   // Bump the "just ahead" car into the lane to the left.
   Isometry3<double> isometry_just_ahead =
@@ -144,7 +145,7 @@ GTEST_TEST(PoseSelectorTest, DragwayTest) {
       FindClosestPair(road, ego_pose, traffic_poses);
 
   // Expect the "far ahead" car to be identified and with the correct speed.
-  EXPECT_EQ(kLeadingSPosition + kSOffset, leading_odometry.pos.s);
+  EXPECT_EQ(kLeadingSPosition + kSOffset, leading_odometry.pos.s());
   EXPECT_EQ(kTrafficXVelocity, leading_odometry.vel[3]);
 
   // Bump the "far ahead" car into the lane to the left.
@@ -155,7 +156,7 @@ GTEST_TEST(PoseSelectorTest, DragwayTest) {
       FindClosestPair(road, ego_pose, traffic_poses);
 
   // Looking forward, we expect there to be no car in sight.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s);
+  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s());
   for (int i = 0; i < 6; ++i) {
     EXPECT_EQ(0., leading_odometry.vel[i]);  // Defaults to zero velocity.
   }
@@ -166,8 +167,9 @@ GTEST_TEST(PoseSelectorTest, DragwayTest) {
 
   // Expect there to be no car behind on the immediate left and the "just ahead"
   // car to be leading.
-  EXPECT_EQ(kLeadingSPosition, leading_odometry.pos.s);
-  EXPECT_EQ(-std::numeric_limits<double>::infinity(), trailing_odometry.pos.s);
+  EXPECT_EQ(kLeadingSPosition, leading_odometry.pos.s());
+  EXPECT_EQ(-std::numeric_limits<double>::infinity(),
+            trailing_odometry.pos.s());
 }
 
 // Verifies the result when the s-positions of the ego traffic vehicles have the

--- a/drake/automotive/test/pose_selector_test.cc
+++ b/drake/automotive/test/pose_selector_test.cc
@@ -195,8 +195,8 @@ GTEST_TEST(PoseSelectorTest, IdenticalSValues) {
 
   // Verifies that the if the cars are side-by-side, then the traffic car is
   // classified as a trailing car.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s);
-  EXPECT_EQ(kEgoSPosition, trailing_odometry.pos.s);
+  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s());
+  EXPECT_EQ(kEgoSPosition, trailing_odometry.pos.s());
 }
 
 GTEST_TEST(PoseSelectorTest, TestGetSVelocity) {


### PR DESCRIPTION
This is the first of several PR's which make the basic `maliput::api` data types interoperate more smoothly with Eigen.  Primarily, the revised interface provides conversions to/from Eigen types (in this case, a 3-vector).  Secondarily, the implementation uses the Eigen type for its internal storage.

This addresses part of #4542.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/5997)
<!-- Reviewable:end -->
