### PR TITLE
Fix packaging permissions

### DIFF
--- a/tools/bullet.BUILD
+++ b/tools/bullet.BUILD
@@ -25,6 +25,7 @@ cc_library(
 pkg_tar(
     name = "license",
     extension = "tar.gz",
+    mode = "0644",
     files = ["LICENSE.txt"],
     package_dir = "bullet",
 )

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -217,5 +217,6 @@ def drake_header_tar(name, deps=[], **kwargs):
   # relative and not absolute paths.
   pkg_tar(name=name,
           extension="tar.gz",
+          mode="0644",
           files=[":" + name + "_gather"],
           strip_prefix="/")

--- a/tools/eigen.BUILD
+++ b/tools/eigen.BUILD
@@ -21,6 +21,7 @@ cc_library(
 pkg_tar(
     name = "license",
     extension = "tar.gz",
+    mode = "0644",
     files = glob(["COPYING.*"]),
     package_dir = "eigen",
 )

--- a/tools/fmt.BUILD
+++ b/tools/fmt.BUILD
@@ -16,6 +16,7 @@ cc_library(
 pkg_tar(
     name = "license",
     extension = "tar.gz",
+    mode = "0644",
     files = ["LICENSE.rst"],
     package_dir = "fmt",
 )

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -24,6 +24,7 @@ cc_library(
 pkg_tar(
     name = "license",
     extension = "tar.gz",
+    mode = "0644",
     files = ["LICENSE"],
     package_dir = "spdlog",
 )

--- a/tools/tinyobjloader.BUILD
+++ b/tools/tinyobjloader.BUILD
@@ -18,6 +18,7 @@ cc_library(
 pkg_tar(
     name = "license",
     extension = "tar.gz",
+    mode = "0644",
     files = ["LICENSE"],
     package_dir = "tinyobjloader",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Override `pkg_tar`'s asinine default of making everything executable.

@jwnimmer-tri for feature review, @sammy-tri for platform review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6002)
<!-- Reviewable:end -->
