### PR TITLE
Change `maliput::api::GeoPosition` into a class (from struct), backed by an Eigen Vector3.

### DIFF
--- a/drake/automotive/automotive_demo.cc
+++ b/drake/automotive/automotive_demo.cc
@@ -234,7 +234,7 @@ void AddVehicles(RoadNetworkType road_network_type,
         throw std::runtime_error(
             "Ran out of lane length to add new MOBIL-controlled SimpleCars.");
       }
-      const double y_offset = lane->ToGeoPosition({0., 0., 0.}).y;
+      const double y_offset = lane->ToGeoPosition({0., 0., 0.}).y();
       state.set_x(x_offset);
       state.set_y(y_offset);
       simulator->AddMobilControlledSimpleCar(name, true /* with_s */, state);
@@ -258,8 +258,8 @@ void AddVehicles(RoadNetworkType road_network_type,
         const maliput::api::GeoPosition position = lane->ToGeoPosition(
             {lane->length() /* s */, 0 /* r */, 0 /* h */});
         SimpleCarState<double> state;
-        state.set_x(position.x);
-        state.set_y(position.y);
+        state.set_x(position.x());
+        state.set_y(position.y());
         simulator->AddPriusSimpleCar("StalledCar" + std::to_string(i),
             "StalledCarChannel" + std::to_string(i), state);
       }

--- a/drake/automotive/create_trajectory_params.cc
+++ b/drake/automotive/create_trajectory_params.cc
@@ -87,8 +87,8 @@ std::tuple<Curve2<double>, double, double> CreateTrajectoryParamsForDragway(
       lane->ToGeoPosition(maliput::api::LanePosition(
           lane->length() /* s */, 0 /* r */, 0 /* h */));
   std::vector<Curve2<double>::Point2> waypoints;
-  waypoints.push_back({start_geo_position.x, start_geo_position.y});
-  waypoints.push_back({end_geo_position.x, end_geo_position.y});
+  waypoints.push_back({start_geo_position.x(), start_geo_position.y()});
+  waypoints.push_back({end_geo_position.x(), end_geo_position.y()});
   Curve2<double> curve(waypoints);
   return std::make_tuple(curve, speed, start_time);
 }

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -58,17 +58,48 @@ struct Rotation {
 };
 
 
-/// A position in 3-dimensional geographical Cartesian space.
-struct GeoPosition {
-  /// Default constructor.
-  GeoPosition() = default;
+/// A position in 3-dimensional geographical Cartesian space, i.e.,
+/// in the world frame, consisting of three components x, y, and z.
+class GeoPosition {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeoPosition)
+
+  /// Default constructor, initializing all components to zero.
+  GeoPosition() : xyz_(0., 0., 0.) {}
 
   /// Fully parameterized constructor.
-  GeoPosition(double _x, double _y, double _z) : x(_x), y(_y), z(_z) {}
+  GeoPosition(double x, double y, double z) : xyz_(x, y, z) {}
 
-  double x{};
-  double y{};
-  double z{};
+  /// Constructs a GeoPosition from a 3-vector @p xyz of the form `[x, y, z]`.
+  static GeoPosition FromXyz(const Vector3<double>& xyz) {
+    return GeoPosition(xyz);
+  }
+
+  /// Returns all components as 3-vector `[x, y, z]`.
+  const Vector3<double>& xyz() const { return xyz_; }
+  /// Sets all components from 3-vector `[x, y, z]`.
+  void set_xyz(const Vector3<double>& xyz) { xyz_ = xyz; }
+
+  /// @name Getters and Setters
+  //@{
+  /// Gets `x` value.
+  double x() const { return xyz_.x(); }
+  /// Sets `x` value.
+  void set_x(double x) { xyz_.x() = x; }
+  /// Gets `y` value.
+  double y() const { return xyz_.y(); }
+  /// Sets `y` value.
+  void set_y(double y) { xyz_.y() = y; }
+  /// Gets `z` vaue.
+  double z() const { return xyz_.z(); }
+  /// Sets `z` value.
+  void set_z(double z) { xyz_.z() = z; }
+  //@}
+
+ private:
+  Vector3<double> xyz_;
+
+  explicit GeoPosition(const Vector3<double>& xyz) : xyz_(xyz) {}
 };
 
 
@@ -96,7 +127,7 @@ class LanePosition {
   /// Sets all components from 3-vector `[s, r, h]`.
   void set_srh(const Vector3<double>& srh) { srh_ = srh; }
 
-  /// @name Accessors
+  /// @name Getters and Setters
   //@{
   /// Gets `s` value.
   double s() const { return srh_.x(); }

--- a/drake/automotive/maliput/api/road_geometry.cc
+++ b/drake/automotive/maliput/api/road_geometry.cc
@@ -60,8 +60,7 @@ Rotation OrientationOutFromLane(const LaneEnd& lane_end) {
 
 // Return the Cartesian distance between two GeoPositions.
 double Distance(const GeoPosition& a, const GeoPosition& b) {
-  const GeoPosition d {a.x - b.x, a.y - b.y, a.z - b.z};
-  return std::sqrt((d.x * d.x) + (d.y * d.y) + (d.z * d.z));
+  return (a.xyz() - b.xyz()).norm();
 }
 
 
@@ -77,17 +76,17 @@ GeoPosition Rotate(const Rotation& rot, const GeoPosition& in) {
   const double cg = std::cos(rot.yaw);
 
   return GeoPosition(
-      ((cb * cg) * in.x) +
-      ((-ca*sg + sa*sb*cg) * in.y) +
-      ((sa*sg + ca*sb*cg) * in.z),
+      ((cb * cg) * in.x()) +
+      ((-ca*sg + sa*sb*cg) * in.y()) +
+      ((sa*sg + ca*sb*cg) * in.z()),
 
-      ((cb*sg) * in.x) +
-      ((ca*cg + sa*sb*sg) * in.y) +
-      ((-sa*cg + ca*sb*sg) * in.z),
+      ((cb*sg) * in.x()) +
+      ((ca*cg + sa*sb*sg) * in.y()) +
+      ((-sa*cg + ca*sb*sg) * in.z()),
 
-      ((-sb) * in.x) +
-      ((sa*cb) * in.y) +
-      ((ca*cb) * in.z));
+      ((-sb) * in.x()) +
+      ((sa*cb) * in.y()) +
+      ((ca*cb) * in.z()));
 }
 
 
@@ -103,9 +102,9 @@ double Distance(const Rotation& a, const Rotation& b) {
   GeoPosition br = Rotate(b, {0., 1., 0.});
   GeoPosition bh = Rotate(b, {0., 0., 1.});
   // Compute angles between pairs of unit vectors.
-  double ds = std::acos((as.x * bs.x) + (as.y * bs.y) + (as.z * bs.z));
-  double dr = std::acos((ar.x * br.x) + (ar.y * br.y) + (ar.z * br.z));
-  double dh = std::acos((ah.x * bh.x) + (ah.y * bh.y) + (ah.z * bh.z));
+  double ds = std::acos(as.xyz().dot(bs.xyz()));
+  double dr = std::acos(ar.xyz().dot(br.xyz()));
+  double dh = std::acos(ah.xyz().dot(bh.xyz()));
 
   return std::sqrt((ds * ds) + (dr * dr) + (dh * dh));
 }

--- a/drake/automotive/maliput/api/test/api_lane_data_test.cc
+++ b/drake/automotive/maliput/api/test/api_lane_data_test.cc
@@ -8,7 +8,7 @@ namespace drake {
 namespace maliput {
 namespace api {
 
-#define CHECK_ALL_LANE_ACCESSORS(dut, _s, _r, _h)                \
+#define CHECK_ALL_LANE_POSITION_ACCESSORS(dut, _s, _r, _h)       \
   do {                                                           \
     EXPECT_EQ(dut.s(), _s);                                      \
     EXPECT_EQ(dut.r(), _r);                                      \
@@ -20,21 +20,21 @@ namespace api {
 GTEST_TEST(LanePositionTest, DefaultConstructor) {
   // Check that default constructor obeys its contract.
   LanePosition dut;
-  CHECK_ALL_LANE_ACCESSORS(dut, 0., 0., 0.);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 0., 0., 0.);
 }
 
 
 GTEST_TEST(LanePositionTest, ParameterizedConstructor) {
   // Check the fully-parameterized constructor.
   LanePosition dut(23., 75., 0.567);
-  CHECK_ALL_LANE_ACCESSORS(dut, 23., 75., 0.567);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 23., 75., 0.567);
 }
 
 
 GTEST_TEST(LanePositionTest, ConstructionFromVector) {
   // Check the conversion-construction from a 3-vector.
   LanePosition dut = LanePosition::FromSrh(Vector3<double>(23., 75., 0.567));
-  CHECK_ALL_LANE_ACCESSORS(dut, 23., 75., 0.567);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 23., 75., 0.567);
 }
 
 
@@ -42,7 +42,7 @@ GTEST_TEST(LanePositionTest, VectorSetter) {
   // Check the vector-based setter.
   LanePosition dut(23., 75., 0.567);
   dut.set_srh(Vector3<double>(9., 7., 8.));
-  CHECK_ALL_LANE_ACCESSORS(dut, 9., 7., 8.);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 9., 7., 8.);
 }
 
 
@@ -51,15 +51,71 @@ GTEST_TEST(LanePositionTest, ComponentSetters) {
   LanePosition dut(0.1, 0.2, 0.3);
 
   dut.set_s(99.);
-  CHECK_ALL_LANE_ACCESSORS(dut, 99., 0.2, 0.3);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 99., 0.2, 0.3);
 
   dut.set_r(2.3);
-  CHECK_ALL_LANE_ACCESSORS(dut, 99., 2.3, 0.3);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 99., 2.3, 0.3);
 
   dut.set_h(42.);
-  CHECK_ALL_LANE_ACCESSORS(dut, 99., 2.3, 42.);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 99., 2.3, 42.);
 }
 
+#undef CHECK_ALL_LANE_POSITION_ACCESSORS
+
+
+#define CHECK_ALL_GEO_POSITION_ACCESSORS(dut, _x, _y, _z)               \
+  do {                                                                  \
+    EXPECT_EQ(dut.x(), _x);                                             \
+    EXPECT_EQ(dut.y(), _y);                                             \
+    EXPECT_EQ(dut.z(), _z);                                             \
+    EXPECT_TRUE(CompareMatrices(dut.xyz(), Vector3<double>(_x, _y, _z))); \
+  } while (0)
+
+
+GTEST_TEST(GeoPositionTest, DefaultConstructor) {
+  // Check that default constructor obeys its contract.
+  GeoPosition dut;
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 0., 0., 0.);
+}
+
+
+GTEST_TEST(GeoPositionTest, ParameterizedConstructor) {
+  // Check the fully-parameterized constructor.
+  GeoPosition dut(23., 75., 0.567);
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 23., 75., 0.567);
+}
+
+
+GTEST_TEST(GeoPositionTest, ConstructionFromVector) {
+  // Check the conversion-construction from a 3-vector.
+  GeoPosition dut = GeoPosition::FromXyz(Vector3<double>(23., 75., 0.567));
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 23., 75., 0.567);
+}
+
+
+GTEST_TEST(GeoPositionTest, VectorSetter) {
+  // Check the vector-based setter.
+  GeoPosition dut(23., 75., 0.567);
+  dut.set_xyz(Vector3<double>(9., 7., 8.));
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 9., 7., 8.);
+}
+
+
+GTEST_TEST(GeoPositionTest, ComponentSetters) {
+  // Check the individual component setters.
+  GeoPosition dut(0.1, 0.2, 0.3);
+
+  dut.set_x(99.);
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 99., 0.2, 0.3);
+
+  dut.set_y(2.3);
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 99., 2.3, 0.3);
+
+  dut.set_z(42.);
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 99., 2.3, 42.);
+}
+
+#undef CHECK_ALL_GEO_POSITION_ACCESSORS
 
 }  // namespace api
 }  // namespace maliput

--- a/drake/automotive/maliput/dragway/lane.cc
+++ b/drake/automotive/maliput/dragway/lane.cc
@@ -101,22 +101,21 @@ api::LanePosition Lane::DoToLanePosition(
   const double min_y = driveable_bounds_.r_min + y_offset_;
   const double max_y = driveable_bounds_.r_max + y_offset_;
 
-  const api::GeoPosition closest_point{math::saturate(geo_pos.x, min_x, max_x),
-                                       math::saturate(geo_pos.y, min_y, max_y),
-                                       geo_pos.z};
+  const api::GeoPosition closest_point{
+    math::saturate(geo_pos.x(), min_x, max_x),
+    math::saturate(geo_pos.y(), min_y, max_y),
+    geo_pos.z()};
   if (nearest_point != nullptr) {
     *nearest_point = closest_point;
   }
 
   if (distance != nullptr) {
-    *distance = std::sqrt(std::pow(geo_pos.x - closest_point.x, 2) +
-                          std::pow(geo_pos.y - closest_point.y, 2) +
-                          std::pow(geo_pos.z - closest_point.z, 2));
+    *distance = (geo_pos.xyz() - closest_point.xyz()).norm();
   }
 
-  return api::LanePosition(closest_point.x              /* s */,
-                           closest_point.y - y_offset_  /* r */,
-                           closest_point.z              /* h */);
+  return api::LanePosition(closest_point.x()              /* s */,
+                           closest_point.y() - y_offset_  /* r */,
+                           closest_point.z()              /* h */);
 }
 
 }  // namespace dragway

--- a/drake/automotive/maliput/dragway/test/dragway_test.cc
+++ b/drake/automotive/maliput/dragway/test/dragway_test.cc
@@ -92,9 +92,10 @@ class MaliputDragwayLaneTest : public ::testing::Test {
               lane->ToGeoPosition(lane_position);
           const double linear_tolerance =
               lane->segment()->junction()->road_geometry()->linear_tolerance();
-          EXPECT_DOUBLE_EQ(geo_position.x, s);
-          EXPECT_NEAR(geo_position.y, expected.y_offset + r, linear_tolerance);
-          EXPECT_DOUBLE_EQ(geo_position.z, h);
+          EXPECT_DOUBLE_EQ(geo_position.x(), s);
+          EXPECT_NEAR(geo_position.y(),
+                      expected.y_offset + r, linear_tolerance);
+          EXPECT_DOUBLE_EQ(geo_position.z(), h);
 
           // Tests Lane::GetOrientation().
           const api::Rotation rotation =
@@ -312,9 +313,9 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
             &distance);
         const api::Lane* expected_lane =
             road_geometry.junction(0)->segment(0)->lane(0);
-        EXPECT_DOUBLE_EQ(nearest_position.x, x);
-        EXPECT_DOUBLE_EQ(nearest_position.y, y);
-        EXPECT_DOUBLE_EQ(nearest_position.z, z);
+        EXPECT_DOUBLE_EQ(nearest_position.x(), x);
+        EXPECT_DOUBLE_EQ(nearest_position.y(), y);
+        EXPECT_DOUBLE_EQ(nearest_position.z(), z);
         EXPECT_DOUBLE_EQ(distance, 0);
         EXPECT_EQ(road_position.lane, expected_lane);
         EXPECT_EQ(road_position.pos.s(), x);
@@ -338,9 +339,9 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
         const int lane_index = (y == 0 ? 0 : 1);
         const api::Lane* expected_lane =
             road_geometry.junction(0)->segment(0)->lane(lane_index);
-        EXPECT_DOUBLE_EQ(nearest_position.x, x);
-        EXPECT_DOUBLE_EQ(nearest_position.y, y);
-        EXPECT_DOUBLE_EQ(nearest_position.z, z);
+        EXPECT_DOUBLE_EQ(nearest_position.x(), x);
+        EXPECT_DOUBLE_EQ(nearest_position.y(), y);
+        EXPECT_DOUBLE_EQ(nearest_position.z(), z);
         EXPECT_DOUBLE_EQ(distance, 0);
         EXPECT_EQ(road_position.lane, expected_lane);
         EXPECT_EQ(road_position.pos.s(), x);
@@ -398,39 +399,39 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOffRoad) {
       const api::RoadPosition road_position = road_geometry.ToRoadPosition(
           api::GeoPosition(x, y, z), nullptr /* hint */, &nearest_position,
           &distance);
-      EXPECT_LE(nearest_position.x, x_max);
-      EXPECT_GE(nearest_position.x, x_min);
-      EXPECT_LE(nearest_position.y, y_max);
-      EXPECT_GE(nearest_position.y, y_min);
+      EXPECT_LE(nearest_position.x(), x_max);
+      EXPECT_GE(nearest_position.x(), x_min);
+      EXPECT_LE(nearest_position.y(), y_max);
+      EXPECT_GE(nearest_position.y(), y_min);
 
       api::GeoPosition expected_nearest_position;
-      expected_nearest_position.x = x;
-      expected_nearest_position.y = y;
-      expected_nearest_position.z = z;
+      expected_nearest_position.set_x(x);
+      expected_nearest_position.set_y(y);
+      expected_nearest_position.set_z(z);
       if (x < x_min) {
-        expected_nearest_position.x = x_min;
+        expected_nearest_position.set_x(x_min);
       }
       if (x > x_max) {
-        expected_nearest_position.x = x_max;
+        expected_nearest_position.set_x(x_max);
       }
       if (y < y_min) {
-        expected_nearest_position.y = y_min;
+        expected_nearest_position.set_y(y_min);
       }
       if (y > y_max) {
-        expected_nearest_position.y = y_max;
+        expected_nearest_position.set_y(y_max);
       }
 
-      EXPECT_DOUBLE_EQ(nearest_position.x, expected_nearest_position.x);
-      EXPECT_DOUBLE_EQ(nearest_position.y, expected_nearest_position.y);
-      EXPECT_DOUBLE_EQ(nearest_position.z, expected_nearest_position.z);
+      EXPECT_DOUBLE_EQ(nearest_position.x(), expected_nearest_position.x());
+      EXPECT_DOUBLE_EQ(nearest_position.y(), expected_nearest_position.y());
+      EXPECT_DOUBLE_EQ(nearest_position.z(), expected_nearest_position.z());
       EXPECT_LT(0, distance);
       const int expected_lane_index = (y > 0 ? 1 : 0);
       const Lane* expected_lane = dynamic_cast<const Lane*>(
           road_geometry.junction(0)->segment(0)->lane(expected_lane_index));
       EXPECT_EQ(road_position.lane, expected_lane);
-      EXPECT_EQ(road_position.pos.s(), expected_nearest_position.x);
+      EXPECT_EQ(road_position.pos.s(), expected_nearest_position.x());
       EXPECT_EQ(road_position.pos.r(),
-          expected_nearest_position.y - expected_lane->y_offset());
+                expected_nearest_position.y() - expected_lane->y_offset());
       EXPECT_EQ(road_position.pos.h(), z);
     }
   }
@@ -527,25 +528,25 @@ TEST_F(MaliputDragwayLaneTest, TestToLanePosition) {
           api::GeoPosition(x, y, z), &nearest_position, &distance);
       api::GeoPosition expected_nearest_position(x, y, z);
       if (x < min_x) {
-        expected_nearest_position.x = min_x;
+        expected_nearest_position.set_x(min_x);
       }
       if (x > max_x) {
-        expected_nearest_position.x = max_x;
+        expected_nearest_position.set_x(max_x);
       }
       if (y < min_y) {
-        expected_nearest_position.y = min_y;
+        expected_nearest_position.set_y(min_y);
       }
       if (y > max_y) {
-        expected_nearest_position.y = max_y;
+        expected_nearest_position.set_y(max_y);
       }
-      EXPECT_DOUBLE_EQ(nearest_position.x, expected_nearest_position.x);
-      EXPECT_DOUBLE_EQ(nearest_position.y, expected_nearest_position.y);
-      EXPECT_DOUBLE_EQ(nearest_position.z, expected_nearest_position.z);
+      EXPECT_DOUBLE_EQ(nearest_position.x(), expected_nearest_position.x());
+      EXPECT_DOUBLE_EQ(nearest_position.y(), expected_nearest_position.y());
+      EXPECT_DOUBLE_EQ(nearest_position.z(), expected_nearest_position.z());
       EXPECT_GE(distance, 0);
-      EXPECT_EQ(lane_position.s(), expected_nearest_position.x);
+      EXPECT_EQ(lane_position.s(), expected_nearest_position.x());
       EXPECT_EQ(lane_position.r(),
-          expected_nearest_position.y - lane->y_offset());
-      EXPECT_EQ(lane_position.h(), expected_nearest_position.z);
+                expected_nearest_position.y() - lane->y_offset());
+      EXPECT_EQ(lane_position.h(), expected_nearest_position.z());
     }
   }
 }

--- a/drake/automotive/maliput/monolane/arc_lane.cc
+++ b/drake/automotive/maliput/monolane/arc_lane.cc
@@ -189,7 +189,7 @@ api::LanePosition ArcLane::DoToLanePosition(
   // TODO(jadecastro): Lift the zero superelevation and zero elevation gradient
   // restriction.
   const V2 center{cx_, cy_};
-  const V2 p{geo_position.x, geo_position.y};
+  const V2 p{geo_position.x(), geo_position.y()};
   DRAKE_DEMAND(p != center);
 
   // Define a vector from p to the center of the arc.
@@ -222,7 +222,7 @@ api::LanePosition ArcLane::DoToLanePosition(
   const double p_scale = r_ * d_theta_;
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
-  const double h = geo_position.z - elevation().a() * p_scale;
+  const double h = geo_position.z() - elevation().a() * p_scale;
 
   const api::LanePosition lane_position{s, r, h};
 
@@ -231,7 +231,7 @@ api::LanePosition ArcLane::DoToLanePosition(
     *nearest_position = nearest;
   }
   if (distance != nullptr) {
-    const V2 p_to_nearest{p(0) - nearest.x, p(1) - nearest.y};
+    const V2 p_to_nearest{p(0) - nearest.x(), p(1) - nearest.y()};
     *distance = p_to_nearest.norm();
   }
 

--- a/drake/automotive/maliput/monolane/line_lane.cc
+++ b/drake/automotive/maliput/monolane/line_lane.cc
@@ -30,7 +30,7 @@ api::LanePosition LineLane::DoToLanePosition(
   const V2 s_unit_vector = d_xy / d_xy.norm();
   const V2 r_unit_vector{-s_unit_vector(1), s_unit_vector(0)};
 
-  const V2 p{geo_position.x, geo_position.y};
+  const V2 p{geo_position.x(), geo_position.y()};
   const V2 lane_origin_to_p = p - xy0;
 
   // Compute the distance from `p` to the start of the lane.
@@ -41,7 +41,7 @@ api::LanePosition LineLane::DoToLanePosition(
                                   driveable_bounds(s).r_max);
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
-  const double h = geo_position.z - elevation().a() * length;
+  const double h = geo_position.z() - elevation().a() * length;
 
   const api::LanePosition lane_position{s, r, h};
 
@@ -50,7 +50,7 @@ api::LanePosition LineLane::DoToLanePosition(
     *nearest_position = nearest;
   }
   if (distance != nullptr) {
-    const V2 p_to_nearest{p(0) - nearest.x, p(1) - nearest.y};
+    const V2 p_to_nearest{p(0) - nearest.x(), p(1) - nearest.y()};
     *distance = p_to_nearest.norm();
   }
 

--- a/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
@@ -37,9 +37,9 @@ GTEST_TEST(MonolaneLanesTest, Rot3) {
     const api::GeoPosition _actual(actual);                  \
     const api::GeoPosition _expected expected;               \
     const double _tolerance = (tolerance);                   \
-    EXPECT_NEAR(_actual.x, _expected.x, _tolerance);         \
-    EXPECT_NEAR(_actual.y, _expected.y, _tolerance);         \
-    EXPECT_NEAR(_actual.z, _expected.z, _tolerance);         \
+    EXPECT_NEAR(_actual.x(), _expected.x(), _tolerance);     \
+    EXPECT_NEAR(_actual.y(), _expected.y(), _tolerance);     \
+    EXPECT_NEAR(_actual.z(), _expected.z(), _tolerance);     \
   } while (0)
 
 #define EXPECT_LANE_NEAR(actual, expected, tolerance)         \

--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -69,9 +69,9 @@ class GeoVertex {
   // A hasher operation suitable for std::unordered_map.
   struct Hash {
     size_t operator()(const GeoVertex& gv) const {
-      const size_t hx(std::hash<double>()(gv.v().x));
-      const size_t hy(std::hash<double>()(gv.v().y));
-      const size_t hz(std::hash<double>()(gv.v().z));
+      const size_t hx(std::hash<double>()(gv.v().x()));
+      const size_t hy(std::hash<double>()(gv.v().y()));
+      const size_t hz(std::hash<double>()(gv.v().z()));
       return hx ^ (hy << 1) ^ (hz << 2);
     }
   };
@@ -79,9 +79,7 @@ class GeoVertex {
   // An equivalence operation suitable for std::unordered_map.
   struct Equiv {
     bool operator()(const GeoVertex& lhs, const GeoVertex& rhs) const {
-      return ((lhs.v().x == rhs.v().x) &&
-              (lhs.v().y == rhs.v().y) &&
-              (lhs.v().z == rhs.v().z));
+      return (lhs.v().xyz() == rhs.v().xyz());
     }
   };
 
@@ -102,9 +100,9 @@ class GeoNormal {
   // A hasher operation suitable for std::unordered_map.
   struct Hash {
     size_t operator()(const GeoNormal& gn) const {
-      const size_t hx(std::hash<double>()(gn.n().x));
-      const size_t hy(std::hash<double>()(gn.n().y));
-      const size_t hz(std::hash<double>()(gn.n().z));
+      const size_t hx(std::hash<double>()(gn.n().x()));
+      const size_t hy(std::hash<double>()(gn.n().y()));
+      const size_t hz(std::hash<double>()(gn.n().z()));
       return hx ^ (hy << 1) ^ (hz << 2);
     }
   };
@@ -112,9 +110,7 @@ class GeoNormal {
   // An equivalence operation suitable for std::unordered_map.
   struct Equiv {
     bool operator()(const GeoNormal& lhs, const GeoNormal& rhs) const {
-      return ((lhs.n().x == rhs.n().x) &&
-              (lhs.n().y == rhs.n().y) &&
-              (lhs.n().z == rhs.n().z));
+      return (lhs.n().xyz() == rhs.n().xyz());
     }
   };
 
@@ -122,7 +118,7 @@ class GeoNormal {
 
   // Construct a GeoNormal as the vector from @p v0 to @p v1.
   GeoNormal(const api::GeoPosition& v0, const api::GeoPosition& v1)
-      : n_({v1.x - v0.x, v1.y - v0.y, v1.z - v0.z}) {}
+      : n_(api::GeoPosition::FromXyz(v1.xyz() - v0.xyz())) {}
 
   const api::GeoPosition& n() const { return n_; }
 
@@ -218,15 +214,15 @@ class GeoMesh {
     fmt::print(os, "# Vertices\n");
     for (const GeoVertex* gv : vertices_.vector()) {
       fmt::print(os, "v {x:.{p}f} {y:.{p}f} {z:.{p}f}\n",
-                 "x"_a = (gv->v().x - origin.x),
-                 "y"_a = (gv->v().y - origin.y),
-                 "z"_a = (gv->v().z - origin.z),
+                 "x"_a = (gv->v().x() - origin.x()),
+                 "y"_a = (gv->v().y() - origin.y()),
+                 "z"_a = (gv->v().z() - origin.z()),
                  "p"_a = precision);
     }
     fmt::print(os, "# Normals\n");
     for (const GeoNormal* gn : normals_.vector()) {
       fmt::print(os, "vn {x:.{p}f} {y:.{p}f} {z:.{p}f}\n",
-                 "x"_a = gn->n().x, "y"_a = gn->n().y, "z"_a = gn->n().z,
+                 "x"_a = gn->n().x(), "y"_a = gn->n().y(), "z"_a = gn->n().z(),
                  "p"_a = precision);
     }
     fmt::print(os, "\n");

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -191,8 +191,7 @@ void MaliputRailcar<T>::ImplCalcPose(const MaliputRailcarParams<T>& params,
           Rotation(-rotation.roll,
                    -rotation.pitch,
                    atan2(-sin(rotation.yaw), -cos(rotation.yaw))));
-  pose->set_translation(
-      Eigen::Translation<T, 3>(geo_position.x, geo_position.y, geo_position.z));
+  pose->set_translation(Eigen::Translation<T, 3>(geo_position.xyz()));
   pose->set_rotation(RollPitchYawToQuaternion(
       Vector3<T>(adjusted_rotation.roll, adjusted_rotation.pitch,
                  adjusted_rotation.yaw)));

--- a/drake/automotive/pure_pursuit.cc
+++ b/drake/automotive/pure_pursuit.cc
@@ -38,8 +38,8 @@ T PurePursuit<T>::Evaluate(const PurePursuitParams<T>& pp_params,
   const T y = pose.get_translation().translation().y();
   const T heading = pose.get_rotation().z();
 
-  const T delta_r = -(goal_position.x - x) * sin(heading) +
-                    (goal_position.y - y) * cos(heading);
+  const T delta_r = -(goal_position.x() - x) * sin(heading) +
+                    (goal_position.y() - y) * cos(heading);
   const T curvature = 2 * delta_r / pow(pp_params.s_lookahead(), 2.);
 
   // Return the steering angle.

--- a/drake/automotive/road_path.cc
+++ b/drake/automotive/road_path.cc
@@ -60,7 +60,7 @@ const PiecewisePolynomial<T> RoadPath<T>::MakePiecewisePolynomial(
 
     GeoPosition geo_pos =
         ld.lane->ToGeoPosition({s_lane /* s */, 0. /* r */, 0. /* h */});
-    geo_knots[i] << T(geo_pos.x), T(geo_pos.y), T(geo_pos.z);
+    geo_knots[i] << T(geo_pos.x()), T(geo_pos.y()), T(geo_pos.z());
 
     // Take a step.
     if (ld.with_s) {
@@ -83,7 +83,7 @@ const PiecewisePolynomial<T> RoadPath<T>::MakePiecewisePolynomial(
           s_lane = cond(ld.with_s, T(ld.lane->length()), T(0.));
           geo_pos =
               ld.lane->ToGeoPosition({s_lane /* s */, 0. /* r */, 0. /* h */});
-          geo_knots[i + 1] << T(geo_pos.x), T(geo_pos.y), T(geo_pos.z);
+          geo_knots[i + 1] << T(geo_pos.x()), T(geo_pos.y()), T(geo_pos.z());
         }
         break;
       }

--- a/drake/automotive/test/pure_pursuit_test.cc
+++ b/drake/automotive/test/pure_pursuit_test.cc
@@ -109,27 +109,27 @@ TEST_F(PurePursuitTest, ComputeGoalPoint) {
       10. /* s_lookahead */, {lane, true /* with_s */}, pose);
 
   // Expect the goal point to lie on the lane ordinate.
-  EXPECT_EQ(60., goal_position.x);
-  EXPECT_EQ(0., goal_position.y);
-  EXPECT_EQ(0., goal_position.z);
+  EXPECT_EQ(60., goal_position.x());
+  EXPECT_EQ(0., goal_position.y());
+  EXPECT_EQ(0., goal_position.z());
 
   // Flip the pose 180 degrees.
   goal_position = PurePursuit<double>::ComputeGoalPoint(
       10. /* s_lookahead */, {lane, false /* with_s */}, pose);
 
   // Expect the goal point to lie on the lane ordinate.
-  EXPECT_EQ(40., goal_position.x);
-  EXPECT_EQ(0., goal_position.y);
-  EXPECT_EQ(0., goal_position.z);
+  EXPECT_EQ(40., goal_position.x());
+  EXPECT_EQ(0., goal_position.y());
+  EXPECT_EQ(0., goal_position.z());
 
   // Take the lookahead distance to be beyond the end of the lane.
   goal_position = PurePursuit<double>::ComputeGoalPoint(
       60. /* s_lookahead */, {lane, true /* with_s */}, pose);
 
   // Expect the result to saturate.
-  EXPECT_EQ(100., goal_position.x);
-  EXPECT_EQ(0., goal_position.y);
-  EXPECT_EQ(0., goal_position.z);
+  EXPECT_EQ(100., goal_position.x());
+  EXPECT_EQ(0., goal_position.y());
+  EXPECT_EQ(0., goal_position.z());
 }
 // TODO(jadecastro): Test with curved lanes once
 // monolane::Lane::ToRoadPosition() is implemented.


### PR DESCRIPTION
This is the second of several PR's which make the basic maliput::api data types interoperate more smoothly with Eigen. Primarily, the revised interface provides conversions to/from Eigen types (in this case, a 3-vector). Secondarily, the implementation uses the Eigen type for its internal storage.

This addresses part of #4542.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6009)
<!-- Reviewable:end -->
