### PR TITLE
Making PoseVector copyable/moveable

### DIFF
--- a/drake/systems/rendering/pose_vector.cc
+++ b/drake/systems/rendering/pose_vector.cc
@@ -22,10 +22,14 @@ PoseVector<T>::PoseVector() : BasicVector<T>(kSize) {
   set_rotation(Eigen::Quaternion<T>::Identity());
 }
 
+// The copy and move semantics rely on the fact that BasicVector's *only* data
+// members are the values returned by get_value() and set by set_value(). If
+// BasicVector were to add data members that were *not* encapsulated in these
+// two methods, these operations would be rendered incomplete.
+
 template <typename T>
-PoseVector<T>::PoseVector(const PoseVector<T>& vec) : BasicVector<T>(kSize) {
-  this->set_value(vec.get_value());
-}
+PoseVector<T>::PoseVector(const PoseVector<T>& vec)
+    : BasicVector<T>(vec.get_value()) {}
 
 template <typename T>
 PoseVector<T>& PoseVector<T>::operator=(const PoseVector<T>& vec) {

--- a/drake/systems/rendering/pose_vector.cc
+++ b/drake/systems/rendering/pose_vector.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/rendering/pose_vector.h"
 
 #include <memory>
+#include <utility>
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_assert.h"

--- a/drake/systems/rendering/pose_vector.cc
+++ b/drake/systems/rendering/pose_vector.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/rendering/pose_vector.h"
 
+#include <memory>
+
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
@@ -17,6 +19,31 @@ template <typename T>
 PoseVector<T>::PoseVector() : BasicVector<T>(kSize) {
   set_translation(Eigen::Translation<T, 3>::Identity());
   set_rotation(Eigen::Quaternion<T>::Identity());
+}
+
+template <typename T>
+PoseVector<T>::PoseVector(const PoseVector<T>& vec) : BasicVector<T>(kSize) {
+  this->set_value(vec.get_value());
+}
+
+template <typename T>
+PoseVector<T>& PoseVector<T>::operator=(const PoseVector<T>& vec) {
+  this->set_value(vec.get_value());
+  return *this;
+}
+
+template <typename T>
+PoseVector<T>::PoseVector(PoseVector<T>&& vec) : BasicVector<T>(kSize) {
+  *this = std::move(vec);
+}
+
+template <typename T>
+PoseVector<T>& PoseVector<T>::operator=(PoseVector<T>&& vec) {
+  this->set_value(vec.get_value());
+  // Reset the input vector back to the default constructor state.
+  vec.set_translation(Eigen::Translation<T, 3>::Identity());
+  vec.set_rotation(Eigen::Quaternion<T>::Identity());
+  return *this;
 }
 
 template <typename T>

--- a/drake/systems/rendering/pose_vector.h
+++ b/drake/systems/rendering/pose_vector.h
@@ -16,9 +16,18 @@ namespace rendering {
 /// @tparam T The Eigen scalar type. Supported scalar types are double,
 ///         AutoDiffXd, and symbolic::Expression.
 template <typename T>
-class PoseVector : public BasicVector<T> {
+class PoseVector final : public BasicVector<T> {
  public:
   PoseVector();
+
+  // Parent class is *not* copyable/assignable; default operators are not
+  // possible. However, because PoseVector is fixed size and final, we don't
+  // have to worry about slicing or resizing.
+  PoseVector(const PoseVector& vec);
+  PoseVector& operator=(const PoseVector& vec);
+  PoseVector(PoseVector&& vec);
+  PoseVector& operator=(PoseVector&& vec);
+
   ~PoseVector() override;
 
   /// Returns the transform X_WA.


### PR DESCRIPTION
This changes the PoseVector to be a final class. This allows us to make
it copyable/movable. However, it can't use the default operations because
it inherits from a parent class that *isn't* default copyable/movable.

Extends test to cover this new functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6018)
<!-- Reviewable:end -->
