### PR TITLE
Integrate OSRF's sdformat library into drake

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -335,8 +335,8 @@ bitbucket_archive(
 bitbucket_archive(
     name = "sdformat",
     repository = "osrf/sdformat",
-    commit = "e52c48cc0820",
-    sha256 = "473320e1352e232f7bdd20b445c15604e242af010ed0c9c69ad518c0b363669b",
+    commit = "deca28cd6cd5",
+    sha256 = "d89a03178ef71d0a222247bf3fc4ccb8c490aebe83516f7290181d64e5da8dac",
     build_file = "tools/sdformat.BUILD",
-    strip_prefix = "osrf-sdformat-e52c48cc0820",
+    strip_prefix = "osrf-sdformat-deca28cd6cd5",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -331,3 +331,12 @@ bitbucket_archive(
     build_file = "tools/ignition_rndf.BUILD",
     strip_prefix = "ignitionrobotics-ign-rndf-b20a4f68333f",
 )
+
+bitbucket_archive(
+    name = "sdformat",
+    repository = "osrf/sdformat",
+    commit = "e52c48cc0820",
+    sha256 = "473320e1352e232f7bdd20b445c15604e242af010ed0c9c69ad518c0b363669b",
+    build_file = "tools/sdformat.BUILD",
+    strip_prefix = "osrf-sdformat-e52c48cc0820",
+)

--- a/drake/doc/mac.rst
+++ b/drake/doc/mac.rst
@@ -19,9 +19,9 @@ Install the prerequisites::
     brew tap-pin robotlocomotion/director
     brew update
     brew upgrade
-    brew install autoconf automake bazel clang-format cmake doxygen gcc glib \
-      graphviz gtk+ jpeg libpng libtool libyaml mpfr ninja numpy python \
-      qt@4 qwt-qt4 scipy vtk5 wget
+    brew install autoconf automake bazel boost clang-format cmake doxygen gcc \
+      glib graphviz gtk+ jpeg libpng libtool libyaml mpfr ninja numpy python \
+      qt@4 qwt-qt4 scipy tinyxml vtk5 wget
     pip install -U beautifulsoup4 html5lib lxml PyYAML Sphinx
 
 You may also want to install ``valgrind``, which can help debug memory issues in C++ code. Valgrind is available from homebrew with ``brew install valgrind``, but homebrew may encounter problems when installing ``valgrind`` on Mac OSX 10.12 (Sierra) or higher. See `this issue <https://github.com/Homebrew/homebrew-core/issues/4841#issuecomment-254217338>`_ for more details. If homebrew fails to install ``valgrind``, you can download it directly from `valgrind.org <http://valgrind.org/downloads/current.html>`_. 

--- a/drake/doc/mac.rst
+++ b/drake/doc/mac.rst
@@ -24,7 +24,7 @@ Install the prerequisites::
       qt@4 qwt-qt4 scipy tinyxml vtk5 wget
     pip install -U beautifulsoup4 html5lib lxml PyYAML Sphinx
 
-You may also want to install ``valgrind``, which can help debug memory issues in C++ code. Valgrind is available from homebrew with ``brew install valgrind``, but homebrew may encounter problems when installing ``valgrind`` on Mac OSX 10.12 (Sierra) or higher. See `this issue <https://github.com/Homebrew/homebrew-core/issues/4841#issuecomment-254217338>`_ for more details. If homebrew fails to install ``valgrind``, you can download it directly from `valgrind.org <http://valgrind.org/downloads/current.html>`_. 
+You may also want to install ``valgrind``, which can help debug memory issues in C++ code. Valgrind is available from homebrew with ``brew install valgrind``, but homebrew may encounter problems when installing ``valgrind`` on Mac OSX 10.12 (Sierra) or higher. See `this issue <https://github.com/Homebrew/homebrew-core/issues/4841#issuecomment-254217338>`_ for more details. If homebrew fails to install ``valgrind``, you can download it directly from `valgrind.org <http://valgrind.org/downloads/current.html>`_.
 
 Add the line::
 

--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -83,12 +83,11 @@ Other prerequisites may be installed as follows::
     sudo apt-get update
     sudo apt-get install --no-install-recommends \
       autoconf automake bison doxygen freeglut3-dev git graphviz \
-      libboost-dev libboost-filesystem-dev libboost-system-dev \
-      libgtk2.0-dev libhtml-form-perl libjpeg-dev libmpfr-dev libpng-dev \
-      libterm-readkey-perl libtinyxml-dev libtool libvtk5-dev libwww-perl make \
-      ninja-build perl pkg-config python-bs4 python-dev python-gtk2 \
-      python-html5lib python-numpy python-pip python-sphinx python-yaml \
-      unzip valgrind
+      libboost-dev libboost-system-dev libgtk2.0-dev libhtml-form-perl \
+      libjpeg-dev libmpfr-dev libpng-dev libterm-readkey-perl libtinyxml-dev \
+      libtool libvtk5-dev libwww-perl make ninja-build perl pkg-config \
+      python-bs4 python-dev python-gtk2 python-html5lib python-numpy \
+      python-pip python-sphinx python-yaml unzip valgrind
 
 If you will be building/using Director, some additional prerequisites may be
 installed as follows::

--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -83,6 +83,7 @@ Other prerequisites may be installed as follows::
     sudo apt-get update
     sudo apt-get install --no-install-recommends \
       autoconf automake bison doxygen freeglut3-dev git graphviz \
+      libboost-dev libboost-filesystem-dev libboost-system-dev \
       libgtk2.0-dev libhtml-form-perl libjpeg-dev libmpfr-dev libpng-dev \
       libterm-readkey-perl libtinyxml-dev libtool libvtk5-dev libwww-perl make \
       ninja-build perl pkg-config python-bs4 python-dev python-gtk2 \

--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -87,7 +87,7 @@ Other prerequisites may be installed as follows::
       libterm-readkey-perl libtinyxml-dev libtool libvtk5-dev libwww-perl make \
       ninja-build perl pkg-config python-bs4 python-dev python-gtk2 \
       python-html5lib python-numpy python-pip python-sphinx python-yaml \
-      ruby-1.9 unzip valgrind
+      unzip valgrind
 
 If you will be building/using Director, some additional prerequisites may be
 installed as follows::

--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -84,9 +84,10 @@ Other prerequisites may be installed as follows::
     sudo apt-get install --no-install-recommends \
       autoconf automake bison doxygen freeglut3-dev git graphviz \
       libgtk2.0-dev libhtml-form-perl libjpeg-dev libmpfr-dev libpng-dev \
-      libterm-readkey-perl libtool libvtk5-dev libwww-perl make ninja-build \
-      perl pkg-config python-bs4 python-dev python-gtk2 python-html5lib \
-      python-numpy python-pip python-sphinx python-yaml unzip valgrind
+      libterm-readkey-perl libtinyxml-dev libtool libvtk5-dev libwww-perl make \
+      ninja-build perl pkg-config python-bs4 python-dev python-gtk2 \
+      python-html5lib python-numpy python-pip python-sphinx python-yaml \
+      ruby-1.9 unzip valgrind
 
 If you will be building/using Director, some additional prerequisites may be
 installed as follows::

--- a/drake/multibody/parsers/BUILD
+++ b/drake/multibody/parsers/BUILD
@@ -121,6 +121,14 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "sdformat_test",
+    srcs = ["test/sdformat_test.cc"],
+    deps = [
+        "@sdformat//:lib",
+    ],
+)
+
 filegroup(
     name = "test_models",
     testonly = 1,

--- a/drake/multibody/parsers/BUILD
+++ b/drake/multibody/parsers/BUILD
@@ -125,7 +125,7 @@ drake_cc_googletest(
     name = "sdformat_test",
     srcs = ["test/sdformat_test.cc"],
     deps = [
-        "@sdformat//:lib",
+        "@sdformat",
     ],
 )
 

--- a/drake/multibody/parsers/test/sdformat_test.cc
+++ b/drake/multibody/parsers/test/sdformat_test.cc
@@ -5,29 +5,34 @@
 #include <sdf/sdf.hh>
 
 namespace drake {
-  namespace multibody {
-    namespace parsers {
-      namespace test {
-        namespace {
+namespace multibody {
+namespace parsers {
+namespace test {
+namespace {
 
-          GTEST_TEST(SDFormatTest, TestBasic) {
-            const std::string sdf_str("<?xml version='1.0'?><sdf version='1.6'><model name='my_model'><link name='link'/></model></sdf>"); // NOLINT
-            sdf::SDFPtr sdf_parsed(new sdf::SDF());
-            ASSERT_TRUE(sdf::init(sdf_parsed));
+  GTEST_TEST(SDFormatTest, TestBasic) {
+    const std::string sdf_str("<?xml version='1.0'?>"
+                              "<sdf version='1.6'>"
+                              "  <model name='my_model'>"
+                              "    <link name='link'/>"
+                              "  </model>"
+                              "</sdf>");
+    sdf::SDFPtr sdf_parsed(new sdf::SDF());
+    ASSERT_TRUE(sdf::init(sdf_parsed));
 
-            EXPECT_TRUE(sdf::readString(sdf_str, sdf_parsed));
+    EXPECT_TRUE(sdf::readString(sdf_str, sdf_parsed));
 
-            sdf::ElementPtr model = sdf_parsed->Root()->GetElement("model");
-            std::string model_name = model->Get<std::string>("name");
+    sdf::ElementPtr model = sdf_parsed->Root()->GetElement("model");
+    std::string model_name = model->Get<std::string>("name");
 
-            EXPECT_EQ(model_name, std::string("my_model"));
+    EXPECT_EQ(model_name, std::string("my_model"));
 
-            std::string link_name = model->GetElement("link")->Get<std::string>("name"); // NOLINT
-            EXPECT_EQ(link_name, std::string("link"));
-          }
+    std::string link_name = model->GetElement("link")->Get<std::string>("name");
+    EXPECT_EQ(link_name, std::string("link"));
+  }
 
-        }  // namespace
-      }  // namespace test
-    }  // namespace parsers
-  }  // namespace multibody
+}  // namespace
+}  // namespace test
+}  // namespace parsers
+}  // namespace multibody
 }  // namespace drake

--- a/drake/multibody/parsers/test/sdformat_test.cc
+++ b/drake/multibody/parsers/test/sdformat_test.cc
@@ -1,0 +1,33 @@
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <sdf/sdf.hh>
+
+namespace drake {
+  namespace multibody {
+    namespace parsers {
+      namespace test {
+	namespace {
+
+	  GTEST_TEST(SDFormatTest, TestBasic) {
+	    const std::string sdf_str("<?xml version='1.0'?><sdf version='1.6'><model name='my_model'><link name='link'/></model></sdf>"); // NOLINT
+	    sdf::SDFPtr sdf_parsed(new sdf::SDF());
+	    ASSERT_TRUE(sdf::init(sdf_parsed));
+
+	    EXPECT_TRUE(sdf::readString(sdf_str, sdf_parsed));
+
+	    sdf::ElementPtr model = sdf_parsed->Root()->GetElement("model");
+	    std::string model_name = model->Get<std::string>("name");
+
+	    EXPECT_EQ(model_name, std::string("my_model"));
+
+	    std::string link_name = model->GetElement("link")->Get<std::string>("name");
+	    EXPECT_EQ(link_name, std::string("link"));
+	  }
+
+	}  // namespace
+      }  // namespace test
+    }  // namespace parsers
+  }  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/parsers/test/sdformat_test.cc
+++ b/drake/multibody/parsers/test/sdformat_test.cc
@@ -22,7 +22,7 @@ namespace drake {
 
             EXPECT_EQ(model_name, std::string("my_model"));
 
-            std::string link_name = model->GetElement("link")->Get<std::string>("name");
+            std::string link_name = model->GetElement("link")->Get<std::string>("name"); // NOLINT
             EXPECT_EQ(link_name, std::string("link"));
           }
 

--- a/drake/multibody/parsers/test/sdformat_test.cc
+++ b/drake/multibody/parsers/test/sdformat_test.cc
@@ -8,7 +8,7 @@ namespace drake {
   namespace multibody {
     namespace parsers {
       namespace test {
-	namespace {
+        namespace {
 
 	  GTEST_TEST(SDFormatTest, TestBasic) {
 	    const std::string sdf_str("<?xml version='1.0'?><sdf version='1.6'><model name='my_model'><link name='link'/></model></sdf>"); // NOLINT
@@ -26,7 +26,7 @@ namespace drake {
 	    EXPECT_EQ(link_name, std::string("link"));
 	  }
 
-	}  // namespace
+        }  // namespace
       }  // namespace test
     }  // namespace parsers
   }  // namespace multibody

--- a/drake/multibody/parsers/test/sdformat_test.cc
+++ b/drake/multibody/parsers/test/sdformat_test.cc
@@ -10,26 +10,26 @@ namespace parsers {
 namespace test {
 namespace {
 
-  GTEST_TEST(SDFormatTest, TestBasic) {
-    const std::string sdf_str("<?xml version='1.0'?>"
-                              "<sdf version='1.6'>"
-                              "  <model name='my_model'>"
-                              "    <link name='link'/>"
-                              "  </model>"
-                              "</sdf>");
-    sdf::SDFPtr sdf_parsed(new sdf::SDF());
-    ASSERT_TRUE(sdf::init(sdf_parsed));
+GTEST_TEST(SDFormatTest, TestBasic) {
+  const std::string sdf_str("<?xml version='1.0'?>"
+                            "<sdf version='1.6'>"
+                            "  <model name='my_model'>"
+                            "    <link name='link'/>"
+                            "  </model>"
+                            "</sdf>");
+  sdf::SDFPtr sdf_parsed(new sdf::SDF());
+  ASSERT_TRUE(sdf::init(sdf_parsed));
 
-    EXPECT_TRUE(sdf::readString(sdf_str, sdf_parsed));
+  EXPECT_TRUE(sdf::readString(sdf_str, sdf_parsed));
 
-    sdf::ElementPtr model = sdf_parsed->Root()->GetElement("model");
-    std::string model_name = model->Get<std::string>("name");
+  sdf::ElementPtr model = sdf_parsed->Root()->GetElement("model");
+  std::string model_name = model->Get<std::string>("name");
 
-    EXPECT_EQ(model_name, std::string("my_model"));
+  EXPECT_EQ(model_name, std::string("my_model"));
 
-    std::string link_name = model->GetElement("link")->Get<std::string>("name");
-    EXPECT_EQ(link_name, std::string("link"));
-  }
+  std::string link_name = model->GetElement("link")->Get<std::string>("name");
+  EXPECT_EQ(link_name, std::string("link"));
+}
 
 }  // namespace
 }  // namespace test

--- a/drake/multibody/parsers/test/sdformat_test.cc
+++ b/drake/multibody/parsers/test/sdformat_test.cc
@@ -24,7 +24,7 @@ namespace drake {
 
             std::string link_name = model->GetElement("link")->Get<std::string>("name");
             EXPECT_EQ(link_name, std::string("link"));
-	  }
+          }
 
         }  // namespace
       }  // namespace test

--- a/drake/multibody/parsers/test/sdformat_test.cc
+++ b/drake/multibody/parsers/test/sdformat_test.cc
@@ -10,20 +10,20 @@ namespace drake {
       namespace test {
         namespace {
 
-	  GTEST_TEST(SDFormatTest, TestBasic) {
-	    const std::string sdf_str("<?xml version='1.0'?><sdf version='1.6'><model name='my_model'><link name='link'/></model></sdf>"); // NOLINT
-	    sdf::SDFPtr sdf_parsed(new sdf::SDF());
-	    ASSERT_TRUE(sdf::init(sdf_parsed));
+          GTEST_TEST(SDFormatTest, TestBasic) {
+            const std::string sdf_str("<?xml version='1.0'?><sdf version='1.6'><model name='my_model'><link name='link'/></model></sdf>"); // NOLINT
+            sdf::SDFPtr sdf_parsed(new sdf::SDF());
+            ASSERT_TRUE(sdf::init(sdf_parsed));
 
-	    EXPECT_TRUE(sdf::readString(sdf_str, sdf_parsed));
+            EXPECT_TRUE(sdf::readString(sdf_str, sdf_parsed));
 
-	    sdf::ElementPtr model = sdf_parsed->Root()->GetElement("model");
-	    std::string model_name = model->Get<std::string>("name");
+            sdf::ElementPtr model = sdf_parsed->Root()->GetElement("model");
+            std::string model_name = model->Get<std::string>("name");
 
-	    EXPECT_EQ(model_name, std::string("my_model"));
+            EXPECT_EQ(model_name, std::string("my_model"));
 
-	    std::string link_name = model->GetElement("link")->Get<std::string>("name");
-	    EXPECT_EQ(link_name, std::string("link"));
+            std::string link_name = model->GetElement("link")->Get<std::string>("name");
+            EXPECT_EQ(link_name, std::string("link"));
 	  }
 
         }  // namespace

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -79,6 +79,12 @@ gfortran-5
 gfortran-5-multilib
 git
 graphviz
+libboost-dev
+libboost-filesystem-dev
+libboost-iostreams-dev
+libboost-program-options-dev
+libboost-regex-dev
+libboost-system-dev
 libgtk2.0-dev
 libhtml-form-perl
 libmpfr-dev
@@ -86,6 +92,7 @@ libpng12-dev
 libqt4-dev
 libqt4-opengl-dev
 libqwt-dev
+libtinyxml-dev
 libtool
 libvtk-java
 libvtk5-dev
@@ -106,6 +113,7 @@ python-scipy
 python-sphinx
 python-vtk
 python-yaml
+ruby1.9
 unzip
 valgrind
 zip

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -81,9 +81,6 @@ git
 graphviz
 libboost-dev
 libboost-filesystem-dev
-libboost-iostreams-dev
-libboost-program-options-dev
-libboost-regex-dev
 libboost-system-dev
 libgtk2.0-dev
 libhtml-form-perl

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -113,7 +113,6 @@ python-scipy
 python-sphinx
 python-vtk
 python-yaml
-ruby1.9
 unzip
 valgrind
 zip

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -80,7 +80,6 @@ gfortran-5-multilib
 git
 graphviz
 libboost-dev
-libboost-filesystem-dev
 libboost-system-dev
 libgtk2.0-dev
 libhtml-form-perl

--- a/tools/cmake_configure_file.py
+++ b/tools/cmake_configure_file.py
@@ -17,7 +17,7 @@ import sys
 from collections import OrderedDict
 
 # Looks like "#cmakedefine VAR ..." or "#cmakedefine01 VAR".
-_cmakedefine = re.compile(r'^#cmakedefine(01)? ([^ \r\n]+)(.*?)([\r\n]*)')
+_cmakedefine = re.compile(r'^#cmakedefine(01)? ([^ \r\n]+)(.*?)([\r\n]+)')
 
 # Looks like "@VAR@" or "${VAR}".
 _varsubst = re.compile(r'^(.*?)(@.+?@|\$\{.+?\})(.*)([\r\n]*)')

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -1,14 +1,131 @@
 # -*- python -*-
 
+load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
+
+# Lets other packages inspect the CMake code, e.g., for the version number.
+filegroup(
+    name = "cmakelists_with_version",
+    srcs = ["CMakeLists.txt"],
+    visibility = ["//visibility:public"],
+)
+
+# Generates config.h based on the version numbers in CMake code.
+cmake_configure_file(
+    name = "config",
+    src = "cmake/config.hh.in",
+    out = "include/ignition/math/config.hh",
+    cmakelists = [
+        ":cmakelists_with_version",
+    ],
+    defines = [
+        # It would be nice to get this information directly from CMakeLists.txt,
+        # but it ends up being too hard.  ignition-math sets a project name
+        # as "ignition-math<version>", and then uses CMake substring to pick
+        # that version out.  We'd have to extend the cmake_configure_file
+        # functionality to do the same, and I'm not sure it is worth it.  We
+        # just hard code the major version here.
+        "PROJECT_NAME_NO_VERSION=ignition-math",
+        "PROJECT_MAJOR_VERSION=3",
+        "PROJECT_VERSION_FULL=3.0.0",
+    ],
+    visibility = [],
+)
+
+public_headers = [
+    "include/ignition/math/Angle.hh",
+    "include/ignition/math/Box.hh",
+    "include/ignition/math/Filter.hh",
+    "include/ignition/math/Frustum.hh",
+    "include/ignition/math/Helpers.hh",
+    "include/ignition/math/Inertial.hh",
+    "include/ignition/math/Kmeans.hh",
+    "include/ignition/math/Line2.hh",
+    "include/ignition/math/Line3.hh",
+    "include/ignition/math/MassMatrix3.hh",
+    "include/ignition/math/Matrix3.hh",
+    "include/ignition/math/Matrix4.hh",
+    "include/ignition/math/PID.hh",
+    "include/ignition/math/Plane.hh",
+    "include/ignition/math/Pose3.hh",
+    "include/ignition/math/Quaternion.hh",
+    "include/ignition/math/Rand.hh",
+    "include/ignition/math/RotationSpline.hh",
+    "include/ignition/math/SemanticVersion.hh",
+    "include/ignition/math/SignalStats.hh",
+    "include/ignition/math/SphericalCoordinates.hh",
+    "include/ignition/math/Spline.hh",
+    "include/ignition/math/System.hh",
+    "include/ignition/math/Temperature.hh",
+    "include/ignition/math/Triangle.hh",
+    "include/ignition/math/Triangle3.hh",
+    "include/ignition/math/Vector2.hh",
+    "include/ignition/math/Vector3.hh",
+    "include/ignition/math/Vector3Stats.hh",
+    "include/ignition/math/Vector4.hh",
+]
+
+# Generates the library exported to users.  The explicitly listed srcs= matches
+# upstream's explicitly listed sources.  The explicitly listed hdrs= matches
+# upstream's explicitly listed headers.
 cc_library(
-    name = "ignition_math",
-    srcs = glob(
-        ["src/*.cc"],
-        exclude = ["src/*_TEST.cc"],
-    ),
-    hdrs = glob([
-        "include/**/*.hh",
-    ]),
+    name = "lib_without_mathhh",
+    srcs = [
+       "src/Angle.cc",
+       "src/Box.cc",
+       "src/Frustum.cc",
+       "src/Helpers.cc",
+       "src/Kmeans.cc",
+       "src/PID.cc",
+       "src/Rand.cc",
+       "src/RotationSpline.cc",
+       "src/RotationSplinePrivate.cc",
+       "src/SemanticVersion.cc",
+       "src/SignalStats.cc",
+       "src/SphericalCoordinates.cc",
+       "src/Spline.cc",
+       "src/Temperature.cc",
+       "src/Vector3Stats.cc",
+    ],
+    # We need to list the private headers along with the public ones so
+    # that bazel copies them all into the right place during the build
+    # phase.
+    hdrs = public_headers + [
+        "include/ignition/math/BoxPrivate.hh",
+        "include/ignition/math/FrustumPrivate.hh",
+        "include/ignition/math/KmeansPrivate.hh",
+        "include/ignition/math/RotationSplinePrivate.hh",
+        "include/ignition/math/SignalStatsPrivate.hh",
+        "include/ignition/math/SplinePrivate.hh",
+        "include/ignition/math/Vector3StatsPrivate.hh",
+        "include/ignition/math/config.hh", # from cmake_configure_file above
+    ],
+    includes = ["include"],
+    visibility = [],
+)
+
+# Generates math.hh, which consists of #include statements for all of the
+# other headers in the library except the *Private.hh ones.  The first line is
+# '#include <ignition/math/config.hh>' followed by one line like
+# '#include <ignition/math/Angle.hh>' for each non-generated header.
+genrule(
+        name = "mathhh_genrule",
+        srcs = public_headers,
+        outs = ["include/ignition/math.hh"],
+        # TODO: centralize this logic, as it is used here, in sdformat.BUILD, and
+        # in fcl.BUILD
+        cmd = "(" + (
+            "echo '#include <ignition/math/config.hh>' && " +
+            "echo '$(SRCS)' | tr ' ' '\\n' | " +
+            "sed 's|.*include/\(.*\)|#include \\<\\1\\>|g'"
+        ) + ") > '$@'",
+        visibility = [],
+    )
+
+# Generates the library exported to users.
+cc_library(
+    name = "lib",
+    hdrs = ["include/ignition/math.hh"],  # From :mathhh_genrule above.
     includes = ["include"],
     visibility = ["//visibility:public"],
+    deps = [":lib_without_mathhh"],
 )

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -123,7 +123,7 @@ genrule(
 
 # Generates the library exported to users.
 cc_library(
-    name = "lib",
+    name = "ignition_math",
     hdrs = ["include/ignition/math.hh"],  # From :mathhh_genrule above.
     includes = ["include"],
     visibility = ["//visibility:public"],

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -77,6 +77,15 @@ genrule(
 cc_library(
     name = "ignition_math",
     srcs = [
+       "include/ignition/math.hh",
+       "include/ignition/math/BoxPrivate.hh",
+       "include/ignition/math/FrustumPrivate.hh",
+       "include/ignition/math/KmeansPrivate.hh",
+       "include/ignition/math/RotationSplinePrivate.hh",
+       "include/ignition/math/SignalStatsPrivate.hh",
+       "include/ignition/math/SplinePrivate.hh",
+       "include/ignition/math/Vector3StatsPrivate.hh",
+       "include/ignition/math/config.hh", # from cmake_configure_file above
        "src/Angle.cc",
        "src/Box.cc",
        "src/Frustum.cc",
@@ -96,17 +105,7 @@ cc_library(
     # We need to list the private headers along with the public ones so
     # that bazel copies them all into the right place during the build
     # phase.
-    hdrs = public_headers + [
-        "include/ignition/math.hh",
-        "include/ignition/math/BoxPrivate.hh",
-        "include/ignition/math/FrustumPrivate.hh",
-        "include/ignition/math/KmeansPrivate.hh",
-        "include/ignition/math/RotationSplinePrivate.hh",
-        "include/ignition/math/SignalStatsPrivate.hh",
-        "include/ignition/math/SplinePrivate.hh",
-        "include/ignition/math/Vector3StatsPrivate.hh",
-        "include/ignition/math/config.hh", # from cmake_configure_file above
-    ],
+    hdrs = public_headers,
     includes = ["include"],
     visibility = ["//visibility:public"],
 )

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -2,21 +2,12 @@
 
 load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
-# Lets other packages inspect the CMake code, e.g., for the version number.
-filegroup(
-    name = "cmakelists_with_version",
-    srcs = ["CMakeLists.txt"],
-    visibility = ["//visibility:public"],
-)
-
 # Generates config.h based on the version numbers in CMake code.
 cmake_configure_file(
     name = "config",
     src = "cmake/config.hh.in",
     out = "include/ignition/math/config.hh",
-    cmakelists = [
-        ":cmakelists_with_version",
-    ],
+    cmakelists = ["CMakeLists.txt"],
     defines = [
         # It would be nice to get this information directly from CMakeLists.txt,
         # but it ends up being too hard.  ignition-math sets a project name

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -2,7 +2,7 @@
 
 load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
-# Generates config.h based on the version numbers in CMake code.
+# Generates config.hh based on the version numbers in CMake code.
 cmake_configure_file(
     name = "config",
     src = "cmake/config.hh.in",
@@ -55,7 +55,7 @@ public_headers = [
 ]
 
 # Generates math.hh, which consists of #include statements for all of the
-# other headers in the library except the *Private.hh ones.  The first line is
+# public headers in the library.  The first line is
 # '#include <ignition/math/config.hh>' followed by one line like
 # '#include <ignition/math/Angle.hh>' for each non-generated header.
 genrule(
@@ -72,8 +72,8 @@ genrule(
 )
 
 # Generates the library exported to users.  The explicitly listed srcs= matches
-# upstream's explicitly listed sources.  The explicitly listed hdrs= matches
-# upstream's explicitly listed headers.
+# upstream's explicitly listed sources plus private headers.  The explicitly
+# listed hdrs= matches upstream's public headers.
 cc_library(
     name = "ignition_math",
     srcs = [
@@ -102,9 +102,6 @@ cc_library(
        "src/Temperature.cc",
        "src/Vector3Stats.cc",
     ],
-    # We need to list the private headers along with the public ones so
-    # that bazel copies them all into the right place during the build
-    # phase.
     hdrs = public_headers,
     includes = ["include"],
     visibility = ["//visibility:public"],

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -99,6 +99,7 @@ cc_library(
        "src/SignalStats.cc",
        "src/SphericalCoordinates.cc",
        "src/Spline.cc",
+       "src/SplinePrivate.cc",
        "src/Temperature.cc",
        "src/Vector3Stats.cc",
     ],

--- a/tools/ignition_rndf.BUILD
+++ b/tools/ignition_rndf.BUILD
@@ -12,6 +12,6 @@ cc_library(
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
-        "@ignition_math//:lib",
+        "@ignition_math",
     ],
 )

--- a/tools/ignition_rndf.BUILD
+++ b/tools/ignition_rndf.BUILD
@@ -12,6 +12,6 @@ cc_library(
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
-        "@ignition_math",
+        "@ignition_math//:lib",
     ],
 )

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -52,6 +52,14 @@ genrule(
 cc_library(
     name = "sdformat",
     srcs = [
+        "include/sdf/Converter.hh",
+        "include/sdf/ExceptionPrivate.hh",
+        "include/sdf/parser_private.hh",
+        "include/sdf/parser_urdf.hh",
+        "include/sdf/SDFExtension.hh",
+        "include/sdf/sdf_config.h", # from cmake_configure_file above
+        "include/sdf/sdf.hh",       # from genrule above
+        "include/sdf/SDFImplPrivate.hh",
         "src/Console.cc",
         "src/Converter.cc",
         "src/Element.cc",
@@ -92,16 +100,7 @@ cc_library(
     ],
     # We need to list the private headers along with the public ones so that
     # bazel copies them all into the right place during the build phase.
-    hdrs = public_headers + [
-        "include/sdf/Converter.hh",
-        "include/sdf/ExceptionPrivate.hh",
-        "include/sdf/parser_private.hh",
-        "include/sdf/parser_urdf.hh",
-        "include/sdf/SDFExtension.hh",
-        "include/sdf/sdf_config.h", # from cmake_configure_file above
-        "include/sdf/sdf.hh",       # from genrule above
-        "include/sdf/SDFImplPrivate.hh",
-    ],
+    hdrs = public_headers,
     includes = [
         "include",
     ],

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -2,21 +2,12 @@
 
 load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
-# Lets other packages inspect the CMake code, e.g., for the version number.
-filegroup(
-    name = "cmakelists_with_version",
-    srcs = ["CMakeLists.txt"],
-    visibility = ["//visibility:public"],
-)
-
 # Generates sdf.hh based on the version numbers in CMake code.
 cmake_configure_file(
     name = "config",
     src = "cmake/sdf_config.h.in",
     out = "include/sdf/sdf_config.h",
-    cmakelists = [
-        ":cmakelists_with_version",
-    ],
+    cmakelists = ["CMakeLists.txt"],
     defines = [
         "PROJECT_NAME=SDFormat",
         "SDF_VERSION_NAME=",

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -22,12 +22,6 @@ cmake_configure_file(
         "SDF_VERSION_NAME=",
         "CMAKE_INSTALL_FULL_DATAROOTDIR=external/sdformat/sdf/1.6",
         "SDF_PKG_VERSION=",
-        # This symbol comes from within the sdformat library's
-        # cmake/SearchForStuff.cmake.  This is needed because the URDF API
-        # deprecates certain functions.  If URDF_GE_0P3 is *not* specified,
-        # then sdformat attempts to build against the older APIs, which
-        # causes compile failure (this is probably a bug that should be fixed).
-        "URDF_GE_0P3=1",
     ],
     visibility = [],
 )

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -61,7 +61,7 @@ genrule(
 # upstream's explicitly listed sources.  The explicitly listed hdrs= matches
 # upstream's explicitly listed headers.
 cc_library(
-    name = "lib",
+    name = "sdformat",
     srcs = [
         "src/Console.cc",
         "src/Converter.cc",
@@ -116,7 +116,7 @@ cc_library(
     visibility = ["//visibility:public"],
     linkopts = ["-lboost_system", "-lboost_filesystem", "-ltinyxml"],
     deps = [
-        "@ignition_math//:lib",
+        "@ignition_math",
     ],
     data = glob(['sdf/1.6/*.sdf']),
 )

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -2,7 +2,7 @@
 
 load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
-# Generates sdf.hh based on the version numbers in CMake code.
+# Generates sdf_config.hh based on the version numbers in CMake code.
 cmake_configure_file(
     name = "config",
     src = "cmake/sdf_config.h.in",
@@ -29,15 +29,15 @@ public_headers = [
     "include/sdf/Types.hh",
 ]
 
-# Generates sdf.hh, which consists of #include statements for *all* of the other
-# headers in the library (!!!).  There is one line like
-# '#include <sdf/Assert.hh>' for each non-generated header, followed at the end
-# by a single '#include <sdf/sdf_config.hh>'.
+# Generates sdf.hh, which consists of #include statements for all of the public
+# headers in the library.  There is one line like '#include <sdf/Assert.hh>'
+# for each non-generated header, followed at the end by a
+# single '#include <sdf/sdf_config.hh>'.
 genrule(
     name = "sdfhh_genrule",
     srcs = public_headers,
     outs = ["include/sdf/sdf.hh"],
-    # TODO: centralize this logic, as it is used here, in ignmath.BUILD, and
+    # TODO: centralize this logic, as it is used here, in ignition_math.BUILD, and
     # in fcl.BUILD
     cmd = "(" + (
         "echo '$(SRCS)' | tr ' ' '\\n' | " +
@@ -47,8 +47,8 @@ genrule(
 )
 
 # Generates the library exported to users.  The explicitly listed srcs= matches
-# upstream's explicitly listed sources.  The explicitly listed hdrs= matches
-# upstream's explicitly listed headers.
+# upstream's explicitly listed sources plus private headers.  The explicitly
+# listed hdrs= matches upstream's public headers.
 cc_library(
     name = "sdformat",
     srcs = [
@@ -98,8 +98,6 @@ cc_library(
         "src/urdf/urdf_world/types.h",
         "src/urdf/urdf_world/world.h",
     ],
-    # We need to list the private headers along with the public ones so that
-    # bazel copies them all into the right place during the build phase.
     hdrs = public_headers,
     includes = [
         "include",

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -1,0 +1,128 @@
+# -*- python -*-
+
+load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
+
+# Lets other packages inspect the CMake code, e.g., for the version number.
+filegroup(
+    name = "cmakelists_with_version",
+    srcs = ["CMakeLists.txt"],
+    visibility = ["//visibility:public"],
+)
+
+# Generates sdf.hh based on the version numbers in CMake code.
+cmake_configure_file(
+    name = "config",
+    src = "cmake/sdf_config.h.in",
+    out = "include/sdf/sdf_config.h",
+    cmakelists = [
+        ":cmakelists_with_version",
+    ],
+    defines = [
+        "PROJECT_NAME=SDFormat",
+        "SDF_VERSION_NAME=",
+        "CMAKE_INSTALL_FULL_DATAROOTDIR=external/sdformat/sdf/1.6",
+        "SDF_PKG_VERSION=",
+        # This symbol comes from within the sdformat library's
+        # cmake/SearchForStuff.cmake.  This is needed because the URDF API
+        # deprecates certain functions.  If URDF_GE_0P3 is *not* specified,
+        # then sdformat attempts to build against the older APIs, which
+        # causes compile failure (this is probably a bug that should be fixed).
+        "URDF_GE_0P3=1",
+    ],
+    visibility = [],
+)
+
+public_headers = [
+    "include/sdf/Assert.hh",
+    "include/sdf/Console.hh",
+    "include/sdf/Element.hh",
+    "include/sdf/Exception.hh",
+    "include/sdf/Filesystem.hh",
+    "include/sdf/Param.hh",
+    "include/sdf/parser.hh",
+    "include/sdf/SDFImpl.hh",
+    "include/sdf/system_util.hh",
+    "include/sdf/Types.hh",
+]
+
+# Generates sdf.hh, which consists of #include statements for *all* of the other
+# headers in the library (!!!).  There is one line like
+# '#include <sdf/Assert.hh>' for each non-generated header, followed at the end
+# by a single '#include <sdf/sdf_config.hh>'.
+genrule(
+    name = "sdfhh_genrule",
+    srcs = public_headers,
+    outs = ["include/sdf/sdf.hh"],
+    # TODO: centralize this logic, as it is used here, in ignmath.BUILD, and
+    # in fcl.BUILD
+    cmd = "(" + (
+        "echo '$(SRCS)' | tr ' ' '\\n' | " +
+        "sed 's|.*include/\(.*\)|#include \\<\\1\\>|g' &&" +
+        "echo '#include <sdf/sdf_config.h>'"
+    ) + ") > '$@'",
+    visibility = [],
+)
+
+# Generates the library exported to users.  The explicitly listed srcs= matches
+# upstream's explicitly listed sources.  The explicitly listed hdrs= matches
+# upstream's explicitly listed headers.
+cc_library(
+    name = "lib",
+    srcs = [
+        "src/Console.cc",
+        "src/Converter.cc",
+        "src/Element.cc",
+        "src/Exception.cc",
+        "src/Filesystem.cc",
+        "src/parser.cc",
+        "src/parser_urdf.cc",
+        "src/Param.cc",
+        "src/SDF.cc",
+        "src/SDFExtension.cc",
+        "src/Types.cc",
+        "src/urdf/urdf_parser/joint.cpp",
+        "src/urdf/urdf_parser/link.cpp",
+        "src/urdf/urdf_parser/model.cpp",
+        "src/urdf/urdf_parser/pose.cpp",
+        "src/urdf/urdf_parser/twist.cpp",
+        "src/urdf/urdf_parser/urdf_model_state.cpp",
+        "src/urdf/urdf_parser/urdf_sensor.cpp",
+        "src/urdf/urdf_parser/world.cpp",
+    ],
+    # We need to list the private headers along with the public ones so that
+    # bazel copies them all into the right place during the build phase.
+    hdrs = public_headers + [
+        "include/sdf/Converter.hh",
+        "include/sdf/ExceptionPrivate.hh",
+        "include/sdf/parser_private.hh",
+        "include/sdf/parser_urdf.hh",
+        "include/sdf/SDFExtension.hh",
+        "include/sdf/sdf_config.h", # from cmake_configure_file above
+        "include/sdf/sdf.hh",       # from genrule above
+        "include/sdf/SDFImplPrivate.hh",
+        "src/urdf/urdf_exception/exception.h",
+        "src/urdf/urdf_model/color.h",
+        "src/urdf/urdf_model/joint.h",
+        "src/urdf/urdf_model/link.h",
+        "src/urdf/urdf_model/model.h",
+        "src/urdf/urdf_model/pose.h",
+        "src/urdf/urdf_model/twist.h",
+        "src/urdf/urdf_model/types.h",
+        "src/urdf/urdf_model/utils.h",
+        "src/urdf/urdf_model_state/model_state.h",
+        "src/urdf/urdf_model_state/twist.h",
+        "src/urdf/urdf_model_state/types.h",
+        "src/urdf/urdf_parser/urdf_parser.h",
+        "src/urdf/urdf_sensor/sensor.h",
+        "src/urdf/urdf_sensor/types.h",
+        "src/urdf/urdf_world/types.h",
+        "src/urdf/urdf_world/world.h",
+    ],
+    includes = ["include", "src/urdf"],
+    visibility = ["//visibility:public"],
+    linkopts = ["-lboost_system", "-lboost_filesystem", "-ltinyxml"],
+    deps = [
+        "@ignition_math//:lib",
+    ],
+    data = glob(['sdf/1.6/*.sdf']),
+)

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -23,7 +23,6 @@ cmake_configure_file(
         "CMAKE_INSTALL_FULL_DATAROOTDIR=external/sdformat/sdf/1.6",
         "SDF_PKG_VERSION=",
     ],
-    visibility = [],
 )
 
 public_headers = [
@@ -54,7 +53,6 @@ genrule(
         "sed 's|.*include/\(.*\)|#include \\<\\1\\>|g' &&" +
         "echo '#include <sdf/sdf_config.h>'"
     ) + ") > '$@'",
-    visibility = [],
 )
 
 # Generates the library exported to users.  The explicitly listed srcs= matches
@@ -74,26 +72,6 @@ cc_library(
         "src/SDF.cc",
         "src/SDFExtension.cc",
         "src/Types.cc",
-        "src/urdf/urdf_parser/joint.cpp",
-        "src/urdf/urdf_parser/link.cpp",
-        "src/urdf/urdf_parser/model.cpp",
-        "src/urdf/urdf_parser/pose.cpp",
-        "src/urdf/urdf_parser/twist.cpp",
-        "src/urdf/urdf_parser/urdf_model_state.cpp",
-        "src/urdf/urdf_parser/urdf_sensor.cpp",
-        "src/urdf/urdf_parser/world.cpp",
-    ],
-    # We need to list the private headers along with the public ones so that
-    # bazel copies them all into the right place during the build phase.
-    hdrs = public_headers + [
-        "include/sdf/Converter.hh",
-        "include/sdf/ExceptionPrivate.hh",
-        "include/sdf/parser_private.hh",
-        "include/sdf/parser_urdf.hh",
-        "include/sdf/SDFExtension.hh",
-        "include/sdf/sdf_config.h", # from cmake_configure_file above
-        "include/sdf/sdf.hh",       # from genrule above
-        "include/sdf/SDFImplPrivate.hh",
         "src/urdf/urdf_exception/exception.h",
         "src/urdf/urdf_model/color.h",
         "src/urdf/urdf_model/joint.h",
@@ -107,15 +85,41 @@ cc_library(
         "src/urdf/urdf_model_state/twist.h",
         "src/urdf/urdf_model_state/types.h",
         "src/urdf/urdf_parser/exportdecl.h",
+        "src/urdf/urdf_parser/joint.cpp",
+        "src/urdf/urdf_parser/link.cpp",
+        "src/urdf/urdf_parser/model.cpp",
+        "src/urdf/urdf_parser/pose.cpp",
+        "src/urdf/urdf_parser/twist.cpp",
+        "src/urdf/urdf_parser/urdf_model_state.cpp",
+        "src/urdf/urdf_parser/urdf_sensor.cpp",
+        "src/urdf/urdf_parser/world.cpp",
         "src/urdf/urdf_parser/urdf_parser.h",
         "src/urdf/urdf_sensor/sensor.h",
         "src/urdf/urdf_sensor/types.h",
         "src/urdf/urdf_world/types.h",
         "src/urdf/urdf_world/world.h",
     ],
-    includes = ["include", "src/urdf"],
+    # We need to list the private headers along with the public ones so that
+    # bazel copies them all into the right place during the build phase.
+    hdrs = public_headers + [
+        "include/sdf/Converter.hh",
+        "include/sdf/ExceptionPrivate.hh",
+        "include/sdf/parser_private.hh",
+        "include/sdf/parser_urdf.hh",
+        "include/sdf/SDFExtension.hh",
+        "include/sdf/sdf_config.h", # from cmake_configure_file above
+        "include/sdf/sdf.hh",       # from genrule above
+        "include/sdf/SDFImplPrivate.hh",
+    ],
+    includes = [
+        "include",
+    ],
     visibility = ["//visibility:public"],
-    linkopts = ["-lboost_system", "-ltinyxml"],
+    linkopts = [
+        "-lboost_system",
+        "-ltinyxml"
+    ],
+    copts = ["-I external/sdformat/src/urdf"],
     deps = [
         "@ignition_math",
     ],

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -106,6 +106,7 @@ cc_library(
         "src/urdf/urdf_model_state/model_state.h",
         "src/urdf/urdf_model_state/twist.h",
         "src/urdf/urdf_model_state/types.h",
+        "src/urdf/urdf_parser/exportdecl.h",
         "src/urdf/urdf_parser/urdf_parser.h",
         "src/urdf/urdf_sensor/sensor.h",
         "src/urdf/urdf_sensor/types.h",

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -11,6 +11,11 @@ cmake_configure_file(
     defines = [
         "PROJECT_NAME=SDFormat",
         "SDF_VERSION_NAME=",
+        # The sdformat library currently requires that it be able to find the
+        # SDF files that are installed in the cc_library :data variable, which
+        # is why we set the DATAROOTDIR below.
+        # TODO: change the sdformat library to not require this, or use bazel
+        # variables to find the correct location to place these files.
         "CMAKE_INSTALL_FULL_DATAROOTDIR=external/sdformat/sdf/1.6",
         "SDF_PKG_VERSION=",
     ],
@@ -107,6 +112,10 @@ cc_library(
         "-lboost_system",
         "-ltinyxml"
     ],
+    # TODO: We are currently using the vendored version of urdfdom embedded
+    # in sdformat, so we need this include path to find it.  We can get
+    # rid of this by either building the vendored version as a separate
+    # cc_library rule, or by using a true external version of URDF.
     copts = ["-I external/sdformat/src/urdf"],
     deps = [
         "@ignition_math",

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -114,7 +114,7 @@ cc_library(
     ],
     includes = ["include", "src/urdf"],
     visibility = ["//visibility:public"],
-    linkopts = ["-lboost_system", "-lboost_filesystem", "-ltinyxml"],
+    linkopts = ["-lboost_system", "-ltinyxml"],
     deps = [
         "@ignition_math",
     ],

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -2,7 +2,7 @@
 
 load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
-# Generates sdf_config.hh based on the version numbers in CMake code.
+# Generates sdf_config.h based on the version numbers in CMake code.
 cmake_configure_file(
     name = "config",
     src = "cmake/sdf_config.h.in",
@@ -32,13 +32,13 @@ public_headers = [
 # Generates sdf.hh, which consists of #include statements for all of the public
 # headers in the library.  There is one line like '#include <sdf/Assert.hh>'
 # for each non-generated header, followed at the end by a
-# single '#include <sdf/sdf_config.hh>'.
+# single '#include <sdf/sdf_config.h>'.
 genrule(
     name = "sdfhh_genrule",
     srcs = public_headers,
     outs = ["include/sdf/sdf.hh"],
-    # TODO: centralize this logic, as it is used here, in ignition_math.BUILD, and
-    # in fcl.BUILD
+    # TODO: We should centralize this logic, as it is used here, in
+    # ignition_math.BUILD, and in fcl.BUILD.
     cmd = "(" + (
         "echo '$(SRCS)' | tr ' ' '\\n' | " +
         "sed 's|.*include/\(.*\)|#include \\<\\1\\>|g' &&" +


### PR DESCRIPTION
This is a pull request for adding in OSRF's sdformat library for parsing SDF, rather than using the hand-built library.  This PR imports sdformat as another bitbucket repository, integrates it into the bazel build system, and adds a simple proof-of-life unit-test.

This PR is a rehash of RobotLocomotion/drake#4831, but I decided to open a new one to make it a bit easier to review.  All comments from the previous version have been taken into account here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6028)
<!-- Reviewable:end -->
