### PR TITLE
Package LCM

### DIFF
--- a/drake/BUILD
+++ b/drake/BUILD
@@ -15,6 +15,7 @@ _LIBDRAKE_COMPONENTS = [
     "//drake/multibody/parsers",
     "//drake/systems/framework",
     "//drake/systems/primitives",
+    "//drake/lcm",
 ]
 
 # The Drake binary package. libdrake.so contains all the symbols from all the
@@ -43,6 +44,7 @@ pkg_tar(
         "@bullet//:license",
         "@eigen//:license",
         "@fmt//:license",
+        "@lcm//:license",
         "@spdlog//:license",
         "@tinyobjloader//:license",
     ],

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -190,7 +190,9 @@ def drake_cc_googletest(
 def _transitive_hdrs_impl(ctx):
   headers = set()
   for dep in ctx.attr.deps:
-    headers += dep.cc.transitive_headers
+    # TODO(mwoehlke-kitware): Figure out a better way to exclude system headers
+    # from being slurped in?
+    headers += [h for h in dep.cc.transitive_headers if not "/_usr_" in h.path]
   return struct(files=headers)
 
 _transitive_hdrs = rule(

--- a/tools/drake.cps
+++ b/tools/drake.cps
@@ -15,6 +15,7 @@
         "@prefix@/include/external/bullet",
         "@prefix@/include/external/eigen",
         "@prefix@/include/external/fmt",
+        "@prefix@/include/external/lcm",
         "@prefix@/include/external/spdlog",
         "@prefix@/include/external/tinyobjloader"
       ],

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 
 load("@//tools:drake.bzl", "drake_generate_file")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -185,4 +186,12 @@ java_binary(
     runtime_deps = [
         ":lcm-java",
     ],
+)
+
+pkg_tar(
+    name = "license",
+    extension = "tar.gz",
+    mode = "0644",
+    files = ["COPYING"],
+    package_dir = "lcm",
 )


### PR DESCRIPTION
Add missing bits (namely, the license stuff) so that Bazel can package external LCM. Add `//drake/lcm` to `libdrake.so` so that consumers can use those bits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6041)
<!-- Reviewable:end -->
