### PR TITLE
Implements VectorBase::get_contiguous_block()

### DIFF
--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -160,7 +160,7 @@ class BasicVector : public VectorBase<T> {
     return values_.segment(start, size);
   }
 
-  virtual optional<Eigen::VectorBlock<VectorX<T>>>
+  optional<Eigen::VectorBlock<VectorX<T>>>
   get_mutable_contiguous_segment_when_possible(int start, int size) final {
     return values_.segment(start, size);
   }

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -156,12 +156,12 @@ class BasicVector : public VectorBase<T> {
   }
 
   optional<Eigen::VectorBlock<const VectorX<T>>>
-  get_contiguous_segment_when_possible(int start, int size) const final {
+  try_getting_contiguous_segment(int start, int size) const final {
     return values_.segment(start, size);
   }
 
   optional<Eigen::VectorBlock<VectorX<T>>>
-  get_mutable_contiguous_segment_when_possible(int start, int size) final {
+  try_getting_mutable_contiguous_segment(int start, int size) final {
     return values_.segment(start, size);
   }
 

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -84,22 +84,6 @@ class BasicVector : public VectorBase<T> {
     return values_.head(values_.rows());
   }
 
-  bool is_contiguous() const override { return true;}
-
-  Eigen::VectorBlock<const VectorX<T>> get_contiguous_segment(
-      int start, int size) const override {
-    DRAKE_ASSERT_VOID(this->IsIndexWithinBoundsOrThrow(start));
-    DRAKE_ASSERT_VOID(this->IsSizeWithinBoundsOrThrow(size));
-    return values_.segment(start, size);
-  }
-
-  Eigen::VectorBlock<VectorX<T>> get_mutable_contiguous_segment(
-      int start, int size) override {
-    DRAKE_ASSERT_VOID(this->IsIndexWithinBoundsOrThrow(start));
-    DRAKE_ASSERT_VOID(this->IsSizeWithinBoundsOrThrow(size));
-    return values_.segment(start, size);
-  }
-
   const T& GetAtIndex(int index) const override {
     DRAKE_THROW_UNLESS(index < size());
     return values_[index];
@@ -169,6 +153,16 @@ class BasicVector : public VectorBase<T> {
   static void MakeRecursive(BasicVector<T>* data, int index,
                             F constructor_arg) {
     data->SetAtIndex(index++, T(constructor_arg));
+  }
+
+  optional<Eigen::VectorBlock<const VectorX<T>>>
+  get_contiguous_segment_when_possible(int start, int size) const final {
+    return values_.segment(start, size);
+  }
+
+  virtual optional<Eigen::VectorBlock<VectorX<T>>>
+  get_mutable_contiguous_segment_when_possible(int start, int size) final {
+    return values_.segment(start, size);
   }
 
  private:

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -61,13 +61,6 @@ class BasicVector : public VectorBase<T> {
 
   int size() const override { return static_cast<int>(values_.rows()); }
 
-  /// Returns `true` if `this` vector has a contiguous in memory layout within
-  /// the range of indexes `start` to `end`.
-  /// @see IsContiguous()
-  bool IsContiguousWithinRange(int start, int end) const override {
-    return true;
-  }
-
   /// Sets the vector to the given value. After a.set_value(b.get_value()), a
   /// must be identical to b.
   /// Throws std::out_of_range if the new value has different dimensions.
@@ -89,6 +82,22 @@ class BasicVector : public VectorBase<T> {
   /// mutation of the values, but does not allow resizing the vector itself.
   Eigen::VectorBlock<VectorX<T>> get_mutable_value() {
     return values_.head(values_.rows());
+  }
+
+  bool is_contiguous() const override { return true;}
+
+  Eigen::VectorBlock<const VectorX<T>> get_contiguous_segment(
+      int start, int size) const override {
+    DRAKE_ASSERT_VOID(this->IsIndexWithinBoundsOrThrow(start));
+    DRAKE_ASSERT_VOID(this->IsSizeWithinBoundsOrThrow(size));
+    return values_.segment(start, size);
+  }
+
+  Eigen::VectorBlock<VectorX<T>> get_mutable_contiguous_segment(
+      int start, int size) override {
+    DRAKE_ASSERT_VOID(this->IsIndexWithinBoundsOrThrow(start));
+    DRAKE_ASSERT_VOID(this->IsSizeWithinBoundsOrThrow(size));
+    return values_.segment(start, size);
   }
 
   const T& GetAtIndex(int index) const override {

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -61,6 +61,13 @@ class BasicVector : public VectorBase<T> {
 
   int size() const override { return static_cast<int>(values_.rows()); }
 
+  /// Returns `true` if `this` vector has a contiguous in memory layout within
+  /// the range of indexes `start` to `end`.
+  /// @see IsContiguous()
+  bool IsContiguousWithinRange(int start, int end) const override {
+    return true;
+  }
+
   /// Sets the vector to the given value. After a.set_value(b.get_value()), a
   /// must be identical to b.
   /// Throws std::out_of_range if the new value has different dimensions.

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -48,14 +48,6 @@ class Subvector : public VectorBase<T> {
 
   int size() const override { return num_elements_; }
 
-  /// Returns `true` if `this` vector has a contiguous in memory layout within
-  /// the range of indexes `start` to `end`.
-  /// @see IsContiguous()
-  bool IsContiguousWithinRange(int start, int end) const override {
-    return vector_->IsContiguousWithinRange(
-        start + first_element_, end + first_element_);
-  }
-
   const T& GetAtIndex(int index) const override {
     DRAKE_THROW_UNLESS(index < size());
     return vector_->GetAtIndex(first_element_ + index);
@@ -64,6 +56,25 @@ class Subvector : public VectorBase<T> {
   T& GetAtIndex(int index) override {
     DRAKE_THROW_UNLESS(index < size());
     return vector_->GetAtIndex(first_element_ + index);
+  }
+
+  bool is_contiguous() const override {
+    return vector_->is_contiguous();
+  }
+
+  Eigen::VectorBlock<const VectorX<T>> get_contiguous_segment(
+      int start, int size) const override {
+    DRAKE_ASSERT_VOID(this->IsIndexWithinBoundsOrThrow(start));
+    DRAKE_ASSERT_VOID(this->IsSizeWithinBoundsOrThrow(size));
+    return vector_->get_contiguous_segment(start + first_element_, size);
+  }
+
+  Eigen::VectorBlock<VectorX<T>> get_mutable_contiguous_segment(
+      int start, int size) override {
+    DRAKE_ASSERT_VOID(this->IsIndexWithinBoundsOrThrow(start));
+    DRAKE_ASSERT_VOID(this->IsSizeWithinBoundsOrThrow(size));
+    return vector_->get_mutable_contiguous_segment(
+        start + first_element_, size);
   }
 
  private:

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -5,6 +5,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/systems/framework/vector_base.h"
@@ -30,6 +31,8 @@ class Subvector : public VectorBase<T> {
       : vector_(vector),
         first_element_(first_element),
         num_elements_(num_elements) {
+    DRAKE_ASSERT(first_element >= 0);
+    DRAKE_ASSERT(num_elements >= 0);
     if (vector_ == nullptr) {
       throw std::logic_error("Cannot create Subvector of a nullptr vector.");
     }

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -23,8 +23,11 @@ class Subvector : public VectorBase<T> {
   // Subvector objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Subvector)
 
-  /// Constructs a subvector of vector that consists of num_elements starting
-  /// at first_element.
+  /// Constructs a subvector of `vector` that consists of `num_elements`
+  /// starting at `first_element`.
+  /// @param first_element Index into `vector` for the first element of this
+  ///                      slice.
+  /// @param num_elements The size of this slice. Zero-sized slices are allowed.
   /// @param vector The vector to slice.  Must not be nullptr. Must remain
   ///               valid for the lifetime of this object.
   Subvector(VectorBase<T>* vector, int first_element, int num_elements)
@@ -64,7 +67,7 @@ class Subvector : public VectorBase<T> {
     return vector_->get_contiguous_segment(start + first_element_, size);
   }
 
-  virtual optional<Eigen::VectorBlock<VectorX<T>>>
+  optional<Eigen::VectorBlock<VectorX<T>>>
   get_mutable_contiguous_segment_when_possible(int start, int size) final {
     return vector_->get_mutable_contiguous_segment(start + first_element_,
                                                    size);

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -48,6 +48,14 @@ class Subvector : public VectorBase<T> {
 
   int size() const override { return num_elements_; }
 
+  /// Returns `true` if `this` vector has a contiguous in memory layout within
+  /// the range of indexes `start` to `end`.
+  /// @see IsContiguous()
+  bool IsContiguousWithinRange(int start, int end) const override {
+    return vector_->IsContiguousWithinRange(
+        start + first_element_, end + first_element_);
+  }
+
   const T& GetAtIndex(int index) const override {
     DRAKE_THROW_UNLESS(index < size());
     return vector_->GetAtIndex(first_element_ + index);

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -58,23 +58,16 @@ class Subvector : public VectorBase<T> {
     return vector_->GetAtIndex(first_element_ + index);
   }
 
-  bool is_contiguous() const override {
-    return vector_->is_contiguous();
-  }
-
-  Eigen::VectorBlock<const VectorX<T>> get_contiguous_segment(
-      int start, int size) const override {
-    DRAKE_ASSERT_VOID(this->IsIndexWithinBoundsOrThrow(start));
-    DRAKE_ASSERT_VOID(this->IsSizeWithinBoundsOrThrow(size));
+ protected:
+  optional<Eigen::VectorBlock<const VectorX<T>>>
+  get_contiguous_segment_when_possible(int start, int size) const final {
     return vector_->get_contiguous_segment(start + first_element_, size);
   }
 
-  Eigen::VectorBlock<VectorX<T>> get_mutable_contiguous_segment(
-      int start, int size) override {
-    DRAKE_ASSERT_VOID(this->IsIndexWithinBoundsOrThrow(start));
-    DRAKE_ASSERT_VOID(this->IsSizeWithinBoundsOrThrow(size));
-    return vector_->get_mutable_contiguous_segment(
-        start + first_element_, size);
+  virtual optional<Eigen::VectorBlock<VectorX<T>>>
+  get_mutable_contiguous_segment_when_possible(int start, int size) final {
+    return vector_->get_mutable_contiguous_segment(start + first_element_,
+                                                   size);
   }
 
  private:

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -63,12 +63,12 @@ class Subvector : public VectorBase<T> {
 
  protected:
   optional<Eigen::VectorBlock<const VectorX<T>>>
-  get_contiguous_segment_when_possible(int start, int size) const final {
+  try_getting_contiguous_segment(int start, int size) const final {
     return vector_->get_contiguous_segment(start + first_element_, size);
   }
 
   optional<Eigen::VectorBlock<VectorX<T>>>
-  get_mutable_contiguous_segment_when_possible(int start, int size) final {
+  try_getting_mutable_contiguous_segment(int start, int size) final {
     return vector_->get_mutable_contiguous_segment(start + first_element_,
                                                    size);
   }

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -50,23 +50,18 @@ class Supervector : public VectorBase<T> {
     return target.first->GetAtIndex(target.second);
   }
 
-  /// Returns `true` if `this` vector has a contiguous in memory layout within
-  /// the range of indexes `start` to `end`.
-  /// @throws std::out_of_range for invalid indices.
-  /// @see IsContiguous()
-  bool IsContiguousWithinRange(int start, int end) const override {
-    const auto start_target = GetSubvectorAndOffset(start);
-    const auto end_target = GetSubvectorAndOffset(end);
-    // If indexes fall within two different vectors return false. This assumes
-    // that these two slices cannot be contiguous in memory.
-    // TODO(amcastro-tri): Deal with the case in which two slices actually do
-    // map into a contiguous chunk of memory.
-    if (start_target.first != end_target.first) return false;
-    // If (start, end) falls within the same slice, ask that slice if that range
-    // is contiguous in memory.
-    // Note: if we are here then start_target.first == end_target.first.
-    return start_target.first->IsContiguousWithinRange(
-        start_target.second, end_target.second);
+  bool is_contiguous() const override { return false;}
+
+  Eigen::VectorBlock<const VectorX<T>> get_contiguous_segment(
+      int start, int size) const override {
+    DRAKE_ABORT_MSG("Supervector does not allow to retrieve a contiguous "
+                    "segment of memory");
+  }
+
+  Eigen::VectorBlock<VectorX<T>> get_mutable_contiguous_segment(
+      int start, int size) override {
+    DRAKE_ABORT_MSG("Supervector does not allow to retrieve a contiguous "
+                    "segment of memory");
   }
 
  private:

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -51,23 +51,23 @@ class Supervector : public VectorBase<T> {
   }
 
  protected:
-  /// VectorBase::get_contiguous_segment_when_possible()'s contract is to
+  /// VectorBase::try_getting_contiguous_segment()'s contract is to
   /// provide a cheap O(1) complexity implementation. Since we currently do not
   /// support an O(1) implementation, %Supervector's implementation of
-  /// get_contiguous_segment_when_possible() returns a drake::optional with no
+  /// try_getting_contiguous_segment() returns a drake::optional with no
   /// value.
   optional<Eigen::VectorBlock<const VectorX<T>>>
-  get_contiguous_segment_when_possible(int, int) const final {
+  try_getting_contiguous_segment(int, int) const final {
     return {};
   }
 
-  /// VectorBase::get_mutable_contiguous_segment_when_possible()'s contract is
+  /// VectorBase::try_getting_mutable_contiguous_segment()'s contract is
   /// to provide a cheap O(1) complexity implementation. Since we currently do
   /// not support an O(1) implementation, %Supervector's implementation of
-  /// get_mutable_contiguous_segment_when_possible() returns a drake::optional
+  /// try_getting_mutable_contiguous_segment() returns a drake::optional
   /// with no value.
   optional<Eigen::VectorBlock<VectorX<T>>>
-  get_mutable_contiguous_segment_when_possible(int, int) final {
+  try_getting_mutable_contiguous_segment(int, int) final {
     return {};
   }
 

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -57,7 +57,7 @@ class Supervector : public VectorBase<T> {
   /// get_contiguous_segment_when_possible() returns a drake::optional with no
   /// value.
   optional<Eigen::VectorBlock<const VectorX<T>>>
-  get_contiguous_segment_when_possible(int start, int size) const final {
+  get_contiguous_segment_when_possible(int, int) const final {
     return {};
   }
 
@@ -67,7 +67,7 @@ class Supervector : public VectorBase<T> {
   /// get_mutable_contiguous_segment_when_possible() returns a drake::optional
   /// with no value.
   optional<Eigen::VectorBlock<VectorX<T>>>
-  get_mutable_contiguous_segment_when_possible(int start, int size) final {
+  get_mutable_contiguous_segment_when_possible(int, int) final {
     return {};
   }
 

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -50,18 +50,28 @@ class Supervector : public VectorBase<T> {
     return target.first->GetAtIndex(target.second);
   }
 
-  bool is_contiguous() const override { return false;}
-
-  Eigen::VectorBlock<const VectorX<T>> get_contiguous_segment(
-      int start, int size) const override {
-    DRAKE_ABORT_MSG("Supervector does not allow to retrieve a contiguous "
-                    "segment of memory");
+ protected:
+  /// VectorBase::get_contiguous_segment_when_possible()'s contract is to
+  /// provide a cheap O(1) complexity implementation. Since we currently do not
+  /// support an O(1) implementation, %Supervector's implementation of
+  /// get_contiguous_segment_when_possible() throws an exception.
+  optional<Eigen::VectorBlock<const VectorX<T>>>
+  get_contiguous_segment_when_possible(int start, int size) const final {
+    return {};
+    //DRAKE_ABORT_MSG("Supervector currently does not allow to retrieve a "
+    //                "contiguous segment of memory with O(1) complexity");
   }
 
-  Eigen::VectorBlock<VectorX<T>> get_mutable_contiguous_segment(
-      int start, int size) override {
-    DRAKE_ABORT_MSG("Supervector does not allow to retrieve a contiguous "
-                    "segment of memory");
+  /// VectorBase::get_mutable_contiguous_segment_when_possible()'s contract is
+  /// to provide a cheap O(1) complexity implementation. Since we currently do
+  /// not support an O(1) implementation, %Supervector's implementation of
+  /// get_mutable_contiguous_segment_when_possible() throws an exception.
+  optional<Eigen::VectorBlock<VectorX<T>>>
+  get_mutable_contiguous_segment_when_possible(int start, int size) final
+  {
+    return {};
+    //DRAKE_ABORT_MSG("Supervector currently does not allow to retrieve a "
+    //                "contiguous segment of memory with O(1) complexity");
   }
 
  private:

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -54,24 +54,21 @@ class Supervector : public VectorBase<T> {
   /// VectorBase::get_contiguous_segment_when_possible()'s contract is to
   /// provide a cheap O(1) complexity implementation. Since we currently do not
   /// support an O(1) implementation, %Supervector's implementation of
-  /// get_contiguous_segment_when_possible() throws an exception.
+  /// get_contiguous_segment_when_possible() returns a drake::optional with no
+  /// value.
   optional<Eigen::VectorBlock<const VectorX<T>>>
   get_contiguous_segment_when_possible(int start, int size) const final {
     return {};
-    //DRAKE_ABORT_MSG("Supervector currently does not allow to retrieve a "
-    //                "contiguous segment of memory with O(1) complexity");
   }
 
   /// VectorBase::get_mutable_contiguous_segment_when_possible()'s contract is
   /// to provide a cheap O(1) complexity implementation. Since we currently do
   /// not support an O(1) implementation, %Supervector's implementation of
-  /// get_mutable_contiguous_segment_when_possible() throws an exception.
+  /// get_mutable_contiguous_segment_when_possible() returns a drake::optional
+  /// with no value.
   optional<Eigen::VectorBlock<VectorX<T>>>
-  get_mutable_contiguous_segment_when_possible(int start, int size) final
-  {
+  get_mutable_contiguous_segment_when_possible(int start, int size) final {
     return {};
-    //DRAKE_ABORT_MSG("Supervector currently does not allow to retrieve a "
-    //                "contiguous segment of memory with O(1) complexity");
   }
 
  private:

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -50,6 +50,25 @@ class Supervector : public VectorBase<T> {
     return target.first->GetAtIndex(target.second);
   }
 
+  /// Returns `true` if `this` vector has a contiguous in memory layout within
+  /// the range of indexes `start` to `end`.
+  /// @throws std::out_of_range for invalid indices.
+  /// @see IsContiguous()
+  bool IsContiguousWithinRange(int start, int end) const override {
+    const auto start_target = GetSubvectorAndOffset(start);
+    const auto end_target = GetSubvectorAndOffset(end);
+    // If indexes fall within two different vectors return false. This assumes
+    // that these two slices cannot be contiguous in memory.
+    // TODO(amcastro-tri): Deal with the case in which two slices actually do
+    // map into a contiguous chunk of memory.
+    if (start_target.first != end_target.first) return false;
+    // If (start, end) falls within the same slice, ask that slice if that range
+    // is contiguous in memory.
+    // Note: if we are here then start_target.first == end_target.first.
+    return start_target.first->IsContiguousWithinRange(
+        start_target.second, end_target.second);
+  }
+
  private:
   // Given an index into the supervector, returns the subvector that
   // contains that index, and its offset within the subvector. This operation

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -28,9 +28,14 @@ GTEST_TEST(BasicVectorTest, SetZero) {
 GTEST_TEST(BasicVectorTest, IsContiguoys) {
   auto vec = BasicVector<double>::Make(1.0, 2.0, 3.0);
   EXPECT_TRUE(vec->is_contiguous());
+  EXPECT_TRUE(vec->is_segment_contiguous(0, vec->size()));
+  // Any other segment should be contiguous.
+  EXPECT_TRUE(vec->is_segment_contiguous(1, 2));
   EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), vec->get_contiguous_vector());
   vec->get_mutable_contiguous_vector().coeffRef(1) = -1.0;
   EXPECT_EQ(Eigen::Vector3d(1.0, -1.0, 3.0), vec->get_contiguous_vector());
+  // And we are able to get a segment if needed.
+  EXPECT_EQ(Eigen::Vector2d(-1.0, 3.0), vec->get_contiguous_segment(1, 2));
 }
 
 // Tests that the BasicVector<double> is initialized to NaN.

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -24,8 +24,8 @@ GTEST_TEST(BasicVectorTest, SetZero) {
   EXPECT_EQ(Eigen::Vector3d(0, 0, 0), vec->get_value());
 }
 
-// Verifies BasicVector is contiguous in memory.
-GTEST_TEST(BasicVectorTest, IsContiguoys) {
+// Verifies BasicVector is contiguous-in-memory.
+GTEST_TEST(BasicVectorTest, IsContiguous) {
   auto vec = BasicVector<double>::Make(1.0, 2.0, 3.0);
   EXPECT_TRUE(vec->is_contiguous());
   EXPECT_TRUE(vec->is_segment_contiguous(0, vec->size()));

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -24,7 +24,7 @@ GTEST_TEST(BasicVectorTest, SetZero) {
   EXPECT_EQ(Eigen::Vector3d(0, 0, 0), vec->get_value());
 }
 
-// Verifies BasicVector is contiguous-in-memory.
+// Verifies BasicVector is contiguous in memory.
 GTEST_TEST(BasicVectorTest, IsContiguous) {
   auto vec = BasicVector<double>::Make(1.0, 2.0, 3.0);
   EXPECT_TRUE(vec->is_contiguous());

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -28,10 +28,9 @@ GTEST_TEST(BasicVectorTest, SetZero) {
 GTEST_TEST(BasicVectorTest, IsContiguoys) {
   auto vec = BasicVector<double>::Make(1.0, 2.0, 3.0);
   EXPECT_TRUE(vec->is_contiguous());
-  EXPECT_TRUE(vec->IsContiguous());
-  EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), vec->get_contiguous_block());
-  vec->get_mutable_contiguous_block().coeffRef(1) = -1.0;
-  EXPECT_EQ(Eigen::Vector3d(1.0, -1.0, 3.0), vec->get_contiguous_block());
+  EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), vec->get_contiguous_vector());
+  vec->get_mutable_contiguous_vector().coeffRef(1) = -1.0;
+  EXPECT_EQ(Eigen::Vector3d(1.0, -1.0, 3.0), vec->get_contiguous_vector());
 }
 
 // Tests that the BasicVector<double> is initialized to NaN.

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -24,6 +24,15 @@ GTEST_TEST(BasicVectorTest, SetZero) {
   EXPECT_EQ(Eigen::Vector3d(0, 0, 0), vec->get_value());
 }
 
+// Verifies BasicVector is contiguous in memory.
+GTEST_TEST(BasicVectorTest, IsContiguoys) {
+  auto vec = BasicVector<double>::Make(1.0, 2.0, 3.0);
+  EXPECT_TRUE(vec->is_contiguous());
+  EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), vec->get_contiguous_block());
+  vec->get_mutable_contiguous_block().coeffRef(1) = -1.0;
+  EXPECT_EQ(Eigen::Vector3d(1.0, -1.0, 3.0), vec->get_contiguous_block());
+}
+
 // Tests that the BasicVector<double> is initialized to NaN.
 GTEST_TEST(BasicVectorTest, DoubleInitiallyNaN) {
   BasicVector<double> vec(3);

--- a/drake/systems/framework/test/basic_vector_test.cc
+++ b/drake/systems/framework/test/basic_vector_test.cc
@@ -28,6 +28,7 @@ GTEST_TEST(BasicVectorTest, SetZero) {
 GTEST_TEST(BasicVectorTest, IsContiguoys) {
   auto vec = BasicVector<double>::Make(1.0, 2.0, 3.0);
   EXPECT_TRUE(vec->is_contiguous());
+  EXPECT_TRUE(vec->IsContiguous());
   EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), vec->get_contiguous_block());
   vec->get_mutable_contiguous_block().coeffRef(1) = -1.0;
   EXPECT_EQ(Eigen::Vector3d(1.0, -1.0, 3.0), vec->get_contiguous_block());

--- a/drake/systems/framework/test/subvector_test.cc
+++ b/drake/systems/framework/test/subvector_test.cc
@@ -237,36 +237,6 @@ GTEST_TEST(SubvectorIsContiguous, WithinContiguousSubvector) {
   EXPECT_EQ(Eigen::Vector2d(3.0, -1.0), subsubvec.get_contiguous_vector());
 }
 
-// Verify that Subvector cannot can map a contiguous block of memory within a
-// non-contiguous Supervector even if the block actually is contiguous in
-// memory. This is a limitation of our current implementation however, there are
-// no use cases like this in our code-base.
-GTEST_TEST(SubvectorIsContiguous, WithinContiguousPartOfASupervector) {
-  auto vector1 = BasicVector<double>::Make({1, 2, 3, 4});
-  auto vector2 = BasicVector<double>::Make({5, 6, 7, 8, 9, 10});
-  // Concatenate into supervector = {vector1, vector2}.
-  auto supervector = std::make_unique<Supervector<double>>(
-      std::vector<VectorBase<double>*>{vector1.get(), vector2.get()});
-
-  // Build a Supervector and verify it indeed is the concatenation of vector1
-  // and vector2.
-  VectorX<double> expected_supervector_value(supervector->size());
-  expected_supervector_value.segment(0, 4) = vector1->get_value();
-  expected_supervector_value.segment(4, 6) = vector2->get_value();
-  EXPECT_EQ(expected_supervector_value.rows(), supervector->size());
-  EXPECT_EQ(expected_supervector_value.cols(), 1);
-  for (int i = 0; i < supervector->size(); ++i) {
-    EXPECT_EQ(expected_supervector_value[i], supervector->GetAtIndex(i));
-  }
-
-  // Create a Subvector into a contiguous chunk of the Supervector.
-  Subvector<double> subvec(
-      supervector.get(), 5 /* first element */, 3 /* size */);
-
-  // subvec is considered non-contiguous since it maps into a Supervector.
-  EXPECT_FALSE(subvec.is_contiguous());
-}
-
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/test/subvector_test.cc
+++ b/drake/systems/framework/test/subvector_test.cc
@@ -218,6 +218,7 @@ GTEST_TEST(SubvectorIsContiguous, WithinBasicVector) {
   auto vector = BasicVector<double>::Make({1, 2, 3, 4, 5, 6});
   Subvector<double> subvec(vector.get(), 1 /* first element */, 2 /* size */);
   EXPECT_TRUE(subvec.is_contiguous());
+  EXPECT_TRUE(subvec.IsContiguous());
   EXPECT_EQ(Eigen::Vector2d(2.0, 3.0), subvec.get_contiguous_block());
   subvec.get_mutable_contiguous_block().coeffRef(1) = -1.0;
   EXPECT_EQ(Eigen::Vector2d(2.0, -1.0), subvec.get_contiguous_block());
@@ -230,7 +231,9 @@ GTEST_TEST(SubvectorIsContiguous, WithinContiguousSubvector) {
   Subvector<double> subvec(vector.get(), 1 /* first element */, 3 /* size */);
   Subvector<double> subsubvec(&subvec, 1 /* first element */, 2 /* size */);
   EXPECT_TRUE(subvec.is_contiguous());
+  EXPECT_TRUE(subvec.IsContiguous());
   EXPECT_TRUE(subsubvec.is_contiguous());
+  EXPECT_TRUE(subsubvec.IsContiguous());
   EXPECT_EQ(Eigen::Vector3d(2.0, 3.0, 4.0), subvec.get_contiguous_block());
   EXPECT_EQ(Eigen::Vector2d(3.0, 4.0), subsubvec.get_contiguous_block());
   subsubvec.get_mutable_contiguous_block().coeffRef(1) = -1.0;
@@ -264,6 +267,7 @@ GTEST_TEST(SubvectorIsContiguous, WithinContiguousPartOfASupervector) {
   // Even though the original Supervector is not contiguous in memory, the
   // Subvector is.
   EXPECT_TRUE(subvec.is_contiguous());
+  EXPECT_TRUE(subvec.IsContiguous());
 
   // Verify it points to the appropriate chunk of memory.
   EXPECT_EQ(Eigen::Vector3d(6.0, 7.0, 8.0), subvec.get_contiguous_block());
@@ -271,6 +275,7 @@ GTEST_TEST(SubvectorIsContiguous, WithinContiguousPartOfASupervector) {
   // Create an extra layer of indirection to verify correctness.
   Subvector<double> subsubvec(&subvec, 1 /* first element */, 2 /* size */);
   EXPECT_TRUE(subsubvec.is_contiguous());
+  EXPECT_TRUE(subsubvec.IsContiguous());
   EXPECT_EQ(Eigen::Vector2d(7.0, 8.0), subsubvec.get_contiguous_block());
 
   // Verify we can change an entry through subsubvec and we can see the result

--- a/drake/systems/framework/test/subvector_test.cc
+++ b/drake/systems/framework/test/subvector_test.cc
@@ -213,7 +213,7 @@ TEST_F(SubvectorTest, PlusEqScaled) {
 }
 
 // Verifies we can request a contiguous-in-memory Eigen vector from Subvector
-// when the original vector being subdivided is a contiguous BasicVector.
+// when the original vector being sliced is a contiguous BasicVector.
 GTEST_TEST(SubvectorIsContiguous, WithinBasicVector) {
   auto vector = BasicVector<double>::Make({1, 2, 3, 4, 5, 6});
   Subvector<double> subvec(vector.get(), 1 /* first element */, 2 /* size */);
@@ -224,7 +224,7 @@ GTEST_TEST(SubvectorIsContiguous, WithinBasicVector) {
 }
 
 // Verifies we can request a contiguous-in-memory Eigen vector from Subvector
-// when the original vector being subdivided is a contiguous Subvector.
+// when the original vector being sliced is a contiguous Subvector.
 GTEST_TEST(SubvectorIsContiguous, WithinContiguousSubvector) {
   auto vector = BasicVector<double>::Make({1, 2, 3, 4, 5, 6});
   Subvector<double> subvec(vector.get(), 1 /* first element */, 3 /* size */);

--- a/drake/systems/framework/test/subvector_test.cc
+++ b/drake/systems/framework/test/subvector_test.cc
@@ -212,7 +212,7 @@ TEST_F(SubvectorTest, PlusEqScaled) {
   EXPECT_EQ(orig_vec.GetAtIndex(1), 446);
 }
 
-// Verifies we can request a contiguous in memory Eigen vector from SubVector
+// Verifies we can request a contiguous-in-memory Eigen vector from Subvector
 // when the original vector being subdivided is a contiguous BasicVector.
 GTEST_TEST(SubvectorIsContiguous, WithinBasicVector) {
   auto vector = BasicVector<double>::Make({1, 2, 3, 4, 5, 6});
@@ -223,7 +223,7 @@ GTEST_TEST(SubvectorIsContiguous, WithinBasicVector) {
   EXPECT_EQ(Eigen::Vector2d(2.0, -1.0), subvec.get_contiguous_vector());
 }
 
-// Verifies we can request a contiguous in memory Eigen vector from SubVector
+// Verifies we can request a contiguous-in-memory Eigen vector from Subvector
 // when the original vector being subdivided is a contiguous Subvector.
 GTEST_TEST(SubvectorIsContiguous, WithinContiguousSubvector) {
   auto vector = BasicVector<double>::Make({1, 2, 3, 4, 5, 6});

--- a/drake/systems/framework/test/supervector_test.cc
+++ b/drake/systems/framework/test/supervector_test.cc
@@ -75,6 +75,24 @@ TEST_F(SupervectorTest, Empty) {
   EXPECT_EQ(0, supervector.size());
 }
 
+// A Supervector composed of several chunks is, in general, not contiguous in
+// memory.
+TEST_F(SupervectorTest, IsNotContiguous) {
+  EXPECT_FALSE(supervector_->is_contiguous());
+}
+
+// A Supervector could be contiguous in memory if, for instance, only composed
+// of a single Subvector.
+TEST_F(SupervectorTest, IsContiguous) {
+  auto contiguous_supervector =
+      std::make_unique<Supervector<double>>(
+          std::vector<VectorBase<double>*>{vec1_.get()});
+  EXPECT_TRUE(contiguous_supervector->is_contiguous());
+  for (int i = 0; i < contiguous_supervector->size(); ++i) {
+    EXPECT_EQ(vec1_->GetAtIndex(i), contiguous_supervector->GetAtIndex(i));
+  }
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/test/supervector_test.cc
+++ b/drake/systems/framework/test/supervector_test.cc
@@ -76,56 +76,9 @@ TEST_F(SupervectorTest, Empty) {
   EXPECT_EQ(0, supervector.size());
 }
 
-// A Supervector composed of several chunks is, in general, not contiguous in
-// memory.
-TEST_F(SupervectorTest, IsNotContiguous) {
+// A Supervector is always considered non-contiguous in memory.
+TEST_F(SupervectorTest, IsAlwaysNotContiguous) {
   EXPECT_FALSE(supervector_->is_contiguous());
-  EXPECT_FALSE(supervector_->IsContiguous());
-}
-
-// A Supervector could be contiguous in memory if, for instance, only composed
-// of a single Subvector.
-TEST_F(SupervectorTest, IsContiguous) {
-  auto contiguous_supervector =
-      std::make_unique<Supervector<double>>(
-          std::vector<VectorBase<double>*>{vec1_.get()});
-  EXPECT_TRUE(contiguous_supervector->is_contiguous());
-  EXPECT_TRUE(contiguous_supervector->IsContiguous());
-  for (int i = 0; i < contiguous_supervector->size(); ++i) {
-    EXPECT_EQ(vec1_->GetAtIndex(i), contiguous_supervector->GetAtIndex(i));
-  }
-}
-
-GTEST_TEST(SupervectorIsContiguous, PatologicalCase) {
-  auto long_basic_vector =
-      BasicVector<double>::Make({0, 1, 2, 3, 4, 5, 6, 7, 8});
-  Subvector<double> subvec1(long_basic_vector.get(),
-                            0 /* first element */, 4 /* size */);
-  Subvector<double> subvec2(long_basic_vector.get(),
-                            4 /* first element */, 5 /* size */);
-  EXPECT_TRUE(subvec1.is_contiguous());
-  EXPECT_TRUE(subvec2.is_contiguous());
-  EXPECT_TRUE(subvec1.IsContiguous());
-  EXPECT_TRUE(subvec2.IsContiguous());
-
-  // The two Subvector objects actually map to an entire contiguous chunk of
-  // memory.
-  auto contiguous_supervector =
-      std::make_unique<Supervector<double>>(
-          std::vector<VectorBase<double>*>{&subvec1, &subvec2});
-  EXPECT_TRUE(contiguous_supervector->is_contiguous());
-  // IsContiguous FAILS IN THIS CASE!
-  EXPECT_FALSE(contiguous_supervector->IsContiguous());
-
-  // A slice into contiguous_supervector. The entire slice fits in a contiguous
-  // chunk of memory. However, since it is created from two Subvector objects,
-  // we lost the information about these two slices being adjacent to each
-  // other.
-  Subvector<double> middle_section(
-      contiguous_supervector.get(), 2 /* first element */, 4 /* size */);
-  EXPECT_TRUE(middle_section.is_contiguous());
-  // IsContiguous FAILS IN THIS CASE!
-  EXPECT_FALSE(middle_section.IsContiguous());
 }
 
 }  // namespace

--- a/drake/systems/framework/test/supervector_test.cc
+++ b/drake/systems/framework/test/supervector_test.cc
@@ -76,7 +76,7 @@ TEST_F(SupervectorTest, Empty) {
   EXPECT_EQ(0, supervector.size());
 }
 
-// A Supervector is always considered non-contiguous-in-memory.
+// A Supervector is always considered non-contiguous in memory.
 TEST_F(SupervectorTest, IsAlwaysNotContiguous) {
   EXPECT_FALSE(supervector_->is_contiguous());
 }

--- a/drake/systems/framework/test/supervector_test.cc
+++ b/drake/systems/framework/test/supervector_test.cc
@@ -76,7 +76,7 @@ TEST_F(SupervectorTest, Empty) {
   EXPECT_EQ(0, supervector.size());
 }
 
-// A Supervector is always considered non-contiguous in memory.
+// A Supervector is always considered non-contiguous-in-memory.
 TEST_F(SupervectorTest, IsAlwaysNotContiguous) {
   EXPECT_FALSE(supervector_->is_contiguous());
 }

--- a/drake/systems/framework/test/supervector_test.cc
+++ b/drake/systems/framework/test/supervector_test.cc
@@ -79,6 +79,10 @@ TEST_F(SupervectorTest, Empty) {
 // A Supervector is always considered non-contiguous in memory.
 TEST_F(SupervectorTest, IsAlwaysNotContiguous) {
   EXPECT_FALSE(supervector_->is_contiguous());
+  // These methods abort when called on a supervector.
+  EXPECT_THROW(supervector_->get_contiguous_vector(), std::runtime_error);
+  EXPECT_THROW(supervector_->get_mutable_contiguous_vector(),
+               std::runtime_error);
 }
 
 }  // namespace

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -76,7 +76,7 @@ class VectorBase {
   /// @see is_contiguous()
   bool is_segment_contiguous(int start, int count) const {
     DRAKE_DEMAND(0 <= start && start < size());
-    DRAKE_DEMAND(0 <= count && start <= size());
+    DRAKE_DEMAND(0 <= count && count <= size());
     DRAKE_DEMAND((start + count) <= size());
     return !!get_contiguous_segment_when_possible(start, count);
   }
@@ -108,7 +108,7 @@ class VectorBase {
   Eigen::VectorBlock<const VectorX<T>> get_contiguous_segment(
       int start, int count) const {
     DRAKE_DEMAND(0 <= start && start < size());
-    DRAKE_DEMAND(0 <= count && start <= size());
+    DRAKE_DEMAND(0 <= count && count <= size());
     DRAKE_DEMAND((start + count) <= size());
     auto result = get_contiguous_segment_when_possible(start, count);
     DRAKE_DEMAND(!!result &&
@@ -126,7 +126,7 @@ class VectorBase {
   virtual Eigen::VectorBlock<VectorX<T>> get_mutable_contiguous_segment(
       int start, int count) {
     DRAKE_DEMAND(0 <= start && start < size());
-    DRAKE_DEMAND(0 <= count && start <= size());
+    DRAKE_DEMAND(0 <= count && count <= size());
     DRAKE_DEMAND((start + count) <= size());
     auto result = get_mutable_contiguous_segment_when_possible(start, count);
     DRAKE_DEMAND(!!result &&
@@ -270,26 +270,24 @@ class VectorBase {
     }
   }
 
-  /// Returns a segment of `count` elements with first element at `start` in
-  /// `this` vector as an Eigen::VectorBlock referencing a contiguous block of
-  /// memory, if possible.
-  /// Implementations should ensure this operation is O(1) and allocates no
-  /// memory. This method should return a drake::optional with no value if the
-  /// underlying memory layout is not contiguous or could not be retrieved with
-  /// O(1) complexity.
+  /// Returns a drake::optional to a const Eigen::VectorBlock of `count`
+  /// elements, with first element at `start` in `this` vector, if and only if:
+  /// - the vector's values already lie in contiguous memory,
+  /// - no memory allocation is required,
+  /// - the block can be retrieved in O(1) time.
+  /// Otherwise a drake::optional with no value should be returned.
   /// This is the NVI implementation to get_contiguous_segment() and therefore
   /// implementations are guaranteed to be called with valid `start` and `count`
   /// arguments.
   virtual optional<Eigen::VectorBlock<const VectorX<T>>>
   get_contiguous_segment_when_possible(int start, int count) const = 0;
 
-  /// Returns a mutable segment of `count` elements with first element at
-  /// `start` in `this` vector as a mutable Eigen::VectorBlock referencing a
-  /// contiguous block of memory, if possible.
-  /// Implementations should ensure this operation is O(1) and allocates no
-  /// memory. This method should return a drake::optional with no value if the
-  /// underlying memory layout is not contiguous or could not be retrieved with
-  /// O(1) complexity.
+  /// Returns a drake::optional to a mutable Eigen::VectorBlock of `count`
+  /// elements, with first element at `start` in `this` vector, if and only if:
+  /// - the vector's values already lie in contiguous memory,
+  /// - no memory allocation is required,
+  /// - the block can be retrieved in O(1) time.
+  /// Otherwise a drake::optional with no value should be returned.
   /// This is the NVI implementation to get_mutable_contiguous_segment() and
   /// therefore implementations are guaranteed to be called with valid `start`
   /// and `count` arguments.

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -60,6 +60,45 @@ class VectorBase {
     GetAtIndex(index) = value;
   }
 
+  /// Returns `true` if `this` vector has a contiguous in memory layout.
+  /// It returns `false` otherwise.
+  /// @see get_contiguous_block()
+  bool is_contiguous() const {
+    // Vector is contiguous in memory if first and last elements are separated
+    // exactly by size() elements.
+    return
+        static_cast<int>(&GetAtIndex(size()-1) - &GetAtIndex(0) + 1) == size();
+  }
+
+  /// Returns the entire vector as a contiguous in memory Eigen expression.
+  /// This method aborts in Debug builds if the underlying memory layout is not
+  /// contiguous. No check is performed in Release builds. If unsure whether the
+  /// memory layout is contiguous or not, call VectorBase::is_contiguous().
+  ///
+  /// @note The returned Eigen expression cannot be resized and attemps to
+  /// do so will abort your application.
+  ///
+  /// @see is_contiguous()
+  virtual const Eigen::Map<const VectorX<T>> get_contiguous_block() const {
+    DRAKE_ASSERT(this->is_contiguous());
+    return Eigen::Map<const VectorX<T>>(&GetAtIndex(0), size());
+  }
+
+  /// Returns the entire vector as a mutable, contiguous in memory, Eigen
+  /// expression.
+  /// This method aborts in Debug builds if the underlying memory layout is not
+  /// contiguous. No check is performed in Release builds. If unsure whether the
+  /// memory layout is contiguous or not, call VectorBase::is_contiguous().
+  ///
+  /// @note Even though entries are mutable, the returned Eigen expression
+  /// cannot be resized and attemps to do so will abort your application.
+  ///
+  /// @see is_contiguous()
+  virtual Eigen::Map<VectorX<T>> get_mutable_contiguous_block() {
+    DRAKE_ASSERT(this->is_contiguous());
+    return Eigen::Map<VectorX<T>>(&GetAtIndex(0), size());
+  }
+
   /// Replaces the entire vector with the contents of @p value. Throws
   /// std::runtime_error if @p value is not a column vector with size() rows.
   ///

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -61,7 +61,6 @@ class VectorBase {
   }
 
   /// Returns `true` if `this` vector has a contiguous in memory layout.
-  /// It returns `false` otherwise.
   /// @see get_contiguous_block()
   bool is_contiguous() const {
     // Vector is contiguous in memory if first and last elements are separated
@@ -70,7 +69,19 @@ class VectorBase {
         static_cast<int>(&GetAtIndex(size()-1) - &GetAtIndex(0) + 1) == size();
   }
 
-  /// Returns the entire vector as a contiguous in memory Eigen expression.
+  /// Returns `true` if `this` vector has a contiguous in memory layout.
+  /// @see get_contiguous_block()
+  bool IsContiguous() const {
+    return IsContiguousWithinRange(0, size() - 1);
+  }
+
+  /// Returns `true` if `this` vector has a contiguous in memory layout within
+  /// the range of indexes `start` to `end`.
+  /// @see IsContiguous()
+  virtual bool IsContiguousWithinRange(int start, int end) const = 0;
+
+  /// Returns the entire vector as an Eigen expression stored in a contiguous
+  /// block of memory, if possible.
   /// This method aborts in Debug builds if the underlying memory layout is not
   /// contiguous. No check is performed in Release builds. If unsure whether the
   /// memory layout is contiguous or not, call VectorBase::is_contiguous().
@@ -84,8 +95,8 @@ class VectorBase {
     return Eigen::Map<const VectorX<T>>(&GetAtIndex(0), size());
   }
 
-  /// Returns the entire vector as a mutable, contiguous in memory, Eigen
-  /// expression.
+  /// Returns the entire vector as a mutable Eigen expression stored in a
+  /// contiguous block of memory, if possible.
   /// This method aborts in Debug builds if the underlying memory layout is not
   /// contiguous. No check is performed in Release builds. If unsure whether the
   /// memory layout is contiguous or not, call VectorBase::is_contiguous().

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -78,7 +78,7 @@ class VectorBase {
     DRAKE_DEMAND(0 <= start && start < size());
     DRAKE_DEMAND(0 <= count && count <= size());
     DRAKE_DEMAND((start + count) <= size());
-    return !!get_contiguous_segment_when_possible(start, count);
+    return !!try_getting_contiguous_segment(start, count);
   }
 
   /// Returns the entire vector as an Eigen::VectorBlock referencing a
@@ -110,7 +110,7 @@ class VectorBase {
     DRAKE_DEMAND(0 <= start && start < size());
     DRAKE_DEMAND(0 <= count && count <= size());
     DRAKE_DEMAND((start + count) <= size());
-    auto result = get_contiguous_segment_when_possible(start, count);
+    auto result = try_getting_contiguous_segment(start, count);
     DRAKE_DEMAND(!!result &&
         "This vector does not have a contiguous contiguous-in-memory layout. "
         "See is_contiguous()");
@@ -128,7 +128,7 @@ class VectorBase {
     DRAKE_DEMAND(0 <= start && start < size());
     DRAKE_DEMAND(0 <= count && count <= size());
     DRAKE_DEMAND((start + count) <= size());
-    auto result = get_mutable_contiguous_segment_when_possible(start, count);
+    auto result = try_getting_mutable_contiguous_segment(start, count);
     DRAKE_DEMAND(!!result &&
         "This vector does not have a contiguous contiguous-in-memory layout. "
         "See is_contiguous()");
@@ -280,7 +280,7 @@ class VectorBase {
   /// implementations are guaranteed to be called with valid `start` and `count`
   /// arguments.
   virtual optional<Eigen::VectorBlock<const VectorX<T>>>
-  get_contiguous_segment_when_possible(int start, int count) const = 0;
+  try_getting_contiguous_segment(int start, int count) const = 0;
 
   /// Returns a drake::optional to a mutable Eigen::VectorBlock of `count`
   /// elements, with first element at `start` in `this` vector, if and only if:
@@ -292,7 +292,7 @@ class VectorBase {
   /// therefore implementations are guaranteed to be called with valid `start`
   /// and `count` arguments.
   virtual optional<Eigen::VectorBlock<VectorX<T>>>
-  get_mutable_contiguous_segment_when_possible(int start, int count) = 0;
+  try_getting_mutable_contiguous_segment(int start, int count) = 0;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -61,10 +61,8 @@ class VectorBase {
     GetAtIndex(index) = value;
   }
 
-  /// Returns `true` if `this` vector has a contiguous-in-memory layout.
-  /// It returns `false` if either `this` vector doesn't have a contiguous in
-  /// memory layout or whenever retrieving such a layout cannot be performed
-  /// with O(1) complexity.
+  /// @returns `true` if and only if this vector can be expressed as an
+  /// Eigen::VectorBlock in constant time.
   /// @see get_contiguous_vector(), get_mutable_contiguous_vector()
   bool is_contiguous() const {
     return is_segment_contiguous(0, size());
@@ -74,12 +72,12 @@ class VectorBase {
   /// `start` in `this` vector has a contiguous-in-memory layout.
   /// This method aborts if:
   ///  - `start` is out-of-bounds,
-  ///  - `count` is either negative or larger than size(),
-  ///  - A contiguous segment cannot be retrieved.
+  ///  - `count` is either negative or larger than size()
   /// @see is_contiguous()
   bool is_segment_contiguous(int start, int count) const {
     DRAKE_DEMAND(0 <= start && start < size());
     DRAKE_DEMAND(0 <= count && start <= size());
+    DRAKE_DEMAND((start + count) <= size());
     return !!get_contiguous_segment_when_possible(start, count);
   }
 
@@ -102,7 +100,7 @@ class VectorBase {
   }
 
   /// Returns a segment of `count` elements with first element at `start` in
-  /// `this` vector as a Eigen::VectorBlock referencing a contiguous block of
+  /// `this` vector as an Eigen::VectorBlock referencing a contiguous block of
   /// memory, if possible.
   /// This method aborts if the underlying memory layout is not contiguous or
   /// could not be retrieved with O(1) complexity.
@@ -111,6 +109,7 @@ class VectorBase {
       int start, int count) const {
     DRAKE_DEMAND(0 <= start && start < size());
     DRAKE_DEMAND(0 <= count && start <= size());
+    DRAKE_DEMAND((start + count) <= size());
     auto result = get_contiguous_segment_when_possible(start, count);
     DRAKE_DEMAND(!!result &&
         "This vector does not have a contiguous contiguous-in-memory layout. "
@@ -126,6 +125,9 @@ class VectorBase {
   /// @see is_segment_contiguous()
   virtual Eigen::VectorBlock<VectorX<T>> get_mutable_contiguous_segment(
       int start, int count) {
+    DRAKE_DEMAND(0 <= start && start < size());
+    DRAKE_DEMAND(0 <= count && start <= size());
+    DRAKE_DEMAND((start + count) <= size());
     auto result = get_mutable_contiguous_segment_when_possible(start, count);
     DRAKE_DEMAND(!!result &&
         "This vector does not have a contiguous contiguous-in-memory layout. "
@@ -276,7 +278,7 @@ class VectorBase {
   /// underlying memory layout is not contiguous or could not be retrieved with
   /// O(1) complexity.
   /// This is the NVI implementation to get_contiguous_segment() and therefore
-  /// implementations are guranteed to be called with valid `start` and `count`
+  /// implementations are guaranteed to be called with valid `start` and `count`
   /// arguments.
   virtual optional<Eigen::VectorBlock<const VectorX<T>>>
   get_contiguous_segment_when_possible(int start, int count) const = 0;
@@ -289,7 +291,7 @@ class VectorBase {
   /// underlying memory layout is not contiguous or could not be retrieved with
   /// O(1) complexity.
   /// This is the NVI implementation to get_mutable_contiguous_segment() and
-  /// therefore implementations are guranteed to be called with valid `start`
+  /// therefore implementations are guaranteed to be called with valid `start`
   /// and `count` arguments.
   virtual optional<Eigen::VectorBlock<VectorX<T>>>
   get_mutable_contiguous_segment_when_possible(int start, int count) = 0;


### PR DESCRIPTION
Implements a method to request a contiguous Eigen expression from a VectorBase when that operation is possible. Needed for #5947.

Based on discussion [here](https://reviewable.io/reviews/robotlocomotion/drake/5947#-KigtehTHhY_ujrB-pYz)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6049)
<!-- Reviewable:end -->
