### PR TITLE
Preserve the mosek environment across calls to Solve().

### DIFF
--- a/drake/solvers/mosek_solver.h
+++ b/drake/solvers/mosek_solver.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <string>
 
 #include <Eigen/Core>
@@ -15,6 +16,7 @@ class MosekSolver : public MathematicalProgramSolverInterface {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MosekSolver)
 
   MosekSolver() : MathematicalProgramSolverInterface(SolverType::kMosek) {}
+  ~MosekSolver();
 
   /**
    * Defined true if Mosek was included during compilation, false otherwise.
@@ -22,6 +24,15 @@ class MosekSolver : public MathematicalProgramSolverInterface {
   bool available() const override;
 
   SolutionResult Solve(MathematicalProgram& prog) const override;
+
+ private:
+  // This is a void* to avoid needing to refer to types from the Mosek
+  // API if we're building without Mosek.  Note that both of these are
+  // mutable to allow latching the allocation of mosek_env_ during the
+  // first call so Solve() (which avoids grabbing a Mosek license
+  // before we know that we actually want one).
+  mutable void* mosek_env_{nullptr};
+  mutable std::mutex env_mutex_;
 };
 
 }  // namespace solvers

--- a/drake/solvers/no_mosek.cc
+++ b/drake/solvers/no_mosek.cc
@@ -4,8 +4,14 @@
 
 #include <stdexcept>
 
+#include "drake/common/drake_assert.h"
+
 namespace drake {
 namespace solvers {
+
+MosekSolver::~MosekSolver() {
+  DRAKE_ASSERT(mosek_env_ == nullptr);
+}
 
 bool MosekSolver::available() const {
   return false;


### PR DESCRIPTION
Most importantly, this holds the lock from the license server (which
can take a while to get) and significantly improves performance on
longer lived problems using remote licenses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6054)
<!-- Reviewable:end -->
