### PR TITLE
Removes DepthSensorOutput<T>::kError since NaN is not comparable.

### DIFF
--- a/drake/systems/sensors/depth_sensor.cc
+++ b/drake/systems/sensors/depth_sensor.cc
@@ -171,16 +171,16 @@ void DepthSensor::DoCalcOutput(const systems::Context<double>& context,
     if (distances[i] < 0) {
       // Infinity distance measurements show up as -1.
       if (distances[i] == -1) {
-        distances[i] = DepthSensorOutput<double>::kTooFar;
+        distances[i] = DepthSensorOutput<double>::GetTooFarDistance();
       } else {
         drake::log()->warn("Measured distance was < 0 and != -1: " +
                            std::to_string(distances[i]));
-        distances[i] = DepthSensorOutput<double>::kError;
+        distances[i] = DepthSensorOutput<double>::GetErrorDistance();
       }
     } else if (distances[i] > specification_.max_range()) {
-      distances[i] = DepthSensorOutput<double>::kTooFar;
+      distances[i] = DepthSensorOutput<double>::GetTooFarDistance();
     } else if (distances[i] < specification_.min_range()) {
-      distances[i] = DepthSensorOutput<double>::kTooClose;
+      distances[i] = DepthSensorOutput<double>::GetTooCloseDistance();
     }
   }
 

--- a/drake/systems/sensors/depth_sensor.h
+++ b/drake/systems/sensors/depth_sensor.h
@@ -76,10 +76,12 @@ namespace sensors {
 /// distance is less than  the sensor's minimum sensing range, a value of
 /// DepthSensor::kTooClose is provided.
 ///
-/// DepthSensor::kError is defined for use when a sensing error occurs. It is
-/// not expected to occur in this system's output because it models an ideal
-/// sensor in which sensing errors do not occur. It is expected to be used by
-/// non-ideal depth sensors.
+/// Sensing errors can be expressed using a distance value of
+/// DepthSensorOutput::GetErrorDistance(), and detected using
+/// DepthSensorOutput::IsError() or DepthSensorOutput::IsValid(). It is not
+/// expected to occur in this system's output because it models an ideal sensor
+/// in which sensing errors do not occur. Sensing errors are expected to be used
+/// by non-ideal depth sensors.
 ///
 /// The second output port contains a PoseVector, which is `X_WS`, i.e., the
 /// transform from this sensor's frame to the world frame. It is useful for

--- a/drake/systems/sensors/depth_sensor_output.h
+++ b/drake/systems/sensors/depth_sensor_output.h
@@ -19,27 +19,47 @@ class DepthSensorOutput : public BasicVector<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DepthSensorOutput)
 
-  /// The depth value when an error occurs in obtaining the measurement.
-  static constexpr double kError{std::numeric_limits<double>::quiet_NaN()};
-
-  /// The depth value when the max sensing range is exceeded.
-  static constexpr double kTooFar{std::numeric_limits<double>::infinity()};
-
-  /// The depth value when the min sensing range is violated because the object
-  /// being sensed is too close. Note that this
-  /// <a href="http://www.ros.org/reps/rep-0117.html">differs from ROS</a>,
-  /// which uses negative infinity in this scenario. Drake uses zero because it
-  /// results in less devastating bugs when users fail to check for the lower
-  /// limit being hit and using negative infinity does not prevent users from
-  /// writing bad code.
-  static constexpr double kTooClose{0};
-
   /// Default constructor.  Sets all rows to zero.
   ///
   /// @param[in] spec The sensor specification. A member variable alias is
   /// maintained. Thus, the lifespan of the reference object must exceed the
   /// lifespan of this class' instance.
   explicit DepthSensorOutput(const DepthSensorSpecification& spec);
+
+  /// @name Depth value methods
+  //@{
+
+  /// Returns the depth value when the max sensing range is exceeded. This value
+  /// can be used in conjunction with IsTooFar().
+  static double GetTooFarDistance();
+
+  /// Returns true if @p distance is the value returned by GetTooFarDistance().
+  static bool IsTooFar(double distance);
+
+  /// Returns the depth value when the min sensing range is violated because the
+  /// object being sensed is too close. Note that this
+  /// <a href="http://www.ros.org/reps/rep-0117.html">differs from ROS</a>,
+  /// which uses negative infinity in this scenario. Drake uses zero because it
+  /// results in less devastating bugs when users fail to check for the lower
+  /// limit being hit and using negative infinity does not prevent users from
+  /// writing bad code. This value can be used in conjunction with IsTooClose().
+  static double GetTooCloseDistance();
+
+  /// Returns true if @p distance is the value returned by
+  /// GetTooCloseDistance().
+  static bool IsTooClose(double distance);
+
+  /// Returns the depth value when an error occurs.  This value can be used in
+  /// conjunction with IsError().
+  static double GetErrorDistance();
+
+  /// Returns true if @p distance is the value returned by GetErrorDistance().
+  static bool IsError(double distance);
+
+  /// Returns true if @p distance is valid. It is valid when it is not erroneous
+  /// and is in the sensor's sensing range.
+  static bool IsValid(double distance);
+  //@}
 
   /// @name Getters and Setters
   //@{
@@ -60,13 +80,8 @@ class DepthSensorOutput : public BasicVector<T> {
   /// @throws std::runtime_error if @p yaw_index or @p pitch_index is invalid.
   double GetDistance(int yaw_index, int pitch_index) const;
 
-  /// Returns the number of valid distance measurements within this output. This
-  /// excludes the following depth values:
-  ///
-  ///   - DepthSensor::kError
-  ///   - DepthSensor::kTooFar
-  ///   - DepthSensor::kTooClose
-  ///
+  /// Returns the number of valid distance measurements within this output. A
+  /// value's validity is determined by IsValid().
   int GetNumValidDistanceMeasurements() const;
 
   /// Returns a point cloud based on the depth image contained within this


### PR DESCRIPTION
This arose from @kunimatsu-tri's observation in #6055 that `kError` isn't useful since it's not comparable. We cannot do `distance != kError` when `kError` is `std::numeric_limits<double>::quiet_NaN()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6059)
<!-- Reviewable:end -->
