### PR TITLE
Revert "Hide warnings from externals in the Bazel build."

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -6,8 +6,6 @@ build -c opt
 build --force_pic
 build --strip=never
 build --crosstool_top=//tools:default-toolchain
-# Only show warnings from Drake, not from externals.
-build --output_filter="^//"
 
 # Default test options.
 test --test_output=errors


### PR DESCRIPTION
Reverts #4925. Our externals don't *produce* warnings, and I just wasted 2½ days (of my own time, not mentioning the time spent by other people I asked for help) trying to figure out why Bazel "wasn't running my rule".

Not 100% sure this is a good idea, but *I* am not seeing the benefit of #4925...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6060)
<!-- Reviewable:end -->
