### PR TITLE
Change `maliput::api::Rotation`into class (from struct), and base the implementation on Eigen::Quaternion.

### DIFF
--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -25,6 +25,7 @@ drake_cc_library(
     ],
     deps = [
         "//drake/common",
+        "//drake/math:geometric_transform",
     ],
 )
 

--- a/drake/automotive/maliput/api/lane_data.cc
+++ b/drake/automotive/maliput/api/lane_data.cc
@@ -1,7 +1,6 @@
 #include "drake/automotive/maliput/api/lane_data.h"
 
 #include <iostream>
-// #include <string>
 
 namespace drake {
 namespace maliput {
@@ -12,8 +11,9 @@ std::ostream& operator<<(std::ostream& out, const LaneEnd::Which& which_end) {
 }
 
 std::ostream& operator<<(std::ostream& out, const Rotation& rotation) {
-  return out << "(roll = " << rotation.roll << ", pitch = " << rotation.pitch
-      << ", yaw = " << rotation.yaw << ")";
+  return out << "(roll = " << rotation.roll()
+             << ", pitch = " << rotation.pitch()
+             << ", yaw = " << rotation.yaw() << ")";
 }
 
 std::ostream& operator<<(std::ostream& out, const GeoPosition& geo_position) {

--- a/drake/automotive/maliput/api/road_geometry.cc
+++ b/drake/automotive/maliput/api/road_geometry.cc
@@ -31,6 +31,9 @@ GeoPosition LaneEndGeoPosition(const LaneEnd& lane_end) {
 // orientation of (-s,-r,h).  This is equivalent to a pre-rotation by PI in
 // the s/r plane.
 Rotation ReverseOrientation(const Rotation& rot) {
+  // TODO(maddog@tri.global)  Find a better way to do this, and probably move
+  //                          it into api::Rotation itself.  seancurtis-tri has
+  //                          volunteered, when the time comes.
   const double ca = std::cos(rot.roll());
   const double sa = std::sin(rot.roll());
   const double cb = std::cos(rot.pitch());

--- a/drake/automotive/maliput/api/road_geometry.cc
+++ b/drake/automotive/maliput/api/road_geometry.cc
@@ -31,15 +31,15 @@ GeoPosition LaneEndGeoPosition(const LaneEnd& lane_end) {
 // orientation of (-s,-r,h).  This is equivalent to a pre-rotation by PI in
 // the s/r plane.
 Rotation ReverseOrientation(const Rotation& rot) {
-  const double ca = std::cos(rot.roll);
-  const double sa = std::sin(rot.roll);
-  const double cb = std::cos(rot.pitch);
-  const double sb = std::sin(rot.pitch);
-  const double cg = std::cos(rot.yaw);
-  const double sg = std::sin(rot.yaw);
-  return Rotation(std::atan2(-sa, ca),  // roll
-                  std::atan2(-sb, cb),  // pitch
-                  std::atan2(-sg, -cg));  // yaw
+  const double ca = std::cos(rot.roll());
+  const double sa = std::sin(rot.roll());
+  const double cb = std::cos(rot.pitch());
+  const double sb = std::sin(rot.pitch());
+  const double cg = std::cos(rot.yaw());
+  const double sg = std::sin(rot.yaw());
+  return Rotation::FromRpy(std::atan2(-sa, ca),  // roll
+                           std::atan2(-sb, cb),  // pitch
+                           std::atan2(-sg, -cg));  // yaw
 }
 
 
@@ -68,12 +68,12 @@ double Distance(const GeoPosition& a, const GeoPosition& b) {
 // TODO(maddog@tri.global)  This should probably be a method of Rotation, and or
 //                          consolidated with something else somehow.
 GeoPosition Rotate(const Rotation& rot, const GeoPosition& in) {
-  const double sa = std::sin(rot.roll);
-  const double ca = std::cos(rot.roll);
-  const double sb = std::sin(rot.pitch);
-  const double cb = std::cos(rot.pitch);
-  const double sg = std::sin(rot.yaw);
-  const double cg = std::cos(rot.yaw);
+  const double sa = std::sin(rot.roll());
+  const double ca = std::cos(rot.roll());
+  const double sb = std::sin(rot.pitch());
+  const double cb = std::cos(rot.pitch());
+  const double sg = std::sin(rot.yaw());
+  const double cg = std::cos(rot.yaw());
 
   return GeoPosition(
       ((cb * cg) * in.x()) +

--- a/drake/automotive/maliput/api/test/lane_data_test.cc
+++ b/drake/automotive/maliput/api/test/lane_data_test.cc
@@ -7,6 +7,7 @@
 namespace drake {
 namespace maliput {
 namespace api {
+namespace {
 
 #define CHECK_ALL_LANE_POSITION_ACCESSORS(dut, _s, _r, _h)       \
   do {                                                           \
@@ -117,6 +118,91 @@ GTEST_TEST(GeoPositionTest, ComponentSetters) {
 
 #undef CHECK_ALL_GEO_POSITION_ACCESSORS
 
+// An arbitrary very small number (that passes the tests).
+const double kRotationTolerance = 1e-15;
+
+#define CHECK_ALL_ROTATION_ACCESSORS(dut, _w, _x, _y, _z, _ro, _pi, _ya) \
+  do {                                                                  \
+    EXPECT_TRUE(CompareMatrices(dut.quat().coeffs(),                    \
+                                Vector4<double>(_x, _y, _z, _w),        \
+                                kRotationTolerance));                   \
+    EXPECT_TRUE(CompareMatrices(dut.rpy(),                              \
+                                Vector3<double>(_ro, _pi, _ya),         \
+                                kRotationTolerance));                   \
+    EXPECT_NEAR(dut.roll(), _ro, kRotationTolerance);                   \
+    EXPECT_NEAR(dut.pitch(), _pi, kRotationTolerance);                  \
+    EXPECT_NEAR(dut.yaw(), _ya, kRotationTolerance);                    \
+  } while (0)
+
+
+class RotationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    twist_quat_ = Quaternion<double> (
+        Eigen::AngleAxis<double>(M_PI * 2. / 3.,
+                                 Vector3<double>(1.0, 1.0, 1.0).normalized()));
+    twist_roll_ = M_PI / 2.;
+    twist_pitch_ = 0.;
+    twist_yaw_ = M_PI / 2.;
+  }
+
+  Quaternion<double> twist_quat_;
+  double twist_roll_;
+  double twist_pitch_;
+  double twist_yaw_;
+};
+
+
+TEST_F(RotationTest, DefaultConstructor) {
+  // Check that default constructor obeys its contract.
+  Rotation dut;
+  CHECK_ALL_ROTATION_ACCESSORS(dut, 1., 0., 0., 0., 0., 0., 0.);
+}
+
+
+TEST_F(RotationTest, ConstructionFromQuaternion) {
+  // Check the conversion-construction from a Quaternion.
+  const Quaternion<double> q(
+      Eigen::AngleAxis<double>(M_PI * 2. / 3.,
+                               Vector3<double>(1.0, 1.0, 1.0).normalized()));
+  Rotation dut = Rotation::FromQuat(twist_quat_);
+  CHECK_ALL_ROTATION_ACCESSORS(
+      dut, twist_quat_.w(), twist_quat_.x(), twist_quat_.y(), twist_quat_.z(),
+      twist_roll_, twist_pitch_, twist_yaw_);
+}
+
+
+TEST_F(RotationTest, ConstructionFromRpyVector) {
+  // Check the conversion-construction from a 3-vector of roll, pitch, yaw.
+  Rotation dut = Rotation::FromRpy(Vector3<double>(
+      twist_roll_, twist_pitch_, twist_yaw_));
+  CHECK_ALL_ROTATION_ACCESSORS(
+      dut, twist_quat_.w(), twist_quat_.x(), twist_quat_.y(), twist_quat_.z(),
+      twist_roll_, twist_pitch_, twist_yaw_);
+}
+
+
+TEST_F(RotationTest, ConstructionFromRpyComponents) {
+  // Check the conversion-construction from individual roll, pitch, yaw.
+  Rotation dut = Rotation::FromRpy(twist_roll_, twist_pitch_, twist_yaw_);
+  CHECK_ALL_ROTATION_ACCESSORS(
+      dut, twist_quat_.w(), twist_quat_.x(), twist_quat_.y(), twist_quat_.z(),
+      twist_roll_, twist_pitch_, twist_yaw_);
+}
+
+
+TEST_F(RotationTest, QuaternionSetter) {
+  // Check the vector-based setter.
+  Rotation dut = Rotation::FromRpy(23., 75., 0.567);
+  dut.set_quat(twist_quat_);
+  CHECK_ALL_ROTATION_ACCESSORS(
+      dut, twist_quat_.w(), twist_quat_.x(), twist_quat_.y(), twist_quat_.z(),
+      twist_roll_, twist_pitch_, twist_yaw_);
+}
+
+#undef CHECK_ALL_ROTATION_ACCESSORS
+
+}  // namespace
 }  // namespace api
 }  // namespace maliput
 }  // namespace drake

--- a/drake/automotive/maliput/api/test/maliput_test.cc
+++ b/drake/automotive/maliput/api/test/maliput_test.cc
@@ -79,8 +79,9 @@ GTEST_TEST(MaliputApiTest, TestLaneDataToStringStream) {
   buffer.clear();
 
   // Tests Rotation.
-  buffer << Rotation({1, 2, 3});
-  EXPECT_EQ(buffer.str(), "(roll = 1, pitch = 2, yaw = 3)");
+  buffer << Rotation::FromRpy(M_PI / 5., M_PI / 6., M_PI / 7.);
+  EXPECT_EQ(buffer.str(),
+            "(roll = 0.628319, pitch = 0.523599, yaw = 0.448799)");
   buffer.str("");
   buffer.clear();
 }

--- a/drake/automotive/maliput/dragway/lane.cc
+++ b/drake/automotive/maliput/dragway/lane.cc
@@ -88,7 +88,7 @@ api::GeoPosition Lane::DoToGeoPosition(
 
 api::Rotation Lane::DoGetOrientation(
     const api::LanePosition&) const {
-  return api::Rotation(0, 0, 0);  // roll, pitch, yaw.
+  return api::Rotation();  // Default is Identity.
 }
 
 api::LanePosition Lane::DoToLanePosition(

--- a/drake/automotive/maliput/dragway/test/dragway_test.cc
+++ b/drake/automotive/maliput/dragway/test/dragway_test.cc
@@ -100,9 +100,9 @@ class MaliputDragwayLaneTest : public ::testing::Test {
           // Tests Lane::GetOrientation().
           const api::Rotation rotation =
               lane->GetOrientation(lane_position);
-          EXPECT_DOUBLE_EQ(rotation.roll, 0);
-          EXPECT_DOUBLE_EQ(rotation.pitch, 0);
-          EXPECT_DOUBLE_EQ(rotation.yaw, 0);
+          EXPECT_DOUBLE_EQ(rotation.roll(), 0);
+          EXPECT_DOUBLE_EQ(rotation.pitch(), 0);
+          EXPECT_DOUBLE_EQ(rotation.yaw(), 0);
 
           // Tests Lane::EvalMotionDerivatives().
           //

--- a/drake/automotive/maliput/monolane/builder.cc
+++ b/drake/automotive/maliput/monolane/builder.cc
@@ -109,10 +109,10 @@ double HeadingIntoLane(const api::Lane* const lane,
                        const api::LaneEnd::Which end) {
   switch (end) {
     case api::LaneEnd::kStart: {
-      return lane->GetOrientation({0., 0., 0.}).yaw;
+      return lane->GetOrientation({0., 0., 0.}).yaw();
     }
     case api::LaneEnd::kFinish: {
-      return lane->GetOrientation({lane->length(), 0., 0.}).yaw + M_PI;
+      return lane->GetOrientation({lane->length(), 0., 0.}).yaw() + M_PI;
     }
     default: { DRAKE_ABORT(); }
   }

--- a/drake/automotive/maliput/monolane/lane.cc
+++ b/drake/automotive/maliput/monolane/lane.cc
@@ -170,7 +170,7 @@ api::Rotation Lane::DoGetOrientation(const api::LanePosition& lane_pos) const {
   const double alpha =
       std::atan2(r_hat.z() / cb,
                  ((r_hat.y() * s_hat.x()) - (r_hat.x() * s_hat.y())) / cb);
-  return api::Rotation(alpha, beta, gamma);
+  return api::Rotation::FromRpy(alpha, beta, gamma);
 }
 
 

--- a/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
@@ -55,11 +55,11 @@ GTEST_TEST(MonolaneLanesTest, Rot3) {
 #define EXPECT_ROT_NEAR(actual, expected, tolerance)                 \
   do {                                                               \
     const api::Rotation _actual(actual);                             \
-    const api::Rotation _expected expected;                          \
+    const api::Rotation _expected(api::Rotation::FromRpy expected);  \
     const double _tolerance = (tolerance);                           \
-    EXPECT_NEAR(_actual.yaw, _expected.yaw, _tolerance);             \
-    EXPECT_NEAR(_actual.pitch, _expected.pitch, _tolerance);         \
-    EXPECT_NEAR(_actual.roll, _expected.roll, _tolerance);           \
+    EXPECT_NEAR(_actual.yaw(), _expected.yaw(), _tolerance);         \
+    EXPECT_NEAR(_actual.pitch(), _expected.pitch(), _tolerance);     \
+    EXPECT_NEAR(_actual.roll(), _expected.roll(), _tolerance);       \
   } while (0)
 
 

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -215,7 +215,7 @@ void MaliputRailcar<T>::ImplCalcVelocity(const MaliputRailcarParams<T>& params,
   const Rotation rotation =
       lane_direction.lane->GetOrientation(
           LanePosition(state.s(), params.r(), params.h()));
-  const Eigen::Matrix<T, 3, 3> R_WL = rotation.quat().matrix();
+  const Eigen::Matrix<T, 3, 3> R_WL = rotation.matrix();
   const Vector3<T> v_WC_W = R_WL * v_LC_L;
 
   // TODO(liang.fok) Add support for non-zero rotational velocity. See #5751.

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -188,13 +188,13 @@ void MaliputRailcar<T>::ImplCalcPose(const MaliputRailcarParams<T>& params,
   // against s.
   const Rotation adjusted_rotation =
       (lane_direction.with_s ? rotation :
-          Rotation(-rotation.roll,
-                   -rotation.pitch,
-                   atan2(-sin(rotation.yaw), -cos(rotation.yaw))));
+       Rotation::FromRpy(-rotation.roll(),
+                         -rotation.pitch(),
+                         atan2(-sin(rotation.yaw()), -cos(rotation.yaw()))));
   pose->set_translation(Eigen::Translation<T, 3>(geo_position.xyz()));
   pose->set_rotation(RollPitchYawToQuaternion(
-      Vector3<T>(adjusted_rotation.roll, adjusted_rotation.pitch,
-                 adjusted_rotation.yaw)));
+      Vector3<T>(adjusted_rotation.roll(), adjusted_rotation.pitch(),
+                 adjusted_rotation.yaw())));
 }
 
 template <typename T>
@@ -215,9 +215,7 @@ void MaliputRailcar<T>::ImplCalcVelocity(const MaliputRailcarParams<T>& params,
   const Rotation rotation =
       lane_direction.lane->GetOrientation(
           LanePosition(state.s(), params.r(), params.h()));
-  const Quaternion<T> q = RollPitchYawToQuaternion(
-      Vector3<T>(rotation.roll, rotation.pitch, rotation.yaw));
-  const Eigen::Matrix<T, 3, 3> R_WL = q.matrix();
+  const Eigen::Matrix<T, 3, 3> R_WL = rotation.quat().matrix();
   const Vector3<T> v_WC_W = R_WL * v_LC_L;
 
   // TODO(liang.fok) Add support for non-zero rotational velocity. See #5751.

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -85,7 +85,7 @@ double GetSVelocity(const RoadOdometry<double>& road_odom) {
   const double vx = road_odom.vel.get_velocity().translational().x();
   const double vy = road_odom.vel.get_velocity().translational().y();
 
-  return vx * std::cos(rot.yaw) + vy * std::sin(rot.yaw);
+  return vx * std::cos(rot.yaw()) + vy * std::sin(rot.yaw());
 }
 
 }  // namespace pose_selector


### PR DESCRIPTION
This is the third of several PR's which make the basic maliput::api data types interoperate more smoothly with Eigen. Primarily, the revised interface provides conversions to/from Eigen types, in particular `Quaternion` in this case (though roll/pitch/yaw expressions are still provided). Secondarily, the implementation uses the Eigen type for its internal storage.

This PR only does minimal repair at call sites; it does not attempt to optimize use of the new API at call sites.

This addresses part of #4542.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6062)
<!-- Reviewable:end -->
