### PR TITLE
Fix RobotLocomotion/lcmtypes repo name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -190,7 +190,7 @@ github_archive(
 
 github_archive(
     name = "robotlocomotion_lcmtypes",
-    repository = "robotlocomotion/lcmtypes",
+    repository = "RobotLocomotion/lcmtypes",
     commit = "4bd59a1b62a1eca31a2550b37f356426bc793d67",
     build_file = "tools/robotlocomotion_lcmtypes.BUILD",
     sha256 = "d4b7b006ffd8918ecafda050d94c18388d9cd113a8849263bbedc7c488144ed4",


### PR DESCRIPTION
GitHub URLs may not be case-sensitive, but CloudFront/S3 URLs (where the archives are mirrored) are.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6066)
<!-- Reviewable:end -->
