### PR TITLE
MBT mobilizer class.

### DIFF
--- a/drake/multibody/multibody_tree/BUILD
+++ b/drake/multibody/multibody_tree/BUILD
@@ -22,19 +22,31 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "mobilizers",
+    name = "multibody_tree_topology",
     srcs = [],
-    hdrs = ["mobilizer.h"],
+    hdrs = [
+        "multibody_tree_topology.h",
+    ],
     deps = [
-        "//drake/common:type_safe_index",
+        ":multibody_tree_indexes",
     ],
 )
 
 drake_cc_library(
-    name = "multibody_tree",
+    name = "multibody_tree_element",
+    srcs = [],
+    hdrs = [
+        "multibody_tree_element.h",
+    ],
+    deps = [
+        ":multibody_tree_topology",
+    ],
+)
+
+drake_cc_library(
+    name = "bodies_and_frames",
     srcs = [
         "fixed_offset_frame.cc",
-        "multibody_tree.cc",
         "rigid_body.cc",
     ],
     hdrs = [
@@ -42,12 +54,40 @@ drake_cc_library(
         "fixed_offset_frame.h",
         "frame.h",
         "frame_base.h",
-        "multibody_tree.h",
-        "multibody_tree_element.h",
-        "multibody_tree_topology.h",
         "rigid_body.h",
     ],
     deps = [
+        ":multibody_tree_element",
+        ":spatial_inertia",
+        "//drake/common:autodiff",
+    ],
+)
+
+drake_cc_library(
+    name = "mobilizers",
+    srcs = ["revolute_mobilizer.cc"],
+    hdrs = [
+        "mobilizer.h",
+        "mobilizer_impl.h",
+        "revolute_mobilizer.h",
+    ],
+    deps = [
+        ":bodies_and_frames",
+        "//drake/common:autodiff",
+        "//drake/common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
+    name = "multibody_tree",
+    srcs = [
+        "multibody_tree.cc",
+    ],
+    hdrs = [
+        "multibody_tree.h",
+    ],
+    deps = [
+        ":bodies_and_frames",
         ":mobilizers",
         ":multibody_tree_indexes",
         ":spatial_inertia",

--- a/drake/multibody/multibody_tree/BUILD
+++ b/drake/multibody/multibody_tree/BUILD
@@ -22,6 +22,15 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "mobilizers",
+    srcs = [],
+    hdrs = ["mobilizer.h"],
+    deps = [
+        "//drake/common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
     name = "multibody_tree",
     srcs = [
         "fixed_offset_frame.cc",
@@ -39,6 +48,7 @@ drake_cc_library(
         "rigid_body.h",
     ],
     deps = [
+        ":mobilizers",
         ":multibody_tree_indexes",
         ":spatial_inertia",
         "//drake/common:autodiff",

--- a/drake/multibody/multibody_tree/body.h
+++ b/drake/multibody/multibody_tree/body.h
@@ -133,14 +133,9 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
   // set of private Body methods.
   friend class internal::BodyAttorney<T>;
 
-  // Implementation for MultibodyTreeElement::DoFinalize().
+  // Implementation for MultibodyTreeElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each body retrieves its topology
   // from the parent MultibodyTree.
-  //void DoFinalize(const MultibodyTree<T>& tree) final {
-  //  topology_ = tree.get_topology().bodies[this->get_index()];
-  //  body_frame_.Finalize(tree);
-  //}
-
   void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
     topology_ = tree_topology.bodies[this->get_index()];
     body_frame_.SetTopology(tree_topology);

--- a/drake/multibody/multibody_tree/body.h
+++ b/drake/multibody/multibody_tree/body.h
@@ -136,9 +136,14 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
   // Implementation for MultibodyTreeElement::DoFinalize().
   // At MultibodyTree::Finalize() time, each body retrieves its topology
   // from the parent MultibodyTree.
-  void DoFinalize(const MultibodyTree<T>& tree) final {
-    topology_ = tree.get_topology().bodies[this->get_index()];
-    body_frame_.Finalize(tree);
+  //void DoFinalize(const MultibodyTree<T>& tree) final {
+  //  topology_ = tree.get_topology().bodies[this->get_index()];
+  //  body_frame_.Finalize(tree);
+  //}
+
+  void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
+    topology_ = tree_topology.bodies[this->get_index()];
+    body_frame_.SetTopology(tree_topology);
   }
 
   // MultibodyTree has access to the mutable BodyFrame through BodyAttorney.

--- a/drake/multibody/multibody_tree/fixed_offset_frame.cc
+++ b/drake/multibody/multibody_tree/fixed_offset_frame.cc
@@ -5,7 +5,6 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/multibody_tree/body.h"
-#include "drake/multibody/multibody_tree/multibody_tree.h"
 #include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
 
 namespace drake {

--- a/drake/multibody/multibody_tree/frame.h
+++ b/drake/multibody/multibody_tree/frame.h
@@ -48,12 +48,7 @@ class Frame : public FrameBase<T> {
   explicit Frame(const Body<T>& body) : body_(body) {}
 
  private:
-  // Implementation for MultibodyTreeElement::DoFinalize().
-  //void DoFinalize(const MultibodyTree<T>& tree) final {
-  //  topology_ = tree.get_topology().get_frame(this->get_index());
-  //  DRAKE_ASSERT(topology_.index == this->get_index());
- // }
-
+  // Implementation for MultibodyTreeElement::DoSetTopology().
   void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
     topology_ = tree_topology.get_frame(this->get_index());
     DRAKE_ASSERT(topology_.index == this->get_index());

--- a/drake/multibody/multibody_tree/frame.h
+++ b/drake/multibody/multibody_tree/frame.h
@@ -49,8 +49,13 @@ class Frame : public FrameBase<T> {
 
  private:
   // Implementation for MultibodyTreeElement::DoFinalize().
-  void DoFinalize(const MultibodyTree<T>& tree) final {
-    topology_ = tree.get_topology().get_frame(this->get_index());
+  //void DoFinalize(const MultibodyTree<T>& tree) final {
+  //  topology_ = tree.get_topology().get_frame(this->get_index());
+  //  DRAKE_ASSERT(topology_.index == this->get_index());
+ // }
+
+  void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
+    topology_ = tree_topology.get_frame(this->get_index());
     DRAKE_ASSERT(topology_.index == this->get_index());
   }
 

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -17,49 +17,93 @@ namespace multibody {
 template<typename T> class Body;
 template<typename T> class BodyNode;
 
+/// %Mobilizer is a fundamental object within Drake's multibody engine used to
+/// specify the allowed motions between two Frame objects within a
+/// MultibodyTree. Specifying the allowed motions between two Frame objects
+/// effectively also specifies a kinematic relation between the two bodies
+/// associtated with those two frames. Consider the following example to build a
+/// simple pendulum system:
+///
+/// @code
+/// MultibodyTree<double> model;
+/// // ... Code here to setup quantities below as mass, com, X_BP, etc. ...
+/// const Body<double>& pendulum =
+///   model.AddBody<RigidBody>(SpatialInertia<double>(mass, com, unit_inertia));
+/// // We will connect the pendulum body to the world frame using a
+/// // RevoluteMobilizer. To do so we define a pin frame P rigidly attached to
+/// // the pendulum body.
+/// FixedOffsetFrame<double>& pin_frame =
+///   model.AddFrame<FixedOffsetFrame>(
+///     pendulum.get_body_frame(),
+///     X_BP /* pose of pin frame P in body frame B */);
+/// // The mobilizer connects the world frame and the pin frame effetively
+/// // adding the single degree of freedom describing this system.
+/// const RevoluteMobilizer<double>& revolute_mobilizer =
+///   model.AddMobilizer<RevoluteMobilizer>(
+///     model.get_world_body().get_body_frame(), /* inboard frame */
+///     pin_frame, /* outboard frame */
+///     Vector3d::UnitZ() /* revolute axis in this case */));
+/// @endcode
+///
+/// A %Mobilizer induces a tree structure within a MultibodyTree
+/// model, connecting an inboard frame to an outboard frame. Every time a
+/// %Mobilizer is added to a MultibodyTree (using the
+/// MultibodyTree::AddMobilizer() method), a number of degrees of
+/// freedom associated with the particular type of %Mobilizer are added to the
+/// multibody system. In the example above for the single pendulum, adding a
+/// RevoluteMobilizer has two purposes:
+/// - It defines the tree structure of the model. World is the "parent" body
+///   while "pendulum" is the "child" body in the MultibodyTree.
+/// - It informs the MultibodyTree of the degress of freedom granted by the
+///   revolute mobilizer between the two frames it connects.
+///
+/// %Mobilizer is an asbtract base class defining the minimum functionality that
+/// derived %Mobilizer objects must implement in order to fully define the
+/// kinematic relationship between the two frames they connect.
+///
+/// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T>
 class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
  public:
-  /// Mobilizer constructor.
+  /// This constructor enforces the minimum requirement to any mobilizer's
+  /// constructor; we must specify the inboard and outboard frames that `this`
+  /// mobilizer connects.
   Mobilizer(const Frame<T>& inboard_frame,
             const Frame<T>& outboard_frame) :
       inboard_frame_(inboard_frame), outboard_frame_(outboard_frame) {}
 
-  // make pure virtual!!!
-  virtual int get_num_positions() const {return 0;};
+  /// Returns the number of generalized coordinates granted by this mobilizer.
+  virtual int get_num_positions() const = 0;
 
-  virtual int get_num_velocities() const {return 0;};
+  /// Returns the number of generalized velocities granted by this mobilizer.
+  virtual int get_num_velocities() const = 0;
 
+  /// Returns a constant reference to the inboard frame.
   const Frame<T>& get_inboard_frame() const {
     return inboard_frame_;
   }
 
+  /// Returns a constant reference to the outboard frame.
   const Frame<T>& get_outboard_frame() const {
     return outboard_frame_;
   }
 
+  /// Returns a constant reference to the body associated with `this`
+  /// mobilizer's inboard frame.
   const Body<T>& get_inboard_body() const {
     return get_inboard_frame().get_body();
   }
 
+  /// Returns a constant reference to the body associated with `this`
+  /// mobilizer's outboard frame.
   const Body<T>& get_outboard_body() const {
     return get_outboard_frame().get_body();
   }
 
-  const MobilizerTopology& get_topology() const { return topology_;}
-
-  //virtual std::unique_ptr<BodyNode<T>> CreateBodyNode(
-  //    const BodyNodeTopology& topology,
-  //    const Body<T>* body, const Mobilizer<T>* mobilizer) const = 0;
-
  private:
-  // Implementation for MultibodyTreeElement::DoFinalize().
+  // Implementation for MultibodyTreeElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each mobilizer retrieves its topology
   // from the parent MultibodyTree.
-  //void DoFinalize(const MultibodyTree<T>& tree) final {
-  //  topology_ = tree.get_topology().mobilizers[this->get_index()];
-  //}
-
   void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
     topology_ = tree_topology.mobilizers[this->get_index()];
   }

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/multibody_tree/frame.h"
+#include "drake/multibody/multibody_tree/multibody_tree_element.h"
+#include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
+#include "drake/multibody/multibody_tree/multibody_tree_topology.h"
+
+namespace drake {
+namespace multibody {
+
+// Forward declarations.
+template<typename T> class Body;
+template<typename T> class BodyNode;
+
+template <typename T>
+class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
+ public:
+  /// Mobilizer constructor.
+  Mobilizer(const Frame<T>& inboard_frame,
+            const Frame<T>& outboard_frame) :
+      inboard_frame_(inboard_frame), outboard_frame_(outboard_frame) {}
+
+  //virtual int get_num_positions() const = 0;
+
+  //virtual int get_num_velocities() const = 0;
+
+  const Frame<T>& get_inboard_frame() const {
+    return inboard_frame_;
+  }
+
+  const Frame<T>& get_outboard_frame() const {
+    return outboard_frame_;
+  }
+
+  const Body<T>& get_inboard_body() const {
+    return get_inboard_frame().get_body();
+  }
+
+  const Body<T>& get_outboard_body() const {
+    return get_outboard_frame().get_body();
+  }
+
+  const MobilizerTopology& get_topology() const { return topology_;}
+
+  //virtual std::unique_ptr<BodyNode<T>> CreateBodyNode(
+  //    const BodyNodeTopology& topology,
+  //    const Body<T>* body, const Mobilizer<T>* mobilizer) const = 0;
+
+ private:
+  // Implementation for MultibodyTreeElement::DoFinalize().
+  // At MultibodyTree::Finalize() time, each mobilizer retrieves its topology
+  // from the parent MultibodyTree.
+  void DoFinalize(const MultibodyTree<T>& tree) final {
+    topology_ = tree.get_topology().mobilizers[this->get_index()];
+  }
+
+  const Frame<T>& inboard_frame_;
+  const Frame<T>& outboard_frame_;
+  MobilizerTopology topology_;
+};
+
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -25,9 +25,10 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
             const Frame<T>& outboard_frame) :
       inboard_frame_(inboard_frame), outboard_frame_(outboard_frame) {}
 
-  //virtual int get_num_positions() const = 0;
+  // make pure virtual!!!
+  virtual int get_num_positions() const {return 0;};
 
-  //virtual int get_num_velocities() const = 0;
+  virtual int get_num_velocities() const {return 0;};
 
   const Frame<T>& get_inboard_frame() const {
     return inboard_frame_;
@@ -55,8 +56,12 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   // Implementation for MultibodyTreeElement::DoFinalize().
   // At MultibodyTree::Finalize() time, each mobilizer retrieves its topology
   // from the parent MultibodyTree.
-  void DoFinalize(const MultibodyTree<T>& tree) final {
-    topology_ = tree.get_topology().mobilizers[this->get_index()];
+  //void DoFinalize(const MultibodyTree<T>& tree) final {
+  //  topology_ = tree.get_topology().mobilizers[this->get_index()];
+  //}
+
+  void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
+    topology_ = tree_topology.mobilizers[this->get_index()];
   }
 
   const Frame<T>& inboard_frame_;

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -43,7 +43,7 @@ template<typename T> class BodyNode;
 /// // to this rotation about the z-axis.
 /// const RevoluteMobilizer<double>& revolute_mobilizer =
 ///   model.AddMobilizer<RevoluteMobilizer>(
-///     model.get_world_body().get_body_frame(), /* inboard frame */
+///     model.get_world_frame(), /* inboard frame */
 ///     pin_frame, /* outboard frame */
 ///     Vector3d::UnitZ() /* revolute axis in this case */));
 /// @endcode

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -49,14 +49,15 @@ template<typename T> class BodyNode;
 /// @endcode
 ///
 /// A %Mobilizer induces a tree structure within a MultibodyTree
-/// model, connecting an inboard frame to an outboard frame. Every time a
+/// model, connecting an inboard (topologically closer to the world) frame to an
+/// outboard (topologically further from the world) frame. Every time a
 /// %Mobilizer is added to a MultibodyTree (using the
 /// MultibodyTree::AddMobilizer() method), a number of degrees of
 /// freedom associated with the particular type of %Mobilizer are added to the
 /// multibody system. In the example above for the single pendulum, adding a
 /// RevoluteMobilizer has two purposes:
-/// - It defines the tree structure of the model. World is the "parent" body
-///   while "pendulum" is the "child" body in the MultibodyTree.
+/// - It defines the tree structure of the model. World is the inboard body
+///   while "pendulum" is the outboard body in the MultibodyTree.
 /// - It informs the MultibodyTree of the degrees of freedom granted by the
 ///   revolute mobilizer between the two frames it connects.
 /// - It defines a permissible motion space spanned by the generalized
@@ -132,22 +133,26 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
     }
   }
 
-  /// Returns the number of generalized coordinates admitted by this mobilizer.
+  /// Returns the number of generalized coordinates granted by this mobilizer.
   /// As an example, consider RevoluteMobilizer, for which
   /// `get_num_positions() == 1` since RevoluteMobilizer adds a single
-  /// rotational degree of freedom about a given axis between the inboard and
-  /// outboard frames. Another example would be a quaternion mobilizer, for
-  /// which this method would return 7 (a quaternion plus a position vector).
+  /// generalized coordinate representing the rotational degree of freedom about
+  /// a given axis between the inboard and outboard frames. Another example
+  /// would be a 6 DOF "free" mobilizer internally using a quaternion
+  /// representation to parametrize free rotations and a position vector to
+  /// parametrize free translations; this method would return 7 (a quaternion
+  /// plus a position vector).
   /// @see get_num_velocities()
   virtual int get_num_positions() const = 0;
 
-  /// Returns the number of generalized velocities admitted by this mobilizer.
+  /// Returns the number of generalized velocities granted by this mobilizer.
+  /// Given that all physics occurs in the generalized velocities space, the
+  /// number of generalized velocities exactly matches the number of degrees of
+  /// freedom granted by the mobilizer.
   /// As an example, consider RevoluteMobilizer, for which
   /// `get_num_velocities() == 1` since for RevoluteMobilizer its one and only
   /// generalized velocity describes the magnitude of the angular velocity about
-  /// a given axis between the inboard and outboard frames. Another example
-  /// would be a quaternion mobilizer, for which this method would return 6 (an
-  /// angular velocity plus a linear velocity).
+  /// a given axis between the inboard and outboard frames.
   /// @see get_num_positions()
   virtual int get_num_velocities() const = 0;
 

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -72,9 +72,17 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   /// the knowledge of the inboard and outboard frames it connects.
   /// Subclasses of %Mobilizer are therefore forced to provide this information
   /// in their respective constructors.
+  /// @throws std::runtime_error if `inboard_frame` and `outboard_frame`
+  /// reference the same frame object.
   Mobilizer(const Frame<T>& inboard_frame,
             const Frame<T>& outboard_frame) :
-      inboard_frame_(inboard_frame), outboard_frame_(outboard_frame) {}
+      inboard_frame_(inboard_frame), outboard_frame_(outboard_frame) {
+    // Verify they are not the same frame.
+    if (&inboard_frame == &outboard_frame) {
+      throw std::runtime_error(
+          "The provided inboard and outboard frames reference the same object");
+    }
+  }
 
   /// Returns the number of generalized coordinates admitted by this mobilizer.
   /// As an example, consider RevoluteMobilizer, for which

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -65,6 +65,8 @@ template<typename T> class BodyNode;
 template <typename T>
 class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Mobilizer)
+
   /// This is the only constructor available for this base class %Mobilizer.
   /// The minimum amount of information that we need to define a %Mobilizer is
   /// the knowledge of the inboard and outboard frames it connects.

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -20,8 +20,8 @@ template<typename T> class BodyNode;
 /// %Mobilizer is a fundamental object within Drake's multibody engine used to
 /// specify the allowed motions between two Frame objects within a
 /// MultibodyTree. Specifying the allowed motions between two Frame objects
-/// effectively also specifies a kinematic relation between the two bodies
-/// associtated with those two frames. Consider the following example to build a
+/// effectively also specifies a kinematic relationship between the two bodies
+/// associated with those two frames. Consider the following example to build a
 /// simple pendulum system:
 ///
 /// @code
@@ -36,7 +36,7 @@ template<typename T> class BodyNode;
 ///   model.AddFrame<FixedOffsetFrame>(
 ///     pendulum.get_body_frame(),
 ///     X_BP /* pose of pin frame P in body frame B */);
-/// // The mobilizer connects the world frame and the pin frame effetively
+/// // The mobilizer connects the world frame and the pin frame effectively
 /// // adding the single degree of freedom describing this system.
 /// const RevoluteMobilizer<double>& revolute_mobilizer =
 ///   model.AddMobilizer<RevoluteMobilizer>(
@@ -65,17 +65,32 @@ template<typename T> class BodyNode;
 template <typename T>
 class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
  public:
-  /// This constructor enforces the minimum requirement to any mobilizer's
-  /// constructor; we must specify the inboard and outboard frames that `this`
-  /// mobilizer connects.
+  /// This is the only constructor available for this base class %Mobilizer.
+  /// The minimum amount of information that we need to define a %Mobilizer is
+  /// the knowledge of the inboard and outboard frames it connects.
+  /// Subclasses of %Mobilizer are therefore forced to provide this information
+  /// in their respective constructors.
   Mobilizer(const Frame<T>& inboard_frame,
             const Frame<T>& outboard_frame) :
       inboard_frame_(inboard_frame), outboard_frame_(outboard_frame) {}
 
-  /// Returns the number of generalized coordinates granted by this mobilizer.
+  /// Returns the number of generalized coordinates admitted by this mobilizer.
+  /// As an example, consider RevoluteMobilizer, for which
+  /// `get_num_positions() == 1` since RevoluteMobilizer adds a single
+  /// rotational degree of freedom about a given axis between the inboard and
+  /// outboard frames. Another example would be a quaternion mobilizer, for
+  /// which this method would return 7 (a quaternion plus a position vector).
+  /// @see get_num_velocities()
   virtual int get_num_positions() const = 0;
 
-  /// Returns the number of generalized velocities granted by this mobilizer.
+  /// Returns the number of generalized velocities admitted by this mobilizer.
+  /// As an example, consider RevoluteMobilizer, for which
+  /// `get_num_velocities() == 1` since for RevoluteMobilizer its one and only
+  /// generalized velocity describes the magnitude of the angular velocity about
+  /// a given axis between the inboard and outboard frames. Another example
+  /// would be a quaternion mobilizer, for which this method would return 6 (an
+  /// angular velocity plus a linear velocity).
+  /// @see get_num_positions()
   virtual int get_num_velocities() const = 0;
 
   /// Returns a constant reference to the inboard frame.

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -38,9 +38,9 @@ template<typename T> class BodyNode;
 ///     X_BP /* pose of pin frame P in body frame B */);
 /// // The mobilizer connects the world frame and the pin frame effectively
 /// // adding the single degree of freedom describing this system. In this
-/// // regard, the role of a mobilizer is different from that of an equivalent
-/// // constraint removing all other five degrees of freedom but the one related
-/// // to this rotation about the z-axis.
+/// // regard, the the role of a mobilizer is equivalent but conceptually
+/// // different than a set of constraints that effectively remove all degrees
+/// // of freedom but the one permitting rotation about the z-axis.
 /// const RevoluteMobilizer<double>& revolute_mobilizer =
 ///   model.AddMobilizer<RevoluteMobilizer>(
 ///     model.get_world_frame(), /* inboard frame */

--- a/drake/multibody/multibody_tree/mobilizer_impl.h
+++ b/drake/multibody/multibody_tree/mobilizer_impl.h
@@ -18,9 +18,9 @@ namespace multibody {
 /// generalized positions and velocities resolved at compile time as template
 /// parameters. This allows specific mobilizer implementations to only work on
 /// fixed-size Eigen expressions therefore allowing for optimized operations on
-/// fixed-size matrices and discouraging the proliferation of dynamic-sized
-/// Eigen matrices that would otherwise lead to run-time dynamic memory
-/// allocations.
+/// fixed-size matrices. In addition, this layer discourages the proliferation
+/// of dynamic-sized Eigen matrices that would otherwise lead to run-time
+/// dynamic memory allocations.
 /// %MobilizerImpl also provides a number of size specific methods to retrieve
 /// multibody quantities of interest from caching structures. These are common
 /// to all mobilizer implementations and therefore they live in this class.
@@ -28,12 +28,14 @@ namespace multibody {
 /// to implement a custom Mobilizer class.
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
-template <typename T, int  num_positions, int num_velocities>
+template <typename T, int num_positions, int num_velocities>
 class MobilizerImpl : public Mobilizer<T> {
  public:
-  /// This constructor enforces the minimum requirement to any mobilizer's
-  /// constructor; we must specify the inboard and outboard frames that `this`
-  /// mobilizer connects.
+  /// As with Mobilizer this the only constructor available for this base class.
+  /// The minimum amount of information that we need to define a mobilizer is
+  /// the knowledge of the inboard and outboard frames it connects.
+  /// Subclasses of %MobilizerImpl are therefore forced to provide this
+  /// information in their respective constructors.
   MobilizerImpl(const Frame<T>& inboard_frame,
                 const Frame<T>& outboard_frame) :
       Mobilizer<T>(inboard_frame, outboard_frame) {}

--- a/drake/multibody/multibody_tree/mobilizer_impl.h
+++ b/drake/multibody/multibody_tree/mobilizer_impl.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/multibody_tree/frame.h"
+#include "drake/multibody/multibody_tree/mobilizer.h"
+#include "drake/multibody/multibody_tree/multibody_tree_element.h"
+#include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
+#include "drake/multibody/multibody_tree/multibody_tree_topology.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T, int  num_positions, int num_velocities>
+class MobilizerImpl : public Mobilizer<T> {
+ public:
+  // static constexpr int i = 42; discouraged.
+  // See answer in: http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
+  enum : int {nq = num_positions, nv = num_velocities};
+
+  MobilizerImpl(const Frame<T>& inboard_frame,
+                const Frame<T>& outboard_frame) :
+      Mobilizer<T>(inboard_frame, outboard_frame) {}
+
+  int get_num_positions() const final { return nq;}
+  int get_num_velocities() const final { return nv;}
+
+};
+
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/multibody_tree/mobilizer_impl.h
+++ b/drake/multibody/multibody_tree/mobilizer_impl.h
@@ -14,20 +14,41 @@
 namespace drake {
 namespace multibody {
 
+/// Base class for specific Mobilizer implementations with the number of
+/// generalized positions and velocities resolved at compile time as template
+/// parameters. This allows specific mobilizer implementations to only work on
+/// fixed-size Eigen expressions therefore allowing for optimized operations on
+/// fixed-size matrices and discouraging the proliferation of dynamic-sized
+/// Eigen matrices that would otherwise lead to run-time dynamic memory
+/// allocations.
+/// %MobilizerImpl also provides a number of size specific methods to retrieve
+/// multibody quantities of interest from caching structures. These are common
+/// to all mobilizer implementations and therefore they live in this class.
+/// Users should not need to interact with this class directly unless they need
+/// to implement a custom Mobilizer class.
+///
+/// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T, int  num_positions, int num_velocities>
 class MobilizerImpl : public Mobilizer<T> {
  public:
-  // static constexpr int i = 42; discouraged.
-  // See answer in: http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
-  enum : int {nq = num_positions, nv = num_velocities};
-
+  /// This constructor enforces the minimum requirement to any mobilizer's
+  /// constructor; we must specify the inboard and outboard frames that `this`
+  /// mobilizer connects.
   MobilizerImpl(const Frame<T>& inboard_frame,
                 const Frame<T>& outboard_frame) :
       Mobilizer<T>(inboard_frame, outboard_frame) {}
 
+  /// Returns the number of generalized coordinates granted by this mobilizer.
   int get_num_positions() const final { return nq;}
+
+  /// Returns the number of generalized velocities granted by this mobilizer.
   int get_num_velocities() const final { return nv;}
 
+ protected:
+  // Handy enum to grant specific implementations compile time sizes.
+  // static constexpr int i = 42; discouraged.
+  // See answer in: http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
+  enum : int {nq = num_positions, nv = num_velocities};
 };
 
 }  // namespace multibody

--- a/drake/multibody/multibody_tree/mobilizer_impl.h
+++ b/drake/multibody/multibody_tree/mobilizer_impl.h
@@ -31,6 +31,8 @@ namespace multibody {
 template <typename T, int num_positions, int num_velocities>
 class MobilizerImpl : public Mobilizer<T> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MobilizerImpl)
+
   /// As with Mobilizer this the only constructor available for this base class.
   /// The minimum amount of information that we need to define a mobilizer is
   /// the knowledge of the inboard and outboard frames it connects.

--- a/drake/multibody/multibody_tree/multibody_tree.cc
+++ b/drake/multibody/multibody_tree/multibody_tree.cc
@@ -37,12 +37,17 @@ void MultibodyTree<T>::Finalize() {
 
   // Give bodies the chance to perform any finalize-time setup.
   for (const auto& body : owned_bodies_) {
-    body->Finalize(*this);
+    body->SetTopology(topology_);
   }
 
   // Give frames the chance to perform any finalize-time setup.
   for (const auto& frame : owned_frames_) {
-    frame->Finalize(*this);
+    frame->SetTopology(topology_);
+  }
+
+  // Give mobilizers the chance to perform any finalize-time setup.
+  for (const auto& mobilizer : owned_mobilizers_) {
+    mobilizer->SetTopology(topology_);
   }
 
   set_valid_topology();

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -269,7 +269,7 @@ class MultibodyTree {
   ///                      specialized on the same scalar type T as this
   ///                      %MultibodyTree. Notice this is a requirement of this
   ///                      method's signature and therefore an input mobilzer
-  ///                      specialized on a different sacalar type than that of
+  ///                      specialized on a different scalar type than that of
   ///                      this %MultibodyTree's T will fail to compile.
   /// @returns A constant reference of type `MobilizerType` to the created
   ///          mobilizer. This reference which will remain valid for the

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -258,6 +258,11 @@ class MultibodyTree {
   ///
   /// @throws std::logic_error if `mobilizer` is a nullptr.
   /// @throws std::logic_error if Finalize() was already called on `this` tree.
+  /// @throws a std::runtime_error if the new mobilizer attempts to connect a
+  /// frame with itself.
+  /// @throws std::runtime_error if the new mobilizer attempts to connect two
+  /// frames which already have a mobilizer between them. More than one
+  /// mobilizer between two frames is not allowed.
   ///
   /// @param[in] mobilizer A unique pointer to a mobilizer to add to `this`
   ///                      %MultibodyTree. The mobilizer class must be
@@ -341,6 +346,11 @@ class MultibodyTree {
   /// @endcode
   ///
   /// @throws std::logic_error if Finalize() was already called on `this` tree.
+  /// @throws a std::runtime_error if the new mobilizer attempts to connect a
+  /// frame with itself.
+  /// @throws std::runtime_error if the new mobilizer attempts to connect two
+  /// frames which already have a mobilizer between them. More than one
+  /// mobilizer between two frames is not allowed.
   ///
   /// @param[in] args The arguments needed to construct a valid Mobilizer of
   ///                 type `MobilizerType`. `MobilizerType` must provide a

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -84,7 +84,7 @@ class MultibodyTree {
                              "See documentation for Finalize() for details.");
     }
     if (body == nullptr) {
-      throw std::logic_error("Input body is an invalid nullptr.");
+      throw std::logic_error("Input body is a nullptr.");
     }
     BodyIndex body_index(0);
     FrameIndex body_frame_index(0);
@@ -181,7 +181,7 @@ class MultibodyTree {
                              "See documentation for Finalize() for details.");
     }
     if (frame == nullptr) {
-      throw std::logic_error("Input frame is an invalid nullptr.");
+      throw std::logic_error("Input frame is a nullptr.");
     }
     FrameIndex frame_index = topology_.add_frame(frame->get_body().get_index());
     // This test MUST be performed BEFORE frames_.push_back() and
@@ -260,7 +260,10 @@ class MultibodyTree {
   /// @param[in] mobilizer A unique pointer to a mobilizer to add to `this`
   ///                      %MultibodyTree. The mobilizer class must be
   ///                      specialized on the same scalar type T as this
-  ///                      %MultibodyTree.
+  ///                      %MultibodyTree. Notice this is a requirement of this
+  ///                      method's signature and therefore an input mobilzer
+  ///                      specialized on a different sacalar type than that of
+  ///                      this %MultibodyTree's T will fail to compile.
   /// @returns A constant reference to the `mobilizer` just added, which will
   ///          remain valid for the lifetime of `this` MultibodyTree.
   ///
@@ -278,7 +281,7 @@ class MultibodyTree {
                              "See documentation for Finalize() for details.");
     }
     if (mobilizer == nullptr) {
-      throw std::logic_error("Input mobilizer is an invalid nullptr.");
+      throw std::logic_error("Input mobilizer is a nullptr.");
     }
     MobilizerIndex mobilizer_index = topology_.add_mobilizer(
         mobilizer->get_inboard_frame().get_index(),

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -395,6 +395,11 @@ class MultibodyTree {
     return *owned_bodies_[world_index()];
   }
 
+  /// Returns a constant reference to the *world* frame.
+  const BodyFrame<T>& get_world_frame() const {
+    return owned_bodies_[world_index()]->get_body_frame();
+  }
+
   /// Returns a constant reference to the body with unique index `body_index`.
   /// This method aborts in Debug builds when `body_index` does not correspond
   /// to a body in this multibody tree.

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -283,13 +283,18 @@ class MultibodyTree {
     if (mobilizer == nullptr) {
       throw std::logic_error("Input mobilizer is a nullptr.");
     }
+    // Verifies that the inboard/outboard frames provided by the user do belong
+    // to this tree. This is a pathological case, but in theory nothing
+    // (but this test) stops a user from adding frames to a tree1 and attempting
+    // later to define mobilizers between those frames in a second tree2.
+    mobilizer->get_inboard_frame().HasThisParentTreeOrThrow(this);
+    mobilizer->get_outboard_frame().HasThisParentTreeOrThrow(this);
     MobilizerIndex mobilizer_index = topology_.add_mobilizer(
         mobilizer->get_inboard_frame().get_index(),
-        mobilizer->get_outboard_frame().get_index(),
-        mobilizer->get_inboard_body().get_index(),
-        mobilizer->get_outboard_body().get_index());
-    // These tests MUST be performed BEFORE owned_mobilizers_.push_back() below.
-    // Do not move them around!
+        mobilizer->get_outboard_frame().get_index());
+
+    // This DRAKE_ASSERT MUST be performed BEFORE owned_mobilizers_.push_back()
+    // below. Do not move it around!
     DRAKE_ASSERT(mobilizer_index == get_num_mobilizers());
 
     // TODO(amcastro-tri): consider not depending on setting this pointer at

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -68,8 +68,9 @@ class MultibodyTree {
   /// @param[in] body A unique pointer to a body to add to `this`
   ///                 %MultibodyTree. The body class must be specialized on the
   ///                 same scalar type T as this %MultibodyTree.
-  /// @returns A constant reference to the `body` just added, which will remain
-  ///          valid for the lifetime of `this` MultibodyTree.
+  /// @returns A constant reference of type `BodyType` to the created body.
+  ///          This reference which will remain valid for the lifetime of `this`
+  ///          %MultibodyTree.
   ///
   /// @tparam BodyType The type of the specific sub-class of Body to add. The
   ///                  template needs to be specialized on the same scalar type
@@ -133,9 +134,9 @@ class MultibodyTree {
   /// @param[in] args The arguments needed to construct a valid Body of type
   ///                 `BodyType`. `BodyType` must provide a public constructor
   ///                 that takes these arguments.
-  /// @returns A constant reference to the body with type `BodyType` just
-  ///          created, which will remain valid for the lifetime of `this`
-  ///          MultibodyTree.
+  /// @returns A constant reference of type `BodyType` to the created body.
+  ///          This reference which will remain valid for the lifetime of `this`
+  ///          %MultibodyTree.
   ///
   /// @tparam BodyType A template for the type of Body to construct. The
   ///                  template will be specialized on the scalar type T of this
@@ -165,8 +166,9 @@ class MultibodyTree {
   /// @param[in] frame A unique pointer to a frame to be added to `this`
   ///                  %MultibodyTree. The frame class must be specialized on
   ///                  the same scalar type T as this %MultibodyTree.
-  /// @returns A constant reference to the frame just added, which will remain
-  ///          valid for the lifetime of `this` MultibodyTree.
+  /// @returns A constant reference of type `FrameType` to the created frame.
+  ///          This reference which will remain valid for the lifetime of `this`
+  ///          %MultibodyTree.
   ///
   /// @tparam FrameType The type of the specific sub-class of Frame to add. The
   ///                   template needs to be specialized on the same scalar type
@@ -224,9 +226,9 @@ class MultibodyTree {
   /// @param[in] args The arguments needed to construct a valid Frame of type
   ///                 `FrameType`. `FrameType` must provide a public constructor
   ///                 that takes these arguments.
-  /// @returns A constant reference to the frame with type `FrameType` just
-  ///          created, which will remain valid for the lifetime of `this`
-  ///          MultibodyTree.
+  /// @returns A constant reference of type `FrameType` to the created frame.
+  ///          This reference which will remain valid for the lifetime of `this`
+  ///          %MultibodyTree.
   ///
   /// @tparam FrameType A template for the type of Frame to construct. The
   ///                   template will be specialized on the scalar type T of
@@ -264,8 +266,9 @@ class MultibodyTree {
   ///                      method's signature and therefore an input mobilzer
   ///                      specialized on a different sacalar type than that of
   ///                      this %MultibodyTree's T will fail to compile.
-  /// @returns A constant reference to the `mobilizer` just added, which will
-  ///          remain valid for the lifetime of `this` MultibodyTree.
+  /// @returns A constant reference of type `MobilizerType` to the created
+  ///          mobilizer. This reference which will remain valid for the
+  ///          lifetime of `this` %MultibodyTree.
   ///
   /// @tparam MobilizerType The type of the specific sub-class of Mobilizer to
   ///                       add. The template needs to be specialized on the
@@ -319,21 +322,32 @@ class MultibodyTree {
   ///   // Notice RevoluteMobilizer is a template an a scalar type.
   ///   const RevoluteMobilizer<T>& pin =
   ///     model.AddMobilizer<RevoluteMobilizer>(
-  ///       inboard_frame, elbow_outboard_frame,
+  ///       inboard_frame, outboard_frame,
   ///       Vector3d::UnitZ() /*revolute axis*/);
   /// @endcode
   ///
   /// Note that for dependent names you must use the template keyword (say for
   /// instance you have a MultibodyTree<T> member within your custom class).
+  /// Like so:
+  /// @code
+  ///   MultibodyTree<T> model;
+  ///   // ... Code to define inboard and outboard frames by calling
+  ///   // MultibodyTree::AddFrame() ...
+  ///   // Notice the usage of the "template" keyword here:
+  ///   const RevoluteMobilizer<T>& pin =
+  ///     model.template AddMobilizer<RevoluteMobilizer>(
+  ///       inboard_frame, outboard_frame,
+  ///       Vector3d::UnitZ() /*revolute axis*/);
+  /// @endcode
   ///
   /// @throws std::logic_error if Finalize() was already called on `this` tree.
   ///
   /// @param[in] args The arguments needed to construct a valid Mobilizer of
   ///                 type `MobilizerType`. `MobilizerType` must provide a
   ///                 public constructor that takes these arguments.
-  /// @returns A constant reference to the mobilizer with type `MobilizerType`
-  ///          just created, which will remain valid for the lifetime of `this`
-  ///          MultibodyTree.
+  /// @returns A constant reference of type `MobilizerType` to the created
+  ///          mobilizer. This reference which will remain valid for the
+  ///          lifetime of `this` %MultibodyTree.
   ///
   /// @tparam MobilizerType A template for the type of Mobilizer to construct.
   ///                       The template will be specialized on the scalar type

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -256,13 +256,15 @@ class MultibodyTree {
   ///       Vector3d::UnitZ() /*revolute axis*/));
   /// @endcode
   ///
+  /// A %Mobilizer effectively connects the two bodies to which the inboard and
+  /// outboard frames belong.
+  ///
   /// @throws std::logic_error if `mobilizer` is a nullptr.
   /// @throws std::logic_error if Finalize() was already called on `this` tree.
   /// @throws a std::runtime_error if the new mobilizer attempts to connect a
   /// frame with itself.
-  /// @throws std::runtime_error if the new mobilizer attempts to connect two
-  /// frames which already have a mobilizer between them. More than one
-  /// mobilizer between two frames is not allowed.
+  /// @throws std::runtime_error if attempting to connect two bodies with more
+  /// than one mobilizer between them.
   ///
   /// @param[in] mobilizer A unique pointer to a mobilizer to add to `this`
   ///                      %MultibodyTree. The mobilizer class must be
@@ -338,9 +340,8 @@ class MultibodyTree {
   /// @throws std::logic_error if Finalize() was already called on `this` tree.
   /// @throws a std::runtime_error if the new mobilizer attempts to connect a
   /// frame with itself.
-  /// @throws std::runtime_error if the new mobilizer attempts to connect two
-  /// frames which already have a mobilizer between them. More than one
-  /// mobilizer between two frames is not allowed.
+  /// @throws std::runtime_error if attempting to connect two bodies with more
+  /// than one mobilizer between them.
   ///
   /// @param[in] args The arguments needed to construct a valid Mobilizer of
   ///                 type `MobilizerType`. `MobilizerType` must provide a

--- a/drake/multibody/multibody_tree/multibody_tree_element.h
+++ b/drake/multibody/multibody_tree/multibody_tree_element.h
@@ -2,6 +2,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/multibody/multibody_tree/multibody_tree_topology.h"
 
 namespace drake {
 namespace multibody {
@@ -133,12 +134,18 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
   /// Gives MultibodyTree elements the opportunity to perform internal setup
   /// when MultibodyTree::Finalize() is invoked.
   /// NVI to pure virtual method DoFinalize().
-  void Finalize(const MultibodyTree<T>& tree) {
-    DoFinalize(tree);
+  //void Finalize(const MultibodyTree<T>& tree) {
+  //  DoFinalize(tree);
+  //}
+
+  void SetTopology(const MultibodyTreeTopology& tree) {
+    DoSetTopology(tree);
   }
 
   /// Implementation of the NVI Finalize().
-  virtual void DoFinalize(const MultibodyTree<T>& tree) = 0;
+  //virtual void DoFinalize(const MultibodyTree<T>& tree) = 0;
+
+  virtual void DoSetTopology(const MultibodyTreeTopology& tree) = 0;
 
  private:
   void set_parent_tree(

--- a/drake/multibody/multibody_tree/multibody_tree_element.h
+++ b/drake/multibody/multibody_tree/multibody_tree_element.h
@@ -138,7 +138,8 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
     DoSetTopology(tree);
   }
 
-  /// Implementation of the NVI SetTopology().
+  /// Implementation of the NVI SetTopology(). For advanced use only for
+  /// developers implementing new MultibodyTree components.
   virtual void DoSetTopology(const MultibodyTreeTopology& tree) = 0;
 
  private:

--- a/drake/multibody/multibody_tree/multibody_tree_element.h
+++ b/drake/multibody/multibody_tree/multibody_tree_element.h
@@ -131,20 +131,14 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
   /// their default constructors if they need to.
   MultibodyTreeElement() {}
 
-  /// Gives MultibodyTree elements the opportunity to perform internal setup
+  /// Gives MultibodyTree elements the opportunity to retrieve their topology
   /// when MultibodyTree::Finalize() is invoked.
-  /// NVI to pure virtual method DoFinalize().
-  //void Finalize(const MultibodyTree<T>& tree) {
-  //  DoFinalize(tree);
-  //}
-
+  /// NVI to pure virtual method DoSetTopology().
   void SetTopology(const MultibodyTreeTopology& tree) {
     DoSetTopology(tree);
   }
 
-  /// Implementation of the NVI Finalize().
-  //virtual void DoFinalize(const MultibodyTree<T>& tree) = 0;
-
+  /// Implementation of the NVI SetTopology().
   virtual void DoSetTopology(const MultibodyTreeTopology& tree) = 0;
 
  private:

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -49,7 +49,7 @@ struct BodyTopology {
 
   /// Unique index to the one and only inboard mobilizer a body can have.
   /// By default this is left initialized to "invalid" so that we can detect
-  /// graph loops whithin add_mobilizer().
+  /// graph loops within add_mobilizer().
   MobilizerIndex inboard_mobilizer{};
 
   /// Unique index to the frame associated with this body.

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -82,6 +82,11 @@ struct MobilizerTopology {
   /// Default construction to invalid configuration.
   MobilizerTopology() {}
 
+  /// Constructs a topology by specifying the the index `mobilizer_index` for
+  /// `this` new topology, the indexes to the inboard and outboard frames the
+  /// Mobilizer will connect, given by in_frame and out_frame respectively, and
+  /// similarly the inboard and outboard bodies being connected, given by
+  /// in_body and out_body, respectively.
   MobilizerTopology(
       MobilizerIndex mobilizer_index,
       FrameIndex in_frame, FrameIndex out_frame,
@@ -169,8 +174,7 @@ struct MultibodyTreeTopology {
   /// @returns The MobilizerIndex assigned to the new MobilizerTopology.
   MobilizerIndex add_mobilizer(
       FrameIndex in_frame, FrameIndex out_frame,
-      BodyIndex in_body, BodyIndex out_body)
-  {
+      BodyIndex in_body, BodyIndex out_body) {
     MobilizerIndex mobilizer_index(get_num_mobilizers());
     mobilizers.emplace_back(mobilizer_index,
                             in_frame, out_frame,

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -80,7 +80,7 @@ struct FrameTopology {
 /// - Indexes to the inboard/outboard frames of this mobilizer.
 /// - Indexes to the inboard/outboard bodies of this mobilizer.
 /// - Numbers of dofs admitted by this mobilizer.
-/// - Indexing information to retrive entries from the parent MultibodyTree
+/// - Indexing information to retrieve entries from the parent MultibodyTree
 ///   Context.
 /// Additional information on topology classes is given in this file's
 /// documentation at the top.
@@ -106,9 +106,8 @@ struct MobilizerTopology {
   /// Returns `true` if this %MobilizerTopology connects frames identified by
   /// indexes `frame1` and `frame2`.
   bool connects_frames(FrameIndex frame1, FrameIndex frame2) const {
-    if ((inboard_frame == frame1 && outboard_frame == frame2) ||
-        (inboard_frame == frame2 && outboard_frame == frame1)) return true;
-    return false;
+    return (inboard_frame == frame1 && outboard_frame == frame2) ||
+           (inboard_frame == frame2 && outboard_frame == frame1);
   }
 
   /// Unique index in the set of mobilizers.
@@ -123,12 +122,12 @@ struct MobilizerTopology {
   BodyIndex outboard_body;
 
   /// Mobilizer indexing info: Set at Finalize() time.
-  // Number of generalized coordinates admitted by this mobilizer.
+  // Number of generalized coordinates granted by this mobilizer.
   int num_positions{0};
   // First entry in the global array of generalized coordinates for the parent
   // MultibodyTree.
   int positions_start{0};
-  // Number of generalized velocities admitted by this mobilizer.
+  // Number of generalized velocities granted by this mobilizer.
   int num_velocities{0};
   // First entry in the global array of generalized velocities for the parent
   // MultibodyTree.
@@ -147,7 +146,9 @@ struct MultibodyTreeTopology {
   /// and adds it to the tree.
   MultibodyTreeTopology() {}
 
-  /// Returns the number of bodies in the multibody tree.
+  /// Returns the number of bodies in the multibody tree. This includes the
+  /// "world" body and therefore the minimum number of bodies after
+  /// MultibodyTree::Finalize() will always be one, not zero.
   int get_num_bodies() const { return static_cast<int>(bodies.size()); }
 
   /// Returns the number of physical frames in the multibody tree.
@@ -155,7 +156,9 @@ struct MultibodyTreeTopology {
     return static_cast<int>(frames.size());
   }
 
-  /// Returns the number of mobilizers in the multibody tree.
+  /// Returns the number of mobilizers in the multibody tree. Since the "world"
+  /// body does not have a mobilizer, the number of mobilizers will always equal
+  /// the number of bodies minus one.
   int get_num_mobilizers() const {
     return static_cast<int>(mobilizers.size());
   }
@@ -191,8 +194,6 @@ struct MultibodyTreeTopology {
   /// Creates and adds a new MobilizerTopology connecting the inboard and
   /// outboard multibody frames identified by indexes `in_frame` and
   /// `out_frame`, respectively.
-  /// `in_body` corresponds to the body associated with the inboard frame while
-  /// `out_body` corresponds to the body associated with the outboard frame.
   /// @returns The MobilizerIndex assigned to the new MobilizerTopology.
   /// @throws std::runtime_error if either `in_frame` or `out_frame` do not
   /// index frame topologies in `this` %MultibodyTreeTopology.

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -74,6 +74,40 @@ struct FrameTopology {
   BodyIndex body{0};
 };
 
+/// Data structure to store the topological information associated with a
+/// Mobilizer object.
+struct MobilizerTopology {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MobilizerTopology);
+
+  /// Default construction to invalid configuration.
+  MobilizerTopology() {}
+
+  MobilizerTopology(
+      MobilizerIndex mobilizer_index,
+      FrameIndex in_frame, FrameIndex out_frame,
+      BodyIndex in_body, BodyIndex out_body) :
+      index(mobilizer_index),
+      inboard_frame(in_frame), outboard_frame(out_frame),
+      inboard_body(in_body), outboard_body(out_body) {}
+
+  /// Unique index in the MultibodyTree.
+  MobilizerIndex index;
+  /// Index to the inboard frame.
+  FrameIndex inboard_frame;
+  /// Index to the outboard frame.
+  FrameIndex outboard_frame;
+  /// Index to the inboard body.
+  BodyIndex inboard_body;
+  /// Index to the outboard body.
+  BodyIndex outboard_body;
+
+  /// MobilizerIndexingInfo
+  int num_positions;
+  int positions_start;
+  int num_velocities;
+  int velocities_start;
+};
+
 /// Data structure to store the topological information associated with an
 /// entire MultibodyTree.
 struct MultibodyTreeTopology {
@@ -92,6 +126,11 @@ struct MultibodyTreeTopology {
   /// Returns the number of physical frames in the multibody tree.
   int get_num_frames() const {
     return static_cast<int>(frames.size());
+  }
+
+  /// Returns the number of mobilizers in the multibody tree.
+  int get_num_mobilizers() const {
+    return static_cast<int>(mobilizers.size());
   }
 
   /// Creates and adds a new BodyTopology to this MultibodyTreeTopology.
@@ -122,6 +161,23 @@ struct MultibodyTreeTopology {
     return frames[index];
   }
 
+  /// Creates and adds a new MobilizerTopology connecting the inboard and
+  /// outboard multibody frames identified by indexes `in_frame` and
+  /// `out_frame`, respectively.
+  /// `in_body` corresponds to the body associated with the inboard frame while
+  /// `out_body` correspoinds to the body associated with the outboard frame.
+  /// @returns The MobilizerIndex assigned to the new MobilizerTopology.
+  MobilizerIndex add_mobilizer(
+      FrameIndex in_frame, FrameIndex out_frame,
+      BodyIndex in_body, BodyIndex out_body)
+  {
+    MobilizerIndex mobilizer_index(get_num_mobilizers());
+    mobilizers.emplace_back(mobilizer_index,
+                            in_frame, out_frame,
+                            in_body, out_body);
+    return mobilizer_index;
+  }
+
   bool is_valid{false};
 
   /// Topology gets validated by MultibodyTree::Finalize().
@@ -129,6 +185,7 @@ struct MultibodyTreeTopology {
 
   std::vector<BodyTopology> bodies;
   std::vector<FrameTopology> frames;
+  std::vector<MobilizerTopology> mobilizers;
 };
 
 }  // namespace multibody

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -76,18 +76,25 @@ struct FrameTopology {
 };
 
 /// Data structure to store the topological information associated with a
-/// Mobilizer object.
+/// Mobilizer object. It stores:
+/// - Indexes to the inboard/outboard frames of this mobilizer.
+/// - Indexes to the inboard/outboard bodies of this mobilizer.
+/// - Numbers of dofs admitted by this mobilizer.
+/// - Indexing information to retrive entries from the parent MultibodyTree
+///   Context.
+/// Additional information on topology classes is given in this file's
+/// documentation at the top.
 struct MobilizerTopology {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MobilizerTopology);
 
   /// Default construction to invalid configuration.
   MobilizerTopology() {}
 
-  /// Constructs a topology by specifying the the index `mobilizer_index` for
-  /// `this` new topology, the indexes to the inboard and outboard frames the
-  /// Mobilizer will connect, given by in_frame and out_frame respectively, and
-  /// similarly the inboard and outboard bodies being connected, given by
-  /// in_body and out_body, respectively.
+  /// Constructs a %MobilizerTopology by specifying the the index
+  /// `mobilizer_index` for `this` new topology, the indexes to the inboard and
+  /// outboard frames the Mobilizer will connect, given by `in_frame` and
+  /// `out_frame` respectively, and similarly the inboard and outboard bodies
+  /// being connected, given by `in_body` and `out_body`, respectively.
   MobilizerTopology(
       MobilizerIndex mobilizer_index,
       FrameIndex in_frame, FrameIndex out_frame,
@@ -96,7 +103,7 @@ struct MobilizerTopology {
       inboard_frame(in_frame), outboard_frame(out_frame),
       inboard_body(in_body), outboard_body(out_body) {}
 
-  /// Unique index in the MultibodyTree.
+  /// Unique index in the set of mobilizers.
   MobilizerIndex index;
   /// Index to the inboard frame.
   FrameIndex inboard_frame;
@@ -107,11 +114,17 @@ struct MobilizerTopology {
   /// Index to the outboard body.
   BodyIndex outboard_body;
 
-  /// MobilizerIndexingInfo
-  int num_positions;
-  int positions_start;
-  int num_velocities;
-  int velocities_start;
+  /// Mobilizer indexing info: Set at Finalize() time.
+  // Number of generalized coordinates admitted by this mobilizer.
+  int num_positions{0};
+  // First entry in the global array of generalized coordinates for the parent
+  // MultibodyTree.
+  int positions_start{0};
+  // Number of generalized velocities admitted by this mobilizer.
+  int num_velocities{0};
+  // First entry in the global array of generalized velocities for the parent
+  // MultibodyTree.
+  int velocities_start{0};
 };
 
 /// Data structure to store the topological information associated with an
@@ -171,7 +184,7 @@ struct MultibodyTreeTopology {
   /// outboard multibody frames identified by indexes `in_frame` and
   /// `out_frame`, respectively.
   /// `in_body` corresponds to the body associated with the inboard frame while
-  /// `out_body` correspoinds to the body associated with the outboard frame.
+  /// `out_body` corresponds to the body associated with the outboard frame.
   /// @returns The MobilizerIndex assigned to the new MobilizerTopology.
   /// @throws std::runtime_error if either `in_frame` or `out_frame` do not
   /// index frame topologies in `this` %MultibodyTreeTopology.

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -26,6 +26,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
 #include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
 
 namespace drake {
@@ -172,13 +173,21 @@ struct MultibodyTreeTopology {
   /// `in_body` corresponds to the body associated with the inboard frame while
   /// `out_body` correspoinds to the body associated with the outboard frame.
   /// @returns The MobilizerIndex assigned to the new MobilizerTopology.
+  /// @throws std::runtime_error if either `in_frame` or `out_frame` do not
+  /// index frame topologies in `this` %MultibodyTreeTopology.
   MobilizerIndex add_mobilizer(
-      FrameIndex in_frame, FrameIndex out_frame,
-      BodyIndex in_body, BodyIndex out_body) {
+      FrameIndex in_frame, FrameIndex out_frame) {
+    // Note: MultibodyTree double checks the mobilizer's frames belong to that
+    // tree. Therefore the validity of in_frame and out_frame is already
+    // guaranteed. We add the checks here for additional security.
+    DRAKE_THROW_UNLESS(in_frame < get_num_frames());
+    DRAKE_THROW_UNLESS(out_frame < get_num_frames());
     MobilizerIndex mobilizer_index(get_num_mobilizers());
+    const BodyIndex inboard_body = frames[in_frame].body;
+    const BodyIndex outboard_body = frames[out_frame].body;
     mobilizers.emplace_back(mobilizer_index,
                             in_frame, out_frame,
-                            in_body, out_body);
+                            inboard_body, outboard_body);
     return mobilizer_index;
   }
 

--- a/drake/multibody/multibody_tree/revolute_mobilizer.cc
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.cc
@@ -1,0 +1,14 @@
+#include "drake/multibody/multibody_tree/revolute_mobilizer.h"
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace multibody {
+
+// Explicitly instantiates on the most common scalar types.
+template class RevoluteMobilizer<double>;
+template class RevoluteMobilizer<AutoDiffXd>;
+
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/multibody_tree/revolute_mobilizer.h
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.h
@@ -16,7 +16,7 @@ namespace multibody {
 /// This Mobilizer grants a single degree of freedom describing the angular
 /// rotation between the inboard and outboard frames it connects.
 /// To fully specify this mobilizer a user must provide the inboard frame F,
-/// the outbourd (or "mobilized") frame M and the axis `axis_F` (expressed in
+/// the outboard (or "mobilized") frame M and the axis `axis_F` (expressed in
 /// frame F) about which frame M rotates with respect to F.
 /// The single generalized coordinate q introduced by this mobilizer
 /// corresponds to the rotation angle in radians of frame M with respect to
@@ -33,14 +33,29 @@ namespace multibody {
 template <typename T>
 class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
  public:
-  /// Constructor for a %RevoluteMobilizer between frames the inboard frame F
+  /// Constructor for a %RevoluteMobilizer between the inboard frame F
   /// `inboard_frame` and the outboard frame M `outboard_frame` granting a
-  /// single rotational degree of fredom about axis `axis_F` expressed in the
+  /// single rotational degree of freedom about axis `axis_F` expressed in the
   /// inboard frame F.
+  /// @pre axis_F must be a unit vector within at least 1.0e-6. This rather
+  /// loose tolerance (at least for simulation) allows users to provide "near
+  /// unity" axis vectors originated, for instance, during the parsing of a
+  /// file with limited precision. Internally, we re-normalize the axis to
+  /// within machine precision.
+  /// @throws std::runtime_error if the provided rotational axis is not a unit
+  /// vector.
   RevoluteMobilizer(const Frame<T>& inboard_frame,
                     const Frame<T>& outboard_frame,
-                    const Vector3<double> axis_F) :
-      MobilizerBase(inboard_frame, outboard_frame), axis_F_(axis_F) {}
+                    const Vector3<double>& axis_F) :
+      MobilizerBase(inboard_frame, outboard_frame), axis_F_(axis_F) {
+    if (!axis_F.isUnitary(1.0e-6)) {
+      throw std::runtime_error("The rotation axis must be a unit vector");
+    }
+    // We allow a rather loose tolerance in the isUnitary check above so that we
+    // don't get spurious exceptions when, for instance, the provided axis comes
+    // from parsing a file. Therefore we re-normalize here.
+    axis_F_.normalize();
+  }
 
   /// Returns a constant reference to the axis, expressed in the inboard frame,
   /// about which the outboard frame rotates with respect to the inboard frame.
@@ -48,6 +63,12 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
 
  private:
   typedef MobilizerImpl<T, 1, 1> MobilizerBase;
+  // Bring the handy number of position and velocities MobilizerImpl enums into
+  // this class' scope. This is useful when writing mathematical expressions
+  // with fixed-sized vectors since we can do things like Vector<T, nq>.
+  // Operations which fixed-sized quantities can be optimized at compile time
+  // and therefore they are highly preferred compared to the very slow dynamic
+  // sized quantities.
   using MobilizerBase::nq;
   using MobilizerBase::nv;
 

--- a/drake/multibody/multibody_tree/revolute_mobilizer.h
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.h
@@ -14,13 +14,17 @@ namespace drake {
 namespace multibody {
 
 /// This Mobilizer grants a single degree of freedom describing the angular
-/// rotation between the inboard and outboard frames it connects.
+/// rotation between the inboard and outboard frames it connects. This mobilizer
+/// permits no translation.
 /// To fully specify this mobilizer a user must provide the inboard frame F,
 /// the outboard (or "mobilized") frame M and the axis `axis_F` (expressed in
 /// frame F) about which frame M rotates with respect to F.
 /// The single generalized coordinate q introduced by this mobilizer
 /// corresponds to the rotation angle in radians of frame M with respect to
-/// frame F about the rotation axis `axis_F`.
+/// frame F about the rotation axis `axis_F`. When `q = 0`, frames F and M are
+/// coincident. Notice that the components of the rotation axis as expressed in
+/// either frame F or M are constant. That is, `axis_F` and `axis_M` remain
+/// unchanged w.r.t. both frames by this mobilizer's motion.
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 ///
@@ -36,7 +40,7 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RevoluteMobilizer)
 
   /// Constructor for a %RevoluteMobilizer between the inboard frame F
-  /// `inboard_frame` and the outboard frame M `outboard_frame` granting a
+  /// `inboard_frame_F` and the outboard frame M `outboard_frame_F` granting a
   /// single rotational degree of freedom about axis `axis_F` expressed in the
   /// inboard frame F.
   /// @pre axis_F must be a unit vector within at least 1.0e-6. This rather
@@ -46,10 +50,10 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   /// within machine precision.
   /// @throws std::runtime_error if the provided rotational axis is not a unit
   /// vector.
-  RevoluteMobilizer(const Frame<T>& inboard_frame,
-                    const Frame<T>& outboard_frame,
+  RevoluteMobilizer(const Frame<T>& inboard_frame_F,
+                    const Frame<T>& outboard_frame_M,
                     const Vector3<double>& axis_F) :
-      MobilizerBase(inboard_frame, outboard_frame), axis_F_(axis_F) {
+      MobilizerBase(inboard_frame_F, outboard_frame_M), axis_F_(axis_F) {
     if (!axis_F.isUnitary(1.0e-6)) {
       throw std::runtime_error("The rotation axis must be a unit vector");
     }
@@ -59,8 +63,8 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
     axis_F_.normalize();
   }
 
-  /// Returns a constant reference to the axis, expressed in the inboard frame,
-  /// about which the outboard frame rotates with respect to the inboard frame.
+  /// @retval axis_F The rotation axis as a unit vector expressed in the inboard
+  ///                frame F.
   const Vector3<double>& get_revolute_axis() const { return axis_F_; }
 
  private:

--- a/drake/multibody/multibody_tree/revolute_mobilizer.h
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.h
@@ -13,15 +13,37 @@ template <typename T> class MultibodyTree;
 namespace drake {
 namespace multibody {
 
+/// This Mobilizer grants a single degree of freedom describing the angular
+/// rotation between the inboard and outboard frames it connects.
+/// To fully specify this mobilizer a user must provide the inboard frame F,
+/// the outbourd (or "mobilized") frame M and the axis `axis_F` (expressed in
+/// frame F) about which frame M rotates with respect to F.
+/// The single generalized coordinate q introduced by this mobilizer
+/// corresponds to the rotation angle in radians of frame M with respect to
+/// frame F about the rotation axis `axis_F`.
+///
+/// @tparam T The scalar type. Must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+///
+/// They are already available to link against in the containing library.
+/// No other values for T are currently supported.
 template <typename T>
 class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
  public:
-  // Creates a revolute mobilizer with axis_F expressed in the inboard frame F.
+  /// Constructor for a %RevoluteMobilizer between frames the inboard frame F
+  /// `inboard_frame` and the outboard frame M `outboard_frame` granting a
+  /// single rotational degree of fredom about axis `axis_F` expressed in the
+  /// inboard frame F.
   RevoluteMobilizer(const Frame<T>& inboard_frame,
                     const Frame<T>& outboard_frame,
                     const Vector3<double> axis_F) :
       MobilizerBase(inboard_frame, outboard_frame), axis_F_(axis_F) {}
 
+  /// Returns a constant reference to the axis, expressed in the inboard frame,
+  /// about which the outboard frame rotates with respect to the inboard frame.
   const Vector3<double>& get_revolute_axis() const { return axis_F_; }
 
  private:

--- a/drake/multibody/multibody_tree/revolute_mobilizer.h
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.h
@@ -33,6 +33,8 @@ namespace multibody {
 template <typename T>
 class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RevoluteMobilizer)
+
   /// Constructor for a %RevoluteMobilizer between the inboard frame F
   /// `inboard_frame` and the outboard frame M `outboard_frame` granting a
   /// single rotational degree of freedom about axis `axis_F` expressed in the

--- a/drake/multibody/multibody_tree/revolute_mobilizer.h
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.h
@@ -68,7 +68,7 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   // Bring the handy number of position and velocities MobilizerImpl enums into
   // this class' scope. This is useful when writing mathematical expressions
   // with fixed-sized vectors since we can do things like Vector<T, nq>.
-  // Operations which fixed-sized quantities can be optimized at compile time
+  // Operations with fixed-sized quantities can be optimized at compile time
   // and therefore they are highly preferred compared to the very slow dynamic
   // sized quantities.
   using MobilizerBase::nq;

--- a/drake/multibody/multibody_tree/revolute_mobilizer.h
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/multibody_tree/frame.h"
+#include "drake/multibody/multibody_tree/mobilizer_impl.h"
+#include "drake/multibody/multibody_tree/multibody_tree_topology.h"
+
+// Forward declarations.
+template <typename T> class MultibodyTree;
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
+ public:
+  // Creates a revolute mobilizer with axis_F expressed in the inboard frame F.
+  RevoluteMobilizer(const Frame<T>& inboard_frame,
+                    const Frame<T>& outboard_frame,
+                    const Vector3<double> axis_F) :
+      MobilizerBase(inboard_frame, outboard_frame), axis_F_(axis_F) {}
+
+  const Vector3<double>& get_revolute_axis() const { return axis_F_; }
+
+ private:
+  typedef MobilizerImpl<T, 1, 1> MobilizerBase;
+  using MobilizerBase::nq;
+  using MobilizerBase::nv;
+
+  // Default joint axis expressed in the inboard frame F.
+  Vector3<double> axis_F_;
+};
+
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/multibody_tree/revolute_mobilizer.h
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.h
@@ -13,9 +13,9 @@ template <typename T> class MultibodyTree;
 namespace drake {
 namespace multibody {
 
-/// This Mobilizer grants a single degree of freedom describing the angular
-/// rotation between the inboard and outboard frames it connects. This mobilizer
-/// permits no translation.
+/// This Mobilizer allows two frames to rotate relatively to one another around
+/// an axis that is constant when measured in either this mobilizer's inboard or
+/// outboard frames, while the distance between the two frames does not vary.
 /// To fully specify this mobilizer a user must provide the inboard frame F,
 /// the outboard (or "mobilized") frame M and the axis `axis_F` (expressed in
 /// frame F) about which frame M rotates with respect to F.

--- a/drake/multibody/multibody_tree/rigid_body.cc
+++ b/drake/multibody/multibody_tree/rigid_body.cc
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/multibody/multibody_tree/multibody_tree.h"
 
 namespace drake {
 namespace multibody {

--- a/drake/multibody/multibody_tree/test/double_pendulum_test.cc
+++ b/drake/multibody/multibody_tree/test/double_pendulum_test.cc
@@ -20,7 +20,7 @@ using Eigen::Translation3d;
 using std::make_unique;
 using std::unique_ptr;
 
-// Tests the logic to create a multibody tree model for a double pendulum.
+// Set of MultibodyTree tests for a double pendulum model.
 // This double pendulum is similar to the acrobot model described in Section 3.1
 // of the Underactuated Robotics notes available online at
 // http://underactuated.csail.mit.edu/underactuated.html?chapter=3.
@@ -29,41 +29,179 @@ using std::unique_ptr;
 // negative y-axis direction.
 // In this model the two links of the pendulum have the same length and their
 // body frames are located at the links' centroids.
-GTEST_TEST(MultibodyTree, CreateModel) {
+class PendulumTests : public ::testing::Test {
+ public:
+  // Creates an "empty" MultibodyTree that only contains the "world" body and
+  // world body frame.
+  void SetUp() override {
+    owned_model_ = std::make_unique<MultibodyTree<double>>();
+    model_ = owned_model_.get();
+
+    // Retrieves the world body.
+    world_body_ = &model_->get_world_body();
+  }
+
+  // Sets up the MultibodyTree model for a double pendulum. See this unit test's
+  // class description for details.
+  void CreatePendulumModel() {
+    // Creates a NaN SpatialInertia to instantiate the two RigidBody links of
+    // the pendulum. Using a NaN spatial inertia is ok so far since we are still
+    // not performing any numerical computations. This is only to test API.
+    // M_Bo_B is the spatial inertia about the body frame's origin Bo and
+    // expressed in the body frame B.
+    SpatialInertia<double> M_Bo_B;
+
+    // Adds the upper and lower links of the pendulum.
+    // Using: const BodyType& AddBody(std::unique_ptr<BodyType> body).
+    upper_link_ =
+        &model_->AddBody(make_unique<RigidBody<double>>(M_Bo_B));
+    // Using: const BodyType<T>& AddBody(Args&&... args)
+    lower_link_ = &model_->AddBody<RigidBody>(M_Bo_B);
+
+    // The shoulder is the mobilizer that connects the world to the upper link.
+    // Its inboard frame, Si, is the world frame. Its outboard frame, So, a
+    // fixed offset frame on the upper link.
+    shoulder_inboard_frame_ = &world_body_->get_body_frame();
+
+    // The body frame of the upper link is U, and that of the lower link is L.
+    // We will add a frame for the pendulum's shoulder. This will be the
+    // shoulder's outboard frame So.
+    // X_USo specifies the pose of the shoulder outboard frame So in the body
+    // frame U of the upper link.
+    // In this case the frame is created explicitly from the body frame of
+    // upper_link.
+    shoulder_outboard_frame_ =
+        &model_->AddFrame<FixedOffsetFrame>(
+            upper_link_->get_body_frame(), X_USo_);
+
+    // The elbow is the mobilizer that connects upper and lower links.
+    // Below we will create inboard and outboard frames associated with the
+    // pendulum's elbow.
+    // An inboard frame Ei is rigidly attached to the upper link. It is located
+    // at y = -half_link_length in the frame of the upper link body.
+    // An outboard frame Eo is rigidly attached to the lower link. It is located
+    // at y = +half_link_length in the frame of the lower link body.
+    // X_UEi specifies the pose of the elbow inboard frame Ei in the body
+    // frame U of the upper link.
+    // X_LEo specifies the pose of the elbow outboard frame Eo in the body
+    // frame L of the lower link.
+    // In this case we create a frame using the FixedOffsetFrame::Create()
+    // method taking a Body, i.e., creating a frame with a fixed offset from the
+    // upper link body frame.
+    elbow_inboard_frame_ =
+        &model_->AddFrame<FixedOffsetFrame>(*upper_link_, X_UEi_);
+    elbow_outboard_frame_ =
+        &model_->AddFrame<FixedOffsetFrame>(*lower_link_, X_LEo_);
+  }
+
+ protected:
+  std::unique_ptr<MultibodyTree<double>> owned_model_;
+  MultibodyTree<double>* model_;
+  const Body<double>* world_body_;
+  // Bodies:
+  const RigidBody<double>* upper_link_;
+  const RigidBody<double>* lower_link_;
+  // Frames:
+  const BodyFrame<double>* shoulder_inboard_frame_;
+  const FixedOffsetFrame<double>* shoulder_outboard_frame_;
+  const FixedOffsetFrame<double>* elbow_inboard_frame_;
+  const FixedOffsetFrame<double>* elbow_outboard_frame_;
+  // Pendulum parameters:
   const double link_length = 1.0;
   const double half_link_length = link_length / 2;
+  // Poses:
+  // Desired pose of the lower link frame L in the world frame W.
+  const Isometry3d X_WL_{Translation3d(0.0, -half_link_length, 0.0)};
+  // Pose of the shoulder outboard frame So in the upper link frame U.
+  const Isometry3d X_USo_{Translation3d(0.0, half_link_length, 0.0)};
+  // Pose of the elbow inboard frame Ei in the upper link frame U.
+  const Isometry3d X_UEi_{Translation3d(0.0, -half_link_length, 0.0)};
+  // Pose of the elbow outboard frame Eo in the lower link frame L.
+  const Isometry3d X_LEo_{Translation3d(0.0, half_link_length, 0.0)};
+};
 
-  auto owned_model = std::make_unique<MultibodyTree<double>>();
-  MultibodyTree<double>* model = owned_model.get();
-
+TEST_F(PendulumTests, CreateModelBasics) {
   // Initially there is only one body, the world.
-  EXPECT_EQ(model->get_num_bodies(), 1);
+  EXPECT_EQ(model_->get_num_bodies(), 1);
   // And there is only one frame, the world frame.
-  EXPECT_EQ(model->get_num_frames(), 1);
+  EXPECT_EQ(model_->get_num_frames(), 1);
 
-  // Retrieves the world body.
-  const Body<double>& world_body = model->get_world_body();
+  CreatePendulumModel();
 
-  // Creates a NaN SpatialInertia to instantiate the two RigidBody links of
-  // the pendulum. Using a NaN spatial inertia is ok so far since we are still
-  // not performing any numerical computations. This is only to test API.
-  // M_Bo_B is the spatial inertia about the body frame's origin Bo and
-  // expressed in the body frame B.
+  // Verifies the number of multibody elements is correct.
+  EXPECT_EQ(model_->get_num_bodies(), 3);
+  EXPECT_EQ(model_->get_num_frames(), 6);
+
+  // Check that frames are associated with the correct bodies.
+  EXPECT_EQ(
+      shoulder_inboard_frame_->get_body().get_index(),
+      world_body_->get_index());
+  EXPECT_EQ(
+      shoulder_outboard_frame_->get_body().get_index(),
+      upper_link_->get_index());
+  EXPECT_EQ(
+      elbow_inboard_frame_->get_body().get_index(), upper_link_->get_index());
+  EXPECT_EQ(
+      elbow_outboard_frame_->get_body().get_index(), lower_link_->get_index());
+
+  // Checks we can retrieve the body associated with a frame.
+  EXPECT_EQ(&shoulder_inboard_frame_->get_body(), world_body_);
+  EXPECT_EQ(&shoulder_outboard_frame_->get_body(), upper_link_);
+  EXPECT_EQ(&elbow_inboard_frame_->get_body(), upper_link_);
+  EXPECT_EQ(&elbow_outboard_frame_->get_body(), lower_link_);
+}
+
+// Frame indexes are assigned by MultibodyTree. The number of frames
+// equals the number of body frames (one per body) plus the number of
+// additional frames added to the system (like FixedOffsetFrame objects).
+// Frames are indexed in the order they are added to the MultibodyTree model.
+// The order of the frames and their indexes is an implementation detail that
+// users do not need to know about. Therefore this unit test would need to
+// change in the future if we decide to change the "internal detail" on how we
+// assign these indexes.
+TEST_F(PendulumTests, Indexes) {
+  CreatePendulumModel();
+  EXPECT_EQ(shoulder_inboard_frame_->get_index(), FrameIndex(0));
+  EXPECT_EQ(upper_link_->get_body_frame().get_index(), FrameIndex(1));
+  EXPECT_EQ(lower_link_->get_body_frame().get_index(), FrameIndex(2));
+  EXPECT_EQ(shoulder_outboard_frame_->get_index(), FrameIndex(3));
+  EXPECT_EQ(elbow_inboard_frame_->get_index(), FrameIndex(4));
+  EXPECT_EQ(elbow_outboard_frame_->get_index(), FrameIndex(5));
+}
+
+// Asserts that the Finalize() stage is successful and that re-finalization is
+// not allowed.
+TEST_F(PendulumTests, Finalize) {
+  CreatePendulumModel();
+  // Finalize() stage.
+  EXPECT_FALSE(model_->topology_is_valid());  // Not valid before Finalize().
+  EXPECT_NO_THROW(model_->Finalize());
+  EXPECT_TRUE(model_->topology_is_valid());  // Valid after Finalize().
+
+  // Asserts that no more bodies can be added after finalize.
   SpatialInertia<double> M_Bo_B;
+  EXPECT_THROW(model_->AddBody<RigidBody>(M_Bo_B), std::logic_error);
+  EXPECT_THROW(model_->AddFrame<FixedOffsetFrame>(*lower_link_, X_LEo_),
+               std::logic_error);
 
-  // Adds the upper and lower links of the pendulum.
-  // Using: const BodyType& AddBody(std::unique_ptr<BodyType> body).
-  const RigidBody<double>& upper_link =
-      model->AddBody(make_unique<RigidBody<double>>(M_Bo_B));
-  // Using: const BodyType<T>& AddBody(Args&&... args)
-  const RigidBody<double>& lower_link = model->AddBody<RigidBody>(M_Bo_B);
+  // Asserts re-finalization is not allowed.
+  EXPECT_THROW(model_->Finalize(), std::logic_error);
+}
 
-  // This is an experiment with std::reference_wrapper to show that we can save
-  // bodies in an array of references.
+// This is an experiment with std::reference_wrapper to show that we can save
+// bodies in an array of references.
+TEST_F(PendulumTests, StdReferenceWrapperExperiment) {
+  // Initially there is only one body, the world.
+  EXPECT_EQ(model_->get_num_bodies(), 1);
+  // And there is only one frame, the world frame.
+  EXPECT_EQ(model_->get_num_frames(), 1);
+  CreatePendulumModel();
+
+  // Vector of references.
   std::vector<std::reference_wrapper<const Body<double>>> bodies;
-  bodies.push_back(world_body);
-  bodies.push_back(upper_link);
-  bodies.push_back(lower_link);
+  bodies.push_back(*world_body_);
+  bodies.push_back(*upper_link_);
+  bodies.push_back(*lower_link_);
 
   // Verify that vector "bodies" effectively holds valid references to the
   // actual body elements in the tree.
@@ -71,100 +209,9 @@ GTEST_TEST(MultibodyTree, CreateModel) {
   // ensure that bodies were not copied instead.
   // Unfortunately we need the ugly get() method since operator.() is not
   // overloaded.
-  EXPECT_EQ(&bodies[world_body.get_index()].get(), &world_body);
-  EXPECT_EQ(&bodies[upper_link.get_index()].get(), &upper_link);
-  EXPECT_EQ(&bodies[lower_link.get_index()].get(), &lower_link);
-
-  // Verifies the number of multibody elements is correct.
-  EXPECT_EQ(model->get_num_bodies(), 3);
-  EXPECT_EQ(model->get_num_frames(), 3);
-
-  // The shoulder is the mobilizer that connects the world to the upper link.
-  // Its inboard frame, Si, is the world frame. Its outboard frame, So, a fixed
-  // offset frame on the upper link.
-  const BodyFrame<double>& shoulder_inboard_frame = world_body.get_body_frame();
-
-  // The body frame of the upper link is U, and that of the lower link is L.
-  // We will add a frame for the pendulum's shoulder. This will be the
-  // shoulder's outboard frame So.
-  // X_USo specifies the pose of the shoulder outboard frame So in the body
-  // frame U of the upper link.
-  Isometry3d X_USo(Translation3d(0.0, half_link_length, 0.0));
-  // In this case the frame is created explicitly from the body frame of
-  // upper_link.
-  const auto& shoulder_outboard_frame =
-      model->AddFrame<FixedOffsetFrame>(upper_link.get_body_frame(), X_USo);
-
-  // The elbow is the mobilizer that connects upper and lower links.
-  // Below we will create inboard and outboard frames associated with the
-  // pendulum's elbow.
-  // An inboard frame Ei is rigidly attached to the upper link. It is located at
-  // y = -half_link_length in the frame of the upper link body.
-  // An outboard frame Eo is rigidly attached to the lower link. It is located
-  // at y = +half_link_length in the frame of the lower link body.
-  // X_UEi specifies the pose of the elbow inboard frame Ei in the body
-  // frame U of the upper link.
-  Isometry3d X_UEi(Translation3d(0.0, -half_link_length, 0.0));
-  // X_LEo specifies the pose of the elbow outboard frame Eo in the body
-  // frame L of the lower link.
-  // In this case we create a frame using the FixedOffsetFrame::Create() method
-  // taking a Body, i.e., creating a frame with a fixed offset from the upper
-  // link body frame.
-  const auto& elbow_inboard_frame =
-      model->AddFrame<FixedOffsetFrame>(upper_link, X_UEi);
-  Isometry3d X_LEo(Translation3d(0.0, +half_link_length, 0.0));
-  const auto& elbow_outboard_frame =
-      model->AddFrame<FixedOffsetFrame>(lower_link, X_LEo);
-
-  // Verify the new number of frames.
-  EXPECT_EQ(model->get_num_frames(), 6);
-
-  // Finalize() stage.
-  EXPECT_FALSE(model->topology_is_valid());  // Not valid before Finalize().
-  EXPECT_NO_THROW(model->Finalize());
-  EXPECT_TRUE(model->topology_is_valid());  // Valid after Finalize().
-
-  // Asserts that no more bodies can be added after finalize.
-  EXPECT_THROW(model->AddBody<RigidBody>(M_Bo_B), std::logic_error);
-  EXPECT_THROW(model->AddFrame<FixedOffsetFrame>(lower_link, X_LEo),
-               std::logic_error);
-
-  // Asserts re-finalization is not allowed.
-  EXPECT_THROW(model->Finalize(), std::logic_error);
-
-  // Frame indexes are assigned by MultibodyTree. The number of physical frames
-  // equals the number of body frames (one per body) plus the number of
-  // additional frames added to the system (like FixedOffsetFrame objects).
-  // The first MultibodyTree::get_num_bodies() frame indexes (starting at zero)
-  // correspond to the body frames. All other physical frames have indexes from
-  // MultibodyTree::get_num_bodies() to
-  // MultibodyTree::get_num_frames() - 1.
-  // The order of the frames and their indexes is an implementation detail that
-  // users do not need to know about. Therefore this unit tests would need to
-  // change in the future if we decide to change th "internal detail" on how we
-  // assign these indexes.
-  EXPECT_EQ(shoulder_inboard_frame.get_index(), FrameIndex(0));
-  EXPECT_EQ(upper_link.get_body_frame().get_index(), FrameIndex(1));
-  EXPECT_EQ(lower_link.get_body_frame().get_index(), FrameIndex(2));
-  EXPECT_EQ(shoulder_outboard_frame.get_index(), FrameIndex(3));
-  EXPECT_EQ(elbow_inboard_frame.get_index(), FrameIndex(4));
-  EXPECT_EQ(elbow_outboard_frame.get_index(), FrameIndex(5));
-
-  // Check that frames are associated with the correct bodies.
-  EXPECT_EQ(
-      shoulder_inboard_frame.get_body().get_index(), world_body.get_index());
-  EXPECT_EQ(
-      shoulder_outboard_frame.get_body().get_index(), upper_link.get_index());
-  EXPECT_EQ(
-      elbow_inboard_frame.get_body().get_index(), upper_link.get_index());
-  EXPECT_EQ(
-      elbow_outboard_frame.get_body().get_index(), lower_link.get_index());
-
-  // Checks we can retrieve the body associated with a frame.
-  EXPECT_EQ(&shoulder_inboard_frame.get_body(), &world_body);
-  EXPECT_EQ(&shoulder_outboard_frame.get_body(), &upper_link);
-  EXPECT_EQ(&elbow_inboard_frame.get_body(), &upper_link);
-  EXPECT_EQ(&elbow_outboard_frame.get_body(), &lower_link);
+  EXPECT_EQ(&bodies[world_body_->get_index()].get(), world_body_);
+  EXPECT_EQ(&bodies[upper_link_->get_index()].get(), upper_link_);
+  EXPECT_EQ(&bodies[lower_link_->get_index()].get(), lower_link_);
 }
 
 }  // namespace

--- a/drake/multibody/multibody_tree/test/double_pendulum_test.cc
+++ b/drake/multibody/multibody_tree/test/double_pendulum_test.cc
@@ -62,7 +62,7 @@ class PendulumTests : public ::testing::Test {
     // The shoulder is the mobilizer that connects the world to the upper link.
     // Its inboard frame, Si, is the world frame. Its outboard frame, So, a
     // fixed offset frame on the upper link.
-    shoulder_inboard_frame_ = &world_body_->get_body_frame();
+    shoulder_inboard_frame_ = &model_->get_world_frame();
 
     // The body frame of the upper link is U, and that of the lower link is L.
     // We will add a frame for the pendulum's shoulder. This will be the

--- a/drake/multibody/multibody_tree/test/double_pendulum_test.cc
+++ b/drake/multibody/multibody_tree/test/double_pendulum_test.cc
@@ -36,8 +36,7 @@ class PendulumTests : public ::testing::Test {
   // Creates an "empty" MultibodyTree that only contains the "world" body and
   // world body frame.
   void SetUp() override {
-    owned_model_ = std::make_unique<MultibodyTree<double>>();
-    model_ = owned_model_.get();
+    model_ = std::make_unique<MultibodyTree<double>>();
 
     // Retrieves the world body.
     world_body_ = &model_->get_world_body();
@@ -111,8 +110,7 @@ class PendulumTests : public ::testing::Test {
   }
 
  protected:
-  std::unique_ptr<MultibodyTree<double>> owned_model_;
-  MultibodyTree<double>* model_;
+  std::unique_ptr<MultibodyTree<double>> model_;
   const Body<double>* world_body_;
   // Bodies:
   const RigidBody<double>* upper_link_;

--- a/drake/multibody/multibody_tree/test/double_pendulum_test.cc
+++ b/drake/multibody/multibody_tree/test/double_pendulum_test.cc
@@ -233,8 +233,9 @@ TEST_F(PendulumTests, Finalize) {
   EXPECT_THROW(model_->AddBody<RigidBody>(M_Bo_B), std::logic_error);
   EXPECT_THROW(model_->AddFrame<FixedOffsetFrame>(*lower_link_, X_LEo_),
                std::logic_error);
-  EXPECT_THROW(model_->AddMobilizer<Mobilizer>(
-      *shoulder_inboard_frame_, *shoulder_outboard_frame_), std::logic_error);
+  EXPECT_THROW(model_->AddMobilizer<RevoluteMobilizer>(
+      *shoulder_inboard_frame_, *shoulder_outboard_frame_,
+      Vector3d::UnitZ()), std::logic_error);
 
   // Asserts re-finalization is not allowed.
   EXPECT_THROW(model_->Finalize(), std::logic_error);

--- a/drake/multibody/multibody_tree/test/double_pendulum_test.cc
+++ b/drake/multibody/multibody_tree/test/double_pendulum_test.cc
@@ -9,6 +9,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/multibody_tree/fixed_offset_frame.h"
+#include "drake/multibody/multibody_tree/revolute_mobilizer.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 
 namespace drake {
@@ -17,6 +18,7 @@ namespace {
 
 using Eigen::Isometry3d;
 using Eigen::Translation3d;
+using Eigen::Vector3d;
 using std::make_unique;
 using std::unique_ptr;
 
@@ -99,11 +101,13 @@ class PendulumTests : public ::testing::Test {
     //  const Mobilizer& AddMobilizer(std::unique_ptr<MobilizerType> mobilizer).
     shoulder_mobilizer_ =
         &model_->AddMobilizer(
-            make_unique<Mobilizer<double>>(
-                *shoulder_inboard_frame_, *shoulder_outboard_frame_));
+            make_unique<RevoluteMobilizer<double>>(
+                *shoulder_inboard_frame_, *shoulder_outboard_frame_,
+                Vector3d::UnitZ() /*revolute axis*/));
     // Using: const MobilizerType<T>& AddMobilizer(Args&&... args)
-    elbow_mobilizer_ = &model_->AddMobilizer<Mobilizer>(
-        *elbow_inboard_frame_, *elbow_outboard_frame_);
+    elbow_mobilizer_ = &model_->AddMobilizer<RevoluteMobilizer>(
+        *elbow_inboard_frame_, *elbow_outboard_frame_,
+        Vector3d::UnitZ() /*revolute axis*/);
   }
 
  protected:
@@ -119,8 +123,8 @@ class PendulumTests : public ::testing::Test {
   const FixedOffsetFrame<double>* elbow_inboard_frame_;
   const FixedOffsetFrame<double>* elbow_outboard_frame_;
   // Mobilizers:
-  const Mobilizer<double>* shoulder_mobilizer_;
-  const Mobilizer<double>* elbow_mobilizer_;
+  const RevoluteMobilizer<double>* shoulder_mobilizer_;
+  const RevoluteMobilizer<double>* elbow_mobilizer_;
   // Pendulum parameters:
   const double link_length = 1.0;
   const double half_link_length = link_length / 2;
@@ -191,6 +195,10 @@ TEST_F(PendulumTests, CreateModelBasics) {
   EXPECT_EQ(&shoulder_mobilizer_->get_outboard_body(), upper_link_);
   EXPECT_EQ(&elbow_mobilizer_->get_inboard_body(), upper_link_);
   EXPECT_EQ(&elbow_mobilizer_->get_outboard_body(), lower_link_);
+
+  // Request revolute mobilizers' axes.
+  EXPECT_EQ(shoulder_mobilizer_->get_revolute_axis(), Vector3d::UnitZ());
+  EXPECT_EQ(elbow_mobilizer_->get_revolute_axis(), Vector3d::UnitZ());
 }
 
 // Frame indexes are assigned by MultibodyTree. The number of frames


### PR DESCRIPTION
Mobilizer objects allow to grant dofs between two frame objects within a multibody tree model. This is a fundamental concept within MBT closely related to the concept of a `Joint` but they should not be confused.  `Joint` objects will allow to specify how two bodies are connected regardless of how internally that joint is implemented (for instance through a `Mobilizer` granting dofs, a `Constraint` or a combination). 
In a nutshell, given an inboard frame `F` and an outboard frame `M` a `Mobilizer` specifies:
 1. How two `Frame` entities (and the bodies they reference to) are connected in a multibody tree structure. Therefore `Mobilizer` conveys the concept of a "tree" (the future `Joint` class will not be tied to this restriction, however, not fundamental to the structure of MBT but mostly syntactic sugar.)
 2. The kinematic relations between the inboard and outboard frames, i.e. `X_FM(q)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6071)
<!-- Reviewable:end -->
