### PR TITLE
Bazel Install

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,8 @@
 # This file is named BUILD.bazel instead of the more typical BUILD, so that on
 # OSX it won't conflict with a build artifacts directory named "build".
 
+load("//tools:install.bzl", "install")
+
 package(
     default_visibility = ["//visibility:public"],
 )
@@ -26,4 +28,13 @@ alias(
 alias(
     name="protobuf_python",
     actual="@protobuf//:protobuf_python",
+)
+
+install(
+    name = "install",
+    deps = [
+        "@lcm//:install",
+        "//drake:install",
+        "//tools:install",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,9 +104,9 @@ maven_jar(
 github_archive(
     name = "lcm",
     repository = "lcm-proj/lcm",
-    commit = "755d8108bf4447d83786e0e6586875371ba859e5",
+    commit = "c0a0093a950fc83e12e8d5918a0319b590356e7e",
     build_file = "tools/lcm.BUILD",
-    sha256 = "062b2daf35deb617552ffc2145ec238a2898710c8c5e9c49dc2514519c5f7930",
+    sha256 = "d5bb1a0153b9c1526590e7d65be8ca79e4f5e9bf4ce58178c992eaca49d17fb0",
 )
 
 github_archive(
@@ -300,8 +300,8 @@ pypi_archive(
 github_archive(
     name = "pycps",
     repository = "mwoehlke/pycps",
-    commit = "1b985467d1fe737ed3a43a25f4da3316bd45106f",
-    sha256 = "4491debd18ee40bf9d7eab9b35776eff98a71bc904a339f709273cbad9ac6efb",
+    commit = "a05280f1ef1d8970aca8c67dc4cf753953e3cdf7",
+    sha256 = "3024d25ddcb6bb6835834575e577f36bfd6e768501b8c2a2fd66181eb27108ce",
     build_file = "tools/pycps.BUILD",
 )
 

--- a/drake/BUILD
+++ b/drake/BUILD
@@ -4,6 +4,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//tools:drake.bzl", "drake_header_tar")
+load("//tools:install.bzl", "install")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 # This list is obviously incomplete.
@@ -32,11 +33,22 @@ cc_binary(
 # All the headers mentioned in "hdrs" attributes of the transitive closure of
 # dependencies of the _LIBDRAKE_COMPONENTS. This is a superset of the headers
 # actually required to operate Drake.
+# TODO(mwoehlke-kitware): remove once install finished
 drake_header_tar(
     name = "libdrake_headers",
     deps = _LIBDRAKE_COMPONENTS,
 )
 
+# Install libdrake.so along with all transitive headers in the same workspace
+# (i.e. in Drake itself; not externals).
+install(
+    name = "install",
+    guess_hdrs = "WORKSPACE",
+    hdr_dest = "include/drake",
+    targets = ["libdrake.so"],
+)
+
+# TODO(mwoehlke-kitware): remove once install finished
 pkg_tar(
     name = "external_licenses",
     extension = "tar.gz",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+load("//tools:install.bzl", "install_files")
+
 package(default_visibility = ["//visibility:public"])
 
 # Depend on this when you need to call clang-format.  (We don't have a label
@@ -57,6 +59,12 @@ genrule(
     cmd = "$(location @pycps//:cps2cmake_executable) $(location drake.cps) > \"$@\"",
     tools = ["@pycps//:cps2cmake_executable"],
     visibility = ["//visibility:private"],
+)
+
+install_files(
+    name = "install",
+    dest = "lib/drake/cmake",
+    files = ["drake-config.cmake"],
 )
 
 # This pulls the otherwise-unused libbot targets into the "//..." label tree.

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -31,6 +31,11 @@ py_binary(
 )
 
 exports_files(
+    ["install.py.in"],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
     ["nlopt-gen-hpp.sh"],
     visibility = ["@nlopt//:__pkg__"],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -47,6 +47,11 @@ exports_files(
     visibility = ["@ipopt//:__pkg__"],
 )
 
+exports_files(
+    ["lcm-create-cps.py"],
+    visibility = ["@lcm//:__pkg__"],
+)
+
 alias(
     name = "buildifier",
     actual = "@com_github_bazelbuild_buildtools//buildifier",

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -1,0 +1,349 @@
+# -*- python -*-
+
+InstallInfo = provider()
+
+#==============================================================================
+#BEGIN internal helpers
+
+#------------------------------------------------------------------------------
+def _join_paths(*args):
+    """Join paths without duplicating separators.
+
+    This is roughly equivalent to Python's `os.path.join`.
+
+    Args:
+        \*args (:obj:`list` of :obj:`str`): Path components to be joined.
+
+    Returns:
+        :obj:`str`: The concatenation of the input path components.
+    """
+    result = ""
+
+    for part in args:
+        if len(part) == 0:
+            continue
+
+        result += part
+        if result[-1] != "/":
+            result += "/"
+
+    return result[:-1]
+
+#------------------------------------------------------------------------------
+# Remove prefix from path.
+def ___remove_prefix(path, prefix):
+    # If the prefix has more parts than the path, failure is certain.
+    if len(prefix) > len(path):
+        return None
+
+    # Iterate over components to determine if a match exists.
+    for n in range(len(prefix)):
+        if prefix[n] == path[n]:
+            continue
+        elif prefix[n] == "*":
+            continue
+        else:
+            return None
+
+    return "/".join(path[len(prefix):])
+
+def __remove_prefix(path, prefix):
+    # Ignore trailing empty element (happens if prefix string ends with "/").
+    if len(prefix[-1]) == 0:
+        prefix = prefix[:-1]
+
+    # If the prefix has more parts than the path, failure is certain. (We also
+    # need at least one component of the path left over so the stripped path is
+    # not empty.)
+    if len(prefix) > (len(path) - 1):
+        return None
+
+    # Iterate over components to determine if a match exists.
+    for n in range(len(prefix)):
+        # Same path components match.
+        if prefix[n] == path[n]:
+            continue
+
+        # Single-glob matches any (one) path component.
+        elif prefix[n] == "*":
+            continue
+
+        # Mulit-glob matches one or more components.
+        elif prefix[n] == "**":
+            # If multi-glob is at the end of the prefix, return the last path
+            # component.
+            if n + 1 == len(prefix):
+                return path[-1]
+
+            # Otherwise, the most components the multi-glob can match is the
+            # remaining components (len(prefix) - n - 1; the 1 is the current
+            # prefix component) less one (since we need to keep at least one
+            # component of the path).
+            k = len(path) - (len(prefix) - n - 2)
+
+            # Try to complete the match, iterating (backwards) over the number
+            # of components that the multi-glob might match.
+            for t in reversed(range(n, k)):
+                x = ___remove_prefix(path[t:], prefix[n + 1:])
+                if x != None:
+                    return x
+
+            # Multi-glob failed to match.
+            return None
+
+        else:
+            # Components did not match.
+            return None
+
+    return "/".join(path[len(prefix):])
+
+def _remove_prefix(path, prefix):
+    """Remove prefix from path.
+
+    This attempts to remove the specified prefix from the specified path. The
+    prefix may contain the globs ``*`` or ``**``, which match one or many
+    path components, respectively. Matching is greedy. Globs may only be
+    matched against complete path components (e.g. ``a/*/`` is okay, but
+    ``a*/`` is not treated as a glob and will be matched literally). Due to
+    Skylark limitations, at most one ``**`` may be matched.
+
+    Args:
+        path (:obj:`str`) The path to modify.
+        prefix (:obj:`str`) The prefix to remove.
+
+    Returns:
+        :obj:`str`: The path with the prefix removed if successful, or None if
+        the prefix does not match the path.
+    """
+    return __remove_prefix(path.split("/"), prefix.split("/"))
+
+#------------------------------------------------------------------------------
+def _output_path(ctx, input_file, strip_prefix):
+    """Compute output path (without destination prefix) for install action.
+
+    This computes the adjusted output path for an input file. Specifically, it
+    a) determines the path relative to the invoking context (which is usually,
+    but not always, the same as the path as specified by the user when the file
+    was mentioned in a rule), without Bazel's various possible extras, and b)
+    to optionally removes prefixes from this path. When removing prefixes, the
+    first matching prefix is removed.
+
+    For example::
+
+        install_files(
+            dest = "docs",
+            files = ["foo/bar.txt"],
+            strip_prefix = ["foo/"],
+            ...)
+
+    The :obj:`File`'s path components will have various Bazel bits added. Our
+    first step is to recover the input path, ``foo/bar.txt``. Then we remove
+    the prefix ``foo``, giving a path of ``bar.txt``, which will become
+    ``docs/bar.txt`` when the install destination is added.
+
+    Args:
+        input_file (:obj:`File`): Artifact to be installed.
+        strip_prefix (:obj:`list` of :obj:`str`): List of prefixes to strip
+            from the input path before prepending the destination.
+
+    Returns:
+        :obj:`str`: The install destination path for the file.
+    """
+
+    # Determine base path of invoking context.
+    package_root = _join_paths(ctx.label.workspace_root, ctx.label.package)
+
+    # Determine effective path by removing path of invoking context and any
+    # Bazel output-files path.
+    input_path = input_file.path
+    if input_file.is_source:
+        input_path = _remove_prefix(input_path, package_root)
+    else:
+        out_root = _join_paths("bazel-out/*/*", package_root)
+        input_path = _remove_prefix(input_path, out_root)
+
+    # Possibly remove prefixes.
+    for p in strip_prefix:
+        output_path = _remove_prefix(input_path, p)
+        if input_path != None:
+            return input_path
+
+    return input_path
+
+#------------------------------------------------------------------------------
+def _install_actions(ctx, file_labels, dests, strip_prefix = []):
+    """Compute install actions for files.
+
+    This takes a list of labels (targets or files) and computes the install
+    actions for the files owned by each label.
+
+    Args:
+        file_labels (:obj:`list` of :obj:`Label`): labels to install.
+        dests (:obj:`str` or :obj:`dict` of :obj:`str` to :obj:`str`):
+            Install destination. If a :obj:`dict` may be given to supply a
+            mapping of file extension to destination path.
+        strip_prefix (:obj:`list` of :obj:`str`): List of prefixes to strip
+            from the input path before prepending the destination.
+
+    Returns:
+        :obj:`list`: A list of install actions.
+    """
+    actions = []
+
+    # Iterate over files. We expect a list of labels, which will have a 'files'
+    # attribute that is a list of File artifacts. Thus this two-level loop.
+    for f in file_labels:
+        for a in f.files:
+            if type(dests) == "dict":
+                dest = dests.get(a.extension, dests[None])
+            else:
+                dest = dests
+            p = _output_path(ctx, a, strip_prefix)
+            actions.append(struct(src = a, dst = _join_paths(dest, p)))
+
+    return actions
+
+#------------------------------------------------------------------------------
+# Compute install actions for a cc_library or cc_binary.
+def _install_cc_actions(ctx, target):
+    # TODO(mwoehlke-kitware): make these parameters.
+    dests = {"a": "lib", "so": "lib", None: "bin"}
+    return _install_actions(ctx, [target], dests)
+
+#------------------------------------------------------------------------------
+# Compute install actions for a java_library or java_binary.
+def _install_java_actions(ctx, target):
+    # TODO(mwoehlke-kitware): Implement this. Probably it mainly needs the
+    # logic to pick install destinations appropriately.
+    return []
+
+#END internal helpers
+#==============================================================================
+#BEGIN rules
+
+#------------------------------------------------------------------------------
+# Generate information to install "stuff". "Stuff" can be library or binary
+# targets, headers, or documentation files.
+def _install_impl(ctx):
+    actions = []
+
+    # Collect install actions from dependencies.
+    for d in ctx.attr.deps:
+        actions += d.install_actions
+
+    # Generate actions for docs and includes.
+    actions += _install_actions(ctx, ctx.attr.docs, ctx.attr.doc_dest)
+    actions += _install_actions(ctx, ctx.attr.hdrs, ctx.attr.hdr_dest,
+                                ctx.attr.hdr_strip_prefix)
+
+    for t in ctx.attr.targets:
+        # TODO(jwnimmer-tri): Raise an error if a target has testonly=1.
+        if hasattr(t, "cc"):
+            actions += _install_cc_actions(ctx, t)
+        elif hasattr(t, "java"):
+            actions += _install_java_actions(ctx, t)
+
+    return InstallInfo(install_actions = actions)
+
+install = rule(
+    attrs = {
+        "deps": attr.label_list(providers = ["install_actions"]),
+        "docs": attr.label_list(allow_files = True),
+        "doc_dest": attr.string(default = "share/doc"),
+        "hdrs": attr.label_list(allow_files = True),
+        "hdr_dest": attr.string(default = "include"),
+        "hdr_strip_prefix": attr.string_list(),
+        "targets": attr.label_list(),
+    },
+    implementation = _install_impl,
+)
+
+"""Generate installation information for various artifacts.
+
+This generates installation information for various artifacts, including
+documentation and header files, and targets (e.g. ``cc_binary``). By default,
+the path of any files is included in the install destination.
+See :rule:`install_files` for details.
+
+
+Args:
+    deps: List of other install rules that this rule should include.
+    docs: List of documentation files to install.
+    doc_dest: Destination for documentation files (default = "share/doc").
+    hdrs: List of header files to install.
+    hdr_dest: Destination for header files (default = "include").
+    hdr_strip_prefix: List of prefixes to remove from header paths.
+    targets: List of targets to install.
+"""
+
+#------------------------------------------------------------------------------
+# Generate information to install files to specified destination.
+def _install_files_impl(ctx):
+    # Get path components.
+    dest = ctx.attr.dest
+    strip_prefix = ctx.attr.strip_prefix
+
+    # Generate actions.
+    actions = _install_actions(ctx, ctx.attr.files, dest, strip_prefix)
+
+    # Return computed actions.
+    return InstallInfo(install_actions = actions)
+
+install_files = rule(
+    attrs = {
+        "dest": attr.string(mandatory = True),
+        "files": attr.label_list(allow_files = True),
+        "strip_prefix": attr.string_list(),
+    },
+    implementation = _install_files_impl,
+)
+
+"""Generate installation information for files.
+
+This generates installation information for a list of files. By default, any
+path portion of the file as named is included in the install destination. For
+example::
+
+    install_files(
+        dest = "docs",
+        files = ["foo/bar.txt"],
+        ...)
+
+This will install ``bar.txt`` to the destination ``docs/foo``.
+
+When this behavior is undesired, the ``strip_prefix`` parameter may be used to
+specify a list of prefixes to be removed from input file paths before computing
+the destination path. Stripping is not recursive; the first matching prefix
+will be stripped. Prefixes support the single-glob (``*``) to match any single
+path component, or the multi-glob (``**``) to match any number of path
+components. Multi-glob matching is greedy. Globs may only be matched against
+complete path components (e.g. ``a/*/`` is okay, but ``a*/`` is not treated as
+a glob and will be matched literally). Due to Skylark limitations, at most one
+``**`` may be matched.
+
+Args:
+    dest: Destination for files.
+    files: List of files to install.
+    strip_prefix: List of prefixes to remove from input paths.
+"""
+
+
+#------------------------------------------------------------------------------
+# Generate install script from install rules.
+def _install_driver_impl(ctx):
+    # TODO(mwoehlke-kitware): Generate script from collected install actions,
+    # and create rule to run the script as an argument to ctx.attr.driver. The
+    # run rule should depend on all file artifacts in the collected install
+    # actions. The run rule should also take a single argument, which is the
+    # install destination.
+    pass
+
+install_driver = rule(
+    attrs = {
+        "deps": attr.label_list(providers = ["install_actions"]),
+        "driver": attr.label(allow_files = True),
+    },
+    implementation = _install_driver_impl,
+)
+
+#END rules

--- a/tools/install.py.in
+++ b/tools/install.py.in
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+import argparse
+import filecmp
+import os
+import shutil
+
+subdirs = set()
+prefix = None
+
+
+def needs_install(src, dst):
+    # Get canonical destination.
+    dst_full = os.path.join(prefix, dst)
+
+    # Check if destination exists.
+    if not os.path.exists(dst_full):
+        # Destination doesn't exist -> installation needed.
+        return True
+
+    # Check if files are different.
+    if filecmp.cmp(src, dst_full, shallow=False):
+        # Files are the same -> no installation needed.
+        return False
+
+    # File needs to be installed.
+    return True
+
+
+def install(src, dst):
+    global subdirs
+
+    # Ensure destination subdirectory exists, creating it if necessary.
+    subdir = os.path.dirname(dst)
+    if subdir not in subdirs:
+        subdir_full = os.path.join(prefix, subdir)
+        if not os.path.exists(subdir_full):
+            os.makedirs(subdir_full)
+        subdirs.add(subdir)
+
+    # Install file, if not up to date.
+    if needs_install(src, dst):
+        print("[Installing] %s" % dst)
+        dst_full = os.path.join(prefix, dst)
+        if os.path.exists(dst_full):
+            os.remove(dst_full)
+        shutil.copy2(src, dst_full)
+
+    else:
+        print("[Up to date] %s" % dst)
+
+
+def main(args):
+    global prefix
+
+    # Set up options.
+    parser = argparse.ArgumentParser()
+    parser.add_argument('prefix', type=str, help='Install prefix')
+    args = parser.parse_args(args)
+
+    # Get install prefix.
+    prefix = args.prefix
+
+    # Because Bazel executes us in a strange working directory and not the
+    # working directory of the user's shell, enforce that the install
+    # location is an absolute path so that the user is not surprised.
+    if not os.path.isabs(prefix):
+        import sys
+        sys.stderr.write(
+            "Install prefix must be an absolute path (got %r)\n"
+            % prefix)
+        sys.exit(1)
+
+    # Execute the install actions.
+    <<actions>>
+
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv[1:])

--- a/tools/lcm-create-cps.py
+++ b/tools/lcm-create-cps.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+def_re = re.compile("#define LCM_(VERSION[^\s]+)\s+([^\s]+)")
+
+defs = {}
+with open(sys.argv[1]) as h:
+    for l in h:
+        m = def_re.match(l)
+        if m is not None:
+            defs[m.group(1)] = m.group(2)
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "lcm",
+  "Description": "Lightweight Communications and Marshaling library",
+  "License": "LGPL-2.1+",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
+  "Default-Components": [ "lcm" ],
+  "Components": {
+    "lcm-coretypes": {
+      "Type": "interface",
+      "Includes": [ "@prefix@/include" ]
+    },
+    "lcm": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/liblcm.so",
+      "Requires": [ ":lcm-coretypes" ]
+    },
+    "lcm-gen": {
+      "Type": "exe",
+      "Location": "@prefix@/bin/lcm-gen"
+    },
+    "lcm-java": {
+      "Type": "jar",
+      "Location": "@prefix@/share/java/lcm.jar"
+    }
+  },
+  "X-CMake-Variables": {
+    "LCM_NAMESPACE": "lcm::",
+    "LCM_VERSION": "${lcm_VERSION}",
+    "LCM_USE_FILE": "${CMAKE_CURRENT_LIST_DIR}/lcmUtilities.cmake"
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -204,8 +204,8 @@ install_files(
     dest = "lib/lcm/cmake",
     files = [
         "lcm-cmake/lcmUtilities.cmake",
-        "lcmConfig.cmake",  # TODO(mwoehlke-kitware) generate me!
-        "lcmConfigVersion.cmake",  # TODO(mwoehlke-kitware) generate me!
+        #"lcmConfig.cmake", # TODO(mwoehlke-kitware) generate me!
+        #"lcmConfigVersion.cmake", # TODO(mwoehlke-kitware) generate me!
     ],
     strip_prefix = ["**/"],
 )


### PR DESCRIPTION
Implement Bazel logic so that installation is driven by Bazel itself, rather than an external script. This allows us to install things that are critical to downstream consumers (especially of externals such as LCM) that aren't readily visible to Bazel as dependencies of `libdrake.so`, allows us to control what is installed (e.g. this fixes #6040), and moves management of install artifacts to the packages' respective BUILD files so that it is right next to the logic that specifies how to build stuff.

This works by adding two new directives — `install` and `install_files` — which gather information about install artifacts and compute the full install destinations, with `install` additionally creating a script (which can be run via `bazel run`) to perform the installation. Each `install` can depend on other `install` or `install_files`, so that the "root" rule installs everything. The file `install.py.in` contains the common install logic and is used as the template for creating the install scripts. (It would be possible to have `install_files` also produce an install script, but I doubt we need that granularity.)

This entire process will (eventually) replace the install mode of `package_drake.sh`. A future PR will replace that script with one that uses the new install process to populate a temporary install tree, which is then packaged into a `.tar.gz`. (As a bonus, Python prints the "what am I doing" lines *much* faster than bash.)

**NOTE:**
The installation produced by `bazel run install -- /install/prefix` is not usable as of this PR, as it does not install most of the externals (with the exception of LCM). However, since the framework is working at this point, I would like to go ahead and get it landed. Installation of the remaining externals would be done in separate commits anyway, and it's possible anyway that @fbudin69500 will be doing that rather than myself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6072)
<!-- Reviewable:end -->
