### PR TITLE
Add Bazel code style config. Update documentation for code style checking

### DIFF
--- a/drake/doc/code_style_tools.rst
+++ b/drake/doc/code_style_tools.rst
@@ -4,10 +4,11 @@
 Tools for Code Style Compliance
 *******************************
 
-This section provides a list of tools that some have found useful for ensuring their
-code abides by :ref:`Drake's coding style <code-style-guide>`. The list is by no means comprehensive.
-If your favorite tools or methodologies are not listed, we would be delighted to learn about them. Please
-document your trick and submit a pull request!
+This section provides a list of tools that some have found useful for ensuring
+their code abides by :ref:`Drake's coding style <code-style-guide>`. The list
+is by no means comprehensive.
+If your favorite tools or methodologies are not listed, we would be delighted
+to learn about them. Please document your trick and submit a pull request!
 
 .. contents:: `Table of contents`
    :depth: 3
@@ -52,7 +53,8 @@ Then install the version you prefer::
 
     sudo apt-get install clang-format-[version]
 
-Once installed, create a symbolic link so you don't need to type the version number every time you execute it::
+Once installed, create a symbolic link so you don't need to type the version
+number every time you execute it::
 
     sudo ln -s /usr/bin/clang-format-[version] /usr/local/bin/clang-format
 

--- a/drake/doc/code_style_tools.rst
+++ b/drake/doc/code_style_tools.rst
@@ -13,6 +13,26 @@ document your trick and submit a pull request!
    :depth: 3
    :local:
 
+All Languages
+=============
+
+.. _code-style-tools-all-languages:
+
+When using the Bazel build system, code style tests are run by default during
+``bazel test`` and its results are cached so that only edited files are
+re-checked.
+In other words, no special action is required to use the tool.
+
+However, you may still invoke code style checks directly if desired, as
+follows::
+
+  cd /path/to/drake-distro
+  bazel test --config lint ...                  # Only run style checks; don't build or test anything else.
+  bazel test --config lint //drake/common/...   # Check common/ and its child subdirectories.
+
+  cd drake/systems/framework
+  bazel test --config lint ...                  # Check systems/framework/ and its child subdirectories.
+
 C/C++
 =====
 
@@ -57,27 +77,20 @@ cpplint
 `cpplint <https://github.com/google/styleguide/tree/gh-pages/cpplint>`_
 is a tool for finding compliance violations.
 
-Using via Bazel
+Usage via Bazel
 ^^^^^^^^^^^^^^^
 
-When using the Bazel build system, cpplint is run by default during ``bazel
-test`` and its results are cached so that only edited files are re-checked.
-In other words, no special action is required to use the tool.
-However, you may still invoke cpplint directly if desired, as follows::
+Use the command in `All Languages`_, but change the configuration to use
+``cpplint``::
 
-  cd /path/to/drake-distro
-  bazel test --config cpplint ...                  # Only run cpplint; don't build or test anything else.
-  bazel test --config cpplint //drake/common/...   # Check common/ and its child subdirectories.
+  bazel test --config cpplint ...
 
-  cd drake/systems/framework
-  bazel test --config cpplint ...                  # Check systems/framework/ and its child subdirectories.
-
-Using without Bazel
+Usage without Bazel
 ^^^^^^^^^^^^^^^^^^^
 
 Here is the command::
 
-    drake-distro/drake/common/test/cpplint_wrapper.py
+  drake-distro/drake/common/test/cpplint_wrapper.py
 
 By default, all files in Drake are checked using the default settings.
 Consult the program's `--help` for more detailed options.
@@ -85,6 +98,51 @@ Consult the program's `--help` for more detailed options.
 
 Python
 ======
+
+.. _code-style-tools-pycodestyle:
+
+pycodestyle.py
+--------------
+
+``pycodestyle``, which used to be ``pep8``, is the primary code style checker
+used within Drake.
+
+Usage via Bazel
+^^^^^^^^^^^^^^^
+
+Use the command in `All Languages`_, but change the configuration to use
+``pycodestyle``::
+
+  bazel test --config pycodestyle ...
+
+Usage without Bazel
+^^^^^^^^^^^^^^^^^^^
+
+First, ensure that you have ``pycodestyle`` installed. On Ubuntu, install via
+``pip``::
+
+  pip install --user -U pycodestyle
+
+To your ``.bashrc`` or ``.profile``, add the line::
+
+  export PATH=$HOME/.local/bin:$PATH
+
+On OSX, similarly::
+
+  pip install --user -U pycodestyle
+
+To your ``.bashrc`` or ``.bash_profile``, add the line::
+
+  export PATH=$HOME/Library/Python/2.7/bin:$PATH
+
+Run ``pycodestyle`` like this::
+
+  pycodestyle [file name]
+
+It is possible to suppress pycodestyle errors, either via configuration files
+in various locations, or command line options. However, it does not support
+individual suppressions via source code comments. Consult the program's
+`--help` or ``pycodestyle.readthedocs.org`` for details.
 
 .. _code-style-tools-pylint:
 
@@ -94,21 +152,10 @@ pylint
 Installation
 ^^^^^^^^^^^^
 
-On Ubuntu, install via ``pip``::
-
-  pip install --user -U pylint
-
-To your ``.bashrc`` or ``.profile``, add the line::
-
-  export PATH=$HOME/.local/bin:$PATH
-
-On OSX, similarly::
-
-  pip install --user -U pylint
-
-To your ``.bashrc`` or ``.bash_profile``, add the line::
-
-  export PATH=$HOME/Library/Python/2.7/bin:$PATH
+Like ``pycodestyle``, ``pylint`` should be installed via ``pip``.
+Instructions are exactly analogous to those for ``pycodestyle`` above,
+substituting the package name
+``pylint``.
 
 Usage
 ^^^^^
@@ -120,25 +167,3 @@ To run ``pylint``, with some noisy reports and questionable rules suppressed::
 It is possible to suppress pylint complaints, either via configuration files in
 various locations, or by special comments in python source files. Consult the
 program's `--help` or ``docs.pylint.org`` for details.
-
-pep8.py
--------
-
-Installation
-^^^^^^^^^^^^
-
-Like ``pylint``, ``pep8`` should be installed via ``pip``. Instructions are
-exactly analogous to those for ``pylint`` above, substituting the package name
-``pep8``.
-
-Usage
-^^^^^
-
-Run ``pep8`` like this::
-
-  pep8 [file name]
-
-It is possible to suppress pep8 errors, either via configuration files in
-various locations, or command line options. However, it does not support
-individual suppressions via source code comments. Consult the program's
-`--help` or ``pep8.readthedocs.org`` for details.

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -90,6 +90,17 @@ build --deleted_packages=externals/snopt,externals/snopt/cppsrc,externals/snopt/
 test:cpplint --build_tests_only
 test:cpplint --test_tag_filters=cpplint
 
+### Pycodestyle. ###
+# Code style compliance checking for python, analogous to cpplint above.
+test:pycodestyle --build_tests_only
+test:pycodestyle --test_tag_filters=pycodestyle
+
+### Lint. ###
+# Code style compliance for C++ and Python, merging both cpplint and
+# pycodestyle.
+test:lint --build_tests_only
+test:lint --test_tag_filters=cpplint,pycodestyle
+
 ### Debug symbols on OS X. ###
 # See https://github.com/bazelbuild/bazel/issues/2537
 build:apple_debug --spawn_strategy=standalone


### PR DESCRIPTION
This adds `--config pycodestyle` for running Python code-style checks, and adds `--config lint` for C++ and Python style checking.

This updates the documentation:
1. Adds usage of the general code style check.
2. Adds usage of Python code style check.
3. Replace usage of `pep8` with `pycodestyle` (per [note on pypi page](https://pypi.python.org/pypi/pycodestyle#pycodestyle-formerly-called-pep8-python-style-guide-checker))
4. Moves `pylint` to the bottom, as it does not appear to be part of CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6076)
<!-- Reviewable:end -->
