### PR TITLE
bazel.rc: Add --test_summary=terse by default to keep failures prominent

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -11,6 +11,7 @@ build --output_filter="^//"
 
 # Default test options.
 test --test_output=errors
+test --test_summary=terse
 
 # By default, disable execution of tests that require proprietary software.
 # Individual targets that use proprietary software are responsible for ensuring


### PR DESCRIPTION
Per Jeremy's recommendation, this PR adds `--test_summary=terse` [[ref]](https://bazel.build/versions/master/docs/bazel-user-manual.html#flag--test_summary) to minimize the amount of output when running commands such as `bazel test //...`, and only print out tests that fail.

Example:
```
$ bazel test --config cpplint //...
..............
INFO: Found 1300 test targets...
INFO: Elapsed time: 24.748s, Critical Path: 5.87s

Executed 1300 out of 1300 tests: 1300 tests pass.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6079)
<!-- Reviewable:end -->
