### PR TITLE
Simplify fcl and nlopt BUILD files

### DIFF
--- a/tools/fcl.BUILD
+++ b/tools/fcl.BUILD
@@ -2,49 +2,23 @@
 
 load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
-# Lets other packages inspect the CMake code, e.g., for the version number.
-filegroup(
-    name = "cmakelists_with_version",
-    srcs = ["CMakeModules/FCLVersion.cmake"],
-    visibility = ["//visibility:public"],
-)
-
 # Generates config.h based on the version numbers in CMake code.
 cmake_configure_file(
     name = "config",
     src = "include/fcl/config.h.in",
     out = "include/fcl/config.h",
     cmakelists = [
-        ":cmakelists_with_version",
+        "CMakeModules/FCLVersion.cmake",
         "@octomap//:cmakelists_with_version",
     ],
     defines = ["FCL_HAVE_OCTOMAP"],
-    visibility = [],
-)
-
-# Generates the entire FCL library except the fcl/fcl.h generated header.
-# The globbed srcs= and hdrs= matches upstream's explicit globs of the same.
-cc_library(
-    name = "fcl_without_fclh",
-    srcs = glob(["src/**/*.cpp"]),
-    hdrs = glob(["include/**/*.h"]) + [
-        "include/fcl/config.h",  # From :config above.
-    ],
-    includes = ["include"],
-    linkstatic = 1,
-    visibility = [],
-    deps = [
-        "@ccd",
-        "@eigen",
-        "@octomap",
-    ],
 )
 
 # Generates fcl.h, which consists of #include statements for *all* of the other
 # headers in the library (!!!).  The first line is '#pragma once' followed by
 # one line like '#include "fcl/common/types.h"' for each non-generated header.
 genrule(
-    name = "fclh_genrule",
+    name = "fcl_h_genrule",
     srcs = glob(["include/**/*.h"]),
     outs = ["include/fcl/fcl.h"],
     cmd = "(" + (
@@ -52,14 +26,21 @@ genrule(
         "echo '$(SRCS)' | tr ' ' '\\n' | " +
         "sed 's|.*include/\(.*\)|#include \\\"\\1\\\"|g'"
     ) + ") > '$@'",
-    visibility = [],
 )
 
-# Generates the library exported to users.
+# The globbed srcs= and hdrs= matches upstream's explicit globs of the same.
 cc_library(
     name = "fcl",
-    hdrs = ["include/fcl/fcl.h"],  # From :fclh_genrule above.
+    srcs = glob(["src/**/*.cpp"]),
+    hdrs = glob(["include/**/*.h"]) + [
+        ":config",
+        ":fcl_h_genrule",
+    ],
     includes = ["include"],
     visibility = ["//visibility:public"],
-    deps = [":fcl_without_fclh"],
+    deps = [
+        "@ccd",
+        "@eigen",
+        "@octomap",
+    ],
 )

--- a/tools/nlopt.BUILD
+++ b/tools/nlopt.BUILD
@@ -2,21 +2,12 @@
 
 load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
-# Lets other packages inspect the CMake code, e.g., for the version number.
-filegroup(
-    name = "cmakelists_with_version",
-    srcs = ["CMakeLists.txt"],
-    visibility = ["//visibility:public"],
-)
-
 # Chooses the nlopt preprocessor substitutions that we want to use from Bazel.
 cmake_configure_file(
     name = "config",
     src = "nlopt_config.h.in",
     out = "nlopt_config.h",
-    cmakelists = [
-        ":cmakelists_with_version",
-    ],
+    cmakelists = ["CMakeLists.txt"],
     defines = [
         # These end up being unused; empty-string is a fail-fast value.
         "SIZEOF_UNSIGNED_INT=",
@@ -49,7 +40,6 @@ cmake_configure_file(
         # Yes, we are going to build the C++ bindings.
         "WITH_CXX=1",
     ],
-    visibility = [],
 )
 
 # Creates api/nlopt.hpp based on api/nlopt.h.
@@ -63,7 +53,6 @@ genrule(
     cmd = "$(location @//tools:nlopt-gen-hpp.sh) $(SRCS) $(OUTS) 2>&1 1>log" +
           " || (cat log && false)",
     tools = ["@//tools:nlopt-gen-hpp.sh"],
-    visibility = [],
 )
 
 cc_library(
@@ -95,8 +84,7 @@ cc_library(
     ).split(" ", None),
     hdrs = [
         "api/nlopt.h",
-        # This comes from a genrule above.
-        "api/nlopt.hpp",
+        ":nlopt_hpp_genrule",
     ],
     copts = [
         "-Wno-all",


### PR DESCRIPTION
I assume we were working around some previous limitation of Bazel before, but this can be done much more directly now. This came up in https://github.com/RobotLocomotion/drake/pull/6028#issuecomment-300884890 when `fcl.BUILD` was being used as a template for another package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6080)
<!-- Reviewable:end -->
