### PR TITLE
Removes dragway .cc files from libdrakeAutomotive to avoid ODR-violation.

### DIFF
--- a/drake/automotive/CMakeLists.txt
+++ b/drake/automotive/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
   bicycle_car.cc
   calc_smooth_acceleration.cc
-  create_trajectory_params.cc
   curve2.cc
   gen/bicycle_car_parameters.cc
   gen/bicycle_car_state.cc
@@ -28,11 +27,6 @@ add_library_with_exports(LIB_NAME drakeAutomotive SOURCE_FILES
   maliput/api/lane_data.cc
   maliput/api/road_geometry.cc
   maliput/api/segment.cc
-  maliput/dragway/branch_point.cc
-  maliput/dragway/junction.cc
-  maliput/dragway/lane.cc
-  maliput/dragway/road_geometry.cc
-  maliput/dragway/segment.cc
   maliput/monolane/arc_lane.cc
   maliput/monolane/branch_point.cc
   maliput/monolane/builder.cc
@@ -138,7 +132,9 @@ if(lcm_FOUND)
       drake-automotive
       drake-rigid-body-plant)
 
-  add_executable(automotive_demo automotive_demo.cc)
+  add_executable(automotive_demo
+      automotive_demo.cc
+      create_trajectory_params.cc)
   target_link_libraries(automotive_demo
       drakeAutomotiveLcm
       drakeMaliputDragway)

--- a/drake/automotive/test/CMakeLists.txt
+++ b/drake/automotive/test/CMakeLists.txt
@@ -26,21 +26,33 @@ drake_add_cc_test(monolane_onramp_merge_test)
 target_link_libraries(monolane_onramp_merge_test drakeAutomotive)
 
 drake_add_cc_test(pose_selector_test)
-target_link_libraries(pose_selector_test drakeAutomotive)
+target_link_libraries(pose_selector_test
+    drakeAutomotive
+    drakeMaliputDragway)
 
 drake_add_cc_test(pure_pursuit_test)
-target_link_libraries(pure_pursuit_test drakeAutomotive)
+target_link_libraries(pure_pursuit_test
+    drakeAutomotive
+    drakeMaliputDragway)
 
 drake_add_cc_test(pure_pursuit_controller_test)
-target_link_libraries(pure_pursuit_controller_test drakeAutomotive)
+target_link_libraries(pure_pursuit_controller_test
+    drakeAutomotive
+    drakeMaliputDragway)
 
 drake_add_cc_test(idm_controller_test)
-target_link_libraries(idm_controller_test drakeAutomotive)
+target_link_libraries(idm_controller_test
+    drakeAutomotive
+    drakeMaliputDragway)
 
 drake_add_cc_test(road_path_test)
-target_link_libraries(road_path_test drakeAutomotive)
+target_link_libraries(road_path_test
+    drakeAutomotive
+    drakeMaliputDragway)
 
 if(lcm_FOUND)
   drake_add_cc_test(automotive_simulator_test)
-  target_link_libraries(automotive_simulator_test drakeAutomotiveLcm)
+  target_link_libraries(automotive_simulator_test
+      drakeAutomotiveLcm
+      drakeMaliputDragway)
 endif()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6083)
<!-- Reviewable:end -->
