### PR TITLE
Add proper constant terms for LinearCost and QuadraticCost. Add cost offsets to Gurobi and MOSEK solution costs.

### DIFF
--- a/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
+++ b/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
@@ -227,12 +227,14 @@ PYBIND11_PLUGIN(_pydrake_mathematicalprogram) {
 
   py::class_<LinearCost, Cost, std::shared_ptr<LinearCost>>(
     m, "LinearCost")
-    .def("A", &LinearCost::A);
+    .def("a", &LinearCost::a)
+    .def("b", &LinearCost::b);
 
   py::class_<QuadraticCost, Cost,
              std::shared_ptr<QuadraticCost>>(m, "QuadraticCost")
     .def("Q", &QuadraticCost::Q)
-    .def("b", &QuadraticCost::b);
+    .def("b", &QuadraticCost::b)
+    .def("c", &QuadraticCost::c);
 
   RegisterBinding<LinearCost>(&m, &prog_cls, "LinearCost");
   RegisterBinding<QuadraticCost>(&m, &prog_cls, "QuadraticCost");

--- a/drake/examples/QPInverseDynamicsForHumanoids/qp_controller.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/qp_controller.cc
@@ -22,7 +22,8 @@ void QPController::AddAsConstraints(
     tmp_vd_vec_.row(row_ctr) = b.row(d);
     row_ctr++;
   }
-  eq->UpdateConstraint(tmp_vd_mat_.topRows(row_ctr), tmp_vd_vec_.head(row_ctr));
+  eq->UpdateCoefficients(tmp_vd_mat_.topRows(row_ctr),
+                         tmp_vd_vec_.head(row_ctr));
 }
 
 template <typename DerivedA, typename DerivedB, typename DerivedW>
@@ -45,7 +46,7 @@ void QPController::AddAsCosts(const Eigen::MatrixBase<DerivedA>& A,
     tmp_vd_mat_ += weight * A.row(d).transpose() * A.row(d);
     tmp_vd_vec_ += weight * A.row(d).transpose() * b.row(d);
   }
-  cost->UpdateQuadraticAndLinearTerms(tmp_vd_mat_, tmp_vd_vec_);
+  cost->UpdateCoefficients(tmp_vd_mat_, tmp_vd_vec_);
 }
 
 void QPController::SetTempMatricesToZero() {
@@ -437,7 +438,7 @@ int QPController::Control(const HumanoidStatus& rs, const QpInput& input,
           -JB_.block(0, i, num_dynamics_equations_, 1);
     }
     dynamics_constant_ = -rs.bias_term().head(num_dynamics_equations_);
-    eq_dynamics_->UpdateConstraint(dynamics_linear_, dynamics_constant_);
+    eq_dynamics_->UpdateCoefficients(dynamics_linear_, dynamics_constant_);
   }
 
   // Contact constraints, 3 rows per contact point
@@ -448,7 +449,7 @@ int QPController::Control(const HumanoidStatus& rs, const QpInput& input,
     int force_dim = 3 * contact.num_contact_points();
     // As cost
     if (contact.acceleration_constraint_type() == ConstraintType::Soft) {
-      cost_contacts_[cost_ctr]->UpdateQuadraticAndLinearTerms(
+      cost_contacts_[cost_ctr]->UpdateCoefficients(
           contact.weight() *
               stacked_contact_jacobians_.block(rowIdx, 0, force_dim, num_vd_)
                   .transpose() *
@@ -463,7 +464,7 @@ int QPController::Control(const HumanoidStatus& rs, const QpInput& input,
       cost_contacts_[cost_ctr++]->set_description(contact.body_name() +
                                                   " contact cost");
     } else {
-      eq_contacts_[eq_ctr]->UpdateConstraint(
+      eq_contacts_[eq_ctr]->UpdateCoefficients(
           stacked_contact_jacobians_.block(rowIdx, 0, force_dim, num_vd_),
           -(stacked_contact_jacobians_dot_times_v_.segment(rowIdx, force_dim) +
             contact.Kd() *
@@ -496,7 +497,7 @@ int QPController::Control(const HumanoidStatus& rs, const QpInput& input,
     inequality_lower_bound_[i] += rs.robot().actuators[i].effort_limit_min_;
     inequality_upper_bound_[i] += rs.robot().actuators[i].effort_limit_max_;
   }
-  ineq_torque_limit_->UpdateConstraint(
+  ineq_torque_limit_->UpdateCoefficients(
       inequality_linear_, inequality_lower_bound_, inequality_upper_bound_);
 
   ////////////////////////////////////////////////////////////////////
@@ -572,8 +573,8 @@ int QPController::Control(const HumanoidStatus& rs, const QpInput& input,
       tmp_vd_vec_[row_ctr] = input.desired_dof_motions().value(d);
       row_ctr++;
     }
-    eq_dof_motion_->UpdateConstraint(tmp_vd_mat_.topRows(row_ctr),
-                                     tmp_vd_vec_.head(row_ctr));
+    eq_dof_motion_->UpdateCoefficients(tmp_vd_mat_.topRows(row_ctr),
+                                       tmp_vd_vec_.head(row_ctr));
   }
   // Procecss cost terms.
   if (row_idx_as_cost.size() > 0) {
@@ -585,12 +586,12 @@ int QPController::Control(const HumanoidStatus& rs, const QpInput& input,
       tmp_vd_mat_(d, d) = weight;
       tmp_vd_vec_[d] = -weight * input.desired_dof_motions().value(d);
     }
-    cost_dof_motion_->UpdateQuadraticAndLinearTerms(tmp_vd_mat_, tmp_vd_vec_);
+    cost_dof_motion_->UpdateCoefficients(tmp_vd_mat_, tmp_vd_vec_);
   }
 
   // Regularize basis to zero.
-  cost_basis_reg_->UpdateQuadraticAndLinearTerms(
-      input.w_basis_reg() * basis_reg_mat_, basis_reg_vec_);
+  cost_basis_reg_->UpdateCoefficients(input.w_basis_reg() * basis_reg_mat_,
+                                      basis_reg_vec_);
 
   ////////////////////////////////////////////////////////////////////
   // Call solver.

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -436,6 +436,7 @@ drake_cc_googletest(
     ],
 )
 
+# TODO(eric.cousineau): Remove dependence on create_cost
 drake_cc_googletest(
     name = "cost_test",
     deps = [

--- a/drake/solvers/constraint.h
+++ b/drake/solvers/constraint.h
@@ -245,8 +245,8 @@ class QuadraticConstraint : public Constraint {
    * @param new_b new linear term
    */
   template <typename DerivedQ, typename DerivedB>
-  void UpdateQuadraticAndLinearTerms(const Eigen::MatrixBase<DerivedQ>& new_Q,
-                                     const Eigen::MatrixBase<DerivedB>& new_b) {
+  void UpdateCoefficients(const Eigen::MatrixBase<DerivedQ>& new_Q,
+                          const Eigen::MatrixBase<DerivedB>& new_b) {
     if (new_Q.rows() != new_Q.cols() || new_Q.rows() != new_b.rows() ||
         new_b.cols() != 1) {
       throw std::runtime_error("New constraints have invalid dimensions");
@@ -472,9 +472,9 @@ class LinearConstraint : public Constraint {
    * @param new_up new upper bound
    */
   template <typename DerivedA, typename DerivedL, typename DerivedU>
-  void UpdateConstraint(const Eigen::MatrixBase<DerivedA>& new_A,
-                        const Eigen::MatrixBase<DerivedL>& new_lb,
-                        const Eigen::MatrixBase<DerivedU>& new_ub) {
+  void UpdateCoefficients(const Eigen::MatrixBase<DerivedA>& new_A,
+                          const Eigen::MatrixBase<DerivedL>& new_lb,
+                          const Eigen::MatrixBase<DerivedU>& new_ub) {
     if (new_A.rows() != new_lb.rows() || new_lb.rows() != new_ub.rows() ||
         new_lb.cols() != 1 || new_ub.cols() != 1) {
       throw std::runtime_error("New constraints have invalid dimensions");
@@ -524,9 +524,9 @@ class LinearEqualityConstraint : public LinearConstraint {
    *different number of linear constraints, but on the same decision variables)
    */
   template <typename DerivedA, typename DerivedB>
-  void UpdateConstraint(const Eigen::MatrixBase<DerivedA>& Aeq,
-                        const Eigen::MatrixBase<DerivedB>& beq) {
-    LinearConstraint::UpdateConstraint(Aeq, beq, beq);
+  void UpdateCoefficients(const Eigen::MatrixBase<DerivedA>& Aeq,
+                          const Eigen::MatrixBase<DerivedB>& beq) {
+    LinearConstraint::UpdateCoefficients(Aeq, beq, beq);
   }
 };
 

--- a/drake/solvers/cost.cc
+++ b/drake/solvers/cost.cc
@@ -21,17 +21,45 @@ void CostShimBase::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   impl_->Eval(x, y);
 }
 
+void LinearCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                        Eigen::VectorXd& y) const {
+  y.resize(1);
+  y(0) = a_.dot(x) + b_;
+}
+void LinearCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                        AutoDiffVecXd& y) const {
+  y.resize(1);
+  y(0) = a_.cast<AutoDiffXd>().dot(x) + b_;
+}
+
+void QuadraticCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                           Eigen::VectorXd& y) const {
+  y.resize(1);
+  y = .5 * x.transpose() * Q_ * x + b_.transpose() * x;
+  y(0) += c_;
+}
+
+void QuadraticCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                           AutoDiffVecXd& y) const {
+  y.resize(1);
+  y = .5 * x.transpose() * Q_.cast<AutoDiffXd>() * x +
+      b_.cast<AutoDiffXd>().transpose() * x;
+  y(0) += c_;
+}
+
 shared_ptr<QuadraticCost> MakeQuadraticErrorCost(
     const Eigen::Ref<const MatrixXd>& Q,
     const Eigen::Ref<const VectorXd>& x_desired) {
-  return make_shared<QuadraticCost>(2 * Q, -2 * Q * x_desired);
+  const double c = x_desired.dot(Q * x_desired);
+  return make_shared<QuadraticCost>(2 * Q, -2 * Q * x_desired, c);
 }
 
 shared_ptr<QuadraticCost> MakeL2NormCost(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
     const Eigen::Ref<const Eigen::VectorXd>& b) {
+  const double c = b.dot(b);
   return make_shared<QuadraticCost>(2 * A.transpose() * A,
-                                    -2 * A.transpose() * b);
+                                    -2 * A.transpose() * b, c);
 }
 
 }  // namespace solvers

--- a/drake/solvers/cost.h
+++ b/drake/solvers/cost.h
@@ -78,52 +78,127 @@ class CostShim : public CostShimBase {
 };
 
 /**
- * Implements a cost of the form @f Ax @f
+ * Implements a cost of the form @f a'x + b @f.
  */
-class LinearCost : public CostShim<LinearConstraint> {
+class LinearCost : public Cost {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearCost)
 
-  explicit LinearCost(const Eigen::Ref<const Eigen::VectorXd>& c)
-      : CostShim(c.transpose(), Vector1<double>::Constant(
-                                    -std::numeric_limits<double>::infinity()),
-                 Vector1<double>::Constant(
-                     std::numeric_limits<double>::infinity())) {}
+  /**
+   * Construct a linear cost of the form @f a'x + b @f.
+   * @param a Linear term.
+   * @param b (optional) Constant term.
+   */
+  // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
+  LinearCost(const Eigen::Ref<const Eigen::VectorXd>& a, double b = 0.)
+      : Cost(a.rows()), a_(a), b_(b) {}
+
+  ~LinearCost() override {}
 
   Eigen::SparseMatrix<double> GetSparseMatrix() const {
-    return constraint()->GetSparseMatrix();
+    // TODO(eric.cousineau): Consider storing or caching sparse matrix, such
+    // that we can return a const lvalue reference.
+    return a_.sparseView();
   }
-  const Eigen::MatrixXd& A() const { return constraint()->A(); }
+
+  const Eigen::VectorXd& a() const { return a_; }
+
+  double b() const { return b_; }
+
+  /**
+   * Updates the linear term, upper and lower bounds in the linear constraint.
+   * The updated constraint is @f a_new' x + b_new @f.
+   * Note that the number of variables (number of cols) cannot change.
+   * @param new_a New linear term.
+   * @param new_b (optional) New constant term.
+   */
+  void UpdateCoefficients(const Eigen::Ref<const Eigen::VectorXd>& new_a,
+                          double new_b = 0.) {
+    if (new_a.rows() != a_.rows()) {
+      throw std::runtime_error("Can't change the number of decision variables");
+    }
+
+    a_ = new_a;
+    b_ = new_b;
+  }
+
+ protected:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd& y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd& y) const override;
+
+ private:
+  Eigen::VectorXd a_;
+  double b_{};
 };
 
 /**
- * Implements a cost of the form @f .5 x'Qx + b'x @f
+ * Implements a cost of the form @f .5 x'Qx + b'x + c @f.
  */
-class QuadraticCost : public CostShim<QuadraticConstraint> {
+class QuadraticCost : public Cost {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(QuadraticCost)
 
+  /**
+   * Constructs a cost of the form @f .5 x'Qx + b'x + c @f.
+   * @param Q Quadratic term.
+   * @param b Linear term.
+   * @param c (optional) Constant term.
+   */
   template <typename DerivedQ, typename Derivedb>
   QuadraticCost(const Eigen::MatrixBase<DerivedQ>& Q,
-                const Eigen::MatrixBase<Derivedb>& f)
-      : CostShim(Q, f, -std::numeric_limits<double>::infinity(),
-                 std::numeric_limits<double>::infinity()) {}
+                const Eigen::MatrixBase<Derivedb>& b, double c = 0.)
+      : Cost(Q.rows()), Q_(Q), b_(b), c_(c) {
+    DRAKE_ASSERT(Q_.rows() == Q_.cols());
+    DRAKE_ASSERT(Q_.cols() == b_.rows());
+  }
 
-  const Eigen::MatrixXd& Q() const { return constraint()->Q(); }
+  ~QuadraticCost() override {}
 
-  const Eigen::VectorXd& b() const { return constraint()->b(); }
+  const Eigen::MatrixXd& Q() const { return Q_; }
+
+  const Eigen::VectorXd& b() const { return b_; }
+
+  double c() const { return c_; }
 
   /**
    * Updates the quadratic and linear term of the constraint. The new
    * matrices need to have the same dimension as before.
    * @param new_Q New quadratic term.
    * @param new_b New linear term.
+   * @param new_c (optional) New constant term.
    */
   template <typename DerivedQ, typename DerivedB>
-  void UpdateQuadraticAndLinearTerms(const Eigen::MatrixBase<DerivedQ>& new_Q,
-                                     const Eigen::MatrixBase<DerivedB>& new_b) {
-    constraint()->UpdateQuadraticAndLinearTerms(new_Q, new_b);
+  void UpdateCoefficients(const Eigen::MatrixBase<DerivedQ>& new_Q,
+                          const Eigen::MatrixBase<DerivedB>& new_b,
+                          double new_c = 0.) {
+    if (new_Q.rows() != new_Q.cols() || new_Q.rows() != new_b.rows() ||
+        new_b.cols() != 1) {
+      throw std::runtime_error("New constraints have invalid dimensions");
+    }
+
+    if (new_b.rows() != b_.rows()) {
+      throw std::runtime_error("Can't change the number of decision variables");
+    }
+
+    Q_ = new_Q;
+    b_ = new_b;
+    c_ = new_c;
   }
+
+ protected:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd& y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd& y) const override;
+
+ private:
+  Eigen::MatrixXd Q_;
+  Eigen::VectorXd b_;
+  double c_{};
 };
 
 /**
@@ -141,8 +216,8 @@ std::shared_ptr<QuadraticCost> MakeL2NormCost(
     const Eigen::Ref<const Eigen::VectorXd>& b);
 
 /**
- *  Implements a cost of the form P(x, y...) where P is a multivariate
- *  polynomial in x, y...
+ * Implements a cost of the form P(x, y...) where P is a multivariate
+ * polynomial in x, y, ...
  *
  * The Polynomial class uses a different variable naming scheme; thus the
  * caller must provide a list of Polynomial::VarType variables that correspond

--- a/drake/solvers/create_cost.cc
+++ b/drake/solvers/create_cost.cc
@@ -45,8 +45,8 @@ Binding<QuadraticCost> DoParseQuadraticCost(
   DecomposeQuadraticExpressionWithMonomialToCoeffMap(
       monomial_to_coeff_map, map_var_to_index, vars_vec.size(), &Q, &b,
       &constant_term);
-  // Now add the quadratic constraint 0.5 * x' * Q * x + b' * x
-  return CreateBinding(make_shared<QuadraticCost>(Q, b), vars_vec);
+  return CreateBinding(make_shared<QuadraticCost>(Q, b, constant_term),
+                       vars_vec);
 }
 
 Binding<LinearCost> DoParseLinearCost(
@@ -56,10 +56,8 @@ Binding<LinearCost> DoParseLinearCost(
   Eigen::RowVectorXd c(vars_vec.size());
   double constant_term;
   DecomposeLinearExpression(e, map_var_to_index, c, &constant_term);
-  // The constant term is ignored now.
-  // TODO(eric.cousineau): support adding constant term to the cost.
-  unused(constant_term);
-  return CreateBinding(make_shared<LinearCost>(c), vars_vec);
+  return CreateBinding(make_shared<LinearCost>(c.transpose(), constant_term),
+                       vars_vec);
 }
 
 }  // anonymous namespace

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -24,6 +24,7 @@
 namespace drake {
 namespace solvers {
 namespace {
+
 // Checks if the number of variables in the Gurobi model is as expected. This
 // operation can be EXPENSIVE, since it requires calling GRBupdatemodel
 // (Gurobi typically adopts lazy update, where it does not update the model
@@ -233,7 +234,8 @@ int AddSecondOrderConeConstraints(
 /*
  * Add quadratic or linear costs to the optimization problem.
  */
-int AddCosts(GRBmodel* model, const MathematicalProgram& prog,
+int AddCosts(GRBmodel* model, double* pconstant_cost,
+             const MathematicalProgram& prog,
              double sparseness_threshold) {
   // Aggregates the quadratic costs and linear costs in the form
   // 0.5 * x' * Q_all * x + linear_term' * x.
@@ -241,11 +243,14 @@ int AddCosts(GRBmodel* model, const MathematicalProgram& prog,
   // record the non-zero entries in the cost 0.5*x'*Q*x + b'*x.
   std::vector<Eigen::Triplet<double>> Q_nonzero_coefs;
   std::vector<Eigen::Triplet<double>> b_nonzero_coefs;
+  double& constant_cost = *pconstant_cost;
+  constant_cost = 0;
   for (const auto& binding : prog.quadratic_costs()) {
     const auto& constraint = binding.constraint();
     const int constraint_variable_dimension = binding.GetNumElements();
     const Eigen::MatrixXd& Q = constraint->Q();
     const Eigen::VectorXd& b = constraint->b();
+    constant_cost += constraint->c();
 
     DRAKE_ASSERT(Q.rows() == constraint_variable_dimension);
 
@@ -284,11 +289,12 @@ int AddCosts(GRBmodel* model, const MathematicalProgram& prog,
   // Add linear cost in prog.linear_costs() to the aggregated cost.
   for (const auto& binding : prog.linear_costs()) {
     const auto& constraint = binding.constraint();
-    Eigen::RowVectorXd c = constraint->A();
+    const auto& a = constraint->a();
+    constant_cost += constraint->b();
 
     for (int i = 0; i < static_cast<int>(binding.GetNumElements()); ++i) {
       b_nonzero_coefs.push_back(Eigen::Triplet<double>(
-          prog.FindDecisionVariableIndex(binding.variables()(i)), 0, c(i)));
+          prog.FindDecisionVariableIndex(binding.variables()(i)), 0, a(i)));
     }
   }
 
@@ -445,7 +451,7 @@ void AddSecondOrderConeVariables(
     }
   }
 }
-}  // close namespace
+}  // anonymous namespace
 
 bool GurobiSolver::available() const { return true; }
 
@@ -535,7 +541,8 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   int error = 0;
   // TODO(naveenoid) : This needs access externally.
   double sparseness_threshold = 1e-14;
-  error = AddCosts(model, prog, sparseness_threshold);
+  double constant_cost = 0;
+  error = AddCosts(model, &constant_cost, prog, sparseness_threshold);
   DRAKE_DEMAND(!error);
 
   error = ProcessLinearConstraints(model, prog, sparseness_threshold);
@@ -642,10 +649,11 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
       }
       prog.SetDecisionVariableValues(prog_sol_vector);
 
-      // Obtain optimal cost
+      // Obtain optimal cost.
       double optimal_cost = std::numeric_limits<double>::quiet_NaN();
       GRBgetdblattr(model, GRB_DBL_ATTR_OBJVAL, &optimal_cost);
-      prog.SetOptimalCost(optimal_cost);
+      // Provide Gurobi's computed cost in addition to the constant cost.
+      prog.SetOptimalCost(optimal_cost + constant_cost);
     }
   }
 

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -235,9 +235,6 @@ Binding<Cost> MathematicalProgram::AddCost(const Binding<Cost>& binding) {
 Binding<LinearCost> MathematicalProgram::AddCost(
     const Binding<LinearCost>& binding) {
   required_capabilities_ |= kLinearCost;
-  DRAKE_ASSERT(binding.constraint()->num_constraints() == 1 &&
-               binding.constraint()->A().cols() ==
-                   static_cast<int>(binding.GetNumElements()));
   CheckIsDecisionVariable(binding.variables());
   linear_costs_.push_back(binding);
   return linear_costs_.back();
@@ -248,9 +245,9 @@ Binding<LinearCost> MathematicalProgram::AddLinearCost(const Expression& e) {
 }
 
 Binding<LinearCost> MathematicalProgram::AddLinearCost(
-    const Eigen::Ref<const Eigen::VectorXd>& c,
+    const Eigen::Ref<const Eigen::VectorXd>& a, double b,
     const Eigen::Ref<const VectorXDecisionVariable>& vars) {
-  return AddCost(make_shared<LinearCost>(c), vars);
+  return AddCost(make_shared<LinearCost>(a, b), vars);
 }
 
 Binding<QuadraticCost> MathematicalProgram::AddCost(
@@ -279,9 +276,16 @@ Binding<QuadraticCost> MathematicalProgram::AddQuadraticErrorCost(
 
 Binding<QuadraticCost> MathematicalProgram::AddQuadraticCost(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c,
+    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+  return AddCost(make_shared<QuadraticCost>(Q, b, c), vars);
+}
+
+Binding<QuadraticCost> MathematicalProgram::AddQuadraticCost(
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::VectorXd>& b,
     const Eigen::Ref<const VectorXDecisionVariable>& vars) {
-  return AddCost(make_shared<QuadraticCost>(Q, b), vars);
+  return AddQuadraticCost(Q, b, 0., vars);
 }
 
 Binding<PolynomialCost> MathematicalProgram::AddPolynomialCost(

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -715,33 +715,47 @@ class MathematicalProgram {
   Binding<LinearCost> AddCost(const Binding<LinearCost>& binding);
 
   /**
-   * Adds a linear cost term of the form c'*x.
+   * Adds a linear cost term of the form a'*x + b.
    * @param e A linear symbolic expression.
-   * @pre{e is a linear expression c'*x, where each entry of x is a decision
-   * variable in the mathematical program}
+   * @pre e is a linear expression a'*x + b, where each entry of x is a decision
+   * variable in the mathematical program.
    * @return The newly added linear constraint, together with the bound
    * variables.
    */
   Binding<LinearCost> AddLinearCost(const symbolic::Expression& e);
 
   /**
-   * Adds a linear cost term of the form c'*x.
+   * Adds a linear cost term of the form a'*x + b.
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
    */
-  Binding<LinearCost> AddLinearCost(const Eigen::Ref<const Eigen::VectorXd>& c,
+  Binding<LinearCost> AddLinearCost(const Eigen::Ref<const Eigen::VectorXd>& a,
+                                    double b,
                                     const VariableRefList& vars) {
-    return AddLinearCost(c, ConcatenateVariableRefList((vars)));
+    return AddLinearCost(a, b, ConcatenateVariableRefList((vars)));
   }
 
   /**
-   * Adds a linear cost term of the form c'*x.
+   * Adds a linear cost term of the form a'*x + b.
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
    */
   Binding<LinearCost> AddLinearCost(
-      const Eigen::Ref<const Eigen::VectorXd>& c,
+      const Eigen::Ref<const Eigen::VectorXd>& a,
+      double b,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
+
+  /**
+   * Adds a linear cost term of the form a'*x.
+   * Applied to a subset of the variables and pushes onto
+   * the linear cost data structure.
+   */
+  template <typename VarType>
+  Binding<LinearCost> AddLinearCost(const Eigen::Ref<const Eigen::VectorXd>& a,
+                                    const VarType& vars) {
+    const double b = 0.;
+    return AddLinearCost(a, b, vars);
+  }
 
   /**
    * Adds a cost term of the form 0.5*x'*Q*x + b'x.
@@ -799,7 +813,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Adds a cost term of the form 0.5*x'*Q*x + b'x
+   * Adds a cost term of the form 0.5*x'*Q*x + b'x.
    * Applied to subset of the variables.
    */
   Binding<QuadraticCost> AddQuadraticCost(
@@ -807,6 +821,16 @@ class MathematicalProgram {
       const Eigen::Ref<const Eigen::VectorXd>& b, const VariableRefList& vars) {
     return AddQuadraticCost(Q, b, ConcatenateVariableRefList(vars));
   }
+
+  /**
+   * Adds a cost term of the form 0.5*x'*Q*x + b'x + c
+   * Applied to subset of the variables.
+   */
+  Binding<QuadraticCost> AddQuadraticCost(
+      const Eigen::Ref<const Eigen::MatrixXd>& Q,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      double c,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
    * Adds a cost term of the form 0.5*x'*Q*x + b'x
@@ -2230,5 +2254,6 @@ class MathematicalProgram {
   Binding<LinearEqualityConstraint> AddLinearEqualityConstraint(
       const std::set<symbolic::Formula>& formulas);
 };
+
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -123,7 +123,7 @@ void LinearSystemExample2::CheckSolution() const {
 }
 
 LinearSystemExample3::LinearSystemExample3() : LinearSystemExample2() {
-  con()->UpdateConstraint(3 * Matrix4d::Identity(), b());
+  con()->UpdateCoefficients(3 * Matrix4d::Identity(), b());
 }
 
 void LinearSystemExample3::CheckSolution() const {
@@ -217,7 +217,8 @@ void NonConvexQPproblem1::AddQuadraticCost() {
       -100 * Eigen::Matrix<double, 5, 5>::Identity();
   Eigen::Matrix<double, 5, 1> c;
   c << 42, 44, 45, 47, 47.5;
-  prog_->AddQuadraticCost(Q, c, x_);
+  double r = -100;
+  prog_->AddQuadraticCost(Q, c, r, x_);
 }
 
 NonConvexQPproblem2::NonConvexQPproblem2(CostForm cost_form,

--- a/drake/solvers/test/quadratic_program_examples.cc
+++ b/drake/solvers/test/quadratic_program_examples.cc
@@ -70,14 +70,15 @@ QuadraticProgram0::QuadraticProgram0(CostForm cost_form,
       Q << 4, 2,
           0, 2;
       // clang-format on
-      Vector2d b(1, 0);
-      prog()->AddQuadraticCost(Q, b, x_);
+      const Vector2d b(1, 0);
+      const double c = 3;
+      prog()->AddQuadraticCost(Q, b, c, x_);
       prog()->AddLinearCost(Vector1d(1.0), x_.segment<1>(1));
       break;
     }
     case CostForm::kSymbolic : {
       prog()->AddQuadraticCost(2 * x_(0) * x_(0) + x_(0) * x_(1) +
-                               x_(1) * x_(1) + x_(0) + x_(1));
+                               x_(1) * x_(1) + x_(0) + x_(1) + 3);
       break;
     }
     default: {
@@ -376,7 +377,7 @@ void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
   for (int i = 0; i < N; i++) {
     double theta = 2.0 * M_PI * i / N;
     x_desired << sin(theta), cos(theta);
-    objective->UpdateQuadraticAndLinearTerms(2.0 * Q, -2.0 * Q * x_desired);
+    objective->UpdateCoefficients(2.0 * Q, -2.0 * Q * x_desired);
 
     if (theta <= M_PI_2) {
       // simple lagrange multiplier problem:
@@ -413,7 +414,7 @@ void TestQPonUnitBallExample(const MathematicalProgramSolverInterface& solver) {
     // now 2(x-xd)^2 + (y-yd)^2 s.t. x+y=1
     x_desired << 1.0, 1.0;
     Q(0, 0) = 2.0;
-    objective->UpdateQuadraticAndLinearTerms(2.0 * Q, -2.0 * Q * x_desired);
+    objective->UpdateCoefficients(2.0 * Q, -2.0 * Q * x_desired);
 
     x_expected << 2.0 / 3.0, 1.0 / 3.0;
 


### PR DESCRIPTION
This addresses Issue #3500, and adds constant terms for `LinearCost` and `QuadraticCost`, incorporates these terms in symbolic parsing, and ensures that the explicitly constant terms are added to the optimal cost if a solver does not support constant cost offsets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6084)
<!-- Reviewable:end -->
