### PR TITLE
Implement MosekLicenseScope to control scope for acquiring / releasing license sessions.

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -320,6 +320,14 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "scoped_singleton",
+    hdrs = ["scoped_singleton.h"],
+    deps = [
+        ":common",
+    ],
+)
+
+drake_cc_library(
     name = "protobuf",
     srcs = ["protobuf.cc"],
     hdrs = ["protobuf.h"],
@@ -772,6 +780,13 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "eigen_autodiff_types_test",
     deps = [":autodiff"],
+)
+
+drake_cc_googletest(
+    name = "scoped_singleton_test",
+    deps = [
+        ":scoped_singleton",
+    ],
 )
 
 # TODO(jwnimmer-tri) These tests are currently missing...

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -68,6 +68,7 @@ set(installed_headers
   nice_type_name.h
   number_traits.h
   polynomial.h
+  scoped_singleton.h
   sorted_vectors_have_intersection.h
   symbolic_environment.h
   symbolic_expression.h

--- a/drake/common/scoped_singleton.h
+++ b/drake/common/scoped_singleton.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+
+/**
+ * Provides thread-safe, global-safe access to a shared resource. When
+ * all references are gone, the resource will be freed due to using a weak_ptr.
+ * @tparam T Class of the resource. Must be default-constructible.
+ * @tparam Unique Optional class, meant to make a unique specialization, such
+ * that you can have multiple singletons of T if necessary.
+ *
+ * @note An example application is obtaining license for multiple disjoint
+ * solver objects, where acquiring a license requires network communication,
+ * and the solver is under an interface where you cannot explicitly pass the
+ * license resource to the solver without violating encapsulation.
+ */
+template <typename T, typename Unique = void>
+std::shared_ptr<T> GetScopedSingleton() {
+  // Confine implementation to a class.
+  class Singleton {
+   public:
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Singleton)
+
+    Singleton() {}
+
+    /*
+     * Acquire a reference to resource if no other instance exists.
+     * Otherwise, return a shared reference to the resource.
+     */
+    std::shared_ptr<T> Acquire() {
+      // Acquiring and releasing the resource via a centralized weak pointer,
+      // will be thread-safe. All constructions of T for this particular
+      // Singleton are assigned to this same weak_ref_; the empty-check,
+      // allocation, and weak_ref_ assignment are all guarded by the same
+      // critical section.
+      auto instance = weak_ref_.lock();
+      if (!instance) {
+        instance = std::make_shared<T>();
+        weak_ref_ = instance;
+      }
+      return instance;
+    }
+
+   private:
+    std::weak_ptr<T> weak_ref_;
+  };
+  // Allocate singleton as a static function local to control initialization.
+  static never_destroyed<Singleton> singleton;
+  return singleton.access().Acquire();
+}
+
+}  // namespace drake

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -123,6 +123,9 @@ target_link_libraries(drake_assert_test drakeCommon)
 drake_add_cc_test(drake_assert_test_compile)
 target_link_libraries(drake_assert_test_compile drakeCommon)
 
+drake_add_cc_test(scoped_singleton_test scoped_singleton_test.cc)
+target_link_libraries(scoped_singleton_test drakeCommon)
+
 # "text_logging.h" unit testing:  If spdlog is available, test that:
 add_executable(text_logging_test_default ../text_logging.cc text_logging_test.cc)
 target_link_libraries(text_logging_test_default GTest::GTest GTest::Main gflags)

--- a/drake/common/test/scoped_singleton_test.cc
+++ b/drake/common/test/scoped_singleton_test.cc
@@ -1,0 +1,68 @@
+#include "drake/common/scoped_singleton.h"
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+
+namespace {
+
+using std::make_shared;
+using std::shared_ptr;
+using std::weak_ptr;
+
+/*
+ * A trivial singleton class that tracks the total number of instances alive.
+ */
+class InstanceCountedDummy {
+ public:
+  InstanceCountedDummy() {
+    instance_count_++;
+  }
+  ~InstanceCountedDummy() {
+    instance_count_--;
+  }
+  static int instance_count() { return instance_count_; }
+ private:
+  static int instance_count_;
+};
+int InstanceCountedDummy::instance_count_ = 0;
+
+// Trivial type for specializing.
+struct Specialized {};
+
+/*
+ * Test neatly nested locks.
+ */
+GTEST_TEST(ScopedSingletonTest, NestedAndSpecializedTest) {
+  weak_ptr<InstanceCountedDummy> wref;
+  EXPECT_EQ(0, wref.use_count());
+  EXPECT_EQ(0, InstanceCountedDummy::instance_count());
+  {
+    auto ref_1 = GetScopedSingleton<InstanceCountedDummy>();
+    wref = ref_1;
+    EXPECT_EQ(1, wref.use_count());
+    EXPECT_EQ(1, InstanceCountedDummy::instance_count());
+    {
+      auto ref_2 = GetScopedSingleton<InstanceCountedDummy>();
+      EXPECT_EQ(2, wref.use_count());
+      EXPECT_EQ(1, InstanceCountedDummy::instance_count());
+      // Use specialized version.
+      auto ref_a = GetScopedSingleton<InstanceCountedDummy, Specialized>();
+      EXPECT_EQ(1, ref_a.use_count());
+      // Original singleton's reference count should not change.
+      EXPECT_EQ(2, wref.use_count());
+      // We should have two unique InstanceCountedDummy instances.
+      EXPECT_EQ(2, InstanceCountedDummy::instance_count());
+    }
+    EXPECT_EQ(1, wref.use_count());
+    EXPECT_EQ(1, InstanceCountedDummy::instance_count());
+  }
+  EXPECT_EQ(0, wref.use_count());
+  EXPECT_EQ(0, InstanceCountedDummy::instance_count());
+}
+
+}  // anonymous namespace
+}  // namespace drake

--- a/drake/multibody/parsers/BUILD
+++ b/drake/multibody/parsers/BUILD
@@ -65,6 +65,7 @@ drake_cc_binary(
 # TODO(jwnimmer-tri) This is just some random program.  Do we want to keep it?
 drake_cc_binary(
     name = "urdf_manipulator_dynamics_test",
+    testonly = 1,
     srcs = ["test/urdf_manipulator_dynamics_test.cc"],
     deps = [
         ":parsers",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -336,6 +336,7 @@ drake_cc_library(
     deps = select({
         "//tools:with_mosek": [
             ":mathematical_program_api",
+            "//drake/common:scoped_singleton",
             "@mosek",
         ],
         "//conditions:default": [
@@ -605,6 +606,7 @@ drake_cc_googletest(
         ":mathematical_program_test_util",
         ":quadratic_program_examples",
     ],
+    use_default_main = False,
 )
 
 drake_cc_googletest(

--- a/drake/solvers/no_mosek.cc
+++ b/drake/solvers/no_mosek.cc
@@ -6,11 +6,14 @@
 
 #include "drake/common/drake_assert.h"
 
+using std::runtime_error;
+using std::shared_ptr;
+
 namespace drake {
 namespace solvers {
 
-MosekSolver::~MosekSolver() {
-  DRAKE_ASSERT(mosek_env_ == nullptr);
+shared_ptr<MosekSolver::License> MosekSolver::AcquireLicense() {
+  return shared_ptr<MosekSolver::License>();
 }
 
 bool MosekSolver::available() const {
@@ -18,7 +21,7 @@ bool MosekSolver::available() const {
 }
 
 SolutionResult MosekSolver::Solve(MathematicalProgram&) const {
-  throw std::runtime_error(
+  throw runtime_error(
       "Mosek is not installed in your build. You'll need to use a different "
       "solver.");
 }

--- a/drake/solvers/test/mosek_solver_test.cc
+++ b/drake/solvers/test/mosek_solver_test.cc
@@ -39,6 +39,16 @@ GTEST_TEST(QPtest, TestUnitBallExample) {
     TestQPonUnitBallExample(solver);
   }
 }
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake
+
+int main(int argc, char** argv) {
+  // Ensure that we have the MOSEK license for the entire duration of this test,
+  // so that we do not have to release and re-acquire the license for every
+  // test.
+  auto mosek_license = drake::solvers::MosekSolver::AcquireLicense();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -179,12 +179,15 @@ def drake_cc_test(
 def drake_cc_googletest(
         name,
         deps=None,
+        use_default_main=True,
         **kwargs):
     """Creates a rule to declare a C++ unit test using googletest.  Always adds
     a deps= entry for googletest main (@gtest//:main).
 
     By default, sets size="small" because that indicates a unit test.
     By default, sets name="test/${name}.cc" per Drake's filename convention.
+    By default, sets use_default_main=True to use GTest's main, via
+    @gtest//:main. Otherwise, it will depend on @gtest//:without_main.
 
     If disable_in_compilation_mode_dbg is True, the srcs will be suppressed
     in debug-mode builds, so the test will trivially pass. This option should
@@ -192,7 +195,10 @@ def drake_cc_googletest(
     """
     if deps == None:
         deps = []
-    deps.append("@gtest//:main")
+    if use_default_main:
+        deps.append("@gtest//:main")
+    else:
+        deps.append("@gtest//:without_main")
     drake_cc_test(
         name=name,
         deps=deps,

--- a/tools/gtest.BUILD
+++ b/tools/gtest.BUILD
@@ -1,7 +1,8 @@
 # -*- python -*-
 
 cc_library(
-    name = "main",
+    name = "without_main",
+    testonly = 1,
     srcs = glob(
         [
             "googlemock/src/*.cc",
@@ -9,6 +10,8 @@ cc_library(
             "googletest/src/*.h",
         ],
         exclude = [
+            "googlemock/src/gmock_main.cc",
+            "googletest/src/gtest_main.cc",
             "googlemock/src/gmock-all.cc",
             "googletest/src/gtest-all.cc",
         ],
@@ -35,4 +38,15 @@ cc_library(
     }),
     linkstatic = 1,
     visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "main",
+    testonly = 1,
+    srcs = ["googlemock/src/gmock_main.cc"],
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":without_main",
+    ],
 )


### PR DESCRIPTION
To augment Sammy's work, this shuffles around when a license lock is acquired, to permit changing the scope in which a license / environment is active.

In `mosek_solver_test.cc`, here are the results with / without the lock being used in `main()`:

* Without lock:

        [==========] 61 tests from 3 test cases ran. (11468 ms total)

* With lock:

        [==========] 61 tests from 3 test cases ran. (338 ms total)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6085)
<!-- Reviewable:end -->
