### PR TITLE
Add support for sanitizer environment variables and suppressions files

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,6 +12,36 @@ filegroup(
 )
 
 sh_binary(
+    name = "asan",
+    srcs = ["asan.sh"],
+    data = ["asan.supp"],
+)
+
+sh_binary(
+    name = "lsan",
+    srcs = ["lsan.sh"],
+    data = ["lsan.supp"],
+)
+
+sh_binary(
+    name = "msan",
+    srcs = ["msan.sh"],
+    data = ["msan.supp"],
+)
+
+sh_binary(
+    name = "tsan",
+    srcs = ["tsan.sh"],
+    data = ["tsan.supp"],
+)
+
+sh_binary(
+    name = "ubsan",
+    srcs = ["ubsan.sh"],
+    data = ["ubsan.supp"],
+)
+
+sh_binary(
     name = "valgrind",
     srcs = ["valgrind.sh"],
     data = ["valgrind.supp"],

--- a/tools/asan.sh
+++ b/tools/asan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
+tools=$(dirname "$me")
+export ASAN_OPTIONS="$ASAN_OPTIONS:check_initialization_order=1:detect_stack_use_after_return=1:suppressions=$tools/asan.supp"
+"$@"

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -123,7 +123,6 @@ test:kcov --test_tag_filters=-cpplint,-gurobi,-pycodestyle
 test:kcov --nocache_test_results
 
 ### ASan build. ###
-build:asan --action_env=ASAN_OPTIONS
 build:asan --copt -g
 build:asan --copt -fsanitize=address
 build:asan --copt -O1
@@ -137,7 +136,6 @@ test:asan --test_lang_filters=-py
 test:asan --test_timeout=120,600,1800,7200
 
 ### LSan build. ###
-build:lsan --action_env=LSAN_OPTIONS
 build:lsan --copt -g
 build:lsan --copt -fsanitize=leak
 build:lsan --copt -O1
@@ -148,7 +146,6 @@ test:lsan --test_env=LSAN_SYMBOLIZER_PATH
 test:lsan --test_lang_filters=-py
 
 ### MSan build. ###
-build:msan --action_env=MSAN_OPTIONS
 build:msan --copt -g
 build:msan --copt -fsanitize=memory
 build:msan --copt -O1
@@ -162,7 +159,6 @@ test:msan --test_env=MSAN_SYMBOLIZER_PATH
 test:msan --test_timeout=180,900,2700,10800
 
 ### TSan build. ###
-build:tsan --action_env=TSAN_OPTIONS
 build:tsan --copt -g
 build:tsan --copt -fsanitize=thread
 build:tsan --copt -O1
@@ -175,7 +171,6 @@ test:tsan --test_lang_filters=-py
 test:tsan --test_timeout=300,1500,5400,18000
 
 ### UBSan build. ###
-build:ubsan --action_env=UBSAN_OPTIONS
 build:ubsan --copt -g
 build:ubsan --copt -fsanitize=undefined
 build:ubsan --copt -O1

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -128,6 +128,7 @@ build:asan --copt -fsanitize=address
 build:asan --copt -O1
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
+test:asan --run_under=//tools:asan
 test:asan --test_env=ASAN_OPTIONS
 test:asan --test_env=ASAN_SYMBOLIZER_PATH
 test:asan --test_lang_filters=-py
@@ -141,6 +142,7 @@ build:lsan --copt -fsanitize=leak
 build:lsan --copt -O1
 build:lsan --copt -fno-omit-frame-pointer
 build:lsan --linkopt -fsanitize=leak
+test:lsan --run_under=//tools:lsan
 test:lsan --test_env=LSAN_OPTIONS
 test:lsan --test_env=LSAN_SYMBOLIZER_PATH
 test:lsan --test_lang_filters=-py
@@ -148,9 +150,11 @@ test:lsan --test_lang_filters=-py
 ### MSan build. ###
 build:msan --copt -g
 build:msan --copt -fsanitize=memory
+build:msan --copt -fsanitize-memory-track-origins
 build:msan --copt -O1
 build:msan --copt -fno-omit-frame-pointer
 build:msan --linkopt -fsanitize=memory
+test:msan --run_under=//tools:msan
 test:msan --test_lang_filters=-py
 test:msan --test_env=MSAN_OPTIONS
 test:msan --test_env=MSAN_SYMBOLIZER_PATH
@@ -164,6 +168,7 @@ build:tsan --copt -fsanitize=thread
 build:tsan --copt -O1
 build:tsan --copt -fno-omit-frame-pointer
 build:tsan --linkopt -fsanitize=thread
+test:tsan --run_under=//tools:tsan
 test:tsan --test_env=TSAN_OPTIONS
 test:tsan --test_lang_filters=-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
@@ -176,6 +181,7 @@ build:ubsan --copt -fsanitize=undefined
 build:ubsan --copt -O1
 build:ubsan --copt -fno-omit-frame-pointer
 build:ubsan --linkopt -fsanitize=undefined
+test:ubsan --run_under=//tools:ubsan
 test:ubsan --test_env=UBSAN_OPTIONS
 test:ubsan --test_lang_filters=-py
 

--- a/tools/lsan.sh
+++ b/tools/lsan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
+tools=$(dirname "$me")
+export LSAN_OPTIONS="$LSAN_OPTIONS:suppressions=$tools/lsan.supp"
+"$@"

--- a/tools/msan.sh
+++ b/tools/msan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
+tools=$(dirname "$me")
+export MSAN_OPTIONS="$MSAN_OPTIONS:suppressions=$tools/msan.supp"
+"$@"

--- a/tools/tsan.sh
+++ b/tools/tsan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
+tools=$(dirname "$me")
+export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=1:second_deadlock_stack=1:suppressions=$tools/tsan.supp"
+"$@"

--- a/tools/ubsan.sh
+++ b/tools/ubsan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
+tools=$(dirname "$me")
+export UBSAN_OPTIONS="$UBSAN_OPTIONS:suppressions=$tools/ubsan.supp"
+"$@"


### PR DESCRIPTION
Still need to sort out `blacklist.txt`, which is compile time for Clang and really freaks out Bazel. Alternatively, I could tweak the F2C source in SNOPT with the necessary attribute to suppress, or upgrade F2C.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6096)
<!-- Reviewable:end -->
