### PR TITLE
Add missing python mode lines to BUILD files

### DIFF
--- a/tools/bot_core_lcmtypes.BUILD
+++ b/tools/bot_core_lcmtypes.BUILD
@@ -1,3 +1,5 @@
+# -*- python -*-
+
 package(default_visibility = ["//visibility:public"])
 
 load("@//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")

--- a/tools/ipopt.BUILD
+++ b/tools/ipopt.BUILD
@@ -1,3 +1,5 @@
+# -*- python -*-
+
 # We build IPOPT by shelling out to autotools.
 
 # A prefix-string for genrule cmd attributes, which uses the Kythe cdexec tool,

--- a/tools/pycps.BUILD
+++ b/tools/pycps.BUILD
@@ -1,3 +1,5 @@
+# -*- python -*-
+
 genrule(
     name = "copy_cps2cmake",
     srcs = ["cps2cmake"],

--- a/tools/robotlocomotion_lcmtypes.BUILD
+++ b/tools/robotlocomotion_lcmtypes.BUILD
@@ -1,3 +1,5 @@
+# -*- python -*-
+
 package(default_visibility = ["//visibility:public"])
 
 load("@//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")

--- a/tools/semantic_version.BUILD
+++ b/tools/semantic_version.BUILD
@@ -1,3 +1,5 @@
+# -*- python -*-
+
 load("@//tools:drake.bzl", "drake_generate_file")
 
 py_library(


### PR DESCRIPTION
Not that this works for my text editor (BBEdit, need `-*- mode: python -*-` or `vi: set ft=python :`), but it at least keeps GitHub happy....

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6097)
<!-- Reviewable:end -->
