### PR TITLE
Convert ipopt build rule to use shell script

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -35,6 +35,11 @@ exports_files(
     visibility = ["@nlopt//:__pkg__"],
 )
 
+exports_files(
+    ["ipopt_build_with_autotools.sh"],
+    visibility = ["@ipopt//:__pkg__"],
+)
+
 alias(
     name = "buildifier",
     actual = "@com_github_bazelbuild_buildtools//buildifier",

--- a/tools/ipopt.BUILD
+++ b/tools/ipopt.BUILD
@@ -2,10 +2,6 @@
 
 # We build IPOPT by shelling out to autotools.
 
-# A prefix-string for genrule cmd attributes, which uses the Kythe cdexec tool,
-# in quiet mode, to execute in the genrule output directory.
-CDEXEC = "$(location @//tools/third_party/kythe/tools/cdexec:cdexec) -q $(@D)"
-
 # We run autotools in a genrule, and only files explicitly identified as outputs
 # of that genrule can be made available to other rules. Therefore, we need a
 # list of every file in the IPOPT install.
@@ -100,30 +96,24 @@ IPOPT_LIBS = [
 # We emit static libraries because dynamic libraries would have different names
 # on OS X and on Linux, and Bazel genrules don't allow platform-dependent outs.
 # https://github.com/bazelbuild/bazel/issues/281
-HALF_THE_CORES = "$$[($$(getconf _NPROCESSORS_ONLN)+1)/2]"
-
-LOG = " 2>> ipopt.log"
-
-PRINT_ERRORS = (
-    "echo \"***IPOPT Build stderr***\"" +
-    " && cat ipopt.log" +
-    " && echo \"***IPOPT Build config.log***\"" +
-    " && find -L . -name config.log | xargs cat"
-)
-
-BUILD_IPOPT_CMD = (
-    "(ADD_CFLAGS=-fPIC ADD_CXXFLAGS=-fPIC " + CDEXEC + " `pwd`/external/ipopt/configure --disable-shared --with-pic" + LOG +
-    " && " + CDEXEC + " make -j " + HALF_THE_CORES + LOG +
-    " && " + CDEXEC + " make install" + LOG +
-    ") || (" + PRINT_ERRORS + " && false)"
-)
-
 genrule(
     name = "build_with_autotools",
     srcs = glob(["**/*"]),
     outs = IPOPT_HDRS + IPOPT_LIBS,
-    cmd = BUILD_IPOPT_CMD,
-    tools = ["@//tools/third_party/kythe/tools/cdexec:cdexec"],
+    cmd = " ".join([
+        "(",
+        "env",
+        "cdexec=$(location @//tools/third_party/kythe/tools/cdexec:cdexec)",
+        "top_builddir=$(@D)",
+        "tools/ipopt_build_with_autotools.sh",
+        " 2>&1 > ipopt_build_with_autotools.log",
+        ")",
+        "|| (cat ipopt_build_with_autotools.log && false)",
+        ]),
+    tools = [
+          "@//tools:ipopt_build_with_autotools.sh",
+          "@//tools/third_party/kythe/tools/cdexec:cdexec",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/tools/ipopt_build_with_autotools.sh
+++ b/tools/ipopt_build_with_autotools.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+me=$(basename "$0")
+
+function die() {
+    set +x
+    echo "$@" 1>&2
+    find -L . -name config.log | xargs -n1 --verbose cat 1>&2
+    exit 1
+}
+
+# Log the current environment varibles.
+echo "*******************************************************************" 1>&2
+echo "$me: Initial environment is ..." 1>&2
+env | sort 1>&2
+echo "... end of environment." 1>&2
+echo "*******************************************************************" 1>&2
+
+# Check if everything we need exists.
+[ -x "$cdexec" ] || die 'Missing $cdexec'
+[ -n "$top_builddir" ] || die 'Missing $top_builddir'
+configure="$PWD"/external/ipopt/configure
+[ -x "$configure" ] || die 'Missing configure'
+
+# How many cores to use while building.  This is a compromise in order to not
+# totally bog down the machine, while still achieving some parallelism.
+half_the_cores="$[($(getconf _NPROCESSORS_ONLN)+1)/2]"
+
+# Set these to match --with-pic below.
+export ADD_CFLAGS=-fPIC
+export ADD_CXXFLAGS=-fPIC
+
+# Log the current environment varibles.
+echo "*******************************************************************" 1>&2
+echo "$me: Final environment is ..." 1>&2
+env | sort 1>&2
+echo "... end of environment." 1>&2
+echo "*******************************************************************" 1>&2
+
+# From now on, echo commands before running them.
+set -x
+
+"$cdexec" "$top_builddir" "$configure" --disable-shared --with-pic \
+    || die "*** IPOPT configure step failed ***"
+
+"$cdexec" "$top_builddir" make -j "$half_the_cores" V=1 \
+    || die "*** IPOPT make step failed ***"
+
+"$cdexec" "$top_builddir" make install \
+    || die "*** IPOPT install step failed ***"


### PR DESCRIPTION
This should be a non-functional change.  This should be easier to maintain than shell code directly in a genrule.

A follow-on PR will update the wrapper script to obey Bazel's `--compiler` target, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6098)
<!-- Reviewable:end -->
