### PR TITLE
Updating gflags

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,8 +49,8 @@ github_archive(
 github_archive(
     name = "gflags",
     repository = "gflags/gflags",
-    commit = "a69b2544d613b4bee404988710503720c487119a",
-    sha256 = "8b3836d5ca34a2da4d6375cf5f2030c719b508ca16014fcc9d5e9b295b56a6c1",
+    commit = "95ffb27c9c7496ede1409e042571054c70cb9519",
+    sha256 = "723c21f783c720c0403c9b44bf500d1961a08bd2635cbc117107af22d2e1643f",
 )
 
 github_archive(


### PR DESCRIPTION
A number of tests don't pass with Address Sanitizer, for ex.:
`bazel test --config=asan  //drake/examples/kuka_iiwa_arm/dev/tools:simple_tree_visualizer_demo_test`

Output: https://gist.github.com/m-chaturvedi/078812ad307fc330ce825a6892390a0b

The issue was with gflags:
https://github.com/gflags/gflags/issues/214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6103)
<!-- Reviewable:end -->
