### PR TITLE
Re-enable all tests that require Gurobi, consolidate Gurobi test tags, and fix latent renames.

### DIFF
--- a/drake/bindings/BUILD
+++ b/drake/bindings/BUILD
@@ -187,18 +187,18 @@ py_test(
     deps = [":pydrake"],
 )
 
-#py_test(
-#    name = "pydrake_mathematical_program_gurobi_solver_test",
-#    size = "small",
-#    srcs = ["python/pydrake/test/testGurobiSolver.py"],
-#    main = "python/pydrake/test/testGurobiSolver.py",
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [":pydrake"],
-#)
+py_test(
+    name = "pydrake_mathematical_program_gurobi_solver_test",
+    size = "small",
+    srcs = ["python/pydrake/test/testGurobiSolver.py"],
+    main = "python/pydrake/test/testGurobiSolver.py",
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [":pydrake"],
+)
 
 py_test(
     name = "pydrake_mathematical_program_mosek_solver_test",
@@ -209,19 +209,18 @@ py_test(
     deps = [":pydrake"],
 )
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#py_test(
-#    name = "DISABLED_pydrake_mathematical_program_test",
-#    size = "small",
-#    srcs = ["python/pydrake/test/testMathematicalProgram.py"],
-#    main = "python/pydrake/test/testMathematicalProgram.py",
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [":pydrake"],
-#)
+py_test(
+    name = "pydrake_mathematical_program_test",
+    size = "small",
+    srcs = ["python/pydrake/test/testMathematicalProgram.py"],
+    main = "python/pydrake/test/testMathematicalProgram.py",
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [":pydrake"],
+)
 
 py_test(
     name = "pydrake_pr2ik_test",

--- a/drake/bindings/BUILD
+++ b/drake/bindings/BUILD
@@ -4,6 +4,7 @@
 load("//tools:cpplint.bzl", "cpplint")
 load("//tools:python_lint.bzl", "python_lint")
 load("//tools:drake.bzl", "drake_cc_binary")
+load("//tools:gurobi.bzl", "gurobi_test_tags")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -192,11 +193,7 @@ py_test(
     size = "small",
     srcs = ["python/pydrake/test/testGurobiSolver.py"],
     main = "python/pydrake/test/testGurobiSolver.py",
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [":pydrake"],
 )
 
@@ -214,11 +211,7 @@ py_test(
     size = "small",
     srcs = ["python/pydrake/test/testMathematicalProgram.py"],
     main = "python/pydrake/test/testMathematicalProgram.py",
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [":pydrake"],
 )
 

--- a/drake/bindings/BUILD
+++ b/drake/bindings/BUILD
@@ -5,6 +5,7 @@ load("//tools:cpplint.bzl", "cpplint")
 load("//tools:python_lint.bzl", "python_lint")
 load("//tools:drake.bzl", "drake_cc_binary")
 load("//tools:gurobi.bzl", "gurobi_test_tags")
+load("//tools:mosek.bzl", "mosek_test_tags")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -202,7 +203,7 @@ py_test(
     size = "small",
     srcs = ["python/pydrake/test/testMosekSolver.py"],
     main = "python/pydrake/test/testMosekSolver.py",
-    tags = ["mosek"],
+    tags = mosek_test_tags(),
     deps = [":pydrake"],
 )
 

--- a/drake/bindings/python/CMakeLists.txt
+++ b/drake/bindings/python/CMakeLists.txt
@@ -27,9 +27,7 @@ if(BUILD_TESTING)
   drake_add_python_test(pydrake.test.testForwardDiff)
   drake_add_python_test(pydrake.test.testSymbolic)
 
-  # Temporarily disabled because we have no Gurobi license in CI. #5862
-  # if(gurobi_FOUND)
-  if (FALSE)
+  if(gurobi_FOUND)
     drake_add_python_test(pydrake.test.testMathematicalProgram)
     drake_add_python_test(pydrake.test.testGurobiSolver)
   endif()

--- a/drake/bindings/python/pydrake/test/testMathematicalProgram.py
+++ b/drake/bindings/python/pydrake/test/testMathematicalProgram.py
@@ -88,7 +88,7 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertTrue(prog.linear_costs())
         for (i, binding) in enumerate(prog.linear_costs()):
             cost = binding.constraint()
-            self.assertTrue(np.allclose(cost.A(), np.ones((1, 2))))
+            self.assertTrue(np.allclose(cost.a(), np.ones((1, 2))))
 
         self.assertTrue(prog.quadratic_costs())
         for (i, binding) in enumerate(prog.quadratic_costs()):

--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -109,52 +109,50 @@ drake_cc_googletest(
     ],
 )
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "valkyrie_balancing_test",
-#    size = "medium",
-#    srcs = ["test/valkyrie_balancing_test.cc"],
-#    data = [
-#        "config/valkyrie.alias_groups",
-#        "config/valkyrie.id_controller_config",
-#        "//drake/examples/Valkyrie:models",
-#    ],
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [
-#        ":control_utils",
-#        ":qp_controller",
-#        "//drake/common:eigen_matrix_compare",
-#        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
-#        "//drake/examples/Valkyrie:valkyrie_constants",
-#        "//drake/multibody/parsers",
-#    ],
-#)
+drake_cc_googletest(
+    name = "valkyrie_balancing_test",
+    size = "medium",
+    srcs = ["test/valkyrie_balancing_test.cc"],
+    data = [
+        "config/valkyrie.alias_groups",
+        "config/valkyrie.id_controller_config",
+        "//drake/examples/Valkyrie:models",
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [
+        ":control_utils",
+        ":qp_controller",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
+        "//drake/examples/Valkyrie:valkyrie_constants",
+        "//drake/multibody/parsers",
+    ],
+)
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "iiwa_inverse_dynamics_test",
-#    srcs = ["test/iiwa_inverse_dynamics_test.cc"],
-#    data = [
-#        "config/iiwa.alias_groups",
-#        "config/iiwa.id_controller_config",
-#        "//drake/manipulation/models/iiwa_description:models",
-#    ],
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [
-#        ":control_utils",
-#        ":qp_controller",
-#        "//drake/common:eigen_matrix_compare",
-#        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
-#        "//drake/multibody/parsers",
-#    ],
-#)
+drake_cc_googletest(
+    name = "iiwa_inverse_dynamics_test",
+    srcs = ["test/iiwa_inverse_dynamics_test.cc"],
+    data = [
+        "config/iiwa.alias_groups",
+        "config/iiwa.id_controller_config",
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [
+        ":control_utils",
+        ":qp_controller",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
+        "//drake/multibody/parsers",
+    ],
+)
 
 cpplint()

--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -3,6 +3,7 @@
 
 load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load("//tools:gurobi.bzl", "gurobi_test_tags")
 
 package(
     default_visibility = [":__subpackages__"],
@@ -118,11 +119,7 @@ drake_cc_googletest(
         "config/valkyrie.id_controller_config",
         "//drake/examples/Valkyrie:models",
     ],
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":control_utils",
         ":qp_controller",
@@ -141,11 +138,7 @@ drake_cc_googletest(
         "config/iiwa.id_controller_config",
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":control_utils",
         ":qp_controller",

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
@@ -8,6 +8,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
+load("//tools:gurobi.bzl", "gurobi_test_tags")
 
 drake_cc_library(
     name = "humanoid_status_translator_system",
@@ -128,11 +129,7 @@ drake_cc_binary(
         "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.id_controller_config",
         "//drake/examples/Valkyrie:models",
     ],
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":valkyrie_controller",
         "//drake/examples/Valkyrie:valkyrie_constants",
@@ -148,11 +145,7 @@ drake_cc_googletest(
         "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.id_controller_config",
         "//drake/examples/Valkyrie:models",
     ],
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":humanoid_plan_eval_system",
         ":qp_controller_system",
@@ -176,11 +169,7 @@ drake_cc_googletest(
         "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":manipulator_inverse_dynamics_controller",
         "//drake/common:eigen_matrix_compare",
@@ -200,11 +189,7 @@ drake_cc_googletest(
         "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":qp_controller_system",
         "//drake/common:eigen_matrix_compare",

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
@@ -140,83 +140,82 @@ drake_cc_binary(
     ],
 )
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "humanoid_plan_eval_test",
-#    srcs = ["test/humanoid_plan_eval_system_test.cc"],
-#    data = [
-#        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.alias_groups",
-#        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.id_controller_config",
-#        "//drake/examples/Valkyrie:models",
-#    ],
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [
-#        ":humanoid_plan_eval_system",
-#        ":qp_controller_system",
-#        "//drake/common:eigen_matrix_compare",
-#        "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
-#        "//drake/examples/QPInverseDynamicsForHumanoids:qp_controller",
-#        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
-#        "//drake/examples/Valkyrie:valkyrie_constants",
-#        "//drake/multibody/parsers",
-#        "//drake/systems/analysis:simulator",
-#        "//drake/systems/framework",
-#        "//drake/systems/primitives:constant_value_source",
-#    ],
-#)
-#
-#drake_cc_googletest(
-#    name = "manipulator_inverse_dynamics_controller_test",
-#    srcs = ["test/manipulator_inverse_dynamics_controller_test.cc"],
-#    data = [
-#        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
-#        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
-#        "//drake/manipulation/models/iiwa_description:models",
-#    ],
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [
-#        ":manipulator_inverse_dynamics_controller",
-#        "//drake/common:eigen_matrix_compare",
-#        "//drake/multibody/parsers",
-#        "//drake/systems/analysis:simulator",
-#        "//drake/systems/controllers:inverse_dynamics_controller",
-#        "//drake/systems/framework",
-#        "//drake/systems/primitives:constant_vector_source",
-#    ],
-#)
-#
-#drake_cc_googletest(
-#    name = "qp_controller_system_test",
-#    srcs = ["test/qp_controller_system_test.cc"],
-#    data = [
-#        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
-#        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
-#        "//drake/manipulation/models/iiwa_description:models",
-#    ],
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [
-#        ":qp_controller_system",
-#        "//drake/common:eigen_matrix_compare",
-#        "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
-#        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
-#        "//drake/multibody/parsers",
-#        "//drake/systems/analysis:simulator",
-#        "//drake/systems/framework",
-#        "//drake/systems/primitives:constant_value_source",
-#    ],
-#)
+drake_cc_googletest(
+    name = "humanoid_plan_eval_test",
+    srcs = ["test/humanoid_plan_eval_system_test.cc"],
+    data = [
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.id_controller_config",
+        "//drake/examples/Valkyrie:models",
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [
+        ":humanoid_plan_eval_system",
+        ":qp_controller_system",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
+        "//drake/examples/QPInverseDynamicsForHumanoids:qp_controller",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
+        "//drake/examples/Valkyrie:valkyrie_constants",
+        "//drake/multibody/parsers",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework",
+        "//drake/systems/primitives:constant_value_source",
+    ],
+)
+
+drake_cc_googletest(
+    name = "manipulator_inverse_dynamics_controller_test",
+    srcs = ["test/manipulator_inverse_dynamics_controller_test.cc"],
+    data = [
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [
+        ":manipulator_inverse_dynamics_controller",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/multibody/parsers",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/controllers:inverse_dynamics_controller",
+        "//drake/systems/framework",
+        "//drake/systems/primitives:constant_vector_source",
+    ],
+)
+
+drake_cc_googletest(
+    name = "qp_controller_system_test",
+    srcs = ["test/qp_controller_system_test.cc"],
+    data = [
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [
+        ":qp_controller_system",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
+        "//drake/multibody/parsers",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework",
+        "//drake/systems/primitives:constant_value_source",
+    ],
+)
 
 drake_cc_googletest(
     name = "joint_level_controller_system_test",

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -27,46 +27,43 @@ drake_cc_library(
     ],
 )
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "global_inverse_kinematics_test",
-#    size = "medium",
-#    srcs = ["test/global_inverse_kinematics_test.cc"],
-#    data = [
-#        "//drake/manipulation/models/iiwa_description:models",
-#    ],
-#    tags = ["gurobi"],
-#    deps = [
-#        ":global_inverse_kinematics_test_util",
-#    ],
-#)
+drake_cc_googletest(
+    name = "global_inverse_kinematics_test",
+    size = "medium",
+    srcs = ["test/global_inverse_kinematics_test.cc"],
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = ["gurobi"],
+    deps = [
+        ":global_inverse_kinematics_test_util",
+    ],
+)
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "global_inverse_kinematics_reachable_test",
-#    size = "medium",
-#    srcs = ["test/global_inverse_kinematics_reachable_test.cc"],
-#    data = [
-#        "//drake/manipulation/models/iiwa_description:models",
-#    ],
-#    tags = ["gurobi"],
-#    deps = [
-#        ":global_inverse_kinematics_test_util",
-#    ],
-#)
+drake_cc_googletest(
+    name = "global_inverse_kinematics_reachable_test",
+    size = "medium",
+    srcs = ["test/global_inverse_kinematics_reachable_test.cc"],
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = ["gurobi"],
+    deps = [
+        ":global_inverse_kinematics_test_util",
+    ],
+)
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "global_inverse_kinematics_collision_avoidance_test",
-#    size = "medium",
-#    srcs = ["test/global_inverse_kinematics_collision_avoidance_test.cc"],
-#    data = [
-#        "//drake/manipulation/models/iiwa_description:models",
-#    ],
-#    tags = ["gurobi"],
-#    deps = [
-#        ":global_inverse_kinematics_test_util",
-#    ],
-#)
+drake_cc_googletest(
+   name = "global_inverse_kinematics_collision_avoidance_test",
+   size = "medium",
+   srcs = ["test/global_inverse_kinematics_collision_avoidance_test.cc"],
+   data = [
+       "//drake/manipulation/models/iiwa_description:models",
+   ],
+   tags = ["gurobi"],
+   deps = [
+       ":global_inverse_kinematics_test_util",
+   ],
+)
 
 cpplint()

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -7,6 +7,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
+load("//tools:gurobi.bzl", "gurobi_test_tags")
 
 drake_cc_library(
     name = "global_inverse_kinematics_test_util",
@@ -34,7 +35,7 @@ drake_cc_googletest(
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    tags = ["gurobi"],
+    tags = gurobi_test_tags(),
     deps = [
         ":global_inverse_kinematics_test_util",
     ],
@@ -47,23 +48,23 @@ drake_cc_googletest(
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    tags = ["gurobi"],
+    tags = gurobi_test_tags(),
     deps = [
         ":global_inverse_kinematics_test_util",
     ],
 )
 
 drake_cc_googletest(
-   name = "global_inverse_kinematics_collision_avoidance_test",
-   size = "medium",
-   srcs = ["test/global_inverse_kinematics_collision_avoidance_test.cc"],
-   data = [
-       "//drake/manipulation/models/iiwa_description:models",
-   ],
-   tags = ["gurobi"],
-   deps = [
-       ":global_inverse_kinematics_test_util",
-   ],
+    name = "global_inverse_kinematics_collision_avoidance_test",
+    size = "medium",
+    srcs = ["test/global_inverse_kinematics_collision_avoidance_test.cc"],
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = gurobi_test_tags(),
+    deps = [
+        ":global_inverse_kinematics_test_util",
+    ],
 )
 
 cpplint()

--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -20,7 +20,7 @@ if(gurobi_FOUND)
             drakeGlobalInverseKinematicsTest)
 
     drake_add_cc_test(global_inverse_kinematics_collision_avoidance_test)
-    set_tests_properties(global_inverse_kinematics_collision_avoidance_test PROPERTIES TIMEOUT 200)
+    set_tests_properties(global_inverse_kinematics_collision_avoidance_test PROPERTIES TIMEOUT 300)
     target_link_libraries(global_inverse_kinematics_collision_avoidance_test
             drakeGlobalInverseKinematicsTest)
 endif()

--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -8,9 +8,7 @@ target_link_libraries(drakeGlobalInverseKinematicsTest
         drakeIK
         GTest::GTest)
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-# if(gurobi_FOUND)
-if (FALSE)
+if(gurobi_FOUND)
     drake_add_cc_test(global_inverse_kinematics_test)
     set_tests_properties(global_inverse_kinematics_test PROPERTIES TIMEOUT 200)
     target_link_libraries(global_inverse_kinematics_test

--- a/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_collision_avoidance_test.cc
@@ -121,7 +121,7 @@ TEST_F(KukaTest, CollisionAvoidanceTest) {
           cache, rigid_body_tree_->get_body(ee_idx_));
   EXPECT_LE(
       (ee_pose_ik_without_collision_avoidance.translation() - ee_pos).norm(),
-      0.05);
+      0.06);
 
   int link6_idx = rigid_body_tree_->FindBodyIndex("iiwa_link_6");
   int link5_idx = rigid_body_tree_->FindBodyIndex("iiwa_link_5");

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -458,26 +458,25 @@ drake_cc_googletest(
     ],
 )
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
 # TODO(hongkai-dai): Separate this test into a test that uses Gurobi, and a
 # test that doesn't.
-#drake_cc_googletest(
-#    name = "convex_optimization_test",
-#    srcs = [
-#        "test/convex_optimization_test.cc",
-#    ],
-#    # This test uses Gurobi if present, but does not require it.
-#    tags = [
-#        "exclusive",
-#        "local",
-#    ],
-#    deps = [
-#        ":add_solver_util",
-#        ":mathematical_program",
-#        ":mathematical_program_test_util",
-#        "//drake/common:eigen_matrix_compare",
-#    ],
-#)
+drake_cc_googletest(
+    name = "convex_optimization_test",
+    srcs = [
+        "test/convex_optimization_test.cc",
+    ],
+    # This test uses Gurobi if present, but does not require it.
+    tags = [
+        "exclusive",
+        "local",
+    ],
+    deps = [
+        ":add_solver_util",
+        ":mathematical_program",
+        ":mathematical_program_test_util",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
 
 drake_cc_googletest(
     name = "decision_variable_test",
@@ -500,26 +499,25 @@ drake_cc_googletest(
     ],
 )
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "gurobi_solver_test",
-#    srcs = [
-#        "test/gurobi_solver_test.cc",
-#    ],
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [
-#        ":gurobi_solver",
-#        ":linear_program_examples",
-#        ":mathematical_program",
-#        ":mathematical_program_test_util",
-#        ":quadratic_program_examples",
-#        "//drake/common:eigen_matrix_compare",
-#    ],
-#)
+drake_cc_googletest(
+    name = "gurobi_solver_test",
+    srcs = [
+        "test/gurobi_solver_test.cc",
+    ],
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [
+        ":gurobi_solver",
+        ":linear_program_examples",
+        ":mathematical_program",
+        ":mathematical_program_test_util",
+        ":quadratic_program_examples",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
 
 drake_cc_googletest(
     name = "ipopt_solver_test",
@@ -577,24 +575,23 @@ drake_cc_googletest(
 
 # TODO(hongkai-dai): Separate this test into a test that uses Gurobi, and a
 # test that doesn't.
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "mixed_integer_optimization_test",
-#    srcs = [
-#        "test/mixed_integer_optimization_test.cc",
-#    ],
-#    # This test uses Gurobi if present, but does not require it.
-#    tags = [
-#        "exclusive",
-#        "local",
-#    ],
-#    deps = [
-#        ":add_solver_util",
-#        ":mathematical_program",
-#        ":mathematical_program_test_util",
-#        "//drake/common:eigen_matrix_compare",
-#    ],
-#)
+drake_cc_googletest(
+    name = "mixed_integer_optimization_test",
+    srcs = [
+        "test/mixed_integer_optimization_test.cc",
+    ],
+    # This test uses Gurobi if present, but does not require it.
+    tags = [
+        "exclusive",
+        "local",
+    ],
+    deps = [
+        ":add_solver_util",
+        ":mathematical_program",
+        ":mathematical_program_test_util",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
 
 drake_cc_googletest(
     name = "moby_lcp_solver_test",
@@ -632,24 +629,23 @@ drake_cc_googletest(
     ],
 )
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "rotation_constraint_test",
-#    size = "medium",
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#        "mosek",
-#    ],
-#    deps = [
-#        ":gurobi_solver",
-#        ":mathematical_program",
-#        ":rotation_constraint",
-#        "//drake/common:eigen_matrix_compare",
-#        "//drake/math:geometric_transform",
-#    ],
-#)
+drake_cc_googletest(
+    name = "rotation_constraint_test",
+    size = "medium",
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+        "mosek",
+    ],
+    deps = [
+        ":gurobi_solver",
+        ":mathematical_program",
+        ":rotation_constraint",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/math:geometric_transform",
+    ],
+)
 
 drake_cc_binary(
     name = "plot_feasible_rotation_matrices",
@@ -662,22 +658,21 @@ drake_cc_binary(
     ],
 )
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-#drake_cc_googletest(
-#    name = "rotation_constraint_limit_test",
-#    size = "large",
-#    tags = [
-#        "exclusive",
-#        "gurobi",
-#        "local",
-#    ],
-#    deps = [
-#        ":gurobi_solver",
-#        ":mathematical_program",
-#        ":rotation_constraint",
-#        "//drake/common:eigen_matrix_compare",
-#    ],
-#)
+drake_cc_googletest(
+    name = "rotation_constraint_limit_test",
+    size = "large",
+    tags = [
+        "exclusive",
+        "gurobi",
+        "local",
+    ],
+    deps = [
+        ":gurobi_solver",
+        ":mathematical_program",
+        ":rotation_constraint",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
 
 drake_cc_googletest(
     name = "snopt_solver_test",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -9,6 +9,7 @@ load(
     "drake_cc_library",
 )
 load("//tools:gurobi.bzl", "gurobi_test_tags")
+load("//tools:mosek.bzl", "mosek_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -597,7 +598,7 @@ drake_cc_googletest(
     srcs = [
         "test/mosek_solver_test.cc",
     ],
-    tags = ["mosek"],
+    tags = mosek_test_tags(),
     deps = [
         ":linear_program_examples",
         ":mathematical_program",
@@ -623,9 +624,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "rotation_constraint_test",
     size = "medium",
-    tags = gurobi_test_tags() + [
-        "mosek",
-    ],
+    tags = gurobi_test_tags() + mosek_test_tags(),
     deps = [
         ":gurobi_solver",
         ":mathematical_program",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -8,6 +8,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
+load("//tools:gurobi.bzl", "gurobi_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -466,10 +467,7 @@ drake_cc_googletest(
         "test/convex_optimization_test.cc",
     ],
     # This test uses Gurobi if present, but does not require it.
-    tags = [
-        "exclusive",
-        "local",
-    ],
+    tags = gurobi_test_tags(gurobi_required = False),
     deps = [
         ":add_solver_util",
         ":mathematical_program",
@@ -504,11 +502,7 @@ drake_cc_googletest(
     srcs = [
         "test/gurobi_solver_test.cc",
     ],
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":gurobi_solver",
         ":linear_program_examples",
@@ -581,10 +575,7 @@ drake_cc_googletest(
         "test/mixed_integer_optimization_test.cc",
     ],
     # This test uses Gurobi if present, but does not require it.
-    tags = [
-        "exclusive",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":add_solver_util",
         ":mathematical_program",
@@ -632,10 +623,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "rotation_constraint_test",
     size = "medium",
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
+    tags = gurobi_test_tags() + [
         "mosek",
     ],
     deps = [
@@ -661,11 +649,7 @@ drake_cc_binary(
 drake_cc_googletest(
     name = "rotation_constraint_limit_test",
     size = "large",
-    tags = [
-        "exclusive",
-        "gurobi",
-        "local",
-    ],
+    tags = gurobi_test_tags(),
     deps = [
         ":gurobi_solver",
         ":mathematical_program",

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -48,9 +48,8 @@ target_link_libraries(drakeRotationConstraintVisualization
         drakeLCMTypes)
 endif()
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-# drake_add_cc_test(convex_optimization_test)
-# target_link_libraries(convex_optimization_test drakeCommon drakeOptimizationTest)
+drake_add_cc_test(convex_optimization_test)
+target_link_libraries(convex_optimization_test drakeCommon drakeOptimizationTest)
 
 drake_add_cc_test(equality_constrained_qp_solver_test)
 target_link_libraries(equality_constrained_qp_solver_test drakeCommon drakeOptimizationTest)
@@ -61,13 +60,11 @@ target_link_libraries(nonlinear_program_test drakeCommon drakeOptimizationTest)
 drake_add_cc_test(linear_system_solver_test)
 target_link_libraries(linear_system_solver_test drakeCommon drakeOptimizationTest)
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-# drake_add_cc_test(mixed_integer_optimization_test)
-# target_link_libraries(mixed_integer_optimization_test drakeCommon drakeOptimizationTest)
+drake_add_cc_test(mixed_integer_optimization_test)
+target_link_libraries(mixed_integer_optimization_test drakeCommon drakeOptimizationTest)
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-# drake_add_cc_test(gurobi_solver_test)
-# target_link_libraries(gurobi_solver_test drakeCommon drakeOptimizationTest)
+drake_add_cc_test(gurobi_solver_test)
+target_link_libraries(gurobi_solver_test drakeCommon drakeOptimizationTest)
 
 drake_add_cc_test(mosek_solver_test)
 target_link_libraries(mosek_solver_test drakeCommon drakeOptimizationTest)
@@ -81,17 +78,13 @@ target_link_libraries(ipopt_solver_test drakeOptimizationTest)
 drake_add_cc_test(snopt_solver_test)
 target_link_libraries(snopt_solver_test drakeOptimizationTest)
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-# if (mosek_FOUND)
-if (FALSE)
+if (mosek_FOUND)
   drake_add_cc_test(rotation_constraint_test rotation_constraint_test.cc)
   set_tests_properties(rotation_constraint_test PROPERTIES TIMEOUT 900)
   target_link_libraries(rotation_constraint_test drakeRotationConstraint)
 endif()
 
-# Temporarily disabled because we have no Gurobi license in CI. #5862
-# if (gurobi_FOUND)
-if (FALSE)
+if (gurobi_FOUND)
   if(NOT APPLE)
 	  drake_add_cc_test(rotation_constraint_limit_test)
 	  set_tests_properties(rotation_constraint_limit_test PROPERTIES TIMEOUT 900)

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <list>
+#include <memory>
 
 #include <gtest/gtest.h>
 
@@ -7,6 +8,8 @@
 #include "drake/common/eigen_types.h"
 #include "drake/solvers/test/add_solver_util.h"
 #include "drake/solvers/test/mathematical_program_test_util.h"
+
+using std::make_shared;
 
 using Eigen::Vector2d;
 using Eigen::Matrix2d;
@@ -239,7 +242,7 @@ void SolveQPasSOCP(const Eigen::MatrixBase<DerivedQ>& Q,
 
   prog_socp.AddLinearConstraint(A, b_lb, b_ub, x_socp);
 
-  auto cost_socp1 = CreateLinearCost(c.transpose());
+  auto cost_socp1 = make_shared<LinearCost>(c.transpose());
   prog_socp.AddCost(cost_socp1, x_socp);
   prog_socp.AddLinearCost(drake::Vector1d(1.0), y);
   RunSolver(&prog_socp, solver);

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -28,6 +28,7 @@ test --test_tag_filters=-gurobi,-mosek,-snopt
 # -- "local", because they are non-hermetic. For the moment, we also require
 # -- the tag "exclusive", to rate-limit license servers with a small number of
 # -- licenses.
+# -- For consistency, use "gurobi_test_tags()" from //tools:gurobi.bzl.
 # -- TODO(david-german-tri): Find a better fix for the license server problem.
 #
 # -- To run tests that require Gurobi, also specify a custom set of

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -23,16 +23,9 @@ test --test_tag_filters=-gurobi,-mosek,-snopt
 # -- To use this config, the GUROBI_PATH environment variable must be the
 # -- linux64 directory in the Gurobi 6.0.5 release.
 #
-# -- Gurobi checks a license file, and may need to contact a license server to
-# -- check out a license. Therefore, tests that use Gurobi must have the tag
-# -- "local", because they are non-hermetic. For the moment, we also require
-# -- the tag "exclusive", to rate-limit license servers with a small number of
-# -- licenses.
-# -- For consistency, use "gurobi_test_tags()" from //tools:gurobi.bzl.
-# -- TODO(david-german-tri): Find a better fix for the license server problem.
-#
-# -- To run tests that require Gurobi, also specify a custom set of
-# -- test_tag_filters that does not exclude the "gurobi" tag.
+# -- To run tests where Gurobi is used, ensure that you include
+# -- "gurobi_test_tags()" from //tools:gurobi.bzl. If Gurobi is optional, set
+# -- gurobi_required=False.
 build:gurobi --define=WITH_GUROBI=ON
 # -- By default, Gurobi looks for the license file in the homedir.
 test:gurobi --test_env=HOME
@@ -43,8 +36,9 @@ test:gurobi --test_env=GRB_LICENSE_FILE
 # -- To use this config, you must have a MOSEK license file installed to
 # -- $HOME/mosek/mosek.lic.
 #
-# -- To run tests that require MOSEK, also specify a set of test_tag_filters
-# -- that does not exclude the "mosek" tag.
+# -- To run tests where MOSEK is used, ensure that you include
+# -- "mosek_test_tags()" from //tools:mosek.bzl. If MOSEK is optional, set
+# -- mosek_required=False.
 build:mosek --define=WITH_MOSEK=ON
 # -- MOSEK looks for its license file at $HOME/mosek/mosek.lic
 test:mosek --test_env=HOME

--- a/tools/gurobi.bzl
+++ b/tools/gurobi.bzl
@@ -64,3 +64,18 @@ gurobi_repository = repository_rule(
     local = True,
     implementation = _gurobi_impl,
 )
+
+def gurobi_test_tags(gurobi_required=True):
+    """Returns the test tags necessary for properly running Gurobi tests.
+
+    By default, sets gurobi_required=True, which will require that the supplied
+    tag filters include "gurobi".
+    """
+    nominal_tags = [
+        "exclusive",
+        "local",
+    ]
+    if gurobi_required:
+        return nominal_tags + ["gurobi"]
+    else:
+        return nominal_tags

--- a/tools/gurobi.bzl
+++ b/tools/gurobi.bzl
@@ -70,7 +70,14 @@ def gurobi_test_tags(gurobi_required=True):
 
     By default, sets gurobi_required=True, which will require that the supplied
     tag filters include "gurobi".
+
+    Gurobi checks a license file, and may need to contact a license server to
+    check out a license. Therefore, tests that use Gurobi must have the tag
+    "local", because they are non-hermetic. For the moment, we also require
+    the tag "exclusive", to rate-limit license servers with a small number of
+    licenses.
     """
+    # TODO(david-german-tri): Find a better fix for the license server problem.
     nominal_tags = [
         "exclusive",
         "local",

--- a/tools/mosek.bzl
+++ b/tools/mosek.bzl
@@ -107,6 +107,10 @@ def mosek_test_tags(mosek_required=True):
 
     By default, sets mosek_required=True, which will require that the supplied
     tag filters include "mosek".
+
+    MOSEK checks a license file, and may need to contact a license server to
+    check out a license. Therefore, tests that use MOSEK must have the tag
+    "local", because they are non-hermetic.
     """
     nominal_tags = [
         "local",

--- a/tools/mosek.bzl
+++ b/tools/mosek.bzl
@@ -101,3 +101,17 @@ cc_library(
     repository_ctx.file("BUILD", content=file_content, executable=False)
 
 mosek_repository = repository_rule(implementation = _impl)
+
+def mosek_test_tags(mosek_required=True):
+    """Returns the test tags necessary for properly running mosek tests.
+
+    By default, sets mosek_required=True, which will require that the supplied
+    tag filters include "mosek".
+    """
+    nominal_tags = [
+        "local",
+    ]
+    if mosek_required:
+        return nominal_tags + ["mosek"]
+    else:
+        return nominal_tags


### PR DESCRIPTION
Per #5862, this reverts the commit in #5863 but still disables Gurobi in CI (via https://github.com/RobotLocomotion/drake-ci/commit/88555be). This permits developers to run tests locally without having to uncomment the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6110)
<!-- Reviewable:end -->
