### PR TITLE
Use "com_github_gflags_gflags" for gflags in bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ github_archive(
 )
 
 github_archive(
-    name = "gflags",
+    name = "com_github_gflags_gflags",
     repository = "gflags/gflags",
     commit = "95ffb27c9c7496ede1409e042571054c70cb9519",
     sha256 = "723c21f783c720c0403c9b44bf500d1961a08bd2635cbc117107af22d2e1643f",

--- a/drake/automotive/maliput/dragway/BUILD
+++ b/drake/automotive/maliput/dragway/BUILD
@@ -39,7 +39,7 @@ drake_cc_binary(
         "//drake/common",
         "//drake/common:text_logging_gflags",
         "//drake/thirdParty:spruce",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -295,7 +295,7 @@ drake_cc_library(
     }),
     deps = [
         ":common",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/Acrobot/BUILD
+++ b/drake/examples/Acrobot/BUILD
@@ -98,7 +98,7 @@ drake_cc_binary(
         "//drake/multibody/parsers",
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis:simulator",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -124,7 +124,7 @@ drake_cc_binary(
         "//drake/systems/primitives:linear_system",
         "//drake/systems/primitives:signal_logger",
         "//drake/systems/sensors:rotary_encoders",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -144,7 +144,7 @@ drake_cc_binary(
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis:simulator",
         "//drake/systems/framework:diagram",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -164,7 +164,7 @@ drake_cc_binary(
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
         "//drake/systems/controllers:linear_quadratic_regulator",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -183,7 +183,7 @@ drake_cc_binary(
         "//drake/systems/analysis",
         "//drake/systems/controllers:linear_quadratic_regulator",
         "//drake/systems/primitives:trajectory_source",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -217,7 +217,7 @@ drake_cc_binary(
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
         "//drake/systems/controllers:linear_quadratic_regulator",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/Pendulum/BUILD
+++ b/drake/examples/Pendulum/BUILD
@@ -108,7 +108,7 @@ drake_cc_binary(
         "//drake/systems/framework",
         "//drake/systems/primitives:trajectory_source",
         "//drake/systems/trajectory_optimization:direct_collocation",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/Quadrotor/BUILD
+++ b/drake/examples/Quadrotor/BUILD
@@ -53,7 +53,7 @@ drake_cc_binary(
         "//drake/systems/analysis:simulator",
         "//drake/systems/framework:diagram",
         "//drake/systems/primitives:constant_vector_source",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -78,7 +78,7 @@ drake_cc_binary(
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis:simulator",
         "//drake/systems/framework:diagram",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/contact_model/BUILD
+++ b/drake/examples/contact_model/BUILD
@@ -27,7 +27,7 @@ drake_cc_binary(
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
         "//drake/systems/primitives:constant_vector_source",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -52,7 +52,7 @@ drake_cc_binary(
         "//drake/multibody/rigid_body_plant:contact_results_to_lcm",
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -76,7 +76,7 @@ drake_cc_binary(
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis",
         "//drake/systems/lcm",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/kuka_iiwa_arm/BUILD
+++ b/drake/examples/kuka_iiwa_arm/BUILD
@@ -112,7 +112,7 @@ drake_cc_binary(
         "//drake/systems/lcm:lcm_driven_loop",
         "//drake/systems/primitives:demultiplexer",
         "@bot_core_lcmtypes",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
         "@robotlocomotion_lcmtypes",
     ],
 )
@@ -144,7 +144,7 @@ drake_cc_binary(
         "//drake/systems/primitives:constant_vector_source",
         "//drake/systems/primitives:matrix_gain",
         "//drake/util:lcm_util",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -167,7 +167,7 @@ drake_cc_binary(
         "//drake/systems/analysis:simulator",
         "//drake/systems/controllers:inverse_dynamics_controller",
         "//drake/systems/primitives:constant_vector_source",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/BUILD
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/BUILD
@@ -25,6 +25,6 @@ drake_cc_binary(
         "//drake/systems/analysis:simulator",
         "//drake/systems/controllers:inverse_dynamics_controller",
         "//drake/systems/primitives:trajectory_source",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD
@@ -55,7 +55,7 @@ drake_cc_binary(
         "//drake/examples/kuka_iiwa_arm:robot_plan_interpolator",
         "//drake/examples/schunk_wsg:schunk_wsg_lcm",
         "@bot_core_lcmtypes",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -72,7 +72,7 @@ drake_cc_binary(
         "//drake/lcm",
         "//drake/systems/analysis",
         "//drake/systems/framework",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/kuka_iiwa_arm/dev/tools/BUILD
+++ b/drake/examples/kuka_iiwa_arm/dev/tools/BUILD
@@ -40,7 +40,7 @@ drake_cc_binary(
         "//drake/lcm",
         "//drake/multibody/parsers",
         "//drake/systems/framework",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/rod2d/BUILD
+++ b/drake/examples/rod2d/BUILD
@@ -28,7 +28,7 @@ drake_cc_binary(
         "//drake/systems/rendering:drake_visualizer_client",
         "//drake/systems/rendering:pose_aggregator",
         "//drake/systems/rendering:pose_bundle_to_draw_message",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/examples/schunk_wsg/BUILD
+++ b/drake/examples/schunk_wsg/BUILD
@@ -84,7 +84,7 @@ drake_cc_binary(
         "//drake/systems/primitives:constant_vector_source",
         "//drake/systems/primitives:matrix_gain",
         "//drake/systems/primitives:multiplexer",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -175,7 +175,7 @@ drake_cc_binary(
         "//drake/common:text_logging_gflags",
         "//drake/lcm",
         "//drake/systems/analysis:simulator",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 


### PR DESCRIPTION
This commit fixes the following warning:

```
WARNING: external/gflags/WORKSPACE:1: Workspace name in
external/gflags/WORKSPACE (@com_github_gflags_gflags) does not match
the name given in the repository's definition (@gflags); this will
cause a build error in future versions.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6114)
<!-- Reviewable:end -->
