### PR TITLE
MBT compile topological information

### DIFF
--- a/drake/multibody/multibody_tree/body.h
+++ b/drake/multibody/multibody_tree/body.h
@@ -137,7 +137,7 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
   // At MultibodyTree::Finalize() time, each body retrieves its topology
   // from the parent MultibodyTree.
   void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
-    topology_ = tree_topology.bodies[this->get_index()];
+    topology_ = tree_topology.get_body(this->get_index());
     body_frame_.SetTopology(tree_topology);
   }
 

--- a/drake/multibody/multibody_tree/mobilizer.h
+++ b/drake/multibody/multibody_tree/mobilizer.h
@@ -183,7 +183,7 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   // At MultibodyTree::Finalize() time, each mobilizer retrieves its topology
   // from the parent MultibodyTree.
   void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
-    topology_ = tree_topology.mobilizers[this->get_index()];
+    topology_ = tree_topology.get_mobilizer(this->get_index());
   }
 
   const Frame<T>& inboard_frame_;

--- a/drake/multibody/multibody_tree/multibody_tree.cc
+++ b/drake/multibody/multibody_tree/multibody_tree.cc
@@ -52,8 +52,6 @@ void MultibodyTree<T>::Finalize() {
   for (const auto& mobilizer : owned_mobilizers_) {
     mobilizer->SetTopology(topology_);
   }
-
-  set_valid_topology();
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/multibody/multibody_tree/multibody_tree.cc
+++ b/drake/multibody/multibody_tree/multibody_tree.cc
@@ -28,6 +28,12 @@ void MultibodyTree<T>::Finalize() {
         "MultibodyTree.");
   }
 
+  // Analyze if a method that verifies the state of the topology with a
+  // signature similar to RoadGeometry::CheckInvariants() is a good scheme to
+  // report errors here. Either during MBTTopology::Finalize() or after the
+  // fact?
+  topology_.Finalize();
+
   // TODO(amcastro-tri): This is a brief list of operations to be added in
   // subsequent PR's:
   //   - Finalize non-T dependent topological information.

--- a/drake/multibody/multibody_tree/multibody_tree.cc
+++ b/drake/multibody/multibody_tree/multibody_tree.cc
@@ -28,15 +28,12 @@ void MultibodyTree<T>::Finalize() {
         "MultibodyTree.");
   }
 
-  // Analyze if a method that verifies the state of the topology with a
-  // signature similar to RoadGeometry::CheckInvariants() is a good scheme to
-  // report errors here. Either during MBTTopology::Finalize() or after the
-  // fact?
+  // Before performing any setup that depends on the scalar type <T>, compile
+  // all the type-T independent topological information.
   topology_.Finalize();
 
   // TODO(amcastro-tri): This is a brief list of operations to be added in
   // subsequent PR's:
-  //   - Finalize non-T dependent topological information.
   //   - Compute degrees of freedom, array sizes and any other information to
   //     allocate a context and request the required cache entries.
   //   - Setup computational structures (BodyNode based).

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -79,7 +79,7 @@ class MultibodyTree {
   const BodyType<T>& AddBody(std::unique_ptr<BodyType<T>> body) {
     static_assert(std::is_convertible<BodyType<T>*, Body<T>*>::value,
                   "BodyType must be a sub-class of Body<T>.");
-    if (topology_.is_valid) {
+    if (topology_is_valid()) {
       throw std::logic_error("This MultibodyTree is finalized already. "
                              "Therefore adding more bodies is not allowed. "
                              "See documentation for Finalize() for details.");
@@ -177,7 +177,7 @@ class MultibodyTree {
   const FrameType<T>& AddFrame(std::unique_ptr<FrameType<T>> frame) {
     static_assert(std::is_convertible<FrameType<T>*, Frame<T>*>::value,
                   "FrameType must be a sub-class of Frame<T>.");
-    if (topology_.is_valid) {
+    if (topology_is_valid()) {
       throw std::logic_error("This MultibodyTree is finalized already. "
                              "Therefore adding more frames is not allowed. "
                              "See documentation for Finalize() for details.");
@@ -285,7 +285,7 @@ class MultibodyTree {
       std::unique_ptr<MobilizerType<T>> mobilizer) {
     static_assert(std::is_convertible<MobilizerType<T>*, Mobilizer<T>*>::value,
                   "MobilizerType must be a sub-class of mobilizer<T>.");
-    if (topology_.is_valid) {
+    if (topology_is_valid()) {
       throw std::logic_error("This MultibodyTree is finalized already. "
                              "Therefore adding more bodies is not allowed. "
                              "See documentation for Finalize() for details.");
@@ -409,7 +409,7 @@ class MultibodyTree {
   /// When a %MultibodyTree is instantiated, its topology remains invalid until
   /// Finalize() is called, which validates the topology.
   /// @see Finalize().
-  bool topology_is_valid() const { return topology_.is_valid; }
+  bool topology_is_valid() const { return topology_.is_valid(); }
 
   /// Returns the topology information for this multibody tree. Users should not
   /// need to call this method since MultibodyTreeTopology is an internal
@@ -439,9 +439,6 @@ class MultibodyTree {
   // TODO(amcastro-tri): In future PR's adding MBT computational methods, write
   // a method that verifies the state of the topology with a signature similar
   // to RoadGeometry::CheckInvariants().
-
-  // Sets a flag indicate the topology is valid.
-  void set_valid_topology() { topology_.set_valid(); }
 
   std::vector<std::unique_ptr<Body<T>>> owned_bodies_;
   std::vector<std::unique_ptr<Frame<T>>> owned_frames_;

--- a/drake/multibody/multibody_tree/multibody_tree_indexes.h
+++ b/drake/multibody/multibody_tree/multibody_tree_indexes.h
@@ -14,6 +14,9 @@ using BodyIndex = TypeSafeIndex<class BodyTag>;
 /// Type used to identify mobilizers by index in a multibody tree system.
 using MobilizerIndex = TypeSafeIndex<class MobilizerTag>;
 
+/// Type used to identify tree nodes by index within a multibody tree system.
+using BodyNodeIndex = TypeSafeIndex<class BodyNodeTag>;
+
 /// For every MultibodyTree the **world** body _always_ has this unique index
 /// and it is always zero.
 // Note:

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -245,7 +245,7 @@ class MultibodyTreeTopology {
 
   /// Returns the number of physical frames in the multibody tree.
   int get_num_frames() const {
-    return static_cast<int>(frames.size());
+    return static_cast<int>(frames_.size());
   }
 
   /// Returns the number of mobilizers in the multibody tree. Since the "world"
@@ -264,7 +264,7 @@ class MultibodyTreeTopology {
   /// FrameIndex.
   const FrameTopology& get_frame(FrameIndex index) const {
     DRAKE_ASSERT(index < get_num_frames());
-    return frames[index];
+    return frames_[index];
   }
 
   /// Returns a constant reference to the corresponding BodyTopology given a
@@ -323,7 +323,7 @@ class MultibodyTreeTopology {
                              "See documentation for Finalize() for details.");
     }
     FrameIndex frame_index(get_num_frames());
-    frames.emplace_back(frame_index, body_index);
+    frames_.emplace_back(frame_index, body_index);
     return frame_index;
   }
 
@@ -362,8 +362,8 @@ class MultibodyTreeTopology {
           "This multibody tree already has a mobilizer connecting these two "
           "frames. More than one mobilizer between two frames is not allowed");
     }
-    const BodyIndex inboard_body = frames[in_frame].body;
-    const BodyIndex outboard_body = frames[out_frame].body;
+    const BodyIndex inboard_body = frames_[in_frame].body;
+    const BodyIndex outboard_body = frames_[out_frame].body;
     if (IsThereAMobilizerBetweenBodies(inboard_body, outboard_body)) {
       throw std::runtime_error(
           "This multibody tree already has a mobilizer connecting these two "
@@ -532,8 +532,6 @@ class MultibodyTreeTopology {
 
   bool is_valid() const { return is_valid_; }
 
-  std::vector<FrameTopology> frames;
-
  private:
   // is_valid is set to `true` after a successful Finalize().
   bool is_valid_{false};
@@ -541,6 +539,8 @@ class MultibodyTreeTopology {
   // there will be at least one level (level = 0) with the world body.
   int num_levels_{-1};
 
+  // Topological elements:
+  std::vector<FrameTopology> frames_;
   std::vector<BodyTopology> bodies_;
   std::vector<MobilizerTopology> mobilizers_;
   std::vector<BodyNodeTopology> body_nodes_;

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -252,7 +252,7 @@ class MultibodyTreeTopology {
   /// body does not have a mobilizer, the number of mobilizers will always equal
   /// the number of bodies minus one.
   int get_num_mobilizers() const {
-    return static_cast<int>(mobilizers.size());
+    return static_cast<int>(mobilizers_.size());
   }
 
   /// Returns the number of tree nodes. This must equal the number of bodies.
@@ -279,6 +279,13 @@ class MultibodyTreeTopology {
   const BodyNodeTopology& get_body_node(BodyNodeIndex index) const {
     DRAKE_ASSERT(index < get_num_body_nodes());
     return body_nodes_[index];
+  }
+
+  /// Returns a constant reference to the corresponding BodyTopology given a
+  /// BodyIndex.
+  const MobilizerTopology& get_mobilizer(MobilizerIndex index) const {
+    DRAKE_ASSERT(index < get_num_mobilizers());
+    return mobilizers_[index];
   }
 
   /// Creates and adds a new BodyTopology to this MultibodyTreeTopology.
@@ -389,7 +396,7 @@ class MultibodyTreeTopology {
     // structure of MultibodyTree.
     bodies_[inboard_body].child_bodies.push_back(outboard_body);
 
-    mobilizers.emplace_back(mobilizer_index,
+    mobilizers_.emplace_back(mobilizer_index,
                             in_frame, out_frame,
                             inboard_body, outboard_body);
     return mobilizer_index;
@@ -398,7 +405,7 @@ class MultibodyTreeTopology {
   /// Returns `true` if there is _any_ mobilizer in the multibody tree
   /// connecting the frames with indexes `frame` and `frame2`.
   bool IsThereAMobilizerBetweenFrames(FrameIndex frame1, FrameIndex frame2) {
-    for (const auto& mobilizer_topology : mobilizers) {
+    for (const auto& mobilizer_topology : mobilizers_) {
       if (mobilizer_topology.connects_frames(frame1, frame2)) return true;
     }
     return false;
@@ -407,7 +414,7 @@ class MultibodyTreeTopology {
   /// Returns `true` if there is _any_ mobilizer in the multibody tree
   /// connecting the bodies with indexes `body2` and `body2`.
   bool IsThereAMobilizerBetweenBodies(BodyIndex body1, BodyIndex body2) {
-    for (const auto& mobilizer_topology : mobilizers) {
+    for (const auto& mobilizer_topology : mobilizers_) {
       if (mobilizer_topology.connects_bodies(body1, body2)) return true;
     }
     return false;
@@ -461,7 +468,7 @@ class MultibodyTreeTopology {
       if (current != 0) {  // Not the world body.
         level = bodies_[parent].level + 1;
         const MobilizerIndex mobilizer = bodies_[current].inboard_mobilizer;
-        mobilizers[mobilizer].body_node = node;
+        mobilizers_[mobilizer].body_node = node;
       }
       // Updates body levels.
       bodies_[current].level = level;
@@ -526,7 +533,6 @@ class MultibodyTreeTopology {
   bool is_valid() const { return is_valid_; }
 
   std::vector<FrameTopology> frames;
-  std::vector<MobilizerTopology> mobilizers;
 
  private:
   // is_valid is set to `true` after a successful Finalize().
@@ -536,6 +542,7 @@ class MultibodyTreeTopology {
   int num_levels_{-1};
 
   std::vector<BodyTopology> bodies_;
+  std::vector<MobilizerTopology> mobilizers_;
   std::vector<BodyNodeTopology> body_nodes_;
 };
 

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -330,7 +330,7 @@ struct MultibodyTreeTopology {
     }
 
     // The checks above guarantee that it is the first time we add an inboard
-    // mobilizer to `outboard_body`. The DRAKE_DEMAND's below double check our
+    // mobilizer to `outboard_body`. The DRAKE_DEMANDs below double check our
     // implementation.
     // BodyTopology::inboard_mobilizer and BodyTopology::parent_body are both
     // set within this method right after these checks.
@@ -431,6 +431,9 @@ struct MultibodyTreeTopology {
     // Checks that all bodies were reached. We could have this situation if a
     // user adds a body but forgets to add a mobilizer to it.
     // Bodies that were not reached were not assigned a valid level.
+    // TODO(amcastro-tri): this will stop at the first body that is not
+    // connected to the tree. Add logic to emit a message with ALL bodies that
+    // are not properly connected to the tree.
     for (BodyIndex body(0); body < get_num_bodies(); ++body) {
       if (bodies[body].level < 0) {
         throw std::runtime_error("Body with index " + std::to_string(body) +

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -324,7 +324,7 @@ class MultibodyTreeTopology {
   FrameIndex add_frame(BodyIndex body_index) {
     if (is_valid()) {
       throw std::logic_error("This MultibodyTreeTopology is finalized already. "
-                             "Therefore adding more bodies is not allowed. "
+                             "Therefore adding more frames is not allowed. "
                              "See documentation for Finalize() for details.");
     }
     FrameIndex frame_index(get_num_frames());
@@ -350,7 +350,7 @@ class MultibodyTreeTopology {
       FrameIndex in_frame, FrameIndex out_frame) {
     if (is_valid()) {
       throw std::logic_error("This MultibodyTreeTopology is finalized already. "
-                             "Therefore adding more bodies is not allowed. "
+                             "Therefore adding more mobilizers is not allowed. "
                              "See documentation for Finalize() for details.");
     }
     // Note: MultibodyTree double checks the mobilizer's frames belong to that

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -407,24 +407,6 @@ class MultibodyTreeTopology {
     return mobilizer_index;
   }
 
-  /// Returns `true` if there is _any_ mobilizer in the multibody tree
-  /// connecting the frames with indexes `frame` and `frame2`.
-  bool IsThereAMobilizerBetweenFrames(FrameIndex frame1, FrameIndex frame2) {
-    for (const auto& mobilizer_topology : mobilizers_) {
-      if (mobilizer_topology.connects_frames(frame1, frame2)) return true;
-    }
-    return false;
-  }
-
-  /// Returns `true` if there is _any_ mobilizer in the multibody tree
-  /// connecting the bodies with indexes `body2` and `body2`.
-  bool IsThereAMobilizerBetweenBodies(BodyIndex body1, BodyIndex body2) {
-    for (const auto& mobilizer_topology : mobilizers_) {
-      if (mobilizer_topology.connects_bodies(body1, body2)) return true;
-    }
-    return false;
-  }
-
   /// This method must be called by MultibodyTree::Finalize() after all
   /// topological elements in the tree (corresponding to joints, bodies, force
   /// elements, constraints) were added and before any computations are
@@ -536,6 +518,26 @@ class MultibodyTreeTopology {
   bool is_valid() const { return is_valid_; }
 
  private:
+  // Returns `true` if there is _any_ mobilizer in the multibody tree
+  // connecting the frames with indexes `frame` and `frame2`.
+  bool IsThereAMobilizerBetweenFrames(
+      FrameIndex frame1, FrameIndex frame2) const {
+    for (const auto& mobilizer_topology : mobilizers_) {
+      if (mobilizer_topology.connects_frames(frame1, frame2)) return true;
+    }
+    return false;
+  }
+
+  // Returns `true` if there is _any_ mobilizer in the multibody tree
+  // connecting the bodies with indexes `body2` and `body2`.
+  bool IsThereAMobilizerBetweenBodies(
+      BodyIndex body1, BodyIndex body2) const {
+    for (const auto& mobilizer_topology : mobilizers_) {
+      if (mobilizer_topology.connects_bodies(body1, body2)) return true;
+    }
+    return false;
+  }
+
   // is_valid is set to `true` after a successful Finalize().
   bool is_valid_{false};
   // Number of levels (or generations) in the tree topology. After Finalize()

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -168,6 +168,13 @@ struct MobilizerTopology {
   int velocities_start{0};
 };
 
+/// Data structure to store the topological information associated with a tree
+/// node. A tree node essentially consists of a body and its inboard mobilizer.
+/// A body node is in charge of the computations associated to that body and
+/// mobilizer, especially when within a base-to-tip or tip-to-base recursion.
+/// As the topological entity associated with a tree node (and specifically a
+/// MultibodyTree node), this struct contains information regarding parent and
+/// child nodes, parent and child bodies, etc.
 struct BodyNodeTopology {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(BodyNodeTopology);
 

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -257,7 +257,7 @@ class MultibodyTreeTopology {
 
   /// Returns the number of tree nodes. This must equal the number of bodies.
   int get_num_body_nodes() const {
-    return static_cast<int>(body_nodes.size());
+    return static_cast<int>(body_nodes_.size());
   }
 
   /// Returns a constant reference to the corresponding FrameTopology given the
@@ -278,7 +278,7 @@ class MultibodyTreeTopology {
   /// a BodyNodeIndex.
   const BodyNodeTopology& get_body_node(BodyNodeIndex index) const {
     DRAKE_ASSERT(index < get_num_body_nodes());
-    return body_nodes[index];
+    return body_nodes_[index];
   }
 
   /// Creates and adds a new BodyTopology to this MultibodyTreeTopology.
@@ -448,7 +448,7 @@ class MultibodyTreeTopology {
     num_levels_ = 1;  // At least one level with the world body at the root.
     // While at it, create body nodes and index them in this BFT order for
     // fast tree traversals of MultibodyTree recursive algorithms.
-    body_nodes.reserve(get_num_bodies());
+    body_nodes_.reserve(get_num_bodies());
     while (!queue.empty()) {
       const BodyNodeIndex node(get_num_body_nodes());
       const BodyIndex current = queue.front();
@@ -473,11 +473,11 @@ class MultibodyTreeTopology {
       BodyNodeIndex parent_node;
       if (node != 0) {  // If we are not at the root:
         parent_node = bodies_[parent].body_node;
-        body_nodes[parent_node].child_nodes.push_back(node);
+        body_nodes_[parent_node].child_nodes.push_back(node);
       }
 
       // Creates BodyNodeTopology.
-      body_nodes.emplace_back(
+      body_nodes_.emplace_back(
           node, level /* node index and level */,
           parent_node /* This node's parent */,
           current     /* This node's body */,
@@ -527,7 +527,6 @@ class MultibodyTreeTopology {
 
   std::vector<FrameTopology> frames;
   std::vector<MobilizerTopology> mobilizers;
-  std::vector<BodyNodeTopology> body_nodes;
 
  private:
   // is_valid is set to `true` after a successful Finalize().
@@ -537,6 +536,7 @@ class MultibodyTreeTopology {
   int num_levels_{-1};
 
   std::vector<BodyTopology> bodies_;
+  std::vector<BodyNodeTopology> body_nodes_;
 };
 
 }  // namespace multibody

--- a/drake/multibody/multibody_tree/multibody_tree_topology.h
+++ b/drake/multibody/multibody_tree/multibody_tree_topology.h
@@ -260,6 +260,11 @@ class MultibodyTreeTopology {
     return static_cast<int>(body_nodes_.size());
   }
 
+  /// Returns the number of tree levels in the topology.
+  int get_num_levels() const {
+    return num_levels_;
+  }
+
   /// Returns a constant reference to the corresponding FrameTopology given the
   /// FrameIndex.
   const FrameTopology& get_frame(FrameIndex index) const {
@@ -274,18 +279,18 @@ class MultibodyTreeTopology {
     return bodies_[index];
   }
 
-  /// Returns a constant reference to the corresponding BodyNodeTopology given
-  /// a BodyNodeIndex.
-  const BodyNodeTopology& get_body_node(BodyNodeIndex index) const {
-    DRAKE_ASSERT(index < get_num_body_nodes());
-    return body_nodes_[index];
-  }
-
   /// Returns a constant reference to the corresponding BodyTopology given a
   /// BodyIndex.
   const MobilizerTopology& get_mobilizer(MobilizerIndex index) const {
     DRAKE_ASSERT(index < get_num_mobilizers());
     return mobilizers_[index];
+  }
+
+  /// Returns a constant reference to the corresponding BodyNodeTopology given
+  /// a BodyNodeIndex.
+  const BodyNodeTopology& get_body_node(BodyNodeIndex index) const {
+    DRAKE_ASSERT(index < get_num_body_nodes());
+    return body_nodes_[index];
   }
 
   /// Creates and adds a new BodyTopology to this MultibodyTreeTopology.
@@ -439,6 +444,7 @@ class MultibodyTreeTopology {
   ///
   /// @throws std::logic_error If users attempt to call this method on an
   ///         already finalized topology.
+  /// @see is_valid()
   void Finalize() {
     // If the topology is valid it means that it was already finalized.
     // Re-compilation is not allowed.
@@ -525,11 +531,8 @@ class MultibodyTreeTopology {
     is_valid_ = true;
   }
 
-  /// Returns the number of tree levels in the topology.
-  int get_num_levels() const {
-    return num_levels_;
-  }
-
+  /// Returns `true` if Finalize() was already called on `this` topology.
+  /// @see Finalize()
   bool is_valid() const { return is_valid_; }
 
  private:

--- a/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
@@ -18,58 +18,13 @@ using Eigen::Vector3d;
 using std::make_unique;
 using std::unique_ptr;
 
-// Test the basic MultibodyTree API to create and add bodies.
-GTEST_TEST(MultibodyTree, AddBodies) {
-  auto owned_model = std::make_unique<MultibodyTree<double>>();
-  MultibodyTree<double>* model = owned_model.get();
-
-  // Initially there is only one body, the world.
-  EXPECT_EQ(model->get_num_bodies(), 1);
-
-  // Retrieves the world body.
-  const Body<double>& world_body = model->get_world_body();
-
-  // Creates a NaN SpatialInertia to instantiate the RigidBody links of the
-  // pendulum. Using a NaN spatial inertia is ok so far since we are still
-  // not performing any numerical computations. This is only to test API.
-  // M_Bo_B is the spatial inertia about the body frame's origin Bo and
-  // expressed in the body frame B.
-  SpatialInertia<double> M_Bo_B;
-
-  // Adds a new body to the world.
-  const RigidBody<double>& pendulum = model->AddBody<RigidBody>(M_Bo_B);
-
-  // Topology is invalid before MultibodyTree::Finalize().
-  EXPECT_FALSE(model->topology_is_valid());
-  // Verifies that the topology of this model gets validated at finalize stage.
-  model->Finalize();
-  EXPECT_TRUE(model->topology_is_valid());
-
-  // Body identifiers are unique and are assigned by MultibodyTree in increasing
-  // order starting with index = 0 (world_index()) for the "world" body.
-  EXPECT_EQ(world_body.get_index(), world_index());
-  EXPECT_EQ(pendulum.get_index(), BodyIndex(1));
-
-  // Tests API to access bodies.
-  EXPECT_EQ(model->get_body(BodyIndex(1)).get_index(), pendulum.get_index());
-  EXPECT_EQ(model->get_body(BodyIndex(1)).get_index(), pendulum.get_index());
-
-  // Rigid bodies have no generalized coordinates.
-  EXPECT_EQ(pendulum.get_num_flexible_positions(), 0);
-  EXPECT_EQ(pendulum.get_num_flexible_velocities(), 0);
-
-  // Verifies that an exception is throw if a call to Finalize() is attempted to
-  // an already finalized MultibodyTree.
-  EXPECT_THROW(model->Finalize(), std::logic_error);
-
-  // Verifies that after compilation no more bodies can be added.
-  EXPECT_THROW(model->AddBody<RigidBody>(M_Bo_B), std::logic_error);
-}
-
-// Tests the basic MultibodyTree API to create and add bodies.
+// Tests the basic MultibodyTree API to add bodies and mobilizers.
 // Tests we cannot create graph loops.
 GTEST_TEST(MultibodyTree, AddMobilizers) {
   auto model = std::make_unique<MultibodyTree<double>>();
+
+  // Initially there is only one body, the world.
+  EXPECT_EQ(model->get_num_bodies(), 1);
 
   // Retrieves the world body.
   const Body<double>& world_body = model->get_world_body();
@@ -121,6 +76,33 @@ GTEST_TEST(MultibodyTree, AddMobilizers) {
   // (failed) call.
   EXPECT_EQ(model->get_num_bodies(), 3);
   EXPECT_EQ(model->get_num_mobilizers(), 2);
+
+  // Topology is invalid before MultibodyTree::Finalize().
+  EXPECT_FALSE(model->topology_is_valid());
+  // Verifies that the topology of this model gets validated at finalize stage.
+  EXPECT_NO_THROW(model->Finalize());
+  EXPECT_TRUE(model->topology_is_valid());
+
+  // Body identifiers are unique and are assigned by MultibodyTree in increasing
+  // order starting with index = 0 (world_index()) for the "world" body.
+  EXPECT_EQ(world_body.get_index(), world_index());
+  EXPECT_EQ(pendulum.get_index(), BodyIndex(1));
+  EXPECT_EQ(pendulum2.get_index(), BodyIndex(2));
+
+  // Tests API to access bodies.
+  EXPECT_EQ(model->get_body(BodyIndex(1)).get_index(), pendulum.get_index());
+  EXPECT_EQ(model->get_body(BodyIndex(2)).get_index(), pendulum2.get_index());
+
+  // Rigid bodies have no generalized coordinates.
+  EXPECT_EQ(pendulum.get_num_flexible_positions(), 0);
+  EXPECT_EQ(pendulum.get_num_flexible_velocities(), 0);
+
+  // Verifies that an exception is throw if a call to Finalize() is attempted to
+  // an already finalized MultibodyTree.
+  EXPECT_THROW(model->Finalize(), std::logic_error);
+
+  // Verifies that after compilation no more bodies can be added.
+  EXPECT_THROW(model->AddBody<RigidBody>(M_Bo_B), std::logic_error);
 }
 
 // Tests the correctness of MultibodyTreeElement checks to verify one or more
@@ -153,8 +135,19 @@ GTEST_TEST(MultibodyTree, MultibodyTreeElementChecks) {
       body2.get_body_frame() /*body2 belongs to model2, not model1!!!*/,
       Vector3d::UnitZ() /*axis of rotation*/)), std::logic_error);
 
-  model1->Finalize();
-  model2->Finalize();
+  // model1 is complete. Expect no-throw.
+  EXPECT_NO_THROW(model1->Finalize());
+
+  // model2->Finalize() is expected to throw an exception since there is no
+  // mobilizer for body2.
+  try {
+    model2->Finalize();
+    GTEST_FAIL();
+  } catch (std::runtime_error& e) {
+    std::string expected_msg =
+        "Body with index 1 was not assigned a mobilizer";
+    EXPECT_EQ(e.what(), expected_msg);
+  }
 
   // Tests that the created multibody elements indeed do have a parent
   // MultibodyTree.
@@ -172,6 +165,61 @@ GTEST_TEST(MultibodyTree, MultibodyTreeElementChecks) {
   EXPECT_NO_THROW(body2.HasThisParentTreeOrThrow(model2.get()));
 }
 
+#if 0
+class TreeTopologyTests : public ::testing::Test {
+ public:
+  // Creates an "empty" MultibodyTree that only contains the "world" body and
+  // world body frame.
+  void SetUp() override {
+    model_ = std::make_unique<MultibodyTree<double>>();
+
+    const int kNumBodies = 7;
+    bodies_.push_back(&model_->get_world_body());
+    for (int i =1; i < kNumBodies; ++i)
+      bodies_.push_back(AddTestBody());
+
+    // Adds mobilizers to connect bodies according to the following diagram:
+    mobilizers_.push_back(ConnectBodies(*bodies_[1], *bodies_[6]));  // mob. 0
+    mobilizers_.push_back(ConnectBodies(*bodies_[4], *bodies_[2]));  // mob. 1
+    mobilizers_.push_back(ConnectBodies(*bodies_[0], *bodies_[7]));  // mob. 2
+    mobilizers_.push_back(ConnectBodies(*bodies_[5], *bodies_[3]));  // mob. 3
+    mobilizers_.push_back(ConnectBodies(*bodies_[0], *bodies_[5]));  // mob. 4
+    mobilizers_.push_back(ConnectBodies(*bodies_[4], *bodies_[1]));  // mob. 5
+    mobilizers_.push_back(ConnectBodies(*bodies_[0], *bodies_[4]));  // mob. 6
+  }
+
+  const RigidBody<double>* AddTestBody() {
+    // NaN SpatialInertia to instantiate the RigidBody objects.
+    // It is safe here since this tests only focus on topological information.
+    const SpatialInertia<double> M_Bo_B;
+    return &model_->AddBody<RigidBody>(M_Bo_B);
+  }
+
+  const Mobilizer<double>* ConnectBodies(
+      const Body<double>& inboard, const Body<double>& outboard) {
+    return &model_->AddMobilizer<RevoluteMobilizer>(
+        inboard.get_body_frame(), outboard.get_body_frame(),
+        Vector3d::UnitZ());
+  }
+
+ protected:
+  std::unique_ptr<MultibodyTree<double>> model_;
+  // Bodies:
+  std::vector<const Body<double>*> bodies_;
+  // Mobilizers:
+  std::vector<const Mobilizer<double>*> mobilizers_;
+};
+
+TEST_F(TreeTopologyTests, Finalize) {
+  EXPECT_EQ(model_->get_num_bodies(), 8);
+  EXPECT_EQ(model_->get_num_mobilizers(), 7);
+}
+#endif
 }  // namespace
 }  // namespace multibody
 }  // namespace drake
+
+//int main() {
+//  drake::multibody::DoMain();
+//  return 0;
+//}

--- a/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
@@ -278,7 +278,7 @@ class TreeTopologyTests : public ::testing::Test {
       EXPECT_EQ(mobilizer, get_body_topology(body).inboard_mobilizer);
 
       // Verifies the mobilizer makes reference to the appropriate node.
-      EXPECT_EQ(topology.mobilizers[mobilizer].body_node, node);
+      EXPECT_EQ(topology.get_mobilizer(mobilizer).body_node, node);
 
       // Helper lambda to check if this "node" effectively is a child of
       // "parent_node".

--- a/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
@@ -263,7 +263,7 @@ class TreeTopologyTests : public ::testing::Test {
     // Either (and thus the exclusive or):
     // 1. `body` is the world, and thus `parent_node` is invalid, XOR
     // 2. `body` is not the world, and thus we have a valid `parent_node`.
-    EXPECT_TRUE(parent_node.is_valid() ^ body == world_index());
+    EXPECT_TRUE(parent_node.is_valid() ^ (body == world_index()));
 
     if (body != world_index()) {
       // Verifies BodyNode has the parent node to the correct body.

--- a/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
@@ -167,6 +167,43 @@ GTEST_TEST(MultibodyTree, MultibodyTreeElementChecks) {
   EXPECT_NO_THROW(body2.HasThisParentTreeOrThrow(model2.get()));
 }
 
+// This unit test builds a MultibodyTree as shown in the schematic below, where
+// the number inside the boxes corresponds to each of the bodies' indexes (
+// assigned by MultibodyTree in the order bodies are created) and "m?" next to
+// each connection denotes a mobilizer with the number corresponding to the
+// mobilizer index (assigned by MultibodyTree in the order mobilizers are
+// created).
+// At Finalize(), a body node is created per (body, inboard_mobilizer) pair.
+// Body node indexes are assigned according to a BFT order.
+// Tests below make references to the indexes in this schematic. The following
+// points are important:
+// - Body nodes are ordered by a BFT sort however,
+// - There is no guarantee on which body node is assigned to which body.
+// - Body nodes at a particular level are not guaranteed to be in any particular
+//   order, only that they belong to the right level is important.
+//
+//                        +---+
+//                        | 0 |                        Level 0 (root, world)
+//            +-----------+-+-+-----------+
+//            |             |             |
+//            | m6          | m2          | m4
+//            |             |             |
+//          +-v-+         +-v-+         +-v-+
+//          | 4 |         | 7 |         | 5 |          Level 1
+//       +--+---+--+      +---+         +-+-+
+//       |         |                      |
+//       | m1      | m5                   | m3
+//       |         |                      |
+//     +-v-+     +-v-+                  +-v-+
+//     | 2 |     | 1 |                  | 3 |          Level 2
+//     +---+     +-+-+                  +---+
+//                 |
+//                 | m0
+//                 |
+//               +-v-+
+//               | 6 |                                 Level 3
+//               +---+
+//
 class TreeTopologyTests : public ::testing::Test {
  public:
   // Creates an "empty" MultibodyTree that only contains the "world" body and
@@ -256,6 +293,7 @@ class TreeTopologyTests : public ::testing::Test {
   std::vector<const Mobilizer<double>*> mobilizers_;
 };
 
+// This unit tests verifies that the multibody topology is properly compiled.
 TEST_F(TreeTopologyTests, Finalize) {
   model_->Finalize();
   EXPECT_EQ(model_->get_num_bodies(), 8);

--- a/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
@@ -175,10 +175,10 @@ GTEST_TEST(MultibodyTree, MultibodyTreeElementChecks) {
 // created).
 // At Finalize(), a body node is created per (body, inboard_mobilizer) pair.
 // Body node indexes are assigned according to a BFT order.
-// Tests below make references to the indexes in this schematic. The following
+// Tests below make reference to the indexes in this schematic. The following
 // points are important:
 // - Body nodes are ordered by a BFT sort however,
-// - There is no guarantee on which body node is assigned to which body.
+// - There is no guarantee on which body node is assigned to which body,
 // - Body nodes at a particular level are not guaranteed to be in any particular
 //   order, only that they belong to the right level is important.
 //

--- a/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
@@ -248,12 +248,12 @@ class TreeTopologyTests : public ::testing::Test {
   // body indexed by `body`.
   void TestBodyNode(BodyIndex body) const {
     const MultibodyTreeTopology& topology = model_->get_topology();
-    const BodyNodeIndex node = topology.bodies[body].body_node;
+    const BodyNodeIndex node = get_body_topology(body).body_node;
 
     // Verify that the corresponding Body and BodyNode reference each other
     // correctly.
-    EXPECT_EQ(topology.bodies[body].body_node, topology.body_nodes[node].index);
-    EXPECT_EQ(topology.body_nodes[node].body, topology.bodies[body].index);
+    EXPECT_EQ(get_body_topology(body).body_node, topology.body_nodes[node].index);
+    EXPECT_EQ(topology.body_nodes[node].body, get_body_topology(body).index);
 
     // They should belong to the same level.
     EXPECT_EQ(topology.bodies[body].level, topology.body_nodes[node].level);
@@ -269,13 +269,13 @@ class TreeTopologyTests : public ::testing::Test {
       // Verifies BodyNode has the parent node to the correct body.
       const BodyIndex parent_body = topology.body_nodes[parent_node].body;
       EXPECT_TRUE(parent_body.is_valid());
-      EXPECT_EQ(parent_body, topology.bodies[body].parent_body);
+      EXPECT_EQ(parent_body, get_body_topology(body).parent_body);
       EXPECT_EQ(topology.body_nodes[parent_node].index,
-                topology.bodies[parent_body].body_node);
+                get_body_topology(parent_body).body_node);
 
       // Verifies that BodyNode makes reference to the proper mobilizer index.
       const MobilizerIndex mobilizer = topology.body_nodes[node].mobilizer;
-      EXPECT_EQ(mobilizer, topology.bodies[body].inboard_mobilizer);
+      EXPECT_EQ(mobilizer, get_body_topology(body).inboard_mobilizer);
 
       // Verifies the mobilizer makes reference to the appropriate node.
       EXPECT_EQ(topology.mobilizers[mobilizer].body_node, node);
@@ -289,6 +289,11 @@ class TreeTopologyTests : public ::testing::Test {
       };
       EXPECT_TRUE(is_child_of_parent());
     }
+  }
+
+  const BodyTopology& get_body_topology(int body_index) const {
+    const MultibodyTreeTopology& topology = model_->get_topology();
+    return topology.bodies[body_index];
   }
 
  protected:
@@ -307,6 +312,7 @@ TEST_F(TreeTopologyTests, Finalize) {
 
   const MultibodyTreeTopology& topology = model_->get_topology();
   EXPECT_EQ(topology.get_num_body_nodes(), model_->get_num_bodies());
+  EXPECT_EQ(topology.get_num_levels(), 4);
 
   // These sets contain the indexes of the bodies in each tree level.
   // The order of these indexes in each set is not important, but only the fact
@@ -334,19 +340,19 @@ TEST_F(TreeTopologyTests, Finalize) {
   // Verifies the expected number of child nodes.
   EXPECT_EQ(topology.body_nodes[0].get_num_children(), 3);
   EXPECT_EQ(
-      topology.body_nodes[topology.bodies[4].body_node].get_num_children(), 2);
+      topology.body_nodes[get_body_topology(4).body_node].get_num_children(), 2);
   EXPECT_EQ(
-      topology.body_nodes[topology.bodies[7].body_node].get_num_children(), 0);
+      topology.body_nodes[get_body_topology(7).body_node].get_num_children(), 0);
   EXPECT_EQ(
-      topology.body_nodes[topology.bodies[5].body_node].get_num_children(), 1);
+      topology.body_nodes[get_body_topology(5).body_node].get_num_children(), 1);
   EXPECT_EQ(
-      topology.body_nodes[topology.bodies[2].body_node].get_num_children(), 0);
+      topology.body_nodes[get_body_topology(2).body_node].get_num_children(), 0);
   EXPECT_EQ(
-      topology.body_nodes[topology.bodies[1].body_node].get_num_children(), 1);
+      topology.body_nodes[get_body_topology(1).body_node].get_num_children(), 1);
   EXPECT_EQ(
-      topology.body_nodes[topology.bodies[3].body_node].get_num_children(), 0);
+      topology.body_nodes[get_body_topology(3).body_node].get_num_children(), 0);
   EXPECT_EQ(
-      topology.body_nodes[topology.bodies[6].body_node].get_num_children(), 0);
+      topology.body_nodes[get_body_topology(6).body_node].get_num_children(), 0);
 
   // Checks the correctness of each BodyNode associated with a body.
   for (BodyIndex body(0); body < model_->get_num_bodies(); ++body) {

--- a/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_creation_tests.cc
@@ -252,11 +252,13 @@ class TreeTopologyTests : public ::testing::Test {
 
     // Verify that the corresponding Body and BodyNode reference each other
     // correctly.
-    EXPECT_EQ(get_body_topology(body).body_node, get_body_node_topology(node).index);
+    EXPECT_EQ(get_body_topology(body).body_node,
+              get_body_node_topology(node).index);
     EXPECT_EQ(get_body_node_topology(node).body, get_body_topology(body).index);
 
     // They should belong to the same level.
-    EXPECT_EQ(get_body_topology(body).level, get_body_node_topology(node).level);
+    EXPECT_EQ(get_body_topology(body).level,
+              get_body_node_topology(node).level);
 
     const BodyNodeIndex parent_node =
         get_body_node_topology(node).parent_body_node;
@@ -344,20 +346,20 @@ TEST_F(TreeTopologyTests, Finalize) {
 
   // Verifies the expected number of child nodes.
   EXPECT_EQ(get_body_node_topology(0).get_num_children(), 3);
-  EXPECT_EQ(
-      get_body_node_topology(get_body_topology(4).body_node).get_num_children(), 2);
-  EXPECT_EQ(
-      get_body_node_topology(get_body_topology(7).body_node).get_num_children(), 0);
-  EXPECT_EQ(
-      get_body_node_topology(get_body_topology(5).body_node).get_num_children(), 1);
-  EXPECT_EQ(
-      get_body_node_topology(get_body_topology(2).body_node).get_num_children(), 0);
-  EXPECT_EQ(
-      get_body_node_topology(get_body_topology(1).body_node).get_num_children(), 1);
-  EXPECT_EQ(
-      get_body_node_topology(get_body_topology(3).body_node).get_num_children(), 0);
-  EXPECT_EQ(
-      get_body_node_topology(get_body_topology(6).body_node).get_num_children(), 0);
+  EXPECT_EQ(get_body_node_topology(
+      get_body_topology(4).body_node).get_num_children(), 2);
+  EXPECT_EQ(get_body_node_topology(
+      get_body_topology(7).body_node).get_num_children(), 0);
+  EXPECT_EQ(get_body_node_topology(
+      get_body_topology(5).body_node).get_num_children(), 1);
+  EXPECT_EQ(get_body_node_topology(
+      get_body_topology(2).body_node).get_num_children(), 0);
+  EXPECT_EQ(get_body_node_topology(
+      get_body_topology(1).body_node).get_num_children(), 1);
+  EXPECT_EQ(get_body_node_topology(
+      get_body_topology(3).body_node).get_num_children(), 0);
+  EXPECT_EQ(get_body_node_topology(
+      get_body_topology(6).body_node).get_num_children(), 0);
 
   // Checks the correctness of each BodyNode associated with a body.
   for (BodyIndex body(0); body < model_->get_num_bodies(); ++body) {


### PR DESCRIPTION
Implements `MultibodyTreeTopology::Finalize()` which essentially sorts multibody nodes in BFT  order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6120)
<!-- Reviewable:end -->
