### PR TITLE
Allow customizing more install destinations

### DIFF
--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -207,8 +207,11 @@ def _install_actions(ctx, file_labels, dests, strip_prefix = []):
 # Compute install actions for a cc_library or cc_binary.
 def _install_cc_actions(ctx, target):
     # Compute actions for target artifacts.
-    # TODO(mwoehlke-kitware): make these parameters.
-    dests = {"a": "lib", "so": "lib", None: "bin"}
+    dests = {
+        "a": ctx.attr.archive_dest,
+        "so": ctx.attr.library_dest,
+        None: ctx.attr.runtime_dest,
+    }
     actions = _install_actions(ctx, [target], dests)
 
     # Compute actions for guessed headers.
@@ -301,6 +304,9 @@ install = rule(
         "hdr_strip_prefix": attr.string_list(),
         "guess_hdrs": attr.string(default = "NONE"),
         "targets": attr.label_list(),
+        "archive_dest": attr.string(default = "lib"),
+        "library_dest": attr.string(default = "lib"),
+        "runtime_dest": attr.string(default = "bin"),
         "install_script_template": attr.label(
             allow_files = True,
             executable = True,
@@ -345,6 +351,9 @@ Args:
     hdr_dest: Destination for header files (default = "include").
     hdr_strip_prefix: List of prefixes to remove from header paths.
     targets: List of targets to install.
+    archive_dest: Destination for static library targets (default = "lib").
+    library_dest: Destination for shared library targets (default = "lib").
+    runtime_dest: Destination for executable targets (default = "bin").
 """
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Add ability to override the default install destinations for archive, library and runtime artifacts. This is needed for proper installation of compiled Python modules. (The only apparent way to install these to the correct location is for the user to override these destinations, as there is no obvious way to differentiate between a Python module and any other compiled library.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6125)
<!-- Reviewable:end -->
