### PR TITLE
Carve out :vector_value separately from :value

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -26,6 +26,7 @@ drake_cc_library(
         ":system",
         ":value",
         ":vector",
+        ":vector_value",
     ],
 )
 
@@ -62,12 +63,23 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "vector_value",
+    hdrs = ["vector_value.h"],
+    deps = [
+        ":value",
+        ":vector",
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
     name = "value_checker",
     srcs = [],
     hdrs = ["value_checker.h"],
     visibility = [":__subpackages__"],
     deps = [
         ":value",
+        ":vector_value",
         "//drake/common",
         "//drake/common:nice_type_name",
     ],
@@ -170,6 +182,7 @@ drake_cc_library(
         ":value",
         ":value_checker",
         ":vector",
+        ":vector_value",
         "//drake/common",
     ],
 )
@@ -243,6 +256,7 @@ drake_cc_library(
     visibility = [":__subpackages__"],
     deps = [
         ":value",
+        ":vector_value",
         ":vector",
         "//drake/common",
     ],
@@ -514,6 +528,13 @@ drake_cc_googletest(
     deps = [
         ":value",
         "//drake/common",
+    ],
+)
+
+drake_cc_googletest(
+    name = "vector_value_test",
+    deps = [
+        ":vector_value",
         "//drake/systems/framework/test_utilities",
     ],
 )

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -70,6 +70,7 @@ set(installed_headers
   value.h
   value_checker.h
   vector_base.h
+  vector_value.h
   )
 
 # Headers that are needed by code here but should not

--- a/drake/systems/framework/model_values.h
+++ b/drake/systems/framework/model_values.h
@@ -8,6 +8,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/value.h"
+#include "drake/systems/framework/vector_value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/output_port_value.h
+++ b/drake/systems/framework/output_port_value.h
@@ -12,6 +12,7 @@
 #include "drake/systems/framework/output_port_listener_interface.h"
 #include "drake/systems/framework/value.h"
 #include "drake/systems/framework/value_checker.h"
+#include "drake/systems/framework/vector_value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/test/value_test.cc
+++ b/drake/systems/framework/test/value_test.cc
@@ -9,14 +9,10 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/test_utilities/my_vector.h"
 
 namespace drake {
 namespace systems {
 namespace {
-
-using MyVector2d = MyVector<2, double>;
 
 // A type with no constructors.
 struct BareStruct {
@@ -227,84 +223,6 @@ GTEST_TEST(ValueTest, SubclassOfValueSurvivesClone) {
       dynamic_cast<PrintInterface*>(cloned.get());
   ASSERT_NE(nullptr, printable_erased);
   EXPECT_EQ("5,6", printable_erased->print());
-}
-
-GTEST_TEST(VectorValueTest, Access) {
-  VectorValue<double> value(BasicVector<double>::Make({1, 2, 3}));
-  EXPECT_EQ(1, value.get_value()->get_value().x());
-  EXPECT_EQ(2, value.get_value()->get_value().y());
-  EXPECT_EQ(3, value.get_value()->get_value().z());
-}
-
-GTEST_TEST(VectorValueTest, CopyConstructor) {
-  VectorValue<double> value(BasicVector<double>::Make({1, 2, 3}));
-
-  VectorValue<double> other_value(value);
-  EXPECT_EQ(1, other_value.get_value()->get_value().x());
-  EXPECT_EQ(2, other_value.get_value()->get_value().y());
-  EXPECT_EQ(3, other_value.get_value()->get_value().z());
-}
-
-GTEST_TEST(VectorValueTest, CopyConstructorSubclass) {
-  VectorValue<double> value(MyVector2d::Make(1, 2));
-  VectorValue<double> other_value(value);
-  value.get_value()->set_value(Eigen::Vector2d(3, 4));
-
-  const MyVector2d* const vector =
-      dynamic_cast<const MyVector2d*>(other_value.get_value());
-  ASSERT_NE(vector, nullptr);
-  EXPECT_EQ(vector->get_value()(0), 1);
-  EXPECT_EQ(vector->get_value()(1), 2);
-}
-
-GTEST_TEST(VectorValueTest, CopyConstructorNull) {
-  VectorValue<double> value{nullptr};
-
-  VectorValue<double> other_value(value);
-  EXPECT_EQ(other_value.get_value(), nullptr);
-}
-
-GTEST_TEST(VectorValueTest, AssignmentOperator) {
-  VectorValue<double> value(BasicVector<double>::Make({1, 2, 3}));
-  VectorValue<double> other_value(BasicVector<double>::Make({4, 5, 6}));
-
-  value = other_value;
-  EXPECT_EQ(4, value.get_value()->get_value().x());
-  EXPECT_EQ(5, value.get_value()->get_value().y());
-  EXPECT_EQ(6, value.get_value()->get_value().z());
-}
-
-GTEST_TEST(VectorValueTest, AssignmentOperatorSubclass) {
-  VectorValue<double> value(MyVector2d::Make(1, 2));
-  VectorValue<double> other_value(BasicVector<double>::Make({5, 6}));
-  other_value = value;
-  value.get_value()->set_value(Eigen::Vector2d(3, 4));
-
-  const MyVector2d* const vector =
-      dynamic_cast<const MyVector2d*>(other_value.get_value());
-  ASSERT_NE(vector, nullptr);
-  EXPECT_EQ(vector->get_value()(0), 1);
-  EXPECT_EQ(vector->get_value()(1), 2);
-}
-
-GTEST_TEST(VectorValueTest, AssignmentOperatorNull) {
-  VectorValue<double> value{nullptr};
-  VectorValue<double> other_value(BasicVector<double>::Make({4, 5, 6}));
-
-  value = other_value;
-  other_value = VectorValue<double>{nullptr};
-  EXPECT_EQ(4, value.get_value()->get_value().x());
-  EXPECT_EQ(5, value.get_value()->get_value().y());
-  EXPECT_EQ(6, value.get_value()->get_value().z());
-  EXPECT_EQ(other_value.get_value(), nullptr);
-}
-
-GTEST_TEST(VectorValueTest, AssignmentOperatorSelf) {
-  VectorValue<double> value(BasicVector<double>::Make({4, 5, 6}));
-  value = value;
-  EXPECT_EQ(4, value.get_value()->get_value().x());
-  EXPECT_EQ(5, value.get_value()->get_value().y());
-  EXPECT_EQ(6, value.get_value()->get_value().z());
 }
 
 }  // namespace

--- a/drake/systems/framework/test/vector_value_test.cc
+++ b/drake/systems/framework/test/vector_value_test.cc
@@ -1,0 +1,94 @@
+#include "drake/systems/framework/vector_value.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using MyVector2d = MyVector<2, double>;
+
+GTEST_TEST(VectorValueTest, Access) {
+  VectorValue<double> value(BasicVector<double>::Make({1, 2, 3}));
+  EXPECT_EQ(1, value.get_value()->get_value().x());
+  EXPECT_EQ(2, value.get_value()->get_value().y());
+  EXPECT_EQ(3, value.get_value()->get_value().z());
+}
+
+GTEST_TEST(VectorValueTest, CopyConstructor) {
+  VectorValue<double> value(BasicVector<double>::Make({1, 2, 3}));
+
+  VectorValue<double> other_value(value);
+  EXPECT_EQ(1, other_value.get_value()->get_value().x());
+  EXPECT_EQ(2, other_value.get_value()->get_value().y());
+  EXPECT_EQ(3, other_value.get_value()->get_value().z());
+}
+
+GTEST_TEST(VectorValueTest, CopyConstructorSubclass) {
+  VectorValue<double> value(MyVector2d::Make(1, 2));
+  VectorValue<double> other_value(value);
+  value.get_value()->set_value(Eigen::Vector2d(3, 4));
+
+  const MyVector2d* const vector =
+      dynamic_cast<const MyVector2d*>(other_value.get_value());
+  ASSERT_NE(vector, nullptr);
+  EXPECT_EQ(vector->get_value()(0), 1);
+  EXPECT_EQ(vector->get_value()(1), 2);
+}
+
+GTEST_TEST(VectorValueTest, CopyConstructorNull) {
+  VectorValue<double> value{nullptr};
+
+  VectorValue<double> other_value(value);
+  EXPECT_EQ(other_value.get_value(), nullptr);
+}
+
+GTEST_TEST(VectorValueTest, AssignmentOperator) {
+  VectorValue<double> value(BasicVector<double>::Make({1, 2, 3}));
+  VectorValue<double> other_value(BasicVector<double>::Make({4, 5, 6}));
+
+  value = other_value;
+  EXPECT_EQ(4, value.get_value()->get_value().x());
+  EXPECT_EQ(5, value.get_value()->get_value().y());
+  EXPECT_EQ(6, value.get_value()->get_value().z());
+}
+
+GTEST_TEST(VectorValueTest, AssignmentOperatorSubclass) {
+  VectorValue<double> value(MyVector2d::Make(1, 2));
+  VectorValue<double> other_value(BasicVector<double>::Make({5, 6}));
+  other_value = value;
+  value.get_value()->set_value(Eigen::Vector2d(3, 4));
+
+  const MyVector2d* const vector =
+      dynamic_cast<const MyVector2d*>(other_value.get_value());
+  ASSERT_NE(vector, nullptr);
+  EXPECT_EQ(vector->get_value()(0), 1);
+  EXPECT_EQ(vector->get_value()(1), 2);
+}
+
+GTEST_TEST(VectorValueTest, AssignmentOperatorNull) {
+  VectorValue<double> value{nullptr};
+  VectorValue<double> other_value(BasicVector<double>::Make({4, 5, 6}));
+
+  value = other_value;
+  other_value = VectorValue<double>{nullptr};
+  EXPECT_EQ(4, value.get_value()->get_value().x());
+  EXPECT_EQ(5, value.get_value()->get_value().y());
+  EXPECT_EQ(6, value.get_value()->get_value().z());
+  EXPECT_EQ(other_value.get_value(), nullptr);
+}
+
+GTEST_TEST(VectorValueTest, AssignmentOperatorSelf) {
+  VectorValue<double> value(BasicVector<double>::Make({4, 5, 6}));
+  value = value;
+  EXPECT_EQ(4, value.get_value()->get_value().x());
+  EXPECT_EQ(5, value.get_value()->get_value().y());
+  EXPECT_EQ(6, value.get_value()->get_value().z());
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -2,14 +2,12 @@
 
 #include <memory>
 #include <stdexcept>
-#include <string>
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
 namespace systems {
@@ -211,55 +209,6 @@ class Value : public AbstractValue {
 
  private:
   T value_;
-};
-
-/// A container class for BasicVector<T>.
-///
-/// @tparam T The type of the vector data. Must be a valid Eigen scalar.
-template <typename T>
-class VectorValue : public Value<BasicVector<T>*> {
- public:
-  explicit VectorValue(std::unique_ptr<BasicVector<T>> v)
-      : Value<BasicVector<T>*>(v.get()), owned_value_(std::move(v)) {
-    DRAKE_ASSERT_VOID(CheckInvariants());
-  }
-
-  ~VectorValue() override {}
-
-  // VectorValues are copyable but not moveable.
-  explicit VectorValue(const VectorValue& other)
-      : Value<BasicVector<T>*>(nullptr) {
-    if (other.get_value() != nullptr) {
-      owned_value_ = other.get_value()->Clone();
-      this->set_value(owned_value_.get());
-    }
-    DRAKE_ASSERT_VOID(CheckInvariants());
-  }
-
-  VectorValue& operator=(const VectorValue& other) {
-    if (this == &other) {
-      // Special case to do nothing, to avoid an unnecessary Clone.
-    } else if (other.get_value() == nullptr) {
-      owned_value_.reset();
-      this->set_value(owned_value_.get());
-    } else {
-      owned_value_ = other.get_value()->Clone();
-      this->set_value(owned_value_.get());
-    }
-    DRAKE_ASSERT_VOID(CheckInvariants());
-    return *this;
-  }
-
-  std::unique_ptr<AbstractValue> Clone() const override {
-    return std::make_unique<VectorValue>(*this);
-  }
-
- private:
-  void CheckInvariants() {
-    DRAKE_DEMAND(owned_value_.get() == this->get_value());
-  }
-
-  std::unique_ptr<BasicVector<T>> owned_value_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/value_checker.h
+++ b/drake/systems/framework/value_checker.h
@@ -8,6 +8,7 @@
 #include "drake/common/nice_type_name.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/value.h"
+#include "drake/systems/framework/vector_value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/vector_value.h
+++ b/drake/systems/framework/vector_value.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+
+/// A container class for BasicVector<T>.
+///
+/// @tparam T The type of the vector data. Must be a valid Eigen scalar.
+template <typename T>
+class VectorValue : public Value<BasicVector<T>*> {
+ public:
+  explicit VectorValue(std::unique_ptr<BasicVector<T>> v)
+      : Value<BasicVector<T>*>(v.get()), owned_value_(std::move(v)) {
+    DRAKE_ASSERT_VOID(CheckInvariants());
+  }
+
+  ~VectorValue() override {}
+
+  // VectorValues are copyable but not moveable.
+  explicit VectorValue(const VectorValue& other)
+      : Value<BasicVector<T>*>(nullptr) {
+    if (other.get_value() != nullptr) {
+      owned_value_ = other.get_value()->Clone();
+      this->set_value(owned_value_.get());
+    }
+    DRAKE_ASSERT_VOID(CheckInvariants());
+  }
+
+  VectorValue& operator=(const VectorValue& other) {
+    if (this == &other) {
+      // Special case to do nothing, to avoid an unnecessary Clone.
+    } else if (other.get_value() == nullptr) {
+      owned_value_.reset();
+      this->set_value(owned_value_.get());
+    } else {
+      owned_value_ = other.get_value()->Clone();
+      this->set_value(owned_value_.get());
+    }
+    DRAKE_ASSERT_VOID(CheckInvariants());
+    return *this;
+  }
+
+  std::unique_ptr<AbstractValue> Clone() const override {
+    return std::make_unique<VectorValue>(*this);
+  }
+
+ private:
+  void CheckInvariants() {
+    DRAKE_DEMAND(owned_value_.get() == this->get_value());
+  }
+
+  std::unique_ptr<BasicVector<T>> owned_value_;
+};
+
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This is just relocating some code; no functional changes.  The C++ code has been literally cut-n-paste with tweaked `#include`s; I have not change the meaningful content at all.

This is groundwork for #5469, which will make `value.h` and its test more complicated.

This is also helpful because `value.h` should be widely used and understood as a core part of the framework, but `vector_value.h` is an abomination that should be private to the framework (and will be rewritten soon enough).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6128)
<!-- Reviewable:end -->
