### PR TITLE
Initializing An Uninitialized Variable In create_cost.cc

### DIFF
--- a/drake/solvers/create_cost.cc
+++ b/drake/solvers/create_cost.cc
@@ -54,7 +54,7 @@ Binding<LinearCost> DoParseLinearCost(
     const VectorXDecisionVariable& vars_vec,
     const unordered_map<Variable::Id, int>& map_var_to_index) {
   Eigen::RowVectorXd c(vars_vec.size());
-  double constant_term;
+  double constant_term{};
   DecomposeLinearExpression(e, map_var_to_index, c, &constant_term);
   return CreateBinding(make_shared<LinearCost>(c.transpose(), constant_term),
                        vars_vec);


### PR DESCRIPTION
To reproduce:
`bazel test  --config=memcheck --verbose_failures //drake/solvers:ipopt_solver_test`

More: https://drake-cdash.csail.mit.edu/viewDynamicAnalysis.php?buildid=600767
Probably we meant to do it like here:
https://github.com/RobotLocomotion/drake/blob/master/drake/solvers/create_constraint.cc#L240

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6142)
<!-- Reviewable:end -->
