### PR TITLE
Add friendly debugging message for drake_optional_external.

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -467,6 +467,9 @@ function(drake_add_external PROJECT)
       # All supported externals are requested
     else()
       # Project is NOT enabled; skip it
+      message(STATUS
+        "Skipping ${PROJECT} - Please see drake_optional_external (cmake/options.cmake) for "
+        "how to enable it.")
       return()
     endif()
   else()


### PR DESCRIPTION
I needed to switch to CMake, as some of the dependencies I may need will not be available in Bazel for the short term (specifically, VTK - I saw Jeremy's prototype branch, and had made a quick draft of my own, but decided it would be quickest to use CMake).

As a newbie to Drake's CMake setup just trying to get things to an initial start, I was trying to add in dependencies, and did not realize that, in addition to `CMakeLists.txt`, I needed to add in a corresponding entry in `cmake/options.cmake`.

This just adds a friendly message stating why the module is disabled.

Diff for CMake output before and after, running `cmake .. -G Ninja`:
(NOTE: I had run these in succession, which may explain the different dependency sets, etc.)

```diff
diff --git a/a b/b
index 6e542ca..3789254 100644
--- a/a
+++ b/b
@@ -1,5 +1,10 @@
+-- Skipping avl - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
+-- Skipping meshconverters - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
+-- Preparing to build qt_property_browser
 -- Preparing to build sedumi
 -- Preparing to build spotless
+-- Skipping xfoil - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
+-- Skipping yalmip - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
 -- Preparing to build eigen
 -- Preparing to build spdlog
 -- Preparing to build bullet
@@ -8,21 +13,28 @@
 -- Preparing to build gflags
 -- Preparing to build googletest
 -- Preparing to build google_styleguide
+-- Skipping gurobi - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
 -- Preparing to build ipopt
+-- Skipping mosek - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
 -- Preparing to build nlopt
 -- Preparing to build protobuf
 -- Preparing to build pybind11
 -- Preparing to build pythonqt
+-- Skipping snopt - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
 -- Preparing to build octomap
+-- Skipping vtk - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
 -- Preparing to build fcl with dependencies ccd;eigen;octomap
+-- Skipping textbook - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
 -- Preparing to build tinyobjloader
 -- Preparing to build yaml_cpp
 -- Preparing to build ctk_python_console with dependencies pythonqt
+-- Skipping iris - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
 -- Preparing to build ignition_math
 -- Preparing to build ignition_rndf with dependencies ignition_math
 -- Preparing to build lcm
 -- Preparing to build libbot with dependencies lcm
 -- Preparing to build bot_core_lcmtypes with dependencies lcm;libbot
 -- Preparing to build robotlocomotion_lcmtypes with dependencies bot_core_lcmtypes;lcm
--- Preparing to build drake with dependencies bot_core_lcmtypes;bullet;ccd;eigen;fcl;fmt;gflags;google_styleguide;googletest;ipopt;lcm;libbot;nlopt;octomap;protobuf;pybind11;robotlocomotion_lcmtypes;sedumi;spdlog;
+-- Skipping signalscope - Please see drake_optional_external (cmake/options.cmake) for how to enable it.
+-- Preparing to build drake with dependencies bot_core_lcmtypes;bullet;ccd;eigen;fcl;fmt;gflags;google_styleguide;googletest;ipopt;lcm;libbot;nlopt;octomap;protobuf;pybind11;robotlocomotion_lcmtypes;sedumi;spdlog;spotless;tinyobjloader;yaml_cpp
 -- Preparing to build director with dependencies bot_core_lcmtypes;ctk_python_console;drake;lcm;libbot;pythonqt;qt_property_browser

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6150)
<!-- Reviewable:end -->
