### PR TITLE
Require installation of licenses

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -30,6 +30,8 @@ alias(
     actual="@protobuf//:protobuf_python",
 )
 
+exports_files(["LICENSE.TXT"])
+
 install(
     name = "install",
     deps = [

--- a/drake/BUILD
+++ b/drake/BUILD
@@ -43,8 +43,10 @@ drake_header_tar(
 # (i.e. in Drake itself; not externals).
 install(
     name = "install",
+    doc_dest = "share/doc/drake",
     guess_hdrs = "WORKSPACE",
     hdr_dest = "include/drake",
+    license_docs = ["//:LICENSE.TXT"],
     targets = ["libdrake.so"],
 )
 

--- a/tools/eigen.BUILD
+++ b/tools/eigen.BUILD
@@ -69,9 +69,9 @@ install_files(
 install(
     name = "install",
     doc_dest = "share/doc/eigen3",
-    docs = glob(["COPYING.*"]),
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/eigen3",
+    license_docs = glob(["COPYING.*"]),
     targets = ["eigen"],
     deps = ["install_cmake"],
 )

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -249,9 +249,9 @@ install(
     doc_dest = "share/doc/lcm",
     docs = [
         "AUTHORS",
-        "COPYING",
         "NEWS",
     ],
+    license_docs = ["COPYING"],
     targets = [
         "lcm",
         "lcm-gen",


### PR DESCRIPTION
Modify `install` directive to also accept a list of license files, and to require that license file(s) are specified when headers and/or targets are being installed. Update users to specify license files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6156)
<!-- Reviewable:end -->
