### PR TITLE
Increase global_inverse_kinematics_collision_avoidance_test timeout in CMake.

### DIFF
--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -20,7 +20,7 @@ if(gurobi_FOUND)
             drakeGlobalInverseKinematicsTest)
 
     drake_add_cc_test(global_inverse_kinematics_collision_avoidance_test)
-    set_tests_properties(global_inverse_kinematics_collision_avoidance_test PROPERTIES TIMEOUT 300)
+    set_tests_properties(global_inverse_kinematics_collision_avoidance_test PROPERTIES TIMEOUT 600)
     target_link_libraries(global_inverse_kinematics_collision_avoidance_test
             drakeGlobalInverseKinematicsTest)
 endif()


### PR DESCRIPTION
This should resolve the timeouts being in encountered in CI.

Example failures:
* [linux-clang-nightly-ros-debug Build #303](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-clang-nightly-ros-debug/303/)
* [linux-gcc-nightly-ros-debug Build #301](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-gcc-nightly-ros-debug/301/)
* [mac-clang-nightly-release Build #425](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-clang-nightly-release/425/)
* [mac-clang-ninja-nightly-release Build #368](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-clang-ninja-nightly-release/368/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6161)
<!-- Reviewable:end -->
