### PR TITLE
Change assert and throw messages to be identical

### DIFF
--- a/drake/common/drake_assert_and_throw.cc
+++ b/drake/common/drake_assert_and_throw.cc
@@ -11,28 +11,35 @@
 
 namespace drake {
 namespace detail {
+namespace {
 
+// Stream into @p out the given failure details; only @p condition may be null.
+void PrintFailureDetailTo(std::ostream& out, const char* condition,
+                          const char* func, const char* file, int line) {
+  out << "Failure at " << file << ":" << line << " in " << func << "()";
+  if (condition) {
+    out << ": condition '" << condition << "' failed.";
+  } else {
+    out << ".";
+  }
+}
+}  // namespace
+
+// Declared in drake_assert.h.
 void Abort(const char* condition, const char* func, const char* file,
            int line) {
-  std::cerr << "abort: failure at " << file << ":" << line
-            << " in " << func << "()";
-  if (condition) {
-    std::cerr << ": assertion '" << condition << "' failed.";
-  } else {
-    std::cerr << ".";
-  }
+  std::cerr << "abort: ";
+  PrintFailureDetailTo(std::cerr, condition, func, file, line);
   std::cerr << std::endl;
-
   std::abort();
 }
 
+// Declared in drake_throw.h.
 void Throw(const char* condition, const char* func, const char* file,
            int line) {
-  std::stringstream message;
-  message
-      << "Failure at " << file << ":" << line << " in " << func << "(): "
-      << "condition '" << condition << "' failed.";
-  throw std::runtime_error(message.str());
+  std::ostringstream what;
+  PrintFailureDetailTo(what, condition, func, file, line);
+  throw std::runtime_error(what.str());
 }
 
 }  // namespace detail

--- a/drake/common/drake_throw.h
+++ b/drake/common/drake_throw.h
@@ -12,6 +12,7 @@
 namespace drake {
 namespace detail {
 // Throw an error message.
+__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
 void Throw(const char* condition, const char* func, const char* file, int line);
 }  // namespace detail
 }  // namespace drake

--- a/drake/common/test/drake_assert_test.cc
+++ b/drake/common/test/drake_assert_test.cc
@@ -11,15 +11,15 @@ GTEST_TEST(DrakeAssertDeathTest, AbortTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(
       { DRAKE_ABORT(); },
-      "abort: failure at .*drake_assert_test.cc:.. in TestBody");
+      "abort: Failure at .*drake_assert_test.cc:.. in TestBody");
 }
 
 GTEST_TEST(DrakeAssertDeathTest, DemandTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(
       { DRAKE_DEMAND(false); },
-      "abort: failure at .*drake_assert_test.cc:.. in TestBody..:"
-      " assertion 'false' failed");
+      "abort: Failure at .*drake_assert_test.cc:.. in TestBody..: "
+      "condition 'false' failed");
 }
 
 struct BoolConvertible { operator bool() const { return true; } };
@@ -35,16 +35,16 @@ GTEST_TEST(DrakeAssertDeathTest, AssertSyntaxTest) {
 GTEST_TEST(DrakeAssertDeathTest, AssertFalseTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(
-      { DRAKE_ASSERT((2 + 2) == 5); },
-      R"(abort: failure at .*drake_assert_test.cc:.. in TestBody\(\): )"
-      R"(assertion '\(2 \+ 2\) == 5' failed)");
+      { DRAKE_ASSERT(2 + 2 == 5); },
+      "abort: Failure at .*drake_assert_test.cc:.. in TestBody..: "
+      "condition '2 \\+ 2 == 5' failed");
 }
 
 GTEST_TEST(DrakeAssertDeathTest, AssertVoidTestArmed) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(
       { DRAKE_ASSERT_VOID(::abort()); },
-      R"()");
+      "");
 }
 
 #endif  //  DRAKE_ASSERT_IS_ARMED

--- a/drake/geometry/test/identifier_test.cc
+++ b/drake/geometry/test/identifier_test.cc
@@ -182,8 +182,8 @@ TEST_F(IdentifierDeathTests, InvalidGetValueCall) {
   int64_t value = -1;
   ASSERT_DEATH(
       {value = invalid.get_value();},
-      "abort: failure at .*identifier.h:.+ in get_value.+"
-          "assertion 'is_valid\\(\\)' failed");
+      "abort: .*identifier.h:.+ in get_value.+"
+          "'is_valid\\(\\)' failed");
   // This lets gcc thinks the variable is used.
   EXPECT_EQ(value, -1);
 }
@@ -195,8 +195,8 @@ TEST_F(IdentifierDeathTests, InvlalidEqualityCompare) {
   bool result = true;
   EXPECT_DEATH(
       {result = invalid == a1_;},
-      "abort: failure at .*identifier.h:.+ in operator==.+"
-          "assertion 'is_valid\\(\\) && other.is_valid\\(\\)' failed");
+      "abort: .*identifier.h:.+ in operator==.+"
+          "'is_valid\\(\\) && other.is_valid\\(\\)' failed");
   // This lets gcc thinks the variable is used.
   EXPECT_EQ(result, true);
 }
@@ -208,8 +208,8 @@ TEST_F(IdentifierDeathTests, InvlalidInequalityCompare) {
   bool result = true;
   EXPECT_DEATH(
       {result = invalid != a1_;},
-      "abort: failure at .*identifier.h:.+ in operator!=.+"
-          "assertion 'is_valid\\(\\) && other.is_valid\\(\\)' failed");
+      "abort:.*identifier.h:.+ in operator!=.+"
+          "'is_valid\\(\\) && other.is_valid\\(\\)' failed");
   // This lets gcc thinks the variable is used.
   EXPECT_EQ(result, true);
 }


### PR DESCRIPTION
This slightly disturbs the expected output in the unit test, but the additional similarity is probably worth it.  Upcoming work to blur the line between assertions and exceptions will be better if the two messages are the same.

We also add noreturn to `detail::Throw`.  This may help compilers optimize what's going on here, and will later be required when this is reused for assertion handling.

Relates #5268.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6164)
<!-- Reviewable:end -->
