### PR TITLE
Fixing trajectory_car_test For Valgrind

### DIFF
--- a/drake/automotive/curve2.h
+++ b/drake/automotive/curve2.h
@@ -83,7 +83,7 @@ class Curve2 {
     }
 
     // Iterate over the segments, up through the requested path_distance.
-    T remaining_distance = std::max(T{}, path_distance);
+    T remaining_distance = std::max(T{0.0}, path_distance);
     for (auto point0 = waypoints_.begin(), point1 = point0 + 1;
          point1 != waypoints_.end();  // BR
          point0 = point1++) {


### PR DESCRIPTION
To reproduce:
`bazel test --copt -O0 --config=memcheck --verbose_failures   //drake/automotive:trajectory_car_test`

Ref: https://github.com/RobotLocomotion/drake/blob/master/drake/automotive/curve2.h#L119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6166)
<!-- Reviewable:end -->
