### PR TITLE
Add ability to turn all assertion failures into exceptions

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -18,6 +18,7 @@ drake_cc_library(
     hdrs = [
         "constants.h",
         "drake_assert.h",
+        "drake_assert_toggle.h",
         "drake_compat.h",
         "drake_copyable.h",
         "drake_deprecated.h",
@@ -452,6 +453,15 @@ sh_test(
         "drake_compat.h",
         "test/drake_assert_test_compile.cc",
         "unused.h",
+    ],
+)
+
+# Functional test of drake_assert_toggle.
+# Do NOT combine this with any other test; it changes process-wide settings.
+drake_cc_googletest(
+    name = "drake_assert_toggle_test",
+    deps = [
+        ":common",
     ],
 )
 

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -42,6 +42,7 @@ set(installed_headers
   copyable_unique_ptr.h
   double_overloads.h
   drake_assert.h
+  drake_assert_toggle.h
   drake_compat.h
   drake_copyable.h
   drake_deprecated.h

--- a/drake/common/drake_assert_and_throw.cc
+++ b/drake/common/drake_assert_and_throw.cc
@@ -1,17 +1,39 @@
 // This file contains the implementation of both drake_assert and drake_throw.
 // clang-format off
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_assert_toggle.h"
 #include "drake/common/drake_throw.h"
 // clang-format on
 
+#include <atomic>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+
+#include "drake/common/never_destroyed.h"
 
 namespace drake {
-namespace detail {
 namespace {
+
+// This is what DRAKE_THROW_UNLESS throws and what DRAKE_ASSERT and
+// DRAKE_DEMAND throw when our assertions are configured to throw.
+class assertion_error : public std::runtime_error {
+ public:
+  explicit assertion_error(const std::string& what_arg)
+      : std::runtime_error(what_arg) {}
+};
+
+// Singleton to manage assertion configuration.
+struct AssertionConfig {
+  static AssertionConfig& singleton() {
+    static never_destroyed<AssertionConfig> global;
+    return global.access();
+  }
+
+  std::atomic<bool> assertion_failures_are_exceptions;
+};
 
 // Stream into @p out the given failure details; only @p condition may be null.
 void PrintFailureDetailTo(std::ostream& out, const char* condition,
@@ -26,8 +48,8 @@ void PrintFailureDetailTo(std::ostream& out, const char* condition,
 }  // namespace
 
 // Declared in drake_assert.h.
-void Abort(const char* condition, const char* func, const char* file,
-           int line) {
+void detail::Abort(const char* condition, const char* func, const char* file,
+                   int line) {
   std::cerr << "abort: ";
   PrintFailureDetailTo(std::cerr, condition, func, file, line);
   std::cerr << std::endl;
@@ -35,12 +57,26 @@ void Abort(const char* condition, const char* func, const char* file,
 }
 
 // Declared in drake_throw.h.
-void Throw(const char* condition, const char* func, const char* file,
-           int line) {
+void detail::Throw(const char* condition, const char* func, const char* file,
+                   int line) {
   std::ostringstream what;
   PrintFailureDetailTo(what, condition, func, file, line);
-  throw std::runtime_error(what.str());
+  throw assertion_error(what.str());
 }
 
-}  // namespace detail
+// Declared in drake_assert.h.
+void detail::AssertionFailed(const char* condition, const char* func,
+                             const char* file, int line) {
+  if (AssertionConfig::singleton().assertion_failures_are_exceptions) {
+    detail::Throw(condition, func, file, line);
+  } else {
+    detail::Abort(condition, func, file, line);
+  }
+}
+
+// Declared in drake_assert_toggle.h.
+void assert::set_assertion_failure_to_throw_exception() {
+  AssertionConfig::singleton().assertion_failures_are_exceptions = true;
+}
+
 }  // namespace drake

--- a/drake/common/drake_assert_toggle.h
+++ b/drake/common/drake_assert_toggle.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace drake {
+namespace assert {
+
+/// Configures the DRAKE_ASSERT and DRAKE_DEMAND assertion failure handling
+/// behavior.
+///
+/// By default, assertion failures will result in an ::abort().  If this method
+/// has ever been called, failures will result in a thrown exception instead.
+///
+/// Assertion configuration has process-wide scope.  Changes here will affect
+/// all assertions within the current process.
+///
+/// This method is intended for projects that consume Drake as a library,
+/// including Drake's bindings for interpreted languages such as Python.  Code
+/// within the Drake project itself should never invoke this method, nor depend
+/// on the assertion failure behavior being set to any particular value.
+void set_assertion_failure_to_throw_exception();
+
+}  // namespace assert
+}  // namespace drake

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -114,6 +114,9 @@ target_link_libraries(drake_assert_test drakeCommon)
 drake_add_cc_test(drake_assert_test_compile)
 target_link_libraries(drake_assert_test_compile drakeCommon)
 
+drake_add_cc_test(drake_assert_toggle_test)
+target_link_libraries(drake_assert_toggle_test drakeCommon)
+
 # "text_logging.h" unit testing:  If spdlog is available, test that:
 add_executable(text_logging_test_default ../text_logging.cc text_logging_test.cc)
 target_link_libraries(text_logging_test_default GTest::GTest GTest::Main gflags)

--- a/drake/common/test/drake_assert_toggle_test.cc
+++ b/drake/common/test/drake_assert_toggle_test.cc
@@ -1,0 +1,31 @@
+#include "drake/common/drake_assert_toggle.h"
+
+#include <stdexcept>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace {
+
+GTEST_TEST(DrakeAssertToggleTest, CatchTest) {
+  drake::assert::set_assertion_failure_to_throw_exception();
+  bool regex_test_was_run = false;
+  EXPECT_THROW(
+    try {
+      // Use a DEMAND so that behavior is the same no matter the build variant.
+      // By code inspection, we see that ASSERT and DEMAND share an execution
+      // path, so we only need to test DEMAND.
+      DRAKE_DEMAND(false);
+    } catch (const std::exception& e) {
+      // Confirm the error message.
+      EXPECT_THAT(e.what(), testing::MatchesRegex(
+          "Failure.*in TestBody.* condition 'false' failed."));
+      regex_test_was_run = true;
+      throw;
+    }, std::exception);
+  EXPECT_TRUE(regex_test_was_run);
+}
+
+}  // namespace


### PR DESCRIPTION
The exact semantics are per `drake_assert.h` comment changes, and the toggle is in a new header `drake_assert_toggle.h`.  Note that `DRAKE_ABORT` behavior is unchanged; only assertions are changed.

This also changes the thrown object (including `DRAKE_THROW_UNLESS`) to be an exception subtype; this detail is not exposed to the user in any way, but might conceivably help diagnostics down the road, e.g., setting a breakpoint on its constructor.

Relates #5268.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6167)
<!-- Reviewable:end -->
