### PR TITLE
Implement drake::FindResource

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -161,6 +161,16 @@ drake_cc_library(
 # Miscellaneous utilities.
 
 drake_cc_library(
+    name = "find_resource",
+    srcs = ["find_resource.cc"],
+    hdrs = ["find_resource.h"],
+    deps = [
+        ":common",
+        "//drake/thirdParty:spruce",
+    ],
+)
+
+drake_cc_library(
     name = "drake_path",
     # TODO(david-german-tri): Set testonly = 1 once the non-test uses of
     # drake_path are removed.
@@ -508,6 +518,16 @@ drake_cc_googletest(
     deps = [
         ":common",
         ":extract_double",
+    ],
+)
+
+drake_cc_googletest(
+    name = "find_resource_test",
+    deps = [
+        ":find_resource",
+    ],
+    data = [
+        "test/find_resource_test_data.txt",
     ],
 )
 

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -17,6 +17,7 @@ set(sources
   double_overloads.cc
   drake_assert_and_throw.cc
   drake_path_cmake.cc
+  find_resource.cc
   functional_form.cc
   monomial.cc
   nice_type_name.cc
@@ -57,6 +58,7 @@ set(installed_headers
   eigen_stl_types.h
   eigen_types.h
   extract_double.h
+  find_resource.h
   functional_form.h
   hash.h
   is_approx_equal_abstol.h
@@ -93,6 +95,7 @@ target_link_libraries(drakeCommon
   Eigen3::Eigen
   fmt
   gflags
+  spruce
   Threads::Threads
   ${PROTOBUF_LIBRARIES})
 

--- a/drake/common/drake_optional.h
+++ b/drake/common/drake_optional.h
@@ -13,4 +13,6 @@ namespace drake {
 template <typename T>
 using optional = std::experimental::optional<T>;
 
+constexpr auto nullopt = std::experimental::nullopt;
+
 }  // namespace drake

--- a/drake/common/find_resource.cc
+++ b/drake/common/find_resource.cc
@@ -1,0 +1,183 @@
+#include "drake/common/find_resource.h"
+
+#include <utility>
+
+#include <spruce.hh>
+
+#include "drake/common/drake_throw.h"
+
+using std::string;
+
+namespace drake {
+
+using Result = FindResourceResult;
+
+optional<string>
+Result::get_absolute_path() const {
+  // If the resource was not found, return nothing.
+  if (!base_path_) { return nullopt; }
+
+  // Otherwise, return the the full path (base + relative).
+  DRAKE_ASSERT(error_message_ == nullopt);
+  return *base_path_ + '/' + resource_path_;
+}
+
+string
+Result::get_absolute_path_or_throw() const {
+  // If we have a path, return it.
+  const auto& optional_path = get_absolute_path();
+  if (optional_path) { return *optional_path; }
+
+  // Otherwise, throw the error message.
+  const auto& optional_error = get_error_message();
+  DRAKE_ASSERT(optional_error != nullopt);
+  throw std::runtime_error(*optional_error);
+}
+
+optional<string>
+Result::get_error_message() const {
+  // If an error has been set, return it.
+  if (error_message_ != nullopt) {
+    DRAKE_ASSERT(base_path_ == nullopt);
+    return error_message_;
+  }
+
+  // If successful, return no-error.
+  if (base_path_ != nullopt) {
+    return nullopt;
+  }
+
+  // Both optionals are null; we are empty; return a default error message.
+  DRAKE_ASSERT(resource_path_.empty());
+  return string("No resource was requested (empty result)");
+}
+
+string Result::get_resource_path() const {
+  return resource_path_;
+}
+
+Result Result::make_success(string resource_path, string base_path) {
+  DRAKE_THROW_UNLESS(!resource_path.empty());
+  DRAKE_THROW_UNLESS(!base_path.empty());
+
+  Result result;
+  result.resource_path_ = std::move(resource_path);
+  result.base_path_ = std::move(base_path);
+  result.CheckInvariants();
+  return result;
+}
+
+Result Result::make_error(string resource_path, string error_message) {
+  DRAKE_THROW_UNLESS(!resource_path.empty());
+  DRAKE_THROW_UNLESS(!error_message.empty());
+
+  Result result;
+  result.resource_path_ = std::move(resource_path);
+  result.error_message_ = std::move(error_message);
+  result.CheckInvariants();
+  return result;
+}
+
+Result Result::make_empty() {
+  Result result;
+  result.CheckInvariants();
+  return result;
+}
+
+void Result::CheckInvariants() {
+  if (resource_path_.empty()) {
+    // For our "empty" state, both success and error must be empty.
+    DRAKE_DEMAND(base_path_ == nullopt);
+    DRAKE_DEMAND(error_message_ == nullopt);
+  } else {
+    // For our "non-empty" state, we must have exactly one of success or error.
+    DRAKE_DEMAND((base_path_ == nullopt) != (error_message_ == nullopt));
+  }
+  // When present, the base_path and error_message cannot be an empty string.
+  DRAKE_DEMAND((base_path_ == nullopt) || !base_path_->empty());
+  DRAKE_DEMAND((error_message_ == nullopt) || !error_message_->empty());
+}
+
+namespace {
+
+bool is_relative_path(const string& path) {
+  // TODO(jwnimmer-tri) Prevent .. escape?
+  return !path.empty() && (path[0] != '/');
+}
+
+string get_cwd() {
+  spruce::path result;
+  result.setAsCurrent();
+  return result.getStr();
+}
+
+bool file_exists(const string& dirpath, const string& relpath) {
+  DRAKE_ASSERT(is_relative_path(relpath));
+  const spruce::path dir_query(dirpath);
+  if (!dir_query.isDir()) { return false; }
+  const spruce::path file_query(dir_query.getStr() + '/' + relpath);
+  return file_query.exists();
+}
+
+optional<string> find_workspace() {
+  spruce::path candidate_dir;
+  candidate_dir.setAsCurrent();
+  int num_attempts = 0;
+  while (true) {
+    DRAKE_THROW_UNLESS(num_attempts < 1000);  // Insanity fail-fast.
+    ++num_attempts;
+
+    // If we fall off the end of the world somehow, stop.
+    if (!candidate_dir.isDir()) {
+      return nullopt;
+    }
+
+    // If we found the WORKSPACE, we win.
+    const spruce::path candidate_file = candidate_dir.getStr() + "/WORKSPACE";
+    if (candidate_file.isFile()) {
+      return candidate_dir.getStr();
+    }
+
+    // Move up one directory; with spruce, "root" means "parent".
+    candidate_dir = candidate_dir.root();
+  }
+}
+
+}  // namespace
+
+Result FindResource(string resource_path) {
+  // Check if resource_path is well-worked.
+  if (!is_relative_path(resource_path)) {
+    return Result::make_error(
+        std::move(resource_path),
+        "resource_path is not a relative path");
+  }
+
+  // Check if the resource is in cwd already.  At a minimum, this handles the
+  // case of runfiles in the Bazel sandbox, but could conceivably match in
+  // other situations as well.
+  const string cwd = get_cwd();
+  if (file_exists(cwd, resource_path)) {
+    return Result::make_success(std::move(resource_path), cwd);
+  }
+
+  // Check if the resource is in cwd's workspace.  Find the Bazel WORKSPACE
+  // file to determine the project's source code root, then look from there.
+  // TODO(jwnimmer-tri) We need automated regression tests for this, but can't
+  // really write them in Bazel, since this code is explicitly for finding
+  // resources when not run from Bazel.
+  const optional<string> workspace = find_workspace();
+  if (workspace && file_exists(*workspace, resource_path)) {
+    return Result::make_success(std::move(resource_path), *workspace);
+  }
+
+  // TODO(jwnimmer-tri) Add more search heuristics for installed copies of
+  // Drake resources.
+
+  // Nothing found.
+  return Result::make_error(
+      std::move(resource_path),
+      "could not find resource");
+}
+
+}  // namespace drake

--- a/drake/common/find_resource.h
+++ b/drake/common/find_resource.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+
+#include <string>
+
+namespace drake {
+
+/// Models the outcome of drake::FindResource.  After a call to FindResource,
+/// typical calling code would use get_absolute_path_or_throw().
+/// Alternatively, get_absolute_path() will return an `optional<string>`, which
+/// can be manually checked to contain a value before using the path.  If the
+/// resource was not found, get_error_message() will contain an error message.
+///
+/// For a given FindResourceResult instance, exactly one of get_absolute_path()
+/// or get_error_message() will contain a value.  (Similarly, exactly one of
+/// them will not contain a value.)
+class FindResourceResult {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FindResourceResult);
+
+  /// Returns the absolute path to the resource, iff the resource was found.
+  optional<std::string> get_absolute_path() const;
+
+  /// Either returns the get_absolute_path() iff the resource was found,
+  /// or else throws runtime_error.
+  std::string get_absolute_path_or_throw() const;
+
+  /// Returns the error message, iff the resource was not found.
+  /// The string will never be empty; only the optional can be empty.
+  optional<std::string> get_error_message() const;
+
+  /// Returns the resource_path asked of FindResource.
+  /// (This may be empty only in the make_empty() case.)
+  std::string get_resource_path() const;
+
+  /// Returns a success result (the requested resource was found).
+  /// @pre neither string parameter is empty
+  /// @param resource_path the value passed to FindResource
+  /// @param base_path an absolute base path that precedes resource_path
+  static FindResourceResult make_success(
+      std::string resource_path, std::string base_path);
+
+  /// Returns an error result (the requested resource was NOT found).
+  /// @pre neither string parameter is empty
+  /// @param resource_path the value passed to FindResource
+  static FindResourceResult make_error(
+      std::string resource_path, std::string error_message);
+
+  /// Returns an empty error result (no requested resource).
+  static FindResourceResult make_empty();
+
+ private:
+  FindResourceResult() = default;
+  void CheckInvariants();
+
+  // The path as requested by the user.
+  std::string resource_path_;
+
+  // The base path (directory where resource_path was found), if found.
+  optional<std::string> base_path_;
+
+  // An error message, permitted to be present only when base_path is empty.
+  //
+  // All three of resource_path, base_path, and error_message can be empty
+  // (e.g., a default-constructed and/or moved-from object), which represents
+  // resource-not-found along with an unspecified non-empty default error
+  // message from get_error_message().
+  optional<std::string> error_message_;
+};
+
+/// Attempts to locate a Drake resource named by the given @p resource_path.
+/// The @p resource_path refers to the relative path within the Drake
+/// repository, e.g., `drake/examples/Pendulum/Pendulum.urdf`.
+///
+/// When called from within a source code workspace (i.e., what a Drake
+/// developer would use), this finds the resource within the current workspace.
+///
+/// When called from an installed binary build of Drake, this is intended to
+/// find the installed resource, but that feature is not yet implemented.
+FindResourceResult FindResource(std::string resource_path);
+
+}  // namespace drake

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -30,6 +30,12 @@ target_link_libraries(eigen_stl_types_test Eigen3::Eigen)
 drake_add_cc_test(extract_double_test)
 target_link_libraries(extract_double_test drakeCommon)
 
+# TODO(jwnimmer-tri) Drake CI's ROS configuration uses an out-of-source build,
+# which this unit test does not yet support:
+#   drake_add_cc_test(find_resource_test)
+add_executable(find_resource_test find_resource_test.cc)
+target_link_libraries(find_resource_test drakeCommon GTest::GTest GTest::Main)
+
 drake_add_cc_test(functional_form_test)
 target_link_libraries(functional_form_test drakeCommon)
 

--- a/drake/common/test/find_resource_test.cc
+++ b/drake/common/test/find_resource_test.cc
@@ -1,0 +1,82 @@
+#include "drake/common/find_resource.h"
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using std::string;
+
+namespace drake {
+namespace {
+
+using Result = FindResourceResult;
+
+GTEST_TEST(FindResourceTest, EmptyResult) {
+  const auto& result = Result::make_empty();
+  EXPECT_EQ(result.get_resource_path(), "");
+  EXPECT_FALSE(result.get_absolute_path());
+  EXPECT_THROW(result.get_absolute_path_or_throw(), std::runtime_error);
+  ASSERT_TRUE(result.get_error_message());
+}
+
+GTEST_TEST(FindResourceTest, NonRelativeRequest) {
+  const string abspath = "/dev/null";
+  const auto& result = FindResource(abspath);
+  EXPECT_EQ(result.get_resource_path(), abspath);
+
+  // We don't get a path back.
+  EXPECT_FALSE(result.get_absolute_path());
+  EXPECT_THROW(result.get_absolute_path_or_throw(), std::runtime_error);
+
+  // We get an error back.
+  const optional<string> error_message = result.get_error_message();
+  ASSERT_TRUE(error_message);
+  EXPECT_EQ(*error_message, "resource_path is not a relative path");
+}
+
+GTEST_TEST(FindResourceTest, NotFound) {
+  const string relpath = "this file does not exist";
+  const auto& result = FindResource(relpath);
+  EXPECT_EQ(result.get_resource_path(), relpath);
+
+  // We don't get a path back.
+  EXPECT_FALSE(result.get_absolute_path());
+  EXPECT_THROW(result.get_absolute_path_or_throw(), std::runtime_error);
+
+  // We get an error back.
+  const optional<string> error_message = result.get_error_message();
+  ASSERT_TRUE(error_message);
+  EXPECT_EQ(*error_message, "could not find resource");
+}
+
+GTEST_TEST(FindResourceTest, FoundDeclaredData) {
+  const string relpath = "drake/common/test/find_resource_test_data.txt";
+  const auto& result = FindResource(relpath);
+  EXPECT_EQ(result.get_resource_path(), relpath);
+
+  // We don't get an error back.
+  EXPECT_FALSE(result.get_error_message());
+
+  // We get a path back.
+  string absolute_path;
+  EXPECT_NO_THROW(absolute_path = result.get_absolute_path_or_throw());
+  ASSERT_TRUE(result.get_absolute_path());
+  EXPECT_EQ(*result.get_absolute_path(), absolute_path);
+
+  // The path is the correct answer.
+  ASSERT_FALSE(absolute_path.empty());
+  EXPECT_EQ(absolute_path[0], '/');
+  std::ifstream input(absolute_path, std::ios::binary);
+  ASSERT_TRUE(input);
+  std::stringstream buffer;
+  buffer << input.rdbuf();
+  EXPECT_EQ(
+      buffer.str(),
+      "Test data for drake/common/test/find_resource_test.cc.\n");
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/common/test/find_resource_test_data.txt
+++ b/drake/common/test/find_resource_test_data.txt
@@ -1,0 +1,1 @@
+Test data for drake/common/test/find_resource_test.cc.


### PR DESCRIPTION
This is intended to replace `GetDrakePath` in both from-source builds as well as installed builds.
Relates #5893 and #2174.

Port gyroscope_test to use `FindResource` as a proof-of-life.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6168)
<!-- Reviewable:end -->
