### PR TITLE
Increase simulated_schunk_wsg_system_test size

### DIFF
--- a/drake/examples/schunk_wsg/test/CMakeLists.txt
+++ b/drake/examples/schunk_wsg/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(lcm_FOUND)
-  drake_add_cc_test(simulated_schunk_wsg_system_test)
+  drake_add_cc_test(NAME simulated_schunk_wsg_system_test SIZE medium)
   target_link_libraries(simulated_schunk_wsg_system_test
     drakeSimulatedSchunkWsg drakeSystemAnalysis drakeSystemPrimitives)
 
@@ -7,8 +7,7 @@ if(lcm_FOUND)
   # takes about 2.5 minutes to run in release mode.  It should *not*
   # be run in debug mode (> 90 minutes).
   drake_add_cc_test(NAME schunk_wsg_lift_test SIZE large
-    CONFIGURATIONS Release
-    SIZE medium)
+    CONFIGURATIONS Release)
   target_link_libraries(schunk_wsg_lift_test
     drakeCommon
     drakeLcmSystem


### PR DESCRIPTION
This test is timing out on the CI ros-debug builds.

PR #6163 changed the size of `schunk_wsg_lift_test` instead of `simulated_schunk_wsg_system_test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6169)
<!-- Reviewable:end -->
