### PR TITLE
Do not explicitly set timeout for tests

### DIFF
--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -9,18 +9,16 @@ target_link_libraries(drakeGlobalInverseKinematicsTest
         GTest::GTest)
 
 if(gurobi_FOUND)
-    drake_add_cc_test(global_inverse_kinematics_test)
-    set_tests_properties(global_inverse_kinematics_test PROPERTIES TIMEOUT 200)
+    drake_add_cc_test(NAME global_inverse_kinematics_test SIZE medium)
     target_link_libraries(global_inverse_kinematics_test
             drakeGlobalInverseKinematicsTest)
 
-    drake_add_cc_test(global_inverse_kinematics_reachable_test)
-    set_tests_properties(global_inverse_kinematics_reachable_test PROPERTIES TIMEOUT 300)
+    drake_add_cc_test(NAME global_inverse_kinematics_reachable_test SIZE medium)
     target_link_libraries(global_inverse_kinematics_reachable_test
             drakeGlobalInverseKinematicsTest)
 
-    drake_add_cc_test(global_inverse_kinematics_collision_avoidance_test)
-    set_tests_properties(global_inverse_kinematics_collision_avoidance_test PROPERTIES TIMEOUT 600)
+    drake_add_cc_test(NAME global_inverse_kinematics_collision_avoidance_test
+            SIZE large)
     target_link_libraries(global_inverse_kinematics_collision_avoidance_test
             drakeGlobalInverseKinematicsTest)
 endif()

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -79,15 +79,14 @@ drake_add_cc_test(snopt_solver_test)
 target_link_libraries(snopt_solver_test drakeOptimizationTest)
 
 if (mosek_FOUND)
-  drake_add_cc_test(rotation_constraint_test rotation_constraint_test.cc)
-  set_tests_properties(rotation_constraint_test PROPERTIES TIMEOUT 900)
+  drake_add_cc_test(NAME rotation_constraint_test rotation_constraint_test.cc
+    SIZE large)
   target_link_libraries(rotation_constraint_test drakeRotationConstraint)
 endif()
 
 if (gurobi_FOUND)
   if(NOT APPLE)
-	  drake_add_cc_test(rotation_constraint_limit_test)
-	  set_tests_properties(rotation_constraint_limit_test PROPERTIES TIMEOUT 900)
+	  drake_add_cc_test(NAME rotation_constraint_limit_test SIZE large)
 	  target_link_libraries(rotation_constraint_limit_test drakeRotationConstraint)
   endif()
 endif()


### PR DESCRIPTION
Explicit test timeouts do not get recalculated for debug, memcheck, etc. builds.

FYI @EricCousineau-TRI @hongkai-dai.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6178)
<!-- Reviewable:end -->