### PR TITLE
Disable copy and copy-assign on VectorValue

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -535,6 +535,7 @@ drake_cc_googletest(
     name = "vector_value_test",
     deps = [
         ":vector_value",
+        "//drake/common:is_dynamic_castable",
         "//drake/systems/framework/test_utilities",
     ],
 )

--- a/drake/systems/framework/test/vector_value_test.cc
+++ b/drake/systems/framework/test/vector_value_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test/is_dynamic_castable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/test_utilities/my_vector.h"
 
@@ -18,75 +19,22 @@ GTEST_TEST(VectorValueTest, Access) {
   EXPECT_EQ(3, value.get_value()->get_value().z());
 }
 
-GTEST_TEST(VectorValueTest, CopyConstructor) {
-  VectorValue<double> value(BasicVector<double>::Make({1, 2, 3}));
-
-  VectorValue<double> other_value(value);
-  EXPECT_EQ(1, other_value.get_value()->get_value().x());
-  EXPECT_EQ(2, other_value.get_value()->get_value().y());
-  EXPECT_EQ(3, other_value.get_value()->get_value().z());
-}
-
-GTEST_TEST(VectorValueTest, CopyConstructorSubclass) {
+GTEST_TEST(VectorValueTest, CloneSubclass) {
   VectorValue<double> value(MyVector2d::Make(1, 2));
-  VectorValue<double> other_value(value);
-  value.get_value()->set_value(Eigen::Vector2d(3, 4));
 
-  const MyVector2d* const vector =
-      dynamic_cast<const MyVector2d*>(other_value.get_value());
-  ASSERT_NE(vector, nullptr);
-  EXPECT_EQ(vector->get_value()(0), 1);
-  EXPECT_EQ(vector->get_value()(1), 2);
-}
+  // Clone of VectorValue should produce a VectorValue.
+  std::unique_ptr<AbstractValue> abstract_value = value.Clone();
+  const VectorValue<double>* const new_value =
+      dynamic_cast<VectorValue<double>*>(abstract_value.get());
+  ASSERT_TRUE(new_value != nullptr);
 
-GTEST_TEST(VectorValueTest, CopyConstructorNull) {
-  VectorValue<double> value{nullptr};
-
-  VectorValue<double> other_value(value);
-  EXPECT_EQ(other_value.get_value(), nullptr);
-}
-
-GTEST_TEST(VectorValueTest, AssignmentOperator) {
-  VectorValue<double> value(BasicVector<double>::Make({1, 2, 3}));
-  VectorValue<double> other_value(BasicVector<double>::Make({4, 5, 6}));
-
-  value = other_value;
-  EXPECT_EQ(4, value.get_value()->get_value().x());
-  EXPECT_EQ(5, value.get_value()->get_value().y());
-  EXPECT_EQ(6, value.get_value()->get_value().z());
-}
-
-GTEST_TEST(VectorValueTest, AssignmentOperatorSubclass) {
-  VectorValue<double> value(MyVector2d::Make(1, 2));
-  VectorValue<double> other_value(BasicVector<double>::Make({5, 6}));
-  other_value = value;
-  value.get_value()->set_value(Eigen::Vector2d(3, 4));
-
-  const MyVector2d* const vector =
-      dynamic_cast<const MyVector2d*>(other_value.get_value());
-  ASSERT_NE(vector, nullptr);
-  EXPECT_EQ(vector->get_value()(0), 1);
-  EXPECT_EQ(vector->get_value()(1), 2);
-}
-
-GTEST_TEST(VectorValueTest, AssignmentOperatorNull) {
-  VectorValue<double> value{nullptr};
-  VectorValue<double> other_value(BasicVector<double>::Make({4, 5, 6}));
-
-  value = other_value;
-  other_value = VectorValue<double>{nullptr};
-  EXPECT_EQ(4, value.get_value()->get_value().x());
-  EXPECT_EQ(5, value.get_value()->get_value().y());
-  EXPECT_EQ(6, value.get_value()->get_value().z());
-  EXPECT_EQ(other_value.get_value(), nullptr);
-}
-
-GTEST_TEST(VectorValueTest, AssignmentOperatorSelf) {
-  VectorValue<double> value(BasicVector<double>::Make({4, 5, 6}));
-  value = value;
-  EXPECT_EQ(4, value.get_value()->get_value().x());
-  EXPECT_EQ(5, value.get_value()->get_value().y());
-  EXPECT_EQ(6, value.get_value()->get_value().z());
+  // The underlying BasicVector should be a MyVector.
+  const BasicVector<double>* const new_vector = new_value->get_value();
+  ASSERT_TRUE(new_vector != nullptr);
+  auto my_vector = dynamic_cast<const MyVector2d*>(new_vector);
+  ASSERT_TRUE(my_vector != nullptr);
+  EXPECT_EQ(1, my_vector->GetAtIndex(0));
+  EXPECT_EQ(2, my_vector->GetAtIndex(1));
 }
 
 }  // namespace

--- a/drake/systems/framework/value.h
+++ b/drake/systems/framework/value.h
@@ -151,7 +151,6 @@ class AbstractValue {
 template <typename T>
 class Value : public AbstractValue {
  public:
-  // Values are copyable but not moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Value)
 
   /// Constructs a Value<T> using T's default constructor, if available.


### PR DESCRIPTION
These are not used anywhere, and only complicate things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6182)
<!-- Reviewable:end -->
