### PR TITLE
Add formula visitor

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -125,6 +125,7 @@ drake_cc_library(
         "symbolic_formula.cc",
         "symbolic_formula_cell.cc",
         "symbolic_formula_cell.h",
+        "symbolic_formula_visitor.cc",
         "symbolic_variable.cc",
         "symbolic_variables.cc",
     ],
@@ -134,6 +135,7 @@ drake_cc_library(
         "symbolic_expression.h",
         "symbolic_expression_visitor.h",
         "symbolic_formula.h",
+        "symbolic_formula_visitor.h",
         "symbolic_variable.h",
         "symbolic_variables.h",
     ],
@@ -687,6 +689,15 @@ drake_cc_googletest(
     deps = [
         ":common",
         ":is_memcpy_movable",
+        ":symbolic",
+        ":symbolic_test_util",
+    ],
+)
+
+drake_cc_googletest(
+    name = "symbolic_formula_visitor_test",
+    deps = [
+        ":common",
         ":symbolic",
         ":symbolic_test_util",
     ],

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -71,6 +71,7 @@ set(installed_headers
   symbolic_expression.h
   symbolic_expression_visitor.h
   symbolic_formula.h
+  symbolic_formula_visitor.h
   symbolic_variable.h
   symbolic_variables.h
   text_logging.h

--- a/drake/common/symbolic_formula.cc
+++ b/drake/common/symbolic_formula.cc
@@ -113,48 +113,44 @@ Formula forall(const Variables& vars, const Formula& f) {
   return Formula{make_shared<FormulaForall>(vars, f)};
 }
 
-Formula operator&&(const Formula& f1, const Formula& f2) {
-  // f && f => f
-  if (f1.EqualTo(f2)) {
-    return f1;
-  }
-  // ff && x => ff    x && ff => ff
-  if (f1.EqualTo(Formula::False()) || f2.EqualTo(Formula::False())) {
-    return Formula::False();
-  }
-  // tt && f2 => f2
-  if (f1.EqualTo(Formula::True())) {
-    return f2;
-  }
-  // f1 && tt => f1
-  if (f2.EqualTo(Formula::True())) {
-    return f1;
-  }
-  // Flattening
-  if (is_conjunction(f1)) {
-    set<Formula> formulas{get_operands(f1)};
-    if (is_conjunction(f2)) {
-      // (f1,1 ∧ ... f1,n) ∧ (f2,1 ∧ ... f2,m)
-      // => (f1,1 ∧ ... f1,n ∧ f2,1 ∧ ... f2,m)
-      const set<Formula>& formulas2{get_operands(f2)};
-      formulas.insert(formulas2.begin(), formulas2.end());
-    } else {
-      // (f1,1 ∧ ... f1,n) ∧ f2
-      // => (f1,1 ∧ ... f1,n ∧ f2)
-      formulas.insert(f2);
+Formula make_conjunction(const set<Formula>& formulas) {
+  set<Formula> operands;
+  for (const Formula& f : formulas) {
+    if (is_false(f)) {
+      // Short-circuits to False.
+      // f₁ ∧ ... ∧ False ∧ ... ∧ fₙ => False
+      return Formula::False();
     }
-    return Formula{make_shared<FormulaAnd>(formulas)};
+    if (is_true(f)) {
+      // Drop redundant True.
+      // f₁ ∧ ... ∧ True ∧ ... ∧ fₙ => f₁ ∧ ... ∧ fₙ
+      continue;
+    }
+    if (is_conjunction(f)) {
+      // Flattening.
+      //    f₁ ∧ ... ∧ (fᵢ₁ ∧ ... ∧ fᵢₘ) ∧ ... ∧ fₙ
+      // => f₁ ∧ ... ∧ fᵢ₁ ∧ ... ∧ fᵢₘ ∧ ... ∧ fₙ
+      const auto& operands_in_f = get_operands(f);
+      operands.insert(operands_in_f.cbegin(), operands_in_f.cend());
+    } else {
+      operands.insert(f);
+    }
   }
-  if (is_conjunction(f2)) {
-    // f1 ∧ (f2,1 ∧ ... f2,m)
-    // => (f1 ∧ f2,1 ∧ ... f2,m)
-    set<Formula> formulas{get_operands(f2)};
-    formulas.insert(f1);
-    return Formula{make_shared<FormulaAnd>(formulas)};
+  if (operands.empty()) {
+    // ⋀{} = True
+    return Formula::True();
   }
-  // Nothing to flatten.
-  return Formula{make_shared<FormulaAnd>(f1, f2)};
+  if (operands.size() == 1) {
+    return *(operands.begin());
+  }
+  // TODO(soonho-tri): Returns False if both f and ¬f appear in operands.
+  return Formula{make_shared<FormulaAnd>(operands)};
 }
+
+Formula operator&&(const Formula& f1, const Formula& f2) {
+  return make_conjunction({f1, f2});
+}
+
 Formula operator&&(const Variable& v, const Formula& f) {
   return Formula(v) && f;
 }
@@ -165,47 +161,42 @@ Formula operator&&(const Variable& v1, const Variable& v2) {
   return Formula(v1) && Formula(v2);
 }
 
-Formula operator||(const Formula& f1, const Formula& f2) {
-  // f || f => f
-  if (f1.EqualTo(f2)) {
-    return f1;
-  }
-  // tt || x => tt    x || tt => tt
-  if (f1.EqualTo(Formula::True()) || f2.EqualTo(Formula::True())) {
-    return Formula::True();
-  }
-  // ff || f2 => f2
-  if (f1.EqualTo(Formula::False())) {
-    return f2;
-  }
-  // f1 || ff => f1
-  if (f2.EqualTo(Formula::False())) {
-    return f1;
-  }
-  // Flattening
-  if (is_disjunction(f1)) {
-    set<Formula> formulas{get_operands(f1)};
-    if (is_disjunction(f2)) {
-      // (f1,1 ∨ ... f1,n) ∨ (f2,1 ∨ ... f2,m)
-      // => (f1,1 ∨ ... f1,n ∨ f2,1 ∨ ... f2,m)
-      const set<Formula>& formulas2{get_operands(f2)};
-      formulas.insert(formulas2.begin(), formulas2.end());
-    } else {
-      // (f1,1 ∨ ... f1,n) ∨ f2
-      // => (f1,1 ∨ ... f1,n ∨ f2)
-      formulas.insert(f2);
+Formula make_disjunction(const set<Formula>& formulas) {
+  set<Formula> operands;
+  for (const Formula& f : formulas) {
+    if (is_true(f)) {
+      // Short-circuits to True.
+      // f₁ ∨ ... ∨ True ∨ ... ∨ fₙ => True
+      return Formula::True();
     }
-    return Formula{make_shared<FormulaOr>(formulas)};
+    if (is_false(f)) {
+      // Drop redundant False.
+      // f₁ ∨ ... ∨ False ∨ ... ∨ fₙ => f₁ ∨ ... ∨ fₙ
+      continue;
+    }
+    if (is_disjunction(f)) {
+      // Flattening.
+      //    f₁ ∨ ... ∨ (fᵢ₁ ∨ ... ∨ fᵢₘ) ∨ ... ∨ fₙ
+      // => f₁ ∨ ... ∨ fᵢ₁ ∨ ... ∨ fᵢₘ ∨ ... ∨ fₙ
+      const auto& operands_in_f = get_operands(f);
+      operands.insert(operands_in_f.cbegin(), operands_in_f.cend());
+    } else {
+      operands.insert(f);
+    }
   }
-  if (is_disjunction(f2)) {
-    // f1 ∨ (f2,1 ∨ ... f2,m)
-    // => (f1 ∨ f2,1 ∨ ... f2,m)
-    set<Formula> formulas{get_operands(f2)};
-    formulas.insert(f1);
-    return Formula{make_shared<FormulaOr>(formulas)};
+  if (operands.empty()) {
+    // ⋁{} = False
+    return Formula::False();
   }
-  // Nothing to flatten.
-  return Formula{make_shared<FormulaOr>(f1, f2)};
+  if (operands.size() == 1) {
+    return *(operands.begin());
+  }
+  // TODO(soonho-tri): Returns True if both f and ¬f appear in operands.
+  return Formula{make_shared<FormulaOr>(operands)};
+}
+
+Formula operator||(const Formula& f1, const Formula& f2) {
+  return make_disjunction({f1, f2});
 }
 Formula operator||(const Variable& v, const Formula& f) {
   return Formula(v) || f;

--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -44,10 +44,20 @@ enum class FormulaKind {
 bool operator<(FormulaKind k1, FormulaKind k2);
 
 class FormulaCell;                  // In drake/common/symbolic_formula_cell.h
+class FormulaFalse;                 // In drake/common/symbolic_formula_cell.h
+class FormulaTrue;                  // In drake/common/symbolic_formula_cell.h
 class FormulaVar;                   // In drake/common/symbolic_formula_cell.h
 class RelationalFormulaCell;        // In drake/common/symbolic_formula_cell.h
+class FormulaEq;                    // In drake/common/symbolic_formula_cell.h
+class FormulaNeq;                   // In drake/common/symbolic_formula_cell.h
+class FormulaGt;                    // In drake/common/symbolic_formula_cell.h
+class FormulaGeq;                   // In drake/common/symbolic_formula_cell.h
+class FormulaLt;                    // In drake/common/symbolic_formula_cell.h
+class FormulaLeq;                   // In drake/common/symbolic_formula_cell.h
 class NaryFormulaCell;              // In drake/common/symbolic_formula_cell.h
 class FormulaNot;                   // In drake/common/symbolic_formula_cell.h
+class FormulaAnd;                   // In drake/common/symbolic_formula_cell.h
+class FormulaOr;                    // In drake/common/symbolic_formula_cell.h
 class FormulaForall;                // In drake/common/symbolic_formula_cell.h
 class FormulaIsnan;                 // In drake/common/symbolic_formula_cell.h
 class FormulaPositiveSemidefinite;  // In drake/common/symbolic_formula_cell.h
@@ -206,9 +216,21 @@ class Formula {
   // Note that the following cast functions are only for low-level operations
   // and not exposed to the user of symbolic_formula.h. These functions are
   // declared in symbolic_formula_cell.h header.
+
+  friend std::shared_ptr<FormulaFalse> to_false(const Formula& f);
+  friend std::shared_ptr<FormulaTrue> to_true(const Formula& f);
   friend std::shared_ptr<FormulaVar> to_variable(const Formula& f);
   friend std::shared_ptr<RelationalFormulaCell> to_relational(const Formula& f);
+  friend std::shared_ptr<FormulaEq> to_equal_to(const Formula& f);
+  friend std::shared_ptr<FormulaNeq> to_not_equal_to(const Formula& f);
+  friend std::shared_ptr<FormulaGt> to_greater_than(const Formula& f);
+  friend std::shared_ptr<FormulaGeq> to_greater_than_or_equal_to(
+      const Formula& f);
+  friend std::shared_ptr<FormulaLt> to_less_than(const Formula& f);
+  friend std::shared_ptr<FormulaLeq> to_less_than_or_equal_to(const Formula& f);
   friend std::shared_ptr<NaryFormulaCell> to_nary(const Formula& f);
+  friend std::shared_ptr<FormulaAnd> to_conjunction(const Formula& f);
+  friend std::shared_ptr<FormulaOr> to_disjunction(const Formula& f);
   friend std::shared_ptr<FormulaNot> to_negation(const Formula& f);
   friend std::shared_ptr<FormulaForall> to_forall(const Formula& f);
   friend std::shared_ptr<FormulaIsnan> to_isnan(const Formula& f);

--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -176,23 +176,6 @@ class Formula {
   /** Conversion to bool. */
   explicit operator bool() const { return Evaluate(); }
 
-  friend Formula operator&&(const Formula& f1, const Formula& f2);
-  friend Formula operator&&(const Variable& v, const Formula& f);
-  friend Formula operator&&(const Formula& f, const Variable& v);
-  friend Formula operator&&(const Variable& v1, const Variable& v2);
-  friend Formula operator||(const Formula& f1, const Formula& f2);
-  friend Formula operator||(const Variable& v, const Formula& f);
-  friend Formula operator||(const Formula& f, const Variable& v);
-  friend Formula operator||(const Variable& v1, const Variable& v2);
-  friend Formula operator!(const Formula& f);
-  friend Formula operator!(const Variable& v);
-  friend Formula operator==(const Expression& e1, const Expression& e2);
-  friend Formula operator!=(const Expression& e1, const Expression& e2);
-  friend Formula operator<(const Expression& e1, const Expression& e2);
-  friend Formula operator<=(const Expression& e1, const Expression& e2);
-  friend Formula operator>(const Expression& e1, const Expression& e2);
-  friend Formula operator>=(const Expression& e1, const Expression& e2);
-
   friend std::ostream& operator<<(std::ostream& os, const Formula& f);
   friend void swap(Formula& a, Formula& b) { std::swap(a.ptr_, b.ptr_); }
 
@@ -216,7 +199,6 @@ class Formula {
   // Note that the following cast functions are only for low-level operations
   // and not exposed to the user of symbolic_formula.h. These functions are
   // declared in symbolic_formula_cell.h header.
-
   friend std::shared_ptr<FormulaFalse> to_false(const Formula& f);
   friend std::shared_ptr<FormulaTrue> to_true(const Formula& f);
   friend std::shared_ptr<FormulaVar> to_variable(const Formula& f);
@@ -244,10 +226,33 @@ class Formula {
 /** Returns a formula @p f, universally quantified by variables @p vars. */
 Formula forall(const Variables& vars, const Formula& f);
 
+/** Returns a conjunction of @p formulas. It performs the following
+ * simplification:
+ *
+ * - make_conjunction({}) returns True.
+ * - make_conjunction({f₁}) returns f₁.
+ * - If False ∈ @p formulas, it returns False.
+ * - If True ∈ @p formulas, it will not appear in the return value.
+ * - Nested conjunctions will be flattened. For example, make_conjunction({f₁,
+ *   f₂ ∧ f₃}) returns f₁ ∧ f₂ ∧ f₃.
+ */
+Formula make_conjunction(const std::set<Formula>& formulas);
 Formula operator&&(const Formula& f1, const Formula& f2);
 Formula operator&&(const Variable& v, const Formula& f);
 Formula operator&&(const Formula& f, const Variable& v);
 Formula operator&&(const Variable& v1, const Variable& v2);
+
+/** Returns a disjunction of @p formulas. It performs the following
+ * simplification:
+ *
+ * - make_disjunction({}) returns False.
+ * - make_disjunction({f₁}) returns f₁.
+ * - If True ∈ @p formulas, it returns True.
+ * - If False ∈ @p formulas, it will not appear in the return value.
+ * - Nested disjunctions will be flattened. For example, make_disjunction({f₁,
+ *   f₂ ∨ f₃}) returns f₁ ∨ f₂ ∨ f₃.
+ */
+Formula make_disjunction(const std::set<Formula>& formulas);
 Formula operator||(const Formula& f1, const Formula& f2);
 Formula operator||(const Variable& v, const Formula& f);
 Formula operator||(const Formula& f, const Variable& v);

--- a/drake/common/symbolic_formula_cell.cc
+++ b/drake/common/symbolic_formula_cell.cc
@@ -663,6 +663,20 @@ bool is_positive_semidefinite(const FormulaCell& f) {
   return f.get_kind() == FormulaKind::PositiveSemidefinite;
 }
 
+shared_ptr<FormulaFalse> to_false(const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_false(*f_ptr));
+  return static_pointer_cast<FormulaFalse>(f_ptr);
+}
+
+shared_ptr<FormulaFalse> to_false(const Formula& f) { return to_false(f.ptr_); }
+
+shared_ptr<FormulaTrue> to_true(const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_true(*f_ptr));
+  return static_pointer_cast<FormulaTrue>(f_ptr);
+}
+
+shared_ptr<FormulaTrue> to_true(const Formula& f) { return to_true(f.ptr_); }
+
 shared_ptr<FormulaVar> to_variable(const shared_ptr<FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_variable(*f_ptr));
   return static_pointer_cast<FormulaVar>(f_ptr);
@@ -682,6 +696,62 @@ shared_ptr<RelationalFormulaCell> to_relational(const Formula& f) {
   return to_relational(f.ptr_);
 }
 
+shared_ptr<FormulaEq> to_equal_to(const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_equal_to(*f_ptr));
+  return static_pointer_cast<FormulaEq>(f_ptr);
+}
+
+shared_ptr<FormulaEq> to_equal_to(const Formula& f) {
+  return to_equal_to(f.ptr_);
+}
+
+shared_ptr<FormulaNeq> to_not_equal_to(const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_not_equal_to(*f_ptr));
+  return static_pointer_cast<FormulaNeq>(f_ptr);
+}
+
+shared_ptr<FormulaNeq> to_not_equal_to(const Formula& f) {
+  return to_not_equal_to(f.ptr_);
+}
+
+shared_ptr<FormulaGt> to_greater_than(const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_greater_than(*f_ptr));
+  return static_pointer_cast<FormulaGt>(f_ptr);
+}
+
+shared_ptr<FormulaGt> to_greater_than(const Formula& f) {
+  return to_greater_than(f.ptr_);
+}
+
+shared_ptr<FormulaGeq> to_greater_than_or_equal_to(
+    const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_greater_than_or_equal_to(*f_ptr));
+  return static_pointer_cast<FormulaGeq>(f_ptr);
+}
+
+shared_ptr<FormulaGeq> to_greater_than_or_equal_to(const Formula& f) {
+  return to_greater_than_or_equal_to(f.ptr_);
+}
+
+shared_ptr<FormulaLt> to_less_than(const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_less_than(*f_ptr));
+  return static_pointer_cast<FormulaLt>(f_ptr);
+}
+
+shared_ptr<FormulaLt> to_less_than(const Formula& f) {
+  return to_less_than(f.ptr_);
+}
+
+shared_ptr<FormulaLeq> to_less_than_or_equal_to(
+    const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_less_than_or_equal_to(*f_ptr));
+  return static_pointer_cast<FormulaLeq>(f_ptr);
+}
+
+shared_ptr<FormulaLeq> to_less_than_or_equal_to(const Formula& f) {
+  return to_less_than_or_equal_to(f.ptr_);
+}
+
 shared_ptr<NaryFormulaCell> to_nary(const shared_ptr<FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_nary(*f_ptr));
   return static_pointer_cast<NaryFormulaCell>(f_ptr);
@@ -689,6 +759,24 @@ shared_ptr<NaryFormulaCell> to_nary(const shared_ptr<FormulaCell>& f_ptr) {
 
 shared_ptr<NaryFormulaCell> to_nary(const Formula& f) {
   return to_nary(f.ptr_);
+}
+
+shared_ptr<FormulaAnd> to_conjunction(const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_conjunction(*f_ptr));
+  return static_pointer_cast<FormulaAnd>(f_ptr);
+}
+
+shared_ptr<FormulaAnd> to_conjunction(const Formula& f) {
+  return to_conjunction(f.ptr_);
+}
+
+shared_ptr<FormulaOr> to_disjunction(const shared_ptr<FormulaCell>& f_ptr) {
+  DRAKE_ASSERT(is_disjunction(*f_ptr));
+  return static_pointer_cast<FormulaOr>(f_ptr);
+}
+
+shared_ptr<FormulaOr> to_disjunction(const Formula& f) {
+  return to_disjunction(f.ptr_);
 }
 
 shared_ptr<FormulaNot> to_negation(const shared_ptr<FormulaCell>& f_ptr) {

--- a/drake/common/symbolic_formula_cell.h
+++ b/drake/common/symbolic_formula_cell.h
@@ -453,80 +453,185 @@ bool is_isnan(const FormulaCell& f);
 /** Checks if @p f is a positive semidefinite formula. */
 bool is_positive_semidefinite(const FormulaCell& f);
 
-/** Casts @p f_ptr of shared_ptr<FormulaCell> to
- * @c shared_ptr<FormulaVar>.
+/** Casts @p f_ptr to @c shared_ptr<FormulaFalse>.
+ * @pre @c is_false(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaFalse> to_false(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+/** Casts @p f to @c shared_ptr<FormulaFalse>.
+ * @pre @c is_false(f) is true.
+ */
+std::shared_ptr<FormulaFalse> to_false(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaTrue>.
+ * @pre @c is_true(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaTrue> to_true(const std::shared_ptr<FormulaCell>& f_ptr);
+/** Casts @p f to @c shared_ptr<FormulaTrue>.
+ * @pre @c is_true(f) is true.
+ */
+std::shared_ptr<FormulaTrue> to_true(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaVar>.
  * @pre @c is_variable(*f_ptr) is true.
  */
 std::shared_ptr<FormulaVar> to_variable(
     const std::shared_ptr<FormulaCell>& f_ptr);
+/** Casts @p f to @c shared_ptr<FormulaVar>.
+ * @pre @c is_variable(f) is true.
+ */
+std::shared_ptr<FormulaVar> to_variable(const Formula& f);
 
-/** Casts @p f_ptr of shared_ptr<FormulaCell> to
- * @c shared_ptr<RelationalFormulaCell>.
- *  \pre{@c is_relational(*f_ptr) is true.}
+/** Casts @p f_ptr to @c shared_ptr<RelationalFormulaCell>.
+ * @pre @c is_relational(*f_ptr) is true.
  */
 std::shared_ptr<RelationalFormulaCell> to_relational(
     const std::shared_ptr<FormulaCell>& f_ptr);
 
-/** Casts @p f of Formula to
- * @c shared_ptr<RelationalFormulaCell>.
- *  \pre{@c is_relational(f) is true.}
+/** Casts @p f to @c shared_ptr<RelationalFormulaCell>.
+ * @pre @c is_relational(f) is true.
  */
 std::shared_ptr<RelationalFormulaCell> to_relational(const Formula& f);
 
-/** Casts @p f_ptr of shared_ptr<FormulaCell>
- * to @c shared_ptr<NaryFormulaCell>.
- *  \pre{@c is_nary(*f_ptr) is true.}
+/** Casts @p f_ptr to @c shared_ptr<FormulaEq>.
+ * @pre @c is_equal_to(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaEq> to_equal_to(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+
+/** Casts @p f to @c shared_ptr<FormulaEq>.
+ * @pre @c is_equal_to(f) is true.
+ */
+std::shared_ptr<FormulaEq> to_equal_to(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaNeq>.
+ * @pre @c is_not_equal_to(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaNeq> to_not_equal_to(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+
+/** Casts @p f to @c shared_ptr<FormulaNeq>.
+ * @pre @c is_not_equal_to(f) is true.
+ */
+std::shared_ptr<FormulaNeq> to_not_equal_to(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaGt>.
+ * @pre @c is_greater_than(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaGt> to_greater_than(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+
+/** Casts @p f to @c shared_ptr<FormulaGt>.
+ * @pre @c is_greater_than(f) is true.
+ */
+std::shared_ptr<FormulaGt> to_greater_than(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaGeq>.
+ * @pre @c is_greater_than_or_equal_to(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaGeq> to_greater_than_or_equal_to(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+
+/** Casts @p f to @c shared_ptr<FormulaGeq>.
+ * @pre @c is_greater_than_or_equal_to(f) is true.
+ */
+std::shared_ptr<FormulaGeq> to_greater_than_or_equal_to(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaLt>.
+ * @pre @c is_less_than(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaLt> to_less_than(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+
+/** Casts @p f to @c shared_ptr<FormulaLt>.
+ * @pre @c is_less_than(f) is true.
+ */
+std::shared_ptr<FormulaLt> to_less_than(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaLeq>.
+ * @pre @c is_less_than_or_equal_to(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaLeq> to_less_than_or_equal_to(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+
+/** Casts @p f to @c shared_ptr<FormulaLeq>.
+ * @pre @c is_less_than_or_equal_to(f) is true.
+ */
+std::shared_ptr<FormulaLeq> to_less_than_or_equal_to(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaAnd>.
+ * @pre @c is_conjunction(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaAnd> to_conjunction(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+
+/** Casts @p f to @c shared_ptr<FormulaAnd>.
+ * @pre @c is_conjunction(f) is true.
+ */
+std::shared_ptr<FormulaAnd> to_conjunction(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<FormulaOr>.
+ * @pre @c is_disjunction(*f_ptr) is true.
+ */
+std::shared_ptr<FormulaOr> to_disjunction(
+    const std::shared_ptr<FormulaCell>& f_ptr);
+
+/** Casts @p f to @c shared_ptr<FormulaOr>.
+ * @pre @c is_disjunction(f) is true.
+ */
+std::shared_ptr<FormulaOr> to_disjunction(const Formula& f);
+
+/** Casts @p f_ptr to @c shared_ptr<NaryFormulaCell>.
+ * @pre @c is_nary(*f_ptr) is true.
  */
 std::shared_ptr<NaryFormulaCell> to_nary(
     const std::shared_ptr<FormulaCell>& f_ptr);
 
-/** Casts @p f of Formula to @c shared_ptr<NaryFormulaCell>.
- *  \pre{@c is_nary(f) is true.}
+/** Casts @p f to @c shared_ptr<NaryFormulaCell>.
+ * @pre @c is_nary(f) is true.
  */
 std::shared_ptr<NaryFormulaCell> to_nary(const Formula& f);
 
-/** Casts @p f_ptr of shared_ptr<FormulaCell> to @c shared_ptr<FormulaNot>.
- *  \pre{@c is_negation(*f_ptr) is true.}
+/** Casts @p f_ptr to @c shared_ptr<FormulaNot>.
+ *  @pre @c is_negation(*f_ptr) is true.
  */
 std::shared_ptr<FormulaNot> to_negation(
     const std::shared_ptr<FormulaCell>& f_ptr);
 
-/** Casts @p f of Formula to @c shared_ptr<FormulaNot>.
- *  \pre{@c is_negation(f) is true.}
+/** Casts @p f to @c shared_ptr<FormulaNot>.
+ *  @pre @c is_negation(f) is true.
  */
 std::shared_ptr<FormulaNot> to_negation(const Formula& f);
 
-/** Casts @p f_ptr of shared_ptr<FormulaCell> to @c shared_ptr<FormulaForall>.
- *  \pre{@c is_forall(*f_ptr) is true.}
+/** Casts @p f_ptr to @c shared_ptr<FormulaForall>.
+ *  @pre @c is_forall(*f_ptr) is true.
  */
 std::shared_ptr<FormulaForall> to_forall(
     const std::shared_ptr<FormulaCell>& f_ptr);
 
-/** Casts @p f of Formula to @c shared_ptr<FormulaForall>.
- *  \pre{@c is_forall(f) is true.}
+/** Casts @p f to @c shared_ptr<FormulaForall>.
+ *  @pre @c is_forall(f) is true.
  */
 std::shared_ptr<FormulaForall> to_forall(const Formula& f);
 
-/** Casts @p f_ptr of shared_ptr<FormulaCell> to @c shared_ptr<FormulaIsnan>.
- *  \pre{@c is_isnan(*f_ptr) is true.}
+/** Casts @p f_ptr to @c shared_ptr<FormulaIsnan>.
+ *  @pre @c is_isnan(*f_ptr) is true.
  */
 std::shared_ptr<FormulaIsnan> to_isnan(
     const std::shared_ptr<FormulaCell>& f_ptr);
 
-/** Casts @p f of Formula to @c shared_ptr<FormulaIsnan>.
- *  \pre{@c is_isnan(f) is true.}
+/** Casts @p f to @c shared_ptr<FormulaIsnan>.
+ *  @pre @c is_isnan(f) is true.
  */
 std::shared_ptr<FormulaIsnan> to_isnan(const Formula& f);
 
-/** Casts @p f_ptr of shared_ptr<FormulaCell> to @c
- * shared_ptr<FormulaPositiveSemidefinite>.
+/** Casts @p f_ptr to @c shared_ptr<FormulaPositiveSemidefinite>.
  * @pre @c is_positive_semidefinite(*f_ptr) is true.
  */
 std::shared_ptr<FormulaPositiveSemidefinite> to_positive_semidefinite(
     const std::shared_ptr<FormulaCell>& f_ptr);
 
-/** Casts @p f of Formula to @c shared_ptr<FormulaPositiveSemidefinite>.
- *
+/** Casts @p f to @c shared_ptr<FormulaPositiveSemidefinite>.
  *  @pre @c is_positive_semidefinite(f) is true.
  */
 std::shared_ptr<FormulaPositiveSemidefinite> to_positive_semidefinite(

--- a/drake/common/symbolic_formula_visitor.cc
+++ b/drake/common/symbolic_formula_visitor.cc
@@ -1,0 +1,4 @@
+#include "drake/common/symbolic_formula_visitor.h"
+
+// For now, this is an empty .cc file that only serves to confirm that
+// symbolic_formula_visitor.h is a stand-alone header.

--- a/drake/common/symbolic_formula_visitor.h
+++ b/drake/common/symbolic_formula_visitor.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/symbolic_formula.h"
+#include "drake/common/symbolic_formula_cell.h"
+
+namespace drake {
+namespace symbolic {
+
+/// Calls visitor object @p v with a symbolic formula @p f, and arguments @p
+/// args. Visitor object is expected to implement <tt>Result operator(...)</tt>
+/// which takes a shared pointer of a class in FormulaCell's inheritance
+/// hierarchy.
+///
+/// Check the implementation of @c NegationNormalFormConverter class in
+/// drake/common/test/symbolic_formula_visitor_test.cc file to find an example.
+template <typename Result, typename Visitor, typename... Args>
+Result VisitFormula(const Visitor& v, const Formula& f, Args&&... args) {
+  switch (f.get_kind()) {
+    case FormulaKind::False:
+      return v(to_false(f), std::forward<Args>(args)...);
+    case FormulaKind::True:
+      return v(to_true(f), std::forward<Args>(args)...);
+    case FormulaKind::Var:
+      return v(to_variable(f), std::forward<Args>(args)...);
+    case FormulaKind::Eq:
+      return v(to_equal_to(f), std::forward<Args>(args)...);
+    case FormulaKind::Neq:
+      return v(to_not_equal_to(f), std::forward<Args>(args)...);
+    case FormulaKind::Gt:
+      return v(to_greater_than(f), std::forward<Args>(args)...);
+    case FormulaKind::Geq:
+      return v(to_greater_than_or_equal_to(f), std::forward<Args>(args)...);
+    case FormulaKind::Lt:
+      return v(to_less_than(f), std::forward<Args>(args)...);
+    case FormulaKind::Leq:
+      return v(to_less_than_or_equal_to(f), std::forward<Args>(args)...);
+    case FormulaKind::And:
+      return v(to_conjunction(f), std::forward<Args>(args)...);
+    case FormulaKind::Or:
+      return v(to_disjunction(f), std::forward<Args>(args)...);
+    case FormulaKind::Not:
+      return v(to_negation(f), std::forward<Args>(args)...);
+    case FormulaKind::Forall:
+      return v(to_forall(f), std::forward<Args>(args)...);
+    case FormulaKind::Isnan:
+      return v(to_isnan(f), std::forward<Args>(args)...);
+    case FormulaKind::PositiveSemidefinite:
+      return v(to_positive_semidefinite(f), std::forward<Args>(args)...);
+  }
+  // Should not be reachable. But we need the following to avoid "control
+  // reaches end of non-void function" gcc-warning.
+  DRAKE_ABORT();
+}
+
+}  // namespace symbolic
+}  // namespace drake

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -87,6 +87,9 @@ target_link_libraries(symbolic_mixing_scalar_types_test drakeCommon)
 drake_add_cc_test(symbolic_formula_test)
 target_link_libraries(symbolic_formula_test drakeCommon)
 
+drake_add_cc_test(symbolic_formula_visitor_test)
+target_link_libraries(symbolic_formula_visitor_test drakeCommon)
+
 drake_add_cc_test(sorted_vectors_have_intersection_test)
 target_link_libraries(sorted_vectors_have_intersection_test drakeCommon)
 

--- a/drake/common/test/symbolic_formula_test.cc
+++ b/drake/common/test/symbolic_formula_test.cc
@@ -566,6 +566,13 @@ TEST_F(SymbolicFormulaTest, And1) {
   EXPECT_PRED2(FormulaEqual, ff_, ff_ && ff_);
   EXPECT_PRED2(FormulaEqual, f1_, tt_ && f1_);
   EXPECT_PRED2(FormulaEqual, f1_, f1_ && tt_);
+  EXPECT_PRED2(FormulaEqual, make_conjunction({tt_, f1_, tt_}), f1_);
+  EXPECT_PRED2(FormulaEqual, make_conjunction({tt_, tt_, ff_}), ff_);
+  // Checks if flattening works: (f₁ ∧ f₂) ∧ (f₃ ∧ f₄) => f₁ ∧ f₂ ∧ f₃ ∧ f₄.
+  EXPECT_PRED2(FormulaEqual, make_conjunction({f1_ && f2_, f3_ && f4_}),
+               make_conjunction({f1_, f2_, f3_, f4_}));
+  // Empty conjunction = True.
+  EXPECT_PRED2(FormulaEqual, make_conjunction({}), Formula::True());
 }
 
 TEST_F(SymbolicFormulaTest, And2) {
@@ -648,6 +655,13 @@ TEST_F(SymbolicFormulaTest, Or1) {
   EXPECT_PRED2(FormulaEqual, ff_, ff_ || ff_);
   EXPECT_PRED2(FormulaEqual, f1_, ff_ || f1_);
   EXPECT_PRED2(FormulaEqual, f1_, f1_ || ff_);
+  EXPECT_PRED2(FormulaEqual, make_disjunction({ff_, f1_, ff_}), f1_);
+  EXPECT_PRED2(FormulaEqual, make_disjunction({ff_, ff_, tt_}), tt_);
+  // Checks if flattening works: (f₁ ∨ f₂) ∨ (f₃ ∨ f₄) => f₁ ∨ f₂ ∨ f₃ ∨ f₄.
+  EXPECT_PRED2(FormulaEqual, make_disjunction({f1_ || f2_, f3_ || f4_}),
+               make_disjunction({f1_, f2_, f3_, f4_}));
+  // Empty disjunction = False.
+  EXPECT_PRED2(FormulaEqual, make_disjunction({}), Formula::False());
 }
 
 TEST_F(SymbolicFormulaTest, Or2) {

--- a/drake/common/test/symbolic_formula_visitor_test.cc
+++ b/drake/common/test/symbolic_formula_visitor_test.cc
@@ -1,0 +1,272 @@
+#include "drake/common/symbolic_formula_visitor.h"
+
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <set>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/symbolic_formula.h"
+#include "drake/common/symbolic_formula_cell.h"
+#include "drake/common/symbolic_variable.h"
+#include "drake/common/test/symbolic_test_util.h"
+
+namespace drake {
+namespace symbolic {
+namespace {
+
+using std::function;
+using std::inserter;
+using std::make_shared;
+using std::set;
+using std::shared_ptr;
+
+using test::FormulaEqual;
+
+// A class implementing NNF (Negation Normal Form) conversion. See
+// https://en.wikipedia.org/wiki/Negation_normal_form for more information on
+// NNF.
+//
+// TODO(soonho-tri): Consider moving this class into a separate file in
+// `drake/common` directory when we have a use-case of this class in Drake. For
+// now, we have it here to test `drake/common/symbolic_formula_visitor.h`.
+class NegationNormalFormConverter {
+ public:
+  // Converts @p f into an equivalent formula @c f' in NNF.
+  Formula Visit(const Formula& f) const { return Visit(f, true); }
+
+  Formula operator()(const shared_ptr<FormulaFalse>& f,
+                     const bool polarity) const {
+    // NNF(False) = False
+    // NNF(¬False) = True
+    return polarity ? Formula::False() : Formula::True();
+  }
+  Formula operator()(const shared_ptr<FormulaTrue>& f,
+                     const bool polarity) const {
+    // NNF(True) = True
+    // NNF(¬True) = False
+    return polarity ? Formula::True() : Formula::False();
+  }
+  Formula operator()(const shared_ptr<FormulaVar>& f,
+                     const bool polarity) const {
+    // NNF(b) = b
+    // NNF(¬b) = ¬b
+    return polarity ? Formula{f} : !Formula{f};
+  }
+  Formula operator()(const shared_ptr<FormulaEq>& f,
+                     const bool polarity) const {
+    // NNF(e1 = e2) = (e1 = e2)
+    // NNF(¬(e1 = e2)) = (e1 != e2)
+    return polarity ? Formula{f}
+                    : f->get_lhs_expression() != f->get_rhs_expression();
+  }
+  Formula operator()(const shared_ptr<FormulaNeq>& f,
+                     const bool polarity) const {
+    // NNF(e1 != e2)    = (e1 != e2)
+    // NNF(¬(e1 != e2)) = (e1 = e2)
+    return polarity ? Formula{f}
+                    : f->get_lhs_expression() == f->get_rhs_expression();
+  }
+  Formula operator()(const shared_ptr<FormulaGt>& f,
+                     const bool polarity) const {
+    // NNF(e1 > e2)    = (e1 > e2)
+    // NNF(¬(e1 > e2)) = (e1 <= e2)
+    return polarity ? Formula{f}
+                    : f->get_lhs_expression() <= f->get_rhs_expression();
+  }
+  Formula operator()(const shared_ptr<FormulaGeq>& f,
+                     const bool polarity) const {
+    // NNF(e1 >= e2)    = (e1 >= e2)
+    // NNF(¬(e1 >= e2)) = (e1 < e2)
+    return polarity ? Formula{f}
+                    : f->get_lhs_expression() < f->get_rhs_expression();
+  }
+  Formula operator()(const shared_ptr<FormulaLt>& f,
+                     const bool polarity) const {
+    // NNF(e1 < e2)    = (e1 < e2)
+    // NNF(¬(e1 < e2)) = (e1 >= e2)
+    return polarity ? Formula{f}
+                    : f->get_lhs_expression() >= f->get_rhs_expression();
+  }
+  Formula operator()(const shared_ptr<FormulaLeq>& f,
+                     const bool polarity) const {
+    // NNF(e1 <= e2)    = (e1 <= e2)
+    // NNF(¬(e1 <= e2)) = (e1 > e2)
+    return polarity ? Formula{f}
+                    : f->get_lhs_expression() > f->get_rhs_expression();
+  }
+  Formula operator()(const shared_ptr<FormulaAnd>& f,
+                     const bool polarity) const {
+    // NNF(f₁ ∧ ... ∨ fₙ)    = NNF(f₁) ∧ ... ∧ NNF(fₙ)
+    // NNF(¬(f₁ ∧ ... ∨ fₙ)) = NNF(¬f₁) ∨ ... ∨ NNF(¬fₙ)
+    const set<Formula> new_operands{
+        map(f->get_operands(), [this, &polarity](const Formula& formula) {
+          return this->Visit(formula, polarity);
+        })};
+    return polarity ? make_conjunction(new_operands)
+                    : make_disjunction(new_operands);
+  }
+  Formula operator()(const shared_ptr<FormulaOr>& f,
+                     const bool polarity) const {
+    // NNF(f₁ ∨ ... ∨ fₙ)    = NNF(f₁) ∨ ... ∨ NNF(fₙ)
+    // NNF(¬(f₁ ∨ ... ∨ fₙ)) = NNF(¬f₁) ∧ ... ∧ NNF(¬fₙ)
+    const set<Formula> new_operands{
+        map(f->get_operands(), [this, &polarity](const Formula& formula) {
+          return this->Visit(formula, polarity);
+        })};
+    return polarity ? make_disjunction(new_operands)
+                    : make_conjunction(new_operands);
+  }
+  Formula operator()(const shared_ptr<FormulaNot>& f,
+                     const bool polarity) const {
+    // NNF(¬f, ⊤) = NNF(f, ⊥)
+    // NNF(¬f, ⊥) = NNF(f, ⊤)
+    return Visit(f->get_operand(), !polarity);
+  }
+  Formula operator()(const shared_ptr<FormulaForall>& f,
+                     const bool polarity) const {
+    // NNF(∀v₁...vₙ. f)    =  ∀v₁...vₙ. f
+    // NNF(¬(∀v₁...vₙ. f)) = ¬∀v₁...vₙ. f
+    // TODO(soonho-tri): The second case be further reduced into
+    // ∃v₁...vₙ. NNF(¬f). However, we do not have a representation
+    // FormulaExists(∃) yet. Revisit this when we add FormulaExists.
+    return polarity ? Formula{f} : !Formula{f};
+  }
+  Formula operator()(const shared_ptr<FormulaIsnan>& f,
+                     const bool polarity) const {
+    // NNF(isnan(f))  =  isnan(f)
+    // NNF(¬isnan(f)) = ¬isnan(f)
+    return polarity ? Formula{f} : !Formula{f};
+  }
+  Formula operator()(const shared_ptr<FormulaPositiveSemidefinite>& f,
+                     const bool polarity) const {
+    // NNF(psd(M))  =  psd(M)
+    // NNF(¬psd(M)) = ¬psd(M)
+    return polarity ? Formula{f} : !Formula{f};
+  }
+
+ private:
+  // Given formulas = {f₁, ..., fₙ} and a func : Formula → Formula,
+  // map(formulas, func) returns a set {func(f₁), ... func(fₙ)}.
+  set<Formula> map(const set<Formula>& formulas,
+                   const function<Formula(const Formula&)>& func) const {
+    set<Formula> result;
+    transform(formulas.cbegin(), formulas.cend(),
+              inserter(result, result.begin()), func);
+    return result;
+  }
+
+  // Converts @p f into an equivalent formula @c f' in NNF. The parameter @p
+  // polarity is to indicate whether it processes @c f (if @p polarity is
+  // true) or @c ¬f (if @p polarity is false).
+  Formula Visit(const Formula& f, const bool polarity) const {
+    return VisitFormula<Formula>(*this, f, polarity);
+  }
+};
+
+class SymbolicFormulaVisitorTest : public ::testing::Test {
+ protected:
+  const Variable x_{"x", Variable::Type::CONTINUOUS};
+  const Variable y_{"y", Variable::Type::CONTINUOUS};
+  const Variable z_{"z", Variable::Type::CONTINUOUS};
+
+  const Variable b1_{"b1", Variable::Type::BOOLEAN};
+  const Variable b2_{"b2", Variable::Type::BOOLEAN};
+  const Variable b3_{"b3", Variable::Type::BOOLEAN};
+
+  Eigen::Matrix<Expression, 2, 2, Eigen::DontAlign> M_;
+
+  NegationNormalFormConverter converter_;
+
+  void SetUp() override {
+    // clang-format off
+    M_ << (x_ + y_),  -1.0,
+               -1.0,   y_;
+    // clang-format on
+  }
+};
+
+TEST_F(SymbolicFormulaVisitorTest, NNFNoChanges) {
+  // No Changes: True
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(Formula::True()),
+               Formula::True());
+
+  // No Changes: False
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(Formula::False()),
+               Formula::False());
+
+  // No Changes: Variables
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(Formula{b1_}), Formula{b1_});
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!b1_), !b1_);
+
+  // No Changes: x ≥ y ∧ y ≤ z
+  const Formula f1{x_ >= y_ && y_ <= z_};
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(f1), f1);
+
+  // No Changes.: x > y ∨ y < z
+  const Formula f2{x_ > y_ || y_ < z_};
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(f2), f2);
+
+  // No Changes: isnan(x)
+  const Formula f3{isnan(x_)};
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(f3), f3);
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!f3), !f3);
+
+  // No Changes: ∀x. x + y ≥ x
+  const Formula f4{forall({x_}, x_ + y_ >= x_)};
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(f4), f4);
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!f4), !f4);
+
+  // No Changes: psd(M)
+  const Formula psd{positive_semidefinite(M_)};
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(psd), psd);
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!psd), !psd);
+}
+
+TEST_F(SymbolicFormulaVisitorTest, NNFRelational) {
+  // ¬(x ≥ y) ∧ ¬(y ≤ z)  ==>  x < y ∧ y > z
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(x_ >= y_) && !(y_ <= z_)),
+               x_ < y_ && y_ > z_);
+
+  // ¬(x ≥ y ∧ y ≤ z)  ==>  x < y ∨ y > z
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(x_ >= y_ && y_ <= z_)),
+               x_ < y_ || y_ > z_);
+
+  // ¬(x > y) ∨ ¬(y < z)  ==>  x ≤ y ∨ y ≥ z
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(x_ > y_) || !(y_ < z_)),
+               x_ <= y_ || y_ >= z_);
+
+  // ¬(x > y ∨ y < z)  ==>  x ≤ y ∧ y ≥ z
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(x_ > y_ || y_ < z_)),
+               x_ <= y_ && y_ >= z_);
+
+  // ¬(x ≠ y) ∧ ¬(y = z)  ==>  x = y ∧ y ≠ z
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(x_ != y_) && !(y_ == z_)),
+               x_ == y_ && y_ != z_);
+
+  // ¬(x ≠ y ∧ y = z)  ==>  x = y ∨ y ≠ z
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(x_ != y_ && y_ == z_)),
+               x_ == y_ || y_ != z_);
+}
+
+TEST_F(SymbolicFormulaVisitorTest, NNFBoolean) {
+  // ¬(b₁ ∨ ¬(b₂ ∧ b₃))  ==>  ¬b₁ ∧ b₂ ∧ b₃
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(b1_ || !(b2_ && b3_))),
+               !b1_ && b2_ && b3_);
+
+  // ¬(b₁ ∨ ¬(b₂ ∨ b₃))  ==>  ¬b₁ ∧ (b₂ ∨ b₃)
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(b1_ || !(b2_ || b3_))),
+               !b1_ && (b2_ || b3_));
+
+  // ¬(b₁ ∧ ¬(b₂ ∨ b₃))  ==>  ¬b₁ ∨ b₂ ∨ b₃
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(b1_ && !(b2_ || b3_))),
+               !b1_ || b2_ || b3_);
+
+  // ¬(b₁ ∧ ¬(b₂ ∧ b₃))  ==>  ¬b₁ ∨ (b₂ ∧ b₃)
+  EXPECT_PRED2(FormulaEqual, converter_.Visit(!(b1_ && !(b2_ && b3_))),
+               !b1_ || (b2_ && b3_));
+}
+}  // namespace
+}  // namespace symbolic
+}  // namespace drake


### PR DESCRIPTION
This is a step toward SMT supports. A suggested sequence of reviews is:

 - `to_<FormulaClass>` functions such as `to_true` in `symbolic_formula.h` and `symbolic_formula_cell.{h,cc}`.
 - `make_conjunction` and `make_disjunction` in `symbolic_formula.{h,cc}`.
 - `symbolic_formula_visitor.h`. I've added a NNFConverter as a usage case of the visitor.

I've run `kcov` and checked that we have 100% coverage for the added code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6183)
<!-- Reviewable:end -->
