### PR TITLE
Teach drake bazel rules to play nicely when drake is an external bazel project

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,10 +16,15 @@
 
 workspace(name = "drake")
 
-load("//tools/third_party/kythe/tools/build_rules/config:pkg_config.bzl", "pkg_config_package")
 load("//tools:bitbucket.bzl", "bitbucket_archive")
 load("//tools:github.bzl", "github_archive")
 load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+
+local_repository(
+    name = "kythe",
+    path = "tools/third_party/kythe",
+)
+load("@kythe//tools/build_rules/config:pkg_config.bzl", "pkg_config_package")
 
 pkg_config_package(
     name = "glib",

--- a/tools/bot_core_lcmtypes.BUILD
+++ b/tools/bot_core_lcmtypes.BUILD
@@ -2,7 +2,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")
+load("@drake//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")
 
 lcm_cc_library(
     name = "bot_core_lcmtypes",

--- a/tools/ccd.BUILD
+++ b/tools/ccd.BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
+load("@drake//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
 # Generates config.h based on the defines= we want in Drake.
 cmake_configure_file(

--- a/tools/eigen.BUILD
+++ b/tools/eigen.BUILD
@@ -1,7 +1,7 @@
 # -*- python -*-
 
-load("@//tools:install.bzl", "install", "install_files")
-load("@//tools:python_lint.bzl", "python_lint")
+load("@drake//tools:install.bzl", "install", "install_files")
+load("@drake//tools:python_lint.bzl", "python_lint")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 package(
@@ -25,8 +25,8 @@ cc_library(
 
 py_binary(
     name = "create-cps",
-    srcs = ["@//tools:eigen-create-cps.py"],
-    main = "@//tools:eigen-create-cps.py",
+    srcs = ["@drake//tools:eigen-create-cps.py"],
+    main = "@drake//tools:eigen-create-cps.py",
     visibility = ["//visibility:private"],
 )
 

--- a/tools/fcl.BUILD
+++ b/tools/fcl.BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
+load("@drake//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
 # Generates config.h based on the version numbers in CMake code.
 cmake_configure_file(

--- a/tools/gtest.BUILD
+++ b/tools/gtest.BUILD
@@ -31,7 +31,7 @@ cc_library(
     ],
     linkopts = select({
         "@drake//tools:linux": ["-pthread"],
-        "@//conditions:default": [],
+        "@//conditions:default": [],  # This is a bazel-default rule, and does not need @drake//
     }),
     linkstatic = 1,
     visibility = ["//visibility:public"],

--- a/tools/gtest.BUILD
+++ b/tools/gtest.BUILD
@@ -30,7 +30,7 @@ cc_library(
         "googletest/include",
     ],
     linkopts = select({
-        "@//tools:linux": ["-pthread"],
+        "@drake//tools:linux": ["-pthread"],
         "@//conditions:default": [],
     }),
     linkstatic = 1,

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
+load("@drake//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
 # Generates config.hh based on the version numbers in CMake code.
 cmake_configure_file(

--- a/tools/ipopt.BUILD
+++ b/tools/ipopt.BUILD
@@ -103,7 +103,7 @@ genrule(
     cmd = " ".join([
         "(",
         "env",
-        "cdexec=$(location @drake//tools/third_party/kythe/tools/cdexec:cdexec)",
+        "cdexec=$(location @kythe//tools/cdexec:cdexec)",
         "top_builddir=$(@D)",
         "$(location @drake//tools:ipopt_build_with_autotools.sh)",
         " 2>&1 > ipopt_build_with_autotools.log",
@@ -112,7 +112,7 @@ genrule(
     ]),
     tools = [
         "@drake//tools:ipopt_build_with_autotools.sh",
-        "@drake//tools/third_party/kythe/tools/cdexec:cdexec",
+        "@kythe//tools/cdexec:cdexec",
     ],
     visibility = ["//visibility:private"],
 )

--- a/tools/ipopt.BUILD
+++ b/tools/ipopt.BUILD
@@ -103,16 +103,16 @@ genrule(
     cmd = " ".join([
         "(",
         "env",
-        "cdexec=$(location @//tools/third_party/kythe/tools/cdexec:cdexec)",
+        "cdexec=$(location @drake//tools/third_party/kythe/tools/cdexec:cdexec)",
         "top_builddir=$(@D)",
-        "tools/ipopt_build_with_autotools.sh",
+        "$(location @drake//tools:ipopt_build_with_autotools.sh)",
         " 2>&1 > ipopt_build_with_autotools.log",
         ")",
         "|| (cat ipopt_build_with_autotools.log && false)",
     ]),
     tools = [
-        "@//tools:ipopt_build_with_autotools.sh",
-        "@//tools/third_party/kythe/tools/cdexec:cdexec",
+        "@drake//tools:ipopt_build_with_autotools.sh",
+        "@drake//tools/third_party/kythe/tools/cdexec:cdexec",
     ],
     visibility = ["//visibility:private"],
 )

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -1,9 +1,9 @@
 # -*- python -*-
 
-load("@//tools:drake.bzl", "drake_generate_file")
-load("@//tools:generate_export_header.bzl", "generate_export_header")
-load("@//tools:install.bzl", "install", "install_files")
-load("@//tools:python_lint.bzl", "python_lint")
+load("@drake//tools:drake.bzl", "drake_generate_file")
+load("@drake//tools:generate_export_header.bzl", "generate_export_header")
+load("@drake//tools:install.bzl", "install", "install_files")
+load("@drake//tools:python_lint.bzl", "python_lint")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
@@ -200,8 +200,8 @@ pkg_tar(
 
 py_binary(
     name = "create-cps",
-    srcs = ["@//tools:lcm-create-cps.py"],
-    main = "@//tools:lcm-create-cps.py",
+    srcs = ["@drake//tools:lcm-create-cps.py"],
+    main = "@drake//tools:lcm-create-cps.py",
     visibility = ["//visibility:private"],
 )
 

--- a/tools/libbot.BUILD
+++ b/tools/libbot.BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@//tools:lcm.bzl", "lcm_java_library", "lcm_py_library")
+load("@drake//tools:lcm.bzl", "lcm_java_library", "lcm_py_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/nlopt.BUILD
+++ b/tools/nlopt.BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
+load("@drake//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
 # Chooses the nlopt preprocessor substitutions that we want to use from Bazel.
 cmake_configure_file(
@@ -50,9 +50,9 @@ genrule(
         "api/nlopt.h",
     ],
     outs = ["api/nlopt.hpp"],
-    cmd = "$(location @//tools:nlopt-gen-hpp.sh) $(SRCS) $(OUTS) 2>&1 1>log" +
+    cmd = "$(location @drake//tools:nlopt-gen-hpp.sh) $(SRCS) $(OUTS) 2>&1 1>log" +
           " || (cat log && false)",
-    tools = ["@//tools:nlopt-gen-hpp.sh"],
+    tools = ["@drake//tools:nlopt-gen-hpp.sh"],
 )
 
 cc_library(

--- a/tools/robotlocomotion_lcmtypes.BUILD
+++ b/tools/robotlocomotion_lcmtypes.BUILD
@@ -2,7 +2,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")
+load("@drake//tools:lcm.bzl", "lcm_cc_library", "lcm_py_library")
 
 lcm_cc_library(
     name = "robotlocomotion_lcmtypes",

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@//tools:cmake_configure_file.bzl", "cmake_configure_file")
+load("@drake//tools:cmake_configure_file.bzl", "cmake_configure_file")
 
 # Generates sdf_config.h based on the version numbers in CMake code.
 cmake_configure_file(

--- a/tools/semantic_version.BUILD
+++ b/tools/semantic_version.BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@//tools:drake.bzl", "drake_generate_file")
+load("@drake//tools:drake.bzl", "drake_generate_file")
 
 py_library(
     name = "semantic_version",

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -16,7 +16,7 @@ cc_library(
     includes = ["include"],
     linkopts = select({
         "@drake//tools:linux": ["-pthread"],
-        "@//conditions:default": [],
+        "@//conditions:default": [],  # This is a bazel-default rule, and does not need @drake//
     }),
     deps = ["@fmt"],
 )

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -15,7 +15,7 @@ cc_library(
     ],
     includes = ["include"],
     linkopts = select({
-        "@//tools:linux": ["-pthread"],
+        "@drake//tools:linux": ["-pthread"],
         "@//conditions:default": [],
     }),
     deps = ["@fmt"],

--- a/tools/third_party/kythe/WORKSPACE
+++ b/tools/third_party/kythe/WORKSPACE
@@ -1,0 +1,6 @@
+# -*- python -*-
+
+# This file marks a workspace root for the Bazel build system. see
+# http://bazel.io/ .
+
+workspace(name = "kythe")

--- a/tools/third_party/kythe/tools/build_rules/config/local.bzl
+++ b/tools/third_party/kythe/tools/build_rules/config/local.bzl
@@ -50,7 +50,7 @@ local_cc_library_configure = repository_rule(
         "default": attr.string(),
         "defines": attr.string_list(),
         "build_file_template": attr.label(
-            default = Label("@//tools/third_party/kythe/tools/build_rules/config:BUILD.tpl"),
+            default = Label("@kythe//tools/build_rules/config:BUILD.tpl"),
             single_file = True,
             allow_files = True,
         ),

--- a/tools/third_party/kythe/tools/build_rules/config/pkg_config.bzl
+++ b/tools/third_party/kythe/tools/build_rules/config/pkg_config.bzl
@@ -174,7 +174,7 @@ pkg_config_package = repository_rule(
         "max_version": attr.string(),
         "exact_version": attr.string(),
         "build_file_template": attr.label(
-            default = Label("@//tools/third_party/kythe/tools/build_rules/config:BUILD.tpl"),
+            default = Label("@kythe//tools/build_rules/config:BUILD.tpl"),
             single_file = True,
             allow_files = True,
         ),

--- a/tools/third_party/kythe/tools/build_rules/config/system.bzl
+++ b/tools/third_party/kythe/tools/build_rules/config/system.bzl
@@ -17,9 +17,9 @@ cc_system_package:
   repository, whose `:lib` target is then bound to '{name}'.
 """
 
-load("@//tools/third_party/kythe/tools/build_rules/config:wrapped_ctx.bzl", "wrapctx")
-load("@//tools/third_party/kythe/tools/build_rules/config:local.bzl", "setup_local_cc_library")
-load("@//tools/third_party/kythe/tools/build_rules/config:pkg_config.bzl", "setup_pkg_config_package")
+load("@kythe//tools/build_rules/config:wrapped_ctx.bzl", "wrapctx")
+load("@kythe//tools/build_rules/config:local.bzl", "setup_local_cc_library")
+load("@kythe//tools/build_rules/config:pkg_config.bzl", "setup_pkg_config_package")
 
 def try_local_library(repo_ctx):
   if repo_ctx.attr.envvar and repo_ctx.attr.envvar in repo_ctx.os.environ:
@@ -58,7 +58,7 @@ cc_system_package_configure = repository_rule(
         "default": attr.string(),
         "defines": attr.string_list(),
         "build_file_template": attr.label(
-            default = Label("@//tools/third_party/kythe/tools/build_rules/config:BUILD.tpl"),
+            default = Label("@kythe//tools/build_rules/config:BUILD.tpl"),
             single_file = True,
             allow_files = True,
         ),


### PR DESCRIPTION
This change would permit `drake` to be used as an external in a Bazel project, and would permit `drake`'s `tools/...` to be usable outside of `drake`.

This follows the workaround listed [here](https://github.com/bazelbuild/bazel/issues/2757#issuecomment-290448615).

* ~Move all non-rule externals to `@drake//tools:externals.bzl`~
* Replace `@//` with `@drake//`
* Replace `tools/*.BUILD` with `@drake//tools:*.BUILD`

Worked with @stonier to whip up an example project:
* [drake_external/](https://github.com/EricCousineau-TRI/drake_external#testing)
    * This consumes `@drake//drake/automotive:curve2` `@drake//drake/solvers:mathematical_program` externally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6190)
<!-- Reviewable:end -->
