### PR TITLE
Correction In eigen_autodiff_types_test.cc

### DIFF
--- a/drake/common/test/eigen_autodiff_types_test.cc
+++ b/drake/common/test/eigen_autodiff_types_test.cc
@@ -9,10 +9,10 @@ GTEST_TEST(EigenAutodiffTypesTest, CheckingInheritance) {
   typedef Eigen::Matrix<Scalar, 2, 2> Deriv;
   typedef Eigen::AutoDiffScalar<Deriv> AD;
 
-  typedef std::numeric_limits<AD> A;
-  typedef std::numeric_limits<Eigen::AutoDiffScalar<Deriv>> B;
+  typedef std::numeric_limits<AD> ADLimits;
+  typedef std::numeric_limits<Scalar> ScalarLimits;
 
-  bool res = std::is_base_of<A, B>::value;
+  bool res = std::is_base_of<ScalarLimits, ADLimits>::value;
   EXPECT_TRUE(res);
 }
 }  // namespace


### PR DESCRIPTION
While writing a test for upstream I figured that the test is incorrect.
Ref: https://github.com/RobotLocomotion/drake/pull/6057

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6191)
<!-- Reviewable:end -->
