### PR TITLE
RNDF implementation for Maliput

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,8 +236,8 @@ drake_add_external(ignition_math PUBLIC CMAKE
 
 # ignition_rndf
 drake_add_external(ignition_rndf PUBLIC CMAKE
-  URL https://bitbucket.org/ignitionrobotics/ign-rndf/get/ignition-rndf_0.1.2.tar.gz
-  URL_HASH SHA256=e0aa1489311679639717d3614c7c55edaa5f6de9a78c31ea48ea637bc1ba001a
+  URL https://bitbucket.org/ignitionrobotics/ign-rndf/get/ignition-rndf_0.1.5.tar.gz
+  URL_HASH SHA256=fa1033be146ff51f3b2c679ff160838c1e3ca736c565b19510a5c9b6d352fbaf
   CMAKE_ARGS
     -DENABLE_TESTS_COMPILATION=OFF
     -DUSE_HOST_CFLAGS=OFF

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -331,10 +331,10 @@ bitbucket_archive(
 bitbucket_archive(
     name = "ignition_rndf",
     repository = "ignitionrobotics/ign-rndf",
-    commit = "ignition-rndf_0.1.2",
-    sha256 = "e0aa1489311679639717d3614c7c55edaa5f6de9a78c31ea48ea637bc1ba001a",
+    commit = "ignition-rndf_0.1.5",
+    sha256 = "fa1033be146ff51f3b2c679ff160838c1e3ca736c565b19510a5c9b6d352fbaf",
     build_file = "tools/ignition_rndf.BUILD",
-    strip_prefix = "ignitionrobotics-ign-rndf-b20a4f68333f",
+    strip_prefix = "ignitionrobotics-ign-rndf-214a333fbdcb",
 )
 
 bitbucket_archive(

--- a/drake/automotive/maliput/rndf/BUILD
+++ b/drake/automotive/maliput/rndf/BUILD
@@ -6,18 +6,68 @@ load(
     "//tools:drake.bzl",
     "drake_cc_binary",
     "drake_cc_googletest",
-    "drake_cc_library",
+    "drake_cc_library"
 )
 
 package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "lanes",
+    srcs = [
+        "branch_point.cc",
+        "junction.cc",
+        "lane.cc",
+        "road_geometry.cc",
+        "segment.cc",
+        "spline_lane.cc",
+    ],
+    hdrs = [
+        "branch_point.h",
+        "junction.h",
+        "lane.h",
+        "road_geometry.h",
+        "segment.h",
+        "spline_lane.h",
+    ],
+    deps = [
+        "//drake/automotive/maliput/api",
+        "//drake/common",
+        "//drake/math:geometric_transform",
+        "//drake/math:saturate",
+        "@ignition_math",
+    ],
+)
 
 # === test/ ===
 
 drake_cc_googletest(
     name = "ignition_rndf_test",
-    srcs = ["test/ignition_rndf_test.cc"],
     deps = [
         "@ignition_rndf",
+    ],
+)
+
+drake_cc_googletest(
+    name = "junction_test",
+    size = "small",
+    deps = [
+        ":lanes",
+    ],
+)
+
+drake_cc_googletest(
+    name = "road_geometry_test",
+    size = "small",
+    deps = [
+        ":lanes",
+    ],
+)
+
+drake_cc_googletest(
+    name = "segment_test",
+    size = "small",
+    deps = [
+        ":lanes",
     ],
 )
 

--- a/drake/automotive/maliput/rndf/CMakeLists.txt
+++ b/drake/automotive/maliput/rndf/CMakeLists.txt
@@ -1,1 +1,38 @@
-add_subdirectory(test)
+if(ignition-rndf0_FOUND)
+
+    add_library_with_exports(LIB_NAME drakeMaliputRndf SOURCE_FILES
+        branch_point.cc
+        junction.cc
+        lane.cc
+        road_geometry.cc
+        segment.cc
+        spline_lane.cc
+    )
+
+    target_include_directories(drakeMaliputRndf PRIVATE
+        "${IGNITION-RNDF_INCLUDE_DIRS}"
+    )
+
+    target_link_libraries(drakeMaliputRndf
+        drakeCommon
+        drakeAutomotive
+        "${IGNITION-RNDF_LIBRARIES}"
+    )
+
+    drake_install_libraries(drakeMaliputRndf)
+
+    drake_install_headers(
+        branch_point.h
+        junction.h
+        lane.h
+        road_geometry.h
+        segment.h
+        spline_lane.h
+    )
+
+endif()
+
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/drake/automotive/maliput/rndf/branch_point.cc
+++ b/drake/automotive/maliput/rndf/branch_point.cc
@@ -1,0 +1,70 @@
+#include "drake/automotive/maliput/rndf/branch_point.h"
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+BranchPoint::BranchPoint(const api::BranchPointId& id,
+                         api::RoadGeometry* road_geometry)
+    : id_(id), road_geometry_(road_geometry) {}
+
+const api::RoadGeometry* BranchPoint::do_road_geometry() const {
+  return road_geometry_;
+}
+
+const api::LaneEndSet* BranchPoint::DoGetConfluentBranches(
+    const api::LaneEnd& end) const {
+  return confluent_branches_.at(end);
+}
+
+const api::LaneEndSet* BranchPoint::DoGetOngoingBranches(
+    const api::LaneEnd& end) const {
+  return ongoing_branches_.at(end);
+}
+
+std::unique_ptr<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
+    const api::LaneEnd& end) const {
+  auto default_it = defaults_.find(end);
+  if (default_it == defaults_.end()) {
+    return nullptr;
+  }
+  return std::make_unique<api::LaneEnd>(default_it->second);
+}
+
+const api::LaneEnd& BranchPoint::AddABranch(const api::LaneEnd& lane_end) {
+  DRAKE_DEMAND(confluent_branches_.find(lane_end) == confluent_branches_.end());
+  DRAKE_DEMAND(ongoing_branches_.find(lane_end) == ongoing_branches_.end());
+  a_side_.add(lane_end);
+  confluent_branches_[lane_end] = &a_side_;
+  ongoing_branches_[lane_end] = &b_side_;
+  return lane_end;
+}
+
+const api::LaneEnd& BranchPoint::AddBBranch(const api::LaneEnd& lane_end) {
+  DRAKE_DEMAND(confluent_branches_.find(lane_end) == confluent_branches_.end());
+  DRAKE_DEMAND(ongoing_branches_.find(lane_end) == ongoing_branches_.end());
+  b_side_.add(lane_end);
+  confluent_branches_[lane_end] = &b_side_;
+  ongoing_branches_[lane_end] = &a_side_;
+  return lane_end;
+}
+
+void BranchPoint::SetDefault(const api::LaneEnd& lane_end,
+                             const api::LaneEnd& default_branch) {
+  const auto& le_ongoing = ongoing_branches_.find(lane_end);
+  const auto& db_confluent = confluent_branches_.find(default_branch);
+  // Verify that lane_end belongs to this BranchPoint.
+  DRAKE_DEMAND(le_ongoing != ongoing_branches_.end());
+  // Verify that default_branch belongs to this BranchPoint.
+  DRAKE_DEMAND(db_confluent != confluent_branches_.end());
+  // Verify that default_branch is an ongoing lane for lane_end.
+  DRAKE_DEMAND(db_confluent->second == le_ongoing->second);
+
+  defaults_[lane_end] = default_branch;
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/branch_point.h
+++ b/drake/automotive/maliput/rndf/branch_point.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+class BranchPoint;
+class Lane;
+
+/// An implementation of LaneEndSet for RNDF.
+class LaneEndSet : public api::LaneEndSet {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LaneEndSet)
+
+  LaneEndSet() = default;
+  ~LaneEndSet() override = default;
+
+  /// Adds a LaneEnd.
+  void add(const api::LaneEnd& end) { ends_.push_back(end); }
+
+ private:
+  int do_size() const override { return ends_.size(); }
+
+  const api::LaneEnd& do_get(int index) const override { return ends_[index]; }
+
+  std::vector<api::LaneEnd> ends_;
+};
+
+/// An implementation of api::BranchPoint for RNDF.
+class BranchPoint : public api::BranchPoint {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BranchPoint)
+
+  /// Constructs an empty BranchPoint.
+  ///
+  /// @param id is the ID of the BranchPoint.
+  /// @param road_geometry is a pointer to the parent api::RoadGeometry, which
+  /// must remain valid for the lifetime of this class.
+  BranchPoint(const api::BranchPointId& id, api::RoadGeometry* road_geometry);
+
+  /// Adds a LaneEnd to the "A side" of the BranchPoint.
+  const api::LaneEnd& AddABranch(const api::LaneEnd& lane_end);
+
+  /// Adds a LaneEnd to the "B side" of the BranchPoint.
+  const api::LaneEnd& AddBBranch(const api::LaneEnd& lane_end);
+
+  /// Sets the default branch for @p lane_end to @p default_branch.
+  ///
+  /// The specified LaneEnds must belong to opposite sides of this BranchPoint.
+  void SetDefault(const api::LaneEnd& lane_end,
+                  const api::LaneEnd& default_branch);
+
+  ~BranchPoint() override = default;
+
+ private:
+  const api::BranchPointId do_id() const override { return id_; }
+
+  const api::RoadGeometry* do_road_geometry() const override;
+
+  const api::LaneEndSet* DoGetConfluentBranches(
+      const api::LaneEnd& end) const override;
+
+  const api::LaneEndSet* DoGetOngoingBranches(
+      const api::LaneEnd& end) const override;
+
+  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+      const api::LaneEnd& end) const override;
+
+  const api::LaneEndSet* DoGetASide() const override { return &a_side_; }
+
+  const api::LaneEndSet* DoGetBSide() const override { return &b_side_; }
+
+  api::BranchPointId id_;
+  api::RoadGeometry* road_geometry_{};
+  LaneEndSet a_side_;
+  LaneEndSet b_side_;
+
+  std::map<api::LaneEnd, LaneEndSet*, api::LaneEnd::StrictOrder>
+      confluent_branches_;
+  std::map<api::LaneEnd, LaneEndSet*, api::LaneEnd::StrictOrder>
+      ongoing_branches_;
+  std::map<api::LaneEnd, api::LaneEnd, api::LaneEnd::StrictOrder> defaults_;
+};
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/junction.cc
+++ b/drake/automotive/maliput/rndf/junction.cc
@@ -1,0 +1,16 @@
+#include "drake/automotive/maliput/rndf/junction.h"
+
+#include <memory>
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+Segment* Junction::NewSegment(api::SegmentId id) {
+  segments_.push_back(std::make_unique<Segment>(id, this));
+  return segments_.back().get();
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/junction.h
+++ b/drake/automotive/maliput/rndf/junction.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/rndf/segment.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+/// An api::Junction implementation for RNDF.
+class Junction : public api::Junction {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Junction)
+
+  /// Constructs an empty Junction.
+  ///
+  /// @param id is the ID of the Junction.
+  /// @param road_geometry must remain valid for the lifetime of this class,
+  /// and must refer to the RoadGeometry which will contain the newly
+  /// constructed Junction instance.
+  Junction(const api::JunctionId& id, api::RoadGeometry* road_geometry)
+      : id_(id), road_geometry_(road_geometry) {}
+
+  /// Creates and adds a new Segment with the specified @p id.
+  ///
+  /// @param id is the ID of the segment.
+  Segment* NewSegment(api::SegmentId id);
+
+  ~Junction() override = default;
+
+ private:
+  const api::JunctionId do_id() const override { return id_; }
+
+  const api::RoadGeometry* do_road_geometry() const override {
+    return road_geometry_;
+  }
+
+  int do_num_segments() const override { return segments_.size(); }
+
+  // Throws an exception in case the index is not in between zero and the
+  // number of segments.
+  const api::Segment* do_segment(int index) const override {
+    DRAKE_THROW_UNLESS(index >= 0 &&
+                       index < static_cast<int>(segments_.size()));
+    return segments_[index].get();
+  }
+
+  api::JunctionId id_;
+  api::RoadGeometry* road_geometry_{};
+  std::vector<std::unique_ptr<Segment>> segments_;
+};
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/lane.cc
+++ b/drake/automotive/maliput/rndf/lane.cc
@@ -1,0 +1,41 @@
+#include "drake/automotive/maliput/rndf/lane.h"
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+const api::Segment* Lane::do_segment() const { return segment_; }
+
+const api::BranchPoint* Lane::DoGetBranchPoint(
+    const api::LaneEnd::Which which_end) const {
+  switch (which_end) {
+    case api::LaneEnd::kStart: {
+      return start_bp_;
+    }
+    case api::LaneEnd::kFinish: {
+      return end_bp_;
+    }
+  }
+  DRAKE_ABORT_MSG("which_end value is not supported.");
+}
+
+const api::LaneEndSet* Lane::DoGetConfluentBranches(
+    api::LaneEnd::Which which_end) const {
+  return GetBranchPoint(which_end)->GetConfluentBranches({this, which_end});
+}
+
+const api::LaneEndSet* Lane::DoGetOngoingBranches(
+    api::LaneEnd::Which which_end) const {
+  return GetBranchPoint(which_end)->GetOngoingBranches({this, which_end});
+}
+
+std::unique_ptr<api::LaneEnd> Lane::DoGetDefaultBranch(
+    api::LaneEnd::Which which_end) const {
+  return GetBranchPoint(which_end)->GetDefaultBranch({this, which_end});
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/lane.h
+++ b/drake/automotive/maliput/rndf/lane.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/rndf/branch_point.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+class BranchPoint;
+
+/// Base class for the RNDF implementation of api::Lane.
+///
+/// This is the base class for subclasses, each of which describe a
+/// primitive reference curve in the xy ground-plane of the world frame.
+/// The specific curve is expressed by a subclass's implementations of
+/// private virtual functions.
+///
+/// This base implementation will handle all the non-geometric stuff from the
+/// lane. All geometric computation will be moved to each sub lane childs. See
+/// SplineLane for an example.
+class Lane : public api::Lane {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Lane)
+
+  /// Constructs a Lane.
+  /// @param id is the ID of the api::Lane.
+  /// @param segment is a pointer that refers to its parent, which must remain
+  /// valid for the lifetime of this class.
+  /// @param width is the value of the width of the lane based on the RNDF
+  /// lane_width parameter. It will be used to set a constant lane_bound
+  /// value along the road.
+  /// @param index is the index that can be used to reference this Lane from
+  /// api::Segment::lane() call.
+  Lane(const api::LaneId& id, const api::Segment* segment, double width,
+       int index)
+      : id_(id), segment_(segment), width_(width), index_(index) {}
+
+  /// Sets the pointer of the BranchPoint that contains a
+  /// api::LaneEnd::Which::kStart value attached to this lane pointer.
+  /// @param bp should be a valid BranchPoint pointer.
+  void SetStartBp(BranchPoint* bp) { start_bp_ = bp; }
+
+  /// Sets the pointer of the BranchPoint that contains a
+  /// api::LaneEnd::Which::kFinish value attached to this lane pointer.
+  /// @param bp should be a valid BranchPoint pointer.
+  void SetEndBp(BranchPoint* bp) { end_bp_ = bp; }
+
+  /// Getter of the BranchPoint set as starting.
+  /// @return The starting BranchPoint pointer.
+  BranchPoint* start_bp() { return start_bp_; }
+
+  /// Getter of the BranchPoint set as ending.
+  /// @return The ending BranchPoint pointer.
+  BranchPoint* end_bp() { return end_bp_; }
+
+  ~Lane() override = default;
+
+ protected:
+  const api::LaneId do_id() const override { return id_; }
+
+  const api::Segment* do_segment() const override;
+
+  int do_index() const override { return index_; }
+
+  const api::Lane* do_to_left() const override {
+    if ((segment_->num_lanes() - 1) == index_) {
+      return nullptr;
+    }
+    return segment_->lane(index_ + 1);
+  }
+
+  const api::Lane* do_to_right() const override {
+    if (index_ == 0) {
+      return nullptr;
+    }
+    return segment_->lane(index_ - 1);
+  }
+
+  const api::BranchPoint* DoGetBranchPoint(
+      const api::LaneEnd::Which which_end) const override;
+
+  const api::LaneEndSet* DoGetConfluentBranches(
+      const api::LaneEnd::Which which_end) const override;
+
+  const api::LaneEndSet* DoGetOngoingBranches(
+      const api::LaneEnd::Which which_end) const override;
+
+  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+      const api::LaneEnd::Which which_end) const override;
+
+  const api::LaneId id_;
+  const api::Segment* segment_{};
+  BranchPoint* start_bp_{};
+  BranchPoint* end_bp_{};
+  const double width_{};
+  const int index_{};
+};
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/road_geometry.cc
+++ b/drake/automotive/maliput/rndf/road_geometry.cc
@@ -1,0 +1,41 @@
+#include "drake/automotive/maliput/rndf/road_geometry.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+Junction* RoadGeometry::NewJunction(api::JunctionId id) {
+  junctions_.push_back(std::make_unique<Junction>(id, this));
+  return junctions_.back().get();
+}
+
+BranchPoint* RoadGeometry::NewBranchPoint(api::BranchPointId id) {
+  branch_points_.push_back(std::make_unique<BranchPoint>(id, this));
+  return branch_points_.back().get();
+}
+
+const api::Junction* RoadGeometry::do_junction(int index) const {
+  DRAKE_THROW_UNLESS(index >= 0 && index < static_cast<int>(junctions_.size()));
+  return junctions_[index].get();
+}
+
+const api::BranchPoint* RoadGeometry::do_branch_point(int index) const {
+  DRAKE_THROW_UNLESS(index >= 0 &&
+                     index < static_cast<int>(branch_points_.size()));
+  return branch_points_[index].get();
+}
+
+api::RoadPosition RoadGeometry::DoToRoadPosition(const api::GeoPosition&,
+                                                 const api::RoadPosition*,
+                                                 api::GeoPosition*,
+                                                 double*) const {
+  // TODO(@agalbachicar) We need to find a way of implement this.
+  DRAKE_ABORT();
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/road_geometry.h
+++ b/drake/automotive/maliput/rndf/road_geometry.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/rndf/branch_point.h"
+#include "drake/automotive/maliput/rndf/junction.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+/// An api::RoadGeometry implementation for RNDF specification.
+/// Use the Builder interface to actually assemble a sensible road network.
+/// Further information on RNDF specification can be found:
+/// https://www.grandchallenge.org/grandchallenge/docs/RNDF_MDF_Formats_031407.pdf
+///
+/// api::RoadGeometry::ToRoadPosition should not be called as DoToRoadPosition
+/// is not implemented.
+class RoadGeometry : public api::RoadGeometry {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadGeometry)
+
+  /// Constructs an empty RoadGeometry with the specified tolerances.
+  ///
+  /// @param id to set a name to the object.
+  /// @param linear_tolerance is the tolerance in the linear sense for the
+  /// api::RoadGeometry::CheckInvariants constraints checks.
+  /// @param angular_tolerance is the tolerance in the angular sense for the
+  /// api::RoadGeometry::CheckInvariants constraints checks.
+  RoadGeometry(const api::RoadGeometryId& id, double linear_tolerance,
+               double angular_tolerance)
+      : id_(id),
+        linear_tolerance_(linear_tolerance),
+        angular_tolerance_(angular_tolerance) {}
+
+  /// Creates and adds a new Junction with the specified @p id.
+  /// @param id is the ID of the junction.
+  /// @return A pointer to a Junction
+  Junction* NewJunction(api::JunctionId id);
+
+  /// Creates and adds a new BranchPoint with the specified @p id.
+  /// @param id is the ID of the branch point.
+  /// @return A pointer to a BranchPoint
+  BranchPoint* NewBranchPoint(api::BranchPointId id);
+
+  ~RoadGeometry() override = default;
+
+ private:
+  const api::RoadGeometryId do_id() const override { return id_; }
+
+  int do_num_junctions() const override { return junctions_.size(); }
+
+  // This function will throw an exception if index is not bounded between 0
+  // and the current maximum available index of junctions_ vector.
+  const api::Junction* do_junction(int index) const override;
+
+  int do_num_branch_points() const override { return branch_points_.size(); }
+
+  // This function will throw an exception if index is not bounded between 0
+  // and the current maximum available index of branch_points_ vector.
+  const api::BranchPoint* do_branch_point(int index) const override;
+
+  // This function will abort as it's not implemented and should not be called.
+  api::RoadPosition DoToRoadPosition(const api::GeoPosition& geo_pos,
+                                     const api::RoadPosition* hint,
+                                     api::GeoPosition* nearest_position,
+                                     double* distance) const override;
+
+  double do_linear_tolerance() const override { return linear_tolerance_; }
+
+  double do_angular_tolerance() const override { return angular_tolerance_; }
+
+  api::RoadGeometryId id_;
+  double linear_tolerance_{};
+  double angular_tolerance_{};
+  std::vector<std::unique_ptr<Junction>> junctions_;
+  std::vector<std::unique_ptr<BranchPoint>> branch_points_;
+};
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/segment.cc
+++ b/drake/automotive/maliput/rndf/segment.cc
@@ -1,0 +1,26 @@
+#include "drake/automotive/maliput/rndf/segment.h"
+
+#include <utility>
+
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+SplineLane* Segment::NewSplineLane(const api::LaneId& id, double width) {
+  std::unique_ptr<SplineLane> lane =
+      std::make_unique<SplineLane>(id, this, width, lanes_.size());
+  SplineLane* spline_lane = lane.get();
+  lanes_.push_back(std::move(lane));
+  return spline_lane;
+}
+
+const api::Lane* Segment::do_lane(int index) const {
+  DRAKE_THROW_UNLESS(index >= 0 && index < static_cast<int>(lanes_.size()));
+  return lanes_[index].get();
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/segment.h
+++ b/drake/automotive/maliput/rndf/segment.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/rndf/lane.h"
+#include "drake/automotive/maliput/rndf/spline_lane.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+class SplineLane;
+
+/// An api::Segment implementation for RNDF.
+class Segment : public api::Segment {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Segment)
+
+  /// Constructs a new Segment.
+  /// @param id to name this segment
+  /// @param junction must remain valid for the lifetime of this class.
+  Segment(const api::SegmentId& id, api::Junction* junction)
+      : id_(id), junction_(junction) {}
+
+  /// Gives the segment a newly constructed SplineLane.
+  ///
+  /// @param id is the id of the lane.
+  /// @param width is the width specified by the RNDF lane_width
+  /// parameter, or the default assigned value by this code. Later, this value
+  /// will be used to construct the api::Lane::lane_bounds() and the
+  /// api::Lane::driveable_bounds() result.
+  /// @return a pointer to a valid SplineLane.
+  SplineLane* NewSplineLane(const api::LaneId& id, double width);
+
+  ~Segment() override = default;
+
+ private:
+  const api::SegmentId do_id() const override { return id_; }
+
+  const api::Junction* do_junction() const override { return junction_; }
+
+  int do_num_lanes() const override { return lanes_.size(); }
+
+  // Throws an exception if the index is not in between 0 and the size of
+  // lanes_ minus one.
+  const api::Lane* do_lane(int index) const override;
+
+  api::SegmentId id_;
+  api::Junction* junction_{};
+  std::vector<std::unique_ptr<Lane>> lanes_;
+};
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/spline_lane.cc
+++ b/drake/automotive/maliput/rndf/spline_lane.cc
@@ -1,0 +1,13 @@
+#include "drake/automotive/maliput/rndf/spline_lane.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+SplineLane::SplineLane(const api::LaneId& id, const api::Segment* segment,
+                       double width, int index)
+    : Lane(id, segment, width, index) {}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/spline_lane.h
+++ b/drake/automotive/maliput/rndf/spline_lane.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/rndf/lane.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+// TODO(@agalbachicar) Implement me.
+/// This class is a stub and will be completed in a subsequent PR.
+class SplineLane : public Lane {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SplineLane)
+
+  SplineLane(const api::LaneId& id, const api::Segment* segment, double width,
+             int index);
+
+  ~SplineLane() override = default;
+
+ private:
+  double do_length() const override { return 0.0; }
+  api::RBounds do_lane_bounds(double) const override {
+    return api::RBounds(0., 0.);
+  }
+  api::RBounds do_driveable_bounds(double) const override {
+    return api::RBounds(0., 0.);
+  }
+  api::GeoPosition DoToGeoPosition(const api::LanePosition&) const override {
+    return api::GeoPosition();
+  }
+  api::LanePosition DoToLanePosition(const api::GeoPosition&, api::GeoPosition*,
+                                     double*) const override {
+    return api::LanePosition();
+  }
+  api::Rotation DoGetOrientation(const api::LanePosition&) const override {
+    return api::Rotation();
+  }
+  api::LanePosition DoEvalMotionDerivatives(
+      const api::LanePosition&, const api::IsoLaneVelocity&) const override {
+    return api::LanePosition();
+  }
+  api::HBounds do_elevation_bounds(double, double) const override {
+    return api::HBounds(0., 0.);
+  }
+};
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/test/CMakeLists.txt
+++ b/drake/automotive/maliput/rndf/test/CMakeLists.txt
@@ -1,6 +1,31 @@
 if(ignition-rndf0_FOUND)
-  drake_add_cc_test(ignition_rndf_test)
-  target_include_directories(ignition_rndf_test PRIVATE
-    "${IGNITION-RNDF_INCLUDE_DIRS}")
-  target_link_libraries(ignition_rndf_test "${IGNITION-RNDF_LIBRARIES}")
+    drake_add_cc_test(ignition_rndf_test)
+    target_include_directories(ignition_rndf_test PRIVATE
+        "${IGNITION-RNDF_INCLUDE_DIRS}"
+    )
+    target_link_libraries(ignition_rndf_test "${IGNITION-RNDF_LIBRARIES}")
+
+    drake_add_cc_test(junction_test)
+    target_include_directories(junction_test PRIVATE
+        "${IGNITION-RNDF_INCLUDE_DIRS}"
+    )
+    target_link_libraries(junction_test
+        drakeMaliputRndf
+        "${IGNITION-RNDF_LIBRARIES}")
+
+    drake_add_cc_test(road_geometry_test)
+    target_include_directories(road_geometry_test PRIVATE
+        "${IGNITION-RNDF_INCLUDE_DIRS}"
+    )
+    target_link_libraries(road_geometry_test
+        drakeMaliputRndf
+        "${IGNITION-RNDF_LIBRARIES}")
+
+    drake_add_cc_test(segment_test)
+    target_include_directories(segment_test PRIVATE
+        "${IGNITION-RNDF_INCLUDE_DIRS}"
+    )
+    target_link_libraries(segment_test
+        drakeMaliputRndf
+        "${IGNITION-RNDF_LIBRARIES}")
 endif()

--- a/drake/automotive/maliput/rndf/test/junction_test.cc
+++ b/drake/automotive/maliput/rndf/test/junction_test.cc
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/rndf/junction.h"
+#include "drake/automotive/maliput/rndf/road_geometry.h"
+#include "drake/automotive/maliput/rndf/segment.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+// The following tolerances are very strict as they are not used to compute
+// anything in the following tests. However, we need them for the RoadGeometry
+// constuctor.
+const double kLinearTolerance = 1e-12;
+const double kAngularTolerance = 1e-12;
+
+// The following tests Junction creation and id assignment.
+GTEST_TEST(RNDFJunctionTest, GettersTest) {
+  RoadGeometry rg({"RG-GettersTest"}, kLinearTolerance, kAngularTolerance);
+  Junction* junction = rg.NewJunction({"j:1"});
+
+  EXPECT_EQ(junction->road_geometry(), &rg);
+  EXPECT_EQ(junction->id().id, std::string("j:1"));
+}
+
+// The following tests Segment creation, getters and index constraints.
+GTEST_TEST(RNDFJunctionTest, SegmentTest) {
+  RoadGeometry rg({"RG-SegmentTest"}, kLinearTolerance, kAngularTolerance);
+  Junction* junction = rg.NewJunction({"j:1"});
+
+  EXPECT_EQ(junction->num_segments(), 0);
+
+  Segment* s1 = junction->NewSegment({"s:1"});
+  EXPECT_EQ(junction->num_segments(), 1);
+  EXPECT_EQ(junction->segment(0), s1);
+
+  Segment* s2 = junction->NewSegment({"s:2"});
+  EXPECT_EQ(junction->num_segments(), 2);
+  EXPECT_EQ(junction->segment(1), s2);
+
+  EXPECT_THROW(junction->segment(-1), std::runtime_error);
+  EXPECT_THROW(junction->segment(2), std::runtime_error);
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/test/road_geometry_test.cc
+++ b/drake/automotive/maliput/rndf/test/road_geometry_test.cc
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/rndf/branch_point.h"
+#include "drake/automotive/maliput/rndf/junction.h"
+#include "drake/automotive/maliput/rndf/road_geometry.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+// The following tolerances are very strict as they are not used to compute
+// anything in the following tests. However, we need them for the RoadGeometry
+// constuctor.
+const double kLinearTolerance = 1e-12;
+const double kAngularTolerance = 1e-12;
+
+// The following tests the Junction relative API.
+GTEST_TEST(RNDFRoadGeometryTest, JunctionTest) {
+  RoadGeometry rg({"RG-Junction"}, kLinearTolerance, kAngularTolerance);
+
+  EXPECT_EQ(rg.num_junctions(), 0);
+
+  Junction* j1 = rg.NewJunction({"j:1"});
+  EXPECT_EQ(rg.num_junctions(), 1);
+  EXPECT_EQ(rg.junction(0), j1);
+
+  Junction* j2 = rg.NewJunction({"j:2"});
+  EXPECT_EQ(rg.num_junctions(), 2);
+  EXPECT_EQ(rg.junction(1), j2);
+
+  EXPECT_THROW(rg.junction(-1), std::runtime_error);
+  EXPECT_THROW(rg.junction(3), std::runtime_error);
+}
+
+// The following tests the BranchPoint relative API.
+GTEST_TEST(RNDFRoadGeometryTest, BranchPointTest) {
+  RoadGeometry rg({"RG-BranchPoint"}, kLinearTolerance, kAngularTolerance);
+
+  EXPECT_EQ(rg.num_branch_points(), 0);
+
+  BranchPoint* bp1 = rg.NewBranchPoint({"bp:1"});
+  EXPECT_EQ(rg.num_branch_points(), 1);
+  EXPECT_EQ(rg.branch_point(0), bp1);
+
+  BranchPoint* bp2 = rg.NewBranchPoint({"bp:2"});
+  EXPECT_EQ(rg.num_branch_points(), 2);
+  EXPECT_EQ(rg.branch_point(1), bp2);
+
+  EXPECT_THROW(rg.junction(-1), std::runtime_error);
+  EXPECT_THROW(rg.junction(3), std::runtime_error);
+}
+
+// The following tests the Getters of tolerances relative API.
+GTEST_TEST(RNDFRoadGeometryTest, GettersTest) {
+  RoadGeometry rg({"RG-Tolerances"}, kLinearTolerance, kAngularTolerance);
+  EXPECT_EQ(rg.linear_tolerance(), kLinearTolerance);
+  EXPECT_EQ(rg.angular_tolerance(), kAngularTolerance);
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/test/segment_test.cc
+++ b/drake/automotive/maliput/rndf/test/segment_test.cc
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/rndf/junction.h"
+#include "drake/automotive/maliput/rndf/road_geometry.h"
+#include "drake/automotive/maliput/rndf/segment.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+// The following tolerances are very strict as they are not used to compute
+// anything in the following tests. However, we need them for the RoadGeometry
+// constuctor.
+const double kLinearTolerance = 1e-12;
+const double kAngularTolerance = 1e-12;
+
+// The following tests segment creation and the values of the lanes' indexes.
+GTEST_TEST(RNDFSegmentTest, MetadataLane) {
+  RoadGeometry rg({"BareSegment"}, kLinearTolerance, kAngularTolerance);
+  Segment* s1 = rg.NewJunction({"j1"})->NewSegment({"s1"});
+
+  EXPECT_EQ(s1->junction(), rg.junction(0));
+  EXPECT_EQ(s1->num_lanes(), 0);
+
+  s1->NewSplineLane({"l1"}, 5.);
+
+  EXPECT_EQ(s1->num_lanes(), 1);
+
+  EXPECT_NO_THROW(s1->NewSplineLane({"l2"}, 5.));
+
+  EXPECT_EQ(s1->num_lanes(), 2);
+
+  EXPECT_THROW(s1->lane(3), std::runtime_error);
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
This is an implementation of [RNDF](https://www.grandchallenge.org/grandchallenge/docs/RNDF_MDF_Formats_031407.pdf) for Maliput. Current code is based on Splines and uses [Ignition Math](https://bitbucket.org/ignitionrobotics/ign-math) as the main geometry for lanes. Also, it uses [Ignition RNDF](https://bitbucket.org/ignitionrobotics/ign-rndf) as the parser to load all the map description before building the RoadGeometry.

Current code can be built both with Bazel and CMake, and includes a set of tests to cover most of the API relevant aspects. We include also some RNDF maps to test different geometries and their visualization.

The scope of this PR is to cover just the Maliput implementation and does not include any demo related code. Builder and Loader implemenetations and left for future PRs.

Here is a picture of darpa.rndf file (can be found in PR and in this [link](http://archive.darpa.mil/grandchallenge/docs/Sample_RNDF(v1.5).txt)) rendered in drake_visualizer :

![darpa](https://cloud.githubusercontent.com/assets/3825465/26558931/ab36f78a-4482-11e7-8f0f-546e7ba3cfc8.png)

And [here](http://archive.darpa.mil/grandchallenge/docs/Sample_RNDF_Map.pdf) you can find a PDF that shows the actual geometry of the map. Zones are represented as bare lanes that connect entries and exits to let that cars go through that part of the map.

This PR also has an update of Ignition RNDF dependency to the last tag ([0.1.5](https://bitbucket.org/ignitionrobotics/ign-rndf/commits/214a333fbdcb))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6198)
<!-- Reviewable:end -->
