### PR TITLE
Install more external targets from the Bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ install(
     deps = [
         "@eigen//:install",
         "@lcm//:install",
+        "@nlopt//:install",
         "@pybind11//:install",
         "//drake:install",
         "//tools:install",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ install(
     deps = [
         "@eigen//:install",
         "@lcm//:install",
+        "@pybind11//:install",
         "//drake:install",
         "//tools:install",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,7 @@ install(
     name = "install",
     deps = [
         "@eigen//:install",
+        "@ipopt//:install",
         "@lcm//:install",
         "@nlopt//:install",
         "@pybind11//:install",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,7 @@ exports_files(["LICENSE.TXT"])
 install(
     name = "install",
     deps = [
+        "@bullet//:install",
         "@eigen//:install",
         "@ipopt//:install",
         "@lcm//:install",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -305,8 +305,8 @@ pypi_archive(
 github_archive(
     name = "pycps",
     repository = "mwoehlke/pycps",
-    commit = "1c806dcecabbc877c7bf80c3565643169968a4e8",
-    sha256 = "9b7ed340e964f94bce428d63bd02a2fa87963e51bfbb1caa912a3211e743f73e",
+    commit = "d68a10ce1130f87d38a13ae42ddb263042e2352a",
+    sha256 = "4de60f6b260b286dc2e68e9cdc31decc8f9ef43f77894c3d33a6fd097549008b",
     build_file = "tools/pycps.BUILD",
 )
 

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -46,7 +46,7 @@ drake_cc_library(
     deps = [
         ":collision_api",
         "//drake/common:unused",
-        "@bullet",
+        "@bullet//:BulletCollision",
     ],
 )
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -87,6 +87,11 @@ exports_files(
     visibility = ["@lcm//:__pkg__"],
 )
 
+exports_files(
+    ["pybind11-create-cps.py"],
+    visibility = ["@pybind11//:__pkg__"],
+)
+
 alias(
     name = "buildifier",
     actual = "@com_github_bazelbuild_buildtools//buildifier",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("//tools:install.bzl", "install_files")
+load("//tools:install.bzl", "exports_create_cps_scripts", "install_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -77,35 +77,14 @@ exports_files(
     visibility = ["@ipopt//:__pkg__"],
 )
 
-exports_files(
-    ["bullet-create-cps.py"],
-    visibility = ["@bullet//:__pkg__"],
-)
-
-exports_files(
-    ["eigen-create-cps.py"],
-    visibility = ["@eigen//:__pkg__"],
-)
-
-exports_files(
-    ["ipopt-create-cps.py"],
-    visibility = ["@ipopt//:__pkg__"],
-)
-
-exports_files(
-    ["lcm-create-cps.py"],
-    visibility = ["@lcm//:__pkg__"],
-)
-
-exports_files(
-    ["nlopt-create-cps.py"],
-    visibility = ["@nlopt//:__pkg__"],
-)
-
-exports_files(
-    ["pybind11-create-cps.py"],
-    visibility = ["@pybind11//:__pkg__"],
-)
+exports_create_cps_scripts([
+    "bullet",
+    "eigen",
+    "ipopt",
+    "lcm",
+    "nlopt",
+    "pybind11",
+])
 
 alias(
     name = "buildifier",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -88,6 +88,11 @@ exports_files(
 )
 
 exports_files(
+    ["nlopt-create-cps.py"],
+    visibility = ["@nlopt//:__pkg__"],
+)
+
+exports_files(
     ["pybind11-create-cps.py"],
     visibility = ["@pybind11//:__pkg__"],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -78,6 +78,11 @@ exports_files(
 )
 
 exports_files(
+    ["bullet-create-cps.py"],
+    visibility = ["@bullet//:__pkg__"],
+)
+
+exports_files(
     ["eigen-create-cps.py"],
     visibility = ["@eigen//:__pkg__"],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -83,6 +83,11 @@ exports_files(
 )
 
 exports_files(
+    ["ipopt-create-cps.py"],
+    visibility = ["@ipopt//:__pkg__"],
+)
+
+exports_files(
     ["lcm-create-cps.py"],
     visibility = ["@lcm//:__pkg__"],
 )

--- a/tools/bullet-create-cps.py
+++ b/tools/bullet-create-cps.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import sys
+
+with open(sys.argv[1]) as h:
+    version = h.readline().strip()
+
+# Keep Components.LinearMath.Definitions in sync with LinearMath.defines in
+# bullet.BUILD.
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "Bullet",
+  "Description": "Real-time collision detection and multi-physics simulation",
+  "License": "Zlib",
+  "Version": "%s",
+  "Default-Components": [":BulletCollision"],
+  "Components": {
+    "BulletCollision": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libBulletCollision.so",
+      "Includes": ["@prefix@/include/bullet"],
+      "Requires": [":LinearMath"]
+    },
+    "LinearMath": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libLinearMath.so",
+      "Definitions": ["BT_USE_DOUBLE_PRECISION"],
+      "Includes": ["@prefix@/include/bullet"]
+    }
+  }
+}
+""" % version
+
+print(content[1:])

--- a/tools/bullet.BUILD
+++ b/tools/bullet.BUILD
@@ -1,25 +1,33 @@
 # -*- python -*-
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
+load("@drake//tools:python_lint.bzl", "python_lint")
 
-package(
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 # Note that this is only a portion of Bullet.
+
+# Keep defines in sync with Components.LinearMath.Definitions in
+# bullet-create-cps.py.
 cc_library(
-    name = "bullet",
-    srcs = glob([
-        "src/BulletCollision/**/*.cpp",
-        "src/LinearMath/**/*.cpp",
-    ]),
-    hdrs = glob([
-        "src/BulletCollision/**/*.h",
-        "src/LinearMath/**/*.h",
-    ]) + ["src/btBulletCollisionCommon.h"],
+    name = "LinearMath",
+    srcs = glob(["src/LinearMath/**/*.cpp"]),
+    hdrs = glob(["src/LinearMath/**/*.h"]),
     copts = ["-Wno-all"],
     defines = ["BT_USE_DOUBLE_PRECISION"],
     includes = ["src"],
+)
+
+cc_library(
+    name = "BulletCollision",
+    srcs = glob(["src/BulletCollision/**/*.cpp"]),
+    hdrs = glob(["src/BulletCollision/**/*.h"]) + [
+        "src/btBulletCollisionCommon.h",
+    ],
+    copts = ["-Wno-all"],
+    includes = ["src"],
+    deps = [":LinearMath"],
 )
 
 pkg_tar(
@@ -29,3 +37,28 @@ pkg_tar(
     mode = "0644",
     package_dir = "bullet",
 )
+
+cmake_config(
+    package = "Bullet",
+    script = "@drake//tools:bullet-create-cps.py",
+    version_file = "VERSION",
+)
+
+install_cmake_config(package = "Bullet")  # Creates rule :install_cmake_config.
+
+install(
+    name = "install",
+    doc_dest = "share/doc/bullet",
+    docs = ["AUTHORS.txt"],
+    guess_hdrs = "PACKAGE",
+    hdr_dest = "include/bullet",
+    hdr_strip_prefix = ["src"],
+    license_docs = ["LICENSE.txt"],
+    targets = [
+        ":BulletCollision",
+        ":LinearMath",
+    ],
+    deps = [":install_cmake_config"],
+)
+
+python_lint()

--- a/tools/eigen.BUILD
+++ b/tools/eigen.BUILD
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@drake//tools:install.bzl", "install", "install_files")
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
 load("@drake//tools:python_lint.bzl", "python_lint")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
@@ -23,48 +23,13 @@ cc_library(
     includes = ["."],
 )
 
-py_binary(
-    name = "create-cps",
-    srcs = ["@drake//tools:eigen-create-cps.py"],
-    main = "@drake//tools:eigen-create-cps.py",
-    visibility = ["//visibility:private"],
+cmake_config(
+    package = "Eigen3",
+    script = "@drake//tools:eigen-create-cps.py",
+    version_file = "Eigen/src/Core/util/Macros.h",
 )
 
-genrule(
-    name = "cps",
-    srcs = ["Eigen/src/Core/util/Macros.h"],
-    outs = ["Eigen3.cps"],
-    cmd = "$(location :create-cps) \"$<\" > \"$@\"",
-    tools = [":create-cps"],
-    visibility = ["//visibility:private"],
-)
-
-genrule(
-    name = "cmake_exports",
-    srcs = ["Eigen3.cps"],
-    outs = ["Eigen3Config.cmake"],
-    cmd = "$(location @pycps//:cps2cmake_executable) \"$<\" > \"$@\"",
-    tools = ["@pycps//:cps2cmake_executable"],
-    visibility = ["//visibility:private"],
-)
-
-genrule(
-    name = "cmake_package_version",
-    srcs = ["Eigen3.cps"],
-    outs = ["Eigen3ConfigVersion.cmake"],
-    cmd = "$(location @pycps//:cps2cmake_executable) --version-check \"$<\" > \"$@\"",
-    tools = ["@pycps//:cps2cmake_executable"],
-    visibility = ["//visibility:private"],
-)
-
-install_files(
-    name = "install_cmake",
-    dest = "lib/cmake/eigen3",
-    files = [
-        "Eigen3Config.cmake",
-        "Eigen3ConfigVersion.cmake",
-    ],
-)
+install_cmake_config(package = "Eigen3")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
@@ -72,8 +37,8 @@ install(
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/eigen3",
     license_docs = glob(["COPYING.*"]),
-    targets = ["eigen"],
-    deps = ["install_cmake"],
+    targets = [":eigen"],
+    deps = [":install_cmake_config"],
 )
 
 pkg_tar(

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -426,6 +426,20 @@ Args:
 #BEGIN macros
 
 #------------------------------------------------------------------------------
+def exports_create_cps_scripts(packages):
+    """Export scripts that create CPS files to other packages.
+
+    Args:
+        packages (:obj:`list` of :obj:`str`): Bazel package names.
+    """
+
+    for package in packages:
+        native.exports_files(
+            ["{}-create-cps.py".format(package)],
+            visibility = ["@{}//:__pkg__".format(package)],
+        )
+
+#------------------------------------------------------------------------------
 def cmake_config(package, script, version_file):
     """Create CMake package configuration and package version files via an
     intermediate CPS file.

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -422,3 +422,79 @@ Args:
 """
 
 #END rules
+#==============================================================================
+#BEGIN macros
+
+#------------------------------------------------------------------------------
+def cmake_config(package, script, version_file):
+    """Create CMake package configuration and package version files via an
+    intermediate CPS file.
+
+    Args:
+        package (:obj:`str`): CMake package name.
+        script (:obj:`Label`): Script that creates the intermediate CPS file.
+        version_file (:obj:`str`): File that the script will search to
+            determine the version of the package.
+    """
+    native.py_binary(
+        name = "create-cps",
+        srcs = [script],
+        main = script,
+        visibility = ["//visibility:private"],
+    )
+
+    cps_file_name = "{}.cps".format(package)
+
+    native.genrule(
+        name = "cps",
+        srcs = [version_file],
+        outs = [cps_file_name],
+        cmd = "$(location :create-cps) \"$<\" > \"$@\"",
+        tools = [":create-cps"],
+        visibility = ["//visibility:private"],
+    )
+
+    config_file_name = "{}Config.cmake".format(package)
+
+    native.genrule(
+        name = "cmake_exports",
+        srcs = [cps_file_name],
+        outs = [config_file_name],
+        cmd = "$(location @pycps//:cps2cmake_executable) \"$<\" > \"$@\"",
+        tools = ["@pycps//:cps2cmake_executable"],
+        visibility = ["//visibility:private"],
+    )
+
+    config_version_file_name = "{}ConfigVersion.cmake".format(package)
+
+    native.genrule(
+        name = "cmake_package_version",
+        srcs = [cps_file_name],
+        outs = [config_version_file_name],
+        cmd = "$(location @pycps//:cps2cmake_executable) --version-check \"$<\" > \"$@\"",
+        tools = ["@pycps//:cps2cmake_executable"],
+        visibility = ["//visibility:private"],
+    )
+
+#------------------------------------------------------------------------------
+def install_cmake_config(package):
+    """Generate installation information for CMake package configuration and
+    package version files. The rule name is always ``:install_cmake_config``.
+
+    Args:
+        package (:obj:`str`): CMake package name.
+    """
+    cmake_config_dest = "lib/cmake/{}".format(package.lower())
+    config_file_name = "{}Config.cmake".format(package)
+    config_version_file_name = "{}ConfigVersion.cmake".format(package)
+
+    install_files(
+        name = "install_cmake_config",
+        dest = cmake_config_dest,
+        files = [
+            config_file_name,
+            config_version_file_name,
+        ],
+    )
+
+#END macros

--- a/tools/ipopt-create-cps.py
+++ b/tools/ipopt-create-cps.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+def_re = re.compile("#define IPOPT_(VERSION[^\s]+)\s+([^\s]+)")
+
+defs = {}
+with open(sys.argv[1]) as h:
+    for l in h:
+        m = def_re.match(l)
+        if m is not None:
+            defs[m.group(1)] = m.group(2)
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "IPOPT",
+  "Description": "Interior Point Optimizer",
+  "License": [
+    "EPL-1.0",
+    "METIS"
+  ],
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_RELEASE)s",
+  "Default-Components": [":ipopt"],
+  "Components": {
+    "ipopt": {
+      "Type": "archive",
+      "Location": "@prefix@/lib/libipopt.a",
+      "Includes": ["@prefix@/include/ipopt"]
+    }
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/ipopt.BUILD
+++ b/tools/ipopt.BUILD
@@ -1,5 +1,10 @@
 # -*- python -*-
 
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
+load("@drake//tools:python_lint.bzl", "python_lint")
+
+package(default_visibility = ["//visibility:public"])
+
 # We build IPOPT by shelling out to autotools.
 
 # We run autotools in a genrule, and only files explicitly identified as outputs
@@ -123,9 +128,28 @@ cc_library(
     hdrs = IPOPT_HDRS,
     includes = ["include/coin"],
     linkstatic = 1,
-    visibility = ["//visibility:public"],
-    deps = [
-        "@gfortran",
-    ],
+    deps = ["@gfortran"],
     alwayslink = 1,
 )
+
+cmake_config(
+    package = "IPOPT",
+    script = "@drake//tools:ipopt-create-cps.py",
+    version_file = "Ipopt/src/Common/config_ipopt_default.h",
+)
+
+install_cmake_config(package = "IPOPT")  # Creates rule :install_cmake_config.
+
+# TODO(jamiesnape): At the moment libipopt.a has gone AWOL.
+install(
+    name = "install",
+    doc_dest = "share/doc/ipopt",
+    guess_hdrs = "PACKAGE",
+    hdr_dest = "include/ipopt",
+    hdr_strip_prefix = ["include/coin"],
+    license_docs = glob(["**/LICENSE"]),
+    targets = [":ipopt"],
+    deps = [":install_cmake_config"],
+)
+
+python_lint()

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -2,7 +2,7 @@
 
 load("@drake//tools:drake.bzl", "drake_generate_file")
 load("@drake//tools:generate_export_header.bzl", "generate_export_header")
-load("@drake//tools:install.bzl", "install", "install_files")
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config", "install_files")
 load("@drake//tools:python_lint.bzl", "python_lint")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
@@ -198,48 +198,18 @@ pkg_tar(
     package_dir = "lcm",
 )
 
-py_binary(
-    name = "create-cps",
-    srcs = ["@drake//tools:lcm-create-cps.py"],
-    main = "@drake//tools:lcm-create-cps.py",
-    visibility = ["//visibility:private"],
+cmake_config(
+    package = "lcm",
+    script = "@drake//tools:lcm-create-cps.py",
+    version_file = "lcm/lcm_version.h",
 )
 
-genrule(
-    name = "cps",
-    srcs = ["lcm/lcm_version.h"],
-    outs = ["lcm.cps"],
-    cmd = "$(location :create-cps) \"$<\" > \"$@\"",
-    tools = [":create-cps"],
-    visibility = ["//visibility:private"],
-)
-
-genrule(
-    name = "cmake_exports",
-    srcs = ["lcm.cps"],
-    outs = ["lcmConfig.cmake"],
-    cmd = "$(location @pycps//:cps2cmake_executable) \"$<\" > \"$@\"",
-    tools = ["@pycps//:cps2cmake_executable"],
-    visibility = ["//visibility:private"],
-)
-
-genrule(
-    name = "cmake_package_version",
-    srcs = ["lcm.cps"],
-    outs = ["lcmConfigVersion.cmake"],
-    cmd = "$(location @pycps//:cps2cmake_executable) --version-check \"$<\" > \"$@\"",
-    tools = ["@pycps//:cps2cmake_executable"],
-    visibility = ["//visibility:private"],
-)
+install_cmake_config(package = "lcm")  # Creates rule :install_cmake_config.
 
 install_files(
-    name = "install_cmake",
+    name = "install_extra_cmake",
     dest = "lib/cmake/lcm",
-    files = [
-        "lcm-cmake/lcmUtilities.cmake",
-        "lcmConfig.cmake",
-        "lcmConfigVersion.cmake",
-    ],
+    files = ["lcm-cmake/lcmUtilities.cmake"],
     strip_prefix = ["**/"],
 )
 
@@ -253,14 +223,17 @@ install(
     ],
     license_docs = ["COPYING"],
     targets = [
-        "lcm",
-        "lcm-gen",
-        "lcm-java",
-        "lcm-logger",
-        "lcm-logplayer",
-        "lcm-spy",
+        ":lcm",
+        ":lcm-gen",
+        ":lcm-java",
+        ":lcm-logger",
+        ":lcm-logplayer",
+        ":lcm-spy",
     ],
-    deps = [":install_cmake"],
+    deps = [
+        ":install_cmake_config",
+        ":install_extra_cmake",
+    ],
 )
 
 # TODO(mwoehlke-kitware): install Python bits

--- a/tools/nlopt-create-cps.py
+++ b/tools/nlopt-create-cps.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+def_re = re.compile("#define ([^\s]+_VERSION)\s+([^\s]+)")
+
+defs = {}
+with open(sys.argv[1]) as h:
+    for l in h:
+        m = def_re.match(l)
+        if m is not None:
+            defs[m.group(1)] = m.group(2)
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "NLopt",
+  "Description": "Nonlinear Optimizer",
+  "License": [
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "LGPL-2.1+",
+    "MIT"
+  ],
+  "Version": "%(MAJOR_VERSION)s.%(MINOR_VERSION)s.%(BUGFIX_VERSION)s",
+  "Default-Components": [":nlopt"],
+  "Components": {
+    "nlopt": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libnlopt.so",
+      "Includes": ["@prefix@/include/nlopt"]
+    }
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/nlopt.BUILD
+++ b/tools/nlopt.BUILD
@@ -1,6 +1,10 @@
 # -*- python -*-
 
 load("@drake//tools:cmake_configure_file.bzl", "cmake_configure_file")
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
+load("@drake//tools:python_lint.bzl", "python_lint")
+
+package(default_visibility = ["//visibility:public"])
 
 # Chooses the nlopt preprocessor substitutions that we want to use from Bazel.
 cmake_configure_file(
@@ -40,6 +44,7 @@ cmake_configure_file(
         # Yes, we are going to build the C++ bindings.
         "WITH_CXX=1",
     ],
+    visibility = ["//visibility:private"],
 )
 
 # Creates api/nlopt.hpp based on api/nlopt.h.
@@ -53,6 +58,7 @@ genrule(
     cmd = "$(location @drake//tools:nlopt-gen-hpp.sh) $(SRCS) $(OUTS) 2>&1 1>log" +
           " || (cat log && false)",
     tools = ["@drake//tools:nlopt-gen-hpp.sh"],
+    visibility = ["//visibility:private"],
 )
 
 cc_library(
@@ -112,5 +118,31 @@ cc_library(
         "esch",
         "api",
     ],
-    visibility = ["//visibility:public"],
 )
+
+cmake_config(
+    package = "NLopt",
+    script = "@drake//tools:nlopt-create-cps.py",
+    version_file = "nlopt_config.h",
+)
+
+install_cmake_config(package = "NLopt")  # Creates rule :install_cmake_config.
+
+install(
+    name = "install",
+    doc_dest = "share/doc/nlopt",
+    docs = [
+        "AUTHORS",
+        "NEWS",
+    ],
+    guess_hdrs = "PACKAGE",
+    hdr_dest = "include/nlopt",
+    license_docs = glob([
+        "**/COPYING",
+        "**/COPYRIGHT",
+    ]),
+    targets = [":nlopt"],
+    deps = [":install_cmake_config"],
+)
+
+python_lint()

--- a/tools/pybind11-create-cps.py
+++ b/tools/pybind11-create-cps.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+def_re = re.compile("#define PYBIND11_(VERSION[^\s]+)\s+([^\s]+)")
+
+defs = {}
+with open(sys.argv[1]) as h:
+    for l in h:
+        m = def_re.match(l)
+        if m is not None:
+            defs[m.group(1)] = m.group(2)
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "pybind11",
+  "Description": "Seamless operability between C++11 and Python",
+  "License": "BSD-3-Clause",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
+  "Default-Components": [":module"],
+  "Components": {
+    "module": {
+      "Type": "interface",
+      "Includes": ["@prefix@/include"],
+      "Compile-Features": ["c++11"]
+    }
+  },
+  "X-CMake-Includes": ["${CMAKE_CURRENT_LIST_DIR}/pybind11Tools.cmake"]
+}
+""" % defs
+
+print(content[1:])

--- a/tools/pybind11.BUILD
+++ b/tools/pybind11.BUILD
@@ -1,5 +1,10 @@
 # -*- python -*-
 
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config", "install_files")
+load("@drake//tools:python_lint.bzl", "python_lint")
+
+package(default_visibility = ["//visibility:public"])
+
 cc_library(
     name = "pybind11",
     hdrs = [
@@ -22,10 +27,43 @@ cc_library(
         "include/pybind11/typeid.h",
     ],
     includes = ["include"],
-    visibility = ["//visibility:public"],
     deps = [
         "@eigen",
         "@numpy",
         "@python",
     ],
 )
+
+cmake_config(
+    package = "pybind11",
+    script = "@drake//tools:pybind11-create-cps.py",
+    version_file = "include/pybind11/common.h",
+)
+
+install_cmake_config(package = "pybind11")  # Creates rule :install_cmake_config.
+
+install_files(
+    name = "install_extra_cmake",
+    dest = "lib/cmake/pybind11",
+    files = [
+        "tools/FindNumPy.cmake",
+        "tools/FindPythonLibsNew.cmake",
+        "tools/pybind11Tools.cmake",
+    ],
+    strip_prefix = ["**/"],
+)
+
+install(
+    name = "install",
+    doc_dest = "share/doc/pybind11",
+    guess_hdrs = "PACKAGE",
+    hdr_strip_prefix = ["include"],
+    license_docs = ["LICENSE"],
+    targets = [":pybind11"],
+    deps = [
+        ":install_cmake_config",
+        ":install_extra_cmake",
+    ],
+)
+
+python_lint()


### PR DESCRIPTION
There is currently an issue with installing the IPOPT libraries, but they are statically linked into `libdrake.so`, so hopefully that is not a blocker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6201)
<!-- Reviewable:end -->
