### PR TITLE
Export transitive dependencies, use new install framework

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -300,8 +300,8 @@ pypi_archive(
 github_archive(
     name = "pycps",
     repository = "mwoehlke/pycps",
-    commit = "a05280f1ef1d8970aca8c67dc4cf753953e3cdf7",
-    sha256 = "3024d25ddcb6bb6835834575e577f36bfd6e768501b8c2a2fd66181eb27108ce",
+    commit = "1c806dcecabbc877c7bf80c3565643169968a4e8",
+    sha256 = "9b7ed340e964f94bce428d63bd02a2fa87963e51bfbb1caa912a3211e743f73e",
     build_file = "tools/pycps.BUILD",
 )
 

--- a/drake/BUILD
+++ b/drake/BUILD
@@ -3,7 +3,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:drake.bzl", "drake_header_tar")
 load("//tools:install.bzl", "install")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
@@ -30,15 +29,6 @@ cc_binary(
     deps = _LIBDRAKE_COMPONENTS,
 )
 
-# All the headers mentioned in "hdrs" attributes of the transitive closure of
-# dependencies of the _LIBDRAKE_COMPONENTS. This is a superset of the headers
-# actually required to operate Drake.
-# TODO(mwoehlke-kitware): remove once install finished
-drake_header_tar(
-    name = "libdrake_headers",
-    deps = _LIBDRAKE_COMPONENTS,
-)
-
 # Install libdrake.so along with all transitive headers in the same workspace
 # (i.e. in Drake itself; not externals).
 install(
@@ -48,18 +38,4 @@ install(
     hdr_dest = "include/drake",
     license_docs = ["//:LICENSE.TXT"],
     targets = ["libdrake.so"],
-)
-
-# TODO(mwoehlke-kitware): remove once install finished
-pkg_tar(
-    name = "external_licenses",
-    extension = "tar.gz",
-    deps = [
-        "@bullet//:license",
-        "@eigen//:license",
-        "@fmt//:license",
-        "@lcm//:license",
-        "@spdlog//:license",
-        "@tinyobjloader//:license",
-    ],
 )

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -198,44 +198,6 @@ def drake_cc_googletest(
         deps=deps,
         **kwargs)
 
-# Collects the transitive closure of header files from ctx.attr.deps.
-def _transitive_hdrs_impl(ctx):
-    headers = set()
-    for dep in ctx.attr.deps:
-        # TODO(mwoehlke-kitware): Figure out a better way to exclude system
-        # headers from being slurped in?
-        headers += [h for h in dep.cc.transitive_headers
-                    if not "/_usr_" in h.path]
-    return struct(files=headers)
-
-_transitive_hdrs = rule(
-    attrs = {
-        "deps": attr.label_list(
-            allow_files = False,
-            providers = ["cc"],
-        ),
-    },
-    implementation = _transitive_hdrs_impl,
-)
-
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-
-def drake_header_tar(name, deps=[], **kwargs):
-    """Creates a .tar.gz that includes all the headers exported by the deps."""
-    # TODO(david-german-tri): The --flagfile that Bazel generates to drive `tar`
-    # tacks a spurious `..` onto the paths of external headers, which we then
-    # have to clean up in package_drake.sh. It's not clear whether this is a
-    # Bazel bug, or a bug in these macros.
-    _transitive_hdrs(name=name + "_gather",
-                     deps=deps)
-    # We must specify a non-default strip prefix so that the tarball contains
-    # relative and not absolute paths.
-    pkg_tar(name=name,
-            extension="tar.gz",
-            mode="0644",
-            files=[":" + name + "_gather"],
-            strip_prefix="/")
-
 # Generate a file with specified content
 def _generate_file_impl(ctx):
     ctx.file_action(output=ctx.outputs.out, content=ctx.attr.content)

--- a/tools/drake.cps
+++ b/tools/drake.cps
@@ -6,20 +6,22 @@
   "Cps-Version": "0.8.0",
   "Name": "drake",
   "Website": "http://drake.mit.edu/",
+  "Requires": {
+    "Eigen3": {
+      "Version": "3.3.3",
+      "Hints": ["@prefix@/lib/cmake/eigen3"],
+      "X-CMake-Find-Args": [ "CONFIG" ]
+    }
+  },
   "Components": {
     "drake": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libdrake.so",
       "Includes": [
-        "@prefix@/include",
-        "@prefix@/include/external/bullet",
-        "@prefix@/include/external/eigen",
-        "@prefix@/include/external/fmt",
-        "@prefix@/include/external/lcm",
-        "@prefix@/include/external/spdlog",
-        "@prefix@/include/external/tinyobjloader"
+        "@prefix@/include"
       ],
-      "Compile-Features": ["c++14"]
+      "Compile-Features": ["c++14"],
+      "Requires": [ "Eigen3:Eigen" ]
     }
   }
 }

--- a/tools/package_drake.sh
+++ b/tools/package_drake.sh
@@ -19,178 +19,54 @@ function canonicalize
   perl -MCwd -le 'print Cwd::abs_path(shift)' "$1"
 }
 
-#------------------------------------------------------------------------------
-# Copy source artifacts to specified install prefix.
-function copy_source_artifacts
-{
-  cp LICENSE.TXT "$1/"
-}
-
-#------------------------------------------------------------------------------
-# Copy built artifacts to specified install prefix.
-function copy_build_artifacts
-{
-  cp bazel-bin/external/lcm/liblcm.so "$1/lib/"
-  cp bazel-bin/drake/libdrake.so "$1/lib/"
-  cp bazel-genfiles/tools/drake-config.cmake "$1/lib/cmake/drake/"
-}
-
-#------------------------------------------------------------------------------
-# Extract headers to specified install prefix.
-function extract_headers
-{ (
-  cd "$1/include/external"
-  mkdir scratch && cd scratch
-
-  # Un-tar the headers. The -P flag and scratch directory are necessary because
-  # Bazel bakes a .. into the paths of external headers.
-  tar -xPzf "$workspace/bazel-bin/drake/libdrake_headers.tar.gz"
-
-  # Headers from Drake proper are now inside include/external/scratch, while
-  # headers from externals are in include/external. Move the Drake headers up
-  # to include/drake.
-  mv drake "$tmpdir/include"
-
-  # Remove the scratch directory
-  cd ..
-  rmdir scratch
-) }
-
-#------------------------------------------------------------------------------
-# Extract licenses to specified install prefix.
-function extract_licenses
-{ (
-  cd "$1/include/external"
-  tar -xzf "$workspace/bazel-bin/drake/external_licenses.tar.gz"
-) }
-
-#------------------------------------------------------------------------------
-# Verify licenses in the specified install prefix.
-function verify_licenses
-{ (
-  cd "$1/include/external"
-
-  missing=()
-
-  # Inspect each external.
-  for ext in $(ls -d1 */); do
-    # Look for a license file or files.
-    if [ -z "$(find $ext -name 'LICENSE*' -o -name 'COPYING*')" ]; then
-      missing+=(${ext%/})
-    fi
-  done
-
-  # Check if any licenses were missing, and if so, report them.
-  if [ ${#missing[*]} -gt 0 ]; then
-    printf -v missing '%s, ' "${missing[@]}"
-    echo "Fatal: missing license for ${missing%, }" >&2
-    exit 1
-  fi
-) }
-
-#------------------------------------------------------------------------------
-# Create tarball of specified install prefix ($1) with specified name ($2).
-function create_tarfile
-{ (
-  cd "$1"
-  tar -czf "$2" *
-) }
-
-#------------------------------------------------------------------------------
-# Copy temporary install prefix ($1) to final install prefix ($2).
-function install_tree
-{ (
-  # Change to source tree and iterate over files.
-  cd "$1"
-  for f in *; do
-    [ "$f" == '*' ] && break # guard against empty directory
-
-    # Test if directory entry is a file or another directory.
-    if [ -d "$f" ]; then
-      # Recursively traverse directories.
-      mkdir -p "$2/$f"
-      install_tree "$1/$f" "$2/$f" "${3-}$f/"
-    else
-      # Copy file if different, otherwise do nothing.
-      if cmp "$1/$f" "$2/$f" >/dev/null 2>&1; then
-        echo "[Up to Date] ${3-}$f"
-      else
-        echo "[Installing] ${3-}$f"
-        cp "$1/$f" "$2/$f"
-      fi
-    fi
-  done
-) }
-
 ###############################################################################
 
 # Initialize action variables.
-install_prefix=
-output_tarfile=
+output_tarfile=""
 
 # Get actions
 while getopts 'd:f:v' opt; do
   case $opt in
-    d) install_prefix="$OPTARG";;
     f) output_tarfile="$OPTARG";;
-    v) set -x
+    d) echo "The -d option is deprecated; use 'bazel run install -- <prefix>'";;
+    v) set -x;;
   esac
 done
+shift $((OPTIND - 1))
+[ -z "$output_tarfile" ] && [ $# -gt 0 ] && output_tarfile="$1"
 
-# Test that we were asked to do something.
-if [ -z "$install_prefix" ] && [ -z "$output_tarfile" ]; then
-  echo "No install directory or output tar file specified." >&2
-  echo "Usage: $0 [-d INSTALL_DIR] [-f FILE.tar.gz]"
+# Test that an output tar file name was given.
+if [ -z "$output_tarfile" ]; then
+  echo "No output tar file specified." >&2
+  echo "Usage: $0 [-v] [-f] FILE.tar.gz"
   exit 1
 fi
 
-# Resolve output paths (before changing directory!).
-if [ -n "$output_tarfile" ]; then
-  tmp="$(canonicalize "$output_tarfile")"
-  if [ -z "$output_tarfile" ]; then
-    echo "Fatal: cannot write '$output_tarfile'" >&2
-    exit 1
-  fi
-  output_tarfile="$tmp"
-  unset tmp
+# Resolve output path (before changing directory!).
+tmp="$(canonicalize "$output_tarfile")"
+if [ -z "$tmp" ]; then
+  echo "Fatal: cannot write '$output_tarfile'" >&2
+  exit 1
 fi
-if [ -n "$install_prefix" ]; then
-  mkdir -p "$install_prefix"
-  if ! [ -d "$install_prefix" ]; then
-    echo "Fatal: cannot create install directory '$install_prefix'" >&2
-    exit 1
-  fi
-  install_prefix="$(canonicalize "$install_prefix")"
-fi
+output_tarfile="$tmp"
+unset tmp
 
 # Find the bazel workspace root and set as working directory.
 cd "$(dirname "$(canonicalize "$0")")"
 workspace="$(canonicalize "$(bazel info workspace)")"
 cd "$workspace"
 
-# Build Drake.
-bazel build \
-  //drake:libdrake.so \
-  //drake:libdrake_headers \
-  //drake:external_licenses
-
-# Create and populate temporary install tree.
+# Create and install into a temporary install tree.
 tmpdir=$(mktemp -d)
-mkdir -p "$tmpdir/lib/cmake/drake"
-mkdir -p "$tmpdir/include/external"
-
-copy_source_artifacts "$tmpdir"
-copy_build_artifacts "$tmpdir"
-extract_headers "$tmpdir"
-extract_licenses "$tmpdir"
-
-verify_licenses "$tmpdir"
-
+# Build Drake.
+bazel run install -- "$tmpdir" >&-
 chmod -R u+w,ugo+r "$tmpdir"
 
-# Execute requested actions.
-[ -n "$output_tarfile" ] && create_tarfile "$tmpdir" "$output_tarfile"
-[ -n "$install_prefix" ] && install_tree "$tmpdir" "$install_prefix"
+# Create tar file.
+(
+  cd "$tmpdir"
+  tar -czf "$output_tarfile" *
+)
 
-# Remove temporary install tree
+# Remove temporary install tree.
 rm -r "$tmpdir"


### PR DESCRIPTION
Modify Drake's CPS to properly export its transitive dependencies (so e.g. users no longer need to find and "link" to Eigen). Update/rewrite `package_drake.sh` to use the new install framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6205)
<!-- Reviewable:end -->
