### PR TITLE
Add elevation (`h`) bounds to the maliput API.

### DIFF
--- a/drake/automotive/maliput/api/lane.h
+++ b/drake/automotive/maliput/api/lane.h
@@ -84,6 +84,13 @@ class Lane {
   /// the lane's segment.
   RBounds driveable_bounds(double s) const { return do_driveable_bounds(s); }
 
+  /// Returns the elevation (`h`) bounds of the lane as a function of `(s, r)`.
+  ///
+  /// These are the elevation bounds for a position that is considered to be
+  /// within the volume modelled by the RoadGeometry.
+  HBounds elevation_bounds(double s, double r) const {
+    return do_elevation_bounds(s, r); }
+
   /// Returns the GeoPosition corresponding to the given LanePosition.
   ///
   /// @pre The s component of @p lane_pos must be in domain [0, Lane::length()].
@@ -193,6 +200,8 @@ class Lane {
   virtual RBounds do_lane_bounds(double s) const = 0;
 
   virtual RBounds do_driveable_bounds(double s) const = 0;
+
+  virtual HBounds do_elevation_bounds(double s, double r) const = 0;
 
   virtual GeoPosition DoToGeoPosition(const LanePosition& lane_pos) const = 0;
 

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -277,6 +277,41 @@ struct RBounds {
   double r_max{};
 };
 
+
+/// Bounds in the elevation dimension (`h` component) of a `Lane`-frame,
+/// consisting of a pair of minimum and maximum `h` value.  The bounds
+/// must straddle `h = 0`, i.e., the minimum must be `<= 0` and the
+/// maximum must be `>= 0`.
+class HBounds {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HBounds)
+
+  /// Default constructor.
+  HBounds() = default;
+
+  /// Fully parameterized constructor.
+  HBounds(double min, double max) : min_(min), max_(max) {
+    DRAKE_DEMAND(min <= 0.);
+    DRAKE_DEMAND(max >= 0.);
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// Gets minimum bound.
+  double min() const { return min_; }
+  /// Sets minimum bound.
+  void set_min(double min) { min_ = min; }
+  /// Gets maximum bound.
+  double max() const { return max_; }
+  /// Sets maximum bound.
+  void set_max(double max) { max_ = max; }
+  //@}
+
+ private:
+  double min_{};
+  double max_{};
+};
+
 }  // namespace api
 }  // namespace maliput
 }  // namespace drake

--- a/drake/automotive/maliput/dragway/lane.h
+++ b/drake/automotive/maliput/dragway/lane.h
@@ -139,6 +139,10 @@ class Lane final : public api::Lane {
 
   api::RBounds do_driveable_bounds(double) const final;
 
+  api::HBounds do_elevation_bounds(double, double) const final {
+    DRAKE_ABORT();  // TODO(maddog@tri.global)  Implement me.
+  }
+
   api::LanePosition DoEvalMotionDerivatives(
       const api::LanePosition& position,
       const api::IsoLaneVelocity& velocity) const final;

--- a/drake/automotive/maliput/monolane/lane.h
+++ b/drake/automotive/maliput/monolane/lane.h
@@ -238,6 +238,10 @@ class Lane : public api::Lane {
     return driveable_bounds_;
   }
 
+  api::HBounds do_elevation_bounds(double, double) const override {
+    DRAKE_ABORT();  // TODO(maddog@tri.global)  Implement me.
+  }
+
   api::GeoPosition DoToGeoPosition(
       const api::LanePosition& lane_pos) const override;
 


### PR DESCRIPTION
This commit only defines an `HBounds` type and adds an accessor method
to the Lane API.  Implementations/use of this method will come in
forthcoming commits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6207)
<!-- Reviewable:end -->
