### PR TITLE
Refactor symbolic formula visitor

### DIFF
--- a/drake/common/symbolic_formula_visitor.h
+++ b/drake/common/symbolic_formula_visitor.h
@@ -4,51 +4,53 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/symbolic_formula.h"
-#include "drake/common/symbolic_formula_cell.h"
 
 namespace drake {
 namespace symbolic {
 
 /// Calls visitor object @p v with a symbolic formula @p f, and arguments @p
-/// args. Visitor object is expected to implement <tt>Result operator(...)</tt>
-/// which takes a shared pointer of a class in FormulaCell's inheritance
-/// hierarchy.
+/// args. Visitor object is expected to implement the following methods which
+/// take @p f and @p args: `VisitFalse`, `VisitTrue`, `VisitVariable`,
+/// `VisitEqualTo`, VisitNotEqualTo, VisitGreaterThan,
+/// `VisitGreaterThanOrEqualTo`, `VisitLessThan`, `VisitLessThanOrEqualTo`,
+/// `VisitConjunction`, `VisitDisjunction`, `VisitNegation`, `VisitForall`,
+/// `VisitIsnan`, `VisitPositiveSemidefinite`.
 ///
 /// Check the implementation of @c NegationNormalFormConverter class in
 /// drake/common/test/symbolic_formula_visitor_test.cc file to find an example.
 template <typename Result, typename Visitor, typename... Args>
-Result VisitFormula(const Visitor& v, const Formula& f, Args&&... args) {
+Result VisitFormula(Visitor* v, const Formula& f, Args&&... args) {
   switch (f.get_kind()) {
     case FormulaKind::False:
-      return v(to_false(f), std::forward<Args>(args)...);
+      return v->VisitFalse(f, std::forward<Args>(args)...);
     case FormulaKind::True:
-      return v(to_true(f), std::forward<Args>(args)...);
+      return v->VisitTrue(f, std::forward<Args>(args)...);
     case FormulaKind::Var:
-      return v(to_variable(f), std::forward<Args>(args)...);
+      return v->VisitVariable(f, std::forward<Args>(args)...);
     case FormulaKind::Eq:
-      return v(to_equal_to(f), std::forward<Args>(args)...);
+      return v->VisitEqualTo(f, std::forward<Args>(args)...);
     case FormulaKind::Neq:
-      return v(to_not_equal_to(f), std::forward<Args>(args)...);
+      return v->VisitNotEqualTo(f, std::forward<Args>(args)...);
     case FormulaKind::Gt:
-      return v(to_greater_than(f), std::forward<Args>(args)...);
+      return v->VisitGreaterThan(f, std::forward<Args>(args)...);
     case FormulaKind::Geq:
-      return v(to_greater_than_or_equal_to(f), std::forward<Args>(args)...);
+      return v->VisitGreaterThanOrEqualTo(f, std::forward<Args>(args)...);
     case FormulaKind::Lt:
-      return v(to_less_than(f), std::forward<Args>(args)...);
+      return v->VisitLessThan(f, std::forward<Args>(args)...);
     case FormulaKind::Leq:
-      return v(to_less_than_or_equal_to(f), std::forward<Args>(args)...);
+      return v->VisitLessThanOrEqualTo(f, std::forward<Args>(args)...);
     case FormulaKind::And:
-      return v(to_conjunction(f), std::forward<Args>(args)...);
+      return v->VisitConjunction(f, std::forward<Args>(args)...);
     case FormulaKind::Or:
-      return v(to_disjunction(f), std::forward<Args>(args)...);
+      return v->VisitDisjunction(f, std::forward<Args>(args)...);
     case FormulaKind::Not:
-      return v(to_negation(f), std::forward<Args>(args)...);
+      return v->VisitNegation(f, std::forward<Args>(args)...);
     case FormulaKind::Forall:
-      return v(to_forall(f), std::forward<Args>(args)...);
+      return v->VisitForall(f, std::forward<Args>(args)...);
     case FormulaKind::Isnan:
-      return v(to_isnan(f), std::forward<Args>(args)...);
+      return v->VisitIsnan(f, std::forward<Args>(args)...);
     case FormulaKind::PositiveSemidefinite:
-      return v(to_positive_semidefinite(f), std::forward<Args>(args)...);
+      return v->VisitPositiveSemidefinite(f, std::forward<Args>(args)...);
   }
   // Should not be reachable. But we need the following to avoid "control
   // reaches end of non-void function" gcc-warning.


### PR DESCRIPTION
1. The type of the first argument of `VisitFormula` is changed: `const Visitor& v` -> `Visitor* v` to allow a visit-process to modify `v` (which might include a state).

2. Previously, we exposed the FormulaCell classes such as `FormulaAnd` and `FormulaVar` in this file, which is violating the encapsulation. This patch changes `Visit*` function to take `const
Formula&` instead of `const shared_ptr<FormulaCell>&`.

I'll open a similar PR for the expression visitor class later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6215)
<!-- Reviewable:end -->
