### PR TITLE
Install fmt and spdlog targets from the Bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,10 +37,12 @@ install(
     deps = [
         "@bullet//:install",
         "@eigen//:install",
+        "@fmt//:install",
         "@ipopt//:install",
         "@lcm//:install",
         "@nlopt//:install",
         "@pybind11//:install",
+        "@spdlog//:install",
         "//drake:install",
         "//tools:install",
     ],

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -80,10 +80,12 @@ exports_files(
 exports_create_cps_scripts([
     "bullet",
     "eigen",
+    "fmt",
     "ipopt",
     "lcm",
     "nlopt",
     "pybind11",
+    "spdlog",
 ])
 
 alias(

--- a/tools/fmt-create-cps.py
+++ b/tools/fmt-create-cps.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+def_re = re.compile("set\(FMT_VERSION\s([0-9]+).([0-9]+).([0-9]+)")
+defs = {}
+with open(sys.argv[1]) as h:
+    for l in h:
+        m = def_re.match(l)
+        if m is not None:
+            defs['VERSION_MAJOR'] = m.group(1)
+            defs['VERSION_MINOR'] = m.group(2)
+            defs['VERSION_PATCH'] = m.group(3)
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "fmt",
+  "Description": "Small, safe and fast formatting library",
+  "License": "BSD-2-Clause",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
+  "Default-Components": [ ":fmt" ],
+  "Components": {
+    "fmt-header-only": {
+      "Type": "interface",
+      "Includes": [ "@prefix@/include" ]
+    },
+    "fmt": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libfmt.so",
+      "Requires": [ ":fmt-header-only" ]
+    }
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/fmt.BUILD
+++ b/tools/fmt.BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -11,6 +12,25 @@ cc_library(
     srcs = glob(["fmt/*.cc"]),
     hdrs = glob(["fmt/*.h"]),
     includes = ["."],
+)
+
+cmake_config(
+    package = "fmt",
+    script = "@drake//tools:fmt-create-cps.py",
+    version_file = "CMakeLists.txt",
+)
+
+install_cmake_config(package = "fmt")  # Creates rule :install_cmake_config.
+
+install(
+    name = "install",
+    doc_dest = "share/doc/fmt",
+    guess_hdrs = "PACKAGE",
+    hdr_dest = "include/fmt",
+    hdr_strip_prefix = ["fmt"],
+    license_docs = ["LICENSE.rst"],
+    targets = [":fmt"],
+    deps = [":install_cmake_config"],
 )
 
 pkg_tar(

--- a/tools/spdlog-create-cps.py
+++ b/tools/spdlog-create-cps.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+def_re = re.compile("project\(spdlog\sVERSION\s([0-9]+).([0-9]+).([0-9]+)")
+defs = {}
+with open(sys.argv[1]) as h:
+    for l in h:
+        m = def_re.match(l)
+        if m is not None:
+            defs['VERSION_MAJOR'] = m.group(1)
+            defs['VERSION_MINOR'] = m.group(2)
+            defs['VERSION_PATCH'] = m.group(3)
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "spdlog",
+  "Description": "Super fast C++ logging library",
+  "License": "MIT",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
+  "Requires": {
+    "fmt": {
+      "Version": "3.0.1",
+      "Hints": ["@prefix@/lib/cmake/fmt"],
+      "X-CMake-Find-Args": [ "CONFIG" ]
+    }
+  },
+  "Default-Components": [ ":spdlog" ],
+  "Components": {
+    "spdlog": {
+      "Type": "interface",
+      "Includes": [ "@prefix@/include" ],
+      "Definitions": ["SPDLOG_FMT_EXTERNAL", "HAVE_SPDLOG"],
+      "Requires": [ "fmt:fmt" ]
+    }
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -1,5 +1,6 @@
 # -*- python -*-
 
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 package(
@@ -19,6 +20,25 @@ cc_library(
         "@//conditions:default": [],  # This is a bazel-default rule, and does not need @drake//
     }),
     deps = ["@fmt"],
+)
+
+cmake_config(
+    package = "spdlog",
+    script = "@drake//tools:spdlog-create-cps.py",
+    version_file = "CMakeLists.txt",
+)
+
+install_cmake_config(package = "spdlog")  # Creates rule :install_cmake_config.
+
+install(
+    name = "install",
+    doc_dest = "share/doc/spdlog",
+    guess_hdrs = "PACKAGE",
+    hdr_dest = "include/spdlog",
+    hdr_strip_prefix = ["include/spdlog"],
+    license_docs = ["LICENSE"],
+    targets = [":spdlog"],
+    deps = [":install_cmake_config"],
 )
 
 pkg_tar(


### PR DESCRIPTION
Following the same pattern used for previous install targets from
the Bazel build, this commit adds fmt and spdlog (which depends on
fmt).

Installing the targets can be done with the following command line:
bazel run install -- /my/install/prefix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6221)
<!-- Reviewable:end -->
