### PR TITLE
Cache the gripper position during discrete updates instead of looking at it in DoCalcOutput

### DIFF
--- a/drake/manipulation/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.cc
+++ b/drake/manipulation/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.cc
@@ -10,12 +10,13 @@ namespace schunk_wsg {
 const int SchunkWsgTrajectoryGeneratorStateVectorIndices::kNumCoordinates;
 const int SchunkWsgTrajectoryGeneratorStateVectorIndices::kLastTargetPosition;
 const int SchunkWsgTrajectoryGeneratorStateVectorIndices::kTrajectoryStartTime;
+const int SchunkWsgTrajectoryGeneratorStateVectorIndices::kLastPosition;
 
 const std::vector<std::string>&
 SchunkWsgTrajectoryGeneratorStateVectorIndices::GetCoordinateNames() {
   static const never_destroyed<std::vector<std::string>> coordinates(
       std::vector<std::string>{
-          "last_target_position", "trajectory_start_time",
+          "last_target_position", "trajectory_start_time", "last_position",
       });
   return coordinates.access();
 }

--- a/drake/manipulation/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h
+++ b/drake/manipulation/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h
@@ -20,11 +20,12 @@ namespace schunk_wsg {
 /// Describes the row indices of a SchunkWsgTrajectoryGeneratorStateVector.
 struct SchunkWsgTrajectoryGeneratorStateVectorIndices {
   /// The total number of rows (coordinates).
-  static const int kNumCoordinates = 2;
+  static const int kNumCoordinates = 3;
 
   // The index of each individual coordinate.
   static const int kLastTargetPosition = 0;
   static const int kTrajectoryStartTime = 1;
+  static const int kLastPosition = 2;
 
   /// Returns a vector containing the names of each coordinate within this
   /// class. The indices within the returned vector matches that of this class.
@@ -67,6 +68,11 @@ class SchunkWsgTrajectoryGeneratorStateVector : public systems::BasicVector<T> {
   void set_trajectory_start_time(const T& trajectory_start_time) {
     this->SetAtIndex(K::kTrajectoryStartTime, trajectory_start_time);
   }
+  /// last_position
+  const T& last_position() const { return this->GetAtIndex(K::kLastPosition); }
+  void set_last_position(const T& last_position) {
+    this->SetAtIndex(K::kLastPosition, last_position);
+  }
   //@}
 
   /// See SchunkWsgTrajectoryGeneratorStateVectorIndices::GetCoordinateNames().
@@ -80,6 +86,7 @@ class SchunkWsgTrajectoryGeneratorStateVector : public systems::BasicVector<T> {
     auto result = (T(0) == T(0));
     result = result && !isnan(last_target_position());
     result = result && !isnan(trajectory_start_time());
+    result = result && !isnan(last_position());
     return result;
   }
 };

--- a/drake/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -32,10 +32,6 @@ SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(
 void SchunkWsgTrajectoryGenerator::DoCalcOutput(
     const Context<double>& context,
     SystemOutput<double>* output) const {
-  const systems::BasicVector<double>* state =
-      this->EvalVectorInput(context, 1);
-  const double cur_position = state->GetAtIndex(position_index_);
-
   const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
       dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
           context.get_discrete_state(0));
@@ -45,7 +41,7 @@ void SchunkWsgTrajectoryGenerator::DoCalcOutput(
         context.get_time() - traj_state->trajectory_start_time());
   } else {
     this->GetMutableOutputVector(output, 0) =
-        Eigen::Vector2d(cur_position, 0);
+        Eigen::Vector2d(traj_state->last_position(), 0);
   }
 }
 
@@ -75,6 +71,7 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
   SchunkWsgTrajectoryGeneratorStateVector<double>* new_traj_state =
       dynamic_cast<SchunkWsgTrajectoryGeneratorStateVector<double>*>(
           discrete_state->get_mutable_vector(0));
+  new_traj_state->set_last_position(cur_position);
 
   if (std::abs(last_traj_state->last_target_position() - target_position) >
       kTargetEpsilon) {

--- a/drake/manipulation/schunk_wsg/schunk_wsg_trajectory_generator_gen.sh
+++ b/drake/manipulation/schunk_wsg/schunk_wsg_trajectory_generator_gen.sh
@@ -13,4 +13,4 @@ namespace="drake::manipulation::schunk_wsg"
 source $drake/tools/lcm_vector_gen.sh
 
 gen_vector "schunk wsg trajectory generator state vector" \
-           last_target_position trajectory_start_time
+           last_target_position trajectory_start_time last_position


### PR DESCRIPTION
This roughly halved the required time to execute a simulation in the
example I was working with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6222)
<!-- Reviewable:end -->
