### PR TITLE
Fix trapezoid rule to match comment

### DIFF
--- a/drake/systems/trajectory_optimization/direct_collocation.cc
+++ b/drake/systems/trajectory_optimization/direct_collocation.cc
@@ -112,13 +112,12 @@ void DircolTrajectoryOptimization::DoAddRunningCost(
   // g_0*h_0/2.0 + [sum_{i=1...N-2} g_i*(h_{i-1} + h_i)/2.0] +
   // g_{N-1}*h_{N-2}/2.0.
 
-  AddCost(0.5 * SubstitutePlaceholderVariables(g * h_vars()(0) / 2, 0));
+  AddCost(SubstitutePlaceholderVariables(g * h_vars()(0) / 2, 0));
   for (int i = 1; i < N() - 2; i++) {
     AddCost(SubstitutePlaceholderVariables(
         g * (h_vars()(i - 1) + h_vars()(i)) / 2, i));
   }
-  AddCost(0.5 *
-          SubstitutePlaceholderVariables(g * h_vars()(N() - 2) / 2, N() - 1));
+  AddCost(SubstitutePlaceholderVariables(g * h_vars()(N() - 2) / 2, N() - 1));
 }
 
 // We just use a generic constraint here since we need to mangle the


### PR DESCRIPTION
I believe the implementation has extra `.5` for the end terms

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6223)
<!-- Reviewable:end -->
