### PR TITLE
Implement elevation bounds in `monolane` maliput backend.

### DIFF
--- a/drake/automotive/maliput/monolane/arc_lane.h
+++ b/drake/automotive/maliput/monolane/arc_lane.h
@@ -26,14 +26,19 @@ class ArcLane : public Lane {
   /// @param d_theta central angle of the arc, i.e., angular displacement
   ///                from start to end.  d_theta > 0 is counter-clockwise.
   ///
-  /// @param id,segment,lane_bounds,driveable_bounds,elevation,superelevation
+  /// @param id,segment,lane_bounds,driveable_bounds,elevation_bounds
+  ///        See documentation for the Lane base class.
+  /// @param elevation,superelevation
   ///        See documentation for the Lane base class.
   ///
   /// N.B. The override ArcLane::ToLanePosition() is currently restricted to
   /// lanes in which superelevation and elevation change are both zero.
-  ArcLane(const api::LaneId& id, const api::Segment* segment, const V2& center,
-          double radius, double theta0, double d_theta,
-          const api::RBounds& lane_bounds, const api::RBounds& driveable_bounds,
+  ArcLane(const api::LaneId& id, const api::Segment* segment,
+          const V2& center, double radius,
+          double theta0, double d_theta,
+          const api::RBounds& lane_bounds,
+          const api::RBounds& driveable_bounds,
+          const api::HBounds& elevation_bounds,
           const CubicPolynomial& elevation,
           const CubicPolynomial& superelevation);
 

--- a/drake/automotive/maliput/monolane/builder.cc
+++ b/drake/automotive/maliput/monolane/builder.cc
@@ -16,10 +16,12 @@ namespace monolane {
 
 Builder::Builder(const api::RBounds& lane_bounds,
                  const api::RBounds& driveable_bounds,
+                 const api::HBounds& elevation_bounds,
                  const double linear_tolerance,
                  const double angular_tolerance)
     : lane_bounds_(lane_bounds),
       driveable_bounds_(driveable_bounds),
+      elevation_bounds_(elevation_bounds),
       linear_tolerance_(linear_tolerance),
       angular_tolerance_(angular_tolerance) {
   DRAKE_DEMAND(lane_bounds_.r_min >= driveable_bounds_.r_min);
@@ -211,6 +213,7 @@ Lane* Builder::BuildConnection(
       lane = segment->NewLineLane(lane_id,
                                   xy0, dxy,
                                   lane_bounds_, driveable_bounds_,
+                                  elevation_bounds_,
                                   elevation, superelevation);
       break;
     }
@@ -237,6 +240,7 @@ Lane* Builder::BuildConnection(
       lane = segment->NewArcLane(lane_id,
                                  center, radius, theta0, d_theta,
                                  lane_bounds_, driveable_bounds_,
+                                 elevation_bounds_,
                                  elevation, superelevation);
       break;
     }

--- a/drake/automotive/maliput/monolane/builder.h
+++ b/drake/automotive/maliput/monolane/builder.h
@@ -25,7 +25,8 @@ class RoadGeometry;
 ///
 /// monolane is a simple road-network implementation:
 ///  - single lane per segment;
-///  - constant lane_bounds and driveable_bounds, same for all lanes;
+///  - constant lane_bounds, driveable_bounds, and elevation_bounds,
+///    same for all lanes;
 ///  - only linear and constant-curvature-arc primitives in XY-plane;
 ///  - cubic polynomials (parameterized on XY-arc-length) for elevation
 ///    and superelevation;
@@ -319,12 +320,14 @@ class Builder {
   /// Constructs a Builder which can be used to specify and assemble a
   /// monolane implementation of an api::RoadGeometry.
   ///
-  /// The bounds @p lane_bounds and @p driveable_bounds are applied uniformly
-  /// to the single lanes of every segment; @p lane_bounds must be a subset
-  /// of @p driveable_bounds.  @p linear_tolerance and @p angular_tolerance
-  /// specify the respective tolerances for the resulting RoadGeometry.
+  /// The bounds @p lane_bounds, @p driveable_bounds, and @p elevation_bounds
+  /// are applied uniformly to the single lanes of every segment;
+  /// @p lane_bounds must be a subset of @p driveable_bounds.
+  /// @p linear_tolerance and @p angular_tolerance specify the respective
+  /// tolerances for the resulting RoadGeometry.
   Builder(const api::RBounds& lane_bounds,
           const api::RBounds& driveable_bounds,
+          const api::HBounds& elevation_bounds,
           const double linear_tolerance,
           const double angular_tolerance);
 
@@ -455,6 +458,7 @@ class Builder {
 
   api::RBounds lane_bounds_;
   api::RBounds driveable_bounds_;
+  api::HBounds elevation_bounds_;
   double linear_tolerance_{};
   double angular_tolerance_{};
   std::vector<std::unique_ptr<Connection>> connections_;

--- a/drake/automotive/maliput/monolane/double_ring.yaml
+++ b/drake/automotive/maliput/monolane/double_ring.yaml
@@ -5,6 +5,7 @@ maliput_monolane_builder:
   id: fig8
   lane_bounds: [-2, 2]
   driveable_bounds: [-4, 4]
+  elevation_bounds: [0, 5]
   position_precision: .01
   orientation_precision: 0.5
   points:

--- a/drake/automotive/maliput/monolane/fig8.yaml
+++ b/drake/automotive/maliput/monolane/fig8.yaml
@@ -5,6 +5,7 @@ maliput_monolane_builder:
   id: fig8
   lane_bounds: [-3, 3]
   driveable_bounds: [-8, 8]
+  elevation_bounds: [0, 5]
   position_precision: .01
   orientation_precision: 0.5
   points:

--- a/drake/automotive/maliput/monolane/helix.yaml
+++ b/drake/automotive/maliput/monolane/helix.yaml
@@ -5,6 +5,7 @@ maliput_monolane_builder:
   id: helix
   lane_bounds: [-2, 2]
   driveable_bounds: [-4, 4]
+  elevation_bounds: [0, 5]
   position_precision: .01
   orientation_precision: 0.5
   points:

--- a/drake/automotive/maliput/monolane/lane.h
+++ b/drake/automotive/maliput/monolane/lane.h
@@ -136,6 +136,8 @@ class Lane : public api::Lane {
   ///        reference path, which must be a subset of @p driveable_bounds
   /// @param driveable_bounds driveable bounds of the lane, uniform along the
   ///        entire reference path
+  /// @param elevation_bounds elevation bounds of the lane, uniform along the
+  ///        entire driveable surface
   /// @param p_scale isotropic scale factor for elevation and superelevation
   /// @param elevation elevation function (see below)
   /// @param superelevation superelevation function (see below)
@@ -178,12 +180,14 @@ class Lane : public api::Lane {
   Lane(const api::LaneId& id, const api::Segment* segment,
        const api::RBounds& lane_bounds,
        const api::RBounds& driveable_bounds,
+       const api::HBounds& elevation_bounds,
        double p_scale,
        const CubicPolynomial& elevation,
        const CubicPolynomial& superelevation)
       : id_(id), segment_(segment),
         lane_bounds_(lane_bounds),
         driveable_bounds_(driveable_bounds),
+        elevation_bounds_(elevation_bounds),
         p_scale_(p_scale),
         elevation_(elevation),
         superelevation_(superelevation) {
@@ -239,7 +243,7 @@ class Lane : public api::Lane {
   }
 
   api::HBounds do_elevation_bounds(double, double) const override {
-    DRAKE_ABORT();  // TODO(maddog@tri.global)  Implement me.
+    return elevation_bounds_;
   }
 
   api::GeoPosition DoToGeoPosition(
@@ -344,6 +348,7 @@ class Lane : public api::Lane {
 
   const api::RBounds lane_bounds_;
   const api::RBounds driveable_bounds_;
+  const api::HBounds elevation_bounds_;
   const double p_scale_{};
   const CubicPolynomial elevation_;
   const CubicPolynomial superelevation_;

--- a/drake/automotive/maliput/monolane/line_lane.cc
+++ b/drake/automotive/maliput/monolane/line_lane.cc
@@ -41,7 +41,10 @@ api::LanePosition LineLane::DoToLanePosition(
                                   driveable_bounds(s).r_max);
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
-  const double h = geo_position.z() - elevation().a() * length;
+  const double h_unsaturated = geo_position.z() - elevation().a() * length;
+  const double h = math::saturate(h_unsaturated,
+                                  elevation_bounds(s, r).min(),
+                                  elevation_bounds(s, r).max());
 
   const api::LanePosition lane_position{s, r, h};
 
@@ -50,8 +53,7 @@ api::LanePosition LineLane::DoToLanePosition(
     *nearest_position = nearest;
   }
   if (distance != nullptr) {
-    const V2 p_to_nearest{p(0) - nearest.x(), p(1) - nearest.y()};
-    *distance = p_to_nearest.norm();
+    *distance = (nearest.xyz() - geo_position.xyz()).norm();
   }
 
   return lane_position;

--- a/drake/automotive/maliput/monolane/line_lane.h
+++ b/drake/automotive/maliput/monolane/line_lane.h
@@ -19,7 +19,9 @@ class LineLane : public Lane {
   /// @param xy0 start point of the reference line segment
   /// @param dxy displacement to the end point of the reference line segment
   ///
-  /// @param id,segment,lane_bounds,driveable_bounds,elevation,superelevation
+  /// @param id,segment,lane_bounds,driveable_bounds,elevation_bounds
+  ///        See documentation for the Lane base class.
+  /// @param elevation,superelevation
   ///        See documentation for the Lane base class.
   ///
   /// N.B. The override LineLane::ToLanePosition() is currently restricted to
@@ -27,10 +29,13 @@ class LineLane : public Lane {
   LineLane(const api::LaneId& id, const api::Segment* segment, const V2& xy0,
            const V2& dxy, const api::RBounds& lane_bounds,
            const api::RBounds& driveable_bounds,
+           const api::HBounds& elevation_bounds,
            const CubicPolynomial& elevation,
            const CubicPolynomial& superelevation)
-      : Lane(id, segment, lane_bounds, driveable_bounds, dxy.norm(), elevation,
-             superelevation),
+      : Lane(id, segment,
+             lane_bounds, driveable_bounds, elevation_bounds,
+             dxy.norm(),
+             elevation, superelevation),
         x0_(xy0.x()),
         y0_(xy0.y()),
         dx_(dxy.x()),

--- a/drake/automotive/maliput/monolane/loader.cc
+++ b/drake/automotive/maliput/monolane/loader.cc
@@ -24,6 +24,13 @@ api::RBounds r_bounds(const YAML::Node& node) {
 }
 
 
+api::HBounds h_bounds(const YAML::Node& node) {
+  DRAKE_DEMAND(node.IsSequence());
+  DRAKE_DEMAND(node.size() == 2);
+  return api::HBounds(node[0].as<double>(), node[1].as<double>());
+}
+
+
 double deg_to_rad(double degrees) {
   return degrees * M_PI / 180.;
 }
@@ -147,6 +154,7 @@ std::unique_ptr<const api::RoadGeometry> BuildFrom(YAML::Node node) {
 
   Builder builder(r_bounds(mmb["lane_bounds"]),
                   r_bounds(mmb["driveable_bounds"]),
+                  h_bounds(mmb["elevation_bounds"]),
                   mmb["position_precision"].as<double>(),
                   deg_to_rad(mmb["orientation_precision"].as<double>()));
 

--- a/drake/automotive/maliput/monolane/ring.yaml
+++ b/drake/automotive/maliput/monolane/ring.yaml
@@ -5,6 +5,7 @@ maliput_monolane_builder:
   id: ring
   lane_bounds: [-3, 3]
   driveable_bounds: [-8, 8]
+  elevation_bounds: [0, 5]
   position_precision: .01
   orientation_precision: 0.5
   points:

--- a/drake/automotive/maliput/monolane/segment.cc
+++ b/drake/automotive/maliput/monolane/segment.cc
@@ -19,12 +19,13 @@ LineLane* Segment::NewLineLane(api::LaneId id,
                                const V2& xy0, const V2& dxy,
                                const api::RBounds& lane_bounds,
                                const api::RBounds& driveable_bounds,
+                               const api::HBounds& elevation_bounds,
                                const CubicPolynomial& elevation,
                                const CubicPolynomial& superelevation) {
   DRAKE_DEMAND(lane_.get() == nullptr);
   std::unique_ptr<LineLane> lane = std::make_unique<LineLane>(
       id, this, xy0, dxy,
-      lane_bounds, driveable_bounds,
+      lane_bounds, driveable_bounds, elevation_bounds,
       elevation, superelevation);
   LineLane* result = lane.get();
   lane_ = std::move(lane);
@@ -37,12 +38,13 @@ ArcLane* Segment::NewArcLane(api::LaneId id,
                              const double theta0, const double d_theta,
                              const api::RBounds& lane_bounds,
                              const api::RBounds& driveable_bounds,
+                             const api::HBounds& elevation_bounds,
                              const CubicPolynomial& elevation,
                              const CubicPolynomial& superelevation) {
   DRAKE_DEMAND(lane_.get() == nullptr);
   std::unique_ptr<ArcLane> lane = std::make_unique<ArcLane>(
       id, this, center, radius, theta0, d_theta,
-      lane_bounds, driveable_bounds,
+      lane_bounds, driveable_bounds, elevation_bounds,
       elevation, superelevation);
   ArcLane* result = lane.get();
   lane_ = std::move(lane);

--- a/drake/automotive/maliput/monolane/segment.h
+++ b/drake/automotive/maliput/monolane/segment.h
@@ -33,6 +33,7 @@ class Segment : public api::Segment {
                         const V2& xy0, const V2& dxy,
                         const api::RBounds& lane_bounds,
                         const api::RBounds& driveable_bounds,
+                        const api::HBounds& elevation_bounds,
                         const CubicPolynomial& elevation,
                         const CubicPolynomial& superelevation);
 
@@ -42,6 +43,7 @@ class Segment : public api::Segment {
                       const double theta0, const double d_theta,
                       const api::RBounds& lane_bounds,
                       const api::RBounds& driveable_bounds,
+                      const api::HBounds& elevation_bounds,
                       const CubicPolynomial& elevation,
                       const CubicPolynomial& superelevation);
 

--- a/drake/automotive/maliput/monolane/sidewinder.yaml
+++ b/drake/automotive/maliput/monolane/sidewinder.yaml
@@ -5,6 +5,7 @@ maliput_monolane_builder:
   id: sidewinder
   lane_bounds: [-3, 3]
   driveable_bounds: [-8, 8]
+  elevation_bounds: [0, 5]
   position_precision: .01
   orientation_precision: 0.5
   points:

--- a/drake/automotive/maliput/monolane/tee_intersection.yaml
+++ b/drake/automotive/maliput/monolane/tee_intersection.yaml
@@ -5,6 +5,7 @@ maliput_monolane_builder:
   id: tee_intersection
   lane_bounds: [-2, 2]
   driveable_bounds: [-4, 4]
+  elevation_bounds: [0, 5]
   position_precision: .01
   orientation_precision: 0.5
   points:

--- a/drake/automotive/maliput/monolane/test/monolane_builder_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_builder_test.cc
@@ -14,9 +14,11 @@ namespace monolane {
 GTEST_TEST(MonolaneBuilderTest, Fig8) {
   const api::RBounds kLaneBounds(-2., 2.);
   const api::RBounds kDriveableBounds(-4., 4.);
+  const api::HBounds kElevationBounds(0., 5.);
   const double kLinearTolerance = 0.01;
   const double kAngularTolerance = 0.01 * M_PI;
-  Builder b(kLaneBounds, kDriveableBounds, kLinearTolerance, kAngularTolerance);
+  Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
+            kLinearTolerance, kAngularTolerance);
 
   const EndpointZ kLowFlatZ(0., 0., 0., 0.);
   const EndpointZ kMidFlatZ(3., 0., 0., 0.);
@@ -96,9 +98,11 @@ GTEST_TEST(MonolaneBuilderTest, Fig8) {
 GTEST_TEST(MonolaneBuilderTest, QuadRing) {
   const api::RBounds kLaneBounds(-2., 2.);
   const api::RBounds kDriveableBounds(-4., 4.);
+  const api::HBounds kElevationBounds(0., 5.);
   const double kLinearTolerance = 0.01;
   const double kAngularTolerance = 0.01 * M_PI;
-  Builder b(kLaneBounds, kDriveableBounds, kLinearTolerance, kAngularTolerance);
+  Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
+            kLinearTolerance, kAngularTolerance);
 
   const EndpointZ kFlatZ(0., 0., 0., 0.);
   const ArcOffset kLargeClockwiseLoop(150., -2. * M_PI);

--- a/drake/automotive/maliput/monolane/village.yaml
+++ b/drake/automotive/maliput/monolane/village.yaml
@@ -5,6 +5,7 @@ maliput_monolane_builder:
   id: maliput_village
   lane_bounds: [-2, 2]
   driveable_bounds: [-4, 4]
+  elevation_bounds: [0, 5]
   position_precision: .01
   orientation_precision: 0.5
   points:

--- a/drake/automotive/maliput/utility/test/generate_obj_test.cc
+++ b/drake/automotive/maliput/utility/test/generate_obj_test.cc
@@ -73,11 +73,12 @@ class GenerateObjBasicDutTest : public GenerateObjTest {
   const double kAngularTolerance = 0.01 * M_PI;
   const api::RBounds kLaneBounds{-0.5, 0.5};
   const api::RBounds kDriveableBounds{-1., 1.};
+  const api::HBounds kElevationBounds{0., 5.};
 
   void SetUp() override {
     GenerateObjTest::SetUp();
 
-    mono::Builder b(kLaneBounds, kDriveableBounds,
+    mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
                     kLinearTolerance, kAngularTolerance);
 
     const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
@@ -129,7 +130,7 @@ TEST_F(GenerateObjBasicDutTest, ChangeOrigin) {
 
   // Reconstruct the basic DUT, but starting at the offset instead of (0,0,0).
   {
-    mono::Builder b(kLaneBounds, kDriveableBounds,
+    mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
                     kLinearTolerance, kAngularTolerance);
 
     const mono::EndpointZ kZeroZ{kOffsetZ, 0., 0., 0.};
@@ -220,7 +221,7 @@ TEST_F(GenerateObjBasicDutTest, StackedBranchPointsObjContent) {
 
   // Construct a RoadGeometry with two lanes that don't quite connect.
   {
-    mono::Builder b(kLaneBounds, kDriveableBounds,
+    mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
                     kLinearTolerance, kAngularTolerance);
 
     const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
@@ -259,6 +260,7 @@ maliput_monolane_builder:
   id: city_1
   lane_bounds: [-2, 2]
   driveable_bounds: [-4, 4]
+  elevation_bounds: [0, 5]
   position_precision: 0.01
   orientation_precision: 0.5
   points:
@@ -298,7 +300,7 @@ TEST_F(GenerateObjBasicDutTest, HighlightedSegments) {
 
   // Construct a RoadGeometry with two segments.
   {
-    mono::Builder b(kLaneBounds, kDriveableBounds,
+    mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
                     kLinearTolerance, kAngularTolerance);
 
     const mono::EndpointZ kZeroZ{0., 0., 0., 0.};

--- a/drake/automotive/maliput/utility/test/generate_urdf_test.cc
+++ b/drake/automotive/maliput/utility/test/generate_urdf_test.cc
@@ -40,7 +40,8 @@ TEST_F(GenerateUrdfTest, AtLeastRunIt) {
   const double kAngularTolerance = 0.01 * M_PI;
   const api::RBounds kLaneBounds{-1., 1.};
   const api::RBounds kDriveableBounds{-2., 2.};
-  mono::Builder b(kLaneBounds, kDriveableBounds,
+  const api::HBounds kElevationBounds{0., 5.};
+  mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
                   kLinearTolerance, kAngularTolerance);
 
   const mono::EndpointZ kZeroZ{0., 0., 0., 0.};

--- a/drake/automotive/models/speed_bump/speed_bump.yaml
+++ b/drake/automotive/models/speed_bump/speed_bump.yaml
@@ -10,6 +10,7 @@ maliput_monolane_builder:
   id: speed_bump
   lane_bounds: [-3, 3]
   driveable_bounds: [-8, 8]
+  elevation_bounds: [0, 5]
   position_precision: .01
   orientation_precision: 0.5
   points:

--- a/drake/automotive/monolane_onramp_merge.cc
+++ b/drake/automotive/monolane_onramp_merge.cc
@@ -13,6 +13,7 @@ std::unique_ptr<const maliput::api::RoadGeometry>
 MonolaneOnrampMerge::BuildOnramp() {
   std::unique_ptr<maliput::monolane::Builder> rb(
       new maliput::monolane::Builder(rc_.lane_bounds, rc_.driveable_bounds,
+                                     rc_.elevation_bounds,
                                      linear_tolerance_, angular_tolerance_));
 
   // Initialize the road from the origin.

--- a/drake/automotive/monolane_onramp_merge.h
+++ b/drake/automotive/monolane_onramp_merge.h
@@ -26,6 +26,7 @@ struct RoadCharacteristics {
   const maliput::api::RBounds lane_bounds{-lane_width / 2., lane_width / 2.};
   const maliput::api::RBounds driveable_bounds{-driveable_width / 2.,
                                                driveable_width / 2.};
+  const maliput::api::HBounds elevation_bounds{0., 5.2};
 };
 
 /// MonolaneOnrampMerge contains an example lane-merge scenario expressed as a

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -58,6 +58,7 @@ class MaliputRailcarTest : public ::testing::Test {
     maliput::monolane::Builder builder(
         maliput::api::RBounds(-2, 2),   /* lane_bounds       */
         maliput::api::RBounds(-4, 4),   /* driveable_bounds  */
+        maliput::api::HBounds(0, 5),    /* elevation bounds */
         0.01,                           /* linear tolerance  */
         0.5 * M_PI / 180.0);            /* angular_tolerance */
     builder.Connect(
@@ -74,6 +75,7 @@ class MaliputRailcarTest : public ::testing::Test {
     maliput::monolane::Builder builder(
         maliput::api::RBounds(-2, 2),   /* lane_bounds       */
         maliput::api::RBounds(-4, 4),   /* driveable_bounds  */
+        maliput::api::HBounds(0, 5),    /* elevation bounds */
         0.01,                           /* linear tolerance  */
         0.5 * M_PI / 180.0);            /* angular_tolerance */
     builder.Connect(
@@ -101,6 +103,7 @@ class MaliputRailcarTest : public ::testing::Test {
     maliput::monolane::Builder builder(
         maliput::api::RBounds(-2, 2),   /* lane_bounds       */
         maliput::api::RBounds(-4, 4),   /* driveable_bounds  */
+        maliput::api::HBounds(0, 5),    /* elevation bounds */
         0.01,                           /* linear tolerance  */
         0.5 * M_PI / 180.0);            /* angular_tolerance */
     const Connection* straight_lane_connection = builder.Connect(

--- a/drake/automotive/test/road_path_test.cc
+++ b/drake/automotive/test/road_path_test.cc
@@ -42,6 +42,7 @@ const EndpointZ kEndZ{0, 0, 0, 0};  // Specifies zero elevation/super-elevation.
 std::unique_ptr<const RoadGeometry> MakeTwoLaneRoad(bool is_opposing) {
   Builder builder(maliput::api::RBounds(-2, 2), /* lane_bounds */
                   maliput::api::RBounds(-4, 4), /* driveable_bounds */
+                  maliput::api::HBounds(0, 5),  /* elevation bounds */
                   0.01,                         /* linear tolerance */
                   M_PI_2 / 180.0);              /* angular_tolerance */
   builder.Connect("0_fwd",                      /* id */


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6225)
<!-- Reviewable:end -->
