### PR TITLE
Refactor PoseSelector to accept poses up to arbitrary lookahead distances

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -145,8 +145,8 @@ drake_cc_library(
         ":generated_vectors",
         ":idm_planner",
         ":pose_selector",
+        ":road_odometry",
         "//drake/automotive/maliput/api",
-        "//drake/math:saturate",
         "//drake/systems/rendering:pose_bundle",
         "//drake/systems/rendering:pose_vector",
     ],
@@ -195,6 +195,7 @@ drake_cc_library(
         ":idm_planner",
         ":lane_direction",
         ":pose_selector",
+        ":road_odometry",
         "//drake/automotive/maliput/api",
         "//drake/common:cond",
         "//drake/common:symbolic",
@@ -220,6 +221,8 @@ drake_cc_library(
     hdrs = ["pose_selector.h"],
     visibility = [],
     deps = [
+        ":lane_direction",
+        ":road_odometry",
         "//drake/automotive/maliput/api",
         "//drake/systems/rendering:pose_bundle",
         "//drake/systems/rendering:pose_vector",
@@ -250,7 +253,6 @@ drake_cc_library(
     deps = [
         ":generated_vectors",
         ":lane_direction",
-        ":pose_selector",
         "//drake/automotive/maliput/api",
         "//drake/common:cond",
         "//drake/common:symbolic",
@@ -266,9 +268,18 @@ drake_cc_library(
     deps = [
         ":generated_vectors",
         ":lane_direction",
-        ":pose_selector",
         ":pure_pursuit",
         "//drake/systems/rendering:pose_vector",
+    ],
+)
+
+drake_cc_library(
+    name = "road_odometry",
+    srcs = ["road_odometry.cc"],
+    hdrs = ["road_odometry.h"],
+    deps = [
+        "//drake/automotive/maliput/api",
+        "//drake/systems/rendering:frame_velocity",
     ],
 )
 
@@ -567,6 +578,7 @@ drake_cc_googletest(
     deps = [
         "//drake/automotive:pose_selector",
         "//drake/automotive/maliput/dragway",
+        "//drake/automotive/maliput/monolane:builder",
     ],
 )
 

--- a/drake/automotive/gen/idm_planner_parameters.cc
+++ b/drake/automotive/gen/idm_planner_parameters.cc
@@ -15,13 +15,14 @@ const int IdmPlannerParametersIndices::kTimeHeadway;
 const int IdmPlannerParametersIndices::kDelta;
 const int IdmPlannerParametersIndices::kBloatDiameter;
 const int IdmPlannerParametersIndices::kDistanceLowerLimit;
+const int IdmPlannerParametersIndices::kScanAheadDistance;
 
 const std::vector<std::string>&
 IdmPlannerParametersIndices::GetCoordinateNames() {
   static const never_destroyed<std::vector<std::string>> coordinates(
       std::vector<std::string>{
           "v_ref", "a", "b", "s_0", "time_headway", "delta", "bloat_diameter",
-          "distance_lower_limit",
+          "distance_lower_limit", "scan_ahead_distance",
       });
   return coordinates.access();
 }

--- a/drake/automotive/gen/idm_planner_parameters.h
+++ b/drake/automotive/gen/idm_planner_parameters.h
@@ -19,7 +19,7 @@ namespace automotive {
 /// Describes the row indices of a IdmPlannerParameters.
 struct IdmPlannerParametersIndices {
   /// The total number of rows (coordinates).
-  static const int kNumCoordinates = 8;
+  static const int kNumCoordinates = 9;
 
   // The index of each individual coordinate.
   static const int kVRef = 0;
@@ -30,6 +30,7 @@ struct IdmPlannerParametersIndices {
   static const int kDelta = 5;
   static const int kBloatDiameter = 6;
   static const int kDistanceLowerLimit = 7;
+  static const int kScanAheadDistance = 8;
 
   /// Returns a vector containing the names of each coordinate within this
   /// class. The indices within the returned vector matches that of this class.
@@ -54,6 +55,7 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
   /// @arg @c delta defaults to 4.0 in units of dimensionless.
   /// @arg @c bloat_diameter defaults to 4.5 in units of m.
   /// @arg @c distance_lower_limit defaults to 1e-2 in units of m.
+  /// @arg @c scan_ahead_distance defaults to 100.0 in units of m.
   IdmPlannerParameters() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_v_ref(10.0);
     this->set_a(1.0);
@@ -63,6 +65,7 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
     this->set_delta(4.0);
     this->set_bloat_diameter(4.5);
     this->set_distance_lower_limit(1e-2);
+    this->set_scan_ahead_distance(100.0);
   }
 
   IdmPlannerParameters<T>* DoClone() const override {
@@ -123,6 +126,15 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
   void set_distance_lower_limit(const T& distance_lower_limit) {
     this->SetAtIndex(K::kDistanceLowerLimit, distance_lower_limit);
   }
+  /// distance to scan ahead on road for a leading vehicle
+  /// @note @c scan_ahead_distance is expressed in units of m.
+  /// @note @c scan_ahead_distance has a limited domain of [0.0, +Inf].
+  const T& scan_ahead_distance() const {
+    return this->GetAtIndex(K::kScanAheadDistance);
+  }
+  void set_scan_ahead_distance(const T& scan_ahead_distance) {
+    this->SetAtIndex(K::kScanAheadDistance, scan_ahead_distance);
+  }
   //@}
 
   /// See IdmPlannerParametersIndices::GetCoordinateNames().
@@ -150,6 +162,8 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
     result = result && (bloat_diameter() >= T(0.0));
     result = result && !isnan(distance_lower_limit());
     result = result && (distance_lower_limit() >= T(0.0));
+    result = result && !isnan(scan_ahead_distance());
+    result = result && (scan_ahead_distance() >= T(0.0));
     return result;
   }
 };

--- a/drake/automotive/idm_controller.cc
+++ b/drake/automotive/idm_controller.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/idm_controller.h"
 
+#include <algorithm>
 #include <limits>
 #include <utility>
 #include <vector>
@@ -7,7 +8,6 @@
 #include "drake/common/cond.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/symbolic_formula.h"
-#include "drake/math/saturate.h"
 
 namespace drake {
 namespace automotive {
@@ -15,8 +15,6 @@ namespace automotive {
 using maliput::api::RoadGeometry;
 using maliput::api::RoadPosition;
 using maliput::api::Rotation;
-using math::saturate;
-using pose_selector::RoadOdometry;
 using systems::rendering::FrameVelocity;
 using systems::rendering::PoseBundle;
 using systems::rendering::PoseVector;
@@ -59,8 +57,7 @@ const systems::InputPortDescriptor<T>& IdmController<T>::traffic_input() const {
 }
 
 template <typename T>
-const systems::OutputPort<T>& IdmController<T>::acceleration_output()
-    const {
+const systems::OutputPort<T>& IdmController<T>::acceleration_output() const {
   return systems::System<T>::get_output_port(acceleration_index_);
 }
 
@@ -96,25 +93,34 @@ void IdmController<T>::ImplCalcAcceleration(
     const PoseBundle<T>& traffic_poses,
     const IdmPlannerParameters<T>& idm_params,
     systems::BasicVector<T>* command) const {
+  using std::abs;
+  using std::max;
+
   DRAKE_DEMAND(idm_params.IsValid());
 
-  // Find the single closest car ahead.
-  const RoadOdometry<T>& lead_car_odom =
-      pose_selector::FindClosestLeading(road_, ego_pose, traffic_poses);
+  const auto translation = ego_pose.get_isometry().translation();
+  const maliput::api::GeoPosition geo_position(translation.x(), translation.y(),
+                                               translation.z());
   const RoadPosition ego_position =
-      pose_selector::CalcRoadPosition(road_, ego_pose.get_isometry());
+      road_.ToRoadPosition(geo_position, nullptr, nullptr, nullptr);
 
-  const T& s_ego = ego_position.pos.s();
-  const T& s_dot_ego = pose_selector::GetSVelocity(
-      RoadOdometry<double>(ego_position, ego_velocity));
-  const T& s_lead = lead_car_odom.pos.s();
-  const T& s_dot_lead = pose_selector::GetSVelocity(lead_car_odom);
+  // Find the single closest car ahead.
+  const ClosestPose<T> lead_car_pose = PoseSelector<T>::FindSingleClosestPose(
+      ego_position.lane, ego_pose, traffic_poses,
+      idm_params.scan_ahead_distance(), AheadOrBehind::kAhead);
+  const double headway_distance = lead_car_pose.distance;
 
-  // Saturate the net_distance at distance_lower_bound away from the ego car to
-  // avoid near-singular solutions inherent to the IDM equation.
-  const T net_distance = saturate(s_lead - s_ego - idm_params.bloat_diameter(),
-                                  idm_params.distance_lower_limit(),
-                                  std::numeric_limits<T>::infinity());
+  T s_dot_ego = PoseSelector<T>::GetSigmaVelocity({ego_position, ego_velocity});
+  T s_dot_lead =
+      (abs(lead_car_pose.odometry.pos.s()) ==
+       std::numeric_limits<T>::infinity())
+          ? 0.
+          : PoseSelector<T>::GetSigmaVelocity(lead_car_pose.odometry);
+
+  // Saturate the net_distance at `idm_params.distance_lower_limit()` away from
+  // the ego car to avoid near-singular solutions inherent to the IDM equation.
+  const T actual_headway = headway_distance - idm_params.bloat_diameter();
+  const T net_distance = max(actual_headway, idm_params.distance_lower_limit());
   const T closing_velocity = s_dot_ego - s_dot_lead;
 
   // Compute the acceleration command from the IDM equation.

--- a/drake/automotive/idm_controller.h
+++ b/drake/automotive/idm_controller.h
@@ -6,6 +6,7 @@
 
 #include "drake/automotive/gen/idm_planner_parameters.h"
 #include "drake/automotive/idm_planner.h"
+#include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/pose_selector.h"
 #include "drake/common/drake_copyable.h"
@@ -38,6 +39,12 @@ namespace automotive {
 ///
 /// Output Port 0: A BasicVector containing the acceleration request.
 ///   (OutputPort getter: acceleration_output())
+///
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+///
+/// They are already available to link against in the containing library.
 ///
 /// @ingroup automotive_controllers
 template <typename T>
@@ -79,6 +86,8 @@ class IdmController : public systems::LeafSystem<T> {
 
   void CalcAcceleration(const systems::Context<T>& context,
                         systems::BasicVector<T>* accel_output) const;
+
+  // TODO(jadecastro): Introduce DoToAutoDiffXd overload and unit tests.
 
   const maliput::api::RoadGeometry& road_;
 

--- a/drake/automotive/idm_planner_parameters.named_vector
+++ b/drake/automotive/idm_planner_parameters.named_vector
@@ -57,3 +57,10 @@ element {
      default_value: "1e-2"
      min_value: "0.0"
 }
+element {
+     name: "scan_ahead_distance"
+     doc: "distance to scan ahead on road for a leading vehicle"
+     doc_units: "m"
+     default_value: "100.0"
+     min_value: "0.0"
+}

--- a/drake/automotive/maliput/api/lane_data.cc
+++ b/drake/automotive/maliput/api/lane_data.cc
@@ -21,6 +21,14 @@ std::ostream& operator<<(std::ostream& out, const GeoPosition& geo_position) {
       << ", z = " << geo_position.z() << ")";
 }
 
+bool operator==(const GeoPosition& lhs, const GeoPosition& rhs) {
+  return (lhs.xyz() == rhs.xyz());
+}
+
+bool operator!=(const GeoPosition& lhs, const GeoPosition& rhs) {
+  return (lhs.xyz() != rhs.xyz());
+}
+
 std::ostream& operator<<(std::ostream& out, const LanePosition& lane_position) {
   return out << "(s = " << lane_position.s() << ", r = " << lane_position.r()
       << ", h = " << lane_position.h() << ")";

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -135,6 +135,10 @@ class GeoPosition {
   /// Fully parameterized constructor.
   GeoPosition(double x, double y, double z) : xyz_(x, y, z) {}
 
+  /// Fully parameterized constructor from a 3-vector @p xyz of the form
+  /// `[x, y, z]`.
+  explicit GeoPosition(const Vector3<double>& xyz) : xyz_(xyz) {}
+
   /// Constructs a GeoPosition from a 3-vector @p xyz of the form `[x, y, z]`.
   static GeoPosition FromXyz(const Vector3<double>& xyz) {
     return GeoPosition(xyz);
@@ -163,14 +167,18 @@ class GeoPosition {
 
  private:
   Vector3<double> xyz_;
-
-  explicit GeoPosition(const Vector3<double>& xyz) : xyz_(xyz) {}
 };
 
 /// Streams a string representation of @p geo_position into @p out. Returns
 /// @p out. This method is provided for the purposes of debugging or
 /// text-logging. It is not intended for serialization.
 std::ostream& operator<<(std::ostream& out, const GeoPosition& geo_position);
+
+/// GeoPosition overload for the equality operator.
+bool operator==(const GeoPosition& lhs, const GeoPosition& rhs);
+
+/// GeoPosition overload for the inequality operator.
+bool operator!=(const GeoPosition& lhs, const GeoPosition& rhs);
 
 /// A 3-dimensional position in a `Lane`-frame, consisting of three components:
 ///  * s is longitudinal position, as arc-length along a Lane's reference line.

--- a/drake/automotive/maliput/api/test/lane_data_test.cc
+++ b/drake/automotive/maliput/api/test/lane_data_test.cc
@@ -117,6 +117,26 @@ GTEST_TEST(GeoPositionTest, ComponentSetters) {
   CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 99., 2.3, 42.);
 }
 
+GTEST_TEST(GeoPositionTest, EqualityInequalityOperators) {
+  // Checks that equality is true iff the constituent components are all equal,
+  // and that inequality is true otherwise.
+  GeoPosition gp1(0.1, 0.2, 0.3);
+  GeoPosition gp2(0.1, 0.2, 0.3);
+
+  EXPECT_TRUE(gp1 == gp2);
+  EXPECT_FALSE(gp1 != gp2);
+
+  GeoPosition gp_xerror(gp2.x() + 1e-6, gp2.y(), gp2.z());
+  EXPECT_FALSE(gp1 == gp_xerror);
+  EXPECT_TRUE(gp1 != gp_xerror);
+  GeoPosition gp_yerror(gp2.x(), gp2.y() + 1e-6, gp2.z());
+  EXPECT_FALSE(gp1 == gp_yerror);
+  EXPECT_TRUE(gp1 != gp_xerror);
+  GeoPosition gp_zerror(gp2.x(), gp2.y(), gp2.z() + 1e-6);
+  EXPECT_FALSE(gp1 == gp_zerror);
+  EXPECT_TRUE(gp1 != gp_xerror);
+}
+
 #undef CHECK_ALL_GEO_POSITION_ACCESSORS
 
 // An arbitrary very small number (that passes the tests).

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -1,15 +1,17 @@
 #include "drake/automotive/pose_selector.h"
 
-#include <cmath>
 #include <limits>
+#include <memory>
+#include <utility>
 
 #include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace automotive {
-namespace pose_selector {
 
+using maliput::api::GeoPosition;
 using maliput::api::Lane;
+using maliput::api::LaneEnd;
 using maliput::api::LanePosition;
 using maliput::api::RoadGeometry;
 using maliput::api::RoadPosition;
@@ -17,77 +19,218 @@ using systems::rendering::FrameVelocity;
 using systems::rendering::PoseBundle;
 using systems::rendering::PoseVector;
 
-const std::pair<RoadOdometry<double>, RoadOdometry<double>> FindClosestPair(
-    const RoadGeometry& road, const PoseVector<double>& ego_pose,
-    const PoseBundle<double>& traffic_poses, const Lane* traffic_lane) {
-  const RoadPosition& ego_position =
-      CalcRoadPosition(road, ego_pose.get_isometry());
-  DRAKE_DEMAND(ego_position.lane != nullptr);
-  // Take the ego car's lane by default.
-  const Lane* const lane =
-      (traffic_lane == nullptr) ? ego_position.lane : traffic_lane;
+template <typename T>
+std::map<AheadOrBehind, const ClosestPose<T>> PoseSelector<T>::FindClosestPair(
+    const Lane* lane, const PoseVector<T>& ego_pose,
+    const PoseBundle<T>& traffic_poses, const T& scan_distance) {
+  std::map<AheadOrBehind, const ClosestPose<T>> result;
+  for (auto side : {AheadOrBehind::kAhead, AheadOrBehind::kBehind}) {
+    result.insert(std::make_pair(
+        side, FindSingleClosestPose(lane, ego_pose, traffic_poses,
+                                    scan_distance, side)));
+  }
+  return result;
+}
 
-  // Default the leading and trailing vehicles with positions extending to,
-  // respectively, positive and negative infinity and with zero velocities.
-  RoadPosition pos_leading = RoadPosition(
-      lane, LanePosition(std::numeric_limits<double>::infinity(), 0., 0.));
-  RoadOdometry<double> result_leading =
-      RoadOdometry<double>(pos_leading, FrameVelocity<double>());
-  RoadPosition pos_trailing = RoadPosition(
-      lane, LanePosition(-std::numeric_limits<double>::infinity(), 0., 0.));
-  RoadOdometry<double> result_trailing =
-      RoadOdometry<double>(pos_trailing, FrameVelocity<double>());
+template <typename T>
+ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
+    const Lane* lane, const PoseVector<T>& ego_pose,
+    const PoseBundle<T>& traffic_poses, const T& scan_distance,
+    const AheadOrBehind side) {
+  using std::abs;
 
-  for (int i = 0; i < traffic_poses.get_num_poses(); ++i) {
-    const RoadPosition traffic_position =
-        CalcRoadPosition(road, traffic_poses.get_pose(i));
-    const double& s_traffic = traffic_position.pos.s();
+  DRAKE_DEMAND(lane != nullptr);
 
-    if (traffic_position.lane->id().id != lane->id().id) continue;
+  const GeoPosition ego_geo_position(ego_pose.get_isometry().translation());
+  const LanePosition ego_lane_position =
+      lane->ToLanePosition(ego_geo_position, nullptr, nullptr);
+  LaneDirection lane_direction = CalcLaneDirection(
+      {lane, ego_lane_position}, ego_pose.get_rotation(), side);
 
-    // If this pose is not the ego car and it is in the correct lane, then
-    // insert it into the correct "leading" or "trailing" bin.
-    if (ego_position.lane->id().id != lane->id().id ||
-        s_traffic != ego_position.pos.s()) {
-      if (result_trailing.pos.s() < s_traffic &&
-          s_traffic < result_leading.pos.s()) {
-        // N.B. The ego car and traffic may reside in different lanes.
-        if (s_traffic > ego_position.pos.s()) {
-          result_leading = RoadOdometry<double>(traffic_position,
-                                                traffic_poses.get_velocity(i));
-        } else {
-          result_trailing = RoadOdometry<double>(traffic_position,
-                                                 traffic_poses.get_velocity(i));
-        }
+  ClosestPose<T> result;
+  result.odometry = MakeInfiniteOdometry(lane_direction);
+  result.distance = std::numeric_limits<T>::infinity();
+  const ClosestPose<T> default_result = result;
+
+  const double ego_s = CalcLaneProgress(lane_direction, ego_lane_position);
+  T distance_scanned = T(-ego_s);  // N.B. ego_s is negated to recover the
+                                   // remaining distance to the end of the lane
+                                   // when `distance_scanned` is incremented by
+                                   // the ego car's lane length.
+  const bool ego_with_s = lane_direction.with_s;
+
+  // Traverse forward or backward from the current lane the given scan_distance,
+  // looking for traffic cars.
+  while (distance_scanned < scan_distance) {
+    T distance_increment{0.};
+    for (int i = 0; i < traffic_poses.get_num_poses(); ++i) {
+      const Isometry3<T> traffic_isometry = traffic_poses.get_pose(i);
+      const GeoPosition traffic_geo_position(traffic_isometry.translation());
+
+      if (ego_geo_position == traffic_geo_position) continue;
+      if (!IsWithinLane(traffic_geo_position, lane_direction.lane)) continue;
+
+      const LanePosition traffic_lane_position =
+          lane_direction.lane->ToLanePosition(traffic_geo_position, nullptr,
+                                              nullptr);
+      const double traffic_s =
+          CalcLaneProgress(lane_direction, traffic_lane_position);
+
+      const double s_delta = traffic_s - ego_s;
+      // Ignore traffic cars that are not in the desired direction (ahead or
+      // behind) of the ego car (with respect to the car's current direction).
+      // Cars with identical s-values as the ego but shifted laterally are
+      // treated as `kBehind` cars.  Note that this check is only needed when
+      // the two share the same lane or, equivalently, `distance_scanned <= 0`.
+      if (distance_scanned <= T(0.)) {
+        if (s_delta < 0.) continue;
+        if (side == AheadOrBehind::kAhead && s_delta == 0.) continue;
+      }
+
+      // Ignore positions at the desired direction (ahead or behind) of the ego
+      // car that are not closer than any other found so far.
+      const double s_solution_difference =
+          result.odometry.pos.s() - traffic_lane_position.s();
+      const double s_improvement =
+          (ego_with_s) ? s_solution_difference : -s_solution_difference;
+      if (s_improvement < 0.) continue;
+
+      // Update the result and incremental distance with the new candidate.
+      result.odometry =
+          RoadOdometry<T>({lane_direction.lane, traffic_lane_position},
+                          traffic_poses.get_velocity(i));
+      distance_increment = traffic_s;
+    }
+
+    if (abs(result.odometry.pos.s()) <
+        std::numeric_limits<double>::infinity()) {
+      // Figure out whether or not the result is within scan_distance.
+      if (distance_scanned + distance_increment < scan_distance) {
+        result.distance = distance_scanned + distance_increment;
+        return result;
       }
     }
+    // Increment distance_scanned.
+    distance_scanned += T(lane_direction.lane->length());
+
+    // Obtain the next lane_direction in the scanned sequence.
+    GetDefaultOngoingLane(&lane_direction);
+    if (lane_direction.lane == nullptr) return result;
   }
-  return std::make_pair(result_leading, result_trailing);
+  return default_result;
 }
 
-const RoadOdometry<double> FindClosestLeading(
-    const RoadGeometry& road, const PoseVector<double>& ego_pose,
-    const PoseBundle<double>& traffic_poses) {
-  return FindClosestPair(road, ego_pose, traffic_poses).first;
-}
-
-const RoadPosition CalcRoadPosition(const RoadGeometry& road,
-                                    const Isometry3<double>& pose) {
-  return road.ToRoadPosition(
-      maliput::api::GeoPosition(pose.translation().x(), pose.translation().y(),
-                                pose.translation().z()),
-      nullptr, nullptr, nullptr);
-}
-
-double GetSVelocity(const RoadOdometry<double>& road_odom) {
+template <typename T>
+T PoseSelector<T>::GetSigmaVelocity(const RoadOdometry<T>& road_odometry) {
+  DRAKE_DEMAND(IsWithinLane(road_odometry.pos, road_odometry.lane));
   const maliput::api::Rotation rot =
-      road_odom.lane->GetOrientation(road_odom.pos);
-  const double vx = road_odom.vel.get_velocity().translational().x();
-  const double vy = road_odom.vel.get_velocity().translational().y();
-
-  return vx * std::cos(rot.yaw()) + vy * std::sin(rot.yaw());
+      road_odometry.lane->GetOrientation(road_odometry.pos);
+  const Vector3<T>& vel = road_odometry.vel.get_velocity().translational();
+  return vel(0) * std::cos(rot.yaw()) + vel(1) * std::sin(rot.yaw());
 }
 
-}  // namespace pose_selector
+template <typename T>
+bool PoseSelector<T>::IsWithinDriveable(const LanePosition& lane_position,
+                                        const Lane* lane) {
+  if (lane_position.s() < 0. || lane_position.s() > lane->length()) {
+    return false;
+  }
+  const maliput::api::RBounds r_bounds =
+      lane->driveable_bounds(lane_position.s());
+  if (lane_position.r() < r_bounds.r_min ||
+      lane_position.r() > r_bounds.r_max) {
+    return false;
+  }
+  const maliput::api::HBounds h_bounds =
+      lane->elevation_bounds(lane_position.s(), lane_position.r());
+  return (lane_position.h() >= h_bounds.min() &&
+          lane_position.h() <= h_bounds.max());
+}
+
+template <typename T>
+bool PoseSelector<T>::IsWithinLane(const GeoPosition& geo_position,
+                                   const Lane* lane) {
+  double distance{};
+  const LanePosition pos =
+      lane->ToLanePosition(geo_position, nullptr, &distance);
+  const maliput::api::RBounds r_bounds = lane->lane_bounds(pos.s());
+  return (distance == 0. && pos.r() >= r_bounds.r_min &&
+          pos.r() <= r_bounds.r_max);
+}
+
+template <typename T>
+bool PoseSelector<T>::IsWithinLane(const LanePosition& lane_position,
+                                   const Lane* lane) {
+  if (IsWithinDriveable(lane_position, lane)) {
+    const maliput::api::RBounds r_bounds = lane->lane_bounds(lane_position.s());
+    if (lane_position.r() >= r_bounds.r_min ||
+        lane_position.r() <= r_bounds.r_max) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename T>
+std::unique_ptr<LaneEnd> PoseSelector<T>::GetDefaultOngoingLane(
+    LaneDirection* lane_direction) {
+  const Lane* const lane{lane_direction->lane};
+  const bool with_s{lane_direction->with_s};
+  std::unique_ptr<LaneEnd> branch =
+      (with_s) ? lane->GetDefaultBranch(LaneEnd::kFinish)
+               : lane->GetDefaultBranch(LaneEnd::kStart);
+  if (branch == nullptr) {
+    lane_direction->lane = nullptr;
+    lane_direction->with_s = true;
+    return branch;
+  }
+  lane_direction->lane = branch->lane;
+  lane_direction->with_s = (branch->end == LaneEnd::kStart) ? true : false;
+  return branch;
+}
+
+template <typename T>
+RoadOdometry<T> PoseSelector<T>::MakeInfiniteOdometry(
+    const LaneDirection& lane_direction) {
+  const double infinite_distance =
+      (lane_direction.with_s) ? std::numeric_limits<double>::infinity()
+                              : -std::numeric_limits<double>::infinity();
+  const RoadPosition default_road_position(lane_direction.lane,
+                                           {infinite_distance, 0., 0.});
+  return {default_road_position, FrameVelocity<T>()};
+}
+
+template <typename T>
+double PoseSelector<T>::CalcLaneProgress(const LaneDirection& lane_direction,
+                                           const LanePosition& lane_position) {
+  DRAKE_DEMAND(IsWithinDriveable(lane_position, lane_direction.lane));
+  if (lane_direction.with_s) {
+    return lane_position.s();
+  } else {
+    return lane_direction.lane->length() - lane_position.s();
+  }
+}
+
+template <typename T>
+LaneDirection PoseSelector<T>::CalcLaneDirection(
+    const RoadPosition& road_position, const Eigen::Quaternion<T>& rotation,
+    AheadOrBehind side) {
+  // Get the vehicle's heading with respect to the current lane; use it to
+  // determine if the vehicle is facing with or against the lane's canonical
+  // direction.
+  const Eigen::Quaternion<T> lane_rotation =
+      road_position.lane->GetOrientation(road_position.pos).quat();
+  // The dot product of two quaternions is the cosine of half the angle between
+  // the two rotations.  Given two quaternions q₀, q₁ and letting θ be the angle
+  // difference between them, then -π/2 ≤ θ ≤ π/2 iff q₀.q₁ ≥ √2/2.
+  const bool with_s = (side == AheadOrBehind::kAhead)
+                          ? lane_rotation.dot(rotation) >= sqrt(2.) / 2.
+                          : lane_rotation.dot(rotation) < sqrt(2.) / 2.;
+  return LaneDirection(road_position.lane, with_s);
+}
+
+// These instantiations must match the API documentation in pose_selector.h.
+template class PoseSelector<double>;
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/pose_selector.h
+++ b/drake/automotive/pose_selector.h
@@ -1,90 +1,167 @@
 #pragma once
 
+#include <map>
+#include <memory>
 #include <utility>
-#include <vector>
 
 #include <Eigen/Geometry>
 
+#include "drake/automotive/lane_direction.h"
 #include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/road_odometry.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/rendering/pose_bundle.h"
 #include "drake/systems/rendering/pose_vector.h"
 
 namespace drake {
 namespace automotive {
-namespace pose_selector {
 
-/// Contains the position of the vehicle with respect to a lane in a road, along
-/// with its velocity vector in the world frame.
+/// ClosestPose bundles together the RoadOdometry of a particular target along
+/// with its distance measure relative to the ego vehicle.  Its intended use is
+/// as the return argument for PoseSelector member functions.
 template <typename T>
-struct RoadOdometry {
+struct ClosestPose {
+ public:
   /// Default constructor.
-  RoadOdometry() = default;
-  /// Fully-parameterized constructor.
-  RoadOdometry(const maliput::api::RoadPosition& road_position,
-               const systems::rendering::FrameVelocity<T>& frame_velocity)
-      : lane(road_position.lane), pos(road_position.pos), vel(frame_velocity) {}
+  ClosestPose() = default;
 
-  const maliput::api::Lane* lane{};
-  maliput::api::LanePosition pos{};
-  systems::rendering::FrameVelocity<T> vel{};
+  /// Constructs the ClosestPose via a full parameterization.
+  ClosestPose(const RoadOdometry<T>& odom, const T& dist)
+      : odometry(odom), distance(dist) {}
+
+  RoadOdometry<T> odometry{};
+  T distance{0.};
 };
 
-/// Returns the leading and trailing cars that have closest `s`-coordinates in a
-/// given @p traffic_lane to an ego car as if the ego car were traveling in @p
-/// traffic_lane at its current `s`-position.  The ego car's pose @ego_pose and
-/// the poses of the traffic cars (@p traffic_poses) are assumed to exist on the
-/// same @p road.  If @p traffic_lane is `nullptr`, the ego car's current lane
-/// is used (this is derived from a call to CalcRoadPosition).  If no
-/// leading/trailing cars are seen within @p traffic_lane, car `s`-positions are
-/// taken to be at infinite distances away from the ego car.
-///
-/// The return values are a pair of leading/trailing RoadOdometries. Note that
-/// when no car is detected in front of (resp. behind) the ego car, the
-/// respective RoadPosition will contain an `s`-value of positive
-/// (resp. negative) infinity (`std::numeric_limits<double>::infinity()`).
-///
-/// N.B. When comparing across lanes, it is assumed that @p road is configured
-/// such that a comparison between the `s`-positions of any two cars on the road
-/// is meaningful.  For instance, if car A is at `s = 10 m` in lane 0's frame
-/// and car B is at `s = 0 m` in lane 1's frame then, if car A moved into lane
-/// 1, it would be 10 meters ahead of car B.  Only straight multi-lane roads are
-/// supported presently.
-///
-/// TODO(jadecastro): Support road networks containing multi-lane segments
-/// (#4934).
-///
-/// TODO(jadecastro): Support vehicles traveling in the negative-`s`-direction
-/// in a given Lane.
-const std::pair<RoadOdometry<double>, RoadOdometry<double>> FindClosestPair(
-    const maliput::api::RoadGeometry& road,
-    const systems::rendering::PoseVector<double>& ego_pose,
-    const systems::rendering::PoseBundle<double>& traffic_poses,
-    const maliput::api::Lane* traffic_lane = nullptr);
+/// Specifies whether to assess the cars ahead or behind the ego car at its
+/// current orientation with respect to its lane.
+enum class AheadOrBehind { kAhead = 0, kBehind = 1 };
 
-/// Same as FindClosestPair() except that: (1) it only considers the ego car's
-/// lane and (2) it returns a single the RoadOdometry of the leading vehicle.
+/// PoseSelector is a class that provides the relevant pose or poses with
+/// respect to a given ego vehicle driving within a given maliput road geometry.
 ///
-///  Note that when no car is detected in front of the ego car, the returned
-///  RoadOdometry will contain an `s`-value of
-///  `std::numeric_limits<double>::infinity()`.
-const RoadOdometry<double> FindClosestLeading(
-    const maliput::api::RoadGeometry& road,
-    const systems::rendering::PoseVector<double>& ego_pose,
-    const systems::rendering::PoseBundle<double>& traffic_poses);
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+///
+/// They are already available to link against in the containing library.
+///
+/// TODO(jadecastro): Enable AutoDiffXd support, and add unit tests.
+template <typename T>
+class PoseSelector {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseSelector)
 
-/// Computes the RoadPosition for a car whose @p pose is located on a given @p
-/// road.
-const maliput::api::RoadPosition CalcRoadPosition(
-    const maliput::api::RoadGeometry& road, const Isometry3<double>& pose);
+  PoseSelector() = delete;
 
-// Extracts the vehicle's `s`-direction velocity based on its RoadOdometry @p
-// road_odom.  Assumes the road has zero elevation and superelevation.
-//
-// TODO(jadecastro): Generalize to three-dimensional rotations.
-double GetSVelocity(const pose_selector::RoadOdometry<double>& road_odom);
+  /// Returns the leading and trailing vehicles in a given @p lane that are
+  /// closest to an ego vehicle (within @p lane or another lane) as measured
+  /// along the `s`-coordinate of the ego vehicle's lane.  The ego vehicle must
+  /// be within the `driveable_bounds` of @p lane (i.e. the road is contiguous
+  /// with @p lane along the `r`-direction).  This function is used, for
+  /// instance, as logic for lane-change planners (e.g. MOBIL).  The ego car's
+  /// pose (@p ego_pose) and the poses of the traffic cars (@p traffic_poses)
+  /// are provided.  The parameter @p scan_distance determines the distance
+  /// along the sequence of lanes to scan before declaring that no traffic car
+  /// is ahead (resp. behind) the ego car.  If no leading/trailing vehicles are
+  /// seen within @p traffic_lane, `s`-positions are taken to be at infinite
+  /// distances away from the ego car.  Traffic vehicles having exactly the same
+  /// s-position as the ego vehicle but situated in a different (parallel) lane
+  /// are taken to be behind the ego vehicle.
+  ///
+  /// @return A map of AheadOrBehind values to vehicle ClosestPoses (containing
+  /// RoadOdometries and closest relative distances).  Relative distances are
+  /// always positive, and a distance of positive infinity is returned if no
+  /// traffic cars are found.  Note that when no vehicle is detected in front of
+  /// (resp. behind) the ego vehicle, the respective RoadPosition within
+  /// ClosestPoses will contain an `s`-value of positive (resp. negative)
+  /// infinity.  Any traffic poses that are redunant with `ego_pose` (i.e. have
+  /// the same RoadPosition as the ego car) are discarded.
+  ///
+  /// The RoadGeometry from which @p lane is drawn is required to have default
+  /// branches set for all branches in the road network.
+  static std::map<AheadOrBehind, const ClosestPose<T>> FindClosestPair(
+      const maliput::api::Lane* lane,
+      const systems::rendering::PoseVector<T>& ego_pose,
+      const systems::rendering::PoseBundle<T>& traffic_poses,
+      const T& scan_distance);
 
-}  // namespace pose_selector
+  /// Same as PoseSelector::FindClosestPair() except that it returns a single
+  /// ClosestPose for either the vehicle ahead (AheadOrBehind::kAhead) or behind
+  /// (AheadOrBehind::kBehind).
+  ///
+  /// Note that when no car is detected in front of the ego car, the returned
+  /// RoadOdometry within ClosestPose will contain an `s`-value of
+  /// `std::numeric_limits<double>::infinity()`.
+  //
+  // TODO(jadecastro): Generalize this function to find and locate cars that are
+  // in lanes that eventually merge with the ego car's default ongoing lane.
+  static ClosestPose<T> FindSingleClosestPose(
+      const maliput::api::Lane* lane,
+      const systems::rendering::PoseVector<T>& ego_pose,
+      const systems::rendering::PoseBundle<T>& traffic_poses,
+      const T& scan_distance, const AheadOrBehind side);
+
+  /// Extracts the vehicle's `s`-direction velocity based on its RoadOdometry @p
+  /// road_odometry in the Lane coordinate frame.  Assumes the road has zero
+  /// elevation and superelevation.  Throws if any element of
+  /// `road_odometry.pos` is not within the respective bounds of
+  /// `road_odometry.lane`.
+  static T GetSigmaVelocity(const RoadOdometry<T>& road_odometry);
+
+  /// Returns `true` if and only if @p lane_position is within the longitudinal
+  /// (s), driveable (r) and elevation (h) bounds of the specified @p lane
+  /// (i.e. within `lane->driveable_bounds()` and `lane->elevation_bounds()`).
+  static bool IsWithinDriveable(
+      const maliput::api::LanePosition& lane_position,
+      const maliput::api::Lane* lane);
+
+  /// Returns `true` if and only if @p geo_position is within the longitudinal
+  /// (s), lateral (r) and elevation (h) bounds of the specified @p lane
+  /// (i.e. within `lane->lane_bounds()` and `lane->elevation_bounds()`).
+  static bool IsWithinLane(const maliput::api::GeoPosition& geo_position,
+                           const maliput::api::Lane* lane);
+
+  /// Returns `true` if and only if @p lane_position is within the driveable
+  /// bounds of @p lane and, in addition, `r` is within its lane bounds.
+  static bool IsWithinLane(const maliput::api::LanePosition& lane_position,
+                           const maliput::api::Lane* lane);
+
+ private:
+  // Given a @p lane_direction, returns its default branch and updates @p
+  // lane_direction to match the `lane` and `with_s` of that branch.  If there
+  // is no default branch, returns `nullptr` and sets `lane_direction->lane` to
+  // `nullptr`.
+  static std::unique_ptr<maliput::api::LaneEnd> GetDefaultOngoingLane(
+      LaneDirection* lane_direction);
+
+  // Returns a RoadOdometry that contains infinite positions and zero `r`, `h`,
+  // and velocity values. If @p lane_direction contains `with_s == True`, a
+  // RoadOdometry containing an s-position at positive infinity is returned;
+  // otherwise a negative-intinite position is returned.
+  static RoadOdometry<T> MakeInfiniteOdometry(
+      const LaneDirection& lane_direction);
+
+  // Returns the distance (along the `s`-coordinate) from an end of a lane to a
+  // @p lane_position in that lane, where the end is determined by the `with_s`
+  // of the provided `lane_direction`.  Both `lane` and `with_s` are specified
+  // in @p lane_direction.  Throws if any element of @p lane_position is not
+  // within the respective bounds of `lane_direction.lane`.
+  static double CalcLaneProgress(
+      const LaneDirection& lane_direction,
+      const maliput::api::LanePosition& lane_position);
+
+  // Constructs a LaneDirection structure based on a vehicle's current @p
+  // road_position and @p rotation (in global coordinates), and the @p side of
+  // the car (ahead or behind) that traffic is being observed.  Note that
+  // `LaneDirection::with_s` is interpreted as the direction along which targets
+  // are being observed (regardless of the ego car's orientation): it is true if
+  // cars are being observed along the `s`-direction and is false otherwise.
+  static LaneDirection CalcLaneDirection(
+      const maliput::api::RoadPosition& road_position,
+      const Eigen::Quaternion<T>& rotation, AheadOrBehind side);
+};
+
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/pure_pursuit.h
+++ b/drake/automotive/pure_pursuit.h
@@ -4,7 +4,6 @@
 #include "drake/automotive/gen/simple_car_params.h"
 #include "drake/automotive/lane_direction.h"
 #include "drake/automotive/maliput/api/lane_data.h"
-#include "drake/automotive/pose_selector.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/rendering/pose_vector.h"
 

--- a/drake/automotive/pure_pursuit_controller.cc
+++ b/drake/automotive/pure_pursuit_controller.cc
@@ -2,7 +2,6 @@
 
 #include <cmath>
 
-#include "drake/automotive/pose_selector.h"
 #include "drake/automotive/pure_pursuit.h"
 #include "drake/common/drake_assert.h"
 

--- a/drake/automotive/road_odometry.cc
+++ b/drake/automotive/road_odometry.cc
@@ -1,0 +1,4 @@
+#include "drake/automotive/road_odometry.h"
+
+// For now, this is an empty .cc file that only serves to confirm that
+// our .h file is a stand-alone header.

--- a/drake/automotive/road_odometry.h
+++ b/drake/automotive/road_odometry.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/systems/rendering/frame_velocity.h"
+
+namespace drake {
+namespace automotive {
+
+/// RoadOdometry contains the position of the vehicle with respect to a lane in
+/// a road, along with its velocity vector in the world frame.
+template <typename T>
+struct RoadOdometry {
+  /// Default constructor.
+  RoadOdometry() = default;
+  /// Fully-parameterized constructor.
+  RoadOdometry(const maliput::api::RoadPosition& road_position,
+               const systems::rendering::FrameVelocity<T>& frame_velocity)
+      : lane(road_position.lane), pos(road_position.pos), vel(frame_velocity) {}
+
+  const maliput::api::Lane* lane{};
+  maliput::api::LanePosition pos{};
+  systems::rendering::FrameVelocity<T> vel{};
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/test/pose_selector_test.cc
+++ b/drake/automotive/test/pose_selector_test.cc
@@ -2,39 +2,77 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
+#include "drake/automotive/maliput/monolane/builder.h"
+#include "drake/math/roll_pitch_yaw_using_quaternion.h"
 
 namespace drake {
 namespace automotive {
-namespace pose_selector {
 namespace {
 
+using maliput::api::GeoPosition;
+using maliput::api::LaneEnd;
+using maliput::api::RoadPosition;
+using maliput::monolane::Builder;
+using maliput::monolane::Connection;
+using maliput::monolane::Endpoint;
+using math::RollPitchYawToQuaternion;
 using systems::rendering::FrameVelocity;
 using systems::rendering::PoseVector;
 using systems::rendering::PoseBundle;
 
-constexpr double kLaneLength{100.};
-constexpr double kLaneWidth{4.};
+// Constants for Dragway tests.
+constexpr double kDragwayLaneLength{100.};
+constexpr double kDragwayLaneWidth{2.};
 
 constexpr double kEgoSPosition{10.};
-constexpr double kEgoRPosition{-0.5 * kLaneWidth};
-constexpr double kLeadingSPosition{31.};
-constexpr double kTrailingSPosition{7.};
-constexpr double kSOffset{4.};
+constexpr double kEgoRPosition{-0.5 * kDragwayLaneWidth};
+
+constexpr double kJustAheadSPosition{31.};
+constexpr double kFarAheadSPosition{35.};
+constexpr double kJustBehindSPosition{7.};
+constexpr double kFarBehindSPosition{3.};
 constexpr double kTrafficXVelocity{27.};
 
-constexpr int kFarAheadIndex{0};
-constexpr int kJustAheadIndex{1};
+constexpr int kNumDragwayTrafficCars{4};
+
+// Indices for a PoseBundle object (used in Dragway tests).
+constexpr int kJustAheadIndex{0};
+constexpr int kFarAheadIndex{1};
 constexpr int kJustBehindIndex{2};
 constexpr int kFarBehindIndex{3};
 
-static void SetDefaultPoses(PoseVector<double>* ego_pose,
-                            PoseBundle<double>* traffic_poses) {
-  DRAKE_DEMAND(traffic_poses->get_num_poses() == 4);
-  DRAKE_DEMAND(kEgoSPosition > 0. && kLaneLength > kEgoSPosition);
-  DRAKE_DEMAND(kLeadingSPosition > kEgoSPosition &&
-               kLaneLength > kLeadingSPosition);
-  DRAKE_DEMAND(kEgoSPosition > kTrailingSPosition && kTrailingSPosition > 0.);
+// The length of a straight monolane segment.
+constexpr double kRoadSegmentLength{15.};
+
+// Specifies zero elevation/super-elevation.
+const maliput::monolane::EndpointZ kEndZ{0., 0., 0., 0.};
+
+class PoseSelectorDragwayTest : public ::testing::Test {
+ protected:
+  void MakeDragway(int num_lanes, double lane_length) {
+    DRAKE_ASSERT(num_lanes >= 0);
+    // Create a dragway with the specified number of lanes starting at `x = 0`
+    // and centered at `y = 0`.
+    road_.reset(new maliput::dragway::RoadGeometry(
+        maliput::api::RoadGeometryId({"Test Dragway"}), num_lanes, lane_length,
+        kDragwayLaneWidth, 0. /* shoulder width */, 5. /* maximum_height */,
+        std::numeric_limits<double>::epsilon() /* linear_tolerance */,
+        std::numeric_limits<double>::epsilon() /* angular_tolerance */));
+  }
+  std::unique_ptr<maliput::dragway::RoadGeometry> road_;
+};
+
+static void SetDefaultDragwayPoses(PoseVector<double>* ego_pose,
+                                   PoseBundle<double>* traffic_poses) {
+  DRAKE_DEMAND(traffic_poses->get_num_poses() == kNumDragwayTrafficCars);
+  DRAKE_DEMAND(kEgoSPosition > 0. && kDragwayLaneLength > kEgoSPosition);
+  DRAKE_DEMAND(kJustAheadSPosition > kEgoSPosition &&
+               kDragwayLaneLength > kJustAheadSPosition);
+  DRAKE_DEMAND(kEgoSPosition > kJustBehindSPosition &&
+               kJustBehindSPosition > 0.);
 
   // Create poses for four traffic cars and one ego positioned in the right
   // lane, interspersed as follows:
@@ -44,17 +82,18 @@ static void SetDefaultPoses(PoseVector<double>* ego_pose,
   //  s=0     3            7           10         31           35           100
   ego_pose->set_translation(Eigen::Translation3d(
       kEgoSPosition /* s */, kEgoRPosition /* r */, 0. /* h */));
+
   const Eigen::Translation3d translation_far_ahead(
-      kLeadingSPosition + kSOffset /* s */, kEgoRPosition /* r */, 0. /* h */);
+      kFarAheadSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
   FrameVelocity<double> velocity_far_ahead{};
   velocity_far_ahead.get_mutable_value() << 0. /* ωx */, 0. /* ωy */,
       0. /* ωz */, kTrafficXVelocity /* vx */, 0. /* vy */, 0. /* vz */;
   const Eigen::Translation3d translation_just_ahead(
-      kLeadingSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
+      kJustAheadSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
   const Eigen::Translation3d translation_just_behind(
-      kTrailingSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
+      kJustBehindSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
   const Eigen::Translation3d translation_far_behind(
-      kTrailingSPosition - kSOffset /* s */, kEgoRPosition /* r */, 0. /* h */);
+      kFarBehindSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
   traffic_poses->set_pose(kFarAheadIndex,
                           Eigen::Isometry3d(translation_far_ahead));
   traffic_poses->set_velocity(kFarAheadIndex, velocity_far_ahead);
@@ -66,176 +105,426 @@ static void SetDefaultPoses(PoseVector<double>* ego_pose,
                           Eigen::Isometry3d(translation_far_behind));
 }
 
-static void SetDefaultPosesSideBySide(PoseVector<double>* ego_pose,
-                                      PoseBundle<double>* traffic_poses) {
+// Sets the poses for one ego car and one traffic car, with the relative
+// positions of each determined by the given s_offset an r_offset values.  The
+// optional `yaw` argument determines the orientation of the ego car with
+// respect to the x-axis.
+static void SetPoses(double s_offset, double r_offset,
+                     PoseVector<double>* ego_pose,
+                     PoseBundle<double>* traffic_poses,
+                     double yaw = 0.) {
   DRAKE_DEMAND(traffic_poses->get_num_poses() == 1);
-  DRAKE_DEMAND(kEgoSPosition > 0. && kLaneLength > kEgoSPosition);
-  DRAKE_DEMAND(kLeadingSPosition > kEgoSPosition &&
-               kLaneLength > kLeadingSPosition);
-  DRAKE_DEMAND(kEgoSPosition > kTrailingSPosition && kTrailingSPosition > 0.);
+  DRAKE_DEMAND(kEgoSPosition > 0. && kDragwayLaneLength > kEgoSPosition);
+  DRAKE_DEMAND(kJustAheadSPosition > kEgoSPosition &&
+               kDragwayLaneLength > kJustAheadSPosition);
+  DRAKE_DEMAND(kEgoSPosition > kJustBehindSPosition &&
+               kJustBehindSPosition > 0.);
 
-  // Create poses for one traffic car and one ego positioned side-by-side, with
-  // the ego vehicle in the right lane and the traffic vehicle in the left lane.
+  // Create poses for one traffic car and one ego car.
   ego_pose->set_translation(Eigen::Translation3d(
       kEgoSPosition /* s */, kEgoRPosition /* r */, 0. /* h */));
-  const Eigen::Translation3d translation(
-      kEgoSPosition /* s */, kEgoRPosition + kLaneWidth /* r */, 0. /* h */);
-  FrameVelocity<double> velocity{};
-  velocity.get_mutable_value() << 0. /* ωx */, 0. /* ωy */,
-      0. /* ωz */, kTrafficXVelocity /* vx */, 0. /* vy */, 0. /* vz */;
+  ego_pose->set_rotation(
+      RollPitchYawToQuaternion(Vector3<double>{0., 0., yaw}));
+
+  const Eigen::Translation3d translation(kEgoSPosition + s_offset /* s */,
+                                         kEgoRPosition + r_offset /* r */,
+                                         0. /* h */);
+  FrameVelocity<double> traffic_velocity{};
+  traffic_velocity.get_mutable_value() << 0. /* ωx */, 0. /* ωy */, 0. /* ωz */,
+      kTrafficXVelocity /* vx */, 0. /* vy */, 0. /* vz */;
   traffic_poses->set_pose(0, Eigen::Isometry3d(translation));
-  traffic_poses->set_velocity(0, velocity);
+  traffic_poses->set_velocity(0, traffic_velocity);
 }
 
+// Returns the lane in the road associated with the provided pose.
+const maliput::api::Lane* get_lane(const PoseVector<double>& pose,
+                                   const maliput::api::RoadGeometry& road) {
+  const GeoPosition geo_position{pose.get_translation().x(),
+                                 pose.get_translation().y(),
+                                 pose.get_translation().z()};
+  return road.ToRoadPosition(geo_position, nullptr, nullptr, nullptr).lane;
+}
 
-GTEST_TEST(PoseSelectorTest, DragwayTest) {
-  // Create a straight road, two lanes wide, in which the two s-r
-  // Lane-coordinate frames are aligned with the x-y world coordinates, with s_i
-  // = 0 for the i-th lane, i ∈ {0, 1}, corresponds to x = 0, and r_i = 0
-  // corresponds to y = (i - 0.5) * kLaneWidth.  See sketch below.
-  //
-  // +y ^
-  //    | -  -  -  -  -  -  -  -   <-- lane 1 (y_1)
-  //  0 |-----------------------> +x
-  //    | -  -  -  -  -  -  -  -   <-- lane 0 (y_0)
-  const int kNumLanes{2};
-  const maliput::dragway::RoadGeometry road(
-      maliput::api::RoadGeometryId({"Test Dragway"}), kNumLanes, kLaneLength,
-      kLaneWidth, 0. /* shoulder width */,
-      5. /* maximum_height */,
-      std::numeric_limits<double>::epsilon() /* linear_tolerance */,
-      std::numeric_limits<double>::epsilon() /* angular_tolerance */);
+TEST_F(PoseSelectorDragwayTest, TwoLaneDragway) {
+  MakeDragway(2 /* num lanes */, kDragwayLaneLength);
+
   PoseVector<double> ego_pose;
-  PoseBundle<double> traffic_poses(4);
+  PoseBundle<double> traffic_poses(kNumDragwayTrafficCars);
 
   // Define the default poses.
-  SetDefaultPoses(&ego_pose, &traffic_poses);
+  SetDefaultDragwayPoses(&ego_pose, &traffic_poses);
 
-  // Calculate the current road position and use it to determine the ego car's
-  // lane.
-  const maliput::api::RoadPosition& ego_position =
-      CalcRoadPosition(road, ego_pose.get_isometry());
+  // Choose a scan-ahead distance shorter than the lane length.
+  const double scan_ahead_distance = kDragwayLaneLength / 2.;
+  {
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(get_lane(ego_pose, *road_),
+                                              ego_pose, traffic_poses,
+                                              scan_ahead_distance);
 
-  RoadOdometry<double> leading_odometry{};
-  RoadOdometry<double> trailing_odometry{};
-  std::tie(leading_odometry, trailing_odometry) =
-      FindClosestPair(road, ego_pose, traffic_poses);
-
-  // Verifies that we are on the road and that the correct car was identified.
-  EXPECT_EQ(kLeadingSPosition, leading_odometry.pos.s());
-  EXPECT_EQ(kTrailingSPosition, trailing_odometry.pos.s());
+    // Verifies that the ego car and traffic cars are on the road and that the
+    // correct leading and trailing cars are identified.
+    EXPECT_EQ(kJustAheadSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(kJustBehindSPosition,
+              closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
+    EXPECT_EQ(kJustAheadSPosition - kEgoSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(kEgoSPosition - kJustBehindSPosition,
+              closest_poses.at(AheadOrBehind::kBehind).distance);
+  }
 
   // Test that we get the same result when just the leading car is returned.
-  const RoadOdometry<double>& traffic_odometry =
-      FindClosestLeading(road, ego_pose, traffic_poses);
-  EXPECT_EQ(kLeadingSPosition, traffic_odometry.pos.s());
+  const ClosestPose<double>& closest_pose =
+      PoseSelector<double>::FindSingleClosestPose(
+          get_lane(ego_pose, *road_), ego_pose, traffic_poses,
+          scan_ahead_distance, AheadOrBehind::kAhead);
+  EXPECT_EQ(kJustAheadSPosition, closest_pose.odometry.pos.s());
+  EXPECT_EQ(kJustAheadSPosition - kEgoSPosition, closest_pose.distance);
+  {
+    // Peer into the adjacent lane to the left.
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(
+            get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
+            scan_ahead_distance);
 
-  // Peer into the adjacent lane to the left.
-  std::tie(leading_odometry, trailing_odometry) = FindClosestPair(
-      road, ego_pose, traffic_poses, ego_position.lane->to_left());
-
-  // Expect to see no cars in the left lane.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s());
-  EXPECT_EQ(-std::numeric_limits<double>::infinity(),
-            trailing_odometry.pos.s());
+    // Expect to see no cars in the left lane.
+    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(-std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
+    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kBehind).distance);
+  }
 
   // Bump the "just ahead" car into the lane to the left.
   Isometry3<double> isometry_just_ahead =
       traffic_poses.get_pose(kJustAheadIndex);
-  isometry_just_ahead.translation().y() += kLaneWidth;
+  isometry_just_ahead.translation().y() += kDragwayLaneWidth;
   traffic_poses.set_pose(kJustAheadIndex, isometry_just_ahead);
-  std::tie(leading_odometry, std::ignore) =
-      FindClosestPair(road, ego_pose, traffic_poses);
+  {
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(get_lane(ego_pose, *road_),
+                                              ego_pose, traffic_poses,
+                                              scan_ahead_distance);
 
-  // Expect the "far ahead" car to be identified and with the correct speed.
-  EXPECT_EQ(kLeadingSPosition + kSOffset, leading_odometry.pos.s());
-  EXPECT_EQ(kTrafficXVelocity, leading_odometry.vel[3]);
+    // Expect the "far ahead" car to be identified and with the correct speed.
+    EXPECT_EQ(kFarAheadSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(kJustBehindSPosition,
+              closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
+    EXPECT_EQ(kFarAheadSPosition - kEgoSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(kEgoSPosition - kJustBehindSPosition,
+              closest_poses.at(AheadOrBehind::kBehind).distance);
+    for (int i{0};
+         i < closest_poses.at(AheadOrBehind::kAhead).odometry.vel.size(); ++i) {
+      const double velocity =
+          closest_poses.at(AheadOrBehind::kAhead).odometry.vel[i];
+      if (i == 3) {
+        EXPECT_EQ(kTrafficXVelocity, velocity);
+      } else {
+        EXPECT_EQ(0., velocity);
+      }
+    }
+  }
 
   // Bump the "far ahead" car into the lane to the left.
   Isometry3<double> isometry_far_ahead = traffic_poses.get_pose(kFarAheadIndex);
-  isometry_far_ahead.translation().y() += kLaneWidth;
+  isometry_far_ahead.translation().y() += kDragwayLaneWidth;
   traffic_poses.set_pose(kFarAheadIndex, isometry_far_ahead);
-  std::tie(leading_odometry, std::ignore) =
-      FindClosestPair(road, ego_pose, traffic_poses);
+  {
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(get_lane(ego_pose, *road_),
+                                              ego_pose, traffic_poses,
+                                              scan_ahead_distance);
 
-  // Looking forward, we expect there to be no car in sight.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s());
-  for (int i = 0; i < 6; ++i) {
-    EXPECT_EQ(0., leading_odometry.vel[i]);  // Defaults to zero velocity.
+    // Looking forward, we expect there to be no car in sight.
+    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kAhead).distance);
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_EQ(0., closest_poses.at(AheadOrBehind::kAhead).odometry.vel[i]);
+      // N.B. Defaults to zero velocity.
+    }
   }
 
-  // Peer into the adjacent lane to the left.
-  std::tie(leading_odometry, trailing_odometry) = FindClosestPair(
-      road, ego_pose, traffic_poses, ego_position.lane->to_left());
+  {
+    // Peer into the adjacent lane to the left.
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(
+            get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
+            scan_ahead_distance);
 
-  // Expect there to be no car behind on the immediate left and the "just ahead"
-  // car to be leading.
-  EXPECT_EQ(kLeadingSPosition, leading_odometry.pos.s());
-  EXPECT_EQ(-std::numeric_limits<double>::infinity(),
-            trailing_odometry.pos.s());
+    // Expect there to be no car behind on the immediate left and the "just
+    // ahead" car to be leading.
+    EXPECT_EQ(kJustAheadSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(-std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
+    EXPECT_EQ(kJustAheadSPosition - kEgoSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kBehind).distance);
+  }
 }
 
-// Verifies the result when the s-positions of the ego traffic vehicles have the
-// same s-position (side-by-side in adjacent lanes).
-GTEST_TEST(PoseSelectorTest, IdenticalSValues) {
-  // Instantiate a two-lane Dragway, identical to DragwayTest.
-  const int kNumLanes{2};
-  const maliput::dragway::RoadGeometry road(
-      maliput::api::RoadGeometryId({"Test Dragway"}), kNumLanes, kLaneLength,
-      kLaneWidth, 0. /* shoulder width */,
-      5. /* maximum_height */,
-      std::numeric_limits<double>::epsilon() /* linear_tolerance */,
-      std::numeric_limits<double>::epsilon() /* angular_tolerance */);
+// Verifies that CalcLaneDirection returns the correct result when the ego
+// vehicle's orientation is altered.
+TEST_F(PoseSelectorDragwayTest, EgoOrientation) {
+  MakeDragway(2 /* num lanes */, kDragwayLaneLength);
+
+  PoseVector<double> ego_pose;
+  PoseBundle<double> traffic_poses(kNumDragwayTrafficCars);
+
+  // Define the default poses.
+  SetDefaultDragwayPoses(&ego_pose, &traffic_poses);
+
+  // Choose a scan-ahead distance shorter than the lane length.
+  const double scan_ahead_distance = kDragwayLaneLength / 2.;
+
+  for (double yaw = -M_PI; yaw <= M_PI; yaw += 0.1) {
+    // N.B. 0 corresponds to "aligned with the lane along the s-direction".
+    ego_pose.set_rotation(
+        RollPitchYawToQuaternion(Vector3<double>{0., 0., yaw}));
+
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(get_lane(ego_pose, *road_),
+                                              ego_pose, traffic_poses,
+                                              scan_ahead_distance);
+
+    // Expect the correct result independent of the ego vehicle's orientation.
+    const bool is_with_s = yaw > -M_PI / 2. && yaw < M_PI / 2.;
+    ClosestPose<double> closest_ahead =
+        (is_with_s) ? closest_poses.at(AheadOrBehind::kAhead)
+                    : closest_poses.at(AheadOrBehind::kBehind);
+    ClosestPose<double> closest_behind =
+        (is_with_s) ? closest_poses.at(AheadOrBehind::kBehind)
+                    : closest_poses.at(AheadOrBehind::kAhead);
+    EXPECT_EQ(kJustAheadSPosition, closest_ahead.odometry.pos.s());
+    EXPECT_EQ(kJustBehindSPosition, closest_behind.odometry.pos.s());
+  }
+}
+
+TEST_F(PoseSelectorDragwayTest, NoCarsOnShortRoad) {
+  // When no cars are found on a dragway whose length is less than the
+  // scan_distance, then infinite distances should be returned.
+  const double kShortLaneLength{40.};
+  MakeDragway(2 /* num lanes */, kShortLaneLength);
+
+  PoseVector<double> ego_pose;
+  PoseBundle<double> traffic_poses(kNumDragwayTrafficCars);
+
+  // Define the default poses.
+  SetDefaultDragwayPoses(&ego_pose, &traffic_poses);
+
+  // Choose a scan-ahead distance greater than the lane length.
+  const double scan_ahead_distance = kShortLaneLength + 10.;
+  EXPECT_GT(scan_ahead_distance,
+            kShortLaneLength - ego_pose.get_translation().x());
+  EXPECT_GT(scan_ahead_distance, ego_pose.get_translation().x());
+
+  // Scan for cars in the left lane, which should contain no cars.
+  const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+      PoseSelector<double>::FindClosestPair(
+          get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
+          scan_ahead_distance);
+
+  // Expect infinite distances.
+  EXPECT_EQ(std::numeric_limits<double>::infinity(),
+            closest_poses.at(AheadOrBehind::kAhead).distance);
+  EXPECT_EQ(std::numeric_limits<double>::infinity(),
+            closest_poses.at(AheadOrBehind::kBehind).distance);
+}
+
+// Verifies the result when the s-positions of the ego and traffic vehicles have
+// the same s-position (side-by-side in adjacent lanes).
+TEST_F(PoseSelectorDragwayTest, IdenticalSValues) {
+  MakeDragway(2 /* num lanes */, kDragwayLaneLength);
+
   PoseVector<double> ego_pose;
   PoseBundle<double> traffic_poses(1);
 
-  // Define the default poses.
-  SetDefaultPosesSideBySide(&ego_pose, &traffic_poses);
+  // Create poses for one traffic car and one ego car positioned side-by-side,
+  // with the ego vehicle in the right lane and the traffic vehicle in the left
+  // lane.
+  SetPoses(0. /* s_offset */, kDragwayLaneWidth /* r_offset */, &ego_pose,
+           &traffic_poses);
 
-  RoadOdometry<double> leading_odometry{};
-  RoadOdometry<double> trailing_odometry{};
-  // Peer into the adjacent lane to the left.
-  std::tie(leading_odometry, trailing_odometry) = FindClosestPair(
-      road, ego_pose, traffic_poses,
-      CalcRoadPosition(road, ego_pose.get_isometry()).lane->to_left());
+  {
+    // Peer into the adjacent lane to the left.
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(
+            get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
+            1000. /* scan_ahead_distance */);
 
-  // Verifies that the if the cars are side-by-side, then the traffic car is
-  // classified as a trailing car.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(), leading_odometry.pos.s());
-  EXPECT_EQ(kEgoSPosition, trailing_odometry.pos.s());
+    // Verifies that, if the cars are side-by-side, then the traffic car is
+    // classified as a trailing car (and not the leading car).
+    //
+    // N.B. The dragway has a magic teleportation device at the end of each lane
+    // that returns cars to the opposite end of the same lane.  The immediate
+    // implication to PoseSelector is that cars located "behind" the ego will be
+    // also visible ahead of it, provided `scan_ahead_distance` is large enough.
+    EXPECT_EQ(kEgoSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(kDragwayLaneLength,
+              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(kEgoSPosition,
+              closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
+    EXPECT_EQ(0., closest_poses.at(AheadOrBehind::kBehind).distance);
+  }
+
+  {
+    // Repeat the same computation, but with a myopic scan-ahead distance that
+    // is much smaller than kDragwayLaneLength.
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(
+            get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
+            kDragwayLaneLength / 2. /* scan_ahead_distance */);
+
+    // Verifies that no traffic car is seen ahead.
+    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(kEgoSPosition,
+              closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
+    EXPECT_EQ(0., closest_poses.at(AheadOrBehind::kBehind).distance);
+  }
 }
 
-GTEST_TEST(PoseSelectorTest, TestGetSVelocity) {
-  // Create a single-lane dragway.
-  const maliput::dragway::RoadGeometry road(
-      maliput::api::RoadGeometryId({"Single-lane dragway"}), 1 /* num_lanes */,
-      kLaneLength, kLaneWidth, 0. /* shoulder width */,
-      5. /* maximum_height */,
-      std::numeric_limits<double>::epsilon() /* linear_tolerance */,
-      std::numeric_limits<double>::epsilon() /* angular_tolerance */);
-  const maliput::api::Lane* lane = road.junction(0)->segment(0)->lane(0);
+TEST_F(PoseSelectorDragwayTest, TestGetSigmaVelocity) {
+  MakeDragway(1 /* num lanes */, kDragwayLaneLength);
 
-  maliput::api::RoadPosition position =
-      maliput::api::RoadPosition(lane, maliput::api::LanePosition(0., 0., 0.));
+  const maliput::api::Lane* lane = road_->junction(0)->segment(0)->lane(0);
+
+  RoadPosition position(lane, maliput::api::LanePosition(0., 0., 0.));
   FrameVelocity<double> velocity{};
 
   // Expect the s-velocity to be zero.
-  EXPECT_EQ(0., GetSVelocity(RoadOdometry<double>(position, velocity)));
+  double sigma_v = PoseSelector<double>::GetSigmaVelocity({position, velocity});
+  EXPECT_EQ(0., sigma_v);
 
   // Set the velocity to be along the lane's s-coordinate.
   velocity[3] = 10.;
   // Expect the s-velocity to match.
-  EXPECT_EQ(10., GetSVelocity(RoadOdometry<double>(position, velocity)));
+  sigma_v = PoseSelector<double>::GetSigmaVelocity({position, velocity});
+  EXPECT_EQ(10., sigma_v);
 
   // Set a velocity vector at 45-degrees with the lane's s-coordinate.
   velocity[3] = 10. * std::cos(M_PI / 4.);
   velocity[4] = 10. * std::sin(M_PI / 4.);
   // Expect the s-velocity to be attenuated by sqrt(2) / 2.
-  EXPECT_NEAR(10. * std::sqrt(2.) / 2.,
-              GetSVelocity(RoadOdometry<double>(position, velocity)), 1e-12);
+  sigma_v = PoseSelector<double>::GetSigmaVelocity({position, velocity});
+  EXPECT_NEAR(10. * std::sqrt(2.) / 2., sigma_v, 1e-12);
+
+  // Verifies the consistency of the result when the s-value is set to
+  // end-of-lane.
+  position.pos.set_s(lane->length());
+  sigma_v = PoseSelector<double>::GetSigmaVelocity({position, velocity});
+  EXPECT_NEAR(10. * std::sqrt(2.) / 2., sigma_v, 1e-12);
+}
+
+// Build a road with three lanes in series.  If is_opposing is true, then the
+// middle segment is reversed.
+std::unique_ptr<const maliput::api::RoadGeometry> MakeThreeSegmentMonolaneRoad(
+    bool is_opposing) {
+  Builder builder(
+      maliput::api::RBounds(-std::abs(kEgoRPosition) - 2.,
+                            std::abs(kEgoRPosition) + 2.) /* lane_bounds */,
+      maliput::api::RBounds(
+          -std::abs(kEgoRPosition) - 2.,
+          std::abs(kEgoRPosition) + 2.) /* driveable_bounds */,
+      maliput::api::HBounds(0., 5.) /* elevation bounds */,
+      0.01 /* linear tolerance */, 0.01 /* angular_tolerance */);
+  const Connection* c0 = builder.Connect(
+      "0_fwd" /* id */, Endpoint({0., 0., 0.}, kEndZ) /* start */,
+      kRoadSegmentLength /* length */, kEndZ /* z_end */);
+  const Connection* c1{};
+  if (is_opposing) {
+    // Construct a segment in the direction opposite to the initial lane.
+    c1 = builder.Connect(
+        "1_rev" /* id */,
+        Endpoint({2. * kRoadSegmentLength, 0., 0.}, kEndZ) /* start */,
+        -kRoadSegmentLength /* length */, kEndZ /* z_end */);
+  } else {
+    // Construct a segment in the direction aligned with the initial lane.
+    c1 = builder.Connect(
+        "1_fwd" /* id */,
+        Endpoint({kRoadSegmentLength, 0., 0.}, kEndZ) /* start */,
+        kRoadSegmentLength /* length */, kEndZ /* z_end */);
+  }
+  const Connection* c2 = builder.Connect(
+      "2_fwd" /* id */,
+      Endpoint({2. * kRoadSegmentLength, 0., 0.}, kEndZ) /* start */,
+      kRoadSegmentLength /* length */, kEndZ /* z_end */);
+
+  if (is_opposing) {
+    builder.SetDefaultBranch(c0, LaneEnd::kFinish, c1, LaneEnd::kFinish);
+    builder.SetDefaultBranch(c1, LaneEnd::kStart, c2, LaneEnd::kStart);
+  } else {
+    builder.SetDefaultBranch(c0, LaneEnd::kFinish, c1, LaneEnd::kStart);
+    builder.SetDefaultBranch(c1, LaneEnd::kFinish, c2, LaneEnd::kStart);
+  }
+
+  return builder.Build(maliput::api::RoadGeometryId({"ThreeLaneStretch"}));
+}
+
+// Verifies the soundness of the results when applied to multi-segment roads.
+GTEST_TEST(PoseSelectorTest, MultiSegmentRoad) {
+  // Instantiate monolane roads with multiple segments.
+  std::vector<std::unique_ptr<const maliput::api::RoadGeometry>> roads;
+  roads.push_back(MakeThreeSegmentMonolaneRoad(false));  // Road with consistent
+                                                         // with_s
+                                                         // directionality.
+  roads.push_back(MakeThreeSegmentMonolaneRoad(true));  // Road constructed with
+                                                        // alternating with_s.
+
+  PoseVector<double> ego_pose;
+  PoseBundle<double> traffic_poses(1);
+
+  // Choose a scan-ahead distance at least as long as the entire road.
+  const double scan_ahead_distance = 3. * kRoadSegmentLength;
+
+  for (const auto& road : roads) {
+    // At each iteration, increment the traffic car's position ahead through
+    // each lane.
+    for (double s_offset = 8.;
+         s_offset <= 3. * kRoadSegmentLength - kEgoSPosition; s_offset += 5.) {
+      // Situate the ego car within the 0th segment, facing along the x-axis,
+      // along with a traffic car that is in front of the ego car by an amount
+      // `s_offset`.
+      SetPoses(s_offset, 0. /* r_offset */, &ego_pose, &traffic_poses,
+               0. /* yaw angle */);
+
+      // Determine the distance to the car ahead the ego car.
+      const ClosestPose<double> closest_pose_ahead =
+          PoseSelector<double>::FindSingleClosestPose(
+              get_lane(ego_pose, *road), ego_pose, traffic_poses,
+              scan_ahead_distance, AheadOrBehind::kAhead);
+
+      // Expect the detected distance to be the offset distance.
+      EXPECT_EQ(s_offset, closest_pose_ahead.distance);
+
+      // Situate the ego car within the 0th segment, facing against the x-axis.
+      SetPoses(s_offset, 0. /* r_offset */, &ego_pose, &traffic_poses,
+               M_PI /* yaw angle */);
+
+      // Determine the distance to the car behind the ego car.
+      const ClosestPose<double> closest_pose_behind =
+          PoseSelector<double>::FindSingleClosestPose(
+              get_lane(ego_pose, *road), ego_pose, traffic_poses,
+              scan_ahead_distance, AheadOrBehind::kBehind);
+
+      // Expect the detected distance to be the offset distance.
+      EXPECT_EQ(s_offset, closest_pose_behind.distance);
+    }
+  }
 }
 
 }  // namespace
-}  // namespace pose_selector
 }  // namespace automotive
 }  // namespace drake


### PR DESCRIPTION
- PoseSelector follows the default lane, up to a given `scan_ahead_distance`.
- Add equality `==` operator to `maliput::api::GeoPosition`.
- Apply updates to `IdmController` and `MobilPlanner`. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6249)
<!-- Reviewable:end -->
