### PR TITLE
Adding geometry::SpatialPose

### DIFF
--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -17,9 +17,26 @@ drake_cc_library(
     deps = ["//drake/common"],
 )
 
+drake_cc_library(
+    name = "spatial_pose",
+    srcs = [],
+    hdrs = ["spatial_pose.h"],
+    deps = ["//drake/common"],
+)
+
+# -----------------------------------------------------
+
 drake_cc_googletest(
     name = "identifier_test",
     deps = [":identifier"],
+)
+
+drake_cc_googletest(
+    name = "spatial_pose_test",
+    deps = [
+        ":spatial_pose",
+        "//drake/common:eigen_matrix_compare",
+    ],
 )
 
 cpplint()

--- a/drake/geometry/spatial_pose.h
+++ b/drake/geometry/spatial_pose.h
@@ -10,10 +10,9 @@ namespace drake {
 namespace geometry {
 
 /** This class is used to represent the pose of a frame, `X_PF` --  the position
- and orientation of a frame F, relative to a parent frame P. Mathematically, it
- is equivalent to using an Isometry3 but it is more compact. This serves as the
- basis for communicating frame kinematics to GeometryWorld and GeometrySystem
- via the FrameKinematicsSet.
+ and orientation of a frame F, relative to a parent frame P--used, for example,
+ as the basis for communicating frame kinematics values to GeometryWorld and
+ GeometrySystem via the FrameKinematicsSet.
 
  The %SpatialPose is _related_ to a SpatialVelocity. Whereas the SpatialVelocity
  `V_PF` represents the rate at which frame F moves with respect to frame P, the
@@ -44,15 +43,16 @@ class SpatialPose {
     DRAKE_ASSERT_VOID(SetNaN());
   }
 
-  /** Construction from the orientation `q_PF` and a position `p_PF` of frame
-   F relative to parent frame P. Both quantities must be measured and expressed
-   in the same frame. */
-  SpatialPose(const Quaternion<T>& q, const Eigen::Ref<const Vector3<T>>& p)
-      : orientation_(q), position_(p) {}
+  /** Construction from the orientation `q_PF_E` and a position `p_PF_E` of
+   frame F relative to parent frame P. Both quantities must be expressed in the
+   same frame E. */
+  SpatialPose(const Quaternion<T>& q_PF_E,
+              const Eigen::Ref<const Vector3<T>>& p_PF_E)
+      : orientation_(q_PF_E), position_(p_PF_E) {}
 
   /** Construction from the pose `X_PF` represented by an Eigen::Isometry. */
-  explicit SpatialPose(const Isometry3<T>& isometry)
-      : orientation_(isometry.linear()), position_(isometry.translation()) {}
+  explicit SpatialPose(const Isometry3<T>& X_PF)
+      : orientation_(X_PF.linear()), position_(X_PF.translation()) {}
 
   //@}
 
@@ -112,7 +112,7 @@ class SpatialPose {
 
   //@}
 
- protected:
+ private:
   // Sets all entries in `this` %SpatialPose to NaN. Typically used to quickly
   // detect uninitialized values since NaN will trigger a chain of invalid
   // computations that can then be tracked back to the source.
@@ -123,7 +123,6 @@ class SpatialPose {
         typename Eigen::NumTraits<T>::Literal>::quiet_NaN());
   }
 
- private:
   Quaternion<T> orientation_;
   Vector3<T> position_;
 };

--- a/drake/geometry/spatial_pose.h
+++ b/drake/geometry/spatial_pose.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <limits>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+
+/** This class is used to represent the pose of a frame, `X_PF`. It represents
+ the position and orientation of a frame F, relative to another frame P. It is
+ *related* to spatial vectors (e.g., SpatialVelocity), but it differs in several
+ ways:
+    - It serves as value storage and supports no mathematical operators.
+    - It doesn't expose a monolithic array of coefficients but represents the
+      pose as discrete orientation and position components.
+
+ @tparam T The underlying scalar type. Must be a valid Eigen scalar. */
+template <typename T>
+class SpatialPose {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SpatialPose)
+
+  /** @name     Constructors  */
+  // @{
+
+  /** Default constructor. In Release builds the elements of the newly
+   constructed spatial pose are left uninitialized resulting in a zero
+   cost operation. However in Debug builds those entries are set to NaN so
+   that operations using this uninitialized spatial vector fail fast,
+   facilitating fast bug detection. */
+  SpatialPose() {
+    DRAKE_ASSERT_VOID(SetNaN());
+  }
+
+  /** Construction from an orientation `q` and a position `p`. */
+  SpatialPose(const Quaternion<T>& q, const Eigen::Ref<const Vector3<T>>& p)
+      : orientation_(q), position_(p) {}
+
+  /** Construction from an isometry. */
+  explicit SpatialPose(const Isometry3<T>& isometry)
+      : orientation_(isometry.linear()), position_(isometry.translation()) {}
+
+  //@}
+
+  /** @name  Const access to pose values */
+  //@{
+
+  /** Returns the pose represented by a 4x4 homogeneous matrix (or isometry).
+   The matrix is measured and expressed in the same frame as the underlying
+   pose. */
+  Isometry3<T> get_isometry() const {
+    Isometry3<T> isometry;
+    isometry.linear() = orientation_.toRotationMatrix();
+    isometry.translation() = translational();
+    return isometry;
+  }
+
+  /** Const access to the rotational component of this spatial vector. */
+  const Quaternion<T>& rotational() const {
+    return orientation_;
+  }
+
+  /** Const access to the translational component of this spatial vector. */
+  const Vector3<T>& translational() const {
+    return position_;
+  }
+
+  //@}
+
+  /** @name  Updating pose values  */
+  // @{
+
+  /** Sets the rotational component of the pose from the given `rotational`. */
+  void set_rotational(const Quaternion<T>& rotational) {
+    orientation_ = rotational;
+  }
+
+  /** Sets the translational component of the pose from the given `position`. */
+  void set_translational(const Vector3<T>& position) {
+    position_ = position;
+  }
+
+  /** Sets the pose from the given isometry. */
+  void set_pose(const Isometry3<T>& pose) {
+    orientation_ = pose.linear();
+    position_ = pose.translation();
+  }
+
+  //@}
+
+  /** @name  Data access and manipulation  */
+  // @{
+
+  /** Compares `this` spatial pose to the provided spatial pose `other`
+   with respect to a specified precision.
+   @returns `true` if `other`'s values lie within a precision given by
+   `tolerance`. The comparison is performed by comparing the translational
+   components and rotational components of `this` and `other`
+   using the fuzzy comparison provided by Eigen's method isApprox(). */
+  bool IsApprox(const SpatialPose& other,
+                double tolerance = Eigen::NumTraits<T>::epsilon()) const {
+    return position_.isApprox(other.position_, tolerance) &&
+        orientation_.isApprox(other.orientation_, tolerance);
+  }
+
+  /** Sets all entries in `this` %SpatialPose to NaN. Typically used to
+   quickly detect uninitialized values since NaN will trigger a chain of
+   invalid computations that can then be tracked back to the source. */
+  void SetNaN() {
+    orientation_.coeffs().setConstant(std::numeric_limits<
+        typename Eigen::NumTraits<T>::Literal>::quiet_NaN());
+    position_.setConstant(std::numeric_limits<
+        typename Eigen::NumTraits<T>::Literal>::quiet_NaN());
+  }
+
+  //@}
+
+ private:
+  Quaternion<T> orientation_;
+  Vector3<T> position_;
+};
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/test/spatial_pose_test.cc
+++ b/drake/geometry/test/spatial_pose_test.cc
@@ -1,0 +1,129 @@
+#include "drake/geometry/spatial_pose.h"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/eigen_matrix_compare.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+using Iso3d = Isometry3<double>;
+using Quatd = Quaternion<double>;
+using SpatialPosed = SpatialPose<double>;
+using Vector3d = Vector3<double>;
+using Vector7d = Eigen::Matrix<double, 7, 1>;
+
+GTEST_TEST(SpatialPose, Constructor) {
+  // Case: with assert armed, all values are NaN.
+#ifndef DRAKE_ASSERT_IS_DISARMED
+  using std::isnan;
+  SpatialPosed pose1;
+  const auto& q1 = pose1.rotational().coeffs();
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_TRUE(isnan(q1[i]));
+  }
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_TRUE(isnan(pose1.translational()[i]));
+  }
+#endif
+
+  const double w = 0.5, q_x = 0.1, q_y = 0.2, q_z = 0.3;
+  const double x = 10, y = 20, z = 30;
+
+  // Case: initialization with orientation and position.
+  Quatd q(w, q_x, q_y, q_z);
+  Vector3d p(x, y, z);
+  SpatialPosed pose2(q, p);
+
+  // Confirms that the data isn't *shared*, but the values are the same.
+  EXPECT_NE(&pose2.rotational(), &q);
+  EXPECT_TRUE(CompareMatrices(pose2.rotational().coeffs(), q.coeffs()));
+  EXPECT_NE(&pose2.translational(), &p);
+  EXPECT_TRUE(CompareMatrices(pose2.translational(), p));
+
+  // Case: initialization with isometry.
+  Iso3d iso;
+  iso.translation() << x, y, z;
+  // A rotation of the axes: z -> y, y -> x, x -> z, expressed in column-major
+  // order.
+  iso.linear() << 0, 1, 0, 0, 0, 1, 1, 0, 0;
+  SpatialPosed pose3(iso);
+  // There are two quaternions which map to the axis rotation. Simply test
+  // against both of them (where one is the negation of the other).
+  Quatd q3(0.5, -0.5, -0.5, -0.5);
+  EXPECT_TRUE(CompareMatrices(pose3.rotational().coeffs(), q3.coeffs()) ||
+              CompareMatrices(pose3.rotational().coeffs(), -q3.coeffs()));
+  EXPECT_TRUE(CompareMatrices(pose3.translational(), p));
+}
+
+GTEST_TEST(SpatialPose, IsometryFromPose) {
+  // A rotation of the axes; the basis goes from x-y-z to y-z-x.
+  Quatd q(0.5, -0.5, -0.5, -0.5);
+  Vector3d p(10, 20, 30);
+  SpatialPosed pose(q, p);
+
+  Iso3d expected;
+  expected.linear() << 0, 1, 0, 0, 0, 1, 1, 0, 0;
+  expected.translation() = p;
+
+  auto derived_iso = pose.get_isometry();
+  // Note: Because the Isometry is "AffineCompact", the bottom row is
+  // effectively garbage; ignore the bad row in comparison.
+  EXPECT_TRUE(CompareMatrices(derived_iso.matrix().template block<3, 4>(0, 0),
+                              expected.matrix().template block<3, 4>(0, 0)));
+}
+
+GTEST_TEST(SpatialPose, Setters) {
+  // A rotation of the axes; the basis goes from x-y-z to y-z-x.
+  Quatd q(0.5, -0.5, -0.5, -0.5);
+  Vector3d p(10, 20, 30);
+  SpatialPosed pose(q, p);
+  SpatialPosed cached_pose = pose;
+
+  Vector3d new_p(-10, -20, -30);
+  Quatd new_q(0.5, 0.5, 0.5, 0.5); // rotation in the opposite direction.
+  Iso3d new_expected;
+  new_expected.linear() << 0, 0, 1, 1, 0, 0, 0, 1, 0;
+  new_expected.translation() = new_p;
+
+  // Confirm initial conditions.
+  EXPECT_FALSE(CompareMatrices(pose.rotational().coeffs(), new_q.coeffs()));
+  EXPECT_FALSE(CompareMatrices(pose.translational(), new_p));
+  EXPECT_FALSE(CompareMatrices(
+      pose.get_isometry().matrix().template block<3, 4>(0, 0),
+      new_expected.matrix().template block<3, 4>(0, 0)));
+
+  // Set rotational and translational components.
+  pose.set_translational(new_p);
+  EXPECT_TRUE(CompareMatrices(pose.translational(), new_p));
+  pose.set_rotational(new_q);
+  EXPECT_TRUE(CompareMatrices(pose.rotational().coeffs(), new_q.coeffs()));
+  EXPECT_TRUE(CompareMatrices(
+      pose.get_isometry().matrix().template block<3, 4>(0, 0),
+      new_expected.matrix().template block<3, 4>(0, 0)));
+
+  // Set isometry.
+  pose = cached_pose;
+  // Confirm initial conditions.
+  EXPECT_FALSE(CompareMatrices(pose.rotational().coeffs(), new_q.coeffs()));
+  EXPECT_FALSE(CompareMatrices(pose.translational(), new_p));
+  EXPECT_FALSE(CompareMatrices(
+      pose.get_isometry().matrix().template block<3, 4>(0, 0),
+      new_expected.matrix().template block<3, 4>(0, 0)));
+
+  pose.set_pose(new_expected);
+  EXPECT_TRUE(CompareMatrices(pose.translational(), new_p));
+  EXPECT_TRUE(CompareMatrices(pose.rotational().coeffs(), new_q.coeffs()));
+  EXPECT_TRUE(CompareMatrices(
+      pose.get_isometry().matrix().template block<3, 4>(0, 0),
+      new_expected.matrix().template block<3, 4>(0, 0)));
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/test/spatial_pose_test.cc
+++ b/drake/geometry/test/spatial_pose_test.cc
@@ -12,10 +12,10 @@ namespace drake {
 namespace geometry {
 namespace {
 
-using Iso3d = Isometry3<double>;
-using Quatd = Quaternion<double>;
+using Eigen::Isometry3d;
+using Eigen::Quaterniond;
 using SpatialPosed = SpatialPose<double>;
-using Vector3d = Vector3<double>;
+using Eigen::Vector3d;
 using Vector7d = Eigen::Matrix<double, 7, 1>;
 
 GTEST_TEST(SpatialPose, Constructor) {
@@ -24,19 +24,15 @@ GTEST_TEST(SpatialPose, Constructor) {
   using std::isnan;
   SpatialPosed pose1;
   const auto& q1 = pose1.rotational().coeffs();
-  for (int i = 0; i < 4; ++i) {
-    EXPECT_TRUE(isnan(q1[i]));
-  }
-  for (int i = 0; i < 3; ++i) {
-    EXPECT_TRUE(isnan(pose1.translational()[i]));
-  }
+  EXPECT_TRUE(q1.array().isNaN().all());
+  EXPECT_TRUE(pose1.translational().array().isNaN().all());
 #endif
 
   const double w = 0.5, q_x = 0.1, q_y = 0.2, q_z = 0.3;
   const double x = 10, y = 20, z = 30;
 
   // Case: initialization with orientation and position.
-  Quatd q(w, q_x, q_y, q_z);
+  Quaterniond q(w, q_x, q_y, q_z);
   Vector3d p(x, y, z);
   SpatialPosed pose2(q, p);
 
@@ -47,15 +43,17 @@ GTEST_TEST(SpatialPose, Constructor) {
   EXPECT_TRUE(CompareMatrices(pose2.translational(), p));
 
   // Case: initialization with isometry.
-  Iso3d iso;
+  Isometry3d iso;
   iso.translation() << x, y, z;
-  // A rotation of the axes: z -> y, y -> x, x -> z, expressed in column-major
+  // A rotation of the axes: z -> y, y -> x, x -> z, expressed in row-major
   // order.
-  iso.linear() << 0, 1, 0, 0, 0, 1, 1, 0, 0;
+  iso.linear() << 0, 1, 0,
+                  0, 0, 1,
+                  1, 0, 0;
   SpatialPosed pose3(iso);
   // There are two quaternions which map to the axis rotation. Simply test
   // against both of them (where one is the negation of the other).
-  Quatd q3(0.5, -0.5, -0.5, -0.5);
+  Quaterniond q3(0.5, -0.5, -0.5, -0.5);
   EXPECT_TRUE(CompareMatrices(pose3.rotational().coeffs(), q3.coeffs()) ||
               CompareMatrices(pose3.rotational().coeffs(), -q3.coeffs()));
   EXPECT_TRUE(CompareMatrices(pose3.translational(), p));
@@ -63,40 +61,43 @@ GTEST_TEST(SpatialPose, Constructor) {
 
 GTEST_TEST(SpatialPose, IsometryFromPose) {
   // A rotation of the axes; the basis goes from x-y-z to y-z-x.
-  Quatd q(0.5, -0.5, -0.5, -0.5);
+  Quaterniond q(0.5, -0.5, -0.5, -0.5);
   Vector3d p(10, 20, 30);
   SpatialPosed pose(q, p);
 
-  Iso3d expected;
+  Isometry3d expected;
   expected.linear() << 0, 1, 0, 0, 0, 1, 1, 0, 0;
   expected.translation() = p;
 
   auto derived_iso = pose.get_isometry();
   // Note: Because the Isometry is "AffineCompact", the bottom row is
   // effectively garbage; ignore the bad row in comparison.
-  EXPECT_TRUE(CompareMatrices(derived_iso.matrix().template block<3, 4>(0, 0),
-                              expected.matrix().template block<3, 4>(0, 0)));
+  EXPECT_TRUE(CompareMatrices(derived_iso.matrix().block<3, 4>(0, 0),
+                              expected.matrix().block<3, 4>(0, 0)));
 }
 
 GTEST_TEST(SpatialPose, Setters) {
   // A rotation of the axes; the basis goes from x-y-z to y-z-x.
-  Quatd q(0.5, -0.5, -0.5, -0.5);
+  Quaterniond q(0.5, -0.5, -0.5, -0.5);
   Vector3d p(10, 20, 30);
   SpatialPosed pose(q, p);
   SpatialPosed cached_pose = pose;
 
   Vector3d new_p(-10, -20, -30);
-  Quatd new_q(0.5, 0.5, 0.5, 0.5); // rotation in the opposite direction.
-  Iso3d new_expected;
+  Quaterniond new_q(0.5, 0.5, 0.5, 0.5);  // rotation in the opposite direction.
+  Isometry3d new_expected;
   new_expected.linear() << 0, 0, 1, 1, 0, 0, 0, 1, 0;
   new_expected.translation() = new_p;
+
+  // Note: Because the Isometry is "AffineCompact", the bottom row is
+  // effectively garbage; ignore the bad row in comparison.
 
   // Confirm initial conditions.
   EXPECT_FALSE(CompareMatrices(pose.rotational().coeffs(), new_q.coeffs()));
   EXPECT_FALSE(CompareMatrices(pose.translational(), new_p));
   EXPECT_FALSE(CompareMatrices(
-      pose.get_isometry().matrix().template block<3, 4>(0, 0),
-      new_expected.matrix().template block<3, 4>(0, 0)));
+      pose.get_isometry().matrix().block<3, 4>(0, 0),
+      new_expected.matrix().block<3, 4>(0, 0)));
 
   // Set rotational and translational components.
   pose.set_translational(new_p);
@@ -104,8 +105,8 @@ GTEST_TEST(SpatialPose, Setters) {
   pose.set_rotational(new_q);
   EXPECT_TRUE(CompareMatrices(pose.rotational().coeffs(), new_q.coeffs()));
   EXPECT_TRUE(CompareMatrices(
-      pose.get_isometry().matrix().template block<3, 4>(0, 0),
-      new_expected.matrix().template block<3, 4>(0, 0)));
+      pose.get_isometry().matrix().block<3, 4>(0, 0),
+      new_expected.matrix().block<3, 4>(0, 0)));
 
   // Set isometry.
   pose = cached_pose;
@@ -113,15 +114,15 @@ GTEST_TEST(SpatialPose, Setters) {
   EXPECT_FALSE(CompareMatrices(pose.rotational().coeffs(), new_q.coeffs()));
   EXPECT_FALSE(CompareMatrices(pose.translational(), new_p));
   EXPECT_FALSE(CompareMatrices(
-      pose.get_isometry().matrix().template block<3, 4>(0, 0),
-      new_expected.matrix().template block<3, 4>(0, 0)));
+      pose.get_isometry().matrix().block<3, 4>(0, 0),
+      new_expected.matrix().block<3, 4>(0, 0)));
 
   pose.set_pose(new_expected);
   EXPECT_TRUE(CompareMatrices(pose.translational(), new_p));
   EXPECT_TRUE(CompareMatrices(pose.rotational().coeffs(), new_q.coeffs()));
   EXPECT_TRUE(CompareMatrices(
-      pose.get_isometry().matrix().template block<3, 4>(0, 0),
-      new_expected.matrix().template block<3, 4>(0, 0)));
+      pose.get_isometry().matrix().block<3, 4>(0, 0),
+      new_expected.matrix().block<3, 4>(0, 0)));
 }
 
 }  // namespace


### PR DESCRIPTION
This adds the SpatialPose class for communication between geometry sources and geometry world/system. It, in some sense, parallels the SpatialVector/Velocity found in multibody tree.

The first of many PRs for constructing GeometryWorld.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6252)
<!-- Reviewable:end -->
