### PR TITLE
Allow leaf systems to allocate custom context types

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -440,6 +440,7 @@ drake_cc_googletest(
     deps = [
         ":leaf_system",
         "//drake/common",
+        "//drake/common:is_dynamic_castable",
         "//drake/systems/framework/test_utilities",
     ],
 )

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -95,7 +95,7 @@ class LeafSystem : public System<T> {
     // Note that the outputs are not part of the Context, but instead are
     // checked by LeafSystemOutput::add_port.
 
-    return std::unique_ptr<LeafContext<T>>(context.release());
+    return std::move(context);
   }
 
   /// Default implementation: sets all continuous and discrete state variables

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -60,8 +60,7 @@ class LeafSystem : public System<T> {
   // Implementations of System<T> methods.
 
   std::unique_ptr<Context<T>> AllocateContext() const override {
-    LeafContext<T>* context = DoMakeContext();
-    std::unique_ptr<Context<T>> return_value(context);
+    std::unique_ptr<LeafContext<T>> context = DoMakeContext();
     // Reserve inputs that have already been declared.
     context->SetNumInputPorts(this->get_num_input_ports());
     // Reserve continuous state via delegation to subclass.
@@ -96,7 +95,7 @@ class LeafSystem : public System<T> {
     // Note that the outputs are not part of the Context, but instead are
     // checked by LeafSystemOutput::add_port.
 
-    return return_value;
+    return std::unique_ptr<LeafContext<T>>(context.release());
   }
 
   /// Default implementation: sets all continuous and discrete state variables
@@ -227,8 +226,8 @@ class LeafSystem : public System<T> {
   /// leaf systems with custom derived leaf system contexts should override this
   /// to provide a context of the appropriate type. The returned pointer must
   /// immediately be wrapped in a unique pointer by the caller.
-  virtual LeafContext<T>* DoMakeContext() const {
-    return new LeafContext<T>();
+  virtual std::unique_ptr<LeafContext<T>> DoMakeContext() const {
+    return std::unique_ptr<LeafContext<T>>(new LeafContext<T>());
   }
 
   /// Returns the per step events declared through DeclarePerStepAction().

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -224,10 +224,15 @@ class LeafSystem : public System<T> {
 
   /// Provides a new instance of the leaf context for this system. Derived
   /// leaf systems with custom derived leaf system contexts should override this
-  /// to provide a context of the appropriate type. The returned pointer must
-  /// immediately be wrapped in a unique pointer by the caller.
+  /// to provide a context of the appropriate type. The returned context should
+  /// be "empty"; invoked by AllocateContext(), the caller will take the
+  /// responsibility to initialize the core LeafContext data.
+  // TODO(SeanCurtis-TRI): This currently assumes that derived LeafContext
+  // classes do *not* add new data members. If that changes, e.g., with the
+  // advent of the cache, this documentation should be changed to include the
+  // initialization of the sub-class's *unique* data members.
   virtual std::unique_ptr<LeafContext<T>> DoMakeContext() const {
-    return std::unique_ptr<LeafContext<T>>(new LeafContext<T>());
+    return std::make_unique<LeafContext<T>>();
   }
 
   /// Returns the per step events declared through DeclarePerStepAction().

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -60,7 +60,8 @@ class LeafSystem : public System<T> {
   // Implementations of System<T> methods.
 
   std::unique_ptr<Context<T>> AllocateContext() const override {
-    std::unique_ptr<LeafContext<T>> context(new LeafContext<T>);
+    LeafContext<T>* context = DoMakeContext();
+    std::unique_ptr<Context<T>> return_value(context);
     // Reserve inputs that have already been declared.
     context->SetNumInputPorts(this->get_num_input_ports());
     // Reserve continuous state via delegation to subclass.
@@ -95,7 +96,7 @@ class LeafSystem : public System<T> {
     // Note that the outputs are not part of the Context, but instead are
     // checked by LeafSystemOutput::add_port.
 
-    return std::unique_ptr<Context<T>>(context.release());
+    return return_value;
   }
 
   /// Default implementation: sets all continuous and discrete state variables
@@ -221,6 +222,14 @@ class LeafSystem : public System<T> {
 
  protected:
   LeafSystem() {}
+
+  /// Provides a new instance of the leaf context for this system. Derived
+  /// leaf systems with custom derived leaf system contexts should override this
+  /// to provide a context of the appropriate type. The returned pointer must
+  /// immediately be wrapped in a unique pointer by the caller.
+  virtual LeafContext<T>* DoMakeContext() const {
+    return new LeafContext<T>();
+  }
 
   /// Returns the per step events declared through DeclarePerStepAction().
   const std::vector<DiscreteEvent<T>>& get_per_step_events() const {

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -748,7 +748,7 @@ class CustomContextSystem : public LeafSystem<T> {
                     SystemOutput<T>* output) const override {}
  protected:
   std::unique_ptr<LeafContext<T>> DoMakeContext() const override {
-    return std::unique_ptr<LeafContext<T>>(new CustomContext<T>());
+    return std::make_unique<CustomContext<T>>();
   }
 };
 

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -747,8 +747,8 @@ class CustomContextSystem : public LeafSystem<T> {
   void DoCalcOutput(const Context<T>& context,
                     SystemOutput<T>* output) const override {}
  protected:
-  LeafContext<T>* DoMakeContext() const override {
-    return new CustomContext<T>();
+  std::unique_ptr<LeafContext<T>> DoMakeContext() const override {
+    return std::unique_ptr<LeafContext<T>>(new CustomContext<T>());
   }
 };
 


### PR DESCRIPTION
Changed the interface to allow the creation of derived LeafContext types using the basic system architecture.

We have, in the works, several systems that have declared custom Context types (derived from `LeafContext`), e.g., `MultibodyTreePlant` and `GeometrySystem`. `LeafSystem::AllocateContext` constructs a `LeafContext` and does important things like setting input ports, continuous state, discrete state, etc. This method, in turn, is called by `System::CreateDefaultContext()`. If a derived `LeafSystem` wants to have a derived `LeafContext` it must re-implement `AllocateContext` (constructing an alternative type). It must also include the substantive functionality of the `LeafSystem::AllocateContext` method.

This PR modifies the LeafSystem allocation mechanism to make the actual instantiation of the `LeafContext` a virtual method such that derived classes can return derived contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6253)
<!-- Reviewable:end -->
