### PR TITLE
RNDF Spline Helpers

### DIFF
--- a/drake/automotive/maliput/rndf/BUILD
+++ b/drake/automotive/maliput/rndf/BUILD
@@ -19,6 +19,7 @@ drake_cc_library(
         "lane.cc",
         "road_geometry.cc",
         "segment.cc",
+        "spline_helpers.cc",
         "spline_lane.cc",
     ],
     hdrs = [
@@ -27,6 +28,7 @@ drake_cc_library(
         "lane.h",
         "road_geometry.h",
         "segment.h",
+        "spline_helpers.h",
         "spline_lane.h",
     ],
     deps = [
@@ -49,6 +51,14 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "junction_test",
+    size = "small",
+    deps = [
+        ":lanes",
+    ],
+)
+
+drake_cc_googletest(
+    name = "spline_helpers_test",
     size = "small",
     deps = [
         ":lanes",

--- a/drake/automotive/maliput/rndf/CMakeLists.txt
+++ b/drake/automotive/maliput/rndf/CMakeLists.txt
@@ -6,6 +6,7 @@ if(ignition-rndf0_FOUND)
         lane.cc
         road_geometry.cc
         segment.cc
+        spline_helpers.cc
         spline_lane.cc
     )
 
@@ -27,6 +28,7 @@ if(ignition-rndf0_FOUND)
         lane.h
         road_geometry.h
         segment.h
+        spline_helpers.h
         spline_lane.h
     )
 

--- a/drake/automotive/maliput/rndf/spline_helpers.cc
+++ b/drake/automotive/maliput/rndf/spline_helpers.cc
@@ -1,0 +1,205 @@
+#include "drake/automotive/maliput/rndf/spline_helpers.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+// The InverseFunctionInterpolator holds a graph structure where each node
+// is a linear interpolant. The graph has kFunctionPartitionTreeDegree on each
+// level and the depth is controlled by kFunctionPartitionTreeMaxDepth. These
+// two numbers are related with the error_boundary provided to
+// InverseFunctionInterpolator's constructor in the sense that we can get
+// smaller error bounds given higher values of kFunctionPartitionTreeDegree
+// and / or kFunctionPartitionTreeMaxDepth.
+static const int kFunctionPartitionTreeDegree = 10;
+static const int kFunctionPartitionTreeMaxDepth = 10;
+
+InverseFunctionInterpolator::InverseFunctionInterpolator(
+    std::function<double(double)> function, double xmin, double xmax,
+    double error_boundary)
+    : function_(function),
+      error_boundary_(error_boundary),
+      partition_tree_degree_(kFunctionPartitionTreeDegree),
+      partition_tree_max_depth_(kFunctionPartitionTreeMaxDepth) {
+  // Make sure the error boundary is attainable.
+  DRAKE_THROW_UNLESS(error_boundary > 0);
+  // Make sure that xmin is smaller that xmax
+  DRAKE_THROW_UNLESS(xmin < xmax);
+  // Instantiate the partition tree root.
+  partition_tree_ =
+      std::make_unique<InverseFunctionInterpolator::FunctionGraphPartition>();
+  partition_tree_->segment.xmin = xmin;
+  partition_tree_->segment.xmax = xmax;
+  partition_tree_->segment.ymin = function(xmin);
+  partition_tree_->segment.ymax = function(xmax);
+}
+
+double InverseFunctionInterpolator::InterpolateMthDerivative(
+    int derivative_order, double y) {
+  // Make sure that the derivative order is non-negative.
+  DRAKE_THROW_UNLESS(derivative_order >= 0);
+  // Make sure that y is not above x(y) image interval upper bound.
+  DRAKE_THROW_UNLESS((y - partition_tree_->segment.ymax) < error_boundary_);
+  // Make sure that y is not below x(y) image interval low bound.
+  DRAKE_THROW_UNLESS((partition_tree_->segment.ymin - y) < error_boundary_);
+
+  // Zero out any derivative of higher order than 1, as this is a piecewise
+  // linear interpolant.
+  if (derivative_order > 1) return 0.0;
+
+  // Get partition tree root.
+  InverseFunctionInterpolator::FunctionGraphPartition* root =
+      partition_tree_.get();
+
+  // Clamp interpolation y.
+  const double iy =
+      std::min(std::max(y, root->segment.ymin), root->segment.ymax);
+
+  // Traverse down the partition tree until the required error is attained.
+  int depth = 0;
+  while (true) {
+    if (root->partitions.empty()) {
+      // Visiting a leaf node.
+
+      // Linearly interpolate x for the given y.
+      const double dx = root->segment.xmax - root->segment.xmin;
+      const double dy = root->segment.ymax - root->segment.ymin;
+      const double ix =
+          root->segment.xmin + (dx / dy) * (iy - root->segment.ymin);
+
+      // Check if the interpolation meets the error bound requirements.
+      if (std::abs(function_(ix) - iy) < error_boundary_) {
+        if (derivative_order == 1) {
+          // Return derivative dx/dy at y.
+          return dx / dy;
+        }
+        // Return interpolated x(y).
+        return ix;
+      }
+
+      // Safety check before building next tree level.
+      DRAKE_DEMAND(depth <= partition_tree_max_depth_);
+
+      // Build sub-partitions for this partition.
+      const double segmentdx = dx / partition_tree_degree_;
+      for (int i = 0; i < partition_tree_degree_; ++i) {
+        const double segmentxmin = root->segment.xmin + i * segmentdx;
+        const double segmentxmax = segmentxmin + segmentdx;
+
+        auto subp = std::make_unique<
+            InverseFunctionInterpolator::FunctionGraphPartition>();
+        subp->segment.xmin = segmentxmin;
+        subp->segment.xmax = segmentxmax;
+        subp->segment.ymin = function_(segmentxmin);
+        subp->segment.ymax = function_(segmentxmax);
+        root->partitions.push_back(std::move(subp));
+      }
+    }
+    // Visiting an inner node.
+
+    // Search subpartition that contains y.
+    auto it = std::find_if(
+        root->partitions.begin(), root->partitions.end(),
+        [&iy](const std::unique_ptr<
+              InverseFunctionInterpolator::FunctionGraphPartition>& subp) {
+          return (subp->segment.ymin <= iy && iy <= subp->segment.ymax);
+        });
+
+    // Use subpartition as new root.
+    DRAKE_DEMAND(it != root->partitions.end());
+    DRAKE_DEMAND(it->get() != nullptr);
+
+    root = it->get();
+    depth++;
+  }
+}
+
+ArcLengthParameterizedSpline::ArcLengthParameterizedSpline(
+    std::unique_ptr<ignition::math::Spline> spline, double error_boundary)
+    : q_t_(std::move(spline)) {
+  DRAKE_THROW_UNLESS(q_t_ != nullptr);
+  // Instantiate an inverse function interpolator
+  // for the given spline path length function.
+  F_ts_ = std::make_unique<InverseFunctionInterpolator>(
+      [this](double t) { return q_t_->ArcLength(t); }, 0.0, 1.0,
+      error_boundary);
+}
+
+ignition::math::Vector3d ArcLengthParameterizedSpline::InterpolateMthDerivative(
+    int derivative_order, double s) {
+  DRAKE_THROW_UNLESS(derivative_order >= 0);
+  if (derivative_order > 3) {
+    // derivative_order > 3 => p = 0 (as this is a cubic interpolator)
+    return ignition::math::Vector3d(0.0, 0.0, 0.0);
+  }
+  const double t_s = F_ts_->InterpolateMthDerivative(0, s);
+  if (derivative_order == 0) {
+    // derivative_order = 0 => P(s) = Q(t(s))
+    return q_t_->InterpolateMthDerivative(0, t_s);
+  }
+  const double t_prime_s = F_ts_->InterpolateMthDerivative(1, s);
+  ignition::math::Vector3d q_prime_t = q_t_->InterpolateMthDerivative(1, t_s);
+
+  if (derivative_order == 1) {
+    // We need to apply chain rule to get the derivative of Q(t(s)) with respect
+    // to s.
+    // derivative_order = 1 => P'(s) = Q'(t(s)) * t'(s)
+    return q_prime_t * t_prime_s;
+  }
+  const double t_prime_s_2 = t_prime_s * t_prime_s;
+  const double t_prime2_s = F_ts_->InterpolateMthDerivative(2, s);
+  const ignition::math::Vector3d q_prime2_t =
+      q_t_->InterpolateMthDerivative(2, t_s);
+  if (derivative_order == 2) {
+    // We need to apply chain rule to get the second of derivative of Q(t(s))
+    // with respect to s.
+    // derivative_order = 2 => P''(s) = Q''(t(s)) * t'(s)^2 + Q'(t(s)) * t''(s)
+    return q_prime2_t * t_prime_s_2 + q_prime_t * t_prime2_s;
+  }
+  const double t_prime_s_3 = t_prime_s_2 * t_prime_s;
+  const double t_prime3_s = F_ts_->InterpolateMthDerivative(3, s);
+  const ignition::math::Vector3d q_prime3_t =
+      q_t_->InterpolateMthDerivative(3, t_s);
+  // We need to apply chain rule to get the third derivative of Q(t(s))
+  // with respect to s.
+  // derivative_order = 3 => P'''(s) = Q'''(t(s)) * t'(s)^3
+  //                                   + 3 * Q''(t(s)) * t'(s) * t''(s)
+  //                                   + Q'(t(s)) * t'''(s)
+  return (q_prime3_t * t_prime_s_3 + 3 * q_prime2_t * t_prime_s * t_prime2_s +
+          q_prime_t * t_prime3_s);
+}
+
+double ArcLengthParameterizedSpline::FindClosestPointTo(
+    const ignition::math::Vector3d& point, double step) const {
+  double closest_s = 0.0;
+  double min_distance = std::numeric_limits<double>::max();
+  double distance = 0.0;
+  double t_s = 0.0;
+  for (double s = 0.0; s < q_t_->ArcLength(); s += step) {
+    t_s = F_ts_->InterpolateMthDerivative(0, s);
+    distance = (q_t_->InterpolateMthDerivative(0, t_s) - point).Length();
+    if (distance < min_distance) {
+      min_distance = distance;
+      closest_s = s;
+    }
+  }
+  t_s = F_ts_->InterpolateMthDerivative(0, q_t_->ArcLength());
+  distance = (q_t_->InterpolateMthDerivative(0, t_s) - point).Length();
+  if (distance < min_distance) {
+    min_distance = distance;
+    closest_s = q_t_->ArcLength();
+  }
+
+  return closest_s;
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/spline_helpers.h
+++ b/drake/automotive/maliput/rndf/spline_helpers.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "ignition/math/Spline.hh"
+#include "ignition/math/Vector3.hh"
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+/// A linear interpolator for arbitrary inverse functions.
+/// Helpful for path-length parameterization with ignition::math::Splines.
+/// Given a function F, its domain D, and codomain CD, this class gives a linear
+/// interpolant of F's inverse that maps CD to D.
+class InverseFunctionInterpolator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InverseFunctionInterpolator)
+
+  /// Constructor that takes the function, its domain interval and an error
+  /// boundary for the interpolation.
+  /// The valid range of @p function's codomain is determined as follows. The
+  /// minimum value is @p xmin applied to @p function. The maximum value is
+  /// @p xmax applied to @p function. This is valid because @p function is
+  /// assumed to be monotonically increasing with x.
+  ///
+  /// @param[in] function an arbitrary continuous function for which to
+  /// interpolate an inverse. It should be monotonically increasing with x.
+  /// @param[in] xmin @p function 's domain interval low bound.
+  /// @param[in] xmax @p function 's domain interval upper bound.
+  /// @param[in] error_boundary a positive constraint on the maximum error
+  /// allowed when approximating the inverse function.
+  /// @throws when @p error_boundary is not positive.
+  /// @throws when @p xmin is equal or greater than @p xmax.
+  /// @throws when evaluating @p function throws.
+  explicit InverseFunctionInterpolator(
+      std::function<double(double)> function, double xmin, double xmax,
+      double error_boundary);
+
+  /// Interpolates @f$ x^{(derivative_order)}(y) @f$, that is, the inverse of
+  /// the given function.
+  /// @param[in] derivative_order a non-negative integer describing
+  /// the order of the inverse function derivative to interpolate. Any value
+  /// bigger than 1 will make the function return 0.0 as this is a linear
+  /// interpolant.
+  /// @param[in] y the range value to interpolate at, constrained by the direct
+  /// function image, which is inside the codomain of the direct function.
+  /// @return interpolated @p derivative_order derivative
+  /// @f$ x^{(derivative_order)}(y) @f$ .
+  /// @throws when @p derivative_order is a negative integer.
+  /// @throws when @p y is larger than the maximum range of the function's
+  /// codomain as described in the constructor's documentation.
+  /// @throws when @p y is smaller than the minimum range of the function's
+  /// codomain as described in the constructor's documentation.
+  double InterpolateMthDerivative(int derivative_order, double y);
+
+ private:
+  // A segment of a single-variable function graph.
+  struct FunctionGraphSegment {
+    double xmin;  //< Lower x bound.
+    double xmax;  //< Upper x bound.
+    double ymin;  //< Lower y bound.
+    double ymax;  //< Upper y bound.
+  };
+
+  // A partition of a single-variable function graph, as a segment plus a set
+  // of sub partitions.
+  struct FunctionGraphPartition {
+    // Segment covered.
+    FunctionGraphSegment segment;
+    // Sub-partitions covered.
+    std::vector<std::unique_ptr<FunctionGraphPartition>> partitions;
+  };
+
+  const std::function<double(double)> function_;  //< Base function.
+  const double error_boundary_{};         //< Error boundary for interpolation.
+  const int partition_tree_degree_{};     //< Function partition tree degree.
+  const int partition_tree_max_depth_{};  //< Function partition tree max depth.
+  std::unique_ptr<FunctionGraphPartition>
+      partition_tree_;  //< Function partition tree.
+};
+
+/// An extension for ignition::math::Splines that reparameterizes
+/// them by path length.
+class ArcLengthParameterizedSpline {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ArcLengthParameterizedSpline)
+
+  /// Constructor that takes a spline and an error bound
+  /// for path length parameterization approximations.
+  /// @param[in] spline the spline to be parameterized by path length.
+  /// @param[in] error_boundary a positive constraint on the
+  /// maximum error allowed when approximating the path length
+  /// parameterization.
+  /// @throws when @p spline is nullptr.
+  /// @throws when @p error_boundary is not a positive number.
+  explicit ArcLengthParameterizedSpline(
+      std::unique_ptr<ignition::math::Spline> spline, double error_boundary);
+
+  /// Interpolates @f$ Q(s) @f$, that is, the spline parameterized
+  /// by path length.
+  /// @param[in] derivative_order a non-negative integer describing
+  /// the order of the function derivative to interpolate. Since cubic
+  /// interpolation is done, any derivative order greater than 3 will be zero.
+  /// @param[in] s path length to interpolate at, constrained
+  /// by the curve dimensions [0, path_length].
+  /// @return the @p derivative_order derivative @f$ Q^{(derivative_order)}(s) .
+  /// @throws if @p derivative_order is a negative integer.
+  ignition::math::Vector3d InterpolateMthDerivative(int derivative_order,
+                                                    double s);
+
+  /// @return a mutable pointer to the underlying spline.
+  inline ignition::math::Spline* BaseSpline() { return this->q_t_.get(); }
+
+  /// Finds the closest point on the spline to a point in space.
+  ///
+  /// It will iterate over the range of s of the spline which is 0 to 1 in terms
+  /// of ignition::math::Spline's parameter at constant path length @p step
+  /// increments. On each iteration we get the distance and save the path
+  /// length coordinate that gives the minimum distance.
+  ///
+  /// @param point the point in space from which we want to get the s path
+  /// length value whose image of the direct function (the spline) within 0 and
+  /// the total length of the direct function.
+  /// @param step the path length increment to iterate over the complete spline
+  /// path length.
+  /// @return the path length value that applied to the
+  /// ignition::math::Spline, which was provided at construction time, has a
+  /// minimum distance to @p point.
+  double FindClosestPointTo(const ignition::math::Vector3d& point,
+                            double step) const;
+
+ private:
+  std::unique_ptr<ignition::math::Spline> q_t_;  //< Parameterized curve Q(t).
+  std::unique_ptr<InverseFunctionInterpolator>
+      F_ts_;  //< Inverse path length function t(s).
+};
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/test/CMakeLists.txt
+++ b/drake/automotive/maliput/rndf/test/CMakeLists.txt
@@ -13,6 +13,14 @@ if(ignition-rndf0_FOUND)
         drakeMaliputRndf
         "${IGNITION-RNDF_LIBRARIES}")
 
+    drake_add_cc_test(spline_helpers_test)
+    target_include_directories(spline_helpers_test PRIVATE
+        "${IGNITION-RNDF_INCLUDE_DIRS}"
+    )
+    target_link_libraries(spline_helpers_test
+        drakeMaliputRndf
+        "${IGNITION-RNDF_LIBRARIES}")
+
     drake_add_cc_test(road_geometry_test)
     target_include_directories(road_geometry_test PRIVATE
         "${IGNITION-RNDF_INCLUDE_DIRS}"

--- a/drake/automotive/maliput/rndf/test/spline_helpers_test.cc
+++ b/drake/automotive/maliput/rndf/test/spline_helpers_test.cc
@@ -1,0 +1,178 @@
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "ignition/math/Spline.hh"
+#include "ignition/math/Vector3.hh"
+
+#include "drake/automotive/maliput/rndf/spline_helpers.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+// We use this tolerance to match the interpolated positions given by the path
+// length interpolator wrappers.
+const double kLinearTolerance = 1e-4;
+// We use this step to sample the spline at this rate, to get the closest path
+// length coordinate to a point in space.
+const double kLinearStep = 1e-2;
+
+#define EXPECT_IGN_VECTOR_NEAR(actual_arg, expected_arg, tolerance_arg) \
+  do {                                                                  \
+    const ignition::math::Vector3d actual(actual_arg);                  \
+    const ignition::math::Vector3d expected(expected_arg);              \
+    const double tolerance(tolerance_arg);                              \
+    EXPECT_NEAR(actual.X(), expected.X(), tolerance);                   \
+    EXPECT_NEAR(actual.Y(), expected.Y(), tolerance);                   \
+    EXPECT_NEAR(actual.Z(), expected.Z(), tolerance);                   \
+  } while (0)
+
+// This is a wrapper to easily create an ignition::math::Spline.
+// @param points a tuple consisting of two ignition::math::Vector3d. The
+// first one is the position of the point and the second one is the tangent
+// vector or the spline first derivative at that point.
+// @return a pointer to an ignition::math::Spline object.
+std::unique_ptr<ignition::math::Spline> CreateSpline(
+    const std::vector<std::tuple<ignition::math::Vector3d,
+                                 ignition::math::Vector3d>>& points) {
+  auto spline = std::make_unique<ignition::math::Spline>();
+  spline->Tension(1.0);
+  spline->AutoCalculate(true);
+  for (const auto& point : points) {
+    spline->AddPoint(std::get<0>(point), std::get<1>(point));
+  }
+  return spline;
+}
+
+// Tests the InverseFunctionInterpolator exceptions.
+GTEST_TEST(RNDFSplineHelperTest, ExceptionsInInverseFunctionInterpolator) {
+  // Error boundary set to negative.
+  EXPECT_THROW(
+      InverseFunctionInterpolator([](double t) { return t; }, 0., 1., -1.),
+      std::runtime_error);
+  // xmin is equal to xmax
+  EXPECT_THROW(
+      InverseFunctionInterpolator([](double t) { return t; }, 0., 0., -1.),
+      std::runtime_error);
+  // xmin is greater than xmax
+  EXPECT_THROW(
+      InverseFunctionInterpolator([](double t) { return t; }, 1., 0., -1.),
+      std::runtime_error);
+
+  InverseFunctionInterpolator function_interpolator([](double t) { return t; },
+                                                    0., 1., kLinearTolerance);
+  // Derivative number set to negative.
+  EXPECT_THROW(function_interpolator.InterpolateMthDerivative(-1, 0.),
+               std::runtime_error);
+  // Minimum bound out of range.
+  EXPECT_THROW(function_interpolator.InterpolateMthDerivative(0, -1.),
+               std::runtime_error);
+  // Maximum bound out of range.
+  EXPECT_THROW(function_interpolator.InterpolateMthDerivative(0, 2.),
+               std::runtime_error);
+}
+
+// Tests the ArcLengthParameterizedSpline exceptions.
+GTEST_TEST(RNDFSplineHelperTest, ExceptionsInArcLengthParameterizedSpline) {
+  std::unique_ptr<ignition::math::Spline> spline;
+  // Spline pointer set to nullptr
+  EXPECT_THROW(
+      ArcLengthParameterizedSpline(std::move(spline), kLinearTolerance),
+      std::runtime_error);
+}
+
+// Checks the spline interpolator class and compares its resolution against
+// a straight line lane.
+GTEST_TEST(RNDFSplineHelperTest, StraightLine) {
+  const ignition::math::Vector3d kTangent(20., 0., 0.);
+  const ignition::math::Vector3d kFirstDerivativeInterpolation(1, 0., 0.);
+  const ignition::math::Vector3d kSecondDerivativeInterpolation(0., 0., 0.);
+  const ignition::math::Vector3d kStartPoint(0., 0.0, 0.0);
+  const ignition::math::Vector3d kEndPoint(20., 0.0, 0.0);
+
+  std::vector<std::tuple<ignition::math::Vector3d, ignition::math::Vector3d>>
+      control_points;
+  control_points.push_back(std::make_tuple(kStartPoint, kTangent));
+  control_points.push_back(std::make_tuple(kEndPoint, kTangent));
+
+  std::unique_ptr<ignition::math::Spline> spline = CreateSpline(control_points);
+  auto arc_length_param_spline = std::make_unique<ArcLengthParameterizedSpline>(
+      std::move(spline), kLinearTolerance);
+
+  const double length = arc_length_param_spline->BaseSpline()->ArcLength();
+  ignition::math::Vector3d p(kStartPoint);
+  for (double l = 0.0; l < length; l += (length / 10.)) {
+    p.X() = l;
+    EXPECT_IGN_VECTOR_NEAR(
+        arc_length_param_spline->InterpolateMthDerivative(0, l), p,
+        kLinearTolerance);
+    EXPECT_IGN_VECTOR_NEAR(
+        arc_length_param_spline->InterpolateMthDerivative(1, l),
+        kFirstDerivativeInterpolation, kLinearTolerance);
+    EXPECT_IGN_VECTOR_NEAR(
+        arc_length_param_spline->InterpolateMthDerivative(2, l),
+        kSecondDerivativeInterpolation, kLinearTolerance);
+  }
+  EXPECT_IGN_VECTOR_NEAR(
+      arc_length_param_spline->InterpolateMthDerivative(0, length), kEndPoint,
+      kLinearTolerance);
+  EXPECT_IGN_VECTOR_NEAR(
+      arc_length_param_spline->InterpolateMthDerivative(1, length),
+      kFirstDerivativeInterpolation, kLinearTolerance);
+  EXPECT_IGN_VECTOR_NEAR(
+      arc_length_param_spline->InterpolateMthDerivative(2, length),
+      kSecondDerivativeInterpolation, kLinearTolerance);
+}
+
+// Tests a set of points and the result of the path length distance that returns
+// a Spline interpolated point closest to it.
+GTEST_TEST(RNDFSplineHelperTest, StraightSplineFindClosesPointTo) {
+  std::vector<std::tuple<ignition::math::Vector3d, ignition::math::Vector3d>>
+      control_points;
+  control_points.push_back(
+      std::make_tuple(ignition::math::Vector3d(0.0, 0.0, 0.0),
+                      ignition::math::Vector3d(10.0, 0.0, 0.0)));
+  control_points.push_back(
+      std::make_tuple(ignition::math::Vector3d(20.0, 0.0, 0.0),
+                      ignition::math::Vector3d(10.0, 0.0, 0.0)));
+
+  std::unique_ptr<ignition::math::Spline> spline = CreateSpline(control_points);
+  auto arc_length_param_spline = std::make_unique<ArcLengthParameterizedSpline>(
+      std::move(spline), kLinearTolerance);
+  // Border checks
+  EXPECT_NEAR(arc_length_param_spline->FindClosestPointTo(
+                  ignition::math::Vector3d(0.0, 5.0, 0.0), kLinearStep),
+              0., kLinearTolerance);
+  EXPECT_NEAR(arc_length_param_spline->FindClosestPointTo(
+                  ignition::math::Vector3d(0.0, -5.0, 0.0), kLinearStep),
+              0., kLinearTolerance);
+  EXPECT_NEAR(arc_length_param_spline->FindClosestPointTo(
+                  ignition::math::Vector3d(20.0, 5.0, 0.0), kLinearStep),
+              20., kLinearTolerance);
+  EXPECT_NEAR(arc_length_param_spline->FindClosestPointTo(
+                  ignition::math::Vector3d(20.0, -5.0, 0.0), kLinearStep),
+              20., kLinearTolerance);
+  // Middle checks
+  EXPECT_NEAR(arc_length_param_spline->FindClosestPointTo(
+                  ignition::math::Vector3d(10.0, 5.0, 0.0), kLinearStep),
+              10., kLinearTolerance);
+  EXPECT_NEAR(arc_length_param_spline->FindClosestPointTo(
+                  ignition::math::Vector3d(10.0, -5.0, 0.0), kLinearStep),
+              10., kLinearTolerance);
+  // Before and after checks
+  EXPECT_NEAR(arc_length_param_spline->FindClosestPointTo(
+                  ignition::math::Vector3d(-5, -5.0, 0.0), kLinearStep),
+              0., kLinearTolerance);
+  EXPECT_NEAR(arc_length_param_spline->FindClosestPointTo(
+                  ignition::math::Vector3d(25, 5.0, 0.0), kLinearStep),
+              20., kLinearTolerance);
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
This PR provides two classes that are used to provide an inverse arc length interpolator. This classes will be used internally by the `drake::maliput::rndf::SplineLane` implementation to provide a mapping between the `ignition::math::Spline` parameter and the _s_ arc length coordinate in terms of the _Lane_ frame.

A future PR will provide the implementation of the SplineLane that uses these classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6256)
<!-- Reviewable:end -->
