### PR TITLE
Allow packages to reference dependencies

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -62,6 +62,12 @@ py_binary(
     srcs = ["drakelint.py"],
 )
 
+py_library(
+    name = "cpsutils",
+    srcs = ["cpsutils.py"],
+    deps = ["@pycps//:cps"]
+)
+
 exports_files(
     ["install.py.in"],
     visibility = ["//visibility:public"],

--- a/tools/cpsutils.py
+++ b/tools/cpsutils.py
@@ -1,0 +1,47 @@
+import cps
+import re
+import sys
+
+# n.b. sys.argv[0] is the program name
+version_file = sys.argv[1]
+dependency_cps_files = sys.argv[2:]
+
+
+def read_defs(pattern, groups=(1, 2)):
+    defs = {}
+    pattern = re.compile(pattern)
+
+    with open(version_file) as f:
+        for line in f:
+            match = pattern.match(line)
+            if match is not None:
+                defs[match.group(groups[0])] = match.group(groups[1])
+
+    return defs
+
+
+def read_version_defs(pattern):
+    pattern = re.compile(pattern)
+
+    with open(version_file) as f:
+        for line in f:
+            match = pattern.match(line)
+            if match is not None:
+                defs = {}
+                defs['VERSION_MAJOR'] = match.group(1)
+                defs['VERSION_MINOR'] = match.group(2)
+                defs['VERSION_PATCH'] = match.group(3)
+                return defs
+
+    return {}
+
+
+def read_requires():
+    defs = {}
+
+    for p in dependency_cps_files:
+        package = cps.read(p)
+        if package.version is not None:
+            defs["%s_VERSION" % package.name] = package.version
+
+    return defs

--- a/tools/eigen-create-cps.py
+++ b/tools/eigen-create-cps.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python
 
-import re
-import sys
+from cpsutils import read_defs
 
-def_re = re.compile("#define\s+EIGEN_(\w+_VERSION)\s+([0-9]+)")
-
-defs = {}
-with open(sys.argv[1]) as h:
-    for l in h:
-        m = def_re.match(l)
-        if m is not None:
-            defs[m.group(1)] = m.group(2)
+defs = read_defs("#define\s+EIGEN_(\w+_VERSION)\s+([0-9]+)")
 
 content = """
 {

--- a/tools/fmt-create-cps.py
+++ b/tools/fmt-create-cps.py
@@ -1,17 +1,8 @@
 #!/usr/bin/env python
 
-import re
-import sys
+from cpsutils import read_version_defs
 
-def_re = re.compile("set\(FMT_VERSION\s([0-9]+).([0-9]+).([0-9]+)")
-defs = {}
-with open(sys.argv[1]) as h:
-    for l in h:
-        m = def_re.match(l)
-        if m is not None:
-            defs['VERSION_MAJOR'] = m.group(1)
-            defs['VERSION_MINOR'] = m.group(2)
-            defs['VERSION_PATCH'] = m.group(3)
+defs = read_version_defs("set\(FMT_VERSION\s([0-9]+).([0-9]+).([0-9]+)")
 
 content = """
 {

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -440,7 +440,7 @@ def exports_create_cps_scripts(packages):
         )
 
 #------------------------------------------------------------------------------
-def cmake_config(package, script, version_file):
+def cmake_config(package, script, version_file, deps = []):
     """Create CMake package configuration and package version files via an
     intermediate CPS file.
 
@@ -455,17 +455,18 @@ def cmake_config(package, script, version_file):
         srcs = [script],
         main = script,
         visibility = ["//visibility:private"],
+        deps = ["@drake//tools:cpsutils"],
     )
 
     cps_file_name = "{}.cps".format(package)
 
     native.genrule(
         name = "cps",
-        srcs = [version_file],
+        srcs = [version_file] + deps,
         outs = [cps_file_name],
-        cmd = "$(location :create-cps) \"$<\" > \"$@\"",
+        cmd = "$(location :create-cps) $(SRCS) > \"$@\"",
         tools = [":create-cps"],
-        visibility = ["//visibility:private"],
+        visibility = ["//visibility:public"],
     )
 
     config_file_name = "{}Config.cmake".format(package)

--- a/tools/ipopt-create-cps.py
+++ b/tools/ipopt-create-cps.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python
 
-import re
-import sys
+from cpsutils import read_defs
 
-def_re = re.compile("#define IPOPT_(VERSION[^\s]+)\s+([^\s]+)")
-
-defs = {}
-with open(sys.argv[1]) as h:
-    for l in h:
-        m = def_re.match(l)
-        if m is not None:
-            defs[m.group(1)] = m.group(2)
+defs = read_defs("#define IPOPT_(VERSION[^\s]+)\s+([^\s]+)")
 
 content = """
 {

--- a/tools/lcm-create-cps.py
+++ b/tools/lcm-create-cps.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python
 
-import re
-import sys
+from cpsutils import read_defs
 
-def_re = re.compile("#define LCM_(VERSION[^\s]+)\s+([^\s]+)")
-
-defs = {}
-with open(sys.argv[1]) as h:
-    for l in h:
-        m = def_re.match(l)
-        if m is not None:
-            defs[m.group(1)] = m.group(2)
+defs = read_defs("#define LCM_(VERSION[^\s]+)\s+([^\s]+)")
 
 content = """
 {

--- a/tools/nlopt-create-cps.py
+++ b/tools/nlopt-create-cps.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python
 
-import re
-import sys
+from cpsutils import read_defs
 
-def_re = re.compile("#define ([^\s]+_VERSION)\s+([^\s]+)")
-
-defs = {}
-with open(sys.argv[1]) as h:
-    for l in h:
-        m = def_re.match(l)
-        if m is not None:
-            defs[m.group(1)] = m.group(2)
+defs = read_defs("#define ([^\s]+_VERSION)\s+([^\s]+)")
 
 content = """
 {

--- a/tools/pybind11-create-cps.py
+++ b/tools/pybind11-create-cps.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python
 
-import re
-import sys
+from cpsutils import read_defs
 
-def_re = re.compile("#define PYBIND11_(VERSION[^\s]+)\s+([^\s]+)")
-
-defs = {}
-with open(sys.argv[1]) as h:
-    for l in h:
-        m = def_re.match(l)
-        if m is not None:
-            defs[m.group(1)] = m.group(2)
+defs = read_defs("#define PYBIND11_(VERSION[^\s]+)\s+([^\s]+)")
 
 content = """
 {

--- a/tools/pycps.BUILD
+++ b/tools/pycps.BUILD
@@ -7,10 +7,11 @@ genrule(
     cmd = "cp \"$<\" \"$(@)\"",
 )
 
+# LGPL; don't use externally (okay for build-time stuff only)
 py_library(
     name = "cps",
     srcs = ["cps.py"],
-    visibility = ["//visibility:private"],  # LGPL; don't use externally
+    visibility = ["//visibility:public"],
     deps = ["@semantic_version"],
 )
 

--- a/tools/spdlog-create-cps.py
+++ b/tools/spdlog-create-cps.py
@@ -1,17 +1,11 @@
 #!/usr/bin/env python
 
-import re
-import sys
+from cpsutils import read_version_defs, read_requires
 
-def_re = re.compile("project\(spdlog\sVERSION\s([0-9]+).([0-9]+).([0-9]+)")
-defs = {}
-with open(sys.argv[1]) as h:
-    for l in h:
-        m = def_re.match(l)
-        if m is not None:
-            defs['VERSION_MAJOR'] = m.group(1)
-            defs['VERSION_MINOR'] = m.group(2)
-            defs['VERSION_PATCH'] = m.group(3)
+def_re = "project\(spdlog\sVERSION\s([0-9]+).([0-9]+).([0-9]+)"
+defs = read_version_defs(def_re)
+
+defs.update(read_requires())
 
 content = """
 {
@@ -22,7 +16,7 @@ content = """
   "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
   "Requires": {
     "fmt": {
-      "Version": "3.0.1",
+      "Version": "%(fmt_VERSION)s",
       "Hints": ["@prefix@/lib/cmake/fmt"],
       "X-CMake-Find-Args": [ "CONFIG" ]
     }

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -26,6 +26,7 @@ cmake_config(
     package = "spdlog",
     script = "@drake//tools:spdlog-create-cps.py",
     version_file = "CMakeLists.txt",
+    deps = ["@fmt//:cps"]
 )
 
 install_cmake_config(package = "spdlog")  # Creates rule :install_cmake_config.


### PR DESCRIPTION
Add a file with common utilities for creating CPS's. Add ability for CPS creation to depend on other CPS's. Add mechanisms to inject the version information from another CPS into a CPS being created.

This allows a CPS to embed the exact version information of its dependencies in a sane manner. For now, only spdlog does this. (Drake proper will need to be updated eventually, but that can wait.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6261)
<!-- Reviewable:end -->
