### PR TITLE
Refactor symbolic::Monomial class

### DIFF
--- a/drake/common/monomial.cc
+++ b/drake/common/monomial.cc
@@ -28,167 +28,49 @@ using std::runtime_error;
 using std::shared_ptr;
 using std::unordered_map;
 
-Monomial::Monomial() : total_degree_{0} {}
-
-Monomial::Monomial(const Variable& var, const int exponent)
-    : total_degree_{exponent} {
-  DRAKE_DEMAND(exponent >= 0);
-  if (exponent > 0) {
-    powers_.emplace(var.get_id(), exponent);
-  }
-}
-
-Monomial::Monomial(const map<Variable::Id, int>& powers)
-    : total_degree_{TotalDegree(powers)} {
-  for (const auto& p : powers) {
-    if (p.second > 0) {
-      powers_.insert(p);
-    } else if (p.second < 0) {
-      throw std::runtime_error("The exponent is negative.");
-    }
-  }
-}
-
-// Forward declaration.
-map<Variable::Id, int> ToMonomialPower(const Expression& e);
-
-Monomial::Monomial(const Expression& e)
-    : Monomial(ToMonomialPower(e.Expand())) {}
-
-size_t Monomial::GetHash() const {
-  // To get a hash value for a Monomial, we re-use the hash value for
-  // powers_. This is suitable because powers_ is the only independent
-  // data-member of Monomial class while another data-member, total_degree_ is
-  // determined by a given powers_.
-  return hash_value<map<Variable::Id, int>>{}(powers_);
-}
-
-bool Monomial::operator==(const Monomial& m) const {
-  return powers_ == m.powers_;
-}
-
-double Monomial::Evaluate(
-    const unordered_map<Variable::Id, double>& env) const {
-  return accumulate(
-      powers_.begin(), powers_.end(), 1.0,
-      [this, &env](const double v, const pair<Variable::Id, int>& p) {
-        const Variable::Id& var_id{p.first};
-        const auto it = env.find(var_id);
-        if (it == env.end()) {
-          ostringstream oss;
-          oss << "Monomial " << *this
-              << " cannot be evaluated with the given "
-                 "environment which does not provide an entry "
-                 "for variable ID = "
-              << var_id << ".";
-          throw out_of_range(oss.str());
-        } else {
-          const double base{it->second};
-          const int exponent{p.second};
-          return v * std::pow(base, exponent);
-        }
-      });
-}
-
-pair<double, Monomial> Monomial::Substitute(
-    const unordered_map<Variable::Id, double>& env) const {
-  double coeff{1.0};
-  map<Variable::Id, int> new_powers;
-  for (const auto& p : powers_) {
-    const Variable::Id& var_id{p.first};
-    const int exponent{p.second};
-    const auto it = env.find(var_id);
-    if (it != env.end()) {
-      const double base{it->second};
-      coeff *= std::pow(base, exponent);
-    } else {
-      new_powers.insert(p);
-    }
-  }
-  return make_pair(coeff, Monomial(new_powers));
-}
-
-Expression Monomial::ToExpression(
-    const unordered_map<Variable::Id, Variable>& id_to_var_map) const {
-  // It builds this base_to_exponent_map and uses ExpressionMulFactory to build
-  // a multiplication expression.
-  map<Expression, Expression> base_to_exponent_map;
-  for (const auto& p : powers_) {
-    const Variable::Id id{p.first};
-    const int exponent{p.second};
-    const auto it = id_to_var_map.find(id);
-    if (it != id_to_var_map.end()) {
-      const Variable& var{it->second};
-      base_to_exponent_map.emplace(Expression{var}, exponent);
-    } else {
-      ostringstream oss;
-      oss << "Variable whose ID is " << id << " appeared in a monomial "
-          << *this << "." << std::endl
-          << "However, Monomial::ToExpression method "
-             "fails to find the corresponding Variable in a given map.";
-      throw runtime_error(oss.str());
-    }
-  }
-  return ExpressionMulFactory{1.0, base_to_exponent_map}.GetExpression();
-}
-
-int Monomial::TotalDegree(const map<Variable::Id, int>& powers) {
+namespace {
+// Computes the total degree of a monomial. This method is used in a
+// constructor of Monomial to set its total degree at construction.
+int TotalDegree(const map<Variable, int>& powers) {
   return accumulate(powers.begin(), powers.end(), 0,
-                    [](const int degree, const pair<Variable::Id, int>& p) {
+                    [](const int degree, const pair<Variable, int>& p) {
                       return degree + p.second;
                     });
 }
 
-std::ostream& operator<<(std::ostream& out, const Monomial& m) {
-  out << "{";
-  for (const auto& power : m.powers_) {
-    out << "(" << power.first << ", " << power.second << ") ";
-  }
-  return out << "}";
-}
-
-Monomial operator*(const Monomial& m1, const Monomial& m2) {
-  map<Variable::Id, int> powers{m1.get_powers()};
-  for (const auto& p : m2.get_powers()) {
-    const Variable::Id var{p.first};
-    const int exponent{p.second};
-    auto it = powers.find(var);
-    if (it == powers.end()) {
-      powers.insert(p);
-    } else {
-      it->second += exponent;
-    }
-  }
-  return Monomial{powers};
-}
-
-map<Variable::Id, int> ToMonomialPower(const Expression& e) {
+// Converts a symbolic expression @p e into an internal representation of
+// Monomial class, a mapping from a base (Variable) to its exponent (int). This
+// function is called inside of the constructor Monomial(const
+// symbolic::Expression&).
+map<Variable, int> ToMonomialPower(const Expression& e) {
+  // TODO(soonho): Re-implement this function by using a Polynomial visitor.
   DRAKE_DEMAND(e.is_polynomial());
-  map<Variable::Id, int> powers;
+  map<Variable, int> powers;
   if (is_one(e)) {  // This block is deliberately left empty.
   } else if (is_constant(e)) {
-    throw runtime_error(
-        "A constant not equal to to 1, this is not a monomial.");
+    throw runtime_error("A constant not equal to 1, this is not a monomial.");
   } else if (is_variable(e)) {
-    powers.emplace(get_variable(e).get_id(), 1);
+    powers.emplace(get_variable(e), 1);
   } else if (is_pow(e)) {
-    const auto& exponent = get_second_argument(e);
-    if (!is_constant(exponent)) {
-      throw runtime_error("The exponent is not a constant.");
-    }
-    auto exponent_val = get_constant_value(exponent);
-    powers = ToMonomialPower(get_first_argument(e));
-    // pow( pow(xᵢ, kᵢ), n) = pow(xᵢ, kᵢ * n)
+    const Expression& base{get_first_argument(e)};
+    const Expression& exponent{get_second_argument(e)};
+    // The following holds because `e` is polynomial.
+    DRAKE_DEMAND(is_constant(exponent));
+    // The following static_cast (double -> int) does not lose information
+    // because of the precondition `e.is_polynomial()`.
+    const int n{static_cast<int>(get_constant_value(exponent))};
+    powers = ToMonomialPower(base);
+    // pow(base, n) => (∏ᵢ xᵢ)^ⁿ => ∏ᵢ (xᵢ^ⁿ)
     for (auto& p : powers) {
-      p.second *= exponent_val;
+      p.second *= n;
     }
   } else if (is_multiplication(e)) {
     if (!is_one(get_constant_in_multiplication(e))) {
       throw runtime_error("The constant in the multiplication is not 1.");
     }
+    // e = ∏ᵢ pow(baseᵢ, exponentᵢ).
     for (const auto& p : get_base_to_exponent_map_in_multiplication(e)) {
-      map<Variable::Id, int> p_powers = ToMonomialPower(pow(p.first, p.second));
-      for (const auto& q : p_powers) {
+      for (const auto& q : ToMonomialPower(pow(p.first, p.second))) {
         auto it = powers.find(q.first);
         if (it == powers.end()) {
           powers.emplace(q.first, q.second);
@@ -202,6 +84,174 @@ map<Variable::Id, int> ToMonomialPower(const Expression& e) {
   }
   return powers;
 }
+}  // namespace
+
+Monomial::Monomial(const Variable& var, const int exponent)
+    : total_degree_{exponent} {
+  DRAKE_DEMAND(exponent >= 0);
+  if (exponent > 0) {
+    powers_.emplace(var, exponent);
+  }
+}
+
+Monomial::Monomial(const map<Variable, int>& powers)
+    : total_degree_{TotalDegree(powers)} {
+  for (const auto& p : powers) {
+    const int exponent{p.second};
+    if (exponent > 0) {
+      powers_.insert(p);
+    } else if (exponent < 0) {
+      throw std::runtime_error("The exponent is negative.");
+    }
+    // Ignore the entry if exponent == 0.
+  }
+}
+
+Monomial::Monomial(const Expression& e)
+    : Monomial(ToMonomialPower(e.Expand())) {}
+
+size_t Monomial::GetHash() const {
+  // To get a hash value for a Monomial, we re-use the hash value for
+  // powers_. This is suitable because powers_ is the only independent
+  // data-member of Monomial class while another data-member, total_degree_ is
+  // determined by a given powers_.
+  return hash_value<map<Variable, int>>{}(powers_);
+}
+
+bool Monomial::operator==(const Monomial& m) const {
+  // TODO(soonho-tri): simplify this function to `return powers_ == m.powers_`.
+  //
+  // For now, the above one-liner doesn't work. std::map<Variable,
+  // int>::operator== uses Variable::operator== to compare two keys (two
+  // Variables) instead of std::equal_to<Variable>. The consequence is that we
+  // end up with var_1 == var_2, which turns to a symbolic::Formula and calls
+  // symbolic::Formula::Evaluate with an empty
+  // environment. symbolic::Formula::Evaluate function will throw a
+  // runtime_error because it cannot find an entry for `var_1` (nor `var_2`) in
+  // an empty environment.
+  //
+  // I think the right approach is to refactor symbolic::Formula::Evaluate to
+  // use structural equality when it handles equality (==) and inequality (!=)
+  // after partially evaluating/substituting with a given environment. When this
+  // fix is landed, I'll simplify this function.
+  if (powers_.size() != m.powers_.size()) {
+    return false;
+  }
+  for (const pair<Variable, int> p : powers_) {
+    const Variable& var{p.first};
+    const int exponent{p.second};
+    const auto it = m.powers_.find(var);
+    if (it == m.powers_.end()) {
+      // Key var is not found in m.powers.
+      return false;
+    }
+    if (exponent != it->second) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Monomial::operator!=(const Monomial& m) const { return !(*this == m); }
+
+double Monomial::Evaluate(const Environment& env) const {
+  return accumulate(powers_.begin(), powers_.end(), 1.0,
+                    [this, &env](const double v, const pair<Variable, int>& p) {
+                      const Variable& var{p.first};
+                      const auto it = env.find(var);
+                      if (it == env.end()) {
+                        ostringstream oss;
+                        oss << "Monomial " << *this
+                            << " cannot be evaluated with the given "
+                               "environment which does not provide an entry "
+                               "for variable = "
+                            << var << ".";
+                        throw out_of_range(oss.str());
+                      } else {
+                        const double base{it->second};
+                        const int exponent{p.second};
+                        return v * std::pow(base, exponent);
+                      }
+                    });
+}
+
+pair<double, Monomial> Monomial::Substitute(const Environment& env) const {
+  double coeff{1.0};
+  map<Variable, int> new_powers;
+  for (const auto& p : powers_) {
+    const Variable& var{p.first};
+    const int exponent{p.second};
+    auto it = env.find(var);
+    if (it != env.end()) {
+      double base{it->second};
+      coeff *= std::pow(base, exponent);
+    } else {
+      new_powers.insert(p);
+    }
+  }
+  return make_pair(coeff, Monomial(new_powers));
+}
+
+Expression Monomial::ToExpression() const {
+  // It builds this base_to_exponent_map and uses ExpressionMulFactory to build
+  // a multiplication expression.
+  map<Expression, Expression> base_to_exponent_map;
+  for (const auto& p : powers_) {
+    const Variable& var{p.first};
+    const int exponent{p.second};
+    base_to_exponent_map.emplace(Expression{var}, exponent);
+  }
+  return ExpressionMulFactory{1.0, base_to_exponent_map}.GetExpression();
+}
+
+Monomial& Monomial::operator*=(const Monomial& m) {
+  for (const auto& p : m.get_powers()) {
+    const Variable& var{p.first};
+    const int exponent{p.second};
+    auto it = powers_.find(var);
+    if (it == powers_.end()) {
+      powers_.insert(p);
+    } else {
+      it->second += exponent;
+    }
+    total_degree_ += exponent;
+  }
+  return *this;
+}
+
+Monomial& Monomial::pow_in_place(const int p) {
+  if (p < 0) {
+    ostringstream oss;
+    oss << "Monomial::pow(int p) is called with a negative p = " << p;
+    throw runtime_error(oss.str());
+  }
+  if (p == 0) {
+    total_degree_ = 0;
+    powers_.clear();
+  } else if (p > 1) {
+    for (auto& item : powers_) {
+      int& exponent{item.second};
+      exponent *= p;
+      total_degree_ += (exponent * (p - 1));
+    }
+  }  // If p == 1, NO OP.
+  return *this;
+}
+
+std::ostream& operator<<(std::ostream& out, const Monomial& m) {
+  out << "{";
+  for (const auto& power : m.powers_) {
+    out << "(" << power.first << ", " << power.second << ") ";
+  }
+  return out << "}";
+}
+
+Monomial operator*(Monomial m1, const Monomial& m2) {
+  m1 *= m2;
+  return m1;
+}
+
+Monomial pow(Monomial m, const int p) { return m.pow_in_place(p); }
 
 /**
  * Adds a term to the polynomial.
@@ -320,8 +370,8 @@ class DecomposePolynomialVisitor {
     // (c₀ + c₁ * pow(x, k₁) + ... + cₙ * pow(x, kₙ))
     // and the last term pow(eₖ, pₖ) as another polynomial
     // (d₀ + d₁ * pow(x, k₁) + ... + dₘ * pow(x, kₘ))
-    // And then multiply the term cᵢ * pow(x, kᵢ) with the term dⱼ * pow(x, kⱼ)
-    // to get each monomial in the product.
+    // And then multiply the term cᵢ * pow(x, kᵢ) with the term dⱼ * pow(x,
+    // kⱼ) to get each monomial in the product.
     // TODO(hongkai.dai):
     // Alternatively, we can do divide and conquer here.
     // for an expression e = pow(e₁, p₁) * pow(e₂, p₂) * ... * pow(eₖ, pₖ)
@@ -421,7 +471,7 @@ class DecomposePolynomialVisitor {
       // For each monomial in the dividend, compute the division from the
       // dividend monomial by the divisor monomial.
       const Monomial dividend_monomial(p1.first);
-      std::map<Variable::Id, int> division_monomial_powers =
+      std::map<Variable, int> division_monomial_powers =
           dividend_monomial.get_powers();
       for (const auto& p_divisor : divisor_monomial_powers) {
         // The variable in divisor has to appear in the dividend.
@@ -435,7 +485,6 @@ class DecomposePolynomialVisitor {
         }
       }
       Monomial division_monomial(division_monomial_powers);
-
       map.emplace(division_monomial, p1.second / divisor_coeff);
     }
     return map;
@@ -465,8 +514,8 @@ MonomialToCoefficientMap DecomposePolynomialIntoMonomial(
         }
       }
     } else {
-      // If the coefficient is a constant, then it cannot be zero, since we have
-      // deleted term with zero constant coefficient already.
+      // If the coefficient is a constant, then it cannot be zero, since we
+      // have deleted term with zero constant coefficient already.
       DRAKE_ASSERT(!is_zero(it->second));
     }
     if (is_zero_term) {
@@ -555,15 +604,10 @@ Eigen::Matrix<Expression, Eigen::Dynamic, 1> MonomialBasis(
 MonomialAsExpressionToCoefficientMap DecomposePolynomialIntoExpression(
     const Expression& e, const Variables& vars) {
   const auto& map_internal = DecomposePolynomialIntoMonomial(e, vars);
-  std::unordered_map<Variable::Id, Variable> map_id_to_var;
-  map_id_to_var.reserve(vars.size());
-  for (const auto& v : vars) {
-    map_id_to_var.emplace(v.get_id(), v);
-  }
   MonomialAsExpressionToCoefficientMap map;
   map.reserve(map_internal.size());
   for (const auto& p : map_internal) {
-    map.emplace(p.first.ToExpression(map_id_to_var), p.second);
+    map.emplace(p.first.ToExpression(), p.second);
   }
   return map;
 }

--- a/drake/common/test/monomial_test.cc
+++ b/drake/common/test/monomial_test.cc
@@ -18,6 +18,7 @@ using std::out_of_range;
 using std::pair;
 using std::unordered_map;
 using std::vector;
+using std::runtime_error;
 
 namespace drake {
 namespace symbolic {
@@ -37,54 +38,27 @@ class MonomialTest : public ::testing::Test {
   const Expression z_{var_z_};
   const Expression y_{var_y_};
   const Expression x_{var_x_};
+
   vector<Monomial> monomials_;
 
   void SetUp() override {
     monomials_ = {
-        Monomial{},                                              // 1.0
-        Monomial{var_x_, 1},                                     // x^1
-        Monomial{var_y_, 1},                                     // y^1
-        Monomial{var_z_, 1},                                     // z^1
-        Monomial{var_x_, 2},                                     // x^2
-        Monomial{var_y_, 3},                                     // y^3
-        Monomial{var_z_, 4},                                     // z^4
-        Monomial{{{var_x_.get_id(), 1}, {var_y_.get_id(), 2}}},  // xy^2
-        Monomial{{{var_y_.get_id(), 2}, {var_z_.get_id(), 5}}},  // y^2z^5
-        Monomial{{{var_x_.get_id(), 1},
-                  {var_y_.get_id(), 2},
-                  {var_z_.get_id(), 3}}},  // xy^2z^3
-        Monomial{{{var_x_.get_id(), 2},
-                  {var_y_.get_id(), 4},
-                  {var_z_.get_id(), 3}}},  // x^2y^4z^3
+        Monomial{},                                         // 1.0
+        Monomial{var_x_, 1},                                // x^1
+        Monomial{var_y_, 1},                                // y^1
+        Monomial{var_z_, 1},                                // z^1
+        Monomial{var_x_, 2},                                // x^2
+        Monomial{var_y_, 3},                                // y^3
+        Monomial{var_z_, 4},                                // z^4
+        Monomial{{{var_x_, 1}, {var_y_, 2}}},               // xy^2
+        Monomial{{{var_y_, 2}, {var_z_, 5}}},               // y^2z^5
+        Monomial{{{var_x_, 1}, {var_y_, 2}, {var_z_, 3}}},  // xy^2z^3
+        Monomial{{{var_x_, 2}, {var_y_, 4}, {var_z_, 3}}},  // x^2y^4z^3
     };
 
     EXPECT_PRED2(VarLess, var_y_, var_x_);
     EXPECT_PRED2(VarLess, var_z_, var_y_);
     EXPECT_PRED2(VarLess, var_w_, var_z_);
-  }
-
-  // Helper function to extract unordered_map<Variable::Id, Variable> from a
-  // symbolic environment.
-  unordered_map<Variable::Id, Variable> ExtractIdToVarMap(
-      const Environment& env) {
-    unordered_map<Variable::Id, Variable> map;
-    map.reserve(env.size());
-    for (const pair<Variable, double>& p : env) {
-      map.emplace(p.first.get_id(), p.first);
-    }
-    return map;
-  }
-
-  // Helper function to extract unordered_map<Variable::Id, double> from a
-  // symbolic environment.
-  unordered_map<Variable::Id, double> ExtractIdToDoubleMap(
-      const Environment& env) {
-    unordered_map<Variable::Id, double> map;
-    map.reserve(env.size());
-    for (const pair<Variable, double>& p : env) {
-      map.emplace(p.first.get_id(), p.second);
-    }
-    return map;
   }
 
   // Helper function to extract Substitution (Variable -> Expression) from a
@@ -113,13 +87,8 @@ class MonomialTest : public ::testing::Test {
   // (top-to-bottom), we directly evaluate a Monomial to double (result2). The
   // two result1 and result2 should be the same.
   bool CheckEvaluate(const Monomial& m, const Environment& env) {
-    const unordered_map<Variable::Id, double> id_to_double_map{
-        ExtractIdToDoubleMap(env)};
-    const unordered_map<Variable::Id, Variable> id_to_var_map{
-        ExtractIdToVarMap(env)};
-
-    const double result1{m.ToExpression(id_to_var_map).Evaluate(env)};
-    const double result2{m.Evaluate(id_to_double_map)};
+    const double result1{m.ToExpression().Evaluate(env)};
+    const double result2{m.Evaluate(env)};
     return result1 == result2;
   }
 
@@ -140,20 +109,13 @@ class MonomialTest : public ::testing::Test {
   // and Monomial. We obtain e2 by multiplying the two. Then, we check if e1 and
   // e2 are structurally equal.
   bool CheckSubstitute(const Monomial& m, const Environment& env) {
-    const unordered_map<Variable::Id, double> id_to_double_map{
-        ExtractIdToDoubleMap(env)};
-    const unordered_map<Variable::Id, Variable> id_to_var_map{
-        {var_x_.get_id(), var_x_},
-        {var_y_.get_id(), var_y_},
-        {var_z_.get_id(), var_z_},
-    };
     const Substitution subst{ExtractSubst(env)};
 
-    const Expression e1{m.ToExpression(id_to_var_map).Substitute(subst)};
+    const Expression e1{m.ToExpression().Substitute(subst)};
 
-    const pair<double, Monomial> subst_result{m.Substitute(id_to_double_map)};
+    const pair<double, Monomial> subst_result{m.Substitute(env)};
     const Expression e2{subst_result.first *
-                        subst_result.second.ToExpression(id_to_var_map)};
+                        subst_result.second.ToExpression()};
 
     return e1.EqualTo(e2);
   }
@@ -162,8 +124,8 @@ class MonomialTest : public ::testing::Test {
 TEST_F(MonomialTest, MonomialOne) {
   // Compares monomials all equal to 1, but with different variables.
   Monomial m1{};
-  Monomial m2({{var_x_.get_id(), 0}});
-  Monomial m3({{var_x_.get_id(), 0}, {var_y_.get_id(), 0}});
+  Monomial m2({{var_x_, 0}});
+  Monomial m3({{var_x_, 0}, {var_y_, 0}});
   EXPECT_EQ(m1, m2);
   EXPECT_EQ(m1, m3);
   EXPECT_EQ(m2, m3);
@@ -171,12 +133,12 @@ TEST_F(MonomialTest, MonomialOne) {
 
 TEST_F(MonomialTest, MonomialWithZeroExponent) {
   // Compares monomials containing zero exponent, such as x^0 * y^2
-  Monomial m1({{var_y_.get_id(), 2}});
-  Monomial m2({{var_x_.get_id(), 0}, {var_y_.get_id(), 2}});
+  Monomial m1({{var_y_, 2}});
+  Monomial m2({{var_x_, 0}, {var_y_, 2}});
   EXPECT_EQ(m1, m2);
   EXPECT_EQ(m2.get_powers().size(), 1);
-  std::map<Variable::Id, int> power_expected;
-  power_expected.emplace(var_y_.get_id(), 2);
+  std::map<Variable, int> power_expected;
+  power_expected.emplace(var_y_, 2);
   EXPECT_EQ(m2.get_powers(), power_expected);
 }
 
@@ -455,9 +417,9 @@ TEST_F(MonomialTest, ToMonomial1) {
 
 // Converts expression x * y to monomial.
 TEST_F(MonomialTest, ToMonomial2) {
-  std::map<Variable::Id, int> powers;
-  powers.emplace(var_x_.get_id(), 1);
-  powers.emplace(var_y_.get_id(), 1);
+  std::map<Variable, int> powers;
+  powers.emplace(var_x_, 1);
+  powers.emplace(var_y_, 1);
   Monomial expected(powers);
   EXPECT_EQ(Monomial(x_ * y_), expected);
 }
@@ -471,9 +433,9 @@ TEST_F(MonomialTest, ToMonomial3) {
 
 // Converts expression x^3 * y to monomial.
 TEST_F(MonomialTest, ToMonomial4) {
-  std::map<Variable::Id, int> powers;
-  powers.emplace(var_x_.get_id(), 3);
-  powers.emplace(var_y_.get_id(), 1);
+  std::map<Variable, int> powers;
+  powers.emplace(var_x_, 3);
+  powers.emplace(var_y_, 1);
   Monomial expected(powers);
   EXPECT_EQ(Monomial(pow(x_, 3) * y_), expected);
   EXPECT_EQ(Monomial(pow(x_, 2) * y_ * x_), expected);
@@ -481,11 +443,106 @@ TEST_F(MonomialTest, ToMonomial4) {
 
 // Converts expression x*(y+z) - x*y to monomial
 TEST_F(MonomialTest, ToMonomial5) {
-  std::map<Variable::Id, int> powers(
-      {{var_x_.get_id(), 1}, {var_z_.get_id(), 1}});
+  std::map<Variable, int> powers({{var_x_, 1}, {var_z_, 1}});
   Monomial expected(powers);
   EXPECT_EQ(Monomial(x_ * z_), expected);
   EXPECT_EQ(Monomial(x_ * (y_ + z_) - x_ * y_), expected);
+}
+
+// `pow(x * y, 2) * pow(x^2 * y^2, 3)` is a monomial (x^8 * y^8).
+TEST_F(MonomialTest, ToMonomial6) {
+  const Monomial m1{pow(x_ * y_, 2) * pow(x_ * x_ * y_ * y_, 3)};
+  const Monomial m2{{{var_x_, 8}, {var_y_, 8}}};
+  EXPECT_EQ(m1, m2);
+}
+
+// x^0 is a monomial (1).
+TEST_F(MonomialTest, ToMonomial7) {
+  const Monomial m1(var_x_, 0);
+  const Monomial m2{Expression{1.0}};
+  const Monomial m3{pow(x_, 0.0)};
+  EXPECT_EQ(m1, m2);
+  EXPECT_EQ(m1, m3);
+  EXPECT_EQ(m2, m3);
+}
+
+// `2 * x` is not a monomial because of its coefficient `2`.
+TEST_F(MonomialTest, ToMonomialException1) {
+  EXPECT_THROW(Monomial{2 * x_}, runtime_error);
+}
+
+// `x + y` is not a monomial.
+TEST_F(MonomialTest, ToMonomialException2) {
+  EXPECT_THROW(Monomial{x_ + y_}, runtime_error);
+}
+
+// `x / 2.0` is not a monomial.
+TEST_F(MonomialTest, ToMonomialException3) {
+  EXPECT_THROW(Monomial{x_ / 2.0}, runtime_error);
+}
+
+// `x ^ -1` is not a monomial.
+TEST_F(MonomialTest, ToMonomialException4) {
+  // Note: Parentheses are required around macro argument containing braced
+  // initializer list.
+  EXPECT_THROW((Monomial{{{var_x_, -1}}}), runtime_error);
+}
+
+TEST_F(MonomialTest, Multiplication) {
+  // m₁ = xy²
+  const Monomial m1{{{var_x_, 1}, {var_y_, 2}}};
+  // m₂ = y²z⁵
+  const Monomial m2{{{var_y_, 2}, {var_z_, 5}}};
+  // m₃ = m₁ * m₂ = xy⁴z⁵
+  const Monomial m3{{{var_x_, 1}, {var_y_, 4}, {var_z_, 5}}};
+  EXPECT_EQ(m1 * m2, m3);
+
+  Monomial m{m1};  // m = m₁
+  m *= m2;         // m = m₁ * m₂
+  EXPECT_EQ(m, m1 * m2);
+}
+
+TEST_F(MonomialTest, Pow) {
+  // m₁ = xy²
+  const Monomial m1{{{var_x_, 1}, {var_y_, 2}}};
+  // m₂ = y²z⁵
+  const Monomial m2{{{var_y_, 2}, {var_z_, 5}}};
+
+  // pow(m₁, 0) = 1.0
+  EXPECT_EQ(pow(m1, 0), Monomial{});
+  // pow(m₂, 0) = 1.0
+  EXPECT_EQ(pow(m2, 0), Monomial{});
+
+  // pow(m₁, 1) = m₁
+  EXPECT_EQ(pow(m1, 1), m1);
+  // pow(m₂, 1) = m₂
+  EXPECT_EQ(pow(m2, 1), m2);
+
+  // pow(m₁, 3) = x³y⁶
+  EXPECT_EQ(pow(m1, 3), Monomial{pow(x_, 3) * pow(y_, 6)});
+  // pow(m₂, 4) = y⁸z²⁰
+  EXPECT_EQ(pow(m2, 4), Monomial{pow(y_, 8) * pow(z_, 20)});
+
+  // pow(m₁, -1) throws an exception.
+  EXPECT_THROW(pow(m1, -1), runtime_error);
+  // pow(m₂, -5) throws an exception.
+  EXPECT_THROW(pow(m2, -5), runtime_error);
+}
+
+TEST_F(MonomialTest, PowInPlace) {
+  // m₁ = xy²
+  Monomial m1{{{var_x_, 1}, {var_y_, 2}}};
+  const Monomial m1_copy{m1};
+  EXPECT_EQ(m1, m1_copy);
+
+  // m₁.pow_in_place modifies m₁.
+  m1.pow_in_place(2);
+  EXPECT_NE(m1, m1_copy);
+  EXPECT_EQ(m1, Monomial({{var_x_, 2}, {var_y_, 4}}));
+
+  // m₁ gets m₁⁰, which is 1.
+  m1.pow_in_place(0);
+  EXPECT_EQ(m1, Monomial());
 }
 
 TEST_F(MonomialTest, Degree) {
@@ -606,8 +663,8 @@ TEST_F(MonomialTest, Evaluate) {
 }
 
 TEST_F(MonomialTest, EvaluateException) {
-  const Monomial m{{{var_x_.get_id(), 1}, {var_y_.get_id(), 2}}};  // xy^2
-  const unordered_map<Variable::Id, double> env{{{var_x_.get_id(), 1.0}}};
+  const Monomial m{{{var_x_, 1}, {var_y_, 2}}};  // xy^2
+  const Environment env{{{var_x_, 1.0}}};
   EXPECT_THROW(m.Evaluate(env), out_of_range);
 }
 

--- a/drake/solvers/symbolic_extraction.cc
+++ b/drake/solvers/symbolic_extraction.cc
@@ -120,10 +120,10 @@ void DecomposeQuadraticExpressionWithMonomialToCoeffMap(
     if (monomial_powers.size() == 2) {
       // cross terms.
       auto it = monomial_powers.begin();
-      const int x1_index = map_var_to_index.at(it->first);
+      const int x1_index = map_var_to_index.at(it->first.get_id());
       DRAKE_DEMAND(it->second == 1);
       ++it;
-      const int x2_index = map_var_to_index.at(it->first);
+      const int x2_index = map_var_to_index.at(it->first.get_id());
       DRAKE_DEMAND(it->second == 1);
       (*Q)(x1_index, x2_index) += coefficient;
       (*Q)(x2_index, x1_index) = (*Q)(x1_index, x2_index);
@@ -133,7 +133,7 @@ void DecomposeQuadraticExpressionWithMonomialToCoeffMap(
       // 2. linear term b*x
       auto it = monomial_powers.begin();
       DRAKE_DEMAND(it->second == 2 || it->second == 1);
-      const int x_index = map_var_to_index.at(it->first);
+      const int x_index = map_var_to_index.at(it->first.get_id());
       if (it->second == 2) {
         // quadratic term a * x^2
         (*Q)(x_index, x_index) += 2 * coefficient;

--- a/drake/solvers/symbolic_extraction.h
+++ b/drake/solvers/symbolic_extraction.h
@@ -163,7 +163,8 @@ DecomposeLinearExpression(
       // Linear coefficient.
       const auto& p_monomial_powers = p_monomial.get_powers();
       DRAKE_DEMAND(p_monomial_powers.size() == 1);
-      const symbolic::Variable::Id var_id = p_monomial_powers.begin()->first;
+      const symbolic::Variable::Id var_id =
+          p_monomial_powers.begin()->first.get_id();
       // TODO(eric.cousineau): Avoid using const_cast.
       const_cast<Eigen::MatrixBase<Derived>&>(coeffs)(
           map_var_to_index.at(var_id)) = p_coeff;


### PR DESCRIPTION
 - Use `Variable → int` instead of `Variable::Id → int` as an internal representation.
 - Add `Monomial::operator*=(const Monomial&)`.
 - Re-implement `Monomial::operator==`.
 - Add `pow(Monomial, Monomial)`.
 - Add more tests. (100% coverage for Monomial class)

Related issue: #6218.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6275)
<!-- Reviewable:end -->
