### PR TITLE
Remove num_vars_ from MathematicalProgram.

### DIFF
--- a/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
+++ b/drake/bindings/pybind11/pydrake_mathematicalprogram.cc
@@ -92,15 +92,15 @@ PYBIND11_PLUGIN(_pydrake_mathematicalprogram) {
     .def(py::init<>())
     .def("NewContinuousVariables", (VectorXDecisionVariable
           (MathematicalProgram::*)(
-          size_t,
+          int,
           const std::string&))
          &MathematicalProgram::NewContinuousVariables,
          py::arg("rows"),
          py::arg("name") = "x")
     .def("NewContinuousVariables", (MatrixXDecisionVariable
           (MathematicalProgram::*)(
-          size_t,
-          size_t,
+          int,
+          int,
           const std::string&))
          &MathematicalProgram::NewContinuousVariables,
          py::arg("rows"),
@@ -108,15 +108,15 @@ PYBIND11_PLUGIN(_pydrake_mathematicalprogram) {
          py::arg("name") = "x")
     .def("NewBinaryVariables", (VectorXDecisionVariable
          (MathematicalProgram::*)(
-         size_t,
+         int,
          const std::string&))
          &MathematicalProgram::NewBinaryVariables,
          py::arg("rows"),
          py::arg("name") = "b")
     .def("NewBinaryVariables", (MatrixXDecisionVariable
          (MathematicalProgram::*)(
-         size_t,
-         size_t,
+         int,
+         int,
          const std::string&))
          &MathematicalProgram::NewBinaryVariables,
          py::arg("rows"),

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -96,8 +96,6 @@ drake_cc_library(
     srcs = ["decision_variable.cc"],
     hdrs = ["decision_variable.h"],
     deps = [
-        "//drake/common",
-        "//drake/common:number_traits",
         "//drake/common:symbolic",
     ],
 )
@@ -482,7 +480,6 @@ drake_cc_googletest(
     name = "decision_variable_test",
     deps = [
         ":mathematical_program",
-        "//drake/common:eigen_matrix_compare",
         "//drake/common:symbolic_test_util",
     ],
 )

--- a/drake/solvers/decision_variable.h
+++ b/drake/solvers/decision_variable.h
@@ -1,13 +1,6 @@
 #pragma once
 
-#include <cstddef>
 #include <list>
-#include <memory>
-#include <string>
-#include <type_traits>
-#include <unordered_set>
-#include <vector>
-
 #include <Eigen/Core>
 
 #include "drake/common/symbolic_variable.h"

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -102,8 +102,7 @@ enum {
 // https://gcc.gnu.org/wiki/VerboseDiagnostics#missing_static_const_definition)
 
 MathematicalProgram::MathematicalProgram()
-    : num_vars_(0),
-      x_initial_guess_(
+    : x_initial_guess_(
           static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)),
       solver_result_(0),
       optimal_cost_(numeric_limits<double>::quiet_NaN()),
@@ -131,17 +130,17 @@ VectorXDecisionVariable MathematicalProgram::NewVariables(
 }
 
 VectorXDecisionVariable MathematicalProgram::NewContinuousVariables(
-    size_t rows, const vector<string>& names) {
+    int rows, const vector<string>& names) {
   return NewVariables(VarType::CONTINUOUS, rows, names);
 }
 
 MatrixXDecisionVariable MathematicalProgram::NewContinuousVariables(
-    size_t rows, size_t cols, const vector<string>& names) {
+    int rows, int cols, const vector<string>& names) {
   return NewVariables(VarType::CONTINUOUS, rows, cols, false, names);
 }
 
 VectorXDecisionVariable MathematicalProgram::NewContinuousVariables(
-    size_t rows, const string& name) {
+    int rows, const string& name) {
   vector<string> names(rows);
   for (int i = 0; i < static_cast<int>(rows); ++i) {
     names[i] = name + "(" + to_string(i) + ")";
@@ -150,7 +149,7 @@ VectorXDecisionVariable MathematicalProgram::NewContinuousVariables(
 }
 
 MatrixXDecisionVariable MathematicalProgram::NewContinuousVariables(
-    size_t rows, size_t cols, const string& name) {
+    int rows, int cols, const string& name) {
   vector<string> names(rows * cols);
   int count = 0;
   for (int j = 0; j < static_cast<int>(cols); ++j) {
@@ -163,12 +162,12 @@ MatrixXDecisionVariable MathematicalProgram::NewContinuousVariables(
 }
 
 MatrixXDecisionVariable MathematicalProgram::NewBinaryVariables(
-    size_t rows, size_t cols, const vector<string>& names) {
+    int rows, int cols, const vector<string>& names) {
   return NewVariables(VarType::BINARY, rows, cols, false, names);
 }
 
 MatrixXDecisionVariable MathematicalProgram::NewBinaryVariables(
-    size_t rows, size_t cols, const string& name) {
+    int rows, int cols, const string& name) {
   vector<string> names(rows * cols);
   int count = 0;
   for (int j = 0; j < static_cast<int>(cols); ++j) {
@@ -181,12 +180,12 @@ MatrixXDecisionVariable MathematicalProgram::NewBinaryVariables(
 }
 
 MatrixXDecisionVariable MathematicalProgram::NewSymmetricContinuousVariables(
-    size_t rows, const vector<string>& names) {
+    int rows, const vector<string>& names) {
   return NewVariables(VarType::CONTINUOUS, rows, rows, true, names);
 }
 
 MatrixXDecisionVariable MathematicalProgram::NewSymmetricContinuousVariables(
-    size_t rows, const string& name) {
+    int rows, const string& name) {
   vector<string> names(rows * (rows + 1) / 2);
   int count = 0;
   for (int j = 0; j < static_cast<int>(rows); ++j) {
@@ -199,7 +198,7 @@ MatrixXDecisionVariable MathematicalProgram::NewSymmetricContinuousVariables(
 }
 
 VectorXDecisionVariable MathematicalProgram::NewBinaryVariables(
-    size_t rows, const string& name) {
+    int rows, const string& name) {
   vector<string> names(rows);
   for (int i = 0; i < static_cast<int>(rows); ++i) {
     names[i] = name + "(" + to_string(i) + ")";
@@ -319,8 +318,8 @@ Binding<Constraint> MathematicalProgram::AddConstraint(
     return AddConstraint(
         BindingDynamicCast<PositiveSemidefiniteConstraint>(binding));
   } else if (dynamic_cast<RotatedLorentzConeConstraint*>(constraint)) {
-    return AddConstraint(BindingDynamicCast<RotatedLorentzConeConstraint>(
-        binding));
+    return AddConstraint(
+        BindingDynamicCast<RotatedLorentzConeConstraint>(binding));
   } else if (dynamic_cast<LorentzConeConstraint*>(constraint)) {
     return AddConstraint(BindingDynamicCast<LorentzConeConstraint>(binding));
   } else if (dynamic_cast<LinearConstraint*>(constraint)) {
@@ -590,8 +589,7 @@ MathematicalProgram::AddLinearMatrixInequalityConstraint(
   return AddConstraint(constraint, vars);
 }
 
-size_t MathematicalProgram::FindDecisionVariableIndex(
-    const Variable& var) const {
+int MathematicalProgram::FindDecisionVariableIndex(const Variable& var) const {
   auto it = decision_variable_index_.find(var.get_id());
   if (it == decision_variable_index_.end()) {
     ostringstream oss;

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -222,7 +222,8 @@ class MathematicalProgram {
    * @endcode
    * This adds a matrix of size 2 x 3 as new variables into the optimization
    * program.
-   * The name of the variable is only used for the user to understand.
+   * The name of the variable is only used for the user in order to ease
+   * readability.
    */
   template <int rows, int cols>
   MatrixDecisionVariable<rows, cols> NewVariables(
@@ -258,22 +259,21 @@ class MathematicalProgram {
 
   /**
    * Adds continuous variables to this MathematicalProgram.
-   * @see NewContinuousVariables(size_t rows, size_t cols, const
+   * @see NewContinuousVariables(int rows, int cols, const
    * std::vector<std::string>& names);
    */
   VectorXDecisionVariable NewContinuousVariables(
-      size_t rows, const std::vector<std::string>& names);
+      int rows, const std::vector<std::string>& names);
 
   /**
    * Adds continuous variables to this MathematicalProgram, with default name
    * "x".
-   * @see NewContinuousVariables(size_t rows, size_t cols, const
+   * @see NewContinuousVariables(int rows, int cols, const
    * std::vector<std::string>& names);
    */
-  VectorXDecisionVariable NewContinuousVariables(size_t rows,
+  VectorXDecisionVariable NewContinuousVariables(int rows,
                                                  const std::string& name = "x");
 
-  /// Adds continuous variables to this MathematicalProgram.
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
@@ -297,22 +297,22 @@ class MathematicalProgram {
    * @endcode
    * This adds a 2 x 3 matrix decision variables into the program.
    *
-   * The name of the variable is only used for the user for understand.
+   * The name of the variable is only used for the user in order to ease
+   * readability.
    */
   MatrixXDecisionVariable NewContinuousVariables(
-      size_t rows, size_t cols, const std::vector<std::string>& names);
+      int rows, int cols, const std::vector<std::string>& names);
 
   /**
    * Adds continuous variables to this MathematicalProgram, with default name
    * "X". The new variables are returned and viewed as a matrix, with size
    * @p rows x @p cols.
-   * @see NewContinuousVariables(size_t rows, size_t cols, const
+   * @see NewContinuousVariables(int rows, int cols, const
    * std::vector<std::string>& names);
    */
-  MatrixXDecisionVariable NewContinuousVariables(size_t rows, size_t cols,
+  MatrixXDecisionVariable NewContinuousVariables(int rows, int cols,
                                                  const std::string& name = "X");
 
-  /// Adds continuous variables to this MathematicalProgram.
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
@@ -336,7 +336,8 @@ class MathematicalProgram {
    * @endcode
    * This adds a 2 x 3 matrix decision variables into the program.
    *
-   * The name of the variable is only used for the user for understand.
+   * The name of the variable is only used for the user in order to ease
+   * readability.
    */
   template <int rows, int cols>
   MatrixDecisionVariable<rows, cols> NewContinuousVariables(
@@ -344,7 +345,6 @@ class MathematicalProgram {
     return NewVariables<rows, cols>(VarType::CONTINUOUS, names);
   }
 
-  /// Adds continuous variables to this MathematicalProgram.
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
@@ -367,7 +367,8 @@ class MathematicalProgram {
    * @endcode
    * This adds a 2 x 3 matrix decision variables into the program.
    *
-   * The name of the variable is only used for the user for understand.
+   * The name of the variable is only used for the user in order to ease
+   * readability.
    */
   template <int rows, int cols>
   MatrixDecisionVariable<rows, cols> NewContinuousVariables(
@@ -382,7 +383,6 @@ class MathematicalProgram {
     return NewVariables<rows, cols>(VarType::CONTINUOUS, names);
   }
 
-  /// Adds continuous variables to this MathematicalProgram.
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
@@ -405,7 +405,8 @@ class MathematicalProgram {
    * @endcode
    * This adds a 2 x 1 vector containing decision variables into the program.
    *
-   * The name of the variable is only used for the user for understand.
+   * The name of the variable is only used for the user in order to ease
+   * readability.
    */
   template <int rows>
   VectorDecisionVariable<rows> NewContinuousVariables(
@@ -423,14 +424,13 @@ class MathematicalProgram {
   VectorDecisionVariable<rows> NewContinuousVariables(
       const std::string& name = "x") {
     std::array<std::string, rows> names;
-    int offset = (name.compare("x") == 0) ? num_vars_ : 0;
+    int offset = (name.compare("x") == 0) ? num_vars() : 0;
     for (int i = 0; i < rows; ++i) {
       names[i] = name + "(" + std::to_string(offset + i) + ")";
     }
     return NewContinuousVariables<rows>(names);
   }
 
-  /// Adds binary variables to this MathematicalProgram.
   /**
    * Adds binary variables, appending them to an internal vector of any
    * existing vars.
@@ -454,7 +454,8 @@ class MathematicalProgram {
    * @endcode
    * This adds a 2 x 3 matrix decision variables into the program.
    *
-   * The name of the variable is only used for the user for understand.
+   * The name of the variable is only used for the user in order to ease
+   * readability.
    */
   template <int rows, int cols>
   MatrixDecisionVariable<rows, cols> NewBinaryVariables(
@@ -508,14 +509,13 @@ class MathematicalProgram {
   VectorDecisionVariable<rows> NewBinaryVariables(
       const std::string& name = "b") {
     std::array<std::string, rows> names;
-    int offset = (name.compare("b") == 0) ? num_vars_ : 0;
+    int offset = (name.compare("b") == 0) ? num_vars() : 0;
     for (int i = 0; i < rows; ++i) {
       names[i] = name + "(" + std::to_string(offset + i) + ")";
     }
     return NewBinaryVariables<rows, 1>(names);
   }
 
-  /// Adds binary variables to this MathematicalProgram.
   /**
    * Adds binary variables, appending them to an internal vector of any
    * existing vars.
@@ -539,28 +539,28 @@ class MathematicalProgram {
    * @endcode
    * This adds a 2 x 3 matrix decision variables into the program.
    *
-   * The name of the variable is only used for the user for understand.
+   * The name of the variable is only used for the user to ease readability.
    */
   MatrixXDecisionVariable NewBinaryVariables(
-      size_t rows, size_t cols, const std::vector<std::string>& names);
+      int rows, int cols, const std::vector<std::string>& names);
 
   /**
    * Adds binary variables to this MathematicalProgram, with default name "b".
    * The new variables are returned and viewed as a matrix, with size
    * \param rows x \param cols.
-   * @see NewBinaryVariables(size_t rows, size_t cols, const
+   * @see NewBinaryVariables(int rows, int cols, const
    * std::vector<std::string>& names);
    */
-  MatrixXDecisionVariable NewBinaryVariables(size_t rows, size_t cols,
+  MatrixXDecisionVariable NewBinaryVariables(int rows, int cols,
                                              const std::string& name = "b");
 
   /**
    * Adds binary variables to this MathematicalProgram. The new variables are
    * viewed as a column vector, with size @p rows x 1.
-   * @see NewBinaryVariables(size_t rows, size_t cols, const
+   * @see NewBinaryVariables(int rows, int cols, const
    * std::vector<std::string>& names);
    */
-  VectorXDecisionVariable NewBinaryVariables(size_t rows,
+  VectorXDecisionVariable NewBinaryVariables(int rows,
                                              const std::string& name = "b");
 
   /**
@@ -574,7 +574,7 @@ class MathematicalProgram {
    * @return The newly added decision variables.
    */
   MatrixXDecisionVariable NewSymmetricContinuousVariables(
-      size_t rows, const std::vector<std::string>& names);
+      int rows, const std::vector<std::string>& names);
 
   /**
    * Adds a runtime sized symmetric matrix as decision variables to
@@ -595,7 +595,7 @@ class MathematicalProgram {
    * @return The newly added decision variables.
    */
   MatrixXDecisionVariable NewSymmetricContinuousVariables(
-      size_t rows, const std::string& name = "Symmetric");
+      int rows, const std::string& name = "Symmetric");
 
   /**
    * Adds a static sized symmetric matrix as decision variables to
@@ -730,8 +730,7 @@ class MathematicalProgram {
    * the linear cost data structure.
    */
   Binding<LinearCost> AddLinearCost(const Eigen::Ref<const Eigen::VectorXd>& a,
-                                    double b,
-                                    const VariableRefList& vars) {
+                                    double b, const VariableRefList& vars) {
     return AddLinearCost(a, b, ConcatenateVariableRefList((vars)));
   }
 
@@ -741,8 +740,7 @@ class MathematicalProgram {
    * the linear cost data structure.
    */
   Binding<LinearCost> AddLinearCost(
-      const Eigen::Ref<const Eigen::VectorXd>& a,
-      double b,
+      const Eigen::Ref<const Eigen::VectorXd>& a, double b,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
@@ -828,8 +826,7 @@ class MathematicalProgram {
    */
   Binding<QuadraticCost> AddQuadraticCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
-      const Eigen::Ref<const Eigen::VectorXd>& b,
-      double c,
+      const Eigen::Ref<const Eigen::VectorXd>& b, double c,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
@@ -1763,7 +1760,8 @@ class MathematicalProgram {
    */
   template <typename Derived>
   void SetInitialGuessForAllVariables(const Eigen::MatrixBase<Derived>& x0) {
-    DRAKE_ASSERT(x0.rows() == static_cast<int>(num_vars_) && x0.cols() == 1);
+    DRAKE_ASSERT(x0.rows() == num_vars() &&
+                 x0.cols() == 1);
     x_initial_guess_ = x0;
   }
 
@@ -1783,7 +1781,7 @@ class MathematicalProgram {
   //    getInfeasibleConstraintNames();
 
   void PrintSolution() {
-    for (int i = 0; i < static_cast<int>(num_vars_); ++i) {
+    for (int i = 0; i < num_vars(); ++i) {
       std::cout << decision_variables_(i).get_name() << " = "
                 << GetSolution(decision_variables_(i)) << std::endl;
     }
@@ -2012,7 +2010,7 @@ class MathematicalProgram {
   }
 
   /** Getter for number of variables in the optimization program */
-  size_t num_vars() const { return num_vars_; }
+  int num_vars() const { return decision_variables_.rows(); }
 
   /** Getter for the initial guess */
   const Eigen::VectorXd& initial_guess() const { return x_initial_guess_; }
@@ -2033,7 +2031,7 @@ class MathematicalProgram {
    * @pre{@p var is a decision variable in the mathematical program, otherwise
    * this function throws a runtime error.}
    */
-  size_t FindDecisionVariableIndex(const symbolic::Variable& var) const;
+  int FindDecisionVariableIndex(const symbolic::Variable& var) const;
 
   /**
    * Gets the solution of an Eigen matrix of decision variables.
@@ -2090,7 +2088,7 @@ class MathematicalProgram {
  private:
   // maps the ID of a symbolic variable to the index of the variable stored in
   // the optimization program.
-  std::unordered_map<symbolic::Variable::Id, size_t> decision_variable_index_{};
+  std::unordered_map<symbolic::Variable::Id, int> decision_variable_index_{};
 
   VectorXDecisionVariable decision_variables_;
   std::vector<Binding<Cost>> generic_costs_;
@@ -2116,7 +2114,6 @@ class MathematicalProgram {
   std::vector<Binding<LinearComplementarityConstraint>>
       linear_complementarity_constraints_;
 
-  size_t num_vars_;
   Eigen::VectorXd x_initial_guess_;
   std::vector<double> x_values_;
   std::shared_ptr<SolverData> solver_data_;
@@ -2166,18 +2163,19 @@ class MathematicalProgram {
       num_new_vars = rows * (rows + 1) / 2;
     }
     DRAKE_ASSERT(static_cast<int>(names.size()) == num_new_vars);
-    decision_variables_.conservativeResize(num_vars_ + num_new_vars,
-                                           Eigen::NoChange);
-    x_values_.resize(num_vars_ + num_new_vars, NAN);
+    decision_variables_.conservativeResize(
+        num_vars() + num_new_vars, Eigen::NoChange);
+    x_values_.resize(num_vars() + num_new_vars, NAN);
     int row_index = 0;
     int col_index = 0;
     for (int i = 0; i < num_new_vars; ++i) {
-      decision_variables_(num_vars_ + i) = symbolic::Variable(names[i], type);
-      const size_t new_var_index = num_vars_ + i;
-      decision_variable_index_.insert(std::pair<size_t, size_t>(
+      decision_variables_(num_vars() - num_new_vars + i) =
+          symbolic::Variable(names[i], type);
+      const int new_var_index = num_vars() - num_new_vars + i;
+      decision_variable_index_.insert(std::pair<int, int>(
           decision_variables_(new_var_index).get_id(), new_var_index));
       decision_variable_matrix(row_index, col_index) =
-          decision_variables_(num_vars_ + i);
+          decision_variables_(num_vars() - num_new_vars + i);
       // If the matrix is not symmetric, then store the variable in column
       // major.
       if (!is_symmetric) {
@@ -2203,8 +2201,7 @@ class MathematicalProgram {
       }
     }
 
-    num_vars_ += num_new_vars;
-    x_initial_guess_.conservativeResize(num_vars_);
+    x_initial_guess_.conservativeResize(num_vars());
     x_initial_guess_.tail(num_new_vars)
         .fill(std::numeric_limits<double>::quiet_NaN());
   }


### PR DESCRIPTION
This PR removes the member num_vars_ from MathematicalProgram. This member stored the amount of decision variables. Instead of using this member, the `decision_variables_.rows()` is used. 

Furthermore, this commit replaces `size_t` by `int` as template parameter in `MathematicalProgram::NewVaraibales`. Eventually, all decision variables are stored in an `Eigen::Matrix` which uses `int`. Thus no information is lost. 

Finally, this PR removes unused dependencies from `decision_variable.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6276)
<!-- Reviewable:end -->
