### PR TITLE
Refactor symbolic expression visitor

### DIFF
--- a/drake/common/symbolic_expression_visitor.h
+++ b/drake/common/symbolic_expression_visitor.h
@@ -5,134 +5,163 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/symbolic_expression.h"
-#include "drake/common/symbolic_expression_cell.h"
 
 namespace drake {
 namespace symbolic {
 
 /// Calls visitor object @p v with a polynomial symbolic-expression @p e, and
-/// arguments @p args. Visitor object is expected to implement <tt>Result
-/// operator()</tt> which takes a shared pointer of a class in ExpressionCell's
-/// inheritance hierarchy.
+/// arguments @p args. Visitor object is expected to implement the following
+/// methods which take @p f and @p args: `VisitConstant`, `VisitVariable`,
+/// `VisitAddition`, `VisitMultiplication`, `VisitDivision`, `VisitPow`.
 ///
 /// @throws std::runtime_error if NaN is detected during a visit.
 ///
 /// See the implementation of @c DegreeVisitor class and @c Degree function in
 /// drake/common/monomial.cc as an example usage.
 ///
-/// \pre{e.is_polynomial() is true.}
+/// @pre e.is_polynomial() is true.
 template <typename Result, typename Visitor, typename... Args>
-Result VisitPolynomial(const Visitor& v, const Expression& e, Args&&... args) {
-  DRAKE_ASSERT(e.is_polynomial());
+Result VisitPolynomial(Visitor* v, const Expression& e, Args&&... args) {
+  DRAKE_DEMAND(e.is_polynomial());
   switch (e.get_kind()) {
     case ExpressionKind::Constant:
-      return v(to_constant(e), std::forward<Args>(args)...);
+      return v->VisitConstant(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Var:
-      return v(to_variable(e), std::forward<Args>(args)...);
+      return v->VisitVariable(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Add:
-      return v(to_addition(e), std::forward<Args>(args)...);
+      return v->VisitAddition(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Mul:
-      return v(to_multiplication(e), std::forward<Args>(args)...);
+      return v->VisitMultiplication(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Div:
-      return v(to_division(e), std::forward<Args>(args)...);
+      return v->VisitDivision(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Pow:
-      return v(to_pow(e), std::forward<Args>(args)...);
+      return v->VisitPow(e, std::forward<Args>(args)...);
 
-    default:
-      // Should be unreachable.
+    case ExpressionKind::NaN:
+      throw std::runtime_error("NaN is detected while visiting an expression.");
+
+    case ExpressionKind::Log:
+    case ExpressionKind::Abs:
+    case ExpressionKind::Exp:
+    case ExpressionKind::Sqrt:
+    case ExpressionKind::Sin:
+    case ExpressionKind::Cos:
+    case ExpressionKind::Tan:
+    case ExpressionKind::Asin:
+    case ExpressionKind::Acos:
+    case ExpressionKind::Atan:
+    case ExpressionKind::Atan2:
+    case ExpressionKind::Sinh:
+    case ExpressionKind::Cosh:
+    case ExpressionKind::Tanh:
+    case ExpressionKind::Min:
+    case ExpressionKind::Max:
+    case ExpressionKind::IfThenElse:
+    case ExpressionKind::UninterpretedFunction:
+      // Should not be reachable because of `DRAKE_DEMAND(e.is_polynomial())` at
+      // the top.
       DRAKE_ABORT();
   }
+  // Should not be reachable. But we need the following to avoid "control
+  // reaches end of non-void function" gcc-warning.
+  DRAKE_ABORT();
 }
 
-/// Calls visitor object @p v with a symbolic expression @p e, and arguments @p
-/// args. Visitor object is expected to implement <tt>Result operator()</tt>
-/// which takes a shared pointer of a class in ExpressionCell's inheritance
-/// hierarchy.
+/// Calls visitor object @p v with a symbolic-expression @p e, and arguments @p
+/// args. Visitor object is expected to implement the following methods which
+/// take @p f and @p args: `VisitConstant`, `VisitVariable`, `VisitAddition`,
+/// `VisitMultiplication`, `VisitDivision`, `VisitLog`, `VisitAbs`, `VisitExp`,
+/// `VisitSqrt`, `VisitPow`, `VisitSin`, `VisitCos`, `VisitTan`, `VisitAsin`,
+/// `VisitAtan`, `VisitAtan2`, `VisitSinh`, `VisitCosh`, `VisitTanh`,
+/// `VisitMin`, `VisitMax`, `VisitIfThenElse`, `VisitUninterpretedFunction.
 ///
 /// @throws std::runtime_error if NaN is detected during a visit.
 template <typename Result, typename Visitor, typename... Args>
-Result VisitExpression(const Visitor& v, const Expression& e, Args&&... args) {
+Result VisitExpression(Visitor* v, const Expression& e, Args&&... args) {
   switch (e.get_kind()) {
     case ExpressionKind::Constant:
-      return v(to_constant(e), std::forward<Args>(args)...);
+      return v->VisitConstant(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Var:
-      return v(to_variable(e), std::forward<Args>(args)...);
+      return v->VisitVariable(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Add:
-      return v(to_addition(e), std::forward<Args>(args)...);
+      return v->VisitAddition(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Mul:
-      return v(to_multiplication(e), std::forward<Args>(args)...);
+      return v->VisitMultiplication(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Div:
-      return v(to_division(e), std::forward<Args>(args)...);
+      return v->VisitDivision(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Log:
-      return v(to_log(e), std::forward<Args>(args)...);
+      return v->VisitLog(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Abs:
-      return v(to_abs(e), std::forward<Args>(args)...);
+      return v->VisitAbs(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Exp:
-      return v(to_exp(e), std::forward<Args>(args)...);
+      return v->VisitExp(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Sqrt:
-      return v(to_sqrt(e), std::forward<Args>(args)...);
+      return v->VisitSqrt(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Pow:
-      return v(to_pow(e), std::forward<Args>(args)...);
+      return v->VisitPow(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Sin:
-      return v(to_sin(e), std::forward<Args>(args)...);
+      return v->VisitSin(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Cos:
-      return v(to_cos(e), std::forward<Args>(args)...);
+      return v->VisitCos(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Tan:
-      return v(to_tan(e), std::forward<Args>(args)...);
+      return v->VisitTan(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Asin:
-      return v(to_asin(e), std::forward<Args>(args)...);
+      return v->VisitAsin(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Acos:
-      return v(to_acos(e), std::forward<Args>(args)...);
+      return v->VisitAcos(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Atan:
-      return v(to_atan(e), std::forward<Args>(args)...);
+      return v->VisitAtan(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Atan2:
-      return v(to_atan2(e), std::forward<Args>(args)...);
+      return v->VisitAtan2(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Sinh:
-      return v(to_sinh(e), std::forward<Args>(args)...);
+      return v->VisitSinh(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Cosh:
-      return v(to_cosh(e), std::forward<Args>(args)...);
+      return v->VisitCosh(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Tanh:
-      return v(to_tanh(e), std::forward<Args>(args)...);
+      return v->VisitTanh(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Min:
-      return v(to_min(e), std::forward<Args>(args)...);
+      return v->VisitMin(e, std::forward<Args>(args)...);
 
     case ExpressionKind::Max:
-      return v(to_max(e), std::forward<Args>(args)...);
+      return v->VisitMax(e, std::forward<Args>(args)...);
 
     case ExpressionKind::IfThenElse:
-      return v(to_if_then_else(e), std::forward<Args>(args)...);
+      return v->VisitIfThenElse(e, std::forward<Args>(args)...);
 
     case ExpressionKind::NaN:
       throw std::runtime_error("NaN is detected while visiting an expression.");
 
     case ExpressionKind::UninterpretedFunction:
-      return v(to_uninterpreted_function(e), std::forward<Args>(args)...);
+      return v->VisitUninterpretedFunction(e, std::forward<Args>(args)...);
   }
+  // Should not be reachable. But we need the following to avoid "control
+  // reaches end of non-void function" gcc-warning.
+  DRAKE_ABORT();
 }
 
 }  // namespace symbolic

--- a/drake/common/test/symbolic_formula_visitor_test.cc
+++ b/drake/common/test/symbolic_formula_visitor_test.cc
@@ -147,9 +147,8 @@ class NegationNormalFormConverter {
   }
 
   // Makes VisitFormula a friend of this class so that it can use private
-  // operator()s.
-  friend Formula drake::symbolic::VisitFormula<
-      Formula, const NegationNormalFormConverter, const bool&>(
+  // methods.
+  friend Formula drake::symbolic::VisitFormula<Formula>(
       const NegationNormalFormConverter*, const Formula&, const bool&);
 };
 


### PR DESCRIPTION
Analogous to https://github.com/RobotLocomotion/drake/pull/6215.

Previously, we exposed the `ExpressionCell` classes such as `ExpressionAdd` and `ExpressionPow` in this file, which is violating the encapsulation. This patch changes `Visit*` function to take `const Formula&` instead of `const shared_ptr<FormulaCell>&`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6278)
<!-- Reviewable:end -->
