### PR TITLE
Refactor Formula::Evaluate

### DIFF
--- a/drake/common/symbolic_environment.cc
+++ b/drake/common/symbolic_environment.cc
@@ -56,6 +56,14 @@ void Environment::insert(const key_type& key, const mapped_type& elem) {
   map_.emplace(key, elem);
 }
 
+Variables Environment::domain() const {
+  Variables dom;
+  for (const auto& p : map_) {
+    dom += p.first;
+  }
+  return dom;
+}
+
 string Environment::to_string() const {
   ostringstream oss;
   oss << *this;

--- a/drake/common/symbolic_environment.h
+++ b/drake/common/symbolic_environment.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/symbolic_variable.h"
+#include "drake/common/symbolic_variables.h"
 
 namespace drake {
 namespace symbolic {
@@ -97,6 +98,9 @@ class Environment {
   iterator find(const key_type& key) { return map_.find(key); }
   /** Finds element with specific key. */
   const_iterator find(const key_type& key) const { return map_.find(key); }
+
+  /** Returns the domain of this environment. */
+  Variables domain() const;
 
   /** Returns string representation. */
   std::string to_string() const;

--- a/drake/common/symbolic_expression.cc
+++ b/drake/common/symbolic_expression.cc
@@ -21,10 +21,12 @@
 
 namespace drake {
 namespace symbolic {
+
 using std::make_shared;
 using std::map;
 using std::ostream;
 using std::ostringstream;
+using std::pair;
 using std::runtime_error;
 using std::shared_ptr;
 using std::string;
@@ -158,6 +160,17 @@ double Expression::Evaluate(const Environment& env) const {
   return ptr_->Evaluate(env);
 }
 
+Expression Expression::EvaluatePartial(const Environment& env) const {
+  if (env.empty()) {
+    return *this;
+  }
+  Substitution subst;
+  for (const pair<Variable, double>& p : env) {
+    subst.emplace(p.first, p.second);
+  }
+  return Substitute(subst);
+}
+
 Expression Expression::Expand() const {
   DRAKE_ASSERT(ptr_ != nullptr);
   return ptr_->Expand();
@@ -172,14 +185,14 @@ Expression Expression::Substitute(const Variable& var,
 Expression Expression::Substitute(const Substitution& s) const {
   DRAKE_ASSERT(ptr_ != nullptr);
   if (!s.empty()) {
-    return Expression{ptr_->Substitute(s)};
+    return ptr_->Substitute(s);
   }
   return *this;
 }
 
 Expression Expression::Differentiate(const Variable& x) const {
   DRAKE_ASSERT(ptr_ != nullptr);
-  return Expression{ptr_->Differentiate(x)};
+  return ptr_->Differentiate(x);
 }
 
 string Expression::to_string() const {

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -231,6 +231,14 @@ class Expression {
    */
   double Evaluate(const Environment& env = Environment{}) const;
 
+  /** Partially evaluates this expression using an environment @p
+   * env. Internally, this method promotes @p env into a substitution
+   * (Variable → Expression) and call Evaluate::Substitute with it.
+   *
+   * @throws std::runtime_error if NaN is detected during evaluation.
+   */
+  Expression EvaluatePartial(const Environment& env) const;
+
   /** Expands out products and positive integer powers in expression. For
    * example, `(x + 1) * (x - 1)` is expanded to `x^2 - 1` and `(x + y)^2` is
    * expanded to `x^2 + 2xy + y^2`. Note that Expand applies recursively to

--- a/drake/common/symbolic_formula.h
+++ b/drake/common/symbolic_formula.h
@@ -151,7 +151,17 @@ class Formula {
    * std::map<symbolic::Formula> and std::set<symbolic::Formula> via
    * std::less<symbolic::Formula>. */
   bool Less(const Formula& f) const;
-  /** Evaluates under a given environment (by default, an empty environment)*/
+
+  /** Evaluates under a given environment (by default, an empty environment).
+   *
+   * @throws runtime_error if a variable `v` is needed for an evaluation but not
+   * provided by @p env.
+   *
+   * Note that for an equality e₁ = e₂ and an inequality e₁ ≠ e₂, this method
+   * partially evaluates e₁ and e₂ and checks the structural equality of the two
+   * results if @p env does not provide complete information to call Evaluate on
+   * e₁ and e₂.
+   */
   bool Evaluate(const Environment& env = Environment{}) const;
 
   /** Returns a copy of this formula replacing all occurrences of @p var

--- a/drake/common/symbolic_formula_cell.cc
+++ b/drake/common/symbolic_formula_cell.cc
@@ -218,9 +218,34 @@ const Variable& FormulaVar::get_variable() const { return var_; }
 FormulaEq::FormulaEq(const Expression& e1, const Expression& e2)
     : RelationalFormulaCell{FormulaKind::Eq, e1, e2} {}
 
+namespace {
+// Helper function for ExpressionEq::Evaluate and ExpressionNeq::Evaluate.
+//
+// Checks if `e1.EvaluatePartial(env)` and `e2.EvaluatePartial(env)` are
+// structurally equal.
+bool CheckStructuralEqualityUptoPartialEvaluation(const Expression& e1,
+                                                  const Expression& e2,
+                                                  const Environment& env) {
+  // Trivial case where env = ∅.
+  if (env.empty()) {
+    return e1.EqualTo(e2);
+  }
+  // Since `Expression::Evaluate` is faster than `Expression::EvaluatePartial`,
+  // we use:
+  //  - `Expression::Evaluate`        if (vars(e₁) ∪ vars(e₂) ⊆ dom(env).
+  //  - `Expression::EvaluatePartial` otherwise.
+  const Variables vars{e1.GetVariables() + e2.GetVariables()};
+  if (vars.size() <= env.size() && vars.IsSubsetOf(env.domain())) {
+    return e1.Evaluate(env) == e2.Evaluate(env);
+  } else {
+    return e1.EvaluatePartial(env).EqualTo(e2.EvaluatePartial(env));
+  }
+}
+}  // namespace
+
 bool FormulaEq::Evaluate(const Environment& env) const {
-  return get_lhs_expression().Evaluate(env) ==
-         get_rhs_expression().Evaluate(env);
+  return CheckStructuralEqualityUptoPartialEvaluation(
+      get_lhs_expression(), get_rhs_expression(), env);
 }
 
 Formula FormulaEq::Substitute(const Substitution& s) const {
@@ -237,8 +262,8 @@ FormulaNeq::FormulaNeq(const Expression& e1, const Expression& e2)
     : RelationalFormulaCell{FormulaKind::Neq, e1, e2} {}
 
 bool FormulaNeq::Evaluate(const Environment& env) const {
-  return get_lhs_expression().Evaluate(env) !=
-         get_rhs_expression().Evaluate(env);
+  return !CheckStructuralEqualityUptoPartialEvaluation(
+      get_lhs_expression(), get_rhs_expression(), env);
 }
 
 Formula FormulaNeq::Substitute(const Substitution& s) const {

--- a/drake/common/test/symbolic_environment_test.cc
+++ b/drake/common/test/symbolic_environment_test.cc
@@ -66,6 +66,13 @@ TEST_F(EnvironmentTest, insert_find) {
   EXPECT_EQ(env1.size(), 5u);
 }
 
+TEST_F(EnvironmentTest, domain) {
+  const Environment env1{};
+  const Environment env2{{var_x_, 2}, {var_y_, 3}, {var_z_, 4}};
+  EXPECT_EQ(env1.domain(), Variables{});
+  EXPECT_EQ(env2.domain(), Variables({var_x_, var_y_, var_z_}));
+}
+
 TEST_F(EnvironmentTest, ToString) {
   const Environment env{{var_x_, 2}, {var_y_, 3}, {var_z_, 3}};
   const string out{env.to_string()};

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -1759,6 +1759,23 @@ TEST_F(SymbolicExpressionTest, ToString) {
   EXPECT_EQ(e_uf_.to_string(), "uf({x, y})");
 }
 
+TEST_F(SymbolicExpressionTest, EvaluatePartial) {
+  // e = xy - 5yz + 10xz.
+  const Expression e{x_ * y_ - 5 * y_ * z_ + 10 * x_ * z_};
+
+  // e1 = e[x ↦ 3] = 3y - 5yz + 30z
+  const Expression e1{e.EvaluatePartial({{var_x_, 3}})};
+  EXPECT_PRED2(ExprEqual, e1, 3 * y_ - 5 * y_ * z_ + 30 * z_);
+
+  // e2 = e1[y ↦ 5] = 15 - 25z + 30z = 15 + 5z
+  const Expression e2{e1.EvaluatePartial({{var_y_, 5}})};
+  EXPECT_PRED2(ExprEqual, e2, 15 + 5 * z_);
+
+  // e3 = e1[z ↦ -2] = 15 + (-10) = 5
+  const Expression e3{e2.EvaluatePartial({{var_z_, -2}})};
+  EXPECT_PRED2(ExprEqual, e3, 5);
+}
+
 // Checks for compatibility with a memcpy primitive move operation.
 // See https://github.com/RobotLocomotion/drake/issues/5974.
 TEST_F(SymbolicExpressionTest, MemcpyKeepsExpressionIntact) {

--- a/drake/common/test/symbolic_variable_test.cc
+++ b/drake/common/test/symbolic_variable_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/symbolic_variable.h"
 
+#include <map>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -19,6 +20,7 @@ using test::IsMemcpyMovable;
 namespace symbolic {
 namespace {
 
+using std::map;
 using std::move;
 using std::ostringstream;
 using std::unordered_map;
@@ -123,6 +125,18 @@ TEST_F(VariableTest, ToString) {
   EXPECT_EQ(w_.to_string(), "w");
 }
 
+TEST_F(VariableTest, EqualityCheck) {
+  // `v₁ == v₂` and `v₁ != v₂` form instances of symbolic::Formula. Inside of
+  // EXPECT_{TRUE,FALSE}, they are converted to bool by Formula::Evaluate() with
+  // an empty environment. This test checks that we do not have
+  // `runtime_error("The following environment does not have an entry for the
+  // variable ...")` in the process.
+  EXPECT_TRUE(x_ != y_);
+  EXPECT_TRUE(x_ != z_);
+  EXPECT_FALSE(x_ == y_);
+  EXPECT_FALSE(x_ == z_);
+}
+
 // This test checks whether Variable is compatible with std::unordered_set.
 TEST_F(VariableTest, CompatibleWithUnorderedSet) {
   unordered_set<Variable, hash_value<Variable>> uset;
@@ -134,6 +148,37 @@ TEST_F(VariableTest, CompatibleWithUnorderedSet) {
 TEST_F(VariableTest, CompatibleWithUnorderedMap) {
   unordered_map<Variable, Variable, hash_value<Variable>> umap;
   umap.emplace(x_, y_);
+}
+
+TEST_F(VariableTest, MapEqual) {
+  // Checking equality between two map<Variable, T> invokes `v₁ == v₂`, which
+  // will calls Formula::Evaluate(). This test checks that we do not have
+  // `runtime_error("The following environment does not have an entry for the
+  // variable ...")` in the process.
+  const map<Variable, int> m1{{x_, 3}, {y_, 4}};
+  const map<Variable, int> m2{{x_, 5}, {y_, 6}};
+  const map<Variable, int> m3{{x_, 5}, {z_, 6}};
+  const map<Variable, int> m4{{y_, 4}, {x_, 3}};  // same as m1.
+
+  EXPECT_EQ(m1, m1);  // m1 == m1
+  EXPECT_NE(m1, m2);
+  EXPECT_NE(m1, m3);
+  EXPECT_EQ(m1, m4);  // m1 == m4
+
+  EXPECT_NE(m2, m1);
+  EXPECT_EQ(m2, m2);  // m2 == m2
+  EXPECT_NE(m2, m3);
+  EXPECT_NE(m2, m4);
+
+  EXPECT_NE(m3, m1);
+  EXPECT_NE(m3, m2);
+  EXPECT_EQ(m3, m3);  // m3 == m3
+  EXPECT_NE(m3, m4);
+
+  EXPECT_EQ(m4, m1);  // m4 == m1
+  EXPECT_NE(m4, m2);
+  EXPECT_NE(m4, m3);
+  EXPECT_EQ(m4, m4);  // m4 == m4
 }
 
 // This test checks whether Variable is compatible with std::vector.


### PR DESCRIPTION
For two symbolic variable `v1` and `v2`, the following statement throws `std::runtime_error("The following environment does not have an entry for the variable x")`. 

```c++
EXPECT_TRUE(x_ != y_);
```

It's because `x_ != y_` forms a symbolic formula `f` and we call `f.Evaluate()` (with an empty environment).

This PR handles equality(`==`) and inequality(`!=`) using `Expression:EvaluatePartial` and structural equality-check (`Expression::EqualTo`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6281)
<!-- Reviewable:end -->
