### PR TITLE
Turn off unused Sphinx extensions

### DIFF
--- a/drake/doc/BUILD
+++ b/drake/doc/BUILD
@@ -28,6 +28,9 @@ genrule(
         # Cleanup temporary files.
         "rm -rf $(@D)/.doctrees/ $(@D)/.tmpout",
     ]),
+    # Some (currently disabled) Sphinx extentions try to reach out to the
+    # network; we should fail-fast if someone tries to turn them on.
+    tags = ["block-network"],
 )
 
 py_binary(

--- a/drake/doc/conf.py
+++ b/drake/doc/conf.py
@@ -16,16 +16,7 @@ import sys
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.coverage',
-    'sphinx.ext.doctest',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
-]
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = []


### PR DESCRIPTION
In particular intersphinx was trying to make http requests during compilation, which is a problem for offline compilation.  None of the other extensions were being used, either.
