### PR TITLE
Condense WORKSPACE and CWD into the same case

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -163,10 +163,15 @@ drake_cc_library(
 
 # Miscellaneous utilities.
 
+DRAKE_RESOURCE_SENTINEL = "//:.drake-resource-sentinel"
+
 drake_cc_library(
     name = "find_resource",
     srcs = ["find_resource.cc"],
     hdrs = ["find_resource.h"],
+    data = [
+        DRAKE_RESOURCE_SENTINEL,
+    ],
     deps = [
         ":common",
         "//drake/thirdParty:spruce",
@@ -181,7 +186,7 @@ drake_cc_library(
     srcs = ["drake_path_bazel.cc"],
     hdrs = ["drake_path.h"],
     data = [
-        "//:.drake-resource-sentinel",
+        DRAKE_RESOURCE_SENTINEL,
     ],
     deps = [
         ":common",


### PR DESCRIPTION
If we place the looked-for file in the sandbox (instead of relying on an undeclared `WORKSPACE` dependency), then the "start at CWD and crawl up through its parents" rule will immediately succeed in the sandbox (since CWD has the sentinel), and will also work out of the sandbox from anywhere at or within `drake-distro`.

This is a feature-neutral refactoring. This preparation for other commits on https://github.com/jwnimmer-tri/drake/tree/build-drakepath. Relates #5893.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6288)
<!-- Reviewable:end -->
