### PR TITLE
Increase implicit_euler_integrator_test size to medium

### DIFF
--- a/drake/systems/analysis/test/CMakeLists.txt
+++ b/drake/systems/analysis/test/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(explicit_euler_integrator_test
         drakeSystemAnalysis drakeSystemFramework drakeCommon
         drakeSpringMassSystemPlant)
 
-drake_add_cc_test(implicit_euler_integrator_test)
+drake_add_cc_test(NAME implicit_euler_integrator_test SIZE medium)
 target_link_libraries(implicit_euler_integrator_test
         drakeSystemAnalysis drakeSystemFramework drakeCommon
         drakeSpringMassSystemPlant)


### PR DESCRIPTION
It times out on the linux-gcc-ros-debug CI jobs.

For example, 

https://drake-jenkins.csail.mit.edu/job/linux-gcc-continuous-ros-debug/1723/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-gcc-nightly-ros-debug/318/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6289)
<!-- Reviewable:end -->
