### PR TITLE
Add resource_tool helper program

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -2,7 +2,13 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_binary",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
+load("//tools:python_lint.bzl", "python_lint")
 load("@protobuf//:protobuf.bzl", "cc_proto_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -339,6 +345,16 @@ drake_cc_library(
     hdrs = ["protobuf.h"],
     deps = [
         "@protobuf",
+    ],
+)
+
+drake_cc_binary(
+    name = "resource_tool",
+    srcs = ["resource_tool.cc"],
+    deps = [
+        ":common",
+        ":find_resource",
+        ":text_logging_gflags",
     ],
 )
 
@@ -795,6 +811,16 @@ drake_cc_googletest(
     ],
 )
 
+py_test(
+    name = "resource_tool_test",
+    srcs = ["test/resource_tool_test.py"],
+    data = [
+        "test/resource_tool_test_data.txt",
+        ":resource_tool",
+        "//drake/examples/Pendulum:models",
+    ],
+)
+
 # TODO(jwnimmer-tri) These tests are currently missing...
 # - drake_assert_test in fancy variants
 # - drake_assert_test_compile in fancy variants
@@ -803,3 +829,4 @@ drake_cc_googletest(
 # - cpplint_wrapper_test.py
 
 cpplint()
+python_lint()

--- a/drake/common/resource_tool.cc
+++ b/drake/common/resource_tool.cc
@@ -1,0 +1,46 @@
+#include <iostream>
+
+#include <gflags/gflags.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/text_logging_gflags.h"
+
+DEFINE_string(
+    print_resource_path, "",
+    "Given the relative path of a resource within Drake, e.g., "
+    "`drake/examples/Pendulum/Pendulum.urdf`, "
+    "find the resource and print its absolute path, e.g., "
+    "`/home/user/tmp/drake/examples/Pendulum/Pendulum.urdf`");
+
+namespace drake {
+namespace {
+
+int main(int argc, char* argv[]) {
+  gflags::SetUsageMessage("Find Drake-related resources");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  logging::HandleSpdlogGflags();
+
+  if (FLAGS_print_resource_path.empty()) {
+    gflags::ShowUsageWithFlags(argv[0]);
+    return 1;
+  }
+
+  const FindResourceResult& result = FindResource(FLAGS_print_resource_path);
+  if (result.get_absolute_path()) {
+    std::cout << *result.get_absolute_path()
+              << "\n";
+    return 0;
+  }
+
+  std::cerr << "resource_tool: "
+            << result.get_error_message().value()
+            << "\n";
+  return 1;
+}
+
+}  // namespace
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  return drake::main(argc, argv);
+}

--- a/drake/common/test/resource_tool_test.py
+++ b/drake/common/test/resource_tool_test.py
@@ -1,0 +1,82 @@
+"""Performs simple within-sandbox tests for resource_tool, exercising its
+command-line API through all corner cases.
+"""
+
+import re
+import subprocess
+import os
+import unittest
+
+
+class TestResourceTool(unittest.TestCase):
+    def _check_call(self, args, expected_returncode=0):
+        """Run resource_tool with the given args; return output.
+        """
+        try:
+            output = subprocess.check_output(
+                ["drake/common/resource_tool"] + args,
+                stderr=subprocess.STDOUT)
+            returncode = 0
+        except subprocess.CalledProcessError as e:
+            output = e.output
+            returncode = e.returncode
+        self.assertEqual(
+            returncode, expected_returncode,
+            "Expected returncode %r from %r but got %r with output %r" % (
+                expected_returncode, args, returncode, output))
+        return output
+
+    def test_help(self):
+        output = self._check_call([
+            "--help",
+            ], expected_returncode=1)
+        self.assertTrue("Find Drake-related resources" in output)
+        self.assertGreater(len(output), 1000)
+
+    def test_no_arguments(self):
+        output = self._check_call([], expected_returncode=1)
+        self.assertGreater(len(output), 1000)
+
+    def test_print_resource_path_found(self):
+        output = self._check_call([
+             "--print_resource_path",
+             "drake/common/test/resource_tool_test_data.txt",
+            ], expected_returncode=0)
+        absolute_path = output.strip()
+        with open(absolute_path, 'r') as data:
+            self.assertEqual(
+                data.read(),
+                "Test data for drake/common/test/resource_tool_test.py.\n")
+
+    def test_print_resource_path_error(self):
+        output = self._check_call([
+            "--print_resource_path",
+            "drake/no_such_file",
+            ], expected_returncode=1)
+        self.assertTrue("could not find resource" in output)
+
+    def test_help_example_is_correct(self):
+        # Look at the usage message, and snarf its Pendulum example paths.
+        output = self._check_call([
+            "--help",
+            ], expected_returncode=1)
+        output = output.replace("\n", " ")
+        m = re.search(
+            (r"-print_resource_path.*`(drake.*)`.*" +
+             r"absolute path.*?`/home/user/tmp/(drake/.*)`"),
+            output)
+        self.assertTrue(m is not None, "Could not match in " + repr(output))
+        example_relpath, example_abspath = m.groups()
+
+        # Ask for the help message's example and make sure it still works.
+        output = self._check_call([
+            "--print_resource_path",
+            example_relpath,
+            ], expected_returncode=0)
+        absolute_path = output.strip()
+        self.assertTrue(absolute_path.endswith(example_abspath))
+        self.assertTrue(os.path.exists(absolute_path))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/drake/common/test/resource_tool_test_data.txt
+++ b/drake/common/test/resource_tool_test_data.txt
@@ -1,0 +1,1 @@
+Test data for drake/common/test/resource_tool_test.py.


### PR DESCRIPTION
What: Given the relative path of a resource within Drake, e.g.,  `drake/examples/Pendulum/Pendulum.urdf`, find the resource and print its absolute path, e.g., `/home/user/tmp/drake/examples/Pendulum/Pendulum.urdf`.

Why: By exporting `FindResource` as a standalone program, we'll be able to write acceptance tests for its logic in a wide variety of magical situations, beyond what is easy or possible in a `drake_cc_googletest`.

Future related commits are at https://github.com/jwnimmer-tri/drake/tree/build-drakepath. Relates #5893.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6290)
<!-- Reviewable:end -->
