### PR TITLE
Add bazel install rules for tinyobjloader and yaml_cpp

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -48,5 +48,7 @@ install(
         "@pybind11//:install",
         "@robotlocomotion_lcmtypes//:install",
         "@spdlog//:install",
+        "@tinyobjloader//:install",
+        "@yaml_cpp//:install",
     ],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -92,6 +92,8 @@ exports_create_cps_scripts([
     "nlopt",
     "pybind11",
     "spdlog",
+    "tinyobjloader",
+    "yaml_cpp",
 ])
 
 exports_files(

--- a/tools/tinyobjloader-create-cps.py
+++ b/tools/tinyobjloader-create-cps.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+from cpsutils import read_version_defs
+
+defs = read_version_defs("set\(TINYOBJLOADER_VERSION\s+([0-9]+).([0-9]+).([0-9]+)")
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "tinyobjloader",
+  "Description": "Tiny but powerful single file wavefront obj loader",
+  "License": "MIT",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
+  "Compat-Version": "%(VERSION_MAJOR)s.0.0",
+  "Default-Components": [ ":tinyobjloader" ],
+  "Components": {
+    "tinyobjloader": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libtinyobjloader.so",
+      "Includes": [ "@prefix@/include/tinyobjloader" ]
+    }
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/tinyobjloader.BUILD
+++ b/tools/tinyobjloader.BUILD
@@ -1,6 +1,11 @@
 # -*- python -*-
 
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
 
 cc_library(
     name = "tinyobjloader",
@@ -11,8 +16,25 @@ cc_library(
         "tiny_obj_loader.h",
     ],
     includes = ["."],
-    linkstatic = 1,
-    visibility = ["//visibility:public"],
+    linkstatic = 0,
+)
+
+cmake_config(
+    package = "tinyobjloader",
+    script = "@drake//tools:tinyobjloader-create-cps.py",
+    version_file = "CMakeLists.txt",
+)
+
+install_cmake_config(package = "tinyobjloader")  # Creates rule :install_cmake_config.
+
+install(
+    name = "install",
+    doc_dest = "share/doc/tinyobjloader",
+    guess_hdrs = "PACKAGE",
+    hdr_dest = "include/tinyobjloader",
+    license_docs = ["LICENSE"],
+    targets = [":tinyobjloader"],
+    deps = [":install_cmake_config"],
 )
 
 pkg_tar(
@@ -21,5 +43,4 @@ pkg_tar(
     files = ["LICENSE"],
     mode = "0644",
     package_dir = "tinyobjloader",
-    visibility = ["//visibility:public"],
 )

--- a/tools/yaml_cpp-create-cps.py
+++ b/tools/yaml_cpp-create-cps.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+from cpsutils import read_defs
+
+defs = read_defs("set\(YAML_CPP_(VERSION_.*)\s+\"([0-9]+)\"")
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "yaml-cpp",
+  "Description": "A YAML parser and emitter in C++",
+  "License": "MIT",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_MINOR)s",
+  "Compat-Version": "%(VERSION_MAJOR)s.0.0",
+  "Default-Components": [ ":yaml-cpp" ],
+  "Components": {
+    "yaml-cpp": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libyaml_cpp.so",
+      "Includes": [ "@prefix@/include" ]
+    }
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/yaml_cpp.BUILD
+++ b/tools/yaml_cpp.BUILD
@@ -1,5 +1,9 @@
 # -*- python -*-
 
+load("@drake//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
+
+package(default_visibility = ["//visibility:public"])
+
 cc_library(
     name = "yaml_cpp",
     srcs = glob([
@@ -10,5 +14,23 @@ cc_library(
         "include/**/*.h",
     ]),
     includes = ["include"],
-    visibility = ["//visibility:public"],
+)
+
+cmake_config(
+    package = "yaml-cpp",
+    script = "@drake//tools:yaml_cpp-create-cps.py",
+    version_file = "CMakeLists.txt",
+)
+
+install_cmake_config(package = "yaml-cpp")  # Creates rule :install_cmake_config.
+
+install(
+    name = "install",
+    doc_dest = "share/doc/yaml-cpp",
+    guess_hdrs = "PACKAGE",
+    hdr_dest = "include",
+    hdr_strip_prefix = ["include"],
+    license_docs = ["LICENSE"],
+    targets = [":yaml_cpp"],
+    deps = [":install_cmake_config"],
 )


### PR DESCRIPTION
Toward #3129.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6291)
<!-- Reviewable:end -->
