### PR TITLE
Increasing Bazel Timeouts For Valgrind

### DIFF
--- a/drake/common/trajectories/BUILD
+++ b/drake/common/trajectories/BUILD
@@ -85,6 +85,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "piecewise_generation_test",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     srcs = ["test/piecewise_polynomial_generation_test.cc"],
     deps = [
         ":piecewise_polynomial",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -677,9 +677,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "system_identification_test",
     # The test takes ~20 sec in opt mode but ~140 sec in dbg mode.
-    # To avoid timeouts in dbg or valgrind, we need "moderate" here.
-    # TODO(bazelbuild/bazel#1748) This produces a spurious complaint.
-    timeout = "moderate",
+    # To avoid timeouts in dbg and valgrind, we need "large" here.
+    size = "large",
     deps = [
         ":system_identification",
         "//drake/common:eigen_matrix_compare",

--- a/drake/systems/analysis/BUILD
+++ b/drake/systems/analysis/BUILD
@@ -179,6 +179,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "implicit_euler_integrator_test",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     deps = [
         ":discontinuous_spring_mass_damper_system",
         ":implicit_euler_integrator",
@@ -199,6 +201,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "runge_kutta3_integrator_test",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     deps = [
         ":my_spring_mass_system",
         ":runge_kutta3_integrator",
@@ -211,6 +215,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "semi_explicit_euler_integrator_test",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     deps = [
         ":explicit_euler_integrator",
         ":my_spring_mass_system",

--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -46,6 +46,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "trajectory_optimization_test",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     deps = [
         ":direct_collocation",
         "//drake/common:eigen_matrix_compare",


### PR DESCRIPTION
Consider:
https://drake-jenkins.csail.mit.edu/view/Valgrind/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/28/console

Now all these tests have the same size across Bazel and CMake.  Note that `piecewise_generation_test` in Bazel is named `piecewise_polynomial_generation_test` in CMake.

Ref: https://github.com/RobotLocomotion/drake/issues/3662

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6292)
<!-- Reviewable:end -->
