### PR TITLE
Add cpplint tests to multibody/multibody_tree/math

### DIFF
--- a/drake/multibody/multibody_tree/math/BUILD
+++ b/drake/multibody/multibody_tree/math/BUILD
@@ -1,6 +1,7 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
+load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
     "drake_cc_googletest",
@@ -60,3 +61,5 @@ drake_cc_googletest(
         "//drake/common:autodiff",
     ],
 )
+
+cpplint()


### PR DESCRIPTION
Adds the missing cpplint tests to the `BUILD` for `multibody/multibody_tree/math`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6297)
<!-- Reviewable:end -->
