### PR TITLE
Make check_missing_sources work again

### DIFF
--- a/tools/dev/check_missing_sources.sh
+++ b/tools/dev/check_missing_sources.sh
@@ -4,13 +4,13 @@ set -e
 
 # Files in git.
 git ls-files |
-    egrep '\.(h|cc)$' |
+    egrep '\.(h|cc|hpp|cpp)$' |
     sort > /tmp/git_files.txt
 
 # Files covered by cc_ something.
-bazel query 'kind("source file", deps(kind("cc_.* rule", //... except //externals/...)))' |
+bazel query 'kind("source file", deps(kind("cc_.* rule", //...)))' |
     grep -v '^@' | grep -v '^//externals' | grep -v '/thirdParty' |
-    egrep '\.(h|cc)$' |
+    egrep '\.(h|cc|hpp|cpp)$' |
     perl -pe 's#^//:?##g; s#:#/#g;' |
     sort > /tmp/cc_files.txt
 


### PR DESCRIPTION
I'm not sure exactly when it broke, but I'm not adding a test because of `dev` and this script will die soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6301)
<!-- Reviewable:end -->
