### PR TITLE
Add cpplint() to source files missing checks

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/BUILD
@@ -96,3 +96,5 @@ drake_cc_library(
         "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",
     ],
 )
+
+cpplint()

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/BUILD
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/BUILD
@@ -28,3 +28,5 @@ drake_cc_binary(
         "@com_github_gflags_gflags//:gflags",
     ],
 )
+
+cpplint()

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD
@@ -49,3 +49,5 @@ drake_cc_binary(
 )
 
 # === test/ ===
+
+cpplint()

--- a/drake/examples/kuka_iiwa_arm/pick_and_place/BUILD
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/BUILD
@@ -43,3 +43,5 @@ drake_cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+cpplint()

--- a/drake/manipulation/planner/BUILD
+++ b/drake/manipulation/planner/BUILD
@@ -42,3 +42,5 @@ drake_cc_googletest(
         ":constraint_relaxing_ik",
     ],
 )
+
+cpplint()

--- a/drake/manipulation/util/BUILD
+++ b/drake/manipulation/util/BUILD
@@ -64,3 +64,5 @@ drake_cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+cpplint()

--- a/tools/dev/add_cpplint.py
+++ b/tools/dev/add_cpplint.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+import re
+import sys, os
+import subprocess
+from multiprocessing import Process, Array
+
+"""
+Iterate through scripts that are not covered by cpplint, and ensure that they
+are properly covered.
+"""
+
+def subshell(cmd, shell=True, strip=True):
+    output = subprocess.check_output(cmd, shell=shell)
+    if strip:
+        output = output.strip()
+    return output
+
+class FileProcessor(object):
+    def __init__(self):
+        # Files processed
+        self.build_files = set()
+
+    def ensure_source_covered(self, source_file):
+        print "Ensure source covered: {}".format(source_file)
+        build_file = (subshell("bazel query --output location {}"
+                               .format(source_file))
+                      .split(':')[0])
+        self.ensure_cpplint(build_file)
+
+    def ensure_cpplint(self, build_file):
+        print "  Check build file: {}".format(build_file)
+        if build_file in self.build_files:
+            print "   Already covered"
+            return
+        with open(build_file) as f:
+            text = f.read()
+        # Not robust, but hoping it's mentioned
+        if "cpplint()" not in text:
+            text = text.rstrip() + "\n\ncpplint()\n"
+            with open(build_file, 'w') as f:
+                f.write(text)
+            print "    Updated file"
+        else:
+            print "    cpplint() already present"
+        self.build_files.add(build_file)
+
+def do_main():
+    workspace = subshell("bazel info workspace").strip()
+    os.chdir(workspace)
+
+    subshell("./tools/dev/check_missing_sources.sh")
+    files_missed = (
+        subshell(r'diff -u /tmp/cc_files.txt /tmp/cpplint_files.txt'
+                 + r' | grep "^-\w" | sed "s#^\-##g"')
+        .strip().split('\n'))
+
+    file_proc = FileProcessor()
+    for source_file in files_missed:
+        file_proc.ensure_source_covered(source_file)
+
+if __name__ == "__main__":
+    do_main()

--- a/tools/dev/check_missing_sources.sh
+++ b/tools/dev/check_missing_sources.sh
@@ -8,7 +8,7 @@ git ls-files |
     sort > /tmp/git_files.txt
 
 # Files covered by cc_ something.
-bazel query 'kind("source file", deps(kind("cc_.* rule", //...)))' |
+bazel query 'kind("source file", deps(kind("cc_.* rule", //... except //externals/...)))' |
     grep -v '^@' | grep -v '^//externals' | grep -v '/thirdParty' |
     egrep '\.(h|cc|hpp|cpp)$' |
     perl -pe 's#^//:?##g; s#:#/#g;' |
@@ -17,7 +17,7 @@ bazel query 'kind("source file", deps(kind("cc_.* rule", //...)))' |
 # Files covered by cpplint.
 bazel query 'kind("source file", deps(attr(tags, cpplint, tests(//...))))' |
     grep -v '^@' | grep -v '^//externals' | grep -v '/thirdParty' |
-    egrep '\.(h|cc)$' |
+    egrep '\.(h|cc|hpp|cpp)$' |
     perl -pe 's#^//:?##g; s#:#/#g;'|
     sort > /tmp/cpplint_files.txt
 


### PR DESCRIPTION
Added `cpplint()` to source files. Had to revert a portion of #6301 as it broke on my machine, but it ended up working.
Made a quick script because I'm lazy. Can be thrown away if `check_missing_sources.sh` is to be done away with.

One file is left (the lift test), possibly because it is disabled dependent on the configuration:
```
Ensure source covered: drake/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
  Check build file: .../drake-distro/master/drake/examples/schunk_wsg/BUILD
    cpplint() already present
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6304)
<!-- Reviewable:end -->
