### PR TITLE
Add doxygen.py tool to generate Doxygen output

### DIFF
--- a/drake/doc/Doxyfile_CXX.in
+++ b/drake/doc/Doxyfile_CXX.in
@@ -320,7 +320,7 @@ GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES
-PERL_PATH              = "@PERL_EXECUTABLE@"
+PERL_PATH              =
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------

--- a/drake/doc/documentation_instructions.rst
+++ b/drake/doc/documentation_instructions.rst
@@ -20,8 +20,7 @@ uses `Sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_.
 When using Bazel
 ================
 
-At the moment, only the website (Sphinx) documentation is supported via the
-Bazel build::
+To generate the website (Sphinx) documentation::
 
     $ bazel run //drake/doc:serve_sphinx
 
@@ -32,6 +31,14 @@ To merely compile the website into ``bazel-genfiles/drake/doc/sphinx.zip``
 without launching a preview::
 
     $ bazel build //drake/doc:sphinx.zip
+
+To generate the Doxygen documentation::
+
+    $ cd drake-distro
+    $ drake/doc/doxygen.py [--quick]
+
+To view the generated documentation, open using a web browser to
+``drake-distro/build/drake/doc/doxygen_cxx/html/index.html``
 
 .. _documentation-generation-instructions-cmake:
 

--- a/drake/doc/doxygen.py
+++ b/drake/doc/doxygen.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+"""Command-line tool to generate Drake's Doxygen content.
+
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+from collections import OrderedDict
+from os.path import dirname
+
+def _get_drake_distro():
+    """Find and return the path to drake-distro."""
+
+    result = dirname(dirname(dirname(os.path.abspath(sys.argv[0]))))
+    if not os.path.exists(os.path.join(result, "WORKSPACE")):
+        raise RuntimeError("Could not place drake-distro at " + result)
+    return result
+
+def _run_doxygen(args):
+    # Find our programs.
+    doxygen = subprocess.check_output(["which", "doxygen"]).strip()
+    dot = subprocess.check_output(["which", "dot"]).strip()
+
+    # Compute the definitions dict needed by Doxygen_CXX.in.
+    drake_distro = _get_drake_distro()
+    binary_dir = os.path.join(drake_distro, "build/drake/doc")
+    if not os.path.exists(binary_dir):
+        os.makedirs(binary_dir)
+    definitions = OrderedDict()
+    definitions["drake_SOURCE_DIR"] = os.path.join(drake_distro, "drake")
+    definitions["drake_BINARY_DIR"] = os.path.join(drake_distro, "build/drake")
+    definitions["CMAKE_CURRENT_BINARY_DIR"] = binary_dir
+    if args.quick:
+        definitions["DOXYGEN_DOT_FOUND"] = "NO"
+        definitions["DOXYGEN_DOT_EXECUTABLE"] = ""
+    else:
+        definitions["DOXYGEN_DOT_FOUND"] = "YES"
+        definitions["DOXYGEN_DOT_EXECUTABLE"] = dot
+    definition_args = ["-D%s=%s" % (key, value)
+                       for key, value in definitions.iteritems()]
+
+    # Create Doxyfile_CXX.
+    in_filename = os.path.join(drake_distro, "drake/doc/Doxyfile_CXX.in")
+    doxyfile = os.path.join(drake_distro, "build/drake/doc/Doxyfile_CXX")
+    subprocess.check_call(
+        [os.path.join(
+            _get_drake_distro(), "tools/cmake_configure_file.py"),
+         "--input", in_filename,
+         "--output", doxyfile,
+         ] + definition_args)
+    assert os.path.exists(doxyfile)
+
+    # Run Doxygen.
+    print "Building C++ Doxygen documentation...",
+    sys.stdout.flush()
+    subprocess.check_call([doxygen, doxyfile], cwd=binary_dir)
+    print "done"
+    print "See file://%s/doxygen_cxx/html/index.html" % binary_dir
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__.strip())
+    parser.add_argument(
+        '--quick', action='store_true', default=False,
+        help="Disable slow features (e.g., all graphs)")
+    args = parser.parse_args()
+    _run_doxygen(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/cmake_configure_file.py
+++ b/tools/cmake_configure_file.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 _cmakedefine = re.compile(r'^#cmakedefine(01)? ([^ \r\n]+)(.*?)([\r\n]+)')
 
 # Looks like "@VAR@" or "${VAR}".
-_varsubst = re.compile(r'^(.*?)(@.+?@|\$\{.+?\})(.*)([\r\n]*)')
+_varsubst = re.compile(r'^(.*?)(@[^ ]+?@|\$\{[^ ]+?\})(.*)([\r\n]*)')
 
 
 # Transform a source code line per CMake's configure_file semantics.


### PR DESCRIPTION
Resolves #5814.  Relates #5881.

Ideas for future improvements:
- Flags to process only certain subdirectories.
- Check for errors in the output log.
- Port `drake/doc/CMakeLists.txt` to call this instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6306)
<!-- Reviewable:end -->
