### PR TITLE
RgbdCamera: Enable depth peeling and FXAA

### DIFF
--- a/drake/systems/sensors/rgbd_camera.cc
+++ b/drake/systems/sensors/rgbd_camera.cc
@@ -364,6 +364,12 @@ RgbdCamera::Impl::Impl(const RigidBodyTree<double>& tree,
     renderer->SetBackground(sky_color.r, sky_color.g, sky_color.b);
   }
 
+#if ((VTK_MAJOR_VERSION == 7) && (VTK_MINOR_VERSION >= 1)) || \
+    (VTK_MAJOR_VERSION >= 8)
+  color_depth_renderer_->SetUseDepthPeeling(1);
+  color_depth_renderer_->UseFXAAOn();
+#endif
+
   const auto windows = MakeVtkInstanceArray<vtkRenderWindow>(
       color_depth_render_window_, label_render_window_);
   for (size_t i = 0; i < windows.size(); ++i) {


### PR DESCRIPTION
This is to address #6295.

I found that this PR doesn't solve the [unit test failure](https://github.com/kunimatsu-tri/drake/blob/master/drake/systems/sensors/test/rgbd_camera_test.cc#L466).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6312)
<!-- Reviewable:end -->
