### PR TITLE
Increase size of yaml_to_obj_test

### DIFF
--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -70,7 +70,7 @@ drake_cc_googletest(
 
 py_test(
     name = "yaml_to_obj_test",
-    size = "small",
+    size = "medium",
     srcs = ["test/yaml_to_obj_test.py"],
     args = ["drake/automotive/maliput/utility/yaml_to_obj"],
     data = [


### PR DESCRIPTION
The last few days, this test has been sporadically timing out on the CI Bazel Debug jobs. It seems to have started happening with PR #6304. See: 

https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-everything-debug/713/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-gcc-bazel-continuous-debug/1029/

Current examples of failure:
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-gcc-bazel-nightly-debug/199/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-gcc-bazel-nightly-everything-debug/122/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6318)
<!-- Reviewable:end -->
