### PR TITLE
Let tools/drake_visualizer work outside the sandbox

### DIFF
--- a/drake/automotive/README.md
+++ b/drake/automotive/README.md
@@ -84,7 +84,7 @@ To run `car_sim_lcm`, open a new terminal and execute the following commands:
 ```
 $ cd drake-distro
 $ bazel build drake/automotive:demo drake/automotive:car_sim_lcm
-$ bazel-bin/external/drake_visualizer/drake-visualizer &
+$ bazel-bin/tools/drake_visualizer &
 $ bazel-bin/drake/automotive/steering_command_driver &
 $ bazel run drake/automotive:car_sim_lcm
 ```

--- a/drake/systems/sensors/test/accelerometer_test/README.md
+++ b/drake/systems/sensors/test/accelerometer_test/README.md
@@ -9,5 +9,6 @@ To run a demo of an accelerometer attached to a pendulum:
 # When building Drake using Bazel
 
     cd drake-distro
-    bazel-bin/external/drake_visualizer/drake-visualizer &
+    bazel build //tools:drake_visualizer
+    bazel-bin/tools/drake_visualizer &
     bazel run -- //drake/systems/sensors:accelerometer_example --initial_q=1.57 --initial_v=0

--- a/tools/drake_visualizer_linux.sh
+++ b/tools/drake_visualizer_linux.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+set -e
+
+# If we are outside the sandbox, then change to the same relative directory as
+# we would be inside the sandbox.
+if ! [ -d "external/director" ]; then
+    guess_runfiles=$(dirname "$0")/drake_visualizer.runfiles/drake
+    if [ -d "$guess_runfiles/external/director" ]; then
+        cd "$guess_runfiles"
+    else
+        echo "$(basename $0) error: could not find director" 1>&2
+        exit 1
+    fi
+fi
+
 export LD_LIBRARY_PATH="external/director/lib:external/vtk/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export PYTHONPATH="external/director/lib/python2.7/dist-packages:external/vtk/lib/python2.7/site-packages${PYTHONPATH:+:$PYTHONPATH}"
 


### PR DESCRIPTION
This fixes a few loose ends from #6259:
- Let tools/drake_visualizer work outside the sandbox
- Tidy up drake-visualizer launching in READMEs

All three of these methods have been tested to work:
```
bazel build //tools:drake_visualizer && ./bazel-bin/tools/drake_visualizer 
bazel run //tools:drake_visualizer 
bazel run //drake/automotive:demo
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6319)
<!-- Reviewable:end -->
