### PR TITLE
Adding bazel install rules for gflags

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,6 +49,7 @@ install(
         ":install_net_sf_jchart2d_jchart2d",
         "//drake:install",
         "//tools:install",
+        "//tools/install/gflags:install",
         "@bot_core_lcmtypes//:install",
         "@bullet//:install",
         "@ccd//:install",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,7 @@ github_archive(
     build_file = "tools/gtest.BUILD",
 )
 
+# When updating the version of gflags, update tools/install/gflags/gflags.cps
 github_archive(
     name = "com_github_gflags_gflags",
     repository = "gflags/gflags",

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -399,7 +399,13 @@ def exports_create_cps_scripts(packages):
         )
 
 #------------------------------------------------------------------------------
-def cmake_config(package, script=None, version_file=None, deps=[]):
+def cmake_config(
+    package,
+    script = None,
+    version_file = None,
+    cps_file_name = None,
+    deps = []
+    ):
     """Create CMake package configuration and package version files via an
     intermediate CPS file.
 
@@ -411,6 +417,10 @@ def cmake_config(package, script=None, version_file=None, deps=[]):
     """
 
     if script and version_file:
+        if cps_file_name:
+            fail("cps_file_name should not be set if"
+                + " script and version_file are set."
+            )
         native.py_binary(
             name = "create-cps",
             srcs = [script],
@@ -429,7 +439,7 @@ def cmake_config(package, script=None, version_file=None, deps=[]):
             tools = [":create-cps"],
             visibility = ["//visibility:public"],
         )
-    else:
+    elif not cps_file_name:
         cps_file_name = "@drake//tools:{}.cps".format(package)
 
     config_file_name = "{}Config.cmake".format(package)
@@ -455,7 +465,11 @@ def cmake_config(package, script=None, version_file=None, deps=[]):
     )
 
 #------------------------------------------------------------------------------
-def install_cmake_config(package, versioned=True):
+def install_cmake_config(
+    package,
+    versioned = True,
+    name = "install_cmake_config"
+    ):
     """Generate installation information for CMake package configuration and
     package version files. The rule name is always ``:install_cmake_config``.
 
@@ -470,7 +484,7 @@ def install_cmake_config(package, versioned=True):
         cmake_config_files += ["{}ConfigVersion.cmake".format(package)]
 
     install_files(
-        name = "install_cmake_config",
+        name = name,
         dest = cmake_config_dest,
         files = cmake_config_files,
         visibility = ["//visibility:private"],

--- a/tools/install/gflags/BUILD
+++ b/tools/install/gflags/BUILD
@@ -1,0 +1,29 @@
+# -*- python -*-
+
+load("//tools:install.bzl", "cmake_config", "install", "install_cmake_config")
+
+package(default_visibility = ["//visibility:public"])
+
+cmake_config(
+    cps_file_name = "gflags.cps",
+    package = "gflags",
+)
+
+install_cmake_config(package = "gflags")  # Creates rule :install_cmake_config.
+
+install(
+    name = "install",
+    allowed_externals = ["@com_github_gflags_gflags//:gflags"],
+    doc_dest = "share/doc/gflags",
+    guess_hdrs = "PACKAGE",
+    guess_hdrs_exclude = [
+        "config.h",
+        "src/mutex.h",
+        "src/util.h",
+    ],
+    hdr_dest = "include",
+    hdr_strip_prefix = ["include"],
+    license_docs = ["@com_github_gflags_gflags//:COPYING.txt"],
+    targets = ["@com_github_gflags_gflags//:gflags"],
+    deps = [":install_cmake_config"],
+)

--- a/tools/install/gflags/gflags.cps
+++ b/tools/install/gflags/gflags.cps
@@ -1,0 +1,15 @@
+{
+  "Cps-Version": "0.8.0",
+  "Name": "gflags",
+  "Description": "A C++ library that implements command line flag processing",
+  "License": "BSD-3-Clause",
+  "Version": "2.2.0",
+  "Default-Components": [":gflags"],
+  "Components": {
+    "gflags": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libgflags.so",
+      "Includes": ["@prefix@/include"]
+    }
+  }
+}

--- a/tools/pathutils.bzl
+++ b/tools/pathutils.bzl
@@ -118,7 +118,7 @@ def join_paths(*args):
     return result[:-1]
 
 #------------------------------------------------------------------------------
-def output_path(ctx, input_file, strip_prefix):
+def output_path(ctx, input_file, strip_prefix, package_root = None):
     """Compute "output path".
 
     This computes the adjusted output path for an input file. Specifically, it
@@ -144,6 +144,9 @@ def output_path(ctx, input_file, strip_prefix):
     the prefix ``foo``, giving a path of ``bar.txt``, which will become
     ``docs/bar.txt`` when the install destination is added.
 
+    The input file must belong to the current package; otherwise, ``None`` is
+    returned.
+
     Args:
         input_file (:obj:`File`): Artifact to be installed.
         strip_prefix (:obj:`list` of :obj:`str`): List of prefixes to strip
@@ -153,8 +156,9 @@ def output_path(ctx, input_file, strip_prefix):
         :obj:`str`: The install destination path for the file.
     """
 
-    # Determine base path of invoking context.
-    package_root = join_paths(ctx.label.workspace_root, ctx.label.package)
+    if package_root == None:
+        # Determine base path of invoking context.
+        package_root = join_paths(ctx.label.workspace_root, ctx.label.package)
 
     # Determine effective path by removing path of invoking context and any
     # Bazel output-files path.
@@ -167,9 +171,7 @@ def output_path(ctx, input_file, strip_prefix):
 
     # Deal with possible case of file outside the package root.
     if input_path == None:
-        print("%s installing file %s which is not in current package"
-              % (package_root, input_file.path))
-        return input_file.basename
+        return None
 
     # Possibly remove prefixes.
     for p in strip_prefix:


### PR DESCRIPTION
Installing files from an external project generates warning messages (install.bzl).
Warning messages are currently silenced in bazel.rc until install.bzl is updated.

Toward #3129.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6323)
<!-- Reviewable:end -->
