### PR TITLE
Ignoring lcm_driven_loop_test For Some Sanitizers

### DIFF
--- a/drake/systems/lcm/BUILD
+++ b/drake/systems/lcm/BUILD
@@ -71,6 +71,11 @@ drake_cc_googletest(
     name = "lcm_driven_loop_test",
     # TODO(jamiesnape, siyuanfeng-tri): Remove flaky flag, see #5936.
     flaky = 1,
+    tags = [
+        "no_asan",
+        "no_memcheck",
+        "no_tsan",
+    ],
     deps = [
         "//drake/common:eigen_matrix_compare",
         "//drake/lcm",


### PR DESCRIPTION
Valgrind:
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/31/consoleText

ASan:
https://drake-jenkins.csail.mit.edu/job/linux-xenial-gcc-bazel-nightly-memcheck-asan/33/consoleText

TSan:
It has been failing with CTest:
https://drake-jenkins.csail.mit.edu/job/linux-clang-nightly-memcheck-tsan/477/consoleText

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6327)
<!-- Reviewable:end -->
