### PR TITLE
Increase unit test tolerance for mac builds (#6208 patch)

### DIFF
--- a/drake/multibody/multibody_tree/test/double_pendulum_test.cc
+++ b/drake/multibody/multibody_tree/test/double_pendulum_test.cc
@@ -450,8 +450,8 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
       EXPECT_EQ(elbow_mobilizer_->get_angle(*context_), elbow_angle);
 
       // Verify this matches the corresponding entries in the context.
-      EXPECT_NEAR(mbt_context_->get_positions()(0), shoulder_angle, kEpsilon);
-      EXPECT_NEAR(mbt_context_->get_positions()(1), elbow_angle, kEpsilon);
+      EXPECT_EQ(mbt_context_->get_positions()(0), shoulder_angle);
+      EXPECT_EQ(mbt_context_->get_positions()(1), elbow_angle);
 
       model_->CalcPositionKinematicsCache(*context_, &pc);
 

--- a/drake/multibody/multibody_tree/test/double_pendulum_test.cc
+++ b/drake/multibody/multibody_tree/test/double_pendulum_test.cc
@@ -420,7 +420,7 @@ class PendulumKinematicTests : public PendulumTests {
 TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
   // This is the minimum factor of the machine precision within which these
   // tests pass.
-  const int kEpsilonFactor = 2;
+  const int kEpsilonFactor = 3;
   const double kEpsilon =
       kEpsilonFactor * std::numeric_limits<double>::epsilon();
 


### PR DESCRIPTION
The unit test `PendulumKinematicTests::CalcPositionKinematics` from `double_pendulum_test.cc` (introduced in #6208) is failing in mac clang builds.
The problem is solved by a small increase of the tolerance used for floating point comparisons within this unit test. Tested in `macsim`.

Thanks @siyuanfeng-tri for finding this out and @soonho-tri and @jwnimmer-tri for helping with `macsim`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6334)
<!-- Reviewable:end -->
