### PR TITLE
Missing lib for bazel built drake_visualizer.

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -87,6 +87,7 @@ libmpfr-dev
 libpng12-dev
 libqt4-dev
 libqt4-opengl-dev
+libqt5multimedia5
 libqt5opengl5-dev
 libqt5x11extras5
 libqwt-dev


### PR DESCRIPTION
In testing the bazel built drake_visualizer
```bash
bazel build //tools:drake_visualizer && ./bazel-bin/tools/drake_visualizer
```
I received the error:
```
INFO: Running command line: bazel-bin/tools/drake_visualizer
external/director/bin/drake-visualizer: error while loading shared libraries: libQt5Multimedia.so.5: cannot open shared object file: No such file or directory
ERROR: Non-zero return code '127' from command: Process exited with status 127.
```
This was alleviated by adding libqt5multimedia5 to the package list in `setup/ubuntu/16.04/install_prereqs.sh`. This is following on from #6259 #6319 and should be blocking for my pending docker PR #6196 so that pretty visualizations are possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6342)
<!-- Reviewable:end -->
