### PR TITLE
Increasing Timeout For dragway_test

### DIFF
--- a/drake/automotive/maliput/dragway/BUILD
+++ b/drake/automotive/maliput/dragway/BUILD
@@ -47,7 +47,8 @@ drake_cc_binary(
 
 drake_cc_googletest(
     name = "dragway_test",
-    size = "small",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     srcs = ["test/dragway_test.cc"],
     deps = [
         ":dragway",


### PR DESCRIPTION
`dragway_test` times out sometimes when run with Valgrind.
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/35/consoleText

It timed out once in the last three `linux-xenial-clang-bazel-nightly-memcheck-valgrind` builds.
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6346)
<!-- Reviewable:end -->
