### PR TITLE
Add installation of resource files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,15 +31,6 @@ alias(
     actual = "@protobuf//:protobuf_python",
 )
 
-# TODO(jwnimmer-tri) The install.bzl should do this automatically, based on the
-# runfiles of //drake/common/resource_tool.  For now, we'll backfill manually.
-install_files(
-    name = "install_resource_tool_data",
-    dest = "share/drake",
-    files = [".drake-resource-sentinel"],
-    visibility = ["//drake/common:__pkg__"],
-)
-
 install(
     name = "install_net_sf_jchart2d_jchart2d",
     doc_dest = "share/doc/jchart2d",

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -367,7 +367,9 @@ install(
     # manually.
     runtime_dest = "libexec/drake/drake/common",
     targets = [":resource_tool"],
-    deps = ["//:install_resource_tool_data"],
+    data_dest = "share/drake",
+    guess_data = "WORKSPACE",
+    allowed_externals = [DRAKE_RESOURCE_SENTINEL],
 )
 
 # === test/ ===


### PR DESCRIPTION
Add support for resource files, including guessing the same, to the Bazel install framework. Use this to install the resource tool tag file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6347)
<!-- Reviewable:end -->
