### PR TITLE
Improve color image rendering speed

### DIFF
--- a/drake/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/drake/systems/sensors/image_to_lcm_image_array_t.cc
@@ -70,7 +70,7 @@ ImageToLcmImageArrayT::ImageToLcmImageArrayT(const string& color_frame_name,
       depth_frame_name_(depth_frame_name),
       label_frame_name_(label_frame_name) {
   color_image_input_port_index_ =
-      DeclareAbstractInputPort(systems::Value<ImageBgra8U>()).get_index();
+      DeclareAbstractInputPort(systems::Value<ImageRgba8U>()).get_index();
 
   depth_image_input_port_index_ =
       DeclareAbstractInputPort(systems::Value<ImageDepth32F>()).get_index();
@@ -105,9 +105,9 @@ ImageToLcmImageArrayT::image_array_t_msg_output_port() const {
 
 void ImageToLcmImageArrayT::CalcImageArray(
     const systems::Context<double>& context, image_array_t* msg) const {
-  const ImageBgra8U& color_image =
+  const ImageRgba8U& color_image =
       this->EvalAbstractInput(context, color_image_input_port_index_)
-          ->GetValue<ImageBgra8U>();
+          ->GetValue<ImageRgba8U>();
 
   const ImageDepth32F& depth_image =
       this->EvalAbstractInput(context, depth_image_input_port_index_)
@@ -121,7 +121,7 @@ void ImageToLcmImageArrayT::CalcImageArray(
       static_cast<int64_t>(context.get_time() * kSecToMillisec);
 
   image_t color_image_msg;
-  PackImageToLcmImageT(color_image, utime, image_t::PIXEL_FORMAT_BGRA,
+  PackImageToLcmImageT(color_image, utime, image_t::PIXEL_FORMAT_RGBA,
                        image_t::CHANNEL_TYPE_UINT8, color_frame_name_,
                        &color_image_msg);
 

--- a/drake/systems/sensors/rgbd_camera.h
+++ b/drake/systems/sensors/rgbd_camera.h
@@ -189,8 +189,8 @@ class RgbdCamera : public LeafSystem<double> {
   /// the RigidBodyTree.
   const InputPortDescriptor<double>& state_input_port() const;
 
-  /// Returns the abstract valued output port that contains a BGRA image of the
-  /// type ImageBgra8U.
+  /// Returns the abstract valued output port that contains a RGBA image of the
+  /// type ImageRgba8U.
   const OutputPort<double>& color_image_output_port() const;
 
   /// Returns the abstract valued output port that contains an ImageDepth32F.
@@ -208,7 +208,7 @@ class RgbdCamera : public LeafSystem<double> {
 
   // These are the calculator methods for the four output ports.
   void OutputColorImage(const Context<double>& context,
-                        ImageBgra8U* color_image) const;
+                        ImageRgba8U* color_image) const;
   void OutputDepthImage(const Context<double>& context,
                         ImageDepth32F* depth_image) const;
   void OutputLabelImage(const Context<double>& context,

--- a/drake/systems/sensors/test/image_to_lcm_image_array_t_test.cc
+++ b/drake/systems/sensors/test/image_to_lcm_image_array_t_test.cc
@@ -19,7 +19,7 @@ const int kImageWidth = 8;
 const int kImageHeight = 6;
 
 robotlocomotion::image_array_t SetUpInputAndOutput(
-    ImageToLcmImageArrayT* dut, const ImageBgra8U& color_image,
+    ImageToLcmImageArrayT* dut, const ImageRgba8U& color_image,
     const ImageDepth32F& depth_image, const ImageLabel16I& label_image) {
   const InputPortDescriptor<double>& color_image_input_port =
       dut->color_image_input_port();
@@ -28,7 +28,7 @@ robotlocomotion::image_array_t SetUpInputAndOutput(
   const InputPortDescriptor<double>& label_image_input_port =
       dut->label_image_input_port();
 
-  auto color_image_value = std::make_unique<Value<ImageBgra8U>>(color_image);
+  auto color_image_value = std::make_unique<Value<ImageRgba8U>>(color_image);
   auto depth_image_value = std::make_unique<Value<ImageDepth32F>>(depth_image);
   auto label_image_value = std::make_unique<Value<ImageLabel16I>>(label_image);
 
@@ -52,7 +52,7 @@ robotlocomotion::image_array_t SetUpInputAndOutput(
 
 
 GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
-  ImageBgra8U color_image(kImageWidth, kImageHeight);
+  ImageRgba8U color_image(kImageWidth, kImageHeight);
   ImageDepth32F depth_image(kImageWidth, kImageHeight);
   ImageLabel16I label_image(kImageWidth, kImageHeight);
 
@@ -93,7 +93,7 @@ GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
         frame_name = kColorFrameName;
         row_stride = color_image.width() * color_image.kNumChannels *
             sizeof(*color_image.at(0, 0));
-        pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_BGRA;
+        pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_RGBA;
         channel_type = robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
         break;
       }

--- a/drake/systems/sensors/test/rgbd_camera_test.cc
+++ b/drake/systems/sensors/test/rgbd_camera_test.cc
@@ -156,7 +156,7 @@ class RenderingSim : public systems::Diagram<double> {
 
 // TODO(kunimatsu-tri) Remove this once the arbitrary terrain color support
 // is added.
-const std::array<uint8_t, 4> kTerrainColor{{204u, 229u, 255u, 255u}};
+const std::array<uint8_t, 4> kTerrainColor{{255u, 229u, 204u, 255u}};
 
 const int kWidth = 640;
 const int kHeight = 480;
@@ -178,11 +178,11 @@ UV kCorners[4] = {
 class ImageTest : public ::testing::Test {
  public:
   typedef std::function<void(
-      const sensors::ImageBgra8U& color_image,
+      const sensors::ImageRgba8U& color_image,
       const sensors::ImageDepth32F& depth_image)> ImageVerifier;
 
   typedef std::function<void(
-      const sensors::ImageBgra8U& color_image,
+      const sensors::ImageRgba8U& color_image,
       const sensors::ImageDepth32F& depth_image,
       int horizon)> ImageHorizonVerifier;
 
@@ -193,7 +193,7 @@ class ImageTest : public ::testing::Test {
     diagram_->CalcOutput(*context_, output_.get());
 
     auto color_image = output_->GetMutableData(0)->GetMutableValue<
-      sensors::ImageBgra8U>();
+      sensors::ImageRgba8U>();
     auto depth_image = output_->GetMutableData(1)->GetMutableValue<
       sensors::ImageDepth32F>();
 
@@ -210,7 +210,7 @@ class ImageTest : public ::testing::Test {
 
   void VerifyPoseUpdate(ImageHorizonVerifier verifier) {
     auto& color_image = output_->GetMutableData(0)->GetMutableValue<
-      sensors::ImageBgra8U>();
+      sensors::ImageRgba8U>();
     auto& depth_image = output_->GetMutableData(1)->GetMutableValue<
       sensors::ImageDepth32F>();
     VectorBase<double>* cstate =
@@ -279,7 +279,7 @@ class ImageTest : public ::testing::Test {
   }
 
   static void VerifyUniformColorAndDepth(
-      const sensors::ImageBgra8U& color_image,
+      const sensors::ImageRgba8U& color_image,
       const sensors::ImageDepth32F& depth_image,
       const std::array<uint8_t, 4>& color, float depth) {
     // Verifies by sampling 32 x 24 points instead of 640 x 480 points. The
@@ -296,14 +296,14 @@ class ImageTest : public ::testing::Test {
     }
   }
 
-  static void VerifyTerrain(const sensors::ImageBgra8U& color_image,
+  static void VerifyTerrain(const sensors::ImageRgba8U& color_image,
                             const sensors::ImageDepth32F& depth_image) {
     VerifyUniformColorAndDepth(color_image, depth_image,
                                kTerrainColor, 4.999f);
   }
 
   static void VerifyBox(
-      const sensors::ImageBgra8U& color_image,
+      const sensors::ImageRgba8U& color_image,
       const sensors::ImageDepth32F& depth_image) {
     // This is given by the material diffuse element in `box.sdf`.
     const std::array<uint8_t, 4> kPixelColor{{255u, 255u, 255u, 255u}};
@@ -311,22 +311,22 @@ class ImageTest : public ::testing::Test {
   }
 
   static void VerifyCylinder(
-      const sensors::ImageBgra8U& color_image,
+      const sensors::ImageRgba8U& color_image,
       const sensors::ImageDepth32F& depth_image) {
     // This is given by the material diffuse element in `cylinder.sdf`.
     const std::array<uint8_t, 4> kPixelColor{{255u, 0u, 255u, 255u}};
     VerifyUniformColorAndDepth(color_image, depth_image, kPixelColor, 1.f);
   }
 
-  static void VerifyMeshBox(const sensors::ImageBgra8U& color_image,
+  static void VerifyMeshBox(const sensors::ImageRgba8U& color_image,
                             const sensors::ImageDepth32F& depth_image) {
     // This is given by `box.png` which is the texture file for `box.obj`.
-    const std::array<uint8_t, 4> kPixelColor{{33u, 241u, 4u, 255u}};
+    const std::array<uint8_t, 4> kPixelColor{{4u, 241u, 33u, 255u}};
     VerifyUniformColorAndDepth(color_image, depth_image, kPixelColor, 1.f);
   }
 
   // Verifies the color and depth of the image at the center and four corners.
-  static void VerifySphere(const sensors::ImageBgra8U& color_image,
+  static void VerifySphere(const sensors::ImageRgba8U& color_image,
                            const sensors::ImageDepth32F& depth_image) {
     // Verifies the four corner points.
 
@@ -357,7 +357,7 @@ class ImageTest : public ::testing::Test {
   }
 
   // Verifies the color and depth of the image at the two visuals (boxes).
-  static void VerifyMultipleVisuals(const sensors::ImageBgra8U& color_image,
+  static void VerifyMultipleVisuals(const sensors::ImageRgba8U& color_image,
                                     const sensors::ImageDepth32F& depth_image) {
     // Verifies the four corner points.
     for (const auto& corner : kCorners) {
@@ -384,7 +384,7 @@ class ImageTest : public ::testing::Test {
                 3.999f, kDepthTolerance);
   }
 
-  static void VerifyMovingCamera(const sensors::ImageBgra8U& color_image,
+  static void VerifyMovingCamera(const sensors::ImageRgba8U& color_image,
                                  const sensors::ImageDepth32F& depth_image,
                                  int expected_horizon) {
     // TODO(jamiesnape): Is depth_image actually needed?

--- a/tools/vtk.bzl
+++ b/tools/vtk.bzl
@@ -361,6 +361,7 @@ def _impl(repository_ctx):
 
     file_content += _vtk_cc_library(repository_ctx.os.name, "vtkIOImage",
         hdrs = [
+            "vtkImageExport.h",
             "vtkImageReader2.h",
             "vtkIOImageModule.h",
             "vtkPNGReader.h",


### PR DESCRIPTION
This PR improves color image (not depth nor label image) rendering speed from 130 ms to 80 ms on my local environment. The rest of 80 ms is mostly consumed during VTK rendering process.

[CAUTION] RgbdCamera now outputs ImageRgba8U instead of ImageBgra8U

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6361)
<!-- Reviewable:end -->
