### PR TITLE
Minor changes to inverse dynamics controller.

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/manipulator_inverse_dynamics_controller_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/manipulator_inverse_dynamics_controller_test.cc
@@ -74,7 +74,7 @@ class ManipulatorInverseDynamicsControllerTest : public ::testing::Test {
     params_->LookupDesiredDofMotionGains(&kp, &kd);
     auto vanilla_id_controller =
         builder.AddSystem<systems::InverseDynamicsController>(
-            kModelPath, nullptr, kp, VectorX<double>::Zero(7), kd, true);
+            std::move(robot), kp, VectorX<double>::Zero(7), kd, true);
     vanilla_id_controller->set_name("vanilla_id_controller");
 
     // Estimated state source.

--- a/drake/examples/kinova_jaco_arm/run_controlled_jaco_demo.cc
+++ b/drake/examples/kinova_jaco_arm/run_controlled_jaco_demo.cc
@@ -183,7 +183,7 @@ int DoMain() {
   VectorX<double> jaco_kp, jaco_kd, jaco_ki;
   SetPositionControlledJacoGains(&jaco_kp, &jaco_ki, &jaco_kd);
   auto control_sys = make_unique<systems::InverseDynamicsController<double>>(
-      kUrdfPath, nullptr, jaco_kp, jaco_ki, jaco_kd,
+      plant->get_rigid_body_tree().Clone(), jaco_kp, jaco_ki, jaco_kd,
       false /* no feedforward acceleration */);
   auto controller =
       builder.AddSystem<systems::InverseDynamicsController<double>>(

--- a/drake/examples/kinova_jaco_arm/run_setpose_jaco_demo.cc
+++ b/drake/examples/kinova_jaco_arm/run_setpose_jaco_demo.cc
@@ -57,7 +57,7 @@ int DoMain() {
   SetPositionControlledJacoGains(&jaco_kp, &jaco_ki, &jaco_kd);
   auto control_sys =
       std::make_unique<systems::InverseDynamicsController<double>>(
-          kUrdfPath, nullptr, jaco_kp, jaco_ki, jaco_kd,
+          plant->get_rigid_body_tree().Clone(), jaco_kp, jaco_ki, jaco_kd,
           false /* no feedforward acceleration */);
   auto controller =
       builder.AddSystem<systems::InverseDynamicsController<double>>(

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_demo.cc
@@ -149,16 +149,17 @@ int DoMain() {
   drake::lcm::DrakeLcm lcm;
   SimDiagramBuilder<double> builder;
   // Adds a plant
-  builder.AddPlant(std::move(tree));
+  auto plant = builder.AddPlant(std::move(tree));
   builder.AddVisualizer(&lcm);
 
   // Adds a iiwa controller
   VectorX<double> iiwa_kp, iiwa_kd, iiwa_ki;
   SetPositionControlledIiwaGains(&iiwa_kp, &iiwa_ki, &iiwa_kd);
+
   auto controller =
       builder.AddController<systems::InverseDynamicsController<double>>(
           RigidBodyTreeConstants::kFirstNonWorldModelInstanceId,
-          GetDrakePath() + kUrdfPath, nullptr, iiwa_kp, iiwa_ki, iiwa_kd,
+          plant->get_rigid_body_tree().Clone(), iiwa_kp, iiwa_ki, iiwa_kd,
           false /* no feedforward acceleration */);
 
   // Adds a trajectory source for desired state.

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.cc
@@ -59,9 +59,14 @@ IiwaAndWsgPlantWithStateEstimator<T>::IiwaAndWsgPlantWithStateEstimator(
 
   // Exposing feedforward acceleration. Should help with more dynamic
   // motions.
+  auto single_arm = std::make_unique<RigidBodyTree<double>>();
+  parsers::urdf::AddModelInstanceFromUrdfFile(
+      iiwa_info.model_path, multibody::joints::kFixed, iiwa_info.world_offset,
+      single_arm.get());
+
   iiwa_controller_ =
       builder.template AddController<systems::InverseDynamicsController<T>>(
-          iiwa_info.instance_id, iiwa_info.model_path, iiwa_info.world_offset,
+          iiwa_info.instance_id, std::move(single_arm),
           iiwa_kp, iiwa_ki, iiwa_kd, true /* with feedforward acceleration */);
   iiwa_controller_->set_name("IIWAInverseDynamicsController");
 

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -92,7 +92,7 @@ int DoMain() {
   auto controller =
       builder.AddController<systems::InverseDynamicsController<double>>(
           RigidBodyTreeConstants::kFirstNonWorldModelInstanceId,
-          urdf, nullptr, iiwa_kp, iiwa_ki, iiwa_kd,
+          tree.Clone(), iiwa_kp, iiwa_ki, iiwa_kd,
           false /* without feedforward acceleration */);
 
   // Create the command subscriber and status publisher.

--- a/drake/examples/kuka_iiwa_arm/test/sim_diagram_builder_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/sim_diagram_builder_test.cc
@@ -6,6 +6,7 @@
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_world/world_sim_tree_builder.h"
+#include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/controllers/inverse_dynamics_controller.h"
@@ -89,10 +90,15 @@ GTEST_TEST(SimDiagramBuilderTest, TestSimulation) {
   SetPositionControlledIiwaGains(&iiwa_kp, &iiwa_ki, &iiwa_kd);
 
   for (const auto& info : iiwa_info) {
+    auto single_arm = std::make_unique<RigidBodyTree<double>>();
+    parsers::urdf::AddModelInstanceFromUrdfFile(
+        info.model_path, multibody::joints::kFixed, info.world_offset,
+        single_arm.get());
+
     auto controller =
         builder
             .template AddController<systems::InverseDynamicsController<double>>(
-                info.instance_id, info.model_path, info.world_offset, iiwa_kp,
+                info.instance_id, std::move(single_arm), iiwa_kp,
                 iiwa_ki, iiwa_kd, false /* no feedforward acceleration */);
     controller->set_name("controller_" + std::to_string(info.instance_id));
 

--- a/drake/systems/controllers/BUILD
+++ b/drake/systems/controllers/BUILD
@@ -34,7 +34,6 @@ drake_cc_library(
         ":pid_controller",
         ":state_feedback_controller_interface",
         "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/parsers",
         "//drake/systems/framework",
         "//drake/systems/primitives:adder",
         "//drake/systems/primitives:constant_vector_source",

--- a/drake/systems/controllers/CMakeLists.txt
+++ b/drake/systems/controllers/CMakeLists.txt
@@ -89,7 +89,6 @@ add_library_with_exports(LIB_NAME drakeSystemControllers
     SOURCE_FILES ${system2_sources} ${system2_installed_headers})
 target_link_libraries(drakeSystemControllers
     drakeCommon
-    drakeMultibodyParsers
     drakeRBM
     drakeSystemFramework
     drakeSystemPrimitives)

--- a/drake/systems/controllers/inverse_dynamics.cc
+++ b/drake/systems/controllers/inverse_dynamics.cc
@@ -71,7 +71,7 @@ void InverseDynamics<T>::CalcOutputTorque(const Context<T>& context,
 }
 
 template class InverseDynamics<double>;
-// TODO(siyuan): some linking issue on mac.
+// TODO(siyuan) template on autodiff.
 // template class InverseDynamics<AutoDiffXd>;
 
 }  // namespace systems

--- a/drake/systems/controllers/inverse_dynamics.h
+++ b/drake/systems/controllers/inverse_dynamics.h
@@ -24,6 +24,11 @@ namespace systems {
  * InverseDynamicsController uses a PID controller to generate desired
  * acceleration and uses this class to compute torque. This class should be used
  * directly if desired acceleration is computed differently.
+ *
+ * @tparam T The vector element type, which must be a valid Eigen scalar.
+ *
+ * Instantiated templates for the following kinds of T's are provided:
+ * - double
  */
 template <typename T>
 class InverseDynamics : public LeafSystem<T> {

--- a/drake/systems/controllers/inverse_dynamics_controller.cc
+++ b/drake/systems/controllers/inverse_dynamics_controller.cc
@@ -3,7 +3,6 @@
 #include <memory>
 #include <utility>
 
-#include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/systems/controllers/inverse_dynamics.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/adder.h"
@@ -15,9 +14,9 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-void InverseDynamicsController<T>::SetUp(const VectorX<T>& kp,
-                                         const VectorX<T>& ki,
-                                         const VectorX<T>& kd) {
+void InverseDynamicsController<T>::SetUp(const VectorX<double>& kp,
+                                         const VectorX<double>& ki,
+                                         const VectorX<double>& kd) {
   DiagramBuilder<T> builder;
   this->set_name("InverseDynamicsController");
 
@@ -84,7 +83,7 @@ void InverseDynamicsController<T>::SetUp(const VectorX<T>& kp,
   if (!has_reference_acceleration_) {
     // Uses a zero constant source for reference acceleration.
     auto zero_feedforward_acceleration =
-        builder.template AddSystem<ConstantVectorSource<double>>(
+        builder.template AddSystem<ConstantVectorSource<T>>(
             VectorX<T>::Zero(robot.get_num_velocities()));
     zero_feedforward_acceleration->set_name("zero");
     builder.Connect(zero_feedforward_acceleration->get_output_port(),
@@ -112,36 +111,16 @@ void InverseDynamicsController<T>::set_integral_value(
 
 template <typename T>
 InverseDynamicsController<T>::InverseDynamicsController(
-    const std::string& model_path,
-    std::shared_ptr<RigidBodyFrame<double>> world_offset, const VectorX<T>& kp,
-    const VectorX<T>& ki, const VectorX<T>& kd, bool has_reference_acceleration)
-    : has_reference_acceleration_(has_reference_acceleration) {
-  robot_for_control_ = std::make_unique<RigidBodyTree<T>>();
-  parsers::urdf::AddModelInstanceFromUrdfFile(
-        model_path, multibody::joints::kFixed, world_offset,
-        robot_for_control_.get());
-  SetUp(kp, ki, kd);
-}
-
-template <typename T>
-InverseDynamicsController<T>::InverseDynamicsController(
-    const RigidBodyTree<T>& robot, const VectorX<T>& kp, const VectorX<T>& ki,
-    const VectorX<T>& kd, bool has_reference_acceleration)
-    : has_reference_acceleration_(has_reference_acceleration) {
-  robot_for_control_ = robot.Clone();
-  SetUp(kp, ki, kd);
-}
-
-template <typename T>
-InverseDynamicsController<T>::InverseDynamicsController(
-    std::unique_ptr<RigidBodyTree<T>> robot, const VectorX<T>& kp,
-    const VectorX<T>& ki, const VectorX<T>& kd, bool has_reference_acceleration)
+    std::unique_ptr<RigidBodyTree<T>> robot, const VectorX<double>& kp,
+    const VectorX<double>& ki, const VectorX<double>& kd,
+    bool has_reference_acceleration)
     : has_reference_acceleration_(has_reference_acceleration) {
   robot_for_control_ = std::move(robot);
   SetUp(kp, ki, kd);
 }
 
 template class InverseDynamicsController<double>;
+template class InverseDynamicsController<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/controllers/inverse_dynamics_controller.cc
+++ b/drake/systems/controllers/inverse_dynamics_controller.cc
@@ -120,7 +120,8 @@ InverseDynamicsController<T>::InverseDynamicsController(
 }
 
 template class InverseDynamicsController<double>;
-template class InverseDynamicsController<AutoDiffXd>;
+// TODO(siyuan) template on autodiff.
+// template class InverseDynamicsController<AutoDiffXd>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/controllers/inverse_dynamics_controller.h
+++ b/drake/systems/controllers/inverse_dynamics_controller.h
@@ -32,45 +32,18 @@ namespace systems {
  * and velocity have the same dimension, it does not have a floating base.
  * If violated, the program will abort. It is discouraged to use this controller
  * for robots with closed kinematic loops.
+ *
+ * Instantiated templates for the following kinds of T's are provided:
+ * - double
+ * - AutoDiffXd
+ *
+ * @ingroup control_systems
  */
 template <typename T>
 class InverseDynamicsController : public StateFeedbackControllerInterface<T>,
                                   public Diagram<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InverseDynamicsController)
-
-  /**
-   * Constructs the controller that instantiates a RigidBodyTree directly
-   * from a model file. Assumes the model is connected to the world with a
-   * multibody::joints::kFixed joint.
-   * @param model_path Path to the model file.
-   * @param world_offset X_WB, where B is the base frame of the model.
-   * @param kp Position gain
-   * @param ki Integral gain
-   * @param kd Velocity gain
-   * @param has_reference_acceleration If true, there is an extra BasicVector
-   * input port for `vd*`. If false, `vd*` is treated as zero, and no extra
-   * input port is declared.
-   */
-  InverseDynamicsController(
-      const std::string& model_path,
-      std::shared_ptr<RigidBodyFrame<double>> world_offset,
-      const VectorX<T>& kp, const VectorX<T>& ki, const VectorX<T>& kd,
-      bool has_reference_acceleration);
-
-  /**
-   * Constructs the controller that clones a given RigidBodyTree.
-   * @param robot Reference to the RigidBodyTree to be cloned.
-   * @param kp Position gain
-   * @param ki Integral gain
-   * @param kd Velocity gain
-   * @param has_reference_acceleration If true, there is an extra BasicVector
-   * input port for `vd*`. If false, `vd*` is treated as zero, and no extra
-   * input port is declared.
-   */
-  InverseDynamicsController(const RigidBodyTree<T>& robot, const VectorX<T>& kp,
-                            const VectorX<T>& ki, const VectorX<T>& kd,
-                            bool has_reference_acceleration);
 
   /**
    * Constructs the controller that takes ownership of a given RigidBodyTree
@@ -85,8 +58,9 @@ class InverseDynamicsController : public StateFeedbackControllerInterface<T>,
    * input port is declared.
    */
   InverseDynamicsController(std::unique_ptr<RigidBodyTree<T>> robot,
-                            const VectorX<T>& kp, const VectorX<T>& ki,
-                            const VectorX<T>& kd,
+                            const VectorX<double>& kp,
+                            const VectorX<double>& ki,
+                            const VectorX<double>& kd,
                             bool has_reference_acceleration);
 
   /**
@@ -134,7 +108,8 @@ class InverseDynamicsController : public StateFeedbackControllerInterface<T>,
   }
 
  private:
-  void SetUp(const VectorX<T>& kp, const VectorX<T>& ki, const VectorX<T>& kd);
+  void SetUp(const VectorX<double>& kp,
+      const VectorX<double>& ki, const VectorX<double>& kd);
 
   std::unique_ptr<RigidBodyTree<T>> robot_for_control_{nullptr};
   PidController<T>* pid_{nullptr};

--- a/drake/systems/controllers/inverse_dynamics_controller.h
+++ b/drake/systems/controllers/inverse_dynamics_controller.h
@@ -33,9 +33,10 @@ namespace systems {
  * If violated, the program will abort. It is discouraged to use this controller
  * for robots with closed kinematic loops.
  *
+ * @tparam T The vector element type, which must be a valid Eigen scalar.
+ *
  * Instantiated templates for the following kinds of T's are provided:
  * - double
- * - AutoDiffXd
  *
  * @ingroup control_systems
  */

--- a/drake/systems/controllers/pid_controller.h
+++ b/drake/systems/controllers/pid_controller.h
@@ -30,6 +30,15 @@ namespace systems {
  * Note that this class assumes |q| = |v|, and |q_d| = |v_d|. Also |q| >= |q_d|.
  * The user can specify a selection matrix that picks the *controlled* states
  * from (q, v) for feedback. See constructor documentations for more details.
+ *
+ * @tparam T The vector element type, which must be a valid Eigen scalar.
+ *
+ * Instantiated templates for the following kinds of T's are provided:
+ * - double
+ * - AutoDiffXd
+ * - symbolic::Expression
+ *
+ * @ingroup control_systems
  */
 template <typename T>
 class PidController : public StateFeedbackControllerInterface<T>,

--- a/drake/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/drake/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -38,13 +38,13 @@ VectorX<double> ComputeTorque(const RigidBodyTree<double>& tree,
 // derived results for the kuka iiwa arm at a given state (q, v), when
 // asked to track reference state (q_r, v_r) and reference acceleration (vd_r).
 GTEST_TEST(InverseDynamicsControllerTest, TestTorque) {
-  auto robot = std::make_unique<RigidBodyTree<double>>();
+  auto robot_ptr = std::make_unique<RigidBodyTree<double>>();
   drake::parsers::urdf::AddModelInstanceFromUrdfFile(
       drake::GetDrakePath() + "/manipulation/models/iiwa_description/urdf/"
           "iiwa14_primitive_collision.urdf",
       drake::multibody::joints::kFixed, nullptr /* weld to frame */,
-      robot.get());
-  const int dim = robot->get_num_positions();
+      robot_ptr.get());
+  const int dim = robot_ptr->get_num_positions();
 
   // Sets pid gains.
   VectorX<double> kp(dim), ki(dim), kd(dim);
@@ -52,10 +52,11 @@ GTEST_TEST(InverseDynamicsControllerTest, TestTorque) {
   ki << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7;
   kd = kp / 2.;
 
-  auto dut = std::make_unique<InverseDynamicsController<double>>(*robot, kp, ki,
-                                                                 kd, true);
+  auto dut = std::make_unique<InverseDynamicsController<double>>(
+      std::move(robot_ptr), kp, ki, kd, true);
   auto context = dut->CreateDefaultContext();
   auto output = dut->AllocateOutput(*context);
+  const RigidBodyTree<double>& robot = dut->get_robot_for_control();
 
   // Sets current state and reference state and acceleration values.
   VectorX<double> q(dim), v(dim), q_r(dim), v_r(dim), vd_r(dim);
@@ -68,15 +69,15 @@ GTEST_TEST(InverseDynamicsControllerTest, TestTorque) {
 
   // Connects inputs.
   auto state_input = std::make_unique<BasicVector<double>>(
-      robot->get_num_positions() + robot->get_num_velocities());
+      robot.get_num_positions() + robot.get_num_velocities());
   state_input->get_mutable_value() << q, v;
 
   auto reference_state_input = std::make_unique<BasicVector<double>>(
-      robot->get_num_positions() + robot->get_num_velocities());
+      robot.get_num_positions() + robot.get_num_velocities());
   reference_state_input->get_mutable_value() << q_r, v_r;
 
   auto reference_acceleration_input =
-      std::make_unique<BasicVector<double>>(robot->get_num_velocities());
+      std::make_unique<BasicVector<double>>(robot.get_num_velocities());
   reference_acceleration_input->get_mutable_value() << vd_r;
 
   context->FixInputPort(dut->get_input_port_estimated_state().get_index(),
@@ -99,7 +100,7 @@ GTEST_TEST(InverseDynamicsControllerTest, TestTorque) {
                          (kd.array() * (v_r - v).array()).matrix() +
                          (ki.array() * q_int.array()).matrix() + vd_r;
 
-  VectorX<double> expected_torque = ComputeTorque(*robot, q, v, vd_d);
+  VectorX<double> expected_torque = ComputeTorque(robot, q, v, vd_d);
 
   // Checks the expected and computed gravity torque.
   const BasicVector<double>* output_vector = output->get_vector_data(0);


### PR DESCRIPTION
Attempted to template InverseDynamicsController / InverseDynamics on AutoDiffXd, but didn't quite make it all the way due to RigidBodyTree can't template on AutoDiffXd. This PR mostly removed RBT parsing from InverseDynamicsController constructors to call sites.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6363)
<!-- Reviewable:end -->
