### PR TITLE
Use new macros for drakeConfig.cmake

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,6 +1,11 @@
 # -*- python -*-
 
-load("//tools:install.bzl", "exports_create_cps_scripts", "install_files")
+load(
+    "//tools:install.bzl",
+    "cmake_config",
+    "exports_create_cps_scripts",
+    "install_cmake_config",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -141,19 +146,16 @@ alias(
     actual = "@com_github_bazelbuild_buildtools//buildifier",
 )
 
-genrule(
-    name = "cmake_exports",
-    srcs = ["drake.cps"],
-    outs = ["drake-config.cmake"],
-    cmd = "$(location @pycps//:cps2cmake_executable) $(location drake.cps) > \"$@\"",
-    tools = ["@pycps//:cps2cmake_executable"],
-    visibility = ["//visibility:private"],
+cmake_config(
+    cps_file_name = "drake.cps",
+    package = "drake",
 )
 
-install_files(
+install_cmake_config(
     name = "install",
-    dest = "lib/cmake/drake",
-    files = ["drake-config.cmake"],
+    package = "drake",
+    versioned = 0,
+    visibility = ["//visibility:public"],
 )
 
 # === CROSSTOOL rules ===

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -468,7 +468,8 @@ def cmake_config(
 def install_cmake_config(
     package,
     versioned = True,
-    name = "install_cmake_config"
+    name = "install_cmake_config",
+    visibility = ["//visibility:private"]
     ):
     """Generate installation information for CMake package configuration and
     package version files. The rule name is always ``:install_cmake_config``.
@@ -487,7 +488,7 @@ def install_cmake_config(
         name = name,
         dest = cmake_config_dest,
         files = cmake_config_files,
-        visibility = ["//visibility:private"],
+        visibility = visibility,
     )
 
 #END macros


### PR DESCRIPTION
Use the new macros for generating and installing Drake's CMake configuration file. This is more consistent with externals (and also happens to get rid of an overly long line).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6364)
<!-- Reviewable:end -->
