### PR TITLE
Remove spurious MultibodyTree forward declaration that was messing with doxygen

### DIFF
--- a/drake/multibody/multibody_tree/revolute_mobilizer.h
+++ b/drake/multibody/multibody_tree/revolute_mobilizer.h
@@ -9,9 +9,6 @@
 #include "drake/multibody/multibody_tree/multibody_tree_topology.h"
 #include "drake/systems/framework/context.h"
 
-// Forward declarations.
-template <typename T> class MultibodyTree;
-
 namespace drake {
 namespace multibody {
 


### PR DESCRIPTION
Fixes #6372.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6375)
<!-- Reviewable:end -->
