### PR TITLE
De-duplicate install actions

### DIFF
--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -217,7 +217,17 @@ def _install_impl(ctx):
             actions += _install_py_actions(ctx, t)
 
     # Generate code for install actions.
-    script_actions = [_install_code(a) for a in actions]
+    script_actions = []
+    installed_files = {}
+    for a in actions:
+        if a.dst not in installed_files:
+            script_actions.append(_install_code(a))
+            installed_files[a.dst] = a.src
+        elif a.src != installed_files[a.dst]:
+            fail("Install conflict detected:\n" +
+                 "\n  src1 = " + repr(installed_files[a.dst]) +
+                 "\n  src2 = " + repr(a.src) +
+                 "\n  dst = " + repr(a.dst))
 
     # Generate install script.
     # TODO(mwoehlke-kitware): Figure out a better way to generate this and run


### PR DESCRIPTION
Add some minor additional logic when generating install scripts to avoid generation of duplicate install actions. Also, fail if trying to install different files to the same location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6382)
<!-- Reviewable:end -->
