### PR TITLE
Bazel style fixes

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -291,20 +291,20 @@ config_setting(
     values = {"define": "WITH_SNOPT=ON"},
 )
 
-# IPOPT is an open-source solver, and is included in the Drake build by default.
-# The IPOPT build is fragile, so we provide a hidden switch to shut it off for
-# developers who don't actually need it.  This is not a supported configuration.
-# Use at your own risk: --define=NO_IPOPT=ON
+# IPOPT is an open-source solver, and is included in the Drake build by
+# default. The IPOPT build is fragile, so we provide a hidden switch to shut it
+# off for developers who don't actually need it.  This is not a supported
+# configuration. Use at your own risk: --define=NO_IPOPT=ON
 config_setting(
     name = "no_ipopt",
     values = {"define": "NO_IPOPT=ON"},
 )
 
-# NLOPT is an open-source solver, and is included in the Drake build by default.
-# The NLOPT solver is irrelvant to some users of MathematicalProgram,
-# so we provide a hidden switch to shut it off for
-# developers who don't actually need it.  This is not a supported configuration.
-# Use at your own risk: --define=NO_NLOPT=ON
+# NLOPT is an open-source solver, and is included in the Drake build by
+# default. The NLOPT solver is irrelvant to some users of MathematicalProgram,
+# so we provide a hidden switch to shut it off for developers who don't
+# actually need it.  This is not a supported configuration. Use at your own
+# risk: --define=NO_NLOPT=ON
 config_setting(
     name = "no_nlopt",
     values = {"define": "NO_NLOPT=ON"},

--- a/tools/bitbucket.bzl
+++ b/tools/bitbucket.bzl
@@ -30,21 +30,23 @@ def bitbucket_archive(
     """
     if repository == None:
         fail("Missing repository=")
-    if commit == None :
+    if commit == None:
         fail("Missing commit=")
     if sha256 == None:
         # This is mostly-required, but we fallback to a wrong-default value to
         # allow the first attempt to fail and print the correct sha256.
         sha256 = "0" * 64
-    if strip_prefix == None :
+    if strip_prefix == None:
         fail("Missing strip_prefix=")
 
-    # Packages are mirrored from Bitbucket to CloudFront backed by an S3 bucket.
-    urls = [
-        "https://bitbucket.org/%s/get/%s.tar.gz" % (repository, commit),
-        "https://d2tbce6hkathzp.cloudfront.net/bitbucket/%s/%s.tar.gz" % (repository, commit),
-        "https://s3.amazonaws.com/drake-mirror/bitbucket/%s/%s.tar.gz" % (repository, commit),
+    # Packages are mirrored from Bitbucket to CloudFront backed by an S3
+    # bucket.
+    mirrors = [
+        "https://bitbucket.org/%s/get/%s.tar.gz",
+        "https://d2tbce6hkathzp.cloudfront.net/bitbucket/%s/%s.tar.gz",
+        "https://s3.amazonaws.com/drake-mirror/bitbucket/%s/%s.tar.gz",
     ]
+    urls = [mirror % (repository, commit) for mirror in mirrors]
 
     repository_split = repository.split("/")
     if len(repository_split) != 2:
@@ -52,16 +54,16 @@ def bitbucket_archive(
 
     if build_file == None:
         native.http_archive(
-            name=name,
-            urls=urls,
-            sha256=sha256,
-            strip_prefix=strip_prefix,
+            name = name,
+            urls = urls,
+            sha256 = sha256,
+            strip_prefix = strip_prefix,
             **kwargs)
     else:
         native.new_http_archive(
-            name=name,
-            urls=urls,
-            sha256=sha256,
-            build_file=build_file,
-            strip_prefix=strip_prefix,
+            name = name,
+            urls = urls,
+            sha256 = sha256,
+            build_file = build_file,
+            strip_prefix = strip_prefix,
             **kwargs)

--- a/tools/ccache.bzl
+++ b/tools/ccache.bzl
@@ -1,14 +1,14 @@
 # -*- python -*-
 
 def impl(ctx):
-  ctx.action(
-      outputs=[ctx.outputs.out],
-      executable=ctx.executable._script,
-      arguments=[
-        ctx.outputs.out.path
-      ],
-      use_default_shell_env=True,
-  )
+    ctx.action(
+        outputs = [ctx.outputs.out],
+        executable = ctx.executable._script,
+        arguments = [
+            ctx.outputs.out.path
+        ],
+        use_default_shell_env = True,
+    )
 
 ccache_is_bad = rule(
     attrs = {

--- a/tools/check_lists_consistency.bzl
+++ b/tools/check_lists_consistency.bzl
@@ -1,9 +1,9 @@
 # -*- python -*-
 
 def check_lists_consistency(
-        glob,
-        file_list,
-        ):
+    glob,
+    file_list,
+):
     """Checks consistency between lists of files and glob expression.
 
     If lists of files are hard-coded (e.g. public and private headers), one may
@@ -20,7 +20,7 @@ def check_lists_consistency(
         headers.
     """
     all_headers = native.glob(glob)
-    unknown_headers = [x for x in all_headers if x not in file_list ]
+    unknown_headers = [x for x in all_headers if x not in file_list]
     if len(unknown_headers) != 0:
         fail(
             "Inconsistent file lists. Unknown file(s): {}"

--- a/tools/cmake_configure_file.bzl
+++ b/tools/cmake_configure_file.bzl
@@ -40,10 +40,10 @@ _cmake_configure_file_gen = rule(
 
 def cmake_configure_file(
         name,
-        src=None,
-        out=None,
-        defines=None,
-        cmakelists=None,
+        src = None,
+        out = None,
+        defines = None,
+        cmakelists = None,
         **kwargs):
     """Creates a rule to generate an out= file from a src= file, using CMake's
     configure_file substitution semantics.  This implementation is incomplete,
@@ -64,9 +64,9 @@ def cmake_configure_file(
 
     """
     _cmake_configure_file_gen(
-        name=name,
-        src=src,
-        out=out,
-        defines=defines,
-        cmakelists=cmakelists,
+        name = name,
+        src = src,
+        out = out,
+        defines = defines,
+        cmakelists = cmakelists,
         **kwargs)

--- a/tools/cpplint.bzl
+++ b/tools/cpplint.bzl
@@ -26,85 +26,86 @@ _EXTENSIONS_ARGS = ["--extensions=" + ",".join(
 )]
 
 def _extract_labels(srcs):
-  """Convert a srcs= or hdrs= value to its set of labels."""
-  # Tuples are already labels.
-  if type(srcs) == type(()):
-    return list(srcs)
-  # The select() syntax returns an object we (apparently) can't inspect.
-  # TODO(jwnimmer-tri) Figure out how to cpplint these files.  For now,
-  # folks will have to pass extra_srcs when calling cpplint() macro.
-  return []
+    """Convert a srcs= or hdrs= value to its set of labels."""
+    # Tuples are already labels.
+    if type(srcs) == type(()):
+        return list(srcs)
+    # The select() syntax returns an object we (apparently) can't inspect.
+    # TODO(jwnimmer-tri) Figure out how to cpplint these files.  For now,
+    # folks will have to pass extra_srcs when calling cpplint() macro.
+    return []
 
 def _is_source_label(label):
-  for extension in _IGNORE_EXTENSIONS:
-      if label.endswith(extension):
-        return False
-  for extension in _SOURCE_EXTENSIONS:
-      if label.endswith(extension):
-        return True
-  return False
+    for extension in _IGNORE_EXTENSIONS:
+        if label.endswith(extension):
+            return False
+    for extension in _SOURCE_EXTENSIONS:
+        if label.endswith(extension):
+            return True
+    return False
 
-def _add_linter_rules(source_labels, source_filenames, name, data=None):
-  # Common attributes for all of our py_test invocations.
-  data = (data or [])
-  size = "small"
-  tags = ["cpplint"]
+def _add_linter_rules(source_labels, source_filenames, name, data = None):
+    # Common attributes for all of our py_test invocations.
+    data = (data or [])
+    size = "small"
+    tags = ["cpplint"]
 
-  # Google cpplint.
-  cpplint_cfg = ["//:CPPLINT.cfg"] + native.glob(['CPPLINT.cfg'])
-  native.py_test(
-    name = name + "_cpplint",
-    srcs = ["@google_styleguide//:cpplint"],
-    data = data + cpplint_cfg + source_labels,
-    args = _EXTENSIONS_ARGS + source_filenames,
-    main = "@google_styleguide//:cpplint/cpplint.py",
-    size = size,
-    tags = tags,
-  )
-
-  # Additional Drake lint.
-  native.py_test(
-    name = name + "_drake_lint",
-    srcs = ["//tools:drakelint"],
-    data = data + source_labels,
-    args = source_filenames,
-    main = "//tools:drakelint.py",
-    size = size,
-    tags = tags,
-  )
-
-def cpplint(data=None, extra_srcs=None):
-  """For every rule in the BUILD file so far, adds a test rule that runs
-  cpplint over the C++ sources listed in that rule.  Thus, BUILD file authors
-  should call this function at the *end* of every C++-related BUILD file.
-
-  By default, only the CPPLINT.cfg from the project root and the current
-  directory are used.  Additional configs can be passed in as data labels.
-
-  Sources that are not discoverable through the "sources so far" heuristic can
-  be passed in as extra_srcs=[].
-
-  """
-  # Iterate over all rules.
-  for rule in native.existing_rules().values():
-    # Extract the list of C++ source code labels and convert to filenames.
-    candidate_labels = (
-      _extract_labels(rule.get("srcs", ())) +
-      _extract_labels(rule.get("hdrs", ()))
+    # Google cpplint.
+    cpplint_cfg = ["//:CPPLINT.cfg"] + native.glob(['CPPLINT.cfg'])
+    native.py_test(
+        name = name + "_cpplint",
+        srcs = ["@google_styleguide//:cpplint"],
+        data = data + cpplint_cfg + source_labels,
+        args = _EXTENSIONS_ARGS + source_filenames,
+        main = "@google_styleguide//:cpplint/cpplint.py",
+        size = size,
+        tags = tags,
     )
-    source_labels = [
-      label for label in candidate_labels
-      if _is_source_label(label)
-    ]
-    source_filenames = ["$(location %s)" % x for x in source_labels]
 
-    # Run the cpplint checker as a unit test.
-    if len(source_filenames) > 0:
-      _add_linter_rules(source_labels, source_filenames, rule["name"], data)
+    # Additional Drake lint.
+    native.py_test(
+        name = name + "_drake_lint",
+        srcs = ["//tools:drakelint"],
+        data = data + source_labels,
+        args = source_filenames,
+        main = "//tools:drakelint.py",
+        size = size,
+        tags = tags,
+    )
 
-  # Lint all of the extra_srcs separately in a single rule.
-  if extra_srcs:
-    source_labels = extra_srcs
-    source_filenames = ["$(location %s)" % x for x in source_labels]
-    _add_linter_rules(source_labels, source_filenames,
-                      "extra_srcs_cpplint", data)
+def cpplint(data = None, extra_srcs = None):
+    """For every rule in the BUILD file so far, adds a test rule that runs
+    cpplint over the C++ sources listed in that rule.  Thus, BUILD file authors
+    should call this function at the *end* of every C++-related BUILD file.
+
+    By default, only the CPPLINT.cfg from the project root and the current
+    directory are used.  Additional configs can be passed in as data labels.
+
+    Sources that are not discoverable through the "sources so far" heuristic
+    can be passed in as extra_srcs=[].
+
+    """
+    # Iterate over all rules.
+    for rule in native.existing_rules().values():
+        # Extract the list of C++ source code labels and convert to filenames.
+        candidate_labels = (
+            _extract_labels(rule.get("srcs", ())) +
+            _extract_labels(rule.get("hdrs", ()))
+        )
+        source_labels = [
+            label for label in candidate_labels
+            if _is_source_label(label)
+        ]
+        source_filenames = ["$(location %s)" % x for x in source_labels]
+
+        # Run the cpplint checker as a unit test.
+        if len(source_filenames) > 0:
+            _add_linter_rules(source_labels, source_filenames,
+                              rule["name"], data)
+
+    # Lint all of the extra_srcs separately in a single rule.
+    if extra_srcs:
+        source_labels = extra_srcs
+        source_filenames = ["$(location %s)" % x for x in source_labels]
+        _add_linter_rules(source_labels, source_filenames,
+                          "extra_srcs_cpplint", data)

--- a/tools/director.bzl
+++ b/tools/director.bzl
@@ -4,7 +4,7 @@
 def _impl(repository_ctx):
     if repository_ctx.os.name == "mac os x":
         archive = "dd-0.1.0-160-ga50a077-qt-5.8.0-Darwin.tar.gz"
-        sha256 = "6873427eb417e03688e85ac59955777fda67f89781245f3146470c5156045691"
+        sha256 = "6873427eb417e03688e85ac59955777fda67f89781245f3146470c5156045691"  # noqa
     elif repository_ctx.os.name == "linux":
         sed = repository_ctx.which("sed")
 
@@ -20,26 +20,27 @@ def _impl(repository_ctx):
 
         if result.return_code != 0:
             fail("Could NOT determine Linux distribution information",
-                 attr=result.stderr)
+                 attr = result.stderr)
 
         distro = [l.strip() for l in result.stdout.strip().split("\n")]
         distro = " ".join(distro)
 
         if distro == "Ubuntu 14.04":
             archive = "dd-0.1.0-160-ga50a077-qt-4.8.6-trusty-x86_64.tar.gz"
-            sha256 = "7d8e5bf66648edffc8f003d0c0a19c80745cdf7b5c9a524069b041dd67c865d1"
+            sha256 = "7d8e5bf66648edffc8f003d0c0a19c80745cdf7b5c9a524069b041dd67c865d1"  # noqa
         elif distro == "Ubuntu 16.04":
             archive = "dd-0.1.0-160-ga50a077-qt-5.5.1-xenial-x86_64.tar.gz"
-            sha256 = "c4dbd896454a293c3bb65761763ce0571e83dd81b6986e1458073d88a7ef55c7"
+            sha256 = "c4dbd896454a293c3bb65761763ce0571e83dd81b6986e1458073d88a7ef55c7"  # noqa
         else:
-            fail("Linux distribution is NOT supported", attr=distro)
+            fail("Linux distribution is NOT supported", attr = distro)
     else:
-        fail("Operating system is NOT supported", attr=repository_ctx.os.name)
+        fail("Operating system is NOT supported",
+             attr = repository_ctx.os.name)
 
     url = "https://d2mbb5ninhlpdu.cloudfront.net/director/{}".format(archive)
     root_path = repository_ctx.path("")
 
-    repository_ctx.download_and_extract(url, root_path, sha256=sha256)
+    repository_ctx.download_and_extract(url, root_path, sha256 = sha256)
 
     file_content = """
 filegroup(
@@ -50,6 +51,6 @@ filegroup(
 )
 """
 
-    repository_ctx.file("BUILD", content=file_content, executable=False)
+    repository_ctx.file("BUILD", content = file_content, executable = False)
 
 director_repository = repository_rule(implementation = _impl)

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -26,7 +26,7 @@ GCC_CC_TEST_FLAGS = [
     "-Wno-unused-parameter",
 ]
 
-def _platform_copts(rule_copts, cc_test=0):
+def _platform_copts(rule_copts, cc_test = 0):
     """Returns both the rule_copts, and platform-specific copts.
 
     When cc_test=1, the GCC_CC_TEST_FLAGS will be added.  It should only be set
@@ -53,11 +53,11 @@ def _dsym_command(name):
 
 def drake_cc_library(
         name,
-        hdrs=None,
-        srcs=None,
-        deps=None,
-        copts=[],
-        linkstatic=1,
+        hdrs = None,
+        srcs = None,
+        deps = None,
+        copts = [],
+        linkstatic = 1,
         **kwargs):
     """Creates a rule to declare a C++ library.
 
@@ -66,25 +66,25 @@ def drake_cc_library(
     could be revisited if binary size becomes a concern.
     """
     native.cc_library(
-        name=name,
-        hdrs=hdrs,
-        srcs=srcs,
-        deps=deps,
-        copts=_platform_copts(copts),
-        linkstatic=linkstatic,
+        name = name,
+        hdrs = hdrs,
+        srcs = srcs,
+        deps = deps,
+        copts = _platform_copts(copts),
+        linkstatic = linkstatic,
         **kwargs)
 
 def drake_cc_binary(
         name,
-        hdrs=None,
-        srcs=None,
-        deps=None,
-        copts=[],
-        linkstatic=1,
-        testonly=0,
-        add_test_rule=0,
-        test_rule_args=[],
-        test_rule_size=None,
+        hdrs = None,
+        srcs = None,
+        deps = None,
+        copts = [],
+        linkstatic = 1,
+        testonly = 0,
+        add_test_rule = 0,
+        test_rule_args = [],
+        test_rule_size = None,
         **kwargs):
     """Creates a rule to declare a C++ binary.
 
@@ -98,46 +98,46 @@ def drake_cc_binary(
     defaults using test_rule_args=["-f", "--bar=42"] or test_rule_size="baz".
     """
     native.cc_binary(
-        name=name,
-        hdrs=hdrs,
-        srcs=srcs,
-        deps=deps,
-        copts=_platform_copts(copts),
-        testonly=testonly,
-        linkstatic=linkstatic,
+        name = name,
+        hdrs = hdrs,
+        srcs = srcs,
+        deps = deps,
+        copts = _platform_copts(copts),
+        testonly = testonly,
+        linkstatic = linkstatic,
         **kwargs)
 
     # Also generate the OS X debug symbol file for this binary.
     native.genrule(
-        name=name + "_dsym",
-        srcs=[":" + name],
-        outs=[name + ".dSYM"],
-        output_to_bindir=1,
-        testonly=testonly,
-        tags=["dsym"],
-        visibility=["//visibility:private"],
-        cmd=_dsym_command(name),
+        name = name + "_dsym",
+        srcs = [":" + name],
+        outs = [name + ".dSYM"],
+        output_to_bindir = 1,
+        testonly = testonly,
+        tags = ["dsym"],
+        visibility = ["//visibility:private"],
+        cmd = _dsym_command(name),
     )
 
     if add_test_rule:
         drake_cc_test(
-            name=name + "_test",
-            hdrs=hdrs,
-            srcs=srcs,
-            deps=deps,
-            copts=copts,
-            size=test_rule_size,
-            testonly=testonly,
-            linkstatic=linkstatic,
-            args=test_rule_args,
+            name = name + "_test",
+            hdrs = hdrs,
+            srcs = srcs,
+            deps = deps,
+            copts = copts,
+            size = test_rule_size,
+            testonly = testonly,
+            linkstatic = linkstatic,
+            args = test_rule_args,
             **kwargs)
 
 def drake_cc_test(
         name,
-        size=None,
-        srcs=None,
-        copts=[],
-        disable_in_compilation_mode_dbg=False,
+        size = None,
+        srcs = None,
+        copts = [],
+        disable_in_compilation_mode_dbg = False,
         **kwargs):
     """Creates a rule to declare a C++ unit test.  Note that for almost all
     cases, drake_cc_googletest should be used, instead of this rule.
@@ -156,30 +156,30 @@ def drake_cc_test(
     if disable_in_compilation_mode_dbg:
         # Remove the test declarations from the test in debug mode.
         # TODO(david-german-tri): Actually suppress the test rule.
-        srcs = select({"//tools:debug" : [], "//conditions:default" : srcs})
+        srcs = select({"//tools:debug": [], "//conditions:default": srcs})
     native.cc_test(
-        name=name,
-        size=size,
-        srcs=srcs,
-        copts=_platform_copts(copts, cc_test=1),
+        name = name,
+        size = size,
+        srcs = srcs,
+        copts = _platform_copts(copts, cc_test = 1),
         **kwargs)
 
     # Also generate the OS X debug symbol file for this test.
     native.genrule(
-        name=name + "_dsym",
-        srcs=[":" + name],
-        outs=[name + ".dSYM"],
-        output_to_bindir=1,
-        testonly=1,
-        tags=["dsym"],
-        visibility=["//visibility:private"],
-        cmd=_dsym_command(name),
+        name = name + "_dsym",
+        srcs = [":" + name],
+        outs = [name + ".dSYM"],
+        output_to_bindir = 1,
+        testonly = 1,
+        tags = ["dsym"],
+        visibility = ["//visibility:private"],
+        cmd = _dsym_command(name),
     )
 
 def drake_cc_googletest(
         name,
-        deps=None,
-        use_default_main=True,
+        deps = None,
+        use_default_main = True,
         **kwargs):
     """Creates a rule to declare a C++ unit test using googletest.  Always adds
     a deps= entry for googletest main (@gtest//:main).
@@ -200,13 +200,13 @@ def drake_cc_googletest(
     else:
         deps.append("@gtest//:without_main")
     drake_cc_test(
-        name=name,
-        deps=deps,
+        name = name,
+        deps = deps,
         **kwargs)
 
 # Generate a file with specified content
 def _generate_file_impl(ctx):
-    ctx.file_action(output=ctx.outputs.out, content=ctx.attr.content)
+    ctx.file_action(output = ctx.outputs.out, content = ctx.attr.content)
 
 drake_generate_file = rule(
     attrs = {

--- a/tools/generate_export_header.bzl
+++ b/tools/generate_export_header.bzl
@@ -20,13 +20,13 @@ def _generate_export_header_impl(ctx):
         "#ifdef %s" % ctx.attr.static_define,
         "#  define %s" % ctx.attr.export_macro_name,
         "#else",
-        "#  define %s __attribute__((visibility(\"default\")))" % ctx.attr.export_macro_name,
+        "#  define %s __attribute__((visibility(\"default\")))" % ctx.attr.export_macro_name,  # noqa
         "#endif",
         "",
         "#endif",
     ]
 
-    ctx.file_action(output=output, content="\n".join(content)+"\n")
+    ctx.file_action(output = output, content = "\n".join(content) + "\n")
 
 # Defines the rule to generate_export_header.
 _generate_export_header_gen = rule(
@@ -40,11 +40,11 @@ _generate_export_header_gen = rule(
 )
 
 def generate_export_header(
-        lib=None,
-        name=None,
-        out=None,
-        export_macro_name=None,
-        static_define=None,
+        lib = None,
+        name = None,
+        out = None,
+        export_macro_name = None,
+        static_define = None,
         **kwargs):
     """Creates a rule to generate an export header for a named library.  This
     is an incomplete implementation of CMake's generate_export_header. (In
@@ -68,8 +68,8 @@ def generate_export_header(
         export_macro_name = "%s_EXPORT" % lib.upper()
 
     _generate_export_header_gen(
-        name=name,
-        out=out,
-        export_macro_name=export_macro_name,
-        static_define=static_define,
+        name = name,
+        out = out,
+        export_macro_name = export_macro_name,
+        static_define = static_define,
         **kwargs)

--- a/tools/generate_include_header.bzl
+++ b/tools/generate_include_header.bzl
@@ -13,7 +13,7 @@ def _generate_include_header_impl(ctx):
     # Generate include header
     content = "#pragma once\n"
     content = content + "\n".join(["#include <%s>" % h for h in hdrs])
-    ctx.file_action(output=ctx.outputs.out, content=content)
+    ctx.file_action(output = ctx.outputs.out, content = content)
 
 drake_generate_include_header = rule(
     attrs = {

--- a/tools/gfortran.bzl
+++ b/tools/gfortran.bzl
@@ -31,7 +31,7 @@ def _gfortran_impl(repository_ctx):
     libquadmath_path = _find_library(repository_ctx, libquadmath)
 
     if repository_ctx.os.name == "mac os x":
-        repository_ctx.file("empty.cc", executable=False)
+        repository_ctx.file("empty.cc", executable = False)
         srcs = ["empty.cc"]
 
         libgfortran_dir = repository_ctx.path(libgfortran_path).dirname
@@ -67,7 +67,7 @@ def _gfortran_impl(repository_ctx):
     """.format(srcs, linkopts).replace(
         "\n    ", "\n")  # Strip leading indentation.
 
-    repository_ctx.file("BUILD", content=BUILD)
+    repository_ctx.file("BUILD", content = BUILD)
 
 gfortran_repository = repository_rule(
     local = True,

--- a/tools/github.bzl
+++ b/tools/github.bzl
@@ -6,7 +6,7 @@ def github_archive(
         commit = None,
         sha256 = None,
         build_file = None,
-        local_repository_override=None,
+        local_repository_override = None,
         **kwargs):
     """A macro to be called in the WORKSPACE that adds an external from github
     using a workspace rule.
@@ -39,11 +39,12 @@ def github_archive(
         sha256 = "0" * 64
 
     # Packages are mirrored from GitHub to CloudFront backed by an S3 bucket.
-    urls = [
-        "https://github.com/%s/archive/%s.tar.gz" % (repository, commit),
-        "https://d2tbce6hkathzp.cloudfront.net/github/%s/%s.tar.gz" % (repository, commit),
-        "https://s3.amazonaws.com/drake-mirror/github/%s/%s.tar.gz" % (repository, commit),
+    mirrors = [
+        "https://github.com/%s/archive/%s.tar.gz",
+        "https://d2tbce6hkathzp.cloudfront.net/github/%s/%s.tar.gz",
+        "https://s3.amazonaws.com/drake-mirror/github/%s/%s.tar.gz",
     ]
+    urls = [mirror % (repository, commit) for mirror in mirrors]
 
     repository_split = repository.split("/")
     if len(repository_split) != 2:
@@ -58,27 +59,27 @@ def github_archive(
     if local_repository_override != None:
         if build_file == None:
             native.local_repository(
-                name=name,
-                path=local_repository_override)
+                name = name,
+                path = local_repository_override)
         else:
             native.new_local_repository(
-                name=name,
-                build_file=build_file,
-                path=local_repository_override)
+                name = name,
+                build_file = build_file,
+                path = local_repository_override)
         return
 
     if build_file == None:
         native.http_archive(
-            name=name,
-            urls=urls,
-            sha256=sha256,
-            strip_prefix=strip_prefix,
+            name = name,
+            urls = urls,
+            sha256 = sha256,
+            strip_prefix = strip_prefix,
             **kwargs)
     else:
         native.new_http_archive(
-            name=name,
-            urls=urls,
-            sha256=sha256,
-            build_file=build_file,
-            strip_prefix=strip_prefix,
+            name = name,
+            urls = urls,
+            sha256 = sha256,
+            build_file = build_file,
+            strip_prefix = strip_prefix,
             **kwargs)

--- a/tools/gurobi.bzl
+++ b/tools/gurobi.bzl
@@ -10,7 +10,7 @@ def _gurobi_impl(repository_ctx):
         repository_ctx.symlink(gurobi_path, "gurobi-distro")
         warning = "Gurobi 7.0.2 is not installed."
 
-        repository_ctx.file("empty.cc", executable=False)
+        repository_ctx.file("empty.cc", executable = False)
         srcs = ["empty.cc"]
 
         lib_path = repository_ctx.path("gurobi-distro/lib")
@@ -34,10 +34,10 @@ def _gurobi_impl(repository_ctx):
 
         # In the Gurobi package, libgurobi70.so is just a symlink to
         # libgurobi.so.7.0.2. However, if you use libgurobi.so.7.0.2 in srcs,
-        # executables that link this library will be unable to find it at runtime
-        # in the Bazel sandbox, because the NEEDED statements in the executable
-        # will not square with the RPATH statements. I don't really know why this
-        # happens, but I suspect it might be a Bazel bug.
+        # executables that link this library will be unable to find it at
+        # runtime in the Bazel sandbox, because the NEEDED statements in the
+        # executable will not square with the RPATH statements. I don't really
+        # know why this happens, but I suspect it might be a Bazel bug.
         srcs = ["gurobi-distro/lib/libgurobi70.so"]
 
         linkopts = ["-pthread"]
@@ -55,9 +55,9 @@ def _gurobi_impl(repository_ctx):
         linkopts = {linkopts},
         visibility = ["//visibility:public"],
     )
-    """.format(warning=warning, srcs=srcs, linkopts=linkopts)
+    """.format(warning = warning, srcs = srcs, linkopts = linkopts)
     BUILD = BUILD.replace("\n    ", "\n")  # Strip leading indent from lines.
-    repository_ctx.file("BUILD", content=BUILD, executable=False)
+    repository_ctx.file("BUILD", content = BUILD, executable = False)
 
 gurobi_repository = repository_rule(
     environ = ["GUROBI_PATH"],
@@ -65,7 +65,7 @@ gurobi_repository = repository_rule(
     implementation = _gurobi_impl,
 )
 
-def gurobi_test_tags(gurobi_required=True):
+def gurobi_test_tags(gurobi_required = True):
     """Returns the test tags necessary for properly running Gurobi tests.
 
     By default, sets gurobi_required=True, which will require that the supplied

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -142,7 +142,7 @@ def _install_cc_actions(ctx, target):
             fail(msg_fmt % ctx.attr.guess_hdrs, ctx.attr.guess_hdrs)
         actions += _install_actions(
             ctx,
-            [struct(files=hdrs)],
+            [struct(files = hdrs)],
             ctx.attr.hdr_dest,
             ctx.attr.hdr_strip_prefix,
             ctx.attr.guess_hdrs_exclude
@@ -415,7 +415,7 @@ def cmake_config(
     version_file = None,
     cps_file_name = None,
     deps = []
-    ):
+):
     """Create CMake package configuration and package version files via an
     intermediate CPS file.
 
@@ -428,9 +428,8 @@ def cmake_config(
 
     if script and version_file:
         if cps_file_name:
-            fail("cps_file_name should not be set if"
-                + " script and version_file are set."
-            )
+            fail("cps_file_name should not be set if " +
+                 "script and version_file are set.")
         native.py_binary(
             name = "create-cps",
             srcs = [script],
@@ -453,12 +452,13 @@ def cmake_config(
         cps_file_name = "@drake//tools:{}.cps".format(package)
 
     config_file_name = "{}Config.cmake".format(package)
+    executable = "$(location @pycps//:cps2cmake_executable)"
 
     native.genrule(
         name = "cmake_exports",
         srcs = [cps_file_name],
         outs = [config_file_name],
-        cmd = "$(location @pycps//:cps2cmake_executable) \"$<\" > \"$@\"",
+        cmd = executable + " \"$<\" > \"$@\"",
         tools = ["@pycps//:cps2cmake_executable"],
         visibility = ["//visibility:private"],
     )
@@ -469,7 +469,7 @@ def cmake_config(
         name = "cmake_package_version",
         srcs = [cps_file_name],
         outs = [config_version_file_name],
-        cmd = "$(location @pycps//:cps2cmake_executable) --version-check \"$<\" > \"$@\"",
+        cmd = executable + " --version-check \"$<\" > \"$@\"",
         tools = ["@pycps//:cps2cmake_executable"],
         visibility = ["//visibility:private"],
     )
@@ -480,7 +480,7 @@ def install_cmake_config(
     versioned = True,
     name = "install_cmake_config",
     visibility = ["//visibility:private"]
-    ):
+):
     """Generate installation information for CMake package configuration and
     package version files. The rule name is always ``:install_cmake_config``.
 

--- a/tools/install/optitrack_driver/BUILD
+++ b/tools/install/optitrack_driver/BUILD
@@ -30,11 +30,11 @@ install(
     doc_strip_prefix = ["**/"],
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/lcmtypes",
-    license_docs = ["@optitrack_driver//:LICENSE"],
     java_strip_prefix = ["**/"],
+    license_docs = ["@optitrack_driver//:LICENSE"],
     py_dest = "lib/python2.7/site-packages/optitrack",
     py_strip_prefix = ["**/"],
     targets = OPTITRACK_TARGETS,
-    deps = [":install_cmake_config"],
     visibility = ["//:__pkg__"],
+    deps = [":install_cmake_config"],
 )

--- a/tools/lcm.bzl
+++ b/tools/lcm.bzl
@@ -34,7 +34,7 @@ def _lcm_outs(lcm_srcs, lcm_package, lcm_structs, extension):
         c_outs = [
             dirname + lcm_package + "_" + lcm_struct + ".c"
             for lcm_struct in (lcm_structs or lcm_basenames)]
-        outs = struct(hdrs=h_outs, srcs=c_outs)
+        outs = struct(hdrs = h_outs, srcs = c_outs)
 
     else:
         outs = [
@@ -107,9 +107,9 @@ _lcm_library_gen = rule(
 
 def lcm_cc_library(
         name,
-        lcm_srcs=None,
-        lcm_package=None,
-        lcm_structs=None,
+        lcm_srcs = None,
+        lcm_package = None,
+        lcm_structs = None,
         **kwargs):
     """Declares a cc_library on message classes generated from `*.lcm` files.
 
@@ -132,27 +132,27 @@ def lcm_cc_library(
 
     outs = _lcm_outs(lcm_srcs, lcm_package, lcm_structs, ".hpp")
     _lcm_library_gen(
-        name=name + "_lcm_library_gen",
-        language="cc",
-        lcm_srcs=lcm_srcs,
-        lcm_package=lcm_package,
-        outs=outs)
+        name = name + "_lcm_library_gen",
+        language = "cc",
+        lcm_srcs = lcm_srcs,
+        lcm_package = lcm_package,
+        outs = outs)
 
     deps = set(kwargs.pop('deps', [])) | ["@lcm"]
     includes = set(kwargs.pop('includes', [])) | ["."]
     native.cc_library(
-        name=name,
-        hdrs=outs,
-        deps=deps,
-        includes=includes,
+        name = name,
+        hdrs = outs,
+        deps = deps,
+        includes = includes,
         **kwargs)
 
 def lcm_c_library(
         name,
         lcm_srcs,
         lcm_package,
-        lcm_structs=None,
-        aggregate_hdr=None,
+        lcm_structs = None,
+        aggregate_hdr = None,
         **kwargs):
     """Declares a cc_library on message C structs generated from `*.lcm` files.
 
@@ -165,11 +165,11 @@ def lcm_c_library(
     outs = _lcm_outs(lcm_srcs, lcm_package, lcm_structs, ".h")
 
     _lcm_library_gen(
-        name=name + "_lcm_library_gen",
-        language="c",
-        lcm_srcs=lcm_srcs,
-        lcm_package=lcm_package,
-        outs=outs.hdrs + outs.srcs)
+        name = name + "_lcm_library_gen",
+        language = "c",
+        lcm_srcs = lcm_srcs,
+        lcm_package = lcm_package,
+        outs = outs.hdrs + outs.srcs)
 
     hdrs = outs.hdrs
     if aggregate_hdr:
@@ -178,18 +178,18 @@ def lcm_c_library(
     deps = set(kwargs.pop('deps', [])) | ["@lcm"]
     includes = set(kwargs.pop('includes', [])) | ["."]
     native.cc_library(
-        name=name,
-        srcs=outs.srcs,
-        hdrs=hdrs,
-        deps=deps,
-        includes=includes,
+        name = name,
+        srcs = outs.srcs,
+        hdrs = hdrs,
+        deps = deps,
+        includes = includes,
         **kwargs)
 
 def lcm_py_library(
         name,
-        lcm_srcs=None,
-        lcm_package=None,
-        lcm_structs=None,
+        lcm_srcs = None,
+        lcm_package = None,
+        lcm_structs = None,
         **kwargs):
     """Declares a py_library on message classes generated from `*.lcm` files.
 
@@ -207,24 +207,24 @@ def lcm_py_library(
 
     outs = _lcm_outs(lcm_srcs, lcm_package, lcm_structs, ".py")
     _lcm_library_gen(
-        name=name + "_lcm_library_gen",
-        language="py",
-        lcm_srcs=lcm_srcs,
-        lcm_package=lcm_package,
-        outs=outs)
+        name = name + "_lcm_library_gen",
+        language = "py",
+        lcm_srcs = lcm_srcs,
+        lcm_package = lcm_package,
+        outs = outs)
 
     imports = set(kwargs.pop('imports', [])) | ["."]
     native.py_library(
-        name=name,
-        srcs=outs,
-        imports=imports,
+        name = name,
+        srcs = outs,
+        imports = imports,
         **kwargs)
 
 def lcm_java_library(
         name,
-        lcm_srcs=None,
-        lcm_package=None,
-        lcm_structs=None,
+        lcm_srcs = None,
+        lcm_package = None,
+        lcm_structs = None,
         **kwargs):
     """Declares a java_library on message classes generated from `*.lcm` files.
 
@@ -239,17 +239,17 @@ def lcm_java_library(
 
     outs = _lcm_outs(lcm_srcs, lcm_package, lcm_structs, ".java")
     _lcm_library_gen(
-        name=name + "_lcm_library_gen",
-        language="java",
-        lcm_srcs=lcm_srcs,
-        lcm_package=lcm_package,
-        outs=outs)
+        name = name + "_lcm_library_gen",
+        language = "java",
+        lcm_srcs = lcm_srcs,
+        lcm_package = lcm_package,
+        outs = outs)
 
     deps = set(kwargs.pop('deps', [])) | ["@lcm//:lcm-java"]
     native.java_library(
-        name=name,
-        srcs=outs,
-        deps=deps,
+        name = name,
+        srcs = outs,
+        deps = deps,
         **kwargs)
 
 # TODO(jamiesnape): Simplify this and possibly merge with lcm_c_library if
@@ -259,7 +259,7 @@ def lcm_c_aggregate_header(
         out,
         lcm_srcs,
         lcm_package,
-        lcm_structs=None,
+        lcm_structs = None,
         **kwargs):
     """Generates a header that includes a set of C headers generated from
     `*.lcm` files.

--- a/tools/mosek.bzl
+++ b/tools/mosek.bzl
@@ -28,12 +28,13 @@ def _impl(repository_ctx):
 
     if repository_ctx.os.name == "mac os x":
         mosek_platform = "osx64x86"
-        sha256 = "26c5bc0be667c92d1a5f81d2a1f7694de1fb0a3e9e9064c17f98e425db0a3c64"
+        sha256 = "26c5bc0be667c92d1a5f81d2a1f7694de1fb0a3e9e9064c17f98e425db0a3c64"  # noqa
     elif repository_ctx.os.name == "linux":
         mosek_platform = "linux64x86"
-        sha256 = "9b2bfcba7bcdd24b7e87ecdcccc11222302ced7b3d2a2af7090bdf625ab7cfae"
+        sha256 = "9b2bfcba7bcdd24b7e87ecdcccc11222302ced7b3d2a2af7090bdf625ab7cfae"  # noqa
     else:
-        fail("Operating system is NOT supported", attr=repository_ctx.os.name)
+        fail("Operating system is NOT supported",
+             attr = repository_ctx.os.name)
 
     url = "http://download.mosek.com/stable/{}/mosektools{}.tar.bz2".format(
         mosek_major_version, mosek_platform)
@@ -42,7 +43,7 @@ def _impl(repository_ctx):
                                                        mosek_platform)
 
     repository_ctx.download_and_extract(
-        url, root_path, sha256=sha256, stripPrefix=strip_prefix)
+        url, root_path, sha256 = sha256, stripPrefix = strip_prefix)
 
     if repository_ctx.os.name == "mac os x":
         install_name_tool = repository_ctx.which("install_name_tool")
@@ -65,9 +66,9 @@ def _impl(repository_ctx):
 
             if result.return_code != 0:
                 fail("Could NOT change shared library identification name",
-                     attr=result.stderr)
+                     attr = result.stderr)
 
-        repository_ctx.file("empty.cc", executable=False)
+        repository_ctx.file("empty.cc", executable = False)
 
         srcs = ["empty.cc"]
 
@@ -98,11 +99,11 @@ cc_library(
 )
     """.format(srcs, linkopts)
 
-    repository_ctx.file("BUILD", content=file_content, executable=False)
+    repository_ctx.file("BUILD", content = file_content, executable = False)
 
 mosek_repository = repository_rule(implementation = _impl)
 
-def mosek_test_tags(mosek_required=True):
+def mosek_test_tags(mosek_required = True):
     """Returns the test tags necessary for properly running mosek tests.
 
     By default, sets mosek_required=True, which will require that the supplied

--- a/tools/numpy.bzl
+++ b/tools/numpy.bzl
@@ -36,11 +36,15 @@ def _impl(repository_ctx):
     result = repository_ctx.execute([
         python,
         "-c",
-        "from __future__ import print_function; import numpy; print(numpy.get_include());",
+        "; ".join([
+            "from __future__ import print_function",
+            "import numpy",
+            "print(numpy.get_include())",
+        ]),
     ])
 
     if result.return_code != 0:
-        fail("Could NOT determine NumPy include", attr=result.stderr)
+        fail("Could NOT determine NumPy include", attr = result.stderr)
 
     source = repository_ctx.path(result.stdout.strip())
     destination = repository_ctx.path("include")
@@ -55,7 +59,7 @@ cc_library(
 )
     """
 
-    repository_ctx.file("BUILD", content=file_content, executable=False)
+    repository_ctx.file("BUILD", content = file_content, executable = False)
 
 numpy_repository = repository_rule(
     _impl,

--- a/tools/pypi.bzl
+++ b/tools/pypi.bzl
@@ -89,7 +89,7 @@ def pypi_archive(
 
     # Packages are mirrored from PyPI to CloudFront backed by an S3 bucket.
     urls = [
-        "https://files.pythonhosted.org/packages/source/{0}/{1}/{1}-{2}.tar.gz".format(
+        "https://files.pythonhosted.org/packages/source/{0}/{1}/{1}-{2}.tar.gz".format(  # noqa
             package[:1], package, version),
         "https://d2tbce6hkathzp.cloudfront.net/pypi/{0}/{0}-{1}.tar.gz".format(
             package, version),
@@ -98,9 +98,9 @@ def pypi_archive(
     ]
 
     native.new_http_archive(
-        name=name,
-        build_file=build_file,
-        sha256=sha256,
-        strip_prefix=strip_prefix,
-        urls=urls,
+        name = name,
+        build_file = build_file,
+        sha256 = sha256,
+        strip_prefix = strip_prefix,
+        urls = urls,
         **kwargs)

--- a/tools/python.bzl
+++ b/tools/python.bzl
@@ -36,7 +36,7 @@ def _impl(repository_ctx):
     result = repository_ctx.execute([python_config, "--includes"])
 
     if result.return_code != 0:
-        fail("Could NOT determine Python includes", attr=result.stderr)
+        fail("Could NOT determine Python includes", attr = result.stderr)
 
     cflags = result.stdout.strip().split(" ")
     cflags = [cflag for cflag in cflags if cflag]
@@ -60,7 +60,7 @@ def _impl(repository_ctx):
     result = repository_ctx.execute([python_config, "--ldflags"])
 
     if result.return_code != 0:
-        fail("Could NOT determine Python linkopts", attr=result.stderr)
+        fail("Could NOT determine Python linkopts", attr = result.stderr)
 
     linkopts = result.stdout.strip().split(" ")
     linkopts = [linkopt for linkopt in linkopts if linkopt]
@@ -79,7 +79,7 @@ cc_library(
 )
     """.format(includes, linkopts)
 
-    repository_ctx.file("BUILD", content=file_content, executable=False)
+    repository_ctx.file("BUILD", content = file_content, executable = False)
 
 python_repository = repository_rule(
     _impl,

--- a/tools/vtk.bzl
+++ b/tools/vtk.bzl
@@ -25,8 +25,8 @@ Argument:
 
 VTK_MAJOR_MINOR_VERSION = "8.0"
 
-def _vtk_cc_library(os_name, name, hdrs=None, visibility=None, deps=None,
-                    header_only=False):
+def _vtk_cc_library(os_name, name, hdrs = None, visibility = None, deps = None,
+                    header_only = False):
     hdr_paths = []
 
     if hdrs:
@@ -79,7 +79,7 @@ def _impl(repository_ctx):
     if repository_ctx.os.name == "mac os x":
         repository_ctx.symlink("/usr/local/opt/vtk@{}/include".format(
             VTK_MAJOR_MINOR_VERSION), "include")
-        repository_ctx.file("empty.cc", executable=False)
+        repository_ctx.file("empty.cc", executable = False)
 
     elif repository_ctx.os.name == "linux":
         sed = repository_ctx.which("sed")
@@ -94,41 +94,45 @@ def _impl(repository_ctx):
 
         if result.return_code != 0:
             fail("Could NOT determine Linux distribution information",
-                 attr=result.stderr)
+                 attr = result.stderr)
 
         distro = [l.strip() for l in result.stdout.strip().split("\n")]
         distro = " ".join(distro)
 
         if distro == "Ubuntu 14.04":
             archive = "vtk-v8.0.0.rc2-qt-4.8.6-trusty-x86_64.tar.gz"
-            sha256 = "78880d8b951355a6ad5a6bfc42275ae42f31e2e05f1b52e3a9883226556b1685"
+            sha256 = "78880d8b951355a6ad5a6bfc42275ae42f31e2e05f1b52e3a9883226556b1685"  # noqa
         elif distro == "Ubuntu 16.04":
             archive = "vtk-v8.0.0.rc2-qt-5.5.1-xenial-x86_64.tar.gz "
-            sha256 = "963f81abd90da4470df1fb20aee8b4ead815f543f3ae9fa00ef2ea6be5cc2c0c"
+            sha256 = "963f81abd90da4470df1fb20aee8b4ead815f543f3ae9fa00ef2ea6be5cc2c0c"  # noqa
         else:
-            fail("Linux distribution is NOT supported", attr=distro)
+            fail("Linux distribution is NOT supported", attr = distro)
 
         url = "https://d2mbb5ninhlpdu.cloudfront.net/vtk/{}".format(archive)
         root_path = repository_ctx.path("")
 
-        repository_ctx.download_and_extract(url, root_path, sha256=sha256)
+        repository_ctx.download_and_extract(url, root_path, sha256 = sha256)
 
     else:
-        fail("Operating system is NOT supported", attr=repository_ctx.os.name)
+        fail("Operating system is NOT supported",
+             attr = repository_ctx.os.name)
 
     # Note that we only create library targets for enough of VTK to support
     # those used directly or indirectly by Drake.
 
     # TODO(jamiesnape): Create a script to help generate the targets.
 
-    file_content = _vtk_cc_library(repository_ctx.os.name, "vtkCommonColor",
+    file_content = _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkCommonColor",
         deps = [
             ":vtkCommonCore",
             ":vtkCommonDataModel",
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name,
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
         "vtkCommonComputationalGeometry",
         deps = [
             ":vtkCommonCore",
@@ -136,7 +140,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkCommonCore",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkCommonCore",
         hdrs = [
             "vtkABI.h",
             "vtkAbstractArray.h",
@@ -198,7 +204,8 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name,
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
         "vtkCommonDataModel",
         hdrs = [
             "vtkAbstractCellLinks.h",
@@ -229,7 +236,8 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name,
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
         "vtkCommonExecutionModel",
         hdrs = [
             "vtkAlgorithm.h",
@@ -244,7 +252,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkCommonMath",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkCommonMath",
         hdrs = [
             "vtkCommonMathModule.h",
             "vtkMatrix4x4.h",
@@ -253,18 +263,23 @@ def _impl(repository_ctx):
         deps = [":vtkCommonCore"],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkCommonMisc",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkCommonMisc",
         deps = [
             ":vtkCommonCore",
             ":vtkCommonMath",
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkCommonSystem",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkCommonSystem",
         deps = [":vtkCommonCore"],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name,
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
         "vtkCommonTransforms",
         hdrs = [
             "vtkAbstractTransform.h",
@@ -279,11 +294,15 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkDICOMParser",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkDICOMParser",
         deps = [":vtksys"],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkFiltersCore",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkFiltersCore",
         hdrs = ["vtkFiltersCoreModule.h"],
         visibility = ["//visibility:private"],
         deps = [
@@ -294,7 +313,8 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name,
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
         "vtkFiltersGeometry",
         deps = [
             ":vtkCommonCore",
@@ -303,7 +323,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkFiltersGeneral",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkFiltersGeneral",
         hdrs = [
             "vtkFiltersGeneralModule.h",
             "vtkTransformPolyDataFilter.h",
@@ -318,7 +340,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkFiltersSources",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkFiltersSources",
         hdrs = [
             "vtkCubeSource.h",
             "vtkCylinderSource.h",
@@ -334,7 +358,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkIOCore",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkIOCore",
         hdrs = [
             "vtkAbstractPolyDataReader.h",
             "vtkIOCoreModule.h",
@@ -346,7 +372,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkIOGeometry",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkIOGeometry",
         hdrs = [
             "vtkIOGeometryModule.h",
             "vtkOBJReader.h",
@@ -359,7 +387,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkIOImage",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkIOImage",
         hdrs = [
             "vtkImageExport.h",
             "vtkImageReader2.h",
@@ -376,7 +406,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkIOImport",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkIOImport",
         hdrs = [
             "vtkImporter.h",
             "vtkIOImportModule.h",
@@ -391,7 +423,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkIOLegacy",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkIOLegacy",
         deps = [
             ":vtkCommonCore",
             ":vtkCommonDataModel",
@@ -400,7 +434,9 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkRenderingCore",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkRenderingCore",
         hdrs = [
             "vtkAbstractMapper.h",
             "vtkAbstractMapper3D.h",
@@ -433,7 +469,8 @@ def _impl(repository_ctx):
         ],
     )
 
-    file_content += _vtk_cc_library(repository_ctx.os.name,
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
         "vtkRenderingOpenGL2",
         visibility = ["//visibility:public"],
         deps = [
@@ -459,7 +496,8 @@ cc_library(
     else:
         file_content += _vtk_cc_library(repository_ctx.os.name, "vtkglew")
 
-    file_content += _vtk_cc_library(repository_ctx.os.name, "vtkkwiml",
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name, "vtkkwiml",
         hdrs = [
             "vtk_kwiml.h",
             "vtkkwiml/abi.h",
@@ -472,8 +510,7 @@ cc_library(
     file_content += _vtk_cc_library(repository_ctx.os.name, "vtklz4")
 
     file_content += _vtk_cc_library(repository_ctx.os.name, "vtkmetaio",
-        deps = ["@zlib"],
-    )
+                                    deps = ["@zlib"])
 
     file_content += _vtk_cc_library(repository_ctx.os.name, "vtksys")
 
@@ -503,6 +540,6 @@ install_files(
 )
 """.format(files_to_install)
 
-    repository_ctx.file("BUILD", content=file_content, executable=False)
+    repository_ctx.file("BUILD", content = file_content, executable = False)
 
 vtk_repository = repository_rule(implementation = _impl)


### PR DESCRIPTION
Buildify. Adjust style of `.bzl` files to match style prescribed by #6384. This makes things more stylistically consistent and is a major step toward enforcing `bazel_lint`. (If nothing else changes, there is one small issue yet in `install.bzl` which I am ignoring because I have a pending change — waiting on #6347 — that will incidentally correct it, after which we should be able to start enforcing `bazel_lint`.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6386)
<!-- Reviewable:end -->
