### PR TITLE
Ask ROS users to set DRAKE_RESOURCE_ROOT

### DIFF
--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -131,6 +131,9 @@ drake_install_pkg_config_file(drake-common
     eigen3
     ${drakeCommon_REQUIRES})
 
+add_executable(resource_tool resource_tool.cc)
+target_link_libraries(resource_tool drakeCommon)
+
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/drake/doc/from_source_ros.rst
+++ b/drake/doc/from_source_ros.rst
@@ -157,6 +157,7 @@ To run a single unit test like ``ros_test.test`` within package
 To run Drake's non-ROS-based unit tests, execute::
 
     cd ~/dev/drake_catkin_workspace/build/drake/drake
+    export DRAKE_RESOURCE_ROOT=$HOME/dev/drake_catkin_workspace/src/drake
     ctest
 
 For more information about how to run Drake's non-ROS unit tests, see


### PR DESCRIPTION
Relates #5893.

(We hypothesize that the ROS build will be substantially reworked in the future and make this either unnecessary or automated, but for now asking users to set it seems like a reasonable stepping stone.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6387)
<!-- Reviewable:end -->
