### PR TITLE
Add renaming support to install framework

### DIFF
--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -18,7 +18,7 @@ def _is_drake_label(x):
         return False
 
 #------------------------------------------------------------------------------
-def _output_path(ctx, input_file, strip_prefix):
+def _output_path(ctx, input_file, strip_prefix = [], warn_foreign = True):
     """Compute output path (without destination prefix) for install action.
 
     This computes the adjusted output path for an input file. It is the same as
@@ -43,8 +43,9 @@ def _output_path(ctx, input_file, strip_prefix):
 
     # If we get here, we were not able to resolve the path; give up, and print
     # a warning about installing the "foreign" file.
-    print("%s installing file %s which is not in current package"
-          % (ctx.label, input_file.path))
+    if warn_foreign:
+        print("%s installing file %s which is not in current package"
+              % (ctx.label, input_file.path))
     return input_file.basename
 
 #------------------------------------------------------------------------------
@@ -129,7 +130,7 @@ def _install_actions(ctx, file_labels, dests, strip_prefixes = [],
             # original relative path and the path with prefix(es) stripped,
             # then use the original relative path for both exclusions and
             # renaming.
-            if _output_path(ctx, a, []) in excluded_files:
+            if _output_path(ctx, a, warn_foreign = False) in excluded_files:
                 continue
 
             actions.append(

--- a/tools/pathutils.bzl
+++ b/tools/pathutils.bzl
@@ -94,6 +94,19 @@ def _remove_prefix(path, prefix):
 #BEGIN macros
 
 #------------------------------------------------------------------------------
+def dirname(path):
+    """Return the directory portion of a file path."""
+    if path == "/":
+        return "/"
+
+    parts = path.split("/")
+
+    if len(parts) > 1:
+        return "/".join(parts[:-1])
+
+    return "."
+
+#------------------------------------------------------------------------------
 def join_paths(*args):
     """Join paths without duplicating separators.
 
@@ -108,12 +121,13 @@ def join_paths(*args):
     result = ""
 
     for part in args:
-        if len(part) == 0:
+        if part.endswith("/"):
+            part = part[-1]
+
+        if part == "" or part == ".":
             continue
 
-        result += part
-        if result[-1] != "/":
-            result += "/"
+        result += part + "/"
 
     return result[:-1]
 


### PR DESCRIPTION
Add support for passing a map of install destinations to alternate file names to the install framework. This allows files to be renamed on install, which will be helpful for e.g. Java libraries, which Bazel insists on prefixing with "lib", and which we often want to have named the same as C++ libraries (which isn't otherwise possible because the build labels must be unique).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6389)
<!-- Reviewable:end -->
