### PR TITLE
Increasing Timeout For global_inverse_kinematics_reachable_test

### DIFF
--- a/drake/multibody/dev/test/CMakeLists.txt
+++ b/drake/multibody/dev/test/CMakeLists.txt
@@ -13,7 +13,7 @@ if(gurobi_FOUND)
     target_link_libraries(global_inverse_kinematics_test
             drakeGlobalInverseKinematicsTest)
 
-    drake_add_cc_test(NAME global_inverse_kinematics_reachable_test SIZE medium)
+    drake_add_cc_test(NAME global_inverse_kinematics_reachable_test SIZE large)
     target_link_libraries(global_inverse_kinematics_reachable_test
             drakeGlobalInverseKinematicsTest)
 


### PR DESCRIPTION
Times out in `linux-gcc-continuous-matlab-release` build:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-gcc-continuous-matlab-release/2406/consoleText

The test size is still medium for Bazel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6392)
<!-- Reviewable:end -->
