### PR TITLE
Revert "Fix trapezoid rule to match comment"

### DIFF
--- a/drake/systems/trajectory_optimization/direct_collocation.cc
+++ b/drake/systems/trajectory_optimization/direct_collocation.cc
@@ -112,12 +112,13 @@ void DircolTrajectoryOptimization::DoAddRunningCost(
   // g_0*h_0/2.0 + [sum_{i=1...N-2} g_i*(h_{i-1} + h_i)/2.0] +
   // g_{N-1}*h_{N-2}/2.0.
 
-  AddCost(SubstitutePlaceholderVariables(g * h_vars()(0) / 2, 0));
+  AddCost(0.5 * SubstitutePlaceholderVariables(g * h_vars()(0) / 2, 0));
   for (int i = 1; i < N() - 2; i++) {
     AddCost(SubstitutePlaceholderVariables(
         g * (h_vars()(i - 1) + h_vars()(i)) / 2, i));
   }
-  AddCost(SubstitutePlaceholderVariables(g * h_vars()(N() - 2) / 2, N() - 1));
+  AddCost(0.5 *
+          SubstitutePlaceholderVariables(g * h_vars()(N() - 2) / 2, N() - 1));
 }
 
 // We just use a generic constraint here since we need to mangle the


### PR DESCRIPTION
Dear @jefesaurus ,

The on-call build cop, @betsymcphail, believes that your PR #6223 may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration pre-merge, because additional
platforms and tests are built post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-clang-bazel-nightly-debug/65/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-clang-bazel-nightly-release/184/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6394)
<!-- Reviewable:end -->
