### PR TITLE
Increasing Size Of MATLAB Test runSwingUp

### DIFF
--- a/drake/examples/UnderwaterAcrobot/CMakeLists.txt
+++ b/drake/examples/UnderwaterAcrobot/CMakeLists.txt
@@ -1,7 +1,7 @@
 drake_add_matlab_test(NAME examples/UnderwaterAcrobot/runLQR COMMAND runLQR)
 drake_add_matlab_test(NAME examples/UnderwaterAcrobot/runPassive COMMAND runPassive)
 drake_add_matlab_test(NAME examples/UnderwaterAcrobot/runPassiveURDF OPTIONAL bullet COMMAND runPassiveURDF)
-drake_add_matlab_test(NAME examples/UnderwaterAcrobot/runSwingUp OPTIONAL snopt COMMAND runSwingUp)
+drake_add_matlab_test(NAME examples/UnderwaterAcrobot/runSwingUp OPTIONAL snopt COMMAND runSwingUp SIZE large)
 drake_add_matlab_test(NAME examples/UnderwaterAcrobot/runURDFandAnalyticSoln OPTIONAL bullet COMMAND runURDFandAnalyticSoln)
 
 if(BUILD_TESTING)


### PR DESCRIPTION
The MATLAB `runSwingUp` timed out in 3/5 recent builds.  All MATLAB tests are by default of `medium` size.

Times out in linux-gcc-continuous-matlab-release build:
https://drake-jenkins.csail.mit.edu/job/linux-gcc-continuous-matlab-release/2407/consoleText

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6395)
<!-- Reviewable:end -->
