### PR TITLE
Add mechanism to override distro detection

### DIFF
--- a/tools/director.bzl
+++ b/tools/director.bzl
@@ -1,29 +1,14 @@
 # -*- mode: python -*-
 # vi: set ft=python :
 
+load("@drake//tools:distro.bzl", "get_linux_distro")
+
 def _impl(repository_ctx):
     if repository_ctx.os.name == "mac os x":
         archive = "dd-0.1.0-160-ga50a077-qt-5.8.0-Darwin.tar.gz"
         sha256 = "6873427eb417e03688e85ac59955777fda67f89781245f3146470c5156045691"  # noqa
     elif repository_ctx.os.name == "linux":
-        sed = repository_ctx.which("sed")
-
-        if not sed:
-            fail("Could NOT determine Linux distribution information because" +
-                 " sed is missing")
-
-        result = repository_ctx.execute([
-            sed,
-            "-n",
-            "/^\(NAME\|VERSION_ID\)=/{s/[^=]*=//;s/\"//g;p}",
-            "/etc/os-release"])
-
-        if result.return_code != 0:
-            fail("Could NOT determine Linux distribution information",
-                 attr = result.stderr)
-
-        distro = [l.strip() for l in result.stdout.strip().split("\n")]
-        distro = " ".join(distro)
+        distro = get_linux_distro(repository_ctx)
 
         if distro == "Ubuntu 14.04":
             archive = "dd-0.1.0-160-ga50a077-qt-4.8.6-trusty-x86_64.tar.gz"

--- a/tools/distro.bzl
+++ b/tools/distro.bzl
@@ -1,0 +1,33 @@
+def get_linux_distro(repository_ctx):
+    """Get 'full' name of Linux distribution.
+
+    This determines the 'full' name of the host platform Linux, i.e. the
+    distribution name and version.
+
+    The environment variable DRAKE_OVERRIDE_DISTRO may be set to override the
+    computed value. Note that this is unsupported.
+    """
+
+    if "DRAKE_OVERRIDE_DISTRO" in repository_ctx.os.environ:
+        distro = repository_ctx.os.environ["DRAKE_OVERRIDE_DISTRO"]
+        print("Overriding built-in distribution detection " +
+              "and pretending you are '%s' instead" % distro)
+        return distro
+
+    else:
+        sed = repository_ctx.which("sed")
+        if sed == None:
+            fail("Could NOT determine Linux distribution information" +
+                 "('sed' is missing?!)", sed)
+        result = repository_ctx.execute([
+            sed,
+            "-n",
+            "/^\(NAME\|VERSION_ID\)=/{s/[^=]*=//;s/\"//g;p}",
+            "/etc/os-release"])
+
+        if result.return_code != 0:
+            fail("Could NOT determine Linux distribution information",
+                 attr = result.stderr)
+
+        distro = [l.strip() for l in result.stdout.strip().split("\n")]
+        return " ".join(distro)

--- a/tools/vtk.bzl
+++ b/tools/vtk.bzl
@@ -1,6 +1,8 @@
 # -*- mode: python -*-
 # vi: set ft=python :
 
+load("@drake//tools:distro.bzl", "get_linux_distro")
+
 """
 Makes selected VTK headers and precompiled shared libraries available to be
 used as a C/C++ dependency. On Ubuntu Trusty and Xenial, a VTK archive is
@@ -82,22 +84,7 @@ def _impl(repository_ctx):
         repository_ctx.file("empty.cc", executable = False)
 
     elif repository_ctx.os.name == "linux":
-        sed = repository_ctx.which("sed")
-        if sed == None:
-            fail("Could NOT determine Linux distribution information" +
-                 "('sed' is missing?!)", sed)
-        result = repository_ctx.execute([
-            sed,
-            "-n",
-            "/^\(NAME\|VERSION_ID\)=/{s/[^=]*=//;s/\"//g;p}",
-            "/etc/os-release"])
-
-        if result.return_code != 0:
-            fail("Could NOT determine Linux distribution information",
-                 attr = result.stderr)
-
-        distro = [l.strip() for l in result.stdout.strip().split("\n")]
-        distro = " ".join(distro)
+        distro = get_linux_distro(repository_ctx)
 
         if distro == "Ubuntu 14.04":
             archive = "vtk-v8.0.0.rc2-qt-4.8.6-trusty-x86_64.tar.gz"


### PR DESCRIPTION
Add ability to override the built-in distribution detection for VTK and Director. This makes it possible for users on unsupported platforms to force use of one of the supported packages of these externals. (Needless to say, this is an "if it breaks, you get to keep the pieces" deal.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6400)
<!-- Reviewable:end -->
