### PR TITLE
Refactor licence enforcement

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@
 # This file is named BUILD.bazel instead of the more typical BUILD, so that on
 # OSX it won't conflict with a build artifacts directory named "build".
 
+load("//tools:check_licenses.bzl", "check_licenses")
 load("//tools:install.bzl", "install", "install_files")
 
 package(
@@ -31,36 +32,42 @@ alias(
     actual = "@protobuf//:protobuf_python",
 )
 
+DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
+    "bullet",
+    "ccd",
+    "eigen",
+    "fcl",
+    "fmt",
+    "ignition_math",
+    "ignition_rndf",
+    "ipopt",
+    "lcm",
+    "lcmtypes_bot2_core",
+    "lcmtypes_robotlocomotion",
+    "libbot",
+    "nlopt",
+    "octomap",
+    "pybind11",
+    "sdformat",
+    "spdlog",
+    "tinyobjloader",
+    "vtk",
+    "yaml_cpp",
+]] + ["//tools/install/%s:install" % p for p in [
+    "gflags",
+    "jchart2d",
+    "optitrack_driver",
+    "protobuf",
+]]
+
 install(
     name = "install",
-    license_docs = ["LICENSE.TXT"],
+    docs = ["LICENSE.TXT"],
     deps = [
         "//drake:install",
         "//drake/common:install",
         "//tools:install",
-        "//tools/install/gflags:install",
-        "//tools/install/jchart2d:install",
-        "//tools/install/optitrack_driver:install",
-        "//tools/install/protobuf:install",
-        "@bullet//:install",
-        "@ccd//:install",
-        "@eigen//:install",
-        "@fcl//:install",
-        "@fmt//:install",
-        "@ignition_math//:install",
-        "@ignition_rndf//:install",
-        "@ipopt//:install",
-        "@lcm//:install",
-        "@lcmtypes_bot2_core//:install",
-        "@lcmtypes_robotlocomotion//:install",
-        "@libbot//:install",
-        "@nlopt//:install",
-        "@octomap//:install",
-        "@pybind11//:install",
-        "@sdformat//:install",
-        "@spdlog//:install",
-        "@tinyobjloader//:install",
-        "@vtk//:install",
-        "@yaml_cpp//:install",
-    ],
+    ] + DRAKE_EXTERNAL_PACKAGE_INSTALLS,
 )
+
+check_licenses(DRAKE_EXTERNAL_PACKAGE_INSTALLS + [":install"])

--- a/drake/BUILD
+++ b/drake/BUILD
@@ -4,7 +4,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//tools:install.bzl", "install")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 # Should include everything any consumer of Drake would ever need.
 # When adding new components to the package, please also add the licenses for

--- a/tools/bullet.BUILD
+++ b/tools/bullet.BUILD
@@ -1,6 +1,5 @@
 # -*- python -*-
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load(
     "@drake//tools:install.bzl",
     "cmake_config",
@@ -76,11 +75,13 @@ install_cmake_config(package = "Bullet")
 
 install(
     name = "install",
-    docs = ["AUTHORS.txt"],
+    docs = [
+        "AUTHORS.txt",
+        "LICENSE.txt",
+    ],
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/bullet",
     hdr_strip_prefix = BULLET_INCLUDES,
-    license_docs = ["LICENSE.txt"],
     targets = [
         ":BulletCollision",
         ":BulletDynamics",

--- a/tools/ccd.BUILD
+++ b/tools/ccd.BUILD
@@ -59,9 +59,9 @@ install_cmake_config(package = "ccd")  # Creates rule :install_cmake_config.
 install(
     name = "install",
     hdrs = CCD_PUBLIC_HEADERS,
+    docs = ["BSD-LICENSE"],
     hdr_dest = "include/ccd",
     hdr_strip_prefix = ["**/"],
-    license_docs = ["BSD-LICENSE"],
     targets = [":ccd"],
     deps = [":install_cmake_config"],
 )

--- a/tools/check_licenses.bzl
+++ b/tools/check_licenses.bzl
@@ -1,0 +1,80 @@
+# -*- python -*-
+
+# List of exact file names of license files
+LICENSE_LITERALS = [
+    "BSD-LICENSE",  # ccd
+    "COPYING",
+    "Copyright.txt",  # vtk
+    "LICENSE",
+]
+
+# List of file name prefixes of license files
+LICENSE_PREFIXES = [
+    "COPYING.",
+    "LICENSE.",
+]
+
+#------------------------------------------------------------------------------
+def _is_license_file(filename):
+    # Check literal file names
+    if filename in LICENSE_LITERALS:
+        return True
+
+    # Check file prefixes
+    for p in LICENSE_PREFIXES:
+        if filename.startswith(p):
+            return True
+
+    # No match
+    return False
+
+#------------------------------------------------------------------------------
+def _check_licenses_for_label(label):
+    has_license = False
+    for a in label.install_actions:
+        if _is_license_file(a.src.basename):
+            has_license = True
+
+    if not has_license:
+        return [label.label]
+
+    return []
+
+#------------------------------------------------------------------------------
+def _check_licenses_impl(ctx):
+    labels_missing_licenses = []
+    for l in ctx.attr.install_labels:
+        labels_missing_licenses += _check_licenses_for_label(l)
+
+    if labels_missing_licenses:
+        fail("Missing license files for install label(s) %s" %
+             labels_missing_licenses)
+
+_check_licenses = rule(
+    attrs = {
+        "install_labels": attr.label_list(providers = ["install_actions"]),
+    },
+    implementation = _check_licenses_impl,
+)
+
+def check_licenses(install_labels, name = "check_licenses"):
+    """Check that install labels include license files.
+
+    Given a list of install labels (e.g. ``//package:install``), check that the
+    set of files installed by the label includes one or more files that appear
+    to provide a license, by checking the file names against a list of known
+    names of license files (e.g. ``LICENSE``).
+
+    This is used to verify that a set of packages is installing the license
+    files for those packages.
+
+    Args:
+        name (:obj:`str`): Rule name (default = ``"check_licenses"``).
+        install_labels (:obj:`list` of :obj:`Label`): List of install labels
+            (must be created by :func:`install` or :func:`install_files`) to
+            be checked.
+    """
+    _check_licenses(
+        name = name,
+        install_labels = install_labels,
+    )

--- a/tools/eigen.BUILD
+++ b/tools/eigen.BUILD
@@ -7,7 +7,6 @@ load(
     "install_cmake_config",
 )
 load("@drake//tools:python_lint.bzl", "python_lint")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -39,19 +38,11 @@ install_cmake_config(package = "Eigen3")  # Creates rule :install_cmake_config.
 install(
     name = "install",
     doc_dest = "share/doc/eigen3",
+    docs = glob(["COPYING.*"]),
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/eigen3",
-    license_docs = glob(["COPYING.*"]),
     targets = [":eigen"],
     deps = [":install_cmake_config"],
-)
-
-pkg_tar(
-    name = "license",
-    extension = "tar.gz",
-    files = glob(["COPYING.*"]),
-    mode = "0644",
-    package_dir = "eigen",
 )
 
 python_lint()

--- a/tools/fcl.BUILD
+++ b/tools/fcl.BUILD
@@ -69,10 +69,10 @@ install_cmake_config(package = "fcl")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
+    docs = ["LICENSE"],
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/fcl",
     hdr_strip_prefix = ["include/fcl"],
-    license_docs = glob(["LICENSE"]),
     targets = [":fcl"],
     deps = [":install_cmake_config"],
 )

--- a/tools/fmt.BUILD
+++ b/tools/fmt.BUILD
@@ -1,6 +1,5 @@
 # -*- python -*-
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load(
     "@drake//tools:install.bzl",
     "cmake_config",
@@ -29,18 +28,10 @@ install_cmake_config(package = "fmt")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
+    docs = ["LICENSE.rst"],
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/fmt",
     hdr_strip_prefix = ["fmt"],
-    license_docs = ["LICENSE.rst"],
     targets = [":fmt"],
     deps = [":install_cmake_config"],
-)
-
-pkg_tar(
-    name = "license",
-    extension = "tar.gz",
-    files = ["LICENSE.rst"],
-    mode = "0644",
-    package_dir = "fmt",
 )

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -142,12 +142,11 @@ install(
         ":config",
         ":mathhh_genrule",
     ],
-    hdr_dest = "include",
-    hdr_strip_prefix = ["include"],
-    license_docs = [
+    docs = [
         "LICENSE",
         "COPYING",
     ],
+    hdr_strip_prefix = ["include"],
     targets = [":ignition_math"],
     workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],

--- a/tools/ignition_rndf.BUILD
+++ b/tools/ignition_rndf.BUILD
@@ -78,12 +78,11 @@ install(
         ":config",
         ":rndfhh_genrule",
     ],
-    hdr_dest = "include",
-    hdr_strip_prefix = ["include"],
-    license_docs = [
+    docs = [
         "LICENSE",
         "COPYING",
     ],
+    hdr_strip_prefix = ["include"],
     targets = [":ignition_rndf"],
     workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -8,16 +8,6 @@ InstallInfo = provider()
 #BEGIN internal helpers
 
 #------------------------------------------------------------------------------
-def _is_drake_label(x):
-    root = x.workspace_root
-    if root == "":
-        x.package.startswith("drake") or fail("Unknown '%s'" % x.package)
-        return True
-    else:
-        root.startswith("external") or fail("Unknown '%s'" % root)
-        return False
-
-#------------------------------------------------------------------------------
 def _workspace(ctx):
     """Compute name of current workspace."""
 
@@ -236,22 +226,11 @@ def _install_code(action):
 def _install_impl(ctx):
     actions = []
 
-    # Check for missing license files.
-    non_drake_labels = [
-        x.label for x in ctx.attr.targets + ctx.attr.hdrs
-        if not _is_drake_label(x.label)]
-    if non_drake_labels and not ctx.attr.license_docs:
-        fail("%s is missing required license_docs= attribute for %s" % (
-            ctx.label, non_drake_labels))
-
     # Collect install actions from dependencies.
     for d in ctx.attr.deps:
         actions += d.install_actions
 
     # Generate actions for data, docs and includes.
-    actions += _install_actions(ctx, ctx.attr.license_docs, ctx.attr.doc_dest,
-                                strip_prefixes = ctx.attr.doc_strip_prefix,
-                                rename = ctx.attr.rename)
     actions += _install_actions(ctx, ctx.attr.docs, ctx.attr.doc_dest,
                                 strip_prefixes = ctx.attr.doc_strip_prefix,
                                 rename = ctx.attr.rename)
@@ -304,7 +283,6 @@ install = rule(
         "docs": attr.label_list(allow_files = True),
         "doc_dest": attr.string(default = "share/doc/@WORKSPACE@"),
         "doc_strip_prefix": attr.string_list(),
-        "license_docs": attr.label_list(allow_files = True),
         "data": attr.label_list(allow_files = True),
         "data_dest": attr.string(default = "share/@WORKSPACE@"),
         "data_strip_prefix": attr.string_list(),
@@ -390,7 +368,6 @@ Args:
     doc_dest: Destination for documentation files
         (default = "share/doc/@WORKSPACE@").
     doc_strip_prefix: List of prefixes to remove from documentation paths.
-    license_docs: List of license files to install (uses doc_dest).
     guess_data: See note.
     guess_data_exclude: List of resources found by ``guess_data`` to exclude
         from installation.

--- a/tools/install/gflags/BUILD
+++ b/tools/install/gflags/BUILD
@@ -15,6 +15,7 @@ install(
     name = "install",
     allowed_externals = ["@com_github_gflags_gflags//:gflags"],
     doc_dest = "share/doc/gflags",
+    docs = ["@com_github_gflags_gflags//:COPYING.txt"],
     guess_hdrs = "PACKAGE",
     guess_hdrs_exclude = [
         "config.h",
@@ -23,8 +24,7 @@ install(
     ],
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
-    license_docs = ["@com_github_gflags_gflags//:COPYING.txt"],
     targets = ["@com_github_gflags_gflags//:gflags"],
-    deps = [":install_cmake_config"],
     visibility = ["//:__pkg__"],
+    deps = [":install_cmake_config"],
 )

--- a/tools/install/jchart2d/BUILD
+++ b/tools/install/jchart2d/BUILD
@@ -25,11 +25,11 @@ JCHART_TARGETS = [
 install(
     name = "install",
     allowed_externals = JCHART_LICENSE_DOCS + JCHART_TARGETS,
-    doc_dest = "share/doc/" + CMAKE_PACKAGE,
     doc_strip_prefix = ["**/"],
-    license_docs = JCHART_LICENSE_DOCS,
+    docs = JCHART_LICENSE_DOCS,
     java_strip_prefix = ["**/"],
     targets = JCHART_TARGETS,
-    deps = [":install_cmake_config"],
     visibility = ["//:__pkg__"],
+    workspace = CMAKE_PACKAGE,
+    deps = [":install_cmake_config"],
 )

--- a/tools/install/optitrack_driver/BUILD
+++ b/tools/install/optitrack_driver/BUILD
@@ -28,12 +28,11 @@ OPTITRACK_TARGETS = [
 install(
     name = "install",
     allowed_externals = OPTITRACK_LICENSE_DOCS + OPTITRACK_TARGETS,
-    doc_dest = "share/doc/" + CMAKE_PACKAGE,
     doc_strip_prefix = ["**/"],
+    docs = OPTITRACK_LICENSE_DOCS,
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/lcmtypes",
     java_strip_prefix = ["**/"],
-    license_docs = OPTITRACK_LICENSE_DOCS,
     py_dest = "lib/python2.7/site-packages/optitrack",
     py_strip_prefix = ["**/"],
     rename = {
@@ -41,5 +40,6 @@ install(
     },
     targets = OPTITRACK_TARGETS,
     visibility = ["//:__pkg__"],
+    workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],
 )

--- a/tools/install/protobuf/BUILD
+++ b/tools/install/protobuf/BUILD
@@ -158,10 +158,10 @@ install(
     hdrs = ["@protobuf//:well_known_protos"],
     allowed_externals = ["@protobuf//:protobuf"],
     doc_dest = "share/doc/protobuf",
+    docs = ["@protobuf//:LICENSE"],
     guess_hdrs = "PACKAGE",
     guess_hdrs_exclude = excluded_headers,
     hdr_strip_prefix = ["src"],
-    license_docs = ["@protobuf//:LICENSE"],
     targets = [
         "@protobuf//:protobuf",
         "@protobuf//:protobuf_lite",

--- a/tools/ipopt.BUILD
+++ b/tools/ipopt.BUILD
@@ -148,10 +148,10 @@ install_cmake_config(package = "IPOPT")  # Creates rule :install_cmake_config.
 # TODO(jamiesnape): At the moment libipopt.a has gone AWOL.
 install(
     name = "install",
+    docs = glob(["**/LICENSE"]),
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/ipopt",
     hdr_strip_prefix = ["include/coin"],
-    license_docs = glob(["**/LICENSE"]),
     targets = [":ipopt"],
     deps = [":install_cmake_config"],
 )

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -10,7 +10,6 @@ load(
     "install_files",
 )
 load("@drake//tools:python_lint.bzl", "python_lint")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -219,14 +218,9 @@ install_files(
     strip_prefix = ["**/"],
 )
 
-# TODO(jamiesnape): Find an alternative to the requirement that a license file
-# must be passed to every single use of the install rule.
-LICENSE_DOCS = ["COPYING"]
-
 install(
     name = "install_python",
     library_dest = "lib/python2.7/site-packages/lcm",
-    license_docs = LICENSE_DOCS,
     py_strip_prefix = ["lcm-python"],
     targets = [
         ":_lcm.so",
@@ -239,9 +233,9 @@ install(
     hdrs = LCM_PUBLIC_HEADERS,
     docs = [
         "AUTHORS",
+        "COPYING",
         "NEWS",
     ],
-    license_docs = LICENSE_DOCS,
     py_strip_prefix = ["lcm-python"],
     rename = {
         "share/java/liblcm-java.jar": "lcm.jar",

--- a/tools/lcmtypes_bot2_core.BUILD
+++ b/tools/lcmtypes_bot2_core.BUILD
@@ -65,12 +65,12 @@ install_cmake_config(
     versioned = 0,
 )
 
-# For license_docs, see  https://github.com/RobotLocomotion/lcmtypes/issues/2
+# For docs, see  https://github.com/RobotLocomotion/lcmtypes/issues/2
 # and https://github.com/openhumanoids/bot_core_lcmtypes/issues/33.
 install(
     name = "install",
+    docs = ["@lcmtypes_robotlocomotion//:LICENSE.txt"],
     guess_hdrs = "PACKAGE",
-    license_docs = ["@lcmtypes_robotlocomotion//:LICENSE.txt"],
     py_strip_prefix = ["lcmtypes"],
     rename = {
         "share/java/liblcmtypes_bot2_core_java.jar": "lcmtypes_bot2_core.jar",

--- a/tools/lcmtypes_robotlocomotion.BUILD
+++ b/tools/lcmtypes_robotlocomotion.BUILD
@@ -60,8 +60,8 @@ install_cmake_config(
 
 install(
     name = "install",
+    docs = ["LICENSE.txt"],
     guess_hdrs = "PACKAGE",
-    license_docs = ["LICENSE.txt"],
     py_strip_prefix = ["lcmtypes"],
     rename = {
         "share/java/liblcmtypes_robotlocomotion_java.jar": "lcmtypes_robotlocomotion.jar",  # noqa

--- a/tools/libbot.BUILD
+++ b/tools/libbot.BUILD
@@ -435,11 +435,6 @@ install_cmake_config(
     versioned = 0,
 )
 
-LICENSE_DOCS = [
-    "LICENSE",
-    "@drake//tools:third_party/libbot/LICENSE.ldpc",
-]
-
 install(
     name = "install_lcmtypes",
     guess_hdrs = "PACKAGE",
@@ -448,7 +443,6 @@ install(
         "bot2-lcmgl",
         "bot2-param",
     ],
-    license_docs = LICENSE_DOCS,
     py_strip_prefix = [
         "bot2-frames/lcmtypes",
         "bot2-lcmgl/lcmtypes",
@@ -482,7 +476,6 @@ install(
     hdrs = BOT2_CORE_PUBLIC_HDRS,
     hdr_dest = HDR_DEST,
     hdr_strip_prefix = ["bot2-core/src"],
-    license_docs = LICENSE_DOCS,
     rename = {
         "share/java/liblcmspy_plugins_bot2.jar": "lcmspy_plugins_bot2.jar",
     },
@@ -495,7 +488,6 @@ install(
 
 install(
     name = "install_bot2_lcm_utils",
-    license_docs = LICENSE_DOCS,
     py_strip_prefix = ["bot2-lcm-utils/python/src"],
     targets = [
         ":bot_log2mat",
@@ -511,7 +503,6 @@ install(
     hdrs = BOT2_PARAM_PUBLIC_HDRS,
     hdr_dest = HDR_DEST + "/" + BOT2_PARAM_INCLUDE_PREFIX,
     hdr_strip_prefix = ["bot2-param/src/param_client"],
-    license_docs = LICENSE_DOCS,
     targets = [
         ":bot-param-dump",
         ":bot-param-server",
@@ -525,7 +516,6 @@ install(
     hdrs = BOT2_FRAMES_PUBLIC_HDRS,
     hdr_dest = HDR_DEST + "/" + BOT2_FRAMES_INCLUDE_PREFIX,
     hdr_strip_prefix = ["bot2-frames/src"],
-    license_docs = LICENSE_DOCS,
     targets = [":bot2_frames"],
 )
 
@@ -534,7 +524,6 @@ install(
     hdrs = BOT2_LCMGL_PUBLIC_HDRS,
     hdr_dest = HDR_DEST,
     hdr_strip_prefix = ["bot2-lcmgl/src"],
-    license_docs = LICENSE_DOCS,
     rename = {
         "share/java/libbot2_lcmgl_java.jar": "bot2_lcmgl.jar",
     },
@@ -548,7 +537,10 @@ install(
 
 install(
     name = "install",
-    license_docs = LICENSE_DOCS,
+    docs = [
+        "LICENSE",
+        "@drake//tools:third_party/libbot/LICENSE.ldpc",
+    ],
     deps = [
         ":install_bot2_core",
         ":install_bot2_frames",

--- a/tools/nlopt.BUILD
+++ b/tools/nlopt.BUILD
@@ -191,13 +191,12 @@ install(
     docs = [
         "AUTHORS",
         "NEWS",
-    ],
-    guess_hdrs = "PACKAGE",
-    hdr_dest = "include/nlopt",
-    license_docs = glob([
+    ] + glob([
         "**/COPYING",
         "**/COPYRIGHT",
     ]),
+    guess_hdrs = "PACKAGE",
+    hdr_dest = "include/nlopt",
     targets = [":nlopt"],
     deps = [":install_cmake_config"],
 )

--- a/tools/octomap.BUILD
+++ b/tools/octomap.BUILD
@@ -64,10 +64,10 @@ install_cmake_config(package = "octomap")
 install(
     name = "install",
     doc_dest = "share/doc",
+    docs = ["octomap/LICENSE.txt"],
     guess_hdrs = "PACKAGE",
     hdr_dest = "include",
     hdr_strip_prefix = ["octomap/include"],
-    license_docs = ["octomap/LICENSE.txt"],
     targets = [
         ":octomap",
         ":octomath",

--- a/tools/pybind11.BUILD
+++ b/tools/pybind11.BUILD
@@ -62,9 +62,9 @@ install_files(
 
 install(
     name = "install",
+    docs = ["LICENSE"],
     guess_hdrs = "PACKAGE",
     hdr_strip_prefix = ["include"],
-    license_docs = ["LICENSE"],
     targets = [":pybind11"],
     deps = [
         ":install_cmake_config",

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -146,12 +146,11 @@ install(
         ":sdfhh_genrule",
         ":config",
     ],
-    hdr_dest = "include",
-    hdr_strip_prefix = ["include"],
-    license_docs = [
+    docs = [
         "LICENSE",
         "COPYING",
     ],
+    hdr_strip_prefix = ["include"],
     targets = [":sdformat"],
     deps = [":install_cmake_config"],
 )

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -6,7 +6,6 @@ load(
     "install",
     "install_cmake_config",
 )
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -39,18 +38,10 @@ install_cmake_config(package = "spdlog")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
+    docs = ["LICENSE"],
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/spdlog",
     hdr_strip_prefix = ["include/spdlog"],
-    license_docs = ["LICENSE"],
     targets = [":spdlog"],
     deps = [":install_cmake_config"],
-)
-
-pkg_tar(
-    name = "license",
-    extension = "tar.gz",
-    files = ["LICENSE"],
-    mode = "0644",
-    package_dir = "spdlog",
 )

--- a/tools/tinyobjloader.BUILD
+++ b/tools/tinyobjloader.BUILD
@@ -6,7 +6,6 @@ load(
     "install",
     "install_cmake_config",
 )
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -35,17 +34,9 @@ install_cmake_config(package = "tinyobjloader")
 
 install(
     name = "install",
+    docs = ["LICENSE"],
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/tinyobjloader",
-    license_docs = ["LICENSE"],
     targets = [":tinyobjloader"],
     deps = [":install_cmake_config"],
-)
-
-pkg_tar(
-    name = "license",
-    extension = "tar.gz",
-    files = ["LICENSE"],
-    mode = "0644",
-    package_dir = "tinyobjloader",
 )

--- a/tools/yaml_cpp.BUILD
+++ b/tools/yaml_cpp.BUILD
@@ -37,9 +37,9 @@ install_cmake_config(package = CMAKE_PACKAGE)
 install(
     name = "install",
     hdrs = public_headers,
+    docs = ["LICENSE"],
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
-    license_docs = ["LICENSE"],
     targets = [":yaml_cpp"],
     workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],


### PR DESCRIPTION
Remove mandatory `license_docs` attribute from `install()`, which also lets us remove special-casing of "drake" targets (which shouldn't be in the non-Drake-specific `install.bzl`). Implement a new `check_licenses()` rule that consumes a list of install labels and verifies that each one installs license files. Update various BUILD files accordingly.

This allows us to remove a lot of duplication from externals that have multiple install rules, as now only the "master" rule for each external needs to install the license files. This is also better as it allows us to enforce checking for Drake itself and for VTK, which were previously exempt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6401)
<!-- Reviewable:end -->
