### PR TITLE
Break out internal solvers into own components

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -126,30 +126,21 @@ drake_cc_library(
 drake_cc_library(
     name = "mathematical_program",
     srcs = [
-        "equality_constrained_qp_solver.cc",
-        "linear_system_solver.cc",
         "mathematical_program.cc",
-        "mathematical_program_solver_interface.cc",
-        "moby_lcp_solver.cc",
-        "no_dreal.cc",
     ],
-    hdrs = [
-        "dreal_solver.h",
-        "equality_constrained_qp_solver.h",
-        "linear_system_solver.h",
-        "mathematical_program.h",
-        "mathematical_program_solver_interface.h",
-        "moby_lcp_solver.h",
-        "mosek_solver.h",
-        "snopt_solver.h",
-    ],
+    hdrs = [],
     deps = [
         ":binding",
         ":create_constraint",
         ":create_cost",
         ":decision_variable",
+        ":dreal_solver",
+        ":equality_constrained_qp_solver",
         ":gurobi_solver",
         ":ipopt_solver",
+        ":linear_system_solver",
+        ":mathematical_program_api",
+        ":moby_lcp_solver",
         ":mosek_solver",
         ":nlopt_solver",
         ":snopt_solver",
@@ -279,7 +270,10 @@ drake_cc_library(
 # with MathematicalProgram itself, and then this target should be deleted.
 drake_cc_library(
     name = "mathematical_program_api",
-    srcs = [],
+    srcs = [
+        "mathematical_program_api.cc",
+        "mathematical_program_solver_interface.cc",
+    ],
     hdrs = [
         "mathematical_program.h",
         "mathematical_program_solver_interface.h",
@@ -294,6 +288,49 @@ drake_cc_library(
         "//drake/common:autodiff",
         "//drake/common:number_traits",
         "//drake/common:polynomial",
+    ],
+)
+
+# Internal Solvers.
+
+drake_cc_library(
+    name = "equality_constrained_qp_solver",
+    srcs = ["equality_constrained_qp_solver.cc"],
+    hdrs = ["equality_constrained_qp_solver.h"],
+    deps = [
+        ":mathematical_program_api",
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
+    name = "linear_system_solver",
+    srcs = ["linear_system_solver.cc"],
+    hdrs = ["linear_system_solver.h"],
+    deps = [
+        ":mathematical_program_api",
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
+    name = "moby_lcp_solver",
+    srcs = ["moby_lcp_solver.cc"],
+    hdrs = ["moby_lcp_solver.h"],
+    deps = [
+        ":mathematical_program_api",
+        "//drake/common",
+    ],
+)
+
+
+drake_cc_library(
+    name = "dreal_solver",
+    srcs = ["no_dreal.cc"],
+    hdrs = ["dreal_solver.h"],
+    deps = [
+        ":mathematical_program_api",
+        "//drake/common",
     ],
 )
 

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND optimization_files
   equality_constrained_qp_solver.cc
   linear_system_solver.cc
   mathematical_program.cc
+  mathematical_program_api.cc
   mathematical_program_solver_interface.cc
   moby_lcp_solver.cc
   no_dreal.cc

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -27,6 +27,9 @@
 #include "drake/solvers/snopt_solver.h"
 #include "drake/solvers/symbolic_extraction.h"
 
+// Note that the file mathematical_program_api.cc also contains some of the
+// implementation of mathematical_program.h
+
 namespace drake {
 namespace solvers {
 
@@ -589,39 +592,15 @@ MathematicalProgram::AddLinearMatrixInequalityConstraint(
   return AddConstraint(constraint, vars);
 }
 
-int MathematicalProgram::FindDecisionVariableIndex(const Variable& var) const {
-  auto it = decision_variable_index_.find(var.get_id());
-  if (it == decision_variable_index_.end()) {
-    ostringstream oss;
-    oss << var << " is not a decision variable in the mathematical program, "
-                  "when calling GetSolution.\n";
-    throw runtime_error(oss.str());
-  }
-  return it->second;
-}
+// Note that FindDecisionVariableIndex is implemented in
+// mathematical_program_api.cc instead of this file.
 
 double MathematicalProgram::GetSolution(const Variable& var) const {
   return x_values_[FindDecisionVariableIndex(var)];
 }
 
-void MathematicalProgram::SetDecisionVariableValues(
-    const Eigen::Ref<const Eigen::VectorXd>& values) {
-  SetDecisionVariableValues(decision_variables_, values);
-}
-
-void MathematicalProgram::SetDecisionVariableValues(
-    const Eigen::Ref<const VectorXDecisionVariable>& variables,
-    const Eigen::Ref<const Eigen::VectorXd>& values) {
-  DRAKE_ASSERT(values.rows() == variables.rows());
-  for (int i = 0; i < values.rows(); ++i) {
-    x_values_[FindDecisionVariableIndex(variables(i))] = values(i);
-  }
-}
-
-void MathematicalProgram::SetDecisionVariableValue(const Variable& var,
-                                                   double value) {
-  x_values_[FindDecisionVariableIndex(var)] = value;
-}
+// Note that SetDecisionVariableValue and SetDecisionVariableValues are
+// implemented in mathematical_program_api.cc instead of this file.
 
 SolutionResult MathematicalProgram::Solve() {
   // This implementation is simply copypasta for now; in the future we will

--- a/drake/solvers/mathematical_program_api.cc
+++ b/drake/solvers/mathematical_program_api.cc
@@ -1,0 +1,48 @@
+#include "drake/solvers/mathematical_program.h"
+
+#include <sstream>
+#include <stdexcept>
+
+// This file contains the portions of mathematical_program.h's implementation
+// that are called by MathematicalProgramSolverInterface implementations.
+
+namespace drake {
+namespace solvers {
+
+using std::ostringstream;
+using std::runtime_error;
+
+using symbolic::Variable;
+
+int MathematicalProgram::FindDecisionVariableIndex(const Variable& var) const {
+  auto it = decision_variable_index_.find(var.get_id());
+  if (it == decision_variable_index_.end()) {
+    ostringstream oss;
+    oss << var << " is not a decision variable in the mathematical program, "
+                  "when calling GetSolution.\n";
+    throw runtime_error(oss.str());
+  }
+  return it->second;
+}
+
+void MathematicalProgram::SetDecisionVariableValues(
+    const Eigen::Ref<const Eigen::VectorXd>& values) {
+  SetDecisionVariableValues(decision_variables_, values);
+}
+
+void MathematicalProgram::SetDecisionVariableValues(
+    const Eigen::Ref<const VectorXDecisionVariable>& variables,
+    const Eigen::Ref<const Eigen::VectorXd>& values) {
+  DRAKE_ASSERT(values.rows() == variables.rows());
+  for (int i = 0; i < values.rows(); ++i) {
+    x_values_[FindDecisionVariableIndex(variables(i))] = values(i);
+  }
+}
+
+void MathematicalProgram::SetDecisionVariableValue(const Variable& var,
+                                                   double value) {
+  x_values_[FindDecisionVariableIndex(var)] = value;
+}
+
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
Relates #6159.

Users should be able to choose which back-ends they want to compile and use.  (Though by default, they should still get everything.)  Splitting up the back-ends into separate components is a necessary step to allow that choice.

The new `.cc` file in this PR is an ugly compromise to make progress.  As the APIs evolve (per the existing TODOs), we will be able to remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6405)
<!-- Reviewable:end -->
