### PR TITLE
Extract solver_type into its own component

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -109,6 +109,11 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "solver_type",
+    hdrs = ["solver_type.h"],
+)
+
 # Supported solvers:
 # - equality_constrained_qp_solver
 # - linear_system_solver
@@ -153,6 +158,7 @@ drake_cc_library(
         ":mosek_solver",
         ":nlopt_solver",
         ":snopt_solver",
+        ":solver_type",
         ":symbolic_extraction",
         "//drake/common",
         "//drake/common:autodiff",
@@ -290,6 +296,7 @@ drake_cc_library(
         ":create_cost",
         ":decision_variable",
         ":function",
+        ":solver_type",
         "//drake/common",
         "//drake/common:autodiff",
         "//drake/common:number_traits",

--- a/drake/solvers/mathematical_program_solver_interface.h
+++ b/drake/solvers/mathematical_program_solver_interface.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/solvers/solver_type.h"
 
 namespace drake {
 namespace solvers {
@@ -17,18 +18,6 @@ enum SolutionResult {
   kUnknownError = -4,
   kInfeasible_Or_Unbounded = -5,
   kIterationLimit = -6,
-};
-
-enum class SolverType {
-  kDReal,
-  kEqualityConstrainedQP,
-  kGurobi,
-  kIpopt,
-  kLinearSystem,
-  kMobyLCP,
-  kMosek,
-  kNlopt,
-  kSnopt,
 };
 
 /// Interface used by implementations of individual solvers.

--- a/drake/solvers/solver_type.h
+++ b/drake/solvers/solver_type.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace drake {
+namespace solvers {
+
+enum class SolverType {
+  kDReal,
+  kEqualityConstrainedQP,
+  kGurobi,
+  kIpopt,
+  kLinearSystem,
+  kMobyLCP,
+  kMosek,
+  kNlopt,
+  kSnopt,
+};
+
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
Relates #6159.

---

_Edited to add:_

This will become useful once `MathematicalProgramSolverInterface` no longer refers to `SolverType`.  The design proposal related to this change goes like like:
- Drake will use `SolverType` in places where we know that we're using MP back-ends drawn from Drake's built-in enumerated set, such as Drake's unit tests or the pydrake wrapper on MP.
- Drake will use `SolverId` (#6407) in places where we don't know that the back-end was one of the built-in ones, such as when we ask `MathematicalProgramSolverInterface` to identify itself.

For context, the full dev branch of commits is https://github.com/jwnimmer-tri/drake/tree/build-solvers-deps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6406)
<!-- Reviewable:end -->
