### PR TITLE
Add solver_id component

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -114,6 +114,16 @@ drake_cc_library(
     hdrs = ["solver_type.h"],
 )
 
+drake_cc_library(
+    name = "solver_id",
+    srcs = ["solver_id.cc"],
+    hdrs = ["solver_id.h"],
+    deps = [
+        "//drake/common",
+        "//drake/common:reinit_after_move",
+    ],
+)
+
 # Supported solvers:
 # - equality_constrained_qp_solver
 # - linear_system_solver
@@ -739,6 +749,13 @@ drake_cc_googletest(
         ":optimization_examples",
         ":quadratic_program_examples",
         "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "solver_id_test",
+    deps = [
+        ":solver_id",
     ],
 )
 

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -23,6 +23,7 @@ set(solver_headers
   mosek_solver.h
   nlopt_solver.h
   snopt_solver.h
+  solver_id.h
   )
 set(optimization_files)
 set(optimization_requires)
@@ -40,6 +41,7 @@ list(APPEND optimization_files
   mathematical_program_solver_interface.cc
   moby_lcp_solver.cc
   no_dreal.cc
+  solver_id.cc
   symbolic_extraction.cc
   system_identification.cc
   )

--- a/drake/solvers/solver_id.cc
+++ b/drake/solvers/solver_id.cc
@@ -1,0 +1,42 @@
+#include "drake/solvers/solver_id.h"
+
+#include <atomic>
+#include <utility>
+
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+
+int get_next_id() {
+  // Note that id 0 is reserved for the SolverId that is created by the default
+  // constructor. As a result, we have an invariant "get_next_id() > 0".
+  static never_destroyed<std::atomic<int>> next_id{1};
+  return next_id.access()++;
+}
+
+}  // namespace
+
+SolverId::SolverId()
+    : id_{0}, name_{"unknown"} {}
+
+SolverId::SolverId(std::string name)
+    : id_{get_next_id()}, name_{std::move(name)} {}
+
+bool operator==(const SolverId& a, const SolverId& b) {
+  return a.id_ == b.id_;
+}
+
+bool operator!=(const SolverId& a, const SolverId& b) {
+  return a.id_ != b.id_;
+}
+
+std::ostream& operator<<(std::ostream& os, const SolverId& self) {
+  // N.B. The ID is _not_ exposed to callers.
+  os << self.name();
+  return os;
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/solver_id.h
+++ b/drake/solvers/solver_id.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <ostream>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/reinit_after_move.h"
+
+namespace drake {
+namespace solvers {
+
+/// Identifies a MathematicalProgramSolverInterface implementation.
+///
+/// A moved-from instance is guaranteed to be identical to a
+/// default-constructed instance.
+class SolverId {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SolverId)
+  ~SolverId() = default;
+
+  /// Constructs a default "unknown" solver type.  All unknown instances are
+  /// considered equal.
+  SolverId();
+
+  /// Constructs a specific, known solver type.  Internally, a hidden
+  /// identifier is allocated and assigned to this instance; all instances that
+  /// share an identifier (including copies of this instance) are considered
+  /// equal.  The solver names are not enforced to be unique, though we
+  /// recommend that they remain so in practice.
+  explicit SolverId(std::string name);
+
+  const std::string& name() const { return name_; }
+
+ private:
+  friend bool operator==(const SolverId&, const SolverId&);
+  friend bool operator!=(const SolverId&, const SolverId&);
+
+  reinit_after_move<int> id_;
+  std::string name_;
+};
+
+bool operator==(const SolverId&, const SolverId&);
+bool operator!=(const SolverId&, const SolverId&);
+std::ostream& operator<<(std::ostream&, const SolverId&);
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -78,6 +78,9 @@ target_link_libraries(ipopt_solver_test drakeOptimizationTest)
 drake_add_cc_test(snopt_solver_test)
 target_link_libraries(snopt_solver_test drakeOptimizationTest)
 
+drake_add_cc_test(solver_id_test)
+target_link_libraries(solver_id_test drakeOptimization)
+
 if (mosek_FOUND)
   drake_add_cc_test(NAME rotation_constraint_test rotation_constraint_test.cc
     SIZE large)

--- a/drake/solvers/test/solver_id_test.cc
+++ b/drake/solvers/test/solver_id_test.cc
@@ -1,0 +1,45 @@
+#include "drake/solvers/solver_id.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace solvers {
+namespace {
+
+GTEST_TEST(SolverId, Equality) {
+  // Default-constructed objects are always equal.
+  // Use the EQ/NE form here to make sure gtest error reporting compiles okay.
+  EXPECT_EQ(SolverId{}, SolverId{});
+  EXPECT_NE(SolverId{}, SolverId{""});
+
+  // Named objects are equal per their assigned IDs; same name is not enough.
+  // Use the op==/op!= form here to be clear which operators are being tested.
+  EXPECT_FALSE(SolverId{"x"} == SolverId{"x"});
+  EXPECT_TRUE(SolverId{"x"} != SolverId{"x"});
+  EXPECT_FALSE(SolverId{"a"} == SolverId{"b"});
+  EXPECT_TRUE(SolverId{"a"} != SolverId{"b"});
+}
+
+GTEST_TEST(SolverId, Copy) {
+  // Copies of objects are equal to each other.
+  SolverId foo{"foo"};
+  EXPECT_TRUE(foo == foo);
+  EXPECT_FALSE(foo != foo);
+  SolverId foo2{foo};
+  EXPECT_TRUE(foo == foo2);
+  EXPECT_FALSE(foo != foo2);
+}
+
+GTEST_TEST(SolverId, Move) {
+  // Moved-from IDs become empty.
+  SolverId old_bar{"bar"};
+  SolverId new_bar{std::move(old_bar)};
+  EXPECT_EQ(old_bar.name(), "");
+  EXPECT_EQ(new_bar.name(), "bar");
+  EXPECT_TRUE(old_bar == SolverId{});
+  EXPECT_FALSE(old_bar != SolverId{});
+}
+
+}  // namespace
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
Relates #6159.

The design proposal related to this change goes like like:
 - Drake will use `SolverType` in places where we know that we're using MP back-ends drawn from Drake's built-in enumerated set, such as Drake's unit tests or the `pydrake` wrapper on MP.
 - Drake will use `SolverId` in places where we _don't_ know that the back-end was one of the built-in ones, such as when we ask `MathematicalProgramSolverInterface` to identify itself.

For context, the full dev branch of commits is https://github.com/jwnimmer-tri/drake/tree/build-solvers-deps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6407)
<!-- Reviewable:end -->
