### PR TITLE
Improve default install destinations

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,7 +43,6 @@ install(
 
 install(
     name = "install",
-    doc_dest = "share/doc/drake",
     license_docs = ["LICENSE.TXT"],
     deps = [
         ":install_net_sf_jchart2d_jchart2d",

--- a/drake/BUILD
+++ b/drake/BUILD
@@ -37,7 +37,6 @@ cc_binary(
 # (i.e. in Drake itself; not externals).
 install(
     name = "install",
-    doc_dest = "share/doc/drake",
     guess_hdrs = "WORKSPACE",
     hdr_dest = "include/drake",
     targets = ["libdrake.so"],

--- a/tools/bullet.BUILD
+++ b/tools/bullet.BUILD
@@ -53,7 +53,6 @@ install_cmake_config(package = "Bullet")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    doc_dest = "share/doc/bullet",
     docs = ["AUTHORS.txt"],
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/bullet",

--- a/tools/ccd.BUILD
+++ b/tools/ccd.BUILD
@@ -59,7 +59,6 @@ install_cmake_config(package = "ccd")  # Creates rule :install_cmake_config.
 install(
     name = "install",
     hdrs = CCD_PUBLIC_HEADERS,
-    doc_dest = "share/doc/ccd",
     hdr_dest = "include/ccd",
     hdr_strip_prefix = ["**/"],
     license_docs = ["BSD-LICENSE"],

--- a/tools/fcl.BUILD
+++ b/tools/fcl.BUILD
@@ -69,7 +69,6 @@ install_cmake_config(package = "fcl")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    doc_dest = "share/doc/fcl",
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/fcl",
     hdr_strip_prefix = ["include/fcl"],

--- a/tools/fmt.BUILD
+++ b/tools/fmt.BUILD
@@ -29,7 +29,6 @@ install_cmake_config(package = "fmt")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    doc_dest = "share/doc/fmt",
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/fmt",
     hdr_strip_prefix = ["fmt"],

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -142,7 +142,6 @@ install(
         ":config",
         ":mathhh_genrule",
     ],
-    doc_dest = "share/doc/" + CMAKE_PACKAGE,
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
     license_docs = [
@@ -150,5 +149,6 @@ install(
         "COPYING",
     ],
     targets = [":ignition_math"],
+    workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],
 )

--- a/tools/ignition_rndf.BUILD
+++ b/tools/ignition_rndf.BUILD
@@ -78,7 +78,6 @@ install(
         ":config",
         ":rndfhh_genrule",
     ],
-    doc_dest = "share/doc/" + CMAKE_PACKAGE,
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
     license_docs = [
@@ -86,5 +85,6 @@ install(
         "COPYING",
     ],
     targets = [":ignition_rndf"],
+    workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],
 )

--- a/tools/ipopt.BUILD
+++ b/tools/ipopt.BUILD
@@ -148,7 +148,6 @@ install_cmake_config(package = "IPOPT")  # Creates rule :install_cmake_config.
 # TODO(jamiesnape): At the moment libipopt.a has gone AWOL.
 install(
     name = "install",
-    doc_dest = "share/doc/ipopt",
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/ipopt",
     hdr_strip_prefix = ["include/coin"],

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -218,13 +218,10 @@ install_files(
 
 # TODO(jamiesnape): Find an alternative to the requirement that a license file
 # must be passed to every single use of the install rule.
-DOC_DEST = "share/doc/lcm"
-
 LICENSE_DOCS = ["COPYING"]
 
 install(
     name = "install_python",
-    doc_dest = DOC_DEST,
     library_dest = "lib/python2.7/site-packages/lcm",
     license_docs = LICENSE_DOCS,
     py_strip_prefix = ["lcm-python"],
@@ -237,7 +234,6 @@ install(
 install(
     name = "install",
     hdrs = LCM_PUBLIC_HEADERS,
-    doc_dest = DOC_DEST,
     docs = [
         "AUTHORS",
         "NEWS",

--- a/tools/lcmtypes_bot2_core.BUILD
+++ b/tools/lcmtypes_bot2_core.BUILD
@@ -68,7 +68,6 @@ install_cmake_config(
 # and https://github.com/openhumanoids/bot_core_lcmtypes/issues/33.
 install(
     name = "install",
-    doc_dest = "share/doc/" + CMAKE_PACKAGE,
     guess_hdrs = "PACKAGE",
     license_docs = ["@lcmtypes_robotlocomotion//:LICENSE.txt"],
     py_strip_prefix = ["lcmtypes"],
@@ -81,5 +80,6 @@ install(
         ":lcmtypes_bot2_core_java",
         ":lcmtypes_bot2_core_py",
     ],
+    workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],
 )

--- a/tools/lcmtypes_robotlocomotion.BUILD
+++ b/tools/lcmtypes_robotlocomotion.BUILD
@@ -60,7 +60,6 @@ install_cmake_config(
 
 install(
     name = "install",
-    doc_dest = "share/doc/" + CMAKE_PACKAGE,
     guess_hdrs = "PACKAGE",
     license_docs = ["LICENSE.txt"],
     py_strip_prefix = ["lcmtypes"],
@@ -73,6 +72,7 @@ install(
         ":lcmtypes_robotlocomotion_java",
         ":lcmtypes_robotlocomotion_py",
     ],
+    workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],
 )
 

--- a/tools/libbot.BUILD
+++ b/tools/libbot.BUILD
@@ -426,8 +426,6 @@ install_cmake_config(
     versioned = 0,
 )
 
-DOC_DEST = "share/doc/" + CMAKE_PACKAGE
-
 LICENSE_DOCS = [
     "LICENSE",
     "@drake//tools:third_party/libbot/LICENSE.ldpc",
@@ -435,7 +433,6 @@ LICENSE_DOCS = [
 
 install(
     name = "install_lcmtypes",
-    doc_dest = DOC_DEST,
     guess_hdrs = "PACKAGE",
     hdr_strip_prefix = [
         "bot2-frames",
@@ -474,7 +471,6 @@ HDR_DEST = "include/" + CMAKE_PACKAGE
 install(
     name = "install_bot2_core",
     hdrs = BOT2_CORE_PUBLIC_HDRS,
-    doc_dest = DOC_DEST,
     hdr_dest = HDR_DEST,
     hdr_strip_prefix = ["bot2-core/src"],
     license_docs = LICENSE_DOCS,
@@ -490,7 +486,6 @@ install(
 
 install(
     name = "install_bot2_lcm_utils",
-    doc_dest = DOC_DEST,
     license_docs = LICENSE_DOCS,
     py_strip_prefix = ["bot2-lcm-utils/python/src"],
     targets = [
@@ -505,7 +500,6 @@ install(
 install(
     name = "install_bot2_param",
     hdrs = BOT2_PARAM_PUBLIC_HDRS,
-    doc_dest = DOC_DEST,
     hdr_dest = HDR_DEST + "/" + BOT2_PARAM_INCLUDE_PREFIX,
     hdr_strip_prefix = ["bot2-param/src/param_client"],
     license_docs = LICENSE_DOCS,
@@ -520,7 +514,6 @@ install(
 install(
     name = "install_bot2_frames",
     hdrs = BOT2_FRAMES_PUBLIC_HDRS,
-    doc_dest = DOC_DEST,
     hdr_dest = HDR_DEST + "/" + BOT2_FRAMES_INCLUDE_PREFIX,
     hdr_strip_prefix = ["bot2-frames/src"],
     license_docs = LICENSE_DOCS,
@@ -530,7 +523,6 @@ install(
 install(
     name = "install_bot2_lcmgl",
     hdrs = BOT2_LCMGL_PUBLIC_HDRS,
-    doc_dest = DOC_DEST,
     hdr_dest = HDR_DEST,
     hdr_strip_prefix = ["bot2-lcmgl/src"],
     license_docs = LICENSE_DOCS,
@@ -547,7 +539,6 @@ install(
 
 install(
     name = "install",
-    doc_dest = DOC_DEST,
     license_docs = LICENSE_DOCS,
     deps = [
         ":install_bot2_core",

--- a/tools/nlopt.BUILD
+++ b/tools/nlopt.BUILD
@@ -188,7 +188,6 @@ install_cmake_config(package = "NLopt")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    doc_dest = "share/doc/nlopt",
     docs = [
         "AUTHORS",
         "NEWS",

--- a/tools/pybind11.BUILD
+++ b/tools/pybind11.BUILD
@@ -62,7 +62,6 @@ install_files(
 
 install(
     name = "install",
-    doc_dest = "share/doc/pybind11",
     guess_hdrs = "PACKAGE",
     hdr_strip_prefix = ["include"],
     license_docs = ["LICENSE"],

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -146,7 +146,6 @@ install(
         ":sdfhh_genrule",
         ":config",
     ],
-    doc_dest = "share/doc/sdformat",
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
     license_docs = [

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -39,7 +39,6 @@ install_cmake_config(package = "spdlog")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    doc_dest = "share/doc/spdlog",
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/spdlog",
     hdr_strip_prefix = ["include/spdlog"],

--- a/tools/tinyobjloader.BUILD
+++ b/tools/tinyobjloader.BUILD
@@ -35,7 +35,6 @@ install_cmake_config(package = "tinyobjloader")
 
 install(
     name = "install",
-    doc_dest = "share/doc/tinyobjloader",
     guess_hdrs = "PACKAGE",
     hdr_dest = "include/tinyobjloader",
     license_docs = ["LICENSE"],

--- a/tools/yaml_cpp.BUILD
+++ b/tools/yaml_cpp.BUILD
@@ -23,22 +23,24 @@ cc_library(
     includes = ["include"],
 )
 
+CMAKE_PACKAGE = "yaml-cpp"
+
 cmake_config(
-    package = "yaml-cpp",
+    package = CMAKE_PACKAGE,
     script = "@drake//tools:yaml_cpp-create-cps.py",
     version_file = "CMakeLists.txt",
 )
 
 # Creates rule :install_cmake_config.
-install_cmake_config(package = "yaml-cpp")
+install_cmake_config(package = CMAKE_PACKAGE)
 
 install(
     name = "install",
     hdrs = public_headers,
-    doc_dest = "share/doc/yaml-cpp",
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
     license_docs = ["LICENSE"],
     targets = [":yaml_cpp"],
+    workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],
 )


### PR DESCRIPTION
Add logic to allow use of `@WORKSPACE@` placeholder in install destinations. Leverage this to simplify many install rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6411)
<!-- Reviewable:end -->
