### PR TITLE
Simplify creation of LCM aggregate headers

### DIFF
--- a/tools/lcmtypes_bot2_core.BUILD
+++ b/tools/lcmtypes_bot2_core.BUILD
@@ -10,7 +10,6 @@ load(
 )
 load(
     "@drake//tools:lcm.bzl",
-    "lcm_c_aggregate_header",
     "lcm_c_library",
     "lcm_cc_library",
     "lcm_java_library",
@@ -25,18 +24,8 @@ LCM_STRUCTS = [
     for f in LCM_SRCS
 ]
 
-lcm_c_aggregate_header(
-    name = "lcmtypes_bot2_core_c_aggregate_header",
-    out = "lcmtypes/bot_core.h",
-    lcm_package = "bot_core",
-    lcm_srcs = LCM_SRCS,
-    lcm_structs = LCM_STRUCTS,
-    visibility = ["//visibility:private"],
-)
-
 lcm_c_library(
     name = "lcmtypes_bot2_core_c",
-    aggregate_hdr = ":lcmtypes_bot2_core_c_aggregate_header",
     includes = ["lcmtypes"],
     lcm_package = "bot_core",
     lcm_srcs = LCM_SRCS,

--- a/tools/lcmtypes_robotlocomotion.BUILD
+++ b/tools/lcmtypes_robotlocomotion.BUILD
@@ -10,7 +10,6 @@ load(
 )
 load(
     "@drake//tools:lcm.bzl",
-    "lcm_c_aggregate_header",
     "lcm_c_library",
     "lcm_cc_library",
     "lcm_java_library",
@@ -19,17 +18,8 @@ load(
 
 LCM_SRCS = glob(["lcmtypes/*.lcm"])
 
-lcm_c_aggregate_header(
-    name = "lcmtypes_robotlocomotion_c_aggregate_header",
-    out = "lcmtypes/robotlocomotion.h",
-    lcm_package = "robotlocomotion",
-    lcm_srcs = LCM_SRCS,
-    visibility = ["//visibility:private"],
-)
-
 lcm_c_library(
     name = "lcmtypes_robotlocomotion_c",
-    aggregate_hdr = ":lcmtypes_robotlocomotion_c_aggregate_header",
     includes = ["lcmtypes"],
     lcm_package = "robotlocomotion",
     lcm_srcs = LCM_SRCS,

--- a/tools/libbot.BUILD
+++ b/tools/libbot.BUILD
@@ -8,7 +8,6 @@ load(
 )
 load(
     "@drake//tools:lcm.bzl",
-    "lcm_c_aggregate_header",
     "lcm_c_library",
     "lcm_cc_library",
     "lcm_java_library",
@@ -161,18 +160,9 @@ BOT2_PARAM_LCM_STRUCTS = [
     for f in BOT2_PARAM_LCM_SRCS
 ]
 
-lcm_c_aggregate_header(
-    name = "lcmtypes_bot2_param_c_aggregate_header",
-    out = "bot2-param/lcmtypes/bot2_param.h",
-    lcm_package = "bot_param",
-    lcm_srcs = BOT2_PARAM_LCM_SRCS,
-    lcm_structs = BOT2_PARAM_LCM_STRUCTS,
-    visibility = ["//visibility:private"],
-)
-
 lcm_c_library(
     name = "lcmtypes_bot2_param_c",
-    aggregate_hdr = ":lcmtypes_bot2_param_c_aggregate_header",
+    aggregate_hdr = "bot2-param/lcmtypes/bot2_param.h",
     includes = ["bot2-param"],
     lcm_package = "bot_param",
     lcm_srcs = BOT2_PARAM_LCM_SRCS,
@@ -284,18 +274,9 @@ BOT2_FRAMES_LCM_STRUCTS = [
     for f in BOT2_FRAMES_LCM_SRCS
 ]
 
-lcm_c_aggregate_header(
-    name = "lcmtypes_bot2_frames_c_aggregate_header",
-    out = "bot2-frames/lcmtypes/bot2_frames.h",
-    lcm_package = "bot_frames",
-    lcm_srcs = BOT2_FRAMES_LCM_SRCS,
-    lcm_structs = BOT2_FRAMES_LCM_STRUCTS,
-    visibility = ["//visibility:private"],
-)
-
 lcm_c_library(
     name = "lcmtypes_bot2_frames_c",
-    aggregate_hdr = ":lcmtypes_bot2_frames_c_aggregate_header",
+    aggregate_hdr = "bot2-frames/lcmtypes/bot2_frames.h",
     includes = ["bot2-frames"],
     lcm_package = "bot_frames",
     lcm_srcs = BOT2_FRAMES_LCM_SRCS,
@@ -355,18 +336,9 @@ BOT2_LCMGL_LCM_STRUCTS = [
     for f in BOT2_LCMGL_LCM_SRCS
 ]
 
-lcm_c_aggregate_header(
-    name = "lcmtypes_bot2_lcmgl_c_aggregate_header",
-    out = "bot2-lcmgl/lcmtypes/bot2_lcmgl.h",
-    lcm_package = "bot_lcmgl",
-    lcm_srcs = BOT2_LCMGL_LCM_SRCS,
-    lcm_structs = BOT2_LCMGL_LCM_STRUCTS,
-    visibility = ["//visibility:private"],
-)
-
 lcm_c_library(
     name = "lcmtypes_bot2_lcmgl_c",
-    aggregate_hdr = ":lcmtypes_bot2_lcmgl_c_aggregate_header",
+    aggregate_hdr = "bot2-lcmgl/lcmtypes/bot2_lcmgl.h",
     includes = ["bot2-lcmgl"],
     lcm_package = "bot_lcmgl",
     lcm_srcs = BOT2_LCMGL_LCM_SRCS,


### PR DESCRIPTION
Merge creation of LCM C aggregate headers into `lcm_c_library`, adding an option whether or not to create the header, which, by default, creates the header using the "standard name" as defined by upstream `lcmUtilities.cmake` (namely `<lcm_package>.h`). This greatly simplifies things for many callers by avoiding a duplicate macro invocation with nearly identical arguments to `lcm_c_library`, and also greatly simplifies generation of the header as the list of per-type headers needs only be computed once for both uses (create the aggregate header, create the library).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6414)
<!-- Reviewable:end -->
