### PR TITLE
Increasing Timeout For implicit_euler_integrator_test

### DIFF
--- a/drake/systems/analysis/BUILD
+++ b/drake/systems/analysis/BUILD
@@ -181,7 +181,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "implicit_euler_integrator_test",
-    size = "medium",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "large",
     deps = [
         ":discontinuous_spring_mass_damper_system",
         ":implicit_euler_integrator",


### PR DESCRIPTION
The Valgrind test, `implicit_euler_integrator_test` has been timing out since https://github.com/RobotLocomotion/drake/pull/6265/files

Jenkins:
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6415)
<!-- Reviewable:end -->
