### PR TITLE
A more fluent construction API for SpatialVector

### DIFF
--- a/drake/multibody/multibody_tree/math/spatial_vector.h
+++ b/drake/multibody/multibody_tree/math/spatial_vector.h
@@ -67,6 +67,24 @@ class SpatialVector {
   template <typename OtherDerived>
   explicit SpatialVector(const Eigen::MatrixBase<OtherDerived>& V) : V_(V) {}
 
+  /// Creates a copy of `this` spatial vector with its rotational component set
+  /// to `v`.
+  SpatialQuantity with_rotational(
+      const Eigen::Ref<const Vector3<T>>& v) const {
+    SpatialQuantity V(get_derived());
+    V.rotational() = v;
+    return V;
+  }
+
+  /// Creates a copy of `this` spatial vector with its translational component
+  /// set to `v`.
+  SpatialQuantity with_translational(
+      const Eigen::Ref<const Vector3<T>>& v) const {
+    SpatialQuantity V(get_derived());
+    V.translational() = v;
+    return V;
+  }
+
   /// The total size of the concatenation of the angular and linear components.
   /// In three dimensions this is six (6) and it is known at compile time.
   int size() const { return kSpatialVectorSize; }
@@ -166,6 +184,12 @@ class SpatialVector {
   }
 
  private:
+  // Helper method to return a const reference to the derived spatial quantity.
+  const SpatialQuantity& get_derived() const {
+    // Static cast is safe since types are resolved at compile time by CRTP.
+    return *static_cast<const SpatialQuantity*>(this);
+  }
+
   CoeffsEigenType V_;
 };
 

--- a/drake/multibody/multibody_tree/math/spatial_vector.h
+++ b/drake/multibody/multibody_tree/math/spatial_vector.h
@@ -68,7 +68,7 @@ class SpatialVector {
   explicit SpatialVector(const Eigen::MatrixBase<OtherDerived>& V) : V_(V) {}
 
   /// Creates a copy of `this` spatial vector with its rotational component set
-  /// to `v`.
+  /// to `rotational`.
   SpatialQuantity with_rotational(
       const Eigen::Ref<const Vector3<T>>& rotational) const {
     SpatialQuantity V_with_rotational(get_derived());

--- a/drake/multibody/multibody_tree/math/spatial_vector.h
+++ b/drake/multibody/multibody_tree/math/spatial_vector.h
@@ -70,19 +70,19 @@ class SpatialVector {
   /// Creates a copy of `this` spatial vector with its rotational component set
   /// to `v`.
   SpatialQuantity with_rotational(
-      const Eigen::Ref<const Vector3<T>>& v) const {
-    SpatialQuantity V(get_derived());
-    V.rotational() = v;
-    return V;
+      const Eigen::Ref<const Vector3<T>>& rotational) const {
+    SpatialQuantity V_with_rotational(get_derived());
+    V_with_rotational.rotational() = rotational;
+    return V_with_rotational;
   }
 
   /// Creates a copy of `this` spatial vector with its translational component
-  /// set to `v`.
+  /// set to `translational`.
   SpatialQuantity with_translational(
-      const Eigen::Ref<const Vector3<T>>& v) const {
-    SpatialQuantity V(get_derived());
-    V.translational() = v;
-    return V;
+      const Eigen::Ref<const Vector3<T>>& translational) const {
+    SpatialQuantity V_with_translational(get_derived());
+    V_with_translational.translational() = translational;
+    return V_with_translational;
   }
 
   /// The total size of the concatenation of the angular and linear components.

--- a/drake/multibody/multibody_tree/math/test/spatial_algebra_tests.cc
+++ b/drake/multibody/multibody_tree/math/test/spatial_algebra_tests.cc
@@ -106,6 +106,43 @@ TYPED_TEST(SpatialQuantityTest, ConstructionFromTwo3DVectors) {
   EXPECT_TRUE(V_AB.rotational().isApprox(w_AB));
 }
 
+// Construction of spatial quantities using methods
+// SpatialVector::with_rotational() and SpatialVector::with_translational().
+TYPED_TEST(SpatialQuantityTest, WithRotationalAndOrWithTranslational) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  typedef typename TestFixture::ScalarType T;
+
+  // Rotational and translational components in ℝ³.
+  const Vector3<T> v(1, 2, 0);
+  const Vector3<T> w(0, 0, 3);
+
+  // A spatial quantity based off the above 3D vectors.
+  const SpatialQuantity V =
+      SpatialQuantity{}.with_rotational(w).with_translational(v);
+
+  EXPECT_EQ(V.rotational(), w);
+  EXPECT_EQ(V.translational(), v);
+
+  // Rotational and translational components in ℝ³ for new component values.
+  const Vector3<T> v2(-1, 2, 3);
+  const Vector3<T> w2(8, -7, 2);
+
+  // A spatial quantity with the given rotational component.
+  const SpatialQuantity V_with_rotational = V.with_rotational(w2);
+  EXPECT_EQ(V_with_rotational.rotational(), w2);
+  EXPECT_EQ(V_with_rotational.translational(), v);
+
+  // A spatial quantity with the given translational component.
+  const SpatialQuantity V_with_translational = V.with_translational(v2);
+  EXPECT_EQ(V_with_translational.rotational(), w);
+  EXPECT_EQ(V_with_translational.translational(), v2);
+
+  // A spatial quantity with the given rotational and translational components.
+  const SpatialQuantity V2 = V.with_rotational(w2).with_translational(v2);
+  EXPECT_EQ(V2.rotational(), w2);
+  EXPECT_EQ(V2.translational(), v2);
+}
+
 // Tests array accessors.
 TYPED_TEST(SpatialQuantityTest, SpatialVelocityArrayAccessor) {
   typedef TypeParam SpatialQuantity;


### PR DESCRIPTION
Per Slack discussion in the "#dynamics" channel, this PR introduces a construction API that allows saying:
```c++
SV{}.with_rotational(angular_velocity).with_translational(linear_velocity);
```
which explicitly sates the rotational and translational components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6431)
<!-- Reviewable:end -->
