### PR TITLE
Add solver_id accessor to MPSolverInterface

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -170,6 +170,7 @@ drake_cc_library(
         ":mosek_solver",
         ":nlopt_solver",
         ":snopt_solver",
+        ":solver_id",
         ":solver_type",
         ":symbolic_extraction",
         "//drake/common",
@@ -320,6 +321,7 @@ drake_cc_library(
         ":decision_variable",
         ":function",
         ":indeterminate",
+        ":solver_id",
         ":solver_type",
         "//drake/common",
         "//drake/common:autodiff",
@@ -362,7 +364,10 @@ drake_cc_library(
 
 drake_cc_library(
     name = "dreal_solver",
-    srcs = ["no_dreal.cc"],
+    srcs = [
+        "dreal_solver_common.cc",
+        "no_dreal.cc",
+    ],
     hdrs = ["dreal_solver.h"],
     deps = [
         ":mathematical_program_api",
@@ -378,8 +383,14 @@ drake_cc_library(
 drake_cc_library(
     name = "gurobi_solver",
     srcs = select({
-        "//tools:with_gurobi": ["gurobi_solver.cc"],
-        "//conditions:default": ["no_gurobi.cc"],
+        "//tools:with_gurobi": [
+            "gurobi_solver.cc",
+            "gurobi_solver_common.cc",
+        ],
+        "//conditions:default": [
+            "gurobi_solver_common.cc",
+            "no_gurobi.cc",
+        ],
     }),
     hdrs = ["gurobi_solver.h"],
     deps = select({
@@ -400,8 +411,14 @@ drake_cc_library(
 drake_cc_library(
     name = "mosek_solver",
     srcs = select({
-        "//tools:with_mosek": ["mosek_solver.cc"],
-        "//conditions:default": ["no_mosek.cc"],
+        "//tools:with_mosek": [
+            "mosek_solver.cc",
+            "mosek_solver_common.cc",
+        ],
+        "//conditions:default": [
+            "mosek_solver_common.cc",
+            "no_mosek.cc",
+        ],
     }),
     hdrs = ["mosek_solver.h"],
     deps = select({
@@ -422,8 +439,14 @@ drake_cc_library(
 drake_cc_library(
     name = "snopt_solver",
     srcs = select({
-        "//tools:with_snopt": ["snopt_solver.cc"],
-        "//conditions:default": ["no_snopt.cc"],
+        "//tools:with_snopt": [
+            "snopt_solver.cc",
+            "snopt_solver_common.cc",
+        ],
+        "//conditions:default": [
+            "no_snopt.cc",
+            "snopt_solver_common.cc",
+        ],
     }),
     hdrs = ["snopt_solver.h"],
     # Some versions of SNOPT's API require passing a `std::string::c_str()`
@@ -452,8 +475,14 @@ drake_cc_library(
 drake_cc_library(
     name = "ipopt_solver",
     srcs = select({
-        "//tools:no_ipopt": ["no_ipopt.cc"],
-        "//conditions:default": ["ipopt_solver.cc"],
+        "//tools:no_ipopt": [
+            "ipopt_solver_common.cc",
+            "no_ipopt.cc",
+        ],
+        "//conditions:default": [
+            "ipopt_solver.cc",
+            "ipopt_solver_common.cc",
+        ],
     }),
     hdrs = ["ipopt_solver.h"],
     deps = select({
@@ -472,8 +501,14 @@ drake_cc_library(
 drake_cc_library(
     name = "nlopt_solver",
     srcs = select({
-        "//tools:no_nlopt": ["no_nlopt.cc"],
-        "//conditions:default": ["nlopt_solver.cc"],
+        "//tools:no_nlopt": [
+            "nlopt_solver_common.cc",
+            "no_nlopt.cc",
+        ],
+        "//conditions:default": [
+            "nlopt_solver.cc",
+            "nlopt_solver_common.cc",
+        ],
     }),
     hdrs = ["nlopt_solver.h"],
     deps = select({
@@ -825,12 +860,16 @@ cpplint(extra_srcs = [
     "gurobi_qp.h",
     "gurobi_solver.cc",
     "gurobi_solver.h",
+    "gurobi_solver_common.cc",
     "ipopt_solver.cc",
     "ipopt_solver.h",
+    "ipopt_solver_common.cc",
     "mosek_solver.cc",
     "mosek_solver.h",
+    "mosek_solver_common.cc",
     "nlopt_solver.cc",
     "nlopt_solver.h",
+    "nlopt_solver_common.cc",
     "no_gurobi.cc",
     "no_ipopt.cc",
     "no_mosek.cc",
@@ -839,4 +878,5 @@ cpplint(extra_srcs = [
     "qp.cc",
     "snopt_solver.cc",
     "snopt_solver.h",
+    "snopt_solver_common.cc",
 ])

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -34,14 +34,20 @@ list(APPEND optimization_files
   create_constraint.cc
   create_cost.cc
   decision_variable.cc
-  indeterminate.cc
+  dreal_solver_common.cc
   equality_constrained_qp_solver.cc
+  gurobi_solver_common.cc
+  indeterminate.cc
+  ipopt_solver_common.cc
   linear_system_solver.cc
   mathematical_program.cc
   mathematical_program_api.cc
   mathematical_program_solver_interface.cc
   moby_lcp_solver.cc
+  mosek_solver_common.cc
+  nlopt_solver_common.cc
   no_dreal.cc
+  snopt_solver_common.cc
   solver_id.cc
   symbolic_extraction.cc
   system_identification.cc

--- a/drake/solvers/dreal_solver.h
+++ b/drake/solvers/dreal_solver.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
 namespace solvers {
@@ -23,7 +23,12 @@ class DrealSolver : public MathematicalProgramSolverInterface {
 
   SolverType solver_type() const override  { return SolverType::kDReal; }
 
-  std::string SolverName() const override { return "dReal"; }
+  std::string SolverName() const override { return id().name(); }
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
 };
 
 }  // namespace solvers

--- a/drake/solvers/dreal_solver_common.cc
+++ b/drake/solvers/dreal_solver_common.cc
@@ -1,0 +1,24 @@
+#include "drake/solvers/dreal_solver.h"
+
+#include "drake/common/never_destroyed.h"
+
+// This file contains implementations that are common to both the available and
+// unavailable flavor of this class.
+//
+// Note that (for now) _only_ the unavailable flavor of this class exists.
+// TODO(jwnimmer-tri) Remove this comment when the available flavor is added.
+
+namespace drake {
+namespace solvers {
+
+SolverId DrealSolver::solver_id() const {
+  return id();
+}
+
+SolverId DrealSolver::id() {
+  static const never_destroyed<SolverId> singleton{"dReal"};
+  return singleton.access();
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/equality_constrained_qp_solver.cc
+++ b/drake/solvers/equality_constrained_qp_solver.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/never_destroyed.h"
 #include "drake/solvers/mathematical_program.h"
 
 namespace drake {
@@ -150,6 +151,15 @@ SolutionResult EqualityConstrainedQPSolver::Solve(
 
   prog.SetSolverResult(solver_type(), 0);
   return SolutionResult::kSolutionFound;
+}
+
+SolverId EqualityConstrainedQPSolver::solver_id() const {
+  return id();
+}
+
+SolverId EqualityConstrainedQPSolver::id() {
+  static const never_destroyed<SolverId> singleton{"Equality constrained QP"};
+  return singleton.access();
 }
 
 }  // namespace solvers

--- a/drake/solvers/equality_constrained_qp_solver.h
+++ b/drake/solvers/equality_constrained_qp_solver.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
 namespace solvers {
@@ -23,9 +23,12 @@ class EqualityConstrainedQPSolver : public MathematicalProgramSolverInterface {
     return SolverType::kEqualityConstrainedQP;
   }
 
-  std::string SolverName() const override {
-    return "Equality constrained QP";
-  }
+  std::string SolverName() const override { return id().name(); }
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
 };
 
 }  // namespace solvers

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -18,6 +18,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/math/eigen_sparse_triplet.h"
+#include "drake/solvers/mathematical_program.h"
 
 // TODO(hongkai.dai): GurobiSolver class should store data member such as
 // GRB_model, GRB_env, is_new_variables, etc.

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
 namespace solvers {
@@ -23,7 +23,12 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
 
   SolverType solver_type() const override { return SolverType::kGurobi; }
 
-  std::string SolverName() const override { return "Gurobi"; }
+  std::string SolverName() const override { return id().name(); }
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
 };
 
 }  // end namespace solvers

--- a/drake/solvers/gurobi_solver_common.cc
+++ b/drake/solvers/gurobi_solver_common.cc
@@ -1,0 +1,21 @@
+#include "drake/solvers/gurobi_solver.h"
+
+#include "drake/common/never_destroyed.h"
+
+// This file contains implementations that are common to both the available and
+// unavailable flavor of this class.
+
+namespace drake {
+namespace solvers {
+
+SolverId GurobiSolver::solver_id() const {
+  return id();
+}
+
+SolverId GurobiSolver::id() {
+  static const never_destroyed<SolverId> singleton{"Gurobi"};
+  return singleton.access();
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/ipopt_solver.cc
+++ b/drake/solvers/ipopt_solver.cc
@@ -13,8 +13,10 @@
 #undef HAVE_CSTDDEF
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
 #include "drake/common/unused.h"
 #include "drake/math/autodiff.h"
+#include "drake/solvers/mathematical_program.h"
 
 using Ipopt::Index;
 using Ipopt::IpoptCalculatedQuantities;

--- a/drake/solvers/ipopt_solver.h
+++ b/drake/solvers/ipopt_solver.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
 namespace solvers {
@@ -23,7 +23,12 @@ class IpoptSolver : public MathematicalProgramSolverInterface {
 
   SolverType solver_type() const override { return SolverType::kIpopt; }
 
-  std::string SolverName() const override { return "IPOPT"; }
+  std::string SolverName() const override { return id().name(); }
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
 };
 
 }  // namespace solvers

--- a/drake/solvers/ipopt_solver_common.cc
+++ b/drake/solvers/ipopt_solver_common.cc
@@ -1,0 +1,18 @@
+#include "drake/solvers/ipopt_solver.h"
+
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace solvers {
+
+SolverId IpoptSolver::solver_id() const {
+  return id();
+}
+
+SolverId IpoptSolver::id() {
+  static const never_destroyed<SolverId> singleton{"IPOPT"};
+  return singleton.access();
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/linear_system_solver.cc
+++ b/drake/solvers/linear_system_solver.cc
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/solvers/mathematical_program.h"
 
 namespace drake {
 namespace solvers {
@@ -50,6 +52,15 @@ SolutionResult LinearSystemSolver::Solve(MathematicalProgram& prog) const {
 
   prog.SetSolverResult(solver_type(), 0);
   return SolutionResult::kSolutionFound;
+}
+
+SolverId LinearSystemSolver::solver_id() const {
+  return id();
+}
+
+SolverId LinearSystemSolver::id() {
+  static const never_destroyed<SolverId> singleton{"Linear system"};
+  return singleton.access();
 }
 
 }  // namespace solvers

--- a/drake/solvers/linear_system_solver.h
+++ b/drake/solvers/linear_system_solver.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
 namespace solvers {
@@ -21,7 +21,12 @@ class LinearSystemSolver : public MathematicalProgramSolverInterface {
 
   SolverType solver_type() const override { return SolverType::kLinearSystem; }
 
-  std::string SolverName() const override { return "Linear system"; }
+  std::string SolverName() const override { return id().name(); }
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
 };
 
 }  // namespace solvers

--- a/drake/solvers/mathematical_program_solver_interface.h
+++ b/drake/solvers/mathematical_program_solver_interface.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/solvers/solver_id.h"
 #include "drake/solvers/solver_type.h"
 
 namespace drake {
@@ -39,10 +40,15 @@ class MathematicalProgramSolverInterface {
   virtual SolutionResult Solve(MathematicalProgram& prog) const = 0;
 
   /// Returns the type of the solver.
+  // TODO(jwnimmer-tri) This is redundant with solver_id(); remove it.
   virtual SolverType solver_type() const = 0;
 
   /// Returns the name of the solver.
+  // TODO(jwnimmer-tri) This is redundant with solver_id(); remove it.
   virtual std::string SolverName() const = 0;
+
+  /// Returns the identifier of this solver.
+  virtual SolverId solver_id() const = 0;
 };
 
 }  // namespace solvers

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -15,6 +15,7 @@
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
 
 namespace drake {
 namespace solvers {
@@ -1397,6 +1398,16 @@ bool MobyLCPSolver<T>::SolveLcpLemkeRegularized(
 
   // still here?  failure...
   return false;
+}
+
+template <typename T>
+SolverId MobyLCPSolver<T>::solver_id() const {
+  return MobyLcpSolverId::id();
+}
+
+SolverId MobyLcpSolverId::id() {
+  static const never_destroyed<SolverId> singleton{"Moby LCP"};
+  return singleton.access();
 }
 
 // Instantiate templates.

--- a/drake/solvers/moby_lcp_solver.h
+++ b/drake/solvers/moby_lcp_solver.h
@@ -11,12 +11,23 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 // TODO(jwnimmer-tri): This class should be renamed MobyLcpSolver to comply with
 //                     style guide.
 
 namespace drake {
 namespace solvers {
+
+/// Non-template class for MobyLcpSolver<T> constants.
+class MobyLcpSolverId {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MobyLcpSolverId);
+  MobyLcpSolverId() = delete;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
+};
 
 /// A class for solving Linear Complementarity Problems (LCPs). Solving a LCP
 /// requires finding a solution to the problem:<pre>
@@ -280,7 +291,11 @@ class MobyLCPSolver : public MathematicalProgramSolverInterface {
 
   SolverType solver_type() const override { return SolverType::kMobyLCP; }
 
-  std::string SolverName() const override { return "Moby LCP"; }
+  std::string SolverName() const override {
+    return MobyLcpSolverId::id().name();
+  }
+
+  SolverId solver_id() const override;
 
   /// Returns the number of pivoting operations made by the last LCP solve.
   int get_num_pivots() const { return pivots_; }

--- a/drake/solvers/mosek_solver.cc
+++ b/drake/solvers/mosek_solver.cc
@@ -12,6 +12,7 @@
 #include <mosek.h>
 
 #include "drake/common/scoped_singleton.h"
+#include "drake/solvers/mathematical_program.h"
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/mosek_solver.h
+++ b/drake/solvers/mosek_solver.h
@@ -6,7 +6,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
 namespace solvers {
@@ -27,7 +27,12 @@ class MosekSolver : public MathematicalProgramSolverInterface {
 
   SolverType solver_type() const override { return SolverType::kMosek; }
 
-  std::string SolverName() const override { return "Mosek"; }
+  std::string SolverName() const override { return id().name(); }
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
 
   /**
    * This type contains a valid MOSEK license environment, and is only to be

--- a/drake/solvers/mosek_solver_common.cc
+++ b/drake/solvers/mosek_solver_common.cc
@@ -1,0 +1,18 @@
+#include "drake/solvers/mosek_solver.h"
+
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace solvers {
+
+SolverId MosekSolver::solver_id() const {
+  return id();
+}
+
+SolverId MosekSolver::id() {
+  static const never_destroyed<SolverId> singleton{"Mosek"};
+  return singleton.access();
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/nlopt_solver.cc
+++ b/drake/solvers/nlopt_solver.cc
@@ -11,7 +11,9 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/never_destroyed.h"
 #include "drake/math/autodiff.h"
+#include "drake/solvers/mathematical_program.h"
 
 namespace drake {
 namespace solvers {

--- a/drake/solvers/nlopt_solver.h
+++ b/drake/solvers/nlopt_solver.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
 namespace solvers {
@@ -23,7 +23,12 @@ class NloptSolver : public MathematicalProgramSolverInterface {
 
   SolverType solver_type() const override { return SolverType::kNlopt; }
 
-  std::string SolverName() const override { return "NLopt"; }
+  std::string SolverName() const override { return id().name(); }
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
 };
 
 }  // namespace solvers

--- a/drake/solvers/nlopt_solver_common.cc
+++ b/drake/solvers/nlopt_solver_common.cc
@@ -1,0 +1,18 @@
+#include "drake/solvers/nlopt_solver.h"
+
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace solvers {
+
+SolverId NloptSolver::solver_id() const {
+  return id();
+}
+
+SolverId NloptSolver::id() {
+  static const never_destroyed<SolverId> singleton{"NLopt"};
+  return singleton.access();
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/snopt_solver.cc
+++ b/drake/solvers/snopt_solver.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "drake/math/autodiff.h"
+#include "drake/solvers/mathematical_program.h"
 
 // TODO(jwnimmer-tri) Eventually resolve these warnings.
 #pragma GCC diagnostic push

--- a/drake/solvers/snopt_solver.h
+++ b/drake/solvers/snopt_solver.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
 namespace solvers {
@@ -23,7 +23,12 @@ class SnoptSolver : public MathematicalProgramSolverInterface  {
 
   SolverType solver_type() const override { return SolverType::kSnopt; }
 
-  std::string SolverName() const override { return "SNOPT"; }
+  std::string SolverName() const override { return id().name(); }
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
 };
 
 }  // namespace solvers

--- a/drake/solvers/snopt_solver_common.cc
+++ b/drake/solvers/snopt_solver_common.cc
@@ -1,0 +1,18 @@
+#include "drake/solvers/snopt_solver.h"
+
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace solvers {
+
+SolverId SnoptSolver::solver_id() const {
+  return id();
+}
+
+SolverId SnoptSolver::id() {
+  static const never_destroyed<SolverId> singleton{"SNOPT"};
+  return singleton.access();
+}
+
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
The intention is to remove `solver_type()` and `SolverName()` once they are no longer used.

Relates #6159.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6433)
<!-- Reviewable:end -->
